### PR TITLE
Kevin/vx mark scan minor cert changes

### DIFF
--- a/apps/mark-scan/frontend/src/pages/diagnostics/accessible_controller_diagnostic_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/diagnostics/accessible_controller_diagnostic_screen.tsx
@@ -174,7 +174,7 @@ export function AccessibleControllerDiagnosticScreen({
         </P>
         {steps[step]}
         <CancelButtonContainer>
-          <Button icon="Delete" onPress={onClose}>
+          <Button icon="Delete" onPress={onClose} variant="danger">
             Cancel Test
           </Button>
         </CancelButtonContainer>

--- a/apps/mark-scan/frontend/src/pages/diagnostics/headphone_input_diagnostic_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/diagnostics/headphone_input_diagnostic_screen.tsx
@@ -77,10 +77,10 @@ export function HeadphoneInputDiagnosticScreen({
           </Button>
         )}
         <ButtonBar style={{ marginTop: '0.5rem' }}>
-          <Button icon="Done" onPress={passTest}>
+          <Button icon="Done" onPress={passTest} variant="primary">
             Sound Is Audible
           </Button>
-          <Button icon="Delete" onPress={failTest}>
+          <Button icon="Delete" onPress={failTest} variant="danger">
             Sound Is Not Audible
           </Button>
         </ButtonBar>

--- a/apps/mark-scan/frontend/src/pages/diagnostics/paper_handler_diagnostic_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/diagnostics/paper_handler_diagnostic_screen.tsx
@@ -20,7 +20,7 @@ export function PaperHandlerDiagnosticScreen({
 
   let contents = <Loading />;
   let closeButton = (
-    <Button icon="Delete" onPress={onClose}>
+    <Button icon="Delete" variant="danger" onPress={onClose}>
       Cancel Test
     </Button>
   );

--- a/apps/mark-scan/frontend/src/pages/pat_device_identification/pat_device_identification_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/pat_device_identification/pat_device_identification_page.tsx
@@ -91,7 +91,7 @@ export function PatDeviceIdentificationPage({
         <Button onPress={onExitCalibration}>
           {isDiagnostic ? (
             <span>
-              <Icons.Delete /> Cancel Test
+              <Icons.Delete color="danger" /> Cancel Test
             </span>
           ) : (
             appStrings.buttonBmdSkipPatCalibration()

--- a/apps/mark-scan/frontend/src/pages/poll_worker_auth_ended_unexpectedly_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_auth_ended_unexpectedly_page.tsx
@@ -4,7 +4,7 @@ import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 export function PollWorkerAuthEndedUnexpectedlyPage(): JSX.Element {
   return (
     <CenteredCardPageLayout
-      icon={<Icons.Warning />}
+      icon={<Icons.Warning color="warning" />}
       title={appStrings.noteBmdSessionRestart()}
       voterFacing={false}
     >

--- a/apps/mark-scan/frontend/src/pages/replace_blank_sheet_page.tsx
+++ b/apps/mark-scan/frontend/src/pages/replace_blank_sheet_page.tsx
@@ -4,7 +4,7 @@ import { CenteredCardPageLayout } from '@votingworks/mark-flow-ui';
 export function ReplaceBlankSheetPage(): JSX.Element {
   return (
     <CenteredCardPageLayout
-      icon={<Icons.Warning />}
+      icon={<Icons.Warning color="warning" />}
       title="Load New Ballot Sheet"
       voterFacing={false}
     >

--- a/apps/scan/frontend/src/components/printer_management/election_manager_printer_tab_content.tsx
+++ b/apps/scan/frontend/src/components/printer_management/election_manager_printer_tab_content.tsx
@@ -40,7 +40,7 @@ function StatusText({ printerStatus }: { printerStatus: PrinterStatus }) {
     case 'idle':
       return (
         <P>
-          <Icons.Done /> The printer is loaded with paper.
+          <Icons.Done color="success" /> The printer is loaded with paper.
         </P>
       );
     /* istanbul ignore next - @preserve */

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -99,7 +99,7 @@ function PrinterAlertText({
   }
   return (
     <P>
-      <Icons.Warning /> {printerSummary.alertText}
+      <Icons.Warning color="warning" /> {printerSummary.alertText}
     </P>
   );
 }
@@ -107,7 +107,7 @@ function PrinterAlertText({
 function UsbDriveAlertText(): JSX.Element {
   return (
     <P>
-      <Icons.Warning /> Insert a USB drive to continue.
+      <Icons.Warning color="warning" /> Insert a USB drive to continue.
     </P>
   );
 }

--- a/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
@@ -5,6 +5,7 @@ import {
   H2,
   H3,
   H4,
+  Icons,
   P,
   SignedHashValidationApiClient,
   SignedHashValidationButton,
@@ -109,6 +110,9 @@ export function SectionSessionStart(
   return (
     <VotingSession>
       <H4 as="h2">Start a New Voting Session</H4>
+      <P>
+        <Icons.Info /> Replace headphone ear covers with a new set.
+      </P>
       <BallotStyleSelect
         election={election}
         configuredPrecinctsAndSplits={getConfiguredPrecinctsAndSplits(


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6766
Preparation for https://github.com/votingworks/vxsuite/issues/6767

1. Adds instructions to mark-flow-ui to replace headphone covers. See discussion: https://votingworks.slack.com/archives/C0230JPBQKS/p1756505955244839
2. Adds appropriate color to icons and buttons with icons that lacked them. Does not yet update for high-contrast compliance.


## Demo Video or Screenshot


VxMark (new):
<img width="992" height="570" alt="Screenshot 2025-08-29 at 4 19 53 PM" src="https://github.com/user-attachments/assets/dd0ec2be-5c67-4aa1-af7c-510e31dc5194" />

VxMarkScan:
<img width="583" height="986" alt="Screenshot 2025-08-29 at 4 19 14 PM" src="https://github.com/user-attachments/assets/f709136f-a0c6-4e44-9c88-61a9f94e790c" />

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
