### PR TITLE
fix(design): prevent crash on contest delete

### DIFF
--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -358,9 +358,9 @@ function ContestForm({
   savedElection: Election;
 }): JSX.Element | null {
   const savedContests = savedElection.contests;
-  const [contest, setContest] = useState<AnyContest>(
+  const [contest, setContest] = useState(
     contestId
-      ? find(savedContests, (c) => c.id === contestId)
+      ? savedContests.find((c) => c.id === contestId)
       : // To make mocked IDs predictable in tests, we pass a function here
         // so it will only be called on initial render.
         createBlankCandidateContest
@@ -369,6 +369,13 @@ function ContestForm({
   const history = useHistory();
   const contestRoutes = routes.election(electionId).contests;
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
+
+  // After deleting a contest, this component may re-render briefly with no
+  // contest before redirecting to the contests list. We can just render
+  // nothing in that case.
+  if (!contest) {
+    return null;
+  }
 
   function onSubmit(updatedContest: AnyContest) {
     const newContests = contestId


### PR DESCRIPTION
## Overview

Fixes https://votingworks.sentry.io/issues/6266281369/

### Steps to Reproduce
1. Create a contest.
2. Delete the contest.

### Expected Result
The contest should be deleted and the user should be redirected back to the contest list.

### Actual Result
Most of the time, it happens exactly as expected. However, the order in which `savedElection` is updated and the `updateElectionMutation` `onSuccess` callback is called is not defined. If `savedElection` is updated first it will no longer have the contest that was just deleted and the `find` call will panic.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.