### PR TITLE
Tests: Add correct default theme modes to ensure tests mirror production

### DIFF
--- a/apps/admin/frontend/test/react_testing_library.tsx
+++ b/apps/admin/frontend/test/react_testing_library.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   makeRender,
   VxRenderOptions,
@@ -11,7 +12,24 @@ import { onTestFinished } from 'vitest';
 // with customized VX utils and types, as recommended at
 // https://testing-library.com/docs/react-testing-library/setup/#custom-render
 export * from '@testing-library/react';
-export const render = makeRender(onTestFinished);
+
+// makeRender's defaults are for voter-facing apps; override to match
+// VxAdmin's desktop production theme.
+const baseRender = makeRender(onTestFinished);
+export function render(
+  ui: React.ReactElement,
+  options: VxRenderOptions = {}
+): VxRenderResult {
+  return baseRender(ui, {
+    ...options,
+    vxTheme: {
+      colorMode: 'desktop',
+      sizeMode: 'desktop',
+      ...(options.vxTheme ?? {}),
+    },
+  });
+}
+
 export { vxTestingLibraryScreen as screen };
 export { vxTestingLibraryWithinFn as within };
 export type { VxRenderOptions as RenderOptions };

--- a/apps/admin/frontend/test/react_testing_library.tsx
+++ b/apps/admin/frontend/test/react_testing_library.tsx
@@ -22,10 +22,9 @@ export function render(
 ): VxRenderResult {
   return baseRender(ui, {
     ...options,
-    vxTheme: {
+    vxTheme: options.vxTheme ?? {
       colorMode: 'desktop',
       sizeMode: 'desktop',
-      ...(options.vxTheme ?? {}),
     },
   });
 }

--- a/apps/central-scan/frontend/test/react_testing_library.tsx
+++ b/apps/central-scan/frontend/test/react_testing_library.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   makeRender,
   VxRenderOptions,
@@ -11,7 +12,24 @@ import { onTestFinished } from 'vitest';
 // with customized VX utils and types, as recommended at
 // https://testing-library.com/docs/react-testing-library/setup/#custom-render
 export * from '@testing-library/react';
-export const render = makeRender(onTestFinished);
+
+// makeRender's defaults are for voter-facing apps; override to match
+// VxCentralScan's desktop production theme.
+const baseRender = makeRender(onTestFinished);
+export function render(
+  ui: React.ReactElement,
+  options: VxRenderOptions = {}
+): VxRenderResult {
+  return baseRender(ui, {
+    ...options,
+    vxTheme: {
+      colorMode: 'desktop',
+      sizeMode: 'desktop',
+      ...(options.vxTheme ?? {}),
+    },
+  });
+}
+
 export { vxTestingLibraryScreen as screen };
 export { vxTestingLibraryWithinFn as within };
 export type { VxRenderOptions as RenderOptions };

--- a/apps/central-scan/frontend/test/react_testing_library.tsx
+++ b/apps/central-scan/frontend/test/react_testing_library.tsx
@@ -22,10 +22,9 @@ export function render(
 ): VxRenderResult {
   return baseRender(ui, {
     ...options,
-    vxTheme: {
+    vxTheme: options.vxTheme ?? {
       colorMode: 'desktop',
       sizeMode: 'desktop',
-      ...(options.vxTheme ?? {}),
     },
   });
 }

--- a/apps/design/frontend/test/api_helpers.tsx
+++ b/apps/design/frontend/test/api_helpers.tsx
@@ -11,7 +11,7 @@ import type {
   OrganizationUser,
 } from '@votingworks/design-backend';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
-import { AppBase, TestErrorBoundary } from '@votingworks/ui';
+import { TestErrorBoundary } from '@votingworks/ui';
 import { ElectionId } from '@votingworks/types';
 import { SupportUser } from '@votingworks/design-backend';
 import { ApiClientContext, createQueryClient } from '../src/api';
@@ -69,19 +69,13 @@ export function provideApi(
   queryClient: QueryClient = createQueryClient()
 ): JSX.Element {
   return (
-    <AppBase
-      defaultColorMode="desktop"
-      defaultSizeMode="desktop"
-      showScrollBars
-    >
-      <TestErrorBoundary>
-        <ApiClientContext.Provider value={apiMock}>
-          <QueryClientProvider client={queryClient}>
-            {children}
-          </QueryClientProvider>
-        </ApiClientContext.Provider>
-      </TestErrorBoundary>
-    </AppBase>
+    <TestErrorBoundary>
+      <ApiClientContext.Provider value={apiMock}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </ApiClientContext.Provider>
+    </TestErrorBoundary>
   );
 }
 

--- a/apps/design/frontend/test/react_testing_library.ts
+++ b/apps/design/frontend/test/react_testing_library.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   makeRender,
   VxRenderOptions,
@@ -11,7 +12,24 @@ import { onTestFinished } from 'vitest';
 // with customized VX utils and types, as recommended at
 // https://testing-library.com/docs/react-testing-library/setup/#custom-render
 export * from '@testing-library/react';
-export const render = makeRender(onTestFinished);
+
+// makeRender's defaults are for voter-facing apps; override to match
+// VxDesign's desktop production theme.
+const baseRender = makeRender(onTestFinished);
+export function render(
+  ui: React.ReactElement,
+  options: VxRenderOptions = {}
+): VxRenderResult {
+  return baseRender(ui, {
+    ...options,
+    vxTheme: {
+      colorMode: 'desktop',
+      sizeMode: 'desktop',
+      ...(options.vxTheme ?? {}),
+    },
+  });
+}
+
 export { vxTestingLibraryScreen as screen };
 export { vxTestingLibraryWithinFn as within };
 export type { VxRenderOptions as RenderOptions };

--- a/apps/design/frontend/test/react_testing_library.ts
+++ b/apps/design/frontend/test/react_testing_library.ts
@@ -22,10 +22,9 @@ export function render(
 ): VxRenderResult {
   return baseRender(ui, {
     ...options,
-    vxTheme: {
+    vxTheme: options.vxTheme ?? {
       colorMode: 'desktop',
       sizeMode: 'desktop',
-      ...(options.vxTheme ?? {}),
     },
   });
 }

--- a/apps/design/frontend/test/unauthenticated_api_helpers.tsx
+++ b/apps/design/frontend/test/unauthenticated_api_helpers.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { UnauthenticatedApi } from '@votingworks/design-backend';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
-import { AppBase, TestErrorBoundary } from '@votingworks/ui';
+import { TestErrorBoundary } from '@votingworks/ui';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { UnauthenticatedApiClientContext } from '../src/public_api';
 import { createQueryClient } from '../src/api';
@@ -17,18 +17,12 @@ export function provideUnauthenticatedApi(
   children: React.ReactNode
 ): JSX.Element {
   return (
-    <AppBase
-      defaultColorMode="desktop"
-      defaultSizeMode="desktop"
-      showScrollBars
-    >
-      <TestErrorBoundary>
-        <UnauthenticatedApiClientContext.Provider value={apiMock}>
-          <QueryClientProvider client={createQueryClient()}>
-            {children}
-          </QueryClientProvider>
-        </UnauthenticatedApiClientContext.Provider>
-      </TestErrorBoundary>
-    </AppBase>
+    <TestErrorBoundary>
+      <UnauthenticatedApiClientContext.Provider value={apiMock}>
+        <QueryClientProvider client={createQueryClient()}>
+          {children}
+        </QueryClientProvider>
+      </UnauthenticatedApiClientContext.Provider>
+    </TestErrorBoundary>
   );
 }


### PR DESCRIPTION
## Overview

When working in VxAdmin last week, we noticed that the tests were running without having the proper `colorMode` and `sizeMode` set, so they were falling back to the touch-based defaults. This PR fixes this for VxAdmin and VxCentralScan, and updates VxDesign so test renders don't double wrap with `AppBase`.

## Demo Video or Screenshot

NA

## Testing Plan

Automated tests all still pass

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
