### PR TITLE
feat(scan): allow expanding write-in search areas

### DIFF
--- a/libs/ballot-interpreter/benches/main.rs
+++ b/libs/ballot-interpreter/benches/main.rs
@@ -46,6 +46,7 @@ impl InterpretFixture {
             true,
             self.timing_mark_algorithm,
             None,
+            None,
         )?;
         let side_a_path = fixture_path
             .join(self.election)

--- a/libs/ballot-interpreter/bin/interpret.rs
+++ b/libs/ballot-interpreter/bin/interpret.rs
@@ -2,7 +2,10 @@ use std::{path::PathBuf, process, time::Instant};
 
 use ballot_interpreter::interpret::{ScanInterpreter, TimingMarkAlgorithm};
 use clap::Parser;
-use types_rs::election::Election;
+use types_rs::{
+    election::{Election, Outset},
+    geometry::SubGridUnit,
+};
 
 #[derive(Debug, clap::Parser)]
 #[allow(clippy::struct_excessive_bools)]
@@ -39,6 +42,22 @@ struct Options {
     /// Detect and reject timing mark grid scales less than this value.
     #[clap(long)]
     minimum_detected_scale: Option<f32>,
+
+    /// How many grid units to expand write-in search areas to the left.
+    #[clap(long, default_value_t)]
+    expand_write_in_areas_left: SubGridUnit,
+
+    /// How many grid units to expand write-in search areas to the right.
+    #[clap(long, default_value_t)]
+    expand_write_in_areas_right: SubGridUnit,
+
+    /// How many grid units to expand write-in search areas up.
+    #[clap(long, default_value_t)]
+    expand_write_in_areas_up: SubGridUnit,
+
+    /// How many grid units to expand write-in search areas down.
+    #[clap(long, default_value_t)]
+    expand_write_in_areas_down: SubGridUnit,
 }
 
 impl Options {
@@ -67,6 +86,12 @@ fn main() -> color_eyre::Result<()> {
         !options.disable_timing_mark_inference,
         options.timing_mark_algorithm,
         options.minimum_detected_scale,
+        Some(Outset {
+            top: options.expand_write_in_areas_up,
+            right: options.expand_write_in_areas_right,
+            bottom: options.expand_write_in_areas_down,
+            left: options.expand_write_in_areas_left,
+        }),
     )?;
 
     let start = Instant::now();

--- a/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/interpret.rs
@@ -16,8 +16,10 @@ use rayon::iter::ParallelIterator;
 use serde::Serialize;
 use serde_with::DeserializeFromStr;
 use types_rs::ballot_card::BallotSide;
+use types_rs::election::Outset;
 use types_rs::election::{BallotStyleId, Election, MetadataEncoding, PrecinctId};
 use types_rs::geometry::PixelPosition;
+use types_rs::geometry::SubGridUnit;
 use types_rs::geometry::{PixelUnit, Size};
 use types_rs::hmpb;
 
@@ -55,6 +57,7 @@ pub struct Options {
     pub debug_side_a_base: Option<PathBuf>,
     pub debug_side_b_base: Option<PathBuf>,
     pub score_write_ins: bool,
+    pub expand_write_in_areas_by: Option<Outset<SubGridUnit>>,
     pub disable_vertical_streak_detection: bool,
     pub infer_timing_marks: bool,
     pub timing_mark_algorithm: TimingMarkAlgorithm,
@@ -213,6 +216,7 @@ pub struct ScanInterpreter {
     bubble_template_image: GrayImage,
     timing_mark_algorithm: TimingMarkAlgorithm,
     minimum_detected_scale: Option<f32>,
+    expand_write_in_areas_by: Option<Outset<SubGridUnit>>,
 }
 
 impl ScanInterpreter {
@@ -228,6 +232,7 @@ impl ScanInterpreter {
         infer_timing_marks: bool,
         timing_mark_algorithm: TimingMarkAlgorithm,
         minimum_detected_scale: Option<f32>,
+        expand_write_in_areas_by: Option<Outset<SubGridUnit>>,
     ) -> Result<Self, image::ImageError> {
         let bubble_template_image = load_ballot_scan_bubble_image()?;
         Ok(Self {
@@ -238,6 +243,7 @@ impl ScanInterpreter {
             bubble_template_image,
             timing_mark_algorithm,
             minimum_detected_scale,
+            expand_write_in_areas_by,
         })
     }
 
@@ -260,6 +266,7 @@ impl ScanInterpreter {
             debug_side_a_base: debug_side_a_base.into(),
             debug_side_b_base: debug_side_b_base.into(),
             score_write_ins: self.score_write_ins,
+            expand_write_in_areas_by: self.expand_write_in_areas_by.clone(),
             disable_vertical_streak_detection: self.disable_vertical_streak_detection,
             infer_timing_marks: self.infer_timing_marks,
             timing_mark_algorithm: self.timing_mark_algorithm,
@@ -724,6 +731,7 @@ pub fn ballot_card(
                         threshold,
                         grid,
                         grid_layout,
+                        options.expand_write_in_areas_by.as_ref(),
                         sheet_number,
                         side,
                         debug,
@@ -824,6 +832,7 @@ mod test {
             bubble_template,
             election,
             score_write_ins: true,
+            expand_write_in_areas_by: None,
             disable_vertical_streak_detection: false,
             infer_timing_marks: true,
             timing_mark_algorithm: TimingMarkAlgorithm::default(),
@@ -854,6 +863,7 @@ mod test {
             bubble_template,
             election,
             score_write_ins: true,
+            expand_write_in_areas_by: None,
             disable_vertical_streak_detection: false,
             infer_timing_marks: true,
             timing_mark_algorithm: TimingMarkAlgorithm::default(),

--- a/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
@@ -69,6 +69,7 @@ fn interpret(
             debug_side_a_base: options.debug_base_path_side_a.map(PathBuf::from),
             debug_side_b_base: options.debug_base_path_side_b.map(PathBuf::from),
             score_write_ins: options.score_write_ins.unwrap_or(false),
+            expand_write_in_areas_by: None,
             disable_vertical_streak_detection: options
                 .disable_vertical_streak_detection
                 .unwrap_or(false),

--- a/libs/types-rs/src/election.rs
+++ b/libs/types-rs/src/election.rs
@@ -127,6 +127,20 @@ pub struct Outset<T> {
     pub left: T,
 }
 
+impl<T> Default for Outset<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self {
+            top: T::default(),
+            right: T::default(),
+            bottom: T::default(),
+            left: T::default(),
+        }
+    }
+}
+
 /// A position on the ballot grid defined by timing marks and the contest/option
 /// for which a mark at this position is a vote for.
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Overview

Adds options to the `interpret` CLI to set the expansions.

## Demo Video or Screenshot
| Current | Example Expanded |
|-|-|
| <img width="399" height="108" alt="image" src="https://github.com/user-attachments/assets/2136c8a8-5eb4-43d2-a6de-a2122f2806cd" /> | <img width="432" height="127" alt="image" src="https://github.com/user-attachments/assets/21f30d40-9477-4d08-b984-cb104d4c18b9" /> |

## Testing Plan
Manual testing.