### PR TITLE
Handle unadjudicated unmarked write-ins

### DIFF
--- a/apps/admin/backend/src/tabulation/write_ins.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.ts
@@ -455,6 +455,7 @@ export function filterOvervoteWriteInsFromElectionResults({
     const isOvervote = cvrContestVotes.length > contestResult.votesAllowed;
     if (isOvervote) {
       if (writeIn.status === 'pending') {
+        if (writeIn.isUnmarked) continue; // pending unmarked write-ins do not contribute to tallies
         const pendingWriteIns = assertDefined(
           contestResult.tallies[Tabulation.GENERIC_WRITE_IN_ID]
         );

--- a/apps/admin/backend/test/mock_cvr_file.ts
+++ b/apps/admin/backend/test/mock_cvr_file.ts
@@ -114,6 +114,7 @@ export function addMockCvrFileToStore({
             side: 'front',
             contestId,
             optionId,
+            isUnmarked: optionId.includes('unmarked'),
           });
         }
       }


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/5656

As I started working with Unmarked Write-Ins today, I realized I had previously mishandled filtering overvotes for _Unadjudicated and Unmarked_ write-ins from the tally report. 

**Context:**
Our initial write-in tally code had a bug in it where we would still add tally marks for Write-In candidates on the tally report even when the vote was part of an overvote.

I then [made a fix](https://github.com/votingworks/vxsuite/pull/5815) for this so we filter those votes out. This worked, but it mishandled Unmarked Write-ins, as those were never tabulated to begin.

**Example**
1. Two ballot contests are cast, both Overvotes. The first votes for candidate A and Write-in, the second votes for candidate A and Unmarked Write-in.
2. Pre-adjudication, the tally report should show an Overvote from ballot 1, and a vote for Candidate A on ballot 2. This is because the UWI from ballot 2 is counted as an undervote before adjudication. NOTE: The **initial** bug was that the Write-In from ballot 1 would contribute a count of 1 to Unadjudicated Write-in, even though it should not since it is part of an overvote. The **current** bug that this PR fixes is that Write-In count would actually show -1, because the pending unmarked write-in would incorrectly decrement from the Unadjudicated write-in count, even though it never contributed to it since we already ignore unmarked write-ins.
3. We adjudicate both write-ins as valid, thus now the second ballot contest is registered as an overvote. Now the tally report should show as 2 overvotes, and no additional votes.

## Demo Video or Screenshot

<img width="718" alt="Screenshot 2025-02-28 at 4 02 04 PM" src="https://github.com/user-attachments/assets/d309932e-69e9-475b-b553-4f0305920f6c" />
This screenshot shows an incorrect Write-In count of 0, because a pending unmarked write-in from an overvote incorrectly decremented a count from Unadjudicated Write-In, when there should be 1. You can confirm because the tally votes do not add up to seats * ballots.

<img width="700" alt="Screenshot 2025-02-28 at 4 01 40 PM" src="https://github.com/user-attachments/assets/27c40453-cb61-4871-8154-182caea8ddd0" />
This screenshot shows the fixed count, now with an Unadjudicated Write-In count of 1.

## Testing Plan

Added test case and manually tested.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
