### PR TITLE
VxMark: Use "ballot style" copy for voter session activation flow

### DIFF
--- a/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
@@ -159,7 +159,7 @@ test('Cardless Voting Flow', async () => {
     },
   });
   await screen.findByText('Remove Card to Begin Voting Session');
-  screen.getByText(hasTextAcrossElements(/Precinct: Center Springfield/));
+  screen.getByText(hasTextAcrossElements(/Ballot Style: Center Springfield/));
 
   // Poll worker removes their card
   apiMock.setAuthStatusCardlessVoterLoggedIn({
@@ -234,7 +234,7 @@ test('in "All Precincts" mode, poll worker must select a precinct', async () => 
   // Activate Voter Session for Cardless Voter
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
   await screen.findByText('Start a New Voting Session');
-  userEvent.click(screen.getByText("Select voter's precinct…"));
+  userEvent.click(screen.getByText('Select ballot style…'));
 
   apiMock.mockApiClient.startCardlessVoterSession
     .expectCallWith({ ballotStyleId: '12' as BallotStyleId, precinctId: '23' })
@@ -269,7 +269,7 @@ test('selecting a precinct split', async () => {
   // Activate Voter Session for Cardless Voter
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
   await screen.findByText('Start a New Voting Session');
-  userEvent.click(screen.getByText("Select voter's precinct…"));
+  userEvent.click(screen.getByText('Select ballot style…'));
 
   apiMock.mockApiClient.startCardlessVoterSession
     .expectCallWith({ ballotStyleId: '5' as BallotStyleId, precinctId: '21' })
@@ -295,7 +295,7 @@ test('selecting a precinct split', async () => {
   });
   await screen.findByText('Remove Card to Begin Voting Session');
   screen.getByText(
-    hasTextAcrossElements(/Precinct: North Springfield - Split 1/)
+    hasTextAcrossElements(/Ballot Style: North Springfield - Split 1/)
   );
 
   // Poll worker removes their card

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.test.tsx
@@ -211,7 +211,7 @@ describe('pre-printed ballots', () => {
       precinctSelection: singlePrecinctSelectionFor(precinct.id),
     });
     apiMock.expectSetAcceptingPaperState(['BlankPage', 'InterpretedBmdPage']);
-    userEvent.click(screen.getByText("Select voter's precinct…"));
+    userEvent.click(screen.getByText('Select ballot style…'));
     userEvent.click(screen.getByText(precinct.splits[0].name));
     await waitFor(() =>
       expect(activateCardlessVoterSessionMock).toHaveBeenCalledOnce()
@@ -248,7 +248,7 @@ describe('pre-printed ballots', () => {
       precinctSelection: ALL_PRECINCTS_SELECTION,
     });
     apiMock.expectSetAcceptingPaperState(['BlankPage', 'InterpretedBmdPage']);
-    userEvent.click(screen.getByText("Select voter's precinct…"));
+    userEvent.click(screen.getByText('Select ballot style…'));
     userEvent.click(screen.getByText(precinct1.name));
     await waitFor(() =>
       expect(activateCardlessVoterSessionMock).toHaveBeenCalledOnce()

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -335,7 +335,7 @@ export function PollWorkerScreen({
         >
           <P weight="bold">Remove card to continue voting session.</P>
           <P>
-            <Font weight="semiBold">Precinct:</Font> {precinctOrSplitName}
+            <Font weight="semiBold">Ballot Style:</Font> {precinctOrSplitName}
           </P>
           <P>
             <ResetVoterSessionButton>Reset Ballot</ResetVoterSessionButton>
@@ -372,7 +372,7 @@ export function PollWorkerScreen({
           voterFacing={false}
         >
           <P>
-            <Font weight="semiBold">Precinct:</Font> {precinctOrSplitName}
+            <Font weight="semiBold">Ballot Style:</Font> {precinctOrSplitName}
           </P>
         </CenteredCardPageLayout>
       );
@@ -424,7 +424,7 @@ export function PollWorkerScreen({
                   })()
                 ) : (
                   <SearchSelect
-                    placeholder="Select voter's precinct…"
+                    placeholder="Select ballot style…"
                     options={configuredPrecinctsAndSplits.map(
                       ({ name, id }) => ({
                         label: name,


### PR DESCRIPTION
## Overview

Revision to #6316 
Based on some team feedback, "ballot style" is a better descriptor than "precinct" in this flow.

## Demo V
![Screenshot-VxMark-2025-04-22T22:09:10 330Z](https://github.com/user-attachments/assets/74432245-4682-4244-b212-bc773b37e667)
![Screenshot-VxMark-2025-04-22T22:09:35 148Z](https://github.com/user-attachments/assets/a1fd74e9-41b3-42ac-8047-df94bc892bc3)


## Testing Plan
Updated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
