### PR TITLE
[pollbook] display error message when unknown ID type is scanned

### DIFF
--- a/apps/pollbook/frontend/src/voter_search_screen.test.tsx
+++ b/apps/pollbook/frontend/src/voter_search_screen.test.tsx
@@ -1,0 +1,158 @@
+import { expect, test, beforeEach, afterEach, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import {
+  AamvaDocument,
+  Voter,
+  VoterSearchParams,
+} from '@votingworks/pollbook-backend';
+import {
+  ApiMock,
+  createApiMock,
+  createMockVoter,
+} from '../test/mock_api_client';
+import { renderInAppContext } from '../test/render_in_app_context';
+import {
+  act,
+  getDefaultNormalizer,
+  screen,
+} from '../test/react_testing_library';
+import { createEmptySearchParams, VoterSearch } from './voter_search_screen';
+import { DEFAULT_QUERY_REFETCH_INTERVAL } from './api';
+
+let apiMock: ApiMock;
+let unmount: () => void;
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  apiMock = createApiMock();
+});
+
+afterEach(() => {
+  apiMock.mockApiClient.assertComplete();
+  vi.clearAllMocks();
+
+  if (unmount) {
+    unmount();
+  }
+
+  vi.useRealTimers();
+});
+
+test('shows a message when no voters are matched', async () => {
+  apiMock.expectGetScannedIdDocument();
+  apiMock.expectSearchVotersWithResults({}, []);
+
+  const result = renderInAppContext(
+    <VoterSearch
+      search={createEmptySearchParams(false)}
+      setSearch={vi.fn()}
+      // Function to call when exactly one voter is matched by scanning an ID
+      onBarcodeScanMatch={vi.fn()}
+      renderAction={() => null}
+    />,
+    {
+      apiMock,
+    }
+  );
+  unmount = result.unmount;
+
+  await act(() => vi.advanceTimersByTime(DEFAULT_QUERY_REFETCH_INTERVAL));
+
+  await screen.findByText('No voters matched.');
+});
+
+test('shows a message when the barcode scanner client reports an unknown document type', async () => {
+  apiMock.expectGetScannedIdDocumentUnknownType();
+  apiMock.expectSearchVotersNull({});
+
+  const result = renderInAppContext(
+    <VoterSearch
+      search={createEmptySearchParams(false)}
+      setSearch={vi.fn()}
+      onBarcodeScanMatch={vi.fn()}
+      renderAction={() => null}
+    />,
+    {
+      apiMock,
+    }
+  );
+  unmount = result.unmount;
+
+  await act(() => vi.advanceTimersByTime(DEFAULT_QUERY_REFETCH_INTERVAL));
+
+  await screen.findByRole('heading', { name: 'ID Not Recognized' });
+  screen.getByText(
+    'Unable to read the scanned barcode. Please try scanning again or enter the name manually.'
+  );
+  userEvent.click(screen.getButton('Close'));
+
+  // Recommended pattern per github.com/vitest-dev/vitest/discussions/6560
+  await expect
+    .poll(() => screen.queryByRole('heading', { name: 'ID Not Recognized' }))
+    .not.toBeInTheDocument();
+});
+
+test('closes the error modal if a valid ID is scanned', async () => {
+  apiMock.expectGetScannedIdDocumentUnknownType();
+  apiMock.expectSearchVotersNull({});
+
+  const setSearchSpy = vi.fn();
+  const result = renderInAppContext(
+    <VoterSearch
+      search={createEmptySearchParams(false)}
+      setSearch={setSearchSpy}
+      onBarcodeScanMatch={vi.fn()}
+      renderAction={() => null}
+    />,
+    {
+      apiMock,
+    }
+  );
+  unmount = result.unmount;
+
+  await act(() => vi.advanceTimersByTime(DEFAULT_QUERY_REFETCH_INTERVAL));
+
+  await screen.findByRole('heading', { name: 'ID Not Recognized' });
+  screen.getByText(
+    'Unable to read the scanned barcode. Please try scanning again or enter the name manually.'
+  );
+
+  const document: AamvaDocument = {
+    firstName: 'Aaron',
+    middleName: 'Danger',
+    lastName: 'Burr',
+    nameSuffix: 'Jr',
+    issuingJurisdiction: 'NH',
+  };
+  const searchParams: VoterSearchParams = {
+    firstName: document.firstName,
+    middleName: document.middleName,
+    lastName: document.lastName,
+    suffix: document.nameSuffix,
+    exactMatch: true,
+  };
+  const mockVoter: Voter = {
+    ...createMockVoter('123', document.firstName, document.lastName),
+    middleName: document.middleName,
+    suffix: document.nameSuffix,
+  };
+
+  apiMock.expectSearchVotersWithResults(searchParams, [mockVoter]);
+  apiMock.expectGetScannedIdDocument(document);
+
+  await act(() => vi.advanceTimersByTime(DEFAULT_QUERY_REFETCH_INTERVAL));
+
+  // Recommended pattern to check for element absence per github.com/vitest-dev/vitest/discussions/6560
+  await expect
+    .poll(() => screen.queryByRole('heading', { name: 'ID Not Recognized' }))
+    .not.toBeInTheDocument();
+
+  expect(setSearchSpy).toHaveBeenCalledWith(searchParams);
+  expect(
+    screen.getByText('Burr, Aaron Danger Jr', {
+      normalizer: getDefaultNormalizer({ collapseWhitespace: true }),
+    })
+  ).toBeInTheDocument();
+});
+
+// Test for barcode scanner happy path is covered in app_poll_worker_screen.test.tsx

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -531,6 +531,12 @@ export function createApiMock() {
         .expectOptionalRepeatedCallsWith()
         .resolves(ok(document));
     },
+
+    expectGetScannedIdDocumentUnknownType() {
+      mockApiClient.getScannedIdDocument
+        .expectOptionalRepeatedCallsWith()
+        .resolves(err(new Error('unknown_document_type')));
+    },
   };
 }
 


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6630

Shows an error message when a barcode is scanned but it's not parsable as a driver's license

## Demo Video or Screenshot

Pollworker screen:
![Screenshot 2025-07-01 at 10 10 14 AM](https://github.com/user-attachments/assets/2e16dfe0-2f26-4798-8c20-189990cd8290)

Election manager screen:
![Screenshot 2025-07-01 at 10 10 04 AM](https://github.com/user-attachments/assets/fe2839d9-8ed8-4a8d-ba15-95820797a8c0)


Video:

https://votingworks.slack.com/archives/C07CR6T1TLK/p1751066312970399

## Testing Plan
- manually tested
- added unit tests for component

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
