### PR TITLE
feat(design): add Ballot Order Info form validation

### DIFF
--- a/apps/design/frontend/src/ballot_order_info_screen.test.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.test.tsx
@@ -47,7 +47,7 @@ test('updating ballot order info', async () => {
     'Number of Absentee Ballots'
   );
   expect(absenteeBallotCountInput).toBeDisabled();
-  expect(absenteeBallotCountInput).toHaveValue('');
+  expect(absenteeBallotCountInput).toHaveValue(null);
 
   const shouldAbsenteeBallotsBeScoredForFoldingCheckbox = screen.getByRole(
     'checkbox',
@@ -60,7 +60,7 @@ test('updating ballot order info', async () => {
     'Number of Polling Place Ballots'
   );
   expect(precinctBallotCountInput).toBeDisabled();
-  expect(precinctBallotCountInput).toHaveValue('');
+  expect(precinctBallotCountInput).toHaveValue(null);
 
   const ballotColorInput = screen.getByLabelText('Paper Color for Ballots');
   expect(ballotColorInput).toBeDisabled();
@@ -102,7 +102,7 @@ test('updating ballot order info', async () => {
   userEvent.type(deliveryRecipientPhoneNumberInput, '(123) 456-7890');
   userEvent.type(deliveryAddressInput, '123 Main St, Town, NH, 00000');
 
-  let expectedBallotOrderInfo: BallotOrderInfo = {
+  const expectedBallotOrderInfo: BallotOrderInfo = {
     absenteeBallotCount: '100',
     shouldAbsenteeBallotsBeScoredForFolding: true,
     precinctBallotCount: '200',
@@ -123,58 +123,16 @@ test('updating ballot order info', async () => {
   userEvent.click(screen.getByRole('button', { name: 'Save' }));
   await screen.findByRole('button', { name: 'Edit' });
 
-  expect(absenteeBallotCountInput).toHaveValue('100');
+  expect(absenteeBallotCountInput).toHaveValue(100);
   expect(shouldAbsenteeBallotsBeScoredForFoldingCheckbox).toBeChecked();
-  expect(precinctBallotCountInput).toHaveValue('200');
+  expect(precinctBallotCountInput).toHaveValue(200);
   expect(ballotColorInput).toHaveValue('Yellow for town, white for school');
   expect(shouldPrintCollatedCheckbox).toBeChecked();
   expect(deliveryRecipientNameInput).toHaveValue('Clerky Clerkson');
   expect(deliveryRecipientPhoneNumberInput).toHaveValue('(123) 456-7890');
   expect(deliveryAddressInput).toHaveValue('123 Main St, Town, NH, 00000');
 
-  // Clear ballot order info
-
-  userEvent.click(screen.getByRole('button', { name: 'Edit' }));
-  userEvent.clear(absenteeBallotCountInput);
-  userEvent.click(shouldAbsenteeBallotsBeScoredForFoldingCheckbox);
-  userEvent.clear(precinctBallotCountInput);
-  userEvent.clear(ballotColorInput);
-  userEvent.click(shouldPrintCollatedCheckbox);
-  userEvent.clear(deliveryRecipientNameInput);
-  userEvent.clear(deliveryRecipientPhoneNumberInput);
-  userEvent.clear(deliveryAddressInput);
-
-  expectedBallotOrderInfo = {
-    absenteeBallotCount: '',
-    shouldAbsenteeBallotsBeScoredForFolding: false,
-    precinctBallotCount: '',
-    ballotColor: '',
-    shouldPrintCollated: false,
-    deliveryRecipientName: '',
-    deliveryRecipientPhoneNumber: '',
-    deliveryAddress: '',
-  };
-  apiMock.updateBallotOrderInfo
-    .expectCallWith({ electionId, ballotOrderInfo: expectedBallotOrderInfo })
-    .resolves();
-  apiMock.getElection.expectCallWith({ electionId }).resolves({
-    ...electionRecord,
-    ballotOrderInfo: expectedBallotOrderInfo,
-  });
-
-  userEvent.type(deliveryAddressInput, '{enter}');
-  await screen.findByRole('button', { name: 'Edit' });
-
-  expect(absenteeBallotCountInput).toHaveValue('');
-  expect(shouldAbsenteeBallotsBeScoredForFoldingCheckbox).not.toBeChecked();
-  expect(precinctBallotCountInput).toHaveValue('');
-  expect(ballotColorInput).toHaveValue('');
-  expect(shouldPrintCollatedCheckbox).not.toBeChecked();
-  expect(deliveryRecipientNameInput).toHaveValue('');
-  expect(deliveryRecipientPhoneNumberInput).toHaveValue('');
-  expect(deliveryAddressInput).toHaveValue('');
-
-  // Begin repopulating ballot order info but cancel
+  // Begin updating ballot order info but cancel
 
   userEvent.click(screen.getByRole('button', { name: 'Edit' }));
   userEvent.type(absenteeBallotCountInput, 'A');
@@ -188,12 +146,43 @@ test('updating ballot order info', async () => {
 
   userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
-  expect(absenteeBallotCountInput).toHaveValue('');
-  expect(shouldAbsenteeBallotsBeScoredForFoldingCheckbox).not.toBeChecked();
-  expect(precinctBallotCountInput).toHaveValue('');
-  expect(ballotColorInput).toHaveValue('');
-  expect(shouldPrintCollatedCheckbox).not.toBeChecked();
+  expect(absenteeBallotCountInput).toHaveValue(100);
+  expect(shouldAbsenteeBallotsBeScoredForFoldingCheckbox).toBeChecked();
+  expect(precinctBallotCountInput).toHaveValue(200);
+  expect(ballotColorInput).toHaveValue('Yellow for town, white for school');
+  expect(shouldPrintCollatedCheckbox).toBeChecked();
+  expect(deliveryRecipientNameInput).toHaveValue('Clerky Clerkson');
+  expect(deliveryRecipientPhoneNumberInput).toHaveValue('(123) 456-7890');
+  expect(deliveryAddressInput).toHaveValue('123 Main St, Town, NH, 00000');
+});
+
+test('updating ballot order info with validation errors', async () => {
+  apiMock.getElection.expectCallWith({ electionId }).resolves(electionRecord);
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Ballot Order Info' });
+
+  userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+  const absenteeBallotCountInput = screen.getByLabelText(
+    'Number of Absentee Ballots'
+  );
+  expect(absenteeBallotCountInput).toBeInvalid();
+  expect(absenteeBallotCountInput).toHaveValue(null);
+
+  const precinctBallotCountInput = screen.getByLabelText(
+    'Number of Polling Place Ballots'
+  );
+  expect(precinctBallotCountInput).toBeInvalid();
+  expect(precinctBallotCountInput).toHaveValue(null);
+
+  // try to save an invalid value
+  const deliveryRecipientNameInput = screen.getByLabelText(
+    'Delivery Recipient Name'
+  );
+  userEvent.type(deliveryRecipientNameInput, '       ');
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+  expect(deliveryRecipientNameInput).toBeInvalid();
+  // value gets trimmed
   expect(deliveryRecipientNameInput).toHaveValue('');
-  expect(deliveryRecipientPhoneNumberInput).toHaveValue('');
-  expect(deliveryAddressInput).toHaveValue('');
 });

--- a/apps/design/frontend/src/ballot_order_info_screen.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.tsx
@@ -71,6 +71,8 @@ function BallotOrderInfoForm({
       <InputGroup label="Number of Absentee Ballots">
         <input
           type="number"
+          min={0}
+          step={1}
           value={ballotOrderInfo.absenteeBallotCount ?? ''}
           onChange={(e) =>
             setBallotOrderInfo({
@@ -107,6 +109,8 @@ function BallotOrderInfoForm({
       <InputGroup label="Number of Polling Place Ballots">
         <input
           type="number"
+          min={0}
+          step={1}
           value={ballotOrderInfo.precinctBallotCount ?? ''}
           onChange={(e) =>
             setBallotOrderInfo({

--- a/apps/design/frontend/src/ballot_order_info_screen.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.tsx
@@ -53,12 +53,8 @@ function BallotOrderInfoForm({
   }
 
   function onReset() {
-    if (isEditing) {
-      setBallotOrderInfo(savedBallotOrderInfo);
-      setIsEditing(false);
-    } else {
-      setIsEditing(true);
-    }
+    setBallotOrderInfo(savedBallotOrderInfo);
+    setIsEditing((prev) => !prev);
   }
 
   return (
@@ -74,7 +70,7 @@ function BallotOrderInfoForm({
     >
       <InputGroup label="Number of Absentee Ballots">
         <input
-          type="text"
+          type="number"
           value={ballotOrderInfo.absenteeBallotCount ?? ''}
           onChange={(e) =>
             setBallotOrderInfo({
@@ -82,7 +78,14 @@ function BallotOrderInfoForm({
               absenteeBallotCount: e.target.value,
             })
           }
+          onBlur={(e) => {
+            setBallotOrderInfo({
+              ...ballotOrderInfo,
+              absenteeBallotCount: e.target.value.trim(),
+            });
+          }}
           disabled={!isEditing}
+          required
         />
       </InputGroup>
       <Annotation>
@@ -103,7 +106,7 @@ function BallotOrderInfoForm({
       />
       <InputGroup label="Number of Polling Place Ballots">
         <input
-          type="text"
+          type="number"
           value={ballotOrderInfo.precinctBallotCount ?? ''}
           onChange={(e) =>
             setBallotOrderInfo({
@@ -111,7 +114,14 @@ function BallotOrderInfoForm({
               precinctBallotCount: e.target.value,
             })
           }
+          onBlur={(e) => {
+            setBallotOrderInfo({
+              ...ballotOrderInfo,
+              precinctBallotCount: e.target.value.trim(),
+            });
+          }}
           disabled={!isEditing}
+          required
         />
       </InputGroup>
       <Annotation>
@@ -127,6 +137,12 @@ function BallotOrderInfoForm({
               ballotColor: e.target.value,
             })
           }
+          onBlur={(e) => {
+            setBallotOrderInfo({
+              ...ballotOrderInfo,
+              ballotColor: e.target.value.trim(),
+            });
+          }}
           disabled={!isEditing}
         />
       </InputGroup>
@@ -155,12 +171,19 @@ function BallotOrderInfoForm({
               deliveryRecipientName: e.target.value,
             })
           }
+          onBlur={(e) => {
+            setBallotOrderInfo({
+              ...ballotOrderInfo,
+              deliveryRecipientName: e.target.value.trim(),
+            });
+          }}
           disabled={!isEditing}
+          required
         />
       </InputGroup>
       <InputGroup label="Delivery Recipient Phone Number">
         <input
-          type="text"
+          type="tel"
           value={ballotOrderInfo.deliveryRecipientPhoneNumber ?? ''}
           onChange={(e) =>
             setBallotOrderInfo({
@@ -168,7 +191,14 @@ function BallotOrderInfoForm({
               deliveryRecipientPhoneNumber: e.target.value,
             })
           }
+          onBlur={(e) => {
+            setBallotOrderInfo({
+              ...ballotOrderInfo,
+              deliveryRecipientPhoneNumber: e.target.value.trim(),
+            });
+          }}
           disabled={!isEditing}
+          required
         />
       </InputGroup>
       <InputGroup label="Delivery Address, City, State, and ZIP">
@@ -181,7 +211,14 @@ function BallotOrderInfoForm({
               deliveryAddress: e.target.value,
             })
           }
+          onBlur={(e) => {
+            setBallotOrderInfo({
+              ...ballotOrderInfo,
+              deliveryAddress: e.target.value.trim(),
+            });
+          }}
           disabled={!isEditing}
+          required
         />
       </InputGroup>
 


### PR DESCRIPTION
## Overview

Adds validation to the Ballot Order Info screen. Changes some of the inputs to more appropriate types (i.e. number/tel) and trims fields on blur. Does not add any server-side validation, which we'll add in a subsequent PR.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/91a20558-6dd3-4327-b776-c0d0a228ae7d

## Testing Plan
Manual testing plus some added/updated automated tests.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
