### PR TITLE
VxAdmin: fix overflowing candidate names

### DIFF
--- a/libs/ui/src/reports/contest_results_table.tsx
+++ b/libs/ui/src/reports/contest_results_table.tsx
@@ -82,6 +82,7 @@ const ContestTable = styled.table`
     &:first-child {
       padding-left: 0.25em;
       text-align: left;
+      word-break: break-word;
     }
 
     &:not(:first-child) {

--- a/libs/ui/src/reports/contest_write_in_summary_table.tsx
+++ b/libs/ui/src/reports/contest_write_in_summary_table.tsx
@@ -58,6 +58,7 @@ const ContestTable = styled.table`
     padding: 0.25em;
     text-align: left;
     font-weight: 400;
+    word-break: break-word;
   }
 
   & th.indent {


### PR DESCRIPTION
## Overview

Closes #6956. Addresses the issue in WIA reports and also, although unreported by SLI, in tally reports.

## Demo Video or Screenshot

### Before

<img width="1153" height="719" alt="Screenshot 2025-08-15 at 11 43 58 PM" src="https://github.com/user-attachments/assets/1049c5e1-245d-4413-a5ab-5d2f2c96e5fa" />

<img width="1154" height="721" alt="Screenshot 2025-08-15 at 11 43 45 PM" src="https://github.com/user-attachments/assets/6ccf70f4-4c5f-4cdc-990a-f7b81de9645e" />

### After

<img width="1153" height="722" alt="Screenshot 2025-08-15 at 11 39 44 PM" src="https://github.com/user-attachments/assets/7920e2f6-8f6c-487e-8497-6d448e2d9bd2" />

<img width="1153" height="722" alt="Screenshot 2025-08-15 at 11 42 41 PM" src="https://github.com/user-attachments/assets/6ad3c7bc-9ea0-43e9-8ad2-259ba30be3f9" />

## Testing Plan

Inspection!

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
