### PR TITLE
VxDesign db restore script and downgrade to Postgres 16.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ executors:
           username: $VX_DOCKER_USERNAME
           password: $VX_DOCKER_PASSWORD
 
-      - image: cimg/postgres:17.0
+      - image: cimg/postgres:16.6
         environment:
           POSTGRES_USER: postgres
 

--- a/apps/design/backend/README.md
+++ b/apps/design/backend/README.md
@@ -3,38 +3,3 @@
 This backend is used by the [VxDesign frontend](../frontend) and isn't intended
 to be run on its own. The best way to develop on the backend is by running the
 frontend.
-
-## PostgreSQL Version
-
-VxDesign expects PostgreSQL version 16.6. Debian 12
-[defaults](https://packages.debian.org/bookworm/postgresql) to PostgreSQL
-version 15.
-
-To upgrade, configure `apt` to use the PostgreSQL Apt Repository. From the
-official [PostgreSQL docs](https://www.postgresql.org/download/linux/debian/)
-run
-
-```bash
-sudo apt install -y postgresql-common
-sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
-```
-
-then install `postgresql-16`:
-
-```bash
-sudo apt install postgresql-16 postgresql-client-16
-```
-
-## Restoring database from snapshot
-
-[restore_db_backup.sh](./scripts/restore_db_backup.sh) can be used to restore a
-database snapshot to your dev environment. Running this script will delete your
-existing local `design` database.
-
-To run this script you may need to configure your environment to use the same
-version of `pg_restore` as production. Add `pg_restore` v16 to your PATH in your
-`.bashrc` or `.bash_profile`:
-
-```
-export PATH=/usr/lib/postgresql/16/bin:$PATH
-```

--- a/apps/design/backend/README.md
+++ b/apps/design/backend/README.md
@@ -3,3 +3,38 @@
 This backend is used by the [VxDesign frontend](../frontend) and isn't intended
 to be run on its own. The best way to develop on the backend is by running the
 frontend.
+
+## PostgreSQL Version
+
+VxDesign expects PostgreSQL version 16.6. Debian 12
+[defaults](https://packages.debian.org/bookworm/postgresql) to PostgreSQL
+version 15.
+
+To upgrade, configure `apt` to use the PostgreSQL Apt Repository. From the
+official [PostgreSQL docs](https://www.postgresql.org/download/linux/debian/)
+run
+
+```bash
+sudo apt install -y postgresql-common
+sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+```
+
+then install `postgresql-16`:
+
+```bash
+sudo apt install postgresql-16 postgresql-client-16
+```
+
+## Restoring database from snapshot
+
+[restore_db_backup.sh](./scripts/restore_db_backup.sh) can be used to restore a
+database snapshot to your dev environment. Running this script will delete your
+existing local `design` database.
+
+To run this script you may need to configure your environment to use the same
+version of `pg_restore` as production. Add `pg_restore` v16 to your PATH in your
+`.bashrc` or `.bash_profile`:
+
+```
+export PATH=/usr/lib/postgresql/16/bin:$PATH
+```

--- a/apps/design/backend/scripts/restore_db_backup.sh
+++ b/apps/design/backend/scripts/restore_db_backup.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 BACKUP=${1:-latest.dump}
+PGPASSWORD=design dropdb -U design -h localhost design
+PGPASSWORD=design createdb -U design -h localhost design
 PGPASSWORD=design pg_restore --verbose --clean --no-acl --no-owner -h localhost -U design -d design $BACKUP

--- a/apps/design/backend/scripts/restore_db_backup.sh
+++ b/apps/design/backend/scripts/restore_db_backup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+BACKUP=${1:-latest.dump}
+PGPASSWORD=design pg_restore --verbose --clean --no-acl --no-owner -h localhost -U design -d design $BACKUP

--- a/apps/design/frontend/README.md
+++ b/apps/design/frontend/README.md
@@ -17,5 +17,56 @@ The server will be available at http://localhost:3000.
 ### Google Cloud Authentication
 
 Follow the instructions
-[here](../backend/src/language_and_audio/README.md#google-cloud-authentication)
+[here](../../../libs/backend/src/language_and_audio/README.md#google-cloud-authentication)
 to authenticate with Google Cloud for language and audio file generation.
+
+## PostgreSQL Version
+
+VxDesign expects PostgreSQL version 16.6. Debian 12
+[defaults](https://packages.debian.org/bookworm/postgresql) to PostgreSQL
+version 15.
+
+To upgrade, configure `apt` to use the PostgreSQL Apt Repository. From the
+official [PostgreSQL docs](https://www.postgresql.org/download/linux/debian/)
+run
+
+```bash
+sudo apt install -y postgresql-common
+sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+```
+
+then install `postgresql-16`:
+
+```bash
+sudo apt install postgresql-16 postgresql-client-16
+```
+
+## Restoring database from snapshot
+
+[restore_db_backup.sh](../backend/scripts/restore_db_backup.sh) can be used to
+restore a database snapshot to your dev environment. Running this script will
+delete your existing local `design` database.
+
+To run this script you may need to configure your environment to use the same
+version of `pg_restore` as production.
+
+Ensure you have installed Postgres 16 and have `pg_restore`:
+
+```bash
+$ /usr/lib/postgresql/16/bin/pg_restore --version
+pg_restore (PostgreSQL) 16.6 (Debian 16.6-1.pgdg120+1)
+```
+
+Add `pg_restore` v16 to your PATH in your `.bashrc` or `.bash_profile`:
+
+```
+export PATH=/usr/lib/postgresql/16/bin:$PATH
+```
+
+Confirm you're running `pg_restore` v16 by default:
+
+```bash
+$ source ~/.bashrc
+$ pg_restore --version
+pg_restore (PostgreSQL) 16.6 (Debian 16.6-1.pgdg120+1)
+```

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -159,7 +159,7 @@ executors:
           username: $VX_DOCKER_USERNAME
           password: $VX_DOCKER_PASSWORD
 
-      - image: cimg/postgres:17.0
+      - image: cimg/postgres:16.6
         environment:
           POSTGRES_USER: postgres
 


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/5900

Adds a script and instructions for restoring a dev db from snapshot.

## Demo Video or Screenshot

N/a

## Testing Plan

- exported from prod and restored locally
