### PR TITLE
Apply OOS DL US state to check-in page when there's exactly 1 hit for ID scan

### DIFF
--- a/apps/pollbook/frontend/src/poll_worker_screen.tsx
+++ b/apps/pollbook/frontend/src/poll_worker_screen.tsx
@@ -45,7 +45,12 @@ import { SelectPartyScreen } from './select_party_screen';
 
 type CheckInFlowState =
   | { step: 'search'; search: VoterSearchParams }
-  | { step: 'confirm_identity'; voterId: string; search: VoterSearchParams }
+  | {
+      step: 'confirm_identity';
+      voterId: string;
+      identificationMethod: VoterIdentificationMethod;
+      search: VoterSearchParams;
+    }
   | {
       step: 'select_party';
       voterId: string;
@@ -131,7 +136,7 @@ export function VoterCheckInScreen(): JSX.Element | null {
   }, []);
 
   const setConfirmIdentity = useCallback(
-    (voterId: string) => {
+    (voterId: string, identificationMethod: VoterIdentificationMethod) => {
       if (flowState.step !== 'search' && flowState.step !== 'select_party') {
         /* istanbul ignore next - @preserve */
         return;
@@ -141,6 +146,7 @@ export function VoterCheckInScreen(): JSX.Element | null {
         step: 'confirm_identity',
         voterId,
         search: flowState.search,
+        identificationMethod,
       });
     },
     [flowState]
@@ -237,6 +243,7 @@ export function VoterCheckInScreen(): JSX.Element | null {
           configuredPrecinctId={configuredPrecinctId}
           election={election}
           onCancel={onCancel}
+          initialIdentificationMethod={flowState.identificationMethod}
           // Called when party must be selected in next step before check-in is completed
           onConfirmVoterIdentity={(
             voterId: string,
@@ -263,7 +270,12 @@ export function VoterCheckInScreen(): JSX.Element | null {
           voterId={flowState.voterId}
           identificationMethod={flowState.identificationMethod}
           onConfirmCheckIn={onConfirmCheckIn}
-          onBack={() => setConfirmIdentity(flowState.voterId)}
+          onBack={() =>
+            setConfirmIdentity(
+              flowState.voterId,
+              flowState.identificationMethod
+            )
+          }
         />
       );
 
@@ -310,8 +322,8 @@ export function VoterCheckInScreen(): JSX.Element | null {
         case 'unknown_voter_party':
           errorMessage = 'Voter Has No Declared Party';
           break;
+        /* istanbul ignore next - @preserve */
         default:
-          /* istanbul ignore next - @preserve */
           throwIllegalValue(flowState.errorType);
       }
       return (

--- a/apps/pollbook/frontend/src/voter_confirm_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_confirm_screen.tsx
@@ -89,6 +89,7 @@ export function VoterConfirmScreen({
   onConfirmCheckIn,
   election,
   configuredPrecinctId,
+  initialIdentificationMethod = { type: 'default' },
 }: {
   voterId: string;
   isAbsenteeMode: boolean;
@@ -104,6 +105,7 @@ export function VoterConfirmScreen({
   ) => void;
   election: Election;
   configuredPrecinctId: string;
+  initialIdentificationMethod?: VoterIdentificationMethod;
 }): JSX.Element | null {
   const getVoterQuery = getVoter.useQuery(voterId);
   const [showUpdateAddressFlow, setShowUpdateAddressFlow] = useState(false);
@@ -112,7 +114,7 @@ export function VoterConfirmScreen({
   const [showInactiveVoterModal, setShowInactiveVoterModal] = useState(false);
   const [identificationMethod, setIdentificationMethod] = useState<
     Partial<VoterIdentificationMethod>
-  >({ type: 'default' });
+  >(initialIdentificationMethod);
 
   if (!getVoterQuery.isSuccess) {
     return null;

--- a/apps/pollbook/frontend/src/voter_search_screen.test.tsx
+++ b/apps/pollbook/frontend/src/voter_search_screen.test.tsx
@@ -17,7 +17,11 @@ import {
   getDefaultNormalizer,
   screen,
 } from '../test/react_testing_library';
-import { createEmptySearchParams, VoterSearch } from './voter_search_screen';
+import {
+  createEmptySearchParams,
+  validateUsState,
+  VoterSearch,
+} from './voter_search_screen';
 import { DEFAULT_QUERY_REFETCH_INTERVAL } from './api';
 import {
   getMockAamvaDocument,
@@ -148,7 +152,9 @@ test('after an ID scan with "hidden" fields, shows full name and "Edit Search" b
   await act(() => vi.advanceTimersByTime(DEFAULT_QUERY_REFETCH_INTERVAL));
 
   await vi.waitFor(() => expect(onBarcodeScanMatch).toHaveBeenCalled());
-  expect(onBarcodeScanMatch).toHaveBeenCalledWith(mockVoter);
+  expect(onBarcodeScanMatch).toHaveBeenCalledWith(mockVoter, {
+    type: 'default',
+  });
 
   // Expect to see disabled form input and Edit Search button
   await screen.findByText('Scanned ID');
@@ -296,6 +302,10 @@ test('closes the error modal if a valid ID is scanned', async () => {
       normalizer: getDefaultNormalizer({ collapseWhitespace: true }),
     })
   ).toBeInTheDocument();
+});
+
+test('validateUsState', () => {
+  expect(validateUsState('NH')).toEqual('NH');
 });
 
 // Test for barcode scanner happy path is covered in app_poll_worker_screen.test.tsx


### PR DESCRIPTION


## Overview

https://github.com/votingworks/vxsuite/issues/6866

Automatically applies the issuing state to the form on the "Confirm Voter Identity" page when scanning an out-of-state driver's license.

## Demo Video or Screenshot

In all these videos a Massachusetts ID is being scanned.

In this video there is exactly 1 match so we jump right to the check-in page and prefill `MA - Massachusetts`

https://github.com/user-attachments/assets/62e9a3ce-cbb4-4683-a250-4c877978ebd8

In this video there is >1 match so we make the pollworker choose and don't prefill the state. I think it's likely we should prefill the US state. While we're not jumping right to the check-in page, it seems clear that the intended voter was found, so their ID scan should be considered valid. If so, we can add that behavior in a follow-up PR.

https://github.com/user-attachments/assets/10874851-76e8-4e29-87bf-b94ba1734b17

In this video the pollworker edits the search; we are far enough away from the original ID scan that I don't think we should prefill the US state.

https://github.com/user-attachments/assets/2899d8e1-493c-44cd-bd3f-3e674357e87d

## Testing Plan
- Added app-level test for check-in with out of state ID scan

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
