### PR TITLE
fix(scan): pass `Uint8Array` instead of `Buffer`

### DIFF
--- a/apps/scan/backend/src/printing/printer.ts
+++ b/apps/scan/backend/src/printing/printer.ts
@@ -85,7 +85,7 @@ export function wrapFujitsuThermalPrinter(
 ): Printer {
   return {
     scheme: 'hardware-v4',
-    printPdf: (data: Uint8Array) => printer.printPdf(Buffer.from(data)),
+    printPdf: (data: Uint8Array) => printer.printPdf(data),
     printImageData: (imageData: ImageData) => printer.printImageData(imageData),
     getStatus: async () => {
       const status = await printer.getStatus();

--- a/libs/fujitsu-thermal-printer/src/mocks/file_printer.test.ts
+++ b/libs/fujitsu-thermal-printer/src/mocks/file_printer.test.ts
@@ -58,7 +58,7 @@ test('fails printing if not initial idle', async () => {
     state: 'no-paper',
   });
 
-  await expect(filePrinter.printPdf(Buffer.from('test'))).rejects.toThrow();
+  await expect(filePrinter.printPdf(Uint8Array.of(1, 2, 3))).rejects.toThrow();
   expect(logger.log).toBeCalledTimes(2);
   expect(logger.log).toHaveBeenCalledWith(
     LogEventId.PrinterPrintRequest,
@@ -83,10 +83,10 @@ test('successful printing', async () => {
   });
   const filePrinterHandler = getMockFileFujitsuPrinterHandler();
 
-  const print1Promise = filePrinter.printPdf(Buffer.from('print-1'));
+  const print1Promise = filePrinter.printPdf(Uint8Array.of(1, 2, 3));
   expect(await print1Promise).toEqual(ok());
 
-  const print2Promise = filePrinter.printPdf(Buffer.from('print-2'));
+  const print2Promise = filePrinter.printPdf(Uint8Array.of(4, 5, 6));
   expect(await print2Promise).toEqual(ok());
 
   expect(filePrinterHandler.getDataPath()).toEqual(
@@ -97,8 +97,8 @@ test('successful printing', async () => {
     /\/tmp\/mock-fujitsu-printer\/prints\/print-job-.*\.pdf/
   );
 
-  expect(readFileSync(filePrinterHandler.getLastPrintPath()!, 'utf-8')).toEqual(
-    'print-2'
+  expect(readFileSync(filePrinterHandler.getLastPrintPath()!)).toEqual(
+    Buffer.of(4, 5, 6)
   );
 
   filePrinterHandler.cleanup();
@@ -125,7 +125,7 @@ test('failed print', async () => {
   });
   const filePrinterHandler = getMockFileFujitsuPrinterHandler();
 
-  const print1Promise = filePrinter.printPdf(Buffer.from('print-1'));
+  const print1Promise = filePrinter.printPdf(Uint8Array.of(1, 2, 3));
   filePrinterHandler.setStatus({
     state: 'no-paper',
   });

--- a/libs/fujitsu-thermal-printer/src/printing.ts
+++ b/libs/fujitsu-thermal-printer/src/printing.ts
@@ -7,7 +7,6 @@ import {
 } from '@votingworks/image-utils';
 import { BITS_PER_BYTE } from '@votingworks/message-coder';
 import { readFileSync } from 'node:fs';
-import { Buffer } from 'node:buffer';
 import {
   FujitsuThermalPrinterDriver,
   FujitsuThermalPrinterDriverInterface,
@@ -395,7 +394,7 @@ export async function printPdf(
   driver: FujitsuThermalPrinterDriverInterface,
   pdfData: Uint8Array
 ): Promise<Result<void, RawPrinterStatus>> {
-  const pdfImages = pdfToImages(Buffer.from(pdfData), {
+  const pdfImages = pdfToImages(pdfData, {
     scale: PDF_SCALE,
   });
   for await (const { page, pageNumber, pageCount } of pdfImages) {


### PR DESCRIPTION
## Overview

The version of `pdfjs-dist` we updated to in #6756, v3.11.174, requires the PDF data be passed as a `Uint8Array` rather than a `Buffer`. This is annoying since TypeScript doesn't complain about a `Buffer` being passed where a `Uint8Array` is expected since the former is a subclass of the latter. #6756 updated most of the places where we were passing `Buffer`s, but missed a couple that this commit addresses.

## Demo Video or Screenshot

I was getting this on a VxDev machine when trying to open or close the polls ([Slack thread](https://votingworks.slack.com/archives/CEL6D3GAD/p1754954224207369)):

```
[backend:run] {"source":"vx-scan-backend","eventId":"printer-print-request","eventType":"user-action","user":"poll_worker","message":"Initiating print","disposition":"na"}
[backend:run] Error: Please provide binary data as `Uint8Array`, rather than `Buffer`.
[backend:run]     at getDataProp (/home/vx/code/vxsuite-complete-system/vxsuite/node_modules/.pnpm/pdfjs-dist@3.11.174/node_modules/pdfjs-dist/legacy/build/pdf.js:3630:11)
[backend:run]     at Object.getDocument (/home/vx/code/vxsuite-complete-system/vxsuite/node_modules/.pnpm/pdfjs-dist@3.11.174/node_modules/pdfjs-dist/legacy/build/pdf.js:3463:27)
[backend:run]     at pdfToImages (/home/vx/code/vxsuite-complete-system/vxsuite/libs/image-utils/build/pdf_to_images.js:18:29)
[backend:run]     at async printPdf (/home/vx/code/vxsuite-complete-system/vxsuite/libs/fujitsu-thermal-printer/build/printing.js:284:52)
[backend:run]     at async FujitsuThermalPrinter.printPdf (/home/vx/code/vxsuite-complete-system/vxsuite/libs/fujitsu-thermal-printer/build/printer.js:97:29)
[backend:run]     at async printReport (/home/vx/code/vxsuite-complete-system/vxsuite/apps/scan/backend/build/app.js:272:25)
[backend:run]     at async /home/vx/code/vxsuite-complete-system/vxsuite/libs/grout/build/server.js:130:26
```

## Testing Plan
Tested on the same machine that previously failed, saw that the printer did properly print the open and close polls reports.
