### PR TITLE
VxPollBook: Fix frontend logging

### DIFF
--- a/apps/pollbook/frontend/package.json
+++ b/apps/pollbook/frontend/package.json
@@ -80,6 +80,7 @@
     "@testing-library/user-event": "^13.5.0",
     "@types/debug": "4.1.8",
     "@types/history": "4.7.11",
+    "@types/kiosk-browser": "workspace:*",
     "@types/lodash.debounce": "^4.0.9",
     "@types/luxon": "^3.0.0",
     "@types/react": "18.3.3",

--- a/apps/pollbook/frontend/prodserver/index.js
+++ b/apps/pollbook/frontend/prodserver/index.js
@@ -13,7 +13,7 @@ const { handleUncaughtExceptions } = require('@votingworks/backend');
 const proxy = require('./setupProxy');
 const app = express();
 const port = 3000;
-const logger = new Logger(LogSource.VxPollBookFrontendServer);
+const logger = new Logger(LogSource.VxPollBookFrontend);
 
 handleUncaughtExceptions(logger);
 
@@ -32,13 +32,13 @@ app.get('*', (req, res) => {
 app
   .listen(port, () => {
     logger.log(LogEventId.ApplicationStartup, 'system', {
-      message: `VxAdmin frontend running at http://localhost:${port}/`,
+      message: `VxPollbook frontend running at http://localhost:${port}/`,
       disposition: 'success',
     });
   })
   .on('error', (error) => {
     logger.log(LogEventId.ApplicationStartup, 'system', {
-      message: `Error in starting VxAdmin frontend: ${error.message}`,
+      message: `Error in starting VxPollbook frontend: ${error.message}`,
       disposition: 'failure',
     });
   });

--- a/apps/pollbook/frontend/src/app.tsx
+++ b/apps/pollbook/frontend/src/app.tsx
@@ -153,7 +153,7 @@ export function App({
 }: {
   apiClient?: ApiClient;
 }): JSX.Element {
-  const logger = new BaseLogger(LogSource.VxPollBookFrontend);
+  const logger = new BaseLogger(LogSource.VxPollBookFrontend, window.kiosk);
 
   return (
     <AppBase

--- a/libs/logging/src/base_logger.ts
+++ b/libs/logging/src/base_logger.ts
@@ -22,6 +22,7 @@ export const CLIENT_SIDE_LOG_SOURCES = [
   LogSource.VxBallotActivationFrontend,
   LogSource.VxMarkFrontend,
   LogSource.VxMarkScanFrontend,
+  LogSource.VxPollBookFrontend,
 ];
 
 const debug = makeDebug('logger');

--- a/libs/logging/src/types.ts
+++ b/libs/logging/src/types.ts
@@ -63,4 +63,5 @@ export const DEVICE_TYPES_FOR_APP: Dictionary<EventLogging.DeviceType> = {
   [LogSource.VxBallotActivationFrontend]:
     EventLogging.DeviceType.BallotActivation,
   [LogSource.VxMarkScanFrontend]: EventLogging.DeviceType.Bmd,
+  [LogSource.VxPollBookFrontend]: EventLogging.DeviceType.ElectronicPollBook,
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2551,6 +2551,9 @@ importers:
       '@types/history':
         specifier: 4.7.11
         version: 4.7.11
+      '@types/kiosk-browser':
+        specifier: workspace:*
+        version: link:../../../libs/@types/kiosk-browser
       '@types/lodash.debounce':
         specifier: ^4.0.9
         version: 4.0.9


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/6968 

Fixes the frontend logging for VxPollBook, this could all be clearer but you need to give window.kiosk to the logger when creating it and it needs to be listed as a CLIENT_SIDE_LOG_SOURCE in the logging framework for the logger command to pipe to window.kiosk.log which will send it to the logging pipeline in the image. 
<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot
N/A

## Testing Plan
Hacked this change onto an imaged machine, saw logs appear as expected. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
