### PR TITLE
build: specify rust version in config file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.86.0"
+components = ["rustfmt", "rust-analyzer"]


### PR DESCRIPTION
## Overview

By default `rustup` will install the latest version. Specifying the version we use in this file will cause that version to be installed when `cargo` et al are used in vxsuite.

## Demo Video or Screenshot
```
❯ cargo --version
cargo 1.91.1 (ea2d97820 2025-10-10)
❯ cd vxsuite
❯ cargo --version
cargo 1.86.0 (adf9b6ad1 2025-02-28)
```

## Testing Plan

Tested locally. I don't expect any CI differences, but we'll see soon enough. As long as this version matches what's in `vxsuite-build-system`, I think that this will be a no-op, but that's something that we might consider testing.