### PR TITLE
perf(ballot-interpreter): use faster image save method

### DIFF
--- a/libs/ballot-interpreter/benchmarks/write_image.bench.ts
+++ b/libs/ballot-interpreter/benchmarks/write_image.bench.ts
@@ -1,0 +1,42 @@
+import { test } from 'vitest';
+import { writeImageData } from '@votingworks/image-utils';
+import { vxFamousNamesFixtures } from '@votingworks/hmpb';
+import { join } from 'node:path';
+import { dirSync } from 'tmp';
+import { removeSync } from 'fs-extra';
+import assert from 'node:assert';
+import { pdfToPageImages } from '../test/helpers/interpretation';
+import { writeImageDataToPng } from '../src/bubble-ballot-ts';
+import { benchmarkRegressionTest } from './benchmarking';
+
+const { blankBallotPath } = vxFamousNamesFixtures;
+
+test('writeImageData (Canvas) vs writeImageToPng (Rust)', async () => {
+  const image = await pdfToPageImages(blankBallotPath).first();
+  assert(image);
+
+  // eslint-disable-next-line no-console
+  console.log(`Image size: ${image.width}x${image.height}`);
+
+  const tmpPath = dirSync().name;
+
+  try {
+    await benchmarkRegressionTest({
+      label: 'writeImageData (Canvas)',
+      func: async () => {
+        await writeImageData(join(tmpPath, 'canvas.png'), image);
+      },
+      runs: 50,
+    });
+
+    await benchmarkRegressionTest({
+      label: 'writeImageToPng (Rust)',
+      func: async () => {
+        await writeImageDataToPng(join(tmpPath, 'rust.png'), image);
+      },
+      runs: 50,
+    });
+  } finally {
+    removeSync(tmpPath);
+  }
+});

--- a/libs/ballot-interpreter/index.d.ts
+++ b/libs/ballot-interpreter/index.d.ts
@@ -41,3 +41,6 @@ export declare function interpretImages(election: Election, sideAImageWidth: num
 export declare function interpretPaths(election: Election, sideAImagePath: string, sideBImagePath: string, options: BridgeInterpretOptions): Promise<BridgeInterpretResult>
 
 export declare function runBlankPaperDiagnosticFromPath(imagePath: string, debugPath?: string): Promise<boolean>
+
+/** Encodes image data (RGBA or grayscale) as a grayscale PNG and writes it to disk. */
+export declare function writeImageToPng(path: string, width: number, height: number, data: Buffer | Uint8ClampedArray): Promise<void>

--- a/libs/ballot-interpreter/index.js
+++ b/libs/ballot-interpreter/index.js
@@ -583,3 +583,4 @@ module.exports.findTimingMarkGridFromPath = nativeBinding.findTimingMarkGridFrom
 module.exports.interpretImages = nativeBinding.interpretImages
 module.exports.interpretPaths = nativeBinding.interpretPaths
 module.exports.runBlankPaperDiagnosticFromPath = nativeBinding.runBlankPaperDiagnosticFromPath
+module.exports.writeImageToPng = nativeBinding.writeImageToPng

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/js/mod.rs
@@ -5,10 +5,11 @@ use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
-use image::{DynamicImage, GrayImage, RgbaImage};
+use image::{DynamicImage, GrayImage, ImageEncoder, RgbaImage};
 use napi::bindgen_prelude::Buffer;
 use napi_derive::napi;
 use serde::{Deserialize, Serialize};
+use std::io::Cursor;
 use types_rs::bmd::cvr::CastVoteRecord;
 use types_rs::bmd::multi_page::MultiPageCastVoteRecord;
 use types_rs::coding;
@@ -426,6 +427,33 @@ pub async fn encode_bmd_ballot_data(
     .map_err(|e| napi::Error::from_reason(format!("encoding failed: {e}")))?;
 
     Ok(Buffer::from(bytes))
+}
+
+/// Encodes image data (RGBA or grayscale) as a grayscale PNG and writes it to disk.
+#[napi(
+    ts_args_type = "path: string, width: number, height: number, data: Buffer | Uint8ClampedArray",
+    ts_return_type = "Promise<void>"
+)]
+pub async fn write_image_to_png(
+    path: String,
+    width: f64,
+    height: f64,
+    data: Buffer,
+) -> napi::Result<()> {
+    let width = as_u32(width)?;
+    let height = as_u32(height)?;
+    let image = gray_image(width, height, data.to_vec())?;
+
+    let mut buf = Vec::new();
+    image::codecs::png::PngEncoder::new(Cursor::new(&mut buf))
+        .write_image(image.as_raw(), width, height, image::ExtendedColorType::L8)
+        .map_err(|err| napi::Error::from_reason(format!("PNG encoding failed: {err}")))?;
+
+    tokio::fs::write(&path, buf)
+        .await
+        .map_err(|err| napi::Error::from_reason(format!("Failed to write {path}: {err}")))?;
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/index.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/index.ts
@@ -20,3 +20,14 @@ export async function findTimingMarkGrid(
         debugBasePath
       );
 }
+
+/**
+ * Encodes image data (RGBA or grayscale) as a grayscale PNG and writes it to
+ * disk.
+ */
+export async function writeImageDataToPng(
+  path: string,
+  image: ImageData
+): Promise<void> {
+  await napi.writeImageToPng(path, image.width, image.height, image.data);
+}

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -9,7 +9,7 @@ import {
   throwIllegalValue,
   typedAs,
 } from '@votingworks/basics';
-import { fromGrayScale, writeImageData } from '@votingworks/image-utils';
+import { fromGrayScale } from '@votingworks/image-utils';
 import {
   AdjudicationInfo,
   AdjudicationReason,
@@ -69,6 +69,7 @@ import {
   ScoredBubbleMark,
   ScoredBubbleMarks,
   ScoredPositionArea,
+  writeImageDataToPng,
 } from './bubble-ballot-ts';
 import { InterpreterOptions } from './types';
 import { normalizeBallotMode } from './validation';
@@ -626,12 +627,12 @@ async function interpretBmdBallot(
 
   if (interpretResult.isErr()) {
     // In case of an error, just write the original images.
-    if (frontNormalizedImageOutputPath) {
-      await writeImageData(frontNormalizedImageOutputPath, ballotImages[0]);
-    }
-    if (backNormalizedImageOutputPath) {
-      await writeImageData(backNormalizedImageOutputPath, ballotImages[1]);
-    }
+    await Promise.all([
+      frontNormalizedImageOutputPath &&
+        writeImageDataToPng(frontNormalizedImageOutputPath, ballotImages[0]),
+      backNormalizedImageOutputPath &&
+        writeImageDataToPng(backNormalizedImageOutputPath, ballotImages[1]),
+    ]);
 
     const error = interpretResult.err();
     switch (error.type) {
@@ -731,12 +732,12 @@ async function interpretBmdBallot(
     type: 'BlankPage',
   };
 
-  if (frontNormalizedImageOutputPath) {
-    await writeImageData(frontNormalizedImageOutputPath, summaryBallotImage);
-  }
-  if (backNormalizedImageOutputPath) {
-    await writeImageData(backNormalizedImageOutputPath, blankPageImage);
-  }
+  await Promise.all([
+    frontNormalizedImageOutputPath &&
+      writeImageDataToPng(frontNormalizedImageOutputPath, summaryBallotImage),
+    backNormalizedImageOutputPath &&
+      writeImageDataToPng(backNormalizedImageOutputPath, blankPageImage),
+  ]);
 
   return validateInterpretResults([front, back], options);
 }
@@ -888,7 +889,7 @@ export async function interpretSheet(
           options.backNormalizedImageOutputPath,
         ],
         async (imageData, path) =>
-          path && (await writeImageData(path, imageData))
+          path && (await writeImageDataToPng(path, imageData))
       );
       return hmpbInterpretation;
     }

--- a/libs/ballot-interpreter/src/save_images.ts
+++ b/libs/ballot-interpreter/src/save_images.ts
@@ -1,9 +1,9 @@
-import { encodeImageData, ImageData } from '@votingworks/image-utils';
+import { ImageData } from '@votingworks/image-utils';
 import { mapSheet, SheetOf } from '@votingworks/types';
 import { time } from '@votingworks/utils';
 import makeDebug from 'debug';
-import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { writeImageDataToPng } from './bubble-ballot-ts';
 
 const debug = makeDebug('ballot-interpreter:save-images');
 
@@ -29,10 +29,8 @@ export async function saveSheetImages({
       ballotImagesPath,
       `${sheetId}-${side}.png`
     );
-    const buffer = await encodeImageData(image, 'image/png');
-    sideTimer.checkpoint('writeImageDataToBuffer');
-    await writeFile(destinationImagePath, buffer);
-    sideTimer.checkpoint('writeFile');
+    await writeImageDataToPng(destinationImagePath, image);
+    sideTimer.checkpoint('writeImageToPng');
     return destinationImagePath;
   });
   timer.end();


### PR DESCRIPTION
## Overview

Refs #8041 

Using `canvas` to encode the PNG and then write to disk is slow, probably because of the round-trips through JS. The underlying C++ is probably pretty fast, but I haven't tested it. Replacing `writeImageData` (or `encodeImageData` + file write) with a Rust NAPI function that does both is much faster (~7x).

## Demo Video or Screenshot

The PR includes a new benchmark file that compares `writeImageData` (Canvas) with `writeImageToPng` (Rust).

| Benchmark | Old median | New Median | Change |
|-|-|-|-|
| `writeImageData` (Canvas) | 88 ms | 88 ms | baseline |
| `writeImageToPng` (Rust) | — | 13 ms | ~7x faster |
| BMD interpretation (e2e) | 386 ms | 236 ms | -39% |

## Testing Plan

Existing automated tests.
