### PR TITLE
Use default react stale time timeout 

### DIFF
--- a/apps/pollbook/frontend/src/api.ts
+++ b/apps/pollbook/frontend/src/api.ts
@@ -44,7 +44,7 @@ export function createQueryClient(): QueryClient {
       ...QUERY_CLIENT_DEFAULT_OPTIONS,
       queries: {
         ...defaultQueryOptions,
-        staleTime: DEFAULT_QUERY_REFETCH_INTERVAL,
+        staleTime: 0, // reset to the default behavior of a stale time of 0
       },
     },
   });

--- a/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
+++ b/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
@@ -54,11 +54,12 @@ describe('PollWorkerScreen', () => {
     apiMock.expectGetDeviceStatuses();
     apiMock.authenticateAsPollWorker(famousNamesElection);
     apiMock.setElection(famousNamesElectionDefinition);
+    apiMock.setIsAbsenteeMode(false);
     const { unmount } = render(<App apiClient={apiMock.mockApiClient} />);
     await screen.findByText('Connect printer to continue.');
 
     apiMock.setPrinterStatus(true);
-    apiMock.setIsAbsenteeMode(false);
+    vi.advanceTimersByTime(100);
     await screen.findByText('No Precinct Selected');
 
     apiMock.setElection(

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -188,7 +188,7 @@ export function createApiMock() {
     expectHaveElectionEventsOccurred(hasEvents: boolean = false): void {
       mockApiClient.haveElectionEventsOccurred.reset();
       mockApiClient.haveElectionEventsOccurred
-        .expectCallWith()
+        .expectRepeatedCallsWith()
         .resolves(hasEvents);
     },
 
@@ -312,7 +312,7 @@ export function createApiMock() {
 
     expectSetConfiguredPrecinct(configuredPrecinctId: string, error?: Error) {
       mockApiClient.setConfiguredPrecinct
-        .expectCallWith({ precinctId: configuredPrecinctId })
+        .expectOptionalRepeatedCallsWith({ precinctId: configuredPrecinctId })
         .resolves(error === undefined ? ok() : err(error));
       if (error === undefined) {
         mockApiClient.getPollbookConfigurationInformation.reset();
@@ -331,7 +331,9 @@ export function createApiMock() {
     },
 
     setIsAbsenteeMode(isAbsenteeMode: boolean) {
-      mockApiClient.getIsAbsenteeMode.expectCallWith().resolves(isAbsenteeMode);
+      mockApiClient.getIsAbsenteeMode
+        .expectRepeatedCallsWith()
+        .resolves(isAbsenteeMode);
     },
 
     setMachineLockedStatus,
@@ -382,7 +384,7 @@ export function createApiMock() {
     expectGetVoter(voter: Voter) {
       mockApiClient.getVoter.reset();
       mockApiClient.getVoter
-        .expectCallWith({
+        .expectOptionalRepeatedCallsWith({
           voterId: voter.voterId,
         })
         .resolves(voter);


### PR DESCRIPTION
## Overview
Resets the value for the stale time to the default of 0. See https://github.com/votingworks/vxsuite/pull/6848 for original context. @jonahkagan pointed out that the default is 0 and we should default to that unless there is a good reason for another value (as in the case with the rest of vxsuite). 
<!-- add a link to a GitHub Issue here -->

Tested by making sure changes between pollbooks propagated on the election manager voter details page. 