### PR TITLE
VxPollBook: Log double check ins when detected

### DIFF
--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -132,6 +132,8 @@ function buildApi({ context, logger, barcodeScannerClient }: BuildAppParams) {
           'getGeneralSummaryStatistics',
           'getPrimarySummaryStatistics',
           'getUsbDriveStatus',
+          'getVoter',
+          'searchVoters',
         ];
         if (silenceMethods.includes(methodName)) {
           return;

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -638,3 +638,7 @@ IDs are logged with each log to identify the log being written.
 **Type:** [application-status](#application-status)
 **Description:** A status message indicating change to the frontend navigation page.
 **Machines:** All
+### pollbook-duplicate-check-in-detected
+**Type:** [application-status](#application-status)
+**Description:** More then one check in event (ignoring undone checkins) for the same voter was detected in the system.
+**Machines:** vx-pollbook

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -1002,3 +1002,9 @@ restrictInDocumentationToApps = ["vx-pollbook"]
 eventId = "navigation-page-change"
 eventType = "application-status"
 documentationMessage = 'A status message indicating change to the frontend navigation page.'
+
+[Events.PollbookDuplicateCheckInDetected]
+eventId = "pollbook-duplicate-check-in-detected"
+eventType = "application-status"
+documentationMessage = 'More then one check in event (ignoring undone checkins) for the same voter was detected in the system.'
+restrictInDocumentationToApps = ["vx-pollbook"]

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -220,6 +220,7 @@ export enum LogEventId {
   PollbookConfigurationStatus = 'pollbook-configuration-status',
   PollbookPaperBackupStatus = 'pollbook-paper-backup-status',
   NavigationPageChange = 'navigation-page-change',
+  PollbookDuplicateCheckInDetected = 'pollbook-duplicate-check-in-detected',
 }
 
 const ElectionConfigured: LogDetails = {
@@ -1362,6 +1363,14 @@ const NavigationPageChange: LogDetails = {
     'A status message indicating change to the frontend navigation page.',
 };
 
+const PollbookDuplicateCheckInDetected: LogDetails = {
+  eventId: LogEventId.PollbookDuplicateCheckInDetected,
+  eventType: LogEventType.ApplicationStatus,
+  documentationMessage:
+    'More then one check in event (ignoring undone checkins) for the same voter was detected in the system.',
+  restrictInDocumentationToApps: [AppName.VxPollBook],
+};
+
 export function getDetailsForEventId(eventId: LogEventId): LogDetails {
   switch (eventId) {
     case LogEventId.ElectionConfigured:
@@ -1676,6 +1685,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return PollbookPaperBackupStatus;
     case LogEventId.NavigationPageChange:
       return NavigationPageChange;
+    case LogEventId.PollbookDuplicateCheckInDetected:
+      return PollbookDuplicateCheckInDetected;
     default:
       throwIllegalValue(eventId);
   }

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -423,5 +423,7 @@ pub enum EventId {
     PollbookPaperBackupStatus,
     #[serde(rename = "navigation-page-change")]
     NavigationPageChange,
+    #[serde(rename = "pollbook-duplicate-check-in-detected")]
+    PollbookDuplicateCheckInDetected,
 }
 derive_display!(EventId);


### PR DESCRIPTION
## Overview
Adds a check when saving a check in event to see if we detect a double (or triple, etc.) check in and log in that event. I was intentionally trying NOT to add another DB query  in the interest of making this the safest possible change which is why I am piggy backing off of the existing getVoter call, the event for the current check in WILL be included already there so we need to check for the number of check in events. When we apply events to the voter we clear out any check in data when we see an undo (even if there was a double check in prior to the undo, for example) so to detect a double check in we want to look at all of the events AFTER the most recent Undo (if there was one) and see if there is more then one event with the type CheckIn. 

I also noticed some more noisy logs now that the frontend is using a default refetchInterval for everything. 

<!-- Add a link to a GitHub issue here -->
https://github.com/votingworks/vxsuite/issues/7080

## Testing Plan
Hacked onto image, created double check ins through simulataneous clicks and through having a machine offline, verified logs. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
