### PR TITLE
VxPollbook: System admin login

### DIFF
--- a/apps/pollbook/backend/src/index.ts
+++ b/apps/pollbook/backend/src/index.ts
@@ -40,7 +40,11 @@ function main(): Promise<number> {
         : new JavaCard(),
     config: {
       allowElectionManagersToAccessUnconfiguredMachines: true,
-      allowedUserRoles: ['election_manager', 'poll_worker'],
+      allowedUserRoles: [
+        'system_administrator',
+        'election_manager',
+        'poll_worker',
+      ],
     },
     logger: baseLogger,
   });

--- a/apps/pollbook/backend/src/pollbook_package.ts
+++ b/apps/pollbook/backend/src/pollbook_package.ts
@@ -8,6 +8,7 @@ import {
   getFileByName,
   readTextEntry,
   isElectionManagerAuth,
+  isSystemAdministratorAuth,
 } from '@votingworks/utils';
 import { join } from 'node:path';
 import { rootDebug } from './debug';
@@ -189,8 +190,13 @@ export function pollUsbDriveForPollbookPackage({
         const authStatus = await auth.getAuthStatus(
           constructAuthMachineState(workspace)
         );
-        if (!isElectionManagerAuth(authStatus)) {
-          usbDebug('Not logged in as election manager, not configuring');
+        if (
+          !isElectionManagerAuth(authStatus) &&
+          !isSystemAdministratorAuth(authStatus)
+        ) {
+          usbDebug(
+            'Not logged in as election manager or system admin, not configuring'
+          );
           return;
         }
 

--- a/apps/pollbook/backend/src/server.ts
+++ b/apps/pollbook/backend/src/server.ts
@@ -1,15 +1,22 @@
 import { useDevDockRouter } from '@votingworks/dev-dock-backend';
 import express from 'express';
 import { CITIZEN_THERMAL_PRINTER_CONFIG } from '@votingworks/printing';
+import { BaseLogger, Logger, LogSource } from '@votingworks/logging';
 import { buildApp } from './app';
 import { PORT } from './globals';
 import { AppContext } from './types';
+import { getUserRole } from './auth';
 
 /**
  * Starts the server.
  */
 export function start(context: AppContext): void {
-  const app = buildApp(context);
+  const baseLogger = new BaseLogger(LogSource.VxPollbookBackend);
+  const logger = Logger.from(baseLogger, () =>
+    getUserRole(context.auth, context.workspace)
+  );
+
+  const app = buildApp({ context, logger });
 
   useDevDockRouter(app, express, {
     printerConfig: CITIZEN_THERMAL_PRINTER_CONFIG,

--- a/apps/pollbook/frontend/src/api.ts
+++ b/apps/pollbook/frontend/src/api.ts
@@ -10,7 +10,10 @@ import {
 } from '@tanstack/react-query';
 import type { Api, VoterSearchParams } from '@votingworks/pollbook-backend';
 import { deepEqual } from '@votingworks/basics';
-import { AUTH_STATUS_POLLING_INTERVAL_MS } from '@votingworks/ui';
+import {
+  AUTH_STATUS_POLLING_INTERVAL_MS,
+  createSystemCallApi,
+} from '@votingworks/ui';
 
 export type ApiClient = grout.Client<Api>;
 
@@ -119,6 +122,18 @@ export const updateSessionExpiry = {
         // necessary
         await queryClient.invalidateQueries(getAuthStatus.queryKey());
       },
+    });
+  },
+} as const;
+
+export const getUsbDriveStatus = {
+  queryKey(): QueryKey {
+    return ['getUsbDriveStatus'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () => apiClient.getUsbDriveStatus(), {
+      refetchInterval: 1000,
     });
   },
 } as const;
@@ -350,3 +365,5 @@ export const exportVoterActivity = {
     return useMutation(apiClient.exportVoterActivity);
   },
 } as const;
+
+export const systemCallApi = createSystemCallApi(useApiClient);

--- a/apps/pollbook/frontend/src/app.tsx
+++ b/apps/pollbook/frontend/src/app.tsx
@@ -11,7 +11,11 @@ import { BrowserRouter } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { DevDock } from '@votingworks/dev-dock-frontend';
 import { assert } from '@votingworks/basics';
-import { isElectionManagerAuth, isPollWorkerAuth } from '@votingworks/utils';
+import {
+  isElectionManagerAuth,
+  isPollWorkerAuth,
+  isSystemAdministratorAuth,
+} from '@votingworks/utils';
 import { BaseLogger, LogSource } from '@votingworks/logging';
 import {
   ApiClient,
@@ -27,6 +31,7 @@ import { PollWorkerScreen } from './poll_worker_screen';
 import { UnconfiguredScreen } from './unconfigured_screen';
 import { MachineLockedScreen } from './machine_locked_screen';
 import { ElectionManagerScreen } from './election_manager_screen';
+import { SystemAdminScreen } from './system_admin_screen';
 
 function AppRoot(): JSX.Element | null {
   const getAuthStatusQuery = getAuthStatus.useQuery();
@@ -89,6 +94,10 @@ function AppRoot(): JSX.Element | null {
 
   if (election.isErr()) {
     return <UnconfiguredScreen />;
+  }
+
+  if (isSystemAdministratorAuth(auth)) {
+    return <SystemAdminScreen />;
   }
 
   if (isElectionManagerAuth(auth)) {

--- a/apps/pollbook/frontend/src/app.tsx
+++ b/apps/pollbook/frontend/src/app.tsx
@@ -31,7 +31,7 @@ import { PollWorkerScreen } from './poll_worker_screen';
 import { UnconfiguredScreen } from './unconfigured_screen';
 import { MachineLockedScreen } from './machine_locked_screen';
 import { ElectionManagerScreen } from './election_manager_screen';
-import { SystemAdminScreen } from './system_admin_screen';
+import { SystemAdministratorScreen } from './system_administrator_screen';
 
 function AppRoot(): JSX.Element | null {
   const getAuthStatusQuery = getAuthStatus.useQuery();
@@ -97,7 +97,7 @@ function AppRoot(): JSX.Element | null {
   }
 
   if (isSystemAdministratorAuth(auth)) {
-    return <SystemAdminScreen />;
+    return <SystemAdministratorScreen />;
   }
 
   if (isElectionManagerAuth(auth)) {

--- a/apps/pollbook/frontend/src/app.tsx
+++ b/apps/pollbook/frontend/src/app.tsx
@@ -5,6 +5,7 @@ import {
   InvalidCardScreen,
   RemoveCardScreen,
   SetupCardReaderPage,
+  SystemCallContextProvider,
   UnlockMachineScreen,
 } from '@votingworks/ui';
 import { BrowserRouter } from 'react-router-dom';
@@ -25,6 +26,7 @@ import {
   createQueryClient,
   getAuthStatus,
   getElection,
+  systemCallApi,
 } from './api';
 import { ErrorScreen } from './error_screen';
 import { PollWorkerScreen } from './poll_worker_screen';
@@ -124,9 +126,11 @@ export function App({
       <ErrorBoundary errorMessage={<ErrorScreen />} logger={logger}>
         <ApiClientContext.Provider value={apiClient}>
           <QueryClientProvider client={createQueryClient()}>
-            <BrowserRouter>
-              <AppRoot />
-            </BrowserRouter>
+            <SystemCallContextProvider api={systemCallApi}>
+              <BrowserRouter>
+                <AppRoot />
+              </BrowserRouter>
+            </SystemCallContextProvider>
           </QueryClientProvider>
         </ApiClientContext.Provider>
       </ErrorBoundary>

--- a/apps/pollbook/frontend/src/machine_locked_screen.tsx
+++ b/apps/pollbook/frontend/src/machine_locked_screen.tsx
@@ -33,11 +33,12 @@ export function MachineLockedScreen(): JSX.Element | null {
           <H3 style={{ fontWeight: 'normal' }}>
             {getElectionQuery.data.isOk() ? (
               <React.Fragment>
-                Insert election manager or poll worker card to unlock.
+                Insert system administrator, election manager, or poll worker
+                card to unlock.
               </React.Fragment>
             ) : (
               <React.Fragment>
-                Insert election manager card to unlock.
+                Insert system administrator or election manager card to unlock.
               </React.Fragment>
             )}
           </H3>

--- a/apps/pollbook/frontend/src/machine_locked_screen.tsx
+++ b/apps/pollbook/frontend/src/machine_locked_screen.tsx
@@ -1,6 +1,5 @@
 import { H1, H3, Main, Screen } from '@votingworks/ui';
 import styled from 'styled-components';
-import React from 'react';
 import { ElectionInfoBar } from './election_info_bar';
 import { getElection, getMachineConfig } from './api';
 import { DeviceStatusBar } from './nav_screen';
@@ -30,18 +29,7 @@ export function MachineLockedScreen(): JSX.Element | null {
         <div>
           <LockedImage src="/locked.svg" alt="Locked Icon" />
           <H1 align="center">VxPollbook Locked</H1>
-          <H3 style={{ fontWeight: 'normal' }}>
-            {getElectionQuery.data.isOk() ? (
-              <React.Fragment>
-                Insert system administrator, election manager, or poll worker
-                card to unlock.
-              </React.Fragment>
-            ) : (
-              <React.Fragment>
-                Insert system administrator or election manager card to unlock.
-              </React.Fragment>
-            )}
-          </H3>
+          <H3 style={{ fontWeight: 'normal' }}>Insert card to unlock.</H3>
         </div>
       </Main>
       <ElectionInfoBar

--- a/apps/pollbook/frontend/src/nav_screen.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.tsx
@@ -316,6 +316,43 @@ export function NavScreen({
   );
 }
 
+export const systemAdminRoutes = {
+  settings: { title: 'Settings', path: '/settings' },
+  voters: { title: 'Voters', path: '/voters' },
+} satisfies Record<string, { title: string; path: string }>;
+
+export function SystemAdminNavScreen({
+  title,
+  children,
+}: {
+  title: string | React.ReactNode;
+  children: React.ReactNode;
+}): JSX.Element {
+  const currentRoute = useRouteMatch();
+
+  return (
+    <NavScreen
+      navContent={
+        <NavList>
+          {Object.values(systemAdminRoutes).map((route) => (
+            <NavListItem key={route.path}>
+              <NavLink
+                to={route.path}
+                isActive={route.path === currentRoute.url}
+              >
+                {route.title}
+              </NavLink>
+            </NavListItem>
+          ))}
+        </NavList>
+      }
+    >
+      <Header>{typeof title === 'string' ? <H1>{title}</H1> : title}</Header>
+      {children}
+    </NavScreen>
+  );
+}
+
 export const electionManagerRoutes = {
   settings: { title: 'Settings', path: '/settings' },
   voters: { title: 'Voters', path: '/voters' },

--- a/apps/pollbook/frontend/src/nav_screen.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.tsx
@@ -317,8 +317,8 @@ export function NavScreen({
 }
 
 export const systemAdministratorRoutes = {
+  election: { title: 'Election', path: '/election' },
   settings: { title: 'Settings', path: '/settings' },
-  voters: { title: 'Voters', path: '/voters' },
 } satisfies Record<string, { title: string; path: string }>;
 
 export function SystemAdministratorNavScreen({

--- a/apps/pollbook/frontend/src/nav_screen.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.tsx
@@ -316,12 +316,12 @@ export function NavScreen({
   );
 }
 
-export const systemAdminRoutes = {
+export const systemAdministratorRoutes = {
   settings: { title: 'Settings', path: '/settings' },
   voters: { title: 'Voters', path: '/voters' },
 } satisfies Record<string, { title: string; path: string }>;
 
-export function SystemAdminNavScreen({
+export function SystemAdministratorNavScreen({
   title,
   children,
 }: {
@@ -334,7 +334,7 @@ export function SystemAdminNavScreen({
     <NavScreen
       navContent={
         <NavList>
-          {Object.values(systemAdminRoutes).map((route) => (
+          {Object.values(systemAdministratorRoutes).map((route) => (
             <NavListItem key={route.path}>
               <NavLink
                 to={route.path}

--- a/apps/pollbook/frontend/src/system_admin_screen.tsx
+++ b/apps/pollbook/frontend/src/system_admin_screen.tsx
@@ -1,0 +1,69 @@
+import {
+  Card,
+  H2,
+  MainContent,
+  P,
+  Seal,
+  UnconfigureMachineButton,
+} from '@votingworks/ui';
+import { assert } from '@votingworks/basics';
+import { format } from '@votingworks/utils';
+import { Redirect, Route, Switch } from 'react-router-dom';
+import { SystemAdminNavScreen, systemAdminRoutes } from './nav_screen';
+import { getElection, unconfigure } from './api';
+import { Column, FieldName, Row } from './layout';
+import { VotersScreen } from './voters_screen';
+
+export function SettingsScreen(): JSX.Element | null {
+  const getElectionQuery = getElection.useQuery();
+  const unconfigureMutation = unconfigure.useMutation();
+
+  assert(getElectionQuery.isSuccess);
+  const election = getElectionQuery.data.unsafeUnwrap();
+
+  return (
+    <SystemAdminNavScreen title="Settings">
+      <MainContent>
+        <Column style={{ gap: '1rem' }}>
+          <div data-testid="election-info">
+            <FieldName>Election</FieldName>
+            <Card color="neutral">
+              <Row style={{ gap: '1rem', alignItems: 'center' }}>
+                <Seal seal={election.seal} maxWidth="7rem" />
+                <div>
+                  <H2>{election.title}</H2>
+                  <P>
+                    {election.county.name}, {election.state}
+                    <br />
+                    {format.localeLongDate(
+                      election.date.toMidnightDatetimeWithSystemTimezone()
+                    )}
+                  </P>
+                </div>
+              </Row>
+            </Card>
+          </div>
+          <div>
+            <UnconfigureMachineButton
+              unconfigureMachine={() => unconfigureMutation.mutateAsync()}
+              isMachineConfigured
+            />
+          </div>
+        </Column>
+      </MainContent>
+    </SystemAdminNavScreen>
+  );
+}
+
+export function SystemAdminScreen(): JSX.Element {
+  return (
+    <Switch>
+      <Route
+        path={systemAdminRoutes.settings.path}
+        component={SettingsScreen}
+      />
+      <Route path={systemAdminRoutes.voters.path} component={VotersScreen} />
+      <Redirect to={systemAdminRoutes.settings.path} />
+    </Switch>
+  );
+}

--- a/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
+++ b/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
@@ -1,0 +1,96 @@
+import { describe, test, beforeEach, afterEach, vi } from 'vitest';
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { DippedSmartCardAuth } from '@votingworks/types';
+import {
+  mockSessionExpiresAt,
+  mockSystemAdministratorUser,
+} from '@votingworks/test-utils';
+// import { createMemoryHistory } from 'history';
+// import { mockUsbDriveStatus } from '@votingworks/ui';
+import userEvent from '@testing-library/user-event';
+import { screen } from '../test/react_testing_library';
+import { ApiMock, createApiMock } from '../test/mock_api_client';
+import { SystemAdministratorScreen } from './system_administrator_screen';
+import { renderInAppContext } from '../test/render_in_app_context';
+
+let apiMock: ApiMock;
+const electionFamousNames = electionFamousNames2021Fixtures.readElection();
+const auth: DippedSmartCardAuth.SystemAdministratorLoggedIn = {
+  status: 'logged_in',
+  user: mockSystemAdministratorUser(),
+  sessionExpiresAt: mockSessionExpiresAt(),
+  programmableCard: { status: 'no_card' },
+};
+
+let unmount: () => void;
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.clearAllMocks();
+  apiMock = createApiMock();
+  apiMock.setElection(electionFamousNames);
+  apiMock.expectGetMachineConfig();
+  apiMock.expectGetDeviceStatuses();
+});
+
+afterEach(() => {
+  apiMock.mockApiClient.assertComplete();
+  unmount();
+});
+
+describe('Election tab', () => {
+  test('basic render', async () => {
+    const renderResult = renderInAppContext(<SystemAdministratorScreen />, {
+      apiMock,
+      auth,
+    });
+    unmount = renderResult.unmount;
+
+    await screen.findByRole('heading', { name: 'Election' });
+  });
+});
+
+describe('Settings tab', () => {
+  async function renderSettingsTab() {
+    const renderResult = renderInAppContext(<SystemAdministratorScreen />, {
+      apiMock,
+      auth,
+    });
+    unmount = renderResult.unmount;
+
+    const settingsTabButton = await screen.findByRole('button', {
+      name: 'Settings',
+    });
+    userEvent.click(settingsTabButton);
+
+    await screen.findByRole('heading', { name: 'Settings' });
+  }
+
+  beforeEach(() => {
+    apiMock.expectGetUsbDriveStatus();
+  });
+
+  afterEach(() => {
+    unmount();
+  });
+
+  test('basic render', async () => {
+    await renderSettingsTab();
+  });
+
+  test('save logs button', async () => {
+    await renderSettingsTab();
+
+    // Full functionality tested in libs/ui/src/export_logs_modal.test.tsx
+    userEvent.click(screen.getByRole('button', { name: 'Save Logs' }));
+    await screen.findByRole('heading', { name: 'No USB Drive Detected' });
+  });
+
+  test('set date and time button', async () => {
+    await renderSettingsTab();
+
+    // Full functionality tested in libs/ui/src/set_clock.test.tsx
+    userEvent.click(screen.getByRole('button', { name: 'Set Date and Time' }));
+    await screen.findByRole('heading', { name: 'Set Date and Time' });
+  });
+});

--- a/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
+++ b/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
@@ -5,8 +5,6 @@ import {
   mockSessionExpiresAt,
   mockSystemAdministratorUser,
 } from '@votingworks/test-utils';
-// import { createMemoryHistory } from 'history';
-// import { mockUsbDriveStatus } from '@votingworks/ui';
 import userEvent from '@testing-library/user-event';
 import { screen } from '../test/react_testing_library';
 import { ApiMock, createApiMock } from '../test/mock_api_client';

--- a/apps/pollbook/frontend/src/system_administrator_screen.tsx
+++ b/apps/pollbook/frontend/src/system_administrator_screen.tsx
@@ -9,7 +9,10 @@ import {
 import { assert } from '@votingworks/basics';
 import { format } from '@votingworks/utils';
 import { Redirect, Route, Switch } from 'react-router-dom';
-import { SystemAdminNavScreen, systemAdminRoutes } from './nav_screen';
+import {
+  SystemAdministratorNavScreen,
+  systemAdministratorRoutes,
+} from './nav_screen';
 import { getElection, unconfigure } from './api';
 import { Column, FieldName, Row } from './layout';
 import { VotersScreen } from './voters_screen';
@@ -22,7 +25,7 @@ export function SettingsScreen(): JSX.Element | null {
   const election = getElectionQuery.data.unsafeUnwrap();
 
   return (
-    <SystemAdminNavScreen title="Settings">
+    <SystemAdministratorNavScreen title="Settings">
       <MainContent>
         <Column style={{ gap: '1rem' }}>
           <div data-testid="election-info">
@@ -51,19 +54,22 @@ export function SettingsScreen(): JSX.Element | null {
           </div>
         </Column>
       </MainContent>
-    </SystemAdminNavScreen>
+    </SystemAdministratorNavScreen>
   );
 }
 
-export function SystemAdminScreen(): JSX.Element {
+export function SystemAdministratorScreen(): JSX.Element {
   return (
     <Switch>
       <Route
-        path={systemAdminRoutes.settings.path}
+        path={systemAdministratorRoutes.settings.path}
         component={SettingsScreen}
       />
-      <Route path={systemAdminRoutes.voters.path} component={VotersScreen} />
-      <Redirect to={systemAdminRoutes.settings.path} />
+      <Route
+        path={systemAdministratorRoutes.voters.path}
+        component={VotersScreen}
+      />
+      <Redirect to={systemAdministratorRoutes.settings.path} />
     </Switch>
   );
 }

--- a/apps/pollbook/frontend/src/system_administrator_screen.tsx
+++ b/apps/pollbook/frontend/src/system_administrator_screen.tsx
@@ -16,7 +16,7 @@ import {
   systemAdministratorRoutes,
 } from './nav_screen';
 import { getElection, getUsbDriveStatus, logOut, unconfigure } from './api';
-import { Column, FieldName, Row } from './layout';
+import { Column, Row } from './layout';
 
 export function SettingsScreen(): JSX.Element | null {
   const logOutMutation = logOut.useMutation();
@@ -62,7 +62,6 @@ export function ElectionScreen(): JSX.Element | null {
       <MainContent>
         <Column style={{ gap: '1rem' }}>
           <div data-testid="election-info">
-            <FieldName>Election</FieldName>
             <Card color="neutral">
               <Row style={{ gap: '1rem', alignItems: 'center' }}>
                 <Seal seal={election.seal} maxWidth="7rem" />

--- a/apps/pollbook/frontend/src/system_administrator_screen.tsx
+++ b/apps/pollbook/frontend/src/system_administrator_screen.tsx
@@ -9,7 +9,6 @@ import {
   SetClockButton,
   UnconfigureMachineButton,
 } from '@votingworks/ui';
-import { assert } from '@votingworks/basics';
 import { format } from '@votingworks/utils';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import {
@@ -52,7 +51,10 @@ export function ElectionScreen(): JSX.Element | null {
   const getElectionQuery = getElection.useQuery();
   const unconfigureMutation = unconfigure.useMutation();
 
-  assert(getElectionQuery.isSuccess);
+  if (!getElectionQuery.isSuccess) {
+    return null;
+  }
+
   const election = getElectionQuery.data.unsafeUnwrap();
 
   return (

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -16,6 +16,7 @@ import {
   mockElectionManagerUser,
   mockPollWorkerUser,
   mockSessionExpiresAt,
+  mockSystemAdministratorUser,
 } from '@votingworks/test-utils';
 import { UsbDriveStatus } from '@votingworks/usb-drive';
 import { mockUsbDriveStatus } from '@votingworks/ui';
@@ -109,15 +110,16 @@ export function createApiMock() {
       });
     },
 
-    * TODO: System administrator user not yet supported
+    */
+
     authenticateAsSystemAdministrator() {
       setAuthStatus({
         status: 'logged_in',
         user: mockSystemAdministratorUser(),
         sessionExpiresAt: mockSessionExpiresAt(),
+        programmableCard: { status: 'ready' },
       });
-    }, 
-    */
+    },
 
     authenticateAsElectionManager(election: Election) {
       setAuthStatus({
@@ -148,6 +150,12 @@ export function createApiMock() {
 
     expectGetMachineConfig(): void {
       mockApiClient.getMachineConfig.expectCallWith().resolves(machineConfig);
+    },
+
+    expectGetUsbDriveStatus(usbDriveStatus?: UsbDriveStatus): void {
+      mockApiClient.getUsbDriveStatus
+        .expectRepeatedCallsWith()
+        .resolves(usbDriveStatus || { status: 'no_drive' });
     },
 
     expectGetDeviceStatuses(): void {
@@ -299,6 +307,15 @@ export function createApiMock() {
       mockApiClient.registerVoter
         .expectCallWith({ registrationData })
         .resolves(voter);
+    },
+
+    /**
+     * Sets an expectation that mockApiClient.unconfigure() will be called. You probably want to pair
+     * this with apiMock.setElection().
+     */
+    expectUnconfigureElection() {
+      mockApiClient.unconfigure.reset();
+      mockApiClient.unconfigure.expectCallWith().resolves();
     },
   };
 }

--- a/apps/pollbook/frontend/test/render_in_app_context.tsx
+++ b/apps/pollbook/frontend/test/render_in_app_context.tsx
@@ -1,0 +1,76 @@
+import { MachineConfig } from '@votingworks/pollbook-backend';
+import {
+  DippedSmartCardAuth,
+  ElectionDefinition,
+  Iso8601Timestamp,
+} from '@votingworks/types';
+import { SystemCallContextProvider, TestErrorBoundary } from '@votingworks/ui';
+import { UsbDriveStatus } from '@votingworks/usb-drive';
+import { createMemoryHistory, MemoryHistory } from 'history';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Router } from 'react-router-dom';
+import { render as testRender, RenderResult } from './react_testing_library';
+import { ApiMock } from './mock_api_client';
+import {
+  ApiClient,
+  ApiClientContext,
+  createQueryClient,
+  systemCallApi,
+} from '../src/api';
+
+export interface RenderInAppContextParams {
+  route?: string;
+  history?: MemoryHistory;
+  electionDefinition?: ElectionDefinition | null;
+  configuredAt?: Iso8601Timestamp;
+  isOfficialResults?: boolean;
+  usbDriveStatus?: UsbDriveStatus;
+  auth?: DippedSmartCardAuth.AuthStatus;
+  machineConfig?: MachineConfig;
+  hasPrinterAttached?: boolean;
+  apiMock?: ApiMock;
+  queryClient?: QueryClient;
+}
+
+export function renderRootElement(
+  component: React.ReactNode,
+  {
+    // If there's no apiClient given, we don't want to create one by default,
+    // since the apiClient needs to have assertComplete called by the test. If
+    // the test doesn't need to make API calls, then it should not pass in an
+    // apiClient here, which will cause an error if the test tries to make an
+    // API call.
+    apiClient,
+    queryClient = createQueryClient(),
+  }: {
+    apiClient?: ApiClient;
+    queryClient?: QueryClient;
+  } = {}
+): RenderResult {
+  return testRender(
+    <TestErrorBoundary>
+      <ApiClientContext.Provider value={apiClient}>
+        <QueryClientProvider client={queryClient}>
+          <SystemCallContextProvider api={systemCallApi}>
+            {component}
+          </SystemCallContextProvider>
+        </QueryClientProvider>
+      </ApiClientContext.Provider>
+    </TestErrorBoundary>
+  );
+}
+
+export function renderInAppContext(
+  component: React.ReactNode,
+  {
+    route = '/',
+    history = createMemoryHistory({ initialEntries: [route] }),
+    apiMock,
+    queryClient,
+  }: RenderInAppContextParams = {}
+): RenderResult {
+  return renderRootElement(<Router history={history}>{component}</Router>, {
+    apiClient: apiMock?.mockApiClient,
+    queryClient,
+  });
+}

--- a/apps/pollbook/frontend/vitest.config.ts
+++ b/apps/pollbook/frontend/vitest.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
 
     coverage: {
       thresholds: {
-        lines: 73,
-        branches: 51,
+        lines: 76,
+        branches: 52,
       },
       exclude: ['src/**/*.d.ts', 'src/index.tsx', 'src/stubs/*'],
     },

--- a/libs/logging/src/base_types/log_source.ts
+++ b/libs/logging/src/base_types/log_source.ts
@@ -23,6 +23,8 @@ export enum LogSource {
   VxBallotActivationService = 'vx-ballot-activation-service',
   VxScanService = 'vx-scan-service',
   VxDevelopmentScript = 'vx-development-script',
+  VxPollbookFrontend = 'vx-pollbook-frontend',
+  VxPollbookBackend = 'vx-pollbook-backend',
 }
 
 export enum AppName {


### PR DESCRIPTION
## Overview

Adds system administrator login and the following behavior.

* Election screen
  * configure/unconfigure
* Settings screen
  * Save logs
  * Date & Time

I'll open separate PRs for USB formatting and Secure Hash Validation.

## Demo Video or Screenshot
![Screenshot 2025-04-08 at 4 50 12 PM](https://github.com/user-attachments/assets/4ce66159-d477-432a-8b1f-9cc570a3c6d0)
![Screenshot 2025-04-08 at 4 50 20 PM](https://github.com/user-attachments/assets/b6842ce9-7e1e-4b9c-90b9-11ecb7b409ef)
![Screenshot 2025-04-08 at 4 50 24 PM](https://github.com/user-attachments/assets/60ce2b4a-a9e9-4002-b1f4-198d4c48effe)

**Configure and unconfigure election**

https://github.com/user-attachments/assets/f5b44f39-1083-4afa-a704-396ababe7ccc

**Settings Screen**

https://github.com/user-attachments/assets/c11dcb75-ad1e-451a-a046-0231b7cb9ac8




## Testing Plan
- [x] Add automated tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
