### PR TITLE
Don't allow yes no with same ids for options

### DIFF
--- a/libs/test-utils/src/arbitraries.ts
+++ b/libs/test-utils/src/arbitraries.ts
@@ -243,15 +243,24 @@ export function arbitraryYesNoContest({
   id?: fc.Arbitrary<YesNoContest['id']>;
   districtId?: fc.Arbitrary<District['id']>;
 } = {}): fc.Arbitrary<YesNoContest> {
-  return fc.record({
-    type: fc.constant('yesno'),
-    title: fc.string({ minLength: 1 }),
-    description: fc.string({ minLength: 1 }),
-    id,
-    districtId,
-    yesOption: arbitraryYesNoOption({ id: arbitraryId() }),
-    noOption: arbitraryYesNoOption({ id: arbitraryId() }),
-  });
+  return fc
+    .tuple(
+      arbitraryYesNoOption({ id: arbitraryId() }),
+      arbitraryYesNoOption({ id: arbitraryId() })
+    )
+    .filter(([yesOption, noOption]) => yesOption.id !== noOption.id)
+    .map(([yesOption, noOption]) =>
+      fc.record({
+        type: fc.constant('yesno' as const),
+        title: fc.string({ minLength: 1 }),
+        description: fc.string({ minLength: 1 }),
+        id,
+        districtId,
+        yesOption: fc.constant(yesOption),
+        noOption: fc.constant(noOption),
+      })
+    )
+    .chain((x) => x);
 }
 
 /**


### PR DESCRIPTION
## Overview
The all_contest_options test started flaking on yes/no contests specifically when the yesOption and noOption on the contest have the same id. This is not an allowed situation, so updated the arbitrary generator to not create that. 

Flake Example: https://app.circleci.com/pipelines/github/votingworks/vxsuite/23038/workflows/7072f089-3031-4149-a84b-72bafb981b8f/jobs/1024624 
<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot
N/A

## Testing Plan
Ran Tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
