### PR TITLE
pdi-scanner: Capture and log stack trace for USB errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,6 @@ dead_code = "deny"
 [workspace.lints.clippy]
 pedantic = { level = "deny", priority = -1 }
 unwrap_used = "deny"
+
+[profile.release.package.pdi-scanner]
+debug = "line-tables-only" # Enable stack traces

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -204,13 +204,15 @@ fn send_to_stdout(message: Message) -> color_eyre::Result<()> {
 
 fn error_to_code_and_message(error: &Error) -> (ErrorCode, Option<String>) {
     match error {
-        Error::Usb(UsbError::DeviceNotFound)
-        | Error::Usb(UsbError::NusbTransfer(nusb::transfer::TransferError::Disconnected))
-        | Error::Usb(UsbError::NusbTransfer(nusb::transfer::TransferError::Fault))
-        | Error::Usb(UsbError::NusbTransfer(nusb::transfer::TransferError::Cancelled))
-        | Error::Usb(UsbError::NusbTransfer(nusb::transfer::TransferError::Stall)) => {
-            (ErrorCode::Disconnected, None)
-        }
+        Error::Usb {
+            source:
+                UsbError::DeviceNotFound
+                | UsbError::NusbTransfer(nusb::transfer::TransferError::Disconnected)
+                | UsbError::NusbTransfer(nusb::transfer::TransferError::Fault)
+                | UsbError::NusbTransfer(nusb::transfer::TransferError::Cancelled)
+                | UsbError::NusbTransfer(nusb::transfer::TransferError::Stall),
+            ..
+        } => (ErrorCode::Disconnected, None),
 
         _ => (ErrorCode::Other, Some(error.to_string())),
     }

--- a/libs/pdi-scanner/src/ts/scanner_client.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.ts
@@ -233,7 +233,9 @@ function loggableMessage(message: PdictlMessage) {
  */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function createPdiScannerClient() {
-  const pdictl = spawn(PDICTL_PATH);
+  const pdictl = spawn(PDICTL_PATH, {
+    env: { ...process.env, RUST_BACKTRACE: '1' },
+  });
   let pdictlIsClosed = false;
 
   const listeners = new Set<Listener>();


### PR DESCRIPTION
## Overview

We've had a number of low-level USB error messages show up in rare cases, but haven't been able to trace them back to a specific function call because only the message is logged ([example](https://votingworks.slack.com/archives/C09MAG9NQSE/p1761149927230019?thread_ts=1761146401.576809&cid=C09MAG9NQSE)). This PR adds a stack trace to USB errors so we can try to track down the root cause more easily.

## Demo Video or Screenshot

I changed `nusb::list_devices` to return an error with the message "test error", then ran pdictl with a `connect` command and got this output:

```
{
  response: 'error',
  code: 'other',
  message: 'usb error: nusb error: test error\n' +
    'Backtrace:\n' +
    '   0: std::backtrace_rs::backtrace::libunwind::trace\n' +
    '             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/../../backtrace/src/backtrace/libunwind.rs:117:9\n' +
    '   1: std::backtrace_rs::backtrace::trace_unsynchronized\n' +
    '             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/../../backtrace/src/backtrace/mod.rs:66:14\n' +
    '   2: std::backtrace::Backtrace::create\n' +
    '             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/backtrace.rs:331:13\n' +
    '   3: from\n' +
    '             at ./src/rust/types.rs:44:20\n' +
    '   4: into<pdi_scanner::types::UsbError, pdi_scanner::types::Error>\n' +
    '             at /home/jonahkagan/.rustup/toolchains/stable-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/convert/mod.rs:761:9\n' +
    '   5: from\n' +
    '             at ./src/rust/types.rs:51:29\n' +
    '   6: from_residual<pdi_scanner::scanner::Scanner, std::io::error::Error, pdi_scanner::types::Error>\n' +
    '             at /home/jonahkagan/.rustup/toolchains/stable-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/result.rs:2014:27\n' +
    '   7: open\n' +
    '             at ./src/rust/scanner.rs:31:27\n' +
    '   8: connect\n' +
    '             at ./src/rust/lib.rs:13:23\n' +
    '   9: {async_block#0}\n' +
    '             at ./src/rust/main.rs:306:63\n' +
    '  10: {closure#0}<pdictl::main::{async_block_env#0}>\n' +
    '             at /home/jonahkagan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/park.rs:284:60\n' +
    '  11: with_budget<core::task::poll::Poll<core::result::Result<(), eyre::Report>>, tokio::runtime::park::{impl#4}::block_on::{closure_env#0}<pdictl::main::{async_block_env#0}>>\n' +
    '             at /home/jonahkagan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/task/coop/mod.rs:167:5\n' +
    '  12: budget<core::task::poll::Poll<core::result::Result<(), eyre::Report>>, tokio::runtime::park::{impl#4}::block_on::{closure_env#0}<pdictl::main::{async_block_env#0}>>\n' +
    '             at /home/jonahkagan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/task/coop/mod.rs:133:5\n' +
    '  13: block_on<pdictl::main::{async_block_env#0}>\n' +
    '             at /home/jonahkagan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/park.rs:284:31\n' +
    '  14: block_on<pdictl::main::{async_block_env#0}>\n' +
    '             at /home/jonahkagan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/context/blocking.rs:66:9\n' +
    '  15: {closure#0}<pdictl::main::{async_block_env#0}>\n' +
    '             at /home/jonahkagan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/scheduler/multi_thread/mod.rs:87:22\n' +
    '  16: enter_runtime<tokio::runtime::scheduler::multi_thread::{impl#0}::block_on::{closure_env#0}<pdictl::main::{async_block_env#0}>, core::result::Result<(), eyre::Report>>\n' +
    '             at /home/jonahkagan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/context/runtime.rs:65:16\n' +
    '  17: block_on<pdictl::main::{async_block_env#0}>\n' +
    '             at /home/jonahkagan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/scheduler/multi_thread/mod.rs:86:9\n' +
    '  18: block_on_inner<pdictl::main::{async_block_env#0}>\n' +
    '             at /home/jonahkagan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/runtime.rs:370:50\n' +
    '  19: block_on<pdictl::main::{async_block_env#0}>\n' +
    '             at /home/jonahkagan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/runtime/runtime.rs:342:13\n' +
    '  20: main\n' +
    '             at ./src/rust/main.rs:270:5\n' +
    '  21: call_once<fn() -> core::result::Result<(), eyre::Report>, ()>\n' +
    '             at /home/jonahkagan/.rustup/toolchains/stable-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5\n' +
    '  22: __rust_begin_short_backtrace<fn() -> core::result::Result<(), eyre::Report>, core::result::Result<(), eyre::Report>>\n' +
    '             at /home/jonahkagan/.rustup/toolchains/stable-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:152:18\n' +
    '  23: {closure#0}<core::result::Result<(), eyre::Report>>\n' +
    '             at /home/jonahkagan/.rustup/toolchains/stable-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/rt.rs:199:18\n' +
    '  24: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once\n' +
    '             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/core/src/ops/function.rs:284:13\n' +
    '  25: std::panicking::try::do_call\n' +
    '             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panicking.rs:587:40\n' +
    '  26: std::panicking::try\n' +
    '             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panicking.rs:550:19\n' +
    '  27: std::panic::catch_unwind\n' +
    '             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panic.rs:358:14\n' +
    '  28: std::rt::lang_start_internal::{{closure}}\n' +
    '             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/rt.rs:168:24\n' +
    '  29: std::panicking::try::do_call\n' +
    '             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panicking.rs:587:40\n' +
    '  30: std::panicking::try\n' +
    '             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panicking.rs:550:19\n' +
    '  31: std::panic::catch_unwind\n' +
    '             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panic.rs:358:14\n' +
    '  32: std::rt::lang_start_internal\n' +
    '             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/rt.rs:164:5\n' +
    '  33: main\n' +
    '  34: <unknown>\n' +
    '  35: __libc_start_main\n' +
    '  36: _start\n'
}
```


## Testing Plan
Manual test as described above

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
