### PR TITLE
VxDesign: Election day "polls close time" options in `system settings`

### DIFF
--- a/apps/design/frontend/src/system_settings_screen.test.tsx
+++ b/apps/design/frontend/src/system_settings_screen.test.tsx
@@ -1025,10 +1025,13 @@ describe('election day polls close time', () => {
       'Election Day Polls Close Time'
     );
 
-    // Set a time that is clearly in the past
     fireEvent.change(input, { target: { value: '2000-01-01T08:00' } });
     expect(input.validity.valid).toEqual(false);
     expect(input.validationMessage).toContain('must be in the future');
+
+    // Form submission is blocked — updateSystemSettings should never be called
+    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    // (apiMock.assertComplete() in afterEach will catch any unexpected calls)
   });
 });
 

--- a/apps/design/frontend/src/system_settings_screen.test.tsx
+++ b/apps/design/frontend/src/system_settings_screen.test.tsx
@@ -950,6 +950,66 @@ describe('election day polls close time', () => {
     const updatedSettings: SystemSettings = {
       ...initialSettings,
       electionDayPollsCloseTime: undefined,
+      disallowClosingPollsBeforeElectionDayPollsCloseTime: undefined,
+      disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: undefined,
+    };
+    apiMock.updateSystemSettings
+      .expectCallWith({ electionId, systemSettings: updatedSettings })
+      .resolves();
+    apiMock.getSystemSettings
+      .expectCallWith({ electionId })
+      .resolves(updatedSettings);
+
+    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByRole('button', { name: 'Edit' });
+  });
+
+  test('clearing close time also unchecks enforcement options', async () => {
+    const initialSettings: SystemSettings = {
+      ...electionRecord.systemSettings,
+      electionDayPollsCloseTime: '2026-11-03T20:00:00',
+      disallowClosingPollsBeforeElectionDayPollsCloseTime: true,
+      disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+    };
+    apiMock.getSystemSettings
+      .expectCallWith({ electionId })
+      .resolves(initialSettings);
+    renderScreen();
+    await screen.findByRole('heading', { name: 'System Settings' });
+
+    userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'Disallow Closing Polls Before Election Day Polls Close Time',
+      })
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'Disallow VxAdmin Tabulation Before Election Day Polls Close Time',
+      })
+    ).toBeChecked();
+
+    fireEvent.change(screen.getByLabelText('Election Day Polls Close Time'), {
+      target: { value: '' },
+    });
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'Disallow Closing Polls Before Election Day Polls Close Time',
+      })
+    ).not.toBeChecked();
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'Disallow VxAdmin Tabulation Before Election Day Polls Close Time',
+      })
+    ).not.toBeChecked();
+
+    const updatedSettings: SystemSettings = {
+      ...initialSettings,
+      electionDayPollsCloseTime: undefined,
+      disallowClosingPollsBeforeElectionDayPollsCloseTime: undefined,
+      disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: undefined,
     };
     apiMock.updateSystemSettings
       .expectCallWith({ electionId, systemSettings: updatedSettings })

--- a/apps/design/frontend/src/system_settings_screen.test.tsx
+++ b/apps/design/frontend/src/system_settings_screen.test.tsx
@@ -7,7 +7,12 @@ import {
 import userEvent from '@testing-library/user-event';
 import { assertDefined } from '@votingworks/basics';
 import type { UserFeaturesConfig } from '@votingworks/design-backend';
-import { render, screen, within } from '../test/react_testing_library';
+import {
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '../test/react_testing_library';
 import {
   MockApiClient,
   createMockApiClient,
@@ -516,7 +521,10 @@ test('cancelling', async () => {
 });
 
 test('all controls are disabled until clicking "Edit"', async () => {
-  const { systemSettings } = electionRecord;
+  const systemSettings: SystemSettings = {
+    ...electionRecord.systemSettings,
+    electionDayPollsCloseTime: '2026-11-03T20:00:00',
+  };
   apiMock.getSystemSettings
     .expectCallWith({ electionId })
     .resolves(systemSettings);
@@ -527,13 +535,13 @@ test('all controls are disabled until clicking "Edit"', async () => {
   const allTextBoxes = document.body.querySelectorAll('input');
 
   for (const textbox of allTextBoxes) {
-    expect(textbox.type).toMatch(/^text|number$/);
+    expect(textbox.type).toMatch(/^text|number|datetime-local$/);
   }
 
   const allCheckboxes = document.body.querySelectorAll('[role=checkbox]');
   const allControls = [...allTextBoxes, ...allCheckboxes];
 
-  expect(allControls).toHaveLength(35);
+  expect(allControls).toHaveLength(38);
 
   for (const control of allControls) {
     expect(control).toBeDisabled();
@@ -773,6 +781,256 @@ test.each<{
     }
   }
 );
+
+describe('election day polls close time', () => {
+  test('enforcement checkboxes disabled when no close time is set', async () => {
+    apiMock.getSystemSettings
+      .expectCallWith({ electionId })
+      .resolves(electionRecord.systemSettings);
+    renderScreen();
+    await screen.findByRole('heading', { name: 'System Settings' });
+
+    userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'Disallow Closing Polls Before Election Day Polls Close Time',
+      })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'Disallow VxAdmin Tabulation Before Election Day Polls Close Time',
+      })
+    ).toBeDisabled();
+
+    // Setting a close time enables the checkboxes
+    fireEvent.change(screen.getByLabelText('Election Day Polls Close Time'), {
+      target: { value: '2026-11-03T20:00' },
+    });
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'Disallow Closing Polls Before Election Day Polls Close Time',
+      })
+    ).not.toBeDisabled();
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'Disallow VxAdmin Tabulation Before Election Day Polls Close Time',
+      })
+    ).not.toBeDisabled();
+  });
+
+  test('disallow closing polls before close time', async () => {
+    const initialSettings: SystemSettings = {
+      ...electionRecord.systemSettings,
+      electionDayPollsCloseTime: '2026-11-03T20:00:00',
+    };
+    apiMock.getSystemSettings
+      .expectCallWith({ electionId })
+      .resolves(initialSettings);
+    renderScreen();
+    await screen.findByRole('heading', { name: 'System Settings' });
+
+    userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    userEvent.click(
+      screen.getByRole('checkbox', {
+        name: 'Disallow Closing Polls Before Election Day Polls Close Time',
+        checked: false,
+      })
+    );
+
+    const updatedSettings: SystemSettings = {
+      ...initialSettings,
+      disallowClosingPollsBeforeElectionDayPollsCloseTime: true,
+    };
+    apiMock.updateSystemSettings
+      .expectCallWith({ electionId, systemSettings: updatedSettings })
+      .resolves();
+    apiMock.getSystemSettings
+      .expectCallWith({ electionId })
+      .resolves(updatedSettings);
+
+    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    screen.getByRole('checkbox', {
+      name: 'Disallow Closing Polls Before Election Day Polls Close Time',
+      checked: true,
+    });
+  });
+
+  test('disallow VxAdmin tabulation before close time', async () => {
+    const initialSettings: SystemSettings = {
+      ...electionRecord.systemSettings,
+      electionDayPollsCloseTime: '2026-11-03T20:00:00',
+    };
+    apiMock.getSystemSettings
+      .expectCallWith({ electionId })
+      .resolves(initialSettings);
+    renderScreen();
+    await screen.findByRole('heading', { name: 'System Settings' });
+
+    userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    userEvent.click(
+      screen.getByRole('checkbox', {
+        name: 'Disallow VxAdmin Tabulation Before Election Day Polls Close Time',
+        checked: false,
+      })
+    );
+
+    const updatedSettings: SystemSettings = {
+      ...initialSettings,
+      disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+    };
+    apiMock.updateSystemSettings
+      .expectCallWith({ electionId, systemSettings: updatedSettings })
+      .resolves();
+    apiMock.getSystemSettings
+      .expectCallWith({ electionId })
+      .resolves(updatedSettings);
+
+    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    screen.getByRole('checkbox', {
+      name: 'Disallow VxAdmin Tabulation Before Election Day Polls Close Time',
+      checked: true,
+    });
+  });
+
+  test('can set and update polls close time', async () => {
+    const initialSettings: SystemSettings = {
+      ...electionRecord.systemSettings,
+      electionDayPollsCloseTime: '2026-11-03T20:00:00',
+    };
+    apiMock.getSystemSettings
+      .expectCallWith({ electionId })
+      .resolves(initialSettings);
+    renderScreen();
+    await screen.findByRole('heading', { name: 'System Settings' });
+
+    const input = screen.getByLabelText<HTMLInputElement>(
+      'Election Day Polls Close Time'
+    );
+    expect(input).toBeDisabled();
+    expect(input).toHaveValue('2026-11-03T20:00');
+
+    userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(input).not.toBeDisabled();
+
+    fireEvent.change(input, { target: { value: '2026-11-03T21:30' } });
+    expect(input).toHaveValue('2026-11-03T21:30');
+
+    const updatedSettings: SystemSettings = {
+      ...initialSettings,
+      electionDayPollsCloseTime: '2026-11-03T21:30:00',
+    };
+    apiMock.updateSystemSettings
+      .expectCallWith({ electionId, systemSettings: updatedSettings })
+      .resolves();
+    apiMock.getSystemSettings
+      .expectCallWith({ electionId })
+      .resolves(updatedSettings);
+
+    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByRole('button', { name: 'Edit' });
+    expect(input).toHaveValue('2026-11-03T21:30');
+  });
+
+  test('clears to undefined when emptied', async () => {
+    const initialSettings: SystemSettings = {
+      ...electionRecord.systemSettings,
+      electionDayPollsCloseTime: '2026-11-03T20:00:00',
+    };
+    apiMock.getSystemSettings
+      .expectCallWith({ electionId })
+      .resolves(initialSettings);
+    renderScreen();
+    await screen.findByRole('heading', { name: 'System Settings' });
+
+    userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    const input = screen.getByLabelText('Election Day Polls Close Time');
+    fireEvent.change(input, { target: { value: '' } });
+
+    const updatedSettings: SystemSettings = {
+      ...initialSettings,
+      electionDayPollsCloseTime: undefined,
+    };
+    apiMock.updateSystemSettings
+      .expectCallWith({ electionId, systemSettings: updatedSettings })
+      .resolves();
+    apiMock.getSystemSettings
+      .expectCallWith({ electionId })
+      .resolves(updatedSettings);
+
+    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByRole('button', { name: 'Edit' });
+  });
+
+  test('shows confirmation modal when polls close time is in the morning', async () => {
+    const initialSettings: SystemSettings = {
+      ...electionRecord.systemSettings,
+      electionDayPollsCloseTime: '2026-11-03T20:00:00',
+    };
+    apiMock.getSystemSettings
+      .expectCallWith({ electionId })
+      .resolves(initialSettings);
+    renderScreen();
+    await screen.findByRole('heading', { name: 'System Settings' });
+
+    userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    const input = screen.getByLabelText('Election Day Polls Close Time');
+    fireEvent.change(input, { target: { value: '2026-11-03T08:00' } });
+
+    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByRole('heading', {
+      name: 'Polls Close Time Is In The Morning',
+    });
+
+    // Cancelling dismisses the modal without saving
+    userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(
+      screen.queryByRole('heading', {
+        name: 'Polls Close Time Is In The Morning',
+      })
+    ).not.toBeInTheDocument();
+
+    // Confirming saves
+    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByRole('heading', {
+      name: 'Polls Close Time Is In The Morning',
+    });
+
+    const updatedSettings: SystemSettings = {
+      ...initialSettings,
+      electionDayPollsCloseTime: '2026-11-03T08:00:00',
+    };
+    apiMock.updateSystemSettings
+      .expectCallWith({ electionId, systemSettings: updatedSettings })
+      .resolves();
+    apiMock.getSystemSettings
+      .expectCallWith({ electionId })
+      .resolves(updatedSettings);
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Save', hidden: false })
+    );
+    await screen.findByRole('button', { name: 'Edit' });
+  });
+
+  test('rejects polls close time in the past', async () => {
+    apiMock.getSystemSettings
+      .expectCallWith({ electionId })
+      .resolves(electionRecord.systemSettings);
+    renderScreen();
+    await screen.findByRole('heading', { name: 'System Settings' });
+
+    userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    const input = screen.getByLabelText<HTMLInputElement>(
+      'Election Day Polls Close Time'
+    );
+
+    // Set a time that is clearly in the past
+    fireEvent.change(input, { target: { value: '2000-01-01T08:00' } });
+    expect(input.validity.valid).toEqual(false);
+    expect(input.validationMessage).toContain('must be in the future');
+  });
+});
 
 test('validates streak width threshold must be less than max cumulative width', async () => {
   apiMock.getSystemSettings

--- a/apps/design/frontend/src/system_settings_screen.tsx
+++ b/apps/design/frontend/src/system_settings_screen.tsx
@@ -8,6 +8,8 @@ import {
   MainContent,
   CheckboxButton,
   SearchSelect,
+  Modal,
+  P,
 } from '@votingworks/ui';
 import { useParams } from 'react-router-dom';
 import {
@@ -119,12 +121,15 @@ export function SystemSettingsForm({
   const [isEditing, setIsEditing] = useState(false);
   const [systemSettings, setSystemSettings] =
     useState<SystemSettings>(savedSystemSettings);
+  const [isConfirmingAmPollsCloseTime, setIsConfirmingAmPollsCloseTime] =
+    useState(false);
   const updateSystemSettingsMutation = updateSystemSettings.useMutation();
   const getUserFeaturesQuery = getUserFeatures.useQuery();
   const getResultsReportingUrlQuery = getResultsReportingUrl.useQuery();
 
   const maxCumulativeStreakWidthInputRef = useRef<HTMLInputElement>(null);
   const retryStreakWidthThresholdInputRef = useRef<HTMLInputElement>(null);
+  const electionDayPollsCloseTimeInputRef = useRef<HTMLInputElement>(null);
 
   function validateStreakSettings(settings: SystemSettings) {
     const parseResult = safeParse(SystemSettingsSchema, settings);
@@ -171,11 +176,33 @@ export function SystemSettingsForm({
   }
   const features = getUserFeaturesQuery.data;
 
-  function onSubmit() {
+  function validatePollsCloseTime(closeTime?: string) {
+    const input = electionDayPollsCloseTimeInputRef.current;
+    if (!input) return;
+    if (closeTime && new Date(closeTime) <= new Date()) {
+      input.setCustomValidity('Polls close time must be in the future.');
+    } else {
+      input.setCustomValidity('');
+    }
+  }
+
+  function saveSettings() {
     updateSystemSettingsMutation.mutate(
       { electionId, systemSettings },
       { onSuccess: () => setIsEditing(false) }
     );
+  }
+
+  function onSubmit() {
+    const { electionDayPollsCloseTime } = systemSettings;
+    if (electionDayPollsCloseTime) {
+      const hour = new Date(electionDayPollsCloseTime).getHours();
+      if (hour < 12) {
+        setIsConfirmingAmPollsCloseTime(true);
+        return;
+      }
+    }
+    saveSettings();
   }
 
   const adjudicationReasonOptions = [
@@ -215,6 +242,7 @@ export function SystemSettingsForm({
       onReset={(e) => {
         e.preventDefault();
         setSystemSettings(savedSystemSettings);
+        validatePollsCloseTime(savedSystemSettings.electionDayPollsCloseTime);
         setIsEditing(false);
       }}
     >
@@ -560,6 +588,61 @@ export function SystemSettingsForm({
           </Column>
         </Card>
         <Card>
+          <H2>Polls Close Time</H2>
+          <Column style={{ gap: '1.5rem' }}>
+            <InputGroup label="Election Day Polls Close Time">
+              <input
+                ref={electionDayPollsCloseTimeInputRef}
+                type="datetime-local"
+                aria-label="Election Day Polls Close Time"
+                value={
+                  systemSettings.electionDayPollsCloseTime?.slice(0, 16) ?? ''
+                }
+                onChange={(e) => {
+                  const closeTime = e.target.value
+                    ? `${e.target.value}:00`
+                    : undefined;
+                  validatePollsCloseTime(closeTime);
+                  setSystemSettings({
+                    ...systemSettings,
+                    electionDayPollsCloseTime: closeTime,
+                  });
+                }}
+                disabled={!isEditing}
+              />
+            </InputGroup>
+            <CheckboxButton
+              label="Disallow Closing Polls Before Election Day Polls Close Time"
+              isChecked={Boolean(
+                systemSettings.disallowClosingPollsBeforeElectionDayPollsCloseTime
+              )}
+              onChange={(isChecked) =>
+                setSystemSettings({
+                  ...systemSettings,
+                  disallowClosingPollsBeforeElectionDayPollsCloseTime: isChecked
+                    ? true
+                    : undefined,
+                })
+              }
+              disabled={!isEditing || !systemSettings.electionDayPollsCloseTime}
+            />
+            <CheckboxButton
+              label="Disallow VxAdmin Tabulation Before Election Day Polls Close Time"
+              isChecked={Boolean(
+                systemSettings.disallowVxAdminTabulationBeforeElectionDayPollsCloseTime
+              )}
+              onChange={(isChecked) =>
+                setSystemSettings({
+                  ...systemSettings,
+                  disallowVxAdminTabulationBeforeElectionDayPollsCloseTime:
+                    isChecked ? true : undefined,
+                })
+              }
+              disabled={!isEditing || !systemSettings.electionDayPollsCloseTime}
+            />
+          </Column>
+        </Card>
+        <Card>
           <H2>Other</H2>
           <Column style={{ gap: '1.5rem' }}>
             <CheckboxButton
@@ -770,6 +853,38 @@ export function SystemSettingsForm({
             Edit
           </Button>
         </FormActionsRow>
+      )}
+      {isConfirmingAmPollsCloseTime && (
+        <Modal
+          title="Polls Close Time Is In The Morning"
+          content={
+            <P>
+              The polls close time is set to the morning. Are you sure this is
+              correct?
+            </P>
+          }
+          actions={
+            <React.Fragment>
+              <Button
+                variant="primary"
+                icon="Done"
+                onPress={() => {
+                  setIsConfirmingAmPollsCloseTime(false);
+                  saveSettings();
+                }}
+              >
+                Save
+              </Button>
+              <Button onPress={() => setIsConfirmingAmPollsCloseTime(false)}>
+                Cancel
+              </Button>
+            </React.Fragment>
+          }
+          onOverlayClick={
+            /* istanbul ignore next - @preserve */
+            () => setIsConfirmingAmPollsCloseTime(false)
+          }
+        />
       )}
     </Form>
   );

--- a/apps/design/frontend/src/system_settings_screen.tsx
+++ b/apps/design/frontend/src/system_settings_screen.tsx
@@ -608,6 +608,14 @@ export function SystemSettingsForm({
                   setSystemSettings({
                     ...systemSettings,
                     electionDayPollsCloseTime: closeTime,
+                    ...(closeTime === undefined
+                      ? {
+                          disallowClosingPollsBeforeElectionDayPollsCloseTime:
+                            undefined,
+                          disallowVxAdminTabulationBeforeElectionDayPollsCloseTime:
+                            undefined,
+                        }
+                      : {}),
                   });
                 }}
                 disabled={!isEditing}

--- a/apps/design/frontend/src/system_settings_screen.tsx
+++ b/apps/design/frontend/src/system_settings_screen.tsx
@@ -121,8 +121,10 @@ export function SystemSettingsForm({
   const [isEditing, setIsEditing] = useState(false);
   const [systemSettings, setSystemSettings] =
     useState<SystemSettings>(savedSystemSettings);
-  const [isConfirmingAmPollsCloseTime, setIsConfirmingAmPollsCloseTime] =
-    useState(false);
+  const [
+    isConfirmingMorningPollsCloseTime,
+    setIsConfirmingMorningPollsCloseTime,
+  ] = useState(false);
   const updateSystemSettingsMutation = updateSystemSettings.useMutation();
   const getUserFeaturesQuery = getUserFeatures.useQuery();
   const getResultsReportingUrlQuery = getResultsReportingUrl.useQuery();
@@ -198,7 +200,7 @@ export function SystemSettingsForm({
     if (electionDayPollsCloseTime) {
       const hour = new Date(electionDayPollsCloseTime).getHours();
       if (hour < 12) {
-        setIsConfirmingAmPollsCloseTime(true);
+        setIsConfirmingMorningPollsCloseTime(true);
         return;
       }
     }
@@ -854,7 +856,7 @@ export function SystemSettingsForm({
           </Button>
         </FormActionsRow>
       )}
-      {isConfirmingAmPollsCloseTime && (
+      {isConfirmingMorningPollsCloseTime && (
         <Modal
           title="Polls Close Time Is In The Morning"
           content={
@@ -869,20 +871,22 @@ export function SystemSettingsForm({
                 variant="primary"
                 icon="Done"
                 onPress={() => {
-                  setIsConfirmingAmPollsCloseTime(false);
+                  setIsConfirmingMorningPollsCloseTime(false);
                   saveSettings();
                 }}
               >
                 Save
               </Button>
-              <Button onPress={() => setIsConfirmingAmPollsCloseTime(false)}>
+              <Button
+                onPress={() => setIsConfirmingMorningPollsCloseTime(false)}
+              >
                 Cancel
               </Button>
             </React.Fragment>
           }
           onOverlayClick={
             /* istanbul ignore next - @preserve */
-            () => setIsConfirmingAmPollsCloseTime(false)
+            () => setIsConfirmingMorningPollsCloseTime(false)
           }
         />
       )}

--- a/libs/types/src/__snapshots__/system_settings.test.ts.snap
+++ b/libs/types/src/__snapshots__/system_settings.test.ts.snap
@@ -1,5 +1,29 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`disallows enforcement flags without polls close time 1`] = `
+[ZodError: [
+  {
+    "code": "custom",
+    "path": [
+      "disallowClosingPollsBeforeElectionDayPollsCloseTime"
+    ],
+    "message": "Election day polls close time must be set when disallowing closing polls before that time"
+  }
+]]
+`;
+
+exports[`disallows enforcement flags without polls close time 2`] = `
+[ZodError: [
+  {
+    "code": "custom",
+    "path": [
+      "disallowVxAdminTabulationBeforeElectionDayPollsCloseTime"
+    ],
+    "message": "Election day polls close time must be set when disallowing VxAdmin tabulation before that time"
+  }
+]]
+`;
+
 exports[`disallows invalid adjudication reasons 1`] = `
 [ZodError: [
   {

--- a/libs/types/src/system_settings.test.ts
+++ b/libs/types/src/system_settings.test.ts
@@ -71,6 +71,26 @@ test('disallows invalid adjudication reasons', () => {
   ).toMatchSnapshot();
 });
 
+test('disallows enforcement flags without polls close time', () => {
+  expect(
+    safeParseSystemSettings(
+      JSON.stringify({
+        ...DEFAULT_SYSTEM_SETTINGS,
+        disallowClosingPollsBeforeElectionDayPollsCloseTime: true,
+      })
+    ).unsafeUnwrapErr()
+  ).toMatchSnapshot();
+
+  expect(
+    safeParseSystemSettings(
+      JSON.stringify({
+        ...DEFAULT_SYSTEM_SETTINGS,
+        disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+      })
+    ).unsafeUnwrapErr()
+  ).toMatchSnapshot();
+});
+
 test('disallows retry streak threshold greater than or equal to normal threshold', () => {
   // Valid: retry threshold less than normal threshold
   expect(

--- a/libs/types/src/system_settings.ts
+++ b/libs/types/src/system_settings.ts
@@ -207,7 +207,49 @@ export const SystemSettingsSchema = z
      * not be using headphones with VxScan.
      */
     precinctScanDisableScreenReaderAudio: z.boolean().optional(),
+
+    /**
+     * The date and time at which polls close on election day, stored as a
+     * timezone-agnostic ISO 8601 datetime string (e.g. "2026-11-03T20:00:00").
+     * Interpreted in the local time of the machine.
+     */
+    electionDayPollsCloseTime: z.string().datetime({ local: true }).optional(),
+
+    /**
+     * When true, machines with a close-polls action (VxScan, VxMark, VxMarkScan)
+     * will block poll workers from closing polls before
+     * {@link SystemSettings.electionDayPollsCloseTime}.
+     */
+    disallowClosingPollsBeforeElectionDayPollsCloseTime: z.boolean().optional(),
+
+    /**
+     * When true, VxAdmin will block tabulation before
+     * {@link SystemSettings.electionDayPollsCloseTime} has passed.
+     */
+    disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: z
+      .boolean()
+      .optional(),
   })
+  .refine(
+    (settings) =>
+      !settings.disallowClosingPollsBeforeElectionDayPollsCloseTime ||
+      settings.electionDayPollsCloseTime !== undefined,
+    {
+      message:
+        'Election day polls close time must be set when disallowing closing polls before that time',
+      path: ['disallowClosingPollsBeforeElectionDayPollsCloseTime'],
+    }
+  )
+  .refine(
+    (settings) =>
+      !settings.disallowVxAdminTabulationBeforeElectionDayPollsCloseTime ||
+      settings.electionDayPollsCloseTime !== undefined,
+    {
+      message:
+        'Election day polls close time must be set when disallowing VxAdmin tabulation before that time',
+      path: ['disallowVxAdminTabulationBeforeElectionDayPollsCloseTime'],
+    }
+  )
   .refine(
     (settings) => {
       // Validate that retry streak threshold is strictly less than max cumulative streak width


### PR DESCRIPTION
## Overview

Relates to https://github.com/votingworks/vxsuite/issues/8026

* Adds 3 options related to "polls close time" to the system settings model
  * "Election Day Polls Close Time". A timezoneless datetime describing when the polls should close. Unlocks downstream functionality like those specified by the next 2 options.
  * "Disallow Closing Polls Before Election Day Polls Close Time"
  * "Disallow VxAdmin Tabulation Before Election Day Polls Closed Time"
* Makes them writeable from system settings page in VxDesign
* Adds validation for writing these system settings
  * Adds a confirmation modal if the polls close time is set to the morning because we expect most elections to end in the evening
  * Requires polls close time to be in the future
  * Requires a polls close time to be set before the `Disallow *` options can be set

## Demo Video or Screenshot


https://github.com/user-attachments/assets/c83a9706-1670-40d1-b8e9-026496abe1a4

This screen can get a little awkward at certain aspect ratios that force the "Polls Close Time" card to be as high as the "Other" card, which contains many more options. There's an argument to be made that the Polls Close Time options should go into "Other" to avoid this, but there's also a greater argument that we need to redesign this page more completely. 

<img width="1888" height="1102" alt="Screenshot 2026-04-15 at 3 57 13 PM" src="https://github.com/user-attachments/assets/fd50d6eb-1e4f-4a00-80b3-9a006724e694" />



## Testing Plan
- adds tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
