### PR TITLE
ignore hidden directories in VxAdmin election packages search

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -375,7 +375,10 @@ function buildApi({
     > {
       const potentialElectionPackages: FileSystemEntry[] = [];
 
-      for await (const result of listDirectoryOnUsbDrive(usbDrive, '', 3)) {
+      for await (const result of listDirectoryOnUsbDrive(usbDrive, '', {
+        depth: 3,
+        excludeHidden: true,
+      })) {
         if (result.isErr()) {
           return result;
         }

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -387,9 +387,7 @@ function buildApi({
 
         if (
           entry.type === FileSystemEntryType.File &&
-          entry.name.endsWith('.zip') &&
-          !entry.name.startsWith('.') &&
-          !entry.name.startsWith('_')
+          entry.name.endsWith('.zip')
         ) {
           potentialElectionPackages.push(entry);
         }

--- a/libs/fs/src/list_directory.test.ts
+++ b/libs/fs/src/list_directory.test.ts
@@ -64,7 +64,7 @@ describe('listDirectory', () => {
     writeFileSync(join(subSubdirectory, 'sub-sub-file-1'), '');
 
     expect(
-      await unwrapAndSortEntries(listDirectory(directory, 1))
+      await unwrapAndSortEntries(listDirectory(directory, { depth: 1 }))
     ).toMatchObject(
       ['file-1', 'file-2', 'subdirectory'].map((name) =>
         expect.objectContaining({ name })
@@ -72,7 +72,7 @@ describe('listDirectory', () => {
     );
 
     expect(
-      await unwrapAndSortEntries(listDirectory(directory, 2))
+      await unwrapAndSortEntries(listDirectory(directory, { depth: 2 }))
     ).toMatchObject(
       [
         'file-1',
@@ -84,7 +84,7 @@ describe('listDirectory', () => {
     );
 
     expect(
-      await unwrapAndSortEntries(listDirectory(directory, 3))
+      await unwrapAndSortEntries(listDirectory(directory, { depth: 3 }))
     ).toMatchObject(
       [
         'file-1',
@@ -97,7 +97,7 @@ describe('listDirectory', () => {
     );
 
     expect(
-      await unwrapAndSortEntries(listDirectory(directory, 4))
+      await unwrapAndSortEntries(listDirectory(directory, { depth: 4 }))
     ).toMatchObject(
       [
         'file-1',

--- a/libs/fs/src/list_directory.ts
+++ b/libs/fs/src/list_directory.ts
@@ -64,7 +64,7 @@ export interface ListDirectoryOptions {
 
 const DEFAULT_LIST_DIRECTORY_OPTIONS: Required<ListDirectoryOptions> = {
   depth: 1,
-  excludeHidden: true,
+  excludeHidden: false,
 } as const;
 
 /**

--- a/libs/fs/src/list_directory.ts
+++ b/libs/fs/src/list_directory.ts
@@ -54,11 +54,15 @@ export type ListDirectoryError =
 
 /**
  * Options for listing directories.
- * - `depth`: How deep to traverse directories. Defaults to 1 (not recursive).
- * - `includeHidden`: Whether to include hidden files (those starting with a dot or underscore).
  */
 export interface ListDirectoryOptions {
+  /**
+   * How deep to traverse directories. Defaults to 1 (not recursive).
+   */
   depth?: number;
+  /**
+   * Whether to include hidden files (those starting with a dot or underscore).
+   */
   excludeHidden?: boolean;
 }
 

--- a/libs/usb-drive/src/list_directory_on_usb_drive.ts
+++ b/libs/usb-drive/src/list_directory_on_usb_drive.ts
@@ -2,6 +2,7 @@ import { Result, err, throwIllegalValue } from '@votingworks/basics';
 import {
   FileSystemEntry,
   ListDirectoryError,
+  ListDirectoryOptions,
   listDirectory,
 } from '@votingworks/fs';
 import { join } from 'node:path';
@@ -21,7 +22,7 @@ export type ListDirectoryOnUsbDriveError =
 export async function* listDirectoryOnUsbDrive(
   usbDrive: UsbDrive,
   relativePath: string,
-  depth = 1
+  options: ListDirectoryOptions = {}
 ): AsyncGenerator<Result<FileSystemEntry, ListDirectoryOnUsbDriveError>> {
   const usbDriveStatus = await usbDrive.status();
 
@@ -38,7 +39,7 @@ export async function* listDirectoryOnUsbDrive(
     case 'mounted':
       yield* listDirectory(
         join(usbDriveStatus.mountPoint, relativePath),
-        depth
+        options
       );
       break;
 


### PR DESCRIPTION
## Overview

Closes #6841. Updates the `listDirectory` method underlying VxAdmin's search for election packages on a USB drive to ignore not only hidden files but also hidden directories and their contents.
