### PR TITLE
VxDesign: Remove placeholder for audio proofing view

### DIFF
--- a/apps/design/frontend/src/ballots_screen.test.tsx
+++ b/apps/design/frontend/src/ballots_screen.test.tsx
@@ -24,7 +24,6 @@ import { render, screen, waitFor, within } from '../test/react_testing_library';
 import { withRoute } from '../test/routing_helpers';
 import { BallotsScreen } from './ballots_screen';
 import { routes } from './routes';
-import { BallotAudioScreen } from './ballot_audio/screen';
 
 vi.mock('./ballot_audio/screen');
 
@@ -368,43 +367,5 @@ describe('Ballot layout tab', () => {
     expect(screen.getByLabelText('8.5 x 14 inches (Legal)')).not.toBeChecked();
     expect(screen.getByLabelText('Default')).toBeChecked();
     expect(screen.getByLabelText('Compact')).not.toBeChecked();
-  });
-});
-
-describe('audio tab', () => {
-  const electionRecord = generalElectionRecord(jurisdiction.id);
-  const { election } = electionRecord;
-  const electionId = election.id;
-
-  beforeEach(() => {
-    expectElectionApiCalls(electionRecord);
-    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-  });
-
-  test('excluded if AUDIO_PROOFING feature is off', async () => {
-    mockStateFeatures(apiMock, electionId, { AUDIO_PROOFING: false });
-
-    renderScreen(electionId);
-    await screen.findByRole('heading', { name: 'Proof Ballots' });
-
-    expect(
-      screen.queryByRole('tab', { name: 'Audio' })
-    ).not.toBeInTheDocument();
-  });
-
-  test('included if AUDIO_PROOFING feature is on', async () => {
-    mockStateFeatures(apiMock, electionId, { AUDIO_PROOFING: true });
-    vi.mocked(BallotAudioScreen).mockImplementation(() => (
-      <div data-testid="Audio Screen" />
-    ));
-
-    renderScreen(electionId);
-    await screen.findByRole('heading', { name: 'Proof Ballots' });
-
-    const tab = screen.getByRole('tab', { name: 'Audio' });
-    expect(screen.queryByTestId('Audio Screen')).not.toBeInTheDocument();
-
-    userEvent.click(tab);
-    screen.queryByTestId('Audio Screen');
   });
 });

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -39,7 +39,6 @@ import { ElectionNavScreen, Header } from './nav_screen';
 import { ElectionIdParams, electionParamRoutes, routes } from './routes';
 import { BallotScreen, paperSizeLabels } from './ballot_screen';
 import { useTitle } from './hooks/use_title';
-import { BallotAudioScreen } from './ballot_audio/screen';
 
 function BallotDesignForm({
   electionId,
@@ -455,8 +454,6 @@ export function BallotsScreen(): JSX.Element | null {
   const ballotsRoutes = routes.election(electionId).ballots;
   useTitle(routes.election(electionId).ballots.root.title);
 
-  const features = getStateFeatures.useQuery(electionId).data;
-
   return (
     <Switch>
       <Route
@@ -473,15 +470,7 @@ export function BallotsScreen(): JSX.Element | null {
           </Header>
           <MainContent>
             <RouterTabBar
-              tabs={
-                features?.AUDIO_PROOFING
-                  ? [
-                      ballotsRoutes.ballotStyles,
-                      ballotsRoutes.ballotLayout,
-                      ballotsRoutes.audio.root,
-                    ]
-                  : [ballotsRoutes.ballotStyles, ballotsRoutes.ballotLayout]
-              }
+              tabs={[ballotsRoutes.ballotStyles, ballotsRoutes.ballotLayout]}
             />
             <Switch>
               <Route
@@ -492,24 +481,6 @@ export function BallotsScreen(): JSX.Element | null {
                 path={ballotsParamRoutes.ballotLayout.path}
                 component={BallotLayoutTab}
               />
-              {features?.AUDIO_PROOFING && (
-                <Route
-                  path={
-                    ballotsParamRoutes.audio.manage(
-                      ':ttsMode',
-                      ':stringKey',
-                      ':subkey?'
-                    ).path
-                  }
-                  component={BallotAudioScreen}
-                />
-              )}
-              {features?.AUDIO_PROOFING && (
-                <Route
-                  path={ballotsParamRoutes.audio.root.path}
-                  component={BallotAudioScreen}
-                />
-              )}
               <Redirect
                 from={ballotsParamRoutes.root.path}
                 to={ballotsParamRoutes.ballotStyles.path}

--- a/apps/design/frontend/src/routes.ts
+++ b/apps/design/frontend/src/routes.ts
@@ -7,7 +7,6 @@ import {
   ElectionId,
   ElectionStringKey,
   SystemSettings,
-  TtsExportSource,
 } from '@votingworks/types';
 import { Route } from '@votingworks/ui';
 
@@ -106,24 +105,6 @@ export const routes = {
         root: {
           title: 'Proof Ballots',
           path: `${root}/ballots`,
-        },
-        audio: {
-          root: {
-            title: 'Audio',
-            path: `${root}/ballots/audio`,
-          },
-          manage: (
-            ttsMode: TtsExportSource | ':ttsMode',
-            stringKey: string,
-            subkey?: string
-          ) => {
-            const subpath = subkey ? `/${subkey}` : '';
-
-            return {
-              title: 'Audio',
-              path: `${root}/ballots/audio/${ttsMode}/${stringKey}${subpath}`,
-            };
-          },
         },
         ballotStyles: {
           title: 'Ballot Styles',


### PR DESCRIPTION
## Overview

We'll be turning on the audio proofing feature flag externally before we get around to adding the search-based audio proofing view, so removing the placeholder view/routes for now. Might add it back under a different feature flag if/when we get to it.

## Testing Plan
N/A

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
