### PR TITLE
VxMarkScan: Test Flakes - Increase retries for markscan waitForStatus helper

### DIFF
--- a/apps/mark-scan/backend/test/app_helpers.ts
+++ b/apps/mark-scan/backend/test/app_helpers.ts
@@ -189,6 +189,6 @@ export async function waitForStatus(
     async () => {
       expect(await apiClient.getPaperHandlerState()).toEqual(status);
     },
-    { interval, retries: 3 }
+    { interval, retries: 5 }
   );
 }


### PR DESCRIPTION
## Overview
Two MarkScan tests flaked semi-recently
https://app.circleci.com/pipelines/github/votingworks/vxsuite/23607/workflows/0587f8ef-565e-49a7-b342-4c21316f2967/jobs/1056233
and
https://app.circleci.com/pipelines/github/votingworks/vxsuite/23619/workflows/dd6db42d-999f-49ed-bcd9-f30b8f12d59a/jobs/1056911

Both on the same step of the mockLoadFlow() helper function in app.test.ts waiting for a loaded sheet to go to the waiting_for_voter_auth status but being on validing_new_sheet. I'm not sure why this flake is so rare / and only just appeared but that seems to be a natural state for the state machine to be in as it makes its way to waiting_for_voter_auth. The app.test.ts logic is using this waitForStatus helper, so I'm just bumping the number of retries here which seems arbitrarily set to hopefully resolve. 

<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot
N/A

## Testing Plan
Tests pass on CI 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
