### PR TITLE
VxDesign: Update DB schema to prep for self-serve downloads

### DIFF
--- a/apps/design/backend/migrations/1768598243965_elections-add-self-serve-download-fields.js
+++ b/apps/design/backend/migrations/1768598243965_elections-add-self-serve-download-fields.js
@@ -1,0 +1,18 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  pgm.addColumn('elections', {
+    ballots_approved_at: { type: 'timestamptz' },
+    official_ballots_url: { type: 'text' },
+    sample_ballots_url: { type: 'text' },
+    test_ballots_url: { type: 'text' },
+  });
+};

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -2700,6 +2700,62 @@ test('Finalize ballots', async () => {
   });
 });
 
+test('approve ballots', async () => {
+  const { apiClient, auth0 } = await setupApp({
+    organizations,
+    jurisdictions,
+    users,
+  });
+
+  auth0.setLoggedInUser(nonVxUser);
+
+  const electionId = (
+    await apiClient.loadElection({
+      newId: 'new-election-id' as ElectionId,
+      jurisdictionId: nonVxJurisdiction.id,
+      upload: {
+        format: 'vxf',
+        electionFileContents:
+          electionFamousNames2021Fixtures.electionJson.asText(),
+      },
+    })
+  ).unsafeUnwrap();
+
+  expect(await apiClient.getBallotsApprovedAt({ electionId })).toEqual(null);
+
+  await suppressingConsoleOutput(async () => {
+    await expect(apiClient.approveBallots({ electionId })).rejects.toThrow(
+      /ballots cannot be approved before being finalized/i
+    );
+  });
+
+  await apiClient.finalizeBallots({ electionId });
+
+  const now = new Date();
+  {
+    vi.useFakeTimers({ now });
+    await apiClient.approveBallots({ electionId });
+    vi.useRealTimers();
+  }
+  expect(await apiClient.getBallotsApprovedAt({ electionId })).toEqual(now);
+
+  await apiClient.unfinalizeBallots({ electionId });
+  expect(await apiClient.getBallotsApprovedAt({ electionId })).toEqual(null);
+
+  // Check permissions:
+  await suppressingConsoleOutput(async () => {
+    auth0.setLoggedInUser(anotherNonVxUser);
+
+    await expect(
+      apiClient.getBallotsApprovedAt({ electionId })
+    ).rejects.toThrow('auth:forbidden');
+
+    await expect(apiClient.approveBallots({ electionId })).rejects.toThrow(
+      'auth:forbidden'
+    );
+  });
+});
+
 test('cloneElection', async () => {
   const { apiClient, auth0 } = await setupApp({
     organizations,
@@ -3066,6 +3122,11 @@ test('Election package management', async () => {
     url: expect.stringMatching(ELECTION_PACKAGE_FILE_NAME_REGEX),
   });
   expect(electionPackageAfterExport.url).toContain(nonVxJurisdiction.id);
+
+  // [TODO] Update worker to split up exports and verify these are set:
+  expect(electionPackageAfterExport.officialBallotsUrl).toBeUndefined();
+  expect(electionPackageAfterExport.testBallotsUrl).toBeUndefined();
+  expect(electionPackageAfterExport.sampleBallotsUrl).toBeUndefined();
 
   // Check that the correct package was returned by the files API endpoint
   const electionPackageUrl = `${baseUrl}${electionPackageAfterExport.url}`;

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -718,10 +718,30 @@ export function buildApi(ctx: AppContext) {
       });
     },
 
-    unfinalizeBallots(input: { electionId: ElectionId }): Promise<void> {
-      return store.setBallotsFinalizedAt({
+    async unfinalizeBallots(input: { electionId: ElectionId }): Promise<void> {
+      await store.setBallotsApprovedAt({
+        approvedAt: null,
+        electionId: input.electionId,
+      });
+      await store.setBallotsFinalizedAt({
         electionId: input.electionId,
         finalizedAt: null,
+      });
+    },
+
+    getBallotsApprovedAt(input: {
+      electionId: ElectionId;
+    }): Promise<Date | null> {
+      return store.getBallotsApprovedAt(input.electionId);
+    },
+
+    async approveBallots(input: { electionId: ElectionId }): Promise<void> {
+      const finalizedAt = await store.getBallotsFinalizedAt(input.electionId);
+      assert(finalizedAt, 'Ballots cannot be approved before being finalized');
+
+      return store.setBallotsApprovedAt({
+        approvedAt: new Date(),
+        electionId: input.electionId,
       });
     },
 


### PR DESCRIPTION
## Overview

[Task](https://github.com/votingworks/vxsuite/issues/7736) | [Spec](https://docs.google.com/document/d/1hI8ASF-rn32NT36Qgtj600VN2YL2BCtbeH1sy4dO_DU/edit?usp=sharing)

Adding a few extra fields to the `elections` DB table to support self-service election artefact downloads:
- `ballots_approved_at` - tracks date/time of the last approval from a support user, which can only be done after ballots are finalized and is required before downloads are made available to the customer.
- `official_ballots_url`, `sample_ballots_url`, `test_ballots_url` - these will track the URLs for separate archives for the corresponding ballot types (these are currently all rolled into a "single election package and ballots" archive and we'd like to split those up so users can download/save them separately (see GitHub issue for more context)

Adding backend APIs for reading/writing the new fields and updating the `unfinalizeBallots` endpoint to nullify any previous ballot approval.

## Testing Plan
- Unit tests for the finalize -> approve -> unfinalize flow
- Placeholder test assertions for the new ballot URL fields - will flesh those out when updating the worker logic

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
