### PR TITLE
VxDesign: Move generation of results reporting url to backend

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -4375,7 +4375,7 @@ test('feature configs', async () => {
   ).toEqual(stateFeatureConfigs.MS);
 });
 
-test('getBaseUrl', async () => {
+test('getResultsReportingUrl', async () => {
   process.env = {
     ...process.env,
     BASE_URL: 'https://test-base-url.com',
@@ -4386,11 +4386,17 @@ test('getBaseUrl', async () => {
     users,
   });
   auth0.setLoggedInUser(vxUser);
-  expect(await apiClient.getBaseUrl()).toEqual('https://test-base-url.com');
+  expect(await apiClient.getResultsReportingUrl()).toEqual(
+    'https://test-base-url.com/report'
+  );
   auth0.setLoggedInUser(nonVxUser);
-  expect(await apiClient.getBaseUrl()).toEqual('https://test-base-url.com');
+  expect(await apiClient.getResultsReportingUrl()).toEqual(
+    'https://test-base-url.com/report'
+  );
   auth0.setLoggedInUser(sliUser);
-  expect(await apiClient.getBaseUrl()).toEqual('https://test-base-url.com');
+  expect(await apiClient.getResultsReportingUrl()).toEqual(
+    'https://test-base-url.com/report'
+  );
 });
 
 test('api call logging', async () => {

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -95,6 +95,7 @@ import {
   ReceivedReportInfo,
   ResultsReportingError,
   User,
+  resultsReportingUrl,
 } from './types';
 import { AppContext } from './context';
 import {
@@ -254,7 +255,7 @@ export function buildApi(ctx: AppContext) {
           'listElections',
           'getUser',
           'getUserFeatures',
-          'getBaseUrl',
+          'getResultsReportingUrl', // Doesn't need authorization, nothing private accessed
           'decryptCvrBallotAuditIds', // Doesn't need authorization, nothing private accessed
           ...ttsStrings.methodsThatHandleAuthThemselves,
         ];
@@ -864,8 +865,8 @@ export function buildApi(ctx: AppContext) {
       return getUserFeaturesConfig(context.user);
     },
 
-    getBaseUrl(): string {
-      return baseUrl();
+    getResultsReportingUrl(): string {
+      return resultsReportingUrl();
     },
 
     async getLiveReportsSummary(input: {

--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -32,6 +32,7 @@ export type {
   ReceivedReportInfo,
   QuickReportedPollStatus,
   GetExportedElectionError,
+  ResultsReportingPath,
 } from './types';
 export type {
   StateFeature,

--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -10,6 +10,7 @@ import {
 import { DateWithoutTime } from '@votingworks/basics';
 import { ContestResults } from '@votingworks/types/src/tabulation';
 import { z } from 'zod/v4';
+import { baseUrl } from './globals';
 
 export const StateCodes = ['DEMO', 'MS', 'NH'] as const;
 export type StateCode = (typeof StateCodes)[number];
@@ -167,3 +168,10 @@ export type ResultsReportingError =
   | 'invalid-payload'
   | 'invalid-signature'
   | GetExportedElectionError;
+
+export const RESULTS_REPORTING_PATH = '/report';
+export type ResultsReportingPath = typeof RESULTS_REPORTING_PATH;
+
+export function resultsReportingUrl(): string {
+  return new URL(RESULTS_REPORTING_PATH, baseUrl()).toString();
+}

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -755,13 +755,13 @@ export const getUserFeatures = {
   },
 } as const;
 
-export const getBaseUrl = {
+export const getResultsReportingUrl = {
   queryKey(): QueryKey {
-    return ['getBaseUrl'];
+    return ['getResultsReportingUrl'];
   },
   useQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getBaseUrl());
+    return useQuery(this.queryKey(), () => apiClient.getResultsReportingUrl());
   },
 } as const;
 

--- a/apps/design/frontend/src/routes.ts
+++ b/apps/design/frontend/src/routes.ts
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/ban-types */
+import { typedAs } from '@votingworks/basics';
 import type {
   ElectionInfo,
   UserFeaturesConfig,
 } from '@votingworks/design-backend';
+import { ResultsReportingPath } from '@votingworks/design-backend';
 import {
   ElectionId,
   ElectionStringKey,
@@ -13,7 +15,7 @@ import { Route } from '@votingworks/ui';
 export const resultsRoutes = {
   root: {
     title: 'Results Reported',
-    path: '/report',
+    path: typedAs<ResultsReportingPath>('/report'),
   },
 } as const;
 

--- a/apps/design/frontend/src/system_settings_screen.test.tsx
+++ b/apps/design/frontend/src/system_settings_screen.test.tsx
@@ -32,7 +32,9 @@ let apiMock: MockApiClient;
 beforeEach(() => {
   apiMock = createMockApiClient();
   apiMock.getUser.expectCallWith().resolves(user);
-  apiMock.getBaseUrl.expectCallWith().resolves('http://test-results-url.com');
+  apiMock.getResultsReportingUrl
+    .expectCallWith()
+    .resolves('http://test-results-url.com/report');
   apiMock.getElectionInfo
     .expectCallWith({ electionId })
     .resolves(electionInfoFromRecord(electionRecord));

--- a/apps/design/frontend/src/system_settings_screen.tsx
+++ b/apps/design/frontend/src/system_settings_screen.tsx
@@ -36,12 +36,12 @@ import {
 import { z } from 'zod/v4';
 import { Form, Column, Row, FormActionsRow, InputGroup } from './layout';
 import { ElectionNavScreen, Header } from './nav_screen';
-import { ElectionIdParams, resultsRoutes, routes } from './routes';
+import { ElectionIdParams, routes } from './routes';
 import {
   updateSystemSettings,
   getUserFeatures,
   getSystemSettings,
-  getBaseUrl,
+  getResultsReportingUrl,
 } from './api';
 import { useTitle } from './hooks/use_title';
 
@@ -118,10 +118,13 @@ export function SystemSettingsForm({
     useState<SystemSettings>(savedSystemSettings);
   const updateSystemSettingsMutation = updateSystemSettings.useMutation();
   const getUserFeaturesQuery = getUserFeatures.useQuery();
-  const getBaseUrlQuery = getBaseUrl.useQuery();
+  const getResultsReportingUrlQuery = getResultsReportingUrl.useQuery();
 
   /* istanbul ignore next - @preserve */
-  if (!getUserFeaturesQuery.isSuccess || !getBaseUrlQuery.isSuccess) {
+  if (
+    !getUserFeaturesQuery.isSuccess ||
+    !getResultsReportingUrlQuery.isSuccess
+  ) {
     return null;
   }
   const features = getUserFeaturesQuery.data;
@@ -589,7 +592,7 @@ export function SystemSettingsForm({
                   setSystemSettings({
                     ...systemSettings,
                     quickResultsReportingUrl: isChecked
-                      ? `${getBaseUrlQuery.data}${resultsRoutes.root.path}`
+                      ? getResultsReportingUrlQuery.data
                       : undefined,
                   })
                 }


### PR DESCRIPTION


## Overview

For the upcoming default system settings feature, we'll need to be able to set the results reporting URL by default when creating new elections, which happens on the backend. To ensure that the frontend path still matches the URL set on the backend, I added a type assertion to the route definition.

## Demo Video or Screenshot
N/A
## Testing Plan
Updated existing tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
