### PR TITLE
VxDesign: Show sortable election status and org name in election list for VX support users

### DIFF
--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -48,6 +48,7 @@ export interface ElectionRecord {
   createdAt: Iso8601Timestamp;
   ballotLanguageConfigs: BallotLanguageConfigs;
   ballotTemplateId: BallotTemplateId;
+  ballotsFinalizedAt: Date | null;
 }
 
 export type TaskName = 'generate_election_package';
@@ -112,6 +113,7 @@ function hydrateElection(row: {
   createdAt: Date;
   ballotLanguageConfigs: BallotLanguageConfigs;
   ballotTemplateId: BallotTemplateId;
+  ballotsFinalizedAt: Date | null;
   orgId: string;
 }): ElectionRecord {
   const { ballotLanguageConfigs } = row;
@@ -155,6 +157,7 @@ function hydrateElection(row: {
     ballotTemplateId: row.ballotTemplateId,
     createdAt: row.createdAt.toISOString(),
     ballotLanguageConfigs,
+    ballotsFinalizedAt: row.ballotsFinalizedAt,
     orgId: row.orgId,
   };
 }
@@ -189,6 +192,7 @@ export class Store {
                 ballot_order_info_data as "ballotOrderInfoData",
                 precinct_data as "precinctData",
                 ballot_template_id as "ballotTemplateId",
+                ballots_finalized_at as "ballotsFinalizedAt",
                 created_at as "createdAt"
               from elections
               ${whereClause}
@@ -203,6 +207,7 @@ export class Store {
             ballotOrderInfoData: string;
             precinctData: string;
             ballotTemplateId: BallotTemplateId;
+            ballotsFinalizedAt: Date | null;
             createdAt: Date;
           }>
       )
@@ -228,6 +233,7 @@ export class Store {
               ballot_order_info_data as "ballotOrderInfoData",
               precinct_data as "precinctData",
               ballot_template_id as "ballotTemplateId",
+              ballots_finalized_at as "ballotsFinalizedAt",
               created_at as "createdAt"
             from elections
             where id = $1
@@ -236,13 +242,14 @@ export class Store {
         )
       )
     ).rows[0] as {
+      orgId: string;
       electionData: string;
       systemSettingsData: string;
       ballotOrderInfoData: string;
       precinctData: string;
       ballotTemplateId: BallotTemplateId;
+      ballotsFinalizedAt: Date | null;
       createdAt: Date;
-      orgId: string;
     };
     assert(electionRow !== undefined);
     return hydrateElection({

--- a/apps/design/frontend/src/elections_screen.tsx
+++ b/apps/design/frontend/src/elections_screen.tsx
@@ -7,9 +7,11 @@ import {
   MainHeader,
   FileInputButton,
   Table,
+  Button,
+  StyledButtonProps,
 } from '@votingworks/ui';
-import { FormEvent } from 'react';
-import { useHistory } from 'react-router-dom';
+import { FormEvent, useMemo } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { format } from '@votingworks/utils';
 import type { ElectionRecord } from '@votingworks/design-backend';
@@ -57,6 +59,75 @@ function electionStatus(electionRecord: ElectionRecord): ElectionStatus {
   return ElectionStatus.OrderSubmitted;
 }
 
+// eslint-disable-next-line vx/gts-no-return-type-only-generics
+function useQueryParamsState<T extends Record<string, string> | undefined>(): [
+  T,
+  (newState: T) => void,
+] {
+  const { search } = useLocation();
+  const history = useHistory();
+
+  const searchState = useMemo(
+    () =>
+      (search
+        ? Object.fromEntries(new URLSearchParams(search).entries())
+        : undefined) as T,
+    [search]
+  );
+
+  function setSearchState(newState: T) {
+    const searchParams = new URLSearchParams();
+    if (newState) {
+      for (const [key, value] of Object.entries(newState)) {
+        searchParams.set(key, value);
+      }
+    }
+    history.push({ search: searchParams.toString() });
+  }
+
+  return [searchState, setSearchState];
+}
+
+type SortDirection = 'asc' | 'desc';
+
+function SortHeaderButton(
+  props: {
+    direction?: SortDirection;
+    onPress: (direction?: SortDirection) => void;
+    children: React.ReactNode;
+  } & Omit<StyledButtonProps, 'onPress'>
+): JSX.Element {
+  const { direction, onPress, ...rest } = props;
+  return (
+    <Button
+      onPress={() => {
+        switch (direction) {
+          case 'asc':
+            return onPress('desc');
+          case 'desc':
+            return onPress();
+          case undefined:
+            return onPress('asc');
+          default: {
+            /* istanbul ignore next - @preserve */
+            throwIllegalValue(direction);
+          }
+        }
+      }}
+      fill="transparent"
+      color={direction ? 'primary' : undefined}
+      icon={
+        direction === 'asc'
+          ? 'SortUp'
+          : direction === 'desc'
+          ? 'SortDown'
+          : 'Sort'
+      }
+      {...rest}
+    />
+  );
+}
+
 function AllOrgsElectionsList({
   elections,
 }: {
@@ -64,24 +135,96 @@ function AllOrgsElectionsList({
 }): JSX.Element | null {
   const getAllOrgsQuery = getAllOrgs.useQuery();
   const history = useHistory();
+  const [sortState, setSortState] = useQueryParamsState<
+    | {
+        field: 'Status' | 'Org';
+        direction: SortDirection;
+      }
+    | undefined
+  >();
 
   if (!getAllOrgsQuery.isSuccess) {
     return null;
   }
   const orgs = getAllOrgsQuery.data;
 
+  const sortedElections = (() => {
+    if (!sortState) {
+      return elections;
+    }
+
+    const { field, direction } = sortState;
+
+    function fieldValue(electionRecord: ElectionRecord): string | number {
+      switch (field) {
+        case 'Status':
+          return electionStatus(electionRecord).valueOf();
+        case 'Org':
+          return find(orgs, (org) => org.id === electionRecord.orgId)
+            .displayName;
+        default: {
+          /* istanbul ignore next - @preserve */
+          throwIllegalValue(field);
+        }
+      }
+    }
+    return [...elections].sort((a, b) => {
+      const aValue = fieldValue(a);
+      const bValue = fieldValue(b);
+      if (typeof aValue === 'number' && typeof bValue === 'number') {
+        return direction === 'asc' ? aValue - bValue : bValue - aValue;
+      }
+      if (typeof aValue === 'string' && typeof bValue === 'string') {
+        return direction === 'asc'
+          ? aValue.localeCompare(bValue)
+          : bValue.localeCompare(aValue);
+      }
+      throw new Error('Unexpected field value types');
+    });
+  })();
+
   return (
     <Table>
       <thead>
         <tr>
-          <th>Status</th>
-          <th>Org</th>
+          <th>
+            <SortHeaderButton
+              direction={
+                sortState?.field === 'Status' ? sortState.direction : undefined
+              }
+              onPress={(direction) => {
+                if (direction) {
+                  setSortState({ field: 'Status', direction });
+                } else {
+                  setSortState(undefined);
+                }
+              }}
+            >
+              Status
+            </SortHeaderButton>
+          </th>
+          <th>
+            <SortHeaderButton
+              direction={
+                sortState?.field === 'Org' ? sortState.direction : undefined
+              }
+              onPress={(direction) => {
+                if (direction) {
+                  setSortState({ field: 'Org', direction });
+                } else {
+                  setSortState(undefined);
+                }
+              }}
+            >
+              Org
+            </SortHeaderButton>
+          </th>
           <th>Title</th>
           <th>Date</th>
         </tr>
       </thead>
       <tbody>
-        {elections.map((electionRecord) => {
+        {sortedElections.map((electionRecord) => {
           const { election, orgId } = electionRecord;
           return (
             <ButtonRow

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -59,6 +59,9 @@ import {
   faGripLines,
   faImage,
   faPrint,
+  faSort,
+  faSortUp,
+  faSortDown,
 } from '@fortawesome/free-solid-svg-icons';
 import {
   faXmarkCircle,
@@ -366,6 +369,18 @@ export const Icons = {
 
   Settings(props) {
     return <FaIcon {...props} type={faGear} />;
+  },
+
+  Sort(props) {
+    return <FaIcon {...props} type={faSort} />;
+  },
+
+  SortUp(props) {
+    return <FaIcon {...props} type={faSortUp} />;
+  },
+
+  SortDown(props) {
+    return <FaIcon {...props} type={faSortDown} />;
   },
 
   SoundOff(props) {


### PR DESCRIPTION
## Overview

Closes #5862

For VX support users, adds an election status column to the election list. Also makes the list sortable by the status or org name column.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/454f07ae-ee37-4a1b-aa01-188caf2d9698



## Testing Plan
Manual testing

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
