### PR TITLE
perf(scan): prevent making some of the image data copies

### DIFF
--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -9,7 +9,7 @@ import {
   throwIllegalValue,
   typedAs,
 } from '@votingworks/basics';
-import { fromGrayScale } from '@votingworks/image-utils';
+import { fromGrayScale, isRgba } from '@votingworks/image-utils';
 import {
   AdjudicationInfo,
   AdjudicationReason,
@@ -606,6 +606,16 @@ async function interpretHmpb(
 }
 
 /**
+ * Ensures an image is in RGBA format. Returns the image unchanged if it's
+ * already RGBA, or converts from grayscale if needed. The summary ballot
+ * interpreter assumes RGBA layout for pixel operations (crop, rotate, etc.).
+ */
+function ensureRgba(image: ImageData): ImageData {
+  if (isRgba(image)) return image;
+  return fromGrayScale(image.data, image.width, image.height);
+}
+
+/**
  * Interpret a ballot sheet and convert the result into
  * the result format used by the rest of VxSuite.
  */
@@ -619,9 +629,11 @@ async function interpretBmdBallot(
     frontNormalizedImageOutputPath,
     backNormalizedImageOutputPath,
   } = options;
+  // The summary ballot interpreter assumes RGBA for pixel operations
+  const rgbaImages = mapSheet(ballotImages, ensureRgba);
   const interpretResult = await interpretVxBmdBallotSheet(
     electionDefinition,
-    ballotImages,
+    rgbaImages,
     disableBmdBallotScanning
   );
 

--- a/libs/pdi-scanner/src/ts/scanner_client.test.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.test.ts
@@ -6,7 +6,6 @@ import {
   MockChildProcess,
 } from '@votingworks/test-utils';
 import { err, iter, ok, sleep } from '@votingworks/basics';
-import { fromGrayScale } from '@votingworks/image-utils';
 import { Buffer } from 'node:buffer';
 import {
   createPdiScannerClient,
@@ -303,13 +302,22 @@ test('converts image data from scanComplete event', async () => {
   };
   mockStdoutResponse(scanCompleteEvent);
   await backendWaitFor(() => {
-    expect(listener).toHaveBeenCalledWith({
-      event: 'scanComplete',
-      images: [
-        fromGrayScale(rawImageGrayscalePixels, SCAN_IMAGE_WIDTH, imageHeight),
-        fromGrayScale(rawImageGrayscalePixels, SCAN_IMAGE_WIDTH, imageHeight),
-      ],
-    });
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'scanComplete',
+      })
+    );
+    const call = listener.mock.calls[0] as [
+      ScannerEvent & { event: 'scanComplete' },
+    ];
+    const [front, back] = call[0].images;
+    expect(front.width).toEqual(SCAN_IMAGE_WIDTH);
+    expect(front.height).toEqual(imageHeight);
+    expect(front.data).toEqual(Uint8ClampedArray.from(rawImageGrayscalePixels));
+    expect(JSON.stringify(front)).toEqual(
+      `"[ImageData ${SCAN_IMAGE_WIDTH}x${imageHeight}]"`
+    );
+    expect(back.data).toEqual(front.data);
   });
 });
 

--- a/libs/pdi-scanner/src/ts/scanner_client.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.ts
@@ -10,11 +10,7 @@ import {
   ok,
   throwIllegalValue,
 } from '@votingworks/basics';
-import {
-  ImageData,
-  createImageData,
-  fromGrayScale,
-} from '@votingworks/image-utils';
+import { ImageData } from '@votingworks/image-utils';
 import { Buffer } from 'node:buffer';
 import { SheetOf, mapSheet } from '@votingworks/types';
 import makeDebug from 'debug';
@@ -276,16 +272,25 @@ export function createPdiScannerClient() {
           event: 'scanComplete',
           images: mapSheet(message.imageData, (imageData) => {
             const buffer = Buffer.from(imageData, 'base64');
-            const grayscaleImage = createImageData(
-              Uint8ClampedArray.from(buffer),
-              SCAN_IMAGE_WIDTH,
-              buffer.length / SCAN_IMAGE_WIDTH
+            // Create a Uint8ClampedArray view over the same memory
+            // instead of copying with Uint8ClampedArray.from(buffer)
+            const data = new Uint8ClampedArray(
+              buffer.buffer,
+              buffer.byteOffset,
+              buffer.byteLength
             );
-            return fromGrayScale(
-              grayscaleImage.data,
-              grayscaleImage.width,
-              grayscaleImage.height
-            );
+            const width = SCAN_IMAGE_WIDTH;
+            const height = data.length / SCAN_IMAGE_WIDTH;
+            return {
+              width,
+              height,
+              data,
+
+              // Define `toJSON` such that `JSON.stringify` does not try to
+              // serialize all the bytes in `data` as an array of numbers.
+              // eslint-disable-next-line vx/gts-identifiers
+              toJSON: () => `[ImageData ${width}x${height}]`,
+            };
           }),
         });
         break;


### PR DESCRIPTION
## Overview

Refs #8041

Eliminates unnecessary image data copies and grayscale-to-RGBA expansion in the PDI scanner hardware path.

Previously, the image data would originate as grayscale (3.7 MB for US Letter at 200dpi) in the Rust side of pdi-scanner before moving into the TS side via a base64 encoding (5 MB each side). It then got copied to a `Uint8ClampedArray` (3.7 MB), stuffed into a `ImageData` from `canvas` (not a copy), then expanded to an RGBA `Uint8ClampedArray` in JS (4x copy, 15 MB), stuffed into another `ImageData` (not a copy), then passed back into Rust in ballot-interpreter and copied one more time (15 MB), before being scaled down to a grayscale image (3.7 MB) again to be fed into the ballot-interpreter algorithm.

This is probably an incomplete list, but already adds up to around 100 MB of image data where only 7.4 MB is needed.

This PR removes one `Uint8ClampedArray` copy (replacing it with a zero-copy `Uint8ClampedArray` view over the underlying `ArrayBuffer`) and the 4x RGBA copy via `fromGrayScale`, leaving the rest unchanged for now. This allows the data to pass through the pipeline as a grayscale `ImageData` and passed back into Rust in ballot-interpreter as grayscale, removing the memory-intensive grayscale-to-RGBA and RGBA-to-grayscale steps. In total it probably saves about 25 MB.

**NOTE:** An earlier version of this change regressed in a huge way (~5s) due to the image data being passed to `JSON.stringify`. This happened because the scan state machine tries to clean the data being passed to the log and specially handles `ImageData` instances, but the new code doesn't use the `ImageData` class from `canvas`, only the `ImageData` interface. The fix this PR uses is to add a `toJSON` method to the image data objects that just returns a string description.

## Demo Video or Screenshot

n/a

## Testing Plan

- [x] Existing automated tests
- [x] Verify on real hardware that scanned images are written correctly