### PR TITLE
VxDesign: Add fixed-viewport form styling

### DIFF
--- a/apps/design/frontend/src/form_fixed.tsx
+++ b/apps/design/frontend/src/form_fixed.tsx
@@ -1,0 +1,73 @@
+import { DesktopPalette } from '@votingworks/ui';
+import styled, { css } from 'styled-components';
+
+export const FormBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  gap: 1.5rem;
+  height: 100%;
+  overflow: auto;
+  padding: 1rem;
+
+  input[type='text'] {
+    min-width: 18rem;
+  }
+
+  .search-select {
+    min-width: 18rem;
+  }
+`;
+
+export const FormErrorContainer = styled.div`
+  margin: 0 1rem;
+  padding-bottom: 1rem;
+
+  :empty {
+    display: none;
+  }
+
+  > * {
+    max-width: calc(55ch + 2rem);
+  }
+`;
+
+export const FormFooter = styled.div`
+  border-top: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid
+    ${DesktopPalette.Gray30};
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0 1rem;
+  padding: 1rem 0;
+`;
+
+export interface FormFixedProps {
+  editing: boolean;
+}
+
+/**
+ * Removes the default "disabled" state's low-contrast styling to optimize for
+ * readability when not editing.
+ */
+const cssFormViewMode = css`
+  input,
+  .search-select > div {
+    background-color: ${(p) => p.theme.colors.background};
+    color: ${(p) => p.theme.colors.onBackground};
+  }
+`;
+
+export const FormFixed = styled.form<FormFixedProps>`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+
+  input:disabled {
+    cursor: not-allowed;
+  }
+
+  ${(p) => !p.editing && cssFormViewMode}
+`;


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7266

*Easier to review with whitespace ignored*

Adding a `FormFixed` component alternative to `Form` which supports a fixed footer and a scrollable body. This is in preparation for the [wider upcoming UI changes](https://www.figma.com/design/g5S6rv7kYH8kfEomZTzZqr/-VxDesign--In-Context-Audio-Editing?node-id=1-19&t=NkYaRJszskC4175m-0) to add audio editing to the existing content editing screens, where we're moving to a consistent footer location for the form buttons.

Only retrofitting the `ElectionInfoScreen` for now, since the other screens will have more involved changes to support audio editing. Tangentially updating the election info form to disable fields when a save is in progress. 

## Demo Video or Screenshot

https://github.com/user-attachments/assets/04124a1d-0e09-445c-9a1d-c5299979a860

Also pinning the form error to the bottom, above the footer. Considering finding a new home for it, since it looks a little odd when scrolling, but leaving as is for now:

<img width="617" height="383" alt="vxdesign-fixed-footer-form-error" src="https://github.com/user-attachments/assets/1148dfd6-d3d2-42d8-b9eb-0ca2a81ec6e6" />

## Testing Plan
- Manual - visual changes only (will backfill tests for the disabled-while-saving state later)

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
