### PR TITLE
VxMark: Add power down buttons to all worker screens

### DIFF
--- a/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/poll_worker_screen.tsx
@@ -254,7 +254,7 @@ export function PollWorkerScreen({
               })
             }
           />
-          <SectionSystem apiClient={apiClient} />
+          <SectionSystem apiClient={apiClient} includePowerButton={false} />
         </div>
       </Main>
       <EnableLiveModeModal

--- a/apps/mark/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.test.tsx
@@ -104,6 +104,13 @@ test('renders date and time settings modal', async () => {
   await screen.findByText(startDate);
 });
 
+test('renders system buttons', async () => {
+  renderScreen();
+  await screen.findByText('System');
+  screen.getByText('Power Down');
+  screen.getByText('Signed Hash Validation');
+});
+
 test('can switch the precinct', () => {
   renderScreen();
 

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -31,6 +31,7 @@ import {
 } from '@votingworks/utils';
 import { PrintMode } from '@votingworks/mark-backend';
 import styled from 'styled-components';
+import { pollWorkerComponents } from '@votingworks/mark-flow-ui';
 import {
   ejectUsbDrive,
   logOut,
@@ -39,6 +40,8 @@ import {
 } from '../api';
 import * as api from '../api';
 import { BubbleMarkCalibration } from '../components/bubble_mark_calibration';
+
+const { H6SectionSystem } = pollWorkerComponents;
 
 export interface AdminScreenProps {
   appPrecinct?: PrecinctSelection;
@@ -76,6 +79,9 @@ export function AdminScreen({
   usbDriveStatus,
 }: AdminScreenProps): JSX.Element {
   const { election } = electionDefinition;
+
+  const apiClient = api.useApiClient();
+
   const logOutMutation = logOut.useMutation();
   const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
   const setPrecinctSelectionMutation = setPrecinctSelection.useMutation();
@@ -211,6 +217,7 @@ export function AdminScreen({
           usbDriveEject={() => ejectUsbDriveMutation.mutate()}
           usbDriveIsEjecting={ejectUsbDriveMutation.isLoading}
         />
+        <H6SectionSystem apiClient={apiClient} />
       </Main>
       <ElectionInfoBar
         mode="admin"

--- a/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
@@ -95,6 +95,7 @@ test('renders PollWorkerScreen', () => {
   expect(
     screen.getByText('Ballots Printed:').parentElement!.textContent
   ).toEqual('Ballots Printed: 0');
+  screen.getByText('Power Down');
 });
 
 test('switching out of test mode on election day', () => {

--- a/apps/mark/frontend/src/pages/system_administrator_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/system_administrator_screen.test.tsx
@@ -53,6 +53,7 @@ test('SystemAdministratorScreen renders expected contents', () => {
   // These buttons are further tested in libs/ui
   screen.getByRole('button', { name: 'Unconfigure Machine' });
   screen.getByRole('button', { name: 'Save Logs' });
+  screen.getByText('Power Down');
 
   screen.getByText(election.title);
   screen.getByText(

--- a/apps/mark/frontend/src/pages/system_administrator_screen.tsx
+++ b/apps/mark/frontend/src/pages/system_administrator_screen.tsx
@@ -5,6 +5,7 @@ import {
   ElectionInfoBar,
   H3,
   Main,
+  PowerDownButton,
   Screen,
   SignedHashValidationButton,
   SystemAdministratorScreenContents,
@@ -65,6 +66,7 @@ export function SystemAdministratorScreen({
                 Diagnostics
               </Button>
               <SignedHashValidationButton apiClient={apiClient} />
+              <PowerDownButton icon="PowerOff" />
             </React.Fragment>
           }
           displayRemoveCardToLeavePrompt

--- a/apps/mark/frontend/vitest.config.ts
+++ b/apps/mark/frontend/vitest.config.ts
@@ -25,6 +25,10 @@ export default defineConfig({
         find: '@votingworks/ui',
         replacement: join(__dirname, '../../../libs/ui/src/index.ts'),
       },
+      {
+        find: '@votingworks/mark-flow-ui',
+        replacement: join(__dirname, '../../../libs/mark-flow-ui/src/index.ts'),
+      },
     ],
   },
 });

--- a/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
@@ -5,7 +5,9 @@ import {
   H2,
   H3,
   H4,
+  H6,
   P,
+  PowerDownButton,
   SignedHashValidationApiClient,
   SignedHashValidationButton,
   TestModeCallout,
@@ -122,19 +124,62 @@ export function SectionSessionStart(
   );
 }
 
-export interface SectionSystemProps {
+interface SystemButtonsProps {
   apiClient: SignedHashValidationApiClient;
+  includePowerButton?: boolean;
 }
 
+function SystemButtons({
+  apiClient,
+  includePowerButton = true,
+}: SystemButtonsProps): JSX.Element {
+  return (
+    <ButtonGrid>
+      <SignedHashValidationButton apiClient={apiClient} />
+      {includePowerButton && <PowerDownButton icon="PowerOff" />}
+    </ButtonGrid>
+  );
+}
+
+export interface SectionSystemProps {
+  apiClient: SignedHashValidationApiClient;
+  /**
+   * Whether to include the Power Down button. Defaults to true.
+   */
+  includePowerButton?: boolean;
+}
+
+/**
+ * System section with H3 heading (for poll worker screen).
+ */
 export function SectionSystem(props: SectionSystemProps): JSX.Element {
-  const { apiClient } = props;
+  const { apiClient, includePowerButton } = props;
 
   return (
     <React.Fragment>
       <H3>System</H3>
-      <ButtonGrid>
-        <SignedHashValidationButton apiClient={apiClient} />
-      </ButtonGrid>
+      <SystemButtons
+        apiClient={apiClient}
+        includePowerButton={includePowerButton}
+      />
+    </React.Fragment>
+  );
+}
+
+/**
+ * System section with H6 heading (for admin screen).
+ * Uses H6 visual styling while allowing semantic heading level to be set via `as` prop.
+ */
+export function H6SectionSystem(props: SectionSystemProps): JSX.Element {
+  const { apiClient, includePowerButton } = props;
+
+  return (
+    <React.Fragment>
+      <H6 as="h2">System</H6>
+      <SystemButtons
+        apiClient={apiClient}
+        includePowerButton={includePowerButton}
+      />
     </React.Fragment>
   );
 }


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/7051

Adds Power Down button to all of: system admin, election manager, and pollworker screens, following model in VxScan. 

<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot

<img width="580" height="994" alt="Screenshot 2025-11-12 at 2 38 53 PM" src="https://github.com/user-attachments/assets/48354cd7-1b30-4008-aaee-b12ce243b050" />
<img width="598" height="1021" alt="Screenshot 2025-11-12 at 2 14 25 PM" src="https://github.com/user-attachments/assets/3de88dba-040b-4dab-93ba-39051a7c332c" />
<img width="584" height="992" alt="Screenshot 2025-11-12 at 2 14 12 PM" src="https://github.com/user-attachments/assets/9d8e588e-59c6-43e3-bdc7-25edbf300923" />

## Testing Plan
Loaded screens.

## Checklist
- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
