### PR TITLE
VxScan: fix test mode banner blipping out during scans

### DIFF
--- a/apps/scan/frontend/src/app_root.tsx
+++ b/apps/scan/frontend/src/app_root.tsx
@@ -284,7 +284,7 @@ export function AppRoot(): JSX.Element | null {
   if (pollsState !== 'polls_open') {
     return (
       <PollsNotOpenScreen
-        isLiveMode={!isTestMode}
+        isTestMode={isTestMode}
         pollsState={pollsState}
         scannedBallotCount={scannerStatus.ballotsCounted}
       />

--- a/apps/scan/frontend/src/components/layout.tsx
+++ b/apps/scan/frontend/src/components/layout.tsx
@@ -30,11 +30,11 @@ export interface ScreenProps {
   hideBallotCount?: boolean;
   centerContent?: boolean;
   children: React.ReactNode;
-  isLiveMode?: boolean;
   infoBarMode?: InfoBarMode;
   hideInfoBar?: boolean;
   padded?: boolean;
   title?: React.ReactNode;
+  showTestModeBanner: boolean;
   voterFacing: boolean;
 }
 
@@ -106,7 +106,7 @@ export function Screen(props: ScreenProps): JSX.Element | null {
     centerContent,
     infoBarMode,
     hideInfoBar: hideInfoBarFromProps,
-    isLiveMode = true,
+    showTestModeBanner,
     padded,
     title,
     voterFacing,
@@ -155,7 +155,7 @@ export function Screen(props: ScreenProps): JSX.Element | null {
 
   return (
     <ScreenBase>
-      {!isLiveMode && <TestMode />}
+      {showTestModeBanner && <TestMode />}
       {voterFacing && (
         <VoterHeader>
           <LanguageSettingsButton

--- a/apps/scan/frontend/src/screens/card_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/card_error_screen.tsx
@@ -3,7 +3,7 @@ import { CenteredText, ScreenMainCenterChild } from '../components/layout';
 
 export function CardErrorScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild voterFacing={false}>
+    <ScreenMainCenterChild voterFacing={false} showTestModeBanner={false}>
       <RotateCardImage />
       <CenteredText>
         <H1>Card Backward</H1>

--- a/apps/scan/frontend/src/screens/cast_vote_record_sync_required_screen.tsx
+++ b/apps/scan/frontend/src/screens/cast_vote_record_sync_required_screen.tsx
@@ -29,7 +29,7 @@ interface Props {
 
 export function CastVoteRecordSyncRequiredVoterScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild voterFacing={false}>
+    <ScreenMainCenterChild voterFacing={false} showTestModeBanner={false}>
       <FullScreenPromptLayout
         title={appStrings.titleScannerCvrSyncRequired()}
         image={
@@ -117,7 +117,7 @@ export function CastVoteRecordSyncRequiredScreen({
   }
 
   return (
-    <ScreenMainCenterChild voterFacing={false}>
+    <ScreenMainCenterChild voterFacing={false} showTestModeBanner={false}>
       <FullScreenPromptLayout
         title="CVR Sync Required"
         image={

--- a/apps/scan/frontend/src/screens/diagnostics_screen.tsx
+++ b/apps/scan/frontend/src/screens/diagnostics_screen.tsx
@@ -58,7 +58,12 @@ export function DiagnosticsScreen({
     !mostRecentScannerDiagnosticQuery.isSuccess
   ) {
     return (
-      <Screen title="Diagnostics" voterFacing={false} padded>
+      <Screen
+        title="Diagnostics"
+        voterFacing={false}
+        showTestModeBanner={false}
+        padded
+      >
         <Loading />
       </Screen>
     );
@@ -91,6 +96,7 @@ export function DiagnosticsScreen({
     <Screen
       title="Diagnostics"
       voterFacing={false}
+      showTestModeBanner={false}
       padded
       hideBallotCount
       hideInfoBar

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -339,6 +339,7 @@ export function ElectionManagerScreen({
       ballotCountOverride={scannerStatus.ballotsCounted}
       title="Election Manager Menu"
       voterFacing={false}
+      showTestModeBanner={false}
     >
       <TabbedSection aria-label="Election Manager Menu" tabs={tabs} />
 

--- a/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
+++ b/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
@@ -3,20 +3,20 @@ import { Screen } from '../components/layout';
 import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';
 
 interface Props {
-  isLiveMode: boolean;
   scannedBallotCount: number;
+  isTestMode: boolean;
 }
 
 export function InsertBallotScreen({
-  isLiveMode,
   scannedBallotCount,
+  isTestMode,
 }: Props): JSX.Element {
   return (
     <Screen
       centerContent
-      isLiveMode={isLiveMode}
       ballotCountOverride={scannedBallotCount}
       voterFacing
+      showTestModeBanner={isTestMode}
     >
       <FullScreenPromptLayout
         title={appStrings.titleScannerInsertBallotScreen()}
@@ -30,10 +30,10 @@ export function InsertBallotScreen({
 
 /* istanbul ignore next - @preserve */
 export function ZeroBallotsScannedPreview(): JSX.Element {
-  return <InsertBallotScreen scannedBallotCount={0} isLiveMode />;
+  return <InsertBallotScreen scannedBallotCount={0} isTestMode={false} />;
 }
 
 /* istanbul ignore next - @preserve */
 export function ManyBallotsScannedPreview(): JSX.Element {
-  return <InsertBallotScreen scannedBallotCount={1234} isLiveMode />;
+  return <InsertBallotScreen scannedBallotCount={1234} isTestMode={false} />;
 }

--- a/apps/scan/frontend/src/screens/insert_usb_screen.tsx
+++ b/apps/scan/frontend/src/screens/insert_usb_screen.tsx
@@ -8,7 +8,7 @@ export function InsertUsbScreen(): JSX.Element {
   React.useEffect(() => playAlarm(), [playAlarm]);
 
   return (
-    <ScreenMainCenterChild voterFacing={false}>
+    <ScreenMainCenterChild voterFacing={false} showTestModeBanner={false}>
       <CenteredText>
         <H1>No USB Drive Detected</H1>
         <P>Insert a USB drive into the USB hub.</P>

--- a/apps/scan/frontend/src/screens/internal_connection_problem_screen.tsx
+++ b/apps/scan/frontend/src/screens/internal_connection_problem_screen.tsx
@@ -37,7 +37,11 @@ export function InternalConnectionProblemScreen({
     printerStatus.scheme === 'hardware-v4' && printerStatus.state === 'error'
   );
   return (
-    <ScreenMainCenterChild ballotCountOverride={scannedBallotCount} voterFacing>
+    <ScreenMainCenterChild
+      ballotCountOverride={scannedBallotCount}
+      voterFacing
+      showTestModeBanner={false}
+    >
       <CenteredText>
         <H1>{appStrings.titleInternalConnectionProblem()}</H1>
         {!isScannerConnected && <P>{appStrings.noteScannerDisconnected()}</P>}

--- a/apps/scan/frontend/src/screens/invalid_card_screen.tsx
+++ b/apps/scan/frontend/src/screens/invalid_card_screen.tsx
@@ -9,7 +9,11 @@ export function InvalidCardScreen({
   authStatus: InsertedSmartCardAuth.LoggedOut;
 }): JSX.Element {
   return (
-    <ScreenMainCenterChild infoBarMode="pollworker" voterFacing={false}>
+    <ScreenMainCenterChild
+      infoBarMode="pollworker"
+      voterFacing={false}
+      showTestModeBanner={false}
+    >
       <SharedInvalidCardScreen
         reasonAndContext={authStatus}
         recommendedAction="Remove the card to continue."

--- a/apps/scan/frontend/src/screens/loading_configuration_screen.tsx
+++ b/apps/scan/frontend/src/screens/loading_configuration_screen.tsx
@@ -3,7 +3,7 @@ import { CenteredText, ScreenMainCenterChild } from '../components/layout';
 
 export function LoadingConfigurationScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild voterFacing={false}>
+    <ScreenMainCenterChild voterFacing={false} showTestModeBanner={false}>
       <LoadingAnimation />
       <CenteredText>
         <H1>Loading Configuration…</H1>

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -653,6 +653,7 @@ function PollWorkerScreenContents({
       title="Poll Worker Menu"
       infoBarMode="admin"
       voterFacing={false}
+      showTestModeBanner={false}
     >
       {content}
     </PlainScreen>

--- a/apps/scan/frontend/src/screens/poll_worker_shared.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_shared.tsx
@@ -6,12 +6,19 @@ import {
 } from '../components/layout';
 
 export function Screen(
-  props: Omit<CenteredScreenProps, 'infoBarMode' | 'voterFacing'>
+  props: Omit<
+    CenteredScreenProps,
+    'infoBarMode' | 'voterFacing' | 'showTestModeBanner'
+  >
 ): JSX.Element {
   const { children } = props;
 
   return (
-    <ScreenMainCenterChild infoBarMode="pollworker" voterFacing={false}>
+    <ScreenMainCenterChild
+      infoBarMode="pollworker"
+      voterFacing={false}
+      showTestModeBanner={false}
+    >
       {children}
     </ScreenMainCenterChild>
   );

--- a/apps/scan/frontend/src/screens/polls_not_open_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/polls_not_open_screen.test.tsx
@@ -35,7 +35,7 @@ function renderScreen(props: Partial<PollsNotOpenScreenProps> = {}) {
     provideApi(
       apiMock,
       <PollsNotOpenScreen
-        isLiveMode
+        isTestMode={false}
         pollsState="polls_closed_initial"
         scannedBallotCount={TEST_BALLOT_COUNT}
         {...props}

--- a/apps/scan/frontend/src/screens/polls_not_open_screen.tsx
+++ b/apps/scan/frontend/src/screens/polls_not_open_screen.tsx
@@ -4,20 +4,20 @@ import { Screen } from '../components/layout';
 import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';
 
 export interface PollsNotOpenScreenProps {
-  isLiveMode: boolean;
+  isTestMode: boolean;
   pollsState: Omit<PollsState, 'polls_open'>;
   scannedBallotCount: number;
 }
 
 export function PollsNotOpenScreen({
-  isLiveMode,
+  isTestMode,
   pollsState,
   scannedBallotCount,
 }: PollsNotOpenScreenProps): JSX.Element {
   return (
     <Screen
       centerContent
-      isLiveMode={isLiveMode}
+      showTestModeBanner={isTestMode}
       infoBarMode="pollworker"
       ballotCountOverride={scannedBallotCount}
       voterFacing={false}
@@ -50,7 +50,7 @@ export function PollsNotOpenScreen({
 export function DefaultPreview(): JSX.Element {
   return (
     <PollsNotOpenScreen
-      isLiveMode
+      isTestMode={false}
       pollsState="polls_closed_initial"
       scannedBallotCount={42}
     />
@@ -61,7 +61,7 @@ export function DefaultPreview(): JSX.Element {
 export function DefaultTestModePreview(): JSX.Element {
   return (
     <PollsNotOpenScreen
-      isLiveMode={false}
+      isTestMode
       pollsState="polls_closed_initial"
       scannedBallotCount={42}
     />
@@ -72,7 +72,7 @@ export function DefaultTestModePreview(): JSX.Element {
 export function NoPowerConnectedPreview(): JSX.Element {
   return (
     <PollsNotOpenScreen
-      isLiveMode
+      isTestMode={false}
       pollsState="polls_closed_initial"
       scannedBallotCount={42}
     />
@@ -83,7 +83,7 @@ export function NoPowerConnectedPreview(): JSX.Element {
 export function PollsPausedPreview(): JSX.Element {
   return (
     <PollsNotOpenScreen
-      isLiveMode
+      isTestMode={false}
       pollsState="polls_paused"
       scannedBallotCount={42}
     />
@@ -94,7 +94,7 @@ export function PollsPausedPreview(): JSX.Element {
 export function PollsClosedFinalPreview(): JSX.Element {
   return (
     <PollsNotOpenScreen
-      isLiveMode
+      isTestMode={false}
       pollsState="polls_closed_final"
       scannedBallotCount={42}
     />

--- a/apps/scan/frontend/src/screens/printer_cover_open_screen.tsx
+++ b/apps/scan/frontend/src/screens/printer_cover_open_screen.tsx
@@ -3,7 +3,7 @@ import { CenteredText, ScreenMainCenterChild } from '../components/layout';
 
 export function PrinterCoverOpenScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild voterFacing>
+    <ScreenMainCenterChild voterFacing showTestModeBanner={false}>
       <CenteredText>
         <H1>{appStrings.titlePrinterCoverIsOpen()}</H1>
         <P>{appStrings.instructionsAskForHelp()}</P>

--- a/apps/scan/frontend/src/screens/scan_busy_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_busy_screen.tsx
@@ -8,9 +8,15 @@ import {
 import { Screen } from '../components/layout';
 import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';
 
-export function ScanBusyScreen(): JSX.Element {
+export interface ScanBusyScreenProps {
+  isTestMode: boolean;
+}
+
+export function ScanBusyScreen({
+  isTestMode,
+}: ScanBusyScreenProps): JSX.Element {
   return (
-    <Screen centerContent voterFacing>
+    <Screen centerContent voterFacing showTestModeBanner={isTestMode}>
       <FullScreenPromptLayout
         title={appStrings.titleRemoveYourBallot()}
         image={
@@ -28,5 +34,5 @@ export function ScanBusyScreen(): JSX.Element {
 
 /* istanbul ignore next - @preserve */
 export function DefaultPreview(): JSX.Element {
-  return <ScanBusyScreen />;
+  return <ScanBusyScreen isTestMode={false} />;
 }

--- a/apps/scan/frontend/src/screens/scan_double_sheet_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_double_sheet_screen.test.tsx
@@ -23,7 +23,10 @@ afterEach(() => {
 
 test('renders double sheet screen as expected', async () => {
   render(
-    provideApi(apiMock, <ScanDoubleSheetScreen scannedBallotCount={42} />)
+    provideApi(
+      apiMock,
+      <ScanDoubleSheetScreen scannedBallotCount={42} isTestMode={false} />
+    )
   );
   await screen.findByText('Ballot Not Counted');
   await screen.findByText('Multiple sheets detected.');

--- a/apps/scan/frontend/src/screens/scan_double_sheet_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_double_sheet_screen.tsx
@@ -10,13 +10,20 @@ import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout'
 
 interface Props {
   scannedBallotCount: number;
+  isTestMode: boolean;
 }
 
 export function ScanDoubleSheetScreen({
   scannedBallotCount,
+  isTestMode,
 }: Props): JSX.Element {
   return (
-    <Screen centerContent ballotCountOverride={scannedBallotCount} voterFacing>
+    <Screen
+      centerContent
+      ballotCountOverride={scannedBallotCount}
+      voterFacing
+      showTestModeBanner={isTestMode}
+    >
       <FullScreenPromptLayout
         title={appStrings.titleScannerBallotNotCounted()}
         image={
@@ -39,5 +46,5 @@ export function ScanDoubleSheetScreen({
 
 /* istanbul ignore next - @preserve */
 export function DefaultPreview(): JSX.Element {
-  return <ScanDoubleSheetScreen scannedBallotCount={42} />;
+  return <ScanDoubleSheetScreen scannedBallotCount={42} isTestMode={false} />;
 }

--- a/apps/scan/frontend/src/screens/scan_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.tsx
@@ -73,7 +73,7 @@ export function ScanErrorScreen({
   return (
     <Screen
       centerContent
-      isLiveMode={!isTestMode}
+      showTestModeBanner={isTestMode}
       ballotCountOverride={scannedBallotCount}
       voterFacing
     >

--- a/apps/scan/frontend/src/screens/scan_jam_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_jam_screen.tsx
@@ -12,15 +12,22 @@ import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout'
 interface Props {
   error?: PrecinctScannerErrorType;
   scannedBallotCount: number;
+  isTestMode: boolean;
 }
 
 export function ScanJamScreen({
   error,
   scannedBallotCount,
+  isTestMode,
 }: Props): JSX.Element {
   const isOutfeedBlocked = error === 'outfeed_blocked';
   return (
-    <Screen centerContent ballotCountOverride={scannedBallotCount} voterFacing>
+    <Screen
+      centerContent
+      ballotCountOverride={scannedBallotCount}
+      voterFacing
+      showTestModeBanner={isTestMode}
+    >
       <FullScreenPromptLayout
         title={
           isOutfeedBlocked
@@ -42,5 +49,5 @@ export function ScanJamScreen({
 
 /* istanbul ignore next - @preserve */
 export function DefaultPreview(): JSX.Element {
-  return <ScanJamScreen scannedBallotCount={42} />;
+  return <ScanJamScreen scannedBallotCount={42} isTestMode={false} />;
 }

--- a/apps/scan/frontend/src/screens/scan_processing_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_processing_screen.tsx
@@ -1,9 +1,15 @@
 import { H1, LoadingAnimation, P, appStrings } from '@votingworks/ui';
 import { CenteredText, ScreenMainCenterChild } from '../components/layout';
 
-export function ScanProcessingScreen(): JSX.Element {
+export interface ScanProcessingScreenProps {
+  isTestMode: boolean;
+}
+
+export function ScanProcessingScreen({
+  isTestMode,
+}: ScanProcessingScreenProps): JSX.Element {
   return (
-    <ScreenMainCenterChild voterFacing>
+    <ScreenMainCenterChild voterFacing showTestModeBanner={isTestMode}>
       <LoadingAnimation />
       <CenteredText>
         <H1>{appStrings.titleScannerProcessingScreen()}</H1>
@@ -15,5 +21,5 @@ export function ScanProcessingScreen(): JSX.Element {
 
 /* istanbul ignore next - @preserve */
 export function DefaultPreview(): JSX.Element {
-  return <ScanProcessingScreen />;
+  return <ScanProcessingScreen isTestMode={false} />;
 }

--- a/apps/scan/frontend/src/screens/scan_returned_ballot_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_returned_ballot_screen.tsx
@@ -1,9 +1,15 @@
 import { Caption, H1, appStrings } from '@votingworks/ui';
 import { CenteredText, ScreenMainCenterChild } from '../components/layout';
 
-export function ScanReturnedBallotScreen(): JSX.Element {
+export interface ScanReturnedBallotScreenProps {
+  isTestMode: boolean;
+}
+
+export function ScanReturnedBallotScreen({
+  isTestMode,
+}: ScanReturnedBallotScreenProps): JSX.Element {
   return (
-    <ScreenMainCenterChild voterFacing>
+    <ScreenMainCenterChild voterFacing showTestModeBanner={isTestMode}>
       {/* TODO: make a graphic for this screen */}
       <CenteredText>
         <H1>{appStrings.titleRemoveYourBallot()}</H1>
@@ -15,5 +21,5 @@ export function ScanReturnedBallotScreen(): JSX.Element {
 
 /* istanbul ignore next - @preserve */
 export function DefaultPreview(): JSX.Element {
-  return <ScanReturnedBallotScreen />;
+  return <ScanReturnedBallotScreen isTestMode={false} />;
 }

--- a/apps/scan/frontend/src/screens/scan_success_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_success_screen.tsx
@@ -5,11 +5,20 @@ import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout'
 
 interface Props {
   scannedBallotCount: number;
+  isTestMode: boolean;
 }
 
-export function ScanSuccessScreen({ scannedBallotCount }: Props): JSX.Element {
+export function ScanSuccessScreen({
+  scannedBallotCount,
+  isTestMode,
+}: Props): JSX.Element {
   return (
-    <Screen centerContent ballotCountOverride={scannedBallotCount} voterFacing>
+    <Screen
+      centerContent
+      ballotCountOverride={scannedBallotCount}
+      voterFacing
+      showTestModeBanner={isTestMode}
+    >
       <FullScreenPromptLayout
         title={appStrings.titleScannerSuccessScreen()}
         image={
@@ -26,5 +35,5 @@ export function ScanSuccessScreen({ scannedBallotCount }: Props): JSX.Element {
 
 /* istanbul ignore next - @preserve */
 export function DefaultPreview(): JSX.Element {
-  return <ScanSuccessScreen scannedBallotCount={42} />;
+  return <ScanSuccessScreen scannedBallotCount={42} isTestMode={false} />;
 }

--- a/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
@@ -61,6 +61,7 @@ function renderScreen(props: Partial<Props> = {}) {
         electionDefinition={electionGeneralDefinition}
         systemSettings={DEFAULT_SYSTEM_SETTINGS}
         adjudicationReasonInfo={[]}
+        isTestMode={false}
         {...props}
       />
     )

--- a/apps/scan/frontend/src/screens/scan_warning_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.tsx
@@ -74,6 +74,7 @@ interface MisvoteWarningScreenProps {
   systemSettings: SystemSettings;
   overvotes: readonly OvervoteAdjudicationReasonInfo[];
   undervotes: readonly UndervoteAdjudicationReasonInfo[];
+  isTestMode: boolean;
 }
 
 function MisvoteWarningScreen({
@@ -81,6 +82,7 @@ function MisvoteWarningScreen({
   systemSettings,
   overvotes,
   undervotes,
+  isTestMode,
 }: MisvoteWarningScreenProps): JSX.Element {
   const returnBallotMutation = returnBallot.useMutation();
   const acceptBallotMutation = acceptBallot.useMutation();
@@ -155,6 +157,7 @@ function MisvoteWarningScreen({
         </React.Fragment>
       }
       voterFacing
+      showTestModeBanner={isTestMode}
     >
       <MisvoteWarnings
         blankContests={blankContests}
@@ -180,7 +183,13 @@ function MisvoteWarningScreen({
   );
 }
 
-function BlankBallotWarningScreen(): JSX.Element {
+interface BlankBallotWarningScreenProps {
+  isTestMode: boolean;
+}
+
+function BlankBallotWarningScreen({
+  isTestMode,
+}: BlankBallotWarningScreenProps): JSX.Element {
   const returnBallotMutation = returnBallot.useMutation();
   const acceptBallotMutation = acceptBallot.useMutation();
   const [confirmTabulate, setConfirmTabulate] = useState(false);
@@ -202,6 +211,7 @@ function BlankBallotWarningScreen(): JSX.Element {
       centerContent
       padded
       voterFacing
+      showTestModeBanner={isTestMode}
     >
       <FullScreenPromptLayout
         title={appStrings.titleScannerBallotWarningsScreen()}
@@ -225,7 +235,13 @@ function BlankBallotWarningScreen(): JSX.Element {
   );
 }
 
-function OtherReasonWarningScreen(): JSX.Element {
+interface OtherReasonWarningScreenProps {
+  isTestMode: boolean;
+}
+
+function OtherReasonWarningScreen({
+  isTestMode,
+}: OtherReasonWarningScreenProps): JSX.Element {
   const returnBallotMutation = returnBallot.useMutation();
   const acceptBallotMutation = acceptBallot.useMutation();
   const [confirmTabulate, setConfirmTabulate] = useState(false);
@@ -247,6 +263,7 @@ function OtherReasonWarningScreen(): JSX.Element {
       centerContent
       padded
       voterFacing
+      showTestModeBanner={isTestMode}
     >
       <FullScreenPromptLayout
         title={appStrings.titleScanningFailed()}
@@ -274,12 +291,14 @@ export interface Props {
   electionDefinition: ElectionDefinition;
   adjudicationReasonInfo: readonly AdjudicationReasonInfo[];
   systemSettings: SystemSettings;
+  isTestMode: boolean;
 }
 
 export function ScanWarningScreen({
   electionDefinition,
   adjudicationReasonInfo,
   systemSettings,
+  isTestMode,
 }: Props): JSX.Element {
   let isBlank = false;
   const overvoteReasons: OvervoteAdjudicationReasonInfo[] = [];
@@ -296,7 +315,7 @@ export function ScanWarningScreen({
   }
 
   if (isBlank) {
-    return <BlankBallotWarningScreen />;
+    return <BlankBallotWarningScreen isTestMode={isTestMode} />;
   }
 
   if (undervoteReasons.length > 0 || overvoteReasons.length > 0) {
@@ -306,11 +325,12 @@ export function ScanWarningScreen({
         systemSettings={systemSettings}
         undervotes={undervoteReasons}
         overvotes={overvoteReasons}
+        isTestMode={isTestMode}
       />
     );
   }
 
-  return <OtherReasonWarningScreen />;
+  return <OtherReasonWarningScreen isTestMode={isTestMode} />;
 }
 
 /* istanbul ignore next - @preserve */
@@ -346,6 +366,7 @@ export function OvervotePreview(): JSX.Element {
         },
       ]}
       systemSettings={DEFAULT_SYSTEM_SETTINGS}
+      isTestMode={false}
     />
   );
 }
@@ -376,6 +397,7 @@ export function UndervoteNoVotes1ContestPreview(): JSX.Element {
           expected: contest.seats,
         },
       ]}
+      isTestMode={false}
     />
   );
 }
@@ -404,6 +426,7 @@ export function UndervoteNoVotesManyContestsPreview(): JSX.Element {
         optionIds: [],
         expected: contest.seats,
       }))}
+      isTestMode={false}
     />
   );
 }
@@ -436,6 +459,7 @@ export function Undervote1ContestPreview(): JSX.Element {
           expected: contest.seats,
         },
       ]}
+      isTestMode={false}
     />
   );
 }
@@ -480,6 +504,7 @@ export function MixedOvervotesAndUndervotesPreview(): JSX.Element {
           expected: c.seats,
         })),
       ]}
+      isTestMode={false}
     />
   );
 }
@@ -498,6 +523,7 @@ export function BlankBallotPreview(): JSX.Element {
       electionDefinition={electionDefinition}
       systemSettings={DEFAULT_SYSTEM_SETTINGS}
       adjudicationReasonInfo={[{ type: AdjudicationReason.BlankBallot }]}
+      isTestMode={false}
     />
   );
 }

--- a/apps/scan/frontend/src/screens/scanner_cover_open_screen.tsx
+++ b/apps/scan/frontend/src/screens/scanner_cover_open_screen.tsx
@@ -3,7 +3,7 @@ import { CenteredText, ScreenMainCenterChild } from '../components/layout';
 
 export function ScannerCoverOpenScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild voterFacing>
+    <ScreenMainCenterChild voterFacing showTestModeBanner={false}>
       <CenteredText>
         <H1>{appStrings.titleScannerCoverIsOpen()}</H1>
         <P>{appStrings.instructionsAskForHelp()}</P>

--- a/apps/scan/frontend/src/screens/system_administrator_screen.tsx
+++ b/apps/scan/frontend/src/screens/system_administrator_screen.tsx
@@ -48,6 +48,7 @@ export function SystemAdministratorScreen({
     <Screen
       title="System Administrator Menu"
       voterFacing={false}
+      showTestModeBanner={false}
       infoBarMode="admin"
       padded
       hideBallotCount

--- a/apps/scan/frontend/src/screens/unconfigured_precinct_screen.tsx
+++ b/apps/scan/frontend/src/screens/unconfigured_precinct_screen.tsx
@@ -3,7 +3,7 @@ import { CenteredText, ScreenMainCenterChild } from '../components/layout';
 
 export function UnconfiguredPrecinctScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild voterFacing={false}>
+    <ScreenMainCenterChild voterFacing={false} showTestModeBanner={false}>
       <CenteredText>
         <H1>No Precinct Selected</H1>
         <P>Insert an election manager card to select a precinct.</P>

--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -85,6 +85,11 @@ export function VoterScreen({
       scannerStatus.state !== 'calibrating_double_feed_detection.done'
   );
 
+  const sharedScreenProps = {
+    isTestMode,
+    scannedBallotCount: scannerStatus.ballotsCounted,
+  } as const;
+
   switch (scannerStatus.state) {
     // This state should pass quickly, so we don't show a message
     case 'connecting':
@@ -97,21 +102,14 @@ export function VoterScreen({
     case 'scanner_diagnostic.running':
     case 'scanner_diagnostic.done':
     case 'no_paper':
-      return (
-        <InsertBallotScreen
-          isLiveMode={!isTestMode}
-          scannedBallotCount={scannerStatus.ballotsCounted}
-        />
-      );
+      return <InsertBallotScreen {...sharedScreenProps} />;
     case 'hardware_ready_to_scan':
     case 'scanning':
     case 'accepting':
     case 'returning_to_rescan':
-      return <ScanProcessingScreen />;
+      return <ScanProcessingScreen {...sharedScreenProps} />;
     case 'accepted':
-      return (
-        <ScanSuccessScreen scannedBallotCount={scannerStatus.ballotsCounted} />
-      );
+      return <ScanSuccessScreen {...sharedScreenProps} />;
     case 'needs_review':
     case 'accepting_after_review':
       assert(scannerStatus.interpretation?.type === 'NeedsReviewSheet');
@@ -120,11 +118,12 @@ export function VoterScreen({
           electionDefinition={electionDefinition}
           systemSettings={systemSettings}
           adjudicationReasonInfo={scannerStatus.interpretation.reasons}
+          {...sharedScreenProps}
         />
       );
     case 'returning':
     case 'returned':
-      return <ScanReturnedBallotScreen />;
+      return <ScanReturnedBallotScreen {...sharedScreenProps} />;
     case 'rejecting':
     case 'rejected':
       return (
@@ -134,34 +133,25 @@ export function VoterScreen({
               ? scannerStatus.interpretation.reason
               : scannerStatus.error
           }
-          isTestMode={isTestMode}
-          scannedBallotCount={scannerStatus.ballotsCounted}
+          {...sharedScreenProps}
         />
       );
     case 'jammed':
       return (
-        <ScanJamScreen
-          error={scannerStatus.error}
-          scannedBallotCount={scannerStatus.ballotsCounted}
-        />
+        <ScanJamScreen error={scannerStatus.error} {...sharedScreenProps} />
       );
     case 'double_sheet_jammed':
-      return (
-        <ScanDoubleSheetScreen
-          scannedBallotCount={scannerStatus.ballotsCounted}
-        />
-      );
+      return <ScanDoubleSheetScreen {...sharedScreenProps} />;
     case 'both_sides_have_paper':
-      return <ScanBusyScreen />;
+      return <ScanBusyScreen {...sharedScreenProps} />;
     case 'recovering_from_error':
-      return <ScanProcessingScreen />;
+      return <ScanProcessingScreen {...sharedScreenProps} />;
     case 'unrecoverable_error':
       return (
         <ScanErrorScreen
           error={scannerStatus.error}
-          isTestMode={isTestMode}
-          scannedBallotCount={scannerStatus.ballotsCounted}
           restartRequired
+          {...sharedScreenProps}
         />
       );
     /* istanbul ignore next - compile time check for completeness @preserve */


### PR DESCRIPTION
## Overview

Closes #5646. We currently show the test mode banner when polls are not open and no one is authenticated, or when polls are open on the "Insert Your Ballot" screen. In other words, the main screens where the machine is just sitting there.

But we are not showing the banner on all the screens in the voter flow, which leads to weird behavior of the test mode banner blipping out while scanning the ballot and after acceptance, but then coming back. This PR adds the banner to all screens that are part of the `VoterScreen`. 

## Demo Video or Screenshot

https://github.com/user-attachments/assets/059779eb-ca09-4030-acc5-f86c44eaf4c8