### PR TITLE
[Spec] Multi-USB drive support

### DIFF
--- a/specs/0004-multi-usb-drive.md
+++ b/specs/0004-multi-usb-drive.md
@@ -50,7 +50,7 @@ export interface UsbPartitionInfo {
   label?: string;
   fstype?: string;
   fsver?: string;
-  mount: UsbPartitionMount; // 'unmounted' | 'mounting' | 'mounted' | 'unmounting'
+  mount: 'unmounted' | 'mounting' | 'mounted' | 'unmounting';
 }
 
 export interface UsbDriveInfo {
@@ -151,7 +151,7 @@ The dev dock gains first-class support for simulating multiple USB drives:
 
 **`createMockFileMultiUsbDrive()`** — the file-backed mock used in development
 and integration tests. Drive state is stored under
-`.mock-state/<NODE_ENV>/usb-drive/usb-drive/<diskName>/` (leveraging the unified
+`.mock-state/<NODE_ENV>/usb-drive/<diskName>/` (leveraging the unified
 mock-state root from spec 0003). Helper functions:
 
 - `addMockDrive()` — creates a new drive directory, returns its path.


### PR DESCRIPTION
## Spec

[specs/0004-multi-usb-drive.md](https://github.com/votingworks/vxsuite/blob/brian/multi-usb-drive-spec/specs/0004-multi-usb-drive.md)

## Summary

VxSuite's existing `UsbDrive` abstraction models a single plugged-in USB drive, which is insufficient for upcoming features like Election Archiving & Backup (which needs to write to multiple drives simultaneously) and Multi-Station Adjudication (which may import CVRs from multiple drives). This spec proposes a new `MultiUsbDrive` interface that tracks all connected drives and their partition state, a backward-compatible `UsbDriveAdapter` to bridge existing single-drive consumers, and corresponding updates to the dev dock, mocks, and VxAdmin.

**Demo from the proof of concept branch:**

[Kooha-2026-03-10-16-55-41.webm](https://github.com/user-attachments/assets/85c43a0d-14b5-413e-856a-0c2479f8440c)
