### PR TITLE
Try preventing dependabot PRs not related to security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    # This only applies to the number of open regular version-update PRs.
+    # Security update PRs will continue to be created, since they have a
+    # separate limit:
+    # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit-
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Overview

Have seen a few PRs from dependabot that don't have an attached security advisory and seem to just be regular version updates. From searching around, this seems to be the most promising solution to quiet those (without removing the config YAML file altogether, which would result in PRs with no lock file updates).

## Testing Plan
- Will have to wait it out and see if it helps reduce the noise. There's apparently a way to dry-run the `dependabot` CLI locally to see what changes it would make, but haven't been able to get it to work yet.
