### PR TITLE
Introduce mechanism for finalizing ballot order info, and sequence ordering ballots after proofing

### DIFF
--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -83,6 +83,7 @@ export interface BallotOrderInfo {
   deliveryAddress?: string;
   deliveryRecipientName?: string;
   deliveryRecipientPhoneNumber?: string;
+  orderSubmittedAt?: string;
   precinctBallotCount?: string;
   shouldAbsenteeBallotsBeScoredForFolding?: boolean;
   shouldPrintCollated?: boolean;
@@ -94,6 +95,7 @@ export const BallotOrderInfoSchema: z.ZodType<BallotOrderInfo> = z.object({
   deliveryAddress: z.string().optional(),
   deliveryRecipientName: z.string().optional(),
   deliveryRecipientPhoneNumber: z.string().optional(),
+  orderSubmittedAt: z.string().optional(),
   precinctBallotCount: z.string().optional(),
   shouldAbsenteeBallotsBeScoredForFolding: z.boolean().optional(),
   shouldPrintCollated: z.boolean().optional(),

--- a/apps/design/frontend/src/ballot_order_info_screen.test.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.test.tsx
@@ -12,6 +12,10 @@ import { withRoute } from '../test/routing_helpers';
 import { BallotOrderInfoScreen } from './ballot_order_info_screen';
 import { routes } from './routes';
 
+jest.useFakeTimers();
+
+const mockDateTime = new Date('2025-01-01T00:00:00.000Z');
+
 const electionRecord = generalElectionRecord;
 const electionId = electionRecord.election.id;
 
@@ -38,61 +42,53 @@ function renderScreen() {
   );
 }
 
-test('updating ballot order info', async () => {
+test('submitting ballot order', async () => {
   apiMock.getElection.expectCallWith({ electionId }).resolves(electionRecord);
+  apiMock.getBallotsFinalizedAt
+    .expectCallWith({ electionId })
+    .resolves(new Date());
   renderScreen();
-  await screen.findByRole('heading', { name: 'Ballot Order Info' });
+  await screen.findByRole('heading', { name: 'Order Ballots' });
 
   const absenteeBallotCountInput = screen.getByLabelText(
     'Number of Absentee Ballots'
   );
-  expect(absenteeBallotCountInput).toBeDisabled();
   expect(absenteeBallotCountInput).toHaveValue(null);
 
   const shouldAbsenteeBallotsBeScoredForFoldingCheckbox = screen.getByRole(
     'checkbox',
     { name: 'Score Absentee Ballots for Folding' }
   );
-  expect(shouldAbsenteeBallotsBeScoredForFoldingCheckbox).toBeDisabled();
   expect(shouldAbsenteeBallotsBeScoredForFoldingCheckbox).not.toBeChecked();
 
   const precinctBallotCountInput = screen.getByLabelText(
     'Number of Polling Place Ballots'
   );
-  expect(precinctBallotCountInput).toBeDisabled();
   expect(precinctBallotCountInput).toHaveValue(null);
 
   const ballotColorInput = screen.getByLabelText('Paper Color for Ballots');
-  expect(ballotColorInput).toBeDisabled();
   expect(ballotColorInput).toHaveValue('');
 
   const shouldPrintCollatedCheckbox = screen.getByRole('checkbox', {
     name: 'Print Collated',
   });
-  expect(shouldPrintCollatedCheckbox).toBeDisabled();
   expect(shouldPrintCollatedCheckbox).not.toBeChecked();
 
   const deliveryRecipientNameInput = screen.getByLabelText(
     'Delivery Recipient Name'
   );
-  expect(deliveryRecipientNameInput).toBeDisabled();
   expect(deliveryRecipientNameInput).toHaveValue('');
 
   const deliveryRecipientPhoneNumberInput = screen.getByLabelText(
     'Delivery Recipient Phone Number'
   );
-  expect(deliveryRecipientPhoneNumberInput).toBeDisabled();
   expect(deliveryRecipientPhoneNumberInput).toHaveValue('');
 
   const deliveryAddressInput = screen.getByLabelText(
     'Delivery Address, City, State, and ZIP'
   );
-  expect(deliveryAddressInput).toBeDisabled();
   expect(deliveryAddressInput).toHaveValue('');
 
-  // Populate ballot order info
-
-  userEvent.click(screen.getByRole('button', { name: 'Edit' }));
   userEvent.type(absenteeBallotCountInput, '100');
   userEvent.click(shouldAbsenteeBallotsBeScoredForFoldingCheckbox);
   userEvent.type(precinctBallotCountInput, '200');
@@ -111,6 +107,7 @@ test('updating ballot order info', async () => {
     deliveryRecipientName: 'Clerky Clerkson',
     deliveryRecipientPhoneNumber: '(123) 456-7890',
     deliveryAddress: '123 Main St, Town, NH, 00000',
+    orderSubmittedAt: mockDateTime.toISOString(),
   };
   apiMock.updateBallotOrderInfo
     .expectCallWith({ electionId, ballotOrderInfo: expectedBallotOrderInfo })
@@ -120,49 +117,38 @@ test('updating ballot order info', async () => {
     ballotOrderInfo: expectedBallotOrderInfo,
   });
 
-  userEvent.click(screen.getByRole('button', { name: 'Save' }));
-  await screen.findByRole('button', { name: 'Edit' });
+  jest.setSystemTime(mockDateTime);
+  userEvent.click(screen.getByRole('button', { name: 'Submit Order' }));
+  userEvent.click(screen.getByRole('button', { name: 'Submit Order' }));
+  await screen.findByRole('heading', { name: 'Order Submitted' });
 
   expect(absenteeBallotCountInput).toHaveValue(100);
+  expect(absenteeBallotCountInput).toBeDisabled();
   expect(shouldAbsenteeBallotsBeScoredForFoldingCheckbox).toBeChecked();
+  expect(shouldAbsenteeBallotsBeScoredForFoldingCheckbox).toBeDisabled();
   expect(precinctBallotCountInput).toHaveValue(200);
+  expect(precinctBallotCountInput).toBeDisabled();
   expect(ballotColorInput).toHaveValue('Yellow for town, white for school');
+  expect(ballotColorInput).toBeDisabled();
   expect(shouldPrintCollatedCheckbox).toBeChecked();
+  expect(shouldPrintCollatedCheckbox).toBeDisabled();
   expect(deliveryRecipientNameInput).toHaveValue('Clerky Clerkson');
+  expect(deliveryRecipientNameInput).toBeDisabled();
   expect(deliveryRecipientPhoneNumberInput).toHaveValue('(123) 456-7890');
+  expect(deliveryRecipientPhoneNumberInput).toBeDisabled();
   expect(deliveryAddressInput).toHaveValue('123 Main St, Town, NH, 00000');
-
-  // Begin updating ballot order info but cancel
-
-  userEvent.click(screen.getByRole('button', { name: 'Edit' }));
-  userEvent.type(absenteeBallotCountInput, 'A');
-  userEvent.click(shouldAbsenteeBallotsBeScoredForFoldingCheckbox);
-  userEvent.type(precinctBallotCountInput, 'B');
-  userEvent.type(ballotColorInput, 'C');
-  userEvent.click(shouldPrintCollatedCheckbox);
-  userEvent.type(deliveryRecipientNameInput, 'E');
-  userEvent.type(deliveryRecipientPhoneNumberInput, 'F');
-  userEvent.type(deliveryAddressInput, 'G');
-
-  userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-
-  expect(absenteeBallotCountInput).toHaveValue(100);
-  expect(shouldAbsenteeBallotsBeScoredForFoldingCheckbox).toBeChecked();
-  expect(precinctBallotCountInput).toHaveValue(200);
-  expect(ballotColorInput).toHaveValue('Yellow for town, white for school');
-  expect(shouldPrintCollatedCheckbox).toBeChecked();
-  expect(deliveryRecipientNameInput).toHaveValue('Clerky Clerkson');
-  expect(deliveryRecipientPhoneNumberInput).toHaveValue('(123) 456-7890');
-  expect(deliveryAddressInput).toHaveValue('123 Main St, Town, NH, 00000');
+  expect(deliveryAddressInput).toBeDisabled();
 });
 
-test('updating ballot order info with validation errors', async () => {
+test('submitting ballot order with validation errors', async () => {
   apiMock.getElection.expectCallWith({ electionId }).resolves(electionRecord);
+  apiMock.getBallotsFinalizedAt
+    .expectCallWith({ electionId })
+    .resolves(new Date());
   renderScreen();
-  await screen.findByRole('heading', { name: 'Ballot Order Info' });
+  await screen.findByRole('heading', { name: 'Order Ballots' });
 
-  userEvent.click(screen.getByRole('button', { name: 'Edit' }));
-  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+  userEvent.click(screen.getByRole('button', { name: 'Submit Order' }));
 
   const absenteeBallotCountInput = screen.getByLabelText(
     'Number of Absentee Ballots'
@@ -176,13 +162,25 @@ test('updating ballot order info with validation errors', async () => {
   expect(precinctBallotCountInput).toBeInvalid();
   expect(precinctBallotCountInput).toHaveValue(null);
 
-  // try to save an invalid value
   const deliveryRecipientNameInput = screen.getByLabelText(
     'Delivery Recipient Name'
   );
-  userEvent.type(deliveryRecipientNameInput, '       ');
-  userEvent.click(screen.getByRole('button', { name: 'Save' }));
   expect(deliveryRecipientNameInput).toBeInvalid();
-  // value gets trimmed
   expect(deliveryRecipientNameInput).toHaveValue('');
+
+  userEvent.type(deliveryRecipientNameInput, '       ');
+  userEvent.click(screen.getByRole('button', { name: 'Submit Order' }));
+
+  expect(deliveryRecipientNameInput).toBeInvalid();
+  expect(deliveryRecipientNameInput).toHaveValue('');
+});
+
+test('ballot order submission required ballots to be proofed first', async () => {
+  apiMock.getElection.expectCallWith({ electionId }).resolves(electionRecord);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Order Ballots' });
+
+  screen.getByRole('heading', { name: 'Ballots are Not Finalized' });
+  expect(screen.getByRole('button', { name: 'Submit Order' })).toBeDisabled();
 });

--- a/apps/design/frontend/src/ballot_order_info_screen.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.tsx
@@ -266,7 +266,7 @@ export function BallotOrderInfoScreen(): JSX.Element | null {
   return (
     <ElectionNavScreen electionId={electionId}>
       <MainHeader>
-        <H1>Ballot Order Info</H1>
+        <H1>Order Ballots</H1>
       </MainHeader>
       <MainContent>
         <BallotOrderInfoForm

--- a/apps/design/frontend/src/ballots_screen.test.tsx
+++ b/apps/design/frontend/src/ballots_screen.test.tsx
@@ -45,7 +45,7 @@ describe('Ballot styles tab', () => {
       .resolves(generalElectionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
-    await screen.findByRole('heading', { name: 'Ballots' });
+    await screen.findByRole('heading', { name: 'Proof Ballots' });
 
     screen.getByRole('tab', { name: 'Ballot Styles', selected: true });
     const table = screen.getByRole('table');
@@ -81,7 +81,7 @@ describe('Ballot styles tab', () => {
       .resolves(primaryElectionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
-    await screen.findByRole('heading', { name: 'Ballots' });
+    await screen.findByRole('heading', { name: 'Proof Ballots' });
 
     screen.getByRole('tab', { name: 'Ballot Styles', selected: true });
     const table = screen.getByRole('table');
@@ -128,7 +128,7 @@ describe('Ballot styles tab', () => {
     apiMock.getElection.expectCallWith({ electionId }).resolves(electionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
-    await screen.findByRole('heading', { name: 'Ballots' });
+    await screen.findByRole('heading', { name: 'Proof Ballots' });
 
     const table = screen.getByRole('table');
     expect(
@@ -156,7 +156,7 @@ describe('Ballot styles tab', () => {
       .resolves(generalElectionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
-    await screen.findByRole('heading', { name: 'Ballots' });
+    await screen.findByRole('heading', { name: 'Proof Ballots' });
 
     screen.getByRole('heading', { name: 'Ballots are Not Finalized' });
 
@@ -202,7 +202,7 @@ test('Ballot layout tab', async () => {
     .resolves(generalElectionRecord);
   apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
   renderScreen(electionId);
-  await screen.findByRole('heading', { name: 'Ballots' });
+  await screen.findByRole('heading', { name: 'Proof Ballots' });
 
   userEvent.click(screen.getByRole('tab', { name: 'Ballot Layout' }));
 

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -433,7 +433,7 @@ export function BallotsScreen(): JSX.Element | null {
       <Route path={ballotsParamRoutes.root.path}>
         <ElectionNavScreen electionId={electionId}>
           <MainHeader>
-            <H1>Ballots</H1>
+            <H1>Proof Ballots</H1>
           </MainHeader>
           <MainContent>
             <RouterTabBar

--- a/apps/design/frontend/src/export_screen.test.tsx
+++ b/apps/design/frontend/src/export_screen.test.tsx
@@ -301,3 +301,38 @@ test('view ballot proofing status and unfinalize ballots', async () => {
   userEvent.click(screen.getButton('Unfinalize Ballots'));
   await screen.findByText('Ballots not finalized');
 });
+
+test('view ballot order status and unsubmit order', async () => {
+  const submittedAt = '1/30/2025, 12:00 PM';
+  apiMock.getElection.reset();
+  apiMock.getElection.expectCallWith({ electionId }).resolves({
+    ...generalElectionRecord,
+    ballotOrderInfo: {
+      absenteeBallotCount: '100',
+      orderSubmittedAt: new Date(submittedAt).toISOString(),
+    },
+  });
+
+  renderScreen();
+  await screen.findAllByRole('heading', { name: 'Export' });
+
+  screen.getByText(`Order submitted at: ${submittedAt}`);
+
+  apiMock.updateBallotOrderInfo
+    .expectCallWith({
+      electionId,
+      ballotOrderInfo: {
+        absenteeBallotCount: '100',
+        orderSubmittedAt: undefined,
+      },
+    })
+    .resolves();
+  apiMock.getElection.expectCallWith({ electionId }).resolves({
+    ...generalElectionRecord,
+    ballotOrderInfo: {
+      absenteeBallotCount: '100',
+    },
+  });
+  userEvent.click(screen.getButton('Unsubmit Order'));
+  await screen.findByText('Order not submitted');
+});

--- a/apps/design/frontend/src/routes.ts
+++ b/apps/design/frontend/src/routes.ts
@@ -88,7 +88,7 @@ export const routes = {
       },
       ballots: {
         root: {
-          title: 'Ballots',
+          title: 'Proof Ballots',
           path: `${root}/ballots`,
         },
         ballotStyles: {
@@ -105,7 +105,7 @@ export const routes = {
         }),
       },
       ballotOrderInfo: {
-        title: 'Ballot Order Info',
+        title: 'Order Ballots',
         path: `${root}/ballot-order-info`,
       },
       tabulation: {


### PR DESCRIPTION
## Overview

This PR introduces a mechanism for finalizing ballot order info (after which it cannot be edited), and explicitly sequences ordering ballots after proofing.

This PR also adds an internal mechanism by which we can unsubmit for a user, if they need to make edits after submitting, much like the tooling we've built for the proofing flow.

## Demo Video or Screenshot

_End user flow_

https://github.com/user-attachments/assets/d045d183-8b7a-4069-a503-d180b5e83925

_Internal Vx tooling_

https://github.com/user-attachments/assets/4a95cbc0-9cbd-4a9f-ab81-8e34294fdc31

## Testing Plan

- [x] Updated automated tests
- [x] Tested manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates