### PR TITLE
[VxDesign] Resize large user images before upload

### DIFF
--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -16,6 +16,7 @@ import {
   TabPanel,
   RouterTabBar,
   Modal,
+  images,
 } from '@votingworks/ui';
 import {
   Switch,
@@ -458,6 +459,13 @@ const ClerkSignatureImageInput = styled(ImageInput)`
   }
 `;
 
+const PDF_PIXELS_PER_INCH = 96;
+const SIGNATURE_IMAGE_NORMALIZE_PARAMS: Readonly<images.NormalizeParams> = {
+  maxHeightPx: 1 * PDF_PIXELS_PER_INCH,
+  minHeightPx: 50,
+  minWidthPx: 100,
+};
+
 function PrecinctForm({
   electionId,
   savedPrecinct,
@@ -698,8 +706,7 @@ function PrecinctForm({
                           }
                           buttonLabel="Upload Signature Image"
                           removeButtonLabel="Remove Signature Image"
-                          minHeightPx={50}
-                          minWidthPx={100}
+                          normalizeParams={SIGNATURE_IMAGE_NORMALIZE_PARAMS}
                         />
                       </div>
                     )}

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -460,8 +460,14 @@ const ClerkSignatureImageInput = styled(ImageInput)`
 `;
 
 const PDF_PIXELS_PER_INCH = 96;
+const LETTER_PAGE_WIDTH_INCHES = 8.5;
+
+/** Generously padded. */
+const LETTER_PAGE_CONTENT_WIDTH_INCHES = LETTER_PAGE_WIDTH_INCHES - 2;
+
 const SIGNATURE_IMAGE_NORMALIZE_PARAMS: Readonly<images.NormalizeParams> = {
   maxHeightPx: 1 * PDF_PIXELS_PER_INCH,
+  maxWidthPx: 0.5 * LETTER_PAGE_CONTENT_WIDTH_INCHES * PDF_PIXELS_PER_INCH,
   minHeightPx: 50,
   minWidthPx: 100,
 };

--- a/apps/design/frontend/src/rich_text_editor.tsx
+++ b/apps/design/frontend/src/rich_text_editor.tsx
@@ -115,7 +115,6 @@ const LETTER_PAGE_WIDTH_INCHES = 8.5;
 const NORMALIZE_PARAMS: Readonly<images.NormalizeParams> = {
   maxHeightPx: (LETTER_PAGE_HEIGHT_INCHES - 3) * PDF_PIXELS_PER_INCH,
   maxWidthPx: (LETTER_PAGE_WIDTH_INCHES - 2) * PDF_PIXELS_PER_INCH,
-  minWidthPx: 1 * PDF_PIXELS_PER_INCH,
 };
 
 function Toolbar({ editor }: { editor: Editor }) {

--- a/apps/design/frontend/src/rich_text_editor.tsx
+++ b/apps/design/frontend/src/rich_text_editor.tsx
@@ -19,7 +19,13 @@ import Dropcursor from '@tiptap/extension-dropcursor';
 import Gapcursor from '@tiptap/extension-gapcursor';
 import History from '@tiptap/extension-history';
 import { Slice } from '@tiptap/pm/model';
-import { Button, ButtonProps, Icons, richTextStyles } from '@votingworks/ui';
+import {
+  Button,
+  ButtonProps,
+  Icons,
+  images,
+  richTextStyles,
+} from '@votingworks/ui';
 import styled from 'styled-components';
 import React from 'react';
 import { Buffer } from 'node:buffer';
@@ -89,6 +95,29 @@ function ControlButton({
   );
 }
 
+const PDF_PIXELS_PER_INCH = 96;
+const LETTER_PAGE_HEIGHT_INCHES = 11;
+const LETTER_PAGE_WIDTH_INCHES = 8.5;
+
+/**
+ * These assume a worst-case of ballots with full-width contest boxes and images
+ * that take up all the available width.
+ *
+ * The subtracted margins are inexact and can be tweaked if needed. Last tested
+ * with "full-height" and "full-width" images rendering without error on
+ * letter-sized pages.
+ *
+ * [TODO] The max width should really be the VxMark screen size (1080px), since
+ * that's the largest render surface for these images, but we need to add image
+ * scaling to the ballot renderer first, to limit them to the bounds of the
+ * contest box.
+ */
+const NORMALIZE_PARAMS: Readonly<images.NormalizeParams> = {
+  maxHeightPx: (LETTER_PAGE_HEIGHT_INCHES - 3) * PDF_PIXELS_PER_INCH,
+  maxWidthPx: (LETTER_PAGE_WIDTH_INCHES - 2) * PDF_PIXELS_PER_INCH,
+  minWidthPx: 1 * PDF_PIXELS_PER_INCH,
+};
+
 function Toolbar({ editor }: { editor: Editor }) {
   return (
     <StyledToolbar>
@@ -137,6 +166,7 @@ function Toolbar({ editor }: { editor: Editor }) {
           buttonProps={{
             fill: 'transparent',
           }}
+          normalizeParams={NORMALIZE_PARAMS}
           onChange={(svgImage) => {
             editor
               .chain()
@@ -148,8 +178,10 @@ function Toolbar({ editor }: { editor: Editor }) {
               })
               .run();
           }}
-          // eslint-disable-next-line no-console
-          onError={(err) => console.error(err)}
+          // [TODO] Display a user-friendly error instead.
+          onError={(err) => {
+            throw err;
+          }}
           aria-label="Insert Image"
         >
           <Icons.Image />

--- a/apps/design/frontend/src/seal_image_input.tsx
+++ b/apps/design/frontend/src/seal_image_input.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { images } from '@votingworks/ui';
 import { ImageInput, ImageInputProps } from './image_input';
 
 const StyledImageInput = styled(ImageInput)`
@@ -8,6 +9,7 @@ const StyledImageInput = styled(ImageInput)`
 `;
 
 type StaticPropsNames =
+  | 'normalizeParams'
   | 'minWidthPx'
   | 'minHeightPx'
   | 'buttonLabel'
@@ -15,12 +17,28 @@ type StaticPropsNames =
 
 export type SealImageInputProps = Omit<ImageInputProps, StaticPropsNames>;
 
+const VXMARK_MAX_SEAL_DISPLAY_SIZE_REM = 7;
+const VXMARK_DEFAULT_FONT_SIZE_PX = 40;
+const VXMARK_MAX_FONT_SIZE_PX = 70;
+
+const MIN_SEAL_SIZE_PX =
+  VXMARK_MAX_SEAL_DISPLAY_SIZE_REM * VXMARK_DEFAULT_FONT_SIZE_PX;
+
+const MAX_SEAL_SIZE_PX =
+  VXMARK_MAX_SEAL_DISPLAY_SIZE_REM * VXMARK_MAX_FONT_SIZE_PX;
+
+const NORMALIZE_PARAMS: Readonly<images.NormalizeParams> = {
+  maxHeightPx: MAX_SEAL_SIZE_PX,
+  maxWidthPx: MAX_SEAL_SIZE_PX,
+  minHeightPx: MIN_SEAL_SIZE_PX,
+  minWidthPx: MIN_SEAL_SIZE_PX,
+};
+
 export function SealImageInput(props: SealImageInputProps): JSX.Element {
   return (
     <StyledImageInput
       {...props}
-      minWidthPx={200}
-      minHeightPx={200}
+      normalizeParams={NORMALIZE_PARAMS}
       buttonLabel="Upload Seal Image"
       removeButtonLabel="Remove Seal Image"
     />

--- a/libs/ui/src/images/index.ts
+++ b/libs/ui/src/images/index.ts
@@ -1,0 +1,1 @@
+export * from './normalize';

--- a/libs/ui/src/images/normalize.ts
+++ b/libs/ui/src/images/normalize.ts
@@ -1,0 +1,161 @@
+/* eslint @typescript-eslint/no-use-before-define: ["error", { "functions": false }] */
+
+/* istanbul ignore file - [TODO] Adding browser tests in future PRs. @preserve */
+
+import { assertDefined, deferred, err, ok, Result } from '@votingworks/basics';
+
+export type NormalizeResult = Result<NormalizedImage, NormalizeError>;
+
+export interface NormalizedImage {
+  dataUrl: string;
+  heightPx: number;
+  widthPx: number;
+}
+
+export type NormalizeError =
+  | { code: 'belowMinHeight'; heightPx: number }
+  | { code: 'belowMinWidth'; widthPx: number }
+  | { code: 'unsupportedImageType' }
+  | { code: 'unexpected'; error: unknown };
+
+export type NormalizeParams = {
+  minHeightPx?: number;
+  minWidthPx?: number;
+} & (
+  | { maxHeightPx: number; maxWidthPx?: number }
+  | { maxHeightPx?: number; maxWidthPx: number }
+);
+
+/**
+ * Normalizes an image, potentially resizing it to fit within the given bounds,
+ * and returns a serialized data URL version of the final image with the same
+ * encoding as the original.
+ *
+ * If minimum dimensions are specified, an error is returned for images that
+ * fall below the given thresholds (see {@link NormlaizeError}).
+ */
+export async function normalizeFile(
+  image: File,
+  params: NormalizeParams
+): Promise<NormalizeResult> {
+  const mimeType = image.type;
+  if (!isSupportedMimeType(mimeType)) {
+    return err({ code: 'unsupportedImageType' });
+  }
+
+  return normalizeDataUrl(await serialize(image), mimeType, params);
+}
+
+const SUPPORTED_MIME_TYPES = ['image/png', 'image/jpeg'] as const;
+export type ImageType = (typeof SUPPORTED_MIME_TYPES)[number];
+
+/**
+ * Normalizes an image, potentially resizing it to fit within the given bounds,
+ * and returns a serialized data URL version of the final image with the same
+ * encoding as the original.
+ *
+ * If minimum dimensions are specified, an error is returned for images that
+ * fall below the given thresholds (see {@link NormlaizeError}).
+ */
+export async function normalizeDataUrl(
+  imageDataUrl: string,
+  mimeType: ImageType,
+  params: NormalizeParams
+): Promise<NormalizeResult> {
+  const { promise, resolve } = deferred<NormalizeResult>();
+
+  const img = new Image();
+  async function onLoad() {
+    if (params.minHeightPx && img.height < params.minHeightPx) {
+      resolve(err({ code: 'belowMinHeight', heightPx: img.height }));
+    }
+
+    if (params.minWidthPx && img.width < params.minWidthPx) {
+      resolve(err({ code: 'belowMinWidth', widthPx: img.width }));
+    }
+
+    try {
+      const scaleX = (params.maxWidthPx || img.width) / img.width;
+      const scaleY = (params.maxHeightPx || img.height) / img.height;
+      const scale = Math.min(scaleX, scaleY);
+
+      if (scale >= 1) {
+        return resolve(
+          ok({
+            dataUrl: imageDataUrl,
+            heightPx: img.height,
+            widthPx: img.width,
+          })
+        );
+      }
+
+      const canvas = document.createElement('canvas');
+      const context = assertDefined(canvas.getContext('2d'));
+
+      canvas.width = img.width * scale;
+      canvas.height = img.height * scale;
+      context.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+      resolve(
+        ok({
+          dataUrl: await canvasToDataUrl(canvas, mimeType),
+          heightPx: canvas.height,
+          widthPx: canvas.width,
+        })
+      );
+    } catch (error) {
+      resolve(err({ code: 'unexpected', error }));
+    }
+  }
+
+  img.addEventListener('load', onLoad, { once: true });
+  img.src = imageDataUrl;
+
+  return promise;
+}
+
+async function canvasToDataUrl(
+  canvas: HTMLCanvasElement,
+  mimeType?: ImageType
+): Promise<string> {
+  const { promise, reject, resolve } = deferred<string>();
+
+  canvas.toBlob(async (blob) => {
+    if (!blob) {
+      return reject(new Error('Missing data in Canvas.toBlob() result'));
+    }
+
+    try {
+      resolve(await serialize(blob));
+    } catch (error) {
+      reject(error);
+    }
+  }, mimeType);
+
+  return promise;
+}
+
+async function serialize(blob: Blob): Promise<string> {
+  const { promise, reject, resolve } = deferred<string>();
+
+  const reader = new FileReader();
+
+  function onRead() {
+    if (typeof reader.result !== 'string') {
+      return reject(
+        new Error(`Expected image data URL, got ${typeof reader.result}`)
+      );
+    }
+
+    resolve(reader.result);
+  }
+
+  reader.addEventListener('load', onRead, { once: true });
+  reader.readAsDataURL(blob);
+
+  return promise;
+}
+
+function isSupportedMimeType(mimeType: string): mimeType is ImageType {
+  return SUPPORTED_MIME_TYPES.includes(mimeType as ImageType);
+}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -1,4 +1,7 @@
 /* istanbul ignore file - @preserve */
+
+export * as images from './images';
+
 export * from './accessible_controllers';
 export * from './app_base';
 export * from './auth';


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6091

- Adding a normalization step to image uploads, which shrinks large images to fit within specified bounds
- Adding maximum bounds for seals, signatures, and ballot measure images, based on the largest display/print size we expect.

### TODO
- The ballot renderer renders images with their original width and height, which causes page overflow for large-enough images. We'll need to add max size restrictions there, which would allow us to set the max upload size appropriately for display in VxMark.
- This PR doesn't address potentially large SVG uploads (large image wrapped in an SVG).
- We can probably relax the 5MB restriction a bit, now that we're resizing before upload, but maybe worth addressing the large-SVG case first.
- Would be useful for users to have a way to resize images in the rich text editor - currently have to resize out side the app first.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/b53fa1a5-54d2-4339-b880-a1511220fdb5

## Testing Plan
- Manual for now (chrome, firefox); adding automated browser tests later:
  - Upload images at lower and upper bounds for seal, clerk signature, ballot measure image
  - Verified upload sizes are reduced
  - Tested long and wide images going through ballot rendering

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
