### PR TITLE
VxAdmin: fix zero index manual tally bug

### DIFF
--- a/apps/admin/backend/src/exports/csv_shared.ts
+++ b/apps/admin/backend/src/exports/csv_shared.ts
@@ -5,11 +5,7 @@ import {
   Tabulation,
 } from '@votingworks/types';
 import { assert, assertDefined } from '@votingworks/basics';
-import {
-  getParentBallotStyleById,
-  getPartyById,
-  getPrecinctById,
-} from '@votingworks/utils';
+import { CachedElectionLookups } from '@votingworks/utils';
 import { ScannerBatchLookup } from '../types';
 import { Store } from '../store';
 
@@ -213,7 +209,9 @@ export function getCsvMetadataRowValues({
 
   if (metadataStructure.precinct === 'single') {
     const precinctId = assertOnlyElement(filter.precinctIds);
-    values.push(getPrecinctById(electionDefinition, precinctId).name);
+    values.push(
+      CachedElectionLookups.getPrecinctById(electionDefinition, precinctId).name
+    );
     values.push(precinctId);
   }
 
@@ -229,11 +227,16 @@ export function getCsvMetadataRowValues({
 
       const ballotStyleGroupId = assertOnlyElement(filter.ballotStyleGroupIds);
       return assertDefined(
-        getParentBallotStyleById(electionDefinition, ballotStyleGroupId).partyId
+        CachedElectionLookups.getParentBallotStyleById(
+          electionDefinition,
+          ballotStyleGroupId
+        ).partyId
       );
     })();
 
-    values.push(getPartyById(electionDefinition, partyId).name);
+    values.push(
+      CachedElectionLookups.getPartyById(electionDefinition, partyId).name
+    );
     values.push(partyId);
   }
 
@@ -281,7 +284,10 @@ export function getCsvMetadataRowValues({
   if (metadataStructure.precinct === 'multi') {
     values.push(
       assertDefined(filter.precinctIds)
-        .map((id) => getPrecinctById(electionDefinition, id).name)
+        .map(
+          (id) =>
+            CachedElectionLookups.getPrecinctById(electionDefinition, id).name
+        )
         .join(CSV_MULTI_VALUE_SEPARATOR)
     );
   }
@@ -289,7 +295,10 @@ export function getCsvMetadataRowValues({
   if (metadataStructure.party === 'multi') {
     values.push(
       assertDefined(filter.partyIds)
-        .map((id) => getPartyById(electionDefinition, id).name)
+        .map(
+          (id) =>
+            CachedElectionLookups.getPartyById(electionDefinition, id).name
+        )
         .join(CSV_MULTI_VALUE_SEPARATOR)
     );
   }

--- a/apps/admin/backend/src/reports/titles.ts
+++ b/apps/admin/backend/src/reports/titles.ts
@@ -7,11 +7,7 @@ import {
   ok,
   throwIllegalValue,
 } from '@votingworks/basics';
-import {
-  getDistrictById,
-  getPartyById,
-  getPrecinctById,
-} from '@votingworks/utils';
+import { CachedElectionLookups } from '@votingworks/utils';
 import { ScannerBatch } from '../types';
 
 const MANUAL_BATCH_REPORT_LABEL = 'Manual Tallies';
@@ -88,7 +84,10 @@ export function generateTitleForReport({
 
   const reportSuffix = (() => {
     if (precinctId) {
-      return getPrecinctById(electionDefinition, precinctId).name;
+      return CachedElectionLookups.getPrecinctById(
+        electionDefinition,
+        precinctId
+      ).name;
     }
 
     if (votingMethod) {
@@ -119,7 +118,8 @@ export function generateTitleForReport({
     }
 
     if (partyId) {
-      return getPartyById(electionDefinition, partyId).fullName;
+      return CachedElectionLookups.getPartyById(electionDefinition, partyId)
+        .fullName;
     }
 
     if (adjudicationFlag) {
@@ -140,7 +140,10 @@ export function generateTitleForReport({
     }
 
     if (districtId) {
-      return getDistrictById(electionDefinition, districtId).name;
+      return CachedElectionLookups.getDistrictById(
+        electionDefinition,
+        districtId
+      ).name;
     }
   })();
 

--- a/apps/admin/backend/src/util/cast_vote_records.ts
+++ b/apps/admin/backend/src/util/cast_vote_records.ts
@@ -1,5 +1,5 @@
 import { AnyContest, ElectionDefinition, Tabulation } from '@votingworks/types';
-import { getContestById } from '@votingworks/utils';
+import { CachedElectionLookups } from '@votingworks/utils';
 import { CastVoteRecordAdjudicationFlags } from '../types';
 
 function getNumberVotesAllowed(contest: AnyContest): number {
@@ -23,7 +23,10 @@ export function getCastVoteRecordAdjudicationFlags(
   let hasWriteIn = false;
 
   for (const [contestId, optionIds] of Object.entries(votes)) {
-    const contest = getContestById(electionDefinition, contestId);
+    const contest = CachedElectionLookups.getContestById(
+      electionDefinition,
+      contestId
+    );
 
     if (optionIds.length > 0) {
       isBlank = false;

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -1,6 +1,7 @@
 import {
   assert,
   assertDefined,
+  find,
   mapObject,
   throwIllegalValue,
 } from '@votingworks/basics';
@@ -41,7 +42,6 @@ import {
 } from '@votingworks/ui';
 import {
   format,
-  getContestById,
   getBallotStyleGroup,
   areContestResultsValid,
 } from '@votingworks/utils';
@@ -549,8 +549,8 @@ function ContestForm({
     getBallotStyleGroup({ election, ballotStyleGroupId })
   );
 
-  const contest = getContestById(electionDefinition, contestId);
   const contests = getContests({ election, ballotStyle: ballotStyleGroup });
+  const contest = find(contests, (c) => c.id === contestId);
   const contestIndex = contests.indexOf(contest);
   const nextContest = contests[contestIndex + 1];
   const previousContest = contests[contestIndex - 1];

--- a/apps/design/backend/src/test_decks.test.ts
+++ b/apps/design/backend/src/test_decks.test.ts
@@ -12,7 +12,7 @@ import {
 import { assert, find, iter } from '@votingworks/basics';
 import {
   buildContestResultsFixture,
-  getBallotStylesByPrecinctId,
+  CachedElectionLookups,
 } from '@votingworks/utils';
 import { ElectionDefinition, LanguageCode } from '@votingworks/types';
 import {
@@ -40,7 +40,10 @@ describe('createPrecinctTestDeck', () => {
     const { election } = electionDefinition;
     const precinctId = election.precincts[0].id;
     assert(
-      getBallotStylesByPrecinctId(electionDefinition, precinctId).length === 1
+      CachedElectionLookups.getBallotStylesByPrecinctId(
+        electionDefinition,
+        precinctId
+      ).length === 1
     );
     const { ballotDocuments } =
       await renderAllBallotsAndCreateElectionDefinition(
@@ -82,7 +85,10 @@ describe('createPrecinctTestDeck', () => {
     const { election } = electionDefinition;
     const precinctId = election.precincts[0].id;
     assert(
-      getBallotStylesByPrecinctId(electionDefinition, precinctId).length > 1
+      CachedElectionLookups.getBallotStylesByPrecinctId(
+        electionDefinition,
+        precinctId
+      ).length > 1
     );
     const { ballotDocuments } =
       await renderAllBallotsAndCreateElectionDefinition(
@@ -114,8 +120,10 @@ describe('createPrecinctTestDeck', () => {
     const precinctWithNoBallotStyles = find(
       election.precincts,
       (precinct) =>
-        getBallotStylesByPrecinctId(electionDefinition, precinct.id).length ===
-        0
+        CachedElectionLookups.getBallotStylesByPrecinctId(
+          electionDefinition,
+          precinct.id
+        ).length === 0
     );
 
     const testDeckDocument = await createPrecinctTestDeck({

--- a/apps/scan/frontend/src/screens/poll_worker_fujitsu_post_print_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_fujitsu_post_print_screen.tsx
@@ -9,7 +9,7 @@ import React, { useCallback, useState } from 'react';
 import { ElectionDefinition, PollsTransitionType } from '@votingworks/types';
 import { Optional, assert } from '@votingworks/basics';
 import {
-  getPartyById,
+  CachedElectionLookups,
   getPollsReportTitle,
   isPollsSuspensionTransition,
 } from '@votingworks/utils';
@@ -40,7 +40,8 @@ function getReportManifest(
       return 'Nonpartisan Contests';
     }
 
-    return getPartyById(electionDefinition, partyId).fullName;
+    return CachedElectionLookups.getPartyById(electionDefinition, partyId)
+      .fullName;
   });
 }
 

--- a/libs/backend/src/cast_vote_records/build_cast_vote_record.ts
+++ b/libs/backend/src/cast_vote_records/build_cast_vote_record.ts
@@ -30,7 +30,7 @@ import {
 import {
   UNMARKED_WRITE_IN_SELECTION_POSITION_OTHER_STATUS,
   buildCVRSnapshotBallotTypeMetadata,
-  getContestById,
+  CachedElectionLookups,
   getMarkStatus,
 } from '@votingworks/utils';
 
@@ -393,7 +393,7 @@ export function buildCVRContestsFromVotes({
   const cvrContests: CVR.CVRContest[] = [];
 
   const contests = Object.keys(votes).map((contestId) =>
-    getContestById(electionDefinition, contestId)
+    CachedElectionLookups.getContestById(electionDefinition, contestId)
   );
   for (const contest of contests) {
     // If there is no element in the `votes` object, there are no votes. We

--- a/libs/ballot-interpreter/src/interpret_bmd_and_hmp_ballots.test.ts
+++ b/libs/ballot-interpreter/src/interpret_bmd_and_hmp_ballots.test.ts
@@ -9,7 +9,10 @@ import {
   VotesDict,
   asSheet,
 } from '@votingworks/types';
-import { ALL_PRECINCTS_SELECTION, getContestById } from '@votingworks/utils';
+import {
+  ALL_PRECINCTS_SELECTION,
+  CachedElectionLookups,
+} from '@votingworks/utils';
 import { pdfToPageImages } from '../test/helpers/interpretation';
 import { interpretSheet } from './interpret';
 
@@ -21,8 +24,12 @@ test('interpret BMD ballot for an election supporting hand-marked paper ballots'
       contestId,
       vote?.slice(
         0,
-        (getContestById(electionDefinition, contestId) as CandidateContest)
-          .seats
+        (
+          CachedElectionLookups.getContestById(
+            electionDefinition,
+            contestId
+          ) as CandidateContest
+        ).seats
       ),
     ])
   );

--- a/libs/ui/src/reports/admin_tally_report_by_party.tsx
+++ b/libs/ui/src/reports/admin_tally_report_by_party.tsx
@@ -2,11 +2,7 @@ import { Admin, ElectionDefinition } from '@votingworks/types';
 import React from 'react';
 
 import { unique } from '@votingworks/basics';
-import {
-  getContestById,
-  getEmptyCardCounts,
-  getPartyById,
-} from '@votingworks/utils';
+import { CachedElectionLookups, getEmptyCardCounts } from '@votingworks/utils';
 import { AdminTallyReport } from './admin_tally_report';
 import { LabeledScannerBatch } from './utils';
 
@@ -51,7 +47,7 @@ export function AdminTallyReportByParty({
   includeSignatureLines,
 }: AdminTallyReportByPartyProps): JSX.Element {
   const contests = tallyReportResults.contestIds.map((contestId) =>
-    getContestById(electionDefinition, contestId)
+    CachedElectionLookups.getContestById(electionDefinition, contestId)
   );
 
   // general election case - just return a single report section
@@ -89,7 +85,10 @@ export function AdminTallyReportByParty({
     const partyCardCounts =
       /* istanbul ignore next - trivial fallthrough case - @preserve */
       tallyReportResults.cardCountsByParty[partyId] ?? getEmptyCardCounts();
-    const partyLabel = getPartyById(electionDefinition, partyId).fullName;
+    const partyLabel = CachedElectionLookups.getPartyById(
+      electionDefinition,
+      partyId
+    ).fullName;
 
     partyCompleteTallyReports.push(
       <AdminTallyReport

--- a/libs/ui/src/reports/ballot_count_report.tsx
+++ b/libs/ui/src/reports/ballot_count_report.tsx
@@ -15,8 +15,7 @@ import {
   getMaxSheetsPerBallot,
   getGroupKey,
   getHmpbBallotCount,
-  getPartyById,
-  getPrecinctById,
+  CachedElectionLookups,
   isGroupByEmpty,
 } from '@votingworks/utils';
 import React from 'react';
@@ -376,14 +375,14 @@ function getCellContent({
     case 'attribute':
       switch (column.id) {
         case 'precinct':
-          return getPrecinctById(
+          return CachedElectionLookups.getPrecinctById(
             electionDefinition,
             assertDefined(cardCounts.precinctId)
           ).name;
         case 'ballot-style':
           return assertDefined(cardCounts.ballotStyleGroupId);
         case 'party':
-          return getPartyById(
+          return CachedElectionLookups.getPartyById(
             electionDefinition,
             assertDefined(determinePartyId(electionDefinition, cardCounts))
           ).name;

--- a/libs/ui/src/reports/custom_filter_summary.tsx
+++ b/libs/ui/src/reports/custom_filter_summary.tsx
@@ -1,10 +1,6 @@
 import { Admin, ElectionDefinition, Tabulation } from '@votingworks/types';
 
-import {
-  getDistrictById,
-  getPartyById,
-  getPrecinctById,
-} from '@votingworks/utils';
+import { CachedElectionLookups } from '@votingworks/utils';
 
 import pluralize from 'pluralize';
 import styled from 'styled-components';
@@ -62,7 +58,10 @@ export function CustomFilterSummary({
           {filter.precinctIds
             .map(
               (precinctId) =>
-                getPrecinctById(electionDefinition, precinctId).name
+                CachedElectionLookups.getPrecinctById(
+                  electionDefinition,
+                  precinctId
+                ).name
             )
             .join(', ')}
         </FilterDisplayRow>
@@ -118,7 +117,10 @@ export function CustomFilterSummary({
           {filter.districtIds
             .map(
               (districtId) =>
-                getDistrictById(electionDefinition, districtId).name
+                CachedElectionLookups.getDistrictById(
+                  electionDefinition,
+                  districtId
+                ).name
             )
             .join(', ')}
         </FilterDisplayRow>
@@ -130,7 +132,9 @@ export function CustomFilterSummary({
           </Font>{' '}
           {filter.partyIds
             .map(
-              (partyId) => getPartyById(electionDefinition, partyId).fullName
+              (partyId) =>
+                CachedElectionLookups.getPartyById(electionDefinition, partyId)
+                  .fullName
             )
             .join(', ')}
         </FilterDisplayRow>

--- a/libs/ui/src/reports/precinct_scanner_report_header.tsx
+++ b/libs/ui/src/reports/precinct_scanner_report_header.tsx
@@ -7,7 +7,7 @@ import {
 } from '@votingworks/types';
 import {
   formatFullDateTimeZone,
-  getPartyById,
+  CachedElectionLookups,
   getPollsReportTitle,
   getPollsTransitionActionPastTense,
   getPrecinctSelectionName,
@@ -62,7 +62,8 @@ export function PrecinctScannerReportHeader({
   const partyLabel =
     showTallies && election.type === 'primary'
       ? partyId
-        ? getPartyById(electionDefinition, partyId).fullName
+        ? CachedElectionLookups.getPartyById(electionDefinition, partyId)
+            .fullName
         : 'Nonpartisan Contests'
       : undefined;
 

--- a/libs/ui/src/reports/write_in_adjudication_report.tsx
+++ b/libs/ui/src/reports/write_in_adjudication_report.tsx
@@ -6,7 +6,7 @@ import {
 } from '@votingworks/types';
 import { ThemeProvider } from 'styled-components';
 import { unique } from '@votingworks/basics';
-import { getPartyById } from '@votingworks/utils';
+import { CachedElectionLookups } from '@votingworks/utils';
 import {
   printedReportThemeFn,
   PrintedReport,
@@ -67,7 +67,9 @@ export function WriteInAdjudicationReport({
       <div data-testid="write-in-tally-report">
         {relevantPartyIds.map((partyId) => {
           const partyLabel =
-            partyId && getPartyById(electionDefinition, partyId).fullName;
+            partyId &&
+            CachedElectionLookups.getPartyById(electionDefinition, partyId)
+              .fullName;
           const partyWriteInContests = allWriteInContests.filter(
             (c) => c.partyId === partyId
           );

--- a/libs/utils/src/ballot_styles.test.ts
+++ b/libs/utils/src/ballot_styles.test.ts
@@ -8,10 +8,12 @@ import {
   hasSplits,
   Party,
   PartyId,
+  Tabulation,
 } from '@votingworks/types';
 import {
   electionPrimaryPrecinctSplitsFixtures,
   readElectionGeneral,
+  readElectionTwoPartyPrimaryDefinition,
 } from '@votingworks/fixtures';
 import { assert } from '@votingworks/basics';
 import {
@@ -21,9 +23,13 @@ import {
   getGroupedBallotStyles,
   getPrecinctsAndSplitsForBallotStyle,
   getRelatedBallotStyle,
+  determinePartyId,
 } from './ballot_styles';
 
 const electionGeneral = readElectionGeneral();
+
+const electionTwoPartyPrimaryDefinition =
+  readElectionTwoPartyPrimaryDefinition();
 
 const GREEN_PARTY: Party = {
   abbrev: 'G',
@@ -349,4 +355,74 @@ test('getPrecinctsAndSplitsForBallotStyle', () => {
       ballotStyle: electionGeneral.ballotStyles[1]!,
     })
   ).toEqual([{ precinct: precinct2, split: precinct2.splits[0]! }]);
+});
+
+test('determinePartyId', () => {
+  const electionDefinition = electionTwoPartyPrimaryDefinition;
+
+  const partyCardCounts: Tabulation.GroupOf<Tabulation.CardCounts> = {
+    partyId: '0',
+    bmd: 1,
+    hmpb: [1],
+  };
+
+  const ballotStyleCardCounts: Tabulation.GroupOf<Tabulation.CardCounts> = {
+    ballotStyleGroupId: '1M' as BallotStyleGroupId,
+    bmd: 1,
+    hmpb: [1],
+  };
+
+  const precinctCardCounts: Tabulation.GroupOf<Tabulation.CardCounts> = {
+    precinctId: 'precinct-1',
+    bmd: 1,
+    hmpb: [1],
+  };
+
+  expect(determinePartyId(electionDefinition, partyCardCounts)).toEqual('0');
+  expect(determinePartyId(electionDefinition, ballotStyleCardCounts)).toEqual(
+    '0'
+  );
+  expect(determinePartyId(electionDefinition, precinctCardCounts)).toEqual(
+    undefined
+  );
+});
+
+test('determinePartyId - multi language election', () => {
+  const electionDefinition =
+    electionPrimaryPrecinctSplitsFixtures.readElectionDefinition();
+
+  const partyCardCounts: Tabulation.GroupOf<Tabulation.CardCounts> = {
+    partyId: '0',
+    bmd: 1,
+    hmpb: [1],
+  };
+
+  const ballotStyleCardCounts: Tabulation.GroupOf<Tabulation.CardCounts> = {
+    ballotStyleGroupId: '1-Ma' as BallotStyleGroupId,
+    bmd: 1,
+    hmpb: [1],
+  };
+
+  const ballotStyleCardCounts2: Tabulation.GroupOf<Tabulation.CardCounts> = {
+    ballotStyleGroupId: 'fake-ballot-style' as BallotStyleGroupId,
+    bmd: 1,
+    hmpb: [1],
+  };
+
+  const precinctCardCounts: Tabulation.GroupOf<Tabulation.CardCounts> = {
+    precinctId: 'precinct-1',
+    bmd: 1,
+    hmpb: [1],
+  };
+
+  expect(determinePartyId(electionDefinition, partyCardCounts)).toEqual('0');
+  expect(determinePartyId(electionDefinition, ballotStyleCardCounts)).toEqual(
+    '0'
+  );
+  expect(determinePartyId(electionDefinition, precinctCardCounts)).toEqual(
+    undefined
+  );
+  expect(determinePartyId(electionDefinition, ballotStyleCardCounts2)).toEqual(
+    undefined
+  );
 });

--- a/libs/utils/src/tabulation/index.ts
+++ b/libs/utils/src/tabulation/index.ts
@@ -1,7 +1,7 @@
 export * from './arguments';
 export * from './contest_filtering';
 export * from './convert';
-export * from './lookups';
+export * as CachedElectionLookups from './lookups';
 export * from './mock_tally_report_results';
 export * from './tabulation';
 export * from './tally_reports';

--- a/libs/utils/src/tabulation/lookups.test.ts
+++ b/libs/utils/src/tabulation/lookups.test.ts
@@ -1,9 +1,5 @@
 import { expect, test } from 'vitest';
-import {
-  BallotStyleGroupId,
-  ElectionDefinition,
-  Tabulation,
-} from '@votingworks/types';
+import { ElectionDefinition } from '@votingworks/types';
 import {
   electionPrimaryPrecinctSplitsFixtures,
   readElectionTwoPartyPrimaryDefinition,
@@ -16,7 +12,6 @@ import {
   getPrecinctById,
   getBallotStylesByPartyId,
   getBallotStylesByPrecinctId,
-  determinePartyId,
 } from './lookups';
 
 const electionTwoPartyPrimaryDefinition =
@@ -125,74 +120,4 @@ test('getBallotStylesByPrecinct', () => {
       (bs) => bs.id
     )
   ).toEqual(['1M', '2F']);
-});
-
-test('determinePartyId', () => {
-  const electionDefinition = electionTwoPartyPrimaryDefinition;
-
-  const partyCardCounts: Tabulation.GroupOf<Tabulation.CardCounts> = {
-    partyId: '0',
-    bmd: 1,
-    hmpb: [1],
-  };
-
-  const ballotStyleCardCounts: Tabulation.GroupOf<Tabulation.CardCounts> = {
-    ballotStyleGroupId: '1M' as BallotStyleGroupId,
-    bmd: 1,
-    hmpb: [1],
-  };
-
-  const precinctCardCounts: Tabulation.GroupOf<Tabulation.CardCounts> = {
-    precinctId: 'precinct-1',
-    bmd: 1,
-    hmpb: [1],
-  };
-
-  expect(determinePartyId(electionDefinition, partyCardCounts)).toEqual('0');
-  expect(determinePartyId(electionDefinition, ballotStyleCardCounts)).toEqual(
-    '0'
-  );
-  expect(determinePartyId(electionDefinition, precinctCardCounts)).toEqual(
-    undefined
-  );
-});
-
-test('determinePartyId - multi language election', () => {
-  const electionDefinition =
-    electionPrimaryPrecinctSplitsFixtures.readElectionDefinition();
-
-  const partyCardCounts: Tabulation.GroupOf<Tabulation.CardCounts> = {
-    partyId: '0',
-    bmd: 1,
-    hmpb: [1],
-  };
-
-  const ballotStyleCardCounts: Tabulation.GroupOf<Tabulation.CardCounts> = {
-    ballotStyleGroupId: '1-Ma' as BallotStyleGroupId,
-    bmd: 1,
-    hmpb: [1],
-  };
-
-  const ballotStyleCardCounts2: Tabulation.GroupOf<Tabulation.CardCounts> = {
-    ballotStyleGroupId: 'fake-ballot-style' as BallotStyleGroupId,
-    bmd: 1,
-    hmpb: [1],
-  };
-
-  const precinctCardCounts: Tabulation.GroupOf<Tabulation.CardCounts> = {
-    precinctId: 'precinct-1',
-    bmd: 1,
-    hmpb: [1],
-  };
-
-  expect(determinePartyId(electionDefinition, partyCardCounts)).toEqual('0');
-  expect(determinePartyId(electionDefinition, ballotStyleCardCounts)).toEqual(
-    '0'
-  );
-  expect(determinePartyId(electionDefinition, precinctCardCounts)).toEqual(
-    undefined
-  );
-  expect(determinePartyId(electionDefinition, ballotStyleCardCounts2)).toEqual(
-    undefined
-  );
 });

--- a/libs/utils/src/tabulation/lookups.ts
+++ b/libs/utils/src/tabulation/lookups.ts
@@ -1,4 +1,4 @@
-import { Optional, assert, assertDefined } from '@votingworks/basics';
+import { assert, assertDefined } from '@votingworks/basics';
 import {
   AnyContest,
   BallotStyle,
@@ -11,9 +11,8 @@ import {
   Party,
   Precinct,
   PrecinctId,
-  Tabulation,
 } from '@votingworks/types';
-import { getBallotStyleGroup, getGroupedBallotStyles } from '../ballot_styles';
+import { getGroupedBallotStyles } from '../ballot_styles';
 
 /**
  * Creates a lookup function for getting some election metadata based on a key.
@@ -140,19 +139,3 @@ export const getBallotStylesByPrecinctId = createElectionMetadataLookupFunction(
     return lookup;
   }
 );
-
-/**
- * Tries to determine party ID from ballot style ID if not available directly.
- */
-export function determinePartyId<T>(
-  electionDefinition: ElectionDefinition,
-  group: Tabulation.GroupOf<T>
-): Optional<string> {
-  if (group.partyId) return group.partyId;
-  if (!group.ballotStyleGroupId) return undefined;
-  const ballotStyleGroup = getBallotStyleGroup({
-    election: electionDefinition.election,
-    ballotStyleGroupId: group.ballotStyleGroupId ,
-  });
-  return ballotStyleGroup?.partyId;
-}


### PR DESCRIPTION
## Overview

Closes #6357. 

The bug was occurring because we were using `indexOf` to identify the index of the `contest` within the list of `contests`. Because these are objects, this only works if the contests are identical object references. Because the `contest` is coming from the `getContestById` function which is actually caching results for faster lookups, the comparison stops working as soon as the `electionDefinition` cached by React Query is different than the one cached by `getContestById`. I'm not sure how this happens in practice, but you can recreate this bug in dev with the React Query devtools by resetting the `getCurrentElectionMetadata` query while doing manual results.

As far as the fix - the current fix is just a one line fix to address the issue. Any suggestions to do more to avoid this sort of footgun are welcome.

As far as testing - it seems like a regression test here would be hyper-specific so I did not write it, but open to writing one.