### PR TITLE
Dev dock: auto-detect election packages from mock USB drive

### DIFF
--- a/libs/backend/src/election_package/election_package_io.ts
+++ b/libs/backend/src/election_package/election_package_io.ts
@@ -290,7 +290,8 @@ export async function readElectionPackageFromFile(
   return result.isErr() ? result : ok({ ...result.ok(), fileContents });
 }
 
-async function getMostRecentElectionPackageFilepath(
+/** Finds the most recent election package ZIP on a mounted USB drive. */
+export async function getMostRecentElectionPackageFilepath(
   usbDrive: UsbDrive
 ): Promise<Result<string, ElectionPackageConfigurationError>> {
   const usbDriveStatus = await usbDrive.status();

--- a/libs/dev-dock/backend/package.json
+++ b/libs/dev-dock/backend/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@votingworks/auth": "workspace:*",
+    "@votingworks/backend": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/fs": "workspace:*",
     "@votingworks/fujitsu-thermal-printer": "workspace:*",

--- a/libs/dev-dock/backend/src/dev_dock_api.test.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.test.ts
@@ -45,7 +45,6 @@ import {
   useDevDockRouter,
   MockSpec,
   MockBatchScannerApi,
-  DEFAULT_DEV_DOCK_ELECTION_INPUT_PATH,
   DEV_DOCK_ELECTION_FILE_NAME,
   PdiScannerStatus,
 } from './dev_dock_api';
@@ -208,9 +207,8 @@ test('election fixture references', async () => {
     apiClient.getCurrentFixtureElectionPaths()
   ).resolves.toMatchObject(
     expectedFixtures.map(({ path, title }) => ({
+      title: expect.stringContaining(title),
       inputPath: expect.stringContaining(path),
-      title,
-      resolvedPath: expect.any(String),
     }))
   );
 });
@@ -222,7 +220,6 @@ test('election setting', async () => {
   const defaultElection = await apiClient.getElection();
   expect(defaultElection).toMatchObject({
     title: electionGeneral.title,
-    inputPath: DEFAULT_DEV_DOCK_ELECTION_INPUT_PATH,
     resolvedPath: expect.any(String),
   });
 
@@ -233,8 +230,6 @@ test('election setting', async () => {
   const updatedElection = await apiClient.getElection();
   expect(updatedElection).toMatchObject({
     title: election.title,
-    inputPath:
-      './libs/fixtures/data/electionFamousNames2021/electionGeneratedWithGridLayoutsEnglishOnly.json',
     resolvedPath: expect.any(String),
   });
 
@@ -274,7 +269,6 @@ test('election loading from zip file', async () => {
   const expectedElectionPath = join(devDockDir, DEV_DOCK_ELECTION_FILE_NAME);
   expect(loadedElection).toMatchObject({
     title: election.title,
-    inputPath: zipPath,
     resolvedPath: expectedElectionPath,
   });
   expect(loadedElection?.resolvedPath).toBeDefined();

--- a/libs/dev-dock/backend/src/dev_dock_api.test.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.test.ts
@@ -12,6 +12,7 @@ import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
 } from '@votingworks/utils';
+import { mockElectionPackageFileTree } from '@votingworks/backend';
 import {
   backendWaitFor,
   mockElectionManagerUser,
@@ -39,7 +40,11 @@ import {
   getMockFileFujitsuPrinterHandler,
 } from '@votingworks/fujitsu-thermal-printer';
 import { createMockPdiScanner } from '@votingworks/pdi-scanner';
-import { listMockDrives, removeMockDriveDir } from '@votingworks/usb-drive';
+import {
+  getMockFileUsbDriveHandler,
+  listMockDrives,
+  removeMockDriveDir,
+} from '@votingworks/usb-drive';
 import {
   Api,
   useDevDockRouter,
@@ -203,14 +208,48 @@ test('election fixture references', async () => {
     },
   ];
 
-  await expect(
-    apiClient.getCurrentFixtureElectionPaths()
-  ).resolves.toMatchObject(
+  await expect(apiClient.getAvailableElections()).resolves.toMatchObject(
     expectedFixtures.map(({ path, title }) => ({
       title: expect.stringContaining(title),
       inputPath: expect.stringContaining(path),
     }))
   );
+});
+
+test('detects election packages on mock USB drive', async () => {
+  const { apiClient } = setup();
+  const usbDrive = getMockFileUsbDriveHandler();
+  const fileTree = await mockElectionPackageFileTree(
+    electionFamousNames2021Fixtures.toElectionPackage()
+  );
+  usbDrive.insert(fileTree);
+
+  const result = await apiClient.getAvailableElections();
+
+  expect(result).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        title: expect.stringMatching(/^USB sdb:/),
+        inputPath: expect.stringContaining('.zip'),
+      }),
+    ])
+  );
+});
+
+test('skips unmounted USB drives and drives without election packages', async () => {
+  const { apiClient } = setup();
+
+  // Insert and then remove a drive — should be skipped (not mounted)
+  const usbDrive = getMockFileUsbDriveHandler();
+  usbDrive.insert();
+  usbDrive.remove();
+
+  // Insert a second drive with no election packages — should be skipped
+  const secondDrive = getMockFileUsbDriveHandler('sdc');
+  secondDrive.insert();
+
+  const result = await apiClient.getAvailableElections();
+  expect(result.every((e) => !e.title.startsWith('USB '))).toEqual(true);
 });
 
 test('election setting', async () => {

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -61,11 +61,14 @@ export interface DevDockUsbDriveInfo {
   devPath: string;
   status: DevDockUsbDriveStatus;
 }
-export interface DevDockElectionInfo {
+export interface DevDockElectionOption {
   title: string;
   /** The path that appears in the file picker and is passed to the backend */
   inputPath: string;
-  /** The actual path to the election.json file (may be extracted from zip to temp file) */
+}
+
+export interface DevDockElectionInfo extends DevDockElectionOption {
+  /** The path to a readable election.json file (extracted from zip if needed) */
   resolvedPath: string;
 }
 
@@ -250,7 +253,7 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
       return getElection(devDockDir);
     },
 
-    getCurrentFixtureElectionPaths(): DevDockElectionInfo[] {
+    getCurrentFixtureElectionPaths(): DevDockElectionOption[] {
       const baseFixturePath = join(__dirname, '../../../../libs/fixtures/data');
       return fs
         .readdirSync(baseFixturePath, {
@@ -263,11 +266,12 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
             /^(electionGenerated.*|election)\.json$/.test(file)
           );
           if (electionFile) {
-            const resolvedPath = join(baseFixturePath, item.name, electionFile);
+            const inputPath = electionAbsolutePathToRelative(
+              join(baseFixturePath, item.name, electionFile)
+            );
             return {
-              title: item.name,
-              inputPath: electionAbsolutePathToRelative(resolvedPath),
-              resolvedPath,
+              title: `${item.name} - ${inputPath}`,
+              inputPath,
             };
           }
           return undefined;

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -2,7 +2,14 @@ import type Express from 'express';
 import * as grout from '@votingworks/grout';
 import * as fs from 'node:fs';
 import { homedir } from 'node:os';
-import { join, extname, isAbsolute, relative, basename } from 'node:path';
+import {
+  join,
+  extname,
+  isAbsolute,
+  relative,
+  basename,
+  dirname,
+} from 'node:path';
 import { Optional, assert, assertDefined, iter } from '@votingworks/basics';
 import {
   asSheet,
@@ -25,8 +32,10 @@ import {
   getFileByName,
   readTextEntry,
 } from '@votingworks/utils';
+import { getMostRecentElectionPackageFilepath } from '@votingworks/backend';
 import {
   addMockDrive,
+  createMockFileUsbDrive,
   getMockFileUsbDriveHandler,
   listMockDrives,
   removeMockDriveDir,
@@ -253,9 +262,9 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
       return getElection(devDockDir);
     },
 
-    getCurrentFixtureElectionPaths(): DevDockElectionOption[] {
+    async getAvailableElections(): Promise<DevDockElectionOption[]> {
       const baseFixturePath = join(__dirname, '../../../../libs/fixtures/data');
-      return fs
+      const fixtureElections: DevDockElectionOption[] = fs
         .readdirSync(baseFixturePath, {
           withFileTypes: true,
         })
@@ -277,6 +286,26 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
           return undefined;
         })
         .filter((item) => item !== undefined);
+
+      // Also scan mock USB drives for election packages
+      const usbElections = await iter(listMockDrives())
+        .async()
+        .filterMap(async (diskName) => {
+          const handler = getMockFileUsbDriveHandler(diskName);
+          if (handler.status().status !== 'mounted') return undefined;
+          const mockUsbDrive = createMockFileUsbDrive(diskName);
+          const result =
+            await getMostRecentElectionPackageFilepath(mockUsbDrive);
+          if (result.isErr()) return undefined;
+          const zipPath = result.ok();
+          return {
+            title: `USB ${diskName}: ${basename(dirname(dirname(zipPath)))}`,
+            inputPath: zipPath,
+          };
+        })
+        .toArray();
+
+      return [...usbElections, ...fixtureElections];
     },
 
     getCardStatus(): CardStatus {

--- a/libs/dev-dock/frontend/src/dev_dock.test.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.test.tsx
@@ -89,17 +89,14 @@ beforeEach(() => {
     {
       title: 'electionGeneral',
       inputPath: './libs/fixtures/data/electionGeneral/election.json',
-      resolvedPath: '/full-path',
     },
     {
       title: 'electionFamousNames2021',
       inputPath: './libs/fixtures/data/electionFamousNames2021/election.json',
-      resolvedPath: '/full-path',
     },
     {
       title: 'electionTwoPartyPrimary',
       inputPath: './libs/fixtures/data/electionTwoPartyPrimary/election.json',
-      resolvedPath: '/full-path',
     },
   ]);
   mockApiClient.getElection.expectCallWith().resolves({

--- a/libs/dev-dock/frontend/src/dev_dock.test.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.test.tsx
@@ -85,7 +85,7 @@ beforeEach(() => {
   mockApiClient.getUsbDriveStatus
     .expectRepeatedCallsWith()
     .resolves([{ devPath: '/dev/sdb', status: 'removed' }]);
-  mockApiClient.getCurrentFixtureElectionPaths.expectCallWith().resolves([
+  mockApiClient.getAvailableElections.expectCallWith().resolves([
     {
       title: 'electionGeneral',
       inputPath: './libs/fixtures/data/electionGeneral/election.json',
@@ -127,7 +127,7 @@ test('renders nothing if dev dock is disabled', () => {
   mockApiClient.getElection.reset();
   mockApiClient.getUsbDriveStatus.reset();
   mockApiClient.getMockSpec.reset();
-  mockApiClient.getCurrentFixtureElectionPaths.reset();
+  mockApiClient.getAvailableElections.reset();
   featureFlagMock.disableFeatureFlag(
     BooleanEnvironmentVariableName.ENABLE_DEV_DOCK
   );

--- a/libs/dev-dock/frontend/src/dev_dock.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.tsx
@@ -119,7 +119,7 @@ function ElectionControl(): JSX.Element | null {
     >
       {elections.map((election) => (
         <option key={election.inputPath} value={election.inputPath}>
-          {election.title} - {election.inputPath}
+          {election.title}
         </option>
       ))}
       {window.kiosk && <option>Pick from file...</option>}

--- a/libs/dev-dock/frontend/src/dev_dock.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.tsx
@@ -71,11 +71,11 @@ function ElectionControl(): JSX.Element | null {
     ['getElection'],
     async () => (await apiClient.getElection()) ?? null
   );
-  const currentFixturesQuery = useQuery(
-    ['getCurrentFixtureElectionPaths'],
-    async () => (await apiClient.getCurrentFixtureElectionPaths()) ?? null
+  const availableElectionsQuery = useQuery(
+    ['getAvailableElections'],
+    async () => (await apiClient.getAvailableElections()) ?? null
   );
-  const fixturesElections = currentFixturesQuery.data || [];
+  const availableElections = availableElectionsQuery.data || [];
   const setElectionMutation = useMutation(apiClient.setElection, {
     onSuccess: async () => await queryClient.invalidateQueries(['getElection']),
   });
@@ -108,7 +108,7 @@ function ElectionControl(): JSX.Element | null {
   }
 
   const elections = uniqueBy(
-    fixturesElections.concat(selectedElection ?? []),
+    availableElections.concat(selectedElection ?? []),
     (election) => election.inputPath
   );
 

--- a/libs/usb-drive/src/mocks/file_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.ts
@@ -110,9 +110,7 @@ export function removeMockDriveDir(diskName: string): void {
   rmSync(getMockDriveDirPath(diskName), { recursive: true, force: true });
 }
 
-export function createMockFileUsbDrive(): UsbDrive {
-  const diskName = 'sdb';
-
+export function createMockFileUsbDrive(diskName = 'sdb'): UsbDrive {
   return {
     status(): Promise<UsbDriveStatus> {
       ensureMockDriveState(diskName);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4038,6 +4038,9 @@ importers:
       '@votingworks/auth':
         specifier: workspace:*
         version: link:../../auth
+      '@votingworks/backend':
+        specifier: workspace:*
+        version: link:../../backend
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../../basics


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

When developing with election packages on mock USB drives (e.g. exported from VxAdmin), the dev dock now auto-detects them and lists them in the election dropdown — no need to manually select the file. USB elections appear first in the dropdown since they're typically what you want when present.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/2c240b14-7476-46ad-87a4-b10519b133c1



## Testing Plan

- [x] Updated automated tests
- [x] Manual: export an election package, place it on mock USB, verify it appears at the top of the dev dock dropdown

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
