### PR TITLE
[logging] CDF exports: stringify each event before passing to jsonStream

### DIFF
--- a/libs/utils/src/json_stream.test.ts
+++ b/libs/utils/src/json_stream.test.ts
@@ -1,7 +1,12 @@
 import { expect, test } from 'vitest';
 import { integers, iter } from '@votingworks/basics';
 import * as fc from 'fast-check';
-import { jsonStream, JsonStreamInput, JsonStreamOptions } from './json_stream';
+import {
+  jsonStream,
+  JsonStreamInput,
+  JsonStreamOptions,
+  RawJson,
+} from './json_stream';
 
 async function asString<T>(
   input: JsonStreamInput<T>,
@@ -201,6 +206,25 @@ test('delegates to toJSON', async () => {
           )
         )
       ).toEqual(JSON.parse(JSON.stringify(input)));
+    })
+  );
+});
+
+test('RawJson', async () => {
+  function* items() {
+    yield new RawJson(JSON.stringify({ item: 0 }));
+    yield { item: 1 };
+  }
+
+  expect(
+    await asString({
+      foo: 'bar',
+      items: items(),
+    })
+  ).toEqual(
+    JSON.stringify({
+      foo: 'bar',
+      items: [{ item: 0 }, { item: 1 }],
     })
   );
 });

--- a/libs/utils/src/json_stream.ts
+++ b/libs/utils/src/json_stream.ts
@@ -36,6 +36,19 @@ export type JsonStreamInput<T> =
   | boolean;
 
 /**
+ * Represents raw JSON for a previously stringified value.
+ *
+ * Provides an improvement to {@link jsonStream} performance for cases where the
+ * shape and size of a value are known ahead of time to be reasonably
+ * serializable in a single batch (e.g. a single element in a large array of log
+ * entry objects).
+ */
+export class RawJson {
+  // eslint-disable-next-line vx/gts-no-public-class-fields
+  constructor(public contents: string) {}
+}
+
+/**
  * Stream a JSON-serializable value as a series of strings. In addition to the
  * standard JSON types, this also supports `Iterable` values such as
  * `Generator`.
@@ -81,6 +94,8 @@ export async function* jsonStream<T>(
 
     if (value === null) {
       yield 'null';
+    } else if (value instanceof RawJson) {
+      yield value.contents;
     } else if (
       typeof value === 'boolean' ||
       typeof value === 'number' ||


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6219

In an attempt to speed up CDF log exports, this adds support to `jsonStream` for handling raw JSON values, identified by instances of a new `RawJson` utility class. Using this in the VxF-to-CDF log converter to pre-stringify log events before yielding to the `jsonStream`, since the latter starts to get fairly expensive for large arrays and nested objects.

Assumption is that each log entry has a known shape, is fairly small, has its only freeform fields, `Details | Description` already stringified anyway.

Tested on `~127MB` sample log file from VxScan, this brings the export time from `~62-64 seconds` down to `~35-37 seconds` on my machine.

We can potentially shave off an extra `~30+` seconds by moving the log schema validation out of `zod` - will be following up with a proposed change for that later.

## Testing Plan
- Existing unit tests + new `jsonStream` test case for raw JSON
- Manually with a sample log files, 12MB & 127MB, to check if time scaling is roughly linear

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
