### PR TITLE
VxMark: Bump flaky test timeout

### DIFF
--- a/apps/mark/frontend/src/pages/review_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/review_screen.test.tsx
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { Route } from 'react-router-dom';
 import { readElectionGeneral } from '@votingworks/fixtures';
 import { createMemoryHistory } from 'history';
@@ -12,6 +12,10 @@ import { render as renderWithBallotContext } from '../../test/test_utils';
 import { ReviewScreen } from './review_screen';
 
 const electionGeneral = readElectionGeneral();
+
+vi.setConfig({
+  testTimeout: 20_000,
+});
 
 test('Renders ReviewScreen with Print My Ballot in final review mode', () => {
   renderWithBallotContext(<Route path="/review" component={ReviewScreen} />, {


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->
Flaked with the default 10s timeout

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
