### PR TITLE
chore(central-scan): unify `test:coverage` command

### DIFF
--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -25,7 +25,7 @@
     "start": "node ./build/index.js",
     "test": "is-ci test:ci test:watch",
     "test:ci": "TZ=America/Anchorage vitest run --coverage",
-    "test:coverage": "TZ=America/Anchorage vitest run --coverage",
+    "test:coverage": "TZ=America/Anchorage vitest --coverage",
     "test:watch": "TZ=America/Anchorage vitest",
     "type-check": "tsc --build"
   },


### PR DESCRIPTION
All the other packages use this command.
