### PR TITLE
VxDesign: Don't allow NH users to change precinct splits

### DIFF
--- a/apps/design/frontend/src/features_context.tsx
+++ b/apps/design/frontend/src/features_context.tsx
@@ -34,16 +34,21 @@ enum UserFeature {
    */
   DELETE_ELECTION = 'DELETE_ELECTION',
   /**
+   * Allow the user to create and delete districts. The goal of this feature
+   * flag is to prevent users from accidentally messing up preset districts.
+   */
+  CREATE_DELETE_DISTRICTS = 'CREATE_DELETE_DISTRICTS',
+  /**
+   * Allow the user to create and delete precincts. The goal of this feature
+   * flag is to prevent users from accidentally messing up preset precincts.
+   */
+  CREATE_DELETE_PRECINCTS = 'CREATE_DELETE_PRECINCTS',
+  /**
    * Allow the user to change the splits for a precinct split. The goal of
    * this feature flag is to prevent users from accidentally messing up preset
    * precinct splits.
    */
   CREATE_DELETE_PRECINCT_SPLITS = 'CREATE_DELETE_PRECINCT_SPLITS',
-  /**
-   * Allow the user to create and delete districts. The goal of this feature
-   * flag is to prevent users from accidentally messing up preset districts.
-   */
-  CREATE_DELETE_DISTRICTS = 'CREATE_DELETE_DISTRICTS',
 }
 
 /**
@@ -83,8 +88,9 @@ const userFeatureConfigs = {
     ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
     CREATE_ELECTION: true,
     DELETE_ELECTION: true,
-    CREATE_DELETE_PRECINCT_SPLITS: true,
     CREATE_DELETE_DISTRICTS: true,
+    CREATE_DELETE_PRECINCTS: true,
+    CREATE_DELETE_PRECINCT_SPLITS: true,
   },
   nh: {
     ACCESS_ALL_ORGS: false,
@@ -93,8 +99,9 @@ const userFeatureConfigs = {
     ONLY_LETTER_AND_LEGAL_PAPER_SIZES: true,
     CREATE_ELECTION: false,
     DELETE_ELECTION: false,
-    CREATE_DELETE_PRECINCT_SPLITS: false,
     CREATE_DELETE_DISTRICTS: false,
+    CREATE_DELETE_PRECINCTS: false,
+    CREATE_DELETE_PRECINCT_SPLITS: false,
   },
 } satisfies Record<string, UserFeaturesConfig>;
 

--- a/apps/design/frontend/src/features_context.tsx
+++ b/apps/design/frontend/src/features_context.tsx
@@ -33,6 +33,12 @@ enum UserFeature {
    * Allow the user to delete an election.
    */
   DELETE_ELECTION = 'DELETE_ELECTION',
+  /**
+   * Allow the user to change the splits for a precinct split. The goal of
+   * this feature flag is to prevent users from accidentally messing up preset
+   * precinct splits.
+   */
+  CREATE_DELETE_PRECINCT_SPLITS = 'CREATE_DELETE_PRECINCT_SPLITS',
 }
 
 /**
@@ -72,6 +78,7 @@ const userFeatureConfigs = {
     ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
     CREATE_ELECTION: true,
     DELETE_ELECTION: true,
+    CREATE_DELETE_PRECINCT_SPLITS: true,
   },
   nh: {
     ACCESS_ALL_ORGS: false,
@@ -80,6 +87,7 @@ const userFeatureConfigs = {
     ONLY_LETTER_AND_LEGAL_PAPER_SIZES: true,
     CREATE_ELECTION: false,
     DELETE_ELECTION: false,
+    CREATE_DELETE_PRECINCT_SPLITS: false,
   },
 } satisfies Record<string, UserFeaturesConfig>;
 

--- a/apps/design/frontend/src/features_context.tsx
+++ b/apps/design/frontend/src/features_context.tsx
@@ -39,6 +39,11 @@ enum UserFeature {
    * precinct splits.
    */
   CREATE_DELETE_PRECINCT_SPLITS = 'CREATE_DELETE_PRECINCT_SPLITS',
+  /**
+   * Allow the user to create and delete districts. The goal of this feature
+   * flag is to prevent users from accidentally messing up preset districts.
+   */
+  CREATE_DELETE_DISTRICTS = 'CREATE_DELETE_DISTRICTS',
 }
 
 /**
@@ -79,6 +84,7 @@ const userFeatureConfigs = {
     CREATE_ELECTION: true,
     DELETE_ELECTION: true,
     CREATE_DELETE_PRECINCT_SPLITS: true,
+    CREATE_DELETE_DISTRICTS: true,
   },
   nh: {
     ACCESS_ALL_ORGS: false,
@@ -88,6 +94,7 @@ const userFeatureConfigs = {
     CREATE_ELECTION: false,
     DELETE_ELECTION: false,
     CREATE_DELETE_PRECINCT_SPLITS: false,
+    CREATE_DELETE_DISTRICTS: false,
   },
 } satisfies Record<string, UserFeaturesConfig>;
 

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -58,6 +58,7 @@ function DistrictsTab(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
   const getElectionQuery = getElection.useQuery(electionId);
   const getBallotsFinalizedAtQuery = getBallotsFinalizedAt.useQuery(electionId);
+  const features = useUserFeatures();
 
   if (!getElectionQuery.isSuccess || !getBallotsFinalizedAtQuery.isSuccess) {
     return null;
@@ -74,16 +75,18 @@ function DistrictsTab(): JSX.Element | null {
       {districts.length === 0 && (
         <P>You haven&apos;t added any districts to this election yet.</P>
       )}
-      <TableActionsRow>
-        <LinkButton
-          icon="Add"
-          variant="primary"
-          to={districtsRoutes.addDistrict.path}
-          disabled={!!ballotsFinalizedAt}
-        >
-          Add District
-        </LinkButton>
-      </TableActionsRow>
+      {features.CREATE_DELETE_DISTRICTS && (
+        <TableActionsRow>
+          <LinkButton
+            icon="Add"
+            variant="primary"
+            to={districtsRoutes.addDistrict.path}
+            disabled={!!ballotsFinalizedAt}
+          >
+            Add District
+          </LinkButton>
+        </TableActionsRow>
+      )}
       {districts.length > 0 && (
         <Table>
           <thead>
@@ -144,6 +147,7 @@ function DistrictForm({
   const updatePrecinctsMutation = updatePrecincts.useMutation();
   const history = useHistory();
   const geographyRoutes = routes.election(electionId).geography;
+  const features = useUserFeatures();
 
   // After deleting a district, this component may re-render briefly with no
   // district before redirecting to the districts list. We can just render
@@ -259,7 +263,7 @@ function DistrictForm({
             Save
           </Button>
         </FormActionsRow>
-        {districtId && (
+        {features.CREATE_DELETE_DISTRICTS && districtId && (
           <FormActionsRow style={{ marginTop: '1rem' }}>
             <Button
               variant="danger"

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -52,7 +52,7 @@ import {
 } from './api';
 import { generateId, hasSplits, replaceAtIndex } from './utils';
 import { ImageInput } from './image_input';
-import { useElectionFeatures } from './features_context';
+import { useElectionFeatures, useUserFeatures } from './features_context';
 
 function DistrictsTab(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
@@ -453,7 +453,8 @@ function PrecinctForm({
   savedPrecincts: Precinct[];
   districts: readonly District[];
 }): JSX.Element | null {
-  const features = useElectionFeatures();
+  const userFeatures = useUserFeatures();
+  const electionFeatures = useElectionFeatures();
   const [precinct, setPrecinct] = useState<Precinct | undefined>(
     precinctId
       ? savedPrecincts.find((p) => p.id === precinctId)
@@ -599,6 +600,7 @@ function PrecinctForm({
                         onChange={(e) =>
                           setSplit(index, { ...split, name: e.target.value })
                         }
+                        disabled={!userFeatures.CREATE_DELETE_PRECINCT_SPLITS}
                       />
                     </InputGroup>
                     <CheckboxGroup
@@ -614,9 +616,10 @@ function PrecinctForm({
                           districtIds: districtIds as DistrictId[],
                         })
                       }
+                      disabled={!userFeatures.CREATE_DELETE_PRECINCT_SPLITS}
                     />
 
-                    {features.PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE && (
+                    {electionFeatures.PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE && (
                       <InputGroup label="Election Title Override">
                         <input
                           type="text"
@@ -631,7 +634,7 @@ function PrecinctForm({
                       </InputGroup>
                     )}
 
-                    {features.PRECINCT_SPLIT_CLERK_SIGNATURE_IMAGE && (
+                    {electionFeatures.PRECINCT_SPLIT_CLERK_SIGNATURE_IMAGE && (
                       <div>
                         <FieldName>Signature Image</FieldName>
                         <ClerkSignatureImageInput
@@ -647,7 +650,7 @@ function PrecinctForm({
                       </div>
                     )}
 
-                    {features.PRECINCT_SPLIT_CLERK_SIGNATURE_CAPTION && (
+                    {electionFeatures.PRECINCT_SPLIT_CLERK_SIGNATURE_CAPTION && (
                       <InputGroup label="Signature Caption">
                         <input
                           type="text"
@@ -662,20 +665,24 @@ function PrecinctForm({
                       </InputGroup>
                     )}
 
-                    <Button
-                      style={{ marginTop: 'auto' }}
-                      onPress={() => onRemoveSplitPress(index)}
-                    >
-                      Remove Split
-                    </Button>
+                    {userFeatures.CREATE_DELETE_PRECINCT_SPLITS && (
+                      <Button
+                        style={{ marginTop: 'auto' }}
+                        onPress={() => onRemoveSplitPress(index)}
+                      >
+                        Remove Split
+                      </Button>
+                    )}
                   </Column>
                 </Card>
               ))}
-              <div>
-                <Button icon="Add" onPress={onAddSplitPress}>
-                  Add Split
-                </Button>
-              </div>
+              {userFeatures.CREATE_DELETE_PRECINCT_SPLITS && (
+                <div>
+                  <Button icon="Add" onPress={onAddSplitPress}>
+                    Add Split
+                  </Button>
+                </div>
+              )}
             </React.Fragment>
           ) : (
             <React.Fragment>

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -348,6 +348,7 @@ function PrecinctsTab(): JSX.Element | null {
   const geographyRoutes = routes.election(electionId).geography;
   const getElectionQuery = getElection.useQuery(electionId);
   const getBallotsFinalizedAtQuery = getBallotsFinalizedAt.useQuery(electionId);
+  const features = useUserFeatures();
 
   if (!getElectionQuery.isSuccess || !getBallotsFinalizedAtQuery.isSuccess) {
     return null;
@@ -365,16 +366,18 @@ function PrecinctsTab(): JSX.Element | null {
       {precincts.length === 0 && (
         <P>You haven&apos;t added any precincts to this election yet.</P>
       )}
-      <TableActionsRow>
-        <LinkButton
-          variant="primary"
-          icon="Add"
-          to={geographyRoutes.precincts.addPrecinct.path}
-          disabled={!!ballotsFinalizedAt}
-        >
-          Add Precinct
-        </LinkButton>
-      </TableActionsRow>
+      {features.CREATE_DELETE_PRECINCTS && (
+        <TableActionsRow>
+          <LinkButton
+            variant="primary"
+            icon="Add"
+            to={geographyRoutes.precincts.addPrecinct.path}
+            disabled={!!ballotsFinalizedAt}
+          >
+            Add Precinct
+          </LinkButton>
+        </TableActionsRow>
+      )}
       {precincts.length > 0 && (
         <Table>
           <thead>
@@ -728,7 +731,7 @@ function PrecinctForm({
             Save
           </Button>
         </FormActionsRow>
-        {precinctId && (
+        {precinctId && userFeatures.CREATE_DELETE_PRECINCTS && (
           <FormActionsRow style={{ marginTop: '1rem' }}>
             <Button
               variant="danger"

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -585,7 +585,7 @@ function PrecinctForm({
         />
       </InputGroup>
       <div>
-        <FieldName>Districts</FieldName>
+        <FieldName>{hasSplits(precinct) ? 'Splits' : 'Districts'}</FieldName>
         <Row style={{ gap: '1rem', flexWrap: 'wrap' }}>
           {hasSplits(precinct) ? (
             <React.Fragment>


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/5917

Adds feature flags to prevent NH users from:
- Creating or deleting districts
- Creating or deleting the splits for a precinct (including editing their name or districts - editing the NH-specific fields is still allowed)

## Demo Video or Screenshot

https://github.com/user-attachments/assets/64d42cb8-c49a-4374-bfd1-911611cffdad


## Testing Plan
Manual testing

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
