### PR TITLE
fix(scan): recompute threshold after cropping

### DIFF
--- a/libs/ballot-interpreter/src/hmpb-rust/diagnostic.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/diagnostic.rs
@@ -14,6 +14,13 @@ use crate::{
 const FAIL_SCORE: f32 = 0.05;
 const CROP_BORDER_PIXELS: u32 = 20;
 
+/// The threshold computed by `otsu_level` might be unreasonbly high if the
+/// scanned image is mostly very white. This can lead to  identifying cells as
+/// overly dark that are actually just a slightly darker white/gray. Setting
+/// a high but not too high maximum white threshold should prevent this from
+/// happening.
+const MAX_WHITE_THRESHOLD: u8 = 200;
+
 fn generate_cells(
     left_start: u32,
     top_start: u32,
@@ -107,7 +114,8 @@ pub fn blank_paper(img: GrayImage, debug_path: Option<PathBuf>) -> bool {
         })
         .collect::<Vec<_>>();
 
-    let (passed_cells, failed_cells) = inspect_cells(&image, &cells, threshold);
+    let (passed_cells, failed_cells) =
+        inspect_cells(&image, &cells, threshold.min(MAX_WHITE_THRESHOLD));
 
     let debug = debug_path.map_or_else(ImageDebugWriter::disabled, |base| {
         ImageDebugWriter::new(base, image)

--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -270,9 +270,8 @@ const CROP_BORDERS_THRESHOLD_RATIO: f32 = 0.1;
 /// Return the image with the black border cropped off.
 #[must_use]
 pub fn crop_ballot_page_image_borders(mut image: GrayImage) -> Option<BallotImage> {
-    let threshold = otsu_level(&image);
     let border_inset =
-        find_scanned_document_inset(&image, threshold, CROP_BORDERS_THRESHOLD_RATIO)?;
+        find_scanned_document_inset(&image, otsu_level(&image), CROP_BORDERS_THRESHOLD_RATIO)?;
     let image = image
         .sub_image(
             border_inset.left,
@@ -282,6 +281,7 @@ pub fn crop_ballot_page_image_borders(mut image: GrayImage) -> Option<BallotImag
         )
         .to_image();
 
+    let threshold = otsu_level(&image);
     Some(BallotImage {
         image,
         threshold,

--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -281,7 +281,11 @@ pub fn crop_ballot_page_image_borders(mut image: GrayImage) -> Option<BallotImag
         )
         .to_image();
 
+    // Re-compute the threshold after cropping to ensure future
+    // re-interpretations based on the saved image are consistent with the
+    // initial one.
     let threshold = otsu_level(&image);
+
     Some(BallotImage {
         image,
         threshold,


### PR DESCRIPTION
## Overview

We want it to be the case that we can always reinterpret an image and get the same result as the initial interpretation. This may not have been the case before because we used the pre-cropping threshold (which should be lower or equal) to determine the threshold we use. With just the cropped image it is impossible to recover that pre-cropping threshold, so we cannot reinterpret in exactly the same way. This change fixes that by re-computing the threshold after cropping.

I had to set a maximum threshold for the diagnostic function because we're scanning white pages and the automatic threshold may end up being set fairly high. This is the nature of [Otsu's Method](https://en.wikipedia.org/wiki/Otsu%27s_method):

> This threshold is determined by minimizing intra-class intensity variance, or equivalently, by maximizing inter-class variance.

Setting a high-ish but still not incredibly high maximum should reduce this issue. Tagging @adghayes for a sanity check on this.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated tests.
