### PR TITLE
[Mark] Use shared components in PollWorkerScreen for parity with MarkScan

### DIFF
--- a/apps/mark/frontend/src/apimachine_config.test.tsx
+++ b/apps/mark/frontend/src/apimachine_config.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, test, vi } from 'vitest';
+import { afterEach, beforeEach, test } from 'vitest';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import { render, screen } from '../test/react_testing_library';
@@ -26,7 +26,7 @@ test('machineConfig is fetched from api client by default', async () => {
   apiMock.expectGetElectionState({
     precinctSelection: ALL_PRECINCTS_SELECTION,
   });
-  render(<App reload={vi.fn()} apiClient={apiMock.mockApiClient} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
   await screen.findByText('mock-code-version');
 });

--- a/apps/mark/frontend/src/app.tsx
+++ b/apps/mark/frontend/src/app.tsx
@@ -30,7 +30,6 @@ const RESTART_MESSAGE =
   'Ask a poll worker to restart the ballot marking device.';
 
 export interface Props {
-  reload?: VoidFunction;
   logger?: BaseLogger;
   apiClient?: ApiClient;
   queryClient?: QueryClient;
@@ -39,7 +38,6 @@ export interface Props {
 }
 
 export function App({
-  reload = () => window.location.reload(),
   logger = new BaseLogger(LogSource.VxMarkFrontend, window.kiosk),
   /* istanbul ignore next - @preserve */ apiClient = createApiClient(),
   queryClient = createQueryClient(),
@@ -64,7 +62,7 @@ export function App({
             noAudio={noAudio}
           >
             <VisualModeDisabledOverlay />
-            <AppRoot reload={reload} />
+            <AppRoot />
             <SessionTimeLimitTracker />
           </ApiProvider>
         </AppErrorBoundary>

--- a/apps/mark/frontend/src/app_card_unhappy_paths.test.tsx
+++ b/apps/mark/frontend/src/app_card_unhappy_paths.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, test, vi } from 'vitest';
+import { afterEach, beforeEach, test } from 'vitest';
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import { render, screen } from '../test/react_testing_library';
@@ -26,7 +26,7 @@ test('Shows card backwards screen when card connection error occurs', async () =
     pollsState: 'polls_open',
   });
 
-  render(<App apiClient={apiMock.mockApiClient} reload={vi.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
   await screen.findByText('Insert Card');
 
   apiMock.setAuthStatus({

--- a/apps/mark/frontend/src/app_contest_candidate_no_party.test.tsx
+++ b/apps/mark/frontend/src/app_contest_candidate_no_party.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test } from 'vitest';
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 
 import { BallotStyleId, CandidateContest, Election } from '@votingworks/types';
@@ -54,7 +54,7 @@ test('Single Seat Contest', async () => {
     pollsState: 'polls_open',
   });
 
-  render(<App apiClient={apiMock.mockApiClient} reload={vi.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   // Start voter session
   apiMock.setAuthStatusCardlessVoterLoggedIn({

--- a/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
+++ b/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
@@ -60,7 +60,7 @@ test('Can vote on a Mississippi Either Neither Contest', async () => {
     pollsState: 'polls_open',
   });
 
-  render(<App apiClient={apiMock.mockApiClient} reload={vi.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
   await advanceTimersAndPromises();
 
   // Start voter session

--- a/apps/mark/frontend/src/app_contest_multi_seat.test.tsx
+++ b/apps/mark/frontend/src/app_contest_multi_seat.test.tsx
@@ -42,7 +42,7 @@ test('Single Seat Contest', async () => {
     pollsState: 'polls_open',
   });
 
-  render(<App apiClient={apiMock.mockApiClient} reload={vi.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
   await advanceTimersAndPromises();
 
   // Start voter session

--- a/apps/mark/frontend/src/app_contest_single_seat.test.tsx
+++ b/apps/mark/frontend/src/app_contest_single_seat.test.tsx
@@ -44,7 +44,7 @@ test('Single Seat Contest', async () => {
     pollsState: 'polls_open',
   });
 
-  render(<App reload={vi.fn()} apiClient={apiMock.mockApiClient} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
   await advanceTimersAndPromises();
 
   // Start voter session

--- a/apps/mark/frontend/src/app_contest_yes_no.test.tsx
+++ b/apps/mark/frontend/src/app_contest_yes_no.test.tsx
@@ -45,7 +45,7 @@ test('Single Seat Contest', async () => {
     pollsState: 'polls_open',
   });
 
-  render(<App apiClient={apiMock.mockApiClient} reload={vi.fn()} />);
+  render(<App apiClient={apiMock.mockApiClient} />);
 
   // Start voter session
   apiMock.setAuthStatusCardlessVoterLoggedIn({

--- a/apps/mark/frontend/src/app_election_package_config.test.tsx
+++ b/apps/mark/frontend/src/app_election_package_config.test.tsx
@@ -27,7 +27,6 @@ test('renders an error if election package config endpoint returns an error', as
 
   render(
     <App
-      reload={vi.fn()}
       logger={mockBaseLogger({ fn: vi.fn })}
       apiClient={apiMock.mockApiClient}
     />

--- a/apps/mark/frontend/src/app_polls_flows.test.tsx
+++ b/apps/mark/frontend/src/app_polls_flows.test.tsx
@@ -52,7 +52,7 @@ test('full polls flow', async () => {
   await screen.findByText(hasTextAcrossElements('Polls: Closed'));
   userEvent.click(await screen.findByText('Open Polls'));
   const openModal = await screen.findByRole('alertdialog');
-  userEvent.click(within(openModal).getByText('Open Polls'));
+  userEvent.click(within(openModal).getButton('Open Polls'));
   await screen.findByText(hasTextAcrossElements('Polls: Open'));
   apiMock.setAuthStatusLoggedOut();
   await screen.findByText('Insert Card');
@@ -64,10 +64,9 @@ test('full polls flow', async () => {
     pollsState: 'polls_paused',
   });
   await screen.findByText(hasTextAcrossElements('Polls: Open'));
-  userEvent.click(screen.getByText('View More Actions'));
   userEvent.click(await screen.findByText('Pause Voting'));
   const pauseModal = await screen.findByRole('alertdialog');
-  userEvent.click(within(pauseModal).getByText('Pause Voting'));
+  userEvent.click(within(pauseModal).getButton('Pause Voting'));
   await screen.findByText(hasTextAcrossElements('Polls: Paused'));
   apiMock.setAuthStatusLoggedOut();
   await screen.findByText('Voting Paused');
@@ -81,7 +80,7 @@ test('full polls flow', async () => {
   await screen.findByText(hasTextAcrossElements('Polls: Paused'));
   userEvent.click(await screen.findByText('Resume Voting'));
   const resumeModal = await screen.findByRole('alertdialog');
-  userEvent.click(within(resumeModal).getByText('Resume Voting'));
+  userEvent.click(within(resumeModal).getButton('Resume Voting'));
   await screen.findByText(hasTextAcrossElements('Polls: Open'));
   apiMock.setAuthStatusLoggedOut();
   await screen.findByText('Insert Card');
@@ -93,10 +92,9 @@ test('full polls flow', async () => {
     pollsState: 'polls_closed_final',
   });
   await screen.findByText(hasTextAcrossElements('Polls: Open'));
-  userEvent.click(screen.getByText('View More Actions'));
   userEvent.click(screen.getByText('Close Polls'));
   const closeModal = await screen.findByRole('alertdialog');
-  userEvent.click(within(closeModal).getByText('Close Polls'));
+  userEvent.click(within(closeModal).getButton('Close Polls'));
   await screen.findByText(hasTextAcrossElements('Polls: Closed'));
   apiMock.setAuthStatusLoggedOut();
   await screen.findByText('Polls Closed');
@@ -124,7 +122,7 @@ test('can close polls from paused', async () => {
   await screen.findByText(hasTextAcrossElements('Polls: Paused'));
   userEvent.click(screen.getByText('Close Polls'));
   const closeModal = await screen.findByRole('alertdialog');
-  userEvent.click(within(closeModal).getByText('Close Polls'));
+  userEvent.click(within(closeModal).getButton('Close Polls'));
   await screen.findByText(hasTextAcrossElements('Polls: Closed'));
   apiMock.setAuthStatusLoggedOut();
   await screen.findByText('Polls Closed');

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -75,10 +75,6 @@ export interface VotingState {
   showPostVotingInstructions?: boolean;
 }
 
-export interface Props {
-  reload: VoidFunction;
-}
-
 export const stateStorageKey = 'state';
 export const blankBallotVotes: VotesDict = {};
 
@@ -132,7 +128,7 @@ function votingStateReducer(
   }
 }
 
-export function AppRoot({ reload }: Props): JSX.Element | null {
+export function AppRoot(): JSX.Element | null {
   const PostVotingInstructionsTimeout = useRef(0);
   const [votingState, dispatchVotingState] = useReducer(
     votingStateReducer,
@@ -485,7 +481,6 @@ export function AppRoot({ reload }: Props): JSX.Element | null {
           ballotsPrintedCount={ballotsPrintedCount}
           machineConfig={machineConfig}
           hasVotes={!!votes}
-          reload={reload}
         />
       );
     }

--- a/apps/mark/frontend/src/app_setup_errors.test.tsx
+++ b/apps/mark/frontend/src/app_setup_errors.test.tsx
@@ -43,7 +43,7 @@ describe('Displays setup warning messages and errors screens', () => {
       pollsState: 'polls_open',
     });
 
-    render(<App apiClient={apiMock.mockApiClient} reload={vi.fn()} />);
+    render(<App apiClient={apiMock.mockApiClient} />);
     const accessibleControllerWarningText =
       'Voting with an accessible controller is not currently available.';
 
@@ -84,7 +84,7 @@ describe('Displays setup warning messages and errors screens', () => {
       pollsState: 'polls_open',
     });
 
-    render(<App apiClient={apiMock.mockApiClient} reload={vi.fn()} />);
+    render(<App apiClient={apiMock.mockApiClient} />);
 
     // Start on Insert Card screen
     await screen.findByText(insertCardScreenText);
@@ -108,7 +108,7 @@ describe('Displays setup warning messages and errors screens', () => {
       pollsState: 'polls_open',
     });
 
-    render(<App apiClient={apiMock.mockApiClient} reload={vi.fn()} />);
+    render(<App apiClient={apiMock.mockApiClient} />);
 
     await screen.findByText('Insert Card');
 
@@ -139,7 +139,7 @@ describe('Displays setup warning messages and errors screens', () => {
       pollsState: 'polls_open',
     });
 
-    render(<App apiClient={apiMock.mockApiClient} reload={vi.fn()} />);
+    render(<App apiClient={apiMock.mockApiClient} />);
 
     await screen.findByText('Insert Card');
 
@@ -165,7 +165,7 @@ describe('Displays setup warning messages and errors screens', () => {
       pollsState: 'polls_open',
     });
 
-    render(<App apiClient={apiMock.mockApiClient} reload={vi.fn()} />);
+    render(<App apiClient={apiMock.mockApiClient} />);
     const findByTextWithMarkup = withMarkup(screen.findByText);
 
     // Start on Insert Card screen

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -1,129 +1,28 @@
-import React, { useState } from 'react';
-
 import {
   BallotStyleId,
   ElectionDefinition,
   PrecinctId,
   PrecinctSelection,
   PollsState,
-  PollsTransitionType,
   InsertedSmartCardAuth,
-  getGroupIdFromBallotStyleId,
 } from '@votingworks/types';
-import {
-  Button,
-  ButtonList,
-  Main,
-  Modal,
-  Screen,
-  ElectionInfoBar,
-  H1,
-  H2,
-  P,
-  Caption,
-  Font,
-  H4,
-  Icons,
-  FullScreenIconWrapper,
-  H3,
-  H6,
-  TestModeCallout,
-} from '@votingworks/ui';
-
-import {
-  getPollsTransitionDestinationState,
-  getPollsStateName,
-  getPollsTransitionAction,
-  getPollTransitionsFromState,
-  getGroupedBallotStyles,
-} from '@votingworks/utils';
+import { Button, Main, Screen, ElectionInfoBar } from '@votingworks/ui';
 
 import type { MachineConfig } from '@votingworks/mark-backend';
-import styled from 'styled-components';
-import { DateWithoutTime, find, throwIllegalValue } from '@votingworks/basics';
 
-import { DiagnosticsScreen } from './diagnostics_screen';
-import { setPollsState, setTestMode } from '../api';
+import { pollWorkerComponents } from '@votingworks/mark-flow-ui';
+import React from 'react';
+import { setPollsState, setTestMode, useApiClient } from '../api';
 
-const VotingSession = styled.div`
-  margin: 30px 0 60px;
-  border: 2px solid #000;
-  border-radius: 20px;
-  padding: 30px 40px;
-
-  & > *:first-child {
-    margin-top: 0;
-  }
-
-  & > *:last-child {
-    margin-bottom: 0;
-  }
-`;
-
-function UpdatePollsButton({
-  pollsTransition,
-  updatePollsState,
-  isPrimaryButton,
-}: {
-  pollsTransition: PollsTransitionType;
-  updatePollsState: (pollsState: PollsState) => void;
-  isPrimaryButton: boolean;
-}): JSX.Element {
-  const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
-
-  function closeModal() {
-    setIsConfirmationModalOpen(false);
-  }
-
-  function confirmUpdate() {
-    updatePollsState(getPollsTransitionDestinationState(pollsTransition));
-    closeModal();
-  }
-
-  const action = getPollsTransitionAction(pollsTransition);
-  const explanationText = (() => {
-    switch (pollsTransition) {
-      case 'open_polls':
-        return `After polls are opened, voters will be able to mark ballots.`;
-      case 'pause_voting':
-        return `After voting is paused, voters will not be able to mark ballots until voting is resumed.`;
-      case 'resume_voting':
-        return `After voting is resumed, voters will be able to mark ballots.`;
-      case 'close_polls':
-        return `After polls are closed, voters will no longer be able to mark ballots. Polls cannot be opened again after being closed.`;
-      default: {
-        /* istanbul ignore next - @preserve */
-        throwIllegalValue(pollsTransition);
-      }
-    }
-  })();
-
-  return (
-    <React.Fragment>
-      <Button
-        variant={isPrimaryButton ? 'primary' : 'neutral'}
-        onPress={() => setIsConfirmationModalOpen(true)}
-      >
-        {action}
-      </Button>
-      {isConfirmationModalOpen && (
-        <Modal
-          title={`Confirm ${action}`}
-          content={<P>{explanationText}</P>}
-          actions={
-            <React.Fragment>
-              <Button variant="primary" onPress={confirmUpdate}>
-                {action}
-              </Button>
-              <Button onPress={closeModal}>Cancel</Button>
-            </React.Fragment>
-          }
-          onOverlayClick={closeModal}
-        />
-      )}
-    </React.Fragment>
-  );
-}
+const {
+  EnableLiveModeModal,
+  ScreenBeginVoting,
+  ScreenVotingInProgress,
+  SectionHeader,
+  SectionPollsState,
+  SectionSessionStart,
+  SectionSystem,
+} = pollWorkerComponents;
 
 export interface PollworkerScreenProps {
   pollWorkerAuth: InsertedSmartCardAuth.PollWorkerLoggedIn;
@@ -140,7 +39,6 @@ export interface PollworkerScreenProps {
   pollsState: PollsState;
   ballotsPrintedCount: number;
   machineConfig: MachineConfig;
-  reload: () => void;
 }
 
 export function PollWorkerScreen({
@@ -155,122 +53,48 @@ export function PollWorkerScreen({
   ballotsPrintedCount,
   machineConfig,
   hasVotes,
-  reload,
 }: PollworkerScreenProps): JSX.Element {
   const { election } = electionDefinition;
-  const isElectionDay = election.date.isEqual(DateWithoutTime.today());
 
-  const setTestModeMutation = setTestMode.useMutation();
+  const apiClient = useApiClient();
   const setPollsStateMutation = setPollsState.useMutation();
+  const setTestModeMutation = setTestMode.useMutation();
 
-  const [selectedCardlessVoterPrecinctId, setSelectedCardlessVoterPrecinctId] =
-    useState<PrecinctId | undefined>(
-      appPrecinct.kind === 'SinglePrecinct' ? appPrecinct.precinctId : undefined
-    );
-
-  const precinctBallotStyles = selectedCardlessVoterPrecinctId
-    ? getGroupedBallotStyles(election.ballotStyles).filter((group) =>
-        group.precincts.includes(selectedCardlessVoterPrecinctId)
-      )
-    : [];
-  /*
-   * Various state parameters to handle controlling when certain modals on the page are open or not.
-   */
-  const [isConfirmingEnableLiveMode, setIsConfirmingEnableLiveMode] = useState(
-    !isLiveMode && isElectionDay
+  const onChooseBallotStyle = React.useCallback(
+    (precinctId: PrecinctId, ballotStyleId: BallotStyleId) => {
+      activateCardlessVoterSession(precinctId, ballotStyleId);
+    },
+    [activateCardlessVoterSession]
   );
-  function cancelEnableLiveMode() {
-    return setIsConfirmingEnableLiveMode(false);
-  }
-  const [isDiagnosticsScreenOpen, setIsDiagnosticsScreenOpen] = useState(false);
-
-  const canSelectBallotStyle = pollsState === 'polls_open';
-  const [isHidingSelectBallotStyle, setIsHidingSelectBallotStyle] =
-    useState(false);
-
-  function confirmEnableLiveMode() {
-    setTestModeMutation.mutate({ isTestMode: false });
-    setIsConfirmingEnableLiveMode(false);
-  }
 
   if (hasVotes && pollWorkerAuth.cardlessVoterUser) {
     return (
-      <Screen>
-        <Main centerChild>
-          <H1
-            aria-label={`Ballot style ${pollWorkerAuth.cardlessVoterUser.ballotStyleId} has been activated.`}
+      <ScreenVotingInProgress
+        election={election}
+        resetVoterSessionButton={
+          <Button
+            variant="danger"
+            icon="Delete"
+            onPress={resetCardlessVoterSession}
           >
-            Ballot Contains Votes
-          </H1>
-          <P>Remove card to allow voter to continue voting, or reset ballot.</P>
-          <P>
-            <Button
-              variant="danger"
-              icon="Delete"
-              onPress={resetCardlessVoterSession}
-            >
-              Reset Ballot
-            </Button>
-          </P>
-        </Main>
-      </Screen>
+            Reset Ballot
+          </Button>
+        }
+        voter={pollWorkerAuth.cardlessVoterUser}
+      />
     );
   }
 
   if (pollWorkerAuth.cardlessVoterUser) {
-    const { precinctId, ballotStyleId } = pollWorkerAuth.cardlessVoterUser;
-    const ballotStyleGroupId = getGroupIdFromBallotStyleId({
-      ballotStyleId,
-      election,
-    });
-    const precinct = find(election.precincts, (p) => p.id === precinctId);
-
     return (
-      <Screen>
-        <Main centerChild padded>
-          <div>
-            <FullScreenIconWrapper align="center">
-              <Icons.Done color="success" />
-            </FullScreenIconWrapper>
-            <H2 as="h1" align="center">
-              Voting Session Active:
-            </H2>
-            <H3 as="h2" align="center">
-              <Font weight="regular">
-                Ballot Style {ballotStyleGroupId} at {precinct.name}
-              </Font>
-            </H3>
-            <ol style={{ marginBottom: '0' }}>
-              <li>
-                <P>
-                  Instruct the voter to press the{' '}
-                  <Font weight="bold" noWrap>
-                    Start Voting
-                  </Font>{' '}
-                  button on the next screen.
-                </P>
-              </li>
-              <li>
-                <P>Remove the poll worker card to continue.</P>
-              </li>
-            </ol>
-            <hr />
-            <P align="center">Deactivate this voter session to start over.</P>
-            <P align="center">
-              <Button onPress={resetCardlessVoterSession}>
-                Deactivate Voting Session
-              </Button>
-            </P>
-          </div>
-        </Main>
-      </Screen>
-    );
-  }
-
-  if (isDiagnosticsScreenOpen) {
-    return (
-      <DiagnosticsScreen
-        onBackButtonPress={() => setIsDiagnosticsScreenOpen(false)}
+      <ScreenBeginVoting
+        election={election}
+        resetVoterSessionButton={
+          <Button onPress={resetCardlessVoterSession}>
+            Deactivate Voting Session
+          </Button>
+        }
+        voter={pollWorkerAuth.cardlessVoterUser}
       />
     );
   }
@@ -279,164 +103,35 @@ export function PollWorkerScreen({
     <Screen>
       <Main padded>
         <div>
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'start',
-            }}
-          >
-            <H2 as="h1">Poll Worker Menu</H2>
-            {!isLiveMode && <TestModeCallout />}
-          </div>
-          <H4 as="h2">
-            <Font noWrap>
-              <Font weight="light">Ballots Printed:</Font> {ballotsPrintedCount}
-            </Font>
-            <br />
-
-            <Font noWrap>
-              <Font weight="light">Polls:</Font> {getPollsStateName(pollsState)}
-            </Font>
-          </H4>
-          {canSelectBallotStyle && !isHidingSelectBallotStyle ? (
-            <React.Fragment>
-              <VotingSession>
-                <H4 as="h2">Start a New Voting Session</H4>
-                {appPrecinct.kind === 'AllPrecincts' && (
-                  <React.Fragment>
-                    <H6 as="h3">1. Select Voter’s Precinct</H6>
-                    <ButtonList data-testid="precincts">
-                      {election.precincts.map((precinct) => (
-                        <Button
-                          key={precinct.id}
-                          aria-label={`Activate Voter Session for Precinct ${precinct.name}`}
-                          onPress={() =>
-                            setSelectedCardlessVoterPrecinctId(precinct.id)
-                          }
-                          variant={
-                            selectedCardlessVoterPrecinctId === precinct.id
-                              ? 'primary'
-                              : 'neutral'
-                          }
-                        >
-                          {precinct.name}
-                        </Button>
-                      ))}
-                    </ButtonList>
-                  </React.Fragment>
-                )}
-                <H6 as="h3">
-                  {appPrecinct.kind === 'AllPrecincts' ? '2. ' : ''}Select
-                  Voter’s Ballot Style
-                </H6>
-                {selectedCardlessVoterPrecinctId ? (
-                  <ButtonList data-testid="ballot-styles">
-                    {precinctBallotStyles.map((ballotStyleGroup) => (
-                      <Button
-                        key={ballotStyleGroup.id}
-                        onPress={() =>
-                          activateCardlessVoterSession(
-                            selectedCardlessVoterPrecinctId,
-                            ballotStyleGroup.defaultLanguageBallotStyle.id
-                          )
-                        }
-                      >
-                        {ballotStyleGroup.id}
-                      </Button>
-                    ))}
-                  </ButtonList>
-                ) : (
-                  <Caption>
-                    <Icons.Info /> Select the voter’s precinct above to view
-                    ballot styles for the precinct.
-                  </Caption>
-                )}
-              </VotingSession>
-              <Button onPress={() => setIsHidingSelectBallotStyle(true)}>
-                View More Actions
-              </Button>
-            </React.Fragment>
-          ) : (
-            <React.Fragment>
-              <div /> {/* Enforces css margin from the following P tag. */}
-              {canSelectBallotStyle && (
-                <React.Fragment>
-                  <P>
-                    <Button
-                      icon="Previous"
-                      variant="primary"
-                      onPress={() => setIsHidingSelectBallotStyle(false)}
-                    >
-                      Back to Ballot Style Selection
-                    </Button>
-                  </P>
-                  <H3 as="h2">More Actions</H3>
-                </React.Fragment>
-              )}
-              <P>
-                {getPollTransitionsFromState(pollsState).map(
-                  (pollsTransition, index) => (
-                    <P key={`${pollsTransition}-button`}>
-                      <UpdatePollsButton
-                        pollsTransition={pollsTransition}
-                        updatePollsState={(newPollsState) =>
-                          setPollsStateMutation.mutate({
-                            pollsState: newPollsState,
-                          })
-                        }
-                        isPrimaryButton={index === 0}
-                      />
-                    </P>
-                  )
-                )}
-              </P>
-              <P>
-                <Button onPress={() => setIsDiagnosticsScreenOpen(true)}>
-                  Diagnostics
-                </Button>
-              </P>
-              <P>
-                <Button onPress={reload}>Reset Accessible Controller</Button>
-              </P>
-            </React.Fragment>
+          <SectionHeader
+            ballotsPrintedCount={ballotsPrintedCount}
+            liveMode={isLiveMode}
+          />
+          {pollsState === 'polls_open' && (
+            <SectionSessionStart
+              election={election}
+              onChooseBallotStyle={onChooseBallotStyle}
+              precinctSelection={appPrecinct}
+            />
           )}
+          <SectionPollsState
+            pollsState={pollsState}
+            updatePollsState={(newPollsState) =>
+              setPollsStateMutation.mutate({
+                pollsState: newPollsState,
+              })
+            }
+          />
+          <SectionSystem apiClient={apiClient} />
         </div>
       </Main>
-      {isConfirmingEnableLiveMode && (
-        <Modal
-          centerContent
-          title="Switch to Official Ballot Mode and reset the Ballots Printed count?"
-          content={
-            <div>
-              <P>
-                Today is election day and this machine is in{' '}
-                <Font noWrap weight="bold">
-                  Test Ballot Mode.
-                </Font>
-              </P>
-              <Caption>
-                Note: Switching back to Test Ballot Mode requires an{' '}
-                <Font noWrap>election manager card.</Font>
-              </Caption>
-            </div>
-          }
-          actions={
-            <React.Fragment>
-              <Button
-                variant="danger"
-                icon="Danger"
-                onPress={confirmEnableLiveMode}
-              >
-                Switch to Official Ballot Mode
-              </Button>
-              <Button onPress={cancelEnableLiveMode}>Cancel</Button>
-            </React.Fragment>
-          }
-        />
-      )}
+      <EnableLiveModeModal
+        election={election}
+        liveMode={isLiveMode}
+        setTestMode={setTestModeMutation.mutate}
+      />
       <ElectionInfoBar
-        mode="admin"
+        mode="pollworker"
         electionDefinition={electionDefinition}
         electionPackageHash={electionPackageHash}
         codeVersion={machineConfig.codeVersion}

--- a/apps/mark/frontend/test/helpers/build_app.tsx
+++ b/apps/mark/frontend/test/helpers/build_app.tsx
@@ -6,20 +6,15 @@ import { createApiMock } from './mock_api_client';
 
 export function buildApp(apiMock: ReturnType<typeof createApiMock>): {
   logger: BaseLogger;
-  reload: () => void;
   renderApp: () => RenderResult;
 } {
   const logger = mockBaseLogger({ fn: vi.fn });
-  const reload = vi.fn();
   function renderApp() {
-    return render(
-      <App reload={reload} logger={logger} apiClient={apiMock.mockApiClient} />
-    );
+    return render(<App logger={logger} apiClient={apiMock.mockApiClient} />);
   }
 
   return {
     logger,
-    reload,
     renderApp,
   };
 }

--- a/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
+++ b/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
@@ -64,7 +64,7 @@ test('configure, open polls, and test contest scroll buttons', async ({
   // Election Manager: set precinct
   await page.getByText('Precinct', { exact: true }).waitFor();
   await page.getByText('Select a precinct…').click({ force: true });
-  await page.getByText('All Precincts', { exact: true }).click();
+  await page.getByText('Center Springfield', { exact: true }).click();
 
   mockCardRemoval();
 
@@ -77,9 +77,8 @@ test('configure, open polls, and test contest scroll buttons', async ({
   await confirmDialog.getByRole('button', { name: 'Open Polls' }).click();
 
   // Poll Worker: initiate voting session
-  await page.getByText('Center Springfield').click();
-  await page.getByText('12').click();
-  await page.getByText('Voting Session Active:').waitFor();
+  await page.getByText('Start Voting Session: Center Springfield').click();
+  await page.getByText('Remove Card to Begin Voting Session').waitFor();
   mockCardRemoval();
 
   await page


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6706

Using `PollWorkerScreen` components extracted from MarkScan in Mark to bring the latter up to date with v4 UX/mechanics.

Also removing the old `Reset Accessible Controller` workaround, which [isn't needed anymore](https://votingworks.slack.com/archives/CEL6D3GAD/p1752172516769329).

Updated pieces include:
- New, human-friendly labels for and updated UX ballot style picker
- Signed hash validation control
- Layout/copy/iconography updates for start/resume voting session interstitials

First commit has PollWorkerScreen changes - may be more helpful to view the incoming code as a plain, non-diff file, since there's so much change.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/2f9e374c-a664-40de-9a9b-c4b012d50818

## Testing Plan
- Updated existing tests, copied over MarkScan tests for the newly added piece, particularly ballot style selector
- Tests could use some cleanup - lots of redundant repeated coverage across unit, functional, integration tests - considering it out of scope for now

## Checklist

<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
