### PR TITLE
VxDesign: Log drag and drop content from rich text editor on sentry alerts

### DIFF
--- a/apps/design/frontend/src/index.tsx
+++ b/apps/design/frontend/src/index.tsx
@@ -32,6 +32,9 @@ if (process.env.NODE_ENV === 'production') {
         // eslint-disable-next-line no-param-reassign
         event.extra['lastPasteClipboardContent'] =
           tiptapErrorContextBox.lastPasteClipboardContent;
+        // eslint-disable-next-line no-param-reassign
+        event.extra['lastDragAndDropContent'] =
+          tiptapErrorContextBox.lastDragAndDropContent;
       }
       return event;
     },

--- a/apps/design/frontend/src/rich_text_editor.tsx
+++ b/apps/design/frontend/src/rich_text_editor.tsx
@@ -372,8 +372,12 @@ interface RichTextEditorProps {
   className?: string;
 }
 
-export const tiptapErrorContextBox: { lastPasteClipboardContent?: string } = {
+export const tiptapErrorContextBox: {
+  lastPasteClipboardContent?: string;
+  lastDragAndDropContent?: string;
+} = {
   lastPasteClipboardContent: undefined,
+  lastDragAndDropContent: undefined,
 };
 
 export function RichTextEditor({
@@ -424,6 +428,11 @@ export function RichTextEditor({
       tiptapErrorContextBox.lastPasteClipboardContent =
         event.clipboardData?.getData('text/html') ||
         event.clipboardData?.getData('text/plain');
+    },
+    onDrop: (event) => {
+      tiptapErrorContextBox.lastDragAndDropContent =
+        event.dataTransfer?.getData('text/html') ||
+        event.dataTransfer?.getData('text/plain');
     },
   });
   return (


### PR DESCRIPTION
## Overview

Follow the pattern [recently added](https://github.com/votingworks/vxsuite/pull/7862) for paste events. We have seen a few of these alerts with drag and drops causing internal errors for TipTap, so we want some more insight on the content leading to these errors.

## Demo Video or Screenshot

[Example alert](https://votingworks.sentry.io/issues/7244868214/?alert_rule_id=15751537&alert_type=issue&notification_uuid=5d140c74-87c8-42ce-926d-30b72cc8aa30&project=4508717994016768&referrer=slack)

## Testing Plan

Didn't manually recreate the error, but verified the drop handler fires on drag and drops and that the `tiptapErrorContextBox` contains the relevant html for both drag and drops of content within the editor and from outside the editor.

<img width="1478" height="269" alt="Screenshot 2026-02-05 at 11 39 59 AM" src="https://github.com/user-attachments/assets/318c2ba4-0722-483d-a4dc-8601eb03c9eb" />

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
