### PR TITLE
VxScan: VXQR: Add space before send report button

### DIFF
--- a/apps/scan/frontend/src/screens/poll_worker_post_print_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_post_print_screen.tsx
@@ -145,7 +145,7 @@ export function PostPrintScreen({
           <P>
             <Button onPress={() => printSection(0)} disabled={disablePrinting}>
               Reprint {getPollsReportTitle(pollsTransitionType)}
-            </Button>
+            </Button>{' '}
             {POLLS_TRANSITIONS_WITH_REPORTS.includes(pollsTransitionType) &&
               reportQuickResultsEnabled && (
                 <Button variant="primary" onPress={onViewReportResults}>


### PR DESCRIPTION
## Overview
Was missing a space between these buttons, already there in the multi-page report case.
<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot
n/a
## Testing Plan
loaded page

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
