### PR TITLE
VxDesign: Fix county ID not being regenerated in loadElection

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -3471,6 +3471,10 @@ test('Election package and ballots export', async () => {
   const expectedElectionWithoutBallotStrings: Election = {
     ...electionWithLegalPaper,
     id: electionId,
+    county: {
+      ...electionWithLegalPaper.county,
+      id: `${electionId}-county`,
+    },
     // Ballot styles are generated in the app, ignoring the ones in the inputted election
     // definition
     ballotStyles,

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -351,7 +351,7 @@ export function buildApi(ctx: AppContext) {
       const stateFeatures = getStateFeaturesConfig(jurisdiction);
 
       try {
-        const election: Election = (() => {
+        const election = ((): Election => {
           switch (input.upload.format) {
             case 'vxf': {
               const sourceElection = safeParseElection(
@@ -390,8 +390,8 @@ export function buildApi(ctx: AppContext) {
                 id: input.newId,
                 county: {
                   ...sourceElection.county,
-                  // County ID needs to be deterministic, but doesn't actually get used anywhere
-                  countyId: `${input.newId}-county`,
+                  // County ID needs to be deterministic
+                  id: `${input.newId}-county`,
                 },
                 districts,
                 pollingPlaces,


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

The `loadElection` handler for VxF imports incorrectly used field name `countyId` instead of `id` when trying to regenerate the county ID for the election. This should have been caught by the type checker, but because the error was inside an immediately invoked function expression (IIFE), the excess property checking did not apply correctly. Fixed the bug and the type checking issue.

## Testing Plan

- Updated test that was also incorrect

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
