### PR TITLE
[Mark] Conditionally print bubble mark overlay, based on flag in DB

### DIFF
--- a/apps/mark/backend/.eslintrc.json
+++ b/apps/mark/backend/.eslintrc.json
@@ -1,6 +1,10 @@
 {
   "extends": ["plugin:vx/recommended"],
   "rules": {
+    "@typescript-eslint/no-use-before-define": [
+      "error",
+      { "functions": false }
+    ],
     // Disable JSDOC rule as code is self-documenting.
     "vx/gts-jsdoc": "off"
   }

--- a/apps/mark/backend/package.json
+++ b/apps/mark/backend/package.json
@@ -33,6 +33,7 @@
     "@votingworks/db": "workspace:*",
     "@votingworks/dev-dock-backend": "workspace:*",
     "@votingworks/grout": "workspace:*",
+    "@votingworks/hmpb": "workspace:*",
     "@votingworks/image-utils": "workspace:*",
     "@votingworks/logging": "workspace:*",
     "@votingworks/printing": "workspace:*",

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -40,11 +40,11 @@ import { UsbDrive, UsbDriveStatus } from '@votingworks/usb-drive';
 import { Printer } from '@votingworks/printing';
 import { getMachineConfig } from './machine_config';
 import { Workspace } from './util/workspace';
-import { ElectionState, PrintBallotProps } from './types';
+import { ElectionState, PrintBallotProps, PrintMode } from './types';
 import { printBallot } from './util/print_ballot';
 import { isAccessibleControllerAttached } from './util/accessible_controller';
 import { constructAuthMachineState } from './util/auth';
-import { ElectionRecord, PrintMode } from './store';
+import { ElectionRecord } from './store';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function buildApi(

--- a/apps/mark/backend/src/index.ts
+++ b/apps/mark/backend/src/index.ts
@@ -8,7 +8,6 @@ import { MARK_WORKSPACE, PORT } from './globals';
 import { createWorkspace, Workspace } from './util/workspace';
 
 export type { Api } from './app';
-export type { PrintMode } from './store';
 export * from './types';
 
 loadEnvVarsFromDotenvFiles();

--- a/apps/mark/backend/src/store.test.ts
+++ b/apps/mark/backend/src/store.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test, vi } from 'vitest';
 import { safeParseSystemSettings, TEST_JURISDICTION } from '@votingworks/types';
 import { electionTwoPartyPrimaryFixtures } from '@votingworks/fixtures';
-import { PrintMode, Store } from './store';
+import { Store } from './store';
+import { PrintMode } from './types';
 
 // We pause in some of these tests so we need to increase the timeout
 vi.setConfig({

--- a/apps/mark/backend/src/store.ts
+++ b/apps/mark/backend/src/store.ts
@@ -26,11 +26,9 @@ import {
   constructElectionKey,
 } from '@votingworks/types';
 import { join } from 'node:path';
+import { PrintMode } from './types';
 
 const SchemaPath = join(__dirname, '../schema.sql');
-
-// [TODO] Fits better in ./types.ts, but this avoids a dependency cycle for now:
-export type PrintMode = 'bubble_marks' | 'summary';
 
 export interface ElectionRecord {
   electionDefinition: ElectionDefinition;

--- a/apps/mark/backend/src/types.ts
+++ b/apps/mark/backend/src/types.ts
@@ -1,5 +1,9 @@
-import { PollsState, PrecinctSelection } from '@votingworks/types';
-import { PrintBallotProps as BackendPrintBallotProps } from './util/print_ballot';
+import {
+  BallotStyleId,
+  PollsState,
+  PrecinctSelection,
+  VotesDict,
+} from '@votingworks/types';
 
 export interface MachineConfig {
   machineId: string;
@@ -16,7 +20,11 @@ export interface ElectionState {
 
 export type ScreenOrientation = 'portrait' | 'landscape';
 
-export type PrintBallotProps = Omit<
-  BackendPrintBallotProps,
-  'store' | 'printer'
->;
+export interface PrintBallotProps {
+  ballotStyleId: BallotStyleId;
+  languageCode: string;
+  precinctId: string;
+  votes: VotesDict;
+}
+
+export type PrintMode = 'bubble_marks' | 'summary';

--- a/apps/mark/backend/src/util/print_ballot.test.tsx
+++ b/apps/mark/backend/src/util/print_ballot.test.tsx
@@ -1,0 +1,209 @@
+import { describe, expect, test, vi } from 'vitest';
+import Stream from 'node:stream';
+import { Buffer } from 'node:buffer';
+
+import { electionGeneralFixtures } from '@votingworks/fixtures';
+import { generateMarkOverlay } from '@votingworks/hmpb';
+import {
+  ElectionDefinition,
+  HmpbBallotPaperSize,
+  UiStringsPackage,
+  VotesDict,
+} from '@votingworks/types';
+import {
+  PrintFunction,
+  PrintSides,
+  RenderSpec,
+  renderToPdf,
+  type Printer,
+} from '@votingworks/printing';
+
+import {
+  BackendLanguageContextProvider,
+  BmdPaperBallot,
+} from '@votingworks/ui';
+import { UiStringsStore } from '@votingworks/backend';
+import { ok } from '@votingworks/basics';
+import { type Store } from '../store';
+import { printBallot } from './print_ballot';
+
+vi.mock('@votingworks/hmpb');
+vi.mock('@votingworks/printing');
+vi.mock('@votingworks/ui');
+
+const electionDefBase = electionGeneralFixtures.readElectionDefinition();
+
+describe(`printMode === "bubble_marks"`, () => {
+  const testValidSizes = test.each<'letter' | 'legal'>(['letter', 'legal']);
+
+  testValidSizes('prints bubble marks - %s', async (size) => {
+    const electionDefinition = mockElection({
+      paperSize: size as HmpbBallotPaperSize,
+    });
+    const ballotStyle = electionDefinition.election.ballotStyles[0];
+    const mockVotes: VotesDict = {
+      foo: ['yes'],
+      bar: [{ id: 'one', name: 'Hon. One III' }],
+    };
+
+    vi.mocked(generateMarkOverlay).mockImplementation(
+      (election, ballotStyleId, votes) => {
+        expect(election).toEqual(electionDefinition.election);
+        expect(ballotStyleId).toEqual(ballotStyle.id);
+        expect(votes).toEqual(mockVotes);
+
+        return Stream.Readable.from([
+          Buffer.of(0xca, 0xfe),
+          Buffer.of(0xf0, 0x0d),
+        ]);
+      }
+    );
+
+    const mockPrint = vi.fn<PrintFunction>();
+    await printBallot({
+      ballotStyleId: ballotStyle.id,
+      languageCode: 'unused',
+      precinctId: 'unused',
+      printer: mockPrinter({ print: mockPrint }),
+      store: mockStore({
+        getElectionRecord: () => ({
+          electionDefinition,
+          electionPackageHash: 'unused',
+        }),
+        getPrintMode: () => 'bubble_marks',
+      }),
+      votes: mockVotes,
+    });
+
+    expect(mockPrint.mock.calls).toEqual<Array<Parameters<PrintFunction>>>([
+      [
+        {
+          data: Uint8Array.of(0xca, 0xfe, 0xf0, 0x0d),
+          sides: PrintSides.TwoSidedLongEdge,
+          size,
+        },
+      ],
+    ]);
+  });
+
+  const testInvalidSizes = test.each<HmpbBallotPaperSize>([
+    HmpbBallotPaperSize.Custom17,
+    HmpbBallotPaperSize.Custom19,
+    HmpbBallotPaperSize.Custom22,
+  ]);
+
+  testInvalidSizes('throws for unsupported paper size - %s', async (size) => {
+    const electionDefinition = mockElection({ paperSize: size });
+
+    await expect(() =>
+      printBallot({
+        ballotStyleId: electionDefinition.election.ballotStyles[0].id,
+        languageCode: 'unused',
+        precinctId: 'unused',
+        printer: mockPrinter({}),
+        store: mockStore({
+          getElectionRecord: () => ({
+            electionDefinition,
+            electionPackageHash: 'unused',
+          }),
+          getPrintMode: () => 'bubble_marks',
+        }),
+        votes: { foo: ['yes'] },
+      })
+    ).rejects.toThrow(/paper size not yet supported/);
+  });
+});
+
+describe(`printMode === "summary"`, () => {
+  test('prints summary ballot', async () => {
+    const electionDefinition = electionDefBase;
+    const ballotStyle = electionDefinition.election.ballotStyles[0];
+    const mockVotes: VotesDict = { foo: ['yes'] };
+
+    vi.mocked(BackendLanguageContextProvider).mockImplementation((p) => (
+      <div>{p.children}</div>
+    ));
+    vi.mocked(BmdPaperBallot).mockImplementation(() => (
+      <div>ballot content</div>
+    ));
+
+    const mockUiStrings: UiStringsPackage = { 'es-US': { hello: 'hola' } };
+    const mockPrecinctId = 'precinct-one';
+    const mockPdf = Uint8Array.of(0xca, 0xfe);
+    vi.mocked(renderToPdf).mockImplementation((spec) => {
+      expect(spec).toEqual<RenderSpec>({
+        document: (
+          <BackendLanguageContextProvider
+            currentLanguageCode="es-US"
+            uiStringsPackage={mockUiStrings}
+          >
+            <BmdPaperBallot
+              electionDefinition={electionDefinition}
+              ballotStyleId={ballotStyle.id}
+              precinctId={mockPrecinctId}
+              votes={mockVotes}
+              isLiveMode
+              machineType="mark"
+            />
+          </BackendLanguageContextProvider>
+        ),
+      });
+
+      return Promise.resolve(ok(mockPdf));
+    });
+
+    const mockPrint = vi.fn<PrintFunction>();
+    await printBallot({
+      ballotStyleId: ballotStyle.id,
+      languageCode: 'es-US',
+      precinctId: mockPrecinctId,
+      printer: mockPrinter({ print: mockPrint }),
+      store: mockStore({
+        getElectionRecord: () => ({
+          electionDefinition,
+          electionPackageHash: 'unused',
+        }),
+        getPrintMode: () => 'summary',
+        getTestMode: () => false,
+        getUiStringsStore: () =>
+          mockUiStringsStore({
+            getAllUiStrings: () => mockUiStrings,
+          }),
+      }),
+      votes: mockVotes,
+    });
+
+    expect(mockPrint.mock.calls).toEqual<Array<Parameters<PrintFunction>>>([
+      [{ data: mockPdf, sides: PrintSides.OneSided }],
+    ]);
+  });
+});
+
+interface MockElectionOpts {
+  paperSize?: HmpbBallotPaperSize;
+}
+
+function mockElection(opts: MockElectionOpts = {}): ElectionDefinition {
+  return {
+    ...electionDefBase,
+    election: {
+      ...electionDefBase.election,
+      ballotLayout: {
+        ...electionDefBase.election.ballotLayout,
+        paperSize: opts.paperSize || HmpbBallotPaperSize.Letter,
+      },
+    },
+  };
+}
+
+function mockPrinter(mocks: Partial<Printer>) {
+  return mocks as unknown as Printer;
+}
+
+function mockStore(mocks: Partial<Store>) {
+  return mocks as unknown as Store;
+}
+
+function mockUiStringsStore(mocks: Partial<UiStringsStore>) {
+  return mocks as unknown as UiStringsStore;
+}

--- a/apps/mark/backend/src/util/print_ballot.tsx
+++ b/apps/mark/backend/src/util/print_ballot.tsx
@@ -1,35 +1,33 @@
-import { PrintSides, Printer, renderToPdf } from '@votingworks/printing';
-import { BallotStyleId, VotesDict } from '@votingworks/types';
+import { Buffer } from 'node:buffer';
 
-import { assertDefined } from '@votingworks/basics';
+import { PrintSides, Printer, renderToPdf } from '@votingworks/printing';
+import { assert, assertDefined } from '@votingworks/basics';
+import { generateMarkOverlay } from '@votingworks/hmpb';
 import {
   BmdPaperBallot,
   BackendLanguageContextProvider,
 } from '@votingworks/ui';
 import { Store } from '../store';
+import { PrintBallotProps as ClientParams } from '../types';
 
-export interface PrintBallotProps {
+export interface PrintBallotProps extends ClientParams {
   printer: Printer;
   store: Store;
-  precinctId: string;
-  ballotStyleId: BallotStyleId;
-  votes: VotesDict;
-  languageCode: string;
 }
 
-export async function printBallot({
-  printer,
-  store,
-  precinctId,
-  ballotStyleId,
-  votes,
-  languageCode,
-}: PrintBallotProps): Promise<void> {
+export async function printBallot(p: PrintBallotProps): Promise<void> {
+  const { printer, store, precinctId, ballotStyleId, votes, languageCode } = p;
+
+  if (store.getPrintMode() === 'bubble_marks') {
+    return printMarkOverlay(p);
+  }
+
   const { electionDefinition } = assertDefined(store.getElectionRecord());
   const isLiveMode = !store.getTestMode();
 
   const ballot = (
     <BackendLanguageContextProvider
+      // [TODO] Derive languageCode from the ballot style instead.
       currentLanguageCode={languageCode}
       uiStringsPackage={store.getUiStringsStore().getAllUiStrings()}
     >
@@ -47,5 +45,32 @@ export async function printBallot({
   return printer.print({
     data: (await renderToPdf({ document: ballot })).unsafeUnwrap(),
     sides: PrintSides.OneSided,
+  });
+}
+
+export async function printMarkOverlay(p: PrintBallotProps): Promise<void> {
+  const { electionDefinition } = assertDefined(p.store.getElectionRecord());
+  const { election } = electionDefinition;
+
+  const size = election.ballotLayout.paperSize;
+  assert(
+    size === 'letter' || size === 'legal',
+    `${size} paper size not yet supported for pre-printed ballot marking`
+  );
+
+  const stream = generateMarkOverlay(election, p.ballotStyleId, p.votes);
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    assert(chunk instanceof Buffer);
+    chunks.push(chunk);
+  }
+
+  const pdf = Buffer.concat(chunks);
+
+  return p.printer.print({
+    data: new Uint8Array(pdf.buffer, pdf.byteOffset, pdf.length),
+    sides: PrintSides.TwoSidedLongEdge,
+    size,
   });
 }

--- a/libs/hmpb/package.json
+++ b/libs/hmpb/package.json
@@ -13,7 +13,7 @@
     "build": "is-ci build:ci build:dev",
     "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
     "build:dev": "pnpm --filter $npm_package_name... build:self",
-    "build:self": "tsc --build tsconfig.build.json",
+    "build:self": "tsc --build tsconfig.build.json && cp -R ./src/fonts ./build",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
     "format": "prettier '**/*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",

--- a/libs/hmpb/src/ballot_components.tsx
+++ b/libs/hmpb/src/ballot_components.tsx
@@ -74,6 +74,23 @@ export function TimingMark({
   return <StyledTimingMark className={TIMING_MARK_CLASS} style={style} />;
 }
 
+export function timingMarkCounts(pageDimensions: InchDimensions): {
+  x: number;
+  y: number;
+} {
+  // Corresponds to the NH Accuvote ballot grid, which we mimic so that our
+  // interpreter can support both Accuvote-style ballots and our ballots.
+  // This formula is replicated in
+  // libs/ballot-interpreter/src/hmpb-rust/ballot_card.rs.
+  const columnsPerInch = 4;
+  const rowsPerInch = 4;
+
+  return {
+    x: pageDimensions.width * columnsPerInch,
+    y: pageDimensions.height * rowsPerInch - 3,
+  };
+}
+
 export function TimingMarkGrid({
   pageDimensions,
   children,
@@ -83,13 +100,7 @@ export function TimingMarkGrid({
   children: React.ReactNode;
   timingMarkStyle?: React.CSSProperties;
 }): JSX.Element {
-  // Corresponds to the NH Accuvote ballot grid, which we mimic so that our
-  // interpreter can support both Accuvote-style ballots and our ballots.
-  // This formula is replicated in libs/ballot-interpreter/src/ballot_card.rs.
-  const columnsPerInch = 4;
-  const rowsPerInch = 4;
-  const gridRows = pageDimensions.height * rowsPerInch - 3;
-  const gridColumns = pageDimensions.width * columnsPerInch;
+  const markCounts = timingMarkCounts(pageDimensions);
 
   function TimingMarkRow() {
     return (
@@ -99,7 +110,7 @@ export function TimingMarkGrid({
           justifyContent: 'space-between',
         }}
       >
-        {range(0, gridColumns).map((i) => (
+        {range(0, markCounts.x).map((i) => (
           <TimingMark key={i} style={timingMarkStyle} />
         ))}
       </div>
@@ -119,7 +130,7 @@ export function TimingMarkGrid({
           ...style,
         }}
       >
-        {range(0, gridRows).map((i) => (
+        {range(0, markCounts.y).map((i) => (
           <TimingMark key={i} style={timingMarkStyle} />
         ))}
       </div>

--- a/libs/hmpb/src/index.ts
+++ b/libs/hmpb/src/index.ts
@@ -4,6 +4,7 @@ export * from './concatenate_pdfs';
 export * from './pdf_conversion';
 export * from './hmpb_strings';
 export * from './mark_ballot';
+export * from './marking';
 export * from './playwright_renderer';
 export * from './render_ballot';
 export * from './renderer';

--- a/libs/hmpb/src/marking.ts
+++ b/libs/hmpb/src/marking.ts
@@ -15,6 +15,7 @@ import {
   BUBBLE_WIDTH_PX,
   pageMarginsInches,
   TIMING_MARK_DIMENSIONS,
+  timingMarkCounts,
 } from './ballot_components';
 
 // NOTE: All values used in this module are in PDF user space `pt` units.
@@ -28,7 +29,6 @@ const pageMargins = [
   pageMarginsInches.top * IN,
 ] as const;
 
-const timingMarkCount = [34, 41] as const;
 const timingMarkSize = [
   TIMING_MARK_DIMENSIONS.width * IN,
   TIMING_MARK_DIMENSIONS.height * IN,
@@ -79,6 +79,7 @@ export function generateMarkOverlay(
   const pageSizeIn = ballotPaperDimensions(election.ballotLayout.paperSize);
   const pageSize = [pageSizeIn.width * IN, pageSizeIn.height * IN] as const;
 
+  const timingMarkCount = timingMarkCounts(pageSizeIn);
   const gridSize = [
     pageSize[0] - 2 * pageMargins[0] - timingMarkSize[0],
     pageSize[1] - 2 * pageMargins[1] - timingMarkSize[1],
@@ -111,8 +112,8 @@ export function generateMarkOverlay(
     doc.switchToPage(pageNumber - 1); // Pages are 0-indexed in `pdfkit`.
 
     const bubbleCenter = [
-      gridOrigin[0] + gridSize[0] * (pos.column / (timingMarkCount[0] - 1)),
-      gridOrigin[1] + gridSize[1] * (pos.row / (timingMarkCount[1] - 1)),
+      gridOrigin[0] + gridSize[0] * (pos.column / (timingMarkCount.x - 1)),
+      gridOrigin[1] + gridSize[1] * (pos.row / (timingMarkCount.y - 1)),
     ];
 
     doc
@@ -131,12 +132,12 @@ export function generateMarkOverlay(
 
     const { writeInArea: area, writeInName: name } = mark;
     const origin = [
-      gridOrigin[0] + gridSize[0] * (area.x / (timingMarkCount[0] - 1)),
-      gridOrigin[1] + gridSize[1] * (area.y / (timingMarkCount[1] - 1)),
+      gridOrigin[0] + gridSize[0] * (area.x / (timingMarkCount.x - 1)),
+      gridOrigin[1] + gridSize[1] * (area.y / (timingMarkCount.y - 1)),
     ];
     const areaSize = [
-      area.width * (gridSize[0] / (timingMarkCount[0] - 1)),
-      area.height * (gridSize[1] / (timingMarkCount[1] - 1)),
+      area.width * (gridSize[0] / (timingMarkCount.x - 1)),
+      area.height * (gridSize[1] / (timingMarkCount.y - 1)),
     ];
 
     let fontSize = writeInFontSizeDefault;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1895,6 +1895,9 @@ importers:
       '@votingworks/grout':
         specifier: workspace:*
         version: link:../../../libs/grout
+      '@votingworks/hmpb':
+        specifier: workspace:*
+        version: link:../../../libs/hmpb
       '@votingworks/image-utils':
         specifier: workspace:*
         version: link:../../../libs/image-utils


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6789

Wiring up VxMark to mark pre-printed ballots using the new `generateMarkOverlay` utility. By default, VxMark will continue to print summary ballots and will switch to printing bubble marks when the [print mode toggle](https://github.com/votingworks/vxsuite/pull/6810) is flipped (which updates the `elections.print_mode` flag in the DB).

### TODO:
- We'll need a way to calibrate x/y offsets for a given machine when generating the bubble mark overlay - will be following up with updates to enable that

## Demo Video or Screenshot
| Front | Back |
| - | - |
| ![IMG_5071 Large](https://github.com/user-attachments/assets/865bafd3-5890-4367-8dfb-d004553e1fd3) | ![IMG_5072 Large](https://github.com/user-attachments/assets/7b88e3d1-44f9-489e-bd53-af41da4d5f81) |
| ![IMG_5073 Large](https://github.com/user-attachments/assets/2af92a95-0591-42bc-9844-85f585d9c7b2) | ![IMG_5074 Large](https://github.com/user-attachments/assets/e5f37903-b2b3-47f7-b5d0-5db3aa4e1198) |
| ![IMG_5075 Large](https://github.com/user-attachments/assets/0614e745-e9ad-4ed3-8cc9-7dd94069dd22) | ![IMG_5076 Large](https://github.com/user-attachments/assets/419133c4-1948-4c8b-aa47-f376503da7ef) |

## Testing Plan
- New unit tests + manual VM test prints on letter and legal paper
- Planning on adding interpretation tests for `generateMarkOverlay` eventually

## Checklist

<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
