### PR TITLE
build(logging-utils): restore unformatted state of generated file

### DIFF
--- a/libs/logging-utils/index.d.ts
+++ b/libs/logging-utils/index.d.ts
@@ -11,15 +11,15 @@
  * the output file cannot be written, or the CDF JSON cannot be serialized.
  */
 export declare function convertVxLogToCdf(
-  log: (
-    eventId: import('@votingworks/logging').LogEventId,
-    message: string,
-    disposition: import('@votingworks/logging').LogDisposition
-  ) => void,
-  source: import('@votingworks/logging').LogSource,
-  machineId: string,
-  codeVersion: string,
-  inputPath: string,
-  outputPath: string,
-  compressed: boolean
-): Promise<void>;
+log: (
+eventId: import('@votingworks/logging').LogEventId,
+message: string,
+disposition: import('@votingworks/logging').LogDisposition
+) => void,
+source: import('@votingworks/logging').LogSource,
+machineId: string,
+codeVersion: string,
+inputPath: string,
+outputPath: string,
+compressed: boolean,
+): Promise<void>


### PR DESCRIPTION
Generated with [Claude Code](https://claude.com/claude-code)

## Summary
- Restores the unformatted state of `libs/logging-utils/index.d.ts`, which should have been included in #8164

## Test plan
- No behavior change — formatting only on a generated `.d.ts` file