### PR TITLE
VxScan: Fix stretched test mode callout on polls closed screen

### DIFF
--- a/apps/scan/frontend/src/components/layout.tsx
+++ b/apps/scan/frontend/src/components/layout.tsx
@@ -71,9 +71,9 @@ const ButtonBar = styled.div`
   }
 `;
 
-const VoterHeader = styled.div`
-  align-items: start;
+const HeaderRow = styled.div`
   display: flex;
+  align-items: start;
   gap: ${(p) => getSpacingValueRem(p)}rem;
   padding: ${(p) => getSpacingValueRem(p)}rem;
   justify-content: space-between;
@@ -82,13 +82,6 @@ const VoterHeader = styled.div`
 const SettingsButtons = styled.div`
   display: flex;
   gap: ${(p) => getSpacingValueRem(p)}rem;
-`;
-
-const TitleBar = styled.div`
-  display: flex;
-  gap: ${(p) => getSpacingValueRem(p)}rem;
-  padding: ${(p) => getSpacingValueRem(p)}rem;
-  justify-content: space-between;
 `;
 
 const TitleContainer = styled.div`
@@ -150,7 +143,7 @@ export function Screen(props: ScreenProps): JSX.Element | null {
   return (
     <ScreenBase>
       {voterFacing && (
-        <VoterHeader>
+        <HeaderRow>
           <SettingsButtons>
             <LanguageSettingsButton
               onPress={() => setShouldShowLanguageSettings(true)}
@@ -159,13 +152,13 @@ export function Screen(props: ScreenProps): JSX.Element | null {
           </SettingsButtons>
           {showTestModeBanner && <TestModeCallout />}
           {ballotCountElement}
-        </VoterHeader>
+        </HeaderRow>
       )}
-      <TitleBar>
+      <HeaderRow>
         <TitleContainer>{title && <H1>{title}</H1>}</TitleContainer>
         {!voterFacing && showTestModeBanner && <TestModeCallout />}
         {!voterFacing && ballotCountElement}
-      </TitleBar>
+      </HeaderRow>
       {voterFacing ? (
         <ReadOnLoad as={Main} centerChild={centerContent} padded={padded}>
           {title && <AudioOnly>{title}</AudioOnly>}


### PR DESCRIPTION
## Overview

The test mode callout was getting stretched on screens where the `isVoterFacing` flag was false.

## Demo Video or Screenshot

Before
![image](https://github.com/user-attachments/assets/cddd23e1-0254-4df8-a692-b22e856dc954)

After
![Screenshot-VxScan-2025-06-30T18:17:32 598Z](https://github.com/user-attachments/assets/2c71950e-3768-4359-94cd-0ba57a6543f8)




## Testing Plan
Visual inspection

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
