### PR TITLE
[VxScan] Set USB audio as default output at startup

### DIFF
--- a/apps/scan/backend/src/server.test.ts
+++ b/apps/scan/backend/src/server.test.ts
@@ -10,7 +10,8 @@ import { LogEventId, mockBaseLogger } from '@votingworks/logging';
 import { Application } from 'express';
 import { dirSync } from 'tmp';
 import { buildMockInsertedSmartCardAuth } from '@votingworks/auth';
-import { testDetectDevices } from '@votingworks/backend';
+import { setDefaultAudio, testDetectDevices } from '@votingworks/backend';
+import { err, ok } from '@votingworks/basics';
 import { buildApp } from './app';
 import { NODE_ENV, PORT } from './globals';
 import { start } from './server';
@@ -23,9 +24,15 @@ vi.mock('./app');
 vi.mock('./audio/info');
 vi.mock('./audio/player');
 
+vi.mock('@votingworks/backend', async (importActual) => ({
+  ...(await importActual()),
+  setDefaultAudio: vi.fn(),
+}));
+
 const buildAppMock = buildApp as MockedFunction<typeof buildApp>;
 const mockGetAudioInfo = vi.mocked(getAudioInfo);
 const mockAudioPlayerClass = vi.mocked(AudioPlayer);
+const mockSetDefaultAudio = vi.mocked(setDefaultAudio);
 
 let workspace!: Workspace;
 
@@ -45,7 +52,6 @@ test('start passes context to `buildApp`', async () => {
 
   mockGetAudioInfo.mockResolvedValueOnce({
     builtin: { headphonesActive: false, name: 'pci.stereo' },
-    usb: { name: 'usb.stereo' },
   });
 
   const mockAudioPlayer = {
@@ -88,21 +94,96 @@ test('start passes context to `buildApp`', async () => {
     'pci.stereo'
   );
 
+  // Only called when USB audio is detected:
+  expect(mockSetDefaultAudio).not.toHaveBeenCalled();
+
   const callback = listen.mock.calls[0][1];
   await callback();
 
-  expect(logger.log).toHaveBeenNthCalledWith(
-    2,
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ApplicationStartup,
     expect.anything(),
     expect.anything()
   );
-  expect(logger.log).toHaveBeenNthCalledWith(
-    3,
+  expect(logger.log).toHaveBeenCalledWith(
     LogEventId.WorkspaceConfigurationMessage,
     expect.anything(),
     expect.anything()
   );
+});
+
+test('sets USB audio device as default, if present', async () => {
+  const listen = vi.fn<(port: number, callback: () => unknown) => void>();
+  const auth = buildMockInsertedSmartCardAuth(vi.fn);
+  const logger = buildMockLogger(auth, workspace);
+  buildAppMock.mockReturnValueOnce({ listen } as unknown as Application);
+
+  mockGetAudioInfo.mockResolvedValueOnce({
+    builtin: { headphonesActive: false, name: 'pci.stereo' },
+    usb: { name: 'usb.stereo' },
+  });
+
+  mockSetDefaultAudio.mockResolvedValueOnce(ok());
+
+  await start({
+    auth: buildMockInsertedSmartCardAuth(vi.fn),
+    workspace,
+    logger,
+  });
+
+  expect(mockSetDefaultAudio).toHaveBeenCalledWith('usb.stereo', {
+    logger,
+    nodeEnv: NODE_ENV,
+  });
+});
+
+test('logs if unable to detect USB audio device', async () => {
+  const listen = vi.fn<(port: number, callback: () => unknown) => void>();
+  const auth = buildMockInsertedSmartCardAuth(vi.fn);
+  const logger = buildMockLogger(auth, workspace);
+  buildAppMock.mockReturnValueOnce({ listen } as unknown as Application);
+
+  mockGetAudioInfo.mockResolvedValueOnce({
+    builtin: { headphonesActive: false, name: 'pci.stereo' },
+  });
+
+  await start({
+    auth: buildMockInsertedSmartCardAuth(vi.fn),
+    workspace,
+    logger,
+  });
+
+  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+    LogEventId.UnknownError,
+    {
+      message: 'USB audio device not detected.',
+      disposition: 'failure',
+    }
+  );
+});
+
+test('throws if unable to set USB audio as default', async () => {
+  const listen = vi.fn<(port: number, callback: () => unknown) => void>();
+  const auth = buildMockInsertedSmartCardAuth(vi.fn);
+  const logger = buildMockLogger(auth, workspace);
+  buildAppMock.mockReturnValueOnce({ listen } as unknown as Application);
+
+  mockGetAudioInfo.mockResolvedValueOnce({
+    builtin: { headphonesActive: false, name: 'pci.stereo' },
+    usb: { name: 'telepathy.stereo' },
+  });
+
+  mockSetDefaultAudio.mockResolvedValueOnce(
+    err({ code: 'pactlError', error: 'output unavailable' })
+  );
+
+  await expect(async () =>
+    start({
+      auth: buildMockInsertedSmartCardAuth(vi.fn),
+      workspace,
+      logger,
+    })
+  ).rejects.toThrow(/unable to set usb/i);
 });
 
 test('logs device attach/unattach events', async () => {

--- a/libs/backend/src/system_call/index.ts
+++ b/libs/backend/src/system_call/index.ts
@@ -4,3 +4,8 @@ export * as audio from './get_audio_info';
 export type { LogsResultType } from './export_logs_to_usb';
 export { getBatteryInfo } from './get_battery_info';
 export type { BatteryInfo } from './get_battery_info';
+export {
+  type SetDefaultAudioErr,
+  type SetDefaultAudioResult,
+  setDefaultAudio,
+} from './set_default_audio';

--- a/libs/backend/src/system_call/set_default_audio.test.ts
+++ b/libs/backend/src/system_call/set_default_audio.test.ts
@@ -1,0 +1,80 @@
+import { expect, test, vi } from 'vitest';
+
+import { LogEventId, mockLogger } from '@votingworks/logging';
+import { err, ok } from '@votingworks/basics';
+import { execFile } from '../exec';
+import { SetDefaultAudioResult, setDefaultAudio } from './set_default_audio';
+
+vi.mock(import('../exec.js'));
+
+const mockExecFile = vi.mocked(execFile);
+
+test('NODE_ENV=production - runs app script via sudo', async () => {
+  mockExecFile.mockResolvedValue({ stderr: '', stdout: '' });
+
+  const sinkName = 'usb.stereo';
+  const result = await setDefaultAudio(sinkName, {
+    logger: mockLogger({ fn: vi.fn }),
+    nodeEnv: 'production',
+  });
+  expect(result).toEqual(ok());
+
+  expect(mockExecFile).toHaveBeenCalledExactlyOnceWith('sudo', [
+    '/vx/code/app-scripts/pactl.sh',
+    'set-default-sink',
+    sinkName,
+  ]);
+});
+
+test('NODE_ENV=development - runs pactl directly', async () => {
+  mockExecFile.mockResolvedValue({ stderr: '', stdout: '' });
+
+  const sinkName = 'usb.stereo';
+  const result = await setDefaultAudio(sinkName, {
+    logger: mockLogger({ fn: vi.fn }),
+    nodeEnv: 'development',
+  });
+  expect(result).toEqual(ok());
+
+  expect(mockExecFile).toHaveBeenCalledExactlyOnceWith('pactl', [
+    'set-default-sink',
+    sinkName,
+  ]);
+});
+
+test('execFile error', async () => {
+  const error = 'execFile failed';
+  mockExecFile.mockRejectedValue(error);
+
+  const logger = mockLogger({ fn: vi.fn });
+  expect(
+    await setDefaultAudio('usb.stereo', { logger, nodeEnv: 'production' })
+  ).toEqual<SetDefaultAudioResult>(err({ code: 'execFileError', error }));
+
+  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+    LogEventId.UnknownError,
+    {
+      message: expect.stringContaining(error),
+      disposition: 'failure',
+    }
+  );
+});
+
+test('pactl error', async () => {
+  const error = 'Failure: No such entity';
+  mockExecFile.mockResolvedValue({ stderr: error, stdout: '' });
+
+  const logger = mockLogger({ fn: vi.fn });
+  const nodeEnv = 'production';
+  expect(
+    await setDefaultAudio('cup_and_string.mono', { logger, nodeEnv })
+  ).toEqual<SetDefaultAudioResult>(err({ code: 'pactlError', error }));
+
+  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+    LogEventId.UnknownError,
+    {
+      message: expect.stringContaining(error),
+      disposition: 'failure',
+    }
+  );
+});

--- a/libs/backend/src/system_call/set_default_audio.ts
+++ b/libs/backend/src/system_call/set_default_audio.ts
@@ -1,0 +1,68 @@
+import { LogEventId, Logger } from '@votingworks/logging';
+import { err, ok, Result } from '@votingworks/basics';
+import { execFile } from '../exec';
+import { NODE_ENV } from '../scan_globals';
+
+/**
+ * Errors returned by {@link setDefaultAudio}.
+ */
+export type SetDefaultAudioErr =
+  | { code: 'execFileError'; error: unknown }
+  | { code: 'pactlError'; error: string };
+
+/**
+ * Result returned by {@link setDefaultAudio}.
+ */
+export type SetDefaultAudioResult = Result<void, SetDefaultAudioErr>;
+
+/**
+ * Sets the default PulseAudio output device.
+ *
+ * @param sinkName - Name of the output device, as returned from
+ *   `getAudioInfo` (see `./get_audio_info.ts`).
+ */
+export async function setDefaultAudio(
+  sinkName: string,
+  ctx: {
+    logger: Logger;
+    nodeEnv: typeof NODE_ENV;
+  }
+): Promise<SetDefaultAudioResult> {
+  const { logger, nodeEnv } = ctx;
+  let errorOutput: string;
+
+  try {
+    if (nodeEnv === 'production') {
+      ({ stderr: errorOutput } = await execFile('sudo', [
+        '/vx/code/app-scripts/pactl.sh',
+        'set-default-sink',
+        sinkName,
+      ]));
+    } else {
+      ({ stderr: errorOutput } = await execFile('pactl', [
+        'set-default-sink',
+        sinkName,
+      ]));
+    }
+  } catch (error) {
+    // [TODO] Update log event ID to something more specific.
+    void logger.logAsCurrentRole(LogEventId.UnknownError, {
+      message: `Unable to run pactl set-default-sink command: ${error}}`,
+      disposition: 'failure',
+    });
+
+    return err({ code: 'execFileError', error });
+  }
+
+  if (errorOutput) {
+    // [TODO] Update log event ID to something more specific.
+    void logger.logAsCurrentRole(LogEventId.UnknownError, {
+      message: `pactl set-default-sink command failed: ${errorOutput}}`,
+      disposition: 'failure',
+    });
+
+    return err({ code: 'pactlError', error: errorOutput });
+  }
+
+  return ok();
+}


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6484

During testing with various USB audio cards, some devices were *not* automatically selected as the default output by the system (seems to only happen for devices that identify as having a headphone output). The tactile controller we've settled on for VxScan is one of those, so this change ensures that we set the USB device as the default output, if detected at startup. This only affects the screen reader audio played in the client/kiosk-browser.

- Triggering a server shutdown if the USB device was detected, but we can't set it as the default.
- Logging if we can't detect the USB device at all - we may eventually want to throw  there as well, but we'll need to support older machines without the USB audio addition for now.

## Testing Plan
- Unit + manual tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
  - (Pending renames for the log event IDs - going to do that all in one go, later, for recently added logs).
