### PR TITLE
VxDesign: Don't export sample ballots by default

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -2304,11 +2304,13 @@ test('Election package management', async () => {
     electionId,
     electionSerializationFormat: 'vxf',
     shouldExportAudio: false,
+    shouldExportSampleBallots: true,
   });
   const expectedPayload = JSON.stringify({
     electionId,
     electionSerializationFormat: 'vxf',
     shouldExportAudio: false,
+    shouldExportSampleBallots: true,
   });
   const electionPackageAfterInitiatingExport =
     await apiClient.getElectionPackage({ electionId });
@@ -2328,6 +2330,7 @@ test('Election package management', async () => {
     electionId,
     electionSerializationFormat: 'cdf',
     shouldExportAudio: false,
+    shouldExportSampleBallots: true,
   });
   const electionPackageAfterInitiatingRedundantExport =
     await apiClient.getElectionPackage({ electionId });
@@ -2389,6 +2392,7 @@ test('Election package management', async () => {
     electionId,
     electionSerializationFormat: 'vxf',
     shouldExportAudio: false,
+    shouldExportSampleBallots: true,
   });
   const electionPackageAfterInitiatingSecondExport =
     await apiClient.getElectionPackage({ electionId });
@@ -2419,6 +2423,7 @@ test('Election package management', async () => {
         electionId,
         electionSerializationFormat: 'vxf',
         shouldExportAudio: false,
+        shouldExportSampleBallots: true,
       })
     ).rejects.toThrow('auth:forbidden');
   });
@@ -2468,6 +2473,7 @@ test('Election package and ballots export', async () => {
     workspace,
     electionSerializationFormat: 'vxf',
     shouldExportAudio: true,
+    shouldExportSampleBallots: true,
   });
   const contents = assertDefined(
     fileStorageClient.getRawFile(join(nonVxUser.orgId, electionPackageFilePath))
@@ -2790,6 +2796,7 @@ test('Election package export with VxDefaultBallot drops signature field', async
     workspace,
     electionSerializationFormat: 'vxf',
     shouldExportAudio: false,
+    shouldExportSampleBallots: false,
   });
 
   const contents = assertDefined(
@@ -2917,6 +2924,7 @@ test('Consistency of ballot hash across exports', async () => {
     workspace,
     electionSerializationFormat: 'vxf',
     shouldExportAudio: false,
+    shouldExportSampleBallots: true,
   });
   const contents = assertDefined(
     fileStorageClient.getRawFile(
@@ -2976,6 +2984,7 @@ test('CDF exports', async () => {
     workspace,
     electionSerializationFormat: 'cdf',
     shouldExportAudio: false,
+    shouldExportSampleBallots: false,
   });
   const contents = assertDefined(
     fileStorageClient.getRawFile(
@@ -3022,7 +3031,8 @@ test('export ballots with audit IDs', async () => {
     electionId,
     workspace,
     electionSerializationFormat: 'vxf',
-    shouldExportAudio: true,
+    shouldExportAudio: false,
+    shouldExportSampleBallots: false,
     numAuditIdBallots,
   });
   const contents = assertDefined(
@@ -3301,6 +3311,7 @@ test('setBallotTemplate changes the ballot template used to render ballots', asy
     workspace,
     electionSerializationFormat: 'vxf',
     shouldExportAudio: false,
+    shouldExportSampleBallots: true,
   });
   expect(renderAllBallotPdfsAndCreateElectionDefinition).toHaveBeenCalledWith(
     expect.any(Object), // Renderer

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -691,17 +691,20 @@ export function buildApi({ auth0, logger, workspace, translator }: AppContext) {
       electionId,
       electionSerializationFormat,
       shouldExportAudio,
+      shouldExportSampleBallots,
       numAuditIdBallots,
     }: {
       electionId: ElectionId;
       electionSerializationFormat: ElectionSerializationFormat;
       shouldExportAudio: boolean;
+      shouldExportSampleBallots: boolean;
       numAuditIdBallots?: number;
     }): Promise<void> {
       return store.createElectionPackageBackgroundTask(
         electionId,
         electionSerializationFormat,
         shouldExportAudio,
+        shouldExportSampleBallots,
         numAuditIdBallots
       );
     },

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -1542,6 +1542,7 @@ export class Store {
     electionId: ElectionId,
     electionSerializationFormat: ElectionSerializationFormat,
     shouldExportAudio: boolean,
+    shouldExportSampleBallots: boolean,
     numAuditIdBallots?: number
   ): Promise<void> {
     await this.db.withClient(async (client) =>
@@ -1558,6 +1559,7 @@ export class Store {
             electionId,
             electionSerializationFormat,
             shouldExportAudio,
+            shouldExportSampleBallots,
             numAuditIdBallots,
           }
         );

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -59,11 +59,13 @@ export async function generateElectionPackageAndBallots(
     electionId,
     electionSerializationFormat,
     shouldExportAudio,
+    shouldExportSampleBallots,
     numAuditIdBallots,
   }: {
     electionId: ElectionId;
     electionSerializationFormat: ElectionSerializationFormat;
     shouldExportAudio: boolean;
+    shouldExportSampleBallots?: boolean;
     numAuditIdBallots?: number;
   }
 ): Promise<void> {
@@ -115,6 +117,11 @@ export async function generateElectionPackageAndBallots(
     ballotStyles,
     compact
   );
+  if (!shouldExportSampleBallots) {
+    allBallotProps = allBallotProps.filter(
+      (props) => props.ballotMode !== 'sample'
+    );
+  }
 
   // If we're exporting ballots with ballot audit IDs...
   if (numAuditIdBallots) {

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -7,9 +7,6 @@ import {
   mergeUiStrings,
   formatElectionHashes,
   LATEST_METADATA,
-  SystemSettings,
-  MarkThresholds,
-  AdjudicationReason,
   ElectionId,
   getPrecinctById,
   formatBallotHash,
@@ -41,15 +38,6 @@ import {
   normalizeBallotColorModeForPrinting,
   renderCalibrationSheetPdf,
 } from './ballot_pdfs';
-
-export interface V3SystemSettings {
-  readonly auth: SystemSettings['auth'];
-  readonly markThresholds: MarkThresholds;
-  readonly adminAdjudicationReasons: readonly AdjudicationReason[];
-  readonly centralScanAdjudicationReasons: readonly AdjudicationReason[];
-  readonly precinctScanAdjudicationReasons: readonly AdjudicationReason[];
-  readonly precinctScanDisallowCastingOvervotes: boolean;
-}
 
 interface GenerateElectionPackageAndBallotsPayload {
   electionId: ElectionId;

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -14,6 +14,8 @@ import {
   getPrecinctById,
   formatBallotHash,
   BallotType,
+  ElectionIdSchema,
+  ElectionSerializationFormatSchema,
 } from '@votingworks/types';
 import {
   hmpbStringsCatalog,
@@ -28,6 +30,7 @@ import {
   getAllStringsForElectionPackage,
 } from '@votingworks/backend';
 import { assertDefined, find, iter, range } from '@votingworks/basics';
+import z from 'zod/v4';
 import { WorkerContext } from './context';
 import {
   createBallotPropsForTemplate,
@@ -48,6 +51,23 @@ export interface V3SystemSettings {
   readonly precinctScanDisallowCastingOvervotes: boolean;
 }
 
+interface GenerateElectionPackageAndBallotsPayload {
+  electionId: ElectionId;
+  electionSerializationFormat: ElectionSerializationFormat;
+  shouldExportAudio: boolean;
+  shouldExportSampleBallots: boolean;
+  numAuditIdBallots?: number;
+}
+
+export const GenerateElectionPackageAndBallotsPayloadSchema: z.ZodType<GenerateElectionPackageAndBallotsPayload> =
+  z.object({
+    electionId: ElectionIdSchema,
+    electionSerializationFormat: ElectionSerializationFormatSchema,
+    shouldExportAudio: z.boolean(),
+    shouldExportSampleBallots: z.boolean(),
+    numAuditIdBallots: z.number().optional(),
+  });
+
 export async function generateElectionPackageAndBallots(
   {
     fileStorageClient,
@@ -61,13 +81,7 @@ export async function generateElectionPackageAndBallots(
     shouldExportAudio,
     shouldExportSampleBallots,
     numAuditIdBallots,
-  }: {
-    electionId: ElectionId;
-    electionSerializationFormat: ElectionSerializationFormat;
-    shouldExportAudio: boolean;
-    shouldExportSampleBallots?: boolean;
-    numAuditIdBallots?: number;
-  }
+  }: GenerateElectionPackageAndBallotsPayload
 ): Promise<void> {
   const { store } = workspace;
 

--- a/apps/design/backend/src/worker/generate_test_decks.ts
+++ b/apps/design/backend/src/worker/generate_test_decks.ts
@@ -1,7 +1,9 @@
 import {
   BallotType,
   ElectionId,
+  ElectionIdSchema,
   ElectionSerializationFormat,
+  ElectionSerializationFormatSchema,
   formatBallotHash,
 } from '@votingworks/types';
 import { translateBallotStrings } from '@votingworks/backend';
@@ -14,6 +16,7 @@ import {
 import { iter } from '@votingworks/basics';
 import JsZip from 'jszip';
 import path from 'node:path';
+import z from 'zod/v4';
 import { WorkerContext } from './context';
 import {
   createBallotPropsForTemplate,
@@ -25,15 +28,20 @@ import {
   FULL_TEST_DECK_TALLY_REPORT_FILE_NAME,
 } from '../test_decks';
 
+interface GenerateTestDecksPayload {
+  electionId: ElectionId;
+  electionSerializationFormat: ElectionSerializationFormat;
+}
+
+export const GenerateTestDecksPayloadSchema: z.ZodType<GenerateTestDecksPayload> =
+  z.object({
+    electionId: ElectionIdSchema,
+    electionSerializationFormat: ElectionSerializationFormatSchema,
+  });
+
 export async function generateTestDecks(
   { translator, workspace, fileStorageClient }: WorkerContext,
-  {
-    electionId,
-    electionSerializationFormat,
-  }: {
-    electionId: ElectionId;
-    electionSerializationFormat: ElectionSerializationFormat;
-  }
+  { electionId, electionSerializationFormat }: GenerateTestDecksPayload
 ): Promise<void> {
   const { store } = workspace;
   const {

--- a/apps/design/backend/src/worker/tasks.ts
+++ b/apps/design/backend/src/worker/tasks.ts
@@ -1,15 +1,16 @@
-import { z } from 'zod/v4';
 import { throwIllegalValue } from '@votingworks/basics';
-import {
-  ElectionIdSchema,
-  ElectionSerializationFormatSchema,
-  safeParseJson,
-} from '@votingworks/types';
+import { safeParseJson } from '@votingworks/types';
 
 import { BackgroundTask } from '../store';
 import { WorkerContext } from './context';
-import { generateElectionPackageAndBallots } from './generate_election_package_and_ballots';
-import { generateTestDecks } from './generate_test_decks';
+import {
+  generateElectionPackageAndBallots,
+  GenerateElectionPackageAndBallotsPayloadSchema,
+} from './generate_election_package_and_ballots';
+import {
+  generateTestDecks,
+  GenerateTestDecksPayloadSchema,
+} from './generate_test_decks';
 
 export async function processBackgroundTask(
   context: WorkerContext,
@@ -21,12 +22,7 @@ export async function processBackgroundTask(
     case 'generate_election_package': {
       const parsedPayload = safeParseJson(
         payload,
-        z.object({
-          electionId: ElectionIdSchema,
-          electionSerializationFormat: ElectionSerializationFormatSchema,
-          shouldExportAudio: z.boolean(),
-          numAuditIdBallots: z.number().optional(),
-        })
+        GenerateElectionPackageAndBallotsPayloadSchema
       ).unsafeUnwrap();
       await generateElectionPackageAndBallots(context, parsedPayload);
       break;
@@ -34,10 +30,7 @@ export async function processBackgroundTask(
     case 'generate_test_decks': {
       const parsedPayload = safeParseJson(
         payload,
-        z.object({
-          electionId: ElectionIdSchema,
-          electionSerializationFormat: ElectionSerializationFormatSchema,
-        })
+        GenerateTestDecksPayloadSchema
       ).unsafeUnwrap();
       await generateTestDecks(context, parsedPayload);
       break;

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -203,7 +203,8 @@ export async function exportElectionPackage({
   fileStorageClient,
   workspace,
   electionSerializationFormat,
-  shouldExportAudio = false,
+  shouldExportAudio,
+  shouldExportSampleBallots,
   numAuditIdBallots,
 }: {
   apiClient: ApiClient;
@@ -212,12 +213,14 @@ export async function exportElectionPackage({
   workspace: Workspace;
   electionSerializationFormat: ElectionSerializationFormat;
   shouldExportAudio: boolean;
+  shouldExportSampleBallots: boolean;
   numAuditIdBallots?: number;
 }): Promise<string> {
   await apiClient.exportElectionPackage({
     electionId,
     electionSerializationFormat,
     shouldExportAudio,
+    shouldExportSampleBallots,
     numAuditIdBallots,
   });
   await processNextBackgroundTaskIfAny({

--- a/apps/design/frontend/src/export_screen.tsx
+++ b/apps/design/frontend/src/export_screen.tsx
@@ -9,7 +9,6 @@ import {
   CheckboxButton,
   SearchSelect,
   H2,
-  SegmentedButton,
   FileInputButton,
   Callout,
 } from '@votingworks/ui';
@@ -221,19 +220,6 @@ export function ExportScreen(): JSX.Element | null {
               <div>Ballots not finalized</div>
             )}
           </div>
-
-          <div>
-            <SegmentedButton
-              label="Export Audio"
-              selectedOptionId={shouldExportAudio ? 1 : 0}
-              options={[
-                { id: 1, label: 'On' },
-                { id: 0, label: 'Off' },
-              ]}
-              onChange={(value) => setShouldExportAudio(value === 1)}
-              disabled={isElectionPackageExportInProgress}
-            />
-          </div>
         </Column>
 
         <H2>Export</H2>
@@ -267,13 +253,21 @@ export function ExportScreen(): JSX.Element | null {
 
         <P>
           <CheckboxButton
+            label="Include audio"
+            isChecked={shouldExportAudio}
+            onChange={(isChecked) => setShouldExportAudio(isChecked)}
+          />
+        </P>
+
+        <P>
+          <CheckboxButton
             label="Include sample ballots"
             isChecked={shouldExportSampleBallots}
             onChange={(isChecked) => setShouldExportSampleBallots(isChecked)}
           />
         </P>
 
-        <P style={{ width: 'max-content' }}>
+        <P>
           <CheckboxButton
             label="Format election using CDF"
             isChecked={electionSerializationFormat === 'cdf'}

--- a/apps/design/frontend/src/export_screen.tsx
+++ b/apps/design/frontend/src/export_screen.tsx
@@ -46,6 +46,8 @@ const ballotTemplateOptions = {
 export function ExportScreen(): JSX.Element | null {
   const { electionId } = useParams<ElectionIdParams>();
   const [shouldExportAudio, setShouldExportAudio] = useState(false);
+  const [shouldExportSampleBallots, setShouldExportSampleBallots] =
+    useState(false);
   useTitle(routes.election(electionId).export.title);
   const getUserFeaturesQuery = getUserFeatures.useQuery();
   const electionPackageQuery = getElectionPackage.useQuery(electionId);
@@ -114,6 +116,7 @@ export function ExportScreen(): JSX.Element | null {
       electionId,
       electionSerializationFormat,
       shouldExportAudio,
+      shouldExportSampleBallots,
       numAuditIdBallots,
     });
   }
@@ -261,6 +264,14 @@ export function ExportScreen(): JSX.Element | null {
             An unexpected error occurred while exporting. Please try again.
           </Callout>
         )}
+
+        <P>
+          <CheckboxButton
+            label="Include sample ballots"
+            isChecked={shouldExportSampleBallots}
+            onChange={(isChecked) => setShouldExportSampleBallots(isChecked)}
+          />
+        </P>
 
         <P style={{ width: 'max-content' }}>
           <CheckboxButton


### PR DESCRIPTION
## Overview

Task: #7233 

Removes sample ballots from the default ballot export. Adds a checkbox to add them back in. This reduces the default number of ballots exported by 1/3, which will save time for the most common use cases.

Also changes the control for whether or not to export audio into a checkbox and moves it inline with the other export options for consistency/clarity.

## Demo Video or Screenshot
<img width="1424" height="930" alt="Screenshot 2025-09-25 at 1 10 41 PM" src="https://github.com/user-attachments/assets/af95b39d-09e0-47e7-a2b8-0585a62acc53" />



## Testing Plan
- Manual testing
- Updated automated tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
