### PR TITLE
Adjust audio output switch delay given further testing (500ms to 300ms)

### DIFF
--- a/libs/backend/src/system_call/set_audio_card_profile.ts
+++ b/libs/backend/src/system_call/set_audio_card_profile.ts
@@ -60,7 +60,7 @@ export async function setAudioCardProfile(
    * briefly play through the previous output. This provides a bit of buffer
    * to allow for things to settle before playing audio.
    */
-  await sleep(500);
+  await sleep(300);
 
   return ok();
 }


### PR DESCRIPTION
## Overview

A follow-up to https://github.com/votingworks/vxsuite/pull/8189, testing on a build in the context of an image has revealed that we can get by with a slightly shorter delay, 300ms instead of 500ms. My full notes:

| Sleep | Description |
| :- | :- |
| No sleep | Speaker sound begins faded |
| sleep(0) | Speaker sound begins faded |
| sleep(100) | Speaker sound begins faded |
| sleep(200) | Speaker sound begins faded |
| sleep(250) | Speaker sound is okay. Maybe because I'm aware of this issue, I still occasionally hear a slight fade in. |
| sleep(300) | No perceptible fade-in and feels better/snappier than sleep(500) |
| sleep(500) | No perceptible fade-in but sometimes feels delayed. Makes sense given the common wisdom that 250ms is the avg human reaction time to stimulus. |

## Demo Video or Screenshot

Reminder that sleeps are not perfectly precise and there'll be some natural timing variation from scan to scan.

### Before (500ms)

https://github.com/user-attachments/assets/65d2b44c-ba52-4d81-b91a-f8bc95ac13b7

### After (300ms)

https://github.com/user-attachments/assets/cb3cbb7c-4791-428d-a57b-29dcac454c0e

## Testing Plan

- [x] Manual

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.