### PR TITLE
fix(hwta-scan): prevent data race with saved images

### DIFF
--- a/apps/scan/backend/src/electrical_testing/app.ts
+++ b/apps/scan/backend/src/electrical_testing/app.ts
@@ -166,13 +166,8 @@ export type ElectricalTestingApi = ReturnType<typeof buildApi>;
 export function buildApp(context: ApiContext): Application {
   const app: Application = express();
   const api = buildApi(context);
-  app.use('/api/images', async (req, res) => {
-    const usbDriveStatus = await context.usbDrive.status();
-    const basedir =
-      usbDriveStatus.status === 'mounted'
-        ? join(usbDriveStatus.mountPoint, 'ballot-images')
-        : context.workspace.ballotImagesPath;
-
+  app.use('/api/images', (req, res) => {
+    const basedir = context.workspace.ballotImagesPath;
     const path = join(basedir, req.path);
     if (!path.startsWith(basedir)) {
       res.status(404).send('Not Found');

--- a/apps/scan/backend/src/electrical_testing/app.ts
+++ b/apps/scan/backend/src/electrical_testing/app.ts
@@ -113,11 +113,7 @@ function buildApi({
     },
 
     async getLatestScannedSheet(): Promise<SheetOf<string> | null> {
-      const usbDriveStatus = await usbDrive.status();
-      const basedir =
-        usbDriveStatus.status === 'mounted'
-          ? join(usbDriveStatus.mountPoint, 'ballot-images')
-          : workspace.ballotImagesPath;
+      const basedir = workspace.ballotImagesPath;
       await mkdir(basedir, { recursive: true });
       const allFileNames = await readdir(basedir);
       const allScannedImageNames = allFileNames.filter((name) =>


### PR DESCRIPTION
## Overview

_(This is part 6 of a series of PRs extracted from #6862 – [Go to Part 5](https://github.com/votingworks/vxsuite/pull/6875))_

The images may not be fully saved to the USB drive when we try to read them for the frontend, so just always pull from the local disk for the purposes of displaying the images.

## Demo Video or Screenshot
n/a

## Testing Plan
Tested manually, saw that the images no longer occasionally failed to load.