### PR TITLE
VxDesign: Make audio editor non-editable after ballots are finalized

### DIFF
--- a/apps/design/frontend/src/ballot_audio/audio_editor.tsx
+++ b/apps/design/frontend/src/ballot_audio/audio_editor.tsx
@@ -33,6 +33,7 @@ const TTS_MODE_OPTIONS: Array<RadioGroupOption<TtsExportSource>> = [
 ];
 
 export interface AudioEditorProps {
+  electionId: string;
   languageCode: string;
   orgId: string;
   ttsDefault: TtsStringDefault;
@@ -46,19 +47,22 @@ export interface AudioEditorProps {
 }
 
 export function AudioEditor(props: AudioEditorProps): React.ReactNode {
-  const { languageCode, orgId, phoneticEnabled, ttsDefault } = props;
+  const { electionId, languageCode, orgId, phoneticEnabled, ttsDefault } =
+    props;
   const [mode, setMode] = React.useState<TtsExportSource | null>(null);
 
+  const ballotsFinalizedAt = api.getBallotsFinalizedAt.useQuery(electionId);
   const savedEdit = api.ttsEditsGet.useQuery({
     orgId,
     languageCode,
     original: ttsDefault.text,
   });
 
-  if (!savedEdit.isSuccess) return null;
+  if (!savedEdit.isSuccess || !ballotsFinalizedAt.isSuccess) return null;
 
   const defaultMode = savedEdit.data?.exportSource || 'text';
   const currentMode = mode || defaultMode;
+  const editable = !ballotsFinalizedAt.data;
 
   // Phonetic editing isn't supported for ballot measures at the moment, given
   // how long/complex they can get.
@@ -74,6 +78,7 @@ export function AudioEditor(props: AudioEditorProps): React.ReactNode {
     <React.Fragment>
       <ModeContainer>
         <RadioGroup
+          disabled={!editable}
           label="Audio Source"
           hideLabel
           numColumns={2}
@@ -88,6 +93,7 @@ export function AudioEditor(props: AudioEditorProps): React.ReactNode {
           case 'text':
             return (
               <TtsTextEditor
+                editable={editable}
                 languageCode={languageCode}
                 orgId={orgId}
                 original={ttsDefault.text}

--- a/apps/design/frontend/src/ballot_audio/audio_editor_panel.test.tsx
+++ b/apps/design/frontend/src/ballot_audio/audio_editor_panel.test.tsx
@@ -31,7 +31,7 @@ test('renders editor, along with a preview of the original text', () => {
   };
 
   const mockApi = createMockApiClient();
-  setUpEditorMock({ languageCode, orgId, ttsDefault });
+  setUpEditorMock({ electionId, languageCode, orgId, ttsDefault });
 
   const header = <h1>Election Audio: State</h1>;
 
@@ -60,7 +60,7 @@ test('renders contest descriptions using original, unstripped HTML', async () =>
     subkey: mockContest.id,
     text: 'Do you agree?',
   };
-  setUpEditorMock({ languageCode, orgId, ttsDefault });
+  setUpEditorMock({ electionId, languageCode, orgId, ttsDefault });
 
   renderPanel(mockApi, {
     electionId,

--- a/apps/design/frontend/src/ballot_audio/audio_editor_panel.tsx
+++ b/apps/design/frontend/src/ballot_audio/audio_editor_panel.tsx
@@ -50,6 +50,7 @@ export function AudioEditorPanel(
       )}
 
       <AudioEditor
+        electionId={electionId}
         languageCode={languageCode}
         orgId={orgId}
         ttsDefault={ttsDefault}

--- a/apps/design/frontend/src/ballot_audio/tts_text_editor.tsx
+++ b/apps/design/frontend/src/ballot_audio/tts_text_editor.tsx
@@ -40,6 +40,13 @@ const TextMirror = styled.pre`
   /* stylelint-disable no-empty-source */
 `;
 
+const TextArea = styled.textarea<{ editable: boolean }>`
+  :disabled {
+    color: ${(p) => !p.editable && p.theme.colors.onBackground};
+    background: ${(p) => !p.editable && p.theme.colors.background};
+  }
+`;
+
 const Editor = styled.div`
   --tts-editor-border-width: ${(p) => p.theme.sizes.bordersRem.thin}rem;
   --tts-editor-line-height: 1.4;
@@ -50,7 +57,7 @@ const Editor = styled.div`
   position: relative;
   width: 100%;
 
-  > textarea {
+  > ${TextArea} {
     border-width: var(--tts-editor-border-width);
     display: block;
     height: 100%;
@@ -153,6 +160,7 @@ const FormButtons = styled.div`
 `;
 
 export interface TtsTextEditorProps {
+  editable: boolean;
   languageCode: string;
   orgId: string;
   original: string;
@@ -176,7 +184,7 @@ export function TtsTextEditor(props: TtsTextEditorProps): React.ReactNode {
 function EditorImpl(
   props: TtsTextEditorProps & { savedEdit: TtsEdit | null }
 ): JSX.Element {
-  const { languageCode, orgId, original, savedEdit } = props;
+  const { editable, languageCode, orgId, original, savedEdit } = props;
   const [edit, setEdit] = React.useState<string | null>(null);
 
   const defaultValue = savedEdit?.text || original;
@@ -224,8 +232,10 @@ function EditorImpl(
   return (
     <Container>
       <Header>
-        <Icons.ChevronRight /> Edit the text below to change the corresponding
-        audio:
+        <Icons.ChevronRight />{' '}
+        {editable
+          ? 'Edit the text below to change the corresponding audio:'
+          : 'Audio will be generated from the following text:'}
       </Header>
 
       <Form onReset={() => setEdit(null)} onSubmit={onSubmit}>
@@ -241,10 +251,10 @@ function EditorImpl(
            */}
           <TextMirror>{value}.</TextMirror>
 
-          <textarea
-            // eslint-disable-next-line jsx-a11y/no-autofocus
+          <TextArea
             autoFocus
-            disabled={saving}
+            editable={editable}
+            disabled={saving || !editable}
             id="ttsTextEditor"
             name="ttsText"
             onChange={(event) => setEdit(event.target.value)}
@@ -271,19 +281,21 @@ function EditorImpl(
               </PlayerOverlay>
             </PlayerContainer>
 
-            <FormButtons>
-              <Button disabled={resetDisabled} type="reset">
-                Reset
-              </Button>
-              <Button
-                disabled={saveDisabled}
-                icon={saving ? 'Loading' : 'Save'}
-                type="submit"
-                variant={saveDisabled ? 'neutral' : 'primary'}
-              >
-                {saving ? 'Saving...' : 'Save Changes'}
-              </Button>
-            </FormButtons>
+            {editable && (
+              <FormButtons>
+                <Button disabled={resetDisabled} type="reset">
+                  Reset
+                </Button>
+                <Button
+                  disabled={saveDisabled}
+                  icon={saving ? 'Loading' : 'Save'}
+                  type="submit"
+                  variant={saveDisabled ? 'neutral' : 'primary'}
+                >
+                  {saving ? 'Saving...' : 'Save Changes'}
+                </Button>
+              </FormButtons>
+            )}
           </Controls>
         </Footer>
       </Form>


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7266

Adding a ballots-finalized state for the audio editor panel:
- Disable the TTS mode picker
- Make the text editor read-only
- Drop the save/reset buttons

## Demo Video or Screenshot

### Unfinalized 

<img width="1921" height="1079" alt="audio-editor-unfinalized" src="https://github.com/user-attachments/assets/aa1de70b-85fd-4208-8a1b-2dfd2d50f167" />

### Finalized

<img width="1921" height="1079" alt="audio-editor-finalized" src="https://github.com/user-attachments/assets/36d441e2-02d4-46f0-ac8f-3b92b308650e" /> 

## Testing Plan
- Unit + manual

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
