### PR TITLE
VxPrint: Update icon/font style for unconfigured version of machine locked screen

### DIFF
--- a/apps/print/frontend/src/screens/machine_locked_screen.tsx
+++ b/apps/print/frontend/src/screens/machine_locked_screen.tsx
@@ -1,7 +1,14 @@
 import styled from 'styled-components';
-import { ElectionInfoBar, H1, H3, Main, Screen } from '@votingworks/ui';
+import {
+  ElectionInfoBar,
+  Font,
+  H1,
+  H3,
+  InsertCardImage,
+  Main,
+  Screen,
+} from '@votingworks/ui';
 import { getElectionRecord, getMachineConfig } from '../api';
-import { Column } from '../layout';
 
 const LockedImage = styled.img`
   margin-right: auto;
@@ -24,15 +31,20 @@ export function MachineLockedScreen(): JSX.Element | null {
   return (
     <Screen>
       <Main centerChild>
-        <Column style={{ alignItems: 'center' }}>
-          <LockedImage src="/locked.svg" alt="Locked Icon" />
-          <H1 style={{ marginTop: '0' }}>VxPrint Locked</H1>
-          <H3 style={{ fontWeight: 'normal' }}>
-            {electionDefinition
-              ? 'Insert card to unlock.'
-              : 'Insert an election manager card to configure VxPrint.'}
-          </H3>
-        </Column>
+        {electionDefinition ? (
+          <Font align="center">
+            <LockedImage src="/locked.svg" alt="Locked Icon" />
+            <H1 style={{ marginTop: '0' }}>VxPrint Locked</H1>
+            <H3 style={{ fontWeight: 'normal' }}>Insert card to unlock.</H3>
+          </Font>
+        ) : (
+          <Font align="center">
+            <InsertCardImage cardInsertionDirection="right" />
+            <H1 style={{ maxWidth: '27rem', marginTop: '0' }}>
+              Insert an election manager card to configure VxPrint.
+            </H1>
+          </Font>
+        )}
       </Main>
       <ElectionInfoBar
         mode="admin"


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7625

Updates the unconfigured version of the machine locked screen to match VxPollbook, VxCentralScan in having the card insert image and only an `<H1>` tag.

## Demo Video or Screenshot
 
After, unconfigured
<img width="890" height="559" alt="Screenshot 2025-12-08 at 3 14 17 PM" src="https://github.com/user-attachments/assets/f99103e9-10b7-416f-aa78-8e9de0f36b92" />

Before, unconfigured
<img width="891" height="558" alt="Screenshot 2025-12-08 at 3 14 34 PM" src="https://github.com/user-attachments/assets/a5842a63-08eb-401d-b1da-6a47f2a150a9" />

After, configured (visually the same)
<img width="884" height="558" alt="Screenshot 2025-12-08 at 3 14 52 PM" src="https://github.com/user-attachments/assets/269bfc09-5722-47ab-8992-a2e2fd3697c2" />

Before, configured (visually the same) - 
<img width="896" height="560" alt="Screenshot 2025-12-08 at 3 13 49 PM" src="https://github.com/user-attachments/assets/3e5c70ad-d275-4dfc-8b53-16c533662756" />



## Testing Plan

Manual for now

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
