### PR TITLE
wip(hwta-scan): stop polling for status

### DIFF
--- a/apps/mark-scan/backend/src/electrical_testing/app.ts
+++ b/apps/mark-scan/backend/src/electrical_testing/app.ts
@@ -44,7 +44,7 @@ function buildApi({
     },
 
     setCardReaderTaskRunning(input: { running: boolean }) {
-      workspace.store.setElectricalTestingStatusMessage(
+      setStatusMessage(
         'card',
         input.running ? 'Resumed' : 'Paused'
       );
@@ -56,7 +56,7 @@ function buildApi({
     },
 
     setPaperHandlerTaskRunning(input: { running: boolean }) {
-      workspace.store.setElectricalTestingStatusMessage(
+      setStatusMessage(
         'paperHandler',
         input.running ? 'Resumed' : 'Paused'
       );
@@ -68,7 +68,7 @@ function buildApi({
     },
 
     setUsbDriveTaskRunning(input: { running: boolean }) {
-      workspace.store.setElectricalTestingStatusMessage(
+      setStatusMessage(
         'usbDrive',
         input.running ? 'Resumed' : 'Paused'
       );

--- a/apps/mark-scan/backend/src/electrical_testing/background.ts
+++ b/apps/mark-scan/backend/src/electrical_testing/background.ts
@@ -52,7 +52,7 @@ export async function runCardReadAndUsbDriveWriteTask({
     logger.log(LogEventId.BackgroundTaskCancelled, 'system', {
       message,
     });
-    workspace.store.setElectricalTestingStatusMessage('card', message);
+    setStatusMessage('card', message);
   });
 
   // eslint-disable-next-line no-constant-condition
@@ -71,7 +71,7 @@ export async function runCardReadAndUsbDriveWriteTask({
     if (cardTask.isRunning()) {
       const machineState = constructAuthMachineState(workspace);
       const cardReadResult = await auth.readCardData(machineState);
-      workspace.store.setElectricalTestingStatusMessage(
+      setStatusMessage(
         'card',
         resultToString(cardReadResult)
       );
@@ -89,7 +89,7 @@ export async function runCardReadAndUsbDriveWriteTask({
       } catch (error) {
         usbDriveWriteResult = err(error);
       }
-      workspace.store.setElectricalTestingStatusMessage(
+      setStatusMessage(
         'usbDrive',
         resultToString(usbDriveWriteResult)
       );
@@ -117,7 +117,7 @@ export async function runPrintAndScanTask({
   });
 
   function setPaperHandlerStatusMessage(message: string) {
-    workspace.store.setElectricalTestingStatusMessage('paperHandler', message);
+    setStatusMessage('paperHandler', message);
   }
 
   void paperHandlerTask.waitUntilIsStopped().then((reason) => {

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -54,6 +54,7 @@
     "copyfiles": "^2.4.1",
     "debug": "4.3.4",
     "express": "4.18.2",
+    "express-ws": "^5.0.2",
     "fs-extra": "11.1.1",
     "js-sha256": "^0.9.0",
     "luxon": "^3.0.0",
@@ -67,6 +68,7 @@
   "devDependencies": {
     "@types/debug": "4.1.8",
     "@types/express": "4.17.14",
+    "@types/express-ws": "^3.0.5",
     "@types/fs-extra": "11.0.1",
     "@types/jest-image-snapshot": "^6.4.0",
     "@types/luxon": "^3.0.0",

--- a/apps/scan/backend/src/electrical_testing/app.ts
+++ b/apps/scan/backend/src/electrical_testing/app.ts
@@ -2,65 +2,91 @@ import { createSystemCallApi } from '@votingworks/backend';
 import * as grout from '@votingworks/grout';
 import { mapSheet } from '@votingworks/types';
 import express, { Application } from 'express';
+import ws from 'express-ws';
 import { basename, join } from 'node:path';
 import { Player as AudioPlayer, SoundName } from '../audio/player';
 import { getMachineConfig } from '../machine_config';
 import type { ScanningMode, ServerContext } from './context';
 import { ScanningSession, ScanningSessionData } from './analysis/scan';
+import { ElectricalTestingComponent } from '../store';
 
 type ApiContext = ServerContext & {
   audioPlayer?: AudioPlayer;
 };
 
-function buildApi({
-  audioPlayer,
-  workspace,
+async function getElectricalTestingStatuses({
+  workspace: { store },
   cardTask,
-  usbDriveTask,
   printerTask,
+  usbDriveTask,
   scannerTask,
   usbDrive,
-  logger,
 }: ApiContext) {
-  const { store } = workspace;
+  const messages = store.getElectricalTestingStatusMessages();
+  const cardMessage = messages.find((message) => message.component === 'card');
+  const usbDriveMessage = messages.find(
+    (message) => message.component === 'usbDrive'
+  );
+  const printerMessage = messages.find(
+    (message) => message.component === 'printer'
+  );
+  const scannerMessage = messages.find(
+    (message) => message.component === 'scanner'
+  );
+  return {
+    card: cardMessage
+      ? { ...cardMessage, taskStatus: cardTask.getStatus() }
+      : undefined,
+    usbDrive: usbDriveMessage
+      ? {
+          ...usbDriveMessage,
+          taskStatus: usbDriveTask.getStatus(),
+          underlyingDeviceStatus: await usbDrive.status(),
+        }
+      : undefined,
+    printer: printerMessage
+      ? { ...printerMessage, taskStatus: printerTask.getStatus() }
+      : undefined,
+    scanner: scannerMessage
+      ? {
+          ...scannerMessage,
+          taskStatus: scannerTask.getStatus(),
+          mode: scannerTask.getState().mode,
+        }
+      : undefined,
+  };
+}
 
+function getCurrentScanningSessionData({
+  scannerTask,
+}: ServerContext): ScanningSessionData {
+  const { sheets, stats } = scannerTask.getState().session.toJSON();
+  return {
+    sheets: sheets.map((sheet) =>
+      mapSheet(sheet, ({ path, analysis }) => ({
+        path: `/api/images/${basename(path)}`,
+        analysis,
+      }))
+    ),
+    stats,
+  };
+}
+
+function buildApi(context: ApiContext) {
+  const {
+    audioPlayer,
+    cardTask,
+    usbDriveTask,
+    printerTask,
+    scannerTask,
+    usbDrive,
+    logger,
+    setStatusMessage,
+    onScanningSessionChanged,
+  } = context;
   return grout.createApi({
-    async getElectricalTestingStatuses() {
-      const messages = store.getElectricalTestingStatusMessages();
-      const cardMessage = messages.find(
-        (message) => message.component === 'card'
-      );
-      const usbDriveMessage = messages.find(
-        (message) => message.component === 'usbDrive'
-      );
-      const printerMessage = messages.find(
-        (message) => message.component === 'printer'
-      );
-      const scannerMessage = messages.find(
-        (message) => message.component === 'scanner'
-      );
-      return {
-        card: cardMessage
-          ? { ...cardMessage, taskStatus: cardTask.getStatus() }
-          : undefined,
-        usbDrive: usbDriveMessage
-          ? {
-              ...usbDriveMessage,
-              taskStatus: usbDriveTask.getStatus(),
-              underlyingDeviceStatus: await usbDrive.status(),
-            }
-          : undefined,
-        printer: printerMessage
-          ? { ...printerMessage, taskStatus: printerTask.getStatus() }
-          : undefined,
-        scanner: scannerMessage
-          ? {
-              ...scannerMessage,
-              taskStatus: scannerTask.getStatus(),
-              mode: scannerTask.getState().mode,
-            }
-          : undefined,
-      };
+    getElectricalTestingStatuses() {
+      return getElectricalTestingStatuses(context);
     },
 
     async playSound(input: { name: SoundName }): Promise<void> {
@@ -68,10 +94,7 @@ function buildApi({
     },
 
     setCardReaderTaskRunning(input: { running: boolean }) {
-      workspace.store.setElectricalTestingStatusMessage(
-        'card',
-        input.running ? 'Resumed' : 'Paused'
-      );
+      setStatusMessage('card', input.running ? 'Resumed' : 'Paused');
       if (input.running) {
         cardTask.resume();
       } else {
@@ -80,10 +103,7 @@ function buildApi({
     },
 
     setUsbDriveTaskRunning(input: { running: boolean }) {
-      workspace.store.setElectricalTestingStatusMessage(
-        'usbDrive',
-        input.running ? 'Resumed' : 'Paused'
-      );
+      setStatusMessage('usbDrive', input.running ? 'Resumed' : 'Paused');
       if (input.running) {
         usbDriveTask.resume();
       } else {
@@ -92,10 +112,7 @@ function buildApi({
     },
 
     setPrinterTaskRunning(input: { running: boolean }) {
-      workspace.store.setElectricalTestingStatusMessage(
-        'printer',
-        input.running ? 'Resumed' : 'Paused'
-      );
+      setStatusMessage('printer', input.running ? 'Resumed' : 'Paused');
       if (input.running) {
         printerTask.resume();
       } else {
@@ -108,10 +125,7 @@ function buildApi({
     },
 
     setScannerTaskRunning(input: { running: boolean }) {
-      workspace.store.setElectricalTestingStatusMessage(
-        'scanner',
-        input.running ? 'Resumed' : 'Paused'
-      );
+      setStatusMessage('scanner', input.running ? 'Resumed' : 'Paused');
       if (input.running) {
         scannerTask.resume();
       } else {
@@ -127,19 +141,11 @@ function buildApi({
     resetScanningSession(): void {
       const { mode } = scannerTask.getState();
       scannerTask.setState({ mode, session: new ScanningSession() });
+      onScanningSessionChanged();
     },
 
     getCurrentScanningSessionData(): ScanningSessionData {
-      const { sheets, stats } = scannerTask.getState().session.toJSON();
-      return {
-        sheets: sheets.map((sheet) =>
-          mapSheet(sheet, ({ path, analysis }) => ({
-            path: `/api/images/${basename(path)}`,
-            analysis,
-          }))
-        ),
-        stats,
-      };
+      return getCurrentScanningSessionData(context);
     },
 
     ...createSystemCallApi({
@@ -154,7 +160,66 @@ function buildApi({
 export type Api = ReturnType<typeof buildApi>;
 
 export function buildApp(context: ApiContext): Application {
-  const app: Application = express();
+  const { app } = ws(express());
+
+  app.ws('/api/echo', (ws) => {
+    ws.on('message', (msg) => {
+      ws.send((msg as unknown as string).split('').reverse().join(''));
+    });
+  });
+
+  app.ws('/api/events', async (ws) => {
+    ws.on('message', (msg) => {
+      console.warn('Ignoring message from client:', msg);
+    });
+
+    async function onStatusMessageChanged() {
+      ws.send(
+        grout.serialize({
+          type: 'status-messages-changed',
+          payload: await getElectricalTestingStatuses(context),
+        })
+      );
+    }
+
+    async function onSheetScanned() {
+      ws.send(
+        grout.serialize({
+          type: 'scanning-session-changed',
+          payload: getCurrentScanningSessionData(context),
+        })
+      );
+    }
+
+    context.eventBus.addListener(
+      'status-messages-changed',
+      onStatusMessageChanged
+    );
+
+    context.eventBus.addListener('sheet-scanned', onSheetScanned);
+
+    ws.on('close', () => {
+      context.eventBus.removeListener(
+        'status-messages-changed',
+        onStatusMessageChanged
+      );
+      context.eventBus.removeListener('sheet-scanned', onSheetScanned);
+    });
+
+    ws.send(
+      grout.serialize({
+        type: 'status-messages-changed',
+        payload: await getElectricalTestingStatuses(context),
+      })
+    );
+    ws.send(
+      grout.serialize({
+        type: 'scanning-session-changed',
+        payload: getCurrentScanningSessionData(context),
+      })
+    );
+  });
+
   const api = buildApi(context);
   app.use('/api/images', (req, res) => {
     const basedir = context.workspace.ballotImagesPath;

--- a/apps/scan/backend/src/electrical_testing/context.ts
+++ b/apps/scan/backend/src/electrical_testing/context.ts
@@ -1,9 +1,11 @@
+import EventEmitter from 'node:events';
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import { TaskController } from '@votingworks/backend';
 import { Logger } from '@votingworks/logging';
 import { UsbDrive } from '@votingworks/usb-drive';
 import { DateTime } from 'luxon';
 import { Printer } from '../printing/printer';
+import { ElectricalTestingComponent } from '../store';
 import { Workspace } from '../util/workspace';
 import { ScanningSession } from './analysis/scan';
 import { SimpleScannerClient } from './simple_scanner_client';
@@ -28,4 +30,10 @@ export interface ServerContext {
   scannerClient: SimpleScannerClient;
   usbDrive: UsbDrive;
   workspace: Workspace;
+  setStatusMessage(
+    component: ElectricalTestingComponent,
+    statusMessage: string
+  ): void;
+  onScanningSessionChanged(): void;
+  eventBus: EventEmitter;
 }

--- a/apps/scan/backend/src/electrical_testing/server.ts
+++ b/apps/scan/backend/src/electrical_testing/server.ts
@@ -15,7 +15,7 @@ import { getAudioInfo } from '../audio/info';
 export async function startElectricalTestingServer(
   context: ServerContext
 ): Promise<void> {
-  const { workspace, logger } = context;
+  const { logger } = context;
   const cardReadAndUsbDriveWriteLoopPromise =
     runCardReadAndUsbDriveWriteTask(context);
   const printAndScanLoopPromise = runPrintAndScanTask(context);
@@ -51,10 +51,7 @@ export async function startElectricalTestingServer(
         disposition: 'success',
         message: 'Print and scan loop completed',
       });
-      workspace.store.setElectricalTestingStatusMessage(
-        'scanner',
-        'Print and scan loop completed'
-      );
+      context.setStatusMessage('scanner', 'Print and scan loop completed');
     })
     .catch((error) => {
       logger.log(LogEventId.BackgroundTaskFailure, 'system', {
@@ -62,7 +59,7 @@ export async function startElectricalTestingServer(
         message: 'Print and scan loop failed',
         error,
       });
-      workspace.store.setElectricalTestingStatusMessage(
+      context.setStatusMessage(
         'scanner',
         `Print and scan loop failed: ${extractErrorMessage(error)}`
       );

--- a/apps/scan/backend/src/electrical_testing/tasks/card_read_and_usb_drive_write_task.ts
+++ b/apps/scan/backend/src/electrical_testing/tasks/card_read_and_usb_drive_write_task.ts
@@ -16,6 +16,7 @@ export async function runCardReadAndUsbDriveWriteTask({
   usbDrive,
   usbDriveTask,
   workspace,
+  setStatusMessage,
 }: ServerContext): Promise<void> {
   void cardTask.waitUntilIsStopped().then((reason) => {
     logger.log(LogEventId.BackgroundTaskCancelled, 'system', {
@@ -45,10 +46,7 @@ export async function runCardReadAndUsbDriveWriteTask({
     if (cardTask.isRunning()) {
       const machineState = constructAuthMachineState(workspace.store);
       const cardReadResult = await auth.readCardData(machineState);
-      workspace.store.setElectricalTestingStatusMessage(
-        'card',
-        resultToString(cardReadResult)
-      );
+      setStatusMessage('card', resultToString(cardReadResult));
     }
 
     if (usbDriveTask.isRunning()) {
@@ -63,10 +61,7 @@ export async function runCardReadAndUsbDriveWriteTask({
       } catch (error) {
         usbDriveWriteResult = err(error);
       }
-      workspace.store.setElectricalTestingStatusMessage(
-        'usbDrive',
-        resultToString(usbDriveWriteResult)
-      );
+      setStatusMessage('usbDrive', resultToString(usbDriveWriteResult));
     }
 
     // Wait for the next interval or until both loops are stopped.

--- a/apps/scan/frontend/prodserver/setupProxy.js
+++ b/apps/scan/frontend/prodserver/setupProxy.js
@@ -17,6 +17,13 @@ module.exports = function (app) {
   app.use(
     proxy({
       pathFilter: ['/api', '/dock'],
+      target: 'ws://localhost:3002/',
+      ws: true,
+    })
+  );
+  app.use(
+    proxy({
+      pathFilter: ['/api', '/dock'],
       target: 'http://localhost:3002/',
     })
   );

--- a/apps/scan/frontend/src/electrical_testing/app_root.tsx
+++ b/apps/scan/frontend/src/electrical_testing/app_root.tsx
@@ -592,6 +592,8 @@ function ScannedSheetImages({ urls }: { urls?: SheetOf<string> }): JSX.Element {
 }
 
 export function AppRoot(): JSX.Element {
+  api.useApiEvents();
+
   const getElectricalTestingStatusMessagesQuery =
     api.getElectricalTestingStatuses.useQuery();
   const setCardReaderTaskRunningMutation =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2713,6 +2713,9 @@ importers:
       express:
         specifier: 4.18.2
         version: 4.18.2
+      express-ws:
+        specifier: ^5.0.2
+        version: 5.0.2(express@4.18.2)
       fs-extra:
         specifier: 11.1.1
         version: 11.1.1
@@ -2747,6 +2750,9 @@ importers:
       '@types/express':
         specifier: 4.17.14
         version: 4.17.14
+      '@types/express-ws':
+        specifier: ^3.0.5
+        version: 3.0.5
       '@types/fs-extra':
         specifier: 11.0.1
         version: 11.0.1
@@ -13089,6 +13095,14 @@ packages:
       '@types/range-parser': 1.2.4
     dev: true
 
+  /@types/express-ws@3.0.5:
+    resolution: {integrity: sha512-lbWMjoHrm/v85j81UCmb/GNZFO3genxRYBW1Ob7rjRI+zxUBR+4tcFuOpKKsYQ1LYTYiy3356epLeYi/5zxUwA==}
+    dependencies:
+      '@types/express': 4.17.14
+      '@types/express-serve-static-core': 4.17.31
+      '@types/ws': 8.18.1
+    dev: true
+
   /@types/express@4.17.14:
     resolution: {integrity: sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==}
     dependencies:
@@ -13602,6 +13616,12 @@ packages:
 
   /@types/w3c-web-usb@1.0.8:
     resolution: {integrity: sha512-ouEoUTyB27wFXUUyl0uKIE6VkeCczDtazWTiZGD1M4onceJnp8KnHDf7CzLbpwzek2ZFWXTC5KrNDRc9q/Jf6Q==}
+
+  /@types/ws@8.18.1:
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+    dependencies:
+      '@types/node': 20.17.31
+    dev: true
 
   /@types/yargs-parser@21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
@@ -17063,6 +17083,19 @@ packages:
       url-join: 4.0.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /express-ws@5.0.2(express@4.18.2):
+    resolution: {integrity: sha512-0uvmuk61O9HXgLhGl3QhNSEtRsQevtmbL94/eILaliEADZBHZOQUAiHFrGPrgsjikohyrmSG5g+sCfASTt0lkQ==}
+    engines: {node: '>=4.5.0'}
+    peerDependencies:
+      express: ^4.0.0 || ^5.0.0-alpha.1
+    dependencies:
+      express: 4.18.2
+      ws: 7.5.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
     dev: false
 
   /express@4.18.2:
@@ -24875,6 +24908,19 @@ packages:
     dependencies:
       async-limiter: 1.0.1
     dev: true
+
+  /ws@7.5.10:
+    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
 
   /ws@8.15.1:
     resolution: {integrity: sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==}


### PR DESCRIPTION
Rather than using grout/HTTP requests at a fixed interval to poll, we now establish a `WebSocket` to watch for changes that the server pushes to us.
