### PR TITLE
VxDesign: Hide some functionality unless user is a VX support user

### DIFF
--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -585,11 +585,6 @@ function buildApi({ auth, workspace, translator }: AppContext) {
     },
 
     /* istanbul ignore next - @preserve */
-    getVotingWorksOrgId(): string {
-      return votingWorksOrgId();
-    },
-
-    /* istanbul ignore next - @preserve */
     getAllOrgs(): Promise<Org[]> {
       return auth.allOrgs();
     },
@@ -664,6 +659,7 @@ export function buildApp(context: AppContext): Application {
     const userInfo: ReturnType<Api['getUser']> = {
       orgId: user.org_id,
       orgName: org.displayName,
+      isVotingWorksUser: user.org_id === votingWorksOrgId(),
     };
 
     res.set('Content-type', 'application/json');

--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -135,6 +135,7 @@ export interface Auth0User {
 export interface User {
   orgId: string;
   orgName?: string;
+  isVotingWorksUser: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -46,16 +46,6 @@ export function createQueryClient(): QueryClient {
   });
 }
 
-export const getVotingWorksOrgId = {
-  queryKey(): QueryKey {
-    return ['getVotingWorksOrgId'];
-  },
-  useQuery() {
-    const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getVotingWorksOrgId());
-  },
-} as const;
-
 /* istanbul ignore next - @preserve */
 export const getUser = {
   queryKey(): QueryKey {
@@ -66,15 +56,6 @@ export const getUser = {
     return useQuery(this.queryKey(), () => apiClient.getUser());
   },
 } as const;
-
-// [TODO] Update consumers to use FeaturesProvider instead.
-/* istanbul ignore next - @preserve */
-export function useIsVotingWorksUser(): boolean {
-  const user = getUser.useQuery().data;
-  const vxOrgId = getVotingWorksOrgId.useQuery().data;
-
-  return !!vxOrgId && user?.orgId === vxOrgId;
-}
 
 /* istanbul ignore next - @preserve */
 export const getAllOrgs = {

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -38,6 +38,7 @@ import { ElectionNavScreen } from './nav_screen';
 import { ElectionIdParams, electionParamRoutes, routes } from './routes';
 import { hasSplits } from './utils';
 import { BallotScreen, paperSizeLabels } from './ballot_screen';
+import { useUserFeatures } from './features_context';
 
 function BallotDesignForm({
   electionId,
@@ -51,6 +52,7 @@ function BallotDesignForm({
   const [isEditing, setIsEditing] = useState(false);
   const [ballotLayout, setBallotLayout] = useState(savedElection.ballotLayout);
   const updateElectionMutation = updateElection.useMutation();
+  const features = useUserFeatures();
 
   function onSubmit() {
     updateElectionMutation.mutate(
@@ -92,10 +94,17 @@ function BallotDesignForm({
     >
       <RadioGroup
         label="Paper Size"
-        options={Object.entries(paperSizeLabels).map(([value, label]) => ({
-          value,
-          label,
-        }))}
+        options={Object.entries(paperSizeLabels)
+          .filter(([value]) =>
+            features.ONLY_LETTER_AND_LEGAL_PAPER_SIZES
+              ? value === HmpbBallotPaperSize.Letter ||
+                value === HmpbBallotPaperSize.Legal
+              : true
+          )
+          .map(([value, label]) => ({
+            value,
+            label,
+          }))}
         value={ballotLayout.paperSize}
         onChange={(paperSize) =>
           setBallotLayout({

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -16,6 +16,7 @@ import {
   Icons,
   Modal,
   Font,
+  Callout,
 } from '@votingworks/ui';
 import { Redirect, Route, Switch, useParams } from 'react-router-dom';
 import { assertDefined } from '@votingworks/basics';
@@ -82,7 +83,6 @@ function BallotDesignForm({
 
   return (
     <Form
-      style={{ maxWidth: '16rem' }}
       onSubmit={(e) => {
         e.preventDefault();
         onSubmit();
@@ -92,29 +92,30 @@ function BallotDesignForm({
         onReset();
       }}
     >
-      <RadioGroup
-        label="Paper Size"
-        options={Object.entries(paperSizeLabels)
-          .filter(([value]) =>
-            features.ONLY_LETTER_AND_LEGAL_PAPER_SIZES
-              ? value === HmpbBallotPaperSize.Letter ||
-                value === HmpbBallotPaperSize.Legal
-              : true
-          )
-          .map(([value, label]) => ({
-            value,
-            label,
-          }))}
-        value={ballotLayout.paperSize}
-        onChange={(paperSize) =>
-          setBallotLayout({
-            ...ballotLayout,
-            paperSize: paperSize as HmpbBallotPaperSize,
-          })
-        }
-        disabled={!isEditing}
-      />
-
+      <div style={{ maxWidth: '16.5rem' }}>
+        <RadioGroup
+          label="Paper Size"
+          options={Object.entries(paperSizeLabels)
+            .filter(([value]) =>
+              features.ONLY_LETTER_AND_LEGAL_PAPER_SIZES
+                ? value === HmpbBallotPaperSize.Letter ||
+                  value === HmpbBallotPaperSize.Legal
+                : true
+            )
+            .map(([value, label]) => ({
+              value,
+              label,
+            }))}
+          value={ballotLayout.paperSize}
+          onChange={(paperSize) =>
+            setBallotLayout({
+              ...ballotLayout,
+              paperSize: paperSize as HmpbBallotPaperSize,
+            })
+          }
+          disabled={!isEditing}
+        />
+      </div>
       {isEditing ? (
         <FormActionsRow>
           <Button type="reset">Cancel</Button>
@@ -133,6 +134,16 @@ function BallotDesignForm({
             Edit
           </Button>
         </FormActionsRow>
+      )}
+      {features.ONLY_LETTER_AND_LEGAL_PAPER_SIZES && (
+        <Callout
+          style={{ alignSelf: 'flex-start' }}
+          icon="Info"
+          color="neutral"
+        >
+          Reach out to VotingWorks support if you would prefer a longer paper
+          size.
+        </Callout>
       )}
     </Form>
   );

--- a/apps/design/frontend/src/create_election_button.tsx
+++ b/apps/design/frontend/src/create_election_button.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import { generateId } from './utils';
 import * as api from './api';
 import { OrgSelect } from './org_select';
+import { useUserFeatures } from './features_context';
 
 export interface CreateElectionButtonProps {
   variant?: ButtonVariant;
@@ -21,6 +22,7 @@ export function CreateElectionButton(
 ): React.ReactNode {
   const { variant } = props;
   const createMutation = api.createElection.useMutation();
+  const features = useUserFeatures();
 
   const [orgId, setOrgId] = React.useState<string>();
   const [modalActive, setModalActive] = React.useState(false);
@@ -34,8 +36,6 @@ export function CreateElectionButton(
       setOrgId(user.orgId);
     }
   }, [user]);
-
-  const isVotingWorksUser = api.useIsVotingWorksUser();
 
   const mutateCreateElection = createMutation.mutate;
   const createElection = React.useCallback(() => {
@@ -62,7 +62,7 @@ export function CreateElectionButton(
       <Button
         variant={variant}
         icon="Add"
-        onPress={isVotingWorksUser ? setModalActive : createElection}
+        onPress={features.ACCESS_ALL_ORGS ? setModalActive : createElection}
         value
         disabled={modalActive}
       >

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -22,6 +22,7 @@ import { FieldName, Form, FormActionsRow, InputGroup } from './layout';
 import { ElectionNavScreen } from './nav_screen';
 import { routes } from './routes';
 import { ImageInput } from './image_input';
+import { useUserFeatures } from './features_context';
 
 const SealImageInput = styled(ImageInput)`
   img {
@@ -53,6 +54,7 @@ function ElectionInfoForm({
   const updateElectionInfoMutation = updateElectionInfo.useMutation();
   const deleteElectionMutation = deleteElection.useMutation();
   const history = useHistory();
+  const features = useUserFeatures();
 
   function onSubmit() {
     updateElectionInfoMutation.mutate(electionInfo, {
@@ -200,16 +202,18 @@ function ElectionInfoForm({
               Edit
             </Button>
           </FormActionsRow>
-          <FormActionsRow style={{ marginTop: '1rem' }}>
-            <Button
-              variant="danger"
-              icon="Delete"
-              onPress={onDeletePress}
-              disabled={deleteElectionMutation.isLoading}
-            >
-              Delete Election
-            </Button>
-          </FormActionsRow>
+          {features.DELETE_ELECTION && (
+            <FormActionsRow style={{ marginTop: '1rem' }}>
+              <Button
+                variant="danger"
+                icon="Delete"
+                onPress={onDeletePress}
+                disabled={deleteElectionMutation.isLoading}
+              >
+                Delete Election
+              </Button>
+            </FormActionsRow>
+          )}
         </div>
       )}
     </Form>

--- a/apps/design/frontend/src/elections_screen.tsx
+++ b/apps/design/frontend/src/elections_screen.tsx
@@ -19,7 +19,6 @@ import {
   loadElection,
   getUser,
   getAllOrgs,
-  useIsVotingWorksUser,
 } from './api';
 import { Column, Row } from './layout';
 import { NavScreen } from './nav_screen';
@@ -43,8 +42,6 @@ export function ElectionsScreen(): JSX.Element | null {
   const loadElectionMutation = loadElection.useMutation();
 
   const user = getUser.useQuery().data;
-  const isVotingWorksUser = useIsVotingWorksUser();
-
   const orgs = getAllOrgs.useQuery().data || [];
 
   const history = useHistory();
@@ -93,8 +90,7 @@ export function ElectionsScreen(): JSX.Element | null {
             <Table>
               <thead>
                 <tr>
-                  {/* [TODO] Replace with FeaturesProvider condition. */}
-                  {isVotingWorksUser && <th>Org</th>}
+                  {features.ACCESS_ALL_ORGS && <th>Org</th>}
                   <th>Title</th>
                   <th>Date</th>
                   <th>Jurisdiction</th>
@@ -107,8 +103,7 @@ export function ElectionsScreen(): JSX.Element | null {
                     key={election.id}
                     onClick={() => history.push(`/elections/${election.id}`)}
                   >
-                    {/* [TODO] Replace with FeaturesProvider condition. */}
-                    {isVotingWorksUser && (
+                    {features.ACCESS_ALL_ORGS && (
                       <td>
                         {orgs.find((org) => org.id === orgId)?.displayName || (
                           <span>

--- a/apps/design/frontend/src/elections_screen.tsx
+++ b/apps/design/frontend/src/elections_screen.tsx
@@ -23,6 +23,7 @@ import {
 import { Column, Row } from './layout';
 import { NavScreen } from './nav_screen';
 import { CreateElectionButton } from './create_election_button';
+import { useUserFeatures, UserFeaturesProvider } from './features_context';
 
 const ButtonRow = styled.tr`
   cursor: pointer;
@@ -36,7 +37,7 @@ const ButtonRow = styled.tr`
   }
 `;
 
-export function ElectionsScreen(): JSX.Element | null {
+function ElectionsScreenContents(): JSX.Element | null {
   const listElectionsQuery = listElections.useQuery();
   const createElectionMutation = createElection.useMutation();
   const loadElectionMutation = loadElection.useMutation();
@@ -45,6 +46,7 @@ export function ElectionsScreen(): JSX.Element | null {
   const orgs = getAllOrgs.useQuery().data || [];
 
   const history = useHistory();
+  const features = useUserFeatures();
 
   function onCreateElectionSuccess(result: Result<Id, Error>) {
     if (result.isOk()) {
@@ -126,20 +128,30 @@ export function ElectionsScreen(): JSX.Element | null {
               </tbody>
             </Table>
           )}
-          <Row style={{ gap: '0.5rem' }}>
-            <CreateElectionButton
-              variant={elections.length === 0 ? 'primary' : undefined}
-            />
-            <FileInputButton
-              accept=".json"
-              onChange={onSelectElectionFile}
-              disabled={createElectionMutation.isLoading}
-            >
-              Load Election
-            </FileInputButton>
-          </Row>
+          {features.CREATE_ELECTION && (
+            <Row style={{ gap: '0.5rem' }}>
+              <CreateElectionButton
+                variant={elections.length === 0 ? 'primary' : undefined}
+              />
+              <FileInputButton
+                accept=".json"
+                onChange={onSelectElectionFile}
+                disabled={createElectionMutation.isLoading}
+              >
+                Load Election
+              </FileInputButton>
+            </Row>
+          )}
         </Column>
       </MainContent>
     </NavScreen>
+  );
+}
+
+export function ElectionsScreen(): JSX.Element {
+  return (
+    <UserFeaturesProvider>
+      <ElectionsScreenContents />
+    </UserFeaturesProvider>
   );
 }

--- a/apps/design/frontend/src/features_context.tsx
+++ b/apps/design/frontend/src/features_context.tsx
@@ -29,6 +29,10 @@ enum UserFeature {
    * Allow the user to create an election.
    */
   CREATE_ELECTION = 'CREATE_ELECTION',
+  /**
+   * Allow the user to delete an election.
+   */
+  DELETE_ELECTION = 'DELETE_ELECTION',
 }
 
 /**
@@ -67,6 +71,7 @@ const userFeatureConfigs = {
     EXPORT_SCREEN: true,
     ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
     CREATE_ELECTION: true,
+    DELETE_ELECTION: true,
   },
   nh: {
     ACCESS_ALL_ORGS: false,
@@ -74,6 +79,7 @@ const userFeatureConfigs = {
     EXPORT_SCREEN: false,
     ONLY_LETTER_AND_LEGAL_PAPER_SIZES: true,
     CREATE_ELECTION: false,
+    DELETE_ELECTION: false,
   },
 } satisfies Record<string, UserFeaturesConfig>;
 

--- a/apps/design/frontend/src/features_context.tsx
+++ b/apps/design/frontend/src/features_context.tsx
@@ -1,79 +1,151 @@
 import React, { createContext, useContext } from 'react';
 import { assertDefined } from '@votingworks/basics';
 import { ElectionId } from '@votingworks/types';
-import { getElection } from './api';
+import { getElection, getUser } from './api';
 
-export enum FeatureName {
-  BALLOT_BUBBLE_SIDE = 'BALLOT_BUBBLE_SIDE',
+/**
+ * Features that should be enabled based on the user's organization - i.e.
+ * differentiating between what VX support users can do and what election
+ * officials can do.
+ */
+enum UserFeature {
+  /**
+   * Allow the user to access all elections across all organizations.
+   */
+  ACCESS_ALL_ORGS = 'ACCESS_ALL_ORGS',
+}
+
+/**
+ * Features that should be enabled based on the organization of the election
+ * currently being viewed. VX support users and election officials should all
+ * have the same functionality for these features when viewing a specific
+ * election.
+ */
+enum ElectionFeature {
+  /**
+   * Add a field to override the election title for a precinct split.
+   */
   PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE = 'PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE',
+  /**
+   * Add a field to upload a clerk signature image for a precinct split.
+   */
   PRECINCT_SPLIT_CLERK_SIGNATURE_IMAGE = 'PRECINCT_SPLIT_CLERK_SIGNATURE_IMAGE',
+  /**
+   * Add a field to enter a caption for the clerk signature image for a precinct split.
+   */
   PRECINCT_SPLIT_CLERK_SIGNATURE_CAPTION = 'PRECINCT_SPLIT_CLERK_SIGNATURE_CAPTION',
 }
 
-export type FeaturesEnabledRecord = Record<FeatureName, boolean>;
+export type UserFeaturesConfig = Record<UserFeature, boolean>;
+export type ElectionFeaturesConfig = Record<ElectionFeature, boolean>;
 
-export const DEFAULT_ENABLED_FEATURES: FeaturesEnabledRecord = {
-  BALLOT_BUBBLE_SIDE: false,
-  PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE: false,
-  PRECINCT_SPLIT_CLERK_SIGNATURE_IMAGE: false,
-  PRECINCT_SPLIT_CLERK_SIGNATURE_CAPTION: false,
-};
+interface FeaturesConfig {
+  user: UserFeaturesConfig;
+  election?: ElectionFeaturesConfig;
+}
 
-export const NH_ENABLED_FEATURES: FeaturesEnabledRecord = {
-  BALLOT_BUBBLE_SIDE: true,
-  PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE: true,
-  PRECINCT_SPLIT_CLERK_SIGNATURE_IMAGE: true,
-  PRECINCT_SPLIT_CLERK_SIGNATURE_CAPTION: true,
-};
+const userFeatureConfigs = {
+  vx: {
+    ACCESS_ALL_ORGS: true,
+  },
+  nh: {
+    ACCESS_ALL_ORGS: false,
+  },
+} satisfies Record<string, UserFeaturesConfig>;
 
-const FeaturesContext = createContext<FeaturesEnabledRecord>(
-  DEFAULT_ENABLED_FEATURES
-);
+const electionFeatureConfigs = {
+  // VX sandbox elections should have not have any state-specific features
+  // enabled
+  vx: {
+    PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE: false,
+    PRECINCT_SPLIT_CLERK_SIGNATURE_IMAGE: false,
+    PRECINCT_SPLIT_CLERK_SIGNATURE_CAPTION: false,
+  },
 
-export function useFeaturesContext(): FeaturesEnabledRecord {
+  nh: {
+    PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE: true,
+    PRECINCT_SPLIT_CLERK_SIGNATURE_IMAGE: true,
+    PRECINCT_SPLIT_CLERK_SIGNATURE_CAPTION: true,
+  },
+} satisfies Record<string, ElectionFeaturesConfig>;
+
+const FeaturesContext = createContext<FeaturesConfig | undefined>(undefined);
+
+function useFeatures(): FeaturesConfig {
   return assertDefined(
     useContext(FeaturesContext),
     'useFeatures must be used within a FeaturesProvider'
   );
 }
 
+export function useUserFeatures(): UserFeaturesConfig {
+  const features = useFeatures();
+  return features.user;
+}
+
+export function useElectionFeatures(): ElectionFeaturesConfig {
+  const features = useFeatures();
+  return assertDefined(
+    features.election,
+    'Must pass electionId to FeaturesProvider to access election features'
+  );
+}
+
+export function UserFeaturesProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element | null {
+  const getUserQuery = getUser.useQuery();
+  if (!getUserQuery.isSuccess) {
+    return null;
+  }
+
+  // TODO: Eventually we'll want to map user org IDs to feature configs (likely
+  // on the backend), but for now we just use a flag to differentiate between
+  // VX and NH users.
+  const userFeatures = getUserQuery.data.isVotingWorksUser
+    ? userFeatureConfigs.vx
+    : userFeatureConfigs.nh;
+
+  return (
+    <FeaturesContext.Provider value={{ user: userFeatures }}>
+      {children}
+    </FeaturesContext.Provider>
+  );
+}
+
 interface FeaturesProviderProps {
   children: React.ReactNode;
-  electionId?: ElectionId;
+  electionId: ElectionId;
 }
 
 export function FeaturesProvider({
   children,
   electionId,
-}: FeaturesProviderProps): JSX.Element {
-  if (!electionId) {
-    return (
-      <FeaturesContext.Provider value={DEFAULT_ENABLED_FEATURES}>
-        {children}
-      </FeaturesContext.Provider>
-    );
-  }
-
+}: FeaturesProviderProps): JSX.Element | null {
+  const getUserQuery = getUser.useQuery();
   const getElectionQuery = getElection.useQuery(electionId);
-  let features = DEFAULT_ENABLED_FEATURES;
-
-  if (getElectionQuery.isSuccess) {
-    const { election } = getElectionQuery.data;
-    const electionState = election.state.toLowerCase();
-    // TODO expand to include vx or SLI users who should have access to all features.
-    // Blocked on auth implementation.
-    switch (electionState) {
-      case 'nh':
-      case 'new hampshire':
-        features = NH_ENABLED_FEATURES;
-        break;
-      default:
-        features = DEFAULT_ENABLED_FEATURES;
-    }
+  if (!(getUserQuery.isSuccess && getElectionQuery.isSuccess)) {
+    return null;
   }
+
+  // TODO: Eventually we'll want to map user org IDs to feature configs (likely
+  // on the backend), but for now we just use a flag to differentiate between
+  // VX and NH users.
+  const userFeatures = getUserQuery.data.isVotingWorksUser
+    ? userFeatureConfigs.vx
+    : userFeatureConfigs.nh;
+  const electionFeatures =
+    getUserQuery.data.isVotingWorksUser &&
+    getElectionQuery.data.orgId === getUserQuery.data.orgId
+      ? electionFeatureConfigs.vx
+      : electionFeatureConfigs.nh;
 
   return (
-    <FeaturesContext.Provider value={features}>
+    <FeaturesContext.Provider
+      value={{ user: userFeatures, election: electionFeatures }}
+    >
       {children}
     </FeaturesContext.Provider>
   );

--- a/apps/design/frontend/src/features_context.tsx
+++ b/apps/design/frontend/src/features_context.tsx
@@ -21,6 +21,10 @@ enum UserFeature {
    * Show the export screen.
    */
   EXPORT_SCREEN = 'EXPORT_SCREEN',
+  /**
+   * Only allow selecting Letter and Legal paper sizes for ballots.
+   */
+  ONLY_LETTER_AND_LEGAL_PAPER_SIZES = 'ONLY_LETTER_AND_LEGAL_PAPER_SIZES',
 }
 
 /**
@@ -57,11 +61,13 @@ const userFeatureConfigs = {
     ACCESS_ALL_ORGS: true,
     TABULATION_SCREEN: true,
     EXPORT_SCREEN: true,
+    ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
   },
   nh: {
     ACCESS_ALL_ORGS: false,
     TABULATION_SCREEN: false,
     EXPORT_SCREEN: false,
+    ONLY_LETTER_AND_LEGAL_PAPER_SIZES: true,
   },
 } satisfies Record<string, UserFeaturesConfig>;
 

--- a/apps/design/frontend/src/features_context.tsx
+++ b/apps/design/frontend/src/features_context.tsx
@@ -13,6 +13,14 @@ enum UserFeature {
    * Allow the user to access all elections across all organizations.
    */
   ACCESS_ALL_ORGS = 'ACCESS_ALL_ORGS',
+  /**
+   * Show the tabulation setting screen.
+   */
+  TABULATION_SCREEN = 'TABULATION_SCREEN',
+  /**
+   * Show the export screen.
+   */
+  EXPORT_SCREEN = 'EXPORT_SCREEN',
 }
 
 /**
@@ -47,9 +55,13 @@ interface FeaturesConfig {
 const userFeatureConfigs = {
   vx: {
     ACCESS_ALL_ORGS: true,
+    TABULATION_SCREEN: true,
+    EXPORT_SCREEN: true,
   },
   nh: {
     ACCESS_ALL_ORGS: false,
+    TABULATION_SCREEN: false,
+    EXPORT_SCREEN: false,
   },
 } satisfies Record<string, UserFeaturesConfig>;
 

--- a/apps/design/frontend/src/features_context.tsx
+++ b/apps/design/frontend/src/features_context.tsx
@@ -25,6 +25,10 @@ enum UserFeature {
    * Only allow selecting Letter and Legal paper sizes for ballots.
    */
   ONLY_LETTER_AND_LEGAL_PAPER_SIZES = 'ONLY_LETTER_AND_LEGAL_PAPER_SIZES',
+  /**
+   * Allow the user to create an election.
+   */
+  CREATE_ELECTION = 'CREATE_ELECTION',
 }
 
 /**
@@ -62,12 +66,14 @@ const userFeatureConfigs = {
     TABULATION_SCREEN: true,
     EXPORT_SCREEN: true,
     ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
+    CREATE_ELECTION: true,
   },
   nh: {
     ACCESS_ALL_ORGS: false,
     TABULATION_SCREEN: false,
     EXPORT_SCREEN: false,
     ONLY_LETTER_AND_LEGAL_PAPER_SIZES: true,
+    CREATE_ELECTION: false,
   },
 } satisfies Record<string, UserFeaturesConfig>;
 

--- a/apps/design/frontend/src/features_context.tsx
+++ b/apps/design/frontend/src/features_context.tsx
@@ -101,26 +101,10 @@ const electionFeatureConfigs = {
 
 const FeaturesContext = createContext<FeaturesConfig | undefined>(undefined);
 
-function useFeatures(): FeaturesConfig {
-  return assertDefined(
-    useContext(FeaturesContext),
-    'useFeatures must be used within a FeaturesProvider'
-  );
-}
-
-export function useUserFeatures(): UserFeaturesConfig {
-  const features = useFeatures();
-  return features.user;
-}
-
-export function useElectionFeatures(): ElectionFeaturesConfig {
-  const features = useFeatures();
-  return assertDefined(
-    features.election,
-    'Must pass electionId to FeaturesProvider to access election features'
-  );
-}
-
+/**
+ * When not in the context of a specific election, use UserFeaturesProvider to
+ * provide {@link UserFeature} flags.
+ */
 export function UserFeaturesProvider({
   children,
 }: {
@@ -150,6 +134,10 @@ interface FeaturesProviderProps {
   electionId: ElectionId;
 }
 
+/**
+ * When in the context of a specific election, use FeaturesProvider to provide both
+ * {@link UserFeature} and {@link ElectionFeature} flags.
+ */
 export function FeaturesProvider({
   children,
   electionId,
@@ -178,5 +166,25 @@ export function FeaturesProvider({
     >
       {children}
     </FeaturesContext.Provider>
+  );
+}
+
+function useFeatures(): FeaturesConfig {
+  return assertDefined(
+    useContext(FeaturesContext),
+    'useFeatures must be used within a FeaturesProvider'
+  );
+}
+
+export function useUserFeatures(): UserFeaturesConfig {
+  const features = useFeatures();
+  return features.user;
+}
+
+export function useElectionFeatures(): ElectionFeaturesConfig {
+  const features = useFeatures();
+  return assertDefined(
+    features.election,
+    'Must pass electionId to FeaturesProvider to access election features'
   );
 }

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -52,7 +52,7 @@ import {
 } from './api';
 import { generateId, hasSplits, replaceAtIndex } from './utils';
 import { ImageInput } from './image_input';
-import { useFeaturesContext } from './features_context';
+import { useElectionFeatures } from './features_context';
 
 function DistrictsTab(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
@@ -453,7 +453,7 @@ function PrecinctForm({
   savedPrecincts: Precinct[];
   districts: readonly District[];
 }): JSX.Element | null {
-  const features = useFeaturesContext();
+  const features = useElectionFeatures();
   const [precinct, setPrecinct] = useState<Precinct | undefined>(
     precinctId
       ? savedPrecincts.find((p) => p.id === precinctId)

--- a/apps/design/frontend/src/nav_screen.tsx
+++ b/apps/design/frontend/src/nav_screen.tsx
@@ -13,6 +13,7 @@ import {
 } from '@votingworks/ui';
 import { Link, useRouteMatch } from 'react-router-dom';
 import { electionNavRoutes } from './routes';
+import { useUserFeatures } from './features_context';
 
 export function NavScreen({
   navContent,
@@ -42,11 +43,12 @@ export function ElectionNavScreen({
   children: React.ReactNode;
 }): JSX.Element {
   const currentRoute = useRouteMatch();
+  const features = useUserFeatures();
   return (
     <NavScreen
       navContent={
         <NavList>
-          {electionNavRoutes(electionId).map(({ title, path }) => (
+          {electionNavRoutes(electionId, features).map(({ title, path }) => (
             <NavListItem key={path}>
               <NavLink to={path} isActive={path === currentRoute.url}>
                 {title}

--- a/apps/design/frontend/src/routes.ts
+++ b/apps/design/frontend/src/routes.ts
@@ -1,5 +1,6 @@
 import { ElectionId } from '@votingworks/types';
 import { Route } from '@votingworks/ui';
+import { UserFeaturesConfig } from './features_context';
 
 export const routes = {
   root: {
@@ -125,7 +126,10 @@ export interface ElectionIdParams {
 export const electionParamRoutes = routes.election(':electionId');
 
 export const rootNavRoutes: Route[] = [];
-export function electionNavRoutes(electionId: ElectionId): Route[] {
+export function electionNavRoutes(
+  electionId: ElectionId,
+  features: UserFeaturesConfig
+): Route[] {
   const electionRoutes = routes.election(electionId);
   return [
     electionRoutes.electionInfo,
@@ -133,7 +137,7 @@ export function electionNavRoutes(electionId: ElectionId): Route[] {
     electionRoutes.contests.root,
     electionRoutes.ballots.root,
     electionRoutes.ballotOrderInfo,
-    electionRoutes.tabulation,
-    electionRoutes.export,
+    ...(features.TABULATION_SCREEN ? [electionRoutes.tabulation] : []),
+    ...(features.EXPORT_SCREEN ? [electionRoutes.export] : []),
   ];
 }


### PR DESCRIPTION
## Overview


Split the features context into user features vs election features:
- User features are features that should be enabled based on the user's organization - i.e. differentiating between what VX support users can do and what election officials can do.
- Election features are features that should be enabled based on the organization of the election currently being viewed. VX support users and election officials should all have the same functionality for these features when viewing a specific election.

This model of feature flagging means we won't need any sort of feature for support users to "log in as" election official users.

Uses this feature flagging to implement a few tasks:
- https://github.com/votingworks/vxsuite/issues/5810
- https://github.com/votingworks/vxsuite/issues/5868
- https://github.com/votingworks/vxsuite/issues/5917 (first two points)

## Demo Video or Screenshot


https://github.com/user-attachments/assets/17f4e7db-16a7-4150-93ea-e139e9aab3d3




## Testing Plan
Manual testing - skipping automated tests since auth integration broke them all

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
