### PR TITLE
Backfill adminAdjudicationReasons on system settings in VxDesign DB

### DIFF
--- a/apps/design/backend/migrations/1749064994074_backfill-admin-adjudication-reasons-on-system-settings.js
+++ b/apps/design/backend/migrations/1749064994074_backfill-admin-adjudication-reasons-on-system-settings.js
@@ -1,0 +1,32 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void>}
+ */
+exports.up = async (pgm) => {
+  const entries = await pgm.db.select({
+    text: 'SELECT id, system_settings_data FROM elections',
+  });
+  for (const {
+    id: electionId,
+    system_settings_data: systemSettingsData,
+  } of entries) {
+    /** @type import('@votingworks/types').SystemSettings */
+    const systemSettings = JSON.parse(systemSettingsData);
+    await pgm.db.query({
+      text: 'UPDATE elections SET system_settings_data = $1 WHERE id = $2',
+      values: [
+        JSON.stringify({
+          ...systemSettings,
+          adminAdjudicationReasons: [],
+        }),
+        electionId,
+      ],
+    });
+  }
+};


### PR DESCRIPTION
## Overview

Deploying VxDesign to the latest main results in elections failing to load when clicked on, with the following error under the hood:

```
[
  {
    "expected": "array",
    "code": "invalid_type",
    "path": [
      "adminAdjudicationReasons"
    ],
    "message": "Invalid input: expected array, received undefined"
  }
]
```

Simple fix: We just need to run a migration to backfill the `adminAdjudicationReasons` field on system settings in the VxDesign DB.

This should allow us to deploy VxDesign to the latest main safely.

## Testing Plan

- [x] Repro locally by creating an election pre-`adminAdjudicationReasons` and then trying to open on main
- [x] Run the migration locally with `pnpm db:migrations:run-dev`
- [x] Successfully open the election

Will also confirm that this works in staging before merging and deploying to production