### PR TITLE
design/backend: Use fake timers to fix flaky test

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -1160,11 +1160,12 @@ test('Finalize ballots', async () => {
   expect(await apiClient.getBallotsFinalizedAt({ electionId })).toEqual(null);
 
   const finalizedAt = new Date();
+  vi.useFakeTimers({ now: finalizedAt });
   await apiClient.finalizeBallots({ electionId });
-
-  expect(
-    (await apiClient.getBallotsFinalizedAt({ electionId }))!.valueOf() / 1000
-  ).toBeCloseTo(finalizedAt.valueOf() / 1000);
+  expect(await apiClient.getBallotsFinalizedAt({ electionId })).toEqual(
+    finalizedAt
+  );
+  vi.useRealTimers();
 
   await apiClient.unfinalizeBallots({ electionId });
 


### PR DESCRIPTION
## Overview

Since the `finalizeBallots` endpoint captures a timestamp on the backend, the approach of comparing to an expected timestamp created in the test was flaky. To make this more reliable, use fake timers to set the exact timestamp.

## Demo Video or Screenshot
N/A

## Testing Plan
N/A
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
