### PR TITLE
VxDesign: Disallow precinct splits with the same district list

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -1049,6 +1049,49 @@ test('CRUD precincts', async () => {
     })
   ).toEqual(err('duplicate-split-name'));
 
+  // Can't create splits with the same district lists
+  expect(
+    await apiClient.createPrecinct({
+      electionId,
+      newPrecinct: {
+        id: 'precinct-3',
+        name: 'Precinct 3',
+        splits: [
+          {
+            id: 'precinct-3-split-1',
+            name: 'Split 1',
+            districtIds: [district1.id],
+          },
+          {
+            id: 'precinct-3-split-2',
+            name: 'Split 2',
+            districtIds: [district1.id],
+          },
+        ],
+      },
+    })
+  ).toEqual(err('duplicate-split-districts'));
+
+  // Can't update splits to have the same district lists
+  expect(
+    await apiClient.updatePrecinct({
+      electionId,
+      updatedPrecinct: {
+        ...updatedPrecinct2,
+        splits: [
+          {
+            ...updatedPrecinct2.splits[0],
+            districtIds: [district1.id],
+          },
+          {
+            ...updatedPrecinct2.splits[1],
+            districtIds: [district1.id],
+          },
+        ],
+      },
+    })
+  ).toEqual(err('duplicate-split-districts'));
+
   // Delete a precinct
   await apiClient.deletePrecinct({
     electionId,

--- a/apps/design/frontend/src/geography_screen.tsx
+++ b/apps/design/frontend/src/geography_screen.tsx
@@ -615,6 +615,12 @@ function PrecinctForm({
               Precinct splits must have different names.
             </Callout>
           );
+        case 'duplicate-split-districts':
+          return (
+            <Callout icon="Danger" color="danger">
+              Each precinct split must have a different set of districts.
+            </Callout>
+          );
         default: {
           /* istanbul ignore next - @preserve */
           throwIllegalValue(error);

--- a/libs/basics/src/unique.test.ts
+++ b/libs/basics/src/unique.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { unique, uniqueBy } from './unique';
+import { unique, uniqueBy, uniqueDeep } from './unique';
 
 test('unique', () => {
   expect(unique([])).toEqual([]);
@@ -24,4 +24,31 @@ test('uniqueBy', () => {
   expect(
     uniqueBy([{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'a' }], (x) => x.id)
   ).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }]);
+});
+
+test('uniqueDeep', () => {
+  expect(uniqueDeep([])).toEqual([]);
+  expect(uniqueDeep(['a'])).toEqual(['a']);
+  expect(uniqueDeep(['a', 'a'])).toEqual(['a']);
+  expect(uniqueDeep(['a', 'b', 'a'])).toEqual(['a', 'b']);
+  expect(uniqueDeep(['a', 'b', 'c'])).toEqual(['a', 'b', 'c']);
+  expect(uniqueDeep(['a', 'b', 'c', 'a', 'b', 'c'])).toEqual(['a', 'b', 'c']);
+  expect(
+    uniqueDeep([{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'a' }])
+  ).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }]);
+  expect(
+    uniqueDeep(
+      [
+        { id: 'a', other: { nested: 1 } },
+        { id: 'b', other: { nested: 2 } },
+        { id: 'c', other: { nested: 1 } },
+        { id: 'a', other: { nested: 3 } },
+      ],
+      (x) => x.other.nested
+    )
+  ).toEqual([
+    { id: 'a', other: { nested: 1 } },
+    { id: 'b', other: { nested: 2 } },
+    { id: 'a', other: { nested: 3 } },
+  ]);
 });

--- a/libs/basics/src/unique.ts
+++ b/libs/basics/src/unique.ts
@@ -1,3 +1,5 @@
+import { deepEqual } from './equality';
+
 /**
  * Returns an array with duplicate values removed.
  */
@@ -22,4 +24,23 @@ export function uniqueBy<T, U>(
     }
   }
   return result;
+}
+
+/**
+ * Returns an array with duplicate values removed, using deep equality to
+ * determine uniqueness. If a key function is provided, it is used to
+ * produce a value to compare instead of the item itself.
+ */
+export function uniqueDeep<T, U = T>(
+  array: readonly T[],
+  keyFn: (item: T) => U = (item) => item as unknown as U
+): T[] {
+  const result: Array<{ item: T; key: U }> = [];
+  for (const item of array) {
+    const key = keyFn(item);
+    if (!result.some((existing) => deepEqual(existing.key, key))) {
+      result.push({ item, key });
+    }
+  }
+  return result.map(({ item }) => item);
 }


### PR DESCRIPTION

## Overview

The point of precinct splits is to allow different combinations of districts for different areas within a precinct. If two splits have the same list of districts, there's no point in having those splits.

The ballot style generation code already assumes that this property is true and relies on that assumption to create a valid set of ballot styles.


## Demo Video or Screenshot

<img width="1312" height="733" alt="Screenshot 2025-10-14 at 4 07 25 PM" src="https://github.com/user-attachments/assets/64496512-f22f-4fd4-97cb-6bc30a765d5b" />


## Testing Plan
- Manual test
- Updated automated tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
