### PR TITLE
VxDesign: Fix contest insertion in relational tables migration

### DIFF
--- a/apps/design/backend/migrations/1742944839600_election-content-tables.js
+++ b/apps/design/backend/migrations/1742944839600_election-content-tables.js
@@ -319,7 +319,7 @@ exports.up = async (pgm) => {
       `);
     }
 
-    for (const [i, contest] of election.contests.entries()) {
+    for (const contest of election.contests) {
       switch (contest.type) {
         case 'candidate': {
           pgm.sql(`
@@ -332,8 +332,7 @@ exports.up = async (pgm) => {
               seats,
               allow_write_ins,
               party_id,
-              term_description,
-              ballot_order
+              term_description
             )
             VALUES (
               '${contest.id}',
@@ -348,8 +347,7 @@ exports.up = async (pgm) => {
                 contest.termDescription
                   ? `'${quote(contest.termDescription)}'`
                   : 'NULL'
-              },
-              ${i + 1}
+              }
             )
           `);
           for (const candidate of contest.candidates) {
@@ -406,8 +404,7 @@ exports.up = async (pgm) => {
               yes_option_id,
               yes_option_label,
               no_option_id,
-              no_option_label,
-              ballot_order
+              no_option_label
             )
             VALUES (
               '${contest.id}',
@@ -419,8 +416,7 @@ exports.up = async (pgm) => {
               '${contest.yesOption.id}',
               '${quote(contest.yesOption.label)}',
               '${contest.noOption.id}',
-              '${quote(contest.noOption.label)}',
-              ${i + 1}
+              '${quote(contest.noOption.label)}'
             )
           `);
           break;


### PR DESCRIPTION


## Overview

When I switched the contests.ballot_order column to be a serial instead of a number, I forgot to remove the insertion of numbers from the migration (to allow for unique serials to be generated instead).

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
