### PR TITLE
feat(scan): change scale measurement to use full width

### DIFF
--- a/libs/ballot-interpreter/src/hmpb-rust/ballot_card.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/ballot_card.rs
@@ -136,7 +136,7 @@ impl Geometry {
     }
 
     /// Gets the distance from the center of a left border timing mark to the
-    /// center of its correspondinng right border timing mark.
+    /// center of its corresponding right border timing mark.
     #[must_use]
     pub fn left_to_right_center_to_center_pixel_distance(&self) -> SubPixelUnit {
         ((self.timing_mark_horizontal_spacing + self.timing_mark_size.width)
@@ -145,7 +145,7 @@ impl Geometry {
     }
 
     /// Gets the distance from the center of a top border timing mark to the
-    /// center of its correspondinng bottom border timing mark.
+    /// center of its corresponding bottom border timing mark.
     #[must_use]
     pub fn top_to_bottom_center_to_center_pixel_distance(&self) -> SubPixelUnit {
         ((self.timing_mark_vertical_spacing + self.timing_mark_size.height)

--- a/libs/ballot-interpreter/src/hmpb-rust/ballot_card.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/ballot_card.rs
@@ -134,6 +134,24 @@ impl Geometry {
         (self.timing_mark_vertical_spacing + self.timing_mark_size.height)
             .pixels(self.pixels_per_inch)
     }
+
+    /// Gets the distance from the center of a left border timing mark to the
+    /// center of its correspondinng right border timing mark.
+    #[must_use]
+    pub fn left_to_right_center_to_center_pixel_distance(&self) -> SubPixelUnit {
+        ((self.timing_mark_horizontal_spacing + self.timing_mark_size.width)
+            * (self.grid_size.width - 1) as f32)
+            .pixels(self.pixels_per_inch)
+    }
+
+    /// Gets the distance from the center of a top border timing mark to the
+    /// center of its correspondinng bottom border timing mark.
+    #[must_use]
+    pub fn top_to_bottom_center_to_center_pixel_distance(&self) -> SubPixelUnit {
+        ((self.timing_mark_vertical_spacing + self.timing_mark_size.height)
+            * (self.grid_size.height - 1) as f32)
+            .pixels(self.pixels_per_inch)
+    }
 }
 
 /// Expected PPI for scanned ballot cards.

--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -43,7 +43,7 @@ use crate::timing_marks::contours;
 use crate::timing_marks::corners;
 use crate::timing_marks::normalize_orientation;
 use crate::timing_marks::BallotPageMetadata;
-use crate::timing_marks::Border;
+use crate::timing_marks::BorderAxis;
 use crate::timing_marks::DefaultForGeometry;
 use crate::timing_marks::TimingMarks;
 
@@ -484,12 +484,11 @@ pub fn ballot_card(
             (SIDE_A_LABEL, &side_a_timing_marks),
             (SIDE_B_LABEL, &side_b_timing_marks),
         ] {
-            // We use the bottom border here because:
-            // - there should be little to no stretching along the horizontal axis (we assume it's perpendicular to the scan direction)
-            // - any stretch/skew tends to occur at the start of scan/top
-            // - the detected scale vs. printed scale delta is smaller compared to the other measures we've tried
+            // We use the horizontal axis here because it is perpendicular to
+            // the scan direction and therefore stretching should be minimal.
+            //
             // See https://votingworks.slack.com/archives/CEL6D3GAD/p1750095447642289 for more context.
-            if let Some(scale) = timing_marks.compute_scale_based_on_border(Border::Bottom) {
+            if let Some(scale) = timing_marks.compute_scale_based_on_axis(BorderAxis::Horizontal) {
                 if scale < minimum_detected_scale {
                     return Err(Error::InvalidScale {
                         label: label.to_owned(),


### PR DESCRIPTION
## Overview

This measurement should be generally quite close to the bottom border-only measurement because they're both measuring features of the timing mark grid at the scale (ahem) of the page, but in practice will likely be a bit higher due to it incorporating some of the skew that may be present toward the top of the scan. Taking the median distance from the left to right timing marks will mitigate that effect to some degree. On the TRR corpus the difference in the measures is very close, about 0.08% average / 0.03% median.

Note that actually using this measurement to reject ballots is still disabled by default, and we'll need to do some testing to determine whether the previously determined 98.5% threshold is still a good value before we use it in an election.

This keeps the ability to compute the border based scale as well as adding the new axis based scale measurement, though as mentioned neither are used by default. Both can be configured to act as thresholds in and are part of the stats output of the `debug-timing-marks` utility.

## Demo Video or Screenshot
This chart shows the difference on the TRR corpus of the "bottom border" and "horizontal axis" scale measurements, plus some stats about the differences below.
![bottom minus horizontal](https://github.com/user-attachments/assets/618d1d9d-7a5c-4fe4-b45e-c46c5801398f)

|Bottom Minus Horizontal …||
|-|-|
|Average | -0.08%|
|Median | -0.03%|
|Min | 0.00%|
|Max | 0.63%|
|Stddev | 0.11%|


## Testing Plan
Tested on the TRR corpus and found the stat to be different, but not in a way that changed what would have been accepted or rejected with a 98.5% threshold.