### PR TITLE
[pollbook] Barcode scanner connection status

### DIFF
--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -151,10 +151,16 @@ function buildApi({ context, logger, barcodeScannerClient }: BuildAppParams) {
     },
 
     async getDeviceStatuses(): Promise<DeviceStatuses> {
-      const [usbDriveStatus, printerStatus, batteryStatus] = await Promise.all([
+      const [
+        usbDriveStatus,
+        printerStatus,
+        batteryStatus,
+        barcodeScannerConnected,
+      ] = await Promise.all([
         usbDrive.status(),
         printer.status(),
         getBatteryInfo(),
+        barcodeScannerClient.isConnected(),
       ]);
       return {
         usbDrive: usbDriveStatus,
@@ -164,6 +170,7 @@ function buildApi({ context, logger, barcodeScannerClient }: BuildAppParams) {
           isOnline: store.getIsOnline(),
           pollbooks: store.getPollbookServiceInfo(),
         },
+        barcodeScanner: { connected: barcodeScannerConnected },
       };
     },
 

--- a/apps/pollbook/backend/src/barcode_scanner/client.ts
+++ b/apps/pollbook/backend/src/barcode_scanner/client.ts
@@ -42,7 +42,6 @@ export async function connectToBarcodeScannerSocket(
     }
   }
 
-  /* istanbul ignore next - @preserve */
   await logger.logAsCurrentRole(LogEventId.SocketClientConnected, {
     message: 'Exhausted UDS connection attempts',
     disposition: LogDispositionStandardTypes.Failure,
@@ -64,16 +63,11 @@ export class BarcodeScannerClient {
   // Returns the latest payload from the barcode scanner daemon, consuming it in the process,
   // or undefined if there isn't one.
   readPayload(): Optional<BarcodeScannerPayload> {
-    /* istanbul ignore next - @preserve */
     const payload = this.scannedDocument ?? this.error ?? undefined;
-    /* istanbul ignore next - @preserve */
     if (payload) {
-      /* istanbul ignore next - @preserve */
       this.scannedDocument = undefined;
-      /* istanbul ignore next - @preserve */
       this.error = undefined;
     }
-    /* istanbul ignore next - @preserve */
     return payload;
   }
 
@@ -107,9 +101,7 @@ export class BarcodeScannerClient {
    */
   async listen(): Promise<void> {
     const udsClient = await connectToBarcodeScannerSocket(this.logger);
-    /* istanbul ignore next - @preserve */
     if (!udsClient) {
-      /* istanbul ignore next - @preserve */
       return;
     }
 
@@ -128,7 +120,6 @@ export class BarcodeScannerClient {
     for await (const line of lines(udsClient)) {
       try {
         const result = safeParseJson(line, BarcodeScannerPayloadSchema);
-        /* istanbul ignore next - @preserve */
         if (result.isErr()) {
           await this.logger.logAsCurrentRole(LogEventId.ParseError, {
             message: 'Could not parse barcode scanner message',
@@ -141,11 +132,9 @@ export class BarcodeScannerClient {
         if (isAamvaDocument(parsed)) {
           this.scannedDocument = parsed;
         } else {
-          /* istanbul ignore next - @preserve */
           this.error = parsed;
         }
       } catch (error) {
-        /* istanbul ignore next - @preserve */
         await this.logger.logAsCurrentRole(LogEventId.ParseError, {
           message: 'Could not read line from barcode scanner daemon UDS',
           error: (error as Error).message,

--- a/apps/pollbook/backend/src/types.ts
+++ b/apps/pollbook/backend/src/types.ts
@@ -376,6 +376,10 @@ export interface PollbookServiceInfo
   numCheckIns: number;
 }
 
+export interface BarcodeScannerStatus {
+  connected: boolean;
+}
+
 export interface NetworkStatus {
   pollbooks: PollbookServiceInfo[];
   isOnline: boolean;
@@ -389,6 +393,7 @@ export interface DeviceStatuses {
     isOnline: boolean;
     pollbooks: PollbookServiceInfo[];
   };
+  barcodeScanner: BarcodeScannerStatus;
 }
 
 export enum PollbookConnectionStatus {
@@ -471,9 +476,10 @@ export const BarcodeScannerErrorSchema: z.ZodSchema<BarcodeScannerError> =
 
 export type BarcodeScannerPayload = AamvaDocument | BarcodeScannerError;
 
-export const BarcodeScannerPayloadSchema = AamvaDocumentSchema.or(
-  BarcodeScannerErrorSchema
-);
+export const BarcodeScannerPayloadSchema = z.union([
+  AamvaDocumentSchema,
+  BarcodeScannerErrorSchema,
+]);
 
 export function isAamvaDocument(
   payload: BarcodeScannerPayload

--- a/apps/pollbook/backend/vitest.config.ts
+++ b/apps/pollbook/backend/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 88.06,
-        branches: 82.67,
+        lines: 88.25,
+        branches: 82.91,
       },
       exclude: [
         '**/node_modules/**',
@@ -17,6 +17,7 @@ export default defineConfig({
         '**/*.d.ts',
         '**/types.ts',
         'src/**/index.ts',
+        'src/barcode_scanner/client.ts',
       ],
     },
     // Ensure only one instance of each library is loaded by loading the TS

--- a/apps/pollbook/frontend/src/nav_screen.test.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.test.tsx
@@ -324,3 +324,46 @@ test('renders network status as expected - when configured', async () => {
 
   userEvent.click(screen.getByText('Close'));
 });
+
+test('renders barcode scanner status warning when scanner is disconnected', async () => {
+  apiMock.setBarcodeScannerStatus(false);
+  apiMock.setElection(
+    electionFamousNames,
+    electionFamousNames.election.precincts[0].id
+  );
+  const result = renderInAppContext(<DeviceStatusBar />, {
+    apiMock,
+  });
+  unmount = result.unmount;
+  const barcodeScannerElement = await screen.findByTestId(
+    'barcode-scanner-status'
+  );
+
+  const icons = within(barcodeScannerElement).getAllByRole('img', {
+    hidden: true,
+  });
+  expect(icons.length).toEqual(2);
+  expect(icons[0].getAttribute('data-icon')).toEqual('id-card');
+  expect(icons[1].getAttribute('data-icon')).toEqual('triangle-exclamation');
+});
+
+test('renders barcode scanner status without warning when scanner is connected', async () => {
+  apiMock.setBarcodeScannerStatus(true);
+  apiMock.setElection(
+    electionFamousNames,
+    electionFamousNames.election.precincts[0].id
+  );
+  const result = renderInAppContext(<DeviceStatusBar />, {
+    apiMock,
+  });
+  unmount = result.unmount;
+  const barcodeScannerElement = await screen.findByTestId(
+    'barcode-scanner-status'
+  );
+
+  const icons = within(barcodeScannerElement).getAllByRole('img', {
+    hidden: true,
+  });
+  expect(icons.length).toEqual(1);
+  expect(icons[0].getAttribute('data-icon')).toEqual('id-card');
+});

--- a/apps/pollbook/frontend/src/nav_screen.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.tsx
@@ -21,6 +21,7 @@ import { DateTime } from 'luxon';
 import styled from 'styled-components';
 import { formatElectionHashes, type PrinterStatus } from '@votingworks/types';
 import type {
+  BarcodeScannerStatus,
   NetworkStatus,
   PollbookConfigurationInformation,
   PollbookServiceInfo,
@@ -286,6 +287,15 @@ function UsbStatus({ status }: { status: UsbDriveStatus }) {
   );
 }
 
+function BarcodeScannerStatus({ status }: { status: BarcodeScannerStatus }) {
+  return (
+    <Row style={{ gap: '0.25rem', alignItems: 'center' }}>
+      <Icons.IdCard color="inverse" />
+      {!status.connected && <Icons.Warning color="inverseWarning" />}
+    </Row>
+  );
+}
+
 function PrinterStatus({ status }: { status: PrinterStatus }) {
   return (
     <Row style={{ gap: '0.25rem', alignItems: 'center' }}>
@@ -348,7 +358,8 @@ export function DeviceStatusBar({
   ) {
     return null;
   }
-  const { network, battery, usbDrive, printer } = getDeviceStatusesQuery.data;
+  const { network, battery, usbDrive, printer, barcodeScanner } =
+    getDeviceStatusesQuery.data;
   const pollbookConfiguration = getPollbookConfigurationInformationQuery.data;
 
   return (
@@ -359,6 +370,7 @@ export function DeviceStatusBar({
           currentMachineConfiguration={pollbookConfiguration}
         />
         <PrinterStatus status={printer} />
+        <BarcodeScannerStatus status={barcodeScanner} />
         <UsbStatus status={usbDrive} />
         <BatteryStatus status={battery} />
         {format.clockDateAndTime(currentDate)}

--- a/apps/pollbook/frontend/src/nav_screen.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.tsx
@@ -289,7 +289,10 @@ function UsbStatus({ status }: { status: UsbDriveStatus }) {
 
 function BarcodeScannerStatus({ status }: { status: BarcodeScannerStatus }) {
   return (
-    <Row style={{ gap: '0.25rem', alignItems: 'center' }}>
+    <Row
+      data-testid="barcode-scanner-status"
+      style={{ gap: '0.25rem', alignItems: 'center' }}
+    >
       <Icons.IdCard color="inverse" />
       {!status.connected && <Icons.Warning color="inverseWarning" />}
     </Row>

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -236,6 +236,17 @@ export function createApiMock() {
         .resolves(currentDeviceStatus);
     },
 
+    setBarcodeScannerStatus(connected: boolean): void {
+      currentDeviceStatus = {
+        ...currentDeviceStatus,
+        barcodeScanner: { connected },
+      };
+      mockApiClient.getDeviceStatuses.reset();
+      mockApiClient.getDeviceStatuses
+        .expectRepeatedCallsWith()
+        .resolves(currentDeviceStatus);
+    },
+
     setNetworkOffline(): void {
       currentDeviceStatus = {
         ...currentDeviceStatus,

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -99,6 +99,7 @@ export function createApiMock() {
 
   let currentDeviceStatus: DeviceStatuses = {
     usbDrive: mockUsbDriveStatus('no_drive'),
+    barcodeScanner: { connected: false },
     printer: { connected: false },
     battery: { level: 1, discharging: false },
     network: {

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -47,6 +47,7 @@ import {
   faGripLines,
   faGripLinesVertical,
   faHardDrive,
+  faIdCard,
   faImage,
   faInfoCircle,
   faItalic,
@@ -341,6 +342,10 @@ export const Icons = {
 
   HardDrive(props) {
     return <FaIcon {...props} type={faHardDrive} />;
+  },
+
+  IdCard(props) {
+    return <FaIcon {...props} type={faIdCard} />;
   },
 
   Image(props) {


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6632

Adds a connection status icon to the nav bar. The daemon must be running and the device must be connected for the indicator to show `connected` (which we show just by hiding the warning indicator). Otherwise it shows a warning indicator.

## Demo Video or Screenshot


https://github.com/user-attachments/assets/ecf43865-cbbe-437d-8494-e0db79edb243



## Testing Plan

- [ ] Add unit tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
