### PR TITLE
VxDesign: Unfinalize ballots button

### DIFF
--- a/libs/utils/src/format.test.ts
+++ b/libs/utils/src/format.test.ts
@@ -28,6 +28,12 @@ test('formats locale long date and time properly', () => {
   ).toEqual('Tuesday, April 14, 2020 at 1:15:09 AM AKDT');
 });
 
+test('formats locale short date and time properly', () => {
+  expect(
+    format.localeShortDateAndTime(new Date(2020, 3, 14, 1, 15, 9, 26))
+  ).toEqual('4/14/2020, 1:15 AM');
+});
+
 test('formats locale weekday and date properly', () => {
   expect(
     format.localeWeekdayAndDate(new Date(2020, 3, 14, 1, 15, 9, 26))

--- a/libs/utils/src/format.ts
+++ b/libs/utils/src/format.ts
@@ -41,6 +41,16 @@ export function localeLongDateAndTime(time?: number | Date): string {
   }).format(time);
 }
 
+export function localeShortDateAndTime(time?: number | Date): string {
+  return new Intl.DateTimeFormat(DEFAULT_LOCALE, {
+    month: 'numeric',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  }).format(time);
+}
+
 export function localeWeekdayAndDate(time?: number | Date): string {
   return new Intl.DateTimeFormat(DEFAULT_LOCALE, {
     weekday: 'long',


### PR DESCRIPTION
## Overview

Task: #5862 

Adds a "Proofing Status" section to the Export screen (which will only be available to support users) that shows whether or not ballots have been finalized. If they have been finalized, shows a button to unfinalize.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/10cec040-575a-49a2-b24e-0c611f4428e8



## Testing Plan
Added automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
