### PR TITLE
VxAdmin: Don't include ballot style ID in report filenames

### DIFF
--- a/apps/admin/frontend/src/utils/reporting.test.ts
+++ b/apps/admin/frontend/src/utils/reporting.test.ts
@@ -210,7 +210,7 @@ test('generateTallyReportPdfFilename', () => {
         ballotStyleGroupIds: ['1M'] as BallotStyleGroupId[],
       },
       expectedFilename:
-        'unofficial-ballot-style-1M-tally-report__2023-12-09_15-59-32.pdf',
+        'unofficial-custom-tally-report__2023-12-09_15-59-32.pdf',
     },
     {
       filter: {
@@ -239,7 +239,7 @@ test('generateTallyReportPdfFilename', () => {
         votingMethods: ['absentee'],
       },
       expectedFilename:
-        'unofficial-ballot-style-1M-absentee-ballots-tally-report__2023-12-09_15-59-32.pdf',
+        'unofficial-custom-tally-report__2023-12-09_15-59-32.pdf',
     },
     {
       filter: {

--- a/apps/admin/frontend/src/utils/reporting.ts
+++ b/apps/admin/frontend/src/utils/reporting.ts
@@ -128,23 +128,18 @@ function generateReportFilenameFilterPrefix({
     return '';
   }
 
-  if (filterRank > 2) {
+  if (filterRank > 2 || filter.ballotStyleGroupIds) {
     return 'custom';
   }
 
   const filterPrefixes: string[] = [];
 
-  const ballotStyleId = filter.ballotStyleGroupIds?.[0];
   const precinctId = filter.precinctIds?.[0];
   const votingMethod = filter.votingMethods?.[0];
   const scannerId = filter.scannerIds?.[0];
   const batchId = filter.batchIds?.[0];
   const adjudicationFlag = filter.adjudicationFlags?.[0];
   const districtId = filter.districtIds?.[0];
-
-  if (ballotStyleId) {
-    filterPrefixes.push(`ballot-style-${ballotStyleId}`);
-  }
 
   if (precinctId) {
     const precinctName = find(


### PR DESCRIPTION
## Overview

Follow up to #6341. Instead of putting the ballot style ID in the report filename when filtering by ballot style, just bail and call it a custom report (similar to how we no longer show the ballot style ID in the report title).

## Demo Video or Screenshot
N/A

## Testing Plan
Updated automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
