### PR TITLE
VxDesign: Load .env.local env vars in database migrations

### DIFF
--- a/apps/design/backend/migrations/1756159958924_organizations-table.js
+++ b/apps/design/backend/migrations/1756159958924_organizations-table.js
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { ManagementClient } = require('auth0');
 const { assertDefined } = require('@votingworks/basics');
+const { loadEnvVarsFromDotenvFiles } = require('@votingworks/backend');
+
+loadEnvVarsFromDotenvFiles();
 
 /**
  * @type {import('node-pg-migrate').ColumnDefinitions | undefined}

--- a/apps/design/backend/migrations/1764784124011_users-table.js
+++ b/apps/design/backend/migrations/1764784124011_users-table.js
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { ManagementClient } = require('auth0');
 const basics = require('@votingworks/basics');
+const { loadEnvVarsFromDotenvFiles } = require('@votingworks/backend');
+
+loadEnvVarsFromDotenvFiles();
 
 /**
  * @type {import('node-pg-migrate').ColumnDefinitions | undefined}


### PR DESCRIPTION


## Overview

This allows using .env.local files to set Auth0 credentials rather than having to enumerate them in the command line when running migrations locally in dev.
## Demo Video or Screenshot
N/A

## Testing Plan
Manual test with staging Auth0 env vars
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
