### PR TITLE
VxDesign: DB schema & TS types for TTS string editing

### DIFF
--- a/apps/design/backend/migrations/1758911600054_add-tts-strings.js
+++ b/apps/design/backend/migrations/1758911600054_add-tts-strings.js
@@ -1,0 +1,53 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  pgm.createTable(
+    'tts_strings',
+    {
+      election_id: {
+        type: 'text',
+        notNull: true,
+        onDelete: 'CASCADE',
+        references: 'elections',
+      },
+      key: {
+        notNull: true,
+        type: 'text',
+      },
+      subkey: {
+        type: 'text',
+      },
+      language_code: {
+        notNull: true,
+        type: 'text',
+      },
+      export_source: {
+        check: `export_source IN ('phonetic', 'text')`,
+        default: 'text',
+        notNull: true,
+        type: 'text',
+      },
+      phonetic: {
+        notNull: true,
+        type: 'jsonb',
+      },
+      text: {
+        notNull: true,
+        type: 'text',
+      },
+    },
+    {
+      constraints: {
+        primaryKey: ['election_id', 'key', 'subkey', 'language_code'],
+      },
+    }
+  );
+};

--- a/apps/design/backend/src/store.test.ts
+++ b/apps/design/backend/src/store.test.ts
@@ -1,15 +1,22 @@
-import { afterAll, beforeEach, expect, test, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { assertDefined } from '@votingworks/basics';
 
-import { LanguageCode } from '@votingworks/types';
-import { mockBaseLogger } from '@votingworks/logging';
-import { TaskName } from './store';
+import {
+  ElectionStringKey,
+  LanguageCode,
+  PhoneticWord,
+  TtsStringKey,
+} from '@votingworks/types';
+import { LogEventId, mockBaseLogger } from '@votingworks/logging';
+import { Store, TaskName } from './store';
 import { TestStore } from '../test/test_store';
+import { createBlankElection } from './app';
 
 const logger = mockBaseLogger({ fn: vi.fn });
 const testStore = new TestStore(logger);
 
 beforeEach(async () => {
+  vi.resetAllMocks();
   await testStore.init();
 });
 
@@ -311,4 +318,83 @@ test('Background task processing - requeuing interrupted tasks', async () => {
   await expectTaskToBeQueued(task2Id);
   await expectTaskToBeQueued(task3Id);
   await expectTaskToBeQueued(task4Id);
+});
+
+describe('tts_strings', () => {
+  const key: TtsStringKey = {
+    electionId: '5678',
+    key: ElectionStringKey.CONTEST_TITLE,
+    languageCode: 'en',
+    subkey: '1234',
+  };
+
+  async function setUpElection(store: Store) {
+    const election = createBlankElection(key.electionId);
+    await store.syncOrganizationsCache([{ id: 'vx', name: 'VotingWorks' }]);
+    await store.createElection('vx', election, 'VxDefaultBallot');
+  }
+
+  test('ttsStringsGet returns null if absent', async () => {
+    const store = testStore.getStore();
+    await setUpElection(store);
+    await expect(store.ttsStringsGet(key)).resolves.toBeNull();
+  });
+
+  test('ttsStringsSet inserts if absent, updates if present', async () => {
+    const store = testStore.getStore();
+    await setUpElection(store);
+
+    await store.ttsStringsSet(key, {
+      exportSource: 'phonetic',
+      phonetic: [{ text: 'one' }, { text: 'two' }],
+      text: 'one two',
+    });
+
+    await expect(store.ttsStringsGet(key)).resolves.toEqual({
+      exportSource: 'phonetic',
+      phonetic: [{ text: 'one' }, { text: 'two' }],
+      text: 'one two',
+    });
+
+    await store.ttsStringsSet(key, {
+      exportSource: 'phonetic',
+      phonetic: [
+        { text: 'one' },
+        { syllables: [{ ipaPhonemes: ['t', 'uː'] }], text: 'two' },
+      ],
+      text: 'one two',
+    });
+
+    await expect(store.ttsStringsGet(key)).resolves.toEqual({
+      exportSource: 'phonetic',
+      phonetic: [
+        { text: 'one' },
+        { syllables: [{ ipaPhonemes: ['t', 'uː'] }], text: 'two' },
+      ],
+      text: 'one two',
+    });
+  });
+
+  test('ttsStringsGet discards malformed/outdated phonetic JSON', async () => {
+    const store = testStore.getStore();
+    await setUpElection(store);
+
+    await store.ttsStringsSet(key, {
+      exportSource: 'phonetic',
+      phonetic: [{ text: 1 }, { text: 2 }] as unknown as PhoneticWord[],
+      text: 'one two',
+    });
+
+    await expect(store.ttsStringsGet(key)).resolves.toEqual({
+      exportSource: 'phonetic',
+      phonetic: [{ text: 'one' }, { text: 'two' }],
+      text: 'one two',
+    });
+
+    expect(logger.log).toHaveBeenCalledWith(LogEventId.ParseError, 'system', {
+      message: 'discarding invalid TTS phonetic edit',
+      ...key,
+      error: expect.any(String),
+    });
+  });
 });

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -1,3 +1,4 @@
+import util from 'node:util';
 import {
   DateWithoutTime,
   Optional,
@@ -37,9 +38,13 @@ import {
   CandidateContest,
   ElectionType,
   Signature,
+  TtsString,
+  TtsStringKey,
+  safeParse,
+  PhoneticWordsSchema,
 } from '@votingworks/types';
 import { v4 as uuid } from 'uuid';
-import { BaseLogger } from '@votingworks/logging';
+import { BaseLogger, LogEventId } from '@votingworks/logging';
 import { BallotTemplateId } from '@votingworks/hmpb';
 import { DatabaseError } from 'pg';
 import {
@@ -351,8 +356,8 @@ async function insertContest(
       if (ballotOrder === undefined) {
         // Get all current contests in order
         const { rows: allContests } = await client.query(
-          `select id, type from contests 
-           where election_id = $1 
+          `select id, type from contests
+           where election_id = $1
            order by ballot_order`,
           electionId
         );
@@ -423,10 +428,13 @@ async function insertContest(
 }
 
 export class Store {
-  constructor(private readonly db: Db) {}
+  constructor(
+    private readonly db: Db,
+    private readonly logger: BaseLogger
+  ) {}
 
   static new(logger: BaseLogger): Store {
-    return new Store(new Db(logger));
+    return new Store(new Db(logger), logger);
   }
 
   /**
@@ -1932,5 +1940,81 @@ export class Store {
         where started_at is not null and completed_at is null
       `)
     );
+  }
+
+  async ttsStringsGet(key: TtsStringKey): Promise<TtsString | null> {
+    return this.db.withClient(async (client) => {
+      const res = await client.query(
+        `
+          select
+            export_source as "exportSource",
+            phonetic,
+            text
+          from tts_strings
+          where
+            election_id = $1 and
+            key = $2 and
+            subkey = $3 and
+            language_code = $4
+        `,
+        key.electionId,
+        key.key,
+        key.subkey,
+        key.languageCode
+      );
+
+      if (res.rows.length === 0) return null;
+
+      return {
+        exportSource: res.rows[0].exportSource,
+
+        phonetic: safeParse(
+          PhoneticWordsSchema,
+          res.rows[0]['phonetic']
+        ).okOrElse((error) => {
+          this.logger.log(LogEventId.ParseError, 'system', {
+            message: 'discarding invalid TTS phonetic edit',
+            ...key,
+            error: util.inspect(error),
+          });
+
+          return (res.rows[0].text as string)
+            .split(' ')
+            .map((word) => ({ text: word }));
+        }),
+
+        text: res.rows[0].text as string,
+      };
+    });
+  }
+
+  async ttsStringsSet(key: TtsStringKey, data: TtsString): Promise<void> {
+    return this.db.withClient(async (client) => {
+      await client.query(
+        `
+            insert into tts_strings (
+              election_id,
+              key,
+              subkey,
+              language_code,
+              export_source,
+              phonetic,
+              text
+            )
+            values ($1, $2, $3, $4, $5, $6, $7)
+            on conflict (election_id, key, subkey, language_code) do update set
+              export_source = EXCLUDED.export_source,
+              phonetic = EXCLUDED.phonetic,
+              text = EXCLUDED.text
+          `,
+        key.electionId,
+        key.key,
+        key.subkey,
+        key.languageCode,
+        data.exportSource,
+        JSON.stringify(data.phonetic),
+        data.text
+      );
+    });
   }
 }

--- a/apps/design/backend/test/test_store.ts
+++ b/apps/design/backend/test/test_store.ts
@@ -13,7 +13,7 @@ export class TestStore {
     this.db = new Db(this.logger, {
       defaultSchemaName: this.schemaName,
     });
-    this.store = new Store(this.db);
+    this.store = new Store(this.db, this.logger);
   }
 
   getStore(): Store {

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -38,6 +38,8 @@ export * from './precinct_selection';
 export * from './system_settings';
 export * as Tabulation from './tabulation';
 export * from './tallies';
+export * from './tts_phonemes';
+export * from './tts_strings';
 export * from './ui_audio_controls';
 export * from './ui_string_audio_clips';
 export * from './ui_string_audio_ids';

--- a/libs/types/src/tts_phonemes.ts
+++ b/libs/types/src/tts_phonemes.ts
@@ -1,0 +1,150 @@
+import { z } from 'zod/v4';
+
+/**
+ * Original mapping and examples pulled from
+ * https://cloud.google.com/text-to-speech/docs/phonemes.
+ */
+// prettier-ignore
+const ALL_BY_IPA = {
+  // [TODO] Convert phonetic samples to use Vx phonemes.
+  "æ": { ipa: 'æ', vx: 'a', sampleWord: 'cat', sampleIpa: 'ˈkæt', consonant: false },
+  "ɑː": { ipa: 'ɑː', vx: 'ah', sampleWord: 'cot', sampleIpa: 'ˈkɑːt', consonant: false },
+  "ɔː": { ipa: 'ɔː', vx: 'au', sampleWord: 'more', sampleIpa: 'ˈmɔːɹ', consonant: false },
+  "eɪ": { ipa: 'eɪ', vx: 'ay', sampleWord: 'shade', sampleIpa: 'ˈʃeɪd', consonant: false },
+  "aɪ": { ipa: 'aɪ', vx: 'aye', sampleWord: 'price', sampleIpa: 'ˈpɹaɪs', consonant: false },
+  "b": { ipa: 'b', vx: 'b', sampleWord: 'bubble', sampleIpa: 'ˈbʌbəl', consonant: true },
+  "ʧ": { ipa: 'ʧ', vx: 'ch', sampleWord: 'changed', sampleIpa: 'ˈʧeɪnʤd', consonant: true },
+  "d": { ipa: 'd', vx: 'd', sampleWord: 'dog', sampleIpa: 'ˈdɑːg', consonant: true },
+  "iː": { ipa: 'iː', vx: 'ee', sampleWord: 'unique', sampleIpa: 'ˌjuːˈniːk', consonant: false },
+  "ɛ": { ipa: 'ɛ', vx: 'eh', sampleWord: 'bed', sampleIpa: 'ˈbɛd', consonant: false },
+  "f": { ipa: 'f', vx: 'f', sampleWord: 'frog', sampleIpa: 'ˈfɹɑːg', consonant: true },
+  "ɡ": { ipa: 'ɡ', vx: 'g', sampleWord: 'gravely', sampleIpa: 'ˈgɹeɪˌvliː', consonant: true },
+  "h": { ipa: 'h', vx: 'h', sampleWord: 'mahogany', sampleIpa: 'məˈhɑːgəˌniː', consonant: true },
+  "ɪ": { ipa: 'ɪ', vx: 'i', sampleWord: 'kit', sampleIpa: 'ˈkɪt', consonant: false },
+  "ɚ": { ipa: 'ɚ', vx: 'ir', sampleWord: 'bird', sampleIpa: 'ˈbɚd', consonant: false },
+  "ʤ": { ipa: 'ʤ', vx: 'j', sampleWord: 'magenta', sampleIpa: 'məˈʤɛntə', consonant: true },
+  "k": { ipa: 'k', vx: 'k', sampleWord: 'crown', sampleIpa: 'ˈkɹaʊn', consonant: true },
+  "l": { ipa: 'l', vx: 'l', sampleWord: 'lately', sampleIpa: 'ˈleɪtˌliː', consonant: true },
+  "m": { ipa: 'm', vx: 'm', sampleWord: 'mapping', sampleIpa: 'ˈmæpəŋ', consonant: true },
+  "n": { ipa: 'n', vx: 'n', sampleWord: 'nine', sampleIpa: 'ˈnaɪn', consonant: true },
+  "ŋ": { ipa: 'ŋ', vx: 'ng', sampleWord: 'bank', sampleIpa: 'ˈbæŋk', consonant: true },
+  "oʊ": { ipa: 'oʊ', vx: 'oa', sampleWord: 'boat', sampleIpa: 'ˈboʊt', consonant: false },
+  "ɔɪ": { ipa: 'ɔɪ', vx: 'oi', sampleWord: 'choice', sampleIpa: 'ˈʧɔɪs', consonant: false },
+  "uː": { ipa: 'uː', vx: 'oo', sampleWord: 'school', sampleIpa: 'ˈskuːl', consonant: false },
+  "aʊ": { ipa: 'aʊ', vx: 'ow', sampleWord: 'flower', sampleIpa: 'ˈflaʊɚ', consonant: false },
+  "p": { ipa: 'p', vx: 'p', sampleWord: 'popular', sampleIpa: 'ˈpɑːpjəlɚ', consonant: true },
+  "ɹ": { ipa: 'ɹ', vx: 'r', sampleWord: 'roaring', sampleIpa: 'ˈɹɔːɹəŋ', consonant: true },
+  "s": { ipa: 's', vx: 's', sampleWord: 'massage', sampleIpa: 'məˈsɑːʒ', consonant: true },
+  "ʃ": { ipa: 'ʃ', vx: 'sh', sampleWord: 'shopping', sampleIpa: 'ˈʃɑːpəŋ', consonant: true },
+  "ʒ": { ipa: 'ʒ', vx: 'szh', sampleWord: 'leisure', sampleIpa: 'ˈliːʒɚ', consonant: true },
+  "t": { ipa: 't', vx: 't', sampleWord: 'tinker', sampleIpa: 'ˈtɪŋkɚ', consonant: true },
+  "ð": { ipa: 'ð', vx: 'th', sampleWord: 'mother', sampleIpa: 'ˈmʌðɚ', consonant: true },
+  "θ": { ipa: 'θ', vx: 'thh', sampleWord: 'thigh', sampleIpa: 'ˈθaɪ', consonant: true },
+  "ʊ": { ipa: 'ʊ', vx: 'ou', sampleWord: 'could', sampleIpa: 'ˈkʊd', consonant: false },
+  "ʌ": { ipa: 'ʌ', vx: 'u', sampleWord: 'pulse', sampleIpa: 'ˈpʌls', consonant: false },
+  "ə": { ipa: 'ə', vx: 'uh', sampleWord: 'again', sampleIpa: 'əˈgɛn', consonant: false },
+  "v": { ipa: 'v', vx: 'v', sampleWord: 'valve', sampleIpa: 'ˈvælv', consonant: true },
+  "w": { ipa: 'w', vx: 'w', sampleWord: 'whirlwind', sampleIpa: 'ˈwɚlˌwɪnd', consonant: true },
+  "j": { ipa: 'j', vx: 'y', sampleWord: 'younger', sampleIpa: 'ˈjʌŋgɚ', consonant: true },
+  "z": { ipa: 'z', vx: 'z', sampleWord: 'zoom', sampleIpa: 'ˈzuːm', consonant: true },
+} as const;
+
+const ALL = Object.values(ALL_BY_IPA);
+
+/**
+ * Represents a phonetic sound in IPA format. Used for speech synthesis via the
+ * Google Cloud Text-To-Speech API.
+ *
+ * @see https://cloud.google.com/text-to-speech/docs/phonemes
+ */
+export type IpaPhoneme = keyof typeof ALL_BY_IPA;
+
+const IPA_PHONEMES = Object.keys(ALL_BY_IPA) as IpaPhoneme[];
+
+/** @see {@link IpaPhoneme} */
+export const IpaPhonemeSchema = z.union(IPA_PHONEMES.map((p) => z.literal(p)));
+
+/**
+ * Display/TTS information for a single phoneme in a given language.
+ */
+export interface TtsPhoneme {
+  /**
+   * `true` if the phoneme represents a consonant sound.
+   */
+  consonant: boolean;
+
+  /**
+   * The IPA notation for the phoneme.
+   */
+  ipa: IpaPhoneme;
+
+  /**
+   * A sample use of the phoneme in context of a recognizable word.
+   */
+  sampleIpa: string;
+
+  /**
+   * The plain language equivalent of {@link sampleIpa}.
+   */
+  sampleWord: string;
+
+  /**
+   * The corresponding label used in Vx apps when displaying the phoneme.
+   */
+  vx: string; // [TODO] Type these as well?
+}
+
+/**
+ * Provides display/TTS phoneme information for a given language
+ */
+export interface TtsPhonemes {
+  /**
+   * All available phonemes for this language, keyed by IPA phoneme.
+   */
+  allByIpa: Record<IpaPhoneme, TtsPhoneme>;
+
+  /**
+   * All available consonant phonemes for this language. Broken out to support
+   * split consonant/vowel layouts for the on-screen phonetic keyboard.
+   */
+  consonants: TtsPhoneme[];
+
+  /**
+   * Syllable emphasis/stress annotations: `vx` for display and `ipa` for
+   * SSML-based speech synthesis.
+   *
+   * @see https://cloud.google.com/text-to-speech/docs/phonemes
+   */
+  stresses: Record<
+    PhoneticSyllableStress,
+    {
+      ipa: string;
+      vx: string;
+    }
+  >;
+
+  /**
+   * All available vowel phonemes for this language. Broken out to support
+   * split consonant/vowel layouts for the on-screen phonetic keyboard.
+   */
+  vowels: TtsPhoneme[];
+}
+
+export const PhoneticSyllableStressSchema = z.enum(['primary', 'secondary']);
+
+export type PhoneticSyllableStress = z.infer<
+  typeof PhoneticSyllableStressSchema
+>;
+
+/**
+ * Phonemes for US English speech synthesis.
+ */
+export const en: TtsPhonemes = {
+  allByIpa: ALL_BY_IPA,
+  consonants: ALL.filter((p) => p.consonant),
+  stresses: {
+    primary: { ipa: 'ˈ', vx: 'ˈ' },
+    secondary: { ipa: 'ˌ', vx: 'ˌ' },
+  },
+  vowels: ALL.filter((p) => !p.consonant),
+};

--- a/libs/types/src/tts_strings.ts
+++ b/libs/types/src/tts_strings.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod/v4';
+
+import { ElectionStringKey } from './ui_string_translations';
+import {
+  IpaPhoneme,
+  IpaPhonemeSchema,
+  PhoneticSyllableStress,
+} from './tts_phonemes';
+
+/**
+ * Loosely represents a distinct syllable in a word, to which stress can be
+ * added to influence emphasis in synthesized speech.
+ *
+ * "Loosely", because a `PhoneticSyllable` may actually encompass multiple
+ * syllables if no stress is needed, or a single stress at the start of the word
+ * is sufficient. Syllable splits are up to the user.
+ */
+export interface PhoneticSyllable {
+  ipaPhonemes: IpaPhoneme[];
+  stress?: PhoneticSyllableStress;
+}
+
+export const PhoneticSyllableSchema: z.ZodType<PhoneticSyllable> = z.object({
+  ipaPhonemes: z.array(IpaPhonemeSchema),
+  stress: z.enum(['primary']).optional(),
+});
+
+/**
+ * Represents a single word in a TTS string. The phonetic editor operates on a
+ * per-word basis. Words are naïvely split out by whitespace from the original
+ * user-entered election strings.
+ */
+export interface PhoneticWord {
+  syllables?: PhoneticSyllable[];
+  text: string;
+}
+
+export const PhoneticWordSchema: z.ZodType<PhoneticWord> = z.object({
+  syllables: z.array(PhoneticSyllableSchema).optional(),
+  text: z.string(),
+});
+
+export const PhoneticWordsSchema = z.array(PhoneticWordSchema);
+
+/**
+ * Unique key identifying a given TTS string in storage.
+ */
+export interface TtsStringKey {
+  electionId: string;
+  key: ElectionStringKey;
+  languageCode: string;
+  subkey?: string;
+}
+
+export const TtsStringKeySchema: z.ZodType<TtsStringKey> = z.object({
+  electionId: z.string(),
+  key: z.enum(ElectionStringKey),
+  languageCode: z.string(),
+  subkey: z.string().optional(),
+});
+
+const ExportSourceSchema = z.enum(['phonetic', 'text']);
+
+/**
+ * Determines which type of input to use when generating election audio for
+ * export (plain text, vs phonetic).
+ */
+export type TtsExportSource = z.infer<typeof ExportSourceSchema>;
+
+/**
+ * Speech synthesis inputs for a given election string.
+ */
+export interface TtsString {
+  exportSource: TtsExportSource;
+  phonetic: PhoneticWord[];
+  text: string;
+}
+
+export const TtsStringSchema: z.ZodType<TtsString> = z.object({
+  exportSource: ExportSourceSchema,
+  phonetic: z.array(PhoneticWordSchema),
+  text: z.string(),
+});


### PR DESCRIPTION
## Overview

[#7264](https://github.com/votingworks/vxsuite/issues/7264)

Chunking up/cleaning up code from the `la-demo` branch - this bit adds foundational types and DB logic to support TTS string edits in VxDesign. Some details may still change over time as the feature comes together.

### Next Up:
- Seed/update rows in the `tts_strings` table whenever a relevant election entity is added (still deciding if this should happen server-side or client-side, but leaning toward the former).
- Use `tts_strings` entries as overrides in the audio generation process when exporting packages.

## Testing Plan
- Store unit tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
