### PR TITLE
Adjust contest adjudication copy for clarity

### DIFF
--- a/apps/admin/frontend/src/components/adjudication_double_vote_alert_modal.tsx
+++ b/apps/admin/frontend/src/components/adjudication_double_vote_alert_modal.tsx
@@ -31,7 +31,7 @@ export function DoubleVoteAlertModal({
             <br />
             If the ballot contest does indeed contain a double vote, you can
             invalidate the write-in by selecting{' '}
-            <Font weight="bold">Not a mark</Font>.
+            <Font weight="bold">Invalid mark</Font>.
           </P>
         );
       case 'adjudicated-official-candidate':
@@ -46,7 +46,7 @@ export function DoubleVoteAlertModal({
             <br />
             If the ballot contest does indeed contain a double vote, you can
             invalidate the write-in by selecting{' '}
-            <Font weight="bold">Not a mark</Font>.
+            <Font weight="bold">Invalid mark</Font>.
           </P>
         );
       default: {

--- a/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
+++ b/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
@@ -110,7 +110,7 @@ export function WriteInAdjudicationButton({
   }
 
   if (!inputValue) {
-    options.unshift({ label: 'Not a mark', value: INVALID_KEY });
+    options.unshift({ label: 'Invalid mark', value: INVALID_KEY });
   }
 
   return (

--- a/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
+++ b/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
@@ -95,7 +95,7 @@ export function WriteInAdjudicationButton({
     options.unshift({ label: value, value });
   }
 
-  // 'Add: NEW_CANDIDATE' entry if there is no exact match
+  // 'Press enter to add: NEW_CANDIDATE' entry if there is no exact match
   if (
     inputValue &&
     inputValue.length < MAX_WRITE_IN_NAME_LENGTH &&

--- a/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
+++ b/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
@@ -103,7 +103,10 @@ export function WriteInAdjudicationButton({
       (item) => normalizeWriteInName(item.label) === normalizedInputValue
     )
   ) {
-    options.push({ label: `Add: ${inputValue}`, value: inputValue });
+    options.push({
+      label: `Press enter to add: ${inputValue}`,
+      value: inputValue,
+    });
   }
 
   if (!inputValue) {
@@ -156,14 +159,16 @@ export function WriteInAdjudicationButton({
         value={value}
         placeholder={
           isFocused ? (
-            'Search or add…'
+            'Type to search or add candidate…'
           ) : (
             <React.Fragment>
               <Icons.Warning
                 color="warning"
                 style={{ marginRight: '0.5rem' }}
               />
-              {isSelected ? 'Adjudicate Write-in' : 'Unmarked Write-in'}
+              {isSelected
+                ? 'Click to adjudicate write-in'
+                : 'Click to adjudicate Unmarked Write-in'}
             </React.Fragment>
           )
         }

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
@@ -139,7 +139,7 @@ describe('hmpb write-in adjudication', () => {
 
     writeInSearchSelect = screen.getByRole('combobox');
     expect(writeInSearchSelect).toHaveAttribute('aria-expanded', 'true');
-    const item = await screen.findByText(/not a mark/i);
+    const item = await screen.findByText(/invalid mark/i);
     fireEvent.click(item);
 
     expect(screen.queryByText(/invalid mark/i)).toBeInTheDocument();
@@ -256,7 +256,7 @@ describe('hmpb write-in adjudication', () => {
 
     // review dropdown options
     expect(screen.queryByText(/add:/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/not a mark/i)).toBeInTheDocument();
+    expect(screen.queryByText(/invalid mark/i)).toBeInTheDocument();
     expect(screen.getAllByText(/elephant/i)).toHaveLength(2);
     expect(screen.getAllByText(/lion/i)).toHaveLength(2);
     expect(screen.getAllByText(/kangaroo/i)).toHaveLength(1);
@@ -265,7 +265,7 @@ describe('hmpb write-in adjudication', () => {
     userEvent.type(writeInSearchSelect, 'e');
 
     expect(screen.queryByText(/add: e/i)).toBeInTheDocument();
-    expect(screen.queryByText(/not a mark/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/invalid mark/i)).not.toBeInTheDocument();
     expect(screen.getAllByText(/elephant/i)).toHaveLength(2);
     expect(screen.getAllByText(/lion/i)).toHaveLength(1);
 
@@ -274,7 +274,7 @@ describe('hmpb write-in adjudication', () => {
     userEvent.type(writeInSearchSelect, 'OLIVER');
 
     expect(screen.queryByText(/add:/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/not a mark/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/invalid mark/i)).not.toBeInTheDocument();
     expect(screen.getAllByText(/elephant/i)).toHaveLength(1);
     expect(screen.getAllByText(/oliver/i)).toHaveLength(2);
 
@@ -348,12 +348,12 @@ describe('hmpb write-in adjudication', () => {
     expect(writeInSearchSelect).toHaveAttribute('aria-expanded', 'true');
 
     expect(screen.queryByText(/add:/i)).not.toBeInTheDocument();
-    expect(screen.queryAllByText(/not a mark/i)).toHaveLength(2);
+    expect(screen.queryAllByText(/invalid mark/i)).toHaveLength(2);
     expect(screen.queryByText(/oliver/i)).toBeInTheDocument();
 
     userEvent.type(writeInSearchSelect, 'siena');
 
-    expect(screen.queryByText(/not a mark/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/invalid mark/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/oliver/i)).not.toBeInTheDocument();
 
     // add new candidate
@@ -457,7 +457,7 @@ describe('bmd write-in adjudication', () => {
     writeInSearchSelect = screen.getByRole('combobox');
     expect(writeInSearchSelect).toHaveAttribute('aria-expanded', 'true');
 
-    const invalidMarkItem = getDropdownItemByLabel('Not a mark');
+    const invalidMarkItem = getDropdownItemByLabel('Invalid mark');
     userEvent.click(invalidMarkItem!);
 
     expect(screen.queryByText(/invalid mark/i)).toBeInTheDocument();

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
@@ -255,7 +255,7 @@ describe('hmpb write-in adjudication', () => {
     expect(writeInSearchSelect).toHaveAttribute('aria-expanded', 'true');
 
     // review dropdown options
-    expect(screen.queryByText(/add:/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/press enter to add:/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/invalid mark/i)).toBeInTheDocument();
     expect(screen.getAllByText(/elephant/i)).toHaveLength(2);
     expect(screen.getAllByText(/lion/i)).toHaveLength(2);
@@ -264,7 +264,7 @@ describe('hmpb write-in adjudication', () => {
 
     userEvent.type(writeInSearchSelect, 'e');
 
-    expect(screen.queryByText(/add: e/i)).toBeInTheDocument();
+    expect(screen.queryByText(/press enter to add: e/i)).toBeInTheDocument();
     expect(screen.queryByText(/invalid mark/i)).not.toBeInTheDocument();
     expect(screen.getAllByText(/elephant/i)).toHaveLength(2);
     expect(screen.getAllByText(/lion/i)).toHaveLength(1);
@@ -273,7 +273,7 @@ describe('hmpb write-in adjudication', () => {
     // case insensitive filter
     userEvent.type(writeInSearchSelect, 'OLIVER');
 
-    expect(screen.queryByText(/add:/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/press enter to add:/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/invalid mark/i)).not.toBeInTheDocument();
     expect(screen.getAllByText(/elephant/i)).toHaveLength(1);
     expect(screen.getAllByText(/oliver/i)).toHaveLength(2);
@@ -347,7 +347,7 @@ describe('hmpb write-in adjudication', () => {
     writeInSearchSelect = screen.getByRole('combobox');
     expect(writeInSearchSelect).toHaveAttribute('aria-expanded', 'true');
 
-    expect(screen.queryByText(/add:/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/press enter to add:/i)).not.toBeInTheDocument();
     expect(screen.queryAllByText(/invalid mark/i)).toHaveLength(2);
     expect(screen.queryByText(/oliver/i)).toBeInTheDocument();
 
@@ -357,7 +357,7 @@ describe('hmpb write-in adjudication', () => {
     expect(screen.queryByText(/oliver/i)).not.toBeInTheDocument();
 
     // add new candidate
-    const addNewItem = getDropdownItemByLabel('Add: siena');
+    const addNewItem = getDropdownItemByLabel('Press enter to add: siena');
     userEvent.click(addNewItem!);
 
     // once that candidate is added, they should be included in the next dropdown search


### PR DESCRIPTION
## Overview

Feedback from offsite electioneers - 
1. Rename "Not a mark" to "Invalid mark"
2. Unsure where to click at first to adjudicate a write-in, what to do after clicking, and where to click to create a new candidate. They liked when I adjusted the copy to give more direction in placeholder texts (3 places)

Edit 5/6 - Drew signed off on these during sync today

## Demo Video or Screenshot

Old...

https://github.com/user-attachments/assets/e6b2f7a5-879c-42b4-a7c7-9ac5908140ba

New...

https://github.com/user-attachments/assets/f6ab3910-d606-4412-915a-5dcb4a4dddd5


## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
