### PR TITLE
VxDesign: Add MI state configuration

### DIFF
--- a/apps/design/backend/migrations/1773500000000_add-mi-state-code.js
+++ b/apps/design/backend/migrations/1773500000000_add-mi-state-code.js
@@ -1,0 +1,6 @@
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ */
+exports.up = (pgm) => {
+  pgm.addTypeValue('state_code', 'MI');
+};

--- a/apps/design/backend/src/__snapshots__/system_settings.test.ts.snap
+++ b/apps/design/backend/src/__snapshots__/system_settings.test.ts.snap
@@ -39,6 +39,42 @@ exports[`Default system settings for 'DEMO' - If a change is intentional, update
 }
 `;
 
+exports[`Default system settings for 'MI' - If a change is intentional, update snapshot 1`] = `
+{
+  "adminAdjudicationReasons": [
+    "Overvote",
+    "BlankBallot",
+    "MarginalMark",
+  ],
+  "auth": {
+    "arePollWorkerCardPinsEnabled": false,
+    "inactiveSessionTimeLimitMinutes": 30,
+    "numIncorrectPinAttemptsAllowedBeforeCardLockout": 5,
+    "overallSessionTimeLimitHours": 12,
+    "startingCardLockoutDurationSeconds": 15,
+  },
+  "bmdPrintMode": "bubble_ballot",
+  "centralScanAdjudicationReasons": [],
+  "disableSystemLimitChecks": true,
+  "disableVoterHelpButtons": true,
+  "disallowCastingOvervotes": false,
+  "markThresholds": {
+    "definite": 0.1,
+    "marginal": 0.05,
+    "writeInTextArea": 0.05,
+  },
+  "maxCumulativeStreakWidth": 5,
+  "precinctScanAdjudicationReasons": [
+    "Overvote",
+    "BlankBallot",
+  ],
+  "precinctScanDisableAlarms": true,
+  "precinctScanDisableScreenReaderAudio": true,
+  "precinctScanEnableBmdBallotScanning": true,
+  "retryStreakWidthThreshold": 1,
+}
+`;
+
 exports[`Default system settings for 'MS' - If a change is intentional, update snapshot 1`] = `
 {
   "adminAdjudicationReasons": [],

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -137,6 +137,7 @@ import {
   msJurisdiction,
   nonVxOrganizationUser,
   supportUser,
+  miJurisdiction,
 } from '../test/mocks';
 import {
   SLI_DEFAULT_SYSTEM_SETTINGS,
@@ -4706,6 +4707,7 @@ test('listJurisdictions', async () => {
   auth0.setLoggedInUser(nonVxOrganizationUser);
   expect(await apiClient.listJurisdictions()).toEqual([
     anotherNonVxJurisdiction,
+    miJurisdiction,
     msJurisdiction,
     nhJurisdiction,
     nonVxJurisdiction,
@@ -4740,6 +4742,9 @@ test('feature configs and default system settings', async () => {
   expect(
     await apiClient.getSystemSettings({ electionId: vxElectionId })
   ).toEqual(stateDefaultSystemSettings.DEMO);
+  expect(
+    await apiClient.getBallotTemplate({ electionId: vxElectionId })
+  ).toEqual('VxDefaultBallot');
 
   const sliElectionId = (
     await apiClient.createElection({
@@ -4753,6 +4758,9 @@ test('feature configs and default system settings', async () => {
   expect(
     await apiClient.getSystemSettings({ electionId: sliElectionId })
   ).toEqual(SLI_DEFAULT_SYSTEM_SETTINGS);
+  expect(
+    await apiClient.getBallotTemplate({ electionId: sliElectionId })
+  ).toEqual('VxDefaultBallot');
 
   const nhElectionId = (
     await apiClient.createElection({
@@ -4766,6 +4774,9 @@ test('feature configs and default system settings', async () => {
   expect(
     await apiClient.getSystemSettings({ electionId: nhElectionId })
   ).toEqual(stateDefaultSystemSettings.NH);
+  expect(
+    await apiClient.getBallotTemplate({ electionId: nhElectionId })
+  ).toEqual('NhBallot');
 
   const msElectionId = (
     await apiClient.createElection({
@@ -4773,13 +4784,31 @@ test('feature configs and default system settings', async () => {
       jurisdictionId: msJurisdiction.id,
     })
   ).unsafeUnwrap();
-
   expect(
     await apiClient.getStateFeatures({ electionId: msElectionId })
   ).toEqual(stateFeatureConfigs.MS);
   expect(
     await apiClient.getSystemSettings({ electionId: msElectionId })
   ).toEqual(stateDefaultSystemSettings.MS);
+  expect(
+    await apiClient.getBallotTemplate({ electionId: msElectionId })
+  ).toEqual('MsBallot');
+
+  const miElectionId = (
+    await apiClient.createElection({
+      id: 'mi-election-id' as ElectionId,
+      jurisdictionId: miJurisdiction.id,
+    })
+  ).unsafeUnwrap();
+  expect(
+    await apiClient.getStateFeatures({ electionId: miElectionId })
+  ).toEqual(stateFeatureConfigs.MI);
+  expect(
+    await apiClient.getSystemSettings({ electionId: miElectionId })
+  ).toEqual(stateDefaultSystemSettings.MI);
+  expect(
+    await apiClient.getBallotTemplate({ electionId: miElectionId })
+  ).toEqual('MiBallot');
 });
 
 test('getResultsReportingUrl', async () => {

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -21,6 +21,8 @@ export function defaultBallotTemplate(
   switch (jurisdiction.stateCode) {
     case 'DEMO':
       return 'VxDefaultBallot';
+    case 'MI':
+      return 'MiBallot';
     case 'MS':
       return 'MsBallot';
     case 'NH':

--- a/apps/design/backend/src/features.ts
+++ b/apps/design/backend/src/features.ts
@@ -194,6 +194,8 @@ export const stateFeatureConfigs: Record<StateCode, StateFeaturesConfig> = {
     EDIT_POLLING_PLACES: true,
   },
 
+  MI: {},
+
   MS: {
     AUDIO_ENABLED: true,
     EXPORT_TEST_BALLOTS: true,

--- a/apps/design/backend/src/system_settings.ts
+++ b/apps/design/backend/src/system_settings.ts
@@ -54,6 +54,27 @@ export const stateDefaultSystemSettings: Record<StateCode, SystemSettings> = {
     quickResultsReportingUrl: resultsReportingUrl(),
   },
 
+  MI: {
+    ...commonSettings,
+    ...commonCustomerSettings,
+
+    markThresholds: DEFAULT_MARK_THRESHOLDS_MARGINAL_MARK_ADJUDICATION_ENABLED,
+
+    precinctScanAdjudicationReasons: [
+      AdjudicationReason.Overvote,
+      AdjudicationReason.BlankBallot,
+    ],
+    disallowCastingOvervotes: false,
+    centralScanAdjudicationReasons: [],
+    adminAdjudicationReasons: [
+      AdjudicationReason.Overvote,
+      AdjudicationReason.BlankBallot,
+      AdjudicationReason.MarginalMark,
+    ],
+
+    bmdPrintMode: 'bubble_ballot',
+  },
+
   MS: {
     ...commonSettings,
     ...commonCustomerSettings,

--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -13,7 +13,7 @@ import { ContestResults } from '@votingworks/types/src/tabulation';
 import { z } from 'zod/v4';
 import { baseUrl } from './globals';
 
-export const StateCodes = ['DEMO', 'MS', 'NH'] as const;
+export const StateCodes = ['DEMO', 'MI', 'MS', 'NH'] as const;
 export type StateCode = (typeof StateCodes)[number];
 export const StateCodeSchema: z.ZodType<StateCode> = z.enum(StateCodes);
 

--- a/apps/design/backend/test/mocks.ts
+++ b/apps/design/backend/test/mocks.ts
@@ -67,6 +67,12 @@ export const msJurisdiction: Jurisdiction = {
   stateCode: 'MS',
   organization: nonVxOrganization,
 };
+export const miJurisdiction: Jurisdiction = {
+  id: 'mi-jurisdiction-id',
+  name: 'Michigan Jurisdiction',
+  stateCode: 'MI',
+  organization: nonVxOrganization,
+};
 export const anotherNonVxUser: JurisdictionUser = {
   ...nonVxUser,
   id: 'auth0|another-non-vx-user-id',
@@ -114,6 +120,7 @@ export const jurisdictions: Jurisdiction[] = [
   sliJurisdiction,
   nhJurisdiction,
   msJurisdiction,
+  miJurisdiction,
 ];
 
 export const users: User[] = [


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Add Michigan (MI) as a supported state in VxDesign. This includes:

- Database migration to add `MI` to the `state_code` PostgreSQL enum
- `MI` added to the TypeScript `StateCodes`
- Default ballot template (`MiBallot`)
- Default system settings (adjudication reasons, mark thresholds)
- Empty feature config entry (features will be added in follow-up PRs)

## Demo Video or Screenshot

N/A

## Testing Plan

Updated tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
