### PR TITLE
VxPollBook: Handle errors in usb configuration to prevent wedged state properly

### DIFF
--- a/apps/pollbook/backend/src/app_config.test.ts
+++ b/apps/pollbook/backend/src/app_config.test.ts
@@ -168,6 +168,7 @@ test('app config - polling usb from backend does trigger with system admin auth'
     expect(await localApiClient.getElection()).toEqual(err('unconfigured'));
 
     mockSystemAdministratorAuth(auth);
+    mockUsbDrive.removeUsbDrive();
     vitest.advanceTimersByTime(CONFIGURATION_POLLING_INTERVAL);
     expect(await localApiClient.getElection()).toEqual(err('unconfigured'));
 

--- a/apps/pollbook/backend/src/pollbook_package.ts
+++ b/apps/pollbook/backend/src/pollbook_package.ts
@@ -235,6 +235,7 @@ export function pollUsbDriveForPollbookPackage({
 
       try {
         if (workspace.store.getElection()) {
+          workspace.store.setConfigurationStatus(undefined);
           clearInterval(intervalId); // Stop the polling interval
           return;
         }
@@ -321,6 +322,11 @@ export function pollUsbDriveForPollbookPackage({
         clearInterval(intervalId); // Stop the polling interval
       } catch (error) {
         debug('Error during polling loop: %O', error);
+        // If we saved the election already, rollback
+        workspace.store.deleteElectionAndVoters();
+
+        // Return early to ensure clean exit from this iteration
+        return;
       } finally {
         pollingIntervalLock = false; // Reset the flag to allow the next iteration
       }


### PR DESCRIPTION
## Overview
When an error would throw in this function we might be in a state where the election was saved in the database but the pollbook package file was not saved as an asset successfully, that then causes on the next loop of the interval that we see we have an election and we kill the configuration polling declaring success. However the usb configuration status is still "loading"

- When there is an error thrown we should roll back if there is an election set to prevent this situation
- If for some reason we to have getElection return a result in the pollbook package polling interval we should clear the configuration status so that we don't end up in a wedged state after clearing the polling interval. 

## Demo Video or Screenshot
N/A

## Testing Plan
Tested ripping out a usb mid-configuration and saw the state properly reset. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
