### PR TITLE
Optimize V3 NH ballot template

### DIFF
--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -561,20 +561,19 @@ async function BallotPageContent(
     const measuredContests = iter(contestElements)
       .zip(contestMeasurements)
       .map(([element, measurements]) => ({ element, ...measurements }))
-      .toArray();
+      .async();
 
-    const { columns, height, leftoverElements } = layOutInColumns({
+    const { columns, height } = await layOutInColumns({
       elements: measuredContests,
       numColumns,
       maxColumnHeight: dimensions.height - heightUsed,
       elementGap: verticalGapPx,
     });
 
-    // Put leftover elements back on the front of the queue
-    if (leftoverElements.length > 0) {
-      contestSectionsLeftToLayout.unshift(
-        leftoverElements.map(({ element }) => element.props.contest)
-      );
+    // Put contests we didn't lay out back on the front of the queue
+    const numElementsUsed = columns.flat().length;
+    if (numElementsUsed < section.length) {
+      contestSectionsLeftToLayout.unshift(section.slice(numElementsUsed));
     }
 
     // If there wasn't enough room left for any contests, go to the next page

--- a/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
@@ -505,20 +505,19 @@ async function BallotPageContent(
     const measuredContests = iter(contestElements)
       .zip(contestMeasurements)
       .map(([element, measurements]) => ({ element, ...measurements }))
-      .toArray();
+      .async();
 
-    const { columns, height, leftoverElements } = layOutInColumns({
+    const { columns, height } = await layOutInColumns({
       elements: measuredContests,
       numColumns,
       maxColumnHeight: dimensions.height - heightUsed,
       elementGap: verticalGapPx,
     });
 
-    // Put leftover elements back on the front of the queue
-    if (leftoverElements.length > 0) {
-      contestSectionsLeftToLayout.unshift(
-        leftoverElements.map(({ element }) => element.props.contest)
-      );
+    // Put contests we didn't lay out back on the front of the queue
+    const numElementsUsed = columns.flat().length;
+    if (numElementsUsed < section.length) {
+      contestSectionsLeftToLayout.unshift(section.slice(numElementsUsed));
     }
 
     // If there wasn't enough room left for any contests, go to the next page

--- a/libs/hmpb/src/layout_in_columns.test.ts
+++ b/libs/hmpb/src/layout_in_columns.test.ts
@@ -1,189 +1,175 @@
 import { expect, test } from 'vitest';
+import { iter } from '@votingworks/basics';
 import { layOutInColumns } from './layout_in_columns';
 
-test('layoutInColumns', () => {
+test('layoutInColumns', async () => {
   const a1 = { id: 'a', height: 1 } as const;
   const b1 = { id: 'b', height: 1 } as const;
   const c2 = { id: 'c', height: 2 } as const;
   const d2 = { id: 'd', height: 2 } as const;
 
   expect(
-    layOutInColumns({
-      elements: [],
+    await layOutInColumns({
+      elements: iter([]).async(),
       numColumns: 1,
       maxColumnHeight: 1,
     })
   ).toEqual({
     columns: [[]],
     height: 0,
-    leftoverElements: [],
   });
 
   expect(
-    layOutInColumns({
-      elements: [a1],
+    await layOutInColumns({
+      elements: iter([a1]).async(),
       numColumns: 1,
       maxColumnHeight: 1,
     })
   ).toEqual({
     columns: [[a1]],
     height: 1,
-    leftoverElements: [],
   });
 
   expect(
-    layOutInColumns({
-      elements: [a1],
+    await layOutInColumns({
+      elements: iter([a1]).async(),
       numColumns: 2,
       maxColumnHeight: 1,
     })
   ).toEqual({
     columns: [[a1], []],
     height: 1,
-    leftoverElements: [],
   });
 
   expect(
-    layOutInColumns({
-      elements: [a1, b1],
+    await layOutInColumns({
+      elements: iter([a1, b1]).async(),
       numColumns: 1,
       maxColumnHeight: 1,
     })
   ).toEqual({
     columns: [[a1]],
     height: 1,
-    leftoverElements: [b1],
   });
 
   expect(
-    layOutInColumns({
-      elements: [a1, b1],
+    await layOutInColumns({
+      elements: iter([a1, b1]).async(),
       numColumns: 2,
       maxColumnHeight: 1,
     })
   ).toEqual({
     columns: [[a1], [b1]],
     height: 1,
-    leftoverElements: [],
   });
 
   expect(
-    layOutInColumns({
-      elements: [a1, b1],
+    await layOutInColumns({
+      elements: iter([a1, b1]).async(),
       numColumns: 1,
       maxColumnHeight: 2,
     })
   ).toEqual({
     columns: [[a1, b1]],
     height: 2,
-    leftoverElements: [],
   });
 
   expect(
-    layOutInColumns({
-      elements: [a1, b1],
+    await layOutInColumns({
+      elements: iter([a1, b1]).async(),
       numColumns: 2,
       maxColumnHeight: 2,
     })
   ).toEqual({
     columns: [[a1], [b1]],
     height: 1,
-    leftoverElements: [],
   });
 
   expect(
-    layOutInColumns({
-      elements: [a1, b1],
+    await layOutInColumns({
+      elements: iter([a1, b1]).async(),
       numColumns: 3,
       maxColumnHeight: 1,
     })
   ).toEqual({
     columns: [[a1], [b1], []],
     height: 1,
-    leftoverElements: [],
   });
 
   expect(
-    layOutInColumns({
-      elements: [a1, b1, c2],
+    await layOutInColumns({
+      elements: iter([a1, b1, c2]).async(),
       numColumns: 1,
       maxColumnHeight: 1,
     })
   ).toEqual({
     columns: [[a1]],
     height: 1,
-    leftoverElements: [b1, c2],
   });
 
   expect(
-    layOutInColumns({
-      elements: [a1, b1, c2],
+    await layOutInColumns({
+      elements: iter([a1, b1, c2]).async(),
       numColumns: 1,
       maxColumnHeight: 2,
     })
   ).toEqual({
     columns: [[a1, b1]],
     height: 2,
-    leftoverElements: [c2],
   });
 
   expect(
-    layOutInColumns({
-      elements: [a1, b1, c2],
+    await layOutInColumns({
+      elements: iter([a1, b1, c2]).async(),
       numColumns: 2,
       maxColumnHeight: 1,
     })
   ).toEqual({
     columns: [[a1], [b1]],
     height: 1,
-    leftoverElements: [c2],
   });
 
   expect(
-    layOutInColumns({
-      elements: [a1, b1, c2],
+    await layOutInColumns({
+      elements: iter([a1, b1, c2]).async(),
       numColumns: 2,
       maxColumnHeight: 2,
     })
   ).toEqual({
     columns: [[a1, b1], [c2]],
     height: 2,
-    leftoverElements: [],
   });
 
   expect(
-    layOutInColumns({
-      elements: [a1, b1, c2],
+    await layOutInColumns({
+      elements: iter([a1, b1, c2]).async(),
       numColumns: 3,
       maxColumnHeight: 1,
     })
   ).toEqual({
     columns: [[a1], [b1], []],
     height: 1,
-    leftoverElements: [c2],
   });
 
   expect(
-    layOutInColumns({
-      elements: [a1, b1, c2],
+    await layOutInColumns({
+      elements: iter([a1, b1, c2]).async(),
       numColumns: 3,
       maxColumnHeight: 2,
     })
   ).toEqual({
     columns: [[a1], [b1], [c2]],
     height: 2,
-    leftoverElements: [],
   });
 
   expect(
-    layOutInColumns({
-      elements: [c2, a1, b1, d2],
+    await layOutInColumns({
+      elements: iter([c2, a1, b1, d2]).async(),
       maxColumnHeight: 2,
       numColumns: 3,
     })
   ).toEqual({
     columns: [[c2], [a1, b1], [d2]],
     height: 2,
-    leftoverElements: [],
   });
 });

--- a/libs/hmpb/src/layout_in_columns.test.ts
+++ b/libs/hmpb/src/layout_in_columns.test.ts
@@ -1,13 +1,13 @@
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { iter } from '@votingworks/basics';
 import { layOutInColumns } from './layout_in_columns';
 
-test('layoutInColumns', async () => {
-  const a1 = { id: 'a', height: 1 } as const;
-  const b1 = { id: 'b', height: 1 } as const;
-  const c2 = { id: 'c', height: 2 } as const;
-  const d2 = { id: 'd', height: 2 } as const;
+const a1 = { id: 'a', height: 1 } as const;
+const b1 = { id: 'b', height: 1 } as const;
+const c2 = { id: 'c', height: 2 } as const;
+const d2 = { id: 'd', height: 2 } as const;
 
+test('lays out as many elements as possible, minimizing column height', async () => {
   expect(
     await layOutInColumns({
       elements: iter([]).async(),
@@ -172,4 +172,31 @@ test('layoutInColumns', async () => {
     columns: [[c2], [a1, b1], [d2]],
     height: 2,
   });
+});
+
+test('doesnt access elements until needed', async () => {
+  const a1Fn = vi.fn().mockResolvedValueOnce(a1);
+  const b1Fn = vi.fn().mockResolvedValueOnce(b1);
+  const c2Fn = vi.fn().mockResolvedValueOnce(c2);
+  const d2Fn = vi.fn().mockResolvedValueOnce(d2);
+  const elements = iter([a1Fn, b1Fn, c2Fn, d2Fn])
+    .map((fn) => fn())
+    .async();
+
+  expect(
+    await layOutInColumns({
+      elements,
+      numColumns: 2,
+      maxColumnHeight: 1,
+    })
+  ).toEqual({
+    columns: [[a1], [b1]],
+    height: 1,
+  });
+
+  expect(a1Fn).toHaveBeenCalledTimes(1);
+  expect(b1Fn).toHaveBeenCalledTimes(1);
+  // Needs to check c2 to know it can't fit
+  expect(c2Fn).toHaveBeenCalledTimes(1);
+  expect(d2Fn).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## Overview

The v3 ballot template copied the logic for laying out contests in columns from existing ballot templates. This logic pre-renders all of the contests to measure their heights, then uses these heights to lay out as many as possible on each page. This is normally fine, since measuring contests is quick. However, in the v3 template, rendering a contest involves measuring all of its children (contest options) to snap them to the grid. This causes a major slowdown for long ballots.

To fix this, this PR changes the column layout function to take an iterable of contests instead of a list (i.e. a lazy list). In the v3 template, we use this laziness to only measure the contests as needed by the layout function. In the other ballot templates, we keep the existing logic to measure all of the contests at once for now, though there may be an opportunity to optimize this as well later.

## Demo Video or Screenshot
Decreases 10 page ballot from 45s to 9s

## Testing Plan
- Manual testing of perf improvement
- Existing automated tests to prevent logical regression
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
