### PR TITLE
[VxPollBook] Fix flaky text app_config.test.ts

### DIFF
--- a/apps/pollbook/backend/src/app_config.test.ts
+++ b/apps/pollbook/backend/src/app_config.test.ts
@@ -42,10 +42,6 @@ afterEach(() => {
   vitest.useRealTimers();
 });
 
-vi.setConfig({
-  testTimeout: 20_000,
-});
-
 test('uses machine config from env', async () => {
   const originalEnv = process.env;
   process.env = {


### PR DESCRIPTION
## Overview
https://github.com/issues/assigned?issue=votingworks%7Cvxsuite%7C6250

I wasn't sure how to handle both the fact that the usb drive polling is triggered every 100ms and can take 100ms or more to occur when I first wrote these tests and solved the problem by both advancing fake time and going back to real timers and sleeping. I have since learned through other tests that using vi.waitFor is the better and more robust solution so hoping this will solve the flakiness issue. 
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
n/a

## Testing Plan
Run several times locally & in CI 


