### PR TITLE
Address VxCentralScan blank screen issue

### DIFF
--- a/apps/central-scan/frontend/src/api.ts
+++ b/apps/central-scan/frontend/src/api.ts
@@ -172,6 +172,9 @@ export const getNextReviewSheet = {
   useQuery() {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(), () => apiClient.getNextReviewSheet(), {
+      // Always refetch - using cached data could result in flashes of old data or even blank
+      // screens, as getNextReviewSheet intentionally returns null when there are no sheets left to
+      // review
       cacheTime: 0,
       staleTime: 0,
     });
@@ -185,8 +188,14 @@ export const getSheetImage = {
 
   useQuery({ sheetId, side }: { sheetId: Id; side: Side }) {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey({ sheetId, side }), () =>
-      apiClient.getSheetImage({ sheetId, side })
+    return useQuery(
+      this.queryKey({ sheetId, side }),
+      () => apiClient.getSheetImage({ sheetId, side }),
+      // Don't let cached images take up memory - there's no benefit to caching them
+      {
+        cacheTime: 0,
+        staleTime: 0,
+      }
     );
   },
 } as const;

--- a/apps/central-scan/frontend/src/api.ts
+++ b/apps/central-scan/frontend/src/api.ts
@@ -171,7 +171,10 @@ export const getNextReviewSheet = {
 
   useQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getNextReviewSheet());
+    return useQuery(this.queryKey(), () => apiClient.getNextReviewSheet(), {
+      cacheTime: 0,
+      staleTime: 0,
+    });
   },
 } as const;
 


### PR DESCRIPTION
## Overview

In transitioning the last VxCentralScan non-Grout endpoints to Grout + react-query (https://github.com/votingworks/vxsuite/pull/6660), we've introduced an edge-case bug. Funnily enough, we recognized the possibility of this bug existing the first time we tried completing this transition (https://github.com/votingworks/vxsuite/pull/5475#discussion_r1790497508).

After removing a ballot that requires adjudication, the next ballot that requires adjudication surfaces a blank white screen:

https://github.com/user-attachments/assets/c4f1bfd5-74cf-4b7f-9a8f-622f28dd1580

The underlying code flow looks something like this:
* The `getNextReviewSheet` query returns the ballot to be adjudicated.
* After the ballot is confirmed removed in the UI, the query is rerun and expectedly returns `null`.
* On the next ballot be adjudicated, we return to the adjudication screen and `getNextReviewSheet` returns the previously cached `null` result. This results in us rendering nothing, per [this condition](https://github.com/votingworks/vxsuite/blob/bf01a8c2dae631804a991cd88a44aa2a2ec2f061/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx#L148-L150).

The fix, as suggested in https://github.com/votingworks/vxsuite/pull/5475#discussion_r1790497508, is to never cache the result of the `getNextReviewSheet` query, which generally makes sense. It should always be run fresh - there is no benefit to caching the result.

I also removed caching from the `getNextSheet` query as there's no benefit to caching that data and doing so just takes up memory.

## Testing Plan

I've tested manually that this fix works. We should add a regression test, but I'm gonna defer that to the team in a follow-up PR. For now, I just want to unblock final v4.0.2 image creation.