### PR TITLE
increase daemon connection timeout and reduce log spam

### DIFF
--- a/apps/pollbook/backend/src/barcode_scanner/socket_server.ts
+++ b/apps/pollbook/backend/src/barcode_scanner/socket_server.ts
@@ -12,7 +12,7 @@ import { AamvaDocumentSchema } from '../types';
 import { tryConnect } from './unix_socket';
 
 export const UDS_CONNECTION_ATTEMPT_DELAY_MS = 1000;
-export const UDS_CONNECTION_TIMEOUT_MS = 60 * 1000;
+export const UDS_CONNECTION_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour
 
 /**
  * Attempts to connect to the barcode scanner Unix socket within a retry loop.

--- a/apps/pollbook/backend/src/barcode_scanner/unix_socket.ts
+++ b/apps/pollbook/backend/src/barcode_scanner/unix_socket.ts
@@ -38,10 +38,12 @@ export function tryConnect(logger: Logger): Promise<net.Socket> {
 
     client.once('error', (err) => {
       const message = `Pollbook backend failed to connect to barcode scanner Unix socket: ${err.message}`;
-      logger.log(LogEventId.SocketClientConnected, 'system', {
-        message,
-        disposition: LogDispositionStandardTypes.Failure,
-      });
+      if (!err.message.match(/ECONNREFUSED/)) {
+        logger.log(LogEventId.SocketClientConnected, 'system', {
+          message,
+          disposition: LogDispositionStandardTypes.Failure,
+        });
+      }
 
       client.destroy();
       reject(new Error(message));


### PR DESCRIPTION
## Overview

* Increases the node backend's connection timeout to the daemon from 1 minute to 1 hour. Both are arbitrary, but 1 minute is inconvenient for development. In production, the daemon and server should start up at approximately the same time, and the daemon will be restarted on failure, so 1 minute or 1 hour will be sufficient.
* Only logs when we get an unexpected error when attempting to connect to the Unix socket. `ECONNREFUSED` is expected and typical when developing without hardware connected, so it was creating log spam.
 
## Demo Video or Screenshot
N/A

## Testing Plan
Manually tested logs are reduced
