### PR TITLE
USB Handling: fix mount wedge state

### DIFF
--- a/libs/usb-drive/src/block_devices.test.ts
+++ b/libs/usb-drive/src/block_devices.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { promises as fs, PathLike } from 'node:fs';
+import { BlockDeviceInfo, getUsbDriveDeviceInfo } from './block_devices';
+import { exec } from './exec';
+
+const readdirMock = vi.mocked<(path: PathLike) => Promise<string[]>>(
+  fs.readdir
+);
+const readlinkMock = vi.mocked(fs.readlink);
+const execMock = vi.mocked(exec);
+
+vi.mock(
+  import('node:fs'),
+  async (importActual): Promise<typeof import('node:fs')> => {
+    const actual = await importActual();
+    return {
+      ...actual,
+      promises: {
+        ...actual.promises,
+        readdir: vi.fn().mockRejectedValue(new Error('readdir not mocked')),
+        readlink: vi.fn().mockRejectedValue(new Error('readlink not mocked')),
+      },
+    };
+  }
+);
+
+vi.mock(
+  import('./exec.js'),
+  async (importActual): Promise<typeof import('./exec')> => ({
+    ...(await importActual()),
+    exec: vi.fn().mockRejectedValue(new Error('exec not mocked')),
+  })
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function lsblkOutput(devices: Array<Partial<BlockDeviceInfo>> = []) {
+  return {
+    stdout: JSON.stringify({
+      blockdevices: devices.map((device) => ({
+        name: 'sdb1',
+        mountpoint: '/media/usb-drive-sdb1',
+        fstype: 'vfat',
+        fsver: 'FAT32',
+        label: 'VxUSB-00000',
+        type: 'part',
+        ...device,
+      })),
+    }),
+    stderr: '',
+  };
+}
+
+export function mockBlockDeviceOnce(
+  device: Partial<BlockDeviceInfo> = {}
+): void {
+  readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
+  readlinkMock.mockResolvedValueOnce('../../sdb1');
+  execMock.mockResolvedValueOnce(lsblkOutput([device]));
+}
+
+describe('getUsbDriveDeviceInfo', () => {
+  test('returns undefined when no USB devices found', async () => {
+    readdirMock.mockResolvedValueOnce([]);
+
+    expect(await getUsbDriveDeviceInfo()).toBeUndefined();
+  });
+
+  test('returns undefined when no appropriately named USB partitions found', async () => {
+    readdirMock.mockResolvedValueOnce(['usb-other1', 'sata-drive-part1']);
+
+    expect(await getUsbDriveDeviceInfo()).toBeUndefined();
+  });
+
+  test('returns undefined when lsblk fails', async () => {
+    readdirMock.mockResolvedValueOnce(['usb-device-part1']);
+    readlinkMock.mockResolvedValueOnce('../../sdb1');
+    execMock.mockRejectedValueOnce(new Error('lsblk failed'));
+
+    expect(await getUsbDriveDeviceInfo()).toBeUndefined();
+  });
+
+  test('returns undefined when no partition type block devices found', async () => {
+    mockBlockDeviceOnce({
+      type: 'disk', // rather than 'part'
+    });
+
+    const result = await getUsbDriveDeviceInfo();
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined when partition is acting as an LVM', async () => {
+    mockBlockDeviceOnce({
+      fstype: 'LVM2_member',
+      type: 'part',
+    });
+
+    const result = await getUsbDriveDeviceInfo();
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined when found drive is mounted outside /media', async () => {
+    mockBlockDeviceOnce({
+      mountpoint: '/home/user/mount',
+      type: 'part',
+      fstype: 'vfat',
+    });
+
+    const result = await getUsbDriveDeviceInfo();
+
+    expect(result).toBeUndefined();
+  });
+
+  test('returns device info for USB drive', async () => {
+    mockBlockDeviceOnce({
+      name: 'sdb1',
+      mountpoint: '/media/usb-drive-sdb1',
+      fstype: 'vfat',
+      fsver: 'FAT32',
+      label: 'VxUSB-12345',
+      type: 'part',
+    });
+
+    const result = await getUsbDriveDeviceInfo();
+
+    expect(result).toEqual({
+      name: 'sdb1',
+      path: '/dev/sdb1',
+      mountpoint: '/media/usb-drive-sdb1',
+      fstype: 'vfat',
+      fsver: 'FAT32',
+      label: 'VxUSB-12345',
+      type: 'part',
+    });
+
+    expect(readdirMock).toHaveBeenCalledWith('/dev/disk/by-id/');
+    expect(readlinkMock).toHaveBeenCalledWith(
+      '/dev/disk/by-id/usb-foobar-part23'
+    );
+    expect(execMock).toHaveBeenCalledWith('lsblk', [
+      '-J',
+      '-n',
+      '-l',
+      '-o',
+      'NAME,MOUNTPOINT,FSTYPE,FSVER,LABEL,TYPE',
+      '/dev/sdb1',
+    ]);
+  });
+
+  test('handles multiple USB devices and selects first valid data drive', async () => {
+    readdirMock.mockResolvedValueOnce([
+      'usb-device1-part1',
+      'usb-device2-part1',
+      'not-usb-device',
+    ]);
+    readlinkMock.mockResolvedValueOnce('../../sdb1');
+    readlinkMock.mockResolvedValueOnce('../../sdc1');
+    execMock.mockResolvedValueOnce(
+      lsblkOutput([
+        {
+          name: 'sdb1',
+          type: 'disk', // not a valid data drive
+        },
+        {
+          name: 'sdc1',
+          mountpoint: '/media/usb-drive-sdc1',
+          type: 'part',
+          fstype: 'vfat',
+        },
+      ])
+    );
+
+    const result = await getUsbDriveDeviceInfo();
+
+    expect(result).toEqual({
+      name: 'sdc1',
+      path: '/dev/sdc1',
+      mountpoint: '/media/usb-drive-sdc1',
+      fstype: 'vfat',
+      fsver: 'FAT32',
+      label: 'VxUSB-00000',
+      type: 'part',
+    });
+  });
+});

--- a/libs/usb-drive/src/block_devices.ts
+++ b/libs/usb-drive/src/block_devices.ts
@@ -1,0 +1,102 @@
+import { assert } from '@votingworks/basics';
+import makeDebug from 'debug';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { exec } from './exec';
+
+const debug = makeDebug('usb-drive');
+
+export interface BlockDeviceInfo {
+  name: string;
+  path: string;
+  mountpoint: string | null;
+  fstype: string | null;
+  fsver: string | null;
+  label: string | null;
+  type: string;
+}
+
+type RawBlockDevice = Omit<BlockDeviceInfo, 'path'>;
+
+async function getBlockDeviceInfo(
+  devicePaths: string[]
+): Promise<BlockDeviceInfo[]> {
+  assert(devicePaths.length > 0);
+
+  try {
+    const { stdout } = await exec('lsblk', [
+      '-J',
+      '-n',
+      '-l',
+      '-o',
+      ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER', 'LABEL', 'TYPE'].join(','),
+      ...devicePaths,
+    ]);
+    const rawData = JSON.parse(stdout) as {
+      blockdevices: RawBlockDevice[];
+    };
+    debug(`Got block device info for ${devicePaths.length} devices: ${stdout}`);
+    return rawData.blockdevices.map((rawBlockDevice) => ({
+      ...rawBlockDevice,
+      path: join('/dev', rawBlockDevice.name),
+    }));
+  } catch (error) {
+    debug(`Error getting block device info: ${error}`);
+    return [];
+  }
+}
+
+async function findUsbDriveDevices(): Promise<string[]> {
+  const DEVICE_ID_PATH_PREFIX = '/dev/disk/by-id/';
+  const USB_DEVICE_ID_REGEXP = /^usb(.+)part(.*)$/;
+
+  // List devices, filtering to only the USB partitions
+  const devicesById = (await fs.readdir(DEVICE_ID_PATH_PREFIX)).filter((name) =>
+    USB_DEVICE_ID_REGEXP.test(name)
+  );
+
+  return Promise.all(
+    devicesById.map(async (deviceId) =>
+      join(
+        DEVICE_ID_PATH_PREFIX,
+        await fs.readlink(join(DEVICE_ID_PATH_PREFIX, deviceId))
+      )
+    )
+  );
+}
+
+const DEFAULT_MEDIA_MOUNT_DIR = '/media';
+
+function isDataUsbDrive(blockDeviceInfo: BlockDeviceInfo): boolean {
+  return (
+    blockDeviceInfo.type === 'part' && // disk partitions only, no disks or logical volumes
+    !blockDeviceInfo.fstype?.includes('LVM') && // no partitions acting as LVMs
+    (!blockDeviceInfo.mountpoint ||
+      blockDeviceInfo.mountpoint.startsWith(DEFAULT_MEDIA_MOUNT_DIR))
+  );
+}
+
+/**
+ * Returns the device info for the USB drive, if it's a removable data drive.
+ * In the case of multiple USB drives, returns the first one enumerated by
+ * lsblk.
+ */
+export async function getUsbDriveDeviceInfo(): Promise<
+  BlockDeviceInfo | undefined
+> {
+  const devicePaths = await findUsbDriveDevices();
+  if (devicePaths.length === 0) {
+    debug(`No USB drives detected`);
+    return undefined;
+  }
+
+  const blockDeviceInfos = await getBlockDeviceInfo(devicePaths);
+  const dataUsbBlockDeviceInfo = blockDeviceInfos.find(isDataUsbDrive);
+  if (!dataUsbBlockDeviceInfo) {
+    debug(`USB drive detected, but it's not mounted as a removable data drive`);
+    return undefined;
+  }
+
+  debug(`Detected USB drive at ${dataUsbBlockDeviceInfo.path}`);
+  return dataUsbBlockDeviceInfo;
+}

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { promises as fs, existsSync, rmSync, PathLike } from 'node:fs';
+import { existsSync, rmSync } from 'node:fs';
 import { deferred } from '@votingworks/basics';
 import { backendWaitFor } from '@votingworks/test-utils';
 import { join } from 'node:path';
@@ -10,39 +10,22 @@ import {
 } from '@votingworks/utils';
 import { PromiseWithChild } from 'node:child_process';
 import {
-  BlockDeviceInfo,
+  MOUNT_TIMEOUT_MS,
   VX_USB_LABEL_REGEXP,
   detectUsbDrive,
 } from './usb_drive';
 import { exec } from './exec';
-import { UsbDrive, UsbDriveStatus } from './types';
+import { UsbDrive } from './types';
 import {
   DEFAULT_MOCK_USB_DRIVE_DIR,
   MOCK_USB_DRIVE_STATE_FILENAME,
 } from './mocks/file_usb_drive';
+import { BlockDeviceInfo, getUsbDriveDeviceInfo } from './block_devices';
 
 const MOUNT_SCRIPT_PATH = join(__dirname, '../scripts');
 
-const readdirMock = vi.mocked<(path: PathLike) => Promise<string[]>>(
-  fs.readdir
-);
-const readlinkMock = vi.mocked(fs.readlink);
 const execMock = vi.mocked(exec);
-
-vi.mock(
-  import('node:fs'),
-  async (importActual): Promise<typeof import('node:fs')> => {
-    const actual = await importActual();
-    return {
-      ...actual,
-      promises: {
-        ...actual.promises,
-        readdir: vi.fn().mockRejectedValue(new Error('readdir not mocked')),
-        readlink: vi.fn().mockRejectedValue(new Error('readlink not mocked')),
-      },
-    };
-  }
-);
+const getUsbDriveDeviceInfoMock = vi.mocked(getUsbDriveDeviceInfo);
 
 vi.mock(
   import('./exec.js'),
@@ -62,32 +45,29 @@ vi.mock(
   })
 );
 
+vi.mock('./block_devices', async (importActual) => ({
+  ...(await importActual()),
+  getUsbDriveDeviceInfo: vi.fn().mockResolvedValue(undefined),
+}));
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.unstubAllEnvs();
 });
 
-function lsblkOutput(devices: Array<Partial<BlockDeviceInfo>> = []) {
+function mockBlockDeviceInfo(
+  blockDeviceInfo: Partial<BlockDeviceInfo> = {}
+): BlockDeviceInfo {
   return {
-    stdout: JSON.stringify({
-      blockdevices: devices.map((device) => ({
-        name: 'sdb1',
-        mountpoint: '/media/usb-drive-sdb1',
-        fstype: 'vfat',
-        fsver: 'FAT32',
-        label: 'VxUSB-00000',
-        type: 'part',
-        ...device,
-      })),
-    }),
-    stderr: '',
+    name: 'sdb1',
+    path: '/dev/sdb1',
+    mountpoint: '/media/usb-drive-sdb1',
+    fstype: 'vfat',
+    fsver: 'FAT32',
+    label: 'VxUSB-00000',
+    type: 'part',
+    ...blockDeviceInfo,
   };
-}
-
-function mockBlockDeviceOnce(device: Partial<BlockDeviceInfo> = {}): void {
-  readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
-  readlinkMock.mockResolvedValueOnce('../../sdb1');
-  execMock.mockResolvedValueOnce(lsblkOutput([device]));
 }
 
 /**
@@ -96,24 +76,19 @@ function mockBlockDeviceOnce(device: Partial<BlockDeviceInfo> = {}): void {
  * was released.
  */
 async function confirmLockReleased(usbDrive: UsbDrive) {
+  // confirm that no lock is held on the drive status and it freely changes
+
   // reset to no drive
-  readdirMock.mockResolvedValueOnce([]);
+  getUsbDriveDeviceInfoMock.mockResolvedValue(undefined);
   await expect(usbDrive.status()).resolves.toEqual({ status: 'no_drive' });
 
-  // insert a drive that should be mounted
-  mockBlockDeviceOnce({ mountpoint: null, name: 'confirm-mount' });
-  execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
-  await expect(usbDrive.status()).resolves.toEqual({ status: 'no_drive' });
-  await vi.waitFor(() => {
-    expect(vi.mocked(exec)).toHaveBeenLastCalledWith('sudo', [
-      '-n',
-      `${MOUNT_SCRIPT_PATH}/mount.sh`,
-      '/dev/confirm-mount',
-    ]);
-  }); // mount script was called, so action state was not locked
-
-  // reset action state by completing mount via status check
-  mockBlockDeviceOnce({ mountpoint: '/media/vx/usb-drive' });
+  // confirm we detect a mounted drive
+  getUsbDriveDeviceInfoMock.mockResolvedValue(
+    mockBlockDeviceInfo({
+      mountpoint: '/media/vx/usb-drive',
+      path: '/dev/lock-check',
+    })
+  );
   await expect(usbDrive.status()).resolves.toEqual({
     status: 'mounted',
     mountPoint: '/media/vx/usb-drive',
@@ -122,62 +97,11 @@ async function confirmLockReleased(usbDrive: UsbDrive) {
 
 describe('status', () => {
   test('no drive', async () => {
-    const logger = mockLogger({
-      source: LogSource.VxAdminFrontend,
-      role: 'election_manager',
-      fn: vi.fn,
-    });
-    const usbDrive = detectUsbDrive(logger);
-
-    readdirMock.mockResolvedValueOnce([]);
-
-    await expect(usbDrive.status()).resolves.toEqual({
-      status: 'no_drive',
-    });
-
-    expect(vi.mocked(fs.readdir)).toHaveBeenCalledWith('/dev/disk/by-id/');
-  });
-
-  test('completely ignores invalid devices', async () => {
     const logger = mockLogger({ fn: vi.fn });
     const usbDrive = detectUsbDrive(logger);
 
-    readdirMock.mockResolvedValue(['usb-foobar-part23']);
-    readlinkMock.mockResolvedValue('../../sdb1');
-    execMock.mockResolvedValueOnce(
-      lsblkOutput([
-        {
-          fstype: 'LVM2',
-        },
-      ])
-    );
-    await expect(usbDrive.status()).resolves.toEqual({
-      status: 'no_drive',
-    });
+    getUsbDriveDeviceInfoMock.mockResolvedValueOnce(undefined);
 
-    readdirMock.mockResolvedValue(['usb-foobar-part23']);
-    readlinkMock.mockResolvedValue('../../sdb1');
-    execMock.mockResolvedValueOnce(
-      lsblkOutput([
-        {
-          type: 'lvm',
-        },
-      ])
-    );
-    await expect(usbDrive.status()).resolves.toEqual({
-      status: 'no_drive',
-    });
-
-    readdirMock.mockResolvedValue(['usb-foobar-part23']);
-    readlinkMock.mockResolvedValue('../../sdb1');
-    execMock.mockResolvedValueOnce(
-      lsblkOutput([
-        {
-          fstype: null,
-          mountpoint: '/',
-        },
-      ])
-    );
     await expect(usbDrive.status()).resolves.toEqual({
       status: 'no_drive',
     });
@@ -187,77 +111,46 @@ describe('status', () => {
     const logger = mockLogger({ fn: vi.fn });
     const usbDrive = detectUsbDrive(logger);
 
-    readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
-    readlinkMock.mockResolvedValueOnce('../../sdb1');
-    execMock.mockResolvedValueOnce(
-      lsblkOutput([{ mountpoint: '/media/usb-drive-sdb1' }])
+    getUsbDriveDeviceInfoMock.mockResolvedValue(
+      mockBlockDeviceInfo({ mountpoint: '/media/usb-drive-sdb1' })
     );
 
     await expect(usbDrive.status()).resolves.toEqual({
       status: 'mounted',
       mountPoint: '/media/usb-drive-sdb1',
     });
-
-    expect(vi.mocked(fs.readdir)).toHaveBeenCalledWith('/dev/disk/by-id/');
-    expect(vi.mocked(fs.readlink)).toHaveBeenCalledWith(
-      '/dev/disk/by-id/usb-foobar-part23'
-    );
-    expect(vi.mocked(exec)).toHaveBeenCalledWith('lsblk', [
-      '-J',
-      '-n',
-      '-l',
-      '-o',
-      ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER', 'LABEL', 'TYPE'].join(','),
-      '/dev/sdb1',
-    ]);
   });
 
   test('one drive, unmounted', async () => {
     const logger = mockLogger({ fn: vi.fn });
     const usbDrive = detectUsbDrive(logger);
 
-    readdirMock.mockResolvedValue(['usb-foobar-part23']);
-    readlinkMock.mockResolvedValue('../../sdb1');
-    // Initial status
-    execMock.mockResolvedValueOnce(lsblkOutput([{ mountpoint: null }]));
-    // Mount
+    // device is initially unmounted, then mounted
+    getUsbDriveDeviceInfoMock.mockResolvedValueOnce(
+      mockBlockDeviceInfo({ mountpoint: null })
+    );
+    getUsbDriveDeviceInfoMock.mockResolvedValue(
+      mockBlockDeviceInfo({ mountpoint: '/media/vx/usb-drive' })
+    );
+
+    // mock mount script
     execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
-    // While mounting, status is 'no_drive'
+    // first call triggers the mount and returns no_drive
     await expect(usbDrive.status()).resolves.toEqual({ status: 'no_drive' });
 
-    // Status after mount
-    execMock.mockResolvedValueOnce(
-      lsblkOutput([{ mountpoint: '/media/vx/usb-drive' }])
-    );
+    // second call returns mounted
     await expect(usbDrive.status()).resolves.toEqual({
       status: 'mounted',
       mountPoint: '/media/vx/usb-drive',
     });
 
-    expect(vi.mocked(exec)).toHaveBeenNthCalledWith(1, 'lsblk', [
-      '-J',
-      '-n',
-      '-l',
-      '-o',
-      ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER', 'LABEL', 'TYPE'].join(','),
-      '/dev/sdb1',
-    ]);
-    expect(vi.mocked(exec)).toHaveBeenNthCalledWith(2, 'sudo', [
+    expect(vi.mocked(exec)).toHaveBeenNthCalledWith(1, 'sudo', [
       '-n',
       `${MOUNT_SCRIPT_PATH}/mount.sh`,
       '/dev/sdb1',
     ]);
-    expect(vi.mocked(exec)).toHaveBeenNthCalledWith(3, 'lsblk', [
-      '-J',
-      '-n',
-      '-l',
-      '-o',
-      ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER', 'LABEL', 'TYPE'].join(','),
-      '/dev/sdb1',
-    ]);
 
-    // check logging
     expect(logger.log).toHaveBeenNthCalledWith(
       1,
       LogEventId.UsbDriveMountInit,
@@ -273,98 +166,14 @@ describe('status', () => {
     await confirmLockReleased(usbDrive);
   });
 
-  test('multiple usb devices - selects first valid', async () => {
-    const testCases: Array<{
-      sdb1: Partial<BlockDeviceInfo>;
-      sdc1: Partial<BlockDeviceInfo>;
-      expectedStatus: UsbDriveStatus;
-      newMountPoint?: string;
-    }> = [
-      {
-        sdb1: { mountpoint: '/media/usb-drive-sdb1' },
-        sdc1: { mountpoint: '/media/usb-drive-sdc1' },
-        expectedStatus: {
-          status: 'mounted',
-          mountPoint: '/media/usb-drive-sdb1',
-        },
-      },
-      {
-        sdb1: { mountpoint: undefined },
-        sdc1: { mountpoint: '/media/usb-drive-sdc1' },
-        expectedStatus: { status: 'no_drive' },
-        newMountPoint: '/dev/sdb1',
-      },
-      {
-        sdb1: { mountpoint: '/' },
-        sdc1: { mountpoint: '/media/usb-drive-sdc1' },
-        expectedStatus: {
-          status: 'mounted',
-          mountPoint: '/media/usb-drive-sdc1',
-        },
-      },
-      {
-        sdb1: { mountpoint: '/' },
-        sdc1: { mountpoint: undefined },
-        expectedStatus: { status: 'no_drive' },
-        newMountPoint: '/dev/sdc1',
-      },
-    ];
-
-    for (const testCase of testCases) {
-      const logger = mockLogger({ fn: vi.fn });
-      const usbDrive = detectUsbDrive(logger);
-      readdirMock.mockResolvedValue([
-        'notausb-bazbar-part21', // this device should be ignored
-        'usb-foobar-part23',
-        'usb-babar-part3',
-      ]);
-      readlinkMock.mockResolvedValueOnce('../../sdb1');
-      readlinkMock.mockResolvedValueOnce('../../sdc1');
-      execMock.mockResolvedValueOnce(
-        lsblkOutput([
-          { ...testCase.sdb1, name: 'sdb1' },
-          { ...testCase.sdc1, name: 'sdc1' },
-        ])
-      );
-      await expect(usbDrive.status()).resolves.toEqual(testCase.expectedStatus);
-
-      if (testCase.newMountPoint) {
-        await backendWaitFor(() => {
-          expect(vi.mocked(exec)).toHaveBeenLastCalledWith('sudo', [
-            '-n',
-            `${MOUNT_SCRIPT_PATH}/mount.sh`,
-            testCase.newMountPoint,
-          ]);
-        });
-      }
-    }
-  });
-
-  test('error getting block device info', async () => {
-    const logger = mockLogger({ fn: vi.fn });
-    const usbDrive = detectUsbDrive(logger);
-
-    readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
-    readlinkMock.mockResolvedValueOnce('../../sdb1');
-    execMock.mockRejectedValue(new Error('Failed to get block device info'));
-
-    await expect(usbDrive.status()).resolves.toEqual({
-      status: 'no_drive',
-    });
-  });
-
   test('bad format', async () => {
     const logger = mockLogger({ fn: vi.fn });
     const usbDrive = detectUsbDrive(logger);
 
-    readdirMock.mockResolvedValue(['usb-foobar-part23']);
-    readlinkMock.mockResolvedValue('../../sdb1');
-    execMock.mockResolvedValueOnce(
-      lsblkOutput([
-        {
-          fstype: 'exfat',
-        },
-      ])
+    getUsbDriveDeviceInfoMock.mockResolvedValue(
+      mockBlockDeviceInfo({
+        fstype: 'exfat',
+      })
     );
 
     await expect(usbDrive.status()).resolves.toEqual({
@@ -372,12 +181,10 @@ describe('status', () => {
       reason: 'bad_format',
     });
 
-    execMock.mockResolvedValueOnce(
-      lsblkOutput([
-        {
-          fsver: 'EXFAT',
-        },
-      ])
+    getUsbDriveDeviceInfoMock.mockResolvedValue(
+      mockBlockDeviceInfo({
+        fstype: 'EXFAT',
+      })
     );
 
     await expect(usbDrive.status()).resolves.toEqual({
@@ -390,26 +197,55 @@ describe('status', () => {
     const logger = mockLogger({ fn: vi.fn });
     const usbDrive = detectUsbDrive(logger);
 
-    readdirMock.mockResolvedValue(['usb-foobar-part23']);
-    readlinkMock.mockResolvedValue('../../sdb1');
-    // Initial status
-    execMock.mockResolvedValueOnce(lsblkOutput([{ mountpoint: null }]));
-    // Mount
+    getUsbDriveDeviceInfoMock.mockResolvedValue(
+      mockBlockDeviceInfo({ mountpoint: null })
+    );
+
+    // mock mount script failing
     execMock.mockRejectedValueOnce(new Error('Failed'));
 
-    // While mounting, status is 'no_drive'
+    // first call triggers the mount and returns no_drive
+    await expect(usbDrive.status()).resolves.toEqual({ status: 'no_drive' });
+
+    // second call is still no_drive because the mount failed
     await expect(usbDrive.status()).resolves.toEqual({ status: 'no_drive' });
 
     // check logging
-    await backendWaitFor(() => {
-      expect(logger.log).toHaveBeenCalledWith(
-        LogEventId.UsbDriveMounted,
-        'system',
-        expect.objectContaining({ disposition: 'failure' })
-      );
-    });
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.UsbDriveMounted,
+      'system',
+      expect.objectContaining({ disposition: 'failure' })
+    );
 
     await confirmLockReleased(usbDrive);
+  });
+
+  test('if mount succeeds but mount point is not found, release lock', async () => {
+    vi.useFakeTimers();
+    const logger = mockLogger({ fn: vi.fn });
+    const usbDrive = detectUsbDrive(logger);
+
+    // mock an unmounted drive that is not found after mounting
+    getUsbDriveDeviceInfoMock.mockResolvedValueOnce(
+      mockBlockDeviceInfo({ mountpoint: null })
+    );
+    getUsbDriveDeviceInfoMock.mockResolvedValue(undefined);
+
+    // mock mount script
+    execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    // first call triggers the mount and returns no_drive
+    await expect(usbDrive.status()).resolves.toEqual({ status: 'no_drive' });
+
+    // status locked to no_drive while waiting for mount point
+    await expect(usbDrive.status()).resolves.toEqual({ status: 'no_drive' });
+    await expect(confirmLockReleased(usbDrive)).rejects.toThrow();
+
+    // after timeout, lock is released
+    vi.advanceTimersByTime(MOUNT_TIMEOUT_MS);
+    await confirmLockReleased(usbDrive);
+
+    vi.useRealTimers();
   });
 });
 
@@ -418,7 +254,7 @@ describe('eject', () => {
     const logger = mockLogger({ fn: vi.fn });
     const usbDrive = detectUsbDrive(logger);
 
-    readdirMock.mockResolvedValueOnce([]);
+    getUsbDriveDeviceInfoMock.mockResolvedValue(undefined);
 
     await expect(usbDrive.eject()).resolves.toBeUndefined();
   });
@@ -427,7 +263,9 @@ describe('eject', () => {
     const logger = mockLogger({ fn: vi.fn });
     const usbDrive = detectUsbDrive(logger);
 
-    mockBlockDeviceOnce({ mountpoint: null });
+    getUsbDriveDeviceInfoMock.mockResolvedValueOnce(
+      mockBlockDeviceInfo({ mountpoint: null })
+    );
 
     await expect(usbDrive.eject()).resolves.toBeUndefined();
   });
@@ -440,24 +278,26 @@ describe('eject', () => {
     });
     const usbDrive = detectUsbDrive(logger);
 
-    mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
+    // mock drive that is mounted, then unmounted
+    getUsbDriveDeviceInfoMock.mockResolvedValueOnce(
+      mockBlockDeviceInfo({ mountpoint: '/media/usb-drive-sdb1' })
+    );
+    getUsbDriveDeviceInfoMock.mockResolvedValue(
+      mockBlockDeviceInfo({ mountpoint: undefined })
+    );
 
-    // Unmount
+    // mock unmount script
     execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
     await expect(usbDrive.eject()).resolves.toBeUndefined();
+    await expect(usbDrive.status()).resolves.toEqual({ status: 'ejected' });
 
-    expect(vi.mocked(exec)).toHaveBeenNthCalledWith(2, 'sudo', [
+    expect(vi.mocked(exec)).toHaveBeenNthCalledWith(1, 'sudo', [
       '-n',
       `${MOUNT_SCRIPT_PATH}/unmount.sh`,
       '/media/usb-drive-sdb1',
     ]);
 
-    mockBlockDeviceOnce({ mountpoint: null });
-
-    await expect(usbDrive.status()).resolves.toEqual({ status: 'ejected' });
-
-    // check logging
     expect(logger.log).toHaveBeenNthCalledWith(
       1,
       LogEventId.UsbDriveEjectInit,
@@ -481,9 +321,11 @@ describe('eject', () => {
     });
     const usbDrive = detectUsbDrive(logger);
 
-    mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
+    getUsbDriveDeviceInfoMock.mockResolvedValueOnce(
+      mockBlockDeviceInfo({ mountpoint: '/media/usb-drive-sdb1' })
+    );
 
-    // Unmount
+    // mock unmount script failing
     execMock.mockRejectedValueOnce(new Error('Failed'));
 
     await expect(usbDrive.eject()).rejects.toThrowError(new Error('Failed'));
@@ -496,13 +338,44 @@ describe('eject', () => {
 
     await confirmLockReleased(usbDrive);
   });
+
+  test('no-op if already ejecting', async () => {
+    const logger = mockLogger({ fn: vi.fn });
+    const usbDrive = detectUsbDrive(logger);
+
+    getUsbDriveDeviceInfoMock.mockResolvedValueOnce(
+      mockBlockDeviceInfo({ mountpoint: '/media/usb-drive-sdb1' })
+    );
+    const { promise: ejectScriptPromise, resolve: ejectScriptResolve } =
+      deferred<{
+        stdout: string;
+        stderr: string;
+      }>();
+    execMock.mockReturnValueOnce(
+      ejectScriptPromise as PromiseWithChild<{
+        stdout: string;
+        stderr: string;
+      }>
+    ); // mock eject script
+
+    const ejectPromise = usbDrive.eject();
+
+    // can call eject again, which will be a no-op and resolve because the
+    // first eject is still running
+    await usbDrive.eject(); // no-op
+
+    ejectScriptResolve({ stdout: '', stderr: '' });
+    await ejectPromise;
+
+    await confirmLockReleased(usbDrive);
+  });
 });
 
 describe('format', () => {
   test('no drive - no op', async () => {
     const logger = mockLogger({ fn: vi.fn });
     const usbDrive = detectUsbDrive(logger);
-    readdirMock.mockResolvedValueOnce([]);
+    getUsbDriveDeviceInfoMock.mockResolvedValueOnce(undefined);
 
     await expect(usbDrive.format()).resolves.toBeUndefined();
     expect(vi.mocked(exec)).not.toHaveBeenCalled();
@@ -515,29 +388,33 @@ describe('format', () => {
       fn: vi.fn,
     });
     const usbDrive = detectUsbDrive(logger);
-    mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
-    execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // unmount
-    execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // format
+
+    // mock drive that is mounted, then unmounted
+    getUsbDriveDeviceInfoMock.mockResolvedValueOnce(
+      mockBlockDeviceInfo({ mountpoint: '/media/usb-drive-sdb1' })
+    );
+    getUsbDriveDeviceInfoMock.mockResolvedValue(
+      mockBlockDeviceInfo({ mountpoint: null })
+    );
+    execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // mock unmount script
+    execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // mock format script
 
     // format should call unmount and format scripts
     await usbDrive.format();
-    expect(vi.mocked(exec)).toHaveBeenNthCalledWith(2, 'sudo', [
+    expect(vi.mocked(exec)).toHaveBeenNthCalledWith(1, 'sudo', [
       '-n',
       `${MOUNT_SCRIPT_PATH}/unmount.sh`,
       '/media/usb-drive-sdb1',
     ]);
-    expect(vi.mocked(exec)).toHaveBeenNthCalledWith(3, 'sudo', [
+    expect(vi.mocked(exec)).toHaveBeenNthCalledWith(2, 'sudo', [
       '-n',
       `${MOUNT_SCRIPT_PATH}/format_fat32.sh`,
       '/dev/sdb',
       'VxUSB-00000',
     ]);
 
-    // status should be ejected
-    mockBlockDeviceOnce({ mountpoint: null });
     await expect(usbDrive.status()).resolves.toEqual({ status: 'ejected' });
 
-    // check logging
     expect(logger.log).toHaveBeenNthCalledWith(
       1,
       LogEventId.UsbDriveFormatInit,
@@ -556,20 +433,25 @@ describe('format', () => {
   test('on bad format drive', async () => {
     const logger = mockLogger({ fn: vi.fn });
     const usbDrive = detectUsbDrive(logger);
-    mockBlockDeviceOnce({ fstype: 'exfat', mountpoint: null, label: 'DATA' });
-    execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // format
+
+    // mock drive that is bad format, then unmounted
+    getUsbDriveDeviceInfoMock.mockResolvedValueOnce(
+      mockBlockDeviceInfo({ fstype: 'exfat', mountpoint: null, label: 'DATA' })
+    );
+    getUsbDriveDeviceInfoMock.mockResolvedValue(
+      mockBlockDeviceInfo({ mountpoint: null })
+    );
+    execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // mock format script
 
     // format should call format script only
     await usbDrive.format();
-    expect(vi.mocked(exec)).toHaveBeenNthCalledWith(2, 'sudo', [
+    expect(vi.mocked(exec)).toHaveBeenNthCalledWith(1, 'sudo', [
       '-n',
       `${MOUNT_SCRIPT_PATH}/format_fat32.sh`,
       '/dev/sdb',
       expect.stringMatching(VX_USB_LABEL_REGEXP),
     ]);
 
-    // status should be ejected
-    mockBlockDeviceOnce({ mountpoint: null });
     await expect(usbDrive.status()).resolves.toEqual({ status: 'ejected' });
   });
 
@@ -580,17 +462,20 @@ describe('format', () => {
       fn: vi.fn,
     });
     const usbDrive = detectUsbDrive(logger);
-    mockBlockDeviceOnce({ fstype: 'unknown', mountpoint: null, label: null });
-    execMock.mockRejectedValueOnce(new Error('Command: failed')); // format
 
-    // format should call format script only
+    // mock drive that is unknown format, then unmounted
+    getUsbDriveDeviceInfoMock.mockResolvedValueOnce(
+      mockBlockDeviceInfo({ fstype: 'unknown', mountpoint: null, label: null })
+    );
+    getUsbDriveDeviceInfoMock.mockResolvedValue(
+      mockBlockDeviceInfo({ mountpoint: null })
+    );
+    execMock.mockRejectedValueOnce(new Error('Command: failed')); // mock format script
+
     await expect(usbDrive.format()).rejects.toThrow('Command: failed');
 
-    // status should be ejected
-    mockBlockDeviceOnce({ mountpoint: null });
     await expect(usbDrive.status()).resolves.toEqual({ status: 'ejected' });
 
-    // check logging
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.UsbDriveFormatted,
       'system_administrator',
@@ -603,22 +488,30 @@ describe('format', () => {
   test('status polling while formatting', async () => {
     const logger = mockLogger({ fn: vi.fn });
     const usbDrive = detectUsbDrive(logger);
-    mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
-    execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // unmount
+
+    // mock drive that is mounted, then unmounted
+    getUsbDriveDeviceInfoMock.mockResolvedValueOnce(
+      mockBlockDeviceInfo({ mountpoint: '/media/usb-drive-sdb1' })
+    );
+    getUsbDriveDeviceInfoMock.mockResolvedValue(
+      mockBlockDeviceInfo({ mountpoint: null })
+    );
+    execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // mock unmount script
     const { promise: formatScriptPromise, resolve: formatScriptResolve } =
       deferred<{
         stdout: string;
         stderr: string;
       }>();
-    execMock.mockReturnValue(
+    execMock.mockReturnValueOnce(
       formatScriptPromise as PromiseWithChild<{
         stdout: string;
         stderr: string;
       }>
-    ); // format
+    ); // mock format script
 
     const formatPromise = usbDrive.format();
 
+    // status is locked to ejected while waiting for format to complete
     await backendWaitFor(async () => {
       expect(await usbDrive.status()).toEqual({ status: 'ejected' });
     });
@@ -626,8 +519,44 @@ describe('format', () => {
     formatScriptResolve({ stdout: '', stderr: '' });
     await formatPromise;
 
-    mockBlockDeviceOnce({ mountpoint: null });
     expect(await usbDrive.status()).toEqual({ status: 'ejected' });
+
+    await confirmLockReleased(usbDrive);
+  });
+
+  test('no-op if already formatting', async () => {
+    const logger = mockLogger({ fn: vi.fn });
+    const usbDrive = detectUsbDrive(logger);
+
+    // mock drive that is bad format, then unmounted
+    getUsbDriveDeviceInfoMock.mockResolvedValueOnce(
+      mockBlockDeviceInfo({ fstype: 'exfat', mountpoint: null, label: 'DATA' })
+    );
+    getUsbDriveDeviceInfoMock.mockResolvedValue(
+      mockBlockDeviceInfo({ mountpoint: null })
+    );
+    const { promise: formatScriptPromise, resolve: formatScriptResolve } =
+      deferred<{
+        stdout: string;
+        stderr: string;
+      }>();
+    execMock.mockReturnValueOnce(
+      formatScriptPromise as PromiseWithChild<{
+        stdout: string;
+        stderr: string;
+      }>
+    ); // mock format script
+
+    const formatPromise = usbDrive.format();
+
+    // can call format again, which will be a no-op and resolve because the
+    // first format is still running
+    await usbDrive.format(); // no-op
+
+    formatScriptResolve({ stdout: '', stderr: '' });
+    await formatPromise;
+
+    await confirmLockReleased(usbDrive);
   });
 });
 
@@ -635,7 +564,8 @@ describe('sync', () => {
   test('no drive - no op', async () => {
     const logger = mockLogger({ fn: vi.fn });
     const usbDrive = detectUsbDrive(logger);
-    readdirMock.mockResolvedValueOnce([]);
+
+    getUsbDriveDeviceInfoMock.mockResolvedValueOnce(undefined);
 
     await expect(usbDrive.sync()).resolves.toBeUndefined();
     expect(vi.mocked(exec)).not.toHaveBeenCalled();
@@ -644,52 +574,19 @@ describe('sync', () => {
   test('when mounted, execs sync', async () => {
     const logger = mockLogger({ fn: vi.fn });
     const usbDrive = detectUsbDrive(logger);
-    mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
-    execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // sync
+
+    getUsbDriveDeviceInfoMock.mockResolvedValueOnce(
+      mockBlockDeviceInfo({ mountpoint: '/media/usb-drive-sdb1' })
+    );
+    execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // mock sync script
 
     await usbDrive.sync();
 
-    expect(vi.mocked(exec)).toHaveBeenCalledTimes(2); // status, sync
     expect(vi.mocked(exec)).toHaveBeenLastCalledWith('sync', [
       '-f',
       '/media/usb-drive-sdb1',
     ]);
   });
-});
-
-test('action locking', async () => {
-  const logger = mockLogger({ fn: vi.fn });
-  const usbDrive = detectUsbDrive(logger);
-
-  mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
-  const { promise: unmountPromise, resolve: unmountResolve } = deferred<{
-    stdout: string;
-    stderr: string;
-  }>();
-  execMock.mockReturnValueOnce(
-    unmountPromise as PromiseWithChild<{
-      stdout: string;
-      stderr: string;
-    }>
-  );
-
-  const ejectPromise = usbDrive.eject();
-
-  await backendWaitFor(() => {
-    expect(vi.mocked(exec)).toHaveBeenNthCalledWith(2, 'sudo', [
-      '-n',
-      `${MOUNT_SCRIPT_PATH}/unmount.sh`,
-      '/media/usb-drive-sdb1',
-    ]);
-  });
-
-  mockBlockDeviceOnce({ mountpoint: '/media/usb-drive-sdb1' });
-  await usbDrive.format();
-
-  unmountResolve({ stdout: '', stderr: '' });
-  await ejectPromise;
-
-  expect(vi.mocked(exec)).toHaveBeenCalledTimes(3); // 1 status, 2 unmount, 3 status, no format
 });
 
 test('uses mock file usb drive if environment variable is set', async () => {

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -1,4 +1,3 @@
-import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { assert, assertDefined, sleep } from '@votingworks/basics';
 import makeDebug from 'debug';
@@ -10,96 +9,9 @@ import {
 import { exec } from './exec';
 import { UsbDriveStatus, UsbDrive } from './types';
 import { MockFileUsbDrive } from './mocks/file_usb_drive';
+import { BlockDeviceInfo, getUsbDriveDeviceInfo } from './block_devices';
 
 const debug = makeDebug('usb-drive');
-
-export interface BlockDeviceInfo {
-  name: string;
-  path: string;
-  mountpoint: string | null;
-  fstype: string | null;
-  fsver: string | null;
-  label: string | null;
-  type: string;
-}
-
-type RawBlockDevice = Omit<BlockDeviceInfo, 'path'>;
-
-async function getBlockDeviceInfo(
-  devicePaths: string[]
-): Promise<BlockDeviceInfo[]> {
-  assert(devicePaths.length > 0);
-
-  try {
-    const { stdout } = await exec('lsblk', [
-      '-J',
-      '-n',
-      '-l',
-      '-o',
-      ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER', 'LABEL', 'TYPE'].join(','),
-      ...devicePaths,
-    ]);
-    const rawData = JSON.parse(stdout) as {
-      blockdevices: RawBlockDevice[];
-    };
-    debug(`Got block device info for ${devicePaths.length} devices: ${stdout}`);
-    return rawData.blockdevices.map((rawBlockDevice) => ({
-      ...rawBlockDevice,
-      path: join('/dev', rawBlockDevice.name),
-    }));
-  } catch (error) {
-    debug(`Error getting block device info: ${error}`);
-    return [];
-  }
-}
-
-async function findUsbDriveDevices(): Promise<string[]> {
-  const DEVICE_ID_PATH_PREFIX = '/dev/disk/by-id/';
-  const USB_DEVICE_ID_REGEXP = /^usb(.+)part(.*)$/;
-
-  // List devices, filtering to only the USB partitions
-  const devicesById = (await fs.readdir(DEVICE_ID_PATH_PREFIX)).filter((name) =>
-    USB_DEVICE_ID_REGEXP.test(name)
-  );
-
-  return Promise.all(
-    devicesById.map(async (deviceId) =>
-      join(
-        DEVICE_ID_PATH_PREFIX,
-        await fs.readlink(join(DEVICE_ID_PATH_PREFIX, deviceId))
-      )
-    )
-  );
-}
-
-const DEFAULT_MEDIA_MOUNT_DIR = '/media';
-
-function isDataUsbDrive(blockDeviceInfo: BlockDeviceInfo): boolean {
-  return (
-    blockDeviceInfo.type === 'part' && // disk partitions only, no disks or logical volumes
-    !blockDeviceInfo.fstype?.includes('LVM') && // no partitions acting as LVMs
-    (!blockDeviceInfo.mountpoint ||
-      blockDeviceInfo.mountpoint.startsWith(DEFAULT_MEDIA_MOUNT_DIR))
-  );
-}
-
-async function getUsbDriveDeviceInfo(): Promise<BlockDeviceInfo | undefined> {
-  const devicePaths = await findUsbDriveDevices();
-  if (devicePaths.length === 0) {
-    debug(`No USB drives detected`);
-    return undefined;
-  }
-
-  const blockDeviceInfos = await getBlockDeviceInfo(devicePaths);
-  const dataUsbBlockDeviceInfo = blockDeviceInfos.find(isDataUsbDrive);
-  if (!dataUsbBlockDeviceInfo) {
-    debug(`USB drive detected, but it's not mounted as a removable data drive`);
-    return undefined;
-  }
-
-  debug(`Detected USB drive at ${dataUsbBlockDeviceInfo.path}`);
-  return dataUsbBlockDeviceInfo;
-}
 
 const MOUNT_SCRIPT_PATH = join(__dirname, '../scripts');
 

--- a/libs/usb-drive/vitest.config.ts
+++ b/libs/usb-drive/vitest.config.ts
@@ -5,10 +5,6 @@ export default defineConfig({
     setupFiles: ['test/setup.ts'],
     coverage: {
       exclude: ['src/cli.ts', 'src/mocks', 'src/**/*.test.ts'],
-      thresholds: {
-        lines: -1,
-        branches: -2,
-      },
     },
   },
 });


### PR DESCRIPTION
## Overview

Closes #7092. The bug is that, when we mount a USB drive, we acquire a lock (mutex) in the `libs/usb-drive` code. For ejecting and formatting, the lock is released in a `finally` block. Since our mounting takes place during a `status` call, which we don't want to hang, we `void` the promise and let the lock persist between calls. The lock is only released once we detect the mount point via `lsblk` and count the drive as mounted, which can take a second. If you remove the USB drive after we successfully mounted i.e. `mount.sh` has exited but _before_ the mount point is detected during `lsblk`, the lock is never released and USB drives cannot be mounted and used until the machine is restarted.

The fix is, as part of our `mount` logic, polling `lsblk` until we get a mount and calling the lock release in all cases. We have to decide how long to wait for a mount point, and I settled on 5 seconds based on my experience of it taking up to a few seconds. What if, on a machine like VSAP, `lsblk` somehow takes longer than 5 seconds? Subsequent polling will trigger re-mounts, which will fail, with errors swallowed and logged. Once the original mount is registered by `lsblk`, the mount point will be seen and it will be mounted. Seems safe to me.

The underlying challenge here is the delay with `lsblk`. According to Linux, the drive is mounted and can be safely used after `mount` exits successfully - we don't have to wait for the `lsblk` status. We do wait for the `lsblk` status to avoid having more internal state. The delay in `lsblk` is due to kernel buffering something something, and it brings me back to wondering whether there's a lower level way to detect USB devices that we should be using. I'm pretty sure we could rewrite this to access the system files like `/sys/class/block` and `/proc/mounts` and we'd mount USB drives and detect changes in general a lot faster. But we might want to save that rewrite for when re-consider polling here or have a larger release.

## Testing Plan

Updated testing. Separated getting USB drive data from the system into a separate file and test suite. Handling everything in one file was making mocking in tests really confusing due to a bunch of different kinds of `exec` calls. With polling, it became impossible.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
