### PR TITLE
Rename system settings flag for VxScan ballot audit IDs

### DIFF
--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -142,7 +142,7 @@ export async function generateElectionPackageAndBallots(
     // Turn on the system setting so VxScan knows to expect ballot audit IDs.
     systemSettings = {
       ...electionRecord.systemSettings,
-      enableAuditBallotIds: true,
+      precinctScanEnableBallotAuditIds: true,
     };
 
     // Instead of generating one of each combo of ballot style/precinct/ballot

--- a/libs/ballot-encoder/src/index.ts
+++ b/libs/ballot-encoder/src/index.ts
@@ -111,7 +111,7 @@ export interface BallotConfig {
    */
   pageNumber?: number;
   /**
-   * For HMPB only, when using the SystemSettings.enableAuditBallotIds feature.
+   * For HMPB only, when using the SystemSettings.precinctScanEnableBallotAuditIds feature.
    */
   ballotAuditId?: string;
 }

--- a/libs/ballot-interpreter/src/hmpb-rust/metadata/hmpb.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/metadata/hmpb.rs
@@ -4,7 +4,7 @@ use types_rs::election::{BallotStyleId, Election, PrecinctId};
 
 use super::{
     coding,
-    types::{AuditBallotIdLength, BallotStyleIndex, PageNumber, PrecinctIndex},
+    types::{BallotAuditIdLength, BallotStyleIndex, PageNumber, PrecinctIndex},
 };
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize)]
@@ -112,7 +112,7 @@ impl FromBitStreamWith<'_> for Metadata {
         let is_test_mode = r.read_bit()?;
         let ballot_type = BallotType::from_reader(r)?;
         let ballot_audit_id = if r.read_bit()? {
-            let ballot_audit_id_length = AuditBallotIdLength::from_reader(r)?;
+            let ballot_audit_id_length = BallotAuditIdLength::from_reader(r)?;
             let ballot_audit_id_bytes = r.read_to_vec(ballot_audit_id_length.get().into())?;
             Some(String::from_utf8(ballot_audit_id_bytes)?)
         } else {

--- a/libs/ballot-interpreter/src/hmpb-rust/metadata/types.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/metadata/types.rs
@@ -7,14 +7,14 @@ use crate::codable;
 codable!(PrecinctIndex, u32, 0..=4096);
 codable!(BallotStyleIndex, u32, 0..=4096);
 codable!(PageNumber, u8, 1..=30);
-codable!(AuditBallotIdLength, u8, 1..=255);
+codable!(BallotAuditIdLength, u8, 1..=255);
 
 // Statically validate our maximum values fit within the types we're using.
 // TODO: move this into `codable!`
 const_assert!(PrecinctIndex::BITS <= usize::BITS);
 const_assert!(BallotStyleIndex::BITS <= usize::BITS);
 const_assert!(PageNumber::BITS <= u8::BITS);
-const_assert!(AuditBallotIdLength::BITS <= u8::BITS);
+const_assert!(BallotAuditIdLength::BITS <= u8::BITS);
 
 impl PageNumber {
     /// Whether this is the first page of its sheet, i.e. the front.

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -890,7 +890,7 @@ export interface HmpbBallotPageMetadata {
   isTestMode: boolean;
   ballotType: BallotType;
   /**
-   * Only used when SystemSettings.enableAuditBallotIds feature is enabled.
+   * Only used when SystemSettings.precinctScanEnableBallotAuditIds feature is enabled.
    */
   ballotAuditId?: BallotId;
 }

--- a/libs/types/src/system_settings.ts
+++ b/libs/types/src/system_settings.ts
@@ -86,7 +86,7 @@ export interface SystemSettings {
    * Turns on the VxScan feature to read ballot IDs from HMPB QR codes, encrypt
    * them, and export them to CVRs (to be used for post-election auditing).
    */
-  readonly enableAuditBallotIds?: boolean;
+  readonly precinctScanEnableBallotAuditIds?: boolean;
 }
 
 export const SystemSettingsSchema: z.ZodType<SystemSettings> = z.object({
@@ -105,7 +105,7 @@ export const SystemSettingsSchema: z.ZodType<SystemSettings> = z.object({
   castVoteRecordsIncludeRedundantMetadata: z.boolean().optional(),
   disableVerticalStreakDetection: z.boolean().optional(),
   quickResultsReportingUrl: z.string().optional(),
-  enableAuditBallotIds: z.boolean().optional(),
+  precinctScanEnableBallotAuditIds: z.boolean().optional(),
 });
 
 /**


### PR DESCRIPTION
## Overview

Missed a couple spots in #6439 😳  
## Demo Video or Screenshot
N/A
## Testing Plan
Automated tests
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
