### PR TITLE
VxDesign: Include election org ID in ElectionInfo for client use

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -360,6 +360,7 @@ test('create/list/delete elections', async () => {
   expect(
     await apiClient.getElectionInfo({ electionId: electionId2 })
   ).toEqual<ElectionInfo>({
+    orgId: vxOrg.id,
     electionId: importedElectionNewId,
     title: election2.title,
     jurisdiction: election2.county.name,
@@ -550,6 +551,7 @@ test('update election info', async () => {
   // Default election info should be blank
   expect(await apiClient.getElectionInfo({ electionId })).toEqual<ElectionInfo>(
     {
+      orgId: nonVxUser.orgId,
       electionId,
       title: '',
       jurisdiction: '',
@@ -563,6 +565,7 @@ test('update election info', async () => {
 
   // Update election info
   const electionInfoUpdate: ElectionInfo = {
+    orgId: nonVxUser.orgId,
     electionId,
     // trim text values
     title: '   Updated Election  ',
@@ -576,6 +579,7 @@ test('update election info', async () => {
   await apiClient.updateElectionInfo(electionInfoUpdate);
   expect(await apiClient.getElectionInfo({ electionId })).toEqual<ElectionInfo>(
     {
+      orgId: nonVxUser.orgId,
       electionId,
       title: 'Updated Election',
       jurisdiction: 'New Hampshire',
@@ -596,6 +600,7 @@ test('update election info', async () => {
   // Election info should be unchanged at first
   expect(await apiClient.getElectionInfo({ electionId })).toEqual<ElectionInfo>(
     {
+      orgId: nonVxUser.orgId,
       electionId,
       title: 'Updated Election',
       jurisdiction: 'New Hampshire',
@@ -608,6 +613,7 @@ test('update election info', async () => {
   );
 
   const electionInfoUpdateWithSignature: ElectionInfo = {
+    orgId: nonVxUser.orgId,
     electionId,
     title: '   Updated Election  ',
     jurisdiction: '   New Hampshire   ',
@@ -624,6 +630,7 @@ test('update election info', async () => {
   // Signature should be included in response
   expect(await apiClient.getElectionInfo({ electionId })).toEqual<ElectionInfo>(
     {
+      orgId: nonVxUser.orgId,
       electionId,
       title: 'Updated Election',
       jurisdiction: 'New Hampshire',
@@ -646,6 +653,7 @@ test('update election info', async () => {
   // Signature should no longer be included in response
   expect(await apiClient.getElectionInfo({ electionId })).toEqual<ElectionInfo>(
     {
+      orgId: nonVxUser.orgId,
       electionId,
       title: 'Updated Election',
       jurisdiction: 'New Hampshire',
@@ -676,6 +684,7 @@ test('update election info', async () => {
     // Empty string values are rejected
     await expect(
       apiClient.updateElectionInfo({
+        orgId: nonVxUser.orgId,
         electionId,
         type: 'primary',
         title: '',
@@ -2099,6 +2108,7 @@ test('cloneElection', async () => {
   });
   expect(destElectionInfo).toEqual({
     ...srcElectionInfo,
+    orgId: anotherNonVxOrg.id,
     electionId: newElectionId,
   });
 
@@ -2819,6 +2829,7 @@ test('Election package export with VxDefaultBallot drops signature field', async
 
   // Set a signature in the election info
   await apiClient.updateElectionInfo({
+    orgId: nonVxOrg.id,
     electionId,
     title: baseElectionDefinition.election.title,
     jurisdiction: baseElectionDefinition.election.county.name,

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -411,10 +411,10 @@ export function buildApi(ctx: AppContext) {
     async getElectionInfo(input: {
       electionId: ElectionId;
     }): Promise<ElectionInfo> {
-      const { election, ballotLanguageConfigs } = await store.getElection(
-        input.electionId
-      );
+      const { election, ballotLanguageConfigs, orgId } =
+        await store.getElection(input.electionId);
       return {
+        orgId,
         electionId: election.id,
         title: election.title,
         date: election.date,

--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -90,6 +90,7 @@ export interface ElectionListing {
 }
 
 export interface ElectionInfo {
+  orgId: string;
   electionId: ElectionId;
   type: ElectionType;
   date: DateWithoutTime;

--- a/apps/design/frontend/src/election_info_screen.test.tsx
+++ b/apps/design/frontend/src/election_info_screen.test.tsx
@@ -19,7 +19,7 @@ import {
 import {
   blankElectionRecord,
   electionInfoFromElection,
-  generalElectionInfo,
+  electionInfoFromRecord,
   generalElectionRecord,
 } from '../test/fixtures';
 import { render, screen, waitFor, within } from '../test/react_testing_library';
@@ -116,7 +116,7 @@ test('edit and save election', async () => {
     .resolves(DEFAULT_SYSTEM_SETTINGS);
   apiMock.getElectionInfo
     .expectCallWith({ electionId })
-    .resolves(electionInfoFromElection(electionRecord.election));
+    .resolves(electionInfoFromRecord(electionRecord));
   apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
   apiMock.getBallotTemplate
     .expectCallWith({ electionId })
@@ -200,6 +200,7 @@ test('edit and save election', async () => {
   userEvent.click(spanishBallotLanguageCheckbox);
 
   const updatedElectionInfo: ElectionInfo = {
+    orgId: electionRecord.orgId,
     electionId,
     title: 'New Title',
     date: new DateWithoutTime('2023-09-06'),
@@ -214,7 +215,7 @@ test('edit and save election', async () => {
   apiMock.updateElectionInfo.expectCallWith(updatedElectionInfo).resolves(ok());
   apiMock.getElectionInfo
     .expectCallWith({ electionId })
-    .resolves({ ...generalElectionInfo, ...updatedElectionInfo });
+    .resolves(updatedElectionInfo);
 
   userEvent.click(screen.getByRole('button', { name: 'Save' }));
   await screen.findByRole('button', { name: 'Edit' });
@@ -230,7 +231,7 @@ test('edit and save election - nhBallotTemplate signature upload', async () => {
     .resolves(DEFAULT_SYSTEM_SETTINGS);
   apiMock.getElectionInfo
     .expectCallWith({ electionId })
-    .resolves(electionInfoFromElection(electionRecord.election));
+    .resolves(electionInfoFromRecord(electionRecord));
   apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
   apiMock.getBallotTemplate.expectCallWith({ electionId }).resolves('NhBallot');
   renderScreen(electionId);
@@ -265,6 +266,7 @@ test('edit and save election - nhBallotTemplate signature upload', async () => {
   expect(signatureCaptionInput).toHaveValue('New Signature Caption');
 
   const updatedElectionInfo: ElectionInfo = {
+    orgId: electionRecord.orgId,
     electionId,
     title: election.title,
     date: election.date,
@@ -279,7 +281,7 @@ test('edit and save election - nhBallotTemplate signature upload', async () => {
   apiMock.updateElectionInfo.expectCallWith(updatedElectionInfo).resolves(ok());
   apiMock.getElectionInfo
     .expectCallWith({ electionId })
-    .resolves({ ...generalElectionInfo, ...updatedElectionInfo });
+    .resolves(updatedElectionInfo);
 
   userEvent.click(screen.getByRole('button', { name: 'Save' }));
   await screen.findByRole('button', { name: 'Edit' });

--- a/apps/design/frontend/test/fixtures.ts
+++ b/apps/design/frontend/test/fixtures.ts
@@ -80,6 +80,7 @@ export function makeElectionRecord(
 
 export function electionInfoFromElection(election: Election): ElectionInfo {
   return {
+    orgId: `org-${election.id}`,
     electionId: election.id,
     title: election.title,
     date: election.date,
@@ -90,6 +91,13 @@ export function electionInfoFromElection(election: Election): ElectionInfo {
     signatureImage: election.signature?.image,
     signatureCaption: election.signature?.caption,
     languageCodes: [LanguageCode.ENGLISH],
+  };
+}
+
+export function electionInfoFromRecord(record: ElectionRecord): ElectionInfo {
+  return {
+    ...electionInfoFromElection(record.election),
+    orgId: record.orgId,
   };
 }
 
@@ -126,5 +134,5 @@ export function primaryElectionRecord(orgId: Id): ElectionRecord {
   );
 }
 export function generalElectionInfo(orgId: Id): ElectionInfo {
-  return electionInfoFromElection(generalElectionRecord(orgId).election);
+  return electionInfoFromRecord(generalElectionRecord(orgId));
 }


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7267

With TTS edits being [keyed on org ID](https://github.com/votingworks/vxsuite/pull/7359), having access to the election org ID in the client simplifies things a bit when saving edits - this change pipes the `orgId` from the `ElectionRecord` to the `ElectionInfo` type that's sent to the client, mirroring what we have with `ElectionListing`.

## Testing Plan
- Updated existing tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
