### PR TITLE
[VxScan] Add relevant handling for controller left/right navigation 

### DIFF
--- a/apps/mark-scan/frontend/src/lib/assistive_technology.ts
+++ b/apps/mark-scan/frontend/src/lib/assistive_technology.ts
@@ -26,7 +26,10 @@ function preventBrowserScroll(event: KeyboardEvent) {
 export function handleKeyboardEvent(event: KeyboardEvent): void {
   switch (event.key) {
     case Keybinding.PAGE_PREVIOUS:
-      triggerPageNavigationButton(PageNavigationButtonId.PREVIOUS);
+      triggerPageNavigationButton(
+        PageNavigationButtonId.PREVIOUS,
+        PageNavigationButtonId.PREVIOUS_AFTER_CONFIRM
+      );
       break;
     case Keybinding.PAGE_NEXT:
       triggerPageNavigationButton(

--- a/apps/mark/frontend/src/lib/gamepad.ts
+++ b/apps/mark/frontend/src/lib/gamepad.ts
@@ -48,7 +48,10 @@ export function handleGamepadKeyboardEvent(event: KeyboardEvent): void {
       advanceElementFocus(1);
       break;
     case Keybinding.PAGE_PREVIOUS:
-      triggerPageNavigationButton(PageNavigationButtonId.PREVIOUS);
+      triggerPageNavigationButton(
+        PageNavigationButtonId.PREVIOUS,
+        PageNavigationButtonId.PREVIOUS_AFTER_CONFIRM
+      );
       break;
     case Keybinding.PAGE_NEXT:
       triggerPageNavigationButton(

--- a/apps/scan/frontend/src/components/misvote_warnings/warning_details_modal_button.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/warning_details_modal_button.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   Modal,
   ModalWidth,
+  PageNavigationButtonId,
   WithScrollButtons,
   appStrings,
 } from '@votingworks/ui';
@@ -29,7 +30,12 @@ export function WarningDetailsModalButton(
           </WithScrollButtons>
         }
         actions={
-          <Button onPress={setIsModalOpen} value={false} variant="primary">
+          <Button
+            id={PageNavigationButtonId.NEXT_AFTER_CONFIRM}
+            onPress={setIsModalOpen}
+            value={false}
+            variant="primary"
+          >
             {appStrings.buttonClose()}
           </Button>
         }

--- a/apps/scan/frontend/src/screens/scan_warning_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.tsx
@@ -18,6 +18,7 @@ import {
   Modal,
   ModalWidth,
   P,
+  PageNavigationButtonId,
   WithScrollButtons,
   appStrings,
 } from '@votingworks/ui';
@@ -49,6 +50,7 @@ function ConfirmModal({ content, onConfirm, onCancel }: ConfirmModalProps) {
       actions={
         <React.Fragment>
           <Button
+            id={PageNavigationButtonId.NEXT_AFTER_CONFIRM}
             variant="primary"
             icon="Done"
             onPress={() => {
@@ -59,7 +61,11 @@ function ConfirmModal({ content, onConfirm, onCancel }: ConfirmModalProps) {
           >
             {appStrings.buttonCastBallot()}
           </Button>
-          <Button onPress={onCancel} disabled={confirmed}>
+          <Button
+            id={PageNavigationButtonId.PREVIOUS_AFTER_CONFIRM}
+            onPress={onCancel}
+            disabled={confirmed}
+          >
             {appStrings.buttonCancel()}
           </Button>
         </React.Fragment>
@@ -136,6 +142,7 @@ function MisvoteWarningScreen({
       actionButtons={
         <React.Fragment>
           <Button
+            id={PageNavigationButtonId.PREVIOUS_AFTER_CONFIRM}
             variant="primary"
             onPress={() => returnBallotMutation.mutate()}
           >
@@ -143,7 +150,10 @@ function MisvoteWarningScreen({
           </Button>
 
           {(allowCastingOvervotes || overvoteContests.length === 0) && (
-            <Button onPress={() => setConfirmTabulate(true)}>
+            <Button
+              id={PageNavigationButtonId.NEXT_AFTER_CONFIRM}
+              onPress={() => setConfirmTabulate(true)}
+            >
               {appStrings.buttonCastBallot()}
             </Button>
           )}
@@ -198,12 +208,16 @@ function BlankBallotWarningScreen({
       actionButtons={
         <React.Fragment>
           <Button
+            id={PageNavigationButtonId.PREVIOUS_AFTER_CONFIRM}
             variant="primary"
             onPress={() => returnBallotMutation.mutate()}
           >
             {appStrings.buttonReturnBallot()}
           </Button>
-          <Button onPress={() => setConfirmTabulate(true)}>
+          <Button
+            id={PageNavigationButtonId.NEXT_AFTER_CONFIRM}
+            onPress={() => setConfirmTabulate(true)}
+          >
             {appStrings.buttonCastBallot()}
           </Button>
         </React.Fragment>
@@ -250,12 +264,16 @@ function OtherReasonWarningScreen({
       actionButtons={
         <React.Fragment>
           <Button
+            id={PageNavigationButtonId.PREVIOUS_AFTER_CONFIRM}
             variant="primary"
             onPress={() => returnBallotMutation.mutate()}
           >
             {appStrings.buttonReturnBallot()}
           </Button>
-          <Button onPress={() => setConfirmTabulate(true)}>
+          <Button
+            id={PageNavigationButtonId.NEXT_AFTER_CONFIRM}
+            onPress={() => setConfirmTabulate(true)}
+          >
             {appStrings.buttonCastBallot()}
           </Button>
         </React.Fragment>

--- a/apps/scan/frontend/src/utils/ui_navigation.test.ts
+++ b/apps/scan/frontend/src/utils/ui_navigation.test.ts
@@ -55,7 +55,8 @@ test('page previous', () => {
 
   expect(mockTriggerPageNavButton).toHaveBeenCalledTimes(1);
   expect(mockTriggerPageNavButton).toHaveBeenCalledWith(
-    PageNavigationButtonId.PREVIOUS
+    PageNavigationButtonId.PREVIOUS,
+    PageNavigationButtonId.PREVIOUS_AFTER_CONFIRM
   );
 
   expect(mockAdvanceFocus).not.toHaveBeenCalled();

--- a/apps/scan/frontend/src/utils/ui_navigation.ts
+++ b/apps/scan/frontend/src/utils/ui_navigation.ts
@@ -20,7 +20,10 @@ function preventBrowserScroll(event: KeyboardEvent) {
 export function handleKeyboardEvent(event: KeyboardEvent): void {
   switch (event.key) {
     case Keybinding.PAGE_PREVIOUS:
-      triggerPageNavigationButton(PageNavigationButtonId.PREVIOUS);
+      triggerPageNavigationButton(
+        PageNavigationButtonId.PREVIOUS,
+        PageNavigationButtonId.PREVIOUS_AFTER_CONFIRM
+      );
       break;
 
     case Keybinding.PAGE_NEXT:

--- a/libs/ui/src/accessible_controllers/navigation.ts
+++ b/libs/ui/src/accessible_controllers/navigation.ts
@@ -2,6 +2,7 @@ export enum PageNavigationButtonId {
   NEXT = 'next',
   NEXT_AFTER_CONFIRM = 'next_after_confirm',
   PREVIOUS = 'previous',
+  PREVIOUS_AFTER_CONFIRM = 'previous_after_confirm',
 }
 
 const TAB_ENABLED_ELEMENT_SELECTORS = [
@@ -54,9 +55,11 @@ export function advanceElementFocus(direction: 1 | -1): void {
 }
 
 /**
- * Looks for all page navigation elements with the specified {@link navigationId} or
- * {@link nagivationOnConfirmId} (if provided). If a visible {@link navigationId} is found, the first element is clicked.
- * Otherwise if a visible {@link navigationOnConfirmId} is found, the first element is focused.
+ * Looks for all page navigation elements with the specified
+ * {@link navigationId} or {@link nagivationOnConfirmId} (if provided). If a
+ * visible {@link navigationId} is found, the first element is clicked.
+ * Otherwise if a visible {@link navigationOnConfirmId} is found, the first
+ * element is focused.
  */
 export function triggerPageNavigationButton(
   navigationId: PageNavigationButtonId,


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6484

Follow-up from https://github.com/votingworks/vxsuite/pull/6580 - adding handling for the left/right arrow keys on the VxScan controller.

Instead of automatically triggering "next/continue" and "previous/return" buttons, this follows the pattern used in the cast confirmation screens on VxMark, where the controller buttons focus on the relevant UI buttons instead and an explicit `select` button press is required to continue.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/1425d87f-f893-4516-a098-2068c62a04d4

## Testing Plan
- Existing unit tests for the focus-only event handling
- Manual testing with keyboard and controller to verify 

## Checklist

<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
