### PR TITLE
[libs/auth] Fix audio performance issues due to unstable auth data

### DIFF
--- a/libs/auth/src/inserted_smart_card_auth.ts
+++ b/libs/auth/src/inserted_smart_card_auth.ts
@@ -157,6 +157,8 @@ function logAuthEvent(
   }
 }
 
+const NEVER = new Date('01/01/9000');
+
 /**
  * The implementation of the inserted smart card auth API
  */
@@ -205,7 +207,7 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
       return {
         status: 'logged_in',
         user: this.cardlessVoterUser,
-        sessionExpiresAt: computeSessionEndTime(machineState),
+        sessionExpiresAt: NEVER,
       };
     }
 

--- a/libs/auth/src/inserted_smart_card_auth.ts
+++ b/libs/auth/src/inserted_smart_card_auth.ts
@@ -207,6 +207,9 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
       return {
         status: 'logged_in',
         user: this.cardlessVoterUser,
+        // This is unused for voter sessions - voter session timeouts are
+        // managed client-side. Making this value static helps avoid unnecessary
+        // UI re-renders whenever the client polls for updates.
         sessionExpiresAt: NEVER,
       };
     }


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6217

We recently added response diffing logic to polling requests across VxSuite to skip updating the cache (and triggering re-renders) when the data hasn't changed.

On VxMark, we're running into an edge case where the auth object changes on every request, since we generate a new (unused) session expiry date each time and this was causing performance issues on pages with lots of elements and manifesting in glitchy audio playback.

Patching by locking the session expiry to a static future date, since it's unused, to keep the auth status response stable for diffing. Voter sessions have a separate timeout logic path.

## Testing Plan
- Reproduced audio issues in a VM with CPU limiting on the kiosk-browser process - then, verified that there's no audible glitching after this change.
- Will also be testing the before and after on a real BMD to verify - there are still some unrelated, remaining perf issues to work out.

## Checklist

- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
