### PR TITLE
VxDesign: Fix PartiesScreen test flake

### DIFF
--- a/apps/design/frontend/src/parties_screen.test.tsx
+++ b/apps/design/frontend/src/parties_screen.test.tsx
@@ -19,7 +19,7 @@ import {
   user,
 } from '../test/api_helpers';
 import { electionInfoFromElection } from '../test/fixtures';
-import { render, screen, waitFor, within } from '../test/react_testing_library';
+import { render, screen, within } from '../test/react_testing_library';
 import { withRoute } from '../test/routing_helpers';
 import { routes } from './routes';
 import { makeIdFactory } from '../test/id_helpers';
@@ -61,7 +61,10 @@ beforeEach(() => {
   apiMock.getUser.expectCallWith().resolves(user);
   mockUserFeatures(apiMock);
 
-  mockStateFeatures(apiMock, electionId);
+  apiMock.getStateFeatures
+    .expectOptionalRepeatedCallsWith({ electionId })
+    .resolves({});
+
   apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
   apiMock.getSystemSettings
     .expectCallWith({ electionId })
@@ -222,12 +225,6 @@ test('editing or adding a party is disabled when ballots are finalized', async (
   apiMock.listParties.expectCallWith({ electionId }).resolves(election.parties);
 
   renderScreen(electionId);
-  // Wait for state features API request to complete (to check whether or not to
-  // show audio buttons). In this case, since audio is disabled, the buttons
-  // aren't shown so there's nothing we can await on screen. But if the API
-  // request doesn't complete in time, the test may fail due to the
-  // assertComplete in afterEach.
-  await waitFor(() => apiMock.assertComplete());
 
   await screen.findByDisplayValue(election.parties[0].name);
   expect(screen.getButton('Add Party')).toBeDisabled();


### PR DESCRIPTION
## Overview

[This test](https://app.circleci.com/pipelines/github/votingworks/vxsuite/24311/workflows/93ae9ff5-7e7f-4d10-b91a-025d3769115e/jobs/1095528) was flaking in a similar way to the one that was fixed in https://github.com/votingworks/vxsuite/pull/7946 - looks like it's due to an unrelated query in a nested component (audio button) that gets rendered in later ticks after the top-level screen, which, in a slow-enough CI run, doesn't get kicked off before the test is done (for short tests with only one wait on the initial load). 

Repro'd by adding a synthetic rendering delay in the nested component to mimic slow CI - fixed more globally by switching the mock for the transitive API dependency to an optional repeated. The `audio editing` test is explicitly checking the API interaction with the button's rendering.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
