### PR TITLE
fix: remove detectDevices USB listeners when the server closes

### DIFF
--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -111,7 +111,7 @@ export async function start(options: StartOptions = {}): Promise<Server> {
   } = options;
 
   debug('starting server...');
-  detectDevices({ logger: baseLogger });
+  const stopDetectingDevices = detectDevices({ logger: baseLogger });
 
   const workspacePath =
     options.workspacePath ?? resolveWorkspacePath(baseLogger);
@@ -274,5 +274,6 @@ export async function start(options: StartOptions = {}): Promise<Server> {
   // (USB_DRIVE_CHANGE_LONG_POLL_TIMEOUT_MS); no socket-level timeout is needed.
   server.timeout = 0;
 
+  server.on('close', stopDetectingDevices);
   return server;
 }

--- a/apps/central-scan/backend/src/server.test.ts
+++ b/apps/central-scan/backend/src/server.test.ts
@@ -8,6 +8,7 @@ import {
 import { anyPollingPlace, TEST_JURISDICTION } from '@votingworks/types';
 import { createMockUsbDrive } from '@votingworks/usb-drive';
 import { testDetectDevices } from '@votingworks/backend';
+import { EventEmitter } from 'node:events';
 import { Server } from 'node:http';
 import { LogEventId, mockBaseLogger } from '@votingworks/logging';
 import { createWorkspace } from './util/workspace.js';
@@ -39,7 +40,7 @@ test('logs device attach/un-attach events', () => {
   // don't actually listen
   vi.spyOn(app, 'listen').mockImplementationOnce((_port, onListening) => {
     onListening?.();
-    return undefined as unknown as Server;
+    return new EventEmitter() as unknown as Server;
   });
   vi.spyOn(console, 'log').mockReturnValue();
 
@@ -101,7 +102,7 @@ test('logs when sheet counts are present at startup', () => {
   // don't actually listen
   vi.spyOn(app, 'listen').mockImplementationOnce((_port, onListening) => {
     onListening?.();
-    return undefined as unknown as Server;
+    return new EventEmitter() as unknown as Server;
   });
   vi.spyOn(console, 'log').mockReturnValue();
 
@@ -141,7 +142,7 @@ test('logs when sheet counts are not present at startup', () => {
   // don't actually listen
   vi.spyOn(app, 'listen').mockImplementationOnce((_port, onListening) => {
     onListening?.();
-    return undefined as unknown as Server;
+    return new EventEmitter() as unknown as Server;
   });
   vi.spyOn(console, 'log').mockReturnValue();
 

--- a/apps/central-scan/backend/src/server.ts
+++ b/apps/central-scan/backend/src/server.ts
@@ -47,7 +47,7 @@ export function start({
   logger: baseLogger = new BaseLogger(LogSource.VxCentralScanService),
   workspace,
 }: Partial<StartOptions> = {}): Server {
-  detectDevices({ logger: baseLogger });
+  const stopDetectingDevices = detectDevices({ logger: baseLogger });
   let resolvedWorkspace = workspace;
   /* istanbul ignore next */
   if (!resolvedWorkspace) {
@@ -146,7 +146,7 @@ export function start({
   // Start periodic CPU metrics logging
   startCpuMetricsLogging(baseLogger);
 
-  return resolvedApp.listen(port, () => {
+  const server = resolvedApp.listen(port, () => {
     baseLogger.log(LogEventId.ApplicationStartup, 'system', {
       message: `Scan Service running at http://localhost:${port}/`,
       disposition: 'success',
@@ -156,4 +156,6 @@ export function start({
       message: `Scanning ballots into ${resolvedWorkspace.ballotImagesPath}`,
     });
   });
+  server.on('close', stopDetectingDevices);
+  return server;
 }

--- a/apps/mark-scan/backend/src/server.ts
+++ b/apps/mark-scan/backend/src/server.ts
@@ -79,7 +79,7 @@ export async function start({
   port,
   workspace,
 }: StartOptions): Promise<Server> {
-  detectDevices({ logger: baseLogger });
+  const stopDetectingDevices = detectDevices({ logger: baseLogger });
   const resolvedAuth = auth ?? getDefaultAuth(baseLogger).auth;
   const logger = Logger.from(baseLogger, () =>
     getUserRole(resolvedAuth, workspace)
@@ -145,7 +145,7 @@ export async function start({
   // Start periodic CPU metrics logging
   startCpuMetricsLogging(logger);
 
-  return app.listen(
+  const server = app.listen(
     port,
     /* istanbul ignore next */
     () => {
@@ -155,4 +155,6 @@ export async function start({
       });
     }
   );
+  server.on('close', stopDetectingDevices);
+  return server;
 }

--- a/apps/scan/backend/src/server.test.ts
+++ b/apps/scan/backend/src/server.test.ts
@@ -7,6 +7,7 @@ import {
   vi,
 } from 'vitest';
 import { LogEventId, Logger, mockBaseLogger } from '@votingworks/logging';
+import { EventEmitter } from 'node:events';
 import { Application } from 'express';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
 import { buildMockInsertedSmartCardAuth } from '@votingworks/auth';
@@ -54,7 +55,9 @@ afterEach(() => {
 const audioCardName = 'alsa_output.pci';
 
 test('start passes context to `buildApp`', async () => {
-  const listen = vi.fn<(port: number, callback: () => unknown) => void>();
+  const listen = vi
+    .fn<(port: number, callback: () => unknown) => EventEmitter>()
+    .mockReturnValue(new EventEmitter());
   const auth = buildMockInsertedSmartCardAuth(vi.fn);
   const logger = buildMockLogger(auth, workspace);
   buildAppMock.mockReturnValueOnce({ listen } as unknown as Application);
@@ -126,7 +129,9 @@ test.each([
 ])(
   'configures audio player correctly',
   async ({ systemSettings, isScreenReaderEnabled }) => {
-    const listen = vi.fn<(port: number, callback: () => unknown) => void>();
+    const listen = vi
+      .fn<(port: number, callback: () => unknown) => EventEmitter>()
+      .mockReturnValue(new EventEmitter());
     const auth = buildMockInsertedSmartCardAuth(vi.fn);
     const logger = buildMockLogger(auth, workspace);
     buildAppMock.mockReturnValueOnce({ listen } as unknown as Application);
@@ -151,7 +156,7 @@ test.each([
 );
 
 test('logs device attach/unattach events', async () => {
-  const listen = vi.fn();
+  const listen = vi.fn().mockReturnValue(new EventEmitter());
   const auth = buildMockInsertedSmartCardAuth(vi.fn);
   const logger = buildMockLogger(auth, workspace);
   buildAppMock.mockReturnValueOnce({ listen } as unknown as Application);

--- a/apps/scan/backend/src/server.ts
+++ b/apps/scan/backend/src/server.ts
@@ -49,7 +49,7 @@ export async function start({
   printer,
   audioPlayer,
 }: StartOptions): Promise<void> {
-  detectDevices({ logger });
+  const stopDetectingDevices = detectDevices({ logger });
   const resolvedUsbDrive = usbDrive ?? detectUsbDriveFromEnv({ logger });
   const resolvedPrinter = printer ?? getFujitsuThermalPrinter(logger);
 
@@ -123,7 +123,7 @@ export async function start({
   // Start periodic CPU metrics logging
   startCpuMetricsLogging(logger);
 
-  app.listen(PORT, () => {
+  const server = app.listen(PORT, () => {
     logger.log(LogEventId.ApplicationStartup, 'system', {
       message: `VxScan backend running at http://localhost:${PORT}/`,
       disposition: 'success',
@@ -133,4 +133,5 @@ export async function start({
       message: `Scanning ballots into ${workspace.ballotImagesPath}`,
     });
   });
+  server.on('close', stopDetectingDevices);
 }

--- a/libs/backend/src/detect_devices.test.ts
+++ b/libs/backend/src/detect_devices.test.ts
@@ -1,10 +1,28 @@
 import { expect, test, vi } from 'vitest';
 import { mockBaseLogger } from '@votingworks/logging';
+import { usb } from 'usb';
 import { detectDevices } from './detect_devices';
 import { testDetectDevices } from './test_detect_devices';
 
 test('detectDevices', () => {
   const logger = mockBaseLogger({ fn: vi.fn });
-  detectDevices({ logger });
+  const stopDetectingDevices = detectDevices({ logger });
   testDetectDevices(logger, expect);
+  stopDetectingDevices();
+});
+
+test('cleanup removes listeners', () => {
+  const logger = mockBaseLogger({ fn: vi.fn });
+  const stopDetectingDevices = detectDevices({ logger });
+  testDetectDevices(logger, expect);
+
+  stopDetectingDevices();
+
+  const callCountAfterCleanup = vi.mocked(logger.log).mock.calls.length;
+  const device = {
+    deviceDescriptor: { idVendor: 1, idProduct: 2 },
+  } as unknown as usb.Device;
+  usb.emit('attach', device);
+  usb.emit('detach', device);
+  expect(logger.log).toHaveBeenCalledTimes(callCountAfterCleanup);
 });

--- a/libs/backend/src/detect_devices.ts
+++ b/libs/backend/src/detect_devices.ts
@@ -2,25 +2,31 @@ import { LogEventId, BaseLogger } from '@votingworks/logging';
 import { usb } from 'usb';
 
 /**
- * Logs when devices are attached or detached.
- *
- * If we ever transition device connection from a polling model to an event-driven
- * model, we could handle subscribers here.
+ * Logs when devices are attached or detached. Returns a cleanup function that
+ * removes the listeners from the global USB event emitter.
  */
-export function detectDevices({ logger }: { logger: BaseLogger }): void {
-  usb.on('attach', (device) => {
+export function detectDevices({ logger }: { logger: BaseLogger }): () => void {
+  function onAttach(device: usb.Device) {
     logger.log(LogEventId.DeviceAttached, 'system', {
       message: `Device attached. Vendor ID: ${device.deviceDescriptor.idVendor}, Product ID: ${device.deviceDescriptor.idProduct}`,
       productId: device.deviceDescriptor.idProduct,
       vendorId: device.deviceDescriptor.idVendor,
     });
-  });
+  }
 
-  usb.on('detach', (device) => {
+  function onDetach(device: usb.Device) {
     logger.log(LogEventId.DeviceUnattached, 'system', {
       message: `Device unattached. Vendor ID: ${device.deviceDescriptor.idVendor}, Product ID: ${device.deviceDescriptor.idProduct}`,
       productId: device.deviceDescriptor.idProduct,
       vendorId: device.deviceDescriptor.idVendor,
     });
-  });
+  }
+
+  usb.on('attach', onAttach);
+  usb.on('detach', onDetach);
+
+  return () => {
+    usb.off('attach', onAttach);
+    usb.off('detach', onDetach);
+  };
 }


### PR DESCRIPTION
## Overview

`detectDevices` adds `attach`/`detach` listeners to the global `usb` singleton but never removes them. Every `start()` call adds another pair, so any test file that starts a server repeatedly blows past Node's default listener limit.

`detectDevices` now returns a cleanup function, and each app's `start()` registers it on the server's `close` event. Every shutdown path that already exists — `withApp`'s `finally` in central-scan, `server.close()` in the admin and mark-scan tests — now releases the listeners, so no call sites and no `StartOptions` had to change.

The mocked `listen()` in the central-scan and scan server tests has to return something `close` can be registered on, hence the `EventEmitter` return values.

## Demo Video or Screenshot

Before, on `main`:

```
$ cd apps/central-scan/backend && pnpm test:run src/app.grout.test.ts
(node) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 attach listeners added to [EventEmitter]. MaxListeners is 10.
(node) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 detach listeners added to [EventEmitter]. MaxListeners is 10.

 Test Files  1 passed (1)
      Tests  17 passed (17)
```

After:

```
$ cd apps/central-scan/backend && pnpm test:coverage

 Test Files  17 passed (17)
      Tests  125 passed (125)
```

## Testing Plan

- `libs/backend` — `pnpm test:coverage`: 359 tests pass. `detect_devices.test.ts` gains a case asserting that no further events are logged after cleanup.
- `apps/central-scan/backend` — `pnpm test:coverage`: 125 tests pass, and the full suite is now free of `MaxListenersExceededWarning`.
- `apps/scan/backend`, `apps/admin/backend`, `apps/mark-scan/backend` — `pnpm test:run src/server.test.ts` passes in each.
- `pnpm lint` passes for all five packages.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
