### PR TITLE
VxDesign: Polish for election list filter

### DIFF
--- a/apps/design/frontend/src/app.tsx
+++ b/apps/design/frontend/src/app.tsx
@@ -8,6 +8,7 @@ import {
 } from '@votingworks/ui';
 import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
 import {
   ApiClient,
   ApiClientContext,
@@ -79,6 +80,7 @@ export function App({
 }: {
   apiClient?: ApiClient;
 }): JSX.Element {
+  const [electionsFilterText, setElectionsFilterText] = useState('');
   return (
     <AppBase
       defaultColorMode="desktop"
@@ -91,11 +93,12 @@ export function App({
             <WaitForUserInfo>
               <BrowserRouter>
                 <Switch>
-                  <Route
-                    path={routes.root.path}
-                    exact
-                    component={ElectionsScreen}
-                  />
+                  <Route path={routes.root.path} exact>
+                    <ElectionsScreen
+                      filterText={electionsFilterText}
+                      setFilterText={setElectionsFilterText}
+                    />
+                  </Route>
                   <Route
                     path={electionParamRoutes.root.path}
                     component={ElectionScreens}

--- a/apps/design/frontend/src/elections_screen.test.tsx
+++ b/apps/design/frontend/src/elections_screen.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { useState } from 'react';
 import { ok } from '@votingworks/basics';
 import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
@@ -60,12 +61,19 @@ afterEach(() => {
   apiMock.assertComplete();
 });
 
+function Wrapper() {
+  const [filterText, setFilterText] = useState('');
+  return (
+    <ElectionsScreen filterText={filterText} setFilterText={setFilterText} />
+  );
+}
+
 function renderScreen() {
   const history = createMemoryHistory();
   const result = render(
     provideApi(
       apiMock,
-      withRoute(<ElectionsScreen />, {
+      withRoute(<Wrapper />, {
         paramPath: routes.root.path,
         path: routes.root.path,
         history,
@@ -188,6 +196,7 @@ test('with elections', async () => {
 
   // Test filter
   const filterInput = screen.getByLabelText(/filter elections/i);
+  expect(filterInput).toHaveFocus();
 
   // Search for general election title
   userEvent.type(filterInput, general.election.title);
@@ -205,7 +214,10 @@ test('with elections', async () => {
   expect(filteredRows).toHaveLength(0);
 
   // Clear search to show all rows again
-  userEvent.clear(filterInput);
+  userEvent.click(
+    within(filterInput.parentElement!).getByRole('button', { name: /Clear/ })
+  );
+  expect(filterInput).toHaveFocus();
 
   rows = within(table).getAllByRole('row').slice(1);
   expect(rows).toHaveLength(2);

--- a/apps/design/frontend/src/elections_screen.tsx
+++ b/apps/design/frontend/src/elections_screen.tsx
@@ -433,6 +433,7 @@ export function ElectionsScreen({
                 }}
                 fill="transparent"
                 icon="X"
+                aria-label="Clear"
                 onPress={() => {
                   setFilterText('');
                   filterRef.current?.focus();

--- a/apps/design/frontend/src/elections_screen.tsx
+++ b/apps/design/frontend/src/elections_screen.tsx
@@ -9,7 +9,7 @@ import {
   Button,
   StyledButtonProps,
 } from '@votingworks/ui';
-import { FormEvent, useMemo, useState } from 'react';
+import { FormEvent, useMemo, useRef } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { format } from '@votingworks/utils';
@@ -357,6 +357,7 @@ export function ElectionsScreen({
   const getUserFeaturesQuery = getUserFeatures.useQuery();
   const user = getUser.useQuery().data;
   const history = useHistory();
+  const filterRef = useRef<HTMLInputElement>(null);
 
   function onCreateElectionSuccess(result: Result<Id, Error>) {
     if (result.isOk()) {
@@ -403,20 +404,41 @@ export function ElectionsScreen({
         <H1>Elections</H1>
       </Header>
       <MainContent>
-        <Column style={{ gap: '1rem' }}>
+        <Column style={{ gap: '1rem', height: '100%', overflow: 'hidden' }}>
           <Row style={{ gap: '0.5rem' }}>
-            <input
-              type="text"
-              aria-label="Filter elections"
-              placeholder={
-                features.ACCESS_ALL_ORGS
-                  ? 'Filter by organization or election title'
-                  : 'Filter by election title'
-              }
-              value={filterText}
-              style={{ flexGrow: 1 }}
-              onChange={(e) => setFilterText(e.target.value)}
-            />
+            <div
+              style={{ position: 'relative', flexGrow: 1, padding: '0.125rem' }}
+            >
+              <input
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus
+                ref={filterRef}
+                type="text"
+                aria-label="Filter elections"
+                placeholder={
+                  features.ACCESS_ALL_ORGS
+                    ? 'Filter by organization or election title'
+                    : 'Filter by election title'
+                }
+                value={filterText}
+                style={{ width: '100%' }}
+                onChange={(e) => setFilterText(e.target.value)}
+              />
+              <Button
+                style={{
+                  position: 'absolute',
+                  right: '0.25rem',
+                  top: '0.25rem',
+                  padding: '0.5rem',
+                }}
+                fill="transparent"
+                icon="X"
+                onPress={() => {
+                  setFilterText('');
+                  filterRef.current?.focus();
+                }}
+              />
+            </div>
             <CreateElectionButton
               variant={elections.length === 0 ? 'primary' : undefined}
             />
@@ -429,11 +451,13 @@ export function ElectionsScreen({
             </FileInputButton>
           </Row>
 
-          {features.ACCESS_ALL_ORGS ? (
-            <AllOrgsElectionsList elections={filteredElections} />
-          ) : (
-            <SingleOrgElectionsList elections={filteredElections} />
-          )}
+          <div style={{ overflow: 'auto' }}>
+            {features.ACCESS_ALL_ORGS ? (
+              <AllOrgsElectionsList elections={filteredElections} />
+            ) : (
+              <SingleOrgElectionsList elections={filteredElections} />
+            )}
+          </div>
         </Column>
       </MainContent>
     </NavScreen>

--- a/apps/design/frontend/src/elections_screen.tsx
+++ b/apps/design/frontend/src/elections_screen.tsx
@@ -341,7 +341,15 @@ function SingleOrgElectionsList({
   );
 }
 
-export function ElectionsScreen(): JSX.Element | null {
+interface Props {
+  filterText: string;
+  setFilterText: (text: string) => void;
+}
+
+export function ElectionsScreen({
+  filterText,
+  setFilterText,
+}: Props): JSX.Element | null {
   useTitle(routes.root.title);
   const listElectionsQuery = listElections.useQuery();
   const createElectionMutation = createElection.useMutation();
@@ -349,7 +357,6 @@ export function ElectionsScreen(): JSX.Element | null {
   const getUserFeaturesQuery = getUserFeatures.useQuery();
   const user = getUser.useQuery().data;
   const history = useHistory();
-  const [filterText, setFilterText] = useState('');
 
   function onCreateElectionSuccess(result: Result<Id, Error>) {
     if (result.isOk()) {


### PR DESCRIPTION
## Overview

Adds some polish to the filter on the elections screen:
- Auto-focus the filter on mount
- Add a button to clear the search
- Persist search when navigating to other pages and coming back to election list
- Only scroll the table so that the filter input doesn't resize while typing

## Demo Video or Screenshot

https://github.com/user-attachments/assets/2df5bb5c-1bd0-4bee-a27f-fa608eb421ac



## Testing Plan
- Manual testing
- Updated automated tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
