### PR TITLE
VxDesign: Add polling place DB tables, CRUD API

### DIFF
--- a/apps/design/backend/migrations/1772748643495_add-polling-places.js
+++ b/apps/design/backend/migrations/1772748643495_add-polling-places.js
@@ -1,0 +1,64 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { PgLiteral } = require('node-pg-migrate');
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  const enumPollingPlaceType = 'polling_place_type';
+  pgm.createType(enumPollingPlaceType, [
+    'absentee',
+    'early_voting',
+    'election_day',
+  ]);
+
+  pgm.createTable(
+    'polling_places',
+    {
+      id: { type: 'text', primaryKey: true },
+      created_at: {
+        type: 'timestamptz',
+        notNull: true,
+        default: new PgLiteral('current_timestamp'),
+      },
+      election_id: {
+        type: 'text',
+        notNull: true,
+        references: 'elections',
+        onDelete: 'CASCADE',
+      },
+      name: { type: 'text', notNull: true },
+      type: { type: enumPollingPlaceType, notNull: true },
+    },
+    {
+      constraints: {
+        unique: ['election_id', 'name', 'type'],
+      },
+    }
+  );
+
+  pgm.createTable(
+    'polling_places_precincts',
+    {
+      polling_place_id: {
+        type: 'text',
+        notNull: true,
+        references: 'polling_places',
+        onDelete: 'CASCADE',
+      },
+      precinct_id: {
+        type: 'text',
+        notNull: true,
+        references: 'precincts',
+        onDelete: 'CASCADE',
+      },
+    },
+    {
+      constraints: {
+        primaryKey: ['polling_place_id', 'precinct_id'],
+      },
+    }
+  );
+};

--- a/apps/design/backend/src/app.polling_places.test.ts
+++ b/apps/design/backend/src/app.polling_places.test.ts
@@ -1,0 +1,153 @@
+import { afterAll, expect, test } from 'vitest';
+import { err, ok } from '@votingworks/basics';
+import { PollingPlace, Precinct, PrecinctSplit } from '@votingworks/types';
+import { testSetupHelpers } from '../test/helpers';
+import { organizations, nonVxUser, nonVxJurisdiction } from '../test/mocks';
+
+const { setupApp, cleanup } = testSetupHelpers();
+
+afterAll(cleanup);
+
+test('polling places CRUD', async () => {
+  const { apiClient, auth0 } = await setupApp({
+    organizations,
+    jurisdictions: nonVxUser.jurisdictions,
+    users: [nonVxUser],
+  });
+
+  auth0.setLoggedInUser(nonVxUser);
+  const electionId = (
+    await apiClient.createElection({
+      jurisdictionId: nonVxJurisdiction.id,
+      id: 'election1',
+    })
+  ).unsafeUnwrap();
+
+  expect(await apiClient.listPollingPlaces({ electionId })).toEqual([]);
+
+  // Should error on invalid precinct:
+
+  const initialPlace1: PollingPlace = {
+    id: 'place1',
+    name: 'Place 1',
+    precincts: {
+      precinct1: { type: 'whole' },
+    },
+    type: 'election_day',
+  };
+  expect(
+    await apiClient.setPollingPlace({ electionId, place: initialPlace1 })
+  ).toEqual(err('invalid-precinct'));
+
+  // Precincts/splits setup:
+
+  const splits: PrecinctSplit[] = [
+    { districtIds: [], id: 's1', name: 'Split 1' },
+    { districtIds: [], id: 's2', name: 'Split 2' },
+  ];
+  const precincts: Precinct[] = [
+    { id: 'precinct1', name: 'Precinct 1', districtIds: [] },
+    { id: 'precinct2', name: 'Precinct 2', districtIds: [], splits },
+  ];
+  for (const newPrecinct of precincts) {
+    const res = await apiClient.createPrecinct({ electionId, newPrecinct });
+    res.unsafeUnwrap();
+  }
+
+  // Add and retrieve valid polling place:
+
+  expect(
+    await apiClient.setPollingPlace({ electionId, place: initialPlace1 })
+  ).toEqual(ok());
+
+  expect(await apiClient.listPollingPlaces({ electionId })).toEqual([
+    initialPlace1,
+  ]);
+
+  // Update and retrieve existing polling place:
+
+  const updatedPlace1: PollingPlace = {
+    ...initialPlace1,
+    name: 'Place 1 (Updated)',
+    precincts: {
+      precinct1: { type: 'whole' },
+      precinct2: { type: 'whole' },
+    },
+  };
+  expect(
+    await apiClient.setPollingPlace({ electionId, place: updatedPlace1 })
+  ).toEqual(ok());
+
+  expect(await apiClient.listPollingPlaces({ electionId })).toEqual([
+    updatedPlace1,
+  ]);
+
+  // Should error on new place with duplicate name:
+
+  expect(
+    await apiClient.setPollingPlace({
+      electionId,
+      place: { ...updatedPlace1, id: 'place1-copy' },
+    })
+  ).toEqual(err('duplicate-name'));
+
+  // Can add polling place with duplicate name, if it has a different type:
+
+  const place1EarlyVoting: PollingPlace = {
+    ...updatedPlace1,
+    id: 'place1-early',
+    type: 'early_voting',
+  };
+
+  expect(
+    await apiClient.setPollingPlace({
+      electionId,
+      place: place1EarlyVoting,
+    })
+  ).toEqual(ok());
+
+  expect(await apiClient.listPollingPlaces({ electionId })).toEqual([
+    updatedPlace1,
+    place1EarlyVoting,
+  ]);
+
+  // Add new place, get updated list:
+
+  const place2: PollingPlace = {
+    id: 'place2',
+    name: 'Place 2',
+    precincts: { precinct1: { type: 'whole' } },
+    type: 'absentee',
+  };
+  const place3: PollingPlace = {
+    id: 'place3',
+    name: 'Place 3',
+    precincts: { precinct2: { type: 'whole' } },
+    type: 'early_voting',
+  };
+
+  expect(
+    await apiClient.setPollingPlace({ electionId, place: place3 })
+  ).toEqual(ok());
+  expect(
+    await apiClient.setPollingPlace({ electionId, place: place2 })
+  ).toEqual(ok());
+
+  expect(await apiClient.listPollingPlaces({ electionId })).toEqual([
+    updatedPlace1,
+    place1EarlyVoting,
+    place2,
+    place3,
+  ]);
+
+  // Delete existing place, get updated list:
+
+  await apiClient.deletePollingPlace({ electionId, id: place2.id });
+  await apiClient.deletePollingPlace({ electionId, id: place2.id }); // no-op
+
+  expect(await apiClient.listPollingPlaces({ electionId })).toEqual([
+    updatedPlace1,
+    place1EarlyVoting,
+    place3,
+  ]);
+});

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -33,6 +33,8 @@ import {
   safeParseElection,
   BallotStyle,
   formatBallotHash,
+  PollingPlaceSchema,
+  PollingPlace,
 } from '@votingworks/types';
 import express, { Application } from 'express';
 import {
@@ -80,6 +82,7 @@ import {
   DuplicatePartyError,
   DuplicatePrecinctError,
   TestDecksTaskMetadata,
+  SetPollingPlaceError,
 } from './store';
 import {
   AggregatedReportedPollsStatus,
@@ -1077,6 +1080,27 @@ export function buildApi(ctx: AppContext) {
 
     getBaseUrl(): string {
       return baseUrl();
+    },
+
+    listPollingPlaces(input: { electionId: string }): Promise<PollingPlace[]> {
+      return store.listPollingPlaces(input.electionId);
+    },
+
+    async setPollingPlace(input: {
+      electionId: ElectionId;
+      place: PollingPlace;
+    }): Promise<Result<void, SetPollingPlaceError>> {
+      return store.setPollingPlace(
+        input.electionId,
+        unsafeParse(PollingPlaceSchema, input.place)
+      );
+    },
+
+    deletePollingPlace(input: {
+      electionId: string;
+      id: string;
+    }): Promise<void> {
+      return store.deletePollingPlace(input);
     },
 
     ...ttsStrings.apiMethods(ctx),

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -52,6 +52,8 @@ import {
   DistrictSchema,
   PartySchema,
   YesNoOption,
+  PollingPlace,
+  PollingPlaceType,
 } from '@votingworks/types';
 import {
   singlePrecinctSelectionFor,
@@ -197,6 +199,17 @@ function isDuplicateKeyError(
   );
 }
 
+function isForeignKeyError(
+  error: unknown,
+  constraint: string
+): error is DatabaseError {
+  return (
+    error instanceof DatabaseError &&
+    error.code === '23503' &&
+    error.constraint === constraint
+  );
+}
+
 export type DuplicateElectionError = 'duplicate-title-and-date';
 
 export type DuplicateDistrictErrorCode = 'duplicate-name';
@@ -225,6 +238,8 @@ export type DuplicateContestError =
   | 'duplicate-contest'
   | 'duplicate-candidate'
   | 'duplicate-option';
+
+export type SetPollingPlaceError = 'duplicate-name' | 'invalid-precinct';
 
 async function insertDistrict(
   client: Client,
@@ -525,14 +540,11 @@ function rowToJurisdiction(row: JurisdictionRow): Jurisdiction {
 }
 
 export class Store {
-  constructor(
-    private readonly db: Db,
-    private readonly logger: BaseLogger
-  ) {}
+  constructor(private readonly db: Db) {}
 
   /* istanbul ignore next - @preserve */
   static new(logger: BaseLogger): Store {
-    return new Store(new Db(logger), logger);
+    return new Store(new Db(logger));
   }
 
   async listOrganizations(): Promise<Organization[]> {
@@ -3125,4 +3137,166 @@ export class Store {
       })
     );
   }
+
+  async listPollingPlaces(electionId: ElectionId): Promise<PollingPlace[]> {
+    return this.db.withClient(async (client) => {
+      const res = (await client.query(
+        `
+          select
+            id,
+            name,
+            array_remove(array_agg(precinct_id), NULL) as "precinct_ids",
+            type
+          from polling_places
+          left join polling_places_precincts as precincts on
+            precincts.polling_place_id = id
+          where
+            election_id = $1
+          group by id
+          order by name collate natural_sort
+      `,
+        electionId
+      )) as {
+        rows: Array<{
+          id: string;
+          name: string;
+          precinct_ids: string[];
+          type: PollingPlaceType;
+        }>;
+      };
+
+      const places: PollingPlace[] = [];
+
+      for (const row of res.rows) {
+        const place: PollingPlace = {
+          id: row.id,
+          name: row.name,
+          precincts: {},
+          type: row.type,
+        };
+
+        for (const precinctId of row.precinct_ids) {
+          // [TODO] Support partial precincts for polling places
+          // covering only a subset of a precinct's splits.
+          place.precincts[precinctId] = { type: 'whole' };
+        }
+
+        places.push(place);
+      }
+
+      return places;
+    });
+  }
+
+  async setPollingPlace(
+    electionId: ElectionId,
+    place: PollingPlace
+  ): Promise<Result<void, SetPollingPlaceError>> {
+    let res: Result<void, SetPollingPlaceError> | undefined;
+
+    await this.db.withClient(async (client) =>
+      client.withTransaction(async () => {
+        await deletePollingPlace(client, {
+          electionId,
+          id: place.id,
+        });
+
+        res = await insertPollingPlace(client, electionId, place);
+
+        return true;
+      })
+    );
+
+    return assertDefined(res);
+  }
+
+  async deletePollingPlace(p: {
+    electionId: string;
+    id: string;
+  }): Promise<void> {
+    await this.db.withClient(async (client) => deletePollingPlace(client, p));
+  }
+}
+
+async function deletePollingPlace(
+  client: Client,
+  p: { electionId: string; id: string }
+): Promise<void> {
+  await client.query(
+    `delete from polling_places where id = $1 and election_id = $2`,
+    p.id,
+    p.electionId
+  );
+}
+
+async function insertPollingPlace(
+  client: Client,
+  electionId: ElectionId,
+  place: PollingPlace
+): Promise<Result<void, SetPollingPlaceError>> {
+  assert(
+    Object.values(place.precincts).every((p) => p.type === 'whole'),
+    'partial precinct coverage not yet supported for polling places'
+  );
+
+  await assertWithinTransaction(client);
+  try {
+    await client.query(
+      `
+        insert into polling_places (
+          election_id,
+          id,
+          name,
+          type
+        )
+        values ($1, $2, $3, $4)
+      `,
+      electionId,
+      place.id,
+      place.name,
+      place.type
+    );
+
+    await insertPollingPlacePrecincts(client, place);
+  } catch (error) {
+    const nameIndex = 'polling_places_uniq_election_id_name_type';
+    if (isDuplicateKeyError(error, nameIndex)) {
+      return err('duplicate-name');
+    }
+
+    const precinctsForeignKey = 'polling_places_precincts_precinct_id_fkey';
+    if (isForeignKeyError(error, precinctsForeignKey)) {
+      return err('invalid-precinct');
+    }
+
+    throw error;
+  }
+
+  return ok();
+}
+
+async function insertPollingPlacePrecincts(
+  client: Client,
+  place: PollingPlace
+) {
+  const precinctIds = Object.keys(place.precincts);
+  if (precinctIds.length === 0) return;
+
+  const params = [place.id, ...precinctIds];
+  const placeholders: string[] = [];
+
+  for (let i = 2; i <= params.length; i += 1) {
+    placeholders.push(`($1, $${i})`);
+  }
+
+  await client.query(
+    `
+      insert into polling_places_precincts (
+        polling_place_id,
+        precinct_id
+      ) values
+        ${placeholders.join(', ')}
+  `,
+    ...params
+  );
 }

--- a/apps/design/backend/test/test_store.ts
+++ b/apps/design/backend/test/test_store.ts
@@ -13,7 +13,7 @@ export class TestStore {
     this.db = new Db(this.logger, {
       defaultSchemaName: this.schemaName,
     });
-    this.store = new Store(this.db, this.logger);
+    this.store = new Store(this.db);
   }
 
   getStore(): Store {


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7872

Adding store/API layer for managing polling places in VxHub.

Starting off with supporting only polling places with whole-precinct coverage for now, since we don't expect any upcoming jurisdictions to have places that only partially cover some of the splits in a precinct. Will later be adding a mapping table from polling place to precinct splits as well.

### Next up:
- Auto-generate polling places from precincts in imported elections (feature-flagged by state) and for manually entered precincts.

## Testing Plan
- CRUD API unit tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.