### PR TITLE
ci(design): don't overwrite the seal in this test

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -1153,7 +1153,6 @@ test('getBallotPreviewPdf returns a ballot pdf for NH election with split precin
     './test/mockSignature.svg'
   ).toString();
   split.electionTitleOverride = 'Test Election Title Override';
-  split.electionSealOverride = split.clerkSignatureImage;
 
   await apiClient.updatePrecincts({ electionId, precincts });
 


### PR DESCRIPTION
Fixes tests in CI.

### Diff

![image](https://github.com/user-attachments/assets/a7b53213-01e1-4a84-a6b8-cb7662c9462a)

I think this only happens sometimes because of a data race.