### PR TITLE
[VxDesign] Generate new IDs for imported elections

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -203,14 +203,17 @@ test('CRUD elections', async () => {
 
   const election2Definition =
     electionFamousNames2021Fixtures.readElectionDefinition();
+
+  const importedElectionNewId = 'new-election-id' as ElectionId;
   const electionId2 = (
     await apiClient.loadElection({
       user: vxUser,
+      newId: importedElectionNewId,
       orgId: nonVxUser.orgId,
       electionData: election2Definition.electionData,
     })
   ).unsafeUnwrap();
-  expect(electionId2).toEqual(election2Definition.election.id);
+  expect(electionId2).toEqual(importedElectionNewId);
 
   const election2 = await apiClient.getElection({
     user: vxUser,
@@ -235,6 +238,7 @@ test('CRUD elections', async () => {
     orgId: nonVxUser.orgId,
     election: {
       ...election2Definition.election,
+      id: importedElectionNewId,
       ballotStyles: expectedBallotStyles.map(convertToVxfBallotStyle),
       gridLayouts: undefined, // Grid layouts should be stripped out
     },
@@ -327,6 +331,7 @@ test.skip('Updating contests with candidate rotation', async () => {
   const electionId = (
     await apiClient.loadElection({
       user: vxUser,
+      newId: 'new-election-id' as ElectionId,
       orgId: nonVxUser.orgId,
       electionData: electionFamousNames2021Fixtures.electionJson.asText(),
     })
@@ -460,6 +465,7 @@ test('Finalize ballots', async () => {
   const electionId = (
     await apiClient.loadElection({
       user: vxUser,
+      newId: 'new-election-id' as ElectionId,
       orgId: nonVxUser.orgId,
       electionData: electionFamousNames2021Fixtures.electionJson.asText(),
     })
@@ -588,6 +594,7 @@ test.skip('Election package management', async () => {
   const electionId = (
     await apiClient.loadElection({
       user: vxUser,
+      newId: 'new-election-id' as ElectionId,
       orgId: nonVxUser.orgId,
       electionData: baseElectionDefinition.electionData,
     })
@@ -710,6 +717,7 @@ test.skip('Election package export', async () => {
   const electionId = (
     await apiClient.loadElection({
       user: vxUser,
+      newId: 'new-election-id' as ElectionId,
       orgId: nonVxUser.orgId,
       electionData: JSON.stringify(electionWithLegalPaper),
     })
@@ -932,6 +940,7 @@ test.skip('Export all ballots', async () => {
   const electionId = (
     await apiClient.loadElection({
       user: vxUser,
+      newId: 'new-election-id' as ElectionId,
       orgId: nonVxUser.orgId,
       electionData: baseElectionDefinition.electionData,
     })
@@ -1033,6 +1042,7 @@ test('Export test decks', async () => {
   const electionId = (
     await apiClient.loadElection({
       user: vxUser,
+      newId: 'new-election-id' as ElectionId,
       orgId: nonVxUser.orgId,
       electionData: electionDefinition.electionData,
     })
@@ -1100,6 +1110,7 @@ test.skip('Consistency of ballot hash across exports', async () => {
   const electionId = (
     await apiClient.loadElection({
       user: vxUser,
+      newId: 'new-election-id' as ElectionId,
       orgId: nonVxUser.orgId,
       electionData: baseElectionDefinition.electionData,
     })
@@ -1151,6 +1162,7 @@ test.skip('CDF exports', async () => {
   const electionId = (
     await apiClient.loadElection({
       user: vxUser,
+      newId: 'new-election-id' as ElectionId,
       orgId: nonVxUser.orgId,
       electionData: baseElectionDefinition.electionData,
     })
@@ -1199,6 +1211,7 @@ test('getBallotPreviewPdf returns a ballot pdf for precinct with splits', async 
   const electionId = (
     await apiClient.loadElection({
       user: vxUser,
+      newId: 'new-election-id' as ElectionId,
       orgId: nonVxUser.orgId,
       electionData: baseElectionDefinition.electionData,
     })
@@ -1244,6 +1257,7 @@ test('getBallotPreviewPdf returns a ballot pdf for NH election with split precin
   const electionId = (
     await apiClient.loadElection({
       user: vxUser,
+      newId: 'new-election-id' as ElectionId,
       orgId: nonVxUser.orgId,
       electionData: JSON.stringify(election),
     })
@@ -1295,6 +1309,7 @@ test('getBallotPreviewPdf returns a ballot pdf for precinct with no split', asyn
   const electionId = (
     await apiClient.loadElection({
       user: vxUser,
+      newId: 'new-election-id' as ElectionId,
       orgId: nonVxUser.orgId,
       electionData: baseElectionDefinition.electionData,
     })
@@ -1353,6 +1368,7 @@ test.skip('setBallotTemplate changes the ballot template used to render ballots'
   const electionId = (
     await apiClient.loadElection({
       user: vxUser,
+      newId: 'new-election-id' as ElectionId,
       orgId: nonVxUser.orgId,
       electionData: electionDefinition.electionData,
     })
@@ -1408,6 +1424,7 @@ test('v3-compatible election package', async () => {
   const electionId = (
     await apiClient.loadElection({
       user: vxUser,
+      newId: 'new-election-id' as ElectionId,
       orgId: nonVxUser.orgId,
       electionData: fixtureElectionDefinition.electionData,
     })

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -186,7 +186,11 @@ function buildApi({ auth, workspace, translator }: AppContext) {
     },
 
     async loadElection(
-      input: WithUserInfo<{ electionData: string; orgId: string }>
+      input: WithUserInfo<{
+        electionData: string;
+        newId: ElectionId;
+        orgId: string;
+      }>
     ): Promise<Result<ElectionId, Error>> {
       if (!auth.hasAccess(input.user, input.orgId)) {
         throw new grout.GroutError('Access denied', {
@@ -200,6 +204,7 @@ function buildApi({ auth, workspace, translator }: AppContext) {
       const precincts = convertVxfPrecincts(election);
       election = {
         ...election,
+        id: input.newId,
         // Remove any existing ballot styles/grid layouts so we can generate our own
         ballotStyles: [],
         precincts,

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -149,7 +149,11 @@ export const loadElection = {
 
     return useMutation(
       (input: { electionData: string; orgId: string }) =>
-        apiClient.loadElection({ ...input, user }),
+        apiClient.loadElection({
+          ...input,
+          newId: generateId() as ElectionId,
+          user,
+        }),
       {
         async onSuccess() {
           await queryClient.invalidateQueries(listElections.queryKey());

--- a/apps/design/frontend/src/elections_screen.test.tsx
+++ b/apps/design/frontend/src/elections_screen.test.tsx
@@ -107,7 +107,12 @@ test('with no elections, loading an election', async () => {
 
   const electionData = JSON.stringify(electionRecord.election);
   apiMock.loadElection
-    .expectCallWith({ user: vxUser, orgId: vxUser.orgId, electionData })
+    .expectCallWith({
+      user: vxUser,
+      orgId: vxUser.orgId,
+      electionData,
+      newId: ELECTION_ID,
+    })
     .resolves(ok(electionRecord.election.id));
   apiMock.listElections
     .expectCallWith({ user: vxUser })


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/5533

Assigning newly generated IDs when importing elections, to avoid conflict errors from importing an election that has already been previously created/imported.

Currently mirroring the `createElection` pattern and sending up a new ID from the client - opened https://github.com/votingworks/vxsuite/issues/6055 for potentially moving ID generation server-side.

## Testing Plan
- Updated existing tests

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
