### PR TITLE
Enable AUDIO_PROOFING feature flag for MS

### DIFF
--- a/apps/design/backend/src/features.ts
+++ b/apps/design/backend/src/features.ts
@@ -171,6 +171,7 @@ export const stateFeatureConfigs: Record<StateCode, StateFeaturesConfig> = {
   },
 
   MS: {
+    AUDIO_PROOFING: true,
     MS_SEMS_CONVERSION: true,
   },
 


### PR DESCRIPTION
We can merge this to main, but we'll also want to bring it over to the demo app we're using for training tomorrow. Kofi's covering the latter.