### PR TITLE
VxDesign: Backend validation for contests form

### DIFF
--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -27,6 +27,8 @@ import {
   SplittablePrecinctSchema,
   Party,
   PartySchema,
+  AnyContest,
+  AnyContestSchema,
 } from '@votingworks/types';
 import express, { Application } from 'express';
 import {
@@ -435,6 +437,46 @@ function buildApi({ auth, workspace, translator }: AppContext) {
       partyId: string;
     }): Promise<void> {
       await store.deleteParty(input.electionId, input.partyId);
+    },
+
+    async listContests(input: {
+      electionId: ElectionId;
+    }): Promise<readonly AnyContest[]> {
+      return store.listContests(input.electionId);
+    },
+
+    async createContest(input: {
+      electionId: ElectionId;
+      newContest: AnyContest;
+    }): Promise<void> {
+      let contest = unsafeParse(AnyContestSchema, input.newContest);
+      const { ballotTemplateId } = await store.getElection(input.electionId);
+      contest = rotateCandidates(contest, ballotTemplateId);
+      await store.createContest(input.electionId, contest);
+    },
+
+    async updateContest(input: {
+      electionId: ElectionId;
+      updatedContest: AnyContest;
+    }): Promise<void> {
+      let contest = unsafeParse(AnyContestSchema, input.updatedContest);
+      const { ballotTemplateId } = await store.getElection(input.electionId);
+      contest = rotateCandidates(contest, ballotTemplateId);
+      await store.updateContest(input.electionId, contest);
+    },
+
+    async reorderContests(input: {
+      electionId: ElectionId;
+      contestIds: string[];
+    }): Promise<void> {
+      await store.reorderContests(input.electionId, input.contestIds);
+    },
+
+    async deleteContest(input: {
+      electionId: ElectionId;
+      contestId: string;
+    }): Promise<void> {
+      await store.deleteContest(input.electionId, input.contestId);
     },
 
     updateSystemSettings(input: {

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -156,6 +156,18 @@ export const listParties = {
   },
 } as const;
 
+export const listContests = {
+  queryKey(id: ElectionId): QueryKey {
+    return ['listContests', id];
+  },
+  useQuery(id: ElectionId) {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(id), () =>
+      apiClient.listContests({ electionId: id })
+    );
+  },
+} as const;
+
 async function invalidateElectionQueries(
   queryClient: QueryClient,
   electionId: ElectionId
@@ -165,6 +177,7 @@ async function invalidateElectionQueries(
   await queryClient.invalidateQueries(listDistricts.queryKey(electionId));
   await queryClient.invalidateQueries(listPrecincts.queryKey(electionId));
   await queryClient.invalidateQueries(listParties.queryKey(electionId));
+  await queryClient.invalidateQueries(listContests.queryKey(electionId));
   await queryClient.invalidateQueries(listElections.queryKey());
 }
 
@@ -365,6 +378,55 @@ export const deleteParty = {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
     return useMutation(apiClient.deleteParty, {
+      async onSuccess(_, { electionId }) {
+        await invalidateElectionQueries(queryClient, electionId);
+      },
+    });
+  },
+} as const;
+
+export const createContest = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.createContest, {
+      async onSuccess(_, { electionId }) {
+        await invalidateElectionQueries(queryClient, electionId);
+        await queryClient.refetchQueries(listContests.queryKey(electionId));
+      },
+    });
+  },
+} as const;
+
+export const updateContest = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.updateContest, {
+      async onSuccess(_, { electionId }) {
+        await invalidateElectionQueries(queryClient, electionId);
+      },
+    });
+  },
+} as const;
+
+export const reorderContests = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.reorderContests, {
+      async onSuccess(_, { electionId }) {
+        await invalidateElectionQueries(queryClient, electionId);
+      },
+    });
+  },
+} as const;
+
+export const deleteContest = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.deleteContest, {
       async onSuccess(_, { electionId }) {
         await invalidateElectionQueries(queryClient, electionId);
       },

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -494,6 +494,7 @@ function ContestForm({
   const contestRoutes = routes.election(electionId).contests;
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
 
+  /* istanbul ignore next - @preserve */
   if (
     !(
       getElectionInfoQuery.isSuccess &&
@@ -989,6 +990,7 @@ function EditContestForm(): JSX.Element | null {
   const listContestsQuery = listContests.useQuery(electionId);
   const contestRoutes = routes.election(electionId).contests;
 
+  /* istanbul ignore next - @preserve */
   if (!listContestsQuery.isSuccess) {
     return null;
   }
@@ -1018,6 +1020,7 @@ function PartiesTab(): JSX.Element | null {
   const listPartiesQuery = listParties.useQuery(electionId);
   const getBallotsFinalizedAtQuery = getBallotsFinalizedAt.useQuery(electionId);
 
+  /* istanbul ignore next - @preserve */
   if (!(listPartiesQuery.isSuccess && getBallotsFinalizedAtQuery.isSuccess)) {
     return null;
   }

--- a/apps/design/frontend/vitest.config.ts
+++ b/apps/design/frontend/vitest.config.ts
@@ -9,8 +9,8 @@ export default defineConfig({
 
     coverage: {
       thresholds: {
-        lines: 92,
-        branches: 79,
+        lines: 93,
+        branches: 80,
       },
       exclude: [
         'src/**/*.d.ts',


### PR DESCRIPTION
## Overview

Task: #6080 

Adds backend form validation for the contests form.

## Demo Video or Screenshot
N/A

## Testing Plan
Updated existing tests, added some new tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
