### PR TITLE
feat(hwta-scan): switch to `desktop` size mode

### DIFF
--- a/apps/scan/frontend/src/electrical_testing/app.tsx
+++ b/apps/scan/frontend/src/electrical_testing/app.tsx
@@ -1,6 +1,14 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { BaseLogger, LogSource } from '@votingworks/logging';
-import { AppErrorBoundary, SystemCallContextProvider } from '@votingworks/ui';
+import {
+  AppBase,
+  AppErrorBoundary,
+  SystemCallContextProvider,
+} from '@votingworks/ui';
+import {
+  BooleanEnvironmentVariableName,
+  isFeatureFlagEnabled,
+} from '@votingworks/utils';
 
 import {
   ApiClientContext,
@@ -9,7 +17,10 @@ import {
   systemCallApi,
 } from './api';
 import { AppRoot } from './app_root';
-import { ScanAppBase } from '../scan_app_base';
+
+export interface AppBaseProps {
+  children: React.ReactNode;
+}
 
 export function App(): JSX.Element {
   const logger = new BaseLogger(LogSource.VxScanFrontend, window.kiosk);
@@ -17,7 +28,14 @@ export function App(): JSX.Element {
   const apiClient = createApiClient();
 
   return (
-    <ScanAppBase>
+    <AppBase
+      defaultColorMode="contrastMedium"
+      defaultSizeMode="desktop"
+      hideCursor={isFeatureFlagEnabled(
+        BooleanEnvironmentVariableName.HIDE_CURSOR
+      )}
+      screenType="elo13"
+    >
       <AppErrorBoundary restartMessage="Restart the machine" logger={logger}>
         <ApiClientContext.Provider value={apiClient}>
           <QueryClientProvider client={queryClient}>
@@ -27,6 +45,6 @@ export function App(): JSX.Element {
           </QueryClientProvider>
         </ApiClientContext.Provider>
       </AppErrorBoundary>
-    </ScanAppBase>
+    </AppBase>
   );
 }

--- a/apps/scan/frontend/src/electrical_testing/app_root.tsx
+++ b/apps/scan/frontend/src/electrical_testing/app_root.tsx
@@ -25,10 +25,7 @@ function CounterButton() {
   const [count, setCount] = useState(0);
 
   return (
-    <Button
-      onPress={() => setCount((prev) => prev + 1)}
-      style={{ transform: 'scale(0.5)' }}
-    >
+    <Button onPress={() => setCount((prev) => prev + 1)}>
       Tap Count: {count}
     </Button>
   );
@@ -49,31 +46,23 @@ const Column = styled.div<{ gap?: string }>`
 `;
 
 const Small = styled.span`
-  font-size: 0.45rem;
+  font-size: 0.9rem;
 `;
 
 const ExtraSmall = styled.span`
-  font-size: 0.3rem;
-`;
-
-const SmallButton = styled(Button)`
-  transform: scale(0.5);
+  font-size: 0.6rem;
 `;
 
 const PlayPauseButtonBase = styled.button`
   flex-shrink: 0;
   background-color: #ddd;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 3rem;
+  height: 3rem;
   border-radius: 50%;
   border: none;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: 2rem;
   padding: 0;
-
-  svg {
-    scale: 0.8;
-  }
 `;
 
 function PlayPauseButton({
@@ -149,7 +138,8 @@ function StatusCard({
     </Card>
   );
 }
-export function ElectricalTestingScreen<Id extends React.Key>({
+
+function ElectricalTestingScreen<Id extends React.Key>({
   tasks,
   perRow,
   modals,
@@ -199,15 +189,15 @@ export function ElectricalTestingScreen<Id extends React.Key>({
               .toArray()}
           </Column>
           <Row style={{ justifyContent: 'center' }}>
-            <SmallButton
+            <Button
               icon={<Icons.Save />}
               onPress={() => setIsSaveLogsModalOpen(true)}
             >
               Save Logs
-            </SmallButton>
-            <SmallButton icon={<Icons.PowerOff />} onPress={powerDown}>
+            </Button>
+            <Button icon={<Icons.PowerOff />} onPress={powerDown}>
               Power Down
-            </SmallButton>
+            </Button>
           </Row>
         </Column>
         {isSaveLogsModalOpen && usbDriveStatus && (
@@ -342,7 +332,7 @@ export function AppRoot(): JSX.Element {
                     position: 'absolute',
                     right: '0',
                     bottom: '0',
-                    transform: 'scale(0.3) translate(100%, 100%)',
+                    transform: 'translate(100%, 100%)',
                   }}
                 >
                   View Latest Sheet

--- a/apps/scan/frontend/src/electrical_testing/app_root.tsx
+++ b/apps/scan/frontend/src/electrical_testing/app_root.tsx
@@ -1,9 +1,16 @@
 import {
   Button,
   Caption,
-  ElectricalTestingScreen,
+  Card,
+  ExportLogsModal,
+  H6,
   Icons,
+  Main,
+  Screen,
+  Task,
 } from '@votingworks/ui';
+import { iter } from '@votingworks/basics';
+import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import { DateTime } from 'luxon';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
@@ -27,6 +34,13 @@ function CounterButton() {
   );
 }
 
+const Row = styled.div<{ gap?: string }>`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${({ gap = 0 }) => gap};
+`;
+
 const Column = styled.div<{ gap?: string }>`
   display: flex;
   flex-direction: column;
@@ -38,8 +52,174 @@ const Small = styled.span`
   font-size: 0.45rem;
 `;
 
+const ExtraSmall = styled.span`
+  font-size: 0.3rem;
+`;
+
+const SmallButton = styled(Button)`
+  transform: scale(0.5);
+`;
+
+const PlayPauseButtonBase = styled.button`
+  flex-shrink: 0;
+  background-color: #ddd;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 0;
+
+  svg {
+    scale: 0.8;
+  }
+`;
+
+function PlayPauseButton({
+  isRunning,
+  onPress,
+}: {
+  isRunning: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <PlayPauseButtonBase onClick={onPress}>
+      {isRunning ? <Icons.Pause /> : <Icons.Play />}
+    </PlayPauseButtonBase>
+  );
+}
+
 function formatTimestamp(timestamp: DateTime): string {
   return timestamp.toLocal().toFormat('h:mm:ss a MM/dd/yyyy');
+}
+
+function StatusCard({
+  title,
+  statusMessage,
+  body,
+  updatedAt,
+  isRunning,
+  onToggleRunning,
+}: {
+  title: React.ReactNode;
+  statusMessage?: React.ReactNode;
+  body?: React.ReactNode;
+  updatedAt?: DateTime;
+  isRunning?: boolean;
+  onToggleRunning?: () => void;
+}) {
+  return (
+    <Card
+      style={{
+        width: '600px',
+        height: '235px',
+        overflow: 'hidden',
+        position: 'relative',
+      }}
+    >
+      <Row style={{ height: '100%', alignItems: 'stretch' }}>
+        <Column style={{ flexGrow: 1 }}>
+          <H6 style={{ flexGrow: 0 }}>{title}</H6>
+          {statusMessage && (
+            <Caption
+              style={{
+                flexGrow: 1,
+                overflowWrap: 'anywhere',
+                maxHeight: '2rem',
+                overflow: 'hidden',
+              }}
+            >
+              <Small>{statusMessage}</Small>
+            </Caption>
+          )}
+          {body && <Caption style={{ flexGrow: 1 }}>{body}</Caption>}
+          {updatedAt && (
+            <Caption style={{ flexGrow: 0 }}>
+              <ExtraSmall>{formatTimestamp(updatedAt)}</ExtraSmall>
+            </Caption>
+          )}
+        </Column>
+        {typeof isRunning === 'boolean' && onToggleRunning && (
+          <Column style={{ flexGrow: 0, alignContent: 'center' }}>
+            <PlayPauseButton isRunning={isRunning} onPress={onToggleRunning} />
+          </Column>
+        )}
+      </Row>
+    </Card>
+  );
+}
+export function ElectricalTestingScreen<Id extends React.Key>({
+  tasks,
+  perRow,
+  modals,
+  powerDown,
+  usbDriveStatus,
+}: {
+  tasks: ReadonlyArray<Task<Id>>;
+  perRow: number;
+  modals?: React.ReactNode;
+  powerDown: () => void;
+  usbDriveStatus?: UsbDriveStatus;
+}): JSX.Element {
+  const [isSaveLogsModalOpen, setIsSaveLogsModalOpen] = React.useState(false);
+
+  return (
+    <Screen>
+      <Main centerChild>
+        <Column style={{ height: '100%' }}>
+          <Column
+            style={{
+              alignItems: 'center',
+              gap: '1rem',
+              justifyContent: 'center',
+            }}
+          >
+            {iter(tasks)
+              .chunks(perRow)
+              .map((tt) => (
+                <Row gap="1rem" key={tt.map((t) => t.id).join('-')}>
+                  {tt.map((t) => (
+                    <StatusCard
+                      key={t.id}
+                      title={
+                        <React.Fragment>
+                          {t.icon} {t.title}
+                        </React.Fragment>
+                      }
+                      body={t.body}
+                      statusMessage={t.statusMessage}
+                      updatedAt={t.updatedAt}
+                      isRunning={t.isRunning}
+                      onToggleRunning={t.toggleIsRunning}
+                    />
+                  ))}
+                </Row>
+              ))
+              .toArray()}
+          </Column>
+          <Row style={{ justifyContent: 'center' }}>
+            <SmallButton
+              icon={<Icons.Save />}
+              onPress={() => setIsSaveLogsModalOpen(true)}
+            >
+              Save Logs
+            </SmallButton>
+            <SmallButton icon={<Icons.PowerOff />} onPress={powerDown}>
+              Power Down
+            </SmallButton>
+          </Row>
+        </Column>
+        {isSaveLogsModalOpen && usbDriveStatus && (
+          <ExportLogsModal
+            onClose={() => setIsSaveLogsModalOpen(false)}
+            usbDriveStatus={usbDriveStatus}
+          />
+        )}
+        {modals}
+      </Main>
+    </Screen>
+  );
 }
 
 export function AppRoot(): JSX.Element {


### PR DESCRIPTION
## Overview
_(This is part 3 of a series of PRs extracted from #6862 – [Go to Part 2](https://github.com/votingworks/vxsuite/pull/6868))_

This lets us get rid of the janky `scale` styles and small font sizes. Note that this isn't where we want to leave this screen, see https://github.com/votingworks/vxsuite/pull/6862 for the goal UI.

## Demo Video or Screenshot
<img width="2266" height="1274" alt="CleanShot 2025-07-29 at 11 05 38@2x" src="https://github.com/user-attachments/assets/5a29322b-9c35-494c-86c4-f71bfbf6e214" />

## Testing Plan
Tested locally.
