### PR TITLE
VxDesign: Fix guards preventing error on rerender after delete

### DIFF
--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -37,7 +37,7 @@ import {
   safeParse,
   YesNoContestSchema,
 } from '@votingworks/types';
-import { find, Result, throwIllegalValue } from '@votingworks/basics';
+import { Result, throwIllegalValue } from '@votingworks/basics';
 import styled from 'styled-components';
 import { Flipper, Flipped } from 'react-flip-toolkit';
 import { z } from 'zod';
@@ -506,14 +506,6 @@ function ContestForm({
   const electionInfo = getElectionInfoQuery.data;
   const districts = listDistrictsQuery.data;
   const parties = listPartiesQuery.data;
-
-  // After deleting a contest, this component may re-render briefly with no
-  // contest before redirecting to the contests list. We can just render
-  // nothing in that case.
-  /* istanbul ignore next - @preserve */
-  if (!contest) {
-    return null;
-  }
 
   function goBackToContestsList() {
     history.push(contestRoutes.root.path);
@@ -997,8 +989,10 @@ function EditContestForm(): JSX.Element | null {
   const contests = listContestsQuery.data;
   const savedContest = contests.find((c) => c.id === contestId);
 
+  // If the contest was just deleted, this form may still render momentarily.
+  // Ignore it.
+  /* istanbul ignore next - @preserve */
   if (!savedContest) {
-    // If the contest was just deleted, this form may still render momentarily. Ignore it.
     return null;
   }
 
@@ -1268,8 +1262,15 @@ function EditPartyForm(): JSX.Element | null {
   }
 
   const parties = listPartiesQuery.data;
-  const savedParty = find(parties, (p) => p.id === partyId);
+  const savedParty = parties.find((p) => p.id === partyId);
   const { title } = partyRoutes.editParty(partyId);
+
+  // If the party was just deleted, this form may still render momentarily.
+  // Ignore it.
+  /* istanbul ignore next - @preserve */
+  if (!savedParty) {
+    return null;
+  }
 
   return (
     <React.Fragment>

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -32,7 +32,7 @@ import {
   PrecinctSplit,
   SplittablePrecinct,
 } from '@votingworks/types';
-import { assert, assertDefined, find } from '@votingworks/basics';
+import { assert, assertDefined } from '@votingworks/basics';
 import styled from 'styled-components';
 import { ElectionNavScreen } from './nav_screen';
 import { ElectionIdParams, electionParamRoutes, routes } from './routes';
@@ -166,14 +166,6 @@ function DistrictForm({
     return null;
   }
   const features = getUserFeaturesQuery.data;
-
-  // After deleting a district, this component may re-render briefly with no
-  // district before redirecting to the districts list. We can just render
-  // nothing in that case.
-  /* istanbul ignore next - @preserve */
-  if (!district) {
-    return null;
-  }
 
   function goBackToDistrictsList() {
     history.push(geographyRoutes.districts.root.path);
@@ -323,8 +315,15 @@ function EditDistrictForm(): JSX.Element | null {
   }
 
   const districts = listDistrictsQuery.data;
-  const savedDistrict = find(districts, (d) => d.id === districtId);
+  const savedDistrict = districts.find((d) => d.id === districtId);
   const { title } = geographyRoutes.districts.editDistrict(districtId);
+
+  // If the district was just deleted, this form may still render momentarily.
+  // Ignore it.
+  /* istanbul ignore next - @preserve */
+  if (!savedDistrict) {
+    return null;
+  }
 
   return (
     <React.Fragment>
@@ -496,14 +495,6 @@ function PrecinctForm({
   const userFeatures = getUserFeaturesQuery.data;
   const electionFeatures = getElectionFeaturesQuery.data;
   const districts = listDistrictsQuery.data;
-
-  // After deleting a precinct, this component may re-render briefly with no
-  // precinct before redirecting to the precincts list. We can just render
-  // nothing in that case.
-  /* istanbul ignore next - @preserve */
-  if (!precinct) {
-    return null;
-  }
 
   function goBackToPrecinctsList() {
     history.push(geographyRoutes.precincts.root.path);
@@ -871,8 +862,15 @@ function EditPrecinctForm(): JSX.Element | null {
   }
 
   const precincts = listPrecinctsQuery.data;
-  const savedPrecinct = find(precincts, (p) => p.id === precinctId);
+  const savedPrecinct = precincts.find((p) => p.id === precinctId);
   const { title } = geographyRoutes.precincts.editPrecinct(precinctId);
+
+  // If the precinct was just deleted, this form may still render momentarily.
+  // Ignore it.
+  /* istanbul ignore next - @preserve */
+  if (!savedPrecinct) {
+    return null;
+  }
 
   return (
     <React.Fragment>


### PR DESCRIPTION

## Overview

Follow up to https://github.com/votingworks/vxsuite/pull/6114. A recent refactor moved the finding of each district/precinct/party/contest up into the edit form component. This meant that the guard that detected when the entity wasn't found (which can occur momentarily after deletion) was no longer reachable. This fix moves the guard next to the find.

## Demo Video or Screenshot
N/A

## Testing Plan
Manually tested and confirmed no error logs in the console

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
