### PR TITLE
VxDesign: [libs/ui] Enable text selection on non-touch UIs

### DIFF
--- a/libs/ui/src/global_styles.tsx
+++ b/libs/ui/src/global_styles.tsx
@@ -67,7 +67,8 @@ ${NORMALIZE_CSS}
     font-weight: ${(p) => p.theme.sizes.fontWeight.regular};
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
-    user-select: none;
+    user-select: ${(p) =>
+      isTouchscreen(p.theme.screenType) ? 'none' : undefined};
   }
 
   ${(p) => (p.theme.sizeMode === 'print' ? undefined : LEGACY_PRINT_STYLES)}


### PR DESCRIPTION
## Overview

We disable text selection by default in our global CSS (to prevent text selection during regular usage of our touchscreen machines) and haven't updated it since adding web-based VxDesign. Updating to only disable selection on whether or not we're using a touchscreen theme.

## Demo Video or Screenshot

### Desktop

https://github.com/user-attachments/assets/1b6d4f54-aa3d-4988-a8c7-43b59075a709

### Touch

https://github.com/user-attachments/assets/60308833-1474-492a-a83c-7232152f9296

## Testing Plan
- Manual

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
