### PR TITLE
VxDesign: Implement basic Slack activity logs for core actions

### DIFF
--- a/apps/design/backend/src/activity_logs.ts
+++ b/apps/design/backend/src/activity_logs.ts
@@ -1,0 +1,99 @@
+import * as Sentry from '@sentry/node';
+import { format } from '@votingworks/utils';
+
+import { baseUrl, slackWebhookUrl } from './globals';
+import { Store } from './store';
+import { User, UserType } from './types';
+
+interface UserContext {
+  userName: string;
+  userType: UserType;
+}
+
+interface ElectionContext {
+  electionId: string;
+}
+
+interface FinalizeBallot extends UserContext, ElectionContext {
+  type: 'finalize_ballot';
+}
+
+interface UnfinalizeBallot extends UserContext, ElectionContext {
+  type: 'unfinalize_ballot';
+}
+
+interface ApproveBallot extends UserContext, ElectionContext {
+  type: 'approve_ballot';
+}
+
+type Activity = FinalizeBallot | UnfinalizeBallot | ApproveBallot;
+type ActivityType = Activity['type'];
+
+const ACTIVITY_TYPE_TO_MESSAGE: Record<ActivityType, string> = {
+  finalize_ballot: ':mag: Ballot finalized and ready for review',
+  unfinalize_ballot: ':rewind: Ballot unfinalized',
+  approve_ballot: ':white_check_mark: Ballot approved and ready for use',
+};
+
+const READABLE_USER_TYPES: Record<User['type'], string> = {
+  jurisdiction_user: 'Jurisdiction user',
+  organization_user: 'Organization user',
+  support_user: 'Support user',
+};
+
+function markdown(text: string) {
+  return { type: 'mrkdwn', text };
+}
+
+export async function logActivity(
+  store: Store,
+  activity: Activity
+): Promise<void> {
+  const { type, userName, userType, electionId } = activity;
+  const { election } = await store.getElection(electionId);
+  const jurisdiction = await store.getElectionJurisdiction(electionId);
+
+  const message = ACTIVITY_TYPE_TO_MESSAGE[type];
+  const userString = `${READABLE_USER_TYPES[userType]} ${userName}`;
+  const electionString = `${election.title} · ${format.localeDate(
+    election.date.toMidnightDatetimeWithSystemTimezone()
+  )}`;
+  const electionUrl = `${baseUrl()}/elections/${election.id}`;
+
+  const formattedMessage = {
+    text: message,
+    blocks: [
+      { type: 'section', text: markdown(`*${message}*`) },
+      {
+        type: 'context',
+        elements: [
+          markdown(`:round_pushpin: ${jurisdiction.name}`),
+          markdown(
+            `:ballot_box_with_ballot: <${electionUrl}|${electionString}>`
+          ),
+          markdown(`:technologist: ${userString}`),
+        ],
+      },
+    ],
+  } as const;
+
+  // Don't block on the request to the Slack webhook
+  void logToSlack(JSON.stringify(formattedMessage));
+}
+
+async function logToSlack(message: string): Promise<void> {
+  /* istanbul ignore next - @preserve */
+  if (slackWebhookUrl()) {
+    try {
+      await fetch(slackWebhookUrl(), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: message,
+      });
+    } catch (error) {
+      Sentry.captureException(error);
+      // eslint-disable-next-line no-console
+      console.error('Error logging to Slack:', error, message);
+    }
+  }
+}

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -121,6 +121,7 @@ import * as ttsStrings from './tts_strings';
 import { convertMsElection } from './convert_ms_election';
 import { convertMsResults, ConvertMsResultsError } from './convert_ms_results';
 import { defaultSystemSettings } from './system_settings';
+import { logActivity } from './activity_logs';
 
 const debug = rootDebug.extend('app');
 
@@ -649,7 +650,10 @@ export function buildApi(ctx: AppContext) {
       return store.getBallotsFinalizedAt(input.electionId);
     },
 
-    async finalizeBallots(input: { electionId: ElectionId }): Promise<void> {
+    async finalizeBallots(
+      input: { electionId: ElectionId },
+      { user }: ApiContext
+    ): Promise<void> {
       const jurisdiction = await store.getElectionJurisdiction(
         input.electionId
       );
@@ -671,9 +675,19 @@ export function buildApi(ctx: AppContext) {
         electionId: input.electionId,
         finalizedAt: new Date(),
       });
+
+      await logActivity(store, {
+        type: 'finalize_ballot',
+        userName: user.name,
+        userType: user.type,
+        electionId: input.electionId,
+      });
     },
 
-    async unfinalizeBallots(input: { electionId: ElectionId }): Promise<void> {
+    async unfinalizeBallots(
+      input: { electionId: ElectionId },
+      { user }: ApiContext
+    ): Promise<void> {
       await store.setBallotsApprovedAt({
         approvedAt: null,
         electionId: input.electionId,
@@ -681,6 +695,13 @@ export function buildApi(ctx: AppContext) {
       await store.setBallotsFinalizedAt({
         electionId: input.electionId,
         finalizedAt: null,
+      });
+
+      await logActivity(store, {
+        type: 'unfinalize_ballot',
+        userName: user.name,
+        userType: user.type,
+        electionId: input.electionId,
       });
     },
 
@@ -690,12 +711,22 @@ export function buildApi(ctx: AppContext) {
       return store.getBallotsApprovedAt(input.electionId);
     },
 
-    async approveBallots(input: { electionId: ElectionId }): Promise<void> {
+    async approveBallots(
+      input: { electionId: ElectionId },
+      { user }: ApiContext
+    ): Promise<void> {
       const finalizedAt = await store.getBallotsFinalizedAt(input.electionId);
       assert(finalizedAt, 'Ballots cannot be approved before being finalized');
 
-      return store.setBallotsApprovedAt({
+      await store.setBallotsApprovedAt({
         approvedAt: new Date(),
+        electionId: input.electionId,
+      });
+
+      await logActivity(store, {
+        type: 'approve_ballot',
+        userName: user.name,
+        userType: user.type,
         electionId: input.electionId,
       });
     },

--- a/apps/design/backend/src/globals.ts
+++ b/apps/design/backend/src/globals.ts
@@ -103,6 +103,10 @@ export function auth0Secret(): string {
   return requiredProdEnvVar('AUTH0_SECRET', '');
 }
 
+export function slackWebhookUrl(): string {
+  return requiredProdEnvVar('SLACK_WEBHOOK_URL', '');
+}
+
 export function votingWorksOrganizationId(): string {
   return requiredProdEnvVar('ORG_ID_VOTINGWORKS', 'votingworks');
 }


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/5813

This PR implements basic Slack activity logs for core actions as we prep for the big wave of towns finalizing their ballots. I've added logs for:
* Customers finalizing a ballot (or us refinalizing after unfinalizing to make a quick edit)
* Us unfinalizing a ballot
* Us approving a ballot

The logs will go to #vxhub-activity-logs (prepping for the eventual rename of VxDesign to VxHub).

<table>
<img width="615" height="205" alt="slack" src="https://github.com/user-attachments/assets/69e76732-824b-43ed-9b7e-10dd8076ff35" />
</table>

## Testing Plan

- [x] Tested manually

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] ~I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~