### PR TITLE
Fix flaky test

### DIFF
--- a/apps/admin/backend/src/tabulation/write_ins.test.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.test.ts
@@ -695,50 +695,44 @@ test('filterOvervoteWriteInsFromElectionResults', async () => {
     contestId: 'zoo-council-mammal',
   });
 
-  const [writeIn1, writeIn2, writeIn3, writeIn4] = writeIns;
   const writeInCandidate = store.addWriteInCandidate({
     electionId,
     contestId,
     name: 'Mr. Pickles',
   });
-  // overvote with write-in candidate
-  await adjudicateWriteIn(
-    {
-      writeInId: writeIn1!.id,
-      type: 'write-in-candidate',
-      candidateId: writeInCandidate.id,
-    },
-    store,
-    logger
-  );
-  // overvote with one invalid write-in and one official candidate write-in
-  await adjudicateWriteIn(
-    {
-      writeInId: writeIn2!.id,
-      type: 'invalid',
-    },
-    store,
-    logger
-  );
-  await adjudicateWriteIn(
-    {
-      writeInId: writeIn3!.id,
-      type: 'official-candidate',
-      candidateId: 'lion',
-    },
-    store,
-    logger
-  );
-  // overvote with unmarked write-in candidate
-  await adjudicateWriteIn(
-    {
-      writeInId: writeIn4!.id,
-      type: 'write-in-candidate',
-      candidateId: writeInCandidate.id,
-    },
-    store,
-    logger
-  );
+
+  for (const writeIn of writeIns) {
+    if (writeIn.optionId.includes('invalid')) {
+      await adjudicateWriteIn(
+        {
+          writeInId: writeIn.id,
+          type: 'invalid',
+        },
+        store,
+        logger
+      );
+    } else if (writeIn.optionId.includes('existing')) {
+      await adjudicateWriteIn(
+        {
+          writeInId: writeIn.id,
+          type: 'official-candidate',
+          candidateId: 'lion',
+        },
+        store,
+        logger
+      );
+    } else {
+      await adjudicateWriteIn(
+        {
+          writeInId: writeIn.id,
+          type: 'write-in-candidate',
+          candidateId: writeInCandidate.id,
+        },
+        store,
+        logger
+      );
+    }
+  }
 
   // Validate post adjudicated election results, with write-ins now associated with candidates
 


### PR DESCRIPTION
## Overview

This test has been flaky, with this [line](https://github.com/votingworks/vxsuite/blob/main/apps/admin/backend/src/tabulation/write_ins.ts#L467) not being consistently hit. 

I was able to reproduce locally about half the time. The ordering of the `writeInRecords` returned from the store was inconsistent, so I updated the test to adjudicate based on optionId, instead of assuming a certain ordering. This ordering mattered because if the "unmarked" write-in gets adjudicated as "invalid", then that cvr has no overvote, so the invalid overvote case is never hit.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
