### PR TITLE
limit render concurrency

### DIFF
--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -541,25 +541,24 @@ export async function renderAllBallotsAndCreateElectionDefinition<
   const { election } = ballotProps[0];
   assert(ballotProps.every((props) => props.election === election));
 
-  const ballotsWithLayouts = await Promise.all(
-    ballotProps.map(async (props) => {
-      // We currently only need to return errors to the user in ballot preview -
-      // we assume the ballot was proofed by the time this function is called.
-      const document = (
-        await renderBallotTemplate(renderer, template, props)
-      ).unsafeUnwrap();
-      const gridLayout = await extractGridLayout(
-        document,
-        props.ballotStyleId,
-        template
-      );
-      return {
-        document,
-        gridLayout,
-        props,
-      };
-    })
-  );
+  const ballotsWithLayouts = [];
+  for (const props of ballotProps) {
+    // We currently only need to return errors to the user in ballot preview -
+    // we assume the ballot was proofed by the time this function is called.
+    const document = (
+      await renderBallotTemplate(renderer, template, props)
+    ).unsafeUnwrap();
+    const gridLayout = await extractGridLayout(
+      document,
+      props.ballotStyleId,
+      template
+    );
+    ballotsWithLayouts.push({
+      document,
+      gridLayout,
+      props,
+    });
+  }
 
   // All ballots of a given ballot style must have the same grid layout.
   // Changing precinct/ballot type/ballot mode shouldn't matter.


### PR DESCRIPTION
## Overview

Mitigates but does not close https://github.com/votingworks/vxsuite/issues/5985.

Uses a `for` loop instead of unbounded `Promise.all` to render ballots in `renderAllBallotsAndCreateElectionDefinition`. Rendering in parallel seemed to cause resource contention and slow down overall ballot and election package export time.

## Demo Video or Screenshot

N/A

## Testing Plan
- manually tested render of large ballot package locally



