### PR TITLE
feat(hwta-scan): allow printing on demand

### DIFF
--- a/apps/scan/backend/src/electrical_testing/app.ts
+++ b/apps/scan/backend/src/electrical_testing/app.ts
@@ -104,6 +104,10 @@ function buildApi({
       }
     },
 
+    resetLastPrintedAt(): void {
+      printerTask.setState({ lastPrintedAt: undefined });
+    },
+
     setScannerTaskRunning(input: { running: boolean }) {
       workspace.store.setElectricalTestingStatusMessage(
         'scanner',

--- a/apps/scan/backend/src/electrical_testing/context.ts
+++ b/apps/scan/backend/src/electrical_testing/context.ts
@@ -5,6 +5,7 @@ import { UsbDrive } from '@votingworks/usb-drive';
 import { Printer } from '../printing/printer';
 import { Workspace } from '../util/workspace';
 import { SimpleScannerClient } from './simple_scanner_client';
+import { DateTime } from 'luxon';
 
 export type ScanningMode =
   | 'shoe-shine'
@@ -16,7 +17,7 @@ export interface ServerContext {
   auth: InsertedSmartCardAuthApi;
   cardTask: TaskController<void, string>;
   usbDriveTask: TaskController<void, string>;
-  printerTask: TaskController<void, string>;
+  printerTask: TaskController<{ lastPrintedAt?: DateTime }, string>;
   scannerTask: TaskController<{ mode: ScanningMode }, string>;
   logger: Logger;
   printer: Printer;

--- a/apps/scan/backend/src/electrical_testing/context.ts
+++ b/apps/scan/backend/src/electrical_testing/context.ts
@@ -2,10 +2,10 @@ import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import { TaskController } from '@votingworks/backend';
 import { Logger } from '@votingworks/logging';
 import { UsbDrive } from '@votingworks/usb-drive';
+import { DateTime } from 'luxon';
 import { Printer } from '../printing/printer';
 import { Workspace } from '../util/workspace';
 import { SimpleScannerClient } from './simple_scanner_client';
-import { DateTime } from 'luxon';
 
 export type ScanningMode =
   | 'shoe-shine'

--- a/apps/scan/backend/src/index.ts
+++ b/apps/scan/backend/src/index.ts
@@ -88,7 +88,7 @@ async function main(): Promise<number> {
       auth,
       cardTask: TaskController.started(),
       usbDriveTask: TaskController.started(),
-      printerTask: TaskController.started(),
+      printerTask: TaskController.started({ lastPrintedAt: undefined }),
       scannerTask: TaskController.started({ mode: 'shoe-shine' }),
       logger,
       printer,

--- a/apps/scan/backend/test/helpers/electrical_test.ts
+++ b/apps/scan/backend/test/helpers/electrical_test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-empty-pattern */
 import { TaskController } from '@votingworks/backend';
+import { DateTime } from 'luxon';
 import { Mocked, test, vi } from 'vitest';
 import {
   ScanningMode,
@@ -26,7 +27,7 @@ export const electricalTest = test.extend<{
   electricalAppContext: ServerContext;
   mockSimpleScannerClient: Mocked<SimpleScannerClient>;
   cardTask: TaskController<void, string>;
-  printerTask: TaskController<void, string>;
+  printerTask: TaskController<{ lastPrintedAt?: DateTime }, string>;
   scannerTask: TaskController<{ mode: ScanningMode }, string>;
   usbDriveTask: TaskController<void, string>;
 }>({
@@ -73,7 +74,7 @@ export const electricalTest = test.extend<{
   },
 
   printerTask: async ({}, use) => {
-    await use(TaskController.started());
+    await use(TaskController.started({ lastPrintedAt: undefined }));
   },
 
   scannerTask: async ({}, use) => {

--- a/apps/scan/frontend/src/electrical_testing/api.ts
+++ b/apps/scan/frontend/src/electrical_testing/api.ts
@@ -129,6 +129,23 @@ export const setScannerTaskMode = {
   },
 } as const;
 
+export const resetLastPrintedAt = {
+  queryKey(): QueryKey {
+    return ['resetLastPrintedAt'];
+  },
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(() => apiClient.resetLastPrintedAt(), {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries(
+          getElectricalTestingStatuses.queryKey()
+        );
+      },
+    });
+  },
+} as const;
+
 export const setUsbDriveTaskRunning = {
   queryKey(): QueryKey {
     return ['setUsbDriveTaskRunning'];

--- a/apps/scan/frontend/src/electrical_testing/app_root.tsx
+++ b/apps/scan/frontend/src/electrical_testing/app_root.tsx
@@ -196,9 +196,11 @@ function CardReaderControls({
 function PrinterControls({
   status,
   setIsEnabled,
+  requestPrintNow,
 }: {
   status?: StatusMessages['printer'];
   setIsEnabled: (isEnabled: boolean) => void;
+  requestPrintNow: () => void;
 }): JSX.Element {
   return (
     <Column gap="0.5rem">
@@ -230,6 +232,12 @@ function PrinterControls({
         onChange={setIsEnabled}
         disabled={!status}
       />
+      <Button
+        onPress={requestPrintNow}
+        disabled={status?.taskStatus !== 'running'}
+      >
+        Request Print Now
+      </Button>
     </Column>
   );
 }
@@ -409,6 +417,7 @@ export function AppRoot(): JSX.Element {
   const setPrinterTaskRunningMutation = api.setPrinterTaskRunning.useMutation();
   const setScannerTaskModeMutation = api.setScannerTaskMode.useMutation();
   const getLatestScannedSheetQuery = api.getLatestScannedSheet.useQuery();
+  const resetLastPrintedAtMutation = api.resetLastPrintedAt.useMutation();
   const powerDownMutation = api.systemCallApi.powerDown.useMutation();
 
   const [speakerEnabled, setSpeakerEnabled] = useState(true);
@@ -475,6 +484,7 @@ export function AppRoot(): JSX.Element {
                 setIsEnabled={(isEnabled) =>
                   setPrinterTaskRunningMutation.mutate(isEnabled)
                 }
+                requestPrintNow={() => resetLastPrintedAtMutation.mutate()}
               />
             </Column>
             <ScannedSheetImages

--- a/apps/scan/frontend/src/electrical_testing/app_root.tsx
+++ b/apps/scan/frontend/src/electrical_testing/app_root.tsx
@@ -236,7 +236,7 @@ function PrinterControls({
         onPress={requestPrintNow}
         disabled={status?.taskStatus !== 'running'}
       >
-        Request Print Now
+        Print Now
       </Button>
     </Column>
   );


### PR DESCRIPTION
## Overview
Adds a button to the printer controls that requests that a print start as soon as possible. It does this by clearing the "last printed at" timestamp, which will trigger a print during the printer/scanner's next tick on the event loop.

## Demo Video or Screenshot
<img width="456" height="251" alt="image" src="https://github.com/user-attachments/assets/b954cce3-15ab-495d-862d-da0bbe334c43" />

## Testing Plan
Tested manually with a mock printer.