### PR TITLE
apps/admin: Bump timeout for flaky integration test

### DIFF
--- a/apps/admin/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/admin/integration-testing/e2e/screenshots.spec.ts
@@ -371,6 +371,7 @@ async function insertUsbDriveWithCvrs({
 }
 
 test('results', async ({ page }) => {
+  test.setTimeout(70_000);
   const usbHandler = getMockFileUsbDriveHandler();
   const printerHandler = getMockFilePrinterHandler();
   printerHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);


### PR DESCRIPTION
## Overview

I've noticed this test timeout somewhat often and just saw it fail on main. When I last worked on it I noticed it silently retrying sometimes increasing ci times, and seems like it's often enough that we should bump it. It's pretty comprehensive (lots of adjudications, reports) so it feels reasonable to give it this longer timeout.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
