### PR TITLE
ballot-interpreter: Fix off-by-one error in vertical streak coalesce

### DIFF
--- a/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
@@ -546,6 +546,36 @@ mod test {
         assert_eq!(coalesced, (l, r));
     }
 
+    proptest::proptest! {
+        #[test]
+        fn coalesce_result_is_consistent(
+            a_start in 0..=1000i32,
+            a_len in 0..=20u32,
+            b_start in 0..=1000i32,
+            b_len in 0..=20u32,
+        ) {
+            let a_end = a_start + a_len as PixelPosition;
+            let b_end = b_start + b_len as PixelPosition;
+            let a = make_streak(a_start..=a_end);
+            let b = make_streak(b_start..=b_end);
+            let gap = (*a.x_range.start().max(b.x_range.start()))
+                - (*a.x_range.end().min(b.x_range.end()));
+            match a.coalesce(b) {
+                Ok(merged) => {
+                    assert!(gap <= 1, "non-adjacent streaks should not coalesce");
+                    assert_eq!(*merged.x_range.start(), a_start.min(b_start));
+                    assert_eq!(*merged.x_range.end(), a_end.max(b_end));
+                    let expected_len = (*merged.x_range.end() - *merged.x_range.start() + 1) as usize;
+                    assert_eq!(merged.scores.len(), expected_len);
+                    assert_eq!(merged.longest_white_gaps.len(), expected_len);
+                }
+                Err(_) => {
+                    assert!(gap > 1, "adjacent/overlapping streaks should coalesce");
+                }
+            }
+        }
+    }
+
     #[test]
     fn test_find_scanned_document_inset_ballot_image() {
         let image_bytes = include_bytes!("../../test/fixtures/scan-inset.jpeg");


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Fix a panic in `VerticalStreak::coalesce()` during ballot interpretation that caused `unrecoverableError` on a VxScan in production.

The original code subtracted `overlap_size` from both the left and right score/gap slices when merging adjacent or overlapping vertical streaks. This had two bugs:

- **Adjacent streaks** (`overlap_size=0`): `scores[..=scores.len()]` accessed 1 past the end, panicking with `range end index N out of range for slice of length M` (this is the bug we saw in the field)
- **Overlapping streaks** (`overlap_size≥1`): silently dropped columns' worth of scores from the result (not a big deal, but still incorrect)

### Example: adjacent streaks

Two streaks detected at columns `0..=6` (7 scores) and `7..=10` (4 scores) are adjacent — they touch but don't overlap, so `overlap_size = 0`.

The original code did:

```rust
scores: [
    &self.scores[..=self.scores.len() - overlap_size],  // scores[..=7] — panic!
    &other.scores[overlap_size..],
].concat()
```

`scores[..=7]` is an inclusive range requesting 8 elements from a 7-element slice → `range end index 8 out of range for slice of length 7`.

## Demo Video or Screenshot

N/A

## Testing Plan

- Added 5 unit tests for `coalesce`: adjacent, overlapping, self-contains-other, other-contains-self, non-adjacent
- Adjacent test reproduces the exact production panic when run against the original code

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
