### PR TITLE
ci: set test timeout to 10s in CI only

### DIFF
--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -26,10 +26,6 @@ import {
 } from '../test/api_mock_data';
 import { MARK_RESULTS_OFFICIAL_BUTTON_TEXT } from './components/mark_official_button';
 
-vi.setConfig({
-  testTimeout: 10_000,
-});
-
 const electionTwoPartyPrimaryDefinition =
   readElectionTwoPartyPrimaryDefinition();
 

--- a/apps/design/backend/src/ballot_style_reports.test.ts
+++ b/apps/design/backend/src/ballot_style_reports.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi } from 'vitest';
+import { expect, test } from 'vitest';
 import { readElectionGeneral } from '@votingworks/fixtures';
 import { createPlaywrightRenderer } from '@votingworks/hmpb';
 import {
@@ -8,10 +8,6 @@ import {
 } from '@votingworks/types';
 import { generateBallotStyleId } from '@votingworks/utils';
 import { renderBallotStyleReadinessReport } from './ballot_style_reports';
-
-vi.setConfig({
-  testTimeout: 10_000,
-});
 
 const electionGeneral = readElectionGeneral();
 const { ENGLISH, CHINESE_SIMPLIFIED, SPANISH } = LanguageCode;
@@ -57,4 +53,4 @@ test('PDF layout regression test', async () => {
   await expect(reportPdf).toMatchPdfSnapshot();
 
   await renderer.cleanup();
-}, 10_000);
+});

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -290,7 +290,7 @@ describe('Contests tab', () => {
       election.districts[0].name,
       'Edit',
     ]);
-  }, 10_000);
+  });
 
   test('editing a candidate contest (primary election)', async () => {
     const electionRecord = makeElectionRecord(
@@ -1056,7 +1056,7 @@ describe('Contests tab', () => {
 
     await screen.findByRole('button', { name: 'Reorder Contests' });
     expect(getRowOrder()).toEqual(newOrder);
-  }, 10_000);
+  });
 
   test('changing contests is disabled when ballots are finalized', async () => {
     const electionRecord = generalElectionRecord(user.orgId);

--- a/apps/design/frontend/src/geography_screen.test.tsx
+++ b/apps/design/frontend/src/geography_screen.test.tsx
@@ -600,7 +600,7 @@ describe('Precincts tab', () => {
         .getAllByRole('cell')
         .map((td) => td.textContent)
     ).toEqual([changedPrecinct.splits[1].name, election.districts[1].name, '']);
-  }, 10_000);
+  });
 
   test('editing a precinct - removing splits', async () => {
     const electionRecord = generalElectionRecord(nonVxUser.orgId);

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -618,7 +618,7 @@ test('printing ballots', async () => {
   assert(interpretationChinese);
   assert(interpretationChinese.type === 'InterpretedBmdPage');
   expectVotesEqual(interpretationChinese.votes, mockVotes);
-}, 10_000);
+});
 
 test('addDiagnosticRecord', async () => {
   await apiClient.addDiagnosticRecord({

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -248,12 +248,12 @@ beforeEach(async () => {
     patConnectionStatusReader,
     clock,
   });
-}, 10_000);
+});
 
 afterEach(async () => {
   await machine.cleanUp();
   vi.resetAllMocks();
-}, 10_000);
+});
 
 async function setMockStatusAndIncrementClock(status: MockPaperHandlerStatus) {
   // Without this sleep the effects of `SimulatedCLock.increment()` are not

--- a/vitest.config.shared.mts
+++ b/vitest.config.shared.mts
@@ -19,6 +19,7 @@ export const base: vitest.ViteUserConfig = {
     maxWorkers: isCI ? 6 : undefined,
     reporters: isCI ? ['verbose', 'junit'] : [],
     outputFile: isCI ? 'reports/junit.xml' : undefined,
+    testTimeout: isCI ? 10_000 : undefined,
   },
 };
 


### PR DESCRIPTION

## Overview

Removes ad hoc test timeout configs that were already 10s, assuming they are set to that for CI purposes.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.