### PR TITLE
[libs/ui] Add polling place name to election info bar

### DIFF
--- a/libs/ui/src/election_info_bar.stories.tsx
+++ b/libs/ui/src/election_info_bar.stories.tsx
@@ -1,11 +1,15 @@
 import { Meta } from '@storybook/react';
 import { safeParseElectionDefinition } from '@votingworks/types';
 import electionTwoPartyPrimaryData from '@fixtures/electionTwoPartyPrimary/election.json?raw';
+import { assertDefined } from '@votingworks/basics';
 import { ElectionInfoBar, ElectionInfoBarProps } from './election_info_bar';
 
 const electionTwoPartyPrimaryDefinition = safeParseElectionDefinition(
   electionTwoPartyPrimaryData
 ).unsafeUnwrap();
+
+const { election } = electionTwoPartyPrimaryDefinition;
+const pollingPlaces = assertDefined(election.pollingPlaces);
 
 const initialArgs: ElectionInfoBarProps = {
   codeVersion: '00986543',
@@ -22,6 +26,12 @@ const meta: Meta<typeof ElectionInfoBar> = {
   title: 'libs-ui/ElectionInfoBar',
   component: ElectionInfoBar,
   args: initialArgs,
+  argTypes: {
+    pollingPlaceId: {
+      type: 'select',
+      options: [undefined, ...pollingPlaces.map((p) => p.id)],
+    },
+  },
 };
 
 export default meta;

--- a/libs/ui/src/election_info_bar.test.tsx
+++ b/libs/ui/src/election_info_bar.test.tsx
@@ -1,17 +1,33 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import {
   ALL_PRECINCTS_SELECTION,
+  BooleanEnvironmentVariableName as Feature,
+  getFeatureFlagMock,
   singlePrecinctSelectionFor,
 } from '@votingworks/utils';
 import { formatElectionHashes } from '@votingworks/types';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
+import { assertDefined } from '@votingworks/basics';
 import { render, screen, within } from '../test/react_testing_library';
 import { ElectionInfoBar, VerticalElectionInfoBar } from './election_info_bar';
 import { makeTheme } from './themes/make_theme';
 
+const featureFlagMock = getFeatureFlagMock();
+vi.mock('@votingworks/utils', async (importActual) => ({
+  ...(await importActual()),
+  isFeatureFlagEnabled: (f: Feature) => featureFlagMock.isEnabled(f),
+}));
+
 const electionGeneralDefinition = readElectionGeneralDefinition();
 const mockElectionPackageHash = '1111111111111111111111111';
+
+const { election } = electionGeneralDefinition;
+const pollingPlaces = assertDefined(election.pollingPlaces);
+
+afterEach(() => {
+  featureFlagMock.resetFeatureFlags();
+});
 
 describe('ElectionInfoBar', () => {
   test('Renders with appropriate information', () => {
@@ -54,6 +70,7 @@ describe('ElectionInfoBar', () => {
   });
 
   test('Renders with all precincts when specified', () => {
+    setPollingPlacesEnabled(false);
     render(
       <ElectionInfoBar
         electionDefinition={electionGeneralDefinition}
@@ -68,6 +85,7 @@ describe('ElectionInfoBar', () => {
   });
 
   test('Renders with specific precinct', () => {
+    setPollingPlacesEnabled(false);
     render(
       <ElectionInfoBar
         electionDefinition={electionGeneralDefinition}
@@ -79,6 +97,24 @@ describe('ElectionInfoBar', () => {
       />
     );
     screen.getByText('Center Springfield');
+  });
+
+  test('Renders with polling place selection', () => {
+    setPollingPlacesEnabled(true);
+    const place = pollingPlaces[0];
+
+    render(
+      <ElectionInfoBar
+        electionDefinition={electionGeneralDefinition}
+        electionPackageHash={mockElectionPackageHash}
+        machineId="0002"
+        codeVersion="DEV"
+        mode="admin"
+        pollingPlaceId={place.id}
+      />
+    );
+
+    screen.getByText(place.name);
   });
 
   test('Renders without admin info in default voter mode', () => {
@@ -146,6 +182,7 @@ describe('VerticalElectionInfoBar', () => {
   });
 
   test('Renders with all precincts when specified', () => {
+    setPollingPlacesEnabled(false);
     render(
       <VerticalElectionInfoBar
         electionDefinition={electionGeneralDefinition}
@@ -160,6 +197,7 @@ describe('VerticalElectionInfoBar', () => {
   });
 
   test('Renders with specific precinct', () => {
+    setPollingPlacesEnabled(false);
     render(
       <VerticalElectionInfoBar
         electionDefinition={electionGeneralDefinition}
@@ -171,6 +209,24 @@ describe('VerticalElectionInfoBar', () => {
       />
     );
     screen.getByText('Center Springfield');
+  });
+
+  test('Renders with polling place selection', () => {
+    setPollingPlacesEnabled(true);
+    const place = pollingPlaces[0];
+
+    render(
+      <VerticalElectionInfoBar
+        electionDefinition={electionGeneralDefinition}
+        electionPackageHash={mockElectionPackageHash}
+        machineId="0002"
+        codeVersion="DEV"
+        mode="admin"
+        pollingPlaceId={place.id}
+      />
+    );
+
+    screen.getByText(place.name);
   });
 
   test('Renders without admin info in default voter mode', () => {
@@ -214,3 +270,12 @@ describe('VerticalElectionInfoBar', () => {
     });
   });
 });
+
+function setPollingPlacesEnabled(enabled: boolean) {
+  const { ENABLE_POLLING_PLACES } = Feature;
+  if (enabled) {
+    featureFlagMock.enableFeatureFlag(ENABLE_POLLING_PLACES);
+  } else {
+    featureFlagMock.disableFeatureFlag(ENABLE_POLLING_PLACES);
+  }
+}

--- a/libs/ui/src/election_info_bar.tsx
+++ b/libs/ui/src/election_info_bar.tsx
@@ -1,16 +1,22 @@
-import React from 'react';
-
 import {
   ElectionDefinition,
   formatElectionHashes,
   PrecinctSelection,
 } from '@votingworks/types';
+import {
+  BooleanEnvironmentVariableName,
+  isFeatureFlagEnabled,
+} from '@votingworks/utils';
 import styled from 'styled-components';
 import { assertDefined } from '@votingworks/basics';
 import { Seal } from './seal';
 import { Caption, Font } from './typography';
 import { LabelledText } from './labelled_text';
-import { electionStrings, PrecinctSelectionName } from './ui_strings';
+import {
+  electionStrings,
+  PollingPlaceName,
+  PrecinctSelectionName,
+} from './ui_strings';
 
 export const InfoBar = styled.div`
   align-content: flex-end;
@@ -43,12 +49,14 @@ export type InfoBarMode = 'voter' | 'pollworker' | 'admin';
 
 interface ElectionInfoProps {
   electionDefinition: ElectionDefinition;
+  pollingPlaceId?: string;
   precinctSelection?: PrecinctSelection;
   inverse?: boolean;
 }
 
 export function ElectionInfo({
   electionDefinition,
+  pollingPlaceId,
   precinctSelection,
   inverse,
 }: ElectionInfoProps): JSX.Element {
@@ -57,18 +65,24 @@ export function ElectionInfo({
     election: { precincts, county, seal },
   } = electionDefinition;
 
+  const usePollingPlaces = pollingPlacesEnabled();
+  const locationName = usePollingPlaces ? (
+    <PollingPlaceName election={election} id={pollingPlaceId} />
+  ) : (
+    <PrecinctSelectionName
+      electionPrecincts={precincts}
+      precinctSelection={precinctSelection}
+    />
+  );
+  const hasLocation = usePollingPlaces ? !!pollingPlaceId : !!precinctSelection;
+
+  const separator = ', ';
   const electionInfoLabel = (
     <Font maxLines={2}>
-      {precinctSelection && (
-        <React.Fragment>
-          <PrecinctSelectionName
-            electionPrecincts={precincts}
-            precinctSelection={precinctSelection}
-          />
-          ,{' '}
-        </React.Fragment>
-      )}
-      {electionStrings.countyName(county)},{' '}
+      {hasLocation && locationName}
+      {hasLocation && separator}
+      {electionStrings.countyName(county)}
+      {separator}
       {electionStrings.stateName(election)}
     </Font>
   );
@@ -148,6 +162,7 @@ export interface ElectionInfoBarProps {
   codeVersion?: string;
   machineId?: string;
   precinctSelection?: PrecinctSelection;
+  pollingPlaceId?: string;
 }
 
 export function ElectionInfoBar({
@@ -157,6 +172,7 @@ export function ElectionInfoBar({
   codeVersion,
   machineId,
   precinctSelection,
+  pollingPlaceId,
 }: ElectionInfoBarProps): JSX.Element {
   return (
     <InfoBar data-testid="electionInfoBar">
@@ -164,6 +180,7 @@ export function ElectionInfoBar({
         <ElectionInfo
           electionDefinition={electionDefinition}
           precinctSelection={precinctSelection}
+          pollingPlaceId={pollingPlaceId}
         />
       )}
       <SystemInfo
@@ -192,6 +209,7 @@ export function VerticalElectionInfoBar({
   codeVersion,
   machineId,
   precinctSelection,
+  pollingPlaceId,
   inverse,
 }: ElectionInfoBarProps & { inverse?: boolean }): JSX.Element {
   if (!electionDefinition) {
@@ -217,6 +235,27 @@ export function VerticalElectionInfoBar({
     election,
     election: { precincts, county, seal },
   } = electionDefinition;
+
+  const usePollingPlaces = pollingPlacesEnabled();
+  const hasLocation = usePollingPlaces ? !!pollingPlaceId : !!precinctSelection;
+  const locationName = usePollingPlaces ? (
+    <div>
+      Polling Place:{' '}
+      <Font weight="semiBold">
+        <PollingPlaceName election={election} id={pollingPlaceId} />
+      </Font>
+    </div>
+  ) : (
+    <div>
+      Precinct:{' '}
+      <Font weight="semiBold">
+        <PrecinctSelectionName
+          electionPrecincts={precincts}
+          precinctSelection={precinctSelection}
+        />
+      </Font>
+    </div>
+  );
 
   return (
     <VerticalBar inverse={inverse}>
@@ -262,18 +301,13 @@ export function VerticalElectionInfoBar({
           </Font>
         </div>
 
-        {precinctSelection && (
-          <div>
-            Precinct:{' '}
-            <Font weight="semiBold">
-              <PrecinctSelectionName
-                electionPrecincts={precincts}
-                precinctSelection={precinctSelection}
-              />
-            </Font>
-          </div>
-        )}
+        {hasLocation && locationName}
       </Caption>
     </VerticalBar>
   );
+}
+
+function pollingPlacesEnabled() {
+  const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
+  return isFeatureFlagEnabled(ENABLE_POLLING_PLACES);
 }


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7870

*Currently guarded by the `ENABLE_POLLING_PLACES` dev feature flag.*

When the feature is turned on, the precinct selection name is now replaced with the name of the selected polling place, if any. This path isn't wired up to any apps yet - will be following up with more changes to pipe the data through.

Uses a translation-enabled component, so it'll be translated along with the other info in the info bar.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/bed2423b-e037-4420-bf98-0975f026c69a

## Testing Plan
- Unit tests + manual spot check in storybook

