### PR TITLE
VxDesign: Handle error in rich text editor when image is too big

### DIFF
--- a/apps/design/frontend/src/rich_text_editor.test.tsx
+++ b/apps/design/frontend/src/rich_text_editor.test.tsx
@@ -191,6 +191,21 @@ test('image', async () => {
   );
 });
 
+test('image too big error', async () => {
+  render(<RichTextEditor initialHtmlContent="Content" onChange={vi.fn()} />);
+  await screen.findByText('Content');
+
+  // Create a file that exceeds the 5 MB limit
+  const largeContent = 'x'.repeat(6 * 1_000 * 1_000);
+  const largeFile = new File([largeContent], 'large.svg', {
+    type: 'image/svg+xml',
+  });
+  const input = screen.getByLabelText('Insert Image');
+  userEvent.upload(input, largeFile);
+
+  await screen.findByText('Image file size must be less than 5 MB');
+});
+
 test('unwraps single cell tables on paste', async () => {
   const onChange = vi.fn();
   render(<RichTextEditor initialHtmlContent="" onChange={onChange} />);


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7298

Handles errors when uploading images via the rich text editor. 

## Demo Video or Screenshot

https://github.com/user-attachments/assets/25037553-528b-4be2-b9ca-3233587e92e2

## Testing Plan

Automated test added

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
