### PR TITLE
VxDesign: Rotate candidates by precinct for some hardcoded NH contests

### DIFF
--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.test.ts
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, test } from 'vitest';
-import { readElectionGeneral } from '@votingworks/fixtures';
+import {
+  electionFamousNames2021Fixtures,
+  readElectionGeneral,
+} from '@votingworks/fixtures';
 import { CandidateContest } from '@votingworks/types';
-import { rotateCandidates } from './nh_ballot_template';
+import {
+  rotateCandidatesByStatute,
+  rotateCandidatesByPrecinct,
+} from './nh_ballot_template';
 
 const electionGeneral = readElectionGeneral();
 
-describe('rotateCandidates', () => {
+describe('rotateCandidatesByStatute', () => {
   const election = electionGeneral;
   const candidateContest = election.contests.find(
     (c): c is CandidateContest => c.type === 'candidate'
@@ -16,7 +22,7 @@ describe('rotateCandidates', () => {
       ...candidateContest,
       candidates: candidateContest.candidates.slice(0, 1),
     };
-    expect(rotateCandidates(contest)).toEqual(
+    expect(rotateCandidatesByStatute(contest)).toEqual(
       contest.candidates.map((c) => c.id)
     );
   });
@@ -40,7 +46,7 @@ describe('rotateCandidates', () => {
         },
       ],
     };
-    expect(rotateCandidates(contest)).toEqual([
+    expect(rotateCandidatesByStatute(contest)).toEqual([
       '1', // Martha Jones
       '3', // Larry Smith
       '2', // John Zorro
@@ -93,7 +99,7 @@ describe('rotateCandidates', () => {
         },
       ],
     };
-    expect(rotateCandidates(contest)).toEqual([
+    expect(rotateCandidatesByStatute(contest)).toEqual([
       '3', // John Curtis
       '4', // Adam Dean
       '5', // Frank French
@@ -131,7 +137,7 @@ describe('rotateCandidates', () => {
         },
       ],
     };
-    expect(rotateCandidates(contest)).toEqual([
+    expect(rotateCandidatesByStatute(contest)).toEqual([
       '3', // John Adams
       // 'del Rey' comes after 'Adams' but before 'Harding'
       '1', // Lana del Rey
@@ -162,7 +168,7 @@ describe('rotateCandidates', () => {
         },
       ],
     };
-    expect(rotateCandidates(contest)).toEqual([
+    expect(rotateCandidatesByStatute(contest)).toEqual([
       '3', // John Adams
       // 'George' comes after 'Adams' but before 'Harding'
       '1', // George
@@ -188,10 +194,57 @@ describe('rotateCandidates', () => {
         },
       ],
     };
-    expect(rotateCandidates(contest)).toEqual([
+    expect(rotateCandidatesByStatute(contest)).toEqual([
       '1', // Martha Jones
       '3', // Larry Smith
       '2', // John Zorro
     ]);
   });
+});
+
+test('rotateCandidatesByPrecinct rotates based on index of precinct within ballot style', () => {
+  const election = electionFamousNames2021Fixtures.readElection();
+  const candidateContest = election.contests.find(
+    (c): c is CandidateContest => c.type === 'candidate'
+  )!;
+  const contest: CandidateContest = {
+    ...candidateContest,
+    candidates: [
+      {
+        id: '1',
+        name: 'Jane Adams',
+      },
+      {
+        id: '2',
+        name: 'John Curtis',
+      },
+      {
+        id: '3',
+        name: 'Bruce Brown',
+      },
+    ],
+  };
+  const [precinct1, precinct2, precinct3, precinct4] = election.precincts;
+
+  expect(rotateCandidatesByPrecinct(contest, election, precinct1.id)).toEqual([
+    '1', // Jane Adams
+    '2', // John Curtis
+    '3', // Bruce Brown
+  ]);
+  expect(rotateCandidatesByPrecinct(contest, election, precinct2.id)).toEqual([
+    '2', // John Curtis
+    '3', // Bruce Brown
+    '1', // Jane Adams
+  ]);
+
+  expect(rotateCandidatesByPrecinct(contest, election, precinct3.id)).toEqual([
+    '3', // Bruce Brown
+    '1', // Jane Adams
+    '2', // John Curtis
+  ]);
+  expect(rotateCandidatesByPrecinct(contest, election, precinct4.id)).toEqual([
+    '1', // Jane Adams
+    '2', // John Curtis
+    '3', // Bruce Brown
+  ]);
 });

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.test.ts
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.test.ts
@@ -212,39 +212,38 @@ test('rotateCandidatesByPrecinct rotates based on index of precinct within ballo
     candidates: [
       {
         id: '1',
-        name: 'Jane Adams',
+        name: 'Martha Jones',
       },
       {
         id: '2',
-        name: 'John Curtis',
+        name: 'John Zorro',
       },
       {
         id: '3',
-        name: 'Bruce Brown',
+        name: 'Larry Smith',
       },
     ],
   };
   const [precinct1, precinct2, precinct3, precinct4] = election.precincts;
 
   expect(rotateCandidatesByPrecinct(contest, election, precinct1.id)).toEqual([
-    '1', // Jane Adams
-    '2', // John Curtis
-    '3', // Bruce Brown
+    '1', // Martha Jones
+    '3', // Larry Smith
+    '2', // John Zorro
   ]);
   expect(rotateCandidatesByPrecinct(contest, election, precinct2.id)).toEqual([
-    '2', // John Curtis
-    '3', // Bruce Brown
-    '1', // Jane Adams
+    '3', // Larry Smith
+    '1', // Martha Jones
+    '2', // John Zorro
   ]);
-
   expect(rotateCandidatesByPrecinct(contest, election, precinct3.id)).toEqual([
-    '3', // Bruce Brown
-    '1', // Jane Adams
-    '2', // John Curtis
+    '2', // John Zorro
+    '1', // Martha Jones
+    '3', // Larry Smith
   ]);
   expect(rotateCandidatesByPrecinct(contest, election, precinct4.id)).toEqual([
-    '1', // Jane Adams
-    '2', // John Curtis
-    '3', // Bruce Brown
+    '1', // Martha Jones
+    '3', // Larry Smith
+    '2', // John Zorro
   ]);
 });

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.test.ts
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.test.ts
@@ -233,8 +233,8 @@ test('rotateCandidatesByPrecinct rotates based on index of precinct within ballo
   ]);
   expect(rotateCandidatesByPrecinct(contest, election, precinct2.id)).toEqual([
     '3', // Larry Smith
-    '1', // Martha Jones
     '2', // John Zorro
+    '1', // Martha Jones
   ]);
   expect(rotateCandidatesByPrecinct(contest, election, precinct3.id)).toEqual([
     '2', // John Zorro

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -159,11 +159,10 @@ export function rotateCandidatesByPrecinct(
     ) % contest.candidates.length;
   // First, rotate by statute
   const candidatesRotatedByStatute = rotateCandidatesByStatute(contest);
-  // Then, put the nth candidate first, leaving the rest in the statue-rotated order
+  // Then rotate by precinct offset
   const rotatedCandidates = [
-    candidatesRotatedByStatute[offset],
+    ...candidatesRotatedByStatute.slice(offset),
     ...candidatesRotatedByStatute.slice(0, offset),
-    ...candidatesRotatedByStatute.slice(offset + 1),
   ];
   return rotatedCandidates;
 }

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -157,11 +157,15 @@ export function rotateCandidatesByPrecinct(
     allPrecinctsWithContest.findIndex(
       (precinct) => precinct.id === precinctId
     ) % contest.candidates.length;
+  // First, rotate by statute
+  const candidatesRotatedByStatute = rotateCandidatesByStatute(contest);
+  // Then, put the nth candidate first, leaving the rest in the statue-rotated order
   const rotatedCandidates = [
-    ...contest.candidates.slice(offset),
-    ...contest.candidates.slice(0, offset),
+    candidatesRotatedByStatute[offset],
+    ...candidatesRotatedByStatute.slice(0, offset),
+    ...candidatesRotatedByStatute.slice(offset + 1),
   ];
-  return rotatedCandidates.map((c) => c.id);
+  return rotatedCandidates;
 }
 
 // Special case for some specific contests in the November 2025 election that
@@ -171,6 +175,7 @@ export function rotateCandidatesByPrecinct(
 const contestsUsingPrecinctRotation: Record<ElectionId, ContestId[]> = {
   '5p1op86c38fe': [
     'brxyaolp9hvi',
+    '3vqx3zkl5dhi',
     '14nvftrtp8cl',
     'exgu2lnf1g1i',
     'fpkjxj4ow10w',

--- a/libs/hmpb/src/render_ballot.test.tsx
+++ b/libs/hmpb/src/render_ballot.test.tsx
@@ -11,7 +11,7 @@ import { BALLOT_MODES } from './types';
 import { createPlaywrightRenderer } from './playwright_renderer';
 import { ballotTemplates } from './ballot_templates';
 import { vxFamousNamesFixtures } from './ballot_fixtures';
-import { rotateCandidates } from './ballot_templates/nh_ballot_template';
+import { rotateCandidatesByStatute } from './ballot_templates/nh_ballot_template';
 
 function combinations<T extends Record<string, unknown>>(
   arrays: Array<Array<Partial<T>>>
@@ -116,7 +116,7 @@ test('reorder candidates based on rotation from template', async () => {
       fixtureContest;
     expect(restContest).toEqual(restFixtureContest);
     expect(candidates.map((c) => c.id)).toEqual(
-      rotateCandidates(fixtureContest)
+      rotateCandidatesByStatute(fixtureContest)
     );
   }
 });


### PR DESCRIPTION
## Overview

Closes #7160 

Special cases some specific contests in the November 2025 election that use rotation by precinct (they have a legal exception). Since this is a very specific exception, we hardcode it for now. In the future, we can revisit whether we want to support this in a more general way.

## Demo Video or Screenshot
(Skipping because this logic only applies to specific contests from production data)

## Testing Plan
- Manual test with the specific contests this applies to
- Basic unit test

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
