### PR TITLE
VxDesign: Use deterministic IDs for autogen polling places

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -3808,7 +3808,8 @@ test('export - polling places auto-generated when EDIT_POLLING_PLACES === false'
   const expectedPlaces = pollingPlacesGenerateFromPrecincts(
     precincts,
     'election_day',
-    (precinct) => expect.not.stringMatching(precinct.id)
+    // Should be consistent to guarantee a consistent ballot hash:
+    (p) => `${p.id}-polling-place`
   );
   expect(outElection.pollingPlaces).toEqual(expectedPlaces);
 

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -45,7 +45,7 @@ import {
   createBallotPropsForTemplate,
   formatElectionForExport,
 } from '../ballots';
-import { generateId, getBallotPdfFileName } from '../utils';
+import { getBallotPdfFileName } from '../utils';
 import {
   normalizeBallotColorModeForPrinting,
   renderCalibrationSheetPdf,
@@ -276,7 +276,7 @@ export async function generateElectionPackageAndBallots(
         pollingPlaces: pollingPlacesGenerateFromPrecincts(
           electionRecord.election.precincts,
           'election_day',
-          generateId
+          (p) => `${p.id}-polling-place`
         ),
       };
 


### PR DESCRIPTION
## Overview

Issue form [Slack thread](https://votingworks.slack.com/archives/C06EZS53GUV/p1775767717346729?thread_ts=1772491372.121959&cid=C06EZS53GUV)

For states where polling place editing is not enabled (where polling places are an internal implementation detail), we auto-generate single-precinct polling places when exporting election packages. Since these are generated on demand, the IDs don't stay consistent across exports with no content changes.

This change moves from using random IDs to appending `-polling-place` to the source precinct ID instead when creating the polling place ID. Ensures that election package hashes stay consistent, as far as election definition contents are concerned.

## Demo Video or Screenshot

<img width="1035" height="808" alt="hub-consistent-polling-place-ids" src="https://github.com/user-attachments/assets/bf937767-0901-4d9e-b3da-cd12d865d9b9" />

## Testing Plan
- Added a test assertion for the deterministic IDs

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
