### PR TITLE
VxAll: update backend processes timezone when the system timezone is changed

### DIFF
--- a/libs/backend/src/system_call/api.test.ts
+++ b/libs/backend/src/system_call/api.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable prefer-regex-literals */
 
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi, afterEach } from 'vitest';
 import { MockUsbDrive, createMockUsbDrive } from '@votingworks/usb-drive';
 import { LogEventId, MockLogger, mockLogger } from '@votingworks/logging';
 import { SystemCallApiMethods, createSystemCallApi } from './api';
@@ -22,6 +22,8 @@ vi.mock(
 
 vi.mock(import('./get_audio_info.js'));
 
+const actualTimezone = process.env.TZ;
+
 let mockUsbDrive: MockUsbDrive;
 let logger: MockLogger;
 let api: SystemCallApiMethods;
@@ -37,6 +39,14 @@ beforeEach(() => {
     machineId: 'TEST-MACHINE-ID',
     codeVersion: 'TEST-CODE-VERSION',
   });
+});
+
+// setClock changes the process's TZ variable so it must be reset
+afterEach(() => {
+  process.env = {
+    ...process.env,
+    TZ: actualTimezone,
+  };
 });
 
 test('exportLogsToUsb', async () => {

--- a/libs/backend/src/system_call/set_clock.ts
+++ b/libs/backend/src/system_call/set_clock.ts
@@ -26,6 +26,7 @@ export async function setClock({
       ianaZone,
       datetimeString,
     ]);
+    process.env.TZ = ianaZone;
   } catch (err) {
     const error = err as Error;
     if ('stderr' in error) {


### PR DESCRIPTION
## Overview

Closes #6036. When the timezone is updated, it is properly reflected in the frontend UI because that timezone is pulled, within JavaScript, from the browser - which properly reflects changes in system timezone. The backend node process does not automatically reflect the timezone change, which is discussed, along with the fix applied, in [this issue
](https://github.com/nodejs/node/issues/33805). 

The bug experienced in the field was switching the correct time in CST (say 5pm) to the correct time in EST (say 6pm) but the reports after the switch still say the original time 5pm. The user experiences the time failing to change on reports. What's actually happening, however, is that the time and timezone is successfully changing at the system level, so backend knows it's 6pm EST, but it still thinks that it's CST, so it renders 6pm EST in CST.

## Demo Video or Screenshot

Before:

https://github.com/user-attachments/assets/edd404a9-1cf0-4601-b8a2-6a498ccabfdd

After:

https://github.com/user-attachments/assets/72964b6f-5a1f-4baa-96eb-6ec55d96be6b

## Testing Plan

- new automated tests written
- manually tested (videos above)

This is the kind of thing where it might be nice to have an integration testing, but because it runs a `sudo` required command that changes the system time, and I'm not sure if our CI docker image would allow that?
