### PR TITLE
VxMark/VxMarkScan: Replace test mode banner with callout 

### DIFF
--- a/apps/mark-scan/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.tsx
@@ -8,7 +8,6 @@ import {
   Screen,
   SegmentedButton,
   SetClockButton,
-  TestMode,
   Font,
   H3,
   UnconfigureMachineButton,
@@ -115,7 +114,6 @@ export function AdminScreen({
 
   return (
     <Screen>
-      {isTestMode && <TestMode />}
       <Main padded>
         <H2 as="h1">Election Manager Menu</H2>
         <P>Remove the election manager card to leave this screen.</P>

--- a/apps/mark-scan/frontend/src/pages/insert_card_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/insert_card_screen.tsx
@@ -7,11 +7,11 @@ import {
 import {
   Main,
   Screen,
-  TestMode,
   ElectionInfoBar,
   InsertCardImage,
   H1,
   P,
+  TestModeCallout,
 } from '@votingworks/ui';
 
 import { throwIllegalValue } from '@votingworks/basics';
@@ -65,7 +65,9 @@ export function InsertCardScreen({
 
   return (
     <Screen>
-      {!isLiveMode && <TestMode />}
+      {!isLiveMode && (
+        <TestModeCallout style={{ alignSelf: 'center', marginTop: '0.5rem' }} />
+      )}
       <Main centerChild>
         <P>
           <InsertCardImage cardInsertionDirection="up" />

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -22,7 +22,6 @@ import {
   Modal,
   Screen,
   ElectionInfoBar,
-  TestMode,
   H2,
   P,
   Caption,
@@ -34,6 +33,7 @@ import {
   SignedHashValidationButton,
   RemoveCardImage,
   electionStrings,
+  TestModeCallout,
 } from '@votingworks/ui';
 
 import {
@@ -566,10 +566,18 @@ export function PollWorkerScreen({
 
   return (
     <Screen>
-      {!isLiveMode && <TestMode />}
       <Main padded>
         <div>
-          <H2 as="h1">Poll Worker Menu</H2>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'start',
+            }}
+          >
+            <H2 as="h1">Poll Worker Menu</H2>
+            {!isLiveMode && <TestModeCallout />}
+          </div>
           <P>Remove the poll worker card to leave this screen.</P>
           <P style={{ fontSize: '1.2em' }}>
             <Font weight="bold">Ballots Printed:</Font>{' '}

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -9,7 +9,6 @@ import {
   Screen,
   SegmentedButton,
   SetClockButton,
-  TestMode,
   UsbControllerButton,
   Caption,
   Icons,
@@ -63,7 +62,6 @@ export function AdminScreen({
 
   return (
     <Screen>
-      {election && isTestMode && <TestMode />}
       <Main padded>
         <H3 as="h1">Election Manager Settings</H3>
         <Caption weight="bold">

--- a/apps/mark/frontend/src/pages/insert_card_screen.tsx
+++ b/apps/mark/frontend/src/pages/insert_card_screen.tsx
@@ -7,7 +7,6 @@ import {
 import {
   Main,
   Screen,
-  TestMode,
   ElectionInfoBar,
   InsertCardImage,
   H1,
@@ -15,6 +14,7 @@ import {
   Caption,
   Icons,
   Font,
+  TestModeCallout,
 } from '@votingworks/ui';
 
 import { throwIllegalValue } from '@votingworks/basics';
@@ -72,7 +72,9 @@ export function InsertCardScreen({
 
   return (
     <Screen>
-      {!isLiveMode && <TestMode />}
+      {!isLiveMode && (
+        <TestModeCallout style={{ alignSelf: 'center', marginTop: '0.5rem' }} />
+      )}
       <Main centerChild>
         {showNoChargerAttachedWarning && (
           <Caption>

--- a/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
@@ -90,7 +90,7 @@ function renderScreen(
 
 test('renders PollWorkerScreen', () => {
   renderScreen(undefined, undefined, undefined);
-  screen.getByText('Poll Worker Actions');
+  screen.getByText('Poll Worker Menu');
   expect(
     screen.getByText('Ballots Printed:').parentElement!.textContent
   ).toEqual('Ballots Printed: 0');

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -17,7 +17,6 @@ import {
   Modal,
   Screen,
   ElectionInfoBar,
-  TestMode,
   H1,
   H2,
   P,
@@ -28,6 +27,7 @@ import {
   FullScreenIconWrapper,
   H3,
   H6,
+  TestModeCallout,
 } from '@votingworks/ui';
 
 import {
@@ -277,15 +277,18 @@ export function PollWorkerScreen({
 
   return (
     <Screen>
-      {!isLiveMode && <TestMode />}
       <Main padded>
         <div>
-          <H2 as="h1">
-            VxMark{' '}
-            <Font weight="light" noWrap>
-              Poll Worker Actions
-            </Font>
-          </H2>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'start',
+            }}
+          >
+            <H2 as="h1">Poll Worker Menu</H2>
+            {!isLiveMode && <TestModeCallout />}
+          </div>
           <H4 as="h2">
             <Font noWrap>
               <Font weight="light">Ballots Printed:</Font> {ballotsPrintedCount}

--- a/libs/ui/src/test_mode.test.tsx
+++ b/libs/ui/src/test_mode.test.tsx
@@ -1,14 +1,6 @@
 import { test } from 'vitest';
 import { render, screen } from '../test/react_testing_library';
-
-import { TestMode, TestModeCallout } from './test_mode';
-
-test('renders TestMode - VVSG styling', () => {
-  render(<TestMode />, {
-    vxTheme: { sizeMode: 'touchLarge' },
-  });
-  screen.getByText('Test Ballot Mode');
-});
+import { TestModeCallout } from './test_mode';
 
 test('TestModeCallout', () => {
   render(<TestModeCallout />);

--- a/libs/ui/src/test_mode.tsx
+++ b/libs/ui/src/test_mode.tsx
@@ -1,57 +1,7 @@
 import styled, { ThemeProvider } from 'styled-components';
-import { H1 } from './typography';
 import { makeTheme, TouchscreenPalette } from './themes/make_theme';
 import { Icons } from './icons';
 import { TextOnly } from './ui_strings';
-
-const TestingModeContainer = styled.div`
-  /* https://stripesgenerator.com/stripe/5302 */
-  background-image: linear-gradient(
-    135deg,
-    #ff8c00 21.43%,
-    #333 21.43%,
-    #333 50%,
-    #ff8c00 50%,
-    #ff8c00 71.43%,
-    #333 71.43%,
-    #333 100%
-  );
-  background-size: 98.99px 98.99px;
-  width: 100%;
-  font-size: 48px;
-  padding: 0.5em 0;
-`;
-
-const Heading = styled(H1)`
-  background: #ff8c00;
-  color: #333;
-  font-size: inherit;
-  margin: 0;
-  padding: 0.1em 0;
-  text-align: center;
-`;
-
-export function TestMode(): JSX.Element {
-  return (
-    // Lock the test mode banner to "small" mode to keep its size from getting
-    // out of had at larger text sizes.
-    <ThemeProvider
-      theme={(theme) =>
-        makeTheme({
-          colorMode: theme.colorMode,
-          screenType: theme.screenType,
-          sizeMode: 'touchSmall',
-        })
-      }
-    >
-      <TestingModeContainer>
-        <div>
-          <Heading>Test Ballot Mode</Heading>
-        </div>
-      </TestingModeContainer>
-    </ThemeProvider>
-  );
-}
 
 const TestModeCard = styled.div`
   font-size: ${(p) => p.theme.sizes.fontDefault}px;

--- a/libs/ui/src/test_mode.tsx
+++ b/libs/ui/src/test_mode.tsx
@@ -64,7 +64,11 @@ const TestModeCard = styled.div`
   background-color: ${(p) => p.theme.colors.background};
 `;
 
-export function TestModeCallout(): JSX.Element {
+export function TestModeCallout({
+  style,
+}: {
+  style?: React.CSSProperties;
+}): JSX.Element {
   return (
     <TextOnly>
       <ThemeProvider
@@ -77,7 +81,7 @@ export function TestModeCallout(): JSX.Element {
           })
         }
       >
-        <TestModeCard>
+        <TestModeCard style={style}>
           <Icons.Warning
             style={{
               // We always want a bright orange, even if the color mode is


### PR DESCRIPTION
## Overview

Closes #6599 

Builds on #6636. The main difference here is that the banner was only being show in 3 places:
- Insert card screen - updated to callout
- Poll worker screen - updated to callout
- Election manager screen - removed, since the control to switch between official and test mode is on this screen, so it's redundant (also, it didn't easily fit alongside the title)

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
VxMarkScan

![Screenshot-VxMark-2025-06-16T22:50:46 440Z](https://github.com/user-attachments/assets/06a5f314-70ef-43fb-838e-52cdbc996413)
![Screenshot-VxMark-2025-06-16T22:50:42 487Z](https://github.com/user-attachments/assets/59c5bac9-99e7-496f-ac5f-00767f0a2ec5)

VxMark

![Screenshot-VxMark-2025-06-16T22:50:16 507Z](https://github.com/user-attachments/assets/aec33bb8-e15c-41d3-9847-2c943781326a)
![Screenshot-VxMark-2025-06-16T22:50:02 292Z](https://github.com/user-attachments/assets/48931396-dbfb-4143-b212-8cd61f8874f0)



## Testing Plan
Manual test

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
