### PR TITLE
VxDesign: Only insert dev data when auth is not enabled

### DIFF
--- a/apps/design/backend/migrations/1765828783133_insert-dev-data.js
+++ b/apps/design/backend/migrations/1765828783133_insert-dev-data.js
@@ -1,5 +1,9 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { votingWorksOrganizationId } = require('../build/globals');
+const {
+  votingWorksOrganizationId,
+  authEnabled,
+  NODE_ENV,
+} = require('../build/globals');
 
 /**
  * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
@@ -14,10 +18,7 @@ exports.shorthands = undefined;
 exports.up = (pgm) => {
   // Seed the database with the dev data needed to bypass Auth0 in development
   // when AUTH_ENABLED=false (using the hardcoded dev user).
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    process.env.NODE_ENV !== 'test'
-  ) {
+  if (NODE_ENV !== 'production' && NODE_ENV !== 'test' && !authEnabled()) {
     // Create the default dev organization (use VotingWorks org ID to get full features)
     pgm.sql(`
       INSERT INTO organizations (id, name) VALUES (


### PR DESCRIPTION
## Overview

Small fix to dev data migration introduced in #7702 so that it doesn't conflict with using a staging/prod db backup locally.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
