### PR TITLE
Address diagnostics retrieval edge case

### DIFF
--- a/libs/backend/src/diagnostics.test.ts
+++ b/libs/backend/src/diagnostics.test.ts
@@ -38,6 +38,18 @@ test('add and get diagnostic records', () => {
     outcome: 'fail',
     timestamp: 3,
   });
+
+  // Check that we're retrieving the latest record using the monotonically increasing ID rather
+  // than the timestamp to ensure that we're pulling by real world time rather than system time,
+  // which can be toggled into the future and then back into the past
+  addDiagnosticRecord(client, { type: 'test-print', outcome: 'pass' }, 0);
+  expect(
+    getMostRecentDiagnosticRecord(client, 'test-print')
+  ).toEqual<DiagnosticRecord>({
+    type: 'test-print',
+    outcome: 'pass',
+    timestamp: 0,
+  });
 });
 
 test('defaults to current timestamp', () => {

--- a/libs/backend/src/diagnostics.ts
+++ b/libs/backend/src/diagnostics.ts
@@ -47,6 +47,9 @@ export function getMostRecentDiagnosticRecord(
   client: Client,
   type: DiagnosticType
 ): DiagnosticRecord | undefined {
+  // Retrieve the latest record using the monotonically increasing ID rather than the timestamp to
+  // ensure that we're pulling by real world time rather than system time, which can be toggled
+  // into the future and then back into the past
   const record = client.one(
     `
       select
@@ -56,7 +59,7 @@ export function getMostRecentDiagnosticRecord(
         timestamp
       from diagnostics
       where type = ?
-      order by timestamp desc
+      order by id desc
       limit 1
     `,
     type


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7212

A kinda funny find by SLI. If you set the clock to some time in the future, record a diagnostic result, reset the clock back, and record a second diagnostic result, the second diagnostic result doesn't show. You remain stuck with the first diagnostic result captured in the "future."

We currently retrieve the diagnostic result with the latest timestamp, where the timestamp is the system time at the time of record creation. Because our machines are offline and clocks are set manually, this time may not actually correspond to the latest created record according to real world time. As a simple fix, I'm now retrieving the diagnostic record with the highest sequential ID.

## Demo Video or Screenshot

### Before

No matter what I click, the diagnostic result doesn't update.

https://github.com/user-attachments/assets/0fe1eb48-c3cb-4f75-bd52-40afba8ec4b1

### After

Now, even if the current result has a future timestamp, the latest interaction according to real world time wins out.

https://github.com/user-attachments/assets/f7baf57e-3558-4bca-861e-dd2306d1bc74

## Testing Plan

- [x] Updated automated tests
- [x] Tested manually

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~ N/A
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~ N/A
- [ ] ~I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~ N/A
