### PR TITLE
Fix libs/ballot-interpreter clean command

### DIFF
--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -18,7 +18,7 @@
     "build:rust-addon": "cargo-cp-artifact -nc build/addon.node -- cargo build --message-format=json-render-diagnostics --release --offline",
     "build:ts": "tsgo --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "cargo clean --release --package $npm_package_name && rm -rf build && tsgo --build --clean tsconfig.build.json",
+    "clean:self": "cargo clean --release --package pdi-scanner && rm -rf build && tsgo --build --clean tsconfig.build.json",
     "install:rust-addon": "cargo fetch",
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->
It was previously giving an error:

```
error: unexpected prerelease field, expected a version like "1.32"
 ELIFECYCLE  Command failed with exit code 101.
```

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
