### PR TITLE
Preserve global contest order in VxScan reports

### DIFF
--- a/libs/utils/src/tabulation/contest_filtering.test.ts
+++ b/libs/utils/src/tabulation/contest_filtering.test.ts
@@ -5,7 +5,7 @@ import {
   readElectionTwoPartyPrimaryDefinition,
   readElectionTwoPartyPrimary,
 } from '@votingworks/fixtures';
-import { find } from '@votingworks/basics';
+import { assert, find } from '@votingworks/basics';
 import {
   doesContestAppearOnPartyBallot,
   getContestIdsForBallotStyle,
@@ -91,35 +91,57 @@ test('getContestIdsForPrecinct', () => {
 test('getContestsForPrecinct', () => {
   const electionDefinition =
     electionPrimaryPrecinctSplitsFixtures.readElectionDefinition();
-  expect(
-    getContestsForPrecinct(
-      electionDefinition,
-      singlePrecinctSelectionFor('precinct-c1-w2')
-    ).map((c) => c.id)
-  ).toEqual([
+  const contestsForPrecinct = getContestsForPrecinct(
+    electionDefinition,
+    singlePrecinctSelectionFor('precinct-c1-w2')
+  );
+  expect(contestsForPrecinct.map((c) => c.id)).toEqual([
     'county-leader-mammal',
-    'congressional-1-mammal',
-    'water-2-fishing',
     'county-leader-fish',
+    'congressional-1-mammal',
     'congressional-1-fish',
+    'water-2-fishing',
   ]);
+
+  // Verify that getContestsForPrecinct preserves the global contest order
+  let lastContestIndex = -1;
+  for (const contest of contestsForPrecinct) {
+    const contestIndexInGlobalOrder =
+      electionDefinition.election.contests.findIndex(
+        (c) => c.id === contest.id
+      );
+    assert(contestIndexInGlobalOrder !== -1);
+    expect(contestIndexInGlobalOrder).toBeGreaterThan(lastContestIndex);
+    lastContestIndex = contestIndexInGlobalOrder;
+  }
 });
 
 test('getContestsForPrecinctAndElection', () => {
   const electionDefinition =
     electionPrimaryPrecinctSplitsFixtures.readElectionDefinition();
-  expect(
-    getContestsForPrecinctAndElection(
-      electionDefinition.election,
-      singlePrecinctSelectionFor('precinct-c1-w2')
-    ).map((c) => c.id)
-  ).toEqual([
+  const contestsForPrecinct = getContestsForPrecinctAndElection(
+    electionDefinition.election,
+    singlePrecinctSelectionFor('precinct-c1-w2')
+  );
+  expect(contestsForPrecinct.map((c) => c.id)).toEqual([
     'county-leader-mammal',
-    'congressional-1-mammal',
-    'water-2-fishing',
     'county-leader-fish',
+    'congressional-1-mammal',
     'congressional-1-fish',
+    'water-2-fishing',
   ]);
+
+  // Verify that getContestsForPrecinctAndElection preserves the global contest order
+  let lastContestIndex = -1;
+  for (const contest of contestsForPrecinct) {
+    const contestIndexInGlobalOrder =
+      electionDefinition.election.contests.findIndex(
+        (c) => c.id === contest.id
+      );
+    assert(contestIndexInGlobalOrder !== -1);
+    expect(contestIndexInGlobalOrder).toBeGreaterThan(lastContestIndex);
+    lastContestIndex = contestIndexInGlobalOrder;
+  }
 });
 
 describe('groupContestsByParty', () => {

--- a/libs/utils/src/tabulation/contest_filtering.ts
+++ b/libs/utils/src/tabulation/contest_filtering.ts
@@ -11,10 +11,7 @@ import {
   getPartyIdsWithContests,
 } from '@votingworks/types';
 import { assert, assertDefined, throwIllegalValue } from '@votingworks/basics';
-import {
-  createElectionMetadataLookupFunction,
-  getContestById,
-} from './lookups';
+import { createElectionMetadataLookupFunction } from './lookups';
 
 /**
  * Contests appear on ballots or not based on the district the contest is
@@ -89,8 +86,8 @@ export function mapContestIdsToContests(
   electionDefinition: ElectionDefinition,
   contestIds: Set<ContestId>
 ): AnyContest[] {
-  return [...contestIds].map((contestId) =>
-    getContestById(electionDefinition, contestId)
+  return electionDefinition.election.contests.filter((c) =>
+    contestIds.has(c.id)
   );
 }
 
@@ -125,14 +122,7 @@ export function getContestsForPrecinctAndElection(
   const lookupPrecinctToContestId = buildPrecinctContestIdsLookup(election);
   const contestIds = lookupPrecinctToContestId[precinctSelection.precinctId];
 
-  const lookupContestIdToContest: Record<ContestId, AnyContest> = {};
-  for (const contest of election.contests) {
-    lookupContestIdToContest[contest.id] = contest;
-  }
-
-  return Array.from(assertDefined(contestIds))
-    .map((id) => lookupContestIdToContest[id])
-    .filter((c): c is AnyContest => c !== undefined);
+  return election.contests.filter((c) => assertDefined(contestIds).has(c.id));
 }
 
 export interface PartyWithContests {


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/8135

In the recent March town/school elections in NH, we found that VxAdmin and VxScan reports display contests in different orders. VxAdmin displays in the expected global contest order, i.e., the order in the election definition. VxScan, however, displays grouped by precinct split (and within each precinct split following the global order), with the precinct splits themselves ordered alphabetically. Wasn't a deal breaker but did come up as a source of confusion. This PR fixes that.

## Demo Video or Screenshot

| Before | After |
| - | - |
| School candidate, school ballot measures, town candidate, town ballot measures - no school ballot measures in the example below but you get the idea | Town candidate, school candidate, town ballot measures, school ballot measures - no school ballot measures in the example below but you get the idea |
| <img width="400" alt="before" src="https://github.com/user-attachments/assets/f608c580-4f6f-4415-8ff7-6e4c2f7713a4" /> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/0c318d89-c90c-4acb-b852-7ec6961dc6b4" /> |

## Testing Plan

- [x] Updated automated tests
- [x] Tested manually

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates