### PR TITLE
Fix portrait no card reader screen text alignment

### DIFF
--- a/libs/ui/src/setup_card_reader_page.tsx
+++ b/libs/ui/src/setup_card_reader_page.tsx
@@ -6,10 +6,10 @@ import { Caption, H1, P } from './typography';
 export function SetupCardReaderPage(): JSX.Element {
   return (
     <Screen>
-      <Main centerChild>
-        <H1>Card Reader Not Detected</H1>
-        <P>{ERROR_SCREEN_MESSAGES.RESTART}</P>
-        <Caption>{ERROR_SCREEN_MESSAGES.REACH_OUT}</Caption>
+      <Main centerChild padded>
+        <H1 align="center">Card Reader Not Detected</H1>
+        <P align="center">{ERROR_SCREEN_MESSAGES.RESTART}</P>
+        <Caption align="center">{ERROR_SCREEN_MESSAGES.REACH_OUT}</Caption>
       </Main>
     </Screen>
   );


### PR DESCRIPTION
## Overview

While working on https://github.com/votingworks/vxsuite/pull/7548, I forgot to manually check the portrait rendering of the no card reader screen. The text alignment is a bit off for that case. This PR corrects accordingly.

## Demo Video or Screenshot

| Before | After |
| - | - |
| <img width="400" height="710" alt="before" src="https://github.com/user-attachments/assets/f3ca2687-ffda-4654-9da7-a8698441a793" /> | <img width="400" height="710" alt="after" src="https://github.com/user-attachments/assets/f3847af4-2e86-4898-831c-a3dc41d73b0d" /> |

## Testing Plan

- [x] Tested manually
- [x] Confirmed that landscape still renders correctly too

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.