### PR TITLE
feat(basics): add `iter::chunksExact`

### DIFF
--- a/docs/exercises/01-iteration/09-image-diff.exercise.ts
+++ b/docs/exercises/01-iteration/09-image-diff.exercise.ts
@@ -172,6 +172,6 @@ function diffImagesSolution({
   return iter(image1)
     .zip(image2)
     .map(([pixel1, pixel2]) => pixel1 === pixel2)
-    .chunks(dimensions.width)
+    .chunksExact(dimensions.width)
     .toArray();
 }

--- a/libs/ballot-interpreter/src/interpret_all_bubble_ballot.test.ts
+++ b/libs/ballot-interpreter/src/interpret_all_bubble_ballot.test.ts
@@ -91,7 +91,7 @@ describe('Interpret - HMPB - All bubble ballot', () => {
     } as const;
 
     const ballotImagePaths = pdfToPageImages(cyclingTestDeckPath);
-    for await (const sheetImages of ballotImagePaths.chunks(2)) {
+    for await (const sheetImages of ballotImagePaths.chunksExact(2)) {
       const [frontResult, backResult] = await interpretSheet(
         {
           electionDefinition,
@@ -100,7 +100,7 @@ describe('Interpret - HMPB - All bubble ballot', () => {
           markThresholds: DEFAULT_MARK_THRESHOLDS,
           adjudicationReasons: [AdjudicationReason.Overvote],
         },
-        asSheet(sheetImages)
+        sheetImages
       );
 
       assert(frontResult.interpretation.type === 'InterpretedHmpbPage');

--- a/libs/ballot-interpreter/src/interpret_vx_hmpb.test.ts
+++ b/libs/ballot-interpreter/src/interpret_vx_hmpb.test.ts
@@ -324,9 +324,8 @@ for (const spec of vxGeneralElectionFixtures.fixtureSpecs) {
 
       const ballotImagePaths = pdfToPageImages(markedBallotPath);
       for await (const [sheetIndex, sheetImages] of iter(ballotImagePaths)
-        .chunks(2)
+        .chunksExact(2)
         .enumerate()) {
-        assert(sheetImages.length === 2);
         const [frontResult, backResult] = await interpretSheet(
           {
             electionDefinition,
@@ -563,9 +562,8 @@ for (const spec of nhGeneralElectionFixtures.fixtureSpecs) {
 
       const ballotImagePaths = pdfToPageImages(markedBallotPath);
       for await (const [sheetIndex, sheetImages] of iter(ballotImagePaths)
-        .chunks(2)
+        .chunksExact(2)
         .enumerate()) {
-        assert(sheetImages.length === 2);
         const [frontResult, backResult] = await interpretSheet(
           {
             electionDefinition,

--- a/libs/basics/src/iterators/types.ts
+++ b/libs/basics/src/iterators/types.ts
@@ -31,7 +31,7 @@ export interface IteratorPlus<T> extends Iterable<T> {
    * expect(iter([1, 2, 3]).chunks(1).toArray()).toEqual([[1], [2], [3]]);
    * ```
    */
-  chunks(groupSize: 1): IteratorPlus<[T]>;
+  chunks(chunkSize: 1): IteratorPlus<[T]>;
 
   /**
    * Yields 2-element tuples, plus a 1-element tuple if there is a final
@@ -43,7 +43,7 @@ export interface IteratorPlus<T> extends Iterable<T> {
    * expect(iter([1, 2, 3]).chunks(2).toArray()).toEqual([[1, 2], [3]]);
    * ```
    */
-  chunks(groupSize: 2): IteratorPlus<[T] | [T, T]>;
+  chunks(chunkSize: 2): IteratorPlus<[T] | [T, T]>;
 
   /**
    * Yields 3-element tuples, plus a 1- or 2-element tuple if there are
@@ -60,7 +60,7 @@ export interface IteratorPlus<T> extends Iterable<T> {
    * ]);
    * ```
    */
-  chunks(groupSize: 3): IteratorPlus<[T] | [T, T] | [T, T, T]>;
+  chunks(chunkSize: 3): IteratorPlus<[T] | [T, T] | [T, T, T]>;
 
   /**
    * Yields 4-element tuples, plus a 1-3-element tuple if there are remaining
@@ -76,13 +76,56 @@ export interface IteratorPlus<T> extends Iterable<T> {
    * ]);
    * ```
    */
-  chunks(groupSize: 4): IteratorPlus<[T] | [T, T] | [T, T, T] | [T, T, T, T]>;
+  chunks(chunkSize: 4): IteratorPlus<[T] | [T, T] | [T, T, T] | [T, T, T, T]>;
 
   /**
    * Yields arrays of {@link groupSize} elements, plus a smaller array if there
    * are remaining elements.
    */
-  chunks(groupSize: number): IteratorPlus<T[]>;
+  chunks(chunkSize: number): IteratorPlus<T[]>;
+
+  /**
+   * Yields tuples of one element at a time.
+   */
+  chunksExact(chunkSize: 1): IteratorPlus<[T]>;
+
+  /**
+   * Yields 2-element tuples, throwing an error if the iterator has an odd
+   * number of elements.
+   *
+   * @example
+   *
+   * ```ts
+   * const pairs = iter([1, 2, 3, 4]).chunksExact(2);
+   * assert.deepStrictEqual([...pairs], [[1, 2], [3, 4]]);
+   * ```
+   */
+  chunksExact(chunkSize: 2): IteratorPlus<[T, T]>;
+
+  /**
+   * Yields 3-element tuples, throwing an error if the iterator has a number of
+   * elements that is not a multiple of 3.
+   *
+   * @example
+   *
+   * ```ts
+   * const triples = iter([1, 2, 3, 4, 5, 6]).chunksExact(3);
+   * assert.deepStrictEqual([...triples], [[1, 2, 3], [4, 5, 6]]);
+   * ```
+   */
+  chunksExact(chunkSize: 3): IteratorPlus<[T, T, T]>;
+
+  /**
+   * Yields 4-element tuples, throwing an error if the iterator has a number of
+   * elements that is not a multiple of 4.
+   */
+  chunksExact(chunkSize: 4): IteratorPlus<[T, T, T, T]>;
+
+  /**
+   * Yields arrays of {@link groupSize} elements, throwing an error if the iterator has a number of
+   * elements that is not a multiple of {@link groupSize}.
+   */
+  chunksExact(chunkSize: number): IteratorPlus<T[]>;
 
   /**
    * Counts the number of elements in `this`. Consumes the entire contained
@@ -773,7 +816,7 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
   /**
    * Yields tuples of one element at a time.
    */
-  chunks(groupSize: 1): AsyncIteratorPlus<[T]>;
+  chunks(chunkSize: 1): AsyncIteratorPlus<[T]>;
 
   /**
    * Yields 2-element tuples, plus a 1-element tuple if there is a final
@@ -788,13 +831,13 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * }
    * ```
    */
-  chunks(groupSize: 2): AsyncIteratorPlus<[T] | [T, T]>;
+  chunks(chunkSize: 2): AsyncIteratorPlus<[T] | [T, T]>;
 
   /**
    * Yields 3-element tuples, plus a 1- or 2-element tuple if there are
    * remaining elements.
    */
-  chunks(groupSize: 3): AsyncIteratorPlus<[T] | [T, T] | [T, T, T]>;
+  chunks(chunkSize: 3): AsyncIteratorPlus<[T] | [T, T] | [T, T, T]>;
 
   /**
    * Yields 4-element tuples, plus a 1-3-element tuple if there are remaining
@@ -808,7 +851,54 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * Yields arrays of {@link groupSize} elements, plus a smaller array if there
    * are remaining elements.
    */
-  chunks(groupSize: number): AsyncIteratorPlus<T[]>;
+  chunks(chunkSize: number): AsyncIteratorPlus<T[]>;
+
+  /**
+   * Yields tuples of one element at a time.
+   */
+  chunksExact(chunkSize: 1): AsyncIteratorPlus<[T]>;
+
+  /**
+   * Yields 2-element tuples, throwing an error if the iterator has an odd
+   * number of elements.
+   *
+   * @example
+   *
+   * ```ts
+   * const linePairs = lines(process.stdin).chunksExact(2);
+   * for await (const [first, second] of linePairs) {
+   *   …
+   * }
+   * ```
+   */
+  chunksExact(chunkSize: 2): AsyncIteratorPlus<[T, T]>;
+
+  /**
+   * Yields 3-element tuples, throwing an error if the iterator has a number of
+   * elements that is not a multiple of 3.
+   *
+   * @example
+   *
+   * ```ts
+   * const lineTriples = lines(process.stdin).chunksExact(3);
+   * for await (const [first, second, third] of lineTriples) {
+   *   …
+   * }
+   * ```
+   */
+  chunksExact(chunkSize: 3): AsyncIteratorPlus<[T, T, T]>;
+
+  /**
+   * Yields 4-element tuples, throwing an error if the iterator has a number of
+   * elements that is not a multiple of 4.
+   */
+  chunksExact(chunkSize: 4): AsyncIteratorPlus<[T, T, T, T]>;
+
+  /**
+   * Yields arrays of {@link groupSize} elements, throwing an error if the iterator has a number of
+   * elements that is not a multiple of {@link groupSize}.
+   */
+  chunksExact(chunkSize: number): AsyncIteratorPlus<T[]>;
 
   /**
    * Counts the number of elements in `this`. Consumes the entire contained iterable.


### PR DESCRIPTION
## Overview

Mirrors Rust's [`std::slice::chunks_exact`](https://doc.rust-lang.org/std/primitive.slice.html#method.chunks_exact) method.

## Demo Video or Screenshot

```ts
const pairs = iter([1, 2, 3, 4]).chunksExact(2);
assert.deepStrictEqual([...pairs], [[1, 2], [3, 4]]);
```

## Testing Plan
New automated tests.