### PR TITLE
[VxScan] Set calibrated system volume level at startup

### DIFF
--- a/libs/backend/src/system_call/index.ts
+++ b/libs/backend/src/system_call/index.ts
@@ -5,6 +5,11 @@ export type { LogsResultType } from './export_logs_to_usb';
 export { getBatteryInfo } from './get_battery_info';
 export type { BatteryInfo } from './get_battery_info';
 export {
+  type SetAudioVolumeErr,
+  type SetAudioVolumeResult,
+  setAudioVolume,
+} from './set_audio_volume';
+export {
   type SetDefaultAudioErr,
   type SetDefaultAudioResult,
   setDefaultAudio,

--- a/libs/backend/src/system_call/set_audio_volume.test.ts
+++ b/libs/backend/src/system_call/set_audio_volume.test.ts
@@ -1,0 +1,127 @@
+import { expect, test, vi } from 'vitest';
+
+import { LogEventId, mockLogger } from '@votingworks/logging';
+import { err, ok } from '@votingworks/basics';
+import { execFile } from '../exec';
+import { SetAudioVolumeResult, setAudioVolume } from './set_audio_volume';
+
+vi.mock(import('../exec.js'));
+
+const mockExecFile = vi.mocked(execFile);
+
+test('NODE_ENV=production - runs app script via sudo', async () => {
+  mockExecFile.mockResolvedValue({ stderr: '', stdout: '' });
+
+  const sinkName = 'usb.stereo';
+  const logger = mockLogger({ fn: vi.fn });
+  const result = await setAudioVolume({
+    logger,
+    nodeEnv: 'production',
+    sinkName,
+    volumePct: 100,
+  });
+  expect(result).toEqual(ok());
+
+  expect(mockExecFile).toHaveBeenCalledExactlyOnceWith('sudo', [
+    '/vx/code/app-scripts/pactl.sh',
+    'set-sink-volume',
+    sinkName,
+    '100%',
+  ]);
+
+  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+    LogEventId.AudioVolumeChanged,
+    { message: expect.stringContaining(sinkName), disposition: 'success' }
+  );
+});
+
+test('NODE_ENV=development - runs pactl directly', async () => {
+  mockExecFile.mockResolvedValue({ stderr: '', stdout: '' });
+
+  const sinkName = 'usb.stereo';
+  const logger = mockLogger({ fn: vi.fn });
+  const result = await setAudioVolume({
+    logger,
+    nodeEnv: 'development',
+    sinkName,
+    volumePct: 50.5,
+  });
+  expect(result).toEqual(ok());
+
+  expect(mockExecFile).toHaveBeenCalledExactlyOnceWith('pactl', [
+    'set-sink-volume',
+    sinkName,
+    '50.5%',
+  ]);
+
+  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+    LogEventId.AudioVolumeChanged,
+    { message: expect.stringContaining(sinkName), disposition: 'success' }
+  );
+});
+
+test('invalid value', async () => {
+  await expect(
+    setAudioVolume({
+      logger: mockLogger({ fn: vi.fn }),
+      nodeEnv: 'production',
+      sinkName: 'usb.stereo',
+      volumePct: -1,
+    })
+  ).rejects.toThrow('Audio volume must be between 0 and 100');
+
+  await expect(
+    setAudioVolume({
+      logger: mockLogger({ fn: vi.fn }),
+      nodeEnv: 'production',
+      sinkName: 'usb.stereo',
+      volumePct: 100.1,
+    })
+  ).rejects.toThrow('Audio volume must be between 0 and 100');
+});
+
+test('execFile error', async () => {
+  const error = 'execFile failed';
+  mockExecFile.mockRejectedValue(error);
+
+  const logger = mockLogger({ fn: vi.fn });
+  expect(
+    await setAudioVolume({
+      logger,
+      nodeEnv: 'production',
+      sinkName: 'usb.stereo',
+      volumePct: 100,
+    })
+  ).toEqual<SetAudioVolumeResult>(err({ code: 'execFileError', error }));
+
+  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+    LogEventId.AudioVolumeChangeError,
+    {
+      message: expect.stringContaining(error),
+      disposition: 'failure',
+    }
+  );
+});
+
+test('pactl error', async () => {
+  const error = 'Failure: No such entity';
+  mockExecFile.mockResolvedValue({ stderr: error, stdout: '' });
+
+  const logger = mockLogger({ fn: vi.fn });
+  expect(
+    await setAudioVolume({
+      logger,
+      nodeEnv: 'production',
+      sinkName: 'cup_and_string.mono',
+      volumePct: 20,
+    })
+  ).toEqual<SetAudioVolumeResult>(err({ code: 'pactlError', error }));
+
+  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+    LogEventId.AudioVolumeChangeError,
+    {
+      message: expect.stringContaining(error),
+      disposition: 'failure',
+    }
+  );
+});

--- a/libs/backend/src/system_call/set_audio_volume.ts
+++ b/libs/backend/src/system_call/set_audio_volume.ts
@@ -1,0 +1,80 @@
+import { LogEventId, Logger } from '@votingworks/logging';
+import { assert, err, ok, Result } from '@votingworks/basics';
+import { execFile } from '../exec';
+import { NODE_ENV } from '../scan_globals';
+
+/**
+ * Errors returned by {@link setAudioVolume}.
+ */
+export type SetAudioVolumeErr =
+  | { code: 'execFileError'; error: unknown }
+  | { code: 'pactlError'; error: string };
+
+/**
+ * Result returned by {@link setAudioVolume}.
+ */
+export type SetAudioVolumeResult = Result<void, SetAudioVolumeErr>;
+
+/**
+ * Sets the volume of a PulseAudio output device.
+ */
+export async function setAudioVolume(params: {
+  logger: Logger;
+  nodeEnv: typeof NODE_ENV;
+  /**
+   * Name of the output device (see `./get_audio_info.ts`).
+   */
+  sinkName: string;
+  /**
+   * The target percentage volume (0-100);
+   */
+  volumePct: number;
+}): Promise<SetAudioVolumeResult> {
+  const { logger, nodeEnv, sinkName, volumePct } = params;
+  let errorOutput: string;
+
+  assert(
+    volumePct >= 0 && volumePct <= 100,
+    'Audio volume must be between 0 and 100'
+  );
+
+  try {
+    if (nodeEnv === 'production') {
+      ({ stderr: errorOutput } = await execFile('sudo', [
+        '/vx/code/app-scripts/pactl.sh',
+        'set-sink-volume',
+        sinkName,
+        `${volumePct}%`,
+      ]));
+    } else {
+      ({ stderr: errorOutput } = await execFile('pactl', [
+        'set-sink-volume',
+        sinkName,
+        `${volumePct}%`,
+      ]));
+    }
+  } catch (error) {
+    void logger.logAsCurrentRole(LogEventId.AudioVolumeChangeError, {
+      message: `Unable to run pactl set-sink-volume command: ${error}`,
+      disposition: 'failure',
+    });
+
+    return err({ code: 'execFileError', error });
+  }
+
+  if (errorOutput) {
+    void logger.logAsCurrentRole(LogEventId.AudioVolumeChangeError, {
+      message: `pactl set-sink-volume command failed: ${errorOutput}`,
+      disposition: 'failure',
+    });
+
+    return err({ code: 'pactlError', error: errorOutput });
+  }
+
+  void logger.logAsCurrentRole(LogEventId.AudioVolumeChanged, {
+    message: `Audio volume for ${sinkName} set to ${volumePct}%`,
+    disposition: 'success',
+  });
+
+  return ok();
+}

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -166,6 +166,14 @@ IDs are logged with each log to identify the log being written.
 **Type:** [application-status](#application-status)
 **Description:** Error while attempting to select a default audio output device.
 **Machines:** All
+### audio-volume-changed
+**Type:** [application-status](#application-status)
+**Description:** The volume level for an audio output device was changed.
+**Machines:** All
+### audio-volume-change-error
+**Type:** [application-status](#application-status)
+**Description:** Error while attempting to change the volume of an audio output device.
+**Machines:** All
 ### audio-playback-error
 **Type:** [application-status](#application-status)
 **Description:** Error while attempting to play audio.

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -317,6 +317,16 @@ eventId = "audio-device-selection-error"
 eventType = "application-status"
 documentationMessage = "Error while attempting to select a default audio output device."
 
+[Events.AudioVolumeChanged]
+eventId = "audio-volume-changed"
+eventType = "application-status"
+documentationMessage = "The volume level for an audio output device was changed."
+
+[Events.AudioVolumeChangeError]
+eventId = "audio-volume-change-error"
+eventType = "application-status"
+documentationMessage = "Error while attempting to change the volume of an audio output device."
+
 [Events.AudioPlaybackError]
 eventId = "audio-playback-error"
 eventType = "application-status"

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -101,6 +101,8 @@ export enum LogEventId {
   AudioDeviceMissing = 'audio-device-missing',
   AudioDeviceSelected = 'audio-device-selected',
   AudioDeviceSelectionError = 'audio-device-selection-error',
+  AudioVolumeChanged = 'audio-volume-changed',
+  AudioVolumeChangeError = 'audio-volume-change-error',
   AudioPlaybackError = 'audio-playback-error',
   UnknownError = 'unknown-error',
   PermissionDenied = 'permission-denied',
@@ -468,6 +470,20 @@ const AudioDeviceSelectionError: LogDetails = {
   eventType: LogEventType.ApplicationStatus,
   documentationMessage:
     'Error while attempting to select a default audio output device.',
+};
+
+const AudioVolumeChanged: LogDetails = {
+  eventId: LogEventId.AudioVolumeChanged,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'The volume level for an audio output device was changed.',
+};
+
+const AudioVolumeChangeError: LogDetails = {
+  eventId: LogEventId.AudioVolumeChangeError,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'Error while attempting to change the volume of an audio output device.',
 };
 
 const AudioPlaybackError: LogDetails = {
@@ -1372,6 +1388,10 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return AudioDeviceSelected;
     case LogEventId.AudioDeviceSelectionError:
       return AudioDeviceSelectionError;
+    case LogEventId.AudioVolumeChanged:
+      return AudioVolumeChanged;
+    case LogEventId.AudioVolumeChangeError:
+      return AudioVolumeChangeError;
     case LogEventId.AudioPlaybackError:
       return AudioPlaybackError;
     case LogEventId.UnknownError:

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -185,6 +185,10 @@ pub enum EventId {
     AudioDeviceSelected,
     #[serde(rename = "audio-device-selection-error")]
     AudioDeviceSelectionError,
+    #[serde(rename = "audio-volume-changed")]
+    AudioVolumeChanged,
+    #[serde(rename = "audio-volume-change-error")]
+    AudioVolumeChangeError,
     #[serde(rename = "audio-playback-error")]
     AudioPlaybackError,
     #[serde(rename = "unknown-error")]

--- a/libs/ui/src/ui_strings/audio_volume.ts
+++ b/libs/ui/src/ui_strings/audio_volume.ts
@@ -44,7 +44,9 @@ export enum AudioVolume {
  * in roughly an output level of {@link MIN_VOLUME_DB_SPL} when the OS volume is
  * set to its maximum output level.
  *
- * Last Calibration: 2024-09-11 on VSAP 150 with Lorelei X6 Headphones.
+ * - Last VxMark Calibration: 2024-09-11 on VSAP 150 with Lorelei X6 Headphones.
+ * - Last VxScan Calibration: 2025-06-16 on Storm Interface 1406-330023 with
+ *   Philips TAH2005 Headphones.
  *
  * TODO: Might be worth defining different offsets for different machines
  * (VxMark vs VxMarkScan), since audio hardware and output levels will likely


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6484

Adding a server startup step to set the system volume for the USB audio device to 100%, which, in combination with the in-app volume setting brings the screen reader audio into the VVSG2 default range of 60db - 70db.

## Testing Plan
- Unit tests for `pactl` integration.
- Manual test for volume levels with our trusty VxAustin foam head:
![IMG_5007](https://github.com/user-attachments/assets/43dd37b1-6d2b-41fd-80fb-0b20ad7c52cc)


## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
