### PR TITLE
build(logging-utils): improve the build & test loop DX

### DIFF
--- a/libs/logging-utils/README.md
+++ b/libs/logging-utils/README.md
@@ -11,3 +11,11 @@ Converts a log file produced with the VotingWorks JSON-lines format and produces
 ## Build
 
 This package use [NAPI-RS](https://napi.rs/) to produce a NodeJS addon in Rust. The JavaScript and TypeScript definitions are all auto-generated and should not be edited manually.
+
+### Development
+
+> **Tip:** Install [`zellij`](https://zellij.dev/) (`cargo install zellij`) for an improved build & test experience with `pnpm test:watch`.
+
+- `pnpm test:watch` (or just `pnpm test` in dev): runs tests and builds, both re-building and re-testing on changes.
+- `pnpm build:watch`: builds just this package, watching for changes and re-building.
+- `pnpm build`: builds the package and all its dependencies.

--- a/libs/logging-utils/package.json
+++ b/libs/logging-utils/package.json
@@ -21,6 +21,7 @@
     "@votingworks/logging": "workspace:*",
     "@votingworks/types": "workspace:*",
     "is-ci-cli": "2.2.0",
+    "nodemon": "^3.1.7",
     "tmp": "^0.2.1",
     "vitest": "^3.1.1"
   },
@@ -29,11 +30,14 @@
     "build": "is-ci build:ci build:dev",
     "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
     "build:dev": "pnpm --filter $npm_package_name... build:self",
+    "build:watch": "nodemon -x 'pnpm build:self' -w src -w test -e rs",
     "build:self": "napi build --platform --release",
     "build:debug": "napi build --platform",
     "prepublishOnly": "napi prepublish -t npm",
     "lint": "cargo clippy",
-    "test": "cargo test && vitest",
+    "test": "is-ci test:ci test:watch",
+    "test:ci": "cargo test && vitest",
+    "test:watch": "if which zellij; then zellij -l test/zellij-layout.kdl; else vitest; fi",
     "universal": "napi universal",
     "version": "napi version"
   },

--- a/libs/logging-utils/test/zellij-layout.kdl
+++ b/libs/logging-utils/test/zellij-layout.kdl
@@ -1,0 +1,10 @@
+layout {
+    pane split_direction="horizontal" {
+        pane name="vitest (^Q to quit all)" command="pnpm" size="60%" close_on_exit=true {
+            args "vitest"
+        }
+        pane name="rust build" command="pnpm" {
+            args "build:watch"
+        }
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4726,6 +4726,9 @@ importers:
       is-ci-cli:
         specifier: 2.2.0
         version: 2.2.0
+      nodemon:
+        specifier: ^3.1.7
+        version: 3.1.7
       tmp:
         specifier: ^0.2.1
         version: 0.2.1


### PR DESCRIPTION

## Overview

This adds a `build:watch` script to make it easier to rebuild the Rust addon whenever the code changes. Additionally, if you have `zellij` installed, running `pnpm test` in development will run both `vitest` and `pnpm build:watch`.

## Demo Video or Screenshot
![CleanShot 2025-04-23 at 11 00 09@2x](https://github.com/user-attachments/assets/656ac487-31c9-4858-ae50-a3ced058d741)

## Testing Plan
Tested locally in VS Code, Zed, and Ghostty. VS Code steals ^Q, so quitting `zellij` there is less ideal (just spam ^C).
