### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
## Overview

Noticed Dependabot PRs to VxSuite are [missing lockfile updates](https://github.com/votingworks/vxsuite/pull/8289) - after following the [breadcrumbs](https://github.com/dependabot/dependabot-core/pull/11487), I *think* all we need is an explicit [config file](https://docs.github.com/en/code-security/concepts/supply-chain-security/about-the-dependabot-yml-file) to point it at the root directory, so it knows to update the lockfile. Testing this out to see if it works. Not sure if re-triggering dependabot will pick up this change, but if not, I'll just manually update the in-flight PRs for now.