### PR TITLE
VxDesign: Log outcome of API calls

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -2876,8 +2876,20 @@ test('feature configs', async () => {
   ).toEqual(electionFeatureConfigs.vx);
 });
 
-test('api method logging', async () => {
+test('api call logging', async () => {
   const { apiClient, logger, auth0 } = await setupApp();
+  await expect(apiClient.getUser()).rejects.toThrow('auth:unauthorized');
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.ApiCall,
+    'system',
+    expect.objectContaining({
+      methodName: 'getUser',
+      input: JSON.stringify(undefined),
+      disposition: 'failure',
+      error: 'auth:unauthorized',
+    })
+  );
+
   auth0.setLoggedInUser(vxUser);
   await apiClient.createElection({
     id: 'election-id' as ElectionId,
@@ -2894,6 +2906,7 @@ test('api method logging', async () => {
       }),
       userOrgId: vxUser.orgId,
       userAuth0Id: vxUser.auth0Id,
+      disposition: 'success',
     })
   );
 });

--- a/libs/grout/package.json
+++ b/libs/grout/package.json
@@ -40,7 +40,8 @@
     "is-ci-cli": "2.2.0",
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^2.1.8",
+    "wait-for-expect": "^3.0.2"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/grout/src/grout.test.ts
+++ b/libs/grout/src/grout.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* eslint-disable no-unused-expressions */
 /* eslint-disable @typescript-eslint/require-await */
 import { expect, test, vi } from 'vitest';
@@ -189,6 +190,19 @@ test('errors if RPC method doesnt have the correct signature', async () => {
   });
   const { baseUrl, server } = createTestApp(api);
   const client = createClient<typeof api>({ baseUrl });
+  vi.spyOn(process, 'exit').mockReturnValue(undefined as never);
+  vi.spyOn(console, 'error').mockReturnValue();
+  void client.sqrt(4);
+  await waitForExpect(() => {
+    expect(process.exit).toHaveBeenCalledTimes(1);
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith(
+      new Error(
+        'Grout error: Grout methods must be called with an object or undefined as the sole argument. The argument received was: 4'
+      )
+    );
+  });
 
   async () => {
     // We can catch the wrong number of arguments when calling a method at compile time
@@ -196,9 +210,6 @@ test('errors if RPC method doesnt have the correct signature', async () => {
     await client.sqrt(4, 5);
   };
 
-  await expect(client.sqrt(4)).rejects.toThrow(
-    'Grout methods must be called with an object or undefined as the sole argument. The argument received was: 4'
-  );
   server.close();
 });
 
@@ -218,9 +229,20 @@ test('errors if app has upstream body-parsing middleware', async () => {
   const baseUrl = `http://localhost:${port}/api`;
   const client = createClient<typeof api>({ baseUrl });
 
-  await expect(client.getStuff()).rejects.toThrow(
-    'Request body was parsed as something other than a string. Make sure you haven\'t added any other body parsers upstream of the Grout router - e.g. app.use(express.json()). Body: {"__grout_type":"undefined","__grout_value":"undefined"}'
-  );
+  vi.spyOn(process, 'exit').mockReturnValue(undefined as never);
+  vi.spyOn(console, 'error').mockReturnValue();
+  void client.getStuff();
+  await waitForExpect(() => {
+    expect(process.exit).toHaveBeenCalledTimes(1);
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith(
+      new Error(
+        'Grout error: Request body was parsed as something other than a string. Make sure you haven\'t added any other body parsers upstream of the Grout router - e.g. app.use(express.json()). Body: {"__grout_type":"undefined","__grout_value":"undefined"}'
+      )
+    );
+  });
+
   server.close();
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4376,6 +4376,9 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.8(jsdom@20.0.1)
+      wait-for-expect:
+        specifier: ^3.0.2
+        version: 3.0.2
 
   libs/grout/test-utils:
     dependencies:
@@ -14013,7 +14016,7 @@ packages:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+      vitest: 2.1.8(jsdom@20.0.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -24369,7 +24372,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
 
   /vitest@3.1.1(@types/debug@4.1.8):
     resolution: {integrity: sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==}


### PR DESCRIPTION
## Overview

<!-- add a link to a GitHub Issue here -->

Instead of logging the API call when it's received (before the method handler is called), we log the API call after its handled and include the outcome (success or failure) as well as any error that occurred.

## Demo Video or Screenshot
Example log line for `getUser` request when user is not logged in
```
[backend:run] 2025-07-14T22:23:22.791Z design-backend:app {
[backend:run]   source: 'vx-design-service',
[backend:run]   eventId: 'api-call',
[backend:run]   eventType: 'application-action',
[backend:run]   user: 'system',
[backend:run]   message: undefined,
[backend:run]   disposition: 'failure',
[backend:run]   methodName: 'getUser',
[backend:run]   input: undefined,
[backend:run]   userAuth0Id: undefined,
[backend:run]   userOrgId: undefined,
[backend:run]   error: 'auth:unauthorized'
[backend:run] }
```

## Testing Plan
- Added new automated tests
- Manual test as shown above

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
