### PR TITLE
Remove System Settings from Design App

### DIFF
--- a/apps/design/frontend/src/system_settings_screen.test.tsx
+++ b/apps/design/frontend/src/system_settings_screen.test.tsx
@@ -92,24 +92,15 @@ test('mark thresholds', async () => {
     electionRecord.systemSettings.markThresholds.marginal
   );
 
-  const bitonalThresholdInput = screen.getByRole('spinbutton', {
-    name: 'Scanner Bitonal Threshold',
-  });
-  expect(bitonalThresholdInput).toBeDisabled();
-  expect(bitonalThresholdInput).toHaveValue(null);
-
   userEvent.click(screen.getByRole('button', { name: 'Edit' }));
 
   // change from 0.07 to 0.08
   userEvent.type(definiteInput, '{backspace}8');
   // change from 0.05 to 0.06
   userEvent.type(marginalInput, '{backspace}6');
-  // change from unset to 50
-  userEvent.type(bitonalThresholdInput, '50');
 
   const updatedSystemSettings: SystemSettings = {
     ...DEFAULT_SYSTEM_SETTINGS,
-    bitonalThreshold: 50,
     markThresholds: {
       ...DEFAULT_SYSTEM_SETTINGS.markThresholds,
       definite: 0.08,
@@ -134,10 +125,6 @@ test('mark thresholds', async () => {
     updatedSystemSettings.markThresholds.marginal
   );
   expect(marginalInput).toBeDisabled();
-  expect(bitonalThresholdInput).toHaveValue(
-    updatedSystemSettings.bitonalThreshold
-  );
-  expect(bitonalThresholdInput).toBeDisabled();
 });
 
 test('minimum detected scale', async () => {
@@ -193,15 +180,14 @@ test('adjudication reasons', async () => {
   for (const machine of ['VxScan', 'VxCentralScan']) {
     const select = screen.getByRole('group', { name: machine });
     const options = within(select).getAllByRole('checkbox');
-    expect(options).toHaveLength(5);
+    expect(options).toHaveLength(4);
     for (const option of options) {
       expect(option).not.toBeChecked();
     }
     expect(options[0]).toHaveTextContent('Overvote');
     expect(options[1]).toHaveTextContent('Undervote');
-    expect(options[2]).toHaveTextContent('Marginal Mark');
-    expect(options[3]).toHaveTextContent('Blank Ballot');
-    expect(options[4]).toHaveTextContent('Unmarked Write-In');
+    expect(options[2]).toHaveTextContent('Blank Ballot');
+    expect(options[3]).toHaveTextContent('Unmarked Write-In');
 
     userEvent.click(options[0]);
     expect(options[0]).toBeChecked();
@@ -545,7 +531,7 @@ test('all controls are disabled until clicking "Edit"', async () => {
   const allCheckboxes = document.body.querySelectorAll('[role=checkbox]');
   const allControls = [...allTextBoxes, ...allCheckboxes];
 
-  expect(allControls).toHaveLength(26);
+  expect(allControls).toHaveLength(23);
 
   for (const control of allControls) {
     expect(control).toBeDisabled();

--- a/apps/design/frontend/src/system_settings_screen.tsx
+++ b/apps/design/frontend/src/system_settings_screen.tsx
@@ -14,7 +14,6 @@ import { useParams } from 'react-router-dom';
 import {
   AdjudicationReason,
   AdjudicationReasonSchema,
-  DEFAULT_BITONAL_THRESHOLD,
   DEFAULT_INACTIVE_SESSION_TIME_LIMIT_MINUTES,
   DEFAULT_MARK_THRESHOLDS,
   DEFAULT_NUM_INCORRECT_PIN_ATTEMPTS_ALLOWED_BEFORE_CARD_LOCKOUT,
@@ -325,33 +324,6 @@ export function SystemSettingsForm({
                 />
               </InputGroup>
             )}
-            <InputGroup label="Scanner Bitonal Threshold">
-              <input
-                type="number"
-                value={systemSettings.bitonalThreshold ?? ''}
-                onChange={(e) => {
-                  const bitonalThreshold = e.target.valueAsNumber;
-                  setSystemSettings({
-                    ...systemSettings,
-                    bitonalThreshold: Number.isNaN(bitonalThreshold)
-                      ? undefined
-                      : bitonalThreshold,
-                  });
-                }}
-                onBlur={(e) => {
-                  if (e.target.value === '') {
-                    setSystemSettings({
-                      ...systemSettings,
-                      bitonalThreshold: DEFAULT_BITONAL_THRESHOLD,
-                    });
-                  }
-                }}
-                step={1}
-                min={0}
-                max={100}
-                disabled={!isEditing}
-              />
-            </InputGroup>
             <InputGroup label="Minimum Detected Scale">
               <input
                 type="number"

--- a/apps/design/frontend/src/system_settings_screen.tsx
+++ b/apps/design/frontend/src/system_settings_screen.tsx
@@ -143,6 +143,10 @@ export function SystemSettingsForm({
     { label: 'Unmarked Write-In', value: AdjudicationReason.UnmarkedWriteIn },
   ];
 
+  const scannerAdjudicationReasonOptions = adjudicationReasonOptions.filter(
+    (option) => option.value !== AdjudicationReason.MarginalMark
+  );
+
   enum CvrOption {
     RedudantMetadata = 'Redundant Metadata',
   }
@@ -177,7 +181,7 @@ export function SystemSettingsForm({
           <Column style={{ gap: '1.5rem' }}>
             <CheckboxGroup
               label="VxScan"
-              options={adjudicationReasonOptions}
+              options={scannerAdjudicationReasonOptions}
               value={
                 (systemSettings.precinctScanAdjudicationReasons ??
                   []) as string[]
@@ -206,7 +210,7 @@ export function SystemSettingsForm({
             />
             <CheckboxGroup
               label="VxCentralScan"
-              options={adjudicationReasonOptions}
+              options={scannerAdjudicationReasonOptions}
               value={
                 (systemSettings.centralScanAdjudicationReasons ??
                   []) as string[]


### PR DESCRIPTION
Removes the System Settings feature from the Design app, as it's not needed in this context. System settings functionality remains available in other VxSuite apps where it's actually used. Changes: Removed SystemSettingsScreen component and related tests, removed system settings route from app navigation, and cleaned up unused imports and dependencies. This simplifies the Design app interface by removing functionality that doesn't belong in this specific application.