### PR TITLE
VxDesign: Cleanup for election filter polish

### DIFF
--- a/apps/design/frontend/src/elections_screen.tsx
+++ b/apps/design/frontend/src/elections_screen.tsx
@@ -405,10 +405,15 @@ export function ElectionsScreen({
       </Header>
       <MainContent>
         <Column style={{ gap: '1rem', height: '100%', overflow: 'hidden' }}>
-          <Row style={{ gap: '0.5rem' }}>
-            <div
-              style={{ position: 'relative', flexGrow: 1, padding: '0.125rem' }}
-            >
+          <Row
+            style={{
+              gap: '0.5rem',
+              // Leave space for focus outlines on buttons/input, which
+              // otherwise overflow and are hidden
+              margin: '0.125rem',
+            }}
+          >
+            <div style={{ position: 'relative', flexGrow: 1 }}>
               <input
                 // eslint-disable-next-line jsx-a11y/no-autofocus
                 autoFocus
@@ -427,8 +432,8 @@ export function ElectionsScreen({
               <Button
                 style={{
                   position: 'absolute',
-                  right: '0.25rem',
-                  top: '0.25rem',
+                  right: '0.125rem',
+                  top: '0.125rem',
                   padding: '0.5rem',
                 }}
                 fill="transparent"


### PR DESCRIPTION

## Overview

<!-- Add a link to a GitHub issue here -->
I accidentally forgot to commit this bit of cleanup in #7085. This makes sure that the focus outline for buttons in the filter row also doesn't get cut off by the hidden overflow (and adds an explanatory comment).

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
