### PR TITLE
VxDesign: Remove warning color from non-error QA status card

### DIFF
--- a/apps/design/frontend/src/proofing_status.tsx
+++ b/apps/design/frontend/src/proofing_status.tsx
@@ -163,7 +163,7 @@ export function ProofingStatus(): React.ReactNode {
               disabled={approveDisabled}
               icon="Done"
               onPress={handleApproveClick}
-              variant={approveDisabled ? 'neutral' : 'primary'}
+              variant={approveDisabled || qaInProgress ? 'neutral' : 'primary'}
             >
               Approve
             </Button>
@@ -306,7 +306,12 @@ function QaStatus({ qaRun }: { qaRun: ExportQaRun }): React.ReactNode {
 
   if (status === 'in_progress') {
     return (
-      <Callout color="warning" icon="Info">
+      <Callout
+        color="primary"
+        icon="Info"
+        // Matching styling of the other other `TaskProgress` elements:
+        style={{ alignSelf: 'stretch', maxWidth: '35rem' }}
+      >
         <div>
           <P style={{ lineHeight: 1 }} weight="bold">
             QA Check Running


### PR DESCRIPTION
## Overview

The warning color on the QA progress card often makes me think something's gone wrong - switching to a primary color to match the other progress cards.
I think part of the intention was to discourage using the `Approve` button while QA's in progress, so bumping that button down to a neutral color while QA is still pending - we still have the confirmation modal for the approval action anyway.

## Demo Video or Screenshot

### Before:

<img width="800"  alt="hub-qa-card-before" src="https://github.com/user-attachments/assets/37024bd7-0ed5-4cb6-bf79-d079d643b9a5" />

### After:

<img width="800" alt="hub-qa-card-after" src="https://github.com/user-attachments/assets/b6eafb9b-54a7-43d6-9535-839e78ab15ad" />

<img width="800" alt="hub-qa-in-progress-approve-neutral" src="https://github.com/user-attachments/assets/ba4b2c85-2e6c-4e1d-9600-032e08738da8" />

<img width="800" alt="hub-qa-success-approve-primary" src="https://github.com/user-attachments/assets/a15b9995-524c-4dda-8259-3f025f554374" />

## Testing Plan
- Existing unit tests + manual

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
