### PR TITLE
Enable adjudication ballot viewing for elections without write-ins

### DIFF
--- a/libs/hmpb/src/ballot_components.tsx
+++ b/libs/hmpb/src/ballot_components.tsx
@@ -279,7 +279,11 @@ export function AlignedBubble({
   );
 }
 
+export const OFFICIAL_OPTION_CLASS = 'official-option';
+
 export const WRITE_IN_OPTION_CLASS = 'write-in-option';
+
+export const BALLOT_MEASURE_OPTION_CLASS = 'ballot-measure-option';
 
 export const MARK_OVERLAY_CLASS = 'mark-overlay';
 

--- a/libs/hmpb/src/ballot_templates/la_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/la_ballot_template.tsx
@@ -50,6 +50,8 @@ import {
   BlankPageMessage,
   AlignedBubble,
   ContestTitle,
+  OFFICIAL_OPTION_CLASS,
+  BALLOT_MEASURE_OPTION_CLASS,
 } from '../ballot_components';
 import { BallotMode, PixelDimensions } from '../types';
 import { layOutInColumns } from '../layout_in_columns';
@@ -306,6 +308,7 @@ function CandidateContest({
           return (
             <li
               key={candidate.id}
+              className={OFFICIAL_OPTION_CLASS}
               style={{
                 padding: '0.375rem 0.5rem',
                 borderTop:
@@ -561,6 +564,7 @@ function BallotMeasureContest({ contest }: { contest: YesNoContest }) {
           {[contest.yesOption, contest.noOption].map((option) => (
             <li
               key={option.id}
+              className={BALLOT_MEASURE_OPTION_CLASS}
               style={{
                 padding: '0.375rem 0.5rem',
                 borderTop: `1px solid ${Colors.LIGHT_GRAY}`,

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -55,6 +55,8 @@ import {
   WriteInLabel,
   ColorTint,
   ContestTitle,
+  OFFICIAL_OPTION_CLASS,
+  BALLOT_MEASURE_OPTION_CLASS,
 } from '../ballot_components';
 import { BallotMode, PixelDimensions } from '../types';
 import { hmpbStrings } from '../hmpb_strings';
@@ -358,6 +360,7 @@ function CandidateContest({
           return (
             <li
               key={candidate.id}
+              className={OFFICIAL_OPTION_CLASS}
               style={{
                 padding: '0.375rem 0.5rem',
                 borderTop:
@@ -510,6 +513,7 @@ function BallotMeasureContest({
             {[contest.yesOption, contest.noOption].map((option) => (
               <li
                 key={option.id}
+                className={BALLOT_MEASURE_OPTION_CLASS}
                 style={{
                   padding: '0.375rem 0.5rem',
                   borderTop: `1px solid ${Colors.LIGHT_GRAY}`,

--- a/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
@@ -49,6 +49,8 @@ import {
   BlankPageMessage,
   AlignedBubble,
   ContestTitle,
+  OFFICIAL_OPTION_CLASS,
+  BALLOT_MEASURE_OPTION_CLASS,
 } from '../ballot_components';
 import { BallotMode, PixelDimensions } from '../types';
 import { layOutInColumns } from '../layout_in_columns';
@@ -270,6 +272,7 @@ function CandidateContest({
           return (
             <li
               key={candidate.id}
+              className={OFFICIAL_OPTION_CLASS}
               style={{
                 padding: '0.375rem 0.5rem',
                 borderTop:
@@ -384,6 +387,7 @@ function BallotMeasureContest({ contest }: { contest: YesNoContest }) {
           {[contest.yesOption, contest.noOption].map((option) => (
             <li
               key={option.id}
+              className={BALLOT_MEASURE_OPTION_CLASS}
               style={{
                 padding: '0.375rem 0.5rem',
                 borderTop: `1px solid ${Colors.LIGHT_GRAY}`,

--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -35,12 +35,14 @@ import {
   CONTENT_SLOT_CLASS,
   ContentSlot,
   BALLOT_HASH_SLOT_CLASS,
+  OFFICIAL_OPTION_CLASS,
   OptionInfo,
   PAGE_CLASS,
   QR_CODE_SIZE,
   QR_CODE_SLOT_CLASS,
   TIMING_MARK_CLASS,
   WRITE_IN_OPTION_CLASS,
+  BALLOT_MEASURE_OPTION_CLASS,
 } from './ballot_components';
 import {
   BALLOT_MODES,
@@ -272,6 +274,14 @@ export function gridHeightToPixels(
   return height * grid.rowGap;
 }
 
+interface DocumentElement {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  data: unknown;
+}
+
 async function extractGridLayout(
   document: RenderDocument,
   ballotStyleId: BallotStyleId
@@ -326,18 +336,53 @@ async function extractGridLayout(
   );
   const gridPositions = optionPositionsPerPage.flat();
 
-  // To compute the bounds of write-in options, we'll just look at the first
-  // write-in option box we find. This relies on all write-in option boxes being
-  // the same size. We may want to eventually switch to a data model where we
-  // compute the bounds for every contest option we care about individually.
+  // To compute the bounds of options, we'll look at the first write-in option
+  // box we find. We use this value for every contest option on the ballot.
+  // We use a write-in option box rather than an official option box because
+  // it is the larger of the two and gives us more margin for error. If there
+  // are no write-ins, we fallback to an official option and then a ballot measure
+  // option. We may want to eventually switch to a data model where we compute bounds
+  // for every contest option we care about individually, since write-in and official
+  // options are not the same size.
   const optionBoundsFromTargetMark: Outset<number> = await (async () => {
+    let optionElement: DocumentElement | null = null;
+    let bubbleElement: DocumentElement | null = null;
+
     const writeInOptions = await document.inspectElements(
       `.${WRITE_IN_OPTION_CLASS}`
     );
-    const writeInOptionBubbles = await document.inspectElements(
-      `.${WRITE_IN_OPTION_CLASS} .${BUBBLE_CLASS}`
-    );
-    if (writeInOptions.length === 0) {
+    if (writeInOptions.length > 0) {
+      [optionElement] = writeInOptions;
+      [bubbleElement] = await document.inspectElements(
+        `.${WRITE_IN_OPTION_CLASS} .${BUBBLE_CLASS}`
+      );
+    }
+
+    if (optionElement === null) {
+      const officialOptions = await document.inspectElements(
+        `.${OFFICIAL_OPTION_CLASS}`
+      );
+      if (officialOptions.length > 0) {
+        [optionElement] = officialOptions;
+        [bubbleElement] = await document.inspectElements(
+          `.${OFFICIAL_OPTION_CLASS} .${BUBBLE_CLASS}`
+        );
+      }
+    }
+
+    if (optionElement === null) {
+      const ballotMeasureOptions = await document.inspectElements(
+        `.${BALLOT_MEASURE_OPTION_CLASS}`
+      );
+      if (ballotMeasureOptions.length > 0) {
+        [optionElement] = ballotMeasureOptions;
+        [bubbleElement] = await document.inspectElements(
+          `.${BALLOT_MEASURE_OPTION_CLASS} .${BUBBLE_CLASS}`
+        );
+      }
+    }
+
+    if (optionElement === null || bubbleElement === null) {
       return {
         top: 0,
         left: 0,
@@ -345,33 +390,22 @@ async function extractGridLayout(
         bottom: 0,
       };
     }
-    const firstWriteInOption = writeInOptions[0];
-    const firstWriteInOptionBubble = writeInOptionBubbles[0];
-    const firstWriteInOptionBubbleCenter: Point<Pixels> = {
-      x: firstWriteInOptionBubble.x + firstWriteInOptionBubble.width / 2,
-      y: firstWriteInOptionBubble.y + firstWriteInOptionBubble.height / 2,
+
+    const bubbleElementCenter: Point<Pixels> = {
+      x: bubbleElement.x + bubbleElement.width / 2,
+      y: bubbleElement.y + bubbleElement.height / 2,
     };
     const grid = await measureTimingMarkGrid(document, 1);
     const bounds: Outset<number> = {
-      top: pixelsToGridHeight(
-        grid,
-        firstWriteInOptionBubbleCenter.y - firstWriteInOption.y
-      ),
-      left: pixelsToGridWidth(
-        grid,
-        firstWriteInOptionBubbleCenter.x - firstWriteInOption.x
-      ),
+      top: pixelsToGridHeight(grid, bubbleElementCenter.y - optionElement.y),
+      left: pixelsToGridWidth(grid, bubbleElementCenter.x - optionElement.x),
       right: pixelsToGridWidth(
         grid,
-        firstWriteInOption.x +
-          firstWriteInOption.width -
-          firstWriteInOptionBubbleCenter.x
+        optionElement.x + optionElement.width - bubbleElementCenter.x
       ),
       bottom: pixelsToGridHeight(
         grid,
-        firstWriteInOption.y +
-          firstWriteInOption.height -
-          firstWriteInOptionBubbleCenter.y
+        optionElement.y + optionElement.height - bubbleElementCenter.y
       ),
     };
     return bounds;


### PR DESCRIPTION
## Overview

I noticed that our adjudication ballot viewer does not work for elections without write-ins, because we rely on the field `optionBoundsFromTargetMark` when determining the contest layout, and that field gets a zero value if we don't find a write-in on a ballot. This value is then used for every contest on the ballot when determining option/contest bounds. 

To fix this, we now fallback to a contest option box, and last a ballot measure box.

This ensures that an election will still have a pretty accurate value for `optionBoundsFromTargetMark` in elections without write-ins, and even elections without candidate contests.

## Demo Video or Screenshot

Before - contest from election with no write-in: 
<img width="867" height="554" alt="Screenshot 2025-09-04 at 12 40 18 PM" src="https://github.com/user-attachments/assets/3c747945-a393-4f13-bf62-4c076be3ce57" />

After - contest from election with no write-in:
<img width="874" height="542" alt="Screenshot 2025-09-05 at 1 22 21 PM" src="https://github.com/user-attachments/assets/5f5e3b29-14f6-4967-bd45-3c306d4900e7" />

After - contest from election with only a BM:
<img width="882" height="552" alt="Screenshot 2025-09-05 at 1 29 29 PM" src="https://github.com/user-attachments/assets/a10ed640-9841-484e-a84b-f27594d111e0" />


## Testing Plan

Manual testing

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
