### PR TITLE
VxDesign: Re-enable backend eslint checks on app.test and test/helpers

### DIFF
--- a/apps/design/backend/.eslintignore
+++ b/apps/design/backend/.eslintignore
@@ -1,6 +1,3 @@
 build
 vitest.config.ts
 coverage
-
-src/app.test.ts
-test/helpers.ts


### PR DESCRIPTION
## Overview

Noticed we still had lint checks disabled for the app tests from, I think, back when we temporarily disabled tests.
Re-enabled and ran auto-fixes, then fixed the remaining errors (mostly just unused `Result`s).

## Demo Video or Screenshot
N/A

## Testing Plan
N/A

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
