### PR TITLE
Remove ballot audit ID plaintext from HMPB footer

### DIFF
--- a/libs/ballot-interpreter/src/interpret_vx_hmpb.test.ts
+++ b/libs/ballot-interpreter/src/interpret_vx_hmpb.test.ts
@@ -686,8 +686,6 @@ test('Ballot audit IDs', async () => {
       'vxf'
     )
   ).ballotDocuments[0]!;
-  const content = await ballotDocument.getContent();
-  expect(content).toContain('Ballot: <b>test-ballot-audit-id</b>');
   const pdf = await ballotDocument.renderToPdf();
   const images = asSheet(await pdfToPageImages(pdf).toArray());
   expect(images).toHaveLength(2);

--- a/libs/hmpb/src/ballot_components.tsx
+++ b/libs/hmpb/src/ballot_components.tsx
@@ -505,7 +505,6 @@ export function Footer({
   pageNumber,
   totalPages,
   colorTint,
-  ballotAuditId,
 }: {
   election: Election;
   ballotStyleId: BallotStyleId;
@@ -513,7 +512,6 @@ export function Footer({
   pageNumber: number;
   totalPages?: number;
   colorTint?: ColorTint;
-  ballotAuditId?: string;
 }): JSX.Element {
   const precinct = assertDefined(getPrecinctById({ election, precinctId }));
   const ballotStyle = assertDefined(
@@ -618,11 +616,6 @@ export function Footer({
               <BallotHashSlot />
             </b>
           </span>
-          {ballotAuditId && (
-            <span>
-              Ballot: <b>{ballotAuditId}</b>
-            </span>
-          )}
           <span>
             Ballot Style: <b>{ballotStyle.groupId}</b>
           </span>

--- a/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
@@ -138,7 +138,6 @@ function BallotPageFrame({
   totalPages,
   children,
   watermark,
-  ballotAuditId,
 }: BaseBallotProps & {
   pageNumber: number;
   totalPages?: number;
@@ -198,7 +197,6 @@ function BallotPageFrame({
               precinctId={precinctId}
               pageNumber={pageNumber}
               totalPages={totalPages}
-              ballotAuditId={ballotAuditId}
             />
           </div>
         </TimingMarkGrid>


### PR DESCRIPTION
## Overview

Task: #6360 

Removes the printed ballot audit ID from HMPBs to improve privacy. It will still be encoded in the QR code metadata.

## Demo Video or Screenshot
N/A

## Testing Plan
Existing automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
