### PR TITLE
Filter down to contests for specified ballot style on ERR import

### DIFF
--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -485,6 +485,7 @@ describe('ERR file import', () => {
   test('success', async () => {
     const { apiClient, auth } = buildTestEnvironment();
     await configureMachine(apiClient, auth, electionGeneralDefinition);
+    // TODO: Get this fixture back in sync with the election definition - it's fallen out of sync
     const errContents = testElectionReport;
     const filepath = tmpNameSync();
     await writeFile(filepath, JSON.stringify(errContents));
@@ -505,7 +506,7 @@ describe('ERR file import', () => {
       manualResultsIdentifier
     );
     const councilContest = assertDefined(
-      manualResults?.manualResults.contestResults['council']
+      manualResults?.manualResults.contestResults['city-council']
     ) as CandidateContestResults;
     const writeInTally = assertDefined(
       Object.values(councilContest.tallies).find(
@@ -522,8 +523,8 @@ describe('ERR file import', () => {
       manualResults: {
         ballotCount: 65,
         contestResults: {
-          fishing: {
-            contestId: 'fishing',
+          'question-a': {
+            contestId: 'question-a',
             contestType: 'yesno',
             yesOptionId: 'fishing-yes',
             noOptionId: 'fishing-no',
@@ -533,19 +534,8 @@ describe('ERR file import', () => {
             undervotes: 5,
             ballots: 65,
           },
-          judge: {
-            contestId: 'judge',
-            contestType: 'yesno',
-            yesOptionId: 'retain-yes',
-            noOptionId: 'retain-no',
-            yesTally: 55,
-            noTally: 10,
-            overvotes: 0,
-            undervotes: 0,
-            ballots: 65,
-          },
-          council: {
-            contestId: 'council',
+          'city-council': {
+            contestId: 'city-council',
             contestType: 'candidate',
             votesAllowed: 2,
             overvotes: 8,

--- a/libs/types/src/cdf/election-results-reporting/convert.test.ts
+++ b/libs/types/src/cdf/election-results-reporting/convert.test.ts
@@ -154,8 +154,8 @@ describe('getManualResultsFromErrElectionResults', () => {
   test('converting an ERR election', () => {
     const expected: ManualElectionResults = {
       contestResults: {
-        fishing: {
-          contestId: 'fishing',
+        'question-a': {
+          contestId: 'question-a',
           contestType: 'yesno',
           yesOptionId: 'fishing-yes',
           noOptionId: 'fishing-no',
@@ -176,8 +176,8 @@ describe('getManualResultsFromErrElectionResults', () => {
           undervotes: 0,
           ballots: 65,
         },
-        council: {
-          contestId: 'council',
+        'city-council': {
+          contestId: 'city-council',
           contestType: 'candidate',
           votesAllowed: 2,
           overvotes: 8,

--- a/libs/types/src/cdf/election-results-reporting/fixtures.ts
+++ b/libs/types/src/cdf/election-results-reporting/fixtures.ts
@@ -88,7 +88,7 @@ export const testElectionReport: ElectionReport = {
       Contest: [
         {
           '@type': 'ElectionResults.BallotMeasureContest',
-          '@id': 'fishing',
+          '@id': 'question-a',
           Name: 'Fishing Proposition',
           ElectionDistrictId: 'state-of-hamilton',
           ContestSelection: [
@@ -173,7 +173,7 @@ export const testElectionReport: ElectionReport = {
         },
         {
           '@type': 'ElectionResults.CandidateContest',
-          '@id': 'council',
+          '@id': 'city-council',
           Name: 'Council',
           ElectionDistrictId: 'state-of-hamilton',
           VotesAllowed: 2,


### PR DESCRIPTION
## Overview

A feature that we thought would only be for cert - CDF election results reporting (ERR) import - is finding a use case in NH cities, where we want to aggregate results across wards. Reminder that, in NH cities, every ward (precinct) will have its own VxAdmin (for onsite write-in adjudication), and an additional VxAdmin will be provided for consolidation across the wards. We're ironing out the exact process in this [VotingWorks City Results Aggregation Instructions](https://docs.google.com/document/d/1JZE3omk5jCk7IydbVyWC4I1Gy7G0Ch_EFP8NtoSMeu8/edit?usp=sharing) doc.

In final QA, I found an issue with the code and the plan as it pertains to primary elections, of which we have one this fall. ERR exports are imported through the manual tally entry UI, which first requires selection of a ballot style group. But ERR exports include results for all ballot style groups in a ward. In NH city general elections, there'll only ever be one ballot style group per ward, but for primaries, there'll be at least as many ballot style groups as there are parties. We planned for this and are simply going to have cities export the same file repeatedly for each ballot style group.

The bug that I found in the ERR import logic is that it doesn't actually filter down the contests in the ERR export to the contests for the selected ballot style group. The ultimate effect of this is that you can end up with double counts.

Kinda confusing I know. My full investigative details can be found in this Slack thread: https://votingworks.slack.com/archives/CJU9MSC6S/p1751255057123449

## Testing Plan

- [x] Updated automated tests
- [x] Tested fix manually