### PR TITLE
test(ui): fix flaky dual-language ballot style test

### DIFF
--- a/libs/ui/src/bmd_paper_ballot.dual_language.test.tsx
+++ b/libs/ui/src/bmd_paper_ballot.dual_language.test.tsx
@@ -327,13 +327,18 @@ describe('English ballot style', () => {
     // Change app-wide language to Spanish to verify ballot language is not
     // affected:
     act(() => getLanguageContext()!.setLanguage('es-US'));
-    await waitFor(() =>
-      expect(getLanguageContext()?.currentLanguageCode).toEqual('es-US')
-    );
 
-    expect(container).not.toHaveTextContent(
-      new RegExp(getMockUiStringPrefix('es-US'))
-    );
+    // Wait for both the language context update and all cascading re-renders
+    // to settle. The language change triggers async effects in UiStringsLoader
+    // (via i18next resource updates and react-i18next re-renders), which can
+    // cause transient intermediate render states where LanguageOverride's
+    // nested context hasn't yet propagated to its children.
+    await waitFor(() => {
+      expect(getLanguageContext()?.currentLanguageCode).toEqual('es-US');
+      expect(container).not.toHaveTextContent(
+        new RegExp(getMockUiStringPrefix('es-US'))
+      );
+    });
   });
 
   test('no votes', async () => {


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Overview

Fixes a flaky test: `English ballot style > all votes filled in` in `bmd_paper_ballot.dual_language.test.tsx`.

Evidence of flake: [pipeline #24923](https://app.circleci.com/pipelines/github/votingworks/vxsuite/24923) — `test-libs-ui` failed then passed on the same commit.

## Cause

After `setLanguage('es-US')`, two assertions ran in separate blocks: a `waitFor` confirmed the language context switched, then a synchronous `expect(container)` checked the DOM. Between those two checks there's a transient render window — the outer `FrontendLanguageContextProvider` has updated to `es-US` but `LanguageOverride`'s nested context hasn't yet re-rendered its children back to `en`. The synchronous assertion can catch this intermediate state.

## Fix

Combine both assertions into a single `waitFor` so they're checked atomically after all cascading re-renders settle.

## Testing Plan

- [x] `pnpm --filter @votingworks/ui test:run src/bmd_paper_ballot.dual_language.test.tsx`

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.