### PR TITLE
fix(pdictl): make `--log-level` option work

### DIFF
--- a/libs/pdi-scanner/examples/get_test_string.rs
+++ b/libs/pdi-scanner/examples/get_test_string.rs
@@ -32,14 +32,7 @@ fn setup_logging(config: &Config) -> color_eyre::Result<()> {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::builder()
-                .with_default_directive(
-                    format!(
-                        "{}={}",
-                        env!("CARGO_BIN_NAME").replace('-', "_"),
-                        config.log_level
-                    )
-                    .parse()?,
-                )
+                .with_default_directive(format!("pdi_scanner={}", config.log_level).parse()?)
                 .from_env_lossy(),
         )
         .with(stderr_log)
@@ -51,7 +44,7 @@ fn setup_logging(config: &Config) -> color_eyre::Result<()> {
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
     let config = Config::parse();
-    setup(&config).unwrap();
+    setup(&config)?;
 
     let mut client = connect()?;
 

--- a/libs/pdi-scanner/examples/scan_forever.rs
+++ b/libs/pdi-scanner/examples/scan_forever.rs
@@ -43,14 +43,7 @@ fn setup_logging(config: &Config) -> color_eyre::Result<()> {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::builder()
-                .with_default_directive(
-                    format!(
-                        "{}={}",
-                        env!("CARGO_BIN_NAME").replace('-', "_"),
-                        config.log_level
-                    )
-                    .parse()?,
-                )
+                .with_default_directive(format!("pdi_scanner={}", config.log_level).parse()?)
                 .from_env_lossy(),
         )
         .with(stderr_log)

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -47,19 +47,13 @@ fn setup_logging(config: &Config) -> color_eyre::Result<()> {
         .with_writer(std::io::stderr)
         .pretty();
 
+    let mut env_filter = tracing_subscriber::EnvFilter::builder()
+        .with_default_directive(format!("pdi_scanner={}", config.log_level).parse()?)
+        .from_env_lossy();
+    env_filter = env_filter.add_directive(format!("pdictl={}", config.log_level).parse()?);
+
     tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::builder()
-                .with_default_directive(
-                    format!(
-                        "{}={}",
-                        env!("CARGO_BIN_NAME").replace('-', "_"),
-                        config.log_level
-                    )
-                    .parse()?,
-                )
-                .from_env_lossy(),
-        )
+        .with(env_filter)
         .with(stderr_log)
         .init();
 


### PR DESCRIPTION
## Overview

Fix `pdictl --log-level` so it filters the `pdi_scanner` tracing target instead of using `CARGO_BIN_NAME`, which was missing the library logs that matter for scanner debugging.

## Demo Video or Screenshot

```
❯ cargo run --release --example register_test -- --log-level=trace
    Finished `release` profile [optimized] target(s) in 0.06s
     Running `target/release/examples/register_test --log-level=trace`
  2026-03-13T00:06:47.937073Z DEBUG pdi_scanner::scanner: Connected to PDI scanner and claimed interface 0
    at libs/pdi-scanner/src/rust/scanner.rs:44

about to unlock register writing
  2026-03-13T00:06:47.937182Z DEBUG pdi_scanner::scanner: Scanner thread started; submitting initial IN endpoint transfers
    at libs/pdi-scanner/src/rust/scanner.rs:99

  2026-03-13T00:06:47.937886Z DEBUG pdi_scanner::scanner: sending packet: WriteRegisterDataRequest(RegisterIndex(63), 194625150) (data: "\u{2}>03f0b99be7e\u{3}�")
    at libs/pdi-scanner/src/rust/scanner.rs:178

  2026-03-13T00:06:47.938251Z DEBUG pdi_scanner::scanner: Received data on primary endpoint: 14 bytes
    at libs/pdi-scanner/src/rust/scanner.rs:142

  2026-03-13T00:06:47.938292Z DEBUG pdi_scanner::scanner: Received incoming packet: WriteRegisterDataResponse(Register { index: RegisterIndex(63), value: 194625150 })
    at libs/pdi-scanner/src/rust/scanner.rs:148

about to lock register writing
  2026-03-13T00:06:47.938379Z DEBUG pdi_scanner::scanner: sending packet: WriteRegisterDataRequest(RegisterIndex(63), 0) (data: "\u{2}>03f00000000\u{3}[")
    at libs/pdi-scanner/src/rust/scanner.rs:178

  2026-03-13T00:06:47.938642Z DEBUG pdi_scanner::scanner: Received data on primary endpoint: 14 bytes
    at libs/pdi-scanner/src/rust/scanner.rs:142

  2026-03-13T00:06:47.938656Z DEBUG pdi_scanner::scanner: Received incoming packet: WriteRegisterDataResponse(Register { index: RegisterIndex(63), value: 0 })
    at libs/pdi-scanner/src/rust/scanner.rs:148

  2026-03-13T00:06:47.938702Z DEBUG pdi_scanner::scanner: sending packet: ReadRegisterDataRequest(RegisterIndex(9)) (data: "\u{2}<009\u{3}�")
    at libs/pdi-scanner/src/rust/scanner.rs:178

  2026-03-13T00:06:47.938962Z DEBUG pdi_scanner::scanner: Received data on primary endpoint: 14 bytes
    at libs/pdi-scanner/src/rust/scanner.rs:142

  2026-03-13T00:06:47.938976Z DEBUG pdi_scanner::scanner: Received incoming packet: ReadRegisterDataResponse(Register { index: RegisterIndex(9), value: 264 })
    at libs/pdi-scanner/src/rust/scanner.rs:148

get register 9 result: Ok(Ok(264))
```

## Testing Plan

- `cd libs/pdi-scanner && cargo test --quiet`

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
