### PR TITLE
upgrade vitest in libs/backend

### DIFF
--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -80,7 +80,7 @@
     "@types/tmp": "0.2.4",
     "@types/uuid": "9.0.5",
     "@types/zip-stream": "workspace:*",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "csv-parse": "^5.5.0",
@@ -95,7 +95,7 @@
     "nodemon": "^3.1.7",
     "sort-package-json": "^1.50.0",
     "supertest": "^6.0.1",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "engines": {
     "node": ">= 16"

--- a/apps/admin/backend/vitest.config.ts
+++ b/apps/admin/backend/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: 100,
-        branches: 97,
+        branches: -17,
       },
       exclude: [
         '**/*.d.ts',

--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -68,7 +68,7 @@
     "@types/supertest": "^2.0.10",
     "@types/tmp": "0.2.4",
     "@types/uuid": "9.0.5",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/bmd-ballot-fixtures": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
     "esbuild": "0.21.2",
@@ -82,7 +82,7 @@
     "nodemon": "^3.1.7",
     "sort-package-json": "^1.50.0",
     "supertest": "^6.0.1",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "engines": {
     "node": ">= 12"

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -301,7 +301,7 @@ function buildApi({
       return workspace.getDiskSpaceSummary();
     },
 
-    /* istanbul ignore next */
+    /* istanbul ignore next - @preserve */
     async generateSignedHashValidationQrCodeValue() {
       const { codeVersion } = getMachineConfig();
       const electionRecord = store.getElectionRecord();

--- a/apps/central-scan/backend/src/readiness_report.ts
+++ b/apps/central-scan/backend/src/readiness_report.ts
@@ -34,7 +34,8 @@ export async function saveReadinessReport({
   const markThresholds = store.getSystemSettings()?.markThresholds;
   const report = CentralScanReadinessReport({
     batteryInfo:
-      (await getBatteryInfo()) ?? /* istanbul ignore next */ undefined,
+      (await getBatteryInfo()) ??
+      /* istanbul ignore next - @preserve */ undefined,
     diskSpaceSummary: await workspace.getDiskSpaceSummary(),
     isScannerAttached,
     mostRecentScannerDiagnostic:

--- a/apps/central-scan/backend/src/server.ts
+++ b/apps/central-scan/backend/src/server.ts
@@ -46,7 +46,7 @@ export function start({
 }: Partial<StartOptions> = {}): Server {
   detectDevices({ logger: baseLogger });
   let resolvedWorkspace = workspace;
-  /* istanbul ignore next */
+  /* istanbul ignore next - @preserve */
   if (!resolvedWorkspace) {
     const workspacePath = SCAN_WORKSPACE;
     if (!workspacePath) {
@@ -67,7 +67,7 @@ export function start({
   resolvedWorkspace.store.cleanupIncompleteBatches();
 
   let resolvedApp = app;
-  /* istanbul ignore next */
+  /* istanbul ignore next - @preserve */
   if (!resolvedApp) {
     const auth = new DippedSmartCardAuth({
       card:

--- a/apps/central-scan/backend/vitest.config.ts
+++ b/apps/central-scan/backend/vitest.config.ts
@@ -18,8 +18,8 @@ export default defineConfig({
         'test/**/*',
       ],
       thresholds: {
-        lines: 90,
-        branches: 82,
+        lines: -50,
+        branches: -42,
       },
     },
     // Ensure only one instance of each library is loaded by loading the TS

--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -83,7 +83,7 @@
     "@types/react": "18.3.3",
     "@types/tmp": "0.2.4",
     "@types/uuid": "9.0.5",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/ballot-interpreter": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/fs": "workspace:*",
@@ -98,7 +98,7 @@
     "lodash.get": "^4.4.2",
     "nodemon": "^3.1.7",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "engines": {
     "node": ">= 12"

--- a/apps/design/backend/src/test_decks.test.ts
+++ b/apps/design/backend/src/test_decks.test.ts
@@ -22,7 +22,7 @@ import {
 } from './test_decks';
 
 vi.setConfig({
-  testTimeout: 30000,
+  testTimeout: 60_000,
 });
 
 let renderer: Renderer;

--- a/apps/design/backend/vitest.config.ts
+++ b/apps/design/backend/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 89,
-        branches: 78,
+        lines: -87,
+        branches: -59,
       },
       exclude: ['src/configure_sentry.ts', '**/*.test.ts'],
     },

--- a/apps/mark-scan/backend/package.json
+++ b/apps/mark-scan/backend/package.json
@@ -71,7 +71,7 @@
     "@types/react": "18.3.3",
     "@types/tmp": "0.2.4",
     "@types/uuid": "9.0.5",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "copyfiles": "^2.4.1",
@@ -83,7 +83,7 @@
     "lint-staged": "11.0.0",
     "nodemon": "^3.1.7",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "engines": {
     "node": ">= 16"

--- a/apps/mark-scan/backend/vitest.config.ts
+++ b/apps/mark-scan/backend/vitest.config.ts
@@ -10,8 +10,8 @@ export default defineConfig({
     ],
     coverage: {
       thresholds: {
-        lines: 94,
-        branches: 88,
+        lines: -21,
+        branches: -22,
       },
       exclude: [
         '**/*.d.ts',

--- a/apps/mark/backend/package.json
+++ b/apps/mark/backend/package.json
@@ -58,7 +58,7 @@
     "@types/node": "20.16.0",
     "@types/react": "18.3.3",
     "@types/tmp": "0.2.4",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "esbuild": "0.21.2",
@@ -69,7 +69,7 @@
     "lint-staged": "11.0.0",
     "nodemon": "^3.1.7",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "engines": {
     "node": ">= 16"

--- a/apps/mark/backend/vitest.config.ts
+++ b/apps/mark/backend/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: 100,
-        branches: 98,
+        branches: -1,
       },
       exclude: [
         '**/*.d.ts',

--- a/apps/pollbook/backend/package.json
+++ b/apps/pollbook/backend/package.json
@@ -70,7 +70,7 @@
     "@types/tmp": "0.2.4",
     "@types/uuid": "9.0.5",
     "@types/yargs": "17.0.22",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/image-utils": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
@@ -83,7 +83,7 @@
     "nodemon": "^3.1.7",
     "sort-package-json": "^1.50.0",
     "tmp": "^0.2.1",
-    "vitest": "^2.1.8",
+    "vitest": "^3.1.1",
     "yargs": "17.7.1"
   },
   "engines": {

--- a/apps/pollbook/backend/src/backup_worker.test.ts
+++ b/apps/pollbook/backend/src/backup_worker.test.ts
@@ -6,7 +6,7 @@ import { getBackupPaperChecklistPdfs } from './backup_worker';
 import { LocalStore } from './local_store';
 
 vitest.setConfig({
-  testTimeout: 30_000,
+  testTimeout: 45_000,
 });
 
 test('can export paper backup checklist', async () => {

--- a/apps/pollbook/backend/src/index.ts
+++ b/apps/pollbook/backend/src/index.ts
@@ -1,4 +1,4 @@
-/* istanbul ignore file */
+/* istanbul ignore file - @preserve */
 
 import { resolve } from 'node:path';
 import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';

--- a/apps/pollbook/backend/vitest.config.ts
+++ b/apps/pollbook/backend/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 78,
-        branches: 70,
+        lines: -200,
+        branches: -119,
       },
       exclude: [
         '**/node_modules/**',

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -76,7 +76,7 @@
     "@types/supertest": "^2.0.10",
     "@types/tmp": "0.2.4",
     "@types/uuid": "9.0.5",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/fixtures": "workspace:*",
     "esbuild": "0.21.2",
     "esbuild-runner": "2.2.2",
@@ -89,7 +89,7 @@
     "nodemon": "^3.1.7",
     "sort-package-json": "^1.50.0",
     "supertest": "^6.0.1",
-    "vitest": "^2.1.8",
+    "vitest": "^3.1.1",
     "wait-for-expect": "^3.0.2"
   },
   "engines": {

--- a/apps/scan/backend/src/export.ts
+++ b/apps/scan/backend/src/export.ts
@@ -97,7 +97,7 @@ export async function exportCastVoteRecordsToUsbDrive({
       });
       break;
     }
-    /* istanbul ignore next: Compile-time check for completeness */
+    /* istanbul ignore next: Compile-time check for completeness - @preserve */
     default: {
       throwIllegalValue(mode);
     }

--- a/apps/scan/backend/src/interpret.ts
+++ b/apps/scan/backend/src/interpret.ts
@@ -28,7 +28,7 @@ export function combinePageInterpretationsForSheet(
     (frontType === 'InterpretedBmdPage' && backType === 'BlankPage') ||
     (backType === 'InterpretedBmdPage' && frontType === 'BlankPage')
   ) {
-    /* istanbul ignore next */
+    /* istanbul ignore next - @preserve */
     const printedPage = frontType === 'InterpretedBmdPage' ? front : back;
     const interpretation = printedPage.interpretation as InterpretedBmdPage;
 

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -1343,7 +1343,7 @@ export function createPrecinctScannerStateMachine({
               type: interpretation.type,
               reasons: interpretation.reasons,
             };
-          /* istanbul ignore next */
+          /* istanbul ignore next - @preserve */
           default:
             throwIllegalValue(interpretation, 'type');
         }
@@ -1376,19 +1376,19 @@ export function createPrecinctScannerStateMachine({
       machineService.stop();
     },
 
-    /* istanbul ignore next */
+    /* istanbul ignore next - @preserve */
     beginDoubleFeedCalibration() {
       throw new Error('Not supported');
     },
-    /* istanbul ignore next */
+    /* istanbul ignore next - @preserve */
     endDoubleFeedCalibration() {
       throw new Error('Not supported');
     },
-    /* istanbul ignore next */
+    /* istanbul ignore next - @preserve */
     beginScannerDiagnostic() {
       throw new Error('Not supported');
     },
-    /* istanbul ignore next */
+    /* istanbul ignore next - @preserve */
     endScannerDiagnostic() {
       throw new Error('Not supported');
     },

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -410,10 +410,10 @@ function buildMachine({
         invoke: [
           {
             src: async () => {
-              /* istanbul ignore next */
+              /* istanbul ignore next - @preserve */
               scanAndInterpretTimer?.checkpoint('accepting');
               (await scannerClient.ejectDocument('toRear')).unsafeUnwrap();
-              /* istanbul ignore next */
+              /* istanbul ignore next - @preserve */
               scanAndInterpretTimer?.checkpoint('eject command sent');
             },
             onDone: 'checkingComplete',
@@ -494,7 +494,7 @@ function buildMachine({
             target: '#error',
             actions: assign({
               error:
-                /* istanbul ignore next - fallback case, shouldn't happen */
+                /* istanbul ignore next - fallback case, shouldn't happen - @preserve */
                 (_, { event }) =>
                   new PrecinctScannerError(
                     'unexpected_event',
@@ -739,13 +739,13 @@ function buildMachine({
           id: 'interpreting',
           invoke: {
             src: async ({ scanImages }) => {
-              /* istanbul ignore next */
+              /* istanbul ignore next - @preserve */
               scanAndInterpretTimer?.checkpoint('interpreting');
               const result = await interpretSheet(
                 workspace,
                 assertDefined(scanImages)
               );
-              /* istanbul ignore next */
+              /* istanbul ignore next - @preserve */
               scanAndInterpretTimer?.checkpoint('interpretComplete');
               return result;
             },
@@ -785,7 +785,7 @@ function buildMachine({
         accepted: {
           id: 'accepted',
           entry: async (context) => {
-            /* istanbul ignore next */
+            /* istanbul ignore next - @preserve */
             scanAndInterpretTimer?.checkpoint('accepted');
             await recordAcceptedSheet(
               workspace,
@@ -793,9 +793,9 @@ function buildMachine({
               assertDefined(context.interpretation),
               logger
             );
-            /* istanbul ignore next */
+            /* istanbul ignore next - @preserve */
             scanAndInterpretTimer?.checkpoint('recordAcceptedSheet complete');
-            /* istanbul ignore next */
+            /* istanbul ignore next - @preserve */
             scanAndInterpretTimer?.end();
             scanAndInterpretTimer = undefined;
           },
@@ -1153,7 +1153,7 @@ function setupLogging(
         await logger.logAsCurrentRole(
           LogEventId.ScannerEvent,
           { message: `Event: ${event.type}`, eventObject: eventString },
-          /* istanbul ignore next */
+          /* istanbul ignore next - @preserve */
           () => debug(`Event: ${eventString}`),
           'cardless_voter'
         );
@@ -1168,7 +1168,7 @@ function setupLogging(
       }
     })
     .onChange((context, previousContext) => {
-      /* istanbul ignore next */
+      /* istanbul ignore next - @preserve */
       if (!previousContext) return;
       const changed = Object.entries(context).filter(
         ([key, value]) => previousContext[key as keyof Context] !== value
@@ -1265,7 +1265,7 @@ export function createPrecinctScannerStateMachine({
           case state.matches('accepting.paperInFront'):
           case state.matches('acceptingAfterReview.paperInFront'):
             return 'both_sides_have_paper';
-          /* istanbul ignore next - state transitions too quickly to test */
+          /* istanbul ignore next - state transitions too quickly to test - @preserve */
           case state.matches('readyToAccept'):
           case state.matches('accepting'):
             return 'accepting';
@@ -1287,7 +1287,7 @@ export function createPrecinctScannerStateMachine({
             return 'jammed';
           case state.matches('coverOpen'):
             return 'cover_open';
-          /* istanbul ignore next - state transitions too quickly to test */
+          /* istanbul ignore next - state transitions too quickly to test - @preserve */
           case state.matches('error'):
           case state.matches('unrecoverableError'):
             return 'unrecoverable_error';
@@ -1303,7 +1303,7 @@ export function createPrecinctScannerStateMachine({
             return 'scanner_diagnostic.done';
           case state.matches('scannerDiagnostic'):
             return 'scanner_diagnostic.running';
-          /* istanbul ignore next */
+          /* istanbul ignore next - @preserve */
           default:
             throw new Error(`Unexpected state: ${state.value}`);
         }
@@ -1327,7 +1327,7 @@ export function createPrecinctScannerStateMachine({
               type: interpretation.type,
               reasons: interpretation.reasons,
             };
-          /* istanbul ignore next */
+          /* istanbul ignore next - @preserve */
           default:
             return throwIllegalValue(interpretation, 'type');
         }
@@ -1354,13 +1354,13 @@ export function createPrecinctScannerStateMachine({
     },
 
     accept: () => {
-      /* istanbul ignore next */
+      /* istanbul ignore next - @preserve */
       scanAndInterpretTimer?.checkpoint('ACCEPT');
       machineService.send('ACCEPT');
     },
 
     return: () => {
-      /* istanbul ignore next */
+      /* istanbul ignore next - @preserve */
       scanAndInterpretTimer?.checkpoint('RETURN');
       machineService.send('RETURN');
     },

--- a/apps/scan/backend/src/server.ts
+++ b/apps/scan/backend/src/server.ts
@@ -47,7 +47,7 @@ export function start({
   const mockPdiScanner = isFeatureFlagEnabled(
     BooleanEnvironmentVariableName.USE_MOCK_PDI_SCANNER
   )
-    ? /* istanbul ignore next */
+    ? /* istanbul ignore next - @preserve */
       createMockPdiScanner()
     : undefined;
 
@@ -63,7 +63,7 @@ export function start({
       })
     : pdiStateMachine.createPrecinctScannerStateMachine({
         scannerClient:
-          /* istanbul ignore next */
+          /* istanbul ignore next - @preserve */
           mockPdiScanner?.client ?? createPdiScannerClient(),
         workspace,
         usbDrive: resolvedUsbDrive,

--- a/apps/scan/backend/src/util/diagnostics.ts
+++ b/apps/scan/backend/src/util/diagnostics.ts
@@ -22,11 +22,11 @@ export function testPrintFailureDiagnosticMessage(
           return 'The printer experienced a data transmission error during printing.';
         case 'hardware':
           return 'The printer experienced an unknown hardware error during printing.';
-        /* istanbul ignore next */
+        /* istanbul ignore next - @preserve */
         default:
           throwIllegalValue(failureStatus.type);
       }
-    /* istanbul ignore next */
+    /* istanbul ignore next - @preserve */
     // eslint-disable-next-line no-fallthrough
     default:
       throwIllegalValue(failureStatus, 'state');

--- a/apps/scan/backend/vitest.config.ts
+++ b/apps/scan/backend/vitest.config.ts
@@ -10,8 +10,8 @@ export default defineConfig({
     ],
     coverage: {
       thresholds: {
-        lines: 94,
-        branches: 87,
+        lines: -54,
+        branches: -58,
       },
       exclude: [
         '**/node_modules/**',

--- a/libs/auth/src/test_utils.ts
+++ b/libs/auth/src/test_utils.ts
@@ -5,7 +5,10 @@ import {
 import type { Mocked, vi } from 'vitest';
 
 import { DippedSmartCardAuthApi } from './dipped_smart_card_auth_api';
-import { InsertedSmartCardAuthApi } from './inserted_smart_card_auth_api';
+import {
+  InsertedSmartCardAuthApi,
+  InsertedSmartCardAuthMachineState,
+} from './inserted_smart_card_auth_api';
 
 /**
  * Builds a mock dipped smart card auth instance for application-level tests
@@ -32,8 +35,9 @@ export function buildMockInsertedSmartCardAuth(
   fn: typeof vi.fn
 ): Mocked<InsertedSmartCardAuthApi> {
   return {
-    getAuthStatus: fn().mockResolvedValue(
-      InsertedSmartCardAuthTypes.DEFAULT_AUTH_STATUS
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    getAuthStatus: fn((machineState: InsertedSmartCardAuthMachineState) =>
+      Promise.resolve(InsertedSmartCardAuthTypes.DEFAULT_AUTH_STATUS)
     ),
     checkPin: fn(),
     logOut: fn(),

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -67,7 +67,7 @@
     "@types/stream-chopper": "workspace:*",
     "@types/stream-json": "^1.7.3",
     "@types/tmp": "0.2.4",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/fs": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
@@ -78,7 +78,7 @@
     "lodash.set": "^4.3.2",
     "memory-streams": "^0.1.3",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/backend/src/cast_vote_records/build_cast_vote_record.ts
+++ b/libs/backend/src/cast_vote_records/build_cast_vote_record.ts
@@ -425,8 +425,8 @@ export function buildCVRContestsFromVotes({
           })
         );
         break;
+      /* istanbul ignore next - @preserve */
       default:
-        /* istanbul ignore next - @preserve */
         throwIllegalValue(contest);
     }
   }

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -497,7 +497,7 @@ async function exportCastVoteRecordFilesToUsbDrive(
       path.join(castVoteRecordId, file.fileName),
       file.open()
     );
-    /* istanbul ignore next: Hard to trigger without significant mocking */
+    /* istanbul ignore next: Hard to trigger without significant mocking - @preserve */
     if (exportResult.isErr()) {
       return exportResult;
     }
@@ -531,7 +531,7 @@ async function exportRejectedSheetToUsbDrive(
       path.join(subDirectoryName, file.fileName),
       file.open()
     );
-    /* istanbul ignore next: Hard to trigger without significant mocking */
+    /* istanbul ignore next: Hard to trigger without significant mocking - @preserve  */
     if (exportResult.isErr()) {
       return exportResult;
     }
@@ -591,7 +591,7 @@ async function exportMetadataFileToUsbDrive(
     CastVoteRecordExportFileName.METADATA,
     metadataFileContents
   );
-  /* istanbul ignore next: Hard to trigger without significant mocking */
+  /* istanbul ignore next: Hard to trigger without significant mocking - @preserve  */
   if (exportResult.isErr()) {
     return exportResult;
   }
@@ -622,7 +622,7 @@ async function exportSignatureFileToUsbDrive(
     signatureFile.fileName,
     signatureFile.fileContents
   );
-  /* istanbul ignore next: Hard to trigger without significant mocking */
+  /* istanbul ignore next: Hard to trigger without significant mocking - @preserve  */
   if (exportResult.isErr()) {
     return exportResult;
   }
@@ -797,7 +797,7 @@ export async function exportCastVoteRecordsToUsbDrive(
         sheet,
         exportDirectoryPathRelativeToUsbMountPoint
       );
-      /* istanbul ignore next: Hard to trigger without significant mocking */
+      /* istanbul ignore next: Hard to trigger without significant mocking - @preserve  */
       if (exportResult.isErr()) {
         return exportResult;
       }
@@ -860,7 +860,7 @@ export async function exportCastVoteRecordsToUsbDrive(
     updatedCastVoteRecordRootHash,
     exportDirectoryPathRelativeToUsbMountPoint
   );
-  /* istanbul ignore next: Hard to trigger without significant mocking */
+  /* istanbul ignore next: Hard to trigger without significant mocking - @preserve  */
   if (exportMetadataFileResult.isErr()) {
     return exportMetadataFileResult;
   }
@@ -871,7 +871,7 @@ export async function exportCastVoteRecordsToUsbDrive(
     metadataFileContents,
     exportDirectoryPathRelativeToUsbMountPoint
   );
-  /* istanbul ignore next: Hard to trigger without significant mocking */
+  /* istanbul ignore next: Hard to trigger without significant mocking - @preserve  */
   if (exportSignatureFileResult.isErr()) {
     return exportSignatureFileResult;
   }

--- a/libs/backend/src/language_and_audio/speech_synthesizer.ts
+++ b/libs/backend/src/language_and_audio/speech_synthesizer.ts
@@ -65,7 +65,7 @@ export class GoogleCloudSpeechSynthesizer implements SpeechSynthesizer {
   }) {
     this.textToSpeechClient =
       input.textToSpeechClient ??
-      /* istanbul ignore next */ new GoogleCloudTextToSpeechClient();
+      /* istanbul ignore next - @preserve */ new GoogleCloudTextToSpeechClient();
   }
 
   async synthesizeSpeech(

--- a/libs/backend/vitest.config.ts
+++ b/libs/backend/vitest.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
     setupFiles: ['./test/setupTests.ts'],
     coverage: {
       thresholds: {
-        lines: 98,
-        branches: 94,
+        lines: -8,
+        branches: -15,
       },
     },
   },

--- a/libs/image-utils/package.json
+++ b/libs/image-utils/package.json
@@ -39,7 +39,7 @@
     "@types/pdfjs-dist": "2.1.3",
     "@types/pixelmatch": "^5.2.6",
     "@types/tmp": "0.2.4",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/fixtures": "workspace:*",
     "esbuild": "0.21.2",
     "esbuild-runner": "2.2.2",
@@ -47,6 +47,6 @@
     "fast-check": "2.23.2",
     "is-ci-cli": "2.2.0",
     "lint-staged": "11.0.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   }
 }

--- a/libs/image-utils/src/image_data.ts
+++ b/libs/image-utils/src/image_data.ts
@@ -172,14 +172,14 @@ export async function encodeImageData(
   const encoded = await new Promise<Buffer>((resolve, reject) => {
     if (mimeType === 'image/png') {
       canvas.toBuffer(
-        /* istanbul ignore next */
+        /* istanbul ignore next - @preserve */
         (err, buffer) => (err ? reject(err) : resolve(buffer)),
         mimeType,
         config as PngConfig
       );
     } else {
       canvas.toBuffer(
-        /* istanbul ignore next */
+        /* istanbul ignore next - @preserve */
         (err, buffer) => (err ? reject(err) : resolve(buffer)),
         mimeType,
         config as JpegConfig

--- a/libs/image-utils/src/index.ts
+++ b/libs/image-utils/src/index.ts
@@ -1,4 +1,4 @@
-/* istanbul ignore file - this file should only have exports, no logic to test */
+/* istanbul ignore file - this file should only have exports, no logic to test - @preserve */
 export * from './crop';
 export * from './image_data';
 export * from './pdf_to_images';

--- a/libs/printing/package.json
+++ b/libs/printing/package.json
@@ -48,7 +48,7 @@
     "@types/react-dom": "18.3.0",
     "@types/styled-components": "^5.1.26",
     "@types/tmp": "0.2.4",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/image-utils": "workspace:*",
     "esbuild": "0.21.2",
@@ -58,7 +58,7 @@
     "jest-image-snapshot": "^6.4.0",
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1968,8 +1968,8 @@ importers:
         specifier: 0.2.4
         version: 0.2.4
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../../../libs/fixtures
@@ -2001,8 +2001,8 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.16.0)
 
   apps/mark/frontend:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 overrides:
   '@babel/traverse': 7.23.2
   '@types/eslint': 8.4.1
@@ -128,7 +124,7 @@ importers:
         version: 5.6.2
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(jsdom@20.0.1)
+        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
 
   apps/admin/backend:
     dependencies:
@@ -1468,7 +1464,7 @@ importers:
         version: 4.5.2(@types/node@20.16.0)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(jsdom@20.0.1)
+        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
 
   apps/mark-scan/backend:
     dependencies:
@@ -1833,7 +1829,7 @@ importers:
         version: 4.5.2(@types/node@20.16.0)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(jsdom@20.0.1)
+        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
 
   apps/mark-scan/frontend/prodserver:
     dependencies:
@@ -2211,7 +2207,7 @@ importers:
         version: 4.5.2(@types/node@20.16.0)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(jsdom@20.0.1)
+        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
 
   apps/mark/frontend/prodserver:
     dependencies:
@@ -2625,7 +2621,7 @@ importers:
         version: 4.5.2(@types/node@20.16.0)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(jsdom@20.0.1)
+        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
 
   apps/pollbook/frontend/prodserver:
     dependencies:
@@ -3107,7 +3103,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(jsdom@20.0.1)
+        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
 
   libs/auth:
     dependencies:
@@ -3213,7 +3209,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^3.1.1
-        version: 3.1.1(@types/debug@4.1.8)
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.16.0)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3339,8 +3335,8 @@ importers:
         specifier: 0.2.4
         version: 0.2.4
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures
@@ -3372,8 +3368,8 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.16.0)
 
   libs/ballot-encoder:
     dependencies:
@@ -3632,7 +3628,7 @@ importers:
         version: 0.12.4
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(jsdom@20.0.1)
+        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
 
   libs/cdf-schema-builder:
     dependencies:
@@ -4403,7 +4399,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(jsdom@20.0.1)
+        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
 
   libs/grout/test-utils:
     dependencies:
@@ -4434,7 +4430,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(jsdom@20.0.1)
+        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
 
   libs/hmpb:
     dependencies:
@@ -4737,7 +4733,7 @@ importers:
         version: 0.2.1
       vitest:
         specifier: ^3.1.1
-        version: 3.1.1(@types/debug@4.1.8)
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.16.0)
 
   libs/mark-flow-ui:
     dependencies:
@@ -9632,7 +9628,7 @@ packages:
   /@joshwooding/vite-plugin-react-docgen-typescript@0.2.1(typescript@5.6.2)(vite@4.5.2):
     resolution: {integrity: sha512-ou4ZJSXMMWHqGS4g8uNRbC5TiTWxAgQZiVucoUrOCWuPrTbkpJbmVyIi9jU72SBry7gQtuMEDp4YR8EEXAg7VQ==}
     peerDependencies:
-      typescript: 5.6.2
+      typescript: '>= 4.3.x'
       vite: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       typescript:
@@ -10720,7 +10716,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       estree-walker: 2.0.2
       picomatch: 2.3.1
     dev: true
@@ -12092,7 +12088,7 @@ packages:
     resolution: {integrity: sha512-3YDxZPJsHOsRQob/85X2Xf6pYfwbQilJBsEcuwmEV0JEO4p3JijOlO8xV58uCjkZSpuJ0ARl6t5oCMBo89DKCQ==}
     peerDependencies:
       '@preact/preset-vite': '*'
-      typescript: 5.6.2
+      typescript: '>= 4.3.x'
       vite: ^3.0.0 || ^4.0.0
       vite-plugin-glimmerx: '*'
     peerDependenciesMeta:
@@ -12550,7 +12546,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-      typescript: 5.6.2
+      typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -13138,7 +13134,6 @@ packages:
 
   /@types/estree@1.0.7:
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
-    dev: true
 
   /@types/express-serve-static-core@4.17.31:
     resolution: {integrity: sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==}
@@ -14087,7 +14082,7 @@ packages:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.1(@types/debug@4.1.8)
+      vitest: 3.1.1(@types/debug@4.1.8)(@types/node@20.16.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -14139,7 +14134,7 @@ packages:
       '@vitest/spy': 3.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
-      vite: 6.3.1
+      vite: 6.3.1(@types/node@20.16.0)
     dev: true
 
   /@vitest/pretty-format@2.1.8:
@@ -17389,7 +17384,7 @@ packages:
     resolution: {integrity: sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': 8.4.1
+      '@types/eslint': '>=8.0.0'
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
       prettier: '>=3.0.0'
@@ -17606,7 +17601,7 @@ packages:
   /estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -21271,12 +21266,12 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: true
 
   /nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+    dev: false
 
   /nanomatch@1.2.13:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
@@ -22327,7 +22322,7 @@ packages:
     resolution: {integrity: sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.7
+      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
     dev: true
@@ -22336,7 +22331,7 @@ packages:
     resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.7
+      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -22344,7 +22339,7 @@ packages:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.7
+      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -22928,7 +22923,7 @@ packages:
   /react-docgen-typescript@2.2.2(typescript@5.6.2):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
-      typescript: 5.6.2
+      typescript: '>= 4.3.x'
     dependencies:
       typescript: 5.6.2
     dev: true
@@ -25100,7 +25095,7 @@ packages:
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
     engines: {node: '>=16'}
     peerDependencies:
-      typescript: 5.6.2
+      typescript: '>=4.2.0'
     dependencies:
       typescript: 5.6.2
 
@@ -25119,7 +25114,7 @@ packages:
       babel-jest: ^29.0.0
       esbuild: '*'
       jest: ^29.0.0
-      typescript: 5.6.2
+      typescript: '>=4.3 <6'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -25165,7 +25160,7 @@ packages:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
-      typescript: 5.6.2
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
       typescript: 5.6.2
@@ -25699,7 +25694,7 @@ packages:
       - supports-color
       - terser
 
-  /vite-node@3.1.1:
+  /vite-node@3.1.1(@types/node@20.16.0):
     resolution: {integrity: sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -25708,7 +25703,7 @@ packages:
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.3.1
+      vite: 6.3.1(@types/node@20.16.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -25798,7 +25793,7 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
 
-  /vite@6.3.1:
+  /vite@6.3.1(@types/node@20.16.0):
     resolution: {integrity: sha512-kkzzkqtMESYklo96HKKPE5KKLkC1amlsqt+RjFMlX2AvbRB/0wghap19NdBxxwGZ+h/C6DLCrcEphPIItlGrRQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -25838,6 +25833,7 @@ packages:
       yaml:
         optional: true
     dependencies:
+      '@types/node': 20.16.0
       esbuild: 0.25.2
       fdir: 6.4.3(picomatch@4.0.2)
       picomatch: 4.0.2
@@ -25917,65 +25913,7 @@ packages:
       - supports-color
       - terser
 
-  /vitest@2.1.8(jsdom@20.0.1):
-    resolution: {integrity: sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.8
-      '@vitest/ui': 2.1.8
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.18)
-      '@vitest/pretty-format': 2.1.8
-      '@vitest/runner': 2.1.8
-      '@vitest/snapshot': 2.1.8
-      '@vitest/spy': 2.1.8
-      '@vitest/utils': 2.1.8
-      chai: 5.1.2
-      debug: 4.4.0
-      expect-type: 1.1.0
-      jsdom: 20.0.1
-      magic-string: 0.30.17
-      pathe: 1.1.2
-      std-env: 3.8.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.1
-      tinypool: 1.0.2
-      tinyrainbow: 1.2.0
-      vite: 5.4.18(@types/node@20.16.0)
-      vite-node: 2.1.8(@types/node@20.16.0)
-      why-is-node-running: 2.3.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
-  /vitest@3.1.1(@types/debug@4.1.8):
+  /vitest@3.1.1(@types/debug@4.1.8)(@types/node@20.16.0):
     resolution: {integrity: sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -26004,6 +25942,7 @@ packages:
         optional: true
     dependencies:
       '@types/debug': 4.1.8
+      '@types/node': 20.16.0
       '@vitest/expect': 3.1.1
       '@vitest/mocker': 3.1.1(vite@6.3.1)
       '@vitest/pretty-format': 3.1.1
@@ -26021,8 +25960,8 @@ packages:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.1
-      vite-node: 3.1.1
+      vite: 6.3.1(@types/node@20.16.0)
+      vite-node: 3.1.1(@types/node@20.16.0)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - jiti
@@ -26481,3 +26420,7 @@ packages:
   /zod@3.23.5:
     resolution: {integrity: sha512-fkwiq0VIQTksNNA131rDOsVJcns0pfVUjHzLrNBiF/O/Xxb5lQyEXkhZWcJ7npWsYlvs+h0jFWXXy4X46Em1JA==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1186,8 +1186,8 @@ importers:
         specifier: 9.0.5
         version: 9.0.5
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/ballot-interpreter':
         specifier: workspace:*
         version: link:../../../libs/ballot-interpreter
@@ -1231,8 +1231,8 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.16.0)
 
   apps/design/frontend:
     dependencies:
@@ -2388,8 +2388,8 @@ importers:
         specifier: 17.0.22
         version: 17.0.22
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../../../libs/fixtures
@@ -2427,8 +2427,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.16.0)
       yargs:
         specifier: 17.7.1
         version: 17.7.1
@@ -4602,8 +4602,8 @@ importers:
         specifier: 0.2.4
         version: 0.2.4
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures
@@ -4626,8 +4626,8 @@ importers:
         specifier: 11.0.0
         version: 11.0.0
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.16.0)
 
   libs/logging:
     dependencies:
@@ -5139,8 +5139,8 @@ importers:
         specifier: 0.2.4
         version: 0.2.4
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures
@@ -5169,8 +5169,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.16.0)
 
   libs/test-utils:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,8 +277,8 @@ importers:
         specifier: workspace:*
         version: link:../../../libs/@types/zip-stream
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../../../libs/fixtures
@@ -322,8 +322,8 @@ importers:
         specifier: ^6.0.1
         version: 6.1.1
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.16.0)
 
   apps/admin/frontend:
     dependencies:
@@ -763,8 +763,8 @@ importers:
         specifier: 9.0.5
         version: 9.0.5
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/bmd-ballot-fixtures':
         specifier: workspace:*
         version: link:../../../libs/bmd-ballot-fixtures
@@ -805,8 +805,8 @@ importers:
         specifier: ^6.0.1
         version: 6.1.1
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.16.0)
 
   apps/central-scan/frontend:
     dependencies:
@@ -1596,8 +1596,8 @@ importers:
         specifier: 9.0.5
         version: 9.0.5
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../../../libs/fixtures
@@ -1632,8 +1632,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.16.0)
 
   apps/mark-scan/frontend:
     dependencies:
@@ -2771,8 +2771,8 @@ importers:
         specifier: 9.0.5
         version: 9.0.5
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../../../libs/fixtures
@@ -2810,8 +2810,8 @@ importers:
         specifier: ^6.0.1
         version: 6.1.1
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.16.0)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.16.0)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2


### PR DESCRIPTION
## Overview

I thought to do a little mindless code contribution but actually this turned out to be a headache. I started with `libs/backend`, but because all the backends import test harnesses from `libs/backend`, conflicting package versions led me to upgrade all the backends. But because most of the backends import test utilities from `libs/image-utils`, I had to upgrade those and then other backends that import them.

In upgraded libraries, I've set the negative coverage thresholds to their maximum. The exception is `pollbook/backend`, which appears to have variable code coverage on every run, which seems bad, but is outside the scope of this PR.
