### PR TITLE
VxPollBook: ensure scanned results also order configured precinct first

### DIFF
--- a/apps/pollbook/backend/src/local_store.ts
+++ b/apps/pollbook/backend/src/local_store.ts
@@ -383,6 +383,8 @@ export class LocalStore extends Store {
     const firstNamePattern = toPatternMatches(nameData.firstName);
     const middleNamePattern = toPatternMatches(nameData.middleName);
     const suffixPattern = toPatternMatches(nameData.suffix);
+    const { configuredPrecinctId } = this.getPollbookConfigurationInformation();
+
     // Query the database for voters matching the first and last name criteria, we don't track the updated suffix/middle name
     // columns in the database so we will filter those from the results later.
     const voterRows = this.client.all(
@@ -428,7 +430,12 @@ export class LocalStore extends Store {
 
     // Convert event rows to pollbook events and apply them to the voters
     const events = convertDbRowsToPollbookEvents(eventRows);
-    return Object.values(applyPollbookEventsToVoters(voters, events));
+    const updatedVoters = applyPollbookEventsToVoters(voters, events);
+
+    return sortedByVoterNameAndMatchingPrecinct(
+      Object.values(updatedVoters),
+      configuredPrecinctId
+    );
   }
 
   registerVoter(voterRegistration: VoterRegistrationRequest): {


### PR DESCRIPTION
## Overview

Closes #6993. Updates voter search method to order voters of the configured precinct first, which is already the case for manual searches but also is now the case for barcode searches.

## Testing Plan

Wrote automated tests.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
