### PR TITLE
Support creating CSR with VxPollBook strongSwan TPM key

### DIFF
--- a/libs/auth/src/env.d.ts
+++ b/libs/auth/src/env.d.ts
@@ -1,6 +1,7 @@
 declare namespace NodeJS {
   export interface ProcessEnv {
     readonly NODE_ENV: 'development' | 'production' | 'test';
+    readonly USE_STRONGSWAN_TPM_KEY?: string;
     readonly VX_CONFIG_ROOT?: string;
     readonly VX_MACHINE_TYPE?:
       | 'admin'


### PR DESCRIPTION
## Overview

This PR exposes a `USE_STRONGSWAN_TPM_KEY` environment variable to support creating a CSR with the VxPollBook strongSwan TPM key. We'll use this in vxsuite-complete-system to create a second TPM key/cert pair for securing local networking on VxPollBook. A second TPM key is necessary because this key requires different attributes than the TPM key we use for auth operations.