### PR TITLE
VxDesign: Set up Google Cloud credentials for translations/audio in prod

### DIFF
--- a/Dockerfile.vxdesign
+++ b/Dockerfile.vxdesign
@@ -69,7 +69,6 @@ COPY . .
 RUN . ~/.bashrc && pnpm install --frozen-lockfile
 
 ENV NODE_ENV="production"
-ENV DEPLOY_ENV=$DEPLOY_ENV
 RUN . ~/.bashrc && pnpm -dir=apps/design/frontend build:prod
 
 EXPOSE 80

--- a/heroku.yml
+++ b/heroku.yml
@@ -3,5 +3,5 @@ build:
     web: Dockerfile.vxdesign
     worker: Dockerfile.vxdesign
 run:
-  web: . /root/.bashrc && node apps/design/backend/build/index.js
-  worker: . /root/.bashrc && node apps/design/backend/build/worker/index.js
+  web: ./run-vxdesign web
+  worker: ./run-vxdesign worker

--- a/run-vxdesign
+++ b/run-vxdesign
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "${#}" -ne 1 || "${1}" != "web" && "${1}" != "worker" ]]; then
+  echo "Usage: run-vxdesign <web|worker>"
+  exit 1
+fi
+
+APP="${1}"
+
+. /root/.bashrc
+
+# Google Cloud looks for a credentials file at the path specified by the
+# GOOGLE_APPLICATION_CREDENTIALS env var
+mkdir -p "$(dirname "${GOOGLE_APPLICATION_CREDENTIALS}")"
+echo "${GOOGLE_APPLICATION_CREDENTIALS_CONTENTS}" > "${GOOGLE_APPLICATION_CREDENTIALS}"
+
+if [[ "${APP}" == "web" ]]; then
+  node /vx/code/vxsuite/apps/design/backend/build/index.js
+elif [[ "${APP}" == "worker" ]]; then
+  node /vx/code/vxsuite/apps/design/backend/build/worker/index.js
+fi


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/6022

This PR unblocks generating translations and audio in production (and staging) VxDesign by setting up our Google Cloud credentials there! I've done so in the simplest way possible for now, and we can refine as we scale VxDesign up.

In Heroku, we just need to set the following env vars:

- `GOOGLE_APP_CREDENTIALS` - `/vx/config/google-cloud-credentials.json`
- `GOOGLE_APP_CREDENTIALS_CONTENTS` - Secret information from the Google Cloud console
- `REACT_APP_VX_ENABLE_CLOUD_TRANSLATION_AND_SPEECH_SYNTHESIS` - `TRUE`

I'll take care of setting these values in both staging and production. Note that I may hold off on enabling the last variable in production until we have a way to show multi-language options for SLI but not NH customers.

## Testing Plan

- [x] Deployed to staging and tested both previews and exports