### PR TITLE
optionally validate image dimensions

### DIFF
--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -169,15 +169,17 @@ function ElectionInfoForm({
       </InputGroup>
       <div>
         <FieldName>Seal</FieldName>
-        <SealImageInput
-          value={electionInfo.seal}
-          onChange={(seal) => setElectionInfo({ ...electionInfo, seal })}
-          disabled={!isEditing}
-          buttonLabel="Upload Seal Image"
-          minWidthPx={200}
-          minHeightPx={200}
-          required
-        />
+        <div style={{ display: 'inline-flex' }}>
+          <SealImageInput
+            value={electionInfo.seal}
+            onChange={(seal) => setElectionInfo({ ...electionInfo, seal })}
+            disabled={!isEditing}
+            buttonLabel="Upload Seal Image"
+            minWidthPx={200}
+            minHeightPx={200}
+            required
+          />
+        </div>
       </div>
 
       {isEditing ? (

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -174,6 +174,8 @@ function ElectionInfoForm({
           onChange={(seal) => setElectionInfo({ ...electionInfo, seal })}
           disabled={!isEditing}
           buttonLabel="Upload Seal Image"
+          minWidthPx={200}
+          minHeightPx={200}
           required
         />
       </div>

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -653,6 +653,8 @@ function PrecinctForm({
                             })
                           }
                           buttonLabel="Upload Image"
+                          minHeightPx={50}
+                          minWidthPx={100}
                         />
                       </div>
                     )}

--- a/apps/design/frontend/src/image_input.test.tsx
+++ b/apps/design/frontend/src/image_input.test.tsx
@@ -110,6 +110,6 @@ describe('ImageInput', () => {
 
     const input = screen.getByLabelText('Upload');
     userEvent.upload(input, tooLargeFile);
-    screen.getByText('Image file size must be less than 1 MB');
+    screen.getByText('Image file size must be less than 5 MB');
   });
 });

--- a/apps/design/frontend/src/image_input.test.tsx
+++ b/apps/design/frontend/src/image_input.test.tsx
@@ -103,17 +103,13 @@ describe('ImageInput', () => {
 
   test('rejects images that are too large', async () => {
     const tooLargeFile = new File([''], 'image.png', { type: 'image/png' });
-    jest.spyOn(tooLargeFile, 'size', 'get').mockReturnValue(6 * 1_000 * 1_000);
-    const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation();
+    jest.spyOn(tooLargeFile, 'size', 'get').mockReturnValue(2 * 1_000 * 1_000);
     render(
       <ImageInput value={undefined} onChange={jest.fn()} buttonLabel="Upload" />
     );
 
     const input = screen.getByLabelText('Upload');
     userEvent.upload(input, tooLargeFile);
-    await waitFor(() => expect(consoleErrorMock).toHaveBeenCalled());
-    expect(consoleErrorMock.mock.calls[0][0]['message']).toEqual(
-      'Image file size must be less than 5 MB'
-    );
+    screen.getByText('Image file size must be less than 1 MB');
   });
 });

--- a/apps/design/frontend/src/image_input.tsx
+++ b/apps/design/frontend/src/image_input.tsx
@@ -1,9 +1,11 @@
 import { Buffer } from 'node:buffer';
 import sanitizeHtml from 'sanitize-html';
-import { FileInputButton, FileInputButtonProps } from '@votingworks/ui';
-import { assert, assertDefined } from '@votingworks/basics';
+import { FileInputButton, FileInputButtonProps, P } from '@votingworks/ui';
+import { assert, assertDefined, err, ok, Result } from '@votingworks/basics';
+import { useEffect, useState } from 'react';
+import { safeParseNumber } from '@votingworks/types';
 
-const MAX_IMAGE_UPLOAD_BYTES = 5 * 1_000 * 1_000; // 5 MB
+const MAX_IMAGE_UPLOAD_BYTES = 1 * 1000 * 1_000; // 1 MB
 
 const ALLOWED_IMAGE_TYPES = ['image/svg+xml', 'image/png', 'image/jpeg'];
 
@@ -113,11 +115,95 @@ async function loadBitmapImageAndConvertToSvg(file: File): Promise<string> {
 interface ImageInputButtonProps
   extends Pick<FileInputButtonProps, 'disabled' | 'buttonProps' | 'children'> {
   onChange: (svgImage: string) => void;
+  onError: (error: Error) => void;
   required?: boolean;
+  minWidthPx?: number;
+  minHeightPx?: number;
+}
+
+function validateSvgDimensions(
+  svgImage: string,
+  minHeightPx?: number,
+  minWidthPx?: number
+): Result<void, Error> {
+  if (!minHeightPx && !minWidthPx) {
+    return ok();
+  }
+
+  const parser = new DOMParser();
+  const scratchDoc = parser.parseFromString(svgImage, 'image/svg+xml');
+  const svgElement = scratchDoc.documentElement;
+
+  if (scratchDoc.querySelector('parsererror')) {
+    return err(new Error('Invalid SVG content'));
+  }
+
+  let width = svgElement.getAttribute('width');
+  let height = svgElement.getAttribute('height');
+
+  // Ignore dimensions in non-px measurements
+  const digitsAndPxOnly = /^\d*(\.\d+)?(px)?$/;
+  if (!width?.match(digitsAndPxOnly)) {
+    width = null;
+  }
+  if (!height?.match(digitsAndPxOnly)) {
+    height = null;
+  }
+
+  // Infer dimensions from viewBox if pixel width/height not present
+  if (width === null || height === null) {
+    const viewBox = svgElement.getAttribute('viewBox');
+    if (viewBox) {
+      // The value of the viewBox attribute is a list of four numbers separated by whitespace and/or a comma: min-x, min-y, width, and height.
+      const [, , viewBoxWidth, viewBoxHeight] = viewBox
+        .replace(/,/g, '')
+        .split(/\s+/);
+      width = width || viewBoxWidth;
+      height = height || viewBoxHeight;
+    }
+  }
+
+  function parseDimension(dimension: string | null) {
+    // Assume an SVG with no dimensions specified is infinitely scalable
+    if (!dimension) {
+      return Number.MAX_SAFE_INTEGER;
+    }
+
+    // Round because viewBox may specify floats as strings
+    return Math.round(
+      safeParseNumber(
+        // Remove units from string
+        dimension.replace(/[a-zA-Z]/g, '')
+      ).unsafeUnwrap()
+    );
+  }
+
+  const widthPx = parseDimension(width);
+  const heightPx = parseDimension(height);
+
+  if (minWidthPx && widthPx < minWidthPx) {
+    return err(
+      new Error(
+        `Image width (${widthPx}px) is smaller than minimum (${minWidthPx}px).`
+      )
+    );
+  }
+  if (minHeightPx && heightPx < minHeightPx) {
+    return err(
+      new Error(
+        `Image height (${heightPx}px) is smaller than minimum (${minHeightPx}px).`
+      )
+    );
+  }
+
+  return ok();
 }
 
 export function ImageInputButton({
   onChange,
+  onError,
+  minHeightPx,
+  minWidthPx,
   ...props
 }: ImageInputButtonProps): JSX.Element {
   return (
@@ -125,27 +211,35 @@ export function ImageInputButton({
       {...props}
       accept={ALLOWED_IMAGE_TYPES.join(',')}
       onChange={async (e) => {
-        try {
-          /* istanbul ignore next */
-          const file = assertDefined(e.target.files?.[0]);
-          if (file.size > MAX_IMAGE_UPLOAD_BYTES) {
-            throw new Error(
+        /* istanbul ignore next */
+        const file = assertDefined(e.target.files?.[0]);
+        if (file.size > MAX_IMAGE_UPLOAD_BYTES) {
+          onError(
+            new Error(
               `Image file size must be less than ${
                 MAX_IMAGE_UPLOAD_BYTES / 1_000 / 1_000
               } MB`
-            );
-          }
-          assert(ALLOWED_IMAGE_TYPES.includes(file.type));
-          const svgImage =
-            file.type === 'image/svg+xml'
-              ? await loadSvgImage(file)
-              : await loadBitmapImageAndConvertToSvg(file);
-          onChange(sanitizeSvg(svgImage));
-        } catch (error) {
-          // TODO handle errors and show to user when we do form validation
-          // eslint-disable-next-line no-console
-          console.error(error);
+            )
+          );
+          return;
         }
+        assert(ALLOWED_IMAGE_TYPES.includes(file.type));
+        const svgImage =
+          file.type === 'image/svg+xml'
+            ? await loadSvgImage(file)
+            : await loadBitmapImageAndConvertToSvg(file);
+
+        const validateResult = validateSvgDimensions(
+          svgImage,
+          minHeightPx,
+          minWidthPx
+        );
+        if (validateResult.isErr()) {
+          onError(validateResult.err());
+          return;
+        }
+
+        onChange(sanitizeSvg(svgImage));
       }}
     />
   );
@@ -158,6 +252,8 @@ export function ImageInput({
   disabled,
   className,
   required,
+  minWidthPx,
+  minHeightPx,
 }: {
   value?: string;
   onChange: (value: string) => void;
@@ -165,7 +261,27 @@ export function ImageInput({
   disabled?: boolean;
   className?: string;
   required?: boolean;
+  minWidthPx?: number;
+  minHeightPx?: number;
 }): JSX.Element {
+  const [error, setError] = useState<Error | undefined>(undefined);
+
+  // Clear error if the parent component has stopped interacting with this one
+  useEffect(() => {
+    if (disabled) {
+      setError(undefined);
+    }
+  }, [disabled]);
+
+  function onError(e: Error) {
+    setError(e);
+  }
+
+  function onSuccessfulImageUpload(newValue: string) {
+    setError(undefined);
+    onChange(newValue);
+  }
+
   return (
     <div className={className}>
       {value && (
@@ -177,10 +293,14 @@ export function ImageInput({
           style={{ marginBottom: '0.5rem' }}
         />
       )}
+      {error && <P style={{ color: 'red' }}>{error.message}</P>}
       <ImageInputButton
         disabled={disabled}
-        onChange={onChange}
+        onChange={onSuccessfulImageUpload}
+        onError={onError}
         required={value ? false : required}
+        minWidthPx={minWidthPx}
+        minHeightPx={minHeightPx}
       >
         {buttonLabel}
       </ImageInputButton>

--- a/apps/design/frontend/src/image_input.tsx
+++ b/apps/design/frontend/src/image_input.tsx
@@ -5,9 +5,8 @@ import {
   FileInputButton,
   FileInputButtonProps,
 } from '@votingworks/ui';
-import { assert, assertDefined, err, ok, Result } from '@votingworks/basics';
+import { assert, assertDefined } from '@votingworks/basics';
 import { useEffect, useRef, useState } from 'react';
-import { safeParseNumber } from '@votingworks/types';
 
 const MAX_IMAGE_UPLOAD_BYTES = 5 * 1_000 * 1_000; // 5 MB
 
@@ -93,22 +92,35 @@ async function getBitmapImageDimensions(
   return { width: img.naturalWidth, height: img.naturalHeight };
 }
 
-async function bitmapImageToSvg(imageDataUrl: string) {
-  const { width, height } = await getBitmapImageDimensions(imageDataUrl);
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
-    <image href="${imageDataUrl}" width="${width}" height="${height}" />
-  </svg>`;
+interface SvgImageWithMetadata {
+  svgImage: string;
+  width: number;
+  height: number;
 }
 
-async function loadBitmapImageAndConvertToSvg(file: File): Promise<string> {
+async function bitmapImageToSvg(
+  imageDataUrl: string
+): Promise<SvgImageWithMetadata> {
+  const { width, height } = await getBitmapImageDimensions(imageDataUrl);
+  return {
+    width,
+    height,
+    svgImage: `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+    <image href="${imageDataUrl}" width="${width}" height="${height}" />
+  </svg>`,
+  };
+}
+
+async function loadBitmapImageAndConvertToSvg(
+  file: File
+): Promise<SvgImageWithMetadata> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = async (e) => {
       /* istanbul ignore next */
       const imageDataUrl = e.target?.result;
       if (typeof imageDataUrl === 'string') {
-        const svgContents = await bitmapImageToSvg(imageDataUrl);
-        resolve(svgContents);
+        resolve(await bitmapImageToSvg(imageDataUrl));
       }
       reject(new Error('Could not read file contents'));
     };
@@ -125,84 +137,6 @@ interface ImageInputButtonProps
   minHeightPx?: number;
 }
 
-function validateSvgDimensions(
-  svgImage: string,
-  minHeightPx?: number,
-  minWidthPx?: number
-): Result<void, Error> {
-  if (!minHeightPx && !minWidthPx) {
-    return ok();
-  }
-
-  const parser = new DOMParser();
-  const scratchDoc = parser.parseFromString(svgImage, 'image/svg+xml');
-  const svgElement = scratchDoc.documentElement;
-
-  if (scratchDoc.querySelector('parsererror')) {
-    return err(new Error('Invalid SVG content'));
-  }
-
-  let width = svgElement.getAttribute('width');
-  let height = svgElement.getAttribute('height');
-
-  // Ignore dimensions in non-px measurements
-  const digitsAndPxOnly = /^\d*(\.\d+)?(px)?$/;
-  if (!width?.match(digitsAndPxOnly)) {
-    width = null;
-  }
-  if (!height?.match(digitsAndPxOnly)) {
-    height = null;
-  }
-
-  // Infer dimensions from viewBox if pixel width/height not present
-  if (width === null || height === null) {
-    const viewBox = svgElement.getAttribute('viewBox');
-    if (viewBox) {
-      // The value of the viewBox attribute is a list of four numbers separated by whitespace and/or a comma: min-x, min-y, width, and height.
-      const [, , viewBoxWidth, viewBoxHeight] = viewBox
-        .replace(/,/g, '')
-        .split(/\s+/);
-      width = width || viewBoxWidth;
-      height = height || viewBoxHeight;
-    }
-  }
-
-  function parseDimension(dimension: string | null) {
-    // Assume an SVG with no dimensions specified is infinitely scalable
-    if (!dimension) {
-      return Number.MAX_SAFE_INTEGER;
-    }
-
-    // Round because viewBox may specify floats as strings
-    return Math.round(
-      safeParseNumber(
-        // Remove units from string
-        dimension.replace(/[a-zA-Z]/g, '')
-      ).unsafeUnwrap()
-    );
-  }
-
-  const widthPx = parseDimension(width);
-  const heightPx = parseDimension(height);
-
-  if (minWidthPx && widthPx < minWidthPx) {
-    return err(
-      new Error(
-        `Image width (${widthPx}px) is smaller than minimum (${minWidthPx}px).`
-      )
-    );
-  }
-  if (minHeightPx && heightPx < minHeightPx) {
-    return err(
-      new Error(
-        `Image height (${heightPx}px) is smaller than minimum (${minHeightPx}px).`
-      )
-    );
-  }
-
-  return ok();
-}
-
 export function ImageInputButton({
   onChange,
   onError,
@@ -217,35 +151,45 @@ export function ImageInputButton({
       {...props}
       accept={ALLOWED_IMAGE_TYPES.join(',')}
       onChange={async (e) => {
+        let imageValidationError;
         /* istanbul ignore next */
         const file = assertDefined(e.target.files?.[0]);
         if (file.size > MAX_IMAGE_UPLOAD_BYTES) {
-          onError(
-            new Error(
-              `Image file size must be less than ${
-                MAX_IMAGE_UPLOAD_BYTES / 1_000 / 1_000
-              } MB`
-            )
+          imageValidationError = new Error(
+            `Image file size must be less than ${
+              MAX_IMAGE_UPLOAD_BYTES / 1_000 / 1_000
+            } MB`
           );
-          return;
         }
         assert(ALLOWED_IMAGE_TYPES.includes(file.type));
-        const svgImage =
-          file.type === 'image/svg+xml'
-            ? await loadSvgImage(file)
-            : await loadBitmapImageAndConvertToSvg(file);
+        let svgImage: string;
+        if (file.type === 'image/svg+xml') {
+          svgImage = await loadSvgImage(file);
+        } else {
+          const svgWithMeta = await loadBitmapImageAndConvertToSvg(file);
+          const { width, height } = svgWithMeta;
 
-        const validateResult = validateSvgDimensions(
-          svgImage,
-          minHeightPx,
-          minWidthPx
-        );
-        inputRef.current?.setCustomValidity('');
-        if (validateResult.isErr()) {
-          inputRef.current?.setCustomValidity(validateResult.err().message);
-          onError(validateResult.err());
-          return;
+          // Validate dimensions against minimums if provided
+          if (minWidthPx && width < minWidthPx) {
+            imageValidationError = new Error(
+              `Image width (${width}px) is smaller than minimum (${minWidthPx}px).`
+            );
+          } else if (minHeightPx && height < minHeightPx) {
+            imageValidationError = new Error(
+              `Image height (${height}px) is smaller than minimum (${minHeightPx}px).`
+            );
+          }
+
+          if (imageValidationError) {
+            onError(imageValidationError);
+            inputRef.current?.setCustomValidity(imageValidationError.message);
+            return;
+          }
+
+          svgImage = svgWithMeta.svgImage;
         }
+
+        inputRef.current?.setCustomValidity('');
 
         onChange(sanitizeSvg(svgImage));
       }}

--- a/apps/design/frontend/src/rich_text_editor.tsx
+++ b/apps/design/frontend/src/rich_text_editor.tsx
@@ -147,6 +147,8 @@ function Toolbar({ editor }: { editor: Editor }) {
               })
               .run();
           }}
+          // eslint-disable-next-line no-console
+          onError={(err) => console.error(err)}
           aria-label="Insert Image"
         >
           <Icons.Image />


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/5866

## Demo Video or Screenshot

https://github.com/user-attachments/assets/9bc47ff9-19e1-4215-99b3-8db2f8cb68bb


![Screenshot 2025-01-31 at 3 18 20 PM](https://github.com/user-attachments/assets/c15dd221-b6a3-43ae-971b-1c13f43614eb)

![Screenshot 2025-01-31 at 3 18 22 PM](https://github.com/user-attachments/assets/f46f4400-84af-44c2-b4c9-dfa2f25e0d06)

![Screenshot 2025-01-31 at 3 18 07 PM](https://github.com/user-attachments/assets/12f534b9-afa1-4946-9ed4-c5b1dda560d5)

![Screenshot 2025-01-31 at 3 18 13 PM](https://github.com/user-attachments/assets/8797219a-7f1d-41f8-b2a0-cb8cd9737c8e)

Styling when a valid seal has been previously uploaded:

![Screenshot 2025-01-31 at 3 17 40 PM](https://github.com/user-attachments/assets/67477be7-497d-47cd-b458-74db65fc61f4)

(The NH seal pictured is valid and remains after I attempted to upload an invalid seal).



## Testing Plan
- manually tested

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
