### PR TITLE
ignore ENOENT when deciding on daemon connection logging

### DIFF
--- a/apps/pollbook/backend/src/barcode_scanner/unix_socket.ts
+++ b/apps/pollbook/backend/src/barcode_scanner/unix_socket.ts
@@ -38,7 +38,7 @@ export function tryConnect(logger: Logger): Promise<net.Socket> {
 
     client.once('error', (err) => {
       const message = `Pollbook backend failed to connect to barcode scanner Unix socket: ${err.message}`;
-      if (!err.message.match(/ECONNREFUSED/)) {
+      if (!err.message.match(/ECONNREFUSED/) && !err.message.match(/ENOENT/)) {
         logger.log(LogEventId.SocketClientConnected, 'system', {
           message,
           disposition: LogDispositionStandardTypes.Failure,


### PR DESCRIPTION
## Overview

Silences barcode scanner connection logs when `ENOENT` in addition to existing `ECONNREFUSED`.

## Demo Video or Screenshot

N/A logging change

## Testing Plan

Manually tested