### PR TITLE
Add support for a remote card certification flow

### DIFF
--- a/libs/auth/README.md
+++ b/libs/auth/README.md
@@ -74,6 +74,35 @@ script can be used to unprogram a card. This can come in handy if you ever need
 to unprogram a system administrator card, the one type of card that can't be
 unprogrammed through VxAdmin.
 
+#### Remote Flow
+
+If you don't have access to the relevant VotingWorks private key, you can
+specify `VX_PRIVATE_KEY_PATH=remote` to complete card configuration via a file
+exchange with someone who does have that key:
+
+```
+NODE_ENV=production \
+    VX_PRIVATE_KEY_PATH=remote \
+    WORKING_DIRECTORY=/path/to/working-directory \
+    ./scripts/configure-java-card
+```
+
+The working directory indicates where to store the files for the file exchange.
+If unspecified, the script will default to your home directory.
+
+If you are the person with the relevant VotingWorks private key, receiving a
+card public key from someone using the remote flow, you can use the following
+command:
+
+```
+CERT_PUBLIC_KEY_PATH=/path/to/public-key-abcd1234.pem \
+    VX_PRIVATE_KEY_PATH=/path/to/vx-private-key.pem \
+    ./scripts/remote-card-vx-certifier
+```
+
+The console outputs of the above commands make it clear what files need to be
+shared.
+
 #### OpenFIPS201 Applet Updating Script
 
 This script builds the latest main of

--- a/libs/auth/scripts/remote-card-vx-certifier
+++ b/libs/auth/scripts/remote-card-vx-certifier
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+require('esbuild-runner').install({
+  type: 'transform',
+});
+require('./src/remote_card_vx_certifier').main();

--- a/libs/auth/scripts/src/configure_java_card.ts
+++ b/libs/auth/scripts/src/configure_java_card.ts
@@ -1,5 +1,7 @@
 import { Buffer } from 'node:buffer';
+import crypto from 'node:crypto';
 import { existsSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { extractErrorMessage, lines } from '@votingworks/basics';
 import { Byte } from '@votingworks/types';
@@ -93,11 +95,13 @@ function checkForScriptDependencies(): void {
 
 interface ScriptEnvVars {
   javaCardConfig: JavaCardConfig;
+  workingDirectory?: string;
 }
 
 function readScriptEnvVars(): ScriptEnvVars {
   return {
     javaCardConfig: constructJavaCardConfigForVxProgramming(), // Uses env vars
+    workingDirectory: process.env['WORKING_DIRECTORY'],
   };
 }
 
@@ -272,12 +276,16 @@ async function runAppletConfigurationCommands(): Promise<void> {
 
 async function createAndStoreCardVxCert({
   javaCardConfig,
+  workingDirectory = os.homedir(),
 }: ScriptEnvVars): Promise<void> {
   sectionLog('🔏', 'Creating and storing card VotingWorks cert...');
 
   const card = new JavaCard(javaCardConfig);
   await waitForReadyCardStatus(card);
-  await card.createAndStoreCardVxCert();
+  await card.createAndStoreCardVxCert({
+    randomId: crypto.randomBytes(3).toString('hex'),
+    workingDirectory,
+  });
 }
 
 /**

--- a/libs/auth/scripts/src/remote_card_vx_certifier.ts
+++ b/libs/auth/scripts/src/remote_card_vx_certifier.ts
@@ -1,0 +1,57 @@
+import fs from 'node:fs/promises';
+import { extractErrorMessage } from '@votingworks/basics';
+
+import {
+  CERT_EXPIRY_IN_DAYS,
+  constructCardCertSubjectWithoutJurisdictionAndCardType,
+} from '../../src/certs';
+import { PROD_VX_CERT_AUTHORITY_CERT_PATH } from '../../src/config';
+import { createCert } from '../../src/cryptography';
+import { getRequiredEnvVar } from '../../src/env_vars';
+
+interface ScriptEnvVars {
+  certPublicKeyPath: string;
+  vxPrivateKeyPath: string;
+}
+
+function readScriptEnvVars(): ScriptEnvVars {
+  const certPublicKeyPath = getRequiredEnvVar('CERT_PUBLIC_KEY_PATH');
+  const vxPrivateKeyPath = getRequiredEnvVar('VX_PRIVATE_KEY_PATH');
+  return { certPublicKeyPath, vxPrivateKeyPath };
+}
+
+async function remoteCardVxCertifier({
+  certPublicKeyPath,
+  vxPrivateKeyPath,
+}: ScriptEnvVars): Promise<void> {
+  const certPublicKey = await fs.readFile(certPublicKeyPath, 'utf-8');
+  const cert = await createCert({
+    certKeyInput: {
+      type: 'public',
+      key: { source: 'inline', content: certPublicKey },
+    },
+    certSubject: constructCardCertSubjectWithoutJurisdictionAndCardType(),
+    expiryInDays: CERT_EXPIRY_IN_DAYS.CARD_VX_CERT,
+    signingCertAuthorityCertPath: PROD_VX_CERT_AUTHORITY_CERT_PATH,
+    signingPrivateKey: { source: 'file', path: vxPrivateKeyPath },
+  });
+  const certPath = certPublicKeyPath.replace('public-key-', 'cert-');
+  await fs.writeFile(certPath, cert);
+  console.log(
+    `✅ Cert written to ${certPath} and can be shared with the sender of the public key`
+  );
+}
+
+/**
+ * A script for creating a card VotingWorks-issued cert given a card public key. Pairs with
+ * the configure-java-card script when that script is run with VX_PRIVATE_KEY_PATH=remote
+ */
+export async function main(): Promise<void> {
+  try {
+    const scriptEnvVars = readScriptEnvVars();
+    await remoteCardVxCertifier(scriptEnvVars);
+  } catch (error) {
+    console.error(`❌ ${extractErrorMessage(error)}`);
+    process.exit(1);
+  }
+}

--- a/libs/auth/src/config.test.ts
+++ b/libs/auth/src/config.test.ts
@@ -202,6 +202,21 @@ test.each<{
       ),
     },
   },
+  {
+    nodeEnv: 'production',
+    vxPrivateKeyPath: 'remote',
+    expectedOutput: {
+      cardProgrammingConfig: {
+        configType: 'vx',
+        vxPrivateKey: {
+          source: 'remote',
+        },
+      },
+      vxCertAuthorityCertPath: expect.stringContaining(
+        '/certs/prod/vx-cert-authority-cert.pem'
+      ),
+    },
+  },
 ])(
   'constructJavaCardConfigForVxProgramming - nodeEnv = $nodeEnv, vxPrivateKeyPath = $vxPrivateKeyPath',
   ({ nodeEnv, vxPrivateKeyPath, expectedOutput }) => {

--- a/libs/auth/src/config.ts
+++ b/libs/auth/src/config.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { isIntegrationTest, isVxDev } from '@votingworks/utils';
 
 import { getRequiredEnvVar, isNodeEnvProduction } from './env_vars';
-import { FileKey, TpmKey } from './keys';
+import { FileKey, RemoteKey, TpmKey } from './keys';
 
 /**
  * The path to the dev root cert
@@ -68,7 +68,7 @@ interface VxAdminCardProgrammingConfig {
 
 interface VxCardProgrammingConfig {
   configType: 'vx';
-  vxPrivateKey: FileKey;
+  vxPrivateKey: FileKey | RemoteKey;
 }
 
 /**
@@ -122,7 +122,10 @@ export function constructJavaCardConfigForVxProgramming(): JavaCardConfig {
   return {
     cardProgrammingConfig: {
       configType: 'vx',
-      vxPrivateKey: { source: 'file', path: vxPrivateKeyPath },
+      vxPrivateKey:
+        vxPrivateKeyPath === 'remote'
+          ? { source: 'remote' }
+          : { source: 'file', path: vxPrivateKeyPath },
     },
     vxCertAuthorityCertPath: getVxCertAuthorityCertPath(),
   };

--- a/libs/auth/src/config.ts
+++ b/libs/auth/src/config.ts
@@ -179,7 +179,7 @@ export interface SignedQuickResultsReportingConfig {
 }
 
 /**
- * Constructs a signed quick results config given relevant env vars
+ * Constructs a signed quick results reporting config given relevant env vars
  */
 export function constructSignedQuickResultsReportingConfig(): SignedQuickResultsReportingConfig {
   const { privateKey } = getMachineCertPathAndPrivateKey();

--- a/libs/auth/src/index.ts
+++ b/libs/auth/src/index.ts
@@ -13,5 +13,5 @@ export * from './java_card';
 export * from './jurisdictions';
 export * from './mock_file_card';
 export * from './signed_hash_validation';
+export * from './signed_quick_results_reporting';
 export * from './test_utils';
-export * from './signed_quick_results_signed_url';

--- a/libs/auth/src/keys.ts
+++ b/libs/auth/src/keys.ts
@@ -19,6 +19,13 @@ export interface InlineKey {
 }
 
 /**
+ * An SSL key in someone else's possession
+ */
+export interface RemoteKey {
+  source: 'remote';
+}
+
+/**
  * An SSL key stored in a TPM
  */
 export interface TpmKey {
@@ -39,6 +46,13 @@ export const FileKeySchema: z.ZodSchema<FileKey> = z.object({
 export const InlineKeySchema: z.ZodSchema<InlineKey> = z.object({
   source: z.literal('inline'),
   content: z.string(),
+});
+
+/**
+ * A Zod schema for RemoteKey
+ */
+export const RemoteKeySchema: z.ZodSchema<RemoteKey> = z.object({
+  source: z.literal('remote'),
 });
 
 /**


### PR DESCRIPTION
## Overview

A little side project to take a task off my plate haha

We have a remote machine certification flow that we've used quite extensively to certify machines that are in the possession of someone who doesn't have acccess to the root VotingWorks private key. We don't yet have an analogous flow for card certification. This PR adds support for that and will make it such that others aren't blocked on the few of us with possession to the latest key when they need smart cards compatible with v4.0.1+ software images. Right now, we've been getting by by certifying and shipping cards around the country, which works but isn't great in a pinch.

## Demo Video or Screenshot

Person without access to the root VotingWorks private key:

```
NODE_ENV=production VX_PRIVATE_KEY_PATH=remote WORKING_DIRECTORY=/media/psf/Shared ./scripts/configure-java-card

[ Skipping irrelevant output lines ]

------------------------------------------------
🔏 Creating and storing card VotingWorks cert...
------------------------------------------------
A card-specific public key has been written to /media/psf/Shared/public-key-26337f.pem.
Share this file with someone who has the appropriate signing key.
They will return to you a cert-26337f.pem file.
Place that file in /media/psf/Shared and press enter. 
No /media/psf/Shared/cert-26337f.pem file found. Make sure that it exists and press enter to try again. 
--------
✅ Done!
--------
```

Person with access to the root votingWorks:

```
$ CERT_PUBLIC_KEY_PATH=/media/psf/Shared/public-key-26337f.pem VX_PRIVATE_KEY_PATH=/path/to/private-key.pem ./scripts/remote-card-vx-certifier 
Enter pass phrase for /path/to/private-key.pem:
✅ Cert written to /media/psf/Shared/cert-26337f.pem and can be shared with the sender of the public key
```

## Testing Plan

- [x] Added automated tests
- [x] Tested manually

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A