### PR TITLE
design/backend: Add review app config to app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,4 +1,15 @@
 {
   "name": "VotingWorks Ballot Designer",
-  "stack": "container"
+  "stack": "container",
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "standard-1x"
+    },
+    "worker": {
+      "quantity": 1,
+      "size": "standard-1x"
+    }
+  },
+  "addons": ["heroku-postgresql:hobby-free"]
 }

--- a/apps/design/backend/src/globals.ts
+++ b/apps/design/backend/src/globals.ts
@@ -24,6 +24,20 @@ export const NODE_ENV = unsafeParse(
   process.env.NODE_ENV ?? 'development'
 );
 
+const DeployEnvSchema = z.union([
+  z.literal('development'),
+  z.literal('staging'),
+  z.literal('production'),
+]);
+
+/**
+ * Which deployment environment is this (production, staging, development)?
+ */
+export const DEPLOY_ENV = unsafeParse(
+  DeployEnvSchema,
+  process.env.DEPLOY_ENV ?? 'development'
+);
+
 /* istanbul ignore next - @preserve */
 function requiredProdEnvVar<Fallback>(
   name: string,
@@ -60,6 +74,12 @@ export function authEnabled(): boolean {
 
 /* istanbul ignore next - @preserve */
 export function baseUrl(): string {
+  // Special case to support Heroku review apps
+  const herokuAppName = process.env['HEROKU_APP_NAME'];
+  if (!process.env['BASE_URL'] && DEPLOY_ENV === 'staging' && herokuAppName) {
+    return `https://${herokuAppName}.herokuapp.com`;
+  }
+
   return requiredProdEnvVar('BASE_URL', `http://localhost:${PORT}`);
 }
 
@@ -90,20 +110,6 @@ export function votingWorksOrgId(): string {
 export function sliOrgId(): string {
   return requiredProdEnvVar('ORG_ID_SLI', 'sli');
 }
-
-const DeployEnvSchema = z.union([
-  z.literal('development'),
-  z.literal('staging'),
-  z.literal('production'),
-]);
-
-/**
- * Which deployment environment is this (production, staging, development)?
- */
-export const DEPLOY_ENV = unsafeParse(
-  DeployEnvSchema,
-  process.env.DEPLOY_ENV ?? 'development'
-);
 
 /**
  * Where should the database go?


### PR DESCRIPTION
## Overview

Task: #6079 

Sets up the necessary config (mainly in app.json) to automatically provision Heroku review apps and their necessary resources.

After this PR, the only manual step required will be initializing the db schema by running the following command locally:
```
DATABASE_URL=<copy from Heroku> psql $DATABASE_URL < schema.sql
```
The imminent migration tooling should make this unnecessary, so I'm not worried about automating it for now.

## Demo Video or Screenshot
N/A

## Testing Plan

Created a review app from this branch 

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
