### PR TITLE
VxAdmin: only allow loading `.zip` files in production

### DIFF
--- a/apps/admin/frontend/src/config/globals.ts
+++ b/apps/admin/frontend/src/config/globals.ts
@@ -1,1 +1,15 @@
+import { unsafeParse } from '@votingworks/types';
+import { z } from 'zod';
+
 export const TIME_FORMAT = 'MM/dd/yyyy hh:mm:ss a';
+
+const NodeEnvSchema = z.union([
+  z.literal('development'),
+  z.literal('test'),
+  z.literal('production'),
+]);
+
+export const NODE_ENV = unsafeParse(
+  NodeEnvSchema,
+  process.env.NODE_ENV ?? 'development'
+);

--- a/apps/admin/frontend/src/screens/tally/import_cvrfiles_modal.tsx
+++ b/apps/admin/frontend/src/screens/tally/import_cvrfiles_modal.tsx
@@ -33,7 +33,7 @@ import {
   CastVoteRecordFilePreprocessedData,
   InputEventFunction,
 } from '../../config/types';
-import { TIME_FORMAT } from '../../config/globals';
+import { NODE_ENV, TIME_FORMAT } from '../../config/globals';
 import {
   addCastVoteRecordFile,
   getCastVoteRecordFileMode,
@@ -354,7 +354,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
         onOverlayClick={onClose}
         actions={
           <React.Fragment>
-            {window.kiosk && process.env.NODE_ENV === 'development' && (
+            {window.kiosk && NODE_ENV === 'development' && (
               <FileInputButton
                 data-testid="manual-input"
                 onChange={processCastVoteRecordFileFromFilePicker}

--- a/apps/admin/frontend/src/screens/unconfigured_screen.tsx
+++ b/apps/admin/frontend/src/screens/unconfigured_screen.tsx
@@ -16,7 +16,7 @@ import { Loading } from '../components/loading';
 import { NavigationScreen } from '../components/navigation_screen';
 import { configure, listPotentialElectionPackagesOnUsbDrive } from '../api';
 import { AppContext } from '../contexts/app_context';
-import { TIME_FORMAT } from '../config/globals';
+import { NODE_ENV, TIME_FORMAT } from '../config/globals';
 
 const ButtonRow = styled.tr`
   cursor: pointer;
@@ -40,7 +40,12 @@ function SelectElectionPackage({
   async function onSelectOtherFile() {
     const dialogResult = await assertDefined(window.kiosk).showOpenDialog({
       properties: ['openFile'],
-      filters: [{ name: '', extensions: ['zip', 'json'] }],
+      filters: [
+        {
+          name: '',
+          extensions: NODE_ENV === 'development' ? ['zip', 'json'] : ['zip'],
+        },
+      ],
     });
     if (dialogResult.canceled) return;
     const selectedPath = dialogResult.filePaths[0];


### PR DESCRIPTION
## Overview

Closes #6064. Restricts loading VxAdmin from an election definition `.json` file to development. 

## Testing Plan

Tested manually & test written.

file selector in development:
<img width="1024" alt="Screenshot 2025-04-16 at 9 39 27 AM" src="https://github.com/user-attachments/assets/931e5ea4-0173-44d9-842a-c23d3aaa2ca8" />


file selector outside of development
<img width="1023" alt="Screenshot 2025-04-16 at 9 39 00 AM" src="https://github.com/user-attachments/assets/af4d8710-ab6f-4fde-9b2c-7fb8c5508f9a" />
