### PR TITLE
VxDesign: Make sure UI has latest copy of districts/parties after save

### DIFF
--- a/apps/design/frontend/src/districts_screen.tsx
+++ b/apps/design/frontend/src/districts_screen.tsx
@@ -120,8 +120,12 @@ function Contents(props: { editing: boolean }): React.ReactNode {
   const electionInfoQuery = getElectionInfo.useQuery(electionId);
   const savedDistrictsQuery = listDistricts.useQuery(electionId);
 
+  // Reset form on initial and post-save fetches:
   React.useEffect(() => {
     if (!savedDistrictsQuery.data) return;
+
+    setNewDistricts([]);
+    setDeletedDistrictIds(new Set());
     setUpdatedDistricts([...savedDistrictsQuery.data]);
   }, [savedDistrictsQuery.data]);
 
@@ -146,9 +150,7 @@ function Contents(props: { editing: boolean }): React.ReactNode {
       },
       {
         onSuccess: (result) => {
-          if (result.isErr()) return;
-          reset();
-          setEditing(false);
+          if (result.isOk()) setEditing(false);
         },
       }
     );

--- a/apps/design/frontend/src/parties_screen.tsx
+++ b/apps/design/frontend/src/parties_screen.tsx
@@ -108,8 +108,12 @@ function Contents(props: { editing: boolean }): React.ReactNode {
   const savedPartiesQuery = listParties.useQuery(electionId);
   const ballotsFinalizedAtQuery = getBallotsFinalizedAt.useQuery(electionId);
 
+  // Reset form on initial and post-save fetches:
   React.useEffect(() => {
     if (!savedPartiesQuery.data) return;
+
+    setNewParties([]);
+    setDeletedPartyIds(new Set());
     setUpdatedParties([...savedPartiesQuery.data]);
   }, [savedPartiesQuery.data]);
 
@@ -130,9 +134,7 @@ function Contents(props: { editing: boolean }): React.ReactNode {
       },
       {
         onSuccess: (result) => {
-          if (result.isErr()) return;
-          reset();
-          setEditing(false);
+          if (result.isOk()) setEditing(false);
         },
       }
     );


### PR DESCRIPTION
## Overview

Fixes https://github.com/votingworks/vxsuite/issues/7760

Noticed while testing that, depending on whether the `onSuccess` callback of the update mutation runs before or after the data re-fetch, we may end up with stale data in the UI (since the `onSuccess` was triggering a reset using the captured state at the time of sending the request).

To fix, moving the reset call out of the `onSuccess` callbacks - it was duplicating work anyway that was already being done by an effect based off changes in the saved data.

## Demo Video or Screenshot

### Demo of the bug before the fix:
https://github.com/user-attachments/assets/d83e62ba-bf4c-4d9c-828e-73330193bb34

## Testing Plan
- Existing tests for reset-on-update behaviour, manual for this specific edge case, which is tough to repro in unit tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
