### PR TITLE
style(clippy): disable `nursery` lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,5 +64,4 @@ dead_code = "deny"
 
 [workspace.lints.clippy]
 pedantic = { level = "deny", priority = -1 }
-nursery = { level = "deny", priority = -1 }
 unwrap_used = "deny"

--- a/libs/ballot-interpreter/src/hmpb-rust/qr_code/detect.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/qr_code/detect.rs
@@ -140,8 +140,6 @@ impl Detected {
     }
 
     /// The areas of the image that were searched for QR codes.
-    // I believe `clippy` is mistaken in thinking this function can be `const`.
-    #[allow(clippy::missing_const_for_fn)]
     pub fn detection_areas(&self) -> &[Rect] {
         &self.detection_areas
     }
@@ -164,8 +162,6 @@ pub enum Error {
 }
 
 impl Error {
-    // I believe `clippy` is mistaken in thinking this function can be `const`.
-    #[allow(clippy::missing_const_for_fn)]
     fn detection_areas(&self) -> &[Rect] {
         match self {
             Self::DecodeFailed {

--- a/libs/logging/bacon.toml
+++ b/libs/logging/bacon.toml
@@ -24,8 +24,6 @@ command = [
     "-W",
     "clippy::pedantic",
     "-W",
-    "clippy::nursery",
-    "-W",
     "clippy::unwrap_used",
     "-A",
     "clippy::cast-possible-truncation",

--- a/libs/pdi-scanner/bacon.toml
+++ b/libs/pdi-scanner/bacon.toml
@@ -15,7 +15,7 @@ need_stdout = false
 watch = ["tests", "benches", "examples"]
 
 [jobs.clippy]
-command = ["cargo", "clippy", "--color", "always", "--", "-W", "clippy::pedantic", "-W", "clippy::nursery", "-W", "clippy::unwrap_used", "-A", "clippy::cast-possible-truncation", "-A", "clippy::cast-possible-wrap"]
+command = ["cargo", "clippy", "--color", "always", "--", "-W", "clippy::pedantic", "-W", "clippy::unwrap_used", "-A", "clippy::cast-possible-truncation", "-A", "clippy::cast-possible-wrap"]
 need_stdout = false
 
 [jobs.clippy-all]


### PR DESCRIPTION
Per the Rust Programming Language Community Discord, `clippy::nursery` lints are not really ready for prime time.

https://discord.com/channels/273534239310479360/1120124565591425034/1361808848448655510

![CleanShot 2025-04-15 at 14 07 02@2x](https://github.com/user-attachments/assets/55d9df50-91d9-457d-8f62-39e609316f17)
