### PR TITLE
VxDesign: Strip HTML from default contest description strings

### DIFF
--- a/apps/design/backend/src/tts_strings.test.ts
+++ b/apps/design/backend/src/tts_strings.test.ts
@@ -118,7 +118,7 @@ test('ttsStringDefaults - accounts for all relevant strings', async () => {
         yesOption: { id: 'option_yes', label: 'YES' },
       },
       {
-        description: 'Ballot measure 2 description.',
+        description: '<p>Ballot <b>measure</b> 2 description.</p>',
         id: 'contest4',
         title: 'Ballot Measure 2',
         type: 'yesno',

--- a/apps/design/backend/src/tts_strings.ts
+++ b/apps/design/backend/src/tts_strings.ts
@@ -6,7 +6,10 @@ import {
   TtsEdit,
   TtsEditKey,
 } from '@votingworks/types';
-import { SpeechSynthesizer } from '@votingworks/backend';
+import {
+  SpeechSynthesizer,
+  convertHtmlToAudioCues,
+} from '@votingworks/backend';
 import { Workspace } from './workspace';
 
 export type DataUrl = string;
@@ -135,7 +138,7 @@ export function apiMethods(ctx: TtsApiContext) {
             strings.push({
               key: ElectionStringKey.CONTEST_DESCRIPTION,
               subkey: contest.id,
-              text: contest.description,
+              text: convertHtmlToAudioCues(contest.description),
             });
 
             // NOTE: Default yes/no option labels are excluded below, since the

--- a/libs/backend/src/language_and_audio/index.ts
+++ b/libs/backend/src/language_and_audio/index.ts
@@ -4,6 +4,7 @@ export * from './ballot_strings';
 export * from './audio';
 export * from './election_strings';
 export * from './election_package_strings';
+export * from './rich_text';
 export * from './speech_synthesizer';
 export * from './test_utils';
 export * from './translator';


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7264

Stripping HTML from contest descriptions when generating TTS string defaults (which eventually get used as the `original` string key when saving `tts_edits`).

Adding a corresponding HTML-strip step to the audio generation/export flow before looking up edits for contest descriptions (this is also happening further downstream in the speech synthesizer, so this moves it up a little higher to make sure we're matching edits on the same default string.

### TODO
- Makes the `ttsStringDefaults` endpoint slower than I'd like for ballot-measure-heavy elections. Might consider breaking it up into a few `yield`ed chunks later to avoid holding up the main thread too much.

## Testing Plan
- New/updated unit tests, manual e2e

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
