### PR TITLE
VxDesign: Refactor districts/precincts forms

### DIFF
--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -255,6 +255,7 @@ export const createDistrict = {
     return useMutation(apiClient.createDistrict, {
       async onSuccess(_, { electionId }) {
         await invalidateElectionQueries(queryClient, electionId);
+        await queryClient.refetchQueries(listDistricts.queryKey(electionId));
       },
     });
   },
@@ -291,6 +292,7 @@ export const createPrecinct = {
     return useMutation(apiClient.createPrecinct, {
       async onSuccess(_, { electionId }) {
         await invalidateElectionQueries(queryClient, electionId);
+        await queryClient.refetchQueries(listPrecincts.queryKey(electionId));
       },
     });
   },


### PR DESCRIPTION


## Overview

I realized that these forms could be a bit simpler and more straightforward if they didn't take in the entire list of saved entities, but rather only the one that was being edited.
## Demo Video or Screenshot
N/A

## Testing Plan
Existing test coverage
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
