### PR TITLE
[mark] Decrease QR code level when combined write-in char count is high

### DIFF
--- a/libs/ui/src/qrcode.tsx
+++ b/libs/ui/src/qrcode.tsx
@@ -9,9 +9,11 @@ const ResponsiveSvgWrapper = styled.div`
   }
 `;
 
+export type QrCodeLevel = 'L' | 'M' | 'Q' | 'H';
+
 export interface QrCodeProps {
   value: string;
-  level?: 'L' | 'M' | 'Q' | 'H';
+  level?: QrCodeLevel;
 }
 
 export function QrCode({ level = 'H', value }: QrCodeProps): JSX.Element {


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6486
https://github.com/votingworks/vxsuite/issues/6486

## Demo Video or Screenshot

With 20 contests and lots of long write-ins:

| QR Level H |  QR Level M |
|--|--|
| ![qr-level-H](https://github.com/user-attachments/assets/1836207f-642d-4d6e-85ab-fc8ebe819c5c) | ![qr-level-M](https://github.com/user-attachments/assets/5308e2d5-66ca-491f-866d-b8f32133846a) |

## Testing Plan
- New + existing unit tests
- Following up with tests on prod hardware later in the week/next week

## Checklist

<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
