### PR TITLE
perf(scan): improve speed of interpretation pipeline

### DIFF
--- a/apps/mark-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/mark-scan/backend/src/app.diagnostics.test.ts
@@ -23,12 +23,8 @@ import { MockUsbDrive } from '@votingworks/usb-drive';
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import { MockPaperHandlerDriver } from '@votingworks/custom-paper-handler';
 import { assertDefined, deferred, ok } from '@votingworks/basics';
-import {
-  InterpretFileResult,
-  interpretSimplexBmdBallot,
-} from '@votingworks/ballot-interpreter';
+import { interpretSimplexBmdBallot } from '@votingworks/ballot-interpreter';
 import { readElection } from '@votingworks/fs';
-import { BLANK_PAGE_IMAGE_DATA } from '@votingworks/image-utils';
 import { SimulatedClock } from 'xstate/lib/SimulatedClock';
 import { Api } from './app';
 import { PatConnectionStatusReader } from './pat-input/connection_status_reader';
@@ -293,30 +289,27 @@ describe('paper handler diagnostic', () => {
     const scannedPath = await getDiagnosticMockBallotImagePath();
     vi.mocked(scanAndSave).mockReturnValue(mockScanResult.promise);
 
-    const interpretationMock: SheetOf<InterpretFileResult> = [
+    const interpretationMock: SheetOf<PageInterpretation> = [
       {
-        interpretation: {
-          type: 'InterpretedBmdPage',
-          metadata: {
-            ballotHash: 'hash',
-            ballotType: BallotType.Precinct,
-            ballotStyleId: electionDefinition.election.ballotStyles[0].id,
-            precinctId: electionDefinition.election.precincts[0].id,
-            isTestMode: true,
-          },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            ignoredReasonInfos: [],
-            enabledReasonInfos: [],
-            enabledReasons: [],
-          },
-          votes: {},
+        type: 'InterpretedBmdPage',
+        metadata: {
+          ballotHash: 'hash',
+          ballotType: BallotType.Precinct,
+          ballotStyleId: electionDefinition.election.ballotStyles[0].id,
+          precinctId: electionDefinition.election.precincts[0].id,
+          isTestMode: true,
         },
-        normalizedImage: BLANK_PAGE_IMAGE_DATA,
+        adjudicationInfo: {
+          requiresAdjudication: false,
+          ignoredReasonInfos: [],
+          enabledReasonInfos: [],
+          enabledReasons: [],
+        },
+        votes: {},
       },
       BLANK_PAGE_MOCK,
     ];
-    const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
+    const mockInterpretResult = deferred<SheetOf<PageInterpretation>>();
     vi.mocked(interpretSimplexBmdBallot).mockReturnValue(
       mockInterpretResult.promise
     );
@@ -413,14 +406,11 @@ describe('paper handler diagnostic', () => {
       const scannedPath = await getDiagnosticMockBallotImagePath();
       vi.mocked(scanAndSave).mockReturnValue(mockScanResult.promise);
 
-      const interpretationMock: SheetOf<InterpretFileResult> = [
-        {
-          interpretation,
-          normalizedImage: BLANK_PAGE_IMAGE_DATA,
-        },
+      const interpretationMock: SheetOf<PageInterpretation> = [
+        interpretation,
         BLANK_PAGE_MOCK,
       ];
-      const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
+      const mockInterpretResult = deferred<SheetOf<PageInterpretation>>();
       vi.mocked(interpretSimplexBmdBallot).mockReturnValue(
         mockInterpretResult.promise
       );

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -259,14 +259,7 @@ export function buildApi(
       // If we can get away with storing the interpretation in memory only in the
       // state machine we should. This simplifies the logic and reduces the risk
       // of accidentally persisting ballot selections to disk.
-      const sheetInterpretation = stateMachine.getInterpretation();
-
-      if (!sheetInterpretation) {
-        return null;
-      }
-
-      // Omit image data before sending to client. It's long, gets logged, and we don't need it.
-      return sheetInterpretation[0].interpretation;
+      return stateMachine.getInterpretation()?.[0] ?? null;
     },
 
     validateBallot(): void {

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -848,9 +848,7 @@ describe('poll_worker_auth_ended_unexpectedly', () => {
 
     const interpretationType: PageInterpretationType = 'InvalidBallotHashPage';
     vi.mocked(interpretSimplexBmdBallot).mockResolvedValue([
-      {
-        interpretation: { type: interpretationType },
-      } as unknown as PageInterpretation,
+      { type: interpretationType } as unknown as PageInterpretation,
       BLANK_PAGE_MOCK,
     ]);
 
@@ -1033,9 +1031,7 @@ describe('insert pre-printed ballot', () => {
     await waitForStatus('validating_new_sheet');
 
     mockInterpretResult.resolve([
-      {
-        interpretation: { type: interpretationType },
-      } as unknown as PageInterpretation,
+      { type: interpretationType } as unknown as PageInterpretation,
       BLANK_PAGE_MOCK,
     ]);
     await waitForStatus('inserted_invalid_new_sheet');
@@ -1200,9 +1196,7 @@ describe('re-insert removed ballot', () => {
     await waitForStatus('validating_reinserted_ballot');
 
     mockInterpretResult.resolve([
-      {
-        interpretation: { type: interpretationType },
-      } as unknown as PageInterpretation,
+      { type: interpretationType } as unknown as PageInterpretation,
       BLANK_PAGE_MOCK,
     ]);
     await waitForStatus('reinserted_invalid_ballot');

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -35,6 +35,7 @@ import {
 import {
   BallotStyleId,
   BallotType,
+  PageInterpretation,
   PageInterpretationType,
   SheetOf,
   TEST_JURISDICTION,
@@ -49,10 +50,7 @@ import {
   renderBmdBallotFixture,
   writeFirstBallotPageToImageFile,
 } from '@votingworks/bmd-ballot-fixtures';
-import {
-  InterpretFileResult,
-  interpretSimplexBmdBallot,
-} from '@votingworks/ballot-interpreter';
+import { interpretSimplexBmdBallot } from '@votingworks/ballot-interpreter';
 import {
   BLANK_PAGE_IMAGE_DATA,
   loadImageData,
@@ -156,26 +154,23 @@ vi.mock(import('@votingworks/utils'), async (importActual) => ({
 vi.mock(import('../audio/outputs.js'));
 vi.setConfig({ testTimeout: 2000 });
 
-const SUCCESSFUL_INTERPRETATION_MOCK: SheetOf<InterpretFileResult> = [
+const SUCCESSFUL_INTERPRETATION_MOCK: SheetOf<PageInterpretation> = [
   {
-    interpretation: {
-      type: 'InterpretedBmdPage',
-      metadata: {
-        ballotHash: 'hash',
-        ballotType: BallotType.Precinct,
-        ballotStyleId: '5' as BallotStyleId,
-        precinctId: '21',
-        isTestMode: true,
-      },
-      adjudicationInfo: {
-        requiresAdjudication: false,
-        ignoredReasonInfos: [],
-        enabledReasonInfos: [],
-        enabledReasons: [],
-      },
-      votes: {},
+    type: 'InterpretedBmdPage',
+    metadata: {
+      ballotHash: 'hash',
+      ballotType: BallotType.Precinct,
+      ballotStyleId: '5' as BallotStyleId,
+      precinctId: '21',
+      isTestMode: true,
     },
-    normalizedImage: BLANK_PAGE_IMAGE_DATA,
+    adjudicationInfo: {
+      requiresAdjudication: false,
+      ignoredReasonInfos: [],
+      enabledReasonInfos: [],
+      enabledReasons: [],
+    },
+    votes: {},
   },
   BLANK_PAGE_MOCK,
 ];
@@ -482,7 +477,7 @@ async function executeLoadPaper(
 async function executePrintBallotAndAssert(
   printData: Uint8Array,
   scanFixtureFilepath: string,
-  interpretationResult: SheetOf<InterpretFileResult> = SUCCESSFUL_INTERPRETATION_MOCK
+  interpretationResult: SheetOf<PageInterpretation> = SUCCESSFUL_INTERPRETATION_MOCK
 ): Promise<void> {
   await executeLoadPaper();
 
@@ -494,7 +489,7 @@ async function executePrintBallotAndAssert(
   const mockScanResult = deferred<string>();
   vi.mocked(scanAndSave).mockReturnValue(mockScanResult.promise);
 
-  const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
+  const mockInterpretResult = deferred<SheetOf<PageInterpretation>>();
   vi.mocked(interpretSimplexBmdBallot).mockReturnValue(
     mockInterpretResult.promise
   );
@@ -855,7 +850,7 @@ describe('poll_worker_auth_ended_unexpectedly', () => {
     vi.mocked(interpretSimplexBmdBallot).mockResolvedValue([
       {
         interpretation: { type: interpretationType },
-      } as unknown as InterpretFileResult,
+      } as unknown as PageInterpretation,
       BLANK_PAGE_MOCK,
     ]);
 
@@ -936,7 +931,7 @@ test('insert and validate new blank sheet', async () => {
   machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
   expect(machine.getSimpleStatus()).toEqual('accepting_paper');
 
-  const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
+  const mockInterpretResult = deferred<SheetOf<PageInterpretation>>();
   vi.mocked(interpretSimplexBmdBallot).mockReturnValue(
     mockInterpretResult.promise
   );
@@ -1027,7 +1022,7 @@ describe('insert pre-printed ballot', () => {
 
     vi.mocked(scanAndSave).mockResolvedValue(await writeTmpBlankImage());
 
-    const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
+    const mockInterpretResult = deferred<SheetOf<PageInterpretation>>();
     vi.mocked(interpretSimplexBmdBallot).mockReturnValue(
       mockInterpretResult.promise
     );
@@ -1040,7 +1035,7 @@ describe('insert pre-printed ballot', () => {
     mockInterpretResult.resolve([
       {
         interpretation: { type: interpretationType },
-      } as unknown as InterpretFileResult,
+      } as unknown as PageInterpretation,
       BLANK_PAGE_MOCK,
     ]);
     await waitForStatus('inserted_invalid_new_sheet');
@@ -1080,7 +1075,7 @@ describe('re-insert removed ballot', () => {
    * the caller to simulate the result of interpretation.
    */
   async function prepareBallotReinsertion(): Promise<
-    Deferred<SheetOf<InterpretFileResult>>
+    Deferred<SheetOf<PageInterpretation>>
   > {
     //
     // 1. [Setup] Seed voting session with pre-printed ballot:
@@ -1112,7 +1107,7 @@ describe('re-insert removed ballot', () => {
     // 3. Re-insert valid ballot:
     //
 
-    const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
+    const mockInterpretResult = deferred<SheetOf<PageInterpretation>>();
     vi.mocked(interpretSimplexBmdBallot).mockReturnValue(
       mockInterpretResult.promise
     );
@@ -1194,7 +1189,7 @@ describe('re-insert removed ballot', () => {
     // 3. Re-insert invalid ballot:
     //
 
-    const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
+    const mockInterpretResult = deferred<SheetOf<PageInterpretation>>();
     vi.mocked(interpretSimplexBmdBallot).mockReturnValue(
       mockInterpretResult.promise
     );
@@ -1207,7 +1202,7 @@ describe('re-insert removed ballot', () => {
     mockInterpretResult.resolve([
       {
         interpretation: { type: interpretationType },
-      } as unknown as InterpretFileResult,
+      } as unknown as PageInterpretation,
       BLANK_PAGE_MOCK,
     ]);
     await waitForStatus('reinserted_invalid_ballot');
@@ -1345,7 +1340,7 @@ describe('unrecoverable_error', () => {
     machine.setAcceptingPaper(ACCEPTED_PAPER_TYPES);
     expect(machine.getSimpleStatus()).toEqual('accepting_paper');
 
-    const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
+    const mockInterpretResult = deferred<SheetOf<PageInterpretation>>();
     vi.mocked(interpretSimplexBmdBallot).mockReturnValue(
       mockInterpretResult.promise
     );
@@ -1384,7 +1379,7 @@ describe('unrecoverable_error', () => {
     const mockScanResult = deferred<string>();
     vi.mocked(scanAndSave).mockReturnValue(mockScanResult.promise);
 
-    const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
+    const mockInterpretResult = deferred<SheetOf<PageInterpretation>>();
     vi.mocked(interpretSimplexBmdBallot).mockReturnValue(
       mockInterpretResult.promise
     );
@@ -1410,7 +1405,7 @@ describe('unrecoverable_error', () => {
     const mockScanResult = deferred<string>();
     vi.mocked(scanAndSave).mockReturnValue(mockScanResult.promise);
 
-    const mockInterpretResult = deferred<SheetOf<InterpretFileResult>>();
+    const mockInterpretResult = deferred<SheetOf<PageInterpretation>>();
     vi.mocked(interpretSimplexBmdBallot).mockReturnValue(
       mockInterpretResult.promise
     );

--- a/apps/mark-scan/backend/test/ballot_helpers.ts
+++ b/apps/mark-scan/backend/test/ballot_helpers.ts
@@ -1,13 +1,10 @@
-import { InterpretFileResult } from '@votingworks/ballot-interpreter';
-import { BLANK_PAGE_IMAGE_DATA } from '@votingworks/image-utils';
-import { SheetOf } from '@votingworks/types';
+import { PageInterpretation, SheetOf } from '@votingworks/types';
 
-export const BLANK_PAGE_MOCK: InterpretFileResult = {
-  interpretation: { type: 'BlankPage' },
-  normalizedImage: BLANK_PAGE_IMAGE_DATA,
+export const BLANK_PAGE_MOCK: PageInterpretation = {
+  type: 'BlankPage',
 };
 
-export const BLANK_PAGE_INTERPRETATION_MOCK: SheetOf<InterpretFileResult> = [
+export const BLANK_PAGE_INTERPRETATION_MOCK: SheetOf<PageInterpretation> = [
   BLANK_PAGE_MOCK,
   BLANK_PAGE_MOCK,
 ];

--- a/apps/scan/backend/src/app_scanning.test.ts
+++ b/apps/scan/backend/src/app_scanning.test.ts
@@ -12,6 +12,10 @@ import { simulateScan, withApp } from '../test/helpers/pdi_helpers';
 import { configureApp, waitForStatus } from '../test/helpers/shared_helpers';
 import { delays } from './scanners/pdi/state_machine';
 
+vi.setConfig({
+  testTimeout: 10_000,
+});
+
 const mockFeatureFlagger = getFeatureFlagMock();
 
 vi.mock(import('@votingworks/utils'), async (importActual) => ({

--- a/apps/scan/backend/src/sheet_requires_adjudication.ts
+++ b/apps/scan/backend/src/sheet_requires_adjudication.ts
@@ -3,12 +3,6 @@ import {
   PageInterpretation,
   SheetOf,
 } from '@votingworks/types';
-import { ImageData } from 'canvas';
-
-export interface InterpretFileResult {
-  interpretation: PageInterpretation;
-  normalizedImage?: ImageData;
-}
 
 /**
  * Determine if a sheet needs adjudication.

--- a/libs/ballot-interpreter/src/adjudication_reasons.ts
+++ b/libs/ballot-interpreter/src/adjudication_reasons.ts
@@ -21,7 +21,7 @@ function rankMarkStatus(markStatus: MarkStatus): number {
       return 1;
     case MarkStatus.Unmarked:
       return 0;
-    /* istanbul ignore next */
+    /* istanbul ignore next - @preserve */
     default:
       throwIllegalValue(markStatus);
   }
@@ -84,7 +84,7 @@ export function getAllPossibleAdjudicationReasonsForBmdVotes(
           // At this point in the code we know there is an undervote,
           // so there must be 0 votes.
           break;
-        /* istanbul ignore next */
+        /* istanbul ignore next - @preserve */
         default:
           throwIllegalValue(contestType);
       }

--- a/libs/ballot-interpreter/src/bmd/interpret.ts
+++ b/libs/ballot-interpreter/src/bmd/interpret.ts
@@ -86,7 +86,7 @@ export async function interpret(
       expectedBallotHash,
       actualBallotHash:
         actualBallotHash ??
-        /* istanbul ignore next */
+        /* istanbul ignore next - @preserve */
         '',
     });
   }

--- a/libs/ballot-interpreter/src/bmd/utils/qrcode.ts
+++ b/libs/ballot-interpreter/src/bmd/utils/qrcode.ts
@@ -19,7 +19,7 @@ function decodeBase64FromUtf8(utf8StringData: Buffer): Buffer {
   try {
     return Buffer.from(new TextDecoder().decode(utf8StringData), 'base64');
   } catch {
-    /* istanbul ignore next */
+    /* istanbul ignore next - @preserve */
     return utf8StringData;
   }
 }

--- a/libs/ballot-interpreter/src/hmpb-rust/js/image_data.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/js/image_data.rs
@@ -1,6 +1,6 @@
-use std::borrow::{Borrow, BorrowMut};
+use std::borrow::Borrow;
 
-use image::{DynamicImage, GrayImage};
+use image::DynamicImage;
 use neon::prelude::*;
 use neon::types::{buffer::TypedArray, JsNumber, JsObject};
 
@@ -23,17 +23,6 @@ impl ImageData {
         }
     }
 
-    /// Converts a JavaScript object compatible with the `ImageData` interface.
-    pub fn convert_gray_image_to_js_object<'a>(
-        cx: &mut FunctionContext<'a>,
-        image: GrayImage,
-    ) -> JsResult<'a, JsObject> {
-        let (width, height) = image.dimensions();
-        let data = DynamicImage::ImageLuma8(image).into_rgba8().into_raw();
-        let image_data = Self::new(width, height, data);
-        image_data.to_js_object(cx)
-    }
-
     /// Converts a JavaScript `ImageData` object to a Rust `ImageData`.
     pub fn from_js_object(
         cx: &mut FunctionContext,
@@ -47,20 +36,6 @@ impl ImageData {
             .as_slice(cx)
             .to_vec();
         Ok(Self::new(width, height, data))
-    }
-
-    pub fn to_js_object<'a>(&self, cx: &mut FunctionContext<'a>) -> JsResult<'a, JsObject> {
-        let js_object = cx.empty_object();
-        let width = cx.number(f64::from(self.width));
-        let height = cx.number(f64::from(self.height));
-        js_object.set(cx, "width", width)?;
-        js_object.set(cx, "height", height)?;
-        let mut data = cx.buffer(self.data.len())?;
-        data.borrow_mut()
-            .as_mut_slice(cx)
-            .copy_from_slice(self.data.as_slice());
-        js_object.set(cx, "data", data)?;
-        Ok(js_object)
     }
 }
 

--- a/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
@@ -20,7 +20,6 @@ use self::args::{
     get_election_definition_from_arg, get_image_data_or_path_from_arg, get_path_from_arg_opt,
     ImageSource,
 };
-use self::image_data::ImageData;
 
 mod args;
 mod image_data;
@@ -68,7 +67,29 @@ pub fn interpret(mut cx: FunctionContext) -> JsResult<JsObject> {
     };
 
     // Equivalent to:
-    //   bet debug_side_a_base =
+    //   let front_normalized_image_output_path =
+    //     typeof options.frontNormalizedImageOutputPath === 'string'
+    //     ? options.frontNormalizedImageOutputPath
+    //     : undefined;
+    let front_normalized_image_output_path = options
+        .get_value(&mut cx, "frontNormalizedImageOutputPath")?
+        .downcast::<JsString, _>(&mut cx)
+        .ok()
+        .map(|path| PathBuf::from(path.value(&mut cx)));
+
+    // Equivalent to:
+    //   let back_normalized_image_output_path =
+    //     typeof options.backNormalizedImageOutputPath === 'string'
+    //     ? options.backNormalizedImageOutputPath
+    //     : undefined;
+    let back_normalized_image_output_path = options
+        .get_value(&mut cx, "backNormalizedImageOutputPath")?
+        .downcast::<JsString, _>(&mut cx)
+        .ok()
+        .map(|path| PathBuf::from(path.value(&mut cx)));
+
+    // Equivalent to:
+    //   let debug_side_a_base =
     //     typeof options.debugBasePathSideA === 'string'
     //     ? options.debugBasePathSideA
     //     : undefined;
@@ -204,21 +225,40 @@ pub fn interpret(mut cx: FunctionContext) -> JsResult<JsObject> {
         ))
     })?;
 
+    let maybe_save_normalized_image =
+        |path: Option<&PathBuf>, image: &GrayImage| -> Result<(), String> {
+            match path {
+                None => Ok(()),
+                Some(path) => image.save(path).map_err(|err| {
+                    format!(
+                        "unable to save image to {path}: {err}",
+                        path = path.display()
+                    )
+                }),
+            }
+        };
+
+    let (front_save_result, back_save_result) = rayon::join(
+        || {
+            maybe_save_normalized_image(
+                front_normalized_image_output_path.as_ref(),
+                &card.front.normalized_image,
+            )
+        },
+        || {
+            maybe_save_normalized_image(
+                back_normalized_image_output_path.as_ref(),
+                &card.back.normalized_image,
+            )
+        },
+    );
+
+    front_save_result
+        .and(back_save_result)
+        .or_else(|err| cx.throw_error(err))?;
+
     let value = Ok(cx.string(json));
-    let result_object = make_interpret_result(&mut cx, value)?;
-
-    let front_js_normalized_image_obj =
-        ImageData::convert_gray_image_to_js_object(&mut cx, card.front.normalized_image)?;
-    let back_js_normalized_image_obj =
-        ImageData::convert_gray_image_to_js_object(&mut cx, card.back.normalized_image)?;
-    result_object.set(
-        &mut cx,
-        "frontNormalizedImage",
-        front_js_normalized_image_obj,
-    )?;
-    result_object.set(&mut cx, "backNormalizedImage", back_js_normalized_image_obj)?;
-
-    Ok(result_object)
+    make_interpret_result(&mut cx, value)
 }
 
 pub fn find_timing_mark_grid(mut cx: FunctionContext) -> JsResult<JsObject> {

--- a/libs/ballot-interpreter/src/hmpb-ts/addon.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/addon.ts
@@ -41,9 +41,9 @@ export function interpret(
   election: Election,
   ballotImageSourceSideA: string | ImageData,
   ballotImageSourceSideB: string | ImageData,
-  debugBasePathSideA?: string,
-  debugBasePathSideB?: string,
   options?: {
+    debugBasePathSideA?: string;
+    debugBasePathSideB?: string;
     scoreWriteIns?: boolean;
     disableVerticalStreakDetection?: boolean;
     timingMarkAlgorithm?: 'contours' | 'corners';
@@ -55,8 +55,6 @@ export function interpret(
     election,
     ballotImageSourceSideA,
     ballotImageSourceSideB,
-    debugBasePathSideA,
-    debugBasePathSideB,
     options
   );
 }

--- a/libs/ballot-interpreter/src/hmpb-ts/addon.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/addon.ts
@@ -20,17 +20,10 @@ const addon = (() => {
 /**
  * The result of calling `interpret`.
  */
-export type BridgeInterpretResult =
-  | {
-      success: false;
-      value: string;
-    }
-  | {
-      success: true;
-      value: string;
-      frontNormalizedImage: ImageData;
-      backNormalizedImage: ImageData;
-    };
+export interface BridgeInterpretResult {
+  success: boolean;
+  value: string;
+}
 
 /**
  * Type of the Rust `interpret` implementation. Under normal circumstances,
@@ -49,6 +42,8 @@ export function interpret(
     timingMarkAlgorithm?: 'contours' | 'corners';
     inferTimingMarks?: boolean;
     minimumDetectedScale?: number;
+    frontNormalizedImageOutputPath?: string;
+    backNormalizedImageOutputPath?: string;
   }
 ): BridgeInterpretResult {
   return addon.interpret(

--- a/libs/ballot-interpreter/src/hmpb-ts/cli.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/cli.ts
@@ -217,18 +217,16 @@ async function interpretFiles(
     useDefaultMarkThresholds?: boolean;
   }
 ): Promise<number> {
-  const result = interpret(
+  const result = interpret({
     electionDefinition,
-    [ballotPathSideA, ballotPathSideB],
-    {
-      scoreWriteIns,
-      disableVerticalStreakDetection:
-        disableVerticalStreakDetection ??
-        systemSettings?.disableVerticalStreakDetection,
-      minimumDetectedScale,
-      debug,
-    }
-  );
+    ballotImages: [ballotPathSideA, ballotPathSideB],
+    scoreWriteIns,
+    disableVerticalStreakDetection:
+      disableVerticalStreakDetection ??
+      systemSettings?.disableVerticalStreakDetection,
+    minimumDetectedScale,
+    debug,
+  });
 
   if (result.isErr()) {
     stderr.write(chalk.red(`Error interpreting ballot:\n`));

--- a/libs/ballot-interpreter/src/hmpb-ts/cli.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/cli.ts
@@ -7,8 +7,6 @@ import {
   Optional,
   Result,
 } from '@votingworks/basics';
-import tmp from 'tmp';
-import { writeImageData } from '@votingworks/image-utils';
 import {
   DEFAULT_MARK_THRESHOLDS,
   ElectionDefinition,
@@ -173,26 +171,6 @@ function prettyPrintInterpretation({
   }
 }
 
-async function writeNormalizedImages({
-  front,
-  back,
-}: InterpretedBallotCard): Promise<{
-  front: string;
-  back: string;
-}> {
-  const frontPath = tmp.tmpNameSync({
-    prefix: 'normalized-front',
-    postfix: '.png',
-  });
-  const backPath = tmp.tmpNameSync({
-    prefix: 'normalized-back',
-    postfix: '.png',
-  });
-  await writeImageData(frontPath, front.normalizedImage);
-  await writeImageData(backPath, back.normalizedImage);
-  return { front: frontPath, back: backPath };
-}
-
 async function interpretFiles(
   electionDefinition: ElectionDefinition,
   systemSettings: SystemSettings | undefined,
@@ -241,22 +219,8 @@ async function interpretFiles(
   const interpreted = result.ok();
 
   if (json) {
-    const normalizedImagePaths = await writeNormalizedImages(interpreted);
     await writeIterToStream(
-      jsonStream(
-        {
-          ...interpreted,
-          front: {
-            ...interpreted.front,
-            normalizedImage: normalizedImagePaths.front,
-          },
-          back: {
-            ...interpreted.back,
-            normalizedImage: normalizedImagePaths.back,
-          },
-        },
-        { compact: false }
-      ),
+      jsonStream(interpreted, { compact: false }),
       stdout
     );
   } else {

--- a/libs/ballot-interpreter/src/hmpb-ts/debug.test.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/debug.test.ts
@@ -1,8 +1,5 @@
 import { vxFamousNamesFixtures } from '@votingworks/hmpb';
-import { asSheet } from '@votingworks/types';
-import { ImageData } from 'canvas';
-import { beforeAll, expect, test, vi } from 'vitest';
-import { pdfToPageImages } from '../../test/helpers/interpretation';
+import { expect, test, vi } from 'vitest';
 import * as addon from './addon';
 import { interpret } from './interpret';
 
@@ -11,14 +8,6 @@ const { electionDefinition } = vxFamousNamesFixtures;
 vi.mock('./addon');
 
 const interpretImplMock = vi.mocked(addon.interpret);
-let frontImageData!: ImageData;
-let backImageData!: ImageData;
-
-beforeAll(async () => {
-  [frontImageData, backImageData] = asSheet(
-    await pdfToPageImages(vxFamousNamesFixtures.markedBallotPath).toArray()
-  );
-});
 
 test('no debug', () => {
   interpretImplMock.mockReturnValue({
@@ -26,57 +15,16 @@ test('no debug', () => {
     value: '{}',
   });
 
-  void interpret(electionDefinition, ['a.jpeg', 'b.jpeg'], { debug: false });
+  void interpret({
+    electionDefinition,
+    ballotImages: ['a.jpeg', 'b.jpeg'],
+    debug: false,
+  });
 
   expect(interpretImplMock).toHaveBeenCalledWith(
     electionDefinition.election,
     'a.jpeg',
     'b.jpeg',
-    undefined,
-    undefined,
-    expect.any(Object)
-  );
-});
-
-test('empty debug paths', () => {
-  interpretImplMock.mockReturnValue({
-    success: false,
-    value: '{}',
-  });
-
-  void interpret(
-    electionDefinition,
-    [frontImageData, backImageData],
-    // @ts-expect-error -- intentionally passing invalid data
-    { debugBasePaths: [] }
-  );
-
-  expect(interpretImplMock).toHaveBeenCalledWith(
-    electionDefinition.election,
-    frontImageData,
-    backImageData,
-    undefined,
-    undefined,
-    expect.any(Object)
-  );
-});
-
-test('undefined debug paths', () => {
-  interpretImplMock.mockReturnValue({
-    success: false,
-    value: '{}',
-  });
-
-  void interpret(electionDefinition, [frontImageData, backImageData], {
-    debugBasePaths: undefined,
-  });
-
-  expect(interpretImplMock).toHaveBeenCalledWith(
-    electionDefinition.election,
-    frontImageData,
-    backImageData,
-    undefined,
-    undefined,
     expect.any(Object)
   );
 });
@@ -87,32 +35,14 @@ test('debug with image paths', () => {
     value: '{}',
   });
 
-  void interpret(electionDefinition, ['a.jpeg', 'b.jpeg'], { debug: true });
-
-  expect(interpretImplMock).toHaveBeenCalledWith(
-    electionDefinition.election,
-    'a.jpeg',
-    'b.jpeg',
-    'a.jpeg',
-    'b.jpeg',
-    expect.any(Object)
-  );
-});
-
-test('debug with image data', () => {
-  interpretImplMock.mockReturnValue({
-    success: false,
-    value: '{}',
-  });
-
-  void interpret(electionDefinition, [frontImageData, backImageData], {
-    debugBasePaths: ['a.jpeg', 'b.jpeg'],
+  void interpret({
+    electionDefinition,
+    ballotImages: ['a.jpeg', 'b.jpeg'],
+    debug: true,
   });
 
   expect(interpretImplMock).toHaveBeenCalledWith(
     electionDefinition.election,
-    frontImageData,
-    backImageData,
     'a.jpeg',
     'b.jpeg',
     expect.any(Object)

--- a/libs/ballot-interpreter/src/hmpb-ts/interpret.test.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/interpret.test.ts
@@ -28,17 +28,17 @@ test('interpret with bad election data', () => {
     election: { bad: 'election' } as unknown as Election,
   };
 
-  expect(() => interpret(electionDefinition, ['a', 'b'])).toThrowError(
-    'missing field `title`'
-  );
+  expect(() =>
+    interpret({ electionDefinition, ballotImages: ['a', 'b'] })
+  ).toThrowError('missing field `title`');
 });
 
 test('interpret with bad ballot image paths', () => {
   const electionDefinition = electionGridLayoutNewHampshireTestBallotDefinition;
 
-  expect(() => interpret(electionDefinition, ['a', 'b'])).toThrowError(
-    'failed to load ballot card images: a, b'
-  );
+  expect(() =>
+    interpret({ electionDefinition, ballotImages: ['a', 'b'] })
+  ).toThrowError('failed to load ballot card images: a, b');
 });
 
 test('interpret `ImageData` objects', async () => {
@@ -46,7 +46,7 @@ test('interpret `ImageData` objects', async () => {
   const ballotImages = asSheet(
     await pdfToPageImages(vxFamousNamesFixtures.markedBallotPath).toArray()
   );
-  const result = interpret(electionDefinition, ballotImages);
+  const result = interpret({ electionDefinition, ballotImages });
   expect(result).toEqual(ok(expect.anything()));
 
   const { front, back } = result.unsafeUnwrap();
@@ -355,7 +355,10 @@ test('interpret images from paths', async () => {
     return path;
   });
 
-  const result = interpret(electionDefinition, ballotImagePaths);
+  const result = interpret({
+    electionDefinition,
+    ballotImages: ballotImagePaths,
+  });
   expect(result).toEqual(ok(expect.anything()));
 
   const { front, back } = result.unsafeUnwrap();
@@ -668,20 +671,16 @@ test('interpret with old timing mark algorithm', async () => {
     return path;
   });
 
-  const contoursInterpretedCard = interpret(
+  const contoursInterpretedCard = interpret({
     electionDefinition,
-    ballotImagePaths,
-    {
-      timingMarkAlgorithm: 'contours',
-    }
-  ).unsafeUnwrap();
-  const cornersInterpretedCard = interpret(
+    ballotImages: ballotImagePaths,
+    timingMarkAlgorithm: 'contours',
+  }).unsafeUnwrap();
+  const cornersInterpretedCard = interpret({
     electionDefinition,
-    ballotImagePaths,
-    {
-      timingMarkAlgorithm: 'corners',
-    }
-  ).unsafeUnwrap();
+    ballotImages: ballotImagePaths,
+    timingMarkAlgorithm: 'corners',
+  }).unsafeUnwrap();
 
   expect(contoursInterpretedCard.front.marks).not.toEqual(
     cornersInterpretedCard.front.marks
@@ -697,7 +696,9 @@ test('score write in areas', async () => {
     await pdfToPageImages(vxFamousNamesFixtures.markedBallotPath).toArray()
   );
 
-  const result = interpret(electionDefinition, ballotImages, {
+  const result = interpret({
+    electionDefinition,
+    ballotImages,
     scoreWriteIns: true,
   });
   expect(result).toEqual(ok(expect.anything()));

--- a/libs/ballot-interpreter/src/hmpb-ts/interpret.test.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/interpret.test.ts
@@ -18,10 +18,6 @@ import { interpret } from './interpret';
 const electionGridLayoutNewHampshireTestBallotDefinition =
   electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
 
-test('interpret exists', () => {
-  expect(interpret).toBeDefined();
-});
-
 test('interpret with bad election data', () => {
   const electionDefinition: ElectionDefinition = {
     ...electionGridLayoutNewHampshireTestBallotDefinition,
@@ -50,19 +46,6 @@ test('interpret `ImageData` objects', async () => {
   expect(result).toEqual(ok(expect.anything()));
 
   const { front, back } = result.unsafeUnwrap();
-
-  expect(front.normalizedImage).toBeDefined();
-  expect(back.normalizedImage).toBeDefined();
-  const [frontImageData, backImageData] = ballotImages;
-  // While we would usually expect a normalized image to differ from the
-  // original more significantly, in this case their dimensions are identical
-  // due to minimal cropping and no scaling, which makes for a basic test.
-  expect(front.normalizedImage.width).toEqual(frontImageData.width);
-  expect(front.normalizedImage.height).toEqual(frontImageData.height);
-  expect(back.normalizedImage.width).toEqual(backImageData.width);
-  expect(back.normalizedImage.height).toEqual(backImageData.height);
-  expect(front.normalizedImage.data.length).toBeGreaterThan(0);
-  expect(back.normalizedImage.data.length).toBeGreaterThan(0);
 
   const gridPositions = assertDefined(
     electionDefinition.election.gridLayouts?.[0]?.gridPositions
@@ -362,19 +345,6 @@ test('interpret images from paths', async () => {
   expect(result).toEqual(ok(expect.anything()));
 
   const { front, back } = result.unsafeUnwrap();
-
-  expect(front.normalizedImage).toBeDefined();
-  expect(back.normalizedImage).toBeDefined();
-  const [frontImageData, backImageData] = ballotImages;
-  // While we would usually expect a normalized image to differ from the
-  // original more significantly, in this case their dimensions are identical
-  // due to minimal cropping and no scaling, which makes for a basic test.
-  expect(front.normalizedImage.width).toEqual(frontImageData.width);
-  expect(front.normalizedImage.height).toEqual(frontImageData.height);
-  expect(back.normalizedImage.width).toEqual(backImageData.width);
-  expect(back.normalizedImage.height).toEqual(backImageData.height);
-  expect(front.normalizedImage.data.length).toBeGreaterThan(0);
-  expect(back.normalizedImage.data.length).toBeGreaterThan(0);
 
   const gridPositions = assertDefined(
     electionDefinition.election.gridLayouts?.[0]?.gridPositions

--- a/libs/ballot-interpreter/src/hmpb-ts/interpret.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/interpret.ts
@@ -28,7 +28,7 @@ function checkImageSource(imageSource: string | ImageData): void {
       assertImageData(imageSource);
       break;
 
-    /* istanbul ignore next */
+    /* istanbul ignore next - @preserve */
     default:
       assert(false, `unknown imageSource type: ${typeof imageSource}`);
   }

--- a/libs/ballot-interpreter/src/hmpb-ts/interpret.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/interpret.ts
@@ -43,6 +43,8 @@ function normalizeOptionsForBridge(options: {
   inferTimingMarks?: boolean;
   minimumDetectedScale?: number;
   debug?: boolean;
+  frontNormalizedImageOutputPath?: string;
+  backNormalizedImageOutputPath?: string;
 }): Parameters<typeof interpretImpl> {
   assert(typeof options.electionDefinition.electionData === 'string');
   assert(options.ballotImages.length === 2);
@@ -72,6 +74,8 @@ function normalizeOptionsForBridge(options: {
       disableVerticalStreakDetection: options.disableVerticalStreakDetection,
       inferTimingMarks: options.inferTimingMarks,
       minimumDetectedScale: options.minimumDetectedScale,
+      frontNormalizedImageOutputPath: options.frontNormalizedImageOutputPath,
+      backNormalizedImageOutputPath: options.backNormalizedImageOutputPath,
     },
   ];
 }
@@ -88,6 +92,8 @@ export function interpret(options: {
   inferTimingMarks?: boolean;
   minimumDetectedScale?: number;
   debug?: boolean;
+  frontNormalizedImageOutputPath?: string;
+  backNormalizedImageOutputPath?: string;
 }): HmpbInterpretResult {
   const args = normalizeOptionsForBridge(options);
   const result = interpretImpl(...args);
@@ -97,23 +103,5 @@ export function interpret(options: {
     return err(value as InterpretError);
   }
 
-  const interpretedBallotCard = value as InterpretedBallotCard;
-
-  // The normalized images are not included in the JSON string for performance
-  // reasons. Instead, they are transferred as `ImageData`-compatible objects
-  // which transfers the pixel data as a fast memory copy. As a result, we need
-  // to add them back in here.
-  const { frontNormalizedImage, backNormalizedImage } = result;
-  interpretedBallotCard.front.normalizedImage = new ImageData(
-    new Uint8ClampedArray(frontNormalizedImage.data),
-    frontNormalizedImage.width,
-    frontNormalizedImage.height
-  );
-  interpretedBallotCard.back.normalizedImage = new ImageData(
-    new Uint8ClampedArray(backNormalizedImage.data),
-    backNormalizedImage.width,
-    backNormalizedImage.height
-  );
-
-  return ok(interpretedBallotCard);
+  return ok(value as InterpretedBallotCard);
 }

--- a/libs/ballot-interpreter/src/hmpb-ts/interpret.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/interpret.ts
@@ -34,53 +34,39 @@ function checkImageSource(imageSource: string | ImageData): void {
   }
 }
 
-function normalizeArgumentsForBridge(
-  electionDefinition: ElectionDefinition,
-  ballotImageSources: SheetOf<string> | SheetOf<ImageData>,
-  options:
-    | {
-        scoreWriteIns?: boolean;
-        disableVerticalStreakDetection?: boolean;
-        timingMarkAlgorithm?: 'contours' | 'corners';
-        inferTimingMarks?: boolean;
-        minimumDetectedScale?: number;
-        debug?: boolean;
-      }
-    | {
-        scoreWriteIns?: boolean;
-        disableVerticalStreakDetection?: boolean;
-        timingMarkAlgorithm?: 'contours' | 'corners';
-        inferTimingMarks?: boolean;
-        minimumDetectedScale?: number;
-        debugBasePaths?: SheetOf<string>;
-      } = {}
-): Parameters<typeof interpretImpl> {
-  assert(typeof electionDefinition.electionData === 'string');
-  assert(ballotImageSources.length === 2);
-  checkImageSource(ballotImageSources[0]);
-  checkImageSource(ballotImageSources[1]);
+function normalizeOptionsForBridge(options: {
+  electionDefinition: ElectionDefinition;
+  ballotImages: SheetOf<string> | SheetOf<ImageData>;
+  scoreWriteIns?: boolean;
+  disableVerticalStreakDetection?: boolean;
+  timingMarkAlgorithm?: 'contours' | 'corners';
+  inferTimingMarks?: boolean;
+  minimumDetectedScale?: number;
+  debug?: boolean;
+}): Parameters<typeof interpretImpl> {
+  assert(typeof options.electionDefinition.electionData === 'string');
+  assert(options.ballotImages.length === 2);
+  checkImageSource(options.ballotImages[0]);
+  checkImageSource(options.ballotImages[1]);
 
   let debugBasePathSideA: string | undefined;
   let debugBasePathSideB: string | undefined;
 
-  if ('debugBasePaths' in options) {
-    [debugBasePathSideA, debugBasePathSideB] = options.debugBasePaths ?? [];
-  } else if (
-    'debug' in options &&
+  if (
     options.debug &&
-    typeof ballotImageSources[0] === 'string' &&
-    typeof ballotImageSources[1] === 'string'
+    typeof options.ballotImages[0] === 'string' &&
+    typeof options.ballotImages[1] === 'string'
   ) {
     [debugBasePathSideA, debugBasePathSideB] =
-      ballotImageSources as SheetOf<string>;
+      options.ballotImages as SheetOf<string>;
   }
 
   return [
-    electionDefinition.election,
-    ...ballotImageSources,
-    debugBasePathSideA,
-    debugBasePathSideB,
+    options.electionDefinition.election,
+    ...options.ballotImages,
     {
+      debugBasePathSideA,
+      debugBasePathSideB,
       scoreWriteIns: options.scoreWriteIns,
       timingMarkAlgorithm: options.timingMarkAlgorithm,
       disableVerticalStreakDetection: options.disableVerticalStreakDetection,
@@ -93,62 +79,17 @@ function normalizeArgumentsForBridge(
 /**
  * Interprets a scanned ballot.
  */
-export function interpret(
-  electionDefinition: ElectionDefinition,
-  ballotImagePaths: SheetOf<string>,
-  options?: {
-    scoreWriteIns?: boolean;
-    disableVerticalStreakDetection?: boolean;
-    timingMarkAlgorithm?: 'contours' | 'corners';
-    inferTimingMarks?: boolean;
-    minimumDetectedScale?: number;
-    debug?: boolean;
-  }
-): HmpbInterpretResult;
-/**
- * Interprets a scanned ballot.
- */
-export function interpret(
-  electionDefinition: ElectionDefinition,
-  ballotImages: SheetOf<ImageData>,
-  options?: {
-    scoreWriteIns?: boolean;
-    disableVerticalStreakDetection?: boolean;
-    timingMarkAlgorithm?: 'contours' | 'corners';
-    inferTimingMarks?: boolean;
-    minimumDetectedScale?: number;
-    debugBasePaths?: SheetOf<string>;
-  }
-): HmpbInterpretResult;
-/**
- * Interprets a scanned ballot.
- */
-export function interpret(
-  electionDefinition: ElectionDefinition,
-  ballotImageSources: SheetOf<string> | SheetOf<ImageData>,
-  options?:
-    | {
-        scoreWriteIns?: boolean;
-        disableVerticalStreakDetection?: boolean;
-        timingMarkAlgorithm?: 'contours' | 'corners';
-        inferTimingMarks?: boolean;
-        minimumDetectedScale?: number;
-        debug?: boolean;
-      }
-    | {
-        scoreWriteIns?: boolean;
-        disableVerticalStreakDetection?: boolean;
-        timingMarkAlgorithm?: 'contours' | 'corners';
-        inferTimingMarks?: boolean;
-        minimumDetectedScale?: number;
-        debugBasePaths?: SheetOf<string>;
-      }
-): HmpbInterpretResult {
-  const args = normalizeArgumentsForBridge(
-    electionDefinition,
-    ballotImageSources,
-    options
-  );
+export function interpret(options: {
+  electionDefinition: ElectionDefinition;
+  ballotImages: SheetOf<string> | SheetOf<ImageData>;
+  scoreWriteIns?: boolean;
+  disableVerticalStreakDetection?: boolean;
+  timingMarkAlgorithm?: 'contours' | 'corners';
+  inferTimingMarks?: boolean;
+  minimumDetectedScale?: number;
+  debug?: boolean;
+}): HmpbInterpretResult {
+  const args = normalizeOptionsForBridge(options);
   const result = interpretImpl(...args);
   const value = safeParseJson(result.value).unsafeUnwrap();
 

--- a/libs/ballot-interpreter/src/hmpb-ts/scoring_report.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/scoring_report.ts
@@ -172,7 +172,9 @@ async function generateScoringReport(
 
   for (const { sheetName, pageImagePaths: imagePaths } of ballotImageSheets) {
     process.stdout.write(`Scoring sheet ${sheetName}\n`);
-    const interpretationResult = interpret(electionDefinition, imagePaths, {
+    const interpretationResult = interpret({
+      electionDefinition,
+      ballotImages: imagePaths,
       scoreWriteIns: true,
     });
     if (!interpretationResult.isOk()) {

--- a/libs/ballot-interpreter/src/hmpb-ts/types.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/types.ts
@@ -1,4 +1,3 @@
-import { ImageData } from 'canvas';
 import {
   HmpbBallotPaperSize,
   GridPosition,
@@ -96,7 +95,6 @@ export interface InterpretedBallotPage {
   metadata: BallotPageMetadata;
   marks: ScoredBubbleMarks;
   writeIns: ScoredPositionArea[];
-  normalizedImage: ImageData;
   contestLayouts: InterpretedContestLayout[];
 }
 

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -578,15 +578,15 @@ async function interpretBmdBallot(
     disableBmdBallotScanning
   );
 
-  if (frontNormalizedImageOutputPath) {
-    await writeImageData(frontNormalizedImageOutputPath, ballotImages[0]);
-  }
-
-  if (backNormalizedImageOutputPath) {
-    await writeImageData(backNormalizedImageOutputPath, ballotImages[1]);
-  }
-
   if (interpretResult.isErr()) {
+    // In case of an error, just write the original images.
+    if (frontNormalizedImageOutputPath) {
+      await writeImageData(frontNormalizedImageOutputPath, ballotImages[0]);
+    }
+    if (backNormalizedImageOutputPath) {
+      await writeImageData(backNormalizedImageOutputPath, ballotImages[1]);
+    }
+
     const error = interpretResult.err();
     switch (error.type) {
       case 'mismatched-election': {
@@ -662,15 +662,11 @@ async function interpretBmdBallot(
     type: 'BlankPage',
   };
 
-  if (options.frontNormalizedImageOutputPath) {
-    await writeImageData(
-      options.frontNormalizedImageOutputPath,
-      summaryBallotImage
-    );
+  if (frontNormalizedImageOutputPath) {
+    await writeImageData(frontNormalizedImageOutputPath, summaryBallotImage);
   }
-
-  if (options.backNormalizedImageOutputPath) {
-    await writeImageData(options.backNormalizedImageOutputPath, blankPageImage);
+  if (backNormalizedImageOutputPath) {
+    await writeImageData(backNormalizedImageOutputPath, blankPageImage);
   }
 
   return validateInterpretResults([front, back], options);

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -571,7 +571,9 @@ function interpretHmpb(
   options: InterpreterOptions
 ): SheetOf<InterpretFileResult> {
   const { electionDefinition } = options;
-  const result = interpretHmpbBallotSheetRust(electionDefinition, sheet, {
+  const result = interpretHmpbBallotSheetRust({
+    electionDefinition,
+    ballotImages: sheet,
     scoreWriteIns: shouldScoreWriteIns(options),
     disableVerticalStreakDetection: options.disableVerticalStreakDetection,
     inferTimingMarks: options.inferTimingMarks,

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -174,7 +174,7 @@ function aggregateContestOptionScores({
       : undefined;
     const writeInTextAreaThreshold =
       options.markThresholds.writeInTextArea ??
-      /* istanbul ignore next */
+      /* istanbul ignore next - @preserve */
       TEMPORARY_DEFAULT_WRITE_IN_AREA_THRESHOLD;
     const writeInAreaStatus = scoredWriteInArea
       ? scoredWriteInArea.score >= writeInTextAreaThreshold
@@ -222,7 +222,7 @@ function convertScoredContestOptionToLegacyMark({
     return { type: option.type, optionId: option.id, ...ballotTargetMarkBase };
   }
 
-  /* istanbul ignore next */
+  /* istanbul ignore next - @preserve */
   throwIllegalValue(option);
 }
 
@@ -443,7 +443,7 @@ export function convertRustInterpretResult(
   result: HmpbInterpretResult,
   sheet: SheetOf<ImageData>
 ): InterpretResult {
-  /* istanbul ignore next */
+  /* istanbul ignore next - @preserve */
   if (result.isErr()) {
     return ok(
       mapSheet(

--- a/libs/ballot-interpreter/src/interpret_all_bubble_ballot.test.ts
+++ b/libs/ballot-interpreter/src/interpret_all_bubble_ballot.test.ts
@@ -41,13 +41,13 @@ describe('Interpret - HMPB - All bubble ballot', () => {
       images
     );
 
-    assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
-    expect(frontResult.interpretation.votes).toEqual({
+    assert(frontResult.type === 'InterpretedHmpbPage');
+    expect(frontResult.votes).toEqual({
       'test-contest-page-1': [],
     });
 
-    assert(backResult.interpretation.type === 'InterpretedHmpbPage');
-    expect(backResult.interpretation.votes).toEqual({
+    assert(backResult.type === 'InterpretedHmpbPage');
+    expect(backResult.votes).toEqual({
       'test-contest-page-2': [],
     });
   });
@@ -69,13 +69,13 @@ describe('Interpret - HMPB - All bubble ballot', () => {
       images
     );
 
-    assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
-    expect(frontResult.interpretation.votes).toEqual({
+    assert(frontResult.type === 'InterpretedHmpbPage');
+    expect(frontResult.votes).toEqual({
       [frontContest.id]: frontContest.candidates,
     });
 
-    assert(backResult.interpretation.type === 'InterpretedHmpbPage');
-    expect(backResult.interpretation.votes).toEqual({
+    assert(backResult.type === 'InterpretedHmpbPage');
+    expect(backResult.votes).toEqual({
       [backContest.id]: backContest.candidates,
     });
   });
@@ -103,12 +103,12 @@ describe('Interpret - HMPB - All bubble ballot', () => {
         sheetImages
       );
 
-      assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
-      assert(backResult.interpretation.type === 'InterpretedHmpbPage');
+      assert(frontResult.type === 'InterpretedHmpbPage');
+      assert(backResult.type === 'InterpretedHmpbPage');
 
       for (const [contestId, candidates] of Object.entries({
-        ...frontResult.interpretation.votes,
-        ...backResult.interpretation.votes,
+        ...frontResult.votes,
+        ...backResult.votes,
       })) {
         votes[contestId]!.push(
           ...((candidates as Optional<CandidateVote>) ?? [])

--- a/libs/ballot-interpreter/src/interpret_and_save_files.test.ts
+++ b/libs/ballot-interpreter/src/interpret_and_save_files.test.ts
@@ -6,7 +6,7 @@ import {
   renderBmdBallotFixture,
 } from '@votingworks/bmd-ballot-fixtures';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
-import { loadImageData } from '@votingworks/image-utils';
+import { BLANK_PAGE_IMAGE_DATA, loadImageData } from '@votingworks/image-utils';
 import { DEFAULT_MARK_THRESHOLDS, asSheet } from '@votingworks/types';
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import { pdfToPageImages } from '../test/helpers/interpretation';
@@ -44,6 +44,33 @@ test('interprets ballot images and saves images for storage', async () => {
   expect(result.map(({ interpretation }) => interpretation.type)).toEqual([
     'InterpretedBmdPage',
     'BlankPage',
+  ]);
+  for (const { imagePath } of result) {
+    await expect(loadImageData(imagePath)).resolves.toBeDefined();
+  }
+});
+
+test('saves images even when interpretation fails', async () => {
+  const electionDefinition =
+    electionFamousNames2021Fixtures.readElectionDefinition();
+
+  const ballotImagesPath = tmpDir();
+  const result = await interpretSheetAndSaveImages(
+    {
+      electionDefinition,
+      precinctSelection: ALL_PRECINCTS_SELECTION,
+      testMode: true,
+      markThresholds: DEFAULT_MARK_THRESHOLDS,
+      adjudicationReasons: [],
+    },
+    [BLANK_PAGE_IMAGE_DATA, BLANK_PAGE_IMAGE_DATA],
+    'sheet-id',
+    ballotImagesPath
+  );
+
+  expect(result.map(({ interpretation }) => interpretation.type)).toEqual([
+    'UnreadablePage',
+    'UnreadablePage',
   ]);
   for (const { imagePath } of result) {
     await expect(loadImageData(imagePath)).resolves.toBeDefined();

--- a/libs/ballot-interpreter/src/interpret_blank_sheet.test.ts
+++ b/libs/ballot-interpreter/src/interpret_blank_sheet.test.ts
@@ -2,7 +2,7 @@ import {
   electionGridLayoutNewHampshireTestBallotFixtures,
   sampleBallotImages,
 } from '@votingworks/fixtures';
-import { DEFAULT_MARK_THRESHOLDS, mapSheet, SheetOf } from '@votingworks/types';
+import { DEFAULT_MARK_THRESHOLDS, SheetOf } from '@votingworks/types';
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import { ImageData } from 'canvas';
 import { beforeEach, expect, test, vi } from 'vitest';
@@ -21,7 +21,7 @@ test('blank sheet of paper', async () => {
     await sampleBallotImages.blankPage.asImageData(),
   ];
 
-  const interpretationWithImages = await interpretSheet(
+  const interpretation = await interpretSheet(
     {
       electionDefinition:
         electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition(),
@@ -33,9 +33,5 @@ test('blank sheet of paper', async () => {
     sheet
   );
 
-  const interpretation = mapSheet(
-    interpretationWithImages,
-    (page) => page.interpretation
-  );
   expect(interpretation).toMatchSnapshot();
 });

--- a/libs/ballot-interpreter/src/interpret_bmd_and_hmp_ballots.test.ts
+++ b/libs/ballot-interpreter/src/interpret_bmd_and_hmp_ballots.test.ts
@@ -55,13 +55,11 @@ test('interpret BMD ballot for an election supporting hand-marked paper ballots'
     bmdBallot
   );
 
-  expect(bmdPage1Result.interpretation).toMatchObject<
-    Partial<PageInterpretation>
-  >({
+  expect(bmdPage1Result).toMatchObject<Partial<PageInterpretation>>({
     type: 'InterpretedBmdPage',
     votes: validBmdVotes,
   });
-  expect(bmdPage2Result.interpretation).toEqual<PageInterpretation>({
+  expect(bmdPage2Result).toEqual<PageInterpretation>({
     type: 'BlankPage',
   });
 
@@ -80,20 +78,16 @@ test('interpret BMD ballot for an election supporting hand-marked paper ballots'
     hmpbBallot
   );
 
-  expect(hmpbPage1Result.interpretation).toMatchObject<
-    Partial<PageInterpretation>
-  >({
+  expect(hmpbPage1Result).toMatchObject<Partial<PageInterpretation>>({
     type: 'InterpretedHmpbPage',
   });
-  expect(hmpbPage2Result.interpretation).toMatchObject<
-    Partial<PageInterpretation>
-  >({
+  expect(hmpbPage2Result).toMatchObject<Partial<PageInterpretation>>({
     type: 'InterpretedHmpbPage',
   });
 
   expect({
-    ...(hmpbPage1Result.interpretation as InterpretedHmpbPage).votes,
-    ...(hmpbPage2Result.interpretation as InterpretedHmpbPage).votes,
+    ...(hmpbPage1Result as InterpretedHmpbPage).votes,
+    ...(hmpbPage2Result as InterpretedHmpbPage).votes,
   }).toEqual(vxFamousNamesFixtures.votes);
 });
 
@@ -125,10 +119,10 @@ test('interpret BMD ballot with test/official ballot mode mismatch error', async
     bmdBallot
   );
 
-  expect(bmdPage1Result.interpretation).toMatchObject<
-    Partial<PageInterpretation>
-  >({ type: 'InvalidTestModePage' });
-  expect(bmdPage2Result.interpretation).toEqual<PageInterpretation>({
+  expect(bmdPage1Result).toMatchObject<Partial<PageInterpretation>>({
+    type: 'InvalidTestModePage',
+  });
+  expect(bmdPage2Result).toEqual<PageInterpretation>({
     type: 'BlankPage',
   });
 });

--- a/libs/ballot-interpreter/src/interpret_bmd_ballots.test.ts
+++ b/libs/ballot-interpreter/src/interpret_bmd_ballots.test.ts
@@ -28,7 +28,6 @@ import {
   asSheet,
   getBallotStyle,
   getContests,
-  mapSheet,
   vote,
 } from '@votingworks/types';
 import {
@@ -89,8 +88,8 @@ describe('adjudication reporting', () => {
       ],
     });
 
-    assert(result[0].interpretation.type === 'InterpretedBmdPage');
-    const frontInterpretation = result[0].interpretation as InterpretedBmdPage;
+    assert(result[0].type === 'InterpretedBmdPage');
+    const frontInterpretation = result[0] as InterpretedBmdPage;
 
     expect(frontInterpretation.adjudicationInfo).toEqual({
       requiresAdjudication: false,
@@ -119,8 +118,8 @@ describe('adjudication reporting', () => {
       ],
     });
 
-    assert(result[0].interpretation.type === 'InterpretedBmdPage');
-    const frontInterpretation = result[0].interpretation as InterpretedBmdPage;
+    assert(result[0].type === 'InterpretedBmdPage');
+    const frontInterpretation = result[0] as InterpretedBmdPage;
 
     // The result of a blank ballot + all undervoted contests is very verbose so
     // we use a snapshot test but check for 'BlankBallot' for extra confidence.
@@ -148,8 +147,8 @@ describe('adjudication reporting', () => {
       adjudicationReasons: [AdjudicationReason.Undervote],
     });
 
-    assert(result[0].interpretation.type === 'InterpretedBmdPage');
-    const frontInterpretation = result[0].interpretation as InterpretedBmdPage;
+    assert(result[0].type === 'InterpretedBmdPage');
+    const frontInterpretation = result[0] as InterpretedBmdPage;
 
     // The result of a blank ballot + all undervoted contests is very verbose so
     // we use a snapshot test but check for absence of 'BlankBallot' for extra confidence.
@@ -186,8 +185,8 @@ describe('adjudication reporting', () => {
       ],
     });
 
-    assert(result[0].interpretation.type === 'InterpretedBmdPage');
-    const frontInterpretation = result[0].interpretation as InterpretedBmdPage;
+    assert(result[0].type === 'InterpretedBmdPage');
+    const frontInterpretation = result[0] as InterpretedBmdPage;
 
     expect(frontInterpretation.adjudicationInfo).toEqual({
       requiresAdjudication: true,
@@ -228,8 +227,8 @@ describe('adjudication reporting', () => {
       ],
     });
 
-    assert(result[0].interpretation.type === 'InterpretedBmdPage');
-    const frontInterpretation = result[0].interpretation as InterpretedBmdPage;
+    assert(result[0].type === 'InterpretedBmdPage');
+    const frontInterpretation = result[0] as InterpretedBmdPage;
 
     expect(frontInterpretation.adjudicationInfo).toEqual({
       requiresAdjudication: true,
@@ -262,8 +261,8 @@ describe('adjudication reporting', () => {
       adjudicationReasons: [AdjudicationReason.BlankBallot],
     });
 
-    assert(result[0].interpretation.type === 'InterpretedBmdPage');
-    const frontInterpretation = result[0].interpretation as InterpretedBmdPage;
+    assert(result[0].type === 'InterpretedBmdPage');
+    const frontInterpretation = result[0] as InterpretedBmdPage;
 
     // Use snapshot testing because ignoredReasonInfos for undervotes
     // on all contests is very verbose
@@ -318,8 +317,8 @@ describe('adjudication reporting', () => {
       ],
     });
 
-    assert(result[0].interpretation.type === 'InterpretedBmdPage');
-    const frontInterpretation = result[0].interpretation as InterpretedBmdPage;
+    assert(result[0].type === 'InterpretedBmdPage');
+    const frontInterpretation = result[0] as InterpretedBmdPage;
 
     expect(frontInterpretation.adjudicationInfo).toEqual({
       requiresAdjudication: true,
@@ -363,7 +362,7 @@ describe('VX BMD interpretation', () => {
   });
 
   test('extracts votes encoded in a QR code', async () => {
-    const result = await interpretSheet(
+    const interpretation = await interpretSheet(
       {
         electionDefinition,
         precinctSelection: ALL_PRECINCTS_SELECTION,
@@ -373,9 +372,7 @@ describe('VX BMD interpretation', () => {
       },
       validBmdSheet
     );
-    expect(
-      mapSheet(result, ({ interpretation }) => interpretation)
-    ).toMatchSnapshot();
+    expect(interpretation).toMatchSnapshot();
   });
 
   test('properly detects test ballot in live mode', async () => {
@@ -390,9 +387,7 @@ describe('VX BMD interpretation', () => {
       validBmdSheet
     );
 
-    expect(interpretationResult[0].interpretation.type).toEqual(
-      'InvalidTestModePage'
-    );
+    expect(interpretationResult[0].type).toEqual('InvalidTestModePage');
   });
 
   test('properly detects bmd ballot with wrong precinct', async () => {
@@ -407,9 +402,7 @@ describe('VX BMD interpretation', () => {
       validBmdSheet
     );
 
-    expect(interpretationResult[0].interpretation.type).toEqual(
-      'InvalidPrecinctPage'
-    );
+    expect(interpretationResult[0].type).toEqual('InvalidPrecinctPage');
   });
 
   test('properly detects bmd ballot with correct precinct', async () => {
@@ -424,9 +417,7 @@ describe('VX BMD interpretation', () => {
       validBmdSheet
     );
 
-    expect(interpretationResult[0].interpretation.type).toEqual(
-      'InterpretedBmdPage'
-    );
+    expect(interpretationResult[0].type).toEqual('InterpretedBmdPage');
   });
 
   test('properly detects a ballot with incorrect ballot hash', async () => {
@@ -444,9 +435,7 @@ describe('VX BMD interpretation', () => {
       validBmdSheet
     );
 
-    expect(
-      interpretationResult[0].interpretation
-    ).toEqual<InvalidBallotHashPage>({
+    expect(interpretationResult[0]).toEqual<InvalidBallotHashPage>({
       type: 'InvalidBallotHashPage',
       actualBallotHash: sliceBallotHashForEncoding(
         electionDefinition.ballotHash
@@ -497,11 +486,11 @@ describe('VX BMD interpretation', () => {
         validBmdSheet
       );
 
-      expect(interpretationResult[0].interpretation).toEqual<UnreadablePage>({
+      expect(interpretationResult[0]).toEqual<UnreadablePage>({
         type: 'UnreadablePage',
         reason: 'bmdBallotScanningDisabled',
       });
-      expect(interpretationResult[1].interpretation).toEqual<UnreadablePage>({
+      expect(interpretationResult[1]).toEqual<UnreadablePage>({
         type: 'UnreadablePage',
         reason: 'bmdBallotScanningDisabled',
       });
@@ -520,8 +509,8 @@ describe('VX BMD interpretation', () => {
       [bmdBlankPage, bmdBlankPage]
     );
 
-    expect(interpretationResult[0].interpretation.type).toEqual('BlankPage');
-    expect(interpretationResult[1].interpretation.type).toEqual('BlankPage');
+    expect(interpretationResult[0].type).toEqual('BlankPage');
+    expect(interpretationResult[1].type).toEqual('BlankPage');
   });
 
   test('treats sheets with multiple QR codes as unreadable', async () => {
@@ -536,25 +525,22 @@ describe('VX BMD interpretation', () => {
       [bmdSummaryBallotPage, bmdSummaryBallotPage]
     );
 
-    expect(interpretationResult[0].interpretation.type).toEqual(
-      'UnreadablePage'
-    );
-    expect(interpretationResult[1].interpretation.type).toEqual(
-      'UnreadablePage'
-    );
+    expect(interpretationResult[0].type).toEqual('UnreadablePage');
+    expect(interpretationResult[1].type).toEqual('UnreadablePage');
   });
 
   test('interpretSimplexBmdBallot', async () => {
-    const result = await interpretSimplexBmdBallot(bmdSummaryBallotPage, {
-      electionDefinition,
-      precinctSelection: ALL_PRECINCTS_SELECTION,
-      testMode: true,
-      markThresholds: DEFAULT_MARK_THRESHOLDS,
-      adjudicationReasons: [],
-    });
-    expect(
-      mapSheet(result, ({ interpretation }) => interpretation)
-    ).toMatchSnapshot();
+    const interpretation = await interpretSimplexBmdBallot(
+      bmdSummaryBallotPage,
+      {
+        electionDefinition,
+        precinctSelection: ALL_PRECINCTS_SELECTION,
+        testMode: true,
+        markThresholds: DEFAULT_MARK_THRESHOLDS,
+        adjudicationReasons: [],
+      }
+    );
+    expect(interpretation).toMatchSnapshot();
   });
 
   test('normalizes ballot modes', async () => {
@@ -577,8 +563,6 @@ describe('VX BMD interpretation', () => {
     );
 
     const interpretationResult = await interpretSheet(options, validBmdSheet);
-    expect(interpretationResult[0].interpretation).toEqual(
-      blankPageInterpretation
-    );
+    expect(interpretationResult[0]).toEqual(blankPageInterpretation);
   });
 });

--- a/libs/ballot-interpreter/src/interpret_vx_hmpb.test.ts
+++ b/libs/ballot-interpreter/src/interpret_vx_hmpb.test.ts
@@ -84,22 +84,22 @@ describe('HMPB - VX Famous Names', () => {
         images
       );
 
-      assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
-      expect(frontResult.interpretation.votes).toEqual({
+      assert(frontResult.type === 'InterpretedHmpbPage');
+      expect(frontResult.votes).toEqual({
         attorney: [],
         'chief-of-police': [],
         controller: [],
         mayor: [],
         'public-works-director': [],
       });
-      assert(backResult.interpretation.type === 'InterpretedHmpbPage');
-      expect(backResult.interpretation.votes).toEqual({
+      assert(backResult.type === 'InterpretedHmpbPage');
+      expect(backResult.votes).toEqual({
         'board-of-alderman': [],
         'city-council': [],
         'parks-and-recreation-director': [],
       });
 
-      expect(frontResult.interpretation.metadata).toEqual({
+      expect(frontResult.metadata).toEqual({
         source: 'qr-code',
         ballotHash: sliceBallotHashForEncoding(electionDefinition.ballotHash),
         precinctId,
@@ -108,7 +108,7 @@ describe('HMPB - VX Famous Names', () => {
         isTestMode: true,
         ballotType: BallotType.Precinct,
       });
-      expect(backResult.interpretation.metadata).toEqual({
+      expect(backResult.metadata).toEqual({
         source: 'qr-code',
         ballotHash: sliceBallotHashForEncoding(electionDefinition.ballotHash),
         precinctId,
@@ -140,12 +140,12 @@ describe('HMPB - VX Famous Names', () => {
         images
       );
 
-      assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
-      assert(backResult.interpretation.type === 'InterpretedHmpbPage');
+      assert(frontResult.type === 'InterpretedHmpbPage');
+      assert(backResult.type === 'InterpretedHmpbPage');
       expect(
         sortVotesDict({
-          ...frontResult.interpretation.votes,
-          ...backResult.interpretation.votes,
+          ...frontResult.votes,
+          ...backResult.votes,
         })
       ).toEqual(sortVotesDict(votes));
     }
@@ -173,8 +173,8 @@ describe('HMPB - VX Famous Names', () => {
         images
       );
 
-      expect(frontResult.interpretation.type).toEqual('InvalidBallotHashPage');
-      expect(backResult.interpretation.type).toEqual('InvalidBallotHashPage');
+      expect(frontResult.type).toEqual('InvalidBallotHashPage');
+      expect(backResult.type).toEqual('InvalidBallotHashPage');
     }
   );
 
@@ -199,8 +199,8 @@ describe('HMPB - VX Famous Names', () => {
         images
       );
 
-      expect(frontResult.interpretation.type).toEqual('InvalidPrecinctPage');
-      expect(backResult.interpretation.type).toEqual('InvalidPrecinctPage');
+      expect(frontResult.type).toEqual('InvalidPrecinctPage');
+      expect(backResult.type).toEqual('InvalidPrecinctPage');
     }
   );
 
@@ -223,8 +223,8 @@ describe('HMPB - VX Famous Names', () => {
         images
       );
 
-      expect(frontResult.interpretation.type).toEqual('InvalidTestModePage');
-      expect(backResult.interpretation.type).toEqual('InvalidTestModePage');
+      expect(frontResult.type).toEqual('InvalidTestModePage');
+      expect(backResult.type).toEqual('InvalidTestModePage');
     }
   );
 
@@ -254,12 +254,8 @@ describe('HMPB - VX Famous Names', () => {
       );
 
       const interpretationResult = await interpretSheet(options, images);
-      expect(interpretationResult[0].interpretation).toEqual(
-        blankPageInterpretation
-      );
-      expect(interpretationResult[1].interpretation).toEqual(
-        blankPageInterpretation
-      );
+      expect(interpretationResult[0]).toEqual(blankPageInterpretation);
+      expect(interpretationResult[1]).toEqual(blankPageInterpretation);
     }
   );
 
@@ -299,8 +295,8 @@ describe('HMPB - VX Famous Names', () => {
         type: 'UnreadablePage',
         reason: 'verticalStreaksDetected',
       };
-      expect(frontResult.interpretation).toEqual(streaksInterpretation);
-      expect(backResult.interpretation).toEqual(streaksInterpretation);
+      expect(frontResult).toEqual(streaksInterpretation);
+      expect(backResult).toEqual(streaksInterpretation);
     }
   );
 });
@@ -472,23 +468,23 @@ for (const spec of vxGeneralElectionFixtures.fixtureSpecs) {
           gridLayout
         );
 
-        assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
-        assert(backResult.interpretation.type === 'InterpretedHmpbPage');
+        assert(frontResult.type === 'InterpretedHmpbPage');
+        assert(backResult.type === 'InterpretedHmpbPage');
         expect(
           sortVotesDict({
-            ...frontResult.interpretation.votes,
-            ...backResult.interpretation.votes,
+            ...frontResult.votes,
+            ...backResult.votes,
           })
         ).toEqual(sortVotesDict(expectedVotes));
 
         expect(
           sortUnmarkedWriteIns([
-            ...(frontResult.interpretation.unmarkedWriteIns ?? []),
-            ...(backResult.interpretation.unmarkedWriteIns ?? []),
+            ...(frontResult.unmarkedWriteIns ?? []),
+            ...(backResult.unmarkedWriteIns ?? []),
           ])
         ).toEqual(sortUnmarkedWriteIns(expectedUnmarkedWriteIns));
 
-        expect(frontResult.interpretation.metadata).toEqual({
+        expect(frontResult.metadata).toEqual({
           source: 'qr-code',
           ballotHash: sliceBallotHashForEncoding(electionDefinition.ballotHash),
           precinctId,
@@ -497,7 +493,7 @@ for (const spec of vxGeneralElectionFixtures.fixtureSpecs) {
           isTestMode: false,
           ballotType: BallotType.Absentee,
         });
-        expect(backResult.interpretation.metadata).toEqual({
+        expect(backResult.metadata).toEqual({
           source: 'qr-code',
           ballotHash: sliceBallotHashForEncoding(electionDefinition.ballotHash),
           precinctId,
@@ -510,10 +506,7 @@ for (const spec of vxGeneralElectionFixtures.fixtureSpecs) {
         // Snapshot the ballot images with write-in crops drawn on them
         // To save time we don't test across paper sizes.
         if (spec.paperSize === HmpbBallotPaperSize.Letter) {
-          snapshotWriteInCrops(sheetImages, [
-            frontResult.interpretation,
-            backResult.interpretation,
-          ]);
+          snapshotWriteInCrops(sheetImages, [frontResult, backResult]);
         }
       }
     });
@@ -554,14 +547,12 @@ describe('HMPB - VX primary election', () => {
         (layout) => layout.ballotStyleId === ballotStyleId
       )!;
 
-      assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
-      expect(frontResult.interpretation.votes).toEqual(
-        votesForSheet({}, 1, gridLayout)
-      );
-      assert(backResult.interpretation.type === 'InterpretedHmpbPage');
-      expect(backResult.interpretation.votes).toEqual({});
+      assert(frontResult.type === 'InterpretedHmpbPage');
+      expect(frontResult.votes).toEqual(votesForSheet({}, 1, gridLayout));
+      assert(backResult.type === 'InterpretedHmpbPage');
+      expect(backResult.votes).toEqual({});
 
-      expect(frontResult.interpretation.metadata).toEqual({
+      expect(frontResult.metadata).toEqual({
         source: 'qr-code',
         ballotHash: sliceBallotHashForEncoding(electionDefinition.ballotHash),
         precinctId,
@@ -570,7 +561,7 @@ describe('HMPB - VX primary election', () => {
         isTestMode: true,
         ballotType: BallotType.Precinct,
       });
-      expect(backResult.interpretation.metadata).toEqual({
+      expect(backResult.metadata).toEqual({
         source: 'qr-code',
         ballotHash: sliceBallotHashForEncoding(electionDefinition.ballotHash),
         precinctId,
@@ -595,12 +586,12 @@ describe('HMPB - VX primary election', () => {
         images
       );
 
-      assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
-      assert(backResult.interpretation.type === 'InterpretedHmpbPage');
+      assert(frontResult.type === 'InterpretedHmpbPage');
+      assert(backResult.type === 'InterpretedHmpbPage');
       expect(
         sortVotesDict({
-          ...frontResult.interpretation.votes,
-          ...backResult.interpretation.votes,
+          ...frontResult.votes,
+          ...backResult.votes,
         })
       ).toEqual(sortVotesDict(votes));
     });
@@ -627,11 +618,11 @@ describe('HMPB - VX primary election', () => {
       [frontImage, backImage]
     );
 
-    expect(frontResult.interpretation).toEqual<PageInterpretation>({
+    expect(frontResult).toEqual<PageInterpretation>({
       type: 'UnreadablePage',
       reason: 'mismatchedPrecincts',
     });
-    expect(backResult.interpretation).toEqual<PageInterpretation>({
+    expect(backResult).toEqual<PageInterpretation>({
       type: 'UnreadablePage',
       reason: 'mismatchedPrecincts',
     });
@@ -658,11 +649,11 @@ describe('HMPB - VX primary election', () => {
       [frontImage, backImage]
     );
 
-    expect(frontResult.interpretation).toEqual<PageInterpretation>({
+    expect(frontResult).toEqual<PageInterpretation>({
       type: 'UnreadablePage',
       reason: 'mismatchedBallotStyles',
     });
-    expect(backResult.interpretation).toEqual<PageInterpretation>({
+    expect(backResult).toEqual<PageInterpretation>({
       type: 'UnreadablePage',
       reason: 'mismatchedBallotStyles',
     });
@@ -710,23 +701,23 @@ for (const spec of nhGeneralElectionFixtures.fixtureSpecs) {
           gridLayout
         );
 
-        assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
-        assert(backResult.interpretation.type === 'InterpretedHmpbPage');
+        assert(frontResult.type === 'InterpretedHmpbPage');
+        assert(backResult.type === 'InterpretedHmpbPage');
         expect(
           sortVotesDict({
-            ...frontResult.interpretation.votes,
-            ...backResult.interpretation.votes,
+            ...frontResult.votes,
+            ...backResult.votes,
           })
         ).toEqual(sortVotesDict(expectedVotes));
 
         expect(
           sortUnmarkedWriteIns([
-            ...(frontResult.interpretation.unmarkedWriteIns ?? []),
-            ...(backResult.interpretation.unmarkedWriteIns ?? []),
+            ...(frontResult.unmarkedWriteIns ?? []),
+            ...(backResult.unmarkedWriteIns ?? []),
           ])
         ).toEqual(sortUnmarkedWriteIns(expectedUnmarkedWriteIns));
 
-        expect(frontResult.interpretation.metadata).toEqual({
+        expect(frontResult.metadata).toEqual({
           source: 'qr-code',
           ballotHash: sliceBallotHashForEncoding(electionDefinition.ballotHash),
           precinctId,
@@ -735,7 +726,7 @@ for (const spec of nhGeneralElectionFixtures.fixtureSpecs) {
           isTestMode: false,
           ballotType: BallotType.Precinct,
         });
-        expect(backResult.interpretation.metadata).toEqual({
+        expect(backResult.metadata).toEqual({
           source: 'qr-code',
           ballotHash: sliceBallotHashForEncoding(electionDefinition.ballotHash),
           precinctId,
@@ -748,10 +739,7 @@ for (const spec of nhGeneralElectionFixtures.fixtureSpecs) {
         // Snapshot the ballot images with write-in crops drawn on them
         // To save time we don't test across paper sizes.
         if (spec.paperSize === HmpbBallotPaperSize.Letter) {
-          snapshotWriteInCrops(sheetImages, [
-            frontResult.interpretation,
-            backResult.interpretation,
-          ]);
+          snapshotWriteInCrops(sheetImages, [frontResult, backResult]);
         }
       }
     });
@@ -777,11 +765,11 @@ test('Non-consecutive page numbers', async () => {
     [frontImage!, backImage!]
   );
 
-  expect(frontResult.interpretation).toEqual<PageInterpretation>({
+  expect(frontResult).toEqual<PageInterpretation>({
     type: 'UnreadablePage',
     reason: 'nonConsecutivePageNumbers',
   });
-  expect(backResult.interpretation).toEqual<PageInterpretation>({
+  expect(backResult).toEqual<PageInterpretation>({
     type: 'UnreadablePage',
     reason: 'nonConsecutivePageNumbers',
   });
@@ -822,14 +810,10 @@ test('Ballot audit IDs', async () => {
     images
   );
 
-  assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
-  assert(backResult.interpretation.type === 'InterpretedHmpbPage');
-  expect(frontResult.interpretation.metadata.ballotAuditId).toEqual(
-    'test-ballot-audit-id'
-  );
-  expect(backResult.interpretation.metadata.ballotAuditId).toEqual(
-    'test-ballot-audit-id'
-  );
+  assert(frontResult.type === 'InterpretedHmpbPage');
+  assert(backResult.type === 'InterpretedHmpbPage');
+  expect(frontResult.metadata.ballotAuditId).toEqual('test-ballot-audit-id');
+  expect(backResult.metadata.ballotAuditId).toEqual('test-ballot-audit-id');
 });
 
 describe('Contest option bounds', () => {
@@ -880,12 +864,9 @@ describe('Contest option bounds', () => {
       images
     );
 
-    assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
-    assert(backResult.interpretation.type === 'InterpretedHmpbPage');
-    snapshotBallotMeasureCrops(images, [
-      frontResult.interpretation,
-      backResult.interpretation,
-    ]);
+    assert(frontResult.type === 'InterpretedHmpbPage');
+    assert(backResult.type === 'InterpretedHmpbPage');
+    snapshotBallotMeasureCrops(images, [frontResult, backResult]);
   });
 
   test('Election with candidate contests only, no write-ins', async () => {
@@ -942,11 +923,8 @@ describe('Contest option bounds', () => {
       images
     );
 
-    assert(frontResult.interpretation.type === 'InterpretedHmpbPage');
-    assert(backResult.interpretation.type === 'InterpretedHmpbPage');
-    snapshotCandidateOptionCrops(images, [
-      frontResult.interpretation,
-      backResult.interpretation,
-    ]);
+    assert(frontResult.type === 'InterpretedHmpbPage');
+    assert(backResult.type === 'InterpretedHmpbPage');
+    snapshotCandidateOptionCrops(images, [frontResult, backResult]);
   });
 });

--- a/libs/ballot-interpreter/src/types.ts
+++ b/libs/ballot-interpreter/src/types.ts
@@ -19,4 +19,6 @@ export interface InterpreterOptions {
   testMode: boolean;
   disableBmdBallotScanning?: boolean;
   minimumDetectedScale?: number;
+  frontNormalizedImageOutputPath?: string;
+  backNormalizedImageOutputPath?: string;
 }

--- a/libs/ballot-interpreter/test/helpers/interpretation.ts
+++ b/libs/ballot-interpreter/test/helpers/interpretation.ts
@@ -95,7 +95,7 @@ export function sortUnmarkedWriteIns(
   return [...writeIns].sort(
     (a, b) =>
       a.contestId.localeCompare(b.contestId) ||
-      /* istanbul ignore next */
+      /* istanbul ignore next - @preserve */
       a.optionId.localeCompare(b.optionId)
   );
 }


### PR DESCRIPTION
## Overview

This change provides a small speed boost to HMPB interpretation by changing the contract of the Rust code to never pass image data back, instead writing the normalized ballot image data to disk in the location that the calling JS code wants it to go.

## Demo Video or Screenshot
<details>
<summary>
Built both versions (JS writes, Rust writes) and ran them several times. Typical times on my i5 machine were <b>75ms</b> for Rust, <b>280ms</b> for JS.
</summary>
<pre>
❯ node compare.js
setup: 131.41ms
JS Writes: 283.72ms
Rust Writes: 72.745ms

❯ node compare.js
setup: 140.669ms
JS Writes: 296.398ms
Rust Writes: 79.841ms

❯ node compare.js
setup: 132.113ms
JS Writes: 274.477ms
Rust Writes: 75.326ms

❯ node compare.js
setup: 145.867ms
JS Writes: 303.028ms
Rust Writes: 81.836ms

❯ node compare.js
setup: 146.944ms
JS Writes: 288.04ms
Rust Writes: 77.003ms
</pre>
</details>

I did some further testing in the context of the VxScan app on my machine (middling Lenovo ThinkCentre i5) and got these numbers:

JS Writes:
- start scan: 0.70s
- end scan: 1.50s
- start eject: 2.04s
- hold time: 2.04s - 1.50s = 540ms

Rust Writes:
- start scan: 0.89s
- end scan: 1.71s
- start eject: 2.02s
- hold time: 2.02s - 1.71s = 310ms

So it seems like the timing using the comparison script roughly translates to the context of the VxScan app, saving about 200ms on this hardware.

## Testing Plan
<details>
<summary>
Tested performance using a script that loaded both versions of the Rust addon and either deferred to Rust ("Rust Writes") or handled writing itself ("JS Writes").
</summary>
<pre>
const jsWrites = require('./build/old.node');
const rustWrites = require('./build/new.node');
const { loadImageData } = require('@votingworks/image-utils');
const { saveSheetImages } = require('./build/save_images');
const assert = require('node:assert');

async function main() {
  console.time('setup');
  const election = require('./test/fixtures/104h-2025-04/election.json');
  const frontImageData = await loadImageData('./test/fixtures/104h-2025-04/imprinter-front.png');
  const backImageData = await loadImageData('./test/fixtures/104h-2025-04/imprinter-back.png');
  console.timeEnd('setup');

  console.time('JS Writes');
  const jsWritesResult = jsWrites.interpret(election, frontImageData, backImageData);
  assert(jsWritesResult.success);
  await saveSheetImages({
    sheetId: 'js-writes',
    ballotImagesPath: '.',
    images: [
      { ...jsWritesResult.frontNormalizedImage, data: new Uint8ClampedArray(jsWritesResult.frontNormalizedImage.data) },
      { ...jsWritesResult.backNormalizedImage, data: new Uint8ClampedArray(jsWritesResult.backNormalizedImage.data) },
    ],
  });
  console.timeEnd('JS Writes');

  console.time('Rust Writes');
  const rustWritesResult = rustWrites.interpret(election, frontImageData, backImageData, {
    frontNormalizedImageOutputPath: 'rust-writes-front.png',
    backNormalizedImageOutputPath: 'rust-writes-back.png',
  });
  console.timeEnd('Rust Writes');
}

main().catch((e) => console.error(e.stack));
</pre>
</details>
