### PR TITLE
Make precinct split config affect election hash

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -1083,6 +1083,10 @@ test('Export test decks', async () => {
       election: {
         ...election,
         ballotStrings: expectedEnglishBallotStrings(election),
+        additionalHashInput: {
+          precinctSplitSeals: {},
+          precinctSplitSignatureImages: {},
+        },
       },
       ballotStyleId: ballotStyle.id,
       precinctId,

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -36,6 +36,10 @@ import {
   DistrictIdSchema,
   ElectionId,
   getBallotLanguageConfigs,
+  SplittablePrecinct,
+  hasSplits,
+  PrecinctWithSplits,
+  PrecinctWithoutSplits,
 } from '@votingworks/types';
 import {
   BooleanEnvironmentVariableName,
@@ -76,12 +80,8 @@ import { FULL_TEST_DECK_TALLY_REPORT_FILE_NAME } from './test_decks';
 import {
   BallotOrderInfo,
   BallotStyle,
-  Precinct,
-  PrecinctWithSplits,
-  PrecinctWithoutSplits,
   User,
   convertToVxfBallotStyle,
-  hasSplits,
 } from './types';
 import { generateBallotStyles } from './ballot_styles';
 import { ElectionRecord } from '.';
@@ -221,7 +221,7 @@ test('CRUD elections', async () => {
     electionId: electionId2,
   });
 
-  const expectedPrecincts: Precinct[] =
+  const expectedPrecincts: SplittablePrecinct[] =
     election2Definition.election.precincts.map((vxfPrecinct) => ({
       id: vxfPrecinct.id,
       name: vxfPrecinct.name,
@@ -1320,7 +1320,7 @@ test('getBallotPreviewPdf returns a ballot pdf for precinct with no split', asyn
   });
 
   function hasDistrictIds(
-    precinct: Precinct
+    precinct: SplittablePrecinct
   ): precinct is PrecinctWithoutSplits {
     return 'districtIds' in precinct && precinct.districtIds.length > 0;
   }

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -65,7 +65,11 @@ import {
   authEnabled,
   sliOrgId,
 } from './globals';
-import { createBallotPropsForTemplate, defaultBallotTemplate } from './ballots';
+import {
+  createBallotPropsForTemplate,
+  defaultBallotTemplate,
+  formatElectionForExport,
+} from './ballots';
 import { getPdfFileName } from './utils';
 
 export const BALLOT_STYLE_READINESS_REPORT_FILE_NAME =
@@ -504,13 +508,14 @@ function buildApi({ auth, workspace, translator }: AppContext) {
         ballotLanguageConfigs,
         precincts
       );
-      const electionWithBallotStrings: Election = {
-        ...election,
+      const formattedElection = formatElectionForExport(
+        election,
         ballotStrings,
-      };
+        precincts
+      );
       const allBallotProps = createBallotPropsForTemplate(
         ballotTemplateId,
-        electionWithBallotStrings,
+        formattedElection,
         precincts,
         ballotStyles
       );

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -19,6 +19,7 @@ import {
   LanguageCode,
   LanguageCodeSchema,
   getAllBallotLanguages,
+  SplittablePrecinct,
 } from '@votingworks/types';
 import express, { Application } from 'express';
 import {
@@ -45,14 +46,7 @@ import { translateBallotStrings } from '@votingworks/backend';
 import { readFileSync } from 'node:fs';
 import { z } from 'zod';
 import { ElectionPackage, ElectionRecord } from './store';
-import {
-  BallotOrderInfo,
-  Org,
-  Precinct,
-  User,
-  UsState,
-  WithUserInfo,
-} from './types';
+import { BallotOrderInfo, Org, User, UsState, WithUserInfo } from './types';
 import {
   createPrecinctTestDeck,
   FULL_TEST_DECK_TALLY_REPORT_FILE_NAME,
@@ -104,7 +98,7 @@ export function createBlankElection(id: ElectionId): Election {
 
 // If we are importing an existing VXF election, we need to convert the
 // precincts to have splits based on the ballot styles.
-export function convertVxfPrecincts(election: Election): Precinct[] {
+export function convertVxfPrecincts(election: Election): SplittablePrecinct[] {
   return election.precincts.map((precinct) => {
     const precinctBallotStyles = election.ballotStyles.filter((ballotStyle) =>
       ballotStyle.precincts.includes(precinct.id)
@@ -368,7 +362,7 @@ function buildApi({ auth, workspace, translator }: AppContext) {
 
     updatePrecincts(input: {
       electionId: ElectionId;
-      precincts: Precinct[];
+      precincts: SplittablePrecinct[];
     }): Promise<void> {
       return store.updatePrecincts(input.electionId, input.precincts);
     },
@@ -417,7 +411,8 @@ function buildApi({ auth, workspace, translator }: AppContext) {
         translator,
         election,
         hmpbStringsCatalog,
-        ballotLanguageConfigs
+        ballotLanguageConfigs,
+        precincts
       );
       const electionWithBallotStrings: Election = {
         ...election,
@@ -501,11 +496,13 @@ function buildApi({ auth, workspace, translator }: AppContext) {
         ballotStyles,
         ballotTemplateId,
       } = await store.getElection(input.electionId);
+
       const ballotStrings = await translateBallotStrings(
         translator,
         election,
         hmpbStringsCatalog,
-        ballotLanguageConfigs
+        ballotLanguageConfigs,
+        precincts
       );
       const electionWithBallotStrings: Election = {
         ...election,

--- a/apps/design/backend/src/ballot_styles.test.ts
+++ b/apps/design/backend/src/ballot_styles.test.ts
@@ -7,6 +7,8 @@ import {
   Party,
   PartyId,
   LanguageCode,
+  SplittablePrecinct,
+  PrecinctSplit,
 } from '@votingworks/types';
 import {
   generateBallotStyleGroupId,
@@ -14,7 +16,7 @@ import {
 } from '@votingworks/utils';
 
 import { generateBallotStyles } from './ballot_styles';
-import { BallotStyle, Precinct, PrecinctSplit } from './types';
+import { BallotStyle } from './types';
 
 function makeContest(
   id: string,
@@ -68,12 +70,12 @@ describe('generateBallotStyles()', () => {
     abbrev: 'C',
   };
 
-  const precinct1District1: Precinct = {
+  const precinct1District1: SplittablePrecinct = {
     id: 'precinct-1',
     name: 'Precinct 1',
     districtIds: [district1.id],
   };
-  const precinct2District2: Precinct = {
+  const precinct2District2: SplittablePrecinct = {
     id: 'precinct-2',
     name: 'Precinct 2',
     districtIds: [district2.id],
@@ -104,20 +106,20 @@ describe('generateBallotStyles()', () => {
       districtIds: [district3NoContests.id],
     }),
   } as const;
-  const precinct3District1And2: Precinct = {
+  const precinct3District1And2: SplittablePrecinct = {
     id: 'precinct-3-with-splits',
     name: 'Precinct 3 - With Splits',
     splits: Object.values(precinct3Splits),
   };
 
-  const precinct4NoDistricts: Precinct = {
+  const precinct4NoDistricts: SplittablePrecinct = {
     id: 'precinct-4',
     name: 'Precinct 4',
     // Shouldn't get a ballot style, since no districts assigned
     districtIds: [],
   };
 
-  const precinct5NoContests: Precinct = {
+  const precinct5NoContests: SplittablePrecinct = {
     id: 'precinct-5',
     name: 'Precinct 5',
     // Shouldn't get a ballot style, since no contests assigned

--- a/apps/design/backend/src/ballot_styles.ts
+++ b/apps/design/backend/src/ballot_styles.ts
@@ -6,13 +6,16 @@ import {
   DistrictId,
   ElectionType,
   Parties,
+  PrecinctOrSplitId,
+  SplittablePrecinct,
+  hasSplits,
 } from '@votingworks/types';
 import {
   generateBallotStyleGroupId,
   generateBallotStyleId,
 } from '@votingworks/utils';
 
-import { BallotStyle, Precinct, PrecinctOrSplitId, hasSplits } from './types';
+import { BallotStyle } from './types';
 
 /**
  * Generates ballot styles for the election based on geography data (districts,
@@ -30,7 +33,7 @@ export function generateBallotStyles(params: {
   ballotLanguageConfigs: BallotLanguageConfigs;
   electionType: ElectionType;
   parties: Parties;
-  precincts: Precinct[];
+  precincts: SplittablePrecinct[];
 }): BallotStyle[] {
   const { ballotLanguageConfigs, contests, electionType, parties, precincts } =
     params;

--- a/apps/design/backend/src/ballots.test.ts
+++ b/apps/design/backend/src/ballots.test.ts
@@ -1,9 +1,20 @@
 import { electionGridLayoutNewHampshireHudsonFixtures } from '@votingworks/fixtures';
-import { Election, LanguageCode } from '@votingworks/types';
+import {
+  DistrictId,
+  Election,
+  ElectionStringKey,
+  LanguageCode,
+  UiStringsPackage,
+} from '@votingworks/types';
+import { TestLanguageCode } from '@votingworks/test-utils';
 import { BallotTemplateId } from '@votingworks/hmpb';
 import { expect, test } from 'vitest';
-import { createBallotPropsForTemplate } from './ballots';
-import { UsState } from './types';
+import { assertDefined } from '@votingworks/basics';
+import {
+  createBallotPropsForTemplate,
+  formatElectionForExport,
+} from './ballots';
+import { Precinct, UsState } from './types';
 
 const election: Election = {
   ...electionGridLayoutNewHampshireHudsonFixtures.readElection(),
@@ -55,4 +66,43 @@ test('compact templates', () => {
       expect(props.compact).toEqual(true);
     }
   }
+});
+
+test('formatElectionForExport', () => {
+  const { CHINESE_SIMPLIFIED, ENGLISH, SPANISH } = TestLanguageCode;
+  const testTranslations: UiStringsPackage = {
+    [CHINESE_SIMPLIFIED]: { [ElectionStringKey.BALLOT_LANGUAGE]: '简体中文' },
+    [ENGLISH]: { [ElectionStringKey.BALLOT_LANGUAGE]: 'English' },
+    [SPANISH]: { [ElectionStringKey.BALLOT_LANGUAGE]: 'Español' },
+  };
+  const testPrecincts: Precinct[] = [
+    {
+      id: 'precinct-1',
+      name: 'Precinct One',
+      splits: [
+        {
+          districtIds: ['district_a' as DistrictId],
+          id: 'split-1',
+          name: 'Split Name',
+          electionTitleOverride: 'election title override',
+          electionSealOverride: '<svg class="somesvg"></svg>',
+          clerkSignatureImage: '<svg class="someothersvg"></svg>',
+        },
+      ],
+    },
+  ];
+
+  const formattedElection = formatElectionForExport(
+    election,
+    testTranslations,
+    testPrecincts
+  );
+  expect(formattedElection).toHaveProperty('additionalHashInput');
+  const hashInput = assertDefined(formattedElection.additionalHashInput);
+  expect(hashInput['precinctSplitSeals']).toMatchObject({
+    'precinct-1-split-1': expect.any(String),
+  });
+  expect(hashInput['precinctSplitSignatureImages']).toMatchObject({
+    'precinct-1-split-1': expect.any(String),
+  });
 });

--- a/apps/design/backend/src/ballots.test.ts
+++ b/apps/design/backend/src/ballots.test.ts
@@ -4,6 +4,7 @@ import {
   Election,
   ElectionStringKey,
   LanguageCode,
+  SplittablePrecinct,
   UiStringsPackage,
 } from '@votingworks/types';
 import { TestLanguageCode } from '@votingworks/test-utils';
@@ -14,7 +15,7 @@ import {
   createBallotPropsForTemplate,
   formatElectionForExport,
 } from './ballots';
-import { Precinct, UsState } from './types';
+import { UsState } from './types';
 
 const election: Election = {
   ...electionGridLayoutNewHampshireHudsonFixtures.readElection(),
@@ -75,7 +76,7 @@ test('formatElectionForExport', () => {
     [ENGLISH]: { [ElectionStringKey.BALLOT_LANGUAGE]: 'English' },
     [SPANISH]: { [ElectionStringKey.BALLOT_LANGUAGE]: 'Español' },
   };
-  const testPrecincts: Precinct[] = [
+  const testPrecincts: SplittablePrecinct[] = [
     {
       id: 'precinct-1',
       name: 'Precinct One',

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -1,4 +1,11 @@
-import { Election, UiStringsPackage } from '@votingworks/types';
+import {
+  Election,
+  hasSplits,
+  PrecinctSplit,
+  PrecinctWithSplits,
+  SplittablePrecinct,
+  UiStringsPackage,
+} from '@votingworks/types';
 import {
   allBaseBallotProps,
   BallotTemplateId,
@@ -7,16 +14,7 @@ import {
 } from '@votingworks/hmpb';
 import { find, throwIllegalValue } from '@votingworks/basics';
 import { sha256 } from 'js-sha256';
-import {
-  BallotStyle,
-  hasSplits,
-  normalizeState,
-  Precinct,
-  PrecinctSplit,
-  PrecinctWithSplits,
-  User,
-  UsState,
-} from './types';
+import { BallotStyle, normalizeState, User, UsState } from './types';
 
 function getPrecinctSplitForBallotStyle(
   precinct: PrecinctWithSplits,
@@ -52,7 +50,7 @@ export function defaultBallotTemplate(
 export function formatElectionForExport(
   election: Election,
   ballotStrings: UiStringsPackage,
-  precincts: Precinct[]
+  precincts: SplittablePrecinct[]
 ): Election {
   const splitPrecincts = precincts.filter((p) => hasSplits(p));
 
@@ -89,7 +87,7 @@ export function formatElectionForExport(
 export function createBallotPropsForTemplate(
   templateId: BallotTemplateId,
   election: Election,
-  precincts: Precinct[],
+  precincts: SplittablePrecinct[],
   ballotStyles: BallotStyle[]
 ): BaseBallotProps[] {
   function buildNhBallotProps(props: BaseBallotProps): NhBallotProps {

--- a/apps/design/backend/src/election_package_strings.test.ts
+++ b/apps/design/backend/src/election_package_strings.test.ts
@@ -1,10 +1,9 @@
 import { expect, test } from 'vitest';
-import { DistrictId } from '@votingworks/types';
-import { Precinct } from './types';
+import { DistrictId, SplittablePrecinct } from '@votingworks/types';
 import { getUserDefinedHmpbStrings } from './election_package_strings';
 
 test('getUserDefinedHmpbStrings', () => {
-  const precincts: Precinct[] = [
+  const precincts: SplittablePrecinct[] = [
     {
       id: 'precinct_1',
       name: 'Example Split Precinct',

--- a/apps/design/backend/src/election_package_strings.test.ts
+++ b/apps/design/backend/src/election_package_strings.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from 'vitest';
+import { DistrictId } from '@votingworks/types';
+import { Precinct } from './types';
+import { getUserDefinedHmpbStrings } from './election_package_strings';
+
+test('getUserDefinedHmpbStrings', () => {
+  const precincts: Precinct[] = [
+    {
+      id: 'precinct_1',
+      name: 'Example Split Precinct',
+      splits: [
+        {
+          districtIds: ['district_1' as DistrictId],
+          id: 'split_1',
+          name: 'Split One',
+          clerkSignatureCaption: 'Clerk Signature',
+          electionTitleOverride: 'Split One Election',
+          clerkSignatureImage: '<svg></svg>',
+          electionSealOverride: '<svg></svg>',
+        },
+        {
+          districtIds: ['district_2' as DistrictId],
+          id: 'split_2',
+          name: 'Split Two',
+          electionTitleOverride: 'Split Two Election',
+        },
+        {
+          districtIds: ['district_3' as DistrictId],
+          id: 'split_3',
+          name: 'Split Three',
+          clerkSignatureCaption: 'Town Clerk Signature',
+        },
+      ],
+    },
+    {
+      id: 'precinct_2',
+      name: 'Example Nonsplit Precinct',
+      districtIds: ['district_1' as DistrictId],
+    },
+  ];
+
+  expect(getUserDefinedHmpbStrings(precincts)).toEqual({
+    hmpbClerkSignatureCaption_precinct_1_split_1: 'Clerk Signature',
+    hmpbElectionTitleOverride_precinct_1_split_1: 'Split One Election',
+    hmpbElectionTitleOverride_precinct_1_split_2: 'Split Two Election',
+    hmpbClerkSignatureCaption_precinct_1_split_3: 'Town Clerk Signature',
+  });
+});

--- a/apps/design/backend/src/election_package_strings.ts
+++ b/apps/design/backend/src/election_package_strings.ts
@@ -1,7 +1,7 @@
-import { hasSplits, Precinct } from './types';
+import { hasSplits, SplittablePrecinct } from '@votingworks/types';
 
 export function getUserDefinedHmpbStrings(
-  precincts: Precinct[]
+  precincts: SplittablePrecinct[]
 ): Record<string, string> {
   const catalog: Record<string, string> = {};
   for (const precinct of precincts) {

--- a/apps/design/backend/src/election_package_strings.ts
+++ b/apps/design/backend/src/election_package_strings.ts
@@ -1,0 +1,23 @@
+import { hasSplits, Precinct } from './types';
+
+export function getUserDefinedHmpbStrings(
+  precincts: Precinct[]
+): Record<string, string> {
+  const catalog: Record<string, string> = {};
+  for (const precinct of precincts) {
+    if (hasSplits(precinct)) {
+      for (const split of precinct.splits) {
+        if (split.clerkSignatureCaption) {
+          catalog[`hmpbClerkSignatureCaption_${precinct.id}_${split.id}`] =
+            split.clerkSignatureCaption;
+        }
+        if (split.electionTitleOverride) {
+          catalog[`hmpbElectionTitleOverride_${precinct.id}_${split.id}`] =
+            split.electionTitleOverride;
+        }
+      }
+    }
+  }
+
+  return catalog;
+}

--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -4,7 +4,6 @@ import './configure_sentry'; // Must be imported first to instrument code
 import { resolve } from 'node:path';
 import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
 import { BaseLogger, LogSource } from '@votingworks/logging';
-
 import { authEnabled, WORKSPACE } from './globals';
 import * as server from './server';
 import { createWorkspace } from './workspace';
@@ -17,16 +16,9 @@ import {
 } from './file_storage_client';
 
 export type { ElectionRecord } from './store';
-export type {
-  BallotOrderInfo,
-  BallotStyle,
-  Precinct,
-  PrecinctSplit,
-  PrecinctWithSplits,
-  PrecinctWithoutSplits,
-  User,
-} from './types';
+export type { BallotOrderInfo, BallotStyle, User } from './types';
 export type { Api, ElectionInfo } from './app';
+
 export type { BallotMode } from '@votingworks/hmpb';
 export type { BallotTemplateId } from '@votingworks/hmpb';
 

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -12,6 +12,7 @@ import {
   safeParseJson,
   ElectionId,
   BallotLanguageConfig,
+  SplittablePrecinct,
 } from '@votingworks/types';
 import { v4 as uuid } from 'uuid';
 import { BaseLogger } from '@votingworks/logging';
@@ -20,7 +21,6 @@ import {
   BallotOrderInfo,
   BallotOrderInfoSchema,
   BallotStyle,
-  Precinct,
   convertToVxfBallotStyle,
 } from './types';
 import { generateBallotStyles } from './ballot_styles';
@@ -30,7 +30,7 @@ import { Bindable } from './db/client';
 export interface ElectionRecord {
   orgId: string;
   election: Election;
-  precincts: Precinct[];
+  precincts: SplittablePrecinct[];
   ballotStyles: BallotStyle[];
   systemSettings: SystemSettings;
   ballotOrderInfo: BallotOrderInfo;
@@ -111,7 +111,7 @@ function hydrateElection(row: {
     (l): BallotLanguageConfig => ({ languages: [l] })
   );
   const rawElection = JSON.parse(row.electionData);
-  const precincts: Precinct[] = JSON.parse(row.precinctData);
+  const precincts: SplittablePrecinct[] = JSON.parse(row.precinctData);
   const ballotStyles = generateBallotStyles({
     ballotLanguageConfigs,
     contests: rawElection.contests,
@@ -256,7 +256,7 @@ export class Store {
   async createElection(
     orgId: string,
     election: Election,
-    precincts: Precinct[],
+    precincts: SplittablePrecinct[],
     ballotTemplateId: BallotTemplateId,
     systemSettings = DEFAULT_SYSTEM_SETTINGS
   ): Promise<void> {
@@ -340,7 +340,7 @@ export class Store {
 
   async updatePrecincts(
     electionId: ElectionId,
-    precincts: Precinct[]
+    precincts: SplittablePrecinct[]
   ): Promise<void> {
     await this.db.withClient((client) =>
       client.query(

--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -3,50 +3,11 @@ import {
   BallotStyle as VxfBallotStyle,
   BallotStyleId,
   DistrictId,
-  Id,
   PartyId,
-  PrecinctId,
   BallotStyleGroupId,
   LanguageCode,
+  PrecinctOrSplitId,
 } from '@votingworks/types';
-import { NhPrecinctSplitOptions } from '@votingworks/hmpb';
-
-// We create new types for precincts that can be split, since the existing
-// election types don't support this. We will likely want to extend the existing
-// types to support it in the future, but doing it separately for now allows us
-// to experiment and learn more first. We'll store these separately in the
-// database and ignore Election.precincts most of the app.
-export interface PrecinctWithoutSplits {
-  districtIds: readonly DistrictId[];
-  id: PrecinctId;
-  name: string;
-}
-export interface PrecinctWithSplits {
-  id: PrecinctId;
-  name: string;
-  splits: readonly PrecinctSplit[];
-}
-interface PrecinctSplitBase {
-  districtIds: readonly DistrictId[];
-  id: Id;
-  name: string;
-}
-
-// NH precinct split options are stored on the Precinct itself for simplicity.
-// Consider refactoring if PrecinctSplit grows to contain options for other
-// states or NhPrecinctSplitOptions adds many more properties.
-export type PrecinctSplit = PrecinctSplitBase & NhPrecinctSplitOptions;
-
-export type Precinct = PrecinctWithoutSplits | PrecinctWithSplits;
-
-export function hasSplits(precinct: Precinct): precinct is PrecinctWithSplits {
-  return 'splits' in precinct && precinct.splits !== undefined;
-}
-
-export interface PrecinctOrSplitId {
-  precinctId: PrecinctId;
-  splitId?: Id;
-}
 
 // We also create a new type for a ballot style, that can reference precincts and
 // splits. We generate ballot styles on demand, so it won't be stored in the db.

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -43,7 +43,6 @@ import {
 import { renderBallotStyleReadinessReport } from '../ballot_style_reports';
 import { getPdfFileName } from '../utils';
 import { isVxOrSliOrg } from '../features';
-import { getUserDefinedHmpbStrings } from '../election_package_strings';
 
 const BALLOT_STYLE_READINESS_REPORT_FILE_NAME =
   'ballot-style-readiness-report.pdf';
@@ -146,20 +145,13 @@ export async function generateElectionPackageAndBallots(
     JSON.stringify(metadata, null, 2)
   );
 
-  const userDefinedHmpbStrings = getUserDefinedHmpbStrings(precincts);
-  // Combine predefined and user-defined HMPB strings here because they can be
-  // translated in the same path.
-  const combinedHmpbStringsCatalog: Record<string, string> = {
-    ...hmpbStringsCatalog,
-    ...userDefinedHmpbStrings,
-  };
-
   const [appStrings, hmpbStrings, electionStrings] =
     await getAllStringsForElectionPackage(
       election,
       translator,
-      combinedHmpbStringsCatalog,
-      ballotLanguageConfigs
+      hmpbStringsCatalog,
+      ballotLanguageConfigs,
+      precincts
     );
 
   electionPackageZip.file(

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -158,8 +158,8 @@ export async function generateElectionPackageAndBallots(
     ElectionPackageFileName.APP_STRINGS,
     JSON.stringify(appStrings, null, 2)
   );
-
   const ballotStrings = mergeUiStrings(electionStrings, hmpbStrings);
+
   const formattedElection = formatElectionForExport(
     election,
     ballotStrings,

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -25,6 +25,7 @@ import {
   Election,
   getPartyForBallotStyle,
   ElectionId,
+  hasSplits,
 } from '@votingworks/types';
 import React, { useState } from 'react';
 import styled from 'styled-components';
@@ -37,7 +38,6 @@ import {
 import { Column, Form, FormActionsRow, NestedTr, Row } from './layout';
 import { ElectionNavScreen } from './nav_screen';
 import { ElectionIdParams, electionParamRoutes, routes } from './routes';
-import { hasSplits } from './utils';
 import { BallotScreen, paperSizeLabels } from './ballot_screen';
 import { useUserFeatures } from './features_context';
 import { useTitle } from './hooks/use_title';

--- a/apps/design/frontend/src/geography_screen.test.tsx
+++ b/apps/design/frontend/src/geography_screen.test.tsx
@@ -1,13 +1,16 @@
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
-import {
-  ElectionRecord,
-  Precinct,
-  PrecinctWithSplits,
-  PrecinctWithoutSplits,
-} from '@votingworks/design-backend';
+import { ElectionRecord } from '@votingworks/design-backend';
 import { Buffer } from 'node:buffer';
 import { createMemoryHistory } from 'history';
-import { District, DistrictId, ElectionId } from '@votingworks/types';
+import {
+  District,
+  DistrictId,
+  ElectionId,
+  SplittablePrecinct,
+  PrecinctWithSplits,
+  PrecinctWithoutSplits,
+  hasSplits,
+} from '@votingworks/types';
 import userEvent from '@testing-library/user-event';
 import { assert, assertDefined } from '@votingworks/basics';
 import { readElectionGeneral } from '@votingworks/fixtures';
@@ -24,7 +27,6 @@ import { withRoute } from '../test/routing_helpers';
 import { routes } from './routes';
 import { render, screen, waitFor, within } from '../test/react_testing_library';
 import { GeographyScreen } from './geography_screen';
-import { hasSplits } from './utils';
 
 let apiMock: MockApiClient;
 
@@ -220,7 +222,7 @@ describe('Districts tab', () => {
     // deleted district from any precincts/splits that reference it)
     assert(electionRecord.precincts.length === 3);
     assert(hasSplits(electionRecord.precincts[1]));
-    const precinctsWithDeletedDistrict: Precinct[] = [
+    const precinctsWithDeletedDistrict: SplittablePrecinct[] = [
       {
         ...electionRecord.precincts[0],
         districtIds: [remainingDistrict.id],
@@ -316,7 +318,7 @@ describe('Precincts tab', () => {
   test('adding a precinct', async () => {
     const { election } = electionWithNoPrecinctsRecord;
     const electionId = election.id;
-    const newPrecinct: Precinct = {
+    const newPrecinct: SplittablePrecinct = {
       id: idFactory.next(),
       name: 'New Precinct',
       districtIds: [election.districts[0].id, election.districts[1].id],

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -29,10 +29,12 @@ import {
   DistrictId,
   Election,
   ElectionId,
+  hasSplits,
   PrecinctId,
+  PrecinctSplit,
+  SplittablePrecinct,
 } from '@votingworks/types';
 import { assert } from '@votingworks/basics';
-import type { Precinct, PrecinctSplit } from '@votingworks/design-backend';
 import styled from 'styled-components';
 import { ElectionNavScreen } from './nav_screen';
 import { ElectionIdParams, electionParamRoutes, routes } from './routes';
@@ -52,7 +54,7 @@ import {
   updateElection,
   updatePrecincts,
 } from './api';
-import { generateId, hasSplits, replaceAtIndex } from './utils';
+import { generateId, replaceAtIndex } from './utils';
 import { ImageInput } from './image_input';
 import { useElectionFeatures, useUserFeatures } from './features_context';
 import { SealImageInput } from './seal_image_input';
@@ -137,7 +139,7 @@ function DistrictForm({
   electionId: ElectionId;
   districtId?: string;
   savedElection: Election;
-  savedPrecincts?: Precinct[];
+  savedPrecincts?: SplittablePrecinct[];
 }): JSX.Element | null {
   const savedDistricts = savedElection.districts;
   const [district, setDistrict] = useState<District | undefined>(
@@ -479,7 +481,7 @@ function PrecinctsTab(): JSX.Element | null {
   );
 }
 
-function createBlankPrecinct(): Precinct {
+function createBlankPrecinct(): SplittablePrecinct {
   return {
     name: '',
     id: generateId(),
@@ -501,12 +503,12 @@ function PrecinctForm({
 }: {
   electionId: ElectionId;
   precinctId?: PrecinctId;
-  savedPrecincts: Precinct[];
+  savedPrecincts: SplittablePrecinct[];
   districts: readonly District[];
 }): JSX.Element | null {
   const userFeatures = useUserFeatures();
   const electionFeatures = useElectionFeatures();
-  const [precinct, setPrecinct] = useState<Precinct | undefined>(
+  const [precinct, setPrecinct] = useState<SplittablePrecinct | undefined>(
     precinctId
       ? savedPrecincts.find((p) => p.id === precinctId)
       : // To make mocked IDs predictable in tests, we pass a function here
@@ -525,7 +527,7 @@ function PrecinctForm({
     return null;
   }
 
-  function onSubmit(updatedPrecinct: Precinct) {
+  function onSubmit(updatedPrecinct: SplittablePrecinct) {
     const newPrecincts = precinctId
       ? savedPrecincts.map((p) => (p.id === precinctId ? updatedPrecinct : p))
       : [...savedPrecincts, updatedPrecinct];

--- a/apps/design/frontend/src/utils.ts
+++ b/apps/design/frontend/src/utils.ts
@@ -1,10 +1,5 @@
 import { assert } from '@votingworks/basics';
-import type { Precinct, PrecinctWithSplits } from '@votingworks/design-backend';
 import { customAlphabet } from 'nanoid';
-
-export function hasSplits(precinct: Precinct): precinct is PrecinctWithSplits {
-  return 'splits' in precinct && precinct.splits !== undefined;
-}
 
 const idGenerator = customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', 12);
 

--- a/libs/backend/src/language_and_audio/ballot_strings.ts
+++ b/libs/backend/src/language_and_audio/ballot_strings.ts
@@ -77,13 +77,16 @@ export async function translateHmpbStrings(
  * Translates (or loads from the translation cache) a UI strings package for
  * HMPB rendering. Includes all election strings and app strings.
  */
-export async function translateBallotStrings(
+export async function translateElectionAndHmpbStrings(
   translator: GoogleCloudTranslator,
   election: Election,
   hmpbStringsCatalog: Record<string, string>,
   ballotLanguageConfigs: BallotLanguageConfigs,
   precincts: SplittablePrecinct[]
-): Promise<UiStringsPackage> {
+): Promise<{
+  electionStrings: UiStringsPackage;
+  hmpbStrings: UiStringsPackage;
+}> {
   const userDefinedHmpbStrings = getUserDefinedHmpbStrings(precincts);
   const combinedHmpbStringsCatalog: Record<string, string> = {
     ...hmpbStringsCatalog,
@@ -100,5 +103,25 @@ export async function translateBallotStrings(
     combinedHmpbStringsCatalog,
     ballotLanguageConfigs
   );
+
+  return { electionStrings, hmpbStrings };
+}
+
+/**
+ * Translates (or loads from the translation cache) HMPB and election strings,
+ * then merges the results into a single UiStringsPackage.
+ * Includes all election strings and app strings needed for HMPB rendering.
+ */
+export async function translateBallotStrings(
+  ...args: [
+    GoogleCloudTranslator,
+    Election,
+    Record<string, string>,
+    BallotLanguageConfigs,
+    SplittablePrecinct[],
+  ]
+): Promise<UiStringsPackage> {
+  const { electionStrings, hmpbStrings } =
+    await translateElectionAndHmpbStrings(...args);
   return mergeUiStrings(electionStrings, hmpbStrings);
 }

--- a/libs/backend/src/language_and_audio/election_package_string.test.ts
+++ b/libs/backend/src/language_and_audio/election_package_string.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test, vi } from 'vitest';
 import { electionPrimaryPrecinctSplitsFixtures } from '@votingworks/fixtures';
-import { LanguageCode, BallotLanguageConfigs } from '@votingworks/types';
+import {
+  LanguageCode,
+  BallotLanguageConfigs,
+  generateSplittablePrecinctsForTest,
+} from '@votingworks/types';
 import { assert } from '@votingworks/basics';
 import { getAllStringsForElectionPackage } from './election_package_strings';
 import { GoogleCloudTranslator } from './translator';
@@ -24,12 +28,14 @@ describe('getAllStringsForElectionPackage', () => {
       fn: vi.fn,
     });
     const mockTranslator = new GoogleCloudTranslator({ translationClient });
+    const election = electionPrimaryPrecinctSplitsFixtures.readElection();
     const [appStrings, hmpbStrings, electionStrings] =
       await getAllStringsForElectionPackage(
-        electionPrimaryPrecinctSplitsFixtures.readElection(),
+        election,
         mockTranslator,
         mockHmpbStringsCatalog,
-        allBallotLanguages
+        allBallotLanguages,
+        generateSplittablePrecinctsForTest(election)
       );
 
     expect(appStrings).toBeDefined();

--- a/libs/backend/src/language_and_audio/election_package_strings.ts
+++ b/libs/backend/src/language_and_audio/election_package_strings.ts
@@ -6,11 +6,7 @@ import {
 } from '@votingworks/types';
 import { GoogleCloudTranslator } from './translator';
 import { translateAppStrings } from './app_strings';
-import {
-  getUserDefinedHmpbStrings,
-  translateHmpbStrings,
-} from './ballot_strings';
-import { extractAndTranslateElectionStrings } from './election_strings';
+import { translateElectionAndHmpbStrings } from './ballot_strings';
 
 /**
  * Helper function to generate all necessary strings used in an election package.
@@ -23,25 +19,18 @@ export async function getAllStringsForElectionPackage(
   ballotLanguageConfigs: BallotLanguageConfigs,
   precincts: SplittablePrecinct[]
 ): Promise<[UiStringsPackage, UiStringsPackage, UiStringsPackage]> {
-  const userDefinedHmpbStrings = getUserDefinedHmpbStrings(precincts);
-  const combinedHmpbStringsCatalog: Record<string, string> = {
-    ...hmpbStringsCatalog,
-    ...userDefinedHmpbStrings,
-  };
+  const { hmpbStrings, electionStrings } =
+    await translateElectionAndHmpbStrings(
+      translator,
+      election,
+      hmpbStringsCatalog,
+      ballotLanguageConfigs,
+      precincts
+    );
 
   const appStrings = await translateAppStrings(
     translator,
     'latest',
-    ballotLanguageConfigs
-  );
-  const hmpbStrings = await translateHmpbStrings(
-    translator,
-    combinedHmpbStringsCatalog,
-    ballotLanguageConfigs
-  );
-  const electionStrings = await extractAndTranslateElectionStrings(
-    translator,
-    election,
     ballotLanguageConfigs
   );
 

--- a/libs/backend/src/language_and_audio/election_package_strings.ts
+++ b/libs/backend/src/language_and_audio/election_package_strings.ts
@@ -1,11 +1,15 @@
 import {
   BallotLanguageConfigs,
   Election,
+  SplittablePrecinct,
   UiStringsPackage,
 } from '@votingworks/types';
 import { GoogleCloudTranslator } from './translator';
 import { translateAppStrings } from './app_strings';
-import { translateHmpbStrings } from './ballot_strings';
+import {
+  getUserDefinedHmpbStrings,
+  translateHmpbStrings,
+} from './ballot_strings';
 import { extractAndTranslateElectionStrings } from './election_strings';
 
 /**
@@ -16,8 +20,15 @@ export async function getAllStringsForElectionPackage(
   election: Election,
   translator: GoogleCloudTranslator,
   hmpbStringsCatalog: Record<string, string>,
-  ballotLanguageConfigs: BallotLanguageConfigs
+  ballotLanguageConfigs: BallotLanguageConfigs,
+  precincts: SplittablePrecinct[]
 ): Promise<[UiStringsPackage, UiStringsPackage, UiStringsPackage]> {
+  const userDefinedHmpbStrings = getUserDefinedHmpbStrings(precincts);
+  const combinedHmpbStringsCatalog: Record<string, string> = {
+    ...hmpbStringsCatalog,
+    ...userDefinedHmpbStrings,
+  };
+
   const appStrings = await translateAppStrings(
     translator,
     'latest',
@@ -25,7 +36,7 @@ export async function getAllStringsForElectionPackage(
   );
   const hmpbStrings = await translateHmpbStrings(
     translator,
-    hmpbStringsCatalog,
+    combinedHmpbStringsCatalog,
     ballotLanguageConfigs
   );
   const electionStrings = await extractAndTranslateElectionStrings(

--- a/libs/fixture-generators/src/generate-election-package/generate_election_package.test.ts
+++ b/libs/fixture-generators/src/generate-election-package/generate_election_package.test.ts
@@ -14,6 +14,7 @@ import {
   mergeUiStrings,
   getBallotLanguageConfigs,
   LanguageCode,
+  generateSplittablePrecinctsForTest,
 } from '@votingworks/types';
 import {
   Renderer,
@@ -77,7 +78,8 @@ describe('fixtures are up to date - run `pnpm generate-election-packages` if thi
             isMultiLanguage
               ? Object.values(LanguageCode)
               : [LanguageCode.ENGLISH]
-          )
+          ),
+          generateSplittablePrecinctsForTest(baseElection)
         );
       const newCombinedStrings = mergeUiStrings(
         newAppStrings,

--- a/libs/fixture-generators/src/generate-election-package/generate_election_package.ts
+++ b/libs/fixture-generators/src/generate-election-package/generate_election_package.ts
@@ -15,6 +15,7 @@ import {
   ElectionPackage,
   ElectionPackageFileName,
   ElectionPackageMetadata,
+  generateSplittablePrecinctsForTest,
   getBallotLanguageConfigs,
   LanguageCode,
   LATEST_METADATA,
@@ -63,7 +64,8 @@ export async function generateElectionPackage(
       election,
       translator,
       hmpbStringsCatalog,
-      ballotLanguageConfigs
+      ballotLanguageConfigs,
+      generateSplittablePrecinctsForTest(election)
     );
 
   zip.file(

--- a/libs/hmpb/src/ballot_templates/index.ts
+++ b/libs/hmpb/src/ballot_templates/index.ts
@@ -2,10 +2,7 @@ import { nhBallotTemplate } from './nh_ballot_template';
 import { nhBallotTemplateV3 } from './v3_nh_ballot_template';
 import { vxDefaultBallotTemplate } from './vx_default_ballot_template';
 
-export type {
-  NhBallotProps,
-  NhPrecinctSplitOptions,
-} from './nh_ballot_template';
+export type { NhBallotProps } from './nh_ballot_template';
 
 /**
  * All ballot templates, indexed by ID.

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -14,6 +14,7 @@ import {
   BallotType,
   CandidateContest as CandidateContestStruct,
   Election,
+  NhPrecinctSplitOptions,
   YesNoContest,
   ballotPaperDimensions,
   getBallotStyle,
@@ -54,13 +55,6 @@ import { BallotMode, PixelDimensions } from '../types';
 import { hmpbStrings } from '../hmpb_strings';
 import { layOutInColumns } from '../layout_in_columns';
 import { Watermark } from './watermark';
-
-export interface NhPrecinctSplitOptions {
-  electionTitleOverride?: string;
-  electionSealOverride?: string;
-  clerkSignatureImage?: string;
-  clerkSignatureCaption?: string;
-}
 
 function Header({
   election,

--- a/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
@@ -14,6 +14,7 @@ import {
   BallotType,
   CandidateContest as CandidateContestStruct,
   Election,
+  NhPrecinctSplitOptions,
   YesNoContest,
   ballotPaperDimensions,
   getBallotStyle,
@@ -51,7 +52,7 @@ import {
 import { BallotMode, PixelDimensions } from '../types';
 import { hmpbStrings } from '../hmpb_strings';
 import { layOutInColumns } from '../layout_in_columns';
-import { NhBallotProps, NhPrecinctSplitOptions } from './nh_ballot_template';
+import { NhBallotProps } from './nh_ballot_template';
 import { Watermark } from './watermark';
 
 const Colors = {

--- a/libs/types/src/election.test.ts
+++ b/libs/types/src/election.test.ts
@@ -43,6 +43,8 @@ import {
   WriteInIdSchema,
   YesNoContest,
   BmdBallotPaperSize,
+  hasSplits,
+  DistrictId,
 } from './election';
 import { safeParse, safeParseJson, unsafeParse } from './generic';
 import {
@@ -625,4 +627,31 @@ test('ballotPaperDimensions', () => {
     width: 8,
     height: 13.25,
   });
+});
+
+test('hasSplits', () => {
+  const districtIds: DistrictId[] = ['district-1' as DistrictId];
+  const precincts = [
+    {
+      id: 'precinct-1',
+      name: 'Precinct 1',
+      splits: [
+        {
+          districtIds,
+          id: 'split-a',
+          name: 'Split A',
+          clerkSignatureCaption: 'Signature',
+          electionTitleOverride: 'Title',
+        },
+      ],
+    },
+    {
+      id: 'precinct-2',
+      name: 'Precinct 2',
+      districtIds,
+    },
+  ];
+
+  expect(hasSplits(precincts[0])).toEqual(true);
+  expect(hasSplits(precincts[1])).toEqual(false);
 });

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -513,6 +513,7 @@ export interface Election {
   readonly state: string;
   readonly title: string;
   readonly type: ElectionType;
+  readonly additionalHashInput?: Record<string, unknown>;
 }
 export const ElectionSchema: z.ZodSchema<Election> = z
   .object({
@@ -531,6 +532,7 @@ export const ElectionSchema: z.ZodSchema<Election> = z
     state: z.string().nonempty(),
     title: z.string().nonempty(),
     type: ElectionTypeSchema,
+    additionalHashInput: z.record(z.any()).optional(),
   })
   .superRefine((election, ctx) => {
     for (const [

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -983,3 +983,43 @@ export interface CompletedBallot {
   readonly isTestMode: boolean;
   readonly ballotType: BallotType;
 }
+
+/**
+ * Precinct splits
+ */
+
+export interface NhPrecinctSplitOptions {
+  electionTitleOverride?: string;
+  electionSealOverride?: string;
+  clerkSignatureImage?: string;
+  clerkSignatureCaption?: string;
+}
+
+export interface PrecinctWithoutSplits {
+  districtIds: readonly DistrictId[];
+  id: PrecinctId;
+  name: string;
+}
+export interface PrecinctWithSplits {
+  id: PrecinctId;
+  name: string;
+  splits: readonly PrecinctSplit[];
+}
+interface PrecinctSplitBase {
+  districtIds: readonly DistrictId[];
+  id: Id;
+  name: string;
+}
+
+export type PrecinctSplit = PrecinctSplitBase & NhPrecinctSplitOptions;
+
+export type SplittablePrecinct = PrecinctWithoutSplits | PrecinctWithSplits;
+
+export function hasSplits(precinct: Precinct): precinct is PrecinctWithSplits {
+  return 'splits' in precinct && precinct.splits !== undefined;
+}
+
+export interface PrecinctOrSplitId {
+  precinctId: PrecinctId;
+  splitId?: Id;
+}

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -38,6 +38,7 @@ export * from './precinct_selection';
 export * from './system_settings';
 export * as Tabulation from './tabulation';
 export * from './tallies';
+export * from './test_utils';
 export * from './ui_audio_controls';
 export * from './ui_string_audio_clips';
 export * from './ui_string_audio_ids';

--- a/libs/types/src/test_utils.ts
+++ b/libs/types/src/test_utils.ts
@@ -1,0 +1,14 @@
+import { assertDefined } from '@votingworks/basics';
+import { Election, SplittablePrecinct } from './election';
+
+// istanbul ignore next - @preserve
+export function generateSplittablePrecinctsForTest(
+  sourceElection: Election
+): SplittablePrecinct[] {
+  return sourceElection.precincts.map(
+    (p): SplittablePrecinct => ({
+      ...p,
+      districtIds: [assertDefined(sourceElection.districts[0]).id],
+    })
+  );
+}


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/5975

Ensures that changes to precinct split-specific fields (text or image) update the election hash.

* Adds `additionalHashInput` to the shared `Election` type and the `election.json` file exported by VxDesign via test deck or election package export. Into this property we add hashes of precinct split signature and seal override images.
* Adds `electionTitleOverride` and `clerkSignatureCaption` to `hmpbStrings` in `election.json`

nb. I decided to write to `election.json` the hashes of the images, rather than the SVGs themselves, since we have seen images up to our max 5 MB and one election may have several precinct splits each with their own seal override and signature. See [discussion](https://votingworks.slack.com/archives/C014MGC0WRE/p1738905661981559) that confirms this does not meaningfully increase chance of hash collision.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/1ba0dda7-8281-4a06-a3bf-5902d297ba57




## Testing Plan
- added test for new utility functions
- manually verified election.json output

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
