### PR TITLE
6486 vxscan playsound api

### DIFF
--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -68,11 +68,13 @@ import {
   testPrintFailureDiagnosticMessage,
 } from './util/diagnostics';
 import { saveReadinessReport } from './printing/readiness_report';
+import { Player as AudioPlayer, SoundName } from './audio/player';
 
 export const BALLOT_AUDIT_ID_FILE_NAME = 'ballot-audit-id-secret-key.txt';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function buildApi({
+  audioPlayer,
   auth,
   machine,
   workspace,
@@ -80,6 +82,7 @@ export function buildApi({
   printer,
   logger,
 }: {
+  audioPlayer: AudioPlayer;
   auth: InsertedSmartCardAuthApi;
   machine: PrecinctScannerStateMachine;
   workspace: Workspace;
@@ -562,6 +565,10 @@ export function buildApi({
       return exportResult;
     },
 
+    playSound(input: { name: SoundName }): Promise<void> {
+      return audioPlayer.play(input.name);
+    },
+
     ...createUiStringsApi({
       logger,
       store: workspace.store.getUiStringsStore(),
@@ -579,6 +586,7 @@ export function buildApi({
 export type Api = ReturnType<typeof buildApi>;
 
 export function buildApp({
+  audioPlayer,
   auth,
   machine,
   workspace,
@@ -586,6 +594,7 @@ export function buildApp({
   printer,
   logger,
 }: {
+  audioPlayer: AudioPlayer;
   auth: InsertedSmartCardAuthApi;
   machine: PrecinctScannerStateMachine;
   workspace: Workspace;
@@ -594,7 +603,15 @@ export function buildApp({
   logger: Logger;
 }): Application {
   const app: Application = express();
-  const api = buildApi({ auth, machine, workspace, usbDrive, printer, logger });
+  const api = buildApi({
+    audioPlayer,
+    auth,
+    machine,
+    workspace,
+    usbDrive,
+    printer,
+    logger,
+  });
   app.use('/api', grout.buildRouter(api, express));
   return app;
 }

--- a/apps/scan/backend/src/app_audio.test.ts
+++ b/apps/scan/backend/src/app_audio.test.ts
@@ -1,0 +1,12 @@
+import { expect, test, vi } from 'vitest';
+import { withApp } from '../test/helpers/pdi_helpers';
+
+vi.mock('./audio/player');
+
+test('playAudio() uses configured audio player', () =>
+  withApp(async ({ apiClient, mockAudioPlayer }) => {
+    mockAudioPlayer.play.mockResolvedValueOnce();
+
+    await apiClient.playSound({ name: 'warning' });
+    expect(mockAudioPlayer.play).toHaveBeenCalledWith('warning');
+  }));

--- a/apps/scan/backend/src/app_ui_strings.test.ts
+++ b/apps/scan/backend/src/app_ui_strings.test.ts
@@ -23,7 +23,7 @@ import {
   testCdfBallotDefinition,
 } from '@votingworks/types';
 import { createMockPrinterHandler } from '@votingworks/printing';
-import { mockBaseLogger } from '@votingworks/logging';
+import { mockBaseLogger, mockLogger } from '@votingworks/logging';
 import { Store } from './store';
 import { buildApi } from './app';
 import { createWorkspace } from './util/workspace';
@@ -32,6 +32,7 @@ import {
   buildMockLogger,
   createPrecinctScannerStateMachineMock,
 } from '../test/helpers/shared_helpers';
+import { Player as AudioPlayer } from './audio/player';
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
@@ -39,6 +40,12 @@ vi.mock(import('@votingworks/utils'), async (importActual) => ({
   ...(await importActual()),
   isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
 }));
+
+vi.mock('./audio/player');
+
+const mockAudioPlayer = vi.mocked(
+  new AudioPlayer('development', mockLogger({ fn: vi.fn() }), 'pci.stereo')
+);
 
 const store = Store.memoryStore();
 const workspace = createWorkspace(
@@ -61,6 +68,7 @@ afterEach(() => {
 
 runUiStringApiTests({
   api: buildApi({
+    audioPlayer: mockAudioPlayer,
     auth: mockAuth,
     machine: createPrecinctScannerStateMachineMock(),
     workspace,
@@ -94,6 +102,7 @@ describe('configureFromElectionPackageOnUsbDrive', () => {
   });
 
   const api = buildApi({
+    audioPlayer: mockAudioPlayer,
     auth: mockAuth,
     machine: createPrecinctScannerStateMachineMock(),
     workspace,
@@ -115,6 +124,7 @@ describe('configureFromElectionPackageOnUsbDrive', () => {
 
 describe('unconfigureElection', () => {
   const api = buildApi({
+    audioPlayer: mockAudioPlayer,
     auth: mockAuth,
     machine: createPrecinctScannerStateMachineMock(),
     workspace,

--- a/apps/scan/backend/src/audio/info.test.ts
+++ b/apps/scan/backend/src/audio/info.test.ts
@@ -1,0 +1,88 @@
+import { audio } from '@votingworks/backend';
+import { expect, test, vi } from 'vitest';
+import { LogEventId, mockLogger } from '@votingworks/logging';
+import { getAudioInfo } from './info';
+
+vi.mock('@votingworks/backend');
+
+vi.useFakeTimers();
+
+const mockGetAudioInfo = vi.mocked(audio.getAudioInfo);
+
+test('retries with increasing delays', async () => {
+  mockGetAudioInfo.mockRejectedValueOnce('first failure');
+
+  const baseRetryDelayMs = 500;
+  const logger = mockLogger({ fn: vi.fn });
+  const deferredAudioInfo = getAudioInfo({
+    baseRetryDelayMs,
+    logger,
+    maxAttempts: 4,
+    nodeEnv: 'development',
+  });
+
+  // Attempt #1: should retry on API error.
+  await vi.advanceTimersByTimeAsync(0);
+  expect(logger.log).toHaveBeenLastCalledWith(LogEventId.Info, 'system', {
+    message: expect.stringContaining('first failure'),
+  });
+
+  // Attempt #2: should retry on missing builtin audio info.
+  mockGetAudioInfo.mockResolvedValueOnce({});
+  await vi.advanceTimersByTimeAsync(baseRetryDelayMs);
+  expect(logger.log).toHaveBeenLastCalledWith(LogEventId.Info, 'system', {
+    message: expect.stringContaining('builtin audio device not found'),
+  });
+
+  // Next delay should be longer than the base:
+  await vi.advanceTimersByTimeAsync(baseRetryDelayMs);
+  expect(mockGetAudioInfo).toHaveBeenCalledTimes(2);
+  expect(logger.log).toHaveBeenCalledTimes(2);
+
+  // Attempt #3: should retry if USB audio is detected, but not builtin audio.
+  mockGetAudioInfo.mockResolvedValueOnce({ usb: { name: 'usb.stereo' } });
+  await vi.advanceTimersByTimeAsync(baseRetryDelayMs);
+  expect(logger.log).toHaveBeenLastCalledWith(LogEventId.Info, 'system', {
+    message: expect.stringContaining('builtin audio device not found'),
+  });
+
+  // Attempt #4: should succeed if builtin audio detected.
+  mockGetAudioInfo.mockResolvedValueOnce({
+    builtin: { headphonesActive: false, name: 'pci.stereo' },
+    usb: { name: 'usb.stereo' },
+  });
+  await vi.advanceTimersByTimeAsync(baseRetryDelayMs * 3);
+  expect(await deferredAudioInfo).toEqual({
+    builtin: { headphonesActive: false, name: 'pci.stereo' },
+  });
+
+  // No more logs expected after attempt #3.
+  expect(logger.log).toHaveBeenCalledTimes(3);
+});
+
+test('throws last error after last retry', async () => {
+  mockGetAudioInfo.mockRejectedValueOnce('first failure');
+
+  const baseRetryDelayMs = 500;
+  const deferredAudioInfo = getAudioInfo({
+    baseRetryDelayMs,
+    logger: mockLogger({ fn: vi.fn }),
+    maxAttempts: 3,
+    nodeEnv: 'development',
+  });
+
+  // Attempt #1:
+  await vi.advanceTimersByTimeAsync(0);
+
+  // Attempt #2:
+  mockGetAudioInfo.mockRejectedValueOnce('second failure');
+  await vi.advanceTimersByTimeAsync(baseRetryDelayMs);
+
+  // Attempt #3:
+  mockGetAudioInfo.mockResolvedValueOnce({ usb: { name: 'usb.stereo' } });
+  vi.advanceTimersByTime(baseRetryDelayMs * 2);
+
+  await expect(deferredAudioInfo).rejects.toThrow(
+    'builtin audio device not found'
+  );
+});

--- a/apps/scan/backend/src/audio/info.ts
+++ b/apps/scan/backend/src/audio/info.ts
@@ -1,0 +1,51 @@
+import { audio } from '@votingworks/backend';
+import { sleep } from '@votingworks/basics';
+import { LogEventId, Logger } from '@votingworks/logging';
+import { NODE_ENV } from '../globals';
+
+type ScanAudioInfo = audio.AudioInfo & {
+  builtin: audio.BuiltinAudio;
+};
+
+/**
+ * Intended to be run at machine startup. Since the PulseAudio service may not
+ * be fully up and running yet, we retry with increasing wait times until
+ * `ctx.maxAttempts` is reached.
+ */
+export async function getAudioInfo(ctx: {
+  /**
+   * Initial delay before the first retry. Will be increased for each successive
+   * retry.
+   */
+  baseRetryDelayMs: number;
+  logger: Logger;
+  nodeEnv: typeof NODE_ENV;
+  maxAttempts: number;
+}): Promise<ScanAudioInfo> {
+  let lastError: unknown;
+  for (let i = 0; i < ctx.maxAttempts; i += 1) {
+    if (i > 0) {
+      ctx.logger.log(LogEventId.Info, 'system', {
+        message:
+          `Unable to get audio device info - ` +
+          `retrying after error: ${lastError}`,
+      });
+      await sleep(ctx.baseRetryDelayMs * i);
+    }
+
+    try {
+      const audioInfo = await audio.getAudioInfo(ctx);
+
+      if (!audioInfo.builtin) {
+        lastError = new Error('builtin audio device not found');
+        continue;
+      }
+
+      return audioInfo as ScanAudioInfo;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+}

--- a/apps/scan/backend/src/index.ts
+++ b/apps/scan/backend/src/index.ts
@@ -61,7 +61,7 @@ function resolveWorkspace(): Workspace {
   return createWorkspace(workspacePath, baseLogger);
 }
 
-function main(): number {
+async function main(): Promise<number> {
   handleUncaughtExceptions(baseLogger);
 
   const auth = new InsertedSmartCardAuth({
@@ -98,7 +98,7 @@ function main(): number {
     return 0;
   }
 
-  server.start({
+  await server.start({
     auth,
     workspace,
     usbDrive,
@@ -109,14 +109,16 @@ function main(): number {
 }
 
 if (require.main === module) {
-  try {
-    process.exitCode = main();
-  } catch (error) {
-    assert(error instanceof Error);
-    baseLogger.log(LogEventId.ApplicationStartup, 'system', {
-      message: `Error in starting VxScan backend: ${error.stack}`,
-      disposition: 'failure',
+  void main()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      assert(error instanceof Error);
+      baseLogger.log(LogEventId.ApplicationStartup, 'system', {
+        message: `Error in starting VxScan backend: ${error.stack}`,
+        disposition: 'failure',
+      });
+      process.exitCode = 1;
     });
-    process.exitCode = 1;
-  }
 }

--- a/apps/scan/backend/test/helpers/custom_helpers.ts
+++ b/apps/scan/backend/test/helpers/custom_helpers.ts
@@ -70,11 +70,15 @@ import {
   wrapFujitsuThermalPrinter,
   wrapLegacyPrinter,
 } from '../../src/printing/printer';
+import { Player as AudioPlayer } from '../../src/audio/player';
+
+vi.mock('./audio/player');
 
 export async function withApp(
   fn: (context: {
     apiClient: grout.Client<Api>;
     app: Application;
+    mockAudioPlayer: Mocked<AudioPlayer>;
     mockAuth: InsertedSmartCardAuthApi;
     mockScanner: Mocked<CustomScanner>;
     workspace: Workspace;
@@ -122,7 +126,13 @@ export async function withApp(
   )
     ? wrapLegacyPrinter(mockPrinterHandler.printer)
     : wrapFujitsuThermalPrinter(mockFujitsuPrinterHandler.printer);
+
+  const mockAudioPlayer = vi.mocked(
+    new AudioPlayer('development', logger, 'pci.stereo')
+  );
+
   const app = buildApp({
+    audioPlayer: mockAudioPlayer,
     auth: mockAuth,
     machine: precinctScannerMachine,
     workspace,
@@ -145,6 +155,7 @@ export async function withApp(
     await fn({
       apiClient,
       app,
+      mockAudioPlayer,
       mockAuth,
       mockScanner,
       workspace,

--- a/apps/scan/backend/test/helpers/pdi_helpers.ts
+++ b/apps/scan/backend/test/helpers/pdi_helpers.ts
@@ -64,6 +64,9 @@ import {
   waitForStatus,
 } from './shared_helpers';
 import { Store } from '../../src/store';
+import { Player as AudioPlayer } from '../../src/audio/player';
+
+vi.mock('./audio/player');
 
 export interface MockPdiScannerClient {
   emitEvent: (event: ScannerEvent) => void;
@@ -132,6 +135,7 @@ export async function simulateScan(
 export interface AppContext {
   apiClient: grout.Client<Api>;
   app: Application;
+  mockAudioPlayer: Mocked<AudioPlayer>;
   mockAuth: Mocked<InsertedSmartCardAuthApi>;
   mockScanner: MockPdiScannerClient;
   workspace: Workspace;
@@ -175,7 +179,12 @@ export async function withApp(
     clock,
   });
 
+  const mockAudioPlayer = vi.mocked(
+    new AudioPlayer('development', logger, 'pci.stereo')
+  );
+
   const app = buildApp({
+    audioPlayer: mockAudioPlayer,
     auth: mockAuth,
     machine: precinctScannerMachine,
     workspace,
@@ -199,6 +208,7 @@ export async function withApp(
     await fn({
       apiClient,
       app,
+      mockAudioPlayer,
       mockAuth,
       mockScanner,
       workspace,


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6484

Adding a server-side `playAudio()` API, which will eventually replace calls to the client-side audio player API for system sounds (scan success/fail, USB alarm, etc).

The server-side audio player is set up at system startup and passed to the API builder:
- First, querying PulseAudio for available output devices (via `libs/backend:getAudioInfo()`).
  - We discovered with VxMark that the app might start up before the PulseAudio service , so adding retry logic here, similar to what we did with VxMark.
- Then, instantiating an audio player targeting the builtin audio card.

### TODO:
- After querying for available devices, we'll need to issue another PulseAudio command to set the USB audio as the default (which will control which output is used by the UI/`kiosk-browser`. Will follow up in another PR.

## Testing Plan
- Unit tests for retry logic, player instantiation and API wiring.

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
