### PR TITLE
VxAdmin: Add support for overvote and undervote adjudication

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -144,9 +144,11 @@ create table cvr_contest_tags (
   cvr_id varchar(36) not null,
   contest_id text not null,
   is_resolved boolean not null default false,
-  has_marginal_mark boolean not null default false,
+  has_overvote boolean not null default false,
+  has_undervote boolean not null default false,
   has_write_in boolean not null default false,
   has_unmarked_write_in boolean not null default false,
+  has_marginal_mark boolean not null default false,
   unique (cvr_id, contest_id),
   foreign key (cvr_id) references cvrs(id) on delete cascade
 );

--- a/apps/admin/backend/src/app.adjudication.test.ts
+++ b/apps/admin/backend/src/app.adjudication.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import {
+  afterEach,
+  beforeEach,
+  expect,
+  test,
+  vi,
+  describe,
+  beforeAll,
+} from 'vitest';
 import {
   electionGridLayoutNewHampshireTestBallotFixtures,
   electionTwoPartyPrimaryFixtures,
@@ -315,6 +323,372 @@ test('getAdjudicationQueue returns a properly ordered queue', async () => {
   expect(finalQueue.slice(1, 4)).toEqual(thirdQueue);
   // nextForAdjudication should not have changed; the new CVR is at the queue's end
   expect(finalNextForAdjudication).toEqual(fourthNextForAdjudication);
+});
+
+describe('getAdjudicationQueue sorts cvrs with different adjudication reasons properly', () => {
+  const systemSettings: SystemSettings = {
+    ...DEFAULT_SYSTEM_SETTINGS,
+    adminAdjudicationReasons: [
+      AdjudicationReason.MarginalMark,
+      AdjudicationReason.Overvote,
+      AdjudicationReason.Undervote,
+    ],
+    markThresholds: {
+      marginal: 0.05,
+      definite: 0.1,
+    },
+  };
+
+  const { manualCastVoteRecordExport } =
+    electionGridLayoutNewHampshireTestBallotFixtures;
+
+  const contestId = 'State-Representatives-Hillsborough-District-34-b1012d38';
+  const electionDefinition =
+    electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
+
+  let cvrWithMarginalMarkOnly: string;
+  let cvrWithOvervote: string;
+  let cvrWithOvervoteAndWriteIn: string;
+  let cvrWithUndervote: string;
+  let cvrWithWriteInOnly: string;
+  let cvrWithWriteInAndMarginalMark: string;
+  let cvrWithUndervoteAndWriteIn: string;
+  beforeAll(async () => {
+    cvrWithWriteInOnly = await modifyCastVoteRecordExport(
+      manualCastVoteRecordExport.asDirectoryPath(),
+      {
+        castVoteRecordModifier: (cvr) => ({
+          ...cvr,
+          UniqueId: `x-${cvr.UniqueId}`,
+        }),
+      }
+    );
+
+    // create a cvr with a write-in and marginal mark (write-in is already set in fixture)
+    cvrWithWriteInAndMarginalMark = await modifyCastVoteRecordExport(
+      manualCastVoteRecordExport.asDirectoryPath(),
+      {
+        castVoteRecordModifier: (cvr) => {
+          const snapshot = find(
+            cvr.CVRSnapshot,
+            (s) => s.Type === CVR.CVRType.Original
+          );
+          const contest = snapshot.CVRContest.find(
+            (c) => c.ContestId === contestId
+          );
+          if (contest) {
+            const option0 = assertDefined(
+              contest.CVRContestSelection[0]?.SelectionPosition[0]
+            );
+            option0.MarkMetricValue = ['0.08'];
+          }
+          return {
+            ...cvr,
+            UniqueId: `x-1-${cvr.UniqueId}`,
+          };
+        },
+      }
+    );
+
+    cvrWithMarginalMarkOnly = await modifyCastVoteRecordExport(
+      manualCastVoteRecordExport.asDirectoryPath(),
+      {
+        castVoteRecordModifier: (cvr) => {
+          const snapshot = find(
+            cvr.CVRSnapshot,
+            (s) => s.Type === CVR.CVRType.Original
+          );
+          const contest = snapshot.CVRContest.find(
+            (c) => c.ContestId === contestId
+          );
+          if (contest) {
+            const option0 = assertDefined(
+              contest.CVRContestSelection[0]?.SelectionPosition[0]
+            );
+            option0.MarkMetricValue = ['0.08'];
+            // mark all remaining options as unmarked, removing the pre-existing write-in
+            for (const option of contest.CVRContestSelection.slice(1)) {
+              assertDefined(option?.SelectionPosition[0]).MarkMetricValue = [
+                '0.0',
+              ];
+              assertDefined(option?.SelectionPosition[0]).HasIndication =
+                CVR.IndicationStatus.No;
+            }
+          }
+          return {
+            ...cvr,
+            UniqueId: `x-2-${cvr.UniqueId}`,
+          };
+        },
+      }
+    );
+
+    cvrWithOvervote = await modifyCastVoteRecordExport(
+      manualCastVoteRecordExport.asDirectoryPath(),
+      {
+        castVoteRecordModifier: (cvr) => {
+          const snapshot = find(
+            cvr.CVRSnapshot,
+            (s) => s.Type === CVR.CVRType.Modified
+          );
+          const contest = snapshot.CVRContest.find(
+            (c) => c.ContestId === contestId
+          );
+          if (contest) {
+            // Add selections for more candidates than seats to create overvote
+            const contestDefinition = electionDefinition.election.contests.find(
+              (c) => c.id === contestId
+            );
+            assert(contestDefinition && contestDefinition.type === 'candidate');
+            contest.CVRContestSelection = [];
+            const candidatesToSelect = contestDefinition.candidates.slice(
+              0,
+              contestDefinition.seats + 1
+            );
+            for (const candidate of candidatesToSelect) {
+              contest.CVRContestSelection.push({
+                '@type': 'CVR.CVRContestSelection',
+                ContestSelectionId: candidate.id,
+                SelectionPosition: [
+                  {
+                    '@type': 'CVR.SelectionPosition',
+                    CVRWriteIn: undefined,
+                    HasIndication: CVR.IndicationStatus.Yes,
+                    MarkMetricValue: ['0.9'],
+                    NumberVotes: 1,
+                    Position: 1,
+                  },
+                ],
+              });
+            }
+          }
+          return {
+            ...cvr,
+            UniqueId: `x-o-${cvr.UniqueId}`,
+          };
+        },
+      }
+    );
+
+    cvrWithOvervoteAndWriteIn = await modifyCastVoteRecordExport(
+      manualCastVoteRecordExport.asDirectoryPath(),
+      {
+        castVoteRecordModifier: (cvr) => {
+          const snapshot = find(
+            cvr.CVRSnapshot,
+            (s) => s.Type === CVR.CVRType.Modified
+          );
+          const contest = snapshot.CVRContest.find(
+            (c) => c.ContestId === contestId
+          );
+          if (contest) {
+            // Add selections for more candidates than seats to create overvote
+            const contestDefinition = electionDefinition.election.contests.find(
+              (c) => c.id === contestId
+            );
+            assert(contestDefinition && contestDefinition.type === 'candidate');
+            const candidatesToSelect = contestDefinition.candidates.slice(
+              0,
+              contestDefinition.seats + 1
+            );
+            for (const candidate of candidatesToSelect) {
+              contest.CVRContestSelection.push({
+                '@type': 'CVR.CVRContestSelection',
+                ContestSelectionId: candidate.id,
+                SelectionPosition: [
+                  {
+                    '@type': 'CVR.SelectionPosition',
+                    CVRWriteIn: undefined,
+                    HasIndication: CVR.IndicationStatus.Yes,
+                    MarkMetricValue: ['0.9'],
+                    NumberVotes: 1,
+                    Position: 1,
+                  },
+                ],
+              });
+            }
+          }
+          return {
+            ...cvr,
+            UniqueId: `x-ow-${cvr.UniqueId}`,
+          };
+        },
+      }
+    );
+
+    cvrWithUndervote = await modifyCastVoteRecordExport(
+      manualCastVoteRecordExport.asDirectoryPath(),
+      {
+        castVoteRecordModifier: (cvr) => {
+          const snapshot = find(
+            cvr.CVRSnapshot,
+            (s) => s.Type === CVR.CVRType.Modified
+          );
+          const contest = snapshot.CVRContest.find(
+            (c) => c.ContestId === contestId
+          );
+          if (contest) {
+            contest.CVRContestSelection = [];
+          }
+          return {
+            ...cvr,
+            UniqueId: `x-u-${cvr.UniqueId}`,
+          };
+        },
+      }
+    );
+
+    cvrWithUndervoteAndWriteIn = await modifyCastVoteRecordExport(
+      manualCastVoteRecordExport.asDirectoryPath(),
+      {
+        castVoteRecordModifier: (cvr) => {
+          const snapshot = find(
+            cvr.CVRSnapshot,
+            (s) => s.Type === CVR.CVRType.Modified
+          );
+          const contest = snapshot.CVRContest.find(
+            (c) => c.ContestId === contestId
+          );
+          if (contest) {
+            contest.CVRContestSelection = contest.CVRContestSelection.slice(1);
+          }
+          return {
+            ...cvr,
+            UniqueId: `x-uw-${cvr.UniqueId}`,
+          };
+        },
+      }
+    );
+  });
+
+  test('overvote only vs overvote with write in sorts on insertion order', async () => {
+    const { auth, apiClient } = buildTestEnvironment();
+    await configureMachine(apiClient, auth, electionDefinition, systemSettings);
+    (
+      await apiClient.addCastVoteRecordFile({
+        path: cvrWithOvervote,
+      })
+    ).unsafeUnwrap();
+
+    const [cvrWithOvervoteId] = await apiClient.getAdjudicationQueue({
+      contestId,
+    });
+    assert(cvrWithOvervoteId !== undefined);
+    (
+      await apiClient.addCastVoteRecordFile({
+        path: cvrWithOvervoteAndWriteIn,
+      })
+    ).unsafeUnwrap();
+
+    const queue = await apiClient.getAdjudicationQueue({
+      contestId,
+    });
+    expect(queue[0]).toEqual(cvrWithOvervoteId);
+    expect(queue[1]).toBeDefined();
+  });
+
+  test('overvote only vs undervote only sorts overvote first', async () => {
+    const { auth, apiClient } = buildTestEnvironment();
+    await configureMachine(apiClient, auth, electionDefinition, systemSettings);
+    (
+      await apiClient.addCastVoteRecordFile({
+        path: cvrWithUndervote,
+      })
+    ).unsafeUnwrap();
+
+    const [cvrWithUndervoteId] = await apiClient.getAdjudicationQueue({
+      contestId,
+    });
+    assert(cvrWithUndervoteId !== undefined);
+    (
+      await apiClient.addCastVoteRecordFile({
+        path: cvrWithOvervote,
+      })
+    ).unsafeUnwrap();
+
+    const queue = await apiClient.getAdjudicationQueue({
+      contestId,
+    });
+    expect(queue[0]).toBeDefined();
+    expect(queue[1]).toEqual(cvrWithUndervoteId);
+  });
+
+  test('undervote only vs undervote with write-in sorts pure undervote last', async () => {
+    const { auth, apiClient } = buildTestEnvironment();
+    await configureMachine(apiClient, auth, electionDefinition, systemSettings);
+    (
+      await apiClient.addCastVoteRecordFile({
+        path: cvrWithUndervote,
+      })
+    ).unsafeUnwrap();
+
+    const [cvrWithUndervoteId] = await apiClient.getAdjudicationQueue({
+      contestId,
+    });
+    assert(cvrWithUndervoteId !== undefined);
+    (
+      await apiClient.addCastVoteRecordFile({
+        path: cvrWithUndervoteAndWriteIn,
+      })
+    ).unsafeUnwrap();
+
+    const queue = await apiClient.getAdjudicationQueue({
+      contestId,
+    });
+    expect(queue[0]).toBeDefined();
+    expect(queue[1]).toEqual(cvrWithUndervoteId);
+  });
+
+  test('write-in only vs write-in with marginal mark sorts pure write-in first', async () => {
+    const { auth, apiClient } = buildTestEnvironment();
+    await configureMachine(apiClient, auth, electionDefinition, systemSettings);
+    (
+      await apiClient.addCastVoteRecordFile({
+        path: cvrWithWriteInOnly,
+      })
+    ).unsafeUnwrap();
+
+    const [cvrWithWriteInOnlyId] = await apiClient.getAdjudicationQueue({
+      contestId,
+    });
+    assert(cvrWithWriteInOnlyId !== undefined);
+    (
+      await apiClient.addCastVoteRecordFile({
+        path: cvrWithWriteInAndMarginalMark,
+      })
+    ).unsafeUnwrap();
+
+    const queue = await apiClient.getAdjudicationQueue({
+      contestId,
+    });
+    expect(queue[0]).toEqual(cvrWithWriteInOnlyId);
+    expect(queue[1]).toBeDefined();
+  });
+
+  test('undervote only vs marginal mark sorts undervote last', async () => {
+    const { auth, apiClient } = buildTestEnvironment();
+    await configureMachine(apiClient, auth, electionDefinition, systemSettings);
+    (
+      await apiClient.addCastVoteRecordFile({
+        path: cvrWithUndervote,
+      })
+    ).unsafeUnwrap();
+    const [cvrWithUndervoteId] = await apiClient.getAdjudicationQueue({
+      contestId,
+    });
+    assert(cvrWithUndervoteId !== undefined);
+    (
+      await apiClient.addCastVoteRecordFile({
+        path: cvrWithMarginalMarkOnly,
+      })
+    ).unsafeUnwrap();
+
+    const queue = await apiClient.getAdjudicationQueue({
+      contestId,
+    });
+    expect(queue[0]).toBeDefined();
+    expect(queue[1]).toEqual(cvrWithUndervoteId);
+  });
 });
 
 test('getAdjudicationQueueMetadata', async () => {

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -104,20 +104,21 @@ type StoreCastVoteRecordAttributes = Omit<
 
 /**
  * Adjudication queue ordering:
- * 1. Overvotes
- * 2. Write-ins (unmarked and marked), no marginal marks, no overvotes, no undervotes
- * 3. Write-ins and marginal marks, no overvotes, no undervotes
- * 4. Marginal marks, no overvotes, no undervotes
- * 5. Undervotes
+ * Note: The intention is to show the most important issues first
+ * 1. All overvotes (regardless of write-ins, marginal marks)
+ * 2. Write-ins (unmarked and marked), no marginal marks, includes undervotes
+ * 3. Write-ins and marginal marks, includes undervotes
+ * 4. Marginal marks, includes undervotes
+ * 5. Undervotes without marginal marks or write-ins
  */
 
 const ADJUDICATION_QUEUE_ORDER_BY = `
   order by
     case
       when has_overvote = 1 then 1
-      when (has_write_in = 1 or has_unmarked_write_in = 1) and has_marginal_mark = 0 and has_undervote = 0 then 2
-      when (has_write_in = 1 or has_unmarked_write_in = 1) and has_marginal_mark = 1 and has_undervote = 0 then 3
-      when has_marginal_mark = 1 and has_overvote = 0 and has_undervote = 0 then 4
+      when (has_write_in = 1 or has_unmarked_write_in = 1) and has_marginal_mark = 0 then 2
+      when (has_write_in = 1 or has_unmarked_write_in = 1) and has_marginal_mark = 1 then 3
+      when has_marginal_mark = 1 then 4
       else 5
     end,
     sequence_id

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -102,12 +102,23 @@ type StoreCastVoteRecordAttributes = Omit<
   readonly partyId: string | null;
 };
 
+/**
+ * Adjudication queue ordering:
+ * 1. Overvotes
+ * 2. Write-ins (unmarked and marked), no marginal marks, no overvotes, no undervotes
+ * 3. Write-ins and marginal marks, no overvotes, no undervotes
+ * 4. Marginal marks, no overvotes, no undervotes
+ * 5. Undervotes
+ */
+
 const ADJUDICATION_QUEUE_ORDER_BY = `
   order by
     case
-      when (has_write_in = 1 or has_unmarked_write_in = 1) and has_marginal_mark = 0 then 1
-      when (has_write_in = 1 or has_unmarked_write_in = 1) and has_marginal_mark = 1 then 2
-      else 3
+      when has_overvote = 1 then 1
+      when (has_write_in = 1 or has_unmarked_write_in = 1) and has_marginal_mark = 0 and has_undervote = 0 then 2
+      when (has_write_in = 1 or has_unmarked_write_in = 1) and has_marginal_mark = 1 and has_undervote = 0 then 3
+      when has_marginal_mark = 1 and has_overvote = 0 and has_undervote = 0 then 4
+      else 5
     end,
     sequence_id
 `;
@@ -2618,6 +2629,8 @@ export class Store {
   addCvrContestTag({
     cvrId,
     contestId,
+    hasOvervote = false,
+    hasUndervote = false,
     hasWriteIn = false,
     hasUnmarkedWriteIn = false,
     hasMarginalMark = false,
@@ -2628,14 +2641,18 @@ export class Store {
           cvr_id,
           contest_id,
           is_resolved,
+          has_overvote,
+          has_undervote,
           has_write_in,
           has_unmarked_write_in,
           has_marginal_mark
-        ) values (?, ?, ?, ?, ?, ?)
+        ) values (?, ?, ?, ?, ?, ?, ?, ?)
       `,
       cvrId,
       contestId,
       asSqliteBool(false),
+      asSqliteBool(hasOvervote),
+      asSqliteBool(hasUndervote),
       asSqliteBool(hasWriteIn),
       asSqliteBool(hasUnmarkedWriteIn),
       asSqliteBool(hasMarginalMark)
@@ -2655,6 +2672,8 @@ export class Store {
           cvr_id as cvrId,
           contest_id as contestId,
           is_resolved as isResolved,
+          has_overvote as hasOvervote,
+          has_undervote as hasUndervote,
           has_write_in as hasWriteIn,
           has_unmarked_write_in as hasUnmarkedWriteIn,
           has_marginal_mark as hasMarginalMark
@@ -2670,6 +2689,8 @@ export class Store {
           cvrId: Id;
           contestId: ContestId;
           isResolved: SqliteBool;
+          hasOvervote: SqliteBool;
+          hasUndervote: SqliteBool;
           hasWriteIn: SqliteBool;
           hasUnmarkedWriteIn: SqliteBool;
           hasMarginalMark: SqliteBool;
@@ -2680,6 +2701,8 @@ export class Store {
       ? {
           ...row,
           isResolved: fromSqliteBool(row.isResolved),
+          hasOvervote: fromSqliteBool(row.hasOvervote),
+          hasUndervote: fromSqliteBool(row.hasUndervote),
           hasWriteIn: fromSqliteBool(row.hasWriteIn),
           hasUnmarkedWriteIn: fromSqliteBool(row.hasUnmarkedWriteIn),
           hasMarginalMark: fromSqliteBool(row.hasMarginalMark),

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -389,6 +389,8 @@ export interface CvrContestTag {
   hasMarginalMark?: boolean;
   hasWriteIn?: boolean;
   hasUnmarkedWriteIn?: boolean;
+  hasOvervote?: boolean;
+  hasUndervote?: boolean;
 }
 
 /**

--- a/apps/admin/backend/src/util/cast_vote_records.ts
+++ b/apps/admin/backend/src/util/cast_vote_records.ts
@@ -8,7 +8,10 @@ import {
 import { CachedElectionLookups } from '@votingworks/utils';
 import { CastVoteRecordAdjudicationFlags, CvrContestTag } from '../types';
 
-function getNumberVotesAllowed(contest: AnyContest): number {
+/**
+ * Returns the number of allowed votes for the contest
+ */
+export function getNumberVotesAllowed(contest: AnyContest): number {
   if (contest.type === 'yesno') {
     return 1;
   }

--- a/apps/admin/backend/test/mock_cvr_file.ts
+++ b/apps/admin/backend/test/mock_cvr_file.ts
@@ -136,6 +136,8 @@ export function addMockCvrFileToStore({
         writeIns,
         isHmpb,
         markScores: mockCastVoteRecord.markScores,
+        votes: mockCastVoteRecord.votes,
+        electionDefinition,
       })) {
         store.addCvrContestTag(tag);
       }

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
@@ -642,10 +642,12 @@ describe('vote adjudication', () => {
     userEvent.click(elephantCheckbox);
     expect(screen.queryByText(/overvote/i)).toBeInTheDocument();
 
-    // remove the overvote
+    // remove the overvote, cause an undervote
+    expect(screen.queryByText(/undervote/i)).toBeNull();
     userEvent.click(zebraCheckbox);
     userEvent.click(elephantCheckbox);
     expect(screen.queryByText(/overvote/i)).toBeNull();
+    expect(screen.queryByText(/undervote/i)).toBeInTheDocument();
 
     // check caption for new vote adjudication from true to false
     expect(kangarooCheckbox).toBeChecked();

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
@@ -924,7 +924,7 @@ export function ContestAdjudicationScreen(): JSX.Element {
             )}
             {isUndervote && (
               <Label>
-                <Icons.Info /> Undervote
+                <Icons.Closed /> Undervote
               </Label>
             )}
           </BallotVoteCount>

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
@@ -682,12 +682,14 @@ export function ContestAdjudicationScreen(): JSX.Element {
   const writeIns = writeInsQuery.data;
   const ballotImage = ballotImageViewQuery.data;
   const writeInCandidates = writeInCandidatesQuery.data;
+  const cvrContestTag = cvrContestTagQuery.data;
   const cvrQueueIndex = maybeCvrQueueIndex;
   const currentCvrId = maybeCurrentCvrId;
 
   const voteCount = Object.values(hasVoteByOptionId).filter(Boolean).length;
   const seatCount = isCandidateContest ? contest.seats : 1;
   const isOvervote = voteCount > seatCount;
+  const isUndervote = voteCount < seatCount;
   const numPendingWriteIns = iter(writeInOptionIds)
     .filter((optionId) => isPendingWriteIn(writeInStatusByOptionId[optionId]))
     .count();
@@ -695,6 +697,11 @@ export function ContestAdjudicationScreen(): JSX.Element {
   const allMarginalMarksAdjudicated = !Object.values(
     marginalMarkStatusByOptionId
   ).some((status) => status !== 'resolved');
+  const allowSaveWithoutChanges =
+    (cvrContestTag.hasOvervote || cvrContestTag.hasUndervote) &&
+    !cvrContestTag.isResolved &&
+    allWriteInsAdjudicated &&
+    allMarginalMarksAdjudicated;
 
   const isHmpb = ballotImage.type === 'hmpb';
   const isBmd = ballotImage.type === 'bmd';
@@ -915,6 +922,11 @@ export function ContestAdjudicationScreen(): JSX.Element {
                 <Icons.Disabled color="danger" /> Overvote
               </Label>
             )}
+            {isUndervote && (
+              <Label>
+                <Icons.Info /> Undervote
+              </Label>
+            )}
           </BallotVoteCount>
           {!isVoteStateReady ? (
             <ContestOptionButtonList style={{ justifyContent: 'center' }}>
@@ -1064,7 +1076,7 @@ export function ContestAdjudicationScreen(): JSX.Element {
                 disabled={
                   !allWriteInsAdjudicated ||
                   !allMarginalMarksAdjudicated ||
-                  !isModified
+                  (!isModified && !allowSaveWithoutChanges)
                 }
                 icon="Done"
                 onPress={saveAndNext}

--- a/apps/design/frontend/src/system_settings_screen.test.tsx
+++ b/apps/design/frontend/src/system_settings_screen.test.tsx
@@ -173,6 +173,19 @@ test('adjudication reasons', async () => {
     expect(options[0]).toBeChecked();
   }
 
+  const admin = screen.getByRole('group', { name: 'VxAdmin' });
+  const options = within(admin).getAllByRole('checkbox');
+  expect(options).toHaveLength(3);
+  for (const option of options) {
+    expect(option).not.toBeChecked();
+  }
+  expect(options[0]).toHaveTextContent('Overvote');
+  expect(options[1]).toHaveTextContent('Undervote');
+  expect(options[2]).toHaveTextContent('Marginal Mark');
+
+  userEvent.click(options[0]);
+  expect(options[0]).toBeChecked();
+
   expect(
     screen.getByRole('checkbox', { name: 'Disallow Casting Overvotes' })
   ).not.toBeChecked();
@@ -187,6 +200,7 @@ test('adjudication reasons', async () => {
     ...DEFAULT_SYSTEM_SETTINGS,
     precinctScanAdjudicationReasons: [AdjudicationReason.Overvote],
     centralScanAdjudicationReasons: [AdjudicationReason.Overvote],
+    adminAdjudicationReasons: [AdjudicationReason.Overvote],
     disallowCastingOvervotes: true,
   };
   apiMock.updateSystemSettings
@@ -505,7 +519,7 @@ test('all controls are disabled until clicking "Edit"', async () => {
   const allCheckboxes = document.body.querySelectorAll('[role=checkbox]');
   const allControls = [...allTextBoxes, ...allCheckboxes];
 
-  expect(allControls).toHaveLength(24);
+  expect(allControls).toHaveLength(26);
 
   for (const control of allControls) {
     expect(control).toBeDisabled();

--- a/apps/design/frontend/src/system_settings_screen.tsx
+++ b/apps/design/frontend/src/system_settings_screen.tsx
@@ -139,7 +139,18 @@ export function SystemSettingsForm({
   ];
 
   const scannerAdjudicationReasonOptions = adjudicationReasonOptions.filter(
+    // Not implemented
     (option) => option.value !== AdjudicationReason.MarginalMark
+  );
+
+  const adminAdjudicationReasonOptions = adjudicationReasonOptions.filter(
+    (option) =>
+      // Not implemented
+      option.value !== AdjudicationReason.BlankBallot &&
+      // UnmarkedWriteIn is excluded from adminAdjudicationReasons because
+      // admin will surface all unmarked write-ins that the scanner tags.
+      // It is effectively equal to the scanner's adjudication setting.
+      option.value !== AdjudicationReason.UnmarkedWriteIn
   );
 
   enum CvrOption {
@@ -217,9 +228,7 @@ export function SystemSettingsForm({
             />
             <CheckboxGroup
               label="VxAdmin"
-              options={adjudicationReasonOptions.filter((option) =>
-                [AdjudicationReason.MarginalMark].includes(option.value)
-              )}
+              options={adminAdjudicationReasonOptions}
               value={systemSettings.adminAdjudicationReasons ?? []}
               onChange={(value) =>
                 setSystemSettings({


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/6505

Porting this over from the `la-demo` branch [PR
](https://github.com/votingworks/vxsuite/pull/7142)
## Demo Video or Screenshot

<img width="879" height="549" alt="undervote" src="https://github.com/user-attachments/assets/33d89721-b27e-4fe8-acb7-1c9fa126e80d" />

https://github.com/user-attachments/assets/e7f3802f-af9d-46de-aa5e-999df7e14834

## Testing Plan

Automated tests added/updated
Manual testing

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
