### PR TITLE
fix(scan): scan up to 22" ballots in HWTA

### DIFF
--- a/apps/scan/backend/src/electrical_testing/simple_scanner_client.ts
+++ b/apps/scan/backend/src/electrical_testing/simple_scanner_client.ts
@@ -42,7 +42,7 @@ export function createSimpleScannerClient(): SimpleScannerClient {
         await client.enableScanning({
           bitonalThreshold: 75,
           doubleFeedDetectionEnabled: false,
-          paperLengthInches: 11,
+          paperLengthInches: 22,
         })
       ).unsafeUnwrap();
     },


### PR DESCRIPTION
## Overview

Closes #6462

Currently we're limited to testing ballots that are 11" long. This unblocks testing longer ballots, but introduces the possibility that we double-feed ballots in testing. We can overcome this later by adding a configuration setting for the ballot length.

## Demo Video or Screenshot
n/a

## Testing Plan
- [x] Test with 11" ballot.
- [x] Test with 14" ballot.
- [x] Test with 22" ballot.