### PR TITLE
[VxDesign] Add missing test deck task info columns to DB

### DIFF
--- a/apps/design/backend/migrations/1742326862308_add-test-deck-task-info.js
+++ b/apps/design/backend/migrations/1742326862308_add-test-deck-task-info.js
@@ -1,0 +1,29 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  pgm.addColumns(
+    'elections',
+    {
+      test_decks_task_id: {
+        type: 'text',
+        references: 'background_tasks(id)',
+        referencesConstraintName: 'fk_test_decks_background_tasks',
+        onDelete: 'SET NULL',
+      },
+      test_decks_url: { type: 'text' },
+    },
+    {
+      // These columns were missing from the prod DB, so they also appear in the
+      // 'init' migration script.
+      ifNotExists: true,
+    }
+  );
+};


### PR DESCRIPTION
## Overview

Adding missing columns to the `elections` table for the test deck worker task:
- `test_decks_task_id`
- `test_decks_url`

Making this a no-op for existing columns (to make sure it works on new and existing DBs), since they're included in the init script, but hadn't yet been added to staging/prod.

Output from local run:

```sh
> node-pg-migrate up

> Migrating files:
> - 1742326862308_add-test-deck-task-info
### MIGRATION 1742326862308_add-test-deck-task-info (UP) ###
ALTER TABLE "elections"
  ADD IF NOT EXISTS "test_decks_task_id" text CONSTRAINT "fk_test_decks_background_tasks" REFERENCES background_tasks(id) ON DELETE SET NULL,
  ADD IF NOT EXISTS "test_decks_url" text;
INSERT INTO "public"."pgmigrations" (name, run_on) VALUES ('1742326862308_add-test-deck-task-info', NOW());


Migrations complete!
```

## Testing Plan
- Testing locally, with and without the existing columns in place
- Verified in [staging](https://dashboard.heroku.com/apps/vxdesign-staging/activity/releases/e14e6c64-1fc8-4432-8845-419f101d6621)

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
