### PR TITLE
VxDesign: Use number-aware locale sort on Precincts/Districts

### DIFF
--- a/apps/design/backend/migrations/1771000000001_add-natural-sort-collation.js
+++ b/apps/design/backend/migrations/1771000000001_add-natural-sort-collation.js
@@ -1,0 +1,23 @@
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  // Enables number-aware locale sorting, e.g.:
+  // ```sql
+  // select id, name from precincts
+  // order by name collate natural_sort;
+  // ```
+  //
+  // Leaving the collation level at the default `level3` for now, which makes
+  // the ordering case/accent-insensitive, but we can alter later if needed.
+  //
+  // https://www.postgresql.org/docs/17/collation.html#ICU-COLLATION-SETTINGS-TABLE
+  pgm.sql(`
+    CREATE COLLATION natural_sort (
+      provider = icu,
+      locale = 'en-u-kn-true'
+    );
+  `);
+};

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -367,8 +367,9 @@ async function insertContest(
             term_description,
             ballot_order
           )
-          values ($1, $2, $3, $4, $5, $6, $7, $8, $9, ${ballotOrder ? '$10' : 'DEFAULT'
-        })
+          values ($1, $2, $3, $4, $5, $6, $7, $8, $9, ${
+            ballotOrder ? '$10' : 'DEFAULT'
+          })
         `,
         contest.id,
         electionId,
@@ -464,8 +465,9 @@ async function insertContest(
             additional_options,
             ballot_order
           )
-          values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, ${ballotOrder ? '$12' : 'DEFAULT'
-        })
+          values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, ${
+            ballotOrder ? '$12' : 'DEFAULT'
+          })
         `,
         contest.id,
         electionId,
@@ -525,7 +527,7 @@ export class Store {
   constructor(
     private readonly db: Db,
     private readonly logger: BaseLogger
-  ) { }
+  ) {}
 
   /* istanbul ignore next - @preserve */
   static new(logger: BaseLogger): Store {
@@ -633,7 +635,7 @@ export class Store {
     if (user.type === 'support_user') {
       assert(
         user.name.endsWith('@voting.works') ||
-        user.name.endsWith('@vx.support'),
+          user.name.endsWith('@vx.support'),
         'Support users must have a @voting.works or @vx.support email'
       );
     }
@@ -708,12 +710,12 @@ export class Store {
         )
       ).rows[0] as
         | {
-          id: string;
-          type: UserType;
-          name: string;
-          organizationId: string;
-          organizationName: string;
-        }
+            id: string;
+            type: UserType;
+            name: string;
+            organizationId: string;
+            organizationName: string;
+          }
         | undefined;
       if (!userRow) return undefined;
 
@@ -903,7 +905,7 @@ export class Store {
               name
             from districts
             where election_id = $1
-            order by name
+            order by name collate natural_sort
           `,
           electionId
         )
@@ -920,7 +922,7 @@ export class Store {
             left join districts_precincts on districts_precincts.precinct_id = precincts.id
             where election_id = $1
             group by precincts.id
-            order by precincts.name
+            order by precincts.name collate natural_sort
           `,
           electionId
         )
@@ -943,7 +945,7 @@ export class Store {
             left join districts_precinct_splits on districts_precinct_splits.precinct_split_id = precinct_splits.id
             where precincts.election_id = $1
             group by precinct_splits.id
-            order by precinct_splits.name
+            order by precinct_splits.name collate natural_sort
           `,
           electionId
         )
@@ -1432,9 +1434,9 @@ export class Store {
           electionInfo.seal,
           electionInfo.signatureImage
             ? JSON.stringify({
-              image: electionInfo.signatureImage,
-              caption: electionInfo.signatureCaption,
-            })
+                image: electionInfo.signatureImage,
+                caption: electionInfo.signatureCaption,
+              })
             : null,
           electionInfo.languageCodes,
           electionInfo.electionId


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7186

Closing out an old TODO to natural-sort precincts and districts containing numbers. Not addressing ballot style id sorting in this change - just entities that we sort at the DB level.

The last migration script has a timestamp in the future, so just incrementing that instead of using the autogenerated name for now - looks like we're only about a week away from the timestamps being consistent again, so not too bad.

Bit of unrelated eslint formatting noise - not sure why those are just now triggering, but didn't see any obvious changes in my dev env.

## Demo Video or Screenshot

| Before | After |
| - | - |
| <img width="348" height="968" alt="ascii-sort" src="https://github.com/user-attachments/assets/8ef20a04-36c0-4bc6-8874-d95f670c1fd6" /> | <img width="355" height="968" alt="natural-sort" src="https://github.com/user-attachments/assets/6db155c9-5ce6-4d06-8af3-33bfcbc7d9d7" /> |

## Testing Plan
- Add repro tests for the previous sorting edge cases

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
