### PR TITLE
VxDesign rich text editor: Unwrap single cell tables on paste

### DIFF
--- a/apps/design/frontend/src/rich_text_editor.test.tsx
+++ b/apps/design/frontend/src/rich_text_editor.test.tsx
@@ -189,3 +189,36 @@ test('image', async () => {
     ).toString('base64')}"><p>Content</p>`
   );
 });
+
+test('unwraps single cell tables on paste', async () => {
+  const onChange = jest.fn();
+  render(<RichTextEditor initialHtmlContent="" onChange={onChange} />);
+
+  const editor = await screen.findByTestId('rich-text-editor');
+  fireEvent.paste(editor.querySelector('.tiptap')!, {
+    clipboardData: {
+      getData: () => '<table><tr><td>Cell contents</td></tr></table>',
+    },
+  });
+
+  await screen.findByText('Cell contents');
+  expect(onChange).toHaveBeenLastCalledWith('<p>Cell contents</p>');
+});
+
+test('doesnt unwrap multiple cell tables on paste', async () => {
+  const onChange = jest.fn();
+  render(<RichTextEditor initialHtmlContent="" onChange={onChange} />);
+
+  const editor = await screen.findByTestId('rich-text-editor');
+  fireEvent.paste(editor.querySelector('.tiptap')!, {
+    clipboardData: {
+      getData: () =>
+        '<table><tr><td>Cell 1 contents</td><td>Cell 2 contents</td></tr></table>',
+    },
+  });
+
+  await screen.findByRole('table');
+  expect(onChange).toHaveBeenLastCalledWith(
+    '<table style="min-width: 0px"><colgroup><col><col></colgroup><tbody><tr><td colspan="1" rowspan="1"><p>Cell 1 contents</p></td><td colspan="1" rowspan="1"><p>Cell 2 contents</p></td></tr></tbody></table>'
+  );
+});


### PR DESCRIPTION


## Overview

Fixes: https://github.com/votingworks/vxsuite/issues/5961

If a user pastes a single cell table, they probably just wanted to paste the contents of that cell, so we unwrap the table, table row, and cell and just paste the contents.
## Demo Video or Screenshot

https://github.com/user-attachments/assets/dd72ef92-9de4-45cc-93a5-4ac823ee4a5d



## Testing Plan
Manual test and automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
