### PR TITLE
HWTA: add shv to all apps hwta

### DIFF
--- a/apps/mark-scan/backend/src/electrical_testing/app.ts
+++ b/apps/mark-scan/backend/src/electrical_testing/app.ts
@@ -4,6 +4,8 @@ import {
   CpuMetrics,
 } from '@votingworks/backend';
 import * as grout from '@votingworks/grout';
+import { SignedHashValidationQrCodeValue } from '@votingworks/types';
+import { generateSignedHashValidationQrCodeValue } from '@votingworks/auth';
 import express, { Application } from 'express';
 import { ServerContext } from './context';
 import { getMachineConfig } from '../machine_config';
@@ -85,6 +87,14 @@ function buildApi({
 
     async getCpuMetrics(): Promise<CpuMetrics> {
       return getCpuMetrics();
+    },
+
+    async generateSignedHashValidationQrCodeValue(): Promise<SignedHashValidationQrCodeValue> {
+      const qrCodeValue = await generateSignedHashValidationQrCodeValue({
+        electionRecord: undefined,
+        softwareVersion: getMachineConfig().codeVersion,
+      });
+      return qrCodeValue;
     },
 
     ...createSystemCallApi({

--- a/apps/mark-scan/frontend/src/electrical_testing/api.ts
+++ b/apps/mark-scan/frontend/src/electrical_testing/api.ts
@@ -122,3 +122,17 @@ export const getCpuMetrics = {
 } as const;
 
 export const systemCallApi = createSystemCallApi(useApiClient);
+
+export const generateSignedHashValidationQrCodeValue = {
+  queryKey(): QueryKey {
+    return ['generateSignedHashValidationQrCodeValue'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(
+      this.queryKey(),
+      () => apiClient.generateSignedHashValidationQrCodeValue(),
+      { cacheTime: 0 }
+    );
+  },
+} as const;

--- a/apps/mark-scan/frontend/src/electrical_testing/app_root.tsx
+++ b/apps/mark-scan/frontend/src/electrical_testing/app_root.tsx
@@ -13,12 +13,14 @@ import {
   setPaperHandlerTaskRunning,
   setUsbDriveTaskRunning,
   systemCallApi,
+  useApiClient,
 } from './api';
 import { useSound } from '../hooks/use_sound';
 
 const SOUND_INTERVAL_SECONDS = 5;
 
 export function AppRoot(): JSX.Element {
+  const apiClient = useApiClient();
   const getElectricalTestingStatusesQuery =
     getElectricalTestingStatuses.useQuery();
   const getCpuMetricsQuery = getCpuMetrics.useQuery();
@@ -120,6 +122,7 @@ export function AppRoot(): JSX.Element {
         perRow={1}
         powerDown={powerDown}
         usbDriveStatus={usbDriveStatus?.underlyingDeviceStatus}
+        apiClient={apiClient}
       />
     </React.Fragment>
   );

--- a/apps/mark/backend/src/electrical_testing/app.ts
+++ b/apps/mark/backend/src/electrical_testing/app.ts
@@ -4,7 +4,11 @@ import {
   CpuMetrics,
 } from '@votingworks/backend';
 import * as grout from '@votingworks/grout';
-import { PrinterStatus } from '@votingworks/types';
+import {
+  PrinterStatus,
+  SignedHashValidationQrCodeValue,
+} from '@votingworks/types';
+import { generateSignedHashValidationQrCodeValue } from '@votingworks/auth';
 import * as hid from 'node-hid';
 import express, { Application } from 'express';
 import { ServerContext } from './context';
@@ -157,6 +161,14 @@ function buildApi({
 
     async playSpeakerSound(input: { name: SoundName }): Promise<void> {
       await audioPlayer?.play(input.name);
+    },
+
+    async generateSignedHashValidationQrCodeValue(): Promise<SignedHashValidationQrCodeValue> {
+      const qrCodeValue = await generateSignedHashValidationQrCodeValue({
+        electionRecord: undefined,
+        softwareVersion: getMachineConfig().codeVersion,
+      });
+      return qrCodeValue;
     },
 
     ...createSystemCallApi({

--- a/apps/mark/frontend/src/electrical_testing/api.ts
+++ b/apps/mark/frontend/src/electrical_testing/api.ts
@@ -182,3 +182,17 @@ export const playSpeakerSound = {
 } as const;
 
 export const systemCallApi = createSystemCallApi(useApiClient);
+
+export const generateSignedHashValidationQrCodeValue = {
+  queryKey(): QueryKey {
+    return ['generateSignedHashValidationQrCodeValue'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(
+      this.queryKey(),
+      () => apiClient.generateSignedHashValidationQrCodeValue(),
+      { cacheTime: 0 }
+    );
+  },
+} as const;

--- a/apps/mark/frontend/src/electrical_testing/app_root.tsx
+++ b/apps/mark/frontend/src/electrical_testing/app_root.tsx
@@ -23,6 +23,7 @@ import {
   setPrinterTaskRunning,
   setUsbDriveTaskRunning,
   systemCallApi,
+  useApiClient,
 } from './api';
 import { useSound } from '../hooks/use_sound';
 
@@ -118,6 +119,7 @@ function AudioControls({
 }
 
 export function AppRoot(): JSX.Element {
+  const apiClient = useApiClient();
   const getElectricalTestingStatusesQuery =
     getElectricalTestingStatuses.useQuery();
   const getCpuMetricsQuery = getCpuMetrics.useQuery();
@@ -292,6 +294,7 @@ export function AppRoot(): JSX.Element {
         perRow={1}
         powerDown={powerDown}
         usbDriveStatus={usbDriveStatus?.underlyingDeviceStatus}
+        apiClient={apiClient}
       />
     </React.Fragment>
   );

--- a/apps/scan/backend/src/electrical_testing/app.ts
+++ b/apps/scan/backend/src/electrical_testing/app.ts
@@ -4,7 +4,8 @@ import {
   CpuMetrics,
 } from '@votingworks/backend';
 import * as grout from '@votingworks/grout';
-import { mapSheet } from '@votingworks/types';
+import { mapSheet, SignedHashValidationQrCodeValue } from '@votingworks/types';
+import { generateSignedHashValidationQrCodeValue } from '@votingworks/auth';
 import express, { Application } from 'express';
 import { basename, join } from 'node:path';
 import { Player as AudioPlayer, SoundName } from '../audio/player';
@@ -148,6 +149,14 @@ function buildApi({
 
     async getCpuMetrics(): Promise<CpuMetrics> {
       return await getCpuMetrics();
+    },
+
+    async generateSignedHashValidationQrCodeValue(): Promise<SignedHashValidationQrCodeValue> {
+      const qrCodeValue = await generateSignedHashValidationQrCodeValue({
+        electionRecord: undefined,
+        softwareVersion: getMachineConfig().codeVersion,
+      });
+      return qrCodeValue;
     },
 
     ...createSystemCallApi({

--- a/apps/scan/frontend/src/electrical_testing/api.ts
+++ b/apps/scan/frontend/src/electrical_testing/api.ts
@@ -202,10 +202,22 @@ export const getCpuMetrics = {
   },
   useQuery() {
     const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () => apiClient.getCpuMetrics(), {
+      refetchInterval: 1000,
+    });
+  },
+} as const;
+
+export const generateSignedHashValidationQrCodeValue = {
+  queryKey(): QueryKey {
+    return ['generateSignedHashValidationQrCodeValue'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
     return useQuery(
       this.queryKey(),
-      () => apiClient.getCpuMetrics(),
-      { refetchInterval: 1000 }
+      () => apiClient.generateSignedHashValidationQrCodeValue(),
+      { cacheTime: 0 }
     );
   },
 } as const;

--- a/apps/scan/frontend/src/electrical_testing/app_root.tsx
+++ b/apps/scan/frontend/src/electrical_testing/app_root.tsx
@@ -10,6 +10,7 @@ import {
   Main,
   RadioGroup,
   Screen,
+  SignedHashValidationButton,
 } from '@votingworks/ui';
 import { format } from '@votingworks/utils';
 import { DateTime } from 'luxon';
@@ -21,6 +22,7 @@ import { mapSheet, SheetOf } from '@votingworks/types';
 import type { HWTA } from '@votingworks/scan-backend';
 import { useSound } from '../utils/use_sound';
 import * as api from './api';
+import { useApiClient } from './api';
 
 const SOUND_INTERVAL_SECONDS = 5;
 
@@ -536,6 +538,7 @@ function ScannedSheetImages({ urls }: { urls?: SheetOf<string> }): JSX.Element {
 }
 
 export function AppRoot(): JSX.Element {
+  const apiClient = useApiClient();
   const getElectricalTestingStatusMessagesQuery =
     api.getElectricalTestingStatuses.useQuery();
   const getCpuMetricsQuery = api.getCpuMetrics.useQuery();
@@ -651,6 +654,7 @@ export function AppRoot(): JSX.Element {
             />
           </Row>
           <Row gap="1rem" center style={{ height: '200px' }}>
+            <SignedHashValidationButton apiClient={apiClient} />
             <Button
               icon={<Icons.Save />}
               onPress={() => setIsSaveLogsModalOpen(true)}

--- a/libs/ui/src/electrical_testing_screen.test.tsx
+++ b/libs/ui/src/electrical_testing_screen.test.tsx
@@ -28,6 +28,7 @@ test('single task', async () => {
       ]}
       powerDown={powerDown}
       perRow={1}
+      apiClient={mockApiClient}
     />
   );
 
@@ -39,6 +40,10 @@ test('single task', async () => {
   expect(powerDownButton).toHaveTextContent('Power Down');
   const saveLogsButton = buttons.pop();
   expect(saveLogsButton).toHaveTextContent('Save Logs');
+  const signedHashValidationButton = buttons.pop();
+  expect(signedHashValidationButton).toHaveTextContent(
+    'Signed Hash Validation'
+  );
   expect(buttons).toHaveLength(1);
 
   // Toggle the task once.
@@ -75,6 +80,7 @@ test('multiple tasks', async () => {
       ]}
       powerDown={powerDown}
       perRow={1}
+      apiClient={mockApiClient}
     />
   );
 
@@ -85,6 +91,10 @@ test('multiple tasks', async () => {
   expect(powerDownButton).toHaveTextContent('Power Down');
   const saveLogsButton = buttons.pop();
   expect(saveLogsButton).toHaveTextContent('Save Logs');
+  const signedHashValidationButton = buttons.pop();
+  expect(signedHashValidationButton).toHaveTextContent(
+    'Signed Hash Validation'
+  );
   expect(buttons).toHaveLength(2);
 
   // Toggle the second task once.
@@ -114,6 +124,7 @@ test('power down', async () => {
       ]}
       powerDown={powerDown}
       perRow={1}
+      apiClient={mockApiClient}
     />
   );
 
@@ -133,6 +144,7 @@ test('save logs', async () => {
       powerDown={vi.fn()}
       perRow={1}
       usbDriveStatus={{ status: 'mounted', mountPoint: '/media/vx/usb-drive' }}
+      apiClient={mockApiClient}
     />
   );
 

--- a/libs/ui/src/electrical_testing_screen.tsx
+++ b/libs/ui/src/electrical_testing_screen.tsx
@@ -10,6 +10,10 @@ import { Main } from './main';
 import { Screen } from './screen';
 import { Caption, H6 } from './typography';
 import { ExportLogsModal } from './export_logs_modal';
+import {
+  SignedHashValidationApiClient,
+  SignedHashValidationButton,
+} from './signed_hash_validation_button';
 
 const Row = styled.div<{ gap?: string }>`
   display: flex;
@@ -30,6 +34,10 @@ const Small = styled.span`
 `;
 
 const SmallButton = styled(Button)`
+  transform: scale(0.5);
+`;
+
+const SmallButtonContainer = styled.div`
   transform: scale(0.5);
 `;
 
@@ -145,6 +153,7 @@ export function ElectricalTestingScreen<Id extends React.Key>({
   powerDown,
   usbDriveStatus,
   topOffset,
+  apiClient,
 }: {
   tasks: ReadonlyArray<Task<Id>>;
   perRow: number;
@@ -153,6 +162,8 @@ export function ElectricalTestingScreen<Id extends React.Key>({
   usbDriveStatus?: UsbDriveStatus;
   /** Optional top offset (e.g., '80px') to account for a fixed top bar */
   topOffset?: string;
+  /** API client for signed hash validation */
+  apiClient: SignedHashValidationApiClient;
 }): JSX.Element {
   const [isSaveLogsModalOpen, setIsSaveLogsModalOpen] = React.useState(false);
 
@@ -194,6 +205,9 @@ export function ElectricalTestingScreen<Id extends React.Key>({
               .toArray()}
           </Column>
           <Row style={{ justifyContent: 'center' }}>
+            <SmallButtonContainer>
+              <SignedHashValidationButton apiClient={apiClient} />
+            </SmallButtonContainer>
             <SmallButton
               icon={<Icons.Save />}
               onPress={() => setIsSaveLogsModalOpen(true)}


### PR DESCRIPTION
## Overview
Adds SHV to the HWTApps
<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot

https://github.com/user-attachments/assets/957a61f2-f87a-4d33-8f7d-e98ce21dd21f

https://github.com/user-attachments/assets/e67ecd2a-41ac-4ee9-8110-ee26368d0a9c


## Testing Plan
Tested from HWTA locally run, saw SHV modal. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
