### PR TITLE
Address flaky test by explicitly advancing time

### DIFF
--- a/apps/scan/backend/src/app_export.test.ts
+++ b/apps/scan/backend/src/app_export.test.ts
@@ -25,6 +25,7 @@ vi.mock(import('@votingworks/utils'), async (importActual) => ({
 }));
 
 beforeEach(() => {
+  vi.useRealTimers();
   mockFeatureFlagger.resetFeatureFlags();
   mockFeatureFlagger.enableFeatureFlag(
     BooleanEnvironmentVariableName.SKIP_ELECTION_PACKAGE_AUTHENTICATION
@@ -114,6 +115,7 @@ test('continuous CVR export, including polls closing', async () => {
 });
 
 test('continuous CVR export, including polls closing, followed by a full export', async () => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
   await withApp(
     async ({
       apiClient,
@@ -139,6 +141,10 @@ test('continuous CVR export, including polls closing, followed by a full export'
       });
 
       await apiClient.closePolls();
+
+      // Ensure that the second export has a different timestamp than the first in its directory
+      // name
+      vi.advanceTimersByTime(1000);
 
       expect(
         await apiClient.exportCastVoteRecordsToUsbDrive({ mode: 'full_export' })


### PR DESCRIPTION
## Overview

This test sporadically fails when run locally (hasn't failed in CI yet as far as I can tell, but it's conceptually possible for it to fail there, too). Addressed by explicitly advancing time to ensure that we get two CVR export directories with unique directory names, e.g., `TEST__machine_0000__2025-05-07_10-15-51` and `TEST__machine_0000__2025-05-07_10-15-52`

```
FAIL  src/app_export.test.ts > continuous CVR export, including polls closing, followed by a full export
AssertionError: expected [ Array(1) ] to have a length of 2 but got 1

- Expected
+ Received

- 2
+ 1

 ❯ src/app_export.test.ts:165:36
    163|       }
    164|       console.log(exportDirectoryPaths);
    165|       expect(exportDirectoryPaths).toHaveLength(2);
       |                                    ^
    166|
    167|       for (const exportDirectoryPath of exportDirectoryPaths) {
 ❯ Module.withApp test/helpers/pdi_helpers.ts:198:5
 ❯ src/app_export.test.ts:119:3
```

## Testing

Ran locally a handful of times without repro and verified through logging that the explicit timer advancement is working