### PR TITLE
[VxScan] Enable screen reader audio for voter-facing screens

### DIFF
--- a/apps/scan/frontend/src/api_machine_configuration.test.tsx
+++ b/apps/scan/frontend/src/api_machine_configuration.test.tsx
@@ -22,7 +22,7 @@ function QueryWrapper(props: { children: React.ReactNode }) {
   const { children } = props;
 
   return (
-    <ApiProvider queryClient={queryClient} apiClient={mockBackendApi}>
+    <ApiProvider queryClient={queryClient} apiClient={mockBackendApi} noAudio>
       {children}
     </ApiProvider>
   );

--- a/apps/scan/frontend/src/api_provider.tsx
+++ b/apps/scan/frontend/src/api_provider.tsx
@@ -17,11 +17,13 @@ export function ApiProvider({
   apiClient,
   enableStringTranslation,
   children,
+  noAudio,
 }: {
   queryClient?: QueryClient;
   apiClient: ApiClient;
   enableStringTranslation?: boolean;
   children: React.ReactNode;
+  noAudio?: boolean;
 }): JSX.Element {
   return (
     <ApiClientContext.Provider value={apiClient}>
@@ -30,7 +32,7 @@ export function ApiProvider({
           <UiStringsContextProvider
             api={uiStringsApi}
             disabled={!enableStringTranslation}
-            noAudio
+            noAudio={noAudio}
           >
             {children}
           </UiStringsContextProvider>

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -39,7 +39,7 @@ const pauseSessionMock = vi.fn();
 const resumeSessionMock = vi.fn();
 
 function renderApp(props: Partial<AppProps> = {}) {
-  render(<App apiClient={apiMock.mockApiClient} {...props} />);
+  render(<App apiClient={apiMock.mockApiClient} noAudio {...props} />);
 }
 
 beforeEach(() => {

--- a/apps/scan/frontend/src/app.tsx
+++ b/apps/scan/frontend/src/app.tsx
@@ -16,6 +16,7 @@ export interface AppProps {
   apiClient?: ApiClient;
   queryClient?: QueryClient;
   enableStringTranslation?: boolean;
+  noAudio?: boolean;
 }
 
 const RESTART_MESSAGE = 'Ask a poll worker to restart the scanner.';
@@ -25,6 +26,7 @@ export function App({
   apiClient = createApiClient(),
   queryClient = createQueryClient(),
   enableStringTranslation,
+  noAudio,
 }: AppProps): JSX.Element {
   return (
     <ScanAppBase>
@@ -34,6 +36,7 @@ export function App({
             queryClient={queryClient}
             apiClient={apiClient}
             enableStringTranslation={enableStringTranslation}
+            noAudio={noAudio}
           >
             <Route path={Paths.VOTER_SETTINGS} exact>
               <VoterSettingsScreen />

--- a/apps/scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/scan/frontend/src/app_unhappy_paths.test.tsx
@@ -23,7 +23,7 @@ const electionGeneralDefinition = readElectionGeneralDefinition();
 let apiMock: ApiMock;
 
 function renderApp(props: Partial<AppProps> = {}) {
-  render(<App apiClient={apiMock.mockApiClient} {...props} />);
+  render(<App apiClient={apiMock.mockApiClient} noAudio {...props} />);
 }
 
 beforeEach(() => {

--- a/apps/scan/frontend/src/components/layout.tsx
+++ b/apps/scan/frontend/src/components/layout.tsx
@@ -8,6 +8,8 @@ import {
   H1,
   LanguageSettingsButton,
   LanguageSettingsScreen,
+  ReadOnLoad,
+  AudioOnly,
 } from '@votingworks/ui';
 import styled, { DefaultTheme, ThemeContext } from 'styled-components';
 import { SizeMode } from '@votingworks/types';
@@ -170,9 +172,16 @@ export function Screen(props: ScreenProps): JSX.Element | null {
         <TitleContainer>{title && <H1>{title}</H1>}</TitleContainer>
         {!voterFacing && ballotCountElement}
       </TitleBar>
-      <Main centerChild={centerContent} padded={padded}>
-        {children}
-      </Main>
+      {voterFacing ? (
+        <ReadOnLoad as={Main} centerChild={centerContent} padded={padded}>
+          {title && <AudioOnly>{title}</AudioOnly>}
+          {children}
+        </ReadOnLoad>
+      ) : (
+        <Main centerChild={centerContent} padded={padded}>
+          {children}
+        </Main>
+      )}
       {actionButtons && <ButtonBar>{actionButtons}</ButtonBar>}
       {!hideInfoBar && (
         <ElectionInfoBar

--- a/apps/scan/frontend/src/components/scanned_ballot_count.tsx
+++ b/apps/scan/frontend/src/components/scanned_ballot_count.tsx
@@ -1,4 +1,4 @@
-import { BigMetric, appStrings } from '@votingworks/ui';
+import { BigMetric, TextOnly, appStrings } from '@votingworks/ui';
 import styled from 'styled-components';
 
 interface Props {
@@ -12,11 +12,18 @@ const BallotsScannedContainer = styled.div`
 export function ScannedBallotCount({ count }: Props): JSX.Element {
   return (
     <BallotsScannedContainer>
-      <BigMetric
-        label={appStrings.labelNumSheetsScanned()}
-        value={count}
-        valueElementTestId="ballot-count"
-      />
+      {/*
+       * The screen reader currently only supports numbers up to ~130. Bumping
+       * that up into the thousands would unnecessarily bloat the audio package.
+       * Not useful for this UI element to be read out, so disabling audio here.
+       */}
+      <TextOnly>
+        <BigMetric
+          label={appStrings.labelNumSheetsScanned()}
+          value={count}
+          valueElementTestId="ballot-count"
+        />
+      </TextOnly>
     </BallotsScannedContainer>
   );
 }

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -372,7 +372,9 @@ export function provideApi(
 ): JSX.Element {
   return (
     <TestErrorBoundary>
-      <ApiProvider apiClient={apiMock.mockApiClient}>{children}</ApiProvider>
+      <ApiProvider apiClient={apiMock.mockApiClient} noAudio>
+        {children}
+      </ApiProvider>
     </TestErrorBoundary>
   );
 }

--- a/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
@@ -7,10 +7,10 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
     <div>
       <div
         aria-hidden="true"
-        class="sc-fPXMVe dwMYLV"
+        class="sc-gFqAkR gWCgPx"
       >
         <div
-          class="sc-gFqAkR daeioy"
+          class="sc-ikkxIA cakAEP"
           data-testid="header"
         >
           <img
@@ -58,7 +58,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
             </p>
           </div>
           <div
-            class="sc-ikkxIA dwzXnI"
+            class="sc-dAbbOL fjIaoX"
           >
             <div>
               <div>
@@ -111,19 +111,19 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
           </div>
         </div>
         <div
-          class="sc-dAbbOL fduIjL"
+          class="sc-feUZmu jGERvx"
         >
           <div
-            class="sc-feUZmu kjoAph"
+            class="sc-fUnMCh ddLMsu"
           >
             <div
-              class="sc-fUnMCh cPTFGw"
+              class="sc-hzhJZQ eTZHeg"
             >
               <div
-                class="sc-hzhJZQ hdQGKH"
+                class="sc-fHjqPf fbZbL"
               >
                 <span
-                  class="sc-bXCLTC ieXDgY"
+                  class="sc-jsJBEP jNqJTi"
                 >
                   <span>
                     President
@@ -131,7 +131,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 </span>
               </div>
               <span
-                class="sc-fHjqPf dAgyJG"
+                class="sc-hmdomO iYDVdN"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -145,13 +145,13 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
               </span>
             </div>
             <div
-              class="sc-fUnMCh cPTFGw"
+              class="sc-hzhJZQ eTZHeg"
             >
               <div
-                class="sc-hzhJZQ hdQGKH"
+                class="sc-fHjqPf fbZbL"
               >
                 <span
-                  class="sc-bXCLTC ieXDgY"
+                  class="sc-jsJBEP jNqJTi"
                 >
                   <span>
                     Senate 
@@ -159,7 +159,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 </span>
               </div>
               <span
-                class="sc-fHjqPf dAgyJG"
+                class="sc-hmdomO iYDVdN"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -173,13 +173,13 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
               </span>
             </div>
             <div
-              class="sc-fUnMCh cPTFGw"
+              class="sc-hzhJZQ eTZHeg"
             >
               <div
-                class="sc-hzhJZQ hdQGKH"
+                class="sc-fHjqPf fbZbL"
               >
                 <span
-                  class="sc-bXCLTC ieXDgY"
+                  class="sc-jsJBEP jNqJTi"
                 >
                   <span>
                     1st Congressional District
@@ -187,7 +187,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 </span>
               </div>
               <span
-                class="sc-fHjqPf dAgyJG"
+                class="sc-hmdomO iYDVdN"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -201,13 +201,13 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
               </span>
             </div>
             <div
-              class="sc-fUnMCh cPTFGw"
+              class="sc-hzhJZQ eTZHeg"
             >
               <div
-                class="sc-hzhJZQ hdQGKH"
+                class="sc-fHjqPf fbZbL"
               >
                 <span
-                  class="sc-bXCLTC ieXDgY"
+                  class="sc-jsJBEP jNqJTi"
                 >
                   <span>
                     Supreme Court District 3(Northern) Position 3
@@ -215,7 +215,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 </span>
               </div>
               <span
-                class="sc-fHjqPf dAgyJG"
+                class="sc-hmdomO iYDVdN"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -229,13 +229,13 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
               </span>
             </div>
             <div
-              class="sc-fUnMCh cPTFGw"
+              class="sc-hzhJZQ eTZHeg"
             >
               <div
-                class="sc-hzhJZQ hdQGKH"
+                class="sc-fHjqPf fbZbL"
               >
                 <span
-                  class="sc-bXCLTC ieXDgY"
+                  class="sc-jsJBEP jNqJTi"
                 >
                   <span>
                     Election Commissioner 04
@@ -243,7 +243,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 </span>
               </div>
               <span
-                class="sc-fHjqPf dAgyJG"
+                class="sc-hmdomO iYDVdN"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -257,13 +257,13 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
               </span>
             </div>
             <div
-              class="sc-fUnMCh cPTFGw"
+              class="sc-hzhJZQ eTZHeg"
             >
               <div
-                class="sc-hzhJZQ hdQGKH"
+                class="sc-fHjqPf fbZbL"
               >
                 <span
-                  class="sc-bXCLTC ieXDgY"
+                  class="sc-jsJBEP jNqJTi"
                 >
                   <span>
                     Ballot Measure 2
@@ -272,7 +272,7 @@ House Concurrent Resolution No. 47
                 </span>
               </div>
               <span
-                class="sc-fHjqPf dAgyJG"
+                class="sc-hmdomO iYDVdN"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -286,13 +286,13 @@ House Concurrent Resolution No. 47
               </span>
             </div>
             <div
-              class="sc-fUnMCh cPTFGw"
+              class="sc-hzhJZQ eTZHeg"
             >
               <div
-                class="sc-hzhJZQ hdQGKH"
+                class="sc-fHjqPf fbZbL"
               >
                 <span
-                  class="sc-bXCLTC ieXDgY"
+                  class="sc-jsJBEP jNqJTi"
                 >
                   <span>
                     Ballot Measure 3
@@ -301,7 +301,7 @@ House Bill 1796 - Flag Referendum
                 </span>
               </div>
               <span
-                class="sc-fHjqPf dAgyJG"
+                class="sc-hmdomO iYDVdN"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -315,13 +315,13 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <div
-              class="sc-fUnMCh cPTFGw"
+              class="sc-hzhJZQ eTZHeg"
             >
               <div
-                class="sc-hzhJZQ hdQGKH"
+                class="sc-fHjqPf fbZbL"
               >
                 <span
-                  class="sc-bXCLTC ieXDgY"
+                  class="sc-jsJBEP jNqJTi"
                 >
                   <span>
                     Ballot Measure 1
@@ -329,7 +329,7 @@ House Bill 1796 - Flag Referendum
                 </span>
               </div>
               <span
-                class="sc-fHjqPf dAgyJG"
+                class="sc-hmdomO iYDVdN"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -343,13 +343,13 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <div
-              class="sc-fUnMCh cPTFGw"
+              class="sc-hzhJZQ eTZHeg"
             >
               <div
-                class="sc-hzhJZQ hdQGKH"
+                class="sc-fHjqPf fbZbL"
               >
                 <span
-                  class="sc-bXCLTC ieXDgY"
+                  class="sc-jsJBEP jNqJTi"
                 >
                   <span>
                     Ballot Measure 1
@@ -357,7 +357,7 @@ House Bill 1796 - Flag Referendum
                 </span>
               </div>
               <span
-                class="sc-fHjqPf dAgyJG"
+                class="sc-hmdomO iYDVdN"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -378,10 +378,10 @@ House Bill 1796 - Flag Referendum
   "container": <div>
     <div
       aria-hidden="true"
-      class="sc-fPXMVe dwMYLV"
+      class="sc-gFqAkR gWCgPx"
     >
       <div
-        class="sc-gFqAkR daeioy"
+        class="sc-ikkxIA cakAEP"
         data-testid="header"
       >
         <img
@@ -429,7 +429,7 @@ House Bill 1796 - Flag Referendum
           </p>
         </div>
         <div
-          class="sc-ikkxIA dwzXnI"
+          class="sc-dAbbOL fjIaoX"
         >
           <div>
             <div>
@@ -482,19 +482,19 @@ House Bill 1796 - Flag Referendum
         </div>
       </div>
       <div
-        class="sc-dAbbOL fduIjL"
+        class="sc-feUZmu jGERvx"
       >
         <div
-          class="sc-feUZmu kjoAph"
+          class="sc-fUnMCh ddLMsu"
         >
           <div
-            class="sc-fUnMCh cPTFGw"
+            class="sc-hzhJZQ eTZHeg"
           >
             <div
-              class="sc-hzhJZQ hdQGKH"
+              class="sc-fHjqPf fbZbL"
             >
               <span
-                class="sc-bXCLTC ieXDgY"
+                class="sc-jsJBEP jNqJTi"
               >
                 <span>
                   President
@@ -502,7 +502,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-fHjqPf dAgyJG"
+              class="sc-hmdomO iYDVdN"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -516,13 +516,13 @@ House Bill 1796 - Flag Referendum
             </span>
           </div>
           <div
-            class="sc-fUnMCh cPTFGw"
+            class="sc-hzhJZQ eTZHeg"
           >
             <div
-              class="sc-hzhJZQ hdQGKH"
+              class="sc-fHjqPf fbZbL"
             >
               <span
-                class="sc-bXCLTC ieXDgY"
+                class="sc-jsJBEP jNqJTi"
               >
                 <span>
                   Senate 
@@ -530,7 +530,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-fHjqPf dAgyJG"
+              class="sc-hmdomO iYDVdN"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -544,13 +544,13 @@ House Bill 1796 - Flag Referendum
             </span>
           </div>
           <div
-            class="sc-fUnMCh cPTFGw"
+            class="sc-hzhJZQ eTZHeg"
           >
             <div
-              class="sc-hzhJZQ hdQGKH"
+              class="sc-fHjqPf fbZbL"
             >
               <span
-                class="sc-bXCLTC ieXDgY"
+                class="sc-jsJBEP jNqJTi"
               >
                 <span>
                   1st Congressional District
@@ -558,7 +558,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-fHjqPf dAgyJG"
+              class="sc-hmdomO iYDVdN"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -572,13 +572,13 @@ House Bill 1796 - Flag Referendum
             </span>
           </div>
           <div
-            class="sc-fUnMCh cPTFGw"
+            class="sc-hzhJZQ eTZHeg"
           >
             <div
-              class="sc-hzhJZQ hdQGKH"
+              class="sc-fHjqPf fbZbL"
             >
               <span
-                class="sc-bXCLTC ieXDgY"
+                class="sc-jsJBEP jNqJTi"
               >
                 <span>
                   Supreme Court District 3(Northern) Position 3
@@ -586,7 +586,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-fHjqPf dAgyJG"
+              class="sc-hmdomO iYDVdN"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -600,13 +600,13 @@ House Bill 1796 - Flag Referendum
             </span>
           </div>
           <div
-            class="sc-fUnMCh cPTFGw"
+            class="sc-hzhJZQ eTZHeg"
           >
             <div
-              class="sc-hzhJZQ hdQGKH"
+              class="sc-fHjqPf fbZbL"
             >
               <span
-                class="sc-bXCLTC ieXDgY"
+                class="sc-jsJBEP jNqJTi"
               >
                 <span>
                   Election Commissioner 04
@@ -614,7 +614,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-fHjqPf dAgyJG"
+              class="sc-hmdomO iYDVdN"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -628,13 +628,13 @@ House Bill 1796 - Flag Referendum
             </span>
           </div>
           <div
-            class="sc-fUnMCh cPTFGw"
+            class="sc-hzhJZQ eTZHeg"
           >
             <div
-              class="sc-hzhJZQ hdQGKH"
+              class="sc-fHjqPf fbZbL"
             >
               <span
-                class="sc-bXCLTC ieXDgY"
+                class="sc-jsJBEP jNqJTi"
               >
                 <span>
                   Ballot Measure 2
@@ -643,7 +643,7 @@ House Concurrent Resolution No. 47
               </span>
             </div>
             <span
-              class="sc-fHjqPf dAgyJG"
+              class="sc-hmdomO iYDVdN"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -657,13 +657,13 @@ House Concurrent Resolution No. 47
             </span>
           </div>
           <div
-            class="sc-fUnMCh cPTFGw"
+            class="sc-hzhJZQ eTZHeg"
           >
             <div
-              class="sc-hzhJZQ hdQGKH"
+              class="sc-fHjqPf fbZbL"
             >
               <span
-                class="sc-bXCLTC ieXDgY"
+                class="sc-jsJBEP jNqJTi"
               >
                 <span>
                   Ballot Measure 3
@@ -672,7 +672,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-fHjqPf dAgyJG"
+              class="sc-hmdomO iYDVdN"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -686,13 +686,13 @@ House Bill 1796 - Flag Referendum
             </span>
           </div>
           <div
-            class="sc-fUnMCh cPTFGw"
+            class="sc-hzhJZQ eTZHeg"
           >
             <div
-              class="sc-hzhJZQ hdQGKH"
+              class="sc-fHjqPf fbZbL"
             >
               <span
-                class="sc-bXCLTC ieXDgY"
+                class="sc-jsJBEP jNqJTi"
               >
                 <span>
                   Ballot Measure 1
@@ -700,7 +700,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-fHjqPf dAgyJG"
+              class="sc-hmdomO iYDVdN"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -714,13 +714,13 @@ House Bill 1796 - Flag Referendum
             </span>
           </div>
           <div
-            class="sc-fUnMCh cPTFGw"
+            class="sc-hzhJZQ eTZHeg"
           >
             <div
-              class="sc-hzhJZQ hdQGKH"
+              class="sc-fHjqPf fbZbL"
             >
               <span
-                class="sc-bXCLTC ieXDgY"
+                class="sc-jsJBEP jNqJTi"
               >
                 <span>
                   Ballot Measure 1
@@ -728,7 +728,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-fHjqPf dAgyJG"
+              class="sc-hmdomO iYDVdN"
             >
               <span
                 class="sc-gEvEer hUnYwC"

--- a/libs/ui/src/__snapshots__/modal.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/modal.test.tsx.snap
@@ -4,13 +4,13 @@ exports[`Modal > can configure a wider max width 1`] = `
 <div
   aria-label="Alert Modal"
   aria-modal="true"
-  class="sc-dhKdcB iNMtHB ReactModal__Content _"
+  class="sc-kpDqfm cXNhoW ReactModal__Content _"
   data-testid="modal"
   role="alertdialog"
   tabindex="-1"
 >
   <div
-    class="sc-jlZhew djrzaJ"
+    class="sc-cwHptR xojiV"
   >
     Do you want to do the thing?
   </div>
@@ -21,13 +21,13 @@ exports[`Modal > can configure fullscreen 1`] = `
 <div
   aria-label="Alert Modal"
   aria-modal="true"
-  class="sc-dhKdcB gkSgdV ReactModal__Content _"
+  class="sc-kpDqfm bpMVuS ReactModal__Content _"
   data-testid="modal"
   role="alertdialog"
   tabindex="-1"
 >
   <div
-    class="sc-jlZhew hIjcWi"
+    class="sc-cwHptR PBWES"
   >
     Do you want to do the thing?
   </div>

--- a/libs/ui/src/ui_strings/read_on_load.tsx
+++ b/libs/ui/src/ui_strings/read_on_load.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
+import styled from 'styled-components';
 import { useAudioContext } from './audio_context';
 
-export interface ReadOnLoadProps {
-  children: React.ReactNode;
-  className?: string;
-}
+const Container = styled.div`
+  /* stylelint-disable no-empty-source */
+`;
+
+export type ReadOnLoadProps = React.ComponentProps<typeof Container>;
 
 /**
  * Returns the react-router location state if a react-router context exists,
@@ -35,7 +37,7 @@ function useLocationIfAvailable() {
  * content within the last `ReadOnLoad` instance.
  */
 export function ReadOnLoad(props: ReadOnLoadProps): JSX.Element {
-  const { children, className } = props;
+  const { as = 'div', children, className, ...rest } = props;
 
   const location = useLocationIfAvailable();
   const currentUrl = location?.pathname;
@@ -68,8 +70,8 @@ export function ReadOnLoad(props: ReadOnLoadProps): JSX.Element {
   }, [currentUrl, isInAudioContext]);
 
   return (
-    <div className={className} ref={containerRef}>
+    <Container {...rest} as={as} className={className} ref={containerRef}>
       {children}
-    </div>
+    </Container>
   );
 }

--- a/libs/ui/src/ui_strings/with_alt_audio.tsx
+++ b/libs/ui/src/ui_strings/with_alt_audio.tsx
@@ -15,7 +15,9 @@ export interface WithAltAudioProps {
  * Renders the given {@link children} within an empty audio context, to exclude
  * them from screen reader audio playback.
  */
-function TextOnly(props: { children: React.ReactNode }): React.ReactNode {
+export function TextOnly(props: {
+  children: React.ReactNode;
+}): React.ReactNode {
   const { children } = props;
 
   return (


### PR DESCRIPTION
## Overview

https://github.com/votingworks/cert-discrepancies/issues/123

Enabling the screen reader for voter-facing app and election strings VxScan. Audio playback will be dependent on [headphones being plugged in](https://github.com/votingworks/vxsuite/blob/c44f5d2/libs/ui/src/ui_strings/audio_context.tsx#L100-L103) - headphone detection is done via [shell command](https://github.com/votingworks/vxsuite/blob/main/libs/backend/src/system_call/get_audio_info.ts) to pulse audio, which will need to be tested on a production machine to verify the configuration and output parsing used for VxMark are sufficient here.

Adding a `<ReadOnLoad>` to the shared `<Screen>` component for voter-facing instances to trigger audio whenever headphones are plugged in or a screen/modal transition happens. Might need to later tweak a few screens to guide the reader explicitly in (e.g. blur modal buttons on modal close to avoid replaying the audio).

## TODO
- Verify headphone detection on real machine
- Silence success/error chimes when headphones are plugged in, since they overlap with the screen reader)
- Clean up any rough edges as needed.

## Demo Video or Screenshot

### Mainline Flow

https://github.com/user-attachments/assets/0112839a-6c4f-4053-bffb-5b2caa62a809

### Error Screens

https://github.com/user-attachments/assets/61ecd638-bf92-4f36-8506-1c6df88dad21

## Testing Plan
- Existing tests for audio framework + manual for audio output.

## Checklist

<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
