### PR TITLE
Tweak VxPollBook backend code coverage threshold

### DIFF
--- a/apps/pollbook/backend/vitest.config.ts
+++ b/apps/pollbook/backend/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: 85.63,
-        branches: 80.18,
+        branches: 80,
       },
       exclude: [
         '**/node_modules/**',


### PR DESCRIPTION
## Overview

I've been seeing some flakiness on main with the following error:

```
ERROR: Coverage for branches (80%) does not meet global threshold (80.18%)
```

I suspect that there's a test that only sometimes exercises a branch, so I'm adjusting the threshold accordingly.