### PR TITLE
VxPrint: Fix active route handling

### DIFF
--- a/apps/print/frontend/src/components/screen_wrapper.tsx
+++ b/apps/print/frontend/src/components/screen_wrapper.tsx
@@ -24,6 +24,7 @@ export function ScreenWrapper({
   const currentRoute = useRouteMatch();
   const getElectionDefinitionQuery = getElectionDefinition.useQuery();
   const electionDefinition = getElectionDefinitionQuery.data;
+
   return (
     <Screen flexDirection="row">
       <LeftNav>

--- a/apps/print/frontend/src/election_manager_app.tsx
+++ b/apps/print/frontend/src/election_manager_app.tsx
@@ -22,23 +22,33 @@ function ElectionManagerElectionScreen(): JSX.Element | null {
 
 export function ElectionManagerApp(): JSX.Element {
   return (
-    <ScreenWrapper authType="election_manager">
-      <Switch>
-        <Route
-          path={electionManagerRoutes.print.path}
-          render={() => <PrintScreen isElectionManagerAuth />}
-        />
-        <Route
-          exact
-          path={electionManagerRoutes.election.path}
-          render={() => <ElectionManagerElectionScreen />}
-        />
-        <Route
-          path={electionManagerRoutes.settings.path}
-          render={() => <SettingsScreen />}
-        />
-        <Redirect to={electionManagerRoutes.election.path} />
-      </Switch>
-    </ScreenWrapper>
+    <Switch>
+      <Route
+        path={electionManagerRoutes.print.path}
+        render={() => (
+          <ScreenWrapper authType="election_manager">
+            <PrintScreen isElectionManagerAuth />
+          </ScreenWrapper>
+        )}
+      />
+      <Route
+        exact
+        path={electionManagerRoutes.election.path}
+        render={() => (
+          <ScreenWrapper authType="election_manager">
+            <ElectionManagerElectionScreen />
+          </ScreenWrapper>
+        )}
+      />
+      <Route
+        path={electionManagerRoutes.settings.path}
+        render={() => (
+          <ScreenWrapper authType="election_manager">
+            <SettingsScreen />
+          </ScreenWrapper>
+        )}
+      />
+      <Redirect to={electionManagerRoutes.election.path} />
+    </Switch>
   );
 }

--- a/apps/print/frontend/src/poll_worker_app.tsx
+++ b/apps/print/frontend/src/poll_worker_app.tsx
@@ -5,14 +5,16 @@ import { pollWorkerRoutes } from './routes';
 
 export function PollWorkerApp(): JSX.Element {
   return (
-    <ScreenWrapper authType="poll_worker">
-      <Switch>
-        <Route
-          path={pollWorkerRoutes.print.path}
-          render={() => <PrintScreen isElectionManagerAuth={false} />}
-        />
-        <Redirect to={pollWorkerRoutes.print.path} />
-      </Switch>
-    </ScreenWrapper>
+    <Switch>
+      <Route
+        path={pollWorkerRoutes.print.path}
+        render={() => (
+          <ScreenWrapper authType="poll_worker">
+            <PrintScreen isElectionManagerAuth={false} />
+          </ScreenWrapper>
+        )}
+      />
+      <Redirect to={pollWorkerRoutes.print.path} />
+    </Switch>
   );
 }

--- a/apps/print/frontend/src/routes.ts
+++ b/apps/print/frontend/src/routes.ts
@@ -1,5 +1,4 @@
 export const systemAdministratorRoutes = {
-  election: { title: 'Election', path: '/election' },
   settings: { title: 'Settings', path: '/settings' },
 } satisfies Record<string, { title: string; path: string }>;
 

--- a/apps/print/frontend/src/system_administrator_app.tsx
+++ b/apps/print/frontend/src/system_administrator_app.tsx
@@ -6,14 +6,16 @@ import { SettingsScreen } from './screens/settings_screen';
 
 export function SystemAdministratorApp(): JSX.Element {
   return (
-    <ScreenWrapper authType="system_admin">
-      <Switch>
-        <Route
-          path={systemAdministratorRoutes.settings.path}
-          render={() => <SettingsScreen />}
-        />
-        <Redirect to={systemAdministratorRoutes.settings.path} />
-      </Switch>
-    </ScreenWrapper>
+    <Switch>
+      <Route
+        path={systemAdministratorRoutes.settings.path}
+        render={() => (
+          <ScreenWrapper authType="system_admin">
+            <SettingsScreen />
+          </ScreenWrapper>
+        )}
+      />
+      <Redirect to={systemAdministratorRoutes.settings.path} />
+    </Switch>
   );
 }


### PR DESCRIPTION
## Overview

The route handling wasn't working properly, so the left nav wasn't properly showing the active tab. This was because the `ScreenWrapper` component was wrapping the whole routing tree, so it didn't have access to the route context. Now it wraps individual screens, so it's within the routing tree and can access context. It means we have to reuse the `<ScreenWrapper>` component around each screen instead of wrapping the whole app.

## Demo Video or Screenshot

Before (no left-nav active tab) -
<img width="877" height="551" alt="Screenshot 2025-11-12 at 1 18 30 PM" src="https://github.com/user-attachments/assets/b510c090-a388-43bb-81d6-73a8fda6c1b6" />


After - 
<img width="891" height="557" alt="Screenshot 2025-11-12 at 1 18 13 PM" src="https://github.com/user-attachments/assets/9220f4c5-7f9a-4945-87ea-393b7620ae59" />

## Testing Plan

Manual testing

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
