### PR TITLE
libs/fixture-generators: Fix bug when picking languages to translate

### DIFF
--- a/libs/fixture-generators/src/generate-election-package/generate_election_package.ts
+++ b/libs/fixture-generators/src/generate-election-package/generate_election_package.ts
@@ -53,7 +53,7 @@ export async function generateElectionPackage(
   );
 
   const ballotLanguageConfigs = getBallotLanguageConfigs(
-    Object.values(LanguageCode)
+    isMultiLanguage ? Object.values(LanguageCode) : [LanguageCode.ENGLISH]
   );
   const translator = new GoogleCloudTranslatorWithElectionCache({
     priorElectionPackage,


### PR DESCRIPTION

## Overview

Regression from https://github.com/votingworks/vxsuite/pull/6069 that caused all election fixtures to be generated with multiple languages instead of respecting the `isMultiLanguage` flag.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
