### PR TITLE
Claude: Add /mutation-test skill for verifying test coverage via intentional bugs

### DIFF
--- a/.claude/skills/mutation-test.md
+++ b/.claude/skills/mutation-test.md
@@ -13,21 +13,26 @@ reverting the mutation.
 1. **Identify the source code to mutate.** Ask the user which code to mutate, or
    infer from context (e.g. the test file being discussed). Read the source file.
 
-2. **Introduce a small, targeted bug.** Examples:
+2. **For new tests, verify the test passes first.** If the test was just
+   written (not modifying an existing test), run it once to confirm it passes
+   before introducing a mutation.
+
+3. **Introduce a small, targeted bug.** Examples:
    - Off-by-one error (e.g. change `range(0, n)` to `range(0, n - 1)`)
    - Swap two values (e.g. swap yes/no option IDs)
    - Remove an item (e.g. drop a candidate from a list)
    - Change a condition (e.g. flip `>` to `<`)
 
    Use the Edit tool to make the change. Keep the mutation minimal — one logical
-   change only.
+   change only. **Tell the user what mutation you chose** so they can evaluate
+   whether it's a meaningful test.
 
-3. **Run the test.** Use `pnpm test:run <file> -t "<test name>"` from the
+4. **Run the test.** Use `pnpm test:run <file> -t "<test name>"` from the
    relevant package directory. Do NOT use watch mode.
 
-4. **Verify the test fails.** If the test fails, the mutation was caught —
+5. **Verify the test fails.** If the test fails, the mutation was caught —
    report what failed and why. If the test passes, the test has a gap — report
    what mutation was not caught so the user can improve the test.
 
-5. **Revert the mutation.** Undo the edit to restore the original source code.
+6. **Revert the mutation.** Undo the edit to restore the original source code.
    Confirm the test passes again after reverting.


### PR DESCRIPTION
🤖 Generated with Claude Code                                                                                                               
                                                       
  ## Summary                                                                                                                                  
                                                       
  - Adds a `/mutation-test` Claude Code skill that verifies test coverage by                                                                  
    introducing intentional bugs in source code, running the test to confirm it                                                               
    fails, then reverting the mutation                                                                                                        
  - Useful for validating that new or refactored tests actually catch the bugs
    they're supposed to catch

  ## Background

  This came out of work on the ballot option encoding test, where we wanted to
  verify that the refactored test still caught bugs like missing candidates,
  wrong write-in indices, and swapped yesno options. The skill encodes that
  process so it's repeatable.

  ## Configuring proactive mutation testing

  The skill can be invoked manually with `/mutation-test` at any time. To have
  Claude use it proactively, add a note to your personal auto memory file
  (`~/.claude/projects/.../memory/MEMORY.md`). For example:

  ```markdown
  ## Proactive Skills
  - Use `/mutation-test` every time you add or modify a test. If this becomes
    too slow, the user will adjust.
```

  You can adjust the trigger to your preference — e.g. only for tests involving
  important correctness assertions, only when explicitly asked, etc.