### PR TITLE
test(hmpb): bump CI timeout for all bubble ballot fixtures

### DIFF
--- a/libs/hmpb/src/all_bubble_ballot_fixtures.test.ts
+++ b/libs/hmpb/src/all_bubble_ballot_fixtures.test.ts
@@ -7,7 +7,7 @@ import { createPlaywrightRendererPool } from './playwright_renderer';
 import { RendererPool } from './renderer';
 
 vi.setConfig({
-  testTimeout: 40_000,
+  testTimeout: 50_000,
 });
 
 let rendererPool: RendererPool;


### PR DESCRIPTION

## Overview

I saw it time out with the 40s timeout in CI, so I'm bumping it up to 50s.

https://app.circleci.com/pipelines/github/votingworks/vxsuite/24755/workflows/aea5245a-7c54-401a-9af5-8cdcac43368e/jobs/1121127

## Demo Video or Screenshot
n/a

## Testing Plan
Automated CI.