### PR TITLE
VxAdmin: Improve SearchSelect behavior when opening upwards

### DIFF
--- a/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
+++ b/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
@@ -161,6 +161,7 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
           // changes. `hasInvalidEntry` as the key forces a re-render
           key={`${hasInvalidEntry}-${value}`}
           menuPortalTarget={document.body}
+          maxMenuHeight={450} // 6 options, 75px each
           options={allOptions}
           onBlur={onInputBlur}
           onFocus={onInputFocus}

--- a/libs/ui/src/search_select.tsx
+++ b/libs/ui/src/search_select.tsx
@@ -78,6 +78,7 @@ interface SearchSelectBaseProps<T = string> {
   onInputChange?: (value?: T) => void;
   menuPortalTarget?: HTMLElement;
   minMenuHeight?: number;
+  maxMenuHeight?: number;
   noOptionsMessage?: () => React.ReactNode;
 }
 
@@ -123,6 +124,7 @@ export function SearchSelect<T = string>({
   menuPortalTarget,
   minMenuHeight,
   noOptionsMessage,
+  maxMenuHeight = 600, // in px, 1/2 admin's vh
   style = {},
 }: SearchSelectSingleProps<T> | SearchSelectMultiProps<T>): JSX.Element {
   const theme = useTheme();
@@ -158,10 +160,10 @@ export function SearchSelect<T = string>({
       unstyled
       components={{ DropdownIndicator, MultiValueRemove }}
       className="search-select"
-      maxMenuHeight="50vh"
       menuPlacement="auto"
       menuPortalTarget={menuPortalTarget}
       minMenuHeight={minMenuHeight}
+      maxMenuHeight={maxMenuHeight}
       noOptionsMessage={noOptionsMessage}
       styles={typedAs<StylesConfig>({
         container: (baseStyles) => ({


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6569

The search select hasn't respected the `maxMenuHeight` and it looks like it's because it needs a number representing pixels. 

## Demo Video or Screenshot

New -

<img width="1082" alt="Screenshot 2025-06-04 at 3 18 28 PM" src="https://github.com/user-attachments/assets/445647ec-6b6c-4b0e-9b6f-b865b8ca6423" />

Old -

<img width="1085" alt="Screenshot 2025-06-04 at 3 18 06 PM" src="https://github.com/user-attachments/assets/2a26d2b8-e0d7-4fb3-8169-ff0042636eb3" />

## Testing Plan

Manual and upcoming QA

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
