### PR TITLE
Add system settings flag to enable auditable ballot IDs

### DIFF
--- a/libs/types/src/system_settings.ts
+++ b/libs/types/src/system_settings.ts
@@ -81,6 +81,12 @@ export interface SystemSettings {
    * Enables quick results reporting and provides the server URL to post results to
    */
   readonly quickResultsReportingUrl?: string;
+
+  /**
+   * Turns on the VxScan feature to read ballot IDs from HMPB QR codes, encrypt
+   * them, and export them to CVRs (to be used for post-election auditing).
+   */
+  readonly enableAuditBallotIds?: boolean;
 }
 
 export const SystemSettingsSchema: z.ZodType<SystemSettings> = z.object({
@@ -99,6 +105,7 @@ export const SystemSettingsSchema: z.ZodType<SystemSettings> = z.object({
   castVoteRecordsIncludeRedundantMetadata: z.boolean().optional(),
   disableVerticalStreakDetection: z.boolean().optional(),
   quickResultsReportingUrl: z.string().optional(),
+  enableAuditBallotIds: z.boolean().optional(),
 });
 
 /**


### PR DESCRIPTION
## Overview

Task: #6360 

Adds a new system settings flag to enable VxScan to read ballot IDs from HMPBs, encrypt them, and add them to the CVRs.

## Demo Video or Screenshot
N/A

## Testing Plan
Nothing to test quite yet, but will get tested in future PRs

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
