### PR TITLE
export test decks from background worker

### DIFF
--- a/apps/design/backend/schema.sql
+++ b/apps/design/backend/schema.sql
@@ -19,6 +19,9 @@ create table elections (
   election_package_task_id text
     constraint fk_background_tasks references background_tasks(id) on delete set null,
   election_package_url text,
+  test_decks_task_id text
+    constraint fk_test_decks_background_tasks references background_tasks(id) on delete set null,
+  test_decks_url text,
   ballot_template_id text not null,
   ballots_finalized_at timestamptz,
   ballot_language_codes text[]

--- a/apps/design/backend/src/worker/generate_test_decks.ts
+++ b/apps/design/backend/src/worker/generate_test_decks.ts
@@ -1,0 +1,120 @@
+import {
+  BallotType,
+  ElectionId,
+  ElectionSerializationFormat,
+  formatBallotHash,
+} from '@votingworks/types';
+import { translateBallotStrings } from '@votingworks/backend';
+import {
+  ballotTemplates,
+  createPlaywrightRenderer,
+  hmpbStringsCatalog,
+  renderAllBallotsAndCreateElectionDefinition,
+} from '@votingworks/hmpb';
+import { iter } from '@votingworks/basics';
+import JsZip from 'jszip';
+import path from 'node:path';
+import { WorkerContext } from './context';
+import {
+  createBallotPropsForTemplate,
+  formatElectionForExport,
+} from '../ballots';
+import {
+  createPrecinctTestDeck,
+  createTestDeckTallyReport,
+  FULL_TEST_DECK_TALLY_REPORT_FILE_NAME,
+} from '../test_decks';
+
+export async function generateTestDecks(
+  { translator, workspace, fileStorageClient }: WorkerContext,
+  {
+    electionId,
+    electionSerializationFormat,
+  }: {
+    electionId: ElectionId;
+    electionSerializationFormat: ElectionSerializationFormat;
+  }
+): Promise<void> {
+  const { store } = workspace;
+  const {
+    election,
+    ballotLanguageConfigs,
+    precincts,
+    ballotStyles,
+    ballotTemplateId,
+    orgId,
+  } = await store.getElection(electionId);
+
+  const ballotStrings = await translateBallotStrings(
+    translator,
+    election,
+    hmpbStringsCatalog,
+    ballotLanguageConfigs,
+    precincts
+  );
+  const formattedElection = formatElectionForExport(
+    election,
+    ballotStrings,
+    precincts
+  );
+  const allBallotProps = createBallotPropsForTemplate(
+    ballotTemplateId,
+    formattedElection,
+    precincts,
+    ballotStyles
+  );
+  const testBallotProps = allBallotProps.filter(
+    (props) =>
+      props.ballotMode === 'test' && props.ballotType === BallotType.Precinct
+  );
+  const renderer = await createPlaywrightRenderer();
+  const { electionDefinition, ballotDocuments } =
+    await renderAllBallotsAndCreateElectionDefinition(
+      renderer,
+      ballotTemplates[ballotTemplateId],
+      testBallotProps,
+      electionSerializationFormat
+    );
+  const ballots = iter(testBallotProps)
+    .zip(ballotDocuments)
+    .map(([props, document]) => ({
+      props,
+      document,
+    }))
+    .toArray();
+
+  const zip = new JsZip();
+
+  for (const precinct of election.precincts) {
+    const testDeckPdf = await createPrecinctTestDeck({
+      renderer,
+      election,
+      precinctId: precinct.id,
+      ballots,
+    });
+
+    if (!testDeckPdf) continue;
+    const fileName = `${precinct.name.replaceAll(' ', '_')}-test-ballots.pdf`;
+    zip.file(fileName, new Uint8Array(testDeckPdf));
+  }
+
+  const tallyReport = await createTestDeckTallyReport({ electionDefinition });
+
+  zip.file(FULL_TEST_DECK_TALLY_REPORT_FILE_NAME, new Uint8Array(tallyReport));
+  const zipContents = await zip.generateAsync({ type: 'nodebuffer' });
+  const zipFilename = `test-decks-${formatBallotHash(
+    electionDefinition.ballotHash
+  )}.zip`;
+
+  const writeResult = await fileStorageClient.writeFile(
+    path.join(orgId, zipFilename),
+    zipContents
+  );
+  writeResult.unsafeUnwrap();
+  const testDecksUrl = `/files/${orgId}/${zipFilename}`;
+
+  await store.setTestDecksUrl({
+    electionId,
+    testDecksUrl,
+  });
+}

--- a/apps/design/backend/src/worker/tasks.ts
+++ b/apps/design/backend/src/worker/tasks.ts
@@ -9,6 +9,7 @@ import {
 import { BackgroundTask } from '../store';
 import { WorkerContext } from './context';
 import { generateElectionPackageAndBallots } from './generate_election_package_and_ballots';
+import { generateTestDecks } from './generate_test_decks';
 
 export async function processBackgroundTask(
   context: WorkerContext,
@@ -27,6 +28,17 @@ export async function processBackgroundTask(
         })
       ).unsafeUnwrap();
       await generateElectionPackageAndBallots(context, parsedPayload);
+      break;
+    }
+    case 'generate_test_decks': {
+      const parsedPayload = safeParseJson(
+        payload,
+        z.object({
+          electionId: ElectionIdSchema,
+          electionSerializationFormat: ElectionSerializationFormatSchema,
+        })
+      ).unsafeUnwrap();
+      await generateTestDecks(context, parsedPayload);
       break;
     }
     default: {

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -250,3 +250,35 @@ export async function unzipElectionPackageAndBallots(fileContents: Buffer) {
     ballotsFileName: ballotsEntry.name,
   };
 }
+
+export const TEST_DECKS_FILE_NAME_REGEX = /test-decks-([0-9a-z]{7})\.zip$/;
+
+export async function exportTestDecks({
+  apiClient,
+  electionId,
+  fileStorageClient,
+  workspace,
+  electionSerializationFormat,
+}: {
+  apiClient: ApiClient;
+  electionId: ElectionId;
+  fileStorageClient: FileStorageClient;
+  workspace: Workspace;
+  electionSerializationFormat: ElectionSerializationFormat;
+}): Promise<string> {
+  await apiClient.exportTestDecks({
+    electionId,
+    electionSerializationFormat,
+  });
+  await processNextBackgroundTaskIfAny({
+    fileStorageClient,
+    workspace,
+  });
+
+  const testDecks = await apiClient.getTestDecks({
+    electionId,
+  });
+  return assertDefined(
+    assertDefined(testDecks.url).match(TEST_DECKS_FILE_NAME_REGEX)
+  )[0];
+}

--- a/apps/design/frontend/vitest.config.ts
+++ b/apps/design/frontend/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: 86,
-        branches: 73,
+        branches: 74,
       },
       exclude: [
         'src/**/*.d.ts',


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6086

Moves test deck generation to the background worker to avoid 30s request timeout.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/198ab8d0-4814-499d-9a57-1068b67c7c42


## Testing Plan
- updated existing test decks tests

## Checklist
- [x] I have added a screenshot and/or video to this PR to demo the change

