### PR TITLE
VxDesign: Consolidate org name fields

### DIFF
--- a/apps/design/backend/scripts/README.md
+++ b/apps/design/backend/scripts/README.md
@@ -32,9 +32,8 @@ pnpm create-org "City of Vx"
 # Output:
 
 ✅ Org created: {
-  displayName: 'City of Vx',
   id: 'org_TUPNZLFFyBgzxdeH',
-  name: 'city-of-vx'
+  name: 'City of Vx',
 }
 ```
 
@@ -49,14 +48,12 @@ pnpm list-orgs
 
 ✅ Orgs: [
   {
-    displayName: 'City of Vx',
     id: 'org_TUPNZLFFyBgzxdeH',
-    name: 'city-of-vx'
+    name: 'City of Vx',
   },
   {
-    displayName: 'VotingWorks',
     id: 'org_Ug9eDziiLfqKelKi',
-    name: 'votingworks'
+    name: 'VotingWorks',
   },
 ]
 ```
@@ -90,9 +87,8 @@ pnpm list-user-orgs "someone@example.com"
 
 ✅ Org memberships for someone@example.com: [
   {
-    displayName: 'City of Vx',
     id: 'org_TUPNZLFFyBgzxdeH',
-    name: 'city-of-vx'
+    name: 'City of Vx',
   }
 ]
 ```

--- a/apps/design/backend/scripts/create_org.ts
+++ b/apps/design/backend/scripts/create_org.ts
@@ -2,7 +2,7 @@ import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
 import util from 'node:util';
 import { Auth0Client } from '../src/auth0_client';
 
-const USAGE = `Usage: pnpm create-org [options...] "<display name>"
+const USAGE = `Usage: pnpm create-org [options...] "<name>"
 
 options:
     [--enableGoogleAuth]: Enables Google auth for this org, in addition to username/password logins.
@@ -12,7 +12,7 @@ options:
 async function main(): Promise<void> {
   loadEnvVarsFromDotenvFiles();
   const {
-    positionals: [displayName],
+    positionals: [name],
     values: { enableGoogleAuth, logoUrl },
   } = util.parseArgs({
     allowPositionals: true,
@@ -24,14 +24,14 @@ async function main(): Promise<void> {
       logoUrl: { type: 'string' },
     },
   });
-  if (!displayName) {
+  if (!name) {
     console.log(USAGE);
     process.exit(0);
   }
 
   const auth = Auth0Client.init();
   const org = await auth.createOrg({
-    displayName,
+    name,
     enableGoogleAuth,
     logoUrl,
   });

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -120,19 +120,11 @@ const anotherNonVxUser = {
 const sliUser: User = { orgId: sliOrgId(), orgName: 'SLI' };
 const vxDemosUser: User = { orgId: vxDemosOrgId(), orgName: 'VX Demos' };
 const orgs: Org[] = [
-  { id: vxUser.orgId, name: 'votingworks', displayName: vxUser.orgName! },
-  { id: nonVxUser.orgId, name: 'other', displayName: nonVxUser.orgName! },
-  {
-    id: anotherNonVxUser.orgId,
-    name: 'another',
-    displayName: anotherNonVxUser.orgName!,
-  },
-  { id: sliUser.orgId, name: 'sli', displayName: sliUser.orgName! },
-  {
-    id: vxDemosUser.orgId,
-    name: 'vx-demos',
-    displayName: vxDemosUser.orgName!,
-  },
+  { id: vxUser.orgId, name: vxUser.orgName! },
+  { id: nonVxUser.orgId, name: nonVxUser.orgName! },
+  { id: anotherNonVxUser.orgId, name: anotherNonVxUser.orgName! },
+  { id: sliUser.orgId, name: sliUser.orgName! },
+  { id: vxDemosUser.orgId, name: vxDemosUser.orgName! },
 ];
 
 const mockFeatureFlagger = getFeatureFlagMock();

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -235,8 +235,7 @@ export function buildApi({ auth0, logger, workspace, translator }: AppContext) {
       return elections.map((election) => ({
         ...election,
         orgName:
-          orgs.find((org) => org.id === election.orgId)?.displayName ??
-          election.orgId,
+          orgs.find((org) => org.id === election.orgId)?.name ?? election.orgId,
       }));
     },
 

--- a/apps/design/backend/src/auth0_client.test.ts
+++ b/apps/design/backend/src/auth0_client.test.ts
@@ -83,14 +83,13 @@ test('createOrg', async () => {
   );
 
   const result = await newClient().createOrg({
-    displayName: 'City of Vx',
+    name: 'City of Vx',
     logoUrl: 'https://example.com/logo.png',
   });
 
   expect(result).toEqual({
-    displayName: 'City of Vx',
     id: 'new-org',
-    name: 'city-of-vx',
+    name: 'City of Vx',
   });
 
   expect(mockOrganizations.create).toHaveBeenCalledWith({
@@ -212,8 +211,8 @@ test('userOrgs', async () => {
   const client = newClient();
   const result = await client.userOrgs('alice@example.com');
   expect(result).toEqual([
-    { displayName: 'City of Vx', id: 'vx-city', name: 'city-of-vx' },
-    { displayName: 'VotingWorks', id: 'vx', name: 'votingworks' },
+    { name: 'City of Vx', id: 'vx-city' },
+    { name: 'VotingWorks', id: 'vx' },
   ]);
 
   expect(mockUsersByEmail.getByEmail).toHaveBeenCalledWith({

--- a/apps/design/backend/src/auth0_client.ts
+++ b/apps/design/backend/src/auth0_client.ts
@@ -107,7 +107,7 @@ export class Auth0Client implements Auth0ClientInterface {
 
     return {
       orgId,
-      orgName: (await deferredOrg).displayName,
+      orgName: (await deferredOrg).name,
     };
   }
 
@@ -126,9 +126,8 @@ export class Auth0Client implements Auth0ClientInterface {
     });
 
     return res.data.map<Org>((o) => ({
-      displayName: o.display_name,
       id: o.id,
-      name: o.name,
+      name: o.display_name,
     }));
   }
 
@@ -141,12 +140,12 @@ export class Auth0Client implements Auth0ClientInterface {
   }
 
   async createOrg(params: {
-    displayName: string;
+    name: string;
     enableGoogleAuth?: boolean;
     logoUrl?: string;
   }): Promise<Org> {
     const VX_PURPLE = '#8d24ce';
-    const { displayName, enableGoogleAuth, logoUrl } = params;
+    const { name: displayName, enableGoogleAuth, logoUrl } = params;
 
     // Org `name` in Auth0 is more of a single-slug shortname (`display_name`
     // holds the user-visible org name).
@@ -183,9 +182,8 @@ export class Auth0Client implements Auth0ClientInterface {
     });
 
     return {
-      displayName: org.data.display_name,
+      name: org.data.display_name,
       id: org.data.id,
-      name: org.data.name,
     };
   }
 
@@ -219,7 +217,7 @@ export class Auth0Client implements Auth0ClientInterface {
 
     return {
       orgId,
-      orgName: org.displayName,
+      orgName: org.name,
     };
   }
 
@@ -251,9 +249,8 @@ export class Auth0Client implements Auth0ClientInterface {
     const res = await this.organizations.get({ id });
 
     return {
-      displayName: res.data.display_name,
       id: res.data.id,
-      name: res.data.name,
+      name: res.data.display_name,
     };
   }
 
@@ -263,7 +260,7 @@ export class Auth0Client implements Auth0ClientInterface {
     const org = await this.org(auth0User.org_id);
     return {
       orgId: org.id,
-      orgName: org.displayName,
+      orgName: org.name,
     };
   }
 
@@ -280,10 +277,9 @@ export class Auth0Client implements Auth0ClientInterface {
       id: user.user_id,
     });
 
-    return res.data.map<Org>((org) => ({
-      displayName: org.display_name,
+    return res.data.map((org) => ({
       id: org.id,
-      name: org.name,
+      name: org.display_name,
     }));
   }
 
@@ -294,19 +290,16 @@ export class Auth0Client implements Auth0ClientInterface {
       allOrgs() {
         return Promise.resolve<Org[]>([
           {
-            displayName: 'VotingWorks',
             id: votingWorksOrgId(),
-            name: 'voting-works',
+            name: 'VotingWorks',
           },
           {
-            displayName: 'SLI',
             id: sliOrgId(),
-            name: 'sli',
+            name: 'SLI',
           },
           {
-            displayName: 'City of Testerton',
             id: 'testerton1',
-            name: 'city-of-testerton',
+            name: 'City of Testerton',
           },
         ]);
       },

--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -91,9 +91,8 @@ export interface User {
 }
 
 export interface Org {
-  displayName: string;
-  id: string;
   name: string;
+  id: string;
 }
 
 export type ElectionStatus =

--- a/apps/design/frontend/src/app.test.tsx
+++ b/apps/design/frontend/src/app.test.tsx
@@ -30,7 +30,6 @@ test('API errors show an error screen', async () => {
       {
         id: user.orgId,
         name: 'Non-Vx Org',
-        displayName: 'Non-Vx Org',
       },
     ]);
     apiMock.listElections.expectCallWith().resolves([]);
@@ -75,7 +74,6 @@ test('API forbidden errors show a page not found error screen', async () => {
       {
         id: user.orgId,
         name: 'Non-Vx Org',
-        displayName: 'Non-Vx Org',
       },
     ]);
     apiMock.listElections.expectCallWith().resolves([]);

--- a/apps/design/frontend/src/clone_election_button.test.tsx
+++ b/apps/design/frontend/src/clone_election_button.test.tsx
@@ -78,14 +78,12 @@ test('clones immediately when ACCESS_ALL_ORGS feature disabled', async () => {
 
 const VX_ORG = {
   id: 'votingworks-org',
-  name: 'votingworks',
-  displayName: 'VotingWorks',
+  name: 'VotingWorks',
 } as const;
 
 const NON_VX_ORG = {
   id: 'not-votingworks-org',
-  name: 'not-voting-works',
-  displayName: 'Not VotingWorks',
+  name: 'Not VotingWorks',
 } as const;
 
 test('shows org picker when ACCESS_ALL_ORGS feature enabled', async () => {
@@ -102,7 +100,7 @@ test('shows org picker when ACCESS_ALL_ORGS feature enabled', async () => {
   const modal = screen.getByRole('alertdialog');
 
   userEvent.click(within(modal).getByRole('combobox'));
-  userEvent.click(within(modal).getByText(NON_VX_ORG.displayName));
+  userEvent.click(within(modal).getByText(NON_VX_ORG.name));
 
   const newElectionId = 'new-election' as ElectionId;
   mockGenerateId.mockReturnValue(newElectionId);

--- a/apps/design/frontend/src/elections_screen.test.tsx
+++ b/apps/design/frontend/src/elections_screen.test.tsx
@@ -47,7 +47,6 @@ vi.mock(import('./clone_election_button.js'), async (importActual) => ({
 const VX_ORG = {
   id: user.orgId,
   name: 'VotingWorks',
-  displayName: 'VotingWorks',
 } as const;
 
 let apiMock: MockApiClient;

--- a/apps/design/frontend/src/org_select.tsx
+++ b/apps/design/frontend/src/org_select.tsx
@@ -15,7 +15,7 @@ export function OrgSelect(props: OrgSelectProps): JSX.Element {
   const options = React.useMemo(
     () =>
       (orgs || []).map<SelectOption>((o) => ({
-        label: o.displayName,
+        label: o.name,
         value: o.id,
       })),
     [orgs]


### PR DESCRIPTION


## Overview

Auth0 orgs have two name fields:
- name (a slug, e.g. `"votingworks"`)
- display name (the actual name, e.g. `"VotingWorks"`)

We only need the display name, so instead of tracking both fields in the app, just use a single `name` field, but populate it with the display name.
## Demo Video or Screenshot
N/A

## Testing Plan
Updated existing tests
## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
