### PR TITLE
[MarkScan] Extract reusable sections from PollWorkerScreen

### DIFF
--- a/libs/mark-flow-ui/src/components/poll_worker/index.ts
+++ b/libs/mark-flow-ui/src/components/poll_worker/index.ts
@@ -1,3 +1,4 @@
 export * from './ballot_style_select';
 export * from './elements';
 export * from './sections';
+export * from './update_polls_button';

--- a/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
@@ -1,13 +1,88 @@
 /* istanbul ignore file - @preserve - currently tested via apps. */
 
-import { H4 } from '@votingworks/ui';
+import {
+  Font,
+  H2,
+  H3,
+  H4,
+  P,
+  SignedHashValidationApiClient,
+  SignedHashValidationButton,
+  TestModeCallout,
+} from '@votingworks/ui';
+import React from 'react';
+import {
+  format,
+  getPollsStateName,
+  getPollTransitionsFromState,
+} from '@votingworks/utils';
 import {
   Election,
   getAllPrecinctsAndSplits,
+  PollsState,
   PrecinctSelection,
 } from '@votingworks/types';
 import { BallotStyleSelect, OnBallotStyleSelect } from './ballot_style_select';
-import { VotingSession } from './elements';
+import { ButtonGrid, VotingSession } from './elements';
+import { UpdatePollsButton } from './update_polls_button';
+
+export interface HeaderProps {
+  ballotsPrintedCount: number;
+  liveMode: boolean;
+}
+
+export function SectionHeader(props: HeaderProps): JSX.Element {
+  const { ballotsPrintedCount, liveMode: isLiveMode } = props;
+
+  return (
+    <React.Fragment>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'start',
+        }}
+      >
+        <H2 as="h1">Poll Worker Menu</H2>
+        {!isLiveMode && <TestModeCallout />}
+      </div>
+      <P>Remove the poll worker card to leave this screen.</P>
+      <P style={{ fontSize: '1.2em' }}>
+        <Font weight="bold">Ballots Printed:</Font>{' '}
+        {format.count(ballotsPrintedCount)}
+      </P>
+    </React.Fragment>
+  );
+}
+
+export interface SectionPollsStateProps {
+  pollsState: PollsState;
+  updatePollsState: (pollsState: PollsState) => void;
+}
+
+export function SectionPollsState(props: SectionPollsStateProps): JSX.Element {
+  const { pollsState, updatePollsState } = props;
+
+  return (
+    <React.Fragment>
+      <H3>
+        Polls: <Font weight="regular">{getPollsStateName(pollsState)}</Font>
+      </H3>
+      <ButtonGrid>
+        {getPollTransitionsFromState(pollsState).map(
+          (pollsTransition, index) => (
+            <UpdatePollsButton
+              pollsTransition={pollsTransition}
+              updatePollsState={updatePollsState}
+              isPrimaryButton={index === 0}
+              key={`${pollsTransition}-button`}
+            />
+          )
+        )}
+      </ButtonGrid>
+    </React.Fragment>
+  );
+}
 
 export interface SectionSessionStartProps {
   election: Election;
@@ -42,5 +117,22 @@ export function SectionSessionStart(
         onSelect={onChooseBallotStyle}
       />
     </VotingSession>
+  );
+}
+
+export interface SectionSystemProps {
+  apiClient: SignedHashValidationApiClient;
+}
+
+export function SectionSystem(props: SectionSystemProps): JSX.Element {
+  const { apiClient } = props;
+
+  return (
+    <React.Fragment>
+      <H3>System</H3>
+      <ButtonGrid>
+        <SignedHashValidationButton apiClient={apiClient} />
+      </ButtonGrid>
+    </React.Fragment>
   );
 }

--- a/libs/mark-flow-ui/src/components/poll_worker/update_polls_button.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/update_polls_button.tsx
@@ -1,0 +1,74 @@
+/* istanbul ignore file - @preserve - currently tested via apps. */
+
+import { throwIllegalValue } from '@votingworks/basics';
+import { type PollsState, type PollsTransitionType } from '@votingworks/types';
+import { Button, Modal, P } from '@votingworks/ui';
+import {
+  getPollsTransitionAction,
+  getPollsTransitionDestinationState,
+} from '@votingworks/utils';
+import React, { useState } from 'react';
+
+export interface UpdatePollsButtonProps {
+  pollsTransition: PollsTransitionType;
+  updatePollsState: (pollsState: PollsState) => void;
+  isPrimaryButton: boolean;
+}
+
+export function UpdatePollsButton(props: UpdatePollsButtonProps): JSX.Element {
+  const { pollsTransition, updatePollsState, isPrimaryButton } = props;
+  const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
+
+  function closeModal() {
+    setIsConfirmationModalOpen(false);
+  }
+
+  function confirmUpdate() {
+    updatePollsState(getPollsTransitionDestinationState(pollsTransition));
+    closeModal();
+  }
+
+  const action = getPollsTransitionAction(pollsTransition);
+  const explanationText = (() => {
+    switch (pollsTransition) {
+      case 'open_polls':
+        return `After polls are opened, voters will be able to mark and cast ballots.`;
+      case 'pause_voting':
+        return `After voting is paused, voters will not be able to mark and cast ballots until voting is resumed.`;
+      case 'resume_voting':
+        return `After voting is resumed, voters will be able to mark and cast ballots.`;
+      case 'close_polls':
+        return `After polls are closed, voters will no longer be able to mark and cast ballots. Polls cannot be opened again.`;
+      default: {
+        /* istanbul ignore next - @preserve */
+        throwIllegalValue(pollsTransition);
+      }
+    }
+  })();
+
+  return (
+    <React.Fragment>
+      <Button
+        variant={isPrimaryButton ? 'primary' : 'neutral'}
+        onPress={() => setIsConfirmationModalOpen(true)}
+      >
+        {action}
+      </Button>
+      {isConfirmationModalOpen && (
+        <Modal
+          title={`${action}`}
+          content={<P>{explanationText}</P>}
+          actions={
+            <React.Fragment>
+              <Button variant="primary" onPress={confirmUpdate}>
+                {action}
+              </Button>
+              <Button onPress={closeModal}>Cancel</Button>
+            </React.Fragment>
+          }
+          onOverlayClick={closeModal}
+        />
+      )}
+    </React.Fragment>
+  );
+}


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6706

Splitting out PollWorkerScreen sections that will be common between Mark and MarkScan:
- Header section, with optional test mode banner.
- Polls state management section, along with with the `UpdatePollsButton` component.
- System section containing the signed hash validation control.

Code unchanged, except for splitting the sections out into components and taking in state/mutation methods as props.

## Testing Plan
- Existing tests in MarkScan cover the code paths for these sections
