### PR TITLE
Initial Framework for Multi-Precinct Pollbooks

### DIFF
--- a/apps/pollbook/backend/schema.sql
+++ b/apps/pollbook/backend/schema.sql
@@ -20,7 +20,8 @@ CREATE TABLE elections (
     ballot_hash TEXT not null,
     package_hash TEXT not null,
     valid_street_data TEXT,
-    is_absentee_mode BOOLEAN NOT NULL
+    is_absentee_mode BOOLEAN NOT NULL,
+    configured_precinct_id TEXT
 );
 
 CREATE TABLE event_log (

--- a/apps/pollbook/backend/src/app.test.ts
+++ b/apps/pollbook/backend/src/app.test.ts
@@ -69,6 +69,7 @@ test('check in a voter', async () => {
       testVoters
     );
     mockPrinterHandler.connectPrinter(CITIZEN_THERMAL_PRINTER_CONFIG);
+    expect(await localApiClient.haveElectionEventsOccurred()).toEqual(false);
     const votersAbigail = await localApiClient.searchVoters({
       searchParams: {
         firstName: 'Abigail',
@@ -88,6 +89,7 @@ test('check in a voter', async () => {
       identificationMethod: { type: 'default' },
     });
     expect(checkInResult.ok()).toEqual(undefined);
+    expect(await localApiClient.haveElectionEventsOccurred()).toEqual(true);
 
     const updatedFirstVoter = await localApiClient.getVoter({
       voterId: firstVoter.voterId,
@@ -150,6 +152,7 @@ test('register a voter', async () => {
       []
     );
     mockPrinterHandler.connectPrinter(CITIZEN_THERMAL_PRINTER_CONFIG);
+    expect(await localApiClient.haveElectionEventsOccurred()).toEqual(false);
 
     const registrationData: VoterRegistrationRequest = {
       firstName: 'Helena',
@@ -179,6 +182,7 @@ test('register a voter', async () => {
       lastName: 'Eagen',
       party: 'REP',
     });
+    expect(await localApiClient.haveElectionEventsOccurred()).toEqual(true);
 
     const receiptPdfPath = mockPrinterHandler.getLastPrintPath();
     expect(receiptPdfPath).toBeDefined();
@@ -345,7 +349,9 @@ test('change a voter name', async () => {
       testStreets,
       testVoters
     );
+
     mockPrinterHandler.connectPrinter(CITIZEN_THERMAL_PRINTER_CONFIG);
+    expect(await localApiClient.haveElectionEventsOccurred()).toEqual(false);
 
     const votersAbigail = await localApiClient.searchVoters({
       searchParams: {
@@ -375,6 +381,7 @@ test('change a voter name', async () => {
       ...nameChangeData,
       timestamp: expect.any(String),
     });
+    expect(await localApiClient.haveElectionEventsOccurred()).toEqual(true);
 
     const receiptPdfPath = mockPrinterHandler.getLastPrintPath();
     expect(receiptPdfPath).toBeDefined();

--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -40,9 +40,9 @@ import {
   LocalAppContext,
   LocalWorkspace,
   ConfigurationError,
-  MachineInformation,
   VoterCheckInError,
   DuplicateVoterError,
+  PollbookConfigurationInformation,
 } from './types';
 import { rootDebug } from './debug';
 import {
@@ -93,19 +93,8 @@ function buildApi({ context, logger }: BuildAppParams) {
   const { store } = workspace;
 
   return grout.createApi({
-    getMachineInformation(): MachineInformation {
-      const pollbookInformation = store.getMachineInformation();
-      if (!pollbookInformation) {
-        return {
-          machineId,
-          codeVersion,
-        };
-      }
-      return {
-        ...pollbookInformation,
-        machineId,
-        codeVersion,
-      };
+    getPollbookConfigurationInformation(): PollbookConfigurationInformation {
+      return store.getPollbookConfigurationInformation();
     },
 
     getAuthStatus() {

--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -174,6 +174,10 @@ function buildApi({ context, logger }: BuildAppParams) {
       return election ? ok(election) : err('unconfigured');
     },
 
+    haveElectionEventsOccurred(): boolean {
+      return store.hasEvents();
+    },
+
     async unconfigure(): Promise<void> {
       store.deleteElectionAndVoters();
       await usbDrive.eject();

--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -199,6 +199,10 @@ function buildApi({ context, logger }: BuildAppParams) {
       store.setIsAbsenteeMode(input.isAbsenteeMode);
     },
 
+    setConfiguredPrecinct(input: { precinctId: string }): void {
+      store.setConfiguredPrecinct(input.precinctId);
+    },
+
     searchVoters(input: {
       searchParams: VoterSearchParams;
     }): Voter[] | number | null {

--- a/apps/pollbook/backend/src/app_config.test.ts
+++ b/apps/pollbook/backend/src/app_config.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, afterEach, expect, test, vi, vitest } from 'vitest';
 import { Buffer } from 'node:buffer';
 import { err } from '@votingworks/basics';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import {
   mockElectionManagerAuth,
   mockSystemAdministratorAuth,
@@ -198,11 +199,13 @@ test('setConfiguredPrecinct sets and getPollbookConfigurationInformation returns
     expect(config.configuredPrecinctId).toBeUndefined();
 
     // Try to set a non-existent precinct and expect an error
-    await expect(
-      localApiClient.setConfiguredPrecinct({ precinctId: 'precinct-xyz' })
-    ).rejects.toThrow(
-      'Precinct with id precinct-xyz does not exist in the election'
-    );
+    await suppressingConsoleOutput(async () => {
+      await expect(
+        localApiClient.setConfiguredPrecinct({ precinctId: 'precinct-xyz' })
+      ).rejects.toThrow(
+        'Precinct with id precinct-xyz does not exist in the election'
+      );
+    });
 
     await localApiClient.setConfiguredPrecinct({
       precinctId: electionDefinition.election.precincts[0].id,

--- a/apps/pollbook/backend/src/app_config.test.ts
+++ b/apps/pollbook/backend/src/app_config.test.ts
@@ -41,7 +41,7 @@ test('uses machine config from env', async () => {
   };
 
   await withApp(async ({ localApiClient }) => {
-    expect(await localApiClient.getMachineInformation()).toEqual({
+    expect(await localApiClient.getPollbookConfigurationInformation()).toEqual({
       machineId: 'test-machine-id',
       codeVersion: 'test-code-version',
     });

--- a/apps/pollbook/backend/src/app_multi_node.test.ts
+++ b/apps/pollbook/backend/src/app_multi_node.test.ts
@@ -622,13 +622,14 @@ test('one pollbook can be configured from another pollbook', async () => {
       })
     ).toEqual(ok());
     expect(
-      await pollbookContext2.peerApiClient.getMachineInformation()
+      await pollbookContext2.peerApiClient.getPollbookConfigurationInformation()
     ).toMatchObject({
       electionBallotHash: electionDefinition.ballotHash,
       electionId: electionDefinition.election.id,
       electionTitle: electionDefinition.election.title,
       pollbookPackageHash: sha256(new Uint8Array(validZip)),
       machineId: 'test-1',
+      codeVersion: 'test',
     });
 
     expect(
@@ -867,7 +868,7 @@ test('one pollbook can be configured from another pollbook automatically as an e
       await extendedWaitFor(async () => {
         vitest.advanceTimersByTime(100);
         expect(
-          await pollbookContext2.peerApiClient.getMachineInformation()
+          await pollbookContext2.peerApiClient.getPollbookConfigurationInformation()
         ).toMatchObject({
           electionBallotHash: electionDefinition.ballotHash,
           electionId: electionDefinition.election.id,

--- a/apps/pollbook/backend/src/index.ts
+++ b/apps/pollbook/backend/src/index.ts
@@ -59,7 +59,8 @@ function main(): Promise<number> {
   const peerWorkspace = createPeerWorkspace(
     workspacePath,
     baseLogger,
-    machineId
+    machineId,
+    codeVersion
   );
   const peerPort = peerServer.start({
     workspace: peerWorkspace,
@@ -72,7 +73,8 @@ function main(): Promise<number> {
     workspacePath,
     baseLogger,
     peerPort,
-    machineId
+    machineId,
+    codeVersion
   );
   localServer.start({
     workspace: localWorkspace,

--- a/apps/pollbook/backend/src/local_store.test.ts
+++ b/apps/pollbook/backend/src/local_store.test.ts
@@ -15,7 +15,8 @@ test('findVotersWithName works as expected - voters without name changes', () =>
   const localStore = LocalStore.fileStore(
     workspacePath,
     mockBaseLogger({ fn: vi.fn }),
-    '0000'
+    '0000',
+    'test'
   );
   const testElectionDefinition = getTestElectionDefinition();
   const voters = [
@@ -143,7 +144,8 @@ test('findVoterWithName works as expected - voters with name changes', () => {
   const localStore = LocalStore.fileStore(
     workspacePath,
     mockBaseLogger({ fn: vi.fn }),
-    '0001'
+    '0001',
+    'test'
   );
   const testElectionDefinition = getTestElectionDefinition();
   const voters = [
@@ -252,7 +254,8 @@ test('registerVoter and findVoterWithName integration', () => {
   const localStore = LocalStore.fileStore(
     workspacePath,
     mockBaseLogger({ fn: vi.fn }),
-    '0002'
+    '0002',
+    'test'
   );
   const testElectionDefinition = getTestElectionDefinition();
   const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];

--- a/apps/pollbook/backend/src/local_store.test.ts
+++ b/apps/pollbook/backend/src/local_store.test.ts
@@ -301,7 +301,6 @@ test('registerVoter and findVoterWithName integration', () => {
   );
 });
 
-// Test that setElectionAndVoters sets configuredPrecinctId only when there is one precinct
 test('setElectionAndVoters sets configuredPrecinctId only when there is one precinct', () => {
   const store = LocalStore.memoryStore('machine-1');
 

--- a/apps/pollbook/backend/src/local_store.test.ts
+++ b/apps/pollbook/backend/src/local_store.test.ts
@@ -14,8 +14,7 @@ test('findVotersWithName works as expected - voters without name changes', () =>
   const localStore = LocalStore.fileStore(
     workspacePath,
     mockBaseLogger({ fn: vi.fn }),
-    '0000',
-    'test'
+    '0000'
   );
   const testElectionDefinition = getTestElectionDefinition();
   const voters = [
@@ -143,8 +142,7 @@ test('findVoterWithName works as expected - voters with name changes', () => {
   const localStore = LocalStore.fileStore(
     workspacePath,
     mockBaseLogger({ fn: vi.fn }),
-    '0001',
-    'test'
+    '0001'
   );
   const testElectionDefinition = getTestElectionDefinition();
   const voters = [
@@ -253,8 +251,7 @@ test('registerVoter and findVoterWithName integration', () => {
   const localStore = LocalStore.fileStore(
     workspacePath,
     mockBaseLogger({ fn: vi.fn }),
-    '0002',
-    'test'
+    '0002'
   );
   const testElectionDefinition = getTestElectionDefinition();
   const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];

--- a/apps/pollbook/backend/src/local_store.test.ts
+++ b/apps/pollbook/backend/src/local_store.test.ts
@@ -14,7 +14,8 @@ test('findVotersWithName works as expected - voters without name changes', () =>
   const localStore = LocalStore.fileStore(
     workspacePath,
     mockBaseLogger({ fn: vi.fn }),
-    '0000'
+    '0000',
+    'test'
   );
   const testElectionDefinition = getTestElectionDefinition();
   const voters = [
@@ -142,7 +143,8 @@ test('findVoterWithName works as expected - voters with name changes', () => {
   const localStore = LocalStore.fileStore(
     workspacePath,
     mockBaseLogger({ fn: vi.fn }),
-    '0001'
+    '0001',
+    'test'
   );
   const testElectionDefinition = getTestElectionDefinition();
   const voters = [
@@ -251,7 +253,8 @@ test('registerVoter and findVoterWithName integration', () => {
   const localStore = LocalStore.fileStore(
     workspacePath,
     mockBaseLogger({ fn: vi.fn }),
-    '0002'
+    '0002',
+    'test'
   );
   const testElectionDefinition = getTestElectionDefinition();
   const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];

--- a/apps/pollbook/backend/src/local_store.test.ts
+++ b/apps/pollbook/backend/src/local_store.test.ts
@@ -341,3 +341,34 @@ test('setElectionAndVoters sets configuredPrecinctId only when there is one prec
   configInfo = store.getPollbookConfigurationInformation();
   expect(configInfo.configuredPrecinctId).toEqual('precinct-1');
 });
+
+test('store can load data from database on restart', () => {
+  const workspacePath = tmp.dirSync().name;
+  const localStore = LocalStore.fileStore(
+    workspacePath,
+    mockBaseLogger({ fn: vi.fn }),
+    '0001',
+    'test'
+  );
+
+  const testElectionDefinition = getTestElectionDefinition();
+  const voters = [createVoter('10', 'Dylan', `O'Brien`, 'MiD', 'I')];
+  const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];
+  localStore.setElectionAndVoters(
+    testElectionDefinition,
+    'fake-package-hash',
+    streets,
+    voters
+  );
+  expect(localStore.getElection()).toEqual(testElectionDefinition.election);
+  expect(localStore.getStreetInfo()).toHaveLength(1);
+
+  const reloadedStore = LocalStore.fileStore(
+    workspacePath,
+    mockBaseLogger({ fn: vi.fn }),
+    '0001',
+    'test'
+  );
+  expect(reloadedStore.getElection()).toEqual(testElectionDefinition.election);
+  expect(reloadedStore.getStreetInfo()).toHaveLength(1);
+});

--- a/apps/pollbook/backend/src/local_store.ts
+++ b/apps/pollbook/backend/src/local_store.ts
@@ -76,19 +76,27 @@ export class LocalStore extends Store {
   static fileStore(
     dbPath: string,
     logger: BaseLogger,
-    machineId: string
+    machineId: string,
+    codeVersion: string
   ): LocalStore {
     const client = DbClient.fileClient(dbPath, logger, SchemaPath, {
       registerRegexpFn: true,
     });
-    return new LocalStore(client, machineId);
+    return new LocalStore(client, machineId, codeVersion);
   }
 
   /**
    * Builds and returns a new store whose data is kept in memory.
    */
-  static memoryStore(machineId: string = 'test-machine'): LocalStore {
-    return new LocalStore(DbClient.memoryClient(SchemaPath), machineId);
+  static memoryStore(
+    machineId: string = 'test-machine',
+    codeVersion: string = 'test-v1'
+  ): LocalStore {
+    return new LocalStore(
+      DbClient.memoryClient(SchemaPath),
+      machineId,
+      codeVersion
+    );
   }
 
   private getNextEventId(): number {
@@ -643,10 +651,11 @@ export class LocalStore extends Store {
         status: row.status as PollbookConnectionStatus,
         lastSeen: new Date(row.last_seen),
         numCheckIns: this.getCheckInCount(row.machine_id),
-        electionBallotHash: pollbookInfo?.electionBallotHash,
-        pollbookPackageHash: pollbookInfo?.pollbookPackageHash,
-        electionId: pollbookInfo?.electionId,
-        electionTitle: pollbookInfo?.electionTitle,
+        electionBallotHash: pollbookInfo.electionBallotHash,
+        pollbookPackageHash: pollbookInfo.pollbookPackageHash,
+        electionId: pollbookInfo.electionId,
+        electionTitle: pollbookInfo.electionTitle,
+        codeVersion: pollbookInfo.codeVersion,
       };
     });
   }

--- a/apps/pollbook/backend/src/local_store.ts
+++ b/apps/pollbook/backend/src/local_store.ts
@@ -158,6 +158,16 @@ export class LocalStore extends Store {
     this.nextEventId = 0;
   }
 
+  hasEvents(): boolean {
+    const row = this.client.one(
+      'SELECT EXISTS(SELECT 1 FROM event_log LIMIT 1) as hasEvents'
+    ) as { hasEvents: number };
+    if (!row) {
+      return false;
+    }
+    return row.hasEvents > 0;
+  }
+
   getIsAbsenteeMode(): boolean {
     const result = this.client.one(
       `

--- a/apps/pollbook/backend/src/local_store.ts
+++ b/apps/pollbook/backend/src/local_store.ts
@@ -162,9 +162,6 @@ export class LocalStore extends Store {
     const row = this.client.one(
       'SELECT EXISTS(SELECT 1 FROM event_log LIMIT 1) as hasEvents'
     ) as { hasEvents: number };
-    if (!row) {
-      return false;
-    }
     return row.hasEvents > 0;
   }
 

--- a/apps/pollbook/backend/src/local_store.ts
+++ b/apps/pollbook/backend/src/local_store.ts
@@ -170,6 +170,7 @@ export class LocalStore extends Store {
   }
 
   setIsAbsenteeMode(isAbsenteeMode: boolean): void {
+    assert(this.getElection() !== undefined);
     this.client.run(
       `
             update elections
@@ -178,6 +179,23 @@ export class LocalStore extends Store {
       asSqliteBool(isAbsenteeMode)
     );
   }
+
+  setConfiguredPrecinct(precinctId: string): void {
+    const election = this.getElection();
+    assert(election !== undefined);
+    assert(
+      election.precincts.some((precinct) => precinct.id === precinctId),
+      `Precinct with id ${precinctId} does not exist in the election`
+    );
+    this.client.run(
+      `
+            update elections
+            set configured_precinct_id = ?
+          `,
+      precinctId
+    );
+  }
+
   groupVotersAlphabeticallyByLastName(): Map<string, VoterGroup> {
     const voters = this.getAllVoters();
     assert(voters);

--- a/apps/pollbook/backend/src/local_store.ts
+++ b/apps/pollbook/backend/src/local_store.ts
@@ -190,22 +190,6 @@ export class LocalStore extends Store {
     );
   }
 
-  setConfiguredPrecinct(precinctId: string): void {
-    const election = this.getElection();
-    assert(election !== undefined);
-    assert(
-      election.precincts.some((precinct) => precinct.id === precinctId),
-      `Precinct with id ${precinctId} does not exist in the election`
-    );
-    this.client.run(
-      `
-            update elections
-            set configured_precinct_id = ?
-          `,
-      precinctId
-    );
-  }
-
   groupVotersAlphabeticallyByLastName(): Map<string, VoterGroup> {
     const voters = this.getAllVoters();
     assert(voters);

--- a/apps/pollbook/backend/src/networking.ts
+++ b/apps/pollbook/backend/src/networking.ts
@@ -67,7 +67,8 @@ export function fetchEventsFromConnectedPollbooks({
         }
 
         const previouslyConnected = workspace.store.getPollbookServicesByName();
-        const myMachineInformation = workspace.store.getMachineInformation();
+        const myMachineInformation =
+          workspace.store.getPollbookConfigurationInformation();
 
         // Maintain a queue of pollbooks to visit, refill and shuffle when empty
         const pollbookNames = Object.keys(previouslyConnected).filter(
@@ -184,7 +185,8 @@ export function setupMachineNetworking({
           return;
         }
 
-        const myMachineInformation = workspace.store.getMachineInformation();
+        const myMachineInformation =
+          workspace.store.getPollbookConfigurationInformation();
         const services = await AvahiService.discoverHttpServices();
         if (!services.length) {
           debug('No services found on the network');
@@ -237,7 +239,8 @@ export function setupMachineNetworking({
               debug('No api client found for %s', name);
               continue;
             }
-            const machineInformation = await apiClient.getMachineInformation();
+            const machineInformation =
+              await apiClient.getPollbookConfigurationInformation();
             if (name === currentNodeServiceName) {
               // current machine, if we got here the network is working
               if (workspace.store.getIsOnline() === false) {

--- a/apps/pollbook/backend/src/peer_app.test.ts
+++ b/apps/pollbook/backend/src/peer_app.test.ts
@@ -30,9 +30,11 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-test('getMachineInformation', async () => {
+test('getPollbookConfigurationInformation', async () => {
   await withApp(async ({ peerApiClient, workspace }) => {
-    expect(await peerApiClient.getMachineInformation()).toMatchObject({
+    expect(
+      await peerApiClient.getPollbookConfigurationInformation()
+    ).toMatchObject({
       machineId: '0102',
     });
 
@@ -49,7 +51,9 @@ test('getMachineInformation', async () => {
       testVoters
     );
 
-    expect(await peerApiClient.getMachineInformation()).toMatchObject({
+    expect(
+      await peerApiClient.getPollbookConfigurationInformation()
+    ).toMatchObject({
       electionBallotHash: electionDefinition.ballotHash,
       electionId: electionDefinition.election.id,
       electionTitle: electionDefinition.election.title,

--- a/apps/pollbook/backend/src/peer_app.ts
+++ b/apps/pollbook/backend/src/peer_app.ts
@@ -3,10 +3,10 @@ import express, { Application } from 'express';
 import { join } from 'node:path';
 import { Result } from '@votingworks/basics';
 import {
-  MachineInformation,
   PollbookEvent,
   PeerAppContext,
   ConfigurationError,
+  PollbookConfigurationInformation,
 } from './types';
 import {
   fetchEventsFromConnectedPollbooks,
@@ -16,23 +16,12 @@ import { pollNetworkForPollbookPackage } from './pollbook_package';
 import { POLLBOOK_PACKAGE_ASSET_FILE_NAME } from './globals';
 
 function buildApi(context: PeerAppContext) {
-  const { workspace, machineId, codeVersion } = context;
+  const { workspace } = context;
   const { store } = workspace;
 
   return grout.createApi({
-    getMachineInformation(): MachineInformation {
-      const pollbookInformation = store.getMachineInformation();
-      if (!pollbookInformation) {
-        return {
-          codeVersion,
-          machineId,
-        };
-      }
-      return {
-        ...pollbookInformation,
-        codeVersion,
-        machineId,
-      };
+    getPollbookConfigurationInformation(): PollbookConfigurationInformation {
+      return store.getPollbookConfigurationInformation();
     },
 
     getEvents(input: { lastEventSyncedPerNode: Record<string, number> }): {

--- a/apps/pollbook/backend/src/peer_store.ts
+++ b/apps/pollbook/backend/src/peer_store.ts
@@ -31,8 +31,8 @@ const debug = rootDebug.extend('store:peer');
 export class PeerStore extends Store {
   private readonly connectedPollbooks: Record<string, PollbookService> = {};
 
-  constructor(client: DbClient, machineId: string) {
-    super(client, machineId);
+  constructor(client: DbClient, machineId: string, codeVersion: string) {
+    super(client, machineId, codeVersion);
 
     // Reset knowledge of connected pollbook
     this.client.run(`DELETE FROM machines`);
@@ -44,19 +44,28 @@ export class PeerStore extends Store {
   static fileStore(
     dbPath: string,
     logger: BaseLogger,
-    machineId: string
+    machineId: string,
+    codeVersion: string
   ): PeerStore {
     return new PeerStore(
       DbClient.fileClient(dbPath, logger, SchemaPath),
-      machineId
+      machineId,
+      codeVersion
     );
   }
 
   /**
    * Builds and returns a new store whose data is kept in memory.
    */
-  static memoryStore(machineId: string = 'test-machine'): PeerStore {
-    return new PeerStore(DbClient.memoryClient(SchemaPath), machineId);
+  static memoryStore(
+    machineId: string = 'test-machine',
+    codeVersion: string = 'test-v1'
+  ): PeerStore {
+    return new PeerStore(
+      DbClient.memoryClient(SchemaPath),
+      machineId,
+      codeVersion
+    );
   }
 
   setOnlineStatus(isOnline: boolean): void {
@@ -201,6 +210,8 @@ export class PeerStore extends Store {
         electionBallotHash: pollbookService.electionBallotHash,
         pollbookPackageHash: pollbookService.pollbookPackageHash,
         electionTitle: pollbookService.electionTitle,
+        codeVersion: pollbookService.codeVersion,
+        machineId: pollbookService.machineId,
       })
     );
   }

--- a/apps/pollbook/backend/src/store.test.ts
+++ b/apps/pollbook/backend/src/store.test.ts
@@ -156,6 +156,7 @@ test('getNewEvents returns hasMore when there are more events from unknown machi
     [],
     voters
   );
+
   const theirClock = new HybridLogicalClock(otherMachineId);
   const events = Array.from({ length: 7 }, (_, i) =>
     createVoterCheckInEvent(i, otherMachineId, `voter-${i}`, theirClock.tick())

--- a/apps/pollbook/backend/src/store.ts
+++ b/apps/pollbook/backend/src/store.ts
@@ -441,6 +441,11 @@ export abstract class Store {
             JSON.stringify(voter)
           );
         }
+        if (electionDefinition.election.precincts.length === 1) {
+          this.setConfiguredPrecinct(
+            electionDefinition.election.precincts[0].id
+          );
+        }
       });
     } catch (error) {
       debug('Failed to set election and voters: %s', error);
@@ -453,6 +458,22 @@ export abstract class Store {
       }
       throw error;
     }
+  }
+
+  setConfiguredPrecinct(precinctId: string): void {
+    const election = this.getElection();
+    assert(election !== undefined);
+    assert(
+      election.precincts.some((precinct) => precinct.id === precinctId),
+      `Precinct with id ${precinctId} does not exist in the election`
+    );
+    this.client.run(
+      `
+              update elections
+              set configured_precinct_id = ?
+            `,
+      precinctId
+    );
   }
 
   // Returns the valid street info. Used when registering a voter to populate address typeahead options.

--- a/apps/pollbook/backend/src/store.ts
+++ b/apps/pollbook/backend/src/store.ts
@@ -359,12 +359,17 @@ export abstract class Store {
   getPollbookConfigurationInformation(): PollbookConfigurationInformation {
     const row = this.client.one(
       `
-          select election_data, ballot_hash, package_hash
+          select election_data, ballot_hash, package_hash, configured_precinct_id
           from elections
           order by rowid desc
           limit 1
         `
-    ) as { election_data: string; ballot_hash: string; package_hash: string };
+    ) as {
+      election_data: string;
+      ballot_hash: string;
+      package_hash: string;
+      configured_precinct_id: string;
+    };
     if (!row) {
       return {
         machineId: this.machineId,
@@ -381,6 +386,7 @@ export abstract class Store {
       pollbookPackageHash: row.package_hash,
       machineId: this.machineId,
       codeVersion: this.codeVersion,
+      configuredPrecinctId: row.configured_precinct_id,
     };
   }
 

--- a/apps/pollbook/backend/src/store.ts
+++ b/apps/pollbook/backend/src/store.ts
@@ -484,7 +484,7 @@ export abstract class Store {
     }
     const row = this.client.one(
       `
-          select valid_street_info 
+          select valid_street_data 
           from elections
           order by rowid desc
           limit 1

--- a/apps/pollbook/backend/src/store_multi_node.test.ts
+++ b/apps/pollbook/backend/src/store_multi_node.test.ts
@@ -22,12 +22,14 @@ function setupFileStores(machineId: string): [LocalStore, PeerStore] {
   const localStore = LocalStore.fileStore(
     workspacePath,
     mockBaseLogger({ fn: vi.fn }),
-    machineId
+    machineId,
+    'test'
   );
   const peerStore = PeerStore.fileStore(
     workspacePath,
     mockBaseLogger({ fn: vi.fn }),
-    machineId
+    machineId,
+    'test'
   );
   return [localStore, peerStore];
 }

--- a/apps/pollbook/backend/src/types.ts
+++ b/apps/pollbook/backend/src/types.ts
@@ -230,11 +230,6 @@ export const VoterSchema: z.ZodSchema<Voter> = z.object({
   isInactive: z.boolean().default(false),
 });
 
-export interface MachineInformation extends PollbookInformation {
-  machineId: string;
-  codeVersion: string;
-}
-
 export type VectorClock = Record<string, number>;
 
 export const VectorClockSchema: z.ZodSchema<VectorClock> = z.record(
@@ -331,11 +326,14 @@ export interface PollbookPackage {
   validStreets: ValidStreetInfo[];
 }
 
-export interface PollbookInformation {
+export interface PollbookConfigurationInformation {
   electionId?: string;
   electionBallotHash?: string;
   pollbookPackageHash?: string;
   electionTitle?: string;
+  configuredPrecinctId?: string;
+  machineId: string;
+  codeVersion: string;
 }
 
 export type ConfigurationError =
@@ -343,15 +341,18 @@ export type ConfigurationError =
   | 'already-configured'
   | 'invalid-pollbook-package';
 
-export const PollbookInformationSchema: z.ZodSchema<PollbookInformation> =
+export const PollbookInformationSchema: z.ZodSchema<PollbookConfigurationInformation> =
   z.object({
     electionId: z.string().optional(),
     electionBallotHash: z.string().optional(),
     pollbookPackageHash: z.string().optional(),
     electionTitle: z.string().optional(),
+    configuredPrecinctId: z.string().optional(),
+    machineId: z.string(),
+    codeVersion: z.string(),
   });
 
-export interface PollbookService extends PollbookInformation {
+export interface PollbookService extends PollbookConfigurationInformation {
   apiClient?: grout.Client<PeerApi>;
   address?: string;
   machineId: string;

--- a/apps/pollbook/backend/src/workspace.ts
+++ b/apps/pollbook/backend/src/workspace.ts
@@ -12,7 +12,8 @@ export function createLocalWorkspace(
   workspacePath: string,
   logger: BaseLogger,
   peerPort: number,
-  machineId: string
+  machineId: string,
+  codeVersion: string
 ): LocalWorkspace {
   ensureDirSync(workspacePath);
 
@@ -20,7 +21,7 @@ export function createLocalWorkspace(
   ensureDirSync(assetDirectoryPath);
 
   const dbPath = join(workspacePath, 'pollbook-backend.db');
-  const store = LocalStore.fileStore(dbPath, logger, machineId);
+  const store = LocalStore.fileStore(dbPath, logger, machineId, codeVersion);
   const peerApiClient = grout.createClient<PeerApi>({
     baseUrl: `http://localhost:${peerPort}/api`,
   });
@@ -31,14 +32,15 @@ export function createLocalWorkspace(
 export function createPeerWorkspace(
   workspacePath: string,
   logger: BaseLogger,
-  machineId: string
+  machineId: string,
+  codeVersion: string
 ): PeerWorkspace {
   ensureDirSync(workspacePath);
 
   const assetDirectoryPath = join(workspacePath, 'assets');
   ensureDirSync(assetDirectoryPath);
   const dbPath = join(workspacePath, 'pollbook-backend.db');
-  const store = PeerStore.fileStore(dbPath, logger, machineId);
+  const store = PeerStore.fileStore(dbPath, logger, machineId, codeVersion);
 
   return { assetDirectoryPath, store };
 }

--- a/apps/pollbook/backend/test/app.ts
+++ b/apps/pollbook/backend/test/app.ts
@@ -107,16 +107,18 @@ export async function withApp(
   const auth = buildMockDippedSmartCardAuth(vi.fn);
   const workspacePath = tmp.dirSync().name;
   const machineId = process.env.VX_MACHINE_ID || TEST_MACHINE_ID;
+  const codeVersion = process.env.VX_CODE_VERSION || 'test';
   const peerWorkspace = createPeerWorkspace(
     workspacePath,
     mockBaseLogger({ fn: vi.fn }),
-    machineId
+    machineId,
+    codeVersion
   );
   const peerApp = buildPeerApp({
     auth,
     workspace: peerWorkspace,
     machineId,
-    codeVersion: process.env.VX_CODE_VERSION || 'test',
+    codeVersion,
   });
 
   const peerServer = peerApp.listen();
@@ -127,7 +129,8 @@ export async function withApp(
     workspacePath,
     mockBaseLogger({ fn: vi.fn }),
     peerPort,
-    machineId
+    machineId,
+    codeVersion
   );
   const logger = buildMockLogger(auth, workspace);
 
@@ -143,7 +146,7 @@ export async function withApp(
       usbDrive: mockUsbDrive.usbDrive,
       printer: mockPrinterHandler.printer,
       machineId,
-      codeVersion: process.env.VX_CODE_VERSION || 'test',
+      codeVersion,
     },
     logger,
   });
@@ -190,6 +193,7 @@ export async function withManyApps(
   fn: (contexts: TestContext[]) => Promise<void>
 ): Promise<void> {
   const contexts: TestContext[] = [];
+  const codeVersion = process.env.VX_CODE_VERSION || 'test';
 
   try {
     for (let i = 0; i < n; i += 1) {
@@ -198,14 +202,15 @@ export async function withManyApps(
       const peerWorkspace = createPeerWorkspace(
         workspacePath,
         mockBaseLogger({ fn: vi.fn }),
-        `test-${i}`
+        `test-${i}`,
+        codeVersion
       );
 
       const peerApp = buildPeerApp({
         auth,
         workspace: peerWorkspace,
         machineId: `test-${i}`,
-        codeVersion: process.env.VX_CODE_VERSION || 'test',
+        codeVersion,
       });
 
       const peerServer = peerApp.listen();
@@ -221,7 +226,8 @@ export async function withManyApps(
         workspacePath,
         mockBaseLogger({ fn: vi.fn }),
         peerPort,
-        `test-${i}`
+        `test-${i}`,
+        codeVersion
       );
       const logger = buildMockLogger(auth, workspace);
 
@@ -232,7 +238,7 @@ export async function withManyApps(
           usbDrive: mockUsbDrive.usbDrive,
           printer: mockPrinterHandler.printer,
           machineId: `test-${i}`,
-          codeVersion: process.env.VX_CODE_VERSION || 'test',
+          codeVersion,
         },
         logger,
       });

--- a/apps/pollbook/backend/vitest.config.ts
+++ b/apps/pollbook/backend/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 84.9,
-        branches: 79.4,
+        lines: 85.2,
+        branches: 79.9,
       },
       exclude: [
         '**/node_modules/**',

--- a/apps/pollbook/backend/vitest.config.ts
+++ b/apps/pollbook/backend/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 85.2,
-        branches: 80,
+        lines: 84.9,
+        branches: 79.4,
       },
       exclude: [
         '**/node_modules/**',

--- a/apps/pollbook/frontend/src/api.ts
+++ b/apps/pollbook/frontend/src/api.ts
@@ -54,15 +54,19 @@ export function createQueryClient(): QueryClient {
   });
 }
 
-export const getMachineInformation = {
+export const getPollbookConfigurationInformation = {
   queryKey(): QueryKey {
-    return ['getMachineInformation'];
+    return ['ionInformation'];
   },
   useQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getMachineInformation(), {
-      refetchInterval: 1000,
-    });
+    return useQuery(
+      this.queryKey(),
+      () => apiClient.getPollbookConfigurationInformation(),
+      {
+        refetchInterval: 1000,
+      }
+    );
   },
 } as const;
 

--- a/apps/pollbook/frontend/src/api.ts
+++ b/apps/pollbook/frontend/src/api.ts
@@ -55,7 +55,7 @@ export function createQueryClient(): QueryClient {
 
 export const getPollbookConfigurationInformation = {
   queryKey(): QueryKey {
-    return ['ionInformation'];
+    return ['getPollbookConfigurationInformation'];
   },
   useQuery() {
     const apiClient = useApiClient();

--- a/apps/pollbook/frontend/src/api.ts
+++ b/apps/pollbook/frontend/src/api.ts
@@ -1,5 +1,4 @@
 import React from 'react';
-// import type { Api, BallotMode } from '@votingworks/design-backend';
 import * as grout from '@votingworks/grout';
 import {
   QueryClient,
@@ -395,6 +394,20 @@ export const setIsAbsenteeMode = {
     return useMutation(apiClient.setIsAbsenteeMode, {
       async onSuccess() {
         await queryClient.invalidateQueries(getIsAbsenteeMode.queryKey());
+      },
+    });
+  },
+} as const;
+
+export const setConfiguredPrecinct = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.setConfiguredPrecinct, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(
+          getPollbookConfigurationInformation.queryKey()
+        );
       },
     });
   },

--- a/apps/pollbook/frontend/src/api.ts
+++ b/apps/pollbook/frontend/src/api.ts
@@ -248,6 +248,22 @@ export const getThroughputStatistics = {
   },
 } as const;
 
+export const getHaveElectionEventsOccurred = {
+  queryKey(): QueryKey {
+    return ['haveElectionEventsOccurred'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(
+      this.queryKey(),
+      () => apiClient.haveElectionEventsOccurred(),
+      {
+        refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL,
+      }
+    );
+  },
+} as const;
+
 async function invalidateCheckInQueries(queryClient: QueryClient) {
   await queryClient.invalidateQueries(getCheckInCounts.queryKey());
   await queryClient.invalidateQueries(getSummaryStatistics.queryKey());

--- a/apps/pollbook/frontend/src/app.test.tsx
+++ b/apps/pollbook/frontend/src/app.test.tsx
@@ -142,6 +142,7 @@ test('renders ElectionManagerScreen when logged in as election manager', async (
   apiMock.authenticateAsElectionManager(famousNamesElection.election);
   apiMock.setElection(famousNamesElection);
   apiMock.setIsAbsenteeMode(false);
+  apiMock.expectHaveElectionEventsOccurred(false);
   render(<App apiClient={apiMock.mockApiClient} />);
   await screen.findByText('Voters');
   await screen.findByText('Statistics');

--- a/apps/pollbook/frontend/src/app.test.tsx
+++ b/apps/pollbook/frontend/src/app.test.tsx
@@ -77,7 +77,7 @@ test('renders MachineLockedScreen when machine is locked - configured', async ()
     status: 'logged_out',
     reason: 'machine_locked',
   });
-  apiMock.setElection(famousNamesElection, 'FAKEHASH');
+  apiMock.setElection(famousNamesElection, undefined, 'FAKEHASH');
   render(<App apiClient={apiMock.mockApiClient} />);
   await screen.findByText('VxPollbook Locked');
   await screen.findByText('Insert card to unlock.');

--- a/apps/pollbook/frontend/src/app_election_manager_screen.test.tsx
+++ b/apps/pollbook/frontend/src/app_election_manager_screen.test.tsx
@@ -30,6 +30,7 @@ beforeEach(() => {
   apiMock = createApiMock();
   apiMock.setElection(undefined);
   apiMock.setIsAbsenteeMode(false);
+  apiMock.expectHaveElectionEventsOccurred();
 });
 
 afterEach(() => {

--- a/apps/pollbook/frontend/src/app_election_manager_screen.test.tsx
+++ b/apps/pollbook/frontend/src/app_election_manager_screen.test.tsx
@@ -69,7 +69,7 @@ test('basic e2e registration flow works', async () => {
 
   apiMock.expectGetDeviceStatuses();
   apiMock.authenticateAsElectionManager(famousNamesElection);
-  apiMock.setElection(famousNamesElectionDef);
+  apiMock.setElection(famousNamesElectionDef, 'precinct-1');
   const { unmount } = render(<App apiClient={apiMock.mockApiClient} />);
 
   apiMock.expectGetValidStreetInfo([validStreetInfo]);

--- a/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
+++ b/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
@@ -39,8 +39,13 @@ describe('PollWorkerScreen', () => {
 
     apiMock.setPrinterStatus(true);
     apiMock.setIsAbsenteeMode(false);
+    await screen.findByText('No Precinct Selected');
+
+    apiMock.setConfiguredPrecinct(famousNamesElection.precincts[0].id);
     apiMock.expectGetCheckInCounts({ allMachines: 25, thisMachine: 5 });
-    await screen.findByText('Check-In');
+    await vi.waitFor(() => {
+      screen.getByText('Check-In');
+    });
     apiMock.expectSearchVotersNull({});
 
     await screen.findByText('Total Check-ins');
@@ -104,6 +109,7 @@ describe('PollWorkerScreen', () => {
       apiMock.expectGetDeviceStatuses();
       apiMock.authenticateAsPollWorker(famousNamesElection);
       apiMock.setElection(famousNamesElectionDefinition);
+      apiMock.setConfiguredPrecinct(famousNamesElection.precincts[0].id);
       const { unmount } = render(<App apiClient={apiMock.mockApiClient} />);
       await screen.findByText('Connect printer to continue.');
 

--- a/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
+++ b/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
@@ -41,7 +41,10 @@ describe('PollWorkerScreen', () => {
     apiMock.setIsAbsenteeMode(false);
     await screen.findByText('No Precinct Selected');
 
-    apiMock.setConfiguredPrecinct(famousNamesElection.precincts[0].id);
+    apiMock.setElection(
+      famousNamesElectionDefinition,
+      famousNamesElection.precincts[0].id
+    );
     apiMock.expectGetCheckInCounts({ allMachines: 25, thisMachine: 5 });
     await vi.waitFor(() => {
       screen.getByText('Check-In');
@@ -108,8 +111,10 @@ describe('PollWorkerScreen', () => {
     test(`check in flow handles ${testCase.error} error path`, async () => {
       apiMock.expectGetDeviceStatuses();
       apiMock.authenticateAsPollWorker(famousNamesElection);
-      apiMock.setElection(famousNamesElectionDefinition);
-      apiMock.setConfiguredPrecinct(famousNamesElection.precincts[0].id);
+      apiMock.setElection(
+        famousNamesElectionDefinition,
+        famousNamesElection.precincts[0].id
+      );
       const { unmount } = render(<App apiClient={apiMock.mockApiClient} />);
       await screen.findByText('Connect printer to continue.');
 

--- a/apps/pollbook/frontend/src/election_info_bar.test.tsx
+++ b/apps/pollbook/frontend/src/election_info_bar.test.tsx
@@ -1,0 +1,126 @@
+import { test, describe, expect, afterEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import {
+  electionFamousNames2021Fixtures,
+  electionGridLayoutNewHampshireHudsonFixtures,
+} from '@votingworks/fixtures';
+import { ElectionInfoBar, VerticalElectionInfoBar } from './election_info_bar';
+import { renderInAppContext } from '../test/render_in_app_context';
+
+const electionDef = electionFamousNames2021Fixtures.readElectionDefinition();
+const { election, ballotHash } = electionDef;
+const singlePrecinctElectionDef =
+  electionGridLayoutNewHampshireHudsonFixtures.readElectionDefinition();
+const singlePrecinctElection = singlePrecinctElectionDef.election;
+const packageHash = 'test-package-hash';
+const codeVersion = '1.2.3';
+const machineId = 'MACHINE-123';
+
+let unmount: () => void;
+
+afterEach(() => {
+  unmount();
+});
+
+describe('ElectionInfoBar', () => {
+  test('renders minimal info if no election', () => {
+    const renderResult = renderInAppContext(
+      <ElectionInfoBar codeVersion={codeVersion} machineId={machineId} />
+    );
+    unmount = renderResult.unmount;
+    screen.getByTestId('electionInfoBar');
+    screen.getByText('Version');
+    screen.getByText('Machine ID');
+  });
+
+  test('renders full election info', () => {
+    const configuredPrecinctId = election.precincts[0].id;
+    const renderResult = renderInAppContext(
+      <ElectionInfoBar
+        election={election}
+        electionBallotHash={ballotHash}
+        pollbookPackageHash={packageHash}
+        codeVersion={codeVersion}
+        machineId={machineId}
+        configuredPrecinctId={configuredPrecinctId}
+      />
+    );
+    unmount = renderResult.unmount;
+    screen.getByText(election.title);
+    screen.getByText(`${election.county.name}, ${election.state}`);
+    screen.getByText('Version');
+    screen.getByText('Machine ID');
+    screen.getByText('Election ID');
+    // Precinct name should be present
+    screen.getByText(election.precincts[0].name);
+  });
+
+  test('does not show precinct if only one precinct', () => {
+    const renderResult = renderInAppContext(
+      <ElectionInfoBar
+        election={singlePrecinctElection}
+        electionBallotHash={singlePrecinctElectionDef.ballotHash}
+        pollbookPackageHash={packageHash}
+        codeVersion={codeVersion}
+        machineId={machineId}
+        configuredPrecinctId={singlePrecinctElection.precincts[0].id}
+      />
+    );
+    unmount = renderResult.unmount;
+    // Should not show the precinct label
+    expect(screen.queryByText('Precinct')).toBeNull();
+  });
+});
+
+describe('VerticalElectionInfoBar', () => {
+  test('renders minimal info if no election', () => {
+    const renderResult = renderInAppContext(
+      <VerticalElectionInfoBar
+        codeVersion={codeVersion}
+        machineId={machineId}
+      />
+    );
+    unmount = renderResult.unmount;
+    screen.getByText('Version:');
+    screen.getByText('Machine ID:');
+  });
+
+  test('renders full election info', () => {
+    const configuredPrecinctId = election.precincts[0].id;
+    const renderResult = renderInAppContext(
+      <VerticalElectionInfoBar
+        election={election}
+        electionBallotHash={ballotHash}
+        pollbookPackageHash={packageHash}
+        codeVersion={codeVersion}
+        machineId={machineId}
+        configuredPrecinctId={configuredPrecinctId}
+      />
+    );
+    unmount = renderResult.unmount;
+    screen.getByText(election.title);
+    screen.getByText(`${election.county.name}, ${election.state}`);
+    screen.getByText('Version:');
+    screen.getByText('Machine ID:');
+    screen.getByText('Election ID:');
+    // Precinct name should be present
+    screen.getByText('Precinct:');
+    screen.getByText(election.precincts[0].name);
+  });
+
+  test('does not show precinct if only one precinct', () => {
+    const renderResult = renderInAppContext(
+      <VerticalElectionInfoBar
+        election={singlePrecinctElection}
+        electionBallotHash={singlePrecinctElectionDef.ballotHash}
+        pollbookPackageHash={packageHash}
+        codeVersion={codeVersion}
+        machineId={machineId}
+        configuredPrecinctId={singlePrecinctElection.precincts[0].id}
+      />
+    );
+    unmount = renderResult.unmount;
+    // Should not show the precinct label
+    expect(screen.queryByText('Precinct:')).toBeNull();
+  });
+});

--- a/apps/pollbook/frontend/src/election_info_bar.tsx
+++ b/apps/pollbook/frontend/src/election_info_bar.tsx
@@ -37,6 +37,7 @@ export interface ElectionInfoBarProps {
   pollbookPackageHash?: string;
   codeVersion?: string;
   machineId?: string;
+  configuredPrecinctId?: string;
   inverse?: boolean;
 }
 export function ElectionInfoBar({
@@ -45,6 +46,7 @@ export function ElectionInfoBar({
   pollbookPackageHash,
   codeVersion,
   machineId,
+  configuredPrecinctId,
   inverse,
 }: ElectionInfoBarProps): JSX.Element {
   const codeVersionInfo = codeVersion ? (
@@ -103,6 +105,19 @@ export function ElectionInfoBar({
     </Caption>
   );
 
+  const setPrecinct = configuredPrecinctId
+    ? election.precincts.find((p) => p.id === configuredPrecinctId)
+    : undefined;
+  const showPrecinct =
+    election.precincts.length > 1 && setPrecinct !== undefined;
+  const configuredPrecinctInfo = showPrecinct && (
+    <Caption>
+      <LabelledText label="Precinct">
+        <Font weight="bold">{setPrecinct.name}</Font>
+      </LabelledText>
+    </Caption>
+  );
+
   return (
     <Bar data-testid="electionInfoBar" inverse={inverse}>
       <ElectionInfoContainer>
@@ -113,6 +128,7 @@ export function ElectionInfoBar({
         {codeVersionInfo}
         {machineIdInfo}
         {electionIdInfo}
+        {configuredPrecinctInfo}
       </SystemInfoContainer>
     </Bar>
   );
@@ -132,6 +148,7 @@ export function VerticalElectionInfoBar({
   pollbookPackageHash,
   codeVersion,
   machineId,
+  configuredPrecinctId,
   inverse,
 }: ElectionInfoBarProps): JSX.Element {
   if (!election || !electionBallotHash || !pollbookPackageHash) {
@@ -153,6 +170,12 @@ export function VerticalElectionInfoBar({
       </VerticalBar>
     );
   }
+
+  const setPrecinct = configuredPrecinctId
+    ? election.precincts.find((p) => p.id === configuredPrecinctId)
+    : undefined;
+  const showPrecinct =
+    election.precincts.length > 1 && setPrecinct !== undefined;
 
   return (
     <VerticalBar inverse={inverse}>
@@ -193,6 +216,11 @@ export function VerticalElectionInfoBar({
             {formatElectionHashes(electionBallotHash, pollbookPackageHash)}
           </Font>
         </div>
+        {showPrecinct && (
+          <div>
+            Precinct: <Font weight="semiBold">{setPrecinct.name}</Font>
+          </div>
+        )}
       </Caption>
     </VerticalBar>
   );

--- a/apps/pollbook/frontend/src/election_manager_screen.test.tsx
+++ b/apps/pollbook/frontend/src/election_manager_screen.test.tsx
@@ -99,7 +99,6 @@ describe('SettingsScreen precinct selection', () => {
   });
 
   test('does not allow changing precinct once events have occurred', async () => {
-    // Setup election with multiple precincts
     apiMock.expectHaveElectionEventsOccurred(true);
     // Render
     const renderResult = renderInAppContext(<ElectionManagerScreen />, {
@@ -116,7 +115,7 @@ describe('SettingsScreen precinct selection', () => {
     );
   });
 
-  test('does not show precinct select for single precinct election', () => {
+  test('does not show precinct select for single precinct election', async () => {
     // Setup election with multiple precincts
     const singlePrecinctElection =
       electionGridLayoutNewHampshireHudsonFixtures.readElectionDefinition();
@@ -129,6 +128,7 @@ describe('SettingsScreen precinct selection', () => {
     unmount = renderResult.unmount;
 
     // There should be no select precinct option shown
+    await screen.findAllByText('Settings');
     const select = screen.queryByLabelText('Select Precinct');
     expect(select).toBeNull();
   });

--- a/apps/pollbook/frontend/src/election_manager_screen.test.tsx
+++ b/apps/pollbook/frontend/src/election_manager_screen.test.tsx
@@ -1,5 +1,8 @@
-import { describe, test, beforeEach, afterEach, vi } from 'vitest';
-import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { describe, test, beforeEach, afterEach, vi, expect } from 'vitest';
+import {
+  electionFamousNames2021Fixtures,
+  electionGridLayoutNewHampshireHudsonFixtures,
+} from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
 import { screen } from '../test/react_testing_library';
 import {
@@ -60,5 +63,57 @@ describe('Voters tab', () => {
     userEvent.click(screen.getButton('View Details'));
 
     await screen.findByRole('heading', { name: 'Voter Details' });
+  });
+});
+
+describe('SettingsScreen precinct selection', () => {
+  test('shows precinct select and allows changing configured precinct', async () => {
+    // Setup election with multiple precincts
+    const electionDef =
+      electionFamousNames2021Fixtures.readElectionDefinition();
+    const { precincts } = electionDef.election;
+    apiMock.setElection(electionDef);
+    apiMock.expectGetDeviceStatuses();
+    // Render
+    const renderResult = renderInAppContext(<ElectionManagerScreen />, {
+      apiMock,
+    });
+    unmount = renderResult.unmount;
+
+    // Wait for the SearchSelect to appear with the correct value
+    const select = await screen.findByLabelText('Select Precinct');
+    expect(select).toBeInTheDocument();
+    // Should have the correct initial value
+    expect((select as HTMLSelectElement).value).toEqual('');
+
+    // Simulate changing the precinct
+    const newPrecinctId = precincts[1].id;
+
+    apiMock.setConfiguredPrecinct(newPrecinctId);
+
+    userEvent.click(screen.getByText('Select Precinct…'));
+    userEvent.click(screen.getByText(precincts[1].name));
+
+    // Wait for the value to update
+    await vi.waitFor(() => {
+      screen.getByText(precincts[1].name);
+    });
+  });
+
+  test('does not show precinct select for single precinct election', () => {
+    // Setup election with multiple precincts
+    const singlePrecinctElection =
+      electionGridLayoutNewHampshireHudsonFixtures.readElectionDefinition();
+    apiMock.setElection(singlePrecinctElection);
+    apiMock.expectGetDeviceStatuses();
+    // Render
+    const renderResult = renderInAppContext(<ElectionManagerScreen />, {
+      apiMock,
+    });
+    unmount = renderResult.unmount;
+
+    // There should be no select precinct option shown
+    const select = screen.queryByLabelText('Select Precinct');
+    expect(select).toBeNull();
   });
 });

--- a/apps/pollbook/frontend/src/election_manager_screen.test.tsx
+++ b/apps/pollbook/frontend/src/election_manager_screen.test.tsx
@@ -87,7 +87,7 @@ describe('SettingsScreen precinct selection', () => {
     // Simulate changing the precinct
     const newPrecinctId = precincts[1].id;
 
-    apiMock.setConfiguredPrecinct(newPrecinctId);
+    apiMock.expectSetConfiguredPrecinct(newPrecinctId);
 
     userEvent.click(screen.getByText('Select Precinct…'));
     userEvent.click(screen.getByText(precincts[1].name));

--- a/apps/pollbook/frontend/src/election_manager_screen.tsx
+++ b/apps/pollbook/frontend/src/election_manager_screen.tsx
@@ -7,6 +7,7 @@ import {
   SegmentedButton,
   UnconfigureMachineButton,
   SearchSelect,
+  Caption,
 } from '@votingworks/ui';
 import { format } from '@votingworks/utils';
 import { Redirect, Route, Switch } from 'react-router-dom';
@@ -18,6 +19,7 @@ import {
   setConfiguredPrecinct,
   unconfigure,
   getPollbookConfigurationInformation,
+  getHaveElectionEventsOccurred,
 } from './api';
 import { Column, FieldName, Row } from './layout';
 import { StatisticsScreen } from './statistics_screen';
@@ -32,13 +34,16 @@ export function SettingsScreen(): JSX.Element | null {
     getPollbookConfigurationInformation.useQuery();
   const unconfigureMutation = unconfigure.useMutation();
   const getIsAbsenteeModeQuery = getIsAbsenteeMode.useQuery();
+  const getHaveElectionEventsOccurredQuery =
+    getHaveElectionEventsOccurred.useQuery();
   const setIsAbsenteeModeMutation = setIsAbsenteeMode.useMutation();
   const setConfiguredPrecinctMutation = setConfiguredPrecinct.useMutation();
 
   if (
     !getIsAbsenteeModeQuery.isSuccess ||
     !getElectionQuery.isSuccess ||
-    !getPollbookConfigurationInformationQuery.isSuccess
+    !getPollbookConfigurationInformationQuery.isSuccess ||
+    !getHaveElectionEventsOccurredQuery.isSuccess
   ) {
     return null;
   }
@@ -55,6 +60,7 @@ export function SettingsScreen(): JSX.Element | null {
   // Find currently configured precinct (if any)
   const { configuredPrecinctId } =
     getPollbookConfigurationInformationQuery.data;
+  const haveElectionEventsOccurred = getHaveElectionEventsOccurredQuery.data;
 
   return (
     <ElectionManagerNavScreen title="Settings">
@@ -106,6 +112,7 @@ export function SettingsScreen(): JSX.Element | null {
                 }}
                 placeholder="Select Precinct…"
                 style={{ minWidth: '16rem' }}
+                disabled={haveElectionEventsOccurred}
                 isSearchable
               />
             )}
@@ -114,6 +121,12 @@ export function SettingsScreen(): JSX.Element | null {
               isMachineConfigured
             />
           </Row>
+          {precinctOptions.length > 1 && haveElectionEventsOccurred && (
+            <Caption>
+              The precinct setting cannot be changed because a voter was
+              checked-in or voter data was updated.
+            </Caption>
+          )}
         </Column>
       </MainContent>
     </ElectionManagerNavScreen>

--- a/apps/pollbook/frontend/src/machine_locked_screen.tsx
+++ b/apps/pollbook/frontend/src/machine_locked_screen.tsx
@@ -2,7 +2,7 @@ import { H1, H3, Main, Screen } from '@votingworks/ui';
 import styled from 'styled-components';
 import React from 'react';
 import { ElectionInfoBar } from './election_info_bar';
-import { getElection, getMachineInformation } from './api';
+import { getElection, getPollbookConfigurationInformation } from './api';
 import { DeviceStatusBar } from './nav_screen';
 
 const LockedImage = styled.img`
@@ -13,7 +13,7 @@ const LockedImage = styled.img`
 `;
 
 export function MachineLockedScreen(): JSX.Element | null {
-  const getMachineInfoQuery = getMachineInformation.useQuery();
+  const getMachineInfoQuery = getPollbookConfigurationInformation.useQuery();
   const getElectionQuery = getElection.useQuery();
 
   if (!getMachineInfoQuery.isSuccess || !getElectionQuery.isSuccess) {

--- a/apps/pollbook/frontend/src/machine_locked_screen.tsx
+++ b/apps/pollbook/frontend/src/machine_locked_screen.tsx
@@ -20,8 +20,13 @@ export function MachineLockedScreen(): JSX.Element | null {
     return null;
   }
   const election = getElectionQuery.data.ok();
-  const { machineId, codeVersion, electionBallotHash, pollbookPackageHash } =
-    getMachineInfoQuery.data;
+  const {
+    machineId,
+    codeVersion,
+    electionBallotHash,
+    pollbookPackageHash,
+    configuredPrecinctId,
+  } = getMachineInfoQuery.data;
 
   return (
     <Screen>
@@ -47,6 +52,7 @@ export function MachineLockedScreen(): JSX.Element | null {
         pollbookPackageHash={pollbookPackageHash}
         machineId={machineId}
         codeVersion={codeVersion}
+        configuredPrecinctId={configuredPrecinctId}
       />
     </Screen>
   );

--- a/apps/pollbook/frontend/src/nav_screen.test.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.test.tsx
@@ -22,6 +22,7 @@ const mockPollbookService: PollbookServiceInfo = {
   lastSeen: new Date('2025-01-01'),
   status: PollbookConnectionStatus.WrongElection,
   numCheckIns: 0,
+  codeVersion: 'test',
 };
 
 let apiMock: ApiMock;

--- a/apps/pollbook/frontend/src/nav_screen.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.tsx
@@ -293,8 +293,13 @@ export function NavScreen({
   }
 
   const election = getElectionQuery.data.ok();
-  const { machineId, codeVersion, electionBallotHash, pollbookPackageHash } =
-    getMachineInfoQuery.data;
+  const {
+    configuredPrecinctId,
+    machineId,
+    codeVersion,
+    electionBallotHash,
+    pollbookPackageHash,
+  } = getMachineInfoQuery.data;
 
   return (
     <Screen flexDirection="row">
@@ -310,6 +315,7 @@ export function NavScreen({
             pollbookPackageHash={pollbookPackageHash}
             machineId={machineId}
             codeVersion={codeVersion}
+            configuredPrecinctId={configuredPrecinctId}
             inverse
           />
         </div>

--- a/apps/pollbook/frontend/src/nav_screen.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.tsx
@@ -28,7 +28,7 @@ import {
   resetNetwork,
   logOut,
   getElection,
-  getMachineInformation,
+  getPollbookConfigurationInformation,
 } from './api';
 import { PollbookConnectionStatus } from './types';
 import { VerticalElectionInfoBar } from './election_info_bar';
@@ -286,7 +286,7 @@ export function NavScreen({
   children?: React.ReactNode;
 }): JSX.Element | null {
   const getElectionQuery = getElection.useQuery();
-  const getMachineInfoQuery = getMachineInformation.useQuery();
+  const getMachineInfoQuery = getPollbookConfigurationInformation.useQuery();
 
   if (!(getElectionQuery.isSuccess && getMachineInfoQuery.isSuccess)) {
     return null;

--- a/apps/pollbook/frontend/src/poll_worker_screen.tsx
+++ b/apps/pollbook/frontend/src/poll_worker_screen.tsx
@@ -12,6 +12,7 @@ import {
   H1,
   Icons,
   MainHeader,
+  P,
 } from '@votingworks/ui';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import {
@@ -30,6 +31,7 @@ import {
   getDeviceStatuses,
   getIsAbsenteeMode,
   getVoter,
+  getPollbookConfigurationInformation,
 } from './api';
 import { AbsenteeModeCallout, VoterName } from './shared_components';
 import { AUTOMATIC_FLOW_STATE_RESET_DELAY_MS } from './globals';
@@ -232,12 +234,20 @@ export function VoterCheckInScreen(): JSX.Element | null {
 
 export function PollWorkerScreen(): JSX.Element | null {
   const getDeviceStatusesQuery = getDeviceStatuses.useQuery();
+  const getPollbookConfigurationInformationQuery =
+    getPollbookConfigurationInformation.useQuery();
 
-  if (!getDeviceStatusesQuery.isSuccess) {
+  if (
+    !getDeviceStatusesQuery.isSuccess ||
+    !getPollbookConfigurationInformationQuery.isSuccess
+  ) {
     return null;
   }
 
   const { printer } = getDeviceStatusesQuery.data;
+
+  const { configuredPrecinctId } =
+    getPollbookConfigurationInformationQuery.data;
   if (!printer.connected) {
     return (
       <PollWorkerNavScreen>
@@ -251,6 +261,25 @@ export function PollWorkerScreen(): JSX.Element | null {
             title="No Printer Detected"
           >
             <p>Connect printer to continue.</p>
+          </FullScreenMessage>
+        </Column>
+      </PollWorkerNavScreen>
+    );
+  }
+
+  if (!configuredPrecinctId) {
+    return (
+      <PollWorkerNavScreen>
+        <Column>
+          <FullScreenMessage
+            title="No Precinct Selected"
+            image={
+              <FullScreenIconWrapper>
+                <Icons.Disabled />
+              </FullScreenIconWrapper>
+            }
+          >
+            <P>Insert an election manager card to select a precinct.</P>
           </FullScreenMessage>
         </Column>
       </PollWorkerNavScreen>

--- a/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
+++ b/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
@@ -25,6 +25,7 @@ const mockPollbookService: PollbookServiceInfo = {
   lastSeen: new Date('2025-01-01'),
   status: PollbookConnectionStatus.WrongElection,
   numCheckIns: 0,
+  codeVersion: 'test',
 };
 
 let unmount: () => void;

--- a/apps/pollbook/frontend/src/voter_details_screen.test.tsx
+++ b/apps/pollbook/frontend/src/voter_details_screen.test.tsx
@@ -7,6 +7,7 @@ import {
 } from '@votingworks/pollbook-backend';
 import { Route, Switch } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import { screen, waitFor } from '../test/react_testing_library';
 import {
   ApiMock,
@@ -27,6 +28,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   apiMock = createApiMock();
   apiMock.expectGetVoter(voter);
+  apiMock.setElection(
+    electionFamousNames2021Fixtures.readElectionDefinition(),
+    'precinct-1'
+  );
 });
 
 afterEach(() => {
@@ -414,4 +419,21 @@ test('mark inactive - error path', async () => {
   userEvent.click(confirmButton);
 
   await screen.findByText('Error Marking Inactive');
+});
+
+test('actions are disabled when precinct not configured', async () => {
+  apiMock.expectGetVoter(voter);
+  apiMock.setElection(electionFamousNames2021Fixtures.readElectionDefinition());
+  apiMock.expectGetDeviceStatuses();
+
+  await renderComponent();
+
+  const markInactiveButton = screen.getButton('Mark Voter as Inactive');
+  expect(markInactiveButton).toBeDisabled();
+
+  const updateNameButton = screen.getButton('Update Name');
+  expect(updateNameButton).toBeDisabled();
+
+  const updateAddressButton = screen.getButton('Update Address');
+  expect(updateAddressButton).toBeDisabled();
 });

--- a/apps/pollbook/frontend/src/voter_details_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_details_screen.tsx
@@ -26,6 +26,7 @@ import {
   reprintVoterReceipt,
   markVoterInactive,
   undoVoterCheckIn,
+  getPollbookConfigurationInformation,
 } from './api';
 import { Column, Row } from './layout';
 import {
@@ -228,6 +229,8 @@ export function VoterDetailsScreen(): JSX.Element | null {
   const [reprintErrorMessage, setReprintErrorMessage] = useState('');
   const reprintVoterReceiptMutation = reprintVoterReceipt.useMutation();
   const getDeviceStatusesQuery = getDeviceStatuses.useQuery();
+  const getPollbookConfigurationInformationQuery =
+    getPollbookConfigurationInformation.useQuery();
 
   async function reprintReceipt() {
     setIsPrinting(true);
@@ -244,11 +247,16 @@ export function VoterDetailsScreen(): JSX.Element | null {
     }
   }
 
-  if (!getDeviceStatusesQuery.isSuccess) {
+  if (
+    !getDeviceStatusesQuery.isSuccess ||
+    !getPollbookConfigurationInformationQuery.isSuccess
+  ) {
     return null;
   }
 
   const { printer } = getDeviceStatusesQuery.data;
+  const { configuredPrecinctId } =
+    getPollbookConfigurationInformationQuery.data;
 
   if (!voterQuery.isSuccess) {
     return (
@@ -373,14 +381,14 @@ export function VoterDetailsScreen(): JSX.Element | null {
           <Row style={{ gap: '0.5rem' }}>
             <Button
               icon="Edit"
-              disabled={voter.isInactive}
+              disabled={voter.isInactive || !configuredPrecinctId}
               onPress={() => setShowUpdateNameFlow(true)}
             >
               Update Name
             </Button>
             <Button
               icon="Edit"
-              disabled={voter.isInactive}
+              disabled={voter.isInactive || !configuredPrecinctId}
               onPress={() => setShowUpdateAddressFlow(true)}
             >
               Update Address
@@ -426,6 +434,7 @@ export function VoterDetailsScreen(): JSX.Element | null {
             <Button
               icon="Delete"
               color="danger"
+              disabled={!configuredPrecinctId}
               onPress={() => setShowMarkInactiveFlow(true)}
             >
               Mark Voter as Inactive

--- a/apps/pollbook/frontend/src/voter_registration_screen.test.tsx
+++ b/apps/pollbook/frontend/src/voter_registration_screen.test.tsx
@@ -54,7 +54,7 @@ let unmount: () => void;
 beforeEach(() => {
   vi.clearAllMocks();
   apiMock = createApiMock();
-  apiMock.setElection(famousNamesElectionDef);
+  apiMock.setElection(famousNamesElectionDef, 'precinct-1');
 });
 
 afterEach(() => {
@@ -98,9 +98,23 @@ test('renders and disables submit until required fields are filled', async () =>
 test('shows printer warning if no printer is attached', async () => {
   apiMock.setPrinterStatus(false);
   apiMock.expectGetDeviceStatuses();
-  renderInAppContext(<VoterRegistrationScreen />, { apiMock });
+  const renderResult = renderInAppContext(<VoterRegistrationScreen />, {
+    apiMock,
+  });
+  unmount = renderResult.unmount;
   await screen.findByRole('heading', { name: 'No Printer Detected' });
   screen.getByText('Connect printer to continue.');
+});
+
+test('shows no precinct warning if no precinct is configured', async () => {
+  apiMock.setElection(famousNamesElectionDef);
+  apiMock.setPrinterStatus(true);
+  apiMock.expectGetDeviceStatuses();
+  const renderResult = renderInAppContext(<VoterRegistrationScreen />, {
+    apiMock,
+  });
+  unmount = renderResult.unmount;
+  await screen.findByRole('heading', { name: 'No Precinct Selected' });
 });
 
 test('shows duplicate name modal and allows override', async () => {

--- a/apps/pollbook/frontend/src/voter_registration_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_registration_screen.tsx
@@ -19,7 +19,11 @@ import {
   SearchSelect,
 } from '@votingworks/ui';
 import { throwIllegalValue, assert } from '@votingworks/basics';
-import { getDeviceStatuses, registerVoter } from './api';
+import {
+  getDeviceStatuses,
+  getPollbookConfigurationInformation,
+  registerVoter,
+} from './api';
 import { AUTOMATIC_FLOW_STATE_RESET_DELAY_MS } from './globals';
 import { ElectionManagerNavScreen, NoNavScreen } from './nav_screen';
 import { Column, FieldName, Row } from './layout';
@@ -90,6 +94,8 @@ type RegistrationFlowState =
 export function VoterRegistrationScreen(): JSX.Element | null {
   const registerVoterMutation = registerVoter.useMutation();
   const getDeviceStatusesQuery = getDeviceStatuses.useQuery();
+  const getPollbookConfigurationInformationQuery =
+    getPollbookConfigurationInformation.useQuery();
   const [flowState, setFlowState] = useState<RegistrationFlowState>({
     step: 'register',
   });
@@ -115,7 +121,10 @@ export function VoterRegistrationScreen(): JSX.Element | null {
     [voter, isAddressValid]
   );
 
-  if (!getDeviceStatusesQuery.isSuccess) {
+  if (
+    !getDeviceStatusesQuery.isSuccess ||
+    !getPollbookConfigurationInformationQuery.isSuccess
+  ) {
     return null;
   }
 
@@ -134,6 +143,25 @@ export function VoterRegistrationScreen(): JSX.Element | null {
           >
             <p>Connect printer to continue.</p>
           </FullScreenMessage>
+        </Column>
+      </ElectionManagerNavScreen>
+    );
+  }
+
+  const { configuredPrecinctId } =
+    getPollbookConfigurationInformationQuery.data;
+  if (!configuredPrecinctId) {
+    return (
+      <ElectionManagerNavScreen>
+        <Column>
+          <FullScreenMessage
+            title="No Precinct Selected"
+            image={
+              <FullScreenIconWrapper>
+                <Icons.Disabled />
+              </FullScreenIconWrapper>
+            }
+          />
         </Column>
       </ElectionManagerNavScreen>
     );

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -276,10 +276,20 @@ export function createApiMock() {
         });
     },
 
-    setConfiguredPrecinct(configuredPrecinctId: string) {
+    expectSetConfiguredPrecinct(configuredPrecinctId: string) {
       mockApiClient.setConfiguredPrecinct
         .expectCallWith({ precinctId: configuredPrecinctId })
         .resolves();
+      mockApiClient.getPollbookConfigurationInformation.reset();
+      mockApiClient.getPollbookConfigurationInformation
+        .expectOptionalRepeatedCallsWith()
+        .resolves({
+          ...machineConfig,
+          configuredPrecinctId,
+        });
+    },
+
+    setConfiguredPrecinct(configuredPrecinctId: string) {
       mockApiClient.getPollbookConfigurationInformation.reset();
       mockApiClient.getPollbookConfigurationInformation
         .expectOptionalRepeatedCallsWith()

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -154,7 +154,7 @@ export function createApiMock() {
     },
 
     expectGetMachineInformation(): void {
-      mockApiClient.getMachineInformation
+      mockApiClient.getPollbookConfigurationInformation
         .expectRepeatedCallsWith()
         .resolves(machineConfig);
     },
@@ -251,7 +251,7 @@ export function createApiMock() {
         mockApiClient.getElection
           .expectRepeatedCallsWith()
           .resolves(err('unconfigured'));
-        mockApiClient.getMachineInformation
+        mockApiClient.getPollbookConfigurationInformation
           .expectOptionalRepeatedCallsWith()
           .resolves(machineConfig);
         return;
@@ -259,7 +259,7 @@ export function createApiMock() {
       mockApiClient.getElection
         .expectRepeatedCallsWith()
         .resolves(ok(electionDefinition.election));
-      mockApiClient.getMachineInformation
+      mockApiClient.getPollbookConfigurationInformation
         .expectOptionalRepeatedCallsWith()
         .resolves({
           electionId: electionDefinition.election.id,

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -165,6 +165,13 @@ export function createApiMock() {
         .resolves(usbDriveStatus || { status: 'no_drive' });
     },
 
+    expectHaveElectionEventsOccurred(hasEvents: boolean = false): void {
+      mockApiClient.haveElectionEventsOccurred.reset();
+      mockApiClient.haveElectionEventsOccurred
+        .expectCallWith()
+        .resolves(hasEvents);
+    },
+
     expectGetDeviceStatuses(): void {
       mockApiClient.getDeviceStatuses
         .expectOptionalRepeatedCallsWith()

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -251,12 +251,14 @@ export function createApiMock() {
 
     setElection(
       electionDefinition?: ElectionDefinition,
+      configuredPrecinctId?: string | null,
       pollbookPackageHash: string = 'test-package-hash'
     ) {
       mockApiClient.getElection.reset();
+      mockApiClient.getPollbookConfigurationInformation.reset();
       if (!electionDefinition) {
         mockApiClient.getElection
-          .expectRepeatedCallsWith()
+          .expectOptionalRepeatedCallsWith()
           .resolves(err('unconfigured'));
         mockApiClient.getPollbookConfigurationInformation
           .expectOptionalRepeatedCallsWith()
@@ -264,15 +266,16 @@ export function createApiMock() {
         return;
       }
       mockApiClient.getElection
-        .expectRepeatedCallsWith()
+        .expectOptionalRepeatedCallsWith()
         .resolves(ok(electionDefinition.election));
       mockApiClient.getPollbookConfigurationInformation
         .expectOptionalRepeatedCallsWith()
         .resolves({
+          ...machineConfig,
           electionId: electionDefinition.election.id,
           electionBallotHash: electionDefinition.ballotHash,
           pollbookPackageHash,
-          ...machineConfig,
+          configuredPrecinctId: configuredPrecinctId ?? undefined,
         });
     },
 
@@ -280,16 +283,6 @@ export function createApiMock() {
       mockApiClient.setConfiguredPrecinct
         .expectCallWith({ precinctId: configuredPrecinctId })
         .resolves();
-      mockApiClient.getPollbookConfigurationInformation.reset();
-      mockApiClient.getPollbookConfigurationInformation
-        .expectOptionalRepeatedCallsWith()
-        .resolves({
-          ...machineConfig,
-          configuredPrecinctId,
-        });
-    },
-
-    setConfiguredPrecinct(configuredPrecinctId: string) {
       mockApiClient.getPollbookConfigurationInformation.reset();
       mockApiClient.getPollbookConfigurationInformation
         .expectOptionalRepeatedCallsWith()

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -269,6 +269,19 @@ export function createApiMock() {
         });
     },
 
+    setConfiguredPrecinct(configuredPrecinctId: string) {
+      mockApiClient.setConfiguredPrecinct
+        .expectCallWith({ precinctId: configuredPrecinctId })
+        .resolves();
+      mockApiClient.getPollbookConfigurationInformation.reset();
+      mockApiClient.getPollbookConfigurationInformation
+        .expectOptionalRepeatedCallsWith()
+        .resolves({
+          ...machineConfig,
+          configuredPrecinctId,
+        });
+    },
+
     setElectionConfiguration(status: ConfigurationStatus) {
       mockApiClient.getElection.reset();
       mockApiClient.getElection.expectRepeatedCallsWith().resolves(err(status));

--- a/apps/pollbook/frontend/vitest.config.ts
+++ b/apps/pollbook/frontend/vitest.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
 
     coverage: {
       thresholds: {
-        lines: 86,
-        branches: 77,
+        lines: 87,
+        branches: 78,
       },
       exclude: [
         'src/**/*.d.ts',


### PR DESCRIPTION
## Overview
I believe we landed on "precinct" as the desired copy but cc @adghayes to confirm. 

Implements the foundation for multi-precinct configuration in pollbooks as outlined in: https://github.com/votingworks/vxsuite/issues/6157

Starts tracking a configured_precinct_id that is displayed as desired in the frontend and can be set from the election manager screen. Precinct can not be changed if voter events have occurred and events are blocked until the precinct is set. A one-precinct election will auto-set the precinct and hide it from the display, keeping the same workflow as is implemented today. 

Best reviewed by commit. 


<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

https://github.com/user-attachments/assets/8abcf328-02a1-467c-ac53-26f9b70a23a7



## Testing Plan
See manual testing video. Added tests to new code. 

## Checklist

<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
