### PR TITLE
Use two-tone warning icon to meet both voter-facing contrast and color requirements

### DIFF
--- a/libs/ui/src/fonts/font_awesome_class_names.ts
+++ b/libs/ui/src/fonts/font_awesome_class_names.ts
@@ -1,0 +1,1 @@
+export const FONT_AWESOME_INLINE_SVG_CLASS_NAME = 'svg-inline--fa';

--- a/libs/ui/src/fonts/font_awesome_styles.test.ts
+++ b/libs/ui/src/fonts/font_awesome_styles.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { makeTemporaryFile } from '@votingworks/fixtures';
 import { generateFontAwesomeStyles } from './generate_font_awesome_styles';
+import { FONT_AWESOME_INLINE_SVG_CLASS_NAME } from './font_awesome_class_names';
 
 test('font_awesome_styles.ts is up to date (if not, run generate-font-awesome-styles)', () => {
   const actual = readFileSync(
@@ -14,4 +15,14 @@ test('font_awesome_styles.ts is up to date (if not, run generate-font-awesome-st
   const expected = readFileSync(expectedPath, 'utf8');
 
   expect(actual).toEqual(expected);
+});
+
+test('FONT_AWESOME_INLINE_SVG_CLASS_NAME can be found in latest Font Awesome styles', () => {
+  const fontAwesomeStyles = readFileSync(
+    join(__dirname, './font_awesome_styles.ts'),
+    'utf8'
+  );
+  expect(fontAwesomeStyles).toContain(
+    `.${FONT_AWESOME_INLINE_SVG_CLASS_NAME} `
+  );
 });

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -90,9 +90,11 @@ import { faUsb } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import styled, { useTheme } from 'styled-components';
 
+import { assert } from '@votingworks/basics';
 import { UiTheme } from '@votingworks/types';
 import { ScreenInfo, useScreenInfo } from './hooks/use_screen_info';
 import { Font, FontProps } from './typography';
+import { FONT_AWESOME_INLINE_SVG_CLASS_NAME } from './fonts/font_awesome_class_names';
 
 export const ICON_COLORS = [
   'neutral',
@@ -147,6 +149,49 @@ function iconColor(theme: UiTheme, color?: IconColor) {
 function FaIcon(props: InnerProps): JSX.Element {
   const { pulse, spin, type, color, style = {} } = props;
   const theme = useTheme();
+
+  /**
+   * For the exclamation triangle with warning coloring in the default voter-facing color mode, use
+   * a custom two-tone SVG with a black border/text and a yellow interior. VVSG2 requires that we
+   * use yellow/orange for warning iconography, but to meet the required 10:1 contrast ratio on a
+   * white background, yellow/orange has to be darkened, enough that it becomes brown. The white
+   * background and two-tone SVG's black border have a 10:1 contrast ratio as do the SVG's black
+   * border and yellow interior.
+   */
+  if (
+    type === faExclamationTriangle &&
+    color === 'warning' &&
+    theme.colorMode === 'contrastMedium'
+  ) {
+    assert(
+      !pulse && !spin,
+      'Custom exclamation triangle SVG does not support pulse or spin'
+    );
+    return (
+      <StyledSvgIcon
+        aria-hidden="true"
+        className={FONT_AWESOME_INLINE_SVG_CLASS_NAME}
+        data-icon="triangle-exclamation"
+        role="img"
+        height="100"
+        width="100"
+        viewBox="0 0 512 512"
+        style={{ color: theme.colors.warningAccent, ...style }}
+      >
+        {/* Triangle with rounded corners */}
+        <path
+          fill={theme.colors.warningContainer}
+          d="M16 429.6c0 19 15.4 34.4 34.4 34.4l411.2 0c19 0 34.4-15.4 34.4-34.4c0-6.1-1.6-12.1-4.7-17.3L290.3 67.7C283.2 55.5 270.1 48 256 48s-27.2 7.5-34.3 19.7L20.7 412.3c-3.1 5.3-4.7 11.2-4.7 17.3z"
+        />
+        {/* Outside border */}
+        <path d="M20.7 412.3c-3.1 5.3-4.7 11.2-4.7 17.3c0 19 15.4 34.4 34.4 34.4l411.2 0c19 0 34.4-15.4 34.4-34.4c0-6.1-1.6-12.1-4.7-17.3L290.3 67.7C283.2 55.5 270.1 48 256 48s-27.2 7.5-34.3 19.7L20.7 412.3zM6.9 404.2l201-344.6C217.9 42.5 236.2 32 256 32s38.1 10.5 48.1 27.6l201 344.6c4.5 7.7 6.9 16.5 6.9 25.4c0 27.8-22.6 50.4-50.4 50.4L50.4 480C22.6 480 0 457.4 0 429.6c0-8.9 2.4-17.7 6.9-25.4z" />
+        {/* Exclamation mark line */}
+        <path d="M232 184c0-13.3 10.7-24 24-24s24 10.7 24 24v112c0 13.3-10.7 24-24 24s-24-10.7-24-24V184z" />
+        {/* Exclamation mark dot */}
+        <path d="M256 416a32 32 0 1 0 0-64 32 32 0 1 0 0 64z" />
+      </StyledSvgIcon>
+    );
+  }
 
   return (
     <FontAwesomeIcon

--- a/libs/ui/src/themes/make_theme.ts
+++ b/libs/ui/src/themes/make_theme.ts
@@ -30,6 +30,7 @@ export const TouchscreenPalette = {
   Purple50: '#b591f3',
   Purple80: '#4d2692',
 
+  Orange20: '#ffc457',
   Orange50: '#ec791e',
   Orange80: '#5c3600',
 
@@ -154,6 +155,7 @@ type TouchscreenColorTheme = Pick<
   | 'danger'
   | 'successAccent'
   | 'warningAccent'
+  | 'warningContainer'
 >;
 
 /**
@@ -185,7 +187,7 @@ function expandToFullColorTheme(theme: TouchscreenColorTheme): ColorTheme {
     onDanger: theme.background,
     dangerContainer: theme.background,
 
-    warningContainer: theme.background,
+    warningContainer: theme.warningContainer,
 
     inverseBackground: theme.onBackground,
     onInverse: theme.background,
@@ -206,6 +208,7 @@ export const colorThemes: Record<ColorMode, ColorTheme> = {
     primary: TouchscreenPalette.Gray100,
     danger: TouchscreenPalette.Gray100,
     warningAccent: TouchscreenPalette.Gray100,
+    warningContainer: TouchscreenPalette.Gray100,
     successAccent: TouchscreenPalette.Gray100,
   }),
 
@@ -215,6 +218,7 @@ export const colorThemes: Record<ColorMode, ColorTheme> = {
     primary: TouchscreenPalette.Gray0,
     danger: TouchscreenPalette.Gray0,
     warningAccent: TouchscreenPalette.Gray0,
+    warningContainer: TouchscreenPalette.Gray0,
     successAccent: TouchscreenPalette.Gray0,
   }),
 
@@ -224,6 +228,7 @@ export const colorThemes: Record<ColorMode, ColorTheme> = {
     primary: TouchscreenPalette.Purple80,
     danger: TouchscreenPalette.Red80,
     warningAccent: TouchscreenPalette.Gray90,
+    warningContainer: TouchscreenPalette.Orange20,
     successAccent: TouchscreenPalette.Green80,
   }),
 
@@ -233,6 +238,7 @@ export const colorThemes: Record<ColorMode, ColorTheme> = {
     primary: TouchscreenPalette.Purple50,
     danger: TouchscreenPalette.Red50,
     warningAccent: TouchscreenPalette.Orange50,
+    warningContainer: TouchscreenPalette.Orange50,
     successAccent: TouchscreenPalette.Green50,
   }),
 
@@ -272,11 +278,12 @@ export const colorThemes: Record<ColorMode, ColorTheme> = {
 
   print: expandToFullColorTheme({
     background: TouchscreenPalette.Gray0,
-    danger: TouchscreenPalette.Gray100,
     onBackground: TouchscreenPalette.Gray100,
     primary: TouchscreenPalette.Gray100,
-    successAccent: TouchscreenPalette.Gray100,
+    danger: TouchscreenPalette.Gray100,
     warningAccent: TouchscreenPalette.Gray100,
+    warningContainer: TouchscreenPalette.Gray100,
+    successAccent: TouchscreenPalette.Gray100,
   }),
 };
 


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6767

We've been stuck between a rock and a hard place as it pertains to VVSG2 contrast requirements and VVSG2 color requirements. For the default voter-facing color mode, we need 10:1 contrast ratios. We also need to use yellow/orange for warning iconography. But achieving a 10:1 contrast ratio with yellow/orange on a white background requires darkening it, enough that it becomes brown.

In our initial cert submission, we decided to just use black for warning iconography, with our take on VVSG2 color requirements being that only _if_ you use color does warning iconography have to be yellow/orange. After some back and forth with SLI, we weren't able to get buy-in on that read.

This PR presents an alternative that I think may work. Rather than using the brown color (which SLI may still not consider okay as it's not really yellow/orange), I'm trying out a two-tone icon with a black border/text and a yellow interior. The white background and icon's black border have a 10:1 contrast ratio as do the icon's black border and yellow interior.

## Demo Video or Screenshot

### Current icon

<img width="4096" height="2160" alt="current" src="https://github.com/user-attachments/assets/b822d1a6-0b9d-4d16-9485-1f81e7afc577" />

### Brown icon that meets 10:1 contrast ratio requirement

<img width="4096" height="2160" alt="brown" src="https://github.com/user-attachments/assets/467a1149-6e16-45ff-bd7f-ba60d46df5ad" />

### Two-tone icon that should also meet the contrast ratio requirement

<img width="4096" height="2160" alt="two-tone" src="https://github.com/user-attachments/assets/77c7c9e0-8e8f-4b64-930f-3c2fc9f300c3" />

<img width="3415" height="2160" alt="two-tone-2" src="https://github.com/user-attachments/assets/be2ab100-cbe3-4bfe-b2de-037bd7e7b1ab" />

## Testing Plan

- [x] Tested manually
- [x] Checked color contrast at https://www.audioeye.com/color-contrast-checker

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~ N/A
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~ N/A
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.