### PR TITLE
[VxDesign] Enable creation/export features for the 'Vx Demos' org

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -94,7 +94,7 @@ import { renderBallotStyleReadinessReport } from './ballot_style_reports';
 import { BALLOT_STYLE_READINESS_REPORT_FILE_NAME } from './app';
 import { join } from 'node:path';
 import { electionFeatureConfigs, userFeatureConfigs } from './features';
-import { sliOrgId } from './globals';
+import { sliOrgId, vxDemosOrgId } from './globals';
 import { LogEventId } from '@votingworks/logging';
 
 vi.setConfig({
@@ -2449,6 +2449,8 @@ test('v3-compatible election package', async () => {
 
 test('feature configs', async () => {
   const sliUser: User = { orgId: sliOrgId() };
+  const vxDemosUser: User = { orgId: vxDemosOrgId() };
+
   const { apiClient } = await setupApp();
   expect(await apiClient.getUserFeatures({ user: vxUser })).toEqual(
     userFeatureConfigs.vx
@@ -2458,6 +2460,9 @@ test('feature configs', async () => {
   );
   expect(await apiClient.getUserFeatures({ user: sliUser })).toEqual(
     userFeatureConfigs.sli
+  );
+  expect(await apiClient.getUserFeatures({ user: vxDemosUser })).toEqual(
+    userFeatureConfigs.demos
   );
 
   const vxElectionId = (
@@ -2481,6 +2486,13 @@ test('feature configs', async () => {
       orgId: sliUser.orgId,
     })
   ).unsafeUnwrap();
+  const vxDemosElectionId = (
+    await apiClient.createElection({
+      id: 'vx-demos-election-id' as ElectionId,
+      user: vxDemosUser,
+      orgId: vxDemosUser.orgId,
+    })
+  ).unsafeUnwrap();
   expect(
     await apiClient.getElectionFeatures({ electionId: vxElectionId })
   ).toEqual(electionFeatureConfigs.vx);
@@ -2490,6 +2502,9 @@ test('feature configs', async () => {
   expect(
     await apiClient.getElectionFeatures({ electionId: sliElectionId })
   ).toEqual(electionFeatureConfigs.sli);
+  expect(
+    await apiClient.getElectionFeatures({ electionId: vxDemosElectionId })
+  ).toEqual(electionFeatureConfigs.vx);
 });
 
 test('api method logging', async () => {

--- a/apps/design/backend/src/features.ts
+++ b/apps/design/backend/src/features.ts
@@ -1,4 +1,4 @@
-import { sliOrgId, votingWorksOrgId } from './globals';
+import { sliOrgId, votingWorksOrgId, vxDemosOrgId } from './globals';
 import { ElectionRecord } from './store';
 import { User } from './types';
 
@@ -134,6 +134,22 @@ export const userFeatureConfigs = {
     BALLOT_LANGUAGE_CONFIG: true,
   },
 
+  demos: {
+    ACCESS_ALL_ORGS: false,
+    SYSTEM_SETTINGS_SCREEN: true,
+    MARGINAL_MARK_THRESHOLD: false,
+    EXPORT_SCREEN: true,
+    CHOOSE_BALLOT_TEMPLATE: false,
+    EXPORT_TEST_DECKS: true,
+    ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
+    CREATE_ELECTION: true,
+    DELETE_ELECTION: true,
+    CREATE_DELETE_DISTRICTS: true,
+    CREATE_DELETE_PRECINCTS: true,
+    CREATE_DELETE_PRECINCT_SPLITS: true,
+    BALLOT_LANGUAGE_CONFIG: true,
+  },
+
   nh: {
     ACCESS_ALL_ORGS: false,
     SYSTEM_SETTINGS_SCREEN: false,
@@ -185,6 +201,9 @@ export function getUserFeaturesConfig(user: User): UserFeaturesConfig {
   if (user.orgId === sliOrgId()) {
     return userFeatureConfigs.sli;
   }
+  if (user.orgId === vxDemosOrgId()) {
+    return userFeatureConfigs.demos;
+  }
   return userFeatureConfigs.nh;
 }
 
@@ -196,6 +215,9 @@ export function getElectionFeaturesConfig(
   }
   if (election.orgId === sliOrgId()) {
     return electionFeatureConfigs.sli;
+  }
+  if (election.orgId === vxDemosOrgId()) {
+    return electionFeatureConfigs.vx;
   }
   return electionFeatureConfigs.nh;
 }

--- a/apps/design/backend/src/features.ts
+++ b/apps/design/backend/src/features.ts
@@ -139,7 +139,7 @@ export const userFeatureConfigs = {
     SYSTEM_SETTINGS_SCREEN: true,
     MARGINAL_MARK_THRESHOLD: false,
     EXPORT_SCREEN: true,
-    CHOOSE_BALLOT_TEMPLATE: false,
+    CHOOSE_BALLOT_TEMPLATE: true,
     EXPORT_TEST_DECKS: true,
     ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
     CREATE_ELECTION: true,

--- a/apps/design/backend/src/globals.ts
+++ b/apps/design/backend/src/globals.ts
@@ -111,6 +111,10 @@ export function sliOrgId(): string {
   return requiredProdEnvVar('ORG_ID_SLI', 'sli');
 }
 
+export function vxDemosOrgId(): string {
+  return requiredProdEnvVar('ORG_ID_VX_DEMOS', 'vx-demos');
+}
+
 /**
  * Where should the database go?
  */


### PR DESCRIPTION
## Overview

We've [recently set up](https://votingworks.slack.com/archives/C085YT4798C/p1744203568443159) a `Vx Demos` org to use for external demos and would like to be able to demo the full feature set of VxDesign without displaying the full list of orgs like we do on the `VotingWorks` support account.

Adding feature flag configuration for the demo org, with most features switched on.
Will be adding the org ID env variable in prod.

## Testing Plan
- Updated unit tests 
- Manual test with mock IDs

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
