### PR TITLE
Rename "audit ballot ID" to "ballot audit ID" for consistency

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -2211,7 +2211,7 @@ test('export ballots with audit IDs', async () => {
       ballotType: BallotType.Precinct,
       ballotMode: 'official',
       election: expect.any(Object),
-      auditBallotId: String(i),
+      ballotAuditId: String(i),
     })
   );
   expect(renderAllBallotsAndCreateElectionDefinition).toHaveBeenCalledWith(

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -137,9 +137,9 @@ export async function generateElectionPackageAndBallots(
     ballotStyles
   );
 
-  // If we're exporting ballots with audit ballot IDs...
+  // If we're exporting ballots with ballot audit IDs...
   if (numAuditIdBallots) {
-    // Turn on the system setting so VxScan knows to expect audit ballot IDs.
+    // Turn on the system setting so VxScan knows to expect ballot audit IDs.
     systemSettings = {
       ...electionRecord.systemSettings,
       enableAuditBallotIds: true,
@@ -158,7 +158,7 @@ export async function generateElectionPackageAndBallots(
     allBallotProps = range(1, numAuditIdBallots + 1).map(
       (ballotIndex): BaseBallotProps => ({
         ...officialPrecinctBallotProps,
-        auditBallotId: String(ballotIndex),
+        ballotAuditId: String(ballotIndex),
       })
     );
   }
@@ -226,7 +226,7 @@ export async function generateElectionPackageAndBallots(
   // Make ballot zip
   for (const [props, document] of iter(allBallotProps).zip(ballotDocuments)) {
     const ballotPdf = await renderBallotPdf(props, document);
-    const { precinctId, ballotStyleId, ballotType, ballotMode, auditBallotId } =
+    const { precinctId, ballotStyleId, ballotType, ballotMode, ballotAuditId } =
       props;
     const precinct = assertDefined(getPrecinctById({ election, precinctId }));
     const fileName = getBallotPdfFileName(
@@ -234,7 +234,7 @@ export async function generateElectionPackageAndBallots(
       ballotStyleId,
       ballotType,
       ballotMode,
-      auditBallotId
+      ballotAuditId
     );
     ballotsZip.file(fileName, ballotPdf);
   }

--- a/libs/ballot-encoder/README.md
+++ b/libs/ballot-encoder/README.md
@@ -125,13 +125,13 @@ is encoded as follows:
 - **Ballot Type:** One of the `BallotType` values, e.g. `Precinct`, `Absentee`,
   or `Provisional` (`C.ballotType`).
   - Size: 4 bits.
-- **Audit Ballot ID Set?:** _(HMPB-only, always false for BMDB)_ This bit is
-  true if there is an audit ballot id, unset otherwise (`C.auditBallotId`).
+- **Ballot Audit ID Set?:** _(HMPB-only, always false for BMDB)_ This bit is
+  true if there is a ballot audit id, unset otherwise (`C.ballotAuditId`).
   - Size: 1 bit.
-- **Audit Ballot ID:** _(HMPB-only)_ Only present if the previous bit is set.
+- **Ballot Audit ID:** _(HMPB-only)_ Only present if the previous bit is set.
   This is a dynamic-length string whose maximum length is 255 bytes
-  (`C.auditBallotId`).
-  - Size: `(1 + bytes(C.auditBallotId)) * 8` bits.
+  (`C.ballotAuditId`).
+  - Size: `(1 + bytes(C.ballotAuditId)) * 8` bits.
 
 ### Completed BMD Ballot Encoding
 

--- a/libs/ballot-encoder/src/index.test.ts
+++ b/libs/ballot-encoder/src/index.test.ts
@@ -638,7 +638,7 @@ test('encode HMPB ballot page metadata', () => {
     pageNumber: 3,
     isTestMode: true,
     ballotType: BallotType.Precinct,
-    auditBallotId: 'test-audit-ballot-id',
+    ballotAuditId: 'test-ballot-audit-id',
   };
 
   const encoded = encodeHmpbBallotPageMetadata(election, ballotMetadata);

--- a/libs/ballot-encoder/src/index.ts
+++ b/libs/ballot-encoder/src/index.ts
@@ -113,7 +113,7 @@ export interface BallotConfig {
   /**
    * For HMPB only, when using the SystemSettings.enableAuditBallotIds feature.
    */
-  auditBallotId?: string;
+  ballotAuditId?: string;
 }
 
 /**
@@ -127,7 +127,7 @@ export function encodeBallotConfigInto(
     isTestMode,
     precinctId,
     pageNumber,
-    auditBallotId,
+    ballotAuditId,
   }: BallotConfig,
   bits: BitWriter
 ): BitWriter {
@@ -158,9 +158,9 @@ export function encodeBallotConfigInto(
   const ballotTypeIndex = Object.values(BallotType).indexOf(ballotType);
   bits.writeUint(ballotTypeIndex, { max: BallotTypeMaximumValue });
 
-  bits.writeBoolean(auditBallotId !== undefined);
-  if (auditBallotId) {
-    bits.writeString(auditBallotId);
+  bits.writeBoolean(ballotAuditId !== undefined);
+  if (ballotAuditId) {
+    bits.writeString(ballotAuditId);
   }
 
   return bits;
@@ -189,7 +189,7 @@ export function decodeBallotConfigFromReader(
   const ballotType = Object.values(BallotType)[ballotTypeIndex];
   assert(ballotType, `ballot type index ${ballotTypeIndex} is invalid`);
 
-  const auditBallotId = bits.readBoolean()
+  const ballotAuditId = bits.readBoolean()
     ? unsafeParse(BallotIdSchema, bits.readString())
     : undefined;
 
@@ -205,7 +205,7 @@ export function decodeBallotConfigFromReader(
     pageNumber,
     isTestMode,
     ballotType,
-    auditBallotId,
+    ballotAuditId,
   };
 }
 
@@ -512,7 +512,7 @@ export function encodeHmpbBallotPageMetadataInto(
     isTestMode,
     pageNumber,
     precinctId,
-    auditBallotId,
+    ballotAuditId,
   }: HmpbBallotPageMetadata,
   bits: BitWriter
 ): BitWriter {
@@ -532,7 +532,7 @@ export function encodeHmpbBallotPageMetadataInto(
           isTestMode,
           pageNumber,
           precinctId,
-          auditBallotId,
+          ballotAuditId,
         },
         bits
       )

--- a/libs/ballot-interpreter/src/interpret_vx_hmpb.test.ts
+++ b/libs/ballot-interpreter/src/interpret_vx_hmpb.test.ts
@@ -668,14 +668,14 @@ test('Non-consecutive page numbers', async () => {
   });
 });
 
-test('Audit ballot IDs', async () => {
+test('Ballot audit IDs', async () => {
   const electionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();
   const { election } = electionDefinition;
   const allBallotProps = allBaseBallotProps(election);
   const ballotPropsWithAuditId: BaseBallotProps = {
     ...find(allBallotProps, (p) => p.ballotMode === 'official'),
-    auditBallotId: 'test-audit-ballot-id',
+    ballotAuditId: 'test-ballot-audit-id',
   };
   const renderer = await createPlaywrightRenderer();
   const ballotDocument = (
@@ -687,7 +687,7 @@ test('Audit ballot IDs', async () => {
     )
   ).ballotDocuments[0]!;
   const content = await ballotDocument.getContent();
-  expect(content).toContain('Ballot: <b>test-audit-ballot-id</b>');
+  expect(content).toContain('Ballot: <b>test-ballot-audit-id</b>');
   const pdf = await ballotDocument.renderToPdf();
   const images = asSheet(await pdfToPageImages(pdf).toArray());
   expect(images).toHaveLength(2);
@@ -708,10 +708,10 @@ test('Audit ballot IDs', async () => {
 
   assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
   assert(backResult.interpretation.type === 'InterpretedHmpbPage');
-  expect(frontResult.interpretation.metadata.auditBallotId).toEqual(
-    'test-audit-ballot-id'
+  expect(frontResult.interpretation.metadata.ballotAuditId).toEqual(
+    'test-ballot-audit-id'
   );
-  expect(backResult.interpretation.metadata.auditBallotId).toEqual(
-    'test-audit-ballot-id'
+  expect(backResult.interpretation.metadata.ballotAuditId).toEqual(
+    'test-ballot-audit-id'
   );
 });

--- a/libs/hmpb/src/ballot_components.tsx
+++ b/libs/hmpb/src/ballot_components.tsx
@@ -505,7 +505,7 @@ export function Footer({
   pageNumber,
   totalPages,
   colorTint,
-  auditBallotId,
+  ballotAuditId,
 }: {
   election: Election;
   ballotStyleId: BallotStyleId;
@@ -513,7 +513,7 @@ export function Footer({
   pageNumber: number;
   totalPages?: number;
   colorTint?: ColorTint;
-  auditBallotId?: string;
+  ballotAuditId?: string;
 }): JSX.Element {
   const precinct = assertDefined(getPrecinctById({ election, precinctId }));
   const ballotStyle = assertDefined(
@@ -618,9 +618,9 @@ export function Footer({
               <BallotHashSlot />
             </b>
           </span>
-          {auditBallotId && (
+          {ballotAuditId && (
             <span>
-              Ballot: <b>{auditBallotId}</b>
+              Ballot: <b>{ballotAuditId}</b>
             </span>
           )}
           <span>

--- a/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
@@ -138,7 +138,7 @@ function BallotPageFrame({
   totalPages,
   children,
   watermark,
-  auditBallotId,
+  ballotAuditId,
 }: BaseBallotProps & {
   pageNumber: number;
   totalPages?: number;
@@ -198,7 +198,7 @@ function BallotPageFrame({
               precinctId={precinctId}
               pageNumber={pageNumber}
               totalPages={totalPages}
-              auditBallotId={auditBallotId}
+              ballotAuditId={ballotAuditId}
             />
           </div>
         </TimingMarkGrid>

--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -519,7 +519,7 @@ export interface BaseBallotProps {
   ballotMode: BallotMode;
   watermark?: string;
   compact?: boolean;
-  auditBallotId?: string;
+  ballotAuditId?: string;
 }
 
 /**
@@ -672,7 +672,7 @@ export async function renderAllBallotsAndCreateElectionDefinition<
           precinctId: props.precinctId,
           ballotType: props.ballotType,
           isTestMode: props.ballotMode !== 'official',
-          auditBallotId: props.auditBallotId,
+          ballotAuditId: props.ballotAuditId,
         },
         template
       );

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -892,7 +892,7 @@ export interface HmpbBallotPageMetadata {
   /**
    * Only used when SystemSettings.enableAuditBallotIds feature is enabled.
    */
-  auditBallotId?: BallotId;
+  ballotAuditId?: BallotId;
 }
 export const HmpbBallotPageMetadataSchema: z.ZodSchema<HmpbBallotPageMetadata> =
   z.object({
@@ -902,12 +902,12 @@ export const HmpbBallotPageMetadataSchema: z.ZodSchema<HmpbBallotPageMetadata> =
     pageNumber: z.number(),
     isTestMode: z.boolean(),
     ballotType: BallotTypeSchema,
-    auditBallotId: BallotIdSchema.optional(),
+    ballotAuditId: BallotIdSchema.optional(),
   });
 
 export type BallotMetadata = Omit<
   HmpbBallotPageMetadata,
-  'pageNumber' | 'auditBallotId'
+  'pageNumber' | 'ballotAuditId'
 >;
 export const BallotMetadataSchema: z.ZodSchema<BallotMetadata> = z.object({
   ballotHash: Sha256Hash,


### PR DESCRIPTION

## Overview

VxCentralScan already has code to support imprinted IDs on ballots, and it calls them "ballot audit IDs," so I figured we should use the same term for the VxScan IDs rather than "audit ballot ID."

## Demo Video or Screenshot
N/A

## Testing Plan
Existing tests
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
