### PR TITLE
VxAdmin: Check polls close time and disable tally reports/marking as official

### DIFF
--- a/apps/admin/frontend/src/components/mark_official_button.test.tsx
+++ b/apps/admin/frontend/src/components/mark_official_button.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
 import userEvent from '@testing-library/user-event';
 import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
 import {
@@ -24,6 +25,7 @@ test('mark results as official', async () => {
     electionFamousNames2021Fixtures.readElectionDefinition();
   apiMock.expectGetCastVoteRecordFileMode('official');
   apiMock.expectGetManualResultsMetadata([]);
+  apiMock.expectGetSystemSettings();
 
   renderInAppContext(<MarkResultsOfficialButton />, {
     electionDefinition,
@@ -54,6 +56,7 @@ test('mark official results button disabled when no cvr files', async () => {
     electionFamousNames2021Fixtures.readElectionDefinition();
   apiMock.expectGetCastVoteRecordFileMode('unlocked'); // no CVR files
   apiMock.expectGetManualResultsMetadata([]); // no manual tallies either
+  apiMock.expectGetSystemSettings();
   renderInAppContext(<MarkResultsOfficialButton />, {
     electionDefinition,
     apiMock,
@@ -72,6 +75,7 @@ test('mark official results button disabled when already official', async () => 
     electionFamousNames2021Fixtures.readElectionDefinition();
   apiMock.expectGetCastVoteRecordFileMode('official');
   apiMock.expectGetManualResultsMetadata([]);
+  apiMock.expectGetSystemSettings();
   renderInAppContext(<MarkResultsOfficialButton />, {
     electionDefinition,
     apiMock,
@@ -90,6 +94,7 @@ test('mark official results button enabled when manual tallies exist but no CVRs
   const electionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();
   apiMock.expectGetCastVoteRecordFileMode('unlocked'); // no CVR files
+  apiMock.expectGetSystemSettings();
   apiMock.expectGetManualResultsMetadata([
     {
       precinctId: 'precinct-1',
@@ -108,4 +113,26 @@ test('mark official results button enabled when manual tallies exist but no CVRs
   await vi.waitFor(() => {
     expect(screen.getButton(MARK_RESULTS_OFFICIAL_BUTTON_TEXT)).toBeEnabled();
   });
+});
+
+test('mark official results button disabled before polls close time in official mode', async () => {
+  vi.useFakeTimers({ now: new Date('2020-11-03T22:22:00') });
+  const electionDefinition =
+    electionFamousNames2021Fixtures.readElectionDefinition();
+  apiMock.expectGetCastVoteRecordFileMode('official');
+  apiMock.expectGetManualResultsMetadata([]);
+  apiMock.expectGetSystemSettings({
+    ...DEFAULT_SYSTEM_SETTINGS,
+    disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+    electionDayPollsCloseTime: '2020-11-03T23:00:00',
+  });
+  renderInAppContext(<MarkResultsOfficialButton />, {
+    electionDefinition,
+    apiMock,
+    isOfficialResults: false,
+  });
+
+  await vi.waitFor(() => apiMock.assertComplete());
+
+  expect(screen.getButton(MARK_RESULTS_OFFICIAL_BUTTON_TEXT)).toBeDisabled();
 });

--- a/apps/admin/frontend/src/components/mark_official_button.test.tsx
+++ b/apps/admin/frontend/src/components/mark_official_button.test.tsx
@@ -18,6 +18,7 @@ beforeEach(() => {
 
 afterEach(() => {
   apiMock.assertComplete();
+  vi.useRealTimers();
 });
 
 test('mark results as official', async () => {
@@ -116,7 +117,10 @@ test('mark official results button enabled when manual tallies exist but no CVRs
 });
 
 test('mark official results button disabled before polls close time in official mode', async () => {
-  vi.useFakeTimers({ now: new Date('2020-11-03T22:22:00') });
+  vi.useFakeTimers({
+    shouldAdvanceTime: true,
+    now: new Date('2020-11-03T22:22:00'),
+  });
   const electionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();
   apiMock.expectGetCastVoteRecordFileMode('official');
@@ -124,7 +128,7 @@ test('mark official results button disabled before polls close time in official 
   apiMock.expectGetSystemSettings({
     ...DEFAULT_SYSTEM_SETTINGS,
     disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
-    electionDayPollsCloseTime: '2020-11-03T23:00:00',
+    electionDayPollsCloseTime: '23:00:00',
   });
   renderInAppContext(<MarkResultsOfficialButton />, {
     electionDefinition,
@@ -132,7 +136,7 @@ test('mark official results button disabled before polls close time in official 
     isOfficialResults: false,
   });
 
-  await vi.waitFor(() => apiMock.assertComplete());
-
-  expect(screen.getButton(MARK_RESULTS_OFFICIAL_BUTTON_TEXT)).toBeDisabled();
+  await vi.waitFor(() => {
+    expect(screen.getButton(MARK_RESULTS_OFFICIAL_BUTTON_TEXT)).toBeDisabled();
+  });
 });

--- a/apps/admin/frontend/src/components/mark_official_button.tsx
+++ b/apps/admin/frontend/src/components/mark_official_button.tsx
@@ -14,7 +14,7 @@ export const MARK_RESULTS_OFFICIAL_BUTTON_TEXT =
   'Mark Election Results as Official';
 
 export function MarkResultsOfficialButton(): JSX.Element {
-  const { isOfficialResults } = useContext(AppContext);
+  const { electionDefinition, isOfficialResults } = useContext(AppContext);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const markResultsOfficialMutation = markResultsOfficial.useMutation();
@@ -33,7 +33,8 @@ export function MarkResultsOfficialButton(): JSX.Element {
     !isOfficialResults &&
     !areClosedPollsActionsBlocked(
       castVoteRecordFileModeQuery.data,
-      systemSettingsQuery.data
+      systemSettingsQuery.data,
+      electionDefinition?.election.date
     );
 
   function openModal() {

--- a/apps/admin/frontend/src/components/mark_official_button.tsx
+++ b/apps/admin/frontend/src/components/mark_official_button.tsx
@@ -3,10 +3,12 @@ import { Button, Modal, P } from '@votingworks/ui';
 import {
   getCastVoteRecordFileMode,
   getManualResultsMetadata,
+  getSystemSettings,
   markResultsOfficial,
   revertResultsToUnofficial,
 } from '../api';
 import { AppContext } from '../contexts/app_context';
+import { areClosedPollsActionsBlocked } from '../utils/closed_polls_actions';
 
 export const MARK_RESULTS_OFFICIAL_BUTTON_TEXT =
   'Mark Election Results as Official';
@@ -18,6 +20,7 @@ export function MarkResultsOfficialButton(): JSX.Element {
   const markResultsOfficialMutation = markResultsOfficial.useMutation();
   const castVoteRecordFileModeQuery = getCastVoteRecordFileMode.useQuery();
   const manualResultsMetadataQuery = getManualResultsMetadata.useQuery();
+  const systemSettingsQuery = getSystemSettings.useQuery();
 
   const hasManualTallies =
     manualResultsMetadataQuery.isSuccess &&
@@ -25,8 +28,13 @@ export function MarkResultsOfficialButton(): JSX.Element {
 
   const canMarkResultsOfficial =
     castVoteRecordFileModeQuery.isSuccess &&
+    systemSettingsQuery.isSuccess &&
     (castVoteRecordFileModeQuery.data !== 'unlocked' || hasManualTallies) &&
-    !isOfficialResults;
+    !isOfficialResults &&
+    !areClosedPollsActionsBlocked(
+      castVoteRecordFileModeQuery.data,
+      systemSettingsQuery.data
+    );
 
   function openModal() {
     setIsModalOpen(true);

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.test.tsx
@@ -7,6 +7,7 @@ import { hasTextAcrossElements } from '@votingworks/test-utils';
 import {
   DEFAULT_SYSTEM_SETTINGS,
   ElectionDefinition,
+  SystemSettings,
 } from '@votingworks/types';
 import { isVoterTurnoutReportEnabled, ReportsScreen } from './reports_screen';
 import { renderInAppContext } from '../../../test/render_in_app_context';
@@ -286,5 +287,95 @@ describe('Send Tally Reports link', () => {
 
     await screen.findButton('Full Election Tally Report');
     expect(screen.queryByText('Send Tally Reports')).not.toBeInTheDocument();
+  });
+});
+
+describe('polls close time enforcement', () => {
+  const POLLS_CLOSE_TIME = '2020-11-03T23:00:00';
+  const systemSettingsWithBlock: SystemSettings = {
+    ...DEFAULT_SYSTEM_SETTINGS,
+    disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+    electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+  };
+
+  // beforeEach sets fake timers to 2020-11-03T22:22:00, which is before
+  // POLLS_CLOSE_TIME
+
+  test('tally report buttons disabled and message shown in official mode before polls close', async () => {
+    apiMock.expectGetCastVoteRecordFileMode('official');
+    apiMock.expectGetManualResultsMetadata([]);
+    apiMock.expectGetTotalBallotCount(0);
+    apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings(systemSettingsWithBlock);
+
+    renderInAppContext(<ReportsScreen />, { electionDefinition, apiMock });
+
+    await vi.waitFor(() => {
+      expect(screen.getButton('Full Election Tally Report')).toBeDisabled();
+    });
+    expect(screen.getButton('All Precincts Tally Report')).toBeDisabled();
+    expect(screen.getButton('Single Precinct Tally Report')).toBeDisabled();
+    expect(screen.getButton('Tally Report Builder')).toBeDisabled();
+    expect(
+      screen.getButton('Unofficial Write-In Adjudication Report')
+    ).toBeDisabled();
+    screen.getByText(
+      /On Election Day, tally reports and official results are unavailable until/
+    );
+  });
+
+  test('ballot count report buttons remain enabled before polls close', async () => {
+    apiMock.expectGetCastVoteRecordFileMode('official');
+    apiMock.expectGetManualResultsMetadata([]);
+    apiMock.expectGetTotalBallotCount(0);
+    apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings(systemSettingsWithBlock);
+
+    renderInAppContext(<ReportsScreen />, { electionDefinition, apiMock });
+
+    await vi.waitFor(() => apiMock.assertComplete());
+    expect(screen.getButton('Precinct Ballot Count Report')).toBeEnabled();
+    expect(screen.getButton('Voting Method Ballot Count Report')).toBeEnabled();
+    expect(screen.getButton('Ballot Count Report Builder')).toBeEnabled();
+  });
+
+  test('tally report buttons not disabled in test mode before polls close', async () => {
+    apiMock.expectGetCastVoteRecordFileMode('test');
+    apiMock.expectGetManualResultsMetadata([]);
+    apiMock.expectGetTotalBallotCount(0);
+    apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings(systemSettingsWithBlock);
+
+    renderInAppContext(<ReportsScreen />, { electionDefinition, apiMock });
+
+    await vi.waitFor(() => apiMock.assertComplete());
+    expect(screen.getButton('Full Election Tally Report')).toBeEnabled();
+  });
+
+  test('tally report buttons not disabled after polls close time', async () => {
+    vi.setSystemTime(new Date('2020-11-03T23:30:00'));
+    apiMock.expectGetCastVoteRecordFileMode('official');
+    apiMock.expectGetManualResultsMetadata([]);
+    apiMock.expectGetTotalBallotCount(0);
+    apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings(systemSettingsWithBlock);
+
+    renderInAppContext(<ReportsScreen />, { electionDefinition, apiMock });
+
+    await vi.waitFor(() => apiMock.assertComplete());
+    expect(screen.getButton('Full Election Tally Report')).toBeEnabled();
+  });
+
+  test('tally report buttons not disabled when setting is not enabled', async () => {
+    apiMock.expectGetCastVoteRecordFileMode('official');
+    apiMock.expectGetManualResultsMetadata([]);
+    apiMock.expectGetTotalBallotCount(0);
+    apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings();
+
+    renderInAppContext(<ReportsScreen />, { electionDefinition, apiMock });
+
+    await vi.waitFor(() => apiMock.assertComplete());
+    expect(screen.getButton('Full Election Tally Report')).toBeEnabled();
   });
 });

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.test.tsx
@@ -301,7 +301,7 @@ describe('polls close time enforcement', () => {
   // beforeEach sets fake timers to 2020-11-03T22:22:00, which is before
   // POLLS_CLOSE_TIME
 
-  test('tally report buttons disabled and message shown in official mode before polls close', async () => {
+  test('tally report + WIA report buttons disabled and message shown in official mode before polls close', async () => {
     apiMock.expectGetCastVoteRecordFileMode('official');
     apiMock.expectGetManualResultsMetadata([]);
     apiMock.expectGetTotalBallotCount(0);
@@ -319,9 +319,42 @@ describe('polls close time enforcement', () => {
     expect(
       screen.getButton('Unofficial Write-In Adjudication Report')
     ).toBeDisabled();
+    // electionDefinition has write-in contests, so message uses "certain reports"
     screen.getByText(
-      /On Election Day, tally reports and official results are unavailable until/
+      /On Election Day, certain reports and official results are unavailable until/
     );
+  });
+
+  test('shows "tally reports" in message when election has no write-in contests', async () => {
+    const electionDefinitionWithoutWriteIns: ElectionDefinition = {
+      ...electionDefinition,
+      election: {
+        ...electionDefinition.election,
+        contests: electionDefinition.election.contests.map((contest) => {
+          if (contest.type === 'candidate') {
+            return { ...contest, allowWriteIns: false };
+          }
+          return contest;
+        }),
+      },
+    };
+
+    apiMock.expectGetCastVoteRecordFileMode('official');
+    apiMock.expectGetManualResultsMetadata([]);
+    apiMock.expectGetTotalBallotCount(0);
+    apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings(systemSettingsWithBlock);
+
+    renderInAppContext(<ReportsScreen />, {
+      electionDefinition: electionDefinitionWithoutWriteIns,
+      apiMock,
+    });
+
+    await vi.waitFor(() => {
+      screen.getByText(
+        /On Election Day, tally reports and official results are unavailable until/
+      );
+    });
   });
 
   test('ballot count report buttons remain enabled before polls close', async () => {

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.test.tsx
@@ -385,7 +385,7 @@ describe('polls close time enforcement', () => {
     expect(
       screen.getButton('Unofficial Write-In Adjudication Report')
     ).toBeEnabled();
-    screen.getByRole('button', { name: 'Mark Election Results as Official' });
+    expect(screen.getButton('Mark Election Results as Official')).toBeEnabled();
     screen.getByText(/Test cast vote records are currently loaded/);
     expect(
       screen.queryByRole('heading', { name: 'Polls Still Open' })
@@ -404,6 +404,27 @@ describe('polls close time enforcement', () => {
     await screen.findButton('Full Election Tally Report');
     expect(
       screen.queryByText(/Test cast vote records are currently loaded/)
+    ).not.toBeInTheDocument();
+  });
+
+  test('automatically shows reports when polls close time passes', async () => {
+    vi.setSystemTime(new Date('2021-09-08T22:59:00')); // 1 minute before close
+    apiMock.expectGetCastVoteRecordFileMode('official');
+    apiMock.expectGetManualResultsMetadata([]);
+    apiMock.expectGetTotalBallotCount(0);
+    apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings(systemSettingsWithBlock);
+
+    renderInAppContext(<ReportsScreen />, { electionDefinition, apiMock });
+
+    await screen.findByRole('heading', { name: 'Polls Still Open' });
+
+    vi.setSystemTime(new Date('2021-09-08T23:00:01'));
+    await vi.runOnlyPendingTimersAsync();
+
+    await screen.findButton('Full Election Tally Report');
+    expect(
+      screen.queryByRole('heading', { name: 'Polls Still Open' })
     ).not.toBeInTheDocument();
   });
 

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.test.tsx
@@ -291,17 +291,14 @@ describe('Send Tally Reports link', () => {
 });
 
 describe('polls close time enforcement', () => {
-  const POLLS_CLOSE_TIME = '2020-11-03T23:00:00';
+  const POLLS_CLOSE_TIME = '23:00:00';
   const systemSettingsWithBlock: SystemSettings = {
     ...DEFAULT_SYSTEM_SETTINGS,
     disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
     electionDayPollsCloseTime: POLLS_CLOSE_TIME,
   };
 
-  // beforeEach sets fake timers to 2020-11-03T22:22:00, which is before
-  // POLLS_CLOSE_TIME
-
-  test('tally report + WIA report buttons disabled and message shown in official mode before polls close', async () => {
+  test('in official mode before polls close: tally/WIA/official sections hidden, callout shown', async () => {
     apiMock.expectGetCastVoteRecordFileMode('official');
     apiMock.expectGetManualResultsMetadata([]);
     apiMock.expectGetTotalBallotCount(0);
@@ -310,54 +307,24 @@ describe('polls close time enforcement', () => {
 
     renderInAppContext(<ReportsScreen />, { electionDefinition, apiMock });
 
-    await vi.waitFor(() => {
-      expect(screen.getButton('Full Election Tally Report')).toBeDisabled();
-    });
-    expect(screen.getButton('All Precincts Tally Report')).toBeDisabled();
-    expect(screen.getButton('Single Precinct Tally Report')).toBeDisabled();
-    expect(screen.getButton('Tally Report Builder')).toBeDisabled();
+    await screen.findByRole('heading', { name: 'Polls Still Open' });
+    screen.getByText(/Reports containing vote totals are unavailable until/);
     expect(
-      screen.getButton('Unofficial Write-In Adjudication Report')
-    ).toBeDisabled();
-    // electionDefinition has write-in contests, so message uses "certain reports"
-    screen.getByText(
-      /On Election Day, certain reports and official results are unavailable until/
-    );
+      screen.queryByRole('button', { name: 'Full Election Tally Report' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: 'Unofficial Write-In Adjudication Report',
+      })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: 'Mark Election Results as Official',
+      })
+    ).not.toBeInTheDocument();
   });
 
-  test('shows "tally reports" in message when election has no write-in contests', async () => {
-    const electionDefinitionWithoutWriteIns: ElectionDefinition = {
-      ...electionDefinition,
-      election: {
-        ...electionDefinition.election,
-        contests: electionDefinition.election.contests.map((contest) => {
-          if (contest.type === 'candidate') {
-            return { ...contest, allowWriteIns: false };
-          }
-          return contest;
-        }),
-      },
-    };
-
-    apiMock.expectGetCastVoteRecordFileMode('official');
-    apiMock.expectGetManualResultsMetadata([]);
-    apiMock.expectGetTotalBallotCount(0);
-    apiMock.expectGetRegisteredVoterCounts(null);
-    apiMock.expectGetSystemSettings(systemSettingsWithBlock);
-
-    renderInAppContext(<ReportsScreen />, {
-      electionDefinition: electionDefinitionWithoutWriteIns,
-      apiMock,
-    });
-
-    await vi.waitFor(() => {
-      screen.getByText(
-        /On Election Day, tally reports and official results are unavailable until/
-      );
-    });
-  });
-
-  test('ballot count report buttons remain enabled before polls close', async () => {
+  test('ballot count reports remain visible before polls close', async () => {
     apiMock.expectGetCastVoteRecordFileMode('official');
     apiMock.expectGetManualResultsMetadata([]);
     apiMock.expectGetTotalBallotCount(0);
@@ -366,27 +333,14 @@ describe('polls close time enforcement', () => {
 
     renderInAppContext(<ReportsScreen />, { electionDefinition, apiMock });
 
-    await vi.waitFor(() => apiMock.assertComplete());
+    await screen.findByRole('heading', { name: 'Polls Still Open' });
     expect(screen.getButton('Precinct Ballot Count Report')).toBeEnabled();
     expect(screen.getButton('Voting Method Ballot Count Report')).toBeEnabled();
     expect(screen.getButton('Ballot Count Report Builder')).toBeEnabled();
   });
 
-  test('tally report buttons not disabled in test mode before polls close', async () => {
-    apiMock.expectGetCastVoteRecordFileMode('test');
-    apiMock.expectGetManualResultsMetadata([]);
-    apiMock.expectGetTotalBallotCount(0);
-    apiMock.expectGetRegisteredVoterCounts(null);
-    apiMock.expectGetSystemSettings(systemSettingsWithBlock);
-
-    renderInAppContext(<ReportsScreen />, { electionDefinition, apiMock });
-
-    await vi.waitFor(() => apiMock.assertComplete());
-    expect(screen.getButton('Full Election Tally Report')).toBeEnabled();
-  });
-
-  test('tally report buttons not disabled after polls close time', async () => {
-    vi.setSystemTime(new Date('2020-11-03T23:30:00'));
+  test('all reports and official button shown after polls close time', async () => {
+    vi.setSystemTime(new Date('2021-09-08T23:30:00'));
     apiMock.expectGetCastVoteRecordFileMode('official');
     apiMock.expectGetManualResultsMetadata([]);
     apiMock.expectGetTotalBallotCount(0);
@@ -395,11 +349,14 @@ describe('polls close time enforcement', () => {
 
     renderInAppContext(<ReportsScreen />, { electionDefinition, apiMock });
 
-    await vi.waitFor(() => apiMock.assertComplete());
-    expect(screen.getButton('Full Election Tally Report')).toBeEnabled();
+    await screen.findButton('Full Election Tally Report');
+    expect(
+      screen.queryByRole('heading', { name: 'Polls Still Open' })
+    ).not.toBeInTheDocument();
+    screen.getByRole('button', { name: 'Mark Election Results as Official' });
   });
 
-  test('tally report buttons not disabled when setting is not enabled', async () => {
+  test('all reports shown when setting is not enabled', async () => {
     apiMock.expectGetCastVoteRecordFileMode('official');
     apiMock.expectGetManualResultsMetadata([]);
     apiMock.expectGetTotalBallotCount(0);
@@ -408,7 +365,63 @@ describe('polls close time enforcement', () => {
 
     renderInAppContext(<ReportsScreen />, { electionDefinition, apiMock });
 
-    await vi.waitFor(() => apiMock.assertComplete());
+    await screen.findButton('Full Election Tally Report');
+    expect(
+      screen.queryByRole('heading', { name: 'Polls Still Open' })
+    ).not.toBeInTheDocument();
+  });
+
+  test('in test mode: all reports shown and test mode callout displayed', async () => {
+    apiMock.expectGetCastVoteRecordFileMode('test');
+    apiMock.expectGetManualResultsMetadata([]);
+    apiMock.expectGetTotalBallotCount(0);
+    apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings(systemSettingsWithBlock);
+
+    renderInAppContext(<ReportsScreen />, { electionDefinition, apiMock });
+
+    await screen.findButton('Full Election Tally Report');
     expect(screen.getButton('Full Election Tally Report')).toBeEnabled();
+    expect(
+      screen.getButton('Unofficial Write-In Adjudication Report')
+    ).toBeEnabled();
+    screen.getByRole('button', { name: 'Mark Election Results as Official' });
+    screen.getByText(/Test cast vote records are currently loaded/);
+    expect(
+      screen.queryByRole('heading', { name: 'Polls Still Open' })
+    ).not.toBeInTheDocument();
+  });
+
+  test('testmode callout not shown when setting is not enabled', async () => {
+    apiMock.expectGetCastVoteRecordFileMode('test');
+    apiMock.expectGetManualResultsMetadata([]);
+    apiMock.expectGetTotalBallotCount(0);
+    apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings();
+
+    renderInAppContext(<ReportsScreen />, { electionDefinition, apiMock });
+
+    await screen.findButton('Full Election Tally Report');
+    expect(
+      screen.queryByText(/Test cast vote records are currently loaded/)
+    ).not.toBeInTheDocument();
+  });
+
+  test('testmode callout not shown when polls close time is not configured', async () => {
+    apiMock.expectGetCastVoteRecordFileMode('test');
+    apiMock.expectGetManualResultsMetadata([]);
+    apiMock.expectGetTotalBallotCount(0);
+    apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings({
+      ...DEFAULT_SYSTEM_SETTINGS,
+      disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+    });
+
+    renderInAppContext(<ReportsScreen />, { electionDefinition, apiMock });
+
+    await screen.findButton('Full Election Tally Report');
+    expect(
+      screen.queryByText(/Test cast vote records are currently loaded/)
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
@@ -107,10 +107,15 @@ export function ReportsScreen(): JSX.Element {
         <MarkResultsOfficialButton />
       </OfficialResultsCard>
       {closedPollsActionsBlocked &&
+        // `electionDayPollsCloseTime` is guaranteed by `closedPollsActionsBlocked`
+        // but we re-check for type safety
         systemSettingsQuery.data?.electionDayPollsCloseTime && (
           <P>
-            <Icons.Info /> On Election Day, tally reports and official results
-            are unavailable until{' '}
+            <Icons.Warning /> On Election Day,
+            {electionHasWriteInContest
+              ? ' certain reports '
+              : ' tally reports '}
+            and official results are unavailable until{' '}
             {format.localeTime(
               new Date(systemSettingsQuery.data.electionDayPollsCloseTime)
             )}{' '}

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
@@ -1,4 +1,5 @@
 import { useContext } from 'react';
+import { DateTime } from 'luxon';
 
 import { format, isElectionManagerAuth } from '@votingworks/utils';
 import { LinkButton, H2, P, Font, H3, Icons } from '@votingworks/ui';
@@ -67,6 +68,13 @@ export function ReportsScreen(): JSX.Element {
     systemSettingsQuery.data,
     electionDefinition.election.date
   );
+  const pollsCloseDateTime = systemSettingsQuery.data?.electionDayPollsCloseTime
+    ? DateTime.fromISO(
+        `${electionDefinition.election.date.toISOString()}T${
+          systemSettingsQuery.data.electionDayPollsCloseTime
+        }`
+      ).toJSDate()
+    : undefined;
 
   const electionHasWriteInContest = electionDefinition.election.contests.some(
     (c) => c.type === 'candidate' && c.allowWriteIns
@@ -107,26 +115,13 @@ export function ReportsScreen(): JSX.Element {
         )}
         <MarkResultsOfficialButton />
       </OfficialResultsCard>
-      {closedPollsActionsBlocked &&
-        // `electionDayPollsCloseTime` is guaranteed by `closedPollsActionsBlocked`
-        // but we re-check for type safety
-        systemSettingsQuery.data?.electionDayPollsCloseTime && (
-          <P>
-            <Icons.Warning /> On Election Day,
-            {electionHasWriteInContest
-              ? ' certain reports '
-              : ' tally reports '}
-            and official results are unavailable until{' '}
-            {format.localeTime(
-              new Date(systemSettingsQuery.data.electionDayPollsCloseTime)
-            )}{' '}
-            (
-            {format.localeDate(
-              new Date(systemSettingsQuery.data.electionDayPollsCloseTime)
-            )}
-            ).
-          </P>
-        )}
+      {closedPollsActionsBlocked && pollsCloseDateTime && (
+        <P>
+          <Icons.Warning /> Reports containing vote totals are unavailable until{' '}
+          {format.localeTime(pollsCloseDateTime)} on Election Day (
+          {format.localeDate(pollsCloseDateTime)}).
+        </P>
+      )}
       <Section>
         <H2>{statusPrefix} Tally Reports</H2>
         <P>

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../api';
 import { MarkResultsOfficialButton } from '../../components/mark_official_button';
 import { OfficialResultsCard } from '../../components/official_results_card';
+import { areClosedPollsActionsBlocked } from '../../utils/closed_polls_actions';
 
 const Section = styled.section`
   margin-bottom: 2rem;
@@ -61,6 +62,10 @@ export function ReportsScreen(): JSX.Element {
     !!systemSettingsQuery.data?.quickResultsReportingUrl;
 
   const fileMode = castVoteRecordFileModeQuery.data;
+  const closedPollsActionsBlocked = areClosedPollsActionsBlocked(
+    fileMode,
+    systemSettingsQuery.data
+  );
 
   const electionHasWriteInContest = electionDefinition.election.contests.some(
     (c) => c.type === 'candidate' && c.allowWriteIns
@@ -101,21 +106,49 @@ export function ReportsScreen(): JSX.Element {
         )}
         <MarkResultsOfficialButton />
       </OfficialResultsCard>
+      {closedPollsActionsBlocked &&
+        systemSettingsQuery.data?.electionDayPollsCloseTime && (
+          <P>
+            <Icons.Info /> On Election Day, tally reports and official results
+            are unavailable until{' '}
+            {format.localeTime(
+              new Date(systemSettingsQuery.data.electionDayPollsCloseTime)
+            )}{' '}
+            (
+            {format.localeDate(
+              new Date(systemSettingsQuery.data.electionDayPollsCloseTime)
+            )}
+            ).
+          </P>
+        )}
       <Section>
         <H2>{statusPrefix} Tally Reports</H2>
         <P>
-          <LinkButton variant="primary" to={routerPaths.tallyFullReport}>
+          <LinkButton
+            variant="primary"
+            to={routerPaths.tallyFullReport}
+            disabled={closedPollsActionsBlocked}
+          >
             Full Election Tally Report
           </LinkButton>{' '}
-          <LinkButton to={routerPaths.tallyAllPrecinctsReport}>
+          <LinkButton
+            to={routerPaths.tallyAllPrecinctsReport}
+            disabled={closedPollsActionsBlocked}
+          >
             All Precincts Tally Report
           </LinkButton>{' '}
-          <LinkButton to={routerPaths.tallySinglePrecinctReport}>
+          <LinkButton
+            to={routerPaths.tallySinglePrecinctReport}
+            disabled={closedPollsActionsBlocked}
+          >
             Single Precinct Tally Report
           </LinkButton>
         </P>
         <P>
-          <LinkButton to={routerPaths.tallyReportBuilder}>
+          <LinkButton
+            to={routerPaths.tallyReportBuilder}
+            disabled={closedPollsActionsBlocked}
+          >
             Tally Report Builder
           </LinkButton>
         </P>
@@ -144,7 +177,10 @@ export function ReportsScreen(): JSX.Element {
           <H2>Other Reports</H2>
           {electionHasWriteInContest && (
             <P>
-              <LinkButton to={routerPaths.tallyWriteInReport}>
+              <LinkButton
+                to={routerPaths.tallyWriteInReport}
+                disabled={closedPollsActionsBlocked}
+              >
                 {statusPrefix} Write-In Adjudication Report
               </LinkButton>
             </P>

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
@@ -64,7 +64,8 @@ export function ReportsScreen(): JSX.Element {
   const fileMode = castVoteRecordFileModeQuery.data;
   const closedPollsActionsBlocked = areClosedPollsActionsBlocked(
     fileMode,
-    systemSettingsQuery.data
+    systemSettingsQuery.data,
+    electionDefinition.election.date
   );
 
   const electionHasWriteInContest = electionDefinition.election.contests.some(

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useEffect, useReducer } from 'react';
 import { DateTime } from 'luxon';
 
 import { format, isElectionManagerAuth } from '@votingworks/utils';
@@ -57,6 +57,8 @@ export function ReportsScreen(): JSX.Element {
   assert(isElectionManagerAuth(auth));
   assert(electionDefinition && typeof configuredAt === 'string');
 
+  const [, forceUpdate] = useReducer((n: number) => n + 1, 0);
+
   const totalBallotCountQuery = getTotalBallotCount.useQuery();
   const castVoteRecordFileModeQuery = getCastVoteRecordFileMode.useQuery();
   const registeredVoterCountsQuery = getRegisteredVoterCounts.useQuery();
@@ -77,8 +79,25 @@ export function ReportsScreen(): JSX.Element {
         `${electionDefinition.election.date.toISOString()}T${
           systemSettingsQuery.data.electionDayPollsCloseTime
         }`
-      ).toJSDate()
+      )
     : undefined;
+  const pollsCloseDateString = pollsCloseDateTime
+    ? `${format.localeTime(
+        pollsCloseDateTime?.toJSDate()
+      )} on Election Day (${format.localeDate(pollsCloseDateTime?.toJSDate())})`
+    : undefined;
+
+  useEffect(() => {
+    if (!closedPollsActionsBlocked || pollsCloseDateTime === undefined) {
+      return;
+    }
+    const diff = pollsCloseDateTime.diffNow();
+    if (diff.toMillis() <= 0 || diff.as('hours') > 24) {
+      return;
+    }
+    const timeout = setTimeout(forceUpdate, diff.toMillis());
+    return () => clearTimeout(timeout);
+  }, [closedPollsActionsBlocked, pollsCloseDateTime, forceUpdate]);
 
   const electionHasWriteInContest = electionDefinition.election.contests.some(
     (c) => c.type === 'candidate' && c.allowWriteIns
@@ -130,13 +149,11 @@ export function ReportsScreen(): JSX.Element {
               Test cast vote records are currently loaded; all reports are
               available. When official cast vote records are loaded, reports
               containing vote totals will be unavailable until{' '}
-              {format.localeTime(pollsCloseDateTime)} on Election Day (
-              {format.localeDate(pollsCloseDateTime)}). Make sure this time is
-              correct.
+              {pollsCloseDateString}. Make sure this time is correct.
             </Callout>
           </Section>
         )}
-      {closedPollsActionsBlocked && pollsCloseDateTime && (
+      {closedPollsActionsBlocked && pollsCloseDateString && (
         <Section>
           <Callout color="neutral">
             <CalloutIconWrapper>
@@ -146,8 +163,7 @@ export function ReportsScreen(): JSX.Element {
               <H3>Polls Still Open</H3>
               <P>
                 Reports containing vote totals are unavailable until{' '}
-                {format.localeTime(pollsCloseDateTime)} on Election Day (
-                {format.localeDate(pollsCloseDateTime)}).
+                {pollsCloseDateString}.
               </P>
             </div>
           </Callout>

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 import { DateTime } from 'luxon';
 
 import { format, isElectionManagerAuth } from '@votingworks/utils';
-import { LinkButton, H2, P, Font, H3, Icons } from '@votingworks/ui';
+import { Callout, LinkButton, H2, P, Font, H3, Icons } from '@votingworks/ui';
 
 import { assert } from '@votingworks/basics';
 import styled from 'styled-components';
@@ -27,6 +27,10 @@ import { areClosedPollsActionsBlocked } from '../../utils/closed_polls_actions';
 
 const Section = styled.section`
   margin-bottom: 2rem;
+`;
+
+const CalloutIconWrapper = styled.span`
+  margin-top: 0.2em;
 `;
 
 export function isVoterTurnoutReportEnabled(
@@ -101,59 +105,75 @@ export function ReportsScreen(): JSX.Element {
   return (
     <NavigationScreen title="Election Reports">
       {ballotCountSummaryText}
-      <OfficialResultsCard>
-        {isOfficialResults ? (
-          <H3>
-            <Icons.Done color="success" />
-            Election Results are Official
-          </H3>
-        ) : (
-          <H3>
-            <Icons.Info />
-            Election Results are Unofficial
-          </H3>
-        )}
-        <MarkResultsOfficialButton />
-      </OfficialResultsCard>
-      {closedPollsActionsBlocked && pollsCloseDateTime && (
-        <P>
-          <Icons.Warning /> Reports containing vote totals are unavailable until{' '}
-          {format.localeTime(pollsCloseDateTime)} on Election Day (
-          {format.localeDate(pollsCloseDateTime)}).
-        </P>
+      {!closedPollsActionsBlocked && (
+        <OfficialResultsCard>
+          {isOfficialResults ? (
+            <H3>
+              <Icons.Done color="success" />
+              Election Results are Official
+            </H3>
+          ) : (
+            <H3>
+              <Icons.Info />
+              Election Results are Unofficial
+            </H3>
+          )}
+          <MarkResultsOfficialButton />
+        </OfficialResultsCard>
       )}
-      <Section>
-        <H2>{statusPrefix} Tally Reports</H2>
-        <P>
-          <LinkButton
-            variant="primary"
-            to={routerPaths.tallyFullReport}
-            disabled={closedPollsActionsBlocked}
-          >
-            Full Election Tally Report
-          </LinkButton>{' '}
-          <LinkButton
-            to={routerPaths.tallyAllPrecinctsReport}
-            disabled={closedPollsActionsBlocked}
-          >
-            All Precincts Tally Report
-          </LinkButton>{' '}
-          <LinkButton
-            to={routerPaths.tallySinglePrecinctReport}
-            disabled={closedPollsActionsBlocked}
-          >
-            Single Precinct Tally Report
-          </LinkButton>
-        </P>
-        <P>
-          <LinkButton
-            to={routerPaths.tallyReportBuilder}
-            disabled={closedPollsActionsBlocked}
-          >
-            Tally Report Builder
-          </LinkButton>
-        </P>
-      </Section>
+      {fileMode === 'test' &&
+        systemSettingsQuery.data
+          ?.disallowVxAdminTabulationBeforeElectionDayPollsCloseTime &&
+        pollsCloseDateTime && (
+          <Section>
+            <Callout color="neutral" icon="Info">
+              Test cast vote records are currently loaded; all reports are
+              available. When official cast vote records are loaded, reports
+              containing vote totals will be unavailable until{' '}
+              {format.localeTime(pollsCloseDateTime)} on Election Day (
+              {format.localeDate(pollsCloseDateTime)}). Make sure this time is
+              correct.
+            </Callout>
+          </Section>
+        )}
+      {closedPollsActionsBlocked && pollsCloseDateTime && (
+        <Section>
+          <Callout color="neutral">
+            <CalloutIconWrapper>
+              <Icons.Info />
+            </CalloutIconWrapper>
+            <div>
+              <H3>Polls Still Open</H3>
+              <P>
+                Reports containing vote totals are unavailable until{' '}
+                {format.localeTime(pollsCloseDateTime)} on Election Day (
+                {format.localeDate(pollsCloseDateTime)}).
+              </P>
+            </div>
+          </Callout>
+        </Section>
+      )}
+      {!closedPollsActionsBlocked && (
+        <Section>
+          <H2>{statusPrefix} Tally Reports</H2>
+          <P>
+            <LinkButton variant="primary" to={routerPaths.tallyFullReport}>
+              Full Election Tally Report
+            </LinkButton>{' '}
+            <LinkButton to={routerPaths.tallyAllPrecinctsReport}>
+              All Precincts Tally Report
+            </LinkButton>{' '}
+            <LinkButton to={routerPaths.tallySinglePrecinctReport}>
+              Single Precinct Tally Report
+            </LinkButton>
+          </P>
+          <P>
+            <LinkButton to={routerPaths.tallyReportBuilder}>
+              Tally Report Builder
+            </LinkButton>
+          </P>
+        </Section>
+      )}
 
       <Section>
         <H2>{statusPrefix} Ballot Count Reports</H2>
@@ -171,37 +191,38 @@ export function ReportsScreen(): JSX.Element {
           </LinkButton>
         </P>
       </Section>
-      {(electionHasWriteInContest ||
-        voterTurnoutReportEnabled ||
-        isLiveResultsReportingEnabled) && (
-        <Section>
-          <H2>Other Reports</H2>
-          {electionHasWriteInContest && (
-            <P>
-              <LinkButton
-                to={routerPaths.tallyWriteInReport}
-                disabled={closedPollsActionsBlocked}
-              >
-                {statusPrefix} Write-In Adjudication Report
-              </LinkButton>
-            </P>
-          )}
-          {voterTurnoutReportEnabled && (
-            <P>
-              <LinkButton to={routerPaths.voterTurnoutReport}>
-                {statusPrefix} Voter Turnout Report
-              </LinkButton>
-            </P>
-          )}
-          {isLiveResultsReportingEnabled && (
-            <P>
-              <LinkButton to={routerPaths.sendTallyReports}>
-                Send Tally Reports
-              </LinkButton>
-            </P>
-          )}
-        </Section>
-      )}
+      {!closedPollsActionsBlocked &&
+        (electionHasWriteInContest ||
+          voterTurnoutReportEnabled ||
+          isLiveResultsReportingEnabled) && (
+          <Section>
+            <H2>Other Reports</H2>
+            {electionHasWriteInContest && (
+              <P>
+                <LinkButton
+                  to={routerPaths.tallyWriteInReport}
+                  disabled={closedPollsActionsBlocked}
+                >
+                  {statusPrefix} Write-In Adjudication Report
+                </LinkButton>
+              </P>
+            )}
+            {voterTurnoutReportEnabled && (
+              <P>
+                <LinkButton to={routerPaths.voterTurnoutReport}>
+                  {statusPrefix} Voter Turnout Report
+                </LinkButton>
+              </P>
+            )}
+            {isLiveResultsReportingEnabled && (
+              <P>
+                <LinkButton to={routerPaths.sendTallyReports}>
+                  Send Tally Reports
+                </LinkButton>
+              </P>
+            )}
+          </Section>
+        )}
     </NavigationScreen>
   );
 }

--- a/apps/admin/frontend/src/utils/closed_polls_actions.test.ts
+++ b/apps/admin/frontend/src/utils/closed_polls_actions.test.ts
@@ -103,7 +103,7 @@ describe('areClosedPollsActionsBlocked', () => {
     ).toEqual(true);
   });
 
-  test('returns true when before polls close time in unlocked file mode', () => {
+  test('returns false in unlocked file mode', () => {
     vi.setSystemTime(new Date('2026-11-03T18:00:00'));
     expect(
       areClosedPollsActionsBlocked(
@@ -115,7 +115,7 @@ describe('areClosedPollsActionsBlocked', () => {
         },
         ELECTION_DATE
       )
-    ).toEqual(true);
+    ).toEqual(false);
   });
 
   test('returns false when after polls close time', () => {

--- a/apps/admin/frontend/src/utils/closed_polls_actions.test.ts
+++ b/apps/admin/frontend/src/utils/closed_polls_actions.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { DateWithoutTime } from '@votingworks/basics';
 import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
 import { areClosedPollsActionsBlocked } from './closed_polls_actions';
 
-const POLLS_CLOSE_TIME = '2026-11-03T20:00:00';
+const ELECTION_DATE = new DateWithoutTime('2026-11-03');
+const POLLS_CLOSE_TIME = '20:00:00';
 
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -16,43 +18,72 @@ describe('areClosedPollsActionsBlocked', () => {
   test('returns false when fileMode is undefined', () => {
     vi.setSystemTime(new Date('2026-11-03T18:00:00'));
     expect(
-      areClosedPollsActionsBlocked(undefined, {
-        ...DEFAULT_SYSTEM_SETTINGS,
-        disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
-        electionDayPollsCloseTime: POLLS_CLOSE_TIME,
-      })
+      areClosedPollsActionsBlocked(
+        undefined,
+        {
+          ...DEFAULT_SYSTEM_SETTINGS,
+          disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+          electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+        },
+        ELECTION_DATE
+      )
     ).toEqual(false);
   });
 
   test('returns false when fileMode is "test"', () => {
     vi.setSystemTime(new Date('2026-11-03T18:00:00'));
     expect(
-      areClosedPollsActionsBlocked('test', {
-        ...DEFAULT_SYSTEM_SETTINGS,
-        disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
-        electionDayPollsCloseTime: POLLS_CLOSE_TIME,
-      })
+      areClosedPollsActionsBlocked(
+        'test',
+        {
+          ...DEFAULT_SYSTEM_SETTINGS,
+          disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+          electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+        },
+        ELECTION_DATE
+      )
     ).toEqual(false);
   });
 
   test('returns false when system settings are undefined', () => {
     vi.setSystemTime(new Date('2026-11-03T18:00:00'));
-    expect(areClosedPollsActionsBlocked('official', undefined)).toEqual(false);
+    expect(
+      areClosedPollsActionsBlocked('official', undefined, ELECTION_DATE)
+    ).toEqual(false);
   });
 
   test('returns false when the setting is not enabled', () => {
     vi.setSystemTime(new Date('2026-11-03T18:00:00'));
     expect(
-      areClosedPollsActionsBlocked('official', DEFAULT_SYSTEM_SETTINGS)
+      areClosedPollsActionsBlocked(
+        'official',
+        DEFAULT_SYSTEM_SETTINGS,
+        ELECTION_DATE
+      )
     ).toEqual(false);
   });
 
   test('returns false when electionDayPollsCloseTime is not set', () => {
     vi.setSystemTime(new Date('2026-11-03T18:00:00'));
     expect(
+      areClosedPollsActionsBlocked(
+        'official',
+        {
+          ...DEFAULT_SYSTEM_SETTINGS,
+          disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+        },
+        ELECTION_DATE
+      )
+    ).toEqual(false);
+  });
+
+  test('returns false when electionDate is not provided', () => {
+    vi.setSystemTime(new Date('2026-11-03T18:00:00'));
+    expect(
       areClosedPollsActionsBlocked('official', {
         ...DEFAULT_SYSTEM_SETTINGS,
         disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+        electionDayPollsCloseTime: POLLS_CLOSE_TIME,
       })
     ).toEqual(false);
   });
@@ -60,44 +91,60 @@ describe('areClosedPollsActionsBlocked', () => {
   test('returns true when before polls close time in official file mode', () => {
     vi.setSystemTime(new Date('2026-11-03T18:00:00'));
     expect(
-      areClosedPollsActionsBlocked('official', {
-        ...DEFAULT_SYSTEM_SETTINGS,
-        disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
-        electionDayPollsCloseTime: POLLS_CLOSE_TIME,
-      })
+      areClosedPollsActionsBlocked(
+        'official',
+        {
+          ...DEFAULT_SYSTEM_SETTINGS,
+          disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+          electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+        },
+        ELECTION_DATE
+      )
     ).toEqual(true);
   });
 
   test('returns true when before polls close time in unlocked file mode', () => {
     vi.setSystemTime(new Date('2026-11-03T18:00:00'));
     expect(
-      areClosedPollsActionsBlocked('unlocked', {
-        ...DEFAULT_SYSTEM_SETTINGS,
-        disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
-        electionDayPollsCloseTime: POLLS_CLOSE_TIME,
-      })
+      areClosedPollsActionsBlocked(
+        'unlocked',
+        {
+          ...DEFAULT_SYSTEM_SETTINGS,
+          disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+          electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+        },
+        ELECTION_DATE
+      )
     ).toEqual(true);
   });
 
   test('returns false when after polls close time', () => {
     vi.setSystemTime(new Date('2026-11-03T21:00:00'));
     expect(
-      areClosedPollsActionsBlocked('official', {
-        ...DEFAULT_SYSTEM_SETTINGS,
-        disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
-        electionDayPollsCloseTime: POLLS_CLOSE_TIME,
-      })
+      areClosedPollsActionsBlocked(
+        'official',
+        {
+          ...DEFAULT_SYSTEM_SETTINGS,
+          disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+          electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+        },
+        ELECTION_DATE
+      )
     ).toEqual(false);
   });
 
   test('returns false at exactly polls close time', () => {
-    vi.setSystemTime(new Date(POLLS_CLOSE_TIME));
+    vi.setSystemTime(new Date('2026-11-03T20:00:00'));
     expect(
-      areClosedPollsActionsBlocked('official', {
-        ...DEFAULT_SYSTEM_SETTINGS,
-        disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
-        electionDayPollsCloseTime: POLLS_CLOSE_TIME,
-      })
+      areClosedPollsActionsBlocked(
+        'official',
+        {
+          ...DEFAULT_SYSTEM_SETTINGS,
+          disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+          electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+        },
+        ELECTION_DATE
+      )
     ).toEqual(false);
   });
 });

--- a/apps/admin/frontend/src/utils/closed_polls_actions.test.ts
+++ b/apps/admin/frontend/src/utils/closed_polls_actions.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
+import { areClosedPollsActionsBlocked } from './closed_polls_actions';
+
+const POLLS_CLOSE_TIME = '2026-11-03T20:00:00';
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('areClosedPollsActionsBlocked', () => {
+  test('returns false when fileMode is undefined', () => {
+    vi.setSystemTime(new Date('2026-11-03T18:00:00'));
+    expect(
+      areClosedPollsActionsBlocked(undefined, {
+        ...DEFAULT_SYSTEM_SETTINGS,
+        disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+        electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+      })
+    ).toEqual(false);
+  });
+
+  test('returns false when fileMode is "test"', () => {
+    vi.setSystemTime(new Date('2026-11-03T18:00:00'));
+    expect(
+      areClosedPollsActionsBlocked('test', {
+        ...DEFAULT_SYSTEM_SETTINGS,
+        disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+        electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+      })
+    ).toEqual(false);
+  });
+
+  test('returns false when system settings are undefined', () => {
+    vi.setSystemTime(new Date('2026-11-03T18:00:00'));
+    expect(areClosedPollsActionsBlocked('official', undefined)).toEqual(false);
+  });
+
+  test('returns false when the setting is not enabled', () => {
+    vi.setSystemTime(new Date('2026-11-03T18:00:00'));
+    expect(
+      areClosedPollsActionsBlocked('official', DEFAULT_SYSTEM_SETTINGS)
+    ).toEqual(false);
+  });
+
+  test('returns false when electionDayPollsCloseTime is not set', () => {
+    vi.setSystemTime(new Date('2026-11-03T18:00:00'));
+    expect(
+      areClosedPollsActionsBlocked('official', {
+        ...DEFAULT_SYSTEM_SETTINGS,
+        disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+      })
+    ).toEqual(false);
+  });
+
+  test('returns true when before polls close time in official file mode', () => {
+    vi.setSystemTime(new Date('2026-11-03T18:00:00'));
+    expect(
+      areClosedPollsActionsBlocked('official', {
+        ...DEFAULT_SYSTEM_SETTINGS,
+        disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+        electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+      })
+    ).toEqual(true);
+  });
+
+  test('returns true when before polls close time in unlocked file mode', () => {
+    vi.setSystemTime(new Date('2026-11-03T18:00:00'));
+    expect(
+      areClosedPollsActionsBlocked('unlocked', {
+        ...DEFAULT_SYSTEM_SETTINGS,
+        disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+        electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+      })
+    ).toEqual(true);
+  });
+
+  test('returns false when after polls close time', () => {
+    vi.setSystemTime(new Date('2026-11-03T21:00:00'));
+    expect(
+      areClosedPollsActionsBlocked('official', {
+        ...DEFAULT_SYSTEM_SETTINGS,
+        disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+        electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+      })
+    ).toEqual(false);
+  });
+
+  test('returns false at exactly polls close time', () => {
+    vi.setSystemTime(new Date(POLLS_CLOSE_TIME));
+    expect(
+      areClosedPollsActionsBlocked('official', {
+        ...DEFAULT_SYSTEM_SETTINGS,
+        disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
+        electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+      })
+    ).toEqual(false);
+  });
+});

--- a/apps/admin/frontend/src/utils/closed_polls_actions.ts
+++ b/apps/admin/frontend/src/utils/closed_polls_actions.ts
@@ -1,3 +1,5 @@
+import { DateTime } from 'luxon';
+import { DateWithoutTime } from '@votingworks/basics';
 import { SystemSettings } from '@votingworks/types';
 import type { CvrFileMode } from '@votingworks/admin-backend';
 
@@ -7,19 +9,24 @@ import type { CvrFileMode } from '@votingworks/admin-backend';
  *
  * Only applies in official (non-test) file mode when the system setting
  * `disallowVxAdminTabulationBeforeElectionDayPollsCloseTime` is enabled and
- * the current time is before `electionDayPollsCloseTime`.
+ * the current time is before `electionDayPollsCloseTime` on election day.
  */
 export function areClosedPollsActionsBlocked(
   fileMode?: CvrFileMode,
-  systemSettings?: SystemSettings
+  systemSettings?: SystemSettings,
+  electionDate?: DateWithoutTime
 ): boolean {
   if (
     fileMode === undefined ||
     fileMode === 'test' ||
     !systemSettings?.disallowVxAdminTabulationBeforeElectionDayPollsCloseTime ||
-    !systemSettings?.electionDayPollsCloseTime
+    !systemSettings?.electionDayPollsCloseTime ||
+    !electionDate
   ) {
     return false;
   }
-  return new Date(systemSettings.electionDayPollsCloseTime) > new Date();
+  const pollsCloseTime = DateTime.fromISO(
+    `${electionDate.toISOString()}T${systemSettings.electionDayPollsCloseTime}`
+  );
+  return DateTime.now() < pollsCloseTime;
 }

--- a/apps/admin/frontend/src/utils/closed_polls_actions.ts
+++ b/apps/admin/frontend/src/utils/closed_polls_actions.ts
@@ -19,6 +19,7 @@ export function areClosedPollsActionsBlocked(
   if (
     fileMode === undefined ||
     fileMode === 'test' ||
+    fileMode === 'unlocked' ||
     !systemSettings?.disallowVxAdminTabulationBeforeElectionDayPollsCloseTime ||
     !systemSettings?.electionDayPollsCloseTime ||
     !electionDate

--- a/apps/admin/frontend/src/utils/closed_polls_actions.ts
+++ b/apps/admin/frontend/src/utils/closed_polls_actions.ts
@@ -1,0 +1,25 @@
+import { SystemSettings } from '@votingworks/types';
+import type { CvrFileMode } from '@votingworks/admin-backend';
+
+/**
+ * Returns true when VxAdmin should block tally reports, write-in adjudication
+ * reports, and marking results official because polls have not yet closed.
+ *
+ * Only applies in official (non-test) file mode when the system setting
+ * `disallowVxAdminTabulationBeforeElectionDayPollsCloseTime` is enabled and
+ * the current time is before `electionDayPollsCloseTime`.
+ */
+export function areClosedPollsActionsBlocked(
+  fileMode?: CvrFileMode,
+  systemSettings?: SystemSettings
+): boolean {
+  if (
+    fileMode === undefined ||
+    fileMode === 'test' ||
+    !systemSettings?.disallowVxAdminTabulationBeforeElectionDayPollsCloseTime ||
+    !systemSettings?.electionDayPollsCloseTime
+  ) {
+    return false;
+  }
+  return new Date(systemSettings.electionDayPollsCloseTime) > new Date();
+}

--- a/apps/admin/frontend/src/utils/closed_polls_actions.ts
+++ b/apps/admin/frontend/src/utils/closed_polls_actions.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import { DateWithoutTime } from '@votingworks/basics';
+import { assert, DateWithoutTime } from '@votingworks/basics';
 import { SystemSettings } from '@votingworks/types';
 import type { CvrFileMode } from '@votingworks/admin-backend';
 
@@ -28,6 +28,10 @@ export function areClosedPollsActionsBlocked(
   }
   const pollsCloseTime = DateTime.fromISO(
     `${electionDate.toISOString()}T${systemSettings.electionDayPollsCloseTime}`
+  );
+  assert(
+    pollsCloseTime.isValid,
+    `Invalid polls close time: ${pollsCloseTime.invalidExplanation}`
   );
   return DateTime.now() < pollsCloseTime;
 }


### PR DESCRIPTION

## Overview

Closes https://github.com/votingworks/vxsuite/issues/8026

> On VxAdmin
> Official Mode - before the close polls time on election day, disable all tally reports, write-in adjudication scatter reports, and marking the election as official. If the system setting is set. Ballot count reports should remain enabled.
> Test Mode & Zero CVR Mode - no behavior change. this allows L&A and printing zero reports.

## Demo Video or Screenshot


https://github.com/user-attachments/assets/ec8475e5-81f3-4296-ae52-6c433dae5bcb





## Testing Plan

- add frontend tests

## Checklist
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
