### PR TITLE
[logging] Use updated log conversion utility for CDF log exports

### DIFF
--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -34,6 +34,7 @@
     "@votingworks/db": "workspace:*",
     "@votingworks/grout": "workspace:*",
     "@votingworks/logging": "workspace:*",
+    "@votingworks/logging-utils": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/usb-drive": "workspace:*",
     "@votingworks/utils": "workspace:*",

--- a/libs/backend/src/system_call/export_logs_to_usb.test.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.test.ts
@@ -10,6 +10,8 @@ import {
 import { LogEventId, MockLogger, mockLogger } from '@votingworks/logging';
 import { tmpNameSync } from 'tmp';
 import { PassThrough } from 'node:stream';
+import { ok } from '@votingworks/basics';
+import { convertVxLogToCdf } from '@votingworks/logging-utils';
 import { execFile } from '../exec';
 import { exportLogsToUsb } from './export_logs_to_usb';
 
@@ -31,6 +33,8 @@ vi.mock(
     execFile: vi.fn(),
   })
 );
+
+vi.mock(import('@votingworks/logging-utils'));
 
 const execFileMock = vi.mocked(execFile);
 
@@ -189,7 +193,7 @@ test('exportLogsToUsb works for vxf format when all conditions are met', async (
   mockUsbDrive.assertComplete();
 });
 
-test('exportLogsToUsb returns error when cdf conversion fails', async () => {
+test('exportLogsToUsb returns error when cdf conversion fails - compressed file', async () => {
   const { createReadStream: realCreateReadStream } =
     await vi.importActual<typeof import('node:fs')>('node:fs');
   const mockUsbDrive = createMockUsbDrive();
@@ -205,7 +209,7 @@ test('exportLogsToUsb returns error when cdf conversion fails', async () => {
   const readdirMock = fs.readdir as unknown as MockInstance<
     () => Promise<string[]>
   >;
-  readdirMock.mockResolvedValue(['vx-logs.log', 'vx-logs.log-20240101.gz']);
+  readdirMock.mockResolvedValue(['vx-logs.log-20240101.gz']);
 
   const logFile = tmpNameSync();
   await fs.writeFile(logFile, ``);
@@ -213,8 +217,48 @@ test('exportLogsToUsb returns error when cdf conversion fails', async () => {
     realCreateReadStream(logFile, 'utf8')
   );
   // There will be an error uncompressing if this is an empty file
-  vi.mocked(createReadStream).mockReturnValueOnce(
-    realCreateReadStream(logFile, 'utf8')
+  execFileMock.mockResolvedValue({ stdout: '', stderr: '' });
+
+  const result = await exportLogsToUsb({
+    usbDrive: mockUsbDrive.usbDrive,
+    logger,
+    machineId: 'TEST-MACHINE-ID',
+    codeVersion: 'TEST-CODE-VERSION',
+    format: 'cdf',
+  });
+  expect(result.isErr()).toBeTruthy();
+  expect(result.err()).toEqual('cdf-conversion-failed');
+});
+
+test('exportLogsToUsb returns error when cdf conversion fails - plain file', async () => {
+  const mockUsbDrive = createMockUsbDrive();
+  mockUsbDrive.usbDrive.status.reset();
+  mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
+    status: 'mounted',
+    mountPoint: '/media/usb-drive',
+  });
+
+  const mockStats = new Stats();
+  mockStats.isDirectory = vi.fn().mockReturnValue(true);
+  vi.mocked(fs.stat).mockResolvedValueOnce(mockStats);
+  const readdirMock = fs.readdir as unknown as MockInstance<
+    () => Promise<string[]>
+  >;
+  readdirMock.mockResolvedValue(['vx-logs.log']);
+
+  const logFile = tmpNameSync();
+  await fs.writeFile(logFile, ``);
+
+  vi.mocked(convertVxLogToCdf).mockImplementation(
+    (
+      _logWrapper,
+      _source,
+      _machineId,
+      _codeVersion,
+      _inputPath,
+      _outputPath,
+      cb
+    ) => cb(new Error('conversion failed'))
   );
 
   execFileMock.mockResolvedValue({ stdout: '', stderr: '' });
@@ -298,17 +342,28 @@ test('exportLogsToUsb works for cdf format when all conditions are met', async (
 
   execFileMock.mockResolvedValue({ stdout: '', stderr: '' });
 
+  vi.mocked(convertVxLogToCdf).mockImplementation(
+    (logWrapper, source, machineId, codeVersion, inputPath, outputPath, cb) => {
+      expect(source).toEqual(logger.getSource());
+      expect(machineId).toEqual('TEST-MACHINE-ID');
+      expect(codeVersion).toEqual('TEST-CODE-VERSION');
+      expect(inputPath).toMatch(/vx-logs.log$/);
+      expect(outputPath).toMatch(/vx-logs.cdf.log.json$/);
+
+      logWrapper(LogEventId.LogConversionToCdfComplete, 'unknown', 'success');
+      cb(null);
+    }
+  );
+
   expect(
-    (
-      await exportLogsToUsb({
-        usbDrive: mockUsbDrive.usbDrive,
-        logger,
-        machineId: 'TEST-MACHINE-ID',
-        codeVersion: 'TEST-CODE-VERSION',
-        format: 'cdf',
-      })
-    ).isOk()
-  ).toBeTruthy();
+    await exportLogsToUsb({
+      usbDrive: mockUsbDrive.usbDrive,
+      logger,
+      machineId: 'TEST-MACHINE-ID',
+      codeVersion: 'TEST-CODE-VERSION',
+      format: 'cdf',
+    })
+  ).toEqual(ok());
   expect(vi.mocked(fs.stat)).toHaveBeenCalledWith('/var/log/votingworks');
 
   expect(execFileMock).toHaveBeenCalledWith('mkdir', [
@@ -321,10 +376,6 @@ test('exportLogsToUsb works for cdf format when all conditions are met', async (
     expect.stringContaining('/tmp/'),
     expect.stringMatching('^/media/usb-drive/logs/machine_TEST-MACHINE-ID/'),
   ]);
-
-  expect(createWriteStream).toHaveBeenCalledWith(
-    expect.stringContaining('vx-logs.cdf.log.json')
-  );
 
   expect(logger.log).toHaveBeenCalledWith(
     LogEventId.LogConversionToCdfComplete,

--- a/libs/backend/src/system_call/export_logs_to_usb.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.ts
@@ -1,4 +1,10 @@
-import { Result, err, ok, throwIllegalValue } from '@votingworks/basics';
+import {
+  Result,
+  deferred,
+  err,
+  ok,
+  throwIllegalValue,
+} from '@votingworks/basics';
 import { UsbDrive } from '@votingworks/usb-drive';
 import * as fs from 'node:fs/promises';
 import { join } from 'node:path';
@@ -15,6 +21,7 @@ import { pipeline } from 'node:stream/promises';
 import { createGunzip, createGzip } from 'node:zlib';
 import { dirSync } from 'tmp';
 import { generateFileTimeSuffix } from '@votingworks/utils';
+import { convertVxLogToCdf } from '@votingworks/logging-utils';
 import { execFile } from '../exec';
 
 const LOG_DIR = '/var/log/votingworks';
@@ -30,6 +37,30 @@ export type LogsResultType = Result<
   | 'error-filtering-failed'
 >;
 
+function convertFileToCdf(
+  logger: Logger,
+  inputPath: string,
+  outputPath: string,
+  machineId: string,
+  codeVersion: string
+): Promise<void> {
+  const { promise, reject, resolve } = deferred<void>();
+
+  convertVxLogToCdf(
+    (eventId, message, disposition) => {
+      void logger.logAsCurrentRole(eventId, { message, disposition });
+    },
+    logger.getSource(),
+    machineId,
+    codeVersion,
+    inputPath,
+    outputPath,
+    (error) => (error ? reject(error) : resolve())
+  );
+
+  return promise;
+}
+
 async function convertLogsToCdf(
   logDir: string,
   outputDir: string,
@@ -41,15 +72,18 @@ async function convertLogsToCdf(
 
   // Create CDF for vx-logs.log
   if (files.includes('vx-logs.log')) {
-    await pipeline(
-      createReadStream(join(logDir, 'vx-logs.log'), 'utf8'),
-      (inputStream: AsyncIterable<string>) =>
-        buildCdfLog(logger, inputStream, machineId, codeVersion),
-      createWriteStream(join(outputDir, 'vx-logs.cdf.log.json'))
+    await convertFileToCdf(
+      logger,
+      join(logDir, 'vx-logs.log'),
+      join(outputDir, 'vx-logs.cdf.log.json'),
+      machineId,
+      codeVersion
     );
   }
 
   // Create CDF for all compressed vx-logs files
+  // [TODO] Add support for gzipped files to `libs/logging-utils` and update
+  // this conversion.
   for (const file of files) {
     if (file.match(COMPRESSED_VX_LOGS_NAME_REGEX)) {
       const cdfFileName = file.replace('vx-logs', 'vx-logs.cdf.json');
@@ -145,7 +179,7 @@ async function exportLogsToUsbHelper({
           machineId,
           codeVersion
         );
-      } catch {
+      } catch (error) {
         await fs.rm(tempDirectory, { recursive: true });
         return err('cdf-conversion-failed');
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3244,6 +3244,9 @@ importers:
       '@votingworks/logging':
         specifier: workspace:*
         version: link:../logging
+      '@votingworks/logging-utils':
+        specifier: workspace:*
+        version: link:../logging-utils
       '@votingworks/types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6219

Addressing slow CDF log exports by switching to the newly added Rust-based conversion utility.

This change covers plain log file conversions - will need to follow up with a change to support converting gzipped files as well.

## Testing Plan
- Conversion utility tested separately; updated consumer unit tests to verify inputs & output handling
- Manual with mock log data

## Checklist

- ~[ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.~
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- ~[ ] I have added a screenshot and/or video to this PR to demo the change~
- ~[ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates~
