### PR TITLE
feat(fixtures): add API to make temp files/dirs

### DIFF
--- a/libs/fixtures/src/tmpdir.test.ts
+++ b/libs/fixtures/src/tmpdir.test.ts
@@ -1,8 +1,14 @@
+import { Buffer } from 'node:buffer';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { afterEach, expect, test } from 'vitest';
 import {
   clearTemporaryRootDir,
   getPathForFile,
   getTemporaryRootDir,
+  makeTemporaryDirectory,
+  makeTemporaryFile,
+  makeTemporaryFileAsync,
+  makeTemporaryPath,
   setTemporaryRootDir,
   setupTemporaryRootDir,
 } from './tmpdir';
@@ -35,4 +41,93 @@ test('getPathForFile throws when temporary root directory is unset', () => {
 test('getPathForFile returns the path to a file in the temporary root directory', () => {
   setTemporaryRootDir('tmp');
   expect(getPathForFile('file')).toEqual('tmp/file');
+});
+
+test('makeTemporaryPath makes a path but does not create anything at that path', () => {
+  setTemporaryRootDir('tmp');
+  const path = makeTemporaryPath();
+  expect(path).toMatch(/tmp\/.*/);
+  expect(existsSync(path)).toBeFalsy();
+});
+
+test('makeTemporaryDirectory makes a directory at a temporary path', () => {
+  setupTemporaryRootDir();
+  const path = makeTemporaryDirectory();
+  expect(path).toMatch(/tmp\/.*/);
+  expect(statSync(path).isDirectory()).toBeTruthy();
+});
+
+test('makeTemporaryFile makes a file at a temporary path', () => {
+  setupTemporaryRootDir();
+
+  const path = makeTemporaryFile();
+  expect(path).toMatch(/tmp\/.*/);
+  expect(statSync(path).isFile()).toBeTruthy();
+  expect(readFileSync(path)).toEqual(Buffer.of());
+
+  const pathWithStringContent = makeTemporaryFile({ content: 'abc' });
+  expect(pathWithStringContent).toMatch(/tmp\/.*/);
+  expect(statSync(pathWithStringContent).isFile()).toBeTruthy();
+  expect(readFileSync(pathWithStringContent, 'utf-8')).toEqual('abc');
+
+  const pathWithBinaryContent = makeTemporaryFile({
+    content: Buffer.of(1, 2, 3),
+  });
+  expect(pathWithBinaryContent).toMatch(/tmp\/.*/);
+  expect(statSync(pathWithBinaryContent).isFile()).toBeTruthy();
+  expect(readFileSync(pathWithBinaryContent)).toEqual(Buffer.of(1, 2, 3));
+});
+
+test('makeTemporaryFileAsync makes a file at a temporary path', async () => {
+  setupTemporaryRootDir();
+
+  const path = await makeTemporaryFileAsync();
+  expect(path).toMatch(/tmp\/.*/);
+  expect(statSync(path).isFile()).toBeTruthy();
+  expect(readFileSync(path)).toEqual(Buffer.of());
+
+  const pathWithStringContent = await makeTemporaryFileAsync({
+    content: 'abc',
+  });
+  expect(pathWithStringContent).toMatch(/tmp\/.*/);
+  expect(statSync(pathWithStringContent).isFile()).toBeTruthy();
+  expect(readFileSync(pathWithStringContent, 'utf-8')).toEqual('abc');
+
+  const pathWithBinaryContent = await makeTemporaryFileAsync({
+    content: Buffer.of(1, 2, 3),
+  });
+  expect(pathWithBinaryContent).toMatch(/tmp\/.*/);
+  expect(statSync(pathWithBinaryContent).isFile()).toBeTruthy();
+  expect(readFileSync(pathWithBinaryContent)).toEqual(Buffer.of(1, 2, 3));
+
+  const pathWithAsyncIteratorContent = await makeTemporaryFileAsync({
+    content: (async function* content() {
+      yield Buffer.of(1);
+      yield Buffer.of(await Promise.resolve(2));
+      yield Buffer.of(3);
+    })(),
+  });
+  expect(pathWithAsyncIteratorContent).toMatch(/tmp\/.*/);
+  expect(statSync(pathWithAsyncIteratorContent).isFile()).toBeTruthy();
+  expect(readFileSync(pathWithAsyncIteratorContent)).toEqual(
+    Buffer.of(1, 2, 3)
+  );
+});
+
+test.each([
+  { fn: makeTemporaryPath, name: 'makeTemporaryPath' },
+  { fn: makeTemporaryDirectory, name: 'makeTemporaryDirectory' },
+  { fn: makeTemporaryFile, name: 'makeTemporaryFile' },
+  { fn: makeTemporaryFileAsync, name: 'makeTemporaryFileAsync' },
+])('$name prefix + postfix', async ({ fn }) => {
+  setupTemporaryRootDir();
+  const prefixPath = await fn({ prefix: 'abc' });
+  expect(prefixPath).toMatch(/\/abc.*/);
+  const postfixPath = await fn({ postfix: '.pdf' });
+  expect(postfixPath).toMatch(/\/.*\.pdf$/);
+  const prefixPostfixPath = await fn({
+    prefix: 'abc',
+    postfix: '.pdf',
+  });
+  expect(prefixPostfixPath).toMatch(/\/abc.*\.pdf$/);
 });

--- a/libs/fixtures/src/tmpdir.ts
+++ b/libs/fixtures/src/tmpdir.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert';
-import { mkdirSync, rmSync } from 'node:fs';
+import * as crypto from 'node:crypto';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, normalize } from 'node:path';
+import Stream from 'node:stream';
 
 let temporaryRootDir: string | undefined;
 
@@ -76,4 +79,83 @@ export function getPathForFile(filePath: string): string {
     'File path must not start with ".."'
   );
   return join(temporaryRootDir, filePath);
+}
+
+/**
+ * Options for generating a temporary file system entry name.
+ */
+export interface TemporaryNameOptions {
+  prefix?: string;
+  postfix?: string;
+}
+
+/**
+ * Makes a path to a temporary file system entry within the root temporary
+ * directory, but does not actually create anything.
+ *
+ * @throws If the temporary root directory has not been set.
+ */
+export function makeTemporaryPath(options?: TemporaryNameOptions): string {
+  let name = crypto.randomUUID();
+  if (options?.prefix) {
+    name = options.prefix + name;
+  }
+  if (options?.postfix) {
+    name += options.postfix;
+  }
+
+  return join(getTemporaryRootDir(), name);
+}
+
+/**
+ * Create a temporary directory within the root temporary directory.
+ *
+ * @throws If the temporary root directory has not been set.
+ */
+export function makeTemporaryDirectory(options?: TemporaryNameOptions): string {
+  const path = makeTemporaryPath(options);
+  mkdirSync(path, { recursive: true });
+  return path;
+}
+
+/**
+ * Options for generating a temporary file.
+ */
+export interface TemporaryFileOptions extends TemporaryNameOptions {
+  content?: string | NodeJS.ArrayBufferView;
+}
+
+/**
+ * Create a temporary file within the root temporary directory.
+ *
+ * @throws If the temporary root directory has not been set.
+ */
+export function makeTemporaryFile(options?: TemporaryFileOptions): string {
+  const path = makeTemporaryPath(options);
+  writeFileSync(path, options?.content ?? '');
+  return path;
+}
+/**
+ * Options for generating a temporary file asynchronously.
+ */
+export interface TemporaryFileAsyncOptions extends TemporaryNameOptions {
+  content?:
+    | string
+    | NodeJS.ArrayBufferView
+    | Iterable<string | NodeJS.ArrayBufferView>
+    | AsyncIterable<string | NodeJS.ArrayBufferView>
+    | Stream;
+}
+
+/**
+ * Create a temporary file within the root temporary directory asynchronously.
+ *
+ * @throws If the temporary root directory has not been set.
+ */
+export async function makeTemporaryFileAsync(
+  options?: TemporaryFileAsyncOptions
+): Promise<string> {
+  const path = makeTemporaryPath(options);
+  await writeFile(path, options?.content ?? '');
+  return path;
 }

--- a/libs/fixtures/src/tmpdir.ts
+++ b/libs/fixtures/src/tmpdir.ts
@@ -4,7 +4,7 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, normalize } from 'node:path';
-import Stream from 'node:stream';
+import { Stream } from 'node:stream';
 
 let temporaryRootDir: string | undefined;
 


### PR DESCRIPTION
## Overview

`vxsuite` has lots of temporary files and directories created in tests, and is inconsistent about cleaning them up. When an effort is made to clean them up, there are often per-package ways of doing so that are effective to varying degrees. This is a step toward unifying tmpfile handling.

The idea is that all tests that need to create temporary files will use these functions to do so rather than using `tmp` (or `tmp-promise`). Why not use `tmp`? It refuses to delete temporary directories recursively on process exit when `setGracefulCleanup` is enabled, instead requiring that you call `dirSync` with `unsafeCleanup: true` and then manually invoke the `removeCallback` method on the returned `DirEntry`. This makes creating temporary files and directories in tests somewhat painful and encourages improper use such as just not cleaning them up or [big hammers like `rm -rf /tmp/mock-print-job-*`, which causes flaky tests](https://github.com/votingworks/vxsuite/pull/6702).

The next step after this is to integrate the `tmpdir` setup/teardown hooks from `@votingworks/fixtures` in any packages that create temporary files/dirs and replace any uses of `fileSync`/`dirSync`/`tmpNameSync` with the functions added here.

## Demo Video or Screenshot

```ts
import { makeTemporaryFile } from '@votingworks/fixtures';

test('a thing', () => {
  // creates a file in `/tmp` and automatically cleans it up on process exit
  const path = makeTemporaryFile({ content: 'some data!' });
  expect(fs.readFileSync(path, 'utf8')).toEqual('some data!');
});
```

## Testing Plan
Added new automated tests.