### PR TITLE
VxScan: Button for election manager to save ballot audit ID secret key to USB drive

### DIFF
--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -69,6 +69,8 @@ import {
 } from './util/diagnostics';
 import { saveReadinessReport } from './printing/readiness_report';
 
+export const BALLOT_AUDIT_ID_FILE_NAME = 'ballot-audit-id-secret-key.txt';
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function buildApi({
   auth,
@@ -522,10 +524,9 @@ export function buildApi({
         usbDrive,
         allowedExportPatterns: SCAN_ALLOWED_EXPORT_PATTERNS,
       });
-      const fileName = 'ballot-audit-id-secret-key.txt';
       const exportResult = await exporter.exportDataToUsbDrive(
         '.',
-        fileName,
+        BALLOT_AUDIT_ID_FILE_NAME,
         ballotAuditIdSecretKey
       );
 
@@ -533,7 +534,7 @@ export function buildApi({
         await logger.logAsCurrentRole(LogEventId.FileSaved, {
           message: `User saved the ballot audit ID secret key to a USB drive.`,
           fileType: 'ballotAuditIdSecretKey',
-          fileName,
+          fileName: BALLOT_AUDIT_ID_FILE_NAME,
           disposition: 'success',
         });
       } else {

--- a/apps/scan/frontend/src/api.ts
+++ b/apps/scan/frontend/src/api.ts
@@ -518,4 +518,11 @@ export const saveReadinessReport = {
   },
 } as const;
 
+export const saveBallotAuditIdSecretKey = {
+  useMutation() {
+    const apiClient = useApiClient();
+    return useMutation(apiClient.saveBallotAuditIdSecretKey);
+  },
+} as const;
+
 export const systemCallApi = createSystemCallApi(useApiClient);

--- a/apps/scan/frontend/src/components/save_ballot_audit_id_secret_key_button.tsx
+++ b/apps/scan/frontend/src/components/save_ballot_audit_id_secret_key_button.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Button, Modal, P } from '@votingworks/ui';
+import { saveBallotAuditIdSecretKey } from '../api';
+
+export function SaveBallotAuditIdSecretKeyButton(): JSX.Element {
+  const saveBallotAuditIdSecretKeyMutation =
+    saveBallotAuditIdSecretKey.useMutation();
+
+  function onClose() {
+    saveBallotAuditIdSecretKeyMutation.reset();
+  }
+
+  const result = saveBallotAuditIdSecretKeyMutation.data;
+
+  return (
+    <React.Fragment>
+      <Button
+        disabled={saveBallotAuditIdSecretKeyMutation.isLoading}
+        onPress={() => saveBallotAuditIdSecretKeyMutation.mutate()}
+      >
+        Save Ballot Audit ID Secret Key
+      </Button>
+      {result?.isOk() && (
+        <Modal
+          title="Ballot Audit ID Secret Key Saved"
+          content={
+            <P>
+              The ballot audit ID secret key has been saved on the inserted USB
+              drive.
+            </P>
+          }
+          onOverlayClick={onClose}
+          actions={<Button onPress={onClose}>Close</Button>}
+        />
+      )}
+      {result?.isErr() && (
+        <Modal
+          title="Failed to Save Ballot Audit ID Secret Key"
+          content={<P>{result.err().message}</P>}
+          onOverlayClick={onClose}
+          actions={<Button onPress={onClose}>Close</Button>}
+        />
+      )}
+    </React.Fragment>
+  );
+}

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -40,6 +40,7 @@ import {
 } from '../api';
 import { ElectionManagerPrinterTabContent } from '../components/printer_management/election_manager_printer_tab_content';
 import { DiagnosticsScreen } from './diagnostics_screen';
+import { SaveBallotAuditIdSecretKeyButton } from '../components/save_ballot_audit_id_secret_key_button';
 
 const TabPanel = styled.div`
   display: flex;
@@ -105,6 +106,7 @@ export function ElectionManagerScreen({
     isSoundMuted,
     isDoubleFeedDetectionDisabled,
     isContinuousExportEnabled,
+    systemSettings,
   } = configQuery.data;
   const { pollsState } = pollsInfoQuery.data;
   const printerStatus = printerStatusQuery.data;
@@ -205,6 +207,9 @@ export function ElectionManagerScreen({
       >
         {isContinuousExportEnabled ? 'Pause' : 'Resume'} Continuous CVR Export
       </Button>{' '}
+      {systemSettings.precinctScanEnableBallotAuditIds && (
+        <SaveBallotAuditIdSecretKeyButton />
+      )}
       <ExportLogsButton usbDriveStatus={usbDrive} />
     </React.Fragment>
   );

--- a/libs/auth/scripts/src/decrypt_cvr_ballot_audit_ids.ts
+++ b/libs/auth/scripts/src/decrypt_cvr_ballot_audit_ids.ts
@@ -14,11 +14,11 @@ import {
 import { decryptAes256 } from '../../src/cryptography';
 
 const usageMessage =
-  'Usage: decrypt-cvr-ballot-audit-ids input-cvr-directory secret-key output-directory';
+  'Usage: decrypt-cvr-ballot-audit-ids input-cvr-directory secret-key-file output-directory';
 
 interface CommandLineArgs {
   inputCvrDirectory: string;
-  secretKey: string;
+  secretKeyFile: string;
   outputDirectory: string;
 }
 
@@ -29,18 +29,20 @@ function parseCommandLineArgs(args: readonly string[]): CommandLineArgs {
   }
   return {
     inputCvrDirectory: assertDefined(args[0]),
-    secretKey: assertDefined(args[1]),
+    secretKeyFile: assertDefined(args[1]),
     outputDirectory: assertDefined(args[2]),
   };
 }
 
 async function decryptCvrBallotAuditIds({
   inputCvrDirectory,
-  secretKey,
+  secretKeyFile,
   outputDirectory,
 }: CommandLineArgs): Promise<void> {
   const cvrIds = await getExportedCastVoteRecordIds(inputCvrDirectory);
   assert(cvrIds.length > 0, 'No CVR IDs found in the input directory');
+
+  const secretKey = await fs.readFile(secretKeyFile, 'utf-8');
 
   await fs.mkdir(outputDirectory, { recursive: true });
 


### PR DESCRIPTION
## Overview

Task: #6360 

Adds a button the VxScan election manager screen (under the CVRs and Logs tab) to save the ballot audit ID secret key to the inserted USB drive. Only shows the button if the system settings flag for this feature is enabled. Exports the key to a plain text file at the root directory of the USB drive.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/f94d50b5-9a42-485d-bec8-78c3af0efbd4



## Testing Plan
- Manual test
- Automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
