### PR TITLE
Run apps-pollbook-backend tests only when code changes occur

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,11 @@
 
 version: 2.1
 
+setup: true
+
+orbs:
+  path-filtering: circleci/path-filtering@1
+
 executors:
   nodejs:
     docker:
@@ -396,32 +401,6 @@ jobs:
           path: apps/mark/integration-testing/test-results/
       - store_artifacts:
           path: apps/mark/integration-testing/test-results/
-
-  # @votingworks/pollbook-backend
-  test-apps-pollbook-backend:
-    executor: nodejs
-    resource_class: xlarge
-    steps:
-      - checkout-and-install:
-          is_node_package: true
-      - run:
-          name: Build
-          command: |
-            pnpm --dir apps/pollbook/backend build
-      - run:
-          name: Lint
-          command: |
-            pnpm --dir apps/pollbook/backend lint
-      - run:
-          name: Test
-          command: |
-            pnpm --dir apps/pollbook/backend test
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/
-      - store_test_results:
-          path: apps/pollbook/backend/reports/
-      - store_artifacts:
-          path: apps/pollbook/backend/src/__image_snapshots__/__diff_output__/
 
   # @votingworks/pollbook-frontend
   test-apps-pollbook-frontend:
@@ -1359,6 +1338,13 @@ jobs:
 workflows:
   test:
     jobs:
+
+      - path-filtering/filter:
+          name: check-updated-files-for-test-filter
+          base-revision: main
+          mapping: |
+            apps/pollbook/backend/.* run-job true
+          config-path: apps/pollbook/backend/.circleci/config.yml
       - test-apps-admin-backend
       - test-apps-admin-frontend
       - test-apps-admin-integration-testing
@@ -1373,7 +1359,6 @@ workflows:
       - test-apps-mark-backend
       - test-apps-mark-frontend
       - test-apps-mark-integration-testing
-      - test-apps-pollbook-backend
       - test-apps-pollbook-frontend
       - test-apps-scan-backend
       - test-apps-scan-frontend

--- a/apps/pollbook/backend/.circleci/config.yml
+++ b/apps/pollbook/backend/.circleci/config.yml
@@ -1,0 +1,101 @@
+version: 2.1
+
+parameters:
+  run-job:
+    type: boolean
+    default: false
+
+executors:
+  nodejs:
+    docker:
+      - image: votingworks/cimg-debian12:4.2.0
+        auth:
+          username: $VX_DOCKER_USERNAME
+          password: $VX_DOCKER_PASSWORD
+
+commands:
+  checkout-and-install:
+    description: Get the code and install dependencies.
+    parameters:
+      is_node_package:
+        type: boolean
+    steps:
+      - run:
+          name: Ensure Rust tooling is in PATH
+          command: |
+            echo 'export PATH="/root/.cargo/bin:$PATH"' >> $BASH_ENV
+      - checkout
+      # Edit this comment somehow in order to invalidate the CircleCI cache.
+      # Since the contents of this file affect the cache key, editing only a
+      # comment will invalidate the cache without changing the behavior.
+      # last edited by Kofi 2024-09-19
+      - when:
+          condition: << parameters.is_node_package >>
+          steps:
+            - restore_cache:
+                name: Restore Node.js Cache
+                key:
+                  pnpm-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum
+                  "pnpm-lock.yaml" }}
+            - run:
+                name: Install Node.js Dependencies
+                command: pnpm install --frozen-lockfile
+            - save_cache:
+                name: Save Node.js Cache
+                key:
+                  pnpm-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum
+                  "pnpm-lock.yaml" }}
+                paths:
+                  - /root/.local/share/pnpm/store/v3
+                  - /root/.cache/ms-playwright
+      - restore_cache:
+          name: Restore Cargo Cache
+          key:
+            cargo-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum
+            "Cargo.lock" }}
+      - run:
+          name: Install Rust Dependencies
+          command: pnpm --recursive install:rust-addon
+      - save_cache:
+          name: Save Cargo Cache
+          key:
+            cargo-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum
+            "Cargo.lock" }}
+          paths:
+            - /root/.cargo
+
+jobs:
+  # @votingworks/pollbook-backend (conditional - only runs test when backend files change)
+  # @votingworks/pollbook-backend
+  test-apps-pollbook-backend:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install:
+          is_node_package: true
+      - run:
+          name: Build
+          command: |
+            pnpm --dir apps/pollbook/backend build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir apps/pollbook/backend lint
+      - when:
+          condition: << pipeline.parameters.run-job >>
+          steps:
+            - run:
+                name: Test
+                command: |
+                  pnpm --dir apps/pollbook/backend test
+                environment:
+                  JEST_JUNIT_OUTPUT_DIR: ./reports/
+            - store_test_results:
+                path: apps/pollbook/backend/reports/
+            - store_artifacts:
+                path: apps/pollbook/backend/src/__image_snapshots__/__diff_output__/
+
+workflows:
+  test:
+    jobs:
+      - test-apps-pollbook-backend

--- a/libs/monorepo-utils/bin/generate-circleci-config
+++ b/libs/monorepo-utils/bin/generate-circleci-config
@@ -7,17 +7,22 @@ require('esbuild-runner').install({
 });
 
 const { join } = require('path');
-const { generateConfig } = require('../src/circleci');
+const { generateAllConfigs } = require('../src/circleci');
 const { getWorkspacePackageInfo } = require('../src/pnpm');
 const { writeFileSync } = require('fs');
 
 const workspaceRoot = join(__dirname, '..', '..', '..');
 
 async function main() {
-  writeFileSync(
-    join(workspaceRoot, '.circleci', 'config.yml'),
-    generateConfig(getWorkspacePackageInfo(workspaceRoot))
-  );
+  const packageInfo = await getWorkspacePackageInfo(workspaceRoot);
+  const configs = await generateAllConfigs(packageInfo);
+  for (const [filePath, fileContents] of configs.entries()) {
+    console.log(`Writing CircleCI config to ${filePath}`);
+    writeFileSync(filePath, fileContents);
+  }
 }
 
-main();
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/libs/monorepo-utils/src/circleci.test.ts
+++ b/libs/monorepo-utils/src/circleci.test.ts
@@ -1,11 +1,24 @@
 import { expect, test } from 'vitest';
 import { join } from 'node:path';
-import { generateConfig } from './circleci';
+import { assert } from '@votingworks/basics';
+import { generateAllConfigs } from './circleci';
 import { getWorkspacePackageInfo } from './pnpm';
 
 test('generateConfig', () => {
   const root = join(__dirname, '../../..');
-  const config = generateConfig(getWorkspacePackageInfo(root));
-  expect(config).toContain('test-libs-basics');
-  expect(config).toContain('test-rust-crates');
+  const configs = generateAllConfigs(getWorkspacePackageInfo(root));
+  const keys = Array.from(configs.keys());
+  assert(keys[0] !== undefined);
+  assert(keys[1] !== undefined);
+  expect(keys[0].endsWith('.circleci/config.yml')).toEqual(true);
+  expect(
+    keys[1].endsWith('apps/pollbook/backend/.circleci/config.yml')
+  ).toEqual(true);
+
+  const mainConfig = configs.get(keys[0]);
+  const pbConfig = configs.get(keys[1]);
+  expect(mainConfig).toBeDefined();
+  expect(mainConfig).toContain('test-libs-basics');
+  expect(mainConfig).toContain('test-rust-crates');
+  expect(pbConfig).toContain('test-apps-pollbook-backend');
 });

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -10,9 +10,12 @@ function jobIdForPackage(pkg: PnpmPackageInfo): string {
 const RUST_CRATES_JOB_ID = 'test-rust-crates';
 
 const POSTGRES_PACKAGES: string[] = ['apps/design/backend'];
+// The following packages are only tested when there is a change to its directory.
+const PACKAGES_ONLY_TEST_ON_CHANGES = ['apps/pollbook/backend'];
 
 function generateTestJobForNodeJsPackage(
-  pkg: PnpmPackageInfo
+  pkg: PnpmPackageInfo,
+  isConditional?: boolean
 ): Optional<string[]> {
   if (!pkg.packageJson?.scripts?.['test']) {
     // exclude packages without tests
@@ -22,6 +25,7 @@ function generateTestJobForNodeJsPackage(
   const hasPlaywrightTests = existsSync(`${pkg.path}/playwright.config.ts`);
   const hasSnapshotTests = existsSync(`${pkg.path}/src/__image_snapshots__`);
   const needsPostgres = POSTGRES_PACKAGES.includes(pkg.relativePath);
+
   const lines = [
     `# ${pkg.name}`,
     `${jobIdForPackage(pkg)}:`,
@@ -47,30 +51,48 @@ function generateTestJobForNodeJsPackage(
     `        name: Lint`,
     `        command: |`,
     `          pnpm --dir ${pkg.relativePath} lint`,
-    `    - run:`,
-    `        name: Test`,
-    `        command: |`,
-    `          pnpm --dir ${pkg.relativePath} test`,
-    `        environment:`,
-    `          JEST_JUNIT_OUTPUT_DIR: ./reports/`,
-    `    - store_test_results:`,
-    `        path: ${pkg.relativePath}/${
-      hasPlaywrightTests ? 'test-results' : 'reports'
-    }/`,
+    ...(isConditional
+      ? [
+          `    - when:`,
+          `        condition: << pipeline.parameters.run-job >>`,
+          `        steps:`,
+          `          - run:`,
+          `              name: Test`,
+          `              command: |`,
+          `                pnpm --dir ${pkg.relativePath} test`,
+          `              environment:`,
+          `                JEST_JUNIT_OUTPUT_DIR: ./reports/`,
+          `          - store_test_results:`,
+          `              path: ${pkg.relativePath}/${
+            /* istanbul ignore next - @preserve */
+            hasPlaywrightTests ? 'test-results' : 'reports'
+          }/`,
+        ]
+      : [
+          `    - run:`,
+          `        name: Test`,
+          `        command: |`,
+          `          pnpm --dir ${pkg.relativePath} test`,
+          `        environment:`,
+          `          JEST_JUNIT_OUTPUT_DIR: ./reports/`,
+          `    - store_test_results:`,
+          `        path: ${pkg.relativePath}/${
+            hasPlaywrightTests ? 'test-results' : 'reports'
+          }/`,
+        ]),
   ];
 
   if (hasSnapshotTests || hasPlaywrightTests) {
-    lines.push(`    - store_artifacts:`);
-  }
-
-  if (hasSnapshotTests) {
-    lines.push(
-      `        path: ${pkg.relativePath}/src/__image_snapshots__/__diff_output__/`
-    );
-  }
-
-  if (hasPlaywrightTests) {
-    lines.push(`        path: ${pkg.relativePath}/test-results/`);
+    const indent = isConditional ? '          ' : '    ';
+    lines.push(`${indent}- store_artifacts:`);
+    if (hasSnapshotTests) {
+      lines.push(
+        `${indent}    path: ${pkg.relativePath}/src/__image_snapshots__/__diff_output__/`
+      );
+    }
+    if (hasPlaywrightTests) {
+      lines.push(`${indent}    path: ${pkg.relativePath}/test-results/`);
+    }
   }
 
   return lines;
@@ -100,10 +122,13 @@ function generateTestJobForRustCrates(): string[] {
   ];
 }
 
-function generateTestJobForPackage(pkg: PnpmPackageInfo): Optional<string[]> {
+function generateTestJobForPackage(
+  pkg: PnpmPackageInfo,
+  isConditional?: boolean
+): Optional<string[]> {
   /* istanbul ignore else - @preserve */
   if (pkg.packageJson) {
-    return generateTestJobForNodeJsPackage(pkg);
+    return generateTestJobForNodeJsPackage(pkg, isConditional);
   }
 
   /* istanbul ignore next - @preserve */
@@ -118,19 +143,139 @@ export const CIRCLECI_CONFIG_PATH = join(
   '../../../.circleci/config.yml'
 );
 
+function generateCircleCiAppLevelConfigPath(pkg: PnpmPackageInfo): string {
+  return join(pkg.relativePath, '.circleci', 'config.yml');
+}
+
+function generateJobFilterForPackage(pkg: PnpmPackageInfo): string[] {
+  return [
+    `    - path-filtering/filter:`,
+    `        name: check-updated-files-for-test-filter`,
+    `        base-revision: main`,
+    `        mapping: |`,
+    `          ${pkg.relativePath}/.* run-job true`,
+    `        config-path: ${generateCircleCiAppLevelConfigPath(pkg)}`,
+  ];
+}
+
+function generateCircleCiFilteredAppConfigForPackage(
+  pkg: PnpmPackageInfo
+): string[] {
+  const jobLines = generateTestJobForPackage(pkg, true); // Pass true for conditional
+  /* istanbul ignore next - @preserve */
+  if (!jobLines) {
+    return [];
+  }
+
+  return [
+    'version: 2.1',
+    '',
+    'parameters:',
+    `  run-job:`,
+    '    type: boolean',
+    '    default: false',
+    '',
+    'executors:',
+    '  nodejs:',
+    '    docker:',
+    '      - image: votingworks/cimg-debian12:4.2.0',
+    '        auth:',
+    '          username: $VX_DOCKER_USERNAME',
+    '          password: $VX_DOCKER_PASSWORD',
+    '',
+    'commands:',
+    '  checkout-and-install:',
+    '    description: Get the code and install dependencies.',
+    '    parameters:',
+    '      is_node_package:',
+    '        type: boolean',
+    '    steps:',
+    '      - run:',
+    '          name: Ensure Rust tooling is in PATH',
+    '          command: |',
+    '            echo \'export PATH="/root/.cargo/bin:$PATH"\' >> $BASH_ENV',
+    '      - checkout',
+    '      # Edit this comment somehow in order to invalidate the CircleCI cache.',
+    '      # Since the contents of this file affect the cache key, editing only a',
+    '      # comment will invalidate the cache without changing the behavior.',
+    '      # last edited by Kofi 2024-09-19',
+    '      - when:',
+    '          condition: << parameters.is_node_package >>',
+    '          steps:',
+    '            - restore_cache:',
+    '                name: Restore Node.js Cache',
+    '                key:',
+    '                  pnpm-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum',
+    '                  "pnpm-lock.yaml" }}',
+    '            - run:',
+    '                name: Install Node.js Dependencies',
+    '                command: pnpm install --frozen-lockfile',
+    '            - save_cache:',
+    '                name: Save Node.js Cache',
+    '                key:',
+    '                  pnpm-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum',
+    '                  "pnpm-lock.yaml" }}',
+    '                paths:',
+    '                  - /root/.local/share/pnpm/store/v3',
+    '                  - /root/.cache/ms-playwright',
+    '      - restore_cache:',
+    '          name: Restore Cargo Cache',
+    '          key:',
+    '            cargo-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum',
+    '            "Cargo.lock" }}',
+    '      - run:',
+    '          name: Install Rust Dependencies',
+    '          command: pnpm --recursive install:rust-addon',
+    '      - save_cache:',
+    '          name: Save Cargo Cache',
+    '          key:',
+    '            cargo-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum',
+    '            "Cargo.lock" }}',
+    '          paths:',
+    '            - /root/.cargo',
+    '',
+    'jobs:',
+    `  # ${pkg.name} (conditional - only runs test when backend files change)`,
+    ...jobLines.map((line) => `  ${line}`),
+    '',
+    'workflows:',
+    '  test:',
+    '    jobs:',
+    `      - ${jobIdForPackage(pkg)}`,
+  ];
+}
+
 /**
- * Generate a CircleCI config file.
+ * Generates all CircleCI config files.
  */
-export function generateConfig(
+export function generateAllConfigs(
   pnpmPackages: ReadonlyMap<string, PnpmPackageInfo>
-): string {
-  const pnpmJobs = [...pnpmPackages.values()].reduce((memo, pkg) => {
+): Map<string, string> {
+  const jobsToRunOnChanges = [...pnpmPackages.values()].filter((pkg) =>
+    PACKAGES_ONLY_TEST_ON_CHANGES.includes(pkg.relativePath)
+  );
+  const jobsToAlwaysRun = [...pnpmPackages.values()].filter(
+    (pkg) => !PACKAGES_ONLY_TEST_ON_CHANGES.includes(pkg.relativePath)
+  );
+  const pnpmJobs = [...jobsToAlwaysRun.values()].reduce((memo, pkg) => {
     const jobLines = generateTestJobForPackage(pkg);
     if (!jobLines) {
       return memo;
     }
     return memo.set(pkg, jobLines);
   }, new Map<PnpmPackageInfo, string[]>());
+  const pnpmJobsToFilter = [...jobsToRunOnChanges.values()].reduce(
+    (memo, pkg) => {
+      const jobLines = generateJobFilterForPackage(pkg);
+      /* istanbul ignore next - @preserve */
+      if (!jobLines) {
+        return memo;
+      }
+      return memo.set(pkg, jobLines);
+    },
+    new Map<PnpmPackageInfo, string[]>()
+  );
+
   const rustJobLines = generateTestJobForRustCrates();
 
   const jobIds = [
@@ -140,11 +285,16 @@ export function generateConfig(
     RUST_CRATES_JOB_ID,
   ];
 
-  return `
+  const baseConfig = `
 # THIS FILE IS GENERATED. DO NOT EDIT IT DIRECTLY.
 # Run \`pnpm -w generate-circleci-config\` to regenerate it.
 
 version: 2.1
+
+setup: true
+
+orbs:
+  path-filtering: circleci/path-filtering@1
 
 executors:
   nodejs:
@@ -190,6 +340,10 @@ ${rustJobLines.map((line) => `  ${line}\n`).join('')}
 workflows:
   test:
     jobs:
+
+${[...pnpmJobsToFilter.values()]
+  .map((lines) => lines.map((line) => `  ${line}`).join('\n'))
+  .join('\n\n')}
 ${jobIds.map((jobId) => `      - ${jobId}`).join('\n')}
 
 commands:
@@ -239,4 +393,20 @@ commands:
           paths:
             - /root/.cargo
 `.trim();
+  const configs = new Map();
+  configs.set(CIRCLECI_CONFIG_PATH, baseConfig);
+  for (const pkg of jobsToRunOnChanges) {
+    const filteredConfigLines =
+      generateCircleCiFilteredAppConfigForPackage(pkg);
+    /* istanbul ignore else - @preserve */
+    if (filteredConfigLines.length > 0) {
+      const filteredConfigPath = join(
+        __dirname,
+        '../../..',
+        generateCircleCiAppLevelConfigPath(pkg)
+      );
+      configs.set(filteredConfigPath, filteredConfigLines.join('\n').trim());
+    }
+  }
+  return configs;
 }

--- a/libs/monorepo-utils/src/index.ts
+++ b/libs/monorepo-utils/src/index.ts
@@ -1,7 +1,7 @@
 /* istanbul ignore file - no logic, just exports */
 export {
   CIRCLECI_CONFIG_PATH,
-  generateConfig as generateCircleCiConfig,
+  generateAllConfigs as generateAllCircleCiConfigs,
 } from './circleci';
 export * from './dependencies';
 export { getWorkspacePackageInfo, getWorkspacePackagePaths } from './pnpm';

--- a/script/src/validate-monorepo/validation/circleci.ts
+++ b/script/src/validate-monorepo/validation/circleci.ts
@@ -1,7 +1,7 @@
 import {
   CIRCLECI_CONFIG_PATH,
   PnpmPackageInfo,
-  generateCircleCiConfig,
+  generateAllCircleCiConfigs,
 } from '@votingworks/monorepo-utils';
 import { readFileSync } from 'node:fs';
 
@@ -31,13 +31,15 @@ export interface OutdatedConfig {
 export function* checkConfig(
   workspacePackages: ReadonlyMap<string, PnpmPackageInfo>
 ): Generator<ValidationIssue> {
-  const expectedCircleCiConfig = generateCircleCiConfig(workspacePackages);
-  const actualConfig = readFileSync(CIRCLECI_CONFIG_PATH, 'utf-8');
+  const expectedCircleCiConfigs = generateAllCircleCiConfigs(workspacePackages);
+  for (const [path, expectedConfig] of expectedCircleCiConfigs) {
+    const actualConfig = readFileSync(path, 'utf-8');
 
-  if (expectedCircleCiConfig !== actualConfig) {
-    yield {
-      kind: ValidationIssueKind.OutdatedConfig,
-      configPath: CIRCLECI_CONFIG_PATH,
-    };
+    if (expectedConfig !== actualConfig) {
+      yield {
+        kind: ValidationIssueKind.OutdatedConfig,
+        configPath: path,
+      };
+    }
   }
 }


### PR DESCRIPTION
## Overview
In order to avoid flaky pollbook tests bothering the rest of vxsuite but still run them for pollbook changes we will now only run the "test" step of apps-pollbook-backend when there are changes in the apps/pollbook/backend directory. You can see whether or not tests were run by looking at the apps-pollbook-backend CI step and looking for the "test" step. You can also look at the output of check-updated-files-for-test-filter  which is the CI step that runs first and decides how to run the pollbook step. 

Set up in the circle CI config generation script so that we can move other apps to this model in the future if we wish. A new second circle ci config will now live in apps/pollbook/backend for the pollbook ci config. 

https://github.com/votingworks/vxsuite/issues/6853

## Testing Plan
See this branch: https://github.com/votingworks/vxsuite/tree/caro/tmp/nonpbtest for an example of when the apps pollbook backend changes are NOT triggered. Note I had to change the circle ci config manually on that branch so the validate-monorepo step is expected to fail. Since this PR changes things in apps/pollbook/backend this PR is an example where it IS triggered. 

