### PR TITLE
fix(hmpb): add "PROOF" watermark to NH v3 template

### DIFF
--- a/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
@@ -52,6 +52,7 @@ import { BallotMode, PixelDimensions } from '../types';
 import { hmpbStrings } from '../hmpb_strings';
 import { layOutInColumns } from '../layout_in_columns';
 import { NhBallotProps, NhPrecinctSplitOptions } from './nh_ballot_template';
+import { Watermark } from './watermark';
 
 const Colors = {
   BLACK: '#000000',
@@ -203,6 +204,7 @@ function BallotPageFrame({
   electionTitleOverride,
   clerkSignatureImage,
   clerkSignatureCaption,
+  watermark,
 }: BaseBallotProps &
   NhPrecinctSplitOptions & {
     pageNumber: number;
@@ -225,6 +227,7 @@ function BallotPageFrame({
         dimensions={pageDimensions}
         margins={pageMarginsInches}
       >
+        {watermark && <Watermark>{watermark}</Watermark>}
         <TimingMarkGrid pageDimensions={pageDimensions}>
           <div
             style={{


### PR DESCRIPTION
## Overview
I believe this was missed because the watermark was added at the same time the v3 template was forked.

## Demo Video or Screenshot
![PROOF-official-precinct-ballot-Precinct_1-1_en](https://github.com/user-attachments/assets/ec5f234b-8c47-427a-bc9a-5cc4213fc603)

## Testing Plan
Tested manually only because automated tests are temporarily disabled.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
