### PR TITLE
VxDesign: Disallow editing parties for MS SEMS elections

### DIFF
--- a/apps/design/frontend/src/parties_screen.test.tsx
+++ b/apps/design/frontend/src/parties_screen.test.tsx
@@ -230,7 +230,7 @@ test('editing or adding a party is disabled when ballots are finalized', async (
   expect(screen.queryButton('Cancel')).not.toBeInTheDocument();
 });
 
-test('adding or deleting a party is disabled for elections with external source', async () => {
+test('adding, editing, or deleting a party is disabled for elections with external source', async () => {
   const savedParties: Party[] = [
     { id: 'p1', abbrev: '1', fullName: 'party 1', name: 'p1' },
     { id: 'p2', abbrev: '2', fullName: 'party 2', name: 'p2' },
@@ -250,11 +250,8 @@ test('adding or deleting a party is disabled for elections with external source'
   // Add Party button should not be visible
   expect(screen.queryButton('Add Party')).not.toBeInTheDocument();
 
-  // Edit should be available but delete buttons should not be visible
-  userEvent.click(screen.getButton('Edit Parties'));
-  await screen.findButton('Save');
-
-  expect(screen.queryButton(/Delete Party/i)).not.toBeInTheDocument();
+  // Edit Parties button should not be visible
+  expect(screen.queryButton('Edit Parties')).not.toBeInTheDocument();
 });
 
 test('cancelling', async () => {

--- a/apps/design/frontend/src/parties_screen.tsx
+++ b/apps/design/frontend/src/parties_screen.tsx
@@ -227,7 +227,6 @@ function Contents(props: { editing: boolean }): React.ReactNode {
                 {updatedParties.map((party, i) => (
                   <PartyRow
                     disabled={disabled}
-                    canDelete={!hasExternalSource}
                     editing={editing}
                     key={party.id}
                     onChange={(p) =>
@@ -246,7 +245,6 @@ function Contents(props: { editing: boolean }): React.ReactNode {
                 {newParties.map((party, i) => (
                   <PartyRow
                     disabled={disabled}
-                    canDelete={!hasExternalSource}
                     editing={editing}
                     key={party.id}
                     onChange={(p) =>
@@ -265,7 +263,7 @@ function Contents(props: { editing: boolean }): React.ReactNode {
             )}
           </FormBody>
 
-          {!ballotsFinalized && (
+          {!ballotsFinalized && !hasExternalSource && (
             <FormFooter>
               {editing ? (
                 <React.Fragment>
@@ -318,7 +316,6 @@ const ERROR_MESSAGE: Record<DuplicatePartyError['code'], string> = {
 
 function PartyRow(props: {
   disabled?: boolean;
-  canDelete: boolean;
   editing: boolean;
   onChange: (party: Party) => void;
   onDelete: (partyId: string) => void;
@@ -326,15 +323,7 @@ function PartyRow(props: {
   // eslint-disable-next-line vx/gts-use-optionals -- require explicit prop
   updateError: DuplicatePartyError | undefined;
 }) {
-  const {
-    disabled,
-    canDelete,
-    editing,
-    updateError,
-    onChange,
-    onDelete,
-    party,
-  } = props;
+  const { disabled, editing, updateError, onChange, onDelete, party } = props;
   const { electionId } = useParams<ElectionIdParams>();
   const partiesRoutes = routes.election(electionId).parties;
 
@@ -405,7 +394,7 @@ function PartyRow(props: {
         }}
       />
 
-      {editing && canDelete ? (
+      {editing ? (
         <TooltipContainer as="div" style={{ width: 'min-content' }}>
           <Button
             aria-label={`Delete Party ${party.fullName}`}


### PR DESCRIPTION
## Overview

Parent task: https://github.com/votingworks/vxsuite/issues/7393
- prevent adding or removing parties

## Demo Video or Screenshot

UPDATED:
https://github.com/user-attachments/assets/0b7348c0-2a89-4fba-a60e-6172a06f1082

OUTDATED:
https://github.com/user-attachments/assets/618287ff-29eb-42ef-a2dd-8ea3a17a78a0

## Testing Plan

Automated test added

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
