### PR TITLE
Cherry-pick VxQR on screen

### DIFF
--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -9,6 +9,7 @@ import {
   DiagnosticOutcome,
 } from '@votingworks/types';
 import {
+  combineElectionResults,
   getPrecinctSelectionName,
   isElectionManagerAuth,
   singlePrecinctSelectionFor,
@@ -30,6 +31,7 @@ import {
   InsertedSmartCardAuthApi,
   generateRandomAes256Key,
   generateSignedHashValidationQrCodeValue,
+  generateSignedQuickResultsReportingUrl,
 } from '@votingworks/auth';
 import { UsbDrive, UsbDriveStatus } from '@votingworks/usb-drive';
 import {
@@ -69,6 +71,7 @@ import {
 } from './util/diagnostics';
 import { saveReadinessReport } from './printing/readiness_report';
 import { Player as AudioPlayer, SoundName } from './audio/player';
+import { getScannerResults } from './util/results';
 
 export const BALLOT_AUDIT_ID_FILE_NAME = 'ballot-audit-id-secret-key.txt';
 
@@ -572,6 +575,35 @@ export function buildApi({
 
     playSound(input: { name: SoundName }): Promise<void> {
       return audioPlayer.play(input.name);
+    },
+
+    async getQuickResultsReportingUrl(): Promise<string> {
+      const { machineId } = getMachineConfig();
+      const { electionDefinition } = assertDefined(store.getElectionRecord());
+      const systemSettings = store.getSystemSettings();
+      const pollState = store.getPollsState();
+      if (
+        !systemSettings ||
+        !systemSettings.quickResultsReportingUrl ||
+        pollState !== 'polls_closed_final'
+      ) {
+        return '';
+      }
+      const scannerResultsByParty = await getScannerResults({ store });
+
+      const combinedResults = combineElectionResults({
+        election: electionDefinition.election,
+        allElectionResults: scannerResultsByParty,
+      });
+      const signedQuickResultsReportingUrl =
+        await generateSignedQuickResultsReportingUrl({
+          electionDefinition,
+          quickResultsReportingUrl: systemSettings.quickResultsReportingUrl,
+          signingMachineId: machineId,
+          isLiveMode: !store.getTestMode(),
+          results: combinedResults,
+        });
+      return signedQuickResultsReportingUrl;
     },
 
     ...createUiStringsApi({

--- a/apps/scan/backend/src/app_quick_results.test.ts
+++ b/apps/scan/backend/src/app_quick_results.test.ts
@@ -1,0 +1,110 @@
+import { expect, test, vi, beforeEach } from 'vitest';
+import { DEFAULT_SYSTEM_SETTINGS, SystemSettings } from '@votingworks/types';
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import {
+  BooleanEnvironmentVariableName,
+  getFeatureFlagMock,
+} from '@votingworks/utils';
+import { configureApp } from '../test/helpers/shared_helpers';
+import { withApp } from '../test/helpers/pdi_helpers';
+import { PrecinctScannerPollsInfo } from '.';
+
+const mockFeatureFlagger = getFeatureFlagMock();
+
+vi.mock(import('@votingworks/utils'), async (importActual) => ({
+  ...(await importActual()),
+  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
+}));
+
+const systemSettings: SystemSettings = {
+  ...DEFAULT_SYSTEM_SETTINGS,
+  quickResultsReportingUrl: 'http://example-results-url.com/something',
+};
+const electionPackageWithQuickResults =
+  electionFamousNames2021Fixtures.electionJson.toElectionPackage(
+    systemSettings
+  );
+
+const electionPackageWithoutQuickResults =
+  electionFamousNames2021Fixtures.electionJson.toElectionPackage(
+    DEFAULT_SYSTEM_SETTINGS
+  );
+
+const pollsTransitionTime = new Date('2021-01-01T00:00:00.000').getTime();
+vi.mock(import('./util/get_current_time.js'), async (importActual) => ({
+  ...(await importActual()),
+  getCurrentTime: () => pollsTransitionTime,
+}));
+
+beforeEach(() => {
+  mockFeatureFlagger.resetFeatureFlags();
+  mockFeatureFlagger.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_ELECTION_PACKAGE_AUTHENTICATION
+  );
+});
+
+test('getQuickResultsReportingUrl returns expected results when system setting flag is set', async () => {
+  await withApp(async ({ apiClient, mockUsbDrive, mockAuth }) => {
+    await configureApp(apiClient, mockAuth, mockUsbDrive, {
+      testMode: true,
+      openPolls: true,
+      electionPackage: electionPackageWithQuickResults,
+    });
+    expect(await apiClient.getPollsInfo()).toEqual<PrecinctScannerPollsInfo>({
+      pollsState: 'polls_open',
+      lastPollsTransition: {
+        type: 'open_polls',
+        ballotCount: 0,
+        time: pollsTransitionTime,
+      },
+    });
+    // getQuickResultsReportingUrl should return an empty string when polls are open
+    expect(await apiClient.getQuickResultsReportingUrl()).toEqual('');
+
+    await apiClient.closePolls();
+    expect(await apiClient.getPollsInfo()).toEqual<PrecinctScannerPollsInfo>({
+      pollsState: 'polls_closed_final',
+      lastPollsTransition: {
+        type: 'close_polls',
+        ballotCount: 0,
+        time: pollsTransitionTime,
+      },
+    });
+    // Quick results URL should be returned as expected after polls are closed
+    expect(await apiClient.getQuickResultsReportingUrl()).toMatch(
+      /http:\/\/example-results-url\.com\/something\/\?p=[^&]+&s=[^&]+$/
+    );
+  });
+});
+
+test('getQuickResultsReportingUrl returns nothing when system setting flag is not set', async () => {
+  await withApp(async ({ apiClient, mockUsbDrive, mockAuth }) => {
+    await configureApp(apiClient, mockAuth, mockUsbDrive, {
+      testMode: true,
+      openPolls: true,
+      electionPackage: electionPackageWithoutQuickResults,
+    });
+    expect(await apiClient.getPollsInfo()).toEqual<PrecinctScannerPollsInfo>({
+      pollsState: 'polls_open',
+      lastPollsTransition: {
+        type: 'open_polls',
+        ballotCount: 0,
+        time: pollsTransitionTime,
+      },
+    });
+    // getQuickResultsReportingUrl should return an empty string when polls are open
+    expect(await apiClient.getQuickResultsReportingUrl()).toEqual('');
+
+    await apiClient.closePolls();
+    expect(await apiClient.getPollsInfo()).toEqual<PrecinctScannerPollsInfo>({
+      pollsState: 'polls_closed_final',
+      lastPollsTransition: {
+        type: 'close_polls',
+        ballotCount: 0,
+        time: pollsTransitionTime,
+      },
+    });
+    // Quick results URL should still be an empty string after polls are closed
+    expect(await apiClient.getQuickResultsReportingUrl()).toEqual('');
+  });
+});

--- a/apps/scan/frontend/src/api.ts
+++ b/apps/scan/frontend/src/api.ts
@@ -583,3 +583,17 @@ export const playSound = {
     return useMutation(apiClient.playSound);
   },
 } as const;
+
+export const getQuickResultsReportingUrl = {
+  queryKey(): QueryKey {
+    return ['getQuickResultsReportingUrl'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(
+      this.queryKey(),
+      () => apiClient.getQuickResultsReportingUrl(),
+      { cacheTime: 0 } // Always generate a fresh QR code value
+    );
+  },
+} as const;

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -162,6 +162,7 @@ test('election manager must set precinct', async () => {
   await screen.findByText('No Precinct Selected');
 
   // Poll worker card does nothing
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionGeneralDefinition);
   await screen.findByText('No Precinct Selected');
   apiMock.removeCard();
@@ -183,6 +184,7 @@ test('election manager must set precinct', async () => {
   screen.getByText('Center Springfield');
 
   // Poll worker card can be used to open polls now
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionGeneralDefinition);
   await screen.findByText('Do you want to open the polls?');
 });
@@ -234,6 +236,7 @@ test('election manager and poll worker configuration', async () => {
   apiMock.expectOpenPolls();
   apiMock.expectPrintReportSection(0).resolve();
   apiMock.expectGetPollsInfo('polls_open');
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionDefinition);
   userEvent.click(await screen.findByText('Open Polls'));
   await screen.findByText(
@@ -270,6 +273,7 @@ test('election manager and poll worker configuration', async () => {
   apiMock.expectOpenPolls();
   apiMock.expectPrintReportSection(0).resolve();
   apiMock.expectGetPollsInfo('polls_open');
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to open the polls?');
   userEvent.click(await screen.findByText('Open Polls'));
@@ -360,6 +364,7 @@ test('voter can cast a ballot that scans successfully', async () => {
 
   // Insert a pollworker card
   apiMock.expectGetScannerStatus(statusBallotCounted);
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionGeneralDefinition);
   await screen.findByText('Do you want to close the polls?');
 
@@ -539,6 +544,7 @@ test('scanning is not triggered when polls closed or cards present', async () =>
   apiMock.setPrinterStatus();
   renderApp();
   await screen.findByText('Polls Closed');
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionGeneralDefinition);
   await screen.findByText('Do you want to open the polls?');
   // Open Polls
@@ -559,6 +565,7 @@ test('scanning is not triggered when polls closed or cards present', async () =>
 
 test('poll worker can open and close polls without scanning any ballots', async () => {
   apiMock.expectGetConfig();
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.expectGetPollsInfo('polls_closed_initial');
   apiMock.expectGetUsbDriveStatus('mounted');
   apiMock.expectGetScannerStatus(statusNoPaper);
@@ -586,6 +593,7 @@ test('poll worker can open and close polls without scanning any ballots', async 
   await screen.findByText(/Insert Your Ballot/i);
 
   // Close Polls Flow
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionGeneralDefinition);
   await screen.findByText('Do you want to close the polls?');
   apiMock.expectClosePolls();
@@ -617,6 +625,7 @@ test('open polls, scan ballot, close polls, save results', async () => {
   renderApp();
   await screen.findByText('Polls Closed');
   // Open Polls Flow
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to open the polls?');
   apiMock.expectOpenPolls();
@@ -632,6 +641,7 @@ test('open polls, scan ballot, close polls, save results', async () => {
   await scanBallot();
 
   // Close Polls
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to close the polls?');
   apiMock.expectClosePolls();
@@ -658,6 +668,7 @@ test('poll worker can open, pause, unpause, and close poll without scanning any 
   await screen.findByText('Polls Closed');
 
   // Open Polls
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionGeneralDefinition);
   await screen.findByText('Do you want to open the polls?');
   apiMock.expectOpenPolls();
@@ -671,6 +682,7 @@ test('poll worker can open, pause, unpause, and close poll without scanning any 
   await screen.findByText(/Insert Your Ballot/i);
 
   // Pause Voting Flow
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionGeneralDefinition);
   await screen.findByText('Do you want to close the polls?');
   userEvent.click(await screen.findByText('Menu'));
@@ -686,6 +698,7 @@ test('poll worker can open, pause, unpause, and close poll without scanning any 
   await screen.findByText('Voting Paused');
 
   // Resume Voting Flow
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionGeneralDefinition);
   await screen.findByText('Do you want to resume voting?');
   apiMock.expectResumeVoting();
@@ -700,6 +713,7 @@ test('poll worker can open, pause, unpause, and close poll without scanning any 
   await screen.findByText(/Insert Your Ballot/i);
 
   // Close Polls Flow
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionGeneralDefinition);
   await screen.findByText('Do you want to close the polls?');
   apiMock.expectClosePolls();
@@ -731,6 +745,7 @@ test('ballot mode banner consistently displayed in voter screens', async () => {
   screen.getByText('Test Ballot Mode');
 
   // open polls
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to open the polls?');
   apiMock.expectOpenPolls();
@@ -771,6 +786,7 @@ test('ballot mode banner consistently displayed in voter screens', async () => {
   await screen.findByText(/Insert Your Ballot/i);
 
   // close polls
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionDefinition);
   await screen.findByText('Do you want to close the polls?');
   apiMock.expectClosePolls();
@@ -945,6 +961,7 @@ test('requires CVR sync if necessary', async () => {
     'A poll worker must sync cast vote records (CVRs) to the USB drive.'
   );
 
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionGeneralDefinition);
   await screen.findByText(
     'The inserted USB drive does not contain up-to-date records of the votes cast at this scanner. ' +

--- a/apps/scan/frontend/src/app_unhappy_paths.test.tsx
+++ b/apps/scan/frontend/src/app_unhappy_paths.test.tsx
@@ -159,6 +159,7 @@ test('shows message when printer cover is open', async () => {
   await screen.findByRole('heading', { name: 'Polls Closed' });
 
   // Open Polls
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionGeneralDefinition);
   await screen.findByText(/The paper roll holder is not attached/);
   apiMock.setPrinterStatus();
@@ -319,6 +320,7 @@ test('shows message when scanner cover is open', async () => {
   await screen.findByRole('heading', { name: 'Polls Closed' });
 
   // Open Polls
+  apiMock.expectGetQuickResultsReportingUrl();
   apiMock.authenticateAsPollWorker(electionGeneralDefinition);
   await screen.findByText('Open Polls');
   apiMock.expectOpenPolls();

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -13,6 +13,7 @@ import {
   H6,
   Font,
   H5,
+  QrCode,
 } from '@votingworks/ui';
 import { getPollsReportTitle } from '@votingworks/utils';
 import { ElectionDefinition, PollsTransitionType } from '@votingworks/types';
@@ -31,6 +32,7 @@ import {
   getPollsInfo,
   useApiClient,
   getConfig,
+  getQuickResultsReportingUrl,
 } from '../api';
 import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout';
 import {
@@ -58,6 +60,9 @@ type PollWorkerFlowState =
     }
   | {
       type: 'printing-report';
+    }
+  | {
+      type: 'view-reporting-qr-code';
     }
   | {
       type: 'post-print';
@@ -281,6 +286,8 @@ function PollWorkerScreenContents({
   const pauseVotingMutation = pauseVotingApi.useMutation();
   const resumeVotingMutation = resumeVotingApi.useMutation();
   const printReportSectionMutation = printReportSection.useMutation();
+  const getQuickResultsReportingUrlQuery =
+    getQuickResultsReportingUrl.useQuery();
 
   const [
     isShowingBallotsAlreadyScannedScreen,
@@ -486,6 +493,24 @@ function PollWorkerScreenContents({
             </CenteredText>
           </Screen>
         );
+      case 'view-reporting-qr-code':
+        return (
+          <Screen>
+            <CenteredText>
+              {getQuickResultsReportingUrlQuery.data && (
+                <div data-testid="quick-results-code">
+                  <QrCode
+                    value={getQuickResultsReportingUrlQuery.data}
+                    level="M"
+                    size={500}
+                  />
+                </div>
+              )}
+              <br />
+              <Button onPress={showAllPollWorkerActions}>Back</Button>
+            </CenteredText>
+          </Screen>
+        );
       case 'post-print':
         return (
           <PostPrintScreen
@@ -624,6 +649,18 @@ function PollWorkerScreenContents({
               Polls are <Font weight="bold">closed</Font>. Voting is complete
               and the polls cannot be reopened.
             </P>
+            <ButtonGrid>
+              {getQuickResultsReportingUrlQuery.data && (
+                <Button
+                  onPress={() =>
+                    setPollWorkerFlowState({ type: 'view-reporting-qr-code' })
+                  }
+                >
+                  View Quick Results Code
+                </Button>
+              )}
+            </ButtonGrid>
+            <H5>Other Actions</H5>
             <ButtonGrid>{commonActions}</ButtonGrid>
           </Container>
         );

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -497,6 +497,10 @@ function PollWorkerScreenContents({
         return (
           <Screen>
             <CenteredText>
+              <H5>Scan QR code for Quick Results Reporting</H5>
+              <br />
+            </CenteredText>
+            <CenteredText>
               {getQuickResultsReportingUrlQuery.data && (
                 <div data-testid="quick-results-code">
                   <QrCode

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -336,6 +336,11 @@ export function createApiMock() {
     expectRebootToVendorMenu() {
       mockApiClient.rebootToVendorMenu.expectCallWith().resolves();
     },
+
+    expectGetQuickResultsReportingUrl(url: string = '') {
+      mockApiClient.getQuickResultsReportingUrl.reset();
+      mockApiClient.getQuickResultsReportingUrl.expectCallWith().resolves(url);
+    },
   };
 }
 

--- a/libs/ui/src/qrcode.tsx
+++ b/libs/ui/src/qrcode.tsx
@@ -14,12 +14,13 @@ export type QrCodeLevel = 'L' | 'M' | 'Q' | 'H';
 export interface QrCodeProps {
   value: string;
   level?: QrCodeLevel;
+  size?: number;
 }
 
-export function QrCode({ level = 'H', value }: QrCodeProps): JSX.Element {
+export function QrCode({ level = 'H', value, size }: QrCodeProps): JSX.Element {
   return (
     <ResponsiveSvgWrapper>
-      <QRCodeSVG value={value} level={level} />
+      <QRCodeSVG value={value} level={level} size={size} />
     </ResponsiveSvgWrapper>
   );
 }

--- a/libs/ui/src/reports/precinct_scanner_tally_report.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_report.tsx
@@ -16,7 +16,6 @@ import {
 } from './layout';
 import { TallyReportCardCounts } from './tally_report_card_counts';
 import { ContestResultsTable } from './contest_results_table';
-import { PrecinctScannerTallyQrCode } from './precinct_scanner_tally_qr_code';
 
 interface Props {
   electionDefinition: ElectionDefinition;
@@ -49,7 +48,8 @@ export function PrecinctScannerTallyReport({
   pollsTransitionedTime,
   reportPrintedTime,
   precinctScannerMachineId,
-  signedQuickResultsReportingUrl,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  signedQuickResultsReportingUrl, // Functionality to include QR codes in tally reports is temporarily disabled, so this is unused
 }: Props): JSX.Element {
   const { election } = electionDefinition;
   const precinctId =
@@ -58,9 +58,6 @@ export function PrecinctScannerTallyReport({
       : undefined;
 
   const { cardCounts } = scannedElectionResults;
-
-  const showQuickResults =
-    signedQuickResultsReportingUrl && signedQuickResultsReportingUrl.length > 0;
 
   return (
     <ThemeProvider theme={printedReportThemeFn}>
@@ -95,11 +92,6 @@ export function PrecinctScannerTallyReport({
             );
           })}
         </TallyReportColumns>
-        {showQuickResults && (
-          <PrecinctScannerTallyQrCode
-            signedQuickResultsReportingUrl={signedQuickResultsReportingUrl}
-          />
-        )}
       </PrintedReport>
     </ThemeProvider>
   );


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7206

just adding @carolinemodic 's work on this branch..

Additional changes:
1. Header added to Scan's Quick Results screen
2. Removed QR code from precinct tally report

## Demo Video or Screenshot

Header added to Scan's Quick Results screen:
<img width="906" height="592" alt="Screenshot 2025-09-15 at 2 18 57 PM" src="https://github.com/user-attachments/assets/9939c627-9d89-44e3-b8d1-2a78a3948d7b" />

## Testing Plan

Manual testing

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
