### PR TITLE
VxDesign: Add in-context audio & batch editing to Parties screen

### DIFF
--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -481,42 +481,15 @@ export const deletePrecinct = {
   },
 } as const;
 
-export const createParty = {
+export const updateParties = {
   useMutation() {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
-    return useMutation(apiClient.createParty, {
-      async onSuccess(result, { electionId }) {
-        if (result.isOk()) {
-          await invalidateElectionQueries(queryClient, electionId);
-          await queryClient.refetchQueries(listParties.queryKey(electionId));
-        }
-      },
-    });
-  },
-} as const;
-
-export const updateParty = {
-  useMutation() {
-    const apiClient = useApiClient();
-    const queryClient = useQueryClient();
-    return useMutation(apiClient.updateParty, {
+    return useMutation(apiClient.updateParties, {
       async onSuccess(result, { electionId }) {
         if (result.isOk()) {
           await invalidateElectionQueries(queryClient, electionId);
         }
-      },
-    });
-  },
-} as const;
-
-export const deleteParty = {
-  useMutation() {
-    const apiClient = useApiClient();
-    const queryClient = useQueryClient();
-    return useMutation(apiClient.deleteParty, {
-      async onSuccess(_, { electionId }) {
-        await invalidateElectionQueries(queryClient, electionId);
       },
     });
   },

--- a/apps/design/frontend/src/routes.ts
+++ b/apps/design/frontend/src/routes.ts
@@ -80,18 +80,14 @@ export const routes = {
           title: 'Parties',
           path: `${root}/parties`,
         },
-        addParty: {
-          title: 'Add Party',
-          path: `${root}/parties/add`,
-        },
         audio: (p: {
           stringKey: ':stringKey' | ElectionStringKey;
           subkey: ':subkey' | (string & {});
         }) => `${root}/parties/audio/${p.stringKey}/${p.subkey}`,
-        editParty: (partyId: string) => ({
-          title: 'Edit Party',
-          path: `${root}/parties/${partyId}`,
-        }),
+        edit: {
+          title: 'Parties',
+          path: `${root}/parties/edit`,
+        },
       },
       contests: {
         root: {


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7266

*Backend API added in https://github.com/votingworks/vxsuite/pull/7714*

Updating the Parties screen to support audio proofing/editing and easier navigation between different parties when making edits:
- Combining the Parties list view and edit form into an inline batch-edit screen
- Wiring up audio button links to the in-context audio preview/edit panel.

## Demo Video or Screenshot

### Empty State:

https://github.com/user-attachments/assets/4fa61670-736f-4a42-8983-38db3bd6aff0

### Audio Panel UX:

https://github.com/user-attachments/assets/34f051ff-3974-46a6-b26d-e6568c9962fd

## Testing Plan
- New & updated unit tests
- Spot checks in Chrome, FF, Safari

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
