### PR TITLE
[pollbook] handle punctuation and whitespace in search

### DIFF
--- a/apps/pollbook/backend/src/app.test.ts
+++ b/apps/pollbook/backend/src/app.test.ts
@@ -796,12 +796,30 @@ test('voter search ignores punctuation', async () => {
     }
 
     const testSearchParams = [
+      // Test puncutation and whitespace in input are ignored
+      {
+        firstName: 'george-washington',
+        lastName: 'carver-farmer',
+      },
+      {
+        firstName: "george'washington",
+        lastName: "carver'farmer",
+      },
+      {
+        firstName: 'mar tha',
+        lastName: 'wash ington',
+      },
+      // Test punctuation and whitespace in db column are ignored
       {
         firstName: 'georgewashington',
         lastName: 'carverfar',
       },
       {
         firstName: 'george',
+        lastName: 'washington',
+      },
+      {
+        firstName: 'martha',
         lastName: 'washington',
       },
     ];

--- a/apps/pollbook/backend/src/app.test.ts
+++ b/apps/pollbook/backend/src/app.test.ts
@@ -728,6 +728,93 @@ test('change a voter address with various formats', async () => {
   });
 });
 
+test('voter search ignores punctuation', async () => {
+  await withApp(async ({ localApiClient, workspace, mockPrinterHandler }) => {
+    const testVoters = parseVotersFromCsvString(
+      electionFamousNames2021Fixtures.pollbookVoters.asText()
+    );
+    const testStreets = parseValidStreetsFromCsvString(
+      electionFamousNames2021Fixtures.pollbookStreetNames.asText()
+    );
+    workspace.store.setElectionAndVoters(
+      electionDefinition,
+      'fake-package-hash',
+      testStreets,
+      testVoters
+    );
+    mockPrinterHandler.connectPrinter(CITIZEN_THERMAL_PRINTER_CONFIG);
+
+    // Register some voters with punctuation in names
+    const baseNewVoter: Omit<
+      VoterRegistrationRequest,
+      'firstName' | 'lastName' | 'middleName'
+    > = {
+      suffix: '',
+      streetNumber: '15',
+      streetName: 'MAIN ST',
+      streetSuffix: '',
+      apartmentUnitNumber: '',
+      houseFractionNumber: '',
+      addressLine2: '',
+      addressLine3: '',
+      city: 'Manchester',
+      state: 'NH',
+      zipCode: '03101',
+      party: 'UND',
+    };
+
+    const registrationRequests: VoterRegistrationRequest[] = [
+      {
+        ...baseNewVoter,
+        firstName: 'George Washington',
+        lastName: 'Carver Farmer',
+        middleName: '',
+      },
+      {
+        ...baseNewVoter,
+        firstName: "Geo'rge",
+        lastName: "Washing'ton",
+        middleName: '',
+      },
+      {
+        ...baseNewVoter,
+        firstName: 'Mar-tha',
+        lastName: 'Washing-ton',
+        middleName: '',
+      },
+    ];
+
+    for (const registrationData of registrationRequests) {
+      const registerResult = await localApiClient.registerVoter({
+        registrationData,
+      });
+      expect(registerResult).toMatchObject({
+        firstName: registrationData.firstName,
+        lastName: registrationData.lastName,
+        party: 'UND',
+      });
+    }
+
+    const testSearchParams = [
+      {
+        firstName: 'georgewashington',
+        lastName: 'carverfar',
+      },
+      {
+        firstName: 'george',
+        lastName: 'washington',
+      },
+    ];
+
+    for (const searchParams of testSearchParams) {
+      const result = await localApiClient.searchVoters({
+        searchParams,
+      });
+      assert(result !== null);
+    }
+  });
+});
+
 test('programCard and unprogramCard', async () => {
   await withApp(async ({ localApiClient, auth: authApi, workspace }) => {
     workspace.store.setElectionAndVoters(

--- a/apps/pollbook/backend/src/local_store.ts
+++ b/apps/pollbook/backend/src/local_store.ts
@@ -3,7 +3,7 @@ import { Client as DbClient } from '@votingworks/db';
 import { safeParseJson } from '@votingworks/types';
 import { assert, groupBy, typedAs } from '@votingworks/basics';
 import { SqliteBool, fromSqliteBool, asSqliteBool } from '@votingworks/utils';
-import debug from 'debug';
+import makeDebug from 'debug';
 import { generateId, SchemaPath, sortedByVoterName, Store } from './store';
 import {
   ConfigurationStatus,
@@ -45,6 +45,21 @@ import {
 } from './street_helpers';
 import { isVoterNameChangeValid } from './voter_helpers';
 
+const debug = makeDebug('pollbook:local-store');
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Takes a raw string input eg. search string for voter name
+// and turns it into a pattern to pass to sqlite3. The pattern
+// ignores apostrophes, dashes, and whitespace
+function toPattern(raw: string): string {
+  const clean = raw.trim().replace(/[\s'-]/g, '');
+  const parts = clean.split('').map((ch) => escapeRegex(ch));
+  return `^${parts.join(`[\\s'\\-]*`)}.*$`;
+}
+
 export class LocalStore extends Store {
   private nextEventId?: number;
   private configurationStatus?: ConfigurationStatus;
@@ -57,10 +72,10 @@ export class LocalStore extends Store {
     logger: BaseLogger,
     machineId: string
   ): LocalStore {
-    return new LocalStore(
-      DbClient.fileClient(dbPath, logger, SchemaPath),
-      machineId
-    );
+    const client = DbClient.fileClient(dbPath, logger, SchemaPath, {
+      registerRegexpFn: true,
+    });
+    return new LocalStore(client, machineId);
   }
 
   /**
@@ -196,20 +211,21 @@ export class LocalStore extends Store {
 
   searchVoters(searchParams: VoterSearchParams): Voter[] | number {
     const { lastName, firstName } = searchParams;
-    const lastNameSearch = lastName.trim().toUpperCase();
-    const firstNameSearch = firstName.trim().toUpperCase();
     const MAX_VOTER_SEARCH_RESULTS = 100;
+
+    const lastNamePattern = toPattern(lastName);
+    const firstNamePattern = toPattern(firstName);
 
     // Query the database for voters matching the search criteria
     const voterRows = this.client.all(
       `
             SELECT v.voter_id, v.voter_data
             FROM voters v
-            WHERE updated_last_name LIKE ? 
-              AND updated_first_name LIKE ?
+            WHERE updated_last_name REGEXP ?
+              AND updated_first_name REGEXP ?
             `,
-      `${lastNameSearch}%`,
-      `${firstNameSearch}%`
+      `${lastNamePattern}`,
+      `${firstNamePattern}`
     ) as Array<{ voter_id: string; voter_data: string }>;
 
     if (voterRows.length === 0) {

--- a/libs/db/src/client.ts
+++ b/libs/db/src/client.ts
@@ -444,7 +444,8 @@ export class Client {
     this.run('pragma foreign_keys = 1');
 
     if (this.connectionOptions?.registerRegexpFn) {
-      debug('registering regexp function');
+      // sqlite3 has no built-in regexp function
+      // This is o(n) and should be used with caution on large tables (>20,000 rows)
       this.db.function('regexp', (pattern: string, value: string) => {
         try {
           return new RegExp(pattern, 'i').test(value) ? 1 : 0;

--- a/libs/db/src/client.ts
+++ b/libs/db/src/client.ts
@@ -33,6 +33,13 @@ export interface Statement<P extends Bindable[] = []> {
 }
 
 /**
+ * Interface describing options for database connection
+ */
+export interface DbConnectionOptions {
+  registerRegexpFn?: boolean;
+}
+
+/**
  * Manages a connection for a SQLite database.
  */
 export class Client {
@@ -44,7 +51,8 @@ export class Client {
   private constructor(
     private readonly dbPath: string,
     private readonly logger: BaseLogger,
-    private readonly schemaPath?: string
+    private readonly schemaPath?: string,
+    private readonly connectionOptions?: DbConnectionOptions
   ) {}
 
   /**
@@ -89,9 +97,12 @@ export class Client {
   static fileClient(
     dbPath: string,
     logger: BaseLogger,
-    schemaPath?: string
+    schemaPath?: string,
+    connectionOptions?: DbConnectionOptions
   ): Client {
-    const client = new Client(dbPath, logger, schemaPath);
+    const client = new Client(dbPath, logger, schemaPath, connectionOptions);
+
+    debug('creating client with connectionOptions: %o', connectionOptions);
 
     if (!schemaPath) {
       return client;
@@ -425,11 +436,23 @@ export class Client {
       },
       debug
     );
+
     this.db = new Database(this.getDatabasePath());
 
     // Enforce foreign key constraints. This is not in schema.sql because that
     // only runs on db creation.
     this.run('pragma foreign_keys = 1');
+
+    if (this.connectionOptions?.registerRegexpFn) {
+      debug('registering regexp function');
+      this.db.function('regexp', (pattern: string, value: string) => {
+        try {
+          return new RegExp(pattern, 'i').test(value) ? 1 : 0;
+        } catch {
+          return 0;
+        }
+      });
+    }
 
     this.logger.log(
       LogEventId.DatabaseConnectComplete,


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/6164

Ignore case, apostrophes, dashes, and whitespace in voter name search.

This is `o(n)`. I haven't noticed any slowdown on the test pollbook package with ~6000 voters but we'll most likely want to replace the regexp search with computing and storing a normalized name column in the future. I didn't do it in this PR because

1. This was much faster to write
2. I'm not sure how much is still in flux with pollbook package reading, voter input files, and so on

## Demo Video or Screenshot


https://github.com/user-attachments/assets/3e6b3668-1014-4dbd-9c70-a49e128fa97f


https://github.com/user-attachments/assets/ca0d6568-17fd-4e45-a72d-c141488d1235


https://github.com/user-attachments/assets/10835a69-9ca8-45ca-aa73-592d2203a6cf


## Testing Plan

- Pollbook backend tests
- libs/db tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
