### PR TITLE
CI: add --all-targets to clippy to lint test code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1375,10 +1375,10 @@ jobs:
       - run:
           name: Lint
           command: |
-            cargo clippy --manifest-path ./Cargo.toml
-            cargo clippy --manifest-path libs/ballot-interpreter/Cargo.toml
-            cargo clippy --manifest-path libs/types-rs/Cargo.toml
-            cargo clippy --manifest-path libs/pdi-scanner/Cargo.toml
+            cargo clippy --all-targets --manifest-path ./Cargo.toml
+            cargo clippy --all-targets --manifest-path libs/ballot-interpreter/Cargo.toml
+            cargo clippy --all-targets --manifest-path libs/types-rs/Cargo.toml
+            cargo clippy --all-targets --manifest-path libs/pdi-scanner/Cargo.toml
       - run:
           name: Test
           command: |

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -153,7 +153,7 @@ function generateTestJobForRustCrates(): string[] {
     `    - run:`,
     `        name: Lint`,
     `        command: |`,
-    ...cargoCommandLines('cargo clippy'),
+    ...cargoCommandLines('cargo clippy --all-targets'),
     `    - run:`,
     `        name: Test`,
     `        command: |`,


### PR DESCRIPTION
🤖 Generated with Claude Code

## Overview

Adds `--all-targets` to all four `cargo clippy` invocations in CI so that
clippy also lints `#[cfg(test)]` modules, integration tests, examples, and
benchmarks — not just lib/bin targets.

Without this flag, clippy warnings in test code go unnoticed in CI. We
discovered this when clippy warnings (e.g. `ignored_unit_patterns`,
`type_complexity`, `len_zero`) in pdi-scanner test code [passed CI but were
caught locally](https://github.com/votingworks/vxsuite/pull/8154#discussion_r2976343194).

## Demo Video or Screenshot

## Testing Plan

- Verified all four Rust crates pass `cargo clippy --all-targets` locally
- Verified that a deliberate lint violation in a `#[cfg(test)]` module is
  caught with `--all-targets` but invisible without it

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
