### PR TITLE
fix(scan): make the HTA image filenames safe for FAT32

### DIFF
--- a/apps/scan/backend/src/electrical_testing/tasks/print_and_scan_task.ts
+++ b/apps/scan/backend/src/electrical_testing/tasks/print_and_scan_task.ts
@@ -76,7 +76,9 @@ export async function runPrintAndScanTask({
         usbDriveStatus.status === 'mounted'
           ? join(usbDriveStatus.mountPoint, 'ballot-images')
           : workspace.ballotImagesPath;
-      const basename = `electrical-testing-${lastScanTime.toISO()}`;
+      const basename = `electrical-testing-${lastScanTime
+        .toISO()
+        .replaceAll(':', '-')}`;
 
       await mkdir(basedir, { recursive: true });
       await saveSheetImages({


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6463

FAT32 doesn't like colons in filenames. This replaces them with dashes.

## Demo Video or Screenshot
n/a

## Testing Plan
- [x] Test in VM with fake USB drive and observe that the filenames no longer have colons.
- [x] Test in VM with real USB drive formatted with FAT32.
