### PR TITLE
support scanner disconnect/reconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,11 +280,13 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "color-eyre",
+ "mockall",
  "nix 0.26.4",
  "nusb",
  "proptest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-serial",
@@ -774,6 +776,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +925,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "futures"
@@ -1576,6 +1590,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if 1.0.0",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "nalgebra"
 version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,6 +2092,32 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "pretty_env_logger"
@@ -2710,6 +2776,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ libc = "0.2.153"
 log = "0.4.17"
 vx-logging = { path = "libs/logging" }
 daemon-utils = { path = "apps/mark-scan/daemon-utils" }
+mockall = "0.13.1"
 napi = { version = "2.16.17", default-features = false, features = [
     "napi4",
     "async",

--- a/apps/pollbook/barcode-scanner-daemon/Cargo.toml
+++ b/apps/pollbook/barcode-scanner-daemon/Cargo.toml
@@ -17,11 +17,15 @@ nusb = { workspace = true }
 proptest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-serial = { workspace = true }
 tokio-test = { workspace = true }
 thiserror = { workspace = true }
 vx-logging = { workspace = true }
+
+[dev-dependencies]
+mockall = { workspace = true }
 
 [lints]
 workspace = true

--- a/apps/pollbook/barcode-scanner-daemon/src/unitech_ts100_daemon.rs
+++ b/apps/pollbook/barcode-scanner-daemon/src/unitech_ts100_daemon.rs
@@ -369,7 +369,7 @@ async fn main() -> color_eyre::Result<()> {
                 log!(EventId::UnknownError, "Error in read/write loop: {err}");
             }
             None => break,
-        };
+        }
     }
 
     let _ = fs::remove_file(UDS_PATH);

--- a/apps/pollbook/barcode-scanner-daemon/src/usb.rs
+++ b/apps/pollbook/barcode-scanner-daemon/src/usb.rs
@@ -1,0 +1,50 @@
+use std::io::{Error, ErrorKind};
+
+pub trait UsbConnection: Send + Sync {
+    fn reset(&mut self) -> Result<(), Error>;
+}
+
+pub struct RealConnection(nusb::Device);
+impl UsbConnection for RealConnection {
+    fn reset(&mut self) -> Result<(), Error> {
+        self.0.reset().map_err(|e| Error::new(ErrorKind::Other, e))
+    }
+}
+
+pub trait UsbDevice: Send + Sync {
+    fn vendor_id(&self) -> u16;
+    fn product_id(&self) -> u16;
+    fn open(&self) -> Result<Box<dyn UsbConnection>, Error>;
+}
+
+pub struct RealDevice(nusb::DeviceInfo);
+
+impl UsbDevice for RealDevice {
+    fn vendor_id(&self) -> u16 {
+        self.0.vendor_id()
+    }
+
+    fn product_id(&self) -> u16 {
+        self.0.product_id()
+    }
+
+    fn open(&self) -> Result<Box<dyn UsbConnection>, Error> {
+        let d = self.0.clone(); // or however you get ownership
+        Ok(Box::new(RealConnection(d.open()?)))
+    }
+}
+
+#[cfg_attr(test, mockall::automock)]
+pub trait UsbLister: Send + Sync + 'static {
+    fn list_devices(&self) -> Result<Vec<Box<dyn UsbDevice>>, Error>;
+}
+
+pub struct SimpleUsbLister;
+impl UsbLister for SimpleUsbLister {
+    fn list_devices(&self) -> Result<Vec<Box<dyn UsbDevice>>, Error> {
+        Ok(nusb::list_devices()?
+            .map(RealDevice)
+            .map(|d| Box::new(d) as Box<dyn UsbDevice>)
+            .collect::<Vec<_>>())
+    }
+}


### PR DESCRIPTION

## Overview
* don't error when scanner is disconnected
* infinitely retry scanner connection on startup and after scanner disconnection


## Demo Video or Screenshot

`ctrl+c` exit before connecting to scanner

https://github.com/user-attachments/assets/96dc1a4b-dc5d-422f-a336-5d1cda948dcb

`ctrl+c` exit after connecting to scanner

https://github.com/user-attachments/assets/27c23628-73a4-4528-9b9f-6c6900194cfd

Scanner disconnect and reconnect

https://github.com/user-attachments/assets/e4981a34-84dc-4d7f-a004-dfdd728c5d5e






## Testing Plan

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
