### PR TITLE
docs: add no-shell-exec rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,11 @@ fn.assertComplete(); // verify all expected calls were made (usually in afterEac
 - **React** — functional components only, with hooks; components return
   `JSX.Element`
 - **Styled-components** — for all CSS-in-JS styling
+- **No shell-interpreted child processes** — never use `exec`, `execSync`,
+  `spawn`, or `spawnSync` from `node:child_process`. Always use `execFile`,
+  `execFileSync`, `fork`, or the `exec` helper in `libs/usb-drive/src/exec.ts`
+  (which wraps `execFile`). Shell-interpreted variants pass arguments through a
+  shell, which invites command injection.
 - **Do not add comments** where the code is self-evident or self-documenting.
   Only add comments where the logic is non-obvious or requires context that
   isn't clear from the code itself.


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## Overview

Add a coding style rule requiring `execFile`/`execFileSync` instead of
`exec`/`execSync`/`spawn`/`spawnSync` from `node:child_process`. The
shell-interpreted variants pass arguments through a shell, which invites
command injection.

## Testing Plan

- [ ] Verify the rule renders correctly in CLAUDE.md

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.