### PR TITLE
dev-dock: add keyboard support to screenshot modal

### DIFF
--- a/libs/dev-dock/frontend/src/dev_dock.test.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.test.tsx
@@ -352,6 +352,40 @@ test('Cmd+K starts screenshot flow', async () => {
   await screen.findByText('Save Screenshot');
 });
 
+test('Esc dismisses screenshot modal', async () => {
+  renderDock(mockApiClient);
+  const screenshotButton = await screen.findByRole('button', {
+    name: 'Capture Screenshot',
+  });
+
+  document.title = 'VotingWorks VxAdmin';
+  userEvent.click(screenshotButton);
+  await screen.findByText('Save Screenshot');
+
+  userEvent.keyboard('{Escape}');
+  await waitFor(() => {
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+});
+
+test('Save button is auto-focused when screenshot modal opens', async () => {
+  renderDock(mockApiClient);
+  const screenshotButton = await screen.findByRole('button', {
+    name: 'Capture Screenshot',
+  });
+
+  document.title = 'VotingWorks VxAdmin';
+  userEvent.click(screenshotButton);
+  await screen.findByText('Save Screenshot');
+
+  expect(screen.getByRole('button', { name: 'Save' })).toHaveFocus();
+
+  userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+  await waitFor(() => {
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+});
+
 test('printer mock control', async () => {
   featureFlagMock.enableFeatureFlag(
     BooleanEnvironmentVariableName.USE_MOCK_PRINTER

--- a/libs/dev-dock/frontend/src/dev_dock.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.tsx
@@ -489,6 +489,7 @@ function ScreenshotControls({
       {screenshotToSave && (
         <ScreenshotModal
           title="Save Screenshot"
+          onOverlayClick={() => setScreenshotToSave(undefined)}
           content={
             <>
               <P>The image will be saved to the Downloads folder as:</P>
@@ -515,6 +516,7 @@ function ScreenshotControls({
           actions={
             <>
               <Button
+                autoFocus
                 onPress={onSaveScreenshot}
                 style={{
                   backgroundColor: Colors.ACTIVE,


### PR DESCRIPTION
## Overview

Fixes missing keyboard support in the dev dock screenshot modal (opened with Cmd/Super+K).

## Demo Video or Screenshot

[Kooha-2026-03-02-11-19-33.webm](https://github.com/user-attachments/assets/d99cb05a-b121-48ad-a6e3-d738abf37f92)

## Testing Plan

- Open the screenshot modal with Cmd+K
- Press **Esc** → modal dismisses
- Press **Enter** → Save button (auto-focused on open) confirms the save

Two new tests cover these behaviors:
- `Esc dismisses screenshot modal`
- `Save button is auto-focused when screenshot modal opens`