### PR TITLE
design/backend: Log API calls

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -82,7 +82,6 @@ import {
 import { FULL_TEST_DECK_TALLY_REPORT_FILE_NAME } from './test_decks';
 import {
   BallotOrderInfo,
-  BallotStyle,
   ElectionInfo,
   ElectionListing,
   ElectionStatus,
@@ -96,6 +95,7 @@ import { BALLOT_STYLE_READINESS_REPORT_FILE_NAME } from './app';
 import { join } from 'node:path';
 import { electionFeatureConfigs, userFeatureConfigs } from './features';
 import { sliOrgId } from './globals';
+import { LogEventId } from '@votingworks/logging';
 
 vi.setConfig({
   testTimeout: 60_000,
@@ -2490,4 +2490,25 @@ test('feature configs', async () => {
   expect(
     await apiClient.getElectionFeatures({ electionId: sliElectionId })
   ).toEqual(electionFeatureConfigs.sli);
+});
+
+test('api method logging', async () => {
+  const { apiClient, logger } = await setupApp();
+  await apiClient.createElection({
+    id: 'election-id' as ElectionId,
+    user: vxUser,
+    orgId: vxUser.orgId,
+  });
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.ApiCall,
+    'system',
+    expect.objectContaining({
+      methodName: 'createElection',
+      input: JSON.stringify({
+        id: 'election-id',
+        user: vxUser,
+        orgId: vxUser.orgId,
+      }),
+    })
+  );
 });

--- a/apps/design/backend/src/context.ts
+++ b/apps/design/backend/src/context.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@votingworks/logging';
 import { AuthClientInterface } from './auth/client';
 import { FileStorageClient } from './file_storage_client';
 import { GoogleCloudSpeechSynthesizerWithDbCache } from './speech_synthesizer';
@@ -10,4 +11,5 @@ export interface AppContext {
   speechSynthesizer: GoogleCloudSpeechSynthesizerWithDbCache;
   translator: GoogleCloudTranslatorWithDbCache;
   workspace: Workspace;
+  logger: Logger;
 }

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -550,3 +550,7 @@ IDs are logged with each log to identify the log being written.
 **Type:** [system-status](#system-status)  
 **Description:** A background task has reported an arbitrary status.  
 **Machines:** All
+### api-call
+**Type:** [application-action](#application-action)  
+**Description:** An API call was made.  
+**Machines:** vx-design

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -765,3 +765,9 @@ eventId = "background-task-status"
 eventType = "system-status"
 documentationMessage = "A background task has reported an arbitrary status."
 defaultMessage = "A background task has reported its status."
+
+[ApiCall]
+eventId = "api-call"
+eventType = "application-action"
+documentationMessage = "An API call was made."
+restrictInDocumentationToApps = ["vx-design"]

--- a/libs/logging/src/base_types/log_source.ts
+++ b/libs/logging/src/base_types/log_source.ts
@@ -31,6 +31,7 @@ export enum AppName {
   VxMarkScan = 'vx-mark-scan',
   VxAdmin = 'vx-admin',
   VxCentralScan = 'vx-central-scan',
+  VxDesign = 'vx-design',
 }
 
 // The following log sources are frontends and always expect to log through window.kiosk

--- a/libs/logging/src/log_event_ids.ts
+++ b/libs/logging/src/log_event_ids.ts
@@ -146,6 +146,7 @@ export enum LogEventId {
   BackgroundTaskSuccess = 'background-task-success',
   BackgroundTaskCancelled = 'background-task-cancelled',
   BackgroundTaskStatus = 'background-task-status',
+  ApiCall = 'api-call',
 }
 
 const ElectionConfigured: LogDetails = {
@@ -1140,6 +1141,13 @@ const BackgroundTaskStatus: LogDetails = {
   defaultMessage: 'A background task has reported its status.',
 };
 
+const ApiCall: LogDetails = {
+  eventId: LogEventId.ApiCall,
+  eventType: LogEventType.ApplicationAction,
+  documentationMessage: 'An API call was made.',
+  restrictInDocumentationToApps: [AppName.VxDesign],
+};
+
 export function getDetailsForEventId(eventId: LogEventId): LogDetails {
   switch (eventId) {
     case LogEventId.ElectionConfigured:
@@ -1410,6 +1418,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return BackgroundTaskCancelled;
     case LogEventId.BackgroundTaskStatus:
       return BackgroundTaskStatus;
+    case LogEventId.ApiCall:
+      return ApiCall;
     default:
       throwIllegalValue(eventId);
   }

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -277,4 +277,6 @@ pub enum EventId {
     BackgroundTaskCancelled,
     #[serde(rename = "background-task-status")]
     BackgroundTaskStatus,
+    #[serde(rename = "api-call")]
+    ApiCall,
 }


### PR DESCRIPTION
## Overview

Closes #6140 

Adds logging middleware to the design/backend API to log method arguments. This will allow us to cross reference API logs with alerts to better investigate.

Note that these logs are logged when the request is received before executing the API method handler. I went back and forth over whether it should happen before or after, but we already have logs from Heroku that are recorded after the request with status code and response time, so the before logs should fill in the information gap (namely, the input parameters) that we need for debugging. It might be a bit difficult to have to look at both log lines together to make sense of things, but the advantage of logging before the handler is that the request will be logged even if the app crashes. I figured that would be nice to have while we're working out error handling kinks, and we can easily improve on it later as needed.

## Demo Video or Screenshot
N/A

## Testing Plan
- Manually tested with debug flag
- Added automated test
## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
