### PR TITLE
update `set-clock` script to be independent of TZ environment variable

### DIFF
--- a/libs/backend/intermediate-scripts/set-clock
+++ b/libs/backend/intermediate-scripts/set-clock
@@ -30,4 +30,8 @@ else
     timedatectl set-timezone "${1}"
 fi
 
+# If the parent node process has a TZ environment variable set, it will
+# override the timezone set by timedatectl. So we unset it here.
+unset TZ
+
 timedatectl set-time "${2}"


### PR DESCRIPTION
## Overview

Closes #6971. Since the fix for #6036, we set the timezone of the node process explicitly after we update the system time. An unintended consequence of that was that, next time you run our `set-clock` script, there's a `TZ` environment variable and `timedatectl set-time` actually respects the environment variable over the actual system timezone. Therefore, on all subsequent time changes, the time was getting set with respect to the old timezone.

One solution is to move the `process.env.TZ` setting up before the script is called. But I wanted the script to make sense in isolation and work as expected regardless of environment

## Demo Video or Screenshot

### Before

https://github.com/user-attachments/assets/77ba62a2-0906-44c2-b07d-117f0c7b34c7

### After

https://github.com/user-attachments/assets/f1159305-a231-46ab-a935-1cee269eab68

## Testing Plan

Manual Testing.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
