### PR TITLE
refactor(admin): simplify adjudication APIs

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -75,7 +75,6 @@ import {
   ScannerBatch,
   WriteInAdjudicationAction,
   WriteInAdjudicationQueueMetadata,
-  WriteInAdjudicationStatus,
   WriteInCandidateRecord,
   WriteInAdjudicationContext,
   WriteInImageView,
@@ -639,27 +638,23 @@ function buildApi({
       adjudicateCvrContest(input, store, logger);
     },
 
-    getVoteAdjudications(
-      input: {
-        contestId?: ContestId;
-        cvrId?: Id;
-      } = {}
-    ): VoteAdjudication[] {
+    getVoteAdjudications(input: {
+      contestId: ContestId;
+      cvrId: Id;
+    }): VoteAdjudication[] {
       return store.getVoteAdjudications({
-        ...input,
         electionId: loadCurrentElectionIdOrThrow(workspace),
+        contestId: input.contestId,
+        cvrId: input.cvrId,
       });
     },
 
-    getWriteInAdjudicationQueueMetadata(
-      input: {
-        contestId?: ContestId;
-        status?: WriteInAdjudicationStatus;
-      } = {}
-    ): WriteInAdjudicationQueueMetadata[] {
+    getWriteInAdjudicationQueueMetadata(input: {
+      contestId: ContestId;
+    }): WriteInAdjudicationQueueMetadata[] {
       return store.getWriteInAdjudicationQueueMetadata({
         electionId: loadCurrentElectionIdOrThrow(workspace),
-        ...input,
+        contestId: input.contestId,
       });
     },
 
@@ -711,24 +706,15 @@ function buildApi({
       });
     },
 
-    getWriteInAdjudicationCvrQueue(
-      input: {
-        contestId?: ContestId;
-      } = {}
-    ): Id[] {
+    getWriteInAdjudicationCvrQueue(input: { contestId: ContestId }): Id[] {
       return store.getWriteInAdjudicationCvrQueue({
-        ...input,
         electionId: loadCurrentElectionIdOrThrow(workspace),
+        contestId: input.contestId,
       });
     },
 
-    getWriteInAdjudicationCvrQueueMetadata(
-      input: {
-        contestId?: ContestId;
-      } = {}
-    ): WriteInAdjudicationQueueMetadata[] {
+    getWriteInAdjudicationCvrQueueMetadata(): WriteInAdjudicationQueueMetadata[] {
       return store.getWriteInAdjudicationCvrQueueMetadata({
-        ...input,
         electionId: loadCurrentElectionIdOrThrow(workspace),
       });
     },

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { deepEqual } from '@votingworks/basics';
+import { deepEqual, fail } from '@votingworks/basics';
 import type { Api } from '@votingworks/admin-backend';
 import {
   AUTH_STATUS_POLLING_INTERVAL_MS,
@@ -276,12 +276,10 @@ export const getWriteInAdjudicationQueue = {
 type GetWriteInAdjudicationCvrQueueInput =
   QueryInput<'getWriteInAdjudicationCvrQueue'>;
 export const getWriteInAdjudicationCvrQueue = {
-  queryKey(input?: GetWriteInAdjudicationCvrQueueInput): QueryKey {
-    return input
-      ? ['getWriteInAdjudicationCvrQueue', input]
-      : ['getWriteInAdjudicationCvrQueue'];
+  queryKey(input: GetWriteInAdjudicationCvrQueueInput): QueryKey {
+    return ['getWriteInAdjudicationCvrQueue', input];
   },
-  useQuery(input: GetWriteInAdjudicationQueueInput) {
+  useQuery(input: GetWriteInAdjudicationCvrQueueInput) {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(input), () =>
       apiClient.getWriteInAdjudicationCvrQueue(input)
@@ -289,18 +287,14 @@ export const getWriteInAdjudicationCvrQueue = {
   },
 } as const;
 
-type GetWriteInAdjudicationCvrQueueMetadataInput =
-  QueryInput<'getWriteInAdjudicationCvrQueueMetadata'>;
 export const getWriteInAdjudicationCvrQueueMetadata = {
-  queryKey(input?: GetWriteInAdjudicationCvrQueueMetadataInput): QueryKey {
-    return input
-      ? ['getWriteInAdjudicationCvrQueueMetadata', input]
-      : ['getWriteInAdjudicationCvrQueueMetadata'];
+  queryKey(): QueryKey {
+    return ['getWriteInAdjudicationCvrQueueMetadata'];
   },
-  useQuery(input?: GetWriteInAdjudicationCvrQueueMetadataInput) {
+  useQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(input), () =>
-      apiClient.getWriteInAdjudicationCvrQueueMetadata(input)
+    return useQuery(this.queryKey(), () =>
+      apiClient.getWriteInAdjudicationCvrQueueMetadata()
     );
   },
 } as const;
@@ -352,7 +346,7 @@ export const getWriteInAdjudicationQueueMetadata = {
       ? ['getWriteInAdjudicationQueueMetadata', input]
       : ['getWriteInAdjudicationQueueMetadata'];
   },
-  useQuery(input?: GetWriteInAdjudicationQueueMetadataInput) {
+  useQuery(input: GetWriteInAdjudicationQueueMetadataInput) {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(input), () =>
       apiClient.getWriteInAdjudicationQueueMetadata(input)
@@ -485,7 +479,9 @@ export const getVoteAdjudications = {
     const apiClient = useApiClient();
     return useQuery(
       this.queryKey(input),
-      () => apiClient.getVoteAdjudications(input),
+      input
+        ? () => apiClient.getVoteAdjudications(input)
+        : () => fail('input is required'),
       { enabled: !!input, keepPreviousData: true }
     );
   },

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
@@ -337,13 +337,13 @@ export function ContestAdjudicationScreen(): JSX.Element {
     currentCvrId ? { cvrId: currentCvrId } : undefined
   );
   const voteAdjudicationsQuery = getVoteAdjudications.useQuery(
-    currentCvrId ? { cvrId: currentCvrId, contestId } : undefined
+    currentCvrId ? { cvrId: currentCvrId, contestId: contest.id } : undefined
   );
   const writeInsQuery = getWriteIns.useQuery(
-    currentCvrId ? { cvrId: currentCvrId, contestId } : undefined
+    currentCvrId ? { cvrId: currentCvrId, contestId: contest.id } : undefined
   );
   const writeInImagesQuery = getCvrWriteInImageViews.useQuery(
-    currentCvrId ? { cvrId: currentCvrId, contestId } : undefined
+    currentCvrId ? { cvrId: currentCvrId, contestId: contest.id } : undefined
   );
   const writeInCandidatesQuery = getWriteInCandidates.useQuery({
     contestId: contest.id,

--- a/apps/admin/frontend/src/screens/write_ins_summary_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/write_ins_summary_screen.test.tsx
@@ -33,7 +33,7 @@ beforeEach(() => {
 });
 
 test('No CVRs loaded', async () => {
-  apiMock.expectGetWriteInAdjudicationQueueMetadata([]);
+  apiMock.expectGetWriteInAdjudicationQueueMetadata([], 'zoo-council-mammal');
   apiMock.expectGetCastVoteRecordFiles([]);
   renderInAppContext(<WriteInsSummaryScreen />, {
     electionDefinition,
@@ -57,7 +57,7 @@ test('Tally results already marked as official', async () => {
       pendingTally: 5,
       totalTally: 5,
     },
-  ]);
+  ], 'zoo-council-mammal');
   apiMock.expectGetCastVoteRecordFiles([]);
   renderInAppContext(<WriteInsSummaryScreen />, {
     electionDefinition,
@@ -80,7 +80,7 @@ test('CVRs with write-ins loaded', async () => {
       pendingTally: 3,
       totalTally: 3,
     },
-  ]);
+  ], 'zoo-council-mammal');
   apiMock.expectGetCastVoteRecordFiles([]);
   const history = createMemoryHistory();
   renderInAppContext(<WriteInsSummaryScreen />, {

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -320,19 +320,13 @@ export function createApiMock(
 
     expectGetWriteInAdjudicationQueueMetadata(
       queueMetadata: WriteInAdjudicationQueueMetadata[],
-      contestId?: ContestId
+      contestId: ContestId
     ) {
-      if (contestId) {
-        apiClient.getWriteInAdjudicationQueueMetadata
-          .expectCallWith({
-            contestId,
-          })
-          .resolves(queueMetadata);
-      } else {
-        apiClient.getWriteInAdjudicationQueueMetadata
-          .expectCallWith()
-          .resolves(queueMetadata);
-      }
+      apiClient.getWriteInAdjudicationQueueMetadata
+        .expectCallWith({
+          contestId,
+        })
+        .resolves(queueMetadata);
     },
 
     expectGetWriteInAdjudicationQueue(writeInIds: Id[], contestId?: string) {


### PR DESCRIPTION
_This started as some comments on #6210, but became unwieldy._

There were a few APIs that were made to take optional `input` with optional properties, but the client never actually needed that optionality. Similarly, `getWriteInAdjudicationCvrQueueMetadata` took an optional `contestId` parameter that was never provided. This complicated the Grout API and also the `Store` methods, but without providing actual benefit.
