### PR TITLE
VxScan: Return audio level to default value after a ballot has been cast

### DIFF
--- a/apps/scan/frontend/src/utils/use_session_settings_manager.test.tsx
+++ b/apps/scan/frontend/src/utils/use_session_settings_manager.test.tsx
@@ -7,11 +7,13 @@ import {
 } from '@votingworks/ui';
 import { DefaultTheme, ThemeContext } from 'styled-components';
 import React from 'react';
+import { mockUseAudioControls } from '@votingworks/test-utils';
 import { useSessionSettingsManager } from './use_session_settings_manager';
 import { renderHook, act } from '../../test/react_testing_library';
 import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;
+const mockAudioControls = mockUseAudioControls(vi.fn);
 const mockLanguageControls: Mocked<LanguageControls> = {
   reset: vi.fn(),
   setLanguage: vi.fn(),
@@ -21,6 +23,7 @@ const mockUseCurrentLanguage = vi.mocked(useCurrentLanguage);
 vi.mock('@votingworks/ui', async () => ({
   ...(await vi.importActual('@votingworks/ui')),
   useCurrentLanguage: vi.fn(),
+  useAudioControls: () => mockAudioControls,
   useLanguageControls: () => mockLanguageControls,
 }));
 
@@ -92,6 +95,7 @@ it('Reset voter settings when resetVoterSettings is called', () => {
   });
 
   // Validate settings were reset
+  expect(mockAudioControls.reset).toHaveBeenCalledTimes(1);
   expect(mockLanguageControls.reset).toHaveBeenCalledTimes(1);
   expect(mockLanguageControls.setLanguage).not.toHaveBeenCalled();
   expect(result.current.theme).toEqual(
@@ -124,6 +128,7 @@ it('First cache/clear voter settings and then restore', () => {
   });
 
   // Validate settings were reset
+  expect(mockAudioControls.reset).toHaveBeenCalledTimes(1);
   expect(mockLanguageControls.reset).toHaveBeenCalledTimes(1);
   expect(mockLanguageControls.setLanguage).not.toHaveBeenCalled();
   expect(result.current.theme).toEqual(

--- a/apps/scan/frontend/src/utils/use_session_settings_manager.ts
+++ b/apps/scan/frontend/src/utils/use_session_settings_manager.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   VoterSettingsManagerContext,
+  useAudioControls,
   useCurrentLanguage,
   useLanguageControls,
 } from '@votingworks/ui';
@@ -17,6 +18,7 @@ export interface SessionSettingsManagerProps {
  * (i.e. needed when an election official interrupts a voter session)
  */
 export function useSessionSettingsManager(): SessionSettingsManagerProps {
+  const audioContext = useAudioControls();
   const languageContext = useLanguageControls();
   const voterSettingsContext = React.useContext(VoterSettingsManagerContext);
   const currentLanguage = useCurrentLanguage();
@@ -29,6 +31,7 @@ export function useSessionSettingsManager(): SessionSettingsManagerProps {
     React.useState<string | null>(null);
 
   function startNewSession() {
+    audioContext.reset();
     languageContext.reset();
     voterSettingsContext.resetThemes();
     setSavedVoterSessionLanguage(null);
@@ -40,6 +43,7 @@ export function useSessionSettingsManager(): SessionSettingsManagerProps {
     setSavedVoterSessionLanguage(currentLanguage);
     voterSettingsContext.resetThemes();
     languageContext.reset();
+    audioContext.reset();
   }
 
   function resumeSession() {


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6959

A quick fix for a reported cert discrepancy to return the audio level to the default value after a ballot has been cast on VxScan. Though I know that discussion regarding headphones on VxScan is ongoing, existing frameworks made this super simple 🎉 and I decided to just close it out as one less thing to think about.

## Testing Plan

- [x] Updated automated tests
- [ ] Tested manually

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~ N/A
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~ Relying on existing logging
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.