### PR TITLE
fix: make `script/bootstrap` not fail on some apps

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -12,7 +12,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 for app in ${DIR}/../apps/*/frontend ${DIR}/../apps/*/backend; do
   if [ -d "${app}" ]; then
-    make -C "${app}" bootstrap
+    make -C "${app}" -n bootstrap && make -C "${app}" bootstrap
   fi
 done
 


### PR DESCRIPTION
Not all apps have a `bootstrap` target in their `Makefile`.