### PR TITLE
VxPollBook: don't redirect on ID scan if voter has checked in

### DIFF
--- a/apps/pollbook/frontend/src/voter_search_screen.tsx
+++ b/apps/pollbook/frontend/src/voter_search_screen.tsx
@@ -439,7 +439,9 @@ export function VoterSearchScreen({
 
   const onBarcodeScanMatch = useCallback(
     (voter: Voter, identificationMethod: VoterIdentificationMethod) => {
-      onSelect(voter.voterId, identificationMethod);
+      if (!voter.checkIn) {
+        onSelect(voter.voterId, identificationMethod);
+      }
     },
     [onSelect]
   );


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7041/

Fixes a bug where scanning the ID of an already-checked-in voter would still navigate to the check in page. Instead, we want to just show the search results.

Election Manager scan behavior is unchanged.

## Demo Video or Screenshot

**Before**


https://github.com/user-attachments/assets/a81b1629-f953-4e3b-aa10-b5e405872845

**After**

https://github.com/user-attachments/assets/649245da-d6b3-459d-ac90-993e5c3ae86e




## Testing Plan

- added e2e test for poll worker `VoterSearchScreen`
- added some tests to the lower-level `VoterSearch` that are likely redundant with existing e2e tests but felt like they belonged at that level

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
