### PR TITLE
Add color tinting to NH ballot template

### DIFF
--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -42,6 +42,7 @@
     "@votingworks/ui": "workspace:*",
     "@votingworks/utils": "workspace:*",
     "auth0": "4.17.0",
+    "csv-parse": "^5.5.0",
     "debug": "4.3.4",
     "dotenv": "16.3.1",
     "dotenv-expand": "9.0.0",

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -5,8 +5,9 @@ import {
   BaseBallotProps,
   NhBallotProps,
   ColorTint,
+  ColorTints,
 } from '@votingworks/hmpb';
-import { find, throwIllegalValue } from '@votingworks/basics';
+import { assert, find, throwIllegalValue } from '@votingworks/basics';
 import { readFileSync } from 'node:fs';
 import { parse } from 'csv-parse/sync';
 import { join } from 'node:path';
@@ -74,20 +75,26 @@ export function createBallotPropsForTemplate(
       (bs) => bs.id === props.ballotStyleId
     );
     const split = getPrecinctSplitForBallotStyle(precinct, ballotStyle);
-    const colorTint = colorTints
+    let colorTint = colorTints
       .find(
         (tintRecord) =>
           tintRecord['Election ID'] === election.id &&
           tintRecord['Ballot Style ID'] === ballotStyle.id
       )
-      ?.['Color']?.toUpperCase();
+      ?.['Color'].toUpperCase();
+    if (colorTint === 'WHITE') {
+      colorTint = undefined;
+    }
+    if (colorTint) {
+      assert(colorTint in ColorTints, `Invalid color tint: ${colorTint}`);
+    }
     return {
       ...props,
       electionTitleOverride: split.electionTitleOverride,
       electionSealOverride: split.electionSealOverride,
       clerkSignatureImage: split.clerkSignatureImage,
       clerkSignatureCaption: split.clerkSignatureCaption,
-      colorTint: colorTint === 'WHITE' ? undefined : (colorTint as ColorTint),
+      colorTint: colorTint as ColorTint,
     };
   }
 

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -62,6 +62,8 @@ export function createBallotPropsForTemplate(
       electionSealOverride: split.electionSealOverride,
       clerkSignatureImage: split.clerkSignatureImage,
       clerkSignatureCaption: split.clerkSignatureCaption,
+      // TODO pick color tint based on election id and ballot style id
+      colorTint: 'GREEN',
     };
   }
 

--- a/apps/design/backend/src/color-tints.csv
+++ b/apps/design/backend/src/color-tints.csv
@@ -13,11 +13,12 @@ Farmington,1qtiu3ved2t1,Town,1_en,White,
 Farmington,1qtiu3ved2t1,School District,2_en,Yellow,
 Fitzwilliam,zftp3jzfmzsb,Town,1_en,White,
 Fitzwilliam,zftp3jzfmzsb,School District,2_en,Yellow,
-Francestown,5w3s6u5p5j0c,Town,1_en,White,
+Francestown,5w3s6u5p5j0c,Town,1_en,White,need to check with Francestown
 Francestown,5w3s6u5p5j0c,School District,2_en,Yellow,
-Francestown,5w3s6u5p5j0c,Zoning,3_en,White, is this meant to be the same as town?
+Francestown,5w3s6u5p5j0c,Zoning,3_en,White,need to check with Francestown
 Gilmanton,4rakts5zl278,Town,1_en,White,
 Gilmanton,4rakts5zl278,School District,2_en,Blue,
+Hampton,lpfw345vk2g6,Town,1_en,White,this is a special case we won't be printing and their current ballots are fine
 Hampton,lpfw345vk2g6,School District,2_en,Yellow,
 Hampton,lpfw345vk2g6,Cooperative High School District,3_en,Blue,
 Hollis,u4ft7f3x13af,Town,1_en,White,
@@ -37,12 +38,12 @@ Pittsfield,n4hly8grf5np,Town,1_en,White,
 Pittsfield,n4hly8grf5np,School District,2_en,Yellow,
 Plymouth,bgljn7wob5js,Town,1_en,White,
 Plymouth,bgljn7wob5js,Elementary School District,2_en,Yellow,
-Plymouth,bgljn7wob5js,High School District,3_en,Blue,does high school = pemi-baker?
+Plymouth,bgljn7wob5js,High School District,3_en,Blue,
 Plymouth,bgljn7wob5js,Water and Sewer,4_en,Pink,was ivory/cream but original request was pink
 Plymouth,bgljn7wob5js,Zoning,5_en,Green,
-Seabrook,bte888j5tijr,Town,1_en,Blue,"this seems inverted, is this right?"
+Seabrook,bte888j5tijr,Town,1_en,White,
 Seabrook,bte888j5tijr,School District,2_en,Yellow,
-Seabrook,bte888j5tijr,Cooperative High School District,3_en,White,"this seems inverted, is this right?"
+Seabrook,bte888j5tijr,Cooperative High School District,3_en,Blue,
 Springfield,wzoa9wu0rn9p,Town,1_en,Blue,
 Springfield,wzoa9wu0rn9p,School District,2_en,Yellow,
 Walpole,abfbg0ih0ezv,Town,1_en,White,

--- a/apps/design/backend/src/color-tints.csv
+++ b/apps/design/backend/src/color-tints.csv
@@ -1,0 +1,52 @@
+Customer,Election ID,Ballot Style Split Name,Ballot Style ID,Color,Notes
+Ashland,e0boigntiut0,Town,1_en,White,
+Ashland,e0boigntiut0,School District,2_en,Yellow,
+Ashland,e0boigntiut0,Pemi-Baker School District,3_en,Green,
+Auburn,281bhhtd7kxl,Town,1_en,White,
+Auburn,281bhhtd7kxl,School District,2_en,Yellow,
+Brentwood,9n0vcfuziyab,Town,1_en,White,
+Brentwood,9n0vcfuziyab,School District,2_en,Yellow,
+Brentwood,9n0vcfuziyab,Co-op,3_en,Green,
+Carroll,2uwd1git0ip4,Town,1_en,White,
+Carroll,2uwd1git0ip4,School District,2_en,Yellow,
+Farmington,1qtiu3ved2t1,Town,1_en,White,
+Farmington,1qtiu3ved2t1,School District,2_en,Yellow,
+Fitzwilliam,zftp3jzfmzsb,Town,1_en,White,
+Fitzwilliam,zftp3jzfmzsb,School District,2_en,Yellow,
+Francestown,5w3s6u5p5j0c,Town,1_en,White,
+Francestown,5w3s6u5p5j0c,School District,2_en,Yellow,
+Francestown,5w3s6u5p5j0c,Zoning,3_en,White, is this meant to be the same as town?
+Gilmanton,4rakts5zl278,Town,1_en,White,
+Gilmanton,4rakts5zl278,School District,2_en,Blue,
+Hampton,lpfw345vk2g6,School District,2_en,Yellow,
+Hampton,lpfw345vk2g6,Cooperative High School District,3_en,Blue,
+Hollis,u4ft7f3x13af,Town,1_en,White,
+Hollis,u4ft7f3x13af,School District,2_en,Green,
+Hollis,u4ft7f3x13af,Hollis Brookline Cooperative School District,3_en,Yellow,
+Hollis,u4ft7f3x13af,2025 Zoning,4_en,Blue,
+Kingston,2y0wr4nbcr56,Town,1_en,White,
+Kingston,2y0wr4nbcr56,School District,2_en,Yellow,
+Middleton,c3vct5opsuhg,Town,1_en,White,confirmed with Melissa
+Middleton,c3vct5opsuhg,School District,2_en,Yellow,confirmed with Melissa
+Middleton,c3vct5opsuhg,Zoning,3_en,Blue,confirmed with Melissa
+New London,emusmatpuzhm,Town,1_en,White,
+New London,emusmatpuzhm,School District,2_en,Yellow,
+Newton,5vhc5vt1qzlj,Town,1_en,White,
+Newton,5vhc5vt1qzlj,School District,2_en,Yellow,
+Pittsfield,n4hly8grf5np,Town,1_en,White,
+Pittsfield,n4hly8grf5np,School District,2_en,Yellow,
+Plymouth,bgljn7wob5js,Town,1_en,White,
+Plymouth,bgljn7wob5js,Elementary School District,2_en,Yellow,
+Plymouth,bgljn7wob5js,High School District,3_en,Blue,does high school = pemi-baker?
+Plymouth,bgljn7wob5js,Water and Sewer,4_en,Pink,was ivory/cream but original request was pink
+Plymouth,bgljn7wob5js,Zoning,5_en,Green,
+Seabrook,bte888j5tijr,Town,1_en,Blue,"this seems inverted, is this right?"
+Seabrook,bte888j5tijr,School District,2_en,Yellow,
+Seabrook,bte888j5tijr,Cooperative High School District,3_en,White,"this seems inverted, is this right?"
+Springfield,wzoa9wu0rn9p,Town,1_en,Blue,
+Springfield,wzoa9wu0rn9p,School District,2_en,Yellow,
+Walpole,abfbg0ih0ezv,Town,1_en,White,
+Walpole,abfbg0ih0ezv,School District,2_en,Yellow,
+Windham,an6ae1abjhxx,Town,1_en,White,
+Windham,an6ae1abjhxx,School District,2_en,Yellow,
+Windham,an6ae1abjhxx,Zoning,3_en,Blue,

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -27,11 +27,6 @@ import {
   getAllStringsForElectionPackage,
 } from '@votingworks/backend';
 import { assertDefined, iter } from '@votingworks/basics';
-import { tmpNameSync } from 'tmp';
-import { promisify } from 'node:util';
-import { exec } from 'node:child_process';
-import { createReadStream, createWriteStream, ReadStream } from 'node:fs';
-import { Buffer } from 'node:buffer';
 import { WorkerContext } from './context';
 import { createBallotPropsForTemplate } from '../ballots';
 import { renderBallotStyleReadinessReport } from '../ballot_style_reports';
@@ -73,29 +68,6 @@ function makeV3Compatible(zip: JsZip, systemSettings: SystemSettings): void {
     ElectionPackageFileName.SYSTEM_SETTINGS,
     JSON.stringify(v3SystemSettings, null, 2)
   );
-}
-
-/**
- * Given a PDF document, convert it to grayscale and return a read stream to
- * the resulting PDF.
- */
-async function convertPdfToGrayscale(pdf: Buffer): Promise<ReadStream> {
-  const tmpPdfFilePath = tmpNameSync();
-  const fileStream = createWriteStream(tmpPdfFilePath);
-  fileStream.write(pdf);
-  fileStream.end();
-  const tmpGrayscalePdfFilePath = tmpNameSync();
-  await promisify(exec)(`
-    gs \
-      -sOutputFile=${tmpGrayscalePdfFilePath} \
-      -sDEVICE=pdfwrite \
-      -sColorConversionStrategy=Gray \
-      -dProcessColorModel=/DeviceGray \
-      -dNOPAUSE \
-      -dBATCH \
-      ${tmpPdfFilePath}
-  `);
-  return createReadStream(tmpGrayscalePdfFilePath);
 }
 
 export async function generateElectionPackageAndBallots(
@@ -223,8 +195,7 @@ export async function generateElectionPackageAndBallots(
 
   // Make ballot zip
   for (const [props, document] of iter(allBallotProps).zip(ballotDocuments)) {
-    const colorPdf = await document.renderToPdf();
-    const grayscalePdf = await convertPdfToGrayscale(colorPdf);
+    const pdf = await document.renderToPdf();
     const { precinctId, ballotStyleId, ballotType, ballotMode } = props;
     const precinct = assertDefined(getPrecinctById({ election, precinctId }));
     const fileName = getPdfFileName(
@@ -233,7 +204,7 @@ export async function generateElectionPackageAndBallots(
       ballotType,
       ballotMode
     );
-    ballotsZip.file(fileName, grayscalePdf);
+    ballotsZip.file(fileName, pdf);
   }
 
   const readinessReportPdf = await renderBallotStyleReadinessReport({

--- a/apps/design/backend/vitest.config.ts
+++ b/apps/design/backend/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: 71.8,
-        branches: 59.7,
+        branches: 59,
       },
       exclude: ['src/configure_sentry.ts'],
     },

--- a/libs/hmpb/src/ballot_components.tsx
+++ b/libs/hmpb/src/ballot_components.tsx
@@ -39,6 +39,15 @@ export const Colors = {
   DARKER_GRAY: '#B0B0B0',
 } as const;
 
+export const ColorTints = {
+  YELLOW: 'hsl(59, 75%, 93%)',
+  BLUE: 'hsl(209, 74%, 93%)',
+  GREEN: 'hsl(129, 60%, 93%)',
+  PINK: 'hsl(315, 58%, 93%)',
+} as const;
+
+export type ColorTint = keyof typeof ColorTints;
+
 export function primaryLanguageCode(ballotStyle: BallotStyle): string {
   return ballotStyle.languages?.[0] ?? 'en';
 }
@@ -381,12 +390,18 @@ export function BlankPageMessage(): React.ReactElement {
   );
 }
 
-export const Box = styled.div<{ fill?: 'transparent' | 'tinted' }>`
+export const Box = styled.div<{
+  fill?: 'transparent' | 'tinted' | ColorTint;
+}>`
   border: 1px solid ${Colors.BLACK};
   border-top-width: 3px;
   padding: 0.75rem;
   background-color: ${(p) =>
-    p.fill === 'tinted' ? Colors.LIGHT_GRAY : 'none'};
+    p.fill === 'tinted'
+      ? Colors.LIGHT_GRAY
+      : p.fill === 'transparent' || !p.fill
+      ? 'none'
+      : ColorTints[p.fill]};
 `;
 
 export function WriteInLabel(): React.ReactElement {
@@ -401,15 +416,17 @@ export function WriteInLabel(): React.ReactElement {
 
 export function Instructions({
   languageCode,
+  colorTint,
 }: {
   languageCode?: string;
+  colorTint?: ColorTint;
 }): React.ReactElement {
   // To minimize vertical space used, we do a slightly different layout for
   // English-only vs bilingual ballots.
   if (!languageCode || languageCode === 'en') {
     return (
       <Box
-        fill="tinted"
+        fill={colorTint ?? 'tinted'}
         style={{
           padding: '0.5rem 0.5rem',
           display: 'grid',
@@ -484,12 +501,14 @@ export function Footer({
   precinctId,
   pageNumber,
   totalPages,
+  colorTint,
 }: {
   election: Election;
   ballotStyleId: BallotStyleId;
   precinctId: PrecinctId;
   pageNumber: number;
   totalPages?: number;
+  colorTint?: ColorTint;
 }): JSX.Element {
   const precinct = assertDefined(getPrecinctById({ election, precinctId }));
   const ballotStyle = assertDefined(
@@ -546,7 +565,7 @@ export function Footer({
       <div style={{ display: 'flex', gap: '0.75rem' }}>
         <QrCodeSlot />
         <Box
-          fill="tinted"
+          fill={colorTint ?? 'tinted'}
           style={{
             padding: '0.25rem 0.5rem',
             flex: 1,
@@ -611,9 +630,11 @@ export function Footer({
 
 interface ContestHeaderProps {
   compact?: boolean;
+  colorTint?: ColorTint;
 }
 
 export const ContestHeader = styled.div<ContestHeaderProps>`
-  background: ${Colors.LIGHT_GRAY};
+  background: ${(p) =>
+    p.colorTint ? ColorTints[p.colorTint] : Colors.LIGHT_GRAY};
   padding: ${(p) => (p.compact ? '0.25rem 0.5rem' : '0.5rem')};
 `;

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -49,6 +49,7 @@ import {
   Instructions,
   primaryLanguageCode,
   WriteInLabel,
+  ColorTint,
 } from '../ballot_components';
 import { BallotMode, PixelDimensions } from '../types';
 import { hmpbStrings } from '../hmpb_strings';
@@ -60,6 +61,7 @@ export interface NhPrecinctSplitOptions {
   electionSealOverride?: string;
   clerkSignatureImage?: string;
   clerkSignatureCaption?: string;
+  colorTint?: ColorTint;
 }
 
 function Header({
@@ -186,6 +188,7 @@ function BallotPageFrame({
   clerkSignatureImage,
   clerkSignatureCaption,
   watermark,
+  colorTint,
 }: BaseBallotProps &
   NhPrecinctSplitOptions & {
     pageNumber: number;
@@ -231,7 +234,10 @@ function BallotPageFrame({
                   clerkSignatureImage={clerkSignatureImage}
                   clerkSignatureCaption={clerkSignatureCaption}
                 />
-                <Instructions languageCode={languageCode} />
+                <Instructions
+                  colorTint={colorTint}
+                  languageCode={languageCode}
+                />
               </>
             )}
             <div
@@ -250,6 +256,7 @@ function BallotPageFrame({
               precinctId={precinctId}
               pageNumber={pageNumber}
               totalPages={totalPages}
+              colorTint={colorTint}
             />
           </div>
         </TimingMarkGrid>
@@ -262,10 +269,12 @@ function CandidateContest({
   election,
   contest,
   compact,
+  colorTint,
 }: {
   election: Election;
   contest: CandidateContestStruct;
   compact?: boolean;
+  colorTint?: ColorTint;
 }) {
   const voteForText = {
     1: hmpbStrings.hmpbVoteForNotMoreThan1,
@@ -305,7 +314,7 @@ function CandidateContest({
         padding: 0,
       }}
     >
-      <ContestHeader>
+      <ContestHeader colorTint={colorTint}>
         <DualLanguageText delimiter="/">
           <h3>{electionStrings.contestTitle(contest)}</h3>
         </DualLanguageText>
@@ -420,15 +429,17 @@ function CandidateContest({
 function BallotMeasureContest({
   contest,
   compact,
+  colorTint,
 }: {
   contest: YesNoContest;
   compact?: boolean;
+  colorTint?: ColorTint;
 }) {
   const ContestTitle = compact ? 'h3' : 'h2';
 
   return (
     <Box style={{ padding: 0 }}>
-      <ContestHeader>
+      <ContestHeader colorTint={colorTint}>
         <DualLanguageText delimiter="/">
           <ContestTitle>{electionStrings.contestTitle(contest)}</ContestTitle>
         </DualLanguageText>
@@ -508,10 +519,12 @@ function Contest({
   compact,
   contest,
   election,
+  colorTint,
 }: {
   compact?: boolean;
   contest: AnyContest;
   election: Election;
+  colorTint?: ColorTint;
 }) {
   switch (contest.type) {
     case 'candidate':
@@ -520,19 +533,26 @@ function Contest({
           compact={compact}
           election={election}
           contest={contest}
+          colorTint={colorTint}
         />
       );
     case 'yesno':
-      return <BallotMeasureContest compact={compact} contest={contest} />;
+      return (
+        <BallotMeasureContest
+          compact={compact}
+          contest={contest}
+          colorTint={colorTint}
+        />
+      );
     default:
       return throwIllegalValue(contest);
   }
 }
 
 async function BallotPageContent(
-  props: (BaseBallotProps & { dimensions: PixelDimensions }) | undefined,
+  props: (NhBallotProps & { dimensions: PixelDimensions }) | undefined,
   scratchpad: RenderScratchpad
-): Promise<ContentComponentResult<BaseBallotProps>> {
+): Promise<ContentComponentResult<NhBallotProps>> {
   if (!props) {
     return ok({
       currentPageElement: <BlankPageMessage />,
@@ -571,6 +591,7 @@ async function BallotPageContent(
         compact={compact}
         contest={contest}
         election={election}
+        colorTint={props.colorTint}
       />
     ));
     const numColumns = section[0].type === 'candidate' ? 3 : 1;

--- a/libs/hmpb/src/index.ts
+++ b/libs/hmpb/src/index.ts
@@ -8,4 +8,4 @@ export * from './render_ballot';
 export * from './renderer';
 export * from './ballot_templates';
 export * from './types';
-export type { ColorTint } from './ballot_components';
+export { type ColorTint, ColorTints } from './ballot_components';

--- a/libs/hmpb/src/index.ts
+++ b/libs/hmpb/src/index.ts
@@ -8,3 +8,4 @@ export * from './render_ballot';
 export * from './renderer';
 export * from './ballot_templates';
 export * from './types';
+export type { ColorTint } from './ballot_components';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1140,6 +1140,9 @@ importers:
       auth0:
         specifier: 4.17.0
         version: 4.17.0
+      csv-parse:
+        specifier: ^5.5.0
+        version: 5.5.0
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
@@ -15727,7 +15730,6 @@ packages:
 
   /csv-parse@5.5.0:
     resolution: {integrity: sha512-RxruSK3M4XgzcD7Trm2wEN+SJ26ChIb903+IWxNOcB5q4jT2Cs+hFr6QP39J05EohshRFEvyzEBoZ/466S2sbw==}
-    dev: true
 
   /csv-stringify@6.4.0:
     resolution: {integrity: sha512-HQsw0QXiN5fdlO+R8/JzCZnR3Fqp8E87YVnhHlaPtNGJjt6ffbV0LpOkieIb1x6V1+xt878IYq77SpXHWAqKkA==}


### PR DESCRIPTION
## Overview

Add a color tint option to the NH v4 ballot template, tinting all previously gray boxes (instructions, contest headers, and footers).

## Demo Video or Screenshot

## Testing Plan
Manual testing

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
