### PR TITLE
Brian/test/design/re enable some tests 3

### DIFF
--- a/apps/design/frontend/.eslintignore
+++ b/apps/design/frontend/.eslintignore
@@ -10,4 +10,3 @@
 /public
 
 src/app.test.tsx
-src/geography_screen.test.tsx

--- a/apps/design/frontend/.eslintignore
+++ b/apps/design/frontend/.eslintignore
@@ -8,5 +8,3 @@
 *.config.js
 *.config.ts
 /public
-
-src/app.test.tsx

--- a/apps/design/frontend/src/app.test.tsx
+++ b/apps/design/frontend/src/app.test.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test } from 'vitest';
 import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import userEvent from '@testing-library/user-event';
 import { ElectionId } from '@votingworks/types';
@@ -11,7 +10,6 @@ import {
 } from '../test/api_helpers';
 import { render, screen } from '../test/react_testing_library';
 import { App } from './app';
-import { User } from '@votingworks/design-backend';
 
 let apiMock: MockApiClient;
 

--- a/apps/design/frontend/src/geography_screen.test.tsx
+++ b/apps/design/frontend/src/geography_screen.test.tsx
@@ -420,7 +420,7 @@ describe('Precincts tab', () => {
 
     apiMock.getUser.expectRepeatedCallsWith().resolves(vxUser);
     apiMock.getElection
-      .expectCallWith({ user: vxUser, electionId })
+      .expectRepeatedCallsWith({ user: vxUser, electionId })
       .resolves(nhElectionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
@@ -572,7 +572,7 @@ describe('Precincts tab', () => {
       })
       .resolves();
     apiMock.getElection
-      .expectCallWith({ user: vxUser, electionId })
+      .expectRepeatedCallsWith({ user: vxUser, electionId })
       .resolves(electionWithChangedPrecinctRecord);
     userEvent.click(screen.getByRole('button', { name: 'Save' }));
 

--- a/apps/design/frontend/src/geography_screen.test.tsx
+++ b/apps/design/frontend/src/geography_screen.test.tsx
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import {
   ElectionRecord,
   Precinct,
@@ -6,14 +7,16 @@ import {
 } from '@votingworks/design-backend';
 import { Buffer } from 'node:buffer';
 import { createMemoryHistory } from 'history';
-import { District, DistrictId } from '@votingworks/types';
+import { District, DistrictId, ElectionId } from '@votingworks/types';
 import userEvent from '@testing-library/user-event';
 import { assert, assertDefined } from '@votingworks/basics';
 import { readElectionGeneral } from '@votingworks/fixtures';
 import {
   MockApiClient,
   createMockApiClient,
+  nonVxUser,
   provideApi,
+  vxUser,
 } from '../test/api_helpers';
 import { generalElectionRecord, makeElectionRecord } from '../test/fixtures';
 import { makeIdFactory } from '../test/id_helpers';
@@ -22,8 +25,6 @@ import { routes } from './routes';
 import { render, screen, waitFor, within } from '../test/react_testing_library';
 import { GeographyScreen } from './geography_screen';
 import { hasSplits } from './utils';
-
-const electionId = generalElectionRecord.election.id;
 
 let apiMock: MockApiClient;
 
@@ -38,7 +39,7 @@ afterEach(() => {
   apiMock.assertComplete();
 });
 
-function renderScreen() {
+function renderScreen(electionId: ElectionId) {
   const { path } = routes.election(electionId).geography.root;
   const history = createMemoryHistory({ initialEntries: [path] });
   render(
@@ -55,30 +56,38 @@ function renderScreen() {
 }
 
 const electionGeneral = readElectionGeneral();
-const electionWithNoGeographyRecord: ElectionRecord = makeElectionRecord({
-  ...electionGeneral,
-  districts: [],
-  precincts: [],
-});
+const electionWithNoGeographyRecord: ElectionRecord = makeElectionRecord(
+  {
+    ...electionGeneral,
+    districts: [],
+    precincts: [],
+  },
+  nonVxUser.orgId
+);
 
-const electionWithNoPrecinctsRecord: ElectionRecord = makeElectionRecord({
-  ...electionGeneral,
-  precincts: [],
-});
+const electionWithNoPrecinctsRecord: ElectionRecord = makeElectionRecord(
+  {
+    ...electionGeneral,
+    precincts: [],
+  },
+  nonVxUser.orgId
+);
 
 describe('Districts tab', () => {
   test('adding a district', async () => {
     const { election } = electionWithNoGeographyRecord;
+    const electionId = election.id;
     const newDistrict: District = {
       id: idFactory.next() as DistrictId,
       name: 'New District',
     };
 
+    apiMock.getUser.expectRepeatedCallsWith().resolves(vxUser);
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ user: vxUser, electionId })
       .resolves(electionWithNoGeographyRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-    renderScreen();
+    renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Geography' });
     screen.getByRole('tab', { name: 'Districts', selected: true });
@@ -100,7 +109,7 @@ describe('Districts tab', () => {
       })
       .resolves();
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ user: vxUser, electionId })
       .resolves(electionWithNewDistrictRecord);
     userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -119,18 +128,21 @@ describe('Districts tab', () => {
   });
 
   test('editing a district', async () => {
-    const { election } = generalElectionRecord;
+    const electionRecord = generalElectionRecord(nonVxUser.orgId);
+    const { election } = electionRecord;
+    const electionId = election.id;
     const savedDistrict = election.districts[0];
     const changedDistrict: District = {
       ...savedDistrict,
       name: 'Changed District',
     };
 
+    apiMock.getUser.expectRepeatedCallsWith().resolves(nonVxUser);
     apiMock.getElection
-      .expectCallWith({ electionId })
-      .resolves(generalElectionRecord);
+      .expectCallWith({ user: nonVxUser, electionId })
+      .resolves(electionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-    renderScreen();
+    renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Geography' });
     screen.getByRole('tab', { name: 'Districts', selected: true });
@@ -151,7 +163,7 @@ describe('Districts tab', () => {
     userEvent.type(nameInput, changedDistrict.name);
 
     const electionWithChangedDistrictRecord: ElectionRecord = {
-      ...generalElectionRecord,
+      ...electionRecord,
       election: {
         ...election,
         districts: [changedDistrict, ...election.districts.slice(1)],
@@ -164,7 +176,7 @@ describe('Districts tab', () => {
       })
       .resolves();
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ user: nonVxUser, electionId })
       .resolves(electionWithChangedDistrictRecord);
     userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -176,17 +188,20 @@ describe('Districts tab', () => {
   });
 
   test('deleting a district', async () => {
-    const { election } = generalElectionRecord;
+    const electionRecord = generalElectionRecord(nonVxUser.orgId);
+    const { election } = electionRecord;
+    const electionId = election.id;
     assert(election.districts.length === 3);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [savedDistrict, remainingDistrict, unusedDistrict] =
       election.districts;
 
+    apiMock.getUser.expectRepeatedCallsWith().resolves(vxUser);
     apiMock.getElection
-      .expectCallWith({ electionId })
-      .resolves(generalElectionRecord);
+      .expectCallWith({ user: vxUser, electionId })
+      .resolves(electionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-    renderScreen();
+    renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Geography' });
     const rows = screen.getAllByRole('row');
@@ -203,33 +218,33 @@ describe('Districts tab', () => {
     // Writing out by hand the expected precincts after deleting the district to
     // avoid replicating the logic we're trying to test (which removes the
     // deleted district from any precincts/splits that reference it)
-    assert(generalElectionRecord.precincts.length === 3);
-    assert(hasSplits(generalElectionRecord.precincts[1]));
+    assert(electionRecord.precincts.length === 3);
+    assert(hasSplits(electionRecord.precincts[1]));
     const precinctsWithDeletedDistrict: Precinct[] = [
       {
-        ...generalElectionRecord.precincts[0],
+        ...electionRecord.precincts[0],
         districtIds: [remainingDistrict.id],
       },
       {
-        ...generalElectionRecord.precincts[1],
+        ...electionRecord.precincts[1],
         splits: [
           {
-            ...generalElectionRecord.precincts[1].splits[0],
+            ...electionRecord.precincts[1].splits[0],
             districtIds: [remainingDistrict.id],
           },
           {
-            ...generalElectionRecord.precincts[1].splits[1],
+            ...electionRecord.precincts[1].splits[1],
             districtIds: [],
           },
         ],
       },
       {
-        ...generalElectionRecord.precincts[2],
+        ...electionRecord.precincts[2],
         districtIds: [],
       },
     ];
     const electionWithDeletedDistrictRecord: ElectionRecord = {
-      ...generalElectionRecord,
+      ...electionRecord,
       election: {
         ...election,
         districts: election.districts.filter(
@@ -251,12 +266,15 @@ describe('Districts tab', () => {
       })
       .resolves();
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ user: vxUser, electionId })
       .resolves(electionWithDeletedDistrictRecord);
     // Two mutations cause two refetches
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ user: vxUser, electionId })
       .resolves(electionWithDeletedDistrictRecord);
+    // Initiate the deletion
+    userEvent.click(screen.getByRole('button', { name: 'Delete District' }));
+    // Confirm the deletion in the modal
     userEvent.click(screen.getByRole('button', { name: 'Delete District' }));
 
     await screen.findByRole('heading', { name: 'Geography' });
@@ -267,16 +285,19 @@ describe('Districts tab', () => {
   });
 
   test('editing or adding a district is disabled when ballots are finalized', async () => {
-    const { election } = generalElectionRecord;
+    const electionRecord = generalElectionRecord(nonVxUser.orgId);
+    const { election } = electionRecord;
+    const electionId = election.id;
     const savedDistrict = election.districts[0];
 
+    apiMock.getUser.expectRepeatedCallsWith().resolves(vxUser);
     apiMock.getElection
-      .expectCallWith({ electionId })
-      .resolves(generalElectionRecord);
+      .expectCallWith({ user: vxUser, electionId })
+      .resolves(electionRecord);
     apiMock.getBallotsFinalizedAt
       .expectCallWith({ electionId })
       .resolves(new Date());
-    renderScreen();
+    renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Geography' });
     screen.getByRole('tab', { name: 'Districts', selected: true });
@@ -294,17 +315,19 @@ describe('Districts tab', () => {
 describe('Precincts tab', () => {
   test('adding a precinct', async () => {
     const { election } = electionWithNoPrecinctsRecord;
+    const electionId = election.id;
     const newPrecinct: Precinct = {
       id: idFactory.next(),
       name: 'New Precinct',
       districtIds: [election.districts[0].id, election.districts[1].id],
     };
 
+    apiMock.getUser.expectRepeatedCallsWith().resolves(vxUser);
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ user: vxUser, electionId })
       .resolves(electionWithNoPrecinctsRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-    renderScreen();
+    renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Geography' });
     userEvent.click(screen.getByRole('tab', { name: 'Precincts' }));
@@ -335,7 +358,7 @@ describe('Precincts tab', () => {
       })
       .resolves();
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ user: vxUser, electionId })
       .resolves(electionWithNewPrecinctRecord);
     userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -358,11 +381,13 @@ describe('Precincts tab', () => {
   });
 
   test('editing a precinct - adding splits in NH', async () => {
+    const general = generalElectionRecord(nonVxUser.orgId);
     const nhElectionRecord: ElectionRecord = {
-      ...generalElectionRecord,
-      election: { ...generalElectionRecord.election, state: 'New Hampshire' },
+      ...general,
+      election: { ...general.election, state: 'New Hampshire' },
     };
     const { election, precincts } = nhElectionRecord;
+    const electionId = election.id;
     const savedPrecinct = precincts[0];
     assert(!hasSplits(savedPrecinct));
 
@@ -393,11 +418,12 @@ describe('Precincts tab', () => {
       ],
     };
 
+    apiMock.getUser.expectRepeatedCallsWith().resolves(vxUser);
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ user: vxUser, electionId })
       .resolves(nhElectionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-    renderScreen();
+    renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Geography' });
     userEvent.click(screen.getByRole('tab', { name: 'Precincts' }));
@@ -489,9 +515,8 @@ describe('Precincts tab', () => {
       split3ElectionTitleOverrideInput,
       assertDefined(changedPrecinct.splits[1].electionTitleOverride)
     );
-    const split3ElectionSealOverrideInput = within(split3Card).getByLabelText(
-      'Election Seal Override'
-    ).parentElement!;
+    const split3ElectionSealOverrideInput =
+      within(split3Card).getByLabelText('Upload Seal Image').parentElement!;
     userEvent.upload(
       split3ElectionSealOverrideInput,
       new File([dummyImage], 'seal.svg', {
@@ -515,8 +540,9 @@ describe('Precincts tab', () => {
       assertDefined(changedPrecinct.splits[1].clerkSignatureCaption)
     );
 
-    const signatureInput =
-      within(split3Card).getByLabelText('Upload Image').parentElement!;
+    const signatureInput = within(split3Card).getByLabelText(
+      'Upload Signature Image'
+    ).parentElement!;
     userEvent.upload(
       signatureInput,
       new File([dummyImage], 'signature.svg', {
@@ -533,7 +559,7 @@ describe('Precincts tab', () => {
     );
 
     const electionWithChangedPrecinctRecord: ElectionRecord = {
-      ...generalElectionRecord,
+      ...general,
       election, // Don't update the election, since it's not used here and it's hard to update ballot styles correctly
       precincts: precincts.map((precinct) =>
         precinct.id === changedPrecinct.id ? changedPrecinct : precinct
@@ -546,7 +572,7 @@ describe('Precincts tab', () => {
       })
       .resolves();
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ user: vxUser, electionId })
       .resolves(electionWithChangedPrecinctRecord);
     userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -575,7 +601,9 @@ describe('Precincts tab', () => {
   });
 
   test('editing a precinct - removing splits', async () => {
-    const { election, precincts } = generalElectionRecord;
+    const electionRecord = generalElectionRecord(nonVxUser.orgId);
+    const { election, precincts } = electionRecord;
+    const electionId = election.id;
     const savedPrecinct = precincts.find(hasSplits)!;
     assert(savedPrecinct.splits.length === 2);
 
@@ -585,11 +613,12 @@ describe('Precincts tab', () => {
       districtIds: savedPrecinct.splits[1].districtIds,
     };
 
+    apiMock.getUser.expectRepeatedCallsWith().resolves(vxUser);
     apiMock.getElection
-      .expectCallWith({ electionId })
-      .resolves(generalElectionRecord);
+      .expectCallWith({ user: vxUser, electionId })
+      .resolves(electionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-    renderScreen();
+    renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Geography' });
     userEvent.click(screen.getByRole('tab', { name: 'Precincts' }));
@@ -627,7 +656,7 @@ describe('Precincts tab', () => {
     });
 
     const electionWithChangedPrecinctRecord: ElectionRecord = {
-      ...generalElectionRecord,
+      ...electionRecord,
       election, // Don't update the election, since it's not used here and it's hard to update ballot styles correctly
       precincts: precincts.map((precinct) =>
         precinct.id === changedPrecinct.id ? changedPrecinct : precinct
@@ -640,7 +669,7 @@ describe('Precincts tab', () => {
       })
       .resolves();
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ user: vxUser, electionId })
       .resolves(electionWithChangedPrecinctRecord);
     userEvent.type(screen.getByLabelText('Name'), '{enter}');
 
@@ -657,15 +686,18 @@ describe('Precincts tab', () => {
   });
 
   test('deleting a precinct', async () => {
-    const { election, precincts } = generalElectionRecord;
+    const electionRecord = generalElectionRecord(nonVxUser.orgId);
+    const { election, precincts } = electionRecord;
+    const electionId = election.id;
     assert(precincts.length === 3);
     const [savedPrecinct] = precincts;
 
+    apiMock.getUser.expectRepeatedCallsWith().resolves(vxUser);
     apiMock.getElection
-      .expectCallWith({ electionId })
-      .resolves(generalElectionRecord);
+      .expectCallWith({ user: vxUser, electionId })
+      .resolves(electionRecord);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-    renderScreen();
+    renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Geography' });
     userEvent.click(screen.getByRole('tab', { name: 'Precincts' }));
@@ -679,7 +711,7 @@ describe('Precincts tab', () => {
     await screen.findByRole('heading', { name: 'Edit Precinct' });
 
     const electionWithDeletedPrecinctRecord: ElectionRecord = {
-      ...generalElectionRecord,
+      ...electionRecord,
       election, // Don't update the election, since it's not used here and it's hard to update ballot styles correctly
       precincts: precincts.filter(
         (precinct) => precinct.id !== savedPrecinct.id
@@ -692,8 +724,11 @@ describe('Precincts tab', () => {
       })
       .resolves();
     apiMock.getElection
-      .expectCallWith({ electionId })
+      .expectCallWith({ user: vxUser, electionId })
       .resolves(electionWithDeletedPrecinctRecord);
+    // Initiate the deletion
+    userEvent.click(screen.getByRole('button', { name: 'Delete Precinct' }));
+    // Confirm the deletion in the modal
     userEvent.click(screen.getByRole('button', { name: 'Delete Precinct' }));
 
     await screen.findByRole('heading', { name: 'Geography' });

--- a/apps/design/frontend/tsconfig.json
+++ b/apps/design/frontend/tsconfig.json
@@ -15,7 +15,7 @@
     "noUncheckedIndexedAccess": false
   },
   "include": ["src", "test"],
-  "exclude": ["src/app.test.tsx", "src/geography_screen.test.tsx"],
+  "exclude": ["src/app.test.tsx"],
   "references": [
     { "path": "../backend/tsconfig.build.json" },
     { "path": "../../../libs/basics/tsconfig.build.json" },

--- a/apps/design/frontend/tsconfig.json
+++ b/apps/design/frontend/tsconfig.json
@@ -15,7 +15,6 @@
     "noUncheckedIndexedAccess": false
   },
   "include": ["src", "test"],
-  "exclude": ["src/app.test.tsx"],
   "references": [
     { "path": "../backend/tsconfig.build.json" },
     { "path": "../../../libs/basics/tsconfig.build.json" },

--- a/apps/design/frontend/vitest.config.ts
+++ b/apps/design/frontend/vitest.config.ts
@@ -5,13 +5,12 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['test/setupTests.ts'],
-    exclude: ['src/app.test.ts'],
     clearMocks: true,
 
     coverage: {
       thresholds: {
-        lines: 58,
-        branches: 43,
+        lines: 92,
+        branches: 72,
       },
       exclude: ['src/**/*.d.ts', 'src/index.tsx'],
     },

--- a/apps/design/frontend/vitest.config.ts
+++ b/apps/design/frontend/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['test/setupTests.ts'],
-    exclude: ['src/app.test.ts', 'src/geography_screen.test.tsx'],
+    exclude: ['src/app.test.ts'],
     clearMocks: true,
 
     coverage: {


### PR DESCRIPTION
## Overview

Closes #5953 
Stacked on #6018 

Re-enables the remaining fully-disabled test files. There are still some `test.skip` instances in the codebase, but I'm okay leaving them for now.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated tests 🥳 