### PR TITLE
Use election org ID rather than user org ID in export background task

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -628,13 +628,10 @@ test.skip('Election package management', async () => {
 
   // Initiate an export
   await apiClient.exportElectionPackage({
-    user: vxUser,
     electionId,
     electionSerializationFormat: 'vxf',
   });
-  const expectedPayload = `{"electionId":"${electionId}","electionSerializationFormat":"vxf","orgId":${JSON.stringify(
-    vxUser.orgId
-  )}}`;
+  const expectedPayload = `{"electionId":"${electionId}","electionSerializationFormat":"vxf"}`;
   const electionPackageAfterInitiatingExport =
     await apiClient.getElectionPackage({ electionId });
   expect(electionPackageAfterInitiatingExport).toEqual<ElectionPackage>({
@@ -650,7 +647,6 @@ test.skip('Election package management', async () => {
   // Check that initiating an export before a prior has completed doesn't trigger a new background
   // task (even with a different serialization format)
   await apiClient.exportElectionPackage({
-    user: vxUser,
     electionId,
     electionSerializationFormat: 'cdf',
   });
@@ -679,7 +675,6 @@ test.skip('Election package management', async () => {
 
   // Check that initiating an export after a prior has completed does trigger a new background task
   await apiClient.exportElectionPackage({
-    user: vxUser,
     electionId,
     electionSerializationFormat: 'vxf',
   });
@@ -741,7 +736,6 @@ test.skip('Election package export', async () => {
   const { ballotLanguageConfigs, election: appElection } = electionRecord;
 
   const electionPackageFilePath = await exportElectionPackage({
-    user: vxUser,
     fileStorageClient,
     apiClient,
     electionId,
@@ -1135,7 +1129,6 @@ test.skip('Consistency of ballot hash across exports', async () => {
   });
 
   const electionPackageFilePath = await exportElectionPackage({
-    user: vxUser,
     fileStorageClient,
     apiClient,
     electionId,
@@ -1187,7 +1180,6 @@ test.skip('CDF exports', async () => {
   });
 
   const electionPackageFilePath = await exportElectionPackage({
-    user: vxUser,
     fileStorageClient,
     apiClient,
     electionId,
@@ -1442,7 +1434,6 @@ test('v3-compatible election package', async () => {
   });
 
   const electionPackageAndBallotsFileName = await exportElectionPackage({
-    user: vxUser,
     fileStorageClient,
     apiClient,
     electionId,
@@ -1451,7 +1442,7 @@ test('v3-compatible election package', async () => {
   });
   const electionPackageAndBallotsZip = await openZip(
     fileStorageClient.getRawFile(
-      join(vxUser.orgId, electionPackageAndBallotsFileName)
+      join(nonVxUser.orgId, electionPackageAndBallotsFileName)
     )!
   );
   const electionPackageAndBallotsZipEntries = getEntries(

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -479,15 +479,13 @@ function buildApi({ auth, workspace, translator }: AppContext) {
     exportElectionPackage({
       electionId,
       electionSerializationFormat,
-      user,
-    }: WithUserInfo<{
+    }: {
       electionId: ElectionId;
       electionSerializationFormat: ElectionSerializationFormat;
-    }>): Promise<void> {
+    }): Promise<void> {
       return store.createElectionPackageBackgroundTask(
         electionId,
-        electionSerializationFormat,
-        user.orgId
+        electionSerializationFormat
       );
     },
 

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -405,8 +405,7 @@ export class Store {
 
   async createElectionPackageBackgroundTask(
     electionId: ElectionId,
-    electionSerializationFormat: ElectionSerializationFormat,
-    orgId: string
+    electionSerializationFormat: ElectionSerializationFormat
   ): Promise<void> {
     await this.db.withClient(async (client) =>
       client.withTransaction(async () => {
@@ -421,7 +420,6 @@ export class Store {
           {
             electionId,
             electionSerializationFormat,
-            orgId,
           }
         );
         await client.query(

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -113,11 +113,9 @@ export async function generateElectionPackageAndBallots(
   {
     electionId,
     electionSerializationFormat,
-    orgId,
   }: {
     electionId: ElectionId;
     electionSerializationFormat: ElectionSerializationFormat;
-    orgId: string;
   }
 ): Promise<void> {
   const { store } = workspace;
@@ -129,6 +127,7 @@ export async function generateElectionPackageAndBallots(
     precincts,
     ballotStyles,
     ballotTemplateId,
+    orgId,
   } = await store.getElection(electionId);
 
   // This function makes separate zips for ballot package and election package

--- a/apps/design/backend/src/worker/tasks.ts
+++ b/apps/design/backend/src/worker/tasks.ts
@@ -23,7 +23,6 @@ export async function processBackgroundTask(
         z.object({
           electionId: ElectionIdSchema,
           electionSerializationFormat: ElectionSerializationFormatSchema,
-          orgId: z.string(),
         })
       ).unsafeUnwrap();
       await generateElectionPackageAndBallots(context, parsedPayload);

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -197,14 +197,12 @@ export const ELECTION_PACKAGE_FILE_NAME_REGEX =
   /election-package-and-ballots-([0-9a-z]{7})-([0-9a-z]{7})\.zip$/;
 
 export async function exportElectionPackage({
-  user,
   apiClient,
   electionId,
   fileStorageClient,
   workspace,
   electionSerializationFormat,
 }: {
-  user: User;
   apiClient: ApiClient;
   electionId: ElectionId;
   fileStorageClient: FileStorageClient;
@@ -212,7 +210,6 @@ export async function exportElectionPackage({
   electionSerializationFormat: ElectionSerializationFormat;
 }): Promise<string> {
   await apiClient.exportElectionPackage({
-    user,
     electionId,
     electionSerializationFormat,
   });

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -360,13 +360,12 @@ export const exportElectionPackage = {
   useMutation() {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
-    const user = assertDefined(getUser.useQuery().data);
 
     return useMutation(
       (input: {
         electionId: ElectionId;
         electionSerializationFormat: ElectionSerializationFormat;
-      }) => apiClient.exportElectionPackage({ ...input, user }),
+      }) => apiClient.exportElectionPackage(input),
       {
         async onSuccess(_, { electionId }) {
           await queryClient.invalidateQueries(

--- a/apps/design/frontend/src/export_screen.test.tsx
+++ b/apps/design/frontend/src/export_screen.test.tsx
@@ -130,7 +130,6 @@ test('export election package and ballots', async () => {
   const taskCreatedAt = new Date();
   apiMock.exportElectionPackage
     .expectCallWith({
-      user: nonVxUser,
       electionId,
       electionSerializationFormat: 'vxf',
     })
@@ -190,7 +189,6 @@ test('export election package error handling', async () => {
   const taskCreatedAt = new Date();
   apiMock.exportElectionPackage
     .expectCallWith({
-      user: nonVxUser,
       electionId,
       electionSerializationFormat: 'vxf',
     })
@@ -284,7 +282,6 @@ test.skip('using CDF', async () => {
 
   apiMock.exportElectionPackage
     .expectCallWith({
-      user: nonVxUser,
       electionId,
       electionSerializationFormat: 'cdf',
     })


### PR DESCRIPTION
## Overview

A quick follow-up to https://github.com/votingworks/vxsuite/pull/6039

Rather than passing the user org ID to the background task for export, I think it makes sense to pass the election org ID. The one circumstance where these two can differ is when a Vx user with the Vx org ID exports an election package for a customer. Feature flags, like whether to export with translations and audio, should be determined given the election org ID rather than the exporting user org ID. An NH election package exported by a Vx user shouldn't have translations and audio enabled for example.

## Testing Plan

- [x] Updated automated test
- [ ] Tested in staging