### PR TITLE
VxDesign: Disable create and load election buttons while either is loading

### DIFF
--- a/apps/design/frontend/src/create_election_button.tsx
+++ b/apps/design/frontend/src/create_election_button.tsx
@@ -9,6 +9,7 @@ import { OrgSelect } from './org_select';
 
 export interface CreateElectionButtonProps {
   variant?: ButtonVariant;
+  disabled: boolean;
 }
 
 const OrgModal = styled(Modal)`
@@ -19,7 +20,7 @@ const OrgModal = styled(Modal)`
 export function CreateElectionButton(
   props: CreateElectionButtonProps
 ): React.ReactNode {
-  const { variant } = props;
+  const { variant, disabled } = props;
   const createMutation = api.createElection.useMutation();
   const getUserFeaturesQuery = api.getUserFeatures.useQuery();
 
@@ -69,7 +70,7 @@ export function CreateElectionButton(
         icon="Add"
         onPress={features.ACCESS_ALL_ORGS ? setModalActive : createElection}
         value
-        disabled={modalActive}
+        disabled={modalActive || disabled}
       >
         Create Election
       </Button>

--- a/apps/design/frontend/src/elections_screen.tsx
+++ b/apps/design/frontend/src/elections_screen.tsx
@@ -398,6 +398,9 @@ export function ElectionsScreen({
       e.title.toLowerCase().includes(filterText.toLowerCase())
   );
 
+  const anyMutationIsLoading =
+    loadElectionMutation.isLoading || createElectionMutation.isLoading;
+
   return (
     <NavScreen>
       <Header>
@@ -446,12 +449,13 @@ export function ElectionsScreen({
               />
             </div>
             <CreateElectionButton
+              disabled={anyMutationIsLoading}
               variant={elections.length === 0 ? 'primary' : undefined}
             />
             <FileInputButton
               accept=".json"
               onChange={onSelectElectionFile}
-              disabled={createElectionMutation.isLoading}
+              disabled={anyMutationIsLoading}
             >
               Load Election
             </FileInputButton>


### PR DESCRIPTION

## Overview

Not a huge deal, just noticed that the existing logic was only to disable the load election button while the create election mutation was loading, so I figured I'd clean it up.
## Demo Video or Screenshot

## Testing Plan
Manual test
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
