### PR TITLE
feat(design): allow per-precinct split seal images

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -1053,6 +1053,7 @@ test('getBallotPreviewPdf returns a ballot pdf for NH election with split precin
     './test/mockSignature.svg'
   ).toString();
   split.electionTitleOverride = 'Test Election Title Override';
+  split.electionSealOverride = split.clerkSignatureImage;
 
   await apiClient.updatePrecincts({ electionId, precincts });
 

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -63,6 +63,7 @@ export function createBallotPropsForTemplate(
         return {
           ...props,
           electionTitleOverride: split.electionTitleOverride,
+          electionSealOverride: split.electionSealOverride,
           clerkSignatureImage: split.clerkSignatureImage,
           clerkSignatureCaption: split.clerkSignatureCaption,
         };

--- a/apps/design/frontend/jest.config.js
+++ b/apps/design/frontend/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: -617,
-      lines: -1115,
+      lines: -1116,
     },
   },
   modulePathIgnorePatterns: [

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -11,7 +11,6 @@ import {
 } from '@votingworks/ui';
 import type { ElectionInfo } from '@votingworks/design-backend';
 import { useHistory, useParams } from 'react-router-dom';
-import styled from 'styled-components';
 import { z } from 'zod';
 import { DateWithoutTime } from '@votingworks/basics';
 import {
@@ -23,14 +22,8 @@ import {
 import { FieldName, Form, FormActionsRow, InputGroup } from './layout';
 import { ElectionNavScreen } from './nav_screen';
 import { routes } from './routes';
-import { ImageInput } from './image_input';
 import { useUserFeatures } from './features_context';
-
-const SealImageInput = styled(ImageInput)`
-  img {
-    width: 10rem;
-  }
-`;
+import { SealImageInput } from './seal_image_input';
 
 function hasBlankElectionInfo(electionInfo: ElectionInfo): boolean {
   return (
@@ -193,10 +186,6 @@ function ElectionInfoForm({
             value={electionInfo.seal}
             onChange={(seal = '') => setElectionInfo({ ...electionInfo, seal })}
             disabled={!isEditing}
-            buttonLabel="Upload Seal Image"
-            removeButtonLabel="Remove Seal Image"
-            minWidthPx={200}
-            minHeightPx={200}
             required
           />
         </div>

--- a/apps/design/frontend/src/features_context.tsx
+++ b/apps/design/frontend/src/features_context.tsx
@@ -63,6 +63,10 @@ enum ElectionFeature {
    */
   PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE = 'PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE',
   /**
+   * Add a field to override the election seal for a precinct split.
+   */
+  PRECINCT_SPLIT_ELECTION_SEAL_OVERRIDE = 'PRECINCT_SPLIT_ELECTION_SEAL_OVERRIDE',
+  /**
    * Add a field to upload a clerk signature image for a precinct split.
    */
   PRECINCT_SPLIT_CLERK_SIGNATURE_IMAGE = 'PRECINCT_SPLIT_CLERK_SIGNATURE_IMAGE',
@@ -110,12 +114,14 @@ const electionFeatureConfigs = {
   // enabled
   vx: {
     PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE: false,
+    PRECINCT_SPLIT_ELECTION_SEAL_OVERRIDE: false,
     PRECINCT_SPLIT_CLERK_SIGNATURE_IMAGE: false,
     PRECINCT_SPLIT_CLERK_SIGNATURE_CAPTION: false,
   },
 
   nh: {
     PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE: true,
+    PRECINCT_SPLIT_ELECTION_SEAL_OVERRIDE: true,
     PRECINCT_SPLIT_CLERK_SIGNATURE_IMAGE: true,
     PRECINCT_SPLIT_CLERK_SIGNATURE_CAPTION: true,
   },

--- a/apps/design/frontend/src/geography_screen.test.tsx
+++ b/apps/design/frontend/src/geography_screen.test.tsx
@@ -386,6 +386,7 @@ describe('Precincts tab', () => {
           name: 'Split 2',
           districtIds: [election.districts[1].id],
           electionTitleOverride: 'Mock Election Override Name',
+          electionSealOverride: dummyImage,
           clerkSignatureImage: dummyImage,
           clerkSignatureCaption: 'Town Clerk',
         },
@@ -487,6 +488,23 @@ describe('Precincts tab', () => {
     userEvent.type(
       split3ElectionTitleOverrideInput,
       assertDefined(changedPrecinct.splits[1].electionTitleOverride)
+    );
+    const split3ElectionSealOverrideInput = within(split3Card).getByLabelText(
+      'Election Seal Override'
+    ).parentElement!;
+    userEvent.upload(
+      split3ElectionSealOverrideInput,
+      new File([dummyImage], 'seal.svg', {
+        type: 'image/svg+xml',
+      })
+    );
+    await waitFor(() =>
+      expect(within(split3Card).getByRole('img')).toHaveAttribute(
+        'src',
+        `data:image/svg+xml;base64,${Buffer.from(dummyImage).toString(
+          'base64'
+        )}`
+      )
     );
 
     const split3ClerkSignatureCaption =

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -54,6 +54,7 @@ import {
 import { generateId, hasSplits, replaceAtIndex } from './utils';
 import { ImageInput } from './image_input';
 import { useElectionFeatures, useUserFeatures } from './features_context';
+import { SealImageInput } from './seal_image_input';
 
 function DistrictsTab(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
@@ -699,6 +700,20 @@ function PrecinctForm({
                             setSplit(index, {
                               ...split,
                               electionTitleOverride: e.target.value,
+                            })
+                          }
+                        />
+                      </InputGroup>
+                    )}
+
+                    {electionFeatures.PRECINCT_SPLIT_ELECTION_SEAL_OVERRIDE && (
+                      <InputGroup label="Election Seal Override">
+                        <SealImageInput
+                          value={split.electionSealOverride}
+                          onChange={(value) =>
+                            setSplit(index, {
+                              ...split,
+                              electionSealOverride: value,
                             })
                           }
                         />

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import {
   Button,
+  Callout,
   Table,
   TH,
   TD,
@@ -625,6 +626,12 @@ function PrecinctForm({
     );
   }
 
+  const noDistrictsCallout = (
+    <Callout icon="Warning" color="warning">
+      No districts yet.
+    </Callout>
+  );
+
   return (
     <Form
       onSubmit={(e) => {
@@ -676,7 +683,7 @@ function PrecinctForm({
                     </InputGroup>
                     <CheckboxGroup
                       label="Districts"
-                      noOptionsMessage="No districts created."
+                      noOptionsMessage={noDistrictsCallout}
                       options={districts.map((district) => ({
                         value: district.id,
                         label: district.name,
@@ -779,7 +786,7 @@ function PrecinctForm({
                 <CheckboxGroup
                   label="Districts"
                   hideLabel
-                  noOptionsMessage="No districts created."
+                  noOptionsMessage={noDistrictsCallout}
                   options={districts.map((district) => ({
                     value: district.id,
                     label: district.name,

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -710,7 +710,7 @@ function PrecinctForm({
                         <FieldName>Signature Image</FieldName>
                         <ClerkSignatureImageInput
                           value={split.clerkSignatureImage}
-                          onChange={(value = '') =>
+                          onChange={(value) =>
                             setSplit(index, {
                               ...split,
                               clerkSignatureImage: value,

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -675,6 +675,7 @@ function PrecinctForm({
                     </InputGroup>
                     <CheckboxGroup
                       label="Districts"
+                      noOptionsMessage="No districts created."
                       options={districts.map((district) => ({
                         value: district.id,
                         label: district.name,
@@ -763,6 +764,7 @@ function PrecinctForm({
                 <CheckboxGroup
                   label="Districts"
                   hideLabel
+                  noOptionsMessage="No districts created."
                   options={districts.map((district) => ({
                     value: district.id,
                     label: district.name,

--- a/apps/design/frontend/src/image_input.tsx
+++ b/apps/design/frontend/src/image_input.tsx
@@ -202,6 +202,18 @@ export function ImageInputButton({
   );
 }
 
+export interface ImageInputProps {
+  value?: string;
+  onChange: (value?: string) => void;
+  buttonLabel: string;
+  removeButtonLabel: string;
+  disabled?: boolean;
+  className?: string;
+  required?: boolean;
+  minWidthPx?: number;
+  minHeightPx?: number;
+}
+
 export function ImageInput({
   value,
   onChange,
@@ -212,17 +224,7 @@ export function ImageInput({
   required,
   minWidthPx,
   minHeightPx,
-}: {
-  value?: string;
-  onChange: (value?: string) => void;
-  buttonLabel: string;
-  removeButtonLabel: string;
-  disabled?: boolean;
-  className?: string;
-  required?: boolean;
-  minWidthPx?: number;
-  minHeightPx?: number;
-}): JSX.Element {
+}: ImageInputProps): JSX.Element {
   const [error, setError] = useState<Error>();
 
   // Clear error if the parent component has stopped interacting with this one

--- a/apps/design/frontend/src/image_input.tsx
+++ b/apps/design/frontend/src/image_input.tsx
@@ -243,6 +243,15 @@ export function ImageInput({
     onChange(newValue);
   }
 
+  function onRemoveButtonClick() {
+    // Prevent the button underlying <input> from also being clicked, which
+    // would trigger a file selection dialog immediately after the remove button
+    // is clicked.
+    setTimeout(() => {
+      onChange(undefined);
+    }, 0);
+  }
+
   return (
     <div className={className}>
       {value && (
@@ -265,7 +274,7 @@ export function ImageInput({
       )}
       {value && !required ? (
         <Button
-          onPress={() => onChange(undefined)}
+          onPress={onRemoveButtonClick}
           disabled={disabled}
           variant="danger"
           fill="outlined"

--- a/apps/design/frontend/src/seal_image_input.test.tsx
+++ b/apps/design/frontend/src/seal_image_input.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '../test/react_testing_library';
+import { SealImageInput } from './seal_image_input';
+
+test('uses "Upload Seal Image" button label', () => {
+  render(<SealImageInput onChange={jest.fn()} />);
+  expect(screen.getByText('Upload Seal Image')).toBeInTheDocument();
+});
+
+test('uses "Remove Seal Image" remove button label', () => {
+  render(<SealImageInput onChange={jest.fn()} value="<svg />" />);
+  expect(screen.getByText('Remove Seal Image')).toBeInTheDocument();
+});

--- a/apps/design/frontend/src/seal_image_input.tsx
+++ b/apps/design/frontend/src/seal_image_input.tsx
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+import { ImageInput, ImageInputProps } from './image_input';
+
+const StyledImageInput = styled(ImageInput)`
+  img {
+    width: 10rem;
+  }
+`;
+
+type PropsWithDefaults =
+  | 'minWidthPx'
+  | 'minHeightPx'
+  | 'buttonLabel'
+  | 'removeButtonLabel';
+
+export type SealImageInputProps = Omit<ImageInputProps, PropsWithDefaults> & {
+  [K in PropsWithDefaults]?: ImageInputProps[K];
+};
+
+export function SealImageInput({
+  minWidthPx = 200,
+  minHeightPx = 200,
+  buttonLabel = 'Upload Seal Image',
+  removeButtonLabel = 'Remove Seal Image',
+  ...rest
+}: SealImageInputProps): JSX.Element {
+  return (
+    <StyledImageInput
+      {...rest}
+      minWidthPx={minWidthPx}
+      minHeightPx={minHeightPx}
+      buttonLabel={buttonLabel}
+      removeButtonLabel={removeButtonLabel}
+    />
+  );
+}

--- a/apps/design/frontend/src/seal_image_input.tsx
+++ b/apps/design/frontend/src/seal_image_input.tsx
@@ -7,30 +7,22 @@ const StyledImageInput = styled(ImageInput)`
   }
 `;
 
-type PropsWithDefaults =
+type StaticPropsNames =
   | 'minWidthPx'
   | 'minHeightPx'
   | 'buttonLabel'
   | 'removeButtonLabel';
 
-export type SealImageInputProps = Omit<ImageInputProps, PropsWithDefaults> & {
-  [K in PropsWithDefaults]?: ImageInputProps[K];
-};
+export type SealImageInputProps = Omit<ImageInputProps, StaticPropsNames>;
 
-export function SealImageInput({
-  minWidthPx = 200,
-  minHeightPx = 200,
-  buttonLabel = 'Upload Seal Image',
-  removeButtonLabel = 'Remove Seal Image',
-  ...rest
-}: SealImageInputProps): JSX.Element {
+export function SealImageInput(props: SealImageInputProps): JSX.Element {
   return (
     <StyledImageInput
-      {...rest}
-      minWidthPx={minWidthPx}
-      minHeightPx={minHeightPx}
-      buttonLabel={buttonLabel}
-      removeButtonLabel={removeButtonLabel}
+      {...props}
+      minWidthPx={200}
+      minHeightPx={200}
+      buttonLabel="Upload Seal Image"
+      removeButtonLabel="Remove Seal Image"
     />
   );
 }

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -57,6 +57,7 @@ import { Watermark } from './watermark';
 
 export interface NhPrecinctSplitOptions {
   electionTitleOverride?: string;
+  electionSealOverride?: string;
   clerkSignatureImage?: string;
   clerkSignatureCaption?: string;
 }
@@ -68,6 +69,7 @@ function Header({
   ballotMode,
 
   electionTitleOverride,
+  electionSealOverride,
   clerkSignatureImage,
   clerkSignatureCaption,
 }: {
@@ -113,7 +115,7 @@ function Header({
           height: '5rem',
           aspectRatio: '1 / 1',
           backgroundImage: `url(data:image/svg+xml;base64,${Buffer.from(
-            election.seal
+            electionSealOverride ?? election.seal
           ).toString('base64')})`,
           backgroundSize: 'contain',
           backgroundRepeat: 'no-repeat',
@@ -172,6 +174,7 @@ function BallotPageFrame({
   totalPages,
   children,
   electionTitleOverride,
+  electionSealOverride,
   clerkSignatureImage,
   clerkSignatureCaption,
   watermark,
@@ -216,6 +219,7 @@ function BallotPageFrame({
                   ballotType={ballotType}
                   ballotMode={ballotMode}
                   electionTitleOverride={electionTitleOverride}
+                  electionSealOverride={electionSealOverride}
                   clerkSignatureImage={clerkSignatureImage}
                   clerkSignatureCaption={clerkSignatureCaption}
                 />

--- a/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
@@ -106,6 +106,7 @@ function Header({
   pageHeight,
 
   electionTitleOverride,
+  electionSealOverride,
   clerkSignatureImage,
   clerkSignatureCaption,
 }: {
@@ -153,7 +154,7 @@ function Header({
           height: '5rem',
           aspectRatio: '1 / 1',
           backgroundImage: `url(data:image/svg+xml;base64,${Buffer.from(
-            election.seal
+            electionSealOverride ?? election.seal
           ).toString('base64')})`,
           backgroundSize: 'contain',
           backgroundRepeat: 'no-repeat',
@@ -212,6 +213,7 @@ function BallotPageFrame({
   totalPages,
   children,
   electionTitleOverride,
+  electionSealOverride,
   clerkSignatureImage,
   clerkSignatureCaption,
   watermark,
@@ -258,6 +260,7 @@ function BallotPageFrame({
                   ballotMode={ballotMode}
                   pageHeight={pageDimensions.height}
                   electionTitleOverride={electionTitleOverride}
+                  electionSealOverride={electionSealOverride}
                   clerkSignatureImage={clerkSignatureImage}
                   clerkSignatureCaption={clerkSignatureCaption}
                 />

--- a/libs/ui/src/checkbox_group.test.tsx
+++ b/libs/ui/src/checkbox_group.test.tsx
@@ -2,6 +2,20 @@ import userEvent from '@testing-library/user-event';
 import { CheckboxGroup } from './checkbox_group';
 import { render, screen, within } from '../test/react_testing_library';
 
+test('renders a message when there are no options', () => {
+  render(
+    <CheckboxGroup
+      label="Pick cards:"
+      noOptionsMessage="No options available."
+      onChange={() => {}}
+      options={[]}
+      value={[]}
+    />
+  );
+
+  screen.getByText('No options available.');
+});
+
 test('renders and selects/unselects options', () => {
   const onChange = jest.fn();
 

--- a/libs/ui/src/checkbox_group.tsx
+++ b/libs/ui/src/checkbox_group.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import React from 'react';
 import { CheckboxButton } from './checkbox_button';
 
 interface Option {
@@ -18,6 +19,7 @@ export interface CheckboxGroupProps {
   onChange: (value: string[]) => void;
   disabled?: boolean;
   direction?: 'row' | 'column';
+  noOptionsMessage?: React.ReactNode;
 }
 
 const LabelContainer = styled.legend`
@@ -44,29 +46,32 @@ export function CheckboxGroup({
   onChange,
   disabled = false,
   direction = 'column',
+  noOptionsMessage,
 }: CheckboxGroupProps): JSX.Element {
   return (
     <fieldset aria-label={label}>
       {!hideLabel && <LabelContainer aria-hidden>{label}</LabelContainer>}
       <OptionsContainer direction={direction}>
-        {options.map((option) => {
-          const isSelected = value.includes(option.value);
-          return (
-            <CheckboxButton
-              key={option.label}
-              label={option.label}
-              disabled={disabled}
-              isChecked={isSelected}
-              onChange={() => {
-                if (isSelected) {
-                  onChange(value.filter((v) => v !== option.value));
-                } else {
-                  onChange([...value, option.value]);
-                }
-              }}
-            />
-          );
-        })}
+        {options.length === 0
+          ? noOptionsMessage
+          : options.map((option) => {
+              const isSelected = value.includes(option.value);
+              return (
+                <CheckboxButton
+                  key={option.label}
+                  label={option.label}
+                  disabled={disabled}
+                  isChecked={isSelected}
+                  onChange={() => {
+                    if (isSelected) {
+                      onChange(value.filter((v) => v !== option.value));
+                    } else {
+                      onChange([...value, option.value]);
+                    }
+                  }}
+                />
+              );
+            })}
       </OptionsContainer>
     </fieldset>
   );


### PR DESCRIPTION
## Overview

Allows setting an election seal image per precinct split that overrides the one for the election as a whole. One must still be provided at the election level, and is optional at the precinct split level.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/588765fe-e85a-4e69-afad-098cc329c160


## Testing Plan
Manually tested only as automated tests are still mostly disabled.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
