### PR TITLE
VxPrint: Eject usb after unconfigure

### DIFF
--- a/apps/print/frontend/src/screens/election_screen.tsx
+++ b/apps/print/frontend/src/screens/election_screen.tsx
@@ -17,6 +17,7 @@ import {
   setPrecinctSelection,
   getPrecinctSelection,
   unconfigureMachine,
+  ejectUsbDrive,
 } from '../api';
 import { TitleBar } from '../components/title_bar';
 
@@ -41,6 +42,7 @@ export function ElectionScreen(): JSX.Element | null {
   const selectedPrecinctQuery = getPrecinctSelection.useQuery();
   const setPrecinctSelectionMutation = setPrecinctSelection.useMutation();
   const unconfigureMutation = unconfigureMachine.useMutation();
+  const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
 
   if (!getElectionRecordQuery.isSuccess || !selectedPrecinctQuery.isSuccess) {
     return null;
@@ -68,6 +70,15 @@ export function ElectionScreen(): JSX.Element | null {
     selectedPrecinct?.kind === 'AllPrecincts'
       ? ALL_PRECINCTS_KEY
       : selectedPrecinct?.precinctId;
+
+  async function unconfigure(): Promise<void> {
+    try {
+      await ejectUsbDriveMutation.mutateAsync();
+      await unconfigureMutation.mutateAsync();
+    } catch {
+      // Handled by default query client error handling
+    }
+  };
 
   return (
     <React.Fragment>
@@ -115,7 +126,7 @@ export function ElectionScreen(): JSX.Element | null {
             />
           )}
           <UnconfigureMachineButton
-            unconfigureMachine={() => unconfigureMutation.mutateAsync()}
+            unconfigureMachine={unconfigure}
             isMachineConfigured
           />
         </Row>

--- a/apps/print/frontend/src/screens/settings_screen.tsx
+++ b/apps/print/frontend/src/screens/settings_screen.tsx
@@ -18,6 +18,7 @@ import {
   getElectionRecord,
   unconfigureMachine,
   getDeviceStatuses,
+  ejectUsbDrive,
 } from '../api';
 import { TitleBar } from '../components/title_bar';
 import { ToggleTestModeButton } from '../components/toggle_test_mode_button';
@@ -37,6 +38,7 @@ export function SettingsScreen({
   const logOutMutation = logOut.useMutation();
 
   const unconfigureMachineMutation = unconfigureMachine.useMutation();
+  const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
   const electionRecordQuery = getElectionRecord.useQuery();
   const deviceStatusesQuery = getDeviceStatuses.useQuery();
 
@@ -48,6 +50,7 @@ export function SettingsScreen({
   const { usbDrive } = deviceStatusesQuery.data;
   async function unconfigure() {
     try {
+      await ejectUsbDriveMutation.mutateAsync();
       await unconfigureMachineMutation.mutateAsync();
       history.replace('/');
     } catch {


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7598

To avoid reconfiguring right about unconfiguring, we eject the usb just before unconfiguring, in the same manner we do in `central-scan`.

@adghayes noting we may want to add a requirement for report/logs to be saved before unconfiguring if official ballots have been printed

## Demo Video or Screenshot

https://github.com/user-attachments/assets/90866152-08d6-45bc-96ce-49283486860c


## Testing Plan

Manual

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
