### PR TITLE
VxDesign: Add feature-flag, routing for audio proofing screen

### DIFF
--- a/apps/design/backend/src/features.ts
+++ b/apps/design/backend/src/features.ts
@@ -11,7 +11,7 @@ export function isVxOrSliOrg(orgId: string): boolean {
  * differentiating between what VX support users can do and what election
  * officials can do.
  */
-enum UserFeature {
+export enum UserFeature {
   /**
    * Allow the user to access all elections across all organizations.
    */
@@ -59,6 +59,10 @@ enum UserFeature {
    * Allow for configuring the Quick Results Reporting system setting on elections.
    */
   QUICK_RESULTS_REPORTING = 'QUICK_RESULTS_REPORTING',
+  /**
+   * Enable audio-proofing UI.
+   */
+  AUDIO_PROOFING = 'AUDIO_PROOFING',
 }
 
 /**
@@ -67,7 +71,7 @@ enum UserFeature {
  * have the same functionality for these features when viewing a specific
  * election.
  */
-enum ElectionFeature {
+export enum ElectionFeature {
   /**
    * Add a field to override the election title for a precinct split.
    */
@@ -86,15 +90,14 @@ enum ElectionFeature {
   PRECINCT_SPLIT_CLERK_SIGNATURE_CAPTION_OVERRIDE = 'PRECINCT_SPLIT_CLERK_SIGNATURE_CAPTION_OVERRIDE',
 }
 
-export type UserFeaturesConfig = Record<UserFeature, boolean>;
-export type ElectionFeaturesConfig = Record<ElectionFeature, boolean>;
+export type UserFeaturesConfig = Partial<Record<UserFeature, boolean>>;
+export type ElectionFeaturesConfig = Partial<Record<ElectionFeature, boolean>>;
 
 export const userFeatureConfigs = {
   vx: {
     ACCESS_ALL_ORGS: true,
 
     BALLOT_LANGUAGE_CONFIG: true,
-    ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
 
     SYSTEM_SETTINGS_SCREEN: true,
     ENABLE_BMD_BALLOT_SCANNING_ON_VXSCAN_OPTION: true,
@@ -105,76 +108,35 @@ export const userFeatureConfigs = {
     CHOOSE_BALLOT_TEMPLATE: true,
     EXPORT_TEST_DECKS: true,
     QUICK_RESULTS_REPORTING: true,
+    AUDIO_PROOFING: true,
   },
 
   sli: {
-    ACCESS_ALL_ORGS: false,
-
     BALLOT_LANGUAGE_CONFIG: true,
-    ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
-
-    SYSTEM_SETTINGS_SCREEN: true,
-    ENABLE_BMD_BALLOT_SCANNING_ON_VXSCAN_OPTION: false,
-    BMD_OVERVOTE_ALLOW_TOGGLE: false,
-    BMD_EXTRA_PRINT_MODES: false,
-
     EXPORT_SCREEN: true,
-    CHOOSE_BALLOT_TEMPLATE: false,
-    EXPORT_TEST_DECKS: false,
-    QUICK_RESULTS_REPORTING: false,
+    SYSTEM_SETTINGS_SCREEN: true,
   },
 
   demos: {
-    ACCESS_ALL_ORGS: false,
-
     BALLOT_LANGUAGE_CONFIG: true,
-    ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
-
-    SYSTEM_SETTINGS_SCREEN: true,
-    ENABLE_BMD_BALLOT_SCANNING_ON_VXSCAN_OPTION: true,
-    BMD_OVERVOTE_ALLOW_TOGGLE: false,
-    BMD_EXTRA_PRINT_MODES: false,
-
-    EXPORT_SCREEN: true,
     CHOOSE_BALLOT_TEMPLATE: true,
+    ENABLE_BMD_BALLOT_SCANNING_ON_VXSCAN_OPTION: true,
+    EXPORT_SCREEN: true,
     EXPORT_TEST_DECKS: true,
-    QUICK_RESULTS_REPORTING: false,
+    SYSTEM_SETTINGS_SCREEN: true,
   },
 
   nh: {
-    ACCESS_ALL_ORGS: false,
-
-    BALLOT_LANGUAGE_CONFIG: false,
     ONLY_LETTER_AND_LEGAL_PAPER_SIZES: true,
-
-    SYSTEM_SETTINGS_SCREEN: false,
-    ENABLE_BMD_BALLOT_SCANNING_ON_VXSCAN_OPTION: false,
-    BMD_OVERVOTE_ALLOW_TOGGLE: false,
-    BMD_EXTRA_PRINT_MODES: false,
-
-    EXPORT_SCREEN: false,
-    CHOOSE_BALLOT_TEMPLATE: false,
-    EXPORT_TEST_DECKS: false,
-    QUICK_RESULTS_REPORTING: false,
   },
 } satisfies Record<string, UserFeaturesConfig>;
 
 export const electionFeatureConfigs = {
   // VX sandbox elections should have not have any state-specific features
   // enabled
-  vx: {
-    PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE: false,
-    PRECINCT_SPLIT_ELECTION_SEAL_OVERRIDE: false,
-    PRECINCT_SPLIT_CLERK_SIGNATURE_IMAGE_OVERRIDE: false,
-    PRECINCT_SPLIT_CLERK_SIGNATURE_CAPTION_OVERRIDE: false,
-  },
+  vx: {},
 
-  sli: {
-    PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE: false,
-    PRECINCT_SPLIT_ELECTION_SEAL_OVERRIDE: false,
-    PRECINCT_SPLIT_CLERK_SIGNATURE_IMAGE_OVERRIDE: false,
-    PRECINCT_SPLIT_CLERK_SIGNATURE_CAPTION_OVERRIDE: false,
-  },
+  sli: {},
 
   nh: {
     PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE: true,

--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -25,7 +25,12 @@ export type {
   ElectionInfo,
   AggregatedReportedResults,
 } from './types';
-export type { ElectionFeaturesConfig, UserFeaturesConfig } from './features';
+export type {
+  ElectionFeature,
+  ElectionFeaturesConfig,
+  UserFeature,
+  UserFeaturesConfig,
+} from './features';
 export type { Api, AuthErrorCode, UnauthenticatedApi } from './app';
 
 export type { BallotMode } from '@votingworks/hmpb';

--- a/apps/design/frontend/src/ballot_audio/screen.tsx
+++ b/apps/design/frontend/src/ballot_audio/screen.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import { H2 } from '@votingworks/ui';
+
+export function BallotAudioScreen(): React.ReactNode {
+  return <H2>TODO</H2>;
+}

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -38,6 +38,7 @@ import { ElectionNavScreen, Header } from './nav_screen';
 import { ElectionIdParams, electionParamRoutes, routes } from './routes';
 import { BallotScreen, paperSizeLabels } from './ballot_screen';
 import { useTitle } from './hooks/use_title';
+import { BallotAudioScreen } from './ballot_audio/screen';
 
 function BallotDesignForm({
   electionId,
@@ -457,6 +458,8 @@ export function BallotsScreen(): JSX.Element | null {
   const ballotsRoutes = routes.election(electionId).ballots;
   useTitle(routes.election(electionId).ballots.root.title);
 
+  const features = getUserFeatures.useQuery().data;
+
   return (
     <Switch>
       <Route
@@ -473,7 +476,15 @@ export function BallotsScreen(): JSX.Element | null {
           </Header>
           <MainContent>
             <RouterTabBar
-              tabs={[ballotsRoutes.ballotStyles, ballotsRoutes.ballotLayout]}
+              tabs={
+                features?.AUDIO_PROOFING
+                  ? [
+                      ballotsRoutes.ballotStyles,
+                      ballotsRoutes.ballotLayout,
+                      ballotsRoutes.audio.root,
+                    ]
+                  : [ballotsRoutes.ballotStyles, ballotsRoutes.ballotLayout]
+              }
             />
             <Switch>
               <Route
@@ -484,6 +495,24 @@ export function BallotsScreen(): JSX.Element | null {
                 path={ballotsParamRoutes.ballotLayout.path}
                 component={BallotLayoutTab}
               />
+              {features?.AUDIO_PROOFING && (
+                <Route
+                  path={
+                    ballotsParamRoutes.audio.manage(
+                      ':ttsMode',
+                      ':stringKey',
+                      ':subkey?'
+                    ).path
+                  }
+                  component={BallotAudioScreen}
+                />
+              )}
+              {features?.AUDIO_PROOFING && (
+                <Route
+                  path={ballotsParamRoutes.audio.root.path}
+                  component={BallotAudioScreen}
+                />
+              )}
               <Redirect
                 from={ballotsParamRoutes.root.path}
                 to={ballotsParamRoutes.ballotStyles.path}

--- a/apps/design/frontend/src/routes.ts
+++ b/apps/design/frontend/src/routes.ts
@@ -1,5 +1,9 @@
 import type { UserFeaturesConfig } from '@votingworks/design-backend';
-import { ElectionId, SystemSettings } from '@votingworks/types';
+import {
+  ElectionId,
+  SystemSettings,
+  TtsExportSource,
+} from '@votingworks/types';
 import { Route } from '@votingworks/ui';
 
 export const resultsRoutes = {
@@ -97,6 +101,24 @@ export const routes = {
         root: {
           title: 'Proof Ballots',
           path: `${root}/ballots`,
+        },
+        audio: {
+          root: {
+            title: 'Audio',
+            path: `${root}/ballots/audio`,
+          },
+          manage: (
+            ttsMode: TtsExportSource | ':ttsMode',
+            stringKey: string,
+            subkey?: string
+          ) => {
+            const subpath = subkey ? `/${subkey}` : '';
+
+            return {
+              title: 'Audio',
+              path: `${root}/ballots/audio/${ttsMode}/${stringKey}${subpath}`,
+            };
+          },
         },
         ballotStyles: {
           title: 'Ballot Styles',

--- a/apps/design/frontend/test/api_helpers.tsx
+++ b/apps/design/frontend/test/api_helpers.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type {
   Api,
+  ElectionFeature,
   ElectionFeaturesConfig,
   User,
+  UserFeature,
   UserFeaturesConfig,
 } from '@votingworks/design-backend';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
@@ -17,7 +19,7 @@ export function createMockApiClient(): MockApiClient {
   return createMockClient<Api>();
 }
 
-const allUserFeaturesOnConfig: UserFeaturesConfig = {
+const allUserFeaturesOnConfig: Record<UserFeature, boolean> = {
   ACCESS_ALL_ORGS: true,
   SYSTEM_SETTINGS_SCREEN: true,
   EXPORT_SCREEN: true,
@@ -29,9 +31,10 @@ const allUserFeaturesOnConfig: UserFeaturesConfig = {
   BALLOT_LANGUAGE_CONFIG: true,
   BMD_EXTRA_PRINT_MODES: true,
   QUICK_RESULTS_REPORTING: true,
+  AUDIO_PROOFING: true,
 };
 
-const allElectionFeaturesOffConfig: ElectionFeaturesConfig = {
+const allElectionFeaturesOffConfig: Record<ElectionFeature, boolean> = {
   PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE: false,
   PRECINCT_SPLIT_ELECTION_SEAL_OVERRIDE: false,
   PRECINCT_SPLIT_CLERK_SIGNATURE_IMAGE_OVERRIDE: false,


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7266

Adding feature-flagged routes for the upcoming audio proofing UI. Currently just an empty page and only enabled for Vx users.

Also moving feature flag types to an optional/off-by-default mode - was starting to get repetitive duplicating each new flag and tough to see at a glance what's enabled for each org group. Hoping this format doesn't break any assumptions not covered by tests.

## Demo Video or Screenshot

Routing pattern is pretty much the same as with the [LA demo app](https://vxdesign-la-demo-c4mujbhscnfug.herokuapp.com/)

## Testing Plan
- New unit tests 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
