### PR TITLE
VxDesign: Order candidate contests ahead of ballot measures

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -1361,6 +1361,41 @@ test('CRUD contests', async () => {
     contest2,
   ]);
 
+  // Create another candidate contest
+
+  const contest3: CandidateContest = {
+    id: 'contest-3',
+    title: 'Contest 3',
+    type: 'candidate',
+    seats: 1,
+    allowWriteIns: true,
+    districtId: district1.id,
+    candidates: [
+      {
+        id: 'candidate-4',
+        firstName: 'Candidate',
+        middleName: 'N',
+        lastName: 'One',
+        name: 'Candidate N One',
+      },
+      {
+        id: 'candidate-5',
+        firstName: 'Candidate',
+        middleName: 'N',
+        lastName: 'Two',
+        name: 'Candidate N Two',
+      },
+    ],
+  };
+
+  await apiClient.createContest({ electionId, newContest: contest3 });
+  // Expect the candidate contest to be inserted ahead of the ballot measure
+  expect(await apiClient.listContests({ electionId })).toEqual([
+    contest1,
+    contest3,
+    contest2,
+  ]);
+
   // Update candidate contest
   const updatedContest1: CandidateContest = {
     ...contest1,
@@ -1385,6 +1420,7 @@ test('CRUD contests', async () => {
   // Expect contests to have their ballot order preserved
   expect(await apiClient.listContests({ electionId })).toEqual([
     updatedContest1,
+    contest3,
     contest2,
   ]);
 
@@ -1400,12 +1436,14 @@ test('CRUD contests', async () => {
   });
   expect(await apiClient.listContests({ electionId })).toEqual([
     updatedContest1,
+    contest3,
     updatedContest2,
   ]);
 
   // Delete a contest
   await apiClient.deleteContest({ electionId, contestId: updatedContest1.id });
   expect(await apiClient.listContests({ electionId })).toEqual([
+    contest3,
     updatedContest2,
   ]);
 


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/5676

New functionality:
1. All new candidate contests are inserted ahead of ballot measures by `ballotOrder` (backend)
2. All new contest orderings have candidate contests ahead of ballot measures (frontend)
3. Candidate contests and ballot measures are shown in separate tables (frontend)

## Demo Video or Screenshot

https://github.com/user-attachments/assets/1aa81e3b-8aa9-4a71-867f-9245f3a3db32

## Testing Plan

Manually tested:
1. Existing election has ballot measure ahead of candidate contest
4. Reorder contests -> Save with the new default order in UI
5. Generate ballots, election package. Report has all candidate contests ahead of ballot measures

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
