### PR TITLE
fix(central-scan): allow Enter key to confirm Delete All Batches modal

### DIFF
--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
@@ -232,6 +232,7 @@ export function ScanBallotsScreen({
                   variant="danger"
                   icon="Delete"
                   onPress={deleteBallotData}
+                  autoFocus
                 >
                   Delete All Batches
                 </Button>


### PR DESCRIPTION
## Overview

Add autoFocus to the Delete All Batches confirmation button to allow confirming the action by pressing Enter, matching the behavior of the single batch delete modal.

## Demo Video or Screenshot

n/a

## Testing Plan

Tested manually in kiosk-browser.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
