### PR TITLE
Add project-level Claude Code settings to deny Heroku CLI

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "deny": ["mcp__heroku", "Bash(heroku:*)"]
+  }
+}


### PR DESCRIPTION
🤖 Generated with Claude Code

## Summary
- Adds `.claude/settings.json` with `permissions.deny` rules blocking both the Heroku MCP tool and `heroku` Bash commands
- The Heroku CLI can access and modify production infrastructure (config vars, dynos, databases, etc.). Denying it at the project level ensures Claude Code can never interact with Heroku apps, even if the MCP server is configured locally.

## Test plan
- [x] Verified Claude Code refuses to invoke Heroku MCP tools
- [x] Verified Claude Code refuses to run `heroku` Bash commands