### PR TITLE
VxDesign: Delineate customer-facing screens from internal screens

### DIFF
--- a/apps/design/frontend/src/nav_screen.tsx
+++ b/apps/design/frontend/src/nav_screen.tsx
@@ -17,7 +17,7 @@ import {
 } from '@votingworks/ui';
 import { Link, useRouteMatch } from 'react-router-dom';
 import styled from 'styled-components';
-import { electionNavRoutes } from './routes';
+import { adminElectionNavRoutes, electionNavRoutes } from './routes';
 import {
   getElectionInfo,
   getSystemSettings,
@@ -130,27 +130,32 @@ export function ElectionNavScreen({
     return null;
   }
   const electionInfo = getElectionInfoQuery.data;
-  const userFeatures = getUserFeaturesQuery.data;
   const systemSettings = getSystemSettingsQuery.data;
+  const userFeatures = getUserFeaturesQuery.data;
   return (
     <NavScreen
       navContent={
         <NavList>
-          {electionNavRoutes(electionInfo, userFeatures, systemSettings).map(
-            (entry, i) => {
-              if (entry === 'DIVIDER') {
-                // eslint-disable-next-line react/no-array-index-key
-                return <NavDivider key={i} />;
-              }
-              const { path, title } = entry;
-              return (
-                <NavListItem key={path}>
-                  <NavLink to={path} isActive={path === currentRoute.url}>
-                    {title}
-                  </NavLink>
-                </NavListItem>
-              );
-            }
+          {electionNavRoutes(electionInfo, systemSettings).map(
+            ({ path, title }) => (
+              <NavListItem key={path}>
+                <NavLink to={path} isActive={path === currentRoute.url}>
+                  {title}
+                </NavLink>
+              </NavListItem>
+            )
+          )}
+          {adminElectionNavRoutes(electionInfo, userFeatures).length > 0 && (
+            <NavDivider />
+          )}
+          {adminElectionNavRoutes(electionInfo, userFeatures).map(
+            ({ path, title }) => (
+              <NavListItem key={path}>
+                <NavLink to={path} isActive={path === currentRoute.url}>
+                  {title}
+                </NavLink>
+              </NavListItem>
+            )
           )}
           <NavDivider />
           <NavListItem>

--- a/apps/design/frontend/src/routes.ts
+++ b/apps/design/frontend/src/routes.ts
@@ -173,11 +173,11 @@ export interface ElectionIdParams {
 export const electionParamRoutes = routes.election(':electionId');
 
 export const rootNavRoutes: Route[] = [];
+
 export function electionNavRoutes(
   electionInfo: ElectionInfo,
-  userFeatures: UserFeaturesConfig,
   electionSystemSettings: SystemSettings
-): Array<Route | 'DIVIDER'> {
+): Route[] {
   const electionRoutes = routes.election(electionInfo.electionId);
   return [
     electionRoutes.electionInfo.root,
@@ -192,9 +192,16 @@ export function electionNavRoutes(
     ...(electionInfo.externalSource === 'ms-sems'
       ? [electionRoutes.convertResults]
       : []),
-    ...(userFeatures.SYSTEM_SETTINGS_SCREEN || userFeatures.EXPORT_SCREEN
-      ? (['DIVIDER'] as const) // Delineate customer-facing screens from internal screens
-      : []),
+  ];
+}
+
+// For screens only relevant for internal users
+export function adminElectionNavRoutes(
+  electionInfo: ElectionInfo,
+  userFeatures: UserFeaturesConfig
+): Route[] {
+  const electionRoutes = routes.election(electionInfo.electionId);
+  return [
     ...(userFeatures.SYSTEM_SETTINGS_SCREEN
       ? [electionRoutes.systemSettings]
       : []),


### PR DESCRIPTION
## Overview

Super small change in the absence of a truly separate support user interface.

To help us better conceptualize what customers see in VxDesign vs. what we see when using it internally, I've tweaked the left nav, grouping all internal screens after customer-facing ones and adding a divider.

| Customer-facing | Internal before | Internal after |
| - | - | - |
| <img width="220" alt="customer" src="https://github.com/user-attachments/assets/0e7b59a1-ce36-4b05-b26c-a0038e2aef60" /> |  <img width="220" alt="internal-old" src="https://github.com/user-attachments/assets/a8ea5a0e-17ce-43cc-9c7d-93441d00d33a" /> | <img width="220" alt="internal-new" src="https://github.com/user-attachments/assets/745c6a83-325c-463a-9999-b4dd94179847" /> |

## Testing Plan

- [x] Tested manually

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [ ] ~I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~