### PR TITLE
VxDesign: Polish empty contests callout to not be squished

### DIFF
--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -307,8 +307,11 @@ function Content(): JSX.Element | null {
               stringKey: ':stringKey',
               subkey: ':subkey',
             })}
-            component={ContestAudioPanel}
-          />
+          >
+            <EditPanel>
+              <ContestAudioPanel />
+            </EditPanel>
+          </Route>
           <Route
             path={contestParamRoutes.add.path}
             component={AddContestForm}

--- a/apps/design/frontend/src/precincts_screen.tsx
+++ b/apps/design/frontend/src/precincts_screen.tsx
@@ -76,7 +76,9 @@ function Content(): React.ReactNode {
     !precincts.isSuccess ||
     !ballotsFinalizedAt.isSuccess ||
     !electionInfoQuery.isSuccess
-  ) return null;
+  ) {
+    return null;
+  }
 
   const precinctRoutes = routes.election(electionId).precincts;
   const precinctParamRoutes = electionParamRoutes.precincts;
@@ -117,8 +119,11 @@ function Content(): React.ReactNode {
               stringKey: ':stringKey',
               subkey: ':subkey',
             })}
-            component={PrecinctAudioPanel}
-          />
+          >
+            <EditPanel>
+              <PrecinctAudioPanel />
+            </EditPanel>
+          </Route>
 
           <Route
             path={precinctParamRoutes.add.path}


### PR DESCRIPTION

## Overview

Changes the contests screen CSS to match the precincts screen CSS so that the callout when there are no contests can flow horizontally rather than being squashed into the sidebar space.

## Demo Video or Screenshot
Before
<img width="1312" height="730" alt="Screenshot 2026-01-27 at 12 35 44 PM" src="https://github.com/user-attachments/assets/72701db3-2a70-4dea-bad3-a909f4dcaa5f" />

After
<img width="1312" height="731" alt="Screenshot 2026-01-27 at 12 35 28 PM" src="https://github.com/user-attachments/assets/93914806-b1e8-4f02-bcd0-7fcb21531c7f" />

## Testing Plan
Visual inspection

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
