### PR TITLE
VxAdmin: Add "Ballots Cast" row to CSV tally report

### DIFF
--- a/apps/admin/backend/src/app.tally_report_csv.test.ts
+++ b/apps/admin/backend/src/app.tally_report_csv.test.ts
@@ -139,11 +139,12 @@ test('exports expected results for full election', async () => {
     fox: '36',
     overvotes: '8',
     undervotes: '4',
+    'ballots-cast': '56',
   };
   const bestAnimalMammalRows = rows.filter(
     (row) => row['Contest ID'] === 'best-animal-mammal'
   );
-  expect(bestAnimalMammalRows).toHaveLength(5);
+  expect(bestAnimalMammalRows).toHaveLength(6);
   for (const [selectionId, votes] of Object.entries(
     bestAnimalMammalExpectedValues
   )) {
@@ -155,9 +156,10 @@ test('exports expected results for full election', async () => {
     'allow-fishing': '8',
     overvotes: '8',
     undervotes: '88',
+    'ballots-cast': '112',
   };
   const fishingRows = rows.filter((row) => row['Contest ID'] === 'fishing');
-  expect(fishingRows).toHaveLength(4);
+  expect(fishingRows).toHaveLength(5);
   for (const [selectionId, votes] of Object.entries(fishingExpectedValues)) {
     expect(votes).toEqual(fishingExpectedValues[selectionId]);
   }
@@ -576,7 +578,7 @@ test('exports ballot styles grouped by language agnostic parent in multi-languag
   const ballotStyle4fRows = rows.filter(
     (row) => row['Ballot Style ID'] === '4-F'
   );
-  expect(ballotStyle1MaRows).toHaveLength(16);
-  expect(ballotStyle4MaRows).toHaveLength(16);
-  expect(ballotStyle4fRows).toHaveLength(15);
+  expect(ballotStyle1MaRows).toHaveLength(19);
+  expect(ballotStyle4MaRows).toHaveLength(19);
+  expect(ballotStyle4fRows).toHaveLength(18);
 });

--- a/apps/admin/backend/src/exports/csv_tally_report.test.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.test.ts
@@ -424,7 +424,7 @@ test('incorporates manual data', async () => {
           type: 'candidate',
           ballots: 20,
           overvotes: 3,
-          undervotes: 2,
+          undervotes: 42,
           officialOptionTallies: {
             lion: 10,
             kangaroo: 5,
@@ -463,7 +463,8 @@ test('incorporates manual data', async () => {
     ['kangaroo', '5', '1', '6'],
     ['elephant', '0', '1', '1'],
     ['overvotes', '3', '0', '3'],
-    ['undervotes', '2', '0', '2'],
+    ['undervotes', '42', '0', '42'],
+    ['ballots-cast', '20', '1', '21'],
   ]);
 
   expect(
@@ -480,6 +481,7 @@ test('incorporates manual data', async () => {
     ['allow-fishing', '9', '0', '9'],
     ['overvotes', '4', '0', '4'],
     ['undervotes', '6', '0', '6'],
+    ['ballots-cast', '20', '1', '21'],
   ]);
 });
 
@@ -564,6 +566,7 @@ test('separate rows for manual data when grouping by an incompatible dimension',
       ['Batch batch-1', 'batch-1', 'scanner-1', 'allow-fishing', '0', '0', '0'],
       ['Batch batch-1', 'batch-1', 'scanner-1', 'overvotes', '0', '0', '0'],
       ['Batch batch-1', 'batch-1', 'scanner-1', 'undervotes', '0', '0', '0'],
+      ['Batch batch-1', 'batch-1', 'scanner-1', 'ballots-cast', '0', '1', '1'],
       [
         'Manual Tallies',
         'NO_BATCH__MANUAL',
@@ -600,6 +603,15 @@ test('separate rows for manual data when grouping by an incompatible dimension',
         '0',
         '0',
       ],
+      [
+        'Manual Tallies',
+        'NO_BATCH__MANUAL',
+        'NO_SCANNER__MANUAL',
+        'ballots-cast',
+        '1',
+        '0',
+        '1',
+      ],
     ]);
   }
 
@@ -626,9 +638,70 @@ test('separate rows for manual data when grouping by an incompatible dimension',
     ['scanner-1', 'allow-fishing', '0', '0', '0'],
     ['scanner-1', 'overvotes', '0', '0', '0'],
     ['scanner-1', 'undervotes', '0', '0', '0'],
+    ['scanner-1', 'ballots-cast', '0', '1', '1'],
     ['NO_SCANNER__MANUAL', 'ban-fishing', '1', '0', '1'],
     ['NO_SCANNER__MANUAL', 'allow-fishing', '0', '0', '0'],
     ['NO_SCANNER__MANUAL', 'overvotes', '0', '0', '0'],
     ['NO_SCANNER__MANUAL', 'undervotes', '0', '0', '0'],
+    ['NO_SCANNER__MANUAL', 'ballots-cast', '1', '0', '1'],
   ]);
+});
+
+test('ballots cast rows reflect per-contest ballot counts across ballot styles', async () => {
+  const store = Store.memoryStore(makeTemporaryDirectory());
+  const { electionData } =
+    electionTwoPartyPrimaryFixtures.readElectionDefinition();
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
+    electionPackageHash: 'test-election-package-hash',
+  });
+  store.setCurrentElectionId(electionId);
+
+  // 3 CVRs on mammal ballot style, 1 CVR on fish ballot style
+  const mockCastVoteRecordFile: MockCastVoteRecordFile = [
+    {
+      ballotStyleGroupId: '1M' as BallotStyleGroupId,
+      batchId: 'batch-1',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
+      votes: { 'best-animal-mammal': ['horse'], fishing: ['ban-fishing'] },
+      card: { type: 'bmd' },
+      multiplier: 3,
+    },
+    {
+      ballotStyleGroupId: '2F' as BallotStyleGroupId,
+      batchId: 'batch-1',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
+      votes: { 'best-animal-fish': ['seahorse'], fishing: ['ban-fishing'] },
+      card: { type: 'bmd' },
+      multiplier: 1,
+    },
+  ];
+  addMockCvrFileToStore({ electionId, mockCastVoteRecordFile, store });
+
+  const iterable = generateTallyReportCsv({
+    store,
+    filename: mockFileName(),
+  });
+  const fileContents = await iterableToString(iterable);
+  const { rows } = parseCsv(fileContents);
+
+  function getBallotsCast(contestId: string): string | undefined {
+    return rows.find(
+      (r) =>
+        r['Contest ID'] === contestId && r['Selection ID'] === 'ballots-cast'
+    )?.['Total Votes'];
+  }
+
+  // mammal-only contest: 3 ballots (only 1M ballot style)
+  expect(getBallotsCast('best-animal-mammal')).toEqual('3');
+  // fish-only contest: 1 ballot (only 2F ballot style)
+  expect(getBallotsCast('best-animal-fish')).toEqual('1');
+  // non-partisan contest on both styles: 4 ballots
+  expect(getBallotsCast('fishing')).toEqual('4');
 });

--- a/apps/admin/backend/src/exports/csv_tally_report.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.ts
@@ -206,6 +206,16 @@ function* generateDataRows({
         hasManualResults,
         manualVotes: manualContestResults?.undervotes ?? 0,
       });
+
+      yield buildRow({
+        metadataValues,
+        contest,
+        selection: 'Ballots Cast',
+        selectionId: 'ballots-cast',
+        scannedVotes: scannedContestResults.ballots,
+        hasManualResults,
+        manualVotes: manualContestResults?.ballots ?? 0,
+      });
     }
   }
 }

--- a/apps/admin/integration-testing/e2e/reports.spec.ts-snapshots/full-election-tally-report-chromium-linux.csv
+++ b/apps/admin/integration-testing/e2e/reports.spec.ts-snapshots/full-election-tally-report-chromium-linux.csv
@@ -5,10 +5,12 @@ Best Animal,best-animal-mammal,Otter,otter,4
 Best Animal,best-animal-mammal,Fox,fox,36
 Best Animal,best-animal-mammal,Overvotes,overvotes,8
 Best Animal,best-animal-mammal,Undervotes,undervotes,4
+Best Animal,best-animal-mammal,Ballots Cast,ballots-cast,56
 Best Animal,best-animal-fish,Seahorse,seahorse,4
 Best Animal,best-animal-fish,Salmon,salmon,44
 Best Animal,best-animal-fish,Overvotes,overvotes,4
 Best Animal,best-animal-fish,Undervotes,undervotes,4
+Best Animal,best-animal-fish,Ballots Cast,ballots-cast,56
 Zoo Council,zoo-council-mammal,Zebra,zebra,32
 Zoo Council,zoo-council-mammal,Lion,lion,28
 Zoo Council,zoo-council-mammal,Kangaroo,kangaroo,24
@@ -16,6 +18,7 @@ Zoo Council,zoo-council-mammal,Elephant,elephant,24
 Zoo Council,zoo-council-mammal,Unadjudicated Write-In,write-in,24
 Zoo Council,zoo-council-mammal,Overvotes,overvotes,12
 Zoo Council,zoo-council-mammal,Undervotes,undervotes,24
+Zoo Council,zoo-council-mammal,Ballots Cast,ballots-cast,56
 Zoo Council,aquarium-council-fish,Manta Ray,manta-ray,20
 Zoo Council,aquarium-council-fish,Pufferfish,pufferfish,16
 Zoo Council,aquarium-council-fish,Rockfish,rockfish,16
@@ -23,15 +26,19 @@ Zoo Council,aquarium-council-fish,Triggerfish,triggerfish,16
 Zoo Council,aquarium-council-fish,Unadjudicated Write-In,write-in,16
 Zoo Council,aquarium-council-fish,Overvotes,overvotes,16
 Zoo Council,aquarium-council-fish,Undervotes,undervotes,12
+Zoo Council,aquarium-council-fish,Ballots Cast,ballots-cast,56
 Ballot Measure 1 - Part 1,new-zoo-either,FOR APPROVAL OF EITHER Initiative No. 12 OR Alternative Initiative No. 12 A,new-zoo-either-approved,8
 Ballot Measure 1 - Part 1,new-zoo-either,AGAINST BOTH Initiative No. 12 AND Alternative Measure 12 A,new-zoo-neither-approved,8
 Ballot Measure 1 - Part 1,new-zoo-either,Overvotes,overvotes,8
 Ballot Measure 1 - Part 1,new-zoo-either,Undervotes,undervotes,88
+Ballot Measure 1 - Part 1,new-zoo-either,Ballots Cast,ballots-cast,112
 Ballot Measure 1 - Part 2,new-zoo-pick,FOR Initiative No. 12,new-zoo-safari,8
 Ballot Measure 1 - Part 2,new-zoo-pick,FOR Alternative Measure No. 12 A,new-zoo-traditional,8
 Ballot Measure 1 - Part 2,new-zoo-pick,Overvotes,overvotes,8
 Ballot Measure 1 - Part 2,new-zoo-pick,Undervotes,undervotes,88
+Ballot Measure 1 - Part 2,new-zoo-pick,Ballots Cast,ballots-cast,112
 Ballot Measure 3,fishing,YES,ban-fishing,8
 Ballot Measure 3,fishing,NO,allow-fishing,8
 Ballot Measure 3,fishing,Overvotes,overvotes,8
 Ballot Measure 3,fishing,Undervotes,undervotes,88
+Ballot Measure 3,fishing,Ballots Cast,ballots-cast,112

--- a/apps/design/backend/src/app.state_ms.test.ts
+++ b/apps/design/backend/src/app.state_ms.test.ts
@@ -186,7 +186,7 @@ test('convert MS results', async () => {
     expect(
       (unexpectedErrorResult.err() as Error).message
     ).toMatchInlineSnapshot(
-      `"Invalid Record Length: columns length is 7, got 1 on line 867"`
+      `"Invalid Record Length: columns length is 7, got 1 on line 987"`
     );
   });
 });

--- a/apps/design/backend/src/convert_ms_results.ts
+++ b/apps/design/backend/src/convert_ms_results.ts
@@ -158,6 +158,12 @@ export function convertMsResults(
     return err('report-contests-mismatch');
   }
 
+  // The SEMS results format has no equivalent of the per-contest "Ballots Cast"
+  // row that VxAdmin's tally report CSV includes, so drop those rows here.
+  allPrecinctsTallyReportRows = allPrecinctsTallyReportRows.filter(
+    (row) => row.selectionId !== 'ballots-cast'
+  );
+
   function extractSemsId(id: string): string {
     const [electionId, semsId] = id.split(MS_ID_SEPARATOR);
     assert(electionId === election.id);

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -400,7 +400,7 @@ export function generateAllPrecinctsTallyReportRows(
         contest: contest.title,
         contestId: contest.id,
       } as const;
-      const overvotesAndUndervotesRows = [
+      const overvotesUndervotesAndBallotsCastRows = [
         {
           ...rowBase,
           selection: 'Overvotes',
@@ -411,6 +411,12 @@ export function generateAllPrecinctsTallyReportRows(
           ...rowBase,
           selection: 'Undervotes',
           selectionId: 'undervotes',
+          totalVotes: `${contestIndex}`,
+        },
+        {
+          ...rowBase,
+          selection: 'Ballots Cast',
+          selectionId: 'ballots-cast',
           totalVotes: `${contestIndex}`,
         },
       ];
@@ -449,7 +455,7 @@ export function generateAllPrecinctsTallyReportRows(
                   },
                 ]
               : []),
-            ...overvotesAndUndervotesRows,
+            ...overvotesUndervotesAndBallotsCastRows,
           ];
         }
         case 'yesno': {
@@ -472,7 +478,7 @@ export function generateAllPrecinctsTallyReportRows(
               selectionId: contest.noOption.id,
               totalVotes: `${contestIndex + 1}`,
             },
-            ...overvotesAndUndervotesRows,
+            ...overvotesUndervotesAndBallotsCastRows,
           ];
         }
         default: {


### PR DESCRIPTION
## Overview

Closes #8263.

Adds a "Ballots Cast" row per contest in the CSV tally report export, alongside the existing overvotes and undervotes rows. This makes the ballot count per contest visible directly in the tally report, so consumers don't need to calculate the ballot count themselves based on summing all option values, undervotes, and overvotes.

The `ballots` field already exists on `Tabulation.ContestResultsMetadata` for both scanned and manual results, so this is purely a CSV output change.

## Demo Video or Screenshot

Example excerpt of new CSV row:
```
Contest,Contest ID,Selection,Selection ID,Total Votes
Ballot Measure 3,fishing,YES,ban-fishing,4
Ballot Measure 3,fishing,NO,allow-fishing,0
Ballot Measure 3,fishing,Overvotes,overvotes,0
Ballot Measure 3,fishing,Undervotes,undervotes,0
Ballot Measure 3,fishing,Ballots Cast,ballots-cast,4
```

## Testing Plan

- [x] Updated existing tests that assert per-contest row structure to include the new `ballots-cast` row
- [x] Added a new test that uses CVRs across two different ballot styles (3 on `1M`, 1 on `2F`) to verify that party-specific contests show different "Ballots Cast" counts (3 for mammal-only, 1 for fish-only) while the shared non-partisan contest shows the total (4). This exercises the core motivation of the ticket.
- [x] Also made the `zoo-council-mammal` manual results fixture internally consistent (undervotes bumped to satisfy `sum_of_tallies + overvotes + undervotes == ballots × seats` for the vote-for-three contest). previously was inconsistent.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions. _(N/A — no new user actions; this is an output-format change to an already-logged export.)_
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)