### PR TITLE
VxDesign: Require unique party names/abbreviations within elections

### DIFF
--- a/apps/design/backend/migrations/1752784464060_party-unique-index.js
+++ b/apps/design/backend/migrations/1752784464060_party-unique-index.js
@@ -1,0 +1,15 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  pgm.createIndex('parties', ['election_id', 'name'], { unique: true });
+  pgm.createIndex('parties', ['election_id', 'full_name'], { unique: true });
+  pgm.createIndex('parties', ['election_id', 'abbrev'], { unique: true });
+};

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -1077,13 +1077,47 @@ test('CRUD parties', async () => {
   await apiClient.createParty({ electionId, newParty: party1 });
   expect(await apiClient.listParties({ electionId })).toEqual([party1]);
 
-  // Create another party
   const party2: Party = {
     id: unsafeParse(PartyIdSchema, 'party-2'),
     name: 'Party 2',
     abbrev: 'P2',
     fullName: 'Party 2 Full Name',
   };
+
+  // Can't create a party with an existing name
+  expect(
+    await apiClient.createParty({
+      electionId,
+      newParty: {
+        ...party2,
+        name: party1.name,
+      },
+    })
+  ).toEqual(err('duplicate-name'));
+
+  // Can't create a party with an existing full name
+  expect(
+    await apiClient.createParty({
+      electionId,
+      newParty: {
+        ...party2,
+        fullName: party1.fullName,
+      },
+    })
+  ).toEqual(err('duplicate-full-name'));
+
+  // Can't create a party with an existing abbrev
+  expect(
+    await apiClient.createParty({
+      electionId,
+      newParty: {
+        ...party2,
+        abbrev: party1.abbrev,
+      },
+    })
+  ).toEqual(err('duplicate-abbrev'));
+
+  // Create another party
   await apiClient.createParty({ electionId, newParty: party2 });
   expect(await apiClient.listParties({ electionId })).toEqual([party1, party2]);
 
@@ -1099,6 +1133,39 @@ test('CRUD parties', async () => {
     party2,
     updatedParty1,
   ]);
+
+  // Can't update a party to an existing name
+  expect(
+    await apiClient.updateParty({
+      electionId,
+      updatedParty: {
+        ...party2,
+        name: updatedParty1.name,
+      },
+    })
+  ).toEqual(err('duplicate-name'));
+
+  // Can't update a party to an existing full name
+  expect(
+    await apiClient.updateParty({
+      electionId,
+      updatedParty: {
+        ...party2,
+        fullName: updatedParty1.fullName,
+      },
+    })
+  ).toEqual(err('duplicate-full-name'));
+
+  // Can't update a party to an existing abbrev
+  expect(
+    await apiClient.updateParty({
+      electionId,
+      updatedParty: {
+        ...party2,
+        abbrev: updatedParty1.abbrev,
+      },
+    })
+  ).toEqual(err('duplicate-abbrev'));
 
   // Delete a party
   await apiClient.deleteParty({ electionId, partyId: party2.id });

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -393,9 +393,11 @@ export const createParty = {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
     return useMutation(apiClient.createParty, {
-      async onSuccess(_, { electionId }) {
-        await invalidateElectionQueries(queryClient, electionId);
-        await queryClient.refetchQueries(listParties.queryKey(electionId));
+      async onSuccess(result, { electionId }) {
+        if (result.isOk()) {
+          await invalidateElectionQueries(queryClient, electionId);
+          await queryClient.refetchQueries(listParties.queryKey(electionId));
+        }
       },
     });
   },
@@ -406,8 +408,10 @@ export const updateParty = {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
     return useMutation(apiClient.updateParty, {
-      async onSuccess(_, { electionId }) {
-        await invalidateElectionQueries(queryClient, electionId);
+      async onSuccess(result, { electionId }) {
+        if (result.isOk()) {
+          await invalidateElectionQueries(queryClient, electionId);
+        }
       },
     });
   },


### PR DESCRIPTION
## Overview

Task: #6263 

Within an election, require that each party has a unique full name, short name, and abbreviation, since all three function as unique labels for a party.

## Demo Video or Screenshot


https://github.com/user-attachments/assets/b506c18b-f141-44d7-815e-2b9377bda994



## Testing Plan
- Manual test
- Automated tests

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
