### PR TITLE
VxPollBook: some post-QA quick fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Includes software for:
 - [VxScan](./apps/scan/frontend) — A precinct scanner for casting of ballots
   (marked by hand or by BMD)
 - [VxDesign](./apps/design/frontend) — An application for designing ballots
-- [VxPollbook](./apps/pollbook/frontend) — A pollbook application for checking
+- [VxPollBook](./apps/pollbook/frontend) — A pollbook application for checking
   in voters
 
 VxAdmin and VxCentralScan comprise the "central system." VxMark and VxScan

--- a/apps/pollbook/backend/README.md
+++ b/apps/pollbook/backend/README.md
@@ -1,5 +1,5 @@
-# VxPollbook Backend
+# VxPollBook Backend
 
-This backend is used by the [VxPollbook frontend](../frontend) and isn't
+This backend is used by the [VxPollBook frontend](../frontend) and isn't
 intended to be run on its own. The best way to develop on the backend is by
 running the frontend.

--- a/apps/pollbook/backend/src/backup_worker.ts
+++ b/apps/pollbook/backend/src/backup_worker.ts
@@ -235,7 +235,7 @@ export function start({
   workspace: LocalWorkspace;
   usbDrive: UsbDrive;
 }): void {
-  console.log('Starting VxPollbook backup worker');
+  console.log('Starting VxPollBook backup worker');
   process.nextTick(async () => {
     await exportBackupVoterChecklist(workspace, usbDrive);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/apps/pollbook/backend/src/barcode_scanner/client.test.ts
+++ b/apps/pollbook/backend/src/barcode_scanner/client.test.ts
@@ -39,7 +39,7 @@ describe('SocketServer.listen event handling', () => {
     vi.useFakeTimers();
     mockSocket = new PassThrough() as unknown as net.Socket;
     logger = mockLogger({
-      source: LogSource.VxPollbookBackend,
+      source: LogSource.VxPollBookBackend,
       getCurrentRole: vi.fn().mockResolvedValue('system'),
       fn: vi.fn,
     });

--- a/apps/pollbook/backend/src/barcode_scanner/unix_socket.test.ts
+++ b/apps/pollbook/backend/src/barcode_scanner/unix_socket.test.ts
@@ -28,7 +28,7 @@ describe('unix socket utils', () => {
       mockSocket as unknown as net.Socket
     );
     logger = mockLogger({
-      source: LogSource.VxPollbookBackend,
+      source: LogSource.VxPollBookBackend,
       getCurrentRole: vi.fn().mockResolvedValue('system'),
       fn: vi.fn,
     });

--- a/apps/pollbook/backend/src/index.ts
+++ b/apps/pollbook/backend/src/index.ts
@@ -110,7 +110,7 @@ if (require.main === module) {
   void main()
     .catch((error) => {
       // eslint-disable-next-line no-console
-      console.error(`Error starting VxPollbook backend: ${error.stack}`);
+      console.error(`Error starting VxPollBook backend: ${error.stack}`);
       return 1;
     })
     .then((code) => {

--- a/apps/pollbook/backend/src/peer_server.ts
+++ b/apps/pollbook/backend/src/peer_server.ts
@@ -11,7 +11,7 @@ export function start(context: PeerAppContext): number {
   app.listen(PEER_PORT, () => {
     // eslint-disable-next-line no-console
     console.log(
-      `VxPollbook p2p backend running at http://localhost:${PEER_PORT}/`
+      `VxPollBook p2p backend running at http://localhost:${PEER_PORT}/`
     );
   });
   return PEER_PORT;

--- a/apps/pollbook/backend/src/server.ts
+++ b/apps/pollbook/backend/src/server.ts
@@ -12,7 +12,7 @@ import { BarcodeScannerClient } from './barcode_scanner/client';
  * Starts the server.
  */
 export function start(context: LocalAppContext): void {
-  const baseLogger = new BaseLogger(LogSource.VxPollbookBackend);
+  const baseLogger = new BaseLogger(LogSource.VxPollBookBackend);
   const logger = Logger.from(baseLogger, () =>
     getUserRole(context.auth, context.workspace)
   );
@@ -33,7 +33,7 @@ export function start(context: LocalAppContext): void {
   app.listen(LOCAL_PORT, () => {
     // eslint-disable-next-line no-console
     console.log(
-      `VxPollbook backend running at http://localhost:${LOCAL_PORT}/`
+      `VxPollBook backend running at http://localhost:${LOCAL_PORT}/`
     );
   });
 }

--- a/apps/pollbook/backend/test/app.ts
+++ b/apps/pollbook/backend/test/app.ts
@@ -64,7 +64,7 @@ export function buildMockLogger(
   workspace: LocalWorkspace
 ): MockLogger {
   return mockLogger({
-    source: LogSource.VxPollbookBackend,
+    source: LogSource.VxPollBookBackend,
     getCurrentRole: () => getUserRole(auth, workspace),
     fn: vi.fn,
   });

--- a/apps/pollbook/barcode-scanner-daemon/src/unitech_ts100_daemon.rs
+++ b/apps/pollbook/barcode-scanner-daemon/src/unitech_ts100_daemon.rs
@@ -21,7 +21,7 @@ mod parse_aamva;
 /*
  * Logging config
  */
-const SOURCE: Source = Source::VxPollbookBarcodeScannerDaemon;
+const SOURCE: Source = Source::VxPollBookBarcodeScannerDaemon;
 /// How often the daemon logs its heartbeat.
 const HEARTBEAT_LOG_INTERVAL: Duration = Duration::from_secs(60);
 /// Interval for general polling

--- a/apps/pollbook/frontend/README.md
+++ b/apps/pollbook/frontend/README.md
@@ -1,4 +1,4 @@
-# VxPollbook Frontend
+# VxPollBook Frontend
 
 ## Setup
 

--- a/apps/pollbook/frontend/index.html
+++ b/apps/pollbook/frontend/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Another election tool from VotingWorks" />
     <link rel="stylesheet" href="/fonts/noto-emoji.css" />
-    <title>VotingWorks VxPollbook</title>
+    <title>VotingWorks VxPollBook</title>
   </head>
 
   <body>

--- a/apps/pollbook/frontend/prodserver/index.js
+++ b/apps/pollbook/frontend/prodserver/index.js
@@ -13,7 +13,7 @@ const { handleUncaughtExceptions } = require('@votingworks/backend');
 const proxy = require('./setupProxy');
 const app = express();
 const port = 3000;
-const logger = new Logger(LogSource.VxPollbookFrontendServer);
+const logger = new Logger(LogSource.VxPollBookFrontendServer);
 
 handleUncaughtExceptions(logger);
 

--- a/apps/pollbook/frontend/src/api.ts
+++ b/apps/pollbook/frontend/src/api.ts
@@ -430,6 +430,9 @@ export const setConfiguredPrecinct = {
         await queryClient.invalidateQueries(
           getPollbookConfigurationInformation.queryKey()
         );
+        // because we sort the voters by placing those in the configured precinct
+        // first, changing the precinct actually changes the search results
+        await invalidateVoterQueries(queryClient);
       },
     });
   },

--- a/apps/pollbook/frontend/src/app.test.tsx
+++ b/apps/pollbook/frontend/src/app.test.tsx
@@ -65,7 +65,7 @@ test('renders MachineLockedScreen when machine is locked - unconfigure', async (
     reason: 'machine_locked',
   });
   render(<App apiClient={apiMock.mockApiClient} />);
-  await screen.findByText('VxPollbook Locked');
+  await screen.findByText('VxPollBook Locked');
   await screen.findByText(
     'Insert system administrator or election manager card to unlock.'
   );
@@ -79,7 +79,7 @@ test('renders MachineLockedScreen when machine is locked - configured', async ()
   });
   apiMock.setElection(famousNamesElection, undefined, 'FAKEHASH');
   render(<App apiClient={apiMock.mockApiClient} />);
-  await screen.findByText('VxPollbook Locked');
+  await screen.findByText('VxPollBook Locked');
   await screen.findByText('Insert card to unlock.');
   await screen.findByText(
     `${famousNamesElection.ballotHash.slice(0, 7)}-FAKEHAS`
@@ -133,7 +133,7 @@ test('system administrator can unconfigure', async () => {
   userEvent.click(confirmButton);
 
   await screen.findByText(
-    'Insert a USB drive containing a pollbook package or power up another configured machine.'
+    'Insert a USB drive containing a poll book package or power up another configured machine.'
   );
 });
 

--- a/apps/pollbook/frontend/src/app.tsx
+++ b/apps/pollbook/frontend/src/app.tsx
@@ -73,7 +73,7 @@ function AppRoot(): JSX.Element | null {
   if (auth.status === 'remove_card') {
     return (
       <RemoveCardScreen
-        productName="VxPollbook"
+        productName="VxPollBook"
         cardInsertionDirection="right"
       />
     );

--- a/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
+++ b/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
@@ -61,13 +61,10 @@ describe('PollWorkerScreen', () => {
     );
 
     apiMock.expectGetCheckInCounts({ allMachines: 25, thisMachine: 5 });
-    await vi.waitFor(() => {
-      screen.getByText('Check-In');
-    });
     apiMock.expectGetScannedIdDocument();
     apiMock.expectSearchVotersNull({});
 
-    await screen.findByText('Total Check-ins');
+    await vi.waitFor(() => screen.getByText('Total Check-ins'));
     const total = screen.getByTestId('total-check-ins');
     within(total).getByText('25');
     const machine = screen.getByTestId('machine-check-ins');
@@ -149,11 +146,7 @@ describe('PollWorkerScreen', () => {
     apiMock.expectGetCheckInCounts({ allMachines: 25, thisMachine: 5 });
     const { unmount } = render(<App apiClient={apiMock.mockApiClient} />);
 
-    await vi.waitFor(() => {
-      screen.getByText('Check-In');
-    });
-
-    await screen.findByText('Total Check-ins');
+    await vi.waitFor(() => screen.getByText('Total Check-ins'));
     const total = screen.getByTestId('total-check-ins');
     within(total).getByText('25');
     const machine = screen.getByTestId('machine-check-ins');
@@ -198,9 +191,7 @@ describe('PollWorkerScreen', () => {
 
     // Render empty voter search screen
     const { unmount } = render(<App apiClient={apiMock.mockApiClient} />);
-    await vi.waitFor(() => {
-      screen.getByText('Check-In');
-    });
+    await vi.waitFor(() => screen.getByText('Voter Check-In'));
 
     const document: AamvaDocument = {
       firstName: 'Aaron',
@@ -259,7 +250,6 @@ describe('PollWorkerScreen', () => {
       apiMock.setPrinterStatus(true);
       apiMock.setIsAbsenteeMode(false);
       apiMock.expectGetCheckInCounts({ allMachines: 25, thisMachine: 5 });
-      await screen.findByText('Check-In');
       apiMock.expectSearchVotersNull({});
       apiMock.expectGetScannedIdDocument();
 

--- a/apps/pollbook/frontend/src/election_manager_screen.test.tsx
+++ b/apps/pollbook/frontend/src/election_manager_screen.test.tsx
@@ -119,7 +119,7 @@ describe('SettingsScreen precinct selection', () => {
     expect(select).toBeInTheDocument();
     expect((select as HTMLSelectElement).disabled).toBeTruthy();
     screen.getByText(
-      /The precinct setting cannot be changed because a voter was checked-in or voter data was updated/
+      /The precinct setting cannot be changed because a voter was checked in or voter information was updated/
     );
   });
 
@@ -166,7 +166,7 @@ describe('SettingsScreen precinct selection', () => {
     expect(selectDisabled).toBeInTheDocument();
     expect((selectDisabled as HTMLSelectElement).disabled).toBeTruthy();
     screen.getByText(
-      /The precinct setting cannot be changed because a voter was checked-in or voter data was updated/
+      /The precinct setting cannot be changed because a voter was checked in or voter information was updated/
     );
   });
 });

--- a/apps/pollbook/frontend/src/election_manager_screen.tsx
+++ b/apps/pollbook/frontend/src/election_manager_screen.tsx
@@ -132,8 +132,8 @@ export function SettingsScreen(): JSX.Element | null {
           </Row>
           {precinctOptions.length > 1 && haveElectionEventsOccurred && (
             <Caption>
-              The precinct setting cannot be changed because a voter was
-              checked-in or voter data was updated.
+              The precinct setting cannot be changed because a voter was checked
+              in or voter information was updated.
             </Caption>
           )}
         </Column>

--- a/apps/pollbook/frontend/src/election_manager_screen.tsx
+++ b/apps/pollbook/frontend/src/election_manager_screen.tsx
@@ -155,12 +155,12 @@ export function ElectionManagerScreen(): JSX.Element {
         component={ElectionManagerVotersScreen}
       />
       <Route
-        path={electionManagerRoutes.statistics.path}
-        component={StatisticsScreen}
-      />
-      <Route
         path={electionManagerRoutes.addVoter.path}
         component={VoterRegistrationScreen}
+      />
+      <Route
+        path={electionManagerRoutes.statistics.path}
+        component={StatisticsScreen}
       />
       <Route path="/voters/:voterId" component={VoterDetailsScreen} />
       <Redirect to={electionManagerRoutes.settings.path} />

--- a/apps/pollbook/frontend/src/machine_locked_screen.tsx
+++ b/apps/pollbook/frontend/src/machine_locked_screen.tsx
@@ -34,7 +34,7 @@ export function MachineLockedScreen(): JSX.Element | null {
       <Main centerChild>
         <div>
           <LockedImage src="/locked.svg" alt="Locked Icon" />
-          <H1 align="center">VxPollbook Locked</H1>
+          <H1 align="center">VxPollBook Locked</H1>
           <H3 align="center" style={{ fontWeight: 'normal' }}>
             {getElectionQuery.data.isOk() ? (
               <React.Fragment>Insert card to unlock.</React.Fragment>

--- a/apps/pollbook/frontend/src/nav_screen.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.tsx
@@ -435,8 +435,8 @@ export function NavScreen({
 
 export const systemAdministratorRoutes = {
   election: { title: 'Election', path: '/election' },
-  settings: { title: 'Settings', path: '/settings' },
   smartCards: { title: 'Smart Cards', path: '/smart-cards' },
+  settings: { title: 'Settings', path: '/settings' },
 } satisfies Record<string, { title: string; path: string }>;
 
 export function SystemAdministratorNavScreen({
@@ -474,8 +474,8 @@ export function SystemAdministratorNavScreen({
 export const electionManagerRoutes = {
   settings: { title: 'Settings', path: '/settings' },
   voters: { title: 'Voters', path: '/voters' },
-  statistics: { title: 'Statistics', path: '/statistics' },
   addVoter: { title: 'Registration', path: '/registration' },
+  statistics: { title: 'Statistics', path: '/statistics' },
 } satisfies Record<string, { title: string; path: string }>;
 
 export function ElectionManagerNavScreen({

--- a/apps/pollbook/frontend/src/nav_screen.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.tsx
@@ -515,35 +515,6 @@ export const pollWorkerRoutes = {
   checkIn: { title: 'Check-In', path: '/check-in' },
 } satisfies Record<string, { title: string; path: string }>;
 
-export function PollWorkerNavScreen({
-  children,
-}: {
-  children: React.ReactNode;
-}): JSX.Element {
-  const currentRoute = useRouteMatch();
-
-  return (
-    <NavScreen
-      navContent={
-        <NavList>
-          {Object.values(pollWorkerRoutes).map((route) => (
-            <NavListItem key={route.path}>
-              <NavLink
-                to={route.path}
-                isActive={route.path === currentRoute.url}
-              >
-                {route.title}
-              </NavLink>
-            </NavListItem>
-          ))}
-        </NavList>
-      }
-    >
-      {children}
-    </NavScreen>
-  );
-}
-
 export function NoNavScreen({
   children,
 }: {

--- a/apps/pollbook/frontend/src/nav_screen.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.tsx
@@ -410,7 +410,7 @@ export function NavScreen({
     <Screen flexDirection="row">
       <LeftNav style={{ width: '13rem' }}>
         <Link to="/">
-          <AppLogo appName="VxPollbook" />
+          <AppLogo appName="VxPollBook" />
         </Link>
         {navContent}
         <div style={{ marginTop: 'auto' }}>

--- a/apps/pollbook/frontend/src/nav_screen.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.tsx
@@ -189,8 +189,7 @@ function NetworkStatus({
               )}
               {isResetting && (
                 <div>
-                  <Icons.Loading /> <br />{' '}
-                  <div>Resetting network connection...</div>
+                  <Icons.Loading /> Resetting network connection...
                 </div>
               )}
               {sortedPollbooks.length === 0 && status.isOnline && (

--- a/apps/pollbook/frontend/src/poll_worker_screen.tsx
+++ b/apps/pollbook/frontend/src/poll_worker_screen.tsx
@@ -20,11 +20,7 @@ import {
   VoterSearchScreen,
 } from './voter_search_screen';
 import { VoterConfirmScreen } from './voter_confirm_screen';
-import {
-  NoNavScreen,
-  PollWorkerNavScreen,
-  pollWorkerRoutes,
-} from './nav_screen';
+import { NavScreen, NoNavScreen, pollWorkerRoutes } from './nav_screen';
 import { Column, Row } from './layout';
 import {
   checkInVoter,
@@ -296,7 +292,7 @@ export function PollWorkerScreen(): JSX.Element | null {
     getPollbookConfigurationInformationQuery.data;
   if (!printer.connected) {
     return (
-      <PollWorkerNavScreen>
+      <NavScreen>
         <Column style={{ justifyContent: 'center', flex: 1 }}>
           <FullScreenMessage
             image={
@@ -309,13 +305,13 @@ export function PollWorkerScreen(): JSX.Element | null {
             <p>Connect printer to continue.</p>
           </FullScreenMessage>
         </Column>
-      </PollWorkerNavScreen>
+      </NavScreen>
     );
   }
 
   if (!configuredPrecinctId) {
     return (
-      <PollWorkerNavScreen>
+      <NavScreen>
         <Column>
           <FullScreenMessage
             title="No Precinct Selected"
@@ -328,7 +324,7 @@ export function PollWorkerScreen(): JSX.Element | null {
             <P>Insert an election manager card to select a precinct.</P>
           </FullScreenMessage>
         </Column>
-      </PollWorkerNavScreen>
+      </NavScreen>
     );
   }
 

--- a/apps/pollbook/frontend/src/shared_components.tsx
+++ b/apps/pollbook/frontend/src/shared_components.tsx
@@ -146,6 +146,8 @@ export const RequiredStaticInput = styled(StaticInput)`
 const TitleBar = styled.div`
   padding: 0.5rem 1rem;
   background-color: ${(p) => p.theme.colors.containerLow};
+  border-top-left-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
+  border-top-right-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
 `;
 
 const StyledTitledCard = styled(Card)`

--- a/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
+++ b/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
@@ -60,7 +60,7 @@ describe('Election tab', () => {
     unmount = renderResult.unmount;
     await screen.findByRole('heading', { name: 'Election' });
     await screen.findByText(
-      'Insert a USB drive containing a pollbook package or power up another configured machine.'
+      'Insert a USB drive containing a poll book package or power up another configured machine.'
     );
   });
 
@@ -72,12 +72,12 @@ describe('Election tab', () => {
     unmount = renderResult.unmount;
     await screen.findByRole('heading', { name: 'Election' });
     await screen.findByText(
-      'Insert a USB drive containing a pollbook package or power up another configured machine.'
+      'Insert a USB drive containing a poll book package or power up another configured machine.'
     );
 
     apiMock.setElectionConfiguration('not-found-usb');
     await screen.findByText(
-      'No pollbook package found on the inserted USB drive.'
+      'No poll book package found on the inserted USB drive.'
     );
 
     // There should be a error if there was an error in configuration from usb
@@ -85,7 +85,7 @@ describe('Election tab', () => {
     await screen.findByText('Failed to configure VxPollBook');
 
     apiMock.setElectionConfiguration('loading');
-    await screen.findByText('Configuring VxPollbook from USB drive…');
+    await screen.findByText('Configuring VxPollBook from USB drive…');
   });
 
   test('sys admin - can configure from networked machine', async () => {
@@ -133,13 +133,13 @@ describe('Election tab', () => {
       `${electionDefFamousNames.ballotHash.slice(0, 7)}-differe`
     );
     await screen.findByText(
-      /Insert a USB drive containing a pollbook package, or configure from another nearby machine listed below./
+      /Insert a USB drive containing a poll book package, or configure from another nearby machine listed below./
     );
 
     // If the usb drive is inserted without a package there is a warning.
     apiMock.setElectionConfiguration('not-found-usb');
     await screen.findByText(
-      /No pollbook package found on the inserted USB drive/
+      /No poll book package found on the inserted USB drive/
     );
 
     // There should be a warning if there was an error in configuration from usb
@@ -150,7 +150,7 @@ describe('Election tab', () => {
     apiMock.expectConfigureOverNetwork('TEST-04', 'invalid-pollbook-package');
     const configureBad = await within(rows[1]).findByText('Configure');
     userEvent.click(configureBad);
-    await screen.findByText(/Error during configuration, please try again./);
+    await screen.findByText(/Error during configuration. Please try again./);
 
     // Try to configure from the "good" election and mimic success
     apiMock.expectConfigureOverNetwork('TEST-01');

--- a/apps/pollbook/frontend/src/system_administrator_screen.tsx
+++ b/apps/pollbook/frontend/src/system_administrator_screen.tsx
@@ -122,12 +122,12 @@ export function SystemAdministratorScreen(): JSX.Element {
         component={ElectionScreen}
       />
       <Route
-        path={systemAdministratorRoutes.settings.path}
-        component={SettingsScreen}
-      />
-      <Route
         path={systemAdministratorRoutes.smartCards.path}
         component={SmartCardsScreen}
+      />
+      <Route
+        path={systemAdministratorRoutes.settings.path}
+        component={SettingsScreen}
       />
       <Redirect to={systemAdministratorRoutes.election.path} />
     </Switch>

--- a/apps/pollbook/frontend/src/unconfigured_screen.tsx
+++ b/apps/pollbook/frontend/src/unconfigured_screen.tsx
@@ -30,7 +30,7 @@ function PollbookConnectionTable({
   pollbooks: PollbookServiceInfo[];
   onConfigure: (pollbooks: PollbookServiceInfo[]) => void;
 }): JSX.Element {
-  // Group pollbooks by election hash (ballotHash-packageHash)
+  // Group poll books by election hash (ballotHash-packageHash)
   const groups = groupBy(
     pollbooks,
     (p) => `${p.electionBallotHash}-${p.pollbookPackageHash}`
@@ -94,7 +94,7 @@ export function UnconfiguredSystemAdminScreen(): JSX.Element {
   if (electionResult.isOk() || electionResult.err() === 'loading') {
     return (
       <FullScreenMessage
-        title="Configuring VxPollbook from USB drive…"
+        title="Configuring VxPollBook from USB drive…"
         image={
           <FullScreenIconWrapper>
             <Icons.Loading />
@@ -106,7 +106,7 @@ export function UnconfiguredSystemAdminScreen(): JSX.Element {
   if (isLoadingFromNetwork && electionResult.err() === 'unconfigured') {
     return (
       <FullScreenMessage
-        title="Configuring VxPollbook from network…"
+        title="Configuring VxPollBook from network…"
         image={
           <FullScreenIconWrapper>
             <Icons.Loading />
@@ -137,27 +137,27 @@ export function UnconfiguredSystemAdminScreen(): JSX.Element {
             </FullScreenIconWrapper>
           }
         >
-          Error configuring machine please try again.
+          Error configuring machine. Please try again.
         </FullScreenMessage>
       );
     }
     if (electionResult.err() === 'not-found-usb') {
       return (
         <FullScreenMessage
-          title="Failed to configure VxPollbook"
+          title="Failed to configure VxPollBook"
           image={
             <FullScreenIconWrapper>
               <Icons.Warning color="warning" />
             </FullScreenIconWrapper>
           }
         >
-          No pollbook package found on the inserted USB drive.
+          No poll book package found on the inserted USB drive.
         </FullScreenMessage>
       );
     }
     return (
       <FullScreenMessage
-        title="Insert a USB drive containing a pollbook package or power up another configured machine."
+        title="Insert a USB drive containing a poll book package or power up another configured machine."
         image={<UsbDriveImage />}
       />
     );
@@ -167,18 +167,18 @@ export function UnconfiguredSystemAdminScreen(): JSX.Element {
     <MainContent>
       {electionResult.err() === 'not-found-usb' && (
         <Card color="warning" style={{ marginBottom: '1rem' }}>
-          <Icons.Warning color="warning" /> No pollbook package found on the
+          <Icons.Warning color="warning" /> No poll book package found on the
           inserted USB drive.
         </Card>
       )}
       {hasError && (
         <Card color="warning" style={{ marginBottom: '1rem' }}>
-          <Icons.Warning color="warning" /> Error during configuration, please
+          <Icons.Warning color="warning" /> Error during configuration. Please
           try again.
         </Card>
       )}
       <P>
-        Insert a USB drive containing a pollbook package, or configure from
+        Insert a USB drive containing a poll book package, or configure from
         another nearby machine listed below.
       </P>
       <PollbookConnectionTable
@@ -222,7 +222,7 @@ export function UnconfiguredElectionManagerScreen(): JSX.Element {
     return (
       <Screen>
         <FullScreenMessage
-          title="Configuring VxPollbook from network…"
+          title="Configuring VxPollBook from network…"
           image={
             <FullScreenIconWrapper>
               <Icons.Loading />
@@ -258,7 +258,7 @@ export function UnconfiguredElectionManagerScreen(): JSX.Element {
     return (
       <Screen>
         <FullScreenMessage
-          title="Configuring VxPollbook from network…"
+          title="Configuring VxPollBook from network…"
           image={
             <FullScreenIconWrapper>
               <Icons.Loading />
@@ -335,8 +335,7 @@ export function UnconfiguredElectionManagerScreen(): JSX.Element {
           </FullScreenIconWrapper>
         }
       >
-        VxPollBook did not detect any other configured poll books on the
-        network.
+        VxPollBook did not detect any configured poll books on the network.
       </FullScreenMessage>
     </Screen>
   );

--- a/apps/pollbook/frontend/src/update_mailing_address_flow.tsx
+++ b/apps/pollbook/frontend/src/update_mailing_address_flow.tsx
@@ -48,7 +48,7 @@ function createBlankMailingAddress(): VoterMailingAddressChangeRequest {
     mailingAddressLine2: '',
     mailingAddressLine3: '',
     mailingCityTown: '',
-    mailingState: 'NH',
+    mailingState: '',
     mailingZip5: '',
     mailingZip4: '',
   };

--- a/apps/pollbook/frontend/src/us_states.ts
+++ b/apps/pollbook/frontend/src/us_states.ts
@@ -1,5 +1,4 @@
 export const usStates = {
-  // NH: 'New Hampshire',
   AL: 'Alabama',
   AK: 'Alaska',
   AZ: 'Arizona',
@@ -28,6 +27,7 @@ export const usStates = {
   MO: 'Missouri',
   MT: 'Montana',
   NE: 'Nebraska',
+  NH: 'New Hampshire',
   NV: 'Nevada',
   NJ: 'New Jersey',
   NM: 'New Mexico',

--- a/apps/pollbook/frontend/src/voter_confirm_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_confirm_screen.tsx
@@ -36,6 +36,9 @@ import { UpdateMailingAddressFlow } from './update_mailing_address_flow';
 import { getVoter } from './api';
 import { getVoterPrecinct } from './types';
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const { NH, ...usStatesWithoutNewHampshire } = usStates;
+
 function isIdentificationMethodComplete(
   identificationMethod: Partial<VoterIdentificationMethod>
 ): identificationMethod is VoterIdentificationMethod {
@@ -242,10 +245,12 @@ export function VoterConfirmScreen({
                 {identificationMethod.type === 'outOfStateLicense' && (
                   <SearchSelect
                     id="state"
-                    options={Object.entries(usStates).map(([value, label]) => ({
-                      value,
-                      label: `${value} - ${label}`,
-                    }))}
+                    options={Object.entries(usStatesWithoutNewHampshire).map(
+                      ([value, label]) => ({
+                        value,
+                        label: `${value} - ${label}`,
+                      })
+                    )}
                     menuPortalTarget={document.body}
                     value={
                       identificationMethod.type === 'outOfStateLicense'

--- a/apps/pollbook/frontend/src/voter_details_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_details_screen.tsx
@@ -505,14 +505,10 @@ export function VoterDetailsScreen(): JSX.Element | null {
                   </LabelledText>
                   {voter.checkIn.identificationMethod.type ===
                     'outOfStateLicense' && (
-                    <React.Fragment>
-                      <LabelledText label="Identification method">
-                        Out of state driver&apos;s license
-                      </LabelledText>
-                      <LabelledText label="State">
-                        {voter.checkIn.identificationMethod.state}
-                      </LabelledText>
-                    </React.Fragment>
+                    <LabelledText label="Identification Method">
+                      Out-of-State ID (
+                      {voter.checkIn.identificationMethod.state})
+                    </LabelledText>
                   )}
                 </Column>
               </React.Fragment>

--- a/apps/pollbook/frontend/src/voter_search_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_search_screen.tsx
@@ -28,7 +28,7 @@ import { Optional, throwIllegalValue } from '@votingworks/basics';
 import { Election } from '@votingworks/types';
 import { useQueryClient } from '@tanstack/react-query';
 import { Column, Form, Row, InputGroup } from './layout';
-import { PollWorkerNavScreen } from './nav_screen';
+import { NavScreen } from './nav_screen';
 import { getCheckInCounts, getScannedIdDocument, searchVoters } from './api';
 import {
   AbsenteeModeCallout,
@@ -353,7 +353,7 @@ export function VoterSearchScreen({
   );
 
   return (
-    <PollWorkerNavScreen>
+    <NavScreen>
       <Main flexColumn>
         <MainHeader>
           <Row
@@ -410,6 +410,6 @@ export function VoterSearchScreen({
           />
         </MainContent>
       </Main>
-    </PollWorkerNavScreen>
+    </NavScreen>
   );
 }

--- a/apps/pollbook/frontend/src/voter_search_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_search_screen.tsx
@@ -24,7 +24,7 @@ import type {
 } from '@votingworks/pollbook-backend';
 import styled from 'styled-components';
 import { format } from '@votingworks/utils';
-import { Optional, throwIllegalValue } from '@votingworks/basics';
+import { Optional } from '@votingworks/basics';
 import { Election } from '@votingworks/types';
 import { useQueryClient } from '@tanstack/react-query';
 import { Column, Form, Row, InputGroup } from './layout';
@@ -296,18 +296,6 @@ export function CheckInDetails({
 }: {
   checkIn: VoterCheckIn;
 }): JSX.Element {
-  const { identificationMethod } = checkIn;
-  const identificationDetails = (() => {
-    switch (identificationMethod.type) {
-      case 'default':
-        return null;
-      case 'outOfStateLicense':
-        return `OOS DL (${identificationMethod.state})`;
-      default:
-        /* istanbul ignore next - @preserve */
-        throwIllegalValue(identificationMethod);
-    }
-  })();
   return (
     <Column>
       {checkIn.isAbsentee ? (
@@ -322,7 +310,6 @@ export function CheckInDetails({
       <Caption noWrap>
         {format.localeTime(new Date(checkIn.timestamp))} &bull;{' '}
         {checkIn.machineId}
-        {identificationDetails && <span> &bull; {identificationDetails}</span>}
       </Caption>
     </Column>
   );

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -92,7 +92,7 @@ function getDefaultExpectedVoterSearchParams(
 }
 
 /**
- * Creates a VxPollbook specific wrapper around commonly used methods from the Grout
+ * Creates a VxPollBook specific wrapper around commonly used methods from the Grout
  * mock API client to make it easier to use for our specific test needs
  */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/libs/fixtures/src/data/election_simple_single_precinct.ts
+++ b/libs/fixtures/src/data/election_simple_single_precinct.ts
@@ -2,7 +2,7 @@ import * as builders from '../builders';
 
 /**
  * Note: This is an election equivalent to the BASE_DEPRECATED version in the other fixtures and does
- * not contain grid layouts, translations, etc. It is used for testing with VxPollbook to test a simplified election
+ * not contain grid layouts, translations, etc. It is used for testing with VxPollBook to test a simplified election
  * definition for a non-vxsuite user. If testing with vxsuite you should set up this base election to generate an election package
  * in libs/fixture-generators before using.
  */

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -88,13 +88,13 @@ source = 'vx-scan-service'
 [LogSources.VxDevelopmentScript]
 source = 'vx-development-script'
 
-[LogSources.VxPollbookFrontend]
+[LogSources.VxPollBookFrontend]
 source = 'vx-pollbook-frontend'
 
-[LogSources.VxPollbookBackend]
+[LogSources.VxPollBookBackend]
 source = 'vx-pollbook-backend'
 
-[LogSources.VxPollbookBarcodeScannerDaemon]
+[LogSources.VxPollBookBarcodeScannerDaemon]
 source = 'vx-pollbook-barcode-scanner-daemon'
 
 [EventTypes.UserAction]

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -51,9 +51,9 @@ export enum LogSource {
   VxBallotActivationService = 'vx-ballot-activation-service',
   VxScanService = 'vx-scan-service',
   VxDevelopmentScript = 'vx-development-script',
-  VxPollbookFrontend = 'vx-pollbook-frontend',
-  VxPollbookBackend = 'vx-pollbook-backend',
-  VxPollbookBarcodeScannerDaemon = 'vx-pollbook-barcode-scanner-daemon',
+  VxPollBookFrontend = 'vx-pollbook-frontend',
+  VxPollBookBackend = 'vx-pollbook-backend',
+  VxPollBookBarcodeScannerDaemon = 'vx-pollbook-barcode-scanner-daemon',
 }
 export enum LogEventType {
   UserAction = 'user-action',

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -82,11 +82,11 @@ pub enum Source {
     #[serde(rename = "vx-development-script")]
     VxDevelopmentScript,
     #[serde(rename = "vx-pollbook-frontend")]
-    VxPollbookFrontend,
+    VxPollBookFrontend,
     #[serde(rename = "vx-pollbook-backend")]
-    VxPollbookBackend,
+    VxPollBookBackend,
     #[serde(rename = "vx-pollbook-barcode-scanner-daemon")]
-    VxPollbookBarcodeScannerDaemon,
+    VxPollBookBarcodeScannerDaemon,
 }
 derive_display!(Source);
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]


### PR DESCRIPTION
## Overview

Addresses some of the issues I noticed in QA that were easy enough to fix. By commit:

1 & 2 - copy changes, mostly capitalizing the 'B' in VxPollBook, separating pollbook into poll book, and a few other small tweaks.
3 - reorder tabs in SA and EM screens to be more in descending importance
4 - add NH to list of states for mailing address updates
5 - fix visual glitch in network menu
6 - fix visual glitch with titled cards
7 - fix niche problem of voter searches maintaining their sort even when the precinct is changed. super corner case, but easy enough to fix

edit: added a few more commits

8 - remove "Check-In" from the poll worker side panel since it's the only entry, and unnecessary
9 - remove OOS DL info from the search screen, as it is TMI. Closes #6774.
10 - tweak how OOS DL information is shown on the voter details page
