### PR TITLE
VxDesign: Hide density UI for MI ballot template

### DIFF
--- a/apps/design/frontend/src/ballot_screen.test.tsx
+++ b/apps/design/frontend/src/ballot_screen.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, test, vi, describe } from 'vitest';
 import { BallotType, CandidateContest, YesNoContest } from '@votingworks/types';
+import type { BallotTemplateId } from '@votingworks/design-backend';
 import { DocumentProps, PageProps } from 'react-pdf';
 import { useEffect } from 'react';
 import { ok, err } from '@votingworks/basics';
@@ -302,109 +303,97 @@ describe('Ballot rendering error handling', () => {
     screen.getByRole('link', { name: 'Election Info' });
   });
 
-  test('Contest too long error shows appropriate message for candidate contest', async () => {
-    const longContest: CandidateContest = {
-      id: 'long-contest',
-      type: 'candidate',
-      title: 'Very Long Contest with Many Candidates',
-      districtId: electionRecord.election.districts[0].id,
-      partyId: undefined,
-      seats: 1,
-      candidates: Array.from({ length: 30 }, (_, i) => ({
-        id: `candidate-${i}`,
-        name: `Candidate Number ${i + 1} with a Very Long Name`,
-        partyIds: [],
-      })),
-      allowWriteIns: false,
-    };
-    apiMock.getBallotPreviewPdf
-      .expectCallWith({
-        electionId,
-        ballotStyleId: ballotStyle.id,
-        precinctId: precinct.id,
-        ballotType: BallotType.Precinct,
-        ballotMode: 'official',
-      })
-      .resolves(
-        err({
-          error: 'contestTooLong',
-          contest: longContest,
+  test.each<{
+    name: string;
+    ballotTemplateId: BallotTemplateId;
+    contest: CandidateContest | YesNoContest;
+    expectedMessage: string;
+  }>([
+    {
+      name: 'candidate contest with default template',
+      ballotTemplateId: 'VxDefaultBallot',
+      contest: {
+        id: 'long-contest',
+        type: 'candidate',
+        title: 'Very Long Contest',
+        districtId: electionRecord.election.districts[0].id,
+        seats: 1,
+        allowWriteIns: false,
+        candidates: [],
+      },
+      expectedMessage:
+        'Contest "Very Long Contest" was too long to fit on the page. Try a longer paper size or higher density.',
+    },
+    {
+      name: 'ballot measure with default template',
+      ballotTemplateId: 'VxDefaultBallot',
+      contest: {
+        id: 'long-contest',
+        type: 'yesno',
+        title: 'Very Long Ballot Measure',
+        districtId: electionRecord.election.districts[0].id,
+        description: '',
+        yesOption: { id: 'yes', label: 'Yes' },
+        noOption: { id: 'no', label: 'No' },
+      },
+      expectedMessage:
+        'Contest "Very Long Ballot Measure" was too long to fit on the page. Try a longer paper size or higher density.',
+    },
+    {
+      name: 'ballot measure with NH template',
+      ballotTemplateId: 'NhBallot',
+      contest: {
+        id: 'long-contest',
+        type: 'yesno',
+        title: 'Very Long Ballot Measure',
+        districtId: electionRecord.election.districts[0].id,
+        description: '',
+        yesOption: { id: 'yes', label: 'Yes' },
+        noOption: { id: 'no', label: 'No' },
+      },
+      expectedMessage:
+        'Contest "Very Long Ballot Measure" was too long to fit on the page. Try a longer paper size, higher density, or adding a line break to the contest description.',
+    },
+    {
+      name: 'MI template',
+      ballotTemplateId: 'MiBallot',
+      contest: {
+        id: 'long-contest',
+        type: 'candidate',
+        title: 'Very Long Contest',
+        districtId: electionRecord.election.districts[0].id,
+        seats: 1,
+        allowWriteIns: false,
+        candidates: [],
+      },
+      expectedMessage:
+        'Contest "Very Long Contest" was too long to fit on the page. Try a longer paper size.',
+    },
+  ])(
+    'Contest too long error: $name',
+    async ({ ballotTemplateId, contest, expectedMessage }) => {
+      apiMock.getBallotTemplate.reset();
+      apiMock.getBallotTemplate
+        .expectCallWith({ electionId })
+        .resolves(ballotTemplateId);
+      apiMock.getBallotPreviewPdf
+        .expectCallWith({
+          electionId,
+          ballotStyleId: ballotStyle.id,
+          precinctId: precinct.id,
+          ballotType: BallotType.Precinct,
+          ballotMode: 'official',
         })
-      );
+        .resolves(
+          err({
+            error: 'contestTooLong',
+            contest,
+          })
+        );
 
-    renderScreen();
+      renderScreen();
 
-    await screen.findByText(
-      'Contest "Very Long Contest with Many Candidates" was too long to fit on the page. ' +
-        'Try a longer paper size or higher density.'
-    );
-  });
-
-  test('Contest too long error shows appropriate message for ballot measure with default template', async () => {
-    const longContest: YesNoContest = {
-      id: 'long-contest',
-      type: 'yesno',
-      title: 'Very Long Ballot Measure',
-      districtId: electionRecord.election.districts[0].id,
-      description: '',
-      yesOption: { id: 'yes', label: 'Yes' },
-      noOption: { id: 'no', label: 'No' },
-    };
-    apiMock.getBallotPreviewPdf
-      .expectCallWith({
-        electionId,
-        ballotStyleId: ballotStyle.id,
-        precinctId: precinct.id,
-        ballotType: BallotType.Precinct,
-        ballotMode: 'official',
-      })
-      .resolves(
-        err({
-          error: 'contestTooLong',
-          contest: longContest,
-        })
-      );
-
-    renderScreen();
-
-    await screen.findByText(
-      'Contest "Very Long Ballot Measure" was too long to fit on the page. Try a longer paper size or higher density.'
-    );
-  });
-
-  test('Contest too long error shows appropriate message for ballot measure with NH template', async () => {
-    apiMock.getBallotTemplate.reset();
-    apiMock.getBallotTemplate
-      .expectCallWith({ electionId })
-      .resolves('NhBallot');
-    const longContest: YesNoContest = {
-      id: 'long-contest',
-      type: 'yesno',
-      title: 'Very Long Ballot Measure',
-      districtId: electionRecord.election.districts[0].id,
-      description: '',
-      yesOption: { id: 'yes', label: 'Yes' },
-      noOption: { id: 'no', label: 'No' },
-    };
-    apiMock.getBallotPreviewPdf
-      .expectCallWith({
-        electionId,
-        ballotStyleId: ballotStyle.id,
-        precinctId: precinct.id,
-        ballotType: BallotType.Precinct,
-        ballotMode: 'official',
-      })
-      .resolves(
-        err({
-          error: 'contestTooLong',
-          contest: longContest,
-        })
-      );
-
-    renderScreen();
-
-    await screen.findByText(
-      'Contest "Very Long Ballot Measure" was too long to fit on the page. Try a longer paper size or higher density, or add a line break to your content.'
-    );
-  });
+      await screen.findByText(expectedMessage);
+    }
+  );
 });

--- a/apps/design/frontend/src/ballot_screen.tsx
+++ b/apps/design/frontend/src/ballot_screen.tsx
@@ -227,12 +227,18 @@ function formContestTooLongErrorMessage(
   contest: AnyContest,
   ballotTemplateId: BallotTemplateId
 ): string {
-  const baseMessage = `Contest "${contest.title}" was too long to fit on the page. Try a longer paper size or higher density`;
+  const issue = `Contest "${contest.title}" was too long to fit on the page.`;
+  let suggestion = 'Try a longer paper size or higher density.';
   // Only the NH template supports flowing ballot measure content onto another page
   if (contest.type === 'yesno' && ballotTemplateId === 'NhBallot') {
-    return `${baseMessage}, or add a line break to your content.`;
+    suggestion =
+      'Try a longer paper size, higher density, or adding a line break to the contest description.';
   }
-  return `${baseMessage}.`;
+  // The MI template doesn't support density settings
+  if (ballotTemplateId === 'MiBallot') {
+    suggestion = 'Try a longer paper size.';
+  }
+  return `${issue} ${suggestion}`;
 }
 
 function ErrorMessage({

--- a/apps/design/frontend/src/ballots_screen.test.tsx
+++ b/apps/design/frontend/src/ballots_screen.test.tsx
@@ -225,6 +225,9 @@ describe('Ballot layout tab', () => {
       paperSize: election.ballotLayout.paperSize,
       compact: false,
     });
+    apiMock.getBallotTemplate
+      .expectCallWith({ electionId })
+      .resolves('VxDefaultBallot');
     renderScreen(electionId);
     await screen.findByRole('heading', { name: 'Proof Ballots' });
 
@@ -303,6 +306,9 @@ describe('Ballot layout tab', () => {
       paperSize: election.ballotLayout.paperSize,
       compact: false,
     });
+    apiMock.getBallotTemplate
+      .expectCallWith({ electionId })
+      .resolves('VxDefaultBallot');
     renderScreen(electionId);
     await screen.findByRole('heading', { name: 'Proof Ballots' });
 
@@ -328,6 +334,26 @@ describe('Ballot layout tab', () => {
     ).toBeChecked();
   });
 
+  test('hides density for MI ballot template', async () => {
+    mockStateFeatures(apiMock, electionId, {});
+    apiMock.getBallotLayoutSettings.expectCallWith({ electionId }).resolves({
+      paperSize: election.ballotLayout.paperSize,
+      compact: false,
+    });
+    apiMock.getBallotTemplate
+      .expectCallWith({ electionId })
+      .resolves('MiBallot');
+    renderScreen(electionId);
+    await screen.findByRole('heading', { name: 'Proof Ballots' });
+
+    userEvent.click(screen.getByRole('tab', { name: 'Ballot Layout' }));
+
+    await screen.findByRole('radiogroup', { name: 'Paper Size' });
+    expect(
+      screen.queryByRole('radiogroup', { name: 'Density' })
+    ).not.toBeInTheDocument();
+  });
+
   test('cancelling', async () => {
     mockStateFeatures(apiMock, electionId, {});
     mockUserFeatures(apiMock, {});
@@ -335,6 +361,9 @@ describe('Ballot layout tab', () => {
       paperSize: election.ballotLayout.paperSize,
       compact: false,
     });
+    apiMock.getBallotTemplate
+      .expectCallWith({ electionId })
+      .resolves('VxDefaultBallot');
     renderScreen(electionId);
     await screen.findByRole('heading', { name: 'Proof Ballots' });
 

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -18,9 +18,11 @@ import { HmpbBallotPaperSize, ElectionId, hasSplits } from '@votingworks/types';
 import { useState } from 'react';
 import styled from 'styled-components';
 import { ballotStyleHasPrecinctOrSplit } from '@votingworks/utils';
+import type { BallotTemplateId } from '@votingworks/design-backend';
 import {
   getBallotsFinalizedAt,
   getBallotLayoutSettings,
+  getBallotTemplate,
   updateBallotLayoutSettings,
   listBallotStyles,
   listPrecincts,
@@ -39,6 +41,7 @@ function BallotDesignForm({
   electionId,
   savedLayoutSettings,
   ballotsFinalizedAt,
+  ballotTemplateId,
 }: {
   electionId: ElectionId;
   savedLayoutSettings: {
@@ -46,6 +49,7 @@ function BallotDesignForm({
     compact: boolean;
   };
   ballotsFinalizedAt: Date | null;
+  ballotTemplateId: BallotTemplateId;
 }): JSX.Element | null {
   const [isEditing, setIsEditing] = useState(false);
   const [layoutSettings, setLayoutSettings] = useState(savedLayoutSettings);
@@ -103,29 +107,31 @@ function BallotDesignForm({
           disabled={!isEditing}
         />
       </div>
-      <div style={{ maxWidth: '16.5rem' }}>
-        <RadioGroup
-          label="Density"
-          options={[
-            {
-              label: 'Default',
-              value: 'default',
-            },
-            {
-              label: 'Compact',
-              value: 'compact',
-            },
-          ]}
-          value={layoutSettings.compact ? 'compact' : 'default'}
-          onChange={(value) =>
-            setLayoutSettings({
-              ...layoutSettings,
-              compact: value === 'compact',
-            })
-          }
-          disabled={!isEditing}
-        />
-      </div>
+      {ballotTemplateId !== 'MiBallot' && (
+        <div style={{ maxWidth: '16.5rem' }}>
+          <RadioGroup
+            label="Density"
+            options={[
+              {
+                label: 'Default',
+                value: 'default',
+              },
+              {
+                label: 'Compact',
+                value: 'compact',
+              },
+            ]}
+            value={layoutSettings.compact ? 'compact' : 'default'}
+            onChange={(value) =>
+              setLayoutSettings({
+                ...layoutSettings,
+                compact: value === 'compact',
+              })
+            }
+            disabled={!isEditing}
+          />
+        </div>
+      )}
       {isEditing ? (
         <FormActionsRow>
           <Button type="reset">Cancel</Button>
@@ -335,11 +341,13 @@ function BallotLayoutTab(): JSX.Element | null {
   const getBallotLayoutSettingsQuery =
     getBallotLayoutSettings.useQuery(electionId);
   const getBallotsFinalizedAtQuery = getBallotsFinalizedAt.useQuery(electionId);
+  const getBallotTemplateQuery = getBallotTemplate.useQuery(electionId);
 
   if (
     !(
       getBallotLayoutSettingsQuery.isSuccess &&
-      getBallotsFinalizedAtQuery.isSuccess
+      getBallotsFinalizedAtQuery.isSuccess &&
+      getBallotTemplateQuery.isSuccess
     )
   ) {
     return null;
@@ -347,6 +355,7 @@ function BallotLayoutTab(): JSX.Element | null {
 
   const layoutSettings = getBallotLayoutSettingsQuery.data;
   const ballotsFinalizedAt = getBallotsFinalizedAtQuery.data;
+  const ballotTemplateId = getBallotTemplateQuery.data;
 
   return (
     <TabPanel>
@@ -354,6 +363,7 @@ function BallotLayoutTab(): JSX.Element | null {
         electionId={electionId}
         savedLayoutSettings={layoutSettings}
         ballotsFinalizedAt={ballotsFinalizedAt}
+        ballotTemplateId={ballotTemplateId}
       />
     </TabPanel>
   );


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Task: #7823

The MI ballot template always uses compact density font styles, so the density setting in VxDesign is meaningless for it. This PR:

- Hides the density radio group on the Ballot Layout tab when the MI template is selected
- Updates the "contest too long" error message for MI to only suggest a longer paper size (not higher density)

## Demo Video or Screenshot

<img width="1312" height="731" alt="Screenshot 2026-04-14 at 4 29 15 PM" src="https://github.com/user-attachments/assets/2db2407d-5793-414c-bb56-a760f3b5555f" />


## Testing Plan

- Updated automated tests
- Manual test

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
