### PR TITLE
Update disabled/enabled actions for wrong precinct and inactive voters

### DIFF
--- a/apps/pollbook/backend/src/event_helpers.ts
+++ b/apps/pollbook/backend/src/event_helpers.ts
@@ -162,12 +162,6 @@ export function applyPollbookEventsToVoters(
           debug('Voter %s not found', event.voterId);
           continue;
         }
-        // If we receive a check in event for a voter that was marked as inactive it should not be processed.
-        // This can only occur if there are offline machines or in rare race conditions. Inactivated voters can
-        // not be checked in.
-        if (voter.isInactive) {
-          continue;
-        }
         updatedVoters[event.voterId] = {
           ...voter,
           checkIn: event.checkInData,
@@ -225,9 +219,6 @@ export function applyPollbookEventsToVoters(
         }
         updatedVoters[event.voterId] = {
           ...voter,
-          // If there was a check in it should be removed, checks in are not allowed on inactivated voters. This can only occur
-          // in rare edge conditions with race conditions // offline machines
-          checkIn: undefined,
           isInactive: true,
         };
         break;

--- a/apps/pollbook/backend/src/store_multi_node.test.ts
+++ b/apps/pollbook/backend/src/store_multi_node.test.ts
@@ -1390,12 +1390,12 @@ test('check in event on an offline machine BEFORE the mark inactive', async () =
   // Bring B online and sync
   peerB.setOnlineStatus(true);
   syncEventsForAllPollbooks([peerA, peerB]);
-  // Both should see voter as inactive and NOT checked in
+  // Both should see voter as inactive and checked in
   for (const store of [localA, localB]) {
     const v = store.getVoter('mia');
     expect(v.isInactive).toEqual(true);
-    expect(v.checkIn).toBeUndefined();
-    expect(store.getCheckInCount()).toEqual(0);
+    expect(v.checkIn).toBeDefined();
+    expect(store.getCheckInCount()).toEqual(1);
   }
 });
 
@@ -1424,7 +1424,7 @@ test('check in event on an offline machine AFTER the mark inactive', async () =>
   localA.markVoterInactive('nia');
   // Wait a bit of time.
   await sleep(10);
-  // Check in on B while offline (should be ignored after sync)
+  // Check in on B while offline
   localB.recordVoterCheckIn({
     voterId: 'nia',
     identificationMethod: { type: 'default' },
@@ -1433,12 +1433,12 @@ test('check in event on an offline machine AFTER the mark inactive', async () =>
   // Bring B online and sync
   peerB.setOnlineStatus(true);
   syncEventsForAllPollbooks([peerA, peerB]);
-  // Both should see voter as inactive and NOT checked in
+  // Both should see voter as inactive and checked in
   for (const store of [localA, localB]) {
     const v = store.getVoter('nia');
     expect(v.isInactive).toEqual(true);
-    expect(v.checkIn).toBeUndefined();
-    expect(store.getCheckInCount()).toEqual(0);
+    expect(v.checkIn).toBeDefined();
+    expect(store.getCheckInCount()).toEqual(1);
   }
 });
 
@@ -1508,7 +1508,7 @@ test('name/address change AFTER mark inactive on another machine get processed',
   }
 });
 
-test('cannot check in after mark inactive event is synced', () => {
+test('can check in after mark inactive event is synced', () => {
   const [localA, peerA] = setupFileStores('pollbook-a');
   const [localB, peerB] = setupFileStores('pollbook-b');
   const testElectionDefinition = getTestElectionDefinition();
@@ -1528,17 +1528,17 @@ test('cannot check in after mark inactive event is synced', () => {
   // Mark inactive on A
   localA.markVoterInactive('ina');
   syncEventsForAllPollbooks([peerA, peerB]);
-  // Try to check in on B (should not be allowed)
+  // Check in on B (should be allowed)
   localB.recordVoterCheckIn({
     voterId: 'ina',
     identificationMethod: { type: 'default' },
     ballotParty: 'DEM',
   });
   syncEventsForAllPollbooks([peerA, peerB]);
-  // Both should see voter as inactive and NOT checked in
+  // Both should see voter as inactive AND checked in
   for (const store of [localA, localB]) {
     const v = store.getVoter('ina');
     expect(v.isInactive).toEqual(true);
-    expect(v.checkIn).toBeUndefined();
+    expect(v.checkIn).toBeDefined();
   }
 });

--- a/apps/pollbook/frontend/src/voter_confirm_screen.test.tsx
+++ b/apps/pollbook/frontend/src/voter_confirm_screen.test.tsx
@@ -527,9 +527,9 @@ test('disables confirm check-in and out-of-state ID checkbox if precincts do not
   const mailingAddrButton = screen.getButton('Update Mailing Address');
   expect(mailingAddrButton).toBeDisabled();
 
-  // Update domicile address button should NOT be disabled
+  // Update domicile address button should also be disabled
   const domicileAddrButton = screen.getButton('Update Domicile Address');
-  expect(domicileAddrButton).not.toBeDisabled();
+  expect(domicileAddrButton).toBeDisabled();
 
   // Out-of-state ID checkbox should also be disabled
   const outOfStateCheckbox = screen.getByRole('checkbox', {

--- a/apps/pollbook/frontend/src/voter_confirm_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_confirm_screen.tsx
@@ -289,6 +289,7 @@ export function VoterConfirmScreen({
             <Row style={{ gap: '0.5rem' }}>
               <Button
                 icon="Edit"
+                disabled={isVoterInWrongPrecinct}
                 onPress={() => setShowUpdateAddressFlow(true)}
               >
                 Update Domicile Address

--- a/apps/pollbook/frontend/src/voter_details_screen.test.tsx
+++ b/apps/pollbook/frontend/src/voter_details_screen.test.tsx
@@ -572,9 +572,8 @@ test('actions are disabled when precinct does not match voter', async () => {
   const updateAddressButtons = screen.getAllByRole('button', {
     name: 'Update Domicile Address',
   });
-  // The address button should be enabled because it could be changed to the current precinct.
   const addressButton = updateAddressButtons[0];
-  expect(addressButton).not.toBeDisabled();
+  expect(addressButton).toBeDisabled();
 
   const updateMailingAddressButtons = screen.getAllByRole('button', {
     name: 'Update Mailing Address',

--- a/apps/pollbook/frontend/src/voter_details_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_details_screen.tsx
@@ -457,7 +457,11 @@ export function VoterDetailsScreen(): JSX.Element | null {
             </Button>
             <Button
               icon="Edit"
-              disabled={voter.isInactive || !configuredPrecinctId}
+              disabled={
+                voter.isInactive ||
+                !configuredPrecinctId ||
+                configuredPrecinctId !== getVoterPrecinct(voter)
+              }
               onPress={() => setShowUpdateAddressFlow(true)}
             >
               Update Domicile Address

--- a/apps/pollbook/frontend/src/voter_details_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_details_screen.tsx
@@ -480,7 +480,7 @@ export function VoterDetailsScreen(): JSX.Element | null {
         </Column>
         <Column style={{ flex: 1, flexBasis: 1, gap: '1rem' }}>
           <Card color="neutral">
-            {voter.isInactive && (
+            {voter.isInactive && !voter.checkIn && (
               <H2 style={{ marginTop: 0 }}>
                 <Icons.Flag /> Inactive
               </H2>

--- a/apps/pollbook/frontend/src/voter_details_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_details_screen.tsx
@@ -447,7 +447,6 @@ export function VoterDetailsScreen(): JSX.Element | null {
             <Button
               icon="Edit"
               disabled={
-                voter.isInactive ||
                 !configuredPrecinctId ||
                 configuredPrecinctId !== getVoterPrecinct(voter)
               }
@@ -458,7 +457,6 @@ export function VoterDetailsScreen(): JSX.Element | null {
             <Button
               icon="Edit"
               disabled={
-                voter.isInactive ||
                 !configuredPrecinctId ||
                 configuredPrecinctId !== getVoterPrecinct(voter)
               }
@@ -471,7 +469,6 @@ export function VoterDetailsScreen(): JSX.Element | null {
             <Button
               icon="Edit"
               disabled={
-                voter.isInactive ||
                 !configuredPrecinctId ||
                 configuredPrecinctId !== getVoterPrecinct(voter)
               }
@@ -493,7 +490,7 @@ export function VoterDetailsScreen(): JSX.Element | null {
                 <Icons.Info /> Not Checked In
               </H2>
             )}
-            {voter.checkIn && !voter.isInactive && (
+            {voter.checkIn && (
               <React.Fragment>
                 <H2 style={{ marginTop: 0 }}>
                   <Icons.Done /> Checked In
@@ -537,7 +534,7 @@ export function VoterDetailsScreen(): JSX.Element | null {
               Flag Voter as Inactive
             </Button>
           )}
-          {voter.checkIn && !voter.isInactive && (
+          {voter.checkIn && (
             <Row style={{ gap: '1rem' }}>
               <Button
                 icon="Print"


### PR DESCRIPTION
## Overview
Updates the following
- When a voter is in the wrong precinct we now disable the update address buttons 
- When a voter is flagged inactive fixes a bug that was preventing check ins on the backend. The feature was originally written so that check ins would be blocked, and specific efforts were went to to make sure that even in rare offline syncing scenarios an illegal check in could not sneak in. When Drew then updated the logic to ALLOW for check ins on inactive voters some of those backend checks were missed and we were silently ignoring these checks in, this fixes that. 
- When a voter is flagged as inactive enable all other actions, see discussion: https://votingworks.slack.com/archives/C07CR6T1TLK/p1753135409790919
- 
https://github.com/votingworks/vxsuite/issues/6818

<!-- add a link to a GitHub Issue here -->

## Demo Video or Screenshot
The view when a voter is both checked in and inactive on the EM screen looks a little weird as there are two headers in the right-hand box. This is an edge case though so in lieu of a better idea I think its ok. 

https://github.com/user-attachments/assets/687497cb-8601-4c9e-974b-0b59cc6396bc



## Testing Plan
Manual testing, updated automated tests. 
