### PR TITLE
VxDesign: Cleanup auth for /files endpoint

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -225,9 +225,7 @@ test('all methods require authentication', async () => {
     }
 
     // Special case for the /files endpoint, which doesn't go through the Grout API
-    const response = await fetch(
-      join(baseUrl, '/files/some-org-id/some-file-path')
-    );
+    const response = await fetch(`${baseUrl}/files/some-org-id/some-file-path`);
     expect(response.status).toEqual(500);
     expect(await response.json()).toEqual({ message: 'auth:unauthorized' });
   });
@@ -1864,7 +1862,8 @@ test('Election package management', async () => {
   expect(electionPackageAfterExport.url).toContain(nonVxUser.orgId);
 
   // Check that the correct package was returned by the files API endpoint
-  const response = await fetch(join(baseUrl, electionPackageAfterExport.url!));
+  const electionPackageUrl = `${baseUrl}${electionPackageAfterExport.url}`;
+  const response = await fetch(electionPackageUrl);
   const body = Buffer.from(await response.arrayBuffer());
   const { electionPackageFileName } =
     await unzipElectionPackageAndBallots(body);
@@ -1876,9 +1875,7 @@ test('Election package management', async () => {
   // Check that other org users can't access the package
   await suppressingConsoleOutput(async () => {
     auth0.setLoggedInUser(anotherNonVxUser);
-    const otherOrgResponse = await fetch(
-      join(baseUrl, electionPackageAfterExport.url!)
-    );
+    const otherOrgResponse = await fetch(electionPackageUrl);
     expect(otherOrgResponse.status).toEqual(500);
     expect(await otherOrgResponse.json()).toEqual({
       message: 'auth:forbidden',

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, expect, test, vi } from 'vitest';
+import { afterAll, afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { Buffer } from 'node:buffer';
 import JsZip from 'jszip';
 import get from 'lodash.get';
@@ -206,10 +206,14 @@ beforeEach(() => {
   mockFeatureFlagger.resetFeatureFlags();
 });
 
+afterEach(() => {
+  vi.mocked(renderAllBallotsAndCreateElectionDefinition).mockRestore();
+});
+
 test('all methods require authentication', async () => {
-  const { apiClient, ...context } = await setupApp();
-  const apiMethodNames = Object.keys(buildApi(context).methods());
+  const { apiClient, baseUrl, ...context } = await setupApp();
   await suppressingConsoleOutput(async () => {
+    const apiMethodNames = Object.keys(buildApi(context).methods());
     for (const apiMethodName of apiMethodNames) {
       // @ts-ignore - Don't pass any input to the API methods since we expect
       // auth middleware to reject it before getting to the handler. A bit of a
@@ -219,6 +223,13 @@ test('all methods require authentication', async () => {
         'auth:unauthorized'
       );
     }
+
+    // Special case for the /files endpoint, which doesn't go through the Grout API
+    const response = await fetch(
+      join(baseUrl, '/files/some-org-id/some-file-path')
+    );
+    expect(response.status).toEqual(500);
+    expect(await response.json()).toEqual({ message: 'auth:unauthorized' });
   });
 });
 
@@ -1772,7 +1783,8 @@ test('cloneElection', async () => {
 test('Election package management', async () => {
   const baseElectionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();
-  const { apiClient, workspace, fileStorageClient, auth0 } = await setupApp();
+  const { apiClient, workspace, fileStorageClient, auth0, baseUrl } =
+    await setupApp();
 
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
@@ -1783,12 +1795,13 @@ test('Election package management', async () => {
     })
   ).unsafeUnwrap();
 
-  // Without mocking all the translations some ballot styles for non-English languages don't fit on a letter
-  // page for this election. To get around this we use legal paper size for the purposes of this test.
-  await apiClient.updateBallotLayoutSettings({
-    electionId,
-    paperSize: HmpbBallotPaperSize.Legal,
-    compact: false,
+  // Mock the ballot documents and election definition to speed up this test,
+  // since we are just testing the export task flows in this test. The next test
+  // checks the actual exported data.
+  const props = allBaseBallotProps(baseElectionDefinition.election);
+  vi.mocked(renderAllBallotsAndCreateElectionDefinition).mockResolvedValue({
+    ballotDocuments: props.map(mockBallotDocument),
+    electionDefinition: baseElectionDefinition,
   });
 
   const electionPackageBeforeExport = await apiClient.getElectionPackage({
@@ -1848,8 +1861,32 @@ test('Election package management', async () => {
     },
     url: expect.stringMatching(ELECTION_PACKAGE_FILE_NAME_REGEX),
   });
+  expect(electionPackageAfterExport.url).toContain(nonVxUser.orgId);
+
+  // Check that the correct package was returned by the files API endpoint
+  const response = await fetch(join(baseUrl, electionPackageAfterExport.url!));
+  const body = Buffer.from(await response.arrayBuffer());
+  const { electionPackageFileName } =
+    await unzipElectionPackageAndBallots(body);
+  const electionHashes = electionPackageFileName.match(
+    /^election-package-(.+)\.zip$/
+  )![1];
+  expect(electionPackageAfterExport.url).toContain(electionHashes);
+
+  // Check that other org users can't access the package
+  await suppressingConsoleOutput(async () => {
+    auth0.setLoggedInUser(anotherNonVxUser);
+    const otherOrgResponse = await fetch(
+      join(baseUrl, electionPackageAfterExport.url!)
+    );
+    expect(otherOrgResponse.status).toEqual(500);
+    expect(await otherOrgResponse.json()).toEqual({
+      message: 'auth:forbidden',
+    });
+  });
 
   // Check that initiating an export after a prior has completed does trigger a new background task
+  auth0.setLoggedInUser(nonVxUser);
   await apiClient.exportElectionPackage({
     electionId,
     electionSerializationFormat: 'vxf',
@@ -2651,7 +2688,6 @@ test('setBallotTemplate changes the ballot template used to render ballots', asy
   expect(
     vi.mocked(renderAllBallotsAndCreateElectionDefinition).mock.calls[0][2]
   ).toHaveLength(props.length);
-  vi.mocked(renderAllBallotsAndCreateElectionDefinition).mockRestore();
 
   await suppressingConsoleOutput(async () => {
     // Check permissions

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -32,6 +32,7 @@ import * as worker from '../src/worker/worker';
 import { createWorkspace, Workspace } from '../src/workspace';
 import { TestStore } from './test_store';
 import { getEntries, openZip, readEntry } from '@votingworks/utils/src';
+import { join } from 'node:path';
 
 tmp.setGracefulCleanup();
 
@@ -131,9 +132,12 @@ export function testSetupHelpers() {
     const server = app.listen();
     servers.push(server);
     const { port } = server.address() as AddressInfo;
-    const baseUrl = `http://localhost:${port}/api`;
-    const apiClient = grout.createClient<Api>({ baseUrl });
+    const baseUrl = `http://localhost:${port}`;
+    const apiClient = grout.createClient<Api>({
+      baseUrl: join(baseUrl, '/api'),
+    });
     return {
+      baseUrl,
       apiClient,
       workspace,
       auth0,

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -32,7 +32,6 @@ import * as worker from '../src/worker/worker';
 import { createWorkspace, Workspace } from '../src/workspace';
 import { TestStore } from './test_store';
 import { getEntries, openZip, readEntry } from '@votingworks/utils/src';
-import { join } from 'node:path';
 
 tmp.setGracefulCleanup();
 
@@ -134,7 +133,7 @@ export function testSetupHelpers() {
     const { port } = server.address() as AddressInfo;
     const baseUrl = `http://localhost:${port}`;
     const apiClient = grout.createClient<Api>({
-      baseUrl: join(baseUrl, '/api'),
+      baseUrl: `${baseUrl}/api`,
     });
     return {
       baseUrl,

--- a/apps/design/backend/vitest.config.ts
+++ b/apps/design/backend/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: -79,
-        branches: -55,
+        lines: -71,
+        branches: -51,
       },
       exclude: ['src/configure_sentry.ts', '**/*.test.ts'],
     },

--- a/libs/grout/src/server.ts
+++ b/libs/grout/src/server.ts
@@ -1,6 +1,11 @@
 /* eslint-disable no-underscore-dangle */
 import type Express from 'express';
-import { assert, isObject, isString } from '@votingworks/basics';
+import {
+  assert,
+  extractErrorMessage,
+  isObject,
+  isString,
+} from '@votingworks/basics';
 import { rootDebug } from './debug';
 import { serialize, deserialize } from './serialization';
 
@@ -257,7 +262,7 @@ export function buildRouter(
         response.status(200).send(jsonResult);
         next();
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = extractErrorMessage(error);
         debug(`Error: ${message}`);
         // eslint-disable-next-line no-console
         console.error(error); // To aid debugging, log the full error with stack trace


### PR DESCRIPTION
## Overview

The `/files` endpoint is separate from the main Grout API, so it has bespoke auth guards. This PR cleans up the auth handling to make it better fit with the rest of the API.

## Demo Video or Screenshot
N/A

## Testing Plan
Added test coverage, since this endpoint was uncovered

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
