### PR TITLE
Kevin/vxdesign custom yes no text

### DIFF
--- a/apps/design/frontend/jest.config.js
+++ b/apps/design/frontend/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: -617,
-      lines: -1116,
+      lines: -1118,
     },
   },
   modulePathIgnorePatterns: [

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -631,11 +631,11 @@ describe('Contests tab', () => {
     );
 
     userEvent.type(
-      screen.getByLabelText('"Yes" Option Label'),
+      screen.getByLabelText('First Option Label'),
       newContest.yesOption.label
     );
     userEvent.type(
-      screen.getByLabelText('"No" Option Label'),
+      screen.getByLabelText('Second Option Label'),
       newContest.noOption.label
     );
 
@@ -752,12 +752,12 @@ describe('Contests tab', () => {
     const descriptionHtml = `<p>${changedContest.description}</p>`;
 
     // Change yes and no labels
-    const yesInput = screen.getByLabelText('"Yes" Option Label');
+    const yesInput = screen.getByLabelText('First Option Label');
     expect(yesInput).toHaveValue(savedContest.yesOption.label);
     userEvent.clear(yesInput);
     userEvent.type(yesInput, changedContest.yesOption.label);
 
-    const noInput = screen.getByLabelText('"No" Option Label');
+    const noInput = screen.getByLabelText('Second Option Label');
     expect(noInput).toHaveValue(savedContest.noOption.label);
     userEvent.clear(noInput);
     userEvent.type(noInput, changedContest.noOption.label);

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -25,6 +25,12 @@ let apiMock: MockApiClient;
 
 const idFactory = makeIdFactory();
 
+const user = {
+  orgId: 'org_123',
+  orgName: 'Example Org',
+  isVotingWorksUser: false,
+};
+
 beforeEach(() => {
   apiMock = createMockApiClient();
   idFactory.reset();
@@ -98,7 +104,7 @@ describe('Contests tab', () => {
     };
 
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ electionId, user })
       .resolves(electionWithNoContestsRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
@@ -191,7 +197,7 @@ describe('Contests tab', () => {
       })
       .resolves();
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ electionId, user })
       .resolves(electionWithNewContestRecord);
     const saveButton = screen.getByRole('button', { name: 'Save' });
     userEvent.click(saveButton);
@@ -256,7 +262,7 @@ describe('Contests tab', () => {
     };
 
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ electionId, user })
       .resolves(primaryElectionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
@@ -392,7 +398,7 @@ describe('Contests tab', () => {
       })
       .resolves();
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ electionId, user })
       .resolves(electionWithChangedContestRecord);
     const saveButton = screen.getByRole('button', { name: 'Save' });
     userEvent.click(saveButton);
@@ -473,7 +479,7 @@ describe('Contests tab', () => {
       };
 
       apiMock.getElection
-        .expectCallWith({ electionId })
+        .expectCallWith({ electionId, user })
         .resolves(electionWithNoContestsRecord);
       apiMock.getBallotsFinalizedAt
         .expectCallWith({ electionId })
@@ -551,7 +557,7 @@ describe('Contests tab', () => {
         })
         .resolves();
       apiMock.getElection
-        .expectCallWith({ electionId })
+        .expectCallWith({ electionId, user })
         .resolves(electionWithNewContestRecord);
       const saveButton = screen.getByRole('button', { name: 'Save' });
       userEvent.click(saveButton);
@@ -597,7 +603,7 @@ describe('Contests tab', () => {
     };
 
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ electionId, user })
       .resolves(generalElectionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
@@ -623,6 +629,16 @@ describe('Contests tab', () => {
       descriptionEditor.querySelector('.tiptap p')!,
       newContest.description
     );
+
+    userEvent.type(
+      screen.getByLabelText('"Yes" Option Label'),
+      newContest.yesOption.label
+    );
+    userEvent.type(
+      screen.getByLabelText('"No" Option Label'),
+      newContest.noOption.label
+    );
+
     await within(descriptionEditor).findByText(newContest.description);
     const descriptionHtml = `<p>${newContest.description}</p>`;
 
@@ -647,7 +663,7 @@ describe('Contests tab', () => {
       })
       .resolves();
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ electionId, user })
       .resolves(electionWithNewContestRecord);
     const saveButton = screen.getByRole('button', { name: 'Save' });
     userEvent.click(saveButton);
@@ -689,16 +705,16 @@ describe('Contests tab', () => {
       description: 'Changed Ballot Measure Description',
       yesOption: {
         ...savedContest.yesOption,
-        label: 'Yes',
+        label: 'Yea',
       },
       noOption: {
         ...savedContest.noOption,
-        label: 'No',
+        label: 'Nay',
       },
     };
 
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ electionId, user })
       .resolves(generalElectionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
@@ -735,6 +751,17 @@ describe('Contests tab', () => {
     await within(descriptionEditor).findByText(changedContest.description);
     const descriptionHtml = `<p>${changedContest.description}</p>`;
 
+    // Change yes and no labels
+    const yesInput = screen.getByLabelText('"Yes" Option Label');
+    expect(yesInput).toHaveValue(savedContest.yesOption.label);
+    userEvent.clear(yesInput);
+    userEvent.type(yesInput, changedContest.yesOption.label);
+
+    const noInput = screen.getByLabelText('"No" Option Label');
+    expect(noInput).toHaveValue(savedContest.noOption.label);
+    userEvent.clear(noInput);
+    userEvent.type(noInput, changedContest.noOption.label);
+
     // Save contest
     const electionWithChangedContestRecord: ElectionRecord = {
       ...generalElectionRecord,
@@ -754,7 +781,7 @@ describe('Contests tab', () => {
       })
       .resolves();
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ electionId, user })
       .resolves(electionWithChangedContestRecord);
     const saveButton = screen.getByRole('button', { name: 'Save' });
     userEvent.click(saveButton);
@@ -776,7 +803,7 @@ describe('Contests tab', () => {
     }));
 
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ electionId, user })
       .resolves(generalElectionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
@@ -846,7 +873,7 @@ describe('Contests tab', () => {
       })
       .resolves();
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ electionId, user })
       .resolves(reorderedElectionRecord);
     userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -863,7 +890,7 @@ describe('Contests tab', () => {
     }));
 
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ electionId, user })
       .resolves(generalElectionRecord);
     apiMock.getBallotsFinalizedAt
       .expectCallWith({ electionId })

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -740,15 +740,49 @@ function ContestForm({
       )}
 
       {contest.type === 'yesno' && (
-        <div>
-          <FieldName>Description</FieldName>
-          <RichTextEditor
-            initialHtmlContent={contest.description}
-            onChange={(htmlContent) =>
-              setContest({ ...contest, description: htmlContent })
-            }
-          />
-        </div>
+        <React.Fragment>
+          <div>
+            <FieldName>Description</FieldName>
+            <RichTextEditor
+              initialHtmlContent={contest.description}
+              onChange={(htmlContent) =>
+                setContest({ ...contest, description: htmlContent })
+              }
+            />
+          </div>
+
+          <div>
+            <FieldName>&quot;Yes&quot; Option Label</FieldName>
+            <input
+              type="text"
+              value={contest.yesOption.label}
+              onChange={(e) =>
+                setContest({
+                  ...contest,
+                  yesOption: { ...contest.yesOption, label: e.target.value },
+                })
+              }
+              autoComplete="off"
+              style={{ width: '4rem' }}
+            />
+          </div>
+
+          <div>
+            <FieldName>&quot;No&quot; Option Label</FieldName>
+            <input
+              type="text"
+              value={contest.noOption.label}
+              onChange={(e) =>
+                setContest({
+                  ...contest,
+                  noOption: { ...contest.noOption, label: e.target.value },
+                })
+              }
+              autoComplete="off"
+              style={{ width: '4rem' }}
+            />
+          </div>
+        </React.Fragment>
       )}
 
       <div>

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -752,7 +752,7 @@ function ContestForm({
           </div>
 
           <div>
-            <FieldName>&quot;Yes&quot; Option Label</FieldName>
+            <FieldName>First Option Label</FieldName>
             <input
               type="text"
               value={contest.yesOption.label}
@@ -768,7 +768,7 @@ function ContestForm({
           </div>
 
           <div>
-            <FieldName>&quot;No&quot; Option Label</FieldName>
+            <FieldName>Second Option Label</FieldName>
             <input
               type="text"
               value={contest.noOption.label}

--- a/apps/design/frontend/test/api_helpers.tsx
+++ b/apps/design/frontend/test/api_helpers.tsx
@@ -15,7 +15,7 @@ export function createMockApiClient(): MockApiClient {
 export function provideApi(
   apiMock: ReturnType<typeof createMockApiClient>,
   children: React.ReactNode,
-  electionId?: ElectionId
+  electionId: ElectionId
 ): JSX.Element {
   return (
     <TestErrorBoundary>

--- a/apps/design/frontend/test/fixtures.ts
+++ b/apps/design/frontend/test/fixtures.ts
@@ -48,6 +48,8 @@ export function makeElectionRecord(baseElection: Election): ElectionRecord {
     createdAt: new Date().toISOString(),
     ballotLanguageConfigs,
     ballotTemplateId: 'VxDefaultBallot',
+    ballotsFinalizedAt: null,
+    orgId: 'TODO',
   };
 }
 


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/5970

Adds custom yes/no label

## Demo Video or Screenshot

Screenshot has latest copy

![Screenshot 2025-02-06 at 12 48 02 PM](https://github.com/user-attachments/assets/ae9c6863-9b6b-43cb-aecb-2433b60de21e)


https://github.com/user-attachments/assets/e923fb12-daf6-48a5-8a9b-3b6ebda39934




## Testing Plan

- [ ] Add properties to existing ballot measure tests (blocked on auth0 dep issue)

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
