### PR TITLE
Add Makefile to VxPrint backend for production

### DIFF
--- a/apps/print/backend/Makefile
+++ b/apps/print/backend/Makefile
@@ -1,0 +1,15 @@
+NODE_ENV ?= development
+
+# a phony dependency that can be used as a dependency to force builds
+FORCE:
+
+install:
+
+build: FORCE
+	pnpm install && pnpm build
+
+bootstrap: install build
+
+run:
+	pnpm start
+


### PR DESCRIPTION
## Overview

This PR adds a Makefile to the VxPrint backend for production since, in production, the backend is run using `make run`. You can see that here: https://github.com/votingworks/vxsuite-complete-system/blob/6f6735ed2086fe10edcb934b37172dc3214af900/run-scripts/run-print.sh#L20

I just copied the Makefile from the VxAdmin backend. This was the one patch that I had to make on top of https://github.com/votingworks/vxsuite-complete-system/pull/492 to get my prelim VxPrint image builds functioning.

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [ ] ~I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~