### PR TITLE
Decrease density of SHV QR codes by decreasing error correction level

### DIFF
--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -541,11 +541,7 @@ function PollWorkerScreenContents({
                   data-testid="quick-results-code"
                   data-value={reports[currentQrIndex]}
                 >
-                  <QrCode
-                    value={reports[currentQrIndex]}
-                    level="M"
-                    size={450}
-                  />
+                  <QrCode value={reports[currentQrIndex]} size={450} />
                 </div>
               )}
               <div style={{ height: '0.3em' }} />

--- a/libs/ui/src/bmd_paper_ballot.test.tsx
+++ b/libs/ui/src/bmd_paper_ballot.test.tsx
@@ -344,7 +344,7 @@ test('BmdPaperBallot passes expected data to encodeBallot for use in QR code', (
 
   expect(QrCodeSpy).toBeCalledWith(
     expect.objectContaining<QrCodeModule.QrCodeProps>({
-      level: undefined,
+      level: 'H',
       value: fromByteArray(mockEncodedBallotData),
     }),
     expect.anything()

--- a/libs/ui/src/bmd_paper_ballot.tsx
+++ b/libs/ui/src/bmd_paper_ballot.tsx
@@ -594,9 +594,7 @@ function qrCodeLevelOverride(
     }
   }
 
-  if (writeInCharCount > MAX_WRITE_IN_CHARS_FOR_HIGH_DENSITY_QR) return 'M';
-
-  return undefined;
+  return writeInCharCount <= MAX_WRITE_IN_CHARS_FOR_HIGH_DENSITY_QR ? 'H' : 'M';
 }
 
 /**

--- a/libs/ui/src/qrcode.tsx
+++ b/libs/ui/src/qrcode.tsx
@@ -9,7 +9,23 @@ const ResponsiveSvgWrapper = styled.div`
   }
 `;
 
+/**
+ * Using a higher level makes a QR code more resilient to damage or distortion but also requires
+ * a larger/denser QR code.
+ */
 export type QrCodeLevel = 'L' | 'M' | 'Q' | 'H';
+
+/**
+ * Our QR codes are generally displayed on high-fidelity screens or printed with high-fidelity
+ * printers, so the highest error correction levels are in most cases unnecessary. In fact, for
+ * some of our larger QR codes, e.g., SHV QR codes, we've found that the highest levels make the QR
+ * codes so large/dense that some phones have trouble reading them.
+ *
+ * We can override with higher levels when we need to optimize for resilience, e.g., summary
+ * ballots printed on lower-fidelity thermal printers. And we can override with lower levels when
+ * we need to optimize for space constraints, e.g., HMP ballots.
+ */
+const DEFAULT_QR_CODE_LEVEL: QrCodeLevel = 'M';
 
 export interface QrCodeProps {
   value: string;
@@ -17,7 +33,11 @@ export interface QrCodeProps {
   size?: number;
 }
 
-export function QrCode({ level = 'H', value, size }: QrCodeProps): JSX.Element {
+export function QrCode({
+  level = DEFAULT_QR_CODE_LEVEL,
+  value,
+  size,
+}: QrCodeProps): JSX.Element {
   return (
     <ResponsiveSvgWrapper>
       <QRCodeSVG value={value} level={level} size={size} />


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7785

Our SHV QR codes can be so large/dense that some phones have trouble reading them. Some of this density is attributable to our use of the highest error correction level. This PR decreases the density of SHV QR codes by decreasing that level. For live reporting, we already use level M instead of level H QR codes, so we have existing signal that this is safe.

As part of this PR, I've also decreased the default error correction level for future QR codes.

Copying the code comment in the PR:

>  Our QR codes are generally displayed on high-fidelity screens or printed with high-fidelity
>  printers, so the highest error correction levels are in most cases unnecessary. In fact, for
>  some of our larger QR codes, e.g., SHV QR codes, we've found that the highest levels make the QR
>  codes so large/dense that some phones have trouble reading them.
> 
>  We can override with higher levels when we need to optimize for resilience, e.g., summary
>  ballots printed on lower-fidelity thermal printers. And we can override with lower levels when
>  we need to optimize for space constraints, e.g., HMP ballots.

## Demo Video or Screenshot

| Before | After |
| - | - |
| <img width="400" alt="before" src="https://github.com/user-attachments/assets/f1da8373-b211-426c-81d4-93d2b0f217ff" /> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/4b46bf43-24a1-40e4-a78b-957effb2f7d1" /> |

## Testing Plan

- [x] Scanned new less dense SHV QR code manually

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~ N/A
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~ N/A
- [ ] ~I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~ N/A