### PR TITLE
VxDesign: Optimize converting ballots to grayscale

### DIFF
--- a/apps/design/backend/src/worker/ballot_pdfs.test.ts
+++ b/apps/design/backend/src/worker/ballot_pdfs.test.ts
@@ -26,20 +26,9 @@ test('normalizeBallotColorModeForPrinting - converts non-tinted ballots to grays
   vi.mocked(convertPdfToGrayscale).mockResolvedValueOnce(mockGrayscalePdfNh);
 
   expect(
-    await normalizeBallotColorModeForPrinting(mockColorPdf, nhProps)
+    await normalizeBallotColorModeForPrinting(mockColorPdf, nhProps, 'NhBallot')
   ).toStrictEqual(mockGrayscalePdfNh);
   expect(convertPdfToGrayscale).toHaveBeenCalledWith(mockColorPdf);
-
-  const nonNhProps: BaseBallotProps = {
-    precinctId: 'non-nh-precinct',
-  } as unknown as BaseBallotProps;
-
-  const mockGrayscalePdfNonNh = Buffer.of(0xac, 0xfe);
-  vi.mocked(convertPdfToGrayscale).mockResolvedValueOnce(mockGrayscalePdfNonNh);
-
-  expect(
-    await normalizeBallotColorModeForPrinting(mockColorPdf, nonNhProps)
-  ).toStrictEqual(mockGrayscalePdfNonNh);
 });
 
 test('normalizeBallotColorModeForPrinting - renders tinted NH ballots in color', async () => {
@@ -55,6 +44,24 @@ test('normalizeBallotColorModeForPrinting - renders tinted NH ballots in color',
   );
 
   expect(
-    await normalizeBallotColorModeForPrinting(mockColorPdf, nhProps)
+    await normalizeBallotColorModeForPrinting(mockColorPdf, nhProps, 'NhBallot')
   ).toStrictEqual(mockColorPdf);
+});
+
+test('normalizeBallotColorModeForPrinting - renders non-NH ballots in color', async () => {
+  const nonNhProps: BaseBallotProps = {
+    precinctId: 'non-nh-precinct',
+  } as unknown as BaseBallotProps;
+
+  const mockColorPdf = Buffer.of(0xac, 0xfe);
+
+  expect(
+    await normalizeBallotColorModeForPrinting(
+      mockColorPdf,
+      nonNhProps,
+      'VxDefaultBallot'
+    )
+  ).toStrictEqual(mockColorPdf);
+
+  expect(convertPdfToGrayscale).not.toHaveBeenCalled();
 });

--- a/apps/design/backend/src/worker/ballot_pdfs.ts
+++ b/apps/design/backend/src/worker/ballot_pdfs.ts
@@ -3,13 +3,17 @@ import {
   BaseBallotProps,
   calibrationSheetTemplate,
   Renderer,
+  BallotTemplateId,
 } from '@votingworks/hmpb';
 import { HmpbBallotPaperSize } from '@votingworks/types';
 
 export async function normalizeBallotColorModeForPrinting(
   ballotPdf: Uint8Array,
-  props: BaseBallotProps
+  props: BaseBallotProps,
+  ballotTemplateId: BallotTemplateId
 ): Promise<Uint8Array> {
+  if (ballotTemplateId !== 'NhBallot') return ballotPdf;
+
   /**
    * Specific to NH V4 ballots with tinted headers/footers.
    * See `import('@votingworks/hmpb').NhBallotProps`.

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -203,7 +203,11 @@ export async function generateElectionPackageAndBallots(
       .zip(ballotPdfs)
       .map(async ([props, ballotPdf]) => ({
         props,
-        ballotPdf: await normalizeBallotColorModeForPrinting(ballotPdf, props),
+        ballotPdf: await normalizeBallotColorModeForPrinting(
+          ballotPdf,
+          props,
+          ballotTemplateId
+        ),
       }))
       .toArray()
   );

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -195,8 +195,21 @@ export async function generateElectionPackageAndBallots(
 
   combinedZip.file(electionPackageFileName, electionPackageZipContents);
 
+  // Normalizing the ballot PDF colors is not very memory intensive, so it's safe
+  // to do them all at once rather than using a worker pool like we do when
+  // rendering ballots.
+  const normalizedBallotPdfs = await Promise.all(
+    iter(allBallotProps)
+      .zip(ballotPdfs)
+      .map(async ([props, ballotPdf]) => ({
+        props,
+        ballotPdf: await normalizeBallotColorModeForPrinting(ballotPdf, props),
+      }))
+      .toArray()
+  );
+
   // Make ballot zip
-  for (const [props, ballotPdf] of iter(allBallotProps).zip(ballotPdfs)) {
+  for (const { props, ballotPdf } of normalizedBallotPdfs) {
     const { precinctId, ballotStyleId, ballotType, ballotMode, ballotAuditId } =
       props;
     const precinct = assertDefined(getPrecinctById({ election, precinctId }));
@@ -207,11 +220,7 @@ export async function generateElectionPackageAndBallots(
       ballotMode,
       ballotAuditId
     );
-    const normalizedColorPdf = await normalizeBallotColorModeForPrinting(
-      ballotPdf,
-      props
-    );
-    ballotsZip.file(fileName, normalizedColorPdf);
+    ballotsZip.file(fileName, ballotPdf);
   }
   const calibrationSheetPdf = await rendererPool.runTask((renderer) =>
     renderCalibrationSheetPdf(renderer, election.ballotLayout.paperSize)


### PR DESCRIPTION
## Overview

Task: #7233 

- Only convert NH ballots to grayscale, since the conversion is only needed for the NH printer
- When converting to grayscale, process all of the ballots concurrently

## Demo Video or Screenshot
N/A

## Testing Plan
Manual test to confirm speed increase, updated automated test
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
