### PR TITLE
pdi-scanner: Treat LIBUSB_TRANSFER_ERROR as disconnection

### DIFF
--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -175,7 +175,7 @@ fn error_to_code_and_message(error: &Error) -> (ErrorCode, Option<String>) {
     match error {
         Error::Usb(UsbError::Rusb(rusb::Error::NotFound))
         | Error::Usb(UsbError::Rusb(rusb::Error::Io))
-        | Error::Usb(UsbError::RusbAsync(rusb_async::Error::Other(_)))
+        | Error::Usb(UsbError::RusbAsync(rusb_async::Error::TransferError))
         | Error::Usb(UsbError::RusbAsync(rusb_async::Error::Stall)) => {
             (ErrorCode::Disconnected, None)
         }

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -175,6 +175,7 @@ fn error_to_code_and_message(error: &Error) -> (ErrorCode, Option<String>) {
     match error {
         Error::Usb(UsbError::Rusb(rusb::Error::NotFound))
         | Error::Usb(UsbError::Rusb(rusb::Error::Io))
+        | Error::Usb(UsbError::RusbAsync(rusb_async::Error::Other(_)))
         | Error::Usb(UsbError::RusbAsync(rusb_async::Error::Stall)) => {
             (ErrorCode::Disconnected, None)
         }

--- a/libs/pdi-scanner/src/rust/rusb_async/error.rs
+++ b/libs/pdi-scanner/src/rust/rusb_async/error.rs
@@ -56,4 +56,7 @@ pub enum Error {
 
     #[error("Transfer was cancelled")]
     Cancelled,
+
+    #[error("Transfer failed")]
+    TransferError,
 }

--- a/libs/pdi-scanner/src/rust/rusb_async/mod.rs
+++ b/libs/pdi-scanner/src/rust/rusb_async/mod.rs
@@ -296,9 +296,7 @@ impl Transfer {
                 return Ok(data);
             }
             ffi::constants::LIBUSB_TRANSFER_CANCELLED => Error::Cancelled,
-            ffi::constants::LIBUSB_TRANSFER_ERROR => {
-                Error::Other("Error occurred during transfer execution")
-            }
+            ffi::constants::LIBUSB_TRANSFER_ERROR => Error::TransferError,
             ffi::constants::LIBUSB_TRANSFER_TIMED_OUT => {
                 unreachable!("We are using timeout=0 which means no timeout")
             }


### PR DESCRIPTION
## Overview

Task: https://github.com/votingworks/vxsuite/issues/5984

In production environments, we've seen `LIBUSB_TRANSFER_ERROR` occur when the scanner is disconnected due to a USB blip (root hardware cause still unknown). To mitigate this, we create a new error variant for this specific error code and treat it as a disconnection. The higher-level state machine logic already tries to reconnect continuously when disconnected, and manual testing has shown that this is sufficient to recover from one of these blips.

There is a slight risk that there may be other causes of `LIBUSB_TRANSFER_ERROR` that are not disconnections, but rather actual unrecoverable errors. In that case, after this change, we'll be showing the "Internal Connection Problem" screen instead of the "restart the scanner" message. I believe that's ok for two reasons:
1. We haven't seen `LIBUSB_TRANSFER_ERROR` in any other cases yet, and we've done a lot of scanning.
2. If it does happen and we show "Internal Connection Problem," I imagine poll workers will likely try restarting the scanner anyway.

## Demo Video or Screenshot
N/A

## Testing Plan
I manually tested the original version of this fix (documented in the first commit) during the initial investigation. It would be a bit of a pain to set up the environment needed to test it again, so I'm hoping we can rely on type-checking/code review alone to validate that the second commit is equivalent. I did do some manual testing to verify that normal operation still works.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
