### PR TITLE
fix(design): create dev user and org

### DIFF
--- a/apps/design/backend/migrations/1756159958924_organizations-table.js
+++ b/apps/design/backend/migrations/1756159958924_organizations-table.js
@@ -2,7 +2,7 @@
 const { ManagementClient } = require('auth0');
 const { assertDefined } = require('@votingworks/basics');
 const { loadEnvVarsFromDotenvFiles } = require('@votingworks/backend');
-const { votingWorksOrgId } = require('../build/globals');
+const { votingWorksJurisdictionId } = require('../build/globals');
 
 loadEnvVarsFromDotenvFiles();
 
@@ -41,7 +41,7 @@ exports.up = async (pgm) => {
     // In dev mode, create the default dev organization (use VotingWorks org ID to get full features)
     pgm.sql(`
       INSERT INTO organizations (id, name) VALUES (
-        '${votingWorksOrgId()}',
+        '${votingWorksJurisdictionId()}',
         'VotingWorks'
       );
     `);

--- a/apps/design/backend/migrations/1764784124011_users-table.js
+++ b/apps/design/backend/migrations/1764784124011_users-table.js
@@ -2,7 +2,7 @@
 const { ManagementClient } = require('auth0');
 const basics = require('@votingworks/basics');
 const { loadEnvVarsFromDotenvFiles } = require('@votingworks/backend');
-const { votingWorksOrgId } = require('../build/globals');
+const { votingWorksJurisdictionId } = require('../build/globals');
 
 loadEnvVarsFromDotenvFiles();
 
@@ -86,7 +86,7 @@ exports.up = async (pgm) => {
     pgm.sql(`
       INSERT INTO users_organizations (user_id, organization_id) VALUES (
         'auth0|devuser',
-        '${votingWorksOrgId()}'
+        '${votingWorksJurisdictionId()}'
       );
     `);
   }


### PR DESCRIPTION
## Overview

If we're in development, we default to the `auth0|devuser` user. This user doesn't exist by default, so we should create it and give it an organization.


## Demo Video or Screenshot
Before, on `main`:
```
[design:server]
[design:server]   VITE v4.5.2  ready in 612 ms
[design:server]
[design:server]   ➜  Local:   http://localhost:3000/
[design:server]   ➜  Network: use --host to expose
[design:server] Browserslist: browsers data (caniuse-lite) is 12 months old. Please run:
[design:server]   npx update-browserslist-db@latest
[design:server]   Why you should do it regularly: https://github.com/browserslist/update-db#readme
[backend:run] VxDesign background worker running
[backend:run] VxDesign backend running at http://localhost:3002/
[backend:run] Error: Auth0 user auth0|devuser not found in database
[backend:run]     at assertDefined (/home/vx/vxsuite/libs/basics/build/assert.js:23:15)
[backend:run]     at loadUser (/home/vx/vxsuite/apps/design/backend/build/app.js:137:57)
[backend:run]     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
[backend:run]     at async /home/vx/vxsuite/libs/grout/build/server.js:123:32
[backend:run] Error: Auth0 user auth0|devuser not found in database
[backend:run]     at assertDefined (/home/vx/vxsuite/libs/basics/build/assert.js:23:15)
[backend:run]     at loadUser (/home/vx/vxsuite/apps/design/backend/build/app.js:137:57)
[backend:run]     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
[backend:run]     at async /home/vx/vxsuite/libs/grout/build/server.js:123:32
[backend:run] Error: Auth0 user auth0|devuser not found in database
[backend:run]     at assertDefined (/home/vx/vxsuite/libs/basics/build/assert.js:23:15)
[backend:run]     at loadUser (/home/vx/vxsuite/apps/design/backend/build/app.js:137:57)
[backend:run]     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
[backend:run]     at async /home/vx/vxsuite/libs/grout/build/server.js:123:32
[backend:run] Error: Auth0 user auth0|devuser not found in database
[backend:run]     at assertDefined (/home/vx/vxsuite/libs/basics/build/assert.js:23:15)
[backend:run]     at loadUser (/home/vx/vxsuite/apps/design/backend/build/app.js:137:57)
[backend:run]     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
[backend:run]     at async /home/vx/vxsuite/libs/grout/build/server.js:123:32
```

After, with this change:

```
[design:server]   VITE v4.5.2  ready in 688 ms
[design:server]
[design:server]   ➜  Local:   http://localhost:3000/
[design:server]   ➜  Network: use --host to expose
[design:server] Browserslist: browsers data (caniuse-lite) is 12 months old. Please run:
[design:server]   npx update-browserslist-db@latest
[design:server]   Why you should do it regularly: https://github.com/browserslist/update-db#readme
[backend:run] VxDesign background worker running
[backend:run] VxDesign backend running at http://localhost:3002/
```

## Testing Plan
Ran locally.
