### PR TITLE
VxDesign: Sync organizations cache on startup

### DIFF
--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -35,7 +35,7 @@ export { createBlankElection } from './app';
 
 loadEnvVarsFromDotenvFiles();
 
-function main(): Promise<number> {
+async function main(): Promise<number> {
   if (!WORKSPACE) {
     throw new Error(
       'Workspace path could not be determined; pass a workspace or run with WORKSPACE'
@@ -47,6 +47,7 @@ function main(): Promise<number> {
   const { store } = workspace;
 
   const auth0 = authEnabled() ? Auth0Client.init() : Auth0Client.dev();
+  await store.syncOrganizationsCache(await auth0.allOrgs());
 
   // We reuse the VxSuite logging library, but it doesn't matter if we meet VVSG
   // requirements in VxDesign, so we can use it a bit loosely. For example, the


### PR DESCRIPTION


## Overview

If it ever gets out of sync, we can simply restart the app to fix it.

## Demo Video or Screenshot
N/A

## Testing Plan
Manual test
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
