### PR TITLE
feat(htwa-scan): add stats & scanning mode to UI

### DIFF
--- a/apps/scan/backend/src/electrical_testing/app.ts
+++ b/apps/scan/backend/src/electrical_testing/app.ts
@@ -6,7 +6,7 @@ import express, { Application } from 'express';
 import { mkdir, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { getMachineConfig } from '../machine_config';
-import { type ServerContext } from './context';
+import { type ScanningMode, type ServerContext } from './context';
 import { SoundName, Player as AudioPlayer } from '../audio/player';
 
 type ApiContext = ServerContext & {
@@ -55,7 +55,11 @@ function buildApi({
           ? { ...printerMessage, taskStatus: printerTask.getStatus() }
           : undefined,
         scanner: scannerMessage
-          ? { ...scannerMessage, taskStatus: scannerTask.getStatus() }
+          ? {
+              ...scannerMessage,
+              taskStatus: scannerTask.getStatus(),
+              mode: scannerTask.getInput().mode,
+            }
           : undefined,
       };
     },
@@ -110,6 +114,10 @@ function buildApi({
       } else {
         scannerTask.pause();
       }
+    },
+
+    setScannerTaskMode(input: { mode: ScanningMode }): void {
+      scannerTask.setInput({ mode: input.mode });
     },
 
     async getLatestScannedSheet(): Promise<SheetOf<string> | null> {

--- a/apps/scan/backend/src/electrical_testing/context.ts
+++ b/apps/scan/backend/src/electrical_testing/context.ts
@@ -6,12 +6,18 @@ import { Printer } from '../printing/printer';
 import { Workspace } from '../util/workspace';
 import { SimpleScannerClient } from './simple_scanner_client';
 
+export type ScanningMode =
+  | 'shoe-shine'
+  | 'manual-front'
+  | 'manual-rear'
+  | 'disabled';
+
 export interface ServerContext {
   auth: InsertedSmartCardAuthApi;
-  cardTask: TaskController<string>;
-  usbDriveTask: TaskController<string>;
-  printerTask: TaskController<string>;
-  scannerTask: TaskController<string>;
+  cardTask: TaskController<void, string>;
+  usbDriveTask: TaskController<void, string>;
+  printerTask: TaskController<void, string>;
+  scannerTask: TaskController<{ mode: ScanningMode }, string>;
   logger: Logger;
   printer: Printer;
   scannerClient: SimpleScannerClient;

--- a/apps/scan/backend/src/electrical_testing/simple_scanner_client.ts
+++ b/apps/scan/backend/src/electrical_testing/simple_scanner_client.ts
@@ -1,6 +1,7 @@
 import { assert, Optional } from '@votingworks/basics';
 import {
   createPdiScannerClient,
+  EjectMotion,
   ScannerClient,
   ScannerEvent,
 } from '@votingworks/pdi-scanner';
@@ -10,7 +11,9 @@ export interface SimpleScannerClient {
   connect(eventListener: (event: ScannerEvent) => void): Promise<void>;
   disconnect(): Promise<void>;
   enableScanning(): Promise<void>;
+  disableScanning(): Promise<void>;
   ejectAndRescanPaperIfPresent(): Promise<void>;
+  ejectPaper(ejectMotion: EjectMotion): Promise<void>;
 }
 
 export function createSimpleScannerClient(): SimpleScannerClient {
@@ -47,6 +50,12 @@ export function createSimpleScannerClient(): SimpleScannerClient {
       ).unsafeUnwrap();
     },
 
+    async disableScanning() {
+      assert(client, 'Scanner client is not connected');
+
+      (await client.disableScanning()).unsafeUnwrap();
+    },
+
     async ejectAndRescanPaperIfPresent() {
       assert(client, 'Scanner client is not connected');
 
@@ -54,6 +63,16 @@ export function createSimpleScannerClient(): SimpleScannerClient {
 
       if (status.rearLeftSensorCovered || status.rearRightSensorCovered) {
         (await client.ejectDocument('toFrontAndRescan')).unsafeUnwrap();
+      }
+    },
+
+    async ejectPaper(ejectMotion: EjectMotion) {
+      assert(client, 'Scanner client is not connected');
+
+      const status = (await client.getScannerStatus()).unsafeUnwrap();
+
+      if (status.rearLeftSensorCovered || status.rearRightSensorCovered) {
+        (await client.ejectDocument(ejectMotion)).unsafeUnwrap();
       }
     },
   };

--- a/apps/scan/backend/src/electrical_testing/tasks/print_and_scan_task.ts
+++ b/apps/scan/backend/src/electrical_testing/tasks/print_and_scan_task.ts
@@ -1,5 +1,10 @@
 import { saveSheetImages } from '@votingworks/ballot-interpreter';
-import { extractErrorMessage, ok, sleep } from '@votingworks/basics';
+import {
+  extractErrorMessage,
+  ok,
+  sleep,
+  throwIllegalValue,
+} from '@votingworks/basics';
 import { LogEventId } from '@votingworks/logging';
 import { ScannerEvent } from '@votingworks/pdi-scanner';
 import { createCanvas, ImageData } from 'canvas';
@@ -12,7 +17,7 @@ import {
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
 import { writeScanPageAnalyses } from '../analysis/scan';
-import { type ServerContext } from '../context';
+import { ScanningMode, type ServerContext } from '../context';
 import { resultToString } from '../utils';
 
 export const LOOP_INTERVAL_MS = 100;
@@ -57,6 +62,7 @@ export async function runPrintAndScanTask({
   const printerTestImage = createPrinterTestImage();
   let lastScanTime: DateTime | undefined;
   let lastPrintTime: DateTime | undefined;
+  let lastMode: ScanningMode | undefined;
   let shouldResetScanning = true;
 
   async function onScannerEvent(scannerEvent: ScannerEvent) {
@@ -122,6 +128,29 @@ export async function runPrintAndScanTask({
     }
   }
 
+  async function ejectPaper() {
+    const { mode } = scannerTask.getInput();
+    switch (mode) {
+      case 'shoe-shine':
+        await scannerClient.ejectAndRescanPaperIfPresent();
+        await scannerClient.enableScanning();
+        break;
+      case 'manual-front':
+        await scannerClient.ejectPaper('toFront');
+        await scannerClient.enableScanning();
+        break;
+      case 'manual-rear':
+        await scannerClient.ejectPaper('toRear');
+        await scannerClient.enableScanning();
+        break;
+      case 'disabled':
+        await scannerClient.disableScanning();
+        break;
+      default:
+        throwIllegalValue(mode);
+    }
+  }
+
   // eslint-disable-next-line no-constant-condition
   while (true) {
     // Exit the loop if both tasks are stopped.
@@ -180,6 +209,13 @@ export async function runPrintAndScanTask({
     }
 
     if (scannerTask.isRunning()) {
+      const { mode } = scannerTask.getInput();
+
+      if (mode !== lastMode) {
+        lastMode = mode;
+        shouldResetScanning = true;
+      }
+
       if (shouldResetScanning) {
         workspace.store.setElectricalTestingStatusMessage(
           'scanner',
@@ -202,13 +238,19 @@ export async function runPrintAndScanTask({
               );
             }
           });
-          await scannerClient.enableScanning();
-          await scannerClient.ejectAndRescanPaperIfPresent();
+          await ejectPaper();
 
-          workspace.store.setElectricalTestingStatusMessage(
-            'scanner',
-            'Scanning enabled; waiting for paper'
-          );
+          if (mode === 'disabled') {
+            workspace.store.setElectricalTestingStatusMessage(
+              'scanner',
+              'Scanning disabled'
+            );
+          } else {
+            workspace.store.setElectricalTestingStatusMessage(
+              'scanner',
+              'Scanning enabled; waiting for paper'
+            );
+          }
           shouldResetScanning = false;
         } catch (error) {
           workspace.store.setElectricalTestingStatusMessage(
@@ -223,13 +265,37 @@ export async function runPrintAndScanTask({
         DateTime.now().diff(lastScanTime).as('milliseconds') >
           DELAY_AFTER_ACCEPT_MS
       ) {
-        await scannerClient.enableScanning();
-        await scannerClient.ejectAndRescanPaperIfPresent();
+        const { mode } = scannerTask.getInput();
 
-        workspace.store.setElectricalTestingStatusMessage(
-          'scanner',
-          'Ejected document to re-scan'
-        );
+        if (mode !== 'disabled') {
+          await ejectPaper();
+
+          switch (mode) {
+            case 'shoe-shine':
+              workspace.store.setElectricalTestingStatusMessage(
+                'scanner',
+                'Ejected document to re-scan'
+              );
+              break;
+
+            case 'manual-front':
+              workspace.store.setElectricalTestingStatusMessage(
+                'scanner',
+                'Ejected document to front'
+              );
+              break;
+
+            case 'manual-rear':
+              workspace.store.setElectricalTestingStatusMessage(
+                'scanner',
+                'Ejected document to rear'
+              );
+              break;
+
+            default:
+              throwIllegalValue(mode);
+          }
+        }
 
         lastScanTime = undefined;
       }

--- a/apps/scan/backend/src/index.ts
+++ b/apps/scan/backend/src/index.ts
@@ -31,6 +31,7 @@ import { createSimpleScannerClient } from './electrical_testing/simple_scanner_c
 
 export type { Api } from './app';
 export type { ElectricalTestingApi } from './electrical_testing/app';
+export type { ScanningMode } from './electrical_testing/context';
 export type {
   PrinterStatus,
   PrintResult,
@@ -86,10 +87,10 @@ async function main(): Promise<number> {
   ) {
     await startElectricalTestingServer({
       auth,
-      cardTask: TaskController.started<string>(),
-      usbDriveTask: TaskController.started<string>(),
-      printerTask: TaskController.started<string>(),
-      scannerTask: TaskController.started<string>(),
+      cardTask: TaskController.started(undefined),
+      usbDriveTask: TaskController.started(undefined),
+      printerTask: TaskController.started(undefined),
+      scannerTask: TaskController.started({ mode: 'shoe-shine' }),
       logger,
       printer,
       scannerClient: createSimpleScannerClient(),

--- a/apps/scan/frontend/src/electrical_testing/api.ts
+++ b/apps/scan/frontend/src/electrical_testing/api.ts
@@ -6,7 +6,10 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 import * as grout from '@votingworks/grout';
-import type { ElectricalTestingApi } from '@votingworks/scan-backend';
+import type {
+  ElectricalTestingApi,
+  ScanningMode,
+} from '@votingworks/scan-backend';
 import {
   createSystemCallApi,
   QUERY_CLIENT_DEFAULT_OPTIONS,
@@ -108,6 +111,26 @@ export const setScannerTaskRunning = {
     );
   },
 } as const;
+
+export const setScannerTaskMode = {
+  queryKey(): QueryKey {
+    return ['setScannerTaskMode'];
+  },
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(
+      (mode: ScanningMode) => apiClient.setScannerTaskMode({ mode }),
+      {
+        onSuccess: async () => {
+          await queryClient.invalidateQueries(
+            getElectricalTestingStatuses.queryKey()
+          );
+        },
+      }
+    );
+  },
+};
 
 export const setUsbDriveTaskRunning = {
   queryKey(): QueryKey {

--- a/apps/scan/frontend/src/electrical_testing/app.tsx
+++ b/apps/scan/frontend/src/electrical_testing/app.tsx
@@ -1,6 +1,10 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { BaseLogger, LogSource } from '@votingworks/logging';
-import { AppErrorBoundary, SystemCallContextProvider } from '@votingworks/ui';
+import {
+  AppBase,
+  AppErrorBoundary,
+  SystemCallContextProvider,
+} from '@votingworks/ui';
 
 import {
   ApiClientContext,
@@ -17,7 +21,11 @@ export function App(): JSX.Element {
   const apiClient = createApiClient();
 
   return (
-    <ScanAppBase>
+    <AppBase
+      defaultColorMode="desktop"
+      defaultSizeMode="desktop"
+      showScrollBars
+    >
       <AppErrorBoundary restartMessage="Restart the machine" logger={logger}>
         <ApiClientContext.Provider value={apiClient}>
           <QueryClientProvider client={queryClient}>
@@ -27,6 +35,6 @@ export function App(): JSX.Element {
           </QueryClientProvider>
         </ApiClientContext.Provider>
       </AppErrorBoundary>
-    </ScanAppBase>
+    </AppBase>
   );
 }

--- a/apps/scan/frontend/src/electrical_testing/app_root.tsx
+++ b/apps/scan/frontend/src/electrical_testing/app_root.tsx
@@ -1,9 +1,15 @@
 import {
   Button,
+  RadioGroup,
   Caption,
-  ElectricalTestingScreen,
+  ExportLogsModal,
+  H6,
   Icons,
+  Main,
+  Screen,
+  CheckboxGroup,
 } from '@votingworks/ui';
+import type { ScanningMode } from '@votingworks/scan-backend';
 import { DateTime } from 'luxon';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
@@ -11,6 +17,7 @@ import useInterval from 'use-interval';
 import { useSound } from '../utils/use_sound';
 import * as api from './api';
 import { SheetImagesModal } from './sheet_images_modal';
+import { iter } from '@votingworks/basics';
 
 const SOUND_INTERVAL_SECONDS = 5;
 
@@ -18,14 +25,18 @@ function CounterButton() {
   const [count, setCount] = useState(0);
 
   return (
-    <Button
-      onPress={() => setCount((prev) => prev + 1)}
-      style={{ transform: 'scale(0.5)' }}
-    >
+    <Button onPress={() => setCount((prev) => prev + 1)}>
       Tap Count: {count}
     </Button>
   );
 }
+
+const Row = styled.div<{ gap?: string }>`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${({ gap = 0 }) => gap};
+`;
 
 const Column = styled.div<{ gap?: string }>`
   display: flex;
@@ -35,11 +46,93 @@ const Column = styled.div<{ gap?: string }>`
 `;
 
 const Small = styled.span`
-  font-size: 0.45rem;
+  font-size: 0.9rem;
 `;
+
+const ExtraSmall = styled.span`
+  font-size: 0.6rem;
+`;
+
+const RadioOptionTitle = styled(H6)`
+  margin-bottom: 0;
+`;
+
+const PlayPauseButtonBase = styled.button`
+  flex-shrink: 0;
+  background-color: #ddd;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  box-shadow: 2px 2px 4px 0px #999;
+  font-size: 1rem;
+  padding: 0;
+`;
+
+function PlayPauseButton({
+  isRunning,
+  onPress,
+}: {
+  isRunning: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <PlayPauseButtonBase onClick={onPress}>
+      {isRunning ? <Icons.Pause /> : <Icons.Play />}
+    </PlayPauseButtonBase>
+  );
+}
 
 function formatTimestamp(timestamp: DateTime): string {
   return timestamp.toLocal().toFormat('h:mm:ss a MM/dd/yyyy');
+}
+
+function StatusCard({
+  title,
+  statusMessage,
+  body,
+  updatedAt,
+  isRunning,
+  onToggleRunning,
+}: {
+  title: React.ReactNode;
+  statusMessage?: React.ReactNode;
+  body?: React.ReactNode;
+  updatedAt?: DateTime;
+  isRunning?: boolean;
+  onToggleRunning?: () => void;
+}) {
+  return (
+    <Row style={{ height: '100%', alignItems: 'stretch', gap: '1em' }}>
+      {typeof isRunning === 'boolean' && onToggleRunning && (
+        <Column style={{ flexGrow: 0, alignContent: 'center' }}>
+          <PlayPauseButton isRunning={isRunning} onPress={onToggleRunning} />
+        </Column>
+      )}
+      <Column style={{ flexGrow: 1 }}>
+        <H6 style={{ flexGrow: 0 }}>{title}</H6>
+        {statusMessage && (
+          <Caption
+            style={{
+              flexGrow: 1,
+              overflowWrap: 'anywhere',
+              maxHeight: '2rem',
+              overflow: 'hidden',
+            }}
+          >
+            <Small>{statusMessage}</Small>
+          </Caption>
+        )}
+        {body && <Caption style={{ flexGrow: 1 }}>{body}</Caption>}
+        {updatedAt && (
+          <Caption style={{ flexGrow: 0 }}>
+            <ExtraSmall>{formatTimestamp(updatedAt)}</ExtraSmall>
+          </Caption>
+        )}
+      </Column>
+    </Row>
+  );
 }
 
 export function AppRoot(): JSX.Element {
@@ -54,6 +147,7 @@ export function AppRoot(): JSX.Element {
   const getLatestScannedSheetQuery = api.getLatestScannedSheet.useQuery();
   const powerDownMutation = api.systemCallApi.powerDown.useMutation();
   const [isShowingLatestSheet, setIsShowingLatestSheet] = useState(false);
+  const [isSaveLogsModalOpen, setIsSaveLogsModalOpen] = React.useState(false);
 
   const [speakerEnabled, setSpeakerEnabled] = useState(true);
   const [headphonesEnabled, setHeadphonesEnabled] = useState(true);
@@ -120,6 +214,12 @@ export function AppRoot(): JSX.Element {
     powerDownMutation.mutate();
   }
 
+  const setScannerTaskModeMutation = api.setScannerTaskMode.useMutation();
+
+  function setScanningMode(mode: ScanningMode) {
+    setScannerTaskModeMutation.mutate(mode);
+  }
+
   useInterval(
     () => playSoundSpeaker({ name: 'success' }),
     speakerEnabled ? SOUND_INTERVAL_SECONDS * 1000 : null
@@ -135,123 +235,316 @@ export function AppRoot(): JSX.Element {
   const scannerStatus = getElectricalTestingStatusMessagesQuery.data?.scanner;
 
   return (
-    <ElectricalTestingScreen
-      tasks={[
-        {
-          id: 'scanner',
-          icon: <Icons.File />,
-          title: 'Scanner',
-          body: (
-            <React.Fragment>
-              <Caption
+    <Screen>
+      <Main centerChild>
+        <Column style={{ height: '100%' }}>
+          <Column
+            style={{
+              alignItems: 'center',
+              gap: '1rem',
+              justifyContent: 'center',
+            }}
+          >
+            <Row gap="2rem">
+              <Row
+                style={{ height: '100%', alignItems: 'stretch', gap: '1em' }}
+              >
+                <Column style={{ flexGrow: 1 }}>
+                  <H6 style={{ flexGrow: 0 }}>
+                    <Icons.File /> Scanner
+                  </H6>
+                  {scannerStatus?.updatedAt && (
+                    <Caption style={{ flexGrow: 0 }}>
+                      <ExtraSmall>
+                        {formatTimestamp(scannerStatus.updatedAt)}
+                      </ExtraSmall>
+                    </Caption>
+                  )}
+                  <Caption style={{ flexGrow: 1 }}>
+                    <Caption
+                      style={{
+                        flexGrow: 1,
+                        overflowWrap: 'anywhere',
+                        maxHeight: '2rem',
+                        overflow: 'hidden',
+                      }}
+                    >
+                      <Small>{scannerStatus?.statusMessage ?? 'Unknown'}</Small>
+                    </Caption>
+                    <div
+                      style={{
+                        marginTop: '1em',
+                        right: '0',
+                        bottom: '0',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '1em',
+                      }}
+                    >
+                      {scannerStatus && (
+                        <RadioGroup
+                          label="Scanning mode"
+                          value={scannerStatus.mode}
+                          onChange={(mode) => mode && setScanningMode(mode)}
+                          options={
+                            [
+                              {
+                                value: 'shoe-shine',
+                                label: (
+                                  <React.Fragment>
+                                    <RadioOptionTitle>
+                                      Shoe-shine
+                                    </RadioOptionTitle>
+                                    <Caption>
+                                      Scan continuously and automatically
+                                    </Caption>
+                                  </React.Fragment>
+                                ),
+                              },
+                              {
+                                value: 'manual-rear',
+                                label: (
+                                  <React.Fragment>
+                                    <RadioOptionTitle>
+                                      Manual (rear)
+                                    </RadioOptionTitle>
+                                    <Caption>
+                                      Eject to the rear after scanning
+                                    </Caption>
+                                  </React.Fragment>
+                                ),
+                              },
+                              {
+                                value: 'manual-front',
+                                label: (
+                                  <React.Fragment>
+                                    <RadioOptionTitle>
+                                      Manual (front)
+                                    </RadioOptionTitle>
+                                    <Caption>
+                                      Eject to the front after scanning
+                                    </Caption>
+                                  </React.Fragment>
+                                ),
+                              },
+                              {
+                                value: 'disabled',
+                                label: (
+                                  <React.Fragment>
+                                    <RadioOptionTitle>
+                                      Disabled
+                                    </RadioOptionTitle>
+                                    <Caption>Do not scan sheets</Caption>
+                                  </React.Fragment>
+                                ),
+                              },
+                            ] as const
+                          }
+                        ></RadioGroup>
+                      )}
+                      {getLatestScannedSheetQuery.data && (
+                        <Button
+                          onPress={() => {
+                            setIsShowingLatestSheet(true);
+                          }}
+                        >
+                          View Latest Sheet
+                        </Button>
+                      )}
+                    </div>
+                  </Caption>
+                </Column>
+              </Row>
+
+              <Row
+                style={{ height: '100%', alignItems: 'stretch', gap: '1em' }}
+              >
+                <Column style={{ flexGrow: 0, alignContent: 'center' }}>
+                  <PlayPauseButton
+                    isRunning={cardStatus?.taskStatus === 'running'}
+                    onPress={toggleCardReaderTaskRunning}
+                  />
+                </Column>
+                <Column style={{ flexGrow: 1 }}>
+                  <H6 style={{ flexGrow: 0 }}>
+                    {' '}
+                    <Icons.SimCard /> Card Reader{' '}
+                  </H6>
+                  <Caption
+                    style={{
+                      flexGrow: 1,
+                      overflowWrap: 'anywhere',
+                      maxHeight: '2rem',
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <Small>{cardStatus?.statusMessage ?? 'Unknown'}</Small>
+                  </Caption>
+                  {cardStatus && (
+                    <Caption style={{ flexGrow: 0 }}>
+                      <ExtraSmall>
+                        {formatTimestamp(cardStatus.updatedAt)}
+                      </ExtraSmall>
+                    </Caption>
+                  )}
+                </Column>
+              </Row>
+            </Row>
+            <Row gap="2rem">
+              {[
+                {
+                  id: 'card',
+                  icon: <Icons.SimCard />,
+                  title: 'Card Reader',
+                  statusMessage: cardStatus?.statusMessage ?? 'Unknown',
+                  body: undefined,
+                  isRunning: cardStatus?.taskStatus === 'running',
+                  toggleIsRunning: toggleCardReaderTaskRunning,
+                  updatedAt: cardStatus?.updatedAt,
+                },
+                {
+                  id: 'printer',
+                  icon: <Icons.Print />,
+                  title: 'Printer',
+                  statusMessage: printerStatus?.statusMessage ?? 'Unknown',
+                  body: undefined,
+                  isRunning: printerStatus?.taskStatus === 'running',
+                  toggleIsRunning: togglePrinterTaskRunning,
+                  updatedAt: printerStatus?.updatedAt,
+                },
+                {
+                  id: 'usbDrive',
+                  icon: <Icons.Print />,
+                  title: 'USB Drive',
+                  statusMessage: usbDriveStatus?.statusMessage ?? 'Unknown',
+                  body: undefined,
+                  isRunning: usbDriveStatus?.taskStatus === 'running',
+                  toggleIsRunning: toggleUsbDriveTaskRunning,
+                  updatedAt: usbDriveStatus?.updatedAt,
+                },
+              ].map((t) => (
+                <Row
+                  style={{
+                    height: '100%',
+                    alignItems: 'stretch',
+                    gap: '1em',
+                  }}
+                  key={t.id}
+                >
+                  {typeof t.isRunning === 'boolean' && t.toggleIsRunning && (
+                    <Column style={{ flexGrow: 0, alignContent: 'center' }}>
+                      <PlayPauseButton
+                        isRunning={t.isRunning}
+                        onPress={t.toggleIsRunning}
+                      />
+                    </Column>
+                  )}
+                  <Column style={{ flexGrow: 1 }}>
+                    <H6 style={{ flexGrow: 0 }}>
+                      {t.icon} {t.title}
+                    </H6>
+                    {t.statusMessage && (
+                      <Caption
+                        style={{
+                          flexGrow: 1,
+                          overflowWrap: 'anywhere',
+                          maxHeight: '2rem',
+                          overflow: 'hidden',
+                        }}
+                      >
+                        <Small>{t.statusMessage}</Small>
+                      </Caption>
+                    )}
+                    {t.body && (
+                      <Caption style={{ flexGrow: 1 }}>{t.body}</Caption>
+                    )}
+                    {t.updatedAt && (
+                      <Caption style={{ flexGrow: 0 }}>
+                        <ExtraSmall>{formatTimestamp(t.updatedAt)}</ExtraSmall>
+                      </Caption>
+                    )}
+                  </Column>
+                </Row>
+              ))}
+            </Row>
+            <Row gap="2rem">
+              <CheckboxGroup
+                label={
+                  <React.Fragment>
+                    <Icons.SoundOn /> Audio
+                  </React.Fragment>
+                }
+                aria-label="Audio"
+                value={[
+                  ...(speakerEnabled ? ['speaker'] : []),
+                  ...(headphonesEnabled ? ['headphones'] : []),
+                ]}
+                onChange={(values) => {
+                  setSpeakerEnabled(values.includes('speaker'));
+                  setHeadphonesEnabled(values.includes('headphones'));
+                }}
+                options={[
+                  { value: 'speaker', label: 'Speaker' },
+                  { value: 'headphones', label: 'Headphones' },
+                ]}
+              />
+              <Row
                 style={{
-                  flexGrow: 1,
-                  overflowWrap: 'anywhere',
-                  maxHeight: '2rem',
-                  overflow: 'hidden',
+                  height: '100%',
+                  alignItems: 'stretch',
+                  gap: '1em',
                 }}
               >
-                <Small>{scannerStatus?.statusMessage ?? 'Unknown'}</Small>
-              </Caption>
-              {getLatestScannedSheetQuery.data && (
-                <Button
-                  onPress={() => {
-                    setIsShowingLatestSheet(true);
-                  }}
-                  style={{
-                    position: 'absolute',
-                    right: '0',
-                    bottom: '0',
-                    transform: 'scale(0.3) translate(100%, 100%)',
-                  }}
-                >
-                  View Latest Sheet
-                </Button>
-              )}
-            </React.Fragment>
-          ),
-          isRunning: scannerStatus?.taskStatus === 'running',
-          toggleIsRunning: toggleScannerTaskRunning,
-          updatedAt: scannerStatus?.updatedAt,
-        },
-        {
-          id: 'card',
-          icon: <Icons.SimCard />,
-          title: 'Card Reader',
-          statusMessage: cardStatus?.statusMessage ?? 'Unknown',
-          isRunning: cardStatus?.taskStatus === 'running',
-          toggleIsRunning: toggleCardReaderTaskRunning,
-          updatedAt: cardStatus?.updatedAt,
-        },
-        {
-          id: 'printer',
-          icon: <Icons.Print />,
-          title: 'Printer',
-          statusMessage: printerStatus?.statusMessage ?? 'Unknown',
-          isRunning: printerStatus?.taskStatus === 'running',
-          toggleIsRunning: togglePrinterTaskRunning,
-          updatedAt: printerStatus?.updatedAt,
-        },
-        {
-          id: 'usbDrive',
-          icon: <Icons.Print />,
-          title: 'USB Drive',
-          statusMessage: usbDriveStatus?.statusMessage ?? 'Unknown',
-          isRunning: usbDriveStatus?.taskStatus === 'running',
-          toggleIsRunning: toggleUsbDriveTaskRunning,
-          updatedAt: usbDriveStatus?.updatedAt,
-        },
-        {
-          id: 'speaker',
-          icon: speakerEnabled ? <Icons.VolumeUp /> : <Icons.VolumeMute />,
-          title: 'Speaker',
-          body: speakerEnabled ? 'Enabled' : 'Disabled',
-          isRunning: speakerEnabled,
-          toggleIsRunning: toggleSpeakerEnabled,
-        },
-        {
-          id: 'headphones',
-          icon: headphonesEnabled ? <Icons.VolumeUp /> : <Icons.VolumeMute />,
-          title: 'Headphones',
-          body: headphonesEnabled ? 'Enabled' : 'Disabled',
-          isRunning: headphonesEnabled,
-          toggleIsRunning: toggleHeadphonesEnabled,
-        },
-        {
-          id: 'inputs',
-          icon: <Icons.Mouse />,
-          title: 'Inputs',
-          body: (
-            <Column>
-              <CounterButton />
+                <Column style={{ flexGrow: 1 }}>
+                  <H6 style={{ flexGrow: 0 }}>
+                    <Icons.Mouse /> Inputs
+                  </H6>
+                  <Caption style={{ flexGrow: 1 }}>
+                    <Column>
+                      <CounterButton />
 
-              <Small>
-                Last key press:{' '}
-                {lastKeyPress ? (
-                  <React.Fragment>
-                    <code>{lastKeyPress.key}</code> at{' '}
-                    {formatTimestamp(lastKeyPress.pressedAt)}
-                  </React.Fragment>
-                ) : (
-                  'n/a'
-                )}
-              </Small>
-            </Column>
-          ),
-        },
-      ]}
-      perRow={3}
-      powerDown={powerDown}
-      modals={
-        isShowingLatestSheet &&
-        getLatestScannedSheetQuery.data && (
+                      <ExtraSmall>
+                        Last key press:{' '}
+                        {lastKeyPress ? (
+                          <React.Fragment>
+                            <code>{lastKeyPress.key}</code> at{' '}
+                            {formatTimestamp(lastKeyPress.pressedAt)}
+                          </React.Fragment>
+                        ) : (
+                          'n/a'
+                        )}
+                      </ExtraSmall>
+                    </Column>
+                  </Caption>
+                </Column>
+              </Row>
+            </Row>
+          </Column>
+          <Row style={{ justifyContent: 'center' }}>
+            <Button
+              icon={<Icons.Save />}
+              onPress={() => setIsSaveLogsModalOpen(true)}
+            >
+              Save Logs
+            </Button>
+            <Button icon={<Icons.PowerOff />} onPress={powerDown}>
+              Power Down
+            </Button>
+          </Row>
+        </Column>
+        {isSaveLogsModalOpen && usbDriveStatus && (
+          <ExportLogsModal
+            onClose={() => setIsSaveLogsModalOpen(false)}
+            usbDriveStatus={usbDriveStatus?.underlyingDeviceStatus}
+          />
+        )}
+        {isShowingLatestSheet && getLatestScannedSheetQuery.data && (
           <SheetImagesModal
             paths={getLatestScannedSheetQuery.data}
             onClose={() => setIsShowingLatestSheet(false)}
           />
-        )
-      }
-      usbDriveStatus={usbDriveStatus?.underlyingDeviceStatus}
-    />
+        )}
+      </Main>
+    </Screen>
   );
 }

--- a/libs/backend/src/task_controller.ts
+++ b/libs/backend/src/task_controller.ts
@@ -9,7 +9,8 @@ export type TaskStatus = 'init' | 'running' | 'paused' | 'stopped';
 /**
  * Keeps track of the status of a running task and provides methods to control it.
  */
-export class TaskController<Product = void> {
+export class TaskController<Input = void, Product = void> {
+  private input: Input;
   private status: TaskStatus = 'init';
   private onRunning = deferred<void>();
   private readonly onStop = deferred<Optional<Product>>();
@@ -72,11 +73,20 @@ export class TaskController<Product = void> {
   }
 
   /**
+   * Creates a new task controller with the given input.
+   */
+  constructor(input: Input) {
+    this.input = input;
+  }
+
+  /**
    * Creates a new task controller that is already started.
    */
   // eslint-disable-next-line vx/gts-no-return-type-only-generics
-  static started<Product = void>(): TaskController<Product> {
-    const controller = new TaskController<Product>();
+  static started<Input = void, Product = void>(
+    input: Input
+  ): TaskController<Input, Product> {
+    const controller = new TaskController<Input, Product>(input);
     controller.start();
     return controller;
   }
@@ -87,6 +97,20 @@ export class TaskController<Product = void> {
    */
   private setStatus(newStatus: TaskStatus): void {
     this.status = newStatus;
+  }
+
+  /**
+   * Gets the current input for this task.
+   */
+  getInput(): Input {
+    return this.input;
+  }
+
+  /**
+   * Updates the task's input to the given value.
+   */
+  setInput(input: Input): void {
+    this.input = input;
   }
 
   /**

--- a/libs/ui/src/electrical_testing_screen.tsx
+++ b/libs/ui/src/electrical_testing_screen.tsx
@@ -26,22 +26,20 @@ const Column = styled.div<{ gap?: string }>`
 `;
 
 const Small = styled.span`
-  font-size: 0.45rem;
+  font-size: 0.9rem;
 `;
 
-const SmallButton = styled(Button)`
-  transform: scale(0.5);
-`;
+const SmallButton = Button;
 
 const ExtraSmall = styled.span`
-  font-size: 0.3rem;
+  font-size: 0.6rem;
 `;
 
 const PlayPauseButtonBase = styled.button`
   flex-shrink: 0;
   background-color: #ddd;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 3rem;
+  height: 3rem;
   border-radius: 50%;
   border: none;
   cursor: pointer;
@@ -49,7 +47,7 @@ const PlayPauseButtonBase = styled.button`
   padding: 0;
 
   svg {
-    scale: 0.8;
+    scale: 2;
   }
 `;
 


### PR DESCRIPTION

## Overview

Adds stats about the last scanned sheet and about the session as a whole. Adds a setting to control how and whether the scanned sheets are ejected and rescanned. Changes the UI to use the VxDesign/desktop theme for a more compact set of labels and controls.

## Demo Video or Screenshot

<img width="2881" height="1800" alt="screenshot" src="https://github.com/user-attachments/assets/adffc850-4dc2-489c-9814-eebe6d6c1923" />

## Testing Plan
Minor updates to automated tests, manual testing with timing mark paper and ballot paper.