### PR TITLE
VxDesign: Show expected errors during ballot preview

### DIFF
--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -30,6 +30,7 @@ import {
 } from '@votingworks/basics';
 import JsZip from 'jszip';
 import {
+  BallotLayoutError,
   BallotMode,
   BallotTemplateId,
   ballotTemplates,
@@ -377,7 +378,9 @@ function buildApi({ workspace, translator }: AppContext) {
       ballotStyleId: BallotStyleId;
       ballotType: BallotType;
       ballotMode: BallotMode;
-    }): Promise<Result<{ pdfData: Buffer; fileName: string }, Error>> {
+    }): Promise<
+      Result<{ pdfData: Buffer; fileName: string }, BallotLayoutError>
+    > {
       const {
         election,
         ballotLanguageConfigs,
@@ -420,13 +423,14 @@ function buildApi({ workspace, translator }: AppContext) {
       );
       // eslint-disable-next-line no-console
       renderer.cleanup().catch(console.error);
+      if (ballotPdf.isErr()) return ballotPdf;
 
       const precinct = find(
         election.precincts,
         (p) => p.id === input.precinctId
       );
       return ok({
-        pdfData: ballotPdf,
+        pdfData: ballotPdf.ok(),
         fileName: `PROOF-${getPdfFileName(
           precinct.name,
           input.ballotStyleId,

--- a/apps/design/frontend/src/ballot_screen.tsx
+++ b/apps/design/frontend/src/ballot_screen.tsx
@@ -1,6 +1,6 @@
 import fileDownload from 'js-file-download';
 import { useParams } from 'react-router-dom';
-import { assertDefined, range } from '@votingworks/basics';
+import { assert, assertDefined, range } from '@votingworks/basics';
 import {
   getPrecinctById,
   getBallotStyle,
@@ -18,7 +18,7 @@ import styled from 'styled-components';
 import { z } from 'zod';
 import {
   Button,
-  Card,
+  Callout,
   H1,
   Icons,
   LinkButton,
@@ -299,6 +299,8 @@ export function BallotScreen(): JSX.Element | null {
             const ballotResult = getBallotPreviewPdfQuery.data;
 
             if (ballotResult.isErr()) {
+              const err = ballotResult.err();
+              assert(err.error === 'contestTooLong');
               return (
                 <Row
                   style={{
@@ -307,10 +309,12 @@ export function BallotScreen(): JSX.Element | null {
                     height: '100%',
                   }}
                 >
-                  <Card color="danger">
-                    Error:{' '}
-                    {ballotResult.err().message ?? 'Something went wrong'}
-                  </Card>
+                  <Callout color="danger" icon="Danger">
+                    <span>
+                      Contest &quot;{err.contest.title}&quot; was too long to
+                      fit on the page. Try a longer paper size.
+                    </span>
+                  </Callout>
                 </Row>
               );
             }

--- a/libs/hmpb/src/all_bubble_ballot_fixtures.tsx
+++ b/libs/hmpb/src/all_bubble_ballot_fixtures.tsx
@@ -12,7 +12,7 @@ import {
   VotesDict,
   ballotPaperDimensions,
 } from '@votingworks/types';
-import { DateWithoutTime, assertDefined, range } from '@votingworks/basics';
+import { DateWithoutTime, assertDefined, ok, range } from '@votingworks/basics';
 import { join } from 'node:path';
 import makeDebug from 'debug';
 import { Buffer } from 'node:buffer';
@@ -26,7 +26,7 @@ import {
 import {
   BallotPageTemplate,
   BaseBallotProps,
-  PagedElementResult,
+  ContentComponentResult,
   renderAllBallotsAndCreateElectionDefinition,
 } from './render_ballot';
 import { RenderScratchpad, Renderer } from './renderer';
@@ -188,7 +188,7 @@ async function BallotPageContent(
   props: (BaseBallotProps & { dimensions: PixelDimensions }) | undefined,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _scratchpad: RenderScratchpad
-): Promise<PagedElementResult<BaseBallotProps>> {
+): Promise<ContentComponentResult<BaseBallotProps>> {
   const { election, ...restProps } = assertDefined(props);
   const pageNumber = numPages - election.contests.length + 1;
   const bubbles = (
@@ -222,7 +222,7 @@ async function BallotPageContent(
     </div>
   );
   const contestsLeft = election.contests.slice(1);
-  return {
+  return ok({
     currentPageElement: bubbles,
     nextPageProps:
       contestsLeft.length === 0
@@ -234,7 +234,7 @@ async function BallotPageContent(
               contests: contestsLeft,
             },
           },
-  };
+  });
 }
 
 const allBubbleBallotTemplate: BallotPageTemplate<BaseBallotProps> = {

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import {
   assertDefined,
+  err,
   iter,
+  ok,
   range,
   throwIllegalValue,
 } from '@votingworks/basics';
@@ -27,7 +29,7 @@ import {
 import {
   BallotPageTemplate,
   BaseBallotProps,
-  PagedElementResult,
+  ContentComponentResult,
 } from '../render_ballot';
 import { RenderScratchpad } from '../renderer';
 import {
@@ -500,12 +502,12 @@ function Contest({
 async function BallotPageContent(
   props: (BaseBallotProps & { dimensions: PixelDimensions }) | undefined,
   scratchpad: RenderScratchpad
-): Promise<PagedElementResult<BaseBallotProps>> {
+): Promise<ContentComponentResult<BaseBallotProps>> {
   if (!props) {
-    return {
+    return ok({
       currentPageElement: <BlankPageMessage />,
       nextPageProps: undefined,
-    };
+    });
   }
 
   const { election, ballotStyleId, dimensions, ...restProps } = props;
@@ -604,6 +606,17 @@ async function BallotPageContent(
     );
   }
 
+  const contestsLeftToLayout = contestSectionsLeftToLayout.flat();
+  if (
+    contests.length > 0 &&
+    contestsLeftToLayout.flat().length === contests.length
+  ) {
+    return err({
+      error: 'contestTooLong',
+      contest: contestsLeftToLayout[0],
+    });
+  }
+
   const currentPageElement =
     pageSections.length > 0 ? (
       <div
@@ -630,10 +643,10 @@ async function BallotPageContent(
         }
       : undefined;
 
-  return {
+  return ok({
     currentPageElement,
     nextPageProps,
-  };
+  });
 }
 
 export type NhBallotProps = BaseBallotProps & NhPrecinctSplitOptions;

--- a/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
@@ -1,7 +1,9 @@
 /* istanbul ignore file - must be manually tested against v3 interpreter @preserve */
 import {
   assertDefined,
+  err,
   iter,
+  ok,
   range,
   throwIllegalValue,
 } from '@votingworks/basics';
@@ -29,7 +31,7 @@ import React from 'react';
 import {
   BallotPageTemplate,
   BaseBallotProps,
-  PagedElementResult,
+  ContentComponentResult,
 } from '../render_ballot';
 import { RenderScratchpad } from '../renderer';
 import {
@@ -634,12 +636,12 @@ async function Contest({
 async function BallotPageContent(
   props: (BaseBallotProps & { dimensions: PixelDimensions }) | undefined,
   scratchpad: RenderScratchpad
-): Promise<PagedElementResult<BaseBallotProps>> {
+): Promise<ContentComponentResult<BaseBallotProps>> {
   if (!props) {
-    return {
+    return ok({
       currentPageElement: <BlankPageMessage />,
       nextPageProps: undefined,
-    };
+    });
   }
 
   const { election, ballotStyleId, dimensions, ...restProps } = props;
@@ -780,6 +782,17 @@ async function BallotPageContent(
     );
   }
 
+  const contestsLeftToLayout = contestSectionsLeftToLayout.flat();
+  if (
+    contests.length > 0 &&
+    contestsLeftToLayout.flat().length === contests.length
+  ) {
+    return err({
+      error: 'contestTooLong',
+      contest: contestsLeftToLayout[0],
+    });
+  }
+
   const currentPageElement =
     pageSections.length > 0 ? (
       <div
@@ -806,10 +819,10 @@ async function BallotPageContent(
         }
       : undefined;
 
-  return {
+  return ok({
     currentPageElement,
     nextPageProps,
-  };
+  });
 }
 
 export const nhBallotTemplateV3: BallotPageTemplate<NhBallotProps> & {

--- a/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import {
   assertDefined,
+  err,
   iter,
+  ok,
   range,
   throwIllegalValue,
 } from '@votingworks/basics';
@@ -27,7 +29,7 @@ import {
 import {
   BallotPageTemplate,
   BaseBallotProps,
-  PagedElementResult,
+  ContentComponentResult,
 } from '../render_ballot';
 import { RenderScratchpad } from '../renderer';
 import {
@@ -444,12 +446,12 @@ function Contest({
 async function BallotPageContent(
   props: (BaseBallotProps & { dimensions: PixelDimensions }) | undefined,
   scratchpad: RenderScratchpad
-): Promise<PagedElementResult<BaseBallotProps>> {
+): Promise<ContentComponentResult<BaseBallotProps>> {
   if (!props) {
-    return {
+    return ok({
       currentPageElement: <BlankPageMessage />,
       nextPageProps: undefined,
-    };
+    });
   }
 
   const { election, ballotStyleId, dimensions, ...restProps } = props;
@@ -548,6 +550,17 @@ async function BallotPageContent(
     );
   }
 
+  const contestsLeftToLayout = contestSectionsLeftToLayout.flat();
+  if (
+    contests.length > 0 &&
+    contestsLeftToLayout.flat().length === contests.length
+  ) {
+    return err({
+      error: 'contestTooLong',
+      contest: contestsLeftToLayout[0],
+    });
+  }
+
   const currentPageElement =
     pageSections.length > 0 ? (
       <div
@@ -574,10 +587,10 @@ async function BallotPageContent(
         }
       : undefined;
 
-  return {
+  return ok({
     currentPageElement,
     nextPageProps,
-  };
+  });
 }
 
 export const vxDefaultBallotTemplate: BallotPageTemplate<BaseBallotProps> = {

--- a/libs/hmpb/src/preview/browser_preview.ts
+++ b/libs/hmpb/src/preview/browser_preview.ts
@@ -103,11 +103,9 @@ export async function main(): Promise<void> {
     await loadConfigFromSearchParams(new URL(location.href));
 
   const renderer = createBrowserPreviewRenderer();
-  const document = await renderBallotTemplate(
-    renderer,
-    template,
-    baseBallotProps
-  );
+  const document = (
+    await renderBallotTemplate(renderer, template, baseBallotProps)
+  ).unsafeUnwrap();
 
   // Mark some votes
   const contests = getContests({ election, ballotStyle });

--- a/libs/hmpb/src/watermark.test.ts
+++ b/libs/hmpb/src/watermark.test.ts
@@ -26,18 +26,16 @@ vi.setConfig({
 rendererTest('watermark', async ({ renderer }) => {
   const election = electionFamousNames2021Fixtures.readElection();
   const ballotStyle = election.ballotStyles[0];
-  const pdf = await renderBallotPreviewToPdf(
-    renderer,
-    vxDefaultBallotTemplate,
-    {
+  const pdf = (
+    await renderBallotPreviewToPdf(renderer, vxDefaultBallotTemplate, {
       election,
       ballotStyleId: ballotStyle.id,
       precinctId: ballotStyle.precincts[0],
       ballotType: BallotType.Precinct,
       ballotMode: 'sample',
       watermark: 'PROOF',
-    }
-  );
+    })
+  ).unsafeUnwrap();
   const firstPage = await iter(pdfToImages(pdf, { scale: 200 / 72 })).first();
   expect(
     await encodeImageData(firstPage!.page, 'image/png')


### PR DESCRIPTION

## Overview

Closes: #5903 

Currently, there's just one type of expected error: when a contest is too tall to fit on the page.

To deliver this error to the frontend during ballot proofing, we catch the error within the ballot template so we know what contest was too long and pass it up the stack using a `Result`.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/8b8a2437-0c7c-4514-8a4e-faabfb0682bc



## Testing Plan
Manual test

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
