### PR TITLE
VxDesign: Require districts/precincts/splits to have unique names

### DIFF
--- a/apps/design/backend/migrations/1752705340558_geography-unique-indexes.js
+++ b/apps/design/backend/migrations/1752705340558_geography-unique-indexes.js
@@ -1,0 +1,17 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  pgm.createIndex('districts', ['election_id', 'name'], { unique: true });
+  pgm.createIndex('precincts', ['election_id', 'name'], { unique: true });
+  pgm.createIndex('precinct_splits', ['precinct_id', 'name'], {
+    unique: true,
+  });
+};

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -823,6 +823,18 @@ test('CRUD precincts', async () => {
   });
   expect(await apiClient.listPrecincts({ electionId })).toEqual([precinct1]);
 
+  // Can't create a precinct with an existing name
+  expect(
+    await apiClient.createPrecinct({
+      electionId,
+      newPrecinct: {
+        id: 'precinct-2',
+        name: 'Precinct 1',
+        districtIds: [],
+      },
+    })
+  ).toEqual(err('duplicate-precinct-name'));
+
   // Add a district to the precinct
   const district1: District = {
     id: unsafeParse(DistrictIdSchema, 'district-1'),
@@ -870,6 +882,17 @@ test('CRUD precincts', async () => {
     precinct2,
   ]);
 
+  // Can't update a precinct name to an existing name
+  expect(
+    await apiClient.updatePrecinct({
+      electionId,
+      updatedPrecinct: {
+        ...updatedPrecinct1,
+        name: 'Precinct 2',
+      },
+    })
+  ).toEqual(err('duplicate-precinct-name'));
+
   // Update splits
   const district2: District = {
     id: unsafeParse(DistrictIdSchema, 'district-2'),
@@ -897,6 +920,46 @@ test('CRUD precincts', async () => {
     updatedPrecinct1,
     updatedPrecinct2,
   ]);
+
+  // Can't update a split name to an existing name within the precinct
+  expect(
+    await apiClient.updatePrecinct({
+      electionId,
+      updatedPrecinct: {
+        ...updatedPrecinct2,
+        splits: [
+          updatedPrecinct2.splits[0],
+          {
+            ...updatedPrecinct2.splits[1],
+            name: 'Split 1',
+          },
+        ],
+      },
+    })
+  ).toEqual(err('duplicate-split-name'));
+
+  // Can't create a precinct with splits with the same name
+  expect(
+    await apiClient.createPrecinct({
+      electionId,
+      newPrecinct: {
+        id: 'precinct-3',
+        name: 'Precinct 3',
+        splits: [
+          {
+            id: 'precinct-3-split-1',
+            name: 'Split 1',
+            districtIds: [district1.id],
+          },
+          {
+            id: 'precinct-3-split-2',
+            name: 'Split 1',
+            districtIds: [district2.id],
+          },
+        ],
+      },
+    })
+  ).toEqual(err('duplicate-split-name'));
 
   // Delete a precinct
   await apiClient.deletePrecinct({

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -634,6 +634,17 @@ test('CRUD districts', async () => {
   });
   expect(await apiClient.listDistricts({ electionId })).toEqual([district1]);
 
+  // Can't create a district with an existing name
+  expect(
+    await apiClient.createDistrict({
+      electionId,
+      newDistrict: {
+        id: unsafeParse(DistrictIdSchema, 'district-3'),
+        name: 'District 1',
+      },
+    })
+  ).toEqual(err('duplicate-name'));
+
   // Create another district
   const district2: District = {
     id: unsafeParse(DistrictIdSchema, 'district-2'),
@@ -662,6 +673,17 @@ test('CRUD districts', async () => {
     district2,
     updatedDistrict1,
   ]);
+
+  // Can't update a district to an existing name
+  expect(
+    await apiClient.updateDistrict({
+      electionId,
+      updatedDistrict: {
+        ...district2,
+        name: 'Updated District 1',
+      },
+    })
+  ).toEqual(err('duplicate-name'));
 
   // Delete a district
   await apiClient.deleteDistrict({

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -392,17 +392,17 @@ export function buildApi({ auth0, logger, workspace, translator }: AppContext) {
     async createDistrict(input: {
       electionId: ElectionId;
       newDistrict: District;
-    }): Promise<void> {
+    }): Promise<Result<void, 'duplicate-name'>> {
       const district = unsafeParse(DistrictSchema, input.newDistrict);
-      await store.createDistrict(input.electionId, district);
+      return store.createDistrict(input.electionId, district);
     },
 
     async updateDistrict(input: {
       electionId: ElectionId;
       updatedDistrict: District;
-    }): Promise<void> {
+    }): Promise<Result<void, 'duplicate-name'>> {
       const district = unsafeParse(DistrictSchema, input.updatedDistrict);
-      await store.updateDistrict(input.electionId, district);
+      return store.updateDistrict(input.electionId, district);
     },
 
     async deleteDistrict(input: {

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -421,17 +421,21 @@ export function buildApi({ auth0, logger, workspace, translator }: AppContext) {
     async createPrecinct(input: {
       electionId: ElectionId;
       newPrecinct: Precinct;
-    }): Promise<void> {
+    }): Promise<
+      Result<void, 'duplicate-precinct-name' | 'duplicate-split-name'>
+    > {
       const precinct = unsafeParse(PrecinctSchema, input.newPrecinct);
-      await store.createPrecinct(input.electionId, precinct);
+      return store.createPrecinct(input.electionId, precinct);
     },
 
     async updatePrecinct(input: {
       electionId: ElectionId;
       updatedPrecinct: Precinct;
-    }): Promise<void> {
+    }): Promise<
+      Result<void, 'duplicate-precinct-name' | 'duplicate-split-name'>
+    > {
       const precinct = unsafeParse(PrecinctSchema, input.updatedPrecinct);
-      await store.updatePrecinct(input.electionId, precinct);
+      return store.updatePrecinct(input.electionId, precinct);
     },
 
     async deletePrecinct(input: {

--- a/apps/design/backend/vitest.config.ts
+++ b/apps/design/backend/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: -71,
-        branches: -52,
+        branches: -53,
       },
       exclude: ['src/configure_sentry.ts', '**/*.test.ts'],
     },

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -311,9 +311,11 @@ export const createDistrict = {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
     return useMutation(apiClient.createDistrict, {
-      async onSuccess(_, { electionId }) {
-        await invalidateElectionQueries(queryClient, electionId);
-        await queryClient.refetchQueries(listDistricts.queryKey(electionId));
+      async onSuccess(result, { electionId }) {
+        if (result.isOk()) {
+          await invalidateElectionQueries(queryClient, electionId);
+          await queryClient.refetchQueries(listDistricts.queryKey(electionId));
+        }
       },
     });
   },
@@ -324,8 +326,10 @@ export const updateDistrict = {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
     return useMutation(apiClient.updateDistrict, {
-      async onSuccess(_, { electionId }) {
-        await invalidateElectionQueries(queryClient, electionId);
+      async onSuccess(result, { electionId }) {
+        if (result.isOk()) {
+          await invalidateElectionQueries(queryClient, electionId);
+        }
       },
     });
   },
@@ -348,9 +352,11 @@ export const createPrecinct = {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
     return useMutation(apiClient.createPrecinct, {
-      async onSuccess(_, { electionId }) {
-        await invalidateElectionQueries(queryClient, electionId);
-        await queryClient.refetchQueries(listPrecincts.queryKey(electionId));
+      async onSuccess(result, { electionId }) {
+        if (result.isOk()) {
+          await invalidateElectionQueries(queryClient, electionId);
+          await queryClient.refetchQueries(listPrecincts.queryKey(electionId));
+        }
       },
     });
   },
@@ -361,8 +367,10 @@ export const updatePrecinct = {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
     return useMutation(apiClient.updatePrecinct, {
-      async onSuccess(_, { electionId }) {
-        await invalidateElectionQueries(queryClient, electionId);
+      async onSuccess(result, { electionId }) {
+        if (result.isOk()) {
+          await invalidateElectionQueries(queryClient, electionId);
+        }
       },
     });
   },

--- a/apps/design/frontend/vitest.config.ts
+++ b/apps/design/frontend/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: 94,
-        branches: 82,
+        branches: 83,
       },
       exclude: [
         'src/**/*.d.ts',


### PR DESCRIPTION
## Overview

Task: #6263 

Enforces the following uniqueness constraints using db indexes:
- Districts: unique name within an election
- Precincts: unique name within an election
- Precinct splits: unique name within a precinct

## Demo Video or Screenshot


https://github.com/user-attachments/assets/c0cef7ec-c11b-4956-aada-83f49fbc069e



## Testing Plan
- Manual testing
- Automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
