### PR TITLE
triple test timeout for markscan happy path test

### DIFF
--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.test.ts
@@ -518,7 +518,7 @@ async function executePrintBallotAndAssert(
   await expect(frontImage).toMatchImage(scanFixtureImageData);
 }
 
-test('voting flow happy path', async () => {
+test('voting flow happy path', { timeout: 6000 }, async () => {
   await executePrintBallotAndAssert(
     ballotPdfData,
     scannedBallotFixtureFilepaths


### PR DESCRIPTION
## Overview

Increases test timeout for VxMarkScan state machine happy path test. This test has been flaking in CI.

## Demo Video or Screenshot
N/A

## Testing Plan
N/A
