### PR TITLE
Add isOpenPrimary() helper and open primary fixture

### DIFF
--- a/libs/dev-dock/backend/src/dev_dock_api.test.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.test.ts
@@ -191,6 +191,10 @@ test('election fixture references', async () => {
       title: 'electionMultiPartyPrimary',
     },
     {
+      path: 'fixtures/data/electionOpenPrimary/election.json',
+      title: 'electionOpenPrimary',
+    },
+    {
       path: 'fixtures/data/electionPrimaryPrecinctSplits/electionGeneratedWithGridLayoutsMultiLang.json',
       title: 'electionPrimaryPrecinctSplits',
     },

--- a/libs/fixtures/data/electionOpenPrimary/election.json
+++ b/libs/fixtures/data/electionOpenPrimary/election.json
@@ -1,0 +1,800 @@
+{
+  "id": "election-open-primary",
+  "type": "primary",
+  "title": "Example Open Primary Election",
+  "state": "State of Sample",
+  "county": {
+    "id": "sample-county",
+    "name": "Sample County"
+  },
+  "date": "2025-08-12",
+  "ballotLayout": {
+    "paperSize": "letter",
+    "metadataEncoding": "qr-code"
+  },
+  "districts": [
+    {
+      "id": "district-state",
+      "name": "State of Sample"
+    },
+    {
+      "id": "district-congressional",
+      "name": "13th Congressional District"
+    },
+    {
+      "id": "district-legislative",
+      "name": "6th State Representative District"
+    },
+    {
+      "id": "district-county",
+      "name": "Sample County"
+    },
+    {
+      "id": "district-judicial",
+      "name": "Judicial District"
+    }
+  ],
+  "parties": [
+    {
+      "id": "democratic-party",
+      "name": "Democratic",
+      "fullName": "Democratic Party",
+      "abbrev": "D"
+    },
+    {
+      "id": "republican-party",
+      "name": "Republican",
+      "fullName": "Republican Party",
+      "abbrev": "R"
+    },
+    {
+      "id": "libertarian-party",
+      "name": "Libertarian",
+      "fullName": "Libertarian Party",
+      "abbrev": "L"
+    }
+  ],
+  "contests": [
+    {
+      "id": "governor-democratic",
+      "districtId": "district-state",
+      "type": "candidate",
+      "title": "Governor",
+      "seats": 1,
+      "partyId": "democratic-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "alice-jones",
+          "name": "Alice Jones"
+        },
+        {
+          "id": "bob-smith",
+          "name": "Bob Smith"
+        },
+        {
+          "id": "carol-white",
+          "name": "Carol White"
+        },
+        {
+          "id": "dan-rivera",
+          "name": "Dan Rivera"
+        },
+        {
+          "id": "emily-tran",
+          "name": "Emily Tran"
+        }
+      ]
+    },
+    {
+      "id": "governor-republican",
+      "districtId": "district-state",
+      "type": "candidate",
+      "title": "Governor",
+      "seats": 1,
+      "partyId": "republican-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "dave-wilson",
+          "name": "Dave Wilson"
+        },
+        {
+          "id": "ellen-brown",
+          "name": "Ellen Brown"
+        },
+        {
+          "id": "frank-lee",
+          "name": "Frank Lee"
+        }
+      ]
+    },
+    {
+      "id": "governor-libertarian",
+      "districtId": "district-state",
+      "type": "candidate",
+      "title": "Governor",
+      "seats": 1,
+      "partyId": "libertarian-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "grace-kim",
+          "name": "Grace Kim"
+        },
+        {
+          "id": "henry-park",
+          "name": "Henry Park"
+        }
+      ]
+    },
+    {
+      "id": "secretary-of-state-democratic",
+      "districtId": "district-state",
+      "type": "candidate",
+      "title": "Secretary of State",
+      "seats": 1,
+      "partyId": "democratic-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "james-martin",
+          "name": "James Martin"
+        },
+        {
+          "id": "karen-ross",
+          "name": "Karen Ross"
+        }
+      ]
+    },
+    {
+      "id": "secretary-of-state-republican",
+      "districtId": "district-state",
+      "type": "candidate",
+      "title": "Secretary of State",
+      "seats": 1,
+      "partyId": "republican-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "larry-chen",
+          "name": "Larry Chen"
+        },
+        {
+          "id": "maria-garcia",
+          "name": "Maria Garcia"
+        },
+        {
+          "id": "noah-pham",
+          "name": "Noah Pham"
+        },
+        {
+          "id": "rachel-ford",
+          "name": "Rachel Ford"
+        }
+      ]
+    },
+    {
+      "id": "secretary-of-state-libertarian",
+      "districtId": "district-state",
+      "type": "candidate",
+      "title": "Secretary of State",
+      "seats": 1,
+      "partyId": "libertarian-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "nathan-brooks",
+          "name": "Nathan Brooks"
+        }
+      ]
+    },
+    {
+      "id": "attorney-general-democratic",
+      "districtId": "district-state",
+      "type": "candidate",
+      "title": "Attorney General",
+      "seats": 1,
+      "partyId": "democratic-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "patricia-young",
+          "name": "Patricia Young"
+        },
+        {
+          "id": "quinn-adams",
+          "name": "Quinn Adams"
+        },
+        {
+          "id": "rosa-delgado",
+          "name": "Rosa Delgado"
+        }
+      ]
+    },
+    {
+      "id": "attorney-general-republican",
+      "districtId": "district-state",
+      "type": "candidate",
+      "title": "Attorney General",
+      "seats": 1,
+      "partyId": "republican-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "robert-king",
+          "name": "Robert King"
+        },
+        {
+          "id": "susan-price",
+          "name": "Susan Price"
+        }
+      ]
+    },
+    {
+      "id": "attorney-general-libertarian",
+      "districtId": "district-state",
+      "type": "candidate",
+      "title": "Attorney General",
+      "seats": 1,
+      "partyId": "libertarian-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "thomas-reed",
+          "name": "Thomas Reed"
+        },
+        {
+          "id": "uma-patel",
+          "name": "Uma Patel"
+        },
+        {
+          "id": "vincent-shaw",
+          "name": "Vincent Shaw"
+        }
+      ]
+    },
+    {
+      "id": "us-rep-democratic",
+      "districtId": "district-congressional",
+      "type": "candidate",
+      "title": "Representative in Congress",
+      "seats": 1,
+      "partyId": "democratic-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "victor-lane",
+          "name": "Victor Lane"
+        },
+        {
+          "id": "wendy-fox",
+          "name": "Wendy Fox"
+        },
+        {
+          "id": "xavier-cruz",
+          "name": "Xavier Cruz"
+        },
+        {
+          "id": "yvette-hall",
+          "name": "Yvette Hall"
+        }
+      ]
+    },
+    {
+      "id": "us-rep-republican",
+      "districtId": "district-congressional",
+      "type": "candidate",
+      "title": "Representative in Congress",
+      "seats": 1,
+      "partyId": "republican-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "yolanda-webb",
+          "name": "Yolanda Webb"
+        },
+        {
+          "id": "zachary-stone",
+          "name": "Zachary Stone"
+        }
+      ]
+    },
+    {
+      "id": "us-rep-libertarian",
+      "districtId": "district-congressional",
+      "type": "candidate",
+      "title": "Representative in Congress",
+      "seats": 1,
+      "partyId": "libertarian-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "brian-cole",
+          "name": "Brian Cole"
+        },
+        {
+          "id": "claire-nash",
+          "name": "Claire Nash"
+        },
+        {
+          "id": "derek-moss",
+          "name": "Derek Moss"
+        }
+      ]
+    },
+    {
+      "id": "state-rep-democratic",
+      "districtId": "district-legislative",
+      "type": "candidate",
+      "title": "State Representative",
+      "seats": 1,
+      "partyId": "democratic-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "eva-grant",
+          "name": "Eva Grant"
+        },
+        {
+          "id": "felix-dunn",
+          "name": "Felix Dunn"
+        },
+        {
+          "id": "gloria-soto",
+          "name": "Gloria Soto"
+        }
+      ]
+    },
+    {
+      "id": "state-rep-republican",
+      "districtId": "district-legislative",
+      "type": "candidate",
+      "title": "State Representative",
+      "seats": 1,
+      "partyId": "republican-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "gina-wolfe",
+          "name": "Gina Wolfe"
+        },
+        {
+          "id": "harold-vega",
+          "name": "Harold Vega"
+        }
+      ]
+    },
+    {
+      "id": "state-rep-libertarian",
+      "districtId": "district-legislative",
+      "type": "candidate",
+      "title": "State Representative",
+      "seats": 1,
+      "partyId": "libertarian-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "iris-quinn",
+          "name": "Iris Quinn"
+        }
+      ]
+    },
+    {
+      "id": "county-commissioner-democratic",
+      "districtId": "district-county",
+      "type": "candidate",
+      "title": "County Commissioner",
+      "seats": 2,
+      "partyId": "democratic-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "kelly-marsh",
+          "name": "Kelly Marsh"
+        },
+        {
+          "id": "liam-foster",
+          "name": "Liam Foster"
+        },
+        {
+          "id": "mona-sharp",
+          "name": "Mona Sharp"
+        },
+        {
+          "id": "neil-cross",
+          "name": "Neil Cross"
+        },
+        {
+          "id": "opal-burke",
+          "name": "Opal Burke"
+        }
+      ]
+    },
+    {
+      "id": "county-commissioner-republican",
+      "districtId": "district-county",
+      "type": "candidate",
+      "title": "County Commissioner",
+      "seats": 2,
+      "partyId": "republican-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "owen-blake",
+          "name": "Owen Blake"
+        },
+        {
+          "id": "penny-tate",
+          "name": "Penny Tate"
+        },
+        {
+          "id": "roy-simms",
+          "name": "Roy Simms"
+        }
+      ]
+    },
+    {
+      "id": "county-commissioner-libertarian",
+      "districtId": "district-county",
+      "type": "candidate",
+      "title": "County Commissioner",
+      "seats": 2,
+      "partyId": "libertarian-party",
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "tina-drake",
+          "name": "Tina Drake"
+        },
+        {
+          "id": "ulric-fenn",
+          "name": "Ulric Fenn"
+        },
+        {
+          "id": "vera-gold",
+          "name": "Vera Gold"
+        },
+        {
+          "id": "wade-knoll",
+          "name": "Wade Knoll"
+        }
+      ]
+    },
+    {
+      "id": "delegate-convention-democratic",
+      "districtId": "district-county",
+      "type": "candidate",
+      "title": "Delegate to County Convention",
+      "seats": 3,
+      "partyId": "democratic-party",
+      "allowWriteIns": true,
+      "candidates": []
+    },
+    {
+      "id": "delegate-convention-republican",
+      "districtId": "district-county",
+      "type": "candidate",
+      "title": "Delegate to County Convention",
+      "seats": 2,
+      "partyId": "republican-party",
+      "allowWriteIns": true,
+      "candidates": []
+    },
+    {
+      "id": "delegate-convention-libertarian",
+      "districtId": "district-county",
+      "type": "candidate",
+      "title": "Delegate to County Convention",
+      "seats": 2,
+      "partyId": "libertarian-party",
+      "allowWriteIns": true,
+      "candidates": []
+    },
+    {
+      "id": "circuit-court-judge",
+      "districtId": "district-judicial",
+      "type": "candidate",
+      "title": "Circuit Court Judge",
+      "seats": 1,
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "margaret-chen",
+          "name": "Margaret Chen"
+        },
+        {
+          "id": "donald-harper",
+          "name": "Donald Harper"
+        },
+        {
+          "id": "lisa-ramirez",
+          "name": "Lisa Ramirez"
+        }
+      ]
+    },
+    {
+      "id": "probate-court-judge",
+      "districtId": "district-judicial",
+      "type": "candidate",
+      "title": "Probate Court Judge",
+      "seats": 1,
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "roger-mills",
+          "name": "Roger Mills"
+        },
+        {
+          "id": "sandra-cook",
+          "name": "Sandra Cook"
+        }
+      ]
+    },
+    {
+      "id": "school-board",
+      "districtId": "district-county",
+      "type": "candidate",
+      "title": "Board of Education Member",
+      "seats": 2,
+      "allowWriteIns": true,
+      "candidates": [
+        {
+          "id": "angela-morris",
+          "name": "Angela Morris"
+        },
+        {
+          "id": "bruce-newton",
+          "name": "Bruce Newton"
+        },
+        {
+          "id": "carmen-ortiz",
+          "name": "Carmen Ortiz"
+        },
+        {
+          "id": "dwight-perry",
+          "name": "Dwight Perry"
+        }
+      ]
+    },
+    {
+      "id": "ballot-measure-1",
+      "districtId": "district-county",
+      "type": "yesno",
+      "title": "County Road Millage Renewal",
+      "description": "Shall the County of Sample renew the previously authorized millage of 1.5 mills ($1.50 per $1,000 of taxable value) for a period of 10 years, 2026 through 2035 inclusive, for the purpose of funding road maintenance, repair, and improvement throughout the county? It is estimated that this millage would raise approximately $3,200,000 in the first year.",
+      "yesOption": {
+        "id": "ballot-measure-1-yes",
+        "label": "Yes"
+      },
+      "noOption": {
+        "id": "ballot-measure-1-no",
+        "label": "No"
+      }
+    },
+    {
+      "id": "ballot-measure-2",
+      "districtId": "district-county",
+      "type": "yesno",
+      "title": "Public Safety Millage",
+      "description": "Shall the County of Sample levy a new millage of 0.75 mills ($0.75 per $1,000 of taxable value) for a period of 5 years, 2026 through 2030 inclusive, for the purpose of funding police, fire, and emergency medical services throughout the county? It is estimated that this millage would raise approximately $1,600,000 in the first year. This is a new additional millage.",
+      "yesOption": {
+        "id": "ballot-measure-2-yes",
+        "label": "Yes"
+      },
+      "noOption": {
+        "id": "ballot-measure-2-no",
+        "label": "No"
+      }
+    },
+    {
+      "id": "ballot-measure-3",
+      "districtId": "district-county",
+      "type": "yesno",
+      "title": "Library Millage Renewal",
+      "description": "Shall the County of Sample renew the previously authorized millage of 0.5 mills ($0.50 per $1,000 of taxable value) for a period of 8 years, 2026 through 2033 inclusive, for the purpose of providing funds for the operation, maintenance, and improvement of the county library system?",
+      "yesOption": {
+        "id": "ballot-measure-3-yes",
+        "label": "Yes"
+      },
+      "noOption": {
+        "id": "ballot-measure-3-no",
+        "label": "No"
+      }
+    }
+  ],
+  "precincts": [
+    {
+      "id": "precinct-1",
+      "name": "Precinct 1",
+      "districtIds": [
+        "district-state",
+        "district-congressional",
+        "district-legislative",
+        "district-county",
+        "district-judicial"
+      ]
+    },
+    {
+      "id": "precinct-2",
+      "name": "Precinct 2",
+      "districtIds": [
+        "district-state",
+        "district-congressional",
+        "district-legislative",
+        "district-county",
+        "district-judicial"
+      ]
+    }
+  ],
+  "ballotStyles": [
+    {
+      "id": "ballot-style-1",
+      "groupId": "ballot-style-1",
+      "precincts": [
+        "precinct-1"
+      ],
+      "districts": [
+        "district-state",
+        "district-congressional",
+        "district-legislative",
+        "district-county",
+        "district-judicial"
+      ]
+    },
+    {
+      "id": "ballot-style-2",
+      "groupId": "ballot-style-2",
+      "precincts": [
+        "precinct-2"
+      ],
+      "districts": [
+        "district-state",
+        "district-congressional",
+        "district-legislative",
+        "district-county",
+        "district-judicial"
+      ]
+    }
+  ],
+  "ballotStrings": {
+    "en": {
+      "ballotLanguage": "English",
+      "ballotStyleId": {
+        "ballot-style-1": "ballot-style-1",
+        "ballot-style-2": "ballot-style-2"
+      },
+      "candidateName": {
+        "alice-jones": "Alice Jones",
+        "bob-smith": "Bob Smith",
+        "carol-white": "Carol White",
+        "dan-rivera": "Dan Rivera",
+        "emily-tran": "Emily Tran",
+        "dave-wilson": "Dave Wilson",
+        "ellen-brown": "Ellen Brown",
+        "frank-lee": "Frank Lee",
+        "grace-kim": "Grace Kim",
+        "henry-park": "Henry Park",
+        "james-martin": "James Martin",
+        "karen-ross": "Karen Ross",
+        "larry-chen": "Larry Chen",
+        "maria-garcia": "Maria Garcia",
+        "noah-pham": "Noah Pham",
+        "rachel-ford": "Rachel Ford",
+        "nathan-brooks": "Nathan Brooks",
+        "patricia-young": "Patricia Young",
+        "quinn-adams": "Quinn Adams",
+        "rosa-delgado": "Rosa Delgado",
+        "robert-king": "Robert King",
+        "susan-price": "Susan Price",
+        "thomas-reed": "Thomas Reed",
+        "uma-patel": "Uma Patel",
+        "vincent-shaw": "Vincent Shaw",
+        "victor-lane": "Victor Lane",
+        "wendy-fox": "Wendy Fox",
+        "xavier-cruz": "Xavier Cruz",
+        "yvette-hall": "Yvette Hall",
+        "yolanda-webb": "Yolanda Webb",
+        "zachary-stone": "Zachary Stone",
+        "brian-cole": "Brian Cole",
+        "claire-nash": "Claire Nash",
+        "derek-moss": "Derek Moss",
+        "eva-grant": "Eva Grant",
+        "felix-dunn": "Felix Dunn",
+        "gloria-soto": "Gloria Soto",
+        "gina-wolfe": "Gina Wolfe",
+        "harold-vega": "Harold Vega",
+        "iris-quinn": "Iris Quinn",
+        "kelly-marsh": "Kelly Marsh",
+        "liam-foster": "Liam Foster",
+        "mona-sharp": "Mona Sharp",
+        "neil-cross": "Neil Cross",
+        "opal-burke": "Opal Burke",
+        "owen-blake": "Owen Blake",
+        "penny-tate": "Penny Tate",
+        "roy-simms": "Roy Simms",
+        "tina-drake": "Tina Drake",
+        "ulric-fenn": "Ulric Fenn",
+        "vera-gold": "Vera Gold",
+        "wade-knoll": "Wade Knoll",
+        "margaret-chen": "Margaret Chen",
+        "donald-harper": "Donald Harper",
+        "lisa-ramirez": "Lisa Ramirez",
+        "roger-mills": "Roger Mills",
+        "sandra-cook": "Sandra Cook",
+        "angela-morris": "Angela Morris",
+        "bruce-newton": "Bruce Newton",
+        "carmen-ortiz": "Carmen Ortiz",
+        "dwight-perry": "Dwight Perry"
+      },
+      "contestDescription": {
+        "ballot-measure-1": "Shall the County of Sample renew the previously authorized millage of 1.5 mills ($1.50 per $1,000 of taxable value) for a period of 10 years, 2026 through 2035 inclusive, for the purpose of funding road maintenance, repair, and improvement throughout the county? It is estimated that this millage would raise approximately $3,200,000 in the first year.",
+        "ballot-measure-2": "Shall the County of Sample levy a new millage of 0.75 mills ($0.75 per $1,000 of taxable value) for a period of 5 years, 2026 through 2030 inclusive, for the purpose of funding police, fire, and emergency medical services throughout the county? It is estimated that this millage would raise approximately $1,600,000 in the first year. This is a new additional millage.",
+        "ballot-measure-3": "Shall the County of Sample renew the previously authorized millage of 0.5 mills ($0.50 per $1,000 of taxable value) for a period of 8 years, 2026 through 2033 inclusive, for the purpose of providing funds for the operation, maintenance, and improvement of the county library system?"
+      },
+      "contestOptionLabel": {
+        "ballot-measure-1-yes": "Yes",
+        "ballot-measure-1-no": "No",
+        "ballot-measure-2-yes": "Yes",
+        "ballot-measure-2-no": "No",
+        "ballot-measure-3-yes": "Yes",
+        "ballot-measure-3-no": "No"
+      },
+      "contestTitle": {
+        "governor-democratic": "Governor",
+        "governor-republican": "Governor",
+        "governor-libertarian": "Governor",
+        "secretary-of-state-democratic": "Secretary of State",
+        "secretary-of-state-republican": "Secretary of State",
+        "secretary-of-state-libertarian": "Secretary of State",
+        "attorney-general-democratic": "Attorney General",
+        "attorney-general-republican": "Attorney General",
+        "attorney-general-libertarian": "Attorney General",
+        "us-rep-democratic": "Representative in Congress",
+        "us-rep-republican": "Representative in Congress",
+        "us-rep-libertarian": "Representative in Congress",
+        "state-rep-democratic": "State Representative",
+        "state-rep-republican": "State Representative",
+        "state-rep-libertarian": "State Representative",
+        "county-commissioner-democratic": "County Commissioner",
+        "county-commissioner-republican": "County Commissioner",
+        "county-commissioner-libertarian": "County Commissioner",
+        "delegate-convention-democratic": "Delegate to County Convention",
+        "delegate-convention-republican": "Delegate to County Convention",
+        "delegate-convention-libertarian": "Delegate to County Convention",
+        "circuit-court-judge": "Circuit Court Judge",
+        "probate-court-judge": "Probate Court Judge",
+        "school-board": "Board of Education Member",
+        "ballot-measure-1": "County Road Millage Renewal",
+        "ballot-measure-2": "Public Safety Millage",
+        "ballot-measure-3": "Library Millage Renewal"
+      },
+      "countyName": "Sample County",
+      "districtName": {
+        "district-state": "State of Sample",
+        "district-congressional": "13th Congressional District",
+        "district-legislative": "6th State Representative District",
+        "district-county": "Sample County",
+        "district-judicial": "Judicial District"
+      },
+      "electionDate": "August 12, 2025",
+      "electionTitle": "Example Open Primary Election",
+      "partyFullName": {
+        "democratic-party": "Democratic Party",
+        "republican-party": "Republican Party",
+        "libertarian-party": "Libertarian Party"
+      },
+      "partyName": {
+        "democratic-party": "Democratic",
+        "republican-party": "Republican",
+        "libertarian-party": "Libertarian"
+      },
+      "precinctName": {
+        "precinct-1": "Precinct 1",
+        "precinct-2": "Precinct 2"
+      },
+      "stateName": "State of Sample"
+    }
+  },
+  "seal": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 512 512\">\n  <!-- Designer: Beau Smith, VotingWorks https://voting.works -->\n  <path d=\"M256 8.8c33.4 0 65.8 6.5 96.2 19.4 29.4 12.5 55.9 30.3 78.6 53 22.7 22.7 40.5 49.1 53 78.6 12.9 30.5 19.4 62.8 19.4 96.2s-6.5 65.8-19.4 96.2c-12.5 29.4-30.3 55.9-53 78.6-22.7 22.7-49.1 40.5-78.6 53-30.5 12.9-62.8 19.4-96.2 19.4s-65.8-6.5-96.2-19.4c-29.4-12.5-55.9-30.3-78.6-53-22.7-22.7-40.5-49.1-53-78.6C15.3 321.8 8.8 289.4 8.8 256s6.5-65.8 19.4-96.2c12.5-29.4 30.3-55.9 53-78.6s49.1-40.5 78.6-53C190.2 15.3 222.6 8.8 256 8.8m0-8.8C114.6 0 0 114.6 0 256s114.6 256 256 256 256-114.6 256-256S397.4 0 256 0z\"/>\n  <path d=\"M383.1 351.5c-.3.1-.6.1-.8.2-4.4 5.7-9.1 11.2-14.3 16.4-29.9 29.9-69.7 46.4-112 46.4-33.5 0-65.5-10.4-92.2-29.6-1 .1-2.1.1-3.1.2-3.4.2-6.9.4-10.4.5 28.8 23.5 65.6 37.7 105.7 37.7 58.5 0 110.1-30.1 139.9-75.7-4.2 1.5-8.5 2.8-12.8 3.9zM453.9 242.4c-2.8-1.5-5.5-2.9-8.3-4.4-3.2-1.7-6.5-2.5-10.1-2.5-.6 0-1.2 0-1.7-.1-1.1-.2-1.5-1-.8-1.9.5-.7 1.2-1.4 1.9-2 3.5-2.7 7.5-3.7 11.8-3.6 3.2.1 6.2.8 9.2 1.9.4.1.7.3 1 .4.4-2.5.7-5 1.3-7.4.8-3.3 2.4-6.3 4.7-8.8.5-.5 1.3-.8 1.9-1.2.3.7.8 1.4.8 2.2.2 5.4 1.5 10.6 3.2 15.7.3.8.7 1.1 1.5 1 7-.7 14-1.3 20.8-3.2.4-.1.9-.2 1.4-.2 1.4 0 1.8.6 1.2 1.8-.3.6-.7 1.3-1.3 1.7-3.6 2.9-7.2 5.8-10.9 8.5-1.9 1.4-4.1 2.3-6.6 2.7.7.9 1.3 1.6 1.9 2.4 3.3 4.3 6 8.9 7.1 14.3.4 1.7.2 3.5.1 5.3 0 .5-.6 1.3-1.1 1.4-.5.1-1.1-.4-1.6-.8-.4-.3-.6-.8-.9-1.2-2.4-4.2-5.8-7.3-10.1-9.5-2.1-1.1-4.3-2.3-6.5-3.5-.8.9-1.6 2-2.4 2.9-4 4.5-8.6 8.1-14.4 9.9-1.2.4-2.4.5-3.7.6-1.4 0-1.8-.8-1.2-2.1.2-.5.5-1 .9-1.3 2.6-2.6 4.2-5.9 5.6-9.2 1-2.2 2-4.4 3-6.5.9-1.3 1.7-2.3 2.3-3.3zM59 242.4c2.8-1.5 5.5-2.9 8.3-4.4 3.2-1.7 6.5-2.5 10.1-2.5.6 0 1.2 0 1.7-.1 1.1-.2 1.5-1 .8-1.9-.5-.7-1.2-1.4-1.9-2-3.5-2.7-7.5-3.7-11.8-3.6-3.2.1-6.2.8-9.2 1.9-.4.1-.7.3-1 .4-.4-2.5-.7-5-1.3-7.4-.8-3.3-2.4-6.3-4.7-8.8-.5-.5-1.3-.8-1.9-1.2-.3.7-.8 1.4-.8 2.2-.2 5.4-1.5 10.6-3.2 15.7-.3.8-.7 1.1-1.5 1-7-.7-14-1.3-20.8-3.2-.4-.1-.9-.2-1.4-.2-1.4 0-1.8.6-1.2 1.8.3.6.7 1.3 1.3 1.7 3.6 2.9 7.2 5.8 10.9 8.5 1.9 1.4 4.1 2.3 6.6 2.7-.7.9-1.3 1.6-1.9 2.4-3.3 4.3-6 8.9-7.1 14.3-.4 1.7-.2 3.5-.1 5.3 0 .5.6 1.3 1.1 1.4.5.1 1.1-.4 1.6-.8.4-.3.6-.8.9-1.2 2.4-4.2 5.8-7.3 10.1-9.5 2.1-1.1 4.3-2.3 6.5-3.5.8.9 1.6 2 2.4 2.9 4 4.5 8.6 8.1 14.4 9.9 1.2.4 2.4.5 3.7.6 1.4 0 1.8-.8 1.2-2.1-.2-.5-.5-1-.9-1.3-2.6-2.6-4.2-5.9-5.6-9.2-1-2.2-2-4.4-3-6.5-.8-1.3-1.6-2.3-2.3-3.3zM74.2 296.1l3.1 11.1c.6 1.9.7 3.7.6 5.3-.2 1.6-.6 3-1.4 4.2-.8 1.2-1.8 2.2-3.1 3.1-1.3.8-2.8 1.5-4.5 2-1.6.4-3.1.7-4.7.6-1.5 0-3-.4-4.3-1-1.3-.7-2.5-1.7-3.6-3.2-1.1-1.4-1.9-3.3-2.6-5.6l-1.7-6.1-17.8 5-1-3.7 41-11.7zm-19.1 9.4l1.8 6.3c.3 1.2.8 2.3 1.4 3.3.6 1 1.3 1.8 2.2 2.4.9.6 1.9 1 3.2 1.1 1.2.2 2.6 0 4.2-.4 3.1-.9 5.1-2.2 5.9-4.1.9-1.8.9-4.2.1-7.1l-1.8-6.3-17 4.8zM82.2 322.1l1.4 3.6L44 341.2l-1.4-3.6 39.6-15.5zM84.2 352.2c2.3-1.2 3.9-2.7 4.7-4.5.8-1.8.6-3.8-.6-6.2-.6-1.2-1.3-2.1-2.1-2.8-.8-.7-1.7-1.2-2.6-1.5-.9-.3-1.9-.4-2.9-.3-1 .1-1.9.4-2.9.9-1.9 1-3.1 2.2-3.7 3.6-.6 1.4-.8 3-.7 4.7.1 1.7.3 3.4.6 5.3.4 1.8.5 3.6.5 5.4 0 1.7-.5 3.4-1.3 4.9-.8 1.5-2.3 2.9-4.5 4-1.8.9-3.6 1.5-5.2 1.6-1.7.2-3.2 0-4.7-.6-1.5-.5-2.8-1.4-3.9-2.5-1.2-1.2-2.2-2.6-3.1-4.3-1.8-3.6-2.3-6.8-1.4-9.7.9-2.8 3.2-5.2 7-7.1l1.1-.6 1.7 3.4-1.4.7c-2.4 1.2-4.1 2.9-4.9 4.9-.8 2-.6 4.3.7 6.8 1.2 2.4 2.9 4.1 4.9 5 2 .9 4.3.6 7-.7 1.4-.7 2.4-1.6 3.1-2.6.6-1 1-2.1 1.2-3.2.2-1.2.2-2.4 0-3.7-.2-1.3-.4-2.6-.6-4-.2-1.3-.4-2.7-.4-4s0-2.7.3-3.9c.3-1.2.9-2.4 1.8-3.5s2.2-2.1 3.9-3c1.5-.8 3-1.2 4.5-1.4 1.5-.2 2.9 0 4.2.4 1.3.4 2.6 1.2 3.7 2.2 1.2 1 2.2 2.4 3 4.1 1.8 3.5 2.3 6.6 1.4 9.1-.9 2.5-3 4.7-6.5 6.5l-1.9-3.4zM89.6 391.3c-4.2 2.6-7.9 3.8-11.3 3.6-3.3-.2-6.1-1.9-8.4-5.1-2.5-3.6-3.1-7.3-1.6-11.3 1.5-4 5.4-8.1 11.6-12.6 6.2-4.4 11.4-6.7 15.7-6.8 4.2-.1 7.6 1.6 10.1 5.1 1.2 1.7 2 3.5 2.3 5.1.3 1.7.3 3.3-.1 4.8s-1.1 2.9-2.1 4.2c-1 1.3-2.3 2.4-3.7 3.5l-2.2-3.1c2.4-1.7 3.9-3.6 4.6-5.9.7-2.2.2-4.5-1.4-6.7-.9-1.2-1.9-2.1-3.2-2.8-1.2-.6-2.7-.8-4.4-.6-1.7.2-3.6.8-5.9 1.8-2.2 1-4.7 2.5-7.5 4.5s-5.1 3.9-6.7 5.6c-1.7 1.8-2.9 3.4-3.6 5-.7 1.5-1 3-.8 4.4.2 1.4.7 2.7 1.6 3.9 1.6 2.2 3.7 3.3 6.2 3.3 2.6 0 5.4-1 8.6-3l2.2 3.1zM115.3 377.4l2.5 2.9-31.9 28.1-2.5-2.9 31.9-28.1zM127.4 405.1c1.8-1.9 2.7-3.8 2.9-5.8.1-1.9-.8-3.8-2.7-5.6-1-.9-1.9-1.5-2.9-1.9-1-.4-2-.6-2.9-.5-1 0-1.9.3-2.8.7-.9.4-1.7 1-2.4 1.8-1.4 1.5-2.2 3.1-2.2 4.6 0 1.5.3 3.1.9 4.6.6 1.6 1.4 3.1 2.4 4.7s1.7 3.2 2.3 4.9c.5 1.7.7 3.3.5 5.1-.2 1.7-1.2 3.5-2.9 5.3-1.4 1.5-2.9 2.6-4.4 3.3-1.5.7-3 1.1-4.6 1.1-1.5 0-3.1-.4-4.6-1s-3-1.7-4.4-3c-3-2.8-4.5-5.6-4.6-8.6-.1-3 1.3-6 4.2-9.1l.9-.9 2.8 2.6-1.1 1.2c-1.9 2-2.9 4.1-3 6.2-.1 2.2.9 4.2 3 6.2 2 1.9 4.1 2.9 6.3 3 2.2.1 4.3-.9 6.3-3.1 1.1-1.2 1.8-2.3 2-3.5s.3-2.3 0-3.4c-.2-1.1-.7-2.3-1.3-3.5-.6-1.2-1.2-2.3-1.9-3.5l-1.8-3.6c-.5-1.2-.9-2.5-1-3.8-.1-1.3 0-2.6.5-3.9.4-1.3 1.3-2.7 2.6-4.1 1.1-1.2 2.4-2.2 3.7-2.8 1.3-.6 2.7-1 4.1-1 1.4 0 2.8.2 4.2.8 1.4.6 2.8 1.5 4.2 2.8 2.9 2.7 4.4 5.4 4.4 8.1 0 2.7-1.3 5.5-3.9 8.3l-2.8-2.7zM139.8 429.6c.5-.8 1.2-1.2 2.1-1.4.9-.2 1.7 0 2.5.5s1.2 1.2 1.4 2.1c.2.9 0 1.7-.5 2.5s-1.2 1.2-2.1 1.4c-.9.2-1.7 0-2.5-.5s-1.2-1.2-1.4-2.1c-.2-.9 0-1.8.5-2.5zM186.9 440.4c1-2.4 1.2-4.6.7-6.4-.6-1.9-2-3.3-4.5-4.3-1.2-.5-2.3-.8-3.4-.8s-2.1.2-2.9.5c-.9.4-1.7.9-2.4 1.6-.7.7-1.2 1.5-1.6 2.5-.8 1.9-1 3.6-.5 5.1.5 1.5 1.3 2.8 2.4 4 1.1 1.2 2.4 2.4 3.9 3.6s2.7 2.4 3.8 3.8c1.1 1.4 1.8 2.9 2.2 4.6s.1 3.7-.9 5.9c-.8 1.9-1.8 3.5-3 4.6s-2.5 2.1-3.9 2.6-3 .7-4.6.6c-1.6-.1-3.4-.6-5.2-1.3-3.7-1.6-6.2-3.7-7.3-6.5-1.1-2.8-.9-6.1.8-10l.5-1.2 3.5 1.5-.6 1.5c-1.1 2.5-1.3 4.8-.6 6.9.6 2.1 2.3 3.6 4.9 4.8 2.5 1.1 4.8 1.3 6.9.7 2.1-.6 3.7-2.3 4.9-5.1.6-1.5.8-2.8.7-3.9-.2-1.2-.5-2.2-1.2-3.2-.6-1-1.4-1.9-2.4-2.8-1-.9-2-1.8-3-2.6-1-.9-2-1.8-2.9-2.8-.9-1-1.7-2-2.3-3.2-.6-1.1-.9-2.4-.9-3.8-.1-1.4.3-3 1-4.8.6-1.5 1.5-2.8 2.5-3.9s2.2-1.9 3.5-2.4c1.3-.5 2.7-.7 4.3-.7 1.6 0 3.2.4 4.9 1.2 3.7 1.5 6 3.6 6.9 6.1 1 2.5.7 5.6-.8 9.1l-3.4-1.5zM194.9 432.8l3.7.8-.9 38.1h.1l15.2-34.9 4.3 1-1.1 38.1h.1l15.4-34.9 3.7.8-18.1 39.6-4.7-1 1.3-38.1h-.1l-15 35-4.7-1 .8-43.5zM237.9 441l3.8.3-3.7 42.4-3.8-.3 3.7-42.4zM246.9 442.3l6.6-.3 11.8 37.3h.1l8.7-38.2 6.3-.2 1.7 42.5-3.8.2-1.6-38.9h-.1l-9.5 39.4-3.6.1-12.6-38.5h-.1l1.6 38.9-3.8.2-1.7-42.5zM284.4 440.4l6.4-1.6 19 34.2h.1l.9-39.1 6.1-1.5 10.2 41.3-3.7.9-9.3-37.8h-.1l-1.4 40.5-3.5.9-20-35.2h-.1l9.3 37.8-3.7.9-10.2-41.3zM321.6 430l3.6-1.4 15.4 39.7-3.6 1.4-15.4-39.7zM351.7 428.1c-1.2-2.3-2.7-3.9-4.4-4.7-1.8-.8-3.8-.6-6.2.6-1.2.6-2.1 1.3-2.8 2.1-.7.8-1.2 1.7-1.5 2.6-.3.9-.4 1.9-.3 2.9.1 1 .4 1.9.9 2.9 1 1.9 2.1 3.1 3.6 3.7 1.4.6 3 .8 4.7.7 1.7-.1 3.4-.3 5.3-.6 1.8-.3 3.6-.5 5.4-.4 1.7.1 3.4.5 4.9 1.3 1.5.8 2.9 2.3 4 4.5.9 1.8 1.5 3.6 1.6 5.3.2 1.7 0 3.2-.6 4.7-.5 1.5-1.4 2.8-2.5 3.9s-2.6 2.2-4.4 3.1c-3.6 1.8-6.8 2.3-9.7 1.4-2.8-.9-5.2-3.3-7.1-7l-.6-1.1 3.4-1.7.7 1.4c1.2 2.4 2.9 4.1 4.8 4.9 2 .8 4.3.6 6.8-.7 2.4-1.2 4.1-2.9 5-4.9.9-2 .6-4.3-.7-7-.7-1.4-1.6-2.4-2.6-3.1s-2.1-1-3.2-1.2c-1.2-.2-2.4-.2-3.7 0-1.3.2-2.6.4-4 .6-1.3.2-2.7.3-4 .4s-2.7 0-3.9-.3-2.4-.9-3.5-1.8-2.1-2.2-3-3.9c-.8-1.5-1.2-3-1.4-4.5-.2-1.5 0-2.9.4-4.2.4-1.3 1.2-2.6 2.2-3.7s2.4-2.2 4.1-3c3.5-1.8 6.6-2.2 9.1-1.4 2.5.9 4.7 3.1 6.4 6.5l-3.2 1.7zM379 424.8c-.5-.7-.8-1.5-.6-2.4.1-.9.6-1.6 1.3-2.2.7-.5 1.5-.8 2.4-.6.9.1 1.6.6 2.2 1.3.6.7.8 1.5.6 2.4-.1.9-.6 1.6-1.3 2.2-.7.6-1.5.8-2.4.6-1-.1-1.7-.5-2.2-1.3zM405.3 384.3c-1.9-1.8-3.8-2.7-5.8-2.8-1.9-.1-3.8.8-5.6 2.7-.9 1-1.5 1.9-1.9 2.9-.4 1-.6 2-.5 2.9 0 1 .3 1.9.7 2.8.4.9 1 1.7 1.8 2.4 1.5 1.4 3.1 2.2 4.6 2.2 1.5 0 3.1-.3 4.6-.9 1.6-.6 3.1-1.4 4.7-2.4s3.2-1.7 4.9-2.3c1.7-.6 3.3-.7 5.1-.5 1.7.2 3.5 1.2 5.3 2.8 1.5 1.4 2.6 2.9 3.3 4.4.7 1.5 1.1 3 1.1 4.6 0 1.5-.3 3.1-1 4.6-.7 1.5-1.7 3-3 4.4-2.8 3-5.6 4.5-8.6 4.6-3 .1-6-1.3-9.1-4.1l-.9-.9 2.6-2.8 1.2 1.1c2 1.9 4.1 2.9 6.2 3 2.2.1 4.2-.9 6.2-3 1.9-2 2.9-4.1 3-6.3.1-2.2-.9-4.3-3.1-6.3-1.2-1.1-2.3-1.8-3.5-2-1.1-.3-2.3-.3-3.4 0-1.1.2-2.3.7-3.5 1.3-1.2.6-2.3 1.3-3.5 1.9l-3.6 1.8c-1.2.6-2.5.9-3.8 1-1.3.1-2.6 0-3.9-.5-1.3-.4-2.7-1.3-4.1-2.6-1.2-1.1-2.2-2.4-2.8-3.7-.7-1.3-1-2.7-1-4.1 0-1.4.2-2.8.8-4.2.6-1.4 1.5-2.8 2.8-4.2 2.7-2.9 5.4-4.4 8.1-4.4 2.7 0 5.5 1.3 8.3 3.9l-2.7 2.7zM419.7 383.6c-6.3-4.3-10.3-8.4-11.8-12.3-1.6-3.9-1.2-7.7 1.3-11.3 2.4-3.6 5.8-5.4 10-5.3s9.5 2.2 15.8 6.5c6.3 4.3 10.2 8.4 11.8 12.3 1.6 3.9 1.1 7.7-1.3 11.3-2.5 3.6-5.8 5.4-10 5.4-4.2-.2-9.5-2.3-15.8-6.6zm2.2-3.2c2.9 1.9 5.4 3.4 7.6 4.4 2.2 1 4.2 1.5 5.9 1.7s3.2-.1 4.4-.7c1.2-.6 2.3-1.6 3.1-2.8.8-1.2 1.3-2.6 1.5-3.9.1-1.4-.2-2.8-.9-4.3-.8-1.5-2-3.2-3.7-4.9-1.7-1.7-4-3.6-6.9-5.5s-5.4-3.4-7.6-4.4c-2.2-1-4.2-1.5-5.9-1.7s-3.2.1-4.4.7c-1.2.6-2.3 1.6-3.1 2.8-.8 1.2-1.3 2.6-1.5 3.9-.1 1.4.2 2.8.9 4.3.8 1.5 2 3.2 3.7 4.9 1.7 1.8 4 3.6 6.9 5.5zM419.1 345.6l1.7-3.4 35.4 17.2 7.7-15.9 2.9 1.4-9.4 19.3-38.3-18.6zM429.2 323.6l1.4-3.6 39.8 15.1-1.4 3.6-39.8-15.1zM448 300c-2.5-.7-4.7-.6-6.4.2-1.8.8-3 2.5-3.7 5-.3 1.3-.4 2.4-.3 3.5.1 1.1.4 2 .9 2.8.5.8 1.1 1.5 1.9 2.1.8.6 1.7 1 2.7 1.3 2 .5 3.7.5 5.1-.2 1.4-.7 2.6-1.7 3.7-3s2.1-2.7 3.1-4.3c1-1.6 2-3 3.3-4.3 1.2-1.3 2.6-2.2 4.2-2.8 1.6-.6 3.6-.6 6 0 2 .5 3.7 1.3 5 2.3 1.3 1 2.4 2.2 3.1 3.5.7 1.4 1.1 2.9 1.2 4.5.1 1.7-.1 3.4-.6 5.3-1.1 3.9-2.9 6.6-5.5 8.1s-5.9 1.7-10 .6l-1.2-.3 1-3.7 1.6.4c2.6.7 4.9.6 6.9-.3 2-.9 3.3-2.7 4-5.5.7-2.6.6-5-.3-7-.9-2-2.8-3.4-5.7-4.2-1.5-.4-2.9-.5-4-.2s-2.1.8-3.1 1.6c-.9.7-1.7 1.7-2.5 2.8-.7 1.1-1.5 2.2-2.2 3.3-.7 1.1-1.5 2.2-2.4 3.3-.8 1.1-1.8 2-2.8 2.7-1.1.7-2.3 1.2-3.7 1.4-1.4.2-3 .1-4.9-.4-1.6-.4-3-1.1-4.2-2-1.2-.9-2.1-1.9-2.8-3.1-.7-1.2-1.1-2.6-1.3-4.1-.2-1.5 0-3.2.5-5 1-3.8 2.7-6.4 5.1-7.7 2.4-1.3 5.4-1.4 9.1-.4l-.8 3.8zM58.7 164.7c-1.2-.5-2.3-.7-3.3-.6-1 .1-1.8.7-2.2 1.6-.5 1.1-.5 2 0 2.9.5.8 1.2 1.4 2 1.8 1.3.6 2.5.6 3.6.1s2.2-1.2 3.3-2.2c1.1-1 2.2-2.1 3.4-3.2 1.2-1.2 2.5-2.2 4-3 1.5-.8 3.1-1.3 4.9-1.5 1.8-.2 3.9.3 6.3 1.3 4.1 1.8 6.6 4.4 7.4 7.6.8 3.2.2 7-1.8 11.5-.9 2.1-1.9 3.9-3 5.4-1.1 1.5-2.3 2.6-3.6 3.3-1.3.7-2.8 1.1-4.5 1-1.6 0-3.5-.5-5.5-1.4l-1.4-.6 4.4-9.8.9.4c1.7.7 3 1 3.9.6.9-.3 1.6-1 2.1-2 .5-1.1.5-2 0-2.9-.5-.9-1.2-1.6-2.3-2-1.3-.6-2.5-.6-3.6-.2-1.1.5-2.2 1.1-3.2 2.1-1.1.9-2.2 2-3.3 3.1-1.2 1.1-2.4 2.1-3.8 2.9-1.4.8-3 1.3-4.8 1.4-1.8.2-3.8-.3-6.1-1.3-4-1.8-6.5-4.2-7.6-7.2-1.1-3-.7-6.7 1.2-11 2-4.4 4.4-7.2 7.2-8.4 2.8-1.1 6.3-.8 10.5 1.1l-4.2 9.5-.9-.3zM64 149.1l-7.9-5.1 15-23.3 7.9 5.1-4.5 7 27.9 18-6 9.3-27.9-18-4.5 7zM87 101.8l39.1 19.9-7.7 9-6.4-4-5.8 6.7 4.9 5.7-7.6 8.8-25.7-35.5 9.2-10.6zm2 11.1l11.8 14.1 4-4.7-15.8-9.4zM100.5 100.8l-6.3-7.1L115 75.4l6.3 7.1L115 88l22 24.9-8.3 7.4-22-24.9-6.2 5.4zM142.1 57.3l5 7.6-11.9 7.7 4 6.1 11.1-7.2 4.8 7.3-11.2 7.2 4.6 7.1 12.3-8 5 7.6-21.6 14.1-23.3-35.7 21.2-13.8zM170.4 55.5c-.4-2.8-.4-5.3.2-7.3.5-2.1 1.6-3.8 3.2-5.2 1.6-1.4 3.7-2.6 6.4-3.5 2.7-.9 5.1-1.3 7.2-1.2 2.1.1 4 .8 5.7 2.1 1.7 1.3 3.3 3.2 4.7 5.6 1.4 2.5 2.8 5.6 4.1 9.4 1.3 3.8 2.2 7 2.6 9.9.4 2.8.4 5.3-.2 7.3-.5 2.1-1.6 3.8-3.2 5.1-1.6 1.4-3.7 2.5-6.4 3.4-2.7.9-5 1.4-7.1 1.3-2.1-.1-4-.7-5.7-2-1.7-1.3-3.3-3.2-4.7-5.6-1.4-2.5-2.8-5.6-4.1-9.4-1.4-3.8-2.3-7.1-2.7-9.9zm15.9 12.7c.7 1.8 1.4 3.1 2 4.1.6 1 1.2 1.6 1.8 1.8.6.2 1.3.2 2.1 0 .8-.3 1.3-.7 1.7-1.3.3-.6.4-1.4.3-2.6-.1-1.1-.5-2.6-1-4.4-.6-1.8-1.3-4.1-2.2-6.8-.9-2.7-1.8-4.9-2.5-6.7-.7-1.8-1.4-3.1-2-4.1-.6-1-1.2-1.6-1.8-1.8-.6-.2-1.3-.2-2.1 0-.8.3-1.3.7-1.7 1.3-.3.6-.4 1.4-.3 2.6.1 1.1.5 2.6 1 4.4.6 1.8 1.3 4.1 2.2 6.8 1 2.8 1.8 5 2.5 6.7zM228.5 28.6l1.6 8.9-13.9 2.5 1.3 7.2 13.1-2.4 1.5 8.6-13.1 2.4 3.1 17.3-10.9 2-7.6-42 24.9-4.5zM266.4 27.5l-.9 15.6 6.8.4.9-15.6 11.1.7-2.5 42.6-11.1-.7 1-17.5-6.8-.4-1 17.5-11.1-.7 2.5-42.6 11.1.7zM315.4 35l.3 43.9-11.5-2.7.6-7.5-8.6-2-2.8 7-11.3-2.7 19.7-39.2 13.6 3.2zm-8.8 6.9l-7.1 16.9 6 1.4 1.2-18.3h-.1z\"/>\n  <path d=\"M347.7 46.5l-6.5 24.8h.1l14.7-21 14.4 6.7-17.9 38.7-9.4-4.4 13.3-28.8h-.1l-18.7 26.4-7.3-3.4 8-31.3h-.1L324.9 83l-9.4-4.4 17.9-38.7 14.3 6.6zM387.4 68.7l-23.7 35.5-9.2-6.2 23.7-35.5 9.2 6.2zM402.8 80.7l-21.6 25.7 10.5 8.8-5.8 7-19-15.9 27.4-32.7 8.5 7.1zM406.2 95.7l6.9-6.5 19 20.2-6.9 6.5-5.7-6.1-24.2 22.8-7.6-8.1 24.2-22.8-5.7-6zM427.3 121.2c2.6-1.2 5-1.7 7.1-1.8 2.1 0 4.1.5 5.9 1.7 1.8 1.1 3.5 2.9 5.1 5.2 1.6 2.3 2.6 4.5 3 6.6.4 2.1.3 4.1-.5 6.1s-2.2 4-4.2 6-4.7 4.1-8 6.4c-3.3 2.3-6.2 4-8.8 5.1-2.6 1.2-5 1.7-7.1 1.8-2.1 0-4.1-.6-5.8-1.7-1.7-1.2-3.4-2.9-5-5.3-1.6-2.3-2.6-4.5-3.1-6.6-.5-2-.3-4 .5-6s2.2-4 4.2-6 4.7-4.1 8-6.4c3.2-2.2 6.1-3.9 8.7-5.1zm-8.1 18.7c-1.5 1.1-2.7 2.1-3.4 3-.8.8-1.2 1.6-1.3 2.3-.1.7.1 1.3.6 2s1 1.1 1.7 1.3c.6.2 1.5 0 2.6-.4s2.4-1.1 4-2.1 3.6-2.3 6-3.9 4.3-3 5.8-4.1c1.5-1.1 2.7-2.1 3.4-3 .8-.8 1.2-1.6 1.3-2.3.1-.7-.1-1.3-.6-2s-1-1.1-1.7-1.3c-.6-.2-1.5 0-2.6.4s-2.4 1.1-4 2.1-3.6 2.3-6 3.9-4.3 3-5.8 4.1zM463.2 159.2l-21 17.4v.1l23.9-10.9 4.3 9.5-38.8 17.6-5-11.1 20.9-17.6v-.1l-24 10.9-4.3-9.5 38.8-17.6 5.2 11.3zM325.8 201.4H269c-4.5-.2-8.1-3.9-8.1-8.5 0-4.7 3.8-8.5 8.5-8.5.5 0 1.1.1 1.6.2 2.1-3.8 6.9-6.2 12.4-6.2 5.9 0 11.1 3 12.8 7.2 4.8-.5 9 2.7 9 6.7 0 .4 0 .8-.1 1.1h20.8c2.2 0 4 1.8 4 4s-1.9 4-4.1 4zm-56.4-14.5c-3.3 0-6 2.7-6 6 0 3.2 2.5 5.9 5.8 6h56.6c.8 0 1.5-.7 1.5-1.5s-.7-1.5-1.5-1.5h-24.7l1.1-1.9c.3-.6.5-1.1.5-1.7 0-2.4-2.5-4.3-5.5-4.3-.5 0-1 .1-1.5.2l-1.2.3-.3-1.2c-.9-3.7-5.5-6.4-10.8-6.4-4.9 0-9.2 2.3-10.5 5.7l-.4 1.1-1.1-.4c-.7-.3-1.4-.4-2-.4zM291.9 248.2H302c.5 0 .8-.4.8-.8V238.3c0-1.9-2.5-3.4-5.9-3.4s-5.9 1.5-5.9 3.4v9.1c.1.5.5.8.9.8zm6-11.6c2.1.2 3.4 1 3.4 1.7v2.9h-3.4v-4.6zm0 6.2h3.4v3.7h-3.4v-3.7zm-5.1-4.6c0-.6 1.3-1.5 3.4-1.7v4.5h-3.4v-2.8zm0 4.6h3.4v3.7h-3.4v-3.7zM329 248.2h10.1c.5 0 .8-.4.8-.8v-9.1c0-1.9-2.5-3.4-5.9-3.4s-5.9 1.5-5.9 3.4v9.1c.1.5.4.8.9.8zm5.9-11.6c2.1.2 3.4 1 3.4 1.7v2.9h-3.4v-4.6zm0 6.2h3.4v3.7h-3.4v-3.7zm-5.1-4.6c0-.6 1.3-1.5 3.4-1.7v4.5h-3.4v-2.8zm0 4.6h3.4v3.7h-3.4v-3.7z\"/>\n  <path d=\"M423.7 319.3c-1.8-.9-3.8-1.6-5.8-2-9.6-2-19.2-.8-28.8-.1-4.9.3-9.9.7-14.9 1.1 1-3.1 2.1-5.7 2.7-8.5.6-2.7.8-5.6 1.1-8.6-5.7.2-10.6 1.7-14.7 4.9-4.1 3.1-7.6 6.9-11.4 10.4.2.2 0 .1-.1 0-1.1-1.3-2.2-2.6-3.2-3.9-10-12.4-22.5-20.3-38.5-22.1-3.7-.4-7.4-1-11.1-1.4-14.3-1.6-26.7-6.3-37.1-13.1 2.2-1.4 5-2.4 9.1-2.4 6.4 0 9.5 2.5 12.5 4.9 2.8 2.3 5.3 4.2 10.2 4.2 5 0 7.4-2 10.2-4.2 3-2.4 6.1-4.9 12.5-4.9s9.5 2.5 12.5 4.9c2.8 2.3 5.3 4.2 10.2 4.2 5 0 7.4-2 10.2-4.2 3-2.4 6.1-4.9 12.5-4.9s9.5 2.5 12.5 4.9c2.8 2.3 5.3 4.2 10.2 4.2 5 0 7.4-2 10.2-4.2 3-2.4 6.1-4.9 12.5-4.9 2.1 0 3.9.3 5.7.8-1.4 12.2-4.2 24-8.2 35.4h1c2.9 0 5.6.2 8.1.5 5.8-17 9-35.2 9-54.1 0-92.4-74.9-167.2-167.2-167.2-39.4 0-75.7 13.7-104.3 36.5 3 .7 6.3.8 9.6.8H164.8c26.4-18.5 57.8-28.5 90.8-28.5 42.3 0 82.1 16.5 112 46.4 27.2 27.2 43.3 62.6 46 100.6-11.2-9.3-23.1-6.7-35.3-2.8v.1c-.3.1-.8.2-1.4.4l-2.3-18.9-3.5-29.5h4.7c.5 0 1-.4 1.2-.9l2-6.5c.1-.4 0-.8-.2-1.1s-.6-.5-1-.5h-8v-8.9h2c.5 0 1-.3 1.2-.8s.1-1-.3-1.4l-11.4-10.3c.9-.8 1.5-2 1.5-3.3 0-2-1.3-3.7-3.1-4.2v-5.7c0-.7-.6-1.2-1.2-1.2s-1.2.6-1.2 1.2v5.7c-1.8.5-3.1 2.2-3.1 4.2 0 1.3.6 2.4 1.5 3.2l-11.5 10.3c-.4.3-.5.9-.3 1.4s.6.8 1.2.8h2v8.9h-8c-.4 0-.8.2-1 .5-.2.3-.3.7-.2 1.1l2 6.5c.2.5.6.9 1.2.9h4.7l-2 16.5H286c-.5 0-1 .3-1.2.8l-7 18c-.1.4-.1.8.1 1.2.2.3.6.5 1 .5h5.1v20.9l-8.1.2c.9-1.5 2.2-3.8 2.8-4.9.5-.9.2-2.5-1-4.1.8-.1 1.4-.2 1.6-.2.6 0 4.1-6-1.1-8-3-1.1-10.4-1-15.3-.3s-3.3 2.4-2.4 2.4c3.8 0 5.6 2.2 2 2.1s-16.4 3.5-12.7 4.4c3.3.8 10.6-1.1 12.1.2.9.8 2.8 1.1 4.7 1.1 2.2 1.7 3.5 4.6 3.5 7.5l-23.5.6c-.4 0-.8.2-1 .5-1.4 1.5-2.6 2.8-3.7 4.1-7.6-10.4-12.8-22.6-15.2-35.7-2.2-11.6-2.3-23.6-3.2-35.4-.7-9.1-1.5-18-5.8-26.3-7-13.8-17.2-23.7-32.8-26.4-6.3-1.1-13-.5-19.5-.6-6.5-.1-12.9.4-19.3-2.1-3.3-1.3-7.1-1.7-10.7-2-5.6-.5-9 1.9-9.4 6.4-.7 10-.1 19.9 3.1 29.5 2.6 7.6 7.8 13.2 13.9 18.1 5.1 4.2 9.4 9.2 10.6 15.7 1.4 7.2 2.1 14.6 2.7 21.9.6 7.2-.9 14-3.9 20.6-2.6 5.7-4.8 11.6-6.9 17.5-1.2 3.5-2.4 7.1-2.8 10.8-2.4-.9-5.3-1.6-8.9-1.6-8.5 0-13 3.6-16.3 6.3-2.6 2.1-3.6 2.9-6.5 2.9s-3.9-.9-6.5-2.9c-1.8-1.5-4-3.2-7-4.5-.4-4.4-.6-8.8-.6-13.2 0-31.7 9.2-62 26.5-87.7-.2-.5-.4-1.1-.6-1.7-1-3-1.8-6.1-2.4-9.3-19.6 27.2-31.6 61.3-31.6 98.2 0 32.1 9 62.1 24.7 87.5 1.2-.4 2.6-.6 4.2-.6h1.1c1.7.1 3.3.2 5 .4-13.3-20.1-21.8-42.8-24.9-66.9.9.6 1.7 1.3 2.5 1.9 2.8 2.3 5.3 4.2 10.2 4.2 5 0 7.4-2 10.2-4.2 3-2.4 6.1-4.9 12.5-4.9 3.8 0 6.4.9 8.6 2.1-.2 7.4 0 14.7.2 22.1.4 15.3 2.5 30.2 8.8 44.3 1.2 2.7 2.1 5.6 3.1 8.4-4.4 2.2-7.3 2.4-13.6 1.7-7.7-.9-15.4-2-23.1-2.5-5-.3-6.8 2.6-5.2 7.4 2.6 7.6 7.1 13.9 13.6 18.5 2.1 1.5 4.8 2.7 7.3 3.1 4.4.6 8.9.8 13.3.6 7.9-.2 15.7-.9 23.6-1.2 1.3 0 2.8.5 3.8 1.3 3.4 2.7 7.2 4.3 11.5 4.8 5.3.6 10.6 1.2 15.9 2.1 1.3.2 2.8 1.1 3.6 2.2 5.2 6.3 11.4 11.1 19.5 12.4 9.5 1.6 19 2.9 28.6 3.6 6.1.5 12.3 0 18.4-.5 5.6-.5 7.6-4.6 4.5-9.3-1.8-2.8-4-5.6-6.6-7.7-5.4-4.3-11.1-8.2-16.9-12.3 15.1-4.2 30.2-8.4 45.2-12.5 19.7-5.4 39.3-11.3 57.7-20.4 1.9-.9 3.4-.8 5.2.3 6.2 3.9 13.2 5 20.1 3.2 7.6-2 15-4.5 22.2-7.6 7.7-3.3 14.8-7.9 20.6-14.2 1.7-1.8 1.4-3.1-.5-4zm-53.5-132.1h6.4l-1.2 4h-5.1v-4zm-1.2-13.9h-4.4l-2.9-6.6 7.3 6.6zm-4.3 11.4v-8.9h3v8.9h-3zm3 2.5v4h-3v-4h3zm-12.4-2.5v-8.9h6.9v8.9h-6.9zm6.9 2.5v4h-6.9v-4h6.9zm-3.4-29c1 0 1.9.9 1.9 1.9s-.9 1.9-1.9 1.9-1.9-.9-1.9-1.9.9-1.9 1.9-1.9zm0 8.1l3.1 7.1h-6.2l3.1-7.1zm-2.9.4l-2.9 6.6h-4.4l7.3-6.6zm-6.1 18v-8.9h3v8.9h-3zm3 2.5v4h-3v-4h3zm-10.6 4l-1.2-4h6.4v4h-5.2zm6.3 2.8h20.6l3.5 29.6 2.3 19.4c-.1 0-.1 0-.2.1l-21.1 6.9-6.4.2v-19.4h4.3c.4 0 .7-.2 1-.5.2-.3.3-.7.3-1l-1.2-6.1v-.1c0-.1-.1-.2-.1-.2 0-.1-.1-.1-.1-.2l-.2-.2c-.1-.1-.1-.1-.2-.1s-.1-.1-.2-.1-.2 0-.3-.1h-5.3l3.3-28.2zm-67.4 34.2l6-15.5h56.6l-1.3 10.6c0 .4.1.7.3 1s.6.4.9.4h5.6l.7 3.6h-68.8zm42 7.4l-7.2-4.5c-.3-.2-.6-.2-.9 0l-7.2 4.5c-.3.2-.5.6-.4.9.1.4.4.6.8.6h1.5V251l-22.8.6v-20.9h57.9v19.4l-23.7.6v-13.6h1.5c.4 0 .7-.3.8-.6.1-.3 0-.7-.3-.9zm-11.9-.1l4.2-2.6 4.2 2.6h-8.4zm8.2 1.7v13.6l-2.9.1h-5v-13.7h7.9zm-46.5 7.3c.1-.2.1-.4.1-.7 1.1-.2 2.3-.4 3.3-.6 3 3.5-.9 5.6-2.4 7.3-.3-1-.9-2.1-1.8-3.1.3-1.1.6-2.3.8-2.9zm-3.9-.1c.4 0 .8-.1 1.2-.2.5-.1 1.1-.2 1.8-.3-.2.9-.6 1.7-.9 2.2-.7-.6-1.4-1.2-2.1-1.7zm-24.8 15.2c1.1-1.3 2.2-2.6 3.6-4.1L354 253c.1 0 .3 0 .4-.1 0 0 24.7-8.1 25.2-8.3 12.5-3.9 23.8-6.3 34.5 4 .1.1.1.1.2.1.1 2.4.2 4.8.2 7.3 0 4.1-.2 8.2-.5 12.2-2-.5-4-.8-6.2-.8-8.5 0-13 3.6-16.3 6.3-2.6 2.1-3.6 2.9-6.5 2.9s-3.9-.9-6.5-2.9c-3.3-2.6-7.8-6.3-16.3-6.3s-13 3.6-16.3 6.3c-2.6 2.1-3.6 2.9-6.5 2.9s-3.9-.9-6.5-2.9c-3.3-2.6-7.8-6.3-16.3-6.3s-13 3.6-16.3 6.3c-2.6 2.1-3.6 2.9-6.5 2.9s-3.9-.9-6.5-2.9c-3.3-2.6-7.8-6.3-16.3-6.3-6.9 0-11.2 2.4-14.3 4.7-4.6-3.7-8.8-7.9-12.5-12.5z\"/></svg>"
+}

--- a/libs/fixtures/src/__snapshots__/index.test.ts.snap
+++ b/libs/fixtures/src/__snapshots__/index.test.ts.snap
@@ -7,6 +7,7 @@ exports[`has various election definitions 1`] = `
   "electionGridLayoutNewHampshireHudsonFixtures",
   "electionGridLayoutNewHampshireTestBallotFixtures",
   "electionMultiPartyPrimaryFixtures",
+  "electionOpenPrimaryFixtures",
   "electionPrimaryPrecinctSplitsFixtures",
   "electionSimpleSinglePrecinctFixtures",
   "electionTwoPartyPrimaryFixtures",

--- a/libs/fixtures/src/data/election_open_primary.test.ts
+++ b/libs/fixtures/src/data/election_open_primary.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'vitest';
+import { isOpenPrimary } from '@votingworks/types';
+import { readElection } from './election_open_primary';
+
+test('is recognized as an open primary', () => {
+  expect(isOpenPrimary(readElection())).toEqual(true);
+});

--- a/libs/fixtures/src/data/election_open_primary.ts
+++ b/libs/fixtures/src/data/election_open_primary.ts
@@ -1,0 +1,6 @@
+import * as builders from '../builders';
+
+export const electionJson = builders.election(
+  'data/electionOpenPrimary/election.json'
+);
+export const { readElection, readElectionDefinition } = electionJson;

--- a/libs/fixtures/src/index.ts
+++ b/libs/fixtures/src/index.ts
@@ -9,6 +9,7 @@ export * as electionTwoPartyPrimaryFixtures from './data/election_two_party_prim
 export * as electionPrimaryPrecinctSplitsFixtures from './data/election_primary_precinct_splits';
 export * as electionWithMsEitherNeitherFixtures from './data/election_with_ms_either_neither';
 export * as electionSimpleSinglePrecinctFixtures from './data/election_simple_single_precinct';
+export * as electionOpenPrimaryFixtures from './data/election_open_primary';
 export * as sampleBallotImages from './data/sample_ballot_images';
 export {
   readElectionDefinition as readElectionGeneralDefinition,
@@ -27,5 +28,9 @@ export {
   readElectionDefinition as readElectionWithMsEitherNeitherDefinition,
   readElection as readElectionWithMsEitherNeither,
 } from './data/election_with_ms_either_neither';
+export {
+  readElectionDefinition as readElectionOpenPrimaryDefinition,
+  readElection as readElectionOpenPrimary,
+} from './data/election_open_primary';
 export const systemSettings = builders.file('data/systemSettings.json');
 export * from './tmpdir';

--- a/libs/types/src/election.test.ts
+++ b/libs/types/src/election.test.ts
@@ -524,6 +524,20 @@ test('election schema', () => {
   }
 });
 
+test('election schema rejects primary with mixed partyId ballot styles', () => {
+  const mixedPrimary: Election = {
+    ...primaryElection,
+    ballotStyles: [
+      primaryElection.ballotStyles[0]!,
+      { ...primaryElection.ballotStyles[1]!, partyId: undefined },
+    ],
+  };
+  const result = safeParseElection(mixedPrimary);
+  expect(result.err()?.message).toContain(
+    'must either all have a partyId (closed primary) or all omit partyId (open primary)'
+  );
+});
+
 test('getCandidateParties', () => {
   expect(
     getCandidateParties(election.parties, {

--- a/libs/types/src/election.test.ts
+++ b/libs/types/src/election.test.ts
@@ -16,6 +16,7 @@ import {
   getPartyFullNameFromBallotStyle,
   getPartyIdsInBallotStyles,
   getPartyIdsWithContests,
+  isOpenPrimary,
   getPartyPrimaryAdjectiveFromBallotStyle,
   getPrecinctById,
   getPrecinctIndexById,
@@ -259,6 +260,24 @@ test('getPartyIdsInBallotStyles', () => {
   expect(getPartyIdsInBallotStyles(electionTwoPartyPrimary)).toEqual(
     electionTwoPartyPrimary.parties.map(({ id }) => id)
   );
+});
+
+test('isOpenPrimary', () => {
+  // general election
+  expect(isOpenPrimary(election)).toEqual(false);
+
+  // closed primary (ballot styles have partyId)
+  expect(isOpenPrimary(primaryElection)).toEqual(false);
+
+  // open primary (ballot styles have no partyId)
+  const openPrimaryElection: Election = {
+    ...primaryElection,
+    ballotStyles: primaryElection.ballotStyles.map((bs) => ({
+      ...bs,
+      partyId: undefined,
+    })),
+  };
+  expect(isOpenPrimary(openPrimaryElection)).toEqual(true);
 });
 
 test('getGroupIdFromBallotStyleId', () => {

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -913,6 +913,24 @@ export const ElectionSchema: z.ZodSchema<Election> = z
         }
       }
     }
+
+    if (election.type === 'primary') {
+      const hasBallotStyleWithPartyId = election.ballotStyles.some(
+        (bs) => bs.partyId
+      );
+      const hasBallotStyleWithoutPartyId = election.ballotStyles.some(
+        (bs) => !bs.partyId
+      );
+      if (hasBallotStyleWithPartyId && hasBallotStyleWithoutPartyId) {
+        ctx.issues.push({
+          code: 'custom',
+          path: ['ballotStyles'],
+          message:
+            'Primary election ballot styles must either all have a partyId (closed primary) or all omit partyId (open primary).',
+          input: election,
+        });
+      }
+    }
   });
 export type OptionalElection = Optional<Election>;
 export const OptionalElectionSchema: z.ZodSchema<OptionalElection> =

--- a/libs/types/src/election_utils.ts
+++ b/libs/types/src/election_utils.ts
@@ -400,6 +400,18 @@ export function getPartyIdsInBallotStyles(
   return Array.from(new Set(election.ballotStyles.map((bs) => bs.partyId)));
 }
 
+/**
+ * An open primary is a primary election where ballot styles don't have a
+ * partyId, meaning voters choose which party's contests to vote in at the
+ * polls rather than being assigned a party ballot.
+ */
+export function isOpenPrimary(election: Election): boolean {
+  return (
+    election.type === 'primary' &&
+    election.ballotStyles.every((bs) => !bs.partyId)
+  );
+}
+
 export function getContestDistrict(
   election: Election,
   contest: ContestLike


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Task: #7823

Foundation for open primary support. Adds an `isOpenPrimary()` helper to detect open primaries (primary elections where ballot styles have no `partyId`), schema validation ensuring primaries are uniformly closed or open, and a generic open primary election fixture.

Part of the MI open primaries project — this is the first in a series of PRs.

## Demo Video or Screenshot

N/A — no UI changes.

## Testing Plan

- Unit tests for `isOpenPrimary()` covering general, closed primary, and open primary elections
- Unit test for schema validation rejecting mixed ballot styles
- Fixture integration test verifying `isOpenPrimary()` returns `true` for the new fixture

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.