### PR TITLE
chore(eslint): remove outdated overrides

### DIFF
--- a/apps/central-scan/backend/.eslintrc.json
+++ b/apps/central-scan/backend/.eslintrc.json
@@ -10,15 +10,6 @@
       "rules": {
         "no-console": "off"
       }
-    },
-    // This file causes this rule to crash on private constructors.
-    // Started happening after TypeScript upgrade to v4.6. I was not able to
-    // find an issue on the GitHub repo for @typescript-eslint/eslint-plugin.
-    {
-      "files": ["src/db_client.ts", "src/store.ts"],
-      "rules": {
-        "@typescript-eslint/prefer-readonly": "off"
-      }
     }
   ]
 }

--- a/apps/mark-scan/backend/.eslintrc.json
+++ b/apps/mark-scan/backend/.eslintrc.json
@@ -3,16 +3,5 @@
   "rules": {
     // Disable JSDOC rule as code is self-documenting.
     "vx/gts-jsdoc": "off"
-  },
-  "overrides": [
-    // This file causes this rule to crash on private constructors.
-    // Started happening after TypeScript upgrade to v4.6. I was not able to
-    // find an issue on the GitHub repo for @typescript-eslint/eslint-plugin.
-    {
-      "files": ["src/db_client.ts", "src/store.ts"],
-      "rules": {
-        "@typescript-eslint/prefer-readonly": "off"
-      }
-    }
-  ]
+  }
 }

--- a/apps/mark/backend/.eslintrc.json
+++ b/apps/mark/backend/.eslintrc.json
@@ -3,16 +3,5 @@
   "rules": {
     // Disable JSDOC rule as code is self-documenting.
     "vx/gts-jsdoc": "off"
-  },
-  "overrides": [
-    // This file causes this rule to crash on private constructors.
-    // Started happening after TypeScript upgrade to v4.6. I was not able to
-    // find an issue on the GitHub repo for @typescript-eslint/eslint-plugin.
-    {
-      "files": ["src/db_client.ts", "src/store.ts"],
-      "rules": {
-        "@typescript-eslint/prefer-readonly": "off"
-      }
-    }
-  ]
+  }
 }

--- a/apps/scan/backend/.eslintrc.json
+++ b/apps/scan/backend/.eslintrc.json
@@ -10,15 +10,6 @@
       "rules": {
         "no-console": "off"
       }
-    },
-    // This file causes this rule to crash on private constructors.
-    // Started happening after TypeScript upgrade to v4.6. I was not able to
-    // find an issue on the GitHub repo for @typescript-eslint/eslint-plugin.
-    {
-      "files": ["src/db_client.ts", "src/store.ts"],
-      "rules": {
-        "@typescript-eslint/prefer-readonly": "off"
-      }
     }
   ]
 }


### PR DESCRIPTION
## Overview
These were added due to a bug or configuration issue with an older version of TypeScript and/or `@typescript-eslint/eslint-plugin`. Removing them seems to have no effect on linting, so I'm removing them.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated linting.