### PR TITLE
feat(scan): allow configuring scanner's bitonal threshold

### DIFF
--- a/apps/design/frontend/src/system_settings_screen.tsx
+++ b/apps/design/frontend/src/system_settings_screen.tsx
@@ -14,6 +14,7 @@ import { useParams } from 'react-router-dom';
 import {
   AdjudicationReason,
   AdjudicationReasonSchema,
+  DEFAULT_BITONAL_THRESHOLD,
   DEFAULT_INACTIVE_SESSION_TIME_LIMIT_MINUTES,
   DEFAULT_MARK_THRESHOLDS,
   DEFAULT_NUM_INCORRECT_PIN_ATTEMPTS_ALLOWED_BEFORE_CARD_LOCKOUT,
@@ -321,6 +322,33 @@ export function SystemSettingsForm({
                 />
               </InputGroup>
             )}
+            <InputGroup label="Scanner Bitonal Threshold">
+              <input
+                type="number"
+                value={systemSettings.bitonalThreshold ?? ''}
+                onChange={(e) => {
+                  const bitonalThreshold = e.target.valueAsNumber;
+                  setSystemSettings({
+                    ...systemSettings,
+                    bitonalThreshold: Number.isNaN(bitonalThreshold)
+                      ? undefined
+                      : bitonalThreshold,
+                  });
+                }}
+                onBlur={(e) => {
+                  if (e.target.value === '') {
+                    setSystemSettings({
+                      ...systemSettings,
+                      bitonalThreshold: DEFAULT_BITONAL_THRESHOLD,
+                    });
+                  }
+                }}
+                step={1}
+                min={0}
+                max={100}
+                disabled={!isEditing}
+              />
+            </InputGroup>
           </Column>
         </Card>
         {ballotTemplateId !== 'NhBallotV3' &&

--- a/apps/scan/backend/src/app_scanning.test.ts
+++ b/apps/scan/backend/src/app_scanning.test.ts
@@ -67,6 +67,7 @@ test('scanBatch with streaked page', async () => {
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
       await waitForStatus(apiClient, { state: 'no_paper' });
       expect(mockScanner.client.enableScanning).toHaveBeenCalledWith({
+        bitonalThreshold: 75,
         doubleFeedDetectionEnabled: true,
         paperLengthInches: 11,
       });
@@ -111,6 +112,7 @@ test('scanBatch with streaked page', async () => {
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
       await waitForStatus(apiClient, { state: 'no_paper' });
       expect(mockScanner.client.enableScanning).toHaveBeenCalledWith({
+        bitonalThreshold: 75,
         doubleFeedDetectionEnabled: true,
         paperLengthInches: 11,
       });

--- a/apps/scan/backend/src/electrical_testing/simple_scanner_client.ts
+++ b/apps/scan/backend/src/electrical_testing/simple_scanner_client.ts
@@ -40,6 +40,7 @@ export function createSimpleScannerClient(): SimpleScannerClient {
       (await client.disableScanning()).unsafeUnwrap();
       (
         await client.enableScanning({
+          bitonalThreshold: 75,
           doubleFeedDetectionEnabled: false,
           paperLengthInches: 11,
         })

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_diagnostic.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_diagnostic.test.ts
@@ -52,6 +52,7 @@ test('scanner diagnostic, unconfigured - pass', async () => {
     await waitForStatus(apiClient, { state: 'scanner_diagnostic.running' });
     expect(mockScanner.client.enableScanning).toHaveBeenCalledTimes(1);
     expect(mockScanner.client.enableScanning).toHaveBeenCalledWith({
+      bitonalThreshold: 75,
       doubleFeedDetectionEnabled: false,
       paperLengthInches: iter(Object.values(HmpbBallotPaperSize))
         .map((paperSize) => ballotPaperDimensions(paperSize).height)
@@ -122,6 +123,7 @@ test('scanner diagnostic, configured - fail', async () => {
       await waitForStatus(apiClient, { state: 'scanner_diagnostic.running' });
       expect(mockScanner.client.enableScanning).toHaveBeenCalledTimes(1);
       expect(mockScanner.client.enableScanning).toHaveBeenCalledWith({
+        bitonalThreshold: 75,
         doubleFeedDetectionEnabled: false,
         paperLengthInches: ballotPaperDimensions(
           election.ballotLayout.paperSize

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan.test.ts
@@ -58,6 +58,7 @@ test('configure and scan hmpb', async () => {
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
       await waitForStatus(apiClient, { state: 'no_paper' });
       expect(mockScanner.client.enableScanning).toHaveBeenCalledWith({
+        bitonalThreshold: 75,
         doubleFeedDetectionEnabled: true,
         paperLengthInches: 11,
       });
@@ -135,6 +136,7 @@ test('configure and scan bmd ballot', async () => {
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
       await waitForStatus(apiClient, { state: 'no_paper' });
       expect(mockScanner.client.enableScanning).toHaveBeenCalledWith({
+        bitonalThreshold: 75,
         doubleFeedDetectionEnabled: true,
         paperLengthInches: 11,
       });

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -602,6 +602,7 @@ function buildMachine({
                   src: async () => {
                     const electionRecord = store.getElectionRecord();
                     if (!electionRecord) return;
+                    const bitonalThreshold = store.getBitonalThreshold();
                     const paperLengthInches = ballotPaperDimensions(
                       electionRecord.electionDefinition.election.ballotLayout
                         .paperSize
@@ -610,6 +611,7 @@ function buildMachine({
                       !store.getIsDoubleFeedDetectionDisabled();
                     (
                       await scannerClient.enableScanning({
+                        bitonalThreshold,
                         doubleFeedDetectionEnabled,
                         paperLengthInches,
                       })
@@ -1061,6 +1063,7 @@ function buildMachine({
               invoke: {
                 src: async () => {
                   const electionRecord = store.getElectionRecord();
+                  const bitonalThreshold = store.getBitonalThreshold();
                   const paperLengthInches = ballotPaperDimensions(
                     electionRecord?.electionDefinition.election.ballotLayout
                       .paperSize ??
@@ -1070,6 +1073,7 @@ function buildMachine({
                   ).height;
                   (
                     await scannerClient.enableScanning({
+                      bitonalThreshold,
                       doubleFeedDetectionEnabled: false,
                       paperLengthInches,
                     })

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -29,6 +29,7 @@ import {
   ElectionKey,
   ElectionId,
   constructElectionKey,
+  DEFAULT_BITONAL_THRESHOLD,
 } from '@votingworks/types';
 import {
   assert,
@@ -345,6 +346,16 @@ export class Store {
     }
 
     return Boolean(electionRow.isSoundMuted);
+  }
+
+  /**
+   * Gets the bitonal threshold for scanning ballots. See Section 2.1.43 of the
+   * PDI PageScan software specification.
+   */
+  getBitonalThreshold(): number {
+    return (
+      this.getSystemSettings()?.bitonalThreshold ?? DEFAULT_BITONAL_THRESHOLD
+    );
   }
 
   /**

--- a/libs/dev-dock/backend/src/dev_dock_api.test.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.test.ts
@@ -302,6 +302,7 @@ test('mock PDI scanner', async () => {
   (await mockPdiScanner.client.connect()).unsafeUnwrap();
   (
     await mockPdiScanner.client.enableScanning({
+      bitonalThreshold: 75,
       doubleFeedDetectionEnabled: false,
       paperLengthInches: 11,
     })

--- a/libs/pdi-scanner/src/rust/client.rs
+++ b/libs/pdi-scanner/src/rust/client.rs
@@ -798,6 +798,7 @@ impl<T> Client<T> {
     /// validate or if the response is not received within the timeout.
     pub fn send_enable_scan_commands(
         &mut self,
+        bitonal_threshold: ClampedPercentage,
         double_feed_detection_mode: DoubleFeedDetectionMode,
         paper_length_inches: f32,
     ) -> Result<()> {
@@ -834,10 +835,10 @@ impl<T> Client<T> {
         self.set_motor_speed(Speed::Full)?;
         // OUT SetThresholdToANewValueRequest { side: Top, new_threshold: 75 }
         // IN AdjustTopCISSensorThresholdResponse { percent_white_threshold: 75 }
-        self.set_threshold(Side::Top, ClampedPercentage::new_unchecked(75), timeout)?;
+        self.set_threshold(Side::Top, bitonal_threshold, timeout)?;
         // OUT SetThresholdToANewValueRequest { side: Bottom, new_threshold: 75 }
         // IN AdjustBottomCISSensorThresholdResponse { percent_white_threshold: 75 }
-        self.set_threshold(Side::Bottom, ClampedPercentage::new_unchecked(75), timeout)?;
+        self.set_threshold(Side::Bottom, bitonal_threshold, timeout)?;
         // OUT SetRequiredInputSensorsRequest { sensors: 2 }
         self.set_required_input_sensors(2)?;
 

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -16,8 +16,8 @@ use pdi_scanner::{
         image::{RawImageData, Sheet, DEFAULT_IMAGE_WIDTH},
         packets::Incoming,
         types::{
-            DoubleFeedDetectionCalibrationType, DoubleFeedDetectionMode, EjectMotion, FeederMode,
-            ScanSideMode, Status,
+            ClampedPercentage, DoubleFeedDetectionCalibrationType, DoubleFeedDetectionMode,
+            EjectMotion, FeederMode, ScanSideMode, Status,
         },
     },
     rusb_async,
@@ -77,6 +77,7 @@ enum Command {
     GetScannerStatus,
 
     EnableScanning {
+        bitonal_threshold: ClampedPercentage,
         double_feed_detection_enabled: bool,
         paper_length_inches: f32,
     },
@@ -299,6 +300,7 @@ fn main() -> color_eyre::Result<()> {
                     (
                         Some(client),
                         Command::EnableScanning {
+                            bitonal_threshold,
                             double_feed_detection_enabled,
                             paper_length_inches,
                         },
@@ -309,6 +311,7 @@ fn main() -> color_eyre::Result<()> {
                             DoubleFeedDetectionMode::Disabled
                         };
                         match client.send_enable_scan_commands(
+                            bitonal_threshold,
                             double_feed_detection_mode,
                             paper_length_inches,
                         ) {

--- a/libs/pdi-scanner/src/rust/rusb_async/pool.rs
+++ b/libs/pdi-scanner/src/rust/rusb_async/pool.rs
@@ -240,7 +240,7 @@ fn poll_completed(ctx: &impl UsbContext, timeout: Duration, completed: &AtomicBo
         let remaining = deadline.saturating_duration_since(Instant::now());
         let timeval = libc::timeval {
             tv_sec: remaining.as_secs().try_into().unwrap(),
-            tv_usec: remaining.subsec_micros().into(),
+            tv_usec: remaining.subsec_micros().try_into().unwrap(),
         };
         unsafe {
             if ffi::libusb_try_lock_events(ctx.as_raw()) == ffi::constants::LIBUSB_SUCCESS {

--- a/libs/pdi-scanner/src/ts/demo.ts
+++ b/libs/pdi-scanner/src/ts/demo.ts
@@ -9,6 +9,7 @@ export async function main(): Promise<void> {
   (await scannerClient.connect()).unsafeUnwrap();
 
   const scanningOptions = {
+    bitonalThreshold: 75,
     doubleFeedDetectionEnabled: true,
     paperLengthInches: 11,
   } as const;

--- a/libs/pdi-scanner/src/ts/mock_scanner.test.ts
+++ b/libs/pdi-scanner/src/ts/mock_scanner.test.ts
@@ -56,6 +56,7 @@ describe('mock scanner', () => {
     // Enable scanning
     expect(
       await client.enableScanning({
+        bitonalThreshold: 75,
         doubleFeedDetectionEnabled: false,
         paperLengthInches: 11,
       })
@@ -111,6 +112,7 @@ describe('mock scanner', () => {
     expect(await client.connect()).toEqual(ok());
     expect(
       await client.enableScanning({
+        bitonalThreshold: 75,
         doubleFeedDetectionEnabled: false,
         paperLengthInches: 11,
       })
@@ -152,6 +154,7 @@ describe('mock scanner', () => {
     expect(await client.connect()).toEqual(ok());
     expect(
       await client.enableScanning({
+        bitonalThreshold: 75,
         doubleFeedDetectionEnabled: false,
         paperLengthInches: 11,
       })
@@ -190,6 +193,7 @@ describe('mock scanner', () => {
     expect(await client.connect()).toEqual(ok());
     expect(
       await client.enableScanning({
+        bitonalThreshold: 75,
         doubleFeedDetectionEnabled: false,
         paperLengthInches: 11,
       })

--- a/libs/pdi-scanner/src/ts/scanner_client.test.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.test.ts
@@ -90,28 +90,32 @@ test('enableScanning({ doubleFeedDetectionEnabled: true, paperLengthInches: 11 }
   mockStdoutResponse({ response: 'ok' });
   expect(
     await client.enableScanning({
+      bitonalThreshold: 75,
       doubleFeedDetectionEnabled: true,
       paperLengthInches: 11,
     })
   ).toEqual(ok());
   expectStdinCommand({
     command: 'enableScanning',
+    bitonalThreshold: 75,
     doubleFeedDetectionEnabled: true,
     paperLengthInches: 11,
   });
 });
 
-test('enableScanning({ doubleFeedDetectionEnabled: false, paperLengthInches: 14 })', async () => {
+test('enableScanning({ bitonalThreshold: 75, doubleFeedDetectionEnabled: false, paperLengthInches: 14 })', async () => {
   const client = createPdiScannerClient();
   mockStdoutResponse({ response: 'ok' });
   expect(
     await client.enableScanning({
+      bitonalThreshold: 75,
       doubleFeedDetectionEnabled: false,
       paperLengthInches: 14,
     })
   ).toEqual(ok());
   expectStdinCommand({
     command: 'enableScanning',
+    bitonalThreshold: 75,
     doubleFeedDetectionEnabled: false,
     paperLengthInches: 14,
   });
@@ -308,6 +312,7 @@ test('queues overlapping commands', async () => {
   const client = createPdiScannerClient();
   const command1Promise = client.getScannerStatus();
   const command2Promise = client.enableScanning({
+    bitonalThreshold: 75,
     doubleFeedDetectionEnabled: true,
     paperLengthInches: 11,
   });
@@ -315,6 +320,7 @@ test('queues overlapping commands', async () => {
     { command: 'getScannerStatus' },
     {
       command: 'enableScanning',
+      bitonalThreshold: 75,
       doubleFeedDetectionEnabled: true,
       paperLengthInches: 11,
     },
@@ -360,6 +366,7 @@ test('simple commands handle unexpected response', async () => {
   mockStdoutResponse({ response: 'scannerStatus', status: scannerStatus });
   expect(
     await client.enableScanning({
+      bitonalThreshold: 75,
       doubleFeedDetectionEnabled: true,
       paperLengthInches: 11,
     })
@@ -373,6 +380,7 @@ test('simple commands handle error response', async () => {
   mockStdoutResponse({ response: 'error', code: 'scanInProgress' });
   expect(
     await client.enableScanning({
+      bitonalThreshold: 75,
       doubleFeedDetectionEnabled: true,
       paperLengthInches: 11,
     })

--- a/libs/pdi-scanner/src/ts/scanner_client.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.ts
@@ -141,6 +141,7 @@ type PdictlCommand =
   | { command: 'getScannerStatus' }
   | {
       command: 'enableScanning';
+      bitonalThreshold: number;
       doubleFeedDetectionEnabled: boolean;
       paperLengthInches: number;
     }
@@ -378,14 +379,17 @@ export function createPdiScannerClient() {
      * automatically scan any document inserted into the scanner.
      */
     async enableScanning({
+      bitonalThreshold,
       doubleFeedDetectionEnabled,
       paperLengthInches,
     }: {
+      bitonalThreshold: number;
       doubleFeedDetectionEnabled: boolean;
       paperLengthInches: number;
     }): Promise<SimpleResult> {
       return sendSimpleCommand({
         command: 'enableScanning',
+        bitonalThreshold,
         doubleFeedDetectionEnabled,
         paperLengthInches,
       });

--- a/libs/types/src/system_settings.ts
+++ b/libs/types/src/system_settings.ts
@@ -60,6 +60,7 @@ export interface SystemSettings {
   readonly allowOfficialBallotsInTestMode?: boolean;
   readonly auth: AuthSettings;
   readonly markThresholds: MarkThresholds;
+  readonly bitonalThreshold?: number;
   readonly centralScanAdjudicationReasons: readonly AdjudicationReason[];
   readonly precinctScanAdjudicationReasons: readonly AdjudicationReason[];
   readonly disallowCastingOvervotes: boolean;
@@ -86,6 +87,7 @@ export const SystemSettingsSchema: z.ZodType<SystemSettings> = z.object({
   allowOfficialBallotsInTestMode: z.boolean().optional(),
   auth: AuthSettingsSchema,
   markThresholds: MarkThresholdsSchema,
+  bitonalThreshold: z.number().min(0).max(100).optional(),
   centralScanAdjudicationReasons: z.array(
     z.lazy(() => AdjudicationReasonSchema)
   ),
@@ -113,6 +115,12 @@ export const DEFAULT_MARK_THRESHOLDS: Readonly<MarkThresholds> = {
   definite: 0.07,
   writeInTextArea: 0.05,
 };
+
+/**
+ * The default bitonal threshold for scanning ballots.
+ * See Section 2.1.43 of the PDI PageScan software specification.
+ */
+export const DEFAULT_BITONAL_THRESHOLD = 75;
 
 export const DEFAULT_SYSTEM_SETTINGS: SystemSettings = {
   auth: {

--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -249,6 +249,7 @@
     "cSpell.words": [
       "accuvote",
       "AGPL",
+      "bitonal",
       "canonicalization",
       "canonicalize",
       "Canonicalized",


### PR DESCRIPTION
## Overview

See [Slack thread](https://votingworks.slack.com/archives/C08EMS6529F)

Adds a system setting called "Bitonal Threshold" which will be passed to the PDI scanner for black & white scans to determine the threshold for determining whether a pixel is black or white. Note that this setting cannot be per ballot style but must be per election (or theoretically, at highest granularity, per scanner). If ballots for an election are printed on multiple colors of paper then this single value must work appropriately for all of them. This likely means non-white color should be quite light if there are any white ballots in the mix and that the contrast between any two ballot paper colors should not be very high.

Though this will allow us to scan paper that is not white, scanning in grayscale would be a better way to go in the long run assuming there are no major tradeoffs to it. Scanning in grayscale means we can use a dynamic threshold, e.g. by applying otsu's method as we do in v3.

## Demo Video or Screenshot
![CleanShot 2025-02-20 at 16 49 06@2x](https://github.com/user-attachments/assets/31d1cb86-fac7-4ca0-91e5-bf8cf8d7d7f2)

## Testing Plan
Tested with the New London election for March 11, 2025. Tested on AstroBrights colors: "cosmic orange", "lunar blue", "martian green", "plasma pink". Also tested on plain white paper. In practice, a 40% threshold worked pretty well for all these colors but missed lighter marks (i.e. line/X/check through bubble) on lighter paper. Worked well with black and blue ballpoint pen, less well with green/red.
