### PR TITLE
VxCentralScan: limit imprinter string to 40 characters for fi-8950

### DIFF
--- a/apps/central-scan/backend/src/fujitsu_scanner.test.ts
+++ b/apps/central-scan/backend/src/fujitsu_scanner.test.ts
@@ -256,9 +256,85 @@ test('fujitsu scanner does imprint as expected when given an imprint ID prefix',
     expect.arrayContaining(['--endorser=yes'])
   );
 
+  // Prefix is under the 34-char limit, so it is used as-is
   expect(exec).toHaveBeenCalledWith(
     'scanimage',
     expect.arrayContaining(['--endorser-string', 'TEST-BATCH-ID_%04ud'])
+  );
+});
+
+test('fujitsu scanner shortens UUID imprint prefix to first and last segments when it exceeds the limit', () => {
+  const scanimage = makeMockChildProcess();
+  const scanner = new FujitsuScanner({
+    logger: new BaseLogger(LogSource.VxScanService),
+  });
+
+  // UUID is 36 chars, which exceeds the 34-char limit, so it is shortened
+  // to the first and last hyphen-separated segments
+  exec.mockReturnValueOnce(scanimage);
+  scanner.scanSheets({
+    imprintIdPrefix: 'b28733b5-dc01-4901-b433-ea179942993b',
+  });
+
+  scanimage.stderr.append(
+    [
+      'Scanning infinity pages, incrementing by 1, numbering from 1\n',
+      'Place document no. 1 on the scanner.\n',
+      'Press <RETURN> to continue.\n',
+      'Press Ctrl + D to terminate.\n',
+    ].join('')
+  );
+  expect(exec).toHaveBeenCalledWith(
+    'scanimage',
+    expect.arrayContaining(['--endorser-string', 'b28733b5-ea179942993b_%04ud'])
+  );
+});
+
+test('fujitsu scanner passes through imprint prefix unchanged when it has no hyphens', () => {
+  const scanimage = makeMockChildProcess();
+  const scanner = new FujitsuScanner({
+    logger: new BaseLogger(LogSource.VxScanService),
+  });
+
+  exec.mockReturnValueOnce(scanimage);
+  scanner.scanSheets({ imprintIdPrefix: 'SIMPLEBATCH' });
+
+  scanimage.stderr.append(
+    [
+      'Scanning infinity pages, incrementing by 1, numbering from 1\n',
+      'Place document no. 1 on the scanner.\n',
+      'Press <RETURN> to continue.\n',
+      'Press Ctrl + D to terminate.\n',
+    ].join('')
+  );
+  expect(exec).toHaveBeenCalledWith(
+    'scanimage',
+    expect.arrayContaining(['--endorser-string', 'SIMPLEBATCH_%04ud'])
+  );
+});
+
+test('fujitsu scanner truncates imprint prefix to fit within endorser string limit', () => {
+  const scanimage = makeMockChildProcess();
+  const scanner = new FujitsuScanner({
+    logger: new BaseLogger(LogSource.VxScanService),
+  });
+
+  // 40-char prefix with no hyphens — truncated to 34 chars to leave room for '_%04ud'
+  const longPrefix = 'A'.repeat(40);
+  exec.mockReturnValueOnce(scanimage);
+  scanner.scanSheets({ imprintIdPrefix: longPrefix });
+
+  scanimage.stderr.append(
+    [
+      'Scanning infinity pages, incrementing by 1, numbering from 1\n',
+      'Place document no. 1 on the scanner.\n',
+      'Press <RETURN> to continue.\n',
+      'Press Ctrl + D to terminate.\n',
+    ].join('')
+  );
+  expect(exec).toHaveBeenCalledWith(
+    'scanimage',
+    expect.arrayContaining(['--endorser-string', `${'A'.repeat(34)}_%04ud`])
   );
 });
 

--- a/apps/central-scan/backend/src/fujitsu_scanner.ts
+++ b/apps/central-scan/backend/src/fujitsu_scanner.ts
@@ -17,6 +17,10 @@ const debug = makeDebug('scan:scanner');
 export const FUJITSU_VENDOR_ID = 0x4c5;
 export const FUJITSU_FI_7160_PRODUCT_ID = 0x132e;
 export const FUJITSU_FI_8170_PRODUCT_ID = 0x15ff;
+const SEQUENTIAL_BALLOT_ID_STRING = '_%04ud';
+const FI_8950_ENDORSER_STRING_CHAR_LIMIT = 40;
+const MAX_PREFIX_LENGTH =
+  FI_8950_ENDORSER_STRING_CHAR_LIMIT - SEQUENTIAL_BALLOT_ID_STRING.length;
 
 export const EXPECTED_IMPRINTER_UNATTACHED_ERROR =
   'attempted to set readonly option endorser';
@@ -163,13 +167,27 @@ export class FujitsuScanner implements BatchScanner {
       // streaming over USB and waiting for the bytes to cross the wire before
       // continuing. Verified that this improves performance with the fi-8170
       // from 1.3s to 0.8s per sheet along with `--prepick=ON`.
-      '--buffermode=ON',
+      // '--buffermode=ON',
     ];
 
     if (imprintIdPrefix !== undefined) {
+      // Truncate the prefix to a safe length. Then imprint the safe prefix
+      // followed by a sequential index for each page in the batch.
+      let safeImprintIdPrefix = imprintIdPrefix;
+      // The fi-8950 silently fails to imprint if the endorser string is too long.
+      // Truncate the prefix if too long.
+      if (imprintIdPrefix.length > MAX_PREFIX_LENGTH) {
+        const idParts = imprintIdPrefix.split('-');
+        safeImprintIdPrefix = (
+          idParts.length > 1
+            ? `${idParts[0]}-${idParts.at(-1)}`
+            : imprintIdPrefix
+        ).substring(0, MAX_PREFIX_LENGTH);
+      }
+      const endorserString = `${safeImprintIdPrefix}${SEQUENTIAL_BALLOT_ID_STRING}`;
+
       args.push('--endorser=yes');
-      // Imprint the prefix followed by a sequential index for each page in the batch
-      args.push('--endorser-string', `${imprintIdPrefix}_%04ud`);
+      args.push('--endorser-string', endorserString);
     }
 
     /**

--- a/apps/central-scan/backend/src/fujitsu_scanner.ts
+++ b/apps/central-scan/backend/src/fujitsu_scanner.ts
@@ -18,6 +18,8 @@ export const FUJITSU_VENDOR_ID = 0x4c5;
 export const FUJITSU_FI_7160_PRODUCT_ID = 0x132e;
 export const FUJITSU_FI_8170_PRODUCT_ID = 0x15ff;
 const SEQUENTIAL_BALLOT_ID_STRING = '_%04ud';
+// The fi-8950 silently fails to imprint if the --endorserString option
+// exceeds this character limit.
 const FI_8950_ENDORSER_STRING_CHAR_LIMIT = 40;
 const MAX_PREFIX_LENGTH =
   FI_8950_ENDORSER_STRING_CHAR_LIMIT - SEQUENTIAL_BALLOT_ID_STRING.length;
@@ -174,8 +176,6 @@ export class FujitsuScanner implements BatchScanner {
       // Truncate the prefix to a safe length. Then imprint the safe prefix
       // followed by a sequential index for each page in the batch.
       let safeImprintIdPrefix = imprintIdPrefix;
-      // The fi-8950 silently fails to imprint if the endorser string is too long.
-      // Truncate the prefix if too long.
       if (imprintIdPrefix.length > MAX_PREFIX_LENGTH) {
         const idParts = imprintIdPrefix.split('-');
         safeImprintIdPrefix = (


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/8053

The imprinter for fi-8950 scanner has a 40 character limit in the imprint command. The imprinter for the fi-8170 supports 43 characters. Our imprinter string was `<UUID>_%04ud` or 42 characters, which means it worked on the 8170 but not 8950.

This PR truncates the UUID to `<first segment>-<last segment>_%04ud` eg. `12345678-abcdef123456-0005` for the 5th ballot in batch `12345678-...-abcdef123456`. It also hard caps the prefix to 34 characters so if we happen to migrate to an ID that isn't splittable by `-` we still can fallback safely.

## Demo Video or Screenshot

Videos of letter, legal, and 22" ballots. This was before the change from underscore to hyphen character as separator.


https://github.com/user-attachments/assets/81864532-d8f9-4b34-8924-de3e8389ec0a


https://github.com/user-attachments/assets/3be0eb23-0d87-436a-accd-84563a422c94


https://github.com/user-attachments/assets/a7ee750e-9631-47f6-9e7d-bb247fec6cc3



## Testing Plan

- manually tested on hardware
- added test for truncating logic

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
