### PR TITLE
test: update all non-UI tests to vitest v3

### DIFF
--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -31,14 +31,14 @@
   "devDependencies": {
     "@types/node": "20.17.31",
     "@types/text-encoding": "^0.0.35",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/fixtures": "workspace:*",
     "eslint-plugin-vx": "workspace:*",
     "fast-check": "2.23.2",
     "is-ci-cli": "2.2.0",
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "engines": {
     "node": ">= 12"

--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -55,7 +55,7 @@
     "@types/node": "20.17.31",
     "@types/node-quirc": "workspace:*",
     "@types/tmp": "0.2.4",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/bmd-ballot-fixtures": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/fs": "workspace:*",
@@ -69,7 +69,7 @@
     "jest-image-snapshot": "^6.4.0",
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/ballot-interpreter/vitest.config.ts
+++ b/libs/ballot-interpreter/vitest.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
     setupFiles: ['src/setupTests.ts'],
     coverage: {
       thresholds: {
-        lines: 51,
-        branches: 47,
+        lines: -275,
+        branches: -139,
       },
     },
   },

--- a/libs/basics/package.json
+++ b/libs/basics/package.json
@@ -29,13 +29,13 @@
   "devDependencies": {
     "@types/deep-eql": "^4.0.2",
     "@types/node": "20.17.31",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "eslint-plugin-vx": "workspace:*",
     "fast-check": "2.23.2",
     "is-ci-cli": "2.2.0",
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/bmd-ballot-fixtures/package.json
+++ b/libs/bmd-ballot-fixtures/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@types/jest-image-snapshot": "^6.4.0",
     "@types/react": "18.3.3",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",
     "jest-image-snapshot": "^6.4.0",
@@ -51,7 +51,7 @@
     "react-dom": "18.3.1",
     "sort-package-json": "^1.50.0",
     "util": "^0.12.4",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "peerDependencies": {
     "react": "18.3.1"

--- a/libs/cdf-schema-builder/package.json
+++ b/libs/cdf-schema-builder/package.json
@@ -37,12 +37,12 @@
     "@types/jsdom": "20.0.0",
     "@types/json-schema": "^7.0.9",
     "@types/node": "20.17.31",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "engines": {
     "node": ">= 12"

--- a/libs/cdf-schema-builder/vitest.config.ts
+++ b/libs/cdf-schema-builder/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
       exclude: ['./test/mock_writable.ts', '**/*.test.ts'],
       thresholds: {
         lines: 100,
-        branches: 95,
+        branches: -6,
       },
     },
   },

--- a/libs/custom-paper-handler/package.json
+++ b/libs/custom-paper-handler/package.json
@@ -37,13 +37,13 @@
     "@types/debug": "4.1.8",
     "@types/node": "20.17.31",
     "@types/w3c-web-usb": "1.0.8",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/test-utils": "workspace:*",
     "esbuild": "0.21.2",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/custom-scanner/package.json
+++ b/libs/custom-scanner/package.json
@@ -37,7 +37,7 @@
     "@types/debug": "4.1.8",
     "@types/node": "20.17.31",
     "@types/w3c-web-usb": "1.0.8",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/test-utils": "workspace:*",
     "esbuild": "0.21.2",
     "esbuild-runner": "2.2.2",
@@ -45,7 +45,7 @@
     "fast-check": "2.23.2",
     "is-ci-cli": "2.2.0",
     "vite": "4.5.2",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/custom-scanner/vitest.config.ts
+++ b/libs/custom-scanner/vitest.config.ts
@@ -11,8 +11,8 @@ export default defineConfig({
         '**/*.test.ts',
       ],
       thresholds: {
-        lines: 99,
-        branches: 98,
+        lines: -1,
+        branches: -5,
       },
     },
   },

--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -33,11 +33,11 @@
     "@types/debug": "4.1.8",
     "@types/node": "20.17.31",
     "@types/tmp": "0.2.4",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/fixtures": "workspace:*",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",
     "tmp": "^0.2.1",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   }
 }

--- a/libs/db/src/client.test.ts
+++ b/libs/db/src/client.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi } from 'vitest';
+import { SqliteError } from 'better-sqlite3';
 import * as fs from 'node:fs';
 import { join } from 'node:path';
 import { makeTemporaryFile } from '@votingworks/fixtures';
@@ -137,7 +138,7 @@ test('file database client with regex enabled in connectionOptions', () => {
     mockBaseLogger({ fn: vi.fn })
   );
   expect(() => anotherClient.all(queryString, '.*ermi.*')).toThrow(
-    new Error('no such function: REGEXP')
+    new SqliteError('no such function: REGEXP', 'SQLITE_ERROR')
   );
 
   client.destroy();

--- a/libs/dev-dock/backend/package.json
+++ b/libs/dev-dock/backend/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@types/express": "4.17.14",
     "@types/node": "20.17.31",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/hmpb": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
@@ -48,7 +48,7 @@
     "is-ci-cli": "2.2.0",
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/dev-dock/backend/vitest.config.ts
+++ b/libs/dev-dock/backend/vitest.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
     setupFiles: ['./test/setupTests.ts'],
     coverage: {
       thresholds: {
-        lines: 76,
-        branches: 64,
+        lines: -5,
+        branches: -3,
       },
     },
   },

--- a/libs/eslint-plugin-vx/package.json
+++ b/libs/eslint-plugin-vx/package.json
@@ -46,10 +46,10 @@
     "@types/node": "20.17.31",
     "@types/react": "18.3.3",
     "@typescript-eslint/rule-tester": "^6.7.0",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "eslint-plugin-vitest": "^0.5.4",
     "is-ci-cli": "2.2.0",
     "react": "18.3.1",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   }
 }

--- a/libs/eslint-plugin-vx/vitest.config.ts
+++ b/libs/eslint-plugin-vx/vitest.config.ts
@@ -13,8 +13,8 @@ export default defineConfig({
         'src/util/index.ts',
       ],
       thresholds: {
-        lines: 99,
-        branches: 98,
+        lines: -1,
+        branches: -9,
       },
     },
   },

--- a/libs/fixture-generators/package.json
+++ b/libs/fixture-generators/package.json
@@ -52,13 +52,13 @@
     "@types/tmp": "0.2.4",
     "@types/uuid": "9.0.5",
     "@types/yargs": "17.0.22",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",
     "tmp": "^0.2.1",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "engines": {
     "node": ">= 12"

--- a/libs/fixture-generators/vitest.config.ts
+++ b/libs/fixture-generators/vitest.config.ts
@@ -12,8 +12,8 @@ export default defineConfig({
         '**/*.test.ts',
       ],
       thresholds: {
-        lines: 95,
-        branches: 80,
+        lines: -4,
+        branches: -18,
       },
     },
     alias: [

--- a/libs/fixtures/package.json
+++ b/libs/fixtures/package.json
@@ -36,12 +36,12 @@
   },
   "devDependencies": {
     "@types/node": "20.17.31",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/fs/package.json
+++ b/libs/fs/package.json
@@ -39,7 +39,7 @@
     "@types/debug": "4.1.8",
     "@types/node": "20.17.31",
     "@types/tmp": "0.2.4",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "eslint-plugin-vx": "workspace:*",
@@ -49,7 +49,7 @@
     "memory-streams": "^0.1.3",
     "sort-package-json": "^1.50.0",
     "tmp": "^0.2.1",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/grout/package.json
+++ b/libs/grout/package.json
@@ -33,14 +33,14 @@
     "@types/express": "4.17.14",
     "@types/luxon": "^3.0.0",
     "@types/node-fetch": "^2.6.0",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "eslint-plugin-vx": "workspace:*",
     "expect-type": "^0.15.0",
     "express": "4.18.2",
     "is-ci-cli": "2.2.0",
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8",
+    "vitest": "^3.1.1",
     "wait-for-expect": "^3.0.2"
   },
   "packageManager": "pnpm@8.15.5"

--- a/libs/grout/src/grout.test.ts
+++ b/libs/grout/src/grout.test.ts
@@ -466,7 +466,7 @@ test('before middleware errors are caught, returned to client, and passed to aft
       expect(methodCall.methodName).toEqual('getStuff');
       expect(methodCall.input).toEqual(undefined);
       expect(methodCall.context).toEqual({});
-      expect(result).toEqual(err(new ServerError('middleware error')));
+      expect(result).toEqual(err(new UserError('middleware error')));
     }
   );
 

--- a/libs/grout/test-utils/package.json
+++ b/libs/grout/test-utils/package.json
@@ -26,14 +26,14 @@
     "@votingworks/test-utils": "workspace:*"
   },
   "devDependencies": {
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/grout": "workspace:*",
     "eslint-plugin-vx": "workspace:*",
     "expect-type": "^0.15.0",
     "is-ci-cli": "2.2.0",
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "peerDependencies": {
     "@votingworks/grout": "workspace:*"

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -43,7 +43,7 @@
     "@types/kiosk-browser": "workspace:*",
     "@types/node": "20.17.31",
     "@types/yargs": "17.0.22",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "esbuild": "0.21.2",
@@ -53,7 +53,7 @@
     "is-ci-cli": "2.2.0",
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/message-coder/package.json
+++ b/libs/message-coder/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "20.17.31",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "eslint-plugin-vx": "workspace:*",
     "fast-check": "2.23.2",
     "is-ci-cli": "2.2.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/monorepo-utils/package.json
+++ b/libs/monorepo-utils/package.json
@@ -29,7 +29,7 @@
     "@types/node": "20.17.31",
     "@typescript-eslint/eslint-plugin": "6.7.0",
     "@typescript-eslint/parser": "6.7.0",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "esbuild-runner": "2.2.2",
     "eslint": "8.57.0",
     "eslint-config-prettier": "^9.0.0",
@@ -43,7 +43,7 @@
     "prettier": "3.0.3",
     "sort-package-json": "^1.50.0",
     "typescript": "5.8.3",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/pdi-scanner/package.json
+++ b/libs/pdi-scanner/package.json
@@ -41,12 +41,12 @@
   "devDependencies": {
     "@types/debug": "4.1.8",
     "@types/node": "20.17.31",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/test-utils": "workspace:*",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/pdi-scanner/vitest.config.ts
+++ b/libs/pdi-scanner/vitest.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
     coverage: {
       exclude: ['src/ts/index.ts', 'src/ts/demo.ts'],
       thresholds: {
-        lines: 100,
-        branches: 93,
+        lines: -3,
+        branches: -3,
       },
     },
   },

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -44,12 +44,12 @@
     "@types/node": "20.17.31",
     "@types/react": "18.3.3",
     "@types/zip-stream": "workspace:*",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/test-utils/vitest.config.ts
+++ b/libs/test-utils/vitest.config.ts
@@ -4,8 +4,8 @@ export default defineConfig({
   test: {
     coverage: {
       thresholds: {
-        lines: 70,
-        branches: 40,
+        lines: -40,
+        branches: -47,
       },
     },
   },

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -44,7 +44,7 @@
     "@types/lodash.setwith": "^4.3.9",
     "@types/node": "20.17.31",
     "@types/react": "18.3.3",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/cdf-schema-builder": "workspace:*",
     "ajv": "^8.12.0",
     "ajv-draft-04": "^1.0.0",
@@ -57,7 +57,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.set": "^4.3.2",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/types/vitest.config.ts
+++ b/libs/types/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: 100,
-        branches: 98,
+        branches: -7,
       },
     },
   },

--- a/libs/usb-drive/package.json
+++ b/libs/usb-drive/package.json
@@ -36,14 +36,14 @@
     "@types/debug": "4.1.8",
     "@types/node": "20.17.31",
     "@types/tmp": "0.2.4",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "esbuild": "0.21.2",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",
     "lint-staged": "11.0.0",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/usb-drive/vitest.config.ts
+++ b/libs/usb-drive/vitest.config.ts
@@ -6,8 +6,8 @@ export default defineConfig({
     coverage: {
       exclude: ['src/cli.ts', 'src/mocks', 'src/**/*.test.ts'],
       thresholds: {
-        lines: 99,
-        branches: 94,
+        lines: -1,
+        branches: -2,
       },
     },
   },

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -48,7 +48,7 @@
     "@types/randombytes": "^2.0.0",
     "@types/tmp": "0.2.4",
     "@types/yargs": "17.0.22",
-    "@vitest/coverage-istanbul": "^2.1.8",
+    "@vitest/coverage-istanbul": "^3.1.1",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "eslint-plugin-vx": "workspace:*",
@@ -58,7 +58,7 @@
     "lint-staged": "11.0.0",
     "node-fetch": "^2.6.0",
     "sort-package-json": "^1.50.0",
-    "vitest": "^2.1.8"
+    "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@8.15.5"
 }

--- a/libs/utils/vitest.config.ts
+++ b/libs/utils/vitest.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
     setupFiles: ['src/setupTests.ts'],
     coverage: {
       thresholds: {
-        lines: 94,
-        branches: 91,
+        lines: -45,
+        branches: -37,
       },
       exclude: [
         '**/*.test.ts',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   '@babel/traverse': 7.23.2
   '@types/eslint': 8.4.1
@@ -124,7 +128,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        version: 2.1.8(jsdom@20.0.1)
 
   apps/admin/backend:
     dependencies:
@@ -1458,7 +1462,7 @@ importers:
         version: 4.5.2(@types/node@20.17.31)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        version: 2.1.8(jsdom@20.0.1)
 
   apps/mark-scan/backend:
     dependencies:
@@ -1823,7 +1827,7 @@ importers:
         version: 4.5.2(@types/node@20.17.31)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        version: 2.1.8(jsdom@20.0.1)
 
   apps/mark-scan/frontend/prodserver:
     dependencies:
@@ -2198,7 +2202,7 @@ importers:
         version: 4.5.2(@types/node@20.17.31)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        version: 2.1.8(jsdom@20.0.1)
 
   apps/mark/frontend/prodserver:
     dependencies:
@@ -2621,7 +2625,7 @@ importers:
         version: 4.5.2(@types/node@20.17.31)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        version: 2.1.8(jsdom@20.0.1)
 
   apps/pollbook/frontend/prodserver:
     dependencies:
@@ -3175,7 +3179,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^3.1.1
-        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.17.31)
+        version: 3.1.1(@types/debug@4.1.8)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3359,8 +3363,8 @@ importers:
         specifier: ^0.0.35
         version: 0.0.35
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures
@@ -3380,8 +3384,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/node@20.17.31)(jsdom@20.0.1)
 
   libs/ballot-interpreter:
     dependencies:
@@ -3450,8 +3454,8 @@ importers:
         specifier: 0.2.4
         version: 0.2.4
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/bmd-ballot-fixtures':
         specifier: workspace:*
         version: link:../bmd-ballot-fixtures
@@ -3492,8 +3496,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.17.31)
 
   libs/basics:
     dependencies:
@@ -3511,8 +3515,8 @@ importers:
         specifier: 20.17.31
         version: 20.17.31
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -3529,8 +3533,8 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/node@20.17.31)(jsdom@20.0.1)
 
   libs/bmd-ballot-fixtures:
     dependencies:
@@ -3569,8 +3573,8 @@ importers:
         specifier: 18.3.3
         version: 18.3.3
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -3596,8 +3600,8 @@ importers:
         specifier: ^0.12.4
         version: 0.12.4
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)
 
   libs/cdf-schema-builder:
     dependencies:
@@ -3624,8 +3628,8 @@ importers:
         specifier: 20.17.31
         version: 20.17.31
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -3639,8 +3643,8 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/node@20.17.31)(jsdom@20.0.1)
 
   libs/custom-paper-handler:
     dependencies:
@@ -3685,8 +3689,8 @@ importers:
         specifier: 1.0.8
         version: 1.0.8
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/test-utils':
         specifier: workspace:*
         version: link:../test-utils
@@ -3703,8 +3707,8 @@ importers:
         specifier: 2.2.0
         version: 2.2.0
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.17.31)
 
   libs/custom-scanner:
     dependencies:
@@ -3743,8 +3747,8 @@ importers:
         specifier: 1.0.8
         version: 1.0.8
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/test-utils':
         specifier: workspace:*
         version: link:../test-utils
@@ -3767,8 +3771,8 @@ importers:
         specifier: 4.5.2
         version: 4.5.2(@types/node@20.17.31)
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.17.31)
 
   libs/db:
     dependencies:
@@ -3798,8 +3802,8 @@ importers:
         specifier: 0.2.4
         version: 0.2.4
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures
@@ -3813,8 +3817,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.17.31)
 
   libs/dev-dock/backend:
     dependencies:
@@ -3859,8 +3863,8 @@ importers:
         specifier: 20.17.31
         version: 20.17.31
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../../fixtures
@@ -3889,8 +3893,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/node@20.17.31)(jsdom@20.0.1)
 
   libs/dev-dock/frontend:
     dependencies:
@@ -4044,11 +4048,11 @@ importers:
         specifier: ^6.7.0
         version: 6.21.0(@eslint/eslintrc@2.1.4)(eslint@8.57.0)(typescript@5.8.3)
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       eslint-plugin-vitest:
         specifier: ^0.5.4
-        version: 0.5.4(@typescript-eslint/eslint-plugin@6.7.0)(eslint@8.57.0)(typescript@5.8.3)(vitest@2.1.8)
+        version: 0.5.4(@typescript-eslint/eslint-plugin@6.7.0)(eslint@8.57.0)(typescript@5.8.3)(vitest@3.1.1)
       is-ci-cli:
         specifier: 2.2.0
         version: 2.2.0
@@ -4056,8 +4060,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/node@20.17.31)(jsdom@20.0.1)
 
   libs/fixture-generators:
     dependencies:
@@ -4132,8 +4136,8 @@ importers:
         specifier: 17.0.22
         version: 17.0.22
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures
@@ -4150,8 +4154,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.17.31)
 
   libs/fixtures:
     dependencies:
@@ -4175,8 +4179,8 @@ importers:
         specifier: 20.17.31
         version: 20.17.31
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -4190,8 +4194,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/node@20.17.31)(jsdom@20.0.1)
 
   libs/fs:
     dependencies:
@@ -4230,8 +4234,8 @@ importers:
         specifier: 0.2.4
         version: 0.2.4
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures
@@ -4260,8 +4264,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.17.31)
 
   libs/fujitsu-thermal-printer:
     dependencies:
@@ -4352,8 +4356,8 @@ importers:
         specifier: ^2.6.0
         version: 2.6.2
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -4373,8 +4377,8 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -4386,8 +4390,8 @@ importers:
         version: link:../../test-utils
     devDependencies:
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/grout':
         specifier: workspace:*
         version: link:..
@@ -4407,8 +4411,8 @@ importers:
         specifier: ^1.50.0
         version: 1.53.1
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)
 
   libs/hmpb:
     dependencies:
@@ -4650,8 +4654,8 @@ importers:
         specifier: 17.0.22
         version: 17.0.22
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures
@@ -4680,8 +4684,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.17.31)
 
   libs/logging-utils:
     devDependencies:
@@ -4723,7 +4727,7 @@ importers:
         version: 0.2.1
       vitest:
         specifier: ^3.1.1
-        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.17.31)
+        version: 3.1.1(@types/debug@4.1.8)
 
   libs/mark-flow-ui:
     dependencies:
@@ -4937,8 +4941,8 @@ importers:
         specifier: 20.17.31
         version: 20.17.31
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -4949,8 +4953,8 @@ importers:
         specifier: 2.2.0
         version: 2.2.0
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/node@20.17.31)(jsdom@20.0.1)
 
   libs/monorepo-utils:
     dependencies:
@@ -4968,8 +4972,8 @@ importers:
         specifier: 6.7.0
         version: 6.7.0(eslint@8.57.0)(typescript@5.8.3)
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       esbuild-runner:
         specifier: 2.2.2
         version: 2.2.2(esbuild@0.21.2)
@@ -5010,8 +5014,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/node@20.17.31)(jsdom@20.0.1)
 
   libs/pdi-scanner:
     dependencies:
@@ -5041,8 +5045,8 @@ importers:
         specifier: 20.17.31
         version: 20.17.31
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/test-utils':
         specifier: workspace:*
         version: link:../test-utils
@@ -5056,8 +5060,8 @@ importers:
         specifier: 2.2.0
         version: 2.2.0
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.17.31)
 
   libs/printing:
     dependencies:
@@ -5214,8 +5218,8 @@ importers:
         specifier: workspace:*
         version: link:../@types/zip-stream
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -5229,8 +5233,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/node@20.17.31)(jsdom@20.0.1)
 
   libs/types:
     dependencies:
@@ -5272,8 +5276,8 @@ importers:
         specifier: 18.3.3
         version: 18.3.3
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/cdf-schema-builder':
         specifier: workspace:*
         version: link:../cdf-schema-builder
@@ -5311,8 +5315,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/node@20.17.31)(jsdom@20.0.1)
 
   libs/ui:
     dependencies:
@@ -5622,8 +5626,8 @@ importers:
         specifier: 0.2.4
         version: 0.2.4
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       esbuild:
         specifier: 0.21.2
         version: 0.21.2
@@ -5643,8 +5647,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.17.31)
 
   libs/utils:
     dependencies:
@@ -5710,8 +5714,8 @@ importers:
         specifier: 17.0.22
         version: 17.0.22
       '@vitest/coverage-istanbul':
-        specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8)
+        specifier: ^3.1.1
+        version: 3.1.1(vitest@3.1.1)
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures
@@ -5740,8 +5744,8 @@ importers:
         specifier: ^1.50.0
         version: 1.50.0
       vitest:
-        specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.8)(@types/node@20.17.31)
 
   script:
     dependencies:
@@ -9585,7 +9589,7 @@ packages:
   /@joshwooding/vite-plugin-react-docgen-typescript@0.2.1(typescript@5.8.3)(vite@4.5.2):
     resolution: {integrity: sha512-ou4ZJSXMMWHqGS4g8uNRbC5TiTWxAgQZiVucoUrOCWuPrTbkpJbmVyIi9jU72SBry7gQtuMEDp4YR8EEXAg7VQ==}
     peerDependencies:
-      typescript: '>= 4.3.x'
+      typescript: 5.8.3
       vite: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       typescript:
@@ -12025,7 +12029,7 @@ packages:
     resolution: {integrity: sha512-3YDxZPJsHOsRQob/85X2Xf6pYfwbQilJBsEcuwmEV0JEO4p3JijOlO8xV58uCjkZSpuJ0ARl6t5oCMBo89DKCQ==}
     peerDependencies:
       '@preact/preset-vite': '*'
-      typescript: '>= 4.3.x'
+      typescript: 5.8.3
       vite: ^3.0.0 || ^4.0.0
       vite-plugin-glimmerx: '*'
     peerDependenciesMeta:
@@ -12483,7 +12487,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-      typescript: '*'
+      typescript: 5.8.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -16728,7 +16732,7 @@ packages:
     resolution: {integrity: sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': '>=8.0.0'
+      '@types/eslint': 8.4.1
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
       prettier: '>=3.0.0'
@@ -16794,7 +16798,7 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@6.7.0)(eslint@8.57.0)(typescript@5.8.3)(vitest@2.1.8):
+  /eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@6.7.0)(eslint@8.57.0)(typescript@5.8.3)(vitest@3.1.1):
     resolution: {integrity: sha512-um+odCkccAHU53WdKAw39MY61+1x990uXjSPguUCq3VcEHdqJrOb8OTMrbYlY6f9jAKx7x98kLVlIe3RJeJqoQ==}
     engines: {node: ^18.0.0 || >= 20.0.0}
     peerDependencies:
@@ -16810,7 +16814,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.57.0)(typescript@5.8.3)
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.8.3)
       eslint: 8.57.0
-      vitest: 2.1.8(@types/node@20.17.31)(jsdom@20.0.1)
+      vitest: 3.1.1(@types/node@20.17.31)(jsdom@20.0.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -21728,7 +21732,7 @@ packages:
   /react-docgen-typescript@2.2.2(typescript@5.8.3):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
-      typescript: '>= 4.3.x'
+      typescript: 5.8.3
     dependencies:
       typescript: 5.8.3
     dev: true
@@ -23613,7 +23617,7 @@ packages:
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
     engines: {node: '>=16'}
     peerDependencies:
-      typescript: '>=4.2.0'
+      typescript: 5.8.3
     dependencies:
       typescript: 5.8.3
 
@@ -23632,7 +23636,7 @@ packages:
       babel-jest: ^29.0.0
       esbuild: '*'
       jest: ^29.0.0
-      typescript: '>=4.3 <6'
+      typescript: 5.8.3
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -23682,7 +23686,7 @@ packages:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+      typescript: 5.8.3
     dependencies:
       tslib: 1.14.1
       typescript: 5.8.3
@@ -24382,6 +24386,128 @@ packages:
       - supports-color
       - terser
 
+  /vitest@2.1.8(jsdom@20.0.1):
+    resolution: {integrity: sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.8
+      '@vitest/ui': 2.1.8
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@vitest/expect': 2.1.8
+      '@vitest/mocker': 2.1.8(vite@5.4.18)
+      '@vitest/pretty-format': 2.1.8
+      '@vitest/runner': 2.1.8
+      '@vitest/snapshot': 2.1.8
+      '@vitest/spy': 2.1.8
+      '@vitest/utils': 2.1.8
+      chai: 5.1.2
+      debug: 4.4.0
+      expect-type: 1.1.0
+      jsdom: 20.0.1
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.2
+      tinyrainbow: 1.2.0
+      vite: 5.4.18(@types/node@20.17.31)
+      vite-node: 2.1.8(@types/node@20.17.31)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest@3.1.1(@types/debug@4.1.8):
+    resolution: {integrity: sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.1.1
+      '@vitest/ui': 3.1.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/debug': 4.1.8
+      '@vitest/expect': 3.1.1
+      '@vitest/mocker': 3.1.1(vite@6.3.1)
+      '@vitest/pretty-format': 3.1.1
+      '@vitest/runner': 3.1.1
+      '@vitest/snapshot': 3.1.1
+      '@vitest/spy': 3.1.1
+      '@vitest/utils': 3.1.1
+      chai: 5.2.0
+      debug: 4.4.0
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 6.3.1(@types/node@20.17.31)
+      vite-node: 3.1.1(@types/node@20.17.31)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    dev: true
+
   /vitest@3.1.1(@types/debug@4.1.8)(@types/node@20.17.31):
     resolution: {integrity: sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -24445,6 +24571,71 @@ packages:
       - terser
       - tsx
       - yaml
+
+  /vitest@3.1.1(@types/node@20.17.31)(jsdom@20.0.1):
+    resolution: {integrity: sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.1.1
+      '@vitest/ui': 3.1.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 20.17.31
+      '@vitest/expect': 3.1.1
+      '@vitest/mocker': 3.1.1(vite@6.3.1)
+      '@vitest/pretty-format': 3.1.1
+      '@vitest/runner': 3.1.1
+      '@vitest/snapshot': 3.1.1
+      '@vitest/spy': 3.1.1
+      '@vitest/utils': 3.1.1
+      chai: 5.2.0
+      debug: 4.4.0
+      expect-type: 1.2.1
+      jsdom: 20.0.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 6.3.1(@types/node@20.17.31)
+      vite-node: 3.1.1(@types/node@20.17.31)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    dev: true
 
   /void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
@@ -24794,7 +24985,3 @@ packages:
   /zod@3.25.42:
     resolution: {integrity: sha512-PcALTLskaucbeHc41tU/xfjfhcz8z0GdhhDcSgrCTmSazUuqnYqiXO63M0QUBVwpBlsLsNVn5qHSC5Dw3KZvaQ==}
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Overview

There seems to be a problem with running `libs/ui` under vitest v3 such that `styled-components`'s `p.theme` is an empty object rather than the expected theme object. I dug into why a bit, but didn't come up with any explanations.

Where relevant, I updated all the coverage thresholds to use negative values (absolute counts instead of percentages). The only code changes were due to [vitest v3 being stricter about matching errors in `toThrow` et al](https://vitest.dev/guide/migration.html#more-strict-error-equality).

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.
