### PR TITLE
[Mark] Add temporary print calibration controls for testing/demo prep

### DIFF
--- a/apps/mark/backend/schema.sql
+++ b/apps/mark/backend/schema.sql
@@ -12,6 +12,14 @@ create table election (
   created_at timestamp not null default current_timestamp
 );
 
+-- Temporary dev table:
+create table print_calibration (
+  -- enforce singleton table
+  id integer primary key check (id = 1),
+  offset_mm_x real not null,
+  offset_mm_y real not null
+);
+
 create table system_settings (
   -- enforce singleton table
   id integer primary key check (id = 1),

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -48,7 +48,7 @@ import {
 } from '@votingworks/printing';
 import { createApp } from '../test/app_helpers';
 import { Api } from './app';
-import { ElectionState, PrintMode } from '.';
+import { ElectionState, PrintCalibration, PrintMode } from '.';
 import { isAccessibleControllerAttached } from './util/accessible_controller';
 
 const electionGeneralDefinition =
@@ -525,4 +525,17 @@ test('print mode get and set', async () => {
   await apiClient.setPrintMode({ mode: 'bubble_marks' });
 
   expect(await apiClient.getPrintMode()).toEqual<PrintMode>('bubble_marks');
+});
+
+test('print calibration', async () => {
+  expect(await apiClient.getPrintCalibration()).toEqual<PrintCalibration>({
+    offsetMmX: 0,
+    offsetMmY: 0,
+  });
+
+  await apiClient.setPrintCalibration({ offsetMmX: 1.5, offsetMmY: 0.5 });
+  expect(await apiClient.getPrintCalibration()).toEqual<PrintCalibration>({
+    offsetMmX: 1.5,
+    offsetMmY: 0.5,
+  });
 });

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -38,6 +38,7 @@ import {
 import { LogEventId, Logger } from '@votingworks/logging';
 import { UsbDrive, UsbDriveStatus } from '@votingworks/usb-drive';
 import { Printer } from '@votingworks/printing';
+import { PrintCalibration } from '@votingworks/hmpb';
 import { getMachineConfig } from './machine_config';
 import { Workspace } from './util/workspace';
 import { ElectionState, PrintBallotProps, PrintMode } from './types';
@@ -306,6 +307,14 @@ export function buildApi(
 
     setPrintMode(input: { mode: PrintMode }) {
       store.setPrintMode(input.mode);
+    },
+
+    getPrintCalibration(): PrintCalibration {
+      return store.getPrintCalibration();
+    },
+
+    setPrintCalibration(input: PrintCalibration) {
+      store.setPrintCalibration(input);
     },
   });
 }

--- a/apps/mark/backend/src/index.ts
+++ b/apps/mark/backend/src/index.ts
@@ -8,6 +8,7 @@ import { MARK_WORKSPACE, PORT } from './globals';
 import { createWorkspace, Workspace } from './util/workspace';
 
 export type { Api } from './app';
+export type { PrintCalibration } from '@votingworks/hmpb';
 export * from './types';
 
 loadEnvVarsFromDotenvFiles();

--- a/apps/mark/backend/src/util/print_ballot.test.tsx
+++ b/apps/mark/backend/src/util/print_ballot.test.tsx
@@ -3,7 +3,7 @@ import Stream from 'node:stream';
 import { Buffer } from 'node:buffer';
 
 import { electionGeneralFixtures } from '@votingworks/fixtures';
-import { generateMarkOverlay } from '@votingworks/hmpb';
+import { generateMarkOverlay, PrintCalibration } from '@votingworks/hmpb';
 import {
   ElectionDefinition,
   HmpbBallotPaperSize,
@@ -46,11 +46,16 @@ describe(`printMode === "bubble_marks"`, () => {
       bar: [{ id: 'one', name: 'Hon. One III' }],
     };
 
+    const mockCalibration: PrintCalibration = {
+      offsetMmX: 0.5,
+      offsetMmY: -0.5,
+    };
     vi.mocked(generateMarkOverlay).mockImplementation(
-      (election, ballotStyleId, votes) => {
+      (election, ballotStyleId, votes, calibration) => {
         expect(election).toEqual(electionDefinition.election);
         expect(ballotStyleId).toEqual(ballotStyle.id);
         expect(votes).toEqual(mockVotes);
+        expect(calibration).toEqual(mockCalibration);
 
         return Stream.Readable.from([
           Buffer.of(0xca, 0xfe),
@@ -70,6 +75,7 @@ describe(`printMode === "bubble_marks"`, () => {
           electionDefinition,
           electionPackageHash: 'unused',
         }),
+        getPrintCalibration: () => mockCalibration,
         getPrintMode: () => 'bubble_marks',
       }),
       votes: mockVotes,

--- a/apps/mark/backend/src/util/print_ballot.tsx
+++ b/apps/mark/backend/src/util/print_ballot.tsx
@@ -48,7 +48,7 @@ export async function printBallot(p: PrintBallotProps): Promise<void> {
   });
 }
 
-export async function printMarkOverlay(p: PrintBallotProps): Promise<void> {
+async function printMarkOverlay(p: PrintBallotProps): Promise<void> {
   const { electionDefinition } = assertDefined(p.store.getElectionRecord());
   const { election } = electionDefinition;
 
@@ -58,7 +58,12 @@ export async function printMarkOverlay(p: PrintBallotProps): Promise<void> {
     `${size} paper size not yet supported for pre-printed ballot marking`
   );
 
-  const stream = generateMarkOverlay(election, p.ballotStyleId, p.votes);
+  const stream = generateMarkOverlay(
+    election,
+    p.ballotStyleId,
+    p.votes,
+    p.store.getPrintCalibration()
+  );
 
   const chunks: Buffer[] = [];
   for await (const chunk of stream) {

--- a/apps/mark/frontend/src/api.ts
+++ b/apps/mark/frontend/src/api.ts
@@ -277,6 +277,28 @@ export const setPrintMode = {
   },
 } as const;
 
+export const getPrintCalibration = {
+  queryKey: (): QueryKey => ['getPrintCalibration'],
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () => apiClient.getPrintCalibration());
+  },
+} as const;
+
+// istanbul ignore next - WIP @preserve
+export const setPrintCalibration = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+
+    return useMutation(apiClient.setPrintCalibration, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getPrintCalibration.queryKey());
+      },
+    });
+  },
+} as const;
+
 export const configureElectionPackageFromUsb = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/mark/frontend/src/components/bubble_mark_calibration.tsx
+++ b/apps/mark/frontend/src/components/bubble_mark_calibration.tsx
@@ -1,0 +1,79 @@
+/* istanbul ignore file - temporary dev/demo component @preserve */
+
+import React from 'react';
+import styled from 'styled-components';
+
+import { PrintCalibration } from '@votingworks/mark-backend';
+import { Button, buttonStyles, Font } from '@votingworks/ui';
+
+import * as api from '../api';
+
+const Container = styled.div`
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  padding: 0 0.5rem;
+`;
+
+const Controls = styled.div`
+  > input {
+    ${buttonStyles} /* Hack to match button height and border styling */
+    border-left: 0;
+    border-radius: 0;
+    border-right: 0;
+    width: 5.5rem;
+  }
+
+  > button:first-child {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
+  }
+
+  > button:last-child {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+`;
+
+interface BubbleMarkCalibrationProps {
+  field: keyof PrintCalibration;
+  label?: string;
+}
+
+const DELTA_MM = 0.5;
+
+export function BubbleMarkCalibration(
+  props: BubbleMarkCalibrationProps
+): React.ReactNode {
+  const { field, label } = props;
+
+  const printCalibration = api.getPrintCalibration.useQuery().data;
+  const setPrintCalibration = api.setPrintCalibration.useMutation().mutate;
+
+  if (!printCalibration) return null;
+
+  const valMinus: PrintCalibration = {
+    ...printCalibration,
+    [field]: printCalibration[field] - DELTA_MM,
+  };
+  const valPlus: PrintCalibration = {
+    ...printCalibration,
+    [field]: printCalibration[field] + DELTA_MM,
+  };
+
+  return (
+    <Container>
+      <Font weight="bold">{label}:</Font>
+      <Controls>
+        <Button onPress={setPrintCalibration} value={valMinus}>
+          &minus;
+        </Button>
+        <input value={`${printCalibration[field].toFixed(1)} mm`} />
+        <Button onPress={setPrintCalibration} value={valPlus}>
+          +
+        </Button>
+      </Controls>
+    </Container>
+  );
+}

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -38,6 +38,7 @@ import {
   setTestMode,
 } from '../api';
 import * as api from '../api';
+import { BubbleMarkCalibration } from '../components/bubble_mark_calibration';
 
 export interface AdminScreenProps {
   appPrecinct?: PrecinctSelection;
@@ -168,6 +169,16 @@ export function AdminScreen({
                     selectedOptionId={printMode || 'summary'}
                   />
                 </Section>
+                {/* istanbul ignore next - temporary @preserve */}
+                {printMode === 'bubble_marks' && (
+                  <React.Fragment>
+                    <H6 as="h2">Bubble Mark Offset Calibration</H6>
+                    <Section style={{ marginTop: '0.5rem' }}>
+                      <BubbleMarkCalibration field="offsetMmX" label="X" />
+                      <BubbleMarkCalibration field="offsetMmY" label="Y" />
+                    </Section>
+                  </React.Fragment>
+                )}
               </React.Fragment>
             )}
           </React.Fragment>

--- a/apps/mark/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark/frontend/test/helpers/mock_api_client.tsx
@@ -101,6 +101,10 @@ export function createApiMock() {
     .expectOptionalRepeatedCallsWith()
     .resolves('summary');
 
+  mockApiClient.getPrintCalibration
+    .expectOptionalRepeatedCallsWith()
+    .resolves({ offsetMmX: 0, offsetMmY: 0 });
+
   function setAuthStatus(authStatus: InsertedSmartCardAuth.AuthStatus): void {
     mockApiClient.getAuthStatus.mockImplementation(() =>
       Promise.resolve(authStatus)

--- a/libs/hmpb/src/marking.test.ts
+++ b/libs/hmpb/src/marking.test.ts
@@ -25,7 +25,8 @@ test('places marks consistently', async () => {
   const overlayStream = generateMarkOverlay(
     election.unsafeUnwrap(),
     fixture.ballotStyleId,
-    fixture.votes
+    fixture.votes,
+    { offsetMmX: 0, offsetMmY: 0 }
   );
 
   const overlayPdf = await new Promise<Uint8Array>((resolve, reject) => {

--- a/libs/hmpb/src/types.ts
+++ b/libs/hmpb/src/types.ts
@@ -27,3 +27,8 @@ export type InchMargins = Margins<Inches>;
 
 export const BALLOT_MODES = ['official', 'test', 'sample'] as const;
 export type BallotMode = (typeof BALLOT_MODES)[number];
+
+export interface PrintCalibration {
+  offsetMmX: number;
+  offsetMmY: number;
+}


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6789

When we flesh out the ballot marking feature, we're going to have a flow for calibrating individual printers against pre-printed ballots, which will likely involve setting x/y offsets (and maybe, if there's a need, scaling up/down the grid).

We don't need that all in place for demos, but there's a chance we'll need to adjust offsets slightly as we test/prep. Adding some temporary controls for making those adjustments to the Election Manager screen for now. These show up when the "Bubble Marks" print mode is selected (which is only visible when the `REACT_APP_VX_MARK_ENABLE_BALLOT_PRINT_MODE_TOGGLE` feature flag is enabled).

## Demo Video or Screenshot

https://github.com/user-attachments/assets/51a24abc-07d9-4a95-8453-d72278b57c1b

### Sample print with off-target offsets applied:

<img width="350" src="https://github.com/user-attachments/assets/56dc5787-9742-4662-9e20-358d9249659b" />

## Testing Plan
- Mostly manual for now  - short-lived component. We'll likely have a proper calibration flow when we build out the full feature, so most of this will be changing.

## Checklist

<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
