### PR TITLE
feat(scan): include scanner component in stress test

### DIFF
--- a/apps/scan/backend/src/electrical_testing/app.ts
+++ b/apps/scan/backend/src/electrical_testing/app.ts
@@ -1,8 +1,8 @@
 import express, { Application } from 'express';
 import * as grout from '@votingworks/grout';
-import { type ElectricalTestingServerContext } from './server';
+import { type ServerContext } from './context';
 
-function buildApi({ workspace, controller }: ElectricalTestingServerContext) {
+function buildApi({ workspace, controller }: ServerContext) {
   const { store } = workspace;
 
   return grout.createApi({
@@ -18,7 +18,7 @@ function buildApi({ workspace, controller }: ElectricalTestingServerContext) {
 
 export type ElectricalTestingApi = ReturnType<typeof buildApi>;
 
-export function buildApp(context: ElectricalTestingServerContext): Application {
+export function buildApp(context: ServerContext): Application {
   const app: Application = express();
   const api = buildApi(context);
   app.use('/api', grout.buildRouter(api, express));

--- a/apps/scan/backend/src/electrical_testing/app.ts
+++ b/apps/scan/backend/src/electrical_testing/app.ts
@@ -1,20 +1,24 @@
 import express, { Application } from 'express';
 import * as grout from '@votingworks/grout';
-import { ServerContext } from './context';
+import { type ElectricalTestingServerContext } from './server';
 
-function buildApi({ workspace }: ServerContext) {
+function buildApi({ workspace, controller }: ElectricalTestingServerContext) {
   const { store } = workspace;
 
   return grout.createApi({
     getElectricalTestingStatusMessages() {
       return store.getElectricalTestingStatusMessages();
     },
+
+    stopElectricalTesting() {
+      controller.abort('User requested testing be stopped');
+    },
   });
 }
 
 export type ElectricalTestingApi = ReturnType<typeof buildApi>;
 
-export function buildApp(context: ServerContext): Application {
+export function buildApp(context: ElectricalTestingServerContext): Application {
   const app: Application = express();
   const api = buildApi(context);
   app.use('/api', grout.buildRouter(api, express));

--- a/apps/scan/backend/src/electrical_testing/background.test.ts
+++ b/apps/scan/backend/src/electrical_testing/background.test.ts
@@ -1,7 +1,7 @@
 import { createImageData } from 'canvas';
 import { expect, Mocked, test, vi } from 'vitest';
 import { printAndScanLoop } from './background';
-import { ElectricalTestingServerContext } from './server';
+import { ServerContext } from './context';
 import { withApp } from '../../test/helpers/pdi_helpers';
 import { wrapLegacyPrinter } from '../printing/printer';
 import { delays } from '../scanners/pdi/state_machine';
@@ -18,7 +18,7 @@ function createMockSimpleScannerClient(): Mocked<SimpleScannerClient> {
 }
 
 const electricalTest = test.extend<{
-  context: ElectricalTestingServerContext;
+  context: ServerContext;
   mockSimpleScannerClient: Mocked<SimpleScannerClient>;
   // eslint-disable-next-line vitest/valid-title
 }>({
@@ -31,7 +31,7 @@ const electricalTest = test.extend<{
   context: async ({ mockSimpleScannerClient }, use) => {
     await withApp(async (context) => {
       const controller = new AbortController();
-      const testingContext: ElectricalTestingServerContext = {
+      const testingContext: ServerContext = {
         auth: context.mockAuth,
         logger: context.logger,
         printer: wrapLegacyPrinter(context.mockPrinterHandler.printer),

--- a/apps/scan/backend/src/electrical_testing/background.test.ts
+++ b/apps/scan/backend/src/electrical_testing/background.test.ts
@@ -1,0 +1,144 @@
+import { createImageData } from 'canvas';
+import { expect, Mocked, test, vi } from 'vitest';
+import { printAndScanLoop } from './background';
+import { ElectricalTestingServerContext } from './server';
+import { withApp } from '../../test/helpers/pdi_helpers';
+import { wrapLegacyPrinter } from '../printing/printer';
+import { delays } from '../scanners/pdi/state_machine';
+import { SimpleScannerClient } from './simple_scanner_client';
+
+function createMockSimpleScannerClient(): Mocked<SimpleScannerClient> {
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    reconnect: vi.fn(),
+    enableScanning: vi.fn(),
+    ejectAndRescanPaperIfPresent: vi.fn(),
+  };
+}
+
+const electricalTest = test.extend<{
+  context: ElectricalTestingServerContext;
+  mockSimpleScannerClient: Mocked<SimpleScannerClient>;
+  // eslint-disable-next-line vitest/valid-title
+}>({
+  // eslint-disable-next-line no-empty-pattern
+  mockSimpleScannerClient: async ({}, use) => {
+    const scannerClient = createMockSimpleScannerClient();
+    await use(scannerClient);
+  },
+
+  context: async ({ mockSimpleScannerClient }, use) => {
+    await withApp(async (context) => {
+      const controller = new AbortController();
+      const testingContext: ElectricalTestingServerContext = {
+        auth: context.mockAuth,
+        logger: context.logger,
+        printer: wrapLegacyPrinter(context.mockPrinterHandler.printer),
+        usbDrive: context.mockUsbDrive.usbDrive,
+        workspace: context.workspace,
+        controller,
+        scannerClient: mockSimpleScannerClient,
+      };
+
+      await use(testingContext);
+    });
+  },
+});
+
+electricalTest(
+  'printAndScanLoop fails if scanner connection fails',
+  async ({ context, mockSimpleScannerClient }) => {
+    mockSimpleScannerClient.connect.mockRejectedValue(
+      new Error('Scanner is not connected')
+    );
+    await expect(printAndScanLoop(context)).rejects.toThrow(
+      'Scanner is not connected'
+    );
+  }
+);
+
+electricalTest(
+  'printAndScanLoop fails if enabling scanner fails',
+  async ({ context, mockSimpleScannerClient }) => {
+    mockSimpleScannerClient.enableScanning.mockRejectedValue(
+      new Error('Failed to enable scanner')
+    );
+    await expect(printAndScanLoop(context)).rejects.toThrow(
+      'Failed to enable scanner'
+    );
+  }
+);
+
+electricalTest(
+  'printAndScanLoop connects, ejects paper, and disconnects when aborted',
+  async ({ context, mockSimpleScannerClient }) => {
+    // don't enter the main loop
+    context.controller.abort();
+
+    await printAndScanLoop(context);
+
+    expect(mockSimpleScannerClient.connect).toHaveBeenCalled();
+    expect(
+      mockSimpleScannerClient.ejectAndRescanPaperIfPresent
+    ).toHaveBeenCalled();
+    expect(mockSimpleScannerClient.disconnect).toHaveBeenCalled();
+  }
+);
+
+electricalTest(
+  'printAndScanLoop ejects paper to re-scan after a scan completes',
+  async ({ context, mockSimpleScannerClient }) => {
+    vi.useFakeTimers({
+      shouldAdvanceTime: true,
+    });
+    const loopPromise = printAndScanLoop(context);
+    const [onScannerEvent] = mockSimpleScannerClient.connect.mock.calls[0];
+
+    onScannerEvent({
+      event: 'scanComplete',
+      images: [createImageData(1, 1), createImageData(1, 1)],
+    });
+
+    // wait long enough that we eject the paper
+    await vi.advanceTimersByTimeAsync(
+      delays.DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT
+    );
+
+    await vi.waitFor(() => {
+      expect(
+        mockSimpleScannerClient.ejectAndRescanPaperIfPresent
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    // exit the loop
+    context.controller.abort();
+
+    await loopPromise;
+  }
+);
+
+electricalTest(
+  'printAndScanLoop reconnects after a scanner error',
+  async ({ context, mockSimpleScannerClient }) => {
+    vi.useFakeTimers({
+      shouldAdvanceTime: true,
+    });
+    const loopPromise = printAndScanLoop(context);
+    const [onScannerEvent] = mockSimpleScannerClient.connect.mock.calls[0];
+
+    onScannerEvent({
+      event: 'error',
+      code: 'scanFailed',
+    });
+
+    await vi.waitFor(() => {
+      expect(mockSimpleScannerClient.reconnect).toHaveBeenCalled();
+    });
+
+    // exit the loop
+    context.controller.abort();
+
+    await loopPromise;
+  }
+);

--- a/apps/scan/backend/src/electrical_testing/background.ts
+++ b/apps/scan/backend/src/electrical_testing/background.ts
@@ -1,6 +1,8 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
+import { DateTime } from 'luxon';
+import { saveSheetImages } from '@votingworks/ballot-interpreter';
 import {
   assert,
   err,
@@ -9,9 +11,12 @@ import {
   Result,
   sleep,
 } from '@votingworks/basics';
+import { LogEventId } from '@votingworks/logging';
+import { ScannerEvent } from '@votingworks/pdi-scanner';
 
 import { constructAuthMachineState } from '../util/auth';
-import { ServerContext } from './context';
+import { type ElectricalTestingServerContext } from './server';
+import { delays } from '../scanners/pdi/state_machine';
 
 const CARD_READ_AND_USB_DRIVE_WRITE_INTERVAL_SECONDS = 5;
 const USB_DRIVE_FILE_NAME = 'electrical-testing.txt';
@@ -26,9 +31,16 @@ export async function cardReadAndUsbDriveWriteLoop({
   auth,
   usbDrive,
   workspace,
-}: ServerContext): Promise<void> {
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
+  controller,
+  logger,
+}: ElectricalTestingServerContext): Promise<void> {
+  controller.signal.addEventListener('abort', () => {
+    void logger.log(LogEventId.BackgroundTaskCancelled, 'system', {
+      message: `Card read and USB drive write loop stopping. Reason: ${controller.signal.reason}`,
+    });
+  });
+
+  while (!controller.signal.aborted) {
     const machineState = constructAuthMachineState(workspace.store);
     const cardReadResult = await auth.readCardData(machineState);
     workspace.store.setElectricalTestingStatusMessage(
@@ -56,9 +68,114 @@ export async function cardReadAndUsbDriveWriteLoop({
   }
 }
 
-export async function printAndScanLoop(): Promise<void> {
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    await sleep(5000);
+export async function printAndScanLoop({
+  workspace,
+  controller,
+  logger,
+  scannerClient,
+}: ElectricalTestingServerContext): Promise<void> {
+  controller.signal.addEventListener('abort', () => {
+    void logger.log(LogEventId.BackgroundTaskCancelled, 'system', {
+      message: `Print and scan loop stopping. Reason: ${controller.signal.reason}`,
+    });
+  });
+
+  let lastScanTime: DateTime | undefined;
+  let shouldResetScanning = false;
+
+  async function onScannerEvent(scannerEvent: ScannerEvent) {
+    workspace.store.setElectricalTestingStatusMessage(
+      'scanner',
+      `Received event: ${scannerEvent.event}`
+    );
+
+    if (scannerEvent.event === 'scanComplete') {
+      lastScanTime = DateTime.now();
+
+      const [front, back] = scannerEvent.images;
+      workspace.store.setElectricalTestingStatusMessage(
+        'scanner',
+        `Scanned sheet: front=${front.width}×${front.height}, back=${back.width}×${back.height}`
+      );
+
+      await saveSheetImages({
+        sheetId: `electrical-testing-${lastScanTime.toISO()}`,
+        ballotImagesPath: workspace.ballotImagesPath,
+        images: scannerEvent.images,
+      });
+    }
+
+    if (scannerEvent.event === 'error') {
+      shouldResetScanning = true;
+      workspace.store.setElectricalTestingStatusMessage(
+        'scanner',
+        `Scanner error: ${scannerEvent.code}`
+      );
+    }
   }
+
+  try {
+    await scannerClient.connect(onScannerEvent);
+    await scannerClient.enableScanning();
+  } catch (error) {
+    workspace.store.setElectricalTestingStatusMessage(
+      'scanner',
+      resultToString(err(error))
+    );
+    throw error;
+  }
+
+  workspace.store.setElectricalTestingStatusMessage(
+    'scanner',
+    'Scanning enabled; waiting for paper'
+  );
+
+  await scannerClient.ejectAndRescanPaperIfPresent();
+
+  while (!controller.signal.aborted) {
+    if (shouldResetScanning) {
+      workspace.store.setElectricalTestingStatusMessage(
+        'scanner',
+        'Resetting scanning'
+      );
+      await scannerClient.reconnect();
+      await scannerClient.enableScanning();
+      await scannerClient.ejectAndRescanPaperIfPresent();
+      workspace.store.setElectricalTestingStatusMessage(
+        'scanner',
+        'Scanning enabled; waiting for paper'
+      );
+      shouldResetScanning = false;
+      lastScanTime = undefined;
+    }
+
+    if (
+      lastScanTime &&
+      DateTime.now().diff(lastScanTime).as('milliseconds') >
+        delays.DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT
+    ) {
+      await scannerClient.ejectAndRescanPaperIfPresent();
+
+      workspace.store.setElectricalTestingStatusMessage(
+        'scanner',
+        'Ejected document to re-scan'
+      );
+
+      lastScanTime = undefined;
+    }
+
+    await sleep(100);
+  }
+
+  workspace.store.setElectricalTestingStatusMessage(
+    'scanner',
+    'Print and scan loop stopping'
+  );
+
+  await scannerClient.disconnect();
+
+  workspace.store.setElectricalTestingStatusMessage(
+    'scanner',
+    'Scanner disconnected'
+  );
 }

--- a/apps/scan/backend/src/electrical_testing/background.ts
+++ b/apps/scan/backend/src/electrical_testing/background.ts
@@ -15,7 +15,7 @@ import { LogEventId } from '@votingworks/logging';
 import { ScannerEvent } from '@votingworks/pdi-scanner';
 
 import { constructAuthMachineState } from '../util/auth';
-import { type ElectricalTestingServerContext } from './server';
+import { type ServerContext } from './context';
 import { delays } from '../scanners/pdi/state_machine';
 
 const CARD_READ_AND_USB_DRIVE_WRITE_INTERVAL_SECONDS = 5;
@@ -33,7 +33,7 @@ export async function cardReadAndUsbDriveWriteLoop({
   workspace,
   controller,
   logger,
-}: ElectricalTestingServerContext): Promise<void> {
+}: ServerContext): Promise<void> {
   controller.signal.addEventListener('abort', () => {
     void logger.log(LogEventId.BackgroundTaskCancelled, 'system', {
       message: `Card read and USB drive write loop stopping. Reason: ${controller.signal.reason}`,
@@ -73,7 +73,7 @@ export async function printAndScanLoop({
   controller,
   logger,
   scannerClient,
-}: ElectricalTestingServerContext): Promise<void> {
+}: ServerContext): Promise<void> {
   controller.signal.addEventListener('abort', () => {
     void logger.log(LogEventId.BackgroundTaskCancelled, 'system', {
       message: `Print and scan loop stopping. Reason: ${controller.signal.reason}`,

--- a/apps/scan/backend/src/electrical_testing/context.ts
+++ b/apps/scan/backend/src/electrical_testing/context.ts
@@ -4,6 +4,7 @@ import { UsbDrive } from '@votingworks/usb-drive';
 
 import { Printer } from '../printing/printer';
 import { Workspace } from '../util/workspace';
+import { SimpleScannerClient } from './simple_scanner_client';
 
 export interface ServerContext {
   auth: InsertedSmartCardAuthApi;
@@ -11,4 +12,6 @@ export interface ServerContext {
   printer: Printer;
   usbDrive: UsbDrive;
   workspace: Workspace;
+  scannerClient: SimpleScannerClient;
+  controller: AbortController;
 }

--- a/apps/scan/backend/src/electrical_testing/server.ts
+++ b/apps/scan/backend/src/electrical_testing/server.ts
@@ -4,21 +4,13 @@ import { PORT } from '../globals';
 import { buildApp } from './app';
 import { cardReadAndUsbDriveWriteLoop, printAndScanLoop } from './background';
 import { ServerContext } from './context';
-import {
-  createSimpleScannerClient,
-  SimpleScannerClient,
-} from './simple_scanner_client';
-
-export interface ElectricalTestingServerContext extends ServerContext {
-  scannerClient: SimpleScannerClient;
-  controller: AbortController;
-}
+import { createSimpleScannerClient } from './simple_scanner_client';
 
 export function startElectricalTestingServer(context: ServerContext): void {
   const { logger } = context;
   const controller = new AbortController();
   const client = createSimpleScannerClient();
-  const testContext: ElectricalTestingServerContext = {
+  const testContext: ServerContext = {
     ...context,
     scannerClient: client,
     controller,

--- a/apps/scan/backend/src/electrical_testing/server.ts
+++ b/apps/scan/backend/src/electrical_testing/server.ts
@@ -4,20 +4,12 @@ import { PORT } from '../globals';
 import { buildApp } from './app';
 import { cardReadAndUsbDriveWriteLoop, printAndScanLoop } from './background';
 import { ServerContext } from './context';
-import { createSimpleScannerClient } from './simple_scanner_client';
 
 export function startElectricalTestingServer(context: ServerContext): void {
   const { logger } = context;
-  const controller = new AbortController();
-  const client = createSimpleScannerClient();
-  const testContext: ServerContext = {
-    ...context,
-    scannerClient: client,
-    controller,
-  };
   const cardReadAndUsbDriveWriteLoopPromise =
-    cardReadAndUsbDriveWriteLoop(testContext);
-  const printAndScanLoopPromise = printAndScanLoop(testContext);
+    cardReadAndUsbDriveWriteLoop(context);
+  const printAndScanLoopPromise = printAndScanLoop(context);
 
   void logger.log(LogEventId.BackgroundTaskStarted, 'system', {
     disposition: 'success',
@@ -59,7 +51,7 @@ export function startElectricalTestingServer(context: ServerContext): void {
       });
     });
 
-  const app = buildApp(testContext);
+  const app = buildApp(context);
 
   app.listen(PORT, async () => {
     await logger.log(LogEventId.ApplicationStartup, 'system', {

--- a/apps/scan/backend/src/electrical_testing/server.ts
+++ b/apps/scan/backend/src/electrical_testing/server.ts
@@ -4,14 +4,70 @@ import { PORT } from '../globals';
 import { buildApp } from './app';
 import { cardReadAndUsbDriveWriteLoop, printAndScanLoop } from './background';
 import { ServerContext } from './context';
+import {
+  createSimpleScannerClient,
+  SimpleScannerClient,
+} from './simple_scanner_client';
+
+export interface ElectricalTestingServerContext extends ServerContext {
+  scannerClient: SimpleScannerClient;
+  controller: AbortController;
+}
 
 export function startElectricalTestingServer(context: ServerContext): void {
   const { logger } = context;
+  const controller = new AbortController();
+  const client = createSimpleScannerClient();
+  const testContext: ElectricalTestingServerContext = {
+    ...context,
+    scannerClient: client,
+    controller,
+  };
+  const cardReadAndUsbDriveWriteLoopPromise =
+    cardReadAndUsbDriveWriteLoop(testContext);
+  const printAndScanLoopPromise = printAndScanLoop(testContext);
 
-  setTimeout(() => cardReadAndUsbDriveWriteLoop(context));
-  setTimeout(() => printAndScanLoop());
+  void logger.log(LogEventId.BackgroundTaskStarted, 'system', {
+    disposition: 'success',
+    message: 'Starting card read loop',
+  });
 
-  const app = buildApp(context);
+  void logger.log(LogEventId.BackgroundTaskStarted, 'system', {
+    disposition: 'success',
+    message: 'Starting print and scan loop',
+  });
+
+  cardReadAndUsbDriveWriteLoopPromise
+    .then(() => {
+      void logger.log(LogEventId.BackgroundTaskCompleted, 'system', {
+        disposition: 'success',
+        message: 'Card read and USB drive write loop completed',
+      });
+    })
+    .catch((error) => {
+      void logger.log(LogEventId.BackgroundTaskFailure, 'system', {
+        disposition: 'failure',
+        message: 'Card read and USB drive write loop failed',
+        error,
+      });
+    });
+
+  printAndScanLoopPromise
+    .then(() => {
+      void logger.log(LogEventId.BackgroundTaskCompleted, 'system', {
+        disposition: 'success',
+        message: 'Print and scan loop completed',
+      });
+    })
+    .catch((error) => {
+      void logger.log(LogEventId.BackgroundTaskFailure, 'system', {
+        disposition: 'failure',
+        message: 'Print and scan loop failed',
+        error,
+      });
+    });
+
+  const app = buildApp(testContext);
 
   app.listen(PORT, async () => {
     await logger.log(LogEventId.ApplicationStartup, 'system', {

--- a/apps/scan/backend/src/electrical_testing/simple_scanner_client.ts
+++ b/apps/scan/backend/src/electrical_testing/simple_scanner_client.ts
@@ -1,0 +1,64 @@
+import { assert, Optional } from '@votingworks/basics';
+import {
+  createPdiScannerClient,
+  ScannerClient,
+  ScannerEvent,
+} from '@votingworks/pdi-scanner';
+
+export interface SimpleScannerClient {
+  connect(eventListener: (event: ScannerEvent) => void): Promise<void>;
+  reconnect(): Promise<void>;
+  disconnect(): Promise<void>;
+  enableScanning(): Promise<void>;
+  ejectAndRescanPaperIfPresent(): Promise<void>;
+}
+
+export function createSimpleScannerClient(): SimpleScannerClient {
+  let client: Optional<ScannerClient>;
+  let eventListener: Optional<(event: ScannerEvent) => void>;
+
+  return {
+    async connect(listener) {
+      eventListener = listener;
+      client = createPdiScannerClient();
+      (await client.connect()).unsafeUnwrap();
+      client.addListener(listener);
+    },
+
+    async reconnect() {
+      assert(client && eventListener, 'Scanner client is not connected');
+
+      (await client.disconnect()).unsafeUnwrap();
+      client = createPdiScannerClient();
+      (await client.connect()).unsafeUnwrap();
+      client.addListener(eventListener);
+    },
+
+    async disconnect() {
+      (await client?.disconnect())?.unsafeUnwrap();
+      client = undefined;
+    },
+
+    async enableScanning() {
+      assert(client, 'Scanner client is not connected');
+
+      (await client.disableScanning()).unsafeUnwrap();
+      (
+        await client.enableScanning({
+          doubleFeedDetectionEnabled: false,
+          paperLengthInches: 11,
+        })
+      ).unsafeUnwrap();
+    },
+
+    async ejectAndRescanPaperIfPresent() {
+      assert(client, 'Scanner client is not connected');
+
+      const status = (await client.getScannerStatus()).unsafeUnwrap();
+
+      if (status.rearLeftSensorCovered || status.rearRightSensorCovered) {
+        (await client.ejectDocument('toFrontAndRescan')).unsafeUnwrap();
+      }
+    },
+  };
+}

--- a/apps/scan/backend/src/index.ts
+++ b/apps/scan/backend/src/index.ts
@@ -25,6 +25,7 @@ import { startElectricalTestingServer } from './electrical_testing/server';
 import { createWorkspace, Workspace } from './util/workspace';
 import { getUserRole } from './util/auth';
 import { getPrinter } from './printing/printer';
+import { createSimpleScannerClient } from './electrical_testing/simple_scanner_client';
 
 export type { Api } from './app';
 export type { ElectricalTestingApi } from './electrical_testing/app';
@@ -86,6 +87,8 @@ async function main(): Promise<number> {
       printer,
       usbDrive,
       workspace,
+      controller: new AbortController(),
+      scannerClient: createSimpleScannerClient(),
     });
     return 0;
   }

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -65,6 +65,7 @@
     "react-router-dom": "^5.3.4",
     "setimmediate": "^1.0.5",
     "styled-components": "^5.3.11",
+    "use-interval": "1.4.0",
     "use-sound": "^4.0.1",
     "util": "^0.12.4",
     "zod": "3.23.5"

--- a/apps/scan/frontend/src/electrical_testing/api.ts
+++ b/apps/scan/frontend/src/electrical_testing/api.ts
@@ -1,6 +1,11 @@
 import type { ElectricalTestingApi } from '@votingworks/scan-backend';
 import React from 'react';
-import { QueryClient, QueryKey, useQuery } from '@tanstack/react-query';
+import {
+  QueryClient,
+  QueryKey,
+  useMutation,
+  useQuery,
+} from '@tanstack/react-query';
 import * as grout from '@votingworks/grout';
 import { QUERY_CLIENT_DEFAULT_OPTIONS } from '@votingworks/ui';
 
@@ -37,5 +42,15 @@ export const getElectricalTestingStatusMessages = {
       () => apiClient.getElectricalTestingStatusMessages(),
       { refetchInterval: 1000 }
     );
+  },
+} as const;
+
+export const stopElectricalTestingMutation = {
+  queryKey(): QueryKey {
+    return ['stopElectricalTesting'];
+  },
+  useMutation() {
+    const apiClient = useApiClient();
+    return useMutation(() => apiClient.stopElectricalTesting());
   },
 } as const;

--- a/apps/scan/frontend/src/electrical_testing/app_root.tsx
+++ b/apps/scan/frontend/src/electrical_testing/app_root.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useInterval } from 'use-interval';
 import { Main } from '@votingworks/ui';
 
 import { useSound } from '../utils/use_sound';
@@ -10,13 +10,7 @@ export function AppRoot(): JSX.Element {
   const getElectricalTestingStatusMessagesQuery =
     getElectricalTestingStatusMessages.useQuery();
   const playSound = useSound('success');
-
-  useEffect(() => {
-    const soundInterval = setInterval(() => {
-      playSound();
-    }, SOUND_INTERVAL_SECONDS * 1000);
-    return () => clearInterval(soundInterval);
-  }, [playSound]);
+  useInterval(playSound, isTestRunning ? SOUND_INTERVAL_SECONDS * 1000 : null);
 
   return (
     <Main centerChild style={{ height: '100%', padding: '1rem' }}>

--- a/apps/scan/frontend/src/electrical_testing/app_root.tsx
+++ b/apps/scan/frontend/src/electrical_testing/app_root.tsx
@@ -1,16 +1,29 @@
 import { useInterval } from 'use-interval';
+import { useState } from 'react';
 import { Main } from '@votingworks/ui';
 
 import { useSound } from '../utils/use_sound';
-import { getElectricalTestingStatusMessages } from './api';
+import {
+  getElectricalTestingStatusMessages,
+  stopElectricalTestingMutation,
+} from './api';
 
 const SOUND_INTERVAL_SECONDS = 5;
 
 export function AppRoot(): JSX.Element {
   const getElectricalTestingStatusMessagesQuery =
     getElectricalTestingStatusMessages.useQuery();
+  const stopElectricalTestingMutationQuery =
+    stopElectricalTestingMutation.useMutation();
   const playSound = useSound('success');
+  const [isTestRunning, setIsTestRunning] = useState(true);
+
   useInterval(playSound, isTestRunning ? SOUND_INTERVAL_SECONDS * 1000 : null);
+
+  function stopTesting() {
+    stopElectricalTestingMutationQuery.mutate();
+    setIsTestRunning(false);
+  }
 
   return (
     <Main centerChild style={{ height: '100%', padding: '1rem' }}>
@@ -25,6 +38,9 @@ export function AppRoot(): JSX.Element {
           )
         )}
       </ul>
+      <button type="button" onClick={stopTesting} disabled={!isTestRunning}>
+        {isTestRunning ? 'Stop Testing' : 'Testing Stopped'}
+      </button>
     </Main>
   );
 }

--- a/libs/ballot-interpreter/src/index.ts
+++ b/libs/ballot-interpreter/src/index.ts
@@ -1,4 +1,5 @@
 /* istanbul ignore file */
 export * from './interpret';
 export * from './hmpb-ts';
+export * from './save_images';
 export * from './types';

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -526,3 +526,23 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)  
 **Description:** Signed hash validation completed. Success or failure indicated by disposition.  
 **Machines:** All
+### background-task-started
+**Type:** [system-status](#system-status)  
+**Description:** A background task has started.  
+**Machines:** All
+### background-task-completed
+**Type:** [system-status](#system-status)  
+**Description:** A background task has completed.  
+**Machines:** All
+### background-task-failure
+**Type:** [system-status](#system-status)  
+**Description:** A background task has failed.  
+**Machines:** All
+### background-task-success
+**Type:** [system-status](#system-status)  
+**Description:** A background task has succeeded.  
+**Machines:** All
+### background-task-cancelled
+**Type:** [system-status](#system-status)  
+**Description:** A background task has been cancelled.  
+**Machines:** All

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -729,3 +729,33 @@ eventId = "signed-hash-validation-complete"
 eventType = "user-action"
 documentationMessage = "Signed hash validation completed. Success or failure indicated by disposition."
 defaultMessage = "Signed hash validation completed."
+
+[BackgroundTaskStarted]
+eventId = "background-task-started"
+eventType = "system-status"
+documentationMessage = "A background task has started."
+defaultMessage = "A background task has started."
+
+[BackgroundTaskCompleted]
+eventId = "background-task-completed"
+eventType = "system-status"
+documentationMessage = "A background task has completed."
+defaultMessage = "A background task has completed."
+
+[BackgroundTaskFailure]
+eventId = "background-task-failure"
+eventType = "system-status"
+documentationMessage = "A background task has failed."
+defaultMessage = "A background task has failed."
+
+[BackgroundTaskSuccess]
+eventId = "background-task-success"
+eventType = "system-status"
+documentationMessage = "A background task has succeeded."
+defaultMessage = "A background task has succeeded."
+
+[BackgroundTaskCancelled]
+eventId = "background-task-cancelled"
+eventType = "system-status"
+documentationMessage = "A background task has been cancelled."
+defaultMessage = "A background task has been cancelled."

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -140,6 +140,11 @@ export enum LogEventId {
   NoPid = 'no-pid',
   SignedHashValidationInit = 'signed-hash-validation-init',
   SignedHashValidationComplete = 'signed-hash-validation-complete',
+  BackgroundTaskStarted = 'background-task-started',
+  BackgroundTaskCompleted = 'background-task-completed',
+  BackgroundTaskFailure = 'background-task-failure',
+  BackgroundTaskSuccess = 'background-task-success',
+  BackgroundTaskCancelled = 'background-task-cancelled',
 }
 
 const ElectionConfigured: LogDetails = {
@@ -1091,6 +1096,41 @@ const SignedHashValidationComplete: LogDetails = {
   defaultMessage: 'Signed hash validation completed.',
 };
 
+const BackgroundTaskStarted: LogDetails = {
+  eventId: LogEventId.BackgroundTaskStarted,
+  eventType: LogEventType.SystemStatus,
+  documentationMessage: 'A background task has started.',
+  defaultMessage: 'A background task has started.',
+};
+
+const BackgroundTaskCompleted: LogDetails = {
+  eventId: LogEventId.BackgroundTaskCompleted,
+  eventType: LogEventType.SystemStatus,
+  documentationMessage: 'A background task has completed.',
+  defaultMessage: 'A background task has completed.',
+};
+
+const BackgroundTaskFailure: LogDetails = {
+  eventId: LogEventId.BackgroundTaskFailure,
+  eventType: LogEventType.SystemStatus,
+  documentationMessage: 'A background task has failed.',
+  defaultMessage: 'A background task has failed.',
+};
+
+const BackgroundTaskSuccess: LogDetails = {
+  eventId: LogEventId.BackgroundTaskSuccess,
+  eventType: LogEventType.SystemStatus,
+  documentationMessage: 'A background task has succeeded.',
+  defaultMessage: 'A background task has succeeded.',
+};
+
+const BackgroundTaskCancelled: LogDetails = {
+  eventId: LogEventId.BackgroundTaskCancelled,
+  eventType: LogEventType.SystemStatus,
+  documentationMessage: 'A background task has been cancelled.',
+  defaultMessage: 'A background task has been cancelled.',
+};
+
 export function getDetailsForEventId(eventId: LogEventId): LogDetails {
   switch (eventId) {
     case LogEventId.ElectionConfigured:
@@ -1349,6 +1389,16 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return SignedHashValidationInit;
     case LogEventId.SignedHashValidationComplete:
       return SignedHashValidationComplete;
+    case LogEventId.BackgroundTaskStarted:
+      return BackgroundTaskStarted;
+    case LogEventId.BackgroundTaskCompleted:
+      return BackgroundTaskCompleted;
+    case LogEventId.BackgroundTaskFailure:
+      return BackgroundTaskFailure;
+    case LogEventId.BackgroundTaskSuccess:
+      return BackgroundTaskSuccess;
+    case LogEventId.BackgroundTaskCancelled:
+      return BackgroundTaskCancelled;
     default:
       throwIllegalValue(eventId);
   }

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -265,4 +265,14 @@ pub enum EventId {
     SignedHashValidationInit,
     #[serde(rename = "signed-hash-validation-complete")]
     SignedHashValidationComplete,
+    #[serde(rename = "background-task-started")]
+    BackgroundTaskStarted,
+    #[serde(rename = "background-task-completed")]
+    BackgroundTaskCompleted,
+    #[serde(rename = "background-task-failure")]
+    BackgroundTaskFailure,
+    #[serde(rename = "background-task-success")]
+    BackgroundTaskSuccess,
+    #[serde(rename = "background-task-cancelled")]
+    BackgroundTaskCancelled,
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2502,6 +2502,9 @@ importers:
       styled-components:
         specifier: ^5.3.11
         version: 5.3.11(react-dom@18.3.1)(react-is@18.2.0)(react@18.3.1)
+      use-interval:
+        specifier: 1.4.0
+        version: 1.4.0(react@18.3.1)
       use-sound:
         specifier: ^4.0.1
         version: 4.0.1(react@18.3.1)


### PR DESCRIPTION
## Overview

Includes the PDI scanner component as part of the stress test loop. Also adds a "Stop Testing" button to stop all the tests, with no way right now to re-start them.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/6f3e3250-6771-439c-af90-e1d502b3b801


## Testing Plan
Manually tested:
- [x] No paper in scanner on launch
- [x] Paper held in rear in scanner on launch
- [x] Paper held mid-way in scanner on launch
- [x] Paper removed during eject & re-inserted

Some basic automated tests added.