### PR TITLE
[VxDesign] Docker: drop corepack, use explicit pnpm installation

### DIFF
--- a/Dockerfile.vxdesign
+++ b/Dockerfile.vxdesign
@@ -60,7 +60,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | b
   nvm install && \
   . ~/.bashrc && \
   node -v && \
-  corepack enable && \
+  npm i -g pnpm@8.15.5 && \
   pnpm -v
 
 COPY . .


### PR DESCRIPTION
## Overview

The Docker build is currently broken, potentially due to a change in corepack (related: https://github.com/nodejs/corepack/issues/612).

To unblock, updating the `Dockerfile` to install a hardcoded version of `pnpm` with `npm` instead.

## Testing Plan
- Tested with local docker build
