### PR TITLE
[VxMark] Prevent PAT keyboard lockup after hitting write-in char limit

### DIFF
--- a/libs/mark-flow-ui/src/components/candidate_contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.test.tsx
@@ -9,8 +9,13 @@ import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import {
+  ACCEPT_KEY,
   AccessibilityMode,
+  CANCEL_KEY,
+  DELETE_KEY,
+  SPACE_BAR_KEY,
   VirtualKeyboard,
+  virtualKeyboardCommon,
   VirtualKeyboardProps,
 } from '@votingworks/ui';
 import { screen, within, render, act } from '../../test/react_testing_library';
@@ -26,7 +31,7 @@ vi.mock('@votingworks/ui', async () => {
 });
 
 function setUpMockVirtualKeyboard() {
-  let checkIsKeyDisabled: (key: string) => boolean;
+  let checkIsKeyDisabled: (key: virtualKeyboardCommon.Key) => boolean;
   let fireBackspaceEvent: () => void;
   let fireKeyPressEvent: (key: string) => void;
 
@@ -43,7 +48,8 @@ function setUpMockVirtualKeyboard() {
     });
 
   return {
-    checkIsKeyDisabled: (key: string) => checkIsKeyDisabled(key),
+    checkIsKeyDisabled: (key: virtualKeyboardCommon.Key) =>
+      checkIsKeyDisabled(key),
     fireBackspaceEvent: () => act(() => fireBackspaceEvent()),
     fireKeyPressEvents: (chars: string) =>
       act(() => {
@@ -502,7 +508,10 @@ describe('supports write-in candidates', () => {
     fireKeyPressEvents(writeInCandidate);
     modal.getByText(hasTextAcrossElements(/characters remaining: 0/i));
 
-    expect(checkIsKeyDisabled(' ')).toEqual(true);
+    expect(checkIsKeyDisabled(SPACE_BAR_KEY)).toEqual(true);
+    expect(checkIsKeyDisabled(DELETE_KEY)).toEqual(false);
+    expect(checkIsKeyDisabled(CANCEL_KEY)).toEqual(false);
+    expect(checkIsKeyDisabled(ACCEPT_KEY)).toEqual(false);
     userEvent.click(modal.getByText('Accept'));
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
 

--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -33,6 +33,7 @@ import {
   ScanPanelVirtualKeyboard,
   AccessibilityMode,
   Font,
+  virtualKeyboardCommon,
 } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 
@@ -227,8 +228,20 @@ export function CandidateContest({
   const writeInCharsRemaining =
     WRITE_IN_CANDIDATE_MAX_LENGTH - writeInCandidateName.length;
 
-  function keyDisabled() {
-    return writeInCharsRemaining === 0;
+  function keyDisabled(key: virtualKeyboardCommon.Key) {
+    switch (key.action) {
+      case virtualKeyboardCommon.ActionKey.ACCEPT:
+        return writeInCandidateName.length === 0;
+
+      case virtualKeyboardCommon.ActionKey.CANCEL:
+        return false;
+
+      case virtualKeyboardCommon.ActionKey.DELETE:
+        return false;
+
+      default:
+        return writeInCharsRemaining === 0;
+    }
   }
 
   function handleDisabledAddWriteInClick() {

--- a/libs/ui/src/virtual_keyboard/virtual_keyboard.test.tsx
+++ b/libs/ui/src/virtual_keyboard/virtual_keyboard.test.tsx
@@ -125,7 +125,7 @@ test("doesn't fire key events for disabled keys", () => {
     <VirtualKeyboard
       onBackspace={onBackspace}
       onKeyPress={onKeyPress}
-      keyDisabled={(k) => k === 'M'}
+      keyDisabled={(k) => k.value === 'M'}
       onCancel={onCancel}
       onAccept={onAccept}
     />
@@ -133,33 +133,6 @@ test("doesn't fire key events for disabled keys", () => {
 
   userEvent.click(screen.getButton(/\bM\b/));
   expect(onKeyPress).not.toHaveBeenCalled();
-});
-
-test('never disables action/delete keys', () => {
-  const onKeyPress = vi.fn();
-  const onBackspace = vi.fn();
-  const onCancel = vi.fn();
-  const onAccept = vi.fn();
-
-  render(
-    <VirtualKeyboard
-      onBackspace={onBackspace}
-      onKeyPress={onKeyPress}
-      keyDisabled={() => true}
-      onCancel={onCancel}
-      onAccept={onAccept}
-      enableWriteInAtiControllerNavigation
-    />
-  );
-
-  userEvent.click(screen.getButton(/delete/));
-  expect(onBackspace).toHaveBeenCalled();
-
-  userEvent.click(screen.getButton(/Accept/));
-  expect(onAccept).toHaveBeenCalled();
-
-  userEvent.click(screen.getButton(/Cancel/));
-  expect(onCancel).toHaveBeenCalled();
 });
 
 test('custom keymap', () => {
@@ -174,7 +147,7 @@ test('custom keymap', () => {
       onKeyPress={onKeyPress}
       onCancel={onCancel}
       onAccept={onAccept}
-      keyDisabled={(k) => k === 'M'}
+      keyDisabled={(k) => k.value === 'M'}
       keyMap={{
         rows: [
           [

--- a/libs/ui/src/virtual_keyboard/virtual_keyboard.tsx
+++ b/libs/ui/src/virtual_keyboard/virtual_keyboard.tsx
@@ -41,7 +41,7 @@ export interface VirtualKeyboardProps {
   onBackspace: () => void;
   onCancel: () => void;
   onAccept: () => void;
-  keyDisabled(key: string): boolean;
+  keyDisabled(key: Key): boolean;
   keyMap?: KeyMap;
   enableWriteInAtiControllerNavigation?: boolean;
 }
@@ -467,6 +467,7 @@ export function VirtualKeyboard({
         flexBasis: getFlexBasis(key.columnSpan),
       },
       icon: key.icon,
+      disabled: keyDisabled(key),
     };
 
     switch (key.action) {
@@ -475,12 +476,12 @@ export function VirtualKeyboard({
         break;
       case ActionKey.ACCEPT:
         buttonProps.onPress = onAccept;
+        buttonProps.variant = 'primary';
         break;
       case ActionKey.CANCEL:
         buttonProps.onPress = onCancel;
         break;
-      default:
-        buttonProps.disabled = keyDisabled(value);
+      default: // no-op
     }
 
     const button = (


### PR DESCRIPTION
## Overview

Resolves https://github.com/votingworks/vxsuite/issues/6444

Follow-up from https://github.com/votingworks/vxsuite/pull/6509, which addresses the lock-up issue for the tactile-controller-based UX. This fixes the issue for the PAT device (sip/puff, etc) UX.

Updating logic in `ScanPanelVirtualKeyboard` so that rows that have no enabled keys can't be activated (before, you could drill in and then get stuck when the individual keys are displayed).

## Demo Video or Screenshot

### Before

https://github.com/user-attachments/assets/04644bf9-9c05-44c4-8463-dada80c2ec80

### After

https://github.com/user-attachments/assets/3bc2e862-192c-4112-a857-156b20eacdf1

## Testing Plan
- Manual + new/updated unit tests

## Checklist

<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
