### PR TITLE
VxPollBook: Update silenced logs to include getUsbDriveStatus

### DIFF
--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -130,6 +130,7 @@ function buildApi({ context, logger, barcodeScannerClient }: BuildAppParams) {
           'getIsAbsenteeMode',
           'getThroughputStatistics',
           'getSummaryStatistics',
+          'getUsbDriveStatus',
         ];
         if (silenceMethods.includes(methodName)) {
           return;


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/6995
<!-- Add a link to a GitHub issue here -->

## Testing Plan
Loaded save logs modal from sysadmin on main, saw constant getUsbDriveStatus logs, switched to branch, no longer saw logs.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
