### PR TITLE
ui: Support complex value types for `SearchSelect`

### DIFF
--- a/apps/admin/frontend/src/components/reporting/filter_editor.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.tsx
@@ -284,7 +284,7 @@ export function FilterEditor({
               aria-label="Edit Filter Type"
             />
             <Predicate>is</Predicate>
-            <SearchSelect
+            <SearchSelect<string>
               isMulti
               isSearchable
               key={filterType}

--- a/apps/pollbook/frontend/src/add_voter_screen.tsx
+++ b/apps/pollbook/frontend/src/add_voter_screen.tsx
@@ -8,7 +8,10 @@ import {
   SearchSelect,
 } from '@votingworks/ui';
 import { useMemo, useState } from 'react';
-import type { VoterRegistrationRequest } from '@votingworks/pollbook-backend';
+import type {
+  PartyAbbreviation,
+  VoterRegistrationRequest,
+} from '@votingworks/pollbook-backend';
 import { Column, Row, FieldName } from './layout';
 import { PollWorkerNavScreen } from './nav_screen';
 import { AddressInputGroup } from './address_input_group';
@@ -74,7 +77,7 @@ export function AddVoterScreen({
           <Row style={{ gap: '1rem' }}>
             <RequiredStaticInput>
               <FieldName>Party Affiliation</FieldName>
-              <SearchSelect
+              <SearchSelect<PartyAbbreviation>
                 id="party"
                 aria-label="Party Affiliation"
                 style={{ width: '20rem' }}

--- a/libs/ui/src/search_select.test.tsx
+++ b/libs/ui/src/search_select.test.tsx
@@ -17,13 +17,13 @@ const options = [
   { value: 'pear', label: 'Pear' },
 ];
 
-function ControlledSingleSelect({
+function ControlledSingleSelect<T>({
   value: valueProp,
   ...rest
-}: Partial<SearchSelectSingleProps>): JSX.Element {
-  const [value, setValue] = React.useState<string | undefined>(valueProp);
+}: Partial<SearchSelectSingleProps<T>>): JSX.Element {
+  const [value, setValue] = React.useState<T | undefined>(valueProp);
   return (
-    <SearchSelect
+    <SearchSelect<T>
       isSearchable={false}
       options={[]}
       {...rest}
@@ -40,7 +40,7 @@ function ControlledMultiSelect({
 }: Partial<SearchSelectProps>): JSX.Element {
   const [value, setValue] = React.useState<string[]>(valueProp as string[]);
   return (
-    <SearchSelect
+    <SearchSelect<string>
       isSearchable={false}
       options={[]}
       {...rest}
@@ -271,4 +271,23 @@ test('empty option', () => {
   userEvent.click(screen.getByText('None'));
   expect(screen.queryByText('Apple')).not.toBeInTheDocument();
   screen.getByText('None');
+});
+
+test('complex value type uses deep equality', () => {
+  render(
+    <ControlledSingleSelect
+      options={[
+        { value: { fruit: 'apple', color: 'red' }, label: 'Red Apple' },
+        { value: { fruit: 'apple', color: 'green' }, label: 'Green Apple' },
+      ]}
+      aria-label="Choose Fruit"
+      value={{ fruit: 'apple', color: 'red' }}
+    />
+  );
+
+  screen.getByText('Red Apple');
+  userEvent.click(screen.getByText('Red Apple'));
+  userEvent.click(screen.getByText('Green Apple'));
+  screen.getByText('Green Apple');
+  expect(screen.queryByText('Red Apple')).not.toBeInTheDocument();
 });

--- a/libs/ui/src/search_select.tsx
+++ b/libs/ui/src/search_select.tsx
@@ -1,4 +1,4 @@
-import { typedAs } from '@votingworks/basics';
+import { deepEqual, typedAs } from '@votingworks/basics';
 import Select, {
   components,
   DropdownIndicatorProps,
@@ -57,12 +57,12 @@ function MultiValueRemove(
   );
 }
 
-export interface SelectOption<T extends string = string> {
+export interface SelectOption<T = string> {
   value: T;
   label: string;
 }
 
-interface SearchSelectBaseProps<T extends string = string> {
+interface SearchSelectBaseProps<T = string> {
   id?: string;
   isMulti?: boolean;
   isSearchable?: boolean;
@@ -74,7 +74,7 @@ interface SearchSelectBaseProps<T extends string = string> {
   required?: boolean;
 }
 
-export interface SearchSelectMultiProps<T extends string = string>
+export interface SearchSelectMultiProps<T = string>
   extends SearchSelectBaseProps<T> {
   isMulti: true;
   value: T[];
@@ -83,7 +83,7 @@ export interface SearchSelectMultiProps<T extends string = string>
   menuPortalTarget?: HTMLElement;
 }
 
-export interface SearchSelectSingleProps<T extends string = string>
+export interface SearchSelectSingleProps<T = string>
   extends SearchSelectBaseProps<T> {
   isMulti?: false;
   value?: T;
@@ -92,18 +92,18 @@ export interface SearchSelectSingleProps<T extends string = string>
   menuPortalTarget?: HTMLElement;
 }
 
-export type SearchSelectProps<T extends string = string> =
+export type SearchSelectProps<T = string> =
   | SearchSelectSingleProps<T>
   | SearchSelectMultiProps<T>;
 
-function findOption<T extends string = string>(
+function findOption<T = string>(
   options: Array<SelectOption<T>>,
   value: T
 ): SelectOption<T> | undefined {
-  return options.find((option) => option.value === value);
+  return options.find((option) => deepEqual(option.value, value));
 }
 
-export function SearchSelect<T extends string = string>({
+export function SearchSelect<T = string>({
   id,
   isMulti,
   isSearchable,

--- a/libs/ui/src/search_select_multi.stories.tsx
+++ b/libs/ui/src/search_select_multi.stories.tsx
@@ -46,7 +46,7 @@ export function Multi(props: SearchSelectMultiProps): JSX.Element {
   const [value, setValue] = useState<string[]>([]);
 
   return (
-    <SearchSelect
+    <SearchSelect<string>
       style={{ minWidth: '8rem' }}
       {...props}
       value={value}


### PR DESCRIPTION

## Overview

I have a use case where I need a select value that is a pair of two strings. To support this use case, this changes `SearchSelect` to support complex value types by using `deepEqual` to compare them.

## Demo Video or Screenshot
N/A

## Testing Plan
Added new test

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
