### PR TITLE
VxDesign: Add audio-enabled form inputs to link to TTS editor

### DIFF
--- a/apps/design/frontend/src/ballot_audio/input_with_audio.test.tsx
+++ b/apps/design/frontend/src/ballot_audio/input_with_audio.test.tsx
@@ -1,0 +1,88 @@
+import { expect, test, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { assert } from '@votingworks/basics';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
+import { render, screen } from '../../test/react_testing_library';
+import { InputWithAudio } from './input_with_audio';
+
+test('passes through input props', () => {
+  const onChange = vi.fn((event: React.ChangeEvent<HTMLInputElement>) => {
+    assert(event.target instanceof HTMLInputElement);
+    expect(event.target.value).toEqual('hello!');
+  });
+
+  render(
+    <InputWithAudio
+      audioScreenUrl="/audio/edit"
+      editing={false}
+      name="test_input"
+      onChange={onChange}
+      title="test_input"
+      value="hello"
+    />
+  );
+
+  const input = screen.getByRole('textbox', { name: 'test_input' });
+  expect(input).toHaveValue('hello');
+  userEvent.type(input, '!');
+  expect(onChange).toHaveBeenCalled();
+});
+
+test('omits button when editing', () => {
+  render(
+    <InputWithAudio
+      audioScreenUrl="/audio/edit"
+      editing
+      defaultValue="General Election"
+    />
+  );
+
+  const input = screen.getByRole('textbox');
+  expect(input).toHaveValue('General Election');
+  expect(screen.queryButton('Preview or Edit Audio')).not.toBeInTheDocument();
+});
+
+test('omits button when empty', () => {
+  render(
+    <InputWithAudio
+      audioScreenUrl="/audio/edit"
+      defaultValue=""
+      editing={false}
+    />
+  );
+
+  screen.getByRole('textbox');
+  expect(screen.queryButton('Preview or Edit Audio')).not.toBeInTheDocument();
+});
+
+test('audio button navigates to given href', () => {
+  const history = createMemoryHistory({ initialEntries: ['/'] });
+
+  render(
+    <Router history={history}>
+      <InputWithAudio
+        audioScreenUrl="/audio/edit"
+        defaultValue="General Election"
+        editing={false}
+      />
+    </Router>
+  );
+
+  userEvent.click(screen.getButton('Preview or Edit Audio'));
+  expect(history.location.pathname).toEqual('/audio/edit');
+});
+
+test('shows button tooltip on hover', () => {
+  render(
+    <InputWithAudio
+      audioScreenUrl="/audio/edit"
+      defaultValue="General Election"
+      editing={false}
+    />
+  );
+
+  userEvent.hover(screen.getButton('Preview or Edit Audio'));
+  screen.getByText('Preview/Edit Audio');
+});

--- a/apps/design/frontend/src/ballot_audio/input_with_audio.tsx
+++ b/apps/design/frontend/src/ballot_audio/input_with_audio.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { LinkButton } from '@votingworks/ui';
+
+import { Tooltip, TooltipContainer, TooltipProps } from '../tooltip';
+
+export type InputWithAudioProps = {
+  audioScreenUrl: string;
+  editing: boolean;
+  tooltipPlacement?: TooltipProps['attachTo'];
+} & React.InputHTMLAttributes<HTMLInputElement>;
+
+const InputWithAudioContainer = styled.div`
+  display: flex;
+  width: 100%;
+
+  > input {
+    /*
+     * Inputs have min widths set across the app at the moment. Disabling
+     * for the audio-related UI updates to support responsive UI scaling, but
+     * keeping it contained to the WIP updates for now.
+     *
+     * [TODO] Remove input min widths at the top level and rely on layout width
+     * limits instead.
+     */
+    min-width: unset !important;
+    width: 100%;
+  }
+
+  > input:not(:last-child) {
+    border-bottom-right-radius: 0;
+    border-right: 0;
+    border-top-right-radius: 0;
+  }
+`;
+
+const ButtonContainer = styled(TooltipContainer)`
+  display: flex;
+
+  > button {
+    border: ${(p) => p.theme.sizes.bordersRem.thin}rem solid
+      ${(p) => p.theme.colors.outline};
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+
+    /*
+     * Vertical padding is a no-op here.
+     * We rely on flex box stretch alignment to match button height to input
+     * height.
+    */
+    padding: 0 0.75rem;
+  }
+`;
+
+export function InputWithAudio(props: InputWithAudioProps): JSX.Element {
+  const {
+    editing,
+    audioScreenUrl: audioScreenHref,
+    tooltipPlacement,
+    ...rest
+  } = props;
+  const audioEnabled = !editing && !!(rest.value || rest.defaultValue);
+
+  return (
+    <InputWithAudioContainer>
+      <input {...rest} />
+
+      {audioEnabled && (
+        <ButtonContainer>
+          <LinkButton
+            aria-label="Preview or Edit Audio"
+            fill="transparent"
+            icon="VolumeUp"
+            to={audioScreenHref}
+            variant="primary"
+          />
+
+          <Tooltip alignTo="right" attachTo={tooltipPlacement} bold>
+            Preview/Edit Audio
+          </Tooltip>
+        </ButtonContainer>
+      )}
+    </InputWithAudioContainer>
+  );
+}

--- a/apps/design/frontend/src/ballot_audio/rich_text_editor_with_audio.test.tsx
+++ b/apps/design/frontend/src/ballot_audio/rich_text_editor_with_audio.test.tsx
@@ -1,0 +1,92 @@
+import { expect, test, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { sleep } from '@votingworks/basics';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
+import { fireEvent, render, screen } from '../../test/react_testing_library';
+import { RichTextEditorWithAudio } from './rich_text_editor_with_audio';
+
+test('passes through editor props', async () => {
+  const onChange = vi.fn((content: string) => {
+    expect(content).toEqual('<p>hello!</p>');
+  });
+
+  render(
+    <RichTextEditorWithAudio
+      audioScreenUrl="/audio/edit"
+      editing={false}
+      onChange={onChange}
+      initialHtmlContent="<p>hello</p>"
+    />
+  );
+
+  const editor = screen.getByTestId('rich-text-editor');
+  screen.getByText('hello');
+
+  fireEvent.change(editor.querySelector('.tiptap')!, {
+    target: { textContent: 'hello!' },
+  });
+  await sleep(0);
+  expect(onChange).toHaveBeenCalled();
+});
+
+test('omits button when editing', () => {
+  render(
+    <RichTextEditorWithAudio
+      audioScreenUrl="/audio/edit"
+      editing
+      initialHtmlContent="<p>Do you agree?<p>"
+      onChange={vi.fn()}
+    />
+  );
+
+  screen.getByTestId('rich-text-editor');
+  screen.getByText('Do you agree?');
+  expect(screen.queryButton('Preview or Edit Audio')).not.toBeInTheDocument();
+});
+
+test('omits button when empty', () => {
+  render(
+    <RichTextEditorWithAudio
+      audioScreenUrl="/audio/edit"
+      editing={false}
+      initialHtmlContent=""
+      onChange={vi.fn()}
+    />
+  );
+
+  screen.getByTestId('rich-text-editor');
+  expect(screen.queryButton('Preview or Edit Audio')).not.toBeInTheDocument();
+});
+
+test('audio button navigates to given href', () => {
+  const history = createMemoryHistory({ initialEntries: ['/'] });
+
+  render(
+    <Router history={history}>
+      <RichTextEditorWithAudio
+        audioScreenUrl="/audio/edit"
+        editing={false}
+        initialHtmlContent="hello"
+        onChange={vi.fn()}
+      />
+    </Router>
+  );
+
+  userEvent.click(screen.getButton('Preview or Edit Audio'));
+  expect(history.location.pathname).toEqual('/audio/edit');
+});
+
+test('shows button tooltip on hover', () => {
+  render(
+    <RichTextEditorWithAudio
+      audioScreenUrl="/audio/edit"
+      editing={false}
+      initialHtmlContent="hello"
+      onChange={vi.fn()}
+    />
+  );
+
+  userEvent.hover(screen.getButton('Preview or Edit Audio'));
+  screen.getByText('Preview/Edit Audio');
+});

--- a/apps/design/frontend/src/ballot_audio/rich_text_editor_with_audio.tsx
+++ b/apps/design/frontend/src/ballot_audio/rich_text_editor_with_audio.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { LinkButton } from '@votingworks/ui';
+
+import { RichTextEditor } from '../rich_text_editor';
+import { Tooltip, TooltipContainer, TooltipProps } from '../tooltip';
+
+export type RickTextEditorWithAudioProps = {
+  audioScreenUrl: string;
+  editing: boolean;
+  tooltipPlacement?: TooltipProps['attachTo'];
+} & React.ComponentProps<typeof RichTextEditor>;
+
+const RichTextEditorWithAudioContainer = styled.div`
+  display: flex;
+
+  > div:first-child {
+    flex-grow: 1;
+  }
+
+  > div:not(:last-child) {
+    border-bottom-right-radius: 0;
+    border-right: ${(p) => p.theme.sizes.bordersRem.thin}rem solid
+      ${(p) => p.theme.colors.outline};
+    border-top-right-radius: 0;
+  }
+
+  :has(button) {
+    > div:not(:last-child) {
+      border-bottom-right-radius: 0;
+      border-right: 0;
+      border-top-right-radius: 0;
+    }
+  }
+
+  &[aria-disabled='true'] {
+    > div:not(:last-child) {
+      border-style: dashed;
+    }
+  }
+`;
+
+const ButtonContainer = styled(TooltipContainer)`
+  border: ${(p) => p.theme.sizes.bordersRem.thin}rem solid
+    ${(p) => p.theme.colors.outline};
+  border-bottom-right-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
+  border-top-right-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
+  display: flex;
+  flex: 0;
+  flex-direction: column;
+  min-height: 100%;
+
+  > button {
+    border-bottom: ${(p) => p.theme.sizes.bordersRem.thin}rem solid
+      ${(p) => p.theme.colors.outline};
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    border-top-left-radius: 0;
+    padding: 0.75rem;
+  }
+`;
+
+export function RichTextEditorWithAudio(
+  props: RickTextEditorWithAudioProps
+): JSX.Element {
+  const {
+    editing,
+    audioScreenUrl: audioScreenHref,
+    tooltipPlacement,
+    ...rest
+  } = props;
+  const audioEnabled = !editing && !!rest.initialHtmlContent;
+
+  return (
+    <RichTextEditorWithAudioContainer aria-disabled={rest.disabled}>
+      <RichTextEditor {...rest} />
+
+      {audioEnabled && (
+        <ButtonContainer>
+          <LinkButton
+            aria-label="Preview or Edit Audio"
+            fill="transparent"
+            icon="VolumeUp"
+            to={audioScreenHref}
+            variant="primary"
+          />
+
+          <Tooltip alignTo="right" attachTo={tooltipPlacement} bold>
+            Preview/Edit Audio
+          </Tooltip>
+        </ButtonContainer>
+      )}
+    </RichTextEditorWithAudioContainer>
+  );
+}

--- a/apps/design/frontend/src/rich_text_editor.tsx
+++ b/apps/design/frontend/src/rich_text_editor.tsx
@@ -60,6 +60,10 @@ const StyledEditor = styled.div`
     ${richTextStyles}
   }
 
+  &[data-disabled='true'] {
+    cursor: not-allowed;
+  }
+
   overflow: auto;
 `;
 
@@ -117,29 +121,33 @@ const NORMALIZE_PARAMS: Readonly<images.NormalizeParams> = {
   maxWidthPx: (LETTER_PAGE_WIDTH_INCHES - 2) * PDF_PIXELS_PER_INCH,
 };
 
-function Toolbar({ editor }: { editor: Editor }) {
+function Toolbar({ disabled, editor }: { disabled?: boolean; editor: Editor }) {
   return (
     <StyledToolbar>
       <ControlGroup>
         <ControlButton
+          disabled={disabled}
           icon="Bold"
           aria-label="Bold"
           isActive={editor.isActive('bold')}
           onPress={() => editor.chain().focus().toggleBold().run()}
         />
         <ControlButton
+          disabled={disabled}
           icon="Italic"
           aria-label="Italic"
           isActive={editor.isActive('italic')}
           onPress={() => editor.chain().focus().toggleItalic().run()}
         />
         <ControlButton
+          disabled={disabled}
           icon="Underline"
           aria-label="Underline"
           isActive={editor.isActive('underline')}
           onPress={() => editor.chain().focus().toggleUnderline().run()}
         />
         <ControlButton
+          disabled={disabled}
           icon="Strikethrough"
           aria-label="Strikethrough"
           isActive={editor.isActive('strike')}
@@ -148,12 +156,14 @@ function Toolbar({ editor }: { editor: Editor }) {
       </ControlGroup>
       <ControlGroup>
         <ControlButton
+          disabled={disabled}
           icon="ListUnordered"
           aria-label="Bullet List"
           isActive={editor.isActive('bulletList')}
           onPress={() => editor.chain().focus().toggleBulletList().run()}
         />
         <ControlButton
+          disabled={disabled}
           icon="ListOrdered"
           aria-label="Number List"
           isActive={editor.isActive('orderedList')}
@@ -165,6 +175,7 @@ function Toolbar({ editor }: { editor: Editor }) {
           buttonProps={{
             fill: 'transparent',
           }}
+          disabled={disabled}
           normalizeParams={NORMALIZE_PARAMS}
           onChange={(svgImage) => {
             editor
@@ -189,6 +200,7 @@ function Toolbar({ editor }: { editor: Editor }) {
 
       <ControlGroup>
         <ControlButton
+          disabled={disabled}
           icon="Table"
           aria-label="Table"
           isActive={editor.isActive('table')}
@@ -205,6 +217,7 @@ function Toolbar({ editor }: { editor: Editor }) {
         {editor.isActive('table') && (
           <React.Fragment>
             <ControlButton
+              disabled={disabled}
               icon={
                 <React.Fragment>
                   <Icons.Add />
@@ -215,6 +228,7 @@ function Toolbar({ editor }: { editor: Editor }) {
               onPress={() => editor.chain().focus().addRowAfter().run()}
             />
             <ControlButton
+              disabled={disabled}
               icon={
                 <React.Fragment>
                   <Icons.Delete />
@@ -225,6 +239,7 @@ function Toolbar({ editor }: { editor: Editor }) {
               onPress={() => editor.chain().focus().deleteRow().run()}
             />
             <ControlButton
+              disabled={disabled}
               icon={
                 <React.Fragment>
                   <Icons.Add />
@@ -235,6 +250,7 @@ function Toolbar({ editor }: { editor: Editor }) {
               onPress={() => editor.chain().focus().addColumnAfter().run()}
             />
             <ControlButton
+              disabled={disabled}
               icon={
                 <React.Fragment>
                   <Icons.Delete />
@@ -279,15 +295,18 @@ function unwrapSingleCellTablesOnPaste(slice: Slice): Slice {
 }
 
 interface RichTextEditorProps {
+  disabled?: boolean;
   initialHtmlContent: string;
   onChange: (htmlContent: string) => void;
 }
 
 export function RichTextEditor({
+  disabled,
   initialHtmlContent,
   onChange,
 }: RichTextEditorProps): JSX.Element {
   const editor = useEditor({
+    editable: !disabled,
     extensions: [
       Document,
       Text,
@@ -326,9 +345,10 @@ export function RichTextEditor({
   return (
     <StyledEditor
       data-testid="rich-text-editor"
+      data-disabled={disabled}
       onClick={() => editor?.chain().focus().run()}
     >
-      {editor && <Toolbar editor={editor} />}
+      {editor && <Toolbar disabled={disabled} editor={editor} />}
       <EditorContent editor={editor} />
     </StyledEditor>
   );


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7266

Adding wrapper components for the text input and rich text editor  that adds a link button to the respective audio preview/edit screen (not yet implemented) when relevant - when the input is non-empty and the parent form is not in edit mode. The idea is that this will be mostly drop-in replacements for `<input>` and `<RichTextEditor>`, with additional `editing` and `audioScreenUrl` props specified.

Relatedly adding a disabled state for the rich text editor (we haven't needed it in the past, since it's only used on the `Contests` screen, which currently only opens in edit mode).

## Demo Video or Screenshot

More detailed in-context mocks available [here](https://www.figma.com/design/g5S6rv7kYH8kfEomZTzZqr/-VxDesign--In-Context-Audio-Editing?node-id=1-19&t=FnqK5R3KRCWAC5fy-0)

https://github.com/user-attachments/assets/247100ac-905a-4f00-953a-e41a8b6e3b91

<img width="1242" height="468" alt="Screenshot 2025-11-18 at 14 55 52" src="https://github.com/user-attachments/assets/49998a67-9e24-4646-ae0a-b5310c6c3943" />

## Testing Plan
- Unit tests
- Browser spot checks (Chrome, FF, Safari)

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.