### PR TITLE
fix(central-scan): fix flaky logger assertions in grout tests

### DIFF
--- a/apps/central-scan/backend/src/app.grout.test.ts
+++ b/apps/central-scan/backend/src/app.grout.test.ts
@@ -172,7 +172,7 @@ test('unconfigure', async () => {
     store.setScannerBackedUp(true);
     await apiClient.unconfigure();
     expect(store.getBallotsCounted()).toEqual(0);
-    expect(logger.log).toHaveBeenLastCalledWith(
+    expect(logger.log).toHaveBeenCalledWith(
       LogEventId.ElectionUnconfigured,
       'unknown',
       {
@@ -346,7 +346,7 @@ test('configure with CDF election', async () => {
     expect(electionRecord?.electionDefinition.election.id).toEqual(
       electionGeneral.id
     );
-    expect(logger.log).toHaveBeenLastCalledWith(
+    expect(logger.log).toHaveBeenCalledWith(
       LogEventId.ElectionConfigured,
       'election_manager',
       {
@@ -375,7 +375,7 @@ test('configure with invalid file', async () => {
     expect(await apiClient.configureFromElectionPackageOnUsbDrive()).toEqual(
       err({ type: 'election_key_mismatch' })
     );
-    expect(logger.log).toHaveBeenLastCalledWith(
+    expect(logger.log).toHaveBeenCalledWith(
       LogEventId.ElectionConfigured,
       'election_manager',
       expect.objectContaining({


### PR DESCRIPTION
Generated with [Claude Code](https://claude.com/claude-code)

## Overview

Three `toHaveBeenLastCalledWith` assertions on `logger.log` in `apps/central-scan/backend/src/app.grout.test.ts` were changed to `toHaveBeenCalledWith`. Background diagnostic-complete log events can fire after the asserted event, making `toHaveBeenLastCalledWith` non-deterministic and causing flaky test failures.

## Demo Video or Screenshot

N/A

## Testing Plan

- Ran the full central-scan backend test suite (`pnpm test:run`); all 14 tests pass.
- The fix ensures assertions check that the expected log call happened at any point, rather than requiring it to be the last call.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.