### PR TITLE
Extend timeout for network config test

### DIFF
--- a/apps/pollbook/backend/src/app_multi_node.test.ts
+++ b/apps/pollbook/backend/src/app_multi_node.test.ts
@@ -62,8 +62,11 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-function extendedWaitFor(fn: () => void | Promise<void>) {
-  return vi.waitFor(fn, { timeout: 3000 });
+function extendedWaitFor(
+  fn: () => void | Promise<void>,
+  timeout: number = 3000
+) {
+  return vi.waitFor(fn, { timeout });
 }
 
 test('connection status between two pollbooks is managed properly', async () => {
@@ -877,7 +880,7 @@ test('one pollbook can be configured from another pollbook automatically as an e
         });
         const election = await pollbookContext2.localApiClient.getElection();
         expect(election.ok()).toEqual(electionDefinition.election);
-      });
+      }, 6000);
 
       expect(
         await pollbookContext2.peerApiClient.configureFromPeerMachine({


### PR DESCRIPTION
This test was flaky in checking the configuration over the network automatically happened. This does make sense to be one of the slower steps in the test so trying to bump the timeout for that waitFor specifically to hopefully resolve. The test actually failed due to a test coverage issue but I think it was just because this test failing lowered the coverage under the barrier. 

Flake: https://app.circleci.com/pipelines/github/votingworks/vxsuite/20605/workflows/74df3ded-52c9-4ac9-ac2d-029908306bb4/jobs/887198 