### PR TITLE
refactor(scan): `BallotImage` encapsulation improvements

### DIFF
--- a/libs/ballot-interpreter/bin/debug-timing-marks.rs
+++ b/libs/ballot-interpreter/bin/debug-timing-marks.rs
@@ -107,7 +107,7 @@ fn process_path<W: Write>(
     *prepare_image_duration += start.elapsed();
 
     let debug = if options.debug {
-        debug::ImageDebugWriter::new(path.to_path_buf(), ballot_page.ballot_image.image.clone())
+        debug::ImageDebugWriter::new(path.to_path_buf(), ballot_page.ballot_image.image().clone())
     } else {
         debug::ImageDebugWriter::disabled()
     };

--- a/libs/ballot-interpreter/src/hmpb-rust/ballot_card.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/ballot_card.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, io, ops::Range};
 
-use image::{GenericImageView, GrayImage};
+use image::{imageops::rotate180_in_place, GenericImageView, GrayImage};
 use imageproc::contrast::{otsu_level, threshold};
 use serde::Serialize;
 
@@ -11,14 +11,32 @@ use types_rs::{
     geometry::{GridUnit, Inch, PixelPosition, PixelUnit, Rect, Size, SubPixelUnit},
 };
 
+/// An image of a ballot after it has had any black areas outside the paper
+/// bounds cropped off. Provides access to the underlying image data, but most
+/// uses should go through the methods such as [`BallotImage::get_pixel`] rather
+/// than comparing the threshold against the underlying image data.
 #[must_use]
 pub struct BallotImage {
-    pub image: GrayImage,
-    pub threshold: u8,
-    pub border_inset: Inset,
+    image: GrayImage,
+    threshold: u8,
+    border_inset: Inset,
 }
 
 impl BallotImage {
+    /// Clamps the threshold to the given range. This is useful for situations
+    /// where the threshold computed by Otsu's method is too extreme, such as
+    /// when most of the image is nearly all one luminosity.
+    pub fn clamp_threshold(&mut self, min: u8, max: u8) {
+        self.threshold = self.threshold.clamp(min, max);
+    }
+
+    /// Rotates the underlying image data, leaving the threshold as-is since
+    /// Otsu's method is rotation-independent.
+    pub fn rotate180(&mut self) {
+        rotate180_in_place(&mut self.image);
+        self.border_inset.rotate180();
+    }
+
     /// This sets the ratio of pixels required to be white (above the threshold) in
     /// a given edge row or column to consider it no longer eligible to be cropped.
     /// This used to be 50%, but we found that too much of the top/bottom of the
@@ -29,7 +47,9 @@ impl BallotImage {
     /// on ballots with significant but still acceptable skew (i.e. 3 degrees).
     const CROP_BORDERS_THRESHOLD_RATIO: f32 = 0.1;
 
-    /// Return the image with the black border cropped off.
+    /// Builds a [`BallotImage`] with the black border outside the paper area
+    /// cropped off. Returns [`None`] if a valid border inset cannot be
+    /// computed.
     #[must_use]
     pub fn from_image(image: GrayImage) -> Option<BallotImage> {
         let threshold = otsu_level(&image);
@@ -64,6 +84,89 @@ impl BallotImage {
             threshold,
             border_inset,
         })
+    }
+
+    /// Gets the underlying image data. Generally you should try to access
+    /// information about the image through the other methods on
+    /// [`BallotImage`].
+    #[must_use]
+    pub fn image(&self) -> &GrayImage {
+        &self.image
+    }
+
+    /// Gets the computed Otsu threshold. Generally you should try to access
+    /// pixel information through [`BallotImage::get_pixel`] rather than
+    /// comparing against this value.
+    #[must_use]
+    pub fn threshold(&self) -> u8 {
+        self.threshold
+    }
+
+    /// Returns the computed border inset, showing the amount cropped off on
+    /// each side.
+    #[must_use]
+    pub fn border_inset(&self) -> Inset {
+        self.border_inset
+    }
+
+    /// Gets the width of the image after cropping.
+    #[must_use]
+    pub fn width(&self) -> u32 {
+        self.image.width()
+    }
+
+    /// Gets the height of the image after cropping.
+    #[must_use]
+    pub fn height(&self) -> u32 {
+        self.image.height()
+    }
+
+    /// Gets the dimensions of the image after cropping.
+    #[must_use]
+    pub fn dimensions(&self) -> (u32, u32) {
+        self.image.dimensions()
+    }
+
+    /// Determines whether the pixel at the given coordinate is foreground
+    /// or background.
+    #[must_use]
+    pub fn get_pixel(&self, x: u32, y: u32) -> BallotPixel {
+        // This must be `<=` so that binarized images whose threshold is 0
+        // still have pixels with luma 0 count as foreground pixels.
+        if self.image.get_pixel(x, y)[0] <= self.threshold {
+            BallotPixel::Foreground
+        } else {
+            BallotPixel::Background
+        }
+    }
+}
+
+/// A pixel from a binarized ballot image.
+///
+/// Note that even though the variants are called "foreground" and
+/// "background", black pixels will likely also come from the area outside the
+/// scanned sheet where there was no paper. These pixels are not distinguished
+/// from "foreground" pixels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BallotPixel {
+    /// A black pixel.
+    Foreground,
+
+    // A white pixel.
+    Background,
+}
+
+impl BallotPixel {
+    /// Determines whether this pixel is a foreground pixel, i.e. black.
+    #[must_use]
+    pub fn is_foreground(self) -> bool {
+        matches!(self, Self::Foreground)
+    }
+
+    /// Determines whether this pixel is a background pixel, i.e. white.
+    #[must_use]
+    pub fn is_background(self) -> bool {
+        matches!(self, Self::Background)
     }
 }
 

--- a/libs/ballot-interpreter/src/hmpb-rust/diagnostic.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/diagnostic.rs
@@ -56,13 +56,10 @@ fn generate_cells(
     cells
 }
 
-fn inspect_cells(
-    img: &GrayImage,
-    cells: &[Rect],
-    foreground_threshold: u8,
-) -> (Vec<Rect>, Vec<Rect>) {
+fn inspect_cells(img: &BallotImage, cells: &[Rect]) -> (Vec<Rect>, Vec<Rect>) {
     let (failed_cells, passed_cells) = cells.par_iter().partition(|cell| {
         let cropped = img
+            .image
             .view(
                 cell.left() as u32,
                 cell.top() as u32,
@@ -70,8 +67,7 @@ fn inspect_cells(
                 cell.height(),
             )
             .to_image();
-        let cropped_and_thresholded =
-            imageproc::contrast::threshold(&cropped, foreground_threshold);
+        let cropped_and_thresholded = imageproc::contrast::threshold(&cropped, img.threshold);
         let match_score = count_pixels(&cropped_and_thresholded, BLACK).ratio();
         match_score > FAIL_SCORE
     });
@@ -93,10 +89,7 @@ pub fn blank_paper(img: GrayImage, debug_path: Option<PathBuf>) -> bool {
             CROP_BORDER_PIXELS + cell_height / 2,
         ),
     ];
-    let Some(BallotImage {
-        image, threshold, ..
-    }) = crop_ballot_page_image_borders(img)
-    else {
+    let Some(ballot_image) = crop_ballot_page_image_borders(img) else {
         return false;
     };
 
@@ -106,19 +99,22 @@ pub fn blank_paper(img: GrayImage, debug_path: Option<PathBuf>) -> bool {
             generate_cells(
                 left_start,
                 top_start,
-                image.width() - CROP_BORDER_PIXELS,
-                image.height() - CROP_BORDER_PIXELS,
+                ballot_image.image.width() - CROP_BORDER_PIXELS,
+                ballot_image.image.height() - CROP_BORDER_PIXELS,
                 cell_width,
                 cell_height,
             )
         })
         .collect::<Vec<_>>();
 
-    let (passed_cells, failed_cells) =
-        inspect_cells(&image, &cells, threshold.min(MAX_WHITE_THRESHOLD));
+    let ballot_image = BallotImage {
+        threshold: ballot_image.threshold.min(MAX_WHITE_THRESHOLD),
+        ..ballot_image
+    };
+    let (passed_cells, failed_cells) = inspect_cells(&ballot_image, &cells);
 
     let debug = debug_path.map_or_else(ImageDebugWriter::disabled, |base| {
-        ImageDebugWriter::new(base, image)
+        ImageDebugWriter::new(base, ballot_image.image.clone())
     });
     debug.write("diagnostic", |canvas| {
         draw_diagnostic_cells(canvas, &passed_cells, &failed_cells);

--- a/libs/ballot-interpreter/src/hmpb-rust/diagnostic.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/diagnostic.rs
@@ -55,10 +55,10 @@ fn generate_cells(
     cells
 }
 
-fn inspect_cells(img: &BallotImage, cells: &[Rect]) -> (Vec<Rect>, Vec<Rect>) {
+fn inspect_cells(ballot_image: &BallotImage, cells: &[Rect]) -> (Vec<Rect>, Vec<Rect>) {
     let (failed_cells, passed_cells) = cells.par_iter().partition(|cell| {
-        let cropped = img
-            .image
+        let cropped = ballot_image
+            .image()
             .view(
                 cell.left() as u32,
                 cell.top() as u32,
@@ -66,7 +66,8 @@ fn inspect_cells(img: &BallotImage, cells: &[Rect]) -> (Vec<Rect>, Vec<Rect>) {
                 cell.height(),
             )
             .to_image();
-        let cropped_and_thresholded = imageproc::contrast::threshold(&cropped, img.threshold);
+        let cropped_and_thresholded =
+            imageproc::contrast::threshold(&cropped, ballot_image.threshold());
         let match_score = count_pixels(&cropped_and_thresholded, BLACK).ratio();
         match_score > FAIL_SCORE
     });
@@ -88,7 +89,7 @@ pub fn blank_paper(img: GrayImage, debug_path: Option<PathBuf>) -> bool {
             CROP_BORDER_PIXELS + cell_height / 2,
         ),
     ];
-    let Some(ballot_image) = BallotImage::from_image(img) else {
+    let Some(mut ballot_image) = BallotImage::from_image(img) else {
         return false;
     };
 
@@ -98,22 +99,19 @@ pub fn blank_paper(img: GrayImage, debug_path: Option<PathBuf>) -> bool {
             generate_cells(
                 left_start,
                 top_start,
-                ballot_image.image.width() - CROP_BORDER_PIXELS,
-                ballot_image.image.height() - CROP_BORDER_PIXELS,
+                ballot_image.width() - CROP_BORDER_PIXELS,
+                ballot_image.height() - CROP_BORDER_PIXELS,
                 cell_width,
                 cell_height,
             )
         })
         .collect::<Vec<_>>();
 
-    let ballot_image = BallotImage {
-        threshold: ballot_image.threshold.min(MAX_WHITE_THRESHOLD),
-        ..ballot_image
-    };
+    ballot_image.clamp_threshold(0, MAX_WHITE_THRESHOLD);
     let (passed_cells, failed_cells) = inspect_cells(&ballot_image, &cells);
 
     let debug = debug_path.map_or_else(ImageDebugWriter::disabled, |base| {
-        ImageDebugWriter::new(base, ballot_image.image.clone())
+        ImageDebugWriter::new(base, ballot_image.image().clone())
     });
     debug.write("diagnostic", |canvas| {
         draw_diagnostic_cells(canvas, &passed_cells, &failed_cells);

--- a/libs/ballot-interpreter/src/hmpb-rust/diagnostic.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/diagnostic.rs
@@ -8,7 +8,6 @@ use crate::{
     ballot_card::{load_ballot_scan_bubble_image, BallotImage},
     debug::{draw_diagnostic_cells, ImageDebugWriter},
     image_utils::{count_pixels, BLACK},
-    interpret::crop_ballot_page_image_borders,
 };
 
 const FAIL_SCORE: f32 = 0.05;
@@ -89,7 +88,7 @@ pub fn blank_paper(img: GrayImage, debug_path: Option<PathBuf>) -> bool {
             CROP_BORDER_PIXELS + cell_height / 2,
         ),
     ];
-    let Some(ballot_image) = crop_ballot_page_image_borders(img) else {
+    let Some(ballot_image) = BallotImage::from_image(img) else {
         return false;
     };
 

--- a/libs/ballot-interpreter/src/hmpb-rust/scoring.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/scoring.rs
@@ -156,7 +156,7 @@ pub fn score_bubble_marks_from_grid_layout(
 /// because the bubble mark may not be exactly where we expect in the scanned
 /// image due to stretching or other distortions.
 pub fn score_bubble_mark(
-    img: &BallotImage,
+    ballot_image: &BallotImage,
     bubble_template: &GrayImage,
     expected_bubble_center: Point<SubPixelUnit>,
     location: &GridLocation,
@@ -193,11 +193,12 @@ pub fn score_bubble_mark(
                 continue;
             }
 
-            let cropped = img
-                .image
+            let cropped = ballot_image
+                .image()
                 .view(x as PixelUnit, y as PixelUnit, width, height)
                 .to_image();
-            let cropped_and_thresholded = imageproc::contrast::threshold(&cropped, img.threshold);
+            let cropped_and_thresholded =
+                imageproc::contrast::threshold(&cropped, ballot_image.threshold());
 
             let match_diff = diff(&cropped_and_thresholded, bubble_template);
             let match_score = UnitIntervalScore(count_pixels(&match_diff, WHITE).ratio());
@@ -222,8 +223,8 @@ pub fn score_bubble_mark(
     }
 
     let best_match = best_match?;
-    let source_image = img
-        .image
+    let source_image = ballot_image
+        .image()
         .view(
             best_match.bounds.left() as PixelUnit,
             best_match.bounds.top() as PixelUnit,
@@ -231,7 +232,8 @@ pub fn score_bubble_mark(
             best_match.bounds.height(),
         )
         .to_image();
-    let binarized_source_image = imageproc::contrast::threshold(&source_image, img.threshold);
+    let binarized_source_image =
+        imageproc::contrast::threshold(&source_image, ballot_image.threshold());
     let diff_image = diff(bubble_template, &binarized_source_image);
     let fill_score = UnitIntervalScore(count_pixels(&diff_image, BLACK).ratio());
 

--- a/libs/ballot-interpreter/src/hmpb-rust/scoring.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/scoring.rs
@@ -10,6 +10,7 @@ use types_rs::geometry::{
     PixelPosition, PixelUnit, Point, Quadrilateral, Rect, SubGridUnit, SubPixelUnit,
 };
 
+use crate::ballot_card::BallotImage;
 use crate::image_utils::{count_pixels, count_pixels_in_shape};
 use crate::timing_marks::TimingMarks;
 use crate::{
@@ -97,8 +98,7 @@ pub type ScoredBubbleMarks = Vec<(GridPosition, Option<ScoredBubbleMark>)>;
 
 #[allow(clippy::too_many_arguments)]
 pub fn score_bubble_marks_from_grid_layout(
-    img: &GrayImage,
-    threshold: u8,
+    img: &BallotImage,
     bubble_template: &GrayImage,
     timing_marks: &TimingMarks,
     grid_layout: &GridLayout,
@@ -129,7 +129,6 @@ pub fn score_bubble_marks_from_grid_layout(
                                 expected_bubble_center,
                                 &location,
                                 DEFAULT_MAXIMUM_SEARCH_DISTANCE,
-                                threshold,
                             ),
                         )]
                     },
@@ -157,12 +156,11 @@ pub fn score_bubble_marks_from_grid_layout(
 /// because the bubble mark may not be exactly where we expect in the scanned
 /// image due to stretching or other distortions.
 pub fn score_bubble_mark(
-    img: &GrayImage,
+    img: &BallotImage,
     bubble_template: &GrayImage,
     expected_bubble_center: Point<SubPixelUnit>,
     location: &GridLocation,
     maximum_search_distance: PixelUnit,
-    threshold: u8,
 ) -> Option<ScoredBubbleMark> {
     struct Match {
         bounds: Rect,
@@ -196,9 +194,10 @@ pub fn score_bubble_mark(
             }
 
             let cropped = img
+                .image
                 .view(x as PixelUnit, y as PixelUnit, width, height)
                 .to_image();
-            let cropped_and_thresholded = imageproc::contrast::threshold(&cropped, threshold);
+            let cropped_and_thresholded = imageproc::contrast::threshold(&cropped, img.threshold);
 
             let match_diff = diff(&cropped_and_thresholded, bubble_template);
             let match_score = UnitIntervalScore(count_pixels(&match_diff, WHITE).ratio());
@@ -224,6 +223,7 @@ pub fn score_bubble_mark(
 
     let best_match = best_match?;
     let source_image = img
+        .image
         .view(
             best_match.bounds.left() as PixelUnit,
             best_match.bounds.top() as PixelUnit,
@@ -231,7 +231,7 @@ pub fn score_bubble_mark(
             best_match.bounds.height(),
         )
         .to_image();
-    let binarized_source_image = imageproc::contrast::threshold(&source_image, threshold);
+    let binarized_source_image = imageproc::contrast::threshold(&source_image, img.threshold);
     let diff_image = diff(bubble_template, &binarized_source_image);
     let fill_score = UnitIntervalScore(count_pixels(&diff_image, BLACK).ratio());
 
@@ -259,8 +259,7 @@ pub type ScoredPositionAreas = Vec<ScoredPositionArea>;
 /// be used to determine which write-in areas are most likely to contain a write-in
 /// vote even if the bubble is not filled in.
 pub fn score_write_in_areas(
-    image: &GrayImage,
-    threshold: u8,
+    image: &BallotImage,
     timing_marks: &TimingMarks,
     grid_layout: &GridLayout,
     sheet_number: u32,
@@ -273,9 +272,7 @@ pub fn score_write_in_areas(
             let location = grid_position.location();
             grid_position.sheet_number() == sheet_number && location.side == side
         })
-        .filter_map(|grid_position| {
-            score_write_in_area(image, timing_marks, grid_position, threshold)
-        })
+        .filter_map(|grid_position| score_write_in_area(image, timing_marks, grid_position))
         .collect();
 
     debug.write("scored_write_in_areas", |canvas| {
@@ -286,10 +283,9 @@ pub fn score_write_in_areas(
 }
 
 fn score_write_in_area(
-    img: &GrayImage,
+    img: &BallotImage,
     timing_marks: &TimingMarks,
     grid_position: &GridPosition,
-    threshold: u8,
 ) -> Option<ScoredPositionArea> {
     let GridPosition::WriteIn { write_in_area, .. } = *grid_position else {
         return None;
@@ -310,7 +306,7 @@ fn score_write_in_area(
         bottom_left: bottom_left_corner,
         bottom_right: bottom_right_corner,
     };
-    let counted = count_pixels_in_shape(img, &shape, threshold);
+    let counted = count_pixels_in_shape(img, &shape);
     let score = UnitIntervalScore(counted.ratio());
 
     Some(ScoredPositionArea {

--- a/libs/ballot-interpreter/src/hmpb-rust/timing_marks/corners/mod.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_marks/corners/mod.rs
@@ -60,7 +60,7 @@ pub fn find_timing_mark_grid(
     });
 
     let corners = corner_finding::BallotGridCorners::find_all(
-        ballot_image.image.dimensions().into(),
+        ballot_image.dimensions().into(),
         geometry,
         &candidates,
         &options.corner_finding_options,

--- a/libs/ballot-interpreter/src/hmpb-rust/timing_marks/corners/shape_finding/mod.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_marks/corners/shape_finding/mod.rs
@@ -38,7 +38,7 @@ impl BallotGridBorderShapes {
     ) -> Self {
         let search_inset = options.search_inset;
 
-        let image = &ballot_image.image;
+        let image = ballot_image.image();
         let (width, height) = image.dimensions();
 
         let search_areas = [
@@ -92,12 +92,7 @@ fn find_timing_mark_shapes(
 ) -> Vec<TimingMarkShape> {
     let allowed_timing_mark_height_range = options.timing_mark_height_range(geometry);
     let mut shape_list_builder = ShapeListBuilder::new();
-    let image_bounds = Rect::new(
-        0,
-        0,
-        ballot_image.image.width(),
-        ballot_image.image.height(),
-    );
+    let image_bounds = Rect::new(0, 0, ballot_image.width(), ballot_image.height());
 
     // Restrict `search_area` to within the image bounds.
     let Some(search_area) = search_area.intersect(&image_bounds) else {
@@ -110,7 +105,7 @@ fn find_timing_mark_shapes(
     for x in x_range {
         for range in y_range
             .clone()
-            .group_by(|&y| ballot_image.image.get_pixel(x, y)[0] <= ballot_image.threshold)
+            .group_by(|&y| ballot_image.get_pixel(x, y).is_foreground())
             .into_iter()
             .filter(|(is_black, _)| *is_black)
             .filter_map(|(_, group)| {

--- a/libs/ballot-interpreter/src/hmpb-rust/timing_marks/corners/shape_finding/mod.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_marks/corners/shape_finding/mod.rs
@@ -1,6 +1,6 @@
 use std::ops::RangeInclusive;
 
-use image::{GrayImage, RgbImage};
+use image::RgbImage;
 use itertools::Itertools;
 use types_rs::geometry::{PixelUnit, Point, Rect};
 
@@ -40,7 +40,6 @@ impl BallotGridBorderShapes {
 
         let image = &ballot_image.image;
         let (width, height) = image.dimensions();
-        let threshold = ballot_image.threshold;
 
         let search_areas = [
             Rect::new(0, 0, search_inset.left, height),
@@ -60,7 +59,7 @@ impl BallotGridBorderShapes {
         ];
 
         search_areas.par_map_edgewise(|search_area| {
-            find_timing_mark_shapes(image, threshold, geometry, search_area, options)
+            find_timing_mark_shapes(ballot_image, geometry, search_area, options)
         })
     }
 
@@ -86,15 +85,19 @@ impl BallotGridBorderShapes {
 ///
 /// See [`ShapeListBuilder::add_slice`] for details on how this works.
 fn find_timing_mark_shapes(
-    image: &GrayImage,
-    threshold: u8,
+    ballot_image: &BallotImage,
     geometry: &Geometry,
     search_area: Rect,
     options: &Options,
 ) -> Vec<TimingMarkShape> {
     let allowed_timing_mark_height_range = options.timing_mark_height_range(geometry);
     let mut shape_list_builder = ShapeListBuilder::new();
-    let image_bounds = Rect::new(0, 0, image.width(), image.height());
+    let image_bounds = Rect::new(
+        0,
+        0,
+        ballot_image.image.width(),
+        ballot_image.image.height(),
+    );
 
     // Restrict `search_area` to within the image bounds.
     let Some(search_area) = search_area.intersect(&image_bounds) else {
@@ -107,7 +110,7 @@ fn find_timing_mark_shapes(
     for x in x_range {
         for range in y_range
             .clone()
-            .group_by(|&y| image.get_pixel(x, y)[0] <= threshold)
+            .group_by(|&y| ballot_image.image.get_pixel(x, y)[0] <= ballot_image.threshold)
             .into_iter()
             .filter(|(is_black, _)| *is_black)
             .filter_map(|(_, group)| {

--- a/libs/ballot-interpreter/src/hmpb-rust/timing_marks/scoring.rs
+++ b/libs/ballot-interpreter/src/hmpb-rust/timing_marks/scoring.rs
@@ -40,8 +40,7 @@ fn score_timing_mark_geometry_match(
     timing_mark: &Rect,
     geometry: &Geometry,
 ) -> TimingMarkScore {
-    let image = &ballot_image.image;
-    let threshold = ballot_image.threshold;
+    let image = ballot_image.image();
     let image_rect = Rect::new(0, 0, image.width(), image.height());
     let expected_width = geometry.timing_mark_width_pixels() as PixelUnit;
     let expected_height = geometry.timing_mark_height_pixels() as PixelUnit;
@@ -64,11 +63,10 @@ fn score_timing_mark_geometry_match(
         for x in search_rect.left()..search_rect.right() {
             let point = Point::new(x, y);
             if image_rect.contains(point) {
-                let luma = image.get_pixel(x as u32, y as u32);
+                let pixel = ballot_image.get_pixel(x as u32, y as u32);
                 let expects_mark_pixel = expected_timing_mark_rect.contains(point);
-                let is_black_pixel = luma.0[0] <= threshold;
 
-                if expects_mark_pixel == is_black_pixel {
+                if expects_mark_pixel == pixel.is_foreground() {
                     if expects_mark_pixel {
                         mark_pixel_match_count += 1;
                     } else {


### PR DESCRIPTION
## Overview

Refs #4980

Adds methods to `BallotImage` rather than using it as a simple plain struct. This should help make the code clearer in general, but most importantly it consolidates the `luma <= threshold` check into a single place within `BallotImage::get_pixel`.

## Demo Video or Screenshot
n/a

## Testing Plan
No functionality should have changed, so this is covered by existing tests.
