### PR TITLE
VxPollBook: ignore period in voter search

### DIFF
--- a/apps/pollbook/backend/src/local_store.test.ts
+++ b/apps/pollbook/backend/src/local_store.test.ts
@@ -40,6 +40,7 @@ test('findVotersWithName works as expected - voters without name changes', () =>
       middleName: 'Samantha',
       suffix: 'II',
     }),
+    createVoter('16', 'Mont', 'St. Michel'),
   ];
   const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];
   localStore.setElectionAndVoters(
@@ -149,6 +150,33 @@ test('findVotersWithName works as expected - voters without name changes', () =>
     expect.arrayContaining([
       expect.objectContaining({ voterId: voters[4].voterId }),
       expect.objectContaining({ voterId: voters[5].voterId }),
+    ])
+  );
+
+  // Test period chars
+  expect(
+    localStore.findVotersWithName({
+      firstName: 'Dy.lan',
+      lastName: '.obrien',
+      middleName: 'mid.',
+      suffix: 'i.',
+    })
+  ).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ voterId: voters[0].voterId }),
+    ])
+  );
+
+  expect(
+    localStore.findVotersWithName({
+      firstName: 'Mont',
+      lastName: 'StMichel',
+      middleName: '',
+      suffix: '',
+    })
+  ).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ voterId: voters[6].voterId }),
     ])
   );
 });


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6992

* Period chars were not being respected in the punctuation-agnostic search
* ie. searching for `St. Clair` if a voter's name was `St Clair` would not work, and vice versa

I refactored the regex construction for exact and prefix searching because it wasn't very DRY.

## Demo Video or Screenshot

**Before**

https://github.com/user-attachments/assets/2647d5da-99b4-4903-9867-216b375d6964

**After**

https://github.com/user-attachments/assets/35521d40-21c2-45f4-b004-e19dd162e847

## Testing Plan

- manually tested
- added store test

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
