### PR TITLE
[VxMark] Read out write-in candidate names just are they were typed

### DIFF
--- a/apps/mark-scan/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_write_in.test.tsx
@@ -128,8 +128,9 @@ test('Single Seat Contest with Write In', async () => {
 
   // Review Screen
   await screen.findByText('Review Your Votes');
-  expect(screen.getByText('SAL')).toBeTruthy();
-  expect(screen.getByText(/\(write-in\)/)).toBeTruthy();
+  // Expect one instance rendered for display and one for audio:
+  expect(screen.getAllByText('SAL')).toHaveLength(2);
+  screen.getByText(/\(write-in\)/);
 
   // Print Screen
   apiMock.expectPrintBallot({

--- a/apps/mark/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark/frontend/src/app_contest_write_in.test.tsx
@@ -131,8 +131,9 @@ test('Single Seat Contest with Write In', async () => {
 
   // Review Screen
   await screen.findByText('Review Your Votes');
-  expect(screen.getByText('SAL')).toBeTruthy();
-  expect(screen.getByText(/\(write-in\)/)).toBeTruthy();
+  // Expect one instance rendered for display and one for audio:
+  expect(screen.getAllByText('SAL')).toHaveLength(2);
+  screen.getByText(/\(write-in\)/);
 
   // Print Screen
   apiMock.expectPrintBallot({

--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -40,6 +40,7 @@ import { UpdateVoteFunction } from '../config/types';
 import { WRITE_IN_CANDIDATE_MAX_LENGTH } from '../config/globals';
 import { ChoicesGrid } from './contest_screen_layout';
 import { BreadcrumbMetadata, ContestHeader } from './contest_header';
+import { WriteInCandidateName } from './write_in_candidate_name';
 
 interface Props {
   breadcrumbs?: BreadcrumbMetadata;
@@ -356,7 +357,7 @@ export function CandidateContest({
                       <React.Fragment>
                         <AudioOnly>
                           {appStrings.labelSelected()}
-                          {appStrings.labelWriteInCandidateName()}
+                          <WriteInCandidateName name={candidate.name} />
                         </AudioOnly>
                         {/* User-generated content - no translation/audio available: */}
                         {candidate.name}

--- a/libs/mark-flow-ui/src/components/review.test.tsx
+++ b/libs/mark-flow-ui/src/components/review.test.tsx
@@ -10,6 +10,9 @@ import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { screen, within, render } from '../../test/react_testing_library';
 import { mergeMsEitherNeitherContests } from '../utils/ms_either_neither_contests';
 import { Review } from './review';
+import { WriteInCandidateName } from './write_in_candidate_name';
+
+vi.mock('./write_in_candidate_name');
 
 const electionGeneral = readElectionGeneral();
 const electionWithMsEitherNeither = readElectionWithMsEitherNeither();
@@ -113,6 +116,37 @@ test('candidate contest fully voted', () => {
     />
   );
   expect(screen.queryByText(/You may still vote/)).not.toBeInTheDocument();
+});
+
+test('candidate contest - write-in', () => {
+  vi.mocked(WriteInCandidateName).mockImplementation((p) => (
+    <span data-testid="MockWriteInAudio">{p.name}</span>
+  ));
+
+  const contest = find(
+    electionGeneral.contests,
+    (c): c is CandidateContest => c.type === 'candidate' && c.seats === 1
+  );
+  const contests = [contest];
+  render(
+    <Review
+      election={electionGeneral}
+      contests={contests}
+      precinctId={electionGeneral.precincts[0].id}
+      votes={{
+        [contest.id]: [
+          {
+            id: 'write-in-foo',
+            name: 'HON. FOO',
+            isWriteIn: true,
+          },
+        ],
+      }}
+      returnToContest={vi.fn()}
+    />
+  );
+
+  expect(screen.getByTestId('MockWriteInAudio')).toHaveTextContent('HON. FOO');
 });
 
 describe('yesno contest', () => {

--- a/libs/mark-flow-ui/src/components/review.tsx
+++ b/libs/mark-flow-ui/src/components/review.tsx
@@ -23,6 +23,7 @@ import {
   NumberString,
   WithAltAudio,
   AssistiveTechInstructions,
+  AudioOnly,
 } from '@votingworks/ui';
 
 import { getSingleYesNoVote } from '@votingworks/utils';
@@ -33,6 +34,7 @@ import {
 } from '../config/types';
 
 import { ContestsWithMsEitherNeither } from '../utils/ms_either_neither_contests';
+import { WriteInCandidateName } from './write_in_candidate_name';
 
 const Contest = styled.div`
   display: block;
@@ -91,7 +93,16 @@ function CandidateContestResult({
             />
           ),
           id: candidate.id,
-          label: electionStrings.candidateName(candidate),
+          label: candidate.isWriteIn ? (
+            <React.Fragment>
+              <AudioOnly>
+                <WriteInCandidateName name={candidate.name} />
+              </AudioOnly>
+              {candidate.name}
+            </React.Fragment>
+          ) : (
+            electionStrings.candidateName(candidate)
+          ),
         })
       )}
     />

--- a/libs/mark-flow-ui/src/components/write_in_candidate_name.test.tsx
+++ b/libs/mark-flow-ui/src/components/write_in_candidate_name.test.tsx
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest';
+import { render, screen } from '../../test/react_testing_library';
+import { WriteInCandidateName } from './write_in_candidate_name';
+
+test('renders all valid virtual keyboard letters without error', () => {
+  render(<WriteInCandidateName name={`ABCDEFGHIJKLMNOPQRSTUVWXYZ . - ' " `} />);
+});
+
+test('renders individual letters for audio readout', () => {
+  render(<WriteInCandidateName name="HON. FOO" />);
+  screen.getByText('H');
+  expect(screen.getAllByText('O')).toHaveLength(3);
+  screen.getByText('N');
+  screen.getByText('.');
+  screen.getByText('F');
+
+  // Contrary to the regular letters, the 'space' display text is rendered as a
+  // separate element, so we expect to find 2 instances of it here:
+  expect(screen.getAllByText('space')).toHaveLength(2);
+});

--- a/libs/mark-flow-ui/src/components/write_in_candidate_name.tsx
+++ b/libs/mark-flow-ui/src/components/write_in_candidate_name.tsx
@@ -1,0 +1,46 @@
+import { assertDefined } from '@votingworks/basics';
+import {
+  SPACE_BAR_KEY,
+  US_ENGLISH_KEYMAP,
+  virtualKeyboardCommon,
+  VirtualKeyboardLabel,
+} from '@votingworks/ui';
+import React from 'react';
+
+interface WriteInCandidateNameProps {
+  name: string;
+}
+
+export const LETTER_KEYS: { [char: string]: virtualKeyboardCommon.Key } =
+  (() => {
+    const keys = US_ENGLISH_KEYMAP.rows.flatMap((row) =>
+      row.map((key) => [key.value, key])
+    );
+
+    keys.push([SPACE_BAR_KEY.value, SPACE_BAR_KEY]);
+
+    return Object.fromEntries(keys);
+  })();
+
+/**
+ * Renders a screen-reader comptible series of letters representing the given
+ * write-in candidate name.
+ */
+export function WriteInCandidateName(
+  props: WriteInCandidateNameProps
+): JSX.Element {
+  const { name } = props;
+
+  const letters: React.ReactNode[] = [];
+  for (let i = 0; i < name.length; i += 1) {
+    const char = name[i];
+    letters.push(
+      <VirtualKeyboardLabel
+        config={assertDefined(LETTER_KEYS[char])}
+        key={`${i}-${char}`}
+      />
+    );
+  }
+
+  return <span>{letters}</span>;
+}

--- a/libs/mark-flow-ui/src/components/write_in_candidate_name.tsx
+++ b/libs/mark-flow-ui/src/components/write_in_candidate_name.tsx
@@ -23,7 +23,7 @@ export const LETTER_KEYS: { [char: string]: virtualKeyboardCommon.Key } =
   })();
 
 /**
- * Renders a screen-reader comptible series of letters representing the given
+ * Renders a screen-reader-compatible series of letters representing the given
  * write-in candidate name.
  */
 export function WriteInCandidateName(

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file - @preserve */
 
 export * as images from './images';
+export * as virtualKeyboardCommon from './virtual_keyboard/common';
 
 export * from './accessible_controllers';
 export * from './app_base';

--- a/libs/ui/src/ui_strings/play_audio_clips.tsx
+++ b/libs/ui/src/ui_strings/play_audio_clips.tsx
@@ -124,5 +124,13 @@ export function PlayAudioClips(props: PlayAudioQueueProps): React.ReactNode {
     return null;
   }
 
-  return <PlayAudioClip {...currentClip} onDone={onClipDone} />;
+  return (
+    <PlayAudioClip
+      {...currentClip}
+      // Ensure that a remount (and, by extension, a replay) is triggered for
+      // repeated audio (e.g. repeated characters in a write-in candidate name).
+      key={clipIndex}
+      onDone={onClipDone}
+    />
+  );
 }

--- a/libs/ui/src/virtual_keyboard/virtual_keyboard.tsx
+++ b/libs/ui/src/virtual_keyboard/virtual_keyboard.tsx
@@ -332,6 +332,27 @@ function getNextRowTargetButtonIndex(
   return getAdjacentRowTargetButtonIndex(keyMap, rowRefs, focusedRowIndex, 1);
 }
 
+export function VirtualKeyboardLabel(props: { config: Key }): JSX.Element {
+  const { config } = props;
+  const {
+    audioLanguageOverride,
+    renderAudioString,
+    value,
+    renderLabel = () => value,
+  } = config;
+
+  const button = (
+    <WithAltAudio
+      audioLanguageOverride={audioLanguageOverride}
+      audioText={renderAudioString()}
+    >
+      {renderLabel()}
+    </WithAltAudio>
+  );
+
+  return button;
+}
+
 export function VirtualKeyboard({
   onBackspace,
   onKeyPress,
@@ -438,12 +459,7 @@ export function VirtualKeyboard({
   }
 
   function renderKey(key: Key) {
-    const {
-      audioLanguageOverride,
-      renderAudioString,
-      value,
-      renderLabel = () => value,
-    } = key;
+    const { value } = key;
     const buttonProps: ButtonProps<string> = {
       value,
       onPress: onKeyPress,
@@ -470,12 +486,7 @@ export function VirtualKeyboard({
 
     const button = (
       <Button key={value} {...buttonProps}>
-        <WithAltAudio
-          audioLanguageOverride={audioLanguageOverride}
-          audioText={renderAudioString()}
-        >
-          {renderLabel()}
-        </WithAltAudio>
+        <VirtualKeyboardLabel config={key} />
       </Button>
     );
 


### PR DESCRIPTION
## Overview

Resolves https://github.com/votingworks/vxsuite/issues/6328

Updating the candidate contest and review screens to read out write-in candidate names as the same series of letters that were typed out on the write-in keyboard (we would previously read out "write-in" instead).

### TODO
- Noticing how weird it sounds for the screen reader to say "single quote" - will follow up with a PR to update that to say "apostrophe" instead.

## Demo Video or Screenshot [ 🔊 ]

https://github.com/user-attachments/assets/15a8bbcc-44e3-452b-ba5a-01f5e302b211

https://github.com/user-attachments/assets/4f29f962-8ee4-43b5-ba2c-899f607ad84e

## Testing Plan
- Mostly manual for verifying audio - with basic unit tests to make sure expected, valid characters render successfully as individual letters.

## Checklist

<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
