### PR TITLE
Check VxMarkScan contests in ballot style system limit

### DIFF
--- a/libs/backend/src/election_package/system_limits.test.ts
+++ b/libs/backend/src/election_package/system_limits.test.ts
@@ -136,6 +136,32 @@ test.each<{
       ...SYSTEM_LIMITS,
       markScanBallotStyle: {
         ...SYSTEM_LIMITS.markScanBallotStyle,
+        contests: 0,
+      },
+    },
+    expectedValidationResult: ok(),
+  },
+  {
+    systemLimits: {
+      ...SYSTEM_LIMITS,
+      markScanBallotStyle: {
+        ...SYSTEM_LIMITS.markScanBallotStyle,
+        contests: 0,
+      },
+    },
+    checkMarkScanSystemLimits: true,
+    expectedValidationResult: err({
+      limitScope: 'markScanBallotStyle',
+      limitType: 'contests',
+      valueExceedingLimit: expect.any(Number),
+      ballotStyleId: '12',
+    }),
+  },
+  {
+    systemLimits: {
+      ...SYSTEM_LIMITS,
+      markScanBallotStyle: {
+        ...SYSTEM_LIMITS.markScanBallotStyle,
         candidatesSummedAcrossContests: 0,
       },
     },

--- a/libs/backend/src/election_package/system_limits.ts
+++ b/libs/backend/src/election_package/system_limits.ts
@@ -149,6 +149,18 @@ export function validateElectionDefinitionAgainstSystemLimits(
         electionDefinition,
         getContestIdsForBallotStyle(electionDefinition, ballotStyle.id)
       );
+
+      if (
+        ballotStyleContests.length > systemLimits.markScanBallotStyle.contests
+      ) {
+        return err({
+          limitScope: 'markScanBallotStyle',
+          limitType: 'contests',
+          valueExceedingLimit: ballotStyleContests.length,
+          ballotStyleId: ballotStyle.id,
+        });
+      }
+
       let seatsSummedAcrossContests = 0;
       let candidatesSummedAcrossContests = 0;
       for (const contest of ballotStyleContests) {

--- a/libs/types/src/system_limits.ts
+++ b/libs/types/src/system_limits.ts
@@ -19,6 +19,7 @@ export const SYSTEM_LIMITS = {
     characters: 10000,
   },
   markScanBallotStyle: {
+    contests: 25,
     candidatesSummedAcrossContests: 135,
     seatsSummedAcrossContests: 75,
   },

--- a/libs/utils/src/system_limits.test.ts
+++ b/libs/utils/src/system_limits.test.ts
@@ -85,6 +85,16 @@ test.each<{ violation: SystemLimitViolation; expectedString: string }>([
   {
     violation: {
       limitScope: 'markScanBallotStyle',
+      limitType: 'contests',
+      valueExceedingLimit: SYSTEM_LIMITS.markScanBallotStyle.contests + 1,
+      ballotStyleId: 'ballot-style-1',
+    },
+    expectedString:
+      'Number of contests in ballot style ballot-style-1 (26) exceeds VxMarkScan system limit of 25.',
+  },
+  {
+    violation: {
+      limitScope: 'markScanBallotStyle',
       limitType: 'candidatesSummedAcrossContests',
       valueExceedingLimit:
         SYSTEM_LIMITS.markScanBallotStyle.candidatesSummedAcrossContests + 1,


### PR DESCRIPTION
## Overview

In preparing election packages for SLI to complete stress testing (testing past our system limits), I realized I missed one system limit check. This PR adds that check in.

<table>
<img width="405" height="715" alt="check" src="https://github.com/user-attachments/assets/82441659-1924-4803-9e83-0f8e7275d55e" />
</table>

## Testing Plan

- [x] Updated automated tests
- [x] Tested manually

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [ ] ~I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~