### PR TITLE
[VxScan] Add preliminary support for controller/keyboard navigation

### DIFF
--- a/apps/scan/frontend/src/app.tsx
+++ b/apps/scan/frontend/src/app.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Route } from 'react-router-dom';
 import { BaseLogger, LogSource } from '@votingworks/logging';
 import { QueryClient } from '@tanstack/react-query';
 import { AppErrorBoundary } from '@votingworks/ui';
+import React from 'react';
 import { AppRoot } from './app_root';
 import { ApiClient, createApiClient, createQueryClient } from './api';
 import { ScanAppBase } from './scan_app_base';
@@ -10,6 +11,7 @@ import { SessionTimeLimitTracker } from './components/session_time_limit_tracker
 import { Paths } from './constants';
 import { VoterSettingsScreen } from './screens/voter_settings_screen';
 import { ApiProvider } from './api_provider';
+import { handleKeyboardEvent } from './utils/ui_navigation';
 
 export interface AppProps {
   logger?: BaseLogger;
@@ -28,6 +30,12 @@ export function App({
   enableStringTranslation,
   noAudio,
 }: AppProps): JSX.Element {
+  // Handle navigation key events from the tactile controller/keyboard.
+  React.useEffect(() => {
+    document.addEventListener('keydown', handleKeyboardEvent);
+    return () => document.removeEventListener('keydown', handleKeyboardEvent);
+  }, []);
+
   return (
     <ScanAppBase>
       <BrowserRouter>

--- a/apps/scan/frontend/src/preview_app.tsx
+++ b/apps/scan/frontend/src/preview_app.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable vx/gts-direct-module-export-access-only */
 /* istanbul ignore file - @preserve */
 
+import React from 'react';
 import { PreviewDashboard } from './preview_dashboard';
 import * as CardErrorScreen from './screens/card_error_screen';
 import * as ElectionManagerScreen from './screens/election_manager_screen';
@@ -23,8 +24,15 @@ import * as SetupScannerScreen from './screens/internal_connection_problem_scree
 import * as UnconfiguredElectionScreenWrapper from './screens/unconfigured_election_screen_wrapper';
 import * as UnconfiguredPrecinctScreen from './screens/unconfigured_precinct_screen';
 import { ScanAppBase } from './scan_app_base';
+import { handleKeyboardEvent } from './utils/ui_navigation';
 
 export function PreviewApp(): JSX.Element {
+  // Handle navigation key events from the tactile controller/keyboard.
+  React.useEffect(() => {
+    document.addEventListener('keydown', handleKeyboardEvent);
+    return () => document.removeEventListener('keydown', handleKeyboardEvent);
+  }, []);
+
   return (
     <ScanAppBase>
       <PreviewDashboard

--- a/apps/scan/frontend/src/utils/ui_navigation.ts
+++ b/apps/scan/frontend/src/utils/ui_navigation.ts
@@ -1,0 +1,46 @@
+import {
+  Keybinding,
+  PageNavigationButtonId,
+  advanceElementFocus,
+  triggerPageNavigationButton,
+} from '@votingworks/ui';
+
+/**
+ * Prevents the default browser scroll behavior for the arrow keys, since we're
+ * re-mapping them for focus navigation.
+ *
+ * This avoids the page constantly scrolling while focus is moved, which could
+ * be a little disorienting for some voters.
+ */
+function preventBrowserScroll(event: KeyboardEvent) {
+  event.preventDefault();
+}
+
+/* istanbul ignore next - @preserve */
+export function handleKeyboardEvent(event: KeyboardEvent): void {
+  switch (event.key) {
+    case Keybinding.PAGE_PREVIOUS:
+      triggerPageNavigationButton(PageNavigationButtonId.PREVIOUS);
+      break;
+
+    case Keybinding.PAGE_NEXT:
+      triggerPageNavigationButton(
+        PageNavigationButtonId.NEXT,
+        PageNavigationButtonId.NEXT_AFTER_CONFIRM
+      );
+      break;
+
+    case Keybinding.FOCUS_PREVIOUS:
+      advanceElementFocus(-1);
+      preventBrowserScroll(event);
+      break;
+
+    case Keybinding.FOCUS_NEXT:
+      advanceElementFocus(1);
+      preventBrowserScroll(event);
+      break;
+
+    default:
+    // Ignore.
+  }
+}


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6484

Copying over the [keyboard navigation handlers](https://github.com/votingworks/vxsuite/blob/main/apps/mark-scan/frontend/src/lib/assistive_technology.ts) from VxMark to VxScan (leaving out the PAT navigation keys, which aren't used on VxScan).

Binding the handlers in the main app and the preview app (for dev testing).

### TODO
- Handling for the volume button on the controller will happen separately in a later PR.
- This change enables triggering action buttons with the left/right keys, but haven't wired up any of the action buttons yet - will do that, wherever it makes sense, in a follow-up.
- Need to verify that the tactile controller emits keyboard events in the same way when running on a prod image. This is the same controller we use on the v2 VxMark, which has an additional set of handlers for browser gamepad events, but it's unclear if that code path is used in prod.
- Also noticed in the preview app that closing a modal doesn't remove the `aria-hidden` attribute from the main view like it should, causing the button elements to then be hidden from the navigation handlers. Need to look into whether this is just a dev thing or if we need a workaround to fix (we've seen this issue in unit tests as well).

## Demo Video or Screenshot

https://github.com/user-attachments/assets/ff969070-1a53-456d-aafc-b3ebac1c77e3

## Testing Plan
- Unit tests + manual verification

## Checklist

<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
