### PR TITLE
VxDesign: Fix candidate rotation assertion for contests with no candidates

### DIFF
--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -568,8 +568,8 @@ function candidateOrderFromGridLayout(
       position.contestId === contest.id && position.type === 'option'
   );
   assert(
-    unique(contestPositions.map((p) => p.sheetNumber)).length === 1,
-    'Contest appears on multiple sheets'
+    unique(contestPositions.map((p) => p.sheetNumber)).length <= 1,
+    `Contest appears on multiple sheets: ${contest.id}`
   );
   return [...contestPositions]
     .sort((a, b) => a.row - b.row)


### PR DESCRIPTION


## Overview

Patch to fix #7216 for contests with no candidates.

## Demo Video or Screenshot
N/A

## Testing Plan
Manual test

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
