### PR TITLE
perf(scan): mutate images in place

### DIFF
--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -402,8 +402,8 @@ pub fn ballot_card(
     // We'll find the appropriate metadata, use it to normalize the image and
     // grid orientation, and extract the ballot style from it.
     let (
-        (front_grid, front_image, front_threshold, front_metadata, front_debug),
-        (back_grid, back_image, back_threshold, back_metadata, back_debug),
+        (front_grid, mut front_image, front_threshold, front_metadata, front_debug),
+        (back_grid, mut back_image, back_threshold, back_metadata, back_debug),
         ballot_style_id,
     ) = match options.election.ballot_layout.metadata_encoding {
         MetadataEncoding::QrCode => {
@@ -688,8 +688,8 @@ pub fn ballot_card(
         })
         .unwrap_or_default();
 
-    let normalized_front_image = imageproc::contrast::threshold(&front_image, front_threshold);
-    let normalized_back_image = imageproc::contrast::threshold(&back_image, back_threshold);
+    imageproc::contrast::threshold_mut(&mut front_image, front_threshold);
+    imageproc::contrast::threshold_mut(&mut back_image, back_threshold);
 
     Ok(InterpretedBallotCard {
         front: InterpretedBallotPage {
@@ -697,7 +697,7 @@ pub fn ballot_card(
             metadata: front_metadata,
             marks: front_scored_bubble_marks,
             write_ins: front_write_in_area_scores,
-            normalized_image: normalized_front_image,
+            normalized_image: front_image,
             contest_layouts: front_contest_layouts,
         },
         back: InterpretedBallotPage {
@@ -705,7 +705,7 @@ pub fn ballot_card(
             metadata: back_metadata,
             marks: back_scored_bubble_marks,
             write_ins: back_write_in_area_scores,
-            normalized_image: normalized_back_image,
+            normalized_image: back_image,
             contest_layouts: back_contest_layouts,
         },
     })


### PR DESCRIPTION
Though it's possible the Rust or llvm stages would optimize the two `image.clone()`s away, I'd rather not pay the memory cost if we can avoid it.
