### PR TITLE
Logging clarifications in response to cert doc discrepancy reports

### DIFF
--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -16,11 +16,11 @@ Types are logged with each log line to categorize the log.
 IDs are logged with each log to identify the log being written.
 ### election-configured
 **Type:** [user-action](#user-action)
-**Description:** The user has configured current machine to a new election definition.
+**Description:** The user has configured the machine with a new election definition (or failed to do so). Success or failure indicated by disposition.
 **Machines:** All
 ### election-unconfigured
 **Type:** [user-action](#user-action)
-**Description:** The user has unconfigured current machine to remove the current election definition, and all other data.
+**Description:** The user has unconfigured the machine, removing the current election definition and all other data (or failed to do so). Success or failure indicated by disposition.
 **Machines:** All
 ### auth-pin-entry
 **Type:** [user-action](#user-action)
@@ -276,7 +276,7 @@ IDs are logged with each log to identify the log being written.
 **Machines:** vx-admin
 ### import-cast-vote-records-complete
 **Type:** [user-action](#user-action)
-**Description:** Cast vote records have been imported from a USB drive (or failed to be imported).
+**Description:** Cast vote records have been imported from a USB drive (or failed to be imported). Success or failure indicated by disposition.
 **Machines:** vx-admin
 ### clear-imported-cast-vote-records-init
 **Type:** [user-action](#user-action)
@@ -284,7 +284,7 @@ IDs are logged with each log to identify the log being written.
 **Machines:** vx-admin
 ### clear-imported-cast-vote-records-complete
 **Type:** [user-action](#user-action)
-**Description:** Imported cast vote records have been cleared (or failed to be cleared).
+**Description:** Imported cast vote records have been cleared (or failed to be cleared). Success or failure indicated by disposition.
 **Machines:** vx-admin
 ### manual-tally-data-edited
 **Type:** [user-action](#user-action)

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -125,13 +125,13 @@ documentationMessage = "Action taken by the votingworks application automaticall
 eventId = "election-configured"
 eventType = "user-action"
 defaultMessage = "Application has been configured for a new election."
-documentationMessage = "The user has configured current machine to a new election definition."
+documentationMessage = "The user has configured the machine with a new election definition (or failed to do so). Success or failure indicated by disposition."
 
 [Events.ElectionUnconfigured]
 eventId = "election-unconfigured"
 eventType = "user-action"
 defaultMessage = "Application has been unconfigured from the previous election."
-documentationMessage = "The user has unconfigured current machine to remove the current election definition, and all other data."
+documentationMessage = "The user has unconfigured the machine, removing the current election definition and all other data (or failed to do so). Success or failure indicated by disposition."
 
 [Events.AuthPinEntry]
 eventId = "auth-pin-entry"
@@ -467,7 +467,7 @@ restrictInDocumentationToApps = ["vx-admin"]
 [Events.ImportCastVoteRecordsComplete]
 eventId = "import-cast-vote-records-complete"
 eventType = "user-action"
-documentationMessage = "Cast vote records have been imported from a USB drive (or failed to be imported)."
+documentationMessage = "Cast vote records have been imported from a USB drive (or failed to be imported). Success or failure indicated by disposition."
 restrictInDocumentationToApps = ["vx-admin"]
 
 [Events.ClearImportedCastVoteRecordsInit]
@@ -479,7 +479,7 @@ restrictInDocumentationToApps = ["vx-admin"]
 [Events.ClearImportedCastVoteRecordsComplete]
 eventId = "clear-imported-cast-vote-records-complete"
 eventType = "user-action"
-documentationMessage = "Imported cast vote records have been cleared (or failed to be cleared)."
+documentationMessage = "Imported cast vote records have been cleared (or failed to be cleared). Success or failure indicated by disposition."
 restrictInDocumentationToApps = ["vx-admin"]
 
 [Events.ManualTallyDataEdited]

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -203,7 +203,7 @@ const ElectionConfigured: LogDetails = {
   eventId: LogEventId.ElectionConfigured,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'The user has configured current machine to a new election definition.',
+    'The user has configured the machine with a new election definition (or failed to do so). Success or failure indicated by disposition.',
   defaultMessage: 'Application has been configured for a new election.',
 };
 
@@ -211,7 +211,7 @@ const ElectionUnconfigured: LogDetails = {
   eventId: LogEventId.ElectionUnconfigured,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'The user has unconfigured current machine to remove the current election definition, and all other data.',
+    'The user has unconfigured the machine, removing the current election definition and all other data (or failed to do so). Success or failure indicated by disposition.',
   defaultMessage:
     'Application has been unconfigured from the previous election.',
 };
@@ -646,7 +646,7 @@ const ImportCastVoteRecordsComplete: LogDetails = {
   eventId: LogEventId.ImportCastVoteRecordsComplete,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'Cast vote records have been imported from a USB drive (or failed to be imported).',
+    'Cast vote records have been imported from a USB drive (or failed to be imported). Success or failure indicated by disposition.',
   restrictInDocumentationToApps: [AppName.VxAdmin],
 };
 
@@ -661,7 +661,7 @@ const ClearImportedCastVoteRecordsComplete: LogDetails = {
   eventId: LogEventId.ClearImportedCastVoteRecordsComplete,
   eventType: LogEventType.UserAction,
   documentationMessage:
-    'Imported cast vote records have been cleared (or failed to be cleared).',
+    'Imported cast vote records have been cleared (or failed to be cleared). Success or failure indicated by disposition.',
   restrictInDocumentationToApps: [AppName.VxAdmin],
 };
 


### PR DESCRIPTION
Logging clarifications in response to cert doc discrepancy reports - mostly just had to add "Success or failure indicated by disposition" to a few log entries

Release steps:
- [ ] Merge this PR
- [ ] Upload the latest .md file to https://github.com/votingworks/docs-vxsuite-v4/tree/main/software-docs
- [ ] Reference latest .md file from GitBook