### PR TITLE
[scan] Support both speaker and headphone audio in the HWTA

### DIFF
--- a/apps/scan/backend/src/electrical_testing/app.ts
+++ b/apps/scan/backend/src/electrical_testing/app.ts
@@ -5,7 +5,6 @@ import { SheetOf } from '@votingworks/types';
 import express, { Application } from 'express';
 import { mkdir, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { LogEventId } from '@votingworks/logging';
 import { getMachineConfig } from '../machine_config';
 import { type ServerContext } from './context';
 import { SoundName, Player as AudioPlayer } from '../audio/player';

--- a/apps/scan/backend/src/index.ts
+++ b/apps/scan/backend/src/index.ts
@@ -84,7 +84,7 @@ async function main(): Promise<number> {
       BooleanEnvironmentVariableName.ENABLE_ELECTRICAL_TESTING_MODE
     )
   ) {
-    startElectricalTestingServer({
+    await startElectricalTestingServer({
       auth,
       cardTask: TaskController.started<string>(),
       usbDriveTask: TaskController.started<string>(),

--- a/apps/scan/frontend/src/electrical_testing/api.ts
+++ b/apps/scan/frontend/src/electrical_testing/api.ts
@@ -144,3 +144,10 @@ export const getLatestScannedSheet = {
     );
   },
 } as const;
+
+export const playSound = {
+  useMutation() {
+    const apiClient = useApiClient();
+    return useMutation(apiClient.playSound);
+  },
+} as const;


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6484

- Mirroring the prod app setup to detect and configure both the builtin and USB audio devices.
  - Not hard-failing when audio configuration fails like we do in prod, since it's helpful to just log and degrade functionality in this case.
- Adding controls for playing audio separately through the speaker and/or the headphones (via USB audio).

## Demo Video or Screenshot

![scan-hwta-dual-audio](https://github.com/user-attachments/assets/be63f7ff-748c-4af9-8f43-8c6f297aff8f)

## Testing Plan
- Manual

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
