### PR TITLE
Smart cards screen: Persist error message momentarily after card removed

### DIFF
--- a/libs/ui/src/smart_cards_screen.test.tsx
+++ b/libs/ui/src/smart_cards_screen.test.tsx
@@ -826,7 +826,7 @@ test.each([
 
     await screen.findByText(expectedErrorMessage);
 
-    await vi.advanceTimersByTimeAsync(3000);
+    await vi.advanceTimersByTimeAsync(4000);
 
     await vi.waitFor(() => {
       expect(screen.queryByText(expectedErrorMessage)).not.toBeInTheDocument();

--- a/libs/ui/src/smart_cards_screen.tsx
+++ b/libs/ui/src/smart_cards_screen.tsx
@@ -571,7 +571,7 @@ export function SmartCardsScreen({
     if (card.status === 'no_card') {
       const timeout = setTimeout(() => {
         setActionResult(undefined);
-      }, 3000);
+      }, 4000);
       return () => clearTimeout(timeout);
     }
 


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6957

During cert testing, SLI has encountered a known edge case where, if you remove a card preemptively after initiating programming, an error message can briefly flash before you have time to read it and we return to the card insertion screen. Errors are currently only displayed on the card details screen, which is naturally cleared when a card is removed.

This PR persists the error message for a couple of seconds even after you remove the card and return to the card insertion screen. I didn't try to distinguish between errors due to preemptive removal and, say, unblessed or misconfigured cards. So these extra seconds of display on the card insertion screen happen for all errors, whether they're strictly needed or not. All of these errors should be exceedingly rare in true production environments.

## Demo Video or Screenshot

### Before

Notice the brief flash of an error message.

https://github.com/user-attachments/assets/6cca7852-51d2-40e5-96e0-d43988004f85

### After

https://github.com/user-attachments/assets/4d20d742-61d1-42e3-a0c0-b4c20642361f

## Testing Plan

- [x] Tested manually with actual Java Cards and preemptive removals
- [x] Added automated tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~ N/A
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
