### PR TITLE
Admin: Fix flaky contest adjudication test

### DIFF
--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
@@ -910,8 +910,8 @@ describe('ballot navigation', () => {
       apiMock,
     });
 
+    await screen.findByTestId('transcribe:id-175');
     await expect(screen.findAllByRole('checkbox')).resolves.not.toHaveLength(0);
-    expect(screen.queryByTestId('transcribe:id-175')).toBeInTheDocument();
 
     let skipButton = getButtonByName('skip');
     expect(skipButton).toBeEnabled();
@@ -932,8 +932,8 @@ describe('ballot navigation', () => {
     );
     userEvent.click(backButton);
 
+    await screen.findByTestId('transcribe:id-174');
     await expect(screen.findAllByRole('checkbox')).resolves.not.toHaveLength(0);
-    expect(screen.queryByTestId('transcribe:id-174')).toBeInTheDocument();
 
     skipButton = getButtonByName('skip');
     expect(skipButton).toBeEnabled();
@@ -991,9 +991,8 @@ describe('ballot navigation', () => {
     skipButton = getButtonByName('skip');
     userEvent.click(skipButton);
 
+    await screen.findByTestId('transcribe:id-176');
     await expect(screen.findAllByRole('checkbox')).resolves.not.toHaveLength(0);
-    expect(screen.queryByTestId('transcribe:id-176')).toBeInTheDocument();
-
     skipButton = getButtonByName('skip');
     expect(skipButton).toBeDisabled();
     backButton = getButtonByName('back');
@@ -1038,8 +1037,9 @@ describe('ballot image viewer', () => {
       apiMock,
     });
 
+    await screen.findByTestId('transcribe:id-174');
     await expect(screen.findAllByRole('checkbox')).resolves.not.toHaveLength(0);
-    expect(screen.queryByTestId('transcribe:id-174')).toBeInTheDocument();
+
     let ballotImage = await screen.findByRole('img', {
       name: /ballot with section highlighted/i,
     });
@@ -1109,8 +1109,8 @@ describe('ballot image viewer', () => {
 
     // When switching to previous adjudication, resets to zoomed in
     userEvent.click(screen.getButton(/Back/));
+    await screen.findByTestId('transcribe:id-174');
     await expect(screen.findAllByRole('checkbox')).resolves.not.toHaveLength(0);
-    expect(screen.queryByTestId('transcribe:id-174')).toBeInTheDocument();
     ballotImage = await screen.findByRole('img', {
       name: /ballot with section highlighted/i,
     });
@@ -1171,8 +1171,8 @@ describe('ballot image viewer', () => {
       apiMock,
     });
 
+    await screen.findByTestId('transcribe:id-174');
     await expect(screen.findAllByRole('checkbox')).resolves.not.toHaveLength(0);
-    expect(screen.queryByTestId('transcribe:id-174')).toBeInTheDocument();
     let ballotImage = await screen.findByRole('img', {
       name: /Full ballot/i,
     });
@@ -1442,8 +1442,8 @@ describe('unsaved changes', () => {
     const skipButton = screen.getByRole('button', { name: /skip/i });
     userEvent.click(skipButton);
 
+    await screen.findByTestId('transcribe:id-175');
     await expect(screen.findAllByRole('checkbox')).resolves.not.toHaveLength(0);
-    expect(screen.queryByTestId('transcribe:id-175')).toBeInTheDocument();
 
     let elephantCheckbox = getCheckboxByName('elephant');
     expect(elephantCheckbox).not.toBeChecked();
@@ -1469,8 +1469,8 @@ describe('unsaved changes', () => {
       name: /discard changes/i,
     });
     userEvent.click(modalDiscardButton);
+    await screen.findByTestId('transcribe:id-174');
     await expect(screen.findAllByRole('checkbox')).resolves.not.toHaveLength(0);
-    expect(screen.queryByTestId('transcribe:id-174')).toBeInTheDocument();
   });
 
   test('detects unsaved changes when navigating with the skip button', async () => {


### PR DESCRIPTION
## Overview

Jonah noticed a [test failure](https://app.circleci.com/pipelines/github/votingworks/vxsuite/19927/workflows/b7e438cb-7f9b-4af7-aa41-e6140cf0d055/jobs/843444/tests#failed-test-0). I haven't been able to repro nor have I seen it occur on other test invocations, but I think this change is helpful. 

The repeated change is when scrolling from cvr A to cvr B - previously the tests awaited the checkboxes to appear as a signal the digital ballot has loaded, but maybe the checkboxes would be around from the previous cvr. Now, we wait for the testID to change before looking for the checkboxes.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
