### PR TITLE
remove spammy log and possible PII log

### DIFF
--- a/apps/pollbook/barcode-scanner-daemon/src/parse_aamva.rs
+++ b/apps/pollbook/barcode-scanner-daemon/src/parse_aamva.rs
@@ -23,8 +23,8 @@ pub enum AamvaParseError {
     #[error("Header input too short. Value: '{0}'")]
     HeaderTooShort(String),
 
-    #[error("Unexpected header prefix. Expected '{EXPECTED_PREFIX}', got '{0}")]
-    UnexpectedHeaderPrefix(String),
+    #[error("Unexpected header prefix.")]
+    UnexpectedHeaderPrefix,
 
     #[error("Unknown issuing jurisdiction ID: {0}")]
     UnknownIssuingJurisdictionId(String),
@@ -48,12 +48,10 @@ impl FromStr for AamvaHeader {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // 1) Validate prefix
         let Some((actual_prefix, rest)) = s.split_at_checked(EXPECTED_PREFIX.len()) else {
-            return Err(AamvaParseError::UnexpectedHeaderPrefix(s.to_owned()));
+            return Err(AamvaParseError::UnexpectedHeaderPrefix);
         };
         if actual_prefix != EXPECTED_PREFIX {
-            return Err(AamvaParseError::UnexpectedHeaderPrefix(
-                actual_prefix.to_owned(),
-            ));
+            return Err(AamvaParseError::UnexpectedHeaderPrefix);
         }
 
         // 2) Validate issuer ID
@@ -243,7 +241,7 @@ DCSLAST
         let bad_prefix = "1234 636039100001DL00310485DLDAQNHL12345678";
         let err = AamvaHeader::from_str(bad_prefix).unwrap_err();
 
-        assert!(matches!(err, AamvaParseError::UnexpectedHeaderPrefix(_)));
+        assert!(matches!(err, AamvaParseError::UnexpectedHeaderPrefix));
     }
 
     #[test]

--- a/apps/pollbook/barcode-scanner-daemon/src/unitech_ts100_daemon.rs
+++ b/apps/pollbook/barcode-scanner-daemon/src/unitech_ts100_daemon.rs
@@ -213,7 +213,6 @@ where
 
                 if buf.is_empty() {
                     // Expected at the end of the document
-                    log!(EventId::Info, "No data preceding terminator character");
                     continue;
                 }
 


### PR DESCRIPTION
## Overview

* Removes a spammy log that happens when we see an empty line in the scan data. The empty line is expected at the end of every valid driver's license scan
* Removes a line that logs the first few characters of scanned data. Since we can't anticipate the format of non-AAMVA barcodes we shouldn't log them in case the first few characters are PII.

## Demo Video or Screenshot
Logging change only

## Testing Plan
Manually verified

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.