### PR TITLE
Kevin/pollbook daemon log on successful scan

### DIFF
--- a/apps/pollbook/barcode-scanner-daemon/src/unitech_ts100_daemon.rs
+++ b/apps/pollbook/barcode-scanner-daemon/src/unitech_ts100_daemon.rs
@@ -280,6 +280,12 @@ where
                     }
                 };
 
+                log!(
+                    event_id: EventId::BarcodeScanned,
+                    message: format!("An ID in AAMVA format was successfully scanned"),
+                    event_type: EventType::SystemAction,
+                    disposition: Disposition::Success
+                );
                 if let Err(err) = broadcast_to_clients(&clients, &doc).await {
                     log!(
                         EventId::SocketServerError,

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -971,3 +971,8 @@ documentationMessage = "A socket server is awaiting a client."
 eventId = "socket-server-error"
 eventType = "application-status"
 documentationMessage = "An error was reported by a socket server."
+
+[Events.BarcodeScanned]
+eventId = "barcode-scanned"
+eventType = "application-status"
+documentationMessage = "A barcode was scanned."

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -214,6 +214,7 @@ export enum LogEventId {
   SocketServerClose = 'socket-server-close',
   SocketServerAwaitingClient = 'socket-server-awaiting-client',
   SocketServerError = 'socket-server-error',
+  BarcodeScanned = 'barcode-scanned',
 }
 
 const ElectionConfigured: LogDetails = {
@@ -1319,6 +1320,12 @@ const SocketServerError: LogDetails = {
   documentationMessage: 'An error was reported by a socket server.',
 };
 
+const BarcodeScanned: LogDetails = {
+  eventId: LogEventId.BarcodeScanned,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage: 'A barcode was scanned.',
+};
+
 export function getDetailsForEventId(eventId: LogEventId): LogDetails {
   switch (eventId) {
     case LogEventId.ElectionConfigured:
@@ -1623,6 +1630,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return SocketServerAwaitingClient;
     case LogEventId.SocketServerError:
       return SocketServerError;
+    case LogEventId.BarcodeScanned:
+      return BarcodeScanned;
     default:
       throwIllegalValue(eventId);
   }

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -411,5 +411,7 @@ pub enum EventId {
     SocketServerAwaitingClient,
     #[serde(rename = "socket-server-error")]
     SocketServerError,
+    #[serde(rename = "barcode-scanned")]
+    BarcodeScanned,
 }
 derive_display!(EventId);


### PR DESCRIPTION
## Overview

Adds a log for successful ID scan.

## Demo Video or Screenshot

Success:

<img width="1453" height="290" alt="Screenshot 2025-07-23 at 4 14 16 PM" src="https://github.com/user-attachments/assets/0545acf4-e743-4914-9e66-a160d79623b0" />

For good measure, scan of a non-ID barcode:
<img width="1457" height="292" alt="Screenshot 2025-07-23 at 4 14 37 PM" src="https://github.com/user-attachments/assets/328ac6f0-bdc2-462b-b32d-aaca6d8d9898" />


## Testing Plan
Manual testing
