### PR TITLE
VxAdmin: search for election packages on USB drive up to depth 3

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -372,7 +372,7 @@ function buildApi({
     > {
       const potentialElectionPackages: FileSystemEntry[] = [];
 
-      for await (const result of listDirectoryOnUsbDrive(usbDrive, '')) {
+      for await (const result of listDirectoryOnUsbDrive(usbDrive, '', 3)) {
         if (result.isErr()) {
           return result;
         }

--- a/libs/usb-drive/src/list_directory_on_usb_drive.ts
+++ b/libs/usb-drive/src/list_directory_on_usb_drive.ts
@@ -20,7 +20,8 @@ export type ListDirectoryOnUsbDriveError =
  */
 export async function* listDirectoryOnUsbDrive(
   usbDrive: UsbDrive,
-  relativePath: string
+  relativePath: string,
+  depth = 1
 ): AsyncGenerator<Result<FileSystemEntry, ListDirectoryOnUsbDriveError>> {
   const usbDriveStatus = await usbDrive.status();
 
@@ -35,9 +36,13 @@ export async function* listDirectoryOnUsbDrive(
       break;
 
     case 'mounted':
-      yield* listDirectory(join(usbDriveStatus.mountPoint, relativePath));
+      yield* listDirectory(
+        join(usbDriveStatus.mountPoint, relativePath),
+        depth
+      );
       break;
 
+    /* istanbul ignore next - @preserve */
     default:
       throwIllegalValue(usbDriveStatus);
   }


### PR DESCRIPTION
## Overview

Closes #5673. Instead of only searching the root of the USB, also searches up to a depth of 3, which means that packages exported on VxAdmin will later be detected by an unconfigured VxAdmin. This is mostly to address internal annoyance during testing. There are probably few customer use cases because customers should be using freshly formatted drives, but if they are re-using a drive and do not place the VxDesign file at the root, it would likely be caught now.