### PR TITLE
[Scan] Bump up the number of pulseaudio connection retries

### DIFF
--- a/apps/scan/backend/src/audio/card.test.ts
+++ b/apps/scan/backend/src/audio/card.test.ts
@@ -4,12 +4,13 @@ import {
   AUDIO_DEVICE_DEFAULT_SINK,
   AudioCardProfile,
   getAudioCardName,
+  GetAudioCardNameParams,
   setAudioCardProfile,
   SetAudioCardProfileParams,
   setAudioVolume,
 } from '@votingworks/backend';
 import { err, ok } from '@votingworks/basics';
-import { AudioCard } from './card';
+import { AudioCard, MAX_CARD_DETECTION_RETRIES } from './card';
 import { NODE_ENV } from '../globals';
 
 vi.mock('@votingworks/backend');
@@ -18,6 +19,18 @@ const mockSetProfile = vi.mocked(setAudioCardProfile);
 const mockSetVolume = vi.mocked(setAudioVolume);
 
 const cardName = 'test.pci';
+
+test('default()', async () => {
+  const logger = mockLogger({ fn: vi.fn });
+  mockGetCardName.mockResolvedValueOnce(ok(cardName));
+
+  await AudioCard.default('production', logger);
+  expect(mockGetCardName).toHaveBeenCalledWith<[GetAudioCardNameParams]>({
+    logger,
+    nodeEnv: 'production',
+    maxRetries: MAX_CARD_DETECTION_RETRIES,
+  });
+});
 
 test('setVolume()', async () => {
   const logger = mockLogger({ fn: vi.fn });

--- a/apps/scan/backend/src/audio/card.ts
+++ b/apps/scan/backend/src/audio/card.ts
@@ -8,7 +8,13 @@ import {
 import { Logger } from '@votingworks/logging';
 import { NODE_ENV } from '../globals';
 
-export const MAX_OUTPUT_CHANGE_RETRIES = 3;
+/**
+ * Last round of testing done on a v4 VxComputer with HWTA running.
+ * Over 10 reboots, the number of retries before successful connection to the
+ * pulseaudio service ranged from 3 to 4. Setting the max a little higher to be
+ * safe.
+ */
+export const MAX_CARD_DETECTION_RETRIES = 6;
 
 export class AudioCard {
   constructor(
@@ -21,7 +27,11 @@ export class AudioCard {
     nodeEnv: typeof NODE_ENV,
     logger: Logger
   ): Promise<AudioCard> {
-    const nameRes = await getAudioCardName({ logger, maxRetries: 3, nodeEnv });
+    const nameRes = await getAudioCardName({
+      logger,
+      maxRetries: MAX_CARD_DETECTION_RETRIES,
+      nodeEnv,
+    });
     const name = nameRes.assertOk('audio card detection failed');
 
     return new AudioCard(nodeEnv, logger, { name });


### PR DESCRIPTION
## Overview

Followup to https://github.com/votingworks/vxsuite/issues/8148

Discovered while testing the production HWTA that the pulseaudio service is usually taking longer to startup than the previous number of connection retries allowed for, causing initial configuration of the server-side audio player to give up and fail. This meant audio playback only worked for sounds played via the client.

Bumping up the number of retries (which happen with increasing delays between each attempt) to 6. 

## Testing Plan
- Bumped retries to 10 on an unsigned VxScan HWTA image and rebooted a few times to check logged retries. Verified audio playing through both the screen and headphones.
