### PR TITLE
VxAdmin: Button for system admin to revert election results to unofficial

### DIFF
--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -187,6 +187,7 @@ test('managing the current election', async () => {
     'election_manager',
     expect.objectContaining({
       disposition: 'success',
+      official: true,
     })
   );
   expect(await apiClient.getCurrentElectionMetadata()).toMatchObject({
@@ -195,11 +196,29 @@ test('managing the current election', async () => {
     electionDefinition,
   });
 
+  // revert results to unofficial as system administrator
+  mockSystemAdministratorAuth(auth);
+  await apiClient.revertResultsToUnofficial();
+  expect(logger.log).toHaveBeenNthCalledWith(
+    6,
+    LogEventId.MarkedTallyResultsOfficial,
+    'system_administrator',
+    expect.objectContaining({
+      disposition: 'success',
+      official: false,
+    })
+  );
+  expect(await apiClient.getCurrentElectionMetadata()).toMatchObject({
+    isOfficialResults: false,
+    id: electionId,
+    electionDefinition,
+  });
+
   // unconfigure as system administrator
   mockSystemAdministratorAuth(auth);
   await apiClient.unconfigure();
   expect(logger.log).toHaveBeenNthCalledWith(
-    6,
+    7,
     LogEventId.ElectionUnconfigured,
     'system_administrator',
     expect.objectContaining({

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -514,6 +514,20 @@ function buildApi({
         message:
           'User has marked the tally results as official, no more cast vote record files can be loaded.',
         disposition: 'success',
+        official: true,
+      });
+    },
+
+    async revertResultsToUnofficial(): Promise<void> {
+      store.setElectionResultsOfficial(
+        loadCurrentElectionIdOrThrow(workspace),
+        false
+      );
+
+      await logger.logAsCurrentRole(LogEventId.MarkedTallyResultsOfficial, {
+        message: 'User reverted the tally results to unofficial.',
+        disposition: 'success',
+        official: false,
       });
     },
 

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -678,6 +678,20 @@ export const markResultsOfficial = {
   },
 } as const;
 
+export const revertResultsToUnofficial = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.revertResultsToUnofficial, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(
+          getCurrentElectionMetadata.queryKey()
+        );
+      },
+    });
+  },
+} as const;
+
 export const clearCastVoteRecordFiles = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/admin/frontend/src/components/mark_official_button.tsx
+++ b/apps/admin/frontend/src/components/mark_official_button.tsx
@@ -1,6 +1,10 @@
 import React, { useContext, useState } from 'react';
 import { Button, Modal, P } from '@votingworks/ui';
-import { getCastVoteRecordFileMode, markResultsOfficial } from '../api';
+import {
+  getCastVoteRecordFileMode,
+  markResultsOfficial,
+  revertResultsToUnofficial,
+} from '../api';
 import { AppContext } from '../contexts/app_context';
 
 export const MARK_RESULTS_OFFICIAL_BUTTON_TEXT =
@@ -27,8 +31,9 @@ export function MarkResultsOfficialButton(): JSX.Element {
   }
 
   function markOfficial() {
-    setIsModalOpen(false);
-    markResultsOfficialMutation.mutate();
+    markResultsOfficialMutation.mutate(undefined, {
+      onSuccess: closeModal,
+    });
   }
 
   return (
@@ -58,8 +63,73 @@ export function MarkResultsOfficialButton(): JSX.Element {
           }
           actions={
             <React.Fragment>
-              <Button icon="Done" variant="primary" onPress={markOfficial}>
+              <Button
+                icon="Done"
+                variant="primary"
+                onPress={markOfficial}
+                disabled={markResultsOfficialMutation.isLoading}
+              >
                 Mark Election Results as Official
+              </Button>
+              <Button onPress={closeModal}>Cancel</Button>
+            </React.Fragment>
+          }
+          onOverlayClick={closeModal}
+        />
+      )}
+    </React.Fragment>
+  );
+}
+
+export function RevertResultsToUnofficialButton(): JSX.Element {
+  const { isOfficialResults } = useContext(AppContext);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const revertResultsToUnofficialMutation =
+    revertResultsToUnofficial.useMutation();
+
+  function openModal() {
+    setIsModalOpen(true);
+  }
+
+  function closeModal() {
+    setIsModalOpen(false);
+  }
+
+  function revertToUnofficial() {
+    revertResultsToUnofficialMutation.mutate(undefined, {
+      onSuccess: closeModal,
+    });
+  }
+
+  return (
+    <React.Fragment>
+      <Button
+        icon="Delete"
+        color="danger"
+        fill="outlined"
+        disabled={!isOfficialResults}
+        onPress={openModal}
+      >
+        Revert Election Results to Unofficial
+      </Button>
+      {isModalOpen && (
+        <Modal
+          title="Revert Election Results to Unofficial"
+          content={
+            <P>
+              After reverting, election managers will be able to modify election
+              data. Void any previously exported official reports.
+            </P>
+          }
+          actions={
+            <React.Fragment>
+              <Button
+                icon="Delete"
+                variant="danger"
+                onPress={revertToUnofficial}
+                disabled={revertResultsToUnofficialMutation.isLoading}
+              >
+                Revert Election Results to Unofficial
               </Button>
               <Button onPress={closeModal}>Cancel</Button>
             </React.Fragment>

--- a/apps/admin/frontend/src/components/mark_official_button.tsx
+++ b/apps/admin/frontend/src/components/mark_official_button.tsx
@@ -118,7 +118,7 @@ export function RevertResultsToUnofficialButton(): JSX.Element {
           content={
             <P>
               After reverting, election managers will be able to modify election
-              data. Void any previously exported official reports.
+              data. Previously exported official reports should be voided.
             </P>
           }
           actions={

--- a/apps/admin/frontend/src/screens/election_screen.tsx
+++ b/apps/admin/frontend/src/screens/election_screen.tsx
@@ -6,13 +6,23 @@ import {
   isSystemAdministratorAuth,
 } from '@votingworks/utils';
 import { assert } from '@votingworks/basics';
-import { Card, H2, P, Seal, UnconfigureMachineButton } from '@votingworks/ui';
+import {
+  Card,
+  H2,
+  H3,
+  Icons,
+  P,
+  Seal,
+  UnconfigureMachineButton,
+} from '@votingworks/ui';
 import { useHistory } from 'react-router-dom';
 import { AppContext } from '../contexts/app_context';
 import { NavigationScreen } from '../components/navigation_screen';
 import { ExportElectionPackageModalButton } from '../components/export_election_package_modal_button';
 import { unconfigure } from '../api';
 import { routerPaths } from '../router_paths';
+import { OfficialResultsCard } from '../components/official_results_card';
+import { RevertResultsToUnofficialButton } from '../components/mark_official_button';
 
 const ElectionCard = styled(Card).attrs({ color: 'neutral' })`
   margin: 1rem 0;
@@ -26,7 +36,8 @@ const ElectionCard = styled(Card).attrs({ color: 'neutral' })`
 `;
 
 export function ElectionScreen(): JSX.Element {
-  const { electionDefinition, configuredAt, auth } = useContext(AppContext);
+  const { electionDefinition, configuredAt, auth, isOfficialResults } =
+    useContext(AppContext);
   const history = useHistory();
   const unconfigureMutation = unconfigure.useMutation();
 
@@ -45,6 +56,15 @@ export function ElectionScreen(): JSX.Element {
 
   return (
     <NavigationScreen title="Election">
+      {isSystemAdministratorAuth(auth) && isOfficialResults && (
+        <OfficialResultsCard>
+          <H3>
+            <Icons.Done color="success" />
+            Election Results are Official
+          </H3>
+          <RevertResultsToUnofficialButton />
+        </OfficialResultsCard>
+      )}
       <P>
         Configured with the current election at{' '}
         {format.localeLongDateAndTime(new Date(configuredAt))}.


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6124

Adds a button to the Election screen for system admins to revert election results to unofficial after they have been marked official (after confirming in a modal).

Note that we only show the callout when election results are marked official, so after reverting there's no confirmation message on screen other than the fact that the callout is gone. While I wouldn't normally want to have a flow with no visual confirmation message, I think it's ok since (1) this isn't a main flow (2) there's still confirmation via the disappearance of the callout, and (3) you can easily check that it worked by logging in as an election manager.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/e162b5d2-2a32-4afd-bb80-cca15305dcd9




## Testing Plan
- Manual test
- Added automated tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
