### PR TITLE
print/frontend: Adjust layout spacing to account for extra padding in radio groups

### DIFF
--- a/apps/print/frontend/src/screens/print_screen.tsx
+++ b/apps/print/frontend/src/screens/print_screen.tsx
@@ -43,8 +43,8 @@ const Form = styled.div`
   overflow-y: hidden;
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1.5rem;
-  padding: 1rem;
+  gap: 0.75rem;
+  padding: 1rem 0.75rem 1rem 1rem;
 `;
 
 const Column = styled.div`
@@ -60,9 +60,14 @@ const FormSection = styled.div`
   gap: 0.5rem;
   overflow-y: hidden;
 
-  /* Ensure RadioGroups can scroll if they overflow and that focus state isn't clipped */
   > fieldset {
+    /* Ensure RadioGroups can scroll if they overflow */
     overflow-y: auto;
+
+    /* Extra padding to prevent clipping of focus outline.
+     * The gap is slightly reduced on FormSection's with RadioGroups
+     * to compensate.
+     */
     padding: 0.25rem;
   }
 
@@ -252,7 +257,7 @@ export function PrintScreen({
         </Column>
         <Column>
           {hidePartySelection ? null : (
-            <FormSection>
+            <FormSection style={{ gap: '0.25rem' }}>
               <strong>Party</strong>
               <RadioGroup
                 label="Party"
@@ -267,7 +272,7 @@ export function PrintScreen({
             </FormSection>
           )}
           {hideLanguageSelection ? null : (
-            <FormSection>
+            <FormSection style={{ gap: '0.25rem' }}>
               <strong>Language</strong>
               <RadioGroup
                 label="Language"


### PR DESCRIPTION

## Overview

I added in padding yesterday around radio groups to ensure the focus highlight isn't clipped. This PR removes some of the extra margin/padding that was in place of other components to compensate for the radio group padding, resulting in a consistent 1rem spacing between different components and 0.5rem of related components.

## Demo Video or Screenshot


**Before**
<img width="894" height="552" alt="Screenshot 2025-12-05 at 10 49 58 AM" src="https://github.com/user-attachments/assets/46fb2cba-5733-4a40-858e-55634e7209d5" />

**After**
<img width="882" height="564" alt="Screenshot 2025-12-05 at 10 57 20 AM" src="https://github.com/user-attachments/assets/34653e30-b37a-483b-8d7a-fa2cec4a31e8" />




## Testing Plan

Manual

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
