### PR TITLE
VxDesign: Clear previous export URLs when starting new tasks

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -2887,7 +2887,8 @@ test('Election package management', async () => {
       payload: expectedPayload,
       taskName: 'generate_election_package',
     },
-    electionPackageUrl: expect.stringMatching(ELECTION_PACKAGE_FILE_NAME_REGEX),
+    // Previous URL should be cleared out when a new task is started:
+    electionPackageUrl: undefined,
   });
   const secondTaskId = assertDefined(
     electionPackageAfterInitiatingSecondExport.task

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -2016,10 +2016,19 @@ export class Store {
         await client.query(
           `
             update elections
-            set election_package_task_id = $1
-            where id = $2
+            set
+              election_package_task_id = $1,
+              election_package_url = $2,
+              official_ballots_url = $3,
+              sample_ballots_url = $4,
+              test_ballots_url = $5
+            where id = $6
           `,
           taskId,
+          null,
+          null,
+          null,
+          null,
           p.electionId
         );
 
@@ -2110,10 +2119,13 @@ export class Store {
         await client.query(
           `
             update elections
-            set test_decks_task_id = $1
-            where id = $2
+            set
+              test_decks_task_id = $1,
+              test_decks_url = $2
+            where id = $3
           `,
           taskId,
+          null,
           electionId
         );
 


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7736

Making sure we clear out stale URLs for previous exports when we kick off a new export task, either manually, or (after upcoming changes) triggered by finalizing ballots.
Reduces the chances of anyone mistakenly downloading an older package when a new one is in progress - mostly only relevant for the `Export` screen, since the [`Downloads`](https://www.figma.com/design/OFxDd1kqHbyvD4tpp15unE/-VxDesign--Self-Serve-Downloads?node-id=0-1&p=f&t=ZiyuRcYt6a8LguvY-0) section will be shown both before and after finalizing.

## Demo Video or Screenshot
N/A

## Testing Plan
- Added new backend store tests, updated a stale assertion in the app tests.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
