### PR TITLE
VxMarkScan HWTA: Don't render power button since VxMS has a physical button and buttons can get triggered during EMI/ESD testing

### DIFF
--- a/apps/mark-scan/frontend/src/electrical_testing/app_root.tsx
+++ b/apps/mark-scan/frontend/src/electrical_testing/app_root.tsx
@@ -14,7 +14,6 @@ import {
   setCardReaderTaskRunning,
   setPaperHandlerTaskRunning,
   setUsbDriveTaskRunning,
-  systemCallApi,
   useApiClient,
 } from './api';
 import { useSound } from '../hooks/use_sound';
@@ -31,7 +30,6 @@ export function AppRoot(): JSX.Element {
   const setCardReaderTaskRunningMutation =
     setCardReaderTaskRunning.useMutation();
   const setUsbDriveTaskRunningMutation = setUsbDriveTaskRunning.useMutation();
-  const powerDownMutation = systemCallApi.powerDown.useMutation();
 
   const [calibratingHeadphones, setCalibratingHeadphones] = useState(false);
   const [isSoundEnabled, setIsSoundEnabled] = useState(true);
@@ -58,10 +56,6 @@ export function AppRoot(): JSX.Element {
 
   function toggleSoundEnabled() {
     setIsSoundEnabled((prev) => !prev);
-  }
-
-  function powerDown() {
-    powerDownMutation.mutate();
   }
 
   useInterval(
@@ -136,7 +130,6 @@ export function AppRoot(): JSX.Element {
           body: <InputControls />,
         },
       ]}
-      powerDown={powerDown}
       usbDriveStatus={usbDriveStatus?.underlyingDeviceStatus}
       apiClient={apiClient}
     />

--- a/libs/ui/src/electrical_testing_screen.tsx
+++ b/libs/ui/src/electrical_testing_screen.tsx
@@ -143,7 +143,7 @@ export function ElectricalTestingScreen<Id extends React.Key>({
   header?: React.ReactNode;
   tasks: ReadonlyArray<Task<Id>>;
   modals?: React.ReactNode;
-  powerDown: () => void;
+  powerDown?: () => void;
   usbDriveStatus?: UsbDriveStatus;
   /** API client for signed hash validation */
   apiClient: SignedHashValidationApiClient;
@@ -181,9 +181,11 @@ export function ElectricalTestingScreen<Id extends React.Key>({
             >
               Save Logs
             </Button>
-            <Button icon={<Icons.PowerOff />} onPress={powerDown}>
-              Power Down
-            </Button>
+            {powerDown && (
+              <Button icon={<Icons.PowerOff />} onPress={powerDown}>
+                Power Down
+              </Button>
+            )}
           </Footer>
         </Column>
         {isSaveLogsModalOpen && usbDriveStatus && (


### PR DESCRIPTION
We've seen touch events get triggered during VxMarkScan EMI/ESD pretesting, and while most button presses are inconsequential, the power down button getting triggered is more likely to get flagged as an issue. I'm removing the power down button from the VxMarkScan HWTA accordingly. It has a physical power button so no need for an on-screen button anyway.