### PR TITLE
VxMS HWTA: Attempt to prevent ESD-triggered touch events

### DIFF
--- a/apps/mark-scan/frontend/src/electrical_testing/app_root.tsx
+++ b/apps/mark-scan/frontend/src/electrical_testing/app_root.tsx
@@ -4,6 +4,7 @@ import {
   HeadphoneCalibrationButton,
   Icons,
   InputControls,
+  MinTouchDurationGuard,
   P,
 } from '@votingworks/ui';
 import { useState } from 'react';
@@ -71,67 +72,69 @@ export function AppRoot(): JSX.Element {
   const usbDriveStatus = getElectricalTestingStatusesQuery.data?.usbDrive;
 
   return (
-    <ElectricalTestingScreen
-      header={
-        <CpuMetricsDisplay
-          metrics={getCpuMetricsQuery.data}
-          orientation="portrait"
-        />
-      }
-      tasks={[
-        {
-          id: 'paperHandler',
-          icon: <Icons.File />,
-          title: 'Paper Handler',
-          statusMessage: paperHandlerStatus?.statusMessage ?? 'Unknown',
-          isRunning: paperHandlerStatus?.taskStatus === 'running',
-          toggleIsRunning: togglePaperHandlerTaskRunning,
-          updatedAt: paperHandlerStatus?.updatedAt,
-        },
-        {
-          id: 'card',
-          icon: <Icons.SimCard />,
-          title: 'Card Reader',
-          statusMessage: cardStatus?.statusMessage ?? 'Unknown',
-          isRunning: cardStatus?.taskStatus === 'running',
-          toggleIsRunning: toggleCardReaderTaskRunning,
-          updatedAt: cardStatus?.updatedAt,
-        },
-        {
-          id: 'usbDrive',
-          icon: <Icons.Print />,
-          title: 'USB Drive',
-          statusMessage: usbDriveStatus?.statusMessage ?? 'Unknown',
-          isRunning: usbDriveStatus?.taskStatus === 'running',
-          toggleIsRunning: toggleUsbDriveTaskRunning,
-          updatedAt: usbDriveStatus?.updatedAt,
-        },
-        {
-          id: 'sound',
-          icon: isSoundEnabled ? <Icons.VolumeUp /> : <Icons.VolumeMute />,
-          title: 'Sound',
-          body: (
-            <div>
-              <P>{isSoundEnabled ? 'Enabled' : 'Disabled'}</P>
-              <HeadphoneCalibrationButton
-                audioUrl="/sounds/tts-sample.mp3"
-                onBegin={() => setCalibratingHeadphones(true)}
-                onEnd={() => setCalibratingHeadphones(false)}
-              />
-            </div>
-          ),
-          isRunning: isSoundEnabled,
-          toggleIsRunning: toggleSoundEnabled,
-        },
-        {
-          id: 'inputs',
-          icon: <Icons.Mouse />,
-          title: 'Inputs',
-          body: <InputControls />,
-        },
-      ]}
-      usbDriveStatus={usbDriveStatus?.underlyingDeviceStatus}
-      apiClient={apiClient}
-    />
+    <MinTouchDurationGuard style={{ height: '100%' }}>
+      <ElectricalTestingScreen
+        header={
+          <CpuMetricsDisplay
+            metrics={getCpuMetricsQuery.data}
+            orientation="portrait"
+          />
+        }
+        tasks={[
+          {
+            id: 'paperHandler',
+            icon: <Icons.File />,
+            title: 'Paper Handler',
+            statusMessage: paperHandlerStatus?.statusMessage ?? 'Unknown',
+            isRunning: paperHandlerStatus?.taskStatus === 'running',
+            toggleIsRunning: togglePaperHandlerTaskRunning,
+            updatedAt: paperHandlerStatus?.updatedAt,
+          },
+          {
+            id: 'card',
+            icon: <Icons.SimCard />,
+            title: 'Card Reader',
+            statusMessage: cardStatus?.statusMessage ?? 'Unknown',
+            isRunning: cardStatus?.taskStatus === 'running',
+            toggleIsRunning: toggleCardReaderTaskRunning,
+            updatedAt: cardStatus?.updatedAt,
+          },
+          {
+            id: 'usbDrive',
+            icon: <Icons.Print />,
+            title: 'USB Drive',
+            statusMessage: usbDriveStatus?.statusMessage ?? 'Unknown',
+            isRunning: usbDriveStatus?.taskStatus === 'running',
+            toggleIsRunning: toggleUsbDriveTaskRunning,
+            updatedAt: usbDriveStatus?.updatedAt,
+          },
+          {
+            id: 'sound',
+            icon: isSoundEnabled ? <Icons.VolumeUp /> : <Icons.VolumeMute />,
+            title: 'Sound',
+            body: (
+              <div>
+                <P>{isSoundEnabled ? 'Enabled' : 'Disabled'}</P>
+                <HeadphoneCalibrationButton
+                  audioUrl="/sounds/tts-sample.mp3"
+                  onBegin={() => setCalibratingHeadphones(true)}
+                  onEnd={() => setCalibratingHeadphones(false)}
+                />
+              </div>
+            ),
+            isRunning: isSoundEnabled,
+            toggleIsRunning: toggleSoundEnabled,
+          },
+          {
+            id: 'inputs',
+            icon: <Icons.Mouse />,
+            title: 'Inputs',
+            body: <InputControls />,
+          },
+        ]}
+        usbDriveStatus={usbDriveStatus?.underlyingDeviceStatus}
+        apiClient={apiClient}
+      />
+    </MinTouchDurationGuard>
   );
 }

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -57,6 +57,7 @@ export * from './left_nav';
 export * from './link_button';
 export * from './list';
 export * from './list_item';
+export * from './min_touch_duration_guard';
 export * from './signed_hash_validation_button';
 export * from './loading';
 export * from './loading_animation';

--- a/libs/ui/src/min_touch_duration_guard.test.tsx
+++ b/libs/ui/src/min_touch_duration_guard.test.tsx
@@ -1,0 +1,77 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { fireEvent, render, screen } from '../test/react_testing_library';
+import {
+  DEFAULT_MIN_TOUCH_DURATION_MS,
+  MinTouchDurationGuard,
+} from './min_touch_duration_guard';
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+function renderWithButton(minTouchDurationMs?: number) {
+  const onClick = vi.fn();
+  render(
+    <MinTouchDurationGuard minTouchDurationMs={minTouchDurationMs}>
+      <button type="button" onClick={onClick}>
+        Press
+      </button>
+    </MinTouchDurationGuard>
+  );
+  return { onClick };
+}
+
+function pointerDownThenClick(durationMs: number) {
+  const button = screen.getByRole('button');
+  fireEvent.pointerDown(button);
+  vi.advanceTimersByTime(durationMs);
+  fireEvent.click(button);
+}
+
+test('blocks clicks from touches shorter than the default minimum duration', () => {
+  const { onClick } = renderWithButton();
+  pointerDownThenClick(DEFAULT_MIN_TOUCH_DURATION_MS - 1);
+  expect(onClick).not.toHaveBeenCalled();
+});
+
+test('allows clicks from touches at the default minimum duration', () => {
+  const { onClick } = renderWithButton();
+  pointerDownThenClick(DEFAULT_MIN_TOUCH_DURATION_MS);
+  expect(onClick).toHaveBeenCalledOnce();
+});
+
+test('allows clicks from touches above the default minimum duration', () => {
+  const { onClick } = renderWithButton();
+  pointerDownThenClick(DEFAULT_MIN_TOUCH_DURATION_MS * 2);
+  expect(onClick).toHaveBeenCalledOnce();
+});
+
+test('respects a custom minimum touch duration', () => {
+  const { onClick } = renderWithButton(200);
+
+  pointerDownThenClick(199);
+  expect(onClick).not.toHaveBeenCalled();
+
+  pointerDownThenClick(200);
+  expect(onClick).toHaveBeenCalledOnce();
+});
+
+test('allows clicks with no preceding pointer event', () => {
+  const { onClick } = renderWithButton();
+  fireEvent.click(screen.getByRole('button'));
+  expect(onClick).toHaveBeenCalledOnce();
+});
+
+test('resets pointer-down tracking after each click', () => {
+  const { onClick } = renderWithButton();
+
+  pointerDownThenClick(DEFAULT_MIN_TOUCH_DURATION_MS);
+  expect(onClick).toHaveBeenCalledOnce();
+
+  pointerDownThenClick(DEFAULT_MIN_TOUCH_DURATION_MS - 1);
+  expect(onClick).toHaveBeenCalledOnce();
+
+  pointerDownThenClick(DEFAULT_MIN_TOUCH_DURATION_MS);
+  expect(onClick).toHaveBeenCalledTimes(2);
+});

--- a/libs/ui/src/min_touch_duration_guard.test.tsx
+++ b/libs/ui/src/min_touch_duration_guard.test.tsx
@@ -43,7 +43,7 @@ test('allows clicks from touches at the default minimum duration', () => {
 
 test('allows clicks from touches above the default minimum duration', () => {
   const { onClick } = renderWithButton();
-  pointerDownThenClick(DEFAULT_MIN_TOUCH_DURATION_MS * 2);
+  pointerDownThenClick(DEFAULT_MIN_TOUCH_DURATION_MS + 1);
   expect(onClick).toHaveBeenCalledOnce();
 });
 

--- a/libs/ui/src/min_touch_duration_guard.tsx
+++ b/libs/ui/src/min_touch_duration_guard.tsx
@@ -1,0 +1,51 @@
+import React, { useRef } from 'react';
+
+/**
+ * Default identified through empirical testing, specifically ESD testing on VxMarkScan
+ */
+export const DEFAULT_MIN_TOUCH_DURATION_MS = 50;
+
+interface MinTouchDurationGuardProps {
+  children: React.ReactNode;
+  minTouchDurationMs?: number;
+  style?: React.CSSProperties;
+}
+
+/**
+ * Wraps children and blocks click events from touches shorter than {@link minPressDurationMs}.
+ * Useful for filtering out electrostatic discharge (ESD) events that manifest as very brief
+ * touches.
+ *
+ * Uses capture-phase event handlers so that short touches are intercepted before reaching any
+ * button's click handler.
+ */
+export function MinTouchDurationGuard({
+  children,
+  minTouchDurationMs = DEFAULT_MIN_TOUCH_DURATION_MS,
+  style,
+}: MinTouchDurationGuardProps): JSX.Element {
+  const pointerDownTime = useRef<number>();
+
+  return (
+    <div
+      onPointerDownCapture={() => {
+        pointerDownTime.current = Date.now();
+      }}
+      onClickCapture={(e) => {
+        if (pointerDownTime.current === undefined) {
+          return;
+        }
+        const touchDurationMs = Date.now() - pointerDownTime.current;
+        pointerDownTime.current = undefined;
+        const touchShouldRegister = touchDurationMs >= minTouchDurationMs;
+        if (!touchShouldRegister) {
+          e.stopPropagation();
+          e.preventDefault();
+        }
+      }}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+}

--- a/libs/ui/src/min_touch_duration_guard.tsx
+++ b/libs/ui/src/min_touch_duration_guard.tsx
@@ -12,7 +12,7 @@ interface MinTouchDurationGuardProps {
 }
 
 /**
- * Wraps children and blocks click events from touches shorter than {@link minPressDurationMs}.
+ * Wraps children and blocks click events from touches shorter than {@link minTouchDurationMs}.
  * Useful for filtering out electrostatic discharge (ESD) events that manifest as very brief
  * touches.
  *


### PR DESCRIPTION
## Overview

As we've been preparing for VxMarkScan ESD testing ⚡, we've seen shocks occasionally trigger touch events on screen, either focusing or fully clicking buttons.

We think we can avoid these by requiring buttons to be pressed for some minimum duration, e.g., 50ms, before registering clicks. ESD-triggered touch events are likely much faster than this.

Lots of manual testing with Chris in Bellingham seems to suggest that 50ms provides sufficient protection without degrading user experience and making button presses too challenging.

Note that VxScan has not demonstrated the same behavior, so leaving its hardware test app as is.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [ ] ~I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~
