### PR TITLE
test(scan): make election fixtures match the schema

### DIFF
--- a/libs/ballot-interpreter/test/fixtures/ashland/election.json
+++ b/libs/ballot-interpreter/test/fixtures/ashland/election.json
@@ -9,6 +9,7 @@
   "ballotStyles": [
     {
       "id": "card-number-5",
+      "groupId": "card-number-5",
       "precincts": ["town-id-01001-precinct-id-default"],
       "districts": ["town-id-01001-precinct-id-default"]
     }
@@ -812,6 +813,7 @@
   "precincts": [
     {
       "id": "town-id-01001-precinct-id-default",
+      "districtIds": [],
       "name": "Ashland"
     }
   ],

--- a/libs/ballot-interpreter/test/fixtures/nh-test-ballot/election.json
+++ b/libs/ballot-interpreter/test/fixtures/nh-test-ballot/election.json
@@ -953,6 +953,7 @@
   "precincts": [
     {
       "id": "town-id-00701-precinct-id-default",
+      "districtIds": [],
       "name": "Test Ballot"
     }
   ],


### PR DESCRIPTION

## Overview

So we can use them with `./bin/interpret`.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated tests.