### PR TITLE
VxScan: Encrypt ballot audit IDs

### DIFF
--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -79,6 +79,7 @@
     "@types/uuid": "9.0.5",
     "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/fixtures": "workspace:*",
+    "@votingworks/hmpb": "workspace:*",
     "esbuild": "0.21.2",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",

--- a/apps/scan/backend/schema.sql
+++ b/apps/scan/backend/schema.sql
@@ -13,7 +13,8 @@ create table election (
   is_sound_muted boolean not null default false,
   is_double_feed_detection_disabled boolean not null default false,
   is_continuous_export_enabled boolean not null default true,
-  created_at timestamp not null default current_timestamp
+  created_at timestamp not null default current_timestamp,
+  ballot_audit_id_secret_key text
 );
 
 create table batches (

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -25,7 +25,7 @@ import {
 import { assert, assertDefined, ok, Result } from '@votingworks/basics';
 import {
   InsertedSmartCardAuthApi,
-  generateRandomKey,
+  generateRandomAes256Key,
   generateSignedHashValidationQrCodeValue,
 } from '@votingworks/auth';
 import { UsbDrive, UsbDriveStatus } from '@votingworks/usb-drive';
@@ -65,8 +65,6 @@ import {
   testPrintFailureDiagnosticMessage,
 } from './util/diagnostics';
 import { saveReadinessReport } from './printing/readiness_report';
-
-const BALLOT_AUDIT_ID_KEY_LENGTH = 16;
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function buildApi({
@@ -184,9 +182,7 @@ export function buildApi({
         }
         store.setSystemSettings(systemSettings);
         if (systemSettings.precinctScanEnableBallotAuditIds) {
-          store.setBallotAuditIdSecretKey(
-            await generateRandomKey(BALLOT_AUDIT_ID_KEY_LENGTH)
-          );
+          store.setBallotAuditIdSecretKey(await generateRandomAes256Key());
         }
 
         configureUiStrings({

--- a/apps/scan/backend/src/app_export.test.ts
+++ b/apps/scan/backend/src/app_export.test.ts
@@ -3,17 +3,25 @@ import {
   getCastVoteRecordExportDirectoryPaths,
   readCastVoteRecordExport,
 } from '@votingworks/backend';
-import { assertDefined, err, ok } from '@votingworks/basics';
-import { CVR } from '@votingworks/types';
+import { assertDefined, err, find, ok } from '@votingworks/basics';
+import { CVR, DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
 import {
   BooleanEnvironmentVariableName,
   convertCastVoteRecordVotesToTabulationVotes,
   getCurrentSnapshot,
   getFeatureFlagMock,
 } from '@votingworks/utils';
-
+import {
+  allBaseBallotProps,
+  ballotTemplates,
+  BaseBallotProps,
+  createPlaywrightRenderer,
+  renderAllBallotsAndCreateElectionDefinition,
+} from '@votingworks/hmpb';
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { decryptAes256 } from '@votingworks/auth';
 import { scanBallot, withApp } from '../test/helpers/pdi_helpers';
-import { configureApp } from '../test/helpers/shared_helpers';
+import { configureApp, pdfToImageSheet } from '../test/helpers/shared_helpers';
 
 vi.setConfig({ testTimeout: 30_000 });
 
@@ -372,6 +380,76 @@ test('CVR export error handling', async () => {
           mode: 'full_export',
         })
       ).toEqual(err({ type: 'missing-usb-drive' }));
+    }
+  );
+});
+
+test('audit ballot IDs', async () => {
+  // Create a ballot and election definition with an audit ID
+  const electionDefinition =
+    electionFamousNames2021Fixtures.readElectionDefinition();
+  const { election } = electionDefinition;
+  const allBallotProps = allBaseBallotProps(election);
+  const ballotPropsWithAuditId: BaseBallotProps = {
+    ...find(allBallotProps, (p) => p.ballotMode === 'official'),
+    ballotAuditId: 'test-ballot-audit-id',
+  };
+  const renderer = await createPlaywrightRenderer();
+  const ballotDocument = (
+    await renderAllBallotsAndCreateElectionDefinition(
+      renderer,
+      ballotTemplates.VxDefaultBallot,
+      [ballotPropsWithAuditId],
+      'vxf'
+    )
+  ).ballotDocuments[0]!;
+  const pdf = await ballotDocument.renderToPdf();
+  const ballotImages = await pdfToImageSheet(pdf);
+
+  await withApp(
+    async ({
+      apiClient,
+      clock,
+      mockAuth,
+      mockScanner,
+      mockUsbDrive,
+      workspace,
+    }) => {
+      await configureApp(apiClient, mockAuth, mockUsbDrive, {
+        electionPackage: {
+          electionDefinition,
+          systemSettings: {
+            ...DEFAULT_SYSTEM_SETTINGS,
+            precinctScanEnableBallotAuditIds: true,
+          },
+        },
+      });
+
+      await scanBallot(mockScanner, clock, apiClient, workspace.store, 0, {
+        waitForContinuousExportToUsbDrive: true,
+        ballotImages,
+      });
+
+      const [exportDirectoryPath] = await getCastVoteRecordExportDirectoryPaths(
+        mockUsbDrive.usbDrive
+      );
+      const { castVoteRecordIterator } = (
+        await readCastVoteRecordExport(exportDirectoryPath)
+      ).unsafeUnwrap();
+      const castVoteRecords: CVR.CVR[] = (
+        await castVoteRecordIterator.toArray()
+      ).map(
+        (castVoteRecordResult) =>
+          castVoteRecordResult.unsafeUnwrap().castVoteRecord
+      );
+      expect(castVoteRecords).toHaveLength(1);
+      const secretKey = workspace.store.getBallotAuditIdSecretKey();
+      expect(
+        await decryptAes256(
+          secretKey,
+          assertDefined(castVoteRecords[0].BallotAuditId)
+        )
+      ).toEqual(ballotPropsWithAuditId.ballotAuditId);
     }
   );
 });

--- a/apps/scan/backend/src/app_export.test.ts
+++ b/apps/scan/backend/src/app_export.test.ts
@@ -392,7 +392,7 @@ test('audit ballot IDs', async () => {
   const allBallotProps = allBaseBallotProps(election);
   const ballotPropsWithAuditId: BaseBallotProps = {
     ...find(allBallotProps, (p) => p.ballotMode === 'official'),
-    ballotAuditId: 'test-ballot-audit-id',
+    ballotAuditId: '123',
   };
   const renderer = await createPlaywrightRenderer();
   const ballotDocument = (

--- a/apps/scan/backend/src/scanners/shared.ts
+++ b/apps/scan/backend/src/scanners/shared.ts
@@ -19,6 +19,7 @@ import { Store } from '../store';
 import { rootDebug } from '../util/debug';
 import { Workspace } from '../util/workspace';
 import { InterpretationResult } from '../types';
+import { encryptBallotAuditId } from '../export';
 
 const debug = rootDebug.extend('state-machine');
 
@@ -60,10 +61,16 @@ async function exportCastVoteRecordToUsbDriveWithLogging(
         message: `Exporting cast vote record for ${acceptedOrRejected} sheet to USB drive...`,
         operationId,
       });
+      const sheet = assertDefined(store.getSheet(sheetId));
+      const sheetWithEncryptedBallotAuditId = await encryptBallotAuditId(
+        store,
+        assertDefined(store.getSystemSettings()),
+        sheet
+      );
       return await exportCastVoteRecordsToUsbDrive(
         store,
         usbDrive,
-        [assertDefined(store.getSheet(sheetId))],
+        [sheetWithEncryptedBallotAuditId],
         { scannerType: 'precinct' }
       );
     });

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -1130,4 +1130,19 @@ export class Store {
       DateTime.now().toUTC().toSQL()
     );
   }
+
+  setBallotAuditIdSecretKey(key: string): void {
+    this.client.run(`update election set ballot_audit_id_secret_key = ?`, key);
+  }
+
+  getBallotAuditIdSecretKey(): string {
+    const row = this.client.one(
+      `select ballot_audit_id_secret_key as key from election`
+    ) as { key: string } | undefined;
+    assert(
+      row,
+      'Cannot get ballot audit ID secret key when machine is not configured'
+    );
+    return row.key;
+  }
 }

--- a/apps/scan/backend/test/helpers/pdi_helpers.ts
+++ b/apps/scan/backend/test/helpers/pdi_helpers.ts
@@ -256,7 +256,10 @@ export async function scanBallot(
   apiClient: grout.Client<Api>,
   store: Store,
   initialBallotsCounted: number,
-  options: { waitForContinuousExportToUsbDrive?: boolean } = {}
+  options: {
+    waitForContinuousExportToUsbDrive?: boolean;
+    ballotImages?: SheetOf<ImageData>;
+  } = {}
 ): Promise<void> {
   clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
   await waitForStatus(apiClient, {
@@ -266,7 +269,7 @@ export async function scanBallot(
   await simulateScan(
     apiClient,
     mockScanner,
-    await ballotImages.completeBmd(),
+    options.ballotImages ?? (await ballotImages.completeBmd()),
     initialBallotsCounted
   );
   await waitForStatus(apiClient, {

--- a/apps/scan/backend/tsconfig.json
+++ b/apps/scan/backend/tsconfig.json
@@ -30,6 +30,7 @@
     { "path": "../../../libs/fixtures/tsconfig.build.json" },
     { "path": "../../../libs/fujitsu-thermal-printer/tsconfig.build.json" },
     { "path": "../../../libs/grout/tsconfig.build.json" },
+    { "path": "../../../libs/hmpb/tsconfig.build.json" },
     { "path": "../../../libs/image-utils/tsconfig.build.json" },
     { "path": "../../../libs/logging/tsconfig.build.json" },
     { "path": "../../../libs/pdi-scanner/tsconfig.build.json" },

--- a/libs/auth/scripts/decrypt-cvr-ballot-audit-ids
+++ b/libs/auth/scripts/decrypt-cvr-ballot-audit-ids
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+require('esbuild-runner').install({
+  type: 'transform',
+});
+require('./src/decrypt_cvr_ballot_audit_ids').main(process.argv.slice(2));

--- a/libs/auth/scripts/src/decrypt_cvr_ballot_audit_ids.ts
+++ b/libs/auth/scripts/src/decrypt_cvr_ballot_audit_ids.ts
@@ -1,0 +1,87 @@
+import {
+  assert,
+  assertDefined,
+  extractErrorMessage,
+} from '@votingworks/basics';
+import { promises as fs } from 'node:fs';
+import { getExportedCastVoteRecordIds } from '@votingworks/utils';
+import path from 'node:path';
+import {
+  CastVoteRecordExportFileName,
+  CastVoteRecordReportWithoutMetadataSchema,
+  safeParseJson,
+} from '@votingworks/types';
+import { decryptAes256 } from '../../src/cryptography';
+
+const usageMessage =
+  'Usage: decrypt-cvr-ballot-audit-ids input-cvr-directory secret-key output-directory';
+
+interface CommandLineArgs {
+  inputCvrDirectory: string;
+  secretKey: string;
+  outputDirectory: string;
+}
+
+function parseCommandLineArgs(args: readonly string[]): CommandLineArgs {
+  if (args.length !== 3) {
+    console.error(usageMessage);
+    process.exit(1);
+  }
+  return {
+    inputCvrDirectory: assertDefined(args[0]),
+    secretKey: assertDefined(args[1]),
+    outputDirectory: assertDefined(args[2]),
+  };
+}
+
+async function decryptCvrBallotAuditIds({
+  inputCvrDirectory,
+  secretKey,
+  outputDirectory,
+}: CommandLineArgs): Promise<void> {
+  const cvrIds = await getExportedCastVoteRecordIds(inputCvrDirectory);
+  assert(cvrIds.length > 0, 'No CVR IDs found in the input directory');
+
+  await fs.mkdir(outputDirectory, { recursive: true });
+
+  for (const cvrId of cvrIds) {
+    const cvrContents = await fs.readFile(
+      path.join(
+        inputCvrDirectory,
+        cvrId,
+        CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT
+      ),
+      'utf-8'
+    );
+    const cvrReport = safeParseJson(
+      cvrContents,
+      CastVoteRecordReportWithoutMetadataSchema
+    ).unsafeUnwrap();
+    assert(cvrReport.CVR?.length === 1);
+    const cvr = assertDefined(cvrReport.CVR[0]);
+    const decryptedBallotAuditId = await decryptAes256(
+      secretKey,
+      assertDefined(cvr.BallotAuditId, `Missing BallotAuditId in CVR: ${cvrId}`)
+    );
+    await fs.writeFile(
+      path.join(outputDirectory, `${decryptedBallotAuditId}.json`),
+      JSON.stringify(cvrReport, null, 2),
+      'utf-8'
+    );
+  }
+}
+
+/**
+ * A script for decrypting CVR ballot audit IDs exported from VxScan.
+ */
+export async function main(args: readonly string[]): Promise<void> {
+  try {
+    const commandLineArgs = parseCommandLineArgs(args);
+    await decryptCvrBallotAuditIds(commandLineArgs);
+    process.exit(0);
+  } catch (error) {
+    console.error(error);
+    console.error(`❌ ${extractErrorMessage(error)}`);
+    process.exit(1);
+  }
+}

--- a/libs/auth/src/cryptography.end_to_end.test.ts
+++ b/libs/auth/src/cryptography.end_to_end.test.ts
@@ -14,6 +14,7 @@ import {
   decryptAes256,
   encryptAes256,
   extractPublicKeyFromCert,
+  generateRandomAes256Key,
   publicKeyDerToPem,
   signMessage,
   verifyFirstCertWasSignedBySecondCert,
@@ -131,8 +132,9 @@ test('signMessage end-to-end', async () => {
 
 test('AES encryption/decryption end-to-end', async () => {
   const message = 'test-message';
-  const key = 'test-key';
+  const key = await generateRandomAes256Key();
   const encryptedMessage = await encryptAes256(key, message);
+  expect(encryptedMessage).toEqual(await encryptAes256(key, message));
   expect(encryptedMessage).not.toEqual(message);
   expect(await decryptAes256(key, encryptedMessage)).toEqual(message);
 });

--- a/libs/auth/src/cryptography.end_to_end.test.ts
+++ b/libs/auth/src/cryptography.end_to_end.test.ts
@@ -11,6 +11,8 @@ import {
 } from './certs';
 import {
   createCert,
+  decryptAes256,
+  encryptAes256,
   extractPublicKeyFromCert,
   publicKeyDerToPem,
   signMessage,
@@ -125,4 +127,12 @@ test('signMessage end-to-end', async () => {
     messageSignature,
     publicKey: vxScanPublicKey,
   });
+});
+
+test('AES encryption/decryption end-to-end', async () => {
+  const message = 'test-message';
+  const key = 'test-key';
+  const encryptedMessage = await encryptAes256(key, message);
+  expect(encryptedMessage).not.toEqual(message);
+  expect(await decryptAes256(key, encryptedMessage)).toEqual(message);
 });

--- a/libs/auth/src/cryptography.test.ts
+++ b/libs/auth/src/cryptography.test.ts
@@ -15,6 +15,7 @@ import {
   createCertHelper,
   CreateCertInput,
   createCertSigningRequest,
+  generateRandomKey,
   manageOpensslConfig,
   openssl,
   parseCreateCertInput,
@@ -699,4 +700,16 @@ test('manageOpensslConfig with addSudo', async () => {
     expect.stringContaining('/src/intermediate-scripts/manage-openssl-config'),
     'restore-default',
   ]);
+});
+
+test('generateRandomKey', async () => {
+  const mockRandomKey = Buffer.from('test-random-key', 'utf-8');
+  setTimeout(() => {
+    mockChildProcess.stdout.emit('data', mockRandomKey);
+    mockChildProcess.emit('close', successExitCode);
+  });
+
+  expect(await generateRandomKey(10)).toEqual(mockRandomKey.toString('base64'));
+  expect(spawn).toHaveBeenCalledTimes(1);
+  expect(spawn).toHaveBeenNthCalledWith(1, 'openssl', ['rand', '10']);
 });

--- a/libs/auth/src/cryptography.ts
+++ b/libs/auth/src/cryptography.ts
@@ -550,3 +550,52 @@ export async function signMessage({
     : [scriptPath, scriptInput];
   return runCommand(command, { stdin: message });
 }
+
+/**
+ * Generates a random key of the specified length using OpenSSL. The key is
+ * returned in base64 encoding.
+ */
+export async function generateRandomKey(length: number): Promise<string> {
+  return (await openssl(['rand', String(length)])).toString('base64');
+}
+
+/**
+ * Encrypts the given utf8-encoded input string using AES-256-CBC with the
+ * specified key, returning the encrypted data in base64 encoding.
+ */
+export async function encryptAes256(
+  key: string,
+  input: string
+): Promise<string> {
+  return (
+    await openssl([
+      'enc',
+      '-aes-256-cbc',
+      '-k',
+      key,
+      '-in',
+      Buffer.from(input, 'utf-8'),
+    ])
+  ).toString('base64');
+}
+
+/**
+ * Decrypts the given base64-encoded input string using AES-256-CBC with the
+ * specified key, returning the decrypted data as a utf8-encoded string.
+ */
+export async function decryptAes256(
+  key: string,
+  input: string
+): Promise<string> {
+  return (
+    await openssl([
+      'enc',
+      '-d',
+      '-aes-256-cbc',
+      '-k',
+      key,
+      '-in',
+      Buffer.from(input, 'base64'),
+    ])
+  ).toString('utf-8');
+}

--- a/libs/auth/src/cryptography.ts
+++ b/libs/auth/src/cryptography.ts
@@ -587,6 +587,7 @@ export async function decryptAes256(
   input: string
 ): Promise<string> {
   const inputBuffer = Buffer.from(input, 'base64');
+  assert(inputBuffer.length === 16, 'Input must be exactly 128 bits');
   return (
     await openssl(['enc', '-d', '-aes-256-ecb', '-K', key, '-in', inputBuffer])
   ).toString('utf-8');

--- a/libs/auth/src/cryptography.ts
+++ b/libs/auth/src/cryptography.ts
@@ -573,14 +573,7 @@ export async function encryptAes256(
   const inputBuffer = Buffer.from(input, 'utf-8');
   assert(inputBuffer.length <= 16, 'Input must be 128 bits or less');
   return (
-    await openssl([
-      'enc',
-      '-aes-256-ecb',
-      '-K',
-      key,
-      '-in',
-      Buffer.from(input, 'utf-8'),
-    ])
+    await openssl(['enc', '-aes-256-ecb', '-K', key, '-in', inputBuffer])
   ).toString('base64');
 }
 
@@ -593,15 +586,8 @@ export async function decryptAes256(
   key: string,
   input: string
 ): Promise<string> {
+  const inputBuffer = Buffer.from(input, 'base64');
   return (
-    await openssl([
-      'enc',
-      '-d',
-      '-aes-256-ecb',
-      '-K',
-      key,
-      '-in',
-      Buffer.from(input, 'base64'),
-    ])
+    await openssl(['enc', '-d', '-aes-256-ecb', '-K', key, '-in', inputBuffer])
   ).toString('utf-8');
 }

--- a/libs/auth/src/index.ts
+++ b/libs/auth/src/index.ts
@@ -5,7 +5,7 @@ export * from './cast_vote_record_hashes';
 export * from './config';
 export {
   manageOpensslConfig,
-  generateRandomKey,
+  generateRandomAes256Key,
   encryptAes256,
   decryptAes256,
 } from './cryptography';

--- a/libs/auth/src/index.ts
+++ b/libs/auth/src/index.ts
@@ -7,6 +7,7 @@ export {
   manageOpensslConfig,
   generateRandomKey,
   encryptAes256,
+  decryptAes256,
 } from './cryptography';
 export * from './dipped_smart_card_auth_api';
 export * from './dipped_smart_card_auth';

--- a/libs/auth/src/index.ts
+++ b/libs/auth/src/index.ts
@@ -3,7 +3,11 @@ export * as cac from './cac';
 export type { CardStatus } from './card';
 export * from './cast_vote_record_hashes';
 export * from './config';
-export { manageOpensslConfig } from './cryptography';
+export {
+  manageOpensslConfig,
+  generateRandomKey,
+  encryptAes256,
+} from './cryptography';
 export * from './dipped_smart_card_auth_api';
 export * from './dipped_smart_card_auth';
 export * from './inserted_smart_card_auth_api';

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -648,7 +648,7 @@ async function randomlyUpdateCreationTimestamps(
 export async function exportCastVoteRecordsToUsbDrive(
   scannerStore: ScannerStore,
   usbDrive: UsbDrive,
-  sheets: Iterable<Sheet>,
+  sheets: Iterable<Sheet> | AsyncIterable<Sheet>,
   exportOptions: ExportOptions
 ): Promise<Result<void, ExportCastVoteRecordsToUsbDriveError>> {
   assert(scannerStore.scannerType === exportOptions.scannerType);
@@ -720,7 +720,7 @@ export async function exportCastVoteRecordsToUsbDrive(
 
   const castVoteRecordHashes: { [castVoteRecordId: string]: string } = {};
   const sheetIds: string[] = [];
-  for (const sheet of sheets) {
+  for await (const sheet of sheets) {
     sheetIds.push(sheet.id);
 
     if (isRecoveryExport) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   '@babel/traverse': 7.23.2
   '@types/eslint': 8.4.1
@@ -124,7 +128,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        version: 2.1.8(jsdom@20.0.1)
 
   apps/admin/backend:
     dependencies:
@@ -1464,7 +1468,7 @@ importers:
         version: 4.5.2(@types/node@20.17.31)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        version: 2.1.8(jsdom@20.0.1)
 
   apps/mark-scan/backend:
     dependencies:
@@ -1829,7 +1833,7 @@ importers:
         version: 4.5.2(@types/node@20.17.31)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        version: 2.1.8(jsdom@20.0.1)
 
   apps/mark-scan/frontend/prodserver:
     dependencies:
@@ -2207,7 +2211,7 @@ importers:
         version: 4.5.2(@types/node@20.17.31)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        version: 2.1.8(jsdom@20.0.1)
 
   apps/mark/frontend/prodserver:
     dependencies:
@@ -2627,7 +2631,7 @@ importers:
         version: 4.5.2(@types/node@20.17.31)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        version: 2.1.8(jsdom@20.0.1)
 
   apps/pollbook/frontend/prodserver:
     dependencies:
@@ -2785,6 +2789,9 @@ importers:
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../../../libs/fixtures
+      '@votingworks/hmpb':
+        specifier: workspace:*
+        version: link:../../../libs/hmpb
       esbuild:
         specifier: 0.21.2
         version: 0.21.2
@@ -3112,7 +3119,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        version: 2.1.8(jsdom@20.0.1)
 
   libs/auth:
     dependencies:
@@ -3218,7 +3225,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^3.1.1
-        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.17.31)
+        version: 3.1.1(@types/debug@4.1.8)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3640,7 +3647,7 @@ importers:
         version: 0.12.4
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        version: 2.1.8(jsdom@20.0.1)
 
   libs/cdf-schema-builder:
     dependencies:
@@ -4414,7 +4421,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        version: 2.1.8(jsdom@20.0.1)
 
   libs/grout/test-utils:
     dependencies:
@@ -4445,7 +4452,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        version: 2.1.8(jsdom@20.0.1)
 
   libs/hardware-scan-diagnostic:
     devDependencies:
@@ -4793,7 +4800,7 @@ importers:
         version: 0.2.1
       vitest:
         specifier: ^3.1.1
-        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.17.31)
+        version: 3.1.1(@types/debug@4.1.8)
 
   libs/mark-flow-ui:
     dependencies:
@@ -9685,7 +9692,7 @@ packages:
   /@joshwooding/vite-plugin-react-docgen-typescript@0.2.1(typescript@5.8.3)(vite@4.5.2):
     resolution: {integrity: sha512-ou4ZJSXMMWHqGS4g8uNRbC5TiTWxAgQZiVucoUrOCWuPrTbkpJbmVyIi9jU72SBry7gQtuMEDp4YR8EEXAg7VQ==}
     peerDependencies:
-      typescript: '>= 4.3.x'
+      typescript: 5.8.3
       vite: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       typescript:
@@ -12250,7 +12257,7 @@ packages:
     resolution: {integrity: sha512-3YDxZPJsHOsRQob/85X2Xf6pYfwbQilJBsEcuwmEV0JEO4p3JijOlO8xV58uCjkZSpuJ0ARl6t5oCMBo89DKCQ==}
     peerDependencies:
       '@preact/preset-vite': '*'
-      typescript: '>= 4.3.x'
+      typescript: 5.8.3
       vite: ^3.0.0 || ^4.0.0
       vite-plugin-glimmerx: '*'
     peerDependenciesMeta:
@@ -12708,7 +12715,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-      typescript: '*'
+      typescript: 5.8.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -17537,7 +17544,7 @@ packages:
     resolution: {integrity: sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': '>=8.0.0'
+      '@types/eslint': 8.4.1
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
       prettier: '>=3.0.0'
@@ -23070,7 +23077,7 @@ packages:
   /react-docgen-typescript@2.2.2(typescript@5.8.3):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
-      typescript: '>= 4.3.x'
+      typescript: 5.8.3
     dependencies:
       typescript: 5.8.3
     dev: true
@@ -25239,7 +25246,7 @@ packages:
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
     engines: {node: '>=16'}
     peerDependencies:
-      typescript: '>=4.2.0'
+      typescript: 5.8.3
     dependencies:
       typescript: 5.8.3
 
@@ -25258,7 +25265,7 @@ packages:
       babel-jest: ^29.0.0
       esbuild: '*'
       jest: ^29.0.0
-      typescript: '>=4.3 <6'
+      typescript: 5.8.3
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -25304,7 +25311,7 @@ packages:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+      typescript: 5.8.3
     dependencies:
       tslib: 1.14.1
       typescript: 5.8.3
@@ -26057,6 +26064,128 @@ packages:
       - supports-color
       - terser
 
+  /vitest@2.1.8(jsdom@20.0.1):
+    resolution: {integrity: sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.8
+      '@vitest/ui': 2.1.8
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@vitest/expect': 2.1.8
+      '@vitest/mocker': 2.1.8(vite@5.4.18)
+      '@vitest/pretty-format': 2.1.8
+      '@vitest/runner': 2.1.8
+      '@vitest/snapshot': 2.1.8
+      '@vitest/spy': 2.1.8
+      '@vitest/utils': 2.1.8
+      chai: 5.1.2
+      debug: 4.4.0
+      expect-type: 1.1.0
+      jsdom: 20.0.1
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.2
+      tinyrainbow: 1.2.0
+      vite: 5.4.18(@types/node@20.17.31)
+      vite-node: 2.1.8(@types/node@20.17.31)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest@3.1.1(@types/debug@4.1.8):
+    resolution: {integrity: sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.1.1
+      '@vitest/ui': 3.1.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/debug': 4.1.8
+      '@vitest/expect': 3.1.1
+      '@vitest/mocker': 3.1.1(vite@6.3.1)
+      '@vitest/pretty-format': 3.1.1
+      '@vitest/runner': 3.1.1
+      '@vitest/snapshot': 3.1.1
+      '@vitest/spy': 3.1.1
+      '@vitest/utils': 3.1.1
+      chai: 5.2.0
+      debug: 4.4.0
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 6.3.1(@types/node@20.17.31)
+      vite-node: 3.1.1(@types/node@20.17.31)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    dev: true
+
   /vitest@3.1.1(@types/debug@4.1.8)(@types/node@20.17.31):
     resolution: {integrity: sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -26563,7 +26692,3 @@ packages:
   /zod@3.23.5:
     resolution: {integrity: sha512-fkwiq0VIQTksNNA131rDOsVJcns0pfVUjHzLrNBiF/O/Xxb5lQyEXkhZWcJ7npWsYlvs+h0jFWXXy4X46Em1JA==}
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Overview

Task: #6360 

When the `precinctScanEnableBallotAuditIds` system setting is turned on, VxScan will:
- Generate a random secret key on configure and store it in the db
- Encrypt ballot audit IDs from scanned ballot metadata and add them to the CVR

This PR also adds a script to decrypt the ballot audit IDs for all of the CVRs in an export directory, copying them into a new directory and renaming each CVR JSON file with the decrypted audit ID for easy reference during an audit.

## Demo Video or Screenshot
Example encrypted ballot audit ID in a CVR
<img width="485" alt="Screenshot 2025-05-15 at 2 51 35 PM" src="https://github.com/user-attachments/assets/050c134d-aa9c-4dc3-83a8-5fae33107952" />

Example decryption script output from a CVR export with ballots with audit IDs 1, 2, and 3
<img width="255" alt="Screenshot 2025-05-15 at 2 51 02 PM" src="https://github.com/user-attachments/assets/ae929489-d0d0-4d4b-9649-2af1139a571b" />


## Testing Plan
- Manual end to end testing
- Added new automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
