### PR TITLE
VxDesign: Add store method for all TTS edits in an election

### DIFF
--- a/apps/design/backend/src/store.test.ts
+++ b/apps/design/backend/src/store.test.ts
@@ -322,8 +322,8 @@ describe('tts_strings', () => {
     languageCode: 'en',
   };
 
-  async function setUpElection(store: Store) {
-    const election = createBlankElection(key.electionId);
+  async function setUpElection(store: Store, id = key.electionId) {
+    const election = createBlankElection(id);
     await store.syncOrganizationsCache([{ id: 'vx', name: 'VotingWorks' }]);
     await store.createElection('vx', election, 'VxDefaultBallot');
   }
@@ -367,5 +367,45 @@ describe('tts_strings', () => {
       ],
       text: 'one two',
     });
+  });
+
+  test('ttsStringsAll', async () => {
+    const electionId = 'election-1';
+    const electionIdOther = 'election-2';
+
+    const store = testStore.getStore();
+    await setUpElection(store, electionId);
+    await setUpElection(store, electionIdOther);
+
+    await store.ttsEditsSet(
+      { electionId, languageCode: 'en', original: 'one two' },
+      { exportSource: 'text', phonetic: [], text: 'wun too' }
+    );
+    await store.ttsEditsSet(
+      { electionId, languageCode: 'es', original: 'three four' },
+      { exportSource: 'text', phonetic: [], text: 'three foar' }
+    );
+
+    await store.ttsEditsSet(
+      { electionId: electionIdOther, languageCode: 'en', original: 'five six' },
+      { exportSource: 'text', phonetic: [], text: 'fayv six' }
+    );
+
+    await expect(store.ttsEditsAll({ electionId })).resolves.toEqual([
+      {
+        exportSource: 'text',
+        languageCode: 'en',
+        original: 'one two',
+        phonetic: [],
+        text: 'wun too',
+      },
+      {
+        exportSource: 'text',
+        languageCode: 'es',
+        original: 'three four',
+        phonetic: [],
+        text: 'three foar',
+      },
+    ]);
   });
 });

--- a/libs/types/src/tts_strings.ts
+++ b/libs/types/src/tts_strings.ts
@@ -78,3 +78,11 @@ export const TtsEditSchema: z.ZodType<TtsEdit> = z.object({
   phonetic: z.array(PhoneticWordSchema),
   text: z.string(),
 });
+
+/**
+ * TTS user edits and metadata for a language-specific string.
+ */
+export type TtsEditEntry = TtsEdit & {
+  original: string;
+  languageCode: string;
+};


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7264

Exposing a `ttsEditsAll()` store method for use in the audio export flow. These will later be used for overriding the base election strings when generating text-to-speech audio, matching on the `original` string field.

## Testing Plan
- Unit tests + e2e on local prototype

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.