### PR TITLE
VxPrint: Update process env var usage

### DIFF
--- a/apps/print/backend/src/env.d.ts
+++ b/apps/print/backend/src/env.d.ts
@@ -3,5 +3,7 @@ declare namespace NodeJS {
   export interface ProcessEnv {
     readonly PORT?: string;
     readonly PRINT_WORKSPACE?: string;
+    readonly VX_MACHINE_ID?: string;
+    readonly VX_CODE_VERSION?: string;
   }
 }

--- a/apps/print/backend/tsconfig.json
+++ b/apps/print/backend/tsconfig.json
@@ -15,8 +15,7 @@
     "noUnusedParameters": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "noUncheckedIndexedAccess": false,
-    "noPropertyAccessFromIndexSignature": false
+    "noUncheckedIndexedAccess": false
   },
   "references": [
     { "path": "../../../libs/auth/tsconfig.build.json" },


### PR DESCRIPTION
## Overview

Follow up to [this](https://github.com/votingworks/vxsuite/pull/7504#discussion_r2524372842) PR discussion, where @kshen0 showed me the right way to get type safety for env vars :ty:

## Testing Plan

No type errors even after dropping `noPropertyAccessFromIndexSignature`

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
