### PR TITLE
Stablize coverage thresholds in Pollbook Backend

### DIFF
--- a/apps/pollbook/backend/src/avahi.test.ts
+++ b/apps/pollbook/backend/src/avahi.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { execFile } from '@votingworks/backend';
+import { spawn } from 'node:child_process';
+import { AvahiService, hasOnlineInterface } from './avahi';
+
+vi.mock(import('@votingworks/backend'));
+vi.mock(import('node:child_process'));
+const mockExecFileFn = vi.mocked(execFile);
+const mockSpawn = vi.mocked(spawn);
+
+describe('hasOnlineInterface', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns true if stdout is non-empty', async () => {
+    mockExecFileFn.mockResolvedValue({ stdout: 'eth0', stderr: '' });
+    await expect(hasOnlineInterface()).resolves.toBe(true);
+    expect(mockExecFileFn).toHaveBeenCalledWith('sudo', [
+      expect.stringContaining('is-online'),
+    ]);
+  });
+
+  it('returns false if stdout is empty', async () => {
+    mockExecFileFn.mockResolvedValue({ stdout: '', stderr: '' });
+    await expect(hasOnlineInterface()).resolves.toBe(false);
+  });
+
+  it('returns false if execFile throws', async () => {
+    mockExecFileFn.mockRejectedValue(new Error('fail'));
+    await expect(hasOnlineInterface()).resolves.toBe(false);
+  });
+});
+
+describe('AvahiService.advertiseHttpService', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('spawns the intermediate avahi-publish-service script with sudo', () => {
+    mockSpawn.mockReturnValue({
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      on: vi.fn(),
+    } as unknown as ReturnType<typeof spawn>);
+    AvahiService.advertiseHttpService('test-service', 1234);
+    expect(mockSpawn).toHaveBeenCalledWith('sudo', [
+      expect.stringContaining('avahi-publish-service'),
+      'test-service',
+      '1234',
+    ]);
+  });
+});
+
+describe('AvahiService.stopAdvertisedService', () => {
+  it('kills the running process if present', () => {
+    const fakeProcess = { kill: vi.fn() } as const;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (AvahiService as any).runningProcess = fakeProcess;
+    AvahiService.stopAdvertisedService();
+    expect(fakeProcess.kill).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((AvahiService as any).runningProcess).toBeNull();
+  });
+  it('does nothing if no process is running', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (AvahiService as any).runningProcess = null;
+    expect(() => AvahiService.stopAdvertisedService()).not.toThrow();
+  });
+});
+
+describe('AvahiService.discoverHttpServices', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns parsed services on success', async () => {
+    const stdout =
+      '=;eth0;IPv4;service1;Web Site;local;host1.local;192.168.1.2;8080;\n=;eth0;IPv4;service2;Web Site;local;host2.local;192.168.1.3;8081;';
+    mockExecFileFn.mockResolvedValue({ stdout, stderr: '' });
+    const services = await AvahiService.discoverHttpServices();
+    expect(services).toEqual([
+      {
+        name: 'service1',
+        host: 'host1.local',
+        resolvedIp: '192.168.1.2',
+        port: '8080',
+      },
+      {
+        name: 'service2',
+        host: 'host2.local',
+        resolvedIp: '192.168.1.3',
+        port: '8081',
+      },
+    ]);
+  });
+
+  it('returns [] if stderr is present', async () => {
+    mockExecFileFn.mockResolvedValue({ stdout: '', stderr: 'error' });
+    const services = await AvahiService.discoverHttpServices();
+    expect(services).toEqual([]);
+  });
+
+  it('returns [] if execFile throws', async () => {
+    mockExecFileFn.mockRejectedValue(new Error('fail'));
+    const services = await AvahiService.discoverHttpServices();
+    expect(services).toEqual([]);
+  });
+
+  it('ignores lines that are not resolved services', async () => {
+    const stdout = '+;lo;IPv4;something;Web Site;local\n';
+    mockExecFileFn.mockResolvedValue({ stdout, stderr: '' });
+    const result = await AvahiService.discoverHttpServices();
+    expect(result).toEqual([]);
+  });
+
+  it('ignores services on the lo interface or non-IPv4', async () => {
+    const stdout =
+      '=;lo;IPv4;service1;Web Site;local;host1.local;127.0.0.1;8080;\n=;eth0;IPv6;service2;Web Site;local;host2.local;::1;8081;';
+    mockExecFileFn.mockResolvedValue({ stdout, stderr: '' });
+    const result = await AvahiService.discoverHttpServices();
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/pollbook/backend/vitest.config.ts
+++ b/apps/pollbook/backend/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 75,
-        branches: 70,
+        lines: 84,
+        branches: 79,
       },
       exclude: [
         '**/node_modules/**',

--- a/apps/pollbook/backend/vitest.config.ts
+++ b/apps/pollbook/backend/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 84,
+        lines: 85,
         branches: 79,
       },
       exclude: [


### PR DESCRIPTION
## Overview
The avahi code was for some reason being "covered" when running test locally (where I have avahi installed) but not when run in CI. In the tests for networking I had mocked out everything at this layer and was never intentionally testing the file so I added a basic test file covering the avahi.ts code so that that is reliably covered in both CI and locally. 

Depends on: https://github.com/votingworks/vxsuite/pull/6549
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
N/A

## Testing Plan
Ran CI Job 50x and saw no failures. 
