### PR TITLE
[eslint] Exclude function declarations from no-use-before-define rule

### DIFF
--- a/apps/design/backend/src/tts_strings.test.ts
+++ b/apps/design/backend/src/tts_strings.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
 import { expect, Mocked, test, vi } from 'vitest';
 import { SpeechSynthesizer } from '@votingworks/backend';
 import { assert } from '@votingworks/basics';

--- a/apps/mark/backend/.eslintrc.json
+++ b/apps/mark/backend/.eslintrc.json
@@ -1,10 +1,6 @@
 {
   "extends": ["plugin:vx/recommended"],
   "rules": {
-    "@typescript-eslint/no-use-before-define": [
-      "error",
-      { "functions": false }
-    ],
     // Disable JSDOC rule as code is self-documenting.
     "vx/gts-jsdoc": "off"
   }

--- a/apps/scan/backend/src/electrical_testing/server.ts
+++ b/apps/scan/backend/src/electrical_testing/server.ts
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/no-use-before-define: ["error", { "functions": false }] */
-
 import { extractErrorMessage } from '@votingworks/basics';
 import { LogEventId, Logger } from '@votingworks/logging';
 

--- a/libs/backend/src/language_and_audio/rich_text.ts
+++ b/libs/backend/src/language_and_audio/rich_text.ts
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/no-use-before-define: ["error", { "functions": false }] */
-
 import { assert, assertDefined } from '@votingworks/basics';
 import { parse as parseHtml, Node, HTMLElement } from 'node-html-parser';
 

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -159,7 +159,7 @@ export = {
     // replace some built-in rules that don't play well with TypeScript, with Typescript-aware versions
     '@typescript-eslint/no-shadow': 'error',
     'no-shadow': 'off',
-    '@typescript-eslint/no-use-before-define': 'error',
+    '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
     'no-use-before-define': 'off',
     '@typescript-eslint/no-useless-constructor': 'error',
     'no-useless-constructor': 'off',

--- a/libs/hmpb/.eslintrc.json
+++ b/libs/hmpb/.eslintrc.json
@@ -2,7 +2,6 @@
   "extends": ["plugin:vx/recommended"],
   "rules": {
     // Disable JSDOC rule as code is self-documenting.
-    "vx/gts-jsdoc": "off",
-    "@typescript-eslint/no-use-before-define": ["error", { "functions": false }]
+    "vx/gts-jsdoc": "off"
   }
 }

--- a/libs/ui/src/images/normalize.ts
+++ b/libs/ui/src/images/normalize.ts
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/no-use-before-define: ["error", { "functions": false }] */
-
 /* istanbul ignore file - [TODO] Adding browser tests in future PRs. @preserve */
 
 import { assertDefined, deferred, err, ok, Result } from '@votingworks/basics';

--- a/libs/ui/src/themes/render_with_themes.tsx
+++ b/libs/ui/src/themes/render_with_themes.tsx
@@ -1,6 +1,3 @@
-// Enable keeping main public exports at the top of the file:
-/* eslint-disable @typescript-eslint/no-use-before-define */
-
 // TODO: This file's scope has gone out of sync with its current name/location -
 // Need to break it up and/or rename/re-locate.
 


### PR DESCRIPTION
## Overview

Forgot to follow up on [this](https://github.com/votingworks/vxsuite/pull/6825#discussion_r2223925888) until I just ran into it again recently. Updating our usage of the `@typescript-eslint/no-use-before-define` rule to exclude function declarations, since those are available anywhere within their declared scope, per ES spec.

## Testing Plan
- Manual
- Also verified that our `gts_func_style` rule catches the edge case that would otherwise slip through the cracks, e.g.:
```ts
foo(); // would only fail at runtime

// violates vx/gts-func-style:
const foo = function () { 
  return "bar";
}
```

