### PR TITLE
default to bubble marks

### DIFF
--- a/apps/mark/backend/schema.sql
+++ b/apps/mark/backend/schema.sql
@@ -8,7 +8,7 @@ create table election (
   is_test_mode boolean not null default true,
   polls_state text not null default "polls_closed_initial",
   ballots_printed_count integer not null default 0,
-  print_mode text default "summary",
+  print_mode text default "bubble_marks",
   created_at timestamp not null default current_timestamp
 );
 


### PR DESCRIPTION
## Overview

@kofi-q to avoid accidentally printing summary ballots, switching the default to `bubble_marks` on this branch. This looks OK, right? I haven't validated but seems very straightforward, if you could validate as you test other VxMark stuff, would be great.