### PR TITLE
VxPrint: Add settings screen for EM and SA

### DIFF
--- a/apps/print/backend/src/machine_config.ts
+++ b/apps/print/backend/src/machine_config.ts
@@ -1,0 +1,13 @@
+import { DEV_MACHINE_ID } from '@votingworks/types';
+import { MachineConfig } from './types';
+
+/**
+ * Returns the ID of the current machine and the version of the currently
+ * running software.
+ */
+export function getMachineConfig(): MachineConfig {
+  return {
+    machineId: process.env.VX_MACHINE_ID || DEV_MACHINE_ID,
+    codeVersion: process.env.VX_CODE_VERSION || 'dev',
+  };
+}

--- a/apps/print/backend/src/types.ts
+++ b/apps/print/backend/src/types.ts
@@ -3,3 +3,12 @@ import { EncodedBallotEntry } from '@votingworks/types';
 export interface BallotPrintEntry extends EncodedBallotEntry {
   ballotPrintId: string;
 }
+
+/**
+ * Environment variables that identify the machine and its software. Set at the
+ * machine-level rather than the at the software-level.
+ */
+export interface MachineConfig {
+  machineId: string;
+  codeVersion: string;
+}

--- a/apps/print/backend/tsconfig.json
+++ b/apps/print/backend/tsconfig.json
@@ -15,7 +15,8 @@
     "noUnusedParameters": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "noUncheckedIndexedAccess": false
+    "noUncheckedIndexedAccess": false,
+    "noPropertyAccessFromIndexSignature": false
   },
   "references": [
     { "path": "../../../libs/auth/tsconfig.build.json" },

--- a/apps/print/frontend/src/api.ts
+++ b/apps/print/frontend/src/api.ts
@@ -10,6 +10,7 @@ import {
 } from '@tanstack/react-query';
 import {
   AUTH_STATUS_POLLING_INTERVAL_MS,
+  createSystemCallApi,
   QUERY_CLIENT_DEFAULT_OPTIONS,
   USB_DRIVE_STATUS_POLLING_INTERVAL_MS,
 } from '@votingworks/ui';
@@ -135,3 +136,5 @@ export const unconfigureMachine = {
     return useMutation(apiClient.unconfigureMachine, {});
   },
 } as const;
+
+export const systemCallApi = createSystemCallApi(useApiClient);

--- a/apps/print/frontend/src/app.tsx
+++ b/apps/print/frontend/src/app.tsx
@@ -6,6 +6,7 @@ import {
   P,
   RemoveCardScreen,
   SetupCardReaderPage,
+  SystemCallContextProvider,
   UnlockMachineScreen,
 } from '@votingworks/ui';
 import { BrowserRouter } from 'react-router-dom';
@@ -29,6 +30,7 @@ import {
   getAuthStatus,
   getElectionDefinition,
   getUsbDriveStatus,
+  systemCallApi,
 } from './api';
 import { ElectionManagerApp } from './election_manager_app';
 import { UnconfiguredScreen } from './screens/unconfigured_screen';
@@ -154,9 +156,11 @@ export function App({
       >
         <ApiClientContext.Provider value={apiClient}>
           <QueryClientProvider client={queryClient}>
-            <BrowserRouter>
-              <AppRoot logger={logger} apiClient={apiClient} />
-            </BrowserRouter>
+            <SystemCallContextProvider api={systemCallApi}>
+              <BrowserRouter>
+                <AppRoot logger={logger} apiClient={apiClient} />
+              </BrowserRouter>
+            </SystemCallContextProvider>
           </QueryClientProvider>
         </ApiClientContext.Provider>
       </AppErrorBoundary>

--- a/apps/print/frontend/src/election_manager_app.tsx
+++ b/apps/print/frontend/src/election_manager_app.tsx
@@ -1,12 +1,12 @@
 import { Redirect, Route, Switch } from 'react-router-dom';
-import { Button } from '@votingworks/ui';
 import { assertDefined } from '@votingworks/basics';
 
-import { getElectionDefinition, unconfigureMachine } from './api';
+import { getElectionDefinition } from './api';
 import { ScreenWrapper } from './components/screen_wrapper';
 import { PrintScreen } from './screens/print_screen';
 import { TitleBar } from './components/title_bar';
 import { electionManagerRoutes } from './routes';
+import { SettingsScreen } from './screens/settings_screen';
 
 function ElectionManagerElectionScreen(): JSX.Element | null {
   const electionDefinitionQuery = getElectionDefinition.useQuery();
@@ -17,18 +17,6 @@ function ElectionManagerElectionScreen(): JSX.Element | null {
       <TitleBar title="Election" />
       Configured for: <strong>{election.title}</strong>
     </div>
-  );
-}
-
-function ElectionManagerSettingsScreen(): JSX.Element {
-  const unconfigureMachineMutation = unconfigureMachine.useMutation();
-  return (
-    <TitleBar
-      title="Settings"
-      actions={
-        <Button onPress={unconfigureMachineMutation.mutate}>Unconfigure</Button>
-      }
-    />
   );
 }
 
@@ -47,7 +35,7 @@ export function ElectionManagerApp(): JSX.Element {
         />
         <Route
           path={electionManagerRoutes.settings.path}
-          render={() => <ElectionManagerSettingsScreen />}
+          render={() => <SettingsScreen />}
         />
         <Redirect to={electionManagerRoutes.election.path} />
       </Switch>

--- a/apps/print/frontend/src/screens/settings_screen.tsx
+++ b/apps/print/frontend/src/screens/settings_screen.tsx
@@ -1,0 +1,74 @@
+import {
+  CurrentDateAndTime,
+  ExportLogsButton,
+  H2,
+  P,
+  SetClockButton,
+  SignedHashValidationButton,
+  UnconfigureMachineButton,
+} from '@votingworks/ui';
+import { useHistory } from 'react-router-dom';
+import styled from 'styled-components';
+
+import {
+  logOut,
+  useApiClient,
+  getElectionDefinition,
+  unconfigureMachine,
+  getUsbDriveStatus,
+} from '../api';
+import { TitleBar } from '../components/title_bar';
+
+const Content = styled.div`
+  padding: 1rem;
+`;
+
+export function SettingsScreen(): JSX.Element | null {
+  const history = useHistory();
+
+  const apiClient = useApiClient();
+  const logOutMutation = logOut.useMutation();
+
+  const unconfigureMachineMutation = unconfigureMachine.useMutation();
+  const electionDefinitionQuery = getElectionDefinition.useQuery();
+  const usbStatusQuery = getUsbDriveStatus.useQuery();
+
+  if (!electionDefinitionQuery.isSuccess || !usbStatusQuery.isSuccess) {
+    return null;
+  }
+
+  const isConfigured = electionDefinitionQuery.data !== null;
+  const usbStatus = usbStatusQuery.data;
+  async function unconfigure() {
+    try {
+      await unconfigureMachineMutation.mutateAsync();
+      history.replace('/');
+    } catch {
+      // Handled by default query client error handling
+    }
+  }
+
+  return (
+    <div>
+      <TitleBar title="Settings" />
+      <Content>
+        <H2>Election</H2>
+        <UnconfigureMachineButton
+          isMachineConfigured={isConfigured}
+          unconfigureMachine={unconfigure}
+        />
+        <H2>Logs</H2>
+        <ExportLogsButton usbDriveStatus={usbStatus} />
+        <H2>Date and Time</H2>
+        <P>
+          <CurrentDateAndTime />
+        </P>
+        <SetClockButton logOut={() => logOutMutation.mutate()}>
+          Set Date and Time
+        </SetClockButton>
+        <H2>Security</H2>
+        <SignedHashValidationButton apiClient={apiClient} />
+      </Content>
+    </div>
+  );
+}

--- a/apps/print/frontend/src/system_administrator_app.tsx
+++ b/apps/print/frontend/src/system_administrator_app.tsx
@@ -1,26 +1,8 @@
-import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
-import { Button, P } from '@votingworks/ui';
 
-import { getElectionDefinition, unconfigureMachine } from './api';
 import { ScreenWrapper } from './components/screen_wrapper';
 import { systemAdministratorRoutes } from './routes';
-
-function SystemAdministratorSettingsScreen(): JSX.Element | null {
-  const unconfigureMachineMutation = unconfigureMachine.useMutation();
-  const electionDefinitionQuery = getElectionDefinition.useQuery();
-  const electionDefinition = electionDefinitionQuery.data;
-
-  return (
-    <React.Fragment>
-      {electionDefinition ? (
-        <Button onPress={unconfigureMachineMutation.mutate}>Unconfigure</Button>
-      ) : (
-        <P>No election configured</P>
-      )}
-    </React.Fragment>
-  );
-}
+import { SettingsScreen } from './screens/settings_screen';
 
 export function SystemAdministratorApp(): JSX.Element {
   return (
@@ -28,7 +10,7 @@ export function SystemAdministratorApp(): JSX.Element {
       <Switch>
         <Route
           path={systemAdministratorRoutes.settings.path}
-          render={() => <SystemAdministratorSettingsScreen />}
+          render={() => <SettingsScreen />}
         />
         <Redirect to={systemAdministratorRoutes.settings.path} />
       </Switch>


### PR DESCRIPTION
## Overview

Adds the Settings screen and required scaffolding for EMs and SAs. The actual settings buttons still have incomplete functionality, as shown in the screen recording. 

I want to get this merged so I have the Settings visible for the demo, but I chose to cut off getting the functionality working as it was taking a bit longer than I think is worth today. 

The solutions are probably pretty straightforward given every other app has them working:
1. Save Logs - need to set the log directory, couldn't determine where this needs to be done yet
2. Set Date and Time - error saying that time is set automatically
3. SHV - no `vx-print-xxx.pem` certificates yet, so generation fails

## Demo Video or Screenshot
<img width="888" height="560" alt="Screenshot 2025-11-12 at 11 35 52 AM" src="https://github.com/user-attachments/assets/00154829-97a9-4efa-bb74-c2d874850225" />

Save Logs error - 
<img width="882" height="562" alt="Screenshot 2025-11-12 at 11 47 07 AM" src="https://github.com/user-attachments/assets/75e3b087-8a5e-4775-a30f-fc087a773ffa" />

Set Date and Time error - 
<img width="1371" height="806" alt="Screenshot 2025-11-12 at 11 47 27 AM" src="https://github.com/user-attachments/assets/fe3891f6-3259-4e22-b2cf-f6f09395b602" />

SHV error - 
<img width="1412" height="353" alt="Screenshot 2025-11-12 at 11 47 52 AM" src="https://github.com/user-attachments/assets/15592e5a-5877-477c-8f48-e38dd9447d16" />

## Testing Plan

Manual testing for now, automated tests to come

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
