### PR TITLE
Pollbook vendor auth

### DIFF
--- a/apps/admin/frontend/src/components/app_routes.tsx
+++ b/apps/admin/frontend/src/components/app_routes.tsx
@@ -99,8 +99,8 @@ export function AppRoutes(): JSX.Element | null {
   if (isVendorAuth(auth)) {
     return (
       <VendorScreen
-        logOut={() => logOutMutation.mutate()}
-        rebootToVendorMenu={() => apiClient.rebootToVendorMenu()}
+        logOut={logOutMutation.mutate}
+        rebootToVendorMenu={apiClient.rebootToVendorMenu}
       />
     );
   }

--- a/apps/pollbook/backend/src/index.ts
+++ b/apps/pollbook/backend/src/index.ts
@@ -45,6 +45,7 @@ function main(): Promise<number> {
         'system_administrator',
         'election_manager',
         'poll_worker',
+        'vendor',
       ],
     },
     logger: baseLogger,

--- a/apps/pollbook/frontend/src/app.test.tsx
+++ b/apps/pollbook/frontend/src/app.test.tsx
@@ -144,3 +144,11 @@ test('renders ElectionManagerScreen when logged in as election manager', async (
     'Lincoln Municipal General Election'
   );
 });
+
+test('renders VendorScreen when logged in as vendor', async () => {
+  apiMock.expectGetDeviceStatuses();
+  apiMock.authenticateAsVendor();
+  render(<App apiClient={apiMock.mockApiClient} />);
+
+  await screen.findByText('Reboot to Vendor Menu');
+});

--- a/apps/pollbook/frontend/src/app.tsx
+++ b/apps/pollbook/frontend/src/app.tsx
@@ -7,6 +7,7 @@ import {
   SetupCardReaderPage,
   SystemCallContextProvider,
   UnlockMachineScreen,
+  VendorScreen,
 } from '@votingworks/ui';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -16,6 +17,7 @@ import {
   isElectionManagerAuth,
   isPollWorkerAuth,
   isSystemAdministratorAuth,
+  isVendorAuth,
 } from '@votingworks/utils';
 import { BaseLogger, LogSource } from '@votingworks/logging';
 import {
@@ -26,7 +28,9 @@ import {
   createQueryClient,
   getAuthStatus,
   getElection,
+  logOut,
   systemCallApi,
+  useApiClient,
 } from './api';
 import { ErrorScreen } from './error_screen';
 import { PollWorkerScreen } from './poll_worker_screen';
@@ -36,8 +40,10 @@ import { ElectionManagerScreen } from './election_manager_screen';
 import { SystemAdministratorScreen } from './system_administrator_screen';
 
 function AppRoot(): JSX.Element | null {
-  const getAuthStatusQuery = getAuthStatus.useQuery();
+  const apiClient = useApiClient();
   const checkPinMutation = checkPin.useMutation();
+  const logOutMutation = logOut.useMutation();
+  const getAuthStatusQuery = getAuthStatus.useQuery();
   const getElectionQuery = getElection.useQuery();
   if (!getAuthStatusQuery.isSuccess) {
     return null;
@@ -80,6 +86,7 @@ function AppRoot(): JSX.Element | null {
     ) {
       return <MachineLockedScreen />;
     }
+
     return (
       <InvalidCardScreen
         reasonAndContext={auth}
@@ -89,6 +96,15 @@ function AppRoot(): JSX.Element | null {
             : 'Use a valid election manager or poll worker card.'
         }
         cardInsertionDirection="right"
+      />
+    );
+  }
+
+  if (isVendorAuth(auth)) {
+    return (
+      <VendorScreen
+        logOut={() => logOutMutation.mutate()}
+        rebootToVendorMenu={() => apiClient.rebootToVendorMenu()}
       />
     );
   }

--- a/apps/pollbook/frontend/src/app.tsx
+++ b/apps/pollbook/frontend/src/app.tsx
@@ -103,8 +103,8 @@ function AppRoot(): JSX.Element | null {
   if (isVendorAuth(auth)) {
     return (
       <VendorScreen
-        logOut={() => logOutMutation.mutate()}
-        rebootToVendorMenu={() => apiClient.rebootToVendorMenu()}
+        logOut={logOutMutation.mutate}
+        rebootToVendorMenu={apiClient.rebootToVendorMenu}
       />
     );
   }

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -22,6 +22,7 @@ import {
   mockPollWorkerUser,
   mockSessionExpiresAt,
   mockSystemAdministratorUser,
+  mockVendorUser,
 } from '@votingworks/test-utils';
 import { UsbDriveStatus } from '@votingworks/usb-drive';
 import { mockUsbDriveStatus } from '@votingworks/ui';
@@ -105,8 +106,6 @@ export function createApiMock() {
 
     setAuthStatus,
 
-    /**
-     * TODO: Vendor user not yet supported 
     authenticateAsVendor() {
       setAuthStatus({
         status: 'logged_in',
@@ -114,8 +113,6 @@ export function createApiMock() {
         sessionExpiresAt: mockSessionExpiresAt(),
       });
     },
-
-    */
 
     authenticateAsSystemAdministrator() {
       setAuthStatus({


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/6309

Adds vendor auth support. Duplicates https://github.com/votingworks/vxsuite/pull/6411, which was accidentally branched off another feature branch.

@nikhilb4a sorry for the mixup! Rerequesting review since merging is blocked again. (Reopened rather than rebased in order to push the more accurate branch name)

## Demo Video or Screenshot


https://github.com/user-attachments/assets/87a4a248-37f1-404f-b811-c40fe3746676



## Testing Plan

Added test that vendor screen is rendered. The rest of the vendor flow is covered by library tests.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
