### PR TITLE
hmpb: Refactor to move base style definition into ballot templates

### DIFF
--- a/libs/hmpb/src/all_bubble_ballot/template.tsx
+++ b/libs/hmpb/src/all_bubble_ballot/template.tsx
@@ -17,6 +17,7 @@ import { RenderScratchpad } from '../renderer';
 import { allBubbleBallotConfig } from './config';
 import { candidateId, contestId } from './election';
 import { Footer } from './footer';
+import { BaseStyles } from '../base_styles';
 
 export function allBubbleBallotTemplate(
   paperSize: HmpbBallotPaperSize
@@ -123,6 +124,7 @@ export function allBubbleBallotTemplate(
   }
 
   return {
+    stylesComponent: BaseStyles,
     frameComponent: BallotPageFrame,
     contentComponent: BallotPageContent,
   };

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -60,6 +60,7 @@ import { hmpbStrings } from '../hmpb_strings';
 import { layOutInColumns } from '../layout_in_columns';
 import { Watermark } from './watermark';
 import { ArrowRightCircle } from '../svg_assets';
+import { BaseStyles } from '../base_styles';
 
 function Header({
   election,
@@ -815,6 +816,7 @@ export type NhBallotProps = BaseBallotProps &
   NhPrecinctSplitOptions & { colorTint?: ColorTint };
 
 export const nhBallotTemplate: BallotPageTemplate<NhBallotProps> = {
+  stylesComponent: BaseStyles,
   frameComponent: BallotPageFrame,
   contentComponent: BallotPageContent,
 };

--- a/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/v3_nh_ballot_template.tsx
@@ -54,6 +54,7 @@ import { hmpbStrings } from '../hmpb_strings';
 import { layOutInColumns } from '../layout_in_columns';
 import { NhBallotProps } from './nh_ballot_template';
 import { Watermark } from './watermark';
+import { BaseStyles } from '../base_styles';
 
 const Colors = {
   BLACK: '#000000',
@@ -848,6 +849,7 @@ async function BallotPageContent(
 export const nhBallotTemplateV3: BallotPageTemplate<NhBallotProps> & {
   machineVersion: 'v3';
 } = {
+  stylesComponent: BaseStyles,
   frameComponent: BallotPageFrame,
   contentComponent: BallotPageContent,
   machineVersion: 'v3',

--- a/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
@@ -53,6 +53,7 @@ import { BallotMode, PixelDimensions } from '../types';
 import { layOutInColumns } from '../layout_in_columns';
 import { hmpbStrings } from '../hmpb_strings';
 import { Watermark } from './watermark';
+import { BaseStyles } from '../base_styles';
 
 function Header({
   election,
@@ -572,6 +573,7 @@ async function BallotPageContent(
 }
 
 export const vxDefaultBallotTemplate: BallotPageTemplate<BaseBallotProps> = {
+  stylesComponent: BaseStyles,
   frameComponent: BallotPageFrame,
   contentComponent: BallotPageContent,
 };

--- a/libs/hmpb/src/base_styles.tsx
+++ b/libs/hmpb/src/base_styles.tsx
@@ -27,11 +27,8 @@ function baseStyles(params: BaseStylesProps) {
     font-family: Vx Roboto;
     font-variant-ligatures: none;
     /*
-     * 12pt is the CCD minimum font size:
-     * https://civicdesign.org/typography-makes-ballots-easy-to-read/
-     *
-     * We drop this down to 10pt font for ballots with lots of contests to help
-     * reduce the total sheet count.
+     * 12pt is the Center for Civic Design's recommended default font size, and
+     * 10pt is their recommended minimum accessible font size.
      */
     font-size: ${compact ? 10 : 12}pt;
     line-height: ${baseLineHeight(compact)};

--- a/libs/hmpb/src/playwright_renderer.tsx
+++ b/libs/hmpb/src/playwright_renderer.tsx
@@ -8,7 +8,6 @@ import {
   createDocument,
   createScratchpad,
 } from './renderer';
-import { BaseStyles } from './base_styles';
 
 export interface PlaywrightRenderer extends Renderer {
   getBrowser(): Browser;
@@ -27,14 +26,12 @@ export async function createPlaywrightRenderer(): Promise<PlaywrightRenderer> {
   });
   const context = await browser.newContext();
   return {
-    async createScratchpad(props = {}): Promise<RenderScratchpad> {
+    async createScratchpad(styles): Promise<RenderScratchpad> {
       const page = await context.newPage();
       await page.setContent(
         `<!DOCTYPE html>${ReactDomServer.renderToStaticMarkup(
           <html>
-            <head>
-              <BaseStyles {...props} />
-            </head>
+            <head>{styles}</head>
             <body />
           </html>
         )}`

--- a/libs/hmpb/src/preview/browser_preview_renderer.tsx
+++ b/libs/hmpb/src/preview/browser_preview_renderer.tsx
@@ -7,7 +7,6 @@ import {
   createDocument,
   createScratchpad,
 } from '../renderer';
-import { BaseStyles, BaseStylesProps } from '../base_styles';
 import { PAGE_CLASS } from '../ballot_components';
 
 function browserPage(): Page {
@@ -30,12 +29,10 @@ function browserPage(): Page {
   };
 }
 
-function createBrowserPreviewDocument(
-  props: BaseStylesProps = {}
-): RenderDocument {
+function createBrowserPreviewDocument(styles: JSX.Element): RenderDocument {
   document.head.innerHTML += ReactDomServer.renderToString(
     <>
-      <BaseStyles {...props} />
+      {styles}
       <style type="text/css">
         {`
         body {
@@ -57,14 +54,14 @@ function createBrowserPreviewDocument(
 }
 
 export function createBrowserPreviewRenderer(): Renderer {
+  let document: RenderDocument;
   return {
-    createScratchpad(props?: BaseStylesProps) {
-      return Promise.resolve(
-        createScratchpad(createBrowserPreviewDocument(props))
-      );
+    createScratchpad(styles) {
+      document = createBrowserPreviewDocument(styles);
+      return Promise.resolve(createScratchpad(document));
     },
     cloneDocument() {
-      return Promise.resolve(createBrowserPreviewDocument());
+      return Promise.resolve(document);
     },
     cleanup() {
       return Promise.resolve();

--- a/libs/hmpb/src/renderer.tsx
+++ b/libs/hmpb/src/renderer.tsx
@@ -6,7 +6,6 @@ import { ServerStyleSheet } from 'styled-components';
 import { assert } from '@votingworks/basics';
 import { PixelMeasurements } from './types';
 import { PAGE_CLASS } from './ballot_components';
-import { BaseStylesProps } from './base_styles';
 
 export type Page = Pick<
   PlaywrightPage,
@@ -178,7 +177,7 @@ export interface Renderer {
   /**
    * Creates a new {@link RenderScratchpad}.
    */
-  createScratchpad(props?: BaseStylesProps): Promise<RenderScratchpad>;
+  createScratchpad(styles: JSX.Element): Promise<RenderScratchpad>;
 
   /**
    * Given a {@link RenderDocument}, creates a new {@link RenderDocument} with the same content.


### PR DESCRIPTION
## Overview

Fixes https://github.com/votingworks/vxsuite/issues/6076

Having the renderer be responsible for including `BaseStyles` was always a bit of a violation of the abstraction that templates specify content and styling while the renderer is just responsible for rendering it. It was a shortcut I put in place since all templates shared the same base styles.

This started to break down when we needed to parameterize the styles based on ballot props (namely, adding `compact`, which changes font size and line height). In the future, it looks like we'll also need to change the fonts for upcoming NH state ballots.

To get ahead of this, I added a new field to the ballot template to specify the base styles to use. The renderer will still only add this to the document head once at the beginning, but it will make it easier to customize these styles on a per-template basis moving forward. Plus, it patches up the separation of concerns shortcut.

## Demo Video or Screenshot
N/A

## Testing Plan
Existing tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
