### PR TITLE
VxDesign: Fix flaky test on parties screen

### DIFF
--- a/apps/design/frontend/src/parties_screen.test.tsx
+++ b/apps/design/frontend/src/parties_screen.test.tsx
@@ -222,18 +222,18 @@ test('editing or adding a party is disabled when ballots are finalized', async (
   apiMock.listParties.expectCallWith({ electionId }).resolves(election.parties);
 
   renderScreen(electionId);
-
-  await screen.findByDisplayValue(election.parties[0].name);
-  expect(screen.getButton('Add Party')).toBeDisabled();
-  expect(screen.queryButton('Edit Parties')).not.toBeInTheDocument();
-  expect(screen.queryButton('Save')).not.toBeInTheDocument();
-  expect(screen.queryButton('Cancel')).not.toBeInTheDocument();
   // Wait for state features API request to complete (to check whether or not to
   // show audio buttons). In this case, since audio is disabled, the buttons
   // aren't shown so there's nothing we can await on screen. But if the API
   // request doesn't complete in time, the test may fail due to the
   // assertComplete in afterEach.
   await waitFor(() => apiMock.assertComplete());
+
+  await screen.findByDisplayValue(election.parties[0].name);
+  expect(screen.getButton('Add Party')).toBeDisabled();
+  expect(screen.queryButton('Edit Parties')).not.toBeInTheDocument();
+  expect(screen.queryButton('Save')).not.toBeInTheDocument();
+  expect(screen.queryButton('Cancel')).not.toBeInTheDocument();
 });
 
 test('adding, editing, or deleting a party is disabled for elections with external source', async () => {


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->
Flake: https://app.circleci.com/pipelines/github/votingworks/vxsuite/24056/workflows/a9d9949f-6091-43a3-ba22-11d0f3036499/jobs/1081280
## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
