### PR TITLE
VxDesign: Update tests with new param

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -569,6 +569,8 @@ test('update election info', async () => {
     type: 'primary',
     date: new DateWithoutTime('2022-01-01'),
     languageCodes: [LanguageCode.ENGLISH, LanguageCode.SPANISH],
+    signatureCaption: 'New caption',
+    signatureImage: '\r\n<svg>new signature</svg>\r\n',
   };
   await apiClient.updateElectionInfo(electionInfoUpdate);
   expect(await apiClient.getElectionInfo({ electionId })).toEqual<ElectionInfo>(

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -569,8 +569,6 @@ test('update election info', async () => {
     type: 'primary',
     date: new DateWithoutTime('2022-01-01'),
     languageCodes: [LanguageCode.ENGLISH, LanguageCode.SPANISH],
-    signatureCaption: 'New caption',
-    signatureImage: '\r\n<svg>new signature</svg>\r\n',
   };
   await apiClient.updateElectionInfo(electionInfoUpdate);
   expect(await apiClient.getElectionInfo({ electionId })).toEqual<ElectionInfo>(
@@ -583,8 +581,76 @@ test('update election info', async () => {
       type: 'primary',
       date: new DateWithoutTime('2022-01-01'),
       languageCodes: [LanguageCode.ENGLISH, LanguageCode.SPANISH],
-      signatureImage: undefined,
-      signatureCaption: undefined,
+    }
+  );
+
+  // Change to NhBallot to test signature behavior
+  await apiClient.setBallotTemplate({
+    electionId,
+    ballotTemplateId: 'NhBallot',
+  });
+
+  // Election info should be unchanged at first
+  expect(await apiClient.getElectionInfo({ electionId })).toEqual<ElectionInfo>(
+    {
+      electionId,
+      title: 'Updated Election',
+      jurisdiction: 'New Hampshire',
+      state: 'NH',
+      seal: '\r\n<svg>updated seal</svg>\r\n',
+      type: 'primary',
+      date: new DateWithoutTime('2022-01-01'),
+      languageCodes: [LanguageCode.ENGLISH, LanguageCode.SPANISH],
+    }
+  );
+
+  const electionInfoUpdateWithSignature: ElectionInfo = {
+    electionId,
+    title: '   Updated Election  ',
+    jurisdiction: '   New Hampshire   ',
+    state: '   NH   ',
+    seal: '\r\n<svg>updated seal</svg>\r\n',
+    type: 'primary',
+    date: new DateWithoutTime('2022-01-01'),
+    languageCodes: [LanguageCode.ENGLISH, LanguageCode.SPANISH],
+    signatureCaption: 'New Caption',
+    signatureImage: '\r\n<svg>new signature</svg>\r\n',
+  };
+  await apiClient.updateElectionInfo(electionInfoUpdateWithSignature);
+
+  // Signature should be included in response
+  expect(await apiClient.getElectionInfo({ electionId })).toEqual<ElectionInfo>(
+    {
+      electionId,
+      title: 'Updated Election',
+      jurisdiction: 'New Hampshire',
+      state: 'NH',
+      seal: '\r\n<svg>updated seal</svg>\r\n',
+      type: 'primary',
+      date: new DateWithoutTime('2022-01-01'),
+      languageCodes: [LanguageCode.ENGLISH, LanguageCode.SPANISH],
+      signatureCaption: 'New Caption',
+      signatureImage: '\r\n<svg>new signature</svg>\r\n',
+    }
+  );
+
+  // Change to NhBallot to test signature behavior
+  await apiClient.setBallotTemplate({
+    electionId,
+    ballotTemplateId: 'VxDefaultBallot',
+  });
+
+  // Signature should no longer be included in response
+  expect(await apiClient.getElectionInfo({ electionId })).toEqual<ElectionInfo>(
+    {
+      electionId,
+      title: 'Updated Election',
+      jurisdiction: 'New Hampshire',
+      state: 'NH',
+      seal: '\r\n<svg>updated seal</svg>\r\n',
+      type: 'primary',
+      date: new DateWithoutTime('2022-01-01'),
+      languageCodes: [LanguageCode.ENGLISH, LanguageCode.SPANISH],
     }
   );
 

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -2768,7 +2768,8 @@ test('Election package and ballots export', async () => {
 test('Election package export with VxDefaultBallot drops signature field', async () => {
   const baseElectionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();
-  const { apiClient, workspace, fileStorageClient, auth0 } = await setupApp();
+  const { apiClient, workspace, fileStorageClient, auth0 } =
+    await setupApp(orgs);
 
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
@@ -3241,7 +3242,7 @@ test('getBallotPreviewPdf returns a ballot pdf for nh precinct with no split', a
       caption: 'Test Image Caption',
     },
   };
-  const { apiClient, auth0 } = await setupApp();
+  const { apiClient, auth0 } = await setupApp(orgs);
 
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -32,7 +32,6 @@ import {
   CastVoteRecordExportFileName,
   safeParseJson,
   CastVoteRecordReportWithoutMetadataSchema,
-  SignatureSchema,
 } from '@votingworks/types';
 import express, { Application } from 'express';
 import {
@@ -138,7 +137,8 @@ const UpdateElectionInfoInputSchema = z.object({
   state: TextInput,
   jurisdiction: TextInput,
   seal: z.string(),
-  signature: SignatureSchema.optional(),
+  signatureImage: z.string().optional(),
+  signatureCaption: z.string().optional(),
   languageCodes: z.array(LanguageCodeSchema),
 });
 


### PR DESCRIPTION
## Overview

I didn't rebase off of `main` before merging, which resulted in my new tests not having the new param for `setupApp()`, causing main to fail.

## Testing Plan

NA

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
