### PR TITLE
[Scan/Mark] Support navigation via PAT-specific keyboard events

### DIFF
--- a/libs/ui/src/keyboard_navigation.test.ts
+++ b/libs/ui/src/keyboard_navigation.test.ts
@@ -39,6 +39,19 @@ test('focus next', () => {
   expect(mockTriggerPageNavButton).not.toHaveBeenCalled();
 });
 
+test('PAT move', () => {
+  const { event, mockPreventDefault } = createEvent({
+    key: Keybinding.PAT_MOVE,
+  });
+
+  handleKeyboardEvent(event);
+
+  expect(mockAdvanceFocus).toHaveBeenCalledOnce();
+  expect(mockAdvanceFocus).toHaveBeenCalledWith(1);
+  expect(mockPreventDefault).toHaveBeenCalledOnce();
+  expect(mockTriggerPageNavButton).not.toHaveBeenCalled();
+});
+
 test('focus previous', () => {
   const { event, mockPreventDefault } = createEvent({
     key: Keybinding.FOCUS_PREVIOUS,
@@ -93,6 +106,16 @@ test('select', () => {
   expect(mockTriggerPageNavButton).not.toHaveBeenCalled();
   expect(mockAdvanceFocus).not.toHaveBeenCalled();
   expect(mockPreventDefault).not.toHaveBeenCalled();
+});
+
+test('PAT select', () => {
+  const onClick = vi.fn();
+  document.addEventListener('click', onClick);
+
+  handleKeyboardEvent(createEvent({ key: Keybinding.PAT_SELECT }).event);
+  expect(onClick).toHaveBeenCalledOnce();
+
+  document.removeEventListener('click', onClick);
 });
 
 test('miscellaneous ignored key', () => {

--- a/libs/ui/src/keyboard_navigation.ts
+++ b/libs/ui/src/keyboard_navigation.ts
@@ -42,8 +42,15 @@ export function handleKeyboardEvent(event: KeyboardEvent): void {
       break;
 
     case Keybinding.FOCUS_NEXT:
+    case Keybinding.PAT_MOVE:
       advanceElementFocus(1);
       preventBrowserScroll(event);
+      break;
+
+    case Keybinding.PAT_SELECT:
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.click();
+      }
       break;
 
     default:


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/6988

Recent clarifications on an RFI regarding peripherals on precinct scanners (details in [Slack](https://votingworks.slack.com/archives/CE7LM9LQ2/p1754960059785999)) mean that we'll need to support PAT input devices on VxScan.

We'll be using the same X-Keys XK3 USB switch that we've picked for VxMark, which can be [configured](https://docs.google.com/document/d/10Nf5HZ_de-WPGGbndrgrNZ9RdifD83t_q-AyIIalTyI/edit?tab=t.wb9xymjo57u5) to emit any keyboard events we want. We're currently configuring it to emit the same `ArrowDown` and `Enter` events as the tactile controller, but will move over to using the `1` and `2` keys that we've been using for VxMarkScan, both for consistency and to help distinguish between tactile controller events and PAT input events.

This change adds handling for the `1` (move) and `2` (select) PAT events - affects both VxScan and VxMark.

### TODO
- PAT input identification in the HWTA

## Testing Plan
- Update unit tests + manual verification with X-Keys device

