### PR TITLE
VxDesign: Revamp live reports ui to be polling place centric

### DIFF
--- a/apps/design/backend/src/app.results.test.ts
+++ b/apps/design/backend/src/app.results.test.ts
@@ -18,6 +18,8 @@ import {
   ContestId,
   ElectionDefinition,
   ElectionId,
+  PollingPlace,
+  PollingPlaceType,
   PrecinctId,
   safeParseElectionDefinition,
   Tabulation,
@@ -26,6 +28,8 @@ import { encodeQuickResultsMessage } from '@votingworks/auth';
 import { electionWithMsEitherNeitherFixtures } from '@votingworks/fixtures';
 import { readElectionPackageFromBuffer } from '@votingworks/backend';
 import { renderAllBallotPdfsAndCreateElectionDefinition } from '@votingworks/hmpb';
+import type * as grout from '@votingworks/grout';
+import type { UnauthenticatedApi } from './app';
 import {
   ApiClient,
   exportElectionPackage,
@@ -41,6 +45,7 @@ import {
   organizations,
   users,
 } from '../test/mocks';
+import { MAX_LIVE_REPORT_ACTIVITY_ITEMS } from './globals';
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
@@ -138,6 +143,11 @@ async function setUpElectionInSystem(
     electionId,
   });
   expect(storedPollStatus).toEqual(err('no-election-export-found'));
+
+  const storedActivityLog = await apiClient.getLiveReportsActivityLog({
+    electionId,
+  });
+  expect(storedActivityLog).toEqual(err('no-election-export-found'));
 
   const exportMeta = await exportElectionPackage({
     electionId,
@@ -565,6 +575,21 @@ test('quick results reporting works e2e with all precinct reports', async () => 
       },
     })
   );
+  const activityLogStatus = await apiClient.getLiveReportsActivityLog({
+    electionId: sampleElectionDefinition.election.id,
+  });
+  expect(activityLogStatus).toEqual(
+    ok({
+      activityLog: [
+        {
+          machineId: 'machineId',
+          pollingPlaceId: 'test-polling-place',
+          pollsTransitionType: 'close_polls',
+          signedTimestamp: new Date('2024-01-02T12:00:00.000Z'),
+        },
+      ],
+    })
+  );
 
   // Report from a different machine should be added to the list of machines reporting
   const result4 = await unauthenticatedApiClient.processQrCodeReport({
@@ -698,30 +723,53 @@ test('quick results reporting works for polls open reporting', async () => {
     electionId: sampleElectionDefinition.election.id,
   });
   expect(pollsStatus).toEqual(
+    ok(
+      expect.objectContaining({
+        election: expect.objectContaining({
+          id: sampleElectionDefinition.election.id,
+        }),
+        ballotHash: sampleElectionDefinition.ballotHash,
+        isLive: false,
+        reportsByPollingPlace: expect.objectContaining({
+          [precinctId]: [
+            {
+              machineId: 'mock-02',
+              pollingPlaceId: precinctId,
+              pollsTransitionType: 'open_polls',
+              signedTimestamp: new Date('2024-05-04T09:00:00Z'),
+            },
+          ],
+          'test-polling-place': [
+            {
+              machineId: 'mock-01',
+              pollingPlaceId: 'test-polling-place',
+              pollsTransitionType: 'open_polls',
+              signedTimestamp: new Date('2024-05-04T08:00:00Z'),
+            },
+          ],
+        }),
+      })
+    )
+  );
+  const activityLogStatus = await apiClient.getLiveReportsActivityLog({
+    electionId: sampleElectionDefinition.election.id,
+  });
+  expect(activityLogStatus).toEqual(
     ok({
-      election: expect.objectContaining({
-        id: sampleElectionDefinition.election.id,
-      }),
-      ballotHash: sampleElectionDefinition.ballotHash,
-      isLive: false,
-      reportsByPollingPlace: expect.objectContaining({
-        [precinctId]: [
-          {
-            machineId: 'mock-02',
-            pollingPlaceId: precinctId,
-            pollsTransitionType: 'open_polls',
-            signedTimestamp: new Date('2024-05-04T09:00:00Z'),
-          },
-        ],
-        'test-polling-place': [
-          {
-            machineId: 'mock-01',
-            pollingPlaceId: 'test-polling-place',
-            pollsTransitionType: 'open_polls',
-            signedTimestamp: new Date('2024-05-04T08:00:00Z'),
-          },
-        ],
-      }),
+      activityLog: [
+        {
+          machineId: 'mock-02',
+          pollingPlaceId: precinctId,
+          pollsTransitionType: 'open_polls',
+          signedTimestamp: new Date('2024-05-04T09:00:00Z'),
+        },
+        {
+          machineId: 'mock-01',
+          pollingPlaceId: 'test-polling-place',
+          pollsTransitionType: 'open_polls',
+          signedTimestamp: new Date('2024-05-04T08:00:00Z'),
+        },
+      ],
     })
   );
 
@@ -857,23 +905,40 @@ test('quick results reporting works for polls open reporting', async () => {
   });
 
   expect(pollsStatusLiveMode).toEqual(
-    ok({
-      election: expect.objectContaining({
-        id: sampleElectionDefinition.election.id,
-      }),
-      isLive: true,
-      ballotHash: sampleElectionDefinition.ballotHash,
-      reportsByPollingPlace: expect.objectContaining({
-        'test-polling-place': [
-          {
-            machineId: 'mock-01',
+    ok(
+      expect.objectContaining({
+        election: expect.objectContaining({
+          id: sampleElectionDefinition.election.id,
+        }),
+        isLive: true,
+        ballotHash: sampleElectionDefinition.ballotHash,
+        reportsByPollingPlace: expect.objectContaining({
+          'test-polling-place': [
+            {
+              machineId: 'mock-01',
 
-            pollingPlaceId: 'test-polling-place',
-            pollsTransitionType: 'open_polls',
-            signedTimestamp: new Date('2024-05-05T08:00:00Z'),
-          },
-        ],
-      }),
+              pollingPlaceId: 'test-polling-place',
+              pollsTransitionType: 'open_polls',
+              signedTimestamp: new Date('2024-05-05T08:00:00Z'),
+            },
+          ],
+        }),
+      })
+    )
+  );
+  const activityLogLiveMode = await apiClient.getLiveReportsActivityLog({
+    electionId: sampleElectionDefinition.election.id,
+  });
+  expect(activityLogLiveMode).toEqual(
+    ok({
+      activityLog: [
+        {
+          machineId: 'mock-01',
+          pollingPlaceId: 'test-polling-place',
+          pollsTransitionType: 'open_polls',
+          signedTimestamp: new Date('2024-05-05T08:00:00Z'),
+        },
+      ],
     })
   );
 });
@@ -2204,5 +2269,389 @@ test('LiveReports uses modified exported election, not original vxdesign electio
         election: reorderedElectionDefinition.election,
       })
     )
+  );
+});
+
+// --- Activity log and votingGroup filter tests ---
+
+async function sendTransitionReport(
+  unauthenticatedApiClient: grout.Client<UnauthenticatedApi>,
+  {
+    ballotHash,
+    machineId,
+    pollingPlaceId,
+    timestamp,
+    transition = 'open_polls',
+    isLive = true,
+    ballotCount = 0,
+  }: {
+    ballotHash: string;
+    machineId: string;
+    pollingPlaceId: string;
+    timestamp: Date;
+    transition?: 'open_polls' | 'pause_voting' | 'resume_voting';
+    isLive?: boolean;
+    ballotCount?: number;
+  }
+): Promise<void> {
+  const result = await unauthenticatedApiClient.processQrCodeReport({
+    payload: `1//qr3//${encodeQuickResultsMessage({
+      ballotHash,
+      signingMachineId: machineId,
+      timestamp: timestamp.getTime() / 1000,
+      isLiveMode: isLive,
+      primaryMessage: transition,
+      numPages: 1,
+      pageIndex: 0,
+      pollingPlaceId,
+      ballotCount,
+      votingType: 'election_day',
+    })}`,
+    signature: 'test-signature',
+    certificate: 'test-certificate',
+  });
+  result.unsafeUnwrap();
+}
+
+test('getLiveReportsActivityLog returns activity log ordered by timestamp desc', async () => {
+  const {
+    unauthenticatedApiClient,
+    apiClient,
+    workspace,
+    fileStorageClient,
+    auth0,
+  } = await setupApp({
+    organizations,
+    jurisdictions,
+    users,
+  });
+  auth0.setLoggedInUser(nonVxUser);
+  const sampleElectionDefinition = await setUpElectionInSystem(
+    apiClient,
+    workspace,
+    fileStorageClient
+  );
+  const { ballotHash } = sampleElectionDefinition;
+  const electionId = sampleElectionDefinition.election.id;
+
+  // Submit three reports out of chronological order
+  await sendTransitionReport(unauthenticatedApiClient, {
+    ballotHash,
+    machineId: 'machine-b',
+    pollingPlaceId: 'pp-b',
+    timestamp: new Date('2024-01-01T09:00:00Z'),
+  });
+  await sendTransitionReport(unauthenticatedApiClient, {
+    ballotHash,
+    machineId: 'machine-a',
+    pollingPlaceId: 'pp-a',
+    timestamp: new Date('2024-01-01T07:00:00Z'),
+  });
+  await sendTransitionReport(unauthenticatedApiClient, {
+    ballotHash,
+    machineId: 'machine-c',
+    pollingPlaceId: 'pp-c',
+    timestamp: new Date('2024-01-01T08:00:00Z'),
+  });
+
+  const activityLogStatus = await apiClient.getLiveReportsActivityLog({
+    electionId,
+  });
+  expect(activityLogStatus.unsafeUnwrap().activityLog).toEqual([
+    {
+      machineId: 'machine-b',
+      pollingPlaceId: 'pp-b',
+      pollsTransitionType: 'open_polls',
+      signedTimestamp: new Date('2024-01-01T09:00:00Z'),
+    },
+    {
+      machineId: 'machine-c',
+      pollingPlaceId: 'pp-c',
+      pollsTransitionType: 'open_polls',
+      signedTimestamp: new Date('2024-01-01T08:00:00Z'),
+    },
+    {
+      machineId: 'machine-a',
+      pollingPlaceId: 'pp-a',
+      pollsTransitionType: 'open_polls',
+      signedTimestamp: new Date('2024-01-01T07:00:00Z'),
+    },
+  ]);
+});
+
+test('getLiveReportsActivityLog includes every state change for a machine', async () => {
+  const {
+    unauthenticatedApiClient,
+    apiClient,
+    workspace,
+    fileStorageClient,
+    auth0,
+  } = await setupApp({
+    organizations,
+    jurisdictions,
+    users,
+  });
+  auth0.setLoggedInUser(nonVxUser);
+  const sampleElectionDefinition = await setUpElectionInSystem(
+    apiClient,
+    workspace,
+    fileStorageClient
+  );
+  const { ballotHash } = sampleElectionDefinition;
+  const electionId = sampleElectionDefinition.election.id;
+
+  // Same machine: open, then pause, then resume
+  await sendTransitionReport(unauthenticatedApiClient, {
+    ballotHash,
+    machineId: 'machine-a',
+    pollingPlaceId: 'pp-a',
+    timestamp: new Date('2024-01-01T07:00:00Z'),
+  });
+  await sendTransitionReport(unauthenticatedApiClient, {
+    ballotHash,
+    machineId: 'machine-a',
+    pollingPlaceId: 'pp-a',
+    timestamp: new Date('2024-01-01T12:00:00Z'),
+    transition: 'pause_voting',
+  });
+  await sendTransitionReport(unauthenticatedApiClient, {
+    ballotHash,
+    machineId: 'machine-a',
+    pollingPlaceId: 'pp-a',
+    timestamp: new Date('2024-01-01T13:00:00Z'),
+    transition: 'resume_voting',
+    ballotCount: 10,
+  });
+
+  const activityLogStatus = await apiClient.getLiveReportsActivityLog({
+    electionId,
+  });
+  const { activityLog } = activityLogStatus.unsafeUnwrap();
+  expect(activityLog).toHaveLength(3);
+  expect(activityLog.map((entry) => entry.pollsTransitionType)).toEqual([
+    'resume_voting',
+    'pause_voting',
+    'open_polls',
+  ]);
+
+  // reportsByPollingPlace still only returns the latest per machine
+  const pollsStatus = await apiClient.getLiveReportsSummary({ electionId });
+  const reports =
+    pollsStatus.unsafeUnwrap().reportsByPollingPlace['pp-a'] ?? [];
+  expect(reports).toHaveLength(1);
+  expect(reports[0].pollsTransitionType).toEqual('resume_voting');
+});
+
+test('getLiveReportsActivityLog limits activity log to MAX_LIVE_REPORT_ACTIVITY_ITEMS', async () => {
+  const {
+    unauthenticatedApiClient,
+    apiClient,
+    workspace,
+    fileStorageClient,
+    auth0,
+  } = await setupApp({
+    organizations,
+    jurisdictions,
+    users,
+  });
+  auth0.setLoggedInUser(nonVxUser);
+  const sampleElectionDefinition = await setUpElectionInSystem(
+    apiClient,
+    workspace,
+    fileStorageClient
+  );
+  const { ballotHash } = sampleElectionDefinition;
+  const electionId = sampleElectionDefinition.election.id;
+
+  const totalReports = MAX_LIVE_REPORT_ACTIVITY_ITEMS + 5;
+  const baseTime = new Date('2024-01-01T00:00:00Z').getTime();
+  for (let i = 0; i < totalReports; i += 1) {
+    await sendTransitionReport(unauthenticatedApiClient, {
+      ballotHash,
+      machineId: `machine-${i.toString().padStart(3, '0')}`,
+      pollingPlaceId: `pp-${i.toString().padStart(3, '0')}`,
+      timestamp: new Date(baseTime + i * 60 * 1000),
+    });
+  }
+
+  const activityLogStatus = await apiClient.getLiveReportsActivityLog({
+    electionId,
+  });
+  const { activityLog } = activityLogStatus.unsafeUnwrap();
+  expect(activityLog).toHaveLength(MAX_LIVE_REPORT_ACTIVITY_ITEMS);
+  // Oldest entries are dropped - only the most recent 50 remain
+  const machineIds = activityLog.map((entry) => entry.machineId);
+  expect(machineIds[0]).toEqual(
+    `machine-${(totalReports - 1).toString().padStart(3, '0')}`
+  );
+  expect(machineIds).not.toContain('machine-000');
+});
+
+test('getLiveReportsActivityLog filters activity log by votingGroup', async () => {
+  const {
+    unauthenticatedApiClient,
+    apiClient,
+    workspace,
+    fileStorageClient,
+    auth0,
+  } = await setupApp({
+    organizations,
+    jurisdictions,
+    users,
+  });
+  auth0.setLoggedInUser(nonVxUser);
+  const sampleElectionDefinition = await setUpElectionInSystem(
+    apiClient,
+    workspace,
+    fileStorageClient
+  );
+  const { ballotHash } = sampleElectionDefinition;
+  const electionId = sampleElectionDefinition.election.id;
+  const firstPrecinctId = sampleElectionDefinition.election.precincts[0].id;
+
+  // Set up polling places of each voting type. The polling places need to
+  // live in the database so the JOIN on polling_places.type works.
+  const placesByType: Record<PollingPlaceType, PollingPlace> = {
+    election_day: {
+      id: 'pp-ed',
+      name: 'Election Day Place',
+      type: 'election_day',
+      precincts: { [firstPrecinctId]: { type: 'whole' } },
+    },
+    early_voting: {
+      id: 'pp-ev',
+      name: 'Early Voting Place',
+      type: 'early_voting',
+      precincts: { [firstPrecinctId]: { type: 'whole' } },
+    },
+    absentee: {
+      id: 'pp-abs',
+      name: 'Absentee Place',
+      type: 'absentee',
+      precincts: { [firstPrecinctId]: { type: 'whole' } },
+    },
+  };
+  for (const place of Object.values(placesByType)) {
+    (await apiClient.setPollingPlace({ electionId, place })).unsafeUnwrap();
+  }
+
+  // Submit one report for each polling place
+  await sendTransitionReport(unauthenticatedApiClient, {
+    ballotHash,
+    machineId: 'machine-ed',
+    pollingPlaceId: placesByType.election_day.id,
+    timestamp: new Date('2024-01-01T07:00:00Z'),
+  });
+  await sendTransitionReport(unauthenticatedApiClient, {
+    ballotHash,
+    machineId: 'machine-ev',
+    pollingPlaceId: placesByType.early_voting.id,
+    timestamp: new Date('2024-01-01T08:00:00Z'),
+  });
+  await sendTransitionReport(unauthenticatedApiClient, {
+    ballotHash,
+    machineId: 'machine-abs',
+    pollingPlaceId: placesByType.absentee.id,
+    timestamp: new Date('2024-01-01T09:00:00Z'),
+  });
+
+  // No votingGroup -> all entries
+  const allStatus = await apiClient.getLiveReportsActivityLog({ electionId });
+  expect(
+    allStatus.unsafeUnwrap().activityLog.map((entry) => entry.machineId)
+  ).toEqual(['machine-abs', 'machine-ev', 'machine-ed']);
+
+  // election_day -> only election day entries
+  const edStatus = await apiClient.getLiveReportsActivityLog({
+    electionId,
+    votingGroup: 'election_day',
+  });
+  expect(edStatus.unsafeUnwrap().activityLog).toEqual([
+    {
+      machineId: 'machine-ed',
+      pollingPlaceId: placesByType.election_day.id,
+      pollsTransitionType: 'open_polls',
+      signedTimestamp: new Date('2024-01-01T07:00:00Z'),
+    },
+  ]);
+
+  // early_voting -> only early voting entries
+  const evStatus = await apiClient.getLiveReportsActivityLog({
+    electionId,
+    votingGroup: 'early_voting',
+  });
+  expect(evStatus.unsafeUnwrap().activityLog).toEqual([
+    {
+      machineId: 'machine-ev',
+      pollingPlaceId: placesByType.early_voting.id,
+      pollsTransitionType: 'open_polls',
+      signedTimestamp: new Date('2024-01-01T08:00:00Z'),
+    },
+  ]);
+
+  // absentee -> only absentee entries
+  const absStatus = await apiClient.getLiveReportsActivityLog({
+    electionId,
+    votingGroup: 'absentee',
+  });
+  expect(absStatus.unsafeUnwrap().activityLog).toEqual([
+    {
+      machineId: 'machine-abs',
+      pollingPlaceId: placesByType.absentee.id,
+      pollsTransitionType: 'open_polls',
+      signedTimestamp: new Date('2024-01-01T09:00:00Z'),
+    },
+  ]);
+});
+
+test('getLiveReportsActivityLog filter still honors the MAX limit', async () => {
+  const {
+    unauthenticatedApiClient,
+    apiClient,
+    workspace,
+    fileStorageClient,
+    auth0,
+  } = await setupApp({
+    organizations,
+    jurisdictions,
+    users,
+  });
+  auth0.setLoggedInUser(nonVxUser);
+  const sampleElectionDefinition = await setUpElectionInSystem(
+    apiClient,
+    workspace,
+    fileStorageClient
+  );
+  const { ballotHash } = sampleElectionDefinition;
+  const electionId = sampleElectionDefinition.election.id;
+  const firstPrecinctId = sampleElectionDefinition.election.precincts[0].id;
+
+  const edPlace: PollingPlace = {
+    id: 'pp-ed',
+    name: 'Election Day Place',
+    type: 'election_day',
+    precincts: { [firstPrecinctId]: { type: 'whole' } },
+  };
+  (
+    await apiClient.setPollingPlace({ electionId, place: edPlace })
+  ).unsafeUnwrap();
+
+  const totalReports = MAX_LIVE_REPORT_ACTIVITY_ITEMS + 3;
+  const baseTime = new Date('2024-01-01T00:00:00Z').getTime();
+  for (let i = 0; i < totalReports; i += 1) {
+    await sendTransitionReport(unauthenticatedApiClient, {
+      ballotHash,
+      machineId: `machine-${i.toString().padStart(3, '0')}`,
+      pollingPlaceId: edPlace.id,
+      timestamp: new Date(baseTime + i * 60 * 1000),
+    });
+  }
+
+  const edStatus = await apiClient.getLiveReportsActivityLog({
+    electionId,
+    votingGroup: 'election_day',
+  });
+  expect(edStatus.unsafeUnwrap().activityLog).toHaveLength(
+    MAX_LIVE_REPORT_ACTIVITY_ITEMS
   );
 });

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -38,6 +38,7 @@ import {
   formatBallotHash,
   PollingPlaceSchema,
   PollingPlace,
+  PollingPlaceType,
   hasPartialRegisteredVoterCounts,
   ElectionTypeSchemaV4p1,
   electionTypeV4p0ToV4p1,
@@ -93,6 +94,7 @@ import {
   SetPollingPlaceError,
 } from './store';
 import {
+  AggregatedLiveReportActivityLog,
   AggregatedReportedPollsStatus,
   AggregatedReportedResults,
   ElectionInfo,
@@ -1008,6 +1010,30 @@ export function buildApi(ctx: AppContext) {
         election,
         isLive,
       });
+    },
+
+    async getLiveReportsActivityLog(input: {
+      electionId: ElectionId;
+      votingGroup?: PollingPlaceType;
+    }): Promise<
+      Result<AggregatedLiveReportActivityLog, GetExportedElectionError>
+    > {
+      const exportedElectionDefinitionResult =
+        await store.getExportedElectionDefinition(input.electionId);
+      if (exportedElectionDefinitionResult.isErr()) {
+        return err(exportedElectionDefinitionResult.err());
+      }
+      const { election, ballotHash } = exportedElectionDefinitionResult.ok();
+      const isLive = await store.electionHasLiveReportData(
+        election.id,
+        ballotHash
+      );
+      const activityLog = await store.getAllReportsForElection(
+        ballotHash,
+        isLive,
+        input.votingGroup
+      );
+      return ok({ activityLog });
     },
 
     async getLiveResultsReports(input: {

--- a/apps/design/backend/src/features.ts
+++ b/apps/design/backend/src/features.ts
@@ -160,6 +160,13 @@ export interface StateFeaturesConfig {
    * the same ballot rather than having a separate ballot for each party.
    */
   OPEN_PRIMARIES?: boolean;
+
+  /**
+   * Allow deleting live reports data. Only enabled for demo jurisdictions so
+   * that demo data can be cleared between runs; live/production data should
+   * never be deletable from the UI.
+   */
+  DELETE_LIVE_REPORTS?: boolean;
 }
 
 export type UserFeature = keyof UserFeaturesConfig;
@@ -197,6 +204,7 @@ export const stateFeatureConfigs: Record<StateCode, StateFeaturesConfig> = {
     BALLOT_LANGUAGE_CONFIG: true,
     EXPORT_TEST_BALLOTS: true,
     EDIT_POLLING_PLACES: true,
+    DELETE_LIVE_REPORTS: true,
   },
 
   MI: {

--- a/apps/design/backend/src/globals.ts
+++ b/apps/design/backend/src/globals.ts
@@ -200,3 +200,8 @@ export const WORKSPACE =
  * The max Postgres index key size is 8191 bytes, so this leaves a little buffer.
  */
 export const MAX_POSTGRES_INDEX_KEY_BYTES = 8000;
+
+/**
+ * Maximum number of activity log items returned in the live reports summary.
+ */
+export const MAX_LIVE_REPORT_ACTIVITY_ITEMS = 50;

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -89,6 +89,7 @@ import { Db } from './db/db';
 import { Bindable, Client } from './db/client';
 import { generateId } from './utils';
 import { getStateFeaturesConfig } from './features';
+import { MAX_LIVE_REPORT_ACTIVITY_ITEMS } from './globals';
 
 export interface ElectionRecord {
   jurisdictionId: string;
@@ -2991,6 +2992,66 @@ export class Store {
       )
     );
     return !!rows.rowCount;
+  }
+
+  /**
+   * Returns all polls transition reports for the election, ordered by
+   * timestamp descending. Used for the activity log. Optionally filtered
+   * to a specific polling place voting group.
+   */
+  async getAllReportsForElection(
+    ballotHash: string,
+    isLive: boolean,
+    votingGroup?: PollingPlaceType
+  ): Promise<QuickReportedPollStatus[]> {
+    const queryParams: Array<string | boolean | number> = [
+      ballotHash,
+      isLive,
+      MAX_LIVE_REPORT_ACTIVITY_ITEMS,
+    ];
+    let pollingPlaceJoin = '';
+    let pollingPlaceWhereClause = '';
+    if (votingGroup) {
+      queryParams.push(votingGroup);
+      pollingPlaceJoin =
+        'inner join polling_places on polling_places.id = results_reports.polling_place_id';
+      pollingPlaceWhereClause = 'and polling_places.type = $4';
+    }
+
+    const rows = (
+      await this.db.withClient((client) =>
+        client.query(
+          `
+            select
+              results_reports.polls_transition as "pollsTransitionType",
+              results_reports.machine_id as "machineId",
+              results_reports.signed_at as "signedAt",
+              results_reports.polling_place_id as "pollingPlaceId"
+            from results_reports
+            ${pollingPlaceJoin}
+            where
+              results_reports.ballot_hash = $1 and
+              results_reports.is_live_mode = $2
+              ${pollingPlaceWhereClause}
+            order by results_reports.signed_at desc
+            limit $3
+          `,
+          ...queryParams
+        )
+      )
+    ).rows as Array<{
+      pollsTransitionType: string;
+      machineId: string;
+      pollingPlaceId: string;
+      signedAt: Date;
+    }>;
+
+    return rows.map((row) => ({
+      machineId: row.machineId,
+      pollingPlaceId: row.pollingPlaceId,
+      signedTimestamp: row.signedAt,
+      pollsTransitionType: row.pollsTransitionType as PollsTransitionType,
+    }));
   }
 
   /**

--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -176,6 +176,10 @@ export interface AggregatedReportedPollsStatus {
   ballotHash: string;
 }
 
+export interface AggregatedLiveReportActivityLog {
+  activityLog: QuickReportedPollStatus[];
+}
+
 export interface QuickReportedPollStatus {
   machineId: string;
   pollingPlaceId: string;

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -18,6 +18,7 @@ import {
   BallotType,
   ElectionId,
   ElectionSerializationFormat,
+  PollingPlaceType,
   PrecinctSelection,
   TtsEditKey,
 } from '@votingworks/types';
@@ -140,9 +141,27 @@ export const getLiveReportsSummary = {
     const apiClient = useApiClient();
     return useQuery(
       this.queryKey(id),
+      () => apiClient.getLiveReportsSummary({ electionId: id }),
+      {
+        refetchInterval: VXQR_REFETCH_INTERVAL_MS,
+        staleTime: 0,
+      }
+    );
+  },
+} as const;
+
+export const getLiveReportsActivityLog = {
+  queryKey(id: ElectionId, votingGroup?: PollingPlaceType): QueryKey {
+    return ['getLiveReportsActivityLog', id, votingGroup ?? ''];
+  },
+  useQuery(id: ElectionId, votingGroup?: PollingPlaceType) {
+    const apiClient = useApiClient();
+    return useQuery(
+      this.queryKey(id, votingGroup),
       () =>
-        apiClient.getLiveReportsSummary({
+        apiClient.getLiveReportsActivityLog({
           electionId: id,
+          ...(votingGroup ? { votingGroup } : {}),
         }),
       { refetchInterval: VXQR_REFETCH_INTERVAL_MS, staleTime: 0, cacheTime: 0 }
     );

--- a/apps/design/frontend/src/live_reports_screen.test.tsx
+++ b/apps/design/frontend/src/live_reports_screen.test.tsx
@@ -7,6 +7,7 @@ import {
   SystemSettings,
   ElectionId,
   Election,
+  PollingPlace,
 } from '@votingworks/types';
 import {
   ALL_PRECINCTS_SELECTION,
@@ -57,20 +58,24 @@ afterEach(() => {
 });
 
 function renderScreen(
-  electionIdParam: ElectionId = electionId
+  electionIdParam?: ElectionId,
+  initialPath?: string
 ): ReturnType<typeof createMemoryHistory> {
+  const resolvedElectionId = electionIdParam ?? electionId;
   apiMock.getElectionInfo
-    .expectCallWith({ electionId: electionIdParam })
+    .expectCallWith({ electionId: resolvedElectionId })
     .resolves(electionInfoFromRecord(electionRecord));
-  const { path } = routes.election(electionIdParam).reports.root;
+  const { path } = routes.election(resolvedElectionId).reports.root;
   const paramPath = routes.election(':electionId').reports.root.path;
-  const history = createMemoryHistory({ initialEntries: [path] });
+  const startingPath = initialPath ?? path;
+  const history = createMemoryHistory({ initialEntries: [startingPath] });
   render(
     provideApi(
       apiMock,
       withRoute(<LiveReportsScreen />, {
         paramPath,
-        path,
+        path: startingPath,
+        history,
       })
     )
   );
@@ -115,17 +120,95 @@ function createMockAggregatedResults(
   };
 }
 
+// Generate an election with polling places from precincts (one per precinct)
+function electionWithPollingPlaces(electionItem: Election): Election {
+  return {
+    ...electionItem,
+    pollingPlaces: electionItem.precincts.map((precinct) => ({
+      id: precinct.id,
+      name: precinct.name,
+      type: 'election_day' as const,
+      precincts: { [precinct.id]: { type: 'whole' as const } },
+    })),
+  };
+}
+
+/**
+ * Generate an election with all three voting group types:
+ * - Election day: one polling place per precinct (1:1)
+ * - Early voting: one polling place covering ALL precincts
+ * - Absentee: one polling place covering ALL precincts
+ */
+function electionWithAllVotingGroups(electionItem: Election): Election {
+  const electionDayPlaces = electionItem.precincts.map((precinct) => ({
+    id: `ed-${precinct.id}`,
+    name: `${precinct.name} Polling Place`,
+    type: 'election_day' as const,
+    precincts: {
+      [precinct.id]: { type: 'whole' as const },
+    },
+  }));
+
+  const allPrecincts = Object.fromEntries(
+    electionItem.precincts.map((p) => [p.id, { type: 'whole' as const }])
+  );
+
+  const earlyVotingPlace: PollingPlace = {
+    id: 'ev-city-hall',
+    name: 'City Hall Early Voting',
+    type: 'early_voting',
+    precincts: allPrecincts,
+  };
+
+  const absenteeSite: PollingPlace = {
+    id: 'abs-county-clerk',
+    name: 'County Clerk Absentee',
+    type: 'absentee',
+    precincts: allPrecincts,
+  };
+
+  return {
+    ...electionItem,
+    pollingPlaces: [...electionDayPlaces, earlyVotingPlace, absenteeSite],
+  };
+}
+
 // Helper function to create mock polls status data
 function createMockPollsStatus(electionItem: Election, isLive = false) {
+  const electionWithPlaces = electionWithPollingPlaces(electionItem);
   const reportsByPollingPlace: Record<string, QuickReportedPollStatus[]> = {};
 
-  // Add empty arrays for each precinct
-  for (const precinct of electionItem.precincts) {
-    reportsByPollingPlace[precinct.id] = [];
+  for (const place of electionWithPlaces.pollingPlaces ?? []) {
+    reportsByPollingPlace[place.id] = [];
   }
 
   return {
-    election: electionItem,
+    election: electionWithPlaces,
+    ballotHash: 'abc123def456',
+    isLive,
+    reportsByPollingPlace,
+  };
+}
+
+function createMockActivityLog(entries: QuickReportedPollStatus[] = []): {
+  activityLog: QuickReportedPollStatus[];
+} {
+  return { activityLog: entries };
+}
+
+function createMockPollsStatusAllGroups(
+  electionItem: Election,
+  isLive = false
+) {
+  const electionWithPlaces = electionWithAllVotingGroups(electionItem);
+  const reportsByPollingPlace: Record<string, QuickReportedPollStatus[]> = {};
+
+  for (const place of electionWithPlaces.pollingPlaces ?? []) {
+    reportsByPollingPlace[place.id] = [];
+  }
+
+  return {
+    election: electionWithPlaces,
     ballotHash: 'abc123def456',
     isLive,
     reportsByPollingPlace,
@@ -133,6 +216,18 @@ function createMockPollsStatus(electionItem: Election, isLive = false) {
 }
 
 const mockPollsStatus = createMockPollsStatus(election);
+const emptyActivityLog = createMockActivityLog();
+
+/**
+ * Set up the default mock for `getLiveReportsActivityLog` to return an empty
+ * activity log for all `votingGroup` calls. Tests that need specific entries
+ * can override with a fresh `expectRepeatedCallsWith` after this.
+ */
+function mockEmptyActivityLogForAllTabs(electionIdOverride: ElectionId) {
+  apiMock.getLiveReportsActivityLog
+    .expectRepeatedCallsWith({ electionId: electionIdOverride })
+    .resolves(ok(emptyActivityLog));
+}
 
 describe('Navigation tab visibility', () => {
   test('Results tab appears in navigation when quickResultsReportingUrl is configured', async () => {
@@ -142,6 +237,7 @@ describe('Navigation tab visibility', () => {
     apiMock.getLiveReportsSummary
       .expectRepeatedCallsWith({ electionId })
       .resolves(ok(mockPollsStatus));
+    mockEmptyActivityLogForAllTabs(electionId);
 
     renderScreen();
 
@@ -166,9 +262,7 @@ describe('Navigation tab visibility', () => {
     );
 
     // There should not be a link to this page in the navigation.
-    expect(
-      screen.queryByRole('button', { name: 'Live Reports' })
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Live Reports' })).toBeNull();
   });
 });
 
@@ -217,7 +311,7 @@ describe('Polls status summary display', () => {
       isLive: boolean;
       reportsByPollingPlace: Record<string, QuickReportedPollStatus[]>;
     } = {
-      election,
+      election: electionWithPollingPlaces(election),
       ballotHash: 'abc123def456',
       isLive: false,
       reportsByPollingPlace: {
@@ -247,34 +341,24 @@ describe('Polls status summary display', () => {
     apiMock.getLiveReportsSummary
       .expectRepeatedCallsWith({ electionId })
       .resolves(ok(mockPollsStatusWithIndividualReports));
+    mockEmptyActivityLogForAllTabs(electionId);
 
     renderScreen();
 
     await screen.findByRole('heading', { name: 'Live Reports' });
 
-    // Check that "View Full Election Tally Report" button is enabled
-    const viewFullReportButton = screen.getByRole('button', {
-      name: 'View Full Election Tally Report',
-    });
-    expect(viewFullReportButton).toBeEnabled();
+    // Check that "View Tally Reports" button is present
+    screen.getByRole('button', { name: 'View Tally Reports' });
 
     expect(screen.getByTestId('no-reports-sent-count')).toHaveTextContent('1');
     expect(screen.getByTestId('polls-open-count')).toHaveTextContent('1');
-    expect(screen.getByTestId('polls-closing-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('polls-paused-count')).toHaveTextContent('0');
     expect(screen.getByTestId('polls-closed-count')).toHaveTextContent('1');
 
-    // Check individual precinct rows in the table
-    screen.getByText(election.precincts[0].name);
-    screen.getByText(election.precincts[1].name);
-    expect(
-      screen.queryByText(/Precinct Not Specified/)
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Precinct Not Specified/)).toBeNull();
 
     // Expect test mode callout
     screen.getByText('Test Ballot Mode');
-
-    // Expect one precinct to have a "View Tally Report" button
-    expect(screen.queryAllByText('View Tally Report')).toHaveLength(1);
   });
 
   test('shows poll status summary correctly when there is "all precinct" data - live mode', async () => {
@@ -289,7 +373,7 @@ describe('Polls status summary display', () => {
       isLive: boolean;
       reportsByPollingPlace: Record<string, QuickReportedPollStatus[]>;
     } = {
-      election,
+      election: electionWithPollingPlaces(election),
       ballotHash: 'abc123def456',
       isLive: true,
       reportsByPollingPlace: {
@@ -329,46 +413,470 @@ describe('Polls status summary display', () => {
     apiMock.getLiveReportsSummary
       .expectRepeatedCallsWith({ electionId })
       .resolves(ok(mockPollsStatusWithAggregatedData));
+    mockEmptyActivityLogForAllTabs(electionId);
 
     renderScreen();
 
     await screen.findByRole('heading', { name: 'Live Reports' });
 
     // Should not show Test Mode callout since isLive is true
-    expect(screen.queryByText(/Test Mode/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Test Mode/)).toBeNull();
 
-    // Check that "View Full Election Tally Report" button is enabled
-    const viewFullReportButton = screen.getByRole('button', {
-      name: 'View Full Election Tally Report',
-    });
-    expect(viewFullReportButton).toBeEnabled();
+    // Check that "View Tally Reports" button is present
+    screen.getByRole('button', { name: 'View Tally Reports' });
 
     expect(screen.getByTestId('no-reports-sent-count')).toHaveTextContent('1');
     expect(screen.getByTestId('polls-open-count')).toHaveTextContent('1');
-    expect(screen.getByTestId('polls-closing-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('polls-paused-count')).toHaveTextContent('0');
     expect(screen.getByTestId('polls-closed-count')).toHaveTextContent('1');
 
-    // Check individual precinct rows in the table
-    screen.getByText(election.precincts[0].name);
-    screen.getByText(election.precincts[1].name);
-    expect(
-      screen.queryByText('Precinct Not Specified')
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Precinct Not Specified')).toBeNull();
 
     // Expect no test mode callout
-    expect(screen.queryByText(/Test Ballot Mode/)).not.toBeInTheDocument();
-    // One precinct has close_polls, so there should be one "View Tally Report" available.
-    expect(screen.queryAllByText('View Tally Report')).toHaveLength(1);
+    expect(screen.queryByText(/Test Ballot Mode/)).toBeNull();
+  });
+});
 
-    // Check last report sent column
-    await screen.findByText('VxScan-002: Polls Open');
+describe('Voting group cards', () => {
+  test('shows tabs and overview cards for each voting group', async () => {
+    apiMock.getSystemSettings
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(mockSystemSettingsWithUrl);
+
+    const pollsStatus = createMockPollsStatusAllGroups(election, true);
+    // Need at least one report so the UI renders
+    pollsStatus.reportsByPollingPlace[`ed-${election.precincts[0].id}`] = [
+      {
+        machineId: 'VxScan-001',
+        pollsTransitionType: 'open_polls',
+        pollingPlaceId: `ed-${election.precincts[0].id}`,
+        signedTimestamp: new Date('2024-01-01T07:00:00Z'),
+      },
+    ];
+
+    apiMock.getLiveReportsSummary
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(pollsStatus));
+    mockEmptyActivityLogForAllTabs(electionId);
+
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Live Reports' });
+
+    // All four tabs should be visible
+    screen.getByRole('tab', { name: 'All Voting Groups' });
+    screen.getByRole('tab', { name: 'Early Voting' });
+    screen.getByRole('tab', { name: 'Election Day' });
+    screen.getByRole('tab', { name: 'Absentee Voting' });
+
+    // Overview cards still exist (one per voting group with polling places)
+    screen.getByTestId('overview-card-early_voting');
+    screen.getByTestId('overview-card-election_day');
+    screen.getByTestId('overview-card-absentee');
+  });
+
+  test('shows only cards for groups with polling places', async () => {
+    apiMock.getSystemSettings
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(mockSystemSettingsWithUrl);
+
+    // election-day-only polling places (from electionWithPollingPlaces)
+    const pollsStatus = createMockPollsStatus(election, true);
+    pollsStatus.reportsByPollingPlace[election.precincts[0].id] = [
+      {
+        machineId: 'VxScan-001',
+        pollsTransitionType: 'open_polls',
+        pollingPlaceId: election.precincts[0].id,
+        signedTimestamp: new Date('2024-01-01T17:00:00Z'),
+      },
+    ];
+
+    apiMock.getLiveReportsSummary
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(pollsStatus));
+    mockEmptyActivityLogForAllTabs(electionId);
+
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Live Reports' });
+
+    // Only the election_day card should be present
+    await screen.findByTestId('overview-card-election_day');
+    expect(screen.queryByTestId('overview-card-early_voting')).toBeNull();
+    expect(screen.queryByTestId('overview-card-absentee')).toBeNull();
+
+    // Tab bar should not render at all (only one voting group has polling places)
+    expect(screen.queryByRole('tab', { name: 'All Voting Groups' })).toBeNull();
+    expect(screen.queryByRole('tab', { name: 'Election Day' })).toBeNull();
+    expect(screen.queryByRole('tab', { name: 'Early Voting' })).toBeNull();
+    expect(screen.queryByRole('tab', { name: 'Absentee Voting' })).toBeNull();
+  });
+
+  test('Election Day tab navigates to election day group page', async () => {
+    apiMock.getSystemSettings
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(mockSystemSettingsWithUrl);
+
+    const pollsStatus = createMockPollsStatusAllGroups(election, true);
+    // Mark some election day places as open
+    pollsStatus.reportsByPollingPlace[`ed-${election.precincts[0].id}`] = [
+      {
+        machineId: 'VxScan-001',
+        pollsTransitionType: 'open_polls',
+        pollingPlaceId: `ed-${election.precincts[0].id}`,
+        signedTimestamp: new Date('2024-01-01T07:00:00Z'),
+      },
+    ];
+
+    apiMock.getLiveReportsSummary
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(pollsStatus));
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(emptyActivityLog));
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId, votingGroup: 'election_day' })
+      .resolves(ok(emptyActivityLog));
+
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Live Reports' });
+
+    // Click Election Day tab
+    userEvent.click(screen.getByRole('tab', { name: 'Election Day' }));
+
+    // Should see election day polling places (wait for query to update)
+    await screen.findByText(`${election.precincts[0].name} Polling Place`);
+    screen.getByText(`${election.precincts[1].name} Polling Place`);
+
+    // Should NOT see early voting or absentee places in the table
+    expect(screen.queryByTestId('polling-place-row-ev-city-hall')).toBeNull();
     expect(
-      screen.queryByText('VxScan-001: Polls Open')
-    ).not.toBeInTheDocument();
-    await screen.findByText('VxScan-005: Polls Closed');
+      screen.queryByTestId('polling-place-row-abs-county-clerk')
+    ).toBeNull();
+
+    // Summary should count only election day places
+    expect(screen.getByTestId('no-reports-sent-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('polls-open-count')).toHaveTextContent('1');
+
+    // Polls open and polls paused should be visible (non-absentee group)
+    screen.getByTestId('polls-open-count');
+    screen.getByTestId('polls-paused-count');
+  });
+
+  test('Early Voting tab navigates to early voting group page', async () => {
+    apiMock.getSystemSettings
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(mockSystemSettingsWithUrl);
+
+    const pollsStatus = createMockPollsStatusAllGroups(election, true);
+    // Mark early voting place as paused
+    pollsStatus.reportsByPollingPlace['ev-city-hall'] = [
+      {
+        machineId: 'VxScan-010',
+        pollsTransitionType: 'pause_voting',
+        pollingPlaceId: 'ev-city-hall',
+        signedTimestamp: new Date('2024-01-01T16:00:00Z'),
+      },
+    ];
+
+    apiMock.getLiveReportsSummary
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(pollsStatus));
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(emptyActivityLog));
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId, votingGroup: 'early_voting' })
+      .resolves(ok(emptyActivityLog));
+
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Live Reports' });
+
+    // Click Early Voting tab
+    userEvent.click(screen.getByRole('tab', { name: 'Early Voting' }));
+
+    // Should see only the early voting polling place (wait for query to update)
+    await screen.findByText('City Hall Early Voting');
+
+    // Should NOT see election day or absentee places in the table
     expect(
-      screen.queryByText('VxScan-003: Polls Closed')
-    ).not.toBeInTheDocument();
+      screen.queryByTestId(`polling-place-row-ed-${election.precincts[0].id}`)
+    ).toBeNull();
+    expect(
+      screen.queryByTestId('polling-place-row-abs-county-clerk')
+    ).toBeNull();
+
+    // Summary counts for early voting only
+    expect(screen.getByTestId('no-reports-sent-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('polls-paused-count')).toHaveTextContent('1');
+  });
+
+  test('Absentee group page hides polls open and polls paused stats', async () => {
+    apiMock.getSystemSettings
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(mockSystemSettingsWithUrl);
+
+    const pollsStatus = createMockPollsStatusAllGroups(election, true);
+    // Absentee place has voting complete
+    pollsStatus.reportsByPollingPlace['abs-county-clerk'] = [
+      {
+        machineId: 'VxAdmin-001',
+        pollsTransitionType: 'close_polls',
+        pollingPlaceId: 'abs-county-clerk',
+        signedTimestamp: new Date('2024-01-01T20:00:00Z'),
+      },
+    ];
+
+    apiMock.getLiveReportsSummary
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(pollsStatus));
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(emptyActivityLog));
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId, votingGroup: 'absentee' })
+      .resolves(ok(emptyActivityLog));
+
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Live Reports' });
+
+    // Click Absentee tab
+    userEvent.click(screen.getByRole('tab', { name: 'Absentee Voting' }));
+
+    // Should see only the absentee polling place (wait for query to update)
+    await screen.findByText('County Clerk Absentee');
+
+    // Should NOT see election day or early voting places in the table
+    expect(
+      screen.queryByTestId(`polling-place-row-ed-${election.precincts[0].id}`)
+    ).toBeNull();
+    expect(screen.queryByTestId('polling-place-row-ev-city-hall')).toBeNull();
+
+    // Polls open and polls paused should NOT be visible
+    expect(screen.queryByTestId('polls-open-count')).toBeNull();
+    expect(screen.queryByTestId('polls-paused-count')).toBeNull();
+
+    // No reports sent and voting complete should still be visible
+    expect(screen.getByTestId('no-reports-sent-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('polls-closed-count')).toHaveTextContent('1');
+  });
+
+  test('Overview shows summary cards for all voting group types', async () => {
+    apiMock.getSystemSettings
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(mockSystemSettingsWithUrl);
+
+    const pollsStatus = createMockPollsStatusAllGroups(election, true);
+    // Set different statuses across types
+    pollsStatus.reportsByPollingPlace[`ed-${election.precincts[0].id}`] = [
+      {
+        machineId: 'VxScan-001',
+        pollsTransitionType: 'close_polls',
+        pollingPlaceId: `ed-${election.precincts[0].id}`,
+        signedTimestamp: new Date('2024-01-01T18:00:00Z'),
+      },
+    ];
+    pollsStatus.reportsByPollingPlace['ev-city-hall'] = [
+      {
+        machineId: 'VxScan-010',
+        pollsTransitionType: 'open_polls',
+        pollingPlaceId: 'ev-city-hall',
+        signedTimestamp: new Date('2024-01-01T07:00:00Z'),
+      },
+    ];
+    pollsStatus.reportsByPollingPlace['abs-county-clerk'] = [
+      {
+        machineId: 'VxAdmin-001',
+        pollsTransitionType: 'close_polls',
+        pollingPlaceId: 'abs-county-clerk',
+        signedTimestamp: new Date('2024-01-01T20:00:00Z'),
+      },
+    ];
+
+    apiMock.getLiveReportsSummary
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(pollsStatus));
+    mockEmptyActivityLogForAllTabs(electionId);
+
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Live Reports' });
+
+    // All three cards should be visible
+    screen.getByTestId('overview-card-early_voting');
+    screen.getByTestId('overview-card-election_day');
+    screen.getByTestId('overview-card-absentee');
+
+    // Overview renders summary stats per card. Cards are rendered in
+    // VOTING_GROUPS order: early_voting (0), election_day (1), absentee (2).
+    const noReportsCounts = screen.getAllByTestId('no-reports-sent-count');
+    expect(noReportsCounts).toHaveLength(3);
+    // early_voting: 0 no reports (1 place, 1 open)
+    expect(noReportsCounts[0]).toHaveTextContent('0');
+    // election_day: 2 no reports (3 places, 1 closed)
+    expect(noReportsCounts[1]).toHaveTextContent('2');
+    // absentee: 0 no reports (1 place, 1 closed)
+    expect(noReportsCounts[2]).toHaveTextContent('0');
+
+    const pollsClosedCounts = screen.getAllByTestId('polls-closed-count');
+    expect(pollsClosedCounts).toHaveLength(3);
+    expect(pollsClosedCounts[0]).toHaveTextContent('0'); // early_voting
+    expect(pollsClosedCounts[1]).toHaveTextContent('1'); // election_day
+    expect(pollsClosedCounts[2]).toHaveTextContent('1'); // absentee
+
+    // polls-open-count is hidden for absentee, so only 2 instances
+    const pollsOpenCounts = screen.getAllByTestId('polls-open-count');
+    expect(pollsOpenCounts).toHaveLength(2);
+    expect(pollsOpenCounts[0]).toHaveTextContent('1'); // early_voting
+    expect(pollsOpenCounts[1]).toHaveTextContent('0'); // election_day
+
+    // polls-paused-count is also hidden for absentee
+    expect(screen.getAllByTestId('polls-paused-count')).toHaveLength(2);
+  });
+
+  test('navigating between groups updates summary counts correctly', async () => {
+    apiMock.getSystemSettings
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(mockSystemSettingsWithUrl);
+
+    const pollsStatus = createMockPollsStatusAllGroups(election, true);
+    // All election day places closed
+    for (const precinct of election.precincts) {
+      pollsStatus.reportsByPollingPlace[`ed-${precinct.id}`] = [
+        {
+          machineId: `VxScan-${precinct.id}`,
+          pollsTransitionType: 'close_polls',
+          pollingPlaceId: `ed-${precinct.id}`,
+          signedTimestamp: new Date('2024-01-01T18:00:00Z'),
+        },
+      ];
+    }
+    // Early voting open
+    pollsStatus.reportsByPollingPlace['ev-city-hall'] = [
+      {
+        machineId: 'VxScan-010',
+        pollsTransitionType: 'open_polls',
+        pollingPlaceId: 'ev-city-hall',
+        signedTimestamp: new Date('2024-01-01T07:00:00Z'),
+      },
+    ];
+
+    apiMock.getLiveReportsSummary
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(pollsStatus));
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(emptyActivityLog));
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId, votingGroup: 'election_day' })
+      .resolves(ok(emptyActivityLog));
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(emptyActivityLog));
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId, votingGroup: 'absentee' })
+      .resolves(ok(emptyActivityLog));
+
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Live Reports' });
+
+    // Navigate to Election Day group
+    userEvent.click(screen.getByRole('tab', { name: 'Election Day' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('polls-open-count')).toHaveTextContent('0');
+    });
+    expect(screen.getByTestId('polls-closed-count')).toHaveTextContent('3');
+    expect(screen.getByTestId('no-reports-sent-count')).toHaveTextContent('0');
+
+    // Click "All Voting Groups" tab to go back to overview
+    userEvent.click(screen.getByRole('tab', { name: 'All Voting Groups' }));
+    await waitFor(() => {
+      expect(screen.queryByTestId('overview-card-absentee')).not.toBeNull();
+    });
+
+    // Navigate to Absentee
+    userEvent.click(screen.getByRole('tab', { name: 'Absentee Voting' }));
+    await waitFor(() => {
+      expect(screen.queryByTestId('polls-open-count')).toBeNull();
+    });
+    expect(screen.getByTestId('polls-closed-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('no-reports-sent-count')).toHaveTextContent('1');
+  });
+
+  test('activity log on group page is filtered to that group', async () => {
+    apiMock.getSystemSettings
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(mockSystemSettingsWithUrl);
+
+    const edActivityEntry: QuickReportedPollStatus = {
+      machineId: 'VxScan-001',
+      pollsTransitionType: 'close_polls',
+      pollingPlaceId: `ed-${election.precincts[0].id}`,
+      signedTimestamp: new Date('2024-01-01T18:00:00Z'),
+    };
+    const absActivityEntry: QuickReportedPollStatus = {
+      machineId: 'VxAdmin-001',
+      pollsTransitionType: 'close_polls',
+      pollingPlaceId: 'abs-county-clerk',
+      signedTimestamp: new Date('2024-01-01T20:00:00Z'),
+    };
+
+    const pollsStatusAll = createMockPollsStatusAllGroups(election, true);
+    pollsStatusAll.reportsByPollingPlace[`ed-${election.precincts[0].id}`] = [
+      edActivityEntry,
+    ];
+    pollsStatusAll.reportsByPollingPlace['abs-county-clerk'] = [
+      absActivityEntry,
+    ];
+
+    apiMock.getLiveReportsSummary
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(pollsStatusAll));
+    // Overview shows all entries; per-group pages get filtered entries.
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(createMockActivityLog([absActivityEntry, edActivityEntry])));
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId, votingGroup: 'election_day' })
+      .resolves(ok(createMockActivityLog([edActivityEntry])));
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(createMockActivityLog([absActivityEntry, edActivityEntry])));
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId, votingGroup: 'absentee' })
+      .resolves(ok(createMockActivityLog([absActivityEntry])));
+
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Live Reports' });
+
+    // Overview shows entries from all groups
+    await screen.findByText(/VxAdmin-001: Polls Closed/);
+    screen.getByText(/VxScan-001: Polls Closed/);
+
+    // Navigate to Election Day group — only election day entries
+    userEvent.click(screen.getByRole('tab', { name: 'Election Day' }));
+    await waitFor(() => {
+      expect(screen.queryByText(/VxAdmin-001: Polls Closed/)).toBeNull();
+    });
+    screen.getByText(/VxScan-001: Polls Closed/);
+
+    // Click "All Voting Groups" tab to go back to overview
+    userEvent.click(screen.getByRole('tab', { name: 'All Voting Groups' }));
+    await waitFor(() => {
+      expect(screen.queryByTestId('overview-card-absentee')).not.toBeNull();
+    });
+
+    // Navigate to Absentee — only absentee entries
+    userEvent.click(screen.getByRole('tab', { name: 'Absentee Voting' }));
+    await waitFor(() => {
+      expect(screen.queryByText(/VxScan-001: Polls Closed/)).toBeNull();
+    });
+    screen.getByText(/VxAdmin-001: Polls Closed/);
   });
 });
 
@@ -400,13 +908,14 @@ describe('Animation behavior', () => {
       },
     ];
     // Start with some initial data - one precinct has a report
+    const electionWithPlaces = electionWithPollingPlaces(election);
     const initialPollsStatus: {
-      election: typeof election;
+      election: Election;
       ballotHash: string;
       isLive: boolean;
       reportsByPollingPlace: Record<string, QuickReportedPollStatus[]>;
     } = {
-      election,
+      election: electionWithPlaces,
       ballotHash: 'abc123def456',
       isLive: false,
       reportsByPollingPlace: initialData,
@@ -415,17 +924,25 @@ describe('Animation behavior', () => {
     apiMock.getLiveReportsSummary
       .expectRepeatedCallsWith({ electionId })
       .resolves(ok(initialPollsStatus));
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId, votingGroup: 'election_day' })
+      .resolves(ok(emptyActivityLog));
 
-    renderScreen();
+    // Render directly at the Election Day group page (where rows are rendered)
+    renderScreen(
+      electionId,
+      routes.election(electionId).reports.votingGroup('election_day').path
+    );
 
     await screen.findByRole('heading', { name: 'Live Reports' });
+    await screen.findByText(election.precincts[0].name);
 
     // Should show initial counts - 2 precincts with no reports, 1 with polls open
     expect(screen.getByTestId('no-reports-sent-count')).toHaveTextContent('2');
     expect(screen.getByTestId('polls-open-count')).toHaveTextContent('1');
 
     for (const precinct of election.precincts) {
-      const row = screen.getByTestId(`precinct-row-${precinct.id}`);
+      const row = screen.getByTestId(`polling-place-row-${precinct.id}`);
       expect(row).toHaveAttribute('data-highlighted', 'false');
     }
 
@@ -458,7 +975,7 @@ describe('Animation behavior', () => {
     // Check that Precinct 2 is updated and highlighted
     await waitFor(() => {
       const precinct2Row = screen.getByTestId(
-        `precinct-row-${election.precincts[1].id}`
+        `polling-place-row-${election.precincts[1].id}`
       );
       expect(precinct2Row).toHaveAttribute('data-highlighted', 'true');
     });
@@ -481,12 +998,12 @@ describe('Animation behavior', () => {
 
     // Start in test mode with some data
     const testModeData: {
-      election: typeof election;
+      election: Election;
       ballotHash: string;
       isLive: boolean;
       reportsByPollingPlace: Record<string, QuickReportedPollStatus[]>;
     } = {
-      election,
+      election: electionWithPollingPlaces(election),
       ballotHash: 'abc123def456',
       isLive: false,
       reportsByPollingPlace: initialData,
@@ -495,13 +1012,21 @@ describe('Animation behavior', () => {
     apiMock.getLiveReportsSummary
       .expectRepeatedCallsWith({ electionId })
       .resolves(ok(testModeData));
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId, votingGroup: 'election_day' })
+      .resolves(ok(emptyActivityLog));
 
-    renderScreen();
+    // Render directly at the Election Day group page (where rows are rendered)
+    renderScreen(
+      electionId,
+      routes.election(electionId).reports.votingGroup('election_day').path
+    );
 
     await screen.findByRole('heading', { name: 'Live Reports' });
 
     // Should show test mode callout
     await screen.findByText('Test Ballot Mode');
+    await screen.findByText(election.precincts[0].name);
 
     initialData[election.precincts[0].id] = [
       {
@@ -514,7 +1039,7 @@ describe('Animation behavior', () => {
 
     // Switch to live mode with same data
     const liveModeData: {
-      election: typeof election;
+      election: Election;
       ballotHash: string;
       isLive: boolean;
       reportsByPollingPlace: Record<string, QuickReportedPollStatus[]>;
@@ -531,7 +1056,7 @@ describe('Animation behavior', () => {
     // Wait for update
     vi.advanceTimersByTime(VXQR_REFETCH_INTERVAL_MS);
     await waitFor(() => {
-      expect(screen.queryByText('Test Ballot Mode')).not.toBeInTheDocument();
+      expect(screen.queryByText('Test Ballot Mode')).toBeNull();
     });
 
     expect(screen.getByTestId('polls-open-count')).toHaveTextContent('1');
@@ -539,10 +1064,10 @@ describe('Animation behavior', () => {
     // Check animation state with waitFor to handle async updates
     await waitFor(() => {
       const precinct0Row = screen.getByTestId(
-        `precinct-row-${election.precincts[0].id}`
+        `polling-place-row-${election.precincts[0].id}`
       );
       const precinct1Row = screen.getByTestId(
-        `precinct-row-${election.precincts[1].id}`
+        `polling-place-row-${election.precincts[1].id}`
       );
 
       // Test that the animation behavior is working by verifying the data changes are reflected
@@ -570,22 +1095,29 @@ describe('Animation behavior', () => {
       .expectRepeatedCallsWith({ electionId })
       .resolves(
         ok({
-          election,
+          election: electionWithPollingPlaces(election),
           isLive: false,
           ballotHash: 'abc123def456',
           reportsByPollingPlace: initialData,
         })
       );
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId, votingGroup: 'election_day' })
+      .resolves(ok(emptyActivityLog));
 
-    renderScreen();
+    // Render directly at the Election Day group page (where rows are rendered)
+    renderScreen(
+      electionId,
+      routes.election(electionId).reports.votingGroup('election_day').path
+    );
 
     await screen.findByRole('heading', { name: 'Live Reports' });
+    await screen.findByText(election.precincts[0].name);
 
     // Should show polls open
     expect(screen.getByTestId('polls-open-count')).toHaveTextContent('1');
-    await screen.findByText('VxScan-001: Polls Open');
     const precinctRow = screen.getByTestId(
-      `precinct-row-${election.precincts[0].id}`
+      `polling-place-row-${election.precincts[0].id}`
     );
     expect(precinctRow).toHaveAttribute('data-highlighted', 'false');
 
@@ -603,7 +1135,7 @@ describe('Animation behavior', () => {
       .expectRepeatedCallsWith({ electionId })
       .resolves(
         ok({
-          election,
+          election: electionWithPollingPlaces(election),
           ballotHash: 'abc123def456',
           isLive: true,
           reportsByPollingPlace: initialData,
@@ -619,13 +1151,12 @@ describe('Animation behavior', () => {
     // Check highlighted state with waitFor to handle async updates
     await waitFor(() => {
       const precinctRowUpdated = screen.getByTestId(
-        `precinct-row-${election.precincts[0].id}`
+        `polling-place-row-${election.precincts[0].id}`
       );
       expect(precinctRowUpdated).toHaveAttribute('data-highlighted', 'true');
     });
 
     expect(screen.getByTestId('polls-open-count')).toHaveTextContent('0');
-    await screen.findByText('VxScan-001: Polls Closed');
   });
 });
 
@@ -637,12 +1168,12 @@ describe('Results navigation and display', () => {
 
     // Set up polls status data with closed polls for first precinct
     const mockPollsStatusWithClosedPolls: {
-      election: typeof election;
+      election: Election;
       ballotHash: string;
       isLive: boolean;
       reportsByPollingPlace: Record<string, QuickReportedPollStatus[]>;
     } = {
-      election,
+      election: electionWithPollingPlaces(election),
       ballotHash: 'abc123def456',
       isLive: false,
       reportsByPollingPlace: {
@@ -662,18 +1193,34 @@ describe('Results navigation and display', () => {
     apiMock.getLiveReportsSummary
       .expectRepeatedCallsWith({ electionId })
       .resolves(ok(mockPollsStatusWithClosedPolls));
+    mockEmptyActivityLogForAllTabs(electionId);
 
     renderScreen();
 
     await screen.findByRole('heading', { name: 'Live Reports' });
 
-    // Check that the "View Tally Report" button is present and enabled for closed polls
-    const viewTallyReportButton = screen.getByRole('button', {
-      name: 'View Tally Report',
-    });
-    expect(viewTallyReportButton).toBeEnabled();
+    // Mock the API call for all precincts results (initial navigation)
+    const mockAllPrecinctsResults = createMockAggregatedResults(
+      election,
+      false
+    );
+    apiMock.getLiveResultsReports
+      .expectCallWith({
+        electionId,
+        precinctSelection: ALL_PRECINCTS_SELECTION,
+      })
+      .resolves(ok(mockAllPrecinctsResults));
 
-    // Mock the API call that will be made when navigating to results view
+    // Click the "View Tally Reports" button
+    const viewTallyReportsLink = screen.getByRole('button', {
+      name: 'View Tally Reports',
+    });
+    userEvent.click(viewTallyReportsLink);
+
+    // Wait for the results page to load
+    await screen.findAllByText(/Unofficial.*Tally Report/);
+
+    // Now select a single precinct from the dropdown
     const mockSinglePrecinctResults = createMockAggregatedResults(
       election,
       false
@@ -685,15 +1232,20 @@ describe('Results navigation and display', () => {
       })
       .resolves(ok(mockSinglePrecinctResults));
 
-    // Click the view tally report button - this should trigger navigation and API call
-    userEvent.click(viewTallyReportButton);
-
-    // Wait for the API call to be made
-    await screen.findAllByText(/Unofficial.*Tally Report/);
+    const precinctSelect = screen.getByRole('combobox', {
+      name: 'Select precinct',
+    });
+    userEvent.click(precinctSelect);
+    const option = await screen.findByRole('option', {
+      name: election.precincts[0].name,
+    });
+    userEvent.click(option);
 
     // At least some contests should be rendered for this precinct
-    const tables = screen.getAllByRole('table');
-    expect(tables.length).toBeGreaterThan(0);
+    await waitFor(() => {
+      const tables = screen.getAllByRole('table');
+      expect(tables.length).toBeGreaterThan(0);
+    });
   });
 
   test('can view results properly for all precincts general election', async () => {
@@ -703,12 +1255,12 @@ describe('Results navigation and display', () => {
 
     // Set up polls status data with all polls closed
     const mockPollsStatusAllClosed: {
-      election: typeof election;
+      election: Election;
       ballotHash: string;
       isLive: boolean;
       reportsByPollingPlace: Record<string, QuickReportedPollStatus[]>;
     } = {
-      election,
+      election: electionWithPollingPlaces(election),
       ballotHash: 'abc123def456',
       isLive: true,
       reportsByPollingPlace: {
@@ -742,16 +1294,15 @@ describe('Results navigation and display', () => {
     apiMock.getLiveReportsSummary
       .expectRepeatedCallsWith({ electionId })
       .resolves(ok(mockPollsStatusAllClosed));
+    mockEmptyActivityLogForAllTabs(electionId);
 
     renderScreen();
 
     await screen.findByRole('heading', { name: 'Live Reports' });
 
-    // Check that the "View Full Election Tally Report" button is present and enabled
     const viewFullReportButton = screen.getByRole('button', {
-      name: 'View Full Election Tally Report',
+      name: 'View Tally Reports',
     });
-    expect(viewFullReportButton).toBeEnabled();
 
     // Mock the API call that will be made when navigating to results view
     const mockAllPrecinctsResults = createMockAggregatedResults(election, true);
@@ -762,14 +1313,14 @@ describe('Results navigation and display', () => {
       })
       .resolves(ok(mockAllPrecinctsResults));
 
-    // Click the view full election tally report button - this should trigger navigation and API call
+    // Click the view tally reports link - this should trigger navigation and API call
     userEvent.click(viewFullReportButton);
 
     // Wait for the API call to be made, confirming navigation attempt worked
     await screen.findAllByText('Unofficial Tally Report');
 
     // In a general election we do not show Nonpartisan Contests as a header
-    expect(screen.queryByText('Nonpartisan Contests')).not.toBeInTheDocument();
+    expect(screen.queryByText('Nonpartisan Contests')).toBeNull();
     for (const contest of election.contests) {
       screen.getByText(contest.title);
     }
@@ -782,12 +1333,12 @@ describe('Results navigation and display', () => {
 
     // Set up polls status data with all polls closed
     const mockPollsStatusAllClosed: {
-      election: typeof election;
+      election: Election;
       ballotHash: string;
       isLive: boolean;
       reportsByPollingPlace: Record<string, QuickReportedPollStatus[]>;
     } = {
-      election: primaryElection,
+      election: electionWithPollingPlaces(primaryElection),
       ballotHash: 'abc123def456',
       isLive: true,
       reportsByPollingPlace: {
@@ -821,6 +1372,7 @@ describe('Results navigation and display', () => {
     apiMock.getLiveReportsSummary
       .expectRepeatedCallsWith({ electionId: primaryElection.id })
       .resolves(ok(mockPollsStatusAllClosed));
+    mockEmptyActivityLogForAllTabs(primaryElection.id);
 
     mockStateFeatures(apiMock, primaryElection.id);
 
@@ -828,11 +1380,9 @@ describe('Results navigation and display', () => {
 
     await screen.findByRole('heading', { name: 'Live Reports' });
 
-    // Check that the "View Full Election Tally Report" button is present and enabled
     const viewFullReportButton = screen.getByRole('button', {
-      name: 'View Full Election Tally Report',
+      name: 'View Tally Reports',
     });
-    expect(viewFullReportButton).toBeEnabled();
 
     // Mock the API call that will be made when navigating to results view
     const mockAllPrecinctsResults = createMockAggregatedResults(
@@ -846,7 +1396,7 @@ describe('Results navigation and display', () => {
       })
       .resolves(ok(mockAllPrecinctsResults));
 
-    // Click the view full election tally report button - this should trigger navigation and API call
+    // Click the view tally reports link - this should trigger navigation and API call
     userEvent.click(viewFullReportButton);
 
     // Wait for the API call to be made, confirming navigation attempt worked
@@ -870,12 +1420,12 @@ describe('Results navigation and display', () => {
 
     // Set up polls status data with all polls closed
     const mockPollsStatusAllClosed: {
-      election: typeof election;
+      election: Election;
       ballotHash: string;
       isLive: boolean;
       reportsByPollingPlace: Record<string, QuickReportedPollStatus[]>;
     } = {
-      election: primaryElection,
+      election: electionWithPollingPlaces(primaryElection),
       ballotHash: 'abc123def456',
       isLive: true,
       reportsByPollingPlace: {
@@ -909,6 +1459,7 @@ describe('Results navigation and display', () => {
     apiMock.getLiveReportsSummary
       .expectRepeatedCallsWith({ electionId: primaryElection.id })
       .resolves(ok(mockPollsStatusAllClosed));
+    mockEmptyActivityLogForAllTabs(primaryElection.id);
 
     mockStateFeatures(apiMock, primaryElection.id);
 
@@ -916,19 +1467,28 @@ describe('Results navigation and display', () => {
 
     await screen.findByRole('heading', { name: 'Live Reports' });
 
-    // There should be three "View Tally Report" buttons - one for each precinct with results
-    expect(
-      screen.getAllByRole('button', {
-        name: 'View Tally Report',
-      })
-    ).toHaveLength(3);
-
-    const precinct0TallyButton = screen.getByTestId(
-      `view-tally-report-${primaryElection.precincts[0].id}`
+    // Mock the API call for all precincts results (initial navigation)
+    const mockAllPrecinctsResults = createMockAggregatedResults(
+      primaryElection,
+      true
     );
-    expect(precinct0TallyButton).toBeEnabled();
+    apiMock.getLiveResultsReports
+      .expectCallWith({
+        electionId: primaryElection.id,
+        precinctSelection: ALL_PRECINCTS_SELECTION,
+      })
+      .resolves(ok(mockAllPrecinctsResults));
 
-    // Mock the API call that will be made when navigating to results view
+    // Click the "View Tally Reports" button
+    const viewTallyReportsLink = screen.getByRole('button', {
+      name: 'View Tally Reports',
+    });
+    userEvent.click(viewTallyReportsLink);
+
+    // Wait for the results page to load
+    await screen.findAllByText('Unofficial Tally Report');
+
+    // Now select a single precinct from the dropdown
     const mockPrecinct0Results = createMockAggregatedResults(
       primaryElection,
       true
@@ -942,30 +1502,36 @@ describe('Results navigation and display', () => {
       })
       .resolves(ok(mockPrecinct0Results));
 
-    // Click the view tally report button - this should trigger navigation and API call
-    userEvent.click(precinct0TallyButton);
-
-    // Wait for the API call to be made, confirming navigation attempt worked
-    await screen.findAllByText('Unofficial Tally Report');
+    const precinctSelect = screen.getByRole('combobox', {
+      name: 'Select precinct',
+    });
+    userEvent.click(precinctSelect);
+    const option = await screen.findByRole('option', {
+      name: primaryElection.precincts[0].name,
+    });
+    userEvent.click(option);
 
     // In a primary election, show party headers
     // At least some contests and party headers should be rendered
-    const tables = screen.getAllByRole('table');
-    expect(tables.length).toBeGreaterThan(0);
+    await waitFor(() => {
+      const tables = screen.getAllByRole('table');
+      expect(tables.length).toBeGreaterThan(0);
+    });
   });
 
   test('can delete data properly', async () => {
     apiMock.getSystemSettings
       .expectRepeatedCallsWith({ electionId })
       .resolves(mockSystemSettingsWithUrl);
+    mockStateFeatures(apiMock, electionId, { DELETE_LIVE_REPORTS: true });
 
     const mockPollsStatusWithData: {
-      election: typeof election;
+      election: Election;
       ballotHash: string;
       isLive: boolean;
       reportsByPollingPlace: Record<string, QuickReportedPollStatus[]>;
     } = {
-      election,
+      election: electionWithPollingPlaces(election),
       ballotHash: 'abc123def456',
       isLive: false,
       reportsByPollingPlace: {
@@ -985,6 +1551,7 @@ describe('Results navigation and display', () => {
     apiMock.getLiveReportsSummary
       .expectRepeatedCallsWith({ electionId })
       .resolves(ok(mockPollsStatusWithData));
+    mockEmptyActivityLogForAllTabs(electionId);
 
     renderScreen();
 
@@ -1012,7 +1579,7 @@ describe('Results navigation and display', () => {
     await waitFor(() => {
       expect(
         screen.queryByRole('heading', { name: 'Delete All Reports' })
-      ).not.toBeInTheDocument();
+      ).toBeNull();
     });
 
     // Reopen the modal
@@ -1035,7 +1602,285 @@ describe('Results navigation and display', () => {
     await waitFor(() => {
       expect(
         screen.queryByRole('heading', { name: 'Delete Reports' })
-      ).not.toBeInTheDocument();
+      ).toBeNull();
     });
+  });
+});
+
+describe('Edge cases', () => {
+  test('shows configuration error when election has no polling places', async () => {
+    apiMock.getSystemSettings
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(mockSystemSettingsWithUrl);
+
+    // Election with pollingPlaces explicitly undefined
+    const electionWithoutPlaces: Election = {
+      ...election,
+      pollingPlaces: undefined,
+    };
+    apiMock.getLiveReportsSummary
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(
+        ok({
+          election: electionWithoutPlaces,
+          ballotHash: 'abc123def456',
+          isLive: false,
+          reportsByPollingPlace: {},
+        })
+      );
+
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Live Reports' });
+    await screen.findByText(/Polling places are required/);
+    // Cards and summary should not be rendered
+    expect(screen.queryByTestId('overview-card-election_day')).toBeNull();
+    expect(screen.queryByTestId('no-reports-sent-count')).toBeNull();
+  });
+
+  test('delete button is hidden when DELETE_LIVE_REPORTS state feature is off', async () => {
+    apiMock.getSystemSettings
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(mockSystemSettingsWithUrl);
+
+    const pollsStatus = createMockPollsStatus(election, true);
+    pollsStatus.reportsByPollingPlace[election.precincts[0].id] = [
+      {
+        machineId: 'VxScan-001',
+        pollsTransitionType: 'close_polls',
+        pollingPlaceId: election.precincts[0].id,
+        signedTimestamp: new Date('2024-01-01T18:00:00Z'),
+      },
+    ];
+    apiMock.getLiveReportsSummary
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(pollsStatus));
+    mockEmptyActivityLogForAllTabs(electionId);
+
+    // DELETE_LIVE_REPORTS is not enabled (default empty state features)
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Live Reports' });
+    await screen.findByRole('button', { name: 'View Tally Reports' });
+    expect(
+      screen.queryByRole('button', { name: 'Delete All Reports' })
+    ).toBeNull();
+  });
+
+  test('activity log displays each polls transition name', async () => {
+    apiMock.getSystemSettings
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(mockSystemSettingsWithUrl);
+
+    const pollsStatus = createMockPollsStatus(election, true);
+    // Put a report in the table so the UI renders
+    pollsStatus.reportsByPollingPlace[election.precincts[0].id] = [
+      {
+        machineId: 'VxScan-001',
+        pollsTransitionType: 'close_polls',
+        pollingPlaceId: election.precincts[0].id,
+        signedTimestamp: new Date('2024-01-01T18:00:00Z'),
+      },
+    ];
+    // Activity log contains every transition type plus an entry referencing
+    // a polling place ID not in the election (to exercise the fallback).
+    const activityLogEntries: QuickReportedPollStatus[] = [
+      {
+        machineId: 'VxScan-open',
+        pollsTransitionType: 'open_polls',
+        pollingPlaceId: election.precincts[0].id,
+        signedTimestamp: new Date('2024-01-01T07:00:00Z'),
+      },
+      {
+        machineId: 'VxScan-paused',
+        pollsTransitionType: 'pause_voting',
+        pollingPlaceId: election.precincts[0].id,
+        signedTimestamp: new Date('2024-01-01T08:00:00Z'),
+      },
+      {
+        machineId: 'VxScan-resumed',
+        pollsTransitionType: 'resume_voting',
+        pollingPlaceId: election.precincts[0].id,
+        signedTimestamp: new Date('2024-01-01T09:00:00Z'),
+      },
+      {
+        machineId: 'VxScan-closed',
+        pollsTransitionType: 'close_polls',
+        pollingPlaceId: election.precincts[0].id,
+        signedTimestamp: new Date('2024-01-01T18:00:00Z'),
+      },
+      {
+        machineId: 'VxScan-orphan',
+        pollsTransitionType: 'close_polls',
+        pollingPlaceId: 'unknown-place-id',
+        signedTimestamp: new Date('2024-01-01T19:00:00Z'),
+      },
+    ];
+
+    apiMock.getLiveReportsSummary
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(pollsStatus));
+    apiMock.getLiveReportsActivityLog
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(createMockActivityLog(activityLogEntries)));
+
+    renderScreen();
+
+    await screen.findByRole('heading', { name: 'Live Reports' });
+
+    // Each transition type is rendered
+    await screen.findByText(/VxScan-open: Polls Open/);
+    screen.getByText(/VxScan-paused: Polls Paused/);
+    screen.getByText(/VxScan-resumed: Polls Resumed/);
+    screen.getByText(/VxScan-closed: Polls Closed/);
+    // Orphan entry shows the raw polling place ID as a fallback
+    screen.getByText('unknown-place-id');
+  });
+
+  test('precinct dropdown navigates back to all precincts when "All Precincts" is selected', async () => {
+    apiMock.getSystemSettings
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(mockSystemSettingsWithUrl);
+
+    const pollsStatus = createMockPollsStatus(election, true);
+    pollsStatus.reportsByPollingPlace[election.precincts[0].id] = [
+      {
+        machineId: 'VxScan-001',
+        pollsTransitionType: 'close_polls',
+        pollingPlaceId: election.precincts[0].id,
+        signedTimestamp: new Date('2024-01-01T18:00:00Z'),
+      },
+    ];
+
+    apiMock.getLiveReportsSummary
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(pollsStatus));
+    mockEmptyActivityLogForAllTabs(electionId);
+
+    renderScreen();
+    await screen.findByRole('heading', { name: 'Live Reports' });
+
+    // Navigate to tally report view
+    const allPrecinctsResults = createMockAggregatedResults(election, true);
+    apiMock.getLiveResultsReports
+      .expectCallWith({
+        electionId,
+        precinctSelection: ALL_PRECINCTS_SELECTION,
+      })
+      .resolves(ok(allPrecinctsResults));
+    userEvent.click(screen.getByRole('button', { name: 'View Tally Reports' }));
+    await screen.findAllByText(/Unofficial.*Tally Report/);
+
+    // Select a single precinct
+    const singlePrecinctResults = createMockAggregatedResults(election, true);
+    apiMock.getLiveResultsReports
+      .expectCallWith({
+        electionId,
+        precinctSelection: singlePrecinctSelectionFor(election.precincts[0].id),
+      })
+      .resolves(ok(singlePrecinctResults));
+    const precinctSelect = screen.getByRole('combobox', {
+      name: 'Select precinct',
+    });
+    userEvent.click(precinctSelect);
+    userEvent.click(
+      await screen.findByRole('option', {
+        name: election.precincts[0].name,
+      })
+    );
+    await waitFor(() => {
+      expect(screen.getAllByRole('table').length).toBeGreaterThan(0);
+    });
+
+    // Now go back to "All Precincts" - expect another call for the all-precincts path
+    apiMock.getLiveResultsReports
+      .expectCallWith({
+        electionId,
+        precinctSelection: ALL_PRECINCTS_SELECTION,
+      })
+      .resolves(ok(allPrecinctsResults));
+    userEvent.click(screen.getByRole('combobox', { name: 'Select precinct' }));
+    userEvent.click(
+      await screen.findByRole('option', { name: 'All Precincts' })
+    );
+    await waitFor(() => {
+      expect(screen.getAllByRole('table').length).toBeGreaterThan(0);
+    });
+  });
+
+  test('tally report page shows error state when election is out of date', async () => {
+    apiMock.getSystemSettings
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(mockSystemSettingsWithUrl);
+
+    const pollsStatus = createMockPollsStatus(election, true);
+    pollsStatus.reportsByPollingPlace[election.precincts[0].id] = [
+      {
+        machineId: 'VxScan-001',
+        pollsTransitionType: 'close_polls',
+        pollingPlaceId: election.precincts[0].id,
+        signedTimestamp: new Date('2024-01-01T18:00:00Z'),
+      },
+    ];
+    apiMock.getLiveReportsSummary
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(pollsStatus));
+    mockEmptyActivityLogForAllTabs(electionId);
+
+    renderScreen();
+    await screen.findByRole('heading', { name: 'Live Reports' });
+
+    apiMock.getLiveResultsReports
+      .expectRepeatedCallsWith({
+        electionId,
+        precinctSelection: ALL_PRECINCTS_SELECTION,
+      })
+      .resolves(err('election-out-of-date'));
+
+    userEvent.click(screen.getByRole('button', { name: 'View Tally Reports' }));
+
+    await screen.findByText(
+      /This election is no longer compatible with Live Reports/
+    );
+  });
+
+  test('tally report page shows "No results reported" when no machines have reported', async () => {
+    apiMock.getSystemSettings
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(mockSystemSettingsWithUrl);
+
+    const pollsStatus = createMockPollsStatus(election, true);
+    pollsStatus.reportsByPollingPlace[election.precincts[0].id] = [
+      {
+        machineId: 'VxScan-001',
+        pollsTransitionType: 'close_polls',
+        pollingPlaceId: election.precincts[0].id,
+        signedTimestamp: new Date('2024-01-01T18:00:00Z'),
+      },
+    ];
+    apiMock.getLiveReportsSummary
+      .expectRepeatedCallsWith({ electionId })
+      .resolves(ok(pollsStatus));
+    mockEmptyActivityLogForAllTabs(electionId);
+
+    renderScreen();
+    await screen.findByRole('heading', { name: 'Live Reports' });
+
+    // Return results with no machinesReporting
+    const fullResults = createMockAggregatedResults(election, true);
+    const emptyResults: typeof fullResults = {
+      ...fullResults,
+      machinesReporting: [],
+    };
+    apiMock.getLiveResultsReports
+      .expectRepeatedCallsWith({
+        electionId,
+        precinctSelection: ALL_PRECINCTS_SELECTION,
+      })
+      .resolves(ok(emptyResults));
+
+    userEvent.click(screen.getByRole('button', { name: 'View Tally Reports' }));
+
+    await screen.findByText('No results reported.');
   });
 });

--- a/apps/design/frontend/src/live_reports_screen.tsx
+++ b/apps/design/frontend/src/live_reports_screen.tsx
@@ -1,4 +1,3 @@
-/* istanbul ignore file - @preserve - Page under construction */
 import {
   Button,
   ContestResultsTable,
@@ -7,12 +6,12 @@ import {
   MainContent,
   Modal,
   P,
+  RouterTabBar,
   TallyReportColumns,
   Table,
   TD,
   TH,
   Icons,
-  Card,
   LabelledText,
   H3,
   Caption,
@@ -22,22 +21,25 @@ import {
   ReportElectionInfo,
   ReportMetadata,
   Callout,
+  SearchSelect,
   TestModeBanner,
   TestModeReportBanner,
   useQueryChangeListener,
 } from '@votingworks/ui';
-import { useParams, Switch, Route } from 'react-router-dom';
+import { useParams, Switch, Route, useHistory } from 'react-router-dom';
 import React, { useState } from 'react';
 import { assert, deepEqual, throwIllegalValue } from '@votingworks/basics';
 import {
   formatBallotHash,
+  PollingPlace,
+  PollingPlaceType,
+  pollingPlaceTypeName,
   PollsTransitionType,
   PrecinctSelection,
 } from '@votingworks/types';
 import {
   format,
   getContestsForPrecinctAndElection,
-  getPrecinctSelectionName,
   groupContestsByParty,
 } from '@votingworks/utils';
 import styled, { useTheme } from 'styled-components';
@@ -49,22 +51,114 @@ import { ElectionNavScreen, Header } from './nav_screen';
 import { ElectionIdParams, routes } from './routes';
 import {
   deleteQuickReportingResults,
+  getLiveReportsActivityLog,
   getLiveResultsReports,
   getLiveReportsSummary,
+  getStateFeatures,
   getSystemSettings,
 } from './api';
 import { useTitle } from './hooks/use_title';
 import { Row } from './layout';
 import { useSound } from './utils';
 
-const PollsStatusLabel = styled.span`
-  font-size: 1rem;
-`;
+// --- Status types and helpers ---
+
+type PollingPlaceOverallStatus = 'no_reports' | 'open' | 'paused' | 'closed';
 
 const POLLS_OPEN_TRANSITIONS: readonly PollsTransitionType[] = [
   'open_polls',
   'resume_voting',
 ];
+
+/* PollingPlaceType's ordered by typical voting timeline, for display in the overview screen. */
+const VOTING_GROUPS: readonly PollingPlaceType[] = [
+  'early_voting',
+  'election_day',
+  'absentee',
+];
+
+function getPollingPlaceOverallStatus(
+  reports: QuickReportedPollStatus[]
+): PollingPlaceOverallStatus {
+  if (reports.length === 0) return 'no_reports';
+  if (reports.every((r) => r.pollsTransitionType === 'close_polls')) {
+    return 'closed';
+  }
+  if (reports.every((r) => r.pollsTransitionType === 'pause_voting')) {
+    return 'paused';
+  }
+  return 'open';
+}
+
+function getOverallStatusIcon(
+  status: PollingPlaceOverallStatus
+): JSX.Element | null {
+  switch (status) {
+    case 'no_reports':
+      return <Icons.Warning color="warning" />;
+    case 'open':
+      return <Icons.Circle color="success" />;
+    case 'paused':
+      return <Icons.Paused />;
+    case 'closed':
+      return <Icons.Done color="primary" />;
+    /* istanbul ignore next - @preserve */
+    default:
+      throwIllegalValue(status);
+  }
+}
+
+function getOverallStatusLabel(status: PollingPlaceOverallStatus): string {
+  switch (status) {
+    case 'no_reports':
+      return 'No reports sent';
+    case 'open':
+      return 'Polls open';
+    case 'paused':
+      return 'Polls paused';
+    case 'closed':
+      return 'Voting complete';
+    /* istanbul ignore next - @preserve */
+    default:
+      throwIllegalValue(status);
+  }
+}
+
+function getScannerDetailsText(
+  reports: QuickReportedPollStatus[]
+): JSX.Element | null {
+  if (reports.length === 0) return null;
+
+  const closedCount = reports.filter(
+    (r) => r.pollsTransitionType === 'close_polls'
+  ).length;
+  const pausedCount = reports.filter(
+    (r) => r.pollsTransitionType === 'pause_voting'
+  ).length;
+  const openCount = reports.filter((r) =>
+    POLLS_OPEN_TRANSITIONS.includes(r.pollsTransitionType)
+  ).length;
+
+  if (closedCount > 0) {
+    return (
+      <span>
+        {closedCount}/{reports.length} complete
+      </span>
+    );
+  }
+  if (pausedCount > 0) {
+    return (
+      <span>
+        {pausedCount}/{reports.length} paused
+      </span>
+    );
+  }
+  return (
+    <span>
+      {openCount}/{reports.length} open
+    </span>
+  );
+}
 
 function getLiveReportTransitionName(
   transitionType: PollsTransitionType
@@ -84,204 +178,549 @@ function getLiveReportTransitionName(
   }
 }
 
-function getPollsStatusText(
-  pollsOpenCount: number,
-  pollsClosedCount: number
-): JSX.Element | string {
-  const totalCount = pollsOpenCount + pollsClosedCount;
-
-  if (totalCount === 0) {
-    return (
-      <span>
-        <Icons.Warning color="warning" /> No reports sent
-      </span>
-    );
-  }
-  if (pollsClosedCount === 0) {
-    return (
-      <span>
-        <Icons.Circle color="success" /> {pollsOpenCount} open
-      </span>
-    );
-  }
-  const icon =
-    pollsClosedCount === totalCount ? (
-      <Icons.Done color="primary" />
-    ) : (
-      <Icons.CircleDot color="primary" />
-    );
-  return (
-    <span>
-      {icon} {pollsClosedCount}/{totalCount} closed
-    </span>
-  );
-}
-
 function getErrorMessage(error: GetExportedElectionError): string {
   switch (error) {
     case 'no-election-export-found':
       return 'This election has not yet been exported. Please export the election and configure VxScan to enable live reports.';
     case 'election-out-of-date':
       return 'This election is no longer compatible with Live Reports. Please export a new election package to continue using Live Reports.';
+    /* istanbul ignore next - @preserve */
     default:
       throwIllegalValue(error);
   }
 }
 
-function getLastUpdateInformation(
-  reports: QuickReportedPollStatus[]
-): JSX.Element {
-  const lastPollsUpdate = [...reports].sort(
-    (a, b) => b.signedTimestamp.getTime() - a.signedTimestamp.getTime()
-  )[0];
+interface StatusCounts {
+  no_reports: number;
+  open: number;
+  paused: number;
+  closed: number;
+}
 
+function computeStatusCounts(
+  places: readonly PollingPlace[],
+  reportsByPollingPlace: Record<string, QuickReportedPollStatus[]>
+): StatusCounts {
+  const counts: StatusCounts = {
+    no_reports: 0,
+    open: 0,
+    paused: 0,
+    closed: 0,
+  };
+  for (const place of places) {
+    const reports = reportsByPollingPlace[place.id] || [];
+    const status = getPollingPlaceOverallStatus(reports);
+    counts[status] += 1;
+  }
+  return counts;
+}
+
+// --- Styled components ---
+
+const PollsStatusLabel = styled.span`
+  font-size: 1rem;
+`;
+
+const ContentLayout = styled.div`
+  display: flex;
+  gap: 1rem;
+  min-height: 0;
+  flex: 1;
+  margin-top: 1rem;
+`;
+
+const MainColumn = styled.div`
+  flex: 2;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow: hidden;
+  height: 100%;
+`;
+
+const ScrollableTableContainer = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+`;
+
+const StatusTable = styled(Table)`
+  td {
+    padding: 0.5rem;
+  }
+`;
+
+const Panel = styled.div`
+  border: ${(p) =>
+    `${p.theme.sizes.bordersRem.thin}rem solid ${p.theme.colors.outline}`};
+  border-radius: 0.5rem;
+  overflow: hidden;
+`;
+
+const PanelHeader = styled.div`
+  background-color: ${(p) => p.theme.colors.containerLow};
+  border-bottom: ${(p) =>
+    `${p.theme.sizes.bordersRem.thin}rem solid ${p.theme.colors.outline}`};
+  padding: 0.75rem 0.5rem 0.5rem 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+`;
+
+const PanelBody = styled.div`
+  background-color: ${(p) => p.theme.colors.background};
+`;
+
+const ActivityColumn = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+const ActivityScroll = styled(PanelBody)`
+  overflow-y: auto;
+  flex: 1;
+`;
+
+const ActivityEntry = styled.div`
+  > :first-child {
+    font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
+  }
+
+  > :not(:first-child) {
+    color: ${(p) => p.theme.colors.onBackgroundMuted};
+  }
+
+  padding: 0.75rem;
+  border-bottom: ${(p) =>
+    `${p.theme.sizes.bordersRem.hairline}rem solid ${p.theme.colors.outline}`};
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const ProgressBar = styled.div`
+  display: flex;
+  height: 0.5rem;
+  border-radius: 0.25rem;
+  overflow: hidden;
+  margin-top: 1rem;
+  margin-bottom: 0.25rem;
+  background: ${(p) => p.theme.colors.containerLow};
+`;
+
+const ProgressSegment = styled.div<{ color: string; widthPercent: number }>`
+  width: ${(p) => p.widthPercent}%;
+  background: ${(p) => p.color};
+  transition: width 0.3s ease;
+`;
+
+interface SummaryStatsGridProps {
+  statusCounts: StatusCounts;
+  totalPlaces: number;
+  isAbsentee: boolean;
+  segmentKey: string;
+}
+
+function SummaryStatsGrid({
+  statusCounts,
+  totalPlaces,
+  isAbsentee,
+  segmentKey,
+}: SummaryStatsGridProps): JSX.Element {
+  const theme = useTheme();
   return (
-    <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <div>
-        {lastPollsUpdate.machineId}: Polls{' '}
-        {getLiveReportTransitionName(lastPollsUpdate.pollsTransitionType)}
+    <div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(4, 1fr)',
+          gap: '2rem',
+          marginBottom: '0.75rem',
+        }}
+      >
+        <LabelledText
+          style={{ marginTop: '-.25rem' }}
+          labelPosition="bottom"
+          label={<PollsStatusLabel>No reports sent</PollsStatusLabel>}
+        >
+          <H1 data-testid="no-reports-sent-count">
+            <Icons.Warning color="warning" /> {statusCounts.no_reports}
+          </H1>
+        </LabelledText>
+        {!isAbsentee && (
+          <LabelledText
+            style={{ marginTop: '-.25rem' }}
+            labelPosition="bottom"
+            label={<PollsStatusLabel>Polls open</PollsStatusLabel>}
+          >
+            <H1 data-testid="polls-open-count">
+              <Icons.Circle color="success" /> {statusCounts.open}
+            </H1>
+          </LabelledText>
+        )}
+        {!isAbsentee && (
+          <LabelledText
+            style={{ marginTop: '-.25rem' }}
+            labelPosition="bottom"
+            label={<PollsStatusLabel>Polls paused</PollsStatusLabel>}
+          >
+            <H1 data-testid="polls-paused-count">
+              <Icons.Paused /> {statusCounts.paused}
+            </H1>
+          </LabelledText>
+        )}
+        <LabelledText
+          style={{
+            marginTop: '-.25rem',
+            gridColumn: isAbsentee ? 2 : undefined,
+          }}
+          labelPosition="bottom"
+          label={<PollsStatusLabel>Voting complete</PollsStatusLabel>}
+        >
+          <H1 data-testid="polls-closed-count">
+            <Icons.Done color="primary" /> {statusCounts.closed}
+          </H1>
+        </LabelledText>
       </div>
-      <Caption>
-        {format.localeShortDateAndTime(lastPollsUpdate.signedTimestamp)}
-      </Caption>
+      {totalPlaces > 0 && (
+        <ProgressBar key={segmentKey}>
+          {!isAbsentee && (
+            <ProgressSegment
+              color={theme.colors.successAccent}
+              widthPercent={(statusCounts.open / totalPlaces) * 100}
+            />
+          )}
+          {!isAbsentee && (
+            <ProgressSegment
+              color={theme.colors.onBackgroundMuted}
+              widthPercent={(statusCounts.paused / totalPlaces) * 100}
+            />
+          )}
+          <ProgressSegment
+            color={theme.colors.primary}
+            widthPercent={(statusCounts.closed / totalPlaces) * 100}
+          />
+        </ProgressBar>
+      )}
     </div>
   );
 }
 
-interface LiveReportsSummaryScreenProps {
+interface ActivityLogPanelProps {
   electionId: string;
+  /** When undefined, the panel shows activity for all groups. */
+  votingGroup?: PollingPlaceType;
+  pollingPlaces: readonly PollingPlace[];
 }
 
-function LiveReportsSummaryScreen({
+function ActivityLogPanel({
   electionId,
-}: LiveReportsSummaryScreenProps): JSX.Element {
-  const [isDeleteDataModalOpen, setIsDeleteDataModalOpen] = useState(false);
-  const [precinctIdsToAnimate, setPrecinctIdsToAnimate] = useState<string[]>(
-    []
+  votingGroup,
+  pollingPlaces,
+}: ActivityLogPanelProps): JSX.Element {
+  const activityLogQuery = getLiveReportsActivityLog.useQuery(
+    electionId,
+    votingGroup
   );
-  const getLiveReportsSummaryQuery = getLiveReportsSummary.useQuery(electionId);
+  const activityLogResult = activityLogQuery.data?.isOk()
+    ? activityLogQuery.data.ok()
+    : undefined;
+  const isLoading =
+    !activityLogQuery.isSuccess || !activityLogQuery.data.isOk();
+  const activityEntries = (activityLogResult?.activityLog ?? []).map(
+    (entry) => {
+      const place = pollingPlaces.find((p) => p.id === entry.pollingPlaceId);
+      return { ...entry, placeName: place?.name ?? entry.pollingPlaceId };
+    }
+  );
 
-  const deleteQuickReportingResultsMutation =
-    deleteQuickReportingResults.useMutation();
+  return (
+    <Panel
+      style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: 0,
+      }}
+    >
+      <PanelHeader>
+        <Row style={{ alignItems: 'center', gap: '0.5rem' }}>
+          <H3 style={{ margin: 0 }}>Activity</H3>
+          {isLoading && <Icons.Loading />}
+        </Row>
+      </PanelHeader>
+      <ActivityScroll>
+        {!isLoading && activityEntries.length === 0 && (
+          <ActivityEntry>
+            <div>No activity yet</div>
+          </ActivityEntry>
+        )}
+        {activityEntries.map((entry) => (
+          <ActivityEntry
+            key={`${entry.machineId}-${entry.signedTimestamp.getTime()}`}
+          >
+            <div>
+              {entry.machineId}: Polls{' '}
+              {getLiveReportTransitionName(entry.pollsTransitionType)}
+            </div>
+            <div>{entry.placeName}</div>
+            <Caption>
+              {format.localeShortDateAndTime(entry.signedTimestamp)}
+            </Caption>
+          </ActivityEntry>
+        ))}
+      </ActivityScroll>
+    </Panel>
+  );
+}
 
-  function setPrecinctsToAnimate(precinctIds: string[]): void {
-    setPrecinctIdsToAnimate(precinctIds);
+interface DeleteReportsModalProps {
+  electionId: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function DeleteReportsModal({
+  electionId,
+  isOpen,
+  onClose,
+}: DeleteReportsModalProps): JSX.Element | null {
+  const deleteMutation = deleteQuickReportingResults.useMutation();
+
+  if (!isOpen) return null;
+
+  async function deleteData(): Promise<void> {
+    try {
+      await deleteMutation.mutateAsync({ electionId });
+    } catch {
+      // Even if there's an error, continue to close modal
+    } finally {
+      onClose();
+    }
+  }
+
+  return (
+    <Modal
+      content={
+        /* istanbul ignore next - @preserve - mutation loading state is transient */
+        deleteMutation.isLoading ? (
+          <Icons.Loading />
+        ) : (
+          <React.Fragment>
+            <H2 as="h1">Delete All Reports</H2>
+            <P>
+              Are you sure you want to delete all reports for this election?
+            </P>
+          </React.Fragment>
+        )
+      }
+      actions={
+        /* istanbul ignore next - @preserve - mutation loading state is transient */
+        deleteMutation.isLoading ? (
+          <Button onPress={onClose} variant="secondary">
+            Cancel
+          </Button>
+        ) : (
+          <React.Fragment>
+            <Button
+              onPress={() => deleteData()}
+              variant="danger"
+              data-testid="confirm-delete-data-button"
+            >
+              Delete Reports
+            </Button>
+            <Button onPress={onClose}>Cancel</Button>
+          </React.Fragment>
+        )
+      }
+      onOverlayClick={
+        /* istanbul ignore next - @preserve - mutation loading state is transient */
+        deleteMutation.isLoading ? undefined : onClose
+      }
+    />
+  );
+}
+
+// --- Animation hook ---
+
+function useDataChangeAnimation(
+  query: ReturnType<typeof getLiveReportsSummary.useQuery>
+): {
+  pollingPlaceIdsToAnimate: string[];
+} {
+  const [pollingPlaceIdsToAnimate, setPollingPlaceIdsToAnimate] = useState<
+    string[]
+  >([]);
+
+  function setPlacesToAnimate(placeIds: string[]): void {
+    setPollingPlaceIdsToAnimate(placeIds);
+    /* istanbul ignore next - @preserve - timer cleanup runs after test completes */
     setTimeout(() => {
-      setPrecinctIdsToAnimate((prev) =>
-        prev.filter((id) => !precinctIds.includes(id))
+      setPollingPlaceIdsToAnimate((prev) =>
+        prev.filter((id) => !placeIds.includes(id))
       );
     }, 1000);
   }
 
-  // Get data for animations (provide empty defaults if not loaded)
-  const pollsStatusData = getLiveReportsSummaryQuery.isSuccess
-    ? getLiveReportsSummaryQuery.data.isOk()
-      ? getLiveReportsSummaryQuery.data.ok()
-      : null
-    : null;
-  const precincts = pollsStatusData ? pollsStatusData.election.precincts : [];
-
   const playSound = useSound('happy-ping');
-  useQueryChangeListener(getLiveReportsSummaryQuery, {
-    // Could also select `isLive` too if that's relevant
+  useQueryChangeListener(query, {
     select: (result) => ({
       reportsByPollingPlace: result.ok()?.reportsByPollingPlace,
       isLive: result.ok()?.isLive,
     }),
     onChange: (newData, oldData) => {
       if (!oldData) return;
-      const { reportsByPollingPlace: newReportsByPrecinct, isLive: newIsLive } =
+      const { reportsByPollingPlace: newReportsByPlace, isLive: newIsLive } =
         newData;
-      const { reportsByPollingPlace: oldReportsByPrecinct, isLive: oldIsLive } =
+      const { reportsByPollingPlace: oldReportsByPlace, isLive: oldIsLive } =
         oldData;
-      if (!newReportsByPrecinct) return;
+      /* istanbul ignore if - @preserve - defensive guard */
+      if (!newReportsByPlace) return;
       const switchedLive = newIsLive && !oldIsLive;
-      const changedPrecincts = Object.entries(newReportsByPrecinct)
-        .filter(([precinctId, newReports]) => {
+      const changedPlaces = Object.entries(newReportsByPlace)
+        .filter(([placeId, newReports]) => {
           const oldReports =
-            switchedLive || !oldReportsByPrecinct
+            switchedLive || !oldReportsByPlace
               ? []
-              : oldReportsByPrecinct[precinctId];
+              : oldReportsByPlace[placeId];
           return !deepEqual(oldReports, newReports);
         })
-        .map(([precinctId]) => precinctId);
-      // do not ping when data is deleted.
-      const hasNewData =
-        Object.entries(newReportsByPrecinct).filter(
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          ([_, newReports]) => newReports.length > 0
-        ).length > 0;
-      setPrecinctsToAnimate(changedPrecincts);
-      if (changedPrecincts.length > 0 && hasNewData) {
+        .map(([placeId]) => placeId);
+      const hasNewData = Object.values(newReportsByPlace).some(
+        (reports) => reports.length > 0
+      );
+      setPlacesToAnimate(changedPlaces);
+      if (changedPlaces.length > 0 && hasNewData) {
         playSound();
       }
     },
   });
 
-  /* // Animation hooks (always called)
-  const precinctAnimations = usePrecinctAnimations(
-    precincts,
-    reportsByPollingPlace,
-    reportsIsLive,
-    playSound
-  ); */
+  return { pollingPlaceIdsToAnimate };
+}
 
-  const theme = useTheme();
+function LoadingScreen(): JSX.Element {
+  return (
+    <div>
+      <Header>
+        <H1 style={{ paddingRight: '1rem', display: 'inline' }}>
+          Live Reports
+        </H1>
+      </Header>
+      <MainContent>
+        <Icons.Loading />
+      </MainContent>
+    </div>
+  );
+}
 
-  async function deleteData(): Promise<void> {
-    try {
-      await deleteQuickReportingResultsMutation.mutateAsync({
-        electionId,
-      });
-    } catch {
-      // Even if there's an error, continue to close modal
-    } finally {
-      // Always close the modal regardless of success or failure
-      setIsDeleteDataModalOpen(false);
-    }
+function ErrorScreen({
+  error,
+}: {
+  error: GetExportedElectionError;
+}): JSX.Element {
+  return (
+    <div>
+      <Header>
+        <H1 style={{ paddingRight: '1rem', display: 'inline' }}>
+          Live Reports
+        </H1>
+      </Header>
+      <MainContent>
+        <Callout color="warning" icon="Warning">
+          {getErrorMessage(error)}
+        </Callout>
+      </MainContent>
+    </div>
+  );
+}
+
+/**
+ * Tab bar that navigates between the All overview and per-voting-group pages.
+ * Only renders tabs for groups that have at least one polling place. Hides
+ * itself entirely if only the All tab would be shown.
+ */
+function LiveReportsTabBar({
+  electionId,
+  pollingPlaces,
+}: {
+  electionId: string;
+  pollingPlaces: readonly PollingPlace[];
+}): JSX.Element | null {
+  const groupsWithPlaces = VOTING_GROUPS.filter((group) =>
+    pollingPlaces.some((p) => p.type === group)
+  );
+  if (groupsWithPlaces.length < 2) return null;
+  const tabs = [
+    {
+      title: 'All Voting Groups',
+      path: routes.election(electionId).reports.root.path,
+    },
+    ...groupsWithPlaces.map((group) => ({
+      title: pollingPlaceTypeName(group),
+      path: routes.election(electionId).reports.votingGroup(group).path,
+    })),
+  ];
+  return <RouterTabBar tabs={tabs} />;
+}
+
+interface LiveReportsOverviewScreenProps {
+  electionId: string;
+}
+
+function LiveReportsOverviewScreen({
+  electionId,
+}: LiveReportsOverviewScreenProps): JSX.Element {
+  const [isDeleteDataModalOpen, setIsDeleteDataModalOpen] = useState(false);
+  const summaryQuery = getLiveReportsSummary.useQuery(electionId);
+  const stateFeaturesQuery = getStateFeatures.useQuery(electionId);
+
+  const canDeleteReports =
+    stateFeaturesQuery.data?.DELETE_LIVE_REPORTS === true;
+
+  useDataChangeAnimation(summaryQuery);
+
+  const pollsStatusData = summaryQuery.isSuccess
+    ? summaryQuery.data.isOk()
+      ? summaryQuery.data.ok()
+      : null
+    : null;
+
+  if (!summaryQuery.isSuccess) {
+    return <LoadingScreen />;
   }
 
-  if (!getLiveReportsSummaryQuery.isSuccess) {
-    return (
-      <div>
-        <Header>
-          <H1 style={{ paddingRight: '1rem', display: 'inline' }}>
-            Live Reports
-          </H1>
-        </Header>
-        <MainContent>
-          <Icons.Loading />
-        </MainContent>
-      </div>
-    );
-  }
-
-  if (getLiveReportsSummaryQuery.data.isErr()) {
-    const errorMessage = getErrorMessage(getLiveReportsSummaryQuery.data.err());
-    return (
-      <div>
-        <Header>
-          <H1 style={{ paddingRight: '1rem', display: 'inline' }}>
-            Live Reports
-          </H1>
-        </Header>
-        <MainContent>
-          <Callout color="warning" icon="Warning">
-            {errorMessage}
-          </Callout>
-        </MainContent>
-      </div>
-    );
+  if (summaryQuery.data.isErr()) {
+    return <ErrorScreen error={summaryQuery.data.err()} />;
   }
 
   assert(pollsStatusData !== null);
+
+  const pollingPlaces: readonly PollingPlace[] =
+    pollsStatusData.election.pollingPlaces ?? [];
 
   const allEntries = Object.values(
     pollsStatusData.reportsByPollingPlace
   ).flat();
 
+  const groupsWithPlaces = VOTING_GROUPS.filter((group) =>
+    pollingPlaces.some((p) => p.type === group)
+  );
+
   return (
-    <div>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        minHeight: 0,
+      }}
+    >
       <Header>
         <Row style={{ alignItems: 'center', gap: '1rem' }}>
           <H1 style={{ paddingRight: '1rem', display: 'inline' }}>
@@ -290,266 +729,253 @@ function LiveReportsSummaryScreen({
         </Row>
       </Header>
       {allEntries.length > 0 && !pollsStatusData.isLive && <TestModeBanner />}
-      <MainContent>
-        {allEntries.length > 0 && (
-          <div
-            style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}
-          >
-            <Card color="neutral">
-              <div
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                }}
-              >
-                <div>
-                  <H3>Precinct Status</H3>
-                  <div
-                    style={{
-                      display: 'grid',
-                      gridTemplateColumns: 'repeat(4, 1fr)',
-                      flex: 1,
-                      gap: '2rem',
-                    }}
-                  >
-                    <LabelledText
-                      style={{ marginTop: '-.25rem' }}
-                      labelPosition="bottom"
-                      label={
-                        <PollsStatusLabel>No reports sent</PollsStatusLabel>
-                      }
-                    >
-                      <H1 data-testid="no-reports-sent-count">
-                        <Icons.Warning color="warning" />{' '}
-                        {
-                          Object.values(
-                            pollsStatusData.reportsByPollingPlace
-                          ).filter((entries) => entries.length === 0).length
-                        }
-                      </H1>
-                    </LabelledText>
-                    <LabelledText
-                      style={{ marginTop: '-.25rem' }}
-                      labelPosition="bottom"
-                      label={<PollsStatusLabel>Polls open</PollsStatusLabel>}
-                    >
-                      <H1 data-testid="polls-open-count">
-                        <Icons.Circle color="success" />{' '}
-                        {
-                          Object.values(
-                            pollsStatusData.reportsByPollingPlace
-                          ).filter(
-                            (entries) =>
-                              entries.length > 0 &&
-                              entries.every((entry) =>
-                                POLLS_OPEN_TRANSITIONS.includes(
-                                  entry.pollsTransitionType
-                                )
-                              )
-                          ).length
-                        }
-                      </H1>
-                    </LabelledText>
-                    <LabelledText
-                      style={{ marginTop: '-.25rem' }}
-                      labelPosition="bottom"
-                      label={<PollsStatusLabel>Polls closing</PollsStatusLabel>}
-                    >
-                      <H1 data-testid="polls-closing-count">
-                        <Icons.CircleDot color="primary" />{' '}
-                        {
-                          Object.values(
-                            pollsStatusData.reportsByPollingPlace
-                          ).filter(
-                            (entries) =>
-                              entries.length > 0 &&
-                              entries.some((entry) =>
-                                POLLS_OPEN_TRANSITIONS.includes(
-                                  entry.pollsTransitionType
-                                )
-                              ) &&
-                              entries.some(
-                                (entry) =>
-                                  entry.pollsTransitionType === 'close_polls'
-                              )
-                          ).length
-                        }
-                      </H1>
-                    </LabelledText>
-                    <LabelledText
-                      style={{ marginTop: '-.25rem' }}
-                      labelPosition="bottom"
-                      label={<PollsStatusLabel>Polls closed</PollsStatusLabel>}
-                    >
-                      <H1 data-testid="polls-closed-count">
-                        <Icons.Done color="primary" />{' '}
-                        {
-                          Object.values(
-                            pollsStatusData.reportsByPollingPlace
-                          ).filter(
-                            (entries) =>
-                              entries.length > 0 &&
-                              entries.every(
-                                (entry) =>
-                                  entry.pollsTransitionType === 'close_polls'
-                              )
-                          ).length
-                        }
-                      </H1>
-                    </LabelledText>
-                  </div>
-                </div>
-                <div
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: '0.5rem',
-                  }}
-                >
-                  <LinkButton
-                    variant="primary"
-                    disabled={
-                      allEntries.filter(
-                        (entry) => entry.pollsTransitionType === 'close_polls'
-                      ).length === 0
-                    }
-                    to={`${
-                      routes.election(electionId).reports.allPrecinctResults
-                        .path
-                    }`}
-                  >
-                    View Full Election Tally Report
-                  </LinkButton>
-                  <Button
-                    color="danger"
-                    icon="Delete"
-                    onPress={() => setIsDeleteDataModalOpen(true)}
-                  >
-                    Delete All Reports
-                  </Button>
-                </div>
-              </div>
-            </Card>
-            <Table>
-              <thead>
-                <tr>
-                  <TH style={{ minWidth: '200px' }}>Precinct</TH>
-                  <TH style={{ minWidth: '180px' }}>Scanner Status</TH>
-                  <TH style={{ minWidth: '250px' }}>Last Report Sent</TH>
-                  <TH style={{ minWidth: '200px' }} />
-                </tr>
-              </thead>
-              <tbody>
-                {precincts.map((precinct) => {
-                  const reportsForPrecinct =
-                    pollsStatusData.reportsByPollingPlace[precinct.id] || [];
-
-                  const pollsOpenCount = reportsForPrecinct.filter((entry) =>
-                    POLLS_OPEN_TRANSITIONS.includes(entry.pollsTransitionType)
-                  ).length;
-                  const pollsClosedCount = reportsForPrecinct.filter(
-                    (entry) => entry.pollsTransitionType === 'close_polls'
-                  ).length;
-
-                  const isHighlighted = precinctIdsToAnimate.includes(
-                    precinct.id
-                  );
-
-                  return (
-                    <tr
-                      key={precinct.id}
-                      data-testid={`precinct-row-${precinct.id}`}
-                      data-highlighted={isHighlighted ? 'true' : 'false'}
-                      style={{
-                        height: '3rem',
-                        transition: 'background-color 0.5s ease-in-out',
-                        backgroundColor: isHighlighted
-                          ? theme.colors.inversePrimary
-                          : 'transparent',
-                      }}
-                    >
-                      <TD>{precinct.name}</TD>
-                      <TD>
-                        {getPollsStatusText(pollsOpenCount, pollsClosedCount)}
-                      </TD>
-                      <TD>
-                        {reportsForPrecinct.length > 0 &&
-                          getLastUpdateInformation(reportsForPrecinct)}
-                      </TD>
-                      <TD textAlign="right" style={{ paddingRight: '1rem' }}>
-                        {pollsClosedCount > 0 && precinct.id && (
-                          <LinkButton
-                            data-testid={`view-tally-report-${precinct.id}`}
-                            to={`${
-                              routes
-                                .election(electionId)
-                                .reports.byPrecinctResults(precinct.id).path
-                            }`}
-                          >
-                            View Tally Report
-                          </LinkButton>
-                        )}
-                      </TD>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </Table>
-            <div style={{ padding: '2rem 0' }} />
-          </div>
-        )}
-
-        {allEntries.length === 0 && (
-          <Callout color="neutral" icon="Info">
-            No machines have sent reports yet.
+      <MainContent
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+          minHeight: 0,
+        }}
+      >
+        {pollingPlaces.length === 0 && (
+          <Callout color="warning" icon="Warning">
+            Polling places are required to support live reports. Please
+            configure polling places for this election.
           </Callout>
         )}
+        {pollingPlaces.length > 0 && (
+          <React.Fragment>
+            <LiveReportsTabBar
+              electionId={electionId}
+              pollingPlaces={pollingPlaces}
+            />
+            <ContentLayout>
+              <MainColumn style={{ overflowY: 'auto' }}>
+                {groupsWithPlaces.map((group) => {
+                  const placesInGroup = pollingPlaces.filter(
+                    (p) => p.type === group
+                  );
+                  const counts = computeStatusCounts(
+                    placesInGroup,
+                    pollsStatusData.reportsByPollingPlace
+                  );
+                  return (
+                    <Panel key={group} data-testid={`overview-card-${group}`}>
+                      <PanelHeader>
+                        <H3 style={{ margin: 0 }}>
+                          {pollingPlaceTypeName(group)} • Polling Place Status
+                        </H3>
+                      </PanelHeader>
+                      <PanelBody style={{ padding: '1rem' }}>
+                        <SummaryStatsGrid
+                          statusCounts={counts}
+                          totalPlaces={placesInGroup.length}
+                          isAbsentee={group === 'absentee'}
+                          segmentKey={group}
+                        />
+                      </PanelBody>
+                    </Panel>
+                  );
+                })}
+              </MainColumn>
+
+              <ActivityColumn>
+                {allEntries.length > 0 && (
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: '0.5rem',
+                    }}
+                  >
+                    <LinkButton
+                      variant="primary"
+                      disabled={
+                        !allEntries.some(
+                          (entry) => entry.pollsTransitionType === 'close_polls'
+                        )
+                      }
+                      to={
+                        routes.election(electionId).reports.allPrecinctResults
+                          .path
+                      }
+                    >
+                      View Tally Reports
+                    </LinkButton>
+                    {canDeleteReports && (
+                      <Button
+                        color="danger"
+                        icon="Delete"
+                        onPress={() => setIsDeleteDataModalOpen(true)}
+                      >
+                        Delete All Reports
+                      </Button>
+                    )}
+                  </div>
+                )}
+                <ActivityLogPanel
+                  electionId={electionId}
+                  pollingPlaces={pollingPlaces}
+                />
+              </ActivityColumn>
+            </ContentLayout>
+          </React.Fragment>
+        )}
       </MainContent>
-      {isDeleteDataModalOpen && (
-        <Modal
-          content={
-            deleteQuickReportingResultsMutation.isLoading ? (
-              <Icons.Loading />
-            ) : (
-              <React.Fragment>
-                <H2 as="h1">Delete All Reports</H2>
-                <P>
-                  Are you sure you want to delete all reports for this election?
-                </P>
-              </React.Fragment>
-            )
-          }
-          actions={
-            deleteQuickReportingResultsMutation.isLoading ? (
-              <Button
-                onPress={() => setIsDeleteDataModalOpen(false)}
-                variant="secondary"
-              >
-                Cancel
-              </Button>
-            ) : (
-              <React.Fragment>
-                <Button
-                  onPress={() => deleteData()}
-                  variant="danger"
-                  data-testid="confirm-delete-data-button"
-                >
-                  Delete Reports
-                </Button>
-                <Button onPress={() => setIsDeleteDataModalOpen(false)}>
-                  Cancel
-                </Button>
-              </React.Fragment>
-            )
-          }
-          onOverlayClick={
-            deleteQuickReportingResultsMutation.isLoading
-              ? undefined
-              : () => setIsDeleteDataModalOpen(false)
-          }
+      <DeleteReportsModal
+        electionId={electionId}
+        isOpen={isDeleteDataModalOpen}
+        onClose={() => setIsDeleteDataModalOpen(false)}
+      />
+    </div>
+  );
+}
+
+interface LiveReportsGroupScreenProps {
+  electionId: string;
+}
+
+function LiveReportsGroupScreen({
+  electionId,
+}: LiveReportsGroupScreenProps): JSX.Element {
+  const { votingGroup } = useParams<{ votingGroup: PollingPlaceType }>();
+  const summaryQuery = getLiveReportsSummary.useQuery(electionId);
+  const theme = useTheme();
+  const { pollingPlaceIdsToAnimate } = useDataChangeAnimation(summaryQuery);
+
+  const pollsStatusData = summaryQuery.isSuccess
+    ? summaryQuery.data.isOk()
+      ? summaryQuery.data.ok()
+      : null
+    : null;
+
+  if (!summaryQuery.isSuccess) {
+    return <LoadingScreen />;
+  }
+
+  if (summaryQuery.data.isErr()) {
+    return <ErrorScreen error={summaryQuery.data.err()} />;
+  }
+
+  assert(pollsStatusData !== null);
+
+  const pollingPlaces: readonly PollingPlace[] =
+    pollsStatusData.election.pollingPlaces ?? [];
+  const filteredPollingPlaces = pollingPlaces.filter(
+    (p) => p.type === votingGroup
+  );
+
+  const allEntries = Object.values(
+    pollsStatusData.reportsByPollingPlace
+  ).flat();
+  const statusCounts = computeStatusCounts(
+    filteredPollingPlaces,
+    pollsStatusData.reportsByPollingPlace
+  );
+  const totalPlaces = filteredPollingPlaces.length;
+  const isAbsentee = votingGroup === 'absentee';
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        minHeight: 0,
+      }}
+    >
+      <Header>
+        <Row style={{ alignItems: 'center', gap: '1rem' }}>
+          <H1 style={{ paddingRight: '1rem', display: 'inline' }}>
+            Live Reports
+          </H1>
+        </Row>
+      </Header>
+      {allEntries.length > 0 && !pollsStatusData.isLive && <TestModeBanner />}
+      <MainContent
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+          minHeight: 0,
+        }}
+      >
+        <LiveReportsTabBar
+          electionId={electionId}
+          pollingPlaces={pollingPlaces}
         />
-      )}
+        <ContentLayout>
+          <MainColumn>
+            <Panel>
+              <PanelHeader>
+                <H3 style={{ margin: 0 }}>Polling Place Status</H3>
+              </PanelHeader>
+              <PanelBody style={{ padding: '1rem' }}>
+                <SummaryStatsGrid
+                  statusCounts={statusCounts}
+                  totalPlaces={totalPlaces}
+                  isAbsentee={isAbsentee}
+                  segmentKey={votingGroup}
+                />
+              </PanelBody>
+            </Panel>
+
+            <ScrollableTableContainer>
+              <StatusTable>
+                <thead>
+                  <tr>
+                    <TH style={{ minWidth: '200px' }}>Polling Place</TH>
+                    <TH style={{ minWidth: '120px' }}>Status</TH>
+                    <TH style={{ minWidth: '150px' }}>Machines</TH>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredPollingPlaces.map((place) => {
+                    const reportsForPlace =
+                      pollsStatusData.reportsByPollingPlace[place.id] || [];
+                    const overallStatus =
+                      getPollingPlaceOverallStatus(reportsForPlace);
+                    const isHighlighted = pollingPlaceIdsToAnimate.includes(
+                      place.id
+                    );
+                    return (
+                      <tr
+                        key={place.id}
+                        data-testid={`polling-place-row-${place.id}`}
+                        data-highlighted={isHighlighted ? 'true' : 'false'}
+                        style={{
+                          height: '3rem',
+                          transition: 'background-color 0.5s ease-in-out',
+                          backgroundColor: isHighlighted
+                            ? theme.colors.inversePrimary
+                            : 'transparent',
+                        }}
+                      >
+                        <TD>{place.name}</TD>
+                        <TD>
+                          <span>
+                            {getOverallStatusIcon(overallStatus)}{' '}
+                            {getOverallStatusLabel(overallStatus)}
+                          </span>
+                        </TD>
+                        <TD>{getScannerDetailsText(reportsForPlace)}</TD>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </StatusTable>
+            </ScrollableTableContainer>
+          </MainColumn>
+
+          <ActivityColumn>
+            <ActivityLogPanel
+              electionId={electionId}
+              votingGroup={votingGroup}
+              pollingPlaces={pollingPlaces}
+            />
+          </ActivityColumn>
+        </ContentLayout>
+      </MainContent>
     </div>
   );
 }
@@ -558,10 +984,13 @@ interface ResultsTabProps {
   electionId: string;
 }
 
+const ALL_PRECINCTS_VALUE = '';
+
 function LiveReportsResultsScreen({
   electionId,
 }: ResultsTabProps): JSX.Element {
   const { precinctId } = useParams<{ precinctId: string }>();
+  const history = useHistory();
   const precinctSelection: PrecinctSelection = precinctId
     ? { kind: 'SinglePrecinct', precinctId }
     : { kind: 'AllPrecincts' };
@@ -570,8 +999,17 @@ function LiveReportsResultsScreen({
     precinctSelection
   );
 
+  function handlePrecinctChange(value?: string): void {
+    if (!value || value === ALL_PRECINCTS_VALUE) {
+      history.push(routes.election(electionId).reports.allPrecinctResults.path);
+    } else {
+      history.push(
+        routes.election(electionId).reports.byPrecinctResults(value).path
+      );
+    }
+  }
+
   if (!getLiveResultsReportsQuery.isSuccess) {
-    // We don't know test/live mode yet or have the election data yet so show a generic title.
     const reportTitle = 'Unofficial Tally Report';
     return (
       <React.Fragment>
@@ -608,13 +1046,7 @@ function LiveReportsResultsScreen({
   >((acc, party) => ({ ...acc, [party.id]: party.fullName }), {});
   const testLivePrefix = aggregatedResults.isLive ? '' : 'Test ';
 
-  const reportTitle =
-    precinctSelection.kind === 'AllPrecincts'
-      ? `Unofficial ${testLivePrefix}Tally Report`
-      : `Unofficial ${testLivePrefix}${getPrecinctSelectionName(
-          aggregatedResults.election.precincts,
-          precinctSelection
-        )} Tally Report`;
+  const reportTitle = `Unofficial ${testLivePrefix}Tally Report`;
 
   return (
     <React.Fragment>
@@ -623,7 +1055,23 @@ function LiveReportsResultsScreen({
           currentTitle={reportTitle}
           parentRoutes={[routes.election(electionId).reports.root]}
         />
-        <H1>{reportTitle}</H1>
+        <Row style={{ alignItems: 'center', gap: '1rem' }}>
+          <H1>{reportTitle}</H1>
+          <SearchSelect
+            id="precinct-select"
+            aria-label="Select precinct"
+            options={[
+              { value: ALL_PRECINCTS_VALUE, label: 'All Precincts' },
+              ...aggregatedResults.election.precincts.map((precinct) => ({
+                value: precinct.id,
+                label: precinct.name,
+              })),
+            ]}
+            value={precinctId ?? ALL_PRECINCTS_VALUE}
+            onChange={handlePrecinctChange}
+            style={{ minWidth: '14rem' }}
+          />
+        </Row>
       </Header>
       <MainContent>
         <div>
@@ -722,8 +1170,16 @@ export function LiveReportsScreen(): JSX.Element | null {
         >
           <LiveReportsResultsScreen electionId={electionId} />
         </Route>
+        <Route
+          path={`${
+            routes.election(':electionId').reports.votingGroup(':votingGroup')
+              .path
+          }`}
+        >
+          <LiveReportsGroupScreen electionId={electionId} />
+        </Route>
         <Route path={routes.election(':electionId').reports.root.path}>
-          <LiveReportsSummaryScreen electionId={electionId} />
+          <LiveReportsOverviewScreen electionId={electionId} />
         </Route>
       </Switch>
     </ElectionNavScreen>

--- a/apps/design/frontend/src/live_reports_screen.tsx
+++ b/apps/design/frontend/src/live_reports_screen.tsx
@@ -297,10 +297,6 @@ const ActivityEntry = styled.div`
   padding: 0.75rem;
   border-bottom: ${(p) =>
     `${p.theme.sizes.bordersRem.hairline}rem solid ${p.theme.colors.outline}`};
-
-  &:last-child {
-    border-bottom: none;
-  }
 `;
 
 const ProgressBar = styled.div`

--- a/apps/design/frontend/src/routes.ts
+++ b/apps/design/frontend/src/routes.ts
@@ -170,6 +170,10 @@ export const routes = {
           title: 'Live Reports',
           path: `${root}/reports`,
         },
+        votingGroup: (votingGroup: string) => ({
+          title: 'Voting Group',
+          path: `${root}/reports/group/${votingGroup}`,
+        }),
         allPrecinctResults: {
           title: 'All Precincts Tally Report',
           path: `${root}/reports/tally-all-precincts`,

--- a/apps/design/frontend/tsconfig.json
+++ b/apps/design/frontend/tsconfig.json
@@ -12,8 +12,7 @@
     "noFallthroughCasesInSwitch": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "noUncheckedIndexedAccess": false,
-    "types": ["@testing-library/jest-dom"]
+    "noUncheckedIndexedAccess": false
   },
   "include": ["src", "test"],
   "references": [

--- a/apps/design/frontend/tsconfig.json
+++ b/apps/design/frontend/tsconfig.json
@@ -12,7 +12,8 @@
     "noFallthroughCasesInSwitch": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "noUncheckedIndexedAccess": false
+    "noUncheckedIndexedAccess": false,
+    "types": ["@testing-library/jest-dom"]
   },
   "include": ["src", "test"],
   "references": [


### PR DESCRIPTION
## Overview
Revamps live reports UI to be centered around polling places with tabs by polling place group and an added activity log. 


## Demo Video or Screenshot

https://github.com/user-attachments/assets/4ec6b106-e94b-4b62-8033-9318d273bf64


## Testing Plan
See above, tested that a live report coming in will switch everything to "live" from test mode. Tested tally report content is displayed correctly. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
