### PR TITLE
Enforce polls close settings in VxScan

### DIFF
--- a/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
@@ -1225,7 +1225,6 @@ describe('election day polls close time enforcement', () => {
       apiMock.expectGetPollsInfo('polls_open');
       renderScreen({});
 
-      // Should show menu (Close Polls button present) but not the easy-close prompt
       await screen.findButton('Close Polls');
       expect(
         screen.queryByText('Do you want to close the polls?')
@@ -1262,7 +1261,6 @@ describe('election day polls close time enforcement', () => {
       apiMock.expectGetPollsInfo('polls_open');
       renderScreen({});
 
-      // Test mode: should show easy-close prompt normally
       await screen.findByText('Close Polls');
       expect(
         screen.queryByText(/Polls cannot be closed until/)
@@ -1285,7 +1283,6 @@ describe('election day polls close time enforcement', () => {
     apiMock.expectGetPollsInfo('polls_open');
     renderScreen({});
 
-    // After close time: enforcement no longer applies, easy-close prompt shown
     await screen.findByText('Do you want to close the polls?');
   });
 
@@ -1304,8 +1301,9 @@ describe('election day polls close time enforcement', () => {
       apiMock.expectGetPollsInfo('polls_open');
       renderScreen({});
 
-      // Should show easy-close as PauseVotingPromptScreen
-      await screen.findByText('Pause Voting');
+      const pauseVotingButton = await screen.findByText('Pause Voting');
+      expect(pauseVotingButton).toHaveAttribute('data-variant', 'primary');
+
       expect(screen.queryByText('Close Polls')).not.toBeInTheDocument();
     });
 
@@ -1324,9 +1322,12 @@ describe('election day polls close time enforcement', () => {
       renderScreen({});
 
       userEvent.click(await screen.findByText('Menu'));
-      // Close Polls should be the primary button, Pause Voting in other actions
+      // "Close Polls" should be the primary button
       const closePollsButton = await screen.findButton('Close Polls');
       expect(closePollsButton).toHaveAttribute('data-variant', 'primary');
+      // "Pause Voting" button should be in "Other Actions" section
+      const pauseVotingButton = await screen.findByText('Pause Voting');
+      expect(pauseVotingButton).not.toHaveAttribute('data-variant', 'primary');
     });
 
     test('past close time - easy-close shows ClosePollsPromptScreen', async () => {
@@ -1343,7 +1344,6 @@ describe('election day polls close time enforcement', () => {
       apiMock.expectGetPollsInfo('polls_open');
       renderScreen({});
 
-      // Should show ClosePollsPromptScreen (not PauseVotingPromptScreen)
       await screen.findByText('Do you want to close the polls?');
       expect(
         screen.queryByText('Do you want to pause voting?')

--- a/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
@@ -1192,3 +1192,162 @@ test('Signed hash validation', async () => {
   userEvent.click(screen.getByText('Signed Hash Validation'));
   await screen.findByText('Done');
 });
+
+describe('election day polls close time enforcement', () => {
+  const POLLS_CLOSE_TIME = '2026-11-03T20:00:00';
+  const BEFORE_CLOSE_TIME = new Date('2026-11-03T19:59:00');
+  const AFTER_CLOSE_TIME = new Date('2026-11-03T20:01:00');
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('official election day mode, before close time, disallow flag set', () => {
+    beforeEach(() => {
+      vi.setSystemTime(BEFORE_CLOSE_TIME);
+      apiMock.mockApiClient.getConfig.reset();
+      apiMock.expectGetConfig({
+        isTestMode: false,
+        ballotCastingMode: 'election_day',
+        systemSettings: {
+          ...DEFAULT_SYSTEM_SETTINGS,
+          electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+          disallowClosingPollsBeforeElectionDayPollsCloseTime: true,
+        },
+      });
+    });
+
+    test('poll worker card insert goes directly to menu, not easy-close prompt', async () => {
+      apiMock.expectGetPollsInfo('polls_open');
+      renderScreen({});
+
+      // Should show menu (Close Polls button present) but not the easy-close prompt
+      await screen.findButton('Close Polls');
+      expect(
+        screen.queryByText('Do you want to close the polls?')
+      ).not.toBeInTheDocument();
+    });
+
+    test('Close Polls button is disabled in menu', async () => {
+      apiMock.expectGetPollsInfo('polls_open');
+      renderScreen({});
+
+      const closePollsButton = await screen.findButton('Close Polls');
+      expect(closePollsButton).toBeDisabled();
+    });
+
+    test('description shows cannot close until time', async () => {
+      apiMock.expectGetPollsInfo('polls_open');
+      renderScreen({});
+
+      await screen.findByText(/Polls cannot be closed until/);
+      await screen.findByText(/8:00 PM/);
+    });
+
+    test('testmode suppresses enforcement - shows easy-close prompt', async () => {
+      apiMock.mockApiClient.getConfig.reset();
+      apiMock.expectGetConfig({
+        isTestMode: true,
+        ballotCastingMode: 'election_day',
+        systemSettings: {
+          ...DEFAULT_SYSTEM_SETTINGS,
+          electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+          disallowClosingPollsBeforeElectionDayPollsCloseTime: true,
+        },
+      });
+      apiMock.expectGetPollsInfo('polls_open');
+      renderScreen({});
+
+      // Test mode: should show easy-close prompt normally
+      await screen.findByText('Close Polls');
+      expect(
+        screen.queryByText(/Polls cannot be closed until/)
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('after close time, easy-close prompt appears normally', async () => {
+    vi.setSystemTime(AFTER_CLOSE_TIME);
+    apiMock.mockApiClient.getConfig.reset();
+    apiMock.expectGetConfig({
+      isTestMode: false,
+      ballotCastingMode: 'election_day',
+      systemSettings: {
+        ...DEFAULT_SYSTEM_SETTINGS,
+        electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+        disallowClosingPollsBeforeElectionDayPollsCloseTime: true,
+      },
+    });
+    apiMock.expectGetPollsInfo('polls_open');
+    renderScreen({});
+
+    // After close time: enforcement no longer applies, easy-close prompt shown
+    await screen.findByText('Do you want to close the polls?');
+  });
+
+  describe('early voting mode', () => {
+    test('before close time - Pause Voting is primary action', async () => {
+      vi.setSystemTime(BEFORE_CLOSE_TIME);
+      apiMock.mockApiClient.getConfig.reset();
+      apiMock.expectGetConfig({
+        isTestMode: false,
+        ballotCastingMode: 'early_voting',
+        systemSettings: {
+          ...DEFAULT_SYSTEM_SETTINGS,
+          electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+        },
+      });
+      apiMock.expectGetPollsInfo('polls_open');
+      renderScreen({});
+
+      // Should show easy-close as PauseVotingPromptScreen
+      await screen.findByText('Pause Voting');
+      expect(screen.queryByText('Close Polls')).not.toBeInTheDocument();
+    });
+
+    test('past close time - Close Polls is primary action in menu', async () => {
+      vi.setSystemTime(AFTER_CLOSE_TIME);
+      apiMock.mockApiClient.getConfig.reset();
+      apiMock.expectGetConfig({
+        isTestMode: false,
+        ballotCastingMode: 'early_voting',
+        systemSettings: {
+          ...DEFAULT_SYSTEM_SETTINGS,
+          electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+        },
+      });
+      apiMock.expectGetPollsInfo('polls_open');
+      renderScreen({});
+
+      userEvent.click(await screen.findByText('Menu'));
+      // Close Polls should be the primary button, Pause Voting in other actions
+      const closePollsButton = await screen.findButton('Close Polls');
+      expect(closePollsButton).toHaveAttribute('data-variant', 'primary');
+    });
+
+    test('past close time - easy-close shows ClosePollsPromptScreen', async () => {
+      vi.setSystemTime(AFTER_CLOSE_TIME);
+      apiMock.mockApiClient.getConfig.reset();
+      apiMock.expectGetConfig({
+        isTestMode: false,
+        ballotCastingMode: 'early_voting',
+        systemSettings: {
+          ...DEFAULT_SYSTEM_SETTINGS,
+          electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+        },
+      });
+      apiMock.expectGetPollsInfo('polls_open');
+      renderScreen({});
+
+      // Should show ClosePollsPromptScreen (not PauseVotingPromptScreen)
+      await screen.findByText('Do you want to close the polls?');
+      expect(
+        screen.queryByText('Do you want to pause voting?')
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
@@ -1194,9 +1194,9 @@ test('Signed hash validation', async () => {
 });
 
 describe('election day polls close time enforcement', () => {
-  const POLLS_CLOSE_TIME = '2026-11-03T20:00:00';
-  const BEFORE_CLOSE_TIME = new Date('2026-11-03T19:59:00');
-  const AFTER_CLOSE_TIME = new Date('2026-11-03T20:01:00');
+  const POLLS_CLOSE_TIME = '20:00:00';
+  const BEFORE_CLOSE_TIME = new Date('2021-06-06T19:59:00');
+  const AFTER_CLOSE_TIME = new Date('2021-06-06T20:01:00');
 
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });

--- a/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
@@ -1301,7 +1301,7 @@ describe('election day polls close time enforcement', () => {
       apiMock.expectGetPollsInfo('polls_open');
       renderScreen({});
 
-      const pauseVotingButton = await screen.findByText('Pause Voting');
+      const pauseVotingButton = await screen.findButton('Pause Voting');
       expect(pauseVotingButton).toHaveAttribute('data-variant', 'primary');
 
       expect(screen.queryByText('Close Polls')).not.toBeInTheDocument();
@@ -1326,7 +1326,7 @@ describe('election day polls close time enforcement', () => {
       const closePollsButton = await screen.findButton('Close Polls');
       expect(closePollsButton).toHaveAttribute('data-variant', 'primary');
       // "Pause Voting" button should be in "Other Actions" section
-      const pauseVotingButton = await screen.findByText('Pause Voting');
+      const pauseVotingButton = await screen.findButton('Pause Voting');
       expect(pauseVotingButton).not.toHaveAttribute('data-variant', 'primary');
     });
 

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { DateTime } from 'luxon';
 
 import {
   Button,
@@ -14,6 +15,7 @@ import {
   Font,
   H5,
   QrCode,
+  useNow,
 } from '@votingworks/ui';
 import { getPollsReportTitle } from '@votingworks/utils';
 import {
@@ -308,6 +310,7 @@ function PollWorkerScreenContents({
   pollsInfo: PrecinctScannerPollsInfo;
 }): JSX.Element {
   const apiClient = useApiClient();
+  const now = useNow();
   const pollsInfoQuery = getPollsInfo.useQuery();
   const configQuery = getConfig.useQuery();
   const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
@@ -376,10 +379,28 @@ function PollWorkerScreenContents({
   const printerStatus = printerStatusQuery.data;
   const printerSummary = getPollsFlowPrinterSummary(printerStatus);
   const { pollsState } = pollsInfo;
-  const { isContinuousExportEnabled, ballotCastingMode, systemSettings } =
-    configQuery.data;
+  const {
+    isContinuousExportEnabled,
+    ballotCastingMode,
+    systemSettings,
+    isTestMode,
+  } = configQuery.data;
   const mustInsertUsbDriveToContinue =
     isContinuousExportEnabled && usbDriveStatus.status !== 'mounted';
+
+  const pollsCloseTime = systemSettings.electionDayPollsCloseTime
+    ? DateTime.fromISO(systemSettings.electionDayPollsCloseTime)
+    : undefined;
+
+  const isClosingPollsBlocked =
+    !isTestMode &&
+    ballotCastingMode === 'election_day' &&
+    systemSettings.disallowClosingPollsBeforeElectionDayPollsCloseTime &&
+    pollsCloseTime !== undefined &&
+    now < pollsCloseTime;
+
+  const isPastPollsCloseTime =
+    !isTestMode && pollsCloseTime !== undefined && now >= pollsCloseTime;
 
   function showAllPollWorkerActions() {
     return setPollWorkerFlowState(undefined);
@@ -503,7 +524,18 @@ function PollWorkerScreenContents({
     return BallotsAlreadyScannedScreen;
   }
 
-  if (pollWorkerFlowState) {
+  if (
+    pollWorkerFlowState &&
+    !(
+      // When polls close time enforcement is active, the flow state may have been
+      // initialized to 'close-polls-prompt' before system settings were available.
+      // Skip it here so we fall through to the poll worker menu instead.
+      (
+        pollWorkerFlowState.type === 'close-polls-prompt' &&
+        isClosingPollsBlocked
+      )
+    )
+  ) {
     switch (pollWorkerFlowState.type) {
       case 'open-polls-prompt':
         return (
@@ -524,7 +556,7 @@ function PollWorkerScreenContents({
           />
         );
       case 'close-polls-prompt':
-        if (ballotCastingMode === 'election_day') {
+        if (ballotCastingMode === 'election_day' || isPastPollsCloseTime) {
           return (
             <ClosePollsPromptScreen
               onConfirm={closePolls}
@@ -736,18 +768,29 @@ function PollWorkerScreenContents({
       case 'polls_open':
         // Do not disable Pausing Voting if shouldAllowTogglingPolls is false as in the unlikely event of an internal connection failure
         // officials may want to pause voting on the machine.
-        if (ballotCastingMode === 'election_day') {
+        if (ballotCastingMode === 'election_day' || isPastPollsCloseTime) {
           return (
             <Container>
               <P>
-                The polls are <Font weight="bold">open</Font>. Close the polls
-                to end voting.
+                {isClosingPollsBlocked ? (
+                  <React.Fragment>
+                    The polls are <Font weight="bold">open</Font>. Polls cannot
+                    be closed until{' '}
+                    {pollsCloseTime.toLocaleString(DateTime.TIME_SIMPLE)}.
+                  </React.Fragment>
+                ) : (
+                  <React.Fragment>
+                    The polls are <Font weight="bold">open</Font>. Close the
+                    polls to end voting.
+                  </React.Fragment>
+                )}
               </P>
               <ButtonGrid>
                 <Button
                   variant="primary"
                   onPress={closePolls}
                   disabled={
+                    isClosingPollsBlocked ||
                     !shouldAllowTogglingPolls(
                       printerSummary,
                       mustInsertUsbDriveToContinue

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -393,7 +393,11 @@ function PollWorkerScreenContents({
     isContinuousExportEnabled && usbDriveStatus.status !== 'mounted';
 
   const pollsCloseTime = systemSettings.electionDayPollsCloseTime
-    ? DateTime.fromISO(systemSettings.electionDayPollsCloseTime)
+    ? DateTime.fromISO(
+        `${electionDefinition.election.date.toISOString()}T${
+          systemSettings.electionDayPollsCloseTime
+        }`
+      )
     : undefined;
 
   const isClosingPollsBlocked =

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -525,17 +525,11 @@ function PollWorkerScreenContents({
   }
 
   if (
-    pollWorkerFlowState &&
-    !(
-      // When polls close time enforcement is active, the flow state may have been
-      // initialized to 'close-polls-prompt' before system settings were available.
-      // Skip it here so we fall through to the poll worker menu instead.
-      (
-        pollWorkerFlowState.type === 'close-polls-prompt' &&
-        isClosingPollsBlocked
-      )
-    )
+    isClosingPollsBlocked &&
+    pollWorkerFlowState?.type === 'close-polls-prompt'
   ) {
+    // Skip the close-polls prompt and fall through to render the pollworker menu below
+  } else if (pollWorkerFlowState) {
     switch (pollWorkerFlowState.type) {
       case 'open-polls-prompt':
         return (

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -6,6 +6,7 @@ import {
   Loading,
   LoadingAnimation,
   H1,
+  Modal,
   P,
   PowerDownButton,
   FullScreenIconWrapper,
@@ -347,6 +348,9 @@ function PollWorkerScreenContents({
     Optional<PollWorkerFlowState>
   >(initialPollWorkerFlowState());
 
+  const [isClosePollsWarningModalOpen, setIsClosePollsWarningModalOpen] =
+    useState(false);
+
   // Track which QR index we're viewing when multiple quick-results reports exist.
   const [currentQrIndex, setCurrentQrIndex] = useState(0);
 
@@ -402,6 +406,11 @@ function PollWorkerScreenContents({
   const isPastPollsCloseTime =
     !isTestMode && pollsCloseTime !== undefined && now >= pollsCloseTime;
 
+  const shouldShowClosePollsWarning =
+    isTestMode &&
+    pollsCloseTime !== undefined &&
+    systemSettings.disallowClosingPollsBeforeElectionDayPollsCloseTime;
+
   function showAllPollWorkerActions() {
     return setPollWorkerFlowState(undefined);
   }
@@ -453,6 +462,19 @@ function PollWorkerScreenContents({
       printResult,
     });
     startNewVoterSession();
+  }
+
+  function handleClosePollsPress() {
+    if (shouldShowClosePollsWarning) {
+      setIsClosePollsWarningModalOpen(true);
+    } else {
+      void closePolls();
+    }
+  }
+
+  async function handleConfirmClosePollsFromModal() {
+    setIsClosePollsWarningModalOpen(false);
+    await closePolls();
   }
 
   async function pauseVoting() {
@@ -524,6 +546,31 @@ function PollWorkerScreenContents({
     return BallotsAlreadyScannedScreen;
   }
 
+  const closePollsWarningModal = isClosePollsWarningModalOpen ? (
+    <Modal
+      title="Close Polls"
+      content={
+        <P>
+          On Election Day polls won&apos;t be closable until{' '}
+          {pollsCloseTime?.toLocaleString(DateTime.TIME_SIMPLE)},{' '}
+          {pollsCloseTime?.toLocaleString(DateTime.DATE_SHORT)}. Confirm the
+          configured polls close time is correct.
+        </P>
+      }
+      actions={
+        <React.Fragment>
+          <Button variant="primary" onPress={handleConfirmClosePollsFromModal}>
+            Close Polls
+          </Button>
+          <Button onPress={() => setIsClosePollsWarningModalOpen(false)}>
+            Cancel
+          </Button>
+        </React.Fragment>
+      }
+      onOverlayClick={() => setIsClosePollsWarningModalOpen(false)}
+    />
+  ) : null;
+
   if (
     isClosingPollsBlocked &&
     pollWorkerFlowState?.type === 'close-polls-prompt'
@@ -552,12 +599,15 @@ function PollWorkerScreenContents({
       case 'close-polls-prompt':
         if (ballotCastingMode === 'election_day' || isPastPollsCloseTime) {
           return (
-            <ClosePollsPromptScreen
-              onConfirm={closePolls}
-              onClose={showAllPollWorkerActions}
-              printerSummary={printerSummary}
-              mustInsertUsbDriveToContinue={mustInsertUsbDriveToContinue}
-            />
+            <React.Fragment>
+              {closePollsWarningModal}
+              <ClosePollsPromptScreen
+                onConfirm={handleClosePollsPress}
+                onClose={showAllPollWorkerActions}
+                printerSummary={printerSummary}
+                mustInsertUsbDriveToContinue={mustInsertUsbDriveToContinue}
+              />
+            </React.Fragment>
           );
         }
         return (
@@ -759,12 +809,13 @@ function PollWorkerScreenContents({
             <ButtonGrid>{commonActions}</ButtonGrid>
           </Container>
         );
-      case 'polls_open':
+      case 'polls_open': {
         // Do not disable Pausing Voting if shouldAllowTogglingPolls is false as in the unlikely event of an internal connection failure
         // officials may want to pause voting on the machine.
         if (ballotCastingMode === 'election_day' || isPastPollsCloseTime) {
           return (
             <Container>
+              {closePollsWarningModal}
               <P>
                 {isClosingPollsBlocked ? (
                   <React.Fragment>
@@ -782,7 +833,7 @@ function PollWorkerScreenContents({
               <ButtonGrid>
                 <Button
                   variant="primary"
-                  onPress={closePolls}
+                  onPress={handleClosePollsPress}
                   disabled={
                     isClosingPollsBlocked ||
                     !shouldAllowTogglingPolls(
@@ -805,6 +856,7 @@ function PollWorkerScreenContents({
 
         return (
           <Container>
+            {closePollsWarningModal}
             <P>
               The polls are <Font weight="bold">open</Font>.
             </P>
@@ -816,7 +868,7 @@ function PollWorkerScreenContents({
             <H5>Other Actions</H5>
             <ButtonGrid>
               <Button
-                onPress={closePolls}
+                onPress={handleClosePollsPress}
                 disabled={
                   !shouldAllowTogglingPolls(
                     printerSummary,
@@ -830,6 +882,7 @@ function PollWorkerScreenContents({
             </ButtonGrid>
           </Container>
         );
+      }
 
       case 'polls_paused':
         return (
@@ -854,7 +907,7 @@ function PollWorkerScreenContents({
             <H6>Other Actions</H6>
             <ButtonGrid>
               <Button
-                onPress={closePolls}
+                onPress={handleClosePollsPress}
                 disabled={
                   !shouldAllowTogglingPolls(
                     printerSummary,

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -64,6 +64,9 @@ export const statusNoPaper: PrecinctScannerStatus = {
 };
 
 type MockApiClient = Omit<MockClient<Api>, 'getDiskSpaceSummary'> & {
+  // Re-declare assertComplete to restore the correct void return type, which is
+  // lost when Omit flattens the MockClient intersection type.
+  assertComplete(): void;
   // Because this is polled so frequently, we opt for a standard vitest mock instead of a
   // libs/test-utils mock since the latter requires every call to be explicitly mocked
   getDiskSpaceSummary: Mock;

--- a/apps/scan/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/scan/frontend/test/helpers/mock_api_client.tsx
@@ -64,9 +64,6 @@ export const statusNoPaper: PrecinctScannerStatus = {
 };
 
 type MockApiClient = Omit<MockClient<Api>, 'getDiskSpaceSummary'> & {
-  // Re-declare assertComplete to restore the correct void return type, which is
-  // lost when Omit flattens the MockClient intersection type.
-  assertComplete(): void;
   // Because this is polled so frequently, we opt for a standard vitest mock instead of a
   // libs/test-utils mock since the latter requires every call to be explicitly mocked
   getDiskSpaceSummary: Mock;


### PR DESCRIPTION
## Overview

Broadly,
* enforces polls close settings on VxScan
* Adds a modal when in test mode informing the user that closing polls would be blocked; intent is to help the user catch incorrect polls close times

Relates to https://github.com/votingworks/vxsuite/issues/8026. See `VxScan` section on that ticket for details.

## Demo Video or Screenshot

**Official Mode**

---
> If polls are open on election day and the time is before the polls closed time, don't go to the "easy close" flow on poll worker login, go to the poll worker menu
> If polls closing is disabled, then the "Close Polls" button on the poll worker menu should be disabled and the text above it should read. "The polls are open. Polls cannot be closed until [polls closed time]"

<img width="1569" height="894" alt="Screenshot 2026-04-17 at 1 18 24 PM" src="https://github.com/user-attachments/assets/0dcdb457-8484-43e2-9203-5e7c836e59bd" />

---
> If the scanner is in Early Voting mode, then after the close polls time, the default flow while open should be "Close Polls" rather than "Pause Voting"


https://github.com/user-attachments/assets/51429c49-b9be-4055-8522-af9f05e7d525

---

Not specified in ticket, but Early Voting + before polls close time = "Pause Voting" (existing behavior)
https://github.com/user-attachments/assets/98af1bc9-ac83-41cf-9acc-7785e20cad4c

**Test Mode**
> We should behave as we already do - "easy close" flow
> If a close polls time is set and "Disallow Closing Polls Before election Day Polls Close Time" is also set, then when the user taps "Close Polls" we should present a modal which informs the user that, on election day, they would have to wait until the close polls time. The goal of this feature is such that, in L&A, an incorrect polls closed time is caught. We will determine copy when we get here.

https://github.com/user-attachments/assets/b169b723-38db-4b8d-95fc-0ce838df31cc

## Testing Plan

- added tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
