### PR TITLE
[VxPrint] [Dev] Replace precinct picker with polling place picker

### DIFF
--- a/apps/print/frontend/src/screens/election_screen.tsx
+++ b/apps/print/frontend/src/screens/election_screen.tsx
@@ -5,14 +5,20 @@ import {
   P,
   Seal,
   UnconfigureMachineButton,
-  SearchSelect,
+  ChangePrecinctButton,
+  PollingPlacePicker,
 } from '@votingworks/ui';
-import { format } from '@votingworks/utils';
-import { Precinct, PrecinctSelection } from '@votingworks/types';
+import {
+  BooleanEnvironmentVariableName,
+  format,
+  isFeatureFlagEnabled,
+} from '@votingworks/utils';
 import { assertDefined } from '@votingworks/basics';
 import styled from 'styled-components';
 import {
   getElectionRecord,
+  getPollingPlaceId,
+  setPollingPlaceId,
   setPrecinctSelection,
   getPrecinctSelection,
   unconfigureMachine,
@@ -30,46 +36,31 @@ const Content = styled(MainContent)`
   display: flex;
   flex-direction: column;
   gap: 1rem;
-
-  /* Ensure SearchSelect dropdown is not cut off */
-  overflow: visible;
 `;
 
-const ALL_PRECINCTS_KEY = '\0all-precincts';
-
 export function ElectionScreen(): JSX.Element | null {
+  const usePollingPlaces = isFeatureFlagEnabled(
+    BooleanEnvironmentVariableName.ENABLE_POLLING_PLACES
+  );
   const getElectionRecordQuery = getElectionRecord.useQuery();
+  const pollingPlaceIdQuery = getPollingPlaceId.useQuery();
   const selectedPrecinctQuery = getPrecinctSelection.useQuery();
-  const setPrecinctSelectionMutation = setPrecinctSelection.useMutation();
+  const selectPrecinct = setPrecinctSelection.useMutation().mutateAsync;
+  const selectPollingPlace = setPollingPlaceId.useMutation().mutateAsync;
   const unconfigureMutation = unconfigureMachine.useMutation();
   const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
 
-  if (!getElectionRecordQuery.isSuccess || !selectedPrecinctQuery.isSuccess) {
+  if (
+    !getElectionRecordQuery.isSuccess ||
+    !selectedPrecinctQuery.isSuccess ||
+    !pollingPlaceIdQuery.isSuccess
+  ) {
     return null;
   }
 
   const {
     electionDefinition: { election },
   } = assertDefined(getElectionRecordQuery.data);
-
-  // Get precinct options for SearchSelect
-  const precinctOptions = election.precincts.map((precinct: Precinct) => ({
-    value: precinct.id,
-    label: precinct.name,
-  }));
-  if (election.precincts.length > 1) {
-    precinctOptions.unshift({
-      value: ALL_PRECINCTS_KEY,
-      label: 'All Precincts',
-    });
-  }
-
-  // Find currently configured precinct (if any)
-  const selectedPrecinct = selectedPrecinctQuery.data;
-  const configuredPrecinctId =
-    selectedPrecinct?.kind === 'AllPrecincts'
-      ? ALL_PRECINCTS_KEY
-      : selectedPrecinct?.precinctId;
 
   async function unconfigure(): Promise<void> {
     try {
@@ -79,6 +70,32 @@ export function ElectionScreen(): JSX.Element | null {
       // Handled by default query client error handling
     }
   }
+
+  const pollingPlaces = election.pollingPlaces || [];
+  const locationPicker = usePollingPlaces
+    ? pollingPlaces.length > 1 && (
+        <PollingPlacePicker
+          mode="default"
+          places={pollingPlaces}
+          searchable
+          selectedId={pollingPlaceIdQuery.data || undefined}
+          selectPlace={(id) => selectPollingPlace({ id })}
+          style={{ width: '16rem' }}
+        />
+      )
+    : election.precincts.length > 1 && (
+        <ChangePrecinctButton
+          appPrecinctSelection={selectedPrecinctQuery.data || undefined}
+          election={election}
+          mode="default"
+          style={{ width: '16rem' }}
+          searchable
+          updatePrecinctSelection={(precinctSelection) =>
+            selectPrecinct({ precinctSelection })
+          }
+          useMenuPortal
+        />
+      );
 
   return (
     <ScreenWrapper authType="election_manager">
@@ -99,32 +116,8 @@ export function ElectionScreen(): JSX.Element | null {
             </div>
           </Row>
         </Card>
-        <Row style={{ alignItems: 'center', gap: '1rem' }}>
-          {precinctOptions.length > 1 && (
-            <SearchSelect
-              aria-label="Select Precinct"
-              options={precinctOptions}
-              value={configuredPrecinctId}
-              onChange={async (precinctId) => {
-                if (precinctId) {
-                  const precinctSelection: PrecinctSelection =
-                    precinctId === ALL_PRECINCTS_KEY
-                      ? { kind: 'AllPrecincts' }
-                      : { kind: 'SinglePrecinct', precinctId };
-                  try {
-                    await setPrecinctSelectionMutation.mutateAsync({
-                      precinctSelection,
-                    });
-                  } catch {
-                    // Handled by default query client error handling
-                  }
-                }
-              }}
-              placeholder="Select Precinct…"
-              style={{ width: '16rem' }}
-              isSearchable
-            />
-          )}
+        <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+          {locationPicker}
           <UnconfigureMachineButton
             unconfigureMachine={unconfigure}
             isMachineConfigured

--- a/libs/ui/src/change_precinct_button.tsx
+++ b/libs/ui/src/change_precinct_button.tsx
@@ -37,6 +37,9 @@ export interface ChangePrecinctButtonProps {
   ) => Promise<void>;
   election: Election;
   mode: ChangePrecinctMode;
+  searchable?: boolean;
+  style?: React.CSSProperties;
+  useMenuPortal?: boolean;
 }
 
 export function ChangePrecinctButton({
@@ -44,6 +47,9 @@ export function ChangePrecinctButton({
   updatePrecinctSelection,
   election,
   mode,
+  searchable,
+  style = { width: '100%' },
+  useMenuPortal,
 }: ChangePrecinctButtonProps): JSX.Element {
   const [isConfirmationModalShowing, setIsConfirmationModalShowing] =
     useState(false);
@@ -91,8 +97,10 @@ export function ChangePrecinctButton({
   const precinctSelectDropdown = (
     <SearchSelect
       isMulti={false}
+      isSearchable={searchable}
       placeholder={SELECT_PRECINCT_TEXT}
       aria-label={SELECT_PRECINCT_TEXT}
+      menuPortalTarget={useMenuPortal ? document.body : undefined}
       options={[
         {
           value: ALL_PRECINCTS_OPTION_VALUE,
@@ -113,7 +121,7 @@ export function ChangePrecinctButton({
       value={dropdownCurrentValue}
       onChange={handlePrecinctSelectionChange}
       disabled={mode === 'disabled'}
-      style={{ width: '100%' }}
+      style={style}
     />
   );
 

--- a/libs/ui/src/polling_place_picker.tsx
+++ b/libs/ui/src/polling_place_picker.tsx
@@ -41,6 +41,8 @@ export interface PollingPlacePickerProps {
   places: readonly PollingPlace[];
   selectedId?: string;
   selectPlace: (id: string) => Promise<void>;
+  searchable?: boolean;
+  style?: React.CSSProperties;
 }
 
 export function PollingPlacePicker({
@@ -49,6 +51,8 @@ export function PollingPlacePicker({
   places,
   selectedId,
   selectPlace,
+  searchable,
+  style = { width: '100%' },
 }: PollingPlacePickerProps): JSX.Element {
   const [showingModal, setShowingModal] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -112,7 +116,7 @@ export function PollingPlacePicker({
       menuShadow
       disabled={saving || mode === 'disabled'}
       isMulti={false}
-      isSearchable={false}
+      isSearchable={searchable}
       menuPortalTarget={document.body}
       onChange={onChange}
       options={groupedList.map((place) => ({
@@ -129,7 +133,7 @@ export function PollingPlacePicker({
         ),
       }))}
       placeholder={POLLING_PLACE_PICKER_LABEL}
-      style={{ width: '100%' }}
+      style={style}
       value={dropdownCurrentValue}
     />
   );


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7875

Currently gated by the `ENABLE_POLLING_PLACES` dev feature, while work's in progress.
Update the `ElectionScreen` to render a polling place picker instead of the existing precinct picker, when the feature flag is on.

Also tweaking the UI a bit to move the "unconfigure" button to the right side of the screen. The height mismatch between the new polling place picker and the button is a little more jarring when they're next to each other. Still not great that the button gets nudged when a selection's made, so will need to revisit.

## Demo Video or Screenshot

### With flag off

https://github.com/user-attachments/assets/2f7a5a99-2626-4f9c-bb53-409f82e0d3fd

### With flag on

https://github.com/user-attachments/assets/85e1e1cb-f5c1-4c23-aa32-f19e6d49ae0e

## Testing Plan
- Manual for now. Noticed VxPrint doesn't have client tests set up yet - will tack on some backfill tests for this screen when it's time to clean up the feature flag.

