### PR TITLE
add delete confirmation modal for election

### DIFF
--- a/apps/design/frontend/src/election_info_screen.test.tsx
+++ b/apps/design/frontend/src/election_info_screen.test.tsx
@@ -242,6 +242,12 @@ test('delete election', async () => {
   apiMock.deleteElection.expectCallWith({ electionId }).resolves();
 
   userEvent.click(screen.getByRole('button', { name: 'Delete Election' }));
+  await screen.findByRole('heading', { name: 'Delete Election' });
+  screen.getByText(
+    'Are you sure you want to delete this election? This action cannot be undone.'
+  );
+  userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
   // Redirects to elections list
   await waitFor(() =>
     expect(history.location.pathname).toEqual(routes.root.path)

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -5,6 +5,8 @@ import {
   H1,
   MainContent,
   MainHeader,
+  Modal,
+  P,
   SegmentedButton,
 } from '@votingworks/ui';
 import type { ElectionInfo } from '@votingworks/design-backend';
@@ -51,6 +53,7 @@ function ElectionInfoForm({
     hasBlankElectionInfo(savedElectionInfo)
   );
   const [electionInfo, setElectionInfo] = useState(savedElectionInfo);
+  const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
   const updateElectionInfoMutation = updateElectionInfo.useMutation();
   const deleteElectionMutation = deleteElection.useMutation();
   const history = useHistory();
@@ -90,6 +93,14 @@ function ElectionInfoForm({
   }
 
   function onDeletePress() {
+    setIsConfirmingDelete(true);
+  }
+
+  function onCancelDelete() {
+    setIsConfirmingDelete(false);
+  }
+
+  function onConfirmDeletePress() {
     deleteElectionMutation.mutate(
       { electionId: electionInfo.electionId },
       {
@@ -191,30 +202,58 @@ function ElectionInfoForm({
           </Button>
         </FormActionsRow>
       ) : (
-        <div>
-          <FormActionsRow>
-            <Button
-              type="reset"
-              variant="primary"
-              icon="Edit"
-              disabled={!!ballotsFinalizedAt}
-            >
-              Edit
-            </Button>
-          </FormActionsRow>
-          {features.DELETE_ELECTION && (
-            <FormActionsRow style={{ marginTop: '1rem' }}>
+        <React.Fragment>
+          <div>
+            <FormActionsRow>
               <Button
-                variant="danger"
-                icon="Delete"
-                onPress={onDeletePress}
-                disabled={deleteElectionMutation.isLoading}
+                type="reset"
+                variant="primary"
+                icon="Edit"
+                disabled={!!ballotsFinalizedAt}
               >
-                Delete Election
+                Edit
               </Button>
             </FormActionsRow>
+            {features.DELETE_ELECTION && (
+              <FormActionsRow style={{ marginTop: '1rem' }}>
+                <Button
+                  variant="danger"
+                  icon="Delete"
+                  onPress={onDeletePress}
+                  disabled={deleteElectionMutation.isLoading}
+                >
+                  Delete Election
+                </Button>
+              </FormActionsRow>
+            )}
+          </div>
+          {electionInfo.electionId && isConfirmingDelete && (
+            <Modal
+              title="Delete Election"
+              onOverlayClick={onCancelDelete}
+              content={
+                <div>
+                  <P>
+                    Are you sure you want to delete this election? This action
+                    cannot be undone.
+                  </P>
+                </div>
+              }
+              actions={
+                <React.Fragment>
+                  <Button
+                    onPress={() => onConfirmDeletePress()}
+                    variant="danger"
+                    autoFocus
+                  >
+                    Delete
+                  </Button>
+                  <Button onPress={onCancelDelete}>Cancel</Button>
+                </React.Fragment>
+              }
+            />
           )}
-        </div>
+        </React.Fragment>
       )}
     </Form>
   );


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/5918

Adds a confirmation modal to the "Delete Election" button. Follows the pattern in https://github.com/votingworks/vxsuite/pull/5940

## Demo Video or Screenshot

https://github.com/user-attachments/assets/9ac81a6e-5d4e-42bf-8295-8bde57c1342e




## Testing Plan
- updates the existing test, but that test needs to be updated to run with the current auth implementation before it can be built
 
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
