### PR TITLE
Add support for audit ballot ID to encoded ballot metadata

### DIFF
--- a/libs/ballot-encoder/README.md
+++ b/libs/ballot-encoder/README.md
@@ -21,7 +21,6 @@ import { CompletedBallot, getContests, vote } from '@votingworks/types';
 
 const ballotStyle = election.ballotStyles[0];
 const precinct = election.precincts[0];
-const ballotId = 'abcde';
 const contests = getContests({ ballotStyle, election });
 const votes = vote(contests, {
   'judicial-robert-demergue': 'judicial-robert-demergue-option-yes'
@@ -34,7 +33,6 @@ const votes = vote(contests, {
   '102': '102-option-yes',
 });
 const ballot: CompletedBallot = {
-  ballotId,
   ballotStyleId: ballotStyle.id,
   precinctId: precinct.id,
   votes,
@@ -118,7 +116,7 @@ is encoded as follows:
 - **Ballot Style Index:** A fixed-width number for the index of the ballot style
   in the election's ballot style list (`C.ballotStyleId`).
   - Size: 12 bits.
-- **Page Number:** _(HMPB-only.)_ A dynamic-width number for the 1-based page
+- **Page Number:** _(HMPB-only)_ A dynamic-width number for the 1-based page
   number up to a maximum number of pages (`C.pageNumber`).
   - Size: 5 bits.
 - **Test Ballot?:** This is a single bit that is set if the ballot is a test
@@ -127,12 +125,13 @@ is encoded as follows:
 - **Ballot Type:** One of the `BallotType` values, e.g. `Precinct`, `Absentee`,
   or `Provisional` (`C.ballotType`).
   - Size: 4 bits.
-- **Ballot ID Set?:** This bit is true if there is a ballot id, unset otherwise
-  (`C.ballotId`).
+- **Audit Ballot ID Set?:** _(HMPB-only, always false for BMDB)_ This bit is
+  true if there is an audit ballot id, unset otherwise (`C.auditBallotId`).
   - Size: 1 bit.
-- **Ballot ID:** Only present if the previous bit is set. This is a
-  dynamic-length string whose maximum length is 255 bytes (`C.ballotId`).
-  - Size: `(1 + bytes(C.ballotId)) * 8` bits.
+- **Audit Ballot ID:** _(HMPB-only)_ Only present if the previous bit is set.
+  This is a dynamic-length string whose maximum length is 255 bytes
+  (`C.auditBallotId`).
+  - Size: `(1 + bytes(C.auditBallotId)) * 8` bits.
 
 ### Completed BMD Ballot Encoding
 

--- a/libs/ballot-encoder/src/index.test.ts
+++ b/libs/ballot-encoder/src/index.test.ts
@@ -638,6 +638,7 @@ test('encode HMPB ballot page metadata', () => {
     pageNumber: 3,
     isTestMode: true,
     ballotType: BallotType.Precinct,
+    auditBallotId: 'test-audit-ballot-id',
   };
 
   const encoded = encodeHmpbBallotPageMetadata(election, ballotMetadata);

--- a/libs/ballot-interpreter/src/hmpb-rust/metadata/types.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/metadata/types.rs
@@ -7,12 +7,14 @@ use crate::codable;
 codable!(PrecinctIndex, u32, 0..=4096);
 codable!(BallotStyleIndex, u32, 0..=4096);
 codable!(PageNumber, u8, 1..=30);
+codable!(AuditBallotIdLength, u8, 1..=255);
 
 // Statically validate our maximum values fit within the types we're using.
 // TODO: move this into `codable!`
 const_assert!(PrecinctIndex::BITS <= usize::BITS);
 const_assert!(BallotStyleIndex::BITS <= usize::BITS);
 const_assert!(PageNumber::BITS <= u8::BITS);
+const_assert!(AuditBallotIdLength::BITS <= u8::BITS);
 
 impl PageNumber {
     /// Whether this is the first page of its sheet, i.e. the front.

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -889,6 +889,10 @@ export interface HmpbBallotPageMetadata {
   pageNumber: number;
   isTestMode: boolean;
   ballotType: BallotType;
+  /**
+   * Only used when SystemSettings.enableAuditBallotIds feature is enabled.
+   */
+  auditBallotId?: BallotId;
 }
 export const HmpbBallotPageMetadataSchema: z.ZodSchema<HmpbBallotPageMetadata> =
   z.object({
@@ -898,12 +902,12 @@ export const HmpbBallotPageMetadataSchema: z.ZodSchema<HmpbBallotPageMetadata> =
     pageNumber: z.number(),
     isTestMode: z.boolean(),
     ballotType: BallotTypeSchema,
-    ballotId: BallotIdSchema.optional(),
+    auditBallotId: BallotIdSchema.optional(),
   });
 
 export type BallotMetadata = Omit<
   HmpbBallotPageMetadata,
-  'pageNumber' | 'ballotId'
+  'pageNumber' | 'auditBallotId'
 >;
 export const BallotMetadataSchema: z.ZodSchema<BallotMetadata> = z.object({
   ballotHash: Sha256Hash,


### PR DESCRIPTION
## Overview

Adds the ability to encode an audit ballot ID to ballot metadata (which goes in the HMPB QR code). I ended up repurposing the ballot ID field that I just removed in #6374 but had left in the encoding for backwards compatibility - a nice coincidence. I also added the ability to decode the audit ballot ID in the ballot interpreter.

## Demo Video or Screenshot
N/A

## Testing Plan
Automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
