### PR TITLE
VxPollBook: Remove unneccessary sudos and intermediate script calls

### DIFF
--- a/apps/pollbook/backend/src/avahi.test.ts
+++ b/apps/pollbook/backend/src/avahi.test.ts
@@ -16,7 +16,7 @@ describe('hasOnlineInterface', () => {
   it('returns true if stdout is non-empty', async () => {
     mockExecFileFn.mockResolvedValue({ stdout: 'eth0', stderr: '' });
     await expect(hasOnlineInterface()).resolves.toBe(true);
-    expect(mockExecFileFn).toHaveBeenCalledWith('sudo', [
+    expect(mockExecFileFn).toHaveBeenCalledWith('bash', [
       expect.stringContaining('is-online'),
     ]);
   });
@@ -37,14 +37,14 @@ describe('AvahiService.advertiseHttpService', () => {
     vi.clearAllMocks();
   });
 
-  it('spawns the intermediate avahi-publish-service script with sudo', () => {
+  it('spawns the intermediate avahi-publish-service script with bash', () => {
     mockSpawn.mockReturnValue({
       stdout: { on: vi.fn() },
       stderr: { on: vi.fn() },
       on: vi.fn(),
     } as unknown as ReturnType<typeof spawn>);
     AvahiService.advertiseHttpService('test-service', 1234);
-    expect(mockSpawn).toHaveBeenCalledWith('sudo', [
+    expect(mockSpawn).toHaveBeenCalledWith('bash', [
       expect.stringContaining('avahi-publish-service'),
       'test-service',
       '1234',

--- a/apps/pollbook/backend/src/avahi.ts
+++ b/apps/pollbook/backend/src/avahi.ts
@@ -15,7 +15,7 @@ export interface AvahiDiscoveredService {
 // Checks if there is any network interface 'UP'.
 export async function hasOnlineInterface(): Promise<boolean> {
   try {
-    const { stdout } = await execFile('sudo', [
+    const { stdout } = await execFile('bash', [
       intermediateScript('is-online'),
     ]);
     debug(`ip link show stdout: ${stdout}`);
@@ -39,7 +39,7 @@ export class AvahiService {
    * @returns A promise that resolves when the service starts.
    */
   static advertiseHttpService(name: string, port: number): void {
-    const process = spawn('sudo', [
+    const process = spawn('bash', [
       intermediateScript('avahi-publish-service'),
       name,
       `${port}`,
@@ -75,7 +75,7 @@ export class AvahiService {
    */
   static async discoverHttpServices(): Promise<AvahiDiscoveredService[]> {
     try {
-      const { stdout, stderr } = await execFile('sudo', [
+      const { stdout, stderr } = await execFile('bash', [
         intermediateScript('avahi-browse'),
       ]);
       // Only return with an error if there is not stdout output, otherwise try to parse it.


### PR DESCRIPTION
## Overview
The extra sudos are really infecting me lately, not sure why I thought I needed these as sudo originally I think I was just being overly cautious. I tested this change on an image and saw all networking behave as expected and the constant sudo action log pummelling be resolved. We should however keep this change in mind when we test fully locked down images if we see a problem. 

Closes https://github.com/votingworks/vxsuite/issues/6969 
<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot

## Testing Plan
Hacked onto image, tested logs and functionality

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
