### PR TITLE
apps/admin, libs/logging: Add log for mark scores distribution on cvr import

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -579,7 +579,8 @@ function buildApi({
           : input.path;
       const importResult = await importCastVoteRecords(
         store,
-        exportDirectoryPath
+        exportDirectoryPath,
+        logger
       );
       if (importResult.isErr()) {
         await logger.logAsCurrentRole(

--- a/apps/admin/backend/src/tabulation/full_results.test.ts
+++ b/apps/admin/backend/src/tabulation/full_results.test.ts
@@ -311,7 +311,8 @@ test('tabulateElectionResults - write-in handling', async () => {
 
   const importResult = await importCastVoteRecords(
     store,
-    castVoteRecordExport.asDirectoryPath()
+    castVoteRecordExport.asDirectoryPath(),
+    logger
   );
   const { id: fileId } = importResult.unsafeUnwrap();
   expect(store.getCastVoteRecordCountByFileId(fileId)).toEqual(184);
@@ -720,7 +721,8 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
   store.setCurrentElectionId(electionId);
   const importResult = await importCastVoteRecords(
     store,
-    castVoteRecordExport.asDirectoryPath()
+    castVoteRecordExport.asDirectoryPath(),
+    logger
   );
   const { id: fileId } = importResult.unsafeUnwrap();
   expect(store.getCastVoteRecordCountByFileId(fileId)).toEqual(184);

--- a/apps/admin/backend/src/util/cast_vote_records.ts
+++ b/apps/admin/backend/src/util/cast_vote_records.ts
@@ -134,7 +134,7 @@ export function formatMarkScoreDistributionForLog(
 ): string {
   return JSON.stringify(
     Object.fromEntries(
-      [...distribution].map(([start, count]) => [`${start.toFixed(2)}`, count])
+      [...distribution].map(([start, count]) => [start.toFixed(2), count])
     )
   );
 }

--- a/apps/admin/backend/src/util/cast_vote_records.ts
+++ b/apps/admin/backend/src/util/cast_vote_records.ts
@@ -91,3 +91,50 @@ export class CvrContestTagList {
     return Array.from(this.byContestId.values());
   }
 }
+
+/**
+ * For logging, used to track mark score distribution on cvr import
+ */
+export interface MarkScoreDistribution {
+  distribution: Map<number, number>;
+  total: number;
+}
+
+/**
+ * Updates the score distribution with a new set of cvr mark scores.
+ * Buckets are 0.01 increments, only recording marks with score <= 0.2.
+ */
+export function updateMarkScoreDistributionFromMarkScores(
+  scoreDist: MarkScoreDistribution,
+  markScores: Tabulation.MarkScores
+): void {
+  for (const contestMarkScores of Object.values(markScores)) {
+    for (const score of Object.values(contestMarkScores)) {
+      if (score > 0.0) {
+        // eslint-disable-next-line no-param-reassign
+        scoreDist.total += 1;
+        if (score <= 0.2) {
+          const bucket = Math.floor(score * 100) / 100;
+          scoreDist.distribution.set(
+            bucket,
+            (scoreDist.distribution.get(bucket) ?? 0) + 1
+          );
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Formats the score distribution for logging.
+ * i.e. "0.01": 15, "0.02": 100...
+ */
+export function formatMarkScoreDistributionForLog(
+  distribution: Map<number, number>
+): string {
+  return JSON.stringify(
+    Object.fromEntries(
+      [...distribution].map(([start, count]) => [`${start.toFixed(2)}`, count])
+    )
+  );
+}

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -302,6 +302,10 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)
 **Description:** Cast vote records are being imported from a USB drive.
 **Machines:** vx-admin
+### import-cast-vote-records-mark-score-distribution
+**Type:** [user-action](#user-action)
+**Description:** Cast vote records have been imported and the associated mark scores have been consolidated into a distribution map.
+**Machines:** vx-admin
 ### import-cast-vote-records-complete
 **Type:** [user-action](#user-action)
 **Description:** Cast vote records have been imported from a USB drive (or failed to be imported). Success or failure indicated by disposition.

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -499,6 +499,12 @@ eventType = "user-action"
 documentationMessage = "Cast vote records are being imported from a USB drive."
 restrictInDocumentationToApps = ["vx-admin"]
 
+[Events.ImportCastVoteRecordsMarkScoreDistribution]
+eventId = "import-cast-vote-records-mark-score-distribution"
+eventType = "user-action"
+documentationMessage = "Cast vote records have been imported and the associated mark scores have been consolidated into a distribution map."
+restrictInDocumentationToApps = ["vx-admin"]
+
 [Events.ImportCastVoteRecordsComplete]
 eventId = "import-cast-vote-records-complete"
 eventType = "user-action"

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -135,6 +135,7 @@ export enum LogEventId {
   SmartCardUnprogramComplete = 'smart-card-unprogram-complete',
   ListCastVoteRecordExportsOnUsbDrive = 'list-cast-vote-record-exports-on-usb-drive',
   ImportCastVoteRecordsInit = 'import-cast-vote-records-init',
+  ImportCastVoteRecordsMarkScoreDistribution = 'import-cast-vote-records-mark-score-distribution',
   ImportCastVoteRecordsComplete = 'import-cast-vote-records-complete',
   ClearImportedCastVoteRecordsInit = 'clear-imported-cast-vote-records-init',
   ClearImportedCastVoteRecordsComplete = 'clear-imported-cast-vote-records-complete',
@@ -701,6 +702,14 @@ const ImportCastVoteRecordsInit: LogDetails = {
   eventType: LogEventType.UserAction,
   documentationMessage:
     'Cast vote records are being imported from a USB drive.',
+  restrictInDocumentationToApps: [AppName.VxAdmin],
+};
+
+const ImportCastVoteRecordsMarkScoreDistribution: LogDetails = {
+  eventId: LogEventId.ImportCastVoteRecordsMarkScoreDistribution,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'Cast vote records have been imported and the associated mark scores have been consolidated into a distribution map.',
   restrictInDocumentationToApps: [AppName.VxAdmin],
 };
 
@@ -1456,6 +1465,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return ListCastVoteRecordExportsOnUsbDrive;
     case LogEventId.ImportCastVoteRecordsInit:
       return ImportCastVoteRecordsInit;
+    case LogEventId.ImportCastVoteRecordsMarkScoreDistribution:
+      return ImportCastVoteRecordsMarkScoreDistribution;
     case LogEventId.ImportCastVoteRecordsComplete:
       return ImportCastVoteRecordsComplete;
     case LogEventId.ClearImportedCastVoteRecordsInit:

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -253,6 +253,8 @@ pub enum EventId {
     ListCastVoteRecordExportsOnUsbDrive,
     #[serde(rename = "import-cast-vote-records-init")]
     ImportCastVoteRecordsInit,
+    #[serde(rename = "import-cast-vote-records-mark-score-distribution")]
+    ImportCastVoteRecordsMarkScoreDistribution,
     #[serde(rename = "import-cast-vote-records-complete")]
     ImportCastVoteRecordsComplete,
     #[serde(rename = "clear-imported-cast-vote-records-init")]


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6618

We want to better understand what thresholds would work well for marginal mark adjudication, so we are introducing a log that includes: 1) total marks (over 0.00 score) and 2) a distribution of low scores (0.2 and below) in 0.01 increments

## Demo Video or Screenshot

Example of a Scan import followed by a CentralScan:

![Screenshot 2025-06-18 at 1 09 48 PM](https://github.com/user-attachments/assets/40acca27-fe03-49bb-98c1-e4d6db74d707)

## Testing Plan

Automated tests and reviewed log

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
