### PR TITLE
VxMarkScan: Add diagnostic-init log for paper handler diagnostic

### DIFF
--- a/apps/mark-scan/backend/src/app.diagnostics.test.ts
+++ b/apps/mark-scan/backend/src/app.diagnostics.test.ts
@@ -328,6 +328,13 @@ describe('paper handler diagnostic', () => {
     clock.increment(delays.DELAY_PAPER_HANDLER_STATUS_POLLING_INTERVAL_MS);
 
     await apiClient.startPaperHandlerDiagnostic();
+    expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+      LogEventId.DiagnosticInit,
+      {
+        message: 'User initiated a paper handler diagnostic.',
+        disposition: 'success',
+      }
+    );
     await waitForStatus('paper_handler_diagnostic.prompt_for_paper');
 
     driver.setMockStatus('paperInserted');
@@ -370,6 +377,13 @@ describe('paper handler diagnostic', () => {
     driver.setMockStatus('noPaper');
     clock.increment(delays.DELAY_PAPER_HANDLER_STATUS_POLLING_INTERVAL_MS);
     await apiClient.startPaperHandlerDiagnostic();
+    expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+      LogEventId.DiagnosticInit,
+      {
+        message: 'User initiated a paper handler diagnostic.',
+        disposition: 'success',
+      }
+    );
 
     await waitForStatus('paper_handler_diagnostic.prompt_for_paper');
 

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -459,6 +459,11 @@ export function buildApi(
     },
 
     startPaperHandlerDiagnostic(): void {
+      void logger.logAsCurrentRole(LogEventId.DiagnosticInit, {
+        message: 'User initiated a paper handler diagnostic.',
+        disposition: 'success',
+      });
+
       if (!stateMachine) {
         const record: Omit<DiagnosticRecord, 'timestamp'> = {
           type: 'mark-scan-paper-handler',


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/8051

Quick tweak for cert discrepancy https://github.com/votingworks/cert-discrepancies/issues/285. Our docs indicate that we emit both `diagnostic-init` and `diagnostic-complete` logs on all our machines. But on VxMarkScan, we actually only emit `diagnostic-complete` logs. This PR adds a `diagnostic-init` log for the paper handler diagnostic as that diagnostic actually does take some time, and having both init and complete logs for it makes sense. I don't think that we need a `diagnostic-init` log for every VxMarkScan diagnostic. SLI just needs to be able to emit and view one such log.

## Testing Plan

- [x] Automated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.