### PR TITLE
feat(design): update `title` based on the screen

### DIFF
--- a/apps/design/frontend/src/ballot_order_info_screen.tsx
+++ b/apps/design/frontend/src/ballot_order_info_screen.tsx
@@ -24,6 +24,8 @@ import {
 } from './api';
 import { Form, FormActionsRow, InputGroup, Row } from './layout';
 import { ElectionNavScreen } from './nav_screen';
+import { routes } from './routes';
+import { useTitle } from './hooks/use_title';
 
 export const StyledForm = styled(Form)`
   width: 30rem;
@@ -317,6 +319,10 @@ export function BallotOrderInfoScreen(): JSX.Element | null {
   );
   const getElectionQuery = getElection.useQuery(electionId);
   const getBallotsFinalizedAtQuery = getBallotsFinalizedAt.useQuery(electionId);
+  useTitle(
+    routes.election(electionId).ballotOrderInfo.title,
+    getElectionQuery.data?.election.title
+  );
 
   if (!getElectionQuery.isSuccess || !getBallotsFinalizedAtQuery.isSuccess) {
     return null;

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -40,6 +40,7 @@ import { ElectionIdParams, electionParamRoutes, routes } from './routes';
 import { hasSplits } from './utils';
 import { BallotScreen, paperSizeLabels } from './ballot_screen';
 import { useUserFeatures } from './features_context';
+import { useTitle } from './hooks/use_title';
 
 function BallotDesignForm({
   electionId,
@@ -416,6 +417,11 @@ export function BallotsScreen(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
   const ballotsParamRoutes = electionParamRoutes.ballots;
   const ballotsRoutes = routes.election(electionId).ballots;
+  const getElectionQuery = getElection.useQuery(electionId);
+  useTitle(
+    routes.election(electionId).ballots.root.title,
+    getElectionQuery.data?.election.title
+  );
 
   return (
     <Switch>

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -55,6 +55,7 @@ import { ElectionIdParams, electionParamRoutes, routes } from './routes';
 import { getBallotsFinalizedAt, getElection, updateElection } from './api';
 import { generateId, reorderElement, replaceAtIndex } from './utils';
 import { RichTextEditor } from './rich_text_editor';
+import { useTitle } from './hooks/use_title';
 
 const ReorderableTr = styled.tr<{ isReordering: boolean }>`
   &:hover {
@@ -1307,6 +1308,11 @@ export function ContestsScreen(): JSX.Element {
   const { electionId } = useParams<ElectionIdParams>();
   const contestParamRoutes = electionParamRoutes.contests;
   const contestRoutes = routes.election(electionId).contests;
+  const getElectionQuery = getElection.useQuery(electionId);
+  useTitle(
+    routes.election(electionId).contests.root.title,
+    getElectionQuery.data?.election.title
+  );
   return (
     <ElectionNavScreen electionId={electionId}>
       <Switch>

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -24,6 +24,7 @@ import { ElectionNavScreen } from './nav_screen';
 import { routes } from './routes';
 import { useUserFeatures } from './features_context';
 import { SealImageInput } from './seal_image_input';
+import { useTitle } from './hooks/use_title';
 
 function hasBlankElectionInfo(electionInfo: ElectionInfo): boolean {
   return (
@@ -269,6 +270,10 @@ export function ElectionInfoScreen(): JSX.Element | null {
   );
   const getElectionInfoQuery = getElectionInfo.useQuery(electionId);
   const getBallotsFinalizedAtQuery = getBallotsFinalizedAt.useQuery(electionId);
+  useTitle(
+    routes.election(electionId).electionInfo.title,
+    getElectionInfoQuery.data?.title
+  );
 
   if (
     !getElectionInfoQuery.isSuccess ||

--- a/apps/design/frontend/src/elections_screen.tsx
+++ b/apps/design/frontend/src/elections_screen.tsx
@@ -26,6 +26,8 @@ import { Column, Row } from './layout';
 import { NavScreen } from './nav_screen';
 import { CreateElectionButton } from './create_election_button';
 import { useUserFeatures, UserFeaturesProvider } from './features_context';
+import { useTitle } from './hooks/use_title';
+import { routes } from './routes';
 
 const ButtonRow = styled.tr`
   cursor: pointer;
@@ -419,6 +421,7 @@ function ElectionsScreenContents(): JSX.Element | null {
 }
 
 export function ElectionsScreen(): JSX.Element {
+  useTitle(routes.root.title);
   return (
     <UserFeaturesProvider>
       <ElectionsScreenContents />

--- a/apps/design/frontend/src/export_screen.tsx
+++ b/apps/design/frontend/src/export_screen.tsx
@@ -33,10 +33,11 @@ import {
   unfinalizeBallots,
 } from './api';
 import { ElectionNavScreen } from './nav_screen';
-import { ElectionIdParams } from './routes';
+import { ElectionIdParams, routes } from './routes';
 import { downloadFile } from './utils';
 import { Column, FieldName, InputGroup } from './layout';
 import { useUserFeatures } from './features_context';
+import { useTitle } from './hooks/use_title';
 
 const ballotTemplateOptions = {
   VxDefaultBallot: 'VotingWorks Default Ballot',
@@ -50,6 +51,10 @@ export function ExportScreen(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
   const getElectionQuery = getElection.useQuery(electionId);
   const userFeatures = useUserFeatures();
+  useTitle(
+    routes.election(electionId).export.title,
+    getElectionQuery.data?.election.title
+  );
 
   const electionPackageQuery = getElectionPackage.useQuery(electionId);
   const exportElectionPackageMutation = exportElectionPackage.useMutation();

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -56,6 +56,7 @@ import { generateId, hasSplits, replaceAtIndex } from './utils';
 import { ImageInput } from './image_input';
 import { useElectionFeatures, useUserFeatures } from './features_context';
 import { SealImageInput } from './seal_image_input';
+import { useTitle } from './hooks/use_title';
 
 function DistrictsTab(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
@@ -935,6 +936,12 @@ export function GeographyScreen(): JSX.Element {
   const { electionId } = useParams<ElectionIdParams>();
   const geographyParamRoutes = electionParamRoutes.geography;
   const geographyRoutes = routes.election(electionId).geography;
+  const getElectionQuery = getElection.useQuery(electionId);
+  useTitle(
+    routes.election(electionId).geography.root.title,
+    getElectionQuery.data?.election.title
+  );
+
   return (
     <ElectionNavScreen electionId={electionId}>
       <Switch>

--- a/apps/design/frontend/src/hooks/use_title.test.ts
+++ b/apps/design/frontend/src/hooks/use_title.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, expect, test } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { setBaseTitle, useTitle } from './use_title';
 

--- a/apps/design/frontend/src/hooks/use_title.test.ts
+++ b/apps/design/frontend/src/hooks/use_title.test.ts
@@ -1,0 +1,54 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { setBaseTitle, useTitle } from './use_title';
+
+beforeEach(() => {
+  setBaseTitle('My Site');
+});
+
+test('null case', async () => {
+  const { unmount } = renderHook(() => useTitle());
+  expect(document.title).toEqual('My Site');
+  unmount();
+  await waitFor(() => {
+    expect(document.title).toEqual('My Site');
+  });
+});
+
+test('no base title', async () => {
+  setBaseTitle('');
+  const { unmount } = renderHook(() => useTitle('My Page'));
+  expect(document.title).toEqual('My Page');
+  unmount();
+  await waitFor(() => {
+    expect(document.title).toEqual('');
+  });
+});
+
+test('single title part', async () => {
+  const { unmount } = renderHook(() => useTitle('My Page'));
+  expect(document.title).toEqual('My Page – My Site');
+  unmount();
+  await waitFor(() => {
+    expect(document.title).toEqual('My Site');
+  });
+});
+
+test('multiple title parts', async () => {
+  const { unmount } = renderHook(() => useTitle('My Page', 'Resource Name'));
+  expect(document.title).toEqual('My Page – Resource Name – My Site');
+  unmount();
+  await waitFor(() => {
+    expect(document.title).toEqual('My Site');
+  });
+});
+
+test('empty title parts', async () => {
+  const { unmount } = renderHook(() =>
+    useTitle('a', '', 'b', undefined, 'c', null)
+  );
+  expect(document.title).toEqual('a – b – c – My Site');
+  unmount();
+  await waitFor(() => {
+    expect(document.title).toEqual('My Site');
+  });
+});

--- a/apps/design/frontend/src/hooks/use_title.ts
+++ b/apps/design/frontend/src/hooks/use_title.ts
@@ -1,0 +1,76 @@
+import { useEffect } from 'react';
+
+/* istanbul ignore next */
+let baseTitle: string | undefined | null =
+  document.getElementsByTagName('title')[0]?.textContent;
+
+/**
+ * Sets the base title to append to titles set by `useTitle`.
+ */
+export function setBaseTitle(title?: string | null): void {
+  baseTitle = title;
+}
+
+/**
+ * Tracks the timeout for resetting the document title to the base title.
+ * Shared across all instances of `useTitle` to allow one to cancel the reset
+ * when another updates the title.
+ */
+let resetToBaseTitleTimeout: ReturnType<typeof setTimeout> | undefined;
+
+/**
+ * Reset the document title to the base title after a short delay
+ * to avoid flickering when the title is updated in quick succession.
+ */
+function resetToBaseTitle() {
+  /* istanbul ignore next */
+  document.title = baseTitle ?? '';
+}
+
+/**
+ * Set the document title while the component is mounted, prepending it to the
+ * base title (which defaults to being extracted from the `<title>` tag).
+ *
+ * NOTE: In React 19, components can simply render a `<title>` element to set
+ * the document title. This hook is only useful for React 18 and below.
+ *
+ * @example
+ *
+ * ```tsx
+ * // Assuming the base title is "My Site"
+ * function MyComponent() {
+ *   // Sets the document title to "My Page – My Site"
+ *   useTitle('My Page');
+ *   return <div>My content</div>;
+ * }
+ * ```
+ *
+ *
+ * ```tsx
+ * // Assuming the base title is "My Site"
+ * function MyComponent() {
+ *   // Sets the document title to "My Page – Resource Name – My Site"
+ *   useTitle('My Page', 'Resource Name');
+ *   return <div>My content</div>;
+ * }
+ * ```
+ */
+export function useTitle(
+  ...titleParts: ReadonlyArray<string | null | undefined>
+): void {
+  const title = [...titleParts, baseTitle].filter((part) => part).join(' – ');
+
+  useEffect(() => {
+    if (resetToBaseTitleTimeout) {
+      // Cancel any pending title reset so we can set it now.
+      clearTimeout(resetToBaseTitleTimeout);
+      resetToBaseTitleTimeout = undefined;
+    }
+    document.title = title;
+    return () => {
+      // Reset the document title to the base title after a short delay
+      // to avoid flickering when the title is updated in quick succession.
+      resetToBaseTitleTimeout = setTimeout(resetToBaseTitle, 100);
+    };
+  }, [title]);
+}

--- a/apps/design/frontend/src/system_settings_screen.tsx
+++ b/apps/design/frontend/src/system_settings_screen.tsx
@@ -38,9 +38,10 @@ import { z } from 'zod';
 import type { BallotTemplateId } from '@votingworks/design-backend';
 import { Form, Column, Row, FormActionsRow, InputGroup } from './layout';
 import { ElectionNavScreen } from './nav_screen';
-import { ElectionIdParams } from './routes';
+import { ElectionIdParams, routes } from './routes';
 import { updateSystemSettings, getElection } from './api';
 import { useUserFeatures } from './features_context';
+import { useTitle } from './hooks/use_title';
 
 function safeParseFormValue<T>(
   schema: z.ZodSchema<T>,
@@ -539,6 +540,11 @@ export function SystemSettingsForm({
 export function SystemSettingsScreen(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
   const getElectionQuery = getElection.useQuery(electionId);
+
+  useTitle(
+    routes.election(electionId).systemSettings.title,
+    getElectionQuery.data?.election.title
+  );
 
   if (!getElectionQuery.isSuccess) {
     return null;


### PR DESCRIPTION
## Overview

Having the same document title for all pages makes it harder to navigate the site, especially when you have multiple tabs open.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/27378240-f09a-4e5f-bdbd-6263395b5f4f

## Testing Plan
Tested manually and added an automated test suite.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
