### PR TITLE
VxDesign: Persist last exported ballot hash

### DIFF
--- a/apps/design/backend/migrations/1758572282198_add-last-exported-ballot-hash.js
+++ b/apps/design/backend/migrations/1758572282198_add-last-exported-ballot-hash.js
@@ -1,0 +1,16 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  // Add optional last_exported_ballot_hash field to elections table
+  pgm.addColumns('elections', {
+    last_exported_ballot_hash: { type: 'text', notNull: false },
+  });
+};

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -2499,6 +2499,17 @@ test('Election package and ballots export', async () => {
   expect(ballotHashFromFileName).toEqual(
     formatBallotHash(electionDefinition.ballotHash)
   );
+  // The election should be retrievable from the ballot hash.
+  const electionRecord = await workspace.store.getElectionFromBallotHash(
+    electionDefinition.ballotHash
+  );
+  expect(electionRecord).toBeDefined();
+  expect(electionRecord?.election.id).toEqual(electionInfo.electionId);
+
+  // The election is not retrievable from the election package hash, since we don't store that
+  const undefinedElectionRecord =
+    await workspace.store.getElectionFromBallotHash(electionPackageHash);
+  expect(undefinedElectionRecord).toBeUndefined();
 
   //
   // Check metadata

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -245,8 +245,9 @@ export async function generateElectionPackageAndBallots(
   writeResult.unsafeUnwrap();
   const electionPackageUrl = `/files/${orgId}/${combinedFileName}`;
 
-  await store.setElectionPackageUrl({
+  await store.setElectionPackageExportInformation({
     electionId,
+    ballotHash: electionDefinition.ballotHash,
     electionPackageUrl,
   });
 }


### PR DESCRIPTION
## Overview
Saves the ballot hash to the elections DB for easier future reference when a ballot package is exported and the ballot hash is generated. 

This does NOT backfill this field on existing records we don't have a way of knowing what the value is so it seems complex to try to fill this in, although we could approximate with whatever the current ballot hash for the election would be. For the VxQr use case of this new field this is ok as we do not need to have any elections that have already been exported work with VxQr. If other features want to utilize this field this might need to be reconsidered however. 

## Demo Video or Screenshot

## Testing Plan
Ran migration locally, saw db column added. Ran automated test testing basic functionality. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
