### PR TITLE
VxPollBook: Handle avahi browse timeouts more gracefully

### DIFF
--- a/apps/pollbook/backend/intermediate-scripts/avahi-browse
+++ b/apps/pollbook/backend/intermediate-scripts/avahi-browse
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-timeout 3 avahi-browse -r -t -p _http._tcp
+
+status=0
+
+timeout -s INT 3 avahi-browse -r -t -p _http._tcp || status=$?
+
+# Don't exit with an error if there is no error (exit 0) or the error is due to timeout (exit 124)
+if [ $status -ne 0 ] && [ $status -ne 124 ]; then
+    exit $status
+fi

--- a/apps/pollbook/backend/src/avahi.ts
+++ b/apps/pollbook/backend/src/avahi.ts
@@ -78,7 +78,8 @@ export class AvahiService {
       const { stdout, stderr } = await execFile('sudo', [
         intermediateScript('avahi-browse'),
       ]);
-      if (stderr) {
+      // Only return with an error if there is not stdout output, otherwise try to parse it.
+      if (stderr && stdout.length <= 0) {
         debug(`avahi-browse stderr: ${stderr}`);
         return [];
       }


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/6967

This broke in the intermediate-scripts refactor, we expect avahi-browse to need to be timed out occasionally or it may hang indefinitely, when the timeout in the script does come into play, however, we don't want to treat that like a thrown error and throw out the stdout output that does get sent through prior to the sigint. This will avoid the avahi-browse script from causing execFile to throw an error by exiting with code 0 in the timeout case and tweaks the result handling in typescript to still try to parse the stdout, even if there is stderr, if it exists. 

## Testing Plan
Patched imaged machine with change, walked out of range, saw it keep the old pollbook as LostConnection (then PoweredOff which is an unrelated change we may want to make), verfied in tty2 that avahi-browse was timing out, walked back into range and saw seamless switch back to Connected. Never saw network drop to offline. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
