### PR TITLE
pdi-scanner: Disable auto-feeding after scan completes

### DIFF
--- a/libs/pdi-scanner/examples/scan_forever.rs
+++ b/libs/pdi-scanner/examples/scan_forever.rs
@@ -105,7 +105,7 @@ fn main() -> color_eyre::Result<()> {
                     match raw_image_data.try_decode_scan(DEFAULT_IMAGE_WIDTH, ScanSideMode::Duplex)
                     {
                         Ok(Sheet::Duplex(top, bottom)) => {
-                            match (top.to_image(), bottom.to_image()) {
+                            match (top.to_cropped_image(), bottom.to_cropped_image()) {
                                 (Some(top_image), Some(bottom_image)) => {
                                     let top_path =
                                         PathBuf::from(format!("scan-{scan_index:04}-top.png"));

--- a/libs/pdi-scanner/src/rust/client.rs
+++ b/libs/pdi-scanner/src/rust/client.rs
@@ -251,12 +251,12 @@ impl<T> Client<T> {
     /// This function will return an error if the connection to the scanner is
     /// lost.
     pub fn eject_document(&mut self, eject_motion: EjectMotion) -> Result<()> {
-        // The feeder needs to be enabled for the eject command to work.
-        self.set_feeder_mode(FeederMode::AutoScanSheets)?;
         self.set_eject_pause_mode(match eject_motion {
             EjectMotion::ToRear => EjectPauseMode::PauseWhileInputPaperDetected,
             _ => EjectPauseMode::DoNotCheckForInputPaper,
         })?;
+        // The feeder needs to be enabled for the eject command to work.
+        self.set_feeder_mode(FeederMode::AutoScanSheets)?;
         self.send(match eject_motion {
             EjectMotion::ToRear => Outgoing::EjectDocumentToRearOfScannerRequest,
             EjectMotion::ToFront => Outgoing::EjectDocumentToFrontOfScannerRequest,

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -373,6 +373,11 @@ fn main() -> color_eyre::Result<()> {
                     send_event(Event::ScanStart)?;
                 }
                 Ok(Incoming::EndScanEvent) => {
+                    // Disable the feeder to prevent another scan from beginning. We've seen cases
+                    // where a scan fails (e.g. if the paper isn't caught by the rollers) and then
+                    // another scan immediately starts. We want to have time to handle the results
+                    // of this scan safely.
+                    c.set_feeder_mode(FeederMode::Disabled)?;
                     match raw_image_data.try_decode_scan(DEFAULT_IMAGE_WIDTH, ScanSideMode::Duplex)
                     {
                         Ok(Sheet::Duplex(top, bottom)) => {

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -381,7 +381,7 @@ fn main() -> color_eyre::Result<()> {
                     match raw_image_data.try_decode_scan(DEFAULT_IMAGE_WIDTH, ScanSideMode::Duplex)
                     {
                         Ok(Sheet::Duplex(top, bottom)) => {
-                            match (top.to_image(), bottom.to_image()) {
+                            match (top.to_cropped_image(), bottom.to_cropped_image()) {
                                 (Some(top_image), Some(bottom_image)) => {
                                     send_event(Event::ScanComplete {
                                         image_data: (
@@ -393,20 +393,20 @@ fn main() -> color_eyre::Result<()> {
                                 (Some(_), None) => {
                                     send_event(Event::Error {
                                         code: ErrorCode::ScanFailed,
-                                        message: Some("failed to decode bottom image".to_owned()),
+                                        message: Some("bottom image is entirely black".to_owned()),
                                     })?;
                                 }
                                 (None, Some(_)) => {
                                     send_event(Event::Error {
                                         code: ErrorCode::ScanFailed,
-                                        message: Some("failed to decode top image".to_owned()),
+                                        message: Some("top image is entirely black".to_owned()),
                                     })?;
                                 }
                                 (None, None) => {
                                     send_event(Event::Error {
                                         code: ErrorCode::ScanFailed,
                                         message: Some(
-                                            "failed to decode top and bottom images".to_owned(),
+                                            "top and bottom images are entirely black".to_owned(),
                                         ),
                                     })?;
                                 }

--- a/libs/pdi-scanner/src/rust/parse_traffic.rs
+++ b/libs/pdi-scanner/src/rust/parse_traffic.rs
@@ -165,7 +165,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 };
 
                 for (side, page) in [(Side::Top, top_page), (Side::Bottom, bottom_page)] {
-                    page.to_image()
+                    page.to_cropped_image()
                         .unwrap()
                         .save(format!("image-{side:?}.png"))?;
                 }

--- a/libs/pdi-scanner/src/rust/protocol/image.rs
+++ b/libs/pdi-scanner/src/rust/protocol/image.rs
@@ -164,7 +164,7 @@ impl ScanPage {
         let data = self.convert_1bpp_to_8bpp();
         let image =
             GrayImage::from_raw(self.width, (data.len() / self.width as usize) as u32, data)
-                .unwrap();
+                .expect("from_raw can only fail if the data buffer is not big enough for the dimensions, but we compute the dimensions from the data buffer");
         let mut image = DynamicImage::ImageLuma8(image);
         let crop_start = self.find_crop_start();
         let crop_end = self.find_crop_end();

--- a/libs/pdi-scanner/src/rust/protocol/image.rs
+++ b/libs/pdi-scanner/src/rust/protocol/image.rs
@@ -157,12 +157,14 @@ impl ScanPage {
         })
     }
 
-    /// Converts the page to an 8bpp grayscale image.
+    /// Converts the page to an 8bpp grayscale image and crops off any all-black
+    /// rows at the top and bottom. Returns None if the image is entirely black.
     #[must_use]
-    pub fn to_image(&self) -> Option<GrayImage> {
+    pub fn to_cropped_image(&self) -> Option<GrayImage> {
         let data = self.convert_1bpp_to_8bpp();
         let image =
-            GrayImage::from_raw(self.width, (data.len() / self.width as usize) as u32, data)?;
+            GrayImage::from_raw(self.width, (data.len() / self.width as usize) as u32, data)
+                .unwrap();
         let mut image = DynamicImage::ImageLuma8(image);
         let crop_start = self.find_crop_start();
         let crop_end = self.find_crop_end();
@@ -260,7 +262,7 @@ mod tests {
     fn test_skip_starting_black_pixels() {
         let scan_page =
             ScanPage::new(8, 4, vec![0b11111111, 0b11111111, 0b10011001, 0b10011001]).unwrap();
-        let image = scan_page.to_image().unwrap();
+        let image = scan_page.to_cropped_image().unwrap();
         assert_eq!(
             image.to_vec(),
             vec![


### PR DESCRIPTION
## Overview

Task: https://github.com/votingworks/vxsuite/issues/6127

We saw a few cases in the field where the logging indicated that a failed scan (likely due to the paper not being grabbed by the rollers) was followed quickly after by a second scan starting. In these cases, the state machine hadn't yet finished attempting to clear out the ballot from the first failed scan, and crashed when the second scan started, since it was unexpected.

To prevent scan events from occurring in rapid succession like this, we disable the auto-feeding immediately after receiving the scan end event from the PDI scanner. Unfortunately, we have to turn the feeder back on in order to eject ballots, but we do so immediately before sending the eject command, so it should be fairly safe.

## Demo Video or Screenshot
N/A - wasn't able to reproduce the original error, so can't demo the fix

## Testing Plan
Manually tested that basic scanning flows still work

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
