### PR TITLE
[VxDesign] DRAFT scripts to help with user/org management

### DIFF
--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -17,6 +17,8 @@
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "create-org": "node -r esbuild-runner/register ./scripts/create_org.ts",
+    "create-user": "node -r esbuild-runner/register ./scripts/create_user.ts",
     "db:reset": "./scripts/db_reset_dev.sh",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "pnpm type-check && eslint .",

--- a/apps/design/backend/scripts/create_org.ts
+++ b/apps/design/backend/scripts/create_org.ts
@@ -1,0 +1,51 @@
+import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
+import util from 'node:util';
+import { AuthClient } from '../src/auth/client';
+
+const USAGE = `Usage: pnpm create-org [options...] "<display name>"
+
+options:
+    [--colorBg=<#xxxxxx>]: Background color for the login page. Defaults to #ffffff.
+    [--colorPrimary=<#xxxxxx>]: Primary color for the login page. Defaults to Vx Purple.
+    [--enableGoogleAuth]: Enables Google auth for this org, in addition to username/password logins.
+    [--logoUrl=<url>]: URL for the login page logo for this org.
+`;
+
+async function main(): Promise<void> {
+  loadEnvVarsFromDotenvFiles();
+  const {
+    positionals: [displayName],
+    values: { colorBg, colorPrimary, enableGoogleAuth, logoUrl },
+  } = util.parseArgs({
+    allowPositionals: true,
+    args: process.argv.slice(2),
+    options: {
+      colorBg: { type: 'string' },
+      colorPrimary: { type: 'string' },
+      enableGoogleAuth: { type: 'boolean' },
+      logoUrl: { type: 'string' },
+    },
+  });
+  if (!displayName) {
+    console.log(USAGE);
+    process.exit(0);
+  }
+
+  const auth = AuthClient.init();
+  const org = await auth.createOrg({
+    displayName,
+    colorBgHex: colorBg,
+    colorPrimaryHex: colorPrimary,
+    enableGoogleAuth,
+    logoUrl,
+  });
+
+  console.log('✅ Org created:', org);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/apps/design/backend/scripts/create_user.ts
+++ b/apps/design/backend/scripts/create_user.ts
@@ -1,0 +1,53 @@
+import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
+import util from 'node:util';
+import { ManagementApiError } from 'auth0';
+import { AuthClient } from '../src/auth/client';
+
+const USAGE = `Usage: pnpm create-user --orgId=<string> <email address>`;
+
+enum ErrorCode {
+  ALREADY_EXISTS = 409,
+}
+
+async function main(): Promise<void> {
+  loadEnvVarsFromDotenvFiles();
+  const {
+    positionals: [userEmail],
+    values: { orgId },
+  } = util.parseArgs({
+    allowPositionals: true,
+    args: process.argv.slice(2),
+    options: {
+      orgId: { type: 'string' },
+    },
+  });
+  if (!userEmail || !orgId) {
+    console.log(USAGE);
+    process.exit(0);
+  }
+
+  const auth = AuthClient.init();
+  try {
+    await auth.createUser({ orgId, userEmail });
+
+    console.log(`✅ User created and added to org ${orgId}`);
+  } catch (error) {
+    if (!(error instanceof ManagementApiError)) {
+      throw error;
+    }
+
+    if ((error.statusCode as ErrorCode) === ErrorCode.ALREADY_EXISTS) {
+      console.log('User already exists. Attempting to add to org...');
+      await auth.addOrgMember({ orgId, userEmail });
+
+      console.log(`✅ Existing user added to org ${orgId}`);
+    }
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -654,10 +654,6 @@ export function buildApp(context: AppContext): Application {
   app.post('/api/getUser', async (req, res) => {
     const user = assertDefined(context.auth.userFromRequest(req));
     const org = await context.auth.org(user.org_id);
-    if (!org) {
-      res.status(500).send('No org found for user');
-      return;
-    }
 
     // A little convoluted, but this is just to form a typechecked link between
     // this handler and the `getUser` API stub.

--- a/apps/design/backend/src/auth/client.ts
+++ b/apps/design/backend/src/auth/client.ts
@@ -2,6 +2,7 @@
 
 import { ManagementClient, AuthenticationClient } from 'auth0';
 import { assertDefined } from '@votingworks/basics';
+import crypto from 'node:crypto';
 import {
   auth0ClientDomain,
   auth0ClientId,
@@ -9,6 +10,8 @@ import {
   votingWorksOrgId,
 } from '../globals';
 import { Auth0User, Org, User } from '../types';
+
+type ConnectionType = 'Username-Password-Authentication' | 'google-oauth2';
 
 export class AuthClient {
   constructor(
@@ -27,6 +30,35 @@ export class AuthClient {
     );
   }
 
+  async addOrgMember(params: {
+    userEmail: string;
+    orgId: string;
+  }): Promise<void> {
+    const { userEmail, orgId } = params;
+
+    const userQueryResults = await this.management.usersByEmail.getByEmail({
+      email: userEmail,
+    });
+    const user = userQueryResults.data[0];
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    await this.management.organizations.addMembers(
+      { id: orgId },
+      { members: [user.user_id] }
+    );
+  }
+
+  async allConnections(): Promise<Array<{ name: ConnectionType; id: string }>> {
+    const res = await this.management.connections.getAll({});
+
+    return res.data.map((c) => ({
+      id: c.id,
+      name: c.name as ConnectionType,
+    }));
+  }
+
   async allOrgs(): Promise<Org[]> {
     const res = await this.management.organizations.getAll({
       sort: 'display_name:1',
@@ -39,6 +71,106 @@ export class AuthClient {
     }));
   }
 
+  async connectionByName(
+    name: ConnectionType
+  ): Promise<{ name: ConnectionType; id: string } | undefined> {
+    const res = await this.management.connections.getAll({ name });
+
+    return res.data.map((c) => ({ id: c.id, name }))[0];
+  }
+
+  async createOrg(params: {
+    colorBgHex?: string;
+    colorPrimaryHex?: string;
+    displayName: string;
+    enableGoogleAuth?: boolean;
+    logoUrl?: string;
+  }): Promise<Org> {
+    const VX_PURPLE = '#8d24ce';
+    const {
+      colorBgHex = '#ffffff',
+      colorPrimaryHex = VX_PURPLE,
+      displayName,
+      enableGoogleAuth,
+      logoUrl,
+    } = params;
+    const name = displayName
+      .trim()
+      .toLowerCase()
+      .replaceAll(/[^a-z0-9-]+/g, '-');
+
+    const connections = (await this.allConnections()).filter((c) => {
+      if (c.name === 'Username-Password-Authentication') {
+        return true;
+      }
+
+      if (enableGoogleAuth && c.name === 'google-oauth2') {
+        return true;
+      }
+
+      return false;
+    });
+
+    const res = await this.management.organizations.create({
+      name,
+      display_name: displayName,
+      enabled_connections: connections.map((c) => ({ connection_id: c.id })),
+      branding: {
+        logo_url: logoUrl,
+        colors: {
+          page_background: colorBgHex,
+          primary: colorPrimaryHex,
+        },
+      },
+    });
+
+    const org = res.data;
+    return {
+      displayName: org.display_name,
+      id: org.id,
+      name: org.name,
+    };
+  }
+
+  async createUser(params: {
+    connectionType?: ConnectionType;
+    userEmail: string;
+    orgId: string;
+  }): Promise<void> {
+    const {
+      connectionType = 'Username-Password-Authentication',
+      userEmail,
+      orgId,
+    } = params;
+
+    const tempPassword = crypto.randomBytes(20).toString('base64');
+
+    const org = await this.org(orgId);
+
+    const user = (
+      await this.management.users.create({
+        connection: connectionType,
+        email: userEmail,
+        password: tempPassword,
+      })
+    ).data;
+
+    await this.management.organizations.addMembers(
+      { id: org.id },
+      { members: [user.user_id] }
+    );
+
+    // Trigger a password reset email disguised as a "Welcome" email.
+    //
+    // See the "Change Password (Link)" template at:
+    // https://manage.auth0.com/dashboard/us/vxdesign/templates
+    await this.authn.database.changePassword({
+      connection: connectionType,
+      email: userEmail,
+      organization: orgId,
+    });
+  }
+
   hasAccess(user: User, orgId: string): boolean {
     if (user.orgId === votingWorksOrgId()) {
       return true;
@@ -47,11 +179,8 @@ export class AuthClient {
     return user.orgId === orgId;
   }
 
-  async org(id: string): Promise<Org | undefined> {
+  async org(id: string): Promise<Org> {
     const res = await this.management.organizations.get({ id });
-    if (res.status !== 200) {
-      return undefined;
-    }
 
     return {
       displayName: res.data.display_name,


### PR DESCRIPTION
To run:
- Add relevant env vars to `.env.local`:
```sh
# Details in the 'vxdesign' tenant in the Auth0 dashboard
AUTH_ENABLED=TRUE
AUTH0_CLIENT_ID='xxxxx'
AUTH0_CLIENT_DOMAIN='vxdesign.us.auth0.com'
AUTH0_SECRET='xxxxx
```
- From `apps/design/backend`:
  - Create orgs with `pnpm create-org "City of Vx"`
    - The new org ID and short name will be printed out to the console
  - Create users with `pnpm create-user --orgId=<orgId from previous step> "someone@example.com"`

Once we have a sense of what we want we can update this to iterate over a list of org names and user emails. Each operation is pretty slow (~5 seconds per org, ~10-20 seconds per user) - might dig into that later.