### PR TITLE
VxScan: Increase scan timeout from 5s to 10s

### DIFF
--- a/apps/scan/backend/src/scanner.ts
+++ b/apps/scan/backend/src/scanner.ts
@@ -387,8 +387,7 @@ export interface Delays {
    */
   DELAY_RECONNECT: number;
   /**
-   * How long to attempt scanning before giving up and disconnecting and
-   * reconnecting to the scanner.
+   * How long to attempt scanning before giving up and declaring an error.
    */
   DELAY_SCANNING_TIMEOUT: number;
   /**
@@ -407,7 +406,7 @@ export const delays = {
   DELAY_SCANNING_ENABLED_POLLING_INTERVAL: 500,
   DELAY_SCANNER_STATUS_POLLING_INTERVAL: 500,
   DELAY_RECONNECT: 500,
-  DELAY_SCANNING_TIMEOUT: 5_000,
+  DELAY_SCANNING_TIMEOUT: 10_000,
   DELAY_ACCEPTING_TIMEOUT: 5_000,
   DELAY_AUTH_STATUS_POLLING_INTERVAL: 500,
 } satisfies Delays;


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Task: https://github.com/votingworks/vxsuite/issues/8063

Increase `DELAY_SCANNING_TIMEOUT` from 5s to 10s to protect against long running scan edge cases.

Analysis of 23,026 scans across 8 machines from the NH March 10, 2026 election found 1 scan that exceeded the 5s timeout (6.08s), causing an unrecoverable error that required a poll worker reboot. All 3 scans >3s in the dataset followed the same pattern: a short/partial scan left paper in an awkward position and the subsequent auto-started scan took abnormally long to complete.

Scan time statistics across the election:

- Median: 1.22s
- P99: 1.40s
- P99.9: 1.85s
- Max: 6.08s (the single timeout)

10s gives ample headroom for outlier scans without meaningfully delaying
detection of genuinely stuck scanners.

## Demo Video or Screenshot

N/A — one-line constant change.

## Testing Plan

- [x] Existing `scanner_scan.test.ts` tests pass (they reference the
      constant, not a hardcoded value)
- [x] Analyzed scan time data from 23,026 production scans to validate
      the new timeout

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
