### PR TITLE
VxAdmin: Improve ballot style selection in manual tally entry 

### DIFF
--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.test.tsx
@@ -144,9 +144,8 @@ test('entering initial ballot count and contest tallies', async () => {
   const { history } = renderScreen();
 
   await screen.findByRole('heading', { name: 'Edit Tallies' });
-  screen.getByText(hasTextAcrossElements('Ballot Style1M'));
-  screen.getByText(hasTextAcrossElements('PrecinctPrecinct 1'));
-  screen.getByText(hasTextAcrossElements('Voting MethodAbsentee'));
+  screen.getByText(hasTextAcrossElements(/Ballot StylePrecinct 1 - Mammal/));
+  screen.getByText(hasTextAcrossElements(/Voting MethodAbsentee/));
 
   // Enter ballot count
   screen.getButton('Close');
@@ -256,7 +255,7 @@ test('editing existing tallies', async () => {
   });
 
   await screen.findByRole('heading', { name: 'Edit Tallies' });
-  screen.getByText(hasTextAcrossElements('Voting MethodPrecinct'));
+  screen.getByText(hasTextAcrossElements(/Voting MethodPrecinct/));
 
   // Edit ballot count
   const ballotCountInput = screen.getByLabelText('Total Ballots Cast');

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -19,6 +19,7 @@ import {
   BallotStyleGroupId,
   Contests,
   Precinct,
+  Election,
 } from '@votingworks/types';
 import {
   Button,
@@ -64,6 +65,10 @@ import {
   ManualTallyFormContestParams,
   ManualTallyFormParams,
 } from '../../config/types';
+import {
+  BallotStyleLabel,
+  VotingMethodLabel,
+} from './manual_tallies_shared_components';
 
 const TallyTaskControls = styled(TaskControls)`
   width: 25rem;
@@ -102,21 +107,28 @@ const TallyMetadataContainer = styled.div`
 `;
 
 function TallyMetadata({
+  election,
   ballotStyleGroupId,
   precinct,
   votingMethod,
 }: {
+  election: Election;
   ballotStyleGroupId: BallotStyleGroupId;
   precinct: Precinct;
-  votingMethod: Tabulation.VotingMethod;
+  votingMethod: ManualResultsVotingMethod;
 }) {
-  const votingMethodTitle =
-    votingMethod === 'absentee' ? 'Absentee' : 'Precinct';
   return (
     <TallyMetadataContainer>
-      <LabelledText label="Ballot Style">{ballotStyleGroupId}</LabelledText>
-      <LabelledText label="Precinct">{precinct.name}</LabelledText>
-      <LabelledText label="Voting Method">{votingMethodTitle}</LabelledText>
+      <LabelledText label="Ballot Style">
+        <BallotStyleLabel
+          election={election}
+          ballotStyleGroupId={ballotStyleGroupId}
+          precinctId={precinct.id}
+        />
+      </LabelledText>
+      <LabelledText label="Voting Method">
+        <VotingMethodLabel votingMethod={votingMethod} />{' '}
+      </LabelledText>
     </TallyMetadataContainer>
   );
 }
@@ -498,6 +510,7 @@ function BallotCountForm({
         <TallyTaskHeader />
         <ControlsContent>
           <TallyMetadata
+            election={election}
             ballotStyleGroupId={ballotStyleGroupId}
             precinct={precinct}
             votingMethod={votingMethod}
@@ -905,6 +918,7 @@ function ContestForm({
         <TallyTaskHeader />
         <ControlsContent>
           <TallyMetadata
+            election={election}
             ballotStyleGroupId={ballotStyleGroupId}
             precinct={precinct}
             votingMethod={votingMethod}

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_shared_components.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_shared_components.tsx
@@ -1,0 +1,52 @@
+import type { ManualResultsVotingMethod } from '@votingworks/admin-backend';
+import { assertDefined, find } from '@votingworks/basics';
+import { Election, PrecinctId, BallotStyleGroupId } from '@votingworks/types';
+import {
+  getBallotStyleGroup,
+  getPrecinctsAndSplitsForBallotStyle,
+} from '@votingworks/utils';
+
+const VOTING_METHOD_LABELS: Record<ManualResultsVotingMethod, string> = {
+  absentee: 'Absentee',
+  precinct: 'Precinct',
+};
+
+export function VotingMethodLabel({
+  votingMethod,
+}: {
+  votingMethod: ManualResultsVotingMethod;
+}): string {
+  return VOTING_METHOD_LABELS[votingMethod];
+}
+
+export function BallotStyleLabel({
+  election,
+  precinctId,
+  ballotStyleGroupId,
+}: {
+  election: Election;
+  precinctId: PrecinctId;
+  ballotStyleGroupId: BallotStyleGroupId;
+}): string {
+  const ballotStyleGroup = assertDefined(
+    getBallotStyleGroup({
+      election,
+      ballotStyleGroupId,
+    })
+  );
+  const precinctOrSplit = find(
+    getPrecinctsAndSplitsForBallotStyle({
+      election,
+      ballotStyle: ballotStyleGroup.defaultLanguageBallotStyle,
+    }),
+    (ps) => ps.precinct.id === precinctId
+  );
+  return (
+    (precinctOrSplit.split?.name || precinctOrSplit.precinct.name) +
+    (ballotStyleGroup.partyId
+      ? ` - ${
+          find(election.parties, (p) => p.id === ballotStyleGroup.partyId).name
+        }`
+      : '')
+  );
+}

--- a/apps/admin/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/admin/integration-testing/e2e/screenshots.spec.ts
@@ -658,8 +658,6 @@ test('manual results', async ({ page }) => {
   await page.getByText('Manual Tallies').click();
   await screenshot('manual-tallies-tab-empty');
   await openDropdown(page, 'Ballot Style');
-  await selectOpenDropdownOption(page, 'card-number-3');
-  await openDropdown(page, 'Precinct');
   await selectOpenDropdownOption(page, 'Test Ballot');
   await openDropdown(page, 'Voting Method');
   await screenshot('manual-tallies-metadata-selection');

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -9,12 +9,12 @@ import {
   InsertedSmartCardAuth,
   PrecinctSelection,
   VotesDict,
-  hasSplits,
   PrecinctOrSplit,
   getBallotStyle,
+  getAllPrecinctsAndSplits,
   Election,
-  getPartyForBallotStyle,
   PrecinctSplitId,
+  getPartyForBallotStyle,
 } from '@votingworks/types';
 import {
   Button,
@@ -555,18 +555,14 @@ export function PollWorkerScreen({
     return null;
   }
 
-  const configuredPrecinctsAndSplits = election.precincts
-    .flatMap((precinct): PrecinctOrSplit[] =>
-      hasSplits(precinct)
-        ? precinct.splits.map((split) => ({ precinct, split }))
-        : [{ precinct }]
-    )
-    .filter(
-      ({ precinct }) =>
-        precinctSelection.kind === 'AllPrecincts' ||
-        (precinctSelection.kind === 'SinglePrecinct' &&
-          precinctSelection.precinctId === precinct.id)
-    );
+  const configuredPrecinctsAndSplits = getAllPrecinctsAndSplits(
+    election
+  ).filter(
+    ({ precinct }) =>
+      precinctSelection.kind === 'AllPrecincts' ||
+      (precinctSelection.kind === 'SinglePrecinct' &&
+        precinctSelection.precinctId === precinct.id)
+  );
 
   return (
     <Screen>

--- a/libs/types/src/election.test.ts
+++ b/libs/types/src/election.test.ts
@@ -26,6 +26,7 @@ import {
   formatElectionHashes,
   getGroupIdFromBallotStyleId,
   getPrecinctSplitById,
+  getAllPrecinctsAndSplits,
 } from './election_utils';
 import {
   election,
@@ -46,6 +47,7 @@ import {
   BmdBallotPaperSize,
   hasSplits,
   DistrictId,
+  Precinct,
 } from './election';
 import { safeParse, safeParseJson, unsafeParse } from './generic';
 import {
@@ -674,4 +676,36 @@ test('hasSplits', () => {
 
   expect(hasSplits(precincts[0])).toEqual(true);
   expect(hasSplits(precincts[1])).toEqual(false);
+});
+
+test('getAllPrecinctsAndSplits', () => {
+  expect(getAllPrecinctsAndSplits(election)).toEqual([
+    { precinct: election.precincts[0] },
+  ]);
+  const precinct2: Precinct = {
+    id: 'precinct-2',
+    name: 'Precinct 2',
+    splits: [
+      {
+        id: 'split-1',
+        name: 'Split 1',
+        districtIds: ['district-1' as DistrictId],
+      },
+      {
+        id: 'split-2',
+        name: 'Split 2',
+        districtIds: ['district-2' as DistrictId],
+      },
+    ],
+  };
+  expect(
+    getAllPrecinctsAndSplits({
+      ...election,
+      precincts: [...election.precincts, precinct2],
+    })
+  ).toEqual([
+    { precinct: election.precincts[0] },
+    { precinct: precinct2, split: precinct2.splits[0] },
+    { precinct: precinct2, split: precinct2.splits[1] },
+  ]);
 });

--- a/libs/types/src/election_utils.ts
+++ b/libs/types/src/election_utils.ts
@@ -31,6 +31,7 @@ import {
   PrecinctSplitId,
   PrecinctSplit,
   hasSplits,
+  PrecinctOrSplit,
 } from './election';
 
 /**
@@ -477,4 +478,14 @@ export function ballotPaperDimensions(paperSize: BallotPaperSize): {
       return throwIllegalValue(paperSize);
     }
   }
+}
+
+export function getAllPrecinctsAndSplits(
+  election: Election
+): PrecinctOrSplit[] {
+  return election.precincts.flatMap((precinct) =>
+    hasSplits(precinct)
+      ? precinct.splits.map((split): PrecinctOrSplit => ({ precinct, split }))
+      : [{ precinct }]
+  );
 }


### PR DESCRIPTION
## Overview

Task: https://github.com/votingworks/vxsuite/issues/6123

Instead of selecting a ballot style ID and a precinct in two dropdowns, merge this choice into a single dropdown that uses precinct/split name (and party name, in primaries), to label each ballot style/precinct combination.

## Demo Video or Screenshot


https://github.com/user-attachments/assets/c0eb5d11-9ee7-4db7-a275-ed6e8b57f622



## Testing Plan
Manual testing and updated automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
