### PR TITLE
VxDesign: Don't sync auth cache when using a prod db backup locally

### DIFF
--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -47,18 +47,23 @@ async function main(): Promise<number> {
   const { store } = workspace;
 
   const auth0 = authEnabled() ? Auth0Client.init() : Auth0Client.dev();
-  try {
-    await store.syncOrganizationsCache(await auth0.allOrgs());
-  } catch (error) {
-    if (NODE_ENV === 'development') {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'Error syncing the auth organizations to the local database.',
-        'Are you using a production database backup in development?',
-        'If so, set AUTH_ENABLED=false and ORG_ID_VOTINGWORKS=<prod_Auth0_VX_org_id>.'
-      );
+  // We want to sync organizations in all cases except when using a prod db
+  // backup for local debugging, in which case auth should be disabled and there
+  // will already be orgs in the db.
+  if (authEnabled() || (await store.listOrganizations()).length === 0) {
+    try {
+      await store.syncOrganizationsCache(await auth0.allOrgs());
+    } catch (error) {
+      if (NODE_ENV === 'development') {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'Error syncing the auth organizations to the local database.',
+          'Are you using a production database backup in development?',
+          'If so, set AUTH_ENABLED=false and ORG_ID_VOTINGWORKS=<prod_Auth0_VX_org_id>.'
+        );
+      }
+      throw error;
     }
-    throw error;
   }
 
   // We reuse the VxSuite logging library, but it doesn't matter if we meet VVSG


### PR DESCRIPTION
## Overview

Fourth or fifth attempt to get this right for all of the use cases 😆 😭 

Builds on https://github.com/votingworks/vxsuite/pull/7246 to make sure we sync orgs to the cache when auth is disabled, but don't do it if auth is disabled and we're using a prod db backup (since there will be conflicts).

## Demo Video or Screenshot

## Testing Plan
Manual test

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
