### PR TITLE
ballot-encoder: Remove outdated sentence from docs

### DIFF
--- a/libs/ballot-encoder/README.md
+++ b/libs/ballot-encoder/README.md
@@ -195,7 +195,7 @@ metadata `H` and election definition `ED`, `H` is encoded as follows:
   (`ED.ballotHash.slice(0, 20)`).
   - Size: `20 * 4` bits.
 - **Ballot Config:** The encoding of a `BallotConfig` derived from `H` and `ED`
-  goes here. Note: `ballotId` is never included in the config for HMPB.
+  goes here.
 
 ## Related Documentation
 


### PR DESCRIPTION
## Overview

This should have been removed in #6374.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
