### PR TITLE
restore error modal when an invalid barcode is scanned

### DIFF
--- a/apps/pollbook/frontend/src/voter_search_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_search_screen.tsx
@@ -265,8 +265,27 @@ export function VoterSearch({
           </Row>
         </Form>
       )}
-      {searchVotersQuery.data ? (
-        typeof searchVotersQuery.data === 'number' ? (
+      {displayUnknownScanError && (
+        <Modal
+          title="ID Not Recognized"
+          content={
+            <div>
+              Unable to read the scanned barcode. Please try scanning again or
+              enter the name manually.
+            </div>
+          }
+          actions={
+            <Button
+              onPress={() => setDisplayUnknownScanError(false)}
+              variant="primary"
+            >
+              Close
+            </Button>
+          }
+        />
+      )}
+      {searchVotersQuery.data &&
+        (typeof searchVotersQuery.data === 'number' ? (
           <Callout icon="Info" color="neutral">
             <div>
               Voters matched: {searchVotersQuery.data}. Refine your search
@@ -320,28 +339,7 @@ export function VoterSearch({
               </VoterTable>
             </VoterTableWrapper>
           </React.Fragment>
-        )
-      ) : (
-        displayUnknownScanError && (
-          <Modal
-            title="ID Not Recognized"
-            content={
-              <div>
-                Unable to read the scanned barcode. Please try scanning again or
-                enter the name manually.
-              </div>
-            }
-            actions={
-              <Button
-                onPress={() => setDisplayUnknownScanError(false)}
-                variant="primary"
-              >
-                Close
-              </Button>
-            }
-          />
-        )
-      )}
+        ))}
     </Column>
   );
 }


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6761

Due to a rebase or merge error changes from https://github.com/votingworks/vxsuite/pull/6690 were reverted in https://github.com/votingworks/vxsuite/commit/72fa8832b9c783332076053b7d6adc3dd21fc596#diff-db907df85a5204be810706c80bacf83c6528c649ff90d04e3697a47bc2d4358f.

This adds the changes from https://github.com/votingworks/vxsuite/pull/6690 back in. It also changes render priority so the "Could not read barcode" error modal shows even if search results exist on the page.

## Demo Video or Screenshot


https://github.com/user-attachments/assets/701d454b-e37d-4d04-acdf-cf0cc2892261

## Testing Plan
- [x] Added daemon test for this specific error to prevent future regression

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
