### PR TITLE
VxDesign: Guards to prevent exporting without ballot styles

### DIFF
--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -140,6 +140,7 @@ export function createBallotPropsForTemplate(
     };
   }
 
+  assert(election.ballotStyles.length > 0, 'Election has no ballot styles');
   const baseBallotProps = allBaseBallotProps(election).map((props) => ({
     ...props,
     compact,

--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -596,6 +596,7 @@ export async function layOutBallotsAndCreateElectionDefinition<
   ballotContents: string[];
   electionDefinition: ElectionDefinition;
 }> {
+  assert(ballotProps.length > 0, 'No ballot props provided');
   const { election } = ballotProps[0];
   assert(ballotProps.every((props) => props.election === election));
 


### PR DESCRIPTION
## Overview

Adds some assertions to help clarify what's wrong when trying to export without ballot styles defined. I opted not to build anything into the UI for now since eventually we probably want to require ballots are finalized before exporting, which would make this a non-issue.
## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
