### PR TITLE
VxPollBook: prevent redirecting too early when IDs are scanned in succession

### DIFF
--- a/apps/pollbook/frontend/src/voter_search_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_search_screen.tsx
@@ -102,6 +102,18 @@ export function createEmptySearchParams(
   };
 }
 
+function documentMatchesParams(
+  document: AamvaDocument,
+  searchParams: VoterSearchParams
+) {
+  return (
+    document.firstName === searchParams.firstName &&
+    document.middleName === searchParams.middleName &&
+    document.lastName === searchParams.lastName &&
+    document.nameSuffix === searchParams.suffix
+  );
+}
+
 export function VoterSearch({
   search,
   setSearch,
@@ -197,6 +209,7 @@ export function VoterSearch({
   useEffect(() => {
     if (
       scannedIdDocument &&
+      documentMatchesParams(scannedIdDocument, voterSearchParams) &&
       searchVotersQuery.isSuccess &&
       searchVotersQuery.data &&
       voterSearchParams.exactMatch

--- a/apps/pollbook/frontend/src/voter_search_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_search_screen.tsx
@@ -209,6 +209,9 @@ export function VoterSearch({
   useEffect(() => {
     if (
       scannedIdDocument &&
+      // We don't want to handle navigation after `scannedIdDocument` updates
+      // but before `voterSearchParams` updates. The latter will be stale
+      // and we'd navigate using the wrong data.
       documentMatchesParams(scannedIdDocument, voterSearchParams) &&
       searchVotersQuery.isSuccess &&
       searchVotersQuery.data &&


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6976

Issue: scanning `ID B` when data from `ID A` is in the search state results in navigating to the check-in screen for `ID A` (but it should be for `ID B`).


* The `VoterSearch` component uses two effects to handle updates to the scanned ID as reported by the backend
* Effect 1: when the scanned ID changes, it populates the search query params with data from the scanned ID
* Effect 2: when there's a scanned ID and exactly 1 ID search result, navigate to the next page. For pollworkers the next page is the check-in screen. For election managers the next page is the voter details page.

The above setup works for scanning from an empty search state or manually entered data because the existing search data doesn't specify `exactMatch: true` and therefore doesn't match the check for Effect 2. But when you

1. Scan an ID for `John Doe`
2. Click "Back" to return from check-in page to search screen
3. Scan a 2nd ID for `Jane Smith`

the "old" search data does match the check for Effect 2. That effect triggers before Effect 1 can finish updating the search params, or the updated search query can finish, or both. Therefore Effect 2 triggers navigation based on data from John Doe's ID, not Jane Smith's.

To fix this I added a check to Effect 2 that ensures the data on the scanned ID matches the data in the current search params.

## Demo Video or Screenshot

Recommend watching with sound so you can hear when scans happen.

**Before**

https://github.com/user-attachments/assets/51a065c8-8c01-4146-8f26-f1be4d86a285

**After**

https://github.com/user-attachments/assets/34b25640-7c1a-40b1-9d1e-ce9a760aa8b7

## Testing Plan
- manually tested

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
