### PR TITLE
fix(hwta): enable scanning on startup

### DIFF
--- a/apps/scan/backend/src/electrical_testing/tasks/print_and_scan_task.ts
+++ b/apps/scan/backend/src/electrical_testing/tasks/print_and_scan_task.ts
@@ -202,6 +202,7 @@ export async function runPrintAndScanTask({
               );
             }
           });
+          await scannerClient.enableScanning();
           await scannerClient.ejectAndRescanPaperIfPresent();
 
           workspace.store.setElectricalTestingStatusMessage(
@@ -222,6 +223,7 @@ export async function runPrintAndScanTask({
         DateTime.now().diff(lastScanTime).as('milliseconds') >
           DELAY_AFTER_ACCEPT_MS
       ) {
+        await scannerClient.enableScanning();
         await scannerClient.ejectAndRescanPaperIfPresent();
 
         workspace.store.setElectricalTestingStatusMessage(


### PR DESCRIPTION
## Overview

#6799 broke scanning with the VxScan HWTA because it removed the line to enable scanning. This adds it back. Additional testing showed that the scanner would also stop accepting sheets if the initially-inserted one was removed. This fixes that as well.

## Demo Video or Screenshot
n/a

## Testing Plan
Tested manually with both the initial scan as well as removing the sheet and re-inserting it.