### PR TITLE
VxDesign: Add temporary special case to resize specific contest images

### DIFF
--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -641,6 +641,16 @@ function BallotMeasureContest({
   compact?: boolean;
   continuesOnNextPage?: boolean;
 }) {
+  // [TODO] Temporary: to be removed after March ballot production run.
+  // This contest contains a lot of images that we'd like to resize to stack
+  // two on each line. Resizing the original images in CSS rather then resizing
+  // them for re-upload avoids noticeable resolution loss that we'll need a
+  // broader fix for in our image upload handling.
+  // https://design.voting.works/elections/g4usy39oo1fw/contests/h9fzgh2orsim
+  const ASHLAND_CONTEST_ID = 'h9fzgh2orsim';
+  /* istanbul ignore next - temporary - @preserve */
+  const imgWithOverride = contest.id === ASHLAND_CONTEST_ID ? '50%' : undefined;
+
   return (
     <Box style={{ padding: 0 }}>
       <ContestHeader>
@@ -666,6 +676,7 @@ function BallotMeasureContest({
         >
           <DualLanguageText>
             <RichText
+              __tempOverrideImgMaxWidth={imgWithOverride}
               tableBorderWidth={'1px'}
               tableBorderColor={Colors.DARKER_GRAY}
               tableHeaderBackgroundColor={Colors.LIGHT_GRAY}

--- a/libs/ui/src/typography.tsx
+++ b/libs/ui/src/typography.tsx
@@ -187,6 +187,8 @@ export function Caption(props: FontProps): JSX.Element {
  * (e.g. in HMPBs).
  */
 interface RichTextProps {
+  /** [TODO] Remove after March ballot production run. */
+  __tempOverrideImgMaxWidth?: string;
   tableBorderWidth?: string;
   tableBorderColor?: string;
   tableHeaderBackgroundColor?: string;
@@ -249,7 +251,9 @@ export const richTextStyles = css<RichTextProps>`
   }
 
   img {
-    max-width: 100%;
+    max-width: ${(p) =>
+      // eslint-disable-next-line no-underscore-dangle
+      p.__tempOverrideImgMaxWidth || '100%'};
     height: auto;
   }
 `;


### PR DESCRIPTION
## Overview

https://votingworks.slack.com/archives/C0AA3ESLM4Y/p1771448566151329

Temporarily adding a special-cased image resize for one [`Ashland, NH` contest](https://design.voting.works/elections/g4usy39oo1fw/contests/h9fzgh2orsim), to help reduce the sheet count for the related ballot style. In order to get the images to stack in pairs on each line, we need to shrink the images to 50% of the available width. Doing this offline and re-uploading requires shrinking them relative to a 96dpi resolution (due to current assumptions in our image upload handling), which causes a bit too much resolution loss.

Will be reverting this after the ballot production run in favour of a broader fix: https://github.com/votingworks/vxsuite/issues/8012

## Demo Video or Screenshot

| Before | After |
| - | - |
| <img width="1086" height="1451" alt="before" src="https://github.com/user-attachments/assets/eed40828-c7d7-4f02-9595-cb69bb59740b" /> | <img width="1060" height="1448" alt="after" src="https://github.com/user-attachments/assets/a751fc7e-75bf-4f03-8cf9-1ba876e54d69" /> |

## Testing Plan
- Manual

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
