### PR TITLE
VxCentralScan: decouple scanning from interpretation for parallel execution

### DIFF
--- a/apps/central-scan/backend/src/app.scanning.test.ts
+++ b/apps/central-scan/backend/src/app.scanning.test.ts
@@ -98,13 +98,15 @@ test('continueScanning after invalid ballot', async () => {
       expect(status.adjudicationsRemaining).toEqual(1);
       expect(status.canUnconfigure).toEqual(true);
       expect(status.batches.length).toEqual(1);
+      // With the default maxScanAhead (0), scanning is sequential, so only
+      // 2 sheets are processed before the adjudication check pauses.
       expect(status.batches[0]).toEqual<BatchInfo>({
         id: expect.any(String),
         batchNumber: 1,
         label: 'Batch 1',
         count: 2,
         startedAt: expect.any(String),
-        endedAt: undefined, // not ended
+        endedAt: undefined, // not ended — paused for adjudication
       });
     }
     await apiClient.continueScanning({ forceAccept: false });

--- a/apps/central-scan/backend/src/importer.test.ts
+++ b/apps/central-scan/backend/src/importer.test.ts
@@ -86,6 +86,8 @@ test('finishBatch clears currentBatch before async cleanup to prevent concurrent
     },
   };
 
+  const finishBatchSpy = vi.spyOn(workspace.store, 'finishBatch');
+
   const importer = new Importer({
     workspace,
     scanner,
@@ -95,12 +97,7 @@ test('finishBatch clears currentBatch before async cleanup to prevent concurrent
 
   await importer.startImport();
 
-  // At this point, scanOneSheet found no sheets and called finishBatch.
-  // finishBatch should have cleared currentBatch immediately, even though
-  // endBatch hasn't resolved yet.
-  const finishBatchSpy = vi.spyOn(workspace.store, 'finishBatch');
-
-  // Wait a tick to let the fire-and-forget scanOneSheet promise run
+  // Wait for the scan loop to call finishBatch (fire-and-forget)
   await vi.waitFor(() => {
     expect(endBatchMock).toHaveBeenCalled();
   });
@@ -109,7 +106,7 @@ test('finishBatch clears currentBatch before async cleanup to prevent concurrent
   expect(importer.getStatus().ongoingBatchId).toBeUndefined();
 
   // store.finishBatch should have been called exactly once
-  // (the call happened before our spy, so check the batch was finished)
+  expect(finishBatchSpy).toHaveBeenCalledTimes(1);
   const batches = workspace.store.getBatches();
   expect(batches).toHaveLength(1);
   expect(batches[0]!.endedAt).toBeDefined();
@@ -119,7 +116,7 @@ test('finishBatch clears currentBatch before async cleanup to prevent concurrent
   await importer.waitForEndOfBatchOrScanningPause();
 
   // No additional finishBatch calls should have been made
-  expect(finishBatchSpy).not.toHaveBeenCalled();
+  expect(finishBatchSpy).toHaveBeenCalledTimes(1);
 });
 
 test('startImport cleans up batch on failure after addBatch', async () => {

--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -1,5 +1,4 @@
 import {
-  assert,
   assertDefined,
   extractErrorMessage,
   Optional,
@@ -26,6 +25,7 @@ import {
   BatchScanner,
   ScannedSheetInfo,
 } from './fujitsu_scanner';
+import { NODE_ENV } from './globals';
 import { Workspace } from './util/workspace';
 import {
   describeValidationError,
@@ -36,10 +36,33 @@ import { ScanStatus } from './types';
 
 const debug = makeDebug('scan:importer');
 
+export const DEFAULT_MAX_SCAN_AHEAD = 0;
+
 export interface Options {
   workspace: Workspace;
   scanner: BatchScanner;
   logger: Logger;
+  /**
+   * Maximum number of sheets the scanner can scan ahead of the interpreter.
+   * - `0` (default): sequential (scan, interpret, scan, interpret, …)
+   * - `1`+: allow bounded parallelism
+   * - `Infinity`: scan as fast as possible
+   *
+   * **Caution:** With values > 0, if an unexpected interpretation error occurs,
+   * up to `maxScanAhead` additional sheets may have been physically pulled
+   * through the scanner without being recorded. The operator has no way to
+   * identify which sheets in the output tray were counted and which weren't.
+   * The default of 0 avoids this problem. Before increasing this value in
+   * production, a reconciliation strategy is needed (e.g. re-scanning the
+   * entire batch on failure, or imprinting sheet IDs for reconciliation).
+   */
+  maxScanAhead?: number;
+  /**
+   * Artificial delay (ms) added before each interpretation. Useful for
+   * simulating slow interpretation on fast development machines. Ignored in
+   * production mode.
+   */
+  artificialInterpretDelayMs?: number;
 }
 
 interface CurrentBatch {
@@ -68,13 +91,26 @@ export class Importer {
   private readonly workspace: Workspace;
   private readonly scanner: BatchScanner;
   private readonly logger: Logger;
+  private readonly maxScanAhead: number;
+  private readonly artificialInterpretDelayMs: number;
   private isStartingBatch = false;
   private currentBatch?: CurrentBatch;
+  private readonly inFlightInterpretations = new Set<Promise<void>>();
+  private interpretationError?: string;
+  private scanLoopPromise?: Promise<void>;
 
-  constructor({ workspace, scanner, logger }: Options) {
+  constructor({
+    workspace,
+    scanner,
+    logger,
+    maxScanAhead,
+    artificialInterpretDelayMs,
+  }: Options) {
     this.workspace = workspace;
     this.scanner = scanner;
     this.logger = logger;
+    this.maxScanAhead = maxScanAhead ?? DEFAULT_MAX_SCAN_AHEAD;
+    this.artificialInterpretDelayMs = artificialInterpretDelayMs ?? 0;
   }
 
   /**
@@ -296,6 +332,7 @@ export class Importer {
       return;
     }
     this.currentBatch = undefined;
+    this.inFlightInterpretations.clear();
 
     this.workspace.store.finishBatch({
       batchId: currentBatch.batchId,
@@ -310,26 +347,94 @@ export class Importer {
   }
 
   /**
-   * Scan a single sheet and see how it looks
+   * Runs the scan-and-interpret pipeline for the current batch. The scanner
+   * runs ahead of interpretation by up to {@link maxScanAhead} sheets.
+   * Interpretation is fire-and-forget; the loop pauses when adjudication is
+   * needed or when in-flight interpretations reach the limit.
    */
-  private async scanOneSheet(): Promise<void> {
-    const { currentBatch } = this;
-    assert(typeof currentBatch !== 'undefined');
+  private async runScanLoop(): Promise<void> {
+    while (this.currentBatch) {
+      const { currentBatch } = this;
 
-    const sheet = await currentBatch.sheetGenerator.scanSheet();
-    if (!sheet) {
-      debug('closing batch %s', currentBatch.batchId);
-      await this.finishBatch();
-    } else {
-      debug('got a ballot card: %o', sheet);
-      const sheetId = await this.sheetAdded(sheet, currentBatch.batchId);
-      debug('got a ballot card: %o, %s', sheet, sheetId);
-
-      const adjudicationStatus = this.workspace.store.adjudicationStatus();
-      if (adjudicationStatus.remaining === 0) {
-        this.continueImport({ forceAccept: false });
+      // Back-pressure: wait if too many in-flight interpretations
+      while (this.inFlightInterpretations.size > this.maxScanAhead) {
+        await Promise.race([...this.inFlightInterpretations]);
+        if (this.interpretationError) break;
       }
+
+      // Abort the batch if any interpretation failed
+      if (this.interpretationError) {
+        await this.failBatch(this.interpretationError);
+        return;
+      }
+
+      // Pause if any sheet needs adjudication
+      const adjudicationStatus = this.workspace.store.adjudicationStatus();
+      if (adjudicationStatus.remaining > 0) {
+        return;
+      }
+
+      // Scan next sheet
+      const sheet = await currentBatch.sheetGenerator.scanSheet();
+
+      if (!sheet) {
+        debug(
+          'no more sheets, waiting for %d in-flight interpretations',
+          this.inFlightInterpretations.size
+        );
+        // Drain in-flight interpretations, bailing on first error
+        while (this.inFlightInterpretations.size > 0) {
+          await Promise.race([...this.inFlightInterpretations]);
+          if (this.interpretationError) {
+            await this.failBatch(this.interpretationError);
+            return;
+          }
+        }
+        // Check if any completed interpretation needs adjudication
+        if (this.workspace.store.adjudicationStatus().remaining > 0) {
+          return;
+        }
+        debug('closing batch %s', currentBatch.batchId);
+        await this.finishBatch();
+        return;
+      }
+
+      // Fire-and-forget interpretation — errors are recorded and checked
+      // by the scan loop on its next iteration, centralizing batch
+      // termination in a single code path.
+      debug('got a ballot card: %o', sheet);
+      const { batchId } = currentBatch;
+      const promise: Promise<void> = this.interpretAndStore(sheet, batchId)
+        .catch((error) => {
+          const message = extractErrorMessage(error);
+          debug('interpretation failed: %s', message);
+          if (!this.interpretationError) {
+            this.interpretationError = message;
+          }
+        })
+        .finally(() => {
+          this.inFlightInterpretations.delete(promise);
+        });
+      this.inFlightInterpretations.add(promise);
     }
+  }
+
+  private async failBatch(error: string): Promise<void> {
+    void this.logger.logAsCurrentRole(LogEventId.ScanSheetComplete, {
+      disposition: 'failure',
+      message: `Processing sheet failed: ${error}`,
+    });
+    await this.finishBatch(error);
+  }
+
+  private async interpretAndStore(
+    sheetInfo: ScannedSheetInfo,
+    batchId: string
+  ): Promise<void> {
+    if (this.artificialInterpretDelayMs > 0 && NODE_ENV !== 'production') {
+      await sleep(this.artificialInterpretDelayMs);
+    }
+    await this.sheetAdded(sheetInfo, batchId);
   }
 
   /**
@@ -381,7 +486,7 @@ export class Importer {
         sheetGenerator,
         directory: batchScanDirectory,
       };
-      this.continueImport({ forceAccept: false });
+      this.startScanLoop();
 
       return batchId;
     } catch (error) {
@@ -422,21 +527,15 @@ export class Importer {
       }
     }
 
-    this.scanOneSheet().catch((error) => {
+    this.startScanLoop();
+  }
+
+  private startScanLoop(): void {
+    this.interpretationError = undefined;
+    this.scanLoopPromise = this.runScanLoop().catch(async (error) => {
       const message = extractErrorMessage(error);
-      debug('processing sheet failed with error: %s', message);
-      void this.logger.logAsCurrentRole(LogEventId.ScanSheetComplete, {
-        disposition: 'failure',
-        message: `Processing sheet failed: ${message}`,
-      });
-      void this.finishBatch(message).catch((finishError) => {
-        void this.logger.logAsCurrentRole(LogEventId.ScanBatchComplete, {
-          disposition: 'failure',
-          message: `Additionally, finishing batch failed: ${extractErrorMessage(
-            finishError
-          )}`,
-        });
-      });
+      debug('scan loop failed: %s', message);
+      await this.failBatch(message);
     });
   }
 
@@ -444,14 +543,10 @@ export class Importer {
    * this is really for testing
    */
   async waitForEndOfBatchOrScanningPause(): Promise<void> {
-    while (this.currentBatch) {
-      const adjudicationStatus = this.workspace.store.adjudicationStatus();
-      if (adjudicationStatus.remaining > 0) {
-        break;
-      }
-
-      await sleep(200);
+    if (this.scanLoopPromise) {
+      await this.scanLoopPromise;
     }
+    await Promise.all([...this.inFlightInterpretations]);
   }
 
   /**

--- a/apps/central-scan/backend/src/scan_interpret_decoupling.test.ts
+++ b/apps/central-scan/backend/src/scan_interpret_decoupling.test.ts
@@ -1,0 +1,435 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+  makeTemporaryDirectory,
+  readElectionGeneralDefinition,
+} from '@votingworks/fixtures';
+import { Deferred, deferred } from '@votingworks/basics';
+import { mockBaseLogger, mockLogger } from '@votingworks/logging';
+import { Importer } from './importer';
+import { createWorkspace, Workspace } from './util/workspace';
+import {
+  DeferredMockScanner,
+  makeDeferredMockScanner,
+  makeImageFile,
+} from '../test/util/mocks';
+import { ScannedSheetInfo } from './fujitsu_scanner';
+
+const electionDefinition = readElectionGeneralDefinition();
+
+async function makeSheet(): Promise<ScannedSheetInfo> {
+  const [frontPath, backPath] = await Promise.all([
+    makeImageFile(),
+    makeImageFile(),
+  ]);
+  return { frontPath, backPath };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnySpy = ReturnType<typeof vi.spyOn<any, any>>;
+
+function setupTimingTest(options?: {
+  maxScanAhead?: number;
+  artificialInterpretDelayMs?: number;
+}): {
+  importer: Importer;
+  workspace: Workspace;
+  scanner: DeferredMockScanner;
+  interpretDeferreds: Array<Deferred<void>>;
+  sheetAddedSpy: AnySpy;
+} {
+  const workspace = createWorkspace(
+    makeTemporaryDirectory(),
+    mockBaseLogger({ fn: vi.fn })
+  );
+  const scanner = makeDeferredMockScanner();
+  const importer = new Importer({
+    workspace,
+    scanner,
+    logger: mockLogger({ fn: vi.fn }),
+    maxScanAhead: options?.maxScanAhead,
+    artificialInterpretDelayMs: options?.artificialInterpretDelayMs,
+  });
+  importer.configure(electionDefinition, 'test-jurisdiction', 'test-hash');
+
+  const interpretDeferreds: Array<Deferred<void>> = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sheetAddedSpy = vi.spyOn(importer as any, 'sheetAdded');
+  sheetAddedSpy.mockImplementation(async () => {
+    const d = deferred<void>();
+    interpretDeferreds.push(d);
+    await d.promise;
+    return 'mock-sheet-id';
+  });
+
+  return { importer, workspace, scanner, interpretDeferreds, sheetAddedSpy };
+}
+
+describe('scan/interpret decoupling', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('maxScanAhead=Infinity: all sheets scanned before interpretations resolve', async () => {
+    const { importer, scanner, interpretDeferreds, sheetAddedSpy } =
+      setupTimingTest({ maxScanAhead: Infinity });
+
+    const sheet1 = await makeSheet();
+    const sheet2 = await makeSheet();
+    const sheet3 = await makeSheet();
+
+    // Add sheets and immediately make them available
+    const d1 = scanner.addSheet(sheet1);
+    const d2 = scanner.addSheet(sheet2);
+    const d3 = scanner.addSheet(sheet3);
+    d1.resolve();
+    d2.resolve();
+    d3.resolve();
+    scanner.endSession();
+
+    await importer.startImport();
+
+    // Let the scan loop run; all scans should complete quickly
+    await vi.waitFor(() => {
+      expect(sheetAddedSpy).toHaveBeenCalledTimes(3);
+    });
+
+    // All 3 interpretations are in-flight, none resolved
+    expect(interpretDeferreds).toHaveLength(3);
+
+    // Resolve all interpretations
+    for (const d of interpretDeferreds) {
+      d.resolve();
+    }
+
+    await importer.waitForEndOfBatchOrScanningPause();
+
+    // Batch should be finished
+    expect(importer.getStatus().ongoingBatchId).toBeUndefined();
+  });
+
+  test('maxScanAhead=0: sequential scan-then-interpret behavior', async () => {
+    const { importer, scanner, interpretDeferreds, sheetAddedSpy } =
+      setupTimingTest({ maxScanAhead: 0 });
+
+    const sheet1 = await makeSheet();
+    const sheet2 = await makeSheet();
+
+    const d1 = scanner.addSheet(sheet1);
+    const d2 = scanner.addSheet(sheet2);
+    d1.resolve();
+    d2.resolve();
+    scanner.endSession();
+
+    await importer.startImport();
+
+    // First sheet scanned and interpretation started
+    await vi.waitFor(() => {
+      expect(sheetAddedSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // Resolve first interpretation
+    interpretDeferreds[0]!.resolve();
+
+    // Now second sheet should be scanned and interpretation started
+    await vi.waitFor(() => {
+      expect(sheetAddedSpy).toHaveBeenCalledTimes(2);
+    });
+
+    // Resolve second interpretation
+    interpretDeferreds[1]!.resolve();
+
+    await importer.waitForEndOfBatchOrScanningPause();
+    expect(importer.getStatus().ongoingBatchId).toBeUndefined();
+  });
+
+  test('maxScanAhead=1: bounded parallelism', async () => {
+    const { importer, scanner, interpretDeferreds, sheetAddedSpy } =
+      setupTimingTest({ maxScanAhead: 1 });
+
+    const sheet1 = await makeSheet();
+    const sheet2 = await makeSheet();
+    const sheet3 = await makeSheet();
+
+    const d1 = scanner.addSheet(sheet1);
+    const d2 = scanner.addSheet(sheet2);
+    const d3 = scanner.addSheet(sheet3);
+    d1.resolve();
+    d2.resolve();
+    d3.resolve();
+    scanner.endSession();
+
+    await importer.startImport();
+
+    // First 2 sheets scanned, 2 interpretations in-flight
+    await vi.waitFor(() => {
+      expect(sheetAddedSpy).toHaveBeenCalledTimes(2);
+    });
+
+    // Resolve first interpretation -> frees a slot
+    interpretDeferreds[0]!.resolve();
+
+    // Now third sheet should be scanned
+    await vi.waitFor(() => {
+      expect(sheetAddedSpy).toHaveBeenCalledTimes(3);
+    });
+
+    // Resolve remaining
+    interpretDeferreds[1]!.resolve();
+    interpretDeferreds[2]!.resolve();
+
+    await importer.waitForEndOfBatchOrScanningPause();
+    expect(importer.getStatus().ongoingBatchId).toBeUndefined();
+  });
+
+  test('adjudication pauses scanning', async () => {
+    const { importer, workspace, scanner, interpretDeferreds, sheetAddedSpy } =
+      setupTimingTest({ maxScanAhead: Infinity });
+
+    const sheet1 = await makeSheet();
+    const sheet2 = await makeSheet();
+
+    const d1 = scanner.addSheet(sheet1);
+    const d2 = scanner.addSheet(sheet2);
+    d1.resolve();
+    d2.resolve();
+    scanner.endSession();
+
+    await importer.startImport();
+
+    // Both sheets scanned
+    await vi.waitFor(() => {
+      expect(sheetAddedSpy).toHaveBeenCalledTimes(2);
+    });
+
+    // Mock the first interpretation to trigger adjudication
+    const adjudicationSpy = vi
+      .spyOn(workspace.store, 'adjudicationStatus')
+      .mockReturnValue({ remaining: 1, adjudicated: 0 });
+
+    // Resolve first interpretation
+    interpretDeferreds[0]!.resolve();
+    // Resolve second interpretation
+    interpretDeferreds[1]!.resolve();
+
+    await importer.waitForEndOfBatchOrScanningPause();
+
+    // Batch should still be ongoing (paused for adjudication)
+    expect(importer.getStatus().ongoingBatchId).toBeDefined();
+
+    // Simulate adjudication resolved
+    adjudicationSpy.mockReturnValue({ remaining: 0, adjudicated: 1 });
+    vi.spyOn(workspace.store, 'getNextAdjudicationSheet').mockReturnValue(
+      undefined
+    );
+
+    // Continue import
+    importer.continueImport({ forceAccept: true });
+
+    await importer.waitForEndOfBatchOrScanningPause();
+
+    // Batch should now be finished
+    expect(importer.getStatus().ongoingBatchId).toBeUndefined();
+  });
+
+  test('interpretation error finishes batch with error', async () => {
+    const { importer, workspace, scanner, sheetAddedSpy } = setupTimingTest({
+      maxScanAhead: Infinity,
+    });
+
+    const sheet1 = await makeSheet();
+    const sheet2 = await makeSheet();
+
+    const d1 = scanner.addSheet(sheet1);
+    const d2 = scanner.addSheet(sheet2);
+    d1.resolve();
+    d2.resolve();
+    scanner.endSession();
+
+    // Override the mock to reject on the first call
+    sheetAddedSpy.mockRejectedValueOnce(new Error('interpret failed'));
+
+    await importer.startImport();
+    await importer.waitForEndOfBatchOrScanningPause();
+
+    // Batch should be finished with an error
+    const batches = workspace.store.getBatches();
+    expect(batches).toHaveLength(1);
+    expect(batches[0]!.error).toContain('interpret failed');
+    expect(importer.getStatus().ongoingBatchId).toBeUndefined();
+  });
+
+  test('waitForEndOfBatchOrScanningPause waits for in-flight interpretations', async () => {
+    const { importer, scanner, interpretDeferreds, sheetAddedSpy } =
+      setupTimingTest({ maxScanAhead: Infinity });
+
+    const sheet1 = await makeSheet();
+
+    const d1 = scanner.addSheet(sheet1);
+    d1.resolve();
+    scanner.endSession();
+
+    await importer.startImport();
+
+    await vi.waitFor(() => {
+      expect(sheetAddedSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // Scan loop has ended (no more sheets), but interpretation still in-flight
+    let waitResolved = false;
+    const waitPromise = importer.waitForEndOfBatchOrScanningPause().then(() => {
+      waitResolved = true;
+    });
+
+    // Give a tick for the wait to potentially resolve prematurely
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(waitResolved).toEqual(false);
+
+    // Resolve interpretation
+    interpretDeferreds[0]!.resolve();
+
+    await waitPromise;
+    expect(waitResolved).toEqual(true);
+    expect(importer.getStatus().ongoingBatchId).toBeUndefined();
+  });
+
+  test('slow scan with fast interpret works correctly', async () => {
+    const { importer, scanner, interpretDeferreds, sheetAddedSpy } =
+      setupTimingTest({ maxScanAhead: 1 });
+
+    const sheet1 = await makeSheet();
+    const sheet2 = await makeSheet();
+
+    // Add sheets but don't resolve them yet (simulating slow scanner)
+    const d1 = scanner.addSheet(sheet1);
+    const d2 = scanner.addSheet(sheet2);
+    scanner.endSession();
+
+    await importer.startImport();
+
+    // Nothing scanned yet (scanner is slow)
+    expect(sheetAddedSpy).not.toHaveBeenCalled();
+
+    // First sheet becomes available
+    d1.resolve();
+
+    await vi.waitFor(() => {
+      expect(sheetAddedSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // Resolve interpretation immediately
+    interpretDeferreds[0]!.resolve();
+
+    // Second sheet becomes available
+    d2.resolve();
+
+    await vi.waitFor(() => {
+      expect(sheetAddedSpy).toHaveBeenCalledTimes(2);
+    });
+
+    interpretDeferreds[1]!.resolve();
+
+    await importer.waitForEndOfBatchOrScanningPause();
+    expect(importer.getStatus().ongoingBatchId).toBeUndefined();
+  });
+
+  test('artificial interpret delay adds delay before interpretation', async () => {
+    const workspace = createWorkspace(
+      makeTemporaryDirectory(),
+      mockBaseLogger({ fn: vi.fn })
+    );
+    const scanner = makeDeferredMockScanner();
+    const importer = new Importer({
+      workspace,
+      scanner,
+      logger: mockLogger({ fn: vi.fn }),
+      artificialInterpretDelayMs: 100,
+    });
+    importer.configure(electionDefinition, 'test-jurisdiction', 'test-hash');
+
+    let sheetAddedCalledAt: number | undefined;
+    vi.spyOn(
+      importer as unknown as { sheetAdded: Importer['importSheet'] },
+      'sheetAdded'
+    ).mockImplementation(() => {
+      sheetAddedCalledAt = Date.now();
+      return Promise.resolve('mock-sheet-id');
+    });
+
+    const sheet1 = await makeSheet();
+    const d1 = scanner.addSheet(sheet1);
+    d1.resolve();
+    scanner.endSession();
+
+    const startTime = Date.now();
+    await importer.startImport();
+    await importer.waitForEndOfBatchOrScanningPause();
+
+    expect(sheetAddedCalledAt).toBeDefined();
+    // The artificial delay should have added at least ~100ms
+    expect(sheetAddedCalledAt! - startTime).toBeGreaterThanOrEqual(90);
+  });
+
+  test('resume after adjudication with in-flight interpretations from before pause', async () => {
+    const { importer, workspace, scanner, interpretDeferreds, sheetAddedSpy } =
+      setupTimingTest({ maxScanAhead: 2 });
+
+    const sheet1 = await makeSheet();
+    const sheet2 = await makeSheet();
+    const sheet3 = await makeSheet();
+    const sheet4 = await makeSheet();
+
+    const d1 = scanner.addSheet(sheet1);
+    const d2 = scanner.addSheet(sheet2);
+    const d3 = scanner.addSheet(sheet3);
+    const d4 = scanner.addSheet(sheet4);
+    d1.resolve();
+    d2.resolve();
+    d3.resolve();
+    d4.resolve();
+    scanner.endSession();
+
+    await importer.startImport();
+
+    // All 3 slots should fill up (maxScanAhead=2)
+    await vi.waitFor(() => {
+      expect(sheetAddedSpy).toHaveBeenCalledTimes(3);
+    });
+
+    // Simulate: sheet 1's interpretation completes, triggers adjudication
+    const adjudicationSpy = vi.spyOn(workspace.store, 'adjudicationStatus');
+    adjudicationSpy.mockReturnValue({ remaining: 1, adjudicated: 0 });
+
+    interpretDeferreds[0]!.resolve();
+
+    // Sheet 2 and 3 are still in-flight. Wait for the loop to pause.
+    // Resolve sheets 2 and 3 too so waitForEndOfBatchOrScanningPause returns.
+    interpretDeferreds[1]!.resolve();
+    interpretDeferreds[2]!.resolve();
+
+    await importer.waitForEndOfBatchOrScanningPause();
+
+    // Batch paused for adjudication, sheet 4 not yet scanned
+    expect(importer.getStatus().ongoingBatchId).toBeDefined();
+    expect(sheetAddedSpy).toHaveBeenCalledTimes(3);
+
+    // Adjudicate and resume
+    adjudicationSpy.mockReturnValue({ remaining: 0, adjudicated: 1 });
+    vi.spyOn(workspace.store, 'getNextAdjudicationSheet').mockReturnValue(
+      undefined
+    );
+
+    importer.continueImport({ forceAccept: true });
+
+    // Sheet 4 should now be scanned
+    await vi.waitFor(() => {
+      expect(sheetAddedSpy).toHaveBeenCalledTimes(4);
+    });
+
+    // Resolve sheet 4's interpretation
+    interpretDeferreds[3]!.resolve();
+
+    await importer.waitForEndOfBatchOrScanningPause();
+    expect(importer.getStatus().ongoingBatchId).toBeUndefined();
+  });
+});

--- a/apps/central-scan/backend/test/util/mocks.ts
+++ b/apps/central-scan/backend/test/util/mocks.ts
@@ -6,7 +6,12 @@ import {
   MockWritable,
   mockWritable,
 } from '@votingworks/test-utils';
-import { Optional, throwIllegalValue } from '@votingworks/basics';
+import {
+  Deferred,
+  deferred,
+  Optional,
+  throwIllegalValue,
+} from '@votingworks/basics';
 import { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { fileSync } from 'tmp';
@@ -176,6 +181,102 @@ export function makeMockChildProcess(): MockChildProcess {
   };
 
   return Object.assign(new EventEmitter(), result) as MockChildProcess;
+}
+
+/**
+ * A mock scanner where each `scanSheet()` call blocks until the test resolves
+ * a deferred, giving precise control over scan timing.
+ */
+export interface DeferredMockScanner extends BatchScanner {
+  /**
+   * Adds a sheet to the scan queue. Returns a deferred whose resolution makes
+   * the sheet available to the scan loop.
+   */
+  addSheet(sheet: ScannedSheetInfo): Deferred<void>;
+  /**
+   * Signals that no more sheets will be added. The next `scanSheet()` call
+   * after all added sheets have been consumed will return `undefined`.
+   */
+  endSession(): void;
+}
+
+export function makeDeferredMockScanner(): DeferredMockScanner {
+  interface QueueEntry {
+    sheet: ScannedSheetInfo;
+    ready: Deferred<void>;
+  }
+
+  const queue: QueueEntry[] = [];
+  let sessionEnded = false;
+  let scanIndex = 0;
+  let endBatchCalled = false;
+  // Waiters are resolved when a new sheet is added or the session ends,
+  // unblocking any scanSheet() call that found an empty queue.
+  let queueChangedWaiters: Array<Deferred<void>> = [];
+
+  function notifyQueueChanged(): void {
+    const waiters = queueChangedWaiters;
+    queueChangedWaiters = [];
+    for (const waiter of waiters) {
+      waiter.resolve();
+    }
+  }
+
+  return {
+    isAttached(): boolean {
+      return true;
+    },
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async isImprinterAttached(): Promise<boolean> {
+      return false;
+    },
+
+    scanSheets(): BatchControl {
+      scanIndex = 0;
+      endBatchCalled = false;
+
+      return {
+        async scanSheet(): Promise<ScannedSheetInfo | undefined> {
+          if (endBatchCalled) return undefined;
+          if (!queue[scanIndex]) {
+            if (sessionEnded) return undefined;
+            // Wait for a sheet to be added or session to end
+            const waiter = deferred<void>();
+            queueChangedWaiters.push(waiter);
+            await waiter.promise;
+            if (endBatchCalled || (sessionEnded && !queue[scanIndex])) {
+              return undefined;
+            }
+          }
+          const current = queue[scanIndex];
+          if (!current) return undefined;
+          await current.ready.promise;
+          if (endBatchCalled) return undefined;
+          scanIndex += 1;
+          return current.sheet;
+        },
+
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async endBatch(): Promise<void> {
+          endBatchCalled = true;
+          notifyQueueChanged();
+        },
+      };
+    },
+
+    addSheet(sheet: ScannedSheetInfo): Deferred<void> {
+      const ready = deferred<void>();
+      queue.push({ sheet, ready });
+      notifyQueueChanged();
+      return ready;
+    },
+
+    endSession(): void {
+      sessionEnded = true;
+      notifyQueueChanged();
+    },
+  };
 }
 
 export async function makeImageFile(): Promise<string> {


### PR DESCRIPTION
## Overview

Refs #8041 

Replaces the sequential scan→interpret→scan→interpret chain with a concurrent pipeline where the scanner can run ahead of the interpreter by a tunable `maxScanAhead` number of sheets. This allows the scanner to keep scanning while interpretation runs in the background.

Key changes:
- Replace recursive `scanOneSheet`/`continueImport` chain with a while-loop `runScanLoop` that fires off interpretations concurrently
- Track in-flight interpretations in a `Set<Promise>` with back-pressure via `Promise.race` when at capacity
- Add configurable `maxScanAhead` (default 0) and `artificialInterpretDelayMs` (default 0) to `Importer` options
- Replace polling `waitForEndOfBatchOrScanningPause` with promise-based waiting
- Add `DeferredMockScanner` for precise scan timing control in tests
- Add 9 timing tests covering sequential, parallel, bounded, adjudication, error, and resume scenarios

**Note the important caveat in the `Importer`'s options for `maxScanAhead`**: if an unexpected error occurs, we do not have a good way to communicate to the scanner operator which of the ballots in the output tray have been counted and which have not. As long as `maxScanAhead` is zero, this isn't a problem as it's always only the top-most sheet.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/04d797aa-7d1a-4b2f-b2a4-82f1ee8018ef

## Testing Plan

- [x] Batches of US letter ballots using the 2025 Claremont election.
- [x] Batches with invalid/non-ballots mixed in to verify stopping behavior is unchanged.
- [x] New automated tests.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
