### PR TITLE
automatically reset after successful check in

### DIFF
--- a/apps/pollbook/frontend/src/add_voter_screen.tsx
+++ b/apps/pollbook/frontend/src/add_voter_screen.tsx
@@ -76,6 +76,7 @@ export function AddVoterScreen({
               <FieldName>Party Affiliation</FieldName>
               <SearchSelect
                 id="party"
+                aria-label="Party Affiliation"
                 style={{ width: '20rem' }}
                 value={voter.party || undefined}
                 onChange={(value) => setVoter({ ...voter, party: value || '' })}

--- a/apps/pollbook/frontend/src/address_input_group.tsx
+++ b/apps/pollbook/frontend/src/address_input_group.tsx
@@ -91,6 +91,7 @@ export function AddressInputGroup({
         <RequiredStaticInput>
           <FieldName>Street #</FieldName>
           <TextField
+            aria-label="Street Number"
             id="streetNumber"
             value={address.streetNumber + address.streetSuffix}
             style={{ width: '8rem' }}
@@ -107,6 +108,7 @@ export function AddressInputGroup({
         <RequiredExpandableInput>
           <FieldName>Street Name</FieldName>
           <SearchSelect
+            aria-label="Street Name"
             id="streetName"
             value={address.streetName || undefined}
             menuPortalTarget={document.body}
@@ -126,6 +128,7 @@ export function AddressInputGroup({
         <StaticInput>
           <FieldName>Apartment/Unit #</FieldName>
           <TextField
+            aria-label="Apartment or Unit Number"
             value={address.apartmentUnitNumber}
             style={{ width: '8rem' }}
             onChange={(e) =>
@@ -141,6 +144,7 @@ export function AddressInputGroup({
         <ExpandableInput>
           <FieldName>Address Line 2</FieldName>
           <TextField
+            aria-label="Address Line 2"
             value={address.addressLine2}
             onChange={(e) =>
               handleChange({
@@ -152,11 +156,11 @@ export function AddressInputGroup({
         </ExpandableInput>
         <RequiredExpandableInput>
           <FieldName>City</FieldName>
-          <TextField value={address.city} disabled />
+          <TextField aria-label="City" value={address.city} disabled />
         </RequiredExpandableInput>
         <RequiredExpandableInput>
           <FieldName>Zip Code</FieldName>
-          <TextField value={address.zipCode} disabled />
+          <TextField aria-label="Zip Code" value={address.zipCode} disabled />
         </RequiredExpandableInput>
       </Row>
     </React.Fragment>

--- a/apps/pollbook/frontend/src/app.test.tsx
+++ b/apps/pollbook/frontend/src/app.test.tsx
@@ -1,5 +1,4 @@
 import { test, beforeEach, afterEach, vi, expect } from 'vitest';
-import userEvent from '@testing-library/user-event';
 import {
   mockElectionManagerUser,
   mockSessionExpiresAt,
@@ -8,11 +7,7 @@ import { constructElectionKey, Election } from '@votingworks/types';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import { render, screen, within } from '../test/react_testing_library';
 import { App } from './app';
-import {
-  ApiMock,
-  createApiMock,
-  createMockVoter,
-} from '../test/mock_api_client';
+import { ApiMock, createApiMock } from '../test/mock_api_client';
 
 let apiMock: ApiMock;
 const famousNamesElection: Election =
@@ -114,57 +109,4 @@ test('renders ElectionManagerScreen when logged in as election manager', async (
   await within(electionInfoSection).findByText(
     'Lincoln Municipal General Election'
   );
-});
-
-test('renders PollWorkerScreen when logged in as poll worker basic e2e check in flow works', async () => {
-  apiMock.expectGetMachineConfig();
-  apiMock.expectGetDeviceStatuses();
-  apiMock.authenticateAsPollWorker(famousNamesElection);
-  apiMock.setElection(famousNamesElection);
-  render(<App apiClient={apiMock.mockApiClient} />);
-  await screen.findByText('Connect printer to continue.');
-
-  apiMock.setPrinterStatus(true);
-  apiMock.setIsAbsenteeMode(false);
-  apiMock.expectGetCheckInCounts({ allMachines: 25, thisMachine: 5 });
-  await screen.findByText('Check-In');
-  await screen.findByText('Registration');
-  apiMock.expectSearchVotersNull({});
-
-  await screen.findByText('Total Check-ins');
-  const total = screen.getByTestId('total-check-ins');
-  within(total).getByText('25');
-  const machine = screen.getByTestId('machine-check-ins');
-  within(machine).getByText('5');
-
-  apiMock.expectSearchVotersTooMany({ firstName: '', lastName: 'SM' }, 153);
-  const lastNameInput = screen.getByLabelText('Last Name');
-  userEvent.type(lastNameInput, 'SM');
-  vi.advanceTimersByTime(1000);
-  await screen.findByText(
-    'Voters matched: 153. Refine your search further to view results.'
-  );
-
-  const voter = createMockVoter('123', 'Abigail', 'Adams');
-
-  apiMock.expectSearchVotersWithResults({ firstName: 'ABI', lastName: 'AD' }, [
-    voter,
-  ]);
-  userEvent.clear(lastNameInput);
-  userEvent.type(lastNameInput, 'AD');
-  const firstNameInput = screen.getByLabelText('First Name');
-  userEvent.type(firstNameInput, 'ABI');
-  vi.advanceTimersByTime(1000);
-  await screen.findByText(/Adams, Abigail/i);
-  const checkInButton = screen.getByTestId('check-in-button#123');
-  within(checkInButton).getByText('Start Check-In');
-
-  apiMock.expectGetVoter(voter);
-  userEvent.click(checkInButton);
-  await screen.findByText('Confirm Voter Identity');
-
-  const confirmButton = screen.getByText('Confirm Check-In');
-  apiMock.expectCheckInVoter(voter);
-  userEvent.click(confirmButton);
-  await screen.findByText('Voter Checked In');
 });

--- a/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
+++ b/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
@@ -37,7 +37,6 @@ describe('PollWorkerScreen', () => {
     apiMock.authenticateAsPollWorker(famousNamesElection);
     apiMock.setElection(famousNamesElection);
     const { unmount } = render(<App apiClient={apiMock.mockApiClient} />);
-    // render(<App apiClient={apiMock.mockApiClient} />);
     await screen.findByText('Connect printer to continue.');
 
     apiMock.setPrinterStatus(true);

--- a/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
+++ b/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
@@ -1,0 +1,167 @@
+import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { Election } from '@votingworks/types';
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import {
+  ValidStreetInfo,
+  VoterRegistrationRequest,
+} from '@votingworks/pollbook-backend';
+import { act, render, screen, within } from '../test/react_testing_library';
+import { App } from './app';
+import {
+  ApiMock,
+  createApiMock,
+  createMockVoter,
+} from '../test/mock_api_client';
+import { AUTOMATIC_FLOW_STATE_RESET_DELAY_MS } from './poll_worker_screen';
+
+let apiMock: ApiMock;
+const famousNamesElection: Election =
+  electionFamousNames2021Fixtures.readElection();
+
+describe('PollWorkerScreen', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.clearAllMocks();
+    apiMock = createApiMock();
+    apiMock.setElection(undefined);
+  });
+
+  afterEach(() => {
+    apiMock.mockApiClient.assertComplete();
+  });
+
+  test('basic e2e check in flow works', async () => {
+    apiMock.expectGetMachineConfig();
+    apiMock.expectGetDeviceStatuses();
+    apiMock.authenticateAsPollWorker(famousNamesElection);
+    apiMock.setElection(famousNamesElection);
+    const { unmount } = render(<App apiClient={apiMock.mockApiClient} />);
+    // render(<App apiClient={apiMock.mockApiClient} />);
+    await screen.findByText('Connect printer to continue.');
+
+    apiMock.setPrinterStatus(true);
+    apiMock.setIsAbsenteeMode(false);
+    apiMock.expectGetCheckInCounts({ allMachines: 25, thisMachine: 5 });
+    await screen.findByText('Check-In');
+    await screen.findByText('Registration');
+    apiMock.expectSearchVotersNull({});
+
+    await screen.findByText('Total Check-ins');
+    const total = screen.getByTestId('total-check-ins');
+    within(total).getByText('25');
+    const machine = screen.getByTestId('machine-check-ins');
+    within(machine).getByText('5');
+
+    apiMock.expectSearchVotersTooMany({ firstName: '', lastName: 'SM' }, 153);
+    const lastNameInput = screen.getByLabelText('Last Name');
+    userEvent.type(lastNameInput, 'SM');
+    vi.advanceTimersByTime(1000);
+    await screen.findByText(
+      'Voters matched: 153. Refine your search further to view results.'
+    );
+
+    const voter = createMockVoter('123', 'Abigail', 'Adams');
+
+    apiMock.expectSearchVotersWithResults(
+      { firstName: 'ABI', lastName: 'AD' },
+      [voter]
+    );
+    userEvent.clear(lastNameInput);
+    userEvent.type(lastNameInput, 'AD');
+    const firstNameInput = screen.getByLabelText('First Name');
+    userEvent.type(firstNameInput, 'ABI');
+    vi.advanceTimersByTime(1000);
+    await screen.findByText(/Adams, Abigail/i);
+    const checkInButton = screen.getByTestId('check-in-button#123');
+    within(checkInButton).getByText('Start Check-In');
+
+    apiMock.expectGetVoter(voter);
+    userEvent.click(checkInButton);
+    await screen.findByText('Confirm Voter Identity');
+
+    const confirmButton = screen.getByText('Confirm Check-In');
+    apiMock.expectCheckInVoter(voter);
+    userEvent.click(confirmButton);
+    await screen.findByText('Voter Checked In');
+
+    apiMock.expectSearchVotersWithResults({ firstName: '', lastName: '' }, []);
+    act(() => {
+      vi.advanceTimersByTime(AUTOMATIC_FLOW_STATE_RESET_DELAY_MS);
+    });
+    expect(screen.queryByText('Voter Checked In')).toBeNull();
+
+    unmount();
+  });
+
+  test('basic e2e registration flow works', async () => {
+    const validStreetInfo: ValidStreetInfo = {
+      streetName: 'Main St',
+      side: 'even',
+      lowRange: 1000,
+      highRange: 2000,
+      postalCity: 'CITYVILLE',
+      zip5: '12345',
+      zip4: '6789',
+      district: 'District',
+    };
+    const voter = createMockVoter('123', 'Abigail', 'Adams');
+    const registrationData: VoterRegistrationRequest = {
+      streetNumber: '1000',
+      streetName: 'MAIN ST',
+      city: 'CITYVILLE',
+      state: 'NH',
+      zipCode: '12345',
+      lastName: voter.lastName.toUpperCase(),
+      firstName: voter.firstName.toUpperCase(),
+      party: 'REP',
+      streetSuffix: '',
+      apartmentUnitNumber: '',
+      houseFractionNumber: '',
+      addressLine2: '',
+      addressLine3: '',
+      suffix: '',
+      middleName: '',
+    };
+
+    apiMock.expectGetMachineConfig();
+    apiMock.expectGetDeviceStatuses();
+    apiMock.authenticateAsPollWorker(famousNamesElection);
+    apiMock.setElection(famousNamesElection);
+    const { unmount } = render(<App apiClient={apiMock.mockApiClient} />);
+    await screen.findByText('Connect printer to continue.');
+
+    apiMock.setPrinterStatus(true);
+    apiMock.expectGetValidStreetInfo([validStreetInfo]);
+    await screen.findByText('Check-In');
+    await screen.findByText('Registration');
+
+    await screen.findByText('Check-In');
+    const registrationTab = await screen.findByRole('button', {
+      name: 'Registration',
+    });
+    userEvent.click(registrationTab);
+
+    const lastNameInput = await screen.findByLabelText('Last Name');
+    userEvent.type(lastNameInput, voter.lastName);
+    const firstNameInput = screen.getByLabelText('First Name');
+    userEvent.type(firstNameInput, voter.firstName);
+    userEvent.type(screen.getByLabelText('Street Number'), '1000');
+    userEvent.click(screen.getByLabelText('Street Name'));
+    userEvent.keyboard('[Enter]');
+    userEvent.click(screen.getByLabelText('Party Affiliation'));
+    userEvent.keyboard('[Enter]');
+
+    apiMock.expectRegisterVoter(registrationData, voter);
+
+    userEvent.click(screen.getByRole('button', { name: 'Add Voter' }));
+
+    await screen.findByText('Give the voter their receipt.');
+    act(() => {
+      vi.advanceTimersByTime(AUTOMATIC_FLOW_STATE_RESET_DELAY_MS);
+    });
+    expect(screen.queryByText('Give the voter their receipt.')).toBeNull();
+
+    unmount();
+  });
+});

--- a/apps/pollbook/frontend/src/name_input_group.tsx
+++ b/apps/pollbook/frontend/src/name_input_group.tsx
@@ -19,6 +19,7 @@ export function NameInputGroup({
       <RequiredExpandableInput>
         <FieldName>Last Name</FieldName>
         <TextField
+          aria-label="Last Name"
           value={name.lastName}
           onChange={(e) =>
             onChange({
@@ -31,6 +32,7 @@ export function NameInputGroup({
       <RequiredExpandableInput>
         <FieldName>First Name</FieldName>
         <TextField
+          aria-label="First Name"
           value={name.firstName}
           onChange={(e) =>
             onChange({
@@ -43,6 +45,7 @@ export function NameInputGroup({
       <ExpandableInput>
         <FieldName>Middle Name</FieldName>
         <TextField
+          aria-label="Middle Name"
           value={name.middleName}
           onChange={(e) =>
             onChange({
@@ -55,6 +58,7 @@ export function NameInputGroup({
       <StaticInput>
         <FieldName>Suffix</FieldName>
         <TextField
+          aria-label="Suffix"
           value={name.suffix}
           style={{ width: '5rem' }}
           onChange={(e) =>

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -8,7 +8,9 @@ import type {
   Api,
   DeviceStatuses,
   MachineConfig,
+  ValidStreetInfo,
   Voter,
+  VoterRegistrationRequest,
 } from '@votingworks/pollbook-backend';
 import {
   mockElectionManagerUser,
@@ -282,6 +284,21 @@ export function createApiMock() {
           },
         })
         .resolves(ok());
+    },
+
+    expectGetValidStreetInfo(streetInfo: ValidStreetInfo[]) {
+      mockApiClient.getValidStreetInfo.reset();
+      mockApiClient.getValidStreetInfo.expectCallWith().resolves(streetInfo);
+    },
+
+    expectRegisterVoter(
+      registrationData: VoterRegistrationRequest,
+      voter: Voter
+    ) {
+      mockApiClient.registerVoter.reset();
+      mockApiClient.registerVoter
+        .expectCallWith({ registrationData })
+        .resolves(voter);
     },
   };
 }

--- a/apps/pollbook/frontend/vitest.config.ts
+++ b/apps/pollbook/frontend/vitest.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
 
     coverage: {
       thresholds: {
-        lines: 62,
-        branches: 42,
+        lines: 73,
+        branches: 51,
       },
       exclude: ['src/**/*.d.ts', 'src/index.tsx', 'src/stubs/*'],
     },


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6197.

Time out check-in and registration confirmation screens after 3s.



## Demo Video or Screenshot

Check in:

https://github.com/user-attachments/assets/bd299897-a45a-4e03-a3e0-4b53d0037f36

Registration:



https://github.com/user-attachments/assets/10c26dce-c74b-4b9e-9888-d07779cae8d7




## Testing Plan
- [x] Manually tested
- [x] Add basic tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
