### PR TITLE
VxDesign: fix flaky districts_screen test

### DIFF
--- a/apps/design/frontend/test/api_helpers.tsx
+++ b/apps/design/frontend/test/api_helpers.tsx
@@ -57,7 +57,7 @@ export function mockStateFeatures(
 ): void {
   apiClient.getStateFeatures.reset();
   apiClient.getStateFeatures
-    .expectCallWith({ electionId })
+    .expectRepeatedCallsWith({ electionId })
     .resolves(features ?? {});
 }
 


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Overview

Fixes an [intermittently failing test in `districts_screen.test.tsx` ("editing or adding a district is disabled when ballots are finalized")](https://app.circleci.com/pipelines/github/votingworks/vxsuite/24882).

## Summary

`mockStateFeatures` used `expectCallWith` (single-call expectation) for the `getStateFeatures` query. Since react-query may or may not fire the query depending on render timing, `assertComplete()` in `afterEach` would sometimes fail with "Expected call but got none". Changed to `expectRepeatedCallsWith` which tolerates zero or more calls.

## Testing Plan

- [x] `pnpm --filter @votingworks/design-frontend test:run src/districts_screen.test.tsx` passes
- [x] Other tests using `mockStateFeatures` still pass

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.