### PR TITLE
VxDesign: Cleanup precinct handling code

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -350,7 +350,7 @@ test('create/list/delete elections', async () => {
       contests: election2Contests,
       electionType: election2.type,
       parties: election2Parties,
-      precincts: election2Precincts,
+      precincts: [...election2Precincts],
     })
   );
   expect(

--- a/apps/design/backend/src/ballots.test.ts
+++ b/apps/design/backend/src/ballots.test.ts
@@ -21,11 +21,6 @@ const election: Election = {
   ...electionGridLayoutNewHampshireHudsonFixtures.readElection(),
   state: UsState.NEW_HAMPSHIRE,
 };
-const precincts = election.precincts.map((p) => ({
-  districtIds: [election.districts[0].id],
-  id: p.id,
-  name: p.name,
-}));
 const ballotStyles = election.ballotStyles.map((b) => ({
   districtIds: b.districts,
   group_id: b.groupId,
@@ -44,7 +39,6 @@ test('compact templates', () => {
     const propLists = createBallotPropsForTemplate(
       templateId,
       election,
-      precincts,
       ballotStyles
     );
     for (const props of propLists) {
@@ -60,7 +54,6 @@ test('compact templates', () => {
     const propLists = createBallotPropsForTemplate(
       templateId,
       election,
-      precincts,
       ballotStyles
     );
     for (const props of propLists) {
@@ -94,9 +87,8 @@ test('formatElectionForExport', () => {
   ];
 
   const formattedElection = formatElectionForExport(
-    election,
-    testTranslations,
-    testPrecincts
+    { ...election, precincts: testPrecincts },
+    testTranslations
   );
   expect(formattedElection).toHaveProperty('additionalHashInput');
   const hashInput = assertDefined(formattedElection.additionalHashInput);

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -3,7 +3,6 @@ import {
   hasSplits,
   PrecinctSplit,
   PrecinctWithSplits,
-  Precinct,
   UiStringsPackage,
 } from '@votingworks/types';
 import {
@@ -55,10 +54,9 @@ export function defaultBallotTemplate(
 
 export function formatElectionForExport(
   election: Election,
-  ballotStrings: UiStringsPackage,
-  precincts: Precinct[]
+  ballotStrings: UiStringsPackage
 ): Election {
-  const splitPrecincts = precincts.filter((p) => hasSplits(p));
+  const splitPrecincts = election.precincts.filter((p) => hasSplits(p));
 
   const signatureImageBySplit = splitPrecincts.flatMap((p) =>
     p.splits.flatMap((split) =>
@@ -106,11 +104,10 @@ const colorTints: ColorTintRecord[] = parse(colorTintsCsv, { columns: true });
 export function createBallotPropsForTemplate(
   templateId: BallotTemplateId,
   election: Election,
-  precincts: Precinct[],
   ballotStyles: BallotStyle[]
 ): BaseBallotProps[] {
   function buildNhBallotProps(props: BaseBallotProps): NhBallotProps {
-    const precinct = find(precincts, (p) => p.id === props.precinctId);
+    const precinct = find(election.precincts, (p) => p.id === props.precinctId);
     if (!hasSplits(precinct)) {
       return props;
     }

--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -32,7 +32,7 @@ export type { BallotTemplateId } from '@votingworks/hmpb';
 
 // Frontend tests import these for generating test data
 export { generateBallotStyles } from './ballot_styles';
-export { createBlankElection, convertVxfPrecincts } from './app';
+export { createBlankElection } from './app';
 
 loadEnvVarsFromDotenvFiles();
 

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -53,7 +53,6 @@ import { Bindable, Client } from './db/client';
 export interface ElectionRecord {
   orgId: string;
   election: Election;
-  precincts: Precinct[];
   ballotStyles: BallotStyle[];
   systemSettings: SystemSettings;
   ballotOrderInfo: BallotOrderInfo;
@@ -754,7 +753,6 @@ export class Store {
   async createElection(
     orgId: string,
     election: Election,
-    precincts: Precinct[],
     ballotTemplateId: BallotTemplateId,
     systemSettings = DEFAULT_SYSTEM_SETTINGS
   ): Promise<void> {
@@ -810,7 +808,7 @@ export class Store {
         for (const district of election.districts) {
           await insertDistrict(client, election.id, district);
         }
-        for (const precinct of precincts) {
+        for (const precinct of election.precincts) {
           await insertPrecinct(client, election.id, precinct);
         }
         for (const party of election.parties) {
@@ -971,9 +969,9 @@ export class Store {
     assert(rowCount === 1, 'District not found');
   }
 
-  async listPrecincts(electionId: ElectionId): Promise<Precinct[]> {
-    const { precincts } = await this.getElection(electionId);
-    return precincts;
+  async listPrecincts(electionId: ElectionId): Promise<readonly Precinct[]> {
+    const { election } = await this.getElection(electionId);
+    return election.precincts;
   }
 
   async createPrecinct(

--- a/apps/design/backend/src/utils.ts
+++ b/apps/design/backend/src/utils.ts
@@ -38,10 +38,7 @@ export function generateId(): string {
  * Regenerate the IDs of all entities in an election, ensuring that all
  * references are updated.
  */
-export function regenerateElectionIds(
-  election: Election,
-  precincts: Precinct[]
-): {
+export function regenerateElectionIds(election: Election): {
   districts: District[];
   precincts: Precinct[];
   parties: Party[];
@@ -59,7 +56,7 @@ export function regenerateElectionIds(
     ...district,
     id: replaceId(district.id),
   }));
-  const updatedPrecincts = precincts.map((precinct) => {
+  const precincts = election.precincts.map((precinct) => {
     if (hasSplits(precinct)) {
       return {
         ...precinct,
@@ -116,7 +113,7 @@ export function regenerateElectionIds(
   }));
   return {
     districts,
-    precincts: updatedPrecincts,
+    precincts,
     parties,
     contests,
   };

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -96,7 +96,6 @@ export async function generateElectionPackageAndBallots(
     ballotLanguageConfigs,
     election,
     systemSettings,
-    precincts,
     ballotStyles,
     ballotTemplateId,
     orgId,
@@ -120,8 +119,7 @@ export async function generateElectionPackageAndBallots(
       election,
       translator,
       hmpbStringsCatalog,
-      ballotLanguageConfigs,
-      precincts
+      ballotLanguageConfigs
     );
 
   electionPackageZip.file(
@@ -130,16 +128,11 @@ export async function generateElectionPackageAndBallots(
   );
   const ballotStrings = mergeUiStrings(electionStrings, hmpbStrings);
 
-  const formattedElection = formatElectionForExport(
-    election,
-    ballotStrings,
-    precincts
-  );
+  const formattedElection = formatElectionForExport(election, ballotStrings);
 
   const allBallotProps = createBallotPropsForTemplate(
     ballotTemplateId,
     formattedElection,
-    precincts,
     ballotStyles
   );
 

--- a/apps/design/backend/src/worker/generate_test_decks.ts
+++ b/apps/design/backend/src/worker/generate_test_decks.ts
@@ -39,7 +39,6 @@ export async function generateTestDecks(
   const {
     election,
     ballotLanguageConfigs,
-    precincts,
     ballotStyles,
     ballotTemplateId,
     orgId,
@@ -49,18 +48,12 @@ export async function generateTestDecks(
     translator,
     election,
     hmpbStringsCatalog,
-    ballotLanguageConfigs,
-    precincts
+    ballotLanguageConfigs
   );
-  const formattedElection = formatElectionForExport(
-    election,
-    ballotStrings,
-    precincts
-  );
+  const formattedElection = formatElectionForExport(election, ballotStrings);
   const allBallotProps = createBallotPropsForTemplate(
     ballotTemplateId,
     formattedElection,
-    precincts,
     ballotStyles
   );
   const testBallotProps = allBallotProps.filter(

--- a/apps/design/frontend/src/ballot_screen.test.tsx
+++ b/apps/design/frontend/src/ballot_screen.test.tsx
@@ -24,7 +24,7 @@ import { BallotScreen } from './ballot_screen';
 const electionRecord = generalElectionRecord(user.orgId);
 const electionId = electionRecord.election.id;
 const ballotStyle = electionRecord.ballotStyles[0];
-const precinct = electionRecord.precincts[0];
+const precinct = electionRecord.election.precincts[0];
 
 function MockDocument({
   children,
@@ -70,7 +70,7 @@ beforeEach(() => {
     .resolves(electionRecord.ballotStyles);
   apiMock.listPrecincts
     .expectCallWith({ electionId })
-    .resolves(electionRecord.precincts);
+    .resolves(electionRecord.election.precincts);
   apiMock.getElectionInfo
     .expectCallWith({ electionId })
     .resolves(electionInfoFromElection(electionRecord.election));

--- a/apps/design/frontend/src/ballots_screen.test.tsx
+++ b/apps/design/frontend/src/ballots_screen.test.tsx
@@ -49,7 +49,7 @@ function expectElectionApiCalls(electionRecord: ElectionRecord) {
     .resolves(electionRecord.ballotStyles);
   apiMock.listPrecincts
     .expectCallWith({ electionId })
-    .resolves(electionRecord.precincts);
+    .resolves(electionRecord.election.precincts);
   apiMock.getElectionInfo
     .expectCallWith({ electionId })
     .resolves(electionInfoFromElection(electionRecord.election));
@@ -89,8 +89,8 @@ describe('Ballot styles tab', () => {
     ).toEqual([
       ['Center Springfield', '1_en', 'View Ballot'],
       ['North Springfield', '', ''],
-      ['North Springfield - Split 1', '1_en', 'View Ballot'],
-      ['North Springfield - Split 2', '2_en', 'View Ballot'],
+      ['North Springfield - Split 1', '2_en', 'View Ballot'],
+      ['North Springfield - Split 2', '1_en', 'View Ballot'],
       ['South Springfield', 'No contests assigned', ''],
     ]);
   });
@@ -166,8 +166,8 @@ describe('Ballot styles tab', () => {
     ).toEqual([
       ['Center Springfield', 'No contests assigned', ''],
       ['North Springfield', '', ''],
-      ['North Springfield - Split 1', 'No contests assigned', ''],
-      ['North Springfield - Split 2', '2_en', 'View Ballot'],
+      ['North Springfield - Split 1', '2_en', 'View Ballot'],
+      ['North Springfield - Split 2', 'No contests assigned', ''],
       ['South Springfield', 'No contests assigned', ''],
     ]);
   });

--- a/apps/design/frontend/src/geography_screen.test.tsx
+++ b/apps/design/frontend/src/geography_screen.test.tsx
@@ -248,7 +248,7 @@ describe('Districts tab', () => {
 });
 
 describe('Precincts tab', () => {
-  const { election, precincts } = generalElectionRecord(user.orgId);
+  const { election } = generalElectionRecord(user.orgId);
   const electionId = election.id;
 
   beforeEach(() => {
@@ -328,10 +328,10 @@ describe('Precincts tab', () => {
       election: { ...general.election, state: 'New Hampshire' },
     };
     // eslint-disable-next-line @typescript-eslint/no-shadow
-    const { election, precincts } = nhElectionRecord;
+    const { election } = nhElectionRecord;
     // eslint-disable-next-line @typescript-eslint/no-shadow
     const electionId = election.id;
-    const savedPrecinct = precincts[0];
+    const savedPrecinct = election.precincts[0];
     assert(!hasSplits(savedPrecinct));
 
     const sealImage =
@@ -369,7 +369,9 @@ describe('Precincts tab', () => {
       PRECINCT_SPLIT_ELECTION_SEAL_OVERRIDE: true,
       PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE: true,
     });
-    apiMock.listPrecincts.expectCallWith({ electionId }).resolves(precincts);
+    apiMock.listPrecincts
+      .expectCallWith({ electionId })
+      .resolves(election.precincts);
     apiMock.listDistricts
       .expectCallWith({ electionId })
       .resolves(election.districts);
@@ -379,7 +381,9 @@ describe('Precincts tab', () => {
     userEvent.click(screen.getByRole('tab', { name: 'Precincts' }));
     await screen.findByText(savedPrecinct.name);
     const rows = screen.getAllByRole('row');
-    expect(rows).toHaveLength(precincts.length + 2 /* precinct splits */ + 1);
+    expect(rows).toHaveLength(
+      election.precincts.length + 2 /* precinct splits */ + 1
+    );
 
     const savedPrecinctRow = screen
       .getByText(savedPrecinct.name)
@@ -514,7 +518,7 @@ describe('Precincts tab', () => {
       .resolves();
     apiMock.listPrecincts
       .expectCallWith({ electionId })
-      .resolves([changedPrecinct, ...precincts.slice(1)]);
+      .resolves([changedPrecinct, ...election.precincts.slice(1)]);
     // Districts haven't changed, but we are using coarse-grained invalidation
     apiMock.listDistricts
       .expectCallWith({ electionId })
@@ -523,7 +527,7 @@ describe('Precincts tab', () => {
 
     await screen.findByRole('heading', { name: 'Geography' });
     expect(screen.getAllByRole('row')).toHaveLength(
-      precincts.length + 4 /* precinct splits */ + 1
+      election.precincts.length + 4 /* precinct splits */ + 1
     );
     const changedPrecinctRow = screen
       .getByText(changedPrecinct.name)
@@ -546,7 +550,7 @@ describe('Precincts tab', () => {
   });
 
   test('editing a precinct - removing splits', async () => {
-    const savedPrecinct = precincts.find(hasSplits)!;
+    const savedPrecinct = election.precincts.find(hasSplits)!;
     assert(savedPrecinct.splits.length === 2);
 
     const changedPrecinct: PrecinctWithoutSplits = {
@@ -556,7 +560,9 @@ describe('Precincts tab', () => {
     };
 
     mockElectionFeatures(apiMock, electionId, {});
-    apiMock.listPrecincts.expectCallWith({ electionId }).resolves(precincts);
+    apiMock.listPrecincts
+      .expectCallWith({ electionId })
+      .resolves(election.precincts);
     apiMock.listDistricts
       .expectCallWith({ electionId })
       .resolves(election.districts);
@@ -590,7 +596,7 @@ describe('Precincts tab', () => {
     });
     screen.getByRole('checkbox', {
       name: election.districts[1].name,
-      checked: false,
+      checked: true,
     });
     screen.getByRole('checkbox', {
       name: election.districts[2].name,
@@ -603,7 +609,7 @@ describe('Precincts tab', () => {
     apiMock.listPrecincts
       .expectCallWith({ electionId })
       .resolves(
-        precincts.map((p) =>
+        election.precincts.map((p) =>
           p.id === changedPrecinct.id ? changedPrecinct : p
         )
       );
@@ -614,7 +620,9 @@ describe('Precincts tab', () => {
     userEvent.type(screen.getByLabelText('Name'), '{enter}');
 
     await screen.findByRole('heading', { name: 'Geography' });
-    expect(screen.getAllByRole('row')).toHaveLength(precincts.length + 1);
+    expect(screen.getAllByRole('row')).toHaveLength(
+      election.precincts.length + 1
+    );
     const changedPrecinctRow = screen
       .getByText(changedPrecinct.name)
       .closest('tr')!;
@@ -622,15 +630,17 @@ describe('Precincts tab', () => {
       within(changedPrecinctRow)
         .getAllByRole('cell')
         .map((td) => td.textContent)
-    ).toEqual([changedPrecinct.name, election.districts[0].name, 'Edit']);
+    ).toEqual([changedPrecinct.name, 'District 1, District 2', 'Edit']);
   });
 
   test('deleting a precinct', async () => {
-    assert(precincts.length === 3);
-    const [savedPrecinct] = precincts;
+    assert(election.precincts.length === 3);
+    const [savedPrecinct] = election.precincts;
 
     mockElectionFeatures(apiMock, electionId, {});
-    apiMock.listPrecincts.expectCallWith({ electionId }).resolves(precincts);
+    apiMock.listPrecincts
+      .expectCallWith({ electionId })
+      .resolves(election.precincts);
     apiMock.listDistricts
       .expectCallWith({ electionId })
       .resolves(election.districts);
@@ -655,7 +665,7 @@ describe('Precincts tab', () => {
       .resolves();
     apiMock.listPrecincts
       .expectCallWith({ electionId })
-      .resolves(precincts.slice(1));
+      .resolves(election.precincts.slice(1));
     // Districts haven't changed, but we are using coarse-grained invalidation
     apiMock.listDistricts
       .expectCallWith({ electionId })
@@ -667,7 +677,7 @@ describe('Precincts tab', () => {
 
     await screen.findByRole('heading', { name: 'Geography' });
     expect(screen.getAllByRole('row')).toHaveLength(
-      precincts.length + 2 /* precinct splits */
+      election.precincts.length + 2 /* precinct splits */
     );
     expect(screen.queryByText(savedPrecinct.name)).not.toBeInTheDocument();
   });
@@ -677,7 +687,9 @@ describe('Precincts tab', () => {
     apiMock.getBallotsFinalizedAt
       .expectCallWith({ electionId })
       .resolves(new Date());
-    apiMock.listPrecincts.expectCallWith({ electionId }).resolves(precincts);
+    apiMock.listPrecincts
+      .expectCallWith({ electionId })
+      .resolves(election.precincts);
     apiMock.listDistricts
       .expectCallWith({ electionId })
       .resolves(election.districts);
@@ -685,14 +697,16 @@ describe('Precincts tab', () => {
 
     await screen.findByRole('heading', { name: 'Geography' });
     userEvent.click(screen.getByRole('tab', { name: 'Precincts' }));
-    await screen.findByText(precincts[0].name);
+    await screen.findByText(election.precincts[0].name);
     expect(screen.getAllByRole('button', { name: 'Edit' })[0]).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Add Precinct' })).toBeDisabled();
   });
 
   test('cancelling', async () => {
     mockElectionFeatures(apiMock, electionId, {});
-    apiMock.listPrecincts.expectCallWith({ electionId }).resolves(precincts);
+    apiMock.listPrecincts
+      .expectCallWith({ electionId })
+      .resolves(election.precincts);
     apiMock.listDistricts
       .expectCallWith({ electionId })
       .resolves(election.districts);

--- a/apps/design/frontend/test/fixtures.ts
+++ b/apps/design/frontend/test/fixtures.ts
@@ -28,13 +28,12 @@ export function makeElectionRecord(
   const ballotLanguageConfigs: BallotLanguageConfigs = [
     { languages: [LanguageCode.ENGLISH] },
   ];
-  const precincts = [...baseElection.precincts];
   const ballotStyles = generateBallotStyles({
     ballotLanguageConfigs,
     contests: baseElection.contests,
     electionType: baseElection.type,
     parties: baseElection.parties,
-    precincts,
+    precincts: [...baseElection.precincts],
   });
   const election: Election = {
     ...baseElection,
@@ -50,7 +49,6 @@ export function makeElectionRecord(
     election,
     systemSettings: DEFAULT_SYSTEM_SETTINGS,
     ballotOrderInfo: {},
-    precincts,
     ballotStyles,
     createdAt: new Date().toISOString(),
     ballotLanguageConfigs,

--- a/apps/design/frontend/test/fixtures.ts
+++ b/apps/design/frontend/test/fixtures.ts
@@ -5,7 +5,6 @@ import type {
 } from '@votingworks/design-backend';
 import {
   createBlankElection,
-  convertVxfPrecincts,
   generateBallotStyles,
 } from '@votingworks/design-backend';
 import {
@@ -29,7 +28,7 @@ export function makeElectionRecord(
   const ballotLanguageConfigs: BallotLanguageConfigs = [
     { languages: [LanguageCode.ENGLISH] },
   ];
-  const precincts = convertVxfPrecincts(baseElection);
+  const precincts = [...baseElection.precincts];
   const ballotStyles = generateBallotStyles({
     ballotLanguageConfigs,
     contests: baseElection.contests,

--- a/libs/backend/src/language_and_audio/ballot_strings.test.ts
+++ b/libs/backend/src/language_and_audio/ballot_strings.test.ts
@@ -41,8 +41,7 @@ describe('translateBallotStrings', () => {
       mockTranslator,
       election,
       mockHmpbStringsCatalog,
-      englishOnlyConfig,
-      [...election.precincts]
+      englishOnlyConfig
     );
 
     expect(result).toBeDefined();
@@ -62,8 +61,7 @@ describe('translateBallotStrings', () => {
       mockTranslator,
       election,
       mockHmpbStringsCatalog,
-      allOtherBallotLanguages,
-      [...election.precincts]
+      allOtherBallotLanguages
     );
 
     expect(result).toBeDefined();

--- a/libs/backend/src/language_and_audio/ballot_strings.ts
+++ b/libs/backend/src/language_and_audio/ballot_strings.ts
@@ -19,7 +19,7 @@ import { setUiString } from './utils';
  * @returns A catalog of strings defined by the user in VxDesign.
  */
 export function getUserDefinedHmpbStrings(
-  precincts: Precinct[]
+  precincts: readonly Precinct[]
 ): Record<string, string> {
   const catalog: Record<string, string> = {};
   for (const precinct of precincts) {
@@ -81,13 +81,12 @@ export async function translateElectionAndHmpbStrings(
   translator: GoogleCloudTranslator,
   election: Election,
   hmpbStringsCatalog: Record<string, string>,
-  ballotLanguageConfigs: BallotLanguageConfigs,
-  precincts: Precinct[]
+  ballotLanguageConfigs: BallotLanguageConfigs
 ): Promise<{
   electionStrings: UiStringsPackage;
   hmpbStrings: UiStringsPackage;
 }> {
-  const userDefinedHmpbStrings = getUserDefinedHmpbStrings(precincts);
+  const userDefinedHmpbStrings = getUserDefinedHmpbStrings(election.precincts);
   const combinedHmpbStringsCatalog: Record<string, string> = {
     ...hmpbStringsCatalog,
     ...userDefinedHmpbStrings,
@@ -118,7 +117,6 @@ export async function translateBallotStrings(
     Election,
     Record<string, string>,
     BallotLanguageConfigs,
-    Precinct[],
   ]
 ): Promise<UiStringsPackage> {
   const { electionStrings, hmpbStrings } =

--- a/libs/backend/src/language_and_audio/election_package_string.test.ts
+++ b/libs/backend/src/language_and_audio/election_package_string.test.ts
@@ -30,8 +30,7 @@ describe('getAllStringsForElectionPackage', () => {
         election,
         mockTranslator,
         mockHmpbStringsCatalog,
-        allBallotLanguages,
-        [...election.precincts]
+        allBallotLanguages
       );
 
     expect(appStrings).toBeDefined();

--- a/libs/backend/src/language_and_audio/election_package_strings.ts
+++ b/libs/backend/src/language_and_audio/election_package_strings.ts
@@ -1,7 +1,6 @@
 import {
   BallotLanguageConfigs,
   Election,
-  Precinct,
   UiStringsPackage,
 } from '@votingworks/types';
 import { GoogleCloudTranslator } from './translator';
@@ -16,16 +15,14 @@ export async function getAllStringsForElectionPackage(
   election: Election,
   translator: GoogleCloudTranslator,
   hmpbStringsCatalog: Record<string, string>,
-  ballotLanguageConfigs: BallotLanguageConfigs,
-  precincts: Precinct[]
+  ballotLanguageConfigs: BallotLanguageConfigs
 ): Promise<[UiStringsPackage, UiStringsPackage, UiStringsPackage]> {
   const { hmpbStrings, electionStrings } =
     await translateElectionAndHmpbStrings(
       translator,
       election,
       hmpbStringsCatalog,
-      ballotLanguageConfigs,
-      precincts
+      ballotLanguageConfigs
     );
 
   const appStrings = await translateAppStrings(

--- a/libs/fixture-generators/src/generate-election-package/generate_election_package.test.ts
+++ b/libs/fixture-generators/src/generate-election-package/generate_election_package.test.ts
@@ -77,8 +77,7 @@ describe('fixtures are up to date - run `pnpm generate-election-packages` if thi
             isMultiLanguage
               ? Object.values(LanguageCode)
               : [LanguageCode.ENGLISH]
-          ),
-          [...baseElection.precincts]
+          )
         );
       const newCombinedStrings = mergeUiStrings(
         newAppStrings,

--- a/libs/fixture-generators/src/generate-election-package/generate_election_package.ts
+++ b/libs/fixture-generators/src/generate-election-package/generate_election_package.ts
@@ -63,8 +63,7 @@ export async function generateElectionPackage(
       election,
       translator,
       hmpbStringsCatalog,
-      ballotLanguageConfigs,
-      [...election.precincts]
+      ballotLanguageConfigs
     );
 
   zip.file(


### PR DESCRIPTION
## Overview

#6298 combines the precinct types for VxDesign and the rest of VxSuite, which means VxDesign no longer needs to pass precincts around separately from the election object. This PR cleans up a bunch of that extra logic to avoid confusion in the future.

## Demo Video or Screenshot
N/A

## Testing Plan
Updated existing tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
