### PR TITLE
[VxMark] Prevent locking up UI after hitting write-in character limit

### DIFF
--- a/libs/ui/src/virtual_keyboard/virtual_keyboard.test.tsx
+++ b/libs/ui/src/virtual_keyboard/virtual_keyboard.test.tsx
@@ -135,6 +135,33 @@ test("doesn't fire key events for disabled keys", () => {
   expect(onKeyPress).not.toHaveBeenCalled();
 });
 
+test('never disables action/delete keys', () => {
+  const onKeyPress = vi.fn();
+  const onBackspace = vi.fn();
+  const onCancel = vi.fn();
+  const onAccept = vi.fn();
+
+  render(
+    <VirtualKeyboard
+      onBackspace={onBackspace}
+      onKeyPress={onKeyPress}
+      keyDisabled={() => true}
+      onCancel={onCancel}
+      onAccept={onAccept}
+      enableWriteInAtiControllerNavigation
+    />
+  );
+
+  userEvent.click(screen.getButton(/delete/));
+  expect(onBackspace).toHaveBeenCalled();
+
+  userEvent.click(screen.getButton(/Accept/));
+  expect(onAccept).toHaveBeenCalled();
+
+  userEvent.click(screen.getButton(/Cancel/));
+  expect(onCancel).toHaveBeenCalled();
+});
+
 test('custom keymap', () => {
   const onKeyPress = vi.fn();
   const onBackspace = vi.fn();

--- a/libs/ui/src/virtual_keyboard/virtual_keyboard.tsx
+++ b/libs/ui/src/virtual_keyboard/virtual_keyboard.tsx
@@ -463,7 +463,6 @@ export function VirtualKeyboard({
     const buttonProps: ButtonProps<string> = {
       value,
       onPress: onKeyPress,
-      disabled: keyDisabled(value),
       style: {
         flexBasis: getFlexBasis(key.columnSpan),
       },
@@ -481,7 +480,7 @@ export function VirtualKeyboard({
         buttonProps.onPress = onCancel;
         break;
       default:
-      // no override
+        buttonProps.disabled = keyDisabled(value);
     }
 
     const button = (


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6444

Fixing an issue where all available UI controls get disabled when the voter reaches the write-in character limit. Re-enabling the "Accept", "Cancel" and `delete` buttons in that case, to allow the voter to update the write-in and/or exit the modal.

### TODO
- The PAT-enabled write-in keyboard is in a different code path that also needs updating, but there might be some additional work to do there, so will follow up with another PR.

## Demo Video or Screenshot

### Before:

https://github.com/user-attachments/assets/0ffd61cc-c641-4261-8751-c6e06c494dee

### After:

https://github.com/user-attachments/assets/aa662c6f-2111-4521-bd38-84382acc026a

## Testing Plan
- Manual + additional unit test for regression guard

## Checklist

<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
