### PR TITLE
[Mark] Update Sys Admin screen to match MarkScan

### DIFF
--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -439,7 +439,11 @@ export function AppRoot({ reload }: Props): JSX.Element | null {
         resetPollsToPaused={
           pollsState === 'polls_closed_final' ? resetPollsToPaused : undefined
         }
+        machineConfig={machineConfig}
+        electionDefinition={electionDefinition}
+        electionPackageHash={electionPackageHash}
         usbDriveStatus={usbDriveStatus}
+        precinctSelection={appPrecinct}
       />
     );
   }

--- a/apps/mark/frontend/src/pages/system_administrator_screen.tsx
+++ b/apps/mark/frontend/src/pages/system_administrator_screen.tsx
@@ -1,13 +1,19 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import {
+  Button,
+  ElectionInfoBar,
   H3,
   Main,
   Screen,
+  SignedHashValidationButton,
   SystemAdministratorScreenContents,
 } from '@votingworks/ui';
 import { UsbDriveStatus } from '@votingworks/usb-drive';
-import { logOut } from '../api';
+import type { MachineConfig } from '@votingworks/mark-backend';
+import { ElectionDefinition, PrecinctSelection } from '@votingworks/types';
+import { logOut, useApiClient } from '../api';
+import { DiagnosticsScreen } from './diagnostics_screen';
 
 const resetPollsToPausedText =
   'The polls are closed and voting is complete. After resetting the polls to paused, it will be possible to re-open the polls and resume voting. The printed ballots count will be preserved.';
@@ -17,6 +23,10 @@ interface Props {
   isMachineConfigured: boolean;
   resetPollsToPaused?: () => Promise<void>;
   usbDriveStatus: UsbDriveStatus;
+  electionDefinition?: ElectionDefinition;
+  electionPackageHash?: string;
+  machineConfig: MachineConfig;
+  precinctSelection?: PrecinctSelection;
 }
 
 /**
@@ -27,19 +37,42 @@ export function SystemAdministratorScreen({
   isMachineConfigured,
   resetPollsToPaused,
   usbDriveStatus,
+  electionDefinition,
+  electionPackageHash,
+  machineConfig,
+  precinctSelection,
 }: Props): JSX.Element {
+  const apiClient = useApiClient();
   const logOutMutation = logOut.useMutation();
+  const [isDiagnosticsScreenOpen, setIsDiagnosticsScreenOpen] = useState(false);
+
+  if (isDiagnosticsScreenOpen) {
+    return (
+      <DiagnosticsScreen
+        onBackButtonPress={() => setIsDiagnosticsScreenOpen(false)}
+      />
+    );
+  }
+
   return (
     <Screen>
       <Main padded>
         <H3 as="h1">System Administrator Menu</H3>
         <SystemAdministratorScreenContents
+          additionalButtons={
+            <React.Fragment>
+              <Button onPress={() => setIsDiagnosticsScreenOpen(true)}>
+                Diagnostics
+              </Button>
+              <SignedHashValidationButton apiClient={apiClient} />
+            </React.Fragment>
+          }
           displayRemoveCardToLeavePrompt
           resetPollsToPausedText={resetPollsToPausedText}
           resetPollsToPaused={resetPollsToPaused}
           primaryText={
             <React.Fragment>
-              To adjust settings for the current election,› please insert an
+              To adjust settings for the current election, please insert an
               election manager or poll worker card.
             </React.Fragment>
           }
@@ -49,6 +82,14 @@ export function SystemAdministratorScreen({
           logOut={() => logOutMutation.mutate()}
         />
       </Main>
+      <ElectionInfoBar
+        mode="admin"
+        electionDefinition={electionDefinition}
+        electionPackageHash={electionPackageHash}
+        codeVersion={machineConfig.codeVersion}
+        machineId={machineConfig.machineId}
+        precinctSelection={precinctSelection}
+      />
     </Screen>
   );
 }


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6706

Adding the following to the VxMark System Administrator screen to match MarkScan:
- Election info bar
- Diagnostics button
- Signed Hash Validation button

## Demo Video or Screenshot

| MarkScan | Mark |
| -- | -- |
| ![Screenshot 2025-07-08 at 15 49 46](https://github.com/user-attachments/assets/93087cfc-d1bc-4de7-9411-fba5cdf60004) | ![Screenshot 2025-07-08 at 16 10 36](https://github.com/user-attachments/assets/32cba96a-a928-4c5f-b702-1411ab7a2435) |

## Testing Plan
- Copied over tests from MarkScan + manual spot checks for diagnostics and signed hash QR

## Checklist

<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
