### PR TITLE
VxAdmin: update manual tally ballot count copy

### DIFF
--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.test.tsx
@@ -152,7 +152,7 @@ test('entering initial ballot count and contest tallies', async () => {
   screen.getButton('Cancel');
   expect(screen.getButton('Save & Next')).toBeDisabled();
   userEvent.type(
-    screen.getByLabelText('Total Ballots Cast'),
+    screen.getByLabelText('Manual Tally Ballot Count'),
     mockValidResults.ballotCount.toString()
   );
   let updatedResults: Tabulation.ManualElectionResults = {
@@ -186,7 +186,7 @@ test('entering initial ballot count and contest tallies', async () => {
       contestNumber === contests.length ? 'Finish' : 'Save & Next';
     expect(screen.getButton(saveButtonLabel)).toBeEnabled();
 
-    const ballotCountInput = screen.getByLabelText('Total Ballots Cast');
+    const ballotCountInput = screen.getByLabelText('Manual Tally Ballot Count');
     expect(ballotCountInput).toHaveValue(`${mockValidResults.ballotCount}`);
     expect(ballotCountInput).toBeDisabled();
 
@@ -258,7 +258,7 @@ test('editing existing tallies', async () => {
   screen.getByText(hasTextAcrossElements(/Voting MethodPrecinct/));
 
   // Edit ballot count
-  const ballotCountInput = screen.getByLabelText('Total Ballots Cast');
+  const ballotCountInput = screen.getByLabelText('Manual Tally Ballot Count');
   expect(ballotCountInput).toHaveValue(`${mockValidResults.ballotCount}`);
   userEvent.clear(ballotCountInput);
   expect(screen.getButton('Save & Next')).toBeDisabled();
@@ -346,7 +346,7 @@ test('cannot add negative or decimal tallies', async () => {
   screen.getByText(hasTextAcrossElements(/Voting MethodAbsentee/));
 
   // Enter ballot count
-  const ballotCountInput = screen.getByLabelText('Total Ballots Cast');
+  const ballotCountInput = screen.getByLabelText('Manual Tally Ballot Count');
 
   userEvent.type(ballotCountInput, '-100');
   expect(ballotCountInput).toHaveValue('100');
@@ -528,7 +528,7 @@ test('previous/cancel button', async () => {
   await screen.findByRole('heading', { name: contests[0].title });
   userEvent.click(screen.getButton('Previous'));
 
-  await screen.findByLabelText('Total Ballots Cast');
+  await screen.findByLabelText('Manual Tally Ballot Count');
   userEvent.click(screen.getButton('Cancel'));
   await vi.waitFor(() =>
     expect(history.location.pathname).toEqual('/tally/manual')
@@ -555,7 +555,7 @@ test('overriding ballot count for a contest', async () => {
   });
 
   await screen.findByRole('heading', { name: contests[0].title });
-  let ballotCountInput = screen.getByLabelText('Total Ballots Cast');
+  let ballotCountInput = screen.getByLabelText('Manual Tally Ballot Count');
   expect(ballotCountInput).toHaveValue(`${mockValidResults.ballotCount}`);
   expect(ballotCountInput).toBeDisabled();
 
@@ -595,7 +595,7 @@ test('overriding ballot count for a contest', async () => {
   userEvent.click(screen.getButton('Previous'));
 
   await screen.findByRole('heading', { name: contests[0].title });
-  ballotCountInput = screen.getByLabelText('Total Ballots Cast');
+  ballotCountInput = screen.getByLabelText('Manual Tally Ballot Count');
   expect(ballotCountInput).toHaveValue(`${mockValidResults.ballotCount * 2}`);
   expect(ballotCountInput).toBeEnabled();
 
@@ -628,10 +628,12 @@ test('changing overall ballot count when there are overrides', async () => {
   });
   renderScreen();
 
-  const ballotCountInput = await screen.findByLabelText('Total Ballots Cast');
+  const ballotCountInput = await screen.findByLabelText(
+    'Manual Tally Ballot Count'
+  );
   expect(ballotCountInput).toHaveValue(`${mockValidResults.ballotCount}`);
   screen.getByText(
-    'Changing the total ballots cast will remove contest overrides.'
+    'Changing the manual tally ballot count will remove contest overrides.'
   );
   userEvent.clear(ballotCountInput);
   expect(screen.getButton('Save & Next')).toBeDisabled();
@@ -659,10 +661,10 @@ test('changing overall ballot count when there are overrides', async () => {
   userEvent.click(screen.getButton('Save & Next'));
 
   await screen.findByRole('heading', { name: contests[0].title });
-  expect(screen.getByLabelText('Total Ballots Cast')).toHaveValue(
+  expect(screen.getByLabelText('Manual Tally Ballot Count')).toHaveValue(
     `${mockValidResults.ballotCount + 1}`
   );
-  expect(screen.getByLabelText('Total Ballots Cast')).toBeDisabled();
+  expect(screen.getByLabelText('Manual Tally Ballot Count')).toBeDisabled();
 });
 
 test('leaving overrides as is when passing through overall ballot count without an update', async () => {
@@ -679,18 +681,20 @@ test('leaving overrides as is when passing through overall ballot count without 
   });
   renderScreen();
 
-  const ballotCountInput = await screen.findByLabelText('Total Ballots Cast');
+  const ballotCountInput = await screen.findByLabelText(
+    'Manual Tally Ballot Count'
+  );
   expect(ballotCountInput).toHaveValue(`${mockValidResults.ballotCount}`);
   screen.getByText(
-    'Changing the total ballots cast will remove contest overrides.'
+    'Changing the manual tally ballot count will remove contest overrides.'
   );
 
   // No API calls are expected since we didn't change the overall ballot count
   userEvent.click(screen.getButton('Save & Next'));
 
   await screen.findByRole('heading', { name: contests[0].title });
-  expect(screen.getByLabelText('Total Ballots Cast')).toHaveValue(
+  expect(screen.getByLabelText('Manual Tally Ballot Count')).toHaveValue(
     `${mockValidResults.ballotCount * 2}`
   );
-  expect(screen.getByLabelText('Total Ballots Cast')).toBeEnabled();
+  expect(screen.getByLabelText('Manual Tally Ballot Count')).toBeEnabled();
 });

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -531,12 +531,13 @@ function BallotCountForm({
       <TallyTaskContent>
         {hasOverrides && (
           <Callout icon="Warning" color="warning">
-            Changing the total ballots cast will remove contest overrides.
+            Changing the manual tally ballot count will remove contest
+            overrides.
           </Callout>
         )}
         <FormCard>
           <label htmlFor="ballotCount">
-            <H3>Total Ballots Cast</H3>
+            <H3>Manual Tally Ballot Count</H3>
           </label>
           <TallyInput
             autoFocus
@@ -813,7 +814,7 @@ function ContestForm({
                 style={{ fontWeight: '500' }}
               />
               <label htmlFor="numBallots">
-                <Font weight="bold">Total Ballots Cast</Font>
+                <Font weight="bold">Manual Tally Ballot Count</Font>
               </label>
               <div style={{ marginLeft: 'auto' }}>
                 {isOverridingBallotCount ? (


### PR DESCRIPTION
## Overview

Closes #7279. See https://votingworks.slack.com/archives/C044XSX6NTY/p1759249744213069.

## Demo Video or Screenshot

### Before

<img width="1536" height="960" alt="Screenshot-VxAdmin-2025-10-14T00:06:05 755Z-tbc-1" src="https://github.com/user-attachments/assets/09c11e60-6cf4-473a-b867-869ebe60a708" />
<img width="1536" height="960" alt="Screenshot-VxAdmin-2025-10-14T00:05:52 281Z-tbc-2" src="https://github.com/user-attachments/assets/d8653a41-18f6-4ae7-9f58-32042e531d3d" />
<img width="1536" height="960" alt="Screenshot-VxAdmin-2025-10-14T00:05:37 524Z-tbc-3" src="https://github.com/user-attachments/assets/424b1080-5cdc-46a9-9408-390c0b190ced" />

### After

<img width="1536" height="960" alt="Screenshot-VxAdmin-2025-10-14T00:00:10 887Z-mtbc-1" src="https://github.com/user-attachments/assets/cb94847b-a0a1-4887-97d3-3a1ba5f75652" />
<img width="1536" height="960" alt="Screenshot-VxAdmin-2025-10-14T00:00:20 348Z-mtbc-2" src="https://github.com/user-attachments/assets/b45e4ae3-1627-43e3-bab1-2c3740955e65" />
<img width="1536" height="960" alt="Screenshot-VxAdmin-2025-10-14T00:09:42 893Z-mtbc-3-redo" src="https://github.com/user-attachments/assets/9c937f82-b41c-4395-8492-a7f0382b2356" />


## Testing Plan

Updated test assertions.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
