### PR TITLE
VxPrint: Scroll to selected precinct if not visible

### DIFF
--- a/apps/print/frontend/src/components/expanded_select.tsx
+++ b/apps/print/frontend/src/components/expanded_select.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import { DesktopPalette, Icons } from '@votingworks/ui';
 import styled from 'styled-components';
@@ -10,7 +10,6 @@ const Container = styled.div`
   border-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
   width: 100%;
   height: 100%;
-  overflow-y: auto;
 `;
 
 const SearchBox = styled.div`
@@ -53,8 +52,9 @@ const SearchBox = styled.div`
 const OptionList = styled.div`
   display: flex;
   flex-direction: column;
-  overflow-y: scroll;
+  overflow-y: auto;
   height: 100%;
+  position: relative;
 `;
 
 const StyledOption = styled.option`
@@ -111,6 +111,29 @@ export function ExpandedSelect({
   onSearch?: (value: string) => void;
   style?: React.CSSProperties;
 }): JSX.Element {
+  const optionListRef = useRef<HTMLDivElement>(null);
+  const selectedOptionRef = useRef<HTMLOptionElement>(null);
+
+  // Scroll to selected option if not visible
+  useEffect(() => {
+    if (selectedOptionRef.current && optionListRef.current) {
+      const option = selectedOptionRef.current;
+      const list = optionListRef.current;
+
+      const isInView =
+        option.offsetTop >= list.scrollTop &&
+        option.offsetTop + option.offsetHeight <=
+          list.scrollTop + list.clientHeight;
+
+      if (!isInView) {
+        option.scrollIntoView({
+          behavior: 'instant',
+          block: 'start',
+        });
+      }
+    }
+  }, [selectedValue]);
+
   return (
     <Container style={style}>
       {onSearch && (
@@ -128,10 +151,11 @@ export function ExpandedSelect({
           />
         </SearchBox>
       )}
-      <OptionList>
+      <OptionList ref={optionListRef}>
         {options.map((option) => (
           <StyledOption
             key={option.value}
+            ref={option.value === selectedValue ? selectedOptionRef : null}
             aria-selected={option.value === selectedValue}
             onClick={() => onSelect(option.value)}
           >


### PR DESCRIPTION
## Overview

This PR improves two cases:
1. The machine is configured to a single precinct in an election with many precincts. Scroll to the selected precinct when navigating to the tab.
2. The user selects a precinct that is at the bottom of the list, and split selection is required taking up the space where the option was clicked. Scroll the precinct selection selector to show the newly selected precinct.

## Demo Video or Screenshot

Both cases shown after fixes:

https://github.com/user-attachments/assets/b1dbef3f-e8d7-4f0f-985a-e316ef327fa9

Both cases shown before fixes:

https://github.com/user-attachments/assets/52fd325c-4435-43f5-a3e4-1be494001833


## Testing Plan

Manual testing

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
