### PR TITLE
dev-dock: Fix flaky test by increasing timeout

### DIFF
--- a/libs/dev-dock/frontend/src/dev_dock.test.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.test.tsx
@@ -501,7 +501,11 @@ describe('PDI scanner mock', () => {
     mockApiClient.pdiScannerGetSheetStatus
       .expectRepeatedCallsWith()
       .resolves('noSheet');
-    await screen.findByRole('button', { name: 'Insert Ballot' });
+    await screen.findByRole(
+      'button',
+      { name: 'Insert Ballot' },
+      { timeout: 2000 }
+    );
   });
 
   test('ignores canceled open file dialog', async () => {


### PR DESCRIPTION

## Overview

Mimic the timeout from an assertion a few lines above.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
