### PR TITLE
fix(usb): detach kernel driver

### DIFF
--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -143,6 +143,20 @@ export async function getPaperHandlerWebDevice(): Promise<
   debug('paper handler found');
 
   try {
+    legacyDevice.open();
+    for (const iface of assertDefined(
+      legacyDevice.interfaces,
+      `Device::interfaces must be set after Device::open() succeeds`
+    )) {
+      if (iface.interfaceNumber === INTERFACE_NUMBER) {
+        if (iface.isKernelDriverActive()) {
+          debug('detaching kernel driver');
+          iface.detachKernelDriver();
+        }
+        break;
+      }
+    }
+
     const webDevice = await WebUSBDevice.createInstance(legacyDevice);
     return webDevice;
   } catch (e) {

--- a/libs/custom-paper-handler/src/driver/test_utils.ts
+++ b/libs/custom-paper-handler/src/driver/test_utils.ts
@@ -67,7 +67,12 @@ export function setUpMockWebUsbDevice(
   legacyDevice: Device;
   mockWebUsbDevice: MockWebUsbDevice;
 } {
-  const legacyDevice = {} as unknown as Device;
+  const legacyDevice = {
+    open: () => {},
+    get interfaces() {
+      return [];
+    },
+  } as unknown as Device;
   findByIdsMock.mockReturnValueOnce(legacyDevice);
 
   const mockWebUsbDevice = mocks.mockWebUsbDevice();

--- a/libs/custom-scanner/src/open_scanner.test.ts
+++ b/libs/custom-scanner/src/open_scanner.test.ts
@@ -18,7 +18,16 @@ test('no Custom A4 device present', async () => {
 });
 
 test('unexpected error during open', async () => {
-  const legacyDevice = {} as unknown as Device;
+  const legacyDevice = {
+    open: vi.fn(),
+    interfaces: [
+      {
+        interfaceNumber: 0,
+        isKernelDriverActive: vi.fn(() => false),
+        detachKernelDriver: vi.fn(),
+      },
+    ],
+  } as unknown as Device;
   findByIdsMock.mockReturnValueOnce(legacyDevice);
   createInstanceMock.mockRejectedValueOnce(new Error('test'));
 
@@ -27,7 +36,16 @@ test('unexpected error during open', async () => {
 });
 
 test('connect success', async () => {
-  const legacyDevice = {} as unknown as Device;
+  const legacyDevice = {
+    open: vi.fn(),
+    interfaces: [
+      {
+        interfaceNumber: 0,
+        isKernelDriverActive: vi.fn(() => true),
+        detachKernelDriver: vi.fn(),
+      },
+    ],
+  } as unknown as Device;
   const usbDevice = mockCustomA4ScannerWebUsbDevice();
   findByIdsMock.mockReturnValueOnce(legacyDevice);
   createInstanceMock.mockResolvedValueOnce(
@@ -40,7 +58,21 @@ test('connect success', async () => {
 });
 
 test('connect error', async () => {
-  const legacyDevice = {} as unknown as Device;
+  const legacyDevice = {
+    open: vi.fn(),
+    interfaces: [
+      {
+        interfaceNumber: 1,
+        isKernelDriverActive: vi.fn(() => false),
+        detachKernelDriver: vi.fn(),
+      },
+      {
+        interfaceNumber: 0,
+        isKernelDriverActive: vi.fn(() => true),
+        detachKernelDriver: vi.fn(),
+      },
+    ],
+  } as unknown as Device;
   const usbDevice = mockCustomA4ScannerWebUsbDevice();
   findByIdsMock.mockReturnValueOnce(legacyDevice);
   createInstanceMock.mockResolvedValueOnce(

--- a/libs/custom-scanner/src/parameters.ts
+++ b/libs/custom-scanner/src/parameters.ts
@@ -52,8 +52,10 @@ function convertToMultiSheetDetectionSensorLevelInternal(
       return MultiSheetDetectionSensorLevelInternal.Level3;
     case DoubleSheetDetectOpt.Level4:
       return MultiSheetDetectionSensorLevelInternal.Level4;
-    default:
+    default: {
+      /* istanbul ignore next - @preserve */
       throwIllegalValue(option);
+    }
   }
 }
 

--- a/libs/custom-scanner/src/protocol.ts
+++ b/libs/custom-scanner/src/protocol.ts
@@ -667,8 +667,10 @@ class GetImageDataRequestScanSideCoder extends BaseCoder<ScanSide> {
         case GetImageDataRequestScanSideCoder.SideB:
           return { value: ScanSide.B, bitOffset: decoded.bitOffset };
 
-        default:
+        default: {
+          /* istanbul ignore next - @preserve */
           return err('InvalidValue');
+        }
       }
     });
   }
@@ -818,8 +820,10 @@ export function checkAnswer(data: Buffer): CheckAnswerResult {
       case ResponseErrorCode.INVALID_JOB_ID:
         return { type: 'error', errorCode: ErrorCode.JobNotValid };
 
-      default:
+      default: {
+        /* istanbul ignore next - @preserve */
         throwIllegalValue(errorCode);
+      }
     }
   }
 
@@ -854,8 +858,10 @@ function mapCoderError<T>(result: Result<T, CoderError>): Result<T, ErrorCode> {
     case 'UnsupportedOffset':
       throw new Error(`BUG: unsupported offset`);
 
-    default:
+    default: {
+      /* istanbul ignore next - @preserve */
       throwIllegalValue(coderError);
+    }
   }
 }
 

--- a/libs/pdi-scanner/src/rust/scanner.rs
+++ b/libs/pdi-scanner/src/rust/scanner.rs
@@ -34,6 +34,8 @@ impl Scanner {
         /// Product ID for the PDI scanner.
         const PRODUCT_ID: u16 = 0xa002;
 
+        const INTERFACE: u8 = 0;
+
         let ctx = rusb::Context::new()?;
         let Some(device) = ctx.devices()?.iter().find(|device| {
             device.device_descriptor().map_or(false, |device_desc| {
@@ -44,8 +46,11 @@ impl Scanner {
         };
 
         let mut device_handle = device.open()?;
+        if device_handle.kernel_driver_active(INTERFACE)? {
+            device_handle.detach_kernel_driver(INTERFACE)?;
+        }
         device_handle.set_active_configuration(1)?;
-        device_handle.claim_interface(0)?;
+        device_handle.claim_interface(INTERFACE)?;
 
         let device_handle = Arc::new(device_handle);
 


### PR DESCRIPTION
While we shouldn't need this in production, and realistically won't need it with most USB devices, it's possible for the kernel to decide that it has a driver to handle one of our devices. In that event, it will open and claim the interface and trying to claim the interface ourselves will fail. This happens on a default install of Debian 12 with the Fujitsu thermal printer.
