### PR TITLE
VxScan: Poll scanner status more frequently during scanning

### DIFF
--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -35,7 +35,14 @@ export function VoterScreen({
   isSoundMuted,
 }: VoterScreenProps): JSX.Element | null {
   const scannerStatusQuery = getScannerStatus.useQuery({
-    refetchInterval: POLLING_INTERVAL_FOR_SCANNER_STATUS_MS,
+    refetchInterval: (status) =>
+      // In order to make the perceived speed of scanning as fast as possible,
+      // we poll more frequently when a scan is in progress so we can find out
+      // promptly when it's done. Experimentally, 100ms hit a sweet spot between
+      // finding out quickly and adding too much overhead.
+      status?.state === 'scanning'
+        ? 100
+        : POLLING_INTERVAL_FOR_SCANNER_STATUS_MS,
   });
 
   useScanFeedbackAudio({


### PR DESCRIPTION


## Overview

Improve the snappiness of showing the result to the voter (either accepted/rejected/needs review).

To determine the interval to use, I measured the time from when the scanner sees the ballot (`scanStart` event) to the time that the frontend finds out that the ballot was accepted (`readyForNextBallot` mutation). On my VxDev machine (a Lenovo IdeaPad), I got the following results:
- 500ms polling interval => scan times from 1.9-2.4s
- 50ms polling interval => scan times from 2.0-2.2s
- 100ms polling interval => scan times from 2.0-2.1s

It seems that there is a small amount of overhead introduced by polling more frequently, but the worst case results are much better (e.g. when the ballot is accepted just after the last polling request, so the frontend waits an entire polling interval to find out).

## Demo Video or Screenshot
Not really noticeable in video

## Testing Plan
Outlined above

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
