### PR TITLE
LA Demo: ballot PDF file parsing fix

### DIFF
--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -89,8 +89,10 @@ async function readBallotPdfsFromUsbDrive(
         async (
           entry
         ): Promise<[[PrecinctId, BallotStyleId], Buffer] | null> => {
+          // must be updated to be resilient to precinct names with hyphens
           const [, precinctName, ballotStyleId] =
-            entry.name.match(/^official-precinct-ballot-(.*)-(.*)\.pdf$/) ?? [];
+            entry.name.match(/^official-precinct-ballot-([^-]*)-(.*)\.pdf$/) ??
+            [];
           if (!(precinctName && ballotStyleId)) return null;
           const precinctId = find(
             electionDefinition.election.precincts,


### PR DESCRIPTION
## Overview

Allows supporting multi-lingual ballots with hyphens in the name. Not resilient to precincts with hyphens in them yet, will need to revisit for production.

## Testing Plan

- tested on our demo election
- tested on an LA election
- confirmed all the LA elections have precincts with no hyphens