### PR TITLE
docs: fix typo `ralative` -> `relative`

### DIFF
--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -517,12 +517,12 @@ export interface GridPositionOption {
   readonly sheetNumber: number;
   readonly side: 'front' | 'back';
   /**
-   * X coordinate for the center of the bubble for this option, ralative to the
+   * X coordinate for the center of the bubble for this option, relative to the
    * timing mark grid.
    */
   readonly column: number;
   /**
-   * Y coordinate for the center of the bubble for this option, ralative to the
+   * Y coordinate for the center of the bubble for this option, relative to the
    * timing mark grid.
    */
   readonly row: number;
@@ -545,12 +545,12 @@ export interface GridPositionWriteIn {
   readonly sheetNumber: number;
   readonly side: 'front' | 'back';
   /**
-   * X coordinate for the center of the bubble for this option, ralative to the
+   * X coordinate for the center of the bubble for this option, relative to the
    * timing mark grid.
    */
   readonly column: number;
   /**
-   * Y coordinate for the center of the bubble for this option, ralative to the
+   * Y coordinate for the center of the bubble for this option, relative to the
    * timing mark grid.
    */
   readonly row: number;


### PR DESCRIPTION
My favorite ralative:

<img width="500" height="717" alt="image" src="https://github.com/user-attachments/assets/12946b36-7e32-495e-8b00-ffb5d2b08175" />
