### PR TITLE
[VxScan] Increase # of retries when detecting audio devices at startup

### DIFF
--- a/apps/scan/backend/src/server.ts
+++ b/apps/scan/backend/src/server.ts
@@ -77,7 +77,7 @@ export async function start({
   workspace.clearUploads();
 
   const audioInfo = await getAudioInfo({
-    baseRetryDelayMs: 500,
+    baseRetryDelayMs: 2000,
     logger,
     maxAttempts: 4,
     nodeEnv: NODE_ENV,


### PR DESCRIPTION
## Overview

Related toL https://github.com/votingworks/vxsuite/issues/6484

Issue found during QA: https://votingworks.slack.com/archives/CJU9MSC6S/p1749840805240489

With the newly added audio device detection at server startup, VxScan was crashing because it seems the PulseAudio service didn't get fully spun up before we run out of retry attempts.

Verified on a QA image that bumping up from 4 to 5 attempts works consistently, so just bumping up the initial wait time to 2 seconds instead, just to be extra safe.

## Testing Plan
- Tested on prod hardware with QA image.
