### PR TITLE
center align the unlock screen

### DIFF
--- a/apps/pollbook/frontend/src/machine_locked_screen.tsx
+++ b/apps/pollbook/frontend/src/machine_locked_screen.tsx
@@ -30,7 +30,7 @@ export function MachineLockedScreen(): JSX.Element | null {
         <div>
           <LockedImage src="/locked.svg" alt="Locked Icon" />
           <H1 align="center">VxPollbook Locked</H1>
-          <H3 style={{ fontWeight: 'normal' }}>
+          <H3 align="center" style={{ fontWeight: 'normal' }}>
             {getElectionQuery.data.isOk() ? (
               <React.Fragment>Insert card to unlock.</React.Fragment>
             ) : (


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6297

Centers text on the unlock screen.

## Demo Video or Screenshot

Before
![Screenshot 2025-04-22 at 2 51 48 PM](https://github.com/user-attachments/assets/f63ceae7-2cb5-4d15-a630-cf06a6a65ab7)

After
![Screenshot 2025-04-22 at 2 51 37 PM](https://github.com/user-attachments/assets/59624ecc-7c05-499b-822d-8ddbc45beab0)


## Testing Plan
Manually tested render

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
