### PR TITLE
VxMark: Eject usb when unconfiguring on EM screen

### DIFF
--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -329,6 +329,7 @@ test('MarkAndPrint end-to-end flow', async () => {
   await screen.findByText('Election Definition is loaded.');
 
   // Unconfigure the machine
+  apiMock.expectEjectUsbDrive();
   apiMock.expectUnconfigureMachine();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionRecord(null);
@@ -361,12 +362,12 @@ test('MarkAndPrint end-to-end flow', async () => {
 
   // Unconfigure with System Administrator card
   apiMock.setAuthStatusSystemAdministratorLoggedIn();
-  userEvent.click(await screen.findByText('Unconfigure Machine'));
-  const modal = await screen.findByRole('alertdialog');
   apiMock.expectUnconfigureMachine();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionRecord(null);
   apiMock.expectGetElectionState();
+  userEvent.click(await screen.findByText('Unconfigure Machine'));
+  const modal = await screen.findByRole('alertdialog');
   userEvent.click(
     within(modal).getByRole('button', {
       name: 'Delete All Election Data',

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -84,6 +84,16 @@ export function AdminScreen({
   const printMode = api.getPrintMode.useQuery().data;
   const setPrintMode = api.setPrintMode.useMutation().mutate;
 
+  async function unconfigureMachineAndEjectUsb() {
+    try {
+      // If there is a mounted usb, eject it so that it doesn't auto reconfigure the machine.
+      await ejectUsbDriveMutation.mutateAsync();
+      await unconfigure();
+    } catch {
+      // Handled by default query client error handling
+    }
+  }
+
   return (
     <Screen>
       <Main padded>
@@ -200,7 +210,7 @@ export function AdminScreen({
         </P>
         <UnconfigureMachineButton
           isMachineConfigured
-          unconfigureMachine={unconfigure}
+          unconfigureMachine={unconfigureMachineAndEjectUsb}
         />
         <H6 as="h2">Logs</H6>
         <ExportLogsButton usbDriveStatus={usbDriveStatus} />


### PR DESCRIPTION
## Overview
Consistently with the other VxSuite apps updates VxMark to auto-eject the usb when unconfiguring on the election manager screen. This prevents the auto-reconfigure possible issue. 
<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot
N/A

## Testing Plan
Unconfigured with usb attached, did not auto-reconfigure. Unconfigure without usb still works fine. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
