### PR TITLE
test(pollbook): suppress expected errors

### DIFF
--- a/apps/pollbook/backend/src/app.test.ts
+++ b/apps/pollbook/backend/src/app.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import { electionSimpleSinglePrecinctFixtures } from '@votingworks/fixtures';
 import { assert } from 'node:console';
 import { CITIZEN_THERMAL_PRINTER_CONFIG } from '@votingworks/printing';
+import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import {
   constructElectionKey,
   DEFAULT_SYSTEM_SETTINGS,
@@ -224,14 +225,16 @@ test('checking in a voter does not allow ballot party during a general', async (
     expect((votersAbigail as Voter[]).length).toEqual(3);
     const firstVoter = (votersAbigail as Voter[])[0];
 
-    await expect(
-      localApiClient.checkInVoter({
-        voterId: firstVoter.voterId,
-        identificationMethod: { type: 'default' },
-        ballotParty: 'REP',
-      })
-    ).rejects.toThrow(
-      'Check-in ballot party cannot be provided during a general election'
+    await suppressingConsoleOutput(() =>
+      expect(
+        localApiClient.checkInVoter({
+          voterId: firstVoter.voterId,
+          identificationMethod: { type: 'default' },
+          ballotParty: 'REP',
+        })
+      ).rejects.toThrow(
+        'Check-in ballot party cannot be provided during a general election'
+      )
     );
   });
 });

--- a/apps/pollbook/backend/src/app_multi_precinct_election.test.ts
+++ b/apps/pollbook/backend/src/app_multi_precinct_election.test.ts
@@ -3,6 +3,7 @@ import { electionMultiPartyPrimaryFixtures } from '@votingworks/fixtures';
 import { assert } from 'node:console';
 import { CITIZEN_THERMAL_PRINTER_CONFIG } from '@votingworks/printing';
 import { BatteryInfo } from '@votingworks/backend';
+import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import { TEST_MACHINE_ID, withApp } from '../test/app';
 import {
   parseValidStreetsFromCsvString,
@@ -690,13 +691,15 @@ test('in a primary, a declared voter must check in with a party selection matchi
       party: 'REP',
     });
 
-    await expect(
-      localApiClient.checkInVoter({
-        voterId: registerOk.voterId,
-        identificationMethod: { type: 'default' },
-        ballotParty: 'DEM',
-      })
-    ).rejects.toThrow('Expected check-in party DEM to match voter party REP');
+    await suppressingConsoleOutput(() =>
+      expect(
+        localApiClient.checkInVoter({
+          voterId: registerOk.voterId,
+          identificationMethod: { type: 'default' },
+          ballotParty: 'DEM',
+        })
+      ).rejects.toThrow('Expected check-in party DEM to match voter party REP')
+    );
 
     const checkInResult = await localApiClient.checkInVoter({
       voterId: registerOk.voterId,


### PR DESCRIPTION
## Overview
When testing it is not helpful to see the grout error messages logged to the console unconditionally. If the messages are different, we'll get an expectation failure in the test.

## Demo Video or Screenshot

**Before:**
```
stderr | src/app_multi_precinct_election.test.ts > in a primary, a declared voter must check in with a party selection matching the declared party
Error: Expected check-in party DEM to match voter party REP
    at assert (/home/brian/code/vxsuite/libs/basics/build/assert.js:14:15)
    at checkInVoter (/home/brian/code/vxsuite/apps/pollbook/backend/src/app.ts:288:13)
    at /home/brian/code/vxsuite/libs/grout/build/server.js:130:32
    at Layer.handle [as handle_request] (/home/brian/code/vxsuite/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/router/layer.js:95:5)
    at next (/home/brian/code/vxsuite/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/router/route.js:144:13)
    at Route.dispatch (/home/brian/code/vxsuite/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/router/route.js:114:3)
    at Layer.handle [as handle_request] (/home/brian/code/vxsuite/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/router/layer.js:95:5)
    at /home/brian/code/vxsuite/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/router/index.js:284:15
    at Function.process_params (/home/brian/code/vxsuite/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/router/index.js:346:12)
    at next (/home/brian/code/vxsuite/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/router/index.js:280:10)

 ✓ src/app_multi_precinct_election.test.ts (8 tests | 1 skipped) 11567ms
   ↓ check in a voter
   ✓ register a voter  1455ms
   ✓ change a voter name  1687ms
   ✓ change a voter mailing address - already has mailing address  1590ms
   ✓ undo a voter check-in  1770ms
   ✓ register a voter, change name and address, and check in  2207ms
   ✓ an undeclared voter cannot check in as undeclared  1314ms
   ✓ in a primary, a declared voter must check in with a party selection matching the declared party  1522ms
```
**After:**
```
✓ src/app_multi_precinct_election.test.ts (8 tests | 1 skipped) 11507ms
   ↓ check in a voter
   ✓ register a voter  1550ms
   ✓ change a voter name  1655ms
   ✓ change a voter mailing address - already has mailing address  1577ms
   ✓ undo a voter check-in  1733ms
   ✓ register a voter, change name and address, and check in  2243ms
   ✓ an undeclared voter cannot check in as undeclared  1204ms
   ✓ in a primary, a declared voter must check in with a party selection matching the declared party  1526ms

 Test Files  1 passed (1)
      Tests  7 passed | 1 skipped (8)
   Start at  15:24:12
   Duration  13.83s
```

## Testing Plan
Automated.