### PR TITLE
CircleCI Tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
           environment:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
-          path: apps/admin/integration-testing/reports/
+          path: apps/admin/integration-testing/test-results/
       - store_artifacts:
           path: apps/admin/integration-testing/test-results/
 
@@ -175,7 +175,7 @@ jobs:
           environment:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
-          path: apps/central-scan/integration-testing/reports/
+          path: apps/central-scan/integration-testing/test-results/
       - store_artifacts:
           path: apps/central-scan/integration-testing/test-results/
 
@@ -301,7 +301,7 @@ jobs:
           environment:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
-          path: apps/mark-scan/integration-testing/reports/
+          path: apps/mark-scan/integration-testing/test-results/
       - store_artifacts:
           path: apps/mark-scan/integration-testing/test-results/
 
@@ -379,7 +379,7 @@ jobs:
           environment:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
-          path: apps/mark/integration-testing/reports/
+          path: apps/mark/integration-testing/test-results/
       - store_artifacts:
           path: apps/mark/integration-testing/test-results/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1573,19 +1573,32 @@ commands:
       # comment will invalidate the cache without changing the behavior.
       # last edited by Kofi 2024-09-19
       - restore_cache:
+          name: Restore pnpm Cache
           key:
-            dotcache-cache-{{checksum ".circleci/config.yml" }}-{{ checksum
+            pnpm-cache-{{checksum ".circleci/config.yml" }}-{{ checksum
             "pnpm-lock.yaml" }}
+      - restore_cache:
+          name: Restore Cargo Cache
+          key:
+            cargo-cache-{{checksum ".circleci/config.yml" }}-{{ checksum
+            "Cargo.lock" }}
       - run:
           name: Setup Dependencies
           command: |
             pnpm install --frozen-lockfile
             pnpm --recursive install:rust-addon
       - save_cache:
+          name: Save pnpm Cache
           key:
-            dotcache-cache-{{checksum ".circleci/config.yml" }}-{{ checksum
+            pnpm-cache-{{checksum ".circleci/config.yml" }}-{{ checksum
             "pnpm-lock.yaml" }}
           paths:
             - /root/.local/share/pnpm/store/v3
             - /root/.cache/ms-playwright
+      - save_cache:
+          name: Save Cargo Cache
+          key:
+            cargo-cache-{{checksum ".circleci/config.yml" }}-{{ checksum
+            "Cargo.lock" }}
+          paths:
             - /root/.cargo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1581,7 +1581,6 @@ commands:
           command: |
             pnpm install --frozen-lockfile
             pnpm --recursive install:rust-addon
-            pnpm --recursive build:rust-addon
       - save_cache:
           key:
             dotcache-cache-{{checksum ".circleci/config.yml" }}-{{ checksum

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -213,7 +213,6 @@ commands:
           command: |
             pnpm install --frozen-lockfile
             pnpm --recursive install:rust-addon
-            pnpm --recursive build:rust-addon
       - save_cache:
           key:
             dotcache-cache-{{checksum ".circleci/config.yml" }}-{{ checksum

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -205,21 +205,34 @@ commands:
       # comment will invalidate the cache without changing the behavior.
       # last edited by Kofi 2024-09-19
       - restore_cache:
+          name: Restore pnpm Cache
           key:
-            dotcache-cache-{{checksum ".circleci/config.yml" }}-{{ checksum
+            pnpm-cache-{{checksum ".circleci/config.yml" }}-{{ checksum
             "pnpm-lock.yaml" }}
+      - restore_cache:
+          name: Restore Cargo Cache
+          key:
+            cargo-cache-{{checksum ".circleci/config.yml" }}-{{ checksum
+            "Cargo.lock" }}
       - run:
           name: Setup Dependencies
           command: |
             pnpm install --frozen-lockfile
             pnpm --recursive install:rust-addon
       - save_cache:
+          name: Save pnpm Cache
           key:
-            dotcache-cache-{{checksum ".circleci/config.yml" }}-{{ checksum
+            pnpm-cache-{{checksum ".circleci/config.yml" }}-{{ checksum
             "pnpm-lock.yaml" }}
           paths:
             - /root/.local/share/pnpm/store/v3
             - /root/.cache/ms-playwright
+      - save_cache:
+          name: Save Cargo Cache
+          key:
+            cargo-cache-{{checksum ".circleci/config.yml" }}-{{ checksum
+            "Cargo.lock" }}
+          paths:
             - /root/.cargo
 `.trim();
 }

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -55,7 +55,9 @@ function generateTestJobForNodeJsPackage(
     `        environment:`,
     `          JEST_JUNIT_OUTPUT_DIR: ./reports/`,
     `    - store_test_results:`,
-    `        path: ${pkg.relativePath}/reports/`,
+    `        path: ${pkg.relativePath}/${
+      hasPlaywrightTests ? 'test-results' : 'reports'
+    }/`,
   ];
 
   if (hasSnapshotTests || hasPlaywrightTests) {


### PR DESCRIPTION
There are three commits making three distinct tweaks:
1. We have still been compiling all our rust libraries on the "Setup Dependencies" phase, even though our build phase now does this in a smarter way, only installing when necessary. Removing that step reduces our overall credit usage on CircleCI by about 20%. 
2. We have been caching the cargo packages alongside the node modules, but only referencing the cache with the checksum of the pnpm lock file. I think this means that when the cargo lock file changes, the wrong packages can still be loaded from storage. It probably just reinstalls in a later step, but separating the two caches can allow persisting cargo packages even when pnpm packages change.
3. We weren't pointing to the right result files for playwright tests, so CircleCI wasn't tracking test results / flaky tests.
