### PR TITLE
Kevin/pollbook move new registration to election manager

### DIFF
--- a/apps/pollbook/frontend/src/add_voter_screen.tsx
+++ b/apps/pollbook/frontend/src/add_voter_screen.tsx
@@ -2,9 +2,7 @@ import {
   Button,
   ButtonBar,
   Callout,
-  H1,
   MainContent,
-  MainHeader,
   SearchSelect,
 } from '@votingworks/ui';
 import { useMemo, useState } from 'react';
@@ -13,7 +11,7 @@ import type {
   VoterRegistrationRequest,
 } from '@votingworks/pollbook-backend';
 import { Column, Row, FieldName } from './layout';
-import { PollWorkerNavScreen } from './nav_screen';
+import { ElectionManagerNavScreen } from './nav_screen';
 import { AddressInputGroup } from './address_input_group';
 import { RequiredStaticInput } from './shared_components';
 import { NameInputGroup } from './name_input_group';
@@ -60,10 +58,7 @@ export function AddVoterScreen({
   );
 
   return (
-    <PollWorkerNavScreen>
-      <MainHeader>
-        <H1>Voter Registration</H1>
-      </MainHeader>
+    <ElectionManagerNavScreen title="Voter Registration">
       <MainContent>
         <Column style={{ gap: '1rem' }}>
           <NameInputGroup
@@ -114,6 +109,6 @@ export function AddVoterScreen({
         </Button>
         <div />
       </ButtonBar>
-    </PollWorkerNavScreen>
+    </ElectionManagerNavScreen>
   );
 }

--- a/apps/pollbook/frontend/src/api.ts
+++ b/apps/pollbook/frontend/src/api.ts
@@ -15,6 +15,8 @@ import {
   createSystemCallApi,
 } from '@votingworks/ui';
 
+export const DEFAULT_QUERY_REFETCH_INTERVAL = 1000;
+
 export type ApiClient = grout.Client<Api>;
 
 export function createApiClient(): ApiClient {
@@ -133,7 +135,7 @@ export const getUsbDriveStatus = {
   useQuery() {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(), () => apiClient.getUsbDriveStatus(), {
-      refetchInterval: 1000,
+      refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL,
     });
   },
 } as const;
@@ -145,7 +147,7 @@ export const getDeviceStatuses = {
   useQuery() {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(), () => apiClient.getDeviceStatuses(), {
-      refetchInterval: 1000,
+      refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL,
     });
   },
 } as const;
@@ -206,7 +208,7 @@ export const getCheckInCounts = {
   useQuery() {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(), () => apiClient.getCheckInCounts(), {
-      refetchInterval: 1000,
+      refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL,
     });
   },
 } as const;
@@ -218,7 +220,7 @@ export const getSummaryStatistics = {
   useQuery() {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(), () => apiClient.getSummaryStatistics(), {
-      refetchInterval: 1000,
+      refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL,
     });
   },
 } as const;
@@ -235,7 +237,7 @@ export const getThroughputStatistics = {
       this.queryKey(input),
       () => apiClient.getThroughputStatistics(input),
       {
-        refetchInterval: 1000,
+        refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL,
       }
     );
   },

--- a/apps/pollbook/frontend/src/app_election_manager_screen.test.tsx
+++ b/apps/pollbook/frontend/src/app_election_manager_screen.test.tsx
@@ -1,0 +1,111 @@
+import { expect, test, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  ValidStreetInfo,
+  VoterRegistrationRequest,
+} from '@votingworks/pollbook-backend';
+import { Election } from '@votingworks/types';
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+
+import userEvent from '@testing-library/user-event';
+import {
+  ApiMock,
+  createApiMock,
+  createMockVoter,
+} from '../test/mock_api_client';
+import { act, render, screen } from '../test/react_testing_library';
+import { App } from './app';
+import { AUTOMATIC_FLOW_STATE_RESET_DELAY_MS } from './globals';
+import { DEFAULT_QUERY_REFETCH_INTERVAL } from './api';
+
+let apiMock: ApiMock;
+const famousNamesElection: Election =
+  electionFamousNames2021Fixtures.readElection();
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.clearAllMocks();
+  apiMock = createApiMock();
+  apiMock.setElection(undefined);
+  apiMock.setIsAbsenteeMode(false);
+});
+
+afterEach(() => {
+  apiMock.mockApiClient.assertComplete();
+});
+
+test('basic e2e registration flow works', async () => {
+  const validStreetInfo: ValidStreetInfo = {
+    streetName: 'Main St',
+    side: 'even',
+    lowRange: 1000,
+    highRange: 2000,
+    postalCity: 'CITYVILLE',
+    zip5: '12345',
+    zip4: '6789',
+    district: 'District',
+  };
+  const voter = createMockVoter('123', 'Abigail', 'Adams');
+  const registrationData: VoterRegistrationRequest = {
+    streetNumber: '1000',
+    streetName: 'MAIN ST',
+    city: 'CITYVILLE',
+    state: 'NH',
+    zipCode: '12345',
+    lastName: voter.lastName.toUpperCase(),
+    firstName: voter.firstName.toUpperCase(),
+    party: 'REP',
+    streetSuffix: '',
+    apartmentUnitNumber: '',
+    houseFractionNumber: '',
+    addressLine2: '',
+    addressLine3: '',
+    suffix: '',
+    middleName: '',
+  };
+
+  apiMock.expectGetMachineConfig();
+  apiMock.expectGetDeviceStatuses();
+  apiMock.authenticateAsElectionManager(famousNamesElection);
+  apiMock.setElection(famousNamesElection);
+  const { unmount } = render(<App apiClient={apiMock.mockApiClient} />);
+
+  // apiMock.setPrinterStatus(true);
+  apiMock.expectGetValidStreetInfo([validStreetInfo]);
+  await screen.findByText('Registration');
+
+  const registrationTab = await screen.findByRole('button', {
+    name: 'Registration',
+  });
+  userEvent.click(registrationTab);
+
+  await screen.findByText('Connect printer to continue.');
+
+  apiMock.setPrinterStatus(true);
+
+  // Allow printer status query to refresh
+  vi.advanceTimersByTime(DEFAULT_QUERY_REFETCH_INTERVAL);
+
+  await screen.findByText('Voter Registration');
+  const lastNameInput = await screen.findByLabelText('Last Name');
+  userEvent.type(lastNameInput, voter.lastName);
+  const firstNameInput = screen.getByLabelText('First Name');
+  userEvent.type(firstNameInput, voter.firstName);
+  userEvent.type(screen.getByLabelText('Street Number'), '1000');
+  userEvent.click(screen.getByLabelText('Street Name'));
+  userEvent.keyboard('[Enter]');
+  userEvent.click(screen.getByLabelText('Party Affiliation'));
+  userEvent.keyboard('[Enter]');
+
+  apiMock.expectRegisterVoter(registrationData, voter);
+
+  userEvent.click(screen.getByRole('button', { name: 'Add Voter' }));
+
+  await screen.findByText('Give the voter their receipt.');
+  act(() => {
+    vi.advanceTimersByTime(AUTOMATIC_FLOW_STATE_RESET_DELAY_MS);
+  });
+  expect(screen.queryByText('Give the voter their receipt.')).toBeNull();
+
+  unmount();
+});

--- a/apps/pollbook/frontend/src/app_election_manager_screen.test.tsx
+++ b/apps/pollbook/frontend/src/app_election_manager_screen.test.tsx
@@ -70,7 +70,6 @@ test('basic e2e registration flow works', async () => {
   apiMock.setElection(famousNamesElection);
   const { unmount } = render(<App apiClient={apiMock.mockApiClient} />);
 
-  // apiMock.setPrinterStatus(true);
   apiMock.expectGetValidStreetInfo([validStreetInfo]);
   await screen.findByText('Registration');
 
@@ -87,13 +86,25 @@ test('basic e2e registration flow works', async () => {
   vi.advanceTimersByTime(DEFAULT_QUERY_REFETCH_INTERVAL);
 
   await screen.findByText('Voter Registration');
+
+  // Set name
   const lastNameInput = await screen.findByLabelText('Last Name');
   userEvent.type(lastNameInput, voter.lastName);
   const firstNameInput = screen.getByLabelText('First Name');
   userEvent.type(firstNameInput, voter.firstName);
-  userEvent.type(screen.getByLabelText('Street Number'), '1000');
+
+  // Set invalid street address
+  const streetNumberInput = screen.getByLabelText('Street Number');
+  userEvent.type(streetNumberInput, '3000');
   userEvent.click(screen.getByLabelText('Street Name'));
   userEvent.keyboard('[Enter]');
+  await screen.findByText(/Invalid address/);
+
+  // Set valid street address
+  userEvent.clear(streetNumberInput);
+  userEvent.type(streetNumberInput, '1000');
+
+  // Set party affiliation
   userEvent.click(screen.getByLabelText('Party Affiliation'));
   userEvent.keyboard('[Enter]');
 

--- a/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
+++ b/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
@@ -2,10 +2,6 @@ import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { Election } from '@votingworks/types';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
-import {
-  ValidStreetInfo,
-  VoterRegistrationRequest,
-} from '@votingworks/pollbook-backend';
 import { act, render, screen, within } from '../test/react_testing_library';
 import { App } from './app';
 import {
@@ -43,7 +39,6 @@ describe('PollWorkerScreen', () => {
     apiMock.setIsAbsenteeMode(false);
     apiMock.expectGetCheckInCounts({ allMachines: 25, thisMachine: 5 });
     await screen.findByText('Check-In');
-    await screen.findByText('Registration');
     apiMock.expectSearchVotersNull({});
 
     await screen.findByText('Total Check-ins');
@@ -89,77 +84,6 @@ describe('PollWorkerScreen', () => {
       vi.advanceTimersByTime(AUTOMATIC_FLOW_STATE_RESET_DELAY_MS);
     });
     expect(screen.queryByText('Voter Checked In')).toBeNull();
-
-    unmount();
-  });
-
-  test('basic e2e registration flow works', async () => {
-    const validStreetInfo: ValidStreetInfo = {
-      streetName: 'Main St',
-      side: 'even',
-      lowRange: 1000,
-      highRange: 2000,
-      postalCity: 'CITYVILLE',
-      zip5: '12345',
-      zip4: '6789',
-      district: 'District',
-    };
-    const voter = createMockVoter('123', 'Abigail', 'Adams');
-    const registrationData: VoterRegistrationRequest = {
-      streetNumber: '1000',
-      streetName: 'MAIN ST',
-      city: 'CITYVILLE',
-      state: 'NH',
-      zipCode: '12345',
-      lastName: voter.lastName.toUpperCase(),
-      firstName: voter.firstName.toUpperCase(),
-      party: 'REP',
-      streetSuffix: '',
-      apartmentUnitNumber: '',
-      houseFractionNumber: '',
-      addressLine2: '',
-      addressLine3: '',
-      suffix: '',
-      middleName: '',
-    };
-
-    apiMock.expectGetMachineConfig();
-    apiMock.expectGetDeviceStatuses();
-    apiMock.authenticateAsPollWorker(famousNamesElection);
-    apiMock.setElection(famousNamesElection);
-    const { unmount } = render(<App apiClient={apiMock.mockApiClient} />);
-    await screen.findByText('Connect printer to continue.');
-
-    apiMock.setPrinterStatus(true);
-    apiMock.expectGetValidStreetInfo([validStreetInfo]);
-    await screen.findByText('Check-In');
-    await screen.findByText('Registration');
-
-    await screen.findByText('Check-In');
-    const registrationTab = await screen.findByRole('button', {
-      name: 'Registration',
-    });
-    userEvent.click(registrationTab);
-
-    const lastNameInput = await screen.findByLabelText('Last Name');
-    userEvent.type(lastNameInput, voter.lastName);
-    const firstNameInput = screen.getByLabelText('First Name');
-    userEvent.type(firstNameInput, voter.firstName);
-    userEvent.type(screen.getByLabelText('Street Number'), '1000');
-    userEvent.click(screen.getByLabelText('Street Name'));
-    userEvent.keyboard('[Enter]');
-    userEvent.click(screen.getByLabelText('Party Affiliation'));
-    userEvent.keyboard('[Enter]');
-
-    apiMock.expectRegisterVoter(registrationData, voter);
-
-    userEvent.click(screen.getByRole('button', { name: 'Add Voter' }));
-
-    await screen.findByText('Give the voter their receipt.');
-    act(() => {
-      vi.advanceTimersByTime(AUTOMATIC_FLOW_STATE_RESET_DELAY_MS);
-    });
-    expect(screen.queryByText('Give the voter their receipt.')).toBeNull();
 
     unmount();
   });

--- a/apps/pollbook/frontend/src/election_manager_screen.tsx
+++ b/apps/pollbook/frontend/src/election_manager_screen.tsx
@@ -20,6 +20,7 @@ import { Column, FieldName, Row } from './layout';
 import { StatisticsScreen } from './statistics_screen';
 import { ElectionManagerVotersScreen } from './voters_screen';
 import { VoterDetailsScreen } from './voter_details_screen';
+import { VoterRegistrationScreen } from './voter_registration_screen';
 
 export function SettingsScreen(): JSX.Element | null {
   const getElectionQuery = getElection.useQuery();
@@ -98,6 +99,10 @@ export function ElectionManagerScreen(): JSX.Element {
       <Route
         path={electionManagerRoutes.statistics.path}
         component={StatisticsScreen}
+      />
+      <Route
+        path={electionManagerRoutes.addVoter.path}
+        component={VoterRegistrationScreen}
       />
       <Route path="/voters/:voterId" component={VoterDetailsScreen} />
       <Redirect to={electionManagerRoutes.settings.path} />

--- a/apps/pollbook/frontend/src/nav_screen.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.tsx
@@ -358,13 +358,14 @@ export const electionManagerRoutes = {
   settings: { title: 'Settings', path: '/settings' },
   voters: { title: 'Voters', path: '/voters' },
   statistics: { title: 'Statistics', path: '/statistics' },
+  addVoter: { title: 'Registration', path: '/registration' },
 } satisfies Record<string, { title: string; path: string }>;
 
 export function ElectionManagerNavScreen({
   title,
   children,
 }: {
-  title: string | React.ReactNode;
+  title?: string | React.ReactNode;
   children: React.ReactNode;
 }): JSX.Element {
   const currentRoute = useRouteMatch();
@@ -386,7 +387,9 @@ export function ElectionManagerNavScreen({
         </NavList>
       }
     >
-      <Header>{typeof title === 'string' ? <H1>{title}</H1> : title}</Header>
+      {title && (
+        <Header>{typeof title === 'string' ? <H1>{title}</H1> : title}</Header>
+      )}
       {children}
     </NavScreen>
   );
@@ -394,7 +397,6 @@ export function ElectionManagerNavScreen({
 
 export const pollWorkerRoutes = {
   checkIn: { title: 'Check-In', path: '/check-in' },
-  addVoter: { title: 'Registration', path: '/registration' },
 } satisfies Record<string, { title: string; path: string }>;
 
 export function PollWorkerNavScreen({

--- a/apps/pollbook/frontend/src/poll_worker_screen.tsx
+++ b/apps/pollbook/frontend/src/poll_worker_screen.tsx
@@ -1,10 +1,6 @@
 import { useCallback, useState } from 'react';
 import { throwIllegalValue } from '@votingworks/basics';
-import type {
-  Voter,
-  VoterRegistrationRequest,
-  VoterSearchParams,
-} from '@votingworks/pollbook-backend';
+import type { VoterSearchParams } from '@votingworks/pollbook-backend';
 import {
   Button,
   ButtonBar,
@@ -31,9 +27,7 @@ import {
   getDeviceStatuses,
   getIsAbsenteeMode,
   getVoter,
-  registerVoter,
 } from './api';
-import { AddVoterScreen } from './add_voter_screen';
 import { AbsenteeModeCallout, VoterName } from './shared_components';
 import { AUTOMATIC_FLOW_STATE_RESET_DELAY_MS } from './globals';
 
@@ -222,100 +216,6 @@ export function VoterCheckInScreen(): JSX.Element | null {
   }
 }
 
-type RegistrationFlowState =
-  | { step: 'register' }
-  | { step: 'printing'; registrationData: VoterRegistrationRequest }
-  | { step: 'success'; voter: Voter };
-
-function VoterRegistrationScreen(): JSX.Element {
-  const registerVoterMutation = registerVoter.useMutation();
-  const [flowState, setFlowState] = useState<RegistrationFlowState>({
-    step: 'register',
-  });
-  const [timeoutIdForFlowStateReset, setTimeoutIdForFlowStateReset] =
-    useState<ReturnType<typeof setTimeout>>();
-  const resetFlowState = useCallback(() => {
-    clearTimeout(timeoutIdForFlowStateReset);
-    setFlowState({ step: 'register' });
-  }, [timeoutIdForFlowStateReset]);
-
-  switch (flowState.step) {
-    case 'register':
-      return (
-        <AddVoterScreen
-          onSubmit={(registrationData) => {
-            setFlowState({ step: 'printing', registrationData });
-            registerVoterMutation.mutate(
-              { registrationData },
-              {
-                onSuccess: (voter) => {
-                  setFlowState({ step: 'success', voter });
-                  setTimeoutIdForFlowStateReset(
-                    setTimeout(
-                      resetFlowState,
-                      AUTOMATIC_FLOW_STATE_RESET_DELAY_MS
-                    )
-                  );
-                },
-              }
-            );
-          }}
-        />
-      );
-
-    case 'printing':
-      return (
-        <NoNavScreen>
-          <MainHeader>
-            <H1>Voter Registration</H1>
-          </MainHeader>
-          <Column style={{ justifyContent: 'center', flex: 1 }}>
-            <FullScreenMessage
-              title="Printing voter receipt…"
-              image={
-                <FullScreenIconWrapper>
-                  <Icons.Loading />
-                </FullScreenIconWrapper>
-              }
-            />
-          </Column>
-        </NoNavScreen>
-      );
-
-    case 'success':
-      return (
-        <NoNavScreen>
-          <MainHeader>
-            <H1>Voter Added</H1>
-          </MainHeader>
-          <Column style={{ justifyContent: 'center', flex: 1 }}>
-            <FullScreenMessage
-              title={null}
-              image={
-                <FullScreenIconWrapper>
-                  <Icons.Done color="primary" />
-                </FullScreenIconWrapper>
-              }
-            >
-              <H1>
-                <VoterName voter={flowState.voter} /> has been added
-              </H1>
-              <p>Give the voter their receipt.</p>
-            </FullScreenMessage>
-          </Column>
-          <ButtonBar>
-            <Button icon="X" onPress={resetFlowState}>
-              Close
-            </Button>
-          </ButtonBar>
-        </NoNavScreen>
-      );
-
-    default:
-      throwIllegalValue(flowState);
-  }
-}
-
 export function PollWorkerScreen(): JSX.Element | null {
   const getDeviceStatusesQuery = getDeviceStatuses.useQuery();
 
@@ -348,10 +248,6 @@ export function PollWorkerScreen(): JSX.Element | null {
       <Route
         path={pollWorkerRoutes.checkIn.path}
         component={VoterCheckInScreen}
-      />
-      <Route
-        path={pollWorkerRoutes.addVoter.path}
-        component={VoterRegistrationScreen}
       />
       <Redirect to={pollWorkerRoutes.checkIn.path} />
     </Switch>

--- a/apps/pollbook/frontend/src/voter_registration_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_registration_screen.tsx
@@ -1,0 +1,140 @@
+import type {
+  Voter,
+  VoterRegistrationRequest,
+} from '@votingworks/pollbook-backend';
+import { useCallback, useState } from 'react';
+import {
+  Button,
+  ButtonBar,
+  FullScreenIconWrapper,
+  FullScreenMessage,
+  H1,
+  Icons,
+  MainHeader,
+} from '@votingworks/ui';
+import { throwIllegalValue } from '@votingworks/basics';
+import { getDeviceStatuses, registerVoter } from './api';
+import { AddVoterScreen } from './add_voter_screen';
+import { AUTOMATIC_FLOW_STATE_RESET_DELAY_MS } from './globals';
+import { ElectionManagerNavScreen, NoNavScreen } from './nav_screen';
+import { Column } from './layout';
+import { VoterName } from './shared_components';
+
+type RegistrationFlowState =
+  | { step: 'register' }
+  | { step: 'printing'; registrationData: VoterRegistrationRequest }
+  | { step: 'success'; voter: Voter };
+
+export function VoterRegistrationScreen(): JSX.Element | null {
+  const registerVoterMutation = registerVoter.useMutation();
+  const getDeviceStatusesQuery = getDeviceStatuses.useQuery();
+  const [flowState, setFlowState] = useState<RegistrationFlowState>({
+    step: 'register',
+  });
+  const [timeoutIdForFlowStateReset, setTimeoutIdForFlowStateReset] =
+    useState<ReturnType<typeof setTimeout>>();
+  const resetFlowState = useCallback(() => {
+    clearTimeout(timeoutIdForFlowStateReset);
+    setFlowState({ step: 'register' });
+  }, [timeoutIdForFlowStateReset]);
+
+  if (!getDeviceStatusesQuery.isSuccess) {
+    return null;
+  }
+
+  const { printer } = getDeviceStatusesQuery.data;
+  if (!printer.connected) {
+    return (
+      <ElectionManagerNavScreen>
+        <Column style={{ justifyContent: 'center', flex: 1 }}>
+          <FullScreenMessage
+            image={
+              <FullScreenIconWrapper>
+                <Icons.Danger />
+              </FullScreenIconWrapper>
+            }
+            title="No Printer Detected"
+          >
+            <p>Connect printer to continue.</p>
+          </FullScreenMessage>
+        </Column>
+      </ElectionManagerNavScreen>
+    );
+  }
+
+  switch (flowState.step) {
+    case 'register':
+      return (
+        <AddVoterScreen
+          onSubmit={(registrationData) => {
+            setFlowState({ step: 'printing', registrationData });
+            registerVoterMutation.mutate(
+              { registrationData },
+              {
+                onSuccess: (voter) => {
+                  setFlowState({ step: 'success', voter });
+                  setTimeoutIdForFlowStateReset(
+                    setTimeout(
+                      resetFlowState,
+                      AUTOMATIC_FLOW_STATE_RESET_DELAY_MS
+                    )
+                  );
+                },
+              }
+            );
+          }}
+        />
+      );
+
+    case 'printing':
+      return (
+        <NoNavScreen>
+          <MainHeader>
+            <H1>Voter Registration</H1>
+          </MainHeader>
+          <Column style={{ justifyContent: 'center', flex: 1 }}>
+            <FullScreenMessage
+              title="Printing voter receipt…"
+              image={
+                <FullScreenIconWrapper>
+                  <Icons.Loading />
+                </FullScreenIconWrapper>
+              }
+            />
+          </Column>
+        </NoNavScreen>
+      );
+
+    case 'success':
+      return (
+        <NoNavScreen>
+          <MainHeader>
+            <H1>Voter Added</H1>
+          </MainHeader>
+          <Column style={{ justifyContent: 'center', flex: 1 }}>
+            <FullScreenMessage
+              title={null}
+              image={
+                <FullScreenIconWrapper>
+                  <Icons.Done color="primary" />
+                </FullScreenIconWrapper>
+              }
+            >
+              <H1>
+                <VoterName voter={flowState.voter} /> has been added
+              </H1>
+              <p>Give the voter their receipt.</p>
+            </FullScreenMessage>
+          </Column>
+          <ButtonBar>
+            <Button icon="X" onPress={resetFlowState}>
+              Close
+            </Button>
+          </ButtonBar>
+        </NoNavScreen>
+      );
+
+    default:
+      throwIllegalValue(flowState);
+  }
+}

--- a/apps/pollbook/frontend/vitest.config.ts
+++ b/apps/pollbook/frontend/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: 84,
-        branches: 70,
+        branches: 71,
       },
       exclude: [
         'src/**/*.d.ts',


### PR DESCRIPTION
## Overview

Moves new registration flow to election manager page instead of poll worker.

## Demo Video or Screenshot
![Screenshot 2025-05-07 at 5 41 31 PM](https://github.com/user-attachments/assets/e1589116-8718-41e7-9fe8-803d8bcfba58)


https://github.com/user-attachments/assets/3cd37f19-20c0-4e8d-a617-892fddfe59a6

Poll worker screen now has a nav with only 1 item in it. I think this is ok for now if we plan to add more poll worker functionality later. We can also remove it if we have no plans for that.

![Screenshot 2025-05-07 at 5 42 35 PM](https://github.com/user-attachments/assets/320ffd06-ab28-46ec-ba1d-4c6aa5165ab3)


## Testing Plan

Updated e2e frontend test 

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
