### PR TITLE
[VxDesign] Avoid DB migration lock race conditions in tests

### DIFF
--- a/apps/design/backend/test/test_store.ts
+++ b/apps/design/backend/test/test_store.ts
@@ -23,7 +23,7 @@ export class TestStore {
   async init(): Promise<void> {
     await this.db.withClient(async (client) => {
       await client.query(`drop schema if exists ${this.schemaName} cascade;`);
-      await client.runMigrations({ schemaName: this.schemaName });
+      await client.runMigrations({ noLock: true, schemaName: this.schemaName });
     });
   }
 


### PR DESCRIPTION
## Overview

`node-pg-migrate` implements locking on DB migrations to ensure that only one is running at a time - this is causing occasional [failures](https://app.circleci.com/pipelines/github/votingworks/vxsuite/19126/workflows/65da1096-d5b2-4589-8041-3e9effb84943/jobs/795066) in our tests, where we run multiple in parallel (but, against different schemas).

Adding an option to disable locking just for tests, since we generate a new, unique schema name for each instance of each test file - we don't have to worry about conflicting migrations in those cases.

## Testing Plan
- Reproduced the failure locally (1 out of 5 runs), tested with locking turned off and haven't run into any failures so far (8 runs) - wouldn't expect the same error as before, FWIW; just making sure we're not introducing another failure path.
- Re-running in CI a few times to be sure.
  - 4 runs with no failures, but will monitor future CI runs, in case something else comes up

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
