### PR TITLE
design/backend: Fix flaky task progress tests

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -2360,14 +2360,19 @@ test('Election package management', async () => {
     .mock.lastCall![4]!;
   emitProgress('Test progress message', 2, 10);
 
-  const electionPackageDuringExport = await apiClient.getElectionPackage({
-    electionId,
-  });
-  expect(electionPackageDuringExport.task?.progress).toEqual({
-    label: 'Test progress message',
-    progress: 2,
-    total: 10,
-  });
+  await backendWaitFor(
+    async () => {
+      const electionPackageDuringExport = await apiClient.getElectionPackage({
+        electionId,
+      });
+      expect(electionPackageDuringExport.task?.progress).toEqual({
+        label: 'Test progress message',
+        progress: 2,
+        total: 10,
+      });
+    },
+    { interval: 500, retries: 3 }
+  );
 
   // Complete the task
   emitProgress('Test progress message', 10, 10);
@@ -2923,12 +2928,17 @@ test('Export test decks', async () => {
     expect.any(Function) // emitProgress callback
   );
 
-  const testDecksTask = await apiClient.getTestDecks({ electionId });
-  expect(testDecksTask.task!.progress).toEqual({
-    label: 'Rendering test decks',
-    progress: expect.any(Number),
-    total: testDecksTask.task!.progress!.progress,
-  });
+  await backendWaitFor(
+    async () => {
+      const testDecksTask = await apiClient.getTestDecks({ electionId });
+      expect(testDecksTask.task!.progress).toEqual({
+        label: 'Rendering test decks',
+        progress: expect.any(Number),
+        total: testDecksTask.task!.progress!.progress,
+      });
+    },
+    { interval: 500, retries: 3 }
+  );
 
   await suppressingConsoleOutput(async () => {
     // Check permissions


### PR DESCRIPTION


## Overview

Saving emitted progress to the database happens out-of-band with the task execution, so we need to wait for the progress to be saved.
## Demo Video or Screenshot

## Testing Plan
I wasn't able to repro the flakiness, so relying on @eventualbuddha's testing.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
