### PR TITLE
VxAdmin: remove voter privacy warning for contests with all undervotes

### DIFF
--- a/apps/admin/backend/src/reports/warnings.test.ts
+++ b/apps/admin/backend/src/reports/warnings.test.ts
@@ -98,16 +98,6 @@ describe('getTallyReportWarning', () => {
       },
       {
         contestResultsSummaries: {
-          fishing: {
-            type: 'yesno',
-            ballots: 25,
-            undervotes: 25,
-          },
-        },
-        expectedContestIds: ['fishing'],
-      },
-      {
-        contestResultsSummaries: {
           'zoo-council-mammal': {
             type: 'candidate',
             ballots: 25,

--- a/apps/admin/backend/src/reports/warnings.ts
+++ b/apps/admin/backend/src/reports/warnings.ts
@@ -67,8 +67,6 @@ function contestHasAllSameVote(
 ): boolean {
   if (contestResults.ballots === 0) return false;
 
-  if (contestResults.undervotes === contestResults.ballots) return true;
-
   if (contestResults.contestType === 'yesno') {
     return (
       contestResults.yesTally === contestResults.ballots ||


### PR DESCRIPTION
## Overview

Closes #7412. We have a privacy warning on the tally report interface when a report contains all votes in a contest for a single option, as this indicates to the viewer the selections of everyone included in that report. The warning also happens when the contest is fully undervoted, although this was broken for vote-for-N contests. Because an all undervote situation seems rare and is a less clear privacy violation, I opted to remove rather than fix the warning.
