### PR TITLE
VxDesign: Backend validation for districts form

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -386,7 +386,6 @@ test('CRUD districts', async () => {
   };
   await apiClient.updateDistrict({
     electionId,
-    districtId: district1.id,
     updatedDistrict: updatedDistrict1,
   });
   expect(await apiClient.listDistricts({ electionId })).toEqual([
@@ -421,8 +420,10 @@ test('CRUD districts', async () => {
     expect(
       apiClient.updateDistrict({
         electionId,
-        districtId: unsafeParse(DistrictIdSchema, 'invalid-id'),
-        updatedDistrict: district1,
+        updatedDistrict: {
+          ...district1,
+          id: unsafeParse(DistrictIdSchema, 'invalid-id'),
+        },
       })
     ).rejects.toThrow()
   );

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -26,7 +26,6 @@ import {
 } from '@votingworks/types';
 import express, { Application } from 'express';
 import {
-  assert,
   assertDefined,
   DateWithoutTime,
   find,
@@ -342,8 +341,7 @@ function buildApi({ auth, workspace, translator }: AppContext) {
     async listDistricts(input: {
       electionId: ElectionId;
     }): Promise<readonly District[]> {
-      const { election } = await store.getElection(input.electionId);
-      return election.districts;
+      return store.listDistricts(input.electionId);
     },
 
     async createDistrict(input: {
@@ -351,34 +349,15 @@ function buildApi({ auth, workspace, translator }: AppContext) {
       newDistrict: District;
     }): Promise<void> {
       const district = unsafeParse(DistrictSchema, input.newDistrict);
-      const { election } = await store.getElection(input.electionId);
-      await store.updateElection(input.electionId, {
-        ...election,
-        districts: [...election.districts, district],
-      });
+      await store.createDistrict(input.electionId, district);
     },
 
     async updateDistrict(input: {
       electionId: ElectionId;
-      districtId: DistrictId;
-      updatedDistrict: Omit<District, 'id'>;
+      updatedDistrict: District;
     }): Promise<void> {
-      const district = unsafeParse(DistrictSchema, {
-        ...input.updatedDistrict,
-        id: input.districtId,
-      });
-      const { election } = await store.getElection(input.electionId);
-      assert(
-        election.districts.some((d) => d.id === input.districtId),
-        'District not found'
-      );
-      const updatedDistricts = election.districts.map((d) =>
-        d.id === input.districtId ? district : d
-      );
-      await store.updateElection(input.electionId, {
-        ...election,
-        districts: updatedDistricts,
-      });
+      const district = unsafeParse(DistrictSchema, input.updatedDistrict);
+      await store.updateDistrict(input.electionId, district);
     },
 
     async deleteDistrict(input: {

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -15,6 +15,7 @@ import {
   SplittablePrecinct,
   DistrictId,
   hasSplits,
+  District,
 } from '@votingworks/types';
 import { v4 as uuid } from 'uuid';
 import { BaseLogger } from '@votingworks/logging';
@@ -338,6 +339,40 @@ export class Store {
         electionId
       )
     );
+  }
+
+  async listDistricts(electionId: ElectionId): Promise<readonly District[]> {
+    const { election } = await this.getElection(electionId);
+    return election.districts;
+  }
+
+  async createDistrict(
+    electionId: ElectionId,
+    district: District
+  ): Promise<void> {
+    const { election } = await this.getElection(electionId);
+    await this.updateElection(electionId, {
+      ...election,
+      districts: [...election.districts, district],
+    });
+  }
+
+  async updateDistrict(
+    electionId: ElectionId,
+    district: District
+  ): Promise<void> {
+    const { election } = await this.getElection(electionId);
+    assert(
+      election.districts.some((d) => d.id === district.id),
+      'District not found'
+    );
+    const updatedDistricts = election.districts.map((d) =>
+      d.id === district.id ? district : d
+    );
+    await this.updateElection(electionId, {
+      ...election,
+      districts: updatedDistricts,
+    });
   }
 
   async deleteDistrict(

--- a/apps/design/backend/vitest.config.ts
+++ b/apps/design/backend/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 86,
+        lines: 87,
         branches: 76,
       },
       exclude: ['src/configure_sentry.ts', '**/*.test.ts'],

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -120,26 +120,27 @@ export const getElectionInfo = {
   },
 } as const;
 
+export const listDistricts = {
+  queryKey(id: ElectionId): QueryKey {
+    return ['listDistricts', id];
+  },
+  useQuery(id: ElectionId) {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(id), () =>
+      apiClient.listDistricts({ electionId: id })
+    );
+  },
+} as const;
+
 async function invalidateElectionQueries(
   queryClient: QueryClient,
   electionId: ElectionId
 ) {
   await queryClient.invalidateQueries(getElection.queryKey(electionId));
   await queryClient.invalidateQueries(getElectionInfo.queryKey(electionId));
+  await queryClient.invalidateQueries(listDistricts.queryKey(electionId));
   await queryClient.invalidateQueries(listElections.queryKey());
 }
-
-export const updateElectionInfo = {
-  useMutation() {
-    const apiClient = useApiClient();
-    const queryClient = useQueryClient();
-    return useMutation(apiClient.updateElectionInfo, {
-      async onSuccess(_, { electionId }) {
-        await invalidateElectionQueries(queryClient, electionId);
-      },
-    });
-  },
-} as const;
 
 export const loadElection = {
   useMutation() {
@@ -216,6 +217,54 @@ export const updateElection = {
           // fresh when user navigates back to elections list
           refetchType: 'all',
         });
+        await invalidateElectionQueries(queryClient, electionId);
+      },
+    });
+  },
+} as const;
+
+export const updateElectionInfo = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.updateElectionInfo, {
+      async onSuccess(_, { electionId }) {
+        await invalidateElectionQueries(queryClient, electionId);
+      },
+    });
+  },
+} as const;
+
+export const createDistrict = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.createDistrict, {
+      async onSuccess(_, { electionId }) {
+        await invalidateElectionQueries(queryClient, electionId);
+      },
+    });
+  },
+} as const;
+
+export const updateDistrict = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.updateDistrict, {
+      async onSuccess(_, { electionId }) {
+        await invalidateElectionQueries(queryClient, electionId);
+      },
+    });
+  },
+} as const;
+
+export const deleteDistrict = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.deleteDistrict, {
+      async onSuccess(_, { electionId }) {
         await invalidateElectionQueries(queryClient, electionId);
       },
     });

--- a/apps/design/frontend/src/geography_screen.test.tsx
+++ b/apps/design/frontend/src/geography_screen.test.tsx
@@ -33,9 +33,28 @@ let apiMock: MockApiClient;
 
 const idFactory = makeIdFactory();
 
+const electionGeneral = readElectionGeneral();
+const electionWithNoGeographyRecord: ElectionRecord = makeElectionRecord(
+  {
+    ...electionGeneral,
+    districts: [],
+    precincts: [],
+  },
+  user.orgId
+);
+
+const electionWithNoPrecinctsRecord: ElectionRecord = makeElectionRecord(
+  {
+    ...electionGeneral,
+    precincts: [],
+  },
+  user.orgId
+);
+
 beforeEach(() => {
   apiMock = createMockApiClient();
   idFactory.reset();
+  apiMock.getUser.expectCallWith().resolves(user);
   mockUserFeatures(apiMock, user);
 });
 
@@ -58,38 +77,24 @@ function renderScreen(electionId: ElectionId) {
   return history;
 }
 
-const electionGeneral = readElectionGeneral();
-const electionWithNoGeographyRecord: ElectionRecord = makeElectionRecord(
-  {
-    ...electionGeneral,
-    districts: [],
-    precincts: [],
-  },
-  user.orgId
-);
-
-const electionWithNoPrecinctsRecord: ElectionRecord = makeElectionRecord(
-  {
-    ...electionGeneral,
-    precincts: [],
-  },
-  user.orgId
-);
-
 describe('Districts tab', () => {
+  const election = electionGeneral;
+  const electionId = electionGeneral.id;
+  beforeEach(() => {
+    // For screen title
+    apiMock.getElection
+      .expectRepeatedCallsWith({ user, electionId })
+      .resolves(electionWithNoGeographyRecord);
+    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+  });
+
   test('adding a district', async () => {
-    const { election } = electionWithNoGeographyRecord;
-    const electionId = election.id;
     const newDistrict: District = {
       id: idFactory.next() as DistrictId,
       name: 'New District',
     };
 
-    apiMock.getUser.expectRepeatedCallsWith().resolves(user);
-    apiMock.getElection
-      .expectCallWith({ user, electionId })
-      .resolves(electionWithNoGeographyRecord);
-    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+    apiMock.listDistricts.expectCallWith({ electionId }).resolves([]);
     renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Geography' });
@@ -101,19 +106,12 @@ describe('Districts tab', () => {
 
     userEvent.type(screen.getByLabelText('Name'), newDistrict.name);
 
-    const electionWithNewDistrictRecord: ElectionRecord = {
-      ...electionWithNoGeographyRecord,
-      election: { ...election, districts: [newDistrict] },
-    };
-    apiMock.updateElection
-      .expectCallWith({
-        electionId,
-        election: electionWithNewDistrictRecord.election,
-      })
+    apiMock.createDistrict
+      .expectCallWith({ electionId, newDistrict })
       .resolves();
-    apiMock.getElection
-      .expectCallWith({ user, electionId })
-      .resolves(electionWithNewDistrictRecord);
+    apiMock.listDistricts
+      .expectCallWith({ electionId })
+      .resolves([newDistrict]);
     userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await screen.findByRole('heading', { name: 'Geography' });
@@ -131,20 +129,15 @@ describe('Districts tab', () => {
   });
 
   test('editing a district', async () => {
-    const electionRecord = generalElectionRecord(user.orgId);
-    const { election } = electionRecord;
-    const electionId = election.id;
     const savedDistrict = election.districts[0];
-    const changedDistrict: District = {
+    const updatedDistrict: District = {
       ...savedDistrict,
-      name: 'Changed District',
+      name: 'Updated District',
     };
 
-    apiMock.getUser.expectRepeatedCallsWith().resolves(user);
-    apiMock.getElection
-      .expectCallWith({ user, electionId })
-      .resolves(electionRecord);
-    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+    apiMock.listDistricts
+      .expectCallWith({ electionId })
+      .resolves(election.districts);
     renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Geography' });
@@ -152,10 +145,12 @@ describe('Districts tab', () => {
     const rows = screen.getAllByRole('row');
     expect(rows).toHaveLength(election.districts.length + 1);
 
-    const savedContestRow = screen.getByText(savedDistrict.name).closest('tr')!;
-    const contestRowIndex = rows.indexOf(savedContestRow);
+    const savedDistrictRow = screen
+      .getByText(savedDistrict.name)
+      .closest('tr')!;
+    const contestRowIndex = rows.indexOf(savedDistrictRow);
     userEvent.click(
-      within(savedContestRow).getByRole('button', { name: 'Edit' })
+      within(savedDistrictRow).getByRole('button', { name: 'Edit' })
     );
 
     await screen.findByRole('heading', { name: 'Edit District' });
@@ -163,47 +158,36 @@ describe('Districts tab', () => {
     const nameInput = screen.getByLabelText('Name');
     expect(nameInput).toHaveValue(savedDistrict.name);
     userEvent.clear(nameInput);
-    userEvent.type(nameInput, changedDistrict.name);
+    userEvent.type(nameInput, updatedDistrict.name);
 
-    const electionWithChangedDistrictRecord: ElectionRecord = {
-      ...electionRecord,
-      election: {
-        ...election,
-        districts: [changedDistrict, ...election.districts.slice(1)],
-      },
-    };
-    apiMock.updateElection
+    apiMock.updateDistrict
       .expectCallWith({
         electionId,
-        election: electionWithChangedDistrictRecord.election,
+        districtId: savedDistrict.id,
+        updatedDistrict,
       })
       .resolves();
-    apiMock.getElection
-      .expectCallWith({ user, electionId })
-      .resolves(electionWithChangedDistrictRecord);
+    apiMock.listDistricts
+      .expectCallWith({ electionId })
+      .resolves([updatedDistrict, ...election.districts.slice(1)]);
     userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await screen.findByRole('heading', { name: 'Geography' });
     screen.getByRole('tab', { name: 'Districts', selected: true });
 
-    const changedContestRow = screen.getAllByRole('row')[contestRowIndex];
-    within(changedContestRow).getByText(changedDistrict.name);
+    const updatedDistrictRow = screen.getAllByRole('row')[contestRowIndex];
+    within(updatedDistrictRow).getByText(updatedDistrict.name);
   });
 
   test('deleting a district', async () => {
-    const electionRecord = generalElectionRecord(user.orgId);
-    const { election } = electionRecord;
-    const electionId = election.id;
     assert(election.districts.length === 3);
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
     const [savedDistrict, remainingDistrict, unusedDistrict] =
       election.districts;
 
-    apiMock.getUser.expectRepeatedCallsWith().resolves(user);
-    apiMock.getElection
-      .expectCallWith({ user, electionId })
-      .resolves(electionRecord);
-    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+    apiMock.listDistricts
+      .expectCallWith({ electionId })
+      .resolves(election.districts);
     renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Geography' });
@@ -218,88 +202,31 @@ describe('Districts tab', () => {
 
     await screen.findByRole('heading', { name: 'Edit District' });
 
-    // Writing out by hand the expected precincts after deleting the district to
-    // avoid replicating the logic we're trying to test (which removes the
-    // deleted district from any precincts/splits that reference it)
-    assert(electionRecord.precincts.length === 3);
-    assert(hasSplits(electionRecord.precincts[1]));
-    const precinctsWithDeletedDistrict: SplittablePrecinct[] = [
-      {
-        ...electionRecord.precincts[0],
-        districtIds: [remainingDistrict.id],
-      },
-      {
-        ...electionRecord.precincts[1],
-        splits: [
-          {
-            ...electionRecord.precincts[1].splits[0],
-            districtIds: [remainingDistrict.id],
-          },
-          {
-            ...electionRecord.precincts[1].splits[1],
-            districtIds: [],
-          },
-        ],
-      },
-      {
-        ...electionRecord.precincts[2],
-        districtIds: [],
-      },
-    ];
-    const electionWithDeletedDistrictRecord: ElectionRecord = {
-      ...electionRecord,
-      election: {
-        ...election,
-        districts: election.districts.filter(
-          (district) => district.id !== savedDistrict.id
-        ),
-      },
-      precincts: precinctsWithDeletedDistrict,
-    };
-    apiMock.updateElection
-      .expectCallWith({
-        electionId,
-        election: electionWithDeletedDistrictRecord.election,
-      })
+    apiMock.deleteDistrict
+      .expectCallWith({ electionId, districtId: savedDistrict.id })
       .resolves();
-    apiMock.updatePrecincts
-      .expectCallWith({
-        electionId,
-        precincts: precinctsWithDeletedDistrict,
-      })
-      .resolves();
-    apiMock.getElection
-      .expectCallWith({ user, electionId })
-      .resolves(electionWithDeletedDistrictRecord);
-    // Two mutations cause two refetches
-    apiMock.getElection
-      .expectCallWith({ user, electionId })
-      .resolves(electionWithDeletedDistrictRecord);
+    apiMock.listDistricts
+      .expectCallWith({ electionId })
+      .resolves([remainingDistrict, unusedDistrict]);
     // Initiate the deletion
     userEvent.click(screen.getByRole('button', { name: 'Delete District' }));
     // Confirm the deletion in the modal
     userEvent.click(screen.getByRole('button', { name: 'Delete District' }));
 
     await screen.findByRole('heading', { name: 'Geography' });
-    expect(screen.getAllByRole('row')).toHaveLength(
-      electionWithDeletedDistrictRecord.election.districts.length + 1
-    );
+    expect(screen.getAllByRole('row')).toHaveLength(election.districts.length);
     expect(screen.queryByText(savedDistrict.name)).not.toBeInTheDocument();
   });
 
   test('editing or adding a district is disabled when ballots are finalized', async () => {
-    const electionRecord = generalElectionRecord(user.orgId);
-    const { election } = electionRecord;
-    const electionId = election.id;
     const savedDistrict = election.districts[0];
-
-    apiMock.getUser.expectRepeatedCallsWith().resolves(user);
-    apiMock.getElection
-      .expectCallWith({ user, electionId })
-      .resolves(electionRecord);
+    apiMock.getBallotsFinalizedAt.reset();
     apiMock.getBallotsFinalizedAt
       .expectCallWith({ electionId })
       .resolves(new Date());
+    apiMock.listDistricts
+      .expectCallWith({ electionId })
+      .resolves(election.districts);
     renderScreen(electionId);
 
     await screen.findByRole('heading', { name: 'Geography' });
@@ -307,9 +234,11 @@ describe('Districts tab', () => {
     const rows = screen.getAllByRole('row');
     expect(rows).toHaveLength(election.districts.length + 1);
 
-    const savedContestRow = screen.getByText(savedDistrict.name).closest('tr')!;
+    const savedDistrictRow = screen
+      .getByText(savedDistrict.name)
+      .closest('tr')!;
     expect(
-      within(savedContestRow).getByRole('button', { name: 'Edit' })
+      within(savedDistrictRow).getByRole('button', { name: 'Edit' })
     ).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Add District' })).toBeDisabled();
   });
@@ -326,10 +255,12 @@ describe('Precincts tab', () => {
     };
 
     mockElectionFeatures(apiMock, electionId, {});
-    apiMock.getUser.expectRepeatedCallsWith().resolves(user);
     apiMock.getElection
       .expectCallWith({ user, electionId })
       .resolves(electionWithNoPrecinctsRecord);
+    apiMock.listDistricts
+      .expectCallWith({ electionId })
+      .resolves(election.districts);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
 
@@ -430,10 +361,12 @@ describe('Precincts tab', () => {
       PRECINCT_SPLIT_ELECTION_SEAL_OVERRIDE: true,
       PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE: true,
     });
-    apiMock.getUser.expectRepeatedCallsWith().resolves(user);
     apiMock.getElection
       .expectCallWith({ user, electionId })
       .resolves(nhElectionRecord);
+    apiMock.listDistricts
+      .expectCallWith({ electionId })
+      .resolves(election.districts);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
 
@@ -626,10 +559,12 @@ describe('Precincts tab', () => {
     };
 
     mockElectionFeatures(apiMock, electionId, {});
-    apiMock.getUser.expectRepeatedCallsWith().resolves(user);
     apiMock.getElection
       .expectCallWith({ user, electionId })
       .resolves(electionRecord);
+    apiMock.listDistricts
+      .expectCallWith({ electionId })
+      .resolves(election.districts);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
 
@@ -706,10 +641,12 @@ describe('Precincts tab', () => {
     const [savedPrecinct] = precincts;
 
     mockElectionFeatures(apiMock, electionId, {});
-    apiMock.getUser.expectRepeatedCallsWith().resolves(user);
     apiMock.getElection
       .expectCallWith({ user, electionId })
       .resolves(electionRecord);
+    apiMock.listDistricts
+      .expectCallWith({ electionId })
+      .resolves(election.districts);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
     renderScreen(electionId);
 

--- a/apps/design/frontend/src/geography_screen.test.tsx
+++ b/apps/design/frontend/src/geography_screen.test.tsx
@@ -161,11 +161,7 @@ describe('Districts tab', () => {
     userEvent.type(nameInput, updatedDistrict.name);
 
     apiMock.updateDistrict
-      .expectCallWith({
-        electionId,
-        districtId: savedDistrict.id,
-        updatedDistrict,
-      })
+      .expectCallWith({ electionId, updatedDistrict })
       .resolves();
     apiMock.listDistricts
       .expectCallWith({ electionId })

--- a/apps/design/frontend/src/geography_screen.test.tsx
+++ b/apps/design/frontend/src/geography_screen.test.tsx
@@ -242,6 +242,33 @@ describe('Districts tab', () => {
     ).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Add District' })).toBeDisabled();
   });
+
+  test('cancelling', async () => {
+    apiMock.listDistricts
+      .expectCallWith({ electionId })
+      .resolves(election.districts);
+    renderScreen(electionId);
+
+    await screen.findByRole('heading', { name: 'Geography' });
+    screen.getByRole('tab', { name: 'Districts', selected: true });
+    userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[0]);
+
+    await screen.findByRole('heading', { name: 'Edit District' });
+    userEvent.click(screen.getByRole('button', { name: 'Delete District' }));
+    await screen.findByRole('heading', { name: 'Delete District' });
+    // Cancel in confirm delete modal
+    userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('heading', { name: 'Delete District' })
+      ).not.toBeInTheDocument()
+    );
+
+    // Cancel edit district
+    userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await screen.findByRole('heading', { name: 'Geography' });
+    screen.getByRole('tab', { name: 'Districts', selected: true });
+  });
 });
 
 describe('Precincts tab', () => {

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -27,7 +27,6 @@ import {
 import {
   District,
   DistrictId,
-  Election,
   ElectionId,
   hasSplits,
   PrecinctId,
@@ -49,11 +48,14 @@ import {
   FieldName,
 } from './layout';
 import {
+  createDistrict,
+  deleteDistrict,
   getBallotsFinalizedAt,
+  listDistricts,
   getElection,
   getElectionFeatures,
   getUserFeatures,
-  updateElection,
+  updateDistrict,
   updatePrecincts,
 } from './api';
 import { generateId, replaceAtIndex } from './utils';
@@ -63,14 +65,14 @@ import { useTitle } from './hooks/use_title';
 
 function DistrictsTab(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
-  const getElectionQuery = getElection.useQuery(electionId);
+  const listDistrictsQuery = listDistricts.useQuery(electionId);
   const getBallotsFinalizedAtQuery = getBallotsFinalizedAt.useQuery(electionId);
   const getUserFeaturesQuery = getUserFeatures.useQuery();
 
   /* istanbul ignore next - @preserve */
   if (
     !(
-      getElectionQuery.isSuccess &&
+      listDistrictsQuery.isSuccess &&
       getBallotsFinalizedAtQuery.isSuccess &&
       getUserFeaturesQuery.isSuccess
     )
@@ -79,9 +81,7 @@ function DistrictsTab(): JSX.Element | null {
   }
 
   const ballotsFinalizedAt = getBallotsFinalizedAtQuery.data;
-  const {
-    election: { districts },
-  } = getElectionQuery.data;
+  const districts = listDistrictsQuery.data;
   const districtsRoutes = routes.election(electionId).geography.districts;
   const features = getUserFeaturesQuery.data;
 
@@ -142,15 +142,12 @@ function createBlankDistrict(): District {
 function DistrictForm({
   electionId,
   districtId,
-  savedElection,
-  savedPrecincts,
+  savedDistricts,
 }: {
   electionId: ElectionId;
-  districtId?: string;
-  savedElection: Election;
-  savedPrecincts?: SplittablePrecinct[];
+  districtId?: DistrictId;
+  savedDistricts: readonly District[];
 }): JSX.Element | null {
-  const savedDistricts = savedElection.districts;
   const [district, setDistrict] = useState<District | undefined>(
     districtId
       ? savedDistricts.find((d) => d.id === districtId)
@@ -158,8 +155,9 @@ function DistrictForm({
         // so it will only be called on initial render.
         createBlankDistrict
   );
-  const updateElectionMutation = updateElection.useMutation();
-  const updatePrecinctsMutation = updatePrecincts.useMutation();
+  const updateDistrictMutation = updateDistrict.useMutation();
+  const createDistrictMutation = createDistrict.useMutation();
+  const deleteDistrictMutation = deleteDistrict.useMutation();
   const history = useHistory();
   const geographyRoutes = routes.election(electionId).geography;
   const getUserFeaturesQuery = getUserFeatures.useQuery();
@@ -179,89 +177,29 @@ function DistrictForm({
     return null;
   }
 
-  function onSubmit(updatedDistrict: District) {
-    const newDistricts = districtId
-      ? savedElection.districts.map((d) =>
-          d.id === districtId ? updatedDistrict : d
-        )
-      : [...savedDistricts, updatedDistrict];
-    updateElectionMutation.mutate(
-      {
-        electionId,
-        election: {
-          ...savedElection,
-          districts: newDistricts,
-        },
-      },
-      {
-        onSuccess: () => {
-          history.push(geographyRoutes.districts.root.path);
-        },
-      }
-    );
-  }
-
-  function onReset() {
+  function goBackToDistrictsList() {
     history.push(geographyRoutes.districts.root.path);
   }
 
-  function onDeletePress() {
-    setIsConfirmingDelete(true);
+  function onSubmit(updatedDistrict: District) {
+    if (districtId) {
+      updateDistrictMutation.mutate(
+        { electionId, districtId, updatedDistrict },
+        { onSuccess: goBackToDistrictsList }
+      );
+    } else {
+      createDistrictMutation.mutate(
+        { electionId, newDistrict: updatedDistrict },
+        { onSuccess: goBackToDistrictsList }
+      );
+    }
   }
 
-  function onConfirmDeletePress(districtIdToRemove: DistrictId) {
-    assert(savedPrecincts !== undefined);
-    const newDistricts = savedDistricts.filter(
-      (d) => d.id !== districtIdToRemove
+  function onDelete(districtIdToDelete: DistrictId) {
+    deleteDistrictMutation.mutate(
+      { electionId, districtId: districtIdToDelete },
+      { onSuccess: goBackToDistrictsList }
     );
-    // When deleting a district, we need to remove it from any precincts that
-    // reference it
-    updatePrecinctsMutation.mutate(
-      {
-        electionId,
-        precincts: savedPrecincts.map((precinct) => {
-          if (hasSplits(precinct)) {
-            return {
-              ...precinct,
-              splits: precinct.splits.map((split) => ({
-                ...split,
-                districtIds: split.districtIds.filter(
-                  (id) => id !== districtIdToRemove
-                ),
-              })),
-            };
-          }
-          return {
-            ...precinct,
-            districtIds: precinct.districtIds.filter(
-              (id) => id !== districtIdToRemove
-            ),
-          };
-        }),
-      },
-      {
-        onSuccess: () => {
-          updateElectionMutation.mutate(
-            {
-              electionId,
-              election: {
-                ...savedElection,
-                districts: newDistricts,
-              },
-            },
-            {
-              onSuccess: () => {
-                history.push(geographyRoutes.districts.root.path);
-              },
-            }
-          );
-        },
-      }
-    );
-  }
-
-  function onCancelDelete() {
-    setIsConfirmingDelete(false);
   }
 
   return (
@@ -272,7 +210,7 @@ function DistrictForm({
       }}
       onReset={(e) => {
         e.preventDefault();
-        onReset();
+        goBackToDistrictsList();
       }}
     >
       <InputGroup label="Name">
@@ -294,7 +232,7 @@ function DistrictForm({
             type="submit"
             variant="primary"
             icon="Done"
-            disabled={updateElectionMutation.isLoading}
+            disabled={updateDistrictMutation.isLoading}
           >
             Save
           </Button>
@@ -304,8 +242,8 @@ function DistrictForm({
             <Button
               variant="danger"
               icon="Delete"
-              onPress={onDeletePress}
-              disabled={updateElectionMutation.isLoading}
+              onPress={() => setIsConfirmingDelete(true)}
+              disabled={deleteDistrictMutation.isLoading}
             >
               Delete District
             </Button>
@@ -326,15 +264,17 @@ function DistrictForm({
               <React.Fragment>
                 <Button
                   variant="danger"
-                  onPress={() => onConfirmDeletePress(district.id)}
+                  onPress={() => onDelete(district.id)}
                   autoFocus
                 >
                   Delete District
                 </Button>
-                <Button onPress={onCancelDelete}>Cancel</Button>
+                <Button onPress={() => setIsConfirmingDelete(false)}>
+                  Cancel
+                </Button>
               </React.Fragment>
             }
-            onOverlayClick={onCancelDelete}
+            onOverlayClick={() => setIsConfirmingDelete(false)}
           />
         )}
       </div>
@@ -344,15 +284,15 @@ function DistrictForm({
 
 function AddDistrictForm(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
-  const getElectionQuery = getElection.useQuery(electionId);
+  const listDistrictsQuery = listDistricts.useQuery(electionId);
   const geographyRoutes = routes.election(electionId).geography;
 
   /* istanbul ignore next - @preserve */
-  if (!getElectionQuery.isSuccess) {
+  if (!listDistrictsQuery.isSuccess) {
     return null;
   }
 
-  const { election } = getElectionQuery.data;
+  const districts = listDistrictsQuery.data;
   const { title } = geographyRoutes.districts.addDistrict;
 
   return (
@@ -365,7 +305,7 @@ function AddDistrictForm(): JSX.Element | null {
         <H1>{title}</H1>
       </MainHeader>
       <MainContent>
-        <DistrictForm electionId={electionId} savedElection={election} />
+        <DistrictForm electionId={electionId} savedDistricts={districts} />
       </MainContent>
     </React.Fragment>
   );
@@ -373,17 +313,17 @@ function AddDistrictForm(): JSX.Element | null {
 
 function EditDistrictForm(): JSX.Element | null {
   const { electionId, districtId } = useParams<
-    ElectionIdParams & { districtId: string }
+    ElectionIdParams & { districtId: DistrictId }
   >();
-  const getElectionQuery = getElection.useQuery(electionId);
+  const listDistrictsQuery = listDistricts.useQuery(electionId);
   const geographyRoutes = routes.election(electionId).geography;
 
   /* istanbul ignore next - @preserve */
-  if (!getElectionQuery.isSuccess) {
+  if (!listDistrictsQuery.isSuccess) {
     return null;
   }
 
-  const { election, precincts } = getElectionQuery.data;
+  const districts = listDistrictsQuery.data;
   const { title } = geographyRoutes.districts.editDistrict(districtId);
 
   return (
@@ -399,8 +339,7 @@ function EditDistrictForm(): JSX.Element | null {
         <DistrictForm
           electionId={electionId}
           districtId={districtId}
-          savedElection={election}
-          savedPrecincts={precincts}
+          savedDistricts={districts}
         />
       </MainContent>
     </React.Fragment>

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -184,7 +184,7 @@ function DistrictForm({
   function onSubmit(updatedDistrict: District) {
     if (districtId) {
       updateDistrictMutation.mutate(
-        { electionId, districtId, updatedDistrict },
+        { electionId, updatedDistrict },
         { onSuccess: goBackToDistrictsList }
       );
     } else {

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -274,7 +274,10 @@ function DistrictForm({
                 </Button>
               </React.Fragment>
             }
-            onOverlayClick={() => setIsConfirmingDelete(false)}
+            onOverlayClick={
+              /* istanbul ignore next - @preserve */
+              () => setIsConfirmingDelete(false)
+            }
           />
         )}
       </div>

--- a/apps/design/frontend/vitest.config.ts
+++ b/apps/design/frontend/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
 
     coverage: {
       thresholds: {
-        lines: 84.9,
+        lines: 85,
         branches: 73,
       },
       exclude: [


### PR DESCRIPTION
## Overview

Task: #6080 

Adds backend validation to the districts form. Adds new CRUD API methods for districts and validates input on the backend. Since there is also frontend validation, we don't actually expect invalid input to be sent to the backend, so we just throw errors if invalid input occurs.

## Demo Video or Screenshot
N/A - no functionality changed

## Testing Plan
Updated existing tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
