### PR TITLE
VxScan: Prevent events from escaping unrecoverableError state

### DIFF
--- a/apps/scan/backend/src/scanner.ts
+++ b/apps/scan/backend/src/scanner.ts
@@ -1305,7 +1305,15 @@ function buildMachine({
           },
         },
 
-        unrecoverableError: { id: 'unrecoverableError' },
+        unrecoverableError: {
+          id: 'unrecoverableError',
+          // Override root-level event handlers to prevent any transitions
+          // out of this terminal error state.
+          on: {
+            SCANNER_EVENT: {},
+            SCANNER_ERROR: {},
+          },
+        },
 
         shoeshineModeRescanningBallot: {
           initial: 'rescanning',

--- a/apps/scan/backend/src/scanner_scan.test.ts
+++ b/apps/scan/backend/src/scanner_scan.test.ts
@@ -765,3 +765,75 @@ test('if scanner status errors, show unrecoverable error', async () => {
     }
   );
 });
+
+// Without the SCANNER_ERROR override in unrecoverableError, a non-disconnect
+// error would escape to the resetting state (a recovery path) and attempt to
+// disconnect and reconnect.
+test('non-disconnect scanner errors absorbed in unrecoverable_error state', async () => {
+  await withApp(
+    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+      await configureApp(apiClient, mockAuth, mockUsbDrive);
+
+      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+      await waitForStatus(apiClient, { state: 'waiting_for_ballot' });
+
+      mockScanner.client.connect.mockResolvedValueOnce(
+        err({ code: 'other', message: 'still broken' })
+      );
+      mockScanner.emitEvent({
+        event: 'error',
+        code: 'other',
+        message: 'nusb error: Protocol error (os error 71)',
+      });
+      await waitForStatus(apiClient, { state: 'unrecoverable_error' });
+
+      // Mock a successful reset so that if the error escapes to the
+      // resetting state, the machine would recover.
+      mockScanner.client.connect.mockResolvedValueOnce(ok());
+      mockScanner.setScannerStatus(mockScannerStatus.idleScanningDisabled);
+      mockScanner.emitEvent({
+        event: 'error',
+        code: 'other',
+        message: 'another error',
+      });
+      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+      await waitForStatus(apiClient, { state: 'unrecoverable_error' });
+    }
+  );
+});
+
+// Without the SCANNER_ERROR override in unrecoverableError, a 'disconnected'
+// error would escape to the disconnected state (a recovery path) and attempt
+// to reconnect.
+test('disconnect scanner errors absorbed in unrecoverable_error state', async () => {
+  await withApp(
+    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+      await configureApp(apiClient, mockAuth, mockUsbDrive);
+
+      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+      await waitForStatus(apiClient, { state: 'waiting_for_ballot' });
+
+      mockScanner.client.connect.mockResolvedValueOnce(
+        err({ code: 'other', message: 'still broken' })
+      );
+      mockScanner.emitEvent({
+        event: 'error',
+        code: 'other',
+        message: 'nusb error: Protocol error (os error 71)',
+      });
+      await waitForStatus(apiClient, { state: 'unrecoverable_error' });
+
+      // Verify via connect mock since status polling alone doesn't
+      // reliably detect the escape with fake timers.
+      mockScanner.client.connect.mockClear();
+      mockScanner.emitEvent({
+        event: 'error',
+        code: 'disconnected',
+      });
+      clock.increment(delays.DELAY_RECONNECT);
+      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+      await waitForStatus(apiClient, { state: 'unrecoverable_error' });
+      expect(mockScanner.client.connect).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/apps/scan/backend/src/scanner_scan_cover_open.test.ts
+++ b/apps/scan/backend/src/scanner_scan_cover_open.test.ts
@@ -3,7 +3,7 @@ import {
   getFeatureFlagMock,
   BooleanEnvironmentVariableName,
 } from '@votingworks/utils';
-import { Result, deferred, ok } from '@votingworks/basics';
+import { Result, deferred, err, ok } from '@votingworks/basics';
 import { mockScannerStatus, ScannerError } from '@votingworks/pdi-scanner';
 import { configureApp, waitForStatus } from '../test/helpers/shared_helpers';
 import { delays } from './scanner';
@@ -87,6 +87,32 @@ test('cover open while jammed', async () => {
       mockScanner.emitEvent({ event: 'coverClosed' });
       clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
       await waitForStatus(apiClient, { state: 'waiting_for_ballot' });
+    }
+  );
+});
+
+test('coverOpen ignored in unrecoverable_error state', async () => {
+  await withApp(
+    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+      await configureApp(apiClient, mockAuth, mockUsbDrive);
+
+      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+      await waitForStatus(apiClient, { state: 'waiting_for_ballot' });
+
+      mockScanner.client.connect.mockResolvedValueOnce(
+        err({ code: 'other', message: 'still broken' })
+      );
+      mockScanner.emitEvent({
+        event: 'error',
+        code: 'other',
+        message: 'nusb error: Protocol error (os error 71)',
+      });
+      await waitForStatus(apiClient, { state: 'unrecoverable_error' });
+
+      // coverOpen should NOT escape unrecoverable_error
+      mockScanner.emitEvent({ event: 'coverOpen' });
+      clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
+      await waitForStatus(apiClient, { state: 'unrecoverable_error' });
     }
   );
 });


### PR DESCRIPTION
🤖 Generated with Claude Code

## Overview

In the VxScan scanner state machine, the `unrecoverableError` state is supposed
to be terminal — once you're there, the only recovery is restarting the
machine. However, root-level event handlers for `SCANNER_EVENT` and
`SCANNER_ERROR` could transition the machine out of this state:

- A `coverOpen` event would escape to the `coverOpen` state
- A scanner error would route to the `error` state, potentially triggering a
  reset attempt

This lead to some confusion when users would accidentally escape the restart screen by opening the scanner.

This PR adds local `on:` overrides to `unrecoverableError` that absorb all scanner
events and errors without transitioning.

## Testing Plan

Added tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
