### PR TITLE
Try all possible summary ballot layout densities on VxMarkScan (as opposed to just 2)

### DIFF
--- a/apps/mark-scan/backend/src/util/render_ballot.tsx
+++ b/apps/mark-scan/backend/src/util/render_ballot.tsx
@@ -18,6 +18,7 @@ import {
   BmdBallotSheetSize,
   getLayout,
   MachineType,
+  ORDERED_BMD_BALLOT_LAYOUTS,
 } from '@votingworks/ui';
 import { getPdfPageCount } from '@votingworks/image-utils';
 import { Store } from '../store';
@@ -95,9 +96,9 @@ export async function renderBallot({
   const { electionDefinition } = assertDefined(store.getElectionRecord());
   const isLiveMode = !store.getTestMode();
 
-  const maxRenderRetry = 2;
+  const maxRenderAttempts = ORDERED_BMD_BALLOT_LAYOUTS.markScan.length;
 
-  for (let i = 0; i < maxRenderRetry; i += 1) {
+  for (let i = 0; i < maxRenderAttempts; i += 1) {
     const layout = getLayout(
       MACHINE_TYPE,
       ballotStyleId,


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7328

While we have a path forward for completing VxMarkScan cert system limit testing (per https://github.com/votingworks/vxsuite/issues/7215#issuecomment-3378928411), this is just a proactive measure to reduce the odds of "Something Went Wrong" errors during other cert testing, internal testing, and demos.

I don't see much harm in trying out all the ballot layout densities that we've configured aside from renders taking a bit longer in worst-case circumstances. But that still feels a lot better than just crashing.

## Testing Plan

- [x] Updated automated tests
- [x] Tested manually

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~ N/A
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~ N/A
- [ ] ~I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~ N/A