### PR TITLE
libs/ui: Add inverseWarningAccent color to themes

### DIFF
--- a/libs/types/src/ui_theme.ts
+++ b/libs/types/src/ui_theme.ts
@@ -77,6 +77,7 @@ export interface ColorTheme {
   readonly onInverse: ColorString;
   readonly inverseContainer: ColorString;
   readonly inversePrimary: ColorString;
+  readonly inverseWarningAccent: ColorString;
 
   readonly dangerAccent: ColorString;
   readonly warningAccent: ColorString;

--- a/libs/ui/src/icons.test.tsx
+++ b/libs/ui/src/icons.test.tsx
@@ -26,7 +26,7 @@ test(`Icon renders with color`, () => {
     danger: theme.colors.dangerAccent,
     inverse: theme.colors.onInverse,
     inversePrimary: theme.colors.inversePrimary,
-    inverseWarning: 'rgb(255 163 84)', // TODO #6167: Update to not use a hardcoded color, only used by VxPollbook
+    inverseWarning: theme.colors.inverseWarningAccent,
   };
 
   for (const [color, expectedColor] of Object.entries(expectedColors)) {

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -135,7 +135,7 @@ function iconColor(theme: UiTheme, color?: IconColor) {
     danger: colors.dangerAccent,
     inverse: colors.onInverse,
     inversePrimary: colors.inversePrimary,
-    inverseWarning: 'rgb(255 163 84)', // TODO #6167: Update to not use a hardcoded color, only used by VxPollbook
+    inverseWarning: colors.inverseWarningAccent,
     default: undefined,
   }[color];
 }

--- a/libs/ui/src/themes/color_theme.stories.tsx
+++ b/libs/ui/src/themes/color_theme.stories.tsx
@@ -406,7 +406,7 @@ export function ColorThemes(): JSX.Element {
               <span style={{ color: colors.dangerAccent, fontSize: '1.5rem' }}>
                 <Icons.Danger />
               </span>
-              Error Accent
+              Danger Accent
               <span style={{ color: colors.dangerAccent }}>
                 <ContrastTag />
               </span>
@@ -450,8 +450,72 @@ export function ColorThemes(): JSX.Element {
               <span style={{ color: colors.dangerAccent, fontSize: '1.5rem' }}>
                 <Icons.Danger />
               </span>
-              Error Accent
+              Danger Accent
               <span style={{ color: colors.dangerAccent }}>
+                <ContrastTag />
+              </span>
+            </Accent>
+          </div>
+        </RoundedRect>
+        <RoundedRect
+          style={{
+            fontWeight: '500',
+            background: colors.inverseBackground,
+            color: colors.onInverse,
+            border: outlineIfTouchscreen,
+          }}
+        >
+          <H4>On Inverse Background</H4>
+          <div
+            style={{
+              marginTop: '1rem',
+              display: 'flex',
+              justifyContent: 'space-between',
+            }}
+          >
+            <Accent>
+              <span
+                style={{
+                  color: colors.inverseWarningAccent,
+                  fontSize: '1.5rem',
+                }}
+              >
+                <Icons.Warning />
+              </span>
+              Inverse Warning Accent
+              <span style={{ color: colors.inverseWarningAccent }}>
+                <ContrastTag />
+              </span>
+            </Accent>
+          </div>
+        </RoundedRect>
+        <RoundedRect
+          style={{
+            fontWeight: '500',
+            background: colors.inverseContainer,
+            color: colors.onInverse,
+            border: outlineIfTouchscreen,
+          }}
+        >
+          <H4>On Inverse Container</H4>
+          <div
+            style={{
+              marginTop: '1rem',
+              display: 'flex',
+              justifyContent: 'space-between',
+            }}
+          >
+            <Accent>
+              <span
+                style={{
+                  color: colors.inverseWarningAccent,
+                  fontSize: '1.5rem',
+                }}
+              >
+                <Icons.Warning />
+              </span>
+              Inverse Warning Accent
+              <span style={{ color: colors.inverseWarningAccent }}>
                 <ContrastTag />
               </span>
             </Accent>

--- a/libs/ui/src/themes/make_theme.ts
+++ b/libs/ui/src/themes/make_theme.ts
@@ -191,6 +191,7 @@ function expandToFullColorTheme(theme: TouchscreenColorTheme): ColorTheme {
     onInverse: theme.background,
     inversePrimary: theme.background,
     inverseContainer: theme.onBackground,
+    inverseWarningAccent: theme.warningAccent,
 
     successAccent: theme.successAccent,
     warningAccent: theme.warningAccent,
@@ -262,6 +263,7 @@ export const colorThemes: Record<ColorMode, ColorTheme> = {
     onInverse: DesktopPalette.Gray0,
     inversePrimary: DesktopPalette.Purple30,
     inverseContainer: DesktopPalette.Gray80,
+    inverseWarningAccent: DesktopPalette.Orange30,
 
     successAccent: DesktopPalette.Green60,
     warningAccent: DesktopPalette.Orange50,


### PR DESCRIPTION

## Overview
Fixes: https://github.com/votingworks/vxsuite/issues/6167

Adds a new theme color `inverseWarningAccent`. Uses it for inverse warning icons (needed in VxPollbook).

## Demo Video or Screenshot

<img width="875" alt="Screenshot 2025-04-09 at 3 00 34 PM" src="https://github.com/user-attachments/assets/fc197451-9024-457e-8560-4760c612b7c5" />


## Testing Plan
Updated unit tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
