### PR TITLE
VxScan HWTA: Ensure both headphone and speaker output work

### DIFF
--- a/apps/scan/backend/src/electrical_testing/server.ts
+++ b/apps/scan/backend/src/electrical_testing/server.ts
@@ -94,11 +94,14 @@ export async function startElectricalTestingServer(
 
 async function configureAudio(logger: Logger): Promise<AudioPlayer> {
   const audioCard = await AudioCard.default(NODE_ENV, logger);
+  const audioPlayer = new AudioPlayer(NODE_ENV, logger, audioCard);
+
+  // Enables the ability to toggle back and forth between headphone and speaker output
+  await audioPlayer.setIsScreenReaderEnabled(true);
 
   // System volume is set to 100% in the prod app, but the HWTA has no UI volume control, so we set
   // to a safe listening level discovered the hard way
-  await audioCard.useHeadphones();
-  await audioCard.setVolume(40);
+  await audioPlayer.setVolume(40);
 
-  return new AudioPlayer(NODE_ENV, logger, audioCard);
+  return audioPlayer;
 }


### PR DESCRIPTION
## Overview

Just remembered that latest changes to VxScan code to disable headphone audio via system setting mean that the audio player needs to be configured just a little differently in the VxScan HWTA for both headphones and speakers to work.

## Testing Plan

- [x] Incorporated into an HWTA image and confirmed on relevant hardware that both headphones and speaker are working as expected