### PR TITLE
[libs/backend] Enable getAudioInfo() usage in dev

### DIFF
--- a/libs/backend/src/system_call/api.ts
+++ b/libs/backend/src/system_call/api.ts
@@ -7,6 +7,7 @@ import { powerDown } from './power_down';
 import { setClock } from './set_clock';
 import { getBatteryInfo } from './get_battery_info';
 import { getAudioInfo } from './get_audio_info';
+import { NODE_ENV } from '../scan_globals';
 
 function buildApi({
   usbDrive,
@@ -32,7 +33,7 @@ function buildApi({
     powerDown: async () => powerDown(logger),
     setClock,
     getBatteryInfo,
-    getAudioInfo: async () => getAudioInfo(logger),
+    getAudioInfo: async () => getAudioInfo({ logger, nodeEnv: NODE_ENV }),
   };
 }
 

--- a/libs/backend/src/system_call/index.ts
+++ b/libs/backend/src/system_call/index.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file - @preserve */
 export * from './api';
+export * as audio from './get_audio_info';
 export type { LogsResultType } from './export_logs_to_usb';
 export { getBatteryInfo } from './get_battery_info';
 export type { BatteryInfo } from './get_battery_info';


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6484

Adding a dev fallback to `getAudioInfo()` to invoke `pactl` directly, instead of going through the app script (which is only available on prod images). This enables dev iteration/testing on VMs.

Also:
- Verified that the tactile controller hardware shows up as `alsa_output.usb...`, so removing that TODO comment
- Exporting the `getAudioInfo()` API externally, so we can later use it directly in VxScan (at startup, to perform audio setup).

## Testing Plan
- Unit tests for the new branch
- Manual test for usb audio detection on dev VM

