### PR TITLE
Misc VxDesign tweaks in prep for QA

### DIFF
--- a/apps/design/frontend/src/export_screen.test.tsx
+++ b/apps/design/frontend/src/export_screen.test.tsx
@@ -110,7 +110,7 @@ test('export election package and ballots', async () => {
       taskName: 'generate_election_package',
     },
   });
-  userEvent.click(screen.getButton('Export Election Package & Ballots'));
+  userEvent.click(screen.getButton('Export Election Package and Ballots'));
 
   await screen.findByText('Exporting Election Package and Ballots...');
   expect(
@@ -130,7 +130,7 @@ test('export election package and ballots', async () => {
     url: 'http://localhost:1234/election-package-1234567890.zip',
   });
 
-  await screen.findByText('Export Election Package & Ballots', undefined, {
+  await screen.findByText('Export Election Package and Ballots', undefined, {
     timeout: 2000,
   });
   expect(
@@ -161,7 +161,7 @@ test('export election package error handling', async () => {
       taskName: 'generate_election_package',
     },
   });
-  userEvent.click(screen.getButton('Export Election Package & Ballots'));
+  userEvent.click(screen.getButton('Export Election Package and Ballots'));
 
   await screen.findByText('Exporting Election Package and Ballots...');
   expect(
@@ -180,7 +180,7 @@ test('export election package error handling', async () => {
     },
   });
 
-  await screen.findByText('Export Election Package & Ballots', undefined, {
+  await screen.findByText('Export Election Package and Ballots', undefined, {
     timeout: 2000,
   });
   expect(
@@ -248,7 +248,7 @@ test('using CDF', async () => {
       taskName: 'generate_election_package',
     },
   });
-  userEvent.click(screen.getButton('Export Election Package & Ballots'));
+  userEvent.click(screen.getButton('Export Election Package and Ballots'));
 
   userEvent.click(
     screen.getByRole('checkbox', {
@@ -300,12 +300,17 @@ test('view ballot proofing status and unfinalize ballots', async () => {
 
   screen.getByText(`Ballots finalized at: ${finalizedAt}`);
 
+  const select = screen.getByLabelText('Ballot Template');
+  expect(select).toBeDisabled();
+
   apiMock.setBallotsFinalizedAt
     .expectCallWith({ electionId, finalizedAt: null })
     .resolves();
   apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
   userEvent.click(screen.getButton('Unfinalize Ballots'));
   await screen.findByText('Ballots not finalized');
+
+  expect(select).not.toBeDisabled();
 });
 
 test('view ballot order status and unsubmit order', async () => {

--- a/apps/design/frontend/src/export_screen.tsx
+++ b/apps/design/frontend/src/export_screen.tsx
@@ -137,6 +137,7 @@ export function ExportScreen(): JSX.Element | null {
                   ballotTemplateId: value as BallotTemplateId,
                 });
               }}
+              disabled={Boolean(ballotsFinalizedAt)}
             />
           </InputGroup>
 
@@ -217,7 +218,7 @@ export function ExportScreen(): JSX.Element | null {
             </LoadingButton>
           ) : (
             <Button onPress={onPressExportElectionPackage} variant="primary">
-              Export Election Package & Ballots
+              Export Election Package and Ballots
             </Button>
           )}
         </P>

--- a/apps/design/frontend/src/tabulation_screen.test.tsx
+++ b/apps/design/frontend/src/tabulation_screen.test.tsx
@@ -228,14 +228,3 @@ test('setting write-in text area threshold', async () => {
     updatedSystemSettings.markThresholds.writeInTextArea
   );
 });
-
-test('editing tabulation options is disabled when ballots are finalized', async () => {
-  apiMock.getElection.expectCallWith({ electionId }).resolves(electionRecord);
-  apiMock.getBallotsFinalizedAt
-    .expectCallWith({ electionId })
-    .resolves(new Date());
-  renderScreen();
-  await screen.findByRole('heading', { name: 'Tabulation' });
-
-  expect(screen.getByRole('button', { name: 'Edit' })).toBeDisabled();
-});

--- a/apps/design/frontend/src/tabulation_screen.tsx
+++ b/apps/design/frontend/src/tabulation_screen.tsx
@@ -22,11 +22,7 @@ import { z } from 'zod';
 import { Form, Column, Row, FormActionsRow, InputGroup } from './layout';
 import { ElectionNavScreen } from './nav_screen';
 import { ElectionIdParams } from './routes';
-import {
-  updateSystemSettings,
-  getElection,
-  getBallotsFinalizedAt,
-} from './api';
+import { updateSystemSettings, getElection } from './api';
 
 type TabulationSettings = Pick<
   SystemSettings,
@@ -43,11 +39,9 @@ type DeepPartial<T> = {
 export function TabulationForm({
   electionId,
   savedSystemSettings,
-  ballotsFinalizedAt,
 }: {
   electionId: ElectionId;
   savedSystemSettings: SystemSettings;
-  ballotsFinalizedAt: Date | null;
 }): JSX.Element {
   const [isEditing, setIsEditing] = useState(false);
   const [tabulationSettings, setTabulationSettings] =
@@ -254,12 +248,7 @@ export function TabulationForm({
         </FormActionsRow>
       ) : (
         <FormActionsRow>
-          <Button
-            type="reset"
-            variant="primary"
-            icon="Edit"
-            disabled={!!ballotsFinalizedAt}
-          >
+          <Button type="reset" variant="primary" icon="Edit">
             Edit
           </Button>
         </FormActionsRow>
@@ -271,14 +260,12 @@ export function TabulationForm({
 export function TabulationScreen(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
   const getElectionQuery = getElection.useQuery(electionId);
-  const getBallotsFinalizedAtQuery = getBallotsFinalizedAt.useQuery(electionId);
 
-  if (!getElectionQuery.isSuccess || !getBallotsFinalizedAtQuery.isSuccess) {
+  if (!getElectionQuery.isSuccess) {
     return null;
   }
 
   const { systemSettings } = getElectionQuery.data;
-  const ballotsFinalizedAt = getBallotsFinalizedAtQuery.data;
 
   return (
     <ElectionNavScreen electionId={electionId}>
@@ -289,7 +276,6 @@ export function TabulationScreen(): JSX.Element | null {
         <TabulationForm
           electionId={electionId}
           savedSystemSettings={systemSettings}
-          ballotsFinalizedAt={ballotsFinalizedAt}
         />
       </MainContent>
     </ElectionNavScreen>


### PR DESCRIPTION
## Overview

This PR makes two simple tweaks.

**After a ballot is finalized, we now:**
1. Still allow editing of tabulation settings, which don't actually affect the ballot
2. No longer allow editing of the ballot template - if this needs to be edited, the ballot needs to be unfinalized first

Just making these changes in prep for the next phase of ballot production.

https://github.com/user-attachments/assets/7afd2b5d-148d-41f9-a771-ef7b545416a8

## Testing Plan

- [x] Tested manually
- [x] Updated automated tests as best as I could, though they aren't running right now