### PR TITLE
VxPrint: remove unconfigure button from EM settings screen

### DIFF
--- a/apps/print/frontend/src/screens/settings_screen.tsx
+++ b/apps/print/frontend/src/screens/settings_screen.tsx
@@ -8,6 +8,7 @@ import {
   ToggleUsbPortsButton,
   UnconfigureMachineButton,
 } from '@votingworks/ui';
+import React from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -58,21 +59,27 @@ export function SettingsScreen({
     <div>
       <TitleBar title="Settings" />
       <Content>
-        <H2>Election</H2>
         {isSystemAdministrator ? (
-          <P>
-            To adjust settings for the current election, please insert an
-            election manager card.
-          </P>
+          <React.Fragment>
+            <H2>Election</H2>
+            <P>
+              To adjust settings for the current election, please insert an
+              election manager card.
+            </P>
+            <UnconfigureMachineButton
+              isMachineConfigured={isConfigured}
+              unconfigureMachine={unconfigure}
+            />
+          </React.Fragment>
         ) : (
-          <P>
-            <ToggleTestModeButton />
-          </P>
+          <React.Fragment>
+            <H2>Ballot Mode</H2>
+            <P>
+              <ToggleTestModeButton />
+            </P>
+          </React.Fragment>
         )}
-        <UnconfigureMachineButton
-          isMachineConfigured={isConfigured}
-          unconfigureMachine={unconfigure}
-        />
+
         <H2>Logs</H2>
         <ExportLogsButton usbDriveStatus={usbDrive} />
         <H2>Date and Time</H2>


### PR DESCRIPTION
## Overview

Closes #7610. Removes the unconfigure button from the EM settings screen. Since the only item under the "Election" section in the EM settings screen is now the test mode toggle, and because there is already an "Election" tab, renames header to "Ballot Mode"

## Demo Video or Screenshot
Before:
<img width="1209" height="762" alt="em_settings" src="https://github.com/user-attachments/assets/2bd1ccee-d5d7-4e29-bb4d-44d20e394b98" />

After:
<img width="1210" height="758" alt="Screenshot 2025-12-05 at 9 28 37 AM" src="https://github.com/user-attachments/assets/c7560faf-73de-4c81-a4fb-9ed17f8f1fdf" />

