### PR TITLE
VxDesign: Allow sandbox users to self-approve elections

### DIFF
--- a/apps/design/frontend/src/proofing_status.tsx
+++ b/apps/design/frontend/src/proofing_status.tsx
@@ -33,7 +33,6 @@ export function ProofingStatus(): React.ReactNode {
   const finalizedAt = api.getBallotsFinalizedAt.useQuery(electionId);
   const mainExports = api.getElectionPackage.useQuery(electionId);
   const testDecks = api.getTestDecks.useQuery(electionId);
-  const user = api.getUser.useQuery();
 
   const approve = api.approveBallots.useMutation();
   const unfinalize = api.unfinalizeBallots.useMutation();
@@ -42,8 +41,7 @@ export function ProofingStatus(): React.ReactNode {
     !approvedAt.isSuccess ||
     !finalizedAt.isSuccess ||
     !mainExports.isSuccess ||
-    !testDecks.isSuccess ||
-    !user.isSuccess
+    !testDecks.isSuccess
   ) {
     return null;
   }
@@ -108,7 +106,7 @@ export function ProofingStatus(): React.ReactNode {
             Unfinalize
           </Button>
 
-          {user.data.type === 'support_user' && !approved && (
+          {!approved && (
             <Button
               disabled={approveDisabled}
               icon="Done"


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7736

The new `Approve` button on the `Export` screen is currently only visible to support users, but it's now occurring to me that it's safe to enable for sandbox users as well (Vx non-support, SLI), since they don't have access to non-sandbox elections.

Removing the `support_user` condition from the `Approve` button, which essentially gives it the same visibility as the `Unfinalize` button.

This also allows sandbox users to test out the approval flow without the need for support user intervention.

## Demo Video or Screenshot

<img width="1920" height="1081" alt="vxdesign-approve-button" src="https://github.com/user-attachments/assets/c1b54bf7-5d9e-46a6-add6-1f1f9e03c781" />

## Testing Plan
- Updated unit tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
