### PR TITLE
VxAdmin: Improve adjudication interface keyboard navigation + support marginally marked write-ins

### DIFF
--- a/apps/admin/frontend/src/components/adjudication_double_vote_alert_modal.tsx
+++ b/apps/admin/frontend/src/components/adjudication_double_vote_alert_modal.tsx
@@ -61,7 +61,7 @@ export function DoubleVoteAlertModal({
       title="Possible Double Vote Detected"
       content={text}
       actions={
-        <Button variant="neutral" onPress={onClose}>
+        <Button variant="neutral" onPress={onClose} autoFocus>
           Cancel
         </Button>
       }

--- a/apps/admin/frontend/src/components/contest_option_button.tsx
+++ b/apps/admin/frontend/src/components/contest_option_button.tsx
@@ -41,11 +41,7 @@ export const ContestOptionButton = forwardRef<HTMLDivElement, Props>(
       marginalMarkStatus === 'pending' && onDismissFlag !== undefined;
 
     return (
-      <div
-        data-option-id={option.id}
-        style={{ display: 'flex', flexDirection: 'column' }}
-        ref={ref}
-      >
+      <div style={{ display: 'flex', flexDirection: 'column' }} ref={ref}>
         {showMarginalMarkFlag && (
           <MarginalMarkFlag onDismissFlag={onDismissFlag} />
         )}

--- a/apps/admin/frontend/src/components/contest_option_button.tsx
+++ b/apps/admin/frontend/src/components/contest_option_button.tsx
@@ -1,32 +1,9 @@
 import React, { forwardRef } from 'react';
 import { Id } from '@votingworks/types';
-import { Button, CheckboxButton, Icons } from '@votingworks/ui';
+import { CheckboxButton } from '@votingworks/ui';
 import styled from 'styled-components';
 import type { MarginalMarkStatus } from '../screens/contest_adjudication_screen';
-
-const MarginalMarkFlag = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  background-color: ${(p) => p.theme.colors.warningContainer};
-  border: ${(p) => p.theme.sizes.bordersRem.thin}rem solid
-    ${(p) => p.theme.colors.outline};
-  border-bottom: 0;
-  border-radius: 0.5rem 0.5rem 0 0;
-  color: ${(p) => p.theme.colors.neutral};
-  font-weight: 500;
-  padding: 0.25rem 0.5rem;
-
-  button {
-    gap: 0.25rem;
-  }
-`;
-
-const IconTextContainer = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-`;
+import { MarginalMarkFlag } from './marginal_mark_flag';
 
 const StyledCheckboxButton = styled(CheckboxButton)<{
   onlyRoundBottom?: boolean;
@@ -44,6 +21,7 @@ interface Props {
   disabled?: boolean;
   marginalMarkStatus?: MarginalMarkStatus;
   onDismissFlag?: () => void;
+  tabIndex?: number;
 }
 
 export const ContestOptionButton = forwardRef<HTMLDivElement, Props>(
@@ -57,6 +35,7 @@ export const ContestOptionButton = forwardRef<HTMLDivElement, Props>(
       disabled,
       marginalMarkStatus,
       onDismissFlag,
+      tabIndex,
     },
     ref
   ) => {
@@ -64,26 +43,17 @@ export const ContestOptionButton = forwardRef<HTMLDivElement, Props>(
       marginalMarkStatus === 'pending' && onDismissFlag !== undefined;
 
     return (
-      <div ref={ref} style={{ display: 'flex', flexDirection: 'column' }}>
+      <div
+        tabIndex={tabIndex}
+        ref={ref}
+        data-option-id={option.id}
+        style={{ display: 'flex', flexDirection: 'column' }}
+      >
         {showMarginalMarkFlag && (
-          <MarginalMarkFlag>
-            <IconTextContainer>
-              <Icons.Warning color="warning" />
-              Review marginal mark
-            </IconTextContainer>
-            <Button
-              aria-label="Dismiss"
-              icon="X"
-              fill="transparent"
-              onPress={onDismissFlag}
-              style={{ padding: '0' }}
-              value={undefined}
-            >
-              Dismiss
-            </Button>
-          </MarginalMarkFlag>
+          <MarginalMarkFlag onDismissFlag={onDismissFlag} />
         )}
         <StyledCheckboxButton
+          tabIndex={-1}
           disabled={disabled}
           onlyRoundBottom={showMarginalMarkFlag}
           isChecked={isSelected}

--- a/apps/admin/frontend/src/components/contest_option_button.tsx
+++ b/apps/admin/frontend/src/components/contest_option_button.tsx
@@ -15,12 +15,12 @@ const StyledCheckboxButton = styled(CheckboxButton)<{
 interface Props {
   option: { id: Id; label: string };
   isSelected: boolean;
+  marginalMarkStatus?: MarginalMarkStatus;
   onSelect: () => void;
   onDeselect?: () => void;
+  onDismissFlag?: () => void;
   caption?: React.ReactNode;
   disabled?: boolean;
-  marginalMarkStatus?: MarginalMarkStatus;
-  onDismissFlag?: () => void;
   tabIndex?: number;
 }
 
@@ -29,12 +29,12 @@ export const ContestOptionButton = forwardRef<HTMLDivElement, Props>(
     {
       option,
       isSelected,
+      marginalMarkStatus,
       onSelect,
       onDeselect,
+      onDismissFlag,
       caption,
       disabled,
-      marginalMarkStatus,
-      onDismissFlag,
       tabIndex,
     },
     ref
@@ -44,21 +44,21 @@ export const ContestOptionButton = forwardRef<HTMLDivElement, Props>(
 
     return (
       <div
-        tabIndex={tabIndex}
-        ref={ref}
         data-option-id={option.id}
         style={{ display: 'flex', flexDirection: 'column' }}
+        ref={ref}
+        tabIndex={tabIndex}
       >
         {showMarginalMarkFlag && (
           <MarginalMarkFlag onDismissFlag={onDismissFlag} />
         )}
         <StyledCheckboxButton
-          tabIndex={-1}
-          disabled={disabled}
-          onlyRoundBottom={showMarginalMarkFlag}
-          isChecked={isSelected}
           key={option.id}
           label={option.label}
+          isChecked={isSelected}
+          disabled={disabled}
+          tabIndex={-1}
+          onlyRoundBottom={showMarginalMarkFlag}
           onChange={() => {
             if (!isSelected) {
               onSelect();

--- a/apps/admin/frontend/src/components/contest_option_button.tsx
+++ b/apps/admin/frontend/src/components/contest_option_button.tsx
@@ -21,7 +21,6 @@ interface Props {
   onDismissFlag?: () => void;
   caption?: React.ReactNode;
   disabled?: boolean;
-  tabIndex?: number;
 }
 
 export const ContestOptionButton = forwardRef<HTMLDivElement, Props>(
@@ -35,7 +34,6 @@ export const ContestOptionButton = forwardRef<HTMLDivElement, Props>(
       onDismissFlag,
       caption,
       disabled,
-      tabIndex,
     },
     ref
   ) => {
@@ -47,7 +45,6 @@ export const ContestOptionButton = forwardRef<HTMLDivElement, Props>(
         data-option-id={option.id}
         style={{ display: 'flex', flexDirection: 'column' }}
         ref={ref}
-        tabIndex={tabIndex}
       >
         {showMarginalMarkFlag && (
           <MarginalMarkFlag onDismissFlag={onDismissFlag} />
@@ -57,7 +54,6 @@ export const ContestOptionButton = forwardRef<HTMLDivElement, Props>(
           label={option.label}
           isChecked={isSelected}
           disabled={disabled}
-          tabIndex={-1}
           onlyRoundBottom={showMarginalMarkFlag}
           onChange={() => {
             if (!isSelected) {

--- a/apps/admin/frontend/src/components/discard_changes_modal.tsx
+++ b/apps/admin/frontend/src/components/discard_changes_modal.tsx
@@ -1,5 +1,5 @@
 import { Button, Modal } from '@votingworks/ui';
-import React, { useEffect } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 const EqualWidthButton = styled(Button)`
@@ -13,22 +13,13 @@ export function DiscardChangesModal({
   onBack: () => void;
   onDiscard: () => void;
 }): JSX.Element {
-  useEffect(() => {
-    function onKeyDown(event: KeyboardEvent): void {
-      if (event.key === 'Enter') {
-        onDiscard();
-      }
-    }
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [onDiscard]);
   return (
     <Modal
       title="Unsaved Changes"
       content="Your adjudications for this ballot have not been saved."
       actions={
         <React.Fragment>
-          <EqualWidthButton variant="danger" onPress={onDiscard}>
+          <EqualWidthButton variant="danger" onPress={onDiscard} autoFocus>
             Discard Changes
           </EqualWidthButton>
           <EqualWidthButton variant="neutral" onPress={onBack}>

--- a/apps/admin/frontend/src/components/marginal_mark_flag.tsx
+++ b/apps/admin/frontend/src/components/marginal_mark_flag.tsx
@@ -1,0 +1,52 @@
+import { Icons, Button } from '@votingworks/ui';
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: ${(p) => p.theme.colors.warningContainer};
+  border: ${(p) => p.theme.sizes.bordersRem.thin}rem solid
+    ${(p) => p.theme.colors.outline};
+  border-bottom: 0;
+  border-radius: 0.5rem 0.5rem 0 0;
+  color: ${(p) => p.theme.colors.neutral};
+  font-weight: 500;
+  padding: 0.25rem 0.5rem;
+
+  button {
+    gap: 0.25rem;
+  }
+`;
+
+const IconTextContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+export function MarginalMarkFlag({
+  onDismissFlag,
+}: {
+  onDismissFlag: () => void;
+}): JSX.Element {
+  return (
+    <Container>
+      <IconTextContainer>
+        <Icons.Warning color="warning" />
+        Review marginal mark
+      </IconTextContainer>
+      <Button
+        aria-label="Dismiss"
+        icon="X"
+        fill="transparent"
+        onPress={onDismissFlag}
+        style={{ padding: '0' }}
+        value={undefined}
+        tabIndex={-1}
+      >
+        Dismiss
+      </Button>
+    </Container>
+  );
+}

--- a/apps/admin/frontend/src/components/marginal_mark_flag.tsx
+++ b/apps/admin/frontend/src/components/marginal_mark_flag.tsx
@@ -16,6 +16,8 @@ const Container = styled.div`
 
   button {
     gap: 0.25rem;
+    padding: 0 0.5rem;
+    line-height: 1.4;
   }
 `;
 
@@ -41,7 +43,6 @@ export function MarginalMarkFlag({
         icon="X"
         fill="transparent"
         onPress={onDismissFlag}
-        style={{ padding: '0' }}
         value={undefined}
         tabIndex={-1}
       >

--- a/apps/admin/frontend/src/components/marginal_mark_flag.tsx
+++ b/apps/admin/frontend/src/components/marginal_mark_flag.tsx
@@ -44,7 +44,6 @@ export function MarginalMarkFlag({
         fill="transparent"
         onPress={onDismissFlag}
         value={undefined}
-        tabIndex={-1}
       >
         Dismiss
       </Button>

--- a/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
+++ b/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
@@ -33,14 +33,13 @@ const StyledCheckboxButton = styled(CheckboxButton)<{
     if (roundTop && roundBottom) return '0.5rem';
     if (roundTop) return '0.5rem 0.5rem 0 0';
     if (roundBottom) return '0 0 0.5rem 0.5rem';
-    return '0';
   }};
 `;
 
 interface Props {
   isFocused: boolean;
   isSelected: boolean;
-  status: WriteInAdjudicationStatus;
+  writeInStatus: WriteInAdjudicationStatus;
   onChange: (newStatus: Exclude<WriteInAdjudicationStatus, undefined>) => void;
   onInputBlur: () => void;
   onInputFocus: () => void;
@@ -61,7 +60,7 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
     {
       isFocused,
       isSelected,
-      status,
+      writeInStatus,
       onChange,
       onInputFocus,
       onInputBlur,
@@ -85,14 +84,15 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
       setInputValue(val);
     }
 
+    // Only show marginal mark flag if the write-in has not been adjudicated
     const showMarginalMarkFlag =
-      status === undefined &&
+      writeInStatus === undefined &&
       marginalMarkStatus === 'pending' &&
       onDismissFlag !== undefined;
 
     let showSearchSelect = true;
     let value: string | undefined;
-    switch (status?.type) {
+    switch (writeInStatus?.type) {
       case 'invalid':
       case undefined: {
         showSearchSelect = false;
@@ -105,12 +105,12 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
       case 'new-write-in':
       case 'existing-official':
       case 'existing-write-in': {
-        value = status.name;
+        value = writeInStatus.name;
         break;
       }
       default: {
         /* istanbul ignore next - @preserve */
-        throwIllegalValue(status, 'type');
+        throwIllegalValue(writeInStatus, 'type');
       }
     }
 
@@ -121,7 +121,6 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
           normalizeWriteInName(name).includes(normalizedInputValue)
         )
       : candidateNames;
-
     const candidateOptions = filteredNames.map((name) => ({
       label: name,
       value: name,
@@ -145,9 +144,10 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
     ) {
       newCandidateOption = {
         label: (
-          <span>
-            <Icons.Add style={{ marginRight: '.125rem' }} /> Press enter to add:{' '}
-            {inputValue}
+          <span
+            style={{ display: 'flex', alignItems: 'center', gap: '.25rem' }}
+          >
+            <Icons.Add /> Press enter to add: {inputValue}
           </span>
         ),
         value: inputValue,
@@ -160,8 +160,10 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
     if (!inputValue) {
       invalidMarkOption = {
         label: (
-          <span>
-            <Icons.Disabled style={{ marginRight: '.125rem' }} /> Invalid mark
+          <span
+            style={{ display: 'flex', alignItems: 'center', gap: '.25rem' }}
+          >
+            <Icons.Disabled /> Invalid mark
           </span>
         ),
         value: INVALID_KEY,
@@ -178,7 +180,6 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
       <Container
         ref={ref}
         data-option-id={optionId}
-        data-has-combobox="true"
         tabIndex={tabIndex}
         style={{ zIndex: isFocused ? 10 : 0 }}
       >

--- a/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
+++ b/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
@@ -49,7 +49,6 @@ const OptionWithIcon = styled.span`
 interface Props {
   isFocused: boolean;
   isSelected: boolean;
-  optionId: string;
   writeInStatus: WriteInAdjudicationStatus;
   marginalMarkStatus?: MarginalMarkStatus;
   onChange: (newStatus: Exclude<WriteInAdjudicationStatus, undefined>) => void;
@@ -69,7 +68,6 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
     {
       isFocused,
       isSelected,
-      optionId,
       writeInStatus,
       marginalMarkStatus,
       onChange,
@@ -91,9 +89,6 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
     function onInputChange(val: string = '') {
       setInputValue(val);
     }
-
-    const showMarginalMarkFlag =
-      marginalMarkStatus === 'pending' && onDismissFlag !== undefined;
 
     let showSearchSelect = true;
     let value: string | undefined;
@@ -118,6 +113,12 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
         throwIllegalValue(writeInStatus, 'type');
       }
     }
+
+    // Only show flag if the searchSelect is not visible
+    const showMarginalMarkFlag =
+      !showSearchSelect &&
+      marginalMarkStatus === 'pending' &&
+      onDismissFlag !== undefined;
 
     const allCandidates = writeInCandidates.concat(officialCandidates);
     const candidateNames = allCandidates.map((c) => c.name);
@@ -174,11 +175,7 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
     ];
 
     return (
-      <Container
-        data-option-id={optionId}
-        style={{ zIndex: isFocused ? 10 : 0 }}
-        ref={ref}
-      >
+      <Container style={{ zIndex: isFocused ? 10 : 0 }} ref={ref}>
         {showMarginalMarkFlag && (
           <MarginalMarkFlag onDismissFlag={onDismissFlag} />
         )}

--- a/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
+++ b/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
@@ -28,12 +28,24 @@ const Container = styled.div`
 const StyledCheckboxButton = styled(CheckboxButton)<{
   roundTop?: boolean;
   roundBottom?: boolean;
+  isSelected?: boolean;
+  isFocused?: boolean;
 }>`
   border-radius: ${({ roundTop, roundBottom }) => {
     if (roundTop && roundBottom) return '0.5rem';
     if (roundTop) return '0.5rem 0.5rem 0 0';
     if (roundBottom) return '0 0 0.5rem 0.5rem';
   }};
+
+  ${({ isSelected, isFocused, theme }) =>
+    !isSelected &&
+    isFocused &&
+    `
+      &:hover {
+        /* the default hover color blends in with the background overlay */
+        background-color: ${theme.colors.primaryContainer} !important;
+      }
+    `}
 `;
 
 interface SearchOption {
@@ -181,6 +193,7 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
         )}
         <StyledCheckboxButton
           isChecked={isSelected}
+          isFocused={isFocused}
           disabled={disabled}
           label={label ?? 'Write-in'}
           roundTop={!showMarginalMarkFlag}
@@ -195,10 +208,10 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
             disabled={disabled}
             options={allOptions}
             value={value}
-            // The inner input does not clear the previous value when a
-            // double vote entry is detected because the `value` prop never
-            // changes. `hasInvalidEntry` as the key forces a re-render
-            key={`${hasInvalidEntry}`}
+            // The inner input does not consistently clear the previous value
+            // when a double vote entry is detected because the `value` prop never
+            // changes, or when scrolling cvrs. The key is used to force a re-render
+            key={String(hasInvalidEntry) + value}
             maxMenuHeight={450} // 6 options, 75px each
             minMenuHeight={300}
             menuPortalTarget={document.body}

--- a/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
+++ b/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
@@ -36,7 +36,10 @@ const StyledCheckboxButton = styled(CheckboxButton)<{
   }};
 `;
 
-interface SearchOption { label: React.ReactNode; value: string }
+interface SearchOption {
+  label: React.ReactNode;
+  value: string;
+}
 const OptionWithIcon = styled.span`
   display: flex;
   align-items: center;
@@ -59,7 +62,6 @@ interface Props {
   caption?: React.ReactNode;
   disabled?: boolean;
   label?: string;
-  tabIndex?: number;
 }
 
 export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
@@ -80,7 +82,6 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
       caption,
       disabled,
       label,
-      tabIndex,
     },
     ref
   ) => {
@@ -177,7 +178,6 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
         data-option-id={optionId}
         style={{ zIndex: isFocused ? 10 : 0 }}
         ref={ref}
-        tabIndex={tabIndex}
       >
         {showMarginalMarkFlag && (
           <MarginalMarkFlag onDismissFlag={onDismissFlag} />
@@ -188,7 +188,6 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
           label={label ?? 'Write-in'}
           roundTop={!showMarginalMarkFlag}
           roundBottom={!showSearchSelect}
-          tabIndex={-1}
           onChange={() => {
             onChange({ type: isSelected ? 'invalid' : 'pending' });
           }}

--- a/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
+++ b/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
@@ -258,6 +258,7 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
                 ? undefined
                 : theme.colors.warningContainer,
               borderRadius: '0 0 0.5rem 0.5rem',
+              marginTop: '-2px',
             }}
           />
         )}

--- a/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
+++ b/apps/admin/frontend/src/components/write_in_adjudication_button.tsx
@@ -5,9 +5,10 @@ import { Candidate } from '@votingworks/types';
 import { assert, throwIllegalValue } from '@votingworks/basics';
 import { normalizeWriteInName } from '../utils/adjudication';
 import type {
-  InvalidWriteIn,
+  MarginalMarkStatus,
   WriteInAdjudicationStatus,
 } from '../screens/contest_adjudication_screen';
+import { MarginalMarkFlag } from './marginal_mark_flag';
 
 export const MAX_WRITE_IN_NAME_LENGTH = 200;
 const INVALID_KEY = '\0invalid';
@@ -24,14 +25,22 @@ const Container = styled.div`
   }
 `;
 
-const RoundedCheckboxButton = styled(CheckboxButton)`
-  border-radius: 0.5rem 0.5rem 0 0;
+const StyledCheckboxButton = styled(CheckboxButton)<{
+  roundTop?: boolean;
+  roundBottom?: boolean;
+}>`
+  border-radius: ${({ roundTop, roundBottom }) => {
+    if (roundTop && roundBottom) return '0.5rem';
+    if (roundTop) return '0.5rem 0.5rem 0 0';
+    if (roundBottom) return '0 0 0.5rem 0.5rem';
+    return '0';
+  }};
 `;
 
 interface Props {
   isFocused: boolean;
   isSelected: boolean;
-  status: Exclude<WriteInAdjudicationStatus, InvalidWriteIn | undefined>;
+  status: WriteInAdjudicationStatus;
   onChange: (newStatus: Exclude<WriteInAdjudicationStatus, undefined>) => void;
   onInputBlur: () => void;
   onInputFocus: () => void;
@@ -40,6 +49,11 @@ interface Props {
   hasInvalidEntry: boolean;
   caption?: React.ReactNode;
   label?: string;
+  tabIndex?: number;
+  optionId: string;
+  disabled?: boolean;
+  marginalMarkStatus?: MarginalMarkStatus;
+  onDismissFlag?: () => void;
 }
 
 export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
@@ -56,32 +70,34 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
       hasInvalidEntry,
       caption,
       label,
+      tabIndex,
+      optionId,
+      disabled,
+      marginalMarkStatus,
+      onDismissFlag,
     },
     ref
   ) => {
     const theme = useTheme();
     const [inputValue, setInputValue] = useState('');
     const normalizedInputValue = normalizeWriteInName(inputValue);
-
     function onInputChange(val: string = '') {
       setInputValue(val);
     }
 
-    const allCandidates = writeInCandidates.concat(officialCandidates);
-    const candidateNames = allCandidates.map((c) => c.name);
-    const filteredNames = inputValue
-      ? candidateNames.filter((name) =>
-          normalizeWriteInName(name).includes(normalizedInputValue)
-        )
-      : candidateNames;
+    const showMarginalMarkFlag =
+      status === undefined &&
+      marginalMarkStatus === 'pending' &&
+      onDismissFlag !== undefined;
 
-    const candidateOptions = filteredNames.map((name) => ({
-      label: name,
-      value: name,
-    }));
-
-    let value: string;
-    switch (status.type) {
+    let showSearchSelect = true;
+    let value: string | undefined;
+    switch (status?.type) {
+      case 'invalid':
+      case undefined: {
+        showSearchSelect = false;
+        break;
+      }
       case 'pending': {
         value = '';
         break;
@@ -97,6 +113,19 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
         throwIllegalValue(status, 'type');
       }
     }
+
+    const allCandidates = writeInCandidates.concat(officialCandidates);
+    const candidateNames = allCandidates.map((c) => c.name);
+    const filteredNames = inputValue
+      ? candidateNames.filter((name) =>
+          normalizeWriteInName(name).includes(normalizedInputValue)
+        )
+      : candidateNames;
+
+    const candidateOptions = filteredNames.map((name) => ({
+      label: name,
+      value: name,
+    }));
 
     // If value has been entered and it is a new entry, add it the dropdown
     if (value && !candidateOptions.some((option) => option.label === value)) {
@@ -146,72 +175,91 @@ export const WriteInAdjudicationButton = forwardRef<HTMLDivElement, Props>(
     ];
 
     return (
-      <Container ref={ref} style={{ zIndex: isFocused ? 10 : 0 }}>
-        <RoundedCheckboxButton
+      <Container
+        ref={ref}
+        data-option-id={optionId}
+        data-has-combobox="true"
+        tabIndex={tabIndex}
+        style={{ zIndex: isFocused ? 10 : 0 }}
+      >
+        {showMarginalMarkFlag && (
+          <MarginalMarkFlag onDismissFlag={onDismissFlag} />
+        )}
+        <StyledCheckboxButton
+          roundTop={!showMarginalMarkFlag}
+          roundBottom={!showSearchSelect}
+          disabled={disabled}
+          tabIndex={-1}
           isChecked={isSelected}
           label={label ?? 'Write-in'}
-          onChange={() =>
-            onChange({ type: isSelected ? 'invalid' : 'pending' })
-          }
+          onChange={() => {
+            onChange({ type: isSelected ? 'invalid' : 'pending' });
+          }}
         />
-        <SearchSelect
-          aria-label="Select or add write-in candidate"
-          // The inner input does not clear the previous value when a
-          // double vote entry is detected because the `value` prop never
-          // changes. `hasInvalidEntry` as the key forces a re-render
-          key={`${hasInvalidEntry}-${value}`}
-          menuPortalTarget={document.body}
-          maxMenuHeight={450} // 6 options, 75px each
-          options={allOptions}
-          onBlur={onInputBlur}
-          onFocus={onInputFocus}
-          onInputChange={onInputChange}
-          onChange={(val) => {
-            setInputValue('');
-            // we are guaranteed a value from SearchSelect with this use-case
-            assert(val !== undefined && val !== '');
-            if (val === INVALID_KEY) {
-              onChange({ type: 'invalid' });
-            } else if (filteredNames.includes(val)) {
-              let candidate = officialCandidates.find((c) => c.name === val);
-              const isOfficialCandidate = !!candidate;
-              if (!isOfficialCandidate) {
-                candidate = writeInCandidates.find((c) => c.name === val);
+        {showSearchSelect && (
+          <SearchSelect
+            disabled={disabled}
+            // tabIndex={-1}
+            aria-label="Select or add write-in candidate"
+            // The inner input does not clear the previous value when a
+            // double vote entry is detected because the `value` prop never
+            // changes. `hasInvalidEntry` as the key forces a re-render
+            key={`${hasInvalidEntry}`}
+            menuPortalTarget={document.body}
+            maxMenuHeight={450} // 6 options, 75px each
+            options={allOptions}
+            onBlur={onInputBlur}
+            onFocus={onInputFocus}
+            onInputChange={onInputChange}
+            onChange={(val) => {
+              setInputValue('');
+              // we are guaranteed a value from SearchSelect with this use-case
+              assert(val !== undefined && val !== '');
+              if (val === INVALID_KEY) {
+                onChange({ type: 'invalid' });
+              } else if (filteredNames.includes(val)) {
+                let candidate = officialCandidates.find((c) => c.name === val);
+                const isOfficialCandidate = !!candidate;
+                if (!isOfficialCandidate) {
+                  candidate = writeInCandidates.find((c) => c.name === val);
+                }
+                assert(candidate !== undefined);
+                const type = isOfficialCandidate
+                  ? 'existing-official'
+                  : 'existing-write-in';
+                onChange({ type, ...candidate });
+              } else {
+                onChange({ type: 'new-write-in', name: val });
               }
-              assert(candidate !== undefined);
-              const type = isOfficialCandidate
-                ? 'existing-official'
-                : 'existing-write-in';
-              onChange({ type, ...candidate });
-            } else {
-              onChange({ type: 'new-write-in', name: val });
+            }}
+            minMenuHeight={300}
+            noOptionsMessage={() =>
+              `Entry exceeds max character length of ${MAX_WRITE_IN_NAME_LENGTH}`
             }
-          }}
-          minMenuHeight={300}
-          noOptionsMessage={() =>
-            `Entry exceeds max character length of ${MAX_WRITE_IN_NAME_LENGTH}`
-          }
-          value={value}
-          placeholder={
-            isFocused ? (
-              'Type to search or add candidate…'
-            ) : (
-              <React.Fragment>
-                <Icons.Warning
-                  color="warning"
-                  style={{ marginRight: '0.5rem' }}
-                />
-                {isSelected
-                  ? 'Click to adjudicate write-in'
-                  : 'Click to adjudicate Unmarked Write-in'}
-              </React.Fragment>
-            )
-          }
-          style={{
-            backgroundColor: value ? undefined : theme.colors.warningContainer,
-            borderRadius: '0 0 0.5rem 0.5rem',
-          }}
-        />
+            value={value}
+            placeholder={
+              isFocused ? (
+                'Type to search or add candidate…'
+              ) : (
+                <React.Fragment>
+                  <Icons.Warning
+                    color="warning"
+                    style={{ marginRight: '0.5rem' }}
+                  />
+                  {isSelected
+                    ? 'Click to adjudicate write-in'
+                    : 'Click to adjudicate unmarked write-in'}
+                </React.Fragment>
+              )
+            }
+            style={{
+              backgroundColor: value
+                ? undefined
+                : theme.colors.warningContainer,
+              borderRadius: '0 0 0.5rem 0.5rem',
+            }}
+          />
+        )}
         {caption}
       </Container>
     );

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
@@ -1097,123 +1097,6 @@ describe('ballot navigation', () => {
     primaryButton = getButtonByName('finish');
     expect(primaryButton).toBeDisabled();
   });
-
-  test('keyboard shortcuts allow for navigation', async () => {
-    renderScreen(contestId, {
-      electionDefinition,
-      apiMock,
-    });
-
-    // Initial ballot load
-    await screen.findByTestId('transcribe:id-175');
-    await expect(screen.findAllByRole('checkbox')).resolves.not.toHaveLength(0);
-
-    // Press right key: go to ballot 176
-    apiMock.expectGetCastVoteRecordVoteInfo(
-      { cvrId: cvrIds[2] },
-      { [contestId]: votes }
-    );
-    apiMock.expectGetVoteAdjudications({ contestId, cvrId: cvrIds[2] }, []);
-    apiMock.expectGetWriteIns(
-      { contestId, cvrId: cvrIds[2] },
-      pendingWriteInRecords176
-    );
-    apiMock.expectGetCvrContestTag(
-      { cvrId: cvrIds[2], contestId },
-      cvrContestTag2
-    );
-    apiMock.expectGetMarginalMarks({ cvrId: cvrIds[2], contestId }, []);
-
-    userEvent.keyboard('{ArrowRight}');
-    await screen.findByTestId('transcribe:id-176');
-    await expect(screen.findAllByRole('checkbox')).resolves.not.toHaveLength(0);
-
-    // Press left key: go back to ballot 175
-    userEvent.keyboard('{ArrowLeft}');
-    await screen.findByTestId('transcribe:id-175');
-    await expect(screen.findAllByRole('checkbox')).resolves.not.toHaveLength(0);
-
-    // Now focus on the first option to test navigating within the listbox
-    const kangarooOption = document.querySelector(
-      '[data-option-id="kangaroo"]'
-    ) as HTMLElement;
-    kangarooOption.focus();
-    let kangarooCheckbox = screen.getByRole('checkbox', {
-      name: /kangaroo/i,
-    });
-    expect(kangarooCheckbox).toBeChecked();
-
-    // Enter should toggle the checkbox
-    userEvent.keyboard('{Enter}');
-    kangarooCheckbox = screen.getByRole('checkbox', {
-      name: /kangaroo/i,
-    });
-    expect(kangarooCheckbox).not.toBeChecked();
-
-    // Toggle back
-    userEvent.keyboard('{Enter}');
-    kangarooCheckbox = screen.getByRole('checkbox', {
-      name: /kangaroo/i,
-    });
-    expect(kangarooCheckbox).toBeChecked();
-
-    // Move to next option
-    userEvent.keyboard('{ArrowDown}');
-
-    // Toggle vote with the space bar this time
-    let elephantCheckbox = screen.getByRole('checkbox', {
-      name: /elephant/i,
-    });
-    expect(elephantCheckbox).not.toBeChecked();
-    userEvent.keyboard(' ');
-
-    elephantCheckbox = screen.getByRole('checkbox', {
-      name: /elephant/i,
-    });
-    expect(elephantCheckbox).toBeChecked();
-    userEvent.keyboard(' ');
-    elephantCheckbox = screen.getByRole('checkbox', {
-      name: /elephant/i,
-    });
-    expect(elephantCheckbox).not.toBeChecked();
-
-    // Return to kangaroo option
-    userEvent.keyboard('{ArrowUp}');
-    expect(document.activeElement).toEqual(kangarooOption);
-
-    // Circle around the top to the first write-in
-
-    userEvent.keyboard('{ArrowUp}');
-    userEvent.keyboard('{ArrowUp}');
-    userEvent.keyboard('{ArrowUp}');
-    userEvent.keyboard('{ArrowUp}');
-    userEvent.keyboard('{ArrowUp}');
-
-    const writeIn0Option = document.querySelector(
-      '[data-option-id="write-in-0"]'
-    ) as HTMLElement;
-    expect(document.activeElement).toEqual(writeIn0Option);
-
-    // It should be checked to start
-    let writeIn0Checkbox = screen.getAllByRole('checkbox', {
-      name: /write-in/i,
-    })[0];
-    expect(writeIn0Checkbox).toBeChecked();
-
-    // Uncheck
-    userEvent.keyboard('{Enter}');
-    [writeIn0Checkbox] = screen.getAllByRole('checkbox', {
-      name: /write-in/i,
-    });
-    expect(writeIn0Checkbox).not.toBeChecked();
-
-    // Check again
-    userEvent.keyboard('{Enter}');
-    [writeIn0Checkbox] = screen.getAllByRole('checkbox', {
-      name: /write-in/i,
-    });
-    expect(writeIn0Checkbox).toBeChecked();
-  });
 });
 
 describe('ballot image viewer', () => {
@@ -2080,7 +1963,6 @@ describe('marginal mark adjudication', () => {
     // flags shouldn't be there anymore and captions should remain
     await screen.findByTestId('transcribe:id-174');
     expect(screen.queryAllByText(/marginal mark/i).length).toEqual(1);
-    screen.logTestingPlaygroundURL();
     expect(screen.queryByText(/valid write-in/i)).toBeInTheDocument();
   });
 });

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
@@ -986,7 +986,6 @@ export function ContestAdjudicationScreen(): JSX.Element {
                   <WriteInAdjudicationButton
                     key={optionId + currentCvrId}
                     label={writeInRecord?.machineMarkedText}
-                    optionId={optionId}
                     writeInStatus={writeInStatus}
                     marginalMarkStatus={marginalMarkStatus}
                     isFocused={isFocused}

--- a/libs/ui/src/checkbox_button.tsx
+++ b/libs/ui/src/checkbox_button.tsx
@@ -7,6 +7,7 @@ export interface CheckboxButtonProps {
   onChange: (isChecked: boolean) => void;
   disabled?: boolean;
   className?: string;
+  tabIndex?: number;
 }
 
 const StyledButton = styled(Button)`
@@ -32,6 +33,7 @@ export function CheckboxButton({
   onChange,
   disabled,
   className,
+  tabIndex,
 }: CheckboxButtonProps): JSX.Element {
   return (
     <StyledButton
@@ -43,6 +45,7 @@ export function CheckboxButton({
       onPress={() => onChange(!isChecked)}
       icon={isChecked ? 'Checkbox' : 'Square'}
       className={className}
+      tabIndex={tabIndex}
     >
       {label}
     </StyledButton>

--- a/libs/ui/src/checkbox_button.tsx
+++ b/libs/ui/src/checkbox_button.tsx
@@ -7,7 +7,6 @@ export interface CheckboxButtonProps {
   onChange: (isChecked: boolean) => void;
   disabled?: boolean;
   className?: string;
-  tabIndex?: number;
 }
 
 const StyledButton = styled(Button)`
@@ -33,7 +32,6 @@ export function CheckboxButton({
   onChange,
   disabled,
   className,
-  tabIndex,
 }: CheckboxButtonProps): JSX.Element {
   return (
     <StyledButton
@@ -45,7 +43,6 @@ export function CheckboxButton({
       onPress={() => onChange(!isChecked)}
       icon={isChecked ? 'Checkbox' : 'Square'}
       className={className}
-      tabIndex={tabIndex}
     >
       {label}
     </StyledButton>


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6554
https://github.com/votingworks/vxsuite/issues/6323

This PR:
1. Improves keyboard navigation. New behavior: Tab moves user into and out of option list, rather than scrolling within the list. Up and Down arrow keys move user within the list, following `aria-listbox` guidelines. Enter/space toggle list checkbox items. Left/Right arrow keys move user between ballots (Back/Skip). Tab indexes are updated so user can jump straight to the first item requiring adjudication in the list. `TabIndex` is set to `-1` for all inner checkboxes, as we navigate via the containers. - EDIT: This is no longer included in this PR. Some miscellaneous keyboard improvements are still included like autofocusing on modal primary buttons.
2. Adds support for marginally marked write-ins to be properly flagged as marginal marks.
3. Design touchups: Align dropdown items that have an icon, increase hover size of "Dismiss" button
4. Previously write-ins that did not require adjudication were rendered as "ContestOptionButtons". Now they are always rendered as WriteInAdjudicationButtons, though the html is equivalent. The change was made so focus could remain when a write-in was toggled from off to on. Previously focus was lost because the component would change. Now, WriteInAdjudicationButtons also support marginal mark flags, as they can have marginal marks. Because of this, I extracted `MarginalMarkFlag` into its own component, as it can be used by `ContestOptionButton` and `WriteInAdjudicationButton`

## Demo Video or Screenshot

UPDATED - simple navigation, tab only, no arrow keys

https://github.com/user-attachments/assets/d57f6b3d-1887-46d6-8b6c-e81b2944e1f0

Navigating to adjudicate

https://github.com/user-attachments/assets/965c12ab-34a2-41e5-81b3-5bf3532755a5

Navigating between ballots (left/right)

https://github.com/user-attachments/assets/726c77e5-c65d-4f4a-bc72-80a85766009e


## Testing Plan

Automated and QA this week.

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
