### PR TITLE
Address bug where contest overrides of ballot counts are wrongly cleared

### DIFF
--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.test.tsx
@@ -664,3 +664,33 @@ test('changing overall ballot count when there are overrides', async () => {
   );
   expect(screen.getByLabelText('Total Ballots Cast')).toBeDisabled();
 });
+
+test('leaving overrides as is when passing through overall ballot count without an update', async () => {
+  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetManualResults(identifier, {
+    ...mockValidResults,
+    contestResults: {
+      ...mockValidResults.contestResults,
+      [contests[0].id]: {
+        ...mockValidResults.contestResults[contests[0].id],
+        ballots: mockValidResults.ballotCount * 2,
+      },
+    },
+  });
+  renderScreen();
+
+  const ballotCountInput = await screen.findByLabelText('Total Ballots Cast');
+  expect(ballotCountInput).toHaveValue(`${mockValidResults.ballotCount}`);
+  screen.getByText(
+    'Changing the total ballots cast will remove contest overrides.'
+  );
+
+  // No API calls are expected since we didn't change the overall ballot count
+  userEvent.click(screen.getButton('Save & Next'));
+
+  await screen.findByRole('heading', { name: contests[0].title });
+  expect(screen.getByLabelText('Total Ballots Cast')).toHaveValue(
+    `${mockValidResults.ballotCount * 2}`
+  );
+  expect(screen.getByLabelText('Total Ballots Cast')).toBeEnabled();
+});

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -490,21 +490,27 @@ function BallotCountForm({
 
   async function saveBallotCount() {
     assert(ballotCount !== '');
-    await setManualTallyMutation.mutateAsync({
-      precinctId,
-      ballotStyleGroupId,
-      votingMethod,
-      manualResults: convertFormResultsToTabulationResults({
-        ballotCount,
-        contestResults: mapObject(
-          initialManualResults.contestResults,
-          (contestResults) => ({
-            ...contestResults,
-            ballots: ballotCount,
-          })
-        ),
-      }),
-    });
+
+    // Only update if the overall ballot count was actually changed as this update will clear any
+    // contest overrides of ballot counts
+    if (ballotCount !== initialManualResults.ballotCount) {
+      await setManualTallyMutation.mutateAsync({
+        precinctId,
+        ballotStyleGroupId,
+        votingMethod,
+        manualResults: convertFormResultsToTabulationResults({
+          ballotCount,
+          contestResults: mapObject(
+            initialManualResults.contestResults,
+            (contestResults) => ({
+              ...contestResults,
+              ballots: ballotCount,
+            })
+          ),
+        }),
+      });
+    }
+
     history.push(
       routerPaths.tallyManualFormContest({
         precinctId,


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/6129

This PR addresses a bug where contest overrides of ballot counts are wrongly cleared when the manual tally flow is reopened.

https://github.com/user-attachments/assets/c9dba68c-3a02-4bae-8756-72a94fd6c603

## Testing Plan

- [x] Tested manually
- [x] Added a regression test

## Checklist

- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced~ N/A