### PR TITLE
VxDesign: Disregard district order when generating ballot styles

### DIFF
--- a/apps/design/backend/src/ballot_styles.test.ts
+++ b/apps/design/backend/src/ballot_styles.test.ts
@@ -414,4 +414,71 @@ describe('generateBallotStyles()', () => {
       })),
     ]);
   });
+
+  test('precincts with the same district IDs in different orders', () => {
+    const precinct1: SplittablePrecinct = {
+      id: 'precinct-1',
+      name: 'Precinct 1',
+      districtIds: [district1.id, district2.id],
+    };
+    const precinct2: SplittablePrecinct = {
+      id: 'precinct-2',
+      name: 'Precinct 2',
+      districtIds: [district2.id, district1.id],
+    };
+    const precinct3: SplittablePrecinct = {
+      id: 'precinct-3',
+      name: 'Precinct 3',
+      splits: [
+        {
+          id: 'precinct-3-split-1',
+          name: 'Precinct 3 - Split 1',
+          districtIds: [district1.id, district2.id],
+        },
+        {
+          id: 'precinct-3-split-2',
+          name: 'Precinct 3 - Split 2',
+          districtIds: [district2.id, district1.id],
+        },
+        {
+          id: 'precinct-3-split-3',
+          name: 'Precinct 3 - Split 3',
+          districtIds: [district1.id],
+        },
+      ],
+    };
+    const precinct4: SplittablePrecinct = {
+      id: 'precinct-4',
+      name: 'Precinct 4',
+      districtIds: [district1.id],
+    };
+
+    const ballotLanguageConfigs = [{ languages: [ENGLISH] }];
+    const ballotStyles = generateBallotStyles({
+      ballotLanguageConfigs,
+      contests: [generalContest1, generalContest2],
+      electionType: 'general',
+      parties: [],
+      precincts: [precinct1, precinct2, precinct3, precinct4],
+    });
+    expect(ballotStyles.length).toEqual(2);
+    expect(ballotStyles[0].districtIds).toEqual([district1.id, district2.id]);
+    expect(ballotStyles[0].precinctsOrSplits).toEqual([
+      { precinctId: precinct1.id },
+      { precinctId: precinct2.id },
+      {
+        precinctId: precinct3.id,
+        splitId: precinct3.splits[0].id,
+      },
+      {
+        precinctId: precinct3.id,
+        splitId: precinct3.splits[1].id,
+      },
+    ]);
+    expect(ballotStyles[1].districtIds).toEqual([district1.id]);
+    expect(ballotStyles[1].precinctsOrSplits).toEqual([
+      { precinctId: precinct3.id, splitId: precinct3.splits[2].id },
+      { precinctId: precinct4.id },
+    ]);
+  });
 });

--- a/apps/design/backend/src/ballot_styles.ts
+++ b/apps/design/backend/src/ballot_styles.ts
@@ -62,9 +62,8 @@ export function generateBallotStyles(params: {
 
   const precinctsOrSplitsByDistricts: Array<
     [readonly DistrictId[], PrecinctOrSplitId[]]
-  > = groupBy(
-    allPrecinctsOrSplitsWithDistricts,
-    ({ districtIds }) => districtIds
+  > = groupBy(allPrecinctsOrSplitsWithDistricts, ({ districtIds }) =>
+    districtIds.toSorted()
   ).map(([districtIds, group]) => [
     districtIds,
     // Remove districtIds after grouping, we don't need them anymore


### PR DESCRIPTION


## Overview

When generating ballot styles for precincts, we combine all precincts/splits that share the same districts into a single shared ballot style. However, we were previously looking at an ordered list of the districts for each precinct/split (rather than treating them as an unordered set). That means if two precincts had the same district list in a different order, they wouldn't end up with the same ballot style. This would create more ballot styles than is necessary.
## Demo Video or Screenshot
N/A

## Testing Plan
Added regression test
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
