### PR TITLE
VxPollBook: Use mock loggers in tests

### DIFF
--- a/apps/pollbook/backend/src/backup_worker.test.ts
+++ b/apps/pollbook/backend/src/backup_worker.test.ts
@@ -1,7 +1,8 @@
-import { expect, test, vitest } from 'vitest';
+import { expect, test, vi, vitest } from 'vitest';
 import { writeFileSync } from 'node:fs';
 import { makeTemporaryPath } from '@votingworks/fixtures';
 import { ElectionDefinition, PrecinctId } from '@votingworks/types';
+import { mockBaseLogger } from '@votingworks/logging';
 import {
   createVoter,
   getTestElection,
@@ -16,7 +17,7 @@ vitest.setConfig({
 });
 
 test('can export paper backup checklist for multi precinct election', async () => {
-  const store = LocalStore.memoryStore();
+  const store = LocalStore.memoryStore(mockBaseLogger({ fn: vi.fn }));
   setupTestElectionAndVoters(store);
   // Set up a configured precinct for multi-precinct testing
   store.setConfiguredPrecinct('precinct-1');
@@ -85,7 +86,7 @@ test('can export paper backup checklist for multi precinct election', async () =
 });
 
 test('backup checklist works for single-precinct election', async () => {
-  const store = LocalStore.memoryStore();
+  const store = LocalStore.memoryStore(mockBaseLogger({ fn: vi.fn }));
 
   // Create a single-precinct election
   const baseElection = getTestElection();

--- a/apps/pollbook/backend/src/local_store.test.ts
+++ b/apps/pollbook/backend/src/local_store.test.ts
@@ -12,7 +12,7 @@ import {
 import { LocalStore } from './local_store';
 
 test('findVotersWithName works as expected - voters without name changes', () => {
-  const localStore = LocalStore.memoryStore();
+  const localStore = LocalStore.memoryStore(mockBaseLogger({ fn: vi.fn }));
   const testElectionDefinition = getTestElectionDefinition();
   const voters = [
     createVoter('10', 'Dylan', `O'Brien`, 'MiD', 'I'),
@@ -135,7 +135,7 @@ test('findVotersWithName works as expected - voters without name changes', () =>
 });
 
 test('findVoterWithName works as expected - voters with name changes', () => {
-  const localStore = LocalStore.memoryStore();
+  const localStore = LocalStore.memoryStore(mockBaseLogger({ fn: vi.fn }));
   const testElectionDefinition = getTestElectionDefinition();
   const voters = [
     createVoter('20', 'John', 'Doe', 'Allen', 'Sr'),
@@ -259,7 +259,7 @@ test('findVoterWithName works as expected - voters with name changes', () => {
 });
 
 test('registerVoter and findVoterWithName integration', () => {
-  const localStore = LocalStore.memoryStore();
+  const localStore = LocalStore.memoryStore(mockBaseLogger({ fn: vi.fn }));
   const testElectionDefinition = getTestElectionDefinition();
   const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];
   localStore.setElectionAndVoters(
@@ -307,7 +307,7 @@ test('registerVoter and findVoterWithName integration', () => {
 });
 
 test('registerVoter - fails when wrong precinct configured', () => {
-  const localStore = LocalStore.memoryStore();
+  const localStore = LocalStore.memoryStore(mockBaseLogger({ fn: vi.fn }));
   const testElectionDefinition = getTestElectionDefinition();
   const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];
   localStore.setElectionAndVoters(
@@ -343,7 +343,7 @@ test('registerVoter - fails when wrong precinct configured', () => {
 });
 
 test('registerVoter - fails when no precinct configured', () => {
-  const localStore = LocalStore.memoryStore();
+  const localStore = LocalStore.memoryStore(mockBaseLogger({ fn: vi.fn }));
   const testElectionDefinition = getTestElectionDefinition();
   const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];
   localStore.setElectionAndVoters(
@@ -378,7 +378,10 @@ test('registerVoter - fails when no precinct configured', () => {
 });
 
 test('setElectionAndVoters sets configuredPrecinctId only when there is one precinct', () => {
-  const store = LocalStore.memoryStore('machine-1');
+  const store = LocalStore.memoryStore(
+    mockBaseLogger({ fn: vi.fn }),
+    'machine-1'
+  );
 
   // Test with a normal test election (multiple precincts)
   const testElectionDefinition = getTestElectionDefinition();
@@ -418,7 +421,7 @@ test('setElectionAndVoters sets configuredPrecinctId only when there is one prec
 });
 
 test('changeVoterAddress works as expected - when precinct is the properly configured one', () => {
-  const localStore = LocalStore.memoryStore();
+  const localStore = LocalStore.memoryStore(mockBaseLogger({ fn: vi.fn }));
   const testElectionDefinition = getTestElectionDefinition();
   const voters = [createVoter('20', 'John', 'Doe', 'Allen', 'Sr')];
   const streets = [

--- a/apps/pollbook/backend/src/local_store.ts
+++ b/apps/pollbook/backend/src/local_store.ts
@@ -1,4 +1,4 @@
-import { BaseLogger, LogSource } from '@votingworks/logging';
+import { BaseLogger } from '@votingworks/logging';
 import { Client as DbClient } from '@votingworks/db';
 import {
   CheckInBallotParty,
@@ -99,9 +99,9 @@ export class LocalStore extends Store {
    * Builds and returns a new store whose data is kept in memory.
    */
   static memoryStore(
+    logger: BaseLogger,
     machineId: string = 'test-machine',
-    codeVersion: string = 'test-v1',
-    logger: BaseLogger = new BaseLogger(LogSource.VxPollBookBackend)
+    codeVersion: string = 'test-v1'
   ): LocalStore {
     return new LocalStore(
       DbClient.memoryClient(SchemaPath, { registerRegexpFn: true }),

--- a/apps/pollbook/backend/src/peer_store.ts
+++ b/apps/pollbook/backend/src/peer_store.ts
@@ -1,4 +1,4 @@
-import { BaseLogger, LogEventId, LogSource } from '@votingworks/logging';
+import { BaseLogger, LogEventId } from '@votingworks/logging';
 import { Client as DbClient } from '@votingworks/db';
 import { Result, err, ok } from '@votingworks/basics';
 import fetch from 'node-fetch';
@@ -66,9 +66,9 @@ export class PeerStore extends Store {
    * Builds and returns a new store whose data is kept in memory.
    */
   static memoryStore(
+    logger: BaseLogger,
     machineId: string = 'test-machine',
-    codeVersion: string = 'test-v1',
-    logger: BaseLogger = new BaseLogger(LogSource.VxPollBookBackend)
+    codeVersion: string = 'test-v1'
   ): PeerStore {
     return new PeerStore(
       DbClient.memoryClient(SchemaPath),

--- a/apps/pollbook/backend/src/store.test.ts
+++ b/apps/pollbook/backend/src/store.test.ts
@@ -1,5 +1,6 @@
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { assert, sleep } from '@votingworks/basics';
+import { mockBaseLogger } from '@votingworks/logging';
 import { HybridLogicalClock } from './hybrid_logical_clock';
 import {
   createVoter,
@@ -16,8 +17,14 @@ export const myMachineId = 'machine-1';
 const otherMachineId = 'machine-2';
 
 function setupTwoStores(): [PeerStore, PeerStore] {
-  const store1 = PeerStore.memoryStore(myMachineId);
-  const store2 = PeerStore.memoryStore(otherMachineId);
+  const store1 = PeerStore.memoryStore(
+    mockBaseLogger({ fn: vi.fn }),
+    myMachineId
+  );
+  const store2 = PeerStore.memoryStore(
+    mockBaseLogger({ fn: vi.fn }),
+    otherMachineId
+  );
   const voters = Array.from({ length: 7 }, (_, i) =>
     createVoter(`voter-${i}`, 'firstname', 'lastname')
   );
@@ -30,7 +37,10 @@ function setupTwoStores(): [PeerStore, PeerStore] {
 }
 
 test('getNewEvents returns events for unknown machines', () => {
-  const store = PeerStore.memoryStore(myMachineId);
+  const store = PeerStore.memoryStore(
+    mockBaseLogger({ fn: vi.fn }),
+    myMachineId
+  );
   const myHlcClock = new HybridLogicalClock(myMachineId);
   const theirHlcClock = new HybridLogicalClock(otherMachineId);
   const event1 = createVoterCheckInEvent(
@@ -58,7 +68,10 @@ test('getNewEvents returns events for unknown machines', () => {
 });
 
 test('getNewEvents returns events for known machines with new events', () => {
-  const store = PeerStore.memoryStore(myMachineId);
+  const store = PeerStore.memoryStore(
+    mockBaseLogger({ fn: vi.fn }),
+    myMachineId
+  );
   const myClock = new HybridLogicalClock(myMachineId);
   const theirClock = new HybridLogicalClock(otherMachineId);
   const event1 = createVoterCheckInEvent(
@@ -96,7 +109,10 @@ test('getNewEvents returns events for known machines with new events', () => {
 });
 
 test('getNewEvents returns no events for known machines and unknown machines', async () => {
-  const store = PeerStore.memoryStore(myMachineId);
+  const store = PeerStore.memoryStore(
+    mockBaseLogger({ fn: vi.fn }),
+    myMachineId
+  );
   const myClock = new HybridLogicalClock(myMachineId);
   const theirClock = new HybridLogicalClock(otherMachineId);
   const event1 = createVoterCheckInEvent(

--- a/apps/pollbook/backend/src/voter_history.test.ts
+++ b/apps/pollbook/backend/src/voter_history.test.ts
@@ -1,6 +1,7 @@
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { readMultiPartyPrimaryElectionDefinition } from '@votingworks/fixtures';
 import { VoterAddressChangeRequest } from '@votingworks/types';
+import { mockBaseLogger } from '@votingworks/logging';
 import { LocalStore } from './local_store';
 import {
   getTestElectionDefinition,
@@ -23,7 +24,7 @@ const mockAddressDetails: VoterAddressChangeRequest = {
 };
 
 test('getNewEvents returns events for unknown machines', () => {
-  const store = LocalStore.memoryStore();
+  const store = LocalStore.memoryStore(mockBaseLogger({ fn: vi.fn }));
   setupTestElectionAndVoters(store);
   store.setConfiguredPrecinct('precinct-1');
   // Check in with a default ID method
@@ -73,7 +74,7 @@ test('getNewEvents returns events for unknown machines', () => {
 
 // Exclusion of "Party Choice" column for general elections is tested in the above test
 test('includes ballot party selection for primaries', () => {
-  const store = LocalStore.memoryStore();
+  const store = LocalStore.memoryStore(mockBaseLogger({ fn: vi.fn }));
   const primaryElectionDef = readMultiPartyPrimaryElectionDefinition();
   setupTestElectionAndVoters(store, primaryElectionDef);
   store.setConfiguredPrecinct('precinct-1');


### PR DESCRIPTION
## Overview
Makes sure tests are using a mock logger to avoid spamming output to the console. 
