### PR TITLE
Reimplement writing vxqrcode on Polls Closed Report

### DIFF
--- a/libs/auth/src/config.ts
+++ b/libs/auth/src/config.ts
@@ -167,3 +167,20 @@ export function constructSignedHashValidationConfig(): SignedHashValidationConfi
     machinePrivateKey: privateKey,
   };
 }
+
+/**
+ * Config params for a signed quick results reporting instance
+ */
+export interface SignedQuickResultsReportingConfig {
+  machinePrivateKey: FileKey | TpmKey;
+}
+
+/**
+ * Constructs a signed hash validation config given relevant env vars
+ */
+export function constructSignedQuickResultsReportingConfig(): SignedQuickResultsReportingConfig {
+  const { privateKey } = getMachineCertPathAndPrivateKey();
+  return {
+    machinePrivateKey: privateKey,
+  };
+}

--- a/libs/auth/src/config.ts
+++ b/libs/auth/src/config.ts
@@ -176,7 +176,7 @@ export interface SignedQuickResultsReportingConfig {
 }
 
 /**
- * Constructs a signed hash validation config given relevant env vars
+ * Constructs a signed quick results config given relevant env vars
  */
 export function constructSignedQuickResultsReportingConfig(): SignedQuickResultsReportingConfig {
   const { privateKey } = getMachineCertPathAndPrivateKey();

--- a/libs/auth/src/index.ts
+++ b/libs/auth/src/index.ts
@@ -14,4 +14,4 @@ export * from './jurisdictions';
 export * from './mock_file_card';
 export * from './signed_hash_validation';
 export * from './test_utils';
-export * from './quick_results_signed_url';
+export * from './signed_quick_results_signed_url';

--- a/libs/auth/src/index.ts
+++ b/libs/auth/src/index.ts
@@ -14,3 +14,4 @@ export * from './jurisdictions';
 export * from './mock_file_card';
 export * from './signed_hash_validation';
 export * from './test_utils';
+export * from './quick_results_signed_url';

--- a/libs/auth/src/quick_results_signed_url.ts
+++ b/libs/auth/src/quick_results_signed_url.ts
@@ -1,0 +1,59 @@
+import { Readable } from 'node:stream';
+import { Buffer } from 'node:buffer';
+import { ElectionDefinition, Tabulation } from '@votingworks/types';
+import { compressTally } from '@votingworks/utils';
+import { constructPrefixedMessage } from './signatures';
+import { signMessage } from './cryptography';
+import { constructSignedQuickResultsReportingConfig } from './config';
+
+interface SignedQuickResultsReportingUrlProps {
+  electionDefinition: ElectionDefinition;
+  quickResultsReportingUrl: string;
+  signingMachineId: string;
+  isLiveMode: boolean;
+  results: Tabulation.ElectionResults;
+}
+
+/**
+ * The separator between parts of the signed hash validation message payload
+ */
+export const SIGNED_QUICK_RESULTS_MESSAGE_PAYLOAD_SEPARATOR = '.';
+
+/**
+ * Returns the URL to encode as a QR Code for quick results reporting.
+ * Encoded data is a URL to the quick results reporting page with a signed payload representing the election results.
+ */
+export async function getSignedQuickResultsReportingUrl(
+  {
+    electionDefinition,
+    quickResultsReportingUrl,
+    signingMachineId,
+    isLiveMode,
+    results,
+  }: SignedQuickResultsReportingUrlProps,
+  signingConfig = constructSignedQuickResultsReportingConfig()
+): Promise<string> {
+  const { ballotHash, election } = electionDefinition;
+  const compressedTally = compressTally(election, results);
+  const secondsSince1970 = Math.round(new Date().getTime() / 1000);
+  const stringToSignParts = [
+    ballotHash,
+    signingMachineId,
+    isLiveMode ? '1' : '0',
+    secondsSince1970.toString(),
+    Buffer.from(JSON.stringify(compressedTally)).toString('base64'),
+  ];
+  const stringToSign = stringToSignParts.join(
+    SIGNED_QUICK_RESULTS_MESSAGE_PAYLOAD_SEPARATOR
+  );
+  const message = constructPrefixedMessage('qr1', stringToSign);
+  const messageSignature = await signMessage({
+    message: Readable.from(message),
+    signingPrivateKey: signingConfig.machinePrivateKey,
+  });
+
+  const url = `${quickResultsReportingUrl}/?p=${encodeURIComponent(
+    message
+  )}&s=${encodeURIComponent(messageSignature.toString('base64url'))}`;
+  return url;
+}

--- a/libs/auth/src/signed_quick_results_signed_url.ts
+++ b/libs/auth/src/signed_quick_results_signed_url.ts
@@ -15,7 +15,7 @@ interface SignedQuickResultsReportingUrlProps {
 }
 
 /**
- * The separator between parts of the signed hash validation message payload
+ * The separator between parts of the signed quick results message payload
  */
 export const SIGNED_QUICK_RESULTS_MESSAGE_PAYLOAD_SEPARATOR = '.';
 

--- a/libs/types/src/system_settings.ts
+++ b/libs/types/src/system_settings.ts
@@ -80,6 +80,11 @@ export interface SystemSettings {
    * positives.
    */
   readonly disableVerticalStreakDetection?: boolean;
+
+  /**
+   * Enables quick results reporting and provides the server URL to post results to
+   */
+  readonly quickResultsReportingUrl?: string;
 }
 
 export const SystemSettingsSchema: z.ZodType<SystemSettings> = z.object({
@@ -97,6 +102,7 @@ export const SystemSettingsSchema: z.ZodType<SystemSettings> = z.object({
   castVoteRecordsIncludeOriginalSnapshots: z.boolean().optional(),
   castVoteRecordsIncludeRedundantMetadata: z.boolean().optional(),
   disableVerticalStreakDetection: z.boolean().optional(),
+  quickResultsReportingUrl: z.string().optional(),
 });
 
 /**

--- a/libs/ui/src/reports/precinct_scanner_tally_qr_code.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_qr_code.tsx
@@ -1,6 +1,4 @@
 import styled from 'styled-components';
-import React from 'react';
-import { LogoMark } from '../logo_mark';
 import { QrCode } from '../qrcode';
 
 const QrCodeWrapper = styled.div`
@@ -15,17 +13,14 @@ export function PrecinctScannerTallyQrCode({
   signedQuickResultsReportingUrl,
 }: PrecinctScannerTallyQrCodeProps): JSX.Element {
   return (
-    <React.Fragment>
-      <LogoMark />
-      <div>
-        <h1>Quick Results Reporting</h1>
-        <QrCodeWrapper
-          data-testid="qrcode"
-          data-value={signedQuickResultsReportingUrl}
-        >
-          <QrCode value={signedQuickResultsReportingUrl} />
-        </QrCodeWrapper>
-      </div>
-    </React.Fragment>
+    <div>
+      <h1>Quick Results Reporting</h1>
+      <QrCodeWrapper
+        data-testid="qrcode"
+        data-value={signedQuickResultsReportingUrl}
+      >
+        <QrCode value={signedQuickResultsReportingUrl} />
+      </QrCodeWrapper>
+    </div>
   );
 }

--- a/libs/ui/src/reports/precinct_scanner_tally_qr_code.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_qr_code.tsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+import React from 'react';
+import { LogoMark } from '../logo_mark';
+import { QrCode } from '../qrcode';
+
+const QrCodeWrapper = styled.div`
+  width: 25%;
+`;
+
+export interface PrecinctScannerTallyQrCodeProps {
+  signedQuickResultsReportingUrl: string;
+}
+
+export function PrecinctScannerTallyQrCode({
+  signedQuickResultsReportingUrl,
+}: PrecinctScannerTallyQrCodeProps): JSX.Element {
+  return (
+    <React.Fragment>
+      <LogoMark />
+      <div>
+        <h1>Quick Results Reporting</h1>
+        <QrCodeWrapper
+          data-testid="qrcode"
+          data-value={signedQuickResultsReportingUrl}
+        >
+          <QrCode value={signedQuickResultsReportingUrl} />
+        </QrCodeWrapper>
+      </div>
+    </React.Fragment>
+  );
+}

--- a/libs/ui/src/reports/precinct_scanner_tally_report.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_report.tsx
@@ -16,6 +16,7 @@ import {
 } from './layout';
 import { TallyReportCardCounts } from './tally_report_card_counts';
 import { ContestResultsTable } from './contest_results_table';
+import { PrecinctScannerTallyQrCode } from './precinct_scanner_tally_qr_code';
 
 interface Props {
   electionDefinition: ElectionDefinition;
@@ -29,6 +30,7 @@ interface Props {
   pollsTransitionedTime: number;
   reportPrintedTime: number;
   precinctScannerMachineId: string;
+  signedQuickResultsReportingUrl?: string;
 }
 
 /**
@@ -47,6 +49,7 @@ export function PrecinctScannerTallyReport({
   pollsTransitionedTime,
   reportPrintedTime,
   precinctScannerMachineId,
+  signedQuickResultsReportingUrl,
 }: Props): JSX.Element {
   const { election } = electionDefinition;
   const precinctId =
@@ -55,6 +58,11 @@ export function PrecinctScannerTallyReport({
       : undefined;
 
   const { cardCounts } = scannedElectionResults;
+
+  const showQuickResults =
+    signedQuickResultsReportingUrl &&
+    signedQuickResultsReportingUrl.length > 0 &&
+    pollsTransition === 'close_polls';
 
   return (
     <ThemeProvider theme={printedReportThemeFn}>
@@ -89,6 +97,11 @@ export function PrecinctScannerTallyReport({
             );
           })}
         </TallyReportColumns>
+        {showQuickResults && (
+          <PrecinctScannerTallyQrCode
+            signedQuickResultsReportingUrl={signedQuickResultsReportingUrl}
+          />
+        )}
       </PrintedReport>
     </ThemeProvider>
   );

--- a/libs/ui/src/reports/precinct_scanner_tally_report.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_report.tsx
@@ -60,9 +60,7 @@ export function PrecinctScannerTallyReport({
   const { cardCounts } = scannedElectionResults;
 
   const showQuickResults =
-    signedQuickResultsReportingUrl &&
-    signedQuickResultsReportingUrl.length > 0 &&
-    pollsTransition === 'close_polls';
+    signedQuickResultsReportingUrl && signedQuickResultsReportingUrl.length > 0;
 
   return (
     <ThemeProvider theme={printedReportThemeFn}>

--- a/libs/ui/src/reports/precinct_scanner_tally_reports.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_reports.tsx
@@ -29,6 +29,7 @@ export interface PrecinctScannerTallyReportsProps {
   pollsTransitionedTime: number;
   reportPrintedTime: number;
   precinctScannerMachineId: string;
+  signedQuickResultsReportingUrl?: string;
 }
 
 /**
@@ -44,12 +45,14 @@ export function PrecinctScannerTallyReports({
   pollsTransitionedTime,
   reportPrintedTime,
   precinctScannerMachineId,
+  signedQuickResultsReportingUrl,
 }: PrecinctScannerTallyReportsProps): JSX.Element[] {
   const { election } = electionDefinition;
   const combinedResults = combineElectionResults({
     election,
     allElectionResults: electionResultsByParty,
   });
+
   const partyIds =
     getPartyIdsForPrecinctScannerTallyReports(electionDefinition);
   const allContests = getContestsForPrecinct(
@@ -83,6 +86,7 @@ export function PrecinctScannerTallyReports({
         pollsTransitionedTime={pollsTransitionedTime}
         reportPrintedTime={reportPrintedTime}
         precinctScannerMachineId={precinctScannerMachineId}
+        signedQuickResultsReportingUrl={signedQuickResultsReportingUrl}
       />
     );
   });


### PR DESCRIPTION
## Overview
When the system settings file has a quick results reporting URL specified, encodes a QR code using the URL to submit the tally represented by the polls closed report. 

Open to adding tests but wasn't sure what was necessary for this small demo feature. 


Relevant related updates to the server: https://github.com/votingworks/quickresults-server/pull/12 
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

Example Polls Closed Report 
[vxqrsamplereport.pdf](https://github.com/user-attachments/files/19326632/vxqrsamplereport.pdf)


## Testing Plan
Manually tested by scannign ballots, creating report, scanning QR code and verifying it took me to the right encoded URL with the tally properly represented. 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
