### PR TITLE
chore: remove unused election property

### DIFF
--- a/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
@@ -8,7 +8,7 @@ use image::GrayImage;
 use serde::Serialize;
 use serde_with::DeserializeFromStr;
 use types_rs::ballot_card::BallotSide;
-use types_rs::election::{BallotStyleId, Election, MetadataEncoding, PrecinctId};
+use types_rs::election::{BallotStyleId, Election, PrecinctId};
 use types_rs::geometry::PixelPosition;
 use types_rs::geometry::{PixelUnit, Size};
 use types_rs::pair::Pair;
@@ -373,11 +373,6 @@ pub fn ballot_card(
     if let Some(minimum_detected_scale) = options.minimum_detected_scale {
         ballot_card.check_minimum_scale(&timing_marks, minimum_detected_scale)?;
     }
-
-    debug_assert_eq!(
-        options.election.ballot_layout.metadata_encoding,
-        MetadataEncoding::QrCode
-    );
 
     // Find the metadata and validate it.
     let mut decoded_qr_codes = ballot_card.decode_ballot_barcodes(&options.election)?;

--- a/libs/types-rs/src/election.rs
+++ b/libs/types-rs/src/election.rs
@@ -31,7 +31,6 @@ pub struct Election {
     pub precincts: Vec<Precinct>,
     pub grid_layouts: Option<Vec<GridLayout>>,
     pub mark_thresholds: Option<MarkThresholds>,
-    pub ballot_layout: BallotLayout,
     pub contests: Vec<Contest>,
 }
 
@@ -71,18 +70,6 @@ impl Election {
             .cloned()
             .collect()
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
-pub enum MetadataEncoding {
-    QrCode,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct BallotLayout {
-    pub metadata_encoding: MetadataEncoding,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
We currently don't use this in the Rust code, so we'll just remove it for now.