### PR TITLE
VxScan: Prevent scanner events from interrupting reset

### DIFF
--- a/apps/scan/backend/src/scanner.ts
+++ b/apps/scan/backend/src/scanner.ts
@@ -1277,6 +1277,11 @@ function buildMachine({
 
         resetting: {
           id: 'resetting',
+          // Prevent any further events from interrupting the reset
+          on: {
+            SCANNER_EVENT: {},
+            SCANNER_ERROR: {},
+          },
           initial: 'disconnecting',
           states: {
             disconnecting: {

--- a/apps/scan/backend/src/scanner_reset.test.ts
+++ b/apps/scan/backend/src/scanner_reset.test.ts
@@ -1,11 +1,15 @@
-import { err, ok } from '@votingworks/basics';
-import { mockScannerStatus } from '@votingworks/pdi-scanner';
+import { deferred, err, ok, Result } from '@votingworks/basics';
+import { mockScannerStatus, ScannerError } from '@votingworks/pdi-scanner';
 import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
 } from '@votingworks/utils';
 import { beforeEach, test, vi } from 'vitest';
-import { withApp, MockPdiScannerClient } from '../test/helpers/scanner_helpers';
+import {
+  ballotImages,
+  withApp,
+  MockPdiScannerClient,
+} from '../test/helpers/scanner_helpers';
 import { configureApp, waitForStatus } from '../test/helpers/shared_helpers';
 import { delays, RESET_COOLDOWN_MS } from './scanner';
 import { getCurrentTime } from './util/get_current_time';
@@ -94,6 +98,56 @@ test('goes to unrecoverable_error if error recurs within cooldown', async () => 
       await waitForStatus(apiClient, { state: 'waiting_for_ballot' });
       simulateNonDisconnectError(mockScanner);
       await waitForStatus(apiClient, { state: 'unrecoverable_error' });
+    }
+  );
+});
+
+test('scanner event during reset is ignored', async () => {
+  await withApp(
+    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+      await configureApp(apiClient, mockAuth, mockUsbDrive);
+
+      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+      await waitForStatus(apiClient, { state: 'waiting_for_ballot' });
+
+      const deferredConnect = deferred<Result<void, ScannerError>>();
+      mockScanner.client.connect.mockReturnValueOnce(deferredConnect.promise);
+      mockScanner.setScannerStatus(mockScannerStatus.idleScanningDisabled);
+      simulateNonDisconnectError(mockScanner);
+
+      await waitForStatus(apiClient, { state: 'resetting' });
+      mockScanner.emitEvent({
+        event: 'scanComplete',
+        images: await ballotImages.blankSheet(),
+      });
+      deferredConnect.resolve(ok());
+
+      await waitForStatus(apiClient, { state: 'waiting_for_ballot' });
+    }
+  );
+});
+
+test('scanner error during reset is ignored', async () => {
+  await withApp(
+    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
+      await configureApp(apiClient, mockAuth, mockUsbDrive);
+
+      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
+      await waitForStatus(apiClient, { state: 'waiting_for_ballot' });
+
+      const deferredConnect = deferred<Result<void, ScannerError>>();
+      mockScanner.client.connect.mockReturnValueOnce(deferredConnect.promise);
+      mockScanner.setScannerStatus(mockScannerStatus.idleScanningDisabled);
+      simulateNonDisconnectError(mockScanner);
+
+      await waitForStatus(apiClient, { state: 'resetting' });
+      mockScanner.emitEvent({
+        event: 'error',
+        code: 'scanFailed',
+      });
+      deferredConnect.resolve(ok());
+
+      await waitForStatus(apiClient, { state: 'waiting_for_ballot' });
     }
   );
 });


### PR DESCRIPTION
## Overview

🤖 Co-authored with Claude Code

Improvement to #8115

While resetting the connection to the scanner, we don't want to get interrupted by any further events/errors from the scanner, since they aren't relevant anymore. I haven't seen this happen, but it's theoretically possible.

This PR adds the same event guard pattern used in `unrecoverableError` (#8119) to the `resetting` state: override both SCANNER_EVENT and SCANNER_ERROR with no-op transitions so events are silently dropped.

## Demo Video or Screenshot

N/A

## Testing Plan

Two new tests in `scanner_reset.test.ts`:

- `scanComplete` emitted during reconnect phase → machine still recovers
-  scanner error emitted during reconnect phase → machine still recovers

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
