### PR TITLE
fix(grout): allow downstream error handling

### DIFF
--- a/libs/grout/src/server.ts
+++ b/libs/grout/src/server.ts
@@ -137,7 +137,7 @@ export function buildRouter(
     // We don't try to use the correct HTTP method because that would require
     // some way to annotate RPC methods with the appropriate method, which is
     // more complexity for little practical gain.
-    router.post(path, async (request, response) => {
+    router.post(path, async (request, response, next) => {
       try {
         debug(`Call: ${methodName}(${request.body})`);
         if (!isString(request.body)) {
@@ -164,12 +164,14 @@ export function buildRouter(
 
         response.set('Content-type', 'application/json');
         response.status(200).send(jsonResult);
+        next();
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         debug(`Error: ${message}`);
         // eslint-disable-next-line no-console
         console.error(error); // To aid debugging, log the full error with stack trace
         response.status(500).json({ message });
+        next(error);
       }
     });
   }


### PR DESCRIPTION
## Overview

Closes #5938 

If we do not pass the error to the `express` handler `next`, no subsequent middleware will be able to see it.

## Demo Video or Screenshot
n/a

## Testing Plan
Tested locally, produced [this error](https://votingworks.sentry.io/issues/6262334709/?project=4508717994016768&query=is:unresolved%20issue.priority:%5Bhigh,%20medium%5D&statsPeriod=1h&stream_index=0).
