### PR TITLE
VxPollBook: validate pollbook package {voter, valid street} ward against election definition

### DIFF
--- a/apps/pollbook/backend/src/pollbook_package.test.ts
+++ b/apps/pollbook/backend/src/pollbook_package.test.ts
@@ -72,7 +72,7 @@ describe('parseVotersFromCsvString', () => {
 
     suppressingConsoleOutput(() => {
       expect(() => parseVotersFromCsvString(csvString, mockElection)).toThrow(
-        'Unexpected ward or precinct: 99'
+        'Unexpected ward or district: 99'
       );
     });
   });
@@ -344,7 +344,7 @@ Main St,100,200,odd,6`;
     suppressingConsoleOutput(() => {
       expect(() =>
         parseValidStreetsFromCsvString(csvString, mockElection)
-      ).toThrow(new Error('Unexpected ward or precinct: 6'));
+      ).toThrow(new Error('Unexpected ward or district: 6'));
     });
   });
 

--- a/apps/pollbook/backend/src/pollbook_package.ts
+++ b/apps/pollbook/backend/src/pollbook_package.ts
@@ -101,7 +101,7 @@ export function parseValidStreetsFromCsvString(
       if (externalWardId && !externalIdToPrecinctId[externalWardId]) {
         throw new Error(`Unexpected ward or district: ${externalWardId}`);
       }
-      const precinct = externalIdToPrecinctId[externalWardId];
+      const precinct = externalIdToPrecinctId[externalWardId] || '';
 
       return {
         ...street,
@@ -138,7 +138,7 @@ export function parseVotersFromCsvString(
       if (externalWardId && !externalIdToPrecinctId[externalWardId]) {
         throw new Error(`Unexpected ward or district: ${externalWardId}`);
       }
-      const precinct = externalIdToPrecinctId[externalWardId];
+      const precinct = externalIdToPrecinctId[externalWardId] || '';
 
       return {
         ...voter,
@@ -229,7 +229,7 @@ export async function readPollbookPackage(
   } catch (error) {
     debug('Error reading pollbook package: %O', error);
     const typedError = error as globalThis.Error;
-    if (typedError.message.startsWith('Unexpected ward or precinct')) {
+    if (typedError.message.startsWith('Unexpected ward or district')) {
       return err({
         type: 'UnexpectedPrecinct',
         error: typedError,


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6963

Validates that both voter ward and valid street ward are in the election definition.

## Demo Video or Screenshot

- [ ] TODO

## Testing Plan

- added tests for voter parsing and valid street parsing

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
