### PR TITLE
VxMark: Dont reset ballot on printer disconnect

### DIFF
--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -27,7 +27,6 @@ import {
   useAudioControls,
   useLanguageControls,
   InvalidCardScreen,
-  useQueryChangeListener,
   VendorScreen,
   handleKeyboardEvent,
   PatDeviceContextProvider,
@@ -361,15 +360,6 @@ export function AppRoot(): JSX.Element | null {
       // Handled by default query client error handling
     }
   }, [endCardlessVoterSessionMutateAsync]);
-
-  // Reset the ballot if the printer is disconnected mid-voting
-  useQueryChangeListener(printerStatusQuery, {
-    onChange: (currentPrinterStatus, previousPrinterStatus) => {
-      if (previousPrinterStatus?.connected && !currentPrinterStatus.connected) {
-        resetBallot();
-      }
-    },
-  });
 
   // Callback for PAT tutorial completion
   const onPatCalibrationComplete = useCallback(() => {


### PR DESCRIPTION
## Overview
If there is a printer blip we don't want the voter to lose their voting session, or if there is a printer blip, as we've seen, in printing the ballot we want to stay at the end of the voter flow, not reset to the beginning. AFAICT MarkScan does not have this logic, its unclear to me why we had this originally implemented. 
<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot
N/A

## Testing Plan
Disconnected/Reconnected printer during various stages of voting process, saw accessibility settings (text, etc.) NOT reset, votes NOT reset, and the page stay on the same page (rather then reset to the beginning) 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
