### PR TITLE
add escape hatch for voter session wedge state

### DIFF
--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -208,6 +208,10 @@ export function PollWorkerScreen({
     return null;
   }
 
+  const voterSessionActionsDisabled =
+    stateMachineState === 'ejecting_to_front' ||
+    stateMachineState === 'ejecting_to_rear';
+
   return (
     <Screen>
       <Main padded>
@@ -222,6 +226,7 @@ export function PollWorkerScreen({
                 election={election}
                 onChooseBallotStyle={onChooseBallotStyle}
                 precinctSelection={precinctSelection}
+                disabled={voterSessionActionsDisabled}
               />
               <VotingSession>
                 <H4 as="h2">Cast a Previously Printed Ballot</H4>
@@ -233,6 +238,7 @@ export function PollWorkerScreen({
                   <Button
                     onPress={setAcceptingPaperStateMutation.mutate}
                     value={ACCEPTING_PREPRINTED_BALLOT_PARAMS}
+                    disabled={voterSessionActionsDisabled}
                   >
                     Insert Printed Ballot
                   </Button>

--- a/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.tsx
@@ -34,10 +34,11 @@ export interface BallotStyleSelectProps {
   election: Election;
   configuredPrecinctsAndSplits: PrecinctOrSplit[];
   onSelect: OnBallotStyleSelect;
+  disabled?: boolean;
 }
 
 export function BallotStyleSelect(props: BallotStyleSelectProps): JSX.Element {
-  const { election, configuredPrecinctsAndSplits, onSelect } = props;
+  const { election, configuredPrecinctsAndSplits, onSelect, disabled } = props;
 
   // Only used for primary elections
   const [selectedPrecinctOrSplitId, setSelectedPrecinctOrSplitId] = useState<
@@ -73,6 +74,7 @@ export function BallotStyleSelect(props: BallotStyleSelectProps): JSX.Element {
               )
             }
             rightIcon="Next"
+            disabled={disabled}
           >
             Start Voting Session: {electionStrings.precinctName(precinct)}
           </Button>
@@ -80,6 +82,7 @@ export function BallotStyleSelect(props: BallotStyleSelectProps): JSX.Element {
       }
       return (
         <SearchSelect
+          aria-label="Select ballot precinct"
           placeholder="Select ballot style…"
           options={configuredPrecinctsAndSplits.map((precinctOrSplit) =>
             precinctOrSplit.split
@@ -107,6 +110,7 @@ export function BallotStyleSelect(props: BallotStyleSelectProps): JSX.Element {
             );
           }}
           style={{ width: '100%' }}
+          disabled={disabled}
         />
       );
     }
@@ -128,6 +132,7 @@ export function BallotStyleSelect(props: BallotStyleSelectProps): JSX.Element {
         >
           {configuredPrecinctsAndSplits.length > 1 && (
             <SearchSelect
+              aria-label="Select voter's precinct"
               placeholder="Select voter's precinct…"
               options={configuredPrecinctsAndSplits.map((precinctOrSplit) =>
                 precinctOrSplit.split
@@ -143,6 +148,7 @@ export function BallotStyleSelect(props: BallotStyleSelectProps): JSX.Element {
               value={selectedPrecinctOrSplitId}
               onChange={setSelectedPrecinctOrSplitId}
               style={{ width: '100%' }}
+              disabled={disabled}
             />
           )}
 
@@ -165,6 +171,7 @@ export function BallotStyleSelect(props: BallotStyleSelectProps): JSX.Element {
                           ballotStyleId
                         )
                       }
+                      disabled={disabled}
                     >
                       {
                         assertDefined(

--- a/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
@@ -88,6 +88,7 @@ export interface SectionSessionStartProps {
   election: Election;
   onChooseBallotStyle: OnBallotStyleSelect;
   precinctSelection: PrecinctSelection;
+  disabled?: boolean;
 }
 
 function getConfiguredPrecinctsAndSplits(
@@ -103,7 +104,7 @@ function getConfiguredPrecinctsAndSplits(
 export function SectionSessionStart(
   props: SectionSessionStartProps
 ): JSX.Element {
-  const { election, onChooseBallotStyle, precinctSelection } = props;
+  const { election, onChooseBallotStyle, precinctSelection, disabled } = props;
 
   return (
     <VotingSession>
@@ -115,6 +116,7 @@ export function SectionSessionStart(
           precinctSelection
         )}
         onSelect={onChooseBallotStyle}
+        disabled={disabled}
       />
     </VotingSession>
   );


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
