### PR TITLE
Remove castVoteRecordsIncludeOriginalSnapshots system setting

### DIFF
--- a/apps/design/frontend/src/system_settings_screen.test.tsx
+++ b/apps/design/frontend/src/system_settings_screen.test.tsx
@@ -422,7 +422,6 @@ test('setting "other" system settings', async () => {
     'Allow Official Ballots in Test Mode',
     'Disable Vertical Streak Detection',
     'Enable Shoeshine Mode on VxScan',
-    'Include Original Snapshots',
     'Include Redundant Metadata',
   ];
 
@@ -434,7 +433,6 @@ test('setting "other" system settings', async () => {
     ...DEFAULT_SYSTEM_SETTINGS,
     allowOfficialBallotsInTestMode: true,
     precinctScanEnableShoeshineMode: true,
-    castVoteRecordsIncludeOriginalSnapshots: true,
     castVoteRecordsIncludeRedundantMetadata: true,
     disableVerticalStreakDetection: true,
   };
@@ -511,7 +509,7 @@ test('all controls are disabled until clicking "Edit"', async () => {
   const allCheckboxes = document.body.querySelectorAll('[role=checkbox]');
   const allControls = [...allTextBoxes, ...allCheckboxes];
 
-  expect(allControls).toHaveLength(24);
+  expect(allControls).toHaveLength(23);
 
   for (const control of allControls) {
     expect(control).toBeDisabled();

--- a/apps/design/frontend/src/system_settings_screen.tsx
+++ b/apps/design/frontend/src/system_settings_screen.tsx
@@ -145,12 +145,10 @@ export function SystemSettingsForm({
   ];
 
   enum CvrOption {
-    OriginalSnapshots = 'Original Snapshots',
     RedudantMetadata = 'Redundant Metadata',
   }
 
   const cvrOptions = [
-    { label: 'Include Original Snapshots', value: CvrOption.OriginalSnapshots },
     { label: 'Include Redundant Metadata', value: CvrOption.RedudantMetadata },
   ];
 
@@ -511,9 +509,6 @@ export function SystemSettingsForm({
                     options={cvrOptions}
                     value={
                       [
-                        systemSettings.castVoteRecordsIncludeOriginalSnapshots
-                          ? CvrOption.OriginalSnapshots
-                          : undefined,
                         systemSettings.castVoteRecordsIncludeRedundantMetadata
                           ? CvrOption.RedudantMetadata
                           : undefined,
@@ -522,9 +517,6 @@ export function SystemSettingsForm({
                     onChange={(value) =>
                       setSystemSettings({
                         ...systemSettings,
-                        castVoteRecordsIncludeOriginalSnapshots: value.includes(
-                          CvrOption.OriginalSnapshots
-                        ),
                         castVoteRecordsIncludeRedundantMetadata: value.includes(
                           CvrOption.RedudantMetadata
                         ),

--- a/libs/backend/src/cast_vote_records/build_cast_vote_record.test.ts
+++ b/libs/backend/src/cast_vote_records/build_cast_vote_record.test.ts
@@ -539,7 +539,6 @@ describe('buildCastVoteRecord - HMPB Ballot', () => {
     ballotMarkingMode: 'hand',
     interpretations: [interpretedHmpbPage1, interpretedHmpbPage2],
     definiteMarkThreshold,
-    includeOriginalSnapshots: true,
   });
 
   test('includes correct metadata, including sheet number as BallotSheetId', () => {
@@ -642,7 +641,6 @@ test('buildCastVoteRecord - HMPB ballot with write-in', () => {
       },
     ],
     definiteMarkThreshold,
-    includeOriginalSnapshots: true,
   });
 
   expect(castVoteRecord.BallotImage).toEqual([
@@ -692,7 +690,6 @@ test('buildCastVoteRecord - HMPB ballot with unmarked write-in', () => {
       },
     ],
     definiteMarkThreshold,
-    includeOriginalSnapshots: true,
   });
 
   const expectedFrontImageData: CVR.ImageData = {

--- a/libs/backend/src/cast_vote_records/build_cast_vote_record.ts
+++ b/libs/backend/src/cast_vote_records/build_cast_vote_record.ts
@@ -531,7 +531,6 @@ type BuildCastVoteRecordParams = {
       interpretations: SheetOf<InterpretedHmpbPage>;
       images?: SheetOf<CvrImageDataInput>;
       definiteMarkThreshold: number;
-      includeOriginalSnapshots?: boolean;
     }
 );
 
@@ -607,12 +606,7 @@ export function buildCastVoteRecord({
     };
   }
 
-  const {
-    interpretations,
-    images,
-    definiteMarkThreshold,
-    includeOriginalSnapshots,
-  } = rest;
+  const { interpretations, images, definiteMarkThreshold } = rest;
 
   // The larger page number should be an even number which, divided by two,
   // yields the sheet number
@@ -658,22 +652,20 @@ export function buildCastVoteRecord({
     ...cvrMetadata,
     BallotSheetId: sheetNumber, // VVSG 2.0 1.1.5-G.5
     CurrentSnapshotId: `${castVoteRecordId}-modified`,
-    CVRSnapshot: includeOriginalSnapshots
-      ? [
-          modifiedSnapshot,
-          buildOriginalSnapshot({
-            castVoteRecordId,
-            marks: [
-              ...interpretations[0].markInfo.marks,
-              ...interpretations[1].markInfo.marks,
-            ],
-            definiteMarkThreshold,
-            election,
-            electionOptionPositionMap,
-            ballotType: ballotMetadata.ballotType,
-          }),
-        ]
-      : [modifiedSnapshot],
+    CVRSnapshot: [
+      modifiedSnapshot,
+      buildOriginalSnapshot({
+        castVoteRecordId,
+        marks: [
+          ...interpretations[0].markInfo.marks,
+          ...interpretations[1].markInfo.marks,
+        ],
+        definiteMarkThreshold,
+        election,
+        electionOptionPositionMap,
+        ballotType: ballotMetadata.ballotType,
+      }),
+    ],
     BallotImage: images?.map(buildCvrImageData),
   };
 }

--- a/libs/backend/src/cast_vote_records/export.test.ts
+++ b/libs/backend/src/cast_vote_records/export.test.ts
@@ -795,52 +795,6 @@ test('castVoteRecordsIncludeRedundantMetadata system setting', async () => {
   expect(castVoteRecords[0]).toEqual(castVoteRecords[1]);
 });
 
-test('castVoteRecordsIncludeOriginalSnapshots system setting', async () => {
-  const sheet = newAcceptedSheet(interpretedHmpb, sheet1Id);
-  const castVoteRecords: CVR.CVR[] = [];
-  for (const includeOriginalSnapshots of [true, false] as const) {
-    mockUsbDrive.removeUsbDrive();
-    mockUsbDrive.insertUsbDrive({});
-
-    mockPrecinctScannerStore.setSystemSettings({
-      ...assertDefined(mockPrecinctScannerStore.getSystemSettings()),
-      castVoteRecordsIncludeOriginalSnapshots: includeOriginalSnapshots,
-    });
-
-    expect(
-      await exportCastVoteRecordsToUsbDrive(
-        mockPrecinctScannerStore,
-        mockUsbDrive.usbDrive,
-        [sheet],
-        { scannerType: 'precinct' }
-      )
-    ).toEqual(ok());
-
-    const exportDirectoryPaths = await getCastVoteRecordExportDirectoryPaths(
-      mockUsbDrive.usbDrive
-    );
-    expect(exportDirectoryPaths).toHaveLength(1);
-    const exportDirectoryPath = assertDefined(exportDirectoryPaths[0]);
-    const { castVoteRecord } = readCastVoteRecord(
-      path.join(exportDirectoryPath, sheet1Id)
-    );
-
-    castVoteRecords.push(castVoteRecord);
-    const modifiedSnapshot = castVoteRecord.CVRSnapshot.find(
-      (snapshot) => snapshot.Type === CVR.CVRType.Modified
-    );
-    expect(modifiedSnapshot).toBeDefined();
-    const originalSnapshot = castVoteRecord.CVRSnapshot.find(
-      (snapshot) => snapshot.Type === CVR.CVRType.Original
-    );
-    if (includeOriginalSnapshots) {
-      expect(originalSnapshot).toBeDefined();
-    } else {
-      expect(originalSnapshot).toBeUndefined();
-    }
-  }
-});
-
 test.each<{
   description: string;
   setupFn: () => void | Promise<void>;

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -341,7 +341,7 @@ async function buildCastVoteRecord(
   }
 ): Promise<CVR.CVR> {
   const { scannerState } = exportContext;
-  const { electionDefinition, systemSettings, markThresholds } = scannerState;
+  const { electionDefinition, markThresholds } = scannerState;
   const { election, ballotHash: electionId } = electionDefinition;
   const electionOptionPositionMap = buildElectionOptionPositionMap(election);
   const scannerId = VX_MACHINE_ID;
@@ -391,8 +391,6 @@ async function buildCastVoteRecord(
     electionDefinition,
     electionId,
     electionOptionPositionMap,
-    includeOriginalSnapshots:
-      systemSettings.castVoteRecordsIncludeOriginalSnapshots,
     images,
     indexInBatch,
     interpretations: [frontInterpretation, backInterpretation],

--- a/libs/types/src/system_settings.ts
+++ b/libs/types/src/system_settings.ts
@@ -66,11 +66,6 @@ export interface SystemSettings {
   readonly disallowCastingOvervotes: boolean;
   readonly precinctScanEnableShoeshineMode?: boolean;
   /**
-   * Includes original snapshots in cast vote record reports, increasing export size and
-   * import/export time (required for CDF).
-   */
-  readonly castVoteRecordsIncludeOriginalSnapshots?: boolean;
-  /**
    * Includes redundant metadata in cast vote record reports, increasing export size and
    * import/export time (required for CDF).
    */
@@ -101,7 +96,6 @@ export const SystemSettingsSchema: z.ZodType<SystemSettings> = z.object({
   ),
   disallowCastingOvervotes: z.boolean(),
   precinctScanEnableShoeshineMode: z.boolean().optional(),
-  castVoteRecordsIncludeOriginalSnapshots: z.boolean().optional(),
   castVoteRecordsIncludeRedundantMetadata: z.boolean().optional(),
   disableVerticalStreakDetection: z.boolean().optional(),
   quickResultsReportingUrl: z.string().optional(),


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/5778

Now that Admin will be doing mark adjudication, the original snapshot is no longer optional, as it contains mark threshold data. This snapshot will also eventually be needed for [cumulative cvr export](https://docs.google.com/document/d/1rfK6BX375Tjiv3eaPYaYNr3VkPGIIF6TQctHIEUHnho/edit?tab=t.lxnmmzw8zcea)

## Demo Video or Screenshot

Old VxDesign
<img width="1512" alt="Screenshot 2025-05-06 at 3 18 07 PM" src="https://github.com/user-attachments/assets/08ade57b-561b-4583-833b-d824c6e3b78f" />

New VxDesign
<img width="1512" alt="Screenshot 2025-05-06 at 3 25 27 PM" src="https://github.com/user-attachments/assets/41394e01-0b90-421e-9a6f-3eeff0be1feb" />


## Testing Plan



## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
