### PR TITLE
VxAdmin: prevent negative and decimal manual tallies + prevent change on scroll

### DIFF
--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -178,7 +178,7 @@ const StyledInput = styled.input.attrs({ type: 'text' })`
 interface TallyInputProps {
   id: string;
   value: number | EmptyValue;
-  onNewValue: (newValue: number | EmptyValue) => void;
+  onChange: (newValue: number | EmptyValue) => void;
   disabled?: boolean;
   autoFocus?: boolean;
   style?: React.CSSProperties;
@@ -188,7 +188,7 @@ interface TallyInputProps {
 function TallyInput({
   id,
   value,
-  onNewValue,
+  onChange,
   disabled,
   autoFocus,
   style = {},
@@ -201,13 +201,13 @@ function TallyInput({
       onChange={(event) => {
         const inputValue = event.currentTarget.value;
         if (inputValue === '') {
-          onNewValue('');
+          onChange('');
           return;
         }
 
         const parsedInput = safeParseInt(inputValue);
         if (parsedInput.isOk() && parsedInput.ok() >= 0) {
-          onNewValue(parsedInput.ok());
+          onChange(parsedInput.ok());
         }
       }}
       disabled={disabled}
@@ -536,7 +536,7 @@ function BallotCountForm({
             autoFocus
             id="ballotCount"
             value={ballotCount}
-            onNewValue={(newValue) => setBallotCount(newValue)}
+            onChange={(newValue) => setBallotCount(newValue)}
           />
         </FormCard>
       </TallyTaskContent>
@@ -802,7 +802,7 @@ function ContestForm({
               <TallyInput
                 id="numBallots"
                 value={getValueForInput('numBallots')}
-                onNewValue={(value) => updateContestData('numBallots', value)}
+                onChange={(value) => updateContestData('numBallots', value)}
                 disabled={!isOverridingBallotCount}
                 style={{ fontWeight: '500' }}
               />
@@ -843,7 +843,7 @@ function ContestForm({
                 inputRef={firstInputRef}
                 id="undervotes"
                 value={getValueForInput('undervotes')}
-                onNewValue={(value) => updateContestData('undervotes', value)}
+                onChange={(value) => updateContestData('undervotes', value)}
               />
               <label htmlFor="undervotes">Undervotes</label>
             </ContestDataRow>
@@ -851,7 +851,7 @@ function ContestForm({
               <TallyInput
                 id="overvotes"
                 value={getValueForInput('overvotes')}
-                onNewValue={(value) => updateContestData('overvotes', value)}
+                onChange={(value) => updateContestData('overvotes', value)}
               />
               <label htmlFor="overvotes">Overvotes</label>
             </ContestDataRow>
@@ -867,7 +867,7 @@ function ContestForm({
                       <TallyInput
                         id={candidate.id}
                         value={getValueForInput(candidate.id)}
-                        onNewValue={(value) =>
+                        onChange={(value) =>
                           updateContestData(candidate.id, value)
                         }
                       />
@@ -881,7 +881,7 @@ function ContestForm({
                     <TallyInput
                       id={candidate.id}
                       value={getValueForInput(candidate.id)}
-                      onNewValue={(value) =>
+                      onChange={(value) =>
                         updateContestData(candidate.id, value, candidate.name)
                       }
                     />
@@ -896,7 +896,7 @@ function ContestForm({
                       autoFocus
                       id={candidate.id}
                       value={getValueForInput(candidate.id)}
-                      onNewValue={(value) =>
+                      onChange={(value) =>
                         updateContestData(candidate.id, value, candidate.name)
                       }
                     />
@@ -924,7 +924,7 @@ function ContestForm({
                   <TallyInput
                     id="yes"
                     value={getValueForInput('yesTally')}
-                    onNewValue={(value) => updateContestData('yesTally', value)}
+                    onChange={(value) => updateContestData('yesTally', value)}
                   />
                   <label htmlFor="yes">{contest.yesOption.label}</label>
                 </ContestDataRow>
@@ -932,7 +932,7 @@ function ContestForm({
                   <TallyInput
                     id="no"
                     value={getValueForInput('noTally')}
-                    onNewValue={(value) => updateContestData('noTally', value)}
+                    onChange={(value) => updateContestData('noTally', value)}
                   />
                   <label htmlFor="no">{contest.noOption.label}</label>
                 </ContestDataRow>

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -21,6 +21,7 @@ import {
   Contests,
   Precinct,
   Election,
+  safeParseInt,
 } from '@votingworks/types';
 import {
   Button,
@@ -167,15 +168,55 @@ const FormCard = styled(Card)`
   background: ${(p) => p.theme.colors.background};
 `;
 
-const TallyInput = styled.input.attrs({ type: 'number' })`
+// if we used a number input here, there is default browser behavior that
+// increases and decreases the value on scroll. instead of preventing this
+// with an event handler, we just use a text input
+const StyledInput = styled.input.attrs({ type: 'text' })`
   width: 5.5em;
-
-  ::-webkit-inner-spin-button,
-  ::-webkit-outer-spin-button {
-    appearance: none;
-    margin: 0;
-  }
 `;
+
+interface TallyInputProps {
+  id: string;
+  value: number | EmptyValue;
+  onNewValue: (newValue: number | EmptyValue) => void;
+  disabled?: boolean;
+  autoFocus?: boolean;
+  style?: React.CSSProperties;
+  inputRef?: React.RefObject<HTMLInputElement>;
+}
+
+function TallyInput({
+  id,
+  value,
+  onNewValue,
+  disabled,
+  autoFocus,
+  style = {},
+  inputRef,
+}: TallyInputProps): JSX.Element {
+  return (
+    <StyledInput
+      id={id}
+      value={value}
+      onChange={(event) => {
+        const inputValue = event.currentTarget.value;
+        if (inputValue === '') {
+          onNewValue('');
+          return;
+        }
+
+        const parsedInput = safeParseInt(inputValue);
+        if (parsedInput.isOk() && parsedInput.ok() >= 0) {
+          onNewValue(parsedInput.ok());
+        }
+      }}
+      disabled={disabled}
+      autoFocus={autoFocus}
+      style={style}
+      ref={inputRef}
+    />
+  );
+}
 
 const ContestSection = styled.div<{ fill?: 'neutral' | 'warning' }>`
   background: ${(p) =>
@@ -494,15 +535,8 @@ function BallotCountForm({
           <TallyInput
             autoFocus
             id="ballotCount"
-            type="number"
             value={ballotCount}
-            onChange={(event) =>
-              setBallotCount(
-                event.currentTarget.value === ''
-                  ? ''
-                  : event.currentTarget.valueAsNumber
-              )
-            }
+            onNewValue={(newValue) => setBallotCount(newValue)}
           />
         </FormCard>
       </TallyTaskContent>
@@ -632,12 +666,10 @@ function ContestForm({
 
   function updateContestData(
     dataKey: string,
-    event: React.FormEvent<HTMLInputElement>,
+    value: number | EmptyValue,
     candidateName?: string
   ) {
     const contestResults = formManualResults.contestResults[contestId];
-    const value =
-      event.currentTarget.value === '' ? '' : event.currentTarget.valueAsNumber;
     let newContestResults = contestResults;
     switch (dataKey) {
       case 'overvotes':
@@ -770,7 +802,7 @@ function ContestForm({
               <TallyInput
                 id="numBallots"
                 value={getValueForInput('numBallots')}
-                onChange={(e) => updateContestData('numBallots', e)}
+                onNewValue={(value) => updateContestData('numBallots', value)}
                 disabled={!isOverridingBallotCount}
                 style={{ fontWeight: '500' }}
               />
@@ -808,10 +840,10 @@ function ContestForm({
           <ContestSection>
             <ContestDataRow>
               <TallyInput
-                ref={firstInputRef}
+                inputRef={firstInputRef}
                 id="undervotes"
                 value={getValueForInput('undervotes')}
-                onChange={(e) => updateContestData('undervotes', e)}
+                onNewValue={(value) => updateContestData('undervotes', value)}
               />
               <label htmlFor="undervotes">Undervotes</label>
             </ContestDataRow>
@@ -819,7 +851,7 @@ function ContestForm({
               <TallyInput
                 id="overvotes"
                 value={getValueForInput('overvotes')}
-                onChange={(e) => updateContestData('overvotes', e)}
+                onNewValue={(value) => updateContestData('overvotes', value)}
               />
               <label htmlFor="overvotes">Overvotes</label>
             </ContestDataRow>
@@ -835,7 +867,9 @@ function ContestForm({
                       <TallyInput
                         id={candidate.id}
                         value={getValueForInput(candidate.id)}
-                        onChange={(e) => updateContestData(candidate.id, e)}
+                        onNewValue={(value) =>
+                          updateContestData(candidate.id, value)
+                        }
                       />
                       <label htmlFor={`${candidate.id}`}>
                         {candidate.name}
@@ -847,8 +881,8 @@ function ContestForm({
                     <TallyInput
                       id={candidate.id}
                       value={getValueForInput(candidate.id)}
-                      onChange={(e) =>
-                        updateContestData(candidate.id, e, candidate.name)
+                      onNewValue={(value) =>
+                        updateContestData(candidate.id, value, candidate.name)
                       }
                     />
                     <label htmlFor={candidate.id}>
@@ -862,8 +896,8 @@ function ContestForm({
                       autoFocus
                       id={candidate.id}
                       value={getValueForInput(candidate.id)}
-                      onChange={(e) =>
-                        updateContestData(candidate.id, e, candidate.name)
+                      onNewValue={(value) =>
+                        updateContestData(candidate.id, value, candidate.name)
                       }
                     />
                     <label htmlFor={candidate.id}>
@@ -890,7 +924,7 @@ function ContestForm({
                   <TallyInput
                     id="yes"
                     value={getValueForInput('yesTally')}
-                    onChange={(e) => updateContestData('yesTally', e)}
+                    onNewValue={(value) => updateContestData('yesTally', value)}
                   />
                   <label htmlFor="yes">{contest.yesOption.label}</label>
                 </ContestDataRow>
@@ -898,7 +932,7 @@ function ContestForm({
                   <TallyInput
                     id="no"
                     value={getValueForInput('noTally')}
-                    onChange={(e) => updateContestData('noTally', e)}
+                    onNewValue={(value) => updateContestData('noTally', value)}
                   />
                   <label htmlFor="no">{contest.noOption.label}</label>
                 </ContestDataRow>


### PR DESCRIPTION
## Overview

Closes #6381 and #6356. In testing negative manual tally values, I noticed decimal values are currently also allowed, which this PR also addresses.

The issue of number inputs changing on scroll is just browser behavior. The two options I could find to turn of it off were a) use a text input or b) use event handlers to stop the default behavior. I preferred a) because it seemed a bit cleaner and lent itself to solving the negative number problem.

## Testing Plan

- updated existing tests
- new test for negative and decimal
- there isn't a way to test the scroll thing because it's browser behavior, not react behavior, that does not exist in the test environment
