### PR TITLE
VxDesign: Use original strings as keys for tts_strings (now tts_edits)

### DIFF
--- a/apps/design/backend/migrations/1759851149270_add-tts-edits.js
+++ b/apps/design/backend/migrations/1759851149270_add-tts-edits.js
@@ -1,0 +1,52 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  pgm.dropTable('tts_strings');
+
+  pgm.createTable(
+    'tts_edits',
+    {
+      election_id: {
+        type: 'text',
+        notNull: true,
+        onDelete: 'CASCADE',
+        references: 'elections',
+      },
+      language_code: {
+        notNull: true,
+        type: 'text',
+      },
+      original: {
+        notNull: true,
+        type: 'text',
+      },
+      export_source: {
+        check: `export_source IN ('phonetic', 'text')`,
+        default: 'text',
+        notNull: true,
+        type: 'text',
+      },
+      phonetic: {
+        notNull: true,
+        type: 'jsonb',
+      },
+      text: {
+        notNull: true,
+        type: 'text',
+      },
+    },
+    {
+      constraints: {
+        primaryKey: ['election_id', 'language_code', 'original'],
+      },
+    }
+  );
+};

--- a/apps/design/backend/src/store.test.ts
+++ b/apps/design/backend/src/store.test.ts
@@ -1,11 +1,7 @@
 import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { assertDefined } from '@votingworks/basics';
 
-import {
-  ElectionStringKey,
-  LanguageCode,
-  TtsStringKey,
-} from '@votingworks/types';
+import { LanguageCode, TtsEditKey } from '@votingworks/types';
 import { mockBaseLogger } from '@votingworks/logging';
 import { Store, TaskName } from './store';
 import { TestStore } from '../test/test_store';
@@ -320,11 +316,10 @@ test('Background task processing - requeuing interrupted tasks', async () => {
 });
 
 describe('tts_strings', () => {
-  const key: TtsStringKey = {
+  const key: TtsEditKey = {
     electionId: '5678',
-    key: ElectionStringKey.CONTEST_TITLE,
+    original: 'one two',
     languageCode: 'en',
-    subkey: '1234',
   };
 
   async function setUpElection(store: Store) {
@@ -336,26 +331,26 @@ describe('tts_strings', () => {
   test('ttsStringsGet returns null if absent', async () => {
     const store = testStore.getStore();
     await setUpElection(store);
-    await expect(store.ttsStringsGet(key)).resolves.toBeNull();
+    await expect(store.ttsEditsGet(key)).resolves.toBeNull();
   });
 
   test('ttsStringsSet inserts if absent, updates if present', async () => {
     const store = testStore.getStore();
     await setUpElection(store);
 
-    await store.ttsStringsSet(key, {
+    await store.ttsEditsSet(key, {
       exportSource: 'phonetic',
       phonetic: [{ text: 'one' }, { text: 'two' }],
       text: 'one two',
     });
 
-    await expect(store.ttsStringsGet(key)).resolves.toEqual({
+    await expect(store.ttsEditsGet(key)).resolves.toEqual({
       exportSource: 'phonetic',
       phonetic: [{ text: 'one' }, { text: 'two' }],
       text: 'one two',
     });
 
-    await store.ttsStringsSet(key, {
+    await store.ttsEditsSet(key, {
       exportSource: 'phonetic',
       phonetic: [
         { text: 'one' },
@@ -364,7 +359,7 @@ describe('tts_strings', () => {
       text: 'one two',
     });
 
-    await expect(store.ttsStringsGet(key)).resolves.toEqual({
+    await expect(store.ttsEditsGet(key)).resolves.toEqual({
       exportSource: 'phonetic',
       phonetic: [
         { text: 'one' },

--- a/libs/types/src/tts_strings.ts
+++ b/libs/types/src/tts_strings.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod/v4';
 
-import { ElectionStringKey } from './ui_string_translations';
 import {
   IpaPhoneme,
   IpaPhonemeSchema,
@@ -43,20 +42,18 @@ export const PhoneticWordSchema: z.ZodType<PhoneticWord> = z.object({
 export const PhoneticWordsSchema = z.array(PhoneticWordSchema);
 
 /**
- * Unique key identifying a given TTS string in storage.
+ * Unique key identifying user edits for a given TTS string in storage.
  */
-export interface TtsStringKey {
+export interface TtsEditKey {
   electionId: string;
-  key: ElectionStringKey;
   languageCode: string;
-  subkey?: string;
+  original: string;
 }
 
-export const TtsStringKeySchema: z.ZodType<TtsStringKey> = z.object({
+export const TtsEditKeySchema: z.ZodType<TtsEditKey> = z.object({
   electionId: z.string(),
-  key: z.enum(ElectionStringKey),
   languageCode: z.string(),
-  subkey: z.string().optional(),
+  original: z.string(),
 });
 
 const ExportSourceSchema = z.enum(['phonetic', 'text']);
@@ -68,15 +65,15 @@ const ExportSourceSchema = z.enum(['phonetic', 'text']);
 export type TtsExportSource = z.infer<typeof ExportSourceSchema>;
 
 /**
- * Speech synthesis inputs for a given election string.
+ * Speech synthesis edits for a given election string.
  */
-export interface TtsString {
+export interface TtsEdit {
   exportSource: TtsExportSource;
   phonetic: PhoneticWord[];
   text: string;
 }
 
-export const TtsStringSchema: z.ZodType<TtsString> = z.object({
+export const TtsEditSchema: z.ZodType<TtsEdit> = z.object({
   exportSource: ExportSourceSchema,
   phonetic: z.array(PhoneticWordSchema),
   text: z.string(),


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7264

Updating the DB schema and types for managing TTS string edits.
Outline of the current plan:
- When there are no edits yet for a given string, the UI will be seeded with the original election string - a DB entry for the TTS edit is only populated when the string is modified and saved in the UI.
- Edits are retrieved form the DB based on a `[election ID, original string]` primary key, meaning that if the original string is modified to a string with no associated TTS edit, the TTS editing UI defaults again to the new base string. If the base string is reverted to a previous value, the old TTS edit will essentially be re-associated with the string.
- When generating audio, we'll look up any existing TTS edits for each relevant string and use the edit as TTS input iff there's a match.

## Testing Plan
- Updated unit tests
- Manual e2e test with local prototype (edit -> save -> export -> load on VxMark)

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
