### PR TITLE
VxPrint: Improve Radio Group styling

### DIFF
--- a/apps/print/frontend/src/screens/print_screen.tsx
+++ b/apps/print/frontend/src/screens/print_screen.tsx
@@ -54,6 +54,16 @@ const FormSection = styled.div`
   flex-direction: column;
   gap: 0.5rem;
   overflow-y: hidden;
+
+  /* Ensure RadioGroups can scroll if they overflow and that focus state isn't clipped */
+  > fieldset {
+    overflow-y: auto;
+    padding: 0.25rem;
+  }
+
+  > strong {
+    padding-left: 0.25rem;
+  }
 `;
 
 const Footer = styled.div`


### PR DESCRIPTION
## Overview

https://votingworks.slack.com/archives/C09GQB0QB4N/p1764881149990999

## Demo Video or Screenshot

Before:

<img width="885" height="561" alt="Screenshot 2025-12-04 at 3 08 31 PM" src="https://github.com/user-attachments/assets/5709e032-2189-48fa-a4dd-25588081585a" />

<img width="968" height="558" alt="Screenshot 2025-12-04 at 3 27 15 PM" src="https://github.com/user-attachments/assets/bd4a0dd4-01c6-4699-bea3-893a6020350f" />

Radio group isn't scrollable and focus outline gets clipped 

After: 

https://github.com/user-attachments/assets/d20655f9-5fd9-4de3-8943-c54825c5a4c8

Radio group is scrollable and focus is visible

<img width="884" height="556" alt="Screenshot 2025-12-04 at 3 22 30 PM" src="https://github.com/user-attachments/assets/9747159c-5aa5-44c8-ba73-946452057c78" />

Standard case where we don't need to scroll

## Testing Plan

Manual

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
