### PR TITLE
feat(ballot-interpreter): add API to find timing mark grid

### DIFF
--- a/apps/scan/backend/test/helpers/electrical_test.ts
+++ b/apps/scan/backend/test/helpers/electrical_test.ts
@@ -34,24 +34,24 @@ export const electricalTest = test.extend<{
   electricalAppContext: async (
     {
       mainAppContext: appContext,
-      cardTask: cardLoop,
+      cardTask,
       mockSimpleScannerClient,
-      printerTask: printerLoop,
-      scannerTask: scannerLoop,
-      usbDriveTask: usbDriveLoop,
+      printerTask,
+      scannerTask,
+      usbDriveTask,
     },
     use
   ) => {
     const testingContext: ServerContext = {
       auth: appContext.mockAuth,
-      cardTask: cardLoop,
+      cardTask,
       logger: appContext.logger,
       printer: wrapLegacyPrinter(appContext.mockPrinterHandler.printer),
-      printerTask: printerLoop,
+      printerTask,
       usbDrive: appContext.mockUsbDrive.usbDrive,
       scannerClient: mockSimpleScannerClient,
-      scannerTask: scannerLoop,
-      usbDriveTask: usbDriveLoop,
+      scannerTask,
+      usbDriveTask,
       workspace: appContext.workspace,
     };
 
@@ -64,22 +64,22 @@ export const electricalTest = test.extend<{
   },
 
   cardTask: async ({}, use) => {
-    const cardLoop = TaskController.started<string>();
-    await use(cardLoop);
+    const cardTask = TaskController.started<string>();
+    await use(cardTask);
   },
 
   printerTask: async ({}, use) => {
-    const printerLoop = TaskController.started<string>();
-    await use(printerLoop);
+    const printerTask = TaskController.started<string>();
+    await use(printerTask);
   },
 
   scannerTask: async ({}, use) => {
-    const scannerLoop = TaskController.started<string>();
-    await use(scannerLoop);
+    const scannerTask = TaskController.started<string>();
+    await use(scannerTask);
   },
 
   usbDriveTask: async ({}, use) => {
-    const usbDriveLoop = TaskController.started<string>();
-    await use(usbDriveLoop);
+    const usbDriveTask = TaskController.started<string>();
+    await use(usbDriveTask);
   },
 });

--- a/libs/ballot-interpreter/src/find_timing_mark_grid.test.ts
+++ b/libs/ballot-interpreter/src/find_timing_mark_grid.test.ts
@@ -1,0 +1,35 @@
+import { timingMarkPaperFixtures } from '@votingworks/hmpb';
+import { HmpbBallotPaperSize } from '@votingworks/types';
+import { readFile } from 'node:fs/promises';
+import { expect, test } from 'vitest';
+import { join } from 'node:path';
+import { loadImageData } from '@votingworks/image-utils';
+import { pdfToPageImages } from '../test/helpers/interpretation';
+import { findTimingMarkGrid } from './hmpb-ts/addon';
+
+test('letter-sized tiing mark paper', async () => {
+  const { pdf } = timingMarkPaperFixtures.specPaths({
+    paperSize: HmpbBallotPaperSize.Letter,
+  });
+  const pdfBytes = Uint8Array.from(await readFile(pdf));
+  const pdfPage = await pdfToPageImages(pdfBytes).first();
+  const { topLeftMark, topRightMark, bottomLeftMark, bottomRightMark } =
+    findTimingMarkGrid(pdfPage!);
+
+  // The fixture has perfect alignment, so that should be reflected in the marks we find.
+  expect(topLeftMark.rect.top).toEqual(topRightMark.rect.top);
+  expect(bottomLeftMark.rect.top).toEqual(bottomRightMark.rect.top);
+  expect(topLeftMark.rect.left).toEqual(bottomLeftMark.rect.left);
+  expect(topRightMark.rect.left).toEqual(bottomRightMark.rect.left);
+});
+
+test('scanned image', async () => {
+  const { topLeftMark, topRightMark } = findTimingMarkGrid(
+    await loadImageData(
+      join(__dirname, '../test/fixtures/vxqa-2024-10/skew-front.png')
+    )
+  );
+
+  // We know the top-right mark is higher than the top-left mark in this fixture.
+  expect(topRightMark.rect.top).toBeLessThan(topLeftMark.rect.top);
+});

--- a/libs/ballot-interpreter/src/find_timing_mark_grid.test.ts
+++ b/libs/ballot-interpreter/src/find_timing_mark_grid.test.ts
@@ -7,7 +7,7 @@ import { loadImageData } from '@votingworks/image-utils';
 import { pdfToPageImages } from '../test/helpers/interpretation';
 import { findTimingMarkGrid } from './hmpb-ts/addon';
 
-test('letter-sized tiing mark paper', async () => {
+test('letter-sized timing mark paper', async () => {
   const { pdf } = timingMarkPaperFixtures.specPaths({
     paperSize: HmpbBallotPaperSize.Letter,
   });

--- a/libs/ballot-interpreter/src/hmpb-rust/lib.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/lib.rs
@@ -21,7 +21,7 @@ pub mod timing_marks;
 #[neon::main]
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("interpret", js::interpret)?;
-
+    cx.export_function("findTimingMarkGrid", js::find_timing_mark_grid)?;
     cx.export_function("runBlankPaperDiagnostic", js::run_blank_paper_diagnostic)?;
 
     Ok(())

--- a/libs/ballot-interpreter/src/hmpb-rust/timing_marks/scoring.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_marks/scoring.rs
@@ -95,6 +95,7 @@ fn score_timing_mark_geometry_match(
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq)]
 #[must_use]
+#[serde(rename_all = "camelCase")]
 pub struct TimingMarkScore {
     mark_score: UnitIntervalScore,
     padding_score: UnitIntervalScore,

--- a/libs/ballot-interpreter/src/hmpb-ts/addon.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/addon.ts
@@ -2,6 +2,7 @@ import { Election } from '@votingworks/types';
 import { ImageData } from 'canvas';
 import { createRequire } from 'node:module';
 import { join } from 'node:path';
+import { TimingMarks } from './types';
 
 const addon = (() => {
   // NOTE: this only works because the build output can get to the root of the
@@ -65,4 +66,14 @@ export function runBlankPaperDiagnostic(
   debugBasePath?: string
 ): boolean {
   return addon.runBlankPaperDiagnostic(image, debugBasePath);
+}
+
+export function findTimingMarkGrid(
+  image: string | ImageData,
+  debugBasePath?: string,
+  options?: {
+    timingMarkAlgorithm?: 'contours' | 'corners';
+  }
+): TimingMarks {
+  return addon.findTimingMarkGrid(image, debugBasePath, options);
 }

--- a/libs/ballot-interpreter/src/hmpb-ts/types.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/types.ts
@@ -157,14 +157,26 @@ export interface TimingMarks {
   topRightCorner: Point<SubPixelUnit>;
   bottomLeftCorner: Point<SubPixelUnit>;
   bottomRightCorner: Point<SubPixelUnit>;
-  topRects: Rect[];
-  bottomRects: Rect[];
-  leftRects: Rect[];
-  rightRects: Rect[];
-  topLeftRect: Rect;
-  topRightRect: Rect;
-  bottomLeftRect: Rect;
-  bottomRightRect: Rect;
+  topMarks: CandidateTimingMark[];
+  bottomMarks: CandidateTimingMark[];
+  leftMarks: CandidateTimingMark[];
+  rightMarks: CandidateTimingMark[];
+  topLeftMark: CandidateTimingMark;
+  topRightMark: CandidateTimingMark;
+  bottomLeftMark: CandidateTimingMark;
+  bottomRightMark: CandidateTimingMark;
+}
+
+/** A possible timing mark. */
+export interface CandidateTimingMark {
+  rect: Rect;
+  scores: TimingMarkScore;
+}
+
+/** Scores for how closely a timing mark matches the expected shape. */
+export interface TimingMarkScore {
+  markScore: f32;
+  paddingScore: f32;
 }
 
 /** Location and score information for a ballot contest option's bubble. */

--- a/libs/hmpb/src/ballot_fixtures.ts
+++ b/libs/hmpb/src/ballot_fixtures.ts
@@ -549,7 +549,8 @@ export const timingMarkPaperFixtures = (() => {
     dir: string;
     pdf: string;
   } {
-    const dir = spec.paperSize;
+    const { paperSize } = spec;
+    const dir = join(fixturesDir, 'timing-mark-paper', paperSize);
     return {
       dir,
       pdf: join(dir, 'timing-mark-paper.pdf'),

--- a/libs/hmpb/src/generate_fixtures.test.ts
+++ b/libs/hmpb/src/generate_fixtures.test.ts
@@ -1,18 +1,16 @@
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
-import * as fs from 'node:fs';
-import { join } from 'node:path';
-import { HmpbBallotPaperSize } from '@votingworks/types';
-import { pdfToImages } from '@votingworks/image-utils';
 import { iter } from '@votingworks/basics';
 import { readElection } from '@votingworks/fs';
+import { pdfToImages } from '@votingworks/image-utils';
+import { HmpbBallotPaperSize } from '@votingworks/types';
+import * as fs from 'node:fs';
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { allBubbleBallotFixtures } from './all_bubble_ballot_fixtures';
 import {
+  nhGeneralElectionFixtures,
+  timingMarkPaperFixtures,
   vxFamousNamesFixtures,
   vxGeneralElectionFixtures,
-  nhGeneralElectionFixtures,
   vxPrimaryElectionFixtures,
-  timingMarkPaperFixtures,
-  fixturesDir,
 } from './ballot_fixtures';
 import { createPlaywrightRenderer } from './playwright_renderer';
 import { Renderer } from './renderer';
@@ -199,12 +197,7 @@ describe('fixtures are up to date - run `pnpm generate-fixtures` if this test fa
     for (const spec of fixtures.fixtureSpecs) {
       const generated = await fixtures.generate(renderer, spec);
       const paths = fixtures.specPaths(spec);
-      const actualPdfPath = join(
-        fixturesDir,
-        'timing-mark-paper',
-        paths.pdf
-      );
-      await expectToMatchSavedPdf(generated.pdf, actualPdfPath);
+      await expectToMatchSavedPdf(generated.pdf, paths.pdf);
     }
   });
 });

--- a/libs/hmpb/src/generate_fixtures.ts
+++ b/libs/hmpb/src/generate_fixtures.ts
@@ -6,14 +6,12 @@ import {
   HmpbBallotPaperSizeSchema,
   unsafeParse,
 } from '@votingworks/types';
-import assert from 'node:assert';
-import { dirname, join, normalize, relative } from 'node:path';
+import { dirname } from 'node:path';
 import {
   AllBubbleBallotFixtures,
   allBubbleBallotFixtures,
 } from './all_bubble_ballot_fixtures';
 import {
-  fixturesDir,
   timingMarkPaperFixtures,
   vxFamousNamesFixtures,
   vxGeneralElectionFixtures,
@@ -129,22 +127,17 @@ async function generateNhGeneralElectionFixtures(renderer: Renderer) {
 
 async function generateTimingMarkPaperFixtures(
   renderer: Renderer,
-  paperSize: HmpbBallotPaperSize,
-  fixtureDir: string
+  paperSize: HmpbBallotPaperSize
 ) {
-  const outputDir = normalize(fixtureDir);
   const specPaths = timingMarkPaperFixtures.specPaths({ paperSize });
-  const specDir = join(outputDir, specPaths.dir);
-  assert(relative(outputDir, specDir).startsWith(specPaths.dir));
-  await rm(specDir, {
+  await rm(specPaths.dir, {
     recursive: true,
     force: true,
   });
   const generated = await timingMarkPaperFixtures.generate(renderer, {
     paperSize,
   });
-  const pdfPath = join(outputDir, specPaths.pdf);
-  assert(pdfPath.startsWith(`${outputDir}/`));
+  const pdfPath = specPaths.pdf;
   await mkdir(dirname(pdfPath), { recursive: true });
   await writeFile(pdfPath, generated.pdf);
 }
@@ -280,11 +273,7 @@ export async function main(): Promise<void> {
         break;
 
       case 'timing-mark-paper': {
-        await generateTimingMarkPaperFixtures(
-          renderer,
-          paperSize,
-          join(fixturesDir, fixtureName)
-        );
+        await generateTimingMarkPaperFixtures(renderer, paperSize);
         break;
       }
 


### PR DESCRIPTION
## Overview
Adds `findTimingMarkGrid` to `@votingworks/ballot-interpreter` for use in the HWTA. We'll replace analysis of blank paper with some analysis of the detected timing mark grid.

## Demo Video or Screenshot
n/a

## Testing Plan
New automated testing.