### PR TITLE
VxPollBook: Fix lost connection / shutdown status issue

### DIFF
--- a/apps/pollbook/backend/src/types.ts
+++ b/apps/pollbook/backend/src/types.ts
@@ -213,6 +213,14 @@ export enum PollbookConnectionStatus {
   IncompatibleSoftwareVersion = 'IncompatibleSoftwareVersion',
 }
 
+// These statuses may exists between pollbooks that are talking to each other. Lost Connection should override them when connectivity is lost.
+export const CommunicatingPollbookConnectionStatuses: PollbookConnectionStatus[] =
+  [
+    PollbookConnectionStatus.Connected,
+    PollbookConnectionStatus.MismatchedConfiguration,
+    PollbookConnectionStatus.IncompatibleSoftwareVersion,
+  ];
+
 export interface EventDbRow {
   event_id: number;
   machine_id: string;


### PR DESCRIPTION
## Overview
When we are changing the status to LostConnection we should only do that if the machine is currently in a Connected, MismatchedConfiguration, or IncompatibleSoftwareVersion state, if the machine is already LostConnection or ShutDown it should not have the state changed. 
<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot
N/A

## Testing Plan
Powered up two VxDev machines, shutdown one, saw the state on the other stable as "Powered Off" rather than resetting to LostConnection.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: "
      if my change is specific to one of those products.
- [x] I have added
      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
      where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to
      automate an announcement in #machine-product-updates.
