### PR TITLE
refactor: extract `MarkScanAppBase`

### DIFF
--- a/apps/mark-scan/frontend/src/app.tsx
+++ b/apps/mark-scan/frontend/src/app.tsx
@@ -1,30 +1,16 @@
-import { BrowserRouter } from 'react-router-dom';
-
-import { BaseLogger, LogSource } from '@votingworks/logging';
 import { QueryClient } from '@tanstack/react-query';
-import {
-  AppBase,
-  AppErrorBoundary,
-  VisualModeDisabledOverlay,
-} from '@votingworks/ui';
-import { ColorMode, ScreenType, SizeMode } from '@votingworks/types';
-
-import {
-  BooleanEnvironmentVariableName,
-  isFeatureFlagEnabled,
-} from '@votingworks/utils';
-import { AppRoot } from './app_root';
+import { BaseLogger, LogSource } from '@votingworks/logging';
+import { AppErrorBoundary, VisualModeDisabledOverlay } from '@votingworks/ui';
+import { BrowserRouter } from 'react-router-dom';
 import { ApiClient, createApiClient, createQueryClient } from './api';
-import { SessionTimeLimitTracker } from './components/session_time_limit_tracker';
 import { ApiProvider } from './api_provider';
+import { AppRoot } from './app_root';
+import { SessionTimeLimitTracker } from './components/session_time_limit_tracker';
+import { MarkScanAppBase } from './mark_scan_app_base';
 
 window.oncontextmenu = (e: MouseEvent): void => {
   e.preventDefault();
 };
-
-const DEFAULT_COLOR_MODE: ColorMode = 'contrastMedium';
-const DEFAULT_SCREEN_TYPE: ScreenType = 'elo15';
-const DEFAULT_SIZE_MODE: SizeMode = 'touchMedium';
 
 export interface Props {
   logger?: BaseLogger;
@@ -45,14 +31,7 @@ export function App({
   noAudio,
 }: Props): JSX.Element {
   return (
-    <AppBase
-      defaultColorMode={DEFAULT_COLOR_MODE}
-      defaultSizeMode={DEFAULT_SIZE_MODE}
-      screenType={DEFAULT_SCREEN_TYPE}
-      hideCursor={isFeatureFlagEnabled(
-        BooleanEnvironmentVariableName.HIDE_CURSOR
-      )}
-    >
+    <MarkScanAppBase>
       <BrowserRouter>
         <AppErrorBoundary restartMessage={RESTART_MESSAGE} logger={logger}>
           <ApiProvider
@@ -67,6 +46,6 @@ export function App({
           </ApiProvider>
         </AppErrorBoundary>
       </BrowserRouter>
-    </AppBase>
+    </MarkScanAppBase>
   );
 }

--- a/apps/mark-scan/frontend/src/electrical_testing/app.tsx
+++ b/apps/mark-scan/frontend/src/electrical_testing/app.tsx
@@ -4,6 +4,7 @@ import { AppErrorBoundary } from '@votingworks/ui';
 
 import { ApiClientContext, createApiClient, createQueryClient } from './api';
 import { AppRoot } from './app_root';
+import { MarkScanAppBase } from '../mark_scan_app_base';
 
 export function App(): JSX.Element {
   const logger = new BaseLogger(LogSource.VxScanFrontend, window.kiosk);
@@ -11,12 +12,14 @@ export function App(): JSX.Element {
   const apiClient = createApiClient();
 
   return (
-    <AppErrorBoundary restartMessage="Restart the machine" logger={logger}>
-      <ApiClientContext.Provider value={apiClient}>
-        <QueryClientProvider client={queryClient}>
-          <AppRoot />
-        </QueryClientProvider>
-      </ApiClientContext.Provider>
-    </AppErrorBoundary>
+    <MarkScanAppBase>
+      <AppErrorBoundary restartMessage="Restart the machine" logger={logger}>
+        <ApiClientContext.Provider value={apiClient}>
+          <QueryClientProvider client={queryClient}>
+            <AppRoot />
+          </QueryClientProvider>
+        </ApiClientContext.Provider>
+      </AppErrorBoundary>
+    </MarkScanAppBase>
   );
 }

--- a/apps/mark-scan/frontend/src/mark_scan_app_base.tsx
+++ b/apps/mark-scan/frontend/src/mark_scan_app_base.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { AppBase } from '@votingworks/ui';
+import { ColorMode, ScreenType, SizeMode } from '@votingworks/types';
+import {
+  BooleanEnvironmentVariableName,
+  isFeatureFlagEnabled,
+} from '@votingworks/utils';
+
+export interface AppBaseProps {
+  children: React.ReactNode;
+}
+
+const DEFAULT_COLOR_MODE: ColorMode = 'contrastMedium';
+const DEFAULT_SCREEN_TYPE: ScreenType = 'elo15';
+const DEFAULT_SIZE_MODE: SizeMode = 'touchMedium';
+
+/**
+ * Installs global styles and UI themes - should be rendered at the root of the
+ * app before anything else.
+ */
+export function MarkScanAppBase({ children }: AppBaseProps): JSX.Element {
+  return (
+    <AppBase
+      defaultColorMode={DEFAULT_COLOR_MODE}
+      defaultSizeMode={DEFAULT_SIZE_MODE}
+      hideCursor={isFeatureFlagEnabled(
+        BooleanEnvironmentVariableName.HIDE_CURSOR
+      )}
+      screenType={DEFAULT_SCREEN_TYPE}
+    >
+      {children}
+    </AppBase>
+  );
+}


### PR DESCRIPTION
## Overview

For use in both the real app and the hardware test app, so we can use `@votingworks/ui` et al in both.

## Demo Video or Screenshot
No changes yet, but this is needed to bring the new HTA UI that we use in VxScan.

## Testing Plan
Manually tested in a VM to ensure the HTA still works as-is.