### PR TITLE
VxDesign: Only apply NH rotation rules if using NH template

### DIFF
--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -288,12 +288,16 @@ function buildApi({ auth, workspace, translator }: AppContext) {
       electionId: ElectionId;
       election: Election;
     }): Promise<void> {
-      const { election } = await store.getElection(input.electionId);
+      const { election, ballotTemplateId } = await store.getElection(
+        input.electionId
+      );
       // TODO validate election, including global ID uniqueness
       await store.updateElection(input.electionId, {
         ...election,
         ...input.election,
-        contests: input.election.contests.map(rotateCandidates),
+        contests: input.election.contests.map((contest) =>
+          rotateCandidates(contest, ballotTemplateId)
+        ),
       });
     },
 

--- a/apps/design/backend/src/candidate_rotation.test.ts
+++ b/apps/design/backend/src/candidate_rotation.test.ts
@@ -14,7 +14,7 @@ describe('rotateCandidates', () => {
     const contest = electionGeneral.contests.find(
       (c) => c.type !== 'candidate'
     )!;
-    expect(rotateCandidates(contest)).toEqual(contest);
+    expect(rotateCandidates(contest, 'NhBallot')).toEqual(contest);
   });
 
   test('skips contests with fewer than 2 candidates', () => {
@@ -22,7 +22,7 @@ describe('rotateCandidates', () => {
       ...candidateContest,
       candidates: candidateContest.candidates.slice(0, 1),
     };
-    expect(rotateCandidates(contest)).toEqual(contest);
+    expect(rotateCandidates(contest, 'NhBallot')).toEqual(contest);
   });
 
   // Examples drawn from NH-provided documentation
@@ -44,7 +44,9 @@ describe('rotateCandidates', () => {
         },
       ],
     };
-    expect((rotateCandidates(contest) as CandidateContest).candidates).toEqual([
+    expect(
+      (rotateCandidates(contest, 'NhBallot') as CandidateContest).candidates
+    ).toEqual([
       {
         id: '1',
         name: 'Martha Jones',
@@ -56,6 +58,39 @@ describe('rotateCandidates', () => {
       {
         id: '2',
         name: 'John Zorro',
+      },
+    ]);
+    expect(
+      (rotateCandidates(contest, 'NhBallotV3') as CandidateContest).candidates
+    ).toEqual([
+      {
+        id: '1',
+        name: 'Martha Jones',
+      },
+      {
+        id: '3',
+        name: 'Larry Smith',
+      },
+      {
+        id: '2',
+        name: 'John Zorro',
+      },
+    ]);
+    expect(
+      (rotateCandidates(contest, 'VxDefaultBallot') as CandidateContest)
+        .candidates
+    ).toEqual([
+      {
+        id: '1',
+        name: 'Martha Jones',
+      },
+      {
+        id: '2',
+        name: 'John Zorro',
+      },
+      {
+        id: '3',
+        name: 'Larry Smith',
       },
     ]);
   });
@@ -107,7 +142,9 @@ describe('rotateCandidates', () => {
       ],
     };
 
-    expect((rotateCandidates(contest) as CandidateContest).candidates).toEqual([
+    expect(
+      (rotateCandidates(contest, 'NhBallot') as CandidateContest).candidates
+    ).toEqual([
       {
         id: '3',
         name: 'John Curtis',
@@ -175,7 +212,9 @@ describe('rotateCandidates', () => {
         },
       ],
     };
-    expect((rotateCandidates(contest) as CandidateContest).candidates).toEqual([
+    expect(
+      (rotateCandidates(contest, 'NhBallot') as CandidateContest).candidates
+    ).toEqual([
       {
         id: '3',
         name: 'John Adams',
@@ -221,7 +260,9 @@ describe('rotateCandidates', () => {
         },
       ],
     };
-    expect((rotateCandidates(contest) as CandidateContest).candidates).toEqual([
+    expect(
+      (rotateCandidates(contest, 'NhBallot') as CandidateContest).candidates
+    ).toEqual([
       {
         id: '3',
         name: 'John Adams',

--- a/apps/design/backend/src/candidate_rotation.ts
+++ b/apps/design/backend/src/candidate_rotation.ts
@@ -1,4 +1,5 @@
 import { assertDefined } from '@votingworks/basics';
+import { BallotTemplateId } from '@votingworks/hmpb';
 import { AnyContest, Candidate } from '@votingworks/types';
 
 // Maps the number of candidates in a contest to the index at which to rotate
@@ -34,9 +35,16 @@ const NH_ROTATION_INDICES: Record<number, number> = {
  * 1. Order the candidates alphabetically by last name.
  * 2. Cut the "deck" at a randomly selected index (see NH_ROTATION_INDICES).
  */
-export function rotateCandidates(contest: AnyContest): AnyContest {
+export function rotateCandidates(
+  contest: AnyContest,
+  ballotTemplateId: BallotTemplateId
+): AnyContest {
   if (contest.type !== 'candidate') return contest;
   if (contest.candidates.length < 2) return contest;
+
+  if (ballotTemplateId !== 'NhBallot' && ballotTemplateId !== 'NhBallotV3') {
+    return contest;
+  }
 
   function getSortingName(candidate: Candidate): string {
     return (


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/5904

This PR updates VxDesign to only apply NH rotation rules if using an NH template. When using the default Vx template, we'll now use the order as entered into the system. Note that if you start with the default Vx template, and switch to an NH template, we won't automatically rotate. We'll only do so on the next save operation. This feels like a fine limitation for now.

Context here is that we're going to be prepping some ballots for SLI where the candidate order has been defined in a spec, and we don't want to apply NH rotation rules.

## Testing Plan

- [x] Updated automated tests
- [x] Tested manually