### PR TITLE
VxDesign: Add padding around error messages in ballot preview

### DIFF
--- a/apps/design/frontend/src/ballot_screen.tsx
+++ b/apps/design/frontend/src/ballot_screen.tsx
@@ -233,6 +233,27 @@ function formContestTooLongErrorMessage(
   return `${baseMessage}.`;
 }
 
+function ErrorMessage({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <Row
+      style={{
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: '100%',
+        padding: '5rem',
+      }}
+    >
+      <Callout color="danger" icon="Danger">
+        {children}
+      </Callout>
+    </Row>
+  );
+}
+
 export function BallotScreen(): JSX.Element | null {
   const params = useParams<{
     electionId: string;
@@ -337,46 +358,30 @@ export function BallotScreen(): JSX.Element | null {
               switch (err.error) {
                 case 'missingSignature':
                   return (
-                    <Row
-                      style={{
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        height: '100%',
-                      }}
-                    >
-                      <Callout color="danger" icon="Danger">
-                        <span>
-                          Missing signature. Upload a signature in{' '}
-                          <Link
-                            to={
-                              routes.election(electionId).electionInfo.root.path
-                            }
-                          >
-                            Election Info
-                          </Link>
-                          .
-                        </span>
-                      </Callout>
-                    </Row>
+                    <ErrorMessage>
+                      <span>
+                        Missing signature. Upload a signature in{' '}
+                        <Link
+                          to={
+                            routes.election(electionId).electionInfo.root.path
+                          }
+                        >
+                          Election Info
+                        </Link>
+                        .
+                      </span>
+                    </ErrorMessage>
                   );
                 case 'contestTooLong':
                   return (
-                    <Row
-                      style={{
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        height: '100%',
-                      }}
-                    >
-                      <Callout color="danger" icon="Danger">
-                        <span>
-                          {formContestTooLongErrorMessage(
-                            err.contest,
-                            ballotTemplateId
-                          )}
-                        </span>
-                      </Callout>
-                    </Row>
+                    <ErrorMessage>
+                      <span>
+                        {formContestTooLongErrorMessage(
+                          err.contest,
+                          ballotTemplateId
+                        )}
+                      </span>
+                    </ErrorMessage>
                   );
                 /* istanbul ignore next - @preserve */
                 default: {


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot
Before
<img width="1312" height="732" alt="Screenshot 2026-02-03 at 11 28 21 AM" src="https://github.com/user-attachments/assets/e5f84cbe-336b-4287-a80c-0714cdfbd76c" />

After
<img width="1424" height="930" alt="Screenshot 2026-02-03 at 12 23 37 PM" src="https://github.com/user-attachments/assets/14823df1-afcf-46dc-8aa3-ba913a890ea6" />

## Testing Plan
Manual test

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
