### PR TITLE
VxPollBook: Refactor offline/online state management and check for bad ip addresses

### DIFF
--- a/apps/pollbook/backend/src/networking.ts
+++ b/apps/pollbook/backend/src/networking.ts
@@ -1,6 +1,6 @@
 import { execFile } from '@votingworks/backend';
 import * as grout from '@votingworks/grout';
-import { assert, sleep } from '@votingworks/basics';
+import { assert, assertDefined, sleep } from '@votingworks/basics';
 import { LogEventId } from '@votingworks/logging';
 import { rootDebug } from './debug';
 import {
@@ -76,6 +76,10 @@ export function shouldPollbooksShareEvents(
   );
 }
 
+export function getNodeServiceName(machineId: string): string {
+  return `Pollbook-${machineId}`;
+}
+
 export function fetchEventsFromConnectedPollbooks({
   workspace,
 }: PeerAppContext): void {
@@ -100,14 +104,17 @@ export function fetchEventsFromConnectedPollbooks({
           workspace.store.getPollbookConfigurationInformation();
 
         // Maintain a queue of pollbooks to visit, refill and shuffle when empty
-        const pollbookNames = Object.keys(previouslyConnected).filter(
+        const pollbookNamesToVisit = Object.keys(previouslyConnected).filter(
           (name) =>
             previouslyConnected[name].status ===
-            PollbookConnectionStatus.Connected
+              PollbookConnectionStatus.Connected &&
+            // We don't need to fetch events from ourselves
+            previouslyConnected[name].machineId !==
+              myMachineInformation.machineId
         );
         if (pollbookQueue.length === 0) {
           // Shuffle pollbookNames
-          pollbookQueue = pollbookNames
+          pollbookQueue = pollbookNamesToVisit
             .map((name) => ({ name, sort: Math.random() }))
             .sort((a, b) => a.sort - b.sort)
             .map(({ name }) => name);
@@ -203,20 +210,26 @@ export function fetchEventsFromConnectedPollbooks({
   });
 }
 
+export function isValidIpv4Address(address: string): boolean {
+  const ipv4Regex =
+    /^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)){3}$/;
+  return ipv4Regex.test(address);
+}
+
 export function setupMachineNetworking({
   machineId,
   workspace,
 }: PeerAppContext): void {
-  const currentNodeServiceName = `Pollbook-${machineId}`;
+  const selfMachineServiceName = getNodeServiceName(machineId);
   // Advertise a service for this machine
   debug(
     'Publishing avahi service %s on port %d',
-    currentNodeServiceName,
+    selfMachineServiceName,
     PEER_PORT
   );
-  AvahiService.advertiseHttpService(currentNodeServiceName, PEER_PORT);
+  AvahiService.advertiseHttpService(selfMachineServiceName, PEER_PORT);
   workspace.logger.log(LogEventId.PollbookNetworkStatus, 'system', {
-    message: `Published service ${currentNodeServiceName} to avahi on port ${PEER_PORT}`,
+    message: `Published service ${selfMachineServiceName} to avahi on port ${PEER_PORT}`,
   });
 
   // Poll for new machines on the network
@@ -229,22 +242,35 @@ export function setupMachineNetworking({
       }
       isPolling = true;
       try {
+        const previousPollbookServices =
+          workspace.store.getPollbookServicesByName();
+        const selfMachinePollbookService = previousPollbookServices[
+          selfMachineServiceName
+        ] || {
+          machineId,
+          codeVersion: workspace.store.getCodeVersion(),
+          status: PollbookConnectionStatus.LostConnection,
+        };
         if (!(await hasOnlineInterface())) {
           // There is no network to try to connect over. Bail out.
-          debug(
-            'No online interface found. Setting online status to false and bailing.'
-          );
-          workspace.store.setOnlineStatus(false);
+          debug('No online interface found. Setting offline and bailing.');
+          workspace.store.setPollbookServiceForName(selfMachineServiceName, {
+            ...selfMachinePollbookService,
+            apiClient: undefined,
+            address: undefined,
+            status: PollbookConnectionStatus.LostConnection,
+          });
           return;
         }
 
         const myMachineInformation =
           workspace.store.getPollbookConfigurationInformation();
         const services = await AvahiService.discoverHttpServices();
-        const previouslyConnected = workspace.store.getPollbookServicesByName();
         // If there are any services that were previously connected that no longer show up in avahi
         // Mark them as shut down
-        for (const [name, service] of Object.entries(previouslyConnected)) {
+        for (const [name, service] of Object.entries(
+          previousPollbookServices
+        )) {
           // Only transition to shutdown for a service we are communicating with.
           if (
             !services.some((s) => s.name === name) &&
@@ -261,41 +287,80 @@ export function setupMachineNetworking({
             });
           }
         }
-        if (!services.some((s) => s.name === currentNodeServiceName)) {
+        if (!services.some((s) => s.name === selfMachineServiceName)) {
           // If the current machine is no longer published on Avahi, mark as offline
           debug(
             'The current service is no longer found on avahi. Setting online status to false'
           );
-          workspace.store.setOnlineStatus(false);
+          workspace.store.setPollbookServiceForName(selfMachineServiceName, {
+            ...selfMachinePollbookService,
+            apiClient: undefined,
+            address: undefined,
+            status: PollbookConnectionStatus.LostConnection,
+          });
           return;
         }
         for (const { name, resolvedIp, port } of services) {
           debug('Checking service %s at %s:%d', name, resolvedIp, port);
           if (
-            name !== currentNodeServiceName &&
+            name !== selfMachineServiceName &&
             !workspace.store.getIsOnline()
           ) {
             // do not bother trying to ping other nodes if we are not online
             continue;
           }
-          const currentPollbookService = previouslyConnected[name];
-          if (currentPollbookService && currentPollbookService.apiClient) {
-            debug('Using previous API client for %s', name);
+          const currentPollbookService = previousPollbookServices[name];
+
+          const advertisedServiceUrl = `http://${resolvedIp}:${port}`;
+          // We want to re-use the old api client if it is set up, and the URL it is using matches the advertised URL.
+          // Avahi can in rare cases return an invalid ipv6 address in the ipv4 field. To mitigate the impact of that when we
+          // see an invalid address we will continue to use the last known good address and api client (if it exists).
+          const reuseApiClient =
+            // We have a valid old api client
+            currentPollbookService &&
+            currentPollbookService.apiClient !== undefined &&
+            // It is for the same address we just got, or the new one is invalid
+            (currentPollbookService.address === advertisedServiceUrl ||
+              !isValidIpv4Address(resolvedIp));
+          if (reuseApiClient) {
+            debug(
+              'Using previous API client for %s with url %s',
+              name,
+              currentPollbookService.address
+            );
+          } else {
+            debug(
+              'Creating new API client for %s with url %s',
+              name,
+              advertisedServiceUrl
+            );
           }
-          const apiClient =
-            currentPollbookService && currentPollbookService.apiClient
-              ? currentPollbookService.apiClient
-              : createPeerApiClientForAddress(`http://${resolvedIp}:${port}`);
+          const machineUrl = reuseApiClient
+            ? assertDefined(currentPollbookService.address)
+            : advertisedServiceUrl;
+
+          const apiClient = reuseApiClient
+            ? assertDefined(currentPollbookService.apiClient)
+            : createPeerApiClientForAddress(machineUrl);
 
           try {
             const machineInformation =
               await apiClient.getPollbookConfigurationInformation();
-            if (name === currentNodeServiceName) {
+            if (name === selfMachineServiceName) {
               // current machine, if we got here the network is working
               if (workspace.store.getIsOnline() === false) {
                 debug('Setting online status to true');
               }
-              workspace.store.setOnlineStatus(true);
+              workspace.store.setPollbookServiceForName(
+                selfMachineServiceName,
+                {
+                  ...selfMachinePollbookService,
+                  apiClient,
+                  address: machineUrl,
+                  lastSeen: new Date(),
+                  status: PollbookConnectionStatus.Connected,
+                }
+              );
               continue;
             }
             if (
@@ -304,7 +369,7 @@ export function setupMachineNetworking({
               workspace.store.setPollbookServiceForName(name, {
                 ...machineInformation,
                 apiClient,
-                address: `http://${resolvedIp}:${port}`,
+                address: machineUrl,
                 lastSeen: new Date(),
                 status: PollbookConnectionStatus.IncompatibleSoftwareVersion,
               });
@@ -319,7 +384,7 @@ export function setupMachineNetworking({
               workspace.store.setPollbookServiceForName(name, {
                 ...machineInformation,
                 apiClient,
-                address: `http://${resolvedIp}:${port}`,
+                address: machineUrl,
                 lastSeen: new Date(),
                 status: PollbookConnectionStatus.MismatchedConfiguration,
               });
@@ -339,17 +404,11 @@ export function setupMachineNetworking({
             workspace.store.setPollbookServiceForName(name, {
               ...machineInformation,
               apiClient,
-              address: `http://${resolvedIp}:${port}`,
+              address: machineUrl,
               lastSeen: new Date(),
               status: PollbookConnectionStatus.Connected,
             });
           } catch (error) {
-            if (name === currentNodeServiceName) {
-              // Could not ping our own machine, mark as offline
-              debug('Failed to establish connection to self: %s', error);
-              debug('Setting online status to false');
-              workspace.store.setOnlineStatus(false);
-            }
             debug(`Failed to establish connection from ${name}: ${error}`);
           }
         }

--- a/apps/pollbook/backend/src/peer_store.ts
+++ b/apps/pollbook/backend/src/peer_store.ts
@@ -83,51 +83,8 @@ export class PeerStore extends Store {
     this.client.run(`DELETE FROM machines`);
   }
 
-  setOnlineStatus(isOnline: boolean): void {
-    const currentOnline = this.getIsOnline();
-    if (currentOnline !== isOnline) {
-      this.logger.log(LogEventId.PollbookNetworkStatus, 'system', {
-        message: `Pollbook status changed to ${
-          isOnline ? 'online' : 'offline'
-        }`,
-      });
-    }
-    this.client.transaction(() => {
-      if (!isOnline) {
-        // If we go offline, we should clear the list of connected pollbooks.
-        debug('Clearing connected pollbooks due to offline status');
-        for (const [avahiServiceName, pollbookService] of Object.entries(
-          this.connectedPollbooks
-        )) {
-          if (
-            CommunicatingPollbookConnectionStatuses.includes(
-              pollbookService.status
-            )
-          ) {
-            this.setPollbookServiceForName(avahiServiceName, {
-              ...pollbookService,
-              status: PollbookConnectionStatus.LostConnection,
-              apiClient: undefined,
-            });
-          }
-        }
-      }
-      this.client.run(
-        `
-      INSERT INTO machines (machine_id, status, last_seen, pollbook_information)
-      VALUES (?, ?, ?, ?)
-      ON CONFLICT(machine_id) DO UPDATE SET
-        status = excluded.status
-        ${isOnline ? ', last_seen = excluded.last_seen' : ''}
-      `,
-        this.machineId,
-        isOnline
-          ? PollbookConnectionStatus.Connected
-          : PollbookConnectionStatus.LostConnection,
-        isOnline ? getCurrentTime() : 0,
-        '{}'
-      );
-    });
+  getCodeVersion(): string {
+    return this.codeVersion;
   }
 
   // Saves all events received from a remote machine. Returning the last event's timestamp.
@@ -271,6 +228,31 @@ export class PeerStore extends Store {
         machineId: pollbookService.machineId,
       })
     );
+
+    if (
+      pollbookService.machineId === this.machineId &&
+      pollbookService.status === PollbookConnectionStatus.LostConnection
+    ) {
+      // We are now offline, we should mark all other services as offline.
+      for (const [otherPollbookName, otherPollbookService] of Object.entries(
+        this.connectedPollbooks
+      )) {
+        if (otherPollbookName === avahiServiceName) {
+          continue;
+        }
+        if (
+          CommunicatingPollbookConnectionStatuses.includes(
+            otherPollbookService.status
+          )
+        ) {
+          this.setPollbookServiceForName(otherPollbookName, {
+            ...otherPollbookService,
+            status: PollbookConnectionStatus.LostConnection,
+            apiClient: undefined,
+          });
+        }
+      }
+    }
   }
 
   cleanupStalePollbookServices(): void {

--- a/apps/pollbook/backend/src/store_multi_node.test.ts
+++ b/apps/pollbook/backend/src/store_multi_node.test.ts
@@ -157,8 +157,6 @@ test('offline undo with later real time check in', async () => {
   expect(localB.getCheckInCount()).toEqual(2);
 
   // PollbookB goes offline
-  peerB.setOnlineStatus(false);
-
   // Sue checks in with a CA id and then is undone on PollbookB while offline
   localB.recordVoterCheckIn({
     voterId: 'sue',
@@ -178,8 +176,6 @@ test('offline undo with later real time check in', async () => {
   });
 
   // PollbookB comes back online
-  peerB.setOnlineStatus(true);
-
   // Pollbook B syncs with Pollbook A
   const finalEventsForB = syncEventsFromTo(peerA, peerB);
   expect(finalEventsForB.length).toEqual(1);
@@ -371,8 +367,6 @@ test("getting a offline machines events when I've synced with the online machine
   expect(localC.getCheckInCount()).toEqual(3);
 
   // PollbookC goes offline
-  peerC.setOnlineStatus(false);
-
   // Wait a bit to ensure physical timestamps will be different
   await sleep(10);
 
@@ -405,11 +399,7 @@ test("getting a offline machines events when I've synced with the online machine
   expect(localC.getCheckInCount()).toEqual(4);
 
   // PollbookB is shutdown
-  peerB.setOnlineStatus(false);
-
   // PollbookC rejoins the network
-  peerC.setOnlineStatus(true);
-
   // Sync events between PollbookA and PollbookC
   syncEventsForAllPollbooks([peerA, peerC]);
 
@@ -435,11 +425,7 @@ test("getting a offline machines events when I've synced with the online machine
   ]);
 
   // PollbookC is shutdown
-  peerC.setOnlineStatus(false);
-
   // PollbookB rejoins the network
-  peerB.setOnlineStatus(true);
-
   // Sync events between PollbookA and PollbookB
   syncEventsForAllPollbooks([peerA, peerB]);
 
@@ -773,11 +759,7 @@ test('late-arriving older event with a more recent undo', () => {
   expect(localB.getCheckInCount()).toEqual(0);
 
   // Pollbook B goes offline
-  peerB.setOnlineStatus(false);
-
   // Pollbook C comes online
-  peerC.setOnlineStatus(true);
-
   // Penny checks in on PollbookC
   localC.recordVoterCheckIn({
     voterId: 'penny',
@@ -792,16 +774,12 @@ test('late-arriving older event with a more recent undo', () => {
   expect(localC.getCheckInCount()).toEqual(2);
 
   // Pollbook A goes offline
-  peerA.setOnlineStatus(false);
-
   // Pollbook B comes online and syncs with Pollbook C
-  peerB.setOnlineStatus(true);
   syncEventsForAllPollbooks([peerC, peerB]);
   expect(localB.getCheckInCount()).toEqual(1);
   expect(localC.getCheckInCount()).toEqual(1);
 
   // Pollbook A comes back online and syncs with Pollbook B
-  peerA.setOnlineStatus(true);
   syncEventsForAllPollbooks([peerB, peerA]);
 
   // Verify final state
@@ -1376,7 +1354,6 @@ test('check in event on an offline machine BEFORE the mark inactive', async () =
   // Sync initial state
   syncEventsForAllPollbooks([peerA, peerB]);
   // PollbookB goes offline
-  peerB.setOnlineStatus(false);
   // Check in on B while offline
   localB.recordVoterCheckIn({
     voterId: 'mia',
@@ -1388,7 +1365,6 @@ test('check in event on an offline machine BEFORE the mark inactive', async () =
   // Mark inactive on A
   localA.markVoterInactive('mia');
   // Bring B online and sync
-  peerB.setOnlineStatus(true);
   syncEventsForAllPollbooks([peerA, peerB]);
   // Both should see voter as inactive and checked in
   for (const store of [localA, localB]) {
@@ -1419,7 +1395,6 @@ test('check in event on an offline machine AFTER the mark inactive', async () =>
   syncEventsForAllPollbooks([peerA, peerB]);
 
   // PollbookB goes offline
-  peerB.setOnlineStatus(false);
   // Mark inactive on A
   localA.markVoterInactive('nia');
   // Wait a bit of time.
@@ -1431,7 +1406,6 @@ test('check in event on an offline machine AFTER the mark inactive', async () =>
     ballotParty: 'DEM',
   });
   // Bring B online and sync
-  peerB.setOnlineStatus(true);
   syncEventsForAllPollbooks([peerA, peerB]);
   // Both should see voter as inactive and checked in
   for (const store of [localA, localB]) {
@@ -1466,7 +1440,6 @@ test('name/address change AFTER mark inactive on another machine get processed',
   syncEventsForAllPollbooks([peerA, peerB]);
 
   // Pollbook B offline
-  peerB.setOnlineStatus(false);
 
   // Mark inactive on A
   localA.markVoterInactive('kai');
@@ -1494,7 +1467,6 @@ test('name/address change AFTER mark inactive on another machine get processed',
     precinct: 'precinct-0',
   });
 
-  peerB.setOnlineStatus(true);
   syncEventsForAllPollbooks([peerA, peerB]);
   // Both should see voter as inactive, with name/address change
   for (const store of [localA, localB]) {


### PR DESCRIPTION
## Overview
This PR makes a few notable changes that are all a little inter-related:

- Updates handling of the self-machine state to be more merged with how we track other connected nodes, we were already sharing the same database but not keeping the data structure updated with a old apiClient. This means we were caching the old apiClient for other pollbooks but not for the self. As part of the merging of the code handling I removed the specific setOnlineStatus function and now you should control with the setPollbookServiceForName method like you do for other pollbook connection updates, it will check for the special case of the machine going offline and set other connections to lost connection in that situation. 
- Specifically checks for a bad ipv4 address from avahi and ignores it, used the previous cached ip (if it exists) instead to handle weird avahi blips more gracefully
- Makes sure for all pollbooks (self, and other nodes) that we update the cached api client if we need a new ip address in avahi for that pollbook service 
- A by product of merging the code paths is that we the cleanupStalePollbooks method that runs will now handle updating the state of the current machine to LostConnection (setting it offline) when we haven't been able to ping ourselves in 10seconds, making that behavior less reactive then if there is one failed ping

## Demo Video or Screenshot

## Testing Plan


## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
