### PR TITLE
libs/hmpb: Remove duplicate renderer.cleanup() call

### DIFF
--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -471,7 +471,6 @@ export async function renderBallotPreviewToPdf<P extends object>(
     return document;
   }
   const pdf = await document.ok().renderToPdf();
-  await renderer.cleanup();
   return ok(pdf);
 }
 


### PR DESCRIPTION
## Overview
The API method that calls this function already cleans up the renderer. Plus, this method shouldn't cleanup resources that it receives as an argument - those should be the responsibility of the caller.

## Demo Video or Screenshot
N/A

## Testing Plan
Existing tests
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
