### PR TITLE
[VxScan] Add USB audio card detection to libs/backend:getAudioInfo

### DIFF
--- a/libs/backend/src/system_call/api.test.ts
+++ b/libs/backend/src/system_call/api.test.ts
@@ -5,7 +5,7 @@ import { MockUsbDrive, createMockUsbDrive } from '@votingworks/usb-drive';
 import { LogEventId, MockLogger, mockLogger } from '@votingworks/logging';
 import { SystemCallApiMethods, createSystemCallApi } from './api';
 import { execFile } from '../exec';
-import { getAudioInfo } from './get_audio_info';
+import { AudioInfo, getAudioInfo } from './get_audio_info';
 import { LogsExportError } from './export_logs_to_usb';
 
 vi.mock(import('node:fs/promises'), async (importActual) => ({
@@ -123,6 +123,15 @@ test('setClock', async () => {
 });
 
 test('getAudioInfo', async () => {
-  vi.mocked(getAudioInfo).mockResolvedValue({ headphonesActive: true });
-  await expect(api.getAudioInfo()).resolves.toEqual({ headphonesActive: true });
+  const audioInfo: AudioInfo = {
+    builtin: {
+      headphonesActive: false,
+      name: 'alsa_output.pci.analog-stereo',
+    },
+    usb: {
+      name: 'alsa_output.usb.stereo',
+    },
+  };
+  vi.mocked(getAudioInfo).mockResolvedValue(audioInfo);
+  await expect(api.getAudioInfo()).resolves.toEqual(audioInfo);
 });

--- a/libs/backend/src/system_call/get_audio_info.ts
+++ b/libs/backend/src/system_call/get_audio_info.ts
@@ -1,10 +1,34 @@
 import { LogEventId, Logger } from '@votingworks/logging';
+import { z } from 'zod/v4';
 import { execFile } from '../exec';
 
 /** System audio info. */
 export interface AudioInfo {
-  headphonesActive: boolean;
+  builtin?: BuiltinAudio;
+  usb?: UsbAudio;
 }
+
+/**
+ * Device info for a machine's built-in audio card.
+ */
+export interface BuiltinAudio {
+  headphonesActive: boolean;
+  name: string;
+}
+
+/**
+ * Device info for a connected USB audio card.
+ */
+export interface UsbAudio {
+  name: string;
+}
+
+const PactlSinkListSchema = z.array(
+  z.object({
+    name: z.string(),
+    active_port: z.union([z.string(), z.null()]).optional(),
+  })
+);
 
 /** Get current system audio status. */
 export async function getAudioInfo(logger: Logger): Promise<AudioInfo> {
@@ -14,16 +38,18 @@ export async function getAudioInfo(logger: Logger): Promise<AudioInfo> {
   try {
     ({ stderr: errorOutput, stdout: commandOutput } = await execFile('sudo', [
       '/vx/code/app-scripts/pactl.sh',
+      '-fjson',
       'list',
       'sinks',
     ]));
   } catch (error) {
+    // [TODO] Update log event ID to something more general.
     void logger.logAsCurrentRole(LogEventId.HeadphonesDetectionError, {
       message: `Unable to run pactl command: ${error}}`,
       disposition: 'failure',
     });
 
-    return { headphonesActive: false };
+    return {};
   }
 
   if (errorOutput) {
@@ -32,12 +58,41 @@ export async function getAudioInfo(logger: Logger): Promise<AudioInfo> {
       disposition: 'failure',
     });
 
-    return { headphonesActive: false };
+    return {};
   }
 
-  const headphonesActive = /Active Port:.+headphones/.test(commandOutput);
+  const audioInfo: AudioInfo = {};
 
-  return {
-    headphonesActive,
-  };
+  try {
+    const audioSinks = PactlSinkListSchema.parse(JSON.parse(commandOutput));
+
+    for (const audioSink of audioSinks) {
+      if (audioSink.name.startsWith('alsa_output.pci')) {
+        audioInfo.builtin = {
+          name: audioSink.name,
+          headphonesActive: /headphones/i.test(audioSink.active_port || ''),
+        };
+
+        continue;
+      }
+
+      // [TODO] Placeholder, based on a few test devices. Verify this sink name
+      // is consistent with the tactile controller  we're using for VxScan and
+      // update, if necessary.
+      if (audioSink.name.startsWith('alsa_output.usb')) {
+        audioInfo.usb = {
+          name: audioSink.name,
+        };
+      }
+    }
+  } catch (error) {
+    void logger.logAsCurrentRole(LogEventId.HeadphonesDetectionError, {
+      message: `unable to parse pactl output: ${error}}`,
+      disposition: 'failure',
+    });
+
+    return {};
+  }
+
+  return audioInfo;
 }

--- a/libs/ui/src/hooks/use_headphones_plugged_in.test.ts
+++ b/libs/ui/src/hooks/use_headphones_plugged_in.test.ts
@@ -41,16 +41,32 @@ beforeEach(() => {
 
 test('uses getAudioInfo system call API', async () => {
   const { mockApiClient, renderHook } = createTestContext();
-  mockApiClient.getAudioInfo.mockResolvedValueOnce({ headphonesActive: false });
+  mockApiClient.getAudioInfo.mockResolvedValueOnce({});
 
   const { result, unmount } = renderHook(useHeadphonesPluggedIn);
   await waitFor(() => expect(result.current).toEqual(false));
 
-  mockApiClient.getAudioInfo.mockResolvedValueOnce({ headphonesActive: true });
+  mockApiClient.getAudioInfo.mockResolvedValueOnce({
+    usb: { name: 'alsa_output.usb-Generic.analog-stereo' },
+  });
   vi.advanceTimersByTime(AUDIO_INFO_POLLING_INTERVAL_MS);
   await waitFor(() => expect(result.current).toEqual(true));
 
-  mockApiClient.getAudioInfo.mockResolvedValueOnce({ headphonesActive: false });
+  mockApiClient.getAudioInfo.mockResolvedValueOnce({
+    builtin: {
+      headphonesActive: true,
+      name: 'alsa_output.pci.analog-stereo',
+    },
+  });
+  vi.advanceTimersByTime(AUDIO_INFO_POLLING_INTERVAL_MS);
+  await waitFor(() => expect(result.current).toEqual(true));
+
+  mockApiClient.getAudioInfo.mockResolvedValueOnce({
+    builtin: {
+      headphonesActive: false,
+      name: 'alsa_output.pci.analog-stereo',
+    },
+  });
   vi.advanceTimersByTime(AUDIO_INFO_POLLING_INTERVAL_MS);
   await waitFor(() => expect(result.current).toEqual(false));
 
@@ -63,7 +79,7 @@ test('always returns true if headphones restriction flag is disabled', async () 
   );
 
   const { mockApiClient, renderHook } = createTestContext();
-  mockApiClient.getAudioInfo.mockResolvedValue({ headphonesActive: false });
+  mockApiClient.getAudioInfo.mockResolvedValue({});
 
   const { result } = renderHook(useHeadphonesPluggedIn);
 

--- a/libs/ui/src/hooks/use_headphones_plugged_in.ts
+++ b/libs/ui/src/hooks/use_headphones_plugged_in.ts
@@ -32,9 +32,17 @@ export function useHeadphonesPluggedIn(): boolean {
   );
 
   const audioInfoQuery = getAudioInfo.useQuery();
-  const headphonesPluggedIn = audioInfoQuery.isSuccess
-    ? audioInfoQuery.data.headphonesActive
-    : false;
+  if (!audioInfoQuery.isSuccess) return false;
 
-  return headphonesPluggedIn;
+  // VxScan: headphone audio provided via always-connected USB tactile
+  // controller.
+  if (audioInfoQuery.data.usb) return true;
+
+  // VxMark (v4): headphone audio provided through headphone port on builtin
+  // audio card.
+  if (audioInfoQuery.data.builtin) {
+    return audioInfoQuery.data.builtin.headphonesActive;
+  }
+
+  return false;
 }


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6484

### Background:
- `getAudioInfo` initially parsed output from `pactl list sinks` to figure out if headphones are connected (for VxMark) to the builtin audio card.
- To support screen reader audio in VxScan, we're connecting a USB controller with an audio card, which will register as a USB audio device and potentially with a `"Speaker"` type - still need to verify the details once I have a device on hand, but stubbing this out for now to get the framework in place.
- Will also be adding functionality later on for playing audio to a specific audio sink (output device), which will require specifying the sink name.

### Implementation:
- Given all that, this expands `getAudioInfo` to include details for the builtin audio card as well as a detected USB audio card, if any. Now using the `-fjson` option for `pactl` to output the device list in JSON for easier parsing.
- Extracting the device names for both and, for builtin audio, including a `headphonesActive` flag to match the previous behaviour.

## Testing Plan
- Updated tests to use sample JSON output from `pactl list sinks`
- Verified on production VxMark hardware that we get the expected `pactl` output for headphone detection with this approach.
