### PR TITLE
VxDesign: Migrate duplicate IDs in election content

### DIFF
--- a/apps/design/backend/migrations/1742941957696_regenerate-duplicate-ids.js
+++ b/apps/design/backend/migrations/1742941957696_regenerate-duplicate-ids.js
@@ -1,0 +1,95 @@
+/* eslint-disable vx/gts-object-literal-types */
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { hasSplits } = require('@votingworks/types');
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+const { regenerateElectionIds } = require('../build/utils.js');
+
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void>}
+ */
+exports.up = async (pgm) => {
+  const allElections = await pgm.db.select({
+    text: 'SELECT id, election_data, precinct_data FROM elections',
+  });
+  const seenIds = new Set();
+
+  /**
+   * @param {{ id: string; election: import('@votingworks/types').Election; precincts: import('@votingworks/types').SplittablePrecinct[]; }} electionRecord
+   */
+  function allIds(electionRecord) {
+    const { election, precincts } = electionRecord;
+    return [
+      ...election.districts.map((d) => d.id),
+      ...precincts.flatMap((p) => [
+        p.id,
+        ...(hasSplits(p)
+          ? p.splits.flatMap((s) => [s.id, s.districtIds])
+          : p.districtIds),
+      ]),
+      ...election.parties.map((p) => p.id),
+      ...election.contests.flatMap((c) => [
+        c.id,
+        ...(c.type === 'candidate' && c.partyId ? [c.partyId] : []),
+        ...(c.type === 'candidate'
+          ? c.candidates.flatMap((cand) => [cand.id, ...(cand.partyIds ?? [])])
+          : [c.yesOption.id, c.noOption.id]),
+      ]),
+    ];
+  }
+
+  for (const electionRow of allElections) {
+    // eslint-disable-next-line camelcase
+    const { id: electionId, election_data, precinct_data } = electionRow;
+    const election = JSON.parse(election_data);
+    const precincts = JSON.parse(precinct_data);
+    const electionRecord = { id: electionId, election, precincts };
+
+    const electionIds = allIds(electionRecord);
+    const shouldRegenerateIds = electionIds.some((id) => seenIds.has(id));
+    for (const id of electionIds) {
+      seenIds.add(id);
+    }
+    if (!shouldRegenerateIds) {
+      continue;
+    }
+
+    const {
+      districts,
+      precincts: updatedPrecincts,
+      parties,
+      contests,
+    } = regenerateElectionIds(election, precincts);
+    const updatedElection = {
+      ...election,
+      districts,
+      parties,
+      precincts: updatedPrecincts.map((p) => ({
+        id: p.id,
+        name: p.name,
+      })),
+      contests,
+    };
+    pgm.sql(
+      `
+      UPDATE elections
+      SET election_data = '${JSON.stringify(updatedElection).replaceAll(
+        "'",
+        "''"
+      )}',
+          precinct_data = '${JSON.stringify(updatedPrecincts).replaceAll(
+            "'",
+            "''"
+          )}'
+      WHERE id = '${electionId}'
+      `
+    );
+  }
+};


### PR DESCRIPTION
## Overview

<!-- add a link to a GitHub Issue here -->
Detects elections with duplicate IDs (for districts/precincts/parties/contests) and regenerates their IDs. This migration can probably be removed once it's been run, since we now have a change in place to prevent duplicate IDs from being saved in the first place.

## Demo Video or Screenshot
N/A

## Testing Plan
Ran on a db snapshot and then ran the migration from #6117 to confirm that there are no more unique index errors for any of the election content.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
