### PR TITLE
VxDesign: Disable feature-flagged precinct split fields in "view" mode

### DIFF
--- a/apps/design/frontend/src/precincts_form.tsx
+++ b/apps/design/frontend/src/precincts_form.tsx
@@ -325,6 +325,7 @@ export function PrecinctForm(props: PrecinctFormProps): React.ReactNode {
                       {features.PRECINCT_SPLIT_ELECTION_TITLE_OVERRIDE && (
                         <InputGroup label="Election Title Override">
                           <input
+                            disabled={disabled}
                             type="text"
                             value={split.electionTitleOverride ?? ''}
                             onChange={(e) =>
@@ -338,8 +339,10 @@ export function PrecinctForm(props: PrecinctFormProps): React.ReactNode {
                       )}
 
                       {features.PRECINCT_SPLIT_ELECTION_SEAL_OVERRIDE && (
-                        <InputGroup label="Election Seal Override">
+                        <div>
+                          <FieldName>Election Seal Override</FieldName>
                           <SealImageInput
+                            disabled={disabled}
                             value={split.electionSealOverride}
                             onChange={(value) =>
                               setSplit(index, {
@@ -348,13 +351,14 @@ export function PrecinctForm(props: PrecinctFormProps): React.ReactNode {
                               })
                             }
                           />
-                        </InputGroup>
+                        </div>
                       )}
 
                       {features.PRECINCT_SPLIT_CLERK_SIGNATURE_IMAGE_OVERRIDE && (
                         <div>
                           <FieldName>Signature Image</FieldName>
                           <SignatureImageInput
+                            disabled={disabled}
                             value={split.clerkSignatureImage}
                             onChange={(value) =>
                               setSplit(index, {
@@ -369,6 +373,7 @@ export function PrecinctForm(props: PrecinctFormProps): React.ReactNode {
                       {features.PRECINCT_SPLIT_CLERK_SIGNATURE_CAPTION_OVERRIDE && (
                         <InputGroup label="Signature Caption">
                           <input
+                            disabled={disabled}
                             type="text"
                             value={split.clerkSignatureCaption ?? ''}
                             onChange={(e) =>


### PR DESCRIPTION
## Overview

Surfaced in Slack: https://votingworks.slack.com/archives/C085YT4798C/p1767813074277349

Missed these feature-flagged form fields while adding view/edit toggle states to the Precinct form, so they are currently staying editable when the form is in the "view" mode. Adding the appropriate `disabled` flags to the remaining elements.

### TODO
- Noticed the dev auth user doesn't currently have the ability to load/create elections in the NH state, in order to enable these flags - will look into getting that working to make dev testing easier.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/b5cca9d1-b87d-43ef-943d-a82b65b9b6d7

## Testing Plan
- Additional unit test for disabled controls in the "view" state
- Manual spot checks

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
