### PR TITLE
VxPrint: fix no paper error

### DIFF
--- a/apps/print/frontend/src/components/toolbar.tsx
+++ b/apps/print/frontend/src/components/toolbar.tsx
@@ -86,7 +86,7 @@ function PrinterStatus({ status }: { status: PrinterStatusType }) {
 
   if (richStatus.state === 'stopped') {
     if (
-      richStatus.stateReasons.find((reason) => reason !== 'media-empty-error')
+      richStatus.stateReasons.find((reason) => reason === 'media-empty-error')
     ) {
       // No paper and paper tray open both return the same error, so we can't
       // differentiate the error message


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7620

## Demo Video or Screenshot
<img width="1850" height="1054" alt="Screenshot 2025-12-05 at 12 05 01 PM" src="https://github.com/user-attachments/assets/226637c4-e79f-4151-bffc-1188c0b748a7" />



## Testing Plan
Manually tested
* No paper in the middle of a job
* No paper with no job
* Other statuses (jam, not connected) still work

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
