### PR TITLE
fix(auth): use explicit `-nameopt oneline` for stable openssl subject parsing

### DIFF
--- a/libs/auth/src/certs.ts
+++ b/libs/auth/src/certs.ts
@@ -259,7 +259,15 @@ export const CERT_EXPIRY_IN_DAYS = {
  * follow VotingWorks's cert format.
  */
 export async function parseCert(cert: Buffer): Promise<CustomCertFields> {
-  const response = await openssl(['x509', '-noout', '-subject', '-in', cert]);
+  const response = await openssl([
+    'x509',
+    '-noout',
+    '-subject',
+    '-nameopt',
+    'oneline',
+    '-in',
+    cert,
+  ]);
 
   const responseString = response.toString('utf-8');
   assert(responseString.startsWith('subject='));


### PR DESCRIPTION
## Overview

The default output format of `openssl x509 -subject` changed in OpenSSL 3.1.0 ([PR](https://github.com/openssl/openssl/pull/16583)) to no longer include spaces. Our `parseCert` function splits on ` = ` and fails with "Malformed cert subject line" on OpenSSL 3.x. Adding `-nameopt oneline` explicitly requests the space-padded format regardless of OpenSSL version, and does not change anything about the production format since the version of OpenSSL we use in production already defaults to `oneline`.

## Demo Video or Screenshot
```sh
# new version
…ock-usb-data/dev-jurisdiction-nh_e_335f11e92b/cast-vote-records on  HEAD (243b66f) [!]
❯ openssl version && openssl x509 -noout -subject -in /tmp/machine_cert.pem
OpenSSL 3.6.0 1 Oct 2025 (Library: OpenSSL 3.6.0 1 Oct 2025)
subject=C=US, ST=CA, O=VotingWorks, 1.3.6.1.4.1.59817.1=scan, 1.3.6.1.4.1.59817.6=0000

# old version (prod-ish)
…ock-usb-data/dev-jurisdiction-nh_e_335f11e92b/cast-vote-records on  HEAD (243b66f) [!]
❯ /usr/bin/openssl version && /usr/bin/openssl x509 -noout -subject -in /tmp/machine_cert
.pem
OpenSSL 3.0.18 30 Sep 2025 (Library: OpenSSL 3.0.18 30 Sep 2025)
subject=C = US, ST = CA, O = VotingWorks, 1.3.6.1.4.1.59817.1 = scan, 1.3.6.1.4.1.59817.6 = 0000

# new version with `-nameopt oneline`
…ock-usb-data/dev-jurisdiction-nh_e_335f11e92b/cast-vote-records on  HEAD (243b66f) [!]
❯ openssl version && openssl x509 -noout -subject -nameopt oneline -in /tmp/machine_cert.pem
OpenSSL 3.6.0 1 Oct 2025 (Library: OpenSSL 3.6.0 1 Oct 2025)
subject=C = US, ST = CA, O = VotingWorks, 1.3.6.1.4.1.59817.1 = scan, 1.3.6.1.4.1.59817.6 = 0000

# old version with `-nameopt oneline`
…ock-usb-data/dev-jurisdiction-nh_e_335f11e92b/cast-vote-records on  HEAD (243b66f) [!]
❯ /usr/bin/openssl version && /usr/bin/openssl x509 -noout -subject -nameopt oneline -in /tmp/machine_cert.pem
OpenSSL 3.0.18 30 Sep 2025 (Library: OpenSSL 3.0.18 30 Sep 2025)
subject=C = US, ST = CA, O = VotingWorks, 1.3.6.1.4.1.59817.1 = scan, 1.3.6.1.4.1.59817.6 = 0000
```

## Testing Plan
Tested in dev manually.