### PR TITLE
[pollbook] Include middle name and suffix on `voters` table

### DIFF
--- a/apps/pollbook/backend/schema.sql
+++ b/apps/pollbook/backend/schema.sql
@@ -1,9 +1,13 @@
 CREATE TABLE voters (
     voter_id TEXT PRIMARY KEY,
     original_first_name TEXT,
+    original_middle_name TEXT,
     original_last_name TEXT,
+    original_suffix TEXT,
     updated_first_name TEXT,
+    updated_middle_name TEXT,
     updated_last_name TEXT,
+    updated_suffix TEXT,
     voter_data TEXT not null
 );
 

--- a/apps/pollbook/backend/scripts/simulate_check_ins.ts
+++ b/apps/pollbook/backend/scripts/simulate_check_ins.ts
@@ -34,7 +34,9 @@ async function searchVoterByInitials(firstName: string, lastName: string) {
     const response = await api.searchVoters({
       searchParams: {
         firstName: firstName[0],
+        middleName: '',
         lastName: lastName[0],
+        suffix: '',
         includeInactiveVoters: false,
       },
     });
@@ -45,12 +47,19 @@ async function searchVoterByInitials(firstName: string, lastName: string) {
   }
 }
 
-async function searchVoterByFullName(firstName: string, lastName: string) {
+async function searchVoterByFullName(
+  firstName: string,
+  middleName: string,
+  lastName: string,
+  suffix: string
+) {
   try {
     const response = await api.searchVoters({
       searchParams: {
         firstName,
+        middleName,
         lastName,
+        suffix,
         includeInactiveVoters: false,
       },
     });
@@ -109,7 +118,12 @@ async function checkInAllVotersOnCurrentMachine(
       );
 
       const startSearchByFullName = performance.now();
-      await searchVoterByFullName(voter.firstName, voter.lastName);
+      await searchVoterByFullName(
+        voter.firstName,
+        voter.middleName,
+        voter.lastName,
+        voter.suffix
+      );
       const endSearchByFullName = performance.now();
       durations.searchByFullName.push(
         endSearchByFullName - startSearchByFullName

--- a/apps/pollbook/backend/src/app.test.ts
+++ b/apps/pollbook/backend/src/app.test.ts
@@ -73,7 +73,9 @@ test('check in a voter', async () => {
     const votersAbigail = await localApiClient.searchVoters({
       searchParams: {
         firstName: 'Abigail',
+        middleName: '',
         lastName: 'Adams',
+        suffix: '',
         includeInactiveVoters: true,
       },
     });
@@ -213,7 +215,9 @@ test('register a voter', async () => {
     const votersEagen = await localApiClient.searchVoters({
       searchParams: {
         firstName: 'H',
+        middleName: '',
         lastName: 'Eagen',
+        suffix: '',
         includeInactiveVoters: true,
       },
     });
@@ -356,7 +360,9 @@ test('change a voter name', async () => {
     const votersAbigail = await localApiClient.searchVoters({
       searchParams: {
         firstName: 'Abigail',
+        middleName: '',
         lastName: 'Adams',
+        suffix: '',
         includeInactiveVoters: true,
       },
     });
@@ -391,7 +397,9 @@ test('change a voter name', async () => {
     const votersAbigail2 = await localApiClient.searchVoters({
       searchParams: {
         firstName: 'Abigail',
+        middleName: '',
         lastName: 'Adams',
+        suffix: '',
         includeInactiveVoters: true,
       },
     });
@@ -406,7 +414,9 @@ test('change a voter name', async () => {
     const votersBarbara = await localApiClient.searchVoters({
       searchParams: {
         firstName: 'Barbara',
+        middleName: '',
         lastName: 'Bee',
+        suffix: '',
         includeInactiveVoters: true,
       },
     });
@@ -436,7 +446,9 @@ test('undo a voter check-in', async () => {
     const votersAbigail = await localApiClient.searchVoters({
       searchParams: {
         firstName: 'Abigail',
+        middleName: '',
         lastName: 'Adams',
+        suffix: '',
         includeInactiveVoters: true,
       },
     });
@@ -667,7 +679,9 @@ test('check in, change name, undo check-in, change address, and check in again',
     const votersAbigail = await localApiClient.searchVoters({
       searchParams: {
         firstName: 'Abigail',
+        middleName: '',
         lastName: 'Adams',
+        suffix: '',
         includeInactiveVoters: true,
       },
     });
@@ -771,7 +785,9 @@ test('change a voter address with various formats', async () => {
     const votersAbigail = await localApiClient.searchVoters({
       searchParams: {
         firstName: 'Abigail',
+        middleName: '',
         lastName: 'Adams',
+        suffix: '',
         includeInactiveVoters: true,
       },
     });
@@ -896,33 +912,45 @@ test('voter search ignores punctuation', async () => {
       // Test puncutation and whitespace in input are ignored
       {
         firstName: 'george-washington',
+        middleName: '',
         lastName: 'carver-farmer',
+        suffix: '',
         includeInactiveVoters: true,
       },
       {
         firstName: "george'washington",
+        middleName: '',
         lastName: "carver'farmer",
+        suffix: '',
         includeInactiveVoters: true,
       },
       {
         firstName: 'mar tha',
+        middleName: '',
         lastName: 'wash ington',
+        suffix: '',
         includeInactiveVoters: true,
       },
       // Test punctuation and whitespace in db column are ignored
       {
         firstName: 'georgewashington',
+        middleName: '',
         lastName: 'carverfar',
+        suffix: '',
         includeInactiveVoters: true,
       },
       {
         firstName: 'george',
+        middleName: '',
         lastName: 'washington',
+        suffix: '',
         includeInactiveVoters: true,
       },
       {
         firstName: 'martha',
+        middleName: '',
         lastName: 'washington',
+        suffix: '',
         includeInactiveVoters: true,
       },
     ];
@@ -1006,7 +1034,9 @@ test('mark a voter inactive', async () => {
     const votersAbigail = await localApiClient.searchVoters({
       searchParams: {
         firstName: 'Abigail',
+        middleName: '',
         lastName: 'Adams',
+        suffix: '',
         includeInactiveVoters: true,
       },
     });
@@ -1075,7 +1105,9 @@ test('mark a voter inactive', async () => {
     const votersAbigail2 = await localApiClient.searchVoters({
       searchParams: {
         firstName: 'Abigail',
+        middleName: '',
         lastName: 'Adams',
+        suffix: '',
         includeInactiveVoters: true,
       },
     });
@@ -1095,7 +1127,9 @@ test('mark a voter inactive', async () => {
     const votersAbigail3 = await localApiClient.searchVoters({
       searchParams: {
         firstName: 'Abigail',
+        middleName: '',
         lastName: 'Adams',
+        suffix: '',
         includeInactiveVoters: false,
       },
     });

--- a/apps/pollbook/backend/src/local_store.test.ts
+++ b/apps/pollbook/backend/src/local_store.test.ts
@@ -11,13 +11,7 @@ import { LocalStore } from './local_store';
 import { VoterRegistrationRequest } from './types';
 
 test('findVotersWithName works as expected - voters without name changes', () => {
-  const workspacePath = tmp.dirSync().name;
-  const localStore = LocalStore.fileStore(
-    workspacePath,
-    mockBaseLogger({ fn: vi.fn }),
-    '0000',
-    'test'
-  );
+  const localStore = LocalStore.memoryStore();
   const testElectionDefinition = getTestElectionDefinition();
   const voters = [
     createVoter('10', 'Dylan', `O'Brien`, 'MiD', 'I'),
@@ -139,14 +133,8 @@ test('findVotersWithName works as expected - voters without name changes', () =>
   );
 });
 
-test('findVoterWithName works as expected - voters with name changes', async () => {
-  const workspacePath = tmp.dirSync().name;
-  const localStore = LocalStore.fileStore(
-    workspacePath,
-    mockBaseLogger({ fn: vi.fn }),
-    '0001',
-    'test'
-  );
+test('findVoterWithName works as expected - voters with name changes', () => {
+  const localStore = LocalStore.memoryStore();
   const testElectionDefinition = getTestElectionDefinition();
   const voters = [
     createVoter('20', 'John', 'Doe', 'Allen', 'Sr'),
@@ -161,44 +149,38 @@ test('findVoterWithName works as expected - voters with name changes', async () 
   );
 
   // Before name change, should match original name
-  await vi.waitFor(() => {
-    expect(
-      localStore.findVotersWithName({
-        firstName: 'John',
-        lastName: 'Doe',
-        middleName: 'Allen',
-        suffix: 'Sr',
-      })
-    ).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ voterId: voters[0].voterId }),
-      ])
-    );
-  });
+  expect(
+    localStore.findVotersWithName({
+      firstName: 'John',
+      lastName: 'Doe',
+      middleName: 'Allen',
+      suffix: 'Sr',
+    })
+  ).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ voterId: voters[0].voterId }),
+    ])
+  );
 
   // Should not match because middle name is excluded
-  await vi.waitFor(() => {
-    expect(
-      localStore.findVotersWithName({
-        firstName: 'John',
-        lastName: 'Doe',
-        middleName: '',
-        suffix: 'Sr',
-      })
-    ).toEqual([]);
-  });
+  expect(
+    localStore.findVotersWithName({
+      firstName: 'John',
+      lastName: 'Doe',
+      middleName: '',
+      suffix: 'Sr',
+    })
+  ).toEqual([]);
 
   // Should not match because suffix is excluded
-  await vi.waitFor(() => {
-    expect(
-      localStore.findVotersWithName({
-        firstName: 'John',
-        lastName: 'Doe',
-        middleName: 'Allen',
-        suffix: '',
-      })
-    ).toEqual([]);
-  });
+  expect(
+    localStore.findVotersWithName({
+      firstName: 'John',
+      lastName: 'Doe',
+      middleName: 'Allen',
+      suffix: '',
+    })
+  ).toEqual([]);
 
   // Change name for John Doe
   localStore.changeVoterName(voters[0].voterId, {
@@ -276,13 +258,7 @@ test('findVoterWithName works as expected - voters with name changes', async () 
 });
 
 test('registerVoter and findVoterWithName integration', () => {
-  const workspacePath = tmp.dirSync().name;
-  const localStore = LocalStore.fileStore(
-    workspacePath,
-    mockBaseLogger({ fn: vi.fn }),
-    '0002',
-    'test'
-  );
+  const localStore = LocalStore.memoryStore();
   const testElectionDefinition = getTestElectionDefinition();
   const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];
   localStore.setElectionAndVoters(

--- a/apps/pollbook/backend/src/local_store.test.ts
+++ b/apps/pollbook/backend/src/local_store.test.ts
@@ -139,7 +139,7 @@ test('findVotersWithName works as expected - voters without name changes', () =>
   );
 });
 
-test('findVoterWithName works as expected - voters with name changes', () => {
+test('findVoterWithName works as expected - voters with name changes', async () => {
   const workspacePath = tmp.dirSync().name;
   const localStore = LocalStore.fileStore(
     workspacePath,
@@ -161,18 +161,20 @@ test('findVoterWithName works as expected - voters with name changes', () => {
   );
 
   // Before name change, should match original name
-  expect(
-    localStore.findVotersWithName({
-      firstName: 'John',
-      lastName: 'Doe',
-      middleName: 'Allen',
-      suffix: 'Sr',
-    })
-  ).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({ voterId: voters[0].voterId }),
-    ])
-  );
+  await vi.waitFor(() => {
+    expect(
+      localStore.findVotersWithName({
+        firstName: 'John',
+        lastName: 'Doe',
+        middleName: 'Allen',
+        suffix: 'Sr',
+      })
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ voterId: voters[0].voterId }),
+      ])
+    );
+  });
 
   // Change name for John Doe
   localStore.changeVoterName(voters[0].voterId, {

--- a/apps/pollbook/backend/src/local_store.test.ts
+++ b/apps/pollbook/backend/src/local_store.test.ts
@@ -176,6 +176,30 @@ test('findVoterWithName works as expected - voters with name changes', async () 
     );
   });
 
+  // Should not match because middle name is excluded
+  await vi.waitFor(() => {
+    expect(
+      localStore.findVotersWithName({
+        firstName: 'John',
+        lastName: 'Doe',
+        middleName: '',
+        suffix: 'Sr',
+      })
+    ).toEqual([]);
+  });
+
+  // Should not match because suffix is excluded
+  await vi.waitFor(() => {
+    expect(
+      localStore.findVotersWithName({
+        firstName: 'John',
+        lastName: 'Doe',
+        middleName: 'Allen',
+        suffix: '',
+      })
+    ).toEqual([]);
+  });
+
   // Change name for John Doe
   localStore.changeVoterName(voters[0].voterId, {
     firstName: 'Jonathan',

--- a/apps/pollbook/backend/src/local_store.ts
+++ b/apps/pollbook/backend/src/local_store.ts
@@ -93,7 +93,7 @@ export class LocalStore extends Store {
     codeVersion: string = 'test-v1'
   ): LocalStore {
     return new LocalStore(
-      DbClient.memoryClient(SchemaPath),
+      DbClient.memoryClient(SchemaPath, { registerRegexpFn: true }),
       machineId,
       codeVersion
     );

--- a/apps/pollbook/backend/src/store.ts
+++ b/apps/pollbook/backend/src/store.ts
@@ -32,6 +32,8 @@ import {
 import {
   getUpdatedVoterFirstName,
   getUpdatedVoterLastName,
+  getUpdatedVoterMiddleName,
+  getUpdatedVoterSuffix,
 } from './voter_helpers';
 
 const debug = rootDebug.extend('store');
@@ -189,6 +191,7 @@ export abstract class Store {
     ) as Array<{ voter_data: string }>;
 
     assert(voterRows.length === 1, `Voter with ID ${voterId} not found.`);
+
     const voter = safeParseJson(
       voterRows[0].voter_data,
       VoterSchema
@@ -210,7 +213,8 @@ export abstract class Store {
       events
     );
 
-    return updatedVoters[voterId];
+    const value = updatedVoters[voterId];
+    return value;
   }
 
   saveEvent(pollbookEvent: PollbookEvent): boolean {
@@ -239,17 +243,25 @@ export abstract class Store {
               INSERT INTO voters (
                 voter_id,
                 original_first_name,
+                original_middle_name,
                 original_last_name,
+                original_suffix,
                 updated_first_name,
+                updated_middle_name,
                 updated_last_name,
+                updated_suffix,
                 voter_data
-              ) VALUES (?, ?, ?, ?, ?, ?)
+              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
               `,
               voter.voterId,
               voter.firstName.toUpperCase(),
+              voter.middleName.toUpperCase(),
               voter.lastName.toUpperCase(),
+              voter.suffix.toUpperCase(),
               getUpdatedVoterFirstName(voter).toUpperCase(),
+              getUpdatedVoterMiddleName(voter).toUpperCase(),
               getUpdatedVoterLastName(voter).toUpperCase(),
+              getUpdatedVoterSuffix(voter).toUpperCase(),
               JSON.stringify(voter)
             );
             return pollbookEvent.registrationData;
@@ -316,11 +328,13 @@ export abstract class Store {
             this.client.run(
               `
                 UPDATE voters
-                SET updated_first_name = ?, updated_last_name = ?
+                SET updated_first_name = ?, updated_middle_name = ?, updated_last_name = ?, updated_suffix = ?
                 WHERE voter_id = ?
                 `,
               voter.nameChange.firstName.toUpperCase(),
+              voter.nameChange.middleName.toUpperCase(),
               voter.nameChange.lastName.toUpperCase(),
+              voter.nameChange.suffix.toUpperCase(),
               pollbookEvent.voterId
             );
           }
@@ -425,19 +439,27 @@ export abstract class Store {
               insert into voters (
                 voter_id,
                 original_first_name,
+                original_middle_name,
                 original_last_name,
+                original_suffix,
                 updated_first_name,
+                updated_middle_name,
                 updated_last_name,
+                updated_suffix,
                 voter_data
               ) values (
-                ?, ?, ?, ?, ?, ?
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
               )
             `,
             voter.voterId,
             voter.firstName.toUpperCase(),
+            voter.middleName.toUpperCase(),
             voter.lastName.toUpperCase(),
+            voter.suffix.toUpperCase(),
             getUpdatedVoterFirstName(voter).toUpperCase(),
+            getUpdatedVoterMiddleName(voter).toUpperCase(),
             getUpdatedVoterLastName(voter).toUpperCase(),
+            getUpdatedVoterSuffix(voter).toUpperCase(),
             JSON.stringify(voter)
           );
         }

--- a/apps/pollbook/backend/src/store.ts
+++ b/apps/pollbook/backend/src/store.ts
@@ -213,8 +213,7 @@ export abstract class Store {
       events
     );
 
-    const value = updatedVoters[voterId];
-    return value;
+    return updatedVoters[voterId];
   }
 
   saveEvent(pollbookEvent: PollbookEvent): boolean {

--- a/apps/pollbook/backend/src/store_multi_node.test.ts
+++ b/apps/pollbook/backend/src/store_multi_node.test.ts
@@ -147,7 +147,9 @@ test('offline undo with later real time check in', async () => {
   // Verify Sue's check-in is from PollbookA with NH id.
   const voters = localA.searchVoters({
     firstName: 'Sue',
+    middleName: '',
     lastName: '',
+    suffix: '',
     includeInactiveVoters: true,
   });
   expect((voters as Voter[]).length).toEqual(1);
@@ -234,12 +236,16 @@ test('bad system time nodes should be able to undo', () => {
   // Verify Bob's status specifically
   const votersA = localA.searchVoters({
     firstName: 'Bob',
+    middleName: '',
     lastName: '',
+    suffix: '',
     includeInactiveVoters: true,
   });
   const votersB = localB.searchVoters({
     firstName: 'Bob',
+    middleName: '',
     lastName: '',
+    suffix: '',
     includeInactiveVoters: true,
   });
   expect((votersA as Voter[])[0].checkIn).toBeUndefined();
@@ -378,7 +384,9 @@ test("getting a offline machines events when I've synced with the online machine
   expect(
     localA.searchVoters({
       firstName: 'Carl',
+      middleName: '',
       lastName: '',
+      suffix: '',
       includeInactiveVoters: true,
     })
   ).toEqual([
@@ -405,7 +413,9 @@ test("getting a offline machines events when I've synced with the online machine
   expect(
     localB.searchVoters({
       firstName: 'Carl',
+      middleName: '',
       lastName: '',
+      suffix: '',
       includeInactiveVoters: true,
     })
   ).toEqual([
@@ -473,7 +483,9 @@ test('last write wins on double check ins', async () => {
   expect(
     localA.searchVoters({
       firstName: 'Bob',
+      middleName: '',
       lastName: '',
+      suffix: '',
       includeInactiveVoters: true,
     })
   ).toEqual([
@@ -490,7 +502,9 @@ test('last write wins on double check ins', async () => {
   expect(
     localB.searchVoters({
       firstName: 'Bob',
+      middleName: '',
       lastName: '',
+      suffix: '',
       includeInactiveVoters: true,
     })
   ).toEqual([
@@ -562,7 +576,9 @@ test('last write wins even when there is bad system time after a sync', () => {
   expect(
     localA.searchVoters({
       firstName: 'Bob',
+      middleName: '',
       lastName: '',
+      suffix: '',
       includeInactiveVoters: true,
     })
   ).toEqual([
@@ -585,7 +601,9 @@ test('last write wins even when there is bad system time after a sync', () => {
   expect(
     localA.searchVoters({
       firstName: 'Bob',
+      middleName: '',
       lastName: '',
+      suffix: '',
       includeInactiveVoters: true,
     })
   ).toEqual([
@@ -602,7 +620,9 @@ test('last write wins even when there is bad system time after a sync', () => {
   expect(
     localB.searchVoters({
       firstName: 'Bob',
+      middleName: '',
       lastName: '',
+      suffix: '',
       includeInactiveVoters: true,
     })
   ).toEqual([
@@ -788,17 +808,23 @@ test('late-arriving older event with a more recent undo', () => {
   // Verify Oscar is undone and Penny is checked in
   const oscarA = localA.searchVoters({
     firstName: 'Oscar',
+    middleName: '',
     lastName: '',
+    suffix: '',
     includeInactiveVoters: true,
   });
   const oscarB = localB.searchVoters({
     firstName: 'Oscar',
+    middleName: '',
     lastName: '',
+    suffix: '',
     includeInactiveVoters: true,
   });
   const oscarC = localC.searchVoters({
     firstName: 'Oscar',
+    middleName: '',
     lastName: '',
+    suffix: '',
     includeInactiveVoters: true,
   });
   expect((oscarA as Voter[])[0].checkIn).toBeUndefined();
@@ -807,17 +833,23 @@ test('late-arriving older event with a more recent undo', () => {
 
   const pennyA = localA.searchVoters({
     firstName: 'Penny',
+    middleName: '',
     lastName: '',
+    suffix: '',
     includeInactiveVoters: true,
   });
   const pennyB = localB.searchVoters({
     firstName: 'Penny',
+    middleName: '',
     lastName: '',
+    suffix: '',
     includeInactiveVoters: true,
   });
   const pennyC = localC.searchVoters({
     firstName: 'Penny',
+    middleName: '',
     lastName: '',
+    suffix: '',
     includeInactiveVoters: true,
   });
   expect((pennyA as Voter[])[0].checkIn).toBeDefined();

--- a/apps/pollbook/backend/src/types.ts
+++ b/apps/pollbook/backend/src/types.ts
@@ -289,7 +289,9 @@ export type PollbookEvent =
 
 export interface VoterSearchParams {
   lastName: string;
+  middleName: string;
   firstName: string;
+  suffix: string;
   includeInactiveVoters: boolean;
 }
 

--- a/apps/pollbook/backend/src/voter_helpers.ts
+++ b/apps/pollbook/backend/src/voter_helpers.ts
@@ -7,11 +7,25 @@ export function getUpdatedVoterFirstName(voter: Voter): string {
   return voter.firstName;
 }
 
+export function getUpdatedVoterMiddleName(voter: Voter): string {
+  if (voter.nameChange) {
+    return voter.nameChange.middleName;
+  }
+  return voter.middleName;
+}
+
 export function getUpdatedVoterLastName(voter: Voter): string {
   if (voter.nameChange) {
     return voter.nameChange.lastName;
   }
   return voter.lastName;
+}
+
+export function getUpdatedVoterSuffix(voter: Voter): string {
+  if (voter.nameChange) {
+    return voter.nameChange.suffix;
+  }
+  return voter.suffix;
 }
 
 export function isVoterNameChangeValid(

--- a/apps/pollbook/frontend/src/voter_search_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_search_screen.tsx
@@ -67,7 +67,9 @@ export function createEmptySearchParams(
 ): VoterSearchParams {
   return {
     lastName: '',
+    middleName: '',
     firstName: '',
+    suffix: '',
     includeInactiveVoters,
   };
 }

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -18,6 +18,7 @@ import type {
   VoterCheckInError,
   VoterNameChangeRequest,
   VoterRegistrationRequest,
+  VoterSearchParams,
 } from '@votingworks/pollbook-backend';
 import {
   mockElectionManagerUser,
@@ -72,6 +73,18 @@ export function createMockVoter(
     party: 'UND',
     district: 'District',
     isInactive: false,
+  };
+}
+
+function getDefaultExpectedVoterSearchParams(
+  input: Partial<VoterSearchParams>
+): VoterSearchParams {
+  return {
+    firstName: input.firstName || '',
+    middleName: input.middleName || '',
+    lastName: input.lastName || '',
+    suffix: input.suffix || '',
+    includeInactiveVoters: input.includeInactiveVoters || false,
   };
 }
 
@@ -313,59 +326,35 @@ export function createApiMock() {
       });
     },
 
-    expectSearchVotersNull(input: {
-      firstName?: string;
-      lastName?: string;
-      includeInactiveVoters?: boolean;
-    }) {
+    expectSearchVotersNull(input: Partial<VoterSearchParams>) {
       mockApiClient.searchVoters.reset();
       mockApiClient.searchVoters
         .expectRepeatedCallsWith({
-          searchParams: {
-            firstName: input.firstName || '',
-            lastName: input.lastName || '',
-            includeInactiveVoters: input.includeInactiveVoters || false,
-          },
+          searchParams: getDefaultExpectedVoterSearchParams(input),
         })
         .resolves(null);
     },
 
     expectSearchVotersTooMany(
-      input: {
-        firstName?: string;
-        lastName?: string;
-        includeInactiveVoters?: boolean;
-      },
+      input: Partial<VoterSearchParams>,
       excessVoters: number
     ) {
       mockApiClient.searchVoters.reset();
       mockApiClient.searchVoters
         .expectRepeatedCallsWith({
-          searchParams: {
-            firstName: input.firstName || '',
-            lastName: input.lastName || '',
-            includeInactiveVoters: input.includeInactiveVoters || false,
-          },
+          searchParams: getDefaultExpectedVoterSearchParams(input),
         })
         .resolves(excessVoters);
     },
 
     expectSearchVotersWithResults(
-      input: {
-        firstName?: string;
-        lastName?: string;
-        includeInactiveVoters?: boolean;
-      },
+      input: Partial<VoterSearchParams>,
       voters: Voter[]
     ) {
       mockApiClient.searchVoters.reset();
       mockApiClient.searchVoters
         .expectRepeatedCallsWith({
-          searchParams: {
-            firstName: input.firstName || '',
-            lastName: input.lastName || '',
-            includeInactiveVoters: input.includeInactiveVoters || false,
-          },
+          searchParams: getDefaultExpectedVoterSearchParams(input),
         })
         .resolves(voters);
     },

--- a/libs/db/src/client.ts
+++ b/libs/db/src/client.ts
@@ -81,11 +81,19 @@ export class Client {
   /**
    * Builds and returns a new client whose data is kept in memory.
    */
-  static memoryClient(schemaPath?: string): Client {
+  static memoryClient(
+    schemaPath?: string,
+    connectionOptions?: DbConnectionOptions
+  ): Client {
+    debug(
+      'creating memory client with connectionOptions: %o',
+      connectionOptions
+    );
     const client = new Client(
       MEMORY_DB_PATH,
       new BaseLogger(LogSource.System),
-      schemaPath
+      schemaPath,
+      connectionOptions
     );
     client.create();
     return client;
@@ -102,7 +110,7 @@ export class Client {
   ): Client {
     const client = new Client(dbPath, logger, schemaPath, connectionOptions);
 
-    debug('creating client with connectionOptions: %o', connectionOptions);
+    debug('creating file client with connectionOptions: %o', connectionOptions);
 
     if (!schemaPath) {
       return client;


### PR DESCRIPTION
## Overview

* Adds `*_middle_name` and `*_suffix` fields to the `voters` table.
* Updates `findVoterWithName` and `searchVoters` to pass those fields. Behavior should be unchanged for both.
* `findVoterWithName` still applies events to the `voter` objects but does not use the events for name matching
* Currently the search frontend does not pass middle name or suffix
 
## Demo Video or Screenshot
Manual test of existing behavior:

https://github.com/user-attachments/assets/88b7e6ea-9c34-48b3-8968-4d8c676efef1



## Testing Plan
- updated tests
- added test that `findVoterWithName` does not find a match if middle name or suffix doesn't match

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
