### PR TITLE
VxDesign: Migration to remove compact template IDs

### DIFF
--- a/apps/design/backend/migrations/1753724000020_remove-compact-template-ids.js
+++ b/apps/design/backend/migrations/1753724000020_remove-compact-template-ids.js
@@ -1,0 +1,21 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  // Replace the compact ballot template IDs with the standard template IDs for
+  // those templates. This should have been done in the add-ballot-compact
+  // migration, but was forgotten.
+  pgm.sql(
+    `UPDATE elections SET ballot_template_id = 'NhBallot' WHERE ballot_template_id = 'NhBallotCompact'`
+  );
+  pgm.sql(
+    `UPDATE elections SET ballot_template_id = 'NhBallotV3' WHERE ballot_template_id = 'NhBallotV3Compact'`
+  );
+};


### PR DESCRIPTION
## Overview

In https://github.com/votingworks/vxsuite/pull/6711, I removed support for the NhBallotV3Compact and NhBallotCompact template IDs, instead adding a `ballot_compact` boolean flag. While I added a migration to add the flag, I forgot to also update the template IDs in that migration. This PR adds a new migration to fix this.

## Demo Video or Screenshot
N/A

## Testing Plan
Ran against a db snapshot

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
