### PR TITLE
CVRs: add scanner model to ReportingDevice

### DIFF
--- a/libs/backend/src/cast_vote_records/build_report_metadata.test.ts
+++ b/libs/backend/src/cast_vote_records/build_report_metadata.test.ts
@@ -24,6 +24,7 @@ test('builds well-formed cast vote record report', () => {
     electionId,
     generatingDeviceId: scannerId,
     scannerIds: [scannerId],
+    scannerType: 'precinct',
     reportTypes: [CVR.ReportType.OriginatingDeviceExport],
     isTestMode: false,
     batchInfo: [
@@ -48,6 +49,7 @@ test('builds well-formed cast vote record report', () => {
       '@id': scannerId,
       SerialNumber: scannerId,
       Manufacturer: 'VotingWorks',
+      Model: 'VxScan',
     },
   ]);
 
@@ -209,6 +211,7 @@ test('represents test mode as an "OtherReportType"', () => {
     electionId,
     generatingDeviceId: scannerId,
     scannerIds: [scannerId],
+    scannerType: 'precinct',
     reportTypes: [CVR.ReportType.OriginatingDeviceExport],
     isTestMode: true,
     batchInfo: [],
@@ -228,6 +231,7 @@ test('still includes the generating device id in the device list if it is not th
     electionId,
     generatingDeviceId,
     scannerIds: [scannerId],
+    scannerType: 'central',
     reportTypes: [CVR.ReportType.OriginatingDeviceExport],
     isTestMode: true,
     batchInfo: [],
@@ -240,11 +244,13 @@ test('still includes the generating device id in the device list if it is not th
         '@id': scannerId,
         SerialNumber: scannerId,
         Manufacturer: 'VotingWorks',
+        Model: 'VxCentralScan',
       }),
       expect.objectContaining({
         '@id': generatingDeviceId,
         SerialNumber: generatingDeviceId,
         Manufacturer: 'VotingWorks',
+        Model: 'VxCentralScan',
       }),
     ])
   );

--- a/libs/backend/src/cast_vote_records/build_report_metadata.ts
+++ b/libs/backend/src/cast_vote_records/build_report_metadata.ts
@@ -127,17 +127,21 @@ function buildElection({
 
 function buildReportingDevices(
   generatingDeviceId: string,
-  scannerIds: string[]
+  scannerIds: string[],
+  scannerType: 'central' | 'precinct'
 ): CVR.ReportingDevice[] {
   const allDeviceIds = scannerIds.includes(generatingDeviceId)
     ? scannerIds
     : [generatingDeviceId, ...scannerIds];
+
+  const model = scannerType === 'precinct' ? 'VxScan' : 'VxCentralScan';
 
   return allDeviceIds.map((deviceId) => ({
     '@type': 'CVR.ReportingDevice',
     '@id': deviceId,
     SerialNumber: deviceId,
     Manufacturer: 'VotingWorks',
+    Model: model,
   }));
 }
 
@@ -146,6 +150,7 @@ interface BuildCastVoteRecordReportMetadataParams {
   electionId: string;
   generatingDeviceId: string;
   scannerIds: string[];
+  scannerType: 'central' | 'precinct';
   reportTypes: CVR.ReportType[];
   isTestMode: boolean;
   batchInfo: BatchInfo[];
@@ -162,6 +167,7 @@ export function buildCastVoteRecordReportMetadata({
   electionId,
   generatingDeviceId,
   scannerIds,
+  scannerType,
   reportTypes,
   isTestMode,
   generatedDate = new Date(),
@@ -180,7 +186,11 @@ export function buildCastVoteRecordReportMetadata({
     GeneratedDate: generatedDate.toISOString(),
     // VVSG 2.0 1.1.5-G.1 requires identification of the creating device
     ReportGeneratingDeviceIds: [generatingDeviceId],
-    ReportingDevice: buildReportingDevices(generatingDeviceId, scannerIds),
+    ReportingDevice: buildReportingDevices(
+      generatingDeviceId,
+      scannerIds,
+      scannerType
+    ),
     Party: election.parties.map((party) => ({
       '@type': 'CVR.Party',
       '@id': party.id,

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -302,6 +302,7 @@ function buildCastVoteRecordReportMetadata(
     isTestMode: inTestMode,
     reportTypes: [CVR.ReportType.OriginatingDeviceExport],
     scannerIds: [scannerId],
+    scannerType: exportContext.exportOptions.scannerType,
   });
 }
 


### PR DESCRIPTION
## Overview

Populate the optional CDF `Model` field on every `ReportingDevice` in CVR exports so the importer can distinguish precinct scanners (VxScan) from central scanners (VxCentralScan) without relying on out-of-band information.

- VxScan exports: `Model: 'VxScan'`
- VxCentralScan exports: `Model: 'VxCentralScan'`

The `scannerType` (`'precinct'` / `'central'`) was already threaded through `ExportOptions` all the way to the shared `buildCastVoteRecordReportMetadata` in `libs/backend` — this change adds one parameter hop to `buildReportingDevices()` and sets the field.

## Demo Video or Screenshot

## Testing Plan

- Unit tests in `libs/backend/src/cast_vote_records/build_report_metadata.test.ts` updated to assert `Model: 'VxScan'` for precinct scanner and `Model: 'VxCentralScan'` for central scanner.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user_facing_change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.