### PR TITLE
VxDesign: Generate polling places for newly created precincts

### DIFF
--- a/apps/design/backend/src/app.polling_places.test.ts
+++ b/apps/design/backend/src/app.polling_places.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, test } from 'vitest';
 import { err, ok } from '@votingworks/basics';
 import {
   PollingPlace,
+  pollingPlaceGenerateFromPrecinct,
   pollingPlacesGenerateFromPrecincts,
   Precinct,
   PrecinctSplit,
@@ -17,16 +18,20 @@ const { setupApp, cleanup } = testSetupHelpers();
 afterAll(cleanup);
 
 test('polling places CRUD', async () => {
+  const user = nonVxUser;
+  const jurisdiction = user.jurisdictions[0];
+  expectEditingEnabled(jurisdiction, false);
+
   const { apiClient, auth0 } = await setupApp({
     organizations,
-    jurisdictions: nonVxUser.jurisdictions,
-    users: [nonVxUser],
+    jurisdictions: user.jurisdictions,
+    users: [user],
   });
 
-  auth0.setLoggedInUser(nonVxUser);
+  auth0.setLoggedInUser(user);
   const electionId = (
     await apiClient.createElection({
-      jurisdictionId: nonVxUser.jurisdictions[0].id,
+      jurisdictionId: jurisdiction.id,
       id: 'election1',
     })
   ).unsafeUnwrap();
@@ -160,6 +165,118 @@ test('polling places CRUD', async () => {
   ]);
 });
 
+test('polling place updates on precinct creation/deletion', async () => {
+  const user = nonVxUser;
+  const jurisdiction = user.jurisdictions[1];
+  expectEditingEnabled(jurisdiction, true);
+
+  const { apiClient: api, auth0 } = await setupApp({
+    organizations,
+    jurisdictions,
+    users: [user],
+  });
+
+  auth0.setLoggedInUser(user);
+
+  const electionId = (
+    await api.createElection({
+      jurisdictionId: jurisdiction.id,
+      id: 'election1',
+    })
+  ).unsafeUnwrap();
+
+  expect(await api.listPollingPlaces({ electionId })).toEqual([]);
+
+  // Expect polling place generation on precinct creation:
+
+  const splits: PrecinctSplit[] = [
+    { districtIds: [], id: 's1', name: 'Split 1' },
+    { districtIds: [], id: 's2', name: 'Split 2' },
+  ];
+  const precincts: Precinct[] = [
+    { id: 'precinct1', name: 'Precinct 1', districtIds: [] },
+    { id: 'precinct2', name: 'Precinct 2', districtIds: [], splits },
+  ];
+  for (const newPrecinct of precincts) {
+    const res = await api.createPrecinct({ electionId, newPrecinct });
+    expect(res).toEqual(ok());
+  }
+
+  const placeFromPrecinct1 = pollingPlaceGenerateFromPrecinct({
+    precinct: precincts[0],
+    id: expect.any(String),
+    type: 'election_day',
+  });
+  const placeFromPrecinct2 = pollingPlaceGenerateFromPrecinct({
+    precinct: precincts[1],
+    id: expect.any(String),
+    type: 'election_day',
+  });
+
+  expect(await api.listPollingPlaces({ electionId })).toEqual([
+    placeFromPrecinct1,
+    placeFromPrecinct2,
+  ]);
+
+  const customPlace1: PollingPlace = {
+    id: 'customPlace1',
+    name: 'Custom Place 1',
+    precincts: {
+      precinct1: { type: 'whole' },
+      precinct2: { type: 'whole' },
+    },
+    type: 'election_day',
+  };
+
+  expect(
+    await api.setPollingPlace({ electionId, place: customPlace1 })
+  ).toEqual(ok());
+
+  expect(await api.listPollingPlaces({ electionId })).toEqual([
+    // Alphabetically sorted:
+    customPlace1,
+    placeFromPrecinct1,
+    placeFromPrecinct2,
+  ]);
+
+  // Deleting precincts removes polling place links:
+
+  await api.deletePrecinct({ electionId, precinctId: precincts[0].id });
+
+  const customPlace1Updated: PollingPlace = {
+    ...customPlace1,
+    precincts: { precinct2: { type: 'whole' } },
+  };
+  const placeFromPrecinct1Updated: PollingPlace = {
+    ...placeFromPrecinct1,
+    precincts: {},
+  };
+  expect(await api.listPollingPlaces({ electionId })).toEqual([
+    customPlace1Updated,
+    placeFromPrecinct1Updated,
+    placeFromPrecinct2,
+  ]);
+
+  // Creating precinct with name matching existing polling place is no-op:
+
+  expect(
+    await api.createPrecinct({
+      electionId,
+      newPrecinct: {
+        districtIds: [],
+        id: 'precinct3',
+        name: customPlace1.name,
+      },
+    })
+  ).toEqual(ok());
+
+  expect(await api.listPollingPlaces({ electionId })).toEqual([
+    customPlace1Updated,
+    placeFromPrecinct1Updated,
+    placeFromPrecinct2,
+  ]);
+});
+
 describe('loadElection', () => {
   const electionDef = electionGeneralFixtures.readElectionDefinition();
   const [precinct1, precinct2] = electionDef.election.precincts;
@@ -208,6 +325,7 @@ describe('loadElection', () => {
 
     return { api, electionId };
   }
+
   describe('stateFeatures.EDIT_POLLING_PLACES === true', () => {
     const user = nonVxUser;
     const jurisdiction = user.jurisdictions[1];

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -54,6 +54,7 @@ import {
   YesNoOption,
   PollingPlace,
   PollingPlaceType,
+  pollingPlaceGenerateFromPrecinct,
 } from '@votingworks/types';
 import {
   singlePrecinctSelectionFor,
@@ -84,6 +85,8 @@ import {
 } from './types';
 import { Db } from './db/db';
 import { Bindable, Client } from './db/client';
+import { generateId } from './utils';
+import { getStateFeaturesConfig } from './features';
 
 export interface ElectionRecord {
   jurisdictionId: string;
@@ -1616,10 +1619,50 @@ export class Store {
     electionId: ElectionId,
     precinct: Precinct
   ): Promise<Result<void, DuplicatePrecinctError>> {
+    const jurisdiction = await this.getElectionJurisdiction(electionId);
+    const stateFeatures = getStateFeaturesConfig(jurisdiction);
+
     try {
       await this.db.withClient((client) =>
         client.withTransaction(async () => {
           await insertPrecinct(client, electionId, precinct);
+
+          // Product assumption: most users will want a corresponding polling
+          // place for every precinct created, so we optimize for that use case
+          // here, to reduce the amount of manual entry work needed.
+          if (stateFeatures.EDIT_POLLING_PLACES) {
+            const generatedPlace = pollingPlaceGenerateFromPrecinct({
+              id: generateId(),
+              precinct,
+              type: 'election_day',
+            });
+
+            const res = await insertPollingPlace(
+              client,
+              electionId,
+              generatedPlace
+            );
+            if (res.isErr()) {
+              const error = res.err();
+              switch (error) {
+                case 'duplicate-name':
+                  // Name collision with existing polling place - assume the
+                  // user will resolve this manually.
+                  break;
+
+                /* istanbul ignore next - shouldn't be possible - @preserve */
+                case 'invalid-precinct':
+                  throw new Error(
+                    `unexpected polling place generation error: ${error}`
+                  );
+
+                /* istanbul ignore next - @preserve */
+                default:
+                  throwIllegalValue(error);
+              }
+            }
+          }
+
           return true;
         })
       );


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7872

Builds on https://github.com/votingworks/vxsuite/pull/8107, which covers the election import/clone paths.

For states with `EDIT_POLLING_PLACES` enabled:
- Automatically generate a single-precinct polling place with a matching name when a precinct is created.
- Remove polling place <> precinct connections when deleting precincts (already handled by DB).

No-op for states which have the `EDIT_POLLING_PLACES` turned off.

### Current tradeoffs:
- Not updating the name of the generated polling place when updating the precinct name, but that seems useful to do at some point. Polling places can also be edited after initial generation, so they may drift from the initial precinct - not sure yet if the added complexity's worth it.
- Not cleaning up polling places that are left empty after precinct deletion. Similar reasoning as above and matches the current behaviour when deleting the last district linked to given precinct. We've had some product discussion about pre-finalize checks we could introduce like "is every precinct covered by a polling place?" - could maybe include something there around a confirmation to drop empty polling places.

## Testing Plan
- New functional test case

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.