### PR TITLE
[libs/printing] Fix printing with Uint8Array data

### DIFF
--- a/libs/printing/src/printer/print.test.ts
+++ b/libs/printing/src/printer/print.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, expect, test, vi } from 'vitest';
 import { ok } from '@votingworks/basics';
-import { Buffer } from 'node:buffer';
 import { exec } from '../utils/exec';
 import { DEFAULT_MANAGED_PRINTER_NAME } from './configure';
 import { print } from './print';
@@ -18,43 +17,49 @@ beforeEach(() => {
 test('prints with defaults', async () => {
   vi.mocked(exec).mockResolvedValueOnce(ok({ stdout: '', stderr: '' }));
 
-  await print({ data: Buffer.of() });
+  await print({ data: Uint8Array.of(0xca, 0xfe) });
 
   expect(exec).toHaveBeenCalledWith(
     'lpr',
     ['-P', DEFAULT_MANAGED_PRINTER_NAME, '-o', 'sides=one-sided'],
-    expect.anything()
+    Uint8Array.of(0xca, 0xfe)
   );
 });
 
 test('allows specifying other sided-ness', async () => {
   vi.mocked(exec).mockResolvedValueOnce(ok({ stdout: '', stderr: '' }));
 
-  await print({ data: Buffer.of(), sides: PrintSides.TwoSidedLongEdge });
+  await print({
+    data: Uint8Array.of(0xf0, 0x0d),
+    sides: PrintSides.TwoSidedLongEdge,
+  });
 
   expect(exec).toHaveBeenCalledWith(
     'lpr',
     ['-P', DEFAULT_MANAGED_PRINTER_NAME, '-o', 'sides=two-sided-long-edge'],
-    expect.anything()
+    Uint8Array.of(0xf0, 0x0d)
   );
 });
 
 test('prints a specified number of copies', async () => {
   vi.mocked(exec).mockResolvedValueOnce(ok({ stdout: '', stderr: '' }));
 
-  await print({ data: Buffer.of(), copies: 3 });
+  await print({ data: Uint8Array.of(0xca, 0xfe), copies: 3 });
 
   expect(exec).toHaveBeenCalledWith(
     'lpr',
     ['-P', DEFAULT_MANAGED_PRINTER_NAME, '-o', 'sides=one-sided', '-#', '3'],
-    expect.anything()
+    Uint8Array.of(0xca, 0xfe)
   );
 });
 
 test('passes through raw options', async () => {
   vi.mocked(exec).mockResolvedValueOnce(ok({ stdout: '', stderr: '' }));
 
-  await print({ data: Buffer.of(), raw: { 'fit-to-page': 'true' } });
+  await print({
+    data: Uint8Array.of(0xf0, 0x0d),
+    raw: { 'fit-to-page': 'true' },
+  });
 
   expect(exec).toHaveBeenCalledWith(
     'lpr',
@@ -66,7 +71,7 @@ test('passes through raw options', async () => {
       '-o',
       'fit-to-page=true',
     ],
-    expect.anything()
+    Uint8Array.of(0xf0, 0x0d)
   );
 });
 
@@ -74,7 +79,7 @@ test('rejects invalid raw options', async () => {
   vi.mocked(exec).mockResolvedValueOnce(ok({ stdout: '', stderr: '' }));
 
   await expect(
-    print({ data: Buffer.of(), raw: { 'fit to page': 'true' } })
+    print({ data: Uint8Array.of(), raw: { 'fit to page': 'true' } })
   ).rejects.toThrowError();
 
   expect(exec).not.toHaveBeenCalled();

--- a/libs/printing/src/utils/exec.test.ts
+++ b/libs/printing/src/utils/exec.test.ts
@@ -43,8 +43,14 @@ test.each([
     stdin: 'foobarbaz to print',
   },
   {
+    // Not explicitly supported, but type system won't stop anyone from passing
+    // one in, since `Buffer` is a subclass of `Uint8Array`:
     name: 'command with buffer stdin',
     stdin: Buffer.from('foobarbaz to print'),
+  },
+  {
+    name: 'command with Uint8Array stdin',
+    stdin: new TextEncoder().encode('foobarbaz to print'),
   },
   {
     name: 'command with stream stdin',
@@ -66,6 +72,16 @@ test.each([
       await sleep(1);
       yield 'baz';
       yield ' to print';
+    })(),
+  },
+  {
+    name: 'command with Uint8Array async iterable stdin',
+    stdin: (async function* gen() {
+      yield new TextEncoder().encode('foo');
+      yield new TextEncoder().encode('bar');
+      await sleep(1);
+      yield new TextEncoder().encode('baz');
+      yield new TextEncoder().encode(' to print');
     })(),
   },
   {

--- a/libs/printing/src/utils/exec.ts
+++ b/libs/printing/src/utils/exec.ts
@@ -87,7 +87,15 @@ export async function exec(
 
   if (stdin) {
     debug('stdin passed to exec, feeding it in now.');
-    Readable.from(stdin).pipe(child.stdin);
+
+    if (stdin instanceof Uint8Array) {
+      // `Readable.from` will chunk each byte in a `Uint8Array` individually, so
+      // a conversion to `Uint8Array[]` is necessary here. This mimics Node's
+      // special handling for `Readable.from(Buffer)`.
+      Readable.from([stdin]).pipe(child.stdin);
+    } else {
+      Readable.from(stdin).pipe(child.stdin);
+    }
   }
 
   return new Promise((resolve) => {


### PR DESCRIPTION
## Overview

Fixing an issue in the print path where `Uint8Array` data is streamed as single-byte chunks when we shell out to `lpr`. This is due to a recent change to generate PDFs as `Uint8Array` data instead of `Buffer` - the latter is [handled differently by Node](https://nodejs.org/docs/latest-v20.x/api/stream.html#streamreadablefromiterable-options) and streamed as a single chunk when using `Readable.from()`. Converting `Uint8Array`s to `Uint8Array[]` before streaming to stdin to mimic that behaviour.

## Testing Plan
- Updated relevant tests to use `Uint8Array` instead of `Buffer`

