### PR TITLE
[VxDesign] Add compact templates for NH ballots

### DIFF
--- a/apps/design/backend/src/ballots.test.ts
+++ b/apps/design/backend/src/ballots.test.ts
@@ -1,0 +1,58 @@
+import { electionGridLayoutNewHampshireHudsonFixtures } from '@votingworks/fixtures';
+import { Election, LanguageCode } from '@votingworks/types';
+import { BallotTemplateId } from '@votingworks/hmpb';
+import { expect, test } from 'vitest';
+import { createBallotPropsForTemplate } from './ballots';
+import { UsState } from './types';
+
+const election: Election = {
+  ...electionGridLayoutNewHampshireHudsonFixtures.readElection(),
+  state: UsState.NEW_HAMPSHIRE,
+};
+const precincts = election.precincts.map((p) => ({
+  districtIds: [election.districts[0].id],
+  id: p.id,
+  name: p.name,
+}));
+const ballotStyles = election.ballotStyles.map((b) => ({
+  districtIds: b.districts,
+  group_id: b.groupId,
+  id: b.id,
+  languages: [LanguageCode.ENGLISH],
+  precinctsOrSplits: [{ precinctId: election.precincts[0].id }],
+}));
+
+test('compact templates', () => {
+  const normalTemplates: BallotTemplateId[] = [
+    'NhBallot',
+    'NhBallotV3',
+    'VxDefaultBallot',
+  ];
+  for (const templateId of normalTemplates) {
+    const propLists = createBallotPropsForTemplate(
+      templateId,
+      election,
+      precincts,
+      ballotStyles
+    );
+    for (const props of propLists) {
+      expect(props.compact).toBeUndefined();
+    }
+  }
+
+  const compactTemplates: BallotTemplateId[] = [
+    'NhBallotCompact',
+    'NhBallotV3Compact',
+  ];
+  for (const templateId of compactTemplates) {
+    const propLists = createBallotPropsForTemplate(
+      templateId,
+      election,
+      precincts,
+      ballotStyles
+    );
+    for (const props of propLists) {
+      expect(props.compact).toEqual(true);
+    }
+  }
+});

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -46,28 +46,37 @@ export function createBallotPropsForTemplate(
   precincts: Precinct[],
   ballotStyles: BallotStyle[]
 ): BaseBallotProps[] {
+  function buildNhBallotProps(props: BaseBallotProps): NhBallotProps {
+    const precinct = find(precincts, (p) => p.id === props.precinctId);
+    if (!hasSplits(precinct)) {
+      return props;
+    }
+    const ballotStyle = find(
+      ballotStyles,
+      (bs) => bs.id === props.ballotStyleId
+    );
+    const split = getPrecinctSplitForBallotStyle(precinct, ballotStyle);
+    return {
+      ...props,
+      electionTitleOverride: split.electionTitleOverride,
+      electionSealOverride: split.electionSealOverride,
+      clerkSignatureImage: split.clerkSignatureImage,
+      clerkSignatureCaption: split.clerkSignatureCaption,
+    };
+  }
+
   const baseBallotProps = allBaseBallotProps(election);
   switch (templateId) {
     case 'NhBallot':
     case 'NhBallotV3': {
-      return baseBallotProps.map((props): NhBallotProps => {
-        const precinct = find(precincts, (p) => p.id === props.precinctId);
-        if (!hasSplits(precinct)) {
-          return props;
-        }
-        const ballotStyle = find(
-          ballotStyles,
-          (bs) => bs.id === props.ballotStyleId
-        );
-        const split = getPrecinctSplitForBallotStyle(precinct, ballotStyle);
-        return {
-          ...props,
-          electionTitleOverride: split.electionTitleOverride,
-          electionSealOverride: split.electionSealOverride,
-          clerkSignatureImage: split.clerkSignatureImage,
-          clerkSignatureCaption: split.clerkSignatureCaption,
-        };
-      });
+      return baseBallotProps.map(buildNhBallotProps);
+    }
+
+    case 'NhBallotCompact':
+    case 'NhBallotV3Compact': {
+      return baseBallotProps
+        .map(buildNhBallotProps)
+        .map((p) => ({ ...p, compact: true }));
     }
 
     case 'VxDefaultBallot':

--- a/apps/design/backend/tsconfig.build.json
+++ b/apps/design/backend/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src", "src/**/*.json"],
+  "include": ["src", "src/**/*.json", "src/ballots.test.ts"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
     "noEmit": false,

--- a/apps/design/backend/tsconfig.build.json
+++ b/apps/design/backend/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src", "src/**/*.json", "src/ballots.test.ts"],
+  "include": ["src", "src/**/*.json"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
     "noEmit": false,

--- a/apps/design/frontend/src/export_screen.tsx
+++ b/apps/design/frontend/src/export_screen.tsx
@@ -39,7 +39,9 @@ import { Column, FieldName, InputGroup } from './layout';
 const ballotTemplateOptions = {
   VxDefaultBallot: 'VotingWorks Default Ballot',
   NhBallot: 'New Hampshire Ballot - V4',
+  NhBallotCompact: '[Compact] New Hampshire Ballot - V4',
   NhBallotV3: 'New Hampshire Ballot - V3',
+  NhBallotV3Compact: '[Compact] New Hampshire Ballot - V3',
 } satisfies Record<BallotTemplateId, string>;
 
 export function ExportScreen(): JSX.Element | null {

--- a/libs/hmpb/src/ballot_components.tsx
+++ b/libs/hmpb/src/ballot_components.tsx
@@ -601,7 +601,11 @@ export function Footer({
   );
 }
 
-export const ContestHeader = styled.div`
+interface ContestHeaderProps {
+  compact?: boolean;
+}
+
+export const ContestHeader = styled.div<ContestHeaderProps>`
   background: ${Colors.LIGHT_GRAY};
-  padding: 0.5rem 0.5rem;
+  padding: ${(p) => (p.compact ? '0.25rem 0.5rem' : '0.5rem')};
 `;

--- a/libs/hmpb/src/ballot_templates/index.ts
+++ b/libs/hmpb/src/ballot_templates/index.ts
@@ -13,7 +13,9 @@ export type {
 export const ballotTemplates = {
   VxDefaultBallot: vxDefaultBallotTemplate,
   NhBallot: nhBallotTemplate,
+  NhBallotCompact: nhBallotTemplate,
   NhBallotV3: nhBallotTemplateV3,
+  NhBallotV3Compact: nhBallotTemplateV3,
 } as const;
 
 /**

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -167,6 +167,7 @@ function Header({
 function BallotPageFrame({
   election,
   ballotStyleId,
+  compact,
   precinctId,
   ballotType,
   ballotMode,
@@ -207,7 +208,7 @@ function BallotPageFrame({
               flex: 1,
               display: 'flex',
               flexDirection: 'column',
-              gap: '0.75rem',
+              gap: compact ? '0.5rem' : '0.75rem',
               padding: '0.125in',
             }}
           >
@@ -407,12 +408,20 @@ function CandidateContest({
   );
 }
 
-function BallotMeasureContest({ contest }: { contest: YesNoContest }) {
+function BallotMeasureContest({
+  contest,
+  compact,
+}: {
+  contest: YesNoContest;
+  compact?: boolean;
+}) {
+  const ContestTitle = compact ? 'h3' : 'h2';
+
   return (
     <Box style={{ padding: 0 }}>
       <ContestHeader>
         <DualLanguageText delimiter="/">
-          <h2>{electionStrings.contestTitle(contest)}</h2>
+          <ContestTitle>{electionStrings.contestTitle(contest)}</ContestTitle>
         </DualLanguageText>
       </ContestHeader>
       <div
@@ -425,10 +434,10 @@ function BallotMeasureContest({ contest }: { contest: YesNoContest }) {
       >
         <div
           style={{
-            padding: '0.5rem 0.5rem',
+            padding: compact ? '0.1rem 0.5rem 0.125rem' : '0.5rem 0.5rem',
             display: 'flex',
             flexDirection: 'column',
-            gap: '0.5rem',
+            gap: compact ? '0.25rem' : '0.5rem',
           }}
         >
           <DualLanguageText>
@@ -487,9 +496,11 @@ function BallotMeasureContest({ contest }: { contest: YesNoContest }) {
 }
 
 function Contest({
+  compact,
   contest,
   election,
 }: {
+  compact?: boolean;
   contest: AnyContest;
   election: Election;
 }) {
@@ -497,7 +508,7 @@ function Contest({
     case 'candidate':
       return <CandidateContest election={election} contest={contest} />;
     case 'yesno':
-      return <BallotMeasureContest contest={contest} />;
+      return <BallotMeasureContest compact={compact} contest={contest} />;
     default:
       return throwIllegalValue(contest);
   }
@@ -514,7 +525,7 @@ async function BallotPageContent(
     });
   }
 
-  const { election, ballotStyleId, dimensions, ...restProps } = props;
+  const { compact, election, ballotStyleId, dimensions, ...restProps } = props;
   const ballotStyle = assertDefined(
     getBallotStyle({ election, ballotStyleId })
   );
@@ -535,12 +546,17 @@ async function BallotPageContent(
 
   // TODO is there some way we can use rem here instead of having to know the
   // font size and map to px?
-  const horizontalGapPx = 0.75 * 16; // Assuming 16px per 1rem
+  const horizontalGapPx = (compact ? 0.5 : 0.75) * 16; // Assuming 16px per 1rem
   const verticalGapPx = horizontalGapPx;
   while (contestSections.length > 0 && heightUsed < dimensions.height) {
     const section = assertDefined(contestSectionsLeftToLayout.shift());
     const contestElements = section.map((contest) => (
-      <Contest key={contest.id} contest={contest} election={election} />
+      <Contest
+        key={contest.id}
+        compact={compact}
+        contest={contest}
+        election={election}
+      />
     ));
     const numColumns = section[0].type === 'candidate' ? 3 : 1;
     const columnWidthPx =
@@ -638,6 +654,7 @@ async function BallotPageContent(
     contestSectionsLeftToLayout.length > 0
       ? {
           ...restProps,
+          compact,
           ballotStyleId,
           election: {
             ...election,

--- a/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
@@ -76,8 +76,10 @@ async function snapToGridRow(
 ) {
   const measurements = await scratchpad.measureElements(
     <div>
-      {renderElementFns.map((renderElement) => (
-        <div className="elementWrapper">{renderElement({})}</div>
+      {renderElementFns.map((renderElement, i) => (
+        <div className="elementWrapper" key={`elem-${i}`}>
+          {renderElement({})}
+        </div>
       ))}
     </div>,
     '.elementWrapper'
@@ -318,6 +320,7 @@ function WriteInLabel() {
 }
 
 async function CandidateContest({
+  compact,
   scratchpad,
   key,
   election,
@@ -325,6 +328,7 @@ async function CandidateContest({
   gridRowHeightInches,
   width,
 }: {
+  compact?: boolean;
   scratchpad: RenderScratchpad;
   key: React.Key;
   election: Election;
@@ -402,7 +406,9 @@ async function CandidateContest({
       <div
         key={candidate.id}
         style={{
-          padding: '0.375rem 0.93rem 0.125rem 0.5rem',
+          padding: compact
+            ? '0.375rem 0.93rem 0.125rem 0.5rem'
+            : '0.375rem 0.75rem 0.125rem 0.5rem',
           borderTop: `1px solid ${Colors.DARK_GRAY}`,
           ...style,
           width,
@@ -452,7 +458,9 @@ async function CandidateContest({
         style={{
           display: 'flex',
           gap: '0.5rem',
-          padding: '0.375rem 0.93rem 0rem 0.5rem',
+          padding: compact
+            ? '0.375rem 0.93rem 0rem 0.5rem'
+            : '0.375rem 0.75rem 0rem 0.5rem',
           borderTop: `1px solid ${Colors.DARK_GRAY}`,
           ...style,
           width,
@@ -562,7 +570,9 @@ async function BallotMeasureContest({
           <div
             key={option.id}
             style={{
-              padding: '0.375rem 0.93rem 0.125rem 0.5rem',
+              padding: compact
+                ? '0.375rem 0.93rem 0.125rem 0.5rem'
+                : '0.375rem 0.75rem 0.125rem 0.5rem',
               borderTop: `1px solid ${Colors.LIGHT_GRAY}`,
               ...style,
               width,
@@ -636,6 +646,7 @@ async function Contest({
   switch (contest.type) {
     case 'candidate':
       return CandidateContest({
+        compact,
         scratchpad,
         key,
         election,
@@ -769,7 +780,6 @@ async function BallotPageContent(
           <div
             key={`column-${i}`}
             style={{
-              // flex: 1,
               display: 'flex',
               flexDirection: 'column',
               gap: `${verticalGapPx}px`,

--- a/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
@@ -145,7 +145,14 @@ function Header({
   return (
     <div
       style={{
-        paddingTop: pageHeight === 11 ? '0.04in' : 0,
+        ...(compact
+          ? {
+              margin: pageHeight === 11 ? '-0.053in 0' : '0.065in 0',
+            }
+          : {
+              paddingTop: pageHeight === 11 ? '0.04in' : 0,
+            }),
+
         display: 'flex',
         gap: '0.75rem',
         alignItems: 'center',
@@ -251,7 +258,7 @@ function BallotPageFrame({
               flexDirection: 'column',
               gap: compact ? '0.5rem' : '0.75rem',
               padding: '0.125in',
-              paddingTop: '0.10in',
+              paddingTop: compact ? '0.115in' : '0.10in',
             }}
           >
             {pageNumber === 1 && (
@@ -395,7 +402,7 @@ async function CandidateContest({
       <div
         key={candidate.id}
         style={{
-          padding: '0.375rem 0.75rem 0.125rem 0.5rem',
+          padding: '0.375rem 0.93rem 0.125rem 0.5rem',
           borderTop: `1px solid ${Colors.DARK_GRAY}`,
           ...style,
           width,
@@ -445,7 +452,7 @@ async function CandidateContest({
         style={{
           display: 'flex',
           gap: '0.5rem',
-          padding: '0.375rem 0.75rem 0rem 0.5rem',
+          padding: '0.375rem 0.93rem 0rem 0.5rem',
           borderTop: `1px solid ${Colors.DARK_GRAY}`,
           ...style,
           width,
@@ -555,7 +562,7 @@ async function BallotMeasureContest({
           <div
             key={option.id}
             style={{
-              padding: '0.375rem 0.75rem 0.125rem 0.5rem',
+              padding: '0.375rem 0.93rem 0.125rem 0.5rem',
               borderTop: `1px solid ${Colors.LIGHT_GRAY}`,
               ...style,
               width,

--- a/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
@@ -149,7 +149,7 @@ function Header({
       style={{
         ...(compact
           ? {
-              margin: pageHeight === 11 ? '-0.053in 0' : '0.065in 0',
+              margin: pageHeight === 11 ? '-0.048in 0' : '0.07in 0',
             }
           : {
               paddingTop: pageHeight === 11 ? '0.04in' : 0,
@@ -260,7 +260,7 @@ function BallotPageFrame({
               flexDirection: 'column',
               gap: compact ? '0.5rem' : '0.75rem',
               padding: '0.125in',
-              paddingTop: compact ? '0.115in' : '0.10in',
+              paddingTop: compact ? '0.105in' : '0.10in',
             }}
           >
             {pageNumber === 1 && (
@@ -306,7 +306,10 @@ function BallotPageFrame({
 
 const ContestHeader = styled.div`
   background: ${Colors.LIGHT_GRAY};
-  padding: 0.25rem 0.5rem 0.125rem 0.5rem;
+  padding: 0.3rem 0.5rem 0.125rem 0.5rem;
+  /* Account for the 3px border on the top of the contest box so that contest
+   * options start exactly at the appropriate grid row. */
+  margin-top: -3px;
 `;
 
 function WriteInLabel() {
@@ -501,8 +504,6 @@ async function CandidateContest({
     <Box
       key={key}
       style={{
-        display: 'flex',
-        flexDirection: 'column',
         padding: 0,
         height: contestHeight,
         width,
@@ -611,8 +612,6 @@ async function BallotMeasureContest({
     <Box
       key={key}
       style={{
-        display: 'flex',
-        flexDirection: 'column',
         padding: 0,
         height: contestHeight,
         width,

--- a/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
@@ -99,6 +99,7 @@ async function snapToGridRow(
 }
 
 function Header({
+  compact,
   election,
   ballotStyleId,
   ballotType,
@@ -110,6 +111,7 @@ function Header({
   clerkSignatureImage,
   clerkSignatureCaption,
 }: {
+  compact?: boolean;
   election: Election;
   ballotStyleId: BallotStyleId;
   ballotType: BallotType;
@@ -217,6 +219,7 @@ function BallotPageFrame({
   clerkSignatureImage,
   clerkSignatureCaption,
   watermark,
+  compact,
 }: BaseBallotProps &
   NhPrecinctSplitOptions & {
     pageNumber: number;
@@ -246,7 +249,7 @@ function BallotPageFrame({
               flex: 1,
               display: 'flex',
               flexDirection: 'column',
-              gap: '0.75rem',
+              gap: compact ? '0.5rem' : '0.75rem',
               padding: '0.125in',
               paddingTop: '0.10in',
             }}
@@ -254,6 +257,7 @@ function BallotPageFrame({
             {pageNumber === 1 && (
               <>
                 <Header
+                  compact={compact}
                   election={election}
                   ballotStyleId={ballotStyleId}
                   ballotType={ballotType}
@@ -497,18 +501,21 @@ async function CandidateContest({
 }
 
 async function BallotMeasureContest({
+  compact,
   scratchpad,
   key,
   contest,
   gridRowHeightInches,
   width,
 }: {
+  compact?: boolean;
   scratchpad: RenderScratchpad;
   key: React.Key;
   contest: YesNoContest;
   gridRowHeightInches: number;
   width: number;
 }) {
+  const ContestTitle = compact ? 'h3' : 'h2';
   const [contestHeader, contestDescription, ...options] = await snapToGridRow(
     scratchpad,
     gridRowHeightInches,
@@ -516,7 +523,7 @@ async function BallotMeasureContest({
       (style) => (
         <ContestHeader key="header" style={{ ...style, width }}>
           <DualLanguageText delimiter="/">
-            <h2>{electionStrings.contestTitle(contest)}</h2>
+            <ContestTitle>{electionStrings.contestTitle(contest)}</ContestTitle>
           </DualLanguageText>
         </ContestHeader>
       ),
@@ -603,6 +610,7 @@ async function BallotMeasureContest({
 }
 
 async function Contest({
+  compact,
   scratchpad,
   key,
   contest,
@@ -610,6 +618,7 @@ async function Contest({
   gridRowHeightInches,
   width,
 }: {
+  compact?: boolean;
   scratchpad: RenderScratchpad;
   key: React.Key;
   contest: AnyContest;
@@ -629,6 +638,7 @@ async function Contest({
       });
     case 'yesno':
       return BallotMeasureContest({
+        compact,
         scratchpad,
         key,
         contest,
@@ -651,7 +661,7 @@ async function BallotPageContent(
     });
   }
 
-  const { election, ballotStyleId, dimensions, ...restProps } = props;
+  const { compact, election, ballotStyleId, dimensions, ...restProps } = props;
   const ballotStyle = assertDefined(
     getBallotStyle({ election, ballotStyleId })
   );
@@ -707,6 +717,7 @@ async function BallotPageContent(
         const element = await Contest({
           scratchpad,
           key: contest.id,
+          compact,
           contest,
           election,
           gridRowHeightInches,
@@ -795,6 +806,7 @@ async function BallotPageContent(
     contestSectionsLeftToLayout.length > 0
       ? {
           ...restProps,
+          compact,
           ballotStyleId,
           election: {
             ...election,

--- a/libs/hmpb/src/base_styles.tsx
+++ b/libs/hmpb/src/base_styles.tsx
@@ -4,7 +4,14 @@ import {
   ROBOTO_ITALIC_FONT_DECLARATIONS,
 } from '@votingworks/ui';
 
-const baseStyles = `
+export interface BaseStylesProps {
+  compact?: boolean;
+}
+
+function baseStyles(params: BaseStylesProps) {
+  const { compact } = params;
+
+  return `
   *,
   *::before,
   *::after {
@@ -15,9 +22,15 @@ const baseStyles = `
     box-sizing: border-box;
     font-family: Vx Roboto;
     font-variant-ligatures: none;
-    /* CCD minimum font size: https://civicdesign.org/typography-makes-ballots-easy-to-read/ */
-    font-size: 12pt;
-    line-height: 1.2;
+    /*
+     * 12pt is the CCD minimum font size:
+     * https://civicdesign.org/typography-makes-ballots-easy-to-read/
+     *
+     * We drop this down to 10pt font for ballots with lots of contests to help
+     * reduce the total sheet count.
+     */
+    font-size: ${compact ? 10 : 12}pt;
+    line-height: ${compact ? 1.1 : 1.2};
   }
 
   body {
@@ -34,7 +47,7 @@ const baseStyles = `
     font-size: 1.2em;
   }
   h3 {
-    font-size: 1.1em;
+    font-size: ${compact ? 1 : 1.1}em;
   }
   h4 {
     font-size: 1em;
@@ -52,23 +65,25 @@ const baseStyles = `
     list-style: none;
   }
 `;
-
-export const baseStyleElements = (
-  <>
-    <style
-      type="text/css"
-      dangerouslySetInnerHTML={{
-        __html: [
-          ROBOTO_REGULAR_FONT_DECLARATIONS,
-          ROBOTO_ITALIC_FONT_DECLARATIONS,
-        ].join('\n'),
-      }}
-    />
-    <style
-      type="text/css"
-      dangerouslySetInnerHTML={{
-        __html: baseStyles,
-      }}
-    />
-  </>
-);
+}
+export function BaseStyles(props: BaseStylesProps): JSX.Element {
+  return (
+    <>
+      <style
+        type="text/css"
+        dangerouslySetInnerHTML={{
+          __html: [
+            ROBOTO_REGULAR_FONT_DECLARATIONS,
+            ROBOTO_ITALIC_FONT_DECLARATIONS,
+          ].join('\n'),
+        }}
+      />
+      <style
+        type="text/css"
+        dangerouslySetInnerHTML={{
+          __html: baseStyles(props),
+        }}
+      />
+    </>
+  );
+}

--- a/libs/hmpb/src/playwright_renderer.tsx
+++ b/libs/hmpb/src/playwright_renderer.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDomServer from 'react-dom/server';
 import { Browser, chromium } from 'playwright';
 import {
@@ -8,7 +7,7 @@ import {
   createDocument,
   createScratchpad,
 } from './renderer';
-import { baseStyleElements } from './base_styles';
+import { BaseStyles } from './base_styles';
 
 export interface PlaywrightRenderer extends Renderer {
   getBrowser(): Browser;
@@ -27,12 +26,14 @@ export async function createPlaywrightRenderer(): Promise<PlaywrightRenderer> {
   });
   const context = await browser.newContext();
   return {
-    async createScratchpad(): Promise<RenderScratchpad> {
+    async createScratchpad(props = {}): Promise<RenderScratchpad> {
       const page = await context.newPage();
       await page.setContent(
         `<!DOCTYPE html>${ReactDomServer.renderToStaticMarkup(
           <html>
-            <head>{baseStyleElements}</head>
+            <head>
+              <BaseStyles {...props} />
+            </head>
             <body />
           </html>
         )}`

--- a/libs/hmpb/src/preview/browser_preview_renderer.tsx
+++ b/libs/hmpb/src/preview/browser_preview_renderer.tsx
@@ -7,7 +7,7 @@ import {
   createDocument,
   createScratchpad,
 } from '../renderer';
-import { baseStyleElements } from '../base_styles';
+import { BaseStyles, BaseStylesProps } from '../base_styles';
 import { PAGE_CLASS } from '../ballot_components';
 
 function browserPage(): Page {
@@ -30,10 +30,12 @@ function browserPage(): Page {
   };
 }
 
-function createBrowserPreviewDocument(): RenderDocument {
+function createBrowserPreviewDocument(
+  props: BaseStylesProps = {}
+): RenderDocument {
   document.head.innerHTML += ReactDomServer.renderToString(
     <>
-      {baseStyleElements}
+      <BaseStyles {...props} />
       <style type="text/css">
         {`
         body {
@@ -56,8 +58,10 @@ function createBrowserPreviewDocument(): RenderDocument {
 
 export function createBrowserPreviewRenderer(): Renderer {
   return {
-    createScratchpad() {
-      return Promise.resolve(createScratchpad(createBrowserPreviewDocument()));
+    createScratchpad(props?: BaseStylesProps) {
+      return Promise.resolve(
+        createScratchpad(createBrowserPreviewDocument(props))
+      );
     },
     cloneDocument() {
       return Promise.resolve(createBrowserPreviewDocument());

--- a/libs/hmpb/src/render_ballot.test.tsx
+++ b/libs/hmpb/src/render_ballot.test.tsx
@@ -80,78 +80,133 @@ test('renderMinimalBallotsToCreateElectionDefinition', async () => {
   expect(electionDefinition).toEqual(fixtureElectionDefinition);
 });
 
-test(
-  'v3-compatible NH ballot - letter',
-  async () => {
-    const fixtureElection = electionGeneralFixtures.readElection();
-    const allBallotProps = allBaseBallotProps(fixtureElection);
-    const renderer = await createPlaywrightRenderer();
-    const electionDefinition =
-      await renderMinimalBallotsToCreateElectionDefinition(
-        renderer,
-        ballotTemplates.NhBallotV3,
-        allBallotProps,
-        'vxf'
-      );
-
-    // Bubbles and WIA crop should be snapped to grid
-    for (const gridLayout of electionDefinition.election.gridLayouts!) {
-      for (const gridPosition of gridLayout.gridPositions) {
-        expect(gridPosition.column % 1).toEqual(0);
-        expect(gridPosition.row % 1).toEqual(0);
-      }
-      expect(gridLayout.optionBoundsFromTargetMark.bottom % 1).toEqual(0);
-      expect(gridLayout.optionBoundsFromTargetMark.left % 1).toEqual(0);
-      expect(gridLayout.optionBoundsFromTargetMark.right % 1).toEqual(0);
-      expect(gridLayout.optionBoundsFromTargetMark.top % 1).toEqual(0);
-    }
-
-    // Election date should be off by one day to account for timezone bug in v3
-    expect(fixtureElection.date.toISOString()).toEqual('2020-11-03');
-    expect(electionDefinition.election.date.toISOString()).toEqual(
-      '2020-11-04'
+test('v3-compatible NH ballot - letter', async () => {
+  const fixtureElection = electionGeneralFixtures.readElection();
+  const allBallotProps = allBaseBallotProps(fixtureElection);
+  const renderer = await createPlaywrightRenderer();
+  const electionDefinition =
+    await renderMinimalBallotsToCreateElectionDefinition(
+      renderer,
+      ballotTemplates.NhBallotV3,
+      allBallotProps,
+      'vxf'
     );
-  },
-  { timeout: 30_000 }
-);
 
-test(
-  'v3-compatible NH ballot - legal',
-  async () => {
-    const fixtureElection = electionGeneralFixtures.readElection();
-    const allBallotProps = allBaseBallotProps({
-      ...fixtureElection,
-      ballotLayout: {
-        ...fixtureElection.ballotLayout,
-        paperSize: HmpbBallotPaperSize.Legal,
-      },
-    });
-    const renderer = await createPlaywrightRenderer();
-    const electionDefinition =
-      await renderMinimalBallotsToCreateElectionDefinition(
-        renderer,
-        ballotTemplates.NhBallotV3,
-        allBallotProps,
-        'vxf'
-      );
-
-    // Bubbles and WIA crop should be snapped to grid
-    for (const gridLayout of electionDefinition.election.gridLayouts!) {
-      for (const gridPosition of gridLayout.gridPositions) {
-        expect(gridPosition.column % 1).toEqual(0);
-        expect(gridPosition.row % 1).toEqual(0);
-      }
-      expect(gridLayout.optionBoundsFromTargetMark.bottom % 1).toEqual(0);
-      expect(gridLayout.optionBoundsFromTargetMark.left % 1).toEqual(0);
-      expect(gridLayout.optionBoundsFromTargetMark.right % 1).toEqual(0);
-      expect(gridLayout.optionBoundsFromTargetMark.top % 1).toEqual(0);
+  // Bubbles and WIA crop should be snapped to grid
+  for (const gridLayout of electionDefinition.election.gridLayouts!) {
+    for (const gridPosition of gridLayout.gridPositions) {
+      expect(gridPosition.column % 1).toEqual(0);
+      expect(gridPosition.row % 1).toEqual(0);
     }
+    expect(gridLayout.optionBoundsFromTargetMark.bottom % 1).toEqual(0);
+    expect(gridLayout.optionBoundsFromTargetMark.left % 1).toEqual(0);
+    expect(gridLayout.optionBoundsFromTargetMark.right % 1).toEqual(0);
+    expect(gridLayout.optionBoundsFromTargetMark.top % 1).toEqual(0);
+  }
 
-    // Election date should be off by one day to account for timezone bug in v3
-    expect(fixtureElection.date.toISOString()).toEqual('2020-11-03');
-    expect(electionDefinition.election.date.toISOString()).toEqual(
-      '2020-11-04'
+  // Election date should be off by one day to account for timezone bug in v3
+  expect(fixtureElection.date.toISOString()).toEqual('2020-11-03');
+  expect(electionDefinition.election.date.toISOString()).toEqual('2020-11-04');
+}, 30_000);
+
+test('v3-compatible NH ballot (compact) - letter', async () => {
+  const fixtureElection = electionGeneralFixtures.readElection();
+  const allBallotProps = allBaseBallotProps(fixtureElection).map((p) => ({
+    ...p,
+    compact: true,
+  }));
+  const renderer = await createPlaywrightRenderer();
+  const electionDefinition =
+    await renderMinimalBallotsToCreateElectionDefinition(
+      renderer,
+      ballotTemplates.NhBallotV3Compact,
+      allBallotProps,
+      'vxf'
     );
-  },
-  { timeout: 30_000 }
-);
+
+  // Bubbles and WIA crop should be snapped to grid
+  for (const gridLayout of electionDefinition.election.gridLayouts!) {
+    for (const gridPosition of gridLayout.gridPositions) {
+      expect(gridPosition.column % 1).toEqual(0);
+      expect(gridPosition.row % 1).toEqual(0);
+    }
+    expect(gridLayout.optionBoundsFromTargetMark.bottom % 1).toEqual(0);
+    expect(gridLayout.optionBoundsFromTargetMark.left % 1).toEqual(0);
+    expect(gridLayout.optionBoundsFromTargetMark.right % 1).toEqual(0);
+    expect(gridLayout.optionBoundsFromTargetMark.top % 1).toEqual(0);
+  }
+
+  // Election date should be off by one day to account for timezone bug in v3
+  expect(fixtureElection.date.toISOString()).toEqual('2020-11-03');
+  expect(electionDefinition.election.date.toISOString()).toEqual('2020-11-04');
+}, 30_000);
+
+test('v3-compatible NH ballot - legal', async () => {
+  const fixtureElection = electionGeneralFixtures.readElection();
+  const allBallotProps = allBaseBallotProps({
+    ...fixtureElection,
+    ballotLayout: {
+      ...fixtureElection.ballotLayout,
+      paperSize: HmpbBallotPaperSize.Legal,
+    },
+  });
+  const renderer = await createPlaywrightRenderer();
+  const electionDefinition =
+    await renderMinimalBallotsToCreateElectionDefinition(
+      renderer,
+      ballotTemplates.NhBallotV3,
+      allBallotProps,
+      'vxf'
+    );
+
+  // Bubbles and WIA crop should be snapped to grid
+  for (const gridLayout of electionDefinition.election.gridLayouts!) {
+    for (const gridPosition of gridLayout.gridPositions) {
+      expect(gridPosition.column % 1).toEqual(0);
+      expect(gridPosition.row % 1).toEqual(0);
+    }
+    expect(gridLayout.optionBoundsFromTargetMark.bottom % 1).toEqual(0);
+    expect(gridLayout.optionBoundsFromTargetMark.left % 1).toEqual(0);
+    expect(gridLayout.optionBoundsFromTargetMark.right % 1).toEqual(0);
+    expect(gridLayout.optionBoundsFromTargetMark.top % 1).toEqual(0);
+  }
+
+  // Election date should be off by one day to account for timezone bug in v3
+  expect(fixtureElection.date.toISOString()).toEqual('2020-11-03');
+  expect(electionDefinition.election.date.toISOString()).toEqual('2020-11-04');
+}, 30_000);
+
+test.only('v3-compatible NH ballot (compact) - legal', async () => {
+  const fixtureElection = electionGeneralFixtures.readElection();
+  const allBallotProps = allBaseBallotProps({
+    ...fixtureElection,
+    ballotLayout: {
+      ...fixtureElection.ballotLayout,
+      paperSize: HmpbBallotPaperSize.Legal,
+    },
+  }).map((p) => ({ ...p, compact: true }));
+  const renderer = await createPlaywrightRenderer();
+  const electionDefinition =
+    await renderMinimalBallotsToCreateElectionDefinition(
+      renderer,
+      ballotTemplates.NhBallotV3Compact,
+      allBallotProps,
+      'vxf'
+    );
+
+  // Bubbles and WIA crop should be snapped to grid
+  for (const gridLayout of electionDefinition.election.gridLayouts!) {
+    for (const gridPosition of gridLayout.gridPositions) {
+      expect(gridPosition.column % 1).toEqual(0);
+      expect(gridPosition.row % 1).toEqual(0);
+    }
+    expect(gridLayout.optionBoundsFromTargetMark.bottom % 1).toEqual(0);
+    expect(gridLayout.optionBoundsFromTargetMark.left % 1).toEqual(0);
+    expect(gridLayout.optionBoundsFromTargetMark.right % 1).toEqual(0);
+    expect(gridLayout.optionBoundsFromTargetMark.top % 1).toEqual(0);
+  }
+
+  // Election date should be off by one day to account for timezone bug in v3
+  expect(fixtureElection.date.toISOString()).toEqual('2020-11-03');
+  expect(electionDefinition.election.date.toISOString()).toEqual('2020-11-04');
+}, 30_000);

--- a/libs/hmpb/src/render_ballot.test.tsx
+++ b/libs/hmpb/src/render_ballot.test.tsx
@@ -176,7 +176,7 @@ test('v3-compatible NH ballot - legal', async () => {
   expect(electionDefinition.election.date.toISOString()).toEqual('2020-11-04');
 }, 30_000);
 
-test.only('v3-compatible NH ballot (compact) - legal', async () => {
+test('v3-compatible NH ballot (compact) - legal', async () => {
   const fixtureElection = electionGeneralFixtures.readElection();
   const allBallotProps = allBaseBallotProps({
     ...fixtureElection,

--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -49,6 +49,7 @@ import {
   Pixels,
   Point,
 } from './types';
+import { BaseStylesProps } from './base_styles';
 
 export type FrameComponent<P> = (
   props: P & { children: JSX.Element; pageNumber: number; totalPages: number }
@@ -462,9 +463,11 @@ async function addQrCodesAndBallotHashes(
 export async function renderBallotTemplate<P extends object>(
   renderer: Renderer,
   template: BallotPageTemplate<P>,
-  props: P
+  props: P & BaseStylesProps
 ): Promise<Result<RenderDocument, BallotLayoutError>> {
-  const scratchpad = await renderer.createScratchpad();
+  const scratchpad = await renderer.createScratchpad({
+    compact: props.compact,
+  });
   const pages = await paginateBallotContent(template, props, scratchpad);
   if (pages.isErr()) {
     return pages;
@@ -503,6 +506,7 @@ export interface BaseBallotProps {
   ballotType: BallotType;
   ballotMode: BallotMode;
   watermark?: string;
+  compact?: boolean;
 }
 
 /**

--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -272,12 +272,12 @@ function snapCoordinatesToGrid(coordinates: { column: number; row: number }): {
   );
   const deltaRow = Math.abs(coordinates.row - Math.round(coordinates.row));
   assert(
-    deltaColumn <= 0.1,
+    deltaColumn <= 0.05,
     'Column coordinate is not close to an integer  - bubble may be misaligned ' +
       `(delta = ${deltaColumn.toPrecision(4)})`
   );
   assert(
-    deltaRow <= 0.1,
+    deltaRow <= 0.05,
     'Row coordinate is not close to an integer - bubble may be misaligned ' +
       `(delta = ${deltaRow.toPrecision(4)})`
   );

--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -273,11 +273,13 @@ function snapCoordinatesToGrid(coordinates: { column: number; row: number }): {
   const deltaRow = Math.abs(coordinates.row - Math.round(coordinates.row));
   assert(
     deltaColumn <= 0.1,
-    'Column coordinate is not close to an integer - bubble may be misaligned'
+    'Column coordinate is not close to an integer  - bubble may be misaligned ' +
+      `(delta = ${deltaColumn.toPrecision(4)})`
   );
   assert(
     deltaRow <= 0.1,
-    'Row coordinate is not close to an integer - bubble may be misaligned'
+    'Row coordinate is not close to an integer - bubble may be misaligned ' +
+      `(delta = ${deltaRow.toPrecision(4)})`
   );
   return {
     column: Math.round(coordinates.column),

--- a/libs/hmpb/src/renderer.tsx
+++ b/libs/hmpb/src/renderer.tsx
@@ -6,6 +6,7 @@ import { ServerStyleSheet } from 'styled-components';
 import { assert } from '@votingworks/basics';
 import { PixelMeasurements } from './types';
 import { PAGE_CLASS } from './ballot_components';
+import { BaseStylesProps } from './base_styles';
 
 export type Page = Pick<
   PlaywrightPage,
@@ -177,7 +178,7 @@ export interface Renderer {
   /**
    * Creates a new {@link RenderScratchpad}.
    */
-  createScratchpad(): Promise<RenderScratchpad>;
+  createScratchpad(props?: BaseStylesProps): Promise<RenderScratchpad>;
 
   /**
    * Given a {@link RenderDocument}, creates a new {@link RenderDocument} with the same content.


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/5959

Adding `*Compact` versions of the NH ballot templates where we (not comprehensive):
- reduce the font-size from `12pt` to `10pt`,
- reduce line height from `1.2` to `1.1`,
- reduce spacing and padding where feasible,
- and reduce ballot measure title sizes.

Updated the ballot template picker to include the new compact variations.

## Demo Video or Screenshot

V4 normal template sample [here](https://drive.google.com/file/d/1WcVDMRTHva8jWX75GgH_cUN43g4PG-rC/view?usp=drive_link)
V4 compact template sample [here](https://drive.google.com/file/d/1md-0Zg4EQZoxnBsvPysF0yPGhoPT3-6v/view?usp=drive_link)

![Screenshot 2025-02-05 at 17 15 23](https://github.com/user-attachments/assets/7e2ea92d-927c-43cd-a185-54e2fb51133e)

## Testing Plan
- Manual for now

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
