### PR TITLE
VxDesign feature flag cleanup

### DIFF
--- a/apps/design/backend/src/features.ts
+++ b/apps/design/backend/src/features.ts
@@ -159,7 +159,7 @@ export const userFeatureConfigs = {
     ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
 
     SYSTEM_SETTINGS_SCREEN: true,
-    ENABLE_BMD_BALLOT_SCANNING_ON_VXSCAN_OPTION: false,
+    ENABLE_BMD_BALLOT_SCANNING_ON_VXSCAN_OPTION: true,
     MINIMUM_DETECTED_SCALE_OPTION: false,
 
     EXPORT_SCREEN: true,
@@ -184,9 +184,7 @@ export const userFeatureConfigs = {
 
     EXPORT_SCREEN: false,
     CHOOSE_BALLOT_TEMPLATE: false,
-    // EXPORT_TEST_DECKS is currently a no-op because export screen is off, but NH users should be able
-    // to export test decks when export screen is turned on.
-    EXPORT_TEST_DECKS: true,
+    EXPORT_TEST_DECKS: false,
   },
 } satisfies Record<string, UserFeaturesConfig>;
 

--- a/apps/design/backend/src/features.ts
+++ b/apps/design/backend/src/features.ts
@@ -109,72 +109,84 @@ export type ElectionFeaturesConfig = Record<ElectionFeature, boolean>;
 export const userFeatureConfigs = {
   vx: {
     ACCESS_ALL_ORGS: true,
-    SYSTEM_SETTINGS_SCREEN: true,
-    EXPORT_SCREEN: true,
-    CHOOSE_BALLOT_TEMPLATE: true,
-    EXPORT_TEST_DECKS: true,
-    ENABLE_BMD_BALLOT_SCANNING_ON_VXSCAN_OPTION: true,
-    MINIMUM_DETECTED_SCALE_OPTION: true,
-    ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
+
     CREATE_ELECTION: true,
     DELETE_ELECTION: true,
     CREATE_DELETE_DISTRICTS: true,
     CREATE_DELETE_PRECINCTS: true,
     CREATE_DELETE_PRECINCT_SPLITS: true,
     BALLOT_LANGUAGE_CONFIG: true,
+    ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
+
+    SYSTEM_SETTINGS_SCREEN: true,
+    ENABLE_BMD_BALLOT_SCANNING_ON_VXSCAN_OPTION: true,
+    MINIMUM_DETECTED_SCALE_OPTION: true,
+
+    EXPORT_SCREEN: true,
+    CHOOSE_BALLOT_TEMPLATE: true,
+    EXPORT_TEST_DECKS: true,
   },
 
   sli: {
     ACCESS_ALL_ORGS: false,
-    SYSTEM_SETTINGS_SCREEN: true,
-    ENABLE_BMD_BALLOT_SCANNING_ON_VXSCAN_OPTION: false,
-    MINIMUM_DETECTED_SCALE_OPTION: false,
-    EXPORT_SCREEN: true,
-    CHOOSE_BALLOT_TEMPLATE: false,
-    EXPORT_TEST_DECKS: false,
-    ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
+
     CREATE_ELECTION: true,
     DELETE_ELECTION: true,
     CREATE_DELETE_DISTRICTS: true,
     CREATE_DELETE_PRECINCTS: true,
     CREATE_DELETE_PRECINCT_SPLITS: true,
     BALLOT_LANGUAGE_CONFIG: true,
+    ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
+
+    SYSTEM_SETTINGS_SCREEN: true,
+    ENABLE_BMD_BALLOT_SCANNING_ON_VXSCAN_OPTION: false,
+    MINIMUM_DETECTED_SCALE_OPTION: false,
+
+    EXPORT_SCREEN: true,
+    CHOOSE_BALLOT_TEMPLATE: false,
+    EXPORT_TEST_DECKS: false,
   },
 
   demos: {
     ACCESS_ALL_ORGS: false,
-    SYSTEM_SETTINGS_SCREEN: true,
-    ENABLE_BMD_BALLOT_SCANNING_ON_VXSCAN_OPTION: false,
-    MINIMUM_DETECTED_SCALE_OPTION: false,
-    EXPORT_SCREEN: true,
-    CHOOSE_BALLOT_TEMPLATE: true,
-    EXPORT_TEST_DECKS: true,
-    ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
+
     CREATE_ELECTION: true,
     DELETE_ELECTION: true,
     CREATE_DELETE_DISTRICTS: true,
     CREATE_DELETE_PRECINCTS: true,
     CREATE_DELETE_PRECINCT_SPLITS: true,
     BALLOT_LANGUAGE_CONFIG: true,
+    ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
+
+    SYSTEM_SETTINGS_SCREEN: true,
+    ENABLE_BMD_BALLOT_SCANNING_ON_VXSCAN_OPTION: false,
+    MINIMUM_DETECTED_SCALE_OPTION: false,
+
+    EXPORT_SCREEN: true,
+    CHOOSE_BALLOT_TEMPLATE: true,
+    EXPORT_TEST_DECKS: true,
   },
 
   nh: {
     ACCESS_ALL_ORGS: false,
-    SYSTEM_SETTINGS_SCREEN: false,
-    ENABLE_BMD_BALLOT_SCANNING_ON_VXSCAN_OPTION: false,
-    MINIMUM_DETECTED_SCALE_OPTION: false,
-    EXPORT_SCREEN: false,
-    CHOOSE_BALLOT_TEMPLATE: false,
-    // EXPORT_TEST_DECKS is currently a no-op because export screen is off, but NH users should be able
-    // to export test decks when export screen is turned on.
-    EXPORT_TEST_DECKS: true,
-    ONLY_LETTER_AND_LEGAL_PAPER_SIZES: true,
+
     CREATE_ELECTION: false,
     DELETE_ELECTION: false,
     CREATE_DELETE_DISTRICTS: false,
     CREATE_DELETE_PRECINCTS: false,
     CREATE_DELETE_PRECINCT_SPLITS: false,
     BALLOT_LANGUAGE_CONFIG: false,
+    ONLY_LETTER_AND_LEGAL_PAPER_SIZES: true,
+
+    SYSTEM_SETTINGS_SCREEN: false,
+    ENABLE_BMD_BALLOT_SCANNING_ON_VXSCAN_OPTION: false,
+    MINIMUM_DETECTED_SCALE_OPTION: false,
+
+    EXPORT_SCREEN: false,
+    CHOOSE_BALLOT_TEMPLATE: false,
+    // EXPORT_TEST_DECKS is currently a no-op because export screen is off, but NH users should be able
+    // to export test decks when export screen is turned on.
+    EXPORT_TEST_DECKS: true,
   },
 } satisfies Record<string, UserFeaturesConfig>;
 


### PR DESCRIPTION
## Overview

I initially opened this PR to set `ENABLE_BMD_BALLOT_SCANNING_ON_VXSCAN_OPTION` to `true` for the Vx demos org to enable demoing VxMark ballot scanning on VxScan. But while I was at it, I also reorganized the feature flag configs to have consistent orders across orgs. Made gauging what's enabled vs. not just a little bit easier.