### PR TITLE
VxPollBook: Fix machine id updates in check in status mat view

### DIFF
--- a/apps/pollbook/backend/src/store.ts
+++ b/apps/pollbook/backend/src/store.ts
@@ -334,13 +334,10 @@ export abstract class Store {
             VALUES (?, ?, ?)
             ON CONFLICT(voter_id) DO UPDATE SET 
             is_checked_in = EXCLUDED.is_checked_in,
-            machine_id = CASE
-              WHEN check_in_status.is_checked_in != EXCLUDED.is_checked_in THEN EXCLUDED.machine_id
-              ELSE check_in_status.machine_id
-            END
+            machine_id = EXCLUDED.machine_id
             `,
             pollbookEvent.voterId,
-            pollbookEvent.machineId,
+            voter.checkIn ? voter.checkIn.machineId : null,
             voter.checkIn ? '1' : '0'
           );
           break;


### PR DESCRIPTION
## Overview
The check_in_status table is only used for performance reasons for the check in counts that populate on the top of the poll worker screen and in the network modal. We are properly handling double checks in when viewing a voter as the getVoter function will get all events for that voter, and resolve them consistently. However I had an error in the way I was updating the machine_id in the materialized view, causing it to be wrong and produce confusing behavior. Here is how it works as an example: 

Machine A checks in Bob at 6:01
Machine B checks in Bob at 6:02 

When Machine A syncs the check in event from Machine B whenever it is fetching Bob it will return the Machine B check in since the last write wins. 
When Machine B syncs the check in event from Machine A it will save it but will still always return the Machine B check in when returning Bob. 

When either machine syncs the remote event it will have a conflict when trying to insert to the check_in_status table, I'm not sure what I was thinking in my original case statement here, but we should update to  machine id that is on the check in event of the voter (not just whatever event we are saving) to make sure it is consistent with how we will reconcile all the events on that voter. When we are undoing a check in (and voter.checkIn is undefined) then we don't need the machine id and can set to null (this table doesn't have any info about voters not checked in, we do not track machine id info for undos like that or need it in the materialized view).

## Testing Plan
Added additional testing to sending in the machine id when calling getCheckInCounts in the store_multi_node tests, the double check in tests will notably fail on main prior to the changes in this PR. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
