### PR TITLE
VxDesign: Deploy worker

### DIFF
--- a/Dockerfile.vxdesign
+++ b/Dockerfile.vxdesign
@@ -75,4 +75,3 @@ EXPOSE 3000
 EXPOSE 3002
 
 ENV HOME="/root"
-CMD . /root/.bashrc && node apps/design/backend/build/index.js

--- a/apps/design/backend/src/worker/index.ts
+++ b/apps/design/backend/src/worker/index.ts
@@ -1,3 +1,5 @@
+import './configure_sentry'; // Must be imported first to instrument code
+
 import path from 'node:path';
 import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
 import { assertDefined } from '@votingworks/basics';

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,3 +1,7 @@
 build:
   docker:
     web: Dockerfile.vxdesign
+    worker: Dockerfile.vxdesign
+run:
+  web: . /root/.bashrc && node apps/design/backend/build/index.js
+  worker: . /root/.bashrc && node apps/design/backend/build/worker/index.js


### PR DESCRIPTION
## Overview

The minimal changes necessary to actually deploy the VxDesign worker as part of our VxDesign Heroku deploy. In a separate PR, I'll include the changes to actually allow the worker to be used. Locally, the server and worker use the shared file system to pass files to each other, which naturally won't work in a deployed environment. In prod, I'll be using S3.

## Testing Plan

- [x] Tested by deploying my branch to Heroku