### PR TITLE
VxDesign: Add API methods for TTS proofing/editing

### DIFF
--- a/apps/design/backend/src/store.test.ts
+++ b/apps/design/backend/src/store.test.ts
@@ -369,13 +369,3 @@ describe('tts_strings', () => {
     });
   });
 });
-
-test('getElectionData', async () => {
-  const store = testStore.getStore();
-  const election = createBlankElection('abc123');
-  await store.syncOrganizationsCache([{ id: 'vx', name: 'VotingWorks' }]);
-  await store.createElection('vx', election, 'VxDefaultBallot');
-
-  const { election: expected } = await store.getElection('abc123');
-  expect(await store.getElectionData('abc123')).toEqual(expected);
-});

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -889,11 +889,6 @@ export class Store {
     });
   }
 
-  async getElectionData(electionId: ElectionId): Promise<Election> {
-    const { election } = await this.getElection(electionId);
-    return election;
-  }
-
   async getElectionFromBallotHash(
     ballotHash: string
   ): Promise<ElectionRecord | undefined> {

--- a/apps/design/backend/src/tts_strings.test.ts
+++ b/apps/design/backend/src/tts_strings.test.ts
@@ -10,9 +10,9 @@ import {
   TtsEditKey,
 } from '@votingworks/types';
 import * as ttsStrings from './tts_strings';
-import { Store } from './store';
+import { ElectionRecord, Store } from './store';
 
-test('synthesizeText', async () => {
+test('ttsSynthesizeFromText', async () => {
   const mockSynthesizer: Mocked<SpeechSynthesizer> = {
     synthesizeSpeech: vi.fn(),
   };
@@ -27,7 +27,7 @@ test('synthesizeText', async () => {
   );
 
   const api = newApi({ speechSynthesizer: mockSynthesizer });
-  const result = await api.synthesizeText({
+  const result = await api.ttsSynthesizeFromText({
     text: 'hola',
     languageCode: 'es-US',
   });
@@ -204,14 +204,16 @@ test('ttsStringDefaults - accounts for all relevant strings', async () => {
     electionDate: [],
   };
 
-  const mockStore: Partial<Mocked<Store>> = { getElectionData: vi.fn() };
+  const mockStore: Partial<Mocked<Store>> = { getElection: vi.fn() };
   const api = newApi({ workspace: { store: mockStore } });
 
-  assert(mockStore.getElectionData);
-  mockStore.getElectionData.mockImplementationOnce((electionId) => {
+  assert(mockStore.getElection);
+  mockStore.getElection.mockImplementationOnce((electionId) => {
     expect(electionId).toEqual('abc123');
 
-    return Promise.resolve(election as Election);
+    const record: PartialDeep<ElectionRecord> = { election };
+
+    return Promise.resolve(record as ElectionRecord);
   });
 
   const result = await api.ttsStringDefaults({ electionId: 'abc123' });
@@ -238,15 +240,12 @@ test('ttsStringDefaults - new/empty election', async () => {
     title: '',
   };
 
-  const mockStore: Partial<Mocked<Store>> = { getElectionData: vi.fn() };
+  const mockStore: Partial<Mocked<Store>> = { getElection: vi.fn() };
   const api = newApi({ workspace: { store: mockStore } });
 
-  assert(mockStore.getElectionData);
-  mockStore.getElectionData.mockImplementationOnce((electionId) => {
-    expect(electionId).toEqual('abc123');
-
-    return Promise.resolve(election as Election);
-  });
+  const electionRecord: PartialDeep<ElectionRecord> = { election };
+  assert(mockStore.getElection);
+  mockStore.getElection.mockResolvedValueOnce(electionRecord as ElectionRecord);
 
   const result = await api.ttsStringDefaults({ electionId: 'abc123' });
   expect(result).toEqual([]);
@@ -274,15 +273,12 @@ test('ttsStringDefaults - spot checks for sort order', async () => {
     precincts: [],
   };
 
-  const mockStore: Partial<Mocked<Store>> = { getElectionData: vi.fn() };
+  const mockStore: Partial<Mocked<Store>> = { getElection: vi.fn() };
   const api = newApi({ workspace: { store: mockStore } });
 
-  assert(mockStore.getElectionData);
-  mockStore.getElectionData.mockImplementationOnce((electionId) => {
-    expect(electionId).toEqual('abc123');
-
-    return Promise.resolve(election as Election);
-  });
+  const electionRecord: PartialDeep<ElectionRecord> = { election };
+  assert(mockStore.getElection);
+  mockStore.getElection.mockResolvedValueOnce(electionRecord as ElectionRecord);
 
   const result = await api.ttsStringDefaults({ electionId: 'abc123' });
   expect(result).toEqual<ttsStrings.TtsStringDefault[]>([

--- a/apps/design/backend/src/tts_strings.ts
+++ b/apps/design/backend/src/tts_strings.ts
@@ -31,18 +31,6 @@ export interface TtsStringDefault {
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function apiMethods(ctx: TtsApiContext) {
   return {
-    async synthesizeText(input: {
-      text: string;
-      languageCode: string;
-    }): Promise<DataUrl> {
-      const base64Data = await ctx.speechSynthesizer.synthesizeSpeech(
-        input.text,
-        input.languageCode as LanguageCode
-      );
-
-      return `data:audio/mp3;base64,${base64Data}`;
-    },
-
     ttsEditsGet(key: TtsEditKey): Promise<TtsEdit | null> {
       return ctx.workspace.store.ttsEditsGet(key);
     },
@@ -54,7 +42,7 @@ export function apiMethods(ctx: TtsApiContext) {
     async ttsStringDefaults(input: {
       electionId: string;
     }): Promise<TtsStringDefault[]> {
-      const election = await ctx.workspace.store.getElectionData(
+      const { election } = await ctx.workspace.store.getElection(
         input.electionId
       );
 
@@ -191,7 +179,21 @@ export function apiMethods(ctx: TtsApiContext) {
         })
       );
     },
+
+    async ttsSynthesizeFromText(input: {
+      text: string;
+      languageCode: string;
+    }): Promise<DataUrl> {
+      const base64Data = await ctx.speechSynthesizer.synthesizeSpeech(
+        input.text,
+        input.languageCode as LanguageCode
+      );
+
+      return `data:audio/mp3;base64,${base64Data}`;
+    },
   } as const;
 }
 
-export const methodsThatHandleAuthThemselves = ['synthesizeText'] as const;
+export const methodsThatHandleAuthThemselves = [
+  'ttsSynthesizeFromText',
+] as const satisfies Array<keyof ReturnType<typeof apiMethods>>;


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7265

Adding:
- Basic get/set API methods for TTS edits
- Text-based speech synthesis API (no SSML-based API for now - sequencing the phonetic editor work after basic plain text editing)
- API for string defaults for all editable TTS strings (these will show up in the election string search/filter component on the audio proofing screen).

## Testing Plan
- New unit tests
- Bit of manual e2e testing with local prototype

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
