### PR TITLE
CentralScan: Always export all ballot images

### DIFF
--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -241,24 +241,20 @@ function buildApi({
       await importer.doZero();
     },
 
-    async exportCastVoteRecordsToUsbDrive(input: {
-      isMinimalExport?: boolean;
-    }): Promise<Result<void, ExportCastVoteRecordsToUsbDriveError>> {
-      const logItem = input.isMinimalExport ? 'cast vote records' : 'backup';
+    async exportCastVoteRecordsToUsbDrive(): Promise<
+      Result<void, ExportCastVoteRecordsToUsbDriveError>
+    > {
+      const logItem = 'all accepted and rejected cast vote records';
       await logger.logAsCurrentRole(LogEventId.ExportCastVoteRecordsInit, {
         message: `Exporting ${logItem}...`,
       });
       const exportResult = await exportCastVoteRecordsToUsbDrive(
         store,
         usbDrive,
-        input.isMinimalExport
-          ? store.forEachAcceptedSheet()
-          : store.forEachSheet(),
-        { scannerType: 'central', isMinimalExport: input.isMinimalExport }
+        store.forEachSheet(),
+        { scannerType: 'central' }
       );
-      if (!input.isMinimalExport) {
-        store.setScannerBackedUp();
-      }
+      store.setScannerBackedUp();
       if (exportResult.isErr()) {
         await logger.logAsCurrentRole(
           LogEventId.ExportCastVoteRecordsComplete,

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -244,9 +244,8 @@ function buildApi({
     async exportCastVoteRecordsToUsbDrive(): Promise<
       Result<void, ExportCastVoteRecordsToUsbDriveError>
     > {
-      const logItem = 'all accepted and rejected cast vote records';
       await logger.logAsCurrentRole(LogEventId.ExportCastVoteRecordsInit, {
-        message: `Exporting ${logItem}...`,
+        message: 'Exporting all accepted and rejected cast vote records...',
       });
       const exportResult = await exportCastVoteRecordsToUsbDrive(
         store,
@@ -260,7 +259,7 @@ function buildApi({
           LogEventId.ExportCastVoteRecordsComplete,
           {
             disposition: 'failure',
-            message: `Error exporting ${logItem}.`,
+            message: `Error exporting all accepted and rejected cast vote records.`,
             errorDetails: JSON.stringify(exportResult.err()),
           }
         );
@@ -269,7 +268,7 @@ function buildApi({
           LogEventId.ExportCastVoteRecordsComplete,
           {
             disposition: 'success',
-            message: `Successfully exported ${logItem}.`,
+            message: `Successfully exported all accepted and rejected cast vote records.`,
           }
         );
       }

--- a/apps/central-scan/backend/src/end_to_end_bmd.test.ts
+++ b/apps/central-scan/backend/src/end_to_end_bmd.test.ts
@@ -84,20 +84,12 @@ test('going through the whole process works - BMD', async () => {
         mockUsbDrive.insertUsbDrive({});
         mockUsbDrive.usbDrive.sync.expectRepeatedCallsWith().resolves();
 
-        expect(
-          await apiClient.exportCastVoteRecordsToUsbDrive({
-            isMinimalExport: true,
-          })
-        ).toEqual(ok());
+        expect(await apiClient.exportCastVoteRecordsToUsbDrive()).toEqual(ok());
 
         // Sleep 1 second to guarantee that this next export directory has a different name than the
         // previously created one
         await sleep(1000);
-        expect(
-          await apiClient.exportCastVoteRecordsToUsbDrive({
-            isMinimalExport: false,
-          })
-        ).toEqual(ok());
+        expect(await apiClient.exportCastVoteRecordsToUsbDrive()).toEqual(ok());
 
         const cvrReportDirectoryPath = (
           await getCastVoteRecordExportDirectoryPaths(mockUsbDrive.usbDrive)
@@ -141,11 +133,7 @@ test('going through the whole process works - BMD', async () => {
       // Sleep 1 second to guarantee that this next export directory has a different name than the
       // previously created one
       await sleep(1000);
-      expect(
-        await apiClient.exportCastVoteRecordsToUsbDrive({
-          isMinimalExport: true,
-        })
-      ).toEqual(ok());
+      expect(await apiClient.exportCastVoteRecordsToUsbDrive()).toEqual(ok());
 
       const cvrReportDirectoryPaths =
         await getCastVoteRecordExportDirectoryPaths(mockUsbDrive.usbDrive);

--- a/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
+++ b/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
@@ -93,11 +93,7 @@ test('going through the whole process works - HMPB', async () => {
         mockUsbDrive.insertUsbDrive({});
         mockUsbDrive.usbDrive.sync.expectRepeatedCallsWith().resolves();
 
-        expect(
-          await apiClient.exportCastVoteRecordsToUsbDrive({
-            isMinimalExport: true,
-          })
-        ).toEqual(ok());
+        expect(await apiClient.exportCastVoteRecordsToUsbDrive()).toEqual(ok());
 
         const cvrReportDirectoryPath = (
           await getCastVoteRecordExportDirectoryPaths(mockUsbDrive.usbDrive)

--- a/apps/central-scan/frontend/src/app.test.tsx
+++ b/apps/central-scan/frontend/src/app.test.tsx
@@ -152,7 +152,7 @@ test('clicking "Save CVRs" shows modal and makes a request to export', async () 
   await vi.waitFor(() => expect(saveButton).toBeEnabled());
   userEvent.click(saveButton);
   await screen.findByRole('alertdialog');
-  apiMock.expectExportCastVoteRecords({ isMinimalExport: true });
+  apiMock.expectExportCastVoteRecords();
   userEvent.click(await screen.findByText('Save'));
   await screen.findByText('CVRs Saved');
   userEvent.click(screen.getByText('Close'));

--- a/apps/central-scan/frontend/src/components/export_results_modal.test.tsx
+++ b/apps/central-scan/frontend/src/components/export_results_modal.test.tsx
@@ -29,7 +29,7 @@ test('render insert USB screen when there is not a valid, mounted usb drive', as
     apiMock.setUsbDriveStatus(usbDriveStatus);
     const closeFn = vi.fn();
     const { unmount } = renderInAppContext(
-      <ExportResultsModal mode="cvrs" onClose={closeFn} />,
+      <ExportResultsModal onClose={closeFn} />,
       {
         apiMock,
       }
@@ -46,12 +46,12 @@ test('render insert USB screen when there is not a valid, mounted usb drive', as
 test('render export modal when a usb drive is mounted as expected and allows export', async () => {
   const closeFn = vi.fn();
   apiMock.setUsbDriveStatus(mockUsbDriveStatus('mounted'));
-  renderInAppContext(<ExportResultsModal mode="cvrs" onClose={closeFn} />, {
+  renderInAppContext(<ExportResultsModal onClose={closeFn} />, {
     apiMock,
   });
   await screen.findByText('Save CVRs');
 
-  apiMock.expectExportCastVoteRecords({ isMinimalExport: true });
+  apiMock.expectExportCastVoteRecords();
   userEvent.click(screen.getByText('Save'));
   await screen.findByText('CVRs Saved');
 
@@ -67,13 +67,13 @@ test('render export modal when a usb drive is mounted as expected and allows exp
 test('render export modal with errors when appropriate', async () => {
   const closeFn = vi.fn();
   apiMock.setUsbDriveStatus(mockUsbDriveStatus('mounted'));
-  renderInAppContext(<ExportResultsModal mode="cvrs" onClose={closeFn} />, {
+  renderInAppContext(<ExportResultsModal onClose={closeFn} />, {
     apiMock,
   });
   await screen.findByText('Save CVRs');
 
   apiMock.apiClient.exportCastVoteRecordsToUsbDrive
-    .expectCallWith({ isMinimalExport: true })
+    .expectCallWith()
     .resolves(err({ type: 'file-system-error' }));
   userEvent.click(screen.getByText('Save'));
   await screen.findByText('Failed to Save CVRs');
@@ -86,16 +86,16 @@ test('render export modal with errors when appropriate', async () => {
 test('render export modal with errors when appropriate - backup', async () => {
   const closeFn = vi.fn();
   apiMock.setUsbDriveStatus(mockUsbDriveStatus('mounted'));
-  renderInAppContext(<ExportResultsModal mode="backup" onClose={closeFn} />, {
+  renderInAppContext(<ExportResultsModal onClose={closeFn} />, {
     apiMock,
   });
-  await screen.findByText('Save Backup');
+  await screen.findByText('Save CVRs');
 
   apiMock.apiClient.exportCastVoteRecordsToUsbDrive
-    .expectCallWith({ isMinimalExport: false })
+    .expectCallWith()
     .resolves(err({ type: 'file-system-error' }));
   userEvent.click(screen.getByText('Save'));
-  await screen.findByText('Failed to Save Backup');
+  await screen.findByText('Failed to Save CVRs');
   await screen.findByText('Unable to write to USB drive.');
 
   userEvent.click(screen.getByText('Close'));

--- a/apps/central-scan/frontend/src/components/export_results_modal.test.tsx
+++ b/apps/central-scan/frontend/src/components/export_results_modal.test.tsx
@@ -82,22 +82,3 @@ test('render export modal with errors when appropriate', async () => {
   userEvent.click(screen.getByText('Close'));
   expect(closeFn).toHaveBeenCalled();
 });
-
-test('render export modal with errors when appropriate - backup', async () => {
-  const closeFn = vi.fn();
-  apiMock.setUsbDriveStatus(mockUsbDriveStatus('mounted'));
-  renderInAppContext(<ExportResultsModal onClose={closeFn} />, {
-    apiMock,
-  });
-  await screen.findByText('Save CVRs');
-
-  apiMock.apiClient.exportCastVoteRecordsToUsbDrive
-    .expectCallWith()
-    .resolves(err({ type: 'file-system-error' }));
-  userEvent.click(screen.getByText('Save'));
-  await screen.findByText('Failed to Save CVRs');
-  await screen.findByText('Unable to write to USB drive.');
-
-  userEvent.click(screen.getByText('Close'));
-  expect(closeFn).toHaveBeenCalled();
-});

--- a/apps/central-scan/frontend/src/components/export_results_modal.tsx
+++ b/apps/central-scan/frontend/src/components/export_results_modal.tsx
@@ -21,7 +21,6 @@ import { InsertUsbDriveModal } from './insert_usb_drive_modal';
 
 export interface Props {
   onClose: () => void;
-  mode: 'cvrs' | 'backup';
 }
 
 enum ModalState {
@@ -31,10 +30,7 @@ enum ModalState {
   INIT = 'init',
 }
 
-export function ExportResultsModal({
-  onClose,
-  mode,
-}: Props): JSX.Element | null {
+export function ExportResultsModal({ onClose }: Props): JSX.Element | null {
   const [currentState, setCurrentState] = useState<ModalState>(ModalState.INIT);
   const [errorMessage, setErrorMessage] = useState('');
 
@@ -47,19 +43,16 @@ export function ExportResultsModal({
 
   function exportResults() {
     setCurrentState(ModalState.SAVING);
-    exportCastVoteRecordsToUsbDriveMutation.mutate(
-      { isMinimalExport: mode === 'cvrs' },
-      {
-        onSuccess: (result) => {
-          if (result.isErr()) {
-            setErrorMessage(userReadableMessageFromExportError(result.err()));
-            setCurrentState(ModalState.ERROR);
-          } else {
-            setCurrentState(ModalState.DONE);
-          }
-        },
-      }
-    );
+    exportCastVoteRecordsToUsbDriveMutation.mutate(undefined, {
+      onSuccess: (result) => {
+        if (result.isErr()) {
+          setErrorMessage(userReadableMessageFromExportError(result.err()));
+          setCurrentState(ModalState.ERROR);
+        } else {
+          setCurrentState(ModalState.DONE);
+        }
+      },
+    });
   }
 
   if (!usbDriveStatusQuery.isSuccess) {
@@ -71,7 +64,7 @@ export function ExportResultsModal({
   if (currentState === ModalState.ERROR) {
     return (
       <Modal
-        title={`Failed to Save ${mode === 'cvrs' ? 'CVRs' : 'Backup'}`}
+        title="Failed to Save CVRs"
         content={<P>{errorMessage}</P>}
         onOverlayClick={onClose}
         actions={<Button onPress={onClose}>Close</Button>}
@@ -85,12 +78,9 @@ export function ExportResultsModal({
         <Modal
           title="USB Drive Ejected"
           content={
-            mode === 'cvrs' ? (
-              <P>
-                Insert the USB drive into VxAdmin for adjudication and
-                reporting.
-              </P>
-            ) : null
+            <P>
+              Insert the USB drive into VxAdmin for adjudication and reporting.
+            </P>
           }
           onOverlayClick={onClose}
           actions={<Button onPress={onClose}>Close</Button>}
@@ -99,14 +89,12 @@ export function ExportResultsModal({
     }
     return (
       <Modal
-        title={mode === 'cvrs' ? 'CVRs Saved' : 'Backup Saved'}
+        title="CVRs Saved"
         content={
-          mode === 'cvrs' ? (
-            <P>
-              Eject the USB drive and insert it into VxAdmin for adjudication
-              and reporting.
-            </P>
-          ) : null
+          <P>
+            Eject the USB drive and insert it into VxAdmin for adjudication and
+            reporting.
+          </P>
         }
         onOverlayClick={onClose}
         actions={
@@ -125,13 +113,7 @@ export function ExportResultsModal({
   }
 
   if (currentState === ModalState.SAVING) {
-    return (
-      <Modal
-        content={
-          <Loading>{mode === 'cvrs' ? 'Saving CVRs' : 'Saving Backup'}</Loading>
-        }
-      />
-    );
+    return <Modal content={<Loading>Saving CVRs</Loading>} />;
   }
 
   // istanbul ignore next -- compile-time check
@@ -145,22 +127,15 @@ export function ExportResultsModal({
     case 'error':
       return (
         <InsertUsbDriveModal
-          message={`Insert a USB drive in order to save ${
-            mode === 'cvrs' ? 'CVRs' : 'a backup'
-          }.`}
+          message="Insert a USB drive in order to save CVRs."
           onClose={onClose}
         />
       );
     case 'mounted':
       return (
         <Modal
-          title={mode === 'cvrs' ? 'Save CVRs' : 'Save Backup'}
-          content={
-            <P>
-              {mode === 'cvrs' ? 'CVRs' : 'A backup'} will be saved to the
-              inserted USB drive.
-            </P>
-          }
+          title="Save CVRs"
+          content={<P>CVRs will be saved to the inserted USB drive.</P>}
           onOverlayClick={onClose}
           actions={
             <React.Fragment>

--- a/apps/central-scan/frontend/src/screens/diagnostics_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/diagnostics_screen.tsx
@@ -53,6 +53,7 @@ export function DiagnosticsScreen(): JSX.Element {
   const diskSpaceSummary = diskSpaceQuery.data;
   const scannerDiagnosticRecord =
     scannerDiagnosticRecordQuery.data ?? undefined;
+  /* istanbul ignore next - @preserve */
   const { markThresholds } = systemSettings.data ?? {};
 
   return (

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
@@ -80,7 +80,7 @@ test('Delete All Batches is not allowed when canUnconfigure is false', () => {
   renderScreen({ status });
 
   userEvent.click(screen.getButton('Delete All Batches'));
-  screen.getByRole('heading', { name: 'Backup Required' });
+  screen.getByRole('heading', { name: 'CVR Backup Required' });
   userEvent.click(screen.getButton('Close'));
   expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
 });

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
@@ -244,12 +244,12 @@ export function ScanBallotsScreen({
           <Modal
             title={
               <span>
-                <Icons.Warning color="warning" /> Backup Required
+                <Icons.Warning color="warning" /> CVR Backup Required
               </span>
             }
             content={
               <P>
-                Go to <Font weight="semiBold">Settings</Font> and save a backup
+                Click <Font weight="semiBold">Save CVRs</Font> to save a backup
                 before deleting all batches.
               </P>
             }

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
@@ -248,10 +248,7 @@ export function ScanBallotsScreen({
               </span>
             }
             content={
-              <P>
-                Click <Font weight="semiBold">Save CVRs</Font> to save a backup
-                before deleting all batches.
-              </P>
+              <P>You must save CVRs before you can delete all batches.</P>
             }
             actions={<Button onPress={resetDeleteBallotDataFlow}>Close</Button>}
             onOverlayClick={resetDeleteBallotDataFlow}

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
@@ -219,10 +219,7 @@ export function ScanBallotsScreen({
         />
       )}
       {isExportingCvrs && (
-        <ExportResultsModal
-          mode="cvrs"
-          onClose={() => setIsExportingCvrs(false)}
-        />
+        <ExportResultsModal onClose={() => setIsExportingCvrs(false)} />
       )}
       {deleteBallotDataFlowState === 'confirmation' &&
         (status.canUnconfigure ? (

--- a/apps/central-scan/frontend/src/screens/settings_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/settings_screen.test.tsx
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
-import { mockUsbDriveStatus } from '@votingworks/ui';
 import { screen, within } from '../../test/react_testing_library';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { SettingsScreenProps, SettingsScreen } from './settings_screen';
@@ -28,31 +27,6 @@ function renderScreen(
     { apiMock, history }
   );
 }
-
-test('clicking "Save Backup" triggers modal', async () => {
-  apiMock.setUsbDriveStatus(mockUsbDriveStatus('no_drive'));
-  renderScreen();
-
-  userEvent.click(await screen.findByText('Save Backup'));
-  await screen.findByText('No USB Drive Detected');
-
-  apiMock.setUsbDriveStatus(mockUsbDriveStatus('mounted'));
-  await screen.findByRole('heading', { name: 'Save Backup' });
-
-  apiMock.expectExportCastVoteRecords({ isMinimalExport: false });
-  userEvent.click(screen.getButton('Save'));
-  await screen.findByText('Saving Backup');
-  await screen.findByText('Backup Saved');
-
-  apiMock.expectEjectUsbDrive();
-  userEvent.click(screen.getButton('Eject USB'));
-  apiMock.setUsbDriveStatus(mockUsbDriveStatus('ejected'));
-  await screen.findByText('USB Drive Ejected');
-  userEvent.click(screen.getButton('Close'));
-  await vi.waitFor(() =>
-    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
-  );
-});
 
 test('Unconfigure Machine button is disabled when canUnconfigure is falsy', () => {
   renderScreen({

--- a/apps/central-scan/frontend/src/screens/settings_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/settings_screen.tsx
@@ -1,7 +1,6 @@
-import { useState, useContext } from 'react';
+import { useContext } from 'react';
 import { assert } from '@votingworks/basics';
 import {
-  Button,
   Caption,
   CurrentDateAndTime,
   ExportLogsButton,
@@ -19,7 +18,6 @@ import { ToggleTestModeButton } from '../components/toggle_test_mode_button';
 import { AppContext } from '../contexts/app_context';
 import { logOut, unconfigure, ejectUsbDrive, useApiClient } from '../api';
 import { NavigationScreen } from '../navigation_screen';
-import { ExportResultsModal } from '../components/export_results_modal';
 
 const ButtonRow = styled.div`
   &:not(:last-child) {
@@ -52,8 +50,6 @@ export function SettingsScreen({
     }
   }
 
-  const [isSavingBackup, setIsSavingBackup] = useState(false);
-
   return (
     <NavigationScreen title="Settings">
       <H2>Election</H2>
@@ -72,11 +68,6 @@ export function SettingsScreen({
           can unconfigure this machine.
         </Caption>
       )}
-
-      <H2>Backup</H2>
-      <ButtonRow>
-        <Button onPress={() => setIsSavingBackup(true)}>Save Backup</Button>
-      </ButtonRow>
 
       <H2>Logs</H2>
       <ButtonRow>
@@ -97,13 +88,6 @@ export function SettingsScreen({
       <ButtonRow>
         <SignedHashValidationButton apiClient={apiClient} />
       </ButtonRow>
-
-      {isSavingBackup && (
-        <ExportResultsModal
-          mode="backup"
-          onClose={() => setIsSavingBackup(false)}
-        />
-      )}
     </NavigationScreen>
   );
 }

--- a/apps/central-scan/frontend/src/screens/settings_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/settings_screen.tsx
@@ -64,7 +64,7 @@ export function SettingsScreen({
       </ButtonRow>
       {!canUnconfigure && (
         <Caption>
-          <Icons.Warning color="warning" /> You must save cvrs before you can
+          <Icons.Warning color="warning" /> You must save CVRs before you can
           unconfigure this machine.
         </Caption>
       )}

--- a/apps/central-scan/frontend/src/screens/settings_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/settings_screen.tsx
@@ -64,8 +64,8 @@ export function SettingsScreen({
       </ButtonRow>
       {!canUnconfigure && (
         <Caption>
-          <Icons.Warning color="warning" /> You must save a backup before you
-          can unconfigure this machine.
+          <Icons.Warning color="warning" /> You must save cvrs before you can
+          unconfigure this machine.
         </Caption>
       )}
 

--- a/apps/central-scan/frontend/test/api.tsx
+++ b/apps/central-scan/frontend/test/api.tsx
@@ -125,10 +125,8 @@ export function createApiMock(
       apiClient.continueScanning.expectCallWith(input).resolves();
     },
 
-    expectExportCastVoteRecords(input: { isMinimalExport: boolean }) {
-      apiClient.exportCastVoteRecordsToUsbDrive
-        .expectCallWith(input)
-        .resolves(ok());
+    expectExportCastVoteRecords() {
+      apiClient.exportCastVoteRecordsToUsbDrive.expectCallWith().resolves(ok());
     },
 
     expectSetTestMode(testMode: boolean) {

--- a/libs/backend/src/cast_vote_records/export.test.ts
+++ b/libs/backend/src/cast_vote_records/export.test.ts
@@ -172,7 +172,7 @@ test.each<{
     ],
   },
   {
-    description: 'accepted HMPB on central scanner, non-minimal export',
+    description: 'accepted HMPB on central scanner',
     sheetGenerator: () => newAcceptedSheet(interpretedHmpb, sheet1Id),
     exportOptions: { scannerType: 'central' },
     expectedDirectoryContents: [
@@ -195,16 +195,6 @@ test.each<{
         Location: `file:${sheet1Id}-back.jpg`,
       },
     ],
-  },
-  {
-    description: 'accepted HMPB on central scanner, minimal export',
-    sheetGenerator: () => newAcceptedSheet(interpretedHmpb, sheet1Id),
-    exportOptions: { scannerType: 'central' },
-    expectedDirectoryContents: [
-      CastVoteRecordExportFileName.METADATA,
-      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
-    ],
-    expectedBallotImageField: undefined,
   },
   {
     description: 'accepted HMPB with write-in on precinct scanner',
@@ -233,8 +223,7 @@ test.each<{
     ],
   },
   {
-    description:
-      'accepted HMPB with write-in on central scanner, non-minimal export',
+    description: 'accepted HMPB with write-in on central scanner',
     sheetGenerator: () =>
       newAcceptedSheet(interpretedHmpbWithWriteIn, sheet1Id),
     exportOptions: { scannerType: 'central' },
@@ -260,35 +249,7 @@ test.each<{
     ],
   },
   {
-    description:
-      'accepted HMPB with write-in on central scanner, minimal export',
-    sheetGenerator: () =>
-      newAcceptedSheet(interpretedHmpbWithWriteIn, sheet1Id),
-    exportOptions: { scannerType: 'central' },
-    expectedDirectoryContents: [
-      CastVoteRecordExportFileName.METADATA,
-      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
-      `${sheet1Id}/${sheet1Id}-front.jpg`,
-      `${sheet1Id}/${sheet1Id}-back.jpg`,
-      `${sheet1Id}/${sheet1Id}-front.layout.json`,
-      `${sheet1Id}/${sheet1Id}-back.layout.json`,
-    ],
-    expectedBallotImageField: [
-      {
-        '@type': 'CVR.ImageData',
-        Hash: anyCastVoteRecordHash,
-        Location: `file:${sheet1Id}-front.jpg`,
-      },
-      {
-        '@type': 'CVR.ImageData',
-        Hash: anyCastVoteRecordHash,
-        Location: `file:${sheet1Id}-back.jpg`,
-      },
-    ],
-  },
-  {
-    description:
-      'accepted HMPB with unmarked write-in on central scanner, minimal export',
+    description: 'accepted HMPB with unmarked write-in on central scanner',
     sheetGenerator: () =>
       newAcceptedSheet(interpretedHmpbWithUnmarkedWriteIn, sheet1Id),
     exportOptions: { scannerType: 'central' },
@@ -337,7 +298,7 @@ test.each<{
     ],
   },
   {
-    description: 'accepted BMD ballot on central scanner, non-minimal export',
+    description: 'accepted BMD ballot on central scanner',
     sheetGenerator: () => newAcceptedSheet(interpretedBmdBallot, sheet1Id),
     exportOptions: { scannerType: 'central' },
     expectedDirectoryContents: [
@@ -360,43 +321,7 @@ test.each<{
     ],
   },
   {
-    description:
-      'accepted BMD ballot with write in on central scanner, non-minimal export',
-    sheetGenerator: () =>
-      newAcceptedSheet(interpretedBmdBallotWithWriteIn, sheet1Id),
-    exportOptions: { scannerType: 'central' },
-    expectedDirectoryContents: [
-      CastVoteRecordExportFileName.METADATA,
-      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
-      `${sheet1Id}/${sheet1Id}-front.jpg`,
-      `${sheet1Id}/${sheet1Id}-back.jpg`,
-    ],
-    expectedBallotImageField: [
-      {
-        '@type': 'CVR.ImageData',
-        Hash: anyCastVoteRecordHash,
-        Location: `file:${sheet1Id}-front.jpg`,
-      },
-      {
-        '@type': 'CVR.ImageData',
-        Hash: anyCastVoteRecordHash,
-        Location: `file:${sheet1Id}-back.jpg`,
-      },
-    ],
-  },
-  {
-    description: 'accepted BMD ballot on central scanner, minimal export',
-    sheetGenerator: () => newAcceptedSheet(interpretedBmdBallot, sheet1Id),
-    exportOptions: { scannerType: 'central' },
-    expectedDirectoryContents: [
-      CastVoteRecordExportFileName.METADATA,
-      `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
-    ],
-    expectedBallotImageField: undefined,
-  },
-  {
-    description:
-      'accepted BMD ballot with write in on central scanner, minimal export',
+    description: 'accepted BMD ballot with write in on central scanner',
     sheetGenerator: () =>
       newAcceptedSheet(interpretedBmdBallotWithWriteIn, sheet1Id),
     exportOptions: { scannerType: 'central' },
@@ -430,7 +355,7 @@ test.each<{
     ],
   },
   {
-    description: 'rejected sheet on central scanner, non-minimal export',
+    description: 'rejected sheet on central scanner',
     sheetGenerator: () => newRejectedSheet(sheet1Id),
     exportOptions: { scannerType: 'central' },
     expectedDirectoryContents: [
@@ -628,8 +553,8 @@ test('precinct scanner full export', async () => {
   }
 });
 
-test('central scanner multiple-sheet export, minimal and non-minimal', async () => {
-  // Perform a minimal export
+test('central scanner multiple-sheet export, subsequent exports', async () => {
+  // Perform an export
   const sheets: Sheet[] = [
     newAcceptedSheet(interpretedHmpb, sheet1Id),
     newAcceptedSheet(interpretedHmpbWithWriteIn, sheet2Id),
@@ -654,12 +579,18 @@ test('central scanner multiple-sheet export, minimal and non-minimal', async () 
   let expectedExportDirectoryContents = [
     CastVoteRecordExportFileName.METADATA,
     `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+    `${sheet1Id}/${sheet1Id}-front.jpg`,
+    `${sheet1Id}/${sheet1Id}-back.jpg`,
+    `${sheet1Id}/${sheet1Id}-front.layout.json`,
+    `${sheet1Id}/${sheet1Id}-back.layout.json`,
     `${sheet2Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
     `${sheet2Id}/${sheet2Id}-front.jpg`,
     `${sheet2Id}/${sheet2Id}-back.jpg`,
     `${sheet2Id}/${sheet2Id}-front.layout.json`,
     `${sheet2Id}/${sheet2Id}-back.layout.json`,
     `${sheet3Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
+    `${sheet3Id}/${sheet3Id}-front.jpg`,
+    `${sheet3Id}/${sheet3Id}-back.jpg`,
   ].sort();
   expect(exportDirectoryContents).toEqual(expectedExportDirectoryContents);
 
@@ -667,7 +598,7 @@ test('central scanner multiple-sheet export, minimal and non-minimal', async () 
   // first
   await sleep(1000);
 
-  // Perform a non-minimal export
+  // Reject a sheet and push a new export, which should include the rejected sheet
   sheets.push(newRejectedSheet(sheet4Id));
   expect(
     await exportCastVoteRecordsToUsbDrive(
@@ -687,12 +618,6 @@ test('central scanner multiple-sheet export, minimal and non-minimal', async () 
     await summarizeDirectoryContents(exportDirectoryPath);
   expectedExportDirectoryContents = [
     ...expectedExportDirectoryContents,
-    `${sheet1Id}/${sheet1Id}-front.jpg`,
-    `${sheet1Id}/${sheet1Id}-back.jpg`,
-    `${sheet1Id}/${sheet1Id}-front.layout.json`,
-    `${sheet1Id}/${sheet1Id}-back.layout.json`,
-    `${sheet3Id}/${sheet3Id}-front.jpg`,
-    `${sheet3Id}/${sheet3Id}-back.jpg`,
     `rejected-${sheet4Id}/${sheet4Id}-front.jpg`,
     `rejected-${sheet4Id}/${sheet4Id}-back.jpg`,
   ].sort();
@@ -717,20 +642,6 @@ test('detecting invalid sheet with incompatible interpretation types', async () 
       subType: 'incompatible-interpretation-types',
       interpretationTypes: ['InterpretedHmpbPage', 'InterpretedBmdPage'],
     })
-  );
-});
-
-test('central scanner minimal export does not allow rejected sheets', async () => {
-  await expect(
-    exportCastVoteRecordsToUsbDrive(
-      mockCentralScannerStore,
-      mockUsbDrive.usbDrive,
-      [newRejectedSheet()],
-      { scannerType: 'central' }
-    )
-  ).rejects.toThrow(
-    'Encountered an unexpected rejected sheet while performing a minimal export. ' +
-      'Minimal exports should only include accepted sheets.'
   );
 });
 

--- a/libs/backend/src/cast_vote_records/export.test.ts
+++ b/libs/backend/src/cast_vote_records/export.test.ts
@@ -174,7 +174,7 @@ test.each<{
   {
     description: 'accepted HMPB on central scanner, non-minimal export',
     sheetGenerator: () => newAcceptedSheet(interpretedHmpb, sheet1Id),
-    exportOptions: { scannerType: 'central', isMinimalExport: false },
+    exportOptions: { scannerType: 'central' },
     expectedDirectoryContents: [
       CastVoteRecordExportFileName.METADATA,
       `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
@@ -199,7 +199,7 @@ test.each<{
   {
     description: 'accepted HMPB on central scanner, minimal export',
     sheetGenerator: () => newAcceptedSheet(interpretedHmpb, sheet1Id),
-    exportOptions: { scannerType: 'central', isMinimalExport: true },
+    exportOptions: { scannerType: 'central' },
     expectedDirectoryContents: [
       CastVoteRecordExportFileName.METADATA,
       `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
@@ -237,7 +237,7 @@ test.each<{
       'accepted HMPB with write-in on central scanner, non-minimal export',
     sheetGenerator: () =>
       newAcceptedSheet(interpretedHmpbWithWriteIn, sheet1Id),
-    exportOptions: { scannerType: 'central', isMinimalExport: false },
+    exportOptions: { scannerType: 'central' },
     expectedDirectoryContents: [
       CastVoteRecordExportFileName.METADATA,
       `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
@@ -264,7 +264,7 @@ test.each<{
       'accepted HMPB with write-in on central scanner, minimal export',
     sheetGenerator: () =>
       newAcceptedSheet(interpretedHmpbWithWriteIn, sheet1Id),
-    exportOptions: { scannerType: 'central', isMinimalExport: true },
+    exportOptions: { scannerType: 'central' },
     expectedDirectoryContents: [
       CastVoteRecordExportFileName.METADATA,
       `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
@@ -291,7 +291,7 @@ test.each<{
       'accepted HMPB with unmarked write-in on central scanner, minimal export',
     sheetGenerator: () =>
       newAcceptedSheet(interpretedHmpbWithUnmarkedWriteIn, sheet1Id),
-    exportOptions: { scannerType: 'central', isMinimalExport: true },
+    exportOptions: { scannerType: 'central' },
     expectedDirectoryContents: [
       CastVoteRecordExportFileName.METADATA,
       `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
@@ -339,7 +339,7 @@ test.each<{
   {
     description: 'accepted BMD ballot on central scanner, non-minimal export',
     sheetGenerator: () => newAcceptedSheet(interpretedBmdBallot, sheet1Id),
-    exportOptions: { scannerType: 'central', isMinimalExport: false },
+    exportOptions: { scannerType: 'central' },
     expectedDirectoryContents: [
       CastVoteRecordExportFileName.METADATA,
       `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
@@ -364,7 +364,7 @@ test.each<{
       'accepted BMD ballot with write in on central scanner, non-minimal export',
     sheetGenerator: () =>
       newAcceptedSheet(interpretedBmdBallotWithWriteIn, sheet1Id),
-    exportOptions: { scannerType: 'central', isMinimalExport: false },
+    exportOptions: { scannerType: 'central' },
     expectedDirectoryContents: [
       CastVoteRecordExportFileName.METADATA,
       `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
@@ -387,7 +387,7 @@ test.each<{
   {
     description: 'accepted BMD ballot on central scanner, minimal export',
     sheetGenerator: () => newAcceptedSheet(interpretedBmdBallot, sheet1Id),
-    exportOptions: { scannerType: 'central', isMinimalExport: true },
+    exportOptions: { scannerType: 'central' },
     expectedDirectoryContents: [
       CastVoteRecordExportFileName.METADATA,
       `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
@@ -399,7 +399,7 @@ test.each<{
       'accepted BMD ballot with write in on central scanner, minimal export',
     sheetGenerator: () =>
       newAcceptedSheet(interpretedBmdBallotWithWriteIn, sheet1Id),
-    exportOptions: { scannerType: 'central', isMinimalExport: true },
+    exportOptions: { scannerType: 'central' },
     expectedDirectoryContents: [
       CastVoteRecordExportFileName.METADATA,
       `${sheet1Id}/${CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT}`,
@@ -432,7 +432,7 @@ test.each<{
   {
     description: 'rejected sheet on central scanner, non-minimal export',
     sheetGenerator: () => newRejectedSheet(sheet1Id),
-    exportOptions: { scannerType: 'central', isMinimalExport: false },
+    exportOptions: { scannerType: 'central' },
     expectedDirectoryContents: [
       CastVoteRecordExportFileName.METADATA,
       `rejected-${sheet1Id}/${sheet1Id}-front.jpg`,
@@ -640,7 +640,7 @@ test('central scanner multiple-sheet export, minimal and non-minimal', async () 
       mockCentralScannerStore,
       mockUsbDrive.usbDrive,
       sheets,
-      { scannerType: 'central', isMinimalExport: true }
+      { scannerType: 'central' }
     )
   ).toEqual(ok());
 
@@ -674,7 +674,7 @@ test('central scanner multiple-sheet export, minimal and non-minimal', async () 
       mockCentralScannerStore,
       mockUsbDrive.usbDrive,
       sheets,
-      { scannerType: 'central', isMinimalExport: false }
+      { scannerType: 'central' }
     )
   ).toEqual(ok());
 
@@ -726,7 +726,7 @@ test('central scanner minimal export does not allow rejected sheets', async () =
       mockCentralScannerStore,
       mockUsbDrive.usbDrive,
       [newRejectedSheet()],
-      { scannerType: 'central', isMinimalExport: true }
+      { scannerType: 'central' }
     )
   ).rejects.toThrow(
     'Encountered an unexpected rejected sheet while performing a minimal export. ' +


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/5781

Previously `central-scan`'s `exportCastVoteRecordsToUsbDrive` mutation offered a minimal export that excluded most ballot images (those w/o write-ins and rejected ballots). Now we plan to include them all to ensure ballots with marginal marks will be viewable. If performance is hit too significantly, we can optimize this by filtering out images. Conversation [here](https://votingworks.slack.com/archives/CEL6D3GAD/p1746555973582259).

This PR removes the `isMinimalExport` option for cvr exports on `central-scan` and the "Save Backup" UI option, as "Save CVRs" will now always perform the same comprehensive backup that "Save Backup" previously did.


### New (w/o save backup)
https://github.com/user-attachments/assets/ab99b9b3-cb31-4ac5-a386-890982741c55

### Old (w/ save backup)
https://github.com/user-attachments/assets/750e0d3d-87bb-475e-81d6-460ca9393cf2


## Testing Plan

 I've updated the relevant tests in `libs/backend` that test whether the image correct files are exported for accepted and rejected ballots with and without write-ins. Now, all should be exported on each export, just as is the case from `scan` already.

Struggling to manually test scanning ballots locally to test the "Save CVRs" or "Unconfigure Machine" flow block on saving cvrs, but none of that logic is really changed here anyways and I reviewed the automated tests and they accurately cover that logic.

## Checklist


- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
