### PR TITLE
fix(scan): make `get_test_string` example work

### DIFF
--- a/libs/pdi-scanner/examples/get_test_string.rs
+++ b/libs/pdi-scanner/examples/get_test_string.rs
@@ -47,7 +47,8 @@ fn setup_logging(config: &Config) -> color_eyre::Result<()> {
     Ok(())
 }
 
-fn main() -> color_eyre::Result<()> {
+#[tokio::main]
+async fn main() -> color_eyre::Result<()> {
     let config = Config::parse();
     setup(&config).unwrap();
 


### PR DESCRIPTION
This broke when we introduced code that needed the tokio async runtime.
