### PR TITLE
Fix bug with multi-language CDF imports to VxSuite

### DIFF
--- a/libs/types/src/cdf/ballot-definition/convert.ts
+++ b/libs/types/src/cdf/ballot-definition/convert.ts
@@ -1076,25 +1076,17 @@ export function convertCdfBallotDefinitionToVxfElection(
 
       // Check if this is a VxDesign formatted Id_LanguageCode Ballot Id.
       // If so extract the group ID from the first part of the Id.
-      if (
+      const useExtractedGroupId =
         ballotStyle.Language &&
         ballotStyle.Language.length === 1 &&
         idParts.length === 2 &&
-        idParts[1] === ballotStyle.Language[0]
-      ) {
-        return {
-          id: ballotStyleId as Vxf.BallotStyleId,
-          groupId: idParts[0] as Vxf.BallotStyleGroupId,
-          districts: districtIds,
-          precincts: precinctIds,
-          partyId: ballotStyle.PartyIds?.[0] as Vxf.PartyId | undefined,
-          languages: ballotStyle.Language,
-        };
-      }
+        idParts[1] === ballotStyle.Language[0];
 
       return {
         id: ballotStyleId as Vxf.BallotStyleId,
-        groupId: ballotStyleId as Vxf.BallotStyleGroupId,
+        groupId: (useExtractedGroupId
+          ? idParts[0]
+          : ballotStyleId) as Vxf.BallotStyleGroupId,
         districts: districtIds,
         precincts: precinctIds,
         partyId: ballotStyle.PartyIds?.[0] as Vxf.PartyId | undefined,

--- a/libs/types/src/cdf/ballot-definition/convert.ts
+++ b/libs/types/src/cdf/ballot-definition/convert.ts
@@ -1070,10 +1070,31 @@ export function convertCdfBallotDefinitionToVxfElection(
       // context).
       assert(ballotStyle.ExternalIdentifier.length === 1);
 
+      const ballotStyleId = ballotStyle.ExternalIdentifier[0].Value;
+
+      const idParts = ballotStyleId.split('_');
+
+      // Check if this is a VxDesign formatted Id_LanguageCode Ballot Id.
+      // If so extract the group ID from the first part of the Id.
+      if (
+        ballotStyle.Language &&
+        ballotStyle.Language.length === 1 &&
+        idParts.length === 2 &&
+        idParts[1] === ballotStyle.Language[0]
+      ) {
+        return {
+          id: ballotStyleId as Vxf.BallotStyleId,
+          groupId: idParts[0] as Vxf.BallotStyleGroupId,
+          districts: districtIds,
+          precincts: precinctIds,
+          partyId: ballotStyle.PartyIds?.[0] as Vxf.PartyId | undefined,
+          languages: ballotStyle.Language,
+        };
+      }
+
       return {
-        id: ballotStyle.ExternalIdentifier[0].Value as Vxf.BallotStyleId,
-        groupId: ballotStyle.ExternalIdentifier[0]
-          .Value as Vxf.BallotStyleGroupId, // All ballot styles can be in their own group from CDF
+        id: ballotStyleId as Vxf.BallotStyleId,
+        groupId: ballotStyleId as Vxf.BallotStyleGroupId,
         districts: districtIds,
         precincts: precinctIds,
         partyId: ballotStyle.PartyIds?.[0] as Vxf.PartyId | undefined,

--- a/libs/types/src/cdf/ballot-definition/fixtures.ts
+++ b/libs/types/src/cdf/ballot-definition/fixtures.ts
@@ -134,11 +134,18 @@ export const testVxfElection: Election = {
       languages: ['en'],
     },
     {
-      id: '3_en_es-US' as BallotStyleId,
+      id: '3_en' as BallotStyleId,
       groupId: '3' as BallotStyleGroupId,
       precincts: ['precinct-2'],
       districts: ['district-1' as DistrictId, 'district-2' as DistrictId],
-      languages: ['en', 'es-US'],
+      languages: ['en'],
+    },
+    {
+      id: '3_es-US' as BallotStyleId,
+      groupId: '3' as BallotStyleGroupId,
+      precincts: ['precinct-2'],
+      districts: ['district-1' as DistrictId, 'district-2' as DistrictId],
+      languages: ['es-US'],
     },
   ],
   ballotLayout: {
@@ -229,7 +236,78 @@ export const testVxfElection: Election = {
       ],
     },
     {
-      ballotStyleId: '3_en_es-US' as BallotStyleId,
+      ballotStyleId: '3_en' as BallotStyleId,
+      optionBoundsFromTargetMark: {
+        bottom: 1,
+        left: 1,
+        right: 9,
+        top: 1,
+      },
+      gridPositions: [
+        {
+          type: 'option',
+          sheetNumber: 1,
+          side: 'front',
+          contestId: 'contest-1',
+          column: 2,
+          row: 12,
+          optionId: 'candidate-1',
+        },
+        {
+          type: 'option',
+          sheetNumber: 1,
+          side: 'front',
+          contestId: 'contest-1',
+          column: 2,
+          row: 14,
+          optionId: 'candidate-2',
+        },
+        {
+          type: 'write-in',
+          sheetNumber: 1,
+          side: 'front',
+          contestId: 'contest-1',
+          column: 2,
+          row: 16,
+          writeInIndex: 0,
+          writeInArea: {
+            x: 2.5,
+            y: 15,
+            width: 3,
+            height: 1,
+          },
+        },
+        {
+          type: 'option',
+          sheetNumber: 1,
+          side: 'front',
+          contestId: 'contest-2',
+          column: 2,
+          row: 21,
+          optionId: 'contest-2-option-yes',
+        },
+        {
+          type: 'option',
+          sheetNumber: 1,
+          side: 'front',
+          contestId: 'contest-2',
+          column: 2,
+          row: 22,
+          optionId: 'contest-2-option-no',
+        },
+        {
+          type: 'option',
+          sheetNumber: 1,
+          side: 'front',
+          contestId: 'contest-3',
+          column: 12,
+          row: 12,
+          optionId: 'candidate-3',
+        },
+      ],
+    },
+    {
+      ballotStyleId: '3_es-US' as BallotStyleId,
       optionBoundsFromTargetMark: {
         bottom: 1,
         left: 1,
@@ -306,7 +384,8 @@ export const testVxfElection: Election = {
       ballotStyleId: {
         '1_en': '1_en',
         '2_en': '2_en',
-        '3_en_es-US': '3_en_es-US',
+        '3_en': '3_en',
+        '3_es-US': '3_es-US',
       },
       candidateName: {
         'candidate-1': 'Sherlock Holmes',
@@ -891,10 +970,167 @@ export const testCdfBallotDefinition: BallotDefinition = {
             {
               '@type': 'BallotDefinition.ExternalIdentifier',
               Type: IdentifierType.StateLevel,
-              Value: '3_en_es-US',
+              Value: '3_en',
             },
           ],
-          Language: ['en', 'es-US'],
+          Language: ['en'],
+        },
+        {
+          '@type': 'BallotDefinition.BallotStyle',
+          GpUnitIds: ['precinct-2'],
+          OrderedContent: [
+            {
+              '@type': 'BallotDefinition.OrderedContest',
+              ContestId: 'contest-1',
+              Physical: [
+                {
+                  '@type': 'BallotDefinition.PhysicalContest',
+                  BallotFormatId: 'ballot-format',
+                  PhysicalContestOption: [
+                    {
+                      '@type': 'BallotDefinition.PhysicalContestOption',
+                      ContestOptionId: 'contest-1-option-candidate-1',
+                      OptionPosition: [
+                        {
+                          '@type': 'BallotDefinition.OptionPosition',
+                          Sheet: 1,
+                          Side: BallotSideType.Front,
+                          X: 2,
+                          Y: 12,
+                          H: 0,
+                          W: 0,
+                          NumberVotes: 1,
+                        },
+                      ],
+                    },
+                    {
+                      '@type': 'BallotDefinition.PhysicalContestOption',
+                      ContestOptionId: 'contest-1-option-candidate-2',
+                      OptionPosition: [
+                        {
+                          '@type': 'BallotDefinition.OptionPosition',
+                          Sheet: 1,
+                          Side: BallotSideType.Front,
+                          X: 2,
+                          Y: 14,
+                          H: 0,
+                          W: 0,
+                          NumberVotes: 1,
+                        },
+                      ],
+                    },
+                    {
+                      '@type': 'BallotDefinition.PhysicalContestOption',
+                      ContestOptionId: 'contest-1-option-write-in-0',
+                      OptionPosition: [
+                        {
+                          '@type': 'BallotDefinition.OptionPosition',
+                          Sheet: 1,
+                          Side: BallotSideType.Front,
+                          X: 2,
+                          Y: 16,
+                          H: 0,
+                          W: 0,
+                          NumberVotes: 1,
+                        },
+                      ],
+                      WriteInPosition: [
+                        {
+                          '@type': 'BallotDefinition.WriteInPosition',
+                          Sheet: 1,
+                          Side: BallotSideType.Front,
+                          H: 1,
+                          W: 3,
+                          X: 2.5,
+                          Y: 15,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              '@type': 'BallotDefinition.OrderedContest',
+              ContestId: 'contest-2',
+              Physical: [
+                {
+                  '@type': 'BallotDefinition.PhysicalContest',
+                  BallotFormatId: 'ballot-format',
+                  PhysicalContestOption: [
+                    {
+                      '@type': 'BallotDefinition.PhysicalContestOption',
+                      ContestOptionId: 'contest-2-option-yes',
+                      OptionPosition: [
+                        {
+                          '@type': 'BallotDefinition.OptionPosition',
+                          Sheet: 1,
+                          Side: BallotSideType.Front,
+                          X: 2,
+                          Y: 21,
+                          H: 0,
+                          W: 0,
+                          NumberVotes: 1,
+                        },
+                      ],
+                    },
+                    {
+                      '@type': 'BallotDefinition.PhysicalContestOption',
+                      ContestOptionId: 'contest-2-option-no',
+                      OptionPosition: [
+                        {
+                          '@type': 'BallotDefinition.OptionPosition',
+                          Sheet: 1,
+                          Side: BallotSideType.Front,
+                          X: 2,
+                          Y: 22,
+                          H: 0,
+                          W: 0,
+                          NumberVotes: 1,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              '@type': 'BallotDefinition.OrderedContest',
+              ContestId: 'contest-3',
+              Physical: [
+                {
+                  '@type': 'BallotDefinition.PhysicalContest',
+                  BallotFormatId: 'ballot-format',
+                  PhysicalContestOption: [
+                    {
+                      '@type': 'BallotDefinition.PhysicalContestOption',
+                      ContestOptionId: 'contest-3-option-candidate-3',
+                      OptionPosition: [
+                        {
+                          '@type': 'BallotDefinition.OptionPosition',
+                          Sheet: 1,
+                          Side: BallotSideType.Front,
+                          X: 12,
+                          Y: 12,
+                          H: 0,
+                          W: 0,
+                          NumberVotes: 1,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          ExternalIdentifier: [
+            {
+              '@type': 'BallotDefinition.ExternalIdentifier',
+              Type: IdentifierType.StateLevel,
+              Value: '3_es-US',
+            },
+          ],
+          Language: ['es-US'],
         },
       ],
     },

--- a/libs/types/test/cdf_conversion_helpers.ts
+++ b/libs/types/test/cdf_conversion_helpers.ts
@@ -1,5 +1,5 @@
 import { mapObject } from '@votingworks/basics';
-import { BallotStyleGroupId, Election } from '../src/election';
+import { Election } from '../src/election';
 import { ElectionStringKey } from '../src/ui_string_translations';
 
 export function normalizeVxfAfterCdfConversion(
@@ -11,11 +11,6 @@ export function normalizeVxfAfterCdfConversion(
     parties: vxfElection.parties.map((party) => ({
       ...party,
       name: party.fullName,
-    })),
-    // CDF only has one field for ballot style id so the group id is always the ballot style id
-    ballotStyles: vxfElection.ballotStyles.map((bs) => ({
-      ...bs,
-      groupId: bs.id as unknown as BallotStyleGroupId,
     })),
     ballotStrings: mapObject(vxfElection.ballotStrings, (strings) => ({
       ...strings,

--- a/libs/types/test/election.ts
+++ b/libs/types/test/election.ts
@@ -127,7 +127,7 @@ export const primaryElection: Election = {
     ...election.ballotStyles.map((bs) => ({
       ...bs,
       id: `${bs.id}R`,
-      groupId: `${bs.id}D`,
+      groupId: `${bs.id}R`,
       partyId: republicanPartyId,
     })),
   ] as BallotStyle[],


### PR DESCRIPTION
## Overview
When an election is exported in VxDesign in CDF format and is multi-language the IDs are created in the style: `{ballotStyleGroupID}_{languageCode}`. If we detect ballots in this format from VxDesign we should parse out the group ID from it so that ballots that are intended to be the same but different language varients of one another are handled properly. In order to use a multi-language election in CDF format as intended in the VxSuite system the ExternalIdentifiers must be specified in this format. 
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
N/A 

## Testing Plan
Loaded a multi-language CDF election into VxAdmin, configured VxMark and VxScan and scanned hmpbs and verified language selector worked as expected. 

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
