### PR TITLE
Miscellaneous electrical testing app cleanup

### DIFF
--- a/apps/mark-scan/backend/src/electrical_testing/background.ts
+++ b/apps/mark-scan/backend/src/electrical_testing/background.ts
@@ -32,15 +32,9 @@ const HEADPHONE_OUTPUT_DURATION_SECONDS = 50;
 const SPEAKER_OUTPUT_DURATION_SECONDS = 10;
 
 function resultToString(result: Result<unknown, unknown>): string {
-  if (result.isOk()) {
-    return 'Success';
-  }
-  const error = result.err();
-  const errorMessage =
-    extractErrorMessage(error) === '[object Object]'
-      ? JSON.stringify(error)
-      : extractErrorMessage(error);
-  return `Error: ${errorMessage}`;
+  return result.isOk()
+    ? 'Success'
+    : `Error: ${extractErrorMessage(result.err())}`;
 }
 
 export async function cardReadLoop({

--- a/apps/mark-scan/backend/src/electrical_testing/background.ts
+++ b/apps/mark-scan/backend/src/electrical_testing/background.ts
@@ -32,16 +32,22 @@ const HEADPHONE_OUTPUT_DURATION_SECONDS = 50;
 const SPEAKER_OUTPUT_DURATION_SECONDS = 10;
 
 function resultToString(result: Result<unknown, unknown>): string {
-  return result.isOk()
-    ? 'Success'
-    : `Error: ${extractErrorMessage(result.err())}`;
+  if (result.isOk()) {
+    return 'Success';
+  }
+  const error = result.err();
+  const errorMessage =
+    extractErrorMessage(error) === '[object Object]'
+      ? JSON.stringify(error)
+      : extractErrorMessage(error);
+  return `Error: ${errorMessage}`;
 }
 
 export async function cardReadLoop({
   auth,
-  workspace,
-  logger,
   controller,
+  logger,
+  workspace,
 }: ServerContext): Promise<void> {
   controller.signal.addEventListener('abort', () => {
     void logger.log(LogEventId.BackgroundTaskCancelled, 'system', {
@@ -62,9 +68,9 @@ export async function cardReadLoop({
 }
 
 export async function printAndScanLoop({
-  workspace,
-  logger: baseLogger,
   controller,
+  logger: baseLogger,
+  workspace,
 }: ServerContext): Promise<void> {
   const logger = Logger.from(baseLogger, () => Promise.resolve('system'));
   await logger.logAsCurrentRole(LogEventId.BackgroundTaskStarted, {
@@ -145,7 +151,7 @@ export async function printAndScanLoop({
       PAPER_LOAD_LOG_INTERVAL_MS
     ) {
       await logger.logAsCurrentRole(LogEventId.BackgroundTaskStatus, {
-        message: 'Waiting for paper load.',
+        message: 'Waiting for paper load',
       });
       setPaperHandlerStatusMessage(
         'Please load a sheet of 8x11" thermal paper'

--- a/apps/mark-scan/backend/src/electrical_testing/context.ts
+++ b/apps/mark-scan/backend/src/electrical_testing/context.ts
@@ -5,7 +5,7 @@ import { Workspace } from '../util/workspace';
 
 export interface ServerContext {
   auth: InsertedSmartCardAuthApi;
+  controller: AbortController;
   logger: BaseLogger;
   workspace: Workspace;
-  controller: AbortController;
 }

--- a/apps/mark-scan/backend/src/index.ts
+++ b/apps/mark-scan/backend/src/index.ts
@@ -50,9 +50,9 @@ async function main(): Promise<number> {
     const controller = new AbortController();
     startElectricalTestingServer({
       auth: getDefaultAuth(logger),
+      controller,
       logger,
       workspace,
-      controller,
     });
     return 0;
   }

--- a/apps/mark-scan/frontend/src/electrical_testing/app_root.tsx
+++ b/apps/mark-scan/frontend/src/electrical_testing/app_root.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ElectricalTestingScreen, Main } from '@votingworks/ui';
 
 import {
@@ -13,15 +13,40 @@ export function AppRoot(): JSX.Element {
     stopElectricalTestingMutation.useMutation();
 
   const [isTestRunning, setIsTestRunning] = useState(true);
+  const [lastKeyPress, setLastKeyPress] = useState<{
+    key: string;
+    pressedAt: Date;
+  }>();
 
   function stopTesting() {
     stopElectricalTestingMutationQuery.mutate();
     setIsTestRunning(false);
   }
 
+  useEffect(() => {
+    function handleKeyboardEvent(e: KeyboardEvent) {
+      if (isTestRunning) {
+        setLastKeyPress({ key: e.key, pressedAt: new Date() });
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyboardEvent);
+    return () => {
+      document.removeEventListener('keydown', handleKeyboardEvent);
+    };
+  }, [isTestRunning]);
+
   return (
     <Main>
       <ElectricalTestingScreen
+        additionalContent={
+          <span>
+            Last key press:{' '}
+            {lastKeyPress
+              ? `${lastKeyPress.key} at ${lastKeyPress.pressedAt.toISOString()}`
+              : 'N/A'}
+          </span>
+        }
         graphic={<img src="/mario.gif" alt="Mario" />}
         isTestRunning={isTestRunning}
         statusMessages={getElectricalTestingStatusMessagesQuery.data ?? []}

--- a/apps/mark-scan/frontend/src/electrical_testing/app_root.tsx
+++ b/apps/mark-scan/frontend/src/electrical_testing/app_root.tsx
@@ -1,18 +1,18 @@
-import { Main } from '@votingworks/ui';
-
 import { useState } from 'react';
+import { ElectricalTestingScreen, Main } from '@votingworks/ui';
+
 import {
   getElectricalTestingStatusMessages,
   stopElectricalTestingMutation,
 } from './api';
 
 export function AppRoot(): JSX.Element {
-  const [isTestRunning, setIsTestRunning] = useState(true);
-
   const getElectricalTestingStatusMessagesQuery =
     getElectricalTestingStatusMessages.useQuery();
   const stopElectricalTestingMutationQuery =
     stopElectricalTestingMutation.useMutation();
+
+  const [isTestRunning, setIsTestRunning] = useState(true);
 
   function stopTesting() {
     stopElectricalTestingMutationQuery.mutate();
@@ -20,23 +20,13 @@ export function AppRoot(): JSX.Element {
   }
 
   return (
-    <Main centerChild style={{ height: '100%', padding: '1rem' }}>
-      <img src="/mario.gif" alt="Mario" />
-      <br />
-      <ul style={{ listStyleType: 'none', margin: 0, padding: 0 }}>
-        {(getElectricalTestingStatusMessagesQuery.data ?? []).map(
-          ({ component, statusMessage, updatedAt }) => (
-            <li key={component}>
-              [{updatedAt}] {component}: {statusMessage}
-            </li>
-          )
-        )}
-      </ul>
-
-      <button type="button" onClick={stopTesting} disabled={!isTestRunning}>
-        {isTestRunning ? 'Stop Testing' : 'Testing Stopped'}
-      </button>
-
+    <Main>
+      <ElectricalTestingScreen
+        graphic={<img src="/mario.gif" alt="Mario" />}
+        isTestRunning={isTestRunning}
+        statusMessages={getElectricalTestingStatusMessagesQuery.data ?? []}
+        stopTesting={stopTesting}
+      />
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       {isTestRunning && <audio autoPlay loop src="/sounds/success-5s.mp3" />}
     </Main>

--- a/apps/scan/backend/src/electrical_testing/background.ts
+++ b/apps/scan/backend/src/electrical_testing/background.ts
@@ -23,15 +23,9 @@ const PRINT_INTERVAL_SECONDS = 5 * 60;
 const USB_DRIVE_FILE_NAME = 'electrical-testing.txt';
 
 function resultToString(result: Result<unknown, unknown>): string {
-  if (result.isOk()) {
-    return 'Success';
-  }
-  const error = result.err();
-  const errorMessage =
-    extractErrorMessage(error) === '[object Object]'
-      ? JSON.stringify(error)
-      : extractErrorMessage(error);
-  return `Error: ${errorMessage}`;
+  return result.isOk()
+    ? 'Success'
+    : `Error: ${extractErrorMessage(result.err())}`;
 }
 
 export async function cardReadAndUsbDriveWriteLoop({

--- a/apps/scan/backend/src/electrical_testing/context.ts
+++ b/apps/scan/backend/src/electrical_testing/context.ts
@@ -8,10 +8,10 @@ import { SimpleScannerClient } from './simple_scanner_client';
 
 export interface ServerContext {
   auth: InsertedSmartCardAuthApi;
+  controller: AbortController;
   logger: Logger;
   printer: Printer;
+  scannerClient: SimpleScannerClient;
   usbDrive: UsbDrive;
   workspace: Workspace;
-  scannerClient: SimpleScannerClient;
-  controller: AbortController;
 }

--- a/apps/scan/backend/src/index.ts
+++ b/apps/scan/backend/src/index.ts
@@ -83,12 +83,12 @@ async function main(): Promise<number> {
   ) {
     startElectricalTestingServer({
       auth,
+      controller: new AbortController(),
       logger,
       printer,
+      scannerClient: createSimpleScannerClient(),
       usbDrive,
       workspace,
-      controller: new AbortController(),
-      scannerClient: createSimpleScannerClient(),
     });
     return 0;
   }

--- a/apps/scan/frontend/src/electrical_testing/app_root.tsx
+++ b/apps/scan/frontend/src/electrical_testing/app_root.tsx
@@ -1,6 +1,6 @@
-import { useInterval } from 'use-interval';
 import { useState } from 'react';
-import { Main } from '@votingworks/ui';
+import { useInterval } from 'use-interval';
+import { ElectricalTestingScreen, Main } from '@votingworks/ui';
 
 import { useSound } from '../utils/use_sound';
 import {
@@ -15,32 +15,25 @@ export function AppRoot(): JSX.Element {
     getElectricalTestingStatusMessages.useQuery();
   const stopElectricalTestingMutationQuery =
     stopElectricalTestingMutation.useMutation();
-  const playSound = useSound('success');
-  const [isTestRunning, setIsTestRunning] = useState(true);
 
-  useInterval(playSound, isTestRunning ? SOUND_INTERVAL_SECONDS * 1000 : null);
+  const [isTestRunning, setIsTestRunning] = useState(true);
+  const playSound = useSound('success');
 
   function stopTesting() {
     stopElectricalTestingMutationQuery.mutate();
     setIsTestRunning(false);
   }
 
+  useInterval(playSound, isTestRunning ? SOUND_INTERVAL_SECONDS * 1000 : null);
+
   return (
-    <Main centerChild style={{ height: '100%', padding: '1rem' }}>
-      <img src="/mario.gif" alt="Mario" />
-      <br />
-      <ul style={{ listStyleType: 'none', margin: 0, padding: 0 }}>
-        {(getElectricalTestingStatusMessagesQuery.data ?? []).map(
-          ({ component, statusMessage, updatedAt }) => (
-            <li key={component}>
-              [{updatedAt}] {component}: {statusMessage}
-            </li>
-          )
-        )}
-      </ul>
-      <button type="button" onClick={stopTesting} disabled={!isTestRunning}>
-        {isTestRunning ? 'Stop Testing' : 'Testing Stopped'}
-      </button>
+    <Main>
+      <ElectricalTestingScreen
+        graphic={<img src="/mario.gif" alt="Mario" />}
+        isTestRunning={isTestRunning}
+        statusMessages={getElectricalTestingStatusMessagesQuery.data ?? []}
+        stopTesting={stopTesting}
+      />
     </Main>
   );
 }

--- a/libs/basics/src/errors.test.ts
+++ b/libs/basics/src/errors.test.ts
@@ -12,7 +12,7 @@ test.each<{ error: unknown; expectedErrorMessage: string }>([
   { error: 'Whoa!', expectedErrorMessage: 'Whoa!' },
   { error: Buffer.from('Whoa!', 'utf-8'), expectedErrorMessage: 'Whoa!' },
   { error: 1234, expectedErrorMessage: '1234' },
-  { error: { error: 'Whoa!' }, expectedErrorMessage: '[object Object]' },
+  { error: { error: 'Whoa!' }, expectedErrorMessage: '{"error":"Whoa!"}' },
 ])('extractErrorMessage', ({ error, expectedErrorMessage }) => {
   expect(extractErrorMessage(error)).toEqual(expectedErrorMessage);
 });

--- a/libs/basics/src/errors.ts
+++ b/libs/basics/src/errors.ts
@@ -5,7 +5,9 @@ export function extractErrorMessage(error: unknown): string {
   return (
     (error as { message?: string }).message ??
     (error as { stack?: string }).stack ??
-    String(error)
+    (String(error) === '[object Object]'
+      ? JSON.stringify(error)
+      : String(error))
   );
 }
 

--- a/libs/ui/src/electrical_testing_screen.test.tsx
+++ b/libs/ui/src/electrical_testing_screen.test.tsx
@@ -1,0 +1,68 @@
+import { expect, test, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '../test/react_testing_library';
+import { ElectricalTestingScreen } from './electrical_testing_screen';
+
+const mockStatusMessages: Array<{
+  component: string;
+  statusMessage: string;
+  updatedAt: string;
+}> = [
+  {
+    component: 'card',
+    statusMessage: 'Success',
+    updatedAt: '2025-02-28T00:00:00.000Z',
+  },
+  {
+    component: 'usbDrive',
+    statusMessage: 'Success',
+    updatedAt: '2025-02-28T00:00:01.000Z',
+  },
+];
+
+test('ElectricalTestingScreen', () => {
+  const stopTesting = vi.fn();
+  render(
+    <ElectricalTestingScreen
+      isTestRunning
+      graphic={<div>Graphic</div>}
+      statusMessages={mockStatusMessages}
+      stopTesting={stopTesting}
+    />
+  );
+
+  screen.getByText('Graphic');
+  screen.getByText('[2025-02-28T00:00:00.000Z] card: Success');
+  screen.getByText('[2025-02-28T00:00:01.000Z] usbDrive: Success');
+  const testButton = screen.getByRole('button', { name: 'Test Button' });
+  expect(screen.queryByText(/Last pressed at/)).not.toBeInTheDocument();
+  const stopTestingButton = screen.getByRole('button', {
+    name: 'Stop Testing',
+  });
+
+  userEvent.click(testButton);
+  screen.getByText(/Last pressed at/);
+
+  userEvent.click(stopTestingButton);
+  expect(stopTesting).toHaveBeenCalledTimes(1);
+});
+
+test('ElectricalTestingScreen after testing has been stopped', () => {
+  const stopTesting = vi.fn();
+  render(
+    <ElectricalTestingScreen
+      isTestRunning={false}
+      graphic={<div>Graphic</div>}
+      statusMessages={mockStatusMessages}
+      stopTesting={stopTesting}
+    />
+  );
+
+  screen.getByText('Graphic');
+  screen.getByText('[2025-02-28T00:00:00.000Z] card: Success');
+  screen.getByText('[2025-02-28T00:00:01.000Z] usbDrive: Success');
+  expect(screen.getByRole('button', { name: 'Test Button' })).toBeDisabled();
+  expect(
+    screen.getByRole('button', { name: 'Testing Stopped' })
+  ).toBeDisabled();
+});

--- a/libs/ui/src/electrical_testing_screen.test.tsx
+++ b/libs/ui/src/electrical_testing_screen.test.tsx
@@ -24,6 +24,7 @@ test('ElectricalTestingScreen', () => {
   const stopTesting = vi.fn();
   render(
     <ElectricalTestingScreen
+      additionalContent={<div>Additional content</div>}
       isTestRunning
       graphic={<div>Graphic</div>}
       statusMessages={mockStatusMessages}
@@ -36,6 +37,7 @@ test('ElectricalTestingScreen', () => {
   screen.getByText('[2025-02-28T00:00:01.000Z] usbDrive: Success');
   const testButton = screen.getByRole('button', { name: 'Test Button' });
   expect(screen.queryByText(/Last pressed at/)).not.toBeInTheDocument();
+  screen.getByText('Additional content');
   const stopTestingButton = screen.getByRole('button', {
     name: 'Stop Testing',
   });

--- a/libs/ui/src/electrical_testing_screen.tsx
+++ b/libs/ui/src/electrical_testing_screen.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 interface Props {
+  additionalContent?: React.ReactNode;
   isTestRunning: boolean;
   graphic: React.ReactNode;
   statusMessages: Array<{
@@ -12,6 +13,7 @@ interface Props {
 }
 
 export function ElectricalTestingScreen({
+  additionalContent,
   isTestRunning,
   graphic,
   statusMessages,
@@ -50,6 +52,7 @@ export function ElectricalTestingScreen({
           <span>Last pressed at {testButtonLastPressedAt.toISOString()}</span>
         )}
       </div>
+      {additionalContent}
       <br />
       <button disabled={!isTestRunning} onClick={stopTesting} type="button">
         {isTestRunning ? 'Stop Testing' : 'Testing Stopped'}

--- a/libs/ui/src/electrical_testing_screen.tsx
+++ b/libs/ui/src/electrical_testing_screen.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+
+interface Props {
+  isTestRunning: boolean;
+  graphic: React.ReactNode;
+  statusMessages: Array<{
+    component: string;
+    statusMessage: string;
+    updatedAt: string;
+  }>;
+  stopTesting: () => void;
+}
+
+export function ElectricalTestingScreen({
+  isTestRunning,
+  graphic,
+  statusMessages,
+  stopTesting,
+}: Props): JSX.Element {
+  const [testButtonLastPressedAt, setTestButtonLastPressedAt] =
+    useState<Date>();
+
+  return (
+    <div
+      style={{
+        alignItems: 'start',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1rem',
+        padding: '1rem',
+      }}
+    >
+      {graphic}
+      <ul style={{ listStyleType: 'none', margin: 0, padding: 0 }}>
+        {statusMessages.map(({ component, statusMessage, updatedAt }) => (
+          <li key={component}>
+            [{updatedAt}] {component}: {statusMessage}
+          </li>
+        ))}
+      </ul>
+      <div style={{ alignItems: 'center', display: 'flex', gap: '0.5rem' }}>
+        <button
+          disabled={!isTestRunning}
+          onClick={() => setTestButtonLastPressedAt(new Date())}
+          type="button"
+        >
+          Test Button
+        </button>
+        {testButtonLastPressedAt && (
+          <span>Last pressed at {testButtonLastPressedAt.toISOString()}</span>
+        )}
+      </div>
+      <br />
+      <button disabled={!isTestRunning} onClick={stopTesting} type="button">
+        {isTestRunning ? 'Stop Testing' : 'Testing Stopped'}
+      </button>
+    </div>
+  );
+}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -20,6 +20,7 @@ export * from './voter_settings_manager_context';
 export * from './diagnostics';
 export * from './error_boundary';
 export * from './election_info_bar';
+export * from './electrical_testing_screen';
 export * from './file_input_button';
 export * from './fonts/font_family';
 export * from './full_screen_message';


### PR DESCRIPTION
## Overview

This PR handles some miscellaneous electrical testing app cleanup. It specifically:

- Adds a test button for testing the touch screen
- Adds a "Last key press" field for testing VxMark controller and PAT input
- Left aligns content (instead of center aligning) so that text doesn't hop around so much
- Refines error message extraction logic to avoid `[object Object]` status messages

Also sets up a shared `ElectricalTestingScreen` component to consolidate logic across VxMark and VxScan.

## Demo Video or Screenshot

_VxMark_

https://github.com/user-attachments/assets/8f00087a-680e-4e8f-81bb-099a0a07f935

_VxScan_

https://github.com/user-attachments/assets/0ce8f37b-2524-410d-9841-a7b234f45278

## Testing Plan

- [x] Tested manually
- [x] Added automated tests