### PR TITLE
feat(ui): improve `CheckboxGroup` type safety

### DIFF
--- a/apps/admin/frontend/src/components/reporting/group_by_editor.tsx
+++ b/apps/admin/frontend/src/components/reporting/group_by_editor.tsx
@@ -30,14 +30,14 @@ export function GroupByEditor({
   setIncludeSheetCounts,
   allowedOptions: allowedGroupings,
 }: GroupByEditorProps): JSX.Element {
-  const checkboxValues = Object.keys(groupBy).filter(
-    (grouping) => groupBy[grouping as keyof Tabulation.GroupBy]
-  );
+  const checkboxValues: GroupByEditorOption[] = (
+    Object.keys(groupBy) as Array<keyof Tabulation.GroupBy>
+  ).filter((grouping) => groupBy[grouping]);
   if (includeSheetCounts) {
     checkboxValues.push('includeSheetCounts');
   }
 
-  function onChange(newCheckboxValues: string[]): void {
+  function onChange(newCheckboxValues: GroupByEditorOption[]): void {
     setGroupBy(
       Object.fromEntries(
         newCheckboxValues

--- a/apps/design/frontend/src/system_settings_screen.tsx
+++ b/apps/design/frontend/src/system_settings_screen.tsx
@@ -181,10 +181,7 @@ export function SystemSettingsForm({
             <CheckboxGroup
               label="VxScan"
               options={scannerAdjudicationReasonOptions}
-              value={
-                (systemSettings.precinctScanAdjudicationReasons ??
-                  []) as string[]
-              }
+              value={systemSettings.precinctScanAdjudicationReasons ?? []}
               onChange={(value) =>
                 setSystemSettings({
                   ...systemSettings,
@@ -210,10 +207,7 @@ export function SystemSettingsForm({
             <CheckboxGroup
               label="VxCentralScan"
               options={scannerAdjudicationReasonOptions}
-              value={
-                (systemSettings.centralScanAdjudicationReasons ??
-                  []) as string[]
-              }
+              value={systemSettings.centralScanAdjudicationReasons ?? []}
               onChange={(value) =>
                 setSystemSettings({
                   ...systemSettings,
@@ -230,9 +224,7 @@ export function SystemSettingsForm({
               options={adjudicationReasonOptions.filter((option) =>
                 [AdjudicationReason.MarginalMark].includes(option.value)
               )}
-              value={
-                (systemSettings.adminAdjudicationReasons ?? []) as string[]
-              }
+              value={systemSettings.adminAdjudicationReasons ?? []}
               onChange={(value) =>
                 setSystemSettings({
                   ...systemSettings,
@@ -544,13 +536,11 @@ export function SystemSettingsForm({
                 <CheckboxGroup
                   label="CVR"
                   options={cvrOptions}
-                  value={
-                    [
-                      systemSettings.castVoteRecordsIncludeRedundantMetadata
-                        ? CvrOption.RedudantMetadata
-                        : undefined,
-                    ].filter((v) => v !== undefined) as string[]
-                  }
+                  value={[
+                    systemSettings.castVoteRecordsIncludeRedundantMetadata
+                      ? CvrOption.RedudantMetadata
+                      : undefined,
+                  ].filter((v) => v !== undefined)}
                   onChange={(value) =>
                     setSystemSettings({
                       ...systemSettings,

--- a/libs/ui/src/checkbox_group.stories.tsx
+++ b/libs/ui/src/checkbox_group.stories.tsx
@@ -22,7 +22,7 @@ const meta: Meta<typeof Component> = {
 
 export default meta;
 
-export function CheckboxGroup(props: CheckboxGroupProps): JSX.Element {
+export function CheckboxGroup(props: CheckboxGroupProps<string>): JSX.Element {
   const { onChange } = props;
   const [value, setValue] = useState<string[]>([]);
 

--- a/libs/ui/src/checkbox_group.test.tsx
+++ b/libs/ui/src/checkbox_group.test.tsx
@@ -103,3 +103,16 @@ test('label is not visible if `hideLabel == true`', () => {
   // Verify the container is still labelled appropriately.
   screen.getByRole('group', { name: 'Pick cards:' });
 });
+
+test('allows constraining the value type based on options', () => {
+  <CheckboxGroup
+    label="Sizes"
+    options={[
+      { value: 'full', label: 'Full' },
+      { value: '800x600', label: '800x600' },
+    ]}
+    onChange={vi.fn()}
+    // @ts-expect-error "bad" is not in the list of options
+    value={['full', 'bad']}
+  />;
+});

--- a/libs/ui/src/checkbox_group.tsx
+++ b/libs/ui/src/checkbox_group.tsx
@@ -2,21 +2,21 @@ import styled from 'styled-components';
 import React from 'react';
 import { CheckboxButton } from './checkbox_button';
 
-interface Option {
+interface Option<T extends string> {
   label: string;
-  value: string;
+  value: T;
 }
 
-export interface CheckboxGroupProps {
+export interface CheckboxGroupProps<T extends string> {
   /**
    * Required for a11y - use {@link hideLabel} to visually hide the label, while
    * still allowing it to be assigned to the control for screen readers.
    */
   label: string;
   hideLabel?: boolean;
-  options: Option[];
-  value: string[];
-  onChange: (value: string[]) => void;
+  options: Array<Option<T>>;
+  value: NoInfer<readonly T[]>;
+  onChange: NoInfer<(value: T[]) => void>;
   disabled?: boolean;
   direction?: 'row' | 'column';
   noOptionsMessage?: React.ReactNode;
@@ -38,7 +38,7 @@ const OptionsContainer = styled.div<{ direction: 'row' | 'column' }>`
 /**
  * A group of labeled checkboxes that allow the user to select multiple options.
  */
-export function CheckboxGroup({
+export function CheckboxGroup<T extends string>({
   label,
   hideLabel,
   options,
@@ -47,7 +47,7 @@ export function CheckboxGroup({
   disabled = false,
   direction = 'column',
   noOptionsMessage,
-}: CheckboxGroupProps): JSX.Element {
+}: CheckboxGroupProps<T>): JSX.Element {
   return (
     <fieldset aria-label={label}>
       {!hideLabel && <LabelContainer aria-hidden>{label}</LabelContainer>}


### PR DESCRIPTION
## Overview
_(This is part 1 of a series of PRs extracted from https://github.com/votingworks/vxsuite/pull/6862)_

Previously, `CheckboxGroup` was unable to enforce that the `options` and `values` parameters matched, treating all values as `string`. In many cases, there is a more appropriately narrow type that can be used. Doing so increases type safety and prevents bugs. Uses the [`NoInfer` utility type](https://www.typescriptlang.org/docs/handbook/utility-types.html#noinfertype) to ensure TypeScript only uses the `options` parameter for inferring the generic type `T`.

## Demo Video or Screenshot
<img width="1262" height="542" alt="CleanShot 2025-07-29 at 06 48 53@2x" src="https://github.com/user-attachments/assets/a7bdca30-8296-4d3f-ab1d-824ed7d7fd68" />

## Testing Plan
Added a type-based test.