### PR TITLE
VxDesign: Audio editing prep - contest form layout updates

### DIFF
--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';
 import {
@@ -90,6 +90,7 @@ function renderScreen(electionId: ElectionId) {
       withRoute(<ContestsScreen />, {
         paramPath: routes.election(':electionId').contests.root.path,
         path,
+        history,
       })
     )
   );
@@ -167,26 +168,492 @@ const electionWithNoContestsRecord = makeElectionRecord(
   user.orgId
 );
 
-describe('Contests tab', () => {
-  // Since we coarsely invalidate all election data on contest changes, there
-  // are a number of other API calls that refetch when we mutate contests
-  function expectOtherElectionApiCalls(election: Election) {
-    const electionId = election.id;
-    apiMock.getElectionInfo
-      .expectCallWith({ electionId })
-      .resolves(electionInfoFromElection(election));
-    apiMock.getSystemSettings
-      .expectOptionalRepeatedCallsWith({ electionId })
-      .resolves(DEFAULT_SYSTEM_SETTINGS);
-    apiMock.listDistricts
-      .expectCallWith({ electionId })
-      .resolves(election.districts);
-    apiMock.listParties
-      .expectCallWith({ electionId })
-      .resolves(election.parties);
+// Since we coarsely invalidate all election data on contest changes, there
+// are a number of other API calls that refetch when we mutate contests
+function expectOtherElectionApiCalls(election: Election) {
+  const electionId = election.id;
+  apiMock.getElectionInfo
+    .expectCallWith({ electionId })
+    .resolves(electionInfoFromElection(election));
+  apiMock.getSystemSettings
+    .expectOptionalRepeatedCallsWith({ electionId })
+    .resolves(DEFAULT_SYSTEM_SETTINGS);
+  apiMock.listDistricts
+    .expectCallWith({ electionId })
+    .resolves(election.districts);
+  apiMock.listParties.expectCallWith({ electionId }).resolves(election.parties);
+}
+
+test('adding a candidate contest (general election)', async () => {
+  const { election } = electionWithNoContestsRecord;
+  const electionId = election.id;
+  const newContest: CandidateContest = {
+    id: idFactory.next(),
+    type: 'candidate',
+    title: 'New Contest',
+    districtId: election.districts[0].id,
+    seats: 2,
+    termDescription: '2 years',
+    allowWriteIns: false,
+    candidates: [
+      {
+        id: idFactory.next(),
+        name: 'New Candidate 1',
+        firstName: 'New Candidate',
+        middleName: undefined,
+        lastName: '1',
+        partyIds: [election.parties[0].id],
+      },
+      {
+        id: idFactory.next(),
+        name: 'New Candidate 2',
+        firstName: 'New Candidate',
+        middleName: undefined,
+        lastName: '2',
+        partyIds: [election.parties[1].id],
+      },
+      {
+        id: idFactory.next(),
+        name: 'New Candidate 3',
+        firstName: 'New Candidate',
+        middleName: undefined,
+        lastName: '3',
+      },
+    ],
+  };
+
+  apiMock.listContests.expectCallWith({ electionId }).resolves([]);
+  expectOtherElectionApiCalls(election);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+  renderScreen(electionId);
+
+  await screen.findByRole('heading', { name: 'Contests' });
+  screen.getByText("You haven't added any contests to this election yet.");
+
+  // Add contest
+  userEvent.click(screen.getByRole('button', { name: 'Add Contest' }));
+  await screen.findByRole('heading', { name: 'Add Contest' });
+  expect(screen.getByRole('link', { name: 'Contests' })).toHaveAttribute(
+    'href',
+    `/elections/${electionId}/contests`
+  );
+
+  // Set title
+  userEvent.type(screen.getByLabelText('Title'), newContest.title);
+
+  // Set district
+  userEvent.click(screen.getByLabelText('District'));
+  userEvent.click(screen.getByText(election.districts[0].name));
+
+  // Default type is candidate contest
+  within(screen.getByLabelText('Type')).getByRole('option', {
+    name: 'Candidate Contest',
+    selected: true,
+  });
+
+  // Set seats
+  const seatsInput = screen.getByLabelText('Seats');
+  expect(seatsInput).toHaveValue(1);
+  userEvent.clear(seatsInput);
+  userEvent.type(seatsInput, '2');
+
+  // Set term
+  userEvent.type(screen.getByLabelText('Term'), newContest.termDescription!);
+
+  // Set write-ins allowed
+  const writeInsControl = screen.getByLabelText('Write-Ins Allowed?');
+  within(writeInsControl).getByRole('option', {
+    name: 'Yes',
+    selected: true,
+  });
+  userEvent.click(within(writeInsControl).getByRole('option', { name: 'No' }));
+
+  // Add candidates
+  screen.getByText("You haven't added any candidates to this contest yet.");
+  for (const [i, candidate] of newContest.candidates.entries()) {
+    userEvent.click(screen.getByRole('button', { name: 'Add Candidate' }));
+    screen.getByRole('columnheader', { name: 'First Name' });
+    screen.getByRole('columnheader', { name: 'Last Name' });
+    screen.getByRole('columnheader', { name: 'Party' });
+    const row = screen.getAllByRole('row')[i + 1];
+
+    // Set name
+    userEvent.type(
+      within(row).getByLabelText(`Candidate ${i + 1} First Name`),
+      'New Candidate'
+    );
+    userEvent.type(
+      within(row).getByLabelText(`Candidate ${i + 1} Last Name`),
+      `${i + 1}`
+    );
+
+    // Set party
+    const partySelect = within(row).getByLabelText(`Candidate ${i + 1} Party`);
+    expect(partySelect).toHaveValue('');
+    userEvent.click(partySelect);
+    const party = election.parties.find(
+      (p) => p.id === candidate.partyIds?.[0]
+    );
+    if (party) {
+      userEvent.click(within(row).getByText(party.name));
+    }
   }
 
-  test('adding a candidate contest (general election)', async () => {
+  // Save contest
+  apiMock.createContest
+    .expectCallWith({ electionId, newContest })
+    .resolves(ok());
+  apiMock.listContests.expectCallWith({ electionId }).resolves([newContest]);
+  expectOtherElectionApiCalls(election);
+  const saveButton = screen.getByRole('button', { name: 'Save' });
+  userEvent.click(saveButton);
+
+  await screen.findByRole('heading', { name: 'Contests' });
+  screen.getByRole('columnheader', { name: 'Title' });
+  screen.getByRole('columnheader', { name: 'District' });
+
+  const candidateRows = getContestTableRows('candidate');
+  expect(candidateRows).toHaveLength(2); // header + 1 contest row
+  expect(
+    within(candidateRows[1])
+      .getAllByRole('cell')
+      .map((cell) => cell.textContent)
+  ).toEqual([newContest.title, election.districts[0].name, 'Edit']);
+});
+
+test('editing a candidate contest (primary election)', async () => {
+  const electionRecord = makeElectionRecord(
+    {
+      id: electionWithNoContestsRecord.election.id,
+      title: 'Test Primary Election',
+      type: 'primary',
+      date: DateWithoutTime.today(),
+      state: 'CA',
+      county: { id: 'test-county', name: 'Test County' },
+      districts: [
+        {
+          id: unsafeParse(DistrictIdSchema, 'test-district-1'),
+          name: 'Test District 1',
+        },
+        {
+          id: unsafeParse(DistrictIdSchema, 'test-district-2'),
+          name: 'Test District 2',
+        },
+      ],
+      precincts: [
+        {
+          id: 'test-precinct-1',
+          name: 'Test Precinct 1',
+          districtIds: [unsafeParse(DistrictIdSchema, 'test-district-1')],
+        },
+        {
+          id: 'test-precinct-2',
+          name: 'Test Precinct 2',
+          districtIds: [],
+        },
+      ],
+      ballotStyles: [
+        {
+          id: unsafeParse(BallotStyleIdSchema, 'test-ballot-style-1'),
+          groupId: unsafeParse(BallotStyleGroupIdSchema, 'test-ballot-group-1'),
+          districts: [unsafeParse(DistrictIdSchema, 'test-district-1')],
+          precincts: [unsafeParse(PrecinctIdSchema, 'test-precinct-1')],
+          partyId: unsafeParse(PartyIdSchema, 'test-party-1'),
+        },
+        {
+          id: unsafeParse(BallotStyleIdSchema, 'test-ballot-style-2'),
+          groupId: unsafeParse(BallotStyleGroupIdSchema, 'test-ballot-group-2'),
+          districts: [unsafeParse(DistrictIdSchema, 'test-district-1')],
+          precincts: [unsafeParse(PrecinctIdSchema, 'test-precinct-1')],
+          partyId: unsafeParse(PartyIdSchema, 'test-party-2'),
+        },
+      ],
+      parties: [
+        {
+          id: unsafeParse(PartyIdSchema, 'test-party-1'),
+          name: 'Test Party 1',
+          fullName: 'Test Party 1',
+          abbrev: 'TP1',
+        },
+        {
+          id: unsafeParse(PartyIdSchema, 'test-party-2'),
+          name: 'Test Party 2',
+          fullName: 'Test Party 2',
+          abbrev: 'TP2',
+        },
+      ],
+      contests: [
+        {
+          id: 'test-contest-1',
+          type: 'candidate',
+          title: 'Test Contest 1',
+          districtId: unsafeParse(DistrictIdSchema, 'test-district-1'),
+          seats: 1,
+          partyId: unsafeParse(PartyIdSchema, 'test-party-1'),
+          allowWriteIns: false,
+          candidates: [
+            {
+              id: 'test-candidate-1',
+              name: 'Test Candidate 1',
+              firstName: 'Test',
+              middleName: 'Candidate',
+              lastName: '1',
+              partyIds: [unsafeParse(PartyIdSchema, 'test-party-1')],
+            },
+            {
+              id: 'test-candidate-2',
+              name: 'Test Candidate 2',
+              firstName: 'Test',
+              middleName: 'Candidate',
+              lastName: '2',
+              partyIds: [unsafeParse(PartyIdSchema, 'test-party-1')],
+            },
+            {
+              id: 'test-candidate-3',
+              name: 'Test Candidate 3',
+              firstName: 'Test',
+              middleName: 'Candidate',
+              lastName: '3',
+              partyIds: [unsafeParse(PartyIdSchema, 'test-party-1')],
+            },
+          ],
+        },
+      ],
+      seal: '',
+      ballotLayout: {
+        metadataEncoding: 'qr-code',
+        paperSize: HmpbBallotPaperSize.Letter,
+      },
+      ballotStrings: {},
+    },
+    user.orgId
+  );
+  const { election } = electionRecord;
+  const electionId = election.id;
+  const savedContest = election.contests.find(
+    (contest): contest is CandidateContest => contest.type === 'candidate'
+  )!;
+  const savedDistrict = election.districts.find(
+    (district) => district.id === savedContest.districtId
+  )!;
+  const savedParty = election.parties.find(
+    (party) => party.id === savedContest.partyId
+  )!;
+  const updatedDistrict = election.districts.find(
+    (district) => district.id !== savedContest.districtId
+  )!;
+  const updatedParty = election.parties.find(
+    (party) => party.id !== savedContest.partyId
+  )!;
+
+  assert(savedContest.candidates.length > 2);
+  const updatedContest: CandidateContest = {
+    ...savedContest,
+    title: 'Updated Contest Title',
+    districtId: updatedDistrict.id,
+    partyId: updatedParty.id,
+    seats: savedContest.seats + 1,
+    allowWriteIns: !savedContest.allowWriteIns,
+    termDescription: 'Updated Term Description',
+    candidates: [
+      {
+        ...savedContest.candidates[1],
+        name: 'Updated Candidate Name',
+        firstName: 'Updated',
+        middleName: 'Candidate',
+        lastName: 'Name',
+        partyIds: undefined,
+      },
+      ...savedContest.candidates.slice(2),
+    ],
+  };
+
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(election.contests);
+  expectOtherElectionApiCalls(election);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+  renderScreen(electionId);
+
+  await screen.findByRole('heading', { name: 'Contests' });
+  screen.getByRole('columnheader', { name: 'Title' });
+  screen.getByRole('columnheader', { name: 'District' });
+  screen.getByRole('columnheader', { name: 'Party' });
+
+  // Count total rows across all tables
+  const allRows = getAllContestRows();
+  // We expect a header per table + candidate contest rows + ballot measure rows
+  const candidateContests = election.contests.filter(
+    (c) => c.type === 'candidate'
+  );
+  const ballotMeasures = election.contests.filter((c) => c.type === 'yesno');
+  const expectedRowCount =
+    (candidateContests.length > 0 ? candidateContests.length + 1 : 0) +
+    (ballotMeasures.length > 0 ? ballotMeasures.length + 1 : 0);
+  expect(allRows).toHaveLength(expectedRowCount);
+
+  const savedContestRow = screen.getByText(savedContest.title).closest('tr')!;
+  within(savedContestRow).getByText(savedDistrict.name);
+  within(savedContestRow).getByText(savedParty.name);
+  userEvent.click(
+    within(savedContestRow).getByRole('button', { name: 'Edit' })
+  );
+
+  await screen.findByRole('heading', { name: 'Edit Contest' });
+  expect(screen.getByRole('link', { name: 'Contests' })).toHaveAttribute(
+    'href',
+    `/elections/${electionId}/contests`
+  );
+
+  // Change title
+  const titleInput = screen.getByLabelText('Title');
+  expect(titleInput).toHaveValue(savedContest.title);
+  userEvent.clear(titleInput);
+  userEvent.type(titleInput, updatedContest.title);
+
+  // Change district
+  userEvent.click(screen.getByText(savedDistrict.name));
+  userEvent.click(screen.getByText(updatedDistrict.name));
+
+  // Change party
+  userEvent.click(
+    within(
+      screen.getByLabelText('Party').parentElement!.parentElement!
+    ).getByText(savedParty.name)
+  );
+  userEvent.click(screen.getByText(updatedParty.name));
+
+  // Change seats
+  const seatsInput = screen.getByLabelText('Seats');
+  expect(seatsInput).toHaveValue(savedContest.seats);
+  userEvent.clear(seatsInput);
+  userEvent.type(seatsInput, updatedContest.seats.toString());
+
+  // Change term
+  const termInput = screen.getByLabelText('Term');
+  expect(termInput).toHaveValue(savedContest.termDescription ?? '');
+  userEvent.clear(termInput);
+  userEvent.type(termInput, updatedContest.termDescription!);
+
+  // Change write-ins allowed
+  const writeInsControl = screen.getByLabelText('Write-Ins Allowed?');
+  within(writeInsControl).getByRole('option', {
+    name: 'No',
+    selected: true,
+  });
+  userEvent.click(within(writeInsControl).getByRole('option', { name: 'Yes' }));
+
+  // Confirm candidates
+  const candidateRows = screen.getAllByRole('row');
+  expect(candidateRows).toHaveLength(savedContest.candidates.length + 1);
+  for (const [i, candidate] of savedContest.candidates.entries()) {
+    const row = candidateRows[i + 1];
+    expect(
+      within(row).getByLabelText(`Candidate ${i + 1} First Name`)
+    ).toHaveValue(candidate.firstName);
+    const party = election.parties.find(
+      (p) => p.id === candidate.partyIds?.[0]
+    )!;
+    within(row).getByText(party.name);
+  }
+
+  // Edit candidate 2
+  const nameUpdateSpec = [
+    {
+      labelText: 'First',
+      nameValue: assertDefined(updatedContest.candidates[0].firstName),
+    },
+    {
+      labelText: 'Middle',
+      nameValue: assertDefined(updatedContest.candidates[0].middleName),
+    },
+    {
+      labelText: 'Last',
+      nameValue: assertDefined(updatedContest.candidates[0].lastName),
+    },
+  ];
+  for (const spec of nameUpdateSpec) {
+    const input = within(candidateRows[2]).getByLabelText(
+      `Candidate 2 ${spec.labelText} Name`
+    );
+    userEvent.clear(input);
+    userEvent.type(input, spec.nameValue);
+  }
+
+  const partySelect = within(candidateRows[2]).getByLabelText(
+    'Candidate 2 Party'
+  );
+  userEvent.click(partySelect);
+  userEvent.click(within(candidateRows[2]).getByText('No Party Affiliation'));
+
+  // Remove candidate 1
+  userEvent.click(
+    within(candidateRows[1]).getByRole('button', {
+      name: 'Remove Candidate Test Candidate 1',
+    })
+  );
+  await waitFor(() => {
+    expect(screen.getAllByRole('row')).toHaveLength(
+      savedContest.candidates.length
+    );
+    expect(
+      screen.queryByText(savedContest.candidates[0].name)
+    ).not.toBeInTheDocument();
+  });
+
+  // Save contest
+  apiMock.updateContest
+    .expectCallWith({ electionId, updatedContest })
+    .resolves(ok());
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves([updatedContest]);
+  expectOtherElectionApiCalls(election);
+  const saveButton = screen.getByRole('button', { name: 'Save' });
+  userEvent.click(saveButton);
+
+  await screen.findByRole('heading', { name: 'Contests' });
+
+  const updatedContestRow = screen
+    .getByText(updatedContest.title)
+    .closest('tr')!;
+  within(updatedContestRow).getByText(updatedDistrict.name);
+  within(updatedContestRow).getByText(updatedParty.name);
+});
+
+interface NameTestSpec {
+  description: string;
+  firstName: string;
+  middleName?: string;
+  lastName: string;
+  expectedNormalizedName: string;
+}
+
+const nameTestSpecs: NameTestSpec[] = [
+  {
+    description: 'first and last name',
+    firstName: 'Thomas',
+    lastName: 'Edison',
+    expectedNormalizedName: 'Thomas Edison',
+  },
+  {
+    description: 'all name fields',
+    firstName: 'Thomas',
+    middleName: 'Alva',
+    lastName: 'Edison',
+    expectedNormalizedName: 'Thomas Alva Edison',
+  },
+  {
+    description: 'whitespace',
+    firstName: ' Thomas ',
+    middleName: 'Alva',
+    lastName: 'Edison ',
+    expectedNormalizedName: 'Thomas Alva Edison',
+  },
+];
+test.each(nameTestSpecs)(
+  'name concatenation for test case: $description',
+  async ({ firstName, middleName, lastName, expectedNormalizedName }) => {
     const { election } = electionWithNoContestsRecord;
     const electionId = election.id;
     const newContest: CandidateContest = {
@@ -194,32 +661,15 @@ describe('Contests tab', () => {
       type: 'candidate',
       title: 'New Contest',
       districtId: election.districts[0].id,
-      seats: 2,
-      termDescription: '2 years',
-      allowWriteIns: false,
+      seats: 1,
+      allowWriteIns: true,
       candidates: [
         {
           id: idFactory.next(),
-          name: 'New Candidate 1',
-          firstName: 'New Candidate',
-          middleName: undefined,
-          lastName: '1',
-          partyIds: [election.parties[0].id],
-        },
-        {
-          id: idFactory.next(),
-          name: 'New Candidate 2',
-          firstName: 'New Candidate',
-          middleName: undefined,
-          lastName: '2',
-          partyIds: [election.parties[1].id],
-        },
-        {
-          id: idFactory.next(),
-          name: 'New Candidate 3',
-          firstName: 'New Candidate',
-          middleName: undefined,
-          lastName: '3',
+          name: expectedNormalizedName,
+          firstName: firstName.trim(),
+          middleName: middleName?.trim(),
+          lastName: lastName.trim(),
         },
       ],
     };
@@ -235,10 +685,6 @@ describe('Contests tab', () => {
     // Add contest
     userEvent.click(screen.getByRole('button', { name: 'Add Contest' }));
     await screen.findByRole('heading', { name: 'Add Contest' });
-    expect(screen.getByRole('link', { name: 'Contests' })).toHaveAttribute(
-      'href',
-      `/elections/${electionId}/contests`
-    );
 
     // Set title
     userEvent.type(screen.getByLabelText('Title'), newContest.title);
@@ -257,52 +703,35 @@ describe('Contests tab', () => {
     const seatsInput = screen.getByLabelText('Seats');
     expect(seatsInput).toHaveValue(1);
     userEvent.clear(seatsInput);
-    userEvent.type(seatsInput, '2');
+    userEvent.type(seatsInput, '1');
 
-    // Set term
-    userEvent.type(screen.getByLabelText('Term'), newContest.termDescription!);
-
-    // Set write-ins allowed
-    const writeInsControl = screen.getByLabelText('Write-Ins Allowed?');
-    within(writeInsControl).getByRole('option', {
-      name: 'Yes',
-      selected: true,
-    });
-    userEvent.click(
-      within(writeInsControl).getByRole('option', { name: 'No' })
-    );
-
-    // Add candidates
+    // Add candidate
     screen.getByText("You haven't added any candidates to this contest yet.");
-    for (const [i, candidate] of newContest.candidates.entries()) {
-      userEvent.click(screen.getByRole('button', { name: 'Add Candidate' }));
-      screen.getByRole('columnheader', { name: 'First Name' });
-      screen.getByRole('columnheader', { name: 'Last Name' });
-      screen.getByRole('columnheader', { name: 'Party' });
-      const row = screen.getAllByRole('row')[i + 1];
+    userEvent.click(screen.getByRole('button', { name: 'Add Candidate' }));
+    screen.getByRole('columnheader', { name: 'First Name' });
+    screen.getByRole('columnheader', { name: 'Last Name' });
+    screen.getByRole('columnheader', { name: 'Party' });
+    const candidateRows = screen.getAllByRole('row');
+    // First row is headers
+    expect(candidateRows).toHaveLength(2);
+    const row = candidateRows[1];
 
-      // Set name
+    // Set name
+    userEvent.type(
+      within(row).getByLabelText(`Candidate 1 First Name`),
+      firstName
+    );
+    if (middleName) {
       userEvent.type(
-        within(row).getByLabelText(`Candidate ${i + 1} First Name`),
-        'New Candidate'
+        within(row).getByLabelText(`Candidate 1 Middle Name`),
+        middleName
       );
+    }
+    if (lastName) {
       userEvent.type(
-        within(row).getByLabelText(`Candidate ${i + 1} Last Name`),
-        `${i + 1}`
+        within(row).getByLabelText(`Candidate 1 Last Name`),
+        lastName
       );
-
-      // Set party
-      const partySelect = within(row).getByLabelText(
-        `Candidate ${i + 1} Party`
-      );
-      expect(partySelect).toHaveValue('');
-      userEvent.click(partySelect);
-      const party = election.parties.find(
-        (p) => p.id === candidate.partyIds?.[0]
-      );
-      if (party) {
-        userEvent.click(within(row).getByText(party.name));
-      }
     }
 
     // Save contest
@@ -318,986 +747,610 @@ describe('Contests tab', () => {
     screen.getByRole('columnheader', { name: 'Title' });
     screen.getByRole('columnheader', { name: 'District' });
 
-    const candidateRows = getContestTableRows('candidate');
-    expect(candidateRows).toHaveLength(2); // header + 1 contest row
+    const contestRows = getContestTableRows('candidate');
+    expect(contestRows).toHaveLength(2); // header + 1 contest row
     expect(
-      within(candidateRows[1])
+      within(contestRows[1])
         .getAllByRole('cell')
         .map((cell) => cell.textContent)
     ).toEqual([newContest.title, election.districts[0].name, 'Edit']);
-  });
-
-  test('editing a candidate contest (primary election)', async () => {
-    const electionRecord = makeElectionRecord(
-      {
-        id: electionWithNoContestsRecord.election.id,
-        title: 'Test Primary Election',
-        type: 'primary',
-        date: DateWithoutTime.today(),
-        state: 'CA',
-        county: { id: 'test-county', name: 'Test County' },
-        districts: [
-          {
-            id: unsafeParse(DistrictIdSchema, 'test-district-1'),
-            name: 'Test District 1',
-          },
-          {
-            id: unsafeParse(DistrictIdSchema, 'test-district-2'),
-            name: 'Test District 2',
-          },
-        ],
-        precincts: [
-          {
-            id: 'test-precinct-1',
-            name: 'Test Precinct 1',
-            districtIds: [unsafeParse(DistrictIdSchema, 'test-district-1')],
-          },
-          {
-            id: 'test-precinct-2',
-            name: 'Test Precinct 2',
-            districtIds: [],
-          },
-        ],
-        ballotStyles: [
-          {
-            id: unsafeParse(BallotStyleIdSchema, 'test-ballot-style-1'),
-            groupId: unsafeParse(
-              BallotStyleGroupIdSchema,
-              'test-ballot-group-1'
-            ),
-            districts: [unsafeParse(DistrictIdSchema, 'test-district-1')],
-            precincts: [unsafeParse(PrecinctIdSchema, 'test-precinct-1')],
-            partyId: unsafeParse(PartyIdSchema, 'test-party-1'),
-          },
-          {
-            id: unsafeParse(BallotStyleIdSchema, 'test-ballot-style-2'),
-            groupId: unsafeParse(
-              BallotStyleGroupIdSchema,
-              'test-ballot-group-2'
-            ),
-            districts: [unsafeParse(DistrictIdSchema, 'test-district-1')],
-            precincts: [unsafeParse(PrecinctIdSchema, 'test-precinct-1')],
-            partyId: unsafeParse(PartyIdSchema, 'test-party-2'),
-          },
-        ],
-        parties: [
-          {
-            id: unsafeParse(PartyIdSchema, 'test-party-1'),
-            name: 'Test Party 1',
-            fullName: 'Test Party 1',
-            abbrev: 'TP1',
-          },
-          {
-            id: unsafeParse(PartyIdSchema, 'test-party-2'),
-            name: 'Test Party 2',
-            fullName: 'Test Party 2',
-            abbrev: 'TP2',
-          },
-        ],
-        contests: [
-          {
-            id: 'test-contest-1',
-            type: 'candidate',
-            title: 'Test Contest 1',
-            districtId: unsafeParse(DistrictIdSchema, 'test-district-1'),
-            seats: 1,
-            partyId: unsafeParse(PartyIdSchema, 'test-party-1'),
-            allowWriteIns: false,
-            candidates: [
-              {
-                id: 'test-candidate-1',
-                name: 'Test Candidate 1',
-                firstName: 'Test',
-                middleName: 'Candidate',
-                lastName: '1',
-                partyIds: [unsafeParse(PartyIdSchema, 'test-party-1')],
-              },
-              {
-                id: 'test-candidate-2',
-                name: 'Test Candidate 2',
-                firstName: 'Test',
-                middleName: 'Candidate',
-                lastName: '2',
-                partyIds: [unsafeParse(PartyIdSchema, 'test-party-1')],
-              },
-              {
-                id: 'test-candidate-3',
-                name: 'Test Candidate 3',
-                firstName: 'Test',
-                middleName: 'Candidate',
-                lastName: '3',
-                partyIds: [unsafeParse(PartyIdSchema, 'test-party-1')],
-              },
-            ],
-          },
-        ],
-        seal: '',
-        ballotLayout: {
-          metadataEncoding: 'qr-code',
-          paperSize: HmpbBallotPaperSize.Letter,
-        },
-        ballotStrings: {},
-      },
-      user.orgId
-    );
-    const { election } = electionRecord;
-    const electionId = election.id;
-    const savedContest = election.contests.find(
-      (contest): contest is CandidateContest => contest.type === 'candidate'
-    )!;
-    const savedDistrict = election.districts.find(
-      (district) => district.id === savedContest.districtId
-    )!;
-    const savedParty = election.parties.find(
-      (party) => party.id === savedContest.partyId
-    )!;
-    const updatedDistrict = election.districts.find(
-      (district) => district.id !== savedContest.districtId
-    )!;
-    const updatedParty = election.parties.find(
-      (party) => party.id !== savedContest.partyId
-    )!;
-
-    assert(savedContest.candidates.length > 2);
-    const updatedContest: CandidateContest = {
-      ...savedContest,
-      title: 'Updated Contest Title',
-      districtId: updatedDistrict.id,
-      partyId: updatedParty.id,
-      seats: savedContest.seats + 1,
-      allowWriteIns: !savedContest.allowWriteIns,
-      termDescription: 'Updated Term Description',
-      candidates: [
-        {
-          ...savedContest.candidates[1],
-          name: 'Updated Candidate Name',
-          firstName: 'Updated',
-          middleName: 'Candidate',
-          lastName: 'Name',
-          partyIds: undefined,
-        },
-        ...savedContest.candidates.slice(2),
-      ],
-    };
-
-    apiMock.listContests
-      .expectCallWith({ electionId })
-      .resolves(election.contests);
-    expectOtherElectionApiCalls(election);
-    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-    renderScreen(electionId);
-
-    await screen.findByRole('heading', { name: 'Contests' });
-    screen.getByRole('columnheader', { name: 'Title' });
-    screen.getByRole('columnheader', { name: 'District' });
-    screen.getByRole('columnheader', { name: 'Party' });
-
-    // Count total rows across all tables
-    const allRows = getAllContestRows();
-    // We expect a header per table + candidate contest rows + ballot measure rows
-    const candidateContests = election.contests.filter(
-      (c) => c.type === 'candidate'
-    );
-    const ballotMeasures = election.contests.filter((c) => c.type === 'yesno');
-    const expectedRowCount =
-      (candidateContests.length > 0 ? candidateContests.length + 1 : 0) +
-      (ballotMeasures.length > 0 ? ballotMeasures.length + 1 : 0);
-    expect(allRows).toHaveLength(expectedRowCount);
-
-    const savedContestRow = screen.getByText(savedContest.title).closest('tr')!;
-    within(savedContestRow).getByText(savedDistrict.name);
-    within(savedContestRow).getByText(savedParty.name);
-    userEvent.click(
-      within(savedContestRow).getByRole('button', { name: 'Edit' })
-    );
-
-    await screen.findByRole('heading', { name: 'Edit Contest' });
-    expect(screen.getByRole('link', { name: 'Contests' })).toHaveAttribute(
-      'href',
-      `/elections/${electionId}/contests`
-    );
-
-    // Change title
-    const titleInput = screen.getByLabelText('Title');
-    expect(titleInput).toHaveValue(savedContest.title);
-    userEvent.clear(titleInput);
-    userEvent.type(titleInput, updatedContest.title);
-
-    // Change district
-    userEvent.click(screen.getByText(savedDistrict.name));
-    userEvent.click(screen.getByText(updatedDistrict.name));
-
-    // Change party
-    userEvent.click(
-      within(
-        screen.getByLabelText('Party').parentElement!.parentElement!
-      ).getByText(savedParty.name)
-    );
-    userEvent.click(screen.getByText(updatedParty.name));
-
-    // Change seats
-    const seatsInput = screen.getByLabelText('Seats');
-    expect(seatsInput).toHaveValue(savedContest.seats);
-    userEvent.clear(seatsInput);
-    userEvent.type(seatsInput, updatedContest.seats.toString());
-
-    // Change term
-    const termInput = screen.getByLabelText('Term');
-    expect(termInput).toHaveValue(savedContest.termDescription ?? '');
-    userEvent.clear(termInput);
-    userEvent.type(termInput, updatedContest.termDescription!);
-
-    // Change write-ins allowed
-    const writeInsControl = screen.getByLabelText('Write-Ins Allowed?');
-    within(writeInsControl).getByRole('option', {
-      name: 'No',
-      selected: true,
-    });
-    userEvent.click(
-      within(writeInsControl).getByRole('option', { name: 'Yes' })
-    );
-
-    // Confirm candidates
-    const candidateRows = screen.getAllByRole('row');
-    expect(candidateRows).toHaveLength(savedContest.candidates.length + 1);
-    for (const [i, candidate] of savedContest.candidates.entries()) {
-      const row = candidateRows[i + 1];
-      expect(
-        within(row).getByLabelText(`Candidate ${i + 1} First Name`)
-      ).toHaveValue(candidate.firstName);
-      const party = election.parties.find(
-        (p) => p.id === candidate.partyIds?.[0]
-      )!;
-      within(row).getByText(party.name);
-    }
-
-    // Edit candidate 2
-    const nameUpdateSpec = [
-      {
-        labelText: 'First',
-        nameValue: assertDefined(updatedContest.candidates[0].firstName),
-      },
-      {
-        labelText: 'Middle',
-        nameValue: assertDefined(updatedContest.candidates[0].middleName),
-      },
-      {
-        labelText: 'Last',
-        nameValue: assertDefined(updatedContest.candidates[0].lastName),
-      },
-    ];
-    for (const spec of nameUpdateSpec) {
-      const input = within(candidateRows[2]).getByLabelText(
-        `Candidate 2 ${spec.labelText} Name`
-      );
-      userEvent.clear(input);
-      userEvent.type(input, spec.nameValue);
-    }
-
-    const partySelect = within(candidateRows[2]).getByLabelText(
-      'Candidate 2 Party'
-    );
-    userEvent.click(partySelect);
-    userEvent.click(within(candidateRows[2]).getByText('No Party Affiliation'));
-
-    // Remove candidate 1
-    userEvent.click(
-      within(candidateRows[1]).getByRole('button', { name: 'Remove' })
-    );
-    await waitFor(() => {
-      expect(screen.getAllByRole('row')).toHaveLength(
-        savedContest.candidates.length
-      );
-      expect(
-        screen.queryByText(savedContest.candidates[0].name)
-      ).not.toBeInTheDocument();
-    });
-
-    // Save contest
-    apiMock.updateContest
-      .expectCallWith({ electionId, updatedContest })
-      .resolves(ok());
-    apiMock.listContests
-      .expectCallWith({ electionId })
-      .resolves([updatedContest]);
-    expectOtherElectionApiCalls(election);
-    const saveButton = screen.getByRole('button', { name: 'Save' });
-    userEvent.click(saveButton);
-
-    await screen.findByRole('heading', { name: 'Contests' });
-
-    const updatedContestRow = screen
-      .getByText(updatedContest.title)
-      .closest('tr')!;
-    within(updatedContestRow).getByText(updatedDistrict.name);
-    within(updatedContestRow).getByText(updatedParty.name);
-  });
-
-  interface NameTestSpec {
-    description: string;
-    firstName: string;
-    middleName?: string;
-    lastName: string;
-    expectedNormalizedName: string;
   }
+);
 
-  const nameTestSpecs: NameTestSpec[] = [
-    {
-      description: 'first and last name',
-      firstName: 'Thomas',
-      lastName: 'Edison',
-      expectedNormalizedName: 'Thomas Edison',
+test('adding a ballot measure', async () => {
+  const electionRecord = generalElectionRecord(user.orgId);
+  const { election } = electionRecord;
+  const electionId = election.id;
+  const id = idFactory.next();
+  idFactory.next(); // Skip over the extra ballot measure ID created when switching to ballot measure type
+  const newContest: YesNoContest = {
+    type: 'yesno',
+    title: 'New Ballot Measure',
+    id,
+    districtId: election.districts[0].id,
+    description: 'New Ballot Measure Description',
+    yesOption: {
+      id: idFactory.next(),
+      label: 'Yes',
     },
-    {
-      description: 'all name fields',
-      firstName: 'Thomas',
-      middleName: 'Alva',
-      lastName: 'Edison',
-      expectedNormalizedName: 'Thomas Alva Edison',
+    noOption: {
+      id: idFactory.next(),
+      label: 'No',
     },
-    {
-      description: 'whitespace',
-      firstName: ' Thomas ',
-      middleName: 'Alva',
-      lastName: 'Edison ',
-      expectedNormalizedName: 'Thomas Alva Edison',
+  };
+
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(election.contests);
+  expectOtherElectionApiCalls(election);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+  renderScreen(electionId);
+
+  await screen.findByRole('heading', { name: 'Contests' });
+  userEvent.click(screen.getByRole('button', { name: 'Add Contest' }));
+
+  // Set title
+  userEvent.type(screen.getByLabelText('Title'), newContest.title);
+
+  // Set district
+  userEvent.click(screen.getByLabelText('District'));
+  userEvent.click(screen.getByText(election.districts[0].name));
+
+  // Change type to ballot measure
+  userEvent.click(screen.getByRole('option', { name: 'Ballot Measure' }));
+
+  // Set description
+  const descriptionEditor = within(
+    screen.getByText('Description').parentElement!
+  ).getByTestId('rich-text-editor');
+  userEvent.type(
+    descriptionEditor.querySelector('.tiptap p')!,
+    newContest.description
+  );
+  await within(descriptionEditor).findByText(newContest.description);
+
+  const yesInput = screen.getByLabelText('First Option Label');
+  const noInput = screen.getByLabelText('Second Option Label');
+  userEvent.clear(yesInput);
+  userEvent.type(yesInput, newContest.yesOption.label);
+  userEvent.clear(noInput);
+  userEvent.type(noInput, newContest.noOption.label);
+
+  await within(descriptionEditor).findByText(newContest.description);
+  const descriptionHtml = `<p>${newContest.description}</p>`;
+
+  // Save contest
+  const newContestWithDescriptionHtml: YesNoContest = {
+    ...newContest,
+    description: descriptionHtml,
+  };
+  apiMock.createContest
+    .expectCallWith({ electionId, newContest: newContestWithDescriptionHtml })
+    .resolves(ok());
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves([...election.contests, newContestWithDescriptionHtml]);
+  expectOtherElectionApiCalls(election);
+  const saveButton = screen.getByRole('button', { name: 'Save' });
+  userEvent.click(saveButton);
+
+  await screen.findByRole('heading', { name: 'Contests' });
+
+  const ballotMeasureRows = getContestTableRows('yesno');
+  // We expect existing ballot measures + 1 new + 1 header
+  const existingBallotMeasures = election.contests.filter(
+    (c) => c.type === 'yesno'
+  ).length;
+  expect(ballotMeasureRows).toHaveLength(existingBallotMeasures + 1 + 1);
+  const lastRow = ballotMeasureRows.at(-1)!;
+  expect(
+    within(lastRow)
+      .getAllByRole('cell')
+      .map((cell) => cell.textContent)
+  ).toEqual([newContest.title, election.districts[0].name, 'Edit']);
+});
+
+test('editing a ballot measure', async () => {
+  const electionRecord = generalElectionRecord(user.orgId);
+  const { election } = electionRecord;
+  const electionId = election.id;
+  const savedContest = election.contests.find(
+    (contest): contest is YesNoContest => contest.type === 'yesno'
+  )!;
+  const savedDistrict = election.districts.find(
+    (district) => district.id === savedContest.districtId
+  )!;
+  const updatedDistrict = election.districts.find(
+    (district) => district.id !== savedContest.districtId
+  )!;
+  const updatedContest: YesNoContest = {
+    ...savedContest,
+    title: 'Updated Ballot Measure Title',
+    districtId: updatedDistrict.id,
+    description: 'Updated Ballot Measure Description',
+    yesOption: {
+      ...savedContest.yesOption,
+      label: 'Yea',
     },
-  ];
-  test.each(nameTestSpecs)(
-    'name concatenation for test case: $description',
-    async ({ firstName, middleName, lastName, expectedNormalizedName }) => {
-      const { election } = electionWithNoContestsRecord;
-      const electionId = election.id;
-      const newContest: CandidateContest = {
-        id: idFactory.next(),
-        type: 'candidate',
-        title: 'New Contest',
-        districtId: election.districts[0].id,
-        seats: 1,
-        allowWriteIns: true,
-        candidates: [
-          {
-            id: idFactory.next(),
-            name: expectedNormalizedName,
-            firstName: firstName.trim(),
-            middleName: middleName?.trim(),
-            lastName: lastName.trim(),
-          },
-        ],
-      };
+    noOption: {
+      ...savedContest.noOption,
+      label: 'Nay',
+    },
+  };
 
-      apiMock.listContests.expectCallWith({ electionId }).resolves([]);
-      expectOtherElectionApiCalls(election);
-      apiMock.getBallotsFinalizedAt
-        .expectCallWith({ electionId })
-        .resolves(null);
-      renderScreen(electionId);
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(election.contests);
+  expectOtherElectionApiCalls(election);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+  renderScreen(electionId);
 
-      await screen.findByRole('heading', { name: 'Contests' });
-      screen.getByText("You haven't added any contests to this election yet.");
-
-      // Add contest
-      userEvent.click(screen.getByRole('button', { name: 'Add Contest' }));
-      await screen.findByRole('heading', { name: 'Add Contest' });
-
-      // Set title
-      userEvent.type(screen.getByLabelText('Title'), newContest.title);
-
-      // Set district
-      userEvent.click(screen.getByLabelText('District'));
-      userEvent.click(screen.getByText(election.districts[0].name));
-
-      // Default type is candidate contest
-      within(screen.getByLabelText('Type')).getByRole('option', {
-        name: 'Candidate Contest',
-        selected: true,
-      });
-
-      // Set seats
-      const seatsInput = screen.getByLabelText('Seats');
-      expect(seatsInput).toHaveValue(1);
-      userEvent.clear(seatsInput);
-      userEvent.type(seatsInput, '1');
-
-      // Add candidate
-      screen.getByText("You haven't added any candidates to this contest yet.");
-      userEvent.click(screen.getByRole('button', { name: 'Add Candidate' }));
-      screen.getByRole('columnheader', { name: 'First Name' });
-      screen.getByRole('columnheader', { name: 'Last Name' });
-      screen.getByRole('columnheader', { name: 'Party' });
-      const candidateRows = screen.getAllByRole('row');
-      // First row is headers
-      expect(candidateRows).toHaveLength(2);
-      const row = candidateRows[1];
-
-      // Set name
-      userEvent.type(
-        within(row).getByLabelText(`Candidate 1 First Name`),
-        firstName
-      );
-      if (middleName) {
-        userEvent.type(
-          within(row).getByLabelText(`Candidate 1 Middle Name`),
-          middleName
-        );
-      }
-      if (lastName) {
-        userEvent.type(
-          within(row).getByLabelText(`Candidate 1 Last Name`),
-          lastName
-        );
-      }
-
-      // Save contest
-      apiMock.createContest
-        .expectCallWith({ electionId, newContest })
-        .resolves(ok());
-      apiMock.listContests
-        .expectCallWith({ electionId })
-        .resolves([newContest]);
-      expectOtherElectionApiCalls(election);
-      const saveButton = screen.getByRole('button', { name: 'Save' });
-      userEvent.click(saveButton);
-
-      await screen.findByRole('heading', { name: 'Contests' });
-      screen.getByRole('columnheader', { name: 'Title' });
-      screen.getByRole('columnheader', { name: 'District' });
-
-      const contestRows = getContestTableRows('candidate');
-      expect(contestRows).toHaveLength(2); // header + 1 contest row
-      expect(
-        within(contestRows[1])
-          .getAllByRole('cell')
-          .map((cell) => cell.textContent)
-      ).toEqual([newContest.title, election.districts[0].name, 'Edit']);
-    }
+  await screen.findByRole('heading', { name: 'Contests' });
+  const savedContestRow = screen.getByText(savedContest.title).closest('tr')!;
+  within(savedContestRow).getByText(savedDistrict.name);
+  userEvent.click(
+    within(savedContestRow).getByRole('button', { name: 'Edit' })
   );
 
-  test('adding a ballot measure', async () => {
-    const electionRecord = generalElectionRecord(user.orgId);
-    const { election } = electionRecord;
-    const electionId = election.id;
-    const id = idFactory.next();
-    idFactory.next(); // Skip over the extra ballot measure ID created when switching to ballot measure type
-    const newContest: YesNoContest = {
-      type: 'yesno',
-      title: 'New Ballot Measure',
-      id,
-      districtId: election.districts[0].id,
-      description: 'New Ballot Measure Description',
-      yesOption: {
-        id: idFactory.next(),
-        label: 'Yes',
-      },
-      noOption: {
-        id: idFactory.next(),
-        label: 'No',
-      },
-    };
+  await screen.findByRole('heading', { name: 'Edit Contest' });
 
-    apiMock.listContests
-      .expectCallWith({ electionId })
-      .resolves(election.contests);
-    expectOtherElectionApiCalls(election);
-    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-    renderScreen(electionId);
+  // Change title
+  const titleInput = screen.getByLabelText('Title');
+  expect(titleInput).toHaveValue(savedContest.title);
+  userEvent.clear(titleInput);
+  userEvent.type(titleInput, updatedContest.title);
 
-    await screen.findByRole('heading', { name: 'Contests' });
-    userEvent.click(screen.getByRole('button', { name: 'Add Contest' }));
+  // Change district
+  userEvent.click(screen.getByText(savedDistrict.name));
+  userEvent.click(screen.getByText(updatedDistrict.name));
 
-    // Set title
-    userEvent.type(screen.getByLabelText('Title'), newContest.title);
-
-    // Set district
-    userEvent.click(screen.getByLabelText('District'));
-    userEvent.click(screen.getByText(election.districts[0].name));
-
-    // Change type to ballot measure
-    userEvent.click(screen.getByRole('option', { name: 'Ballot Measure' }));
-
-    // Set description
-    const descriptionEditor = within(
-      screen.getByText('Description').parentElement!
-    ).getByTestId('rich-text-editor');
-    userEvent.type(
-      descriptionEditor.querySelector('.tiptap p')!,
-      newContest.description
-    );
-    await within(descriptionEditor).findByText(newContest.description);
-
-    const yesInput = screen.getByLabelText('First Option Label');
-    const noInput = screen.getByLabelText('Second Option Label');
-    userEvent.clear(yesInput);
-    userEvent.type(yesInput, newContest.yesOption.label);
-    userEvent.clear(noInput);
-    userEvent.type(noInput, newContest.noOption.label);
-
-    await within(descriptionEditor).findByText(newContest.description);
-    const descriptionHtml = `<p>${newContest.description}</p>`;
-
-    // Save contest
-    const newContestWithDescriptionHtml: YesNoContest = {
-      ...newContest,
-      description: descriptionHtml,
-    };
-    apiMock.createContest
-      .expectCallWith({ electionId, newContest: newContestWithDescriptionHtml })
-      .resolves(ok());
-    apiMock.listContests
-      .expectCallWith({ electionId })
-      .resolves([...election.contests, newContestWithDescriptionHtml]);
-    expectOtherElectionApiCalls(election);
-    const saveButton = screen.getByRole('button', { name: 'Save' });
-    userEvent.click(saveButton);
-
-    await screen.findByRole('heading', { name: 'Contests' });
-
-    const ballotMeasureRows = getContestTableRows('yesno');
-    // We expect existing ballot measures + 1 new + 1 header
-    const existingBallotMeasures = election.contests.filter(
-      (c) => c.type === 'yesno'
-    ).length;
-    expect(ballotMeasureRows).toHaveLength(existingBallotMeasures + 1 + 1);
-    const lastRow = ballotMeasureRows.at(-1)!;
-    expect(
-      within(lastRow)
-        .getAllByRole('cell')
-        .map((cell) => cell.textContent)
-    ).toEqual([newContest.title, election.districts[0].name, 'Edit']);
+  // Change description
+  const descriptionEditor = within(
+    screen.getByText('Description').parentElement!
+  ).getByTestId('rich-text-editor');
+  within(descriptionEditor).getByText(savedContest.description);
+  // userEvent.type doesn't work for updating the content for some reason
+  fireEvent.change(descriptionEditor.querySelector('.tiptap p')!, {
+    target: { textContent: updatedContest.description },
   });
+  await within(descriptionEditor).findByText(updatedContest.description);
+  const descriptionHtml = `<p>${updatedContest.description}</p>`;
 
-  test('editing a ballot measure', async () => {
-    const electionRecord = generalElectionRecord(user.orgId);
-    const { election } = electionRecord;
-    const electionId = election.id;
-    const savedContest = election.contests.find(
-      (contest): contest is YesNoContest => contest.type === 'yesno'
-    )!;
-    const savedDistrict = election.districts.find(
-      (district) => district.id === savedContest.districtId
-    )!;
-    const updatedDistrict = election.districts.find(
-      (district) => district.id !== savedContest.districtId
-    )!;
-    const updatedContest: YesNoContest = {
-      ...savedContest,
-      title: 'Updated Ballot Measure Title',
-      districtId: updatedDistrict.id,
-      description: 'Updated Ballot Measure Description',
-      yesOption: {
-        ...savedContest.yesOption,
-        label: 'Yea',
-      },
-      noOption: {
-        ...savedContest.noOption,
-        label: 'Nay',
-      },
-    };
+  // Change yes and no labels
+  const yesInput = screen.getByLabelText('First Option Label');
+  expect(yesInput).toHaveValue(savedContest.yesOption.label);
+  userEvent.clear(yesInput);
+  userEvent.type(yesInput, updatedContest.yesOption.label);
 
-    apiMock.listContests
-      .expectCallWith({ electionId })
-      .resolves(election.contests);
-    expectOtherElectionApiCalls(election);
-    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-    renderScreen(electionId);
+  const noInput = screen.getByLabelText('Second Option Label');
+  expect(noInput).toHaveValue(savedContest.noOption.label);
+  userEvent.clear(noInput);
+  userEvent.type(noInput, updatedContest.noOption.label);
 
-    await screen.findByRole('heading', { name: 'Contests' });
-    const savedContestRow = screen.getByText(savedContest.title).closest('tr')!;
-    within(savedContestRow).getByText(savedDistrict.name);
-    userEvent.click(
-      within(savedContestRow).getByRole('button', { name: 'Edit' })
-    );
-
-    await screen.findByRole('heading', { name: 'Edit Contest' });
-
-    // Change title
-    const titleInput = screen.getByLabelText('Title');
-    expect(titleInput).toHaveValue(savedContest.title);
-    userEvent.clear(titleInput);
-    userEvent.type(titleInput, updatedContest.title);
-
-    // Change district
-    userEvent.click(screen.getByText(savedDistrict.name));
-    userEvent.click(screen.getByText(updatedDistrict.name));
-
-    // Change description
-    const descriptionEditor = within(
-      screen.getByText('Description').parentElement!
-    ).getByTestId('rich-text-editor');
-    within(descriptionEditor).getByText(savedContest.description);
-    // userEvent.type doesn't work for updating the content for some reason
-    fireEvent.change(descriptionEditor.querySelector('.tiptap p')!, {
-      target: { textContent: updatedContest.description },
-    });
-    await within(descriptionEditor).findByText(updatedContest.description);
-    const descriptionHtml = `<p>${updatedContest.description}</p>`;
-
-    // Change yes and no labels
-    const yesInput = screen.getByLabelText('First Option Label');
-    expect(yesInput).toHaveValue(savedContest.yesOption.label);
-    userEvent.clear(yesInput);
-    userEvent.type(yesInput, updatedContest.yesOption.label);
-
-    const noInput = screen.getByLabelText('Second Option Label');
-    expect(noInput).toHaveValue(savedContest.noOption.label);
-    userEvent.clear(noInput);
-    userEvent.type(noInput, updatedContest.noOption.label);
-
-    // Save contest
-    const updatedContestWithDescriptionHtml: YesNoContest = {
-      ...updatedContest,
-      description: descriptionHtml,
-    };
-    apiMock.updateContest
-      .expectCallWith({
-        electionId,
-        updatedContest: updatedContestWithDescriptionHtml,
-      })
-      .resolves(ok());
-    apiMock.listContests
-      .expectCallWith({ electionId })
-      .resolves(
-        election.contests.map((contest) =>
-          contest.id === savedContest.id
-            ? updatedContestWithDescriptionHtml
-            : contest
-        )
-      );
-    expectOtherElectionApiCalls(election);
-    const saveButton = screen.getByRole('button', { name: 'Save' });
-    userEvent.click(saveButton);
-
-    await screen.findByRole('heading', { name: 'Contests' });
-    const updatedContestRow = screen
-      .getByText(updatedContest.title)
-      .closest('tr')!;
-    within(updatedContestRow).getByText(updatedDistrict.name);
-  });
-
-  test('reordering contests', async () => {
-    const electionRecord = generalElectionRecord(user.orgId);
-    const { election } = electionRecord;
-    const electionId = election.id;
-    // Mock needed for react-flip-toolkit
-    window.matchMedia = vi.fn().mockImplementation(() => ({
-      matches: false,
-    }));
-
-    apiMock.listContests
-      .expectCallWith({ electionId })
-      .resolves(election.contests);
-    expectOtherElectionApiCalls(election);
-    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-    renderScreen(electionId);
-
-    await screen.findByRole('heading', { name: 'Contests' });
-
-    function getRowOrder() {
-      return screen
-        .getAllByRole('row')
-        .slice(1) // Skip header row
-        .map((row) => row.childNodes[0].textContent);
-    }
-
-    const originalOrder = getRowOrder();
-
-    userEvent.click(screen.getByRole('button', { name: 'Reorder Contests' }));
-    expect(screen.getByRole('button', { name: 'Add Contest' })).toBeDisabled();
-
-    userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-    expect(getRowOrder()).toEqual(originalOrder);
-
-    userEvent.click(screen.getByRole('button', { name: 'Reorder Contests' }));
-
-    const [contest1Title, contest2Title, contest3Title] = originalOrder;
-    const contest1Row = screen.getByText(contest1Title!).closest('tr')!;
-    expect(
-      within(contest1Row).getByRole('button', { name: 'Move Up' })
-    ).toBeDisabled();
-    userEvent.click(
-      within(contest1Row).getByRole('button', { name: 'Move Down' })
-    );
-
-    const contest3Row = screen.getByText(contest3Title!).closest('tr')!;
-    userEvent.click(
-      within(contest3Row).getByRole('button', { name: 'Move Up' })
-    );
-
-    const lastContestRow = screen.getAllByRole('row').at(-1)!;
-    expect(
-      within(lastContestRow).getByRole('button', { name: 'Move Down' })
-    ).toBeDisabled();
-
-    const newOrder = [
-      contest2Title,
-      contest3Title,
-      contest1Title,
-      ...originalOrder.slice(3),
-    ];
-    expect(getRowOrder()).toEqual(newOrder);
-
-    const reorderedContests = [
-      election.contests[1],
-      election.contests[2],
-      election.contests[0],
-      ...election.contests.slice(3),
-    ];
-    apiMock.reorderContests
-      .expectCallWith({
-        electionId,
-        contestIds: reorderedContests.map((contest) => contest.id),
-      })
-      .resolves();
-    apiMock.listContests
-      .expectCallWith({ electionId })
-      .resolves(reorderedContests);
-    expectOtherElectionApiCalls(election);
-    userEvent.click(screen.getByRole('button', { name: 'Save' }));
-
-    await screen.findByRole('button', { name: 'Reorder Contests' });
-    expect(getRowOrder()).toEqual(newOrder);
-  }, 20000);
-
-  test('deleting a contest', async () => {
-    const electionRecord = generalElectionRecord(user.orgId);
-    const { election } = electionRecord;
-    const electionId = election.id;
-    const [savedContest] = election.contests;
-
-    apiMock.listContests
-      .expectCallWith({ electionId })
-      .resolves(election.contests);
-    expectOtherElectionApiCalls(election);
-    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-    renderScreen(electionId);
-
-    await screen.findByRole('heading', { name: 'Contests' });
-    const contestRow = screen.getByText(savedContest.title).closest('tr')!;
-    userEvent.click(within(contestRow).getByRole('button', { name: 'Edit' }));
-    await screen.findByRole('heading', { name: 'Edit Contest' });
-
-    apiMock.deleteContest
-      .expectCallWith({ electionId, contestId: savedContest.id })
-      .resolves();
-    apiMock.listContests
-      .expectCallWith({ electionId })
-      .resolves(election.contests.slice(1));
-    expectOtherElectionApiCalls(election);
-    // Initiate the deletion
-    userEvent.click(screen.getByRole('button', { name: 'Delete Contest' }));
-    // Confirm the deletion in the modal
-    userEvent.click(screen.getByRole('button', { name: 'Delete Contest' }));
-
-    await screen.findByRole('heading', { name: 'Contests' });
-
-    const allRows = getAllContestRows();
-    const remainingContests = election.contests.slice(1);
-    const candidateContests = remainingContests.filter(
-      (c) => c.type === 'candidate'
-    );
-    const ballotMeasures = remainingContests.filter((c) => c.type === 'yesno');
-    const expectedRowCount =
-      (candidateContests.length > 0 ? candidateContests.length + 1 : 0) +
-      (ballotMeasures.length > 0 ? ballotMeasures.length + 1 : 0);
-    expect(allRows).toHaveLength(expectedRowCount);
-    expect(screen.queryByText(savedContest.title)).not.toBeInTheDocument();
-  });
-
-  test('changing contests is disabled when ballots are finalized', async () => {
-    const electionRecord = generalElectionRecord(user.orgId);
-    const { election } = electionRecord;
-    const electionId = election.id;
-    // Mock needed for react-flip-toolkit
-    window.matchMedia = vi.fn().mockImplementation(() => ({
-      matches: false,
-    }));
-
-    apiMock.listContests
-      .expectCallWith({ electionId })
-      .resolves(election.contests);
-    expectOtherElectionApiCalls(election);
-    apiMock.getBallotsFinalizedAt
-      .expectCallWith({ electionId })
-      .resolves(new Date());
-    renderScreen(electionId);
-
-    await screen.findByRole('heading', { name: 'Contests' });
-
-    expect(
-      screen.getByRole('button', { name: 'Reorder Contests' })
-    ).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Add Contest' })).toBeDisabled();
-
-    const savedContest = election.contests.find(
-      (contest): contest is CandidateContest => contest.type === 'candidate'
-    )!;
-    const savedContestRow = screen.getByText(savedContest.title).closest('tr')!;
-    expect(
-      within(savedContestRow).getByRole('button', { name: 'Edit' })
-    ).toBeDisabled();
-  });
-
-  test('cancelling', async () => {
-    const electionRecord = generalElectionRecord(user.orgId);
-    const { election } = electionRecord;
-    const electionId = election.id;
-
-    apiMock.listContests
-      .expectCallWith({ electionId })
-      .resolves(election.contests);
-    expectOtherElectionApiCalls(election);
-    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-    renderScreen(electionId);
-
-    await screen.findByRole('heading', { name: 'Contests' });
-    userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[0]);
-    await screen.findByRole('heading', { name: 'Edit Contest' });
-    userEvent.click(screen.getByRole('button', { name: 'Delete Contest' }));
-    await screen.findByRole('heading', { name: 'Delete Contest' });
-    // Cancel delete contest confirmation modal
-    userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-    await waitFor(() => {
-      expect(
-        screen.queryByRole('heading', { name: 'Delete Contest' })
-      ).not.toBeInTheDocument();
-    });
-
-    // Cancel edit contest
-    userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-    await screen.findByRole('heading', { name: 'Contests' });
-  });
-
-  test('error messages for duplicate candidate contest/candidates', async () => {
-    const electionRecord = generalElectionRecord(user.orgId);
-    const { election } = electionRecord;
-    const electionId = election.id;
-
-    apiMock.listContests
-      .expectCallWith({ electionId })
-      .resolves(election.contests);
-    expectOtherElectionApiCalls(election);
-    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-    renderScreen(electionId);
-
-    await screen.findByRole('heading', { name: 'Contests' });
-    userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[1]);
-    await screen.findByRole('heading', { name: 'Edit Contest' });
-
-    // Mock the duplicate contest error, even though we didn't actually change anything
-    apiMock.updateContest
-      .expectCallWith({
-        electionId,
-        updatedContest: election.contests[1],
-      })
-      .resolves(err('duplicate-contest'));
-    userEvent.click(screen.getByRole('button', { name: 'Save' }));
-
-    await screen.findByText(
-      'There is already a contest with the same district, title, seats, and term.'
-    );
-
-    // Mock the duplicate candidate error
-    apiMock.updateContest
-      .expectCallWith({
-        electionId,
-        updatedContest: election.contests[1],
-      })
-      .resolves(err('duplicate-candidate'));
-    userEvent.click(screen.getByRole('button', { name: 'Save' }));
-
-    await screen.findByText('Candidates must have different names.');
-  });
-
-  test('error messages for duplicate ballot measure', async () => {
-    const electionRecord = generalElectionRecord(user.orgId);
-    const { election } = electionRecord;
-    const electionId = election.id;
-    const ballotMeasureContest = find(
-      election.contests,
-      (contest): contest is YesNoContest => contest.type === 'yesno'
-    );
-
-    apiMock.listContests
-      .expectCallWith({ electionId })
-      .resolves(election.contests);
-    expectOtherElectionApiCalls(election);
-    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-    renderScreen(electionId);
-
-    await screen.findByRole('heading', { name: 'Contests' });
-    userEvent.click(
-      within(
-        screen.getByText(ballotMeasureContest.title).closest('tr')!
-      ).getByRole('button', { name: 'Edit' })
-    );
-    await screen.findByRole('heading', { name: 'Edit Contest' });
-
-    // Mock the duplicate contest error, even though we didn't actually change anything
-    apiMock.updateContest
-      .expectCallWith({
-        electionId,
-        updatedContest: ballotMeasureContest,
-      })
-      .resolves(err('duplicate-contest'));
-    userEvent.click(screen.getByRole('button', { name: 'Save' }));
-
-    await screen.findByText(
-      'There is already a contest with the same district and title.'
-    );
-
-    // Mock the duplicate option error
-    apiMock.updateContest
-      .expectCallWith({
-        electionId,
-        updatedContest: ballotMeasureContest,
-      })
-      .resolves(err('duplicate-option'));
-    userEvent.click(screen.getByRole('button', { name: 'Save' }));
-
-    await screen.findByText('Options must have different labels.');
-  });
-
-  test('error messages for candidate contest with no candidates and write-ins disallowed', async () => {
-    const electionRecord = generalElectionRecord(user.orgId);
-    const { election } = electionRecord;
-    const electionId = election.id;
-    const candidateContest = find(
-      election.contests,
-      (contest): contest is CandidateContest => contest.type === 'candidate'
-    );
-
-    apiMock.listContests
-      .expectCallWith({ electionId })
-      .resolves(election.contests);
-    expectOtherElectionApiCalls(election);
-    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-    renderScreen(electionId);
-
-    await screen.findByRole('heading', { name: 'Contests' });
-    userEvent.click(
-      within(screen.getByText(candidateContest.title).closest('tr')!).getByRole(
-        'button',
-        { name: 'Edit' }
+  // Save contest
+  const updatedContestWithDescriptionHtml: YesNoContest = {
+    ...updatedContest,
+    description: descriptionHtml,
+  };
+  apiMock.updateContest
+    .expectCallWith({
+      electionId,
+      updatedContest: updatedContestWithDescriptionHtml,
+    })
+    .resolves(ok());
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(
+      election.contests.map((contest) =>
+        contest.id === savedContest.id
+          ? updatedContestWithDescriptionHtml
+          : contest
       )
     );
-    await screen.findByRole('heading', { name: 'Edit Contest' });
+  expectOtherElectionApiCalls(election);
+  const saveButton = screen.getByRole('button', { name: 'Save' });
+  userEvent.click(saveButton);
 
-    // Remove all candidates
-    for (const row of screen.getAllByRole('row').slice(1)) {
-      userEvent.click(within(row).getByRole('button', { name: 'Remove' }));
-    }
-    // Disallow write-ins
-    const writeInsControl = screen.getByLabelText('Write-Ins Allowed?');
-    userEvent.click(
-      within(writeInsControl).getByRole('option', { name: 'No' })
-    );
+  await screen.findByRole('heading', { name: 'Contests' });
+  const updatedContestRow = screen
+    .getByText(updatedContest.title)
+    .closest('tr')!;
+  within(updatedContestRow).getByText(updatedDistrict.name);
+});
+
+test('reordering contests', async () => {
+  const electionRecord = generalElectionRecord(user.orgId);
+  const { election } = electionRecord;
+  const electionId = election.id;
+  // Mock needed for react-flip-toolkit
+  window.matchMedia = vi.fn().mockImplementation(() => ({
+    matches: false,
+  }));
+
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(election.contests);
+  expectOtherElectionApiCalls(election);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+  renderScreen(electionId);
+
+  await screen.findByRole('heading', { name: 'Contests' });
+
+  function getRowOrder() {
+    return screen
+      .getAllByRole('row')
+      .slice(1) // Skip header row
+      .map((row) => row.childNodes[0].textContent);
+  }
+
+  const originalOrder = getRowOrder();
+
+  userEvent.click(screen.getByRole('button', { name: 'Reorder Contests' }));
+  expect(screen.getByRole('button', { name: 'Add Contest' })).toBeDisabled();
+
+  userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+  expect(getRowOrder()).toEqual(originalOrder);
+
+  userEvent.click(screen.getByRole('button', { name: 'Reorder Contests' }));
+
+  const [contest1Title, contest2Title, contest3Title] = originalOrder;
+  const contest1Row = screen.getByText(contest1Title!).closest('tr')!;
+  expect(
+    within(contest1Row).getByRole('button', { name: 'Move Up' })
+  ).toBeDisabled();
+  userEvent.click(
+    within(contest1Row).getByRole('button', { name: 'Move Down' })
+  );
+
+  const contest3Row = screen.getByText(contest3Title!).closest('tr')!;
+  userEvent.click(within(contest3Row).getByRole('button', { name: 'Move Up' }));
+
+  const lastContestRow = screen.getAllByRole('row').at(-1)!;
+  expect(
+    within(lastContestRow).getByRole('button', { name: 'Move Down' })
+  ).toBeDisabled();
+
+  const newOrder = [
+    contest2Title,
+    contest3Title,
+    contest1Title,
+    ...originalOrder.slice(3),
+  ];
+  expect(getRowOrder()).toEqual(newOrder);
+
+  const reorderedContests = [
+    election.contests[1],
+    election.contests[2],
+    election.contests[0],
+    ...election.contests.slice(3),
+  ];
+  apiMock.reorderContests
+    .expectCallWith({
+      electionId,
+      contestIds: reorderedContests.map((contest) => contest.id),
+    })
+    .resolves();
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(reorderedContests);
+  expectOtherElectionApiCalls(election);
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+  await screen.findByRole('button', { name: 'Reorder Contests' });
+  expect(getRowOrder()).toEqual(newOrder);
+}, 20000);
+
+test('deleting a contest', async () => {
+  const electionRecord = generalElectionRecord(user.orgId);
+  const { election } = electionRecord;
+  const electionId = election.id;
+  const [savedContest] = election.contests;
+
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(election.contests);
+  expectOtherElectionApiCalls(election);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+  renderScreen(electionId);
+
+  await screen.findByRole('heading', { name: 'Contests' });
+  const contestRow = screen.getByText(savedContest.title).closest('tr')!;
+  userEvent.click(within(contestRow).getByRole('button', { name: 'Edit' }));
+  await screen.findByRole('heading', { name: 'Edit Contest' });
+
+  apiMock.deleteContest
+    .expectCallWith({ electionId, contestId: savedContest.id })
+    .resolves();
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(election.contests.slice(1));
+  expectOtherElectionApiCalls(election);
+  // Initiate the deletion
+  userEvent.click(screen.getByRole('button', { name: 'Delete Contest' }));
+  // Confirm the deletion in the modal
+  userEvent.click(screen.getByRole('button', { name: 'Delete Contest' }));
+
+  await screen.findByRole('heading', { name: 'Contests' });
+
+  const allRows = getAllContestRows();
+  const remainingContests = election.contests.slice(1);
+  const candidateContests = remainingContests.filter(
+    (c) => c.type === 'candidate'
+  );
+  const ballotMeasures = remainingContests.filter((c) => c.type === 'yesno');
+  const expectedRowCount =
+    (candidateContests.length > 0 ? candidateContests.length + 1 : 0) +
+    (ballotMeasures.length > 0 ? ballotMeasures.length + 1 : 0);
+  expect(allRows).toHaveLength(expectedRowCount);
+  expect(screen.queryByText(savedContest.title)).not.toBeInTheDocument();
+});
+
+test('changing contests is disabled when ballots are finalized', async () => {
+  const electionRecord = generalElectionRecord(user.orgId);
+  const { election } = electionRecord;
+  const electionId = election.id;
+  // Mock needed for react-flip-toolkit
+  window.matchMedia = vi.fn().mockImplementation(() => ({
+    matches: false,
+  }));
+
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(election.contests);
+  expectOtherElectionApiCalls(election);
+  apiMock.getBallotsFinalizedAt
+    .expectCallWith({ electionId })
+    .resolves(new Date());
+  renderScreen(electionId);
+
+  await screen.findByRole('heading', { name: 'Contests' });
+
+  expect(
+    screen.getByRole('button', { name: 'Reorder Contests' })
+  ).toBeDisabled();
+  expect(screen.getByRole('button', { name: 'Add Contest' })).toBeDisabled();
+
+  const savedContest = election.contests.find(
+    (contest): contest is CandidateContest => contest.type === 'candidate'
+  )!;
+  const savedContestRow = screen.getByText(savedContest.title).closest('tr')!;
+  expect(
+    within(savedContestRow).getByRole('button', { name: 'Edit' })
+  ).toBeDisabled();
+});
+
+test('cancelling', async () => {
+  const electionRecord = generalElectionRecord(user.orgId);
+  const { election } = electionRecord;
+  const electionId = election.id;
+
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(election.contests);
+  expectOtherElectionApiCalls(election);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+  renderScreen(electionId);
+
+  await screen.findByRole('heading', { name: 'Contests' });
+  userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[0]);
+  await screen.findByRole('heading', { name: 'Edit Contest' });
+  userEvent.click(screen.getByRole('button', { name: 'Delete Contest' }));
+  await screen.findByRole('heading', { name: 'Delete Contest' });
+  // Cancel delete contest confirmation modal
+  userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+  await waitFor(() => {
     expect(
-      within(writeInsControl).getByRole('option', { name: 'No' })
-    ).toHaveAttribute('aria-selected', 'true');
-
-    userEvent.click(screen.getByRole('button', { name: 'Save' }));
-    await screen.findByText(
-      /contest must have at least one candidate or allow write-ins./i
-    );
+      screen.queryByRole('heading', { name: 'Delete Contest' })
+    ).not.toBeInTheDocument();
   });
+
+  // Cancel edit contest
+  userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+  await screen.findByRole('heading', { name: 'Contests' });
+});
+
+test('error messages for duplicate candidate contest/candidates', async () => {
+  const electionRecord = generalElectionRecord(user.orgId);
+  const { election } = electionRecord;
+  const electionId = election.id;
+
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(election.contests);
+  expectOtherElectionApiCalls(election);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+  renderScreen(electionId);
+
+  await screen.findByRole('heading', { name: 'Contests' });
+  userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[1]);
+  await screen.findByRole('heading', { name: 'Edit Contest' });
+
+  // Mock the duplicate contest error, even though we didn't actually change anything
+  apiMock.updateContest
+    .expectCallWith({
+      electionId,
+      updatedContest: election.contests[1],
+    })
+    .resolves(err('duplicate-contest'));
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+  await screen.findByText(
+    'There is already a contest with the same district, title, seats, and term.'
+  );
+
+  // Mock the duplicate candidate error
+  apiMock.updateContest
+    .expectCallWith({
+      electionId,
+      updatedContest: election.contests[1],
+    })
+    .resolves(err('duplicate-candidate'));
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+  await screen.findByText('Candidates must have different names.');
+});
+
+test('error messages for duplicate ballot measure', async () => {
+  const electionRecord = generalElectionRecord(user.orgId);
+  const { election } = electionRecord;
+  const electionId = election.id;
+  const ballotMeasureContest = find(
+    election.contests,
+    (contest): contest is YesNoContest => contest.type === 'yesno'
+  );
+
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(election.contests);
+  expectOtherElectionApiCalls(election);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+  renderScreen(electionId);
+
+  await screen.findByRole('heading', { name: 'Contests' });
+  userEvent.click(
+    within(
+      screen.getByText(ballotMeasureContest.title).closest('tr')!
+    ).getByRole('button', { name: 'Edit' })
+  );
+  await screen.findByRole('heading', { name: 'Edit Contest' });
+
+  // Mock the duplicate contest error, even though we didn't actually change anything
+  apiMock.updateContest
+    .expectCallWith({
+      electionId,
+      updatedContest: ballotMeasureContest,
+    })
+    .resolves(err('duplicate-contest'));
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+  await screen.findByText(
+    'There is already a contest with the same district and title.'
+  );
+
+  // Mock the duplicate option error
+  apiMock.updateContest
+    .expectCallWith({
+      electionId,
+      updatedContest: ballotMeasureContest,
+    })
+    .resolves(err('duplicate-option'));
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+  await screen.findByText('Options must have different labels.');
+});
+
+test('error messages for candidate contest with no candidates and write-ins disallowed', async () => {
+  const electionRecord = generalElectionRecord(user.orgId);
+  const { election } = electionRecord;
+  const electionId = election.id;
+  const candidateContest = find(
+    election.contests,
+    (contest): contest is CandidateContest => contest.type === 'candidate'
+  );
+
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(election.contests);
+  expectOtherElectionApiCalls(election);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+  renderScreen(electionId);
+
+  await screen.findByRole('heading', { name: 'Contests' });
+  userEvent.click(
+    within(screen.getByText(candidateContest.title).closest('tr')!).getByRole(
+      'button',
+      { name: 'Edit' }
+    )
+  );
+  await screen.findByRole('heading', { name: 'Edit Contest' });
+
+  // Remove all candidates
+  for (const row of screen.getAllByRole('row').slice(1)) {
+    userEvent.click(within(row).getByRole('button', { name: /Remove/ }));
+  }
+  // Disallow write-ins
+  const writeInsControl = screen.getByLabelText('Write-Ins Allowed?');
+  userEvent.click(within(writeInsControl).getByRole('option', { name: 'No' }));
+  expect(
+    within(writeInsControl).getByRole('option', { name: 'No' })
+  ).toHaveAttribute('aria-selected', 'true');
+
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+  await screen.findByText(
+    /contest must have at least one candidate or allow write-ins./i
+  );
+});
+
+test('disables form and shows edit button when in "view" mode', async () => {
+  const electionRecord = generalElectionRecord(user.orgId);
+  const { election } = electionRecord;
+  const electionId = election.id;
+  const [savedContest] = election.contests;
+
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(election.contests);
+  expectOtherElectionApiCalls(election);
+
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+
+  const history = renderScreen(electionId);
+  history.replace(
+    routes.election(electionId).contests.view(savedContest.id).path
+  );
+
+  await screen.findByRole('heading', { name: 'Edit Contest' });
+
+  // Initial "view" state:
+
+  screen.getButton('Edit');
+  screen.getButton('Delete Contest');
+  expect(screen.queryButton('Cancel')).not.toBeInTheDocument();
+  expect(screen.queryButton('Save')).not.toBeInTheDocument();
+  expect(screen.queryButton(/Remove Candidate/)).not.toBeInTheDocument();
+
+  const inputs = screen.queryAllByRole('textbox');
+  expect(inputs.length).toBeGreaterThan(0);
+  for (const input of inputs) expect(input).toBeDisabled();
+
+  const options = screen.queryAllByRole('option');
+  expect(options.length).toBeGreaterThan(0);
+  for (const option of options) expect(option).toBeDisabled();
+
+  // Switch to "edit" state:
+
+  userEvent.click(screen.getButton('Edit'));
+
+  await screen.findButton('Save');
+  screen.getButton('Cancel');
+  screen.getButton('Delete Contest');
+  expect(screen.queryButton('Edit')).not.toBeInTheDocument();
+});
+
+test('form actions omitted when election is finalized', async () => {
+  const electionRecord = generalElectionRecord(user.orgId);
+  const { election } = electionRecord;
+  const electionId = election.id;
+  const [savedContest] = election.contests;
+
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(election.contests);
+
+  expectOtherElectionApiCalls(election);
+
+  apiMock.getBallotsFinalizedAt
+    .expectCallWith({ electionId })
+    .resolves(new Date());
+
+  const history = renderScreen(electionId);
+  history.replace(
+    routes.election(electionId).contests.view(savedContest.id).path
+  );
+
+  await screen.findByRole('heading', { name: 'Edit Contest' });
+  expect(screen.queryButton('Edit')).not.toBeInTheDocument();
+  expect(screen.queryButton('Cancel')).not.toBeInTheDocument();
+  expect(screen.queryButton('Save')).not.toBeInTheDocument();
+  expect(screen.queryButton('Delete Contest')).not.toBeInTheDocument();
 });

--- a/apps/design/frontend/src/form_fixed.tsx
+++ b/apps/design/frontend/src/form_fixed.tsx
@@ -1,5 +1,7 @@
 import { DesktopPalette } from '@votingworks/ui';
 import styled, { css } from 'styled-components';
+import { cssThemedScrollbars } from './scrollbars';
+import { StyledRichTextEditor } from './rich_text_editor';
 
 export const FormBody = styled.div`
   display: flex;
@@ -9,6 +11,8 @@ export const FormBody = styled.div`
   height: 100%;
   overflow: auto;
   padding: 1rem;
+
+  ${cssThemedScrollbars}
 
   input[type='text'] {
     min-width: 18rem;
@@ -52,9 +56,10 @@ export interface FormFixedProps {
  */
 const cssFormViewMode = css`
   input,
-  .search-select > div {
-    background-color: ${(p) => p.theme.colors.background};
-    color: ${(p) => p.theme.colors.onBackground};
+  .search-select > div,
+  ${StyledRichTextEditor} {
+    background-color: ${(p) => p.theme.colors.background} !important;
+    color: ${(p) => p.theme.colors.onBackground} !important;
   }
 `;
 

--- a/apps/design/frontend/src/rich_text_editor.tsx
+++ b/apps/design/frontend/src/rich_text_editor.tsx
@@ -31,14 +31,30 @@ import React from 'react';
 import { Buffer } from 'node:buffer';
 import { ImageInputButton } from './image_input';
 
-const StyledEditor = styled.div`
+const ControlGroup = styled.div`
+  display: flex;
+  gap: 0.125rem;
+  border: ${(p) => p.theme.sizes.bordersRem.thin}rem solid
+    ${(p) => p.theme.colors.outline};
+  border-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
+
+  > button,
+  > label /* Image input button is rendered as a label */ {
+    border: 0;
+  }
+`;
+
+export const StyledRichTextEditor = styled.div`
+  --rich-text-editor-padding: 0.5rem;
+
   cursor: text;
   border: ${(p) => p.theme.sizes.bordersRem.thin}rem solid
     ${(p) => p.theme.colors.outline};
   background: ${(p) => p.theme.colors.containerLow};
-  padding: 0.5rem;
+  padding: var(--rich-text-editor-padding);
   line-height: ${(p) => p.theme.sizes.lineHeight};
   border-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
+  max-width: calc(75ch + (2 * var(--rich-text-editor-padding)));
 
   &:focus-within {
     background: none;
@@ -61,7 +77,12 @@ const StyledEditor = styled.div`
   }
 
   &[data-disabled='true'] {
+    border-style: dashed;
     cursor: not-allowed;
+
+    ${ControlGroup} {
+      border-style: dashed;
+    }
   }
 
   overflow: auto;
@@ -76,14 +97,6 @@ const StyledToolbar = styled.div`
     padding: 0.25rem 0.5rem;
     gap: 0.25rem;
   }
-`;
-
-const ControlGroup = styled.div`
-  display: flex;
-  gap: 0.125rem;
-  border: ${(p) => p.theme.sizes.bordersRem.thin}rem solid
-    ${(p) => p.theme.colors.outline};
-  border-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
 `;
 
 function ControlButton({
@@ -343,13 +356,13 @@ export function RichTextEditor({
     },
   });
   return (
-    <StyledEditor
+    <StyledRichTextEditor
       data-testid="rich-text-editor"
       data-disabled={disabled}
       onClick={() => editor?.chain().focus().run()}
     >
       {editor && <Toolbar disabled={disabled} editor={editor} />}
       <EditorContent editor={editor} />
-    </StyledEditor>
+    </StyledRichTextEditor>
   );
 }

--- a/apps/design/frontend/src/routes.ts
+++ b/apps/design/frontend/src/routes.ts
@@ -82,11 +82,15 @@ export const routes = {
           title: 'Contests',
           path: `${root}/contests`,
         },
-        addContest: {
+        add: {
           title: 'Add Contest',
           path: `${root}/contests/add`,
         },
-        editContest: (contestId: string) => ({
+        edit: (contestId: string) => ({
+          title: 'Edit Contest',
+          path: `${root}/contests/${contestId}/edit`,
+        }),
+        view: (contestId: string) => ({
           title: 'Edit Contest',
           path: `${root}/contests/${contestId}`,
         }),

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -78,6 +78,7 @@ import {
   faStrikethrough,
   faTable,
   faTextHeight,
+  faTrash,
   faUnderline,
   faVolumeHigh,
   faVolumeMute,
@@ -543,6 +544,10 @@ export const Icons = {
 
   TextSize(props) {
     return <FaIcon {...props} type={faTextHeight} />;
+  },
+
+  Trash(props) {
+    return <FaIcon {...props} type={faTrash} />;
   },
 
   Underline(props) {


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7266

_Easier to review with whitespace ignored - lots of nesting level changes_

Applying contest form layout updates as part of the [move to in-context audio editing](https://www.figma.com/design/g5S6rv7kYH8kfEomZTzZqr/-VxDesign--In-Context-Audio-Editing?node-id=0-1&p=f&t=ZzE35pCJaQd6Zs0f-0) and having a persistent contest list while editing:
- Use a fixed-footer layout for the form to keep action buttons accessible on large contests
- Group a few inputs into rows where feasible to reduce vertical space usage
- Add a "view" state (not yet reachable), similar to the Election Info form, with an "Edit" button and all fields disabled
  - Special-casing the "view" state to override the low-contrast disabled styling to improve readability in that state. The default disabled styling still applies when a save operation is in progress.
- Add a bit more sizing flexibility to inputs, since we'll be adding a contest list sidebar
- Switch candidate deletion button to icon, for visual consistency with upcoming audio preview/edit button

## Demo Video or Screenshot

| View | Edit |
| -- | -- |
| <img width="1920" height="1081" alt="Screenshot 2025-12-02 at 13 39 21" src="https://github.com/user-attachments/assets/3ecebdad-6008-4c58-8282-7a1c1579b4b7" /> | <img width="1920" height="1081" alt="Screenshot 2025-12-02 at 13 39 31" src="https://github.com/user-attachments/assets/ca0e6dea-f6a5-4669-8dde-2a1c575945df" /> |

https://github.com/user-attachments/assets/c1fb499d-f278-4406-8332-52e42ea8bcf9

## Testing Plan
- Existing tests for edit functionality, a few additional ones for "view" state
- Styling spot checks in Chrome, FF, Safari

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
