### PR TITLE
pdi-scanner: Use built-in setting to disable feeder after scan

### DIFF
--- a/libs/pdi-scanner/src/rust/client.rs
+++ b/libs/pdi-scanner/src/rust/client.rs
@@ -810,7 +810,9 @@ impl<T> Client<T> {
         self.set_scan_side_mode(ScanSideMode::Duplex)?;
         // OUT Enable AutoScanStart
         self.send_command(&Command::new(b"g"))?;
-        // OUT DisablePickOnCommandModeRequest
+        // OUT EnablePickOnCommandModeRequest
+        // Ensure the next scan will not start until we explicitly enable the feeder.
+        // This ensures we can safely process the results of one scan before another starts.
         self.set_pick_on_command_mode(PickOnCommandMode::FeederMustBeReenabledBetweenScans)?;
         // OUT SetDoubleFeedDetectionSensitivityRequest { percentage: 50 }
         self.set_double_feed_sensitivity(ClampedPercentage::new_unchecked(50))?;

--- a/libs/pdi-scanner/src/rust/client.rs
+++ b/libs/pdi-scanner/src/rust/client.rs
@@ -811,7 +811,7 @@ impl<T> Client<T> {
         // OUT Enable AutoScanStart
         self.send_command(&Command::new(b"g"))?;
         // OUT DisablePickOnCommandModeRequest
-        self.set_pick_on_command_mode(PickOnCommandMode::FeederStaysEnabledBetweenScans)?;
+        self.set_pick_on_command_mode(PickOnCommandMode::FeederMustBeReenabledBetweenScans)?;
         // OUT SetDoubleFeedDetectionSensitivityRequest { percentage: 50 }
         self.set_double_feed_sensitivity(ClampedPercentage::new_unchecked(50))?;
         // OUT SetDoubleFeedDetectionMinimumDocumentLengthRequest { length_in_hundredths_of_an_inch: 100 }

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -386,11 +386,6 @@ fn main() -> color_eyre::Result<()> {
                     send_event(Event::ScanStart)?;
                 }
                 Ok(Incoming::EndScanEvent) => {
-                    // Disable the feeder to prevent another scan from beginning. We've seen cases
-                    // where a scan fails (e.g. if the paper isn't caught by the rollers) and then
-                    // another scan immediately starts. We want to have time to handle the results
-                    // of this scan safely.
-                    c.set_feeder_mode(FeederMode::Disabled)?;
                     match raw_image_data.try_decode_scan(DEFAULT_IMAGE_WIDTH, ScanSideMode::Duplex)
                     {
                         Ok(Sheet::Duplex(top, bottom)) => {


### PR DESCRIPTION
## Overview

In #6386, we added a "disable feeder" command after receiving the `EndScan` event (in order to prevent a new scan from starting too quickly). It turns out there's a built-in setting for this behavior, so we use that instead (which should be even more effective).

## Demo Video or Screenshot
N/A

## Testing Plan
Some basic manual testing

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
