### PR TITLE
VxMark: allow custom paper sizes in fully printed ballots from VxMark

### DIFF
--- a/apps/mark/backend/src/util/print_ballot.test.tsx
+++ b/apps/mark/backend/src/util/print_ballot.test.tsx
@@ -35,11 +35,13 @@ vi.mock('@votingworks/ui');
 const electionDefBase = electionGeneralFixtures.readElectionDefinition();
 
 describe(`printMode === "marks_on_preprinted_ballot"`, () => {
-  const testValidSizes = test.each<'letter' | 'legal'>(['letter', 'legal']);
+  const testValidSizes = test.each<HmpbBallotPaperSize>(
+    Object.values(HmpbBallotPaperSize)
+  );
 
   testValidSizes('prints bubble marks - %s', async (size) => {
     const electionDefinition = mockElection({
-      paperSize: size as HmpbBallotPaperSize,
+      paperSize: size,
     });
     const ballotStyle = electionDefinition.election.ballotStyles[0];
     const mockVotes: VotesDict = {
@@ -170,11 +172,13 @@ describe(`printMode === "summary"`, () => {
 });
 
 describe(`printMode === "bubble_ballot"`, () => {
-  const testValidSizes = test.each<'letter' | 'legal'>(['letter', 'legal']);
+  const testValidSizes = test.each<HmpbBallotPaperSize>(
+    Object.values(HmpbBallotPaperSize)
+  );
 
   testValidSizes('prints bubble ballot with marks - %s', async (size) => {
     const electionDefinition = mockElection({
-      paperSize: size as HmpbBallotPaperSize,
+      paperSize: size,
     });
     const ballotStyle = electionDefinition.election.ballotStyles[0];
     const mockVotes: VotesDict = {

--- a/apps/mark/backend/src/util/print_ballot.tsx
+++ b/apps/mark/backend/src/util/print_ballot.tsx
@@ -63,12 +63,6 @@ async function printBubbleBallot(p: PrintBallotProps): Promise<void> {
   const { electionDefinition } = assertDefined(p.store.getElectionRecord());
   const { election } = electionDefinition;
 
-  const size = election.ballotLayout.paperSize;
-  assert(
-    size === 'letter' || size === 'legal',
-    `${size} paper size not yet supported for bubble ballot marking`
-  );
-
   const isLiveMode = !p.store.getTestMode();
 
   // Get the base ballot PDF from the election package
@@ -100,7 +94,7 @@ async function printBubbleBallot(p: PrintBallotProps): Promise<void> {
   return p.printer.print({
     data: markedBallotPdf,
     sides: PrintSides.TwoSidedLongEdge,
-    size,
+    size: election.ballotLayout.paperSize,
   });
 }
 


### PR DESCRIPTION
## Overview

In #7322, I allowed printing longer than legal _mark overlays_ on `main`. At that time, full ballot printing hadn't made it onto `main` yet. When it was ported over to `main`, it still had the restriction on longer than legal ballots. This removes that restriction.
