### PR TITLE
VxDesign: fix test flake in districts_screen.test

### DIFF
--- a/apps/design/frontend/src/districts_screen.test.tsx
+++ b/apps/design/frontend/src/districts_screen.test.tsx
@@ -61,7 +61,9 @@ beforeEach(() => {
   apiMock.getUser.expectCallWith().resolves(user);
   mockUserFeatures(apiMock);
 
-  mockStateFeatures(apiMock, electionId);
+  apiMock.getStateFeatures
+    .expectOptionalRepeatedCallsWith({ electionId })
+    .resolves({});
   apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
   apiMock.getElectionInfo
     .expectRepeatedCallsWith({ electionId })


### PR DESCRIPTION
## Overview

Generated with [Claude Code](https://claude.com/claude-code)

- Fix test flake in `districts_screen.test.tsx` by replacing `mockStateFeatures` with an explicit `expectOptionalRepeatedCallsWith` call for `getStateFeatures`, which properly handles non-deterministic call timing.

## Demo Video or Screenshot

N/A — test-only change.

## Testing Plan

```sh
pnpm --filter @votingworks/design-frontend test:run apps/design/frontend/src/districts_screen.test.tsx
```

Verify the test passes reliably (no flakes).

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.