### PR TITLE
VxPrint: Polish for loading states

### DIFF
--- a/apps/print/frontend/src/api.ts
+++ b/apps/print/frontend/src/api.ts
@@ -187,8 +187,10 @@ export const getDistinctBallotStylesCount = {
   },
   useQuery(input: { ballotType: BallotType; languageCode: LanguageCode }) {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(input), () =>
-      apiClient.getDistinctBallotStylesCount(input)
+    return useQuery(
+      this.queryKey(input),
+      () => apiClient.getDistinctBallotStylesCount(input),
+      { keepPreviousData: true }
     );
   },
 } as const;

--- a/apps/print/frontend/src/components/print_all_button.tsx
+++ b/apps/print/frontend/src/components/print_all_button.tsx
@@ -57,7 +57,7 @@ function PrintAllModal({
 
   if (
     !getElectionRecordQuery.isSuccess ||
-    !getDistinctBallotStylesCountQuery.isSuccess
+    getDistinctBallotStylesCountQuery.data === undefined
   ) {
     return null;
   }
@@ -141,7 +141,12 @@ function PrintAllModal({
       onOverlayClick={onClose}
       actions={
         <React.Fragment>
-          <Button icon="Print" variant="primary" onPress={handlePrint}>
+          <Button
+            icon="Print"
+            variant="primary"
+            onPress={handlePrint}
+            disabled={!getDistinctBallotStylesCountQuery.isSuccess}
+          >
             Print {numberOfBallotStyles} Ballot Styles
           </Button>
           <Button onPress={onClose}>Cancel</Button>

--- a/apps/print/frontend/src/components/toolbar.tsx
+++ b/apps/print/frontend/src/components/toolbar.tsx
@@ -240,7 +240,11 @@ export function Toolbar(): JSX.Element | null {
 
   const getDeviceStatusesQuery = getDeviceStatuses.useQuery();
   if (!getDeviceStatusesQuery.isSuccess) {
-    return null;
+    return (
+      <ToolbarContainer>
+        <LockMachineButton />
+      </ToolbarContainer>
+    );
   }
 
   const { usbDrive, printer, battery } = getDeviceStatusesQuery.data;


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7626

1. Upon clicking the segmented button on the "Print All" modal for the first time, the screen would flash white because the ballot count query would refetch, causing the null early return. To fix this I've 1) edited the early return for the ballot count query to only return if undefined, meaning it is the initial page load, and 2) added the flag to `keepPreviousData` ensuring that the ballot count in the button doesn't temporarily become empty
2. Previously, on some page loads there was jumpiness due the toolbar initially being null and then pushing the rest of the screen down as it appears. This PR edits the toolbar to always return the container, with lock machine button at minimum.


## Demo Video or Screenshot


**Fixed Print All**
https://github.com/user-attachments/assets/ab29d5e2-66e9-40c9-9062-fc7a135893d4

**Screen Flash Print All**
https://github.com/user-attachments/assets/b3b43eaa-83c6-44b6-9ce8-187e9b029142


## Testing Plan

Manually tested for now

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
