### PR TITLE
VxPollBook: re-enable barcode scanner client test coverage

### DIFF
--- a/apps/pollbook/backend/package.json
+++ b/apps/pollbook/backend/package.json
@@ -72,6 +72,7 @@
     "@types/node-fetch": "^2.6.0",
     "@types/react": "18.3.3",
     "@types/styled-components": "^5.1.26",
+    "@types/tmp": "0.2.4",
     "@types/uuid": "9.0.5",
     "@types/yargs": "17.0.22",
     "@vitest/coverage-istanbul": "^3.1.1",
@@ -86,6 +87,7 @@
     "lint-staged": "11.0.0",
     "nodemon": "^3.1.7",
     "sort-package-json": "^1.50.0",
+    "tmp": "^0.2.1",
     "yargs": "17.7.1"
   },
   "engines": {

--- a/apps/pollbook/backend/src/barcode_scanner/client.test.ts
+++ b/apps/pollbook/backend/src/barcode_scanner/client.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable vx/gts-no-public-class-fields */
-
 import {
   describe,
   test,
@@ -11,13 +9,20 @@ import {
 } from 'vitest';
 import { PassThrough } from 'node:stream';
 import * as net from 'node:net';
-import { mockLogger, LogSource, MockLogger } from '@votingworks/logging';
+import {
+  mockLogger,
+  LogSource,
+  MockLogger,
+  LogEventId,
+  LogDispositionStandardTypes,
+} from '@votingworks/logging';
 import { tryConnect } from './unix_socket';
 import {
   connectToBarcodeScannerSocket,
   BarcodeScannerClient,
   UDS_CONNECTION_ATTEMPT_DELAY_MS,
 } from './client';
+import { AamvaDocument } from '../types';
 
 vi.mock('./unix_socket');
 
@@ -28,7 +33,7 @@ const mockedTryConnect = tryConnect as unknown as MockedFunction<
   typeof tryConnect
 >;
 
-describe('SocketServer.listen event handling', () => {
+describe('listen', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     mockSocket = new PassThrough() as unknown as net.Socket;
@@ -43,7 +48,12 @@ describe('SocketServer.listen event handling', () => {
     vi.useRealTimers();
   });
 
-  test('schedules reconnect on "end" event', async () => {
+  // Sets up a mock UDS client and returns a Promise that resolves when
+  // listen() completes
+  async function setUpMockSocket(): Promise<{
+    barcodeScannerClient: BarcodeScannerClient;
+    listenPromise: Promise<void>;
+  }> {
     const onSpy = vi.spyOn(mockSocket, 'on');
 
     mockedTryConnect.mockResolvedValue(mockSocket as unknown as net.Socket);
@@ -58,6 +68,36 @@ describe('SocketServer.listen event handling', () => {
     );
 
     expect(mockedTryConnect).toHaveBeenCalledTimes(1);
+
+    return { barcodeScannerClient, listenPromise };
+  }
+
+  test('can read from scanner socket', async () => {
+    const { barcodeScannerClient, listenPromise } = await setUpMockSocket();
+    const doc: AamvaDocument = {
+      firstName: 'Jane',
+      middleName: '',
+      lastName: 'Doe',
+      nameSuffix: '',
+      issuingJurisdiction: 'NH',
+    };
+    mockSocket.write(`${JSON.stringify(doc)}\n`);
+    mockSocket.end();
+    await listenPromise;
+    expect(barcodeScannerClient.readPayload()).toEqual(doc);
+  });
+
+  test('reports an error if socket sends one', async () => {
+    const { barcodeScannerClient, listenPromise } = await setUpMockSocket();
+    const error = 'a mock error occurred';
+    mockSocket.write(`${JSON.stringify({ error })}\n`);
+    mockSocket.end();
+    await listenPromise;
+    expect(barcodeScannerClient.readPayload()).toEqual({ error });
+  });
+
+  test('schedules reconnect on "end" event', async () => {
+    const { listenPromise } = await setUpMockSocket();
 
     // End the socket to trigger reconnection
     mockSocket.end();
@@ -105,6 +145,36 @@ describe('connectToBarcodeScannerSocket', () => {
     // Second attempt should succeed
     const socket = await socketPromise;
     expect(socket).toEqual(mockSocket);
+    vi.useRealTimers();
+  });
+
+  test('times out of the time limit is reached', async () => {
+    vi.useFakeTimers();
+    // First call fails
+    mockedTryConnect.mockRejectedValue(
+      new Error('Test error connecting to socket')
+    );
+
+    // Start querying for socket
+    const socketPromise = connectToBarcodeScannerSocket(
+      logger,
+      UDS_CONNECTION_ATTEMPT_DELAY_MS + 10
+    );
+
+    // Wait until tryConnect has been called once (failure) to advance timer
+    await vi.waitFor(() => expect(mockedTryConnect).toHaveBeenCalledTimes(1));
+    vi.advanceTimersByTime(UDS_CONNECTION_ATTEMPT_DELAY_MS);
+
+    // Timeout should expire and function should resolve without a socket
+    const socket = await socketPromise;
+    expect(socket).toEqual(undefined);
+    expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+      LogEventId.SocketClientConnected,
+      {
+        message: 'Exhausted UDS connection attempts',
+        disposition: LogDispositionStandardTypes.Failure,
+      }
+    );
     vi.useRealTimers();
   });
 });

--- a/apps/pollbook/backend/src/barcode_scanner/client.test.ts
+++ b/apps/pollbook/backend/src/barcode_scanner/client.test.ts
@@ -1,3 +1,5 @@
+import tmp from 'tmp';
+import { symlink } from 'node:fs/promises';
 import {
   describe,
   test,
@@ -15,14 +17,16 @@ import {
   MockLogger,
   LogEventId,
   LogDispositionStandardTypes,
+  Logger,
 } from '@votingworks/logging';
+import path from 'node:path';
 import { tryConnect } from './unix_socket';
 import {
   connectToBarcodeScannerSocket,
   BarcodeScannerClient,
   UDS_CONNECTION_ATTEMPT_DELAY_MS,
 } from './client';
-import { AamvaDocument } from '../types';
+import { AamvaDocument, BarcodeScannerError } from '../types';
 
 vi.mock('./unix_socket');
 
@@ -33,44 +37,103 @@ const mockedTryConnect = tryConnect as unknown as MockedFunction<
   typeof tryConnect
 >;
 
-describe('listen', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    mockSocket = new PassThrough() as unknown as net.Socket;
-    logger = mockLogger({
-      source: LogSource.VxPollBookBackend,
-      getCurrentRole: vi.fn().mockResolvedValue('system'),
-      fn: vi.fn,
+// Sets up a mock UDS client and returns a Promise that resolves when
+// listen() completes
+async function setUpMockSocket(
+  overrides: Partial<{
+    logger: Logger;
+    scannedDocument?: AamvaDocument;
+    error?: BarcodeScannerError;
+    connectedToDaemon: boolean;
+    devicePath: string;
+  }> = {}
+): Promise<{
+  barcodeScannerClient: BarcodeScannerClient;
+  listenPromise: Promise<void>;
+}> {
+  const onSpy = vi.spyOn(mockSocket, 'on');
+
+  mockedTryConnect.mockResolvedValue(mockSocket as unknown as net.Socket);
+
+  const { scannedDocument, error, connectedToDaemon, devicePath } = overrides;
+
+  const barcodeScannerClient = new BarcodeScannerClient(
+    overrides.logger || logger,
+    scannedDocument,
+    error,
+    connectedToDaemon,
+    devicePath
+  );
+  expect(mockedTryConnect).toHaveBeenCalledTimes(0);
+  const listenPromise = barcodeScannerClient.listen();
+
+  // Wait for listener to be bound
+  await vi.waitFor(() =>
+    expect(onSpy).toHaveBeenCalledWith('error', expect.any(Function))
+  );
+
+  expect(mockedTryConnect).toHaveBeenCalledTimes(1);
+
+  return { barcodeScannerClient, listenPromise };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockSocket = new PassThrough() as unknown as net.Socket;
+  logger = mockLogger({
+    source: LogSource.VxPollBookBackend,
+    getCurrentRole: vi.fn().mockResolvedValue('system'),
+    fn: vi.fn,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('isConnected', () => {
+  test('returns true when device symlink exists and connected to socket', async () => {
+    const tmpDir = tmp.dirSync();
+    const mockDevicePath = tmp.fileSync({ tmpdir: tmpDir.name });
+    const devicePath = path.join(tmpDir.name, 'mock-barcode-scanner');
+    await symlink(mockDevicePath.name, devicePath);
+
+    const { barcodeScannerClient, listenPromise } = await setUpMockSocket({
+      devicePath,
     });
+
+    expect(await barcodeScannerClient.isConnected()).toEqual(true);
+
+    mockSocket.end();
+    await listenPromise;
   });
-  afterEach(() => {
-    vi.restoreAllMocks();
-    vi.useRealTimers();
+
+  test('returns false when device symlink does not exist', async () => {
+    const { barcodeScannerClient, listenPromise } = await setUpMockSocket({
+      devicePath: '/tmp/does-not-exist',
+    });
+
+    expect(await barcodeScannerClient.isConnected()).toEqual(false);
+
+    mockSocket.end();
+    await listenPromise;
+  });
+});
+
+describe('listen', () => {
+  test('returns undefined if no data has been received from barcode scanner', async () => {
+    const { barcodeScannerClient, listenPromise } = await setUpMockSocket();
+    mockSocket.end();
+    await listenPromise;
+
+    expect(barcodeScannerClient.readPayload()).toEqual(undefined);
   });
 
-  // Sets up a mock UDS client and returns a Promise that resolves when
-  // listen() completes
-  async function setUpMockSocket(): Promise<{
-    barcodeScannerClient: BarcodeScannerClient;
-    listenPromise: Promise<void>;
-  }> {
-    const onSpy = vi.spyOn(mockSocket, 'on');
-
-    mockedTryConnect.mockResolvedValue(mockSocket as unknown as net.Socket);
-
+  test('returns without error if no UDS client exists', async () => {
     const barcodeScannerClient = new BarcodeScannerClient(logger);
-    expect(mockedTryConnect).toHaveBeenCalledTimes(0);
-    const listenPromise = barcodeScannerClient.listen();
-
-    // Wait for listener to be bound
-    await vi.waitFor(() =>
-      expect(onSpy).toHaveBeenCalledWith('error', expect.any(Function))
-    );
-
-    expect(mockedTryConnect).toHaveBeenCalledTimes(1);
-
-    return { barcodeScannerClient, listenPromise };
-  }
+    expect(await barcodeScannerClient.listen()).toEqual(undefined);
+  });
 
   test('can read from scanner socket', async () => {
     const { barcodeScannerClient, listenPromise } = await setUpMockSocket();
@@ -93,7 +156,22 @@ describe('listen', () => {
     mockSocket.write(`${JSON.stringify({ error })}\n`);
     mockSocket.end();
     await listenPromise;
+
     expect(barcodeScannerClient.readPayload()).toEqual({ error });
+  });
+
+  test('logs if error occurs during message parsing', async () => {
+    const { listenPromise } = await setUpMockSocket();
+    mockSocket.write('{"oops": ""\n');
+    mockSocket.end();
+    await listenPromise;
+    expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+      LogEventId.ParseError,
+      {
+        message: 'Could not parse barcode scanner message',
+        error: 'Unexpected end of JSON input',
+      }
+    );
   });
 
   test('schedules reconnect on "end" event', async () => {

--- a/apps/pollbook/backend/src/barcode_scanner/client.ts
+++ b/apps/pollbook/backend/src/barcode_scanner/client.ts
@@ -25,16 +25,14 @@ const DEVICE_PATH = '/dev/barcode_scanner';
  * Allows failure to connect so the app can fall back gracefully.
  */
 export async function connectToBarcodeScannerSocket(
-  logger: Logger
+  logger: Logger,
+  timeoutMs: number = UDS_CONNECTION_TIMEOUT_MS
 ): Promise<Optional<net.Socket>> {
   await logger.logAsCurrentRole(LogEventId.SocketClientConnectInit, {
     message: 'Connection to barcode scanner daemon UDS initiated',
   });
   const connectStart = new Date();
-  while (
-    new Date().getTime() - connectStart.getTime() <
-    UDS_CONNECTION_TIMEOUT_MS
-  ) {
+  while (new Date().getTime() - connectStart.getTime() < timeoutMs) {
     try {
       return await tryConnect(logger);
     } catch (e) {

--- a/apps/pollbook/backend/src/barcode_scanner/client.ts
+++ b/apps/pollbook/backend/src/barcode_scanner/client.ts
@@ -79,6 +79,7 @@ export class BarcodeScannerClient {
       return deviceFound && this.connectedToDaemon;
     } catch (err: unknown) {
       const typedError = err as NodeJS.ErrnoException;
+      /* istanbul ignore next - @preserve */
       if (typedError.code !== 'ENOENT') {
         await this.logger.logAsCurrentRole(LogEventId.UnknownError, {
           message: 'Unknown error trying to lstat barcode scanner',
@@ -115,8 +116,8 @@ export class BarcodeScannerClient {
       this.scheduleReconnect();
     });
 
-    for await (const line of lines(udsClient)) {
-      try {
+    try {
+      for await (const line of lines(udsClient)) {
         const result = safeParseJson(line, BarcodeScannerPayloadSchema);
         if (result.isErr()) {
           await this.logger.logAsCurrentRole(LogEventId.ParseError, {
@@ -132,12 +133,13 @@ export class BarcodeScannerClient {
         } else {
           this.error = parsed;
         }
-      } catch (error) {
-        await this.logger.logAsCurrentRole(LogEventId.ParseError, {
-          message: 'Could not read line from barcode scanner daemon UDS',
-          error: (error as Error).message,
-        });
       }
+    } catch (error) {
+      /* istanbul ignore next - @preserve */
+      await this.logger.logAsCurrentRole(LogEventId.ParseError, {
+        message: 'Could not read line from barcode scanner daemon UDS',
+        error: (error as Error).message,
+      });
     }
   }
 }

--- a/apps/pollbook/backend/vitest.config.ts
+++ b/apps/pollbook/backend/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 88.3,
-        branches: 82.5,
+        lines: 88.7,
+        branches: 83,
       },
       exclude: [
         '**/node_modules/**',

--- a/apps/pollbook/backend/vitest.config.ts
+++ b/apps/pollbook/backend/vitest.config.ts
@@ -17,7 +17,6 @@ export default defineConfig({
         '**/*.d.ts',
         '**/types.ts',
         'src/**/index.ts',
-        'src/barcode_scanner/client.ts',
       ],
     },
     // Ensure only one instance of each library is loaded by loading the TS

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2388,6 +2388,9 @@ importers:
       '@types/styled-components':
         specifier: ^5.1.26
         version: 5.1.26
+      '@types/tmp':
+        specifier: 0.2.4
+        version: 0.2.4
       '@types/uuid':
         specifier: 9.0.5
         version: 9.0.5
@@ -2430,6 +2433,9 @@ importers:
       sort-package-json:
         specifier: ^1.50.0
         version: 1.50.0
+      tmp:
+        specifier: ^0.2.1
+        version: 0.2.1
       yargs:
         specifier: 17.7.1
         version: 17.7.1


### PR DESCRIPTION
## Overview

Re-enables tests for the barcode scanner node client and adds coverage.

## Demo Video or Screenshot

N/A tests only

## Testing Plan

Increased coverage on this file to 100%

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.

