### PR TITLE
VxDesign: Fix incorrect breadcrumbs links for precinct forms

### DIFF
--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -208,6 +208,10 @@ describe('Contests tab', () => {
     // Add contest
     userEvent.click(screen.getByRole('button', { name: 'Add Contest' }));
     await screen.findByRole('heading', { name: 'Add Contest' });
+    expect(screen.getByRole('link', { name: 'Contests' })).toHaveAttribute(
+      'href',
+      `/elections/${electionId}/contests/contests`
+    );
 
     // Set title
     userEvent.type(screen.getByLabelText('Title'), newContest.title);
@@ -476,6 +480,10 @@ describe('Contests tab', () => {
     );
 
     await screen.findByRole('heading', { name: 'Edit Contest' });
+    expect(screen.getByRole('link', { name: 'Contests' })).toHaveAttribute(
+      'href',
+      `/elections/${electionId}/contests/contests`
+    );
 
     // Change title
     const titleInput = screen.getByLabelText('Title');
@@ -1160,6 +1168,10 @@ describe('Parties tab', () => {
 
     userEvent.click(screen.getByRole('button', { name: 'Add Party' }));
     await screen.findByRole('heading', { name: 'Add Party' });
+    expect(screen.getByRole('link', { name: 'Parties' })).toHaveAttribute(
+      'href',
+      `/elections/${electionId}/contests/parties`
+    );
 
     userEvent.type(screen.getByLabelText('Full Name'), newParty.fullName);
     userEvent.type(screen.getByLabelText('Short Name'), newParty.name);
@@ -1206,6 +1218,10 @@ describe('Parties tab', () => {
       within(savedPartyRow).getByRole('button', { name: 'Edit' })
     );
     await screen.findByRole('heading', { name: 'Edit Party' });
+    expect(screen.getByRole('link', { name: 'Parties' })).toHaveAttribute(
+      'href',
+      `/elections/${electionId}/contests/parties`
+    );
 
     const fullNameInput = screen.getByLabelText('Full Name');
     expect(fullNameInput).toHaveValue(savedParty.fullName);

--- a/apps/design/frontend/src/geography_screen.test.tsx
+++ b/apps/design/frontend/src/geography_screen.test.tsx
@@ -82,6 +82,10 @@ describe('Districts tab', () => {
 
     userEvent.click(screen.getByRole('button', { name: 'Add District' }));
     await screen.findByRole('heading', { name: 'Add District' });
+    expect(screen.getByRole('link', { name: 'Districts' })).toHaveAttribute(
+      'href',
+      `/elections/${electionId}/geography/districts`
+    );
 
     userEvent.type(screen.getByLabelText('Name'), newDistrict.name);
 
@@ -133,6 +137,10 @@ describe('Districts tab', () => {
     );
 
     await screen.findByRole('heading', { name: 'Edit District' });
+    expect(screen.getByRole('link', { name: 'Districts' })).toHaveAttribute(
+      'href',
+      `/elections/${electionId}/geography/districts`
+    );
 
     const nameInput = screen.getByLabelText('Name');
     expect(nameInput).toHaveValue(savedDistrict.name);
@@ -276,6 +284,10 @@ describe('Precincts tab', () => {
 
     userEvent.click(screen.getByRole('button', { name: 'Add Precinct' }));
     await screen.findByRole('heading', { name: 'Add Precinct' });
+    expect(screen.getByRole('link', { name: 'Precincts' })).toHaveAttribute(
+      'href',
+      `/elections/${electionId}/geography/precincts`
+    );
 
     userEvent.type(screen.getByLabelText('Name'), newPrecinct.name);
 
@@ -400,6 +412,10 @@ describe('Precincts tab', () => {
       within(savedPrecinctRow).getByRole('button', { name: 'Edit' })
     );
     await screen.findByRole('heading', { name: 'Edit Precinct' });
+    expect(screen.getByRole('link', { name: 'Precincts' })).toHaveAttribute(
+      'href',
+      `/elections/${electionId}/geography/precincts`
+    );
 
     const nameInput = screen.getByLabelText('Name');
     expect(nameInput).toHaveValue(savedPrecinct.name);

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -850,7 +850,7 @@ function AddPrecinctForm(): JSX.Element | null {
       <Header>
         <Breadcrumbs
           currentTitle={title}
-          parentRoutes={[geographyRoutes.districts.root]}
+          parentRoutes={[geographyRoutes.precincts.root]}
         />
         <H1>{title}</H1>
       </Header>
@@ -889,7 +889,7 @@ function EditPrecinctForm(): JSX.Element | null {
       <Header>
         <Breadcrumbs
           currentTitle={title}
-          parentRoutes={[geographyRoutes.districts.root]}
+          parentRoutes={[geographyRoutes.precincts.root]}
         />
         <H1>{title}</H1>
       </Header>


### PR DESCRIPTION
## Overview

They were accidentally pointed to the districts tab rather than the
precincts tab.

## Demo Video or Screenshot
<img width="242" height="104" alt="Screenshot 2025-07-17 at 12 02 38 PM" src="https://github.com/user-attachments/assets/dc122c6b-e7fc-4130-885b-64b3de4da402" />



## Testing Plan
- Manual test
- Added test coverage

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
