### PR TITLE
chore(vitest): use built-in `mergeConfig`

### DIFF
--- a/libs/eslint-plugin-vx/vitest.config.ts
+++ b/libs/eslint-plugin-vx/vitest.config.ts
@@ -6,7 +6,12 @@ export default defineConfig({
     setupFiles: ['tests/setupTests.ts'],
     coverage: {
       include: ['src/rules/*.ts'],
-      exclude: ['src/rules/index.ts'],
+      exclude: [
+        'src/rules/index.ts',
+        'src/index.ts',
+        'src/configs/*.ts',
+        'src/util/index.ts',
+      ],
       thresholds: {
         lines: 99,
         branches: 98,

--- a/libs/ui/vitest.config.ts
+++ b/libs/ui/vitest.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
         'src/printing_ballot_image.tsx',
         'src/rotate_card_image.tsx',
         'src/svg.tsx',
-        'src/tabbed_section/.*.tsx?',
+        'src/tabbed_section/*.tsx',
         'src/touch_text_input.tsx',
         'src/verify_ballot_image.tsx',
         'src/voter_contest_summary.tsx',

--- a/vitest.config.shared.mts
+++ b/vitest.config.shared.mts
@@ -23,31 +23,8 @@ export const base: vitest.ViteUserConfig = {
   },
 };
 
-/**
- * Merge two objects recursively. Merges only objects, not arrays, strings, etc.
- * If the two values cannot be merged, then `b` is used.
- */
-function merge(a: any, b: any): any {
-  if (
-    typeof a !== 'object' ||
-    typeof b !== 'object' ||
-    !a ||
-    !b ||
-    Array.isArray(a) ||
-    Array.isArray(b)
-  ) {
-    return b;
-  }
-
-  const result: any = { ...a };
-  for (const [key, value] of Object.entries(b)) {
-    result[key] = merge(a[key], value);
-  }
-  return result;
-}
-
 export function defineConfig(
   config: vitest.ViteUserConfig = {}
 ): vitest.ViteUserConfig {
-  return vitest.defineConfig(merge(base, config));
+  return vitest.defineConfig(vitest.mergeConfig(base, config));
 }


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6072

Removes our custom config merge function and replaces it with `mergeConfig` from `vitest`.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated testing. I also diffed the merged configs in a few project and found that the only difference is in how values excluded from coverage were handled. `mergeConfig` appends the arrays from the base and the extension together, whereas ours replaced the values. I think `vitest`s is probably more correct.