### PR TITLE
fix(design): prevent crash on contest delete

### DIFF
--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -995,7 +995,13 @@ function EditContestForm(): JSX.Element | null {
   }
 
   const contests = listContestsQuery.data;
-  const savedContest = find(contests, (c) => c.id === contestId);
+  const savedContest = contests.find((c) => c.id === contestId);
+
+  if (!savedContest) {
+    // If the contest was just deleted, this form may still render momentarily. Ignore it.
+    return null;
+  }
+
   const { title } = contestRoutes.contests.editContest(contestId);
 
   return (


### PR DESCRIPTION
## Overview
Another instance of the same problem fixed by #5980.

Sentry link: https://votingworks.sentry.io/issues/6427061651/

## Demo Video or Screenshot

https://github.com/user-attachments/assets/3a97b276-cc13-48bb-a037-a02e42b8136e

## Testing Plan
Manually verified that the crash no longer occurs.