### PR TITLE
[libs/ui] Try fixing BMD paper ballot test flake

### DIFF
--- a/libs/ui/src/bmd_paper_ballot.dual_language.test.tsx
+++ b/libs/ui/src/bmd_paper_ballot.dual_language.test.tsx
@@ -140,9 +140,7 @@ describe('non-English ballot style', () => {
       />
     );
 
-    await waitFor(() =>
-      expect(getLanguageContext()?.currentLanguageCode).toEqual('en')
-    );
+    await screen.findAllByTestId(ElectionStringKey.ELECTION_TITLE);
 
     expectDualLanguageString({ key: 'titleOfficialBallot' });
     expectDualLanguageString({ key: ElectionStringKey.ELECTION_TITLE });
@@ -184,9 +182,7 @@ describe('non-English ballot style', () => {
       />
     );
 
-    await waitFor(() =>
-      expect(getLanguageContext()?.currentLanguageCode).toEqual('en')
-    );
+    await screen.findAllByTestId(ElectionStringKey.ELECTION_TITLE);
 
     expectDualLanguageString({
       key: ElectionStringKey.CONTEST_TITLE,
@@ -234,9 +230,7 @@ describe('non-English ballot style', () => {
       />
     );
 
-    await waitFor(() =>
-      expect(getLanguageContext()?.currentLanguageCode).toEqual('en')
-    );
+    await screen.findAllByTestId(ElectionStringKey.ELECTION_TITLE);
 
     expectDualLanguageString({ key: 'noteBallotContestNoSelection' });
   });
@@ -261,9 +255,7 @@ describe('non-English ballot style', () => {
       />
     );
 
-    await waitFor(() =>
-      expect(getLanguageContext()?.currentLanguageCode).toEqual('en')
-    );
+    await screen.findAllByTestId(ElectionStringKey.ELECTION_TITLE);
 
     expectDualLanguageString({
       key: ElectionStringKey.CONTEST_TITLE,
@@ -297,9 +289,7 @@ describe('non-English ballot style', () => {
       />
     );
 
-    await waitFor(() =>
-      expect(getLanguageContext()?.currentLanguageCode).toEqual('en')
-    );
+    await screen.findAllByTestId(ElectionStringKey.ELECTION_TITLE);
 
     expectDualLanguageString({
       key: ElectionStringKey.CONTEST_TITLE,
@@ -365,9 +355,7 @@ describe('English ballot style', () => {
       />
     );
 
-    await waitFor(() =>
-      expect(getLanguageContext()?.currentLanguageCode).toEqual('en')
-    );
+    await screen.findAllByTestId(ElectionStringKey.ELECTION_TITLE);
 
     expect(container).not.toHaveTextContent(
       new RegExp(getMockUiStringPrefix('es-US'))


### PR DESCRIPTION
## Overview

Following up on an old TODO from flaky test review.

Wasn't able to repro [this flake](https://app.circleci.com/pipelines/github/votingworks/vxsuite/21256/workflows/aa336786-62de-4bb2-bb15-66b66710b99d/jobs/926373/parallel-runs/0/steps/0-111) locally, but following the breadcrumbs, the tests might be too optimistic about the document content being ready once the parent language context is ready. Switching to waiting for a specific piece of content on the ballot to show up instead, before checking assertions. Should be a more stable condition.

## Testing Plan
- Locally: ran a bunch of times
- CI: 🤞
