### PR TITLE
pdi-scanner: Ensure we always load image calibration tables

### DIFF
--- a/libs/pdi-scanner/src/rust/client.rs
+++ b/libs/pdi-scanner/src/rust/client.rs
@@ -823,7 +823,10 @@ impl<T> Client<T> {
     ///
     /// This function will return an error if any of the commands fail to
     /// validate or if the response is not received within the timeout.
-    pub fn send_initial_commands_after_connect(&mut self, timeout: Duration) -> Result<()> {
+    pub fn send_initial_commands_after_connect(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<ImageCalibrationTables> {
         self.get_test_string(timeout)?;
         self.set_feeder_mode(FeederMode::Disabled)?;
 
@@ -835,7 +838,7 @@ impl<T> Client<T> {
         // OUT UNKNOWN Packet { transfer_type: 0x03, endpoint_address: 0x05, data: <02 1b 4b 03 1b> } (string: "\u{2}\u{1b}K\u{3}\u{1b}") (length: 5)
         self.send_command(&Command::new(b"\x1bK"))?;
 
-        Ok(())
+        self.get_image_calibration_tables(timeout)
     }
 
     /// Sends the same commands to enable scanning that were captured by

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -275,7 +275,8 @@ async fn main() -> color_eyre::Result<()> {
                         Ok(mut c) => {
                             match c.send_initial_commands_after_connect(Duration::from_millis(500))
                             {
-                                Ok(()) => {
+                                Ok(calibration_tables) => {
+                                    image_calibration_tables = Some(calibration_tables);
                                     send_response(Response::Ok)?;
                                 }
                                 // Sometimes, after closing the previous scanner
@@ -286,11 +287,9 @@ async fn main() -> color_eyre::Result<()> {
                                 Err(_) => match c
                                     .send_initial_commands_after_connect(Duration::from_secs(3))
                                 {
-                                    Ok(()) => {
+                                    Ok(calibration_tables) => {
+                                        image_calibration_tables = Some(calibration_tables);
                                         send_response(Response::Ok)?;
-                                        image_calibration_tables = Some(
-                                            c.get_image_calibration_tables(Duration::from_secs(1))?,
-                                        );
                                     }
                                     Err(e) => send_error_response(&e)?,
                                 },


### PR DESCRIPTION


## Overview

Previously, we were only loading them in the case where we needed to retry the initial commands after connect. This was happening so consistently that I didn't notice the bug until just recently.

To mitigate this, I instead moved the request for the image calibration tables to within the initial commands after connect.
## Demo Video or Screenshot
N/A

## Testing Plan
Manual test
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
