### PR TITLE
VxDesign: Add AudioEditor/AudioEditorPanel components

### DIFF
--- a/apps/design/frontend/src/ballot_audio/audio_editor.test.tsx
+++ b/apps/design/frontend/src/ballot_audio/audio_editor.test.tsx
@@ -1,0 +1,168 @@
+import { expect, test, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+
+import { TtsStringDefault } from '@votingworks/design-backend';
+import { ElectionStringKey } from '@votingworks/types';
+
+import { TtsTextEditor, TtsTextEditorProps } from './tts_text_editor';
+import {
+  createMockApiClient,
+  MockApiClient,
+  provideApi,
+} from '../../test/api_helpers';
+import { render, screen } from '../../test/react_testing_library';
+import { AudioEditor, AudioEditorProps } from './audio_editor';
+
+vi.mock('./tts_text_editor.js');
+
+const TEXT_EDITOR_TEST_ID = 'TtsTextEditor';
+const PHONETIC_EDITOR_PLACEHOLDER = 'TODO: Phonetic Editor';
+
+const orgId = 'org-1';
+const languageCode = 'en';
+
+test('defaults to plain text editor if no saved edits exist', async () => {
+  const ttsDefault: TtsStringDefault = {
+    key: ElectionStringKey.STATE_NAME,
+    text: 'CA',
+  };
+
+  const mockApi = createMockApiClient();
+  mockApi.ttsEditsGet
+    .expectCallWith({ orgId, languageCode, original: ttsDefault.text })
+    .resolves(null);
+
+  setUpTextEditorMock({ languageCode, orgId, original: ttsDefault.text });
+
+  renderEditor(mockApi, {
+    languageCode,
+    orgId,
+    ttsDefault,
+    phoneticEnabled: true,
+  });
+
+  await screen.findByTestId(TEXT_EDITOR_TEST_ID);
+  mockApi.assertComplete();
+});
+
+test('picks initial editor based on saved edits', async () => {
+  const ttsDefault: TtsStringDefault = {
+    key: ElectionStringKey.STATE_NAME,
+    text: 'CA',
+  };
+
+  const mockApi = createMockApiClient();
+  mockApi.ttsEditsGet
+    .expectCallWith({ orgId, languageCode, original: ttsDefault.text })
+    .resolves({ exportSource: 'phonetic', phonetic: [], text: 'CA' });
+
+  setUpTextEditorMock({ languageCode, orgId, original: ttsDefault.text });
+
+  renderEditor(mockApi, {
+    languageCode,
+    orgId,
+    ttsDefault,
+    phoneticEnabled: true,
+  });
+
+  await screen.findByText(PHONETIC_EDITOR_PLACEHOLDER);
+  expect(screen.queryByTestId(TEXT_EDITOR_TEST_ID)).not.toBeInTheDocument();
+  mockApi.assertComplete();
+});
+
+test('supports switching between text and phonetic editing', async () => {
+  const ttsDefault: TtsStringDefault = {
+    key: ElectionStringKey.STATE_NAME,
+    text: 'CA',
+  };
+
+  const mockApi = createMockApiClient();
+  mockApi.ttsEditsGet
+    .expectCallWith({ orgId, languageCode, original: ttsDefault.text })
+    .resolves({ exportSource: 'phonetic', phonetic: [], text: 'CA' });
+
+  setUpTextEditorMock({ languageCode, orgId, original: ttsDefault.text });
+
+  renderEditor(mockApi, {
+    languageCode,
+    orgId,
+    ttsDefault,
+    phoneticEnabled: true,
+  });
+
+  // Start with phonetic:
+  await screen.findByText(PHONETIC_EDITOR_PLACEHOLDER);
+  mockApi.assertComplete();
+
+  // Switch to text:
+  userEvent.click(screen.getButton('Text-To-Speech'));
+  screen.getByTestId(TEXT_EDITOR_TEST_ID);
+  expect(
+    screen.queryByText(PHONETIC_EDITOR_PLACEHOLDER)
+  ).not.toBeInTheDocument();
+
+  // Switch back to phonetic:
+  userEvent.click(screen.getButton('Phonetic'));
+  screen.getByText(PHONETIC_EDITOR_PLACEHOLDER);
+  expect(screen.queryByTestId(TEXT_EDITOR_TEST_ID)).not.toBeInTheDocument();
+});
+
+test('only supports text editing for contest descriptions', async () => {
+  const ttsDefault: TtsStringDefault = {
+    key: ElectionStringKey.CONTEST_DESCRIPTION,
+    subkey: 'contest-1',
+    text: 'Do you agree?',
+  };
+
+  const mockApi = createMockApiClient();
+  mockApi.ttsEditsGet
+    .expectCallWith({ orgId, languageCode, original: ttsDefault.text })
+    .resolves(null);
+
+  setUpTextEditorMock({ languageCode, orgId, original: ttsDefault.text });
+
+  renderEditor(mockApi, {
+    languageCode,
+    orgId,
+    ttsDefault,
+    phoneticEnabled: true,
+  });
+
+  await screen.findByTestId(TEXT_EDITOR_TEST_ID);
+  screen.getButton('Text-To-Speech');
+  expect(screen.queryButton('Phonetic')).not.toBeInTheDocument();
+});
+
+test('omits phonetic editor when not enabled', async () => {
+  const ttsDefault: TtsStringDefault = {
+    key: ElectionStringKey.CONTEST_DESCRIPTION,
+    subkey: 'contest-1',
+    text: 'Do you agree?',
+  };
+
+  const mockApi = createMockApiClient();
+  mockApi.ttsEditsGet
+    .expectCallWith({ orgId, languageCode, original: ttsDefault.text })
+    .resolves(null);
+
+  setUpTextEditorMock({ languageCode, orgId, original: ttsDefault.text });
+
+  // `phoneticEnabled` should be `false` by default:
+  renderEditor(mockApi, { languageCode, orgId, ttsDefault });
+
+  await screen.findByTestId(TEXT_EDITOR_TEST_ID);
+  screen.getButton('Text-To-Speech');
+  expect(screen.queryButton('Phonetic')).not.toBeInTheDocument();
+});
+
+function renderEditor(mockApi: MockApiClient, props: AudioEditorProps) {
+  return render(provideApi(mockApi, <AudioEditor {...props} />));
+}
+
+function setUpTextEditorMock(expectedProps: TtsTextEditorProps) {
+  vi.mocked(TtsTextEditor).mockImplementation((props) => {
+    expect(props).toEqual(expectedProps);
+
+    return <div data-testid={TEXT_EDITOR_TEST_ID} />;
+  });
+}

--- a/apps/design/frontend/src/ballot_audio/audio_editor.tsx
+++ b/apps/design/frontend/src/ballot_audio/audio_editor.tsx
@@ -1,0 +1,106 @@
+import styled from 'styled-components';
+import React from 'react';
+
+import { throwIllegalValue } from '@votingworks/basics';
+import { TtsStringDefault } from '@votingworks/design-backend';
+import { ElectionStringKey, TtsExportSource } from '@votingworks/types';
+import { H3, P, RadioGroup, RadioGroupOption } from '@votingworks/ui';
+
+import * as api from '../api';
+import { TtsTextEditor } from './tts_text_editor';
+
+const ModeContainer = styled.div`
+  button {
+    padding: 0.5rem 0.75rem !important;
+  }
+`;
+
+const ModeTitle = styled(H3)`
+  font-size: 1rem;
+  font-weight: ${(p) => p.theme.sizes.fontWeight.bold};
+  margin: 0;
+`;
+
+const TTS_MODE_OPTIONS: Array<RadioGroupOption<TtsExportSource>> = [
+  {
+    value: 'text',
+    label: <ModeTitle>Text-To-Speech</ModeTitle>,
+  },
+  {
+    value: 'phonetic',
+    label: <ModeTitle>Phonetic</ModeTitle>,
+  },
+];
+
+export interface AudioEditorProps {
+  languageCode: string;
+  orgId: string;
+  ttsDefault: TtsStringDefault;
+
+  /**
+   * For development/testing - phonetic editing will be a fast-follow after
+   * initial launch of plain text editing.
+   * [TODO] Remove once launched.
+   */
+  phoneticEnabled?: boolean;
+}
+
+export function AudioEditor(props: AudioEditorProps): React.ReactNode {
+  const { languageCode, orgId, phoneticEnabled, ttsDefault } = props;
+  const [mode, setMode] = React.useState<TtsExportSource | null>(null);
+
+  const savedEdit = api.ttsEditsGet.useQuery({
+    orgId,
+    languageCode,
+    original: ttsDefault.text,
+  });
+
+  if (!savedEdit.isSuccess) return null;
+
+  const defaultMode = savedEdit.data?.exportSource || 'text';
+  const currentMode = mode || defaultMode;
+
+  // Phonetic editing isn't supported for ballot measures at the moment, given
+  // how long/complex they can get.
+  //
+  // [TODO] Consider approaches that allow users to edit with a combination of
+  // text editing and spot editing certain words, like names of people/places,
+  // with phonetic edits.
+  const textOnly =
+    ttsDefault.key === ElectionStringKey.CONTEST_DESCRIPTION ||
+    !phoneticEnabled;
+
+  return (
+    <React.Fragment>
+      <ModeContainer>
+        <RadioGroup
+          label="Audio Source"
+          hideLabel
+          numColumns={2}
+          onChange={setMode}
+          options={textOnly ? [TTS_MODE_OPTIONS[0]] : TTS_MODE_OPTIONS}
+          value={currentMode}
+        />
+      </ModeContainer>
+
+      {(() => {
+        switch (currentMode) {
+          case 'text':
+            return (
+              <TtsTextEditor
+                languageCode={languageCode}
+                orgId={orgId}
+                original={ttsDefault.text}
+              />
+            );
+
+          case 'phonetic':
+            return <P>TODO: Phonetic Editor</P>;
+
+          default:
+            throwIllegalValue(currentMode);
+        }
+      })()}
+    </React.Fragment>
+  );
+}

--- a/apps/design/frontend/src/ballot_audio/audio_editor_panel.test.tsx
+++ b/apps/design/frontend/src/ballot_audio/audio_editor_panel.test.tsx
@@ -1,0 +1,90 @@
+import { expect, test, vi } from 'vitest';
+
+import { TtsStringDefault } from '@votingworks/design-backend';
+import {
+  AnyContest,
+  ElectionStringKey,
+  YesNoContest,
+} from '@votingworks/types';
+
+import { AudioEditor, AudioEditorProps } from './audio_editor';
+import {
+  createMockApiClient,
+  MockApiClient,
+  provideApi,
+} from '../../test/api_helpers';
+import { AudioEditorPanel, AudioEditorPanelProps } from './audio_editor_panel';
+import { render, screen } from '../../test/react_testing_library';
+
+vi.mock('./audio_editor.js');
+
+const EDITOR_TEST_ID = 'TtsTextEditor';
+
+const electionId = 'election-1';
+const orgId = 'org-1';
+const languageCode = 'en';
+
+test('renders editor, along with a preview of the original text', () => {
+  const ttsDefault: TtsStringDefault = {
+    key: ElectionStringKey.STATE_NAME,
+    text: 'CA',
+  };
+
+  const mockApi = createMockApiClient();
+  setUpEditorMock({ languageCode, orgId, ttsDefault });
+
+  const header = <h1>Election Audio: State</h1>;
+
+  renderPanel(mockApi, { electionId, header, languageCode, orgId, ttsDefault });
+
+  mockApi.assertComplete();
+  screen.getByRole('heading', { name: 'Election Audio: State' });
+  screen.getByText('CA');
+  screen.getByTestId(EDITOR_TEST_ID);
+});
+
+test('renders contest descriptions using original, unstripped HTML', async () => {
+  const mockContest: Partial<YesNoContest> = {
+    id: 'contest-1',
+    description: '<p data-testid="preview">Do you agree?<p>',
+    type: 'yesno',
+  };
+
+  const mockApi = createMockApiClient();
+  mockApi.listContests
+    .expectCallWith({ electionId })
+    .resolves([mockContest as AnyContest]);
+
+  const ttsDefault: TtsStringDefault = {
+    key: ElectionStringKey.CONTEST_DESCRIPTION,
+    subkey: mockContest.id,
+    text: 'Do you agree?',
+  };
+  setUpEditorMock({ languageCode, orgId, ttsDefault });
+
+  renderPanel(mockApi, {
+    electionId,
+    header: null,
+    languageCode,
+    orgId,
+    ttsDefault,
+  });
+
+  expect(await screen.findByTestId('preview')).toHaveTextContent(
+    'Do you agree?'
+  );
+  mockApi.assertComplete();
+  screen.getByTestId(EDITOR_TEST_ID);
+});
+
+function renderPanel(mockApi: MockApiClient, props: AudioEditorPanelProps) {
+  return render(provideApi(mockApi, <AudioEditorPanel {...props} />));
+}
+
+function setUpEditorMock(expectedProps: AudioEditorProps) {
+  vi.mocked(AudioEditor).mockImplementation((props) => {
+    expect(props).toEqual(expectedProps);
+
+    return <div data-testid={EDITOR_TEST_ID} />;
+  });
+}

--- a/apps/design/frontend/src/ballot_audio/audio_editor_panel.tsx
+++ b/apps/design/frontend/src/ballot_audio/audio_editor_panel.tsx
@@ -1,0 +1,88 @@
+import styled from 'styled-components';
+import React from 'react';
+
+import { assertDefined } from '@votingworks/basics';
+import { TtsStringDefault } from '@votingworks/design-backend';
+import { ElectionStringKey, YesNoContest } from '@votingworks/types';
+
+import * as api from '../api';
+import { UiStringPreview } from './ui_string_preview';
+import { AudioEditor } from './audio_editor';
+
+const Container = styled.div`
+  display: grid;
+  gap: 0.75rem;
+  grid-template-rows: min-content max-content min-content 1fr;
+  height: 100%;
+  max-height: 100%;
+  max-width: 50rem;
+  overflow: hidden;
+  padding: 1rem;
+`;
+
+export interface AudioEditorPanelProps {
+  electionId: string;
+  header: React.ReactNode;
+  languageCode: string;
+  orgId: string;
+  ttsDefault: TtsStringDefault;
+}
+
+export function AudioEditorPanel(
+  props: AudioEditorPanelProps
+): React.ReactNode {
+  const { electionId, header, languageCode, orgId, ttsDefault } = props;
+
+  return (
+    <Container>
+      <div>{header}</div>
+
+      {ttsDefault.key === ElectionStringKey.CONTEST_DESCRIPTION ? (
+        <ContestDescriptionPreview
+          contestId={assertDefined(
+            ttsDefault.subkey,
+            'subkey missing for contest description TTS string'
+          )}
+          electionId={electionId}
+        />
+      ) : (
+        <UiStringPreview stringKey={ttsDefault.key} text={ttsDefault.text} />
+      )}
+
+      <AudioEditor
+        languageCode={languageCode}
+        orgId={orgId}
+        ttsDefault={ttsDefault}
+      />
+    </Container>
+  );
+}
+
+/**
+ * Displays the original description HTML for the given contest, since the
+ * the corresponding TTS string default has HTML stripped for speech synthesis.
+ */
+export function ContestDescriptionPreview(props: {
+  contestId: string;
+  electionId: string;
+}): React.ReactNode {
+  const { contestId, electionId } = props;
+  const contests = api.listContests.useQuery(electionId).data;
+
+  const contest = React.useMemo(() => {
+    if (!contests) return undefined;
+
+    return contests.find(
+      (c): c is YesNoContest => c.id === contestId && c.type === 'yesno'
+    );
+  }, [contestId, contests]);
+
+  if (!contest) return null;
+
+  return (
+    <UiStringPreview
+      stringKey={ElectionStringKey.CONTEST_DESCRIPTION}
+      text={contest.description}
+    />
+  );
+}

--- a/apps/design/frontend/src/ballot_audio/ui_string_preview.tsx
+++ b/apps/design/frontend/src/ballot_audio/ui_string_preview.tsx
@@ -1,0 +1,71 @@
+import styled from 'styled-components';
+
+import { ElectionStringKey } from '@votingworks/types';
+import { DesktopPalette, richTextStyles } from '@votingworks/ui';
+
+import { cssThemedScrollbars } from '../scrollbars';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  border-bottom: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid
+    ${DesktopPalette.Gray30};
+
+  > :last-child {
+    padding-bottom: 0.75rem;
+  }
+`;
+
+const ContestDescription = styled.div`
+  height: max-content;
+  line-height: 1.4;
+  overflow-y: auto;
+
+  /*
+  * These bounds can be tweaked as needed. Tuned to provide decent
+  * responsiveness on a 1920 x 1080 viewport, when paired with the
+  * TtsTextEditor component, with the latter taking up more or the viewport.
+  */
+  max-height: calc(0.25 * calc(100vh - 10rem));
+  min-height: 4rem;
+
+  /*
+   * Hide for short viewports, since there isn't enough room to show a useful
+   * preview anyway.
+   */
+  @media (max-height: 600px) {
+    height: 0;
+    min-height: 0;
+    padding: 0 !important;
+  }
+
+  ${cssThemedScrollbars}
+  ${richTextStyles}
+`;
+
+export interface UiStringPreviewProps {
+  stringKey: string;
+  text: string;
+}
+
+/**
+ * Displays the original for a given UI string, to provide a reference for users
+ * when making text-to-speech edits.
+ */
+export function UiStringPreview(props: UiStringPreviewProps): JSX.Element {
+  const { stringKey, text } = props;
+
+  if (stringKey === ElectionStringKey.CONTEST_DESCRIPTION) {
+    return (
+      <Container>
+        <ContestDescription dangerouslySetInnerHTML={{ __html: text }} />
+      </Container>
+    );
+  }
+
+  return (
+    <Container>
+      <span>{text}</span>
+    </Container>
+  );
+}

--- a/libs/ui/src/radio_group.tsx
+++ b/libs/ui/src/radio_group.tsx
@@ -10,7 +10,7 @@ import { useCurrentTheme } from './hooks/use_current_theme';
 type RadioGroupValue = string | number;
 
 /** Data schema for a single option in the RadioGroup component. */
-interface RadioGroupOption<T extends RadioGroupValue> {
+export interface RadioGroupOption<T extends RadioGroupValue> {
   value: T;
   label: React.ReactNode;
 }


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7266

Adding the shared audio editing panel components, to be eventually [used on edit screens](https://www.figma.com/design/g5S6rv7kYH8kfEomZTzZqr/-VxDesign--In-Context-Audio-Editing?node-id=1-19&t=QYUaDWh62oIaTg0X-0).

Its pieces will also be used later in the search-and-edit audio proofing flow that we've previously demo'd, so trying to keep things modular as I go.

## Demo Video or Screenshot

<img width="825" height="707" alt="vxdesign-audio-edit-panel" src="https://github.com/user-attachments/assets/5ea81233-a6de-4e45-9391-a7b402de0230" /> 

https://github.com/user-attachments/assets/7ad8d4c1-67b2-49c4-97be-c16788df9517

## Testing Plan
- Unit tests for display states/interaction
- Manual cross-browser checks: Chrome, FF, Safari

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.