### PR TITLE
voter details page style changes

### DIFF
--- a/apps/pollbook/frontend/src/voter_details_screen.test.tsx
+++ b/apps/pollbook/frontend/src/voter_details_screen.test.tsx
@@ -372,7 +372,7 @@ test('undo check-in', async () => {
   });
   userEvent.click(undoButton);
 
-  await screen.findByText('Not checked in');
+  await screen.findByText('Not Checked In');
 });
 
 test('reprint check-in receipt', async () => {

--- a/apps/pollbook/frontend/src/voter_details_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_details_screen.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  ButtonBar,
   Caption,
   Card,
   H1,
@@ -19,6 +20,7 @@ import React, { useCallback, useState } from 'react';
 import type { Voter } from '@votingworks/pollbook-backend';
 import { assertDefined, sleep, assert } from '@votingworks/basics';
 import { PrinterStatus } from '@votingworks/types';
+import { DateTime } from 'luxon';
 import { electionManagerRoutes, NoNavScreen } from './nav_screen';
 import {
   getDeviceStatuses,
@@ -184,9 +186,6 @@ function VoterDetailsScreenLayout({
       <MainHeader>
         <Row style={{ justifyContent: 'space-between' }}>
           <H1>Voter Details</H1>
-          <Button icon="Delete" onPress={onClose} variant="primary">
-            Close
-          </Button>
         </Row>
       </MainHeader>
       <MainContent
@@ -194,6 +193,11 @@ function VoterDetailsScreenLayout({
       >
         {children}
       </MainContent>
+      <ButtonBar>
+        <Button icon="Delete" onPress={onClose} variant="primary">
+          Close
+        </Button>
+      </ButtonBar>
     </NoNavScreen>
   );
 }
@@ -409,22 +413,29 @@ export function VoterDetailsScreen(): JSX.Element | null {
         </Column>
         <Column style={{ flex: 1, flexBasis: 1, gap: '1rem' }}>
           <Card color="neutral">
-            <Column style={{ gap: '1rem' }}>
-              {voter.isInactive && (
+            {voter.isInactive && (
+              <H2 style={{ marginTop: 0 }}>
+                <Icons.Flag /> Inactive
+              </H2>
+            )}
+            {!voter.checkIn && !voter.isInactive && (
+              <H2 style={{ marginTop: 0 }}>
+                <Icons.Info /> Not Checked In
+              </H2>
+            )}
+            {voter.checkIn && !voter.isInactive && (
+              <React.Fragment>
                 <H2 style={{ marginTop: 0 }}>
-                  <Icons.Flag /> Inactive
+                  <Icons.Done /> Checked In
                 </H2>
-              )}
-              {!voter.checkIn && !voter.isInactive && (
-                <H2 style={{ marginTop: 0 }}>Not checked in</H2>
-              )}
-              {voter.checkIn && !voter.isInactive && (
-                <React.Fragment>
-                  <H2 style={{ marginTop: 0 }}>Checked in</H2>
+                <Column style={{ gap: '1rem' }}>
                   <LabelledText label="Time">
-                    {voter.checkIn.timestamp}
+                    {DateTime.fromISO(voter.checkIn.timestamp).toLocaleString({
+                      ...DateTime.DATETIME_SHORT,
+                      second: 'numeric',
+                    })}
                   </LabelledText>
-                  <LabelledText label="Machine">
+                  <LabelledText label="Poll Book">
                     {voter.checkIn.machineId}
                   </LabelledText>
                   {voter.checkIn.identificationMethod.type ===
@@ -438,9 +449,9 @@ export function VoterDetailsScreen(): JSX.Element | null {
                       </LabelledText>
                     </React.Fragment>
                   )}
-                </React.Fragment>
-              )}
-            </Column>
+                </Column>
+              </React.Fragment>
+            )}
           </Card>
           {!voter.checkIn && !voter.isInactive && (
             <Button
@@ -467,6 +478,8 @@ export function VoterDetailsScreen(): JSX.Element | null {
               <Button
                 icon="Delete"
                 onPress={() => setShowUndoCheckinFlow(true)}
+                color="danger"
+                fill="outlined"
               >
                 Undo Check-In
               </Button>

--- a/apps/pollbook/frontend/src/voter_details_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_details_screen.tsx
@@ -194,7 +194,7 @@ function VoterDetailsScreenLayout({
         {children}
       </MainContent>
       <ButtonBar>
-        <Button icon="Delete" onPress={onClose} variant="primary">
+        <Button onPress={onClose} variant="primary">
           Close
         </Button>
       </ButtonBar>

--- a/apps/pollbook/frontend/src/voters_screen.tsx
+++ b/apps/pollbook/frontend/src/voters_screen.tsx
@@ -1,13 +1,16 @@
 import { MainContent, Font, H1, LinkButton, Icons } from '@votingworks/ui';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { Voter, VoterSearchParams } from '@votingworks/pollbook-backend';
 import { useHistory } from 'react-router-dom';
 import { assertDefined } from '@votingworks/basics';
-import { DateTime } from 'luxon';
 import { getDeviceStatuses, getElection } from './api';
 import { Column, Row } from './layout';
 import { ElectionManagerNavScreen } from './nav_screen';
-import { VoterSearch, createEmptySearchParams } from './voter_search_screen';
+import {
+  CheckInDetails,
+  VoterSearch,
+  createEmptySearchParams,
+} from './voter_search_screen';
 import { ExportVoterActivityButton } from './export_voter_activity';
 
 function getDetailsPageUrl(voter: Voter): string {
@@ -52,17 +55,7 @@ export function ElectionManagerVotersScreen(): JSX.Element | null {
           renderAction={(voter) => (
             <Column style={{ gap: '0.5rem' }}>
               {voter.checkIn ? (
-                <React.Fragment>
-                  <span>
-                    <Icons.Done /> Checked In
-                  </span>
-                  <span>
-                    {DateTime.fromISO(voter.checkIn.timestamp).toLocaleString(
-                      DateTime.TIME_SIMPLE
-                    )}{' '}
-                    • {voter.checkIn.machineId}
-                  </span>
-                </React.Fragment>
+                <CheckInDetails checkIn={voter.checkIn} />
               ) : (
                 <span>
                   <Icons.Info /> Not Checked In

--- a/apps/pollbook/frontend/src/voters_screen.tsx
+++ b/apps/pollbook/frontend/src/voters_screen.tsx
@@ -1,10 +1,11 @@
-import { MainContent, Font, H1, LinkButton } from '@votingworks/ui';
-import { useState } from 'react';
+import { MainContent, Font, H1, LinkButton, Icons } from '@votingworks/ui';
+import React, { useState } from 'react';
 import type { Voter, VoterSearchParams } from '@votingworks/pollbook-backend';
 import { useHistory } from 'react-router-dom';
 import { assertDefined } from '@votingworks/basics';
+import { DateTime } from 'luxon';
 import { getDeviceStatuses, getElection } from './api';
-import { Row } from './layout';
+import { Column, Row } from './layout';
 import { ElectionManagerNavScreen } from './nav_screen';
 import { VoterSearch, createEmptySearchParams } from './voter_search_screen';
 import { ExportVoterActivityButton } from './export_voter_activity';
@@ -49,12 +50,32 @@ export function ElectionManagerVotersScreen(): JSX.Element | null {
             history.push(getDetailsPageUrl(voter));
           }}
           renderAction={(voter) => (
-            <LinkButton
-              style={{ flexWrap: 'nowrap' }}
-              to={getDetailsPageUrl(voter)}
-            >
-              <Font noWrap>View Details</Font>
-            </LinkButton>
+            <Column style={{ gap: '0.5rem' }}>
+              {voter.checkIn ? (
+                <React.Fragment>
+                  <span>
+                    <Icons.Done /> Checked In
+                  </span>
+                  <span>
+                    {DateTime.fromISO(voter.checkIn.timestamp).toLocaleString(
+                      DateTime.TIME_SIMPLE
+                    )}{' '}
+                    • {voter.checkIn.machineId}
+                  </span>
+                </React.Fragment>
+              ) : (
+                <span>
+                  <Icons.Info /> Not Checked In
+                </span>
+              )}
+
+              <LinkButton
+                style={{ flexWrap: 'nowrap' }}
+                to={getDetailsPageUrl(voter)}
+              >
+                <Font noWrap>View Details</Font>
+              </LinkButton>
+            </Column>
           )}
         />
       </MainContent>


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6440

Cosmetic changes for election manager voter search UX.

## Demo Video or Screenshot

cc @adghayes for product feedback

**Search**

<img width="987" alt="Screenshot 2025-07-07 at 10 35 33 AM" src="https://github.com/user-attachments/assets/b4cd5882-d466-4632-8e2d-59f23a3c1c0c" />

**Voter checked in**

<img width="985" alt="Screenshot 2025-07-07 at 10 35 38 AM" src="https://github.com/user-attachments/assets/1e07d274-56dc-4f16-9f4c-3355bc82dadd" />

* Buttons look misaligned relative to each other even though they are correctly aligned to their columns
* We might consider a hamburger menu on these columns as functionality continues to grow and it becomes cumbersome to add more buttons
* "Close" button is actually in the opposite place compared to the pollworker screen, where it's on the bottom left
  * In a footer with only 1 button I think it feels more natural to keep it on the right because I generally associate action with sides of the screen (left for previous, right for next, probably has to do with reading direction)
  * That said, open to feedback if we want to put the "Cancel" button in the exact same spot (on the left)

**Voter not checked in**

<img width="984" alt="Screenshot 2025-07-07 at 10 45 51 AM" src="https://github.com/user-attachments/assets/2dc91891-1d55-412b-8d78-007098021278" />

## Testing Plan

- N/A display changes only

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
