### PR TITLE
Update running process varaible to be a map

### DIFF
--- a/apps/pollbook/backend/test/app.ts
+++ b/apps/pollbook/backend/test/app.ts
@@ -294,8 +294,9 @@ export async function withManyApps(
     }
   } finally {
     for (const context of contexts) {
+      const serviceName = `Pollbook-test-${contexts.indexOf(context)}`;
       await new Promise<void>((resolve, reject) => {
-        AvahiService.stopAdvertisedService();
+        AvahiService.stopAdvertisedService(serviceName);
         context.localServer.close((error) =>
           error ? reject(error) : resolve()
         );


### PR DESCRIPTION
As discussed there was an issue with how this runningProcess variable was handled in conjunction with the withManyApps test helper. In real life there should only be one pollbook app running per machine and using a static variable here is fine but the withManyApps helper creates multiple instances of the app within a process. The test behavior seems unchanged by this change to ensure that the mutlitple apps have their own publish-service thread running but its possible this could help alleviate some of the flakiness issues we've been seeing. 