### PR TITLE
VxPrint: Prevent PW access if a precinct has not been selected by an EM

### DIFF
--- a/apps/print/backend/src/util/auth.ts
+++ b/apps/print/backend/src/util/auth.ts
@@ -14,12 +14,13 @@ export function constructAuthMachineState(
   const machineType = 'print';
   const systemSettings = store.getSystemSettings() ?? DEFAULT_SYSTEM_SETTINGS;
   const jurisdiction = store.getJurisdiction();
+  const requiresPrecinctSelection = store.getPrecinctSelection() === undefined;
   return {
     ...systemSettings.auth,
     electionKey,
     jurisdiction,
     machineType,
-    isConfigured: !!electionKey, // TODO(Nikhil): Add check for configuredPrecinctId
+    isConfigured: !!electionKey && !requiresPrecinctSelection,
   };
 }
 

--- a/apps/print/frontend/src/app.tsx
+++ b/apps/print/frontend/src/app.tsx
@@ -104,7 +104,7 @@ function AppRoot({
         reasonAndContext={authStatus}
         recommendedAction={
           authStatus.reason === 'machine_not_configured'
-            ? 'Use a system administrator or election manager card.'
+            ? 'Use an election manager card and select a precinct to finish configuration.'
             : 'Use a valid card.'
         }
         cardInsertionDirection="right"

--- a/apps/print/frontend/src/screens/machine_locked_screen.tsx
+++ b/apps/print/frontend/src/screens/machine_locked_screen.tsx
@@ -8,7 +8,11 @@ import {
   Main,
   Screen,
 } from '@votingworks/ui';
-import { getElectionRecord, getMachineConfig } from '../api';
+import {
+  getElectionRecord,
+  getMachineConfig,
+  getPrecinctSelection,
+} from '../api';
 
 const LockedImage = styled.img`
   margin-right: auto;
@@ -20,18 +24,27 @@ const LockedImage = styled.img`
 export function MachineLockedScreen(): JSX.Element | null {
   const getElectionRecordQuery = getElectionRecord.useQuery();
   const getMachineConfigQuery = getMachineConfig.useQuery();
+  const getPrecinctSelectionQuery = getPrecinctSelection.useQuery();
 
-  if (!getElectionRecordQuery.isSuccess || !getMachineConfigQuery.isSuccess) {
+  if (
+    !getElectionRecordQuery.isSuccess ||
+    !getMachineConfigQuery.isSuccess ||
+    !getPrecinctSelectionQuery.isSuccess
+  ) {
     return null;
   }
 
   const electionDefinition = getElectionRecordQuery.data?.electionDefinition;
   const electionPackageHash = getElectionRecordQuery.data?.electionPackageHash;
   const machineConfig = getMachineConfigQuery.data;
+  const requiresElectionConfiguration = !electionDefinition;
+  const requiresPrecinctSelection = !getPrecinctSelectionQuery.data;
+  const isConfigured =
+    !requiresElectionConfiguration && !requiresPrecinctSelection;
   return (
     <Screen>
       <Main centerChild>
-        {electionDefinition ? (
+        {isConfigured ? (
           <Font align="center">
             <LockedImage src="/locked.svg" alt="Locked Icon" />
             <H1 style={{ marginTop: '0' }}>VxPrint Locked</H1>
@@ -41,7 +54,9 @@ export function MachineLockedScreen(): JSX.Element | null {
           <Font align="center">
             <InsertCardImage cardInsertionDirection="right" />
             <H1 style={{ maxWidth: '27rem', marginTop: '0' }}>
-              Insert an election manager card to configure VxPrint.
+              {requiresPrecinctSelection
+                ? 'Insert an election manager card to select a precinct.'
+                : 'Insert an election manager card to configure VxPrint.'}
             </H1>
           </Font>
         )}


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7601

Currently VxPrint allows PW access even if a precinct has not been selected. Following the pattern in VxPollbook/VxScan, we  now block PW login until the EM selects a precinct.

Does not yet close the ticket as will have a follow up to update VxMark, VxMarkScan. Doing as a follow up PR to just agree on the copy/approach with this PR first.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/85155ae9-cd76-4d60-917a-54e61ea88a3b

## Testing Plan

Manual for now, automated tests next week

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
