### PR TITLE
fix(design): allow draft dates to be invalid

### DIFF
--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -54,6 +54,7 @@ function ElectionInfoForm({
   );
   const [electionInfo, setElectionInfo] = useState(savedElectionInfo);
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
+  const [draftDate, setDraftDate] = useState<string>();
   const updateElectionInfoMutation = updateElectionInfo.useMutation();
   const deleteElectionMutation = deleteElection.useMutation();
   const history = useHistory();
@@ -136,14 +137,21 @@ function ElectionInfoForm({
       <InputGroup label="Date">
         <input
           type="date"
-          value={electionInfo.date.toISOString()}
-          onChange={(e) =>
-            setElectionInfo({
-              ...electionInfo,
-              date: new DateWithoutTime(e.target.value),
-            })
-          }
+          value={draftDate ?? electionInfo.date.toISOString()}
+          onChange={(e) => {
+            try {
+              const newDate = new DateWithoutTime(e.target.value);
+              setElectionInfo({
+                ...electionInfo,
+                date: newDate,
+              });
+              setDraftDate(undefined);
+            } catch {
+              setDraftDate(e.target.value);
+            }
+          }}
           disabled={!isEditing}
+          required
         />
       </InputGroup>
       <SegmentedButton


### PR DESCRIPTION

## Overview
Closes #5946

Rather than forcing the value to always be a valid date, store the draft entry while it's not valid. The built-in HTML validation will ensure we cannot submit the form while the date is invalid.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/1a6675c3-e5a5-4ef4-99f6-6370239b00f6


## Testing Plan
Manually tested since automated tests are temporarily disabled.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
