### PR TITLE
[VxDesign] Resume grayscale PDF conversion for non-tinted NH ballots

### DIFF
--- a/apps/design/backend/src/worker/ballot_pdfs.test.ts
+++ b/apps/design/backend/src/worker/ballot_pdfs.test.ts
@@ -1,0 +1,66 @@
+import { expect, Mocked, test, vi } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { createReadStream, ReadStream } from 'node:fs';
+
+import {
+  BaseBallotProps,
+  ColorTints,
+  NhBallotProps,
+  RenderDocument,
+} from '@votingworks/hmpb';
+
+import { renderBallotPdf } from './ballot_pdfs';
+import { convertPdfToGrayscale } from './grayscale';
+
+vi.mock('./grayscale.js');
+
+test('renderBallotPdf - converts non-tinted ballots to grayscale', async () => {
+  const nhProps: NhBallotProps = {
+    colorTint: undefined,
+    precinctId: 'nh-precinct',
+  } as unknown as NhBallotProps;
+
+  const mockColorPdf = Buffer.of(0xca, 0xfe);
+  const mockDocument: Mocked<RenderDocument> = {
+    renderToPdf: vi.fn(() => mockColorPdf),
+  } as unknown as Mocked<RenderDocument>;
+
+  const mockGrayscalePdfNh: ReadStream = createReadStream('/dev/null');
+  vi.mocked(convertPdfToGrayscale).mockResolvedValueOnce(mockGrayscalePdfNh);
+
+  expect(await renderBallotPdf(nhProps, mockDocument)).toStrictEqual(
+    mockGrayscalePdfNh
+  );
+  expect(convertPdfToGrayscale).toHaveBeenCalledWith(mockColorPdf);
+
+  const nonNhProps: BaseBallotProps = {
+    precinctId: 'non-nh-precinct',
+  } as unknown as BaseBallotProps;
+
+  const mockGrayscalePdfNonNh: ReadStream = createReadStream('/dev/null');
+  vi.mocked(convertPdfToGrayscale).mockResolvedValueOnce(mockGrayscalePdfNonNh);
+
+  expect(await renderBallotPdf(nonNhProps, mockDocument)).toStrictEqual(
+    mockGrayscalePdfNonNh
+  );
+});
+
+test('renderBallotPdf - renders tinted NH ballots in color', async () => {
+  const nhProps: NhBallotProps = {
+    colorTint: ColorTints.YELLOW,
+    precinctId: 'nh-precinct',
+  } as unknown as NhBallotProps;
+
+  const mockColorPdf = Buffer.of(0xca, 0xfe);
+  const mockDocument: Mocked<RenderDocument> = {
+    renderToPdf: vi.fn(() => mockColorPdf),
+  } as unknown as Mocked<RenderDocument>;
+
+  vi.mocked(convertPdfToGrayscale).mockRejectedValue(
+    new Error('unexpected grayscale conversion')
+  );
+
+  expect(await renderBallotPdf(nhProps, mockDocument)).toStrictEqual(
+    mockColorPdf
+  );
+});

--- a/apps/design/backend/src/worker/ballot_pdfs.ts
+++ b/apps/design/backend/src/worker/ballot_pdfs.ts
@@ -1,0 +1,24 @@
+import { ReadStream } from 'node:fs';
+import { Buffer } from 'node:buffer';
+
+import { BaseBallotProps, RenderDocument } from '@votingworks/hmpb';
+
+import { convertPdfToGrayscale } from './grayscale';
+
+export async function renderBallotPdf(
+  props: BaseBallotProps,
+  document: RenderDocument
+): Promise<Buffer | ReadStream> {
+  /**
+   * Specific to NH V4 ballots with tinted headers/footers.
+   * See `import('@votingworks/hmpb').NhBallotProps`.
+   */
+  const needsColorPrint = 'colorTint' in props && !!props.colorTint;
+
+  const colorPdf = await document.renderToPdf();
+  if (needsColorPrint) {
+    return colorPdf;
+  }
+
+  return convertPdfToGrayscale(colorPdf);
+}

--- a/apps/design/backend/src/worker/grayscale.ts
+++ b/apps/design/backend/src/worker/grayscale.ts
@@ -1,0 +1,28 @@
+import { tmpNameSync } from 'tmp';
+import { promisify } from 'node:util';
+import { exec } from 'node:child_process';
+import { createReadStream, createWriteStream, ReadStream } from 'node:fs';
+import { Buffer } from 'node:buffer';
+
+/**
+ * Given a PDF document, convert it to grayscale and return a read stream to
+ * the resulting PDF.
+ */
+export async function convertPdfToGrayscale(pdf: Buffer): Promise<ReadStream> {
+  const tmpPdfFilePath = tmpNameSync();
+  const fileStream = createWriteStream(tmpPdfFilePath);
+  fileStream.write(pdf);
+  fileStream.end();
+  const tmpGrayscalePdfFilePath = tmpNameSync();
+  await promisify(exec)(`
+    gs \
+      -sOutputFile=${tmpGrayscalePdfFilePath} \
+      -sDEVICE=pdfwrite \
+      -sColorConversionStrategy=Gray \
+      -dProcessColorModel=/DeviceGray \
+      -dNOPAUSE \
+      -dBATCH \
+      ${tmpPdfFilePath}
+  `);
+  return createReadStream(tmpGrayscalePdfFilePath);
+}


### PR DESCRIPTION
## Overview

We recently added support for tinted headers/footers to v4 NH ballots, which removed the grayscale conversion for all v4 NH ballots. This resumes grayscale conversion for all ballots except tinted v4 NH ballots.

### Context

This is to remove the responsibility of color space conversion from the print service provider (and to avoid the potential waste of printing non-color content in color).

Most recent relevant thread: https://votingworks.slack.com/archives/C08B80X72LE/p1744290147068419
Ballot tinting task: https://github.com/votingworks/vxsuite/issues/6141

## Demo Video or Screenshot

| Non-Tinted  | Tinted |
| ------------- | ------------- |
| ![Screenshot 2025-04-10 at 14 33 56](https://github.com/user-attachments/assets/5a2ff3df-9095-48df-966b-843b9421e661) | ![Screenshot 2025-04-10 at 14 34 10](https://github.com/user-attachments/assets/7897f4c4-63f9-4afc-ac51-96ef3716f105) |

## Testing Plan
- Unit + manual

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
