### PR TITLE
refactor: do not assert `Result::isOk`

### DIFF
--- a/apps/admin/backend/perf/load_cvrs.test.ts
+++ b/apps/admin/backend/perf/load_cvrs.test.ts
@@ -1,7 +1,6 @@
 import { test, vi } from 'vitest';
 import { join } from 'node:path';
 import { readElectionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
-import { assert } from '@votingworks/basics';
 import {
   buildTestEnvironment,
   configureMachine,
@@ -35,10 +34,11 @@ test('loading CVR file performance', async () => {
       RECORDS_PER_REPORT.toString(),
       i.toString()
     );
-    const addReportResult = await apiClient.addCastVoteRecordFile({
-      path: reportDirectoryPath,
-    });
-    assert(addReportResult.isOk());
+    (
+      await apiClient.addCastVoteRecordFile({
+        path: reportDirectoryPath,
+      })
+    ).unsafeUnwrap();
     timer.checkpoint(`file ${i} added`);
   }
 

--- a/apps/admin/backend/src/app.ballot_count_report_csv.test.ts
+++ b/apps/admin/backend/src/app.ballot_count_report_csv.test.ts
@@ -13,6 +13,7 @@ import { readFileSync } from 'node:fs';
 import { LogEventId } from '@votingworks/logging';
 import { Tabulation } from '@votingworks/types';
 import { Client } from '@votingworks/grout';
+import { err, ok } from '@votingworks/basics';
 import { parseCsv } from '../test/csv';
 import {
   buildTestEnvironment,
@@ -68,7 +69,7 @@ test('logs success if export succeeds', async () => {
     groupBy: {},
     includeSheetCounts: false,
   });
-  expect(failedExportResult.isErr()).toEqual(true);
+  expect(failedExportResult).toEqual(err(expect.anything()));
   expect(logger.log).toHaveBeenLastCalledWith(
     LogEventId.FileSaved,
     'election_manager',
@@ -101,7 +102,7 @@ test('logs failure if export fails', async () => {
     groupBy: {},
     includeSheetCounts: false,
   });
-  expect(exportResult.isOk()).toEqual(true);
+  expect(exportResult).toEqual(ok(expect.anything()));
   expect(logger.log).toHaveBeenLastCalledWith(
     LogEventId.FileSaved,
     'election_manager',
@@ -129,7 +130,7 @@ async function getParsedExport({
     filter,
     includeSheetCounts: false,
   });
-  expect(exportResult.isOk()).toEqual(true);
+  expect(exportResult).toEqual(ok(expect.anything()));
   return parseCsv(readFileSync(path, 'utf-8').toString());
 }
 

--- a/apps/admin/backend/src/app.caching.test.ts
+++ b/apps/admin/backend/src/app.caching.test.ts
@@ -39,7 +39,7 @@ async function getParsedExport({
     filter: {},
     groupBy: {},
   });
-  expect(exportResult.isOk()).toEqual(true);
+  expect(exportResult).toEqual(ok(expect.anything()));
   return parseCsv(readFileSync(path, 'utf-8').toString());
 }
 

--- a/apps/admin/backend/src/app.cvr_files.test.ts
+++ b/apps/admin/backend/src/app.cvr_files.test.ts
@@ -528,7 +528,7 @@ test('cast vote records authentication error ignored if SKIP_CAST_VOTE_RECORDS_A
   const result = await apiClient.addCastVoteRecordFile({
     path: castVoteRecordExport.asDirectoryPath(),
   });
-  expect(result.isOk()).toEqual(true);
+  expect(result).toEqual(ok(expect.anything()));
 });
 
 test('error if report metadata is not parseable', async () => {
@@ -711,7 +711,7 @@ test('specifying path to metadata file instead of path to export directory (for 
       CastVoteRecordExportFileName.METADATA
     ),
   });
-  expect(importResult.isOk()).toEqual(true);
+  expect(importResult).toEqual(ok(expect.anything()));
 });
 
 test.each<{

--- a/apps/admin/backend/src/app.cvr_files.test.ts
+++ b/apps/admin/backend/src/app.cvr_files.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { Buffer } from 'node:buffer';
 import set from 'lodash.set';
-import { assert, err, ok } from '@votingworks/basics';
+import { err, ok } from '@votingworks/basics';
 import {
   electionGridLayoutNewHampshireTestBallotFixtures,
   electionTwoPartyPrimaryFixtures,
@@ -250,10 +250,11 @@ test('happy path - mock election flow', async () => {
   );
 
   exportDirectoryPath = availableCastVoteRecordFiles2[0]!.path;
-  const addLiveFileResult = await apiClient.addCastVoteRecordFile({
-    path: exportDirectoryPath,
-  });
-  assert(addLiveFileResult.isOk());
+  (
+    await apiClient.addCastVoteRecordFile({
+      path: exportDirectoryPath,
+    })
+  ).unsafeUnwrap();
   expect(logger.log).toHaveBeenLastCalledWith(
     LogEventId.ImportCastVoteRecordsComplete,
     'election_manager',
@@ -275,11 +276,12 @@ test('adding a file with BMD cast vote records', async () => {
   await configureMachine(apiClient, auth, electionTwoPartyPrimaryDefinition);
   mockElectionManagerAuth(auth, electionTwoPartyPrimaryDefinition.election);
 
-  const addTestFileResult = await apiClient.addCastVoteRecordFile({
-    path: electionTwoPartyPrimaryFixtures.castVoteRecordExport.asDirectoryPath(),
-  });
-  assert(addTestFileResult.isOk());
-  expect(addTestFileResult.ok()).toMatchObject({
+  const cvrImportInfo = (
+    await apiClient.addCastVoteRecordFile({
+      path: electionTwoPartyPrimaryFixtures.castVoteRecordExport.asDirectoryPath(),
+    })
+  ).unsafeUnwrap();
+  expect(cvrImportInfo).toMatchObject({
     wasExistingFile: false,
     alreadyPresent: 0,
     newlyAdded: 112,
@@ -319,11 +321,12 @@ test('handles duplicate exports', async () => {
   ).assertOk('expected to load cast vote record report successfully');
 
   // try adding duplicate file
-  const addDuplicateFileResult = await apiClient.addCastVoteRecordFile({
-    path: exportDirectoryPath,
-  });
-  assert(addDuplicateFileResult.isOk());
-  expect(addDuplicateFileResult.ok()).toMatchObject({
+  const cvrImportInfo = (
+    await apiClient.addCastVoteRecordFile({
+      path: exportDirectoryPath,
+    })
+  ).unsafeUnwrap();
+  expect(cvrImportInfo).toMatchObject({
     wasExistingFile: true,
     alreadyPresent: 184,
     newlyAdded: 0,
@@ -367,11 +370,12 @@ test('handles file with previously added entries by adding only the new entries'
     castVoteRecordExport.asDirectoryPath(),
     { numCastVoteRecordsToKeep: 20 }
   );
-  const addDuplicateEntriesResult = await apiClient.addCastVoteRecordFile({
-    path: laterReportDirectoryPath,
-  });
-  assert(addDuplicateEntriesResult.isOk());
-  expect(addDuplicateEntriesResult.ok()).toMatchObject({
+  const cvrImportInfo = (
+    await apiClient.addCastVoteRecordFile({
+      path: laterReportDirectoryPath,
+    })
+  ).unsafeUnwrap();
+  expect(cvrImportInfo).toMatchObject({
     wasExistingFile: false,
     newlyAdded: 10,
     alreadyPresent: 10,

--- a/apps/admin/backend/src/app.err_cdf_export.test.ts
+++ b/apps/admin/backend/src/app.err_cdf_export.test.ts
@@ -19,7 +19,7 @@ import {
   safeParse,
   safeParseJson,
 } from '@votingworks/types';
-import { assert, assertDefined, find } from '@votingworks/basics';
+import { assert, assertDefined, err, find, ok } from '@votingworks/basics';
 import { Client } from '@votingworks/grout';
 import { modifyCastVoteRecordExport } from '@votingworks/backend';
 import {
@@ -67,7 +67,7 @@ test('logs success if export succeeds', async () => {
   const failedExportResult = await apiClient.exportCdfElectionResultsReport({
     path: offLimitsPath,
   });
-  expect(failedExportResult.isErr()).toEqual(true);
+  expect(failedExportResult).toEqual(err(expect.anything()));
   expect(logger.log).toHaveBeenLastCalledWith(
     LogEventId.FileSaved,
     'election_manager',
@@ -91,7 +91,7 @@ test('logs failure if export fails', async () => {
   const exportResult = await apiClient.exportCdfElectionResultsReport({
     path,
   });
-  expect(exportResult.isOk()).toEqual(true);
+  expect(exportResult).toEqual(ok(expect.anything()));
   expect(logger.log).toHaveBeenLastCalledWith(
     LogEventId.FileSaved,
     'election_manager',

--- a/apps/admin/backend/src/app.tally_report_csv.test.ts
+++ b/apps/admin/backend/src/app.tally_report_csv.test.ts
@@ -14,6 +14,7 @@ import { readFileSync } from 'node:fs';
 import { LogEventId } from '@votingworks/logging';
 import { Tabulation } from '@votingworks/types';
 import { Client } from '@votingworks/grout';
+import { err, ok } from '@votingworks/basics';
 import { parseCsv } from '../test/csv';
 import {
   buildTestEnvironment,
@@ -63,7 +64,7 @@ async function getParsedExport({
     groupBy,
     filter,
   });
-  expect(exportResult.isOk()).toEqual(true);
+  expect(exportResult).toEqual(ok(expect.anything()));
   return parseCsv(readFileSync(path, 'utf-8').toString());
 }
 
@@ -87,7 +88,7 @@ test('exports expected results for full election', async () => {
     groupBy: {},
     path,
   });
-  expect(exportResult.isOk()).toEqual(true);
+  expect(exportResult).toEqual(ok(expect.anything()));
   expect(logger.log).toHaveBeenLastCalledWith(
     LogEventId.FileSaved,
     'election_manager',
@@ -158,7 +159,7 @@ test('logs failure if export fails for some reason', async () => {
     groupBy: {},
     path: offLimitsPath,
   });
-  expect(failedExportResult.isErr()).toEqual(true);
+  expect(failedExportResult).toEqual(err(expect.anything()));
   expect(logger.log).toHaveBeenLastCalledWith(
     LogEventId.FileSaved,
     'election_manager',
@@ -429,7 +430,7 @@ test('exports ballot styles grouped by language agnostic parent in multi-languag
     groupBy: { groupByBallotStyle: true },
     path,
   });
-  expect(exportResult.isOk()).toEqual(true);
+  expect(exportResult).toEqual(ok(expect.anything()));
   expect(logger.log).toHaveBeenLastCalledWith(
     LogEventId.FileSaved,
     'election_manager',

--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -94,8 +94,9 @@ test('managing the current election', async () => {
   const badConfigureResult = await apiClient.configure({
     electionFilePath: saveTmpFile('{}'),
   });
-  assert(badConfigureResult.isErr());
-  expect(badConfigureResult.err().type).toEqual('invalid-zip');
+  expect(badConfigureResult).toEqual(
+    err(expect.objectContaining({ type: 'invalid-zip' }))
+  );
   expect(logger.log).toHaveBeenNthCalledWith(
     1,
     LogEventId.ElectionConfigured,
@@ -112,8 +113,9 @@ test('managing the current election', async () => {
   const badElectionConfigureResult = await apiClient.configure({
     electionFilePath: saveTmpFile(badElectionPackage),
   });
-  assert(badElectionConfigureResult.isErr());
-  expect(badElectionConfigureResult.err().type).toEqual('invalid-election');
+  expect(badElectionConfigureResult).toEqual(
+    err(expect.objectContaining({ type: 'invalid-election' }))
+  );
 
   expect(logger.log).toHaveBeenNthCalledWith(
     2,
@@ -136,9 +138,8 @@ test('managing the current election', async () => {
   const badSystemSettingsConfigureResult = await apiClient.configure({
     electionFilePath: saveTmpFile(badSystemSettingsPackage),
   });
-  assert(badSystemSettingsConfigureResult.isErr());
-  expect(badSystemSettingsConfigureResult.err().type).toEqual(
-    'invalid-system-settings'
+  expect(badSystemSettingsConfigureResult).toEqual(
+    err(expect.objectContaining({ type: 'invalid-system-settings' }))
   );
   expect(logger.log).toHaveBeenNthCalledWith(
     3,
@@ -461,7 +462,7 @@ describe('ERR file import', () => {
       filepath,
     });
 
-    expect(result.isOk()).toEqual(true);
+    expect(result).toEqual(ok());
 
     const manualResults = await apiClient.getManualResults(
       manualResultsIdentifier
@@ -564,7 +565,7 @@ describe('ERR file import', () => {
       filepath,
     });
 
-    expect(result.isOk()).toEqual(true);
+    expect(result).toEqual(ok());
 
     // Import the same ERR file again for absentee tallies
     manualResultsIdentifier.votingMethod = 'absentee';
@@ -574,7 +575,7 @@ describe('ERR file import', () => {
     });
 
     // Expect no error when importing a write-in candidate with exactly the same {election, contest, name} combination
-    expect(result.isOk()).toEqual(true);
+    expect(result).toEqual(ok());
   });
 
   test('logs when file parsing fails', async () => {

--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -156,11 +156,11 @@ test('managing the current election', async () => {
       DEFAULT_SYSTEM_SETTINGS
     ),
   });
-  const configureResult = await apiClient.configure({
-    electionFilePath: saveTmpFile(goodPackage),
-  });
-  assert(configureResult.isOk());
-  const { electionId } = configureResult.ok();
+  const { electionId } = (
+    await apiClient.configure({
+      electionFilePath: saveTmpFile(goodPackage),
+    })
+  ).unsafeUnwrap();
   expect(logger.log).toHaveBeenNthCalledWith(
     4,
     LogEventId.ElectionConfigured,
@@ -245,11 +245,11 @@ test('configuring with a CDF election', async () => {
   });
 
   // configure with well-formed election data
-  const configureResult = await apiClient.configure({
-    electionFilePath: saveTmpFile(electionPackage),
-  });
-  assert(configureResult.isOk());
-  configureResult.ok();
+  (
+    await apiClient.configure({
+      electionFilePath: saveTmpFile(electionPackage),
+    })
+  ).unsafeUnwrap();
   expect(logger.log).toHaveBeenNthCalledWith(
     1,
     LogEventId.ElectionConfigured,

--- a/apps/admin/backend/src/tabulation/election_results_reporting.test.ts
+++ b/apps/admin/backend/src/tabulation/election_results_reporting.test.ts
@@ -3,7 +3,6 @@ import { LogEventId, mockLogger } from '@votingworks/logging';
 import { testElectionReport } from '@votingworks/types';
 import { writeFile } from 'node:fs/promises';
 import { tmpNameSync } from 'tmp';
-import { assert } from 'node:console';
 import { parseElectionResultsReportingFile } from './election_results_reporting';
 
 test('reads and parses an Election Results Reporting file', async () => {
@@ -13,9 +12,10 @@ test('reads and parses an Election Results Reporting file', async () => {
 
   const logger = mockLogger({ fn: vi.fn });
 
-  const result = await parseElectionResultsReportingFile(filepath, logger);
-  assert(result.isOk(), 'Unexpected error in test when parsing ERR file');
-  expect(result.ok()).toEqual(errContents);
+  const electionReport = (
+    await parseElectionResultsReportingFile(filepath, logger)
+  ).unsafeUnwrap();
+  expect(electionReport).toEqual(errContents);
 });
 
 test('logs on file reading error', async () => {

--- a/apps/admin/backend/src/tabulation/election_results_reporting.test.ts
+++ b/apps/admin/backend/src/tabulation/election_results_reporting.test.ts
@@ -3,6 +3,7 @@ import { LogEventId, mockLogger } from '@votingworks/logging';
 import { testElectionReport } from '@votingworks/types';
 import { writeFile } from 'node:fs/promises';
 import { tmpNameSync } from 'tmp';
+import { err } from '@votingworks/basics';
 import { parseElectionResultsReportingFile } from './election_results_reporting';
 
 test('reads and parses an Election Results Reporting file', async () => {
@@ -24,7 +25,7 @@ test('logs on file reading error', async () => {
     './not/a/real/filepath',
     logger
   );
-  expect(result.isErr()).toEqual(true);
+  expect(result).toEqual(err(expect.anything()));
   expect(logger.log).toHaveBeenCalledWith(
     LogEventId.FileReadError,
 

--- a/apps/admin/backend/src/tabulation/manual_results.test.ts
+++ b/apps/admin/backend/src/tabulation/manual_results.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from 'vitest';
 import { Buffer } from 'node:buffer';
 import { electionTwoPartyPrimaryFixtures } from '@votingworks/fixtures';
 import { buildManualResultsFixture } from '@votingworks/utils';
-import { assert } from '@votingworks/basics';
 import {
   BallotStyleGroupId,
   DEFAULT_SYSTEM_SETTINGS,
@@ -281,39 +280,37 @@ describe('tabulateManualResults & tabulateManualBallotCounts', () => {
     ];
 
     for (const { filter, groupBy, expected } of testCases) {
-      const result = tabulateManualResults({
+      const manualResultsGroupMap = tabulateManualResults({
         electionId,
         store,
         filter,
         groupBy,
-      });
-      assert(result.isOk());
+      }).unsafeUnwrap();
 
       for (const [groupKey, ballotCount] of expected) {
-        expect(result.ok()[groupKey]).toEqual(
+        expect(manualResultsGroupMap[groupKey]).toEqual(
           getSimpleManualResultsFixture(ballotCount)
         );
       }
 
-      expect(Object.values(result.ok())).toHaveLength(
+      expect(Object.values(manualResultsGroupMap)).toHaveLength(
         Object.values(expected).length
       );
     }
 
     for (const { filter, groupBy, expected } of testCases) {
-      const result = tabulateManualBallotCounts({
+      const manualBallotCountsGroupMap = tabulateManualBallotCounts({
         electionId,
         store,
         filter,
         groupBy,
-      });
-      assert(result.isOk());
+      }).unsafeUnwrap();
 
       for (const [groupKey, ballotCount] of expected) {
-        expect(result.ok()[groupKey]).toEqual(ballotCount);
+        expect(manualBallotCountsGroupMap[groupKey]).toEqual(ballotCount);
       }
 
-      expect(Object.values(result.ok())).toHaveLength(
+      expect(Object.values(manualBallotCountsGroupMap)).toHaveLength(
         Object.values(expected).length
       );
     }

--- a/apps/central-scan/backend/src/app.grout.test.ts
+++ b/apps/central-scan/backend/src/app.grout.test.ts
@@ -22,7 +22,7 @@ import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
 } from '@votingworks/utils';
-import { assert } from 'node:console';
+import { err } from '@votingworks/basics';
 import { withApp } from '../test/helpers/setup_app';
 import { mockElectionManagerAuth } from '../test/helpers/auth';
 
@@ -366,9 +366,9 @@ test('configure with invalid file', async () => {
       })
     );
 
-    const badResult = await apiClient.configureFromElectionPackageOnUsbDrive();
-    assert(badResult.isErr());
-    expect(badResult.err()).toEqual('election_key_mismatch');
+    expect(await apiClient.configureFromElectionPackageOnUsbDrive()).toEqual(
+      err('election_key_mismatch')
+    );
     expect(logger.log).toHaveBeenLastCalledWith(
       LogEventId.ElectionConfigured,
       'election_manager',

--- a/apps/central-scan/backend/src/end_to_end_bmd.test.ts
+++ b/apps/central-scan/backend/src/end_to_end_bmd.test.ts
@@ -42,10 +42,9 @@ test('going through the whole process works - BMD', async () => {
           electionFamousNames2021Fixtures.electionJson.toElectionPackage()
         )
       );
-      const configureResult =
-        await apiClient.configureFromElectionPackageOnUsbDrive();
-      expect(configureResult.isOk()).toEqual(true);
-      expect(configureResult.ok()).toEqual(electionDefinition);
+      expect(await apiClient.configureFromElectionPackageOnUsbDrive()).toEqual(
+        ok(electionDefinition)
+      );
       mockUsbDrive.removeUsbDrive();
 
       await apiClient.setTestMode({ testMode: true });

--- a/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
+++ b/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
@@ -55,10 +55,9 @@ test('going through the whole process works - HMPB', async () => {
           )
         )
       );
-      const configureResult =
-        await apiClient.configureFromElectionPackageOnUsbDrive();
-      expect(configureResult.isOk()).toEqual(true);
-      expect(configureResult.ok()).toEqual(electionDefinition);
+      expect(await apiClient.configureFromElectionPackageOnUsbDrive()).toEqual(
+        ok(electionDefinition)
+      );
       mockUsbDrive.removeUsbDrive();
 
       await apiClient.setTestMode({ testMode: false });

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -1,4 +1,4 @@
-import { assert, deferred, mapObject } from '@votingworks/basics';
+import { assert, deferred, err, mapObject } from '@votingworks/basics';
 import tmp from 'tmp';
 import {
   electionFamousNames2021Fixtures,
@@ -270,8 +270,7 @@ test('configureElectionPackageFromUsb returns an error if election package parsi
   });
 
   const result = await apiClient.configureElectionPackageFromUsb();
-  assert(result.isErr());
-  expect(result.err()).toEqual('auth_required_before_election_package_load');
+  expect(result).toEqual(err('auth_required_before_election_package_load'));
   expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
     LogEventId.ElectionConfigured,
     expect.objectContaining({

--- a/apps/mark-scan/backend/test/app_helpers.ts
+++ b/apps/mark-scan/backend/test/app_helpers.ts
@@ -28,7 +28,7 @@ import {
   TEST_JURISDICTION,
 } from '@votingworks/types';
 import { MockPaperHandlerDriver } from '@votingworks/custom-paper-handler';
-import { assert } from '@votingworks/basics';
+import { assert, ok } from '@votingworks/basics';
 import { createMockUsbDrive, MockUsbDrive } from '@votingworks/usb-drive';
 import { SimulatedClock } from 'xstate/lib/SimulatedClock';
 import { Api, buildApp } from '../src/app';
@@ -171,7 +171,7 @@ export async function configureApp(
     )
   );
   const result = await apiClient.configureElectionPackageFromUsb();
-  expect(result.isOk()).toEqual(true);
+  expect(result).toEqual(ok(expect.anything()));
   mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
     Promise.resolve({
       status: 'logged_out',

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -159,8 +159,7 @@ test('configureElectionPackageFromUsb reads to and writes from store', async () 
     })
   );
 
-  const writeResult = await apiClient.configureElectionPackageFromUsb();
-  assert(writeResult.isOk());
+  (await apiClient.configureElectionPackageFromUsb()).unsafeUnwrap();
   expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
     LogEventId.ElectionConfigured,
     expect.objectContaining({
@@ -195,8 +194,7 @@ test('unconfigureMachine deletes system settings and election definition', async
     })
   );
 
-  const writeResult = await apiClient.configureElectionPackageFromUsb();
-  assert(writeResult.isOk());
+  (await apiClient.configureElectionPackageFromUsb()).unsafeUnwrap();
   await apiClient.unconfigureMachine();
   expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
     LogEventId.ElectionUnconfigured,
@@ -324,8 +322,7 @@ async function configureMachine(
     })
   );
 
-  const writeResult = await apiClient.configureElectionPackageFromUsb();
-  assert(writeResult.isOk());
+  (await apiClient.configureElectionPackageFromUsb()).unsafeUnwrap();
 
   usbDrive.removeUsbDrive();
   mockNoCard();

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -1,4 +1,4 @@
-import { assert } from '@votingworks/basics';
+import { err } from '@votingworks/basics';
 import {
   electionFamousNames2021Fixtures,
   electionGeneralFixtures,
@@ -242,8 +242,7 @@ test('configureElectionPackageFromUsb returns an error if election package parsi
   });
 
   const result = await apiClient.configureElectionPackageFromUsb();
-  assert(result.isErr());
-  expect(result.err()).toEqual('auth_required_before_election_package_load');
+  expect(result).toEqual(err('auth_required_before_election_package_load'));
   expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
     LogEventId.ElectionConfigured,
     expect.objectContaining({

--- a/apps/mark/backend/test/app_helpers.ts
+++ b/apps/mark/backend/test/app_helpers.ts
@@ -31,6 +31,7 @@ import {
   createMockPrinterHandler,
   MemoryPrinterHandler,
 } from '@votingworks/printing';
+import { ok } from '@votingworks/basics';
 import { Api, buildApp } from '../src/app';
 import { createWorkspace, Workspace } from '../src/util/workspace';
 import { getUserRole } from '../src/util/auth';
@@ -115,7 +116,7 @@ export async function configureApp(
     )
   );
   const result = await apiClient.configureElectionPackageFromUsb();
-  expect(result.isOk()).toEqual(true);
+  expect(result).toEqual(ok(expect.anything()));
   mockOf(mockAuth.getAuthStatus).mockImplementation(() =>
     Promise.resolve({
       status: 'logged_out',

--- a/libs/auth/src/artifact_authentication.test.ts
+++ b/libs/auth/src/artifact_authentication.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import path from 'node:path';
 import { dirSync } from 'tmp';
 import { z } from 'zod';
-import { assert, ok } from '@votingworks/basics';
+import { assert, err, ok } from '@votingworks/basics';
 import {
   CastVoteRecordExportFileName,
   CastVoteRecordExportMetadata,
@@ -468,8 +468,13 @@ test.each<{
       artifactToImport,
       importingMachineConfig
     );
-    expect(authenticationResult.isErr()).toEqual(true);
-    expect(authenticationResult.err()?.message).toContain(expectedErrorMessage);
+    expect(authenticationResult).toEqual(
+      err(
+        expect.objectContaining({
+          message: expect.stringContaining(expectedErrorMessage),
+        })
+      )
+    );
   }
 );
 

--- a/libs/backend/src/cast_vote_records/export.test.ts
+++ b/libs/backend/src/cast_vote_records/export.test.ts
@@ -1284,17 +1284,14 @@ test('export and subsequent import of that export', async () => {
   );
   expect(exportDirectoryPaths).toHaveLength(1);
   const exportDirectoryPath = assertDefined(exportDirectoryPaths[0]);
-  const readResult = await readCastVoteRecordExport(exportDirectoryPath);
-  expect(readResult.isOk()).toEqual(true);
-  assert(readResult.isOk());
-  const { castVoteRecordIterator } = readResult.ok();
+  const { castVoteRecordIterator } = (
+    await readCastVoteRecordExport(exportDirectoryPath)
+  ).unsafeUnwrap();
   const castVoteRecordResults = await castVoteRecordIterator.toArray();
   expect(castVoteRecordResults).toHaveLength(3);
-  expect(
-    castVoteRecordResults.every((castVoteRecordResult) =>
-      castVoteRecordResult.isOk()
-    )
-  ).toEqual(true);
+  for (const castVoteRecordResult of castVoteRecordResults) {
+    castVoteRecordResult.unsafeUnwrap();
+  }
 });
 
 test('recovery export', async () => {

--- a/libs/backend/src/election_package/election_package_io.test.ts
+++ b/libs/backend/src/election_package/election_package_io.test.ts
@@ -418,13 +418,13 @@ test('readElectionPackageFromUsb can read an election package from usb', async (
     })
   );
 
-  const electionPackageResult = await readSignedElectionPackageFromUsb(
-    authStatus,
-    mockUsbDrive.usbDrive,
-    mockBaseLogger({ fn: vi.fn })
-  );
-  assert(electionPackageResult.isOk());
-  const { electionPackage } = electionPackageResult.ok();
+  const { electionPackage } = (
+    await readSignedElectionPackageFromUsb(
+      authStatus,
+      mockUsbDrive.usbDrive,
+      mockBaseLogger({ fn: vi.fn })
+    )
+  ).unsafeUnwrap();
   expect(electionPackage.electionDefinition).toEqual(electionDefinition);
   expect(electionPackage.systemSettings).toEqual(
     safeParseSystemSettings(systemSettings.asText()).unsafeUnwrap()
@@ -457,13 +457,13 @@ test("readElectionPackageFromUsb uses default system settings when system settin
     })
   );
 
-  const electionPackageResult = await readSignedElectionPackageFromUsb(
-    authStatus,
-    mockUsbDrive.usbDrive,
-    mockBaseLogger({ fn: vi.fn })
-  );
-  assert(electionPackageResult.isOk());
-  const { electionPackage } = electionPackageResult.ok();
+  const { electionPackage } = (
+    await readSignedElectionPackageFromUsb(
+      authStatus,
+      mockUsbDrive.usbDrive,
+      mockBaseLogger({ fn: vi.fn })
+    )
+  ).unsafeUnwrap();
   expect(electionPackage.electionDefinition).toEqual(electionDefinition);
   expect(electionPackage.systemSettings).toEqual(DEFAULT_SYSTEM_SETTINGS);
 });
@@ -618,13 +618,13 @@ test('configures using the most recently created election package for an electio
     )
   );
 
-  const electionPackageResult = await readSignedElectionPackageFromUsb(
-    authStatus,
-    mockUsbDrive.usbDrive,
-    mockBaseLogger({ fn: vi.fn })
-  );
-  assert(electionPackageResult.isOk());
-  const { electionPackage } = electionPackageResult.ok();
+  const { electionPackage } = (
+    await readSignedElectionPackageFromUsb(
+      authStatus,
+      mockUsbDrive.usbDrive,
+      mockBaseLogger({ fn: vi.fn })
+    )
+  ).unsafeUnwrap();
   // use correct system settings as a proxy for the correct election package
   expect(electionPackage.systemSettings).toEqual(specificSystemSettings);
 });
@@ -685,13 +685,13 @@ test('configures using the most recently created election package across electio
     ),
   ]);
 
-  const electionPackageResult = await readSignedElectionPackageFromUsb(
-    authStatus,
-    mockUsbDrive.usbDrive,
-    mockBaseLogger({ fn: vi.fn })
-  );
-  assert(electionPackageResult.isOk());
-  const { electionPackage } = electionPackageResult.ok();
+  const { electionPackage } = (
+    await readSignedElectionPackageFromUsb(
+      authStatus,
+      mockUsbDrive.usbDrive,
+      mockBaseLogger({ fn: vi.fn })
+    )
+  ).unsafeUnwrap();
   expect(electionPackage.electionDefinition).toEqual(electionDefinition);
 });
 
@@ -736,13 +736,13 @@ test('ignores hidden `.`-prefixed files, even if they are newer', async () => {
     )
   );
 
-  const electionPackageResult = await readSignedElectionPackageFromUsb(
-    authStatus,
-    mockUsbDrive.usbDrive,
-    mockBaseLogger({ fn: vi.fn })
-  );
-  assert(electionPackageResult.isOk());
-  const { electionPackage } = electionPackageResult.ok();
+  const { electionPackage } = (
+    await readSignedElectionPackageFromUsb(
+      authStatus,
+      mockUsbDrive.usbDrive,
+      mockBaseLogger({ fn: vi.fn })
+    )
+  ).unsafeUnwrap();
   expect(electionPackage.electionDefinition).toEqual(electionDefinition);
   expect(electionPackage.systemSettings).toEqual(
     safeParseSystemSettings(systemSettings.asText()).unsafeUnwrap()

--- a/libs/backend/src/election_package/election_package_io.test.ts
+++ b/libs/backend/src/election_package/election_package_io.test.ts
@@ -488,9 +488,8 @@ test('errors if logged-out auth is passed', async () => {
     mockUsbDrive.usbDrive,
     logger
   );
-  assert(electionPackageResult.isErr());
-  expect(electionPackageResult.err()).toEqual(
-    'auth_required_before_election_package_load'
+  expect(electionPackageResult).toEqual(
+    err('auth_required_before_election_package_load')
   );
 });
 
@@ -518,8 +517,7 @@ test('errors if election key on provided auth is different than election package
     mockUsbDrive.usbDrive,
     mockBaseLogger({ fn: vi.fn })
   );
-  assert(electionPackageResult.isErr());
-  expect(electionPackageResult.err()).toEqual('election_key_mismatch');
+  expect(electionPackageResult).toEqual(err('election_key_mismatch'));
 });
 
 test('errors if there is no election package on usb drive', async () => {
@@ -540,9 +538,8 @@ test('errors if there is no election package on usb drive', async () => {
     mockUsbDrive.usbDrive,
     mockBaseLogger({ fn: vi.fn })
   );
-  assert(electionPackageResult.isErr());
-  expect(electionPackageResult.err()).toEqual(
-    'no_election_package_on_usb_drive'
+  expect(electionPackageResult).toEqual(
+    err('no_election_package_on_usb_drive')
   );
 });
 
@@ -809,5 +806,5 @@ test('readElectionPackageFromUsb ignores election package authentication errors 
     mockUsbDrive.usbDrive,
     mockBaseLogger({ fn: vi.fn })
   );
-  expect(electionPackageResult.isOk()).toEqual(true);
+  expect(electionPackageResult).toEqual(ok(expect.anything()));
 });

--- a/libs/basics/.eslintrc.json
+++ b/libs/basics/.eslintrc.json
@@ -1,3 +1,8 @@
 {
-  "extends": ["plugin:vx/recommended"]
+  "extends": ["plugin:vx/recommended"],
+  "rules": {
+    // disable this rule since this package tests `Result` and needs
+    // to have tests that assert on the result's predicates
+    "vx/no-assert-result-predicates": "off"
+  }
 }

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -95,11 +95,11 @@ function buildApi(devDockFilePath: string, mockSpec: MockSpec) {
         electionPathToAbsolute(input.path),
         'utf-8'
       );
-      const parseResult = safeParseElectionDefinition(electionData);
-      assert(parseResult.isOk());
+      const electionDefinition =
+        safeParseElectionDefinition(electionData).unsafeUnwrap();
       const electionInfo: DevDockElectionInfo = {
         path: input.path,
-        title: parseResult.ok().election.title,
+        title: electionDefinition.election.title,
       };
 
       writeDevDockFileContents(devDockFilePath, {

--- a/libs/eslint-plugin-vx/docs/rules/no-assert-result-predicates.md
+++ b/libs/eslint-plugin-vx/docs/rules/no-assert-result-predicates.md
@@ -1,0 +1,28 @@
+# Forbits `assert` or `expect` on `Result::isOk` et al (vx/no-assert-result-predicates)
+
+`Result` wraps either a successful value or an error. You may want to check if
+the result is successful before proceeding or to narrow the type of the result.
+However, asserting on the `isOk` or `isErr` methods yields unhelpful error
+messages such as `expected true, got false`. Instead, in tests you should either
+`expect` the `Result` to equal another `Result` or simply unwrap the result and
+let it throw the `Err` value if it is one.
+
+Note that if your code is _not_ in a test file, you should be checking the
+`Result` value and handling the `Err` case appropriately rather than crashing
+with `unsafeUnwrap`.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```ts
+assert(result.isOk());
+expect(result.isOk()).toBe(true);
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+expect(result).toEqual(ok('value'));
+result.unsafeUnwrap();
+```

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -76,6 +76,7 @@ export = {
     // See libs/eslint-plugin-vx/docs for more documentation on individual rules.
     'vx/no-array-sort-mutation': 'error',
     'vx/no-assert-truthiness': 'error',
+    'vx/no-assert-result-predicates': 'error',
     'vx/no-floating-results': ['error', { ignoreVoid: true }],
     'vx/no-import-workspace-subfolders': 'error',
 

--- a/libs/eslint-plugin-vx/src/rules/index.ts
+++ b/libs/eslint-plugin-vx/src/rules/index.ts
@@ -28,6 +28,7 @@ import gtsUseOptionals from './gts_use_optionals';
 import noArraySortMutation from './no_array_sort_mutation';
 import noAssertStringOrNumber from './no_assert_truthiness';
 import noFloatingVoids from './no_floating_results';
+import noAssertResultPredicates from './no_assert_result_predicates';
 import noImportSubfolders from './no_import_workspace_subfolders';
 import noExpectToBe from './no_expect_to_be';
 import noReactHookMutationDependency from './no_react_hook_mutation_dependency';
@@ -61,6 +62,7 @@ const rules: Record<string, Rule.RuleModule> = {
   'gts-use-optionals': gtsUseOptionals,
   'no-array-sort-mutation': noArraySortMutation,
   'no-assert-truthiness': noAssertStringOrNumber,
+  'no-assert-result-predicates': noAssertResultPredicates,
   'no-floating-results': noFloatingVoids,
   'no-import-workspace-subfolders': noImportSubfolders,
   'no-expect-to-be': noExpectToBe,

--- a/libs/eslint-plugin-vx/src/rules/no_assert_result_predicates.ts
+++ b/libs/eslint-plugin-vx/src/rules/no_assert_result_predicates.ts
@@ -1,0 +1,114 @@
+import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils';
+import { createRule } from '../util';
+
+type MessageId = 'noAssertResultPredicates' | 'noExpectResultPredicates';
+
+const rule: TSESLint.RuleModule<MessageId, readonly unknown[]> = createRule({
+  name: 'gts-no-assert-result-predicates',
+  meta: {
+    docs: {
+      description:
+        'Do not use assert on `Result` predicates like `isErr` and `isOk`',
+      recommended: 'recommended',
+    },
+    fixable: 'code',
+    messages: {
+      noAssertResultPredicates:
+        'Do not use assert `Result` predicates like `isErr` and `isOk`. Consider using `unsafeUnwrap` instead.',
+      noExpectResultPredicates:
+        'Do not call `expect` on `Result` predicates like `isErr` and `isOk`. Consider calling `expect(…).toEqual(ok(…))` instead.',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
+
+  create(context) {
+    function checkCallExpression(
+      node: TSESTree.CallExpression,
+      reportNode: TSESTree.Node,
+      messageId: MessageId
+    ) {
+      if (
+        node.callee.type === AST_NODE_TYPES.MemberExpression &&
+        node.callee.property.type === AST_NODE_TYPES.Identifier &&
+        ['isErr', 'isOk'].includes(node.callee.property.name)
+      ) {
+        context.report({
+          messageId,
+          node: reportNode,
+        });
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        if (
+          // assert(result.isOk());
+          (node.callee.type === AST_NODE_TYPES.Identifier &&
+            node.callee.name === 'assert' &&
+            node.arguments.length === 1) ||
+          // assert.ok(result.isOk());
+          (node.callee.type === AST_NODE_TYPES.MemberExpression &&
+            node.callee.property.type === AST_NODE_TYPES.Identifier &&
+            node.callee.object.type === AST_NODE_TYPES.Identifier &&
+            node.callee.object.name === 'assert' &&
+            node.callee.property.name === 'ok' &&
+            node.arguments.length === 1)
+        ) {
+          const arg = node.arguments[0];
+          if (arg.type === AST_NODE_TYPES.CallExpression) {
+            checkCallExpression(arg, node, 'noAssertResultPredicates');
+          }
+
+          // assert(!result.isOk());
+          if (arg.type === AST_NODE_TYPES.UnaryExpression) {
+            if (
+              arg.operator === '!' &&
+              arg.argument.type === AST_NODE_TYPES.CallExpression
+            ) {
+              checkCallExpression(
+                arg.argument,
+                node,
+                'noAssertResultPredicates'
+              );
+            }
+          }
+        }
+
+        // expect(result.isOk()).toBe(true);
+        if (
+          node.callee.type === AST_NODE_TYPES.MemberExpression &&
+          node.callee.property.type === AST_NODE_TYPES.Identifier &&
+          /^to[A-Z]/.test(node.callee.property.name) &&
+          node.arguments.length === 1 &&
+          node.callee.object.type === AST_NODE_TYPES.CallExpression &&
+          node.callee.object.callee.type === AST_NODE_TYPES.Identifier &&
+          node.callee.object.callee.name === 'expect' &&
+          node.callee.object.arguments.length === 1
+        ) {
+          const arg = node.callee.object.arguments[0];
+          if (arg.type === AST_NODE_TYPES.CallExpression) {
+            checkCallExpression(arg, node, 'noExpectResultPredicates');
+          }
+
+          // expect(!result.isOk()).toBe(true);
+          if (arg.type === AST_NODE_TYPES.UnaryExpression) {
+            if (
+              arg.operator === '!' &&
+              arg.argument.type === AST_NODE_TYPES.CallExpression
+            ) {
+              checkCallExpression(
+                arg.argument,
+                node,
+                'noExpectResultPredicates'
+              );
+            }
+          }
+        }
+      },
+    };
+  },
+});
+
+export default rule;

--- a/libs/eslint-plugin-vx/tests/rules/no_assert_result_predicates.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/no_assert_result_predicates.test.ts
@@ -17,6 +17,11 @@ ruleTester.run('no-assert-result-predicates', rule, {
     'assert(false);',
     'result.isOk();',
     'result.isErr();',
+    'result.isOk() ? 1 : 0;',
+    'assert(!result.ok());',
+    'assert(+result.ok());',
+    'expect(result.ok()).toBe(true);',
+    'expect(+result.ok()).toEqual(1);',
   ],
   invalid: [
     {

--- a/libs/eslint-plugin-vx/tests/rules/no_assert_result_predicates.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/no_assert_result_predicates.test.ts
@@ -1,0 +1,87 @@
+import { join } from 'node:path';
+import { RuleTester } from '@typescript-eslint/utils/ts-eslint';
+import rule from '../../src/rules/no_assert_result_predicates';
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: join(__dirname, '../fixtures'),
+    project: './tsconfig.json',
+  },
+  parser: require.resolve('@typescript-eslint/parser'),
+});
+
+ruleTester.run('no-assert-result-predicates', rule, {
+  valid: [
+    'assert(true);',
+    'assert(false);',
+    'result.isOk();',
+    'result.isErr();',
+  ],
+  invalid: [
+    {
+      code: 'assert(result.isOk());',
+      errors: [{ line: 1, messageId: 'noAssertResultPredicates' }],
+    },
+    {
+      code: 'assert(result.isErr());',
+      errors: [{ line: 1, messageId: 'noAssertResultPredicates' }],
+    },
+    {
+      code: 'assert(!result.isOk());',
+      errors: [{ line: 1, messageId: 'noAssertResultPredicates' }],
+    },
+    {
+      code: 'assert(!result.isErr());',
+      errors: [{ line: 1, messageId: 'noAssertResultPredicates' }],
+    },
+    {
+      code: 'assert.ok(result.isOk());',
+      errors: [{ line: 1, messageId: 'noAssertResultPredicates' }],
+    },
+    {
+      code: 'assert.ok(result.isErr());',
+      errors: [{ line: 1, messageId: 'noAssertResultPredicates' }],
+    },
+    {
+      code: 'assert.ok(!result.isOk());',
+      errors: [{ line: 1, messageId: 'noAssertResultPredicates' }],
+    },
+    {
+      code: 'assert.ok(!result.isErr());',
+      errors: [{ line: 1, messageId: 'noAssertResultPredicates' }],
+    },
+    {
+      code: 'expect(result.isOk()).toBe(true);',
+      errors: [{ line: 1, messageId: 'noExpectResultPredicates' }],
+    },
+    {
+      code: 'expect(result.isErr()).toBe(true);',
+      errors: [{ line: 1, messageId: 'noExpectResultPredicates' }],
+    },
+    {
+      code: 'expect(!result.isOk()).toBe(true);',
+      errors: [{ line: 1, messageId: 'noExpectResultPredicates' }],
+    },
+    {
+      code: 'expect(!result.isErr()).toBe(true);',
+      errors: [{ line: 1, messageId: 'noExpectResultPredicates' }],
+    },
+    {
+      code: 'expect(result.isOk()).toEqual(true);',
+      errors: [{ line: 1, messageId: 'noExpectResultPredicates' }],
+    },
+    {
+      code: 'expect(result.isErr()).toEqual(true);',
+      errors: [{ line: 1, messageId: 'noExpectResultPredicates' }],
+    },
+    {
+      code: 'expect(!result.isOk()).toEqual(true);',
+      errors: [{ line: 1, messageId: 'noExpectResultPredicates' }],
+    },
+    {
+      code: 'expect(!result.isErr()).toEqual(true);',
+      errors: [{ line: 1, messageId: 'noExpectResultPredicates' }],
+    },
+  ],
+});

--- a/libs/types/src/cdf/election-results-reporting/convert.test.ts
+++ b/libs/types/src/cdf/election-results-reporting/convert.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { assert, assertDefined } from '@votingworks/basics';
+import { assert, assertDefined, err } from '@votingworks/basics';
 import { ResultsReporting } from '../..';
 import {
   findBallotMeasureSelectionWithContent,
@@ -377,35 +377,49 @@ describe('getManualResultsFromErrElectionResults', () => {
 
   test('returns an error if a non-write-in candidate ID in the ERR report is not a known ID', () => {
     // Known IDs are intended to represent candidate IDs in a VX election definition but are technically arbitrary
-    const results = convertElectionResultsReportingReportToVxManualResults(
-      testElectionReport,
-      new Set<string>()
-    );
-    expect(results.isErr()).toEqual(true);
-    expect(results.err()?.message).toEqual(
-      'Candidate ID in ERR file has no matching ID in VX election definition: barchi-hallaren'
+    expect(
+      convertElectionResultsReportingReportToVxManualResults(
+        testElectionReport,
+        new Set()
+      )
+    ).toEqual(
+      err(
+        expect.objectContaining({
+          message:
+            'Candidate ID in ERR file has no matching ID in VX election definition: barchi-hallaren',
+        })
+      )
     );
   });
 
   test('returns an error for unsupported contest type', () => {
-    const results = convertElectionResultsReportingReportToVxManualResults(
-      testElectionReportUnsupportedContestType,
-      getValidCandidateIds(testElectionReportUnsupportedContestType)
-    );
-    expect(results.isErr()).toEqual(true);
-    expect(results.err()?.message).toEqual(
-      'Unsupported Election Results Reporting contest type ElectionResults.PartyContest'
+    expect(
+      convertElectionResultsReportingReportToVxManualResults(
+        testElectionReportUnsupportedContestType,
+        getValidCandidateIds(testElectionReportUnsupportedContestType)
+      )
+    ).toEqual(
+      err(
+        expect.objectContaining({
+          message:
+            'Unsupported Election Results Reporting contest type ElectionResults.PartyContest',
+        })
+      )
     );
   });
 
   test('when total ballot count computation results in a non-integer result', () => {
-    const result = convertElectionResultsReportingReportToVxManualResults(
-      testElectionReportInvalidBallotTotal,
-      getValidCandidateIds(testElectionReportInvalidBallotTotal)
-    );
-    expect(result.isErr()).toEqual(true);
-    expect(result.err()?.message).toEqual(
-      'Expected an integer value for total ballots but got 4.5'
+    expect(
+      convertElectionResultsReportingReportToVxManualResults(
+        testElectionReportInvalidBallotTotal,
+        getValidCandidateIds(testElectionReportInvalidBallotTotal)
+      )
+    ).toEqual(
+      err(
+        expect.objectContaining({
+          message: 'Expected an integer value for total ballots but got 4.5',
+        })
+      )
     );
   });
 });

--- a/libs/types/src/schema.test.ts
+++ b/libs/types/src/schema.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest';
+import { err } from '@votingworks/basics';
 import { election as electionGeneral, electionData } from '../test/election';
 import * as t from '.';
 import { safeParse, safeParseJson, unsafeParse } from './generic';
@@ -14,7 +15,7 @@ test('parsing JSON.parses a string', () => {
 });
 
 test('parsing invalid JSON', () => {
-  expect(t.safeParseElection('{').isErr()).toEqual(true);
+  expect(t.safeParseElection('{')).toEqual(err(expect.anything()));
 });
 
 test('parsing JSON without a schema', () => {

--- a/libs/types/src/system_settings.test.ts
+++ b/libs/types/src/system_settings.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { assert } from '@votingworks/basics';
+import { err, ok } from '@votingworks/basics';
 
 import {
   DEFAULT_SYSTEM_SETTINGS,
@@ -9,14 +9,15 @@ import {
 const systemSettingsString = JSON.stringify(DEFAULT_SYSTEM_SETTINGS);
 
 test('safeParseSystemSettings safely parses valid system settings', () => {
-  const parsed = safeParseSystemSettings(systemSettingsString);
-  assert(parsed.isOk());
-  expect(parsed.unsafeUnwrap()).toEqual(DEFAULT_SYSTEM_SETTINGS);
+  expect(safeParseSystemSettings(systemSettingsString)).toEqual(
+    ok(DEFAULT_SYSTEM_SETTINGS)
+  );
 });
 
 test('safeParseSystemSettings returns an error for malformed system settings', () => {
-  const parsed = safeParseSystemSettings(JSON.stringify({ invalid: 'field' }));
-  assert(parsed.isErr());
+  expect(safeParseSystemSettings(JSON.stringify({ invalid: 'field' }))).toEqual(
+    err(expect.anything())
+  );
 });
 
 test('disallows invalid mark thresholds', () => {

--- a/libs/types/src/ui_string_audio_clips.test.ts
+++ b/libs/types/src/ui_string_audio_clips.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest';
+import { err, ok } from '@votingworks/basics';
 import { safeParseJson } from './generic';
 import { UiStringAudioClipSchema } from './ui_string_audio_clips';
 
@@ -12,12 +13,13 @@ test('valid structure', () => {
     UiStringAudioClipSchema
   );
 
-  expect(result.isOk()).toEqual(true);
-  expect(result.ok()).toEqual({
-    dataBase64: 'test data',
-    id: 'testKey',
-    languageCode: 'zh-Hant',
-  });
+  expect(result).toEqual(
+    ok({
+      dataBase64: 'test data',
+      id: 'testKey',
+      languageCode: 'zh-Hant',
+    })
+  );
 });
 
 test('missing field', () => {
@@ -29,5 +31,5 @@ test('missing field', () => {
     UiStringAudioClipSchema
   );
 
-  expect(result.isOk()).toEqual(false);
+  expect(result).toEqual(err(expect.anything()));
 });

--- a/libs/types/src/ui_string_audio_ids.test.ts
+++ b/libs/types/src/ui_string_audio_ids.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest';
+import { err, ok } from '@votingworks/basics';
 import { safeParseJson } from './generic';
 import {
   UiStringAudioIdsPackage,
@@ -24,8 +25,7 @@ test('valid structure', () => {
     UiStringAudioIdsPackageSchema
   );
 
-  expect(result.isOk()).toEqual(true);
-  expect(result.ok()).toEqual(testPackage);
+  expect(result).toEqual(ok(testPackage));
 });
 
 test('invalid values', () => {
@@ -39,7 +39,7 @@ test('invalid values', () => {
     UiStringAudioIdsPackageSchema
   );
 
-  expect(result.isOk()).toEqual(false);
+  expect(result).toEqual(err(expect.anything()));
 });
 
 test('invalid nesting', () => {
@@ -57,5 +57,5 @@ test('invalid nesting', () => {
     UiStringAudioIdsPackageSchema
   );
 
-  expect(result.isOk()).toEqual(false);
+  expect(result).toEqual(err(expect.anything()));
 });

--- a/libs/types/src/ui_string_translations.test.ts
+++ b/libs/types/src/ui_string_translations.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest';
+import { err, ok } from '@votingworks/basics';
 import { safeParseJson } from './generic';
 import {
   UiStringsPackage,
@@ -26,8 +27,7 @@ test('valid structure', () => {
     UiStringsPackageSchema
   );
 
-  expect(result.isOk()).toEqual(true);
-  expect(result.ok()).toEqual(testPackage);
+  expect(result).toEqual(ok(testPackage));
 });
 
 test('invalid structure', () => {
@@ -45,7 +45,7 @@ test('invalid structure', () => {
     UiStringsPackageSchema
   );
 
-  expect(result.isOk()).toEqual(false);
+  expect(result).toEqual(err(expect.anything()));
 });
 
 test('mergeUiStrings', () => {


### PR DESCRIPTION

## Overview

The error message from doing so is terrible and provides no context. Calling `Result::unsafeUnwrap` at least throws the `Err` value.

## Demo Video or Screenshot
```ts
$ node
> assert(ok(1).isOk())
undefined
> assert(err(new Error('NOPE')).isOk())
Uncaught AssertionError [ERR_ASSERTION]: false == true
> ok(1).unsafeUnwrap()
1
> err(new Error('NOPE')).unsafeUnwrap()
Uncaught Error: NOPE
```

## Testing Plan
Automated tests.