### PR TITLE
[VxScan] Add/update IDs for audio-related log events

### DIFF
--- a/apps/scan/backend/src/audio/player.test.ts
+++ b/apps/scan/backend/src/audio/player.test.ts
@@ -54,7 +54,7 @@ test('with execFile error', async () => {
   await player.play('alarm');
 
   expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
-    LogEventId.UnknownError,
+    LogEventId.AudioPlaybackError,
     {
       message: expect.stringContaining('execFile failed'),
       disposition: 'failure',
@@ -74,7 +74,7 @@ test('with paplay error', async () => {
   await player.play('warning');
 
   expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
-    LogEventId.UnknownError,
+    LogEventId.AudioPlaybackError,
     {
       message: expect.stringContaining('No such file or directory'),
       disposition: 'failure',

--- a/apps/scan/backend/src/audio/player.ts
+++ b/apps/scan/backend/src/audio/player.ts
@@ -35,8 +35,7 @@ export class Player {
         ]));
       }
     } catch (error) {
-      // [TODO] Add log event ID for audio playback errors.
-      void this.logger.logAsCurrentRole(LogEventId.UnknownError, {
+      void this.logger.logAsCurrentRole(LogEventId.AudioPlaybackError, {
         message: `Unable to run 'paplay' command: ${error}}`,
         disposition: 'failure',
       });
@@ -45,8 +44,7 @@ export class Player {
     }
 
     if (errorOutput) {
-      // [TODO] Add log event ID for audio playback errors.
-      void this.logger.logAsCurrentRole(LogEventId.UnknownError, {
+      void this.logger.logAsCurrentRole(LogEventId.AudioPlaybackError, {
         message: `'paplay' command failed: ${errorOutput}}`,
         disposition: 'failure',
       });

--- a/apps/scan/backend/src/server.test.ts
+++ b/apps/scan/backend/src/server.test.ts
@@ -154,7 +154,7 @@ test('logs if unable to detect USB audio device', async () => {
   });
 
   expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
-    LogEventId.UnknownError,
+    LogEventId.AudioDeviceMissing,
     {
       message: 'USB audio device not detected.',
       disposition: 'failure',

--- a/apps/scan/backend/src/server.ts
+++ b/apps/scan/backend/src/server.ts
@@ -90,8 +90,7 @@ export async function start({
     });
     result.assertOk('unable to set USB audio as default output');
   } else {
-    // [TODO] Update log event ID to something more specific.
-    void logger.logAsCurrentRole(LogEventId.UnknownError, {
+    void logger.logAsCurrentRole(LogEventId.AudioDeviceMissing, {
       message: 'USB audio device not detected.',
       disposition: 'failure',
     });

--- a/libs/backend/src/system_call/get_audio_info.test.ts
+++ b/libs/backend/src/system_call/get_audio_info.test.ts
@@ -246,7 +246,7 @@ test('execFile error', async () => {
   expect(await getAudioInfo({ logger, nodeEnv })).toEqual<AudioInfo>({});
 
   expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
-    LogEventId.HeadphonesDetectionError,
+    LogEventId.AudioDeviceDetectionError,
     {
       message: expect.stringContaining('execFile failed'),
       disposition: 'failure',
@@ -262,7 +262,7 @@ test('pactl error', async () => {
   expect(await getAudioInfo({ logger, nodeEnv })).toEqual<AudioInfo>({});
 
   expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
-    LogEventId.HeadphonesDetectionError,
+    LogEventId.AudioDeviceDetectionError,
     {
       message: expect.stringContaining('access denied'),
       disposition: 'failure',
@@ -278,7 +278,7 @@ test('pactl output parse error', async () => {
   expect(await getAudioInfo({ logger, nodeEnv })).toEqual<AudioInfo>({});
 
   expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
-    LogEventId.HeadphonesDetectionError,
+    LogEventId.AudioDeviceDetectionError,
     {
       message: expect.stringContaining('ZodError'),
       disposition: 'failure',

--- a/libs/backend/src/system_call/get_audio_info.ts
+++ b/libs/backend/src/system_call/get_audio_info.ts
@@ -55,8 +55,7 @@ export async function getAudioInfo(ctx: {
       ));
     }
   } catch (error) {
-    // [TODO] Update log event ID to something more general.
-    void logger.logAsCurrentRole(LogEventId.HeadphonesDetectionError, {
+    void logger.logAsCurrentRole(LogEventId.AudioDeviceDetectionError, {
       message: `Unable to run pactl command: ${error}}`,
       disposition: 'failure',
     });
@@ -65,7 +64,7 @@ export async function getAudioInfo(ctx: {
   }
 
   if (errorOutput) {
-    void logger.logAsCurrentRole(LogEventId.HeadphonesDetectionError, {
+    void logger.logAsCurrentRole(LogEventId.AudioDeviceDetectionError, {
       message: `pactl command failed: ${errorOutput}}`,
       disposition: 'failure',
     });
@@ -95,7 +94,7 @@ export async function getAudioInfo(ctx: {
       }
     }
   } catch (error) {
-    void logger.logAsCurrentRole(LogEventId.HeadphonesDetectionError, {
+    void logger.logAsCurrentRole(LogEventId.AudioDeviceDetectionError, {
       message: `unable to parse pactl output: ${error}}`,
       disposition: 'failure',
     });

--- a/libs/backend/src/system_call/set_default_audio.ts
+++ b/libs/backend/src/system_call/set_default_audio.ts
@@ -45,9 +45,8 @@ export async function setDefaultAudio(
       ]));
     }
   } catch (error) {
-    // [TODO] Update log event ID to something more specific.
-    void logger.logAsCurrentRole(LogEventId.UnknownError, {
-      message: `Unable to run pactl set-default-sink command: ${error}}`,
+    void logger.logAsCurrentRole(LogEventId.AudioDeviceSelectionError, {
+      message: `Unable to run pactl set-default-sink command: ${error}`,
       disposition: 'failure',
     });
 
@@ -55,14 +54,18 @@ export async function setDefaultAudio(
   }
 
   if (errorOutput) {
-    // [TODO] Update log event ID to something more specific.
-    void logger.logAsCurrentRole(LogEventId.UnknownError, {
-      message: `pactl set-default-sink command failed: ${errorOutput}}`,
+    void logger.logAsCurrentRole(LogEventId.AudioDeviceSelectionError, {
+      message: `pactl set-default-sink command failed: ${errorOutput}`,
       disposition: 'failure',
     });
 
     return err({ code: 'pactlError', error: errorOutput });
   }
+
+  void logger.logAsCurrentRole(LogEventId.AudioDeviceSelected, {
+    message: `Selected default audio output: ${sinkName}`,
+    disposition: 'success',
+  });
 
   return ok();
 }

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -150,9 +150,25 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)
 **Description:** The user has saved an equipment readiness report.
 **Machines:** All
-### headphones-detection-errors
+### audio-device-detection-error
 **Type:** [application-status](#application-status)
-**Description:** Error while attempting to detect headphones.
+**Description:** Error while attempting to detect audio devices.
+**Machines:** All
+### audio-device-missing
+**Type:** [application-status](#application-status)
+**Description:** An expected audio device was not detected.
+**Machines:** All
+### audio-device-selected
+**Type:** [application-status](#application-status)
+**Description:** A default audio output device was selected.
+**Machines:** All
+### audio-device-selection-error
+**Type:** [application-status](#application-status)
+**Description:** Error while attempting to select a default audio output device.
+**Machines:** All
+### audio-playback-error
+**Type:** [application-status](#application-status)
+**Description:** Error while attempting to play audio.
 **Machines:** All
 ### unknown-error
 **Type:** [application-status](#application-status)

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -16,7 +16,6 @@ name = 'vx-central-scan'
 [Apps.VxDesign]
 name = 'vx-design'
 
-
 [LogSources.System]
 source = 'system'
 
@@ -95,7 +94,6 @@ source = 'vx-pollbook-frontend'
 [LogSources.VxPollbookBackend]
 source = 'vx-pollbook-backend'
 
-
 [EventTypes.UserAction]
 eventType = "user-action"
 documentationMessage = "A log that results from a user taking an action, i.e. an election admin uploading an election definition to a machine."
@@ -115,7 +113,6 @@ documentationMessage = "Status update or message that the application took witho
 [EventTypes.ApplicationAction]
 eventType = "application-action"
 documentationMessage = "Action taken by the votingworks application automatically when a certain condition is met. Example: When a new USB drive is detected, the application will automatically mount it."
-
 
 # Configuration for log event details, general logs are defined first
 # followed by application specific logs for VxAdmin, VxCentralScan, VxMark, VxScan, and VxMarkScan
@@ -297,10 +294,30 @@ eventId = "readiness-report-saved"
 eventType = "user-action"
 documentationMessage = "The user has saved an equipment readiness report."
 
-[Events.HeadphonesDetectionError]
-eventId = "headphones-detection-errors"
+[Events.AudioDeviceDetectionError]
+eventId = "audio-device-detection-error"
 eventType = "application-status"
-documentationMessage = "Error while attempting to detect headphones."
+documentationMessage = "Error while attempting to detect audio devices."
+
+[Events.AudioDeviceMissing]
+eventId = "audio-device-missing"
+eventType = "application-status"
+documentationMessage = "An expected audio device was not detected."
+
+[Events.AudioDeviceSelected]
+eventId = "audio-device-selected"
+eventType = "application-status"
+documentationMessage = "A default audio output device was selected."
+
+[Events.AudioDeviceSelectionError]
+eventId = "audio-device-selection-error"
+eventType = "application-status"
+documentationMessage = "Error while attempting to select a default audio output device."
+
+[Events.AudioPlaybackError]
+eventId = "audio-playback-error"
+eventType = "application-status"
+documentationMessage = "Error while attempting to play audio."
 
 [Events.UnknownError]
 eventId = "unknown-error"

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -96,7 +96,11 @@ export enum LogEventId {
   DiagnosticComplete = 'diagnostic-complete',
   ReadinessReportPrinted = 'readiness-report-printed',
   ReadinessReportSaved = 'readiness-report-saved',
-  HeadphonesDetectionError = 'headphones-detection-errors',
+  AudioDeviceDetectionError = 'audio-device-detection-error',
+  AudioDeviceMissing = 'audio-device-missing',
+  AudioDeviceSelected = 'audio-device-selected',
+  AudioDeviceSelectionError = 'audio-device-selection-error',
+  AudioPlaybackError = 'audio-playback-error',
   UnknownError = 'unknown-error',
   PermissionDenied = 'permission-denied',
   ParseError = 'parse-error',
@@ -431,10 +435,35 @@ const ReadinessReportSaved: LogDetails = {
   documentationMessage: 'The user has saved an equipment readiness report.',
 };
 
-const HeadphonesDetectionError: LogDetails = {
-  eventId: LogEventId.HeadphonesDetectionError,
+const AudioDeviceDetectionError: LogDetails = {
+  eventId: LogEventId.AudioDeviceDetectionError,
   eventType: LogEventType.ApplicationStatus,
-  documentationMessage: 'Error while attempting to detect headphones.',
+  documentationMessage: 'Error while attempting to detect audio devices.',
+};
+
+const AudioDeviceMissing: LogDetails = {
+  eventId: LogEventId.AudioDeviceMissing,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage: 'An expected audio device was not detected.',
+};
+
+const AudioDeviceSelected: LogDetails = {
+  eventId: LogEventId.AudioDeviceSelected,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage: 'A default audio output device was selected.',
+};
+
+const AudioDeviceSelectionError: LogDetails = {
+  eventId: LogEventId.AudioDeviceSelectionError,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'Error while attempting to select a default audio output device.',
+};
+
+const AudioPlaybackError: LogDetails = {
+  eventId: LogEventId.AudioPlaybackError,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage: 'Error while attempting to play audio.',
 };
 
 const UnknownError: LogDetails = {
@@ -1268,8 +1297,16 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return ReadinessReportPrinted;
     case LogEventId.ReadinessReportSaved:
       return ReadinessReportSaved;
-    case LogEventId.HeadphonesDetectionError:
-      return HeadphonesDetectionError;
+    case LogEventId.AudioDeviceDetectionError:
+      return AudioDeviceDetectionError;
+    case LogEventId.AudioDeviceMissing:
+      return AudioDeviceMissing;
+    case LogEventId.AudioDeviceSelected:
+      return AudioDeviceSelected;
+    case LogEventId.AudioDeviceSelectionError:
+      return AudioDeviceSelectionError;
+    case LogEventId.AudioPlaybackError:
+      return AudioPlaybackError;
     case LogEventId.UnknownError:
       return UnknownError;
     case LogEventId.PermissionDenied:

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -175,8 +175,16 @@ pub enum EventId {
     ReadinessReportPrinted,
     #[serde(rename = "readiness-report-saved")]
     ReadinessReportSaved,
-    #[serde(rename = "headphones-detection-errors")]
-    HeadphonesDetectionError,
+    #[serde(rename = "audio-device-detection-error")]
+    AudioDeviceDetectionError,
+    #[serde(rename = "audio-device-missing")]
+    AudioDeviceMissing,
+    #[serde(rename = "audio-device-selected")]
+    AudioDeviceSelected,
+    #[serde(rename = "audio-device-selection-error")]
+    AudioDeviceSelectionError,
+    #[serde(rename = "audio-playback-error")]
+    AudioPlaybackError,
     #[serde(rename = "unknown-error")]
     UnknownError,
     #[serde(rename = "permission-denied")]


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6484

Follow-up from recent work adding screen reader audio support to VxScan - replacing a few placeholder log event IDs related to system audio.

## Testing Plan
- Updated relevant tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.

