### PR TITLE
fix(logging-utils): don't crash when logging from converter

### DIFF
--- a/libs/logging-utils/index.d.ts
+++ b/libs/logging-utils/index.d.ts
@@ -8,7 +8,12 @@
  * provided callback after completion.
  */
 export declare function convertVxLogToCdf(
-logger: import('@votingworks/logging').Logger,
+log: (
+eventId: import('@votingworks/logging').LogEventId,
+message: string,
+disposition: import('@votingworks/logging').LogDisposition
+) => void,
+source: import('@votingworks/logging').LogSource,
 machineId: string,
 codeVersion: string,
 inputPath: string,

--- a/libs/logging-utils/package.json
+++ b/libs/logging-utils/package.json
@@ -19,6 +19,7 @@
     "@types/tmp": "0.2.4",
     "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/logging": "workspace:*",
+    "@votingworks/test-utils": "workspace:*",
     "@votingworks/types": "workspace:*",
     "is-ci-cli": "2.2.0",
     "tmp": "^0.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4720,6 +4720,9 @@ importers:
       '@votingworks/logging':
         specifier: workspace:*
         version: link:../logging
+      '@votingworks/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
       '@votingworks/types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION

## Overview

Introducing the `ThreadsafeFunction` indirection caused the call context with `logger.logAsCurrentRole` to be lost, so `this` was `undefined` which caused a crash. This changes the API to just accept a plain function to avoid this problem.

## Demo Video or Screenshot
n/a

## Testing Plan
Added a test that uses the real `Logger`, though that's sort of moot with the API change.
