### PR TITLE
VxDesign: Add last paste contents to rich text editor Sentry errors

### DIFF
--- a/apps/design/frontend/src/index.tsx
+++ b/apps/design/frontend/src/index.tsx
@@ -1,8 +1,19 @@
 import * as Sentry from '@sentry/browser';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { assert } from '@votingworks/basics';
+import { assert, isArray, isPlainObject, isString } from '@votingworks/basics';
 import { App } from './app';
+import { tiptapErrorContextBox } from './rich_text_editor';
+
+function isTiptapError(event: Sentry.ErrorEvent): boolean {
+  const extraArgs = event.extra?.['arguments'];
+  if (!isArray(extraArgs)) return false;
+  if (!isPlainObject(extraArgs[0])) return false;
+  // eslint-disable-next-line prefer-destructuring
+  const currentTarget = extraArgs[0]['currentTarget'];
+  if (!isString(currentTarget)) return false;
+  return currentTarget.includes('tiptap');
+}
 
 /* istanbul ignore next - @preserve */
 if (process.env.NODE_ENV === 'production') {
@@ -16,6 +27,14 @@ if (process.env.NODE_ENV === 'production') {
     environment: envVars._vxdesign_deploy_env,
     integrations: [Sentry.browserTracingIntegration()],
     tracesSampleRate: 0.2,
+    beforeSend(event) {
+      if (event.extra && isTiptapError(event)) {
+        // eslint-disable-next-line no-param-reassign
+        event.extra['lastPasteClipboardContent'] =
+          tiptapErrorContextBox.lastPasteClipboardContent;
+      }
+      return event;
+    },
   });
 }
 

--- a/apps/design/frontend/src/rich_text_editor.tsx
+++ b/apps/design/frontend/src/rich_text_editor.tsx
@@ -372,6 +372,10 @@ interface RichTextEditorProps {
   className?: string;
 }
 
+export const tiptapErrorContextBox: { lastPasteClipboardContent?: string } = {
+  lastPasteClipboardContent: undefined,
+};
+
 export function RichTextEditor({
   disabled,
   initialHtmlContent,
@@ -415,6 +419,11 @@ export function RichTextEditor({
     content: initialHtmlContent,
     onUpdate: (update) => {
       onChange(update.editor.getHTML());
+    },
+    onPaste: (event) => {
+      tiptapErrorContextBox.lastPasteClipboardContent =
+        event.clipboardData?.getData('text/html') ||
+        event.clipboardData?.getData('text/plain');
     },
   });
   return (


### PR DESCRIPTION
## Overview

Every once in a while we get Sentry errors that seem to be caused by pasting content into the rich text editor that TipTap can't process. We haven't been able to repro these errors since we don't know what the pasted content is. This PR captures the clipboard content on every paste. Then, if there's a Sentry error derived from TipTap, it adds the paste content to the error.

## Demo Video or Screenshot
Example Sentry error: https://votingworks.sentry.io/issues/7228867260/?referrer=slack&alert_rule_id=15751537&alert_type=issue

## Testing Plan
I had a hard time knowing exactly how to simulate the type of error we're trying to handle here (since that's the whole problem). But I was able to trigger a seemingly similar error by returning invalid content from `unwrapSingleCellTableOnPaste`.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
