### PR TITLE
VxScan: Handle scanStart during status polls to prevent scanner crash

### DIFF
--- a/apps/scan/backend/src/scanner.ts
+++ b/apps/scan/backend/src/scanner.ts
@@ -776,6 +776,14 @@ function buildMachine({
               id: 'checkingStatus',
               invoke: pollScannerStatus,
               on: {
+                // If the ballot is teased and initially not caught, but then
+                // pulled in, we might get a partial scan followed by a second
+                // scan in quick succession after the first scan completes
+                // (since there will be no ballot in the back during checkingComplete).
+                SCANNER_EVENT: {
+                  cond: (_, { event }) => event.event === 'scanStart',
+                  target: '#scanning',
+                },
                 SCANNER_STATUS: [
                   {
                     cond: (_, { status }) => anyRearSensorCovered(status),
@@ -910,6 +918,17 @@ function buildMachine({
             checkingComplete: {
               invoke: pollScannerStatus,
               on: {
+                // If the ballot is teased, we might get a second scanStart in
+                // quick succession after the first completes before we're able
+                // to get the scanner status. We abort the current scan (which
+                // was almost definitely an incomplete scan) and start the next
+                // one.
+                SCANNER_EVENT: {
+                  cond: (_, { event }) => event.event === 'scanStart',
+                  target: 'waitingForScanComplete',
+                  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                  actions: assign({ scanImages: (_context) => undefined }),
+                },
                 SCANNER_STATUS: [
                   {
                     cond: (_, { status }) => status.documentJam,

--- a/apps/scan/backend/src/scanner_scan.test.ts
+++ b/apps/scan/backend/src/scanner_scan.test.ts
@@ -1,8 +1,12 @@
-import { err, typedAs } from '@votingworks/basics';
+import { Result, deferred, err, ok, typedAs } from '@votingworks/basics';
 import { DEFAULT_FAMOUS_NAMES_PRECINCT_ID } from '@votingworks/bmd-ballot-fixtures';
 import { electionGridLayoutNewHampshireTestBallotFixtures } from '@votingworks/fixtures';
 import { vxFamousNamesFixtures } from '@votingworks/hmpb';
-import { mockScannerStatus } from '@votingworks/pdi-scanner';
+import {
+  ScannerError,
+  ScannerStatus,
+  mockScannerStatus,
+} from '@votingworks/pdi-scanner';
 import {
   AdjudicationReason,
   AdjudicationReasonInfo,
@@ -630,6 +634,119 @@ test('if scanning times out, show unrecoverable error', async () => {
         },
         expect.any(Function)
       );
+    }
+  );
+});
+
+test('scanStart during scanning.checkingComplete restarts scan', async () => {
+  await withApp(
+    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+      await configureApp(apiClient, mockAuth, mockUsbDrive, {
+        testMode: true,
+        electionPackage: {
+          electionDefinition: vxFamousNamesFixtures.electionDefinition,
+        },
+      });
+
+      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+      await waitForStatus(apiClient, { state: 'waiting_for_ballot' });
+
+      // Start first scan
+      mockScanner.emitEvent({ event: 'scanStart' });
+      await expectStatus(apiClient, { state: 'scanning' });
+
+      // Hold the status poll so we stay in checkingComplete
+      const { promise: statusPromise, resolve: resolveStatus } =
+        deferred<Result<ScannerStatus, ScannerError>>();
+      mockScanner.client.getScannerStatus.mockReturnValueOnce(statusPromise);
+
+      // Complete the scan with a blank sheet (would be rejected if
+      // interpreted). This proves the second scan's images are used.
+      mockScanner.setScannerStatus(mockScannerStatus.documentInRear);
+      mockScanner.emitEvent({
+        event: 'scanComplete',
+        images: await ballotImages.blankSheet(),
+      });
+
+      // Emit a new scanStart before the status poll resolves (paper tease)
+      mockScanner.emitEvent({ event: 'scanStart' });
+      await expectStatus(apiClient, { state: 'scanning' });
+      resolveStatus(ok(mockScannerStatus.documentInRear));
+
+      // Now complete a full valid scan — interpretation succeeds, proving
+      // the blank sheet from the first scan was discarded
+      mockScanner.emitEvent({
+        event: 'scanComplete',
+        images: await ballotImages.completeHmpb(),
+      });
+      clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
+      await waitForStatus(apiClient, {
+        state: 'accepting',
+        interpretation: { type: 'ValidSheet' },
+      });
+    }
+  );
+});
+
+test('scanStart during waitingForBallot.checkingStatus transitions to scanning', async () => {
+  await withApp(
+    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+      await configureApp(apiClient, mockAuth, mockUsbDrive, {
+        testMode: true,
+        electionPackage: {
+          electionDefinition: vxFamousNamesFixtures.electionDefinition,
+        },
+      });
+
+      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+      await waitForStatus(apiClient, { state: 'waiting_for_ballot' });
+
+      // Start a scan where paper gets pulled out
+      mockScanner.emitEvent({ event: 'scanStart' });
+      await expectStatus(apiClient, { state: 'scanning' });
+
+      // Paper pulled out: documentInScanner=false
+      mockScanner.setScannerStatus(mockScannerStatus.idleScanningDisabled);
+
+      // Queue two mockReturnValueOnce calls:
+      // 1. checkingComplete poll: resolves immediately with no document
+      //    (triggers transition to waitingForBallot.checkingStatus)
+      // 2. checkingStatus poll: held via deferred so we can emit scanStart
+      const { promise: statusPromise, resolve: resolveStatus } =
+        deferred<Result<ScannerStatus, ScannerError>>();
+      mockScanner.client.getScannerStatus
+        .mockReturnValueOnce(
+          Promise.resolve(ok(mockScannerStatus.idleScanningDisabled))
+        )
+        .mockReturnValueOnce(statusPromise);
+
+      // scanComplete with no document → checkingComplete sees
+      // documentInScanner=false → transitions to waitingForBallot.checkingStatus
+      // (where the poll is now held)
+      mockScanner.emitEvent({
+        event: 'scanComplete',
+        images: await ballotImages.blankSheet(),
+      });
+      // Let the checkingComplete status poll resolve and transition to
+      // waitingForBallot.checkingStatus
+      await waitForStatus(apiClient, { state: 'waiting_for_ballot' });
+
+      // Now in checkingStatus with a held poll — emit scanStart
+      mockScanner.emitEvent({ event: 'scanStart' });
+      await expectStatus(apiClient, { state: 'scanning' });
+      resolveStatus(ok(mockScannerStatus.idleScanningDisabled));
+
+      // Complete a normal scan and verify interpretation succeeds
+      mockScanner.setScannerStatus(mockScannerStatus.documentInRear);
+      mockScanner.emitEvent({
+        event: 'scanComplete',
+        images: await ballotImages.completeHmpb(),
+      });
+      clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
+      await waitForStatus(apiClient, {
+        state: 'accepting',
+        interpretation: { type: 'ValidSheet' },
+      });
     }
   );
 });


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Task: #8063

During L&A testing in Londonderry and Fremont, VxScan crashed to a "Scanner
Error" screen when paper was teased at the PDI scanner feeder. We were able to
reproduce the behavior on a dev machine and identified two crash paths.

### Root cause

When paper is teased, the PDI scanner fires rapid back-to-back scan cycles with
partial images. A `scanStart` event can arrive while the state machine is in the
middle of an async status poll. Two states lack `SCANNER_EVENT` handlers, so the
event falls through to the root-level catch-all, which transitions to
`unrecoverableError`.

**Londonderry (SC-13-078):** `scanStart` arrives while in
`scanning.checkingComplete` — the state that polls scanner status after a scan
completes. The partial scan completes, the machine enters `checkingComplete` to
check if the ballot made it through, but a new `scanStart` fires before the
status poll returns.

**Fremont (SC-13-067):** Same trigger, but different timing. The
`checkingComplete` status poll returns fast enough (showing `documentInScanner:
false`), so the machine advances to `waitingForBallot.checkingStatus`. The
`scanStart` arrives there instead, ~1.3s later.

Full analysis: https://votingworks.slack.com/docs/TE6RHHERY/F0AJS8TA0TX

### Fix

- Add `scanStart` handler to `scanning.checkingComplete`: clears `scanImages`
  and transitions back to `waitingForScanComplete`.
- Add `scanStart` handler to `waitingForBallot.checkingStatus`: transitions to
  `#scanning`, same target as the adjacent `waiting` state.


## Testing Plan

- [x] New tests for both states pass
- [x] Full `apps/scan/backend` regression passes (213 tests)
- [x] Mutation tested: removing either handler causes the corresponding test to
  fail with `unrecoverable_error`
- [x] Manual test: teased paper at feeder, confirmed new code paths were used

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.