### PR TITLE
fix(usb-drive): broaden mount.sh partition device filter

### DIFF
--- a/libs/usb-drive/scripts/mount.sh
+++ b/libs/usb-drive/scripts/mount.sh
@@ -11,20 +11,20 @@ if ! [[ $# -eq 1 ]]; then
     usage
 fi
 
-USB_DRIVE_DEVICE_REGEX='^/dev/sd[a-z][0-9]$'
-LOOP_DEVICE_REGEX='^/dev/loop[0-9]p[0-9]$'
+PARTITION_DEVICE_REGEX='^/dev/(sd[a-z]+[0-9]+|nvme[0-9]+n[0-9]+p[0-9]+|mmcblk[0-9]+p[0-9]+)$'
 
-if ! [[ $1 =~ $USB_DRIVE_DEVICE_REGEX || $1 =~ $LOOP_DEVICE_REGEX ]]; then
-    echo "mount.sh: device \"${1}\" is not a USB drive"
+if ! [[ $1 =~ $PARTITION_DEVICE_REGEX ]]; then
+    echo "mount.sh: \"${1}\" is not a recognized partition device"
     exit 1
 fi
 
 DEVICE=$1
-MOUNTPOINT=/media/vx/usb-drive
+DEVNAME=$(basename "$1")
+MOUNTPOINT=/media/vx/usb-drive-${DEVNAME}
 
 # If a drive was previously removed without being ejected first, it may leave a
 # "phantom" mounted drive - a mount entry for an inaccessible file system. Although
-# "phantom" drives do not cause problems for our application code, the system's 
+# "phantom" drives do not cause problems for our application code, the system's
 # file picker will confusingly show multiple drives with the same name. Thus,
 # before mounting, we check for a (probably "phantom") mounted drive and
 # unmount it if it exists.
@@ -35,6 +35,6 @@ fi
 
 # The mount point will already exist in production but possibly not in development
 if ! [[ -e $MOUNTPOINT ]]; then
-    mkdir -p $MOUNTPOINT 
+    mkdir -p $MOUNTPOINT
 fi
 mount -w -o umask=000,nosuid,nodev,noexec $DEVICE $MOUNTPOINT


### PR DESCRIPTION
## Overview

Extracted from #8057
Refs #7897

Look for more kinds of drives than simply those that show up as /dev/sd*. Also changes the mount point to include the partition name so multiple partitions may be mounted simultaneously.

## Demo Video or Screenshot

```sh
❯ lsblk
NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sda      8:0    0    4G  0 disk
└─sda1   8:1    0    4G  0 part
sdb      8:16   0    4G  0 disk
└─sdb1   8:17   0    4G  0 part
sr0     11:0    1 1024M  0 rom
vda    254:0    0  100G  0 disk
├─vda1 254:1    0   99G  0 part /
├─vda2 254:2    0    1K  0 part
└─vda5 254:5    0  975M  0 part [SWAP]

❯ sudo ./scripts/mount.sh /dev/sda1

❯ sudo ./scripts/mount.sh /dev/sdb1

❯ mount | rg /dev/sd
/dev/sda1 on /media/vx/usb-drive-sda1 type vfat (rw,nosuid,nodev,noexec,relatime,fmask=0000,dmask=0000,allow_utime=0022,codepage=437,iocharset=ascii,shortname=mixed,utf8,errors=remount-ro)
/dev/sdb1 on /media/vx/usb-drive-sdb1 type vfat (rw,nosuid,nodev,noexec,relatime,fmask=0000,dmask=0000,allow_utime=0022,codepage=437,iocharset=ascii,shortname=mixed,utf8,errors=remount-ro)

❯ ./bin/usb-drive watch
{"status":"mounted","mountPoint":"/media/vx/usb-drive-sda1"}
```

Since `libs/usb-drive` doesn't support multiple drives yet, only the first one is reported as expected.

## Testing Plan

Tested manually as shown above.