### PR TITLE
fix(scan): attempt to recover from failed scanner reconnects

### DIFF
--- a/apps/scan/backend/src/electrical_testing/server.ts
+++ b/apps/scan/backend/src/electrical_testing/server.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from '@votingworks/basics';
 import { LogEventId } from '@votingworks/logging';
 
 import { PORT } from '../globals';
@@ -6,7 +7,7 @@ import { cardReadAndUsbDriveWriteLoop, printAndScanLoop } from './background';
 import { ServerContext } from './context';
 
 export function startElectricalTestingServer(context: ServerContext): void {
-  const { logger } = context;
+  const { workspace, logger } = context;
   const cardReadAndUsbDriveWriteLoopPromise =
     cardReadAndUsbDriveWriteLoop(context);
   const printAndScanLoopPromise = printAndScanLoop(context);
@@ -42,6 +43,10 @@ export function startElectricalTestingServer(context: ServerContext): void {
         disposition: 'success',
         message: 'Print and scan loop completed',
       });
+      workspace.store.setElectricalTestingStatusMessage(
+        'scanner',
+        'Print and scan loop completed'
+      );
     })
     .catch((error) => {
       void logger.log(LogEventId.BackgroundTaskFailure, 'system', {
@@ -49,6 +54,10 @@ export function startElectricalTestingServer(context: ServerContext): void {
         message: 'Print and scan loop failed',
         error,
       });
+      workspace.store.setElectricalTestingStatusMessage(
+        'scanner',
+        `Print and scan loop failed: ${extractErrorMessage(error)}`
+      );
     });
 
   const app = buildApp(context);

--- a/libs/pdi-scanner/src/ts/scanner_client.test.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.test.ts
@@ -197,6 +197,13 @@ test('disconnect', async () => {
   expectStdinCommand({ command: 'disconnect' });
 });
 
+test('disconnect when already disconnected', async () => {
+  const client = createPdiScannerClient();
+  mockStdoutResponse({ response: 'error', code: 'disconnected' });
+  expect(await client.disconnect()).toEqual(ok());
+  expectStdinCommand({ command: 'disconnect' });
+});
+
 test('exit', async () => {
   const client = createPdiScannerClient();
   let closed = false;

--- a/libs/pdi-scanner/src/ts/scanner_client.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.ts
@@ -454,7 +454,13 @@ export function createPdiScannerClient() {
      * Disconnects pdictl from the scanner, but keeps it running.
      */
     async disconnect(): Promise<SimpleResult> {
-      return sendSimpleCommand({ command: 'disconnect' });
+      const result = await sendSimpleCommand({ command: 'disconnect' });
+
+      if (result.err()?.code === 'disconnected') {
+        return ok();
+      }
+
+      return result;
     },
 
     /**


### PR DESCRIPTION
## Overview

Mostly this just causes the loop to not exit when reconnecting fails. Additionally, this adds logging whenever the testing status message changes.

## Demo Video or Screenshot
Some example logging:
```
[backend:run] {"source":"vx-scan-backend","eventId":"info","eventType":"system-status","user":"system","message":"Setting electrical testing status message","disposition":"na","component":"usbDrive","statusMessage":"Success"}
[backend:run] {"source":"vx-scan-backend","eventId":"info","eventType":"system-status","user":"system","message":"Setting electrical testing status message","disposition":"na","component":"scanner","statusMessage":"Received event: scanStart"}
[backend:run] {"source":"vx-scan-backend","eventId":"info","eventType":"system-status","user":"system","message":"Setting electrical testing status message","disposition":"na","component":"scanner","statusMessage":"Received event: scanComplete"}
[backend:run] {"source":"vx-scan-backend","eventId":"info","eventType":"system-status","user":"system","message":"Setting electrical testing status message","disposition":"na","component":"scanner","statusMessage":"Scanned sheet: front=1728×2248, back=1728×2249"}
[backend:run] {"source":"vx-scan-backend","eventId":"info","eventType":"system-status","user":"system","message":"Setting electrical testing status message","disposition":"na","component":"scanner","statusMessage":"Ejected document to re-scan"}
[backend:run] {"source":"vx-scan-backend","eventId":"info","eventType":"system-status","user":"system","message":"Setting electrical testing status message","disposition":"na","component":"scanner","statusMessage":"Received event: scanStart"}
[backend:run] {"source":"vx-scan-backend","eventId":"info","eventType":"system-status","user":"system","message":"Setting electrical testing status message","disposition":"na","component":"scanner","statusMessage":"Received event: error"}
[backend:run] {"source":"vx-scan-backend","eventId":"info","eventType":"system-status","user":"system","message":"Setting electrical testing status message","disposition":"na","component":"scanner","statusMessage":"Scanner error: scanFailed"}
[backend:run] {"source":"vx-scan-backend","eventId":"info","eventType":"system-status","user":"system","message":"Setting electrical testing status message","disposition":"na","component":"scanner","statusMessage":"Resetting scanning"}
[backend:run] {"source":"vx-scan-backend","eventId":"info","eventType":"system-status","user":"system","message":"Setting electrical testing status message","disposition":"na","component":"scanner","statusMessage":"Scanning enabled; waiting for paper"}
[backend:run] {"source":"vx-scan-backend","eventId":"info","eventType":"system-status","user":"system","message":"Setting electrical testing status message","disposition":"na","component":"card","statusMessage":"Success"}
```

## Testing Plan
Tested manually by disconnecting the scanner at startup and during the scanning loop to ensure it recovers in both cases.