### PR TITLE
VxAdmin: Update adjudication queue ordering

### DIFF
--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -104,7 +104,15 @@ type StoreCastVoteRecordAttributes = Omit<
   readonly partyId: string | null;
 };
 
-const ADJUDICATION_QUEUE_ORDER_BY = `order by sequence_id`;
+const ADJUDICATION_QUEUE_ORDER_BY = `
+  order by
+    case
+      when (has_write_in = 1 or has_unmarked_write_in = 1) and has_marginal_mark = 0 then 1
+      when (has_write_in = 1 or has_unmarked_write_in = 1) and has_marginal_mark = 1 then 2
+      else 3
+    end,
+    sequence_id
+`;
 
 /**
  * Path to the store's schema file, i.e. the file that defines the database.


### PR DESCRIPTION
## Overview

Closes: 
https://github.com/votingworks/vxsuite/issues/6532

This PR updates the adjudication queue ordering:
- Previously the queue was ordered by insertion order.
- Now the queue is ordered according to the flow we think will be the simplest for adjudicators - write-ins/no marginal mark -> write-ins and marginal marks -> marginal marks only.

## Testing Plan

Backend test

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
