### PR TITLE
Generalize identifier for programming machine cert on Java Cards in prep for VxPollBook-programmed cards

### DIFF
--- a/libs/auth/scripts/src/configure_java_card.ts
+++ b/libs/auth/scripts/src/configure_java_card.ts
@@ -19,8 +19,8 @@ import {
   JavaCard,
   MAX_NUM_INCORRECT_PIN_ATTEMPTS,
   OPEN_FIPS_201_AID,
+  PROGRAMMING_MACHINE_CERT_AUTHORITY_CERT,
   PUK,
-  VX_ADMIN_CERT_AUTHORITY_CERT,
 } from '../../src/java_card';
 import {
   construct8BytePinBuffer,
@@ -236,7 +236,9 @@ async function runAppletConfigurationCommands(): Promise<void> {
     // Configure data object slots
     configureDataObjectSlotCommandApdu(CARD_VX_CERT.OBJECT_ID),
     configureDataObjectSlotCommandApdu(CARD_IDENTITY_CERT.OBJECT_ID),
-    configureDataObjectSlotCommandApdu(VX_ADMIN_CERT_AUTHORITY_CERT.OBJECT_ID),
+    configureDataObjectSlotCommandApdu(
+      PROGRAMMING_MACHINE_CERT_AUTHORITY_CERT.OBJECT_ID
+    ),
     ...GENERIC_STORAGE_SPACE.OBJECT_IDS.map((objectId) =>
       configureDataObjectSlotCommandApdu(objectId)
     ),

--- a/libs/auth/scripts/src/program_production_system_administrator_java_card_without_vx_admin.ts
+++ b/libs/auth/scripts/src/program_production_system_administrator_java_card_without_vx_admin.ts
@@ -59,9 +59,9 @@ async function instantiateJavaCardWithOneOffVxAdminPrivateKeyAndCertAuthorityCer
 
   const card = new JavaCard({
     cardProgrammingConfig: {
-      configType: 'vx_admin',
-      vxAdminCertAuthorityCertPath,
-      vxAdminPrivateKey: { source: 'file', path: vxAdminPrivateKeyPath },
+      configType: 'machine',
+      machineCertAuthorityCertPath: vxAdminCertAuthorityCertPath,
+      machinePrivateKey: { source: 'file', path: vxAdminPrivateKeyPath },
     },
     vxCertAuthorityCertPath: PROD_VX_CERT_AUTHORITY_CERT_PATH,
   });

--- a/libs/auth/src/config.test.ts
+++ b/libs/auth/src/config.test.ts
@@ -41,11 +41,11 @@ test.each<{
     machineType: 'admin',
     expectedOutput: {
       cardProgrammingConfig: {
-        configType: 'vx_admin',
-        vxAdminCertAuthorityCertPath: expect.stringContaining(
+        configType: 'machine',
+        machineCertAuthorityCertPath: expect.stringContaining(
           '/certs/dev/vx-admin-cert-authority-cert.pem'
         ),
-        vxAdminPrivateKey: {
+        machinePrivateKey: {
           source: 'file',
           path: expect.stringContaining('/certs/dev/vx-admin-private-key.pem'),
         },
@@ -69,10 +69,10 @@ test.each<{
     machineType: 'admin',
     expectedOutput: {
       cardProgrammingConfig: {
-        configType: 'vx_admin',
-        vxAdminCertAuthorityCertPath:
+        configType: 'machine',
+        machineCertAuthorityCertPath:
           '/vx/config/vx-admin-cert-authority-cert.pem',
-        vxAdminPrivateKey: { source: 'tpm' },
+        machinePrivateKey: { source: 'tpm' },
       },
       vxCertAuthorityCertPath: expect.stringContaining(
         '/certs/prod/vx-cert-authority-cert.pem'
@@ -94,11 +94,11 @@ test.each<{
     machineType: 'admin',
     expectedOutput: {
       cardProgrammingConfig: {
-        configType: 'vx_admin',
-        vxAdminCertAuthorityCertPath: expect.stringContaining(
+        configType: 'machine',
+        machineCertAuthorityCertPath: expect.stringContaining(
           '/certs/dev/vx-admin-cert-authority-cert.pem'
         ),
-        vxAdminPrivateKey: {
+        machinePrivateKey: {
           source: 'file',
           path: expect.stringContaining('/certs/dev/vx-admin-private-key.pem'),
         },
@@ -124,11 +124,11 @@ test.each<{
     machineType: 'admin',
     expectedOutput: {
       cardProgrammingConfig: {
-        configType: 'vx_admin',
-        vxAdminCertAuthorityCertPath: expect.stringContaining(
+        configType: 'machine',
+        machineCertAuthorityCertPath: expect.stringContaining(
           '/certs/dev/vx-admin-cert-authority-cert.pem'
         ),
-        vxAdminPrivateKey: {
+        machinePrivateKey: {
           source: 'file',
           path: expect.stringContaining('/certs/dev/vx-admin-private-key.pem'),
         },

--- a/libs/auth/src/config.ts
+++ b/libs/auth/src/config.ts
@@ -60,10 +60,10 @@ function getMachineCertPathAndPrivateKey(): {
   };
 }
 
-interface VxAdminCardProgrammingConfig {
-  configType: 'vx_admin';
-  vxAdminCertAuthorityCertPath: string;
-  vxAdminPrivateKey: FileKey | TpmKey;
+interface MachineCardProgrammingConfig {
+  configType: 'machine';
+  machineCertAuthorityCertPath: string;
+  machinePrivateKey: FileKey | TpmKey;
 }
 
 interface VxCardProgrammingConfig {
@@ -75,7 +75,7 @@ interface VxCardProgrammingConfig {
  * Config params for card programming, by either a VxAdmin or VotingWorks directly
  */
 export type CardProgrammingConfig =
-  | VxAdminCardProgrammingConfig
+  | MachineCardProgrammingConfig
   | VxCardProgrammingConfig;
 
 /**
@@ -100,9 +100,9 @@ export function constructJavaCardConfig(): JavaCardConfig {
   if (machineType === 'admin') {
     const { certPath, privateKey } = getMachineCertPathAndPrivateKey();
     cardProgrammingConfig = {
-      configType: 'vx_admin',
-      vxAdminCertAuthorityCertPath: certPath,
-      vxAdminPrivateKey: privateKey,
+      configType: 'machine',
+      machineCertAuthorityCertPath: certPath,
+      machinePrivateKey: privateKey,
     };
   }
   return {

--- a/libs/auth/src/java_card.test.ts
+++ b/libs/auth/src/java_card.test.ts
@@ -52,8 +52,8 @@ import {
   JavaCard,
   MAX_NUM_INCORRECT_PIN_ATTEMPTS,
   OPEN_FIPS_201_AID,
+  PROGRAMMING_MACHINE_CERT_AUTHORITY_CERT,
   PUK,
-  VX_ADMIN_CERT_AUTHORITY_CERT,
 } from './java_card';
 import {
   construct8BytePinBuffer,
@@ -119,11 +119,11 @@ const config: JavaCardConfig = {
 const configWithVxAdminCardProgrammingConfig: JavaCardConfig = {
   ...config,
   cardProgrammingConfig: {
-    configType: 'vx_admin',
-    vxAdminCertAuthorityCertPath: getTestFilePath({
+    configType: 'machine',
+    machineCertAuthorityCertPath: getTestFilePath({
       fileType: 'vx-admin-cert-authority-cert.pem',
     }),
-    vxAdminPrivateKey: {
+    machinePrivateKey: {
       source: 'file',
       path: getTestFilePath({
         fileType: 'vx-admin-private-key.pem',
@@ -397,7 +397,7 @@ test.each<{
   // Use null to indicate that the relevant data is not expected to be retrieved or used
   cardIdentityCert: TestFileSetId | null;
   isCardIdentityCertExpired?: boolean;
-  vxAdminCertAuthorityCert: TestFileSetId | null;
+  programmingMachineCertAuthorityCert: TestFileSetId | null;
   cardVxPrivateKey: TestFileSetId | null;
   cardIdentityPrivateKey: TestFileSetId | null;
   numRemainingPinAttempts: number | Error | null;
@@ -409,7 +409,7 @@ test.each<{
     vxCertAuthorityCert: '1',
     cardVxCert: '1',
     cardIdentityCert: '1',
-    vxAdminCertAuthorityCert: null,
+    programmingMachineCertAuthorityCert: null,
     cardVxPrivateKey: '1',
     cardIdentityPrivateKey: null,
     numRemainingPinAttempts: MAX_NUM_INCORRECT_PIN_ATTEMPTS,
@@ -423,7 +423,7 @@ test.each<{
     vxCertAuthorityCert: '1',
     cardVxCert: '1',
     cardIdentityCert: '1',
-    vxAdminCertAuthorityCert: '1',
+    programmingMachineCertAuthorityCert: '1',
     cardVxPrivateKey: '1',
     cardIdentityPrivateKey: null,
     numRemainingPinAttempts: MAX_NUM_INCORRECT_PIN_ATTEMPTS,
@@ -437,7 +437,7 @@ test.each<{
     vxCertAuthorityCert: '1',
     cardVxCert: '1',
     cardIdentityCert: '1',
-    vxAdminCertAuthorityCert: '1',
+    programmingMachineCertAuthorityCert: '1',
     cardVxPrivateKey: '1',
     cardIdentityPrivateKey: null,
     numRemainingPinAttempts: MAX_NUM_INCORRECT_PIN_ATTEMPTS,
@@ -451,7 +451,7 @@ test.each<{
     vxCertAuthorityCert: '1',
     cardVxCert: '1',
     cardIdentityCert: '1',
-    vxAdminCertAuthorityCert: '1',
+    programmingMachineCertAuthorityCert: '1',
     cardVxPrivateKey: '1',
     cardIdentityPrivateKey: '1',
     numRemainingPinAttempts: null,
@@ -466,7 +466,7 @@ test.each<{
     vxCertAuthorityCert: '1',
     cardVxCert: '1',
     cardIdentityCert: '1',
-    vxAdminCertAuthorityCert: '1',
+    programmingMachineCertAuthorityCert: '1',
     cardVxPrivateKey: '1',
     cardIdentityPrivateKey: null,
     numRemainingPinAttempts: MAX_NUM_INCORRECT_PIN_ATTEMPTS,
@@ -481,7 +481,7 @@ test.each<{
     vxCertAuthorityCert: '1',
     cardVxCert: '2',
     cardIdentityCert: null,
-    vxAdminCertAuthorityCert: null,
+    programmingMachineCertAuthorityCert: null,
     cardVxPrivateKey: null,
     cardIdentityPrivateKey: null,
     numRemainingPinAttempts: null,
@@ -496,7 +496,7 @@ test.each<{
     vxCertAuthorityCert: '1',
     cardVxCert: '1',
     cardIdentityCert: '2',
-    vxAdminCertAuthorityCert: null,
+    programmingMachineCertAuthorityCert: null,
     cardVxPrivateKey: null,
     cardIdentityPrivateKey: null,
     numRemainingPinAttempts: null,
@@ -511,7 +511,7 @@ test.each<{
     vxCertAuthorityCert: '1',
     cardVxCert: '1',
     cardIdentityCert: '2',
-    vxAdminCertAuthorityCert: '1',
+    programmingMachineCertAuthorityCert: '1',
     cardVxPrivateKey: null,
     cardIdentityPrivateKey: null,
     numRemainingPinAttempts: null,
@@ -526,7 +526,7 @@ test.each<{
     vxCertAuthorityCert: '1',
     cardVxCert: '1',
     cardIdentityCert: '1',
-    vxAdminCertAuthorityCert: '2',
+    programmingMachineCertAuthorityCert: '2',
     cardVxPrivateKey: null,
     cardIdentityPrivateKey: null,
     numRemainingPinAttempts: null,
@@ -543,7 +543,7 @@ test.each<{
     vxCertAuthorityCert: '1',
     cardVxCert: '1',
     cardIdentityCert: '1',
-    vxAdminCertAuthorityCert: '1',
+    programmingMachineCertAuthorityCert: '1',
     cardVxPrivateKey: '2',
     cardIdentityPrivateKey: null,
     numRemainingPinAttempts: null,
@@ -560,7 +560,7 @@ test.each<{
     vxCertAuthorityCert: '1',
     cardVxCert: '1',
     cardIdentityCert: '1',
-    vxAdminCertAuthorityCert: '1',
+    programmingMachineCertAuthorityCert: '1',
     cardVxPrivateKey: '1',
     cardIdentityPrivateKey: '2',
     numRemainingPinAttempts: null,
@@ -575,7 +575,7 @@ test.each<{
     vxCertAuthorityCert: '1',
     cardVxCert: '1',
     cardIdentityCert: '1',
-    vxAdminCertAuthorityCert: '1',
+    programmingMachineCertAuthorityCert: '1',
     cardVxPrivateKey: '1',
     cardIdentityPrivateKey: null,
     numRemainingPinAttempts: MAX_NUM_INCORRECT_PIN_ATTEMPTS - 5,
@@ -590,7 +590,7 @@ test.each<{
     vxCertAuthorityCert: '1',
     cardVxCert: '1',
     cardIdentityCert: '1',
-    vxAdminCertAuthorityCert: '1',
+    programmingMachineCertAuthorityCert: '1',
     cardVxPrivateKey: '1',
     cardIdentityPrivateKey: null,
     numRemainingPinAttempts: new Error('Whoa!'),
@@ -606,7 +606,7 @@ test.each<{
     cardVxCert: '1',
     cardIdentityCert: '1',
     isCardIdentityCertExpired: true,
-    vxAdminCertAuthorityCert: null,
+    programmingMachineCertAuthorityCert: null,
     cardVxPrivateKey: null,
     cardIdentityPrivateKey: null,
     numRemainingPinAttempts: null,
@@ -622,7 +622,7 @@ test.each<{
     cardVxCert: '1',
     cardIdentityCert: '1',
     isCardIdentityCertExpired: true,
-    vxAdminCertAuthorityCert: '1',
+    programmingMachineCertAuthorityCert: '1',
     cardVxPrivateKey: null,
     cardIdentityPrivateKey: null,
     numRemainingPinAttempts: null,
@@ -638,7 +638,7 @@ test.each<{
     cardVxCert: '1',
     cardIdentityCert: '1',
     isCardIdentityCertExpired: true,
-    vxAdminCertAuthorityCert: '1',
+    programmingMachineCertAuthorityCert: '1',
     cardVxPrivateKey: null,
     cardIdentityPrivateKey: null,
     numRemainingPinAttempts: null,
@@ -654,7 +654,7 @@ test.each<{
     cardVxCert: '1',
     cardIdentityCert: '1',
     isCardIdentityCertExpired: true,
-    vxAdminCertAuthorityCert: '1',
+    programmingMachineCertAuthorityCert: '1',
     cardVxPrivateKey: null,
     cardIdentityPrivateKey: null,
     numRemainingPinAttempts: null,
@@ -671,7 +671,7 @@ test.each<{
     cardVxCert,
     cardIdentityCert,
     isCardIdentityCertExpired,
-    vxAdminCertAuthorityCert,
+    programmingMachineCertAuthorityCert,
     cardVxPrivateKey,
     cardIdentityPrivateKey,
     numRemainingPinAttempts,
@@ -706,11 +706,11 @@ test.each<{
         })
       );
     }
-    if (vxAdminCertAuthorityCert) {
+    if (programmingMachineCertAuthorityCert) {
       mockCardCertRetrievalRequest(
-        VX_ADMIN_CERT_AUTHORITY_CERT.OBJECT_ID,
+        PROGRAMMING_MACHINE_CERT_AUTHORITY_CERT.OBJECT_ID,
         getTestFilePath({
-          setId: vxAdminCertAuthorityCert,
+          setId: programmingMachineCertAuthorityCert,
           fileType: 'vx-admin-cert-authority-cert.der',
         })
       );
@@ -834,7 +834,7 @@ test.each<{
   expectedExpiryInDays: number;
   expectedSigningCertAuthorityCertPath: string;
   expectedSigningPrivateKeyPath: string;
-  isVxAdminCertAuthorityCertRetrievalRequestExpected: boolean;
+  isProgrammingMachineCertAuthorityCertRetrievalRequestExpected: boolean;
   expectedCardDetailsAfterProgramming: CardDetails;
 }>([
   {
@@ -857,7 +857,7 @@ test.each<{
     expectedSigningPrivateKeyPath: getTestFilePath({
       fileType: 'vx-private-key.pem',
     }),
-    isVxAdminCertAuthorityCertRetrievalRequestExpected: false,
+    isProgrammingMachineCertAuthorityCertRetrievalRequestExpected: false,
     expectedCardDetailsAfterProgramming: {
       user: vendorUser,
     },
@@ -882,7 +882,7 @@ test.each<{
     expectedSigningPrivateKeyPath: getTestFilePath({
       fileType: 'vx-admin-private-key.pem',
     }),
-    isVxAdminCertAuthorityCertRetrievalRequestExpected: true,
+    isProgrammingMachineCertAuthorityCertRetrievalRequestExpected: true,
     expectedCardDetailsAfterProgramming: {
       user: systemAdministratorUser,
     },
@@ -909,7 +909,7 @@ test.each<{
     expectedSigningPrivateKeyPath: getTestFilePath({
       fileType: 'vx-admin-private-key.pem',
     }),
-    isVxAdminCertAuthorityCertRetrievalRequestExpected: true,
+    isProgrammingMachineCertAuthorityCertRetrievalRequestExpected: true,
     expectedCardDetailsAfterProgramming: {
       user: electionManagerUser,
     },
@@ -935,7 +935,7 @@ test.each<{
     expectedSigningPrivateKeyPath: getTestFilePath({
       fileType: 'vx-admin-private-key.pem',
     }),
-    isVxAdminCertAuthorityCertRetrievalRequestExpected: true,
+    isProgrammingMachineCertAuthorityCertRetrievalRequestExpected: true,
     expectedCardDetailsAfterProgramming: {
       user: pollWorkerUser,
       hasPin: false,
@@ -963,7 +963,7 @@ test.each<{
     expectedSigningPrivateKeyPath: getTestFilePath({
       fileType: 'vx-admin-private-key.pem',
     }),
-    isVxAdminCertAuthorityCertRetrievalRequestExpected: true,
+    isProgrammingMachineCertAuthorityCertRetrievalRequestExpected: true,
     expectedCardDetailsAfterProgramming: {
       user: pollWorkerUser,
       hasPin: true,
@@ -979,7 +979,7 @@ test.each<{
     expectedExpiryInDays,
     expectedSigningCertAuthorityCertPath,
     expectedSigningPrivateKeyPath,
-    isVxAdminCertAuthorityCertRetrievalRequestExpected,
+    isProgrammingMachineCertAuthorityCertRetrievalRequestExpected,
     expectedCardDetailsAfterProgramming,
   }) => {
     const javaCard = new JavaCard(configToUse);
@@ -1006,9 +1006,9 @@ test.each<{
       CARD_IDENTITY_CERT.OBJECT_ID,
       cardIdentityCertPath
     );
-    if (isVxAdminCertAuthorityCertRetrievalRequestExpected) {
+    if (isProgrammingMachineCertAuthorityCertRetrievalRequestExpected) {
       mockCardCertStorageRequest(
-        VX_ADMIN_CERT_AUTHORITY_CERT.OBJECT_ID,
+        PROGRAMMING_MACHINE_CERT_AUTHORITY_CERT.OBJECT_ID,
         getTestFilePath({
           fileType: 'vx-admin-cert-authority-cert.der',
         })
@@ -1056,7 +1056,10 @@ test('Unprogramming', async () => {
   mockCardAppletSelectionRequest();
   mockCardPinResetRequest(DEFAULT_PIN);
   mockCardPutDataRequest(CARD_IDENTITY_CERT.OBJECT_ID, Buffer.of());
-  mockCardPutDataRequest(VX_ADMIN_CERT_AUTHORITY_CERT.OBJECT_ID, Buffer.of());
+  mockCardPutDataRequest(
+    PROGRAMMING_MACHINE_CERT_AUTHORITY_CERT.OBJECT_ID,
+    Buffer.of()
+  );
   mockCardAppletSelectionRequest();
   for (const objectId of GENERIC_STORAGE_SPACE.OBJECT_IDS) {
     mockCardPutDataRequest(objectId, Buffer.of());


### PR DESCRIPTION
## Overview

When programming a Java Card, we write the cert authority cert of the VxAdmin that programmed the card to the card. In code, we refer to this certificate slot on the card as the `VX_ADMIN_CERT_AUTHORITY_CERT` slot. Let's rename that `PROGRAMMING_MACHINE_CERT_AUTHORITY_CERT` as the certificate in this slot may soon be either a VxAdmin cert or a VxPollBook cert.

Separating this rename out from the main PR for VxPollBook cert setup and card programming setup.