### PR TITLE
[MarkScan] Split out PollWorkerScreen sub-screens for reuse

### DIFF
--- a/libs/mark-flow-ui/src/components/poll_worker/elements.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/elements.tsx
@@ -1,6 +1,65 @@
 /* istanbul ignore file - @preserve - currently tested via apps. */
 
+import React from 'react';
 import styled from 'styled-components';
+
+import { assertDefined, find } from '@votingworks/basics';
+import {
+  CardlessVoterUser,
+  Election,
+  getBallotStyle,
+  getPartyForBallotStyle,
+} from '@votingworks/types';
+import { electionStrings, P, Font } from '@votingworks/ui';
+import { getPrecinctsAndSplitsForBallotStyle } from '@votingworks/utils';
+
+export interface BallotStyleLabelProps {
+  election: Election;
+  voter: CardlessVoterUser;
+}
+
+export function BallotStyleLabel(props: BallotStyleLabelProps): JSX.Element {
+  const { election, voter } = props;
+  const { precinctId, ballotStyleId } = voter;
+
+  const ballotStyle = assertDefined(
+    getBallotStyle({ election, ballotStyleId })
+  );
+  const precinctOrSplit = find(
+    getPrecinctsAndSplitsForBallotStyle({ election, ballotStyle }),
+    ({ precinct }) => precinct.id === precinctId
+  );
+  const precinctOrSplitName = precinctOrSplit.split
+    ? electionStrings.precinctSplitName(precinctOrSplit.split)
+    : electionStrings.precinctName(precinctOrSplit.precinct);
+
+  if (election.type === 'general') {
+    return (
+      <P>
+        <Font weight="semiBold">Ballot Style:</Font> {precinctOrSplitName}
+      </P>
+    );
+  }
+
+  return (
+    <React.Fragment>
+      <P>
+        <Font weight="semiBold">Precinct:</Font> {precinctOrSplitName}
+      </P>
+      <P>
+        <Font weight="semiBold">Ballot Style:</Font>{' '}
+        {
+          assertDefined(
+            getPartyForBallotStyle({
+              election,
+              ballotStyleId: ballotStyle.id,
+            })
+          ).name
+        }
+      </P>
+    </React.Fragment>
+  );
+}
 
 export const ButtonGrid = styled.div`
   display: grid;

--- a/libs/mark-flow-ui/src/components/poll_worker/enable_live_mode_modal.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/enable_live_mode_modal.tsx
@@ -1,0 +1,61 @@
+/* istanbul ignore file - @preserve - currently tested via apps. */
+
+import { DateWithoutTime } from '@votingworks/basics';
+import { Election } from '@votingworks/types';
+import { Modal, P, Font, Caption, Button } from '@votingworks/ui';
+import React from 'react';
+
+export interface EnableLiveModeModalProps {
+  election: Election;
+  liveMode: boolean;
+  setTestMode: (params: { isTestMode: boolean }) => void;
+}
+
+export function EnableLiveModeModal(
+  props: EnableLiveModeModalProps
+): React.ReactNode {
+  const { election, liveMode, setTestMode } = props;
+  const isElectionDay = election.date.isEqual(DateWithoutTime.today());
+
+  const [modalActive, setModalActive] = React.useState(
+    !liveMode && isElectionDay
+  );
+
+  if (!modalActive) return null;
+
+  function onConfirm() {
+    setTestMode({ isTestMode: false });
+    setModalActive(false);
+  }
+
+  return (
+    <Modal
+      centerContent
+      title="Switch to Official Ballot Mode and reset the Ballots Printed count?"
+      content={
+        <div>
+          <P>
+            Today is election day and this machine is in{' '}
+            <Font noWrap weight="bold">
+              Test Ballot Mode.
+            </Font>
+          </P>
+          <Caption>
+            Note: Switching back to Test Ballot Mode requires an{' '}
+            <Font noWrap>election manager card.</Font>
+          </Caption>
+        </div>
+      }
+      actions={
+        <React.Fragment>
+          <Button variant="danger" icon="Danger" onPress={onConfirm}>
+            Switch to Official Ballot Mode
+          </Button>
+          <Button onPress={setModalActive} value={false}>
+            Cancel
+          </Button>
+        </React.Fragment>
+      }
+    />
+  );
+}

--- a/libs/mark-flow-ui/src/components/poll_worker/index.ts
+++ b/libs/mark-flow-ui/src/components/poll_worker/index.ts
@@ -1,4 +1,6 @@
 export * from './ballot_style_select';
+export * from './enable_live_mode_modal';
 export * from './elements';
+export * from './screens';
 export * from './sections';
 export * from './update_polls_button';

--- a/libs/mark-flow-ui/src/components/poll_worker/screens.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/screens.tsx
@@ -1,0 +1,66 @@
+/* istanbul ignore file - @preserve - currently tested via apps. */
+
+import React from 'react';
+
+import { Icons, P, RemoveCardImage } from '@votingworks/ui';
+import { Election, CardlessVoterUser } from '@votingworks/types';
+import { CenteredCardPageLayout } from '../centered_card_page_layout';
+
+import { BallotStyleLabel } from './elements';
+
+export interface ScreenBeginVotingProps {
+  election: Election;
+  resetVoterSessionButton: React.ReactNode;
+  voter: CardlessVoterUser;
+}
+
+export function ScreenBeginVoting(props: ScreenBeginVotingProps): JSX.Element {
+  const { election, resetVoterSessionButton, voter } = props;
+
+  return (
+    <CenteredCardPageLayout
+      buttons={resetVoterSessionButton}
+      icon={
+        <div
+          style={{
+            height: '5rem',
+            margin: '0 0.5rem 0 1rem',
+            position: 'relative',
+            left: '-1rem',
+            top: '-6.5rem',
+          }}
+        >
+          <RemoveCardImage aria-hidden cardInsertionDirection="up" />
+        </div>
+      }
+      title="Remove Card to Begin Voting Session"
+      voterFacing={false}
+    >
+      <BallotStyleLabel election={election} voter={voter} />
+    </CenteredCardPageLayout>
+  );
+}
+
+export interface ScreenVotingInProgressProps {
+  election: Election;
+  resetVoterSessionButton: React.ReactNode;
+  voter: CardlessVoterUser;
+}
+
+export function ScreenVotingInProgress(
+  props: ScreenVotingInProgressProps
+): JSX.Element {
+  const { election, resetVoterSessionButton, voter } = props;
+
+  return (
+    <CenteredCardPageLayout
+      title="Voting Session Paused"
+      icon={<Icons.Paused />}
+      voterFacing={false}
+    >
+      <P weight="bold">Remove card to continue voting session.</P>
+      <BallotStyleLabel election={election} voter={voter} />
+      <P>{resetVoterSessionButton}</P>
+    </CenteredCardPageLayout>
+  );
+}


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6706

Last bit of PollWorkerScreen decomposition - splitting out the various sub-screens that will be common between MarkScan and Mark, including switch-to-live-mode-on-election-day modal.

Code unchanged except for splitting out the screens and `<BallotStyleLabel>` into separate components.

## Testing Plan
- Existing tests cover these code paths
- Manual spot-checks to trigger the sub-screens
