### PR TITLE
DRAFT: [VxQR] Set up reporting endpoint scaffolding in VxDesign

### DIFF
--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -56,6 +56,7 @@
     "@votingworks/ui": "workspace:*",
     "@votingworks/utils": "workspace:*",
     "auth0": "4.17.0",
+    "cookie-parser": "^1.4.7",
     "csv-parse": "^5.5.0",
     "debug": "4.3.4",
     "dotenv": "16.3.1",
@@ -74,6 +75,7 @@
     "zod": "3.25.42"
   },
   "devDependencies": {
+    "@types/cookie-parser": "^1.4.9",
     "@types/debug": "4.1.8",
     "@types/express": "4.17.14",
     "@types/fs-extra": "11.0.1",

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -212,6 +212,18 @@ export const getBallotTemplate = {
   },
 } as const;
 
+export const getResultsReportConfirmationDetails = {
+  queryKey(): QueryKey {
+    return ['getResultsReportConfirmationDetails'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () =>
+      apiClient.getResultsReportConfirmationDetails()
+    );
+  },
+} as const;
+
 async function invalidateElectionQueries(
   queryClient: QueryClient,
   electionId: ElectionId

--- a/apps/design/frontend/src/app.tsx
+++ b/apps/design/frontend/src/app.tsx
@@ -17,7 +17,7 @@ import {
   getUser,
 } from './api';
 import { ElectionsScreen } from './elections_screen';
-import { electionParamRoutes, routes } from './routes';
+import { electionParamRoutes, routes, resultsRoutes } from './routes';
 import { ElectionInfoScreen } from './election_info_screen';
 import { GeographyScreen } from './geography_screen';
 import { ContestsScreen } from './contests_screen';
@@ -25,6 +25,7 @@ import { BallotsScreen } from './ballots_screen';
 import { SystemSettingsScreen } from './system_settings_screen';
 import { ExportScreen } from './export_screen';
 import { ErrorScreen } from './error_screen';
+import { ReportingResultsConfirmationScreen } from './reporting_results_confirmation_screen';
 
 function ElectionScreens(): JSX.Element {
   return (
@@ -81,6 +82,7 @@ export function App({
   apiClient?: ApiClient;
 }): JSX.Element {
   const [electionsFilterText, setElectionsFilterText] = useState('');
+  console.log('app render ');
   return (
     <AppBase
       defaultColorMode="desktop"
@@ -90,9 +92,12 @@ export function App({
       <ErrorBoundary errorMessage={ErrorScreen}>
         <ApiClientContext.Provider value={apiClient}>
           <QueryClientProvider client={createQueryClient()}>
-            <WaitForUserInfo>
-              <BrowserRouter>
-                <Switch>
+            <BrowserRouter>
+              <Switch>
+                <Route path={resultsRoutes.root.path} exact>
+                  <ReportingResultsConfirmationScreen />
+                </Route>
+                <WaitForUserInfo>
                   <Route path={routes.root.path} exact>
                     <ElectionsScreen
                       filterText={electionsFilterText}
@@ -103,9 +108,9 @@ export function App({
                     path={electionParamRoutes.root.path}
                     component={ElectionScreens}
                   />
-                </Switch>
-              </BrowserRouter>
-            </WaitForUserInfo>
+                </WaitForUserInfo>
+              </Switch>
+            </BrowserRouter>
           </QueryClientProvider>
         </ApiClientContext.Provider>
       </ErrorBoundary>

--- a/apps/design/frontend/src/reporting_results_confirmation_screen.tsx
+++ b/apps/design/frontend/src/reporting_results_confirmation_screen.tsx
@@ -1,0 +1,13 @@
+import { getResultsReportConfirmationDetails } from './api';
+
+export function ReportingResultsConfirmationScreen(): JSX.Element | null {
+  const getResultsReportConfirmationDetailsQuery =
+    getResultsReportConfirmationDetails.useQuery();
+  const resultsDetails = getResultsReportConfirmationDetailsQuery.data;
+  if (!resultsDetails) {
+    return <div>Invalid Request</div>;
+  }
+  console.log(resultsDetails);
+
+  return <div>Thank you for reporting your election results!</div>;
+}

--- a/apps/design/frontend/src/routes.ts
+++ b/apps/design/frontend/src/routes.ts
@@ -2,6 +2,13 @@ import type { UserFeaturesConfig } from '@votingworks/design-backend';
 import { ElectionId } from '@votingworks/types';
 import { Route } from '@votingworks/ui';
 
+export const resultsRoutes = {
+  root: {
+    title: 'Results Reported',
+    path: '/results/',
+  },
+} as const;
+
 export const routes = {
   root: {
     title: 'Elections',

--- a/apps/design/frontend/vite.config.ts
+++ b/apps/design/frontend/vite.config.ts
@@ -85,6 +85,7 @@ export default defineConfig(async (env) => {
         '/auth': 'http://localhost:3002',
         '/api': 'http://localhost:3002',
         '/files': 'http://localhost:3002',
+        '/report': 'http://localhost:3002',
       },
       port: 3000,
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1107,6 +1107,9 @@ importers:
       auth0:
         specifier: 4.17.0
         version: 4.17.0
+      cookie-parser:
+        specifier: ^1.4.7
+        version: 1.4.7
       csv-parse:
         specifier: ^5.5.0
         version: 5.5.0
@@ -1156,6 +1159,9 @@ importers:
         specifier: 3.25.42
         version: 3.25.42
     devDependencies:
+      '@types/cookie-parser':
+        specifier: ^1.4.9
+        version: 1.4.9(@types/express@4.17.14)
       '@types/debug':
         specifier: 4.1.8
         version: 4.1.8
@@ -13039,6 +13045,14 @@ packages:
     dependencies:
       '@types/node': 20.17.31
 
+  /@types/cookie-parser@1.4.9(@types/express@4.17.14):
+    resolution: {integrity: sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==}
+    peerDependencies:
+      '@types/express': '*'
+    dependencies:
+      '@types/express': 4.17.14
+    dev: true
+
   /@types/cookiejar@2.1.2:
     resolution: {integrity: sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==}
     dev: true
@@ -15497,12 +15511,25 @@ packages:
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  /cookie-parser@1.4.7:
+    resolution: {integrity: sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      cookie: 0.7.2
+      cookie-signature: 1.0.6
+    dev: false
+
   /cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
   /cookie@0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
     engines: {node: '>= 0.6'}
+
+  /cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+    dev: false
 
   /cookiejar@2.1.2:
     resolution: {integrity: sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==}


### PR DESCRIPTION
## Overview
This PR is currently in DRAFT form. The code is not written to be ready to merge but is meant to provide an example on how I am intending to implement this at a high level. 

The intention here:
 - /report - The endpoint whose URL will get encoded on the VxQR printed QR code. The url will accept query parameters with the reporting data, the endpoint will parse that data, verify the signature, and save the data to postgres. It will also generate a session ID for a cookie and set that cookie, then redirect to a results reporting confirmation page (currently /results, will likely be renamed) 
 - The frontend react App will switch and find any /results routes and return a seperate UI screen for that route without loading user / auth information. 
 - That results confirmation page from the frontend will call a backend GET endpoint which will load the session id from the cookie in order to associate the current session with the submitted results. The results will be returned back to the UI and rendered (not included in this PR) so the user can see the data they submitted. 

The major alternative I can think of to doing this cookie dance is to simply return templated html from the /report endpoint (similar to how we do in the current python backend: https://github.com/votingworks/quickresults-server/blob/main/server.py#L136 ) that includes all of the submitted results. I think its worth figuring out the approach outlined in this PR so that we can keep the frontend code in apps/design/frontend, and use our general react frameworks/libraries/etc. I also wasn't sure the easiest way to plug in templated html to the current express app setup. But I'm not entirely sure on the ideal way to do this so wanted to put up this proof of concept for discussion / alignment. 

A variation of this could be having a similar set up but having a multi-page react app with a different index.html / App.tsx file for the /results path. 

Note that there are two main new UIs we will need for VxQR, this confirmation page is one of them, the other is the aggregated results view. That second view WILL be under the authentication overhead so I imagine will be much more simply implemented in the SPA of apps/design/frontend with grout endpoints as needed for data in the backend. 

## Demo Video or Screenshot
You can test this with the review app, navigating to: /report should automatically redirect you to /results without requiring a log in. 

Review App: https://vxdesign-caro-vxqr-back-mm4ifq.herokuapp.com/ 
Reporting endpoint example: https://vxdesign-caro-vxqr-back-mm4ifq.herokuapp.com/report?p=ajshdkjahd&s=ajdksahd

## Testing Plan
With localhost and review app navigate to /report with and without query parameters, see redirect to /results work as expected with logs of query parameters and cookie session id as expected. 

