### PR TITLE
refactor(scan): improve coherence of scanning options

### DIFF
--- a/libs/ballot-interpreter/benches/main.rs
+++ b/libs/ballot-interpreter/benches/main.rs
@@ -42,7 +42,7 @@ impl InterpretFixture {
         let interpreter = ScanInterpreter::new(
             election,
             true,
-            false,
+            VerticalStreakDetection::Enabled,
             true,
             self.timing_mark_algorithm,
             None,

--- a/libs/ballot-interpreter/benches/main.rs
+++ b/libs/ballot-interpreter/benches/main.rs
@@ -2,7 +2,9 @@
 
 use std::{fmt::Display, fs::File, io::BufReader, path::PathBuf};
 
-use ballot_interpreter::interpret::{ScanInterpreter, TimingMarkAlgorithm};
+use ballot_interpreter::interpret::{
+    Inference, ScanInterpreter, TimingMarkAlgorithm, VerticalStreakDetection,
+};
 use divan::{black_box, Bencher};
 use image::GrayImage;
 
@@ -43,7 +45,6 @@ impl InterpretFixture {
             election,
             true,
             VerticalStreakDetection::Enabled,
-            true,
             self.timing_mark_algorithm,
             None,
         )?;
@@ -72,8 +73,8 @@ impl Display for InterpretFixture {
 }
 
 #[divan::bench(args = [
-    InterpretFixture::new("all-bubble-ballot", "blank", ".jpg", TimingMarkAlgorithm::Contours),
-    InterpretFixture::new("vxqa-2024-10", "skew", ".png", TimingMarkAlgorithm::Contours),
+    InterpretFixture::new("all-bubble-ballot", "blank", ".jpg", TimingMarkAlgorithm::Contours { inference: Inference::Enabled }),
+    InterpretFixture::new("vxqa-2024-10", "skew", ".png", TimingMarkAlgorithm::Contours { inference: Inference::Enabled }),
     InterpretFixture::new("all-bubble-ballot", "blank", ".jpg", TimingMarkAlgorithm::Corners),
     InterpretFixture::new("vxqa-2024-10", "skew", ".png", TimingMarkAlgorithm::Corners),
 ])]

--- a/libs/ballot-interpreter/benches/main.rs
+++ b/libs/ballot-interpreter/benches/main.rs
@@ -3,7 +3,7 @@
 use std::{fmt::Display, fs::File, io::BufReader, path::PathBuf};
 
 use ballot_interpreter::interpret::{
-    Inference, ScanInterpreter, TimingMarkAlgorithm, VerticalStreakDetection,
+    Inference, ScanInterpreter, TimingMarkAlgorithm, VerticalStreakDetection, WriteInScoring,
 };
 use divan::{black_box, Bencher};
 use image::GrayImage;
@@ -43,7 +43,7 @@ impl InterpretFixture {
             serde_json::from_reader(BufReader::new(File::open(election_path)?))?;
         let interpreter = ScanInterpreter::new(
             election,
-            true,
+            WriteInScoring::Enabled,
             VerticalStreakDetection::Enabled,
             self.timing_mark_algorithm,
             None,

--- a/libs/ballot-interpreter/bin/interpret.rs
+++ b/libs/ballot-interpreter/bin/interpret.rs
@@ -1,6 +1,8 @@
 use std::{path::PathBuf, process, time::Instant};
 
-use ballot_interpreter::interpret::{ScanInterpreter, TimingMarkAlgorithm};
+use ballot_interpreter::interpret::{
+    ScanInterpreter, TimingMarkAlgorithm, VerticalStreakDetection,
+};
 use clap::Parser;
 use types_rs::election::Election;
 
@@ -24,9 +26,9 @@ struct Options {
     #[clap(long, default_value = "false")]
     score_write_ins: bool,
 
-    /// Determines whether to disable vertical streak detection.
-    #[clap(long, default_value = "false")]
-    disable_vertical_streak_detection: bool,
+    /// Vertical streak detection setting.
+    #[clap(long, short = 'v', default_value_t = Default::default())]
+    vertical_streak_detection: VerticalStreakDetection,
 
     /// Determines whether to disable timing mark inference.
     #[clap(long, default_value = "false")]
@@ -63,7 +65,7 @@ fn main() -> color_eyre::Result<()> {
     let interpreter = ScanInterpreter::new(
         options.load_election()?,
         options.score_write_ins,
-        options.disable_vertical_streak_detection,
+        options.vertical_streak_detection,
         !options.disable_timing_mark_inference,
         options.timing_mark_algorithm,
         options.minimum_detected_scale,

--- a/libs/ballot-interpreter/bin/interpret.rs
+++ b/libs/ballot-interpreter/bin/interpret.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, process, time::Instant};
 
 use ballot_interpreter::interpret::{
-    ScanInterpreter, TimingMarkAlgorithm, VerticalStreakDetection,
+    Inference, ScanInterpreter, TimingMarkAlgorithm, VerticalStreakDetection,
 };
 use clap::Parser;
 use types_rs::election::Election;
@@ -30,7 +30,7 @@ struct Options {
     #[clap(long, short = 'v', default_value_t = Default::default())]
     vertical_streak_detection: VerticalStreakDetection,
 
-    /// Determines whether to disable timing mark inference.
+    /// Determines whether to disable timing mark inference (only applicable to contours algorithm).
     #[clap(long, default_value = "false")]
     disable_timing_mark_inference: bool,
 
@@ -62,12 +62,23 @@ impl Options {
 fn main() -> color_eyre::Result<()> {
     let options = Options::parse();
 
+    // Apply timing mark inference setting to the algorithm if it's Contours
+    let timing_mark_algorithm = match options.timing_mark_algorithm {
+        TimingMarkAlgorithm::Contours { .. } => TimingMarkAlgorithm::Contours {
+            inference: if options.disable_timing_mark_inference {
+                Inference::Disabled
+            } else {
+                Inference::Enabled
+            },
+        },
+        TimingMarkAlgorithm::Corners => TimingMarkAlgorithm::Corners,
+    };
+
     let interpreter = ScanInterpreter::new(
         options.load_election()?,
         options.score_write_ins,
         options.vertical_streak_detection,
-        !options.disable_timing_mark_inference,
-        options.timing_mark_algorithm,
+        timing_mark_algorithm,
         options.minimum_detected_scale,
     )?;
 

--- a/libs/ballot-interpreter/bin/interpret.rs
+++ b/libs/ballot-interpreter/bin/interpret.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, process, time::Instant};
 
 use ballot_interpreter::interpret::{
-    Inference, ScanInterpreter, TimingMarkAlgorithm, VerticalStreakDetection,
+    Inference, ScanInterpreter, TimingMarkAlgorithm, VerticalStreakDetection, WriteInScoring,
 };
 use clap::Parser;
 use types_rs::election::Election;
@@ -76,7 +76,11 @@ fn main() -> color_eyre::Result<()> {
 
     let interpreter = ScanInterpreter::new(
         options.load_election()?,
-        options.score_write_ins,
+        if options.score_write_ins {
+            WriteInScoring::Enabled
+        } else {
+            WriteInScoring::Disabled
+        },
         options.vertical_streak_detection,
         timing_mark_algorithm,
         options.minimum_detected_scale,

--- a/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
@@ -13,7 +13,7 @@ use crate::ballot_card::{load_ballot_scan_bubble_image, PaperInfo};
 use crate::debug::ImageDebugWriter;
 use crate::interpret::{
     self, ballot_card, prepare_ballot_page_image, Inference, InterpretedBallotCard, Options,
-    TimingMarkAlgorithm, VerticalStreakDetection,
+    TimingMarkAlgorithm, VerticalStreakDetection, WriteInScoring,
 };
 use crate::scoring::UnitIntervalScore;
 use crate::timing_marks::contours::FindTimingMarkGridOptions;
@@ -68,7 +68,11 @@ fn interpret(
             bubble_template,
             debug_side_a_base: options.debug_base_path_side_a.map(PathBuf::from),
             debug_side_b_base: options.debug_base_path_side_b.map(PathBuf::from),
-            score_write_ins: options.score_write_ins.unwrap_or(false),
+            write_in_scoring: if options.score_write_ins.unwrap_or(false) {
+                WriteInScoring::Enabled
+            } else {
+                WriteInScoring::Disabled
+            },
             vertical_streak_detection: if options.disable_vertical_streak_detection.unwrap_or(false)
             {
                 VerticalStreakDetection::Disabled

--- a/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/js/mod.rs
@@ -13,7 +13,7 @@ use crate::ballot_card::{load_ballot_scan_bubble_image, PaperInfo};
 use crate::debug::ImageDebugWriter;
 use crate::interpret::{
     self, ballot_card, prepare_ballot_page_image, InterpretedBallotCard, Options,
-    TimingMarkAlgorithm,
+    TimingMarkAlgorithm, VerticalStreakDetection,
 };
 use crate::scoring::UnitIntervalScore;
 use crate::timing_marks::contours::FindTimingMarkGridOptions;
@@ -69,9 +69,12 @@ fn interpret(
             debug_side_a_base: options.debug_base_path_side_a.map(PathBuf::from),
             debug_side_b_base: options.debug_base_path_side_b.map(PathBuf::from),
             score_write_ins: options.score_write_ins.unwrap_or(false),
-            disable_vertical_streak_detection: options
-                .disable_vertical_streak_detection
-                .unwrap_or(false),
+            vertical_streak_detection: if options.disable_vertical_streak_detection.unwrap_or(false)
+            {
+                VerticalStreakDetection::Disabled
+            } else {
+                VerticalStreakDetection::Enabled
+            },
             infer_timing_marks: options.infer_timing_marks.unwrap_or(true),
             timing_mark_algorithm: options.timing_mark_algorithm.unwrap_or_default(),
             minimum_detected_scale,

--- a/libs/ballot-interpreter/src/hmpb-rust/timing_marks/contours/mod.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_marks/contours/mod.rs
@@ -10,6 +10,7 @@ use types_rs::geometry::{
 };
 use types_rs::{election::UnitIntervalValue, geometry::IntersectionBounds};
 
+use crate::interpret::Inference;
 use crate::timing_marks::scoring::{CandidateTimingMark, TimingMarkScore};
 use crate::timing_marks::{rect_could_be_timing_mark, Border, Corner, TimingMarks};
 use crate::{
@@ -191,7 +192,7 @@ impl From<TimingMarks> for Partial {
 pub struct FindTimingMarkGridOptions<'a> {
     pub allowed_timing_mark_inset_percentage_of_width: UnitIntervalValue,
     pub debug: &'a mut debug::ImageDebugWriter,
-    pub infer_timing_marks: bool,
+    pub inference: Inference,
 }
 
 /// Finds the timing marks in the given image and computes the grid of timing
@@ -228,7 +229,7 @@ pub fn find_timing_mark_grid(
         &FindCompleteTimingMarksFromPartialTimingMarksOptions {
             allowed_timing_mark_inset_percentage_of_width: options
                 .allowed_timing_mark_inset_percentage_of_width,
-            infer_timing_marks: options.infer_timing_marks,
+            inference: options.inference,
             debug,
         },
     ) {
@@ -832,7 +833,7 @@ pub const MAX_ALLOWED_TIMING_MARK_DISTANCE_ERROR: UnitIntervalValue = 0.2;
 pub struct FindCompleteTimingMarksFromPartialTimingMarksOptions<'a> {
     pub allowed_timing_mark_inset_percentage_of_width: UnitIntervalValue,
     pub debug: &'a debug::ImageDebugWriter,
-    pub infer_timing_marks: bool,
+    pub inference: Inference,
 }
 
 /// Finds complete timing marks from partial timing marks.
@@ -958,7 +959,7 @@ pub fn find_complete_from_partial(
     let median_horizontal_distance = horizontal_distances[horizontal_distances.len() / 2];
     let median_vertical_distance = vertical_distances[vertical_distances.len() / 2];
 
-    let should_infer_timing_marks = options.infer_timing_marks;
+    let should_infer_timing_marks = matches!(options.inference, Inference::Enabled);
 
     let complete_top_line_marks = if should_infer_timing_marks {
         infer_missing_timing_marks_on_segment(


### PR DESCRIPTION
In preparing for the main part of #4980, I noticed the options for interpretation were factored a bit poorly. This makes some small improvements to the readability of the options and co-locates `infer_timing_marks` within the options for the `Contours` algorithm, since that's the only place where we do timing mark inference.