### PR TITLE
Implement Pollbook Package Hash

### DIFF
--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -34,7 +34,6 @@ import {
   ConfigurationStatus,
   ValidStreetInfo,
   VoterRegistrationRequest,
-  MachineConfig,
   VoterAddressChangeRequest,
   SummaryStatistics,
   ThroughputStat,
@@ -43,6 +42,7 @@ import {
   LocalAppContext,
   LocalWorkspace,
   ConfigurationError,
+  MachineInformation,
 } from './types';
 import { rootDebug } from './debug';
 import {
@@ -90,8 +90,16 @@ function buildApi({ context, logger }: BuildAppParams) {
   const { store } = workspace;
 
   return grout.createApi({
-    getMachineConfig(): MachineConfig {
+    getMachineInformation(): MachineInformation {
+      const pollbookInformation = store.getMachineInformation();
+      if (!pollbookInformation) {
+        return {
+          machineId,
+          codeVersion,
+        };
+      }
       return {
+        ...pollbookInformation,
         machineId,
         codeVersion,
       };

--- a/apps/pollbook/backend/src/app_config.test.ts
+++ b/apps/pollbook/backend/src/app_config.test.ts
@@ -41,7 +41,7 @@ test('uses machine config from env', async () => {
   };
 
   await withApp(async ({ localApiClient }) => {
-    expect(await localApiClient.getMachineConfig()).toEqual({
+    expect(await localApiClient.getMachineInformation()).toEqual({
       machineId: 'test-machine-id',
       codeVersion: 'test-code-version',
     });

--- a/apps/pollbook/backend/src/networking.ts
+++ b/apps/pollbook/backend/src/networking.ts
@@ -70,7 +70,7 @@ export function fetchEventsFromConnectedPollbooks({
         }
 
         const previouslyConnected = workspace.store.getPollbookServicesByName();
-        const election = workspace.store.getElection();
+        const myMachineInformation = workspace.store.getMachineInformation();
 
         // Maintain a queue of pollbooks to visit, refill and shuffle when empty
         const pollbookNames = Object.keys(previouslyConnected).filter(
@@ -102,8 +102,11 @@ export function fetchEventsFromConnectedPollbooks({
               return;
             }
             if (
-              !election ||
-              currentPollbookService.electionId !== election.id
+              !myMachineInformation?.electionBallotHash ||
+              myMachineInformation.electionBallotHash !==
+                currentPollbookService.electionBallotHash ||
+              myMachineInformation.pollbookPackageHash !==
+                currentPollbookService.pollbookPackageHash
             ) {
               workspace.store.setPollbookServiceForName(currentName, {
                 ...currentPollbookService,
@@ -184,7 +187,7 @@ export async function setupMachineNetworking({
           return;
         }
 
-        const currentElection = workspace.store.getElection();
+        const myMachineInformation = workspace.store.getMachineInformation();
         const services = await AvahiService.discoverHttpServices();
         if (!services.length) {
           debug('No services found on the network');
@@ -247,8 +250,11 @@ export async function setupMachineNetworking({
               continue;
             }
             if (
-              !currentElection ||
-              currentElection.id !== machineInformation.electionId
+              !myMachineInformation?.electionBallotHash ||
+              myMachineInformation.electionBallotHash !==
+                machineInformation.electionBallotHash ||
+              myMachineInformation.pollbookPackageHash !==
+                machineInformation.pollbookPackageHash
             ) {
               // Only connect if the two machines are configured for the same election.
               workspace.store.setPollbookServiceForName(name, {

--- a/apps/pollbook/backend/src/peer_app.ts
+++ b/apps/pollbook/backend/src/peer_app.ts
@@ -16,7 +16,7 @@ import { pollNetworkForPollbookPackage } from './pollbook_package';
 import { POLLBOOK_PACKAGE_ASSET_FILE_NAME } from './globals';
 
 function buildApi(context: PeerAppContext) {
-  const { workspace, machineId } = context;
+  const { workspace, machineId, codeVersion } = context;
   const { store } = workspace;
 
   return grout.createApi({
@@ -24,11 +24,13 @@ function buildApi(context: PeerAppContext) {
       const pollbookInformation = store.getMachineInformation();
       if (!pollbookInformation) {
         return {
+          codeVersion,
           machineId,
         };
       }
       return {
         ...pollbookInformation,
+        codeVersion,
         machineId,
       };
     },

--- a/apps/pollbook/backend/src/types.ts
+++ b/apps/pollbook/backend/src/types.ts
@@ -227,6 +227,7 @@ export const VoterSchema: z.ZodSchema<Voter> = z.object({
 
 export interface MachineInformation extends PollbookInformation {
   machineId: string;
+  codeVersion: string;
 }
 
 export type VectorClock = Record<string, number>;

--- a/apps/pollbook/frontend/src/api.ts
+++ b/apps/pollbook/frontend/src/api.ts
@@ -54,13 +54,15 @@ export function createQueryClient(): QueryClient {
   });
 }
 
-export const getMachineConfig = {
+export const getMachineInformation = {
   queryKey(): QueryKey {
-    return ['getMachineConfig'];
+    return ['getMachineInformation'];
   },
   useQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getMachineConfig());
+    return useQuery(this.queryKey(), () => apiClient.getMachineInformation(), {
+      refetchInterval: 1000,
+    });
   },
 } as const;
 

--- a/apps/pollbook/frontend/src/app.test.tsx
+++ b/apps/pollbook/frontend/src/app.test.tsx
@@ -167,12 +167,11 @@ test('renders VendorScreen when logged in as vendor', async () => {
 });
 
 test('election manager - unconfigured screen - loading', async () => {
-  apiMock.expectGetMachineConfig();
   apiMock.expectGetDeviceStatuses();
   apiMock.setAuthStatus({
     status: 'logged_in',
     user: mockElectionManagerUser({
-      electionKey: constructElectionKey(famousNamesElection),
+      electionKey: constructElectionKey(famousNamesElection.election),
     }),
     sessionExpiresAt: mockSessionExpiresAt(),
   });
@@ -182,12 +181,11 @@ test('election manager - unconfigured screen - loading', async () => {
 });
 
 test('election manager - unconfigured screen - recently unconfigured', async () => {
-  apiMock.expectGetMachineConfig();
   apiMock.expectGetDeviceStatuses();
   apiMock.setAuthStatus({
     status: 'logged_in',
     user: mockElectionManagerUser({
-      electionKey: constructElectionKey(famousNamesElection),
+      electionKey: constructElectionKey(famousNamesElection.election),
     }),
     sessionExpiresAt: mockSessionExpiresAt(),
   });
@@ -197,12 +195,11 @@ test('election manager - unconfigured screen - recently unconfigured', async () 
 });
 
 test('election manager - unconfigured screen - network configuration error', async () => {
-  apiMock.expectGetMachineConfig();
   apiMock.expectGetDeviceStatuses();
   apiMock.setAuthStatus({
     status: 'logged_in',
     user: mockElectionManagerUser({
-      electionKey: constructElectionKey(famousNamesElection),
+      electionKey: constructElectionKey(famousNamesElection.election),
     }),
     sessionExpiresAt: mockSessionExpiresAt(),
   });
@@ -213,11 +210,10 @@ test('election manager - unconfigured screen - network configuration error', asy
 
 test('election manager - unconfigured screen - network-conflicting-pollbook-packages-match-card', async () => {
   apiMock.expectGetDeviceStatuses();
-  apiMock.expectGetMachineConfig();
   apiMock.setAuthStatus({
     status: 'logged_in',
     user: mockElectionManagerUser({
-      electionKey: constructElectionKey(famousNamesElection),
+      electionKey: constructElectionKey(famousNamesElection.election),
     }),
     sessionExpiresAt: mockSessionExpiresAt(),
   });
@@ -231,11 +227,10 @@ test('election manager - unconfigured screen - network-conflicting-pollbook-pack
 
 test('election manager - unconfigured screen - not-found-configuration-matching-election-card', async () => {
   apiMock.expectGetDeviceStatuses();
-  apiMock.expectGetMachineConfig();
   apiMock.setAuthStatus({
     status: 'logged_in',
     user: mockElectionManagerUser({
-      electionKey: constructElectionKey(famousNamesElection),
+      electionKey: constructElectionKey(famousNamesElection.election),
     }),
     sessionExpiresAt: mockSessionExpiresAt(),
   });
@@ -248,12 +243,11 @@ test('election manager - unconfigured screen - not-found-configuration-matching-
 });
 
 test('election manager - unconfigured screen - not-found-network', async () => {
-  apiMock.expectGetMachineConfig();
   apiMock.expectGetDeviceStatuses();
   apiMock.setAuthStatus({
     status: 'logged_in',
     user: mockElectionManagerUser({
-      electionKey: constructElectionKey(famousNamesElection),
+      electionKey: constructElectionKey(famousNamesElection.election),
     }),
     sessionExpiresAt: mockSessionExpiresAt(),
   });

--- a/apps/pollbook/frontend/src/app_election_manager_screen.test.tsx
+++ b/apps/pollbook/frontend/src/app_election_manager_screen.test.tsx
@@ -4,7 +4,7 @@ import {
   ValidStreetInfo,
   VoterRegistrationRequest,
 } from '@votingworks/pollbook-backend';
-import { Election } from '@votingworks/types';
+import { Election, ElectionDefinition } from '@votingworks/types';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 
 import userEvent from '@testing-library/user-event';
@@ -21,6 +21,8 @@ import { DEFAULT_QUERY_REFETCH_INTERVAL } from './api';
 let apiMock: ApiMock;
 const famousNamesElection: Election =
   electionFamousNames2021Fixtures.readElection();
+const famousNamesElectionDef: ElectionDefinition =
+  electionFamousNames2021Fixtures.readElectionDefinition();
 
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -64,10 +66,9 @@ test('basic e2e registration flow works', async () => {
     middleName: '',
   };
 
-  apiMock.expectGetMachineConfig();
   apiMock.expectGetDeviceStatuses();
   apiMock.authenticateAsElectionManager(famousNamesElection);
-  apiMock.setElection(famousNamesElection);
+  apiMock.setElection(famousNamesElectionDef);
   const { unmount } = render(<App apiClient={apiMock.mockApiClient} />);
 
   apiMock.expectGetValidStreetInfo([validStreetInfo]);

--- a/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
+++ b/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
@@ -1,7 +1,11 @@
 import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { Election } from '@votingworks/types';
+import { Election, ElectionDefinition } from '@votingworks/types';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import type {
+  ValidStreetInfo,
+  VoterRegistrationRequest,
+} from '@votingworks/pollbook-backend';
 import { act, render, screen, within } from '../test/react_testing_library';
 import { App } from './app';
 import {
@@ -14,6 +18,8 @@ import { AUTOMATIC_FLOW_STATE_RESET_DELAY_MS } from './globals';
 let apiMock: ApiMock;
 const famousNamesElection: Election =
   electionFamousNames2021Fixtures.readElection();
+const famousNamesElectionDefinition: ElectionDefinition =
+  electionFamousNames2021Fixtures.readElectionDefinition();
 
 describe('PollWorkerScreen', () => {
   beforeEach(() => {
@@ -28,10 +34,9 @@ describe('PollWorkerScreen', () => {
   });
 
   test('basic e2e check in flow works', async () => {
-    apiMock.expectGetMachineConfig();
     apiMock.expectGetDeviceStatuses();
     apiMock.authenticateAsPollWorker(famousNamesElection);
-    apiMock.setElection(famousNamesElection);
+    apiMock.setElection(famousNamesElectionDefinition);
     const { unmount } = render(<App apiClient={apiMock.mockApiClient} />);
     await screen.findByText('Connect printer to continue.');
 
@@ -84,6 +89,76 @@ describe('PollWorkerScreen', () => {
       vi.advanceTimersByTime(AUTOMATIC_FLOW_STATE_RESET_DELAY_MS);
     });
     expect(screen.queryByText('Voter Checked In')).toBeNull();
+
+    unmount();
+  });
+
+  test('basic e2e registration flow works', async () => {
+    const validStreetInfo: ValidStreetInfo = {
+      streetName: 'Main St',
+      side: 'even',
+      lowRange: 1000,
+      highRange: 2000,
+      postalCity: 'CITYVILLE',
+      zip5: '12345',
+      zip4: '6789',
+      district: 'District',
+    };
+    const voter = createMockVoter('123', 'Abigail', 'Adams');
+    const registrationData: VoterRegistrationRequest = {
+      streetNumber: '1000',
+      streetName: 'MAIN ST',
+      city: 'CITYVILLE',
+      state: 'NH',
+      zipCode: '12345',
+      lastName: voter.lastName.toUpperCase(),
+      firstName: voter.firstName.toUpperCase(),
+      party: 'REP',
+      streetSuffix: '',
+      apartmentUnitNumber: '',
+      houseFractionNumber: '',
+      addressLine2: '',
+      addressLine3: '',
+      suffix: '',
+      middleName: '',
+    };
+
+    apiMock.expectGetDeviceStatuses();
+    apiMock.authenticateAsPollWorker(famousNamesElection);
+    apiMock.setElection(famousNamesElectionDefinition);
+    const { unmount } = render(<App apiClient={apiMock.mockApiClient} />);
+    await screen.findByText('Connect printer to continue.');
+
+    apiMock.setPrinterStatus(true);
+    apiMock.expectGetValidStreetInfo([validStreetInfo]);
+    await screen.findByText('Check-In');
+    await screen.findByText('Registration');
+
+    await screen.findByText('Check-In');
+    const registrationTab = await screen.findByRole('button', {
+      name: 'Registration',
+    });
+    userEvent.click(registrationTab);
+
+    const lastNameInput = await screen.findByLabelText('Last Name');
+    userEvent.type(lastNameInput, voter.lastName);
+    const firstNameInput = screen.getByLabelText('First Name');
+    userEvent.type(firstNameInput, voter.firstName);
+    userEvent.type(screen.getByLabelText('Street Number'), '1000');
+    userEvent.click(screen.getByLabelText('Street Name'));
+    userEvent.keyboard('[Enter]');
+    userEvent.click(screen.getByLabelText('Party Affiliation'));
+    userEvent.keyboard('[Enter]');
+
+    apiMock.expectRegisterVoter(registrationData, voter);
+
+    userEvent.click(screen.getByRole('button', { name: 'Add Voter' }));
+
+    await screen.findByText('Give the voter their receipt.');
+    act(() => {
+      vi.advanceTimersByTime(AUTOMATIC_FLOW_STATE_RESET_DELAY_MS);
+    });
+    expect(screen.queryByText('Give the voter their receipt.')).toBeNull();
 
     unmount();
   });

--- a/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
+++ b/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
@@ -2,10 +2,6 @@ import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { Election, ElectionDefinition } from '@votingworks/types';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
-import type {
-  ValidStreetInfo,
-  VoterRegistrationRequest,
-} from '@votingworks/pollbook-backend';
 import { act, render, screen, within } from '../test/react_testing_library';
 import { App } from './app';
 import {
@@ -89,76 +85,6 @@ describe('PollWorkerScreen', () => {
       vi.advanceTimersByTime(AUTOMATIC_FLOW_STATE_RESET_DELAY_MS);
     });
     expect(screen.queryByText('Voter Checked In')).toBeNull();
-
-    unmount();
-  });
-
-  test('basic e2e registration flow works', async () => {
-    const validStreetInfo: ValidStreetInfo = {
-      streetName: 'Main St',
-      side: 'even',
-      lowRange: 1000,
-      highRange: 2000,
-      postalCity: 'CITYVILLE',
-      zip5: '12345',
-      zip4: '6789',
-      district: 'District',
-    };
-    const voter = createMockVoter('123', 'Abigail', 'Adams');
-    const registrationData: VoterRegistrationRequest = {
-      streetNumber: '1000',
-      streetName: 'MAIN ST',
-      city: 'CITYVILLE',
-      state: 'NH',
-      zipCode: '12345',
-      lastName: voter.lastName.toUpperCase(),
-      firstName: voter.firstName.toUpperCase(),
-      party: 'REP',
-      streetSuffix: '',
-      apartmentUnitNumber: '',
-      houseFractionNumber: '',
-      addressLine2: '',
-      addressLine3: '',
-      suffix: '',
-      middleName: '',
-    };
-
-    apiMock.expectGetDeviceStatuses();
-    apiMock.authenticateAsPollWorker(famousNamesElection);
-    apiMock.setElection(famousNamesElectionDefinition);
-    const { unmount } = render(<App apiClient={apiMock.mockApiClient} />);
-    await screen.findByText('Connect printer to continue.');
-
-    apiMock.setPrinterStatus(true);
-    apiMock.expectGetValidStreetInfo([validStreetInfo]);
-    await screen.findByText('Check-In');
-    await screen.findByText('Registration');
-
-    await screen.findByText('Check-In');
-    const registrationTab = await screen.findByRole('button', {
-      name: 'Registration',
-    });
-    userEvent.click(registrationTab);
-
-    const lastNameInput = await screen.findByLabelText('Last Name');
-    userEvent.type(lastNameInput, voter.lastName);
-    const firstNameInput = screen.getByLabelText('First Name');
-    userEvent.type(firstNameInput, voter.firstName);
-    userEvent.type(screen.getByLabelText('Street Number'), '1000');
-    userEvent.click(screen.getByLabelText('Street Name'));
-    userEvent.keyboard('[Enter]');
-    userEvent.click(screen.getByLabelText('Party Affiliation'));
-    userEvent.keyboard('[Enter]');
-
-    apiMock.expectRegisterVoter(registrationData, voter);
-
-    userEvent.click(screen.getByRole('button', { name: 'Add Voter' }));
-
-    await screen.findByText('Give the voter their receipt.');
-    act(() => {
-      vi.advanceTimersByTime(AUTOMATIC_FLOW_STATE_RESET_DELAY_MS);
-    });
-    expect(screen.queryByText('Give the voter their receipt.')).toBeNull();
 
     unmount();
   });

--- a/apps/pollbook/frontend/src/election_info_bar.tsx
+++ b/apps/pollbook/frontend/src/election_info_bar.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { Caption, Font, LabelledText, DateString, Seal } from '@votingworks/ui';
-import type { Election } from '@votingworks/types';
+import { formatElectionHashes, type Election } from '@votingworks/types';
 
 const Bar = styled.div<{ inverse?: boolean }>`
   background: ${(p) => p.inverse && p.theme.colors.inverseBackground};
@@ -33,12 +33,16 @@ const SystemInfoContainer = styled.div`
 
 export interface ElectionInfoBarProps {
   election?: Election;
+  electionBallotHash?: string;
+  pollbookPackageHash?: string;
   codeVersion?: string;
   machineId?: string;
   inverse?: boolean;
 }
 export function ElectionInfoBar({
   election,
+  electionBallotHash,
+  pollbookPackageHash,
   codeVersion,
   machineId,
   inverse,
@@ -59,7 +63,7 @@ export function ElectionInfoBar({
     </Caption>
   ) : null;
 
-  if (!election) {
+  if (!election || !electionBallotHash || !pollbookPackageHash) {
     return (
       <Bar data-testid="electionInfoBar" inverse={inverse}>
         <SystemInfoContainer>
@@ -92,7 +96,9 @@ export function ElectionInfoBar({
   const electionIdInfo = (
     <Caption>
       <LabelledText label="Election ID">
-        <Font weight="bold">{election.id}</Font>
+        <Font weight="bold">
+          {formatElectionHashes(electionBallotHash, pollbookPackageHash)}
+        </Font>
       </LabelledText>
     </Caption>
   );
@@ -122,11 +128,13 @@ const VerticalBar = styled.div<{ inverse?: boolean }>`
 
 export function VerticalElectionInfoBar({
   election,
+  electionBallotHash,
+  pollbookPackageHash,
   codeVersion,
   machineId,
   inverse,
 }: ElectionInfoBarProps): JSX.Element {
-  if (!election) {
+  if (!election || !electionBallotHash || !pollbookPackageHash) {
     return (
       <VerticalBar inverse={inverse}>
         <Caption>
@@ -180,7 +188,10 @@ export function VerticalElectionInfoBar({
         )}
 
         <div>
-          Election ID: <Font weight="semiBold">{election.id}</Font>
+          Election ID:{' '}
+          <Font weight="semiBold">
+            {formatElectionHashes(electionBallotHash, pollbookPackageHash)}
+          </Font>
         </div>
       </Caption>
     </VerticalBar>

--- a/apps/pollbook/frontend/src/election_manager_screen.test.tsx
+++ b/apps/pollbook/frontend/src/election_manager_screen.test.tsx
@@ -11,7 +11,8 @@ import { renderInAppContext } from '../test/render_in_app_context';
 import { ElectionManagerScreen } from './election_manager_screen';
 
 let apiMock: ApiMock;
-const electionFamousNames = electionFamousNames2021Fixtures.readElection();
+const electionDefFamousNames =
+  electionFamousNames2021Fixtures.readElectionDefinition();
 
 let unmount: () => void;
 
@@ -19,8 +20,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   apiMock = createApiMock();
   apiMock.setIsAbsenteeMode(false);
-  apiMock.setElection(electionFamousNames);
-  apiMock.expectGetMachineConfig();
+  apiMock.setElection(electionDefFamousNames);
   apiMock.expectGetDeviceStatuses();
 });
 

--- a/apps/pollbook/frontend/src/machine_locked_screen.tsx
+++ b/apps/pollbook/frontend/src/machine_locked_screen.tsx
@@ -2,7 +2,7 @@ import { H1, H3, Main, Screen } from '@votingworks/ui';
 import styled from 'styled-components';
 import React from 'react';
 import { ElectionInfoBar } from './election_info_bar';
-import { getElection, getMachineConfig } from './api';
+import { getElection, getMachineInformation } from './api';
 import { DeviceStatusBar } from './nav_screen';
 
 const LockedImage = styled.img`
@@ -13,15 +13,15 @@ const LockedImage = styled.img`
 `;
 
 export function MachineLockedScreen(): JSX.Element | null {
+  const getMachineInfoQuery = getMachineInformation.useQuery();
   const getElectionQuery = getElection.useQuery();
-  const getMachineConfigQuery = getMachineConfig.useQuery();
 
-  if (!(getElectionQuery.isSuccess && getMachineConfigQuery.isSuccess)) {
+  if (!getMachineInfoQuery.isSuccess || !getElectionQuery.isSuccess) {
     return null;
   }
-
   const election = getElectionQuery.data.ok();
-  const { machineId, codeVersion } = getMachineConfigQuery.data;
+  const { machineId, codeVersion, electionBallotHash, pollbookPackageHash } =
+    getMachineInfoQuery.data;
 
   return (
     <Screen>
@@ -43,6 +43,8 @@ export function MachineLockedScreen(): JSX.Element | null {
       </Main>
       <ElectionInfoBar
         election={election}
+        electionBallotHash={electionBallotHash}
+        pollbookPackageHash={pollbookPackageHash}
         machineId={machineId}
         codeVersion={codeVersion}
       />

--- a/apps/pollbook/frontend/src/nav_screen.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.tsx
@@ -28,7 +28,7 @@ import {
   resetNetwork,
   logOut,
   getElection,
-  getMachineConfig,
+  getMachineInformation,
 } from './api';
 import { PollbookConnectionStatus } from './types';
 import { VerticalElectionInfoBar } from './election_info_bar';
@@ -283,14 +283,15 @@ export function NavScreen({
   children?: React.ReactNode;
 }): JSX.Element | null {
   const getElectionQuery = getElection.useQuery();
-  const getMachineConfigQuery = getMachineConfig.useQuery();
+  const getMachineInfoQuery = getMachineInformation.useQuery();
 
-  if (!(getElectionQuery.isSuccess && getMachineConfigQuery.isSuccess)) {
+  if (!(getElectionQuery.isSuccess && getMachineInfoQuery.isSuccess)) {
     return null;
   }
 
   const election = getElectionQuery.data.ok();
-  const { machineId, codeVersion } = getMachineConfigQuery.data;
+  const { machineId, codeVersion, electionBallotHash, pollbookPackageHash } =
+    getMachineInfoQuery.data;
 
   return (
     <Screen flexDirection="row">
@@ -302,6 +303,8 @@ export function NavScreen({
         <div style={{ marginTop: 'auto' }}>
           <VerticalElectionInfoBar
             election={election}
+            electionBallotHash={electionBallotHash}
+            pollbookPackageHash={pollbookPackageHash}
             machineId={machineId}
             codeVersion={codeVersion}
             inverse

--- a/apps/pollbook/frontend/src/smart_cards_screen.test.tsx
+++ b/apps/pollbook/frontend/src/smart_cards_screen.test.tsx
@@ -1,12 +1,12 @@
 import { test, beforeEach, afterEach, vi } from 'vitest';
-import { readElectionGeneral } from '@votingworks/fixtures';
+import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import { screen } from '../test/react_testing_library';
 import { ApiMock, createApiMock } from '../test/mock_api_client';
 import { renderInAppContext } from '../test/render_in_app_context';
 import { SmartCardsScreen } from './smart_cards_screen';
 
 let apiMock: ApiMock;
-const electionGeneral = readElectionGeneral();
+const electionGeneral = readElectionGeneralDefinition();
 
 let unmount: () => void;
 
@@ -16,7 +16,6 @@ beforeEach(() => {
   apiMock = createApiMock();
   apiMock.setElection(electionGeneral);
   apiMock.authenticateAsSystemAdministrator();
-  apiMock.expectGetMachineConfig();
   apiMock.expectGetDeviceStatuses();
 });
 

--- a/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
+++ b/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
@@ -33,7 +33,6 @@ beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.clearAllMocks();
   apiMock = createApiMock();
-  apiMock.expectGetMachineConfig();
   apiMock.expectGetDeviceStatuses();
 });
 
@@ -43,7 +42,7 @@ describe('Election tab', () => {
     unmount();
   });
   test('basic render', async () => {
-    apiMock.setElection(electionFamousNames);
+    apiMock.setElection(electionDefFamousNames);
     const renderResult = renderInAppContext(<SystemAdministratorScreen />, {
       apiMock,
     });
@@ -167,7 +166,7 @@ describe('Settings tab', () => {
   }
 
   beforeEach(() => {
-    apiMock.setElection(electionFamousNames);
+    apiMock.setElection(electionDefFamousNames);
     apiMock.expectGetUsbDriveStatus({
       status: 'mounted',
       mountPoint: '/dev/null',


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/6179

Following up on https://github.com/votingworks/vxsuite/pull/6370 this PR finishes the implementation of the new pollbook package hash. It updates the networking logic to only "connect" two machines and share events in the ballot hash and pollbook package hash match, rather than checking the election id. In addition we update the frontend to show the first 7 characters each of the ballotHash-pollbookPackageHash as the election ID in the UI, matching the ballotHash-electionPackageHash structure in vxsuite. 

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
<img width="1920" alt="Screenshot 2025-05-08 at 12 19 09 PM" src="https://github.com/user-attachments/assets/f12b9f42-65e3-4049-baa3-dade7315915c" />

<img width="1920" alt="Screenshot 2025-05-08 at 12 18 59 PM" src="https://github.com/user-attachments/assets/4654fcf4-27b8-49b2-8ba8-8bf7b6dc8818" />

## Testing Plan
Tested UI was updated as appropriate, tested basic connection logic. 


