### PR TITLE
fix(design): prevent crash on cancel image input

### DIFF
--- a/apps/design/frontend/jest.config.js
+++ b/apps/design/frontend/jest.config.js
@@ -12,8 +12,8 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: -635,
-      lines: -1152,
+      branches: -617,
+      lines: -1115,
     },
   },
   modulePathIgnorePatterns: [
@@ -26,7 +26,6 @@ module.exports = {
     '<rootDir>/src/elections_screen.test.tsx',
     '<rootDir>/src/ballots_screen.test.tsx',
     '<rootDir>/src/geography_screen.test.tsx',
-    '<rootDir>/src/image_input.test.tsx',
     '<rootDir>/src/features_context.test.tsx',
     '<rootDir>/src/export_screen.test.tsx',
   ],

--- a/apps/design/frontend/src/image_input.tsx
+++ b/apps/design/frontend/src/image_input.tsx
@@ -6,7 +6,7 @@ import {
   FileInputButton,
   FileInputButtonProps,
 } from '@votingworks/ui';
-import { assert, assertDefined } from '@votingworks/basics';
+import { assert } from '@votingworks/basics';
 import { useEffect, useRef, useState } from 'react';
 
 const MAX_IMAGE_UPLOAD_BYTES = 5 * 1_000 * 1_000; // 5 MB
@@ -152,9 +152,12 @@ export function ImageInputButton({
       {...props}
       accept={ALLOWED_IMAGE_TYPES.join(',')}
       onChange={async (e) => {
+        const file = e.target.files?.[0];
+        if (!file) {
+          return;
+        }
         let imageValidationError;
         /* istanbul ignore next */
-        const file = assertDefined(e.target.files?.[0]);
         if (file.size > MAX_IMAGE_UPLOAD_BYTES) {
           imageValidationError = new Error(
             `Image file size must be less than ${

--- a/apps/design/frontend/tsconfig.json
+++ b/apps/design/frontend/tsconfig.json
@@ -25,7 +25,6 @@
     "src/elections_screen.test.tsx",
     "src/ballots_screen.test.tsx",
     "src/geography_screen.test.tsx",
-    "src/image_input.test.tsx",
     "src/features_context.test.tsx",
     "src/export_screen.test.tsx",
     "test/api_helpers.tsx",


### PR DESCRIPTION
Resolves this Sentry issue: https://votingworks.sentry.io/issues/6271094120/

### Steps to Reproduce
1. Go to the Election Info screen.
2. Click "Edit".
3. Click "Upload Seal Image".
4. Choose an image.
5. Click "Upload Seal Image" again.
6. Cancel without choosing a new image.

### Expected Behavior
The image chosen in step 4 is still shown as the current selection.

### Actual Behavior
The page crashes with "Something went wrong".

### Stack
```
unhandled promise rejection: Error
    at assertDefined (assert.ts:20:11)
    at onChange (image_input.tsx:157:22)
```