### PR TITLE
VxDesign: Backend validation for parties form

### DIFF
--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -25,6 +25,8 @@ import {
   DistrictId,
   PrecinctId,
   SplittablePrecinctSchema,
+  Party,
+  PartySchema,
 } from '@votingworks/types';
 import express, { Application } from 'express';
 import {
@@ -404,6 +406,35 @@ function buildApi({ auth, workspace, translator }: AppContext) {
           rotateCandidates(contest, ballotTemplateId)
         ),
       });
+    },
+
+    async listParties(input: {
+      electionId: ElectionId;
+    }): Promise<readonly Party[]> {
+      return store.listParties(input.electionId);
+    },
+
+    async createParty(input: {
+      electionId: ElectionId;
+      newParty: Party;
+    }): Promise<void> {
+      const party = unsafeParse(PartySchema, input.newParty);
+      return store.createParty(input.electionId, party);
+    },
+
+    async updateParty(input: {
+      electionId: ElectionId;
+      updatedParty: Party;
+    }): Promise<void> {
+      const party = unsafeParse(PartySchema, input.updatedParty);
+      await store.updateParty(input.electionId, party);
+    },
+
+    async deleteParty(input: {
+      electionId: ElectionId;
+      partyId: string;
+    }): Promise<void> {
+      await store.deleteParty(input.electionId, input.partyId);
     },
 
     updateSystemSettings(input: {

--- a/apps/design/backend/vitest.config.ts
+++ b/apps/design/backend/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 87,
-        branches: 77,
+        lines: 88,
+        branches: 78,
       },
       exclude: ['src/configure_sentry.ts', '**/*.test.ts'],
     },

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -144,6 +144,18 @@ export const listPrecincts = {
   },
 } as const;
 
+export const listParties = {
+  queryKey(id: ElectionId): QueryKey {
+    return ['listParties', id];
+  },
+  useQuery(id: ElectionId) {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(id), () =>
+      apiClient.listParties({ electionId: id })
+    );
+  },
+} as const;
+
 async function invalidateElectionQueries(
   queryClient: QueryClient,
   electionId: ElectionId
@@ -152,6 +164,7 @@ async function invalidateElectionQueries(
   await queryClient.invalidateQueries(getElectionInfo.queryKey(electionId));
   await queryClient.invalidateQueries(listDistricts.queryKey(electionId));
   await queryClient.invalidateQueries(listPrecincts.queryKey(electionId));
+  await queryClient.invalidateQueries(listParties.queryKey(electionId));
   await queryClient.invalidateQueries(listElections.queryKey());
 }
 
@@ -315,6 +328,43 @@ export const deletePrecinct = {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
     return useMutation(apiClient.deletePrecinct, {
+      async onSuccess(_, { electionId }) {
+        await invalidateElectionQueries(queryClient, electionId);
+      },
+    });
+  },
+} as const;
+
+export const createParty = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.createParty, {
+      async onSuccess(_, { electionId }) {
+        await invalidateElectionQueries(queryClient, electionId);
+        await queryClient.refetchQueries(listParties.queryKey(electionId));
+      },
+    });
+  },
+} as const;
+
+export const updateParty = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.updateParty, {
+      async onSuccess(_, { electionId }) {
+        await invalidateElectionQueries(queryClient, electionId);
+      },
+    });
+  },
+} as const;
+
+export const deleteParty = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.deleteParty, {
       async onSuccess(_, { electionId }) {
         await invalidateElectionQueries(queryClient, electionId);
       },

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -1246,6 +1246,7 @@ function EditPartyForm(): JSX.Element | null {
   const listPartiesQuery = listParties.useQuery(electionId);
   const partyRoutes = routes.election(electionId).contests.parties;
 
+  /* istanbul ignore next - @preserve */
   if (!listPartiesQuery.isSuccess) {
     return null;
   }

--- a/apps/design/frontend/vitest.config.ts
+++ b/apps/design/frontend/vitest.config.ts
@@ -9,8 +9,8 @@ export default defineConfig({
 
     coverage: {
       thresholds: {
-        lines: 86,
-        branches: 74,
+        lines: 92,
+        branches: 79,
       },
       exclude: [
         'src/**/*.d.ts',


### PR DESCRIPTION
## Overview

Task: #6080 

Continuing the patterns established in #6093, #6095, and #6097. Adds backend validation to the parties form.

## Demo Video or Screenshot
N/A

## Testing Plan
Added new tests (pretty much all of this code was not covered)

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
