### PR TITLE
Add warnings not to remove USB drives to VxAdmin USB format modal and VxCentralScan CVR save modal

### DIFF
--- a/apps/central-scan/frontend/src/components/export_results_modal.tsx
+++ b/apps/central-scan/frontend/src/components/export_results_modal.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useState } from 'react';
 
 import {
   Button,
-  Loading,
+  Icons,
   Modal,
   P,
   UsbControllerButton,
@@ -113,7 +113,16 @@ export function ExportResultsModal({ onClose }: Props): JSX.Element | null {
   }
 
   if (currentState === ModalState.SAVING) {
-    return <Modal content={<Loading>Saving CVRs</Loading>} />;
+    return (
+      <Modal
+        title="Saving CVRs…"
+        content={
+          <P>
+            <Icons.Warning color="warning" /> Do not remove the USB drive.
+          </P>
+        }
+      />
+    );
   }
 
   // istanbul ignore next -- compile-time check

--- a/libs/ui/src/format_usb_modal.tsx
+++ b/libs/ui/src/format_usb_modal.tsx
@@ -6,7 +6,6 @@ import { Button } from './button';
 import { Modal } from './modal';
 import { Font, P } from './typography';
 import { Icons } from './icons';
-import { Loading } from './loading';
 
 type FlowState =
   | { stage: 'confirm' }
@@ -74,7 +73,16 @@ function FormatUsbFlow({
         />
       );
     case 'formatting':
-      return <Modal content={<Loading>Formatting USB Drive</Loading>} />;
+      return (
+        <Modal
+          title="Formatting USB Drive…"
+          content={
+            <P>
+              <Icons.Warning color="warning" /> Do not remove the USB drive.
+            </P>
+          }
+        />
+      );
     case 'done':
       return (
         <Modal


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6960
Closes https://github.com/votingworks/vxsuite/issues/6961

After some discussion with SLI, for two cert discrepancies both involving errors that (expectedly) surface when USB drives are removed while being written to, we landed on warnings not to remove the USB drives as acceptable solutions.

This task prompted a general discussion about our progress modals, and if we have time before the cert campaign ends, it could be nice to revisit all progress modals holistically (https://github.com/votingworks/vxsuite/issues/7049). For now though, what we've landed on in this PR is reasonably compatible with the old pattern still in use elsewhere.

## Demo Video or Screenshot

_VxAdmin USB format modal_

| Before | After |
| - | - |
| <img width="400" alt="format-before" src="https://github.com/user-attachments/assets/6f6f43c1-12a0-40fa-805a-5993c530a5dd" /> | <img width="400" alt="format-after" src="https://github.com/user-attachments/assets/9c1e41b9-2e48-46b9-a8c0-891454a07f30" /> |

_VxCentralScan CVR save modal_

| Before | After |
| - | - |
| <img width="400" alt="save-before" src="https://github.com/user-attachments/assets/0dd46f00-54fd-47ad-8430-6eef07045285" /> | <img width="400" alt="save-after" src="https://github.com/user-attachments/assets/69e30eed-cdd1-4fa7-93ff-08811debc311" /> |

_In action_

Note: We decided not to include our typical progress ellipses. Those only work on center-aligned content and we deemed it not worth the trouble to get those working on left-aligned content.

https://github.com/user-attachments/assets/58dcc1f9-3362-4030-a082-7824c932c40a

## Testing Plan

- [x] Tested manually

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~ N/A
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~ N/A
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.