### PR TITLE
Do not sync events across pollbooks when code version and/or precinct do not match

### DIFF
--- a/apps/pollbook/backend/src/app.test.ts
+++ b/apps/pollbook/backend/src/app.test.ts
@@ -76,7 +76,7 @@ test('getDeviceStatuses()', async () => {
       );
       workspace.store.setElectionAndVoters(
         electionDefinition,
-        'fake-package-hash',
+        'mock-package-hash',
         testStreets,
         testVoters
       );
@@ -121,7 +121,7 @@ test('check in a voter', async () => {
     );
     workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       testVoters
     );
@@ -206,7 +206,7 @@ test('register a voter', async () => {
     );
     workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       []
     );
@@ -301,7 +301,7 @@ test('register a voter - duplicate name', async () => {
     );
     workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       [createVoter('original', 'Dylan', `O'Brien`, 'Darren', 'I')]
     );
@@ -361,7 +361,7 @@ test('register a voter - invalid address', async () => {
     );
     workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       []
     );
@@ -406,7 +406,7 @@ test('change a voter name', async () => {
     );
     workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       testVoters
     );
@@ -494,7 +494,7 @@ test('undo a voter check-in', async () => {
     );
     workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       testVoters
     );
@@ -550,7 +550,7 @@ test('register a voter, change name and address, and check in', async () => {
       );
       workspace.store.setElectionAndVoters(
         electionDefinition,
-        'fake-package-hash',
+        'mock-package-hash',
         testStreets,
         []
       );
@@ -723,7 +723,7 @@ test('check in, change name, undo check-in, change address, and check in again',
     );
     workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       testVoters
     );
@@ -833,7 +833,7 @@ test('change a voter address with various formats', async () => {
     );
     workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       testVoters
     );
@@ -907,7 +907,7 @@ test('voter search ignores punctuation', async () => {
     );
     workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       testVoters
     );
@@ -1025,7 +1025,7 @@ test('programCard and unprogramCard', async () => {
   await withApp(async ({ localApiClient, auth: authApi, workspace }) => {
     workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       [],
       []
     );
@@ -1082,7 +1082,7 @@ test('mark a voter inactive', async () => {
     );
     workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       testVoters
     );

--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -1,6 +1,13 @@
 import * as grout from '@votingworks/grout';
 import express, { Application } from 'express';
-import { assertDefined, err, ok, Result, sleep } from '@votingworks/basics';
+import {
+  assert,
+  assertDefined,
+  err,
+  ok,
+  Result,
+  sleep,
+} from '@votingworks/basics';
 import {
   DEFAULT_SYSTEM_SETTINGS,
   Election,
@@ -203,8 +210,14 @@ function buildApi({ context, logger }: BuildAppParams) {
       store.setIsAbsenteeMode(input.isAbsenteeMode);
     },
 
-    setConfiguredPrecinct(input: { precinctId: string }): void {
-      store.setConfiguredPrecinct(input.precinctId);
+    setConfiguredPrecinct(input: { precinctId: string }): Result<void, Error> {
+      try {
+        store.setConfiguredPrecinct(input.precinctId);
+        return ok();
+      } catch (error) {
+        assert(error instanceof Error);
+        return err(error);
+      }
     },
 
     searchVoters(input: {

--- a/apps/pollbook/backend/src/app_config.test.ts
+++ b/apps/pollbook/backend/src/app_config.test.ts
@@ -191,7 +191,7 @@ test('setConfiguredPrecinct sets and getPollbookConfigurationInformation returns
     );
     workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       []
     );

--- a/apps/pollbook/backend/src/app_config.test.ts
+++ b/apps/pollbook/backend/src/app_config.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, afterEach, expect, test, vi, vitest } from 'vitest';
 import { Buffer } from 'node:buffer';
 import { err } from '@votingworks/basics';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
-import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import {
   mockElectionManagerAuth,
   mockSystemAdministratorAuth,
@@ -198,18 +197,17 @@ test('setConfiguredPrecinct sets and getPollbookConfigurationInformation returns
     );
     expect(config.configuredPrecinctId).toBeUndefined();
 
-    // Try to set a non-existent precinct and expect an error
-    await suppressingConsoleOutput(async () => {
-      await expect(
-        localApiClient.setConfiguredPrecinct({ precinctId: 'precinct-xyz' })
-      ).rejects.toThrow(
-        'Precinct with id precinct-xyz does not exist in the election'
-      );
+    const result = await localApiClient.setConfiguredPrecinct({
+      precinctId: 'precinct-xyz',
     });
+    expect(result.err()).toEqual(
+      new Error('Precinct with id precinct-xyz does not exist in the election')
+    );
 
-    await localApiClient.setConfiguredPrecinct({
+    const ok = await localApiClient.setConfiguredPrecinct({
       precinctId: electionDefinition.election.precincts[0].id,
     });
+    expect(ok.ok()).toEqual(undefined);
 
     // Now it should be returned
     config = await localApiClient.getPollbookConfigurationInformation();

--- a/apps/pollbook/backend/src/app_multi_node.test.ts
+++ b/apps/pollbook/backend/src/app_multi_node.test.ts
@@ -234,7 +234,7 @@ test('connection status between two pollbooks is managed properly', async () => 
     // Set the pollbooks for the same election and precinct
     pollbookContext1.workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       testVoters
     );
@@ -253,7 +253,7 @@ test('connection status between two pollbooks is managed properly', async () => 
 
     pollbookContext2.workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       testVoters
     );
@@ -511,7 +511,7 @@ test('connection status is managed properly with many pollbooks', async () => {
     for (const context of pollbookContexts) {
       context.workspace.store.setElectionAndVoters(
         electionDefinition,
-        'fake-package-hash',
+        'mock-package-hash',
         testStreets,
         testVoters
       );
@@ -560,7 +560,7 @@ test('connection status is managed properly with many pollbooks', async () => {
       context.workspace.store.deleteElectionAndVoters();
       context.workspace.store.setElectionAndVoters(
         electionDefinition,
-        `fake-package-hash-${i}`,
+        `mock-package-hash-${i}`,
         testStreets,
         testVoters
       );
@@ -695,7 +695,7 @@ test('pollbooks with different code versions can not connect', async () => {
       // Set the pollbooks for the same election and precinct
       pollbookContext1.workspace.store.setElectionAndVoters(
         electionDefinition,
-        'fake-package-hash',
+        'mock-package-hash',
         testStreets,
         testVoters
       );
@@ -704,7 +704,7 @@ test('pollbooks with different code versions can not connect', async () => {
       );
       pollbookContext2.workspace.store.setElectionAndVoters(
         electionDefinition,
-        'fake-package-hash',
+        'mock-package-hash',
         testStreets,
         testVoters
       );
@@ -844,7 +844,7 @@ test('pollbooks with different pollbook package hash values can not connect', as
     // Set the election with different pollbook package hash values
     pollbookContext1.workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash-1',
+      'mock-package-hash-1',
       testStreets,
       testVoters
     );
@@ -853,7 +853,7 @@ test('pollbooks with different pollbook package hash values can not connect', as
     );
     pollbookContext2.workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash-2',
+      'mock-package-hash-2',
       testStreets,
       testVoters
     );
@@ -991,13 +991,13 @@ test('pollbooks with different configured precinct values can not connect', asyn
     // Set the election without setting configured precinct should not connect
     pollbookContext1.workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       testVoters
     );
     pollbookContext2.workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       testVoters
     );
@@ -1114,7 +1114,7 @@ test('one pollbook can be configured from another pollbook', async () => {
     );
     pollbookContext1.workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       testVoters
     );
@@ -1227,7 +1227,7 @@ test('one pollbook can be configured from another pollbook automatically as an e
       );
       pollbookContext1.workspace.store.setElectionAndVoters(
         electionDefinition,
-        'fake-package-hash',
+        'mock-package-hash',
         testStreets,
         testVoters
       );

--- a/apps/pollbook/backend/src/app_networking.test.ts
+++ b/apps/pollbook/backend/src/app_networking.test.ts
@@ -1,0 +1,40 @@
+import { vi, expect, test, beforeEach } from 'vitest';
+import { execFile } from '@votingworks/backend';
+import { withApp } from '../test/app';
+import { AvahiService } from './avahi';
+
+vi.mock('./avahi.js', () => ({
+  hasOnlineInterface: vi.fn().mockResolvedValue(false),
+  AvahiService: {
+    advertiseHttpService: vi.fn().mockReturnValue(undefined),
+    stopAdvertisedService: vi.fn(),
+    discoverHttpServices: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock(import('@votingworks/backend'));
+const mockExecFileFn = vi.mocked(execFile);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+});
+
+test('resetNetwork calls resetNetworkSetup and AvahiService methods', async () => {
+  await withApp(async ({ localApiClient }) => {
+    // Call resetNetwork on the localApiClient
+    mockExecFileFn.mockResolvedValue({ stdout: '', stderr: '' });
+    void localApiClient.resetNetwork();
+    await vi.waitFor(() => {
+      expect(AvahiService.stopAdvertisedService).toHaveBeenCalled();
+    });
+
+    // Fast-forward timers to allow sleep(5000) to resolve
+    vi.advanceTimersByTime(5000);
+    expect(mockExecFileFn).toHaveBeenCalledWith('sudo', [
+      expect.stringContaining('reset-network'),
+    ]);
+
+    expect(AvahiService.advertiseHttpService).toHaveBeenCalled();
+  });
+});

--- a/apps/pollbook/backend/src/avahi.test.ts
+++ b/apps/pollbook/backend/src/avahi.test.ts
@@ -107,8 +107,9 @@ describe('AvahiService.discoverHttpServices', () => {
     expect(services).toEqual([]);
   });
 
-  it('ignores lines that are not resolved services', async () => {
-    const stdout = '+;lo;IPv4;something;Web Site;local\n';
+  it('ignores lines that are not resolved services or incomplete', async () => {
+    const stdout =
+      '+;lo;IPv4;something;Web Site;local\n=;host1.local;192.168.1.2;8080;';
     mockExecFileFn.mockResolvedValue({ stdout, stderr: '' });
     const result = await AvahiService.discoverHttpServices();
     expect(result).toEqual([]);

--- a/apps/pollbook/backend/src/avahi.ts
+++ b/apps/pollbook/backend/src/avahi.ts
@@ -43,14 +43,6 @@ export class AvahiService {
     ]);
 
     this.runningProcess = process;
-
-    process.stdout?.on('data', (data) => {
-      debug(`avahi-publish-service successful stdout: ${data}`);
-    });
-
-    process.stderr?.on('data', (data) => {
-      debug(`avahi-publish-service stderr: ${data}`);
-    });
   }
 
   /**

--- a/apps/pollbook/backend/src/local_store.test.ts
+++ b/apps/pollbook/backend/src/local_store.test.ts
@@ -24,7 +24,7 @@ test('findVotersWithName works as expected - voters without name changes', () =>
   const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];
   localStore.setElectionAndVoters(
     testElectionDefinition,
-    'fake-package-hash',
+    'mock-package-hash',
     streets,
     voters
   );
@@ -143,7 +143,7 @@ test('findVoterWithName works as expected - voters with name changes', () => {
   const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];
   localStore.setElectionAndVoters(
     testElectionDefinition,
-    'fake-package-hash',
+    'mock-package-hash',
     streets,
     voters
   );
@@ -263,7 +263,7 @@ test('registerVoter and findVoterWithName integration', () => {
   const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];
   localStore.setElectionAndVoters(
     testElectionDefinition,
-    'fake-package-hash',
+    'mock-package-hash',
     streets,
     []
   );
@@ -310,7 +310,7 @@ test('setElectionAndVoters sets configuredPrecinctId only when there is one prec
   const testElectionDefinition = getTestElectionDefinition();
   store.setElectionAndVoters(
     testElectionDefinition,
-    'fake-package-hash',
+    'mock-package-hash',
     [],
     []
   );
@@ -335,7 +335,7 @@ test('setElectionAndVoters sets configuredPrecinctId only when there is one prec
   store.deleteElectionAndVoters();
   store.setElectionAndVoters(
     singlePrecinctElectionDefinition,
-    'fake-package-hash',
+    'mock-package-hash',
     [],
     []
   );
@@ -357,7 +357,7 @@ test('store can load data from database on restart', () => {
   const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];
   localStore.setElectionAndVoters(
     testElectionDefinition,
-    'fake-package-hash',
+    'mock-package-hash',
     streets,
     voters
   );

--- a/apps/pollbook/backend/src/local_store.ts
+++ b/apps/pollbook/backend/src/local_store.ts
@@ -158,13 +158,6 @@ export class LocalStore extends Store {
     this.nextEventId = 0;
   }
 
-  hasEvents(): boolean {
-    const row = this.client.one(
-      'SELECT EXISTS(SELECT 1 FROM event_log LIMIT 1) as hasEvents'
-    ) as { hasEvents: number };
-    return row.hasEvents > 0;
-  }
-
   getIsAbsenteeMode(): boolean {
     const result = this.client.one(
       `

--- a/apps/pollbook/backend/src/networking.ts
+++ b/apps/pollbook/backend/src/networking.ts
@@ -215,10 +215,6 @@ export function setupMachineNetworking({
         const myMachineInformation =
           workspace.store.getPollbookConfigurationInformation();
         const services = await AvahiService.discoverHttpServices();
-        if (!services.length) {
-          debug('No services found on the network');
-          return;
-        }
         const previouslyConnected = workspace.store.getPollbookServicesByName();
         // If there are any services that were previously connected that no longer show up in avahi
         // Mark them as shut down

--- a/apps/pollbook/backend/src/peer_app.test.ts
+++ b/apps/pollbook/backend/src/peer_app.test.ts
@@ -46,7 +46,7 @@ test('getPollbookConfigurationInformation', async () => {
     );
     workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       testVoters
     );
@@ -57,7 +57,7 @@ test('getPollbookConfigurationInformation', async () => {
       electionBallotHash: electionDefinition.ballotHash,
       electionId: electionDefinition.election.id,
       electionTitle: electionDefinition.election.title,
-      pollbookPackageHash: 'fake-package-hash',
+      pollbookPackageHash: 'mock-package-hash',
       machineId: '0102',
     });
   });
@@ -87,7 +87,7 @@ test('GET /file/pollbook-package returns 404 if file does not exist, 200 if it d
 
     workspace.store.setElectionAndVoters(
       electionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       testStreets,
       testVoters
     );

--- a/apps/pollbook/backend/src/peer_app.ts
+++ b/apps/pollbook/backend/src/peer_app.ts
@@ -26,9 +26,13 @@ function buildApi(context: PeerAppContext) {
 
     getEvents(input: { lastEventSyncedPerNode: Record<string, number> }): {
       events: PollbookEvent[];
+      configurationInformation: PollbookConfigurationInformation;
       hasMore: boolean;
     } {
-      return store.getNewEvents(input.lastEventSyncedPerNode);
+      return {
+        ...store.getNewEvents(input.lastEventSyncedPerNode),
+        configurationInformation: store.getPollbookConfigurationInformation(),
+      };
     },
 
     unconfigure() {

--- a/apps/pollbook/backend/src/pollbook_package.ts
+++ b/apps/pollbook/backend/src/pollbook_package.ts
@@ -326,7 +326,8 @@ export function pollNetworkForPollbookPackage({
         const pollbooksOnNetwork = workspace.store.getPollbookServicesByName();
         const configuredPollbooks = Object.values(pollbooksOnNetwork).filter(
           (pollbook) =>
-            pollbook.status === PollbookConnectionStatus.WrongElection &&
+            pollbook.status ===
+              PollbookConnectionStatus.MismatchedConfiguration &&
             pollbook.electionId
         );
         if (configuredPollbooks.length === 0) {

--- a/apps/pollbook/backend/src/store.test.ts
+++ b/apps/pollbook/backend/src/store.test.ts
@@ -19,7 +19,7 @@ function setupTwoStores(): [PeerStore, PeerStore] {
   );
   const testElection = getTestElectionDefinition();
   for (const store of [store1, store2]) {
-    store.setElectionAndVoters(testElection, 'fake-package-hash', [], voters);
+    store.setElectionAndVoters(testElection, 'mock-package-hash', [], voters);
     store.setConfiguredPrecinct(testElection.election.precincts[0].id);
   }
   return [store1, store2];

--- a/apps/pollbook/backend/src/store.test.ts
+++ b/apps/pollbook/backend/src/store.test.ts
@@ -11,6 +11,20 @@ import { PeerStore } from './peer_store';
 export const myMachineId = 'machine-1';
 const otherMachineId = 'machine-2';
 
+function setupTwoStores(): [PeerStore, PeerStore] {
+  const store1 = PeerStore.memoryStore(myMachineId);
+  const store2 = PeerStore.memoryStore(otherMachineId);
+  const voters = Array.from({ length: 7 }, (_, i) =>
+    createVoter(`voter-${i}`, 'firstname', 'lastname')
+  );
+  const testElection = getTestElectionDefinition();
+  for (const store of [store1, store2]) {
+    store.setElectionAndVoters(testElection, 'fake-package-hash', [], voters);
+    store.setConfiguredPrecinct(testElection.election.precincts[0].id);
+  }
+  return [store1, store2];
+}
+
 test('getNewEvents returns events for unknown machines', () => {
   const store = PeerStore.memoryStore(myMachineId);
   const myHlcClock = new HybridLogicalClock(myMachineId);
@@ -145,17 +159,7 @@ test('getNewEvents returns no events for known machines and unknown machines', a
 });
 
 test('getNewEvents returns hasMore when there are more events from unknown machines', () => {
-  const store = PeerStore.memoryStore(myMachineId);
-  const store2 = PeerStore.memoryStore('machine-2');
-  const voters = Array.from({ length: 7 }, (_, i) =>
-    createVoter(`voter-${i}`, 'firstname', 'lastname')
-  );
-  store2.setElectionAndVoters(
-    getTestElectionDefinition(),
-    'fake-package-hash',
-    [],
-    voters
-  );
+  const [store, store2] = setupTwoStores();
 
   const theirClock = new HybridLogicalClock(otherMachineId);
   const events = Array.from({ length: 7 }, (_, i) =>
@@ -170,7 +174,10 @@ test('getNewEvents returns hasMore when there are more events from unknown machi
     store2.getMostRecentEventIdPerMachine(), // empty
     5
   );
-  store2.saveRemoteEvents(firstBatch);
+  store2.saveRemoteEvents(
+    firstBatch,
+    store.getPollbookConfigurationInformation()
+  );
 
   assert(firstBatch.length === 5);
   expect(firstBatch).toEqual(events.slice(0, 5));
@@ -191,17 +198,7 @@ test('getNewEvents returns hasMore when there are more events from unknown machi
 });
 
 test('getNewEvents returns hasMore when there are more events from known machines (no unknown machines)', () => {
-  const store = PeerStore.memoryStore(myMachineId);
-  const store2 = PeerStore.memoryStore('machine-2');
-  const voters = Array.from({ length: 7 }, (_, i) =>
-    createVoter(`voter-${i}`, 'firstname', 'lastname')
-  );
-  store2.setElectionAndVoters(
-    getTestElectionDefinition(),
-    'fake-package-hash',
-    [],
-    voters
-  );
+  const [store, store2] = setupTwoStores();
   const myClock = new HybridLogicalClock(myMachineId);
   const events = Array.from({ length: 7 }, (_, i) =>
     createVoterCheckInEvent(i, myMachineId, `voter-${i + 1}`, myClock.tick())
@@ -212,7 +209,10 @@ test('getNewEvents returns hasMore when there are more events from known machine
   }
 
   // Set up store2 to have synced the first event only from myMachineId
-  store2.saveRemoteEvents([events[0]]);
+  store2.saveRemoteEvents(
+    [events[0]],
+    store.getPollbookConfigurationInformation()
+  );
   expect(store2.getMostRecentEventIdPerMachine()).toEqual({ [myMachineId]: 0 });
 
   const { events: firstBatch, hasMore: firstHasMore } = store.getNewEvents(
@@ -224,7 +224,10 @@ test('getNewEvents returns hasMore when there are more events from known machine
   expect(firstBatch).toEqual(events.slice(1, 6));
   expect(firstHasMore).toEqual(true);
 
-  store2.saveRemoteEvents(firstBatch);
+  store2.saveRemoteEvents(
+    firstBatch,
+    store.getPollbookConfigurationInformation()
+  );
   expect(store2.getMostRecentEventIdPerMachine()).toEqual({ [myMachineId]: 5 });
 
   const { events: secondBatch, hasMore: secondHasMore } = store.getNewEvents(
@@ -238,17 +241,7 @@ test('getNewEvents returns hasMore when there are more events from known machine
 });
 
 test('getNewEvents returns hasMore when there are more events from known machines and unknown machines combined', () => {
-  const store = PeerStore.memoryStore(myMachineId);
-  const store2 = PeerStore.memoryStore('test-machine');
-  const voters = Array.from({ length: 10 }, (_, i) =>
-    createVoter(`voter-${i}`, 'firstname', 'lastname')
-  );
-  store2.setElectionAndVoters(
-    getTestElectionDefinition(),
-    'fake-package-hash',
-    [],
-    voters
-  );
+  const [store, store2] = setupTwoStores();
   const myClock = new HybridLogicalClock(myMachineId);
   const theirClock = new HybridLogicalClock(otherMachineId);
   const machine1Events = Array.from({ length: 4 }, (_, i) =>
@@ -271,7 +264,10 @@ test('getNewEvents returns hasMore when there are more events from known machine
   }
 
   // Set up store2 to have synced the first event only from myMachineId
-  store2.saveRemoteEvents([machine1Events[0]]);
+  store2.saveRemoteEvents(
+    [machine1Events[0]],
+    store.getPollbookConfigurationInformation()
+  );
   expect(store2.getMostRecentEventIdPerMachine()).toEqual({ [myMachineId]: 0 });
   const { events: firstBatch, hasMore: firstHasMore } = store.getNewEvents(
     store2.getMostRecentEventIdPerMachine(),
@@ -285,7 +281,10 @@ test('getNewEvents returns hasMore when there are more events from known machine
   ]);
   expect(firstHasMore).toEqual(true);
 
-  store2.saveRemoteEvents(firstBatch);
+  store2.saveRemoteEvents(
+    firstBatch,
+    store.getPollbookConfigurationInformation()
+  );
   expect(store2.getMostRecentEventIdPerMachine()).toEqual({
     [myMachineId]: 2,
     [otherMachineId]: 2,

--- a/apps/pollbook/backend/src/store_multi_node.test.ts
+++ b/apps/pollbook/backend/src/store_multi_node.test.ts
@@ -50,13 +50,13 @@ test('stores will not sync when not configured properly', () => {
   // Initialize both pollbooks with same election data
   localA.setElectionAndVoters(
     testElectionDefinition,
-    'fake-package-hash',
+    'mock-package-hash',
     [],
     testVoters
   );
   localB.setElectionAndVoters(
     testElectionDefinition,
-    'fake-package-hash',
+    'mock-package-hash',
     [],
     testVoters
   );
@@ -116,7 +116,7 @@ test('offline undo with later real time check in', async () => {
   for (const store of [localA, localB]) {
     store.setElectionAndVoters(
       testElectionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       [],
       testVoters
     );
@@ -227,7 +227,7 @@ test('bad system time nodes should be able to undo', () => {
   for (const store of [localA, localB]) {
     store.setElectionAndVoters(
       testElectionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       [],
       testVoters
     );
@@ -322,7 +322,7 @@ test("getting a offline machines events when I've synced with the online machine
   for (const store of [localA, localB, localC]) {
     store.setElectionAndVoters(
       testElectionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       [],
       testVoters
     );
@@ -471,7 +471,7 @@ test('last write wins on double check ins', async () => {
   for (const store of [localA, localB]) {
     store.setElectionAndVoters(
       testElectionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       [],
       testVoters
     );
@@ -555,7 +555,7 @@ test('last write wins even when there is bad system time after a sync', () => {
   for (const store of [localA, localB]) {
     store.setElectionAndVoters(
       testElectionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       [],
       testVoters
     );
@@ -676,7 +676,7 @@ test('simultaneous events are handled properly', () => {
   for (const store of [localA, localB, localC]) {
     store.setElectionAndVoters(
       testElectionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       [],
       testVoters
     );
@@ -734,7 +734,7 @@ test('late-arriving older event with a more recent undo', () => {
   for (const store of [localA, localB, localC]) {
     store.setElectionAndVoters(
       testElectionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       [],
       testVoters
     );
@@ -863,7 +863,7 @@ test('all possible events are synced', () => {
   for (const store of [localA, localB]) {
     store.setElectionAndVoters(
       testElectionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       streets,
       testVoters
     );
@@ -993,7 +993,7 @@ test('register on A, check in on B, name/address change on C, sync all', () => {
   for (const store of [localA, localB, localC]) {
     store.setElectionAndVoters(
       testElectionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       streets,
       []
     );
@@ -1077,7 +1077,7 @@ test('last write wins for name/address changes with bad system time after sync',
   for (const store of [localA, localB]) {
     store.setElectionAndVoters(
       testElectionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       streets,
       voters
     );
@@ -1188,7 +1188,7 @@ test('register, check in, then change name/address, sync', () => {
   for (const store of [localA, localB]) {
     store.setElectionAndVoters(
       testElectionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       streets,
       []
     );
@@ -1263,7 +1263,7 @@ test('simultaneous name/address changes, last write wins', async () => {
   for (const store of [localA, localB]) {
     store.setElectionAndVoters(
       testElectionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       streets,
       [voter]
     );
@@ -1334,7 +1334,7 @@ test('check in event on an offline machine BEFORE the mark inactive', async () =
   for (const store of [localA, localB]) {
     store.setElectionAndVoters(
       testElectionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       [],
       [voter]
     );
@@ -1376,7 +1376,7 @@ test('check in event on an offline machine AFTER the mark inactive', async () =>
   for (const store of [localA, localB]) {
     store.setElectionAndVoters(
       testElectionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       [],
       [voter]
     );
@@ -1419,7 +1419,7 @@ test('name/address change AFTER mark inactive on another machine get processed',
   for (const store of [localA, localB]) {
     store.setElectionAndVoters(
       testElectionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       streets,
       [voter]
     );
@@ -1480,7 +1480,7 @@ test('cannot check in after mark inactive event is synced', () => {
   for (const store of [localA, localB]) {
     store.setElectionAndVoters(
       testElectionDefinition,
-      'fake-package-hash',
+      'mock-package-hash',
       [],
       [voter]
     );

--- a/apps/pollbook/backend/src/store_multi_node.test.ts
+++ b/apps/pollbook/backend/src/store_multi_node.test.ts
@@ -34,6 +34,57 @@ function setupFileStores(machineId: string): [LocalStore, PeerStore] {
   return [localStore, peerStore];
 }
 
+test('stores will not sync when not configured properly', () => {
+  // Set up two pollbook nodes
+  const [localA, peerA] = setupFileStores('pollbook-a');
+  const [localB, peerB] = setupFileStores('pollbook-b');
+
+  // Set up test election and voters
+  const testElectionDefinition = getTestElectionDefinition();
+  const testVoters = [
+    createVoter('bob', 'Bob', 'Smith'),
+    createVoter('charlie', 'Charlie', 'Brown'),
+    createVoter('sue', 'Sue', 'Jones'),
+  ];
+
+  // Initialize both pollbooks with same election data
+  localA.setElectionAndVoters(
+    testElectionDefinition,
+    'fake-package-hash',
+    [],
+    testVoters
+  );
+  localB.setElectionAndVoters(
+    testElectionDefinition,
+    'fake-package-hash',
+    [],
+    testVoters
+  );
+
+  // Configure Pollbook A
+  localA.setConfiguredPrecinct(testElectionDefinition.election.precincts[0].id);
+  // Bob checks in on PollbookA
+  localA.recordVoterCheckIn({
+    voterId: 'bob',
+    identificationMethod: { type: 'default' },
+  });
+  expect(localA.getCheckInCount()).toEqual(1);
+  expect(peerA.getCheckInCount()).toEqual(1);
+
+  expect(syncEventsFromTo(peerA, peerB)).toHaveLength(0);
+
+  // Events still should not sync as the configured precinct does not match.
+  expect(syncEventsFromTo(peerA, peerB)).toHaveLength(0);
+
+  // Configure Pollbook B to a different precinct
+  localB.setConfiguredPrecinct(testElectionDefinition.election.precincts[1].id);
+  expect(syncEventsFromTo(peerA, peerB)).toHaveLength(0);
+
+  // Configure Pollbook B to the same precinct
+  localB.setConfiguredPrecinct(testElectionDefinition.election.precincts[0].id);
+  expect(syncEventsFromTo(peerA, peerB)).toHaveLength(1);
+});
+
 // Multi-Node test for the following scenario:
 // - PollbookA comes online
 // - PollbookB comes online
@@ -62,24 +113,17 @@ test('offline undo with later real time check in', async () => {
     createVoter('charlie', 'Charlie', 'Brown'),
     createVoter('sue', 'Sue', 'Jones'),
   ];
-
-  // Initialize both pollbooks with same election data
-  localA.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    testVoters
-  );
-  localB.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    testVoters
-  );
-
-  // Both pollbooks come online
-  peerA.setOnlineStatus(true);
-  peerB.setOnlineStatus(true);
+  for (const store of [localA, localB]) {
+    store.setElectionAndVoters(
+      testElectionDefinition,
+      'fake-package-hash',
+      [],
+      testVoters
+    );
+    store.setConfiguredPrecinct(
+      testElectionDefinition.election.precincts[0].id
+    );
+  }
 
   // Bob checks in on PollbookA
   localA.recordVoterCheckIn({
@@ -180,23 +224,17 @@ test('bad system time nodes should be able to undo', () => {
   const testElectionDefinition = getTestElectionDefinition();
   const testVoters = [createVoter('bob', 'Bob', 'Smith')];
 
-  // Initialize both pollbooks with same election data
-  localA.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    testVoters
-  );
-  localB.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    testVoters
-  );
-
-  // Both pollbooks come online
-  peerA.setOnlineStatus(true);
-  peerB.setOnlineStatus(true);
+  for (const store of [localA, localB]) {
+    store.setElectionAndVoters(
+      testElectionDefinition,
+      'fake-package-hash',
+      [],
+      testVoters
+    );
+    store.setConfiguredPrecinct(
+      testElectionDefinition.election.precincts[0].id
+    );
+  }
 
   // Set time to 9am for PollbookB's check-in
   const nineAm = new Date('2024-01-01T09:00:00Z').getTime();
@@ -281,30 +319,17 @@ test("getting a offline machines events when I've synced with the online machine
     createVoter('eve', 'Eve', 'Johnson'),
   ];
 
-  // Initialize all pollbooks with same election data
-  localA.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    testVoters
-  );
-  localB.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    testVoters
-  );
-  localC.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    testVoters
-  );
-
-  // All pollbooks come online
-  peerA.setOnlineStatus(true);
-  peerB.setOnlineStatus(true);
-  peerC.setOnlineStatus(true);
+  for (const store of [localA, localB, localC]) {
+    store.setElectionAndVoters(
+      testElectionDefinition,
+      'fake-package-hash',
+      [],
+      testVoters
+    );
+    store.setConfiguredPrecinct(
+      testElectionDefinition.election.precincts[0].id
+    );
+  }
 
   // Alice checks in on PollbookA
   localA.recordVoterCheckIn({
@@ -443,21 +468,17 @@ test('last write wins on double check ins', async () => {
     createVoter('sue', 'Sue', 'Jones'),
   ];
 
-  localA.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    testVoters
-  );
-  localB.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    testVoters
-  );
-
-  peerA.setOnlineStatus(true);
-  peerB.setOnlineStatus(true);
+  for (const store of [localA, localB]) {
+    store.setElectionAndVoters(
+      testElectionDefinition,
+      'fake-package-hash',
+      [],
+      testVoters
+    );
+    store.setConfiguredPrecinct(
+      testElectionDefinition.election.precincts[0].id
+    );
+  }
 
   localA.recordVoterCheckIn({
     voterId: 'bob',
@@ -531,23 +552,17 @@ test('last write wins even when there is bad system time after a sync', () => {
   const testElectionDefinition = getTestElectionDefinition();
   const testVoters = [createVoter('bob', 'Bob', 'Smith')];
 
-  // Initialize both pollbooks with same election data
-  localA.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    testVoters
-  );
-  localB.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    testVoters
-  );
-
-  // Both pollbooks come online
-  peerA.setOnlineStatus(true);
-  peerB.setOnlineStatus(true);
+  for (const store of [localA, localB]) {
+    store.setElectionAndVoters(
+      testElectionDefinition,
+      'fake-package-hash',
+      [],
+      testVoters
+    );
+    store.setConfiguredPrecinct(
+      testElectionDefinition.election.precincts[0].id
+    );
+  }
 
   // Set time to 9am for PollbookB's check-in
   const nineAm = new Date('2024-01-01T09:00:00Z').getTime();
@@ -658,30 +673,17 @@ test('simultaneous events are handled properly', () => {
     createVoter('sue', 'Sue', 'Jones'),
   ];
 
-  // Initialize both pollbooks with same election data
-  localA.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    testVoters
-  );
-  localB.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    testVoters
-  );
-  localC.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    testVoters
-  );
-
-  // Both pollbooks come online
-  peerA.setOnlineStatus(true);
-  peerB.setOnlineStatus(true);
-  peerC.setOnlineStatus(true);
+  for (const store of [localA, localB, localC]) {
+    store.setElectionAndVoters(
+      testElectionDefinition,
+      'fake-package-hash',
+      [],
+      testVoters
+    );
+    store.setConfiguredPrecinct(
+      testElectionDefinition.election.precincts[0].id
+    );
+  }
 
   // Charlie checks in and then is undone on pollbookA
   localA.recordVoterCheckIn({
@@ -729,29 +731,17 @@ test('late-arriving older event with a more recent undo', () => {
     createVoter('penny', 'Penny', 'Lane'),
   ];
 
-  // Initialize all pollbooks with same election data
-  localA.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    testVoters
-  );
-  localB.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    testVoters
-  );
-  localC.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    testVoters
-  );
-
-  // Pollbook A and B come online
-  peerA.setOnlineStatus(true);
-  peerB.setOnlineStatus(true);
+  for (const store of [localA, localB, localC]) {
+    store.setElectionAndVoters(
+      testElectionDefinition,
+      'fake-package-hash',
+      [],
+      testVoters
+    );
+    store.setConfiguredPrecinct(
+      testElectionDefinition.election.precincts[0].id
+    );
+  }
 
   // Oscar checks in on PollbookB
   localB.recordVoterCheckIn({
@@ -868,24 +858,19 @@ test('all possible events are synced', () => {
     createVoter('oscar', 'Oscar', 'Wilde'),
     createVoter('penny', 'Penny', 'Lane'),
   ];
+  const streets = [createValidStreetInfo('MAIN ST', 'odd', 1, 15)];
 
-  // Initialize all pollbooks with same election data
-  localA.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [createValidStreetInfo('MAIN ST', 'odd', 1, 15)],
-    testVoters
-  );
-  localB.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [createValidStreetInfo('MAIN ST', 'odd', 1, 15)],
-    testVoters
-  );
-
-  // Pollbook A and B come online
-  peerA.setOnlineStatus(true);
-  peerB.setOnlineStatus(true);
+  for (const store of [localA, localB]) {
+    store.setElectionAndVoters(
+      testElectionDefinition,
+      'fake-package-hash',
+      streets,
+      testVoters
+    );
+    store.setConfiguredPrecinct(
+      testElectionDefinition.election.precincts[0].id
+    );
+  }
 
   const nameChangeData: VoterNameChangeRequest = {
     firstName: 'Ozcar',
@@ -1004,27 +989,18 @@ test('register on A, check in on B, name/address change on C, sync all', () => {
   const [localC, peerC] = setupFileStores('pollbook-c');
   const testElectionDefinition = getTestElectionDefinition();
   const streets = [createValidStreetInfo('MAIN', 'even', 2, 10)];
-  localA.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    streets,
-    []
-  );
-  localB.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    streets,
-    []
-  );
-  localC.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    streets,
-    []
-  );
-  peerA.setOnlineStatus(true);
-  peerB.setOnlineStatus(true);
-  peerC.setOnlineStatus(true);
+
+  for (const store of [localA, localB, localC]) {
+    store.setElectionAndVoters(
+      testElectionDefinition,
+      'fake-package-hash',
+      streets,
+      []
+    );
+    store.setConfiguredPrecinct(
+      testElectionDefinition.election.precincts[0].id
+    );
+  }
 
   // Register voter on A
   const { voter } = localA.registerVoter({
@@ -1097,20 +1073,18 @@ test('last write wins for name/address changes with bad system time after sync',
     createVoter('tia', 'Tia', 'Traveler'),
   ];
   const streets = [createValidStreetInfo('MAPLE', 'even', 2, 400)];
-  localA.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    streets,
-    voters
-  );
-  localB.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    streets,
-    voters
-  );
-  peerA.setOnlineStatus(true);
-  peerB.setOnlineStatus(true);
+
+  for (const store of [localA, localB]) {
+    store.setElectionAndVoters(
+      testElectionDefinition,
+      'fake-package-hash',
+      streets,
+      voters
+    );
+    store.setConfiguredPrecinct(
+      testElectionDefinition.election.precincts[0].id
+    );
+  }
   // Name change on A at 9am
   const nineAm = new Date('2024-01-01T09:00:00Z').getTime();
   vi.setSystemTime(nineAm);
@@ -1210,20 +1184,18 @@ test('register, check in, then change name/address, sync', () => {
   const [localB, peerB] = setupFileStores('pollbook-b');
   const testElectionDefinition = getTestElectionDefinition();
   const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];
-  localA.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    streets,
-    []
-  );
-  localB.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    streets,
-    []
-  );
-  peerA.setOnlineStatus(true);
-  peerB.setOnlineStatus(true);
+
+  for (const store of [localA, localB]) {
+    store.setElectionAndVoters(
+      testElectionDefinition,
+      'fake-package-hash',
+      streets,
+      []
+    );
+    store.setConfiguredPrecinct(
+      testElectionDefinition.election.precincts[0].id
+    );
+  }
   // Register on A
   const { voter } = localA.registerVoter({
     firstName: 'Sam',
@@ -1287,20 +1259,18 @@ test('simultaneous name/address changes, last write wins', async () => {
   const testElectionDefinition = getTestElectionDefinition();
   const voter = createVoter('sim', 'Sim', 'Multi');
   const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];
-  localA.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    streets,
-    [voter]
-  );
-  localB.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    streets,
-    [voter]
-  );
-  peerA.setOnlineStatus(true);
-  peerB.setOnlineStatus(true);
+
+  for (const store of [localA, localB]) {
+    store.setElectionAndVoters(
+      testElectionDefinition,
+      'fake-package-hash',
+      streets,
+      [voter]
+    );
+    store.setConfiguredPrecinct(
+      testElectionDefinition.election.precincts[0].id
+    );
+  }
   // Name change on A
   localA.changeVoterName('sim', {
     firstName: 'Simone',
@@ -1360,20 +1330,18 @@ test('check in event on an offline machine BEFORE the mark inactive', async () =
   const [localB, peerB] = setupFileStores('pollbook-b');
   const testElectionDefinition = getTestElectionDefinition();
   const voter = createVoter('mia', 'Mia', 'Inactive');
-  localA.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    [voter]
-  );
-  localB.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    [voter]
-  );
-  peerA.setOnlineStatus(true);
-  peerB.setOnlineStatus(true);
+
+  for (const store of [localA, localB]) {
+    store.setElectionAndVoters(
+      testElectionDefinition,
+      'fake-package-hash',
+      [],
+      [voter]
+    );
+    store.setConfiguredPrecinct(
+      testElectionDefinition.election.precincts[0].id
+    );
+  }
   // Sync initial state
   syncEventsForAllPollbooks([peerA, peerB]);
   // PollbookB goes offline
@@ -1404,20 +1372,18 @@ test('check in event on an offline machine AFTER the mark inactive', async () =>
   const [localB, peerB] = setupFileStores('pollbook-b');
   const testElectionDefinition = getTestElectionDefinition();
   const voter = createVoter('nia', 'Nia', 'Inactive');
-  localA.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    [voter]
-  );
-  localB.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    [voter]
-  );
-  peerA.setOnlineStatus(true);
-  peerB.setOnlineStatus(true);
+
+  for (const store of [localA, localB]) {
+    store.setElectionAndVoters(
+      testElectionDefinition,
+      'fake-package-hash',
+      [],
+      [voter]
+    );
+    store.setConfiguredPrecinct(
+      testElectionDefinition.election.precincts[0].id
+    );
+  }
   syncEventsForAllPollbooks([peerA, peerB]);
 
   // PollbookB goes offline
@@ -1449,20 +1415,19 @@ test('name/address change AFTER mark inactive on another machine get processed',
   const [localB, peerB] = setupFileStores('pollbook-b');
   const testElectionDefinition = getTestElectionDefinition();
   const voter = createVoter('kai', 'Kai', 'Inactive');
-  localA.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    streets,
-    [voter]
-  );
-  localB.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    streets,
-    [voter]
-  );
-  peerA.setOnlineStatus(true);
-  peerB.setOnlineStatus(true);
+
+  for (const store of [localA, localB]) {
+    store.setElectionAndVoters(
+      testElectionDefinition,
+      'fake-package-hash',
+      streets,
+      [voter]
+    );
+    store.setConfiguredPrecinct(
+      testElectionDefinition.election.precincts[0].id
+    );
+  }
+
   syncEventsForAllPollbooks([peerA, peerB]);
 
   // Pollbook B offline
@@ -1512,20 +1477,17 @@ test('cannot check in after mark inactive event is synced', () => {
   const [localB, peerB] = setupFileStores('pollbook-b');
   const testElectionDefinition = getTestElectionDefinition();
   const voter = createVoter('ina', 'Ina', 'Active');
-  localA.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    [voter]
-  );
-  localB.setElectionAndVoters(
-    testElectionDefinition,
-    'fake-package-hash',
-    [],
-    [voter]
-  );
-  peerA.setOnlineStatus(true);
-  peerB.setOnlineStatus(true);
+  for (const store of [localA, localB]) {
+    store.setElectionAndVoters(
+      testElectionDefinition,
+      'fake-package-hash',
+      [],
+      [voter]
+    );
+    store.setConfiguredPrecinct(
+      testElectionDefinition.election.precincts[0].id
+    );
+  }
   syncEventsForAllPollbooks([peerA, peerB]);
   // Mark inactive on A
   localA.markVoterInactive('ina');

--- a/apps/pollbook/backend/src/types.ts
+++ b/apps/pollbook/backend/src/types.ts
@@ -392,7 +392,7 @@ export enum PollbookConnectionStatus {
   Connected = 'Connected',
   ShutDown = 'ShutDown',
   LostConnection = 'LostConnection',
-  WrongElection = 'WrongElection',
+  MismatchedConfiguration = 'MismatchedConfiguration',
 }
 
 export interface EventDbRow {

--- a/apps/pollbook/backend/test/app.ts
+++ b/apps/pollbook/backend/test/app.ts
@@ -37,7 +37,7 @@ import { buildPeerApp, PeerApi } from '../src/peer_app';
 
 export const TEST_MACHINE_ID = '0102';
 
-interface TestContext {
+export interface TestContext {
   auth: DippedSmartCardAuthApi;
   workspace: LocalWorkspace;
   peerWorkspace: PeerWorkspace;

--- a/apps/pollbook/backend/test/app.ts
+++ b/apps/pollbook/backend/test/app.ts
@@ -190,13 +190,17 @@ export async function withApp(
  */
 export async function withManyApps(
   n: number,
-  fn: (contexts: TestContext[]) => Promise<void>
+  fn: (contexts: TestContext[]) => Promise<void>,
+  setUniqueCodeVersions: boolean = false
 ): Promise<void> {
   const contexts: TestContext[] = [];
-  const codeVersion = process.env.VX_CODE_VERSION || 'test';
 
   try {
     for (let i = 0; i < n; i += 1) {
+      const codeVersion = setUniqueCodeVersions
+        ? `test-${i}`
+        : process.env.VX_CODE_VERSION || 'test';
+
       const auth = buildMockDippedSmartCardAuth(vi.fn);
       const workspacePath = tmp.dirSync().name;
       const peerWorkspace = createPeerWorkspace(

--- a/apps/pollbook/backend/test/test_helpers.ts
+++ b/apps/pollbook/backend/test/test_helpers.ts
@@ -208,7 +208,7 @@ export function setupTestElectionAndVoters(store: Store): void {
   ];
   store.setElectionAndVoters(
     testElectionDefinition,
-    'fake-package-hash',
+    'mock-package-hash',
     testStreetInfo,
     testVoters
   );

--- a/apps/pollbook/backend/vitest.config.ts
+++ b/apps/pollbook/backend/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 85.63,
-        branches: 80,
+        lines: 87.5,
+        branches: 80.7,
       },
       exclude: [
         '**/node_modules/**',

--- a/apps/pollbook/frontend/src/election_manager_screen.test.tsx
+++ b/apps/pollbook/frontend/src/election_manager_screen.test.tsx
@@ -132,4 +132,30 @@ describe('SettingsScreen precinct selection', () => {
     const select = screen.queryByLabelText('Select Precinct');
     expect(select).toBeNull();
   });
+
+  test('handles error when setting precinct by disabling', async () => {
+    const { precincts } = electionDefFamousNames.election;
+    // Render
+    const renderResult = renderInAppContext(<ElectionManagerScreen />, {
+      apiMock,
+    });
+    unmount = renderResult.unmount;
+
+    // Wait for the SearchSelect to appear with the correct value
+    const select = await screen.findByLabelText('Select Precinct');
+    expect(select).toBeInTheDocument();
+    expect((select as HTMLSelectElement).disabled).toBeFalsy();
+
+    apiMock.expectSetConfiguredPrecinct(precincts[1].id, new Error('test'));
+
+    userEvent.click(screen.getByText('Select Precinct…'));
+    userEvent.click(screen.getByText(precincts[1].name));
+
+    const selectDisabled = await screen.findByLabelText('Select Precinct');
+    expect(selectDisabled).toBeInTheDocument();
+    expect((selectDisabled as HTMLSelectElement).disabled).toBeTruthy();
+    screen.getByText(
+      /The precinct setting cannot be changed because a voter was checked-in or voter data was updated/
+    );
+  });
 });

--- a/apps/pollbook/frontend/src/nav_screen.test.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.test.tsx
@@ -20,7 +20,7 @@ const mockPollbookService: PollbookServiceInfo = {
   electionTitle: 'Test Election',
   machineId: 'TEST',
   lastSeen: new Date('2025-01-01'),
-  status: PollbookConnectionStatus.WrongElection,
+  status: PollbookConnectionStatus.MismatchedConfiguration,
   numCheckIns: 0,
   codeVersion: 'test',
 };
@@ -77,7 +77,7 @@ test('renders network status as expected', async () => {
     },
     {
       ...mockPollbookService,
-      status: PollbookConnectionStatus.WrongElection,
+      status: PollbookConnectionStatus.MismatchedConfiguration,
       machineId: '0004',
     },
     {

--- a/apps/pollbook/frontend/src/nav_screen.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.tsx
@@ -154,7 +154,7 @@ function NetworkStatus({ status }: { status: NetworkStatus }) {
                             <Icons.Warning color="inverseWarning" />
                           )}
                           {pollbook.status ===
-                            PollbookConnectionStatus.WrongElection && (
+                            PollbookConnectionStatus.MismatchedConfiguration && (
                             <Icons.X color="danger" />
                           )}
                         </td>

--- a/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
+++ b/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
@@ -23,7 +23,7 @@ const mockPollbookService: PollbookServiceInfo = {
   electionTitle: 'Test Election',
   machineId: 'TEST',
   lastSeen: new Date('2025-01-01'),
-  status: PollbookConnectionStatus.WrongElection,
+  status: PollbookConnectionStatus.MismatchedConfiguration,
   numCheckIns: 0,
   codeVersion: 'test',
 };
@@ -93,7 +93,7 @@ describe('Election tab', () => {
       {
         ...mockPollbookService,
         machineId: 'TEST-01',
-        status: PollbookConnectionStatus.WrongElection,
+        status: PollbookConnectionStatus.MismatchedConfiguration,
       },
       {
         ...mockPollbookService,
@@ -108,7 +108,7 @@ describe('Election tab', () => {
       {
         ...mockPollbookService,
         machineId: 'TEST-04',
-        status: PollbookConnectionStatus.WrongElection,
+        status: PollbookConnectionStatus.MismatchedConfiguration,
         pollbookPackageHash: 'different-pollbook-hash',
         electionTitle: 'Bad Election',
       },

--- a/apps/pollbook/frontend/src/types.ts
+++ b/apps/pollbook/frontend/src/types.ts
@@ -2,5 +2,5 @@ export enum PollbookConnectionStatus {
   Connected = 'Connected',
   ShutDown = 'ShutDown',
   LostConnection = 'LostConnection',
-  WrongElection = 'WrongElection',
+  MismatchedConfiguration = 'MismatchedConfiguration',
 }

--- a/apps/pollbook/frontend/src/unconfigured_screen.tsx
+++ b/apps/pollbook/frontend/src/unconfigured_screen.tsx
@@ -120,7 +120,9 @@ export function UnconfiguredSystemAdminScreen(): JSX.Element {
     : getDevicesQuery.data.network;
 
   const configuredPollbooks = pollbooks.filter(
-    (p) => p.electionId && p.status === PollbookConnectionStatus.WrongElection
+    (p) =>
+      p.electionId &&
+      p.status === PollbookConnectionStatus.MismatchedConfiguration
   );
   const hasError =
     hadConfigurationError || electionResult.err() === 'usb-configuration-error';

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -292,17 +292,19 @@ export function createApiMock() {
         });
     },
 
-    expectSetConfiguredPrecinct(configuredPrecinctId: string) {
+    expectSetConfiguredPrecinct(configuredPrecinctId: string, error?: Error) {
       mockApiClient.setConfiguredPrecinct
         .expectCallWith({ precinctId: configuredPrecinctId })
-        .resolves();
-      mockApiClient.getPollbookConfigurationInformation.reset();
-      mockApiClient.getPollbookConfigurationInformation
-        .expectOptionalRepeatedCallsWith()
-        .resolves({
-          ...machineConfig,
-          configuredPrecinctId,
-        });
+        .resolves(error === undefined ? ok() : err(error));
+      if (error === undefined) {
+        mockApiClient.getPollbookConfigurationInformation.reset();
+        mockApiClient.getPollbookConfigurationInformation
+          .expectOptionalRepeatedCallsWith()
+          .resolves({
+            ...machineConfig,
+            configuredPrecinctId,
+          });
+      }
     },
 
     setElectionConfiguration(status: ConfigurationStatus) {


### PR DESCRIPTION
## Overview
Updates pollbook connection logic to only share events when the code version and precinct match, along with the previous blockers. Also in rethinking the potential race conditions and edge cases here added two more stricter checks (see commits 2 and 3 respectively):

- Checks in the same transaction when setting precinct that events do not exist and return an error to the frontend if they do. The frontend is already checking if events exist and disabling the button but its possible one could sneak in from another machine and this will prevent the write from saving if it happens. The UI handles the error by just disabling the button not showing a message, since this is never really expected to happen in the real world I think thats ok. 
- Returns the current pollbook configuration information with events when sending events to another machine. That machine then checks, in the same transaction, that that configuration matches its internal configuration before committing the events to its own db. This could prevent against a scenario where two pollbooks are connected/configured for Precinct 1. Pollbook-2 checks in Bob in Precinct-1, and I change to Precinct-2 right before I recieve that event from Pollbook-2. This will ensure that I realize the precinct mismatch and bail out before saving the Bob check in event. 

My goal in this PR was to get to 100% test coverage in networking.ts and avahi.ts so there are a few semi-unrelated tests added, some istanbul ignores, and some removal of unneeded lines of code (checking for impossible conditions, debugging remnants from the past, etc.) 

## Demo Video or Screenshot
N/A 

## Testing Plan
Ran tests, ensured 100% coverage of networking.ts

## Checklist

- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
