### PR TITLE
bump `pollbook/backend` `vitest` threshold

### DIFF
--- a/apps/pollbook/backend/vitest.config.ts
+++ b/apps/pollbook/backend/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: -200,
-        branches: -119,
+        branches: -120,
       },
       exclude: [
         '**/node_modules/**',


### PR DESCRIPTION
## Overview

In #6345, I moved all upgraded packages, including `pollbook/backend`, to negative test thresholds. It seems like `pollbook/backend` has variable line coverage across runs. Perhaps due to inconsistent behavior across network simulations? To prevent these failures on main, bumping the threshold by 1. 