### PR TITLE
VxPollbook Multi Precinct Check In Restrictions

### DIFF
--- a/apps/pollbook/backend/src/store.ts
+++ b/apps/pollbook/backend/src/store.ts
@@ -66,6 +66,30 @@ export function sortedByVoterName(
   });
 }
 
+export function sortedByVoterNameAndMatchingPrecinct(
+  voters: Voter[],
+  configuredPrecinctId?: string,
+  { useOriginalName = false } = {}
+): Voter[] {
+  if (!configuredPrecinctId) {
+    return sortedByVoterName(voters, { useOriginalName });
+  }
+  const matching = voters.filter(
+    (v) =>
+      (v.addressChange ? v.addressChange.precinct : v.precinct) ===
+      configuredPrecinctId
+  );
+  const nonMatching = voters.filter(
+    (v) =>
+      (v.addressChange ? v.addressChange.precinct : v.precinct) !==
+      configuredPrecinctId
+  );
+  return [
+    ...sortedByVoterName(matching, { useOriginalName }),
+    ...sortedByVoterName(nonMatching, { useOriginalName }),
+  ];
+}
+
 export abstract class Store {
   protected election?: Election;
   protected validStreetInfo?: ValidStreetInfo[];

--- a/apps/pollbook/backend/vitest.config.ts
+++ b/apps/pollbook/backend/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 88.06,
-        branches: 82.67,
+        lines: 88.13,
+        branches: 83.09,
       },
       exclude: [
         '**/node_modules/**',

--- a/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
+++ b/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
@@ -23,6 +23,7 @@ const famousNamesElection: Election =
   electionFamousNames2021Fixtures.readElection();
 const famousNamesElectionDefinition: ElectionDefinition =
   electionFamousNames2021Fixtures.readElectionDefinition();
+const precinct1 = famousNamesElection.precincts[0].id;
 
 describe('PollWorkerScreen', () => {
   beforeEach(() => {
@@ -74,7 +75,7 @@ describe('PollWorkerScreen', () => {
       'Voters matched: 153. Refine your search further to view results.'
     );
 
-    const voter = createMockVoter('123', 'Abigail', 'Adams');
+    const voter = createMockVoter('123', 'Abigail', 'Adams', precinct1);
 
     apiMock.expectSearchVotersWithResults(
       { firstName: 'ABI', lastName: 'AD' },
@@ -144,7 +145,12 @@ describe('PollWorkerScreen', () => {
       exactMatch: true,
     };
     const mockVoter: Voter = {
-      ...createMockVoter('123', document.firstName, document.lastName),
+      ...createMockVoter(
+        '123',
+        document.firstName,
+        document.lastName,
+        precinct1
+      ),
       middleName: document.middleName,
       suffix: document.nameSuffix,
     };
@@ -174,10 +180,7 @@ describe('PollWorkerScreen', () => {
     test(`check in flow handles ${testCase.error} error path`, async () => {
       apiMock.expectGetDeviceStatuses();
       apiMock.authenticateAsPollWorker(famousNamesElection);
-      apiMock.setElection(
-        famousNamesElectionDefinition,
-        famousNamesElection.precincts[0].id
-      );
+      apiMock.setElection(famousNamesElectionDefinition, precinct1);
       const { unmount } = render(<App apiClient={apiMock.mockApiClient} />);
       await screen.findByText('Connect printer to continue.');
 
@@ -204,7 +207,7 @@ describe('PollWorkerScreen', () => {
         'Voters matched: 153. Refine your search further to view results.'
       );
 
-      const voter = createMockVoter('123', 'Abigail', 'Adams');
+      const voter = createMockVoter('123', 'Abigail', 'Adams', precinct1);
 
       apiMock.expectSearchVotersWithResults(
         { firstName: 'ABI', lastName: 'AD' },

--- a/apps/pollbook/frontend/src/election_manager_screen.test.tsx
+++ b/apps/pollbook/frontend/src/election_manager_screen.test.tsx
@@ -17,6 +17,8 @@ let apiMock: ApiMock;
 const electionDefFamousNames =
   electionFamousNames2021Fixtures.readElectionDefinition();
 
+const precinct1 = electionDefFamousNames.election.precincts[0].id;
+
 let unmount: () => void;
 
 beforeEach(() => {
@@ -36,6 +38,7 @@ afterEach(() => {
 
 describe('Voters tab', () => {
   test('view voter details from voter search', async () => {
+    apiMock.setElection(electionDefFamousNames, precinct1);
     const renderResult = renderInAppContext(<ElectionManagerScreen />, {
       apiMock,
     });
@@ -47,7 +50,7 @@ describe('Voters tab', () => {
 
     await screen.findByRole('heading', { name: 'Voters' });
 
-    const voter = createMockVoter('123', 'Abigail', 'Adams');
+    const voter = createMockVoter('123', 'Abigail', 'Adams', precinct1);
     apiMock.expectSearchVotersWithResults(
       {
         firstName: 'ABI',
@@ -124,7 +127,10 @@ describe('SettingsScreen precinct selection', () => {
     // Setup election with multiple precincts
     const singlePrecinctElection =
       electionSimpleSinglePrecinctFixtures.readElectionDefinition();
-    apiMock.setElection(singlePrecinctElection);
+    apiMock.setElection(
+      singlePrecinctElection,
+      singlePrecinctElection.election.precincts[0].id
+    );
     apiMock.expectGetDeviceStatuses();
     // Render
     const renderResult = renderInAppContext(<ElectionManagerScreen />, {

--- a/apps/pollbook/frontend/src/shared_components.tsx
+++ b/apps/pollbook/frontend/src/shared_components.tsx
@@ -2,6 +2,7 @@ import type { Voter, VoterAddressChange } from '@votingworks/pollbook-backend';
 import { Callout, Card, H4 } from '@votingworks/ui';
 import styled from 'styled-components';
 import { throwIllegalValue } from '@votingworks/basics';
+import { Election } from '@votingworks/types';
 import { Column } from './layout';
 
 export const AbsenteeModeCallout = styled(Callout).attrs({
@@ -150,4 +151,18 @@ export function PartyName({ party }: { party: 'DEM' | 'REP' | 'UND' }): string {
     default:
       throwIllegalValue(party);
   }
+}
+
+export function PrecinctName({
+  precinctId,
+  election,
+}: {
+  precinctId: string;
+  election: Election;
+}): string {
+  const precinct = election.precincts.find((p) => p.id === precinctId);
+  if (!precinct) {
+    throw new Error(`Precinct with ID ${precinctId} not found in election.`);
+  }
+  return precinct.name;
 }

--- a/apps/pollbook/frontend/src/types.ts
+++ b/apps/pollbook/frontend/src/types.ts
@@ -1,7 +1,16 @@
+import type { Voter } from '@votingworks/pollbook-backend';
+
 export enum PollbookConnectionStatus {
   Connected = 'Connected',
   ShutDown = 'ShutDown',
   LostConnection = 'LostConnection',
   MismatchedConfiguration = 'MismatchedConfiguration',
   IncompatibleSoftwareVersion = 'IncompatibleSoftwareVersion',
+}
+
+export function getVoterPrecinct(voter: Voter): string {
+  if (voter.addressChange) {
+    return voter.addressChange.precinct;
+  }
+  return voter.precinct;
 }

--- a/apps/pollbook/frontend/src/voter_confirm_screen.test.tsx
+++ b/apps/pollbook/frontend/src/voter_confirm_screen.test.tsx
@@ -5,7 +5,7 @@ import {
   VoterIdentificationMethod,
 } from '@votingworks/pollbook-backend';
 import userEvent from '@testing-library/user-event';
-import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { electionMultiPartyPrimaryFixtures } from '@votingworks/fixtures';
 import { screen, waitFor, within } from '../test/react_testing_library';
 import {
   ApiMock,
@@ -22,6 +22,10 @@ let voter: Voter;
 let onCancel: ReturnType<typeof vi.fn>;
 let onConfirm: ReturnType<typeof vi.fn>;
 
+const electionDefinition =
+  electionMultiPartyPrimaryFixtures.readElectionDefinition();
+const precinct = electionDefinition.election.precincts[0].id;
+
 beforeEach(() => {
   voter = createMockVoter(mockVoterId, 'ABIGAIL', 'ADAMS');
   vi.clearAllMocks();
@@ -29,10 +33,7 @@ beforeEach(() => {
   onConfirm = vi.fn();
   apiMock = createApiMock();
   apiMock.expectGetVoter(voter);
-  apiMock.setElection(
-    electionFamousNames2021Fixtures.readElectionDefinition(),
-    'precinct-1'
-  );
+  apiMock.setElection(electionDefinition, precinct);
 });
 
 afterEach(() => {
@@ -42,9 +43,11 @@ afterEach(() => {
 
 async function renderComponent({
   isAbsenteeMode = false,
+  configuredPrecinctId = precinct,
   voterOverride,
 }: {
   isAbsenteeMode?: boolean;
+  configuredPrecinctId?: string;
   voterOverride?: Voter;
 } = {}) {
   if (voterOverride) {
@@ -57,6 +60,8 @@ async function renderComponent({
       isAbsenteeMode={isAbsenteeMode}
       onCancel={onCancel}
       onConfirm={onConfirm}
+      election={electionDefinition.election}
+      configuredPrecinctId={configuredPrecinctId}
     />,
     {
       apiMock,
@@ -295,6 +300,8 @@ test('returns null when voter query is not successful', () => {
       isAbsenteeMode={false}
       onCancel={onCancel}
       onConfirm={onConfirm}
+      election={electionDefinition.election}
+      configuredPrecinctId={precinct}
     />,
     {
       apiMock,

--- a/apps/pollbook/frontend/src/voter_search_screen.test.tsx
+++ b/apps/pollbook/frontend/src/voter_search_screen.test.tsx
@@ -5,6 +5,7 @@ import {
   Voter,
   VoterSearchParams,
 } from '@votingworks/pollbook-backend';
+import { electionSimpleSinglePrecinctFixtures } from '@votingworks/fixtures';
 import {
   ApiMock,
   createApiMock,
@@ -21,6 +22,7 @@ import { DEFAULT_QUERY_REFETCH_INTERVAL } from './api';
 
 let apiMock: ApiMock;
 let unmount: () => void;
+const election = electionSimpleSinglePrecinctFixtures.readElection();
 
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -49,6 +51,7 @@ test('shows a message when no voters are matched', async () => {
       // Function to call when exactly one voter is matched by scanning an ID
       onBarcodeScanMatch={vi.fn()}
       renderAction={() => null}
+      election={election}
     />,
     {
       apiMock,
@@ -71,6 +74,7 @@ test('shows a message when the barcode scanner client reports an unknown documen
       setSearch={vi.fn()}
       onBarcodeScanMatch={vi.fn()}
       renderAction={() => null}
+      election={election}
     />,
     {
       apiMock,
@@ -103,6 +107,7 @@ test('closes the error modal if a valid ID is scanned', async () => {
       setSearch={setSearchSpy}
       onBarcodeScanMatch={vi.fn()}
       renderAction={() => null}
+      election={election}
     />,
     {
       apiMock,

--- a/apps/pollbook/frontend/src/voter_search_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_search_screen.tsx
@@ -214,7 +214,10 @@ export function VoterSearch({
               <VoterTable>
                 <tbody>
                   {searchVotersQuery.data.map((voter) => (
-                    <tr key={voter.voterId}>
+                    <tr
+                      key={voter.voterId}
+                      data-testid={`voter-row#${voter.voterId}`}
+                    >
                       <td>
                         {voter.nameChange && <Caption>Updated Name</Caption>}
                         <H2 style={{ margin: 0 }}>

--- a/apps/pollbook/frontend/src/voter_search_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_search_screen.tsx
@@ -25,6 +25,7 @@ import type {
 import styled from 'styled-components';
 import { format } from '@votingworks/utils';
 import { Optional, throwIllegalValue } from '@votingworks/basics';
+import { Election } from '@votingworks/types';
 import { Column, Form, Row, InputGroup } from './layout';
 import { PollWorkerNavScreen } from './nav_screen';
 import { getCheckInCounts, getScannedIdDocument, searchVoters } from './api';
@@ -32,9 +33,11 @@ import {
   AbsenteeModeCallout,
   AddressChange,
   PartyName,
+  PrecinctName,
   VoterAddress,
   VoterName,
 } from './shared_components';
+import { getVoterPrecinct } from './types';
 
 const VoterTableWrapper = styled(Card)`
   overflow: hidden;
@@ -79,11 +82,13 @@ export function VoterSearch({
   // Function to call when exactly one voter is matched by scanning an ID
   onBarcodeScanMatch,
   renderAction,
+  election,
 }: {
   search: VoterSearchParams;
   setSearch: (search: VoterSearchParams) => void;
   onBarcodeScanMatch: (voter: Voter) => void;
   renderAction: (voter: Voter) => React.ReactNode;
+  election: Election;
 }): JSX.Element {
   const [voterSearchParams, setVoterSearchParams] =
     useState<VoterSearchParams>(search);
@@ -216,6 +221,15 @@ export function VoterSearch({
                           <VoterName voter={voter} lastNameFirst />
                         </H2>
                         <PartyName party={voter.party} />
+                        {election.precincts.length > 1 && (
+                          <span>
+                            {' • '}
+                            <PrecinctName
+                              precinctId={getVoterPrecinct(voter)}
+                              election={election}
+                            />
+                          </span>
+                        )}
                       </td>
                       <td>
                         {voter.addressChange ? (
@@ -301,11 +315,15 @@ export function VoterSearchScreen({
   setSearch,
   isAbsenteeMode,
   onSelect,
+  election,
+  configuredPrecinctId,
 }: {
   search: VoterSearchParams;
   setSearch: (search: VoterSearchParams) => void;
   isAbsenteeMode: boolean;
   onSelect: (voterId: string) => void;
+  election: Election;
+  configuredPrecinctId?: string;
 }): JSX.Element | null {
   const getCheckInCountsQuery = getCheckInCounts.useQuery();
 
@@ -351,6 +369,7 @@ export function VoterSearchScreen({
             search={search}
             setSearch={setSearch}
             onBarcodeScanMatch={onBarcodeScanMatch}
+            election={election}
             renderAction={(voter) =>
               voter.checkIn ? (
                 <CheckInDetails checkIn={voter.checkIn} />
@@ -362,7 +381,12 @@ export function VoterSearchScreen({
                   data-testid={`check-in-button#${voter.voterId}`}
                   onPress={() => onSelect(voter.voterId)}
                 >
-                  <Font noWrap>Start Check-In</Font>
+                  <Font noWrap>
+                    {configuredPrecinctId &&
+                    configuredPrecinctId === getVoterPrecinct(voter)
+                      ? 'Start Check-In'
+                      : 'View Details'}
+                  </Font>
                 </Button>
               )
             }

--- a/apps/pollbook/frontend/src/voters_screen.tsx
+++ b/apps/pollbook/frontend/src/voters_screen.tsx
@@ -2,7 +2,8 @@ import { MainContent, Font, H1, LinkButton } from '@votingworks/ui';
 import { useState } from 'react';
 import type { Voter, VoterSearchParams } from '@votingworks/pollbook-backend';
 import { useHistory } from 'react-router-dom';
-import { getDeviceStatuses } from './api';
+import { assertDefined } from '@votingworks/basics';
+import { getDeviceStatuses, getElection } from './api';
 import { Row } from './layout';
 import { ElectionManagerNavScreen } from './nav_screen';
 import { VoterSearch, createEmptySearchParams } from './voter_search_screen';
@@ -18,11 +19,14 @@ export function ElectionManagerVotersScreen(): JSX.Element | null {
     createEmptySearchParams(false)
   );
   const getDeviceStatusesQuery = getDeviceStatuses.useQuery();
+  const getElectionQuery = getElection.useQuery();
 
-  if (!getDeviceStatusesQuery.isSuccess) {
+  if (!getDeviceStatusesQuery.isSuccess || !getElectionQuery.isSuccess) {
     /* istanbul ignore next - @preserve */
     return null;
   }
+
+  const election = assertDefined(getElectionQuery.data.unsafeUnwrap());
 
   return (
     <ElectionManagerNavScreen
@@ -36,6 +40,7 @@ export function ElectionManagerVotersScreen(): JSX.Element | null {
       <MainContent>
         <VoterSearch
           search={search}
+          election={election}
           setSearch={setSearch}
           onBarcodeScanMatch={(voter) => {
             /* istanbul ignore next - @preserve */

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -41,7 +41,8 @@ export const machineConfig: MachineConfig = {
 export function createMockVoter(
   voterId: string,
   firstName: string,
-  lastName: string
+  lastName: string,
+  precinctId: string = 'precinct-1'
 ): Voter {
   return {
     voterId,
@@ -72,7 +73,7 @@ export function createMockVoter(
     mailingZip5: '12345',
     mailingZip4: '6789',
     party: 'UND',
-    precinct: 'precinct-1',
+    precinct: precinctId,
     isInactive: false,
   };
 }


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/6156

Implements the restrictions for checking in, or making other voter changes, when a voter is not in the correct precinct. Address changes are always permitted as you can change a voter address into the current precinct. Notably as implemented in a previous PR you can NOT change a voter address outside of the precinct, this combined with the fact that you can only sync with machines configured for the same precinct means that we do not have to worry about the voter being configured for the correct precinct on the backend as there is no way for an event to sneak in and change that if the frontend is allowing a check in (or name change/ etc.). I have previously added backend errors for situations like checking in a voter that is flagged as inactive as an event that changes that status CAN sneak in and sync after a UI is displayed. 

In a single precinct election, nothing in the UI is changed and a voter's precinct is not surfaced. 

In a multi precinct election adds the voters precinct to:
- The search results UI 
- The EM voter details screen
- The PW voter confirm screen

If the voter is not in the precinct that the machine is configured for, changing name, flagging inactive, and checking in are not allowed. 

Some notes mostly for @adghayes to review on his return:
- The Ticket mentions a few UI options. This UI is what Matt thought looked the most sensible when we looked at it but I'm assuming you may take a pass. 
- I am sorting the voter search results to put matching precinct voters first before voters from other precincts. This was not mentioned in the ticket but it seems very unlikely you would want to find someone outside of the precinct so I thought this was a better pattern. Matt also suggested just filtering to only voters in the same precinct but then you would need a toggle in case you want to see all. 
- You did not specifically say we should block flagging as inactive on the matching precinct but it is simpler to do so and I don't see why someone would need to do that for a voter in the wrong precinct. 


<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot

https://github.com/user-attachments/assets/5bbc5fc7-4102-4d3b-b927-70ecfe07fbbf



## Testing Plan
Manual testing as shown above + similar run through on a single precinct election to verify no changed. 

Added tests for all new flows/branches 

## Checklist
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
