### PR TITLE
VxPrint: print double sided ballots

### DIFF
--- a/apps/print/backend/src/app.ts
+++ b/apps/print/backend/src/app.ts
@@ -27,6 +27,7 @@ import {
   singlePrecinctSelectionFor,
 } from '@votingworks/utils';
 import { generateSignedHashValidationQrCodeValue } from '@votingworks/auth';
+import { PrintProps, PrintSides } from '@votingworks/printing';
 import { AppContext } from './context';
 import { rootDebug } from './debug';
 import { constructAuthMachineState } from './util/auth';
@@ -45,6 +46,13 @@ const debug = rootDebug.extend('app');
 export function buildApi(ctx: AppContext) {
   const { auth, usbDrive, logger, workspace, printer } = ctx;
   const { store } = workspace;
+
+  function printBallots(options: PrintProps) {
+    return printer.print({
+      ...options,
+      sides: PrintSides.TwoSidedLongEdge,
+    });
+  }
 
   const methods = {
     getMachineConfig,
@@ -285,7 +293,7 @@ export function buildApi(ctx: AppContext) {
         return;
       }
 
-      await printer.print({
+      await printBallots({
         data: Buffer.from(ballot.encodedBallot, 'base64'),
         copies: input.copies,
       });
@@ -339,7 +347,7 @@ export function buildApi(ctx: AppContext) {
 
       let totalPrintCount = 0;
       for (const ballot of ballots) {
-        await printer.print({
+        await printBallots({
           data: Buffer.from(ballot.encodedBallot, 'base64'),
           copies: input.copiesPerStyle,
         });


### PR DESCRIPTION
## Overview

Prints ballots double sided

## Demo Video or Screenshot



## Testing Plan

Manually tested on hardware

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
