### PR TITLE
VxPollBook: very small export adjustments

### DIFF
--- a/apps/pollbook/backend/package.json
+++ b/apps/pollbook/backend/package.json
@@ -29,6 +29,7 @@
     "type-check": "tsc --build"
   },
   "dependencies": {
+    "@types/luxon": "^3.0.0",
     "@votingworks/auth": "workspace:*",
     "@votingworks/backend": "workspace:*",
     "@votingworks/basics": "workspace:*",
@@ -53,6 +54,7 @@
     "helmet": "^8.1.0",
     "js-sha256": "^0.9.0",
     "jsbarcode": "^3.11.6",
+    "luxon": "^3.0.0",
     "nanoid": "^3.3.7",
     "node-fetch": "^2.6.0",
     "pdf-lib": "^1.17.1",

--- a/apps/pollbook/backend/src/__snapshots__/voter_history.test.ts.snap
+++ b/apps/pollbook/backend/src/__snapshots__/voter_history.test.ts.snap
@@ -1,18 +1,18 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`getNewEvents returns events for unknown machines 1`] = `
-"Voter ID,Party,Last Name,First Name,Middle Name,Name Suffix,Street Number,Street Number Suffix,Street Number Fraction,Street Name,Apartment/Unit Number,Address Line 2,Address Line 3,City/Town,Zip Code,Check-In,Absentee,Address Change,Name Change,New Registration,OOSDL,Party Choice
-abigail,UND,Adams,Abigail,,,123,,,Main St,,line 2,,,12345,Y,N,N,N,N,,
-charlie,UND,Beauty,Bella,The,II,10,I,2,MAIN,1,line 2,,Somewhere,00000,N,N,Y,Y,N,,
-test-random-id-1,UND,Enchanting,Eevee,The,Sr,10,I,2,MAIN,1,line 2,,Somewhere,00000,N,N,N,N,Y,,
-bob,UND,Smith,Bob,,,123,,,Main St,,line 2,,,12345,Y,Y,N,N,N,CA,
+"Voter ID,Party,Last Name,First Name,Middle Name,Name Suffix,Street Number,Street Number Suffix,Street Number Fraction,Street Name,Apartment/Unit Number,Address Line 2,Address Line 3,City/Town,Zip Code,Check-In,Absentee,Address Change,Name Change,New Registration,OOSDL,Party Choice,Check-In Time
+abigail,UND,Adams,Abigail,,,123,,,Main St,,line 2,,,12345,Y,N,N,N,N,,,2025-08-06T16:21
+charlie,UND,Beauty,Bella,The,II,10,I,2,MAIN,1,line 2,,Somewhere,00000,N,N,Y,Y,N,,,
+test-random-id-1,UND,Enchanting,Eevee,The,Sr,10,I,2,MAIN,1,line 2,,Somewhere,00000,N,N,N,N,Y,,,
+bob,UND,Smith,Bob,,,123,,,Main St,,line 2,,,12345,Y,Y,N,N,N,CA,,2025-08-06T16:21
 "
 `;
 
 exports[`includes ballot party selection for primaries 1`] = `
-"Voter ID,Party,Last Name,First Name,Middle Name,Name Suffix,Street Number,Street Number Suffix,Street Number Fraction,Street Name,Apartment/Unit Number,Address Line 2,Address Line 3,City/Town,Zip Code,Check-In,Absentee,Address Change,Name Change,New Registration,OOSDL,Party Choice
-abigail,UND,Adams,Abigail,,,123,,,Main St,,line 2,,,12345,Y,N,N,N,N,,REP
-charlie,UND,Beauty,Bella,The,II,123,,,Main St,,line 2,,,12345,N,N,N,Y,N,,
-bob,UND,Smith,Bob,,,123,,,Main St,,line 2,,,12345,Y,N,N,N,N,,DEM
+"Voter ID,Party,Last Name,First Name,Middle Name,Name Suffix,Street Number,Street Number Suffix,Street Number Fraction,Street Name,Apartment/Unit Number,Address Line 2,Address Line 3,City/Town,Zip Code,Check-In,Absentee,Address Change,Name Change,New Registration,OOSDL,Party Choice,Check-In Time
+abigail,UND,Adams,Abigail,,,123,,,Main St,,line 2,,,12345,Y,N,N,N,N,,REP,2025-08-06T16:21
+charlie,UND,Beauty,Bella,The,II,123,,,Main St,,line 2,,,12345,N,N,N,Y,N,,,
+bob,UND,Smith,Bob,,,123,,,Main St,,line 2,,,12345,Y,N,N,N,N,,DEM,2025-08-06T16:21
 "
 `;

--- a/apps/pollbook/backend/src/__snapshots__/voter_history.test.ts.snap
+++ b/apps/pollbook/backend/src/__snapshots__/voter_history.test.ts.snap
@@ -2,17 +2,17 @@
 
 exports[`getNewEvents returns events for unknown machines 1`] = `
 "Voter ID,Party,Last Name,First Name,Middle Name,Name Suffix,Street Number,Street Number Suffix,Street Number Fraction,Street Name,Apartment/Unit Number,Address Line 2,Address Line 3,City/Town,Zip Code,Check-In,Absentee,Address Change,Name Change,New Registration,OOSDL,Party Choice,Check-In Time
-abigail,UND,Adams,Abigail,,,123,,,Main St,,line 2,,,12345,Y,N,N,N,N,,,2025-08-06T16:21
+abigail,UND,Adams,Abigail,,,123,,,Main St,,line 2,,,12345,Y,N,N,N,N,,,2025-01-01T13:05
 charlie,UND,Beauty,Bella,The,II,10,I,2,MAIN,1,line 2,,Somewhere,00000,N,N,Y,Y,N,,,
 test-random-id-1,UND,Enchanting,Eevee,The,Sr,10,I,2,MAIN,1,line 2,,Somewhere,00000,N,N,N,N,Y,,,
-bob,UND,Smith,Bob,,,123,,,Main St,,line 2,,,12345,Y,Y,N,N,N,CA,,2025-08-06T16:21
+bob,UND,Smith,Bob,,,123,,,Main St,,line 2,,,12345,Y,Y,N,N,N,CA,,2025-01-01T13:05
 "
 `;
 
 exports[`includes ballot party selection for primaries 1`] = `
 "Voter ID,Party,Last Name,First Name,Middle Name,Name Suffix,Street Number,Street Number Suffix,Street Number Fraction,Street Name,Apartment/Unit Number,Address Line 2,Address Line 3,City/Town,Zip Code,Check-In,Absentee,Address Change,Name Change,New Registration,OOSDL,Party Choice,Check-In Time
-abigail,UND,Adams,Abigail,,,123,,,Main St,,line 2,,,12345,Y,N,N,N,N,,REP,2025-08-06T16:21
+abigail,UND,Adams,Abigail,,,123,,,Main St,,line 2,,,12345,Y,N,N,N,N,,REP,2025-01-01T13:05
 charlie,UND,Beauty,Bella,The,II,123,,,Main St,,line 2,,,12345,N,N,N,Y,N,,,
-bob,UND,Smith,Bob,,,123,,,Main St,,line 2,,,12345,Y,N,N,N,N,,DEM,2025-08-06T16:21
+bob,UND,Smith,Bob,,,123,,,Main St,,line 2,,,12345,Y,N,N,N,N,,DEM,2025-01-01T13:05
 "
 `;

--- a/apps/pollbook/backend/src/voter_checklist.tsx
+++ b/apps/pollbook/backend/src/voter_checklist.tsx
@@ -275,11 +275,13 @@ export function VoterChecklistTable({
               )}
             </td>
             <td>
-              {voter.checkIn && voter.checkIn.ballotParty !== voter.party && (
-                <div style={{ color: redTextColor }}>
-                  {voter.checkIn.ballotParty}
-                </div>
-              )}
+              {voter.checkIn &&
+                voter.checkIn.ballotParty !== 'NOT_APPLICABLE' &&
+                voter.checkIn.ballotParty !== voter.party && (
+                  <div style={{ color: redTextColor }}>
+                    {voter.checkIn.ballotParty}
+                  </div>
+                )}
               {voter.party}
             </td>
             <td>

--- a/apps/pollbook/backend/src/voter_history.test.ts
+++ b/apps/pollbook/backend/src/voter_history.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi } from 'vitest';
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
 import { readMultiPartyPrimaryElectionDefinition } from '@votingworks/fixtures';
 import { VoterAddressChangeRequest } from '@votingworks/types';
 import { mockBaseLogger } from '@votingworks/logging';
@@ -22,6 +22,17 @@ const mockAddressDetails: VoterAddressChangeRequest = {
   city: 'Somewhere',
   precinct: 'precinct-1',
 };
+
+beforeEach(() => {
+  vi.useFakeTimers({
+    now: new Date(2025, 0, 1, 13, 5, 0),
+    toFake: ['Date'],
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 test('getNewEvents returns events for unknown machines', () => {
   const store = LocalStore.memoryStore(mockBaseLogger({ fn: vi.fn }));

--- a/apps/pollbook/backend/src/voter_history.ts
+++ b/apps/pollbook/backend/src/voter_history.ts
@@ -2,6 +2,7 @@
 
 import { stringify } from 'csv-stringify/sync';
 import { Election, Voter } from '@votingworks/types';
+import { DateTime } from 'luxon';
 
 export function generateVoterHistoryCsvContent(
   voters: Voter[],
@@ -54,6 +55,11 @@ export function generateVoterHistoryCsvContent(
             : '',
         'Party Choice':
           election.type === 'primary' ? voter.checkIn?.ballotParty || '' : '',
+        'Check-In Time': voter.checkIn
+          ? `${DateTime.fromISO(voter.checkIn.timestamp).toFormat(
+              "yyyy-MM-dd'T'T"
+            )}`
+          : '',
       };
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2264,6 +2264,9 @@ importers:
 
   apps/pollbook/backend:
     dependencies:
+      '@types/luxon':
+        specifier: ^3.0.0
+        version: 3.2.0
       '@votingworks/auth':
         specifier: workspace:*
         version: link:../../../libs/auth
@@ -2336,6 +2339,9 @@ importers:
       jsbarcode:
         specifier: ^3.11.6
         version: 3.11.6
+      luxon:
+        specifier: ^3.0.0
+        version: 3.3.0
       nanoid:
         specifier: ^3.3.7
         version: 3.3.7
@@ -13285,7 +13291,6 @@ packages:
 
   /@types/luxon@3.2.0:
     resolution: {integrity: sha512-lGmaGFoaXHuOLXFvuju2bfvZRqxAqkHPx9Y9IQdQABrinJJshJwfNCKV+u7rR3kJbiqfTF/NhOkcxxAFrObyaA==}
-    dev: true
 
   /@types/mdx@2.0.3:
     resolution: {integrity: sha512-IgHxcT3RC8LzFLhKwP3gbMPeaK7BM9eBH46OdapPA7yvuIUJ8H6zHZV53J8hGZcTSnt95jANt+rTBNUUc22ACQ==}


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6907

* Prevents `NOT_APPLICABLE` ballot party from showing up in the paper backups during generals. This value is assigned to `checkIn.ballotParty` as a dummy value but shouldn't be user-facing.

https://github.com/votingworks/vxsuite/issues/6666

* Adds timestamps to the voter history export

## Demo Video or Screenshot

<img width="1073" height="832" alt="Screenshot 2025-08-06 at 5 35 50 PM" src="https://github.com/user-attachments/assets/0e4dba50-e838-46f1-906f-ecfe5bb36f63" />



## Testing Plan

Updated snapshot test

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: "
      if my change is specific to one of those products.
- [ ] I have added
      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
      where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to
      automate an announcement in #machine-product-updates.
