### PR TITLE
VxMark: Add party selection screen for open primaries

### DIFF
--- a/apps/mark/frontend/src/app_open_primary.test.tsx
+++ b/apps/mark/frontend/src/app_open_primary.test.tsx
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { singlePrecinctSelectionFor } from '@votingworks/utils';
+import { electionOpenPrimaryFixtures } from '@votingworks/fixtures';
+import userEvent from '@testing-library/user-event';
+import { BallotStyleId, CandidateContest } from '@votingworks/types';
+import { find } from '@votingworks/basics';
+import { hasTextAcrossElements } from '@votingworks/test-utils';
+import { render, screen } from '../test/react_testing_library';
+
+import { App } from './app';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+const BALLOT_STYLE_ID = 'ballot-style-1' as BallotStyleId;
+const PRECINCT_ID = 'precinct-1';
+const PRECINCT_NAME = 'Precinct 1';
+const PRECINCT_SELECTION = singlePrecinctSelectionFor(PRECINCT_ID);
+const electionDefinition = electionOpenPrimaryFixtures.readElectionDefinition();
+const { election } = electionDefinition;
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  apiMock = createApiMock();
+  apiMock.expectGetMachineConfig();
+  apiMock.expectGetSystemSettings();
+  apiMock.expectGetElectionRecord(electionDefinition);
+  apiMock.expectGetElectionState({
+    precinctSelection: PRECINCT_SELECTION,
+    pollsState: 'polls_open',
+  });
+});
+
+afterEach(() => {
+  apiMock.mockApiClient.assertComplete();
+});
+
+test('poll worker activates session, voter picks party and walks through ballot', async () => {
+  render(<App apiClient={apiMock.mockApiClient} />);
+  await screen.findByText('Insert Card');
+
+  // Poll worker logs in to activate a cardless voter session.
+  apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
+  await screen.findByText('Start Voting Session:');
+
+  apiMock.mockApiClient.startCardlessVoterSession
+    .expectCallWith({
+      ballotStyleId: BALLOT_STYLE_ID,
+      precinctId: PRECINCT_ID,
+    })
+    .resolves();
+  userEvent.click(screen.getButton(`Start Voting Session: ${PRECINCT_NAME}`));
+  apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
+    cardlessVoterUserParams: {
+      ballotStyleId: BALLOT_STYLE_ID,
+      precinctId: PRECINCT_ID,
+    },
+  });
+
+  // After activation the poll worker sees the BallotStyleLabel. For open
+  // primaries it shows just the precinct — no party since the ballot style
+  // has none.
+  await screen.findByText('Remove Card to Begin Voting Session');
+  await screen.findByText(
+    hasTextAcrossElements(`Ballot Style: ${PRECINCT_NAME}`)
+  );
+  expect(screen.queryByText(/Precinct:/)).toBeNull();
+
+  // Poll worker removes card; voter takes over.
+  apiMock.setAuthStatusCardlessVoterLoggedIn({
+    ballotStyleId: BALLOT_STYLE_ID,
+    precinctId: PRECINCT_ID,
+  });
+  await screen.findByText('Start Voting');
+
+  // Start screen -> party selection
+  userEvent.click(screen.getByText('Start Voting'));
+  await screen.findByRole('heading', { name: 'Choose Your Party' });
+
+  // Next disabled until a party is selected
+  expect(screen.getButton(/next/i)).toBeDisabled();
+
+  // Select Democratic
+  userEvent.click(screen.getButton('Democratic Party'));
+  expect(screen.getButton(/next/i)).toBeEnabled();
+
+  // Advance to the first contest — only Democratic + nonpartisan contests appear.
+  userEvent.click(screen.getButton(/next/i));
+  await screen.findByRole('heading', { name: 'Governor' });
+
+  // Walk through all contests to review. The voter should see exactly the
+  // Democratic partisan contests + all nonpartisan contests for
+  // ballot-style-1 — and none of the Republican or Libertarian partisan
+  // contests.
+  const expectedContestTitles = [
+    'Governor',
+    'Secretary of State',
+    'Attorney General',
+    'Representative in Congress',
+    'State Representative',
+    'County Commissioner',
+    'Delegate to County Convention',
+    'Circuit Court Judge',
+    'Probate Court Judge',
+    'Board of Education Member',
+    'County Road Millage Renewal',
+    'Public Safety Millage',
+    'Library Millage Renewal',
+  ];
+  for (const title of expectedContestTitles) {
+    await screen.findByRole('heading', { name: title });
+    userEvent.click(screen.getButton(/next/i));
+  }
+  await screen.findByRole('heading', { name: /review your votes/i });
+});
+
+test('switching party clears votes from the previous party', async () => {
+  render(<App apiClient={apiMock.mockApiClient} />);
+  await screen.findByText('Insert Card');
+
+  apiMock.setAuthStatusCardlessVoterLoggedIn({
+    ballotStyleId: BALLOT_STYLE_ID,
+    precinctId: PRECINCT_ID,
+  });
+  await screen.findByText('Start Voting');
+
+  // Pick Democratic and vote for a Democratic Governor candidate
+  userEvent.click(screen.getByText('Start Voting'));
+  await screen.findByRole('heading', { name: 'Choose Your Party' });
+  userEvent.click(screen.getButton('Democratic Party'));
+  userEvent.click(screen.getButton(/next/i));
+  await screen.findByRole('heading', { name: 'Governor' });
+
+  const demGovernorContest = find(
+    election.contests,
+    (c): c is CandidateContest => c.id === 'governor-democratic'
+  );
+  const demGovernorCandidate = demGovernorContest.candidates[0];
+  userEvent.click(screen.getByText(demGovernorCandidate.name));
+
+  // Back to party selection, switch to Republican (clears votes), then back
+  // to Democratic. The Democratic vote from earlier should be gone.
+  userEvent.click(screen.getButton(/back/i));
+  await screen.findByRole('heading', { name: 'Choose Your Party' });
+  userEvent.click(screen.getButton('Republican Party'));
+  userEvent.click(screen.getButton(/next/i));
+  await screen.findByRole('heading', { name: 'Governor' });
+
+  // The Republican Governor candidates are shown, not the Democratic ones.
+  const repGovernorContest = find(
+    election.contests,
+    (c): c is CandidateContest => c.id === 'governor-republican'
+  );
+  screen.getByText(repGovernorContest.candidates[0].name);
+  expect(screen.queryByText(demGovernorCandidate.name)).toBeNull();
+
+  userEvent.click(screen.getButton(/back/i));
+  await screen.findByRole('heading', { name: 'Choose Your Party' });
+  userEvent.click(screen.getButton('Democratic Party'));
+  userEvent.click(screen.getButton(/next/i));
+  await screen.findByRole('heading', { name: 'Governor' });
+
+  // Jump to the review screen to inspect the Democratic Governor contest
+  userEvent.click(screen.getButton(/view all/i));
+  await screen.findByRole('heading', { name: /review your votes/i });
+
+  // The Democratic Governor candidate the voter previously selected should
+  // no longer appear on the review — vote was cleared by the party switch.
+  expect(screen.queryByText(demGovernorCandidate.name)).toBeNull();
+});

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -5,6 +5,8 @@ import {
   getBallotStyle,
   getContests,
   ContestId,
+  isOpenPrimary,
+  PartyId,
   PrecinctId,
   BallotStyleId,
   InsertedSmartCardAuth,
@@ -79,6 +81,8 @@ import { InternalConnectionProblemScreen } from './pages/internal_connection_pro
 
 export interface VotingState {
   votes?: VotesDict;
+  // Only set for open primary elections; see BallotContextInterface.
+  selectedPartyId?: PartyId;
   showPostVotingInstructions?: boolean;
   showingPatCalibration?: boolean;
   isPatCalibrationComplete?: boolean;
@@ -96,6 +100,7 @@ export const initialElectionState: Readonly<ElectionState> = {
 
 const initialVotingState: Readonly<VotingState> = {
   votes: undefined,
+  selectedPartyId: undefined,
   showPostVotingInstructions: undefined,
   showingPatCalibration: undefined,
   isPatCalibrationComplete: undefined,
@@ -106,6 +111,7 @@ type VotingAction =
   | { type: 'unconfigure' }
   | { type: 'updateVote'; contestId: ContestId; vote: OptionalVote }
   | { type: 'resetBallot'; showPostVotingInstructions?: boolean }
+  | { type: 'selectParty'; partyId: PartyId }
   | { type: 'showPatCalibration' }
   | { type: 'completePatCalibration' };
 
@@ -134,6 +140,13 @@ function votingStateReducer(
         ...initialVotingState,
         showPostVotingInstructions: action.showPostVotingInstructions,
       };
+    case 'selectParty':
+      return {
+        ...state,
+        selectedPartyId: action.partyId,
+        // Clear votes on party change to prevent crossover voting
+        votes: {},
+      };
     case 'showPatCalibration':
       return {
         ...state,
@@ -161,6 +174,7 @@ export function AppRoot(): JSX.Element | null {
   const {
     showPostVotingInstructions,
     votes,
+    selectedPartyId,
     showingPatCalibration,
     isPatCalibrationComplete,
   } = votingState;
@@ -245,7 +259,21 @@ export function AppRoot(): JSX.Element | null {
             ballotStyle,
           })
         )
+          // For open primaries, show only partisan contests for the party
+          // selected by the user + nonpartisan contests.
+          .filter((contest) => {
+            if (isOpenPrimary(electionDefinition.election) && selectedPartyId) {
+              return contest.type === 'candidate'
+                ? !contest.partyId || contest.partyId === selectedPartyId
+                : true;
+            }
+            return true;
+          })
       : [];
+
+  const selectParty = useCallback((partyId: PartyId) => {
+    dispatchVotingState({ type: 'selectParty', partyId });
+  }, []);
 
   const { onSessionEnd } = useSessionSettingsManager({ authStatus });
 
@@ -614,6 +642,8 @@ export function AppRoot(): JSX.Element | null {
               isLiveMode: !isTestMode,
               endVoterSession,
               resetBallot,
+              selectedPartyId,
+              selectParty,
               updateVote,
               votes: votes ?? blankBallotVotes,
             }}

--- a/apps/mark/frontend/src/components/ballot.tsx
+++ b/apps/mark/frontend/src/components/ballot.tsx
@@ -10,6 +10,7 @@ import { IDLE_TIMEOUT_SECONDS } from '@votingworks/mark-flow-ui';
 import { ContestScreen } from '../pages/contest_screen';
 import { IdlePage } from '../pages/idle_page';
 import { NotFoundPage } from '../pages/not_found_page';
+import { PartySelectionScreen } from '../pages/party_selection_screen';
 import { PrintPage } from '../pages/print_page';
 import { ReviewScreen } from '../pages/review_screen';
 import { StartScreen } from '../pages/start_screen';
@@ -53,6 +54,9 @@ export function Ballot(): JSX.Element {
         <Switch>
           <Route path="/" exact>
             <StartScreen />
+          </Route>
+          <Route path="/party-selection">
+            <PartySelectionScreen />
           </Route>
           <Route path="/contests/:contestNumber">
             <ContestScreen />

--- a/apps/mark/frontend/src/config/types.ts
+++ b/apps/mark/frontend/src/config/types.ts
@@ -1,6 +1,7 @@
 import {
   BallotStyleId,
   ElectionDefinition,
+  PartyId,
   PrecinctId,
   VotesDict,
 } from '@votingworks/types';
@@ -21,6 +22,12 @@ export interface BallotContextInterface {
   endVoterSession: () => Promise<void>;
   precinctId?: PrecinctId;
   resetBallot: (showPostVotingInstructions?: boolean) => void;
+  // `selectedPartyId` and `selectParty` apply only to open primaries, where the
+  // voter picks a party at the start of their session. In closed primaries the
+  // party is determined by the ballot style; in general elections there is no
+  // party. `selectedPartyId` is undefined until the voter makes a selection.
+  selectedPartyId?: PartyId;
+  selectParty: (partyId: PartyId) => void;
   updateVote: UpdateVoteFunction;
   votes: VotesDict;
 }

--- a/apps/mark/frontend/src/contexts/ballot_context.ts
+++ b/apps/mark/frontend/src/contexts/ballot_context.ts
@@ -13,6 +13,7 @@ const ballot: BallotContextInterface = {
   isLiveMode: false,
   endVoterSession: () => Promise.resolve(),
   resetBallot: () => undefined,
+  selectParty: () => undefined,
   updateVote: () => undefined,
   votes: {},
 };

--- a/apps/mark/frontend/src/pages/contest_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/contest_screen.test.tsx
@@ -1,9 +1,13 @@
 import { expect, test } from 'vitest';
 import { Route } from 'react-router-dom';
-import { readElectionGeneral } from '@votingworks/fixtures';
+import {
+  electionOpenPrimaryFixtures,
+  readElectionGeneral,
+} from '@votingworks/fixtures';
 import { createMemoryHistory } from 'history';
 import { MARK_FLOW_UI_VOTER_SCREEN_TEST_ID } from '@votingworks/mark-flow-ui';
 import userEvent from '@testing-library/user-event';
+import { BallotStyleId, PartyId } from '@votingworks/types';
 import { screen } from '../../test/react_testing_library';
 import { mockMachineConfig } from '../../test/helpers/mock_machine_config';
 
@@ -121,4 +125,43 @@ test('renders as voter screen', () => {
   );
 
   screen.getByTestId(MARK_FLOW_UI_VOTER_SCREEN_TEST_ID);
+});
+
+test('Back from first contest goes to start screen when no party selected', () => {
+  const history = createMemoryHistory({ initialEntries: ['/contests/0'] });
+
+  renderWithBallotContext(
+    <Route path="/contests/:contestNumber" component={ContestScreen} />,
+    {
+      history,
+      route: '/contests/0',
+      precinctId: electionGeneral.precincts[0].id,
+      ballotStyleId: electionGeneral.ballotStyles[0].id,
+    }
+  );
+
+  userEvent.click(screen.getButton(/back/i));
+  expect(history.location.pathname).toEqual('/');
+});
+
+test('Back from first contest goes to party selection when a party is selected', () => {
+  const electionDefinition =
+    electionOpenPrimaryFixtures.readElectionDefinition();
+  const history = createMemoryHistory({ initialEntries: ['/contests/0'] });
+
+  renderWithBallotContext(
+    <Route path="/contests/:contestNumber" component={ContestScreen} />,
+    {
+      electionDefinition,
+      contests: electionDefinition.election.contests,
+      history,
+      route: '/contests/0',
+      precinctId: 'precinct-1',
+      ballotStyleId: 'ballot-style-1' as BallotStyleId,
+      selectedPartyId: 'democratic-party' as PartyId,
+    }
+  );
+
+  userEvent.click(screen.getButton(/back/i));
+  expect(history.location.pathname).toEqual('/party-selection');
 });

--- a/apps/mark/frontend/src/pages/contest_screen.tsx
+++ b/apps/mark/frontend/src/pages/contest_screen.tsx
@@ -18,21 +18,25 @@ function getReviewPageUrl(contestId?: ContestId) {
   return '/review';
 }
 
-function getStartPageUrl() {
-  return '/';
-}
-
 export function ContestScreen(): JSX.Element {
   const {
     ballotStyleId,
     contests,
     electionDefinition,
     precinctId,
+    selectedPartyId,
     updateVote,
     votes,
   } = React.useContext(BallotContext);
 
   const isPatDeviceConnected = useIsPatDeviceConnected();
+
+  // In open primaries, Back from the first contest returns to party selection so the
+  // voter can change their party. `selectedPartyId` being set implies the
+  // voter came from the party selection screen.
+  function getStartPageUrl() {
+    return selectedPartyId ? '/party-selection' : '/';
+  }
 
   return (
     <ContestPage

--- a/apps/mark/frontend/src/pages/party_selection_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/party_selection_screen.test.tsx
@@ -1,0 +1,81 @@
+import { expect, test, vi } from 'vitest';
+import { Route } from 'react-router-dom';
+import { electionOpenPrimaryFixtures } from '@votingworks/fixtures';
+import { createMemoryHistory } from 'history';
+import { MARK_FLOW_UI_VOTER_SCREEN_TEST_ID } from '@votingworks/mark-flow-ui';
+import userEvent from '@testing-library/user-event';
+import { PartyId } from '@votingworks/types';
+import { screen } from '../../test/react_testing_library';
+import { render } from '../../test/test_utils';
+import { PartySelectionScreen } from './party_selection_screen';
+
+const electionDefinition = electionOpenPrimaryFixtures.readElectionDefinition();
+
+test('renders as voter screen with party options', () => {
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    route: '/party-selection',
+  });
+
+  screen.getByTestId(MARK_FLOW_UI_VOTER_SCREEN_TEST_ID);
+  screen.getByRole('heading', { name: 'Choose Your Party' });
+  screen.getByRole('radio', { name: 'Democratic Party' });
+  screen.getByRole('radio', { name: 'Republican Party' });
+  screen.getByRole('radio', { name: 'Libertarian Party' });
+});
+
+test('Next button disabled until a party is selected', () => {
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    route: '/party-selection',
+  });
+
+  expect(screen.getButton(/next/i)).toBeDisabled();
+});
+
+test('Next button enabled once a party is selected', () => {
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    route: '/party-selection',
+    selectedPartyId: 'democratic-party' as PartyId,
+  });
+
+  expect(screen.getButton(/next/i)).toBeEnabled();
+});
+
+test('selecting a party calls selectParty with the party id', () => {
+  const selectParty = vi.fn();
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    route: '/party-selection',
+    selectParty,
+  });
+
+  userEvent.click(screen.getByRole('radio', { name: 'Republican Party' }));
+  expect(selectParty).toHaveBeenCalledWith('republican-party');
+});
+
+test('Back button navigates to start screen', () => {
+  const history = createMemoryHistory({ initialEntries: ['/party-selection'] });
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    history,
+    route: '/party-selection',
+  });
+
+  userEvent.click(screen.getButton(/back/i));
+  expect(history.location.pathname).toEqual('/');
+});
+
+test('Next button navigates to first contest when a party is selected', () => {
+  const history = createMemoryHistory({ initialEntries: ['/party-selection'] });
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    history,
+    route: '/party-selection',
+    selectedPartyId: 'democratic-party' as PartyId,
+  });
+
+  userEvent.click(screen.getButton(/next/i));
+  expect(history.location.pathname).toEqual('/contests/0');
+});

--- a/apps/mark/frontend/src/pages/party_selection_screen.tsx
+++ b/apps/mark/frontend/src/pages/party_selection_screen.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import styled from 'styled-components';
+import { assertDefined } from '@votingworks/basics';
+import { PartyId } from '@votingworks/types';
+import {
+  Caption,
+  H2,
+  LinkButton,
+  PageNavigationButtonId,
+  RadioGroup,
+  WithScrollButtons,
+} from '@votingworks/ui';
+import { VoterScreen } from '@votingworks/mark-flow-ui';
+import { BallotContext } from '../contexts/ballot_context';
+
+const Header = styled.div`
+  padding: 0.5rem;
+`;
+
+const OptionRadioGroup = styled(RadioGroup<PartyId>)`
+  button {
+    font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
+  }
+`;
+
+export function PartySelectionScreen(): JSX.Element {
+  const { electionDefinition, selectParty, selectedPartyId } =
+    React.useContext(BallotContext);
+  const { election } = assertDefined(electionDefinition);
+
+  return (
+    <VoterScreen
+      actionButtons={
+        <React.Fragment>
+          <LinkButton
+            icon="Previous"
+            id={PageNavigationButtonId.PREVIOUS}
+            to="/"
+          >
+            Back
+          </LinkButton>
+          <LinkButton
+            rightIcon="Next"
+            id={PageNavigationButtonId.NEXT}
+            variant={selectedPartyId ? 'primary' : 'neutral'}
+            to={selectedPartyId ? '/contests/0' : undefined}
+            disabled={!selectedPartyId}
+          >
+            Next
+          </LinkButton>
+        </React.Fragment>
+      }
+    >
+      <Header>
+        <H2>Choose Your Party</H2>
+        <Caption>
+          You will be able to vote for your party&apos;s contests and any
+          nonpartisan contests.
+        </Caption>
+      </Header>
+      <WithScrollButtons>
+        <OptionRadioGroup
+          label="Party"
+          hideLabel
+          options={election.parties.map((party) => ({
+            value: party.id,
+            label: party.fullName,
+          }))}
+          value={selectedPartyId}
+          onChange={(partyId) => selectParty(partyId)}
+        />
+      </WithScrollButtons>
+    </VoterScreen>
+  );
+}

--- a/apps/mark/frontend/src/pages/start_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/start_screen.test.tsx
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest';
 import { Route } from 'react-router-dom';
 import {
+  electionOpenPrimaryFixtures,
   readElectionGeneralDefinition,
   readElectionTwoPartyPrimaryDefinition,
 } from '@votingworks/fixtures';
@@ -8,6 +9,7 @@ import { createMemoryHistory } from 'history';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { MARK_FLOW_UI_VOTER_SCREEN_TEST_ID } from '@votingworks/mark-flow-ui';
 import { BallotStyleId } from '@votingworks/types';
+import userEvent from '@testing-library/user-event';
 import { screen } from '../../test/react_testing_library';
 import { render } from '../../test/test_utils';
 import { StartScreen } from './start_screen';
@@ -48,4 +50,37 @@ test('renders as voter screen', () => {
   });
 
   screen.getByTestId(MARK_FLOW_UI_VOTER_SCREEN_TEST_ID);
+});
+
+test('Start navigates to first contest for non-open-primary elections', () => {
+  const electionDefinition = readElectionGeneralDefinition();
+  const history = createMemoryHistory({ initialEntries: ['/'] });
+
+  render(<Route path="/" component={StartScreen} />, {
+    ballotStyleId: '12' as BallotStyleId,
+    electionDefinition,
+    history,
+    precinctId: '23',
+    route: '/',
+  });
+
+  userEvent.click(screen.getButton(/start voting/i));
+  expect(history.location.pathname).toEqual('/contests/0');
+});
+
+test('Start navigates to party selection for open primary elections', () => {
+  const electionDefinition =
+    electionOpenPrimaryFixtures.readElectionDefinition();
+  const history = createMemoryHistory({ initialEntries: ['/'] });
+
+  render(<Route path="/" component={StartScreen} />, {
+    ballotStyleId: 'ballot-style-1' as BallotStyleId,
+    electionDefinition,
+    history,
+    precinctId: 'precinct-1',
+    route: '/',
+  });
+
+  userEvent.click(screen.getButton(/start voting/i));
+  expect(history.location.pathname).toEqual('/party-selection');
 });

--- a/apps/mark/frontend/src/pages/start_screen.tsx
+++ b/apps/mark/frontend/src/pages/start_screen.tsx
@@ -2,6 +2,8 @@ import { StartPage } from '@votingworks/mark-flow-ui';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { appStrings } from '@votingworks/ui';
+import { isOpenPrimary } from '@votingworks/types';
+import { assertDefined } from '@votingworks/basics';
 import { BallotContext } from '../contexts/ballot_context';
 
 export function StartScreen(): JSX.Element {
@@ -10,7 +12,11 @@ export function StartScreen(): JSX.Element {
     React.useContext(BallotContext);
 
   function onStart() {
-    history.push('/contests/0');
+    if (isOpenPrimary(assertDefined(electionDefinition).election)) {
+      history.push('/party-selection');
+    } else {
+      history.push('/contests/0');
+    }
   }
 
   return (

--- a/apps/mark/frontend/test/test_utils.tsx
+++ b/apps/mark/frontend/test/test_utils.tsx
@@ -6,6 +6,7 @@ import {
   BallotStyleId,
   Contests,
   ElectionDefinition,
+  PartyId,
   PrecinctId,
   VotesDict,
 } from '@votingworks/types';
@@ -30,6 +31,8 @@ export function render(
     machineConfig = mockMachineConfig(),
     precinctId,
     resetBallot = vi.fn(),
+    selectedPartyId,
+    selectParty = vi.fn(),
     updateVote = vi.fn(),
     votes = {},
   }: {
@@ -44,6 +47,8 @@ export function render(
     machineConfig?: MachineConfig;
     precinctId?: PrecinctId;
     resetBallot?(): void;
+    selectedPartyId?: PartyId;
+    selectParty?(partyId: PartyId): void;
     setUserSettings?(): void;
     updateVote?(): void;
     votes?: VotesDict;
@@ -62,6 +67,8 @@ export function render(
           endVoterSession,
           precinctId,
           resetBallot,
+          selectedPartyId,
+          selectParty,
           updateVote,
           votes,
         }}

--- a/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.test.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.test.tsx
@@ -1,9 +1,15 @@
 import { describe, expect, test, vi } from 'vitest';
 import {
+  electionOpenPrimaryFixtures,
   electionPrimaryPrecinctSplitsFixtures,
   readElectionGeneralDefinition,
 } from '@votingworks/fixtures';
-import { hasSplits, Precinct, PrecinctOrSplit } from '@votingworks/types';
+import {
+  BallotStyleId,
+  hasSplits,
+  Precinct,
+  PrecinctOrSplit,
+} from '@votingworks/types';
 
 import userEvent from '@testing-library/user-event';
 
@@ -176,6 +182,51 @@ describe('primary election', () => {
     userEvent.click(screen.getButton('Fish'));
     expect(onSelect).toHaveBeenCalledOnce();
     expect(onSelect).toHaveBeenLastCalledWith(p4.id, '4-F_en');
+  });
+});
+
+describe('open primary election', () => {
+  const electionDefinitionOpenPrimary =
+    electionOpenPrimaryFixtures.readElectionDefinition();
+  const { election } = electionDefinitionOpenPrimary;
+
+  test('single precinct configuration', () => {
+    const precinct = election.precincts[0];
+    const onSelect = vi.fn();
+
+    renderSelect({
+      election,
+      onSelect,
+      configuredPrecinctsAndSplits: toPrecinctsOrSplitList([precinct]),
+    });
+
+    // No party picker — pressing the precinct button immediately selects the
+    // precinct's single (partyless) ballot style.
+    userEvent.click(screen.getButton(`Start Voting Session: ${precinct.name}`));
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledWith(
+      precinct.id,
+      'ballot-style-1' as BallotStyleId
+    );
+  });
+
+  test('multiple precincts configuration', () => {
+    const [p1, p2] = election.precincts;
+    const onSelect = vi.fn();
+
+    renderSelect({
+      election,
+      onSelect,
+      configuredPrecinctsAndSplits: toPrecinctsOrSplitList([p1, p2]),
+    });
+
+    userEvent.click(screen.getByText('Select ballot style…'));
+    userEvent.click(screen.getByText(p2.name));
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenLastCalledWith(
+      p2.id,
+      'ballot-style-2' as BallotStyleId
+    );
   });
 });
 

--- a/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.tsx
@@ -1,11 +1,7 @@
-import {
-  assert,
-  assertDefined,
-  find,
-  throwIllegalValue,
-} from '@votingworks/basics';
+import { assert, assertDefined, find } from '@votingworks/basics';
 import {
   getPartyForBallotStyle,
+  isOpenPrimary,
   type BallotStyleId,
   type Election,
   type PrecinctId,
@@ -43,45 +39,90 @@ export function BallotStyleSelect(props: BallotStyleSelectProps): JSX.Element {
     PrecinctId | PrecinctSplitId
   >();
 
-  switch (election.type) {
-    case 'general': {
-      // eslint-disable-next-line no-inner-declarations
-      function getBallotStyleForPrecinctOrSplit(
-        precinctOrSplit: PrecinctOrSplit
-      ) {
-        const ballotStyleGroups = getBallotStyleGroupsForPrecinctOrSplit({
-          election,
-          precinctOrSplit,
-        });
-        assert(
-          ballotStyleGroups.length === 1,
-          'General elections should have exactly one ballot style group per precinct or split'
-        );
-        return ballotStyleGroups[0].defaultLanguageBallotStyle;
-      }
+  function getBallotStyleForPrecinctOrSplit(precinctOrSplit: PrecinctOrSplit) {
+    const ballotStyleGroups = getBallotStyleGroupsForPrecinctOrSplit({
+      election,
+      precinctOrSplit,
+    });
+    assert(
+      ballotStyleGroups.length === 1,
+      'Expected exactly one ballot style group per precinct or split'
+    );
+    return ballotStyleGroups[0].defaultLanguageBallotStyle;
+  }
 
-      if (configuredPrecinctsAndSplits.length === 1) {
-        const [precinctOrSplit] = configuredPrecinctsAndSplits;
-        const { precinct } = precinctOrSplit;
-        return (
-          <Button
-            onPress={() =>
-              onSelect(
-                precinct.id,
-                getBallotStyleForPrecinctOrSplit(precinctOrSplit).id
-              )
-            }
-            rightIcon="Next"
-            disabled={disabled}
-          >
-            Start Voting Session: {electionStrings.precinctName(precinct)}
-          </Button>
-        );
-      }
+  if (election.type === 'general' || isOpenPrimary(election)) {
+    if (configuredPrecinctsAndSplits.length === 1) {
+      const [precinctOrSplit] = configuredPrecinctsAndSplits;
+      const { precinct } = precinctOrSplit;
       return (
+        <Button
+          onPress={() =>
+            onSelect(
+              precinct.id,
+              getBallotStyleForPrecinctOrSplit(precinctOrSplit).id
+            )
+          }
+          rightIcon="Next"
+          disabled={disabled}
+        >
+          Start Voting Session: {electionStrings.precinctName(precinct)}
+        </Button>
+      );
+    }
+    return (
+      <SearchSelect
+        aria-label="Select ballot precinct"
+        placeholder="Select ballot style…"
+        options={configuredPrecinctsAndSplits.map((precinctOrSplit) =>
+          precinctOrSplit.split
+            ? {
+                label: precinctOrSplit.split.name,
+                value: precinctOrSplit.split.id,
+              }
+            : {
+                label: precinctOrSplit.precinct.name,
+                value: precinctOrSplit.precinct.id,
+              }
+        )}
+        value=""
+        onChange={(value) => {
+          const precinctOrSplit = find(
+            configuredPrecinctsAndSplits,
+            // eslint-disable-next-line @typescript-eslint/no-shadow
+            (precinctOrSplit) =>
+              value ===
+              (precinctOrSplit.split?.id ?? precinctOrSplit.precinct.id)
+          );
+          onSelect(
+            precinctOrSplit.precinct.id,
+            getBallotStyleForPrecinctOrSplit(precinctOrSplit).id
+          );
+        }}
+        style={{ width: '100%' }}
+        disabled={disabled}
+      />
+    );
+  }
+
+  assert(election.type === 'primary');
+
+  const selectedPrecinctOrSplit =
+    configuredPrecinctsAndSplits.length === 1
+      ? configuredPrecinctsAndSplits[0]
+      : selectedPrecinctOrSplitId &&
+        find(
+          configuredPrecinctsAndSplits,
+          (precinctOrSplit) =>
+            precinctOrSplit.split?.id === selectedPrecinctOrSplitId ||
+            precinctOrSplit.precinct.id === selectedPrecinctOrSplitId
+        );
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      {configuredPrecinctsAndSplits.length > 1 && (
         <SearchSelect
-          aria-label="Select ballot precinct"
-          placeholder="Select ballot style…"
+          aria-label="Select voter's precinct"
+          placeholder="Select voter's precinct…"
           options={configuredPrecinctsAndSplits.map((precinctOrSplit) =>
             precinctOrSplit.split
               ? {
@@ -93,102 +134,42 @@ export function BallotStyleSelect(props: BallotStyleSelectProps): JSX.Element {
                   value: precinctOrSplit.precinct.id,
                 }
           )}
-          value=""
-          onChange={(value) => {
-            const precinctOrSplit = find(
-              configuredPrecinctsAndSplits,
-              // eslint-disable-next-line @typescript-eslint/no-shadow
-              (precinctOrSplit) =>
-                value ===
-                (precinctOrSplit.split?.id ?? precinctOrSplit.precinct.id)
-            );
-            onSelect(
-              precinctOrSplit.precinct.id,
-              getBallotStyleForPrecinctOrSplit(precinctOrSplit).id
-            );
-          }}
+          value={selectedPrecinctOrSplitId}
+          onChange={setSelectedPrecinctOrSplitId}
           style={{ width: '100%' }}
           disabled={disabled}
         />
-      );
-    }
+      )}
 
-    case 'primary': {
-      const selectedPrecinctOrSplit =
-        configuredPrecinctsAndSplits.length === 1
-          ? configuredPrecinctsAndSplits[0]
-          : selectedPrecinctOrSplitId &&
-            find(
-              configuredPrecinctsAndSplits,
-              (precinctOrSplit) =>
-                precinctOrSplit.split?.id === selectedPrecinctOrSplitId ||
-                precinctOrSplit.precinct.id === selectedPrecinctOrSplitId
-            );
-      return (
-        <div
-          style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
-        >
-          {configuredPrecinctsAndSplits.length > 1 && (
-            <SearchSelect
-              aria-label="Select voter's precinct"
-              placeholder="Select voter's precinct…"
-              options={configuredPrecinctsAndSplits.map((precinctOrSplit) =>
-                precinctOrSplit.split
-                  ? {
-                      label: precinctOrSplit.split.name,
-                      value: precinctOrSplit.split.id,
-                    }
-                  : {
-                      label: precinctOrSplit.precinct.name,
-                      value: precinctOrSplit.precinct.id,
-                    }
-              )}
-              value={selectedPrecinctOrSplitId}
-              onChange={setSelectedPrecinctOrSplitId}
-              style={{ width: '100%' }}
-              disabled={disabled}
-            />
-          )}
-
-          {selectedPrecinctOrSplit && (
-            <P>
-              <Font weight="semiBold">Select ballot style:</Font>
-              <ButtonGrid>
-                {getBallotStyleGroupsForPrecinctOrSplit({
-                  election,
-                  precinctOrSplit: selectedPrecinctOrSplit,
-                }).map((ballotStyleGroup) => {
-                  const ballotStyleId =
-                    ballotStyleGroup.defaultLanguageBallotStyle.id;
-                  return (
-                    <Button
-                      key={ballotStyleId}
-                      onPress={() =>
-                        onSelect(
-                          selectedPrecinctOrSplit.precinct.id,
-                          ballotStyleId
-                        )
-                      }
-                      disabled={disabled}
-                    >
-                      {
-                        assertDefined(
-                          getPartyForBallotStyle({ election, ballotStyleId })
-                        ).name
-                      }
-                    </Button>
-                  );
-                })}
-              </ButtonGrid>
-            </P>
-          )}
-        </div>
-      );
-    }
-
-    default: {
-      /* istanbul ignore next - @preserve */
-      throwIllegalValue(election.type);
-    }
-  }
+      {selectedPrecinctOrSplit && (
+        <P>
+          <Font weight="semiBold">Select ballot style:</Font>
+          <ButtonGrid>
+            {getBallotStyleGroupsForPrecinctOrSplit({
+              election,
+              precinctOrSplit: selectedPrecinctOrSplit,
+            }).map((ballotStyleGroup) => {
+              const ballotStyleId =
+                ballotStyleGroup.defaultLanguageBallotStyle.id;
+              return (
+                <Button
+                  key={ballotStyleId}
+                  onPress={() =>
+                    onSelect(selectedPrecinctOrSplit.precinct.id, ballotStyleId)
+                  }
+                  disabled={disabled}
+                >
+                  {
+                    assertDefined(
+                      getPartyForBallotStyle({ election, ballotStyleId })
+                    ).name
+                  }
+                </Button>
+              );
+            })}
+          </ButtonGrid>
+        </P>
+      )}
+    </div>
+  );
 }

--- a/libs/mark-flow-ui/src/components/poll_worker/elements.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/elements.tsx
@@ -9,6 +9,7 @@ import {
   Election,
   getBallotStyle,
   getPartyForBallotStyle,
+  isOpenPrimary,
 } from '@votingworks/types';
 import { electionStrings, P, Font } from '@votingworks/ui';
 import { getPrecinctsAndSplitsForBallotStyle } from '@votingworks/utils';
@@ -33,7 +34,9 @@ export function BallotStyleLabel(props: BallotStyleLabelProps): JSX.Element {
     ? electionStrings.precinctSplitName(precinctOrSplit.split)
     : electionStrings.precinctName(precinctOrSplit.precinct);
 
-  if (election.type === 'general') {
+  // Open primary ballot styles have no party, so show just the precinct name
+  // like in a general election.
+  if (election.type === 'general' || isOpenPrimary(election)) {
     return (
       <P>
         <Font weight="semiBold">Ballot Style:</Font> {precinctOrSplitName}

--- a/libs/ui/src/radio_group.test.tsx
+++ b/libs/ui/src/radio_group.test.tsx
@@ -105,6 +105,22 @@ test('desktop, inverse', () => {
   expect(option).toHaveStyle(`border-width: ${theme.sizes.bordersRem.thin}rem`);
 });
 
+test('forwards className for styled-components support', () => {
+  render(
+    <RadioGroup
+      className="custom-class"
+      label="Pick a card:"
+      onChange={vi.fn()}
+      options={[{ value: 'hearts-4', label: 'Four of Hearts' }]}
+      value="hearts-4"
+    />
+  );
+
+  expect(screen.getByRole('radiogroup', { name: 'Pick a card:' })).toHaveClass(
+    'custom-class'
+  );
+});
+
 test('works with accessible controller interaction pattern', () => {
   const onChange = vi.fn();
 

--- a/libs/ui/src/radio_group.tsx
+++ b/libs/ui/src/radio_group.tsx
@@ -17,6 +17,7 @@ export interface RadioGroupOption<T extends RadioGroupValue> {
 
 /** Props for {@link RadioGroup}. */
 export interface RadioGroupProps<T extends RadioGroupValue> {
+  className?: string;
   disabled?: boolean;
   hideLabel?: boolean;
   inverse?: boolean;
@@ -172,6 +173,7 @@ export function RadioGroupWithRef<T extends RadioGroupValue>(
   ref: React.ForwardedRef<HTMLFieldSetElement>
 ): JSX.Element {
   const {
+    className,
     disabled,
     hideLabel,
     inverse,
@@ -191,7 +193,7 @@ export function RadioGroupWithRef<T extends RadioGroupValue>(
   );
 
   return (
-    <OuterContainer aria-label={label} ref={ref}>
+    <OuterContainer aria-label={label} className={className} ref={ref}>
       {!hideLabel && <LabelContainer aria-hidden>{label}</LabelContainer>}
       <OptionsContainer numColumns={numColumns || 1}>
         {options.map((option) => {


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Task: #7823.

Adds a party selection screen to VxMark for open primary elections. Open primary ballot styles have no party, so the voter picks their party at the start of their session. The selection filters which partisan contests they see. Switching party clears any votes cast.

Voter-facing strings on the party selection screen are hardcoded English for now and will be moved to `appStrings` in a follow-up PR (along with audio support).

## Demo Video or Screenshot

https://github.com/user-attachments/assets/cd236ece-8b2a-4e64-9f0c-c7b861efc1d3




## Testing Plan

- Updated automated test
- Manual testing

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.