### PR TITLE
feat(scan): debug bubble scoring pixels as pink

### DIFF
--- a/libs/ballot-interpreter/src/hmpb-rust/debug.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/debug.rs
@@ -21,7 +21,7 @@ fn imageproc_rect_from_rect(rect: &Rect) -> imageproc::rect::Rect {
     imageproc::rect::Rect::at(rect.left(), rect.top()).of_size(rect.width(), rect.height())
 }
 
-use crate::image_utils::{dark_rainbow, rainbow};
+use crate::image_utils::{dark_rainbow, rainbow, BLACK};
 use crate::layout::InterpretedContestLayout;
 use crate::scoring::UnitIntervalScore;
 use crate::timing_marks::{
@@ -1145,6 +1145,16 @@ pub fn draw_scored_bubble_marks_debug_image_mut(
                 fill_score_color,
                 WHITE_RGB,
             );
+
+            for (x, y, &luma) in scored_bubble_mark.fill_diff_image.enumerate_pixels() {
+                if luma == BLACK {
+                    let x = scored_bubble_mark.matched_bounds.left() + x as i32;
+                    let y = scored_bubble_mark.matched_bounds.top() + y as i32;
+                    if let (Ok(x), Ok(y)) = (x.try_into(), y.try_into()) {
+                        *canvas.get_pixel_mut(x, y) = PINK;
+                    }
+                }
+            }
 
             draw_hollow_rect_mut(
                 canvas,

--- a/libs/ballot-interpreter/src/hmpb-rust/scoring.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/scoring.rs
@@ -84,6 +84,10 @@ pub struct ScoredBubbleMark {
     /// The bounds of the bubble mark in the scanned source image that was
     /// determined to be the best match.
     pub matched_bounds: Rect,
+
+    /// The diff image that was used to produce `fill_score`.
+    #[serde(skip)]
+    pub fill_diff_image: GrayImage,
 }
 
 impl std::fmt::Debug for ScoredBubbleMark {
@@ -245,6 +249,7 @@ pub fn score_bubble_mark(
         fill_score,
         expected_bounds,
         matched_bounds: best_match.bounds,
+        fill_diff_image: diff_image,
     })
 }
 


### PR DESCRIPTION
## Overview
Gives a sense of what parts of the bubble actually counted toward the score.

## Demo Video or Screenshot
![CleanShot 2025-05-30 at 16 48 47@2x](https://github.com/user-attachments/assets/74d594f5-679b-4a73-b8ce-6f96b0fc912b)

## Testing Plan
Tested manually with several of the fixtures.