### PR TITLE
fix(pdi-scanner): Auto-disable feeder after every scan to prevent double scanStart

### DIFF
--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -475,6 +475,18 @@ async fn main() -> color_eyre::Result<()> {
                         raw_image_data.extend_from_slice(&image_data.0);
                     }
                     Incoming::EndScanEvent => {
+                        // Disable the feeder immediately after every scan completes
+                        // to prevent the firmware from auto-starting another
+                        // scan (e.g. if the first scan was just a paper tease).
+                        // PickOnCommandMode::FeederMustBeReenabledBetweenScans
+                        // is supposed to do this, but it only works when the
+                        // paper reaches the rear sensors.
+                        if let Some(c) = client.as_mut() {
+                            if let Err(e) = c.set_feeder_mode(FeederMode::Disabled).await {
+                                tracing::warn!("failed to disable feeder after scan: {e:?}");
+                            }
+                        }
+
                         match raw_image_data.try_decode_scan(
                             DEFAULT_IMAGE_WIDTH,
                             ScanSideMode::Duplex,


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Relates to #8063.

Prevents the PDI scanner firmware from auto-starting a second scan when paper shifts after an incomplete scan (e.g. a paper tease/pullback).

The scanner is configured with Pick-on-Command mode `FeederMustBeReenabledBetweenScans`, which is supposed to auto-disable the feeder after each scan. However, hardware testing revealed that this only works when the paper reaches the rear sensors. If a scan completes without reaching the rear sensors (partial scan, paper tease), the feeder stays enabled and the firmware can auto-start another scan before the state machine is ready to process it.

This fix disables the feeder in pdictl immediately on every `EndScan` event. The VxScan state machine already re-enables the feeder via `enableScanning()` when it transitions back to `waitingForBallot`, so no state machine changes are needed.

## Testing Plan

Manual hardware testing confirmed:

- Disabling the feeder during a scan does not interrupt the current scan
- This approach prevents double `scanStart` in all tested scenarios (normal scans, pullbacks, errors — 12+ trials)

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.