### PR TITLE
test-utils: Fix flaky coverage

### DIFF
--- a/libs/test-utils/src/arbitraries.ts
+++ b/libs/test-utils/src/arbitraries.ts
@@ -198,7 +198,7 @@ export function arbitraryDateTime({
     .map((parts) => {
       try {
         const result = DateTime.fromObject(parts, {
-          zone: zoneName ?? undefined,
+          zone: zoneName,
         });
         if (
           result.year === parts.year &&
@@ -213,6 +213,7 @@ export function arbitraryDateTime({
       } catch {
         // ignore invalid dates
       }
+      /* istanbul ignore next - @preserve */
       return undefined;
     })
     .filter((dateTime): dateTime is DateTime => !!dateTime);


### PR DESCRIPTION
## Overview

I've seen a very occasional flake due to an edge case in the `arbitraryDateTime` test util not getting covered. Fixed by omitting this line from coverage.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
