### PR TITLE
Sketch of changes to support candidate rotation by precinct

### DIFF
--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -77,7 +77,6 @@ import {
   UsState,
 } from './types';
 import { AppContext } from './context';
-import { rotateCandidates } from './candidate_rotation';
 import {
   auth0ClientId,
   auth0IssuerBaseUrl,
@@ -514,9 +513,7 @@ export function buildApi({ auth0, logger, workspace, translator }: AppContext) {
       electionId: ElectionId;
       newContest: AnyContest;
     }): Promise<Result<void, DuplicateContestError>> {
-      let contest = unsafeParse(AnyContestSchema, input.newContest);
-      const { ballotTemplateId } = await store.getElection(input.electionId);
-      contest = rotateCandidates(contest, ballotTemplateId);
+      const contest = unsafeParse(AnyContestSchema, input.newContest);
       return store.createContest(input.electionId, contest);
     },
 
@@ -524,9 +521,7 @@ export function buildApi({ auth0, logger, workspace, translator }: AppContext) {
       electionId: ElectionId;
       updatedContest: AnyContest;
     }): Promise<Result<void, DuplicateContestError>> {
-      let contest = unsafeParse(AnyContestSchema, input.updatedContest);
-      const { ballotTemplateId } = await store.getElection(input.electionId);
-      contest = rotateCandidates(contest, ballotTemplateId);
+      const contest = unsafeParse(AnyContestSchema, input.updatedContest);
       return store.updateContest(input.electionId, contest);
     },
 

--- a/apps/design/backend/src/candidate_rotation.ts
+++ b/apps/design/backend/src/candidate_rotation.ts
@@ -1,6 +1,5 @@
 import { assertDefined } from '@votingworks/basics';
-import { BallotTemplateId } from '@votingworks/hmpb';
-import { AnyContest, Candidate } from '@votingworks/types';
+import { Candidate, CandidateContest, CandidateId } from '@votingworks/types';
 
 // Maps the number of candidates in a contest to the index at which to rotate
 // the candidates. These indexes are randomly selected by the state every 2
@@ -35,16 +34,10 @@ const NH_ROTATION_INDICES: Record<number, number> = {
  * 1. Order the candidates alphabetically by last name.
  * 2. Cut the "deck" at a randomly selected index (see NH_ROTATION_INDICES).
  */
-export function rotateCandidates(
-  contest: AnyContest,
-  ballotTemplateId: BallotTemplateId
-): AnyContest {
-  if (contest.type !== 'candidate') return contest;
-  if (contest.candidates.length < 2) return contest;
-
-  if (ballotTemplateId !== 'NhBallot') {
-    return contest;
-  }
+export function rotateCandidatesByNhStatutes(
+  contest: CandidateContest
+): CandidateId[] {
+  if (contest.candidates.length < 2) return contest.candidates.map((c) => c.id);
 
   function getSortingName(candidate: Candidate): string {
     return (
@@ -71,9 +64,16 @@ export function rotateCandidates(
     ...orderedCandidates.slice(rotationIndex),
     ...orderedCandidates.slice(0, rotationIndex),
   ];
+  return rotatedCandidates.map((c) => c.id);
+}
 
-  return {
-    ...contest,
-    candidates: rotatedCandidates,
-  };
+export function rotateCandidateByOffset(
+  contest: CandidateContest,
+  offset: number
+): CandidateId[] {
+  const rotatedCandidates = [
+    ...contest.candidates.slice(offset),
+    ...contest.candidates.slice(0, offset),
+  ];
+  return rotatedCandidates.map((c) => c.id);
 }

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -3,6 +3,7 @@ import {
   assert,
   assertDefined,
   err,
+  find,
   iter,
   ok,
   range,
@@ -16,6 +17,7 @@ import {
   BallotStyleId,
   BallotType,
   CandidateContest as CandidateContestStruct,
+  CandidateRotation,
   Election,
   LanguageCode,
   NhPrecinctSplitOptions,
@@ -295,11 +297,13 @@ function CandidateContest({
   contest,
   compact,
   colorTint,
+  candidateRotation,
 }: {
   election: Election;
   contest: CandidateContestStruct;
   compact?: boolean;
   colorTint?: ColorTint;
+  candidateRotation: CandidateRotation;
 }) {
   const voteForText = {
     1: hmpbStrings.hmpbVoteForNotMoreThan1,
@@ -358,7 +362,11 @@ function CandidateContest({
         )}
       </ContestHeader>
       <ul>
-        {contest.candidates.map((candidate, i) => {
+        {assertDefined(candidateRotation[contest.id]).map((candidateId, i) => {
+          const candidate = find(
+            contest.candidates,
+            (c) => c.id === candidateId
+          );
           const partyText =
             election.type === 'primary' ? undefined : (
               <CandidatePartyList
@@ -563,11 +571,13 @@ function Contest({
   contest,
   election,
   colorTint,
+  candidateRotation,
 }: {
   compact?: boolean;
   contest: AnyContest;
   election: Election;
   colorTint?: ColorTint;
+  candidateRotation: CandidateRotation;
 }) {
   switch (contest.type) {
     case 'candidate':
@@ -577,6 +587,7 @@ function Contest({
           election={election}
           contest={contest}
           colorTint={colorTint}
+          candidateRotation={candidateRotation}
         />
       );
     case 'yesno':
@@ -705,6 +716,7 @@ async function BallotPageContent(
         contest={contest}
         election={election}
         colorTint={props.colorTint}
+        candidateRotation={props.candidateRotation}
       />
     ));
     const numColumns = section[0].type === 'candidate' ? 3 : 1;
@@ -781,7 +793,12 @@ async function BallotPageContent(
       const { firstContestElement, restContest } =
         await splitLongBallotMeasureAcrossPages(
           tooLongContest,
-          { election, compact, colorTint: props.colorTint },
+          {
+            election,
+            compact,
+            colorTint: props.colorTint,
+            candidateRotation: props.candidateRotation,
+          },
           ballotStyle,
           dimensions,
           scratchpad
@@ -830,7 +847,9 @@ async function BallotPageContent(
 }
 
 export type NhBallotProps = BaseBallotProps &
-  NhPrecinctSplitOptions & { colorTint?: ColorTint };
+  NhPrecinctSplitOptions & { colorTint?: ColorTint } & {
+    candidateRotation: CandidateRotation;
+  };
 
 export const nhBallotTemplate: BallotPageTemplate<NhBallotProps> = {
   stylesComponent: BaseStyles,

--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -577,6 +577,13 @@ export async function layOutBallotsAndCreateElectionDefinition<
     .map((layouts) => assertDefined(iter(layouts.values()).first()))
     .toArray();
 
+  // TOOD: Look at each candidate contest: if all grid layouts have the same
+  // ordering of candidates, change the election definition to also have that
+  // ordering of candidates. This will ensure that VxMark and reports list
+  // candidates in the same order that they appear on the HMPB. Eventually, we
+  // should use the gridLayouts for that ordering instead of the election
+  // contests.
+
   const electionWithGridLayouts: Election = {
     ...election,
     gridLayouts,

--- a/libs/types/src/hmpb.ts
+++ b/libs/types/src/hmpb.ts
@@ -1,6 +1,7 @@
 import { assert, assertDefined } from '@votingworks/basics';
 import { z } from 'zod/v4';
 import {
+  CandidateId,
   ContestId,
   ContestOption,
   ContestOptionSchema,
@@ -209,4 +210,12 @@ export function mapSheet<F extends (...args: unknown[]) => unknown>(
 export function asSheet<T>(array: T[]): SheetOf<T> {
   assert(array.length === 2);
   return array as unknown as SheetOf<T>;
+}
+
+/**
+ * Maps contests to the order that its candidates should be listed on the
+ * ballot.
+ */
+export interface CandidateRotation {
+  [contestId: ContestId]: CandidateId[];
 }


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
