### PR TITLE
fix coverage from merge conflict

### DIFF
--- a/apps/pollbook/backend/vitest.config.ts
+++ b/apps/pollbook/backend/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: 87.69,
-        branches: 82.4,
+        branches: 82.32,
       },
       exclude: [
         '**/node_modules/**',


### PR DESCRIPTION
Merge conflict accidently set the coverage threshold too high 