### PR TITLE
VxAdmin: fix extension filtering

### DIFF
--- a/apps/admin/frontend/src/screens/tally/import_cvrfiles_modal.tsx
+++ b/apps/admin/frontend/src/screens/tally/import_cvrfiles_modal.tsx
@@ -230,7 +230,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
       filters: [
         {
           name: '',
-          extensions: 'json',
+          extensions: ['json'],
         },
       ],
     });

--- a/apps/admin/frontend/src/screens/tally/import_election_results_reporting_file_modal.tsx
+++ b/apps/admin/frontend/src/screens/tally/import_election_results_reporting_file_modal.tsx
@@ -71,7 +71,7 @@ export function ImportElectionsResultReportingFileModal({
       filters: [
         {
           name: '',
-          extensions: 'json',
+          extensions: ['json'],
         },
       ],
     });


### PR DESCRIPTION
## Overview

For our manual imports on VxAdmin, other than the election package, we are not actually passing the right arguments to electron to filter out files of the wrong extension. The incorrect instances were corrected to match the correct instances. Tested manually.
