### PR TITLE
VV40ECT-12: Clarify meaning of dmverity-boot logs

### DIFF
--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -196,7 +196,7 @@ IDs are logged with each log to identify the log being written.
 **Machines:** All
 ### dmverity-boot
 **Type:** [system-status](#system-status)  
-**Description:** The system booted with dm-verity enabled.  
+**Description:** The system either successfully booted with dm-verity enabled or failed to do so, as indicated by the disposition.  
 **Machines:** All
 ### machine-boot-init
 **Type:** [system-action](#system-action)  

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -237,7 +237,7 @@ documentationMessage = "A system action failed to read a file from disk."
 [DmVerityBoot]
 eventId = "dmverity-boot"
 eventType = "system-status"
-documentationMessage = "The system booted with dm-verity enabled."
+documentationMessage = "The system either successfully booted with dm-verity enabled or failed to do so, as indicated by the disposition."
 
 [MachineBootInit]
 eventId = "machine-boot-init"

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -452,7 +452,8 @@ const FileReadError: LogDetails = {
 const DmVerityBoot: LogDetails = {
   eventId: LogEventId.DmVerityBoot,
   eventType: LogEventType.SystemStatus,
-  documentationMessage: 'The system booted with dm-verity enabled.',
+  documentationMessage:
+    'The system either successfully booted with dm-verity enabled or failed to do so, as indicated by the disposition.',
 };
 
 const MachineBootInit: LogDetails = {


### PR DESCRIPTION
## Overview

We're chipping away at cert documentation discpreancies/issues flagged by SLI, and there was some confusion about the meaning of the `dmverity-boot` log in the case of failure. This PR addresses that confusion. Once this is approved, I'll:

- [ ] Merge this PR
- [ ] Cherry-pick the change onto the v4.0.2 release branch
- [ ] Upload the updated .md file to https://github.com/votingworks/docs-vxsuite-v4/tree/main/software-docs