### PR TITLE
VxMark: Handle primary elections in start voter session flow

### DIFF
--- a/libs/utils/src/ballot_styles.test.ts
+++ b/libs/utils/src/ballot_styles.test.ts
@@ -9,12 +9,15 @@ import {
   Party,
   PartyId,
 } from '@votingworks/types';
-import { readElectionGeneral } from '@votingworks/fixtures';
+import {
+  electionPrimaryPrecinctSplitsFixtures,
+  readElectionGeneral,
+} from '@votingworks/fixtures';
 import { assert } from '@votingworks/basics';
 import {
   generateBallotStyleId,
   getBallotStyleGroup,
-  getBallotStyleGroupForPrecinctOrSplit,
+  getBallotStyleGroupsForPrecinctOrSplit,
   getGroupedBallotStyles,
   getPrecinctsAndSplitsForBallotStyle,
   getRelatedBallotStyle,
@@ -278,28 +281,53 @@ describe('ballot style groups', () => {
   });
 });
 
-test('getBallotStyleGroupForPrecinctOrSplit', () => {
+test('getBallotStyleGroupForPrecinctOrSplit - general election', () => {
   const [precinct1, precinct2] = electionGeneral.precincts;
   assert(precinct1 && !hasSplits(precinct1));
   assert(precinct2 && hasSplits(precinct2));
   expect(
-    getBallotStyleGroupForPrecinctOrSplit({
+    getBallotStyleGroupsForPrecinctOrSplit({
       election: electionGeneral,
       precinctOrSplit: { precinct: precinct1 },
-    }).id
-  ).toEqual('12' as BallotStyleGroupId);
+    }).map((group) => group.id)
+  ).toEqual(['12']);
   expect(
-    getBallotStyleGroupForPrecinctOrSplit({
+    getBallotStyleGroupsForPrecinctOrSplit({
       election: electionGeneral,
       precinctOrSplit: { precinct: precinct2, split: precinct2.splits[0]! },
-    }).id
-  ).toEqual('5' as BallotStyleGroupId);
+    }).map((group) => group.id)
+  ).toEqual(['5']);
   expect(
-    getBallotStyleGroupForPrecinctOrSplit({
+    getBallotStyleGroupsForPrecinctOrSplit({
       election: electionGeneral,
       precinctOrSplit: { precinct: precinct2, split: precinct2.splits[1]! },
-    }).id
-  ).toEqual('12' as BallotStyleGroupId);
+    }).map((group) => group.id)
+  ).toEqual(['12']);
+});
+
+test('getBallotStyleGroupForPrecinctOrSplit - primary election', () => {
+  const election = electionPrimaryPrecinctSplitsFixtures.readElection();
+  const [precinct1, , , precinct4] = election.precincts;
+  assert(precinct1 && !hasSplits(precinct1));
+  assert(precinct4 && hasSplits(precinct4));
+  expect(
+    getBallotStyleGroupsForPrecinctOrSplit({
+      election,
+      precinctOrSplit: { precinct: precinct1 },
+    }).map((group) => group.id)
+  ).toEqual(['1-Ma', '1-F']);
+  expect(
+    getBallotStyleGroupsForPrecinctOrSplit({
+      election,
+      precinctOrSplit: { precinct: precinct4, split: precinct4.splits[0]! },
+    }).map((group) => group.id)
+  ).toEqual(['3-Ma', '3-F']);
+  expect(
+    getBallotStyleGroupsForPrecinctOrSplit({
+      election,
+      precinctOrSplit: { precinct: precinct4, split: precinct4.splits[1]! },
+    }).map((group) => group.id)
+  ).toEqual(['4-Ma', '4-F']);
 });
 
 test('getPrecinctsAndSplitsForBallotStyle', () => {

--- a/libs/utils/src/ballot_styles.ts
+++ b/libs/utils/src/ballot_styles.ts
@@ -5,7 +5,6 @@ import {
   deepEqual,
   iter,
   ok,
-  find,
 } from '@votingworks/basics';
 import {
   BallotStyle,
@@ -162,17 +161,17 @@ function hasMatchingDistrictIds(
 }
 
 /**
- * Given a precinct or split, returns its associated ballot style group.
+ * Given a precinct or split, returns its associated ballot style groups (there
+ * may be multiple since each party has a ballot style in a primary election).
  */
-export function getBallotStyleGroupForPrecinctOrSplit({
+export function getBallotStyleGroupsForPrecinctOrSplit({
   election,
   precinctOrSplit,
 }: {
   election: Election;
   precinctOrSplit: PrecinctOrSplit;
-}): BallotStyleGroup {
-  return find(
-    getGroupedBallotStyles(election.ballotStyles),
+}): BallotStyleGroup[] {
+  return getGroupedBallotStyles(election.ballotStyles).filter(
     (ballotStyleGroup) =>
       hasMatchingDistrictIds(ballotStyleGroup, precinctOrSplit)
   );


### PR DESCRIPTION
## Overview

Another follow up to #6316

In a general election, there's exactly one ballot style group for each precinct or split. However, in a primary election, there are multiple - one for each party. To handle this case, we add a second selection step for the party when a poll worker is starting a new voter session.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/fde4d667-bfe0-4ad3-ac80-cd2556d67d50



## Testing Plan
- Manual testing
- Added new test coverage
- Relied on existing tests to prevent regressions for the general election case

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
