### PR TITLE
Always clean up renderer

### DIFF
--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -452,16 +452,20 @@ function buildApi({ auth, workspace, translator }: AppContext) {
           props.ballotMode === input.ballotMode
       );
       const renderer = await createPlaywrightRenderer();
-      const ballotPdf = await renderBallotPreviewToPdf(
-        renderer,
-        ballotTemplates[ballotTemplateId],
-        // NOTE: Changing this text means you should also change the font size
-        // of the <Watermark> component in the ballot template.
+      let ballotPdf: Result<Buffer, BallotLayoutError>;
+      try {
+        ballotPdf = await renderBallotPreviewToPdf(
+          renderer,
+          ballotTemplates[ballotTemplateId],
+          // NOTE: Changing this text means you should also change the font size
+          // of the <Watermark> component in the ballot template.
 
-        { ...ballotProps, watermark: 'PROOF' }
-      );
-      // eslint-disable-next-line no-console
-      renderer.cleanup().catch(console.error);
+          { ...ballotProps, watermark: 'PROOF' }
+        );
+      } finally {
+        // eslint-disable-next-line no-console
+        renderer.cleanup().catch(console.error);
+      }
       if (ballotPdf.isErr()) return ballotPdf;
 
       const precinct = find(


### PR DESCRIPTION
## Overview

Thinking through error handling flows and noticed that we don't clean up the renderer if the call to `renderBallotPreviewToPdf` fails. Figured we should always be doing that. Maybe this will address the error I posted about in https://votingworks.slack.com/archives/C085YT4798C/p1738280647190929 - but I'm not sure. I'm not able to reproduce that error locally unfortunately.