### PR TITLE
VxAdmin: Add icons to non-candidate adjudication dropdown options

### DIFF
--- a/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
+++ b/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
@@ -75,7 +75,7 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
         )
       : candidateNames;
 
-    const options = filteredNames.map((name) => ({
+    const candidateOptions = filteredNames.map((name) => ({
       label: name,
       value: name,
     }));
@@ -99,27 +99,51 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
     }
 
     // If value has been entered and it is a new entry, add it the dropdown
-    if (value && !options.some((option) => option.label === value)) {
-      options.unshift({ label: value, value });
+    if (value && !candidateOptions.some((option) => option.label === value)) {
+      candidateOptions.unshift({ label: value, value });
     }
 
     // 'Press enter to add: NEW_CANDIDATE' entry if there is no exact match
+    let newCandidateOption:
+      | { label: React.ReactNode; value: string }
+      | undefined;
     if (
       inputValue &&
       inputValue.length < MAX_WRITE_IN_NAME_LENGTH &&
-      !options.some(
+      !candidateOptions.some(
         (item) => normalizeWriteInName(item.label) === normalizedInputValue
       )
     ) {
-      options.push({
-        label: `Press enter to add: ${inputValue}`,
+      newCandidateOption = {
+        label: (
+          <span>
+            <Icons.Add style={{ marginRight: '.125rem' }} /> Press enter to add:{' '}
+            {inputValue}
+          </span>
+        ),
         value: inputValue,
-      });
+      };
     }
 
+    let invalidMarkOption:
+      | { label: React.ReactNode; value: string }
+      | undefined;
     if (!inputValue) {
-      options.unshift({ label: 'Invalid mark', value: INVALID_KEY });
+      invalidMarkOption = {
+        label: (
+          <span>
+            <Icons.Disabled style={{ marginRight: '.125rem' }} /> Invalid mark
+          </span>
+        ),
+        value: INVALID_KEY,
+      };
     }
+
+    const allOptions: Array<{ label: React.ReactNode; value: string }> = [
+      ...(invalidMarkOption ? [invalidMarkOption] : []),
+      ...candidateOptions,
+      ...(newCandidateOption ? [newCandidateOption] : []),
+    ];
 
     return (
       <Container ref={ref} style={{ zIndex: isFocused ? 10 : 0 }}>
@@ -137,7 +161,7 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
           // changes. `hasInvalidEntry` as the key forces a re-render
           key={`${hasInvalidEntry}-${value}`}
           menuPortalTarget={document.body}
-          options={options}
+          options={allOptions}
           onBlur={onInputBlur}
           onFocus={onInputFocus}
           onInputChange={onInputChange}

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
@@ -61,6 +61,22 @@ function getDropdownItemByLabel(label: string) {
     .find((el) => el.getAttribute('aria-disabled') === 'false');
 }
 
+function getInvalidMarkItem() {
+  return screen.getByText(
+    (_, node) =>
+      (node?.textContent ?? '').includes('Invalid mark') &&
+      node?.getAttribute('aria-disabled') === 'false'
+  );
+}
+
+function getAddCandidateItem() {
+  return screen.getByText(
+    (_, node) =>
+      (node?.textContent ?? '').includes('Press enter to add:') &&
+      node?.getAttribute('aria-disabled') === 'false'
+  );
+}
+
 function getButtonByName(name: string) {
   return screen.getByRole('button', { name: new RegExp(name, 'i') });
 }
@@ -372,7 +388,7 @@ describe('hmpb write-in adjudication', () => {
     expect(writeInSearchSelect).toHaveAttribute('aria-expanded', 'true');
 
     expect(screen.queryByText(/press enter to add:/i)).not.toBeInTheDocument();
-    expect(screen.queryAllByText(/invalid mark/i)).toHaveLength(2);
+    expect(screen.queryByText(/invalid mark/i)).toBeInTheDocument();
     expect(screen.queryByText(/oliver/i)).toBeInTheDocument();
 
     userEvent.type(writeInSearchSelect, 'siena');
@@ -381,8 +397,8 @@ describe('hmpb write-in adjudication', () => {
     expect(screen.queryByText(/oliver/i)).not.toBeInTheDocument();
 
     // add new candidate
-    const addNewItem = getDropdownItemByLabel('Press enter to add: siena');
-    userEvent.click(addNewItem!);
+    const addNewItem = getAddCandidateItem();
+    userEvent.click(addNewItem);
 
     // once that candidate is added, they should be included in the next dropdown search
     writeInSearchSelect = screen.getByRole('combobox');
@@ -494,8 +510,8 @@ describe('bmd write-in adjudication', () => {
     writeInSearchSelect = screen.getByRole('combobox');
     expect(writeInSearchSelect).toHaveAttribute('aria-expanded', 'true');
 
-    const invalidMarkItem = getDropdownItemByLabel('Invalid mark');
-    userEvent.click(invalidMarkItem!);
+    const invalidMarkItem = getInvalidMarkItem();
+    userEvent.click(invalidMarkItem);
 
     expect(screen.queryByText(/invalid mark/i)).toBeInTheDocument();
 

--- a/libs/ui/src/search_select.tsx
+++ b/libs/ui/src/search_select.tsx
@@ -60,7 +60,7 @@ function MultiValueRemove(
 
 export interface SelectOption<T = string> {
   value: T;
-  label: string;
+  label: React.ReactNode;
 }
 
 interface SearchSelectBaseProps<T = string> {


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6242

This PR adds an icon to the "Add candidate" and "Invalid mark" dropdown options, to help distinguish them from the existing candidate options.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/e7582fcc-7e1e-429d-87fc-d6fa0f0077bf

## Testing Plan

Manual testing and updated existing tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
