### PR TITLE
fix(types-rs): ignore zero-sized rects in `Rect::union`

### DIFF
--- a/libs/types-rs/src/geometry.rs
+++ b/libs/types-rs/src/geometry.rs
@@ -343,6 +343,14 @@ impl Rect {
 
     // Returns the smallest rectangle that contains both `self` and `other`.
     pub fn union(&self, other: &Self) -> Self {
+        if self.width == 0 || self.height == 0 {
+            return *other;
+        }
+
+        if other.width == 0 || other.height == 0 {
+            return *self;
+        }
+
         let left = self.left.min(other.left);
         let top = self.top.min(other.top);
         let right = self.right().max(other.right());
@@ -784,5 +792,17 @@ mod test_quadrilateral {
         assert!(!quad.contains_subpixel(5.0, 15.0));
         assert!(!quad.contains_subpixel(-5.0, 5.0));
         assert!(!quad.contains_subpixel(5.0, -5.0));
+    }
+
+    #[test]
+    fn test_rect_union() {
+        assert_eq!(
+            Rect::new(0, 0, 1, 1).union(&Rect::new(1, 1, 1, 1)),
+            Rect::new(0, 0, 2, 2)
+        );
+        assert_eq!(
+            Rect::zero().union(&Rect::new(1, 1, 1, 1)),
+            Rect::new(1, 1, 1, 1)
+        );
     }
 }


### PR DESCRIPTION

## Overview
Previously, `Rect::zero` used with `foldl` to determine an extent of `Rect` instances would always start at the origin. Now it properly starts at the minimum x and y values present in all the non-zero-sized `Rect`s.

## Demo Video or Screenshot
| Before | After |
|-|-|
|![CleanShot 2025-05-28 at 20 13 49@2x](https://github.com/user-attachments/assets/afb74344-55e1-4897-a6e3-11f8697323a5)|<img width="180" alt="image" src="https://github.com/user-attachments/assets/764b59ba-ef5e-4227-9438-65192864ea3c" />|

## Testing Plan
Tested manually for its effect on debug images. Added a unit test.
