### PR TITLE
VxDesign: Improve warning for error with syncing org cache

### DIFF
--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -47,8 +47,20 @@ async function main(): Promise<number> {
   const { store } = workspace;
 
   const auth0 = authEnabled() ? Auth0Client.init() : Auth0Client.dev();
-  if (NODE_ENV === 'production') {
-    await store.syncOrganizationsCache(await auth0.allOrgs());
+  if (authEnabled()) {
+    try {
+      await store.syncOrganizationsCache(await auth0.allOrgs());
+    } catch (error) {
+      if (NODE_ENV === 'development') {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'Error syncing the auth organizations to the local database.',
+          'Are you using a production database backup in development?',
+          'If so, set AUTH_ENABLED=false and ORG_ID_VOTINGWORKS=<prod_Auth0_VX_org_id>.'
+        );
+      }
+      throw error;
+    }
   }
 
   // We reuse the VxSuite logging library, but it doesn't matter if we meet VVSG


### PR DESCRIPTION

## Overview

I realized that the previous guard to only sync the org cache on startup in production (#7176) was not working well in development. I originally thought that running `pnpm db:reset-dev` would repopulate the org cache in development, but that's only true if you run that command with `AUTH_ENABLED=true` in its environment (it doesn't know how to check .env.local).

So instead, I decided to change the sync-on-startup logic to run whenever auth is enabled (in either prod or development). However, this brings back the original issue: if you're using a prod db backup for debugging but are pointed at the dev Auth0 instance, syncing will fail.

I added some logic to catch this error and log instructions for how to easily work around this. Since debugging from a prod backup is an uncommon use case, I'm ok with having to do a few steps to enable it.


<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
