### PR TITLE
VxPollBook: add a space within "pollbook" :)

### DIFF
--- a/apps/pollbook/frontend/src/nav_screen.test.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.test.tsx
@@ -75,7 +75,7 @@ test('renders network status as expected - when unconfigured', async () => {
   expect(icon.getAttribute('data-icon')).toEqual('tower-broadcast');
   userEvent.click(icon);
   await screen.findByText('Network Details');
-  await screen.findByText('No pollbooks found.');
+  await screen.findByText('No poll books found.');
   userEvent.click(screen.getByText('Close'));
   // Test with other pollbooks on the network
   apiMock.setNetworkOnline([
@@ -202,7 +202,7 @@ test('renders network status as expected - when configured', async () => {
   expect(icon.getAttribute('data-icon')).toEqual('tower-broadcast');
   userEvent.click(icon);
   await screen.findByText('Network Details');
-  await screen.findByText('No pollbooks found.');
+  await screen.findByText('No poll books found.');
   userEvent.click(screen.getByText('Close'));
   // Test with other pollbooks on the network
   apiMock.setNetworkOnline([

--- a/apps/pollbook/frontend/src/nav_screen.tsx
+++ b/apps/pollbook/frontend/src/nav_screen.tsx
@@ -200,7 +200,7 @@ function NetworkStatus({
                 </div>
               )}
               {sortedPollbooks.length === 0 && status.isOnline && (
-                <span>No pollbooks found.</span>
+                <span>No poll books found.</span>
               )}
               {status.isOnline &&
                 !isResetting &&


### PR DESCRIPTION
## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
