### PR TITLE
[VxDesign] Enable local dev with prod DB snapshots

### DIFF
--- a/apps/design/frontend/src/elections_screen.tsx
+++ b/apps/design/frontend/src/elections_screen.tsx
@@ -137,7 +137,7 @@ function AllOrgsElectionsList({
   const history = useHistory();
   const [sortState, setSortState] = useQueryParamsState<
     | {
-        field: 'Status' | 'Org';
+        field: 'Status' | 'Org' | 'Jurisdiction';
         direction: SortDirection;
       }
     | undefined
@@ -162,6 +162,8 @@ function AllOrgsElectionsList({
         case 'Org':
           return find(orgs, (org) => org.id === electionRecord.orgId)
             .displayName;
+        case 'Jurisdiction':
+          return electionRecord.election.county.name;
         default: {
           /* istanbul ignore next - @preserve */
           throwIllegalValue(field);
@@ -182,6 +184,8 @@ function AllOrgsElectionsList({
       throw new Error('Unexpected field value types');
     });
   })();
+
+  const showJurisdiction = process.env.NODE_ENV !== 'production';
 
   return (
     <Table>
@@ -219,6 +223,26 @@ function AllOrgsElectionsList({
               Org
             </SortHeaderButton>
           </th>
+          {showJurisdiction && (
+            <th>
+              <SortHeaderButton
+                direction={
+                  sortState?.field === 'Jurisdiction'
+                    ? sortState.direction
+                    : undefined
+                }
+                onPress={(direction) => {
+                  if (direction) {
+                    setSortState({ field: 'Jurisdiction', direction });
+                  } else {
+                    setSortState(undefined);
+                  }
+                }}
+              >
+                Jurisdiction
+              </SortHeaderButton>
+            </th>
+          )}
           <th>Title</th>
           <th>Date</th>
         </tr>
@@ -266,7 +290,10 @@ function AllOrgsElectionsList({
                   }
                 })()}
               </td>
-              <td>{find(orgs, (org) => org.id === orgId).displayName}</td>
+              <td>
+                {orgs.find((org) => org.id === orgId)?.displayName || orgId}
+              </td>
+              {showJurisdiction && <td>{election.county.name}</td>}
               <td>{election.title || 'Untitled Election'}</td>
               <td>
                 {election.date &&


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/5951

Since dev org IDs don't match the ones in prod, we're unable retrieve org display names for elections when running locally against prod DB snapshots, which causes the UI to crash. This removes the assertion on the org name search in the client and falls back to displaying the org ID instead.

When `NODE_ENV !== "production"`, also adding a `Jurisdiction` column to stand in for the org name, since they're closely linked. Will be repetitive for cases where we do have the org names available (running against dev data), so we can refine the show/hide logic if it become cumbersome.

## Testing Plan
- Manual for now

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
