### PR TITLE
Update connection copy to "synced"

### DIFF
--- a/apps/pollbook/frontend/src/nav_screen.test.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.test.tsx
@@ -255,7 +255,7 @@ test('renders network status as expected - when configured', async () => {
   // Check each row
   const pollbookRows = screen.getAllByTestId('pollbook-row');
   expect(pollbookRows).toHaveLength(6);
-  expect(within(pollbookRows[0]).getByText('Connected')).toBeInTheDocument();
+  expect(within(pollbookRows[0]).getByText('Synced')).toBeInTheDocument();
   const iconElement0 = within(pollbookRows[0]).getByRole('img', {
     hidden: true,
   });

--- a/apps/pollbook/frontend/src/nav_screen.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.tsx
@@ -68,7 +68,7 @@ function getIconAndLabelForPollbookConnection(
       assert(isCurrentMachineConfigured(currentMachineConfiguration));
       return [
         <Icons.Checkmark key={pollbook.machineId} color="success" />,
-        'Connected',
+        'Synced',
       ];
     }
     case PollbookConnectionStatus.LostConnection: {


### PR DESCRIPTION
https://github.com/votingworks/vxsuite/issues/6736

When showing the connected pollbooks change the copy to "Synced" to designate when they are sharing events and "Connected" when the pollbook is unconfigured and sees another pollbook. 