### PR TITLE
perf(scan): stop uselessly cropping images

### DIFF
--- a/libs/ballot-interpreter/src/hmpb-rust/image_utils.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/image_utils.rs
@@ -52,6 +52,12 @@ pub struct Inset {
     pub right: PixelUnit,
 }
 
+impl Inset {
+    pub fn is_zero(&self) -> bool {
+        self.top == 0 && self.bottom == 0 && self.left == 0 && self.right == 0
+    }
+}
+
 /// Bleed the given luma value outwards from any pixels that match it.
 pub fn bleed(img: &GrayImage, luma: Luma<u8>) -> GrayImage {
     let mut out = img.clone();


### PR DESCRIPTION
## Overview
In the event that there is no need to crop off any pixels from the image, skip copying the pixels over to a newly allocated image and just return the original.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated tests.