### PR TITLE
VxDesign: Extract shared tooltip component from CloneElectionButton

### DIFF
--- a/apps/design/frontend/src/clone_election_button.tsx
+++ b/apps/design/frontend/src/clone_election_button.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import type { ElectionListing } from '@votingworks/design-backend';
 import * as api from './api';
 import { OrgSelect } from './org_select';
+import { Tooltip, TooltipContainer } from './tooltip';
 
 export interface CloneElectionButtonProps {
   election: ElectionListing;
@@ -15,44 +16,6 @@ export interface CloneElectionButtonProps {
 const OrgModal = styled(Modal)`
   /* Allow modal to grow with user zoom setting and cap near screen height. */
   min-height: min(40rem, 98%);
-`;
-
-const Tooltip = styled.span`
-  /*
-   * [TODO] No easy way to use theme colors for transparency, since they're
-   * defined in 'HSL' - need to bring in the 'polished' lib used in libs/ui, or
-   * create a generalized tooltip component in libs/ui.
-   */
-  background: rgba(0, 0, 0, 75%);
-  border-radius: 0.25rem;
-  bottom: calc(100% + 0.7rem);
-  box-shadow: 0.1rem 0.1rem 0.2rem 0.05rem rgba(0, 0, 0, 25%);
-  color: #fff;
-  font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
-  padding: 0.5rem 0.75rem 0.6rem;
-  position: absolute;
-  right: 0;
-  width: max-content;
-
-  &:hover {
-    /* Prevent it from sticking around when moving quickly between buttons. */
-    display: none !important;
-  }
-`;
-
-const ButtonContainer = styled.span`
-  position: relative;
-
-  ${Tooltip} {
-    display: none;
-  }
-
-  &:focus,
-  &:hover {
-    ${Tooltip} {
-      display: block;
-    }
-  }
 `;
 
 export function CloneElectionButton(
@@ -90,8 +53,10 @@ export function CloneElectionButton(
 
   return (
     <React.Fragment>
-      <ButtonContainer>
-        <Tooltip role="tooltip">{`Make a copy of ${election.title}`}</Tooltip>
+      <TooltipContainer>
+        <Tooltip alignTo="right" bold>
+          Make a copy of {election.title}
+        </Tooltip>
         <Button
           variant={variant}
           onPress={features.ACCESS_ALL_ORGS ? setModalActive : cloneElection}
@@ -101,7 +66,7 @@ export function CloneElectionButton(
         >
           <Icons.Copy />
         </Button>
-      </ButtonContainer>
+      </TooltipContainer>
       {modalActive && (
         <OrgModal
           title="Duplicate Election"

--- a/apps/design/frontend/src/tooltip.tsx
+++ b/apps/design/frontend/src/tooltip.tsx
@@ -1,0 +1,80 @@
+// [TODO] Move to libs/ui. Not quite ready for general use.
+// Limitations:
+// - Will not be visible outside the bounds of any parents with
+//   `overflow: hidden`. A React.Portal-style approach is likely better here.
+// - Placement isn't very flexible and adjusting placement based on proximity to
+//   screen/container edge is currently manual.
+// - Optimized for use on block elements; doesn't handle inline elements without
+//   additional custom styling.
+
+import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
+
+export interface TooltipProps {
+  attachTo?: TooltipAttach;
+  alignTo?: 'left' | 'right';
+  bold?: boolean;
+  opaque?: boolean;
+  textAlign?: 'left' | 'center' | 'right';
+}
+
+export type TooltipAttach = 'bottom' | 'top';
+
+const cssAttach: Record<TooltipAttach, FlattenSimpleInterpolation> = {
+  bottom: css`
+    bottom: calc(-100% - 0.25rem);
+  `,
+  top: css`
+    bottom: calc(100% + 0.25rem);
+  `,
+};
+
+export const Tooltip = styled.span.attrs({ role: 'tooltip' })<TooltipProps>`
+  background: rgba(0, 0, 0, ${(p) => (p.opaque ? 100 : 85)}%);
+  border-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
+  box-shadow: 0.1rem 0.1rem 0.2rem 0.05rem rgba(0, 0, 0, 25%);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: ${(p) =>
+    p.bold ? p.theme.sizes.fontWeight.semiBold : undefined};
+  left: ${(p) => (!p.alignTo || p.alignTo === 'left' ? 0 : undefined)};
+  line-height: 1.3;
+  max-width: 45ch;
+  padding: 0.5rem 0.75rem;
+  position: absolute;
+  text-align: ${(p) => p.textAlign || 'left'};
+  right: ${(p) => (p.alignTo === 'right' ? 0 : undefined)};
+  width: max-content;
+  z-index: 1;
+
+  ${(p) => cssAttach[p.attachTo || 'top']}
+
+  &:hover {
+    /* Prevent it from sticking around when moving quickly between buttons. */
+    display: none !important;
+  }
+`;
+
+export const tooltipContainerCss = css`
+  position: relative;
+  width: min-content;
+
+  ${Tooltip} {
+    display: none;
+  }
+
+  :hover {
+    ${Tooltip} {
+      display: block;
+    }
+  }
+
+  :focus-visible:focus-within {
+    ${Tooltip} {
+      display: block;
+    }
+  }
+`;
+
+export const TooltipContainer = styled.div`
+  ${tooltipContainerCss}
+`;


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7266

The upcoming UI changes to support in-context audio editing includes a bit of tooltip usage - splitting out the tooltip component used in the `CloneElectionButton` to a shared location (just VxDesign for now, since it's not really feature-complete) in preparation.

## Demo Video or Screenshot

**Existing:**
<img width="350"  src="https://github.com/user-attachments/assets/ebb0c475-1d68-4450-bcc6-57956d690131" />

**Upcoming:**
<img width="350"  src="https://github.com/user-attachments/assets/296ee859-c35c-4819-a2ea-e9a21ce051d8" />

## Testing Plan
- Manual

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.

