### PR TITLE
[VxDesign] Add UI for cloning elections

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -255,8 +255,8 @@ test('CRUD elections', async () => {
   });
 
   expect(await apiClient.listElections({ user: vxUser })).toEqual([
-    election,
     election2,
+    election,
   ]);
 
   const updatedElection: Election = {
@@ -542,6 +542,7 @@ test('cloneElection', async () => {
   expect(destElectionRecord.election).toEqual({
     ...srcElectionRecord.election,
     id: 'election-clone-1',
+    title: `(Copy) ${srcElectionRecord.election.title}`,
   });
   expect(destElectionRecord.ballotTemplateId).toEqual('VxDefaultBallot');
   expect(destElectionRecord.orgId).toEqual('dest-org-id');

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -276,6 +276,7 @@ function buildApi({ auth, workspace, translator }: AppContext) {
         {
           ...election,
           id: input.destId,
+          title: `(Copy) ${election.title}`,
         },
         precincts,
         ballotTemplateId,

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -190,6 +190,7 @@ export class Store {
                 ballot_language_codes as "ballotLanguageCodes"
               from elections
               ${whereClause}
+              order by created_at desc
             `,
               ...params
             )

--- a/apps/design/backend/vitest.config.ts
+++ b/apps/design/backend/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 86.8,
-        branches: 73.6,
+        lines: 86.5,
+        branches: 73.1,
       },
       exclude: ['src/configure_sentry.ts', '**/*.test.ts'],
     },

--- a/apps/design/backend/vitest.config.ts
+++ b/apps/design/backend/vitest.config.ts
@@ -7,10 +7,10 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 71.8,
-        branches: 59.7,
+        lines: 86.8,
+        branches: 73.6,
       },
-      exclude: ['src/configure_sentry.ts'],
+      exclude: ['src/configure_sentry.ts', '**/*.test.ts'],
     },
     alias: [
       {

--- a/apps/design/frontend/src/clone_election_button.test.tsx
+++ b/apps/design/frontend/src/clone_election_button.test.tsx
@@ -61,7 +61,7 @@ afterEach(() => {
   apiMock.assertComplete();
 });
 
-test('clones immediately for Vx users', async () => {
+test('clones immediately for non-Vx users', async () => {
   mockUseUserFeatures.mockReturnValue(userFeatureConfigs.nh);
 
   const { election } = generalElectionRecord(nonVxUser.orgId);

--- a/apps/design/frontend/src/clone_election_button.test.tsx
+++ b/apps/design/frontend/src/clone_election_button.test.tsx
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { createMemoryHistory } from 'history';
+import { User } from '@votingworks/design-backend';
+import userEvent from '@testing-library/user-event';
+import { ElectionId } from '@votingworks/types';
+import { sleep } from '@votingworks/basics';
+import {
+  createMockApiClient,
+  MockApiClient,
+  nonVxUser,
+  provideApi,
+  vxUser,
+} from '../test/api_helpers';
+import { generalElectionRecord } from '../test/fixtures';
+import { render, screen, within } from '../test/react_testing_library';
+import { CloneElectionButton } from './clone_election_button';
+import { userFeatureConfigs, useUserFeatures } from './features_context';
+import { generateId } from './utils';
+import { withRoute } from '../test/routing_helpers';
+import { routes } from './routes';
+import * as api from './api';
+
+vi.mock(import('./features_context.js'), async (importActual) => ({
+  ...(await importActual()),
+  useUserFeatures: vi.fn(),
+}));
+const mockUseUserFeatures = vi.mocked(useUserFeatures);
+
+vi.mock(import('./utils.js'), async (importActual) => ({
+  ...(await importActual()),
+  generateId: vi.fn(),
+}));
+const mockGenerateId = vi.mocked(generateId);
+
+let apiMock: MockApiClient;
+
+function renderButton(user: User, element: React.ReactElement) {
+  const history = createMemoryHistory();
+
+  const ui = withRoute(element, {
+    paramPath: routes.root.path,
+    path: routes.root.path,
+    history,
+  });
+
+  const queryClient = api.createQueryClient();
+  queryClient.setQueryData(api.getUser.queryKey(), user);
+
+  return {
+    ...render(provideApi(apiMock, ui, undefined, queryClient)),
+    history,
+    queryClient,
+  };
+}
+
+beforeEach(() => {
+  apiMock = createMockApiClient();
+});
+
+afterEach(() => {
+  apiMock.assertComplete();
+});
+
+test('clones immediately for Vx users', async () => {
+  mockUseUserFeatures.mockReturnValue(userFeatureConfigs.nh);
+
+  const { election } = generalElectionRecord(nonVxUser.orgId);
+  const { history } = renderButton(
+    nonVxUser,
+    <CloneElectionButton election={election} />
+  );
+
+  const newElectionId = 'new-election' as ElectionId;
+  mockGenerateId.mockReturnValue(newElectionId);
+  apiMock.cloneElection
+    .expectCallWith({
+      destId: newElectionId,
+      destOrgId: nonVxUser.orgId,
+      srcId: election.id,
+      user: nonVxUser,
+    })
+    .resolves(newElectionId);
+
+  userEvent.click(screen.getButton(`Make a copy of ${election.title}`));
+  await sleep(0); // Allow redirect to resolve
+  expect(history.location.pathname).toEqual(`/elections/${newElectionId}`);
+});
+
+const VX_ORG = {
+  id: vxUser.orgId,
+  name: 'votingworks',
+  displayName: 'VotingWorks',
+} as const;
+
+const NON_VX_ORG = {
+  id: nonVxUser.orgId,
+  name: 'not-voting-works',
+  displayName: 'Not VotingWorks',
+} as const;
+
+test('shows org picker for Vx users', async () => {
+  mockUseUserFeatures.mockReturnValue(userFeatureConfigs.vx);
+
+  const { election } = generalElectionRecord(vxUser.orgId);
+  const { history, queryClient } = renderButton(
+    vxUser,
+    <CloneElectionButton election={election} />
+  );
+
+  queryClient.setQueryData(api.getAllOrgs.queryKey(), [VX_ORG, NON_VX_ORG]);
+
+  userEvent.click(screen.getButton(`Make a copy of ${election.title}`));
+  const modal = screen.getByRole('alertdialog');
+
+  userEvent.click(within(modal).getByRole('combobox'));
+  userEvent.click(within(modal).getByText(NON_VX_ORG.displayName));
+
+  const newElectionId = 'new-election' as ElectionId;
+  mockGenerateId.mockReturnValue(newElectionId);
+  apiMock.cloneElection
+    .expectCallWith({
+      destId: newElectionId,
+      destOrgId: NON_VX_ORG.id,
+      srcId: election.id,
+      user: vxUser,
+    })
+    .resolves(newElectionId);
+
+  userEvent.click(screen.getButton('Confirm'));
+  await sleep(0); // Allow redirect to resolve
+  expect(history.location.pathname).toEqual(`/elections/${newElectionId}`);
+});

--- a/apps/design/frontend/src/clone_election_button.tsx
+++ b/apps/design/frontend/src/clone_election_button.tsx
@@ -92,7 +92,7 @@ export function CloneElectionButton(
           onPress={features.ACCESS_ALL_ORGS ? setModalActive : cloneElection}
           aria-label={`Make a copy of ${election.title}`}
           value
-          disabled={modalActive}
+          disabled={cloneMutation.isLoading || modalActive}
         >
           <Icons.Copy />
         </Button>

--- a/apps/design/frontend/src/clone_election_button.tsx
+++ b/apps/design/frontend/src/clone_election_button.tsx
@@ -1,0 +1,140 @@
+import { assert } from '@votingworks/basics';
+import { Election } from '@votingworks/types';
+import { P, Button, Modal, ButtonVariant, Icons, Font } from '@votingworks/ui';
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+import styled from 'styled-components';
+import * as api from './api';
+import { OrgSelect } from './org_select';
+import { useUserFeatures } from './features_context';
+
+export interface CloneElectionButtonProps {
+  election: Election;
+  variant?: ButtonVariant;
+}
+
+const OrgModal = styled(Modal)`
+  /* Allow modal to grow with user zoom setting and cap near screen height. */
+  min-height: min(40rem, 98%);
+`;
+
+const Tooltip = styled.span`
+  /*
+   * [TODO] No easy way to use theme colors for transparency, since they're
+   * defined in 'HSL' - need to bring in the 'polished' lib used in libs/ui, or
+   * create a generalized tooltip component in libs/ui.
+   */
+  background: rgba(0, 0, 0, 75%);
+  border-radius: 0.25rem;
+  bottom: calc(100% + 0.7rem);
+  box-shadow: 0.1rem 0.1rem 0.2rem 0.05rem rgba(0, 0, 0, 25%);
+  color: #fff;
+  font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
+  padding: 0.5rem 0.75rem 0.6rem;
+  position: absolute;
+  right: 0;
+  width: max-content;
+
+  &:hover {
+    /* Prevent it from sticking around when moving quickly between buttons. */
+    display: none !important;
+  }
+`;
+
+const ButtonContainer = styled.span`
+  position: relative;
+
+  ${Tooltip} {
+    display: none;
+  }
+
+  &:focus,
+  &:hover {
+    ${Tooltip} {
+      display: block;
+    }
+  }
+`;
+
+export function CloneElectionButton(
+  props: CloneElectionButtonProps
+): React.ReactNode {
+  const { election, variant } = props;
+
+  const history = useHistory();
+  const features = useUserFeatures();
+  const user = api.getUser.useQuery().data;
+
+  const [orgId, setOrgId] = React.useState<string | undefined>(user?.orgId);
+  const [modalActive, setModalActive] = React.useState(false);
+
+  const cloneMutation = api.cloneElection.useMutation();
+  const mutateCloneElection = cloneMutation.mutate;
+  const cloneElection = React.useCallback(() => {
+    assert(!!orgId);
+
+    mutateCloneElection(
+      { id: election.id, orgId },
+      {
+        onSuccess(electionId) {
+          history.push(`/elections/${electionId}`);
+        },
+      }
+    );
+  }, [election, history, mutateCloneElection, orgId]);
+
+  return (
+    <React.Fragment>
+      <ButtonContainer>
+        <Tooltip role="tooltip">{`Make a copy of ${election.title}`}</Tooltip>
+        <Button
+          variant={variant}
+          onPress={features.ACCESS_ALL_ORGS ? setModalActive : cloneElection}
+          aria-label={`Make a copy of ${election.title}`}
+          value
+          disabled={modalActive}
+        >
+          <Icons.Copy />
+        </Button>
+      </ButtonContainer>
+      {modalActive && (
+        <OrgModal
+          title="Duplicate Election"
+          actions={
+            <React.Fragment>
+              <Button
+                disabled={cloneMutation.isLoading}
+                onPress={cloneElection}
+                variant="primary"
+              >
+                Confirm
+              </Button>
+              <Button
+                disabled={cloneMutation.isLoading}
+                onPress={setModalActive}
+                value={false}
+              >
+                Cancel
+              </Button>
+            </React.Fragment>
+          }
+          onOverlayClick={() => setModalActive(false)}
+          content={
+            <React.Fragment>
+              <P>
+                You are making a copy of{' '}
+                <Font weight="bold">{election.title}</Font>.
+              </P>
+              <P>Select an organization for the new election:</P>
+              <OrgSelect
+                disabled={cloneMutation.isLoading}
+                onChange={setOrgId}
+                selectedOrgId={orgId}
+              />
+            </React.Fragment>
+          }
+        />
+      )}
+    </React.Fragment>
+  );
+}

--- a/apps/design/frontend/src/create_election_button.tsx
+++ b/apps/design/frontend/src/create_election_button.tsx
@@ -14,7 +14,8 @@ export interface CreateElectionButtonProps {
 }
 
 const OrgModal = styled(Modal)`
-  min-height: 50%;
+  /* Allow modal to grow with user zoom setting and cap near screen height.  */
+  min-height: min(40rem, 98%);
 `;
 
 export function CreateElectionButton(

--- a/apps/design/frontend/test/api_helpers.tsx
+++ b/apps/design/frontend/test/api_helpers.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { Api, User } from '@votingworks/design-backend';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
 import { ElectionId } from '@votingworks/types';
@@ -16,12 +16,13 @@ export function createMockApiClient(): MockApiClient {
 export function provideApi(
   apiMock: ReturnType<typeof createMockApiClient>,
   children: React.ReactNode,
-  electionId?: ElectionId
+  electionId?: ElectionId,
+  queryClient: QueryClient = createQueryClient()
 ): JSX.Element {
   return (
     <TestErrorBoundary>
       <ApiClientContext.Provider value={apiMock}>
-        <QueryClientProvider client={createQueryClient()}>
+        <QueryClientProvider client={queryClient}>
           {electionId ? (
             <FeaturesProvider electionId={electionId}>
               {children}

--- a/apps/design/frontend/vitest.config.ts
+++ b/apps/design/frontend/vitest.config.ts
@@ -9,10 +9,15 @@ export default defineConfig({
 
     coverage: {
       thresholds: {
-        lines: 92,
-        branches: 72,
+        lines: 84.9,
+        branches: 74,
       },
-      exclude: ['src/**/*.d.ts', 'src/index.tsx'],
+      exclude: [
+        'src/**/*.d.ts',
+        'src/index.tsx',
+        '**/*.test.ts',
+        '**/*.test.tsx',
+      ],
     },
 
     // Create alias for libs/ui to load the TS source code instead of the

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -67,6 +67,7 @@ import {
   faXmarkCircle,
   faPauseCircle,
   faSquare,
+  faCopy,
   faCircle,
   faCircleDot,
   faEye,
@@ -183,14 +184,6 @@ export const Icons = {
     return <FaIcon {...props} type={faCaretDown} />;
   },
 
-  Circle(props) {
-    return <FaIcon {...props} type={faCircle} />;
-  },
-
-  CircleDot(props) {
-    return <FaIcon {...props} type={faCircleDot} />;
-  },
-
   Checkbox(props) {
     return <FaIcon {...props} type={faCheckSquare} />;
   },
@@ -239,12 +232,24 @@ export const Icons = {
     return <FaIcon {...props} type={faChevronLeft} />;
   },
 
+  Circle(props) {
+    return <FaIcon {...props} type={faCircle} />;
+  },
+
+  CircleDot(props) {
+    return <FaIcon {...props} type={faCircleDot} />;
+  },
+
   Closed(props) {
     return <FaIcon {...props} type={faMinusCircle} />;
   },
 
   Contrast(props) {
     return <FaIcon {...props} type={faCircleHalfStroke} />;
+  },
+
+  Copy(props) {
+    return <FaIcon {...props} type={faCopy} />;
   },
 
   Danger(props) {


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/5530

(Some alternatives/future ideas considered in this thread: https://votingworks.slack.com/archives/C085YT4798C/p1740606709518789)

Adding UI for cloning elections from the election list screen (API added in https://github.com/votingworks/vxsuite/pull/6051). Uses the same pattern from `CreateElectionButton` - Vx users get an org selection modal; single-org users get a new election created immediately) - we could explore adding a confirmation for the latter eventually, but easy enough to delete accidental copies at the moment.

## Demo Video or Screenshot

### Vx Users:

https://github.com/user-attachments/assets/163c3257-18b9-4ecc-8e24-201a2dcc667b

### Single-Org Users (Creation Enabled):

https://github.com/user-attachments/assets/fcc04aca-7e14-4048-ba3c-3ca0350b9cf6

### Creation Disabled:

![Screenshot 2025-02-27 at 10 58 40](https://github.com/user-attachments/assets/3715c82d-5c6f-4783-a092-322f1b79c4e7)


## Testing Plan

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
