### PR TITLE
ci: perform recursive builds sequentially

### DIFF
--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -10,7 +10,9 @@
     "schema.sql"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -9,7 +9,9 @@
     "prodserver"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "pnpm type-check && vite build",
     "build:stubs": "script/build-stubs fs:src/stubs/fs.ts glob:src/stubs/glob.ts os:src/stubs/os.ts jsdom:src/stubs/jsdom.ts",
     "clean": "pnpm --filter $npm_package_name... clean:self",

--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -12,7 +12,9 @@
     "schema.sql"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/apps/central-scan/frontend/package.json
+++ b/apps/central-scan/frontend/package.json
@@ -9,7 +9,9 @@
     "prodserver"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "pnpm type-check && vite build",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build",

--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -12,7 +12,9 @@
     "schema.sql"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:prod": "pnpm --filter-prod $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",

--- a/apps/design/frontend/package.json
+++ b/apps/design/frontend/package.json
@@ -9,7 +9,9 @@
     "prodserver"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:prod": "pnpm --filter-prod $npm_package_name... build:self",
     "build:self": "pnpm type-check && vite build",
     "clean": "pnpm --filter $npm_package_name... clean:self",

--- a/apps/mark-scan/backend/package.json
+++ b/apps/mark-scan/backend/package.json
@@ -9,7 +9,9 @@
     "build"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json && copyfiles -u 3 src/custom-paper-handler/diagnostic/*.json build/custom-paper-handler/diagnostic",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/apps/mark-scan/frontend/package.json
+++ b/apps/mark-scan/frontend/package.json
@@ -9,7 +9,9 @@
     "prodserver"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "pnpm type-check && vite build",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build",

--- a/apps/mark/backend/package.json
+++ b/apps/mark/backend/package.json
@@ -9,7 +9,9 @@
     "build"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/apps/mark/frontend/package.json
+++ b/apps/mark/frontend/package.json
@@ -9,7 +9,9 @@
     "prodserver"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "pnpm type-check && vite build",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build",

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -12,7 +12,9 @@
     "schema.sql"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json && copyfiles -u 2 src/printing/test-print.pdf build/printing",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -9,7 +9,9 @@
     "prodserver"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "pnpm type-check && vite build",
     "build:stubs": "script/build-stubs fs:src/stubs/fs.ts os:src/stubs/os.ts",
     "clean": "pnpm --filter $npm_package_name... clean:self",

--- a/libs/api/package.json
+++ b/libs/api/package.json
@@ -10,7 +10,9 @@
     "build"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -7,7 +7,9 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -10,7 +10,9 @@
     "build"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -9,7 +9,9 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -11,7 +11,9 @@
   ],
   "scripts": {
     "benchmark": "cd benchmarks && vitest",
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "pnpm install:rust-addon && pnpm build:rust-addon && pnpm build:ts",
     "build:rust-addon": "cargo-cp-artifact -nc build/addon.node -- cargo build --message-format=json-render-diagnostics --release --offline",
     "build:ts": "tsc --build tsconfig.build.json",

--- a/libs/basics/package.json
+++ b/libs/basics/package.json
@@ -7,7 +7,9 @@
   "main": "build/index.js",
   "types": "build/index.d.js",
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/bmd-ballot-fixtures/package.json
+++ b/libs/bmd-ballot-fixtures/package.json
@@ -12,7 +12,9 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/cdf-schema-builder/package.json
+++ b/libs/cdf-schema-builder/package.json
@@ -12,7 +12,9 @@
     "build"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/custom-paper-handler/package.json
+++ b/libs/custom-paper-handler/package.json
@@ -6,7 +6,9 @@
   "license": "GPL-3.0-only",
   "main": "build/index.js",
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/custom-scanner/package.json
+++ b/libs/custom-scanner/package.json
@@ -8,7 +8,9 @@
   "main": "build/index.js",
   "scripts": {
     "analyze-packets": "cd tools/analyze-packets && vite",
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -8,7 +8,9 @@
   "types": "build/index.d.ts",
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/dev-dock/backend/package.json
+++ b/libs/dev-dock/backend/package.json
@@ -7,7 +7,9 @@
   "main": "build/index.js",
   "types": "build/index.d.js",
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/dev-dock/frontend/package.json
+++ b/libs/dev-dock/frontend/package.json
@@ -7,7 +7,9 @@
   "main": "build/index.js",
   "types": "build/index.d.js",
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/eslint-plugin-vx/package.json
+++ b/libs/eslint-plugin-vx/package.json
@@ -12,7 +12,9 @@
   "scripts": {
     "type-check": "tsc --build",
     "type-check:watch": "tsc --build --watch",
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build --watch tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",

--- a/libs/fixture-generators/package.json
+++ b/libs/fixture-generators/package.json
@@ -10,7 +10,9 @@
   },
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/fixtures/package.json
+++ b/libs/fixtures/package.json
@@ -13,7 +13,9 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/fs/package.json
+++ b/libs/fs/package.json
@@ -10,7 +10,9 @@
     "build"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/fujitsu-thermal-printer/package.json
+++ b/libs/fujitsu-thermal-printer/package.json
@@ -6,7 +6,9 @@
   "license": "GPL-3.0-only",
   "main": "build/index.js",
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/grout/package.json
+++ b/libs/grout/package.json
@@ -7,7 +7,9 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/grout/test-utils/package.json
+++ b/libs/grout/test-utils/package.json
@@ -7,7 +7,9 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/hmpb/package.json
+++ b/libs/hmpb/package.json
@@ -10,7 +10,9 @@
     "bin"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/image-utils/package.json
+++ b/libs/image-utils/package.json
@@ -7,7 +7,9 @@
   "main": "build/index.js",
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -11,7 +11,9 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "build:generate-docs": "pnpm esr --cache ./scripts/generate_documentation.ts",
     "build:generate-typescript-types": "pnpm esr --cache ./scripts/generate_types_from_toml.ts",

--- a/libs/mark-flow-ui/package.json
+++ b/libs/mark-flow-ui/package.json
@@ -12,7 +12,9 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/message-coder/package.json
+++ b/libs/message-coder/package.json
@@ -6,7 +6,9 @@
   "license": "GPL-3.0-only",
   "main": "build/index.js",
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/monorepo-utils/package.json
+++ b/libs/monorepo-utils/package.json
@@ -8,7 +8,9 @@
   "types": "build/index.d.ts",
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/pdi-scanner/package.json
+++ b/libs/pdi-scanner/package.json
@@ -10,7 +10,9 @@
     "build"
   ],
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "pnpm install:rust-addon && pnpm build:rust-addon && pnpm build:ts",
     "build:ts": "tsc --build tsconfig.build.json",
     "build:rust-addon": "cargo build --release --offline",

--- a/libs/printing/package.json
+++ b/libs/printing/package.json
@@ -7,7 +7,9 @@
   "main": "build/index.js",
   "types": "build/index.d.js",
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -11,7 +11,9 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -11,7 +11,9 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -12,7 +12,9 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json && pnpm build:app-strings-catalog",
     "build:app-strings-catalog": "i18next && ./scripts/finalize-app-strings-catalog",
     "check:app-strings-catalog": "./scripts/check-app-strings-catalog",

--- a/libs/usb-drive/package.json
+++ b/libs/usb-drive/package.json
@@ -7,7 +7,9 @@
   "main": "build/index.js",
   "types": "build/index.d.js",
   "scripts": {
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -11,7 +11,9 @@
   ],
   "scripts": {
     "type-check": "tsc --build",
-    "build": "pnpm --filter $npm_package_name... build:self",
+    "build": "is-ci build:ci build:dev",
+    "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
+    "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",


### PR DESCRIPTION
## Overview

Something with `tsc` gets tripped up when multiple processes try to build the same package simultaneously. We haven't seen this be a problem in dev, so I'm only making this change in CI. It will slow CI down a bit, but it should reduce flakiness. Long term, I don't think we want this recursive `pnpm` package-based build setup, so I don't feel bad disabling it here.

An alternative, if we don't like how messy this makes the `package.json` files, would be to simply always do these builds sequentially. For example, on my M4 MacBook Pro `apps/scan/frontend` builds from a clean state in 45s without `CI=true` and in 50s with `CI=true`.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.