### PR TITLE
ui: Add "option" ARIA role to SearchSelect

### DIFF
--- a/libs/ui/src/search_select.test.tsx
+++ b/libs/ui/src/search_select.test.tsx
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { render, screen } from '../test/react_testing_library';
+import { render, screen, within } from '../test/react_testing_library';
 import {
   SearchSelect,
   SearchSelectProps,
@@ -313,4 +313,26 @@ test('complex value type uses deep equality', () => {
   userEvent.click(screen.getByText('Green Apple'));
   screen.getByText('Green Apple');
   expect(screen.queryByText('Red Apple')).not.toBeInTheDocument();
+});
+
+test('a11y', () => {
+  render(
+    <ControlledSingleSelect options={options} aria-label="Choose Fruit" />
+  );
+
+  const combobox = screen.getByRole('combobox', { name: 'Choose Fruit' });
+  userEvent.click(combobox);
+  const listbox = screen.getByRole('listbox');
+  expect(combobox).toHaveAttribute('aria-expanded', 'true');
+  expect(combobox).toHaveAttribute('aria-controls', listbox.id);
+  expect(within(listbox).getAllByRole('option').length).toEqual(options.length);
+
+  const appleOption = within(listbox).getByRole('option', {
+    name: 'Apple',
+    selected: false,
+  });
+  userEvent.click(appleOption);
+  expect(combobox).toHaveAttribute('aria-expanded', 'false');
+  // Note: since menu is closed, options are removed from DOM, so we can't test
+  // aria-selected="true" here
 });

--- a/libs/ui/src/search_select.tsx
+++ b/libs/ui/src/search_select.tsx
@@ -2,6 +2,7 @@ import { deepEqual, typedAs } from '@votingworks/basics';
 import Select, {
   components,
   DropdownIndicatorProps,
+  MenuProps,
   MultiValueRemoveProps,
   OptionProps,
   StylesConfig,
@@ -60,13 +61,27 @@ function MultiValueRemove(
 }
 
 function Option(props: OptionProps<unknown, true>): JSX.Element {
+  const { isSelected, innerProps } = props;
   return (
     <components.Option
       {...props}
       innerProps={{
-        // eslint-disable-next-line react/destructuring-assignment
-        ...props.innerProps,
+        ...innerProps,
+        'aria-selected': isSelected,
         role: 'option',
+      }}
+    />
+  );
+}
+
+function Menu(props: MenuProps<unknown, true>): JSX.Element {
+  const { innerProps } = props;
+  return (
+    <components.Menu
+      {...props}
+      innerProps={{
+        ...innerProps,
+        role: 'listbox',
       }}
     />
   );
@@ -172,7 +187,7 @@ export function SearchSelect<T = string>({
       required={required}
       aria-label={ariaLabel}
       unstyled
-      components={{ DropdownIndicator, MultiValueRemove, Option }}
+      components={{ DropdownIndicator, MultiValueRemove, Option, Menu }}
       className="search-select"
       menuPlacement="auto"
       menuPortalTarget={menuPortalTarget}


### PR DESCRIPTION

## Overview

<!-- Add a link to a GitHub issue here -->
This enables us to more easily select options in frontend tests using `getByRole('option')`.

## Demo Video or Screenshot
N/A

## Testing Plan
Updated unit tests
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
