### PR TITLE
VxScan: Remove reference to color of paper roll holder lever

### DIFF
--- a/apps/scan/frontend/src/components/printer_management/load_paper_modal.tsx
+++ b/apps/scan/frontend/src/components/printer_management/load_paper_modal.tsx
@@ -42,8 +42,8 @@ export function LoadPaperModal({
         title="Remove Paper Roll Holder"
         content={
           <P>
-            Open the access door to reveal the printer. Press the white lever on
-            the paper roll holder to separate it from the printer.
+            Open the access door to reveal the printer. Press the lever on the
+            right side of the paper roll holder to separate it from the printer.
           </P>
         }
         actions={<Button onPress={onClose}>Cancel</Button>}


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6955

To future proof against lever color changes (in early prototypes we've used both green and white), we've opted to fully remove the lever color from the UI copy. This will make it such that, if we ever have to change the lever color after cert, we won't have to go through a Trusted Build and prepare a wholely new software image.

## Demo Video or Screenshot

| Before | After |
| - | - |
| <img width="400" alt="before" src="https://github.com/user-attachments/assets/258afbc0-73a8-404b-9fd8-97d6513998bf" /> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/b8c33fa3-d0df-4541-8639-01f6b579e9a4" /> |

## Testing Plan

 - [x] Tested manually

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.