### PR TITLE
Live Reports: Add per-precinct bitmap tally helpers

### DIFF
--- a/apps/design/backend/src/app.results.test.ts
+++ b/apps/design/backend/src/app.results.test.ts
@@ -5,7 +5,7 @@ import {
   compressAndEncodeTally,
   ContestResultsSummary,
   ContestResultsSummaries,
-  encodeCompressedTally,
+  encodeV0CompressedTally,
   getFeatureFlagMock,
   singlePrecinctSelectionFor,
   getContestsForPrecinct,
@@ -205,7 +205,7 @@ test('processQRCodeReport returns "invalid-signature" when authenticating the si
     [1, 1, 3, 5],
     [0, 0, 0, 0],
   ] as CompressedTally;
-  const encodedTally = encodeCompressedTally(mockCompressedTally, 1)[0];
+  const encodedTally = encodeV0CompressedTally(mockCompressedTally, 1)[0];
 
   mockAuthReturnValue = err('invalid-signature');
 
@@ -240,7 +240,7 @@ test('processQRCodeReport returns no election found where there is no election f
     [1, 1, 3, 5],
     [0, 0, 0, 0],
   ] as CompressedTally;
-  const encodedTally = encodeCompressedTally(mockCompressedTally, 1)[0];
+  const encodedTally = encodeV0CompressedTally(mockCompressedTally, 1)[0];
 
   const result = await unauthenticatedApiClient.processQrCodeReport({
     payload: `1//qr2//${encodeQuickResultsMessage({

--- a/libs/utils/src/tabulation/compressed_tallies.test.ts
+++ b/libs/utils/src/tabulation/compressed_tallies.test.ts
@@ -17,10 +17,14 @@ import { find, assert, assertDefined } from '@votingworks/basics';
 import fc from 'fast-check';
 import {
   compressAndEncodeTally,
+  compressAndEncodePerPrecinctTally,
   compressTally,
-  decodeCompressedTally,
-  encodeCompressedTally,
+  decodeV0CompressedTally,
+  encodeV0CompressedTally,
   decodeAndReadCompressedTally,
+  decodeAndReadPerPrecinctCompressedTally,
+  encodePrecinctBitmap,
+  getPrecinctIdsFromBitmap,
 } from './compressed_tallies';
 import {
   buildElectionResultsFixture,
@@ -64,7 +68,7 @@ describe('compressTally', () => {
     expect(compressedTally).toMatchInlineSnapshot(
       `"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"`
     );
-    const decodedCompressedTally = decodeCompressedTally(
+    const decodedCompressedTally = decodeV0CompressedTally(
       compressedTally,
       ALL_PRECINCTS_SELECTION,
       electionEitherNeither
@@ -89,7 +93,7 @@ describe('compressTally', () => {
     expect(compressedTallySinglePrecinct).toMatchInlineSnapshot(
       `"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"`
     );
-    const decodedCompressedTallySinglePrecinct = decodeCompressedTally(
+    const decodedCompressedTallySinglePrecinct = decodeV0CompressedTally(
       compressedTallySinglePrecinct,
       singlePrecinctSelectionFor('6522'),
       electionEitherNeither
@@ -188,7 +192,7 @@ describe('compressTally', () => {
     expect(compressedTally).toMatchInlineSnapshot(
       `"AAAFAAQAFAAAAAIABAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"`
     );
-    const decodedCompressedTally = decodeCompressedTally(
+    const decodedCompressedTally = decodeV0CompressedTally(
       compressedTally,
       ALL_PRECINCTS_SELECTION,
       electionEitherNeither
@@ -237,7 +241,7 @@ describe('compressTally', () => {
     expect(compressedTally).toMatchInlineSnapshot(
       `"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQADABQABwAJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"`
     );
-    const decodedCompressedTally = decodeCompressedTally(
+    const decodedCompressedTally = decodeV0CompressedTally(
       compressedTally,
       ALL_PRECINCTS_SELECTION,
       electionEitherNeither
@@ -259,7 +263,7 @@ describe('readCompressTally', () => {
     const tally = decodeAndReadCompressedTally({
       election: electionEitherNeither,
       precinctSelection: ALL_PRECINCTS_SELECTION,
-      encodedTally: assertDefined(encodeCompressedTally(zeroTally, 1)[0]),
+      encodedTally: assertDefined(encodeV0CompressedTally(zeroTally, 1)[0]),
     });
     // Check that all tallies are 0
     for (const contestTally of Object.values(tally)) {
@@ -293,7 +297,9 @@ describe('readCompressTally', () => {
     const tally = decodeAndReadCompressedTally({
       election: electionEitherNeither,
       precinctSelection: ALL_PRECINCTS_SELECTION,
-      encodedTally: assertDefined(encodeCompressedTally(compressedTally, 1)[0]),
+      encodedTally: assertDefined(
+        encodeV0CompressedTally(compressedTally, 1)[0]
+      ),
     });
     const presidentTally = tally['775020876'];
     assert(presidentTally);
@@ -338,7 +344,9 @@ describe('readCompressTally', () => {
     const tally = decodeAndReadCompressedTally({
       election,
       precinctSelection: ALL_PRECINCTS_SELECTION,
-      encodedTally: assertDefined(encodeCompressedTally(compressedTally, 1)[0]),
+      encodedTally: assertDefined(
+        encodeV0CompressedTally(compressedTally, 1)[0]
+      ),
     });
     const presidentTally = tally['president'];
     assert(presidentTally);
@@ -412,7 +420,9 @@ describe('readCompressTally', () => {
     const tally = decodeAndReadCompressedTally({
       election: electionEitherNeither,
       precinctSelection: ALL_PRECINCTS_SELECTION,
-      encodedTally: assertDefined(encodeCompressedTally(compressedTally, 1)[0]),
+      encodedTally: assertDefined(
+        encodeV0CompressedTally(compressedTally, 1)[0]
+      ),
     });
     const yesNoTally = tally['750000017'];
     assert(yesNoTally?.contestType === 'yesno');
@@ -492,8 +502,8 @@ test('compresses and decompresses tally for a single precinct', () => {
   );
   expect(compressedTally).toHaveLength(10); // There are 14 contests in this election but only 10 for the precinct
   expect(compressedTallyPrecinct2).toHaveLength(9); // There are 14 contests in this election but only 9 for the precinct
-  const encodedTally = encodeCompressedTally(compressedTally, 1);
-  const encodedTallyPrecinct2 = encodeCompressedTally(
+  const encodedTally = encodeV0CompressedTally(compressedTally, 1);
+  const encodedTallyPrecinct2 = encodeV0CompressedTally(
     compressedTallyPrecinct2,
     1
   );
@@ -536,4 +546,179 @@ test('compresses and decompresses tally for a single precinct', () => {
       "775020902",
     ]
   `);
+});
+
+describe('precinct bitmap encoding', () => {
+  test('encodePrecinctBitmap and getPrecinctIdsFromBitmap round-trip', () => {
+    const election = readElectionGeneral();
+    const precinctIds = election.precincts.map((p) => p.id);
+    const selectedIds = [precinctIds[0], precinctIds[2]];
+    const resultsByPrecinct: Partial<
+      Record<string, Tabulation.ElectionResults>
+    > = {};
+    for (const id of selectedIds) {
+      assert(id !== undefined);
+      resultsByPrecinct[id] = getEmptyElectionResults(election);
+    }
+
+    const encoded = encodePrecinctBitmap(election, resultsByPrecinct);
+    const decoded = getPrecinctIdsFromBitmap(election, encoded);
+    expect(decoded).toEqual(selectedIds);
+  });
+
+  test('bitmap with all precincts returns all IDs', () => {
+    const election = readElectionGeneral();
+    const resultsByPrecinct: Partial<
+      Record<string, Tabulation.ElectionResults>
+    > = {};
+    for (const precinct of election.precincts) {
+      resultsByPrecinct[precinct.id] = getEmptyElectionResults(election);
+    }
+
+    const encoded = encodePrecinctBitmap(election, resultsByPrecinct);
+    const decoded = getPrecinctIdsFromBitmap(election, encoded);
+    expect(decoded).toEqual(election.precincts.map((p) => p.id));
+  });
+
+  test('bitmap with no precincts returns empty array', () => {
+    const election = readElectionGeneral();
+    const encoded = encodePrecinctBitmap(election, {});
+    const decoded = getPrecinctIdsFromBitmap(election, encoded);
+    expect(decoded).toEqual([]);
+  });
+});
+
+describe('per-precinct tally encoding (V1)', () => {
+  test('compressAndEncodePerPrecinctTally round-trips through decodeAndReadPerPrecinctCompressedTally', () => {
+    const electionEitherNeither =
+      electionWithMsEitherNeitherFixtures.readElection();
+    const precinct1Id = '6522';
+    const precinct2Id = '6525';
+
+    const results1 = buildElectionResultsFixture({
+      election: electionEitherNeither,
+      cardCounts: { bmd: [10], hmpb: [] },
+      contestResultsSummaries: {
+        '775020876': {
+          type: 'candidate',
+          undervotes: 2,
+          overvotes: 1,
+          ballots: 10,
+          officialOptionTallies: {
+            '775031988': 3,
+            '775031987': 2,
+            '775031989': 1,
+          },
+        },
+      },
+      includeGenericWriteIn: true,
+    });
+    const results2 = buildElectionResultsFixture({
+      election: electionEitherNeither,
+      cardCounts: { bmd: [5], hmpb: [] },
+      contestResultsSummaries: {},
+      includeGenericWriteIn: true,
+    });
+
+    const encoded = compressAndEncodePerPrecinctTally({
+      election: electionEitherNeither,
+      resultsByPrecinct: {
+        [precinct1Id]: results1,
+        [precinct2Id]: results2,
+      },
+      numPages: 1,
+    });
+    expect(encoded).toHaveLength(1);
+
+    const perPrecinctResults = decodeAndReadPerPrecinctCompressedTally({
+      election: electionEitherNeither,
+      encodedTally: assertDefined(encoded[0]),
+    });
+
+    expect(Object.keys(perPrecinctResults)).toEqual([precinct1Id, precinct2Id]);
+
+    const precinct1Results = perPrecinctResults[precinct1Id];
+    assert(precinct1Results !== undefined);
+    const presidentResult = precinct1Results['775020876'];
+    assert(presidentResult?.contestType === 'candidate');
+    expect(presidentResult.ballots).toEqual(10);
+    expect(presidentResult.undervotes).toEqual(2);
+    expect(presidentResult.overvotes).toEqual(1);
+  });
+
+  test('per-precinct tally supports pagination', () => {
+    const electionEitherNeither =
+      electionWithMsEitherNeitherFixtures.readElection();
+    const precinct1Id = '6522';
+
+    const results1 = buildElectionResultsFixture({
+      election: electionEitherNeither,
+      cardCounts: { bmd: [10], hmpb: [] },
+      contestResultsSummaries: {},
+      includeGenericWriteIn: true,
+    });
+
+    const pages = compressAndEncodePerPrecinctTally({
+      election: electionEitherNeither,
+      resultsByPrecinct: { [precinct1Id]: results1 },
+      numPages: 3,
+    });
+    expect(pages).toHaveLength(3);
+
+    // Reassemble
+    const combined = Buffer.concat(
+      pages.map((p) => Buffer.from(p, 'base64url'))
+    ).toString('base64url');
+
+    const perPrecinctResults = decodeAndReadPerPrecinctCompressedTally({
+      election: electionEitherNeither,
+      encodedTally: combined,
+    });
+    expect(Object.keys(perPrecinctResults)).toEqual([precinct1Id]);
+  });
+
+  test('decodeAndReadPerPrecinctCompressedTally rejects V0 data', () => {
+    const election = readElectionGeneral();
+    const results = getEmptyElectionResults(election);
+    const encoded = compressAndEncodeTally({
+      election,
+      results,
+      precinctSelection: ALL_PRECINCTS_SELECTION,
+      numPages: 1,
+    });
+
+    expect(() =>
+      decodeAndReadPerPrecinctCompressedTally({
+        election,
+        encodedTally: assertDefined(encoded[0]),
+      })
+    ).toThrow('Per-precinct decode requires V1 bitmap format');
+  });
+
+  test('V0 tally still works through decodeAndReadCompressedTally', () => {
+    const election = readElectionGeneral();
+    const results = buildElectionResultsFixture({
+      election,
+      cardCounts: { bmd: [10], hmpb: [] },
+      contestResultsSummaries: {},
+      includeGenericWriteIn: true,
+    });
+    const encoded = compressAndEncodeTally({
+      election,
+      results,
+      precinctSelection: ALL_PRECINCTS_SELECTION,
+      numPages: 1,
+    });
+
+    const decoded = decodeAndReadCompressedTally({
+      election,
+      precinctSelection: ALL_PRECINCTS_SELECTION,
+      encodedTally: assertDefined(encoded[0]),
+    });
+
+    // All contests should be present in decoded results
+    for (const contest of election.contests) {
+      expect(decoded[contest.id]).toBeDefined();
+    }
+  });
 });

--- a/libs/utils/src/tabulation/compressed_tallies.test.ts
+++ b/libs/utils/src/tabulation/compressed_tallies.test.ts
@@ -16,6 +16,7 @@ import {
 import { find, assert, assertDefined } from '@votingworks/basics';
 import fc from 'fast-check';
 import {
+  buildPrecinctBitmap,
   compressAndEncodeTally,
   compressAndEncodePerPrecinctTally,
   compressTally,
@@ -23,8 +24,7 @@ import {
   encodeV0CompressedTally,
   decodeAndReadCompressedTally,
   decodeAndReadPerPrecinctCompressedTally,
-  encodePrecinctBitmap,
-  getPrecinctIdsFromBitmap,
+  readPrecinctBitmap,
 } from './compressed_tallies';
 import {
   buildElectionResultsFixture,
@@ -548,8 +548,8 @@ test('compresses and decompresses tally for a single precinct', () => {
   `);
 });
 
-describe('precinct bitmap encoding', () => {
-  test('encodePrecinctBitmap and getPrecinctIdsFromBitmap round-trip', () => {
+describe('precinct bitmap', () => {
+  test('buildPrecinctBitmap and readPrecinctBitmap round-trip with subset of precincts', () => {
     const election = readElectionGeneral();
     const precinctIds = election.precincts.map((p) => p.id);
     const selectedIds = [precinctIds[0], precinctIds[2]];
@@ -561,12 +561,19 @@ describe('precinct bitmap encoding', () => {
       resultsByPrecinct[id] = getEmptyElectionResults(election);
     }
 
-    const encoded = encodePrecinctBitmap(election, resultsByPrecinct);
-    const decoded = getPrecinctIdsFromBitmap(election, encoded);
-    expect(decoded).toEqual(selectedIds);
+    const bitmap = buildPrecinctBitmap(election, resultsByPrecinct);
+    const { bitmap: booleanBitmap } = readPrecinctBitmap(
+      bitmap,
+      0,
+      election.precincts.length
+    );
+    const decodedIds = election.precincts
+      .filter((_p, i) => booleanBitmap[i])
+      .map((p) => p.id);
+    expect(decodedIds).toEqual(selectedIds);
   });
 
-  test('bitmap with all precincts returns all IDs', () => {
+  test('buildPrecinctBitmap with all precincts sets all bits', () => {
     const election = readElectionGeneral();
     const resultsByPrecinct: Partial<
       Record<string, Tabulation.ElectionResults>
@@ -575,16 +582,24 @@ describe('precinct bitmap encoding', () => {
       resultsByPrecinct[precinct.id] = getEmptyElectionResults(election);
     }
 
-    const encoded = encodePrecinctBitmap(election, resultsByPrecinct);
-    const decoded = getPrecinctIdsFromBitmap(election, encoded);
-    expect(decoded).toEqual(election.precincts.map((p) => p.id));
+    const bitmap = buildPrecinctBitmap(election, resultsByPrecinct);
+    const { bitmap: booleanBitmap } = readPrecinctBitmap(
+      bitmap,
+      0,
+      election.precincts.length
+    );
+    expect(booleanBitmap.every(Boolean)).toEqual(true);
   });
 
-  test('bitmap with no precincts returns empty array', () => {
+  test('buildPrecinctBitmap with no precincts produces all-zero bitmap', () => {
     const election = readElectionGeneral();
-    const encoded = encodePrecinctBitmap(election, {});
-    const decoded = getPrecinctIdsFromBitmap(election, encoded);
-    expect(decoded).toEqual([]);
+    const bitmap = buildPrecinctBitmap(election, {});
+    const { bitmap: booleanBitmap } = readPrecinctBitmap(
+      bitmap,
+      0,
+      election.precincts.length
+    );
+    expect(booleanBitmap.every((b) => !b)).toEqual(true);
   });
 });
 

--- a/libs/utils/src/tabulation/compressed_tallies.ts
+++ b/libs/utils/src/tabulation/compressed_tallies.ts
@@ -146,7 +146,7 @@ export function compressAndEncodeTally({
  * Bit i (in word floor(i/16), bit position i%16) is set when
  * election.precincts[i].id exists in the resultsByPrecinct keys.
  */
-function buildPrecinctBitmap(
+export function buildPrecinctBitmap(
   election: Election,
   resultsByPrecinct: Partial<Record<PrecinctId, Tabulation.ElectionResults>>
 ): Uint16Array {
@@ -168,7 +168,7 @@ function buildPrecinctBitmap(
 /**
  * Reads a precinct bitmap from a uint16 array at the given offset.
  */
-function readPrecinctBitmap(
+export function readPrecinctBitmap(
   uint16Array: Uint16Array,
   offset: number,
   numPrecincts: number
@@ -184,43 +184,6 @@ function readPrecinctBitmap(
     bitmap.push(((word >> bitIndex) & 1) === 1);
   }
   return { bitmap, nextOffset: offset + numWords };
-}
-
-/**
- * Encodes the precinct bitmap as a standalone base64url string.
- */
-export function encodePrecinctBitmap(
-  election: Election,
-  resultsByPrecinct: Partial<Record<PrecinctId, Tabulation.ElectionResults>>
-): string {
-  const bitmap = buildPrecinctBitmap(election, resultsByPrecinct);
-  return Buffer.from(
-    bitmap.buffer,
-    bitmap.byteOffset,
-    bitmap.byteLength
-  ).toString('base64url');
-}
-
-/**
- * Decodes a base64url-encoded precinct bitmap and returns the precinct IDs
- * that have data according to the bitmap.
- */
-export function getPrecinctIdsFromBitmap(
-  election: Election,
-  encodedBitmap: string
-): PrecinctId[] {
-  const bitmapBuffer = Buffer.from(encodedBitmap, 'base64url');
-  const bitmapUint16 = new Uint16Array(
-    bitmapBuffer.buffer,
-    bitmapBuffer.byteOffset,
-    bitmapBuffer.byteLength / Uint16Array.BYTES_PER_ELEMENT
-  );
-  const { bitmap } = readPrecinctBitmap(
-    bitmapUint16,
-    0,
-    election.precincts.length
-  );
-  return election.precincts.filter((_p, i) => bitmap[i]).map((p) => p.id);
 }
 
 /**

--- a/libs/utils/src/tabulation/compressed_tallies.ts
+++ b/libs/utils/src/tabulation/compressed_tallies.ts
@@ -20,6 +20,7 @@ import { getContestsForPrecinctAndElection } from './contest_filtering';
 import { singlePrecinctSelectionFor } from '../precinct_selection';
 
 const MAX_UINT16 = 0xffff;
+const UINT16_BITS = 16;
 
 /**
  * V0: single precinct selection. Layout: [0, contest_entries...]
@@ -150,12 +151,12 @@ export function buildPrecinctBitmap(
   election: Election,
   resultsByPrecinct: Partial<Record<PrecinctId, Tabulation.ElectionResults>>
 ): Uint16Array {
-  const numWords = Math.ceil(election.precincts.length / 16);
+  const numWords = Math.ceil(election.precincts.length / UINT16_BITS);
   const bitmap = new Uint16Array(numWords); // initialized to 0
   for (const [i, precinct] of election.precincts.entries()) {
     if (resultsByPrecinct[precinct.id] !== undefined) {
-      const wordIndex = Math.floor(i / 16);
-      const bitIndex = i % 16;
+      const wordIndex = Math.floor(i / UINT16_BITS);
+      const bitIndex = i % UINT16_BITS;
       const current = bitmap[wordIndex];
       assert(current !== undefined);
       // eslint-disable-next-line no-bitwise
@@ -173,11 +174,11 @@ export function readPrecinctBitmap(
   offset: number,
   numPrecincts: number
 ): { bitmap: boolean[]; nextOffset: number } {
-  const numWords = Math.ceil(numPrecincts / 16);
+  const numWords = Math.ceil(numPrecincts / UINT16_BITS);
   const bitmap: boolean[] = [];
   for (let i = 0; i < numPrecincts; i += 1) {
-    const wordIndex = Math.floor(i / 16);
-    const bitIndex = i % 16;
+    const wordIndex = Math.floor(i / UINT16_BITS);
+    const bitIndex = i % UINT16_BITS;
     const word = uint16Array[offset + wordIndex];
     assert(word !== undefined, 'Bitmap data truncated');
     // eslint-disable-next-line no-bitwise

--- a/libs/utils/src/tabulation/compressed_tallies.ts
+++ b/libs/utils/src/tabulation/compressed_tallies.ts
@@ -6,6 +6,7 @@ import {
   CompressedTallyEntry,
   ContestId,
   Election,
+  PrecinctId,
   PrecinctSelection,
   Tabulation,
   unsafeParse,
@@ -16,17 +17,24 @@ import { Buffer } from 'node:buffer';
 import { assert, throwIllegalValue, typedAs } from '@votingworks/basics';
 import { ContestResults } from '@votingworks/types/src/tabulation';
 import { getContestsForPrecinctAndElection } from './contest_filtering';
+import { singlePrecinctSelectionFor } from '../precinct_selection';
 
 const MAX_UINT16 = 0xffff;
 
-// TODO(CARO) Set to 1 for first stable version after initial VxQR development is complete.
-const COMPRESSED_TALLY_VERSION = 0; // Increment this if the format changes and make sure the reading code can handle multiple versions.
+/**
+ * V0: single precinct selection. Layout: [0, contest_entries...]
+ */
+const COMPRESSED_TALLY_V0 = 0;
 
-export function encodeCompressedTally(
-  compressedTally: CompressedTally,
+/**
+ * V1: per-precinct bitmap format. Layout: [1, bitmap_words..., precinct_entries...]
+ */
+const COMPRESSED_TALLY_V1 = 1;
+
+function encodeUint16ArrayToPages(
+  flatArray: number[],
   numPages: number
 ): string[] {
-  const flatArray = [COMPRESSED_TALLY_VERSION, ...compressedTally.flat()];
   for (const value of flatArray) {
     assert(
       Number.isInteger(value) && value >= 0 && value <= MAX_UINT16,
@@ -51,8 +59,17 @@ export function encodeCompressedTally(
   return sections;
 }
 
+export function encodeV0CompressedTally(
+  compressedTally: CompressedTally,
+  numPages: number
+): string[] {
+  const flatArray = [COMPRESSED_TALLY_V0, ...compressedTally.flat()];
+  return encodeUint16ArrayToPages(flatArray, numPages);
+}
+
 /**
- * Compresses election results
+ * Compresses election results for a given set of contests determined by
+ * precinctSelection.
  */
 export function compressTally(
   election: Election,
@@ -107,7 +124,7 @@ export function compressTally(
 }
 
 /**
- * Compresses and encodes election results
+ * Compresses and encodes election results in V0 format.
  */
 export function compressAndEncodeTally({
   election,
@@ -121,7 +138,127 @@ export function compressAndEncodeTally({
   numPages: number;
 }): string[] {
   const compressedTally = compressTally(election, results, precinctSelection);
-  return encodeCompressedTally(compressedTally, numPages);
+  return encodeV0CompressedTally(compressedTally, numPages);
+}
+
+/**
+ * Builds a bitmap of uint16 words indicating which precincts have data.
+ * Bit i (in word floor(i/16), bit position i%16) is set when
+ * election.precincts[i].id exists in the resultsByPrecinct keys.
+ */
+function buildPrecinctBitmap(
+  election: Election,
+  resultsByPrecinct: Partial<Record<PrecinctId, Tabulation.ElectionResults>>
+): Uint16Array {
+  const numWords = Math.ceil(election.precincts.length / 16);
+  const bitmap = new Uint16Array(numWords); // initialized to 0
+  for (const [i, precinct] of election.precincts.entries()) {
+    if (resultsByPrecinct[precinct.id] !== undefined) {
+      const wordIndex = Math.floor(i / 16);
+      const bitIndex = i % 16;
+      const current = bitmap[wordIndex];
+      assert(current !== undefined);
+      // eslint-disable-next-line no-bitwise
+      bitmap[wordIndex] = current | (1 << bitIndex);
+    }
+  }
+  return bitmap;
+}
+
+/**
+ * Reads a precinct bitmap from a uint16 array at the given offset.
+ */
+function readPrecinctBitmap(
+  uint16Array: Uint16Array,
+  offset: number,
+  numPrecincts: number
+): { bitmap: boolean[]; nextOffset: number } {
+  const numWords = Math.ceil(numPrecincts / 16);
+  const bitmap: boolean[] = [];
+  for (let i = 0; i < numPrecincts; i += 1) {
+    const wordIndex = Math.floor(i / 16);
+    const bitIndex = i % 16;
+    const word = uint16Array[offset + wordIndex];
+    assert(word !== undefined, 'Bitmap data truncated');
+    // eslint-disable-next-line no-bitwise
+    bitmap.push(((word >> bitIndex) & 1) === 1);
+  }
+  return { bitmap, nextOffset: offset + numWords };
+}
+
+/**
+ * Encodes the precinct bitmap as a standalone base64url string.
+ */
+export function encodePrecinctBitmap(
+  election: Election,
+  resultsByPrecinct: Partial<Record<PrecinctId, Tabulation.ElectionResults>>
+): string {
+  const bitmap = buildPrecinctBitmap(election, resultsByPrecinct);
+  return Buffer.from(
+    bitmap.buffer,
+    bitmap.byteOffset,
+    bitmap.byteLength
+  ).toString('base64url');
+}
+
+/**
+ * Decodes a base64url-encoded precinct bitmap and returns the precinct IDs
+ * that have data according to the bitmap.
+ */
+export function getPrecinctIdsFromBitmap(
+  election: Election,
+  encodedBitmap: string
+): PrecinctId[] {
+  const bitmapBuffer = Buffer.from(encodedBitmap, 'base64url');
+  const bitmapUint16 = new Uint16Array(
+    bitmapBuffer.buffer,
+    bitmapBuffer.byteOffset,
+    bitmapBuffer.byteLength / Uint16Array.BYTES_PER_ELEMENT
+  );
+  const { bitmap } = readPrecinctBitmap(
+    bitmapUint16,
+    0,
+    election.precincts.length
+  );
+  return election.precincts.filter((_p, i) => bitmap[i]).map((p) => p.id);
+}
+
+/**
+ * Compresses and encodes per-precinct election results using V1 bitmap
+ * format. Layout: [version=1, bitmap_words..., precinct_entries...]
+ *
+ * The bitmap flags which precincts have data. Each precinct's tally
+ * entries are concatenated in election.precincts order.
+ */
+export function compressAndEncodePerPrecinctTally({
+  election,
+  resultsByPrecinct,
+  numPages,
+}: {
+  election: Election;
+  resultsByPrecinct: Partial<Record<PrecinctId, Tabulation.ElectionResults>>;
+  numPages: number;
+}): string[] {
+  const bitmap = buildPrecinctBitmap(election, resultsByPrecinct);
+  const tallyEntries: number[] = [];
+
+  for (const precinct of election.precincts) {
+    const precinctResults = resultsByPrecinct[precinct.id];
+    if (precinctResults) {
+      const precinctSelection = singlePrecinctSelectionFor(precinct.id);
+      const compressedTally = compressTally(
+        election,
+        precinctResults,
+        precinctSelection
+      );
+      tallyEntries.push(...compressedTally.flat());
+    }
+  }
+
+  return encodeUint16ArrayToPages(
+    [COMPRESSED_TALLY_V1, ...bitmap, ...tallyEntries],
+    numPages
+  );
 }
 
 function getContestTalliesForCompressedContest(
@@ -215,7 +352,10 @@ function getNumberOfEntriesInContest(contest: AnyContest): number {
   }
 }
 
-export function decodeCompressedTally(
+/**
+ * Decodes a V0-format encoded tally (version byte + flat contest entries).
+ */
+export function decodeV0CompressedTally(
   encodedCompressedTally: string,
   precinctSelection: PrecinctSelection,
   election: Election
@@ -228,11 +368,9 @@ export function decodeCompressedTally(
   );
   const compressedTally: CompressedTally = [];
   const encodedVersion = uint16Array[0];
-  // Currently we only support one version, so this is just a check that the version is correct. As breaking changes occur after
-  // initial VxQR development is complete, this function will need to handle reading multiple versions for backwards compatibility.
   assert(
-    encodedVersion === COMPRESSED_TALLY_VERSION,
-    `Unsupported compressed tally version ${encodedVersion}`
+    encodedVersion === COMPRESSED_TALLY_V0,
+    `Unsupported compressed tally version ${encodedVersion} for V0 decode`
   );
   let offset = 1;
   const contests = getContestsForPrecinctAndElection(
@@ -272,9 +410,90 @@ export function decodeCompressedTally(
 }
 
 /**
- * Creates a tally from a serialized tally read from a smart card. If a
- * `partyId` is provided, only includes contests associated with that party.
- * If `partyId` is undefined, only includes nonpartisan races.
+ * Decodes contest entries from a uint16 array for a given set of contests,
+ * starting at the given offset.
+ */
+function decodeContestEntriesFromUint16Array(
+  uint16Array: Uint16Array,
+  contests: readonly AnyContest[],
+  offset: number
+): { contestResults: Record<ContestId, ContestResults>; nextOffset: number } {
+  const contestResults: Record<ContestId, ContestResults> = {};
+  let currentOffset = offset;
+  for (const contest of contests) {
+    const tallyLength = getNumberOfEntriesInContest(contest);
+    const entryArray = Array.from(
+      uint16Array.slice(currentOffset, currentOffset + tallyLength)
+    );
+    let compressedEntry: CompressedTallyEntry;
+    if (contest.type === 'yesno') {
+      compressedEntry = entryArray as YesNoContestCompressedTally;
+    } else {
+      compressedEntry = entryArray as CandidateContestCompressedTally;
+    }
+    contestResults[contest.id] = getContestTalliesForCompressedContest(
+      contest,
+      compressedEntry
+    );
+    currentOffset += tallyLength;
+  }
+  return { contestResults, nextOffset: currentOffset };
+}
+
+/**
+ * Decodes a V1 bitmap-format encoded tally into per-precinct contest results.
+ * Layout: [version=1, bitmap_words..., precinct_entries...]
+ */
+function decodeBitmapTally(
+  uint16Array: Uint16Array,
+  election: Election
+): Record<PrecinctId, Record<ContestId, ContestResults>> {
+  // Skip version byte at offset 0
+  const { bitmap, nextOffset: dataOffset } = readPrecinctBitmap(
+    uint16Array,
+    1,
+    election.precincts.length
+  );
+
+  const result: Record<PrecinctId, Record<ContestId, ContestResults>> = {};
+  let offset = dataOffset;
+
+  for (const [i, precinct] of election.precincts.entries()) {
+    if (bitmap[i]) {
+      const precinctSelection = singlePrecinctSelectionFor(precinct.id);
+      const contests = getContestsForPrecinctAndElection(
+        election,
+        precinctSelection
+      );
+      const { contestResults, nextOffset } =
+        decodeContestEntriesFromUint16Array(uint16Array, contests, offset);
+      result[precinct.id] = contestResults;
+      offset = nextOffset;
+    }
+  }
+
+  assert(
+    offset === uint16Array.length,
+    `Expected to consume all data, but ${
+      uint16Array.length - offset
+    } entries remain`
+  );
+
+  return result;
+}
+
+function decodeEncodedTallyToUint16Array(encodedTally: string): Uint16Array {
+  const buffer = Buffer.from(encodedTally, 'base64url');
+  return new Uint16Array(
+    buffer.buffer,
+    buffer.byteOffset,
+    buffer.byteLength / Uint16Array.BYTES_PER_ELEMENT
+  );
+}
+
+/**
+ * Decodes an encoded compressed tally and returns aggregated contest results.
+ * Auto-detects format: version 0 -> V0, version 1 -> V1 bitmap.
  */
 export function decodeAndReadCompressedTally({
   election,
@@ -285,7 +504,11 @@ export function decodeAndReadCompressedTally({
   precinctSelection: PrecinctSelection;
   encodedTally: string;
 }): Record<ContestId, ContestResults> {
-  const compressedTally = decodeCompressedTally(
+  const uint16Array = decodeEncodedTallyToUint16Array(encodedTally);
+  const version = uint16Array[0];
+
+  assert(version === COMPRESSED_TALLY_V0);
+  const compressedTally = decodeV0CompressedTally(
     encodedTally,
     precinctSelection,
     election
@@ -294,16 +517,34 @@ export function decodeAndReadCompressedTally({
     election,
     precinctSelection
   );
-  const allContestResults: Tabulation.ElectionResults['contestResults'] = {};
+  const allContestResults: Record<ContestId, ContestResults> = {};
   for (const [contestIdx, contest] of contests.entries()) {
     const serializedContestTally = compressedTally[contestIdx];
     assert(serializedContestTally);
-    const contestResults = getContestTalliesForCompressedContest(
+    allContestResults[contest.id] = getContestTalliesForCompressedContest(
       contest,
       serializedContestTally
     );
-    allContestResults[contest.id] = contestResults;
   }
-
   return allContestResults;
+}
+
+/**
+ * Decodes a V1 bitmap-format encoded tally and returns per-precinct contest
+ * results. Asserts the data is V1 format.
+ */
+export function decodeAndReadPerPrecinctCompressedTally({
+  election,
+  encodedTally,
+}: {
+  election: Election;
+  encodedTally: string;
+}): Record<PrecinctId, Record<ContestId, ContestResults>> {
+  const uint16Array = decodeEncodedTallyToUint16Array(encodedTally);
+  const version = uint16Array[0];
+  assert(
+    version === COMPRESSED_TALLY_V1,
+    `Per-precinct decode requires V1 bitmap format, got version ${version}`
+  );
+  return decodeBitmapTally(uint16Array, election);
 }


### PR DESCRIPTION
## Overview
https://github.com/issues/assigned?issue=votingworks%7Cvxsuite%7C7949
First step to prep for sending per-precinct data and polling place information in live reports. Adds V1 compressed tally format with per-precinct bitmap encoding. V0 (version=0) remains unchanged for single-precinct-selection tallies, but will be deprecated and removed in a future PR once VxScan is writing its report information in V1 format. V1 prepends a precinct bitmap indicating which precincts have data, followed by each precinct's contest entries in election.precincts order. We will be sending the polling place id rather than precinct id when we update the overall live report message format so we could simply include all tally results for all precincts in that polling place, or keep this bitmap but limit the entries to precincts in the polling place rather than all precincts.  I leaned towards this approach for a few reasons: 

- A bitmap is pretty small, even in a 1000 precinct scenario its ~128 bytes which is most likely not the biggest problem in a 1000 precinct scenario, including this bitmap is much smaller then including an empty set of tally data for even a single precinct in a polling place that did not actually have any ballot scanned for it. In a more realistic scenario this is only a few bytes.
- We previously debated where to put polling place information and if it should impact the ballotHash, we landed on putting it in the electionDefinition for now, and therefore changes to polling places WILL change the ballotHash, but ambiguity was left open for the future where we may want to move off of this. By not tying the results themselves to the polling place information we remain flexible to changes here in the future without having to change this (hard to version and manage backwords compatibility) format. 

## Demo Video or Screenshot
N/A

## Testing Plan
Ran Tests 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
