### PR TITLE
[MarkScan] Extract page layouts to mark-flow-ui for use in VxMark

### DIFF
--- a/apps/mark-scan/frontend/src/pages/ask_poll_worker_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/ask_poll_worker_page.tsx
@@ -3,7 +3,7 @@ import { appStrings, Caption, H6, Icons, P } from '@votingworks/ui';
 import { InsertedSmartCardAuth } from '@votingworks/types';
 import { isPollWorkerAuth } from '@votingworks/utils';
 import React from 'react';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 interface Props {
   authStatus: InsertedSmartCardAuth.AuthStatus;

--- a/apps/mark-scan/frontend/src/pages/ballot_ready_for_review_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_ready_for_review_screen.tsx
@@ -1,6 +1,6 @@
 import { Icons, P } from '@votingworks/ui';
 
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 import { ResetVoterSessionButton } from '../components/deactivate_voter_session_button';
 
 export function BallotReadyForReviewScreen(): JSX.Element {

--- a/apps/mark-scan/frontend/src/pages/ballot_successfully_cast_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/ballot_successfully_cast_page.tsx
@@ -1,5 +1,5 @@
 import { Icons, P, appStrings } from '@votingworks/ui';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 export function BallotSuccessfullyCastPage(): JSX.Element {
   return (

--- a/apps/mark-scan/frontend/src/pages/casting_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/casting_ballot_page.tsx
@@ -1,5 +1,5 @@
 import { H2, InsertBallotImage, appStrings } from '@votingworks/ui';
-import { CenteredPageLayout } from '../components/centered_page_layout';
+import { CenteredPageLayout } from '@votingworks/mark-flow-ui';
 
 export function CastingBallotPage(): JSX.Element {
   return (

--- a/apps/mark-scan/frontend/src/pages/continue_to_review_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/continue_to_review_page.tsx
@@ -6,7 +6,7 @@ import {
   PageNavigationButtonId,
   Icons,
 } from '@votingworks/ui';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 // This page is rendered as part of the blank ballot interpretation flow immediately after
 // the poll worker card is removed. To protect voter privacy, we render this screen first to

--- a/apps/mark-scan/frontend/src/pages/empty_ballot_box_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/empty_ballot_box_page.tsx
@@ -1,9 +1,9 @@
 import { InsertedSmartCardAuth } from '@votingworks/types';
 
 import { Button, Icons, P, appStrings } from '@votingworks/ui';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 import { AskPollWorkerPage } from './ask_poll_worker_page';
 import { confirmBallotBoxEmptied } from '../api';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
 
 interface Props {
   authStatus: InsertedSmartCardAuth.AuthStatus;

--- a/apps/mark-scan/frontend/src/pages/inserted_blank_sheet_instead_of_ballot_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_blank_sheet_instead_of_ballot_screen.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Icons, P } from '@votingworks/ui';
 
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 export function InsertedBlankSheetInsteadOfBallotScreen(): React.ReactNode {
   return (

--- a/apps/mark-scan/frontend/src/pages/inserted_preprinted_ballot_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_preprinted_ballot_screen.tsx
@@ -4,8 +4,8 @@ import { Button, Icons, P } from '@votingworks/ui';
 import { BallotStyleId, PrecinctId, VotesDict } from '@votingworks/types';
 import { assert } from '@votingworks/basics';
 
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 import * as api from '../api';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
 
 export interface InsertedPreprintedBallotScreenProps {
   activateCardlessVoterSession: (

--- a/apps/mark-scan/frontend/src/pages/inserted_unreadable_ballot_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_unreadable_ballot_screen.tsx
@@ -1,6 +1,6 @@
 import { Caption, Icons, P } from '@votingworks/ui';
 
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 export function InsertedUnreadableBallotScreen(): JSX.Element {
   return (

--- a/apps/mark-scan/frontend/src/pages/inserted_wrong_election_ballot_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_wrong_election_ballot_screen.tsx
@@ -1,6 +1,6 @@
 import { appStrings, Caption, Icons, P } from '@votingworks/ui';
 
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 export function InsertedWrongElectionBallotScreen(): JSX.Element {
   return (

--- a/apps/mark-scan/frontend/src/pages/inserted_wrong_precinct_ballot_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_wrong_precinct_ballot_screen.tsx
@@ -1,6 +1,6 @@
 import { appStrings, Caption, Icons, P } from '@votingworks/ui';
 
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 export function InsertedWrongPrecinctBallotScreen(): JSX.Element {
   return (

--- a/apps/mark-scan/frontend/src/pages/inserted_wrong_test_mode_ballot_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/inserted_wrong_test_mode_ballot_screen.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { appStrings, Caption, Font, Icons, P } from '@votingworks/ui';
 import { assert, assertDefined } from '@votingworks/basics';
 
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 import * as api from '../api';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
 
 export function InsertedWrongTestModeBallotScreen(): React.ReactNode {
   const interpretationQuery = api.getInterpretation.useQuery();

--- a/apps/mark-scan/frontend/src/pages/load_paper_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/load_paper_page.tsx
@@ -1,5 +1,5 @@
 import { Caption, Icons, LoadPaperAnimation, P } from '@votingworks/ui';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 import { ResetVoterSessionButton } from '../components/deactivate_voter_session_button';
 
 export function LoadPaperPage(): JSX.Element {

--- a/apps/mark-scan/frontend/src/pages/loading_new_sheet_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/loading_new_sheet_screen.tsx
@@ -1,7 +1,7 @@
 import { Icons } from '@votingworks/ui';
 
 import React from 'react';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 export function LoadingNewSheetScreen(): JSX.Element {
   return (

--- a/apps/mark-scan/frontend/src/pages/loading_reinserted_ballot_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/loading_reinserted_ballot_screen.tsx
@@ -1,6 +1,6 @@
 import { appStrings, Icons, P } from '@votingworks/ui';
 
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 export function LoadingReinsertedBallotScreen(): JSX.Element {
   return (

--- a/apps/mark-scan/frontend/src/pages/paper_reloaded_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/paper_reloaded_page.tsx
@@ -1,7 +1,7 @@
 import { Icons, P } from '@votingworks/ui';
 import { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 export interface PaperReloadedPageProps {
   votesSelected: boolean;

--- a/apps/mark-scan/frontend/src/pages/poll_worker_auth_ended_unexpectedly_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_auth_ended_unexpectedly_page.tsx
@@ -1,5 +1,5 @@
 import { appStrings, Icons, P } from '@votingworks/ui';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 export function PollWorkerAuthEndedUnexpectedlyPage(): JSX.Element {
   return (

--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -61,6 +61,7 @@ import {
   throwIllegalValue,
 } from '@votingworks/basics';
 
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 import { LoadPaperPage } from './load_paper_page';
 import {
   getStateMachineState,
@@ -68,7 +69,6 @@ import {
   setPollsState,
   setTestMode,
 } from '../api';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
 import * as api from '../api';
 import { InsertedInvalidNewSheetScreen } from './inserted_invalid_new_sheet_screen';
 import { InsertedPreprintedBallotScreen } from './inserted_preprinted_ballot_screen';

--- a/apps/mark-scan/frontend/src/pages/print_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/print_page.tsx
@@ -1,9 +1,9 @@
 import React, { useContext } from 'react';
 import { assert } from '@votingworks/basics';
 import { Icons, P, appStrings, useCurrentLanguage } from '@votingworks/ui';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 import { BallotContext } from '../contexts/ballot_context';
 import { printBallot } from '../api';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
 
 export function PrintPage(): JSX.Element | null {
   const { ballotStyleId, precinctId, votes } = useContext(BallotContext);

--- a/apps/mark-scan/frontend/src/pages/reinserted_non_ballot_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/reinserted_non_ballot_screen.tsx
@@ -1,6 +1,6 @@
 import { appStrings, Caption, Icons, P } from '@votingworks/ui';
 
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 export function ReinsertedNonBallotScreen(): JSX.Element {
   return (

--- a/apps/mark-scan/frontend/src/pages/reinserted_wrong_election_ballot_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/reinserted_wrong_election_ballot_screen.tsx
@@ -1,6 +1,6 @@
 import { appStrings, Caption, Icons, P } from '@votingworks/ui';
 
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 export function ReinsertedWrongElectionBallotScreen(): JSX.Element {
   return (

--- a/apps/mark-scan/frontend/src/pages/reinserted_wrong_precinct_ballot_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/reinserted_wrong_precinct_ballot_screen.tsx
@@ -1,6 +1,6 @@
 import { appStrings, Caption, Icons, P } from '@votingworks/ui';
 
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 export function ReinsertedWrongPrecinctBallotScreen(): JSX.Element {
   return (

--- a/apps/mark-scan/frontend/src/pages/reinserted_wrong_test_mode_ballot_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/reinserted_wrong_test_mode_ballot_screen.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { appStrings, Caption, Icons, P } from '@votingworks/ui';
 
 import { assert, assertDefined } from '@votingworks/basics';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 import * as api from '../api';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
 
 export function ReinsertedWrongTestModeBallotScreen(): React.ReactNode {
   const interpretationQuery = api.getInterpretation.useQuery();

--- a/apps/mark-scan/frontend/src/pages/remove_invalidated_ballot_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/remove_invalidated_ballot_page.tsx
@@ -1,8 +1,8 @@
 import { Button, Icons, P } from '@votingworks/ui';
 import { useHistory } from 'react-router-dom';
 import { useEffect } from 'react';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 import { confirmInvalidateBallot } from '../api';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
 
 interface Props {
   paperPresent: boolean;

--- a/apps/mark-scan/frontend/src/pages/remove_jammed_sheet_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/remove_jammed_sheet_screen.tsx
@@ -1,7 +1,7 @@
 /* istanbul ignore file - trivial presentational component. @preserve */
 
 import { Icons, P } from '@votingworks/ui';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 export function RemoveJammedSheetScreen(): JSX.Element {
   return (

--- a/apps/mark-scan/frontend/src/pages/replace_blank_sheet_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/replace_blank_sheet_page.tsx
@@ -1,5 +1,5 @@
 import { Icons, P } from '@votingworks/ui';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 export function ReplaceBlankSheetPage(): JSX.Element {
   return (

--- a/apps/mark-scan/frontend/src/pages/replace_jammed_sheet_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/replace_jammed_sheet_screen.tsx
@@ -1,7 +1,7 @@
 import { Caption, Icons, P } from '@votingworks/ui';
 import type { SimpleServerStatus } from '@votingworks/mark-scan-backend';
 import React from 'react';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 import { ResetVoterSessionButton } from '../components/deactivate_voter_session_button';
 
 export const JAM_CLEARED_STATES = [

--- a/apps/mark-scan/frontend/src/pages/scanner_open_alarm_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/scanner_open_alarm_screen.tsx
@@ -9,7 +9,7 @@ import {
 } from '@votingworks/ui';
 
 import React from 'react';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 export function ScannerOpenAlarmScreen(): JSX.Element {
   const wasAudioEnabled = React.useRef(useAudioEnabled());

--- a/apps/mark-scan/frontend/src/pages/unrecoverable_error_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/unrecoverable_error_page.tsx
@@ -1,5 +1,5 @@
 import { P, appStrings, Icons } from '@votingworks/ui';
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 
 export function UnrecoverableErrorPage(): JSX.Element {
   return (

--- a/apps/mark-scan/frontend/src/pages/waiting_for_ballot_reinsertion_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/waiting_for_ballot_reinsertion_screen.tsx
@@ -1,6 +1,6 @@
 import { appStrings, Caption, Icons, P } from '@votingworks/ui';
 
-import { CenteredCardPageLayout } from '../components/centered_card_page_layout';
+import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 import { useIsVoterAuth } from '../hooks/use_is_voter_auth';
 import { ResetVoterSessionButton } from '../components/deactivate_voter_session_button';
 

--- a/libs/mark-flow-ui/src/components/centered_card_page_layout.tsx
+++ b/libs/mark-flow-ui/src/components/centered_card_page_layout.tsx
@@ -1,3 +1,5 @@
+/* istanbul ignore file - @preserve - tested via apps. */
+
 import React from 'react';
 
 import { Card, FullScreenIconWrapper, H2 } from '@votingworks/ui';

--- a/libs/mark-flow-ui/src/components/centered_page_layout.tsx
+++ b/libs/mark-flow-ui/src/components/centered_page_layout.tsx
@@ -1,3 +1,5 @@
+/* istanbul ignore file - @preserve - tested via apps. */
+
 import React from 'react';
 import styled from 'styled-components';
 
@@ -8,7 +10,8 @@ import {
   ReadOnLoad as ReadOnLoadBase,
   Screen,
 } from '@votingworks/ui';
-import { VoterScreen, ButtonFooter } from '@votingworks/mark-flow-ui';
+import { ButtonFooter } from './button_footer';
+import { VoterScreen } from './voter_screen';
 
 export interface CenteredPageLayoutProps {
   buttons?: React.ReactNode;

--- a/libs/mark-flow-ui/src/index.ts
+++ b/libs/mark-flow-ui/src/index.ts
@@ -1,5 +1,7 @@
 export * from './components/button_footer';
 export * from './components/contest';
+export * from './components/centered_card_page_layout';
+export * from './components/centered_page_layout';
 export * from './components/voter_settings_button';
 export * from './components/review';
 export * from './components/voter_screen';


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6706

Moving this centred card layout from MarkScan to `mark-flow-ui`, so we can reuse in VxMark:

![Screenshot 2025-07-07 at 13 59 29](https://github.com/user-attachments/assets/b2d1d216-a487-4c71-a7fa-a5679a70bfdf)

## Testing Plan
- Existing tests
