### PR TITLE
Properly error when programming cards configured for the incorrect environment

### DIFF
--- a/libs/auth/src/java_card.test.ts
+++ b/libs/auth/src/java_card.test.ts
@@ -1076,6 +1076,13 @@ test.each<{
         cardType: expectedCardType,
       })
     );
+    await mockCardSignatureRequest(
+      CARD_VX_CERT.PRIVATE_KEY_ID,
+      getTestFilePath({
+        fileType: 'card-vx-private-key.pem',
+        cardType: expectedCardType,
+      })
+    );
     mockCardPinResetRequest(pin);
     mockCardPinVerificationRequest(pin);
     mockCardKeyPairGenerationRequest(

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -302,6 +302,7 @@ export class JavaCard implements Card {
       cardVxCert,
       this.vxCertAuthorityCertPath
     );
+    await this.verifyCardPrivateKey(CARD_VX_CERT.PRIVATE_KEY_ID, cardVxCert);
 
     await this.resetPinAndInvalidateCard(pin);
 


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6597

While working on a loosely related cert discrepancy, I decided to finally close out a classic source of confusion that has come up in almost every QA run.

If you program a card configured for the incorrect environment, i.e., a dev/QA card on a prod machine or a prod card on a dev/QA machine, VxAdmin will indicate that the card has been successfully programmed. But if you then use the card, it'll show up as invalid/blank.

The current card programming logic declares success so long as the card programming commands succeed. It doesn't actually check the overall state of the card to ensure validity. This PR updates the `program` method to verify that the card has been configured for the correct environment before proceeding with programming commands.

## Demo Video or Screenshot

_Before_

Programming a dev-blessed card on a prod-blessed machine or vice versa results in what appears to be a successful program. But removing and reinserting the card reveals it to be invalid/blank.

https://github.com/user-attachments/assets/eed36135-f303-42c2-b16f-1e94c2f125ea

_After_

The program operation now clearly fails :relieved:

https://github.com/user-attachments/assets/b5e520a8-3963-4580-b567-0f5f498fd3fc

## Testing Plan

- [x] Lots of manual testing with actual Java Cards
- [x] Updated automated tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions. ➡️ Relying on existing logging though there's room for improvement here
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.