### PR TITLE
clean up avahi services after tests

### DIFF
--- a/apps/pollbook/backend/test/app.ts
+++ b/apps/pollbook/backend/test/app.ts
@@ -35,6 +35,7 @@ import { LocalWorkspace, PeerWorkspace } from '../src';
 import { getUserRole } from '../src/auth';
 import { buildPeerApp, PeerApi } from '../src/peer_app';
 import { BarcodeScannerClient } from '../src/barcode_scanner/client';
+import { AvahiService } from '../src/avahi';
 
 vi.mock('../barcode_scanner/client', () => ({
   BarcodeScannerClient: vi.fn().mockImplementation(() => ({
@@ -188,6 +189,7 @@ export async function withApp(
   } finally {
     // wait for paper backup export to finish?
     await new Promise<void>((resolve, reject) => {
+      AvahiService.stopAdvertisedService();
       localServer.close((error) => (error ? reject(error) : resolve()));
       peerServer.close((error) => (error ? reject(error) : resolve()));
     });
@@ -293,6 +295,7 @@ export async function withManyApps(
   } finally {
     for (const context of contexts) {
       await new Promise<void>((resolve, reject) => {
+        AvahiService.stopAdvertisedService();
         context.localServer.close((error) =>
           error ? reject(error) : resolve()
         );


### PR DESCRIPTION
When the pollbooks announce to the network that they exist for discovery by other pollbooks it requires calling and leaving open this process with avahi. The backend index.ts file when running the app either in dev or in production will close this thread on exit but the tests are operating slightly downstream from that logic and need to remember to clean this up at the end of their runs. 