### PR TITLE
VxDesign: Add event message to unexpected error during image normalization

### DIFF
--- a/apps/design/frontend/src/image_normalization.ts
+++ b/apps/design/frontend/src/image_normalization.ts
@@ -172,7 +172,9 @@ async function normalizeDataUrl(
     return resolve(
       err({
         code: 'unexpected',
-        error: new Error(`Error while decoding image for resize`),
+        error: new Error(
+          `Error while decoding image for resize: ${event.message}`
+        ),
       })
     );
   }


### PR DESCRIPTION

## Overview

[Slack thread](https://votingworks.slack.com/archives/C08AWNY93PB/p1770393787263749?thread_ts=1770313028.624239&cid=C08AWNY93PB)

Adding the event message to the error to get some more info on the unexpected error

## Demo Video or Screenshot

[Example error
](https://votingworks.sentry.io/issues/7245203417/?referrer=slack&notification_uuid=5c39fb47-c351-4791-b1af-1ae21ef158d2&alert_rule_id=15751537&alert_type=issue)

## Testing Plan

Keep our eye on subsequent alerts

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
