### PR TITLE
VxPollBook: Networking Management Tweaks

### DIFF
--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -69,7 +69,6 @@ import {
   NameChangeReceipt,
 } from './receipts';
 import { pollUsbDriveForPollbookPackage } from './pollbook_package';
-import { resetNetworkSetup } from './networking';
 import { UndoCheckInReceipt } from './receipts/undo_check_in_receipt';
 import { renderAndPrintReceipt } from './receipts/printing';
 import { UNCONFIGURE_LOCKOUT_TIMEOUT } from './globals';
@@ -687,7 +686,7 @@ function buildApi({ context, logger, barcodeScannerClient }: BuildAppParams) {
     },
 
     async resetNetwork(): Promise<boolean> {
-      await resetNetworkSetup(context.machineId);
+      await workspace.peerApiClient.resetNetwork();
       return true;
     },
 

--- a/apps/pollbook/backend/src/networking.ts
+++ b/apps/pollbook/backend/src/networking.ts
@@ -4,6 +4,7 @@ import { assert, sleep } from '@votingworks/basics';
 import { LogEventId } from '@votingworks/logging';
 import { rootDebug } from './debug';
 import {
+  CommunicatingPollbookConnectionStatuses,
   PeerAppContext,
   PollbookConfigurationInformation,
   PollbookConnectionStatus,
@@ -244,7 +245,11 @@ export function setupMachineNetworking({
         // If there are any services that were previously connected that no longer show up in avahi
         // Mark them as shut down
         for (const [name, service] of Object.entries(previouslyConnected)) {
-          if (!services.some((s) => s.name === name)) {
+          // Only transition to shutdown for a service we are communicating with.
+          if (
+            !services.some((s) => s.name === name) &&
+            CommunicatingPollbookConnectionStatuses.includes(service.status)
+          ) {
             debug(
               'Marking %s as shut down as it is no longer published on Avahi',
               name

--- a/apps/pollbook/backend/src/peer_app.ts
+++ b/apps/pollbook/backend/src/peer_app.ts
@@ -11,6 +11,7 @@ import {
 } from './types';
 import {
   fetchEventsFromConnectedPollbooks,
+  resetNetworkSetup,
   setupMachineNetworking,
 } from './networking';
 import { pollNetworkForPollbookPackage } from './pollbook_package';
@@ -39,6 +40,11 @@ function buildApi(context: PeerAppContext) {
 
     unconfigure() {
       pollNetworkForPollbookPackage(context);
+    },
+
+    async resetNetwork() {
+      await resetNetworkSetup(context.machineId);
+      store.clearConnectedPollbooks();
     },
 
     async configureFromPeerMachine(input: {

--- a/apps/pollbook/backend/src/peer_store.ts
+++ b/apps/pollbook/backend/src/peer_store.ts
@@ -32,7 +32,7 @@ import { shouldPollbooksShareEvents } from './networking';
 const debug = rootDebug.extend('store:peer');
 
 export class PeerStore extends Store {
-  private readonly connectedPollbooks: Record<string, PollbookService> = {};
+  private connectedPollbooks: Record<string, PollbookService> = {};
 
   constructor(
     client: DbClient,
@@ -42,8 +42,7 @@ export class PeerStore extends Store {
   ) {
     super(client, machineId, codeVersion, logger);
 
-    // Reset knowledge of connected pollbook
-    this.client.run(`DELETE FROM machines`);
+    this.clearConnectedPollbooks();
   }
 
   /**
@@ -77,6 +76,11 @@ export class PeerStore extends Store {
       codeVersion,
       logger
     );
+  }
+
+  clearConnectedPollbooks(): void {
+    this.connectedPollbooks = {};
+    this.client.run(`DELETE FROM machines`);
   }
 
   setOnlineStatus(isOnline: boolean): void {


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/6966

Makes two changes to network management:
- Checks that machines are in a currently communicating state before transitioning to ShutDown, this will prevent LostConnection -> ShutDown transitions specifically which we should not perform as we can not know if a machine shut down when we are not connected to it. 
- Removes the current knowledge about the list of machines when reseting the network. We already do this on reboot and after discussion decided it makes the most sense that when you click reset network something in lost connection would be removed. 


## Testing Plan
Copied build dir to a imaged machine performed the following tests:

- Connected two machines, shut one down, verified transition -> powered off. Reset network. Saw machine no longer listed. 
- Connected two machines, walked one out of range, verified transition -> lost connection. Waited for several minutes. Saw state remain in lost connection after avahi stops returning the old machine information (rather then previous behavior to transition to powered off) 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
