### PR TITLE
Add checkbox for "allowOfficialBallotsInTestMode" setting

### DIFF
--- a/apps/design/frontend/jest.config.js
+++ b/apps/design/frontend/jest.config.js
@@ -12,8 +12,8 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      branches: -617,
-      lines: -1118,
+      branches: -618,
+      lines: -1119,
     },
   },
   modulePathIgnorePatterns: [

--- a/apps/design/frontend/src/tabulation_screen.tsx
+++ b/apps/design/frontend/src/tabulation_screen.tsx
@@ -19,6 +19,7 @@ import {
   unsafeParse,
 } from '@votingworks/types';
 import { z } from 'zod';
+import type { BallotTemplateId } from '@votingworks/design-backend';
 import { Form, Column, Row, FormActionsRow, InputGroup } from './layout';
 import { ElectionNavScreen } from './nav_screen';
 import { ElectionIdParams } from './routes';
@@ -30,6 +31,7 @@ type TabulationSettings = Pick<
   | 'disallowCastingOvervotes'
   | 'centralScanAdjudicationReasons'
   | 'markThresholds'
+  | 'allowOfficialBallotsInTestMode'
 >;
 
 type DeepPartial<T> = {
@@ -37,9 +39,11 @@ type DeepPartial<T> = {
 };
 
 export function TabulationForm({
+  ballotTemplateId,
   electionId,
   savedSystemSettings,
 }: {
+  ballotTemplateId: BallotTemplateId;
   electionId: ElectionId;
   savedSystemSettings: SystemSettings;
 }): JSX.Element {
@@ -233,6 +237,25 @@ export function TabulationForm({
             )}
           </Column>
         </Card>
+        {ballotTemplateId !== 'NhBallotV3' &&
+          ballotTemplateId !== 'NhBallotV3Compact' && (
+            <Card>
+              <H2>Other</H2>
+              <CheckboxButton
+                label="Allow Official Ballots in Test Mode"
+                isChecked={Boolean(
+                  tabulationSettings.allowOfficialBallotsInTestMode
+                )}
+                onChange={(isChecked) =>
+                  setTabulationSettings({
+                    ...tabulationSettings,
+                    allowOfficialBallotsInTestMode: isChecked,
+                  })
+                }
+                disabled={!isEditing}
+              />
+            </Card>
+          )}
       </Row>
       {isEditing ? (
         <FormActionsRow>
@@ -265,7 +288,7 @@ export function TabulationScreen(): JSX.Element | null {
     return null;
   }
 
-  const { systemSettings } = getElectionQuery.data;
+  const { ballotTemplateId, systemSettings } = getElectionQuery.data;
 
   return (
     <ElectionNavScreen electionId={electionId}>
@@ -274,6 +297,7 @@ export function TabulationScreen(): JSX.Element | null {
       </MainHeader>
       <MainContent>
         <TabulationForm
+          ballotTemplateId={ballotTemplateId}
           electionId={electionId}
           savedSystemSettings={systemSettings}
         />


### PR DESCRIPTION
## Overview

One more tweak in prep for election package exports and upcoming NH ballot QA, as I need this enabled for all v4 election package exports. Threw things under an "other" bucket for now, but don't put too much stock in that. We'll be revisiting this soon, as we add additional toggles for other system settings to unblock SLI's testing.

<img width="1512" alt="new-toggle" src="https://github.com/user-attachments/assets/35ddedbc-4bd1-40b1-b296-09157f15ab50" />

## Testing Plan

- [x] Tested manually
- [ ] Working on an automated test though the relevant one is still disabled