### PR TITLE
[libs/backend] Add more detail to log export errors

### DIFF
--- a/libs/backend/src/system_call/api.test.ts
+++ b/libs/backend/src/system_call/api.test.ts
@@ -6,6 +6,7 @@ import { LogEventId, MockLogger, mockLogger } from '@votingworks/logging';
 import { SystemCallApiMethods, createSystemCallApi } from './api';
 import { execFile } from '../exec';
 import { getAudioInfo } from './get_audio_info';
+import { LogsExportError } from './export_logs_to_usb';
 
 vi.mock(import('node:fs/promises'), async (importActual) => ({
   ...(await importActual()),
@@ -50,9 +51,9 @@ afterEach(() => {
 });
 
 test('exportLogsToUsb', async () => {
-  expect((await api.exportLogsToUsb({ format: 'vxf' })).err()).toEqual(
-    'no-logs-directory'
-  );
+  expect(
+    (await api.exportLogsToUsb({ format: 'vxf' })).err()
+  ).toEqual<LogsExportError>({ code: 'no-logs-directory' });
 });
 
 test('rebootToVendorMenu', async () => {

--- a/libs/backend/src/system_call/export_logs_to_usb.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.ts
@@ -2,6 +2,7 @@ import {
   Result,
   deferred,
   err,
+  extractErrorMessage,
   ok,
   throwIllegalValue,
 } from '@votingworks/basics';
@@ -256,9 +257,9 @@ export async function exportLogsToUsb({
     let cause: string | undefined;
     if ('cause' in error) {
       if (error.cause instanceof Error) {
-        cause = error.cause.stack || error.cause.toString();
+        cause = error.cause.stack || extractErrorMessage(error.cause);
       } else {
-        cause = `${error.cause}`;
+        cause = extractErrorMessage(error.cause);
       }
     }
 

--- a/libs/ui/src/export_logs_modal.test.tsx
+++ b/libs/ui/src/export_logs_modal.test.tsx
@@ -12,7 +12,9 @@ const { mockApiClient, render } = newTestContext({
 });
 
 test('renders no log file found when usb is mounted but no log file on machine', async () => {
-  mockApiClient.exportLogsToUsb.mockResolvedValueOnce(err('no-logs-directory'));
+  mockApiClient.exportLogsToUsb.mockResolvedValueOnce(
+    err({ code: 'no-logs-directory' })
+  );
 
   render(<ExportLogsButton usbDriveStatus={mockUsbDriveStatus('mounted')} />);
   userEvent.click(screen.getByText('Save Logs'));

--- a/libs/ui/src/export_logs_modal.tsx
+++ b/libs/ui/src/export_logs_modal.tsx
@@ -40,7 +40,7 @@ export function ExportLogsModal({
     const result = await exportLogsToUsbMutation.mutateAsync({ format });
 
     if (result.isErr()) {
-      setErrorMessage(result.err());
+      setErrorMessage(result.err().code);
       setCurrentState(ModalState.Error);
     } else {
       setCurrentState(ModalState.Done);


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6325

We had a report come out of cert testing of a `copy-failed` error during a logs export, but we don't have granular enough logs to figure a root cause.
Adding the original error as additional log metadata to help with that (as well as upcoming attempts to repro on a real machine).

## Testing Plan
- Manual + updated unit tests
