### PR TITLE
pdi-scanner: Mitigate USB blips

### DIFF
--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -174,6 +174,7 @@ fn error_to_code_and_message(error: &Error) -> (ErrorCode, Option<String>) {
     match error {
         Error::Usb(UsbError::Rusb(rusb::Error::NotFound))
         | Error::Usb(UsbError::Rusb(rusb::Error::Io))
+        | Error::Usb(UsbError::Rusb(rusb::Error::Other))
         | Error::Usb(UsbError::RusbAsync(rusb_async::Error::Stall)) => {
             (ErrorCode::Disconnected, None)
         }


### PR DESCRIPTION
## Overview

Sketch of two patches to mitigate two different PDI scanner errors:
- `Error occurred during transfer execution` - If we see this error when polling the scanner, retry polling a couple of times before bailing.
- `rusb error: Other error` - If we see this error when connecting, treat it as if the scanner is disconnected.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
