### PR TITLE
[VV40ECT-115] Fix flow for exiting voting session after paper jam

### DIFF
--- a/apps/mark-scan/frontend/src/pages/remove_jammed_sheet_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/remove_jammed_sheet_screen.tsx
@@ -2,7 +2,6 @@
 
 import { Caption, Icons, P } from '@votingworks/ui';
 import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
-import { ResetVoterSessionButton } from '../components/deactivate_voter_session_button';
 
 export function RemoveJammedSheetScreen(): JSX.Element {
   return (
@@ -10,7 +9,6 @@ export function RemoveJammedSheetScreen(): JSX.Element {
       icon={<Icons.Warning color="warning" />}
       title="Paper is Jammed"
       voterFacing={false}
-      buttons={<ResetVoterSessionButton />}
     >
       <P>
         Please remove the jammed sheet, opening the printer cover or ballot box

--- a/apps/mark-scan/frontend/src/pages/replace_jammed_sheet_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/replace_jammed_sheet_screen.tsx
@@ -2,6 +2,7 @@ import { Icons, P } from '@votingworks/ui';
 import type { SimpleServerStatus } from '@votingworks/mark-scan-backend';
 import React from 'react';
 import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { ResetVoterSessionButton } from '../components/deactivate_voter_session_button';
 
 export const JAM_CLEARED_STATES = [
   'accepting_paper_after_jam',
@@ -55,6 +56,7 @@ export function ReplaceJammedSheetScreen(
       icon={<Icons.Info />}
       title="Jam Cleared"
       voterFacing={false}
+      buttons={<ResetVoterSessionButton />}
     >
       {STATUS_MESSAGES[stateMachineState]}
     </CenteredCardPageLayout>


### PR DESCRIPTION
## Overview

Addresses https://github.com/votingworks/cert-discrepancies/issues/126

Previously, a session deactivation button was provided on the initial Poll-Worker-facing screen for the jammed paper removal flow - that was a confusing experience, since there was no feedback on clicking the button and doing so didn't prevent the system from requiring a new sheet to be inserted after clearing the jam:

https://github.com/user-attachments/assets/0017e0d6-28b6-4c27-a7e1-869e2ffdfc9a

With this change, the session deactivation button is moved later in the flow, to after the jam is cleared and a request for a new sheet appears. This allows the Poll Worker to exit the session without having to insert a new sheet:

https://github.com/user-attachments/assets/5523188d-7ce1-4efb-b167-e85479e128bf

## Testing Plan
- Manual

## Checklist

<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
