### PR TITLE
VxScan: Allow scanning another ballot immediately after accepting a ballot

### DIFF
--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -405,6 +405,10 @@ export function buildApi({
       machine.return();
     },
 
+    readyForNextBallot(): void {
+      machine.readyForNextBallot();
+    },
+
     beginDoubleFeedCalibration(): void {
       machine.beginDoubleFeedCalibration();
     },

--- a/apps/scan/backend/src/electrical_testing/tasks/print_and_scan_task.test.ts
+++ b/apps/scan/backend/src/electrical_testing/tasks/print_and_scan_task.test.ts
@@ -1,8 +1,10 @@
 import { createImageData } from 'canvas';
 import { afterEach, beforeEach, expect, vi } from 'vitest';
 import { test } from '../../../test/helpers/test';
-import { delays } from '../../scanners/pdi/state_machine';
-import { runPrintAndScanTask } from './print_and_scan_task';
+import {
+  DELAY_AFTER_ACCEPT_MS,
+  runPrintAndScanTask,
+} from './print_and_scan_task';
 
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -46,9 +48,7 @@ test.electrical(
     });
 
     // Wait long enough that we eject the paper.
-    await vi.advanceTimersByTimeAsync(
-      delays.DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT
-    );
+    await vi.advanceTimersByTimeAsync(DELAY_AFTER_ACCEPT_MS);
 
     await vi.waitFor(() => {
       expect(

--- a/apps/scan/backend/src/electrical_testing/tasks/print_and_scan_task.ts
+++ b/apps/scan/backend/src/electrical_testing/tasks/print_and_scan_task.ts
@@ -7,13 +7,13 @@ import { DateTime } from 'luxon';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { inspect } from 'node:util';
-import { delays } from '../../scanners/pdi/state_machine';
 import { writeScanPageAnalyses } from '../analysis/scan';
 import { type ServerContext } from '../context';
 import { resultToString } from '../utils';
 
 export const LOOP_INTERVAL_MS = 100;
 export const PRINT_INTERVAL_SECONDS = 5 * 60;
+export const DELAY_AFTER_ACCEPT_MS = 2_500;
 
 function createPrinterTestImage(): ImageData {
   const canvas = createCanvas(200, 50);
@@ -194,7 +194,7 @@ export async function runPrintAndScanTask({
       if (
         lastScanTime &&
         DateTime.now().diff(lastScanTime).as('milliseconds') >
-          delays.DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT
+          DELAY_AFTER_ACCEPT_MS
       ) {
         await scannerClient.ejectAndRescanPaperIfPresent();
 

--- a/apps/scan/backend/src/scanners/custom/state_machine.ts
+++ b/apps/scan/backend/src/scanners/custom/state_machine.ts
@@ -1377,6 +1377,10 @@ export function createPrecinctScannerStateMachine({
     },
 
     /* istanbul ignore next - @preserve */
+    readyForNextBallot() {
+      throw new Error('Not supported');
+    },
+    /* istanbul ignore next - @preserve */
     beginDoubleFeedCalibration() {
       throw new Error('Not supported');
     },

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan.test.ts
@@ -83,8 +83,7 @@ test('configure and scan hmpb', async () => {
         ballotsCounted: 1,
       });
 
-      // Test waiting for automatic transition back to no_paper
-      clock.increment(delays.DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT);
+      await apiClient.readyForNextBallot();
       await waitForStatus(apiClient, { state: 'no_paper', ballotsCounted: 1 });
 
       // Do some basic logging checks to ensure that we're logging state machine changes

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_double_sheet.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_double_sheet.test.ts
@@ -268,7 +268,7 @@ test('insert second ballot after accept, should be scanned', async () => {
       // Simulate inserting a second ballot
       mockScanner.setScannerStatus(mockScannerStatus.documentInFront);
 
-      clock.increment(delays.DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT);
+      await apiClient.readyForNextBallot();
       await waitForStatus(apiClient, {
         state: 'no_paper',
         ballotsCounted,

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_jam.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_jam.test.ts
@@ -108,7 +108,7 @@ test('jam while accepting', async () => {
         interpretation,
         ballotsCounted: 1,
       });
-      clock.increment(delays.DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT);
+      await apiClient.readyForNextBallot();
       await waitForStatus(apiClient, {
         state: 'jammed',
         error: 'outfeed_blocked',
@@ -154,7 +154,7 @@ test('timeout while accepting', async () => {
         ballotsCounted: 1,
       });
 
-      clock.increment(delays.DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT);
+      await apiClient.readyForNextBallot();
       await waitForStatus(apiClient, {
         state: 'jammed',
         error: 'outfeed_blocked',

--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_shoeshine_mode.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_shoeshine_mode.test.ts
@@ -68,7 +68,7 @@ test('shoeshine mode scans the same ballot repeatedly', async () => {
       });
       expect(mockScanner.client.ejectDocument).not.toHaveBeenCalled();
 
-      clock.increment(delays.DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT);
+      await apiClient.readyForNextBallot();
       await waitForStatus(apiClient, {
         state: 'accepted',
         ballotsCounted: 1,
@@ -122,7 +122,7 @@ test('handles error on eject for rescan', async () => {
       mockScanner.client.ejectDocument.mockRejectedValue(
         new Error('eject failed')
       );
-      clock.increment(delays.DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT);
+      await apiClient.readyForNextBallot();
       await waitForStatus(apiClient, {
         state: 'unrecoverable_error',
         ballotsCounted: 1,

--- a/apps/scan/backend/src/types.ts
+++ b/apps/scan/backend/src/types.ts
@@ -55,6 +55,7 @@ export interface PrecinctScannerStateMachine {
   // in the status.
   accept: () => void;
   return: () => void;
+  readyForNextBallot: () => void;
 
   beginDoubleFeedCalibration: () => void;
   endDoubleFeedCalibration: () => void;

--- a/apps/scan/backend/test/helpers/pdi_helpers.ts
+++ b/apps/scan/backend/test/helpers/pdi_helpers.ts
@@ -286,7 +286,7 @@ export async function scanBallot(
     interpretation: { type: 'ValidSheet' },
     ballotsCounted: initialBallotsCounted + 1,
   });
-  clock.increment(delays.DELAY_ACCEPTED_READY_FOR_NEXT_BALLOT);
+  await apiClient.readyForNextBallot();
   await waitForStatus(apiClient, {
     state: 'no_paper',
     ballotsCounted: initialBallotsCounted + 1,

--- a/apps/scan/backend/test/helpers/shared_helpers.ts
+++ b/apps/scan/backend/test/helpers/shared_helpers.ts
@@ -152,6 +152,7 @@ export function createPrecinctScannerStateMachineMock(): Mocked<PrecinctScannerS
     status: vi.fn(),
     accept: vi.fn(),
     return: vi.fn(),
+    readyForNextBallot: vi.fn(),
     stop: vi.fn(),
     beginDoubleFeedCalibration: vi.fn(),
     endDoubleFeedCalibration: vi.fn(),

--- a/apps/scan/frontend/src/api.ts
+++ b/apps/scan/frontend/src/api.ts
@@ -393,6 +393,13 @@ export const returnBallot = {
   },
 } as const;
 
+export const readyForNextBallot = {
+  useMutation() {
+    const apiClient = useApiClient();
+    return useMutation(apiClient.readyForNextBallot);
+  },
+} as const;
+
 export const beginDoubleFeedCalibration = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -1,6 +1,8 @@
 import { ElectionDefinition, SystemSettings } from '@votingworks/types';
 import { assert, throwIllegalValue } from '@votingworks/basics';
-import { getScannerStatus } from '../api';
+import { useQueryChangeListener } from '@votingworks/ui';
+import { useRef, useState } from 'react';
+import { getScannerStatus, readyForNextBallot } from '../api';
 import { POLLING_INTERVAL_FOR_SCANNER_STATUS_MS } from '../config/globals';
 import { InsertBallotScreen } from './insert_ballot_screen';
 import { ScanBusyScreen } from './scan_busy_screen';
@@ -12,6 +14,12 @@ import { ScanSuccessScreen } from './scan_success_screen';
 import { ScanWarningScreen } from './scan_warning_screen';
 import { ScanDoubleSheetScreen } from './scan_double_sheet_screen';
 import { useScanFeedbackAudio } from '../utils/use_scan_feedback_audio';
+
+/**
+ * How long to show the accepted screen after a ballot is accepted before
+ * resetting to the insert ballot screen.
+ */
+export const DELAY_ACCEPTED_SCREEN_MS = 3_000;
 
 export interface VoterScreenProps {
   electionDefinition: ElectionDefinition;
@@ -33,6 +41,32 @@ export function VoterScreen({
   useScanFeedbackAudio({
     currentState: scannerStatusQuery.data?.state,
     isSoundMuted,
+  });
+
+  // When a ballot is accepted, show the accepted screen for a few seconds.
+  // Once we're sure that the accepted screen is shown, tell the backend to
+  // re-enable scanning (in case a user wants to insert another ballot right
+  // away). This will transition the scanner to the `no_paper` state, so we use
+  // a separate local state variable to track how long to show the accepted
+  // screen.
+  const readyForNextBallotMutation = readyForNextBallot.useMutation();
+  const [isShowingAcceptedScreen, setIsShowingAcceptedScreen] = useState(false);
+  const acceptedScreenTimeoutRef = useRef<number>();
+  useQueryChangeListener(scannerStatusQuery, {
+    select: (status) => status.state,
+    onChange: (newState) => {
+      if (newState === 'accepted') {
+        setIsShowingAcceptedScreen(true);
+        if (acceptedScreenTimeoutRef.current) {
+          window.clearTimeout(acceptedScreenTimeoutRef.current);
+        }
+        acceptedScreenTimeoutRef.current = window.setTimeout(
+          () => setIsShowingAcceptedScreen(false),
+          DELAY_ACCEPTED_SCREEN_MS
+        );
+        readyForNextBallotMutation.mutate();
+      }
+    },
   });
 
   if (!scannerStatusQuery.isSuccess) {
@@ -71,8 +105,12 @@ export function VoterScreen({
     case 'paused':
     case 'scanner_diagnostic.running':
     case 'scanner_diagnostic.done':
-    case 'no_paper':
+    case 'no_paper': {
+      if (isShowingAcceptedScreen) {
+        return <ScanSuccessScreen {...sharedScreenProps} />;
+      }
       return <InsertBallotScreen {...sharedScreenProps} />;
+    }
     case 'hardware_ready_to_scan':
     case 'scanning':
     case 'accepting':

--- a/apps/scan/frontend/vitest.config.ts
+++ b/apps/scan/frontend/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: 94,
-        branches: 84,
+        branches: 91,
       },
       exclude: [
         'src/config/*',


### PR DESCRIPTION
## Overview

Closes: #6122 

Previously, we enforced a 2.5s delay after a ballot was accepted before another ballot could be scanned. This caused issues for both election officials during L&A (who need to scan many ballots in succession) and voters with multi-sheet ballots (who didn't want to wait between sheets).

We had previously thought this delay was necessary to prevent the scanner from overheating, but it turns out this is not an issue.

This PR removes the delay. In order to make sure the user gets feedback that their ballot was accepted, we now wait for the frontend to tell the backend when it can allow another ballot to be inserted after accept. The frontend waits to send this signal to the backend until it's made sure to show the accepted screen and play the associated chime. The frontend then continues to show the accepted screen for up to 3s. If a new ballot is inserted during this 3s window, we'll immediately transition to the  scan in progress screen.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/21c2fcb2-9017-41e3-a4ed-6b95aea3991e



## Testing Plan
- Manual testing
- Updated automated tests
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
