### PR TITLE
feat(scan): add basic view of latest hardware testing scanned image

### DIFF
--- a/apps/scan/backend/src/electrical_testing/app.ts
+++ b/apps/scan/backend/src/electrical_testing/app.ts
@@ -1,5 +1,5 @@
 import { createSystemCallApi } from '@votingworks/backend';
-import { iter, Optional } from '@votingworks/basics';
+import { iter } from '@votingworks/basics';
 import * as grout from '@votingworks/grout';
 import { SheetOf } from '@votingworks/types';
 import express, { Application } from 'express';
@@ -124,7 +124,7 @@ function buildApi({
       }
 
       const id = latestElectricalTestingImageName.replace(
-        /-(front|back)\.(jpe?g|png)/,
+        /-(front|back)\.(jpe?g|png)$/,
         ''
       );
       const frontAndBackNames = allScannedImageNames.filter((name) =>

--- a/apps/scan/backend/src/electrical_testing/app.ts
+++ b/apps/scan/backend/src/electrical_testing/app.ts
@@ -3,8 +3,7 @@ import { iter } from '@votingworks/basics';
 import * as grout from '@votingworks/grout';
 import { SheetOf } from '@votingworks/types';
 import express, { Application } from 'express';
-import { readdir, stat } from 'node:fs/promises';
-import { join } from 'node:path';
+import { readdir } from 'node:fs/promises';
 import { getMachineConfig } from '../machine_config';
 import { ElectricalTestingComponent } from '../store';
 import { type ServerContext } from './context';
@@ -111,13 +110,9 @@ function buildApi({
 
     async getLatestScannedSheet(): Promise<SheetOf<string> | null> {
       const allScannedImageNames = await readdir(workspace.ballotImagesPath);
-      const latestElectricalTestingImageName = await iter(allScannedImageNames)
-        .async()
+      const latestElectricalTestingImageName = iter(allScannedImageNames)
         .filter((name) => name.startsWith('electrical-testing-'))
-        .maxBy(
-          async (name) =>
-            (await stat(join(workspace.ballotImagesPath, name))).mtimeMs
-        );
+        .max((a, b) => a.localeCompare(b));
 
       if (!latestElectricalTestingImageName) {
         return null;

--- a/apps/scan/backend/src/electrical_testing/app.ts
+++ b/apps/scan/backend/src/electrical_testing/app.ts
@@ -1,6 +1,10 @@
 import { createSystemCallApi } from '@votingworks/backend';
+import { iter, Optional } from '@votingworks/basics';
 import * as grout from '@votingworks/grout';
+import { SheetOf } from '@votingworks/types';
 import express, { Application } from 'express';
+import { readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
 import { getMachineConfig } from '../machine_config';
 import { ElectricalTestingComponent } from '../store';
 import { type ServerContext } from './context';
@@ -105,6 +109,41 @@ function buildApi({
       }
     },
 
+    async getLatestScannedSheet(): Promise<SheetOf<string> | null> {
+      const allScannedImageNames = await readdir(workspace.ballotImagesPath);
+      const latestElectricalTestingImageName = await iter(allScannedImageNames)
+        .async()
+        .filter((name) => name.startsWith('electrical-testing-'))
+        .maxBy(
+          async (name) =>
+            (await stat(join(workspace.ballotImagesPath, name))).mtimeMs
+        );
+
+      if (!latestElectricalTestingImageName) {
+        return null;
+      }
+
+      const id = latestElectricalTestingImageName.replace(
+        /-(front|back)\.(jpe?g|png)/,
+        ''
+      );
+      const frontAndBackNames = allScannedImageNames.filter((name) =>
+        name.startsWith(id)
+      );
+      if (frontAndBackNames.length !== 2) {
+        return null;
+      }
+
+      const frontName = frontAndBackNames.find((name) => /-front\./.test(name));
+      const backName = frontAndBackNames.find((name) => /-back\./.test(name));
+
+      if (!frontName || !backName) {
+        return null;
+      }
+
+      return [`/api/images/${frontName}`, `/api/images/${backName}`];
+    },
+
     ...createSystemCallApi({
       usbDrive,
       logger,
@@ -119,6 +158,7 @@ export type ElectricalTestingApi = ReturnType<typeof buildApi>;
 export function buildApp(context: ServerContext): Application {
   const app: Application = express();
   const api = buildApi(context);
+  app.use('/api/images', express.static(context.workspace.ballotImagesPath));
   app.use('/api', grout.buildRouter(api, express));
   return app;
 }

--- a/apps/scan/frontend/src/electrical_testing/api.ts
+++ b/apps/scan/frontend/src/electrical_testing/api.ts
@@ -134,3 +134,15 @@ export const setUsbDriveLoopRunning = {
 } as const;
 
 export const systemCallApi = createSystemCallApi(useApiClient);
+
+export const getLatestScannedSheet = {
+  queryKey(): QueryKey {
+    return ['getLatestScannedSheet'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(getLatestScannedSheet.queryKey(), () =>
+      apiClient.getLatestScannedSheet()
+    );
+  },
+} as const;

--- a/apps/scan/frontend/src/electrical_testing/api.ts
+++ b/apps/scan/frontend/src/electrical_testing/api.ts
@@ -141,8 +141,10 @@ export const getLatestScannedSheet = {
   },
   useQuery() {
     const apiClient = useApiClient();
-    return useQuery(getLatestScannedSheet.queryKey(), () =>
-      apiClient.getLatestScannedSheet()
+    return useQuery(
+      getLatestScannedSheet.queryKey(),
+      () => apiClient.getLatestScannedSheet(),
+      { refetchInterval: 1000 }
     );
   },
 } as const;

--- a/apps/scan/frontend/src/electrical_testing/electrical_testing_screen.tsx
+++ b/apps/scan/frontend/src/electrical_testing/electrical_testing_screen.tsx
@@ -15,6 +15,7 @@ import { useInterval } from 'use-interval';
 import { useSound } from '../utils/use_sound';
 import {
   getElectricalTestingStatuses,
+  getLatestScannedSheet,
   getTestTaskStatuses,
   setCardReaderLoopRunning,
   setPrinterLoopRunning,
@@ -22,6 +23,7 @@ import {
   setUsbDriveLoopRunning,
   systemCallApi,
 } from './api';
+import { SheetImagesModal } from './sheet_images_modal';
 
 type ElectricalTestingComponent = keyof ReturnType<
   ElectricalTestingApi['getElectricalTestingStatuses']
@@ -129,6 +131,7 @@ function StatusCard({
         width: '600px',
         height: '235px',
         overflow: 'hidden',
+        position: 'relative',
       }}
     >
       <Row style={{ height: '100%', alignItems: 'stretch' }}>
@@ -175,6 +178,8 @@ export function ElectricalTestingScreen(): JSX.Element {
   const setUsbDriveLoopRunningMutation = setUsbDriveLoopRunning.useMutation();
   const setPrinterLoopRunningMutation = setPrinterLoopRunning.useMutation();
   const setScannerLoopRunningMutation = setScannerLoopRunning.useMutation();
+  const getLatestScannedSheetQuery = getLatestScannedSheet.useQuery();
+  const [isShowingLatestSheet, setIsShowingLatestSheet] = useState(false);
 
   const [isSoundEnabled, setIsSoundEnabled] = useState(true);
   const playSound = useSound('success');
@@ -269,7 +274,35 @@ export function ElectricalTestingScreen(): JSX.Element {
                     <Icons.File /> Scanner
                   </React.Fragment>
                 }
-                statusMessage={scannerStatus?.statusMessage ?? 'Unknown'}
+                body={
+                  <React.Fragment>
+                    <Caption
+                      style={{
+                        flexGrow: 1,
+                        overflowWrap: 'anywhere',
+                        maxHeight: '2rem',
+                        overflow: 'hidden',
+                      }}
+                    >
+                      <Small>{scannerStatus?.statusMessage ?? 'Unknown'}</Small>
+                    </Caption>
+                    {getLatestScannedSheetQuery.data && (
+                      <Button
+                        onPress={() => {
+                          setIsShowingLatestSheet(true);
+                        }}
+                        style={{
+                          position: 'absolute',
+                          right: '0',
+                          bottom: '0',
+                          transform: 'scale(0.3) translate(100%, 100%)',
+                        }}
+                      >
+                        View Latest Sheet
+                      </Button>
+                    )}
+                  </React.Fragment>
+                }
                 updatedAt={scannerStatus?.updatedAt}
                 taskStatus={scannerStatus?.taskStatus}
                 onToggleRunning={toggleScannerTaskRunning}
@@ -347,6 +380,12 @@ export function ElectricalTestingScreen(): JSX.Element {
             </SmallButton>
           </Row>
         </Column>
+        {isShowingLatestSheet && getLatestScannedSheetQuery.data && (
+          <SheetImagesModal
+            paths={getLatestScannedSheetQuery.data}
+            onClose={() => setIsShowingLatestSheet(false)}
+          />
+        )}
       </Main>
     </Screen>
   );

--- a/apps/scan/frontend/src/electrical_testing/sheet_images_modal.test.tsx
+++ b/apps/scan/frontend/src/electrical_testing/sheet_images_modal.test.tsx
@@ -1,0 +1,61 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import userEvent from '@testing-library/user-event';
+import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
+import type { ElectricalTestingApi } from '@votingworks/scan-backend';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { render as renderBase, screen } from '../../test/react_testing_library';
+import { ApiClientContext } from './api';
+import { SheetImagesModal } from './sheet_images_modal';
+
+let queryClient: QueryClient;
+let mockClient: MockClient<ElectricalTestingApi>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queryClient = new QueryClient();
+  mockClient = createMockClient<ElectricalTestingApi>();
+});
+
+afterEach(() => {
+  mockClient.assertComplete();
+});
+
+function render(element: React.ReactElement) {
+  renderBase(
+    <QueryClientProvider client={queryClient}>
+      <ApiClientContext.Provider value={mockClient}>
+        {element}
+      </ApiClientContext.Provider>
+    </QueryClientProvider>
+  );
+}
+
+test('closes on click', async () => {
+  const onClose = vi.fn();
+
+  render(
+    <SheetImagesModal
+      paths={['/api/images/front.jpeg', '/api/images/back.jpeg']}
+      onClose={onClose}
+    />
+  );
+
+  await screen.findByRole('alertdialog');
+  const presentation = await screen.findByRole('presentation');
+  userEvent.click(presentation);
+  await vi.waitFor(() => expect(onClose).toHaveBeenCalled());
+});
+
+test('shows an image for each page', async () => {
+  const onClose = vi.fn();
+
+  render(
+    <SheetImagesModal
+      paths={['/api/images/front.jpeg', '/api/images/back.jpeg']}
+      onClose={onClose}
+    />
+  );
+
+  await screen.findByRole('alertdialog');
+  expect(await screen.findAllByRole('img')).toHaveLength(2);
+});

--- a/apps/scan/frontend/src/electrical_testing/sheet_images_modal.tsx
+++ b/apps/scan/frontend/src/electrical_testing/sheet_images_modal.tsx
@@ -1,5 +1,5 @@
 import { SheetOf } from '@votingworks/types';
-import { Modal } from '@votingworks/ui';
+import { Icons, Modal } from '@votingworks/ui';
 import styled from 'styled-components';
 
 export interface Props {
@@ -10,6 +10,28 @@ export interface Props {
 const SheetImage = styled.img`
   max-width: 50%;
 `;
+
+function CloseButton({ onPress }: { onPress: () => void }) {
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+    <div
+      role="button"
+      tabIndex={-1}
+      onClick={onPress}
+      style={{
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        background: 'white',
+        borderRadius: '50%',
+        boxShadow: '0 0px 5px 3px rgba(255, 255, 255, 1)',
+        transform: 'translate(25%, -25%)',
+      }}
+    >
+      <Icons.Delete />
+    </div>
+  );
+}
 
 /**
  * Renders a modal showing images for a scanned sheet.
@@ -24,10 +46,12 @@ export function SheetImagesModal({ paths, onClose }: Props): JSX.Element {
             display: 'flex',
             flexDirection: 'row',
             alignItems: 'center',
+            position: 'relative',
           }}
           role="presentation"
           onClick={onClose}
         >
+          <CloseButton onPress={onClose} />
           <SheetImage src={paths[0]} alt="Front Sheet" />
           <SheetImage src={paths[1]} alt="Back Sheet" />
         </div>

--- a/apps/scan/frontend/src/electrical_testing/sheet_images_modal.tsx
+++ b/apps/scan/frontend/src/electrical_testing/sheet_images_modal.tsx
@@ -1,0 +1,37 @@
+import { SheetOf } from '@votingworks/types';
+import { Modal } from '@votingworks/ui';
+import styled from 'styled-components';
+
+export interface Props {
+  paths: SheetOf<string>;
+  onClose: () => void;
+}
+
+const SheetImage = styled.img`
+  max-width: 50%;
+`;
+
+/**
+ * Renders a modal showing images for a scanned sheet.
+ */
+export function SheetImagesModal({ paths, onClose }: Props): JSX.Element {
+  return (
+    <Modal
+      onOverlayClick={onClose}
+      content={
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+          }}
+          role="presentation"
+          onClick={onClose}
+        >
+          <SheetImage src={paths[0]} alt="Front Sheet" />
+          <SheetImage src={paths[1]} alt="Back Sheet" />
+        </div>
+      }
+    />
+  );
+}


### PR DESCRIPTION
## Overview

Adds a button to the "Scanner" status card that allows viewing the latest scanned image, if one exists.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/4405ceb6-29f0-4136-9013-5665b20031b1

## Testing Plan

Added some basic tests, but mostly tested manually. Ensured the button is absent when there are no scanned images and present and working when there are.