### PR TITLE
[Scan] Add a brief delay after switching audio outputs

### DIFF
--- a/libs/backend/src/system_call/set_audio_card_profile.test.ts
+++ b/libs/backend/src/system_call/set_audio_card_profile.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import { LogEventId, mockLogger } from '@votingworks/logging';
 import { err, ok } from '@votingworks/basics';
@@ -14,6 +14,14 @@ const mockPactl = vi.mocked(pactl);
 
 const cardName = 'alsa_output.pci';
 
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 test('happy path', async () => {
   mockPactl.mockResolvedValue(ok(''));
 
@@ -26,6 +34,8 @@ test('happy path', async () => {
     nodeEnv: 'production',
     profile,
   });
+
+  await vi.runAllTimersAsync();
   expect(await result).toEqual(ok());
 
   expect(mockPactl).toHaveBeenCalledExactlyOnceWith('production', logger, [
@@ -41,13 +51,15 @@ test('happy path', async () => {
 });
 
 test('is no-op in dev', async () => {
-  const result = await setAudioCardProfile({
+  const result = setAudioCardProfile({
     cardName,
     logger: mockLogger({ fn: vi.fn }),
     nodeEnv: 'development',
     profile: AudioCardProfile.HDMI,
   });
-  expect(result).toEqual(ok());
+
+  await vi.runAllTimersAsync();
+  expect(await result).toEqual(ok());
   expect(mockPactl).not.toHaveBeenCalled();
 });
 
@@ -62,6 +74,8 @@ test('pactl error', async () => {
     nodeEnv: 'production',
     profile: AudioCardProfile.ANALOG,
   });
+
+  await vi.runAllTimersAsync();
   expect(await res).toEqual<SetAudioCardProfileResult>(
     err(expect.stringContaining(error))
   );

--- a/libs/backend/src/system_call/set_audio_card_profile.ts
+++ b/libs/backend/src/system_call/set_audio_card_profile.ts
@@ -1,4 +1,4 @@
-import { ok, Result } from '@votingworks/basics';
+import { ok, Result, sleep } from '@votingworks/basics';
 import { LogEventId, Logger } from '@votingworks/logging';
 import type { NODE_ENV } from '../scan_globals';
 import { pactl } from './pulse_audio';
@@ -53,6 +53,14 @@ export async function setAudioCardProfile(
     disposition: 'success',
     message: `audio output set to ${p.profile}`,
   });
+
+  /**
+   * We've noticed a slight delay in profile switching taking effect when
+   * testing on a production VxScan, causing sounds targeting one output to
+   * briefly play through the previous output. This provides a bit of buffer
+   * to allow for things to settle before playing audio.
+   */
+  await sleep(500);
 
   return ok();
 }


### PR DESCRIPTION
## Overview

Context in [Slack thread](https://votingworks.slack.com/archives/CJU9MSC6S/p1774543903877639)

When we switch between audio profiles/outputs, it seems to take a brief amount of time before the output is fully initialized and ready to play audio, so sounds play in the previous output briefly before actually switching over. Adding a delay after every profile switch to hopefully try to make up for this gap.

Trying to strike a balance between delaying long enough for the output to be ready and not having too long of a pause between visual and audio feedback, but we can increase this as needed.

## Testing Plan
- Verified the client waits until the server audio is done playing and the delay is resolved before resuming TTS audio.
- Will need proper verification on a full production setup WRT whether the delay is enough.

