### PR TITLE
style: silence a clippy warning

### DIFF
--- a/libs/ballot-interpreter/src/hmpb-rust/timing_marks/corners/shape_finding/shape_list_builder.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_marks/corners/shape_finding/shape_list_builder.rs
@@ -152,6 +152,7 @@ mod tests {
         }
 
         #[test]
+        #[allow(clippy::range_minus_one)]
         fn test_ranges_do_not_overlap_with_adjacent_ranges(n: u32) {
             assert!(!ranges_overlap(n..=n, n - 1..=n - 1));
             assert!(!ranges_overlap(n..=n, n + 1..=n + 1));


### PR DESCRIPTION
This one is not clearer as an exclusive range because of how it's used in a property test.