### PR TITLE
Split loadElection into specific method for each format

### DIFF
--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -305,92 +305,86 @@ export function buildApi(ctx: AppContext) {
       }));
     },
 
-    async loadElection(
+    async loadElectionVxf(
       input: {
-        upload: ElectionUpload;
+        electionFileContents: string;
         newId: ElectionId;
         orgId: string;
       },
       context: ApiContext
     ): Promise<Result<ElectionId, Error>> {
-      const electionResult = ((): Result<Election, Error> => {
-        switch (input.upload.format) {
-          case 'vxf': {
-            const parseResult = safeParseElection(
-              input.upload.electionFileContents
-            );
-            if (parseResult.isErr()) return parseResult;
-            const sourceElection = parseResult.ok();
-            const { districts, precincts, parties, contests } =
-              regenerateElectionIds(sourceElection);
-            // Split candidate names into first, middle, and last names, if they are
-            // not already split
-            const contestsWithSplitCandidateNames = contests.map((contest) => {
-              if (contest.type !== 'candidate') return contest;
-              return {
-                ...contest,
-                candidates: contest.candidates.map((candidate) => {
-                  if (
-                    candidate.firstName !== undefined &&
-                    candidate.middleName !== undefined &&
-                    candidate.lastName !== undefined
-                  ) {
-                    return candidate;
-                  }
-                  return {
-                    ...candidate,
-                    ...splitCandidateName(candidate.name),
-                  };
-                }),
-              };
-            });
-            const election: Election = {
-              ...sourceElection,
-              id: input.newId,
-              districts,
-              precincts,
-              parties,
-              contests: contestsWithSplitCandidateNames,
-              // Remove any existing ballot styles/grid layouts so we can generate our own
-              ballotStyles: [],
-              gridLayouts: undefined,
-              // Fill in a blank seal if none is provided
-              seal: sourceElection.seal ?? '',
-              signature: sourceElection.signature,
-            };
-            return ok(election);
-          }
-
-          case 'ms-sems': {
-            try {
-              return ok(
-                convertMsElection(
-                  input.newId,
-                  input.upload.electionFileContents,
-                  input.upload.candidateFileContents
-                )
-              );
-            } catch (error) {
-              return wrapException(error);
+      const parseResult = safeParseElection(input.electionFileContents);
+      if (parseResult.isErr()) return parseResult;
+      const sourceElection = parseResult.ok();
+      const { districts, precincts, parties, contests } =
+        regenerateElectionIds(sourceElection);
+      // Split candidate names into first, middle, and last names, if they are
+      // not already split
+      const contestsWithSplitCandidateNames = contests.map((contest) => {
+        if (contest.type !== 'candidate') return contest;
+        return {
+          ...contest,
+          candidates: contest.candidates.map((candidate) => {
+            if (
+              candidate.firstName !== undefined &&
+              candidate.middleName !== undefined &&
+              candidate.lastName !== undefined
+            ) {
+              return candidate;
             }
-          }
-
-          default: {
-            /* istanbul ignore next - @preserve */
-            return throwIllegalValue(input.upload);
-          }
-        }
-      })();
-      if (electionResult.isErr()) {
-        return electionResult;
-      }
-      const election = electionResult.ok();
+            return {
+              ...candidate,
+              ...splitCandidateName(candidate.name),
+            };
+          }),
+        };
+      });
+      const election: Election = {
+        ...sourceElection,
+        id: input.newId,
+        districts,
+        precincts,
+        parties,
+        contests: contestsWithSplitCandidateNames,
+        // Remove any existing ballot styles/grid layouts so we can generate our own
+        ballotStyles: [],
+        gridLayouts: undefined,
+        // Fill in a blank seal if none is provided
+        seal: sourceElection.seal ?? '',
+        signature: sourceElection.signature,
+      };
       await store.createElection(
         input.orgId,
         election,
         defaultBallotTemplate(election.state, context.user)
       );
       return ok(election.id);
+    },
+
+    async loadElectionMsSems(
+      input: {
+        electionFileContents: string;
+        candidateFileContents: string;
+        newId: ElectionId;
+        orgId: string;
+      },
+      context: ApiContext
+    ): Promise<Result<ElectionId, Error>> {
+      try {
+        const election = convertMsElection(
+          input.newId,
+          input.electionFileContents,
+          input.candidateFileContents
+        );
+        await store.createElection(
+          input.orgId,
+          election,
+          defaultBallotTemplate(election.state, context.user)
+        );
+        return ok(election.id);
+      } catch (error) {
+        return wrapException(error);
+      }
     },
 
     async createElection(

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -350,13 +350,38 @@ async function invalidateElectionQueries(
   ]);
 }
 
-export const loadElection = {
+export const loadElectionVxf = {
   useMutation() {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
     return useMutation(
-      (input: { upload: ElectionUpload; orgId: string }) =>
-        apiClient.loadElection({
+      (input: { electionFileContents: string; orgId: string }) =>
+        apiClient.loadElectionVxf({
+          ...input,
+          newId: generateId(),
+        }),
+      {
+        async onSuccess(result) {
+          if (result.isOk()) {
+            await queryClient.invalidateQueries(listElections.queryKey());
+          }
+        },
+      }
+    );
+  },
+} as const;
+
+export const loadElectionMsSems = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(
+      (input: {
+        electionFileContents: string;
+        candidateFileContents: string;
+        orgId: string;
+      }) =>
+        apiClient.loadElectionMsSems({
           ...input,
           newId: generateId(),
         }),


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
