### PR TITLE
fix(dev-dock): Add ThemeProvider to fix screenshot modal crash

### DIFF
--- a/libs/dev-dock/frontend/src/dev_dock.test.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.test.tsx
@@ -8,7 +8,13 @@ import {
   test,
   vi,
 } from 'vitest';
-import { screen, waitFor, within } from '@testing-library/react';
+import {
+  cleanup,
+  render as renderWithoutTheme,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import { assertDefined } from '@votingworks/basics';
 import userEvent from '@testing-library/user-event';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
@@ -363,6 +369,23 @@ test('Esc dismisses screenshot modal', async () => {
   await screen.findByText('Save Screenshot');
 
   userEvent.keyboard('{Escape}');
+  await waitFor(() => {
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+});
+
+test('screenshot modal renders without an outer ThemeProvider', async () => {
+  onTestFinished(cleanup);
+  renderWithoutTheme(<DevDock apiClient={mockApiClient} enableAccessibleNav />);
+  const screenshotButton = await screen.findByRole('button', {
+    name: 'Capture Screenshot',
+  });
+
+  document.title = 'VotingWorks VxAdmin';
+  userEvent.click(screenshotButton);
+  await screen.findByText('Save Screenshot');
+
+  userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
   await waitFor(() => {
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });

--- a/libs/dev-dock/frontend/src/dev_dock.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.tsx
@@ -26,7 +26,7 @@ import {
   isFeatureFlagEnabled,
   BooleanEnvironmentVariableName,
 } from '@votingworks/utils';
-import { Button, Modal, P } from '@votingworks/ui';
+import { Button, Modal, P, VxThemeProvider } from '@votingworks/ui';
 import { UsbDriveIcon } from './usb_drive_icon';
 import { Colors } from './colors';
 import { FujitsuPrinterMockControl } from './fujitsu_printer_mock';
@@ -415,7 +415,7 @@ interface ScreenshotToSaveProps {
 const ScreenshotModal = styled(Modal)`
   background-color: ${Colors.BACKGROUND};
   border-color: ${Colors.BORDER} !important;
-  color: ${Colors} !important;
+  color: ${Colors.TEXT} !important;
 `;
 
 function ScreenshotControls({
@@ -1060,10 +1060,12 @@ function DevDockWrapper({
     BooleanEnvironmentVariableName.ENABLE_DEV_DOCK
   ) ? (
     <QueryClientProvider client={createQueryClient()}>
-      <ApiClientContext.Provider value={apiClient}>
-        <DevDock enableAccessibleNav={enableAccessibleNav} />
-        {false && <ReactQueryDevtools initialIsOpen={false} />}
-      </ApiClientContext.Provider>
+      <VxThemeProvider colorMode="desktop" sizeMode="desktop">
+        <ApiClientContext.Provider value={apiClient}>
+          <DevDock enableAccessibleNav={enableAccessibleNav} />
+          {false && <ReactQueryDevtools initialIsOpen={false} />}
+        </ApiClientContext.Provider>
+      </VxThemeProvider>
     </QueryClientProvider>
   ) : null;
 }


### PR DESCRIPTION
## Overview

🤖 Co-authored with Claude Code

The DevDock's screenshot modal crashes on VxScan, VxMark, VxMarkScan, and VxCentralScan with `Cannot read properties of undefined (reading 'inverseBackground')`. This happens because the `Modal` component from `@votingworks/ui` needs a theme context, but the DevDock has no `ThemeProvider`. On the four voter-facing apps, the DevDock is rendered as a sibling of `App`, outside `AppBase`, so it has no theme.

**Fix:** Add a `VxThemeProvider` with locked `colorMode="desktop"` and `sizeMode="desktop"` to `DevDockWrapper`, so the DevDock always has its own theme regardless of app structure or voter accessibility settings.

## Demo Video or Screenshot

Before

https://github.com/user-attachments/assets/778f0b9a-ac89-4e16-8c86-ea8532b3e587

After

https://github.com/user-attachments/assets/6c5d91fa-a4cf-49e8-90fc-56b8c0b26932



## Testing Plan

- [x] New regression test renders DevDock without an outer ThemeProvider, opens the screenshot modal, and verifies it renders without crashing
- [x] Manual testing on VxScan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
