### PR TITLE
Allow line wrap for candidate names in write-in adjudication report

### DIFF
--- a/libs/ui/src/reports/contest_write_in_summary_table.tsx
+++ b/libs/ui/src/reports/contest_write_in_summary_table.tsx
@@ -9,7 +9,7 @@ import {
 import { find } from '@votingworks/basics';
 import pluralize from 'pluralize';
 import { format } from '@votingworks/utils';
-import { TD, TH } from '../table';
+import { TD } from '../table';
 import { Caption, Font, FontProps } from '../typography';
 import { reportColors } from './layout';
 
@@ -83,12 +83,12 @@ function TallyRow({
 }): JSX.Element {
   return (
     <tr>
-      <TH
+      <th
         className={indent ? 'indent' : undefined}
         colSpan={tally === undefined ? 2 : 1}
       >
         <Font weight={weight}>{label}</Font>
-      </TH>
+      </th>
       {tally !== undefined && (
         <TD narrow textAlign="right">
           {format.count(tally)}


### PR DESCRIPTION

## Overview

Fixes: https://github.com/votingworks/vxsuite/issues/6128

Previously, we were using the `TH` component, which defaults to not allowing line wrapping. Instead, just use a plain `th` component like the tally report components do, which defaults to allowing line wrapping.

## Demo Video or Screenshot

Before
<img width="833" alt="Screenshot 2025-05-12 at 4 18 18 PM" src="https://github.com/user-attachments/assets/eba2ed64-3980-4221-9e24-df82c73e66ea" />


After
<img width="830" alt="Screenshot 2025-05-12 at 4 18 05 PM" src="https://github.com/user-attachments/assets/184f405c-bf91-4171-92b5-dfee316b5ac5" />

## Testing Plan
Manual test

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
