### PR TITLE
VxPrint: toolbar printer status copy changes

### DIFF
--- a/apps/print/frontend/src/components/toolbar.tsx
+++ b/apps/print/frontend/src/components/toolbar.tsx
@@ -87,7 +87,7 @@ function PrinterStatus({ status }: { status: PrinterStatusType }) {
       return (
         <BasePrinterStatus
           icon={<Icons.Danger color="danger" />}
-          labelText="Jammed"
+          labelText="Paper Jam"
         />
       );
     }
@@ -102,7 +102,7 @@ function PrinterStatus({ status }: { status: PrinterStatusType }) {
       return (
         <BasePrinterStatus
           icon={<Icons.Danger color="danger" />}
-          labelText="Tray Full"
+          labelText="Output Bin Full"
         />
       );
     }
@@ -144,7 +144,7 @@ function PrinterStatus({ status }: { status: PrinterStatusType }) {
     );
   }
 
-  return <BasePrinterStatus />;
+  return <PrinterConnectionStatus connected={connected} />;
 }
 
 function UsbStatus({ status }: { status: UsbDriveStatus }) {


### PR DESCRIPTION
## Overview

Copy changes to VxPrint printer status.
* "Jammed" -> "Paper Jam"
* "Tray Full" -> "Output Bin Full"

## Demo Video or Screenshot

<img width="1475" height="833" alt="Screenshot 2025-12-03 at 1 57 45 PM" src="https://github.com/user-attachments/assets/3d5a8329-0eb2-4cdd-bd0c-56a795757224" />
<img width="1482" height="834" alt="Screenshot 2025-12-03 at 1 58 13 PM" src="https://github.com/user-attachments/assets/be8d2f29-df0b-408e-87ba-3a3df1ef73f2" />

For reference here is the icon without any warning status:
<img width="1481" height="834" alt="Screenshot 2025-12-03 at 1 59 12 PM" src="https://github.com/user-attachments/assets/e428c624-081c-4933-aa99-ed295404ee5c" />

There's a small advantage to putting the text on the left so it can flex without changing position of the printer icons. But I like being able to read the icons and text from general to specific, left to right: "Printer" -> "There's a problem" -> "Paper Jam"

## Testing Plan
N/A

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
