### PR TITLE
Fix log source in scan/central-scan frontend prodserver

### DIFF
--- a/apps/central-scan/frontend/prodserver/index.js
+++ b/apps/central-scan/frontend/prodserver/index.js
@@ -13,7 +13,7 @@ const { handleUncaughtExceptions } = require('@votingworks/backend');
 const proxy = require('./setupProxy')
 const app = express()
 const port = 3000
-const logger = new Logger(LogSource.VxMarkScanFrontendServer)
+const logger = new Logger(LogSource.VxCentralScanFrontendServer)
 
 handleUncaughtExceptions(logger);
 

--- a/apps/scan/frontend/prodserver/index.js
+++ b/apps/scan/frontend/prodserver/index.js
@@ -13,7 +13,7 @@ const { handleUncaughtExceptions } = require('@votingworks/backend');
 const proxy = require('./setupProxy');
 const app = express();
 const port = 3000;
-const logger = new Logger(LogSource.VxMarkScanFrontendServer);
+const logger = new Logger(LogSource.VxScanFrontendServer);
 
 handleUncaughtExceptions(logger);
 


### PR DESCRIPTION
## Overview

I noticed that the log source was incorrect in some VxScan logs. Looks like a copy-paste error.

## Demo Video or Screenshot
N/A
## Testing Plan
Checked all the prodserver files
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
