### PR TITLE
VxDesign: Fix test flake in districts_screen.test

### DIFF
--- a/apps/design/frontend/src/districts_screen.test.tsx
+++ b/apps/design/frontend/src/districts_screen.test.tsx
@@ -313,7 +313,7 @@ test('audio editing', async () => {
   for (const district of districts) {
     const input = await screen.findByDisplayValue(district.name);
     const container = assertDefined(input.parentElement);
-    const button = within(container).getButton(/preview or edit audio/i);
+    const button = await within(container).findButton(/preview or edit audio/i);
 
     userEvent.click(button);
 


### PR DESCRIPTION
## Overview

Noticed a recent [flake](https://app.circleci.com/pipelines/github/votingworks/vxsuite/23639/workflows/2dbb7bd3-c908-4f7b-8e89-6e0182d68492/jobs/1058056/tests#failed-test-0) in the Districts screen test that I was able to occasionally reproduce locally.

The test was only waiting for the initial "Edit Districts" button to appear, but not long enough for the audio buttons to appear (which rely on a state features query having resolved). Updating to a deferred `find` instead of `get` when looking for the audio buttons to fix.

