### PR TITLE
test(test-utils): ignore `else` branch for coverage

### DIFF
--- a/libs/test-utils/src/arbitraries.ts
+++ b/libs/test-utils/src/arbitraries.ts
@@ -200,6 +200,7 @@ export function arbitraryDateTime({
         const result = DateTime.fromObject(parts, {
           zone: zoneName,
         });
+        /* istanbul ignore else - @preserve */
         if (
           result.year === parts.year &&
           result.month === parts.month &&


### PR DESCRIPTION
## Overview
Sometimes a date is generated that doesn't make sense, like 2/31, and in those cases we just try again. Making this part of the coverage stats means we sometimes cover it and sometimes don't, leading to potential flakes like [this](https://app.circleci.com/pipelines/github/votingworks/vxsuite/23619/workflows/dd6db42d-999f-49ed-bcd9-f30b8f12d59a/jobs/1056907).

## Demo Video or Screenshot
n/a

## Testing Plan
Automated.