### PR TITLE
[VxScan] Mute scan success/fail sound effects when using headphones

### DIFF
--- a/apps/scan/frontend/src/screens/voter_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.test.tsx
@@ -1,0 +1,70 @@
+import { expect, test, vi } from 'vitest';
+import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
+import { electionGeneralFixtures } from '@votingworks/fixtures';
+import { PrecinctScannerStatus } from '@votingworks/scan-backend';
+import { render, waitFor } from '../../test/react_testing_library';
+import { VoterScreen, VoterScreenProps } from './voter_screen';
+import {
+  ApiMock,
+  createApiMock,
+  provideApi,
+  statusNoPaper,
+} from '../../test/helpers/mock_api_client';
+import {
+  useScanFeedbackAudio,
+  UseScanFeedbackAudioInput,
+} from '../utils/use_scan_feedback_audio';
+
+vi.mock('../utils/use_scan_feedback_audio.ts');
+vi.mock('./insert_ballot_screen');
+
+const electionDefinition = electionGeneralFixtures.readElectionDefinition();
+
+const useScanFeedbackAudioMock = vi
+  .mocked(useScanFeedbackAudio)
+  .mockImplementation(() => {});
+
+function renderScreen(
+  scannerStatus: PrecinctScannerStatus,
+  props: Partial<VoterScreenProps>
+): { apiMock: ApiMock } {
+  const apiMock = createApiMock();
+  apiMock.expectGetScannerStatus(scannerStatus);
+
+  render(
+    provideApi(
+      apiMock,
+      <VoterScreen
+        electionDefinition={electionDefinition}
+        isSoundMuted={false}
+        isTestMode={false}
+        systemSettings={DEFAULT_SYSTEM_SETTINGS}
+        {...props}
+      />
+    )
+  );
+
+  return { apiMock };
+}
+
+test('renders useScanFeedbackAudio hook', async () => {
+  const { apiMock } = renderScreen(statusNoPaper, { isSoundMuted: false });
+
+  expect(useScanFeedbackAudioMock).toHaveBeenLastCalledWith<
+    [UseScanFeedbackAudioInput]
+  >({
+    currentState: undefined,
+    isSoundMuted: false,
+  });
+
+  apiMock.mockApiClient.assertComplete();
+
+  await waitFor(() =>
+    expect(useScanFeedbackAudioMock).toHaveBeenLastCalledWith<
+      [UseScanFeedbackAudioInput]
+    >({
+      currentState: 'no_paper',
+      isSoundMuted: false,
+    })
+  );
+});

--- a/apps/scan/frontend/src/utils/use_scan_feedback_audio.test.ts
+++ b/apps/scan/frontend/src/utils/use_scan_feedback_audio.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, expect, Mock, test, vi } from 'vitest';
+import {
+  PRECINCT_SCANNER_STATES,
+  PrecinctScannerState,
+} from '@votingworks/types';
+import { assertDefined } from '@votingworks/basics';
+import { useHeadphonesPluggedIn } from '@votingworks/ui';
+import { SoundType, useSound } from './use_sound';
+import { renderHook } from '../../test/react_testing_library';
+import { useScanFeedbackAudio } from './use_scan_feedback_audio';
+
+vi.mock('../utils/use_sound');
+vi.mock('@votingworks/ui');
+
+const useSoundMock = vi.mocked(useSound);
+const mockSounds: Partial<Record<SoundType, Mock<() => void>>> = {
+  error: vi.fn(),
+  warning: vi.fn(),
+  success: vi.fn(),
+};
+
+const useHeadphonesPluggedInMock = vi.mocked(useHeadphonesPluggedIn);
+
+function throwOnAllMockSounds() {
+  for (const [type, mockSound] of Object.entries(mockSounds)) {
+    mockSound.mockImplementation(() => {
+      throw new Error(`Unexpected sound played: ${type}`);
+    });
+  }
+}
+
+beforeEach(() => {
+  throwOnAllMockSounds();
+  useSoundMock.mockImplementation((type) => assertDefined(mockSounds[type]));
+});
+
+const STATE_SOUND_MAPPING: Array<{
+  state: PrecinctScannerState;
+  sound: SoundType;
+}> = [
+  { state: 'accepted', sound: 'success' },
+  { state: 'needs_review', sound: 'warning' },
+  { state: 'both_sides_have_paper', sound: 'warning' },
+  { state: 'rejecting', sound: 'error' },
+  { state: 'jammed', sound: 'error' },
+  { state: 'double_sheet_jammed', sound: 'error' },
+  { state: 'unrecoverable_error', sound: 'error' },
+];
+
+test.each(STATE_SOUND_MAPPING)(
+  '$state state change plays $expected sound',
+  ({ sound, state }) => {
+    useHeadphonesPluggedInMock.mockReturnValue(false);
+    throwOnAllMockSounds();
+
+    const result = renderHook(useScanFeedbackAudio, {
+      initialProps: { currentState: 'no_paper', isSoundMuted: false },
+    });
+
+    const expectedSoundMock = assertDefined(mockSounds[sound]);
+    expectedSoundMock.mockImplementation(() => {});
+
+    result.rerender({ currentState: state, isSoundMuted: false });
+    expect(expectedSoundMock).toHaveBeenCalledOnce();
+
+    expectedSoundMock.mockClear();
+
+    // No sound if state is unchanged:
+    result.rerender({ currentState: state, isSoundMuted: false });
+    expect(expectedSoundMock).not.toHaveBeenCalled();
+  }
+);
+
+const STATES_WITH_SOUND = STATE_SOUND_MAPPING.map((m) => m.state);
+
+test.each(STATES_WITH_SOUND)("no '%s' sound over headphones", (state) => {
+  useHeadphonesPluggedInMock.mockReturnValue(true);
+  throwOnAllMockSounds();
+
+  const result = renderHook(useScanFeedbackAudio, {
+    initialProps: { currentState: 'no_paper', isSoundMuted: false },
+  });
+
+  result.rerender({ currentState: state, isSoundMuted: false });
+});
+
+test.each(STATES_WITH_SOUND)("no '%s' sound when system is muted", (state) => {
+  useHeadphonesPluggedInMock.mockReturnValue(false);
+  throwOnAllMockSounds();
+
+  const result = renderHook(useScanFeedbackAudio, {
+    initialProps: { currentState: 'no_paper', isSoundMuted: false },
+  });
+
+  result.rerender({ currentState: state, isSoundMuted: true });
+});
+
+test('no sound for all other states', () => {
+  useHeadphonesPluggedInMock.mockReturnValue(false);
+  throwOnAllMockSounds();
+
+  const result = renderHook(useScanFeedbackAudio, {
+    initialProps: { currentState: 'no_paper', isSoundMuted: false },
+  });
+
+  for (const state of PRECINCT_SCANNER_STATES) {
+    if (STATES_WITH_SOUND.includes(state)) continue;
+
+    result.rerender({ currentState: state, isSoundMuted: false });
+  }
+});

--- a/apps/scan/frontend/src/utils/use_scan_feedback_audio.ts
+++ b/apps/scan/frontend/src/utils/use_scan_feedback_audio.ts
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import { PrecinctScannerState } from '@votingworks/types';
+import { useHeadphonesPluggedIn } from '@votingworks/ui';
+
+import { useSound } from './use_sound';
+
+export interface UseScanFeedbackAudioInput {
+  // eslint-disable-next-line vx/gts-use-optionals
+  currentState: PrecinctScannerState | undefined;
+  isSoundMuted: boolean;
+}
+
+export function useScanFeedbackAudio(input: UseScanFeedbackAudioInput): void {
+  const { currentState, isSoundMuted } = input;
+  const previousState = React.useRef<PrecinctScannerState | undefined>();
+
+  const headphonesPluggedIn = useHeadphonesPluggedIn();
+  const playSuccess = useSound('success');
+  const playWarning = useSound('warning');
+  const playError = useSound('error');
+
+  if (isSoundMuted || headphonesPluggedIn) return;
+  if (previousState.current === currentState) return;
+
+  switch (currentState) {
+    case 'accepted': {
+      playSuccess();
+      break;
+    }
+
+    case 'needs_review':
+    case 'both_sides_have_paper': {
+      playWarning();
+      break;
+    }
+
+    case 'rejecting':
+    case 'jammed':
+    case 'double_sheet_jammed':
+    case 'unrecoverable_error': {
+      playError();
+      break;
+    }
+
+    default: {
+      // No sound
+      break;
+    }
+  }
+
+  previousState.current = currentState;
+}

--- a/apps/scan/frontend/src/utils/use_sound.ts
+++ b/apps/scan/frontend/src/utils/use_sound.ts
@@ -1,8 +1,8 @@
 import useSoundLib from 'use-sound';
 
-export function useSound(
-  sound: 'success' | 'warning' | 'error' | 'alarm'
-): () => void {
+export type SoundType = 'success' | 'warning' | 'error' | 'alarm';
+
+export function useSound(sound: SoundType): () => void {
   const [playSound] = useSoundLib(`/sounds/${sound}.mp3`);
   return playSound;
 }

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -37,6 +37,7 @@ export * from './hooks/use_available_languages';
 export * from './hooks/use_change_listener';
 export * from './hooks/use_current_language';
 export * from './hooks/use_current_theme';
+export * from './hooks/use_headphones_plugged_in';
 export * from './hooks/use_language_controls';
 export * from './hooks/use_lock';
 export * from './hooks/use_now';


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6484

Now that we're enabling screen reader audio over headphones on VxScan, the scan success/fail sounds collide with speech audio and are redundant. Skipping those sounds whenever we detect that headphones are plugged in.

## Demo Video or Screenshot

### Without Headphones

https://github.com/user-attachments/assets/ae625cfc-6a7f-4ab4-b0b6-d134e7fbe7f4

### With Headphones Detected

https://github.com/user-attachments/assets/ef53b435-0fb3-4bfc-a557-b727fadc3ecc


## Testing Plan
- Manual & unit tests - broke out state-based audio logic to make testing easier

## Checklist

<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
