### PR TITLE
Claude: Convert /learn and /mutation-test skills to directory format

### DIFF
--- a/.claude/skills/learn/SKILL.md
+++ b/.claude/skills/learn/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: learn
 description: Learn from user feedback — either edits they made to code or suggestions in their messages about how to improve code.
 ---
 

--- a/.claude/skills/mutation-test/SKILL.md
+++ b/.claude/skills/mutation-test/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: mutation-test
 description: Introduce an intentional bug in source code to verify a test catches it, then revert the bug.
 ---
 


### PR DESCRIPTION
🤖 Generated with Claude Code

## Summary

Skills in the flat `.md` format could not be invoked as slash commands. Moving
them to the directory format (`<name>/SKILL.md`) fixes invocation.

Changes:
- Move `learn.md` → `learn/SKILL.md`
- Move `mutation-test.md` → `mutation-test/SKILL.md`
- Add `name` field to frontmatter of each skill

## Test plan

- [x] Verified `/learn` and `/mutation-test` can be invoked as slash commands after the rename