### PR TITLE
fix(design): properly dispose of tmpfiles

### DIFF
--- a/apps/design/backend/src/worker/ballot_pdfs.test.ts
+++ b/apps/design/backend/src/worker/ballot_pdfs.test.ts
@@ -1,6 +1,5 @@
 import { expect, Mocked, test, vi } from 'vitest';
 import { Buffer } from 'node:buffer';
-import { createReadStream, ReadStream } from 'node:fs';
 
 import {
   BaseBallotProps,
@@ -25,7 +24,7 @@ test('renderBallotPdf - converts non-tinted ballots to grayscale', async () => {
     renderToPdf: vi.fn(() => mockColorPdf),
   } as unknown as Mocked<RenderDocument>;
 
-  const mockGrayscalePdfNh: ReadStream = createReadStream('/dev/null');
+  const mockGrayscalePdfNh = Buffer.of(0xca, 0xef);
   vi.mocked(convertPdfToGrayscale).mockResolvedValueOnce(mockGrayscalePdfNh);
 
   expect(await renderBallotPdf(nhProps, mockDocument)).toStrictEqual(
@@ -37,7 +36,7 @@ test('renderBallotPdf - converts non-tinted ballots to grayscale', async () => {
     precinctId: 'non-nh-precinct',
   } as unknown as BaseBallotProps;
 
-  const mockGrayscalePdfNonNh: ReadStream = createReadStream('/dev/null');
+  const mockGrayscalePdfNonNh = Buffer.of(0xac, 0xfe);
   vi.mocked(convertPdfToGrayscale).mockResolvedValueOnce(mockGrayscalePdfNonNh);
 
   expect(await renderBallotPdf(nonNhProps, mockDocument)).toStrictEqual(

--- a/apps/design/backend/src/worker/ballot_pdfs.ts
+++ b/apps/design/backend/src/worker/ballot_pdfs.ts
@@ -1,4 +1,3 @@
-import { ReadStream } from 'node:fs';
 import { Buffer } from 'node:buffer';
 
 import { BaseBallotProps, RenderDocument } from '@votingworks/hmpb';
@@ -8,7 +7,7 @@ import { convertPdfToGrayscale } from './grayscale';
 export async function renderBallotPdf(
   props: BaseBallotProps,
   document: RenderDocument
-): Promise<Buffer | ReadStream> {
+): Promise<Buffer> {
   /**
    * Specific to NH V4 ballots with tinted headers/footers.
    * See `import('@votingworks/hmpb').NhBallotProps`.
@@ -20,5 +19,5 @@ export async function renderBallotPdf(
     return colorPdf;
   }
 
-  return convertPdfToGrayscale(colorPdf);
+  return await convertPdfToGrayscale(colorPdf);
 }

--- a/apps/design/backend/src/worker/grayscale.ts
+++ b/apps/design/backend/src/worker/grayscale.ts
@@ -1,28 +1,30 @@
 import { tmpNameSync } from 'tmp';
 import { promisify } from 'node:util';
-import { exec } from 'node:child_process';
-import { createReadStream, createWriteStream, ReadStream } from 'node:fs';
+import { execFile } from 'node:child_process';
 import { Buffer } from 'node:buffer';
+import { readFile, rm, writeFile } from 'node:fs/promises';
 
 /**
  * Given a PDF document, convert it to grayscale and return a read stream to
  * the resulting PDF.
  */
-export async function convertPdfToGrayscale(pdf: Buffer): Promise<ReadStream> {
+export async function convertPdfToGrayscale(pdf: Buffer): Promise<Buffer> {
   const tmpPdfFilePath = tmpNameSync();
-  const fileStream = createWriteStream(tmpPdfFilePath);
-  fileStream.write(pdf);
-  fileStream.end();
+  await writeFile(tmpPdfFilePath, pdf);
   const tmpGrayscalePdfFilePath = tmpNameSync();
-  await promisify(exec)(`
-    gs \
-      -sOutputFile=${tmpGrayscalePdfFilePath} \
-      -sDEVICE=pdfwrite \
-      -sColorConversionStrategy=Gray \
-      -dProcessColorModel=/DeviceGray \
-      -dNOPAUSE \
-      -dBATCH \
-      ${tmpPdfFilePath}
-  `);
-  return createReadStream(tmpGrayscalePdfFilePath);
+  await promisify(execFile)('gs', [
+    `-sOutputFile=${tmpGrayscalePdfFilePath}`,
+    '-sDEVICE=pdfwrite',
+    '-sColorConversionStrategy=Gray',
+    '-dProcessColorModel=/DeviceGray',
+    '-dNOPAUSE',
+    '-dBATCH',
+    tmpPdfFilePath,
+  ]);
+  try {
+    return await readFile(tmpGrayscalePdfFilePath);
+  } finally {
+    await rm(tmpGrayscalePdfFilePath);
+    await rm(tmpPdfFilePath);
+  }
 }


### PR DESCRIPTION
## Overview

When converting a PDF to grayscale we should be deleting the files that are written to disk, but we weren't.

Also, changes `convertPdfToGrayscale` to use `execFile` instead of `exec` to avoid the possibility of command injection.

## Demo Video or Screenshot
n/a

## Testing Plan
Updated existing tests.