### PR TITLE
VxPrint: Relocate ScreenWrapper for code cleanliness

### DIFF
--- a/apps/print/frontend/src/election_manager_app.tsx
+++ b/apps/print/frontend/src/election_manager_app.tsx
@@ -1,7 +1,6 @@
+import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
-import React from 'react';
-import { ScreenWrapper } from './components/screen_wrapper';
 import { PrintScreen } from './screens/print_screen';
 import { SettingsScreen } from './screens/settings_screen';
 import { ReportScreen } from './screens/report_screen';
@@ -15,36 +14,20 @@ export function ElectionManagerApp(): JSX.Element {
       <Switch>
         <Route
           path={electionManagerRoutes.print.path}
-          render={() => (
-            <ScreenWrapper authType="election_manager">
-              <PrintScreen isElectionManagerAuth />
-            </ScreenWrapper>
-          )}
+          render={() => <PrintScreen isElectionManagerAuth />}
         />
         <Route
           path={electionManagerRoutes.reports.path}
-          render={() => (
-            <ScreenWrapper authType="election_manager">
-              <ReportScreen />
-            </ScreenWrapper>
-          )}
+          render={() => <ReportScreen isElectionManagerAuth />}
         />
         <Route
           exact
           path={electionManagerRoutes.election.path}
-          render={() => (
-            <ScreenWrapper authType="election_manager">
-              <ElectionScreen />
-            </ScreenWrapper>
-          )}
+          render={() => <ElectionScreen />}
         />
         <Route
           path={electionManagerRoutes.settings.path}
-          render={() => (
-            <ScreenWrapper authType="election_manager">
-              <SettingsScreen />
-            </ScreenWrapper>
-          )}
+          render={() => <SettingsScreen />}
         />
         <Redirect to={electionManagerRoutes.election.path} />
       </Switch>

--- a/apps/print/frontend/src/poll_worker_app.tsx
+++ b/apps/print/frontend/src/poll_worker_app.tsx
@@ -2,7 +2,6 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 import React from 'react';
 import { PrintScreen } from './screens/print_screen';
 import { ReportScreen } from './screens/report_screen';
-import { ScreenWrapper } from './components/screen_wrapper';
 import { pollWorkerRoutes } from './routes';
 import { PrinterAlertWrapper } from './components/printer_alert_wrapper';
 
@@ -12,19 +11,11 @@ export function PollWorkerApp(): JSX.Element {
       <Switch>
         <Route
           path={pollWorkerRoutes.print.path}
-          render={() => (
-            <ScreenWrapper authType="poll_worker">
-              <PrintScreen isElectionManagerAuth={false} />
-            </ScreenWrapper>
-          )}
+          render={() => <PrintScreen />}
         />
         <Route
           path={pollWorkerRoutes.reports.path}
-          render={() => (
-            <ScreenWrapper authType="poll_worker">
-              <ReportScreen />
-            </ScreenWrapper>
-          )}
+          render={() => <ReportScreen />}
         />
         <Redirect to={pollWorkerRoutes.print.path} />
       </Switch>

--- a/apps/print/frontend/src/screens/election_screen.tsx
+++ b/apps/print/frontend/src/screens/election_screen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   Card,
   H2,
@@ -20,6 +19,7 @@ import {
   ejectUsbDrive,
 } from '../api';
 import { TitleBar } from '../components/title_bar';
+import { ScreenWrapper } from '../components/screen_wrapper';
 
 const Row = styled.div`
   display: flex;
@@ -78,10 +78,10 @@ export function ElectionScreen(): JSX.Element | null {
     } catch {
       // Handled by default query client error handling
     }
-  };
+  }
 
   return (
-    <React.Fragment>
+    <ScreenWrapper authType="election_manager">
       <TitleBar title="Election" />
       <Content>
         <Card color="neutral">
@@ -131,6 +131,6 @@ export function ElectionScreen(): JSX.Element | null {
           />
         </Row>
       </Content>
-    </React.Fragment>
+    </ScreenWrapper>
   );
 }

--- a/apps/print/frontend/src/screens/print_screen.tsx
+++ b/apps/print/frontend/src/screens/print_screen.tsx
@@ -24,6 +24,7 @@ import {
   printBallot,
 } from '../api';
 import { getPartyOptions } from '../utils';
+import { ScreenWrapper } from '../components/screen_wrapper';
 
 const DEFAULT_PROGRESS_MODAL_DELAY_SECONDS = 3;
 
@@ -109,7 +110,7 @@ const PrintButton = styled(Button)`
 export function PrintScreen({
   isElectionManagerAuth,
 }: {
-  isElectionManagerAuth: boolean;
+  isElectionManagerAuth?: boolean;
 }): JSX.Element | null {
   const [numCopies, setNumCopies] = useState(1);
   const [searchValue, setSearchValue] = useState<string>('');
@@ -186,164 +187,172 @@ export function PrintScreen({
   }
 
   return (
-    <Container>
-      <TitleBar
-        title="Print"
-        actions={
-          isElectionManagerAuth ? (
-            <PrintAllButton disabled={!printer.connected} />
-          ) : undefined
-        }
-      />
-      <Form>
-        <Column>
-          <FormSection
-            style={{
-              // Grow to fill space when precinct selection is enabled
-              flex: hidePrecinctSelection ? undefined : 1,
-              // Provide buffer for alignment when precinct selection is hidden
-              marginBottom: hidePrecinctSelection ? '2.75rem' : undefined,
-            }}
-          >
-            <strong>Precinct</strong>
-            {hidePrecinctSelection ? (
-              /* We still show the ExpandedSelect for ui consistency, but lock it to the configured precinct */
-              <ExpandedSelect
-                selectedValue={configuredPrecinct.precinctId}
-                options={[
-                  {
-                    value: configuredPrecinct.precinctId,
-                    label: assertDefined(
-                      precincts.find(
-                        (p) => p.id === configuredPrecinct.precinctId
-                      )
-                    ).name,
-                  },
-                ]}
-                onSelect={() => null}
-              />
-            ) : (
-              <ExpandedSelect
-                selectedValue={selectedPrecinctId}
-                options={precincts
-                  .map((p) => ({ value: p.id, label: p.name }))
-                  .filter(
-                    (o) =>
-                      !searchValue ||
-                      o.label.toLowerCase().includes(searchValue.toLowerCase())
-                  )}
-                onSearch={setSearchValue}
-                onSelect={(value) => {
-                  if (value !== selectedPrecinctId) {
-                    setSelectedPrecinctId(value);
-                    setSelectedSplitId('');
-                  }
-                }}
-              />
-            )}
-          </FormSection>
-          {hideSplitSelection ? null : (
-            <FormSection>
-              <strong style={{ marginBottom: '0.25rem' }}>Split</strong>
-              <ExpandedSelect
-                selectedValue={selectedSplitId}
-                options={availableSplits.map((split) => ({
-                  value: split.id,
-                  label: split.name,
-                }))}
-                onSelect={setSelectedSplitId}
-              />
-            </FormSection>
-          )}
-        </Column>
-        <Column>
-          {hidePartySelection ? null : (
-            <FormSection style={{ gap: '0.25rem' }}>
-              <strong>Party</strong>
-              <RadioGroup
-                label="Party"
-                value={selectedPartyId}
-                options={parties.map((party) => ({
-                  label: party.name,
-                  value: party.id,
-                }))}
-                onChange={setSelectedPartyId}
-                hideLabel
-              />
-            </FormSection>
-          )}
-          {hideLanguageSelection ? null : (
-            <FormSection style={{ gap: '0.25rem' }}>
-              <strong>Language</strong>
-              <RadioGroup
-                label="Language"
-                value={selectedLanguageCode}
-                options={languages.map((language) => ({
-                  label: format.languageDisplayName({
-                    languageCode: language,
-                    displayLanguageCode: 'en',
-                  }),
-                  value: language,
-                }))}
-                onChange={setSelectedLanguageCode}
-                hideLabel
-              />
-            </FormSection>
-          )}
-        </Column>
-      </Form>
-      <Footer>
-        {isElectionManagerAuth && (
-          <FooterSection style={{ marginRight: 'auto' }}>
-            <strong>Ballot Type:</strong>
-            <SegmentedButton
-              label="Precinct or Absentee"
-              selectedOptionId={isAbsentee ? 'absentee' : 'precinct'}
-              options={[
-                { label: 'Precinct', id: 'precinct' },
-                { label: 'Absentee', id: 'absentee' },
-              ]}
-              onChange={(newValue) => {
-                setIsAbsentee(newValue === 'absentee');
-              }}
-              hideLabel
-            />
-          </FooterSection>
-        )}
-        <FooterSection>
-          <strong>Copies:</strong>
-          <NumberInput
-            value={numCopies}
-            onChange={(value) => setNumCopies(value || 0)}
-            style={{ width: '4rem' }}
-          />
-        </FooterSection>
-        <PrintButton
-          icon="Print"
-          color="primary"
-          fill="filled"
-          onPress={handlePrint}
-          disabled={
-            !selectedPrecinct ||
-            !selectedLanguageCode ||
-            (!hidePartySelection && !selectedPartyId) ||
-            (!hideSplitSelection && !selectedSplitId) ||
-            !printer.connected
-          }
-        >
-          Print Ballot
-        </PrintButton>
-      </Footer>
-      {isShowingPrintingModal && (
-        <Modal
-          centerContent
-          content={
-            <Loading animationDurationS={DEFAULT_PROGRESS_MODAL_DELAY_SECONDS}>
-              Printing
-            </Loading>
+    <ScreenWrapper
+      authType={isElectionManagerAuth ? 'election_manager' : 'poll_worker'}
+    >
+      <Container>
+        <TitleBar
+          title="Print"
+          actions={
+            isElectionManagerAuth ? (
+              <PrintAllButton disabled={!printer.connected} />
+            ) : undefined
           }
         />
-      )}
-    </Container>
+        <Form>
+          <Column>
+            <FormSection
+              style={{
+                // Grow to fill space when precinct selection is enabled
+                flex: hidePrecinctSelection ? undefined : 1,
+                // Provide buffer for alignment when precinct selection is hidden
+                marginBottom: hidePrecinctSelection ? '2.75rem' : undefined,
+              }}
+            >
+              <strong>Precinct</strong>
+              {hidePrecinctSelection ? (
+                /* We still show the ExpandedSelect for ui consistency, but lock it to the configured precinct */
+                <ExpandedSelect
+                  selectedValue={configuredPrecinct.precinctId}
+                  options={[
+                    {
+                      value: configuredPrecinct.precinctId,
+                      label: assertDefined(
+                        precincts.find(
+                          (p) => p.id === configuredPrecinct.precinctId
+                        )
+                      ).name,
+                    },
+                  ]}
+                  onSelect={() => null}
+                />
+              ) : (
+                <ExpandedSelect
+                  selectedValue={selectedPrecinctId}
+                  options={precincts
+                    .map((p) => ({ value: p.id, label: p.name }))
+                    .filter(
+                      (o) =>
+                        !searchValue ||
+                        o.label
+                          .toLowerCase()
+                          .includes(searchValue.toLowerCase())
+                    )}
+                  onSearch={setSearchValue}
+                  onSelect={(value) => {
+                    if (value !== selectedPrecinctId) {
+                      setSelectedPrecinctId(value);
+                      setSelectedSplitId('');
+                    }
+                  }}
+                />
+              )}
+            </FormSection>
+            {hideSplitSelection ? null : (
+              <FormSection>
+                <strong style={{ marginBottom: '0.25rem' }}>Split</strong>
+                <ExpandedSelect
+                  selectedValue={selectedSplitId}
+                  options={availableSplits.map((split) => ({
+                    value: split.id,
+                    label: split.name,
+                  }))}
+                  onSelect={setSelectedSplitId}
+                />
+              </FormSection>
+            )}
+          </Column>
+          <Column>
+            {hidePartySelection ? null : (
+              <FormSection style={{ gap: '0.25rem' }}>
+                <strong>Party</strong>
+                <RadioGroup
+                  label="Party"
+                  value={selectedPartyId}
+                  options={parties.map((party) => ({
+                    label: party.name,
+                    value: party.id,
+                  }))}
+                  onChange={setSelectedPartyId}
+                  hideLabel
+                />
+              </FormSection>
+            )}
+            {hideLanguageSelection ? null : (
+              <FormSection style={{ gap: '0.25rem' }}>
+                <strong>Language</strong>
+                <RadioGroup
+                  label="Language"
+                  value={selectedLanguageCode}
+                  options={languages.map((language) => ({
+                    label: format.languageDisplayName({
+                      languageCode: language,
+                      displayLanguageCode: 'en',
+                    }),
+                    value: language,
+                  }))}
+                  onChange={setSelectedLanguageCode}
+                  hideLabel
+                />
+              </FormSection>
+            )}
+          </Column>
+        </Form>
+        <Footer>
+          {isElectionManagerAuth && (
+            <FooterSection style={{ marginRight: 'auto' }}>
+              <strong>Ballot Type:</strong>
+              <SegmentedButton
+                label="Precinct or Absentee"
+                selectedOptionId={isAbsentee ? 'absentee' : 'precinct'}
+                options={[
+                  { label: 'Precinct', id: 'precinct' },
+                  { label: 'Absentee', id: 'absentee' },
+                ]}
+                onChange={(newValue) => {
+                  setIsAbsentee(newValue === 'absentee');
+                }}
+                hideLabel
+              />
+            </FooterSection>
+          )}
+          <FooterSection>
+            <strong>Copies:</strong>
+            <NumberInput
+              value={numCopies}
+              onChange={(value) => setNumCopies(value || 0)}
+              style={{ width: '4rem' }}
+            />
+          </FooterSection>
+          <PrintButton
+            icon="Print"
+            color="primary"
+            fill="filled"
+            onPress={handlePrint}
+            disabled={
+              !selectedPrecinct ||
+              !selectedLanguageCode ||
+              (!hidePartySelection && !selectedPartyId) ||
+              (!hideSplitSelection && !selectedSplitId) ||
+              !printer.connected
+            }
+          >
+            Print Ballot
+          </PrintButton>
+        </Footer>
+        {isShowingPrintingModal && (
+          <Modal
+            centerContent
+            content={
+              <Loading
+                animationDurationS={DEFAULT_PROGRESS_MODAL_DELAY_SECONDS}
+              >
+                Printing
+              </Loading>
+            }
+          />
+        )}
+      </Container>
+    </ScreenWrapper>
   );
 }

--- a/apps/print/frontend/src/screens/settings_screen.tsx
+++ b/apps/print/frontend/src/screens/settings_screen.tsx
@@ -22,15 +22,16 @@ import {
 } from '../api';
 import { TitleBar } from '../components/title_bar';
 import { ToggleTestModeButton } from '../components/toggle_test_mode_button';
+import { ScreenWrapper } from '../components/screen_wrapper';
 
 const Content = styled.div`
   padding: 1rem;
 `;
 
 export function SettingsScreen({
-  isSystemAdministrator,
+  isSystemAdminAuth,
 }: {
-  isSystemAdministrator?: boolean;
+  isSystemAdminAuth?: boolean;
 }): JSX.Element | null {
   const history = useHistory();
 
@@ -59,10 +60,12 @@ export function SettingsScreen({
   }
 
   return (
-    <div>
+    <ScreenWrapper
+      authType={isSystemAdminAuth ? 'system_admin' : 'election_manager'}
+    >
       <TitleBar title="Settings" />
       <Content>
-        {isSystemAdministrator ? (
+        {isSystemAdminAuth ? (
           <React.Fragment>
             <H2>Election</H2>
             <P>
@@ -96,12 +99,12 @@ export function SettingsScreen({
         <P>
           <SignedHashValidationButton apiClient={apiClient} />
         </P>
-        {isSystemAdministrator && (
+        {isSystemAdminAuth && (
           <P>
             <ToggleUsbPortsButton />
           </P>
         )}
       </Content>
-    </div>
+    </ScreenWrapper>
   );
 }

--- a/apps/print/frontend/src/system_administrator_app.tsx
+++ b/apps/print/frontend/src/system_administrator_app.tsx
@@ -1,6 +1,5 @@
 import { Redirect, Route, Switch } from 'react-router-dom';
 
-import { ScreenWrapper } from './components/screen_wrapper';
 import { systemAdministratorRoutes } from './routes';
 import { SettingsScreen } from './screens/settings_screen';
 
@@ -9,11 +8,7 @@ export function SystemAdministratorApp(): JSX.Element {
     <Switch>
       <Route
         path={systemAdministratorRoutes.settings.path}
-        render={() => (
-          <ScreenWrapper authType="system_admin">
-            <SettingsScreen isSystemAdministrator />
-          </ScreenWrapper>
-        )}
+        render={() => <SettingsScreen isSystemAdminAuth />}
       />
       <Redirect to={systemAdministratorRoutes.settings.path} />
     </Switch>


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7653

I've had on my mind that it might be cleaner to move the ScreenWrapper to wrap the screens within the screen components, rather than having them wrap them within the routers. 

I think it is better, but curious what you think @kshen0. Also noting, the only change to the Screen components was adding the <ScreenWrapper>, the diff makes it seem larger.

## Demo Video or Screenshot

NA, no visual changes

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
