### PR TITLE
VxPollBook/VxAdmin/VxCentralScan: handle out of range battery levels

### DIFF
--- a/apps/admin/backend/src/reports/readiness.ts
+++ b/apps/admin/backend/src/reports/readiness.ts
@@ -17,10 +17,12 @@ async function getReadinessReport({
   workspace,
   printer,
   generatedAtTime = new Date(getCurrentTime()),
+  logger,
 }: {
   workspace: Workspace;
   printer: Printer;
   generatedAtTime?: Date;
+  logger: Logger;
 }): Promise<JSX.Element> {
   const { store } = workspace;
   const currentElectionId = store.getCurrentElectionId();
@@ -30,7 +32,7 @@ async function getReadinessReport({
 
   return AdminReadinessReport({
     batteryInfo:
-      (await getBatteryInfo()) ??
+      (await getBatteryInfo({ logger })) ??
       /* istanbul ignore next - @preserve */
       undefined,
     diskSpaceSummary: await workspace.getDiskSpaceSummary(),
@@ -60,7 +62,7 @@ export async function saveReadinessReport({
   logger: Logger;
 }): Promise<ExportDataResult> {
   const generatedAtTime = new Date(getCurrentTime());
-  const report = await getReadinessReport({ workspace, printer });
+  const report = await getReadinessReport({ workspace, printer, logger });
 
   // Readiness reports shouldn't be large enough to hit the PDF size limit, so
   // we don't expect rendering the PDF to error

--- a/apps/central-scan/backend/src/readiness_report.ts
+++ b/apps/central-scan/backend/src/readiness_report.ts
@@ -34,7 +34,7 @@ export async function saveReadinessReport({
   const markThresholds = store.getSystemSettings()?.markThresholds;
   const report = CentralScanReadinessReport({
     batteryInfo:
-      (await getBatteryInfo()) ??
+      (await getBatteryInfo({ logger })) ??
       /* istanbul ignore next - @preserve */ undefined,
     diskSpaceSummary: await workspace.getDiskSpaceSummary(),
     isScannerAttached,

--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -216,7 +216,7 @@ function buildApi({ context, logger, barcodeScannerClient }: BuildAppParams) {
       ] = await Promise.all([
         usbDrive.status(),
         printer.status(),
-        getBatteryInfo(),
+        getBatteryInfo({ logger }),
         barcodeScannerClient.isConnected(),
       ]);
       return {

--- a/libs/backend/src/system_call/api.ts
+++ b/libs/backend/src/system_call/api.ts
@@ -32,7 +32,7 @@ function buildApi({
     rebootToVendorMenu: async () => rebootToVendorMenu(logger),
     powerDown: async () => powerDown(logger),
     setClock,
-    getBatteryInfo,
+    getBatteryInfo: async () => getBatteryInfo({ logger }),
     getAudioInfo: async () => getAudioInfo({ logger, nodeEnv: NODE_ENV }),
   };
 }

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -545,7 +545,7 @@ IDs are logged with each log to identify the log being written.
 ### unexpected-hardware-device-response
 **Type:** [system-status](#system-status)
 **Description:** A connected hardware device returned an unexpected response.
-**Machines:** vx-mark-scan
+**Machines:** vx-pollbook
 ### no-pid
 **Type:** [system-status](#system-status)
 **Description:** No PID was readable from PID file, or PID file did not exist.

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -873,7 +873,7 @@ restrictInDocumentationToApps = ["vx-mark-scan"]
 eventId = "unexpected-hardware-device-response"
 eventType = "system-status"
 documentationMessage = "A connected hardware device returned an unexpected response."
-restrictInDocumentationToApps = ["vx-mark-scan"]
+restrictInDocumentationToApps = ["vx-pollbook"]
 
 [Events.NoPid]
 eventId = "no-pid"

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -1200,7 +1200,7 @@ const UnexpectedHardwareDeviceResponse: LogDetails = {
   eventType: LogEventType.SystemStatus,
   documentationMessage:
     'A connected hardware device returned an unexpected response.',
-  restrictInDocumentationToApps: [AppName.VxMarkScan],
+  restrictInDocumentationToApps: [AppName.VxPollBook],
 };
 
 const NoPid: LogDetails = {


### PR DESCRIPTION
## Overview

Closes #7067. We saw a machine crash because its battery level was outside of the range 0 to 1. The most likely cause of this is that Linux updates it's "battery level" above the "battery level current capacity" and if the previous capacity was a little low, we very briefly get a higher than 100% value. It makes sense that we've only seen this on VxPollBook, where the battery level is shown and polled constantly in the navbar, rather than VxAdmin where it is only shown when logged in.

I didn't end up wanting to clamp. If there were some larger bug with the battery reporting mechanism that caused values to be consistently out of range, we would just report 100% or 0% constantly. I think we'd rather know that something odd is happening with the battery, so we treat it as if we cannot get the battery level. The frontend handles this by showing `--%`. In the error case, this will be so rare and so brief that users won't notice. But it will allow us to notice in cases where something is really amiss. We also log whenever it happens, with the battery level, so we know.

## Testing Plan

Updated automated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
