### PR TITLE
VxPrint: Drop backend endpoint

### DIFF
--- a/apps/print/backend/src/app.ts
+++ b/apps/print/backend/src/app.ts
@@ -8,7 +8,6 @@ import {
   ElectionPackageConfigurationError,
   PrecinctId,
   PrecinctSelection,
-  PrinterStatus,
   SinglePrecinctSelection,
   LanguageCode,
   Id,
@@ -71,10 +70,6 @@ export function buildApi(ctx: AppContext) {
 
     logOut() {
       return auth.logOut(constructAuthMachineState(store));
-    },
-
-    getPrinterStatus(): Promise<PrinterStatus> {
-      return printer.status();
     },
 
     async configureElectionPackageFromUsb(): Promise<


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7726

Noticed an extra endpoint while writing tests. I think it's no longer needed, as we use `getDeviceStatuses` to get the printer info. 

## Demo Video or Screenshot

NA

## Testing Plan

NA

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
