### PR TITLE
design/backend: Re-enable skipped tests

### DIFF
--- a/apps/design/backend/vitest.config.ts
+++ b/apps/design/backend/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 85.1,
-        branches: 74.0,
+        lines: 86,
+        branches: 76,
       },
       exclude: ['src/configure_sentry.ts', '**/*.test.ts'],
     },

--- a/libs/backend/src/election_package/election_package_io.test.ts
+++ b/libs/backend/src/election_package/election_package_io.test.ts
@@ -4,7 +4,6 @@ import {
   DEFAULT_SYSTEM_SETTINGS,
   ElectionPackageFileName,
   ElectionPackageMetadata,
-  ElectionPackageWithHash,
   InsertedSmartCardAuth,
   LATEST_METADATA,
   SystemSettings,
@@ -51,7 +50,6 @@ import {
 import {
   ElectionPackageWithFileContents,
   readElectionPackageFromFile,
-  readNestedElectionPackageFromBuffer,
   readSignedElectionPackageFromUsb,
 } from './election_package_io';
 
@@ -101,32 +99,6 @@ function saveTmpFile(contents: Buffer) {
   fs.writeFileSync(tmpFile, contents);
   return tmpFile;
 }
-
-test('readNestedElectionPackageFromFile reads an election package nested in another zip file', async () => {
-  const electionDefinition =
-    electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
-  const innerPkg = await zipFile({
-    [ElectionPackageFileName.ELECTION]: electionDefinition.electionData,
-  });
-  const filename = 'election-package-abc123.zip';
-  const outerPkg = await zipFile({ [filename]: innerPkg });
-  const file = saveTmpFile(outerPkg);
-  const fileContents = fs.readFileSync(file);
-
-  const result = (
-    await readNestedElectionPackageFromBuffer(fileContents)
-  ).unsafeUnwrap();
-  expect(result).toEqual<ElectionPackageWithHash>({
-    electionPackage: {
-      electionDefinition,
-      systemSettings: DEFAULT_SYSTEM_SETTINGS,
-      uiStrings: electionDefinition.election.ballotStrings,
-      uiStringAudioClips: [],
-      uiStringAudioIds: undefined,
-    },
-    electionPackageHash: sha256(innerPkg),
-  });
-});
 
 test('readElectionPackageFromFile reads an election package without system settings from a file', async () => {
   const electionDefinition =

--- a/libs/backend/src/election_package/election_package_io.ts
+++ b/libs/backend/src/election_package/election_package_io.ts
@@ -20,7 +20,6 @@ import {
   maybeGetFileByName,
   openZip,
   readTextEntry,
-  readEntry,
 } from '@votingworks/utils';
 import * as fs from 'node:fs/promises';
 import { LogEventId, BaseLogger } from '@votingworks/logging';
@@ -203,22 +202,6 @@ export async function readElectionPackageFromBuffer(
       message: String(error),
     });
   }
-}
-
-/**
- * Given a nested zip containing an election package zip,
- * parses the election package from the parent zip and hashes the raw contents.
- */
-export async function readNestedElectionPackageFromBuffer(
-  fileContents: Buffer
-): Promise<Result<ElectionPackageWithHash, ElectionPackageError>> {
-  const zipFile = await openZip(fileContents);
-  const entries = getEntries(zipFile);
-  const entry = assertDefined(
-    entries.find((e) => !!e.name.match(/election-package-.*\.zip/)),
-    'Could not find election package in zip'
-  );
-  return await readElectionPackageFromBuffer(await readEntry(entry));
 }
 
 /**


### PR DESCRIPTION
## Overview

Re-enables the remaining skipped tests in design/backend/src/app.test.ts
## Demo Video or Screenshot
N/A

## Testing Plan
The tests pass

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
