### PR TITLE
VxDesign: Script to cancel background task

### DIFF
--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -15,6 +15,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:prod": "pnpm --filter-prod $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
+    "cancel-background-task": "node -r esbuild-runner/register ./scripts/cancel_background_task.ts",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
     "create-org": "node -r esbuild-runner/register ./scripts/create_org.ts",

--- a/apps/design/backend/scripts/README.md
+++ b/apps/design/backend/scripts/README.md
@@ -1,5 +1,17 @@
 # Scripts
 
+## Cancel Background Task
+
+If the worker is stuck while processing a background task, you can cancel it
+with:
+
+```sh
+pnpm cancel-background-task
+```
+
+This will mark the currently running background task as canceled in the
+database. Then, restart the worker. It won't pick up the canceled task again.
+
 ## User/Org Management
 
 Until we build out our support tooling, auth scripts for user and org management

--- a/apps/design/backend/scripts/cancel_background_task.ts
+++ b/apps/design/backend/scripts/cancel_background_task.ts
@@ -1,0 +1,32 @@
+import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
+import { BaseLogger, LogSource } from '@votingworks/logging';
+import { Db } from '../src/db/db';
+
+async function main(): Promise<void> {
+  loadEnvVarsFromDotenvFiles();
+  const logger = new BaseLogger(LogSource.VxDesignService);
+  const db = new Db(logger);
+  const result = await db.withClient(async (client) =>
+    client.query(
+      `
+      update background_tasks
+      set completed_at = current_timestamp, error = 'Canceled'
+      where started_at is not null and completed_at is null
+      `
+    )
+  );
+  if (result.rowCount === 0) {
+    console.log('No in-progress task found.');
+    return;
+  }
+  console.log(
+    'Marked the in-progress task as canceled in the database. Restart the worker.'
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Overview

Task: #7233 

Adds a script to cancel the currently running background task for cases where the worker gets stuck. Previously we just ran a database command by hand.

## Demo Video or Screenshot
N/A

## Testing Plan
Manual test

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
