### PR TITLE
VxDesign: Fix migration to add ballot_compact column

### DIFF
--- a/apps/design/backend/migrations/1751482460757_add-ballot-compact.js
+++ b/apps/design/backend/migrations/1751482460757_add-ballot-compact.js
@@ -27,9 +27,8 @@ exports.up = async (pgm) => {
     const compact =
       ballotTemplateId === 'NhBallotCompact' ||
       ballotTemplateId === 'NhBallotV3Compact';
-    await pgm.db.query({
-      text: 'UPDATE elections SET ballot_compact = $1 WHERE id = $2',
-      values: [compact, electionId],
-    });
+    pgm.sql(
+      `UPDATE elections SET ballot_compact = ${compact} WHERE id = '${electionId}'`
+    );
   }
 };


### PR DESCRIPTION

## Overview

It turns out `pgm.db.query` doesn't register newly added columns from earlier in the migration, but `pgm.sql` does.

## Demo Video or Screenshot

## Testing Plan

Ran migration locally with a db snapshot

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
