### PR TITLE
ballot-interpreter: Save binarized ballot images

### DIFF
--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -831,6 +831,13 @@ mod test {
         }
     }
 
+    fn is_binary_image(image: &GrayImage) -> bool {
+        image
+            .as_raw()
+            .iter()
+            .all(|&pixel| pixel == 0 || pixel == 255)
+    }
+
     #[test]
     fn test_par_map_pair() {
         assert_eq!(par_map_pair(1, 2, |n| n * 2), (2, 4));
@@ -840,7 +847,15 @@ mod test {
     fn test_interpret_ballot_card() {
         let (side_a_image, side_b_image, options) =
             load_ballot_card_fixture("ashland", ("scan-side-a.jpeg", "scan-side-b.jpeg"));
-        ballot_card(side_a_image, side_b_image, &options).unwrap();
+        let result = ballot_card(side_a_image, side_b_image, &options).unwrap();
+        assert!(
+            is_binary_image(&result.front.normalized_image),
+            "Front image is not binary"
+        );
+        assert!(
+            is_binary_image(&result.back.normalized_image),
+            "Back image is not binary"
+        );
 
         let (side_a_image, side_b_image, options) = load_ballot_card_fixture(
             "ashland",

--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -688,13 +688,16 @@ pub fn ballot_card(
         })
         .unwrap_or_default();
 
+    let normalized_front_image = imageproc::contrast::threshold(&front_image, front_threshold);
+    let normalized_back_image = imageproc::contrast::threshold(&back_image, back_threshold);
+
     Ok(InterpretedBallotCard {
         front: InterpretedBallotPage {
             grid: front_grid,
             metadata: front_metadata,
             marks: front_scored_bubble_marks,
             write_ins: front_write_in_area_scores,
-            normalized_image: front_image,
+            normalized_image: normalized_front_image,
             contest_layouts: front_contest_layouts,
         },
         back: InterpretedBallotPage {
@@ -702,7 +705,7 @@ pub fn ballot_card(
             metadata: back_metadata,
             marks: back_scored_bubble_marks,
             write_ins: back_write_in_area_scores,
-            normalized_image: back_image,
+            normalized_image: normalized_back_image,
             contest_layouts: back_contest_layouts,
         },
     })


### PR DESCRIPTION
## Overview

Task: #5294 

Now that we're switching the PDI scanner from bitonal to grayscale scanning, the ballot images it produces are much larger. In order to preserve the amount of disk space used, we want to binarize them before saving. For reference, the binarized images are ~100KB, while the grayscale images are ~4MB.

Previously, the interpreter passed through whatever ballot images it was given after cropping and normalizing their orientation. This PR changes it to also binarize the image. This will also have the side-effect of binarizing images in VxCentralScan, which will be good for consistency.

## Demo Video or Screenshot
Example binarized image
![f18c495f-05e5-41d7-858e-dfe1d868d615-front](https://github.com/user-attachments/assets/3ebc7209-27ea-4b67-bfbf-6459ae664837)


## Testing Plan
- Manual testing
- Added a basic unit test
- Ran benchmarks and saw no perf regression
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
