### PR TITLE
VxPollBook: update list of AAMVA issuers and mailing provinces to avoid crash

### DIFF
--- a/apps/pollbook/barcode-scanner-daemon/src/aamva_jurisdictions.rs
+++ b/apps/pollbook/barcode-scanner-daemon/src/aamva_jurisdictions.rs
@@ -155,7 +155,6 @@ impl FromStr for AamvaIssuingJurisdiction {
             "636014" => Ok(Self::CA),
             "636015" => Ok(Self::TX),
             "636018" => Ok(Self::IA),
-            "636019" => Ok(Self::GU),
             "636020" => Ok(Self::CO),
             "636021" => Ok(Self::AR),
             "636022" => Ok(Self::KS),
@@ -192,12 +191,13 @@ impl FromStr for AamvaIssuingJurisdiction {
             "636059" => Ok(Self::AK),
             "636060" => Ok(Self::WY),
             "636061" => Ok(Self::WV),
-            "636062" => Ok(Self::VI),
 
             // U.S. territories
             "604427" => Ok(Self::AS),
             "604430" => Ok(Self::MP),
             "604431" => Ok(Self::PR),
+            "636019" => Ok(Self::GU),
+            "636062" => Ok(Self::VI),
 
             _ => Err(Self::Err::UnknownIssuingJurisdictionId(s.to_owned())),
         }

--- a/apps/pollbook/barcode-scanner-daemon/src/aamva_jurisdictions.rs
+++ b/apps/pollbook/barcode-scanner-daemon/src/aamva_jurisdictions.rs
@@ -5,7 +5,7 @@ use crate::parse_aamva::AamvaParseError;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize)]
 pub enum AamvaIssuingJurisdiction {
-    // US States
+    // US States & D.C.
     VA,
     NY,
     MA,
@@ -23,6 +23,7 @@ pub enum AamvaIssuingJurisdiction {
     IA,
     CO,
     AR,
+    KS,
     OH,
     VT,
     PA,
@@ -56,13 +57,13 @@ pub enum AamvaIssuingJurisdiction {
     AK,
     WY,
     WV,
-    VI,
 
+    // US Territories
     AS, // American Samoa
-    MP, // Northern Marianna Islands
+    MP, // Northern Mariana Islands
     PR, // Puerto Rico
     GU, // Guam
-    StateDept,
+    VI, // Virgin Islands
 }
 
 impl AamvaIssuingJurisdiction {
@@ -85,6 +86,7 @@ impl AamvaIssuingJurisdiction {
             Self::IA => "IA",
             Self::CO => "CO",
             Self::AR => "AR",
+            Self::KS => "KS",
             Self::OH => "OH",
             Self::VT => "VT",
             Self::PA => "PA",
@@ -118,12 +120,11 @@ impl AamvaIssuingJurisdiction {
             Self::AK => "AK",
             Self::WY => "WY",
             Self::WV => "WV",
-            Self::VI => "VI",
             Self::AS => "AS",
             Self::MP => "MP",
             Self::PR => "PR",
             Self::GU => "GU",
-            Self::StateDept => "StateDept",
+            Self::VI => "VI",
         }
     }
 }

--- a/apps/pollbook/barcode-scanner-daemon/src/aamva_jurisdictions.rs
+++ b/apps/pollbook/barcode-scanner-daemon/src/aamva_jurisdictions.rs
@@ -158,6 +158,7 @@ impl FromStr for AamvaIssuingJurisdiction {
             "636019" => Ok(Self::GU),
             "636020" => Ok(Self::CO),
             "636021" => Ok(Self::AR),
+            "636022" => Ok(Self::KS),
             "636023" => Ok(Self::OH),
             "636024" => Ok(Self::VT),
             "636025" => Ok(Self::PA),

--- a/apps/pollbook/barcode-scanner-daemon/src/aamva_jurisdictions.rs
+++ b/apps/pollbook/barcode-scanner-daemon/src/aamva_jurisdictions.rs
@@ -198,8 +198,6 @@ impl FromStr for AamvaIssuingJurisdiction {
             "604430" => Ok(Self::MP),
             "604431" => Ok(Self::PR),
 
-            "636027" => Ok(Self::StateDept),
-
             _ => Err(Self::Err::UnknownIssuingJurisdictionId(s.to_owned())),
         }
     }

--- a/apps/pollbook/frontend/src/mailing_address_input_group.tsx
+++ b/apps/pollbook/frontend/src/mailing_address_input_group.tsx
@@ -9,7 +9,7 @@ import {
   StaticInput,
   ExpandableInput,
 } from './shared_components';
-import { usStates } from './us_states';
+import { usJurisdictions } from './us_states';
 import type { VoterMailingAddressChangeRequest } from './update_mailing_address_flow';
 import { splitStreetNumberDetails } from './address_input_group';
 
@@ -144,7 +144,7 @@ export function MailingAddressInputGroup({
                 mailingState: value || '',
               })
             }
-            options={Object.entries(usStates).map(([value, label]) => ({
+            options={Object.entries(usJurisdictions).map(([value, label]) => ({
               value,
               label: `${value} - ${label}`,
             }))}

--- a/apps/pollbook/frontend/src/us_states.ts
+++ b/apps/pollbook/frontend/src/us_states.ts
@@ -1,6 +1,7 @@
 export const usStates = {
   AL: 'Alabama',
   AK: 'Alaska',
+  AS: 'American Samoa',
   AZ: 'Arizona',
   AR: 'Arkansas',
   CA: 'California',
@@ -10,6 +11,7 @@ export const usStates = {
   DC: 'District of Columbia',
   FL: 'Florida',
   GA: 'Georgia',
+  GU: 'Guam',
   HI: 'Hawaii',
   ID: 'Idaho',
   IL: 'Illinois',
@@ -23,6 +25,7 @@ export const usStates = {
   MA: 'Massachusetts',
   MI: 'Michigan',
   MN: 'Minnesota',
+  MP: 'Northern Mariana Islands',
   MS: 'Mississippi',
   MO: 'Missouri',
   MT: 'Montana',

--- a/apps/pollbook/frontend/src/us_states.ts
+++ b/apps/pollbook/frontend/src/us_states.ts
@@ -1,4 +1,4 @@
-export const usStates = {
+export const usJurisdictions = {
   AL: 'Alabama',
   AK: 'Alaska',
   AS: 'American Samoa',

--- a/apps/pollbook/frontend/src/voter_confirm_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_confirm_screen.tsx
@@ -23,7 +23,7 @@ import { assert, throwIllegalValue } from '@votingworks/basics';
 import { Election } from '@votingworks/types';
 import { Column, Row } from './layout';
 import { NoNavScreen } from './nav_screen';
-import { usStates } from './us_states';
+import { usJurisdictions } from './us_states';
 import {
   AbsenteeModeCallout,
   AddressChange,
@@ -41,7 +41,7 @@ import { getVoter } from './api';
 import { getVoterPrecinct } from './types';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const { NH, ...usStatesWithoutNewHampshire } = usStates;
+const { NH, ...usJurisdictionsWithoutNewHampshire } = usJurisdictions;
 
 function isIdentificationMethodComplete(
   identificationMethod: Partial<VoterIdentificationMethod>
@@ -299,12 +299,12 @@ export function VoterConfirmScreen({
                 {identificationMethod.type === 'outOfStateLicense' && (
                   <SearchSelect
                     id="state"
-                    options={Object.entries(usStatesWithoutNewHampshire).map(
-                      ([value, label]) => ({
-                        value,
-                        label: `${value} - ${label}`,
-                      })
-                    )}
+                    options={Object.entries(
+                      usJurisdictionsWithoutNewHampshire
+                    ).map(([value, label]) => ({
+                      value,
+                      label: `${value} - ${label}`,
+                    }))}
                     menuPortalTarget={document.body}
                     value={
                       identificationMethod.type === 'outOfStateLicense'

--- a/apps/pollbook/frontend/src/voter_search_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_search_screen.tsx
@@ -30,7 +30,7 @@ import {
   VoterIdentificationMethod,
 } from '@votingworks/types';
 import { useQueryClient } from '@tanstack/react-query';
-import { usStates } from './us_states';
+import { usJurisdictions } from './us_states';
 import { Column, Form, Row, InputGroup } from './layout';
 import { NavScreen } from './nav_screen';
 import { getCheckInCounts, getScannedIdDocument, searchVoters } from './api';
@@ -81,7 +81,7 @@ function formatNameSearch(search: VoterSearchParams): string {
 }
 
 export function validateUsState(aamvaIssuingJurisdiction: string): string {
-  if (Object.keys(usStates).includes(aamvaIssuingJurisdiction)) {
+  if (Object.keys(usJurisdictions).includes(aamvaIssuingJurisdiction)) {
     return aamvaIssuingJurisdiction;
   }
 


### PR DESCRIPTION
## Overview

Closes #7032. 

## Demo Video or Screenshot

Tested manually.

## Testing Plan

No tests changed. Hard to test against a static list.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
