### PR TITLE
VxDesign: Sync dev auth orgs to the DB cache

### DIFF
--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -47,22 +47,18 @@ async function main(): Promise<number> {
   const { store } = workspace;
 
   const auth0 = authEnabled() ? Auth0Client.init() : Auth0Client.dev();
-  if (authEnabled()) {
-    try {
-      await store.syncOrganizationsCache(await auth0.allOrgs());
-    } catch (error) {
-      if (NODE_ENV === 'development') {
-        // eslint-disable-next-line no-console
-        console.warn(
-          'Error syncing the auth organizations to the local database.',
-          'Are you using a production database backup in development?',
-          'If so, set AUTH_ENABLED=false and ORG_ID_VOTINGWORKS=<prod_Auth0_VX_org_id>.'
-        );
-      }
-      throw error;
-    }
-  } else {
+  try {
     await store.syncOrganizationsCache(await auth0.allOrgs());
+  } catch (error) {
+    if (NODE_ENV === 'development') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Error syncing the auth organizations to the local database.',
+        'Are you using a production database backup in development?',
+        'If so, set AUTH_ENABLED=false and ORG_ID_VOTINGWORKS=<prod_Auth0_VX_org_id>.'
+      );
+    }
+    throw error;
   }
 
   // We reuse the VxSuite logging library, but it doesn't matter if we meet VVSG

--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -61,6 +61,8 @@ async function main(): Promise<number> {
       }
       throw error;
     }
+  } else {
+    await store.syncOrganizationsCache(await auth0.allOrgs());
   }
 
   // We reuse the VxSuite logging library, but it doesn't matter if we meet VVSG


### PR DESCRIPTION
## Overview

Ran into an issue in dev where the API requests fail after doing a DB reset, due to missing dev orgs in the cache.
Adding the startup org sync call for non-auth-enabled dev as well to make sure they get restored after DB resets.

## Testing Plan
- Manual

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.