### PR TITLE
[pollbook] Add `NOT_APPLICABLE` option to check-in `ballotParty` property

### DIFF
--- a/apps/pollbook/backend/src/__snapshots__/voter_history.test.ts.snap
+++ b/apps/pollbook/backend/src/__snapshots__/voter_history.test.ts.snap
@@ -12,6 +12,7 @@ bob,UND,Smith,Bob,,,123,,,Main St,,line 2,,,12345,Y,Y,N,N,N,CA,
 exports[`includes ballot party selection for primaries 1`] = `
 "Voter ID,Party,Last Name,First Name,Middle Name,Name Suffix,Street Number,Street Number Suffix,Street Number Fraction,Street Name,Apartment/Unit Number,Address Line 2,Address Line 3,City/Town,Zip Code,Check-In,Absentee,Address Change,Name Change,New Registration,OOSDL,Party Choice
 abigail,UND,Adams,Abigail,,,123,,,Main St,,line 2,,,12345,Y,N,N,N,N,,REP
+charlie,UND,Beauty,Bella,The,II,123,,,Main St,,line 2,,,12345,N,N,N,Y,N,,
 bob,UND,Smith,Bob,,,123,,,Main St,,line 2,,,12345,Y,N,N,N,N,,DEM
 "
 `;

--- a/apps/pollbook/backend/src/app.test.ts
+++ b/apps/pollbook/backend/src/app.test.ts
@@ -224,12 +224,15 @@ test('checking in a voter does not allow ballot party during a general', async (
     expect((votersAbigail as Voter[]).length).toEqual(3);
     const firstVoter = (votersAbigail as Voter[])[0];
 
-    const checkInResult = await localApiClient.checkInVoter({
-      voterId: firstVoter.voterId,
-      identificationMethod: { type: 'default' },
-      ballotParty: 'REP',
-    });
-    expect(checkInResult.err()).toEqual('ballot_party_not_applicable');
+    await expect(
+      localApiClient.checkInVoter({
+        voterId: firstVoter.voterId,
+        identificationMethod: { type: 'default' },
+        ballotParty: 'REP',
+      })
+    ).rejects.toThrow(
+      'Check-in ballot party cannot be provided during a general election'
+    );
   });
 });
 

--- a/apps/pollbook/backend/src/app.test.ts
+++ b/apps/pollbook/backend/src/app.test.ts
@@ -143,7 +143,7 @@ test('check in a voter', async () => {
     const checkInResult = await localApiClient.checkInVoter({
       voterId: firstVoter.voterId,
       identificationMethod: { type: 'default' },
-      ballotParty: 'UND',
+      ballotParty: 'NOT_APPLICABLE',
     });
     expect(checkInResult.ok()).toEqual(undefined);
     expect(await localApiClient.haveElectionEventsOccurred()).toEqual(true);
@@ -157,7 +157,7 @@ test('check in a voter', async () => {
       timestamp: expect.any(String),
       machineId: TEST_MACHINE_ID,
       receiptNumber: 1,
-      ballotParty: 'UND',
+      ballotParty: 'NOT_APPLICABLE',
     });
 
     const receiptPdfPath = mockPrinterHandler.getLastPrintPath();
@@ -168,7 +168,7 @@ test('check in a voter', async () => {
     const checkInResultOos = await localApiClient.checkInVoter({
       voterId: secondVoter.voterId,
       identificationMethod: { type: 'outOfStateLicense', state: 'CA' },
-      ballotParty: 'UND',
+      ballotParty: 'NOT_APPLICABLE',
     });
     expect(checkInResultOos.ok()).toEqual(undefined);
 
@@ -181,7 +181,7 @@ test('check in a voter', async () => {
       timestamp: expect.any(String),
       machineId: TEST_MACHINE_ID,
       receiptNumber: 2,
-      ballotParty: 'UND',
+      ballotParty: 'NOT_APPLICABLE',
     });
 
     const receiptPdfPathOos = mockPrinterHandler.getLastPrintPath();
@@ -197,6 +197,39 @@ test('check in a voter', async () => {
     const receiptReprint = mockPrinterHandler.getLastPrintPath();
     expect(receiptReprint).toBeDefined();
     await expect(receiptReprint).toMatchPdfSnapshot();
+  });
+});
+
+test('checking in a voter does not allow ballot party during a general', async () => {
+  await withApp(async ({ localApiClient, workspace, mockPrinterHandler }) => {
+    workspace.store.setElectionAndVoters(
+      electionDefinition,
+      'mock-package-hash',
+      townStreetNames,
+      townVoters
+    );
+    mockPrinterHandler.connectPrinter(CITIZEN_THERMAL_PRINTER_CONFIG);
+    expect(await localApiClient.haveElectionEventsOccurred()).toEqual(false);
+    const votersAbigail = await localApiClient.searchVoters({
+      searchParams: {
+        firstName: 'Abigail',
+        middleName: '',
+        lastName: 'Adams',
+        suffix: '',
+      },
+    });
+
+    assert(votersAbigail !== null);
+    assert(Array.isArray(votersAbigail));
+    expect((votersAbigail as Voter[]).length).toEqual(3);
+    const firstVoter = (votersAbigail as Voter[])[0];
+
+    const checkInResult = await localApiClient.checkInVoter({
+      voterId: firstVoter.voterId,
+      identificationMethod: { type: 'default' },
+      ballotParty: 'REP',
+    });
+    expect(checkInResult.err()).toEqual('ballot_party_not_applicable');
   });
 });
 
@@ -250,7 +283,7 @@ test('register a voter', async () => {
     const checkInResult = await localApiClient.checkInVoter({
       voterId: registerOk.voterId,
       identificationMethod: { type: 'default' },
-      ballotParty: 'REP',
+      ballotParty: 'NOT_APPLICABLE',
     });
     expect(checkInResult.ok()).toEqual(undefined);
 
@@ -263,7 +296,7 @@ test('register a voter', async () => {
       timestamp: expect.any(String),
       receiptNumber: 2,
       machineId: TEST_MACHINE_ID,
-      ballotParty: 'REP',
+      ballotParty: 'NOT_APPLICABLE',
     });
 
     const checkInReceiptPdfPath = mockPrinterHandler.getLastPrintPath();
@@ -553,7 +586,7 @@ test('undo a voter check-in', async () => {
     const checkInResult = await localApiClient.checkInVoter({
       voterId: firstVoter.voterId,
       identificationMethod: { type: 'default' },
-      ballotParty: 'UND',
+      ballotParty: 'NOT_APPLICABLE',
     });
     expect(checkInResult.isOk()).toBeTruthy();
 
@@ -711,7 +744,7 @@ test.skip('register a voter, change name and address, and check in', async () =>
       const checkInResult = await localApiClient.checkInVoter({
         voterId: registerOk.voterId,
         identificationMethod: { type: 'default' },
-        ballotParty: 'DEM',
+        ballotParty: 'NOT_APPLICABLE',
       });
       expect(checkInResult.ok()).toEqual(undefined);
 
@@ -734,7 +767,7 @@ test.skip('register a voter, change name and address, and check in', async () =>
           timestamp: expect.any(String),
           receiptNumber: 6,
           machineId: TEST_MACHINE_ID,
-          ballotParty: 'DEM',
+          ballotParty: 'NOT_APPLICABLE',
         },
       });
 
@@ -782,7 +815,7 @@ test('check in, change name, undo check-in, change address, and check in again',
     const checkInResult = await localApiClient.checkInVoter({
       voterId: firstVoter.voterId,
       identificationMethod: { type: 'default' },
-      ballotParty: 'UND',
+      ballotParty: 'NOT_APPLICABLE',
     });
     expect(checkInResult.ok()).toEqual(undefined);
 
@@ -836,7 +869,7 @@ test('check in, change name, undo check-in, change address, and check in again',
     const finalCheckInResult = await localApiClient.checkInVoter({
       voterId: firstVoter.voterId,
       identificationMethod: { type: 'default' },
-      ballotParty: 'UND',
+      ballotParty: 'NOT_APPLICABLE',
     });
     expect(finalCheckInResult.ok()).toEqual(undefined);
 
@@ -849,7 +882,7 @@ test('check in, change name, undo check-in, change address, and check in again',
       timestamp: expect.any(String),
       receiptNumber: 5,
       machineId: TEST_MACHINE_ID,
-      ballotParty: 'UND',
+      ballotParty: 'NOT_APPLICABLE',
     });
 
     const finalReceiptPdfPath = mockPrinterHandler.getLastPrintPath();
@@ -1131,7 +1164,7 @@ test('mark a voter inactive', async () => {
     const checkInResult = await localApiClient.checkInVoter({
       voterId: firstVoter.voterId,
       identificationMethod: { type: 'default' },
-      ballotParty: 'UND',
+      ballotParty: 'NOT_APPLICABLE',
     });
     expect(checkInResult.ok()).toEqual(undefined);
 
@@ -1139,7 +1172,7 @@ test('mark a voter inactive', async () => {
     const checkIn = await localApiClient.checkInVoter({
       voterId: secondVoter.voterId,
       identificationMethod: { type: 'default' },
-      ballotParty: 'UND',
+      ballotParty: 'NOT_APPLICABLE',
     });
     expect(checkIn.ok()).toEqual(undefined);
     // Trying to mark this voter as inactive should return an error.

--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -285,20 +285,20 @@ function buildApi({ context, logger, barcodeScannerClient }: BuildAppParams) {
             break;
           case 'REP':
           case 'DEM':
-            if (input.ballotParty !== voterParty) {
-              return err('mismatched_party_selection');
-            }
+            assert(
+              input.ballotParty === voterParty,
+              `Expected check-in party ${input.ballotParty} to match voter party ${voterParty}`
+            );
             break;
+          /* istanbul ignore next - @preserve */
           default:
-            /* istanbul ignore next - @preserve */
             return err('unknown_voter_party');
         }
-      } else if (
-        election.type === 'general' &&
-        input.ballotParty !== 'NOT_APPLICABLE'
-      ) {
-        // In generals the ballot party is not applicable
-        return err('ballot_party_not_applicable');
+      } else if (election.type === 'general') {
+        assert(
+          input.ballotParty === 'NOT_APPLICABLE',
+          'Check-in ballot party cannot be provided during a general election'
+        );
       }
 
       const { voter, receiptNumber } = store.recordVoterCheckIn({

--- a/apps/pollbook/backend/src/app_multi_node.test.ts
+++ b/apps/pollbook/backend/src/app_multi_node.test.ts
@@ -253,7 +253,7 @@ test('connection status between two pollbooks is managed properly', async () => 
     const checkIn = await pollbookContext1.localApiClient.checkInVoter({
       voterId: testVoters[0].voterId,
       identificationMethod: { type: 'default' },
-      ballotParty: 'UND',
+      ballotParty: 'NOT_APPLICABLE',
     });
     expect(checkIn.ok()).toEqual(undefined);
 

--- a/apps/pollbook/backend/src/app_multi_precinct_election.test.ts
+++ b/apps/pollbook/backend/src/app_multi_precinct_election.test.ts
@@ -647,7 +647,7 @@ test('an undeclared voter cannot check in as undeclared', async () => {
   });
 });
 
-test('a declared voter must check in with a party selection matching the declared party', async () => {
+test('in a primary, a declared voter must check in with a party selection matching the declared party', async () => {
   await withApp(async ({ localApiClient, workspace, mockPrinterHandler }) => {
     workspace.store.setElectionAndVoters(
       electionDefinition,
@@ -690,11 +690,19 @@ test('a declared voter must check in with a party selection matching the declare
       party: 'REP',
     });
 
+    await expect(
+      localApiClient.checkInVoter({
+        voterId: registerOk.voterId,
+        identificationMethod: { type: 'default' },
+        ballotParty: 'DEM',
+      })
+    ).rejects.toThrow('Expected check-in party DEM to match voter party REP');
+
     const checkInResult = await localApiClient.checkInVoter({
       voterId: registerOk.voterId,
       identificationMethod: { type: 'default' },
-      ballotParty: 'DEM',
+      ballotParty: 'REP',
     });
-    expect(checkInResult.err()).toEqual('mismatched_party_selection');
+    expect(checkInResult.isOk()).toBeTruthy();
   });
 });

--- a/apps/pollbook/backend/src/app_multi_precinct_election.test.ts
+++ b/apps/pollbook/backend/src/app_multi_precinct_election.test.ts
@@ -639,7 +639,7 @@ test('an undeclared voter cannot check in as undeclared', async () => {
     const checkInResult = await localApiClient.checkInVoter({
       voterId: firstVoter.voterId,
       identificationMethod: { type: 'default' },
-      ballotParty: 'UND',
+      ballotParty: 'NOT_APPLICABLE',
     });
     expect(checkInResult.err()).toEqual(
       'undeclared_voter_missing_ballot_party'

--- a/apps/pollbook/backend/src/local_store.ts
+++ b/apps/pollbook/backend/src/local_store.ts
@@ -40,7 +40,7 @@ import {
   VoterRegistrationRequest,
   VoterSchema,
   VoterSearchParams,
-  PartyAbbreviation,
+  CheckInBallotParty,
 } from './types';
 import {
   applyPollbookEventsToVoters,
@@ -299,7 +299,7 @@ export class LocalStore extends Store {
   }: {
     voterId: string;
     identificationMethod: VoterIdentificationMethod;
-    ballotParty: PartyAbbreviation;
+    ballotParty: CheckInBallotParty;
   }): { voter: Voter; receiptNumber: number } {
     debug(`Recording check-in for voter ${voterId}`);
     const voter = this.getVoter(voterId);

--- a/apps/pollbook/backend/src/receipts/check_in_receipt.tsx
+++ b/apps/pollbook/backend/src/receipts/check_in_receipt.tsx
@@ -72,7 +72,14 @@ export function CheckInReceipt({
         <VoterName voter={voter} />
       </div>
       <div>
-        <PartyName party={voter.checkIn?.ballotParty ?? voter.party} />
+        <PartyName
+          party={
+            voter.checkIn?.ballotParty === 'DEM' ||
+            voter.checkIn?.ballotParty === 'REP'
+              ? voter.checkIn.ballotParty
+              : voter.party
+          }
+        />
       </div>
       <VoterAddress voter={voter} election={metadata.election} />
       <div>Voter ID: {voter.voterId}</div>

--- a/apps/pollbook/backend/src/receipts/receipt_helpers.tsx
+++ b/apps/pollbook/backend/src/receipts/receipt_helpers.tsx
@@ -155,8 +155,8 @@ export function PartyName({ party }: { party: 'DEM' | 'REP' | 'UND' }): string {
       return 'Republican';
     case 'UND':
       return 'Undeclared';
+    /* istanbul ignore next: Compile-time check for completeness @preserve */
     default: {
-      /* istanbul ignore next: Compile-time check for completeness @preserve */
       throwIllegalValue(party);
     }
   }

--- a/apps/pollbook/backend/src/types.ts
+++ b/apps/pollbook/backend/src/types.ts
@@ -505,8 +505,6 @@ export type ConfigurationStatus =
 export type VoterCheckInError =
   | 'already_checked_in'
   | 'undeclared_voter_missing_ballot_party'
-  | 'mismatched_party_selection'
-  | 'ballot_party_not_applicable'
   | 'unknown_voter_party';
 
 export interface DuplicateVoterError {

--- a/apps/pollbook/backend/src/types.ts
+++ b/apps/pollbook/backend/src/types.ts
@@ -62,13 +62,20 @@ export const PartyAbbreviationSchema = z.union([
   z.literal('UND'),
 ]);
 
+export type CheckInBallotParty = 'DEM' | 'REP' | 'NOT_APPLICABLE';
+export const CheckInBallotPartySchema = z.union([
+  z.literal('DEM'),
+  z.literal('REP'),
+  z.literal('NOT_APPLICABLE'),
+]);
+
 export interface VoterCheckIn {
   identificationMethod: VoterIdentificationMethod;
   isAbsentee: boolean;
   timestamp: string;
   machineId: string;
   receiptNumber: number;
-  ballotParty: PartyAbbreviation;
+  ballotParty: CheckInBallotParty;
 }
 
 export const VoterCheckInSchema: z.ZodSchema<VoterCheckIn> = z.object({
@@ -85,7 +92,7 @@ export const VoterCheckInSchema: z.ZodSchema<VoterCheckIn> = z.object({
   timestamp: z.string(),
   machineId: z.string(),
   receiptNumber: z.number(),
-  ballotParty: PartyAbbreviationSchema,
+  ballotParty: CheckInBallotPartySchema,
 });
 
 export interface Voter {
@@ -499,6 +506,7 @@ export type VoterCheckInError =
   | 'already_checked_in'
   | 'undeclared_voter_missing_ballot_party'
   | 'mismatched_party_selection'
+  | 'ballot_party_not_applicable'
   | 'unknown_voter_party';
 
 export interface DuplicateVoterError {

--- a/apps/pollbook/backend/src/voter_history.test.ts
+++ b/apps/pollbook/backend/src/voter_history.test.ts
@@ -88,6 +88,13 @@ test('includes ballot party selection for primaries', () => {
     identificationMethod: { type: 'default' },
     ballotParty: 'DEM',
   });
+  // Record a name change so the voter shows up in the voter history without a check-in
+  store.changeVoterName('charlie', {
+    firstName: 'Bella',
+    middleName: 'The',
+    lastName: 'Beauty',
+    suffix: 'II',
+  });
 
   expect(
     generateVoterHistoryCsvContent(

--- a/apps/pollbook/backend/vitest.config.ts
+++ b/apps/pollbook/backend/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 84.5,
-        branches: 79,
+        lines: 85.1,
+        branches: 81,
       },
       exclude: [
         '**/node_modules/**',

--- a/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
+++ b/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
@@ -127,7 +127,7 @@ describe('PollWorkerScreen', () => {
     await screen.findByText('Confirm Voter Identity');
 
     const confirmButton = screen.getByText('Confirm Check-In');
-    apiMock.expectCheckInVoter(voter, voter.party);
+    apiMock.expectCheckInVoter(voter, 'NOT_APPLICABLE');
     apiMock.expectGetVoter(voter);
     userEvent.click(confirmButton);
     await screen.findByText('Voter Checked In');
@@ -374,7 +374,7 @@ describe('PollWorkerScreen', () => {
       await screen.findByText('Confirm Voter Identity');
 
       const confirmButton = screen.getByText('Confirm Check-In');
-      apiMock.expectCheckInVoterError(voter, testCase.error, voter.party);
+      apiMock.expectCheckInVoterError(voter, testCase.error, 'NOT_APPLICABLE');
       userEvent.click(confirmButton);
       await screen.findByText(testCase.expectedMessage);
 

--- a/apps/pollbook/frontend/src/poll_worker_screen.tsx
+++ b/apps/pollbook/frontend/src/poll_worker_screen.tsx
@@ -6,7 +6,7 @@ import {
   throwIllegalValue,
 } from '@votingworks/basics';
 import type {
-  PartyAbbreviation,
+  CheckInBallotParty,
   VoterCheckInError,
   VoterIdentificationMethod,
   VoterSearchParams,
@@ -164,7 +164,7 @@ export function VoterCheckInScreen(): JSX.Element | null {
     (
       voterId: string,
       identificationMethod: VoterIdentificationMethod,
-      ballotParty: PartyAbbreviation
+      ballotParty: CheckInBallotParty
     ) => {
       setFlowState({ step: 'printing' });
       checkInVoterMutate(
@@ -302,15 +302,19 @@ export function VoterCheckInScreen(): JSX.Element | null {
         case 'already_checked_in':
           errorMessage = 'Voter Already Checked In';
           break;
-        case 'mismatched_party_selection':
-          errorMessage =
-            "Voter's Declared Party Differs From Ballot Party Selection";
-          break;
         case 'undeclared_voter_missing_ballot_party':
           errorMessage = 'Undeclared Primary Voters Must Choose a Party Ballot';
           break;
         case 'unknown_voter_party':
           errorMessage = 'Voter Has No Declared Party';
+          break;
+        // Next 2 errors should be unreachable.
+        case 'mismatched_party_selection':
+          errorMessage =
+            "Voter's Declared Party Differs From Ballot Party Selection";
+          break;
+        case 'ballot_party_not_applicable':
+          errorMessage = 'A Ballot Party Was Specified For a General Election';
           break;
         default:
           /* istanbul ignore next - @preserve */

--- a/apps/pollbook/frontend/src/poll_worker_screen.tsx
+++ b/apps/pollbook/frontend/src/poll_worker_screen.tsx
@@ -308,14 +308,6 @@ export function VoterCheckInScreen(): JSX.Element | null {
         case 'unknown_voter_party':
           errorMessage = 'Voter Has No Declared Party';
           break;
-        // Next 2 errors should be unreachable.
-        case 'mismatched_party_selection':
-          errorMessage =
-            "Voter's Declared Party Differs From Ballot Party Selection";
-          break;
-        case 'ballot_party_not_applicable':
-          errorMessage = 'A Ballot Party Was Specified For a General Election';
-          break;
         default:
           /* istanbul ignore next - @preserve */
           throwIllegalValue(flowState.errorType);

--- a/apps/pollbook/frontend/src/select_party_screen.tsx
+++ b/apps/pollbook/frontend/src/select_party_screen.tsx
@@ -1,5 +1,5 @@
 import {
-  PartyAbbreviation,
+  CheckInBallotParty,
   VoterIdentificationMethod,
 } from '@votingworks/pollbook-backend';
 import {
@@ -21,7 +21,7 @@ interface SelectPartyScreenProps {
   onConfirmCheckIn: (
     voterId: string,
     identificationMethod: VoterIdentificationMethod,
-    ballotParty: PartyAbbreviation
+    ballotParty: CheckInBallotParty
   ) => void;
   onBack: () => void;
 }
@@ -33,7 +33,7 @@ export function SelectPartyScreen({
   onBack,
 }: SelectPartyScreenProps): JSX.Element {
   const [selectedBallotParty, setSelectedBallotParty] =
-    useState<Optional<PartyAbbreviation>>(undefined);
+    useState<Optional<CheckInBallotParty>>(undefined);
 
   return (
     <NoNavScreen>

--- a/apps/pollbook/frontend/src/shared_components.tsx
+++ b/apps/pollbook/frontend/src/shared_components.tsx
@@ -182,7 +182,7 @@ export function TitledCard({
 export function PartyName({ party }: { party: 'DEM' | 'REP' | 'UND' }): string {
   switch (party) {
     case 'DEM':
-      return 'Democrat';
+      return 'Democratic';
     case 'REP':
       return 'Republican';
     case 'UND':

--- a/apps/pollbook/frontend/src/strings.test.ts
+++ b/apps/pollbook/frontend/src/strings.test.ts
@@ -1,11 +1,18 @@
 import { test, expect } from 'vitest';
-import { PartyAbbreviation } from '@votingworks/pollbook-backend';
+import {
+  CheckInBallotParty,
+  PartyAbbreviation,
+} from '@votingworks/pollbook-backend';
 import { partyAbbreviationToString } from './strings';
 
-const cases: Array<{ abbreviation: PartyAbbreviation; str: string }> = [
+const cases: Array<{
+  abbreviation: PartyAbbreviation | CheckInBallotParty;
+  str: string;
+}> = [
   { abbreviation: 'DEM', str: 'Democratic' },
   { abbreviation: 'REP', str: 'Republican' },
   { abbreviation: 'UND', str: 'Undeclared' },
+  { abbreviation: 'NOT_APPLICABLE', str: 'Not Applicable' },
 ];
 
 test.each(cases)(

--- a/apps/pollbook/frontend/src/strings.ts
+++ b/apps/pollbook/frontend/src/strings.ts
@@ -1,7 +1,12 @@
 import { throwIllegalValue } from '@votingworks/basics';
-import type { PartyAbbreviation } from '@votingworks/pollbook-backend';
+import type {
+  CheckInBallotParty,
+  PartyAbbreviation,
+} from '@votingworks/pollbook-backend';
 
-export function partyAbbreviationToString(party: PartyAbbreviation): string {
+export function partyAbbreviationToString(
+  party: CheckInBallotParty | PartyAbbreviation
+): string {
   switch (party) {
     case 'DEM':
       return 'Democratic';
@@ -10,6 +15,8 @@ export function partyAbbreviationToString(party: PartyAbbreviation): string {
     case 'UND':
       /* istanbul ignore next - @preserve */
       return 'Undeclared';
+    case 'NOT_APPLICABLE':
+      return 'Not Applicable';
     default:
       /* istanbul ignore next - @preserve */
       throwIllegalValue(party);

--- a/apps/pollbook/frontend/src/voter_confirm_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_confirm_screen.tsx
@@ -15,6 +15,7 @@ import {
 } from '@votingworks/ui';
 import React, { useState } from 'react';
 import type {
+  CheckInBallotParty,
   PartyAbbreviation,
   VoterIdentificationMethod,
 } from '@votingworks/pollbook-backend';
@@ -57,6 +58,29 @@ function isIdentificationMethodComplete(
   }
 }
 
+function partyAbbreviationToCheckInBallotParty(
+  election: Election,
+  abbreviation: PartyAbbreviation
+): CheckInBallotParty {
+  if (election.type === 'general') {
+    return 'NOT_APPLICABLE';
+  }
+
+  switch (abbreviation) {
+    case 'DEM':
+      return 'DEM';
+    case 'REP':
+      return 'REP';
+    case 'UND':
+      throw new Error(
+        'REP or DEM ballot party must be specified for undeclared voters in a primary'
+      );
+    default:
+      /* istanbul ignore next */
+      throwIllegalValue(abbreviation);
+  }
+}
+
 export function VoterConfirmScreen({
   voterId,
   isAbsenteeMode,
@@ -76,7 +100,7 @@ export function VoterConfirmScreen({
   onConfirmCheckIn: (
     voterId: string,
     identificationMethod: VoterIdentificationMethod,
-    ballotParty: PartyAbbreviation
+    ballotParty: CheckInBallotParty
   ) => void;
   election: Election;
   configuredPrecinctId: string;
@@ -324,8 +348,7 @@ export function VoterConfirmScreen({
               onConfirmCheckIn(
                 voterId,
                 identificationMethod,
-                // No party selection required for voters with declared party
-                voter.party
+                partyAbbreviationToCheckInBallotParty(election, voter.party)
               );
             }
           }}
@@ -354,8 +377,10 @@ export function VoterConfirmScreen({
                     onConfirmCheckIn(
                       voterId,
                       identificationMethod,
-                      // No party selection required for voters with declared party
-                      voter.party
+                      partyAbbreviationToCheckInBallotParty(
+                        election,
+                        voter.party
+                      )
                     );
                   }
                 }}

--- a/apps/pollbook/frontend/src/voter_search_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_search_screen.tsx
@@ -216,7 +216,10 @@ export function VoterSearch({
                   data-testid="scanned-id-input"
                   style={{ flexGrow: 1 }}
                   disabled
-                  onChange={() => {}}
+                  onChange={
+                    /* istanbul ignore next */
+                    () => {}
+                  }
                   type="text"
                 />
               </InputGroup>

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -8,6 +8,7 @@ import { createMockClient } from '@votingworks/grout-test-utils';
 import type {
   AamvaDocument,
   Api,
+  CheckInBallotParty,
   ConfigurationError,
   ConfigurationStatus,
   DeviceStatuses,
@@ -387,7 +388,7 @@ export function createApiMock() {
         .resolves(voter);
     },
 
-    expectCheckInVoter(voter: Voter, ballotParty: PartyAbbreviation) {
+    expectCheckInVoter(voter: Voter, ballotParty: CheckInBallotParty) {
       mockApiClient.checkInVoter.reset();
       mockApiClient.checkInVoter
         .expectCallWith({
@@ -403,7 +404,7 @@ export function createApiMock() {
     expectCheckInVoterError(
       voter: Voter,
       error: VoterCheckInError,
-      ballotParty: PartyAbbreviation
+      ballotParty: CheckInBallotParty
     ) {
       mockApiClient.checkInVoter.reset();
       mockApiClient.checkInVoter

--- a/apps/pollbook/frontend/vitest.config.ts
+++ b/apps/pollbook/frontend/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: 89.5,
-        branches: 86.2,
+        branches: 86.58,
       },
       exclude: [
         'src/**/*.d.ts',

--- a/apps/pollbook/frontend/vitest.config.ts
+++ b/apps/pollbook/frontend/vitest.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
 
     coverage: {
       thresholds: {
-        lines: 89.5,
-        branches: 86.58,
+        lines: 90,
+        branches: 87,
       },
       exclude: [
         'src/**/*.d.ts',


### PR DESCRIPTION
## Overview

Adds a `NOT_APPLICABLE` option for the `ballotParty` field on check-ins. `ballotParty` describes the chosen ballot in a primary check in:
* Registered Democrats or Republicans must choose the corresponding `DEM` or `REP` ballot
* Undeclared voters can choose either `DEM` or `REP` but must choose one

In generals there are no party ballots to choose from so this field doesn't really make sense. Previously we were just writing `voter.party` ie. `REP`, `DEM`, or `UND` but the value in this field had no meaning. In this PR we make it explicit that the value is unused for generals by writing `NOT_APPLICABLE` for all general election check ins.

Recapping previous discussion, we originally wanted to and still want to keep this field as required in the API and schema because the type safety is useful.


## Demo Video or Screenshot

User-facing behavior is unchanged.

## Testing Plan
- Updated tests
- Added a few tests for coverage

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
