### PR TITLE
V3 NH ballot: Add missing React keys

### DIFF
--- a/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
@@ -346,7 +346,7 @@ async function CandidateContest({
 
   function contestHeaderRenderFn(style: React.CSSProperties) {
     return (
-      <ContestHeader style={{ ...style, width }}>
+      <ContestHeader key="header" style={{ ...style, width }}>
         <DualLanguageText delimiter="/">
           <h3>{electionStrings.contestTitle(contest)}</h3>
         </DualLanguageText>
@@ -507,7 +507,7 @@ async function BallotMeasureContest({
     gridRowHeightInches,
     [
       (style) => (
-        <ContestHeader style={{ ...style, width }}>
+        <ContestHeader key="header" style={{ ...style, width }}>
           <DualLanguageText delimiter="/">
             <h2>{electionStrings.contestTitle(contest)}</h2>
           </DualLanguageText>
@@ -515,6 +515,7 @@ async function BallotMeasureContest({
       ),
       (style) => (
         <div
+          key="description"
           style={{
             padding: '0.5rem 0.5rem 0.25rem 0.5rem',
             display: 'flex',


### PR DESCRIPTION

## Overview

Meant to add these in https://github.com/votingworks/vxsuite/pull/5962 but forgot to commit them. Just silences a warning during browser preview - no functional change.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
