### PR TITLE
VxCentralScan: Log imprinter attachment status on scan start

### DIFF
--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -335,6 +335,10 @@ export class Importer {
       throw new Error('scanning already in progress');
     }
 
+    this.logger.log(LogEventId.ImprinterStatus, 'system', {
+      message: `Imprinter is ${hasImprinter ? 'attached' : 'not attached'}.`,
+    });
+
     const batchId = this.workspace.store.addBatch();
     const batchScanDirectory = join(
       this.workspace.ballotImagesPath,

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -398,6 +398,10 @@ IDs are logged with each log to identify the log being written.
 **Type:** [application-status](#application-status)
 **Description:** Message from the driver handling the fujitsu scanner regarding scanning progress.
 **Machines:** vx-central-scan
+### imprinter-status
+**Type:** [application-status](#application-status)
+**Description:** Indicates the status of the imprinter, namely whether or not it is registering as attached.
+**Machines:** vx-central-scan
 ### election-package-load-from-usb-complete
 **Type:** [user-action](#user-action)
 **Description:** The election package has been read from the USB drive. Success or failure indicated by disposition.

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -648,6 +648,12 @@ eventType = "application-status"
 documentationMessage = "Message from the driver handling the fujitsu scanner regarding scanning progress."
 restrictInDocumentationToApps = ["vx-central-scan"]
 
+[Events.ImprinterStatus]
+eventId = "imprinter-status"
+eventType = "application-status"
+documentationMessage = "Indicates the status of the imprinter, namely whether or not it is registering as attached."
+restrictInDocumentationToApps = ["vx-central-scan"]
+
 # Scanners, central and precinct
 [Events.ElectionPackageLoadedFromUsb]
 eventId = "election-package-load-from-usb-complete"

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -160,6 +160,7 @@ export enum LogEventId {
   FujitsuScanImageScanned = 'fujitsu-scan-sheet-scanned',
   FujitsuScanBatchComplete = 'fujitsu-scan-batch-complete',
   FujitsuScanMessage = 'fujitsu-scan-message',
+  ImprinterStatus = 'imprinter-status',
   ElectionPackageLoadedFromUsb = 'election-package-load-from-usb-complete',
   ExportCastVoteRecordsInit = 'export-cast-vote-records-init',
   ExportCastVoteRecordsComplete = 'export-cast-vote-records-complete',
@@ -900,6 +901,14 @@ const FujitsuScanMessage: LogDetails = {
   restrictInDocumentationToApps: [AppName.VxCentralScan],
 };
 
+const ImprinterStatus: LogDetails = {
+  eventId: LogEventId.ImprinterStatus,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'Indicates the status of the imprinter, namely whether or not it is registering as attached.',
+  restrictInDocumentationToApps: [AppName.VxCentralScan],
+};
+
 const ElectionPackageLoadedFromUsb: LogDetails = {
   eventId: LogEventId.ElectionPackageLoadedFromUsb,
   eventType: LogEventType.UserAction,
@@ -1556,6 +1565,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return FujitsuScanBatchComplete;
     case LogEventId.FujitsuScanMessage:
       return FujitsuScanMessage;
+    case LogEventId.ImprinterStatus:
+      return ImprinterStatus;
     case LogEventId.ElectionPackageLoadedFromUsb:
       return ElectionPackageLoadedFromUsb;
     case LogEventId.ExportCastVoteRecordsInit:

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -303,6 +303,8 @@ pub enum EventId {
     FujitsuScanBatchComplete,
     #[serde(rename = "fujitsu-scan-message")]
     FujitsuScanMessage,
+    #[serde(rename = "imprinter-status")]
+    ImprinterStatus,
     #[serde(rename = "election-package-load-from-usb-complete")]
     ElectionPackageLoadedFromUsb,
     #[serde(rename = "export-cast-vote-records-init")]


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7060

This is in response to a cert discrepancy reported by SLI:

> SLI does not see any documentation for printing errors in regards to the imprinters on the Ricoh fi-819PRB and fi-760PRB. Since the imprinters provide a printing function, there should be some potential messages. Such as the imprinter being detached.

I've opted for a simple imprinter status log that indicates whether or not the imprinter is registering as attached. This log is emitted on scan start.

I didn't want to add a log on actual disconnect/reconnect since that would require some kind of event listening and/or polling. The way we currently check imprinter status involves sending a scan request to the Fujitsu, and I don't want us constantly making that request to the Fujitsu in the background:

https://github.com/votingworks/vxsuite/blob/726e1abae8768a7f3591c6aa217ce88527af1232/apps/central-scan/backend/src/fujitsu_scanner.ts#L96-L104

I think that this log on scan start paired with the right documentation will be sufficient for SLI. We can make further adjustments if SLI doesn't find it sufficient.

Sample logs:

```
 {"source":"vx-central-scan-service","eventId":"imprinter-status","eventType":"application-status","user":"system","message":"Imprinter is attached.","disposition":"na"}
```

```
 {"source":"vx-central-scan-service","eventId":"imprinter-status","eventType":"application-status","user":"system","message":"Imprinter is not attached.","disposition":"na"}
```

## Testing Plan

- [x] Tested manually

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~ N/A
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] ~I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~ N/A