### PR TITLE
pdi-scanner: Add locations to USB error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,6 +1174,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,13 +1309,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.16.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1510,6 +1517,34 @@ name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
+name = "locate-error"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2c1f586abae08ac352f62211724d0b48bad906e414ff7eaf149e7fb92fbe847"
+dependencies = [
+ "locate-error-core",
+ "locate-error-derive",
+]
+
+[[package]]
+name = "locate-error-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64def73bb9053df7bb10b93c7607542ded3720d641f9bf18cb9c75a274bcf9b5"
+
+[[package]]
+name = "locate-error-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd25c0d2eccb1d5f6c0b67ac30103dcd7100a7b60d81f8f47a17ebdbeed270c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "trybuild",
+]
 
 [[package]]
 name = "lock_api"
@@ -2112,6 +2147,7 @@ dependencies = [
  "csv",
  "image",
  "libc",
+ "locate-error",
  "nom",
  "nusb",
  "psutil",
@@ -2284,9 +2320,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -2681,6 +2717,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,7 +2735,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.6",
+ "indexmap 2.12.0",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -2875,7 +2920,7 @@ dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml",
+ "toml 0.8.12",
  "version-compare",
 ]
 
@@ -2884,6 +2929,12 @@ name = "target-lexicon"
 version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
+
+[[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
 
 [[package]]
 name = "tempfile"
@@ -3061,9 +3112,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.5",
+ "toml_datetime 0.6.5",
  "toml_edit 0.22.9",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+dependencies = [
+ "indexmap 2.12.0",
+ "serde_core",
+ "serde_spanned 1.0.3",
+ "toml_datetime 0.7.3",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -3076,13 +3142,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
- "toml_datetime",
+ "indexmap 2.12.0",
+ "toml_datetime 0.6.5",
  "winnow 0.5.40",
 ]
 
@@ -3092,12 +3167,27 @@ version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.12.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.5",
+ "toml_datetime 0.6.5",
  "winnow 0.6.6",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+dependencies = [
+ "winnow 0.7.13",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "tracing"
@@ -3168,6 +3258,21 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "559b6a626c0815c942ac98d434746138b4f89ddd6a1b8cbb168c6845fb3376c5"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 0.9.8",
 ]
 
 [[package]]
@@ -3589,6 +3694,12 @@ checksum = "f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "zbar-rust"

--- a/libs/pdi-scanner/Cargo.toml
+++ b/libs/pdi-scanner/Cargo.toml
@@ -45,3 +45,4 @@ tokio = { workspace = true, features = [
   "time",
   "sync",
 ] }
+locate-error = "0.1.1"

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -204,11 +204,11 @@ fn send_to_stdout(message: Message) -> color_eyre::Result<()> {
 
 fn error_to_code_and_message(error: &Error) -> (ErrorCode, Option<String>) {
     match error {
-        Error::Usb(UsbError::DeviceNotFound)
-        | Error::Usb(UsbError::NusbTransfer(nusb::transfer::TransferError::Disconnected))
-        | Error::Usb(UsbError::NusbTransfer(nusb::transfer::TransferError::Fault))
-        | Error::Usb(UsbError::NusbTransfer(nusb::transfer::TransferError::Cancelled))
-        | Error::Usb(UsbError::NusbTransfer(nusb::transfer::TransferError::Stall)) => {
+        Error::Usb(UsbError::DeviceNotFound, _)
+        | Error::Usb(UsbError::NusbTransfer(nusb::transfer::TransferError::Disconnected, _), _)
+        | Error::Usb(UsbError::NusbTransfer(nusb::transfer::TransferError::Fault, _), _)
+        | Error::Usb(UsbError::NusbTransfer(nusb::transfer::TransferError::Cancelled, _), _)
+        | Error::Usb(UsbError::NusbTransfer(nusb::transfer::TransferError::Stall, _), _) => {
             (ErrorCode::Disconnected, None)
         }
 
@@ -248,13 +248,13 @@ async fn main() -> color_eyre::Result<()> {
     };
 
     let send_error_response = |error: &Error| -> color_eyre::Result<()> {
-        tracing::error!("sending error: {error:?}");
+        tracing::error!("sending error: {error}");
         let (code, message) = error_to_code_and_message(error);
         send_response(Response::Error { code, message })
     };
 
     let send_error_event = |error: &Error| -> color_eyre::Result<()> {
-        tracing::error!("sending error event: {error:?}");
+        tracing::error!("sending error event: {error}");
         let (code, message) = error_to_code_and_message(error);
         send_event(Event::Error { code, message })
     };

--- a/libs/pdi-scanner/src/rust/scanner.rs
+++ b/libs/pdi-scanner/src/rust/scanner.rs
@@ -19,7 +19,7 @@ pub struct Scanner {
 }
 
 impl Scanner {
-    pub fn open() -> Result<Self> {
+    pub fn open() -> Result<Self, UsbError> {
         /// Vendor ID for the PDI scanner.
         const VENDOR_ID: u16 = 0x0bd7;
 
@@ -107,7 +107,7 @@ impl Scanner {
 
                     completion = in_image_data_queue.next_complete() => {
                         if completion.status.is_err() {
-                            let err = completion.status.unwrap_err();
+                            let err: UsbError = completion.status.unwrap_err().into();
                             tracing::error!("Error while polling image data endpoint: {err:?}");
                             scanner_to_host_tx.send(Err(err.into())).unwrap();
                             break;
@@ -124,7 +124,7 @@ impl Scanner {
 
                     completion = in_primary_queue.next_complete() => {
                         if completion.status.is_err() {
-                            let err = completion.status.unwrap_err();
+                            let err: UsbError = completion.status.unwrap_err().into();
                             tracing::error!("Error while polling primary IN endpoint: {err:?}");
                             scanner_to_host_tx.send(Err(err.into())).unwrap();
                             break;

--- a/libs/pdi-scanner/src/rust/types.rs
+++ b/libs/pdi-scanner/src/rust/types.rs
@@ -1,21 +1,22 @@
+use locate_error::Location;
 use tokio::sync::mpsc::error::TryRecvError;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, locate_error::Locate)]
 pub enum UsbError {
-    #[error("nusb error: {0}")]
-    Nusb(nusb::Error),
+    #[error("nusb error: {0} ({1})")]
+    Nusb(#[locate_from] nusb::Error, Location),
 
-    #[error("nusb transfer error: {0}")]
-    NusbTransfer(nusb::transfer::TransferError),
+    #[error("nusb transfer error: {0} ({1})")]
+    NusbTransfer(#[locate_from] nusb::transfer::TransferError, Location),
 
     #[error("device not found")]
     DeviceNotFound,
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, locate_error::Locate)]
 pub enum Error {
-    #[error("usb error: {0}")]
-    Usb(#[from] UsbError),
+    #[error("usb error: {0} ({1})")]
+    Usb(#[locate_from] UsbError, Location),
 
     #[error("failed to validate request: {0}")]
     ValidateRequest(String),
@@ -31,17 +32,6 @@ pub enum Error {
 
     #[error("UTF-8 error: {0}")]
     Utf8(#[from] std::str::Utf8Error),
-}
-
-impl From<nusb::Error> for Error {
-    fn from(err: nusb::Error) -> Self {
-        Self::Usb(UsbError::Nusb(err))
-    }
-}
-impl From<nusb::transfer::TransferError> for Error {
-    fn from(err: nusb::transfer::TransferError) -> Self {
-        Self::Usb(UsbError::NusbTransfer(err))
-    }
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;


### PR DESCRIPTION
## Overview

We've had a number of low-level USB error messages show up in rare cases, but haven't been able to trace them back to a specific function call because only the message is logged ([example](https://votingworks.slack.com/archives/C09MAG9NQSE/p1761149927230019?thread_ts=1761146401.576809&cid=C09MAG9NQSE)). This PR adds a location trace to USB errors so we can at least know where they originate in our codebase (though it won't be a full stack trace into any dependencies). Uses the [locate-error crate](https://crates.io/crates/locate-error).

## Demo Video or Screenshot
I changed `nusb::list_devices` to return an error with the message "test error", then ran pdictl with a `connect` command and got this output:

```
{"response":"error","code":"other","message":"usb error: nusb error: test error (libs/pdi-scanner/src/rust/scanner.rs:31:27) (libs/pdi-scanner/src/rust/lib.rs:13:23)"}
```

Here are the code points in the trace:
- [libs/pdi-scanner/src/rust/scanner.rs:31:27](https://github.com/votingworks/vxsuite/blob/jonah/pdi-scanner-error-trace/libs/pdi-scanner/src/rust/scanner.rs#L31)
- [libs/pdi-scanner/src/rust/lib.rs:13:23](https://github.com/votingworks/vxsuite/blob/jonah/pdi-scanner-error-trace/libs/pdi-scanner/src/rust/lib.rs#L13)

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
