### PR TITLE
VxDesign: Improve resilience to Auth0 outages

### DIFF
--- a/apps/design/backend/migrations/1756159958924_organizations-table.js
+++ b/apps/design/backend/migrations/1756159958924_organizations-table.js
@@ -1,0 +1,45 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { ManagementClient } = require('auth0');
+const { assertDefined } = require('@votingworks/basics');
+
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void>}
+ */
+exports.up = async (pgm) => {
+  pgm.createTable('organizations', {
+    id: { type: 'text', primaryKey: true },
+    name: { type: 'text', notNull: true, unique: true },
+  });
+
+  if (process.env.NODE_ENV === 'production' || process.env.AUTH_ENABLED) {
+    const auth0Client = new ManagementClient({
+      clientId: assertDefined(process.env.AUTH0_CLIENT_ID),
+      clientSecret: assertDefined(process.env.AUTH0_SECRET),
+      domain: assertDefined(process.env.AUTH0_CLIENT_DOMAIN),
+    });
+    const organizations = (await auth0Client.organizations.getAll()).data;
+    for (const org of organizations) {
+      pgm.sql(
+        `INSERT INTO organizations (id, name) VALUES (
+        '${org.id}',
+        '${org.display_name}'
+      )`
+      );
+    }
+  }
+
+  pgm.addConstraint('elections', null, {
+    foreignKeys: {
+      columns: 'org_id',
+      references: 'organizations',
+      onDelete: 'CASCADE',
+    },
+  });
+};

--- a/apps/design/backend/scripts/create_org.ts
+++ b/apps/design/backend/scripts/create_org.ts
@@ -1,6 +1,11 @@
 import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
 import util from 'node:util';
+import { resolve } from 'node:path';
+import { BaseLogger, LogSource } from '@votingworks/logging';
+import { assertDefined } from '@votingworks/basics';
 import { Auth0Client } from '../src/auth0_client';
+import { createWorkspace } from '../src/workspace';
+import { WORKSPACE } from '../src/globals';
 
 const USAGE = `Usage: pnpm create-org [options...] "<name>"
 
@@ -30,11 +35,17 @@ async function main(): Promise<void> {
   }
 
   const auth = Auth0Client.init();
+  const workspace = createWorkspace(
+    resolve(assertDefined(WORKSPACE)),
+    new BaseLogger(LogSource.VxDesignService)
+  );
+
   const org = await auth.createOrg({
     name,
     enableGoogleAuth,
     logoUrl,
   });
+  await workspace.store.cacheOrganizations(await auth.allOrgs());
 
   console.log('✅ Org created:', org);
 }

--- a/apps/design/backend/scripts/create_org.ts
+++ b/apps/design/backend/scripts/create_org.ts
@@ -45,7 +45,7 @@ async function main(): Promise<void> {
     enableGoogleAuth,
     logoUrl,
   });
-  await workspace.store.cacheOrganizations(await auth.allOrgs());
+  await workspace.store.syncOrganizationsCache(await auth.allOrgs());
 
   console.log('✅ Org created:', org);
 }

--- a/apps/design/backend/scripts/create_user.ts
+++ b/apps/design/backend/scripts/create_user.ts
@@ -28,9 +28,9 @@ async function main(): Promise<void> {
 
   const auth = Auth0Client.init();
   try {
-    const { orgName } = await auth.createUser({ orgId, userEmail });
+    await auth.createUser({ orgId, userEmail });
 
-    console.log(`✅ User created and added to org '${orgName}'`);
+    console.log(`✅ User created and added to org ${orgId}`);
   } catch (error) {
     if (!(error instanceof ManagementApiError)) {
       throw error;
@@ -41,9 +41,9 @@ async function main(): Promise<void> {
     // idempotent.
     if ((error.statusCode as ErrorCode) === ErrorCode.ALREADY_EXISTS) {
       console.log('User already exists. Attempting to add to org...');
-      const { orgName } = await auth.addOrgMember({ orgId, userEmail });
+      await auth.addOrgMember({ orgId, userEmail });
 
-      console.log(`✅ Existing user added to org '${orgName}'`);
+      console.log(`✅ Existing user added to org ${orgId}`);
     }
   }
 }

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -3246,24 +3246,24 @@ test('getUser', async () => {
   expect(await apiClient.getUser()).toEqual(nonVxUser);
 });
 
-test('getAllOrgs', async () => {
+test('listOrganizations', async () => {
   const { apiClient, auth0 } = await setupApp(orgs);
   await suppressingConsoleOutput(() =>
-    expect(apiClient.getAllOrgs()).rejects.toThrow('auth:unauthorized')
+    expect(apiClient.listOrganizations()).rejects.toThrow('auth:unauthorized')
   );
   auth0.setLoggedInUser(vxUser);
-  expect(await apiClient.getAllOrgs()).toEqual(orgs);
+  expect(await apiClient.listOrganizations()).toEqual(orgs);
   auth0.setLoggedInUser(nonVxUser);
   await suppressingConsoleOutput(() =>
-    expect(apiClient.getAllOrgs()).rejects.toThrow('auth:forbidden')
+    expect(apiClient.listOrganizations()).rejects.toThrow('auth:forbidden')
   );
   auth0.setLoggedInUser(sliUser);
   await suppressingConsoleOutput(() =>
-    expect(apiClient.getAllOrgs()).rejects.toThrow('auth:forbidden')
+    expect(apiClient.listOrganizations()).rejects.toThrow('auth:forbidden')
   );
   auth0.setLoggedInUser(vxDemosUser);
   await suppressingConsoleOutput(() =>
-    expect(apiClient.getAllOrgs()).rejects.toThrow('auth:forbidden')
+    expect(apiClient.listOrganizations()).rejects.toThrow('auth:forbidden')
   );
 });
 

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -100,7 +100,7 @@ import { generateBallotStyles } from './ballot_styles';
 import { BackgroundTaskMetadata } from './store';
 import { join } from 'node:path';
 import { electionFeatureConfigs, userFeatureConfigs } from './features';
-import { sliOrgId, vxDemosOrgId } from './globals';
+import { sliOrgId, votingWorksOrgId, vxDemosOrgId } from './globals';
 import { LogEventId } from '@votingworks/logging';
 import { buildApi } from './app';
 import { readdir, readFile } from 'node:fs/promises';
@@ -117,43 +117,57 @@ function compareName(a: { name: string }, b: { name: string }) {
   return a.name.localeCompare(b.name);
 }
 
+const vxOrg: Org = {
+  id: votingWorksOrgId(),
+  name: 'VotingWorks',
+};
 const vxUser: User = {
   name: 'vx.user@example.com',
   auth0Id: 'auth0|vx-user-id',
-  orgId: 'votingworks',
-  orgName: 'VotingWorks',
+  orgId: vxOrg.id,
+};
+
+const nonVxOrg: Org = {
+  id: 'other-org-id',
+  name: 'Other Org',
 };
 const nonVxUser: User = {
   name: 'non.vx.user@example.com',
   auth0Id: 'auth0|non-vx-user-id',
-  orgId: '123',
-  orgName: 'Other Org',
+  orgId: nonVxOrg.id,
+};
+
+const anotherNonVxOrg: Org = {
+  id: 'another-org-id',
+  name: 'Another Org',
 };
 const anotherNonVxUser = {
   ...nonVxUser,
   auth0Id: 'auth0|another-non-vx-user-id',
-  orgId: 'another-org-id',
-  orgName: 'Another Org',
+  orgId: anotherNonVxOrg.id,
+};
+
+const sliOrg: Org = {
+  id: sliOrgId(),
+  name: 'SLI',
 };
 const sliUser: User = {
   name: 'sli.user@example.com',
   auth0Id: 'auth0|sli-user-id',
-  orgId: sliOrgId(),
-  orgName: 'SLI',
+  orgId: sliOrg.id,
+};
+
+const vxDemosOrg: Org = {
+  id: vxDemosOrgId(),
+  name: 'VX Demos',
 };
 const vxDemosUser: User = {
   name: 'vx.demos.user@example.com',
   auth0Id: 'auth0|vx-demos-user-id',
-  orgId: vxDemosOrgId(),
-  orgName: 'VX Demos',
+  orgId: vxDemosOrg.id,
 };
-const orgs: Org[] = [
-  { id: vxUser.orgId, name: vxUser.orgName! },
-  { id: nonVxUser.orgId, name: nonVxUser.orgName! },
-  { id: anotherNonVxUser.orgId, name: anotherNonVxUser.orgName! },
-  { id: sliUser.orgId, name: sliUser.orgName! },
-  { id: vxDemosUser.orgId, name: vxDemosUser.orgName! },
-];
+
+const orgs: Org[] = [vxOrg, nonVxOrg, anotherNonVxOrg, sliOrg, vxDemosOrg];
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
@@ -241,7 +255,7 @@ afterEach(() => {
 });
 
 test('all methods require authentication', async () => {
-  const { apiClient, baseUrl, ...context } = await setupApp();
+  const { apiClient, baseUrl, ...context } = await setupApp(orgs);
   await suppressingConsoleOutput(async () => {
     const apiMethodNames = Object.keys(buildApi(context).methods());
     for (const apiMethodName of apiMethodNames) {
@@ -262,8 +276,7 @@ test('all methods require authentication', async () => {
 });
 
 test('create/list/delete elections', async () => {
-  const { apiClient, auth0 } = await setupApp();
-  auth0.setOrgs(orgs);
+  const { apiClient, auth0 } = await setupApp(orgs);
 
   auth0.setLoggedInUser(vxUser);
   expect(await apiClient.listElections()).toEqual([]);
@@ -278,8 +291,8 @@ test('create/list/delete elections', async () => {
   expect(electionId).toEqual(expectedElectionId);
 
   const expectedElectionListing: ElectionListing = {
-    orgId: nonVxUser.orgId,
-    orgName: nonVxUser.orgName!,
+    orgId: nonVxOrg.id,
+    orgName: nonVxOrg.name,
     electionId: expectedElectionId,
     title: '',
     date: DateWithoutTime.today(),
@@ -309,8 +322,8 @@ test('create/list/delete elections', async () => {
   expect(electionId2).toEqual(importedElectionNewId);
 
   const expectedElection2Listing: ElectionListing = {
-    orgId: vxUser.orgId,
-    orgName: vxUser.orgName!,
+    orgId: vxOrg.id,
+    orgName: vxOrg.name,
     electionId: importedElectionNewId,
     title: election2.title,
     date: election2.date,
@@ -520,7 +533,7 @@ test('create/list/delete elections', async () => {
 });
 
 test('update election info', async () => {
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
   auth0.setLoggedInUser(nonVxUser);
 
   const electionId = unsafeParse(ElectionIdSchema, 'election-1');
@@ -613,7 +626,7 @@ test('update election info', async () => {
 });
 
 test('CRUD districts', async () => {
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
     await apiClient.createElection({
@@ -756,7 +769,7 @@ test('CRUD districts', async () => {
 test('deleting a district updates associated precincts', async () => {
   const baseElectionDefinition =
     electionPrimaryPrecinctSplitsFixtures.readElectionDefinition();
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
     await apiClient.loadElection({
@@ -801,7 +814,7 @@ test('deleting a district updates associated precincts', async () => {
 });
 
 test('CRUD precincts', async () => {
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
     await apiClient.createElection({
@@ -1057,7 +1070,7 @@ test('CRUD precincts', async () => {
 });
 
 test('CRUD parties', async () => {
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
     await apiClient.createElection({
@@ -1235,7 +1248,7 @@ test('CRUD parties', async () => {
 test('deleting a party updates associated contests', async () => {
   const baseElectionDefinition =
     electionPrimaryPrecinctSplitsFixtures.readElectionDefinition();
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
     await apiClient.loadElection({
@@ -1266,7 +1279,7 @@ test('deleting a party updates associated contests', async () => {
 });
 
 test('CRUD contests', async () => {
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
     await apiClient.createElection({
@@ -1756,7 +1769,7 @@ test('CRUD contests', async () => {
 });
 
 test('creating/updating contests with candidate rotation', async () => {
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
     await apiClient.createElection({
@@ -1855,7 +1868,7 @@ test('creating/updating contests with candidate rotation', async () => {
 });
 
 test('reordering contests', async () => {
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
     await apiClient.loadElection({
@@ -1903,7 +1916,7 @@ test('reordering contests', async () => {
 });
 
 test('get/update ballot layout', async () => {
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
   auth0.setLoggedInUser(nonVxUser);
   const electionId = unsafeParse(ElectionIdSchema, 'election-1');
   (
@@ -1956,7 +1969,7 @@ test('get/update ballot layout', async () => {
 });
 
 test('get/update system settings', async () => {
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
   auth0.setLoggedInUser(nonVxUser);
   const electionId = unsafeParse(ElectionIdSchema, 'election-1');
   (
@@ -2024,7 +2037,7 @@ test('get/update system settings', async () => {
 });
 
 test('Finalize ballots', async () => {
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
     await apiClient.loadElection({
@@ -2064,7 +2077,7 @@ test('Finalize ballots', async () => {
 });
 
 test('cloneElection', async () => {
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
 
   const srcElectionId = 'election-1' as ElectionId;
   const nonDefaultSystemSettings: SystemSettings = {
@@ -2095,14 +2108,14 @@ test('cloneElection', async () => {
   const newElectionId = await apiClient.cloneElection({
     electionId: srcElectionId,
     destElectionId: 'election-clone-1' as ElectionId,
-    destOrgId: 'dest-org-id',
+    destOrgId: anotherNonVxOrg.id,
   });
   expect(newElectionId).toEqual('election-clone-1');
 
   // Ensure cloned election has the same data with new IDs
   const elections = await apiClient.listElections();
-  expect(elections[0].electionId).toEqual('election-clone-1');
-  expect(elections[0].orgId).toEqual('dest-org-id');
+  expect(elections[0].electionId).toEqual(newElectionId);
+  expect(elections[0].orgId).toEqual(anotherNonVxOrg.id);
 
   const srcElectionInfo = await apiClient.getElectionInfo({
     electionId: srcElectionId,
@@ -2289,7 +2302,7 @@ test('Election package management', async () => {
   const baseElectionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();
   const { apiClient, workspace, fileStorageClient, auth0, baseUrl } =
-    await setupApp();
+    await setupApp(orgs);
 
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
@@ -2458,7 +2471,8 @@ test('Election package and ballots export', async () => {
       AdjudicationReason.UnmarkedWriteIn,
     ],
   };
-  const { apiClient, workspace, fileStorageClient, auth0 } = await setupApp();
+  const { apiClient, workspace, fileStorageClient, auth0 } =
+    await setupApp(orgs);
 
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
@@ -2751,7 +2765,8 @@ test('Election package and ballots export', async () => {
 
 test('Export test decks', async () => {
   const electionDefinition = readElectionTwoPartyPrimaryDefinition();
-  const { apiClient, fileStorageClient, workspace, auth0 } = await setupApp();
+  const { apiClient, fileStorageClient, workspace, auth0 } =
+    await setupApp(orgs);
 
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
@@ -2833,7 +2848,8 @@ test('Export test decks', async () => {
 test('Consistency of ballot hash across exports', async () => {
   const baseElectionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();
-  const { apiClient, workspace, fileStorageClient, auth0 } = await setupApp();
+  const { apiClient, workspace, fileStorageClient, auth0 } =
+    await setupApp(orgs);
 
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
@@ -2891,7 +2907,8 @@ test('Consistency of ballot hash across exports', async () => {
 test('CDF exports', async () => {
   const baseElectionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();
-  const { apiClient, workspace, fileStorageClient, auth0 } = await setupApp();
+  const { apiClient, workspace, fileStorageClient, auth0 } =
+    await setupApp(orgs);
 
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
@@ -2944,7 +2961,8 @@ test('CDF exports', async () => {
 test('export ballots with audit IDs', async () => {
   const baseElectionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();
-  const { apiClient, workspace, fileStorageClient, auth0 } = await setupApp();
+  const { apiClient, workspace, fileStorageClient, auth0 } =
+    await setupApp(orgs);
 
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
@@ -3002,7 +3020,7 @@ test('export ballots with audit IDs', async () => {
 test('getBallotPreviewPdf returns a ballot pdf for precinct with splits', async () => {
   const baseElectionDefinition =
     electionPrimaryPrecinctSplitsFixtures.readElectionDefinition();
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
 
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
@@ -3060,7 +3078,7 @@ test('getBallotPreviewPdf returns a ballot pdf for NH election with split precin
     ...baseElectionDefinition.election,
     state: 'New Hampshire',
   };
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
 
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
@@ -3110,7 +3128,7 @@ test('getBallotPreviewPdf returns a ballot pdf for NH election with split precin
 test('getBallotPreviewPdf returns a ballot pdf for precinct with no split', async () => {
   const baseElectionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
 
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
@@ -3162,7 +3180,8 @@ function mockBallotDocument(): RenderDocument {
 test('setBallotTemplate changes the ballot template used to render ballots', async () => {
   const electionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();
-  const { apiClient, fileStorageClient, workspace, auth0 } = await setupApp();
+  const { apiClient, fileStorageClient, workspace, auth0 } =
+    await setupApp(orgs);
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
     await apiClient.loadElection({
@@ -3217,7 +3236,7 @@ test('setBallotTemplate changes the ballot template used to render ballots', asy
 });
 
 test('getUser', async () => {
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
   await suppressingConsoleOutput(() =>
     expect(apiClient.getUser()).rejects.toThrow('auth:unauthorized')
   );
@@ -3228,11 +3247,10 @@ test('getUser', async () => {
 });
 
 test('getAllOrgs', async () => {
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
   await suppressingConsoleOutput(() =>
     expect(apiClient.getAllOrgs()).rejects.toThrow('auth:unauthorized')
   );
-  auth0.setOrgs(orgs);
   auth0.setLoggedInUser(vxUser);
   expect(await apiClient.getAllOrgs()).toEqual(orgs);
   auth0.setLoggedInUser(nonVxUser);
@@ -3250,7 +3268,7 @@ test('getAllOrgs', async () => {
 });
 
 test('feature configs', async () => {
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
   auth0.setLoggedInUser(vxUser);
   expect(await apiClient.getUserFeatures()).toEqual(userFeatureConfigs.vx);
   auth0.setLoggedInUser(nonVxUser);
@@ -3300,7 +3318,7 @@ test('feature configs', async () => {
 });
 
 test('api call logging', async () => {
-  const { apiClient, logger, auth0 } = await setupApp();
+  const { apiClient, logger, auth0 } = await setupApp(orgs);
   await expect(apiClient.getUser()).rejects.toThrow('auth:unauthorized');
   expect(logger.log).toHaveBeenCalledWith(
     LogEventId.ApiCall,
@@ -3358,7 +3376,7 @@ test('decryptCvrBallotAuditIds', async () => {
   await execFile('zip', ['-r', cvrZipPath, '.'], { cwd: cvrDirectoryPath });
   const cvrZipFileContents = await readFile(cvrZipPath);
 
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
   auth0.setLoggedInUser(nonVxUser);
 
   const decryptedCvrZipContents = await apiClient.decryptCvrBallotAuditIds({

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -179,8 +179,8 @@ export function buildApi({ auth0, logger, workspace, translator }: AppContext) {
 
   const middlewares: grout.Middlewares<ApiContext> = {
     before: [
-      async function loadUser({ request, context }) {
-        const user = await auth0.userFromRequest(request);
+      function loadUser({ request, context }) {
+        const user = auth0.userFromRequest(request);
         if (!user) {
           throw new AuthError('auth:unauthorized');
         }
@@ -860,7 +860,7 @@ export function buildApp(context: AppContext): Application {
 
   app.get('/files/:orgId/:fileName', async (req, res, next) => {
     try {
-      const user = await context.auth0.userFromRequest(req);
+      const user = context.auth0.userFromRequest(req);
       if (!user) {
         throw new AuthError('auth:unauthorized');
       }

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -253,7 +253,7 @@ export function buildApi({ auth0, logger, workspace, translator }: AppContext) {
       const elections = await store.listElections({
         orgId: userFeatures.ACCESS_ALL_ORGS ? undefined : user.orgId,
       });
-      const orgs = await auth0.allOrgs();
+      const orgs = await store.listOrganizations();
       return elections.map((election) => ({
         ...election,
         orgName:
@@ -730,7 +730,7 @@ export function buildApi({ auth0, logger, workspace, translator }: AppContext) {
       if (!userFeaturesConfig.ACCESS_ALL_ORGS) {
         throw new AuthError('auth:forbidden');
       }
-      return auth0.allOrgs();
+      return store.listOrganizations();
     },
 
     getUserFeatures(

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -210,10 +210,10 @@ export function buildApi({ auth0, logger, workspace, translator }: AppContext) {
           }
         }
         const methodsThatHandleAuthThemselves = [
+          'listOrganizations',
           'listElections',
           'getUser',
           'getUserFeatures',
-          'getAllOrgs',
           'decryptCvrBallotAuditIds', // Doesn't need authorization, nothing private accessed
         ];
         assert(methodsThatHandleAuthThemselves.includes(methodName));
@@ -244,6 +244,14 @@ export function buildApi({ auth0, logger, workspace, translator }: AppContext) {
   };
 
   const methods = {
+    listOrganizations(_input: undefined, context: ApiContext): Promise<Org[]> {
+      const userFeaturesConfig = getUserFeaturesConfig(context.user);
+      if (!userFeaturesConfig.ACCESS_ALL_ORGS) {
+        throw new AuthError('auth:forbidden');
+      }
+      return store.listOrganizations();
+    },
+
     async listElections(
       _input: undefined,
       context: ApiContext
@@ -723,14 +731,6 @@ export function buildApi({ auth0, logger, workspace, translator }: AppContext) {
 
     getUser(_input: undefined, context: ApiContext): User {
       return context.user;
-    },
-
-    getAllOrgs(_input: undefined, context: ApiContext): Promise<Org[]> {
-      const userFeaturesConfig = getUserFeaturesConfig(context.user);
-      if (!userFeaturesConfig.ACCESS_ALL_ORGS) {
-        throw new AuthError('auth:forbidden');
-      }
-      return store.listOrganizations();
     },
 
     getUserFeatures(

--- a/apps/design/backend/src/auth0_client.test.ts
+++ b/apps/design/backend/src/auth0_client.test.ts
@@ -132,7 +132,6 @@ test('createUser', async () => {
   expect(result).toEqual<User>({
     name: 'alice@example.com',
     auth0Id: 'new-user',
-    orgName: 'VotingWorks',
     orgId: 'vx',
   });
 
@@ -157,14 +156,6 @@ test('addOrgMember', async () => {
     ])
   );
 
-  mockOrganizations.get.mockResolvedValue(
-    mockApiResponse<GetOrganizations200ResponseOneOfInner>({
-      display_name: 'VotingWorks',
-      id: VX_ORG_ID,
-      name: 'votingworks',
-    })
-  );
-
   mockOrganizations.addMembers.mockResolvedValueOnce(mockApiResponseVoid());
 
   const result = await newClient().addOrgMember({
@@ -175,11 +166,8 @@ test('addOrgMember', async () => {
   expect(result).toEqual<User>({
     name: 'someone@example.com',
     auth0Id: 'existing-user',
-    orgName: 'VotingWorks',
     orgId: 'vx',
   });
-
-  expect(mockOrganizations.get).toHaveBeenCalledWith({ id: 'vx' });
 
   expect(mockOrganizations.addMembers).toHaveBeenCalledWith(
     { id: 'vx' },

--- a/apps/design/backend/src/env.d.ts
+++ b/apps/design/backend/src/env.d.ts
@@ -3,6 +3,7 @@ declare namespace NodeJS {
   export interface ProcessEnv {
     readonly AUTH_ENABLED?: string;
     readonly AUTH0_CLIENT_ID?: string;
+    readonly AUTH0_CLIENT_DOMAIN?: string;
     readonly AUTH0_ISSUER_BASE_URL?: string;
     readonly AUTH0_SECRET?: string;
     readonly AWS_S3_BUCKET_NAME?: string;

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -467,6 +467,20 @@ export class Store {
     );
   }
 
+  async listOrganizations(): Promise<Org[]> {
+    return await this.db.withClient(async (client) => {
+      const orgRows = (
+        await client.query(
+          `
+          select id, name
+          from organizations
+          `
+        )
+      ).rows as Array<{ id: string; name: string }>;
+      return orgRows;
+    });
+  }
+
   async listElections(input: {
     orgId?: string;
   }): Promise<Array<Omit<ElectionListing, 'orgName'>>> {

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -46,6 +46,7 @@ import {
   convertToVxfBallotStyle,
   ElectionInfo,
   ElectionListing,
+  Org,
 } from './types';
 import { generateBallotStyles } from './ballot_styles';
 import { Db } from './db/db';
@@ -425,6 +426,45 @@ export class Store {
 
   static new(logger: BaseLogger): Store {
     return new Store(new Db(logger));
+  }
+
+  /**
+   * Takes the organizations from Auth0 (the source of truth) and caches them in
+   * the database, adding/removing/updating records as necessary.
+   */
+  async cacheOrganizations(organizations: Org[]): Promise<void> {
+    await this.db.withClient((client) =>
+      client.withTransaction(async () => {
+        // Add new orgs or update existing orgs
+        // Relies on invariant that Auth0 org IDs never change
+        for (const org of organizations) {
+          const { rowCount } = await client.query(
+            `
+            insert into organizations (id, name)
+            values ($1, $2)
+            on conflict (id) do update
+            set name = excluded.name
+            `,
+            org.id,
+            org.name
+          );
+          assert(rowCount === 1, `Failed to insert or update org ${org.id}`);
+        }
+
+        if (organizations.length > 0) {
+          // Delete orgs that are no longer in Auth0
+          await client.query(
+            `
+            delete from organizations
+            where not (id = any ($1))
+            `,
+            organizations.map((org) => org.id)
+          );
+        }
+
+        return true;
+      })
+    );
   }
 
   async listElections(input: {

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -432,7 +432,7 @@ export class Store {
    * Takes the organizations from Auth0 (the source of truth) and caches them in
    * the database, adding/removing/updating records as necessary.
    */
-  async cacheOrganizations(organizations: Org[]): Promise<void> {
+  async syncOrganizationsCache(organizations: Org[]): Promise<void> {
     await this.db.withClient((client) =>
       client.withTransaction(async () => {
         // Add new orgs or update existing orgs

--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -63,7 +63,6 @@ export interface User {
   name: string;
   auth0Id: string;
   orgId: string;
-  orgName: string;
 }
 
 export interface Org {

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -59,7 +59,7 @@ class MockAuth0Client implements Auth0ClientInterface {
     return this.orgs.slice();
   }
 
-  async userFromRequest(_req: Request) {
+  userFromRequest(_req: Request) {
     return this.loggedInUser;
   }
 }
@@ -101,13 +101,15 @@ export function testSetupHelpers() {
   });
   const testStore = new TestStore(baseLogger);
 
-  async function setupApp() {
+  async function setupApp(orgs: Org[]) {
     const store = testStore.getStore();
     await testStore.init();
 
     const workspace = createWorkspace(tmp.dirSync().name, baseLogger, store);
 
     const auth0 = new MockAuth0Client();
+    auth0.setOrgs(orgs);
+    await store.cacheOrganizations(orgs);
     const fileStorageClient = new MockFileStorageClient();
     const speechSynthesizer = new GoogleCloudSpeechSynthesizerWithDbCache({
       store,

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -109,7 +109,7 @@ export function testSetupHelpers() {
 
     const auth0 = new MockAuth0Client();
     auth0.setOrgs(orgs);
-    await store.cacheOrganizations(orgs);
+    await store.syncOrganizationsCache(orgs);
     const fileStorageClient = new MockFileStorageClient();
     const speechSynthesizer = new GoogleCloudSpeechSynthesizerWithDbCache({
       store,

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -84,13 +84,13 @@ export const getUser = {
 } as const;
 
 /* istanbul ignore next - @preserve */
-export const getAllOrgs = {
+export const listOrganizations = {
   queryKey(): QueryKey {
-    return ['getAllOrgs'];
+    return ['listOrganizations'];
   },
   useQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getAllOrgs());
+    return useQuery(this.queryKey(), () => apiClient.listOrganizations());
   },
 } as const;
 

--- a/apps/design/frontend/src/app.test.tsx
+++ b/apps/design/frontend/src/app.test.tsx
@@ -44,7 +44,7 @@ test('Shows user info and logout button', async () => {
 test('API errors show an error screen', async () => {
   await suppressingConsoleOutput(async () => {
     mockUserFeatures(apiMock, {});
-    apiMock.getAllOrgs.expectCallWith().resolves([
+    apiMock.listOrganizations.expectCallWith().resolves([
       {
         id: user.orgId,
         name: 'Non-Vx Org',
@@ -88,7 +88,7 @@ test('API unauthorized errors redirect to login', async () => {
 test('API forbidden errors show a page not found error screen', async () => {
   await suppressingConsoleOutput(async () => {
     mockUserFeatures(apiMock, {});
-    apiMock.getAllOrgs.expectCallWith().resolves([
+    apiMock.listOrganizations.expectCallWith().resolves([
       {
         id: user.orgId,
         name: 'Non-Vx Org',

--- a/apps/design/frontend/src/clone_election_button.test.tsx
+++ b/apps/design/frontend/src/clone_election_button.test.tsx
@@ -94,7 +94,10 @@ test('shows org picker when ACCESS_ALL_ORGS feature enabled', async () => {
     <CloneElectionButton election={electionListing(electionRecord)} />
   );
 
-  queryClient.setQueryData(api.getAllOrgs.queryKey(), [VX_ORG, NON_VX_ORG]);
+  queryClient.setQueryData(api.listOrganizations.queryKey(), [
+    VX_ORG,
+    NON_VX_ORG,
+  ]);
 
   userEvent.click(await screen.findButton(`Make a copy of ${election.title}`));
   const modal = screen.getByRole('alertdialog');

--- a/apps/design/frontend/src/elections_screen.test.tsx
+++ b/apps/design/frontend/src/elections_screen.test.tsx
@@ -88,7 +88,7 @@ function renderScreen() {
 
 test('with no elections, creating a new election', async () => {
   apiMock.getUser.expectCallWith().resolves(user);
-  apiMock.getAllOrgs.expectCallWith().resolves([VX_ORG]);
+  apiMock.listOrganizations.expectCallWith().resolves([VX_ORG]);
   apiMock.listElections.expectCallWith().resolves([]);
   const { history } = renderScreen();
   await screen.findByRole('heading', { name: 'Elections' });

--- a/apps/design/frontend/src/org_select.tsx
+++ b/apps/design/frontend/src/org_select.tsx
@@ -10,7 +10,7 @@ export interface OrgSelectProps {
 export function OrgSelect(props: OrgSelectProps): JSX.Element {
   const { disabled, onChange, selectedOrgId } = props;
 
-  const orgs = api.getAllOrgs.useQuery().data;
+  const orgs = api.listOrganizations.useQuery().data;
 
   const options = React.useMemo(
     () =>

--- a/apps/design/frontend/test/api_helpers.tsx
+++ b/apps/design/frontend/test/api_helpers.tsx
@@ -81,5 +81,4 @@ export const user: User = {
   name: 'Test User',
   auth0Id: 'auth0|123456789',
   orgId: 'org1',
-  orgName: 'Test Organization',
 };


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7070

Auth0 is the source of truth for organizations. VxDesign currently loads organizations from the Auth0 API in a few different places:
1. On every API request, load the user's organization name 
2. When listing elections, load each election's organization name
3. When creating/cloning an election, load a list of organizations to select the new election's org (only for users with access to all orgs)

This is problematic if Auth0 has an outage, since it will impede users from using VxDesign (in particular, users that are already logged in and have a stored session cookie). To prevent this, this PR makes a few changes:
1. Stop loading the user's organization name - we weren't actually using it
2. Cache the organizations in the database and load them from there instead as needed

## Demo Video or Screenshot
N/A

## Testing Plan
- Manual testing
- Updated automated tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
