### PR TITLE
VxDesign: VxQR: Implement scaffolding in VxDesign for VxQR reporting endpoint

### DIFF
--- a/apps/design/backend/src/app.results.test.ts
+++ b/apps/design/backend/src/app.results.test.ts
@@ -14,7 +14,7 @@ beforeEach(() => {
 });
 
 test('processQRCodeReport handles invalid payloads as expected', async () => {
-  const { apiClient } = await setupApp([]);
+  const { unauthenticatedApiClient } = await setupApp([]);
   // You can call processQrCodeReport without authentication
 
   const invalidPayloads = [
@@ -26,7 +26,7 @@ test('processQRCodeReport handles invalid payloads as expected', async () => {
     '1//qr1//ballotHash.machineId.0.1757449351.notb64data', // Bad data
   ];
   for (const payload of invalidPayloads) {
-    const result = await apiClient.processQrCodeReport({
+    const result = await unauthenticatedApiClient.processQrCodeReport({
       payload,
       signature: 'test-signature',
     });
@@ -35,7 +35,7 @@ test('processQRCodeReport handles invalid payloads as expected', async () => {
 });
 
 test('processQRCodeReport handles valid payloads as expected', async () => {
-  const { apiClient } = await setupApp([]);
+  const { unauthenticatedApiClient } = await setupApp([]);
   // You can call processQrCodeReport without authentication
   const mockCompressedTally = [
     [0, 4, 5, 6, 1],
@@ -45,7 +45,7 @@ test('processQRCodeReport handles valid payloads as expected', async () => {
   const b64EncodedTally = Buffer.from(
     JSON.stringify(mockCompressedTally)
   ).toString('base64');
-  const result = await apiClient.processQrCodeReport({
+  const result = await unauthenticatedApiClient.processQrCodeReport({
     payload: `1//qr1//ballotHash.DEV-1.0.1757449351.${b64EncodedTally}`,
     signature: 'test-signature',
   });

--- a/apps/design/backend/src/app.results.test.ts
+++ b/apps/design/backend/src/app.results.test.ts
@@ -1,0 +1,59 @@
+import { afterAll, beforeEach, expect, test } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { getFeatureFlagMock } from '@votingworks/utils';
+import { testSetupHelpers } from '../test/helpers';
+
+const mockFeatureFlagger = getFeatureFlagMock();
+
+const { setupApp, cleanup } = testSetupHelpers();
+
+afterAll(cleanup);
+
+beforeEach(() => {
+  mockFeatureFlagger.resetFeatureFlags();
+});
+
+test('processQRCodeReport handles invalid payloads as expected', async () => {
+  const { apiClient } = await setupApp([]);
+  // You can call processQrCodeReport without authentication
+
+  const invalidPayloads = [
+    'bad-payload', // No seperator
+    '0//qr1//message', // Bad version
+    '1//bad-header//message', // Bad header
+    '1//qr1//', // No message
+    '1//qr1//ballotHash.machineId.0.badtimestamp.', // Bad timestamp
+    '1//qr1//ballotHash.machineId.0.1757449351.notb64data', // Bad data
+  ];
+  for (const payload of invalidPayloads) {
+    const result = await apiClient.processQrCodeReport({
+      payload,
+      signature: 'test-signature',
+    });
+    expect(result.err()).toEqual('invalid-payload');
+  }
+});
+
+test('processQRCodeReport handles valid payloads as expected', async () => {
+  const { apiClient } = await setupApp([]);
+  // You can call processQrCodeReport without authentication
+  const mockCompressedTally = [
+    [0, 4, 5, 6, 1],
+    [1, 1, 3, 5],
+    [0, 0, 0, 0],
+  ];
+  const b64EncodedTally = Buffer.from(
+    JSON.stringify(mockCompressedTally)
+  ).toString('base64');
+  const result = await apiClient.processQrCodeReport({
+    payload: `1//qr1//ballotHash.DEV-1.0.1757449351.${b64EncodedTally}`,
+    signature: 'test-signature',
+  });
+  expect(result.ok()).toEqual({
+    ballotHash: 'ballotHash',
+    machineId: 'DEV-1',
+    isLive: false,
+    signedTimestamp: new Date(1757449351 * 1000),
+    tally: mockCompressedTally,
+  });
+});

--- a/apps/design/backend/src/app.results.test.ts
+++ b/apps/design/backend/src/app.results.test.ts
@@ -18,7 +18,7 @@ test('processQRCodeReport handles invalid payloads as expected', async () => {
   // You can call processQrCodeReport without authentication
 
   const invalidPayloads = [
-    'bad-payload', // No seperator
+    'bad-payload', // No separator
     '0//qr1//message', // Bad version
     '1//bad-header//message', // Bad header
     '1//qr1//', // No message

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -100,7 +100,7 @@ import { join } from 'node:path';
 import { electionFeatureConfigs, userFeatureConfigs } from './features';
 import { sliOrgId, votingWorksOrgId, vxDemosOrgId } from './globals';
 import { LogEventId } from '@votingworks/logging';
-import { buildApi } from './app';
+import { buildApi, METHODS_THAT_DO_NOT_REQUIRE_OAUTH_INTEGRATION } from './app';
 import { readdir, readFile } from 'node:fs/promises';
 
 vi.setConfig({
@@ -255,11 +255,16 @@ afterEach(() => {
   vi.mocked(renderAllBallotPdfsAndCreateElectionDefinition).mockRestore();
 });
 
-test('all methods require authentication', async () => {
+test('all methods require authentication other than METHODS_THAT_DO_NOT_REQUIRE_OAUTH_INTEGRATION', async () => {
   const { apiClient, baseUrl, ...context } = await setupApp(orgs);
   await suppressingConsoleOutput(async () => {
     const apiMethodNames = Object.keys(buildApi(context).methods());
     for (const apiMethodName of apiMethodNames) {
+      if (
+        METHODS_THAT_DO_NOT_REQUIRE_OAUTH_INTEGRATION.includes(apiMethodName)
+      ) {
+        continue;
+      }
       // @ts-ignore - Don't pass any input to the API methods since we expect
       // auth middleware to reject it before getting to the handler. A bit of a
       // hack, but lets us test all the methods quickly without constructing

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -100,7 +100,7 @@ import { join } from 'node:path';
 import { electionFeatureConfigs, userFeatureConfigs } from './features';
 import { sliOrgId, votingWorksOrgId, vxDemosOrgId } from './globals';
 import { LogEventId } from '@votingworks/logging';
-import { buildApi, METHODS_THAT_DO_NOT_REQUIRE_OAUTH_INTEGRATION } from './app';
+import { buildApi } from './app';
 import { readdir, readFile } from 'node:fs/promises';
 
 vi.setConfig({
@@ -255,16 +255,11 @@ afterEach(() => {
   vi.mocked(renderAllBallotPdfsAndCreateElectionDefinition).mockRestore();
 });
 
-test('all methods require authentication other than METHODS_THAT_DO_NOT_REQUIRE_OAUTH_INTEGRATION', async () => {
+test('all methods require authentication', async () => {
   const { apiClient, baseUrl, ...context } = await setupApp(orgs);
   await suppressingConsoleOutput(async () => {
     const apiMethodNames = Object.keys(buildApi(context).methods());
     for (const apiMethodName of apiMethodNames) {
-      if (
-        METHODS_THAT_DO_NOT_REQUIRE_OAUTH_INTEGRATION.includes(apiMethodName)
-      ) {
-        continue;
-      }
       // @ts-ignore - Don't pass any input to the API methods since we expect
       // auth middleware to reject it before getting to the handler. A bit of a
       // hack, but lets us test all the methods quickly without constructing

--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -24,7 +24,7 @@ export type {
   ElectionInfo,
 } from './types';
 export type { ElectionFeaturesConfig, UserFeaturesConfig } from './features';
-export type { Api, AuthErrorCode } from './app';
+export type { Api, AuthErrorCode, UnauthenticatedApi } from './app';
 
 export type { BallotMode } from '@votingworks/hmpb';
 export type { BallotTemplateId } from '@votingworks/hmpb';

--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -8,6 +8,7 @@ import {
   PrecinctOrSplitId,
   ElectionType,
   ElectionId,
+  CompressedTally,
 } from '@votingworks/types';
 import { DateWithoutTime } from '@votingworks/basics';
 
@@ -96,3 +97,14 @@ export interface ElectionInfo {
   signatureImage?: string;
   signatureCaption?: string;
 }
+
+export interface ResultsReportInfo {
+  ballotHash: string;
+  machineId: string;
+  isLive: boolean;
+  signedTimestamp: Date;
+  tally: CompressedTally;
+  precinctId?: PrecinctOrSplitId;
+}
+
+export type ResultsReportingError = 'invalid-payload';

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -18,7 +18,7 @@ import { AddressInfo } from 'node:net';
 import { Readable } from 'stream';
 import * as tmp from 'tmp';
 import { vi } from 'vitest';
-import type { Api, ApiContext } from '../src/app';
+import type { Api, ApiContext, UnauthenticatedApi } from '../src/app';
 import { buildApp } from '../src/app';
 import { Auth0ClientInterface } from '../src/auth0_client';
 import {
@@ -137,9 +137,13 @@ export function testSetupHelpers() {
     const apiClient = grout.createClient<Api>({
       baseUrl: `${baseUrl}/api`,
     });
+    const unauthenticatedApiClient = grout.createClient<UnauthenticatedApi>({
+      baseUrl: `${baseUrl}/public/api`,
+    });
     return {
       baseUrl,
       apiClient,
+      unauthenticatedApiClient,
       workspace,
       auth0,
       fileStorageClient,

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -691,3 +691,10 @@ export const decryptCvrBallotAuditIds = {
     return useMutation(apiClient.decryptCvrBallotAuditIds);
   },
 } as const;
+
+export const processQrCodeReport = {
+  useMutation() {
+    const apiClient = useApiClient();
+    return useMutation(apiClient.processQrCodeReport);
+  },
+} as const;

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -1,9 +1,5 @@
 import React from 'react';
-import type {
-  Api,
-  BallotMode,
-  AuthErrorCode,
-} from '@votingworks/design-backend';
+import { Api, BallotMode, AuthErrorCode } from '@votingworks/design-backend';
 import * as grout from '@votingworks/grout';
 import {
   QueryClient,
@@ -689,12 +685,5 @@ export const decryptCvrBallotAuditIds = {
   useMutation() {
     const apiClient = useApiClient();
     return useMutation(apiClient.decryptCvrBallotAuditIds);
-  },
-} as const;
-
-export const processQrCodeReport = {
-  useMutation() {
-    const apiClient = useApiClient();
-    return useMutation(apiClient.processQrCodeReport);
   },
 } as const;

--- a/apps/design/frontend/src/app.tsx
+++ b/apps/design/frontend/src/app.tsx
@@ -16,6 +16,11 @@ import {
   createQueryClient,
   getUser,
 } from './api';
+import {
+  createUnauthenticatedApiClient,
+  UnauthenticatedApiClient,
+  UnauthenticatedApiClientContext,
+} from './public_api';
 import { ElectionsScreen } from './elections_screen';
 import { electionParamRoutes, routes, resultsRoutes } from './routes';
 import { ElectionInfoScreen } from './election_info_screen';
@@ -78,8 +83,10 @@ function WaitForUserInfo(props: { children: React.ReactNode }) {
 
 export function App({
   apiClient = createApiClient(),
+  unauthenticatedApiClient = createUnauthenticatedApiClient(),
 }: {
   apiClient?: ApiClient;
+  unauthenticatedApiClient?: UnauthenticatedApiClient;
 }): JSX.Element {
   const [electionsFilterText, setElectionsFilterText] = useState('');
   return (
@@ -90,27 +97,31 @@ export function App({
     >
       <ErrorBoundary errorMessage={ErrorScreen}>
         <ApiClientContext.Provider value={apiClient}>
-          <QueryClientProvider client={createQueryClient()}>
-            <BrowserRouter>
-              <Switch>
-                <Route path={resultsRoutes.root.path} exact>
-                  <ReportingResultsConfirmationScreen />
-                </Route>
-                <WaitForUserInfo>
-                  <Route path={routes.root.path} exact>
-                    <ElectionsScreen
-                      filterText={electionsFilterText}
-                      setFilterText={setElectionsFilterText}
-                    />
+          <UnauthenticatedApiClientContext.Provider
+            value={unauthenticatedApiClient}
+          >
+            <QueryClientProvider client={createQueryClient()}>
+              <BrowserRouter>
+                <Switch>
+                  <Route path={resultsRoutes.root.path} exact>
+                    <ReportingResultsConfirmationScreen />
                   </Route>
-                  <Route
-                    path={electionParamRoutes.root.path}
-                    component={ElectionScreens}
-                  />
-                </WaitForUserInfo>
-              </Switch>
-            </BrowserRouter>
-          </QueryClientProvider>
+                  <WaitForUserInfo>
+                    <Route path={routes.root.path} exact>
+                      <ElectionsScreen
+                        filterText={electionsFilterText}
+                        setFilterText={setElectionsFilterText}
+                      />
+                    </Route>
+                    <Route
+                      path={electionParamRoutes.root.path}
+                      component={ElectionScreens}
+                    />
+                  </WaitForUserInfo>
+                </Switch>
+              </BrowserRouter>
+            </QueryClientProvider>
+          </UnauthenticatedApiClientContext.Provider>
         </ApiClientContext.Provider>
       </ErrorBoundary>
     </AppBase>

--- a/apps/design/frontend/src/app.tsx
+++ b/apps/design/frontend/src/app.tsx
@@ -17,7 +17,7 @@ import {
   getUser,
 } from './api';
 import { ElectionsScreen } from './elections_screen';
-import { electionParamRoutes, routes } from './routes';
+import { electionParamRoutes, routes, resultsRoutes } from './routes';
 import { ElectionInfoScreen } from './election_info_screen';
 import { GeographyScreen } from './geography_screen';
 import { ContestsScreen } from './contests_screen';
@@ -25,6 +25,7 @@ import { BallotsScreen } from './ballots_screen';
 import { SystemSettingsScreen } from './system_settings_screen';
 import { ExportScreen } from './export_screen';
 import { ErrorScreen } from './error_screen';
+import { ReportingResultsConfirmationScreen } from './reporting_results_confirmation_screen';
 
 function ElectionScreens(): JSX.Element {
   return (
@@ -90,9 +91,12 @@ export function App({
       <ErrorBoundary errorMessage={ErrorScreen}>
         <ApiClientContext.Provider value={apiClient}>
           <QueryClientProvider client={createQueryClient()}>
-            <WaitForUserInfo>
-              <BrowserRouter>
-                <Switch>
+            <BrowserRouter>
+              <Switch>
+                <Route path={resultsRoutes.root.path} exact>
+                  <ReportingResultsConfirmationScreen />
+                </Route>
+                <WaitForUserInfo>
                   <Route path={routes.root.path} exact>
                     <ElectionsScreen
                       filterText={electionsFilterText}
@@ -103,9 +107,9 @@ export function App({
                     path={electionParamRoutes.root.path}
                     component={ElectionScreens}
                   />
-                </Switch>
-              </BrowserRouter>
-            </WaitForUserInfo>
+                </WaitForUserInfo>
+              </Switch>
+            </BrowserRouter>
           </QueryClientProvider>
         </ApiClientContext.Provider>
       </ErrorBoundary>

--- a/apps/design/frontend/src/app.tsx
+++ b/apps/design/frontend/src/app.tsx
@@ -96,33 +96,33 @@ export function App({
       showScrollBars
     >
       <ErrorBoundary errorMessage={ErrorScreen}>
-        <ApiClientContext.Provider value={apiClient}>
-          <UnauthenticatedApiClientContext.Provider
-            value={unauthenticatedApiClient}
-          >
-            <QueryClientProvider client={createQueryClient()}>
-              <BrowserRouter>
-                <Switch>
-                  <Route path={resultsRoutes.root.path} exact>
-                    <ReportingResultsConfirmationScreen />
-                  </Route>
-                  <WaitForUserInfo>
-                    <Route path={routes.root.path} exact>
-                      <ElectionsScreen
-                        filterText={electionsFilterText}
-                        setFilterText={setElectionsFilterText}
-                      />
-                    </Route>
-                    <Route
-                      path={electionParamRoutes.root.path}
-                      component={ElectionScreens}
+        <QueryClientProvider client={createQueryClient()}>
+          <BrowserRouter>
+            <Switch>
+              <Route path={resultsRoutes.root.path} exact>
+                <UnauthenticatedApiClientContext.Provider
+                  value={unauthenticatedApiClient}
+                >
+                  <ReportingResultsConfirmationScreen />
+                </UnauthenticatedApiClientContext.Provider>
+              </Route>
+              <ApiClientContext.Provider value={apiClient}>
+                <WaitForUserInfo>
+                  <Route path={routes.root.path} exact>
+                    <ElectionsScreen
+                      filterText={electionsFilterText}
+                      setFilterText={setElectionsFilterText}
                     />
-                  </WaitForUserInfo>
-                </Switch>
-              </BrowserRouter>
-            </QueryClientProvider>
-          </UnauthenticatedApiClientContext.Provider>
-        </ApiClientContext.Provider>
+                  </Route>
+                  <Route
+                    path={electionParamRoutes.root.path}
+                    component={ElectionScreens}
+                  />
+                </WaitForUserInfo>
+              </ApiClientContext.Provider>
+            </Switch>
+          </BrowserRouter>
+        </QueryClientProvider>
       </ErrorBoundary>
     </AppBase>
   );

--- a/apps/design/frontend/src/public_api.ts
+++ b/apps/design/frontend/src/public_api.ts
@@ -1,0 +1,29 @@
+import React from 'react';
+import * as grout from '@votingworks/grout';
+import type { UnauthenticatedApi } from '@votingworks/design-backend';
+import { useMutation } from '@tanstack/react-query';
+
+export type UnauthenticatedApiClient = grout.Client<UnauthenticatedApi>;
+
+export function createUnauthenticatedApiClient(): UnauthenticatedApiClient {
+  return grout.createClient<UnauthenticatedApi>({ baseUrl: '/public/api' });
+}
+
+export const UnauthenticatedApiClientContext = React.createContext<
+  UnauthenticatedApiClient | undefined
+>(undefined);
+
+export function useUnauthenticatedApiClient(): UnauthenticatedApiClient {
+  const apiClient = React.useContext(UnauthenticatedApiClientContext);
+  if (!apiClient) {
+    throw new Error('UnauthenticatedApiClientContext.Provider not found');
+  }
+  return apiClient;
+}
+
+export const processQrCodeReport = {
+  useMutation() {
+    const apiClient = useUnauthenticatedApiClient();
+    return useMutation(apiClient.processQrCodeReport);
+  },
+} as const;

--- a/apps/design/frontend/src/reporting_results_confirmation_screen.tsx
+++ b/apps/design/frontend/src/reporting_results_confirmation_screen.tsx
@@ -6,7 +6,7 @@ import {
   MainHeader,
   Screen,
 } from '@votingworks/ui';
-import { processQrCodeReport } from './api';
+import { processQrCodeReport } from './public_api';
 
 export function ResultsScreen({
   children,

--- a/apps/design/frontend/src/reporting_results_confirmation_screen.tsx
+++ b/apps/design/frontend/src/reporting_results_confirmation_screen.tsx
@@ -1,0 +1,119 @@
+import { useEffect } from 'react';
+import {
+  LoadingAnimation,
+  Main,
+  MainContent,
+  MainHeader,
+  Screen,
+} from '@votingworks/ui';
+import { processQrCodeReport } from './api';
+
+export function ResultsScreen({
+  children,
+}: {
+  children?: React.ReactNode;
+}): JSX.Element {
+  return (
+    <Screen flexDirection="row">
+      <Main flexColumn>
+        <MainHeader>
+          <h1>Quick Results Reporting</h1>
+        </MainHeader>
+        {children}
+      </Main>
+    </Screen>
+  );
+}
+
+export function ReportingResultsConfirmationScreen(): JSX.Element | null {
+  const queryParams = new URLSearchParams(window.location.search);
+  const payload = queryParams.get('p');
+  const signature = queryParams.get('s');
+
+  const {
+    mutate: processQrCodeReportMutate,
+    data: reportResult,
+    isLoading,
+    error,
+  } = processQrCodeReport.useMutation();
+
+  useEffect(() => {
+    if (payload && signature) {
+      processQrCodeReportMutate({ payload, signature });
+    }
+  }, [payload, signature, processQrCodeReportMutate]);
+
+  if (
+    !payload ||
+    !signature ||
+    error ||
+    (reportResult && reportResult.isErr())
+  ) {
+    return (
+      <ResultsScreen>
+        <MainContent>
+          <div>Invalid Request</div>
+        </MainContent>
+      </ResultsScreen>
+    );
+  }
+
+  if (isLoading || !reportResult) {
+    return (
+      <Screen>
+        <Main centerChild>
+          <LoadingAnimation />
+        </Main>
+      </Screen>
+    );
+  }
+
+  const reportData = reportResult.ok();
+
+  return (
+    <ResultsScreen>
+      <MainContent>
+        <div>
+          <p>Thank you for reporting your election results!</p>
+          <div style={{ marginTop: '20px' }}>
+            <h2>Report Details:</h2>
+            <p>
+              <strong>Ballot Hash:</strong> {reportData.ballotHash}
+            </p>
+            <p>
+              <strong>Machine ID:</strong> {reportData.machineId}
+            </p>
+            <p>
+              <strong>Environment:</strong>{' '}
+              {reportData.isLive ? 'Live' : 'Test'}
+            </p>
+            <p>
+              <strong>Timestamp:</strong>{' '}
+              {reportData.signedTimestamp.toLocaleString()}
+            </p>
+            <p>
+              <strong>Precinct:</strong>{' '}
+              {reportData.precinctId
+                ? String(reportData.precinctId)
+                : 'Not specified'}
+            </p>
+            <details style={{ marginTop: '20px' }}>
+              <summary>
+                <strong>Tally Data</strong>
+              </summary>
+              <pre
+                style={{
+                  backgroundColor: '#f5f5f5',
+                  padding: '10px',
+                  overflow: 'auto',
+                }}
+              >
+                {JSON.stringify(reportData.tally, null, 2)}
+              </pre>
+            </details>
+          </div>
+        </div>
+      </MainContent>
+    </ResultsScreen>
+  );
+}

--- a/apps/design/frontend/src/routes.ts
+++ b/apps/design/frontend/src/routes.ts
@@ -2,6 +2,13 @@ import type { UserFeaturesConfig } from '@votingworks/design-backend';
 import { ElectionId } from '@votingworks/types';
 import { Route } from '@votingworks/ui';
 
+export const resultsRoutes = {
+  root: {
+    title: 'Results Reported',
+    path: '/report',
+  },
+} as const;
+
 export const routes = {
   root: {
     title: 'Elections',

--- a/apps/design/frontend/vite.config.ts
+++ b/apps/design/frontend/vite.config.ts
@@ -84,6 +84,7 @@ export default defineConfig(async (env) => {
       proxy: {
         '/auth': 'http://localhost:3002',
         '/api': 'http://localhost:3002',
+        '/public/api': 'http://localhost:3002',
         '/files': 'http://localhost:3002',
       },
       port: 3000,


### PR DESCRIPTION
## Overview
Adds the basic scaffolding in VxDesign for an endpoint that will be encoded in the QR code itself, hit with query paramters of the results data, pass that data to a grout backend endpoint to save it, and return a UI to the user confirming the results. The actual UI and logic in the "save" endpoint here are not meant to be fully featured and will be fleshed out further in future PRs. This is just a barebones setup that receives a url, formatted and encoded in the historical format used for previous demos, and returns the parsed information back to the frontend to be displayed. 

This page is NOT meant to be behind oauth, so tweaks to how we enforce that needed to be made to allow for this carve out. 

## Demo Video or Screenshot

<img width="880" height="541" alt="Screenshot 2025-09-09 at 1 33 07 PM" src="https://github.com/user-attachments/assets/cf2c068b-d780-4208-84f4-ac2434fa94f9" />

See in review app, legal qr code url: https://vxdesign-caro-vxqr-back-mm4ifq.herokuapp.com/report?p=1%2F%2Fqr1%2F%2F331fbe5e67a29cbc066e2d237facd9a9da9cea6151f4de7420a01da6ca433e39.0000.1.1757440695.W1sxLDIsMywwLDAsMF0sWzMsMCwzLDAsMCwwLDBdLFsxLDIsMywwLDAsMF0sWzMsMCwzLDAsMCwwLDBdLFsxLDIsMywwLDAsMCwwLDBdLFszLDAsMywwLDAsMCwwLDBdLFs0LDgsMywwLDAsMCwwLDAsMCwwXSxbNiwwLDMsMiwwLDAsMCwwLDAsMCwyLDIsMF1d&s=MEUCIQCUMqMP_Th_ioZqzBkTw7o2Fp3bFU-5f8KsxaurRASdcwIgbqpMIztriWT7saJWRdT0djjWFOJ2TY-NsfY4yEGPq3A
invalid url: https://vxdesign-caro-vxqr-back-mm4ifq.herokuapp.com/report

## Testing Plan
Loaded valid and invalid url params, saw desired results, did not see redirect to auth login. Went to normal vxdesign routes, got redirected to auth login. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
