### PR TITLE
VxPrint: disable print buttons when printer is not connected

### DIFF
--- a/apps/print/frontend/src/components/print_all_button.tsx
+++ b/apps/print/frontend/src/components/print_all_button.tsx
@@ -150,12 +150,17 @@ function PrintAllModal({
   );
 }
 
-export function PrintAllButton(): JSX.Element {
+export function PrintAllButton({
+  disabled,
+}: {
+  disabled: boolean;
+}): JSX.Element {
   const [isShowingModal, setIsShowingModal] = useState(false);
 
   return (
     <React.Fragment>
       <StyledButton
+        disabled={disabled}
         color="neutral"
         fill="outlined"
         onPress={() => setIsShowingModal(true)}

--- a/apps/print/frontend/src/screens/report_screen.tsx
+++ b/apps/print/frontend/src/screens/report_screen.tsx
@@ -21,6 +21,7 @@ import {
   getElectionRecord,
   getBallotPrintCounts,
   printBallotsPrintedReport,
+  getDeviceStatuses,
 } from '../api';
 import { Row } from '../layout';
 import { TitleBar } from '../components/title_bar';
@@ -83,6 +84,7 @@ export function ReportScreen(): JSX.Element | null {
   const getBallotPrintCountsQuery = getBallotPrintCounts.useQuery();
   const getElectionRecordQuery = getElectionRecord.useQuery();
   const printReportMutation = printBallotsPrintedReport.useMutation();
+  const getDeviceStatusesQuery = getDeviceStatuses.useQuery();
   const [filterText, setFilterText] = useState('');
   const electionRecord = getElectionRecordQuery.data;
   const election = electionRecord?.electionDefinition.election;
@@ -103,7 +105,8 @@ export function ReportScreen(): JSX.Element | null {
 
   if (
     !getBallotPrintCountsQuery.isSuccess ||
-    !getElectionRecordQuery.isSuccess
+    !getElectionRecordQuery.isSuccess ||
+    !getDeviceStatusesQuery.isSuccess
   ) {
     return null;
   }
@@ -111,6 +114,7 @@ export function ReportScreen(): JSX.Element | null {
   assert(election !== undefined);
   const ballotPrintCounts = getBallotPrintCountsQuery.data;
   const hasParties = election.type === 'primary';
+  const { printer } = getDeviceStatusesQuery.data;
 
   return (
     <Container>
@@ -118,7 +122,9 @@ export function ReportScreen(): JSX.Element | null {
         title="Report"
         actions={
           <React.Fragment>
-            <Button onPress={handlePrint}>Print Report</Button>
+            <Button disabled={!printer.connected} onPress={handlePrint}>
+              Print Report
+            </Button>
             <ExportReportButton />
           </React.Fragment>
         }


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7593

Disables ballot print and print report buttons when printer isn't connected.

## Demo Video or Screenshot

**Connected**
Election Manager
<img width="1475" height="843" alt="Screenshot 2025-12-05 at 9 22 03 AM" src="https://github.com/user-attachments/assets/0f775d29-b619-48f9-be33-3a8649d0fb09" />

<img width="1466" height="830" alt="Screenshot 2025-12-05 at 9 21 59 AM" src="https://github.com/user-attachments/assets/b5caae72-7876-4857-9358-05ff4fcbcec1" />

Poll Worker
<img width="1470" height="831" alt="Screenshot 2025-12-05 at 9 21 27 AM" src="https://github.com/user-attachments/assets/de5f449f-6f5c-47f9-8823-5236136b5724" />
<img width="1469" height="833" alt="Screenshot 2025-12-05 at 9 21 21 AM" src="https://github.com/user-attachments/assets/810b7712-cc84-4c57-9551-13949d0fd61d" />


**Not Connected**
Election Manager

<img width="1475" height="839" alt="Screenshot 2025-12-05 at 9 34 52 AM" src="https://github.com/user-attachments/assets/c68243af-e628-44ae-a476-ae93729be0cd" />


<img width="1478" height="841" alt="Screenshot 2025-12-05 at 9 22 16 AM" src="https://github.com/user-attachments/assets/39c28322-53fd-40ff-84fd-68a68f247be1" />

Poll Worker
<img width="1479" height="835" alt="Screenshot 2025-12-05 at 9 21 41 AM" src="https://github.com/user-attachments/assets/82fd2b8f-0a11-4f59-828d-d6fa5f7d7a17" />


<img width="1471" height="834" alt="Screenshot 2025-12-05 at 9 21 36 AM" src="https://github.com/user-attachments/assets/76b12262-3369-403c-ab39-cdb1bb4e020f" />


## Testing Plan
- manual

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
