### PR TITLE
change lock screen to match other parts of vxsuite

### DIFF
--- a/apps/pollbook/frontend/src/app.test.tsx
+++ b/apps/pollbook/frontend/src/app.test.tsx
@@ -67,20 +67,19 @@ test('renders RemoveCardScreen when card needs to be removed', async () => {
   await screen.findByText(/Remove card to unlock/);
 });
 
-test('renders MachineLockedScreen when machine is locked - unconfigure', async () => {
+test('renders MachineLockedScreen when machine is locked - completely unconfigured', async () => {
   apiMock.expectGetDeviceStatuses();
   apiMock.setAuthStatus({
     status: 'logged_out',
     reason: 'machine_locked',
   });
   renderApp();
-  await screen.findByText('VxPollBook Locked');
-  await screen.findByText(
-    'Insert system administrator or election manager card to unlock.'
-  );
+  await screen.findByRole('heading', {
+    name: 'Insert a system administrator or election manager card to configure VxPollBook',
+  });
 });
 
-test('renders MachineLockedScreen when machine is locked - configured', async () => {
+test('renders MachineLockedScreen when machine is locked - configured with election only', async () => {
   apiMock.expectGetDeviceStatuses();
   apiMock.setAuthStatus({
     status: 'logged_out',
@@ -88,8 +87,28 @@ test('renders MachineLockedScreen when machine is locked - configured', async ()
   });
   apiMock.setElection(famousNamesElection, undefined, 'FAKEHASH');
   renderApp();
+  await screen.findByRole('heading', {
+    name: 'Insert a system administrator or election manager card to select a precinct',
+  });
+  await screen.findByText(
+    `${famousNamesElection.ballotHash.slice(0, 7)}-FAKEHAS`
+  );
+});
+
+test('renders MachineLockedScreen when machine is locked - configured with election and precinct', async () => {
+  apiMock.expectGetDeviceStatuses();
+  apiMock.setAuthStatus({
+    status: 'logged_out',
+    reason: 'machine_locked',
+  });
+  apiMock.setElection(
+    famousNamesElection,
+    famousNamesElection.election.precincts[0].id,
+    'FAKEHASH'
+  );
+  renderApp();
   await screen.findByText('VxPollBook Locked');
-  await screen.findByText('Insert card to unlock.');
+  await screen.findByText('Insert card to unlock');
   await screen.findByText(
     `${famousNamesElection.ballotHash.slice(0, 7)}-FAKEHAS`
   );

--- a/apps/pollbook/frontend/src/app.tsx
+++ b/apps/pollbook/frontend/src/app.tsx
@@ -29,6 +29,7 @@ import {
   createQueryClient,
   getAuthStatus,
   getElection,
+  getPollbookConfigurationInformation,
   logOut,
   systemCallApi,
   useApiClient,
@@ -46,6 +47,7 @@ function AppRoot({ logger }: { logger: BaseLogger }): JSX.Element | null {
   const logOutMutation = logOut.useMutation();
   const getAuthStatusQuery = getAuthStatus.useQuery();
   const getElectionQuery = getElection.useQuery({ refetchInterval: 100 });
+  const getMachineInfoQuery = getPollbookConfigurationInformation.useQuery();
   const history = useHistory();
 
   const loggableUserName = useMemo(
@@ -70,7 +72,11 @@ function AppRoot({ logger }: { logger: BaseLogger }): JSX.Element | null {
     };
   }, [logger, history, loggableUserName]);
 
-  if (!getAuthStatusQuery.isSuccess || !getElectionQuery.isSuccess) {
+  if (
+    !getAuthStatusQuery.isSuccess ||
+    !getElectionQuery.isSuccess ||
+    !getMachineInfoQuery.isSuccess
+  ) {
     return null;
   }
   const auth = getAuthStatusQuery.data;

--- a/apps/pollbook/frontend/src/machine_locked_screen.tsx
+++ b/apps/pollbook/frontend/src/machine_locked_screen.tsx
@@ -1,4 +1,4 @@
-import { H1, H3, Main, Screen } from '@votingworks/ui';
+import { H1, H3, InsertCardImage, Main, Screen } from '@votingworks/ui';
 import styled from 'styled-components';
 import React from 'react';
 import { ElectionInfoBar } from './election_info_bar';
@@ -32,19 +32,31 @@ export function MachineLockedScreen(): JSX.Element | null {
     <Screen>
       <DeviceStatusBar showLogOutButton={false} />
       <Main centerChild>
-        <div>
-          <LockedImage src="/locked.svg" alt="Locked Icon" />
-          <H1 align="center">VxPollBook Locked</H1>
-          <H3 align="center" style={{ fontWeight: 'normal' }}>
-            {getElectionQuery.data.isOk() ? (
-              <React.Fragment>Insert card to unlock.</React.Fragment>
-            ) : (
-              <React.Fragment>
-                Insert system administrator or election manager card to unlock.
-              </React.Fragment>
-            )}
-          </H3>
-        </div>
+        {configuredPrecinctId ? (
+          <React.Fragment>
+            <LockedImage src="/locked.svg" alt="Locked Icon" />
+            <H1 align="center">VxPollBook Locked</H1>
+            <H3 align="center" style={{ fontWeight: 'normal' }}>
+              Insert card to unlock
+            </H3>
+          </React.Fragment>
+        ) : getElectionQuery.data.isOk() ? (
+          <React.Fragment>
+            <InsertCardImage cardInsertionDirection="right" />
+            <H1 align="center" style={{ maxWidth: '36rem' }}>
+              Insert a system administrator or election manager card to select a
+              precinct
+            </H1>
+          </React.Fragment>
+        ) : (
+          <React.Fragment>
+            <InsertCardImage cardInsertionDirection="right" />
+            <H1 align="center" style={{ maxWidth: '36rem' }}>
+              Insert a system administrator or election manager card to
+              configure VxPollBook
+            </H1>
+          </React.Fragment>
+        )}
       </Main>
       <ElectionInfoBar
         election={election}

--- a/apps/pollbook/frontend/vitest.config.ts
+++ b/apps/pollbook/frontend/vitest.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
 
     coverage: {
       thresholds: {
-        lines: 89.9,
-        branches: 86.8,
+        lines: 90.8,
+        branches: 87.4,
       },
       exclude: [
         'src/**/*.d.ts',


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6777

Updates lock screen to match other parts of VxSuite.

* Adds card swipe graphic
* Updates copy to specify configuration action (configure election or configure precinct)

## Demo Video or Screenshot

https://github.com/user-attachments/assets/869c01be-1b31-414f-8a05-2552adb63244

<img width="1468" height="923" alt="Screenshot 2025-08-01 at 11 53 24 AM" src="https://github.com/user-attachments/assets/89727673-25e5-4bf2-a285-f389dfed0e3d" />

<img width="1464" height="921" alt="Screenshot 2025-08-01 at 11 53 44 AM" src="https://github.com/user-attachments/assets/0e201cd2-ae0e-4fd3-81b1-804eea2f8e4b" />


## Testing Plan

- added tests for new config states

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [x] I have added a screenshot and/or video to this PR to demo the change
- [x] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
