### PR TITLE
VxPollBook: replace *all* hyphens in machine IDs with non-breaking hyphens in SA network table

### DIFF
--- a/apps/pollbook/frontend/src/unconfigured_screen.tsx
+++ b/apps/pollbook/frontend/src/unconfigured_screen.tsx
@@ -64,7 +64,7 @@ function PollbookConnectionTable({
                 {pollbooksForElection
                   // replace regular hyphens in IDs with non-breaking hyphen character
                   // so any given ID won't break across lines
-                  .map((p) => p.machineId.replace('-', '‑'))
+                  .map((p) => p.machineId.replaceAll('-', '‑'))
                   .join(', ')}
               </td>
               <td>


### PR DESCRIPTION
## Overview

Closes #7046.

## Demo Video or Screenshot

Not tested but feel confident about this one.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
