### PR TITLE
central-scan/backend: Don't mount deprecated API endpoints at root

### DIFF
--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -363,7 +363,7 @@ export function buildCentralScannerApp({
   deprecatedApiRouter.use(express.urlencoded({ extended: false }));
 
   deprecatedApiRouter.get(
-    '/central-scanner/scan/hmpb/ballot/:sheetId/:side/image',
+    '/scan/hmpb/ballot/:sheetId/:side/image',
     (request, response) => {
       const { sheetId, side } = request.params;
 
@@ -385,7 +385,7 @@ export function buildCentralScannerApp({
   );
 
   deprecatedApiRouter.get<NoParams, Scan.GetNextReviewSheetResponse>(
-    '/central-scanner/scan/hmpb/review/next-sheet',
+    '/scan/hmpb/review/next-sheet',
     (_request, response) => {
       const sheet = store.getNextAdjudicationSheet();
 
@@ -431,7 +431,7 @@ export function buildCentralScannerApp({
     }
   );
 
-  app.use(deprecatedApiRouter);
+  app.use('/central-scanner', deprecatedApiRouter);
 
   return app;
 }


### PR DESCRIPTION


## Overview

The JSON parser was interfering with the grout API, since the deprecated API endpoints were mounted first at the app root. To fix this, we mount the deprecated API router at `/central-scan` so that its middleware is scoped only to those endpoints.
## Demo Video or Screenshot
N/A
## Testing Plan
Manually tested that I can run the app locally and the dev dock works
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
