### PR TITLE
VxPollBook: filter absentee checkins from throughput stats

### DIFF
--- a/apps/pollbook/backend/src/local_store.test.ts
+++ b/apps/pollbook/backend/src/local_store.test.ts
@@ -1166,6 +1166,12 @@ test('getThroughputStatistics returns correct throughput data for single interva
       precinct: 'precinct-1',
       party: 'UND',
     }),
+    createVoter('13', 'Absentee', 'Voter', {
+      middleName: '',
+      suffix: '',
+      precinct: 'precinct-1',
+      party: 'DEM',
+    }),
   ];
   const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];
   localStore.setElectionAndVoters(
@@ -1201,6 +1207,16 @@ test('getThroughputStatistics returns correct throughput data for single interva
     ballotParty: 'NOT_APPLICABLE',
   });
 
+  // Fourth check-in (absentee) at 11:46 AM
+  vi.setSystemTime(new Date('2025-08-04T11:46:00.000Z'));
+  localStore.setIsAbsenteeMode(true);
+  localStore.recordVoterCheckIn({
+    voterId: voters[3].voterId,
+    identificationMethod: { type: 'default' },
+    ballotParty: 'DEM',
+  });
+  localStore.setIsAbsenteeMode(false);
+
   // Set current time for generating statistics
   vi.setSystemTime(new Date('2025-08-04T11:50:00.000Z'));
 
@@ -1208,6 +1224,7 @@ test('getThroughputStatistics returns correct throughput data for single interva
   expect(throughputStats).toHaveLength(1);
   expect(throughputStats[0]).toMatchObject({
     interval: 60,
+    // 3 precinct check-ins and 1 absentee check-in, but absentee check-in shouldn't count
     checkIns: 3,
     startTime: '2025-08-04T11:00:00.000Z',
   });

--- a/apps/pollbook/backend/src/local_store.ts
+++ b/apps/pollbook/backend/src/local_store.ts
@@ -662,7 +662,7 @@ export class LocalStore extends Store {
     const filteredCheckInEvents = checkInEvents.filter(
       (e) =>
         // Absentee check-ins are less relevant for throughput stats, which are
-        // intended to measure efficiency of the physical line
+        // intended to give a sense of foot traffic throughout the day
         !e.checkInData.isAbsentee &&
         // Events must match the party (if any) specified in filter
         (!partyFilter ||

--- a/apps/pollbook/backend/src/local_store.ts
+++ b/apps/pollbook/backend/src/local_store.ts
@@ -659,15 +659,19 @@ export class LocalStore extends Store {
         event.type === EventType.VoterCheckIn
     );
 
-    const checkInEventsMatchingParty = checkInEvents.filter(
+    const filteredCheckInEvents = checkInEvents.filter(
       (e) =>
-        !partyFilter ||
-        partyFilter === 'ALL' ||
-        e.checkInData.ballotParty === partyFilter
+        // Absentee check-ins are less relevant for throughput stats, which are
+        // intended to measure efficiency of the physical line
+        !e.checkInData.isAbsentee &&
+        // Events must match the party (if any) specified in filter
+        (!partyFilter ||
+          partyFilter === 'ALL' ||
+          e.checkInData.ballotParty === partyFilter)
     );
 
-    const orderedByEventMachineTime = [...checkInEventsMatchingParty].sort(
-      (a, b) => a.checkInData.timestamp.localeCompare(b.checkInData.timestamp)
+    const orderedByEventMachineTime = [...filteredCheckInEvents].sort((a, b) =>
+      a.checkInData.timestamp.localeCompare(b.checkInData.timestamp)
     );
     // Group events by interval based on checkInData.timestamp
     const throughputStats: ThroughputStat[] = [];

--- a/apps/pollbook/frontend/src/statistics_screen.test.tsx
+++ b/apps/pollbook/frontend/src/statistics_screen.test.tsx
@@ -227,7 +227,7 @@ describe('GeneralElectionStatistics', () => {
     }));
 
     await waitFor(() => {
-      screen.getByText(/Throughput/);
+      screen.getByRole('heading', { name: 'Voter Throughput' });
       screen.getByText('1,000'); // Look for total voters count
     });
 

--- a/apps/pollbook/frontend/src/statistics_screen.test.tsx
+++ b/apps/pollbook/frontend/src/statistics_screen.test.tsx
@@ -227,7 +227,7 @@ describe('GeneralElectionStatistics', () => {
     }));
 
     await waitFor(() => {
-      screen.getByRole('heading', { name: 'Voter Throughput' });
+      screen.getByRole('heading', { name: 'Precinct Voter Throughput' });
       screen.getByText('1,000'); // Look for total voters count
     });
 
@@ -272,7 +272,9 @@ describe('GeneralElectionStatistics', () => {
     }));
 
     await waitFor(() => {
-      expect(screen.getAllByText('Voter Throughput')[0]).toBeInTheDocument();
+      expect(
+        screen.getAllByText('Precinct Voter Throughput')[0]
+      ).toBeInTheDocument();
       expect(screen.getAllByTestId('chart')[0]).toBeInTheDocument();
     });
   });
@@ -392,7 +394,9 @@ describe('ThroughputChart', () => {
     }));
 
     await waitFor(() => {
-      expect(screen.getAllByText('Voter Throughput')[0]).toBeInTheDocument();
+      expect(
+        screen.getAllByText('Precinct Voter Throughput')[0]
+      ).toBeInTheDocument();
       expect(screen.getAllByTestId('chart')[0]).toBeInTheDocument();
     });
 
@@ -437,7 +441,9 @@ describe('ThroughputChart', () => {
     }));
 
     await waitFor(() => {
-      expect(screen.getAllByText('Voter Throughput')[0]).toBeInTheDocument();
+      expect(
+        screen.getAllByText('Precinct Voter Throughput')[0]
+      ).toBeInTheDocument();
     });
 
     // Click 30m interval button (it has role="option" not "button") - use the last one which should be in the chart area

--- a/apps/pollbook/frontend/src/statistics_screen.tsx
+++ b/apps/pollbook/frontend/src/statistics_screen.tsx
@@ -76,30 +76,28 @@ export function ThroughputChart({
 
   return (
     <TitledCard
-      title={
-        <Row
-          style={{
-            gap: '1rem',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-          }}
-        >
-          <H4>Voter Throughput</H4>
-          <SmallSegmentedControl
-            label="Interval"
-            hideLabel
-            selectedOptionId={String(intervalMin)}
-            options={[
-              { id: '15', label: '15m' },
-              { id: '30', label: '30m' },
-              { id: '60', label: '1h' },
-            ]}
-            onChange={(selectedId) =>
-              setIntervalMin(safeParseInt(selectedId).unsafeUnwrap())
-            }
-          />
-        </Row>
-      }
+      title=<Row
+        style={{
+          gap: '1rem',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <H4>Precinct Voter Throughput</H4>
+        <SmallSegmentedControl
+          label="Interval"
+          hideLabel
+          selectedOptionId={String(intervalMin)}
+          options={[
+            { id: '15', label: '15m' },
+            { id: '30', label: '30m' },
+            { id: '60', label: '1h' },
+          ]}
+          onChange={(selectedId) =>
+            setIntervalMin(safeParseInt(selectedId).unsafeUnwrap())
+          }
+        />
+      </Row>
     >
       <div style={{ height: '17rem' }}>
         <Bar


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6983

* Filters absentee check-ins from the voter throughput stats
* Updates the title to "Precinct Voter Throughput" to suggest this (in line with "Precinct" and "Absentee" voters being distinct in the stats above)

## Demo Video or Screenshot

<img width="1473" height="929" alt="Screenshot 2025-08-14 at 5 57 08 PM" src="https://github.com/user-attachments/assets/c000796b-dcec-4331-8b4c-ee93cdd604da" />


## Testing Plan

- updated FE test for new copy
- added test to local_store that absentee check in isn't reported in throughput stats

## Checklist

- x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
