### PR TITLE
Add shared PollingPlaceName component, mirroring PrecinctSelectionName

### DIFF
--- a/libs/ui/src/ui_strings/utils.test.tsx
+++ b/libs/ui/src/ui_strings/utils.test.tsx
@@ -2,15 +2,22 @@ import { test } from 'vitest';
 import {
   Candidate,
   DistrictId,
+  Election,
+  ElectionStringKey,
   Parties,
   PartyId,
+  PollingPlace,
   Precinct,
 } from '@votingworks/types';
 import {
   ALL_PRECINCTS_SELECTION,
   singlePrecinctSelectionFor,
 } from '@votingworks/utils';
-import { CandidatePartyList, PrecinctSelectionName } from './utils';
+import {
+  CandidatePartyList,
+  PollingPlaceName,
+  PrecinctSelectionName,
+} from './utils';
 import { newTestContext } from '../../test/test_context';
 import { H1 } from '..';
 import { screen } from '../../test/react_testing_library';
@@ -171,3 +178,59 @@ test('PrecinctSelectionName - no selection', async () => {
 
   await screen.findByRole('heading', { name: 'Precincts:' });
 });
+
+test('PollingPlaceName - with selection', async () => {
+  const { mockApiClient, render } = newTestContext();
+  mockApiClient.getAvailableLanguages.mockResolvedValue(['es-US']);
+  mockApiClient.getUiStrings.mockResolvedValue({
+    [ElectionStringKey.POLLING_PLACE_NAME]: {
+      p1: 'Centro de votación 1',
+      p2: 'Centro de votación 2',
+    },
+  });
+
+  const election = mockElection({
+    pollingPlaces: [
+      mockPollingPlace({ id: 'p1', name: 'Place 1' }),
+      mockPollingPlace({ id: 'p2', name: 'Place 2' }),
+    ],
+  });
+
+  render(
+    <H1>
+      Polling Place: <PollingPlaceName election={election} id="p2" />
+    </H1>
+  );
+
+  await screen.findByRole('heading', {
+    name: 'Polling Place: Centro de votación 2',
+  });
+});
+
+test('PollingPlaceName - no selection', async () => {
+  const { mockApiClient, render } = newTestContext();
+  mockApiClient.getAvailableLanguages.mockResolvedValue(['es-US']);
+  mockApiClient.getUiStrings.mockResolvedValue({
+    [ElectionStringKey.POLLING_PLACE_NAME]: { p1: 'Centro de votación 1' },
+  });
+
+  const election = mockElection({
+    pollingPlaces: [mockPollingPlace({ id: 'p1', name: 'Place 1' })],
+  });
+
+  render(
+    <H1>
+      Polling Place: <PollingPlaceName election={election} id={undefined} />
+    </H1>
+  );
+
+  await screen.findByRole('heading', { name: 'Polling Place:' });
+});
+
+function mockElection(partial: Partial<Election>): Election {
+  return partial as Election;
+}
+
+function mockPollingPlace(partial: Partial<PollingPlace>): PollingPlace {
+  return partial as PollingPlace;
+}

--- a/libs/ui/src/ui_strings/utils.tsx
+++ b/libs/ui/src/ui_strings/utils.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 import {
   Candidate,
+  Election,
   Parties,
   Precinct,
   PrecinctSelection,
   getCandidateParties,
+  pollingPlaceFromElection,
 } from '@votingworks/types';
 import { getPrecinctSelection } from '@votingworks/utils';
 
@@ -57,4 +59,17 @@ export function PrecinctSelectionName(props: {
   const precinct = getPrecinctSelection(electionPrecincts, precinctSelection);
 
   return electionStrings.precinctName(precinct);
+}
+
+export function PollingPlaceName(props: {
+  election: Election;
+  id?: string;
+}): React.ReactNode {
+  const { election, id } = props;
+
+  if (!id) return null;
+
+  return electionStrings.pollingPlaceName(
+    pollingPlaceFromElection(election, id)
+  );
 }


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7870

We use the current `PrecinctSelectionName` component in a few places, where we may or may not have an active precinct selection. Adding an equivalent `PollingPlaceName` component that also handles the absence of a polling place selection by rendering a null node.

Not used yet - breaking off common pieces as I convert the precinct apps - will eventually render conditionally in place of `PrecinctSelectionName`, based on the `ENABLE_POLLING_PLACES` feature flag.

## Demo Video or Screenshot

N/A - simple textual component

## Testing Plan
- New unit tests
