### PR TITLE
chore(pollbook): remove extraneous `Cargo.toml` field

### DIFF
--- a/apps/pollbook/barcode-scanner-daemon/Cargo.toml
+++ b/apps/pollbook/barcode-scanner-daemon/Cargo.toml
@@ -3,7 +3,6 @@ name = "barcode-scanner-daemon"
 version = "0.1.0"
 edition = "2021"
 license.workspace = true
-license-file.workspace = true
 
 [[bin]]
 name = "barcodescannerd"


### PR DESCRIPTION
We shouldn't have both `license` and `license-file`, and the latter is for when using a non-standard license.
