### PR TITLE
fix: ensure `Display` matches `FromStr`

### DIFF
--- a/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
@@ -122,10 +122,7 @@ impl Display for VerticalStreakDetection {
         match self {
             Self::Enabled {
                 max_cumulative_streak_width,
-            } => write!(
-                f,
-                "enabled (max cumulative streak width: {max_cumulative_streak_width}px)",
-            ),
+            } => write!(f, "enabled:{max_cumulative_streak_width}px",),
             Self::Disabled => write!(f, "disabled"),
         }
     }
@@ -140,7 +137,18 @@ impl FromStr for VerticalStreakDetection {
                 max_cumulative_streak_width: DEFAULT_MAX_CUMULATIVE_STREAK_WIDTH,
             }),
             "disabled" => Ok(Self::Disabled),
-            _ => Err(format!("Unexpected vertical streak detection setting: {s}")),
+            _ => match s.split_once(':') {
+                Some(("enabled", pixels)) => {
+                    let pixels_str = pixels.strip_suffix("px").unwrap_or(pixels);
+                    let max_cumulative_streak_width = pixels_str
+                        .parse()
+                        .map_err(|e| format!("Invalid pixel value '{pixels_str}': {e}"))?;
+                    Ok(Self::Enabled {
+                        max_cumulative_streak_width,
+                    })
+                }
+                _ => Err(format!("Unexpected vertical streak detection setting: {s}")),
+            },
         }
     }
 }


### PR DESCRIPTION
## Overview
It appears clap converts the `default_value_t` value to a string using `Display`, then parses it with `FromStr`. This means anything created by `Display` for the default value has to parse with `FromStr`. This commit updates both trait implementations to match and be simplified to allow "enabled", "disabled", "enabled:10px", or "enabled:10".

## Demo Video or Screenshot
On `main`, running `interpret` with no options crashes due to an invalid default value for `--vertical-streak-detection`. Switching to this branch shows the help output as expected.
```
vxsuite main ❯ cargo run --release --bin interpret
    Finished `release` profile [optimized] target(s) in 0.06s
     Running `target/release/interpret`
error: invalid value 'enabled (max cumulative streak width: 5px)' for '--vertical-streak-detection <VERTICAL_STREAK_DETECTION>': Unexpected vertical streak detection setting: enabled (max cumulative streak width: 5px)

For more information, try '--help'.

vxsuite main ✗ git switch -
Switched to branch 'brian/fix/scan/interpret-binary-fixes'
Your branch is up to date with 'origin/brian/fix/scan/interpret-binary-fixes'.

vxsuite brian/fix/scan/interpret-binary-fixes ❯ cargo run --release --bin interpret
   Compiling ballot-interpreter v0.1.0 (/home/brian/code/vxsuite/libs/ballot-interpreter)
    Finished `release` profile [optimized] target(s) in 4.28s
     Running `target/release/interpret`
error: the following required arguments were not provided:
  <ELECTION_PATH>
  <SIDE_A_PATH>
  <SIDE_B_PATH>

Usage: interpret <ELECTION_PATH> <SIDE_A_PATH> <SIDE_B_PATH>

For more information, try '--help'.
```

## Testing Plan
Tested manually.
