### PR TITLE
VxPollBook: fix search flow corner case bugs

### DIFF
--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -246,6 +246,11 @@ function buildApi({ context, logger, barcodeScannerClient }: BuildAppParams) {
       return ok(payload);
     },
 
+    // Deletes the latest scanned ID document from the client
+    flushScannedIdDocument(): void {
+      barcodeScannerClient.readPayload();
+    },
+
     getPrinterStatus(): Promise<PrinterStatus> {
       return printer.status();
     },

--- a/apps/pollbook/backend/src/barcode_scanner/client.ts
+++ b/apps/pollbook/backend/src/barcode_scanner/client.ts
@@ -20,6 +20,12 @@ export const UDS_CONNECTION_ATTEMPT_DELAY_MS = 1000;
 export const UDS_CONNECTION_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour
 const DEVICE_PATH = '/dev/barcode_scanner';
 
+// The time scan data will live before it's cleaned up.
+// Because only certain pages in the frontend handle ID scans,
+// we don't want stale scans to sit around in memory to be read
+// later when the user has no context on the scan.
+export const SCAN_DATA_TTL_MS = 1000;
+
 /**
  * Attempts to connect to the barcode scanner Unix socket within a retry loop.
  * Allows failure to connect so the app can fall back gracefully.
@@ -57,18 +63,30 @@ export class BarcodeScannerClient {
     private scannedDocument: Optional<AamvaDocument> = undefined,
     private error: Optional<BarcodeScannerError> = undefined,
     private connectedToDaemon = false,
-    private readonly devicePath = DEVICE_PATH
+    private readonly devicePath = DEVICE_PATH,
+    private ttlTimeout: Optional<ReturnType<typeof setTimeout>> = undefined
   ) {}
 
   // Returns the latest payload from the barcode scanner daemon, consuming it in the process,
   // or undefined if there isn't one.
   readPayload(): Optional<BarcodeScannerPayload> {
+    if (this.ttlTimeout) {
+      clearTimeout(this.ttlTimeout);
+      this.ttlTimeout = undefined;
+    }
     const payload = this.scannedDocument ?? this.error ?? undefined;
     if (payload) {
       this.scannedDocument = undefined;
       this.error = undefined;
     }
     return payload;
+  }
+
+  scheduleCleanup(): void {
+    this.ttlTimeout = setTimeout(() => {
+      this.scannedDocument = undefined;
+      this.error = undefined;
+    }, SCAN_DATA_TTL_MS);
   }
 
   async isConnected(): Promise<boolean> {
@@ -134,6 +152,8 @@ export class BarcodeScannerClient {
         } else {
           this.error = parsed;
         }
+
+        this.scheduleCleanup();
       } catch (error) {
         await this.logger.logAsCurrentRole(LogEventId.ParseError, {
           message: 'Could not read line from barcode scanner daemon UDS',

--- a/apps/pollbook/backend/src/local_store.test.ts
+++ b/apps/pollbook/backend/src/local_store.test.ts
@@ -40,6 +40,7 @@ test('findVotersWithName works as expected - voters without name changes', () =>
       middleName: 'Samantha',
       suffix: 'II',
     }),
+    createVoter('16', 'Mont', 'St. Michel'),
   ];
   const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];
   localStore.setElectionAndVoters(
@@ -149,6 +150,33 @@ test('findVotersWithName works as expected - voters without name changes', () =>
     expect.arrayContaining([
       expect.objectContaining({ voterId: voters[4].voterId }),
       expect.objectContaining({ voterId: voters[5].voterId }),
+    ])
+  );
+
+  // Test period chars
+  expect(
+    localStore.findVotersWithName({
+      firstName: 'Dy.lan',
+      lastName: '.obrien',
+      middleName: 'mid.',
+      suffix: 'i.',
+    })
+  ).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ voterId: voters[0].voterId }),
+    ])
+  );
+
+  expect(
+    localStore.findVotersWithName({
+      firstName: 'Mont',
+      lastName: 'StMichel',
+      middleName: '',
+      suffix: '',
+    })
+  ).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ voterId: voters[6].voterId }),
     ])
   );
 });

--- a/apps/pollbook/frontend/src/api.ts
+++ b/apps/pollbook/frontend/src/api.ts
@@ -491,4 +491,16 @@ export const formatUsbDrive = {
   },
 } as const;
 
+export const flushScannedIdDocument = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.flushScannedIdDocument, {
+      async onMutate() {
+        await queryClient.invalidateQueries(getScannedIdDocument.queryKey());
+      },
+    });
+  },
+} as const;
+
 export const systemCallApi = createSystemCallApi(useApiClient);

--- a/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
+++ b/apps/pollbook/frontend/src/app_poll_worker_screen.test.tsx
@@ -44,6 +44,7 @@ describe('PollWorkerScreen', () => {
     vi.clearAllMocks();
     apiMock = createApiMock();
     apiMock.setElection(undefined);
+    apiMock.expectFlushScannedIdDocument();
   });
 
   afterEach(() => {

--- a/apps/pollbook/frontend/src/election_manager_screen.test.tsx
+++ b/apps/pollbook/frontend/src/election_manager_screen.test.tsx
@@ -29,6 +29,7 @@ beforeEach(() => {
   apiMock.expectGetDeviceStatuses();
   apiMock.expectHaveElectionEventsOccurred(false);
   apiMock.expectGetScannedIdDocument();
+  apiMock.expectFlushScannedIdDocument();
 });
 
 afterEach(() => {

--- a/apps/pollbook/frontend/src/voter_search_screen.test.tsx
+++ b/apps/pollbook/frontend/src/voter_search_screen.test.tsx
@@ -35,6 +35,7 @@ const election = electionSimpleSinglePrecinctFixtures.readElection();
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   apiMock = createApiMock();
+  apiMock.expectFlushScannedIdDocument();
 });
 
 afterEach(() => {
@@ -195,9 +196,11 @@ test('after an ID scan with "hidden" fields, shows full name and "Edit Search" b
 });
 
 test('an ID scan with first and last name only can still render "Edit Search" button', async () => {
-  const overrides: Partial<VoterSearchParams> = { middleName: '', suffix: '' };
-  const mockDocument = getMockAamvaDocument(overrides);
-  const mockSearchParams = getMockExactSearchParams(overrides);
+  const mockDocument = getMockAamvaDocument({ middleName: '', nameSuffix: '' });
+  const mockSearchParams = getMockExactSearchParams({
+    middleName: '',
+    suffix: '',
+  });
   // Voters who exactly match first/last name of the scanned ID.
   const mockVoters: Voter[] = ['123', '456'].map((id) => ({
     ...createMockVoter(

--- a/apps/pollbook/frontend/src/voter_search_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_search_screen.tsx
@@ -102,6 +102,18 @@ export function createEmptySearchParams(
   };
 }
 
+function documentMatchesParams(
+  document: AamvaDocument,
+  searchParams: VoterSearchParams
+) {
+  return (
+    document.firstName === searchParams.firstName &&
+    document.middleName === searchParams.middleName &&
+    document.lastName === searchParams.lastName &&
+    document.nameSuffix === searchParams.suffix
+  );
+}
+
 export function VoterSearch({
   search,
   setSearch,
@@ -192,11 +204,12 @@ export function VoterSearch({
       setSearch(merged);
       setVoterSearchParams(merged);
     }
-  }, [scannedIdDocument, setSearch]);
+  }, [scannedIdDocument, searchVotersQuery, setSearch]);
 
   useEffect(() => {
     if (
       scannedIdDocument &&
+      documentMatchesParams(scannedIdDocument, voterSearchParams) &&
       searchVotersQuery.isSuccess &&
       searchVotersQuery.data &&
       voterSearchParams.exactMatch

--- a/apps/pollbook/frontend/test/mock_api_client.tsx
+++ b/apps/pollbook/frontend/test/mock_api_client.tsx
@@ -612,6 +612,12 @@ export function createApiMock() {
         .expectOptionalRepeatedCallsWith()
         .resolves(err(new Error('unknown_document_type')));
     },
+
+    expectFlushScannedIdDocument() {
+      mockApiClient.flushScannedIdDocument
+        .expectOptionalRepeatedCallsWith()
+        .resolves();
+    },
   };
 }
 


### PR DESCRIPTION
## Overview

Recommend watching videos with sound to hear when the scans happen.

Closes https://github.com/votingworks/vxsuite/issues/6976

Issue: scanning `ID B` when data from `ID A` is in the search state results in navigating to the check-in screen for `ID A` (but it should be for `ID B`).

**Before**

https://github.com/user-attachments/assets/51a065c8-8c01-4146-8f26-f1be4d86a285

**After**

https://github.com/user-attachments/assets/34b25640-7c1a-40b1-9d1e-ce9a760aa8b7

* The `VoterSearch` component uses two effects to handle updates to the scanned ID as reported by the backend
* Effect 1: when the scanned ID changes, it populates the search query params with data from the scanned ID
* Effect 2: when there's a scanned ID and exactly 1 ID search result, navigate to the next page. For pollworkers the next page is the check-in screen. For election managers the next page is the voter details page.

The above setup works for scanning from an empty search state or manually entered data because the existing search data doesn't specify `exactMatch: true` and therefore doesn't match the check for Effect 2. But when you

1. Scan an ID for `John Doe`
2. Click "Back" to return from check-in page to search screen
3. Scan a 2nd ID for `Jane Smith`

the "old" search data does match the check for Effect 2. That effect triggers before Effect 1 can finish updating the search params, or the updated search query can finish, or both. Therefore Effect 2 triggers navigation based on data from John Doe's ID, not Jane Smith's.

To fix this I added a check to Effect 2 that ensures the data on the scanned ID matches the data in the current search params.

----

Closes https://github.com/votingworks/vxsuite/issues/6981

Issue: scanning an ID from the check-in page enqueues a scan that is instantly processed when the user clicks "Back", making the "Back" button seem like a no-op.

**Before**

https://github.com/user-attachments/assets/2cd662f1-e9d4-469f-96b7-cd7737bad41b

**After**

https://github.com/user-attachments/assets/d88ddb01-f0cf-4cd8-8279-13d152b2308b


* The barcode scanner client works by reading scans from the daemon and storing the latest in memory
* When the app backend reads a scan it consumes the data
* Only the voter search page polls the backend to read scans
* Therefore scanning a valid ID on a page that doesn't poll the backend for ID scans means the scan data persists in the backend until it's read
* This was causing an issue where scanning from eg. the check-in page would enqueue a scan to be read when the user clicked "Back". The scan would immediately be read and trigger search update and possibly navigation back to the check-in page

To fix this I added fixes to both the frontend and client
1. Added a method to consume the scanned ID value without reading it, which the voter search component now calls on initial render
2. Adds a 1 second TTL to scanned data stored in the client

Fix 1 should be sufficient because it invalidates the query to get scanned ID values, so it shouldn't be racing against that query, but I actually added Fix 2 first and I think it's nice to have the redundancy.

-----

Closes https://github.com/votingworks/vxsuite/issues/6992
* Period chars were not being respected in the punctuation-agnostic search
* ie. searching for `St. Clair` if a voter's name was `St Clair` would not work, and vice versa

I refactored the regex construction for exact and prefix searching because it wasn't very DRY.

**Before**

https://github.com/user-attachments/assets/2647d5da-99b4-4903-9867-216b375d6964

**After**

https://github.com/user-attachments/assets/35521d40-21c2-45f4-b004-e19dd162e847


## Demo Video or Screenshot

Inlined in description

## Testing Plan
- manually tested all issues
- added test for period scan
- no test for race conditions yet, will add as time allows

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
