### PR TITLE
print/backend: Print all in consistent order with reports

### DIFF
--- a/apps/print/backend/src/app.ts
+++ b/apps/print/backend/src/app.ts
@@ -339,11 +339,31 @@ export function buildApi(ctx: AppContext) {
       const isTestMode = store.getTestMode();
       const ballotMode = isTestMode ? 'test' : 'official';
 
-      const ballots = store.getBallots({
+      const ballotPrintCounts = store.getBallotPrintCounts({
         ballotMode,
-        languageCode: input.languageCode,
-        ballotType: input.ballotType,
       });
+
+      const ballots = store
+        .getBallots({
+          ballotMode,
+          languageCode: input.languageCode,
+          ballotType: input.ballotType,
+        })
+        // Sort by index in ballotPrintCounts to ensure
+        // consistent order as those are pre-sorted
+        .sort((a, b) => {
+          const indexA = ballotPrintCounts.findIndex(
+            (count) =>
+              count.ballotStyleId === a.ballotStyleId &&
+              count.precinctId === a.precinctId
+          );
+          const indexB = ballotPrintCounts.findIndex(
+            (count) =>
+              count.ballotStyleId === b.ballotStyleId &&
+              count.precinctId === b.precinctId
+          );
+          return indexA - indexB;
+        });
 
       let totalPrintCount = 0;
       for (const ballot of ballots) {

--- a/libs/types/src/print.ts
+++ b/libs/types/src/print.ts
@@ -4,6 +4,7 @@ import { LanguageCode } from './language_code';
 export interface BallotPrintCount {
   ballotStyleId: Id;
   precinctOrSplitName: string;
+  precinctId: Id;
   partyName?: string;
   languageCode: LanguageCode;
   absenteeCount: number;


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7621

Uses the ordering of ballot print counts to determine the order of ballots. Potential for improving this logic in the future.

## Demo Video or Screenshot


https://github.com/user-attachments/assets/ede5a9a7-7648-4269-8930-70ef716c25cb


## Testing Plan

Manually tested and saw that jobs were printed in the correct order

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
