### PR TITLE
VxPollBook + VxPrint: Add CPU metrics logging

### DIFF
--- a/apps/pollbook/backend/src/server.ts
+++ b/apps/pollbook/backend/src/server.ts
@@ -2,6 +2,7 @@ import { useDevDockRouter } from '@votingworks/dev-dock-backend';
 import express from 'express';
 import { CITIZEN_THERMAL_PRINTER_CONFIG } from '@votingworks/printing';
 import { BaseLogger, Logger, LogSource } from '@votingworks/logging';
+import { startCpuMetricsLogging } from '@votingworks/backend';
 import { buildLocalApp } from './app';
 import { PORT } from './globals';
 import { LocalAppContext } from './types';
@@ -29,6 +30,8 @@ export function start(context: LocalAppContext): void {
   useDevDockRouter(app, express, {
     printerConfig: CITIZEN_THERMAL_PRINTER_CONFIG,
   });
+
+  startCpuMetricsLogging(baseLogger);
 
   app.listen(PORT, () => {
     // eslint-disable-next-line no-console

--- a/apps/pollbook/backend/vitest.config.ts
+++ b/apps/pollbook/backend/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 92.59,
+        lines: 92.53,
         branches: 88,
       },
       exclude: [

--- a/apps/print/backend/src/server.ts
+++ b/apps/print/backend/src/server.ts
@@ -14,6 +14,7 @@ import {
 import { detectUsbDrive } from '@votingworks/usb-drive';
 import { useDevDockRouter } from '@votingworks/dev-dock-backend';
 import { detectPrinter, HP_LASER_PRINTER_CONFIG } from '@votingworks/printing';
+import { startCpuMetricsLogging } from '@votingworks/backend';
 import { buildApp } from './app';
 import { PORT } from './globals';
 import { Workspace } from './util/workspace';
@@ -70,6 +71,8 @@ export function start({ auth, baseLogger, workspace }: StartOptions): void {
   useDevDockRouter(app, express, {
     printerConfig: HP_LASER_PRINTER_CONFIG,
   });
+
+  startCpuMetricsLogging(baseLogger);
 
   app.listen(PORT, () => {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
## Overview

Just noticed that we never added CPU metrics logging to VxPollBook and VxPrint. Not critical for those apps but good to have for consistency with all other apps.

## Testing

Ran both apps and verified that logs were emitted every minute