### PR TITLE
fix(scan): ensure message and newline are written together

### DIFF
--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -196,8 +196,8 @@ enum Message {
 }
 
 fn send_to_stdout(message: Message) -> color_eyre::Result<()> {
-    serde_json::to_writer(io::stdout(), &message)?;
     let mut stdout = io::stdout().lock();
+    serde_json::to_writer(&mut stdout, &message)?;
     stdout.write_all(b"\n")?;
     Ok(())
 }


### PR DESCRIPTION
## Overview
Without locking for both writes it may be that some other writes happen simultaneously.

## Demo Video or Screenshot
For example, stdout could look like this:
```
{"responsehello world!
":"hello again!
ok"}final hello!


```
This might happen if the writes to stdout made by `serde_json::to_writer` were being made while another thread was writing to stdout.

## Testing Plan
Manually tested to ensure that `pdictl` still works as expected.
