### PR TITLE
VxDesign: Update precincts in place instead of deleting/re-inserting

### DIFF
--- a/apps/design/backend/src/app.polling_places.test.ts
+++ b/apps/design/backend/src/app.polling_places.test.ts
@@ -165,7 +165,7 @@ test('polling places CRUD', async () => {
   ]);
 });
 
-test('polling place updates on precinct creation/deletion', async () => {
+test('polling place updates on precinct creation/update/deletion', async () => {
   const user = nonVxUser;
   const jurisdiction = user.jurisdictions[1];
   expectEditingEnabled(jurisdiction, true);
@@ -234,6 +234,24 @@ test('polling place updates on precinct creation/deletion', async () => {
 
   expect(await api.listPollingPlaces({ electionId })).toEqual([
     // Alphabetically sorted:
+    customPlace1,
+    placeFromPrecinct1,
+    placeFromPrecinct2,
+  ]);
+
+  // Updating a precinct maintains polling place links:
+
+  expect(
+    await api.updatePrecinct({
+      electionId,
+      updatedPrecinct: {
+        ...precincts[0],
+        name: 'Precinct 1 (Updated)',
+      },
+    })
+  ).toEqual(ok());
+
+  expect(await api.listPollingPlaces({ electionId })).toEqual([
     customPlace1,
     placeFromPrecinct1,
     placeFromPrecinct2,

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -283,6 +283,16 @@ async function insertPrecinct(
     electionId,
     precinct.name
   );
+
+  await insertPrecinctDistrictsOrSplits(client, precinct);
+}
+
+async function insertPrecinctDistrictsOrSplits(
+  client: Client,
+  precinct: Precinct
+) {
+  await assertWithinTransaction(client);
+
   if (hasSplits(precinct)) {
     if (
       uniqueDeep(precinct.splits, (split) => split.districtIds.toSorted())
@@ -1679,21 +1689,31 @@ export class Store {
     try {
       await this.db.withClient((client) =>
         client.withTransaction(async () => {
-          // It's safe to delete and re-insert the precinct because:
-          // 1. The IDs of precincts/splits are stable
-          // 2. Precincts/splits are leaf nodes. There are no other tables with
-          // foreign keys that reference precincts/splits, so we don't need to
-          // worry about ON DELETE triggers.
           const { rowCount } = await client.query(
             `
-            delete from precincts
-            where id = $1 and election_id = $2
-          `,
+              update precincts set name = $1
+              where
+                id = $2
+                and election_id = $3
+            `,
+            precinct.name,
             precinct.id,
             electionId
           );
           assert(rowCount === 1, 'Precinct not found');
-          await insertPrecinct(client, electionId, precinct);
+
+          await client.query(
+            `delete from districts_precincts where precinct_id = $1`,
+            precinct.id
+          );
+
+          await client.query(
+            `delete from precinct_splits where precinct_id = $1`,
+            precinct.id
+          );
+
+          await insertPrecinctDistrictsOrSplits(client, precinct);
+
           return true;
         })
       );


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7872

Now that we have a links from polling places to precincts, it's no longer safe to delete/re-insert precincts when updating them. Updating the the `updatePrecinct` logic to edit the precinct in place instead. Still retaining the deletion for the leaf tables (`districts_precincts` and `precinct_splits`), but will likely  remove those as well when we add polling place -> precinct split links.

## Testing Plan
- Existing tests for precinct update, new test assertion for retained polling place link

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
