### PR TITLE
feat(scan): add option to disable timing mark inference

### DIFF
--- a/libs/ballot-interpreter/Cargo.toml
+++ b/libs/ballot-interpreter/Cargo.toml
@@ -8,6 +8,10 @@ exclude = ["build/addon.node"]
 crate-type = ["cdylib", "rlib"]
 path = "src/hmpb-rust/lib.rs"
 
+[[bin]]
+name = "interpret"
+path = "bin/interpret.rs"
+
 [[bench]]
 name = "main"
 harness = false

--- a/libs/ballot-interpreter/benches/main.rs
+++ b/libs/ballot-interpreter/benches/main.rs
@@ -32,7 +32,7 @@ impl InterpretFixture {
         let election_path = fixture_path.join(self.election).join("election.json");
         let election: types_rs::election::Election =
             serde_json::from_reader(BufReader::new(File::open(election_path)?))?;
-        let interpreter = ScanInterpreter::new(election, true, false)?;
+        let interpreter = ScanInterpreter::new(election, true, false, true)?;
         let side_a_path = fixture_path
             .join(self.election)
             .join(format!("{}-front{}", self.name, self.extension));

--- a/libs/ballot-interpreter/bin/interpret.rs
+++ b/libs/ballot-interpreter/bin/interpret.rs
@@ -22,6 +22,10 @@ struct Options {
     /// Determines whether to disable vertical streak detection.
     #[clap(long, default_value = "false")]
     disable_vertical_streak_detection: bool,
+
+    /// Determines whether to disable timing mark inference.
+    #[clap(long, default_value = "false")]
+    disable_timing_mark_inference: bool,
 }
 
 impl Options {
@@ -47,6 +51,7 @@ fn main() -> color_eyre::Result<()> {
         options.load_election()?,
         options.score_write_ins,
         options.disable_vertical_streak_detection,
+        !options.disable_timing_mark_inference,
     )?;
 
     let start = Instant::now();

--- a/libs/ballot-interpreter/bin/interpret.rs
+++ b/libs/ballot-interpreter/bin/interpret.rs
@@ -62,7 +62,7 @@ fn main() -> color_eyre::Result<()> {
         None,
     );
     let duration = start.elapsed();
-    let exit_code = if result.is_ok() { 0 } else { 1 };
+    let exit_code = i32::from(!result.is_ok());
 
     match result {
         Ok(interpretation) => {

--- a/libs/ballot-interpreter/src/hmpb-rust/ballot_card.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/ballot_card.rs
@@ -1,12 +1,13 @@
 use std::{cmp::Ordering, io, ops::Range};
 
 use image::GrayImage;
+use imageproc::contrast::{otsu_level, threshold};
 use serde::Serialize;
 use types_rs::geometry::PixelUnit;
 
 pub use types_rs::ballot_card::*;
 
-use crate::image_utils::Inset;
+use crate::image_utils::{bleed, Inset, BLACK};
 
 use types_rs::geometry::{GridUnit, Inch, PixelPosition, Rect, Size, SubPixelUnit};
 
@@ -301,7 +302,8 @@ pub fn get_matching_paper_info_for_image_size(
 pub fn load_ballot_scan_bubble_image() -> Result<GrayImage, image::ImageError> {
     let bubble_image_bytes = include_bytes!("../../data/bubble_scan.png");
     let inner = io::Cursor::new(bubble_image_bytes);
-    image::load(inner, image::ImageFormat::Png).map(|image| image.to_luma8())
+    let image = image::load(inner, image::ImageFormat::Png).map(|image| image.to_luma8())?;
+    Ok(bleed(&threshold(&image, otsu_level(&image)), BLACK))
 }
 
 #[cfg(test)]

--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -748,16 +748,11 @@ mod test {
     };
 
     use image::Luma;
-    use imageproc::{
-        contrast::threshold,
-        geometric_transformations::{self, Interpolation, Projection},
-    };
+    use imageproc::geometric_transformations::{self, Interpolation, Projection};
     use types_rs::geometry::{Degrees, PixelPosition, Radians, Rect};
 
     use crate::{
-        ballot_card::load_ballot_scan_bubble_image,
-        image_utils::{bleed, BLACK},
-        scoring::UnitIntervalScore,
+        ballot_card::load_ballot_scan_bubble_image, scoring::UnitIntervalScore,
         timing_marks::Complete,
     };
 
@@ -782,10 +777,6 @@ mod test {
         let election: Election =
             serde_json::from_reader(BufReader::new(File::open(election_path).unwrap())).unwrap();
         let bubble_template = load_ballot_scan_bubble_image().unwrap();
-        let bubble_template = bleed(
-            &threshold(&bubble_template, otsu_level(&bubble_template)),
-            BLACK,
-        );
         let side_a_path = fixture_path.join(fixture_name).join(side_a_name);
         let side_b_path = fixture_path.join(fixture_name).join(side_b_name);
         let (side_a_image, side_b_image) = load_ballot_card_images(&side_a_path, &side_b_path);

--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -182,8 +182,8 @@ impl ScanInterpreter {
             election,
             score_write_ins,
             disable_vertical_streak_detection,
-            bubble_template_image,
             infer_timing_marks,
+            bubble_template_image,
         })
     }
 
@@ -311,7 +311,7 @@ pub fn crop_ballot_page_image_borders(image: GrayImage) -> Option<BallotImage> {
 
 /// Prepare a ballot page image for interpretation by cropping the black border.
 #[allow(clippy::result_large_err)]
-fn prepare_ballot_page_image(
+pub fn prepare_ballot_page_image(
     label: &str,
     image: GrayImage,
     possible_paper_infos: &[PaperInfo],

--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -55,6 +55,7 @@ pub struct Options {
     pub debug_side_b_base: Option<PathBuf>,
     pub score_write_ins: bool,
     pub disable_vertical_streak_detection: bool,
+    pub infer_timing_marks: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -160,6 +161,7 @@ pub struct ScanInterpreter {
     election: Election,
     score_write_ins: bool,
     disable_vertical_streak_detection: bool,
+    infer_timing_marks: bool,
     bubble_template_image: GrayImage,
 }
 
@@ -173,6 +175,7 @@ impl ScanInterpreter {
         election: Election,
         score_write_ins: bool,
         disable_vertical_streak_detection: bool,
+        infer_timing_marks: bool,
     ) -> Result<Self, image::ImageError> {
         let bubble_template_image = load_ballot_scan_bubble_image()?;
         Ok(Self {
@@ -180,6 +183,7 @@ impl ScanInterpreter {
             score_write_ins,
             disable_vertical_streak_detection,
             bubble_template_image,
+            infer_timing_marks,
         })
     }
 
@@ -203,6 +207,7 @@ impl ScanInterpreter {
             debug_side_b_base: debug_side_b_base.into(),
             score_write_ins: self.score_write_ins,
             disable_vertical_streak_detection: self.disable_vertical_streak_detection,
+            infer_timing_marks: self.infer_timing_marks,
         };
         ballot_card(side_a_image, side_b_image, &options)
     }
@@ -398,6 +403,7 @@ pub fn ballot_card(
                 FindTimingMarkGridOptions {
                     allowed_timing_mark_inset_percentage_of_width:
                         ALLOWED_TIMING_MARK_INSET_PERCENTAGE_OF_WIDTH,
+                    infer_timing_marks: options.infer_timing_marks,
                     debug,
                 },
             )
@@ -787,6 +793,7 @@ mod test {
             election,
             score_write_ins: true,
             disable_vertical_streak_detection: false,
+            infer_timing_marks: true,
         };
         (side_a_image, side_b_image, options)
     }
@@ -814,6 +821,7 @@ mod test {
             election,
             score_write_ins: true,
             disable_vertical_streak_detection: false,
+            infer_timing_marks: true,
         };
         (side_a_image, side_b_image, options)
     }

--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -311,7 +311,7 @@ pub fn crop_ballot_page_image_borders(image: GrayImage) -> Option<BallotImage> {
 
 /// Prepare a ballot page image for interpretation by cropping the black border.
 #[allow(clippy::result_large_err)]
-pub fn prepare_ballot_page_image(
+fn prepare_ballot_page_image(
     label: &str,
     image: GrayImage,
     possible_paper_infos: &[PaperInfo],

--- a/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
@@ -85,7 +85,7 @@ pub fn interpret(mut cx: FunctionContext) -> JsResult<JsObject> {
     //   let infer_timing_marks =
     //     typeof options.inferTimingMarks === 'boolean'
     //     ? options.inferTimingMarks
-    //     : false;
+    //     : true;
     let infer_timing_marks = options
         .get_value(&mut cx, "inferTimingMarks")?
         .downcast::<JsBoolean, _>(&mut cx)

--- a/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
@@ -1,12 +1,10 @@
 #![allow(clippy::similar_names)]
 
-use image::{DynamicImage, GrayImage, Luma};
-use imageproc::contrast::{otsu_level, threshold};
+use image::{DynamicImage, GrayImage};
 use neon::prelude::*;
 use neon::types::JsObject;
 
 use crate::ballot_card::load_ballot_scan_bubble_image;
-use crate::image_utils::{bleed, BLACK};
 use crate::interpret::{ballot_card, Options, SIDE_A_LABEL, SIDE_B_LABEL};
 
 use self::args::{
@@ -102,10 +100,6 @@ pub fn interpret(mut cx: FunctionContext) -> JsResult<JsObject> {
         };
 
     let bubble_template = load_ballot_scan_bubble_image().expect("failed to load bubble template");
-    let bubble_template = bleed(
-        &threshold(&bubble_template, otsu_level(&bubble_template)),
-        BLACK,
-    );
     let interpret_result = ballot_card(
         side_a_image,
         side_b_image,

--- a/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
@@ -81,6 +81,18 @@ pub fn interpret(mut cx: FunctionContext) -> JsResult<JsObject> {
         .ok()
         .is_some_and(|b| b.value(&mut cx));
 
+    // Equivalent to:
+    //   let infer_timing_marks =
+    //     typeof options.inferTimingMarks === 'boolean'
+    //     ? options.inferTimingMarks
+    //     : false;
+    let infer_timing_marks = options
+        .get_value(&mut cx, "inferTimingMarks")?
+        .downcast::<JsBoolean, _>(&mut cx)
+        .ok()
+        .and_then(|b| Some(b.value(&mut cx)))
+        .unwrap_or(true);
+
     let side_a_label = side_a_image_or_path.as_label_or(SIDE_A_LABEL);
     let side_b_label = side_b_image_or_path.as_label_or(SIDE_B_LABEL);
     let (side_a_image, side_b_image) = rayon::join(
@@ -110,6 +122,7 @@ pub fn interpret(mut cx: FunctionContext) -> JsResult<JsObject> {
             debug_side_b_base,
             score_write_ins,
             disable_vertical_streak_detection,
+            infer_timing_marks,
         },
     );
 

--- a/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
@@ -90,8 +90,7 @@ pub fn interpret(mut cx: FunctionContext) -> JsResult<JsObject> {
         .get_value(&mut cx, "inferTimingMarks")?
         .downcast::<JsBoolean, _>(&mut cx)
         .ok()
-        .and_then(|b| Some(b.value(&mut cx)))
-        .unwrap_or(true);
+        .is_none_or(|b| b.value(&mut cx));
 
     let side_a_label = side_a_image_or_path.as_label_or(SIDE_A_LABEL);
     let side_b_label = side_b_image_or_path.as_label_or(SIDE_B_LABEL);

--- a/libs/ballot-interpreter/src/hmpb-ts/addon.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/addon.ts
@@ -45,6 +45,7 @@ export function interpret(
   options?: {
     scoreWriteIns?: boolean;
     disableVerticalStreakDetection?: boolean;
+    inferTimingMarks?: boolean;
   }
 ): BridgeInterpretResult {
   return addon.interpret(

--- a/libs/ballot-interpreter/src/hmpb-ts/interpret.test.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/interpret.test.ts
@@ -1,8 +1,10 @@
-import { expect, test } from 'vitest';
 import { assertDefined, iter, ok, unique } from '@votingworks/basics';
-import { ImageData } from 'canvas';
 import { electionGridLayoutNewHampshireTestBallotFixtures } from '@votingworks/fixtures';
+import { loadImageData } from '@votingworks/image-utils';
 import { Election, ElectionDefinition, SheetOf } from '@votingworks/types';
+import { ImageData } from 'canvas';
+import { join } from 'node:path';
+import { expect, test } from 'vitest';
 import { interpret } from './interpret';
 
 const electionGridLayoutNewHampshireTestBallotDefinition =
@@ -717,6 +719,32 @@ test('score write in areas', async () => {
 
   expect(front.writeIns).toMatchSnapshot();
   expect(back.writeIns).toMatchSnapshot();
+});
+
+test('disable timing mark inference', async () => {
+  const electionDefinition = electionGridLayoutNewHampshireTestBallotDefinition;
+  const ballotImages: SheetOf<ImageData> = [
+    await loadImageData(
+      join(
+        __dirname,
+        '../../test/fixtures/m17-backup/1d8eb82c-43bb-454d-a85b-1ffaf65c2b72-front.jpg'
+      )
+    ),
+    await loadImageData(
+      join(
+        __dirname,
+        '../../test/fixtures/m17-backup/1d8eb82c-43bb-454d-a85b-1ffaf65c2b72-back.jpg'
+      )
+    ),
+  ];
+
+  const result = interpret(electionDefinition, ballotImages, {
+    scoreWriteIns: true,
+    inferTimingMarks: false,
+  });
+  expect(result.assertErr('interpret unexpectedly succeeded').type).toEqual(
+    'missingTimingMarks'
+  );
 });
 
 test('interpret with grainy timing marks', async () => {

--- a/libs/ballot-interpreter/src/hmpb-ts/interpret.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/interpret.ts
@@ -41,11 +41,13 @@ function normalizeArgumentsForBridge(
     | {
         scoreWriteIns?: boolean;
         disableVerticalStreakDetection?: boolean;
+        inferTimingMarks?: boolean;
         debug?: boolean;
       }
     | {
         scoreWriteIns?: boolean;
         disableVerticalStreakDetection?: boolean;
+        inferTimingMarks?: boolean;
         debugBasePaths?: SheetOf<string>;
       } = {}
 ): Parameters<typeof interpretImpl> {
@@ -77,6 +79,7 @@ function normalizeArgumentsForBridge(
     {
       scoreWriteIns: options.scoreWriteIns,
       disableVerticalStreakDetection: options.disableVerticalStreakDetection,
+      inferTimingMarks: options.inferTimingMarks,
     },
   ];
 }
@@ -90,6 +93,7 @@ export function interpret(
   options?: {
     scoreWriteIns?: boolean;
     disableVerticalStreakDetection?: boolean;
+    inferTimingMarks?: boolean;
     debug?: boolean;
   }
 ): HmpbInterpretResult;
@@ -102,6 +106,7 @@ export function interpret(
   options?: {
     scoreWriteIns?: boolean;
     disableVerticalStreakDetection?: boolean;
+    inferTimingMarks?: boolean;
     debugBasePaths?: SheetOf<string>;
   }
 ): HmpbInterpretResult;
@@ -115,11 +120,13 @@ export function interpret(
     | {
         scoreWriteIns?: boolean;
         disableVerticalStreakDetection?: boolean;
+        inferTimingMarks?: boolean;
         debug?: boolean;
       }
     | {
         scoreWriteIns?: boolean;
         disableVerticalStreakDetection?: boolean;
+        inferTimingMarks?: boolean;
         debugBasePaths?: SheetOf<string>;
       }
 ): HmpbInterpretResult {

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -615,6 +615,7 @@ function interpretHmpb(
   const result = interpretHmpbBallotSheetRust(electionDefinition, sheet, {
     scoreWriteIns: shouldScoreWriteIns(options),
     disableVerticalStreakDetection: options.disableVerticalStreakDetection,
+    inferTimingMarks: options.inferTimingMarks,
   });
 
   return validateInterpretResults(

--- a/libs/ballot-interpreter/src/types.ts
+++ b/libs/ballot-interpreter/src/types.ts
@@ -13,6 +13,7 @@ export interface InterpreterOptions {
   electionDefinition: ElectionDefinition;
   allowOfficialBallotsInTestMode?: boolean;
   disableVerticalStreakDetection?: boolean;
+  inferTimingMarks?: boolean;
   markThresholds: MarkThresholds;
   precinctSelection: PrecinctSelection;
   testMode: boolean;


### PR DESCRIPTION
## Overview
As part of deciding whether to stop doing timing mark inference it is useful to be able to see how the interpreter performs without it on specific ballots or on a corpus of ballots. Does not hook it up to system settings or anything like that in production.

## Demo Video or Screenshot
n/a

## Testing Plan
Added an automated test to verify that the interpreter fails to find timing marks in a ballot without some bottom timing marks.
