### PR TITLE
VxPollBook: [UX] Improve jumpiness of network last seen time

### DIFF
--- a/apps/pollbook/frontend/src/nav_screen.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.tsx
@@ -42,7 +42,7 @@ import { PollbookConnectionStatus } from './types';
 import { VerticalElectionInfoBar } from './election_info_bar';
 
 // To avoid constant jumpiness in the last seen time in the UI round the time difference down to the last 5 seconds.
-export const NETWORK_LAST_SEEN_TIME_ROUND_IN_SECONDS = 5;
+const NETWORK_LAST_SEEN_TIME_ROUND_IN_SECONDS = 5;
 
 export const Header = styled(MainHeader)`
   display: flex;
@@ -248,7 +248,8 @@ function NetworkStatus({
                                   .as('seconds');
                                 const roundedTimeDiffInSeconds =
                                   NETWORK_LAST_SEEN_TIME_ROUND_IN_SECONDS *
-                                  Math.round(
+                                  Math.ceil(
+                                    // the numbers are negative, so we use ceiling as oppose to floor to round towards 0
                                     timeDiffInSeconds /
                                       NETWORK_LAST_SEEN_TIME_ROUND_IN_SECONDS
                                   );


### PR DESCRIPTION
## Overview
https://github.com/votingworks/vxsuite/issues/6914
<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot
Ignore the lost connection / shutdown status changing that is unrelated to this issue. 



https://github.com/user-attachments/assets/f5e3cbf9-e928-4a79-9576-af08ddab43b9




## Testing Plan
Tested on VxDev machine, shut down other machines to force non-"Now" times

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: "
      if my change is specific to one of those products.
- [x] I have added
      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
      where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to
      automate an announcement in #machine-product-updates.
