### PR TITLE
Do not allow configuration over the network between machines with incompatible code versions

### DIFF
--- a/apps/pollbook/backend/src/networking.ts
+++ b/apps/pollbook/backend/src/networking.ts
@@ -120,6 +120,7 @@ export function fetchEventsFromConnectedPollbooks({
         await Promise.all(
           pollbooksToQuery.map(async (currentName) => {
             const currentPollbookService = previouslyConnected[currentName];
+            /* istanbul ignore next - extremely unlikely scenario, a machine would need to change code versions to trigger included for defense in depth - @preserve */
             if (
               !arePollbooksCompatible(
                 myMachineInformation,

--- a/apps/pollbook/backend/src/networking.ts
+++ b/apps/pollbook/backend/src/networking.ts
@@ -52,8 +52,15 @@ export function createPeerApiClientForAddress(
   });
 }
 
+export function arePollbooksCompatible(
+  pollbook1: PollbookConfigurationInformation,
+  pollbook2: PollbookConfigurationInformation
+): boolean {
+  return pollbook1.codeVersion === pollbook2.codeVersion;
+}
+
 /* Checks that two pollbooks have compatible configurations to connect and share events */
-export function shouldPollbooksConnect(
+export function shouldPollbooksShareEvents(
   pollbook1: PollbookConfigurationInformation,
   pollbook2: PollbookConfigurationInformation
 ): boolean {
@@ -63,7 +70,7 @@ export function shouldPollbooksConnect(
     pollbook1.pollbookPackageHash === pollbook2.pollbookPackageHash &&
     !!pollbook1.configuredPrecinctId &&
     pollbook1.configuredPrecinctId === pollbook2.configuredPrecinctId &&
-    pollbook1.codeVersion === pollbook2.codeVersion
+    arePollbooksCompatible(pollbook1, pollbook2)
   );
 }
 
@@ -114,7 +121,20 @@ export function fetchEventsFromConnectedPollbooks({
           pollbooksToQuery.map(async (currentName) => {
             const currentPollbookService = previouslyConnected[currentName];
             if (
-              !shouldPollbooksConnect(
+              !arePollbooksCompatible(
+                myMachineInformation,
+                currentPollbookService
+              )
+            ) {
+              workspace.store.setPollbookServiceForName(currentName, {
+                ...currentPollbookService,
+                lastSeen: new Date(),
+                status: PollbookConnectionStatus.IncompatibleSoftwareVersion,
+              });
+              return;
+            }
+            if (
+              !shouldPollbooksShareEvents(
                 myMachineInformation,
                 currentPollbookService
               )
@@ -269,7 +289,22 @@ export function setupMachineNetworking({
               continue;
             }
             if (
-              !shouldPollbooksConnect(myMachineInformation, machineInformation)
+              !arePollbooksCompatible(myMachineInformation, machineInformation)
+            ) {
+              workspace.store.setPollbookServiceForName(name, {
+                ...machineInformation,
+                apiClient,
+                address: `http://${resolvedIp}:${port}`,
+                lastSeen: new Date(),
+                status: PollbookConnectionStatus.IncompatibleSoftwareVersion,
+              });
+              continue;
+            }
+            if (
+              !shouldPollbooksShareEvents(
+                myMachineInformation,
+                machineInformation
+              )
             ) {
               workspace.store.setPollbookServiceForName(name, {
                 ...machineInformation,

--- a/apps/pollbook/backend/src/types.ts
+++ b/apps/pollbook/backend/src/types.ts
@@ -393,6 +393,7 @@ export enum PollbookConnectionStatus {
   ShutDown = 'ShutDown',
   LostConnection = 'LostConnection',
   MismatchedConfiguration = 'MismatchedConfiguration',
+  IncompatibleSoftwareVersion = 'IncompatibleSoftwareVersion',
 }
 
 export interface EventDbRow {


### PR DESCRIPTION
## Overview
Follow-up and depends on: https://github.com/votingworks/vxsuite/pull/6643

We want to block configuration over the network when the code version is incompatible, and we will (in the next task) have a somewhat different UI treatment for that situation compared to the rest of the possible of reasons to end up in "MismatchedConfiguration." So this updates the implementation to create a seperate enum value IncompatibleSoftwareVersion and updates the networked configuration code in the backend to make sure we are only configuring from machines in "MismatchedConfiguration" 

The frontend is already only displayed pollbooks with the state MismatchedConfiguration in the UI to configure from so that will automatically now not show ones with wrong code versions. 
<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
N/A
## Testing Plan
Rant Tests
