### PR TITLE
VxDesign: Add TTS plain text editor shared component

### DIFF
--- a/apps/design/frontend/src/ballot_audio/tts_text_editor.test.tsx
+++ b/apps/design/frontend/src/ballot_audio/tts_text_editor.test.tsx
@@ -1,0 +1,236 @@
+import React from 'react';
+import { expect, test } from 'vitest';
+
+import userEvent from '@testing-library/user-event';
+import { deferred, sleep } from '@votingworks/basics';
+import { TtsEdit } from '@votingworks/types';
+
+import { act, render, screen, waitFor } from '../../test/react_testing_library';
+import { TtsTextEditor } from './tts_text_editor';
+import {
+  createMockApiClient,
+  MockApiClient,
+  provideApi,
+} from '../../test/api_helpers';
+
+const orgId = 'org-1';
+const languageCode = 'en';
+
+test('renders TTS defaults if no edits exist', async () => {
+  const original = 'CA';
+  const mockAudio = 'audioData';
+
+  const mockApi = createMockApiClient();
+  mockApi.ttsEditsGet
+    .expectCallWith({ orgId, languageCode, original })
+    .resolves(null);
+
+  mockApi.ttsSynthesizeFromText
+    .expectCallWith({ languageCode, text: original })
+    .resolves(mockAudio);
+
+  const { container } = renderEditor(
+    mockApi,
+    <TtsTextEditor
+      languageCode={languageCode}
+      orgId={orgId}
+      original={original}
+    />
+  );
+
+  await screen.findByText(/edit the text below/i);
+  mockApi.assertComplete();
+
+  expect(screen.getByRole('textbox')).toHaveValue('CA');
+  expectAudioPlayerData(container, mockAudio);
+});
+
+test('renders saved edits if available', async () => {
+  const original = 'CA';
+  const savedEdit: TtsEdit = {
+    exportSource: 'text',
+    phonetic: [],
+    text: 'California',
+  };
+
+  const mockApi = createMockApiClient();
+  mockApi.ttsEditsGet
+    .expectCallWith({ orgId, languageCode, original })
+    .resolves(savedEdit);
+
+  const mockAudio = 'audioData';
+  mockApi.ttsSynthesizeFromText
+    .expectCallWith({ languageCode, text: savedEdit.text })
+    .resolves(mockAudio);
+
+  const { container } = renderEditor(
+    mockApi,
+    <TtsTextEditor
+      languageCode={languageCode}
+      orgId={orgId}
+      original={original}
+    />
+  );
+
+  await screen.findByText(/edit the text below/i);
+  mockApi.assertComplete();
+
+  expect(screen.getByRole('textbox')).toHaveValue('California');
+  expectAudioPlayerData(container, mockAudio);
+});
+
+test('enables save and reset button when applicable', async () => {
+  const mockApi = createMockApiClient();
+  mockApi.ttsEditsGet
+    .expectCallWith({ orgId, languageCode, original: 'CA' })
+    .resolves(null);
+
+  mockApi.ttsSynthesizeFromText
+    .expectCallWith({ languageCode, text: 'CA' })
+    .resolves('audioData');
+
+  renderEditor(
+    mockApi,
+    <TtsTextEditor languageCode={languageCode} orgId={orgId} original="CA" />
+  );
+
+  await screen.findByText(/edit the text below/i);
+  mockApi.assertComplete();
+
+  expect(screen.getByRole('textbox')).toHaveValue('CA');
+  expect(screen.getButton(/save/i)).toBeDisabled();
+  expect(screen.getButton(/reset/i)).toBeDisabled();
+
+  userEvent.type(screen.getByRole('textbox'), 'li');
+  expect(screen.getByRole('textbox')).toHaveValue('CAli');
+  expect(screen.getButton(/save/i)).toBeEnabled();
+  expect(screen.getButton(/reset/i)).toBeEnabled();
+
+  userEvent.clear(screen.getByRole('textbox'));
+  expect(screen.getByRole('textbox')).toHaveValue('');
+  expect(screen.getButton(/save/i)).toBeDisabled();
+  expect(screen.getButton(/reset/i)).toBeEnabled();
+});
+
+test('reset button restores saved state', async () => {
+  const original = 'CA';
+  const savedEdit: TtsEdit = {
+    exportSource: 'text',
+    phonetic: [],
+    text: 'California',
+  };
+
+  const mockApi = createMockApiClient();
+  mockApi.ttsEditsGet
+    .expectCallWith({ orgId, languageCode, original })
+    .resolves(savedEdit);
+
+  mockApi.ttsSynthesizeFromText
+    .expectCallWith({ languageCode, text: savedEdit.text })
+    .resolves('audioData');
+
+  renderEditor(
+    mockApi,
+    <TtsTextEditor
+      languageCode={languageCode}
+      orgId={orgId}
+      original={original}
+    />
+  );
+
+  await screen.findByText(/edit the text below/i);
+  mockApi.assertComplete();
+
+  expect(screen.getByRole('textbox')).toHaveValue('California');
+
+  userEvent.clear(screen.getByRole('textbox'));
+  userEvent.type(screen.getByRole('textbox'), 'CA');
+  expect(screen.getByRole('textbox')).toHaveValue('CA');
+
+  userEvent.click(screen.getButton(/reset/i));
+  expect(screen.getByRole('textbox')).toHaveValue('California');
+});
+
+test('save button updates backend data, refreshes content', async () => {
+  const original = 'CA';
+
+  const mockApi = createMockApiClient();
+  mockApi.ttsEditsGet
+    .expectCallWith({ orgId, languageCode, original })
+    .resolves(null);
+
+  mockApi.ttsSynthesizeFromText
+    .expectCallWith({ languageCode, text: original })
+    .resolves('audioData');
+
+  const { container } = renderEditor(
+    mockApi,
+    <TtsTextEditor
+      languageCode={languageCode}
+      orgId={orgId}
+      original={original}
+    />
+  );
+
+  await screen.findByText(/edit the text below/i);
+  mockApi.assertComplete();
+
+  expect(screen.getByRole('textbox')).toHaveValue('CA');
+  userEvent.clear(screen.getByRole('textbox'));
+  userEvent.type(screen.getByRole('textbox'), '  California  ');
+
+  const expectedEdit: TtsEdit = {
+    exportSource: 'text',
+    phonetic: [],
+    text: 'California',
+  };
+
+  //
+  // Expect mutation API call on submit:
+  //
+
+  const deferredSet = deferred<void>();
+  mockApi.ttsEditsSet
+    .expectCallWith({ data: expectedEdit, languageCode, original, orgId })
+    .returns(deferredSet.promise);
+
+  userEvent.click(screen.getButton(/save/i));
+  await sleep(0);
+  expect(screen.getByRole('textbox')).toBeDisabled();
+  expect(screen.getButton(/saving/i)).toBeDisabled();
+  expect(screen.getButton(/reset/i)).toBeDisabled();
+
+  mockApi.assertComplete();
+
+  //
+  // Expect data re-fetch after successful save:
+  //
+
+  mockApi.ttsEditsGet
+    .expectCallWith({ orgId, languageCode, original })
+    .resolves(expectedEdit);
+
+  const newAudioData = 'newAudioDta';
+  mockApi.ttsSynthesizeFromText
+    .expectCallWith({ languageCode, text: expectedEdit.text })
+    .resolves(newAudioData);
+
+  act(deferredSet.resolve);
+  await waitFor(() => expectAudioPlayerData(container, newAudioData));
+  expect(screen.getByRole('textbox')).toHaveValue('California');
+  expect(screen.getByRole('textbox')).toBeEnabled();
+  expect(screen.getButton(/save/i)).toBeDisabled();
+  expect(screen.getButton(/reset/i)).toBeDisabled();
+
+  mockApi.assertComplete();
+});
+
+function expectAudioPlayerData(container: HTMLElement, data: string) {
+  const results = container.getElementsByTagName('audio');
+  expect(results).toHaveLength(1);
+  expect(results.item(0)).toHaveAttribute('src', data);
+}
+
+function renderEditor(mockApi: MockApiClient, ui: React.ReactNode) {
+  return render(provideApi(mockApi, ui));
+}

--- a/apps/design/frontend/src/ballot_audio/tts_text_editor.tsx
+++ b/apps/design/frontend/src/ballot_audio/tts_text_editor.tsx
@@ -1,0 +1,292 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { assertDefined } from '@votingworks/basics';
+import { TtsEdit } from '@votingworks/types';
+import { Icons, Button, DesktopPalette, Caption, Font } from '@votingworks/ui';
+
+import * as api from '../api';
+import { cssThemedScrollbars } from '../scrollbars';
+
+const Container = styled.div`
+  display: grid;
+  max-height: 100%;
+  grid-template-rows: min-content 1fr;
+  overflow: hidden;
+`;
+
+const Header = styled(Font)`
+  box-shadow: 0 0.25rem 0.5rem rgba(255, 255, 255, 75%);
+  display: block;
+  padding: 0 0 0.5rem;
+  margin: 0;
+  z-index: 1;
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 10rem;
+  overflow-y: auto;
+  position: relative;
+  margin: 0.25rem 0 0;
+  padding-right: 0.25rem;
+
+  ${cssThemedScrollbars}
+`;
+
+const TextMirror = styled.pre`
+  /* stylelint-disable no-empty-source */
+`;
+
+const Editor = styled.div`
+  --tts-editor-border-width: ${(p) => p.theme.sizes.bordersRem.thin}rem;
+  --tts-editor-line-height: 1.4;
+  --tts-editor-padding: 0.5rem 0.75rem;
+
+  line-height: var(--tts-editor-line-height);
+  margin: 0 0 1rem;
+  position: relative;
+  width: 100%;
+
+  > textarea {
+    border-width: var(--tts-editor-border-width);
+    display: block;
+    height: 100%;
+    left: 0;
+    line-height: var(--tts-editor-line-height);
+    margin: 0 0 0.25rem;
+    min-height: 100%;
+    overflow: hidden;
+    padding: var(--tts-editor-padding);
+    position: absolute;
+    resize: none;
+    top: 0;
+    width: 100%;
+
+    ${cssThemedScrollbars}
+
+    :focus {
+      border-color: ${DesktopPalette.Purple60};
+      outline: none;
+    }
+  }
+
+  ${TextMirror} {
+    border: var(--tts-editor-border-width) solid transparent;
+    display: block;
+    font-family: inherit;
+    font-size: inherit;
+    height: 100%;
+    line-height: var(--tts-editor-line-height);
+    margin: 0;
+    min-height: 4rem;
+    padding: var(--tts-editor-padding);
+    visibility: hidden;
+    white-space: pre-wrap;
+  }
+`;
+
+const Note = styled(Caption)`
+  color: #444;
+  display: block;
+  margin: 0 0 0.5rem 0.1rem;
+`;
+
+const Footer = styled.div`
+  background: ${(p) => p.theme.colors.background};
+  border-top: 1px solid ${DesktopPalette.Gray30};
+  gap: 0.5rem;
+  padding: 0.5rem 0 0;
+  position: sticky;
+
+  /** Bottom of the buttons get clipped a bit on Safari and Firefox. */
+  bottom: 0.125rem;
+`;
+
+const Controls = styled.div`
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap-reverse;
+  gap: 0.5rem;
+  justify-content: space-between;
+`;
+
+const Player = styled.audio`
+  &[aria-disabled] {
+    cursor: not-allowed;
+  }
+`;
+
+const PlayerOverlay = styled.div`
+  align-items: center;
+  background: rgba(255, 255, 255, 50%);
+  display: flex;
+  font-size: 1.5rem;
+  height: 100%;
+  justify-content: center;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+`;
+
+type PlayerState = 'disabled' | 'loading' | 'ready';
+
+const PlayerContainer = styled.div<{ state: PlayerState }>`
+  position: relative;
+
+  > ${PlayerOverlay} {
+    cursor: not-allowed;
+    display: ${(p) => (p.state === 'ready' ? 'none' : 'flex')};
+
+    > svg {
+      display: ${(p) => (p.state === 'loading' ? undefined : 'none')};
+    }
+  }
+`;
+
+const FormButtons = styled.div`
+  display: flex;
+  gap: 0.5rem;
+`;
+
+export interface TtsTextEditorProps {
+  languageCode: string;
+  orgId: string;
+  original: string;
+}
+
+export function TtsTextEditor(props: TtsTextEditorProps): React.ReactNode {
+  const { languageCode, orgId, original } = props;
+
+  const savedEdit = api.ttsEditsGet.useQuery({
+    orgId,
+    languageCode,
+    original,
+  });
+
+  // [TODO] Render a loading state instead.
+  if (!savedEdit.isSuccess) return null;
+
+  return <EditorImpl {...props} savedEdit={savedEdit.data} />;
+}
+
+function EditorImpl(
+  props: TtsTextEditorProps & { savedEdit: TtsEdit | null }
+): JSX.Element {
+  const { languageCode, orgId, original, savedEdit } = props;
+  const [edit, setEdit] = React.useState<string | null>(null);
+
+  const defaultValue = savedEdit?.text || original;
+
+  const { data: audioDataUrl, isLoading: audioLoading } =
+    api.ttsSynthesizeFromText.useQuery({
+      languageCode,
+      text: defaultValue,
+    });
+
+  const { mutate: save, isLoading: saving } = api.ttsEditsSet.useMutation();
+
+  function onSubmit(event: React.FormEvent) {
+    event.stopPropagation();
+    event.preventDefault();
+
+    save(
+      {
+        orgId: assertDefined(orgId),
+        original,
+        languageCode,
+        data: {
+          exportSource: 'text',
+          phonetic: savedEdit?.phonetic || [],
+          text: assertDefined(edit).trim(),
+        },
+      },
+      { onSuccess: () => setEdit(null) }
+    );
+  }
+
+  const value = edit ?? defaultValue;
+  const textChanged = value !== defaultValue;
+  const isEmpty = !value || value.trim() === '';
+
+  const resetDisabled = !textChanged || audioLoading || saving;
+  const saveDisabled = resetDisabled || isEmpty;
+
+  const playerState: PlayerState = (() => {
+    if (textChanged) return 'disabled';
+    if (audioLoading) return 'loading';
+    return 'ready';
+  })();
+
+  return (
+    <Container>
+      <Header>
+        <Icons.ChevronRight /> Edit the text below to change the corresponding
+        audio:
+      </Header>
+
+      <Form onReset={() => setEdit(null)} onSubmit={onSubmit}>
+        <Editor>
+          {/*
+           * Mirror the textarea's text in a background element to provide an
+           * explicit height for the container (since we can't dynamically
+           * grow a textarea with just CSS).
+           *
+           * The extra period just ensures that the `Mirror` grows accordingly
+           * when the last character inserted is a newline (the newline is
+           * otherwise ignored by the browser, it seems).
+           */}
+          <TextMirror>{value}.</TextMirror>
+
+          <textarea
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+            disabled={saving}
+            id="ttsTextEditor"
+            name="ttsText"
+            onChange={(event) => setEdit(event.target.value)}
+            value={value}
+          />
+        </Editor>
+
+        <Footer>
+          <Note>
+            <Icons.Info /> This will only affect audio output on BMDs. The text
+            will continue to appear as shown in the section above.
+          </Note>
+
+          <Controls>
+            <PlayerContainer state={playerState}>
+              <Player
+                aria-disabled={playerState !== 'ready'}
+                aria-label="Audio Player"
+                controls
+                src={playerState === 'ready' ? audioDataUrl : ''}
+              />
+              <PlayerOverlay>
+                <Icons.Loading />
+              </PlayerOverlay>
+            </PlayerContainer>
+
+            <FormButtons>
+              <Button disabled={resetDisabled} type="reset">
+                Reset
+              </Button>
+              <Button
+                disabled={saveDisabled}
+                icon={saving ? 'Loading' : 'Save'}
+                type="submit"
+                variant={saveDisabled ? 'neutral' : 'primary'}
+              >
+                {saving ? 'Saving...' : 'Save Changes'}
+              </Button>
+            </FormButtons>
+          </Controls>
+        </Footer>
+      </Form>
+    </Container>
+  );
+}

--- a/apps/design/frontend/src/scrollbars.tsx
+++ b/apps/design/frontend/src/scrollbars.tsx
@@ -1,0 +1,32 @@
+import { DesktopPalette } from '@votingworks/ui';
+import { css } from 'styled-components';
+
+const colorBg = 'transparent';
+const colorThumb = DesktopPalette.Purple40;
+const thicknessRem = 0.45;
+
+export const cssThemedScrollbars = css`
+  scrollbar-track-color: ${colorBg};
+  scrollbar-color: ${colorThumb};
+  scrollbar-width: ${thicknessRem}rem;
+  scroll-behavior: smooth;
+
+  ::-webkit-scrollbar {
+    height: ${thicknessRem}rem;
+    width: ${thicknessRem}rem;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: ${colorBg};
+    border-radius: 100vw;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: ${colorThumb};
+    border-radius: 100vw;
+
+    :hover {
+      background: ${DesktopPalette.Purple60};
+    }
+  }
+`;


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7266

Adding the plain text editing version of the audio editor (vs the word-based phonetic editor, which will come later). Currently unused, but will be eventually wrapped in a component that takes care of switching between plain text and phonetic editing and displaying a preview of the original string (full context shown in screengrabs below.

### TODO
- Currently assumes the happy path - will need to add any appropriate error handling as the feature gets fleshed out.

## Demo Video or Screenshot

### In Context:
<img width="1920" height="1079" alt="vxdesign-tts-test-editor" src="https://github.com/user-attachments/assets/061866f4-e0d4-40e2-98c6-62d0722b74c8" />

### Basic Edit States:

https://github.com/user-attachments/assets/3d829c6a-def0-4a87-a4cf-c3709d62d87a

### Layout Edge Cases:

https://github.com/user-attachments/assets/91d86d2c-68d6-4e5a-b846-407e74593000

## Testing Plan
- Unit tests for basic interaction/state changes
- Manual functional/styling spot checks on Chrome, FF, Safari

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
