### PR TITLE
VxMark: support printing longer ballot sizes

### DIFF
--- a/apps/mark/backend/src/util/print_ballot.test.tsx
+++ b/apps/mark/backend/src/util/print_ballot.test.tsx
@@ -91,33 +91,6 @@ describe(`printMode === "bubble_marks"`, () => {
       ],
     ]);
   });
-
-  const testInvalidSizes = test.each<HmpbBallotPaperSize>([
-    HmpbBallotPaperSize.Custom17,
-    HmpbBallotPaperSize.Custom19,
-    HmpbBallotPaperSize.Custom22,
-  ]);
-
-  testInvalidSizes('throws for unsupported paper size - %s', async (size) => {
-    const electionDefinition = mockElection({ paperSize: size });
-
-    await expect(() =>
-      printBallot({
-        ballotStyleId: electionDefinition.election.ballotStyles[0].id,
-        languageCode: 'unused',
-        precinctId: 'unused',
-        printer: mockPrinter({}),
-        store: mockStore({
-          getElectionRecord: () => ({
-            electionDefinition,
-            electionPackageHash: 'unused',
-          }),
-          getPrintMode: () => 'bubble_marks',
-        }),
-        votes: { foo: ['yes'] },
-      })
-    ).rejects.toThrow(/paper size not yet supported/);
-  });
 });
 
 describe(`printMode === "summary"`, () => {

--- a/apps/mark/backend/src/util/print_ballot.tsx
+++ b/apps/mark/backend/src/util/print_ballot.tsx
@@ -52,12 +52,6 @@ async function printMarkOverlay(p: PrintBallotProps): Promise<void> {
   const { electionDefinition } = assertDefined(p.store.getElectionRecord());
   const { election } = electionDefinition;
 
-  const size = election.ballotLayout.paperSize;
-  assert(
-    size === 'letter' || size === 'legal',
-    `${size} paper size not yet supported for pre-printed ballot marking`
-  );
-
   const stream = generateMarkOverlay(
     election,
     p.ballotStyleId,
@@ -76,6 +70,6 @@ async function printMarkOverlay(p: PrintBallotProps): Promise<void> {
   return p.printer.print({
     data: new Uint8Array(pdf.buffer, pdf.byteOffset, pdf.length),
     sides: PrintSides.TwoSidedLongEdge,
-    size,
+    size: election.ballotLayout.paperSize,
   });
 }

--- a/libs/printing/src/printer/types.ts
+++ b/libs/printing/src/printer/types.ts
@@ -1,4 +1,4 @@
-import { PrinterStatus } from '@votingworks/types';
+import { HmpbBallotPaperSize, PrinterStatus } from '@votingworks/types';
 
 export enum PrintSides {
   /**
@@ -21,10 +21,12 @@ export enum PrintSides {
   TwoSidedShortEdge = 'two-sided-short-edge',
 }
 
+export type PaperSize = `${HmpbBallotPaperSize}`;
+
 export interface PrintOptions {
   copies?: number;
   sides?: PrintSides;
-  size?: 'letter' | 'legal';
+  size?: PaperSize;
   raw?: { [key: string]: string };
 }
 

--- a/libs/printing/supported_printers/generic-postscript-driver.ppd
+++ b/libs/printing/supported_printers/generic-postscript-driver.ppd
@@ -46,6 +46,9 @@
 *PageSize EnvC5/Envelope C5: "<</PageSize[459 649]/ImagingBBox null>>setpagedevice"
 *PageSize EnvDL/Envelope DL: "<</PageSize[312 624]/ImagingBBox null>>setpagedevice"
 *PageSize EnvMonarch/Envelope Monarch: "<</PageSize[279 540]/ImagingBBox null>>setpagedevice"
+*PageSize Custom-8.5x17/Custom 8.5x17: "<</PageSize[612 1224]/ImagingBBox null>>setpagedevice"
+*PageSize Custom-8.5x19/Custom 8.5x19: "<</PageSize[612 1368]/ImagingBBox null>>setpagedevice"
+*PageSize Custom-8.5x22/Custom 8.5x22: "<</PageSize[612 1584]/ImagingBBox null>>setpagedevice"
 *CloseUI: *PageSize
 *OpenUI *PageRegion/Media Size: PickOne
 *OrderDependency: 10 AnySetup *PageRegion
@@ -63,6 +66,9 @@
 *PageRegion EnvC5/Envelope C5: "<</PageSize[459 649]/ImagingBBox null>>setpagedevice"
 *PageRegion EnvDL/Envelope DL: "<</PageSize[312 624]/ImagingBBox null>>setpagedevice"
 *PageRegion EnvMonarch/Envelope Monarch: "<</PageSize[279 540]/ImagingBBox null>>setpagedevice"
+*PageRegion Custom-8.5x17/Custom 8.5x17: "<</PageSize[612 1224]/ImagingBBox null>>setpagedevice"
+*PageRegion Custom-8.5x19/Custom 8.5x19: "<</PageSize[612 1368]/ImagingBBox null>>setpagedevice"
+*PageRegion Custom-8.5x22/Custom 8.5x22: "<</PageSize[612 1584]/ImagingBBox null>>setpagedevice"
 *CloseUI: *PageRegion
 *DefaultImageableArea: Letter
 *ImageableArea Letter/US Letter: "12 12 600 780"
@@ -78,6 +84,9 @@
 *ImageableArea EnvC5/Envelope C5: "12 12 447 637"
 *ImageableArea EnvDL/Envelope DL: "12 12 300 612"
 *ImageableArea EnvMonarch/Envelope Monarch: "12 12 267 528"
+*ImageableArea Custom-8.5x17/Custom 8.5x17: "12 12 600 1212"
+*ImageableArea Custom-8.5x19/Custom 8.5x19: "12 12 600 1356"
+*ImageableArea Custom-8.5x22/Custom 8.5x22: "12 12 600 1572"
 *DefaultPaperDimension: Letter
 *PaperDimension Letter/US Letter: "612 792"
 *PaperDimension Legal/US Legal: "612 1008"
@@ -92,6 +101,9 @@
 *PaperDimension EnvC5/Envelope C5: "459 649"
 *PaperDimension EnvDL/Envelope DL: "312 624"
 *PaperDimension EnvMonarch/Envelope Monarch: "279 540"
+*PaperDimension Custom-8.5x17/Custom 8.5x17: "612 1224"
+*PaperDimension Custom-8.5x19/Custom 8.5x19: "612 1368"
+*PaperDimension Custom-8.5x22/Custom 8.5x22: "612 1584"
 *OpenUI *InputSlot/Media Source: PickOne
 *OrderDependency: 10 AnySetup *InputSlot
 *DefaultInputSlot: Default


### PR DESCRIPTION
## Overview

Currently we can create ballots from VxMark that print marks onto pre-printed ballots. It's been limited to letter and legal size ballots because the typical LaserJet Pro 4001dn supports maximum 14" paper. With a custom tray and custom firmware provided by HP, however, plus some configuration changes, we can print on up to 22" paper. This PR allows those sizes. 

I'm not sure if we can detect the firmware version systematically, which would be nice to only allow this option when it's availabile. The key change is actually not the "engine firmware" but the "formatter firmware" which I think would be even more unlikely to detect. I think on those printers, the job just fails (as it now would crash the app). 

## Demo Video or Screenshot

![IMG_3272](https://github.com/user-attachments/assets/46117711-52d7-46e5-8d37-e9c15fa95974)

## Testing Plan

Tested manually on 22", 19", and 17".

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
