### PR TITLE
VxDesign: Safety improvements when splitting long ballot measures

### DIFF
--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -831,6 +831,7 @@ async function splitLongBallotMeasureAcrossPages(
   }
 
   const descriptionHtmlNode = parseHtml(tooLongContest.description);
+  const descriptionHtmlText = descriptionHtmlNode.toString();
   for (const overflowingChild of descriptionHtmlNode.childNodes.slice(
     firstOverflowingChildIndex
   )) {
@@ -838,7 +839,7 @@ async function splitLongBallotMeasureAcrossPages(
   }
   const splitIndex = descriptionHtmlNode.toString().length;
 
-  const firstDescriptionChunk = tooLongContest.description.slice(0, splitIndex);
+  const firstDescriptionChunk = descriptionHtmlText.slice(0, splitIndex);
   const firstContest: YesNoContest = {
     ...tooLongContest,
     description: firstDescriptionChunk,
@@ -851,7 +852,7 @@ async function splitLongBallotMeasureAcrossPages(
     />
   );
 
-  const restDescription = tooLongContest.description.slice(splitIndex);
+  const restDescription = descriptionHtmlText.slice(splitIndex);
   const continuedTitleSuffix = ' (Continued)';
   const continuedTitle = tooLongContest.title.endsWith(continuedTitleSuffix)
     ? tooLongContest.title


### PR DESCRIPTION


## Overview

I noticed that the current logic to split long ballot measures parses the description HTML so that it can figure out where to split the ballot measure. It then decides where to split the string based on stringifying that parsed HTML, but splits the original description string. There's a chance that parsing and stringifying might yield a slightly different HTML string, in which case the splitting might be slightly off. I haven't seen this happen in practice, but just to be safe I tweaked the logic to use the stringified HTML string as the source for splitting rather than the original description HTML.

## Demo Video or Screenshot
N/A

## Testing Plan
Manually tested that splitting still works, plus relying on automated tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
