### PR TITLE
fix(pdi-scanner): reset USB device on connect to prevent image corruption

### DIFF
--- a/libs/pdi-scanner/src/rust/scanner.rs
+++ b/libs/pdi-scanner/src/rust/scanner.rs
@@ -126,24 +126,38 @@ impl Scanner {
 /// Fails if the device is not found, cannot be opened, or the interface
 /// cannot be claimed.
 fn open_usb_interface() -> Result<nusb::Interface> {
+    const INTERFACE: u8 = 0;
+
+    let device = find_pdi_device()?;
+
+    // Reset the USB device to prevent possible image corruption on the first
+    // scan after reconnection. Without this, the first scan may produce images
+    // with a horizontal pixel offset and dark bands at the top — we hypothesize
+    // this is due to stale data in the scanner's internal buffer. The reset
+    // triggers a USB bus reset and forces the device to re-enumerate.
+    device.reset()?;
+
+    // reset() invalidates the device handle, so re-find the device.
+    let device = find_pdi_device()?;
+    device.set_configuration(1)?;
+    let scanner_interface = device.detach_and_claim_interface(INTERFACE)?;
+    tracing::debug!("Connected to PDI scanner and claimed interface {INTERFACE}");
+
+    Ok(scanner_interface)
+}
+
+fn find_pdi_device() -> Result<nusb::Device> {
     /// Vendor ID for the PDI scanner.
     const VENDOR_ID: u16 = 0x0bd7;
 
     /// Product ID for the PDI scanner.
     const PRODUCT_ID: u16 = 0xa002;
 
-    const INTERFACE: u8 = 0;
-
-    let mut devices = nusb::list_devices()?;
-    let device = devices
-        .find(|device| device.vendor_id() == VENDOR_ID && device.product_id() == PRODUCT_ID)
+    nusb::list_devices()?
+        .find(|d| d.vendor_id() == VENDOR_ID && d.product_id() == PRODUCT_ID)
         .ok_or(UsbError::DeviceNotFound)?
-        .open()?;
-    device.set_configuration(1)?;
-    let scanner_interface = device.detach_and_claim_interface(INTERFACE)?;
-    tracing::debug!("Connected to PDI scanner and claimed interface {INTERFACE}");
-
-    Ok(scanner_interface)
+        .open()
+        .map_err(Into::into)
 }
 
 /// Spawns a background task that bridges USB I/O with in-process channels.


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Fixes possible image corruption on the first scan after a USB disconnect/reconnect cycle (e.g., after the scanner state machine's soft reset flow, or after restarting the backend service).

**Problem:** The first scan after reconnection may produce corrupted images with a horizontal pixel offset and dark bands at the top. We hypothesize this is due to stale data in the scanner firmware's internal buffer that gets mixed into the scan's image stream.

**Fix:** Send a USB bus reset (via `nusb::Device::reset()`) on every connect, before claiming the interface. This forces the device to re-enumerate, clearing the stale state.

**Latency:** The reset adds ~100ms to the connect flow (typical ~340ms vs ~233ms without). Occasional outliers around ~530ms. Connects happen at app startup and on error recovery, so this is negligible.

## Testing Plan

- [x] Hardware test: cover open mid-scan -> soft reset -> scan. First scan after reset should be clean (no vertical streaks / horizontal offset).

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
