### PR TITLE
[VxScan] Wire up controller volume button to cycle through volumes

### DIFF
--- a/libs/test-utils/src/mock_use_audio_controls.ts
+++ b/libs/test-utils/src/mock_use_audio_controls.ts
@@ -6,6 +6,7 @@ export function mockUseAudioControls(
   fn: typeof vi.fn
 ): Record<keyof AudioControls, any> {
   return {
+    cycleVolume: fn(),
     decreasePlaybackRate: fn(),
     decreaseVolume: fn(),
     increasePlaybackRate: fn(),

--- a/libs/types/src/ui_audio_controls.ts
+++ b/libs/types/src/ui_audio_controls.ts
@@ -1,4 +1,5 @@
 export interface AudioControls {
+  cycleVolume: () => void;
   decreasePlaybackRate: () => void;
   decreaseVolume: () => void;
   increasePlaybackRate: () => void;

--- a/libs/ui/src/hooks/use_audio_controls.test.tsx
+++ b/libs/ui/src/hooks/use_audio_controls.test.tsx
@@ -25,6 +25,7 @@ test('returns external-facing audio context API', () => {
   } as const;
 
   const mockScreenReaderContextControls = {
+    cycleVolume: vi.fn(),
     decreaseVolume: vi.fn(),
     increaseVolume: vi.fn(),
     replay: vi.fn(),

--- a/libs/ui/src/hooks/use_audio_controls.ts
+++ b/libs/ui/src/hooks/use_audio_controls.ts
@@ -15,6 +15,7 @@ export function useAudioControls(): AudioControls {
   const screenReaderContext = useUiStringScreenReaderContext();
 
   return {
+    cycleVolume: screenReaderContext?.cycleVolume || noOp,
     decreasePlaybackRate: audioContext?.decreasePlaybackRate || noOp,
     decreaseVolume: screenReaderContext?.decreaseVolume || noOp,
     increasePlaybackRate: audioContext?.increasePlaybackRate || noOp,

--- a/libs/ui/src/keybindings.ts
+++ b/libs/ui/src/keybindings.ts
@@ -17,6 +17,7 @@ export enum Keybinding {
   TOGGLE_AUDIO = 'M',
   TOGGLE_HELP = 'R',
   TOGGLE_PAUSE = 'P',
+  VOLUME_CYCLE = 'F17', // Storm-Interface tactile controller
   VOLUME_DOWN = '-',
   VOLUME_UP = '=',
 

--- a/libs/ui/src/ui_strings/keyboard_shortcut_handlers.test.tsx
+++ b/libs/ui/src/ui_strings/keyboard_shortcut_handlers.test.tsx
@@ -73,6 +73,7 @@ test.each([
     expectedFnCall: audioControls.increasePlaybackRate,
   },
   { key: Keybinding.TOGGLE_PAUSE, expectedFnCall: audioControls.togglePause },
+  { key: Keybinding.VOLUME_CYCLE, expectedFnCall: audioControls.cycleVolume },
   { key: Keybinding.VOLUME_DOWN, expectedFnCall: audioControls.decreaseVolume },
   { key: Keybinding.VOLUME_UP, expectedFnCall: audioControls.increaseVolume },
 ])(
@@ -81,7 +82,8 @@ test.each([
     render(<KeyboardShortcutHandlers />);
 
     await act(async () => {
-      userEvent.keyboard(key);
+      const input = key.length === 1 ? key : `{${key}}`;
+      userEvent.keyboard(input);
       await advancePromises();
     });
 

--- a/libs/ui/src/ui_strings/keyboard_shortcut_handlers.tsx
+++ b/libs/ui/src/ui_strings/keyboard_shortcut_handlers.tsx
@@ -39,6 +39,9 @@ export function KeyboardShortcutHandlers(): React.ReactNode {
         case Keybinding.TOGGLE_PAUSE:
           audioControls.togglePause();
           break;
+        case Keybinding.VOLUME_CYCLE:
+          audioControls.cycleVolume();
+          break;
         case Keybinding.VOLUME_DOWN:
           audioControls.decreaseVolume();
           break;

--- a/libs/ui/src/ui_strings/ui_string_screen_reader.test.tsx
+++ b/libs/ui/src/ui_strings/ui_string_screen_reader.test.tsx
@@ -274,6 +274,8 @@ test('volume control API', async () => {
     newTestContext();
 
   const mockAudioIds: Partial<Record<AppStringKey, string[]>> = {
+    audioFeedbackMinimumVolume: ['min-volume'],
+    audioFeedback10PercentVolume: ['10%-volume'],
     audioFeedback90PercentVolume: ['90%-volume'],
     audioFeedbackMaximumVolume: ['max-volume'],
     titleBmdReviewScreen: ['screen-title'],
@@ -321,12 +323,24 @@ test('volume control API', async () => {
     getMockClipOutput({ audioId: 'max-volume', languageCode: ENGLISH })
   );
 
+  // Simulate cycling volume level (for single-button volume-control devices):
+  act(() => getAudioControls()?.cycleVolume());
+  expect(getAudioContext()?.volume).toEqual(AudioVolume.MINIMUM);
+  expect(await screen.findByTestId('mockClipOutput')).toHaveTextContent(
+    getMockClipOutput({ audioId: 'min-volume', languageCode: ENGLISH })
+  );
+  act(() => getAudioControls()?.cycleVolume());
+  expect(getAudioContext()?.volume).toEqual(AudioVolume.TEN_PERCENT);
+  expect(await screen.findByTestId('mockClipOutput')).toHaveTextContent(
+    getMockClipOutput({ audioId: '10%-volume', languageCode: ENGLISH })
+  );
+
   // Decreasing volume while no screen reader audio is active should play
   // appropriate feedback:
   act(() => getAudioControls()?.decreaseVolume());
-  expect(getAudioContext()?.volume).toEqual(AudioVolume.NINETY_PERCENT);
+  expect(getAudioContext()?.volume).toEqual(AudioVolume.MINIMUM);
   expect(await screen.findByTestId('mockClipOutput')).toHaveTextContent(
-    getMockClipOutput({ audioId: '90%-volume', languageCode: ENGLISH })
+    getMockClipOutput({ audioId: 'min-volume', languageCode: ENGLISH })
   );
 
   // Simulate screen reader audio ending:

--- a/libs/ui/src/ui_strings/ui_string_screen_reader.tsx
+++ b/libs/ui/src/ui_strings/ui_string_screen_reader.tsx
@@ -42,6 +42,7 @@ interface UiStringParams {
 }
 
 export interface UiStringScreenReaderContextInterface {
+  cycleVolume: () => void;
   decreaseVolume: () => void;
   increaseVolume: () => void;
   /** Replays audio for any `UiString`s currently under focus. */
@@ -82,6 +83,15 @@ function useVolumeControls(params: {
     [baseSetVolume, currentLanguageCode, playVolumeChangeFeedback]
   );
 
+  const cycleVolume = React.useCallback(() => {
+    if (volume === AudioVolume.MAXIMUM) {
+      setVolume(AudioVolume.MINIMUM);
+      return;
+    }
+
+    setVolume(getIncreasedVolume(volume));
+  }, [setVolume, volume]);
+
   const increaseVolume = React.useCallback(
     () => setVolume(getIncreasedVolume(volume)),
     [setVolume, volume]
@@ -92,7 +102,7 @@ function useVolumeControls(params: {
     [setVolume, volume]
   );
 
-  return { decreaseVolume, increaseVolume };
+  return { cycleVolume, decreaseVolume, increaseVolume };
 }
 
 /**
@@ -108,7 +118,7 @@ export function UiStringScreenReader(
   const [audioFeedbackQueue, setAudioFeedbackQueue] =
     React.useState<UiStringParams[]>();
 
-  const { decreaseVolume, increaseVolume } = useVolumeControls({
+  const { cycleVolume, decreaseVolume, increaseVolume } = useVolumeControls({
     playVolumeChangeFeedback: setAudioFeedbackQueue,
   });
 
@@ -282,7 +292,7 @@ export function UiStringScreenReader(
 
   return (
     <UiStringScreenReaderContext.Provider
-      value={{ decreaseVolume, increaseVolume, replay }}
+      value={{ cycleVolume, decreaseVolume, increaseVolume, replay }}
     >
       {isEnabled && (
         <PlayAudioClips clips={memoizedClipQueue} onDone={onDone} />


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6484

The tactile controller we're using for VxScan has a single volume button that emits `F17` key events. Since can't use the same `increase/decreaseVolume()` API we use for VxMark, this wires us `F17` to cycle through volume levels in increasing order and loop around to the min volume when going past the max.

## Demo Video or Screenshot

Watch out for the volume increase if you're watching this:

https://github.com/user-attachments/assets/063c9050-aeb2-4ec1-afb9-eacf6accb983

## Testing Plan
- Unit + manual tests

## Checklist

<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
