### PR TITLE
fix(design): disable controls until "Edit" is clicked

### DIFF
--- a/apps/design/frontend/src/system_settings_screen.test.tsx
+++ b/apps/design/frontend/src/system_settings_screen.test.tsx
@@ -490,3 +490,36 @@ test('cancelling', async () => {
     })
   ).not.toBeChecked();
 });
+
+test('all controls are disabled until clicking "Edit"', async () => {
+  mockUserFeatures(apiMock, user, { MARGINAL_MARK_THRESHOLD: true });
+  const { systemSettings } = electionRecord;
+  apiMock.getUser.expectCallWith().resolves(user);
+  apiMock.getSystemSettings
+    .expectCallWith({ electionId })
+    .resolves(systemSettings);
+  renderScreen();
+
+  await screen.findByRole('heading', { name: 'System Settings' });
+
+  const allTextBoxes = document.body.querySelectorAll('input');
+
+  for (const textbox of allTextBoxes) {
+    expect(textbox.type).toMatch(/^text|number$/);
+  }
+
+  const allCheckboxes = document.body.querySelectorAll('[role=checkbox]');
+  const allControls = [...allTextBoxes, ...allCheckboxes];
+
+  expect(allControls).toHaveLength(24);
+
+  for (const control of allControls) {
+    expect(control).toBeDisabled();
+  }
+
+  userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+  for (const control of allControls) {
+    expect(control).not.toBeDisabled();
+  }
+});

--- a/apps/design/frontend/src/system_settings_screen.tsx
+++ b/apps/design/frontend/src/system_settings_screen.tsx
@@ -365,6 +365,7 @@ export function SystemSettingsForm({
                       isMulti={false}
                       isSearchable={false}
                       value={systemSettings.auth.inactiveSessionTimeLimitMinutes.toString()}
+                      disabled={!isEditing}
                       options={[
                         { value: '10', label: '10 minutes' },
                         { value: '15', label: '15 minutes' },
@@ -390,6 +391,7 @@ export function SystemSettingsForm({
                       isMulti={false}
                       isSearchable={false}
                       value={systemSettings.auth.numIncorrectPinAttemptsAllowedBeforeCardLockout.toString()}
+                      disabled={!isEditing}
                       options={[
                         { value: '3', label: '3' },
                         { value: '4', label: '4' },
@@ -418,6 +420,7 @@ export function SystemSettingsForm({
                       isMulti={false}
                       isSearchable={false}
                       value={systemSettings.auth.startingCardLockoutDurationSeconds.toString()}
+                      disabled={!isEditing}
                       options={[
                         { value: '15', label: '15 seconds' },
                         { value: '30', label: '30 seconds' },
@@ -444,6 +447,7 @@ export function SystemSettingsForm({
                       step={1}
                       min={1}
                       max={12}
+                      disabled={!isEditing}
                       onChange={(e) => {
                         setSystemSettings({
                           ...systemSettings,


### PR DESCRIPTION

## Overview

Ensure all form controls are disabled by default and enable them only after clicking the "Edit" button.

## Demo Video or Screenshot
![CleanShot 2025-04-30 at 14 10 28@2x](https://github.com/user-attachments/assets/abaa8376-89cd-4527-90fe-2acc99af5f1a)

## Testing Plan
- [x] Tested manually.
- [x] Added a test to ensure all controls are disabled.