### PR TITLE
feat(usb-drive): add `getAllUsbDrives` with disk/partition hierarchy

### DIFF
--- a/libs/usb-drive/src/block_devices.test.ts
+++ b/libs/usb-drive/src/block_devices.test.ts
@@ -4,7 +4,9 @@ import { mockChildProcess } from '@votingworks/test-utils';
 import {
   BlockDeviceInfo,
   createUsbDriveMonitor,
+  getAllUsbDrives,
   getUsbDriveDeviceInfo,
+  UsbDiskDeviceInfo,
 } from './block_devices';
 import { exec, spawn } from './exec';
 
@@ -611,5 +613,180 @@ describe('createUsbDriveMonitor', () => {
     expect(() => proc.emit('error', new Error('spawn ENOENT'))).not.toThrow();
 
     monitor.stop();
+  });
+});
+
+describe('getAllUsbDrives', () => {
+  test('returns empty array when no USB block devices found', async () => {
+    execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    readFileMock.mockResolvedValueOnce('');
+
+    expect(await getAllUsbDrives()).toEqual([]);
+  });
+
+  test('returns empty array when udevadm fails', async () => {
+    execMock.mockRejectedValueOnce(new Error('udevadm failed'));
+    readFileMock.mockResolvedValueOnce('');
+
+    expect(await getAllUsbDrives()).toEqual([]);
+  });
+
+  test('returns disk with its partitions', async () => {
+    execMock.mockResolvedValueOnce({
+      stdout: [
+        exportDbEntry({
+          devname: '/dev/sdb',
+          devtype: 'disk',
+          vendor: 'SanDisk',
+          model: 'Ultra',
+          serial: 'ABC123',
+        }),
+        exportDbEntry({
+          devname: '/dev/sdb1',
+          devtype: 'partition',
+          fstype: 'vfat',
+          fsver: 'FAT32',
+          label: 'VxUSB-ABCDE',
+        }),
+      ].join('\n\n'),
+      stderr: '',
+    });
+    readFileMock.mockResolvedValueOnce(
+      procMountsContent([
+        { device: '/dev/sdb1', mountpoint: '/media/vx/usb-drive-sdb1' },
+      ])
+    );
+
+    const result = await getAllUsbDrives();
+
+    expect(result).toEqual([
+      {
+        devPath: '/dev/sdb',
+        vendor: 'SanDisk',
+        model: 'Ultra',
+        serial: 'ABC123',
+        partitions: [
+          {
+            devPath: '/dev/sdb1',
+            mountpoint: '/media/vx/usb-drive-sdb1',
+            fstype: 'vfat',
+            fsver: 'FAT32',
+            label: 'VxUSB-ABCDE',
+          },
+        ],
+      },
+    ]);
+  });
+
+  test('returns disk with empty partitions array when unformatted', async () => {
+    execMock.mockResolvedValueOnce(
+      exportDbOutput([{ devname: '/dev/sdb', devtype: 'disk' }])
+    );
+    readFileMock.mockResolvedValueOnce(procMountsContent());
+
+    const result = await getAllUsbDrives();
+
+    expect(result).toEqual<UsbDiskDeviceInfo[]>([
+      {
+        devPath: '/dev/sdb',
+        vendor: undefined,
+        model: undefined,
+        serial: undefined,
+        partitions: [],
+      },
+    ]);
+  });
+
+  test('returns multiple disks', async () => {
+    execMock.mockResolvedValueOnce({
+      stdout: [
+        exportDbEntry({ devname: '/dev/sdb', devtype: 'disk' }),
+        exportDbEntry({
+          devname: '/dev/sdb1',
+          devtype: 'partition',
+          fstype: 'vfat',
+          fsver: 'FAT32',
+          label: 'VxUSB-11111',
+        }),
+        exportDbEntry({ devname: '/dev/sdc', devtype: 'disk' }),
+        exportDbEntry({
+          devname: '/dev/sdc1',
+          devtype: 'partition',
+          fstype: 'vfat',
+          fsver: 'FAT32',
+          label: 'VxUSB-22222',
+        }),
+      ].join('\n\n'),
+      stderr: '',
+    });
+    readFileMock.mockResolvedValueOnce(procMountsContent());
+
+    const result = await getAllUsbDrives();
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ devPath: '/dev/sdb' });
+    expect(result[1]).toMatchObject({ devPath: '/dev/sdc' });
+  });
+
+  test('excludes LVM partitions from partitions list', async () => {
+    execMock.mockResolvedValueOnce({
+      stdout: [
+        exportDbEntry({ devname: '/dev/sdb', devtype: 'disk' }),
+        exportDbEntry({
+          devname: '/dev/sdb1',
+          devtype: 'partition',
+          fstype: 'LVM2_member',
+        }),
+      ].join('\n\n'),
+      stderr: '',
+    });
+    readFileMock.mockResolvedValueOnce(procMountsContent());
+
+    const result = await getAllUsbDrives();
+
+    // Disk is included but LVM partition is excluded
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      devPath: '/dev/sdb',
+      partitions: [],
+    });
+  });
+
+  test('excludes disks mounted outside /media', async () => {
+    execMock.mockResolvedValueOnce(
+      exportDbOutput([{ devname: '/dev/sdb', devtype: 'disk' }])
+    );
+    readFileMock.mockResolvedValueOnce(
+      procMountsContent([
+        { device: '/dev/sdb', mountpoint: '/home/user/mount' },
+      ])
+    );
+
+    const result = await getAllUsbDrives();
+
+    // Disk mounted outside /media is not a valid data drive
+    expect(result).toEqual([]);
+  });
+
+  test('treats drive as unmounted when /proc/mounts is unreadable', async () => {
+    execMock.mockResolvedValueOnce({
+      stdout: [
+        exportDbEntry({ devname: '/dev/sdb', devtype: 'disk' }),
+        exportDbEntry({
+          devname: '/dev/sdb1',
+          devtype: 'partition',
+          fstype: 'vfat',
+          fsver: 'FAT32',
+          label: 'VxUSB-ABCDE',
+        }),
+      ].join('\n\n'),
+      stderr: '',
+    });
+    readFileMock.mockRejectedValueOnce(new Error('/proc/mounts unreadable'));
+
+    const result = await getAllUsbDrives();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.partitions[0]).toMatchObject({ mountpoint: undefined });
   });
 });

--- a/libs/usb-drive/src/block_devices.ts
+++ b/libs/usb-drive/src/block_devices.ts
@@ -95,6 +95,28 @@ function isDataUsbDrive(blockDeviceInfo: BlockDeviceInfo): boolean {
   );
 }
 
+function isPartitionOfDisk(
+  partitionDevname: string,
+  diskDevname: string
+): boolean {
+  if (!partitionDevname.startsWith(diskDevname)) {
+    return false;
+  }
+
+  const suffix = partitionDevname.slice(diskDevname.length);
+
+  // Common Linux partition naming patterns:
+  // - /dev/sda1   (disk: /dev/sda, suffix: "1")
+  // - /dev/sda10  (disk: /dev/sda, suffix: "10")
+  // - /dev/nvme0n1p1 (disk: /dev/nvme0n1, suffix: "p1")
+  // - /dev/mmcblk0p1 (disk: /dev/mmcblk0, suffix: "p1")
+  if (suffix.length === 0) {
+    return false;
+  }
+
+  return /^[0-9]+$/.test(suffix) || /^p[0-9]+$/.test(suffix);
+}
+
 /**
  * Returns the device info for the USB drive, if it's a removable data drive.
  * Returns info for both partitioned drives (type 'part') and unpartitioned
@@ -118,28 +140,6 @@ export async function getUsbDriveDeviceInfo(): Promise<
   if (usbBlockDevices.length === 0) {
     debug('No USB block devices found in udev database');
     return undefined;
-  }
-
-  function isPartitionOfDisk(
-    partitionDevname: string,
-    diskDevname: string
-  ): boolean {
-    if (!partitionDevname.startsWith(diskDevname)) {
-      return false;
-    }
-
-    const suffix = partitionDevname.slice(diskDevname.length);
-
-    // Common Linux partition naming patterns:
-    // - /dev/sda1   (disk: /dev/sda, suffix: "1")
-    // - /dev/sda10  (disk: /dev/sda, suffix: "10")
-    // - /dev/nvme0n1p1 (disk: /dev/nvme0n1, suffix: "p1")
-    // - /dev/mmcblk0p1 (disk: /dev/mmcblk0, suffix: "p1")
-    if (suffix.length === 0) {
-      return false;
-    }
-
-    return /^[0-9]+$/.test(suffix) || /^p[0-9]+$/.test(suffix);
   }
 
   // Prefer partitions over their parent disks: skip disk entries that have
@@ -173,6 +173,111 @@ export async function getUsbDriveDeviceInfo(): Promise<
 
   debug(`Detected USB drive at ${dataUsbDrive.path}`);
   return dataUsbDrive;
+}
+
+export interface UsbPartitionDeviceInfo {
+  devPath: string;
+  mountpoint?: string;
+  fstype?: string;
+  fsver?: string;
+  label?: string;
+}
+
+export interface UsbDiskDeviceInfo {
+  devPath: string;
+  vendor?: string;
+  model?: string;
+  serial?: string;
+  partitions: UsbPartitionDeviceInfo[];
+}
+
+/**
+ * Returns all USB block devices as a structured disk → partitions hierarchy.
+ * Includes vendor/model/serial parsed from udev for each disk. Applies the
+ * same `isDataUsbDrive` filter as `getUsbDriveDeviceInfo`.
+ */
+export async function getAllUsbDrives(): Promise<UsbDiskDeviceInfo[]> {
+  const [exportDbOutput, mountsContent] = await Promise.all([
+    exec('udevadm', ['info', '--export-db'])
+      .then(({ stdout }) => stdout)
+      .catch(() => ''),
+    fs.readFile('/proc/mounts', 'utf-8').catch(() => ''),
+  ]);
+
+  const usbBlockDevices = parseExportDb(exportDbOutput);
+  if (usbBlockDevices.length === 0) {
+    debug('No USB block devices found in udev database');
+    return [];
+  }
+
+  const mountpoints = parseMountpoints(mountsContent);
+
+  const diskDevices = usbBlockDevices.filter((d) => d.devtype === 'disk');
+  const partitionDevices = usbBlockDevices.filter(
+    (d) => d.devtype === 'partition'
+  );
+
+  const result: UsbDiskDeviceInfo[] = [];
+
+  for (const disk of diskDevices) {
+    const diskInfo: BlockDeviceInfo = {
+      name: basename(disk.devname),
+      path: disk.devname,
+      type: 'disk',
+      mountpoint: mountpoints.get(disk.devname),
+      fstype: disk.fstype,
+      fsver: disk.fsver,
+      label: disk.label,
+    };
+
+    const diskPartitions = partitionDevices.filter((p) =>
+      isPartitionOfDisk(p.devname, disk.devname)
+    );
+
+    if (diskPartitions.length > 0) {
+      // Drive has partitions — only include valid data partitions
+      const validPartitions: UsbPartitionDeviceInfo[] = diskPartitions
+        .map(
+          (p): BlockDeviceInfo => ({
+            name: basename(p.devname),
+            path: p.devname,
+            type: 'part',
+            mountpoint: mountpoints.get(p.devname),
+            fstype: p.fstype,
+            fsver: p.fsver,
+            label: p.label,
+          })
+        )
+        .filter(isDataUsbDrive)
+        .map((p) => ({
+          devPath: p.path,
+          mountpoint: p.mountpoint,
+          fstype: p.fstype,
+          fsver: p.fsver,
+          label: p.label,
+        }));
+
+      result.push({
+        devPath: disk.devname,
+        vendor: disk.vendor,
+        model: disk.model,
+        serial: disk.serial,
+        partitions: validPartitions,
+      });
+    } else if (isDataUsbDrive(diskInfo)) {
+      // Unformatted drive (no partitions) — include it with empty partitions
+      result.push({
+        devPath: disk.devname,
+        vendor: disk.vendor,
+        model: disk.model,
+        serial: disk.serial,
+        partitions: [],
+      });
+    }
+  }
+
+  debug(`Found ${result.length} USB drive(s)`);
+  return result;
 }
 
 export interface UsbDriveMonitor {


### PR DESCRIPTION
## Overview

Extracted from #8057 
Refs #7897 

Adds a base USB drive API that can enumerate all drives and all their partitions.

## Demo Video or Screenshot

```js
> console.log(util.inspect(await require('./build/block_devices').getAllUsbDrives(), { depth: Infinity }))
[
  {
    devPath: '/dev/sda',
    vendor: 'QEMU',
    model: 'QEMU_HARDDISK',
    serial: '1-0000:00:02.1:00.0-5',
    partitions: [
      {
        devPath: '/dev/sda1',
        mountpoint: '/media/vx/usb-drive-sda1',
        fstype: 'vfat',
        fsver: 'FAT32',
        label: 'VxUSB-NMXPJ'
      }
    ]
  },
  {
    devPath: '/dev/sdb',
    vendor: 'QEMU',
    model: 'QEMU_HARDDISK',
    serial: '1-0000:00:02.1:00.0-6',
    partitions: [
      {
        devPath: '/dev/sdb1',
        mountpoint: '/media/vx/usb-drive-sdb1',
        fstype: 'vfat',
        fsver: 'FAT32',
        label: 'VxUSB'
      }
    ]
  }
]
```

## Testing Plan
- [x] New automated tests.
- [x] Manual testing as shown 
