### PR TITLE
VxPollBook: a handful of low and medium priority fixes emerging from v1.1.0 beta QA

### DIFF
--- a/apps/pollbook/frontend/src/update_address_flow.tsx
+++ b/apps/pollbook/frontend/src/update_address_flow.tsx
@@ -243,7 +243,6 @@ export function UpdateAddressFlow({
               <H1>
                 Domicile address updated for <VoterName voter={voter} />
               </H1>
-              <p>Give the voter their receipt.</p>
             </FullScreenMessage>
           </Column>
           <Row style={{ padding: '1rem', justifyContent: 'flex-end' }}>

--- a/apps/pollbook/frontend/src/update_mailing_address_flow.tsx
+++ b/apps/pollbook/frontend/src/update_mailing_address_flow.tsx
@@ -195,7 +195,6 @@ export function UpdateMailingAddressFlow({
               <H1>
                 Mailing address updated for <VoterName voter={voter} />
               </H1>
-              <p>Give the voter their receipt.</p>
             </FullScreenMessage>
           </Column>
           <Row style={{ padding: '1rem', justifyContent: 'flex-end' }}>

--- a/apps/pollbook/frontend/src/update_mailing_address_flow.tsx
+++ b/apps/pollbook/frontend/src/update_mailing_address_flow.tsx
@@ -67,7 +67,11 @@ function UpdateMailingAddressScreen({
     useState<VoterMailingAddressChangeRequest>(createBlankMailingAddress());
 
   const isMailingAddressValid =
-    mailingAddress.mailingCityTown !== '' && mailingAddress.mailingZip5 !== '';
+    mailingAddress.mailingCityTown !== '' &&
+    mailingAddress.mailingState !== '' &&
+    mailingAddress.mailingZip5.length === 5 &&
+    (mailingAddress.mailingZip4.length === 0 ||
+      mailingAddress.mailingZip4.length === 4);
 
   return (
     <NoNavScreen>

--- a/apps/pollbook/frontend/src/voter_confirm_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_confirm_screen.tsx
@@ -239,38 +239,41 @@ export function VoterConfirmScreen({
                     </LabelledText>
                   )}
                 </Row>
-                {hasMailingAddress(voter) && (
-                  <LabelledText
-                    style={{ width: '100%' }}
-                    label={
-                      voter.mailingAddressChange ? (
-                        <s>Mailing Address</s>
-                      ) : (
-                        'Mailing Address'
-                      )
-                    }
-                  >
-                    <VoterMailingAddress
-                      voter={voter}
-                      style={
-                        voter.mailingAddressChange && {
-                          textDecoration: 'line-through',
+                {(hasMailingAddress(voter) || voter.mailingAddressChange) && (
+                  <Row style={{ gap: '1.5rem' }}>
+                    {hasMailingAddress(voter) && (
+                      <LabelledText
+                        style={{ width: '100%' }}
+                        label={
+                          voter.mailingAddressChange ? (
+                            <s>Mailing Address</s>
+                          ) : (
+                            'Mailing Address'
+                          )
                         }
-                      }
-                    />
-                  </LabelledText>
+                      >
+                        <VoterMailingAddress
+                          voter={voter}
+                          style={
+                            voter.mailingAddressChange && {
+                              textDecoration: 'line-through',
+                            }
+                          }
+                        />
+                      </LabelledText>
+                    )}
+                    {voter.mailingAddressChange && (
+                      <LabelledText
+                        label="Updated Mailing Address"
+                        style={{ width: '100%' }}
+                      >
+                        <MailingAddressChange
+                          address={voter.mailingAddressChange}
+                        />
+                      </LabelledText>
+                    )}
+                  </Row>
                 )}
-                {voter.mailingAddressChange && (
-                  <LabelledText
-                    label="Updated Mailing Address"
-                    style={{ width: '100%' }}
-                  >
-                    <MailingAddressChange
-                      address={voter.mailingAddressChange}
-                    />
-                  </LabelledText>
-                )}
-
                 <LabelledText label="Voter ID">{voter.voterId}</LabelledText>
               </Column>
             </Row>

--- a/apps/pollbook/frontend/src/voter_details_screen.test.tsx
+++ b/apps/pollbook/frontend/src/voter_details_screen.test.tsx
@@ -812,6 +812,29 @@ describe('common functionality', () => {
     await screen.findByText('100 1/2A STREET STREET #1');
     await screen.findByText('SOMEWHERE, AL 12345-6789');
   });
+
+  test('absentee check-in shows "Absentee Checked In"', async () => {
+    const checkedInAbsenteeVoter: Voter = {
+      ...voter,
+      checkIn: {
+        identificationMethod: { type: 'default' },
+        timestamp: new Date().toISOString(),
+        isAbsentee: true,
+        receiptNumber: 0,
+        machineId: 'test-machine-01',
+        ballotParty: 'DEM',
+      },
+    };
+
+    apiMock.expectGetVoter(checkedInAbsenteeVoter);
+    apiMock.expectGetDeviceStatuses();
+    apiMock.setPrinterStatus(true);
+
+    await renderComponent();
+
+    // Verify that "Absentee" value appears
+    screen.getByRole('heading', { name: 'Absentee Checked In' });
+  });
 });
 
 describe('primary election functionality', () => {

--- a/apps/pollbook/frontend/src/voter_details_screen.test.tsx
+++ b/apps/pollbook/frontend/src/voter_details_screen.test.tsx
@@ -643,10 +643,16 @@ describe('common functionality', () => {
         newValue: '12345-6789',
       },
     ];
+
+    const updateButton = screen.getButton('Confirm Mailing Address Update');
     for (const part of addressParts) {
       const partInput = await screen.findByRole('textbox', {
         name: part.domElementText,
       });
+
+      // should be disabled until all required fields are filled
+      expect(updateButton).toBeDisabled();
+
       userEvent.type(partInput, part.newValue);
     }
 
@@ -676,7 +682,7 @@ describe('common functionality', () => {
         timestamp: new Date().toISOString(),
       },
     };
-    const updateButton = screen.getButton('Confirm Mailing Address Update');
+    expect(updateButton).not.toBeDisabled();
     userEvent.click(updateButton);
 
     apiMock.expectGetVoter(updatedVoter);

--- a/apps/pollbook/frontend/src/voter_details_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_details_screen.tsx
@@ -419,34 +419,40 @@ export function VoterDetailsScreen(): JSX.Element | null {
                   </LabelledText>
                 )}
               </Row>
-              {hasMailingAddress(voter) && (
-                <LabelledText
-                  style={{ width: '100%' }}
-                  label={
-                    voter.mailingAddressChange ? (
-                      <s>Mailing Address</s>
-                    ) : (
-                      'Mailing Address'
-                    )
-                  }
-                >
-                  <VoterMailingAddress
-                    voter={voter}
-                    style={
-                      voter.mailingAddressChange && {
-                        textDecoration: 'line-through',
+              {(hasMailingAddress(voter) || voter.mailingAddressChange) && (
+                <Row style={{ gap: '1.5rem' }}>
+                  {hasMailingAddress(voter) && (
+                    <LabelledText
+                      style={{ width: '100%' }}
+                      label={
+                        voter.mailingAddressChange ? (
+                          <s>Mailing Address</s>
+                        ) : (
+                          'Mailing Address'
+                        )
                       }
-                    }
-                  />
-                </LabelledText>
-              )}
-              {voter.mailingAddressChange && (
-                <LabelledText
-                  label="Updated Mailing Address"
-                  style={{ width: '100%' }}
-                >
-                  <MailingAddressChange address={voter.mailingAddressChange} />
-                </LabelledText>
+                    >
+                      <VoterMailingAddress
+                        voter={voter}
+                        style={
+                          voter.mailingAddressChange && {
+                            textDecoration: 'line-through',
+                          }
+                        }
+                      />
+                    </LabelledText>
+                  )}
+                  {voter.mailingAddressChange && (
+                    <LabelledText
+                      label="Updated Mailing Address"
+                      style={{ width: '100%' }}
+                    >
+                      <MailingAddressChange
+                        address={voter.mailingAddressChange}
+                      />
+                    </LabelledText>
+                  )}
+                </Row>
               )}
               <LabelledText label="Voter ID">{voter.voterId}</LabelledText>
             </Column>

--- a/apps/pollbook/frontend/src/voter_details_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_details_screen.tsx
@@ -507,7 +507,15 @@ export function VoterDetailsScreen(): JSX.Element | null {
             {voter.checkIn && (
               <React.Fragment>
                 <H2 style={{ marginTop: 0 }}>
-                  <Icons.Done /> Checked In
+                  {voter.checkIn.isAbsentee ? (
+                    <React.Fragment>
+                      <Icons.Envelope /> Absentee Checked In
+                    </React.Fragment>
+                  ) : (
+                    <React.Fragment>
+                      <Icons.Done /> Checked In{' '}
+                    </React.Fragment>
+                  )}
                 </H2>
                 <Column style={{ gap: '1rem' }}>
                   <LabelledText label="Time">

--- a/libs/ui/src/invalid_card_screen.test.tsx
+++ b/libs/ui/src/invalid_card_screen.test.tsx
@@ -91,8 +91,7 @@ const testCases: Array<{
       reason: 'certificate_not_yet_valid',
     },
     expectedHeading: 'Invalid Card',
-    expectedText:
-      'Check that the your machines have the correct date and time.',
+    expectedText: 'Check that your machines have the correct date and time.',
   },
   {
     description: 'other error',

--- a/libs/ui/src/invalid_card_screen.tsx
+++ b/libs/ui/src/invalid_card_screen.tsx
@@ -56,7 +56,7 @@ export function InvalidCardScreen({
     }
     case 'certificate_not_yet_valid': {
       recommendedAction =
-        'Check that the your machines have the correct date and time.';
+        'Check that your machines have the correct date and time.';
       break;
     }
     case 'machine_not_configured': {


### PR DESCRIPTION
## Overview

In order of commits:

1. Closes #6985. Fixes grammatical problem on copy for cards with wrong time.
2. Closes #6980. Moves updated mailing address to the side rather than below.
3. Closes #6978. Requires complete ZIP and a state for mailing addresses.
4. Closes #6979. Removes "Give voter receipt" text for address changes.
5. Closes #6984. Updates voter details page to indicate if a check-in was absentee.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
