### PR TITLE
VxDesign: Return minimal info in listElections response

### DIFF
--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -18,7 +18,7 @@ import {
 export type { ElectionRecord } from './store';
 export type { BallotOrderInfo, BallotStyle, User } from './types';
 export type { ElectionFeaturesConfig, UserFeaturesConfig } from './features';
-export type { Api, ElectionInfo } from './app';
+export type { Api, ElectionInfo, ElectionStatus, ElectionListing } from './app';
 
 export type { BallotMode } from '@votingworks/hmpb';
 export type { BallotTemplateId } from '@votingworks/hmpb';

--- a/apps/design/backend/vitest.config.ts
+++ b/apps/design/backend/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: 89,
-        branches: 78,
+        branches: 79,
       },
       exclude: ['src/configure_sentry.ts', '**/*.test.ts'],
     },

--- a/apps/design/frontend/src/clone_election_button.test.tsx
+++ b/apps/design/frontend/src/clone_election_button.test.tsx
@@ -10,7 +10,7 @@ import {
   user,
   provideApi,
 } from '../test/api_helpers';
-import { generalElectionRecord } from '../test/fixtures';
+import { electionListing, generalElectionRecord } from '../test/fixtures';
 import { render, screen, within } from '../test/react_testing_library';
 import { CloneElectionButton } from './clone_election_button';
 import { generateId } from './utils';
@@ -55,8 +55,11 @@ afterEach(() => {
 
 test('clones immediately when ACCESS_ALL_ORGS feature disabled', async () => {
   mockUserFeatures(apiMock, user, { ACCESS_ALL_ORGS: false });
-  const { election } = generalElectionRecord(user.orgId);
-  const { history } = renderButton(<CloneElectionButton election={election} />);
+  const electionRecord = generalElectionRecord(user.orgId);
+  const { election } = electionRecord;
+  const { history } = renderButton(
+    <CloneElectionButton election={electionListing(electionRecord)} />
+  );
 
   const newElectionId = 'new-election' as ElectionId;
   mockGenerateId.mockReturnValue(newElectionId);
@@ -88,9 +91,10 @@ const NON_VX_ORG = {
 
 test('shows org picker when ACCESS_ALL_ORGS feature enabled', async () => {
   mockUserFeatures(apiMock, user, { ACCESS_ALL_ORGS: true });
-  const { election } = generalElectionRecord(user.orgId);
+  const electionRecord = generalElectionRecord(user.orgId);
+  const { election } = electionRecord;
   const { history, queryClient } = renderButton(
-    <CloneElectionButton election={election} />
+    <CloneElectionButton election={electionListing(electionRecord)} />
   );
 
   queryClient.setQueryData(api.getAllOrgs.queryKey(), [VX_ORG, NON_VX_ORG]);

--- a/apps/design/frontend/src/clone_election_button.tsx
+++ b/apps/design/frontend/src/clone_election_button.tsx
@@ -1,14 +1,14 @@
 import { assert } from '@votingworks/basics';
-import { Election } from '@votingworks/types';
 import { P, Button, Modal, ButtonVariant, Icons, Font } from '@votingworks/ui';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
+import type { ElectionListing } from '@votingworks/design-backend';
 import * as api from './api';
 import { OrgSelect } from './org_select';
 
 export interface CloneElectionButtonProps {
-  election: Election;
+  election: ElectionListing;
   variant?: ButtonVariant;
 }
 
@@ -73,7 +73,7 @@ export function CloneElectionButton(
     assert(!!orgId);
 
     mutateCloneElection(
-      { id: election.id, orgId },
+      { id: election.electionId, orgId },
       {
         onSuccess(electionId) {
           history.push(`/elections/${electionId}`);

--- a/apps/design/frontend/test/fixtures.ts
+++ b/apps/design/frontend/test/fixtures.ts
@@ -1,4 +1,8 @@
-import type { ElectionInfo, ElectionRecord } from '@votingworks/design-backend';
+import type {
+  ElectionInfo,
+  ElectionListing,
+  ElectionRecord,
+} from '@votingworks/design-backend';
 import {
   createBlankElection,
   convertVxfPrecincts,
@@ -67,6 +71,23 @@ export function electionInfoFromElection(election: Election): ElectionInfo {
     jurisdiction: election.county.name,
     seal: election.seal,
     languageCodes: [LanguageCode.ENGLISH],
+  };
+}
+
+export function electionListing(
+  electionRecord: ElectionRecord
+): ElectionListing {
+  const { election, orgId } = electionRecord;
+  return {
+    orgId,
+    orgName: `${orgId} Name`,
+    electionId: election.id,
+    title: election.title,
+    date: election.date,
+    type: election.type,
+    state: election.state,
+    jurisdiction: election.county.name,
+    status: 'inProgress',
   };
 }
 


### PR DESCRIPTION
## Overview

Don't send the entire election record to the frontend, just the fields needed. Compute the election status on the backend. This isn't strictly necessary yet, but sets up a more reasonable interface for easy refactoring/optimizing of data loading from the db later. The basic goal was just to remove all knowledge of ElectionRecord from the frontend.

## Demo Video or Screenshot
N/A

## Testing Plan
Updated existing tests
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
