### PR TITLE
Ensure that VxScan warnings screen can be scrolled by a PAT user when content overflows

### DIFF
--- a/apps/scan/frontend/src/components/misvote_warnings/warning_details.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/warning_details.tsx
@@ -24,6 +24,12 @@ const Container = styled.div<ContainerProps>`
   flex-direction: column;
   grid-template-columns: repeat(${(p) => p.numCardsPerRow}, 1fr);
   grid-gap: ${(p) => CONTENT_SPACING_VALUES_REM[p.theme.sizeMode]}rem;
+
+  /**
+   * Necessary to ensure that scroll buttons properly display when content overflows. Leave 40vh
+   * for other elements like the modal title and action buttons.
+   */
+  max-height: 60vh;
 `;
 
 export function WarningDetails(props: MisvoteWarningsProps): JSX.Element {

--- a/apps/scan/frontend/src/components/misvote_warnings/warning_details_modal_button.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/warning_details_modal_button.tsx
@@ -21,7 +21,9 @@ export function WarningDetailsModalButton(
       <Modal
         modalWidth={ModalWidth.Wide}
         content={
-          <WithScrollButtons>
+          // TODO: Check whether the accessible input is a tactile controller vs. a PAT and only
+          // set focusable to true when using a PAT
+          <WithScrollButtons focusable>
             <WarningDetails
               blankContests={blankContests}
               overvoteContests={overvoteContests}

--- a/apps/scan/frontend/src/screens/scan_warning_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.tsx
@@ -177,7 +177,9 @@ function MisvoteWarningScreen({
       {confirmTabulate && (
         <ConfirmModal
           content={
-            <WithScrollButtons>
+            // TODO: Check whether the accessible input is a tactile controller vs. a PAT and only
+            // set focusable to true when using a PAT
+            <WithScrollButtons focusable>
               <MisvoteWarningDetails
                 blankContests={blankContests}
                 overvoteContests={overvoteContests}

--- a/libs/ui/src/with_scroll_buttons.tsx
+++ b/libs/ui/src/with_scroll_buttons.tsx
@@ -208,6 +208,8 @@ export function WithScrollButtons(props: WithScrollButtonsProps): JSX.Element {
             });
           }}
         >
+          {/* When aria-hidden is set to false, an element remains focusable by tab navigation but
+            not by our custom accessible navigation logic */}
           <Controls aria-hidden={!focusable}>
             <Control
               disabled={!canScrollUp}


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7365

This is in response to a cert discrepancy that found that the VxScan adjudication warnings modal can't be scrolled by a PAT user. It's rare that this modal has enough content to be scrollable. But this can come up if when the text size has been set to XL and there are many contests to report on. Turns out we'd already added our PAT-accessible scroll buttons to this UI. They just weren't activating because of a CSS styling quirk.

### In action, with simulated PAT nav

https://github.com/user-attachments/assets/23bce196-0483-4c11-b5cc-e1e02045d582

### Screenshots, XL text, many contests to report on

| Before | After |
| - | - |
| <img width="1512" height="983" alt="before-0" src="https://github.com/user-attachments/assets/f26099e2-f967-4858-95ca-2f91fb3bddb5" /> | <img width="1512" height="983" alt="after-0" src="https://github.com/user-attachments/assets/9466e58b-b04b-4b68-a7b4-5461756e72e3" /> |

| Before | After |
| - | - |
| <img width="1512" height="983" alt="before-1" src="https://github.com/user-attachments/assets/9c3f134c-91b4-4bc7-9561-6a4fab5c8332" /> | <img width="1512" height="983" alt="after-1" src="https://github.com/user-attachments/assets/683dc648-efb5-41a7-b98f-7d50586a59b3" /> |

_When scroll isn't required, unchanged_

<img width="400" alt="standard" src="https://github.com/user-attachments/assets/27590908-42ee-43fd-9ba2-d3e7d35daf4a" />

## Demo Video or Screenshot

## Testing Plan

- [x] Tested manually

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.