### PR TITLE
VxPollBook: silence summary statistics after names changed

### DIFF
--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -129,7 +129,8 @@ function buildApi({ context, logger, barcodeScannerClient }: BuildAppParams) {
           'getScannedIdDocument',
           'getIsAbsenteeMode',
           'getThroughputStatistics',
-          'getSummaryStatistics',
+          'getGeneralSummaryStatistics',
+          'getPrimarySummaryStatistics',
           'getUsbDriveStatus',
         ];
         if (silenceMethods.includes(methodName)) {


### PR DESCRIPTION
## Overview

Haven't created a ticket for this one, was just on Slack.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
