### PR TITLE
fix(utils): add overloads for contest types

### DIFF
--- a/libs/utils/src/hmpb/all_contest_options.test.ts
+++ b/libs/utils/src/hmpb/all_contest_options.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from 'vitest';
 import {
   arbitraryCandidateContest,
-  arbitraryCandidateId,
   arbitraryYesNoContest,
 } from '@votingworks/test-utils';
 import { ContestOption } from '@votingworks/types';
@@ -41,51 +40,6 @@ test('candidate contest with write-ins', () => {
           expect(option.id).toEqual(
             contest.candidates[i]?.id ??
               `write-in-${i - contest.candidates.length}`
-          );
-          expect(option.contestId).toEqual(contest.id);
-          expect(option.name).toEqual(
-            contest.candidates[i]?.name ?? 'Write-In'
-          );
-          expect(option.isWriteIn).toEqual(i >= contest.candidates.length);
-          expect(option.writeInIndex).toEqual(
-            i >= contest.candidates.length
-              ? i - contest.candidates.length
-              : undefined
-          );
-        }
-      }
-    )
-  );
-});
-
-test('candidate contest with provided write-in IDs', () => {
-  fc.assert(
-    fc.property(
-      // Make a contest…
-      arbitraryCandidateContest({
-        allowWriteIns: fc.constant(true),
-      }).chain((contest) =>
-        // …and come up with IDs for the write-ins.
-        fc.tuple(
-          fc.array(arbitraryCandidateId(), {
-            minLength: contest.seats,
-            maxLength: contest.seats,
-          }),
-          fc.constant(contest)
-        )
-      ),
-      ([writeInOptionIds, contest]) => {
-        const options = Array.from(
-          allContestOptions(contest, writeInOptionIds)
-        );
-        expect(options).toHaveLength(
-          contest.candidates.length + writeInOptionIds.length
-        );
-        for (const [i, option] of options.entries()) {
-          assert(option.type === 'candidate');
-          expect(option.id).toEqual(
-            contest.candidates[i]?.id ??
-              writeInOptionIds[i - contest.candidates.length]
           );
           expect(option.contestId).toEqual(contest.id);
           expect(option.name).toEqual(

--- a/libs/utils/src/hmpb/all_contest_options.ts
+++ b/libs/utils/src/hmpb/all_contest_options.ts
@@ -5,8 +5,7 @@ import { throwIllegalValue } from '@votingworks/basics';
  * Enumerates all contest options in the order they would appear on a HMPB.
  */
 export function* allContestOptions(
-  contest: AnyContest,
-  writeInOptionIds?: readonly string[]
+  contest: AnyContest
 ): Generator<ContestOption> {
   switch (contest.type) {
     case 'candidate': {
@@ -21,28 +20,15 @@ export function* allContestOptions(
       }
 
       if (contest.allowWriteIns) {
-        if (writeInOptionIds?.length) {
-          for (const [writeInIndex, writeInId] of writeInOptionIds.entries()) {
-            yield {
-              type: 'candidate',
-              id: writeInId,
-              contestId: contest.id,
-              name: 'Write-In',
-              isWriteIn: true,
-              writeInIndex,
-            };
-          }
-        } else {
-          for (let i = 0; i < contest.seats; i += 1) {
-            yield {
-              type: 'candidate',
-              id: `write-in-${i}`,
-              contestId: contest.id,
-              name: 'Write-In',
-              isWriteIn: true,
-              writeInIndex: i,
-            };
-          }
+        for (let i = 0; i < contest.seats; i += 1) {
+          yield {
+            type: 'candidate',
+            id: `write-in-${i}`,
+            contestId: contest.id,
+            name: 'Write-In',
+            isWriteIn: true,
+            writeInIndex: i,
+          };
         }
       }
       break;

--- a/libs/utils/src/hmpb/all_contest_options.ts
+++ b/libs/utils/src/hmpb/all_contest_options.ts
@@ -1,6 +1,31 @@
-import { AnyContest, ContestOption } from '@votingworks/types';
 import { throwIllegalValue } from '@votingworks/basics';
+import {
+  AnyContest,
+  CandidateContest,
+  CandidateContestOption,
+  ContestOption,
+  YesNoContest,
+  YesNoContestOption,
+} from '@votingworks/types';
 
+/**
+ * Enumerates all contest options in the order they would appear on a HMPB.
+ */
+export function allContestOptions(
+  contest: CandidateContest
+): Generator<CandidateContestOption>;
+/**
+ * Enumerates all contest options in the order they would appear on a HMPB.
+ */
+export function allContestOptions(
+  contest: YesNoContest
+): Generator<YesNoContestOption>;
+/**
+ * Enumerates all contest options in the order they would appear on a HMPB.
+ */
+export function allContestOptions(
+  contest: AnyContest
+): Generator<ContestOption>;
 /**
  * Enumerates all contest options in the order they would appear on a HMPB.
  */


### PR DESCRIPTION
When we know the contest type we know the contest option type. This change encodes this knowledge in the type system.
