### PR TITLE
VxAdmin: Disable primary adjudication button if there have been no changes

### DIFF
--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
@@ -633,12 +633,14 @@ describe('vote adjudication', () => {
     expect(kangarooCheckbox).toBeChecked();
     expect(screen.queryByText(/invalid mark/i)).toBeNull();
 
+    // add vote for kangaroo so there is some change, enabling the primary button
+    userEvent.click(kangarooCheckbox);
+
     const primaryButton = screen.getByRole('button', { name: /save & next/i });
     expect(primaryButton).toBeEnabled();
 
     const adjudicatedCvrContest = formAdjudicatedCvrContest(cvrId, {
       lion: { type: 'candidate-option', hasVote: true },
-      kangaroo: { type: 'candidate-option', hasVote: true },
     });
     apiMock.expectAdjudicateCvrContest(adjudicatedCvrContest);
     apiMock.expectGetVoteAdjudications({ contestId, cvrId }, voteAdjudications);
@@ -660,7 +662,7 @@ describe('vote adjudication', () => {
 
     userEvent.click(primaryButton);
     await waitFor(() => {
-      expect(screen.queryByTestId('transcribe:id-174')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('transcribe:id-175')).toBeInTheDocument();
     });
   });
 
@@ -1043,50 +1045,9 @@ describe('ballot navigation', () => {
     backButton = getButtonByName('back');
     expect(backButton).toBeDisabled();
     primaryButton = getButtonByName('save & next');
-    // primary button should be enabled as this cvr already has write-ins resolved
-    expect(primaryButton).toBeEnabled();
-
-    // save & next, which will require refetching as we adjudicate a ballot, invalidating the current queries
-    const adjudicatedCvrContest = formAdjudicatedCvrContest(cvrIds[0], {
-      kangaroo: { type: 'candidate-option', hasVote: true },
-      'write-in-1': {
-        type: 'write-in-option',
-        hasVote: true,
-        candidateType: 'official-candidate',
-        candidateId: 'lion',
-      },
-      'write-in-2': {
-        type: 'write-in-option',
-        hasVote: true,
-        candidateType: 'write-in-candidate',
-        candidateName: 'oliver',
-      },
-    });
-    apiMock.expectAdjudicateCvrContest(adjudicatedCvrContest);
-    apiMock.expectGetVoteAdjudications({ contestId, cvrId: cvrIds[0] }, []);
-    apiMock.expectGetWriteIns(
-      { contestId, cvrId: cvrIds[0] },
-      completedWriteInRecords174
-    );
-    apiMock.expectGetWriteInCandidates(writeInCandidates, contestId);
-    apiMock.expectGetCvrContestTag(
-      { cvrId: cvrIds[0], contestId },
-      cvrContestTag0
-    );
-
-    apiMock.expectGetVoteAdjudications(
-      { contestId, cvrId: firstPendingCvrId },
-      []
-    );
-    apiMock.expectGetWriteIns(
-      { contestId, cvrId: firstPendingCvrId },
-      pendingWriteInRecords175
-    );
-    apiMock.expectGetCvrContestTag(
-      { cvrId: firstPendingCvrId, contestId },
-      cvrContestTag1
-    );
-    userEvent.click(primaryButton);
+    // primary button should be disabled because there have been no modifications
+    expect(primaryButton).toBeDisabled();
+    userEvent.click(skipButton);
     await screen.findByTestId('transcribe:id-175');
 
     // Skip to last ballot

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
@@ -1049,7 +1049,9 @@ export function ContestAdjudicationScreen(): JSX.Element {
               </SecondaryNavButton>
               <PrimaryNavButton
                 disabled={
-                  !allWriteInsAdjudicated || !allMarginalMarksAdjudicated
+                  !allWriteInsAdjudicated ||
+                  !allMarginalMarksAdjudicated ||
+                  !isModified
                 }
                 icon="Done"
                 onPress={saveAndNext}


### PR DESCRIPTION
## Overview

Closes:
https://github.com/votingworks/vxsuite/issues/6504

Previously the primary button was enabled when revisiting a previously adjudicated cvr. But, we thought this might be confusing, and that a user should use "Skip" if they have made no new adjudications.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/8c375a63-5b8b-45c3-9df8-226a7690608b

The video shows that when revisiting a previously adjudicated ballot, `Save & Next` is disabled since there have been no changes.

## Testing Plan

Frontend tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
