### PR TITLE
VxDesign: Tweak rich text editor paste handler regex

### DIFF
--- a/apps/design/frontend/src/rich_text_editor.test.tsx
+++ b/apps/design/frontend/src/rich_text_editor.test.tsx
@@ -297,6 +297,12 @@ describe('sanitizeTrailingNbspOnPaste', () => {
       sanitizeTrailingNbspOnPaste('<table><tr><td> </td></tr></table>')
     ).toEqual('<table><tbody><tr><td></td></tr></tbody></table>');
   });
+
+  test('does not strip trailing pure whitespace with no nbsp', () => {
+    expect(
+      sanitizeTrailingNbspOnPaste('<table><tr><td>text      </td></tr></table>')
+    ).toEqual('<table><tbody><tr><td>text      </td></tr></tbody></table>');
+  });
 });
 
 test('disabled', async () => {

--- a/apps/design/frontend/src/rich_text_editor.tsx
+++ b/apps/design/frontend/src/rich_text_editor.tsx
@@ -345,9 +345,9 @@ function findLastTextNode(root: Node): Text | null {
   return last;
 }
 
-// Remove trailing NBSPs and trailing whitespace, if there is at least one nbsp (unicode U+00A0)
+// Remove trailing nbsps and trailing whitespace, if there is at least one nbsp (unicode U+00A0)
 function stripTrailingNbsp(text: string): string {
-  return text.replace(/[\u00A0\s]+$/, '');
+  return text.replace(/[\s\u00A0]*\u00A0[\s\u00A0]*$/, '');
 }
 
 // HTML_BLOCKS includes the HTML elements that most commonly have unintended trailing


### PR DESCRIPTION
## Overview

As I was looking into the alert last week, I realized my regex was too general and didn't match the comment associated with it. Somewhere in my iterations I left it capturing all trailing whitespace, but the intention was for it to require at least one nbsp. 

Adding this fix since it makes the code comment correct, and we will still see what further fix is needed to address the empty node alert.

## Demo Video or Screenshot

## Testing Plan

Test added

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
