### PR TITLE
fix(design): improve `ContestsScreen` UX

### DIFF
--- a/apps/admin/frontend/src/components/reporting/filter_editor.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.tsx
@@ -279,7 +279,7 @@ export function FilterEditor({
                 assert(newFilterType !== undefined);
                 updateRowFilterType(rowId, newFilterType);
               }}
-              ariaLabel="Edit Filter Type"
+              aria-label="Edit Filter Type"
             />
             <Predicate>is</Predicate>
             <SearchSelect
@@ -295,7 +295,7 @@ export function FilterEditor({
               onChange={(filterValues) => {
                 updateRowFilterValues(rowId, filterValues);
               }}
-              ariaLabel="Select Filter Values"
+              aria-label="Select Filter Values"
             />
             <div>
               <RemoveButton
@@ -325,7 +325,7 @@ export function FilterEditor({
                 addRow(filterType);
                 setIsAddingRow(false);
               }}
-              ariaLabel="Select New Filter Type"
+              aria-label="Select New Filter Type"
             />
           ) : (
             <AddButton icon="Add" onPress={() => setIsAddingRow(true)}>

--- a/apps/admin/frontend/src/screens/reporting/single_precinct_tally_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/single_precinct_tally_report_screen.tsx
@@ -45,7 +45,7 @@ export function SinglePrecinctTallyReportScreen(): JSX.Element {
               label: precinct.name,
             }))}
             onChange={(value) => setPrecinctId(value)}
-            ariaLabel="Select Precinct"
+            aria-label="Select Precinct"
             style={{ width: '30rem' }}
             placeholder="Select a precinct..."
           />

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_tab.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_tab.tsx
@@ -295,7 +295,7 @@ export function ManualTalliesTab(): JSX.Element | null {
               <FieldName>Ballot Style</FieldName>
               <SearchSelect
                 id="selectBallotStyle"
-                ariaLabel="Ballot Style"
+                aria-label="Ballot Style"
                 options={selectableBallotStyles.map((bs) => ({
                   label: bs.id,
                   value: bs.id,
@@ -310,7 +310,7 @@ export function ManualTalliesTab(): JSX.Element | null {
               <FieldName>Precinct</FieldName>
               <SearchSelect
                 id="selectPrecinct"
-                ariaLabel="Precinct"
+                aria-label="Precinct"
                 options={selectablePrecincts.map((p) => ({
                   label: p.name,
                   value: p.id,
@@ -325,7 +325,7 @@ export function ManualTalliesTab(): JSX.Element | null {
               <FieldName>Voting Method</FieldName>
               <SearchSelect
                 id="selectBallotType"
-                ariaLabel="Voting Method"
+                aria-label="Voting Method"
                 options={selectableBallotTypes.map((bt) => ({
                   label: bt === 'absentee' ? 'Absentee' : 'Precinct',
                   value: bt,

--- a/apps/design/frontend/.eslintignore
+++ b/apps/design/frontend/.eslintignore
@@ -10,5 +10,4 @@
 /public
 
 src/app.test.tsx
-src/contests_screen.test.tsx
 src/geography_screen.test.tsx

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -192,9 +192,6 @@ describe('Contests tab', () => {
     // Set title
     userEvent.type(screen.getByLabelText('Title'), newContest.title);
 
-    // Try and fail to save
-    // userEvent.click(screen.getByRole('button', { name: 'Save' }));
-
     // Set district
     userEvent.click(screen.getByLabelText('District'));
     userEvent.click(screen.getByText(election.districts[0].name));

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -1,14 +1,28 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';
 import type { ElectionRecord } from '@votingworks/design-backend';
-import { CandidateContest, ElectionId, YesNoContest } from '@votingworks/types';
-import { assert, assertDefined } from '@votingworks/basics';
+import {
+  BallotStyleGroupIdSchema,
+  BallotStyleIdSchema,
+  CandidateContest,
+  DistrictIdSchema,
+  ElectionId,
+  ElectionIdSchema,
+  HmpbBallotPaperSize,
+  PartyIdSchema,
+  PrecinctIdSchema,
+  unsafeParse,
+  YesNoContest,
+} from '@votingworks/types';
+import { assert, assertDefined, DateWithoutTime } from '@votingworks/basics';
 import {
   MockApiClient,
   createMockApiClient,
+  nonVxUser,
   provideApi,
 } from '../test/api_helpers';
-import { generalElectionRecord, primaryElectionRecord } from '../test/fixtures';
+import { generalElectionRecord, makeElectionRecord } from '../test/fixtures';
 import {
   fireEvent,
   render,
@@ -25,11 +39,7 @@ let apiMock: MockApiClient;
 
 const idFactory = makeIdFactory();
 
-const user = {
-  orgId: 'org_123',
-  orgName: 'Example Org',
-  isVotingWorksUser: false,
-};
+const user = nonVxUser;
 
 beforeEach(() => {
   apiMock = createMockApiClient();
@@ -56,13 +66,74 @@ function renderScreen(electionId: ElectionId) {
   return history;
 }
 
-const electionWithNoContestsRecord: ElectionRecord = {
-  ...generalElectionRecord,
-  election: {
-    ...generalElectionRecord.election,
+const electionWithNoContestsRecord = makeElectionRecord(
+  {
+    id: unsafeParse(ElectionIdSchema, 'test-general-election'),
+    title: 'Test General Election',
+    type: 'general',
+    date: DateWithoutTime.today(),
+    state: 'CA',
+    county: { id: 'test-county', name: 'Test County' },
+    districts: [
+      {
+        id: unsafeParse(DistrictIdSchema, 'test-district-1'),
+        name: 'Test District 1',
+      },
+      {
+        id: unsafeParse(DistrictIdSchema, 'test-district-2'),
+        name: 'Test District 2',
+      },
+    ],
+    precincts: [
+      {
+        id: 'test-precinct-1',
+        name: 'Test Precinct 1',
+      },
+      {
+        id: 'test-precinct-2',
+        name: 'Test Precinct 2',
+      },
+    ],
+    ballotStyles: [
+      {
+        id: unsafeParse(BallotStyleIdSchema, 'test-ballot-style-1'),
+        groupId: unsafeParse(BallotStyleGroupIdSchema, 'test-ballot-group-1'),
+        districts: [unsafeParse(DistrictIdSchema, 'test-district-1')],
+        precincts: [unsafeParse(PrecinctIdSchema, 'test-precinct-1')],
+        partyId: unsafeParse(PartyIdSchema, 'test-party-1'),
+      },
+      {
+        id: unsafeParse(BallotStyleIdSchema, 'test-ballot-style-2'),
+        groupId: unsafeParse(BallotStyleGroupIdSchema, 'test-ballot-group-2'),
+        districts: [unsafeParse(DistrictIdSchema, 'test-district-1')],
+        precincts: [unsafeParse(PrecinctIdSchema, 'test-precinct-1')],
+        partyId: unsafeParse(PartyIdSchema, 'test-party-2'),
+      },
+    ],
     contests: [],
+    ballotLayout: {
+      metadataEncoding: 'qr-code',
+      paperSize: HmpbBallotPaperSize.Letter,
+    },
+    ballotStrings: {},
+    parties: [
+      {
+        id: unsafeParse(PartyIdSchema, 'test-party-1'),
+        name: 'Test Party 1',
+        fullName: 'Test Party 1',
+        abbrev: 'TP1',
+      },
+      {
+        id: unsafeParse(PartyIdSchema, 'test-party-2'),
+        name: 'Test Party 2',
+        fullName: 'Test Party 2',
+        abbrev: 'TP2',
+      },
+    ],
+    seal: '',
   },
-};
+  user.orgId
+);
 
 describe('Contests tab', () => {
   test('adding a candidate contest (general election)', async () => {
@@ -103,6 +174,7 @@ describe('Contests tab', () => {
       ],
     };
 
+    apiMock.getUser.expectRepeatedCallsWith().resolves(user);
     apiMock.getElection
       .expectCallWith({ electionId, user })
       .resolves(electionWithNoContestsRecord);
@@ -119,6 +191,9 @@ describe('Contests tab', () => {
 
     // Set title
     userEvent.type(screen.getByLabelText('Title'), newContest.title);
+
+    // Try and fail to save
+    // userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     // Set district
     userEvent.click(screen.getByLabelText('District'));
@@ -221,7 +296,117 @@ describe('Contests tab', () => {
   });
 
   test('editing a candidate contest (primary election)', async () => {
-    const { election } = primaryElectionRecord;
+    const electionRecord = makeElectionRecord(
+      {
+        id: unsafeParse(ElectionIdSchema, 'test-primary-election'),
+        title: 'Test Primary Election',
+        type: 'primary',
+        date: DateWithoutTime.today(),
+        state: 'CA',
+        county: { id: 'test-county', name: 'Test County' },
+        districts: [
+          {
+            id: unsafeParse(DistrictIdSchema, 'test-district-1'),
+            name: 'Test District 1',
+          },
+          {
+            id: unsafeParse(DistrictIdSchema, 'test-district-2'),
+            name: 'Test District 2',
+          },
+        ],
+        precincts: [
+          {
+            id: 'test-precinct-1',
+            name: 'Test Precinct 1',
+          },
+          {
+            id: 'test-precinct-2',
+            name: 'Test Precinct 2',
+          },
+        ],
+        ballotStyles: [
+          {
+            id: unsafeParse(BallotStyleIdSchema, 'test-ballot-style-1'),
+            groupId: unsafeParse(
+              BallotStyleGroupIdSchema,
+              'test-ballot-group-1'
+            ),
+            districts: [unsafeParse(DistrictIdSchema, 'test-district-1')],
+            precincts: [unsafeParse(PrecinctIdSchema, 'test-precinct-1')],
+            partyId: unsafeParse(PartyIdSchema, 'test-party-1'),
+          },
+          {
+            id: unsafeParse(BallotStyleIdSchema, 'test-ballot-style-2'),
+            groupId: unsafeParse(
+              BallotStyleGroupIdSchema,
+              'test-ballot-group-2'
+            ),
+            districts: [unsafeParse(DistrictIdSchema, 'test-district-1')],
+            precincts: [unsafeParse(PrecinctIdSchema, 'test-precinct-1')],
+            partyId: unsafeParse(PartyIdSchema, 'test-party-2'),
+          },
+        ],
+        parties: [
+          {
+            id: unsafeParse(PartyIdSchema, 'test-party-1'),
+            name: 'Test Party 1',
+            fullName: 'Test Party 1',
+            abbrev: 'TP1',
+          },
+          {
+            id: unsafeParse(PartyIdSchema, 'test-party-2'),
+            name: 'Test Party 2',
+            fullName: 'Test Party 2',
+            abbrev: 'TP2',
+          },
+        ],
+        contests: [
+          {
+            id: 'test-contest-1',
+            type: 'candidate',
+            title: 'Test Contest 1',
+            districtId: unsafeParse(DistrictIdSchema, 'test-district-1'),
+            seats: 1,
+            partyId: unsafeParse(PartyIdSchema, 'test-party-1'),
+            allowWriteIns: false,
+            candidates: [
+              {
+                id: 'test-candidate-1',
+                name: 'Test Candidate 1',
+                firstName: 'Test',
+                middleName: 'Candidate',
+                lastName: '1',
+                partyIds: [unsafeParse(PartyIdSchema, 'test-party-1')],
+              },
+              {
+                id: 'test-candidate-2',
+                name: 'Test Candidate 2',
+                firstName: 'Test',
+                middleName: 'Candidate',
+                lastName: '2',
+                partyIds: [unsafeParse(PartyIdSchema, 'test-party-1')],
+              },
+              {
+                id: 'test-candidate-3',
+                name: 'Test Candidate 3',
+                firstName: 'Test',
+                middleName: 'Candidate',
+                lastName: '3',
+                partyIds: [unsafeParse(PartyIdSchema, 'test-party-1')],
+              },
+            ],
+          },
+        ],
+        seal: '',
+        ballotLayout: {
+          metadataEncoding: 'qr-code',
+          paperSize: HmpbBallotPaperSize.Letter,
+        },
+        ballotStrings: {},
+      },
+      user.orgId
+    );
+    const { election } = electionRecord;
     const electionId = election.id;
     const savedContest = election.contests.find(
       (contest): contest is CandidateContest => contest.type === 'candidate'
@@ -261,14 +446,15 @@ describe('Contests tab', () => {
       ],
     };
 
+    apiMock.getUser.expectRepeatedCallsWith().resolves(user);
     apiMock.getElection
       .expectCallWith({ electionId, user })
-      .resolves(primaryElectionRecord);
+      .resolves(electionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Contests' });
-    screen.getByRole('tab', { name: 'Contests', selected: true });
+    await screen.findByRole('tab', { name: 'Contests', selected: true });
     screen.getByRole('columnheader', { name: 'Title' });
     screen.getByRole('columnheader', { name: 'District' });
     screen.getByRole('columnheader', { name: 'Party' });
@@ -332,7 +518,7 @@ describe('Contests tab', () => {
       const row = candidateRows[i + 1];
       expect(
         within(row).getByLabelText(`Candidate ${i + 1} First Name`)
-      ).toHaveValue(candidate.name);
+      ).toHaveValue(candidate.firstName);
       const party = election.parties.find(
         (p) => p.id === candidate.partyIds?.[0]
       )!;
@@ -383,7 +569,7 @@ describe('Contests tab', () => {
 
     // Save contest
     const electionWithChangedContestRecord: ElectionRecord = {
-      ...generalElectionRecord,
+      ...electionRecord,
       election: {
         ...election,
         contests: election.contests.map((contest) =>
@@ -404,7 +590,6 @@ describe('Contests tab', () => {
     userEvent.click(saveButton);
 
     await screen.findByRole('heading', { name: 'Contests' });
-    screen.getByRole('tab', { name: 'Contests', selected: true });
 
     const changedContestRow = screen
       .getByText(changedContest.title)
@@ -418,22 +603,11 @@ describe('Contests tab', () => {
     description: string;
     firstName: string;
     middleName?: string;
-    lastName?: string;
+    lastName: string;
     expectedNormalizedName: string;
   }
 
   const nameTestSpecs: NameTestSpec[] = [
-    {
-      description: 'first name only',
-      firstName: 'Thomas',
-      expectedNormalizedName: 'Thomas',
-    },
-    {
-      description: 'first and middle name',
-      firstName: 'Thomas',
-      middleName: 'Alva',
-      expectedNormalizedName: 'Thomas Alva',
-    },
     {
       description: 'first and last name',
       firstName: 'Thomas',
@@ -452,7 +626,7 @@ describe('Contests tab', () => {
       firstName: ' Thomas ',
       middleName: 'Alva',
       lastName: 'Edison ',
-      expectedNormalizedName: 'Thomas  Alva Edison',
+      expectedNormalizedName: 'Thomas Alva Edison',
     },
   ];
   test.each(nameTestSpecs)(
@@ -471,13 +645,14 @@ describe('Contests tab', () => {
           {
             id: idFactory.next(),
             name: expectedNormalizedName,
-            firstName,
-            middleName,
-            lastName,
+            firstName: firstName.trim(),
+            middleName: middleName?.trim(),
+            lastName: lastName.trim(),
           },
         ],
       };
 
+      apiMock.getUser.expectRepeatedCallsWith().resolves(user);
       apiMock.getElection
         .expectCallWith({ electionId, user })
         .resolves(electionWithNoContestsRecord);
@@ -582,7 +757,8 @@ describe('Contests tab', () => {
   );
 
   test('adding a ballot measure', async () => {
-    const { election } = generalElectionRecord;
+    const electionRecord = generalElectionRecord(user.orgId);
+    const { election } = electionRecord;
     const electionId = election.id;
     const id = idFactory.next();
     idFactory.next(); // Skip over the extra ballot measure ID created when switching to ballot measure type
@@ -602,9 +778,10 @@ describe('Contests tab', () => {
       },
     };
 
+    apiMock.getUser.expectRepeatedCallsWith().resolves(user);
     apiMock.getElection
       .expectCallWith({ electionId, user })
-      .resolves(generalElectionRecord);
+      .resolves(electionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
 
@@ -629,22 +806,21 @@ describe('Contests tab', () => {
       descriptionEditor.querySelector('.tiptap p')!,
       newContest.description
     );
+    await within(descriptionEditor).findByText(newContest.description);
 
-    userEvent.type(
-      screen.getByLabelText('First Option Label'),
-      newContest.yesOption.label
-    );
-    userEvent.type(
-      screen.getByLabelText('Second Option Label'),
-      newContest.noOption.label
-    );
+    const yesInput = screen.getByLabelText('First Option Label');
+    const noInput = screen.getByLabelText('Second Option Label');
+    userEvent.clear(yesInput);
+    userEvent.type(yesInput, newContest.yesOption.label);
+    userEvent.clear(noInput);
+    userEvent.type(noInput, newContest.noOption.label);
 
     await within(descriptionEditor).findByText(newContest.description);
     const descriptionHtml = `<p>${newContest.description}</p>`;
 
     // Save contest
     const electionWithNewContestRecord: ElectionRecord = {
-      ...generalElectionRecord,
+      ...electionRecord,
       election: {
         ...election,
         contests: [
@@ -687,7 +863,8 @@ describe('Contests tab', () => {
   });
 
   test('editing a ballot measure', async () => {
-    const { election } = generalElectionRecord;
+    const electionRecord = generalElectionRecord(user.orgId);
+    const { election } = electionRecord;
     const electionId = election.id;
     const savedContest = election.contests.find(
       (contest): contest is YesNoContest => contest.type === 'yesno'
@@ -713,9 +890,10 @@ describe('Contests tab', () => {
       },
     };
 
+    apiMock.getUser.expectRepeatedCallsWith().resolves(user);
     apiMock.getElection
       .expectCallWith({ electionId, user })
-      .resolves(generalElectionRecord);
+      .resolves(electionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
 
@@ -764,7 +942,7 @@ describe('Contests tab', () => {
 
     // Save contest
     const electionWithChangedContestRecord: ElectionRecord = {
-      ...generalElectionRecord,
+      ...electionRecord,
       election: {
         ...election,
         contests: election.contests.map((contest) =>
@@ -795,16 +973,18 @@ describe('Contests tab', () => {
   });
 
   test('reordering contests', async () => {
-    const { election } = generalElectionRecord;
+    const electionRecord = generalElectionRecord(user.orgId);
+    const { election } = electionRecord;
     const electionId = election.id;
     // Mock needed for react-flip-toolkit
-    window.matchMedia = jest.fn().mockImplementation(() => ({
+    window.matchMedia = vi.fn().mockImplementation(() => ({
       matches: false,
     }));
 
+    apiMock.getUser.expectRepeatedCallsWith().resolves(user);
     apiMock.getElection
       .expectCallWith({ electionId, user })
-      .resolves(generalElectionRecord);
+      .resolves(electionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
 
@@ -855,7 +1035,7 @@ describe('Contests tab', () => {
     expect(getRowOrder()).toEqual(newOrder);
 
     const reorderedElectionRecord: ElectionRecord = {
-      ...generalElectionRecord,
+      ...electionRecord,
       election: {
         ...election,
         contests: [
@@ -882,16 +1062,18 @@ describe('Contests tab', () => {
   });
 
   test('changing contests is disabled when ballots are finalized', async () => {
-    const { election } = generalElectionRecord;
+    const electionRecord = generalElectionRecord(user.orgId);
+    const { election } = electionRecord;
     const electionId = election.id;
     // Mock needed for react-flip-toolkit
-    window.matchMedia = jest.fn().mockImplementation(() => ({
+    window.matchMedia = vi.fn().mockImplementation(() => ({
       matches: false,
     }));
 
+    apiMock.getUser.expectRepeatedCallsWith().resolves(user);
     apiMock.getElection
       .expectCallWith({ electionId, user })
-      .resolves(generalElectionRecord);
+      .resolves(electionRecord);
     apiMock.getBallotsFinalizedAt
       .expectCallWith({ electionId })
       .resolves(new Date());

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -479,6 +479,7 @@ function ContestForm({
       </InputGroup>
       <InputGroup label="District">
         <SearchSelect
+          aria-label="District"
           value={contest.districtId}
           onChange={(value) =>
             setContest({ ...contest, districtId: value ?? ('' as DistrictId) })
@@ -516,7 +517,7 @@ function ContestForm({
           {savedElection.type === 'primary' && (
             <InputGroup label="Party">
               <SearchSelect
-                ariaLabel="Party"
+                aria-label="Party"
                 options={[
                   { value: '' as PartyId, label: 'No Party Affiliation' },
                   ...savedElection.parties.map((party) => ({
@@ -671,7 +672,7 @@ function ContestForm({
                       </TD>
                       <TD>
                         <SearchSelect
-                          ariaLabel={`Candidate ${index + 1} Party`}
+                          aria-label={`Candidate ${index + 1} Party`}
                           options={[
                             {
                               value: '' as PartyId,

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -742,18 +742,16 @@ function ContestForm({
 
       {contest.type === 'yesno' && (
         <React.Fragment>
-          <div>
-            <FieldName>Description</FieldName>
+          <InputGroup label="Description">
             <RichTextEditor
               initialHtmlContent={contest.description}
               onChange={(htmlContent) =>
                 setContest({ ...contest, description: htmlContent })
               }
             />
-          </div>
+          </InputGroup>
 
-          <div>
-            <FieldName>First Option Label</FieldName>
+          <InputGroup label="First Option Label">
             <input
               type="text"
               value={contest.yesOption.label}
@@ -766,10 +764,9 @@ function ContestForm({
               autoComplete="off"
               style={{ width: '4rem' }}
             />
-          </div>
+          </InputGroup>
 
-          <div>
-            <FieldName>Second Option Label</FieldName>
+          <InputGroup label="Second Option Label">
             <input
               type="text"
               value={contest.noOption.label}
@@ -782,7 +779,7 @@ function ContestForm({
               autoComplete="off"
               style={{ width: '4rem' }}
             />
-          </div>
+          </InputGroup>
         </React.Fragment>
       )}
 

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -26,7 +26,8 @@ import {
 import {
   AnyContest,
   Candidate,
-  CandidateContest,
+  CandidateContestSchema,
+  CandidateId,
   ContestId,
   Contests,
   DistrictId,
@@ -34,11 +35,13 @@ import {
   ElectionId,
   Party,
   PartyId,
-  YesNoContest,
+  safeParse,
+  YesNoContestSchema,
 } from '@votingworks/types';
-import { assert, find } from '@votingworks/basics';
+import { assert, find, Result, throwIllegalValue } from '@votingworks/basics';
 import styled from 'styled-components';
 import { Flipper, Flipped } from 'react-flip-toolkit';
+import { z } from 'zod';
 import {
   FieldName,
   Form,
@@ -61,6 +64,97 @@ const ReorderableTr = styled.tr<{ isReordering: boolean }>`
 
 const FILTER_ALL = 'all';
 const FILTER_NONPARTISAN = 'nonpartisan';
+
+interface DraftCandidate {
+  id: CandidateId;
+  firstName: string;
+  middleName: string;
+  lastName: string;
+  partyIds?: PartyId[];
+}
+
+interface DraftCandidateContest {
+  id: ContestId;
+  type: 'candidate';
+  districtId?: DistrictId;
+  title: string;
+  termDescription?: string;
+  seats: number;
+  allowWriteIns: boolean;
+  candidates: DraftCandidate[];
+  partyId?: PartyId;
+}
+
+interface DraftYesNoContest {
+  id: ContestId;
+  type: 'yesno';
+  districtId?: DistrictId;
+  title: string;
+  description: string;
+  yesOption: { id: string; label: string };
+  noOption: { id: string; label: string };
+}
+
+type DraftContest = DraftCandidateContest | DraftYesNoContest;
+
+function draftCandidateFromCandidate(candidate: Candidate): DraftCandidate {
+  let firstName = candidate.firstName ?? '';
+  let middleName = candidate.middleName ?? '';
+  let lastName = candidate.lastName ?? '';
+
+  if (!firstName && !middleName && !lastName) {
+    const [firstPart, ...middleParts] = candidate.name.split(' ');
+    firstName = firstPart ?? '';
+    lastName = middleParts.pop() ?? '';
+    middleName = middleParts.join(' ');
+  }
+
+  return {
+    id: candidate.id,
+    firstName,
+    middleName,
+    lastName,
+    partyIds: candidate.partyIds?.slice(),
+  };
+}
+
+function draftContestFromContest(contest: AnyContest): DraftContest {
+  switch (contest.type) {
+    case 'candidate':
+      return {
+        ...contest,
+        candidates: contest.candidates.map(draftCandidateFromCandidate),
+      };
+    case 'yesno':
+      return { ...contest };
+    default:
+      throwIllegalValue(contest, 'type');
+  }
+}
+
+function tryContestFromDraftContest(
+  draftContest: DraftContest
+): Result<AnyContest, z.ZodError> {
+  switch (draftContest.type) {
+    case 'candidate':
+      return safeParse(CandidateContestSchema, {
+        ...draftContest,
+        candidates: draftContest.candidates.map((candidate) => ({
+          ...candidate,
+          name: [candidate.firstName, candidate.middleName, candidate.lastName]
+            .map((part) => part.trim())
+            .filter((part) => part)
+            .join(' '),
+        })),
+      });
+
+    case 'yesno':
+      return safeParse(YesNoContestSchema, draftContest);
+
+    default:
+      throwIllegalValue(draftContest, 'type');
+  }
+}
 
 function ContestsTab(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
@@ -311,11 +405,10 @@ function ContestsTab(): JSX.Element | null {
   );
 }
 
-function createBlankCandidateContest(): CandidateContest {
+function createBlankCandidateContest(): DraftCandidateContest {
   return {
     id: generateId(),
     type: 'candidate',
-    districtId: '' as DistrictId,
     title: '',
     seats: 1,
     allowWriteIns: true,
@@ -323,11 +416,10 @@ function createBlankCandidateContest(): CandidateContest {
   };
 }
 
-function createBlankYesNoContest(): YesNoContest {
+function createBlankYesNoContest(): DraftYesNoContest {
   return {
     id: generateId(),
     type: 'yesno',
-    districtId: '' as DistrictId,
     title: '',
     description: '',
     yesOption: {
@@ -341,10 +433,12 @@ function createBlankYesNoContest(): YesNoContest {
   };
 }
 
-function createBlankCandidate(): Candidate {
+function createBlankCandidate(): DraftCandidate {
   return {
     id: generateId(),
-    name: '',
+    firstName: '',
+    middleName: '',
+    lastName: '',
   };
 }
 
@@ -358,9 +452,11 @@ function ContestForm({
   savedElection: Election;
 }): JSX.Element | null {
   const savedContests = savedElection.contests;
+  const savedContest =
+    contestId && savedContests.find((c) => c.id === contestId);
   const [contest, setContest] = useState(
-    contestId
-      ? savedContests.find((c) => c.id === contestId)
+    savedContest
+      ? draftContestFromContest(savedContest)
       : // To make mocked IDs predictable in tests, we pass a function here
         // so it will only be called on initial render.
         createBlankCandidateContest
@@ -377,10 +473,12 @@ function ContestForm({
     return null;
   }
 
-  function onSubmit(updatedContest: AnyContest) {
+  function onSubmit(updatedContest: DraftContest) {
+    const validatedContest =
+      tryContestFromDraftContest(updatedContest).unsafeUnwrap();
     const newContests = contestId
-      ? savedContests.map((c) => (c.id === contestId ? updatedContest : c))
-      : [...savedContests, updatedContest];
+      ? savedContests.map((c) => (c.id === contestId ? validatedContest : c))
+      : [...savedContests, validatedContest];
     updateElectionMutation.mutate(
       {
         electionId,
@@ -428,8 +526,8 @@ function ContestForm({
   }
 
   function onNameChange(
-    contestToUpdate: CandidateContest,
-    candidate: Candidate,
+    contestToUpdate: DraftCandidateContest,
+    candidate: DraftCandidate,
     index: number,
     nameParts: {
       first?: string;
@@ -437,16 +535,15 @@ function ContestForm({
       last?: string;
     }
   ) {
-    const { first, middle, last } = nameParts;
-    const fullName = [first, middle, last]
-      .filter((part) => !!part)
-      .join(' ')
-      .trim();
+    const {
+      first = candidate.firstName,
+      middle = candidate.middleName,
+      last = candidate.lastName,
+    } = nameParts;
     setContest({
       ...contestToUpdate,
       candidates: replaceAtIndex(contestToUpdate.candidates, index, {
         ...candidate,
-        name: fullName,
         firstName: first,
         middleName: middle,
         lastName: last,
@@ -480,10 +577,10 @@ function ContestForm({
       <InputGroup label="District">
         <SearchSelect
           aria-label="District"
-          value={contest.districtId}
-          onChange={(value) =>
-            setContest({ ...contest, districtId: value ?? ('' as DistrictId) })
-          }
+          value={contest.districtId || undefined}
+          onChange={(value) => {
+            setContest({ ...contest, districtId: value || undefined });
+          }}
           options={[
             { value: '' as DistrictId, label: '' },
             ...savedElection.districts.map((district) => ({
@@ -491,6 +588,7 @@ function ContestForm({
               label: district.name,
             })),
           ]}
+          required
         />
       </InputGroup>
       <SegmentedButton
@@ -603,15 +701,12 @@ function ContestForm({
                         <input
                           aria-label={`Candidate ${index + 1} First Name`}
                           type="text"
-                          // Fall back to candidate.name for backwards compatibility
-                          value={candidate.firstName || candidate.name || ''}
+                          value={candidate.firstName}
                           // eslint-disable-next-line jsx-a11y/no-autofocus
                           autoFocus
                           onChange={(e) =>
                             onNameChange(contest, candidate, index, {
                               first: e.target.value,
-                              middle: candidate.middleName,
-                              last: candidate.lastName,
                             })
                           }
                           onBlur={(e) =>
@@ -684,7 +779,7 @@ function ContestForm({
                             })),
                           ]}
                           // Only support one party per candidate for now
-                          value={candidate.partyIds?.[0] ?? ('' as PartyId)}
+                          value={candidate.partyIds?.[0]}
                           onChange={(value) =>
                             setContest({
                               ...contest,
@@ -742,14 +837,15 @@ function ContestForm({
 
       {contest.type === 'yesno' && (
         <React.Fragment>
-          <InputGroup label="Description">
+          <div>
+            <FieldName>Description</FieldName>
             <RichTextEditor
               initialHtmlContent={contest.description}
               onChange={(htmlContent) =>
                 setContest({ ...contest, description: htmlContent })
               }
             />
-          </InputGroup>
+          </div>
 
           <InputGroup label="First Option Label">
             <input

--- a/apps/design/frontend/src/export_screen.tsx
+++ b/apps/design/frontend/src/export_screen.tsx
@@ -130,7 +130,7 @@ export function ExportScreen(): JSX.Element | null {
         <Column style={{ gap: '1rem' }}>
           <InputGroup label="Ballot Template">
             <SearchSelect
-              ariaLabel="Ballot Template"
+              aria-label="Ballot Template"
               value={ballotTemplateId}
               options={Object.entries(ballotTemplateOptions).map(
                 ([value, label]) => ({ value, label })

--- a/apps/design/frontend/tsconfig.json
+++ b/apps/design/frontend/tsconfig.json
@@ -15,11 +15,7 @@
     "noUncheckedIndexedAccess": false
   },
   "include": ["src", "test"],
-  "exclude": [
-    "src/app.test.tsx",
-    "src/contests_screen.test.tsx",
-    "src/geography_screen.test.tsx"
-  ],
+  "exclude": ["src/app.test.tsx", "src/geography_screen.test.tsx"],
   "references": [
     { "path": "../backend/tsconfig.build.json" },
     { "path": "../../../libs/basics/tsconfig.build.json" },

--- a/apps/design/frontend/vitest.config.ts
+++ b/apps/design/frontend/vitest.config.ts
@@ -5,11 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['test/setupTests.ts'],
-    exclude: [
-      'src/app.test.ts',
-      'src/contests_screen.test.tsx',
-      'src/geography_screen.test.tsx',
-    ],
+    exclude: ['src/app.test.ts', 'src/geography_screen.test.tsx'],
     clearMocks: true,
 
     coverage: {

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -340,7 +340,7 @@ export function ElectionManagerScreen({
       title="Election Manager Menu"
       voterFacing={false}
     >
-      <TabbedSection ariaLabel="Election Manager Menu" tabs={tabs} />
+      <TabbedSection aria-label="Election Manager Menu" tabs={tabs} />
 
       {isConfirmingBallotModeSwitch &&
         (() => (

--- a/libs/types/src/election.test.ts
+++ b/libs/types/src/election.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import * as fc from 'fast-check';
 import { sha256 } from 'js-sha256';
-import { find } from '@votingworks/basics';
+import { find, ok } from '@votingworks/basics';
 import {
   ballotPaperDimensions,
   getBallotStyle,
@@ -365,6 +365,39 @@ test('candidate schema', () => {
     name: 'Write-in',
     isWriteIn: true,
   }).unsafeUnwrap();
+
+  expect(
+    safeParse(CandidateSchema, {
+      id: 'bob-loblaw',
+      name: 'Bob Loblaw',
+      firstName: 'Bob',
+      middleName: 'Lob',
+      lastName: 'Loblaw',
+    })
+  ).toEqual(
+    ok({
+      id: 'bob-loblaw',
+      name: 'Bob Loblaw',
+      firstName: 'Bob',
+      middleName: 'Lob',
+      lastName: 'Loblaw',
+    })
+  );
+
+  expect(
+    safeParse(CandidateSchema, {
+      id: 'bob-loblaw',
+      name: 'Bob Loblaw',
+      firstName: '',
+      middleName: '',
+      lastName: '',
+    })
+  ).toEqual(
+    ok({
+      id: 'bob-loblaw',
+      name: 'Bob Loblaw',
+    })
+  );
 });
 
 test('write-in ID schema', () => {

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -120,10 +120,22 @@ export interface Candidate {
 export const CandidateSchema: z.ZodSchema<Candidate> = z
   .object({
     id: CandidateIdSchema,
-    name: z.string().nonempty(),
+    name: z.string().min(1),
     partyIds: z.array(PartyIdSchema).optional(),
     isWriteIn: z.boolean().optional(),
     writeInIndex: z.number().int().nonnegative().optional(),
+    firstName: z
+      .string()
+      .transform((s) => s.trim() || undefined)
+      .optional(),
+    middleName: z
+      .string()
+      .transform((s) => s.trim() || undefined)
+      .optional(),
+    lastName: z
+      .string()
+      .transform((s) => s.trim() || undefined)
+      .optional(),
   })
   .refine(
     ({ id, isWriteIn }) => !!isWriteIn === id.startsWith('write-in'),

--- a/libs/ui/src/change_precinct_button.tsx
+++ b/libs/ui/src/change_precinct_button.tsx
@@ -92,7 +92,7 @@ export function ChangePrecinctButton({
     <SearchSelect
       isMulti={false}
       placeholder={SELECT_PRECINCT_TEXT}
-      ariaLabel={SELECT_PRECINCT_TEXT}
+      aria-label={SELECT_PRECINCT_TEXT}
       options={[
         {
           value: ALL_PRECINCTS_OPTION_VALUE,

--- a/libs/ui/src/contest_choice_button.test.tsx
+++ b/libs/ui/src/contest_choice_button.test.tsx
@@ -15,10 +15,10 @@ test('renders with default accessible name', () => {
   screen.getByRole('option', { name: 'Cleopatra Ptolemaic' });
 });
 
-test('uses optional ariaLabel as accessible name', () => {
+test('uses optional aria-label as accessible name', () => {
   render(
     <ContestChoiceButton
-      ariaLabel="The Queen of Kings"
+      aria-label="The Queen of Kings"
       label="Cleopatra"
       choice="cleo"
       onPress={jest.fn()}

--- a/libs/ui/src/contest_choice_button.tsx
+++ b/libs/ui/src/contest_choice_button.tsx
@@ -7,7 +7,7 @@ import { Checkbox } from './checkbox';
 import { Caption, P } from './typography';
 
 export interface ContestChoiceButtonProps<T extends string = string> {
-  ariaLabel?: string;
+  'aria-label'?: string;
   caption?: React.ReactNode;
   choice: T;
   isSelected?: boolean;
@@ -82,8 +82,15 @@ const Label = styled(P)`
 export function ContestChoiceButton<T extends string>(
   props: ContestChoiceButtonProps<T>
 ): JSX.Element {
-  const { ariaLabel, caption, choice, gridArea, isSelected, label, onPress } =
-    props;
+  const {
+    'aria-label': ariaLabel,
+    caption,
+    choice,
+    gridArea,
+    isSelected,
+    label,
+    onPress,
+  } = props;
 
   const handlePress = useCallback(() => onPress(choice), [onPress, choice]);
 

--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -140,7 +140,7 @@ const ReadOnOpen = styled(ReadOnLoad)`
 
 /** Props for {@link Modal}. */
 export interface ModalProps {
-  ariaLabel?: string;
+  'aria-label'?: string;
   // If a Modal is created and destroyed too quickly it can screw up the aria
   // focus elements. In that case use ariaHideApp=true to disable the default
   // focusing behavior on the Modal. See https://github.com/votingworks/vxsuite/issues/988
@@ -180,7 +180,7 @@ export interface ModalProps {
 
 export function Modal({
   actions,
-  ariaLabel = 'Alert Modal',
+  'aria-label': ariaLabel = 'Alert Modal',
   centerContent,
   content,
   disableAutoplayAudio,

--- a/libs/ui/src/search_select.test.tsx
+++ b/libs/ui/src/search_select.test.tsx
@@ -55,7 +55,7 @@ test('single and not searchable', () => {
     <ControlledSingleSelect
       isSearchable={false}
       options={options}
-      ariaLabel="Choose Fruit"
+      aria-label="Choose Fruit"
       placeholder="Pick a fruit"
     />,
     // Change theme in one test for coverage
@@ -96,7 +96,7 @@ test('single and searchable', async () => {
     <ControlledSingleSelect
       isSearchable
       options={options}
-      ariaLabel="Choose Fruit"
+      aria-label="Choose Fruit"
     />
   );
 
@@ -144,7 +144,7 @@ test('single disabled', () => {
   render(
     <ControlledSingleSelect
       options={options}
-      ariaLabel="Choose Fruit"
+      aria-label="Choose Fruit"
       value="apple"
       disabled
     />
@@ -159,7 +159,7 @@ test('multi and not searchable', () => {
     <ControlledMultiSelect
       isSearchable={false}
       options={options}
-      ariaLabel="Choose Fruit"
+      aria-label="Choose Fruit"
     />,
     // Change theme in one test for coverage
     { vxTheme: makeTheme({ sizeMode: 'desktop', colorMode: 'desktop' }) }
@@ -199,7 +199,7 @@ test('multi and searchable', async () => {
     <ControlledMultiSelect
       isSearchable
       options={options}
-      ariaLabel="Choose Fruit"
+      aria-label="Choose Fruit"
     />
   );
 
@@ -245,7 +245,7 @@ test('multi disabled', () => {
   render(
     <ControlledMultiSelect
       options={options}
-      ariaLabel="Choose Fruit"
+      aria-label="Choose Fruit"
       value={['apple', 'pear']}
       disabled
     />
@@ -260,7 +260,7 @@ test('empty option', () => {
   render(
     <ControlledSingleSelect
       options={[{ value: '', label: 'None' }, ...options]}
-      ariaLabel="Choose Fruit"
+      aria-label="Choose Fruit"
       value="apple"
     />
   );

--- a/libs/ui/src/search_select.tsx
+++ b/libs/ui/src/search_select.tsx
@@ -67,7 +67,7 @@ interface SearchSelectBaseProps<T extends string = string> {
   isMulti?: boolean;
   isSearchable?: boolean;
   options: Array<SelectOption<T>>;
-  ariaLabel?: string;
+  'aria-label'?: string;
   style?: React.CSSProperties;
   placeholder?: string;
 }
@@ -106,7 +106,7 @@ export function SearchSelect<T extends string = string>({
   options,
   value,
   onChange,
-  ariaLabel,
+  'aria-label': ariaLabel,
   disabled,
   placeholder,
   style = {},

--- a/libs/ui/src/search_select.tsx
+++ b/libs/ui/src/search_select.tsx
@@ -70,6 +70,8 @@ interface SearchSelectBaseProps<T extends string = string> {
   'aria-label'?: string;
   style?: React.CSSProperties;
   placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
 }
 
 export interface SearchSelectMultiProps<T extends string = string>
@@ -77,7 +79,6 @@ export interface SearchSelectMultiProps<T extends string = string>
   isMulti: true;
   value: T[];
   onChange: (values: T[]) => void;
-  disabled?: boolean;
 }
 
 export interface SearchSelectSingleProps<T extends string = string>
@@ -85,7 +86,6 @@ export interface SearchSelectSingleProps<T extends string = string>
   isMulti?: false;
   value?: T;
   onChange: (value?: T) => void;
-  disabled?: boolean;
 }
 
 export type SearchSelectProps<T extends string = string> =
@@ -109,6 +109,7 @@ export function SearchSelect<T extends string = string>({
   'aria-label': ariaLabel,
   disabled,
   placeholder,
+  required,
   style = {},
 }: SearchSelectSingleProps<T> | SearchSelectMultiProps<T>): JSX.Element {
   const theme = useTheme();
@@ -136,6 +137,7 @@ export function SearchSelect<T extends string = string>({
           : (selectedOption: SelectOption<T>) => onChange(selectedOption.value)
       }
       placeholder={placeholder ?? null}
+      required={required}
       aria-label={ariaLabel}
       unstyled
       components={{ DropdownIndicator, MultiValueRemove }}

--- a/libs/ui/src/search_select_multi.stories.tsx
+++ b/libs/ui/src/search_select_multi.stories.tsx
@@ -23,7 +23,7 @@ const initialProps: SearchSelectMultiProps = {
   value: [],
   isMulti: true,
   isSearchable: true,
-  ariaLabel: 'Fruit Select',
+  'aria-label': 'Fruit Select',
   disabled: false,
 };
 

--- a/libs/ui/src/search_select_single.stories.tsx
+++ b/libs/ui/src/search_select_single.stories.tsx
@@ -23,7 +23,7 @@ const initialProps: SearchSelectSingleProps = {
   value: undefined,
   isMulti: false,
   isSearchable: true,
-  ariaLabel: 'Fruit Select',
+  'aria-label': 'Fruit Select',
   disabled: false,
 };
 

--- a/libs/ui/src/segmented_button.stories.tsx
+++ b/libs/ui/src/segmented_button.stories.tsx
@@ -14,7 +14,7 @@ const initialProps: SegmentedButtonProps<string> = {
     {
       id: 'official',
       label: 'Official',
-      ariaLabel: 'Enable official ballot mode',
+      'aria-label': 'Enable official ballot mode',
     },
     {
       id: 'test',

--- a/libs/ui/src/segmented_button.test.tsx
+++ b/libs/ui/src/segmented_button.test.tsx
@@ -8,7 +8,7 @@ type TestOptionId = 'a' | 'b' | 'c';
 const TEST_OPTIONS: ReadonlyArray<SegmentedButtonOption<TestOptionId>> = [
   { id: 'a', label: 'Option A' },
   { id: 'b', label: 'Option B' },
-  { id: 'c', label: 'Option C', ariaLabel: 'Enable Option C' },
+  { id: 'c', label: 'Option C', 'aria-label': 'Enable Option C' },
 ];
 
 test('renders all provided options ', () => {

--- a/libs/ui/src/segmented_button.tsx
+++ b/libs/ui/src/segmented_button.tsx
@@ -24,7 +24,7 @@ export interface SegmentedButtonOption<
 > {
   id: T;
   label: React.ReactNode;
-  ariaLabel?: string;
+  'aria-label'?: string;
 }
 
 /** Option ID type for {@link SegmentedButton}. */
@@ -132,7 +132,7 @@ export function SegmentedButton<T extends SegmentedButtonOptionId>(
           const isSelected = o.id === selectedOptionId;
           return (
             <OptionButton
-              aria-label={o.ariaLabel}
+              aria-label={o['aria-label']}
               aria-selected={o.id === selectedOptionId}
               disabled={disabled}
               key={o.id}

--- a/libs/ui/src/tabbed_section/tabbed_section.tsx
+++ b/libs/ui/src/tabbed_section/tabbed_section.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { TabBar, TabInfo } from './tab_bar';
 
 export interface TabbedSectionProps<Id extends string = string> {
-  ariaLabel: string;
+  'aria-label': string;
   tabs: ReadonlyArray<TabConfig<Id>>;
 }
 
@@ -25,7 +25,7 @@ const Content = styled.div.attrs({ role: 'tabpanel' })`
 export function TabbedSection<Id extends string = string>(
   props: TabbedSectionProps<Id>
 ): JSX.Element {
-  const { ariaLabel, tabs } = props;
+  const { 'aria-label': ariaLabel, tabs } = props;
 
   const [activePaneId, setActivePaneId] = React.useState<Id>(tabs[0].paneId);
 


### PR DESCRIPTION
## Overview

Refs #5953 
Closes #5893

Re-enabling and fixing the tests revealed a few problems with this screen:
- deleting the First Name field would instantly insert the rest of the name as the first name; this was due to the "fallback" logic we had
- submitting without a District selected was allowed but produced an invalid contest

To fix the name issue, I changed the form to work with "draft" versions of the contest and candidate data structures that better fit the form. We then validate the data on form submit, both using the HTML `required` attribute and then using our Zod schemas.

## Demo Video or Screenshot
![CleanShot 2025-02-12 at 17 10 48@2x](https://github.com/user-attachments/assets/4b75d9ce-f8e2-4f33-b19e-ee563a665b73)

## Testing Plan
Re-enabled automated tests, plus some manual testing.
