### PR TITLE
[VxPollbook] System admins can format USB drives

### DIFF
--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -424,6 +424,24 @@ test('usbDrive', async () => {
   expect(await apiClient.formatUsbDrive()).toEqual(err(error));
 });
 
+test('usbDrive without proper auth', async () => {
+  const {
+    apiClient,
+    auth,
+    mockUsbDrive: { usbDrive },
+  } = buildTestEnvironment();
+  const electionDefinition =
+    electionTwoPartyPrimaryFixtures.readElectionDefinition();
+  await configureMachine(apiClient, auth, electionDefinition);
+
+  mockElectionManagerAuth(auth, electionDefinition.election);
+
+  usbDrive.format.expectCallWith().resolves();
+  (await apiClient.formatUsbDrive()).assertErr(
+    'Formatting USB drive requires system administrator auth.'
+  );
+});
+
 test('printer status', async () => {
   const { mockPrinterHandler, apiClient } = buildTestEnvironment();
 

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -40,6 +40,7 @@ import {
   getBallotCount,
   groupMapToGroupList,
   isIntegrationTest,
+  isSystemAdministratorAuth,
 } from '@votingworks/utils';
 import { dirSync } from 'tmp';
 import {
@@ -275,6 +276,15 @@ function buildApi({
     },
 
     async formatUsbDrive(): Promise<Result<void, Error>> {
+      const authStatus = await auth.getAuthStatus(
+        constructAuthMachineState(workspace)
+      );
+      if (!isSystemAdministratorAuth(authStatus)) {
+        return err(
+          new Error('Formatting USB drive requires system administrator auth.')
+        );
+      }
+
       try {
         await usbDrive.format();
         return ok();

--- a/apps/admin/frontend/src/screens/settings_screen.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import {
   CurrentDateAndTime,
   ExportLogsButton,
+  FormatUsbButton,
   H2,
   P,
   SetClockButton,
@@ -11,13 +12,13 @@ import { isSystemAdministratorAuth } from '@votingworks/utils';
 
 import { AppContext } from '../contexts/app_context';
 import { NavigationScreen } from '../components/navigation_screen';
-import { FormatUsbButton } from '../components/format_usb_modal';
-import { logOut, useApiClient } from '../api';
+import { formatUsbDrive, logOut, useApiClient } from '../api';
 
-export function SettingsScreen(): JSX.Element {
+export function SettingsScreen(): JSX.Element | null {
   const { auth, usbDriveStatus } = useContext(AppContext);
   const apiClient = useApiClient();
   const logOutMutation = logOut.useMutation();
+  const formatUsbDriveMutation = formatUsbDrive.useMutation();
 
   return (
     <NavigationScreen title="Settings">
@@ -35,7 +36,10 @@ export function SettingsScreen(): JSX.Element {
       {isSystemAdministratorAuth(auth) && (
         <React.Fragment>
           <H2>USB Formatting</H2>
-          <FormatUsbButton />
+          <FormatUsbButton
+            usbDriveStatus={usbDriveStatus}
+            formatUsbDriveMutation={formatUsbDriveMutation}
+          />
         </React.Fragment>
       )}
       <H2>Security</H2>

--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -13,7 +13,10 @@ import {
   Exporter,
   getBatteryInfo,
 } from '@votingworks/backend';
-import { generateFileTimeSuffix } from '@votingworks/utils';
+import {
+  generateFileTimeSuffix,
+  isSystemAdministratorAuth,
+} from '@votingworks/utils';
 import { stringify } from 'csv-stringify/sync';
 import { UsbDriveStatus } from '@votingworks/usb-drive';
 import { Logger } from '@votingworks/logging';
@@ -105,6 +108,15 @@ function buildApi({ context, logger }: BuildAppParams) {
     },
 
     async formatUsbDrive(): Promise<Result<void, Error>> {
+      const authStatus = await auth.getAuthStatus(
+        constructAuthMachineState(workspace)
+      );
+      if (!isSystemAdministratorAuth(authStatus)) {
+        return err(
+          new Error('Formatting USB drive requires system administrator auth.')
+        );
+      }
+
       try {
         await usbDrive.format();
         return ok();

--- a/apps/pollbook/frontend/src/api.ts
+++ b/apps/pollbook/frontend/src/api.ts
@@ -366,4 +366,11 @@ export const exportVoterActivity = {
   },
 } as const;
 
+export const formatUsbDrive = {
+  useMutation() {
+    const apiClient = useApiClient();
+    return useMutation(apiClient.formatUsbDrive);
+  },
+} as const;
+
 export const systemCallApi = createSystemCallApi(useApiClient);

--- a/apps/pollbook/frontend/src/machine_locked_screen.tsx
+++ b/apps/pollbook/frontend/src/machine_locked_screen.tsx
@@ -1,5 +1,6 @@
 import { H1, H3, Main, Screen } from '@votingworks/ui';
 import styled from 'styled-components';
+import React from 'react';
 import { ElectionInfoBar } from './election_info_bar';
 import { getElection, getMachineConfig } from './api';
 import { DeviceStatusBar } from './nav_screen';
@@ -29,7 +30,15 @@ export function MachineLockedScreen(): JSX.Element | null {
         <div>
           <LockedImage src="/locked.svg" alt="Locked Icon" />
           <H1 align="center">VxPollbook Locked</H1>
-          <H3 style={{ fontWeight: 'normal' }}>Insert card to unlock.</H3>
+          <H3 style={{ fontWeight: 'normal' }}>
+            {getElectionQuery.data.isOk() ? (
+              <React.Fragment>Insert card to unlock.</React.Fragment>
+            ) : (
+              <React.Fragment>
+                Insert system administrator or election manager card to unlock.
+              </React.Fragment>
+            )}
+          </H3>
         </div>
       </Main>
       <ElectionInfoBar

--- a/apps/pollbook/frontend/src/system_administrator_screen.tsx
+++ b/apps/pollbook/frontend/src/system_administrator_screen.tsx
@@ -2,6 +2,7 @@ import {
   Card,
   CurrentDateAndTime,
   ExportLogsButton,
+  FormatUsbButton,
   H2,
   MainContent,
   P,
@@ -15,12 +16,19 @@ import {
   SystemAdministratorNavScreen,
   systemAdministratorRoutes,
 } from './nav_screen';
-import { getElection, getUsbDriveStatus, logOut, unconfigure } from './api';
+import {
+  formatUsbDrive,
+  getElection,
+  getUsbDriveStatus,
+  logOut,
+  unconfigure,
+} from './api';
 import { Column, Row } from './layout';
 
 export function SettingsScreen(): JSX.Element | null {
   const logOutMutation = logOut.useMutation();
   const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
+  const formatUsbDriveMutation = formatUsbDrive.useMutation();
 
   if (!usbDriveStatusQuery.isSuccess) {
     return null;
@@ -41,6 +49,13 @@ export function SettingsScreen(): JSX.Element | null {
           <SetClockButton logOut={() => logOutMutation.mutate()}>
             Set Date and Time
           </SetClockButton>
+        </P>
+        <H2>USB</H2>
+        <P>
+          <FormatUsbButton
+            usbDriveStatus={usbDriveStatus}
+            formatUsbDriveMutation={formatUsbDriveMutation}
+          />
         </P>
       </MainContent>
     </SystemAdministratorNavScreen>

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -154,7 +154,7 @@ export function createApiMock() {
 
     expectGetUsbDriveStatus(usbDriveStatus?: UsbDriveStatus): void {
       mockApiClient.getUsbDriveStatus
-        .expectRepeatedCallsWith()
+        .expectOptionalRepeatedCallsWith()
         .resolves(usbDriveStatus || { status: 'no_drive' });
     },
 

--- a/apps/pollbook/frontend/test/render_in_app_context.tsx
+++ b/apps/pollbook/frontend/test/render_in_app_context.tsx
@@ -1,11 +1,4 @@
-import { MachineConfig } from '@votingworks/pollbook-backend';
-import {
-  DippedSmartCardAuth,
-  ElectionDefinition,
-  Iso8601Timestamp,
-} from '@votingworks/types';
 import { SystemCallContextProvider, TestErrorBoundary } from '@votingworks/ui';
-import { UsbDriveStatus } from '@votingworks/usb-drive';
 import { createMemoryHistory, MemoryHistory } from 'history';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Router } from 'react-router-dom';
@@ -21,13 +14,6 @@ import {
 export interface RenderInAppContextParams {
   route?: string;
   history?: MemoryHistory;
-  electionDefinition?: ElectionDefinition | null;
-  configuredAt?: Iso8601Timestamp;
-  isOfficialResults?: boolean;
-  usbDriveStatus?: UsbDriveStatus;
-  auth?: DippedSmartCardAuth.AuthStatus;
-  machineConfig?: MachineConfig;
-  hasPrinterAttached?: boolean;
   apiMock?: ApiMock;
   queryClient?: QueryClient;
 }

--- a/libs/ui/src/format_usb_modal.test.tsx
+++ b/libs/ui/src/format_usb_modal.test.tsx
@@ -46,7 +46,7 @@ test('formatting', async () => {
   );
   userEvent.click(screen.getButton('Format USB Drive'));
   await screen.findByText(
-    'USB drive successfully formatted and ejected. It can now be used with VxSuite components.'
+    'USB drive successfully formatted and ejected. It can now be used with VotingWorks components.'
   );
   expect(mockMutate).toHaveBeenCalledOnce();
 });

--- a/libs/ui/src/format_usb_modal.test.tsx
+++ b/libs/ui/src/format_usb_modal.test.tsx
@@ -1,0 +1,79 @@
+import { expect, test, vi } from 'vitest';
+import { ok, Result } from '@votingworks/basics';
+import {
+  QueryClient,
+  QueryClientProvider,
+  useMutation,
+} from '@tanstack/react-query';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '../test/react_testing_library';
+import { FormatUsbButton, FormatUsbButtonProps } from './format_usb_modal';
+import { mockUsbDriveStatus } from './test-utils/mock_usb_drive';
+import { QUERY_CLIENT_DEFAULT_OPTIONS } from './react_query';
+
+const mockMutate = vi
+  .fn<() => Promise<Result<void, Error>>>()
+  .mockResolvedValue(ok());
+
+const queryClient = new QueryClient({
+  defaultOptions: QUERY_CLIENT_DEFAULT_OPTIONS,
+});
+
+function MockComponent({
+  usbDriveStatus,
+}: Omit<FormatUsbButtonProps, 'formatUsbDriveMutation'>): JSX.Element {
+  const mutation = useMutation(mockMutate);
+
+  return (
+    <FormatUsbButton
+      usbDriveStatus={usbDriveStatus}
+      formatUsbDriveMutation={mutation}
+    />
+  );
+}
+
+test('formatting', async () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MockComponent usbDriveStatus={mockUsbDriveStatus('error')} />
+    </QueryClientProvider>
+  );
+
+  userEvent.click(screen.getButton('Format USB Drive'));
+  await screen.findByRole('heading', { name: 'Format USB Drive' });
+  screen.getByText(
+    'Formatting will delete all files on the USB drive. Back up USB drive files before formatting.'
+  );
+  userEvent.click(screen.getButton('Format USB Drive'));
+  await screen.findByText(
+    'USB drive successfully formatted and ejected. It can now be used with VxSuite components.'
+  );
+  expect(mockMutate).toHaveBeenCalledOnce();
+});
+
+test('modal open and close', async () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MockComponent usbDriveStatus={mockUsbDriveStatus('error')} />
+    </QueryClientProvider>
+  );
+
+  userEvent.click(screen.getButton('Format USB Drive'));
+  await screen.findByRole('heading', { name: 'Format USB Drive' });
+  userEvent.click(screen.getButton('Close'));
+  expect(
+    screen.queryByRole('heading', { name: 'Format USB Drive' })
+  ).toBeNull();
+});
+
+test('already-formatted usb drives', async () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MockComponent usbDriveStatus={mockUsbDriveStatus('mounted')} />
+    </QueryClientProvider>
+  );
+
+  userEvent.click(screen.getButton('Format USB Drive'));
+  await screen.findByRole('heading', { name: 'Format USB Drive' });
+  screen.getByText('already compatible');
+});

--- a/libs/ui/src/format_usb_modal.tsx
+++ b/libs/ui/src/format_usb_modal.tsx
@@ -45,14 +45,14 @@ function FormatUsbFlow({
               {usbDriveStatus.status === 'error' ? (
                 <P>
                   The format of the inserted USB drive is{' '}
-                  <Font weight="semiBold">not compatible</Font> with VxSuite
+                  <Font weight="semiBold">not compatible</Font> with VotingWorks
                   components.
                 </P>
               ) : (
                 <P>
                   The format of the inserted USB drive is{' '}
-                  <Font weight="semiBold">already compatible</Font> with VxSuite
-                  components.
+                  <Font weight="semiBold">already compatible</Font> with
+                  VotingWorks components.
                 </P>
               )}
               <P>

--- a/libs/ui/src/format_usb_modal.tsx
+++ b/libs/ui/src/format_usb_modal.tsx
@@ -82,7 +82,7 @@ function FormatUsbFlow({
           content={
             <P>
               USB drive successfully formatted and ejected. It can now be used
-              with VxSuite components.
+              with VotingWorks components.
             </P>
           }
           onOverlayClick={onClose}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -93,6 +93,7 @@ export * from './export_logs_modal';
 export * from './task_screen';
 export * from './types';
 export * from './unconfigured_election_screen';
+export * from './format_usb_modal';
 export * from './usb_drive';
 export * from './usb_drive_image';
 export * from './power_down_button';


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6234

* reverts to previous copy for unconfigured screen https://github.com/votingworks/vxsuite/pull/6254#issuecomment-2794707175
* factors out `FormatUsbButton` to `libs/ui`
* adds usage of `FormatUsbButton` to VxPollbook
* deletes some unused params in `apps/pollbook` test helpers


## Demo Video or Screenshot

https://github.com/user-attachments/assets/aa1cf5a4-dd0b-4c43-aa4f-23ad4cf251e5

## Testing Plan
- added tests to `libs/ui` and boundary tests to `apps/pollbook`

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
