### PR TITLE
VxDesign: Warn NH users about potential post-finalize change fees

### DIFF
--- a/apps/design/backend/src/features.ts
+++ b/apps/design/backend/src/features.ts
@@ -126,7 +126,7 @@ export enum StateFeature {
    */
   ADDITIONAL_BALLOT_MEASURE_OPTIONS = 'ADDITIONAL_BALLOT_MEASURE_OPTIONS',
   /**
-   * Show a warning when finalizing a ballot that requesting a change after finalizing may cost a
+   * Show a warning when finalizing a ballot that requesting a change after finalizing may incur a
    * fee.
    */
   POST_FINALIZE_CHANGE_FEE_WARNING = 'POST_FINALIZE_CHANGE_FEE_WARNING',

--- a/apps/design/frontend/src/ballots_status.test.tsx
+++ b/apps/design/frontend/src/ballots_status.test.tsx
@@ -123,7 +123,7 @@ test.each([false, true])(
     within(modal).getByText(
       'Once ballots are finalized, the election may not be edited further.'
     );
-    const warningText = 'Requesting a change after finalizing may cost a fee.';
+    const warningText = 'Requesting a change after finalizing may incur a fee.';
     if (isPostFinalizeChangeFeeWarningEnabled) {
       within(modal).getByText(warningText);
     } else {

--- a/apps/design/frontend/src/ballots_status.tsx
+++ b/apps/design/frontend/src/ballots_status.tsx
@@ -118,7 +118,7 @@ export function BallotsStatus(): React.ReactNode {
                 <React.Fragment>
                   {' '}
                   <strong>
-                    Requesting a change after finalizing may cost a fee.
+                    Requesting a change after finalizing may incur a fee.
                   </strong>
                 </React.Fragment>
               )}


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7744

Our operations in NH are unique in that we serve as a printing middleman for all customers. In other states, we expect that customers will communincate with printing partners directly.

This means that, when a change needs to be made to a ballot after it's been finalized, it's very possible that we've already given Evans Printing the greenlight to start printing ballots. There's obviously the lost printing cost but also a fairly high logistical cost for the Customer Success Team in coordination efforts when this happens.

To encourage customers to proof as diligently as possible, we're planning to charge a fee for late-stage edits. The intent here is not to be draconian. If a mistake is one that we think the software should've caught, we obviously wouldn't charge. Likewise for factors outside of an election office's control, e.g., a candidate has passed away. We're more concerned about cases like a forgotten contest or a ballot measure with the wrong content (both of which did come up last year), i.e., issues that we truly couldn't have caught on our end with even the most sophisticated software checks.

While the Customer Success Team has communicated this policy, they've also asked that we include a quick note in the product as a final reminder. Only NH elections will surface this warning.

_With warning_

<table>
<img width="600" alt="warning" src="https://github.com/user-attachments/assets/57e13df3-ae3e-4310-b6ef-9397313ec10d" />
</table>

_Without warning_

<table>
<img width="600" alt="without-warning" src="https://github.com/user-attachments/assets/786907c9-072e-45c5-b165-1347414c669d" />
</table>

## Testing Plan

- [x] Tested manually
- [x] Updated automated tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.