### PR TITLE
[printing] Add support for printing to legal-sized paper via lpr

### DIFF
--- a/libs/printing/src/printer/print.test.ts
+++ b/libs/printing/src/printer/print.test.ts
@@ -21,7 +21,14 @@ test('prints with defaults', async () => {
 
   expect(exec).toHaveBeenCalledWith(
     'lpr',
-    ['-P', DEFAULT_MANAGED_PRINTER_NAME, '-o', 'sides=one-sided'],
+    [
+      '-P',
+      DEFAULT_MANAGED_PRINTER_NAME,
+      '-o',
+      'sides=one-sided',
+      '-o',
+      'media=letter',
+    ],
     Uint8Array.of(0xca, 0xfe)
   );
 });
@@ -36,7 +43,14 @@ test('allows specifying other sided-ness', async () => {
 
   expect(exec).toHaveBeenCalledWith(
     'lpr',
-    ['-P', DEFAULT_MANAGED_PRINTER_NAME, '-o', 'sides=two-sided-long-edge'],
+    [
+      '-P',
+      DEFAULT_MANAGED_PRINTER_NAME,
+      '-o',
+      'sides=two-sided-long-edge',
+      '-o',
+      'media=letter',
+    ],
     Uint8Array.of(0xf0, 0x0d)
   );
 });
@@ -48,7 +62,16 @@ test('prints a specified number of copies', async () => {
 
   expect(exec).toHaveBeenCalledWith(
     'lpr',
-    ['-P', DEFAULT_MANAGED_PRINTER_NAME, '-o', 'sides=one-sided', '-#', '3'],
+    [
+      '-P',
+      DEFAULT_MANAGED_PRINTER_NAME,
+      '-o',
+      'sides=one-sided',
+      '-o',
+      'media=letter',
+      '-#',
+      '3',
+    ],
     Uint8Array.of(0xca, 0xfe)
   );
 });
@@ -69,6 +92,8 @@ test('passes through raw options', async () => {
       '-o',
       'sides=one-sided',
       '-o',
+      'media=letter',
+      '-o',
       'fit-to-page=true',
     ],
     Uint8Array.of(0xf0, 0x0d)
@@ -83,4 +108,23 @@ test('rejects invalid raw options', async () => {
   ).rejects.toThrowError();
 
   expect(exec).not.toHaveBeenCalled();
+});
+
+test('supports legal-sized paper option', async () => {
+  vi.mocked(exec).mockResolvedValueOnce(ok({ stdout: '', stderr: '' }));
+
+  await print({ data: Uint8Array.of(0xca, 0xfe), size: 'legal' });
+
+  expect(exec).toHaveBeenCalledWith(
+    'lpr',
+    [
+      '-P',
+      DEFAULT_MANAGED_PRINTER_NAME,
+      '-o',
+      'sides=one-sided',
+      '-o',
+      'media=legal',
+    ],
+    Uint8Array.of(0xca, 0xfe)
+  );
 });

--- a/libs/printing/src/printer/print.ts
+++ b/libs/printing/src/printer/print.ts
@@ -10,6 +10,7 @@ export async function print({
   data,
   copies,
   sides = PrintSides.OneSided,
+  size = 'letter',
   raw = {},
 }: PrintProps): Promise<void> {
   const lprOptions: string[] = [];
@@ -17,6 +18,7 @@ export async function print({
   lprOptions.push('-P', DEFAULT_MANAGED_PRINTER_NAME);
 
   lprOptions.push('-o', `sides=${sides}`);
+  lprOptions.push('-o', `media=${size}`);
 
   // -o already pushed, can add options from raw
   for (const [key, value] of Object.entries(raw)) {

--- a/libs/printing/src/printer/types.ts
+++ b/libs/printing/src/printer/types.ts
@@ -24,6 +24,7 @@ export enum PrintSides {
 export interface PrintOptions {
   copies?: number;
   sides?: PrintSides;
+  size?: 'letter' | 'legal';
   raw?: { [key: string]: string };
 }
 


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6789

Ran into an issue printing on legal-sized paper while testing out pre-printed ballot marking on VxMark, since it was using the device default `letter` size. Adding an option for `legal` as well to the print API (mostly for dev/testing - we'll likely be doing the upcoming demo of the bubble-marking feature with letter-sized paper).

We'll eventually want to support the longer custom sizes as well, but that requires some coordination between configuring the printers with custom size options and using references to those in the shell command, so we'll tackle that later.

## Testing Plan
- Unit for shell command format + manual verification
