### PR TITLE
fix(types-rs): allow for missing `gridLayouts`

### DIFF
--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -195,6 +195,9 @@ pub enum Error {
         label: String,
         x_coordinates: Vec<PixelPosition>,
     },
+
+    #[error("invalid election: {message}")]
+    InvalidElection { message: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -416,6 +419,11 @@ pub fn ballot_card(
     side_b_image: GrayImage,
     options: &Options,
 ) -> Result<InterpretedBallotCard> {
+    let Some(ref grid_layouts) = options.election.grid_layouts else {
+        return Err(Error::InvalidElection {
+            message: "required field `gridLayouts` is missing".to_owned(),
+        });
+    };
     let BallotCard {
         side_a,
         side_b,
@@ -636,9 +644,7 @@ pub fn ballot_card(
         }
     };
 
-    let Some(grid_layout) = options
-        .election
-        .grid_layouts
+    let Some(grid_layout) = grid_layouts
         .iter()
         .find(|layout| layout.ballot_style_id == ballot_style_id)
     else {

--- a/libs/ballot-interpreter/src/hmpb-ts/types.ts
+++ b/libs/ballot-interpreter/src/hmpb-ts/types.ts
@@ -336,6 +336,10 @@ export type InterpretError =
       type: 'verticalStreaksDetected';
       label: string;
       xCoordinates: PixelPosition[];
+    }
+  | {
+      type: 'invalidElection';
+      message: string;
     };
 
 /**

--- a/libs/types-rs/src/election.rs
+++ b/libs/types-rs/src/election.rs
@@ -26,7 +26,7 @@ pub struct Election {
     pub title: String,
     pub ballot_styles: Vec<BallotStyle>,
     pub precincts: Vec<Precinct>,
-    pub grid_layouts: Vec<GridLayout>,
+    pub grid_layouts: Option<Vec<GridLayout>>,
     pub mark_thresholds: Option<MarkThresholds>,
     pub ballot_layout: BallotLayout,
 }


### PR DESCRIPTION
Any `Election` with HMPBs will have this field, but a BMD-only election will not. This brings the Rust type better in line with the TypeScript version.