### PR TITLE
VxPollBook: handle thrown errors in backup worker export

### DIFF
--- a/apps/pollbook/backend/src/backup_worker.ts
+++ b/apps/pollbook/backend/src/backup_worker.ts
@@ -264,14 +264,21 @@ export function start({
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for await (const _ of setInterval(BACKUP_INTERVAL)) {
-      const result = await exportBackupVoterChecklist(
-        workspace,
-        usbDrive,
-        workspace.logger
-      );
-      if (result.isErr()) {
+      try {
+        const result = await exportBackupVoterChecklist(
+          workspace,
+          usbDrive,
+          workspace.logger
+        );
+        if (result.isErr()) {
+          workspace.logger.log(LogEventId.PollbookPaperBackupStatus, 'system', {
+            message: result.err().message,
+            disposition: 'failure',
+          });
+        }
+      } catch (error) {
         workspace.logger.log(LogEventId.PollbookPaperBackupStatus, 'system', {
-          message: result.err().message,
+          message: (error as Error).message,
           disposition: 'failure',
         });
       }


### PR DESCRIPTION
## Overview
We always want to continue trying to export the backup so we should wrap the work in a try/catch to make sure a thrown error doesn't break the polling interval. Specifically if you remove a usb while the export is processing it will throw an error. 
<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot

## Testing Plan
Removed usb while export was processing, saw the catch get hit and the interval continue, reinsertted usb, saw backup export onto it fine. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
