### PR TITLE
VxPrint: Show printing modal upon print

### DIFF
--- a/apps/print/frontend/src/screens/print_screen.tsx
+++ b/apps/print/frontend/src/screens/print_screen.tsx
@@ -11,7 +11,7 @@ import {
   Modal,
   Loading,
 } from '@votingworks/ui';
-import { assertDefined, sleep } from '@votingworks/basics';
+import { assertDefined } from '@votingworks/basics';
 
 import { ExpandedSelect } from '../components/expanded_select';
 import { TitleBar } from '../components/title_bar';
@@ -145,8 +145,11 @@ export function PrintScreen({
       : [];
   const hideSplitSelection = availableSplits.length === 0;
 
-  async function handlePrint() {
+  function handlePrint() {
     setIsShowingPrintingModal(true);
+    setTimeout(() => {
+      setIsShowingPrintingModal(false);
+    }, DEFAULT_PROGRESS_MODAL_DELAY_SECONDS * 1000);
     printBallotMutation.mutate({
       precinctId: assertDefined(selectedPrecinct).id,
       splitId: selectedSplitId,
@@ -155,13 +158,6 @@ export function PrintScreen({
       ballotType: isAbsentee ? BallotType.Absentee : BallotType.Precinct,
       copies: numCopies,
     });
-    console.log(
-      `Printing ballot style: ${selectedPrecinct?.name}, ${selectedPartyId}, ${selectedLanguageCode}${
-        selectedSplitId ? `, ${selectedSplitId}` : ''
-      }, ${isAbsentee ? 'Absentee' : 'Precinct'}, Copies: ${numCopies} `
-    );
-    await sleep(DEFAULT_PROGRESS_MODAL_DELAY_SECONDS * 1000);
-    setIsShowingPrintingModal(false);
   }
 
   return (


### PR DESCRIPTION
## Overview

Follows the pattern in VxAdmin of showing a modal after print is submitted. Note that we may optimize the timing further in the future, but for now it matches Admins 3s delay.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/a82223be-c71c-46a6-ba79-0b117ae8c3ee

## Testing Plan

Manual for now, automated later

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
