### PR TITLE
VxScan: Improve error message when ballot removed before scan

### DIFF
--- a/apps/scan/backend/src/scanners/pdi/pdi_app_scan_double_sheet.test.ts
+++ b/apps/scan/backend/src/scanners/pdi/pdi_app_scan_double_sheet.test.ts
@@ -315,7 +315,10 @@ test('insert two sheets back-to-back as if they were one long sheet', async () =
         event: 'scanComplete',
         images: await ballotImages.completeBmd(),
       });
-      await waitForStatus(apiClient, { state: 'jammed' });
+      await waitForStatus(apiClient, {
+        state: 'jammed',
+        error: 'scanning_failed',
+      });
 
       mockScanner.setScannerStatus(mockScannerStatus.idleScanningDisabled);
       clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);

--- a/apps/scan/backend/src/scanners/pdi/state_machine.ts
+++ b/apps/scan/backend/src/scanners/pdi/state_machine.ts
@@ -726,6 +726,11 @@ function buildMachine({
                   {
                     cond: (_, { status }) => status.documentJam,
                     target: '#rejecting',
+                    actions: assign({
+                      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                      error: (_context) =>
+                        new PrecinctScannerError('scanning_failed'),
+                    }),
                   },
                   // If you pull the ballot out before it can be fully scanned,
                   // we either get a scanFailed event (handled above) or a


### PR DESCRIPTION
## Overview

While debugging another scan issue, I noticed that "teasing" a ballot (triggering a scan, but removing it before the scanner can grab it) was resulting in an error message to restart the scanner.

I've tested this behavior countless times and never seen this error message before, so I'm assuming it was either behavior that was introduced accidentally or that my scanner is behaving slightly differently than before.

The reason this error message is shown is because the state machine is getting jam flag from the scanner, so it tries to reject the ballot. Since there's no ballot, it thinks it has successfully rejected the ballot. However, if the frontend sees the `rejected` state with no error code, it assumes something weird happened and shows the message to restart the scanner (since there's should always be a reason for rejecting a ballot).

To fix this, I simply added an error code for this case.

## Demo Video or Screenshot

Before

https://github.com/user-attachments/assets/dd8e0254-7da7-4951-939d-f24433532b1c



After

https://github.com/user-attachments/assets/8342122d-0468-481d-a668-64c4bbf8a509



## Testing Plan
- Manual testing
- Updated automated tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
