### PR TITLE
VxDesign: Remove VX Demos feature flags

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -117,9 +117,6 @@ import {
   anotherNonVxJurisdiction,
   sliJurisdiction,
   sliUser,
-  vxDemosUser,
-  vxOrganization,
-  nonVxOrganization,
   nhJurisdiction,
   msJurisdiction,
 } from '../test/mocks';
@@ -3789,8 +3786,6 @@ test('feature configs', async () => {
   expect(await apiClient.getUserFeatures()).toEqual({});
   auth0.setLoggedInUser(sliUser);
   expect(await apiClient.getUserFeatures()).toEqual(userFeatureConfigs.sli);
-  auth0.setLoggedInUser(vxDemosUser);
-  expect(await apiClient.getUserFeatures()).toEqual(userFeatureConfigs.demos);
 
   auth0.setLoggedInUser(vxUser);
   const vxElectionId = (
@@ -3846,8 +3841,6 @@ test('getBaseUrl', async () => {
   auth0.setLoggedInUser(nonVxUser);
   expect(await apiClient.getBaseUrl()).toEqual('https://test-base-url.com');
   auth0.setLoggedInUser(sliUser);
-  expect(await apiClient.getBaseUrl()).toEqual('https://test-base-url.com');
-  auth0.setLoggedInUser(vxDemosUser);
   expect(await apiClient.getBaseUrl()).toEqual('https://test-base-url.com');
 });
 

--- a/apps/design/backend/src/features.ts
+++ b/apps/design/backend/src/features.ts
@@ -1,8 +1,4 @@
-import {
-  sliOrganizationId,
-  votingWorksOrganizationId,
-  vxDemosOrganizationId,
-} from './globals';
+import { sliOrganizationId, votingWorksOrganizationId } from './globals';
 import { Jurisdiction, StateCode, User } from './types';
 import { userBelongsToOrganization } from './utils';
 
@@ -149,8 +145,6 @@ const vxUserFeaturesConfig: UserFeaturesConfig = {
 export const userFeatureConfigs = {
   vx: vxUserFeaturesConfig,
 
-  demos: { ...vxUserFeaturesConfig, ACCESS_ALL_ORGS: false },
-
   sli: {
     EXPORT_SCREEN: true,
     SYSTEM_SETTINGS_SCREEN: true,
@@ -183,9 +177,6 @@ export function getUserFeaturesConfig(user: User): UserFeaturesConfig {
   }
   if (userBelongsToOrganization(user, sliOrganizationId())) {
     return userFeatureConfigs.sli;
-  }
-  if (userBelongsToOrganization(user, vxDemosOrganizationId())) {
-    return userFeatureConfigs.demos;
   }
   return {};
 }

--- a/apps/design/backend/src/globals.ts
+++ b/apps/design/backend/src/globals.ts
@@ -111,10 +111,6 @@ export function sliOrganizationId(): string {
   return requiredProdEnvVar('ORG_ID_SLI', 'sli');
 }
 
-export function vxDemosOrganizationId(): string {
-  return requiredProdEnvVar('ORG_ID_VX_DEMOS', 'vx-demos');
-}
-
 /**
  * Where should the database go?
  */

--- a/apps/design/backend/test/mocks.ts
+++ b/apps/design/backend/test/mocks.ts
@@ -1,8 +1,4 @@
-import {
-  votingWorksOrganizationId,
-  sliOrganizationId,
-  vxDemosOrganizationId,
-} from '../src/globals';
+import { votingWorksOrganizationId, sliOrganizationId } from '../src/globals';
 import { Jurisdiction, Organization, User } from '../src/types';
 
 export const vxOrganization: Organization = {
@@ -16,10 +12,6 @@ export const nonVxOrganization: Organization = {
 export const sliOrganization: Organization = {
   id: sliOrganizationId(),
   name: 'SLI Organization',
-};
-export const vxDemosOrganization: Organization = {
-  id: vxDemosOrganizationId(),
-  name: 'VX Demos',
 };
 
 export const vxJurisdiction: Jurisdiction = {
@@ -85,18 +77,10 @@ export const sliUser: User = {
   jurisdictions: [sliJurisdiction],
 };
 
-export const vxDemosUser: User = {
-  name: 'vx.demos.user@example.com',
-  id: 'auth0|vx-demos-user-id',
-  organization: vxDemosOrganization,
-  jurisdictions: [],
-};
-
 export const organizations: Organization[] = [
   vxOrganization,
   nonVxOrganization,
   sliOrganization,
-  vxDemosOrganization,
 ];
 
 export const jurisdictions: Jurisdiction[] = [
@@ -108,10 +92,4 @@ export const jurisdictions: Jurisdiction[] = [
   msJurisdiction,
 ];
 
-export const users: User[] = [
-  vxUser,
-  nonVxUser,
-  anotherNonVxUser,
-  sliUser,
-  vxDemosUser,
-];
+export const users: User[] = [vxUser, nonVxUser, anotherNonVxUser, sliUser];


### PR DESCRIPTION

## Overview

We no longer need this jurisdiction to have different behavior, per Slack discussion.

## Demo Video or Screenshot
N/A

## Testing Plan
Existing tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
