### PR TITLE
Update error message for contest ID assertion

### DIFF
--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -1893,7 +1893,7 @@ export class Store {
         ).rows.map((row) => row.id);
         assert(
           contestIds.length === existingContestIds.length,
-          'Invalid contest IDs'
+          'Contest list is out of date'
         );
         for (const contestId of contestIds) {
           const { rowCount } = await client.query(


### PR DESCRIPTION
This can show up when a client is stale. This new message might tell the user enough to know they should refresh, whereas the old one does not.

Prompted by [this Sentry error](https://votingworks.sentry.io/issues/7192652758/?alert_rule_id=15751537&alert_type=issue&notification_uuid=dc1e5873-e571-4f3f-b240-c647e24b5c0a&project=4508717994016768&referrer=slack).