### PR TITLE
VxDesign: Only sync auth cache on startup in production

### DIFF
--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -4,7 +4,7 @@ import './configure_sentry'; // Must be imported first to instrument code
 import { resolve } from 'node:path';
 import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
 import { BaseLogger, Logger, LogSource } from '@votingworks/logging';
-import { authEnabled, WORKSPACE } from './globals';
+import { authEnabled, NODE_ENV, WORKSPACE } from './globals';
 import * as server from './server';
 import { createWorkspace } from './workspace';
 import { GoogleCloudTranslatorWithDbCache } from './translator';
@@ -47,7 +47,9 @@ async function main(): Promise<number> {
   const { store } = workspace;
 
   const auth0 = authEnabled() ? Auth0Client.init() : Auth0Client.dev();
-  await store.syncOrganizationsCache(await auth0.allOrgs());
+  if (NODE_ENV === 'production') {
+    await store.syncOrganizationsCache(await auth0.allOrgs());
+  }
 
   // We reuse the VxSuite logging library, but it doesn't matter if we meet VVSG
   // requirements in VxDesign, so we can use it a bit loosely. For example, the


### PR DESCRIPTION

## Overview

In development, if working with a prod db backup locally (e.g. for debugging a prod issue), syncing the auth cache will fail, since the local app isn't connected to the prod Auth0 tenant. In this case, we don't need to sync the auth cache on startup anyway, since the db should already be up to date. For other dev use cases, the db migrations run by `pnpm db:reset-dev` will sync the cache.

## Demo Video or Screenshot
N/A

## Testing Plan
Manual test
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
