### PR TITLE
VxDesign: Add pnpm command for create-support-user

### DIFF
--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -22,6 +22,7 @@
     "create-jurisdiction-user": "node -r esbuild-runner/register ./scripts/create_jurisdiction_user.ts",
     "create-organization": "node -r esbuild-runner/register ./scripts/create_organization.ts",
     "create-organization-user": "node -r esbuild-runner/register ./scripts/create_organization_user.ts",
+    "create-support-user": "node -r esbuild-runner/register ./scripts/create_support_user.ts",
     "db:migrations:ci-validate": "./scripts/ci-validate-migrations.sh",
     "db:migrations:create": "node-pg-migrate create",
     "db:migrations:run": "node-pg-migrate up",


### PR DESCRIPTION
## Overview

Follow up to https://github.com/votingworks/vxsuite/pull/7747 

Realized this command was missing when I went to add the support user 

## Demo Video or Screenshot

NA

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
