### PR TITLE
[Scan] Use all availalble system volume headroom for headphones

### DIFF
--- a/apps/scan/backend/src/electrical_testing/server.ts
+++ b/apps/scan/backend/src/electrical_testing/server.ts
@@ -94,12 +94,8 @@ export async function startElectricalTestingServer(
 
 async function configureAudio(logger: Logger): Promise<AudioPlayer> {
   const audioCard = await AudioCard.default(NODE_ENV, logger);
-
-  // This is set to 100% in the prod app, but the HWTA has no UI volume
-  // control at the moment, so this is set to a safe listening level
-  // discovered the hard way:
   await audioCard.useHeadphones();
-  await audioCard.setVolume(40);
+  await audioCard.setVolume(150);
 
   return new AudioPlayer(NODE_ENV, logger, audioCard);
 }

--- a/apps/scan/backend/src/server.test.ts
+++ b/apps/scan/backend/src/server.test.ts
@@ -120,7 +120,7 @@ test('configures audio device', async () => {
   });
 
   expect(mockAudioCard.useHeadphones).toHaveBeenCalledOnce();
-  expect(mockAudioCard.setVolume).toHaveBeenCalledExactlyOnceWith(100);
+  expect(mockAudioCard.setVolume).toHaveBeenCalledExactlyOnceWith(150);
 });
 
 test('throws if unable to set volume', async () => {

--- a/apps/scan/backend/src/server.ts
+++ b/apps/scan/backend/src/server.ts
@@ -71,9 +71,12 @@ export async function start({
   const audioCard = await AudioCard.default(NODE_ENV, logger);
 
   // Screen reader volume levels are calibrated against a maximum system
-  // volume setting:
+  // volume setting.
+  // NOTE: pulseaudio outputs can be pushed a little higher than 100%
+  // to account for the builtin headroom, which we make use of to get a
+  // workable volume baseline for VxScan:
   await audioCard.useHeadphones();
-  await audioCard.setVolume(100);
+  await audioCard.setVolume(150);
 
   const audioPlayer = new AudioPlayer(NODE_ENV, logger, audioCard);
 

--- a/libs/backend/src/system_call/set_audio_volume.test.ts
+++ b/libs/backend/src/system_call/set_audio_volume.test.ts
@@ -68,16 +68,16 @@ test('invalid value', async () => {
       sinkName: 'usb.stereo',
       volumePct: -1,
     })
-  ).rejects.toThrow('Audio volume must be between 0 and 100');
+  ).rejects.toThrow('Audio volume must be between 0 and 150');
 
   await expect(
     setAudioVolume({
       logger: mockLogger({ fn: vi.fn }),
       nodeEnv: 'production',
       sinkName: 'usb.stereo',
-      volumePct: 100.1,
+      volumePct: 150.1,
     })
-  ).rejects.toThrow('Audio volume must be between 0 and 100');
+  ).rejects.toThrow('Audio volume must be between 0 and 150');
 });
 
 test('execFile error', async () => {

--- a/libs/backend/src/system_call/set_audio_volume.ts
+++ b/libs/backend/src/system_call/set_audio_volume.ts
@@ -34,8 +34,8 @@ export async function setAudioVolume(params: {
   let errorOutput: string;
 
   assert(
-    volumePct >= 0 && volumePct <= 100,
-    'Audio volume must be between 0 and 100'
+    volumePct >= 0 && volumePct <= 150,
+    'Audio volume must be between 0 and 150'
   );
 
   try {


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->

TODO

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
