### PR TITLE
VxDesign: Remove unused audio string segmentation logic

### DIFF
--- a/libs/backend/src/language_and_audio/audio.ts
+++ b/libs/backend/src/language_and_audio/audio.ts
@@ -47,26 +47,13 @@ export function generateAudioIdsAndClips({
     stringKey: string | [string, string];
     stringInLanguage: string;
   }): void {
-    const segmentsWithAudioIds = prepareTextForSpeechSynthesis(
+    const { audioId, text } = prepareTextForSpeechSynthesis(
       languageCode,
       stringInLanguage
     );
-    setUiStringAudioIds(
-      uiStringAudioIds,
-      languageCode,
-      stringKey,
-      segmentsWithAudioIds.map(({ audioId }) => audioId)
-    );
+    setUiStringAudioIds(uiStringAudioIds, languageCode, stringKey, [audioId]);
 
-    textToSynthesizeSpeechFor.push(
-      ...segmentsWithAudioIds
-        .filter(({ segment }) => !segment.isInterpolated)
-        .map(({ audioId, segment }) => ({
-          audioId,
-          languageCode,
-          text: segment.content,
-        }))
-    );
+    textToSynthesizeSpeechFor.push({ audioId, languageCode, text });
   }
 
   // Prepare UI string audio IDs

--- a/libs/backend/src/language_and_audio/utils.test.ts
+++ b/libs/backend/src/language_and_audio/utils.test.ts
@@ -5,163 +5,40 @@ import {
   LanguageCode,
 } from '@votingworks/types';
 import {
-  cleanText,
   forEachUiString,
   prepareTextForSpeechSynthesis,
-  Segment,
   setUiString,
   setUiStringAudioIds,
-  splitInterpolatedText,
 } from './utils';
-
-test.each<{ input: string; expectedOutput: string }>([
-  {
-    input: 'Do you prefer <1>apple pie</1> or <3>orange marmalade</3>?',
-    expectedOutput: 'Do you prefer apple pie or orange marmalade?',
-  },
-  {
-    input: 'Do you prefer apple pie or orange marmalade?',
-    expectedOutput: 'Do you prefer apple pie or orange marmalade?',
-  },
-])('cleanText - $input', ({ input, expectedOutput }) => {
-  expect(cleanText(input)).toEqual(expectedOutput);
-});
-
-test.each<{ input: string; expectedOutput: Segment[] }>([
-  {
-    input: 'I see {{count1}} cats and {{count2}} dogs.',
-    expectedOutput: [
-      { content: 'I see', isInterpolated: false },
-      { content: '{{count1}}', isInterpolated: true },
-      { content: 'cats and', isInterpolated: false },
-      { content: '{{count2}}', isInterpolated: true },
-      { content: 'dogs.', isInterpolated: false },
-    ],
-  },
-  {
-    input: '{{name}} is my name',
-    expectedOutput: [
-      { content: '{{name}}', isInterpolated: true },
-      { content: 'is my name', isInterpolated: false },
-    ],
-  },
-  {
-    input: 'My name is {{name}}',
-    expectedOutput: [
-      { content: 'My name is', isInterpolated: false },
-      { content: '{{name}}', isInterpolated: true },
-    ],
-  },
-  {
-    input: 'My name is {{name}}.',
-    expectedOutput: [
-      { content: 'My name is', isInterpolated: false },
-      { content: '{{name}}', isInterpolated: true },
-    ],
-  },
-  {
-    input: 'My name is {{name}}!',
-    expectedOutput: [
-      { content: 'My name is', isInterpolated: false },
-      { content: '{{name}}', isInterpolated: true },
-    ],
-  },
-  {
-    input: 'Is your name {{name}}?',
-    expectedOutput: [
-      { content: 'Is your name', isInterpolated: false },
-      { content: '{{name}}', isInterpolated: true },
-    ],
-  },
-  {
-    input: 'Vote for {{count}}:',
-    expectedOutput: [
-      { content: 'Vote for', isInterpolated: false },
-      { content: '{{count}}', isInterpolated: true },
-    ],
-  },
-  {
-    input: 'Vote for {{count}}: ',
-    expectedOutput: [
-      { content: 'Vote for', isInterpolated: false },
-      { content: '{{count}}', isInterpolated: true },
-    ],
-  },
-  {
-    input: 'Vote for {{count}}...',
-    expectedOutput: [
-      { content: 'Vote for', isInterpolated: false },
-      { content: '{{count}}', isInterpolated: true },
-    ],
-  },
-  {
-    input: '0 {{unit}} remaining.',
-    expectedOutput: [
-      { content: '0', isInterpolated: false },
-      { content: '{{unit}}', isInterpolated: true },
-      { content: 'remaining.', isInterpolated: false },
-    ],
-  },
-  { input: ' ', expectedOutput: [] },
-  { input: "'", expectedOutput: [{ content: "'", isInterpolated: false }] },
-  { input: '"', expectedOutput: [{ content: '"', isInterpolated: false }] },
-  { input: ',', expectedOutput: [{ content: ',', isInterpolated: false }] },
-  { input: '.', expectedOutput: [{ content: '.', isInterpolated: false }] },
-  { input: '-', expectedOutput: [{ content: '-', isInterpolated: false }] },
-])('splitInterpolatedText - "$input"', ({ input, expectedOutput }) => {
-  expect(splitInterpolatedText(input)).toEqual(expectedOutput);
-});
 
 test.each<{
   languageCode: LanguageCode;
   text: string;
-  expectedOutput: Array<{ audioId: string; segment: Segment }>;
+  expectedOutput: { audioId: string; text: string };
 }>([
   {
     languageCode: LanguageCode.ENGLISH,
-    text: 'Would you rather have {{count1}} <1>apple pies</1> or {{count2}} <3>key lime pies</3>?',
-    expectedOutput: [
-      {
-        audioId: '68411c2228',
-        segment: { content: 'Would you rather have', isInterpolated: false },
-      },
-      {
-        audioId: '{{count1}}',
-        segment: { content: '{{count1}}', isInterpolated: true },
-      },
-      {
-        audioId: '44dcb41a1a',
-        segment: { content: 'apple pies or', isInterpolated: false },
-      },
-      {
-        audioId: '{{count2}}',
-        segment: { content: '{{count2}}', isInterpolated: true },
-      },
-      {
-        audioId: '3afbfe74b7',
-        segment: { content: 'key lime pies?', isInterpolated: false },
-      },
-    ],
+    text: 'Would you rather have 2 <1>apple pies</1> or 3 <3>key lime pies</3>?',
+    expectedOutput: {
+      audioId: '837829d72c',
+      text: 'Would you rather have 2 apple pies or 3 key lime pies?',
+    },
   },
   {
     languageCode: LanguageCode.ENGLISH,
     text: '1234',
-    expectedOutput: [
-      {
-        audioId: 'af14c6060f',
-        segment: { content: '1234', isInterpolated: false },
-      },
-    ],
+    expectedOutput: {
+      audioId: 'af14c6060f',
+      text: '1234',
+    },
   },
   {
     languageCode: LanguageCode.SPANISH,
     text: '1234',
-    expectedOutput: [
-      {
-        audioId: '695752ff7c',
-        segment: { content: '1234', isInterpolated: false },
-      },
-    ],
+    expectedOutput: {
+      audioId: '695752ff7c',
+      text: '1234',
+    },
   },
 ])(
   'prepareTextForSpeechSynthesis - $text in $languageCode',


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7264

We initially had a need for string interpolation in translated/TTS UI strings e.g. `You have {{count}} votes remaining`. We've since been able to work around that in all cases using a `<label>: <value>` approach to string combinations that would otherwise require interpolation.

Given that, we can safely remove the segmentation logic for now - this simplifies the user-facing TTS editing feature as well, since we don't have to support editing around placeholders for interpolated strings.

If the need comes up again for interpolation, apologies in advance to our future selves for having to deal with that.

## Testing Plan
- Updated unit tests
- Reviewed existing app/election strings
- e2e spot check: export -> configure VxMark -> tab through audio strings

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
