### PR TITLE
Fix PR template checklist formatting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,10 +8,6 @@
 
 ## Checklist
 
-- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: "
-      if my change is specific to one of those products.
-- [ ] I have added
-      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
-      where appropriate for any new user actions.
-- [ ] I have added the "user_facing_change" label to this PR, if relevant, to
-      automate an announcement in #machine-product-updates.
+- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
+- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
+- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.


### PR DESCRIPTION
Truly so minor but noticed that the PR template checklist items are wrapping funny. My editor added in these breaks automatically on save when I opened https://github.com/votingworks/vxsuite/pull/6911, and I didn't realize that they'd actually show up as line breaks. Fixed to wrap appropriately.

## Before

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: "
      if my change is specific to one of those products.
- [ ] I have added
      [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging)
      where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to
      automate an announcement in #machine-product-updates.

## After

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.