### PR TITLE
VxAdmin: Fix flaky test

### DIFF
--- a/apps/admin/frontend/src/screens/write_ins_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_adjudication_screen.test.tsx
@@ -731,5 +731,5 @@ test('jumping to first pending write-in', async () => {
     apiMock,
   });
 
-  await screen.findByText('win1');
+  await screen.findByRole('img', { name: /Ballot with write-in highlighted/i });
 });


### PR DESCRIPTION
## Overview

This test fails inconsistently, and I think it is because the `await` call might be met from some other page item before the mock calls are all made. I've updated the test to wait on the ballot image itself, as that should ensure the page data has actually loaded. 

I'm not 100% certain this will fix it, so I'll keep an eye on it.

## Demo Video or Screenshot

## Testing Plan

I got the old test to fail only one out of 20 times locally. The new test hasn't failed in 20 local attempts.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
