### PR TITLE
perf(scan): skip summary fallback for bubble ballot errors

### DIFF
--- a/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
@@ -193,13 +193,6 @@ pub enum Error {
     #[error("could not find border inset for {label}")]
     BorderInsetNotFound { label: String },
 
-    #[error("invalid card metadata: {SIDE_A_LABEL}: {side_a:?}, {SIDE_B_LABEL}: {side_b:?}")]
-    #[serde(rename_all = "camelCase")]
-    InvalidCardMetadata {
-        side_a: BallotPageMetadata,
-        side_b: BallotPageMetadata,
-    },
-
     #[error("invalid QR code metadata for {label}: {message}")]
     InvalidQrCodeMetadata { label: String, message: String },
 
@@ -265,6 +258,29 @@ pub enum Error {
 
     #[error("invalid election: {message}")]
     InvalidElection { message: String },
+}
+
+impl Error {
+    /// Returns true if this error definitively identifies the ballot as a
+    /// bubble ballot, not a summary ballot. These are errors that can only be
+    /// produced after the bubble ballot QR code was decoded or after
+    /// bubble-ballot-specific algorithms ran.
+    #[must_use]
+    pub fn is_bubble_ballot(&self) -> bool {
+        matches!(
+            self,
+            // These errors occur after both QR codes were successfully decoded
+            // as bubble ballot (HMPB) metadata.
+            Self::MismatchedPrecincts { .. }
+                | Self::MismatchedBallotStyles { .. }
+                | Self::NonConsecutivePageNumbers { .. }
+                | Self::MissingGridLayout { .. }
+                | Self::CouldNotComputeLayout { .. }
+                // InvalidScale is only reachable after find_timing_marks()
+                // succeeds, which requires bubble-ballot-specific timing marks.
+                | Self::InvalidScale { .. }
+        )
+    }
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/debug.test.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/debug.test.ts
@@ -12,7 +12,7 @@ const interpretImplMock = vi.mocked(addon.interpret);
 test('no debug', () => {
   interpretImplMock.mockReturnValue({
     type: 'err',
-    value: { type: 'invalidScale', label: 'side A', scale: 0.9 },
+    value: { type: 'invalidScale', label: 'side A', scale: 0.9, isBubbleBallot: true },
   });
 
   void interpret({
@@ -32,7 +32,7 @@ test('no debug', () => {
 test('debug with image paths', () => {
   interpretImplMock.mockReturnValue({
     type: 'err',
-    value: { type: 'invalidScale', label: 'side A', scale: 0.9 },
+    value: { type: 'invalidScale', label: 'side A', scale: 0.9, isBubbleBallot: true },
   });
 
   void interpret({

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/types.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/types.ts
@@ -302,14 +302,13 @@ export interface Size<T> {
 
 /**
  * Possible errors that can occur when interpreting a ballot card.
+ *
+ * `isBubbleBallot` is set by the Rust interpreter and is true when the error
+ * definitively identifies the ballot as a bubble ballot rather than a summary
+ * ballot. When true, summary ballot interpretation can be skipped.
  */
-export type InterpretError =
+export type InterpretError = { isBubbleBallot: boolean } & (
   | { type: 'borderInsetNotFound'; path: string }
-  | {
-      type: 'invalidCardMetadata';
-      sideA: BallotPageMetadata;
-      sideB: BallotPageMetadata;
-    }
   | { type: 'invalidQrCodeMetadata'; label: string; message: string }
   | { type: 'mismatchedPrecincts'; sideA: PrecinctId; sideB: PrecinctId }
   | {
@@ -340,7 +339,8 @@ export type InterpretError =
   | {
       type: 'invalidElection';
       message: string;
-    };
+    }
+);
 
 /**
  * Information about a ballot page that has failed to be interpreted.

--- a/libs/ballot-interpreter/src/should_skip_summary_ballot_interpretation.test.ts
+++ b/libs/ballot-interpreter/src/should_skip_summary_ballot_interpretation.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from 'vitest';
+import {
+  BallotStyleId,
+  BallotType,
+  PageInterpretation,
+  SheetOf,
+} from '@votingworks/types';
+import { shouldSkipSummaryBallotInterpretation } from './should_skip_summary_ballot_interpretation';
+
+const BLANK_PAGE: PageInterpretation = { type: 'BlankPage' };
+
+const INVALID_BALLOT_HASH: PageInterpretation = {
+  type: 'InvalidBallotHashPage',
+  expectedBallotHash: 'abc123',
+  actualBallotHash: 'def456',
+};
+
+const INVALID_TEST_MODE: PageInterpretation = {
+  type: 'InvalidTestModePage',
+  metadata: {
+    ballotHash: 'abc123',
+    ballotType: BallotType.Precinct,
+    ballotStyleId: '1' as BallotStyleId,
+    precinctId: 'precinct-1',
+    isTestMode: true,
+  },
+};
+
+const INVALID_PRECINCT: PageInterpretation = {
+  type: 'InvalidPrecinctPage',
+  metadata: {
+    ballotHash: 'abc123',
+    ballotType: BallotType.Precinct,
+    ballotStyleId: '1' as BallotStyleId,
+    precinctId: 'precinct-1',
+    isTestMode: false,
+  },
+};
+
+test('returns true for InvalidBallotHashPage', () => {
+  const sheet: SheetOf<PageInterpretation> = [INVALID_BALLOT_HASH, BLANK_PAGE];
+  expect(shouldSkipSummaryBallotInterpretation(sheet)).toEqual(true);
+});
+
+test('returns true for InvalidTestModePage', () => {
+  const sheet: SheetOf<PageInterpretation> = [INVALID_TEST_MODE, BLANK_PAGE];
+  expect(shouldSkipSummaryBallotInterpretation(sheet)).toEqual(true);
+});
+
+test('returns true for InvalidPrecinctPage', () => {
+  const sheet: SheetOf<PageInterpretation> = [INVALID_PRECINCT, BLANK_PAGE];
+  expect(shouldSkipSummaryBallotInterpretation(sheet)).toEqual(true);
+});
+
+test('returns true when only one page has a definitive error', () => {
+  const sheet: SheetOf<PageInterpretation> = [
+    { type: 'UnreadablePage', reason: 'missingTimingMarks' },
+    INVALID_BALLOT_HASH,
+  ];
+  expect(shouldSkipSummaryBallotInterpretation(sheet)).toEqual(true);
+});
+
+test('returns false for BlankPage on both sides', () => {
+  const sheet: SheetOf<PageInterpretation> = [BLANK_PAGE, BLANK_PAGE];
+  expect(shouldSkipSummaryBallotInterpretation(sheet)).toEqual(false);
+});
+
+test('returns false for UnreadablePage (Rust-side bubble ballot detection handled separately)', () => {
+  const sheet: SheetOf<PageInterpretation> = [
+    { type: 'UnreadablePage', reason: 'missingTimingMarks' },
+    BLANK_PAGE,
+  ];
+  expect(shouldSkipSummaryBallotInterpretation(sheet)).toEqual(false);
+});

--- a/libs/ballot-interpreter/src/should_skip_summary_ballot_interpretation.ts
+++ b/libs/ballot-interpreter/src/should_skip_summary_ballot_interpretation.ts
@@ -1,0 +1,27 @@
+import { PageInterpretation, SheetOf } from '@votingworks/types';
+
+const BUBBLE_BALLOT_DEFINITIVE_PAGE_TYPES: ReadonlySet<PageInterpretation['type']> =
+  new Set([
+    'InvalidBallotHashPage',
+    'InvalidTestModePage',
+    'InvalidPrecinctPage',
+  ]);
+
+/**
+ * Determines whether the bubble ballot interpretation result is definitive
+ * enough to skip summary ballot fallback interpretation.
+ *
+ * This handles the TypeScript-validation cases: when the QR code decoded
+ * successfully (confirming a bubble ballot) but the scanner configuration
+ * rejected it (wrong election hash, test mode, or precinct). The Rust-side
+ * `isBubbleBallot` flag covers the complementary cases (e.g. QR decode
+ * failures, streak/scale detection) and is checked separately in
+ * `interpretSheet` before this function is called.
+ */
+export function shouldSkipSummaryBallotInterpretation(
+  bubbleBallotInterpretation: SheetOf<PageInterpretation>
+): boolean {
+  return bubbleBallotInterpretation.some((page) =>
+    BUBBLE_BALLOT_DEFINITIVE_PAGE_TYPES.has(page.type)
+  );
+}

--- a/libs/logging-utils/index.d.ts
+++ b/libs/logging-utils/index.d.ts
@@ -3,6 +3,10 @@
 /**
  * Convert a VX-formatted log file to a CDF-formatted log file and calls the
  * provided callback after completion.
+ *
+ * # Errors
+ *
+ * Throws if the source is not a known source.
  */
 export declare function convertVxLogToCdf(
 log: (


### PR DESCRIPTION
## Overview
Fixes #7769

When bubble ballot interpretation produces errors that definitively identify the ballot as a bubble ballot (wrong election hash, wrong precinct, wrong test mode, invalid scale, etc), skip the slow summary ballot fallback interpretation since it cannot produce a better result.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated tests.
