### PR TITLE
VxAdmin: Increase test timeout for admin integration test

### DIFF
--- a/apps/admin/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/admin/integration-testing/e2e/screenshots.spec.ts
@@ -422,7 +422,7 @@ async function insertUsbDriveWithCvrs({
 }
 
 test('results', async ({ page }) => {
-  test.setTimeout(70_000);
+  test.setTimeout(120_000);
   const usbHandler = getMockFileUsbDriveHandler();
   const printerHandler = getMockFilePrinterHandler();
   printerHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);


### PR DESCRIPTION
## Overview

https://votingworks.slack.com/archives/C09JHUWB8UX/p1767649561595139?thread_ts=1767630602.663129&cid=C09JHUWB8UX

The VxAdmin 'results' integration test [failed](https://app.circleci.com/pipelines/github/votingworks/vxsuite/23533/workflows/275f15fe-d2e5-4e8e-a76a-e3d25667fd7d/jobs/1052016) due to timeouts today, and it looks like there are passed runs where we have been failing 1-2 times before eventually succeeding ([example](https://app.circleci.com/pipelines/github/votingworks/vxsuite/23508/workflows/0f14a17b-1111-4e82-8f0a-39268a0e4bc1/jobs/1050565)).

The tests are failing at different points, so it doesn't seem like there is a consistent hanging point. It is a long test, so I think a timeout bump makes sense but open to other input.

## Demo Video or Screenshot

NA

## Testing Plan

Will review at the end of the week to see if we still see more flakes.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
