### PR TITLE
VxDesign: Replace election ID key with org ID key in tts_edits table

### DIFF
--- a/apps/design/backend/migrations/1760123772907_tts-edits-use-org-id-key.js
+++ b/apps/design/backend/migrations/1760123772907_tts-edits-use-org-id-key.js
@@ -1,0 +1,53 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  // The `tts_edits` table is unused at this point in time.
+  pgm.dropTable('tts_edits');
+
+  pgm.createTable(
+    'tts_edits',
+    {
+      org_id: {
+        type: 'text',
+        notNull: true,
+        onDelete: 'CASCADE',
+        references: 'organizations',
+      },
+      language_code: {
+        notNull: true,
+        type: 'text',
+      },
+      original: {
+        notNull: true,
+        type: 'text',
+      },
+      export_source: {
+        check: `export_source IN ('phonetic', 'text')`,
+        default: 'text',
+        notNull: true,
+        type: 'text',
+      },
+      phonetic: {
+        notNull: true,
+        type: 'jsonb',
+      },
+      text: {
+        notNull: true,
+        type: 'text',
+      },
+    },
+    {
+      constraints: {
+        primaryKey: ['org_id', 'language_code', 'original'],
+      },
+    }
+  );
+};

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -1982,7 +1982,7 @@ export class Store {
     );
   }
 
-  async ttsEditsAll(params: { electionId: string }): Promise<TtsEditEntry[]> {
+  async ttsEditsAll(params: { orgId: string }): Promise<TtsEditEntry[]> {
     return this.db.withClient(async (client) => {
       const res = await client.query(
         `
@@ -1993,9 +1993,9 @@ export class Store {
             phonetic,
             text
           from tts_edits
-          where election_id = $1
+          where org_id = $1
         `,
-        params.electionId
+        params.orgId
       );
 
       return res.rows.map<TtsEditEntry>((row) => ({
@@ -2018,11 +2018,11 @@ export class Store {
             text
           from tts_edits
           where
-            election_id = $1 and
+            org_id = $1 and
             language_code = $2 and
             original = $3
         `,
-        key.electionId,
+        key.orgId,
         key.languageCode,
         key.original
       );
@@ -2047,7 +2047,7 @@ export class Store {
       await client.query(
         `
             insert into tts_edits (
-              election_id,
+              org_id,
               language_code,
               original,
               export_source,
@@ -2055,12 +2055,12 @@ export class Store {
               text
             )
             values ($1, $2, $3, $4, $5, $6)
-            on conflict (election_id, language_code, original) do update set
+            on conflict (org_id, language_code, original) do update set
               export_source = EXCLUDED.export_source,
               phonetic = EXCLUDED.phonetic,
               text = EXCLUDED.text
           `,
-        key.electionId,
+        key.orgId,
         key.languageCode,
         key.original,
         data.exportSource,

--- a/apps/design/backend/src/tts_strings.test.ts
+++ b/apps/design/backend/src/tts_strings.test.ts
@@ -41,7 +41,7 @@ test('ttsEditsGet', async () => {
   };
 
   const input: TtsEditKey = {
-    electionId: 'general_election',
+    orgId: 'vx',
     languageCode: 'en',
     original: 'ratatouille',
   };
@@ -74,7 +74,7 @@ test('ttsEditsSet', async () => {
 
   const api = newApi({ workspace: { store: mockStore } });
   const input: Parameters<typeof api.ttsEditsSet>[0] = {
-    electionId: 'general_election',
+    orgId: 'nh',
     languageCode: 'en',
     original: 'ratatouille',
     data: {

--- a/libs/types/src/tts_strings.ts
+++ b/libs/types/src/tts_strings.ts
@@ -45,14 +45,14 @@ export const PhoneticWordsSchema = z.array(PhoneticWordSchema);
  * Unique key identifying user edits for a given TTS string in storage.
  */
 export interface TtsEditKey {
-  electionId: string;
   languageCode: string;
+  orgId: string;
   original: string;
 }
 
 export const TtsEditKeySchema: z.ZodType<TtsEditKey> = z.object({
-  electionId: z.string(),
   languageCode: z.string(),
+  orgId: z.string(),
   original: z.string(),
 });
 


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7264

Given that we'll be [expecting to persist TTS edits](https://votingworks.slack.com/archives/C085YT4798C/p1760115614140519) across elections for a given org, this updates the key for TTS edits to use org IDs in place of election IDs.

## Testing Plan
- Existing tests, with a couple related type updates

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
