### PR TITLE
refactor: remove `FileInputButton` from voting system

### DIFF
--- a/apps/admin/frontend/src/screens/tally/import_cvrfiles_modal.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/import_cvrfiles_modal.test.tsx
@@ -1,12 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { mockKiosk } from '@votingworks/test-utils';
 
-import { ElectronFile, mockUsbDriveStatus } from '@votingworks/ui';
+import { mockUsbDriveStatus } from '@votingworks/ui';
 import userEvent from '@testing-library/user-event';
 import { ok } from '@votingworks/basics';
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import {
-  fireEvent,
   getByText as domGetByText,
   getByTestId as domGetByTestId,
   screen,
@@ -59,7 +58,8 @@ test('when USB is not present or valid', async () => {
 
 describe('when USB is properly mounted', () => {
   test('no files found screen & manual load', async () => {
-    window.kiosk = mockKiosk(vi.fn);
+    const kiosk = mockKiosk(vi.fn);
+    window.kiosk = kiosk;
     const closeFn = vi.fn();
     apiMock.expectGetCastVoteRecordFileMode('unlocked');
     apiMock.expectGetCastVoteRecordFiles([]);
@@ -83,13 +83,11 @@ describe('when USB is properly mounted', () => {
       .resolves(ok(mockCastVoteRecordImportInfo));
 
     // You can still manually load files
-    const file: ElectronFile = {
-      ...new File([''], 'cast-vote-record.jsonl'),
-      path: '/tmp/cast-vote-record.jsonl',
-    };
-    fireEvent.change(screen.getByTestId('manual-input'), {
-      target: { files: [file] },
+    kiosk.showOpenDialog.mockResolvedValue({
+      canceled: false,
+      filePaths: ['/tmp/cast-vote-record.jsonl'],
     });
+    userEvent.click(screen.getByText('Select CVR Export Manually…'));
 
     // modal refetches after adding cast vote record
     apiMock.expectGetCastVoteRecordFileMode('test');

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -95,7 +95,6 @@ export * from './unconfigure_machine_button';
 export * from './change_precinct_button';
 export * from './export_logs_modal';
 export * from './task_screen';
-export * from './types';
 export * from './unconfigured_election_screen';
 export * from './format_usb_modal';
 export * from './usb_drive';

--- a/libs/ui/src/types.ts
+++ b/libs/ui/src/types.ts
@@ -1,6 +1,0 @@
-/**
- * Electron has added a `path` attribute to the `File` interface which exposes
- * the file's real path on filesystem. The regular DOM `File` interface does
- * not include the path due to security concerns when browsing the web.
- */
-export type ElectronFile = File & { path: string };


### PR DESCRIPTION
## Overview

This will be a barrier to any future `electron` upgrades, so replacing our old use of `Electron`'s non-standard `File` properties with the `showOpenDialog` we use elsewhere. 
