### PR TITLE
Update backend pollbook makefile

### DIFF
--- a/apps/pollbook/backend/Makefile
+++ b/apps/pollbook/backend/Makefile
@@ -1,12 +1,19 @@
-# Placeholder for build
+NODE_ENV ?= development
+OS := $(shell lsb_release -cs)
+TIMESTAMP := $(shell date --iso-8601=seconds --utc | sed 's/+.*$\//g' | tr ':' '-')
 
-install:
+install-dev-dependencies:
 	# Install necessary packages for Avahi
 	sudo apt install -y avahi-daemon avahi-utils
 
-build:
+FORCE:
 
-bootstrap:
+install:
+
+build: FORCE
+	pnpm install && pnpm build
+
+bootstrap: install build
 
 run:
 	pnpm start


### PR DESCRIPTION
## Overview
Updates the pollbook backend's makefile to match other vxsuite apps.

 @amcmanus I assume eventually we would want the avahi packages here to be included in the ansible inventory that gets installed for vxdev / devolopment VMs but we do NOT want them installed for vxsuite production build processes. They are already included for the pollbook production build process. Should I remove them here and add them in build system somewhere? I thought it would be useful to still have install-dev-dependencies here for people updating an existing VM for pollbook development 

