### PR TITLE
RadioGroup: Skip onChange when re-selecting current option

### DIFF
--- a/libs/ui/src/radio_group.test.tsx
+++ b/libs/ui/src/radio_group.test.tsx
@@ -130,3 +130,44 @@ test('works with accessible controller interaction pattern', () => {
   userEvent.click(screen.getButton('Four of Hearts'));
   expect(onChange).toBeCalledWith('hearts-4');
 });
+
+test('does not fire onChange when re-selecting current option (native radio input)', () => {
+  const onChange = vi.fn();
+
+  render(
+    <RadioGroup
+      label="Pick a card:"
+      onChange={onChange}
+      options={[
+        { value: 'hearts-4', label: 'Four of Hearts' },
+        { value: 'diamonds-jack', label: 'Jack of Diamonds' },
+      ]}
+      value="diamonds-jack"
+    />
+  );
+
+  userEvent.click(
+    screen.getByRole('radio', { name: 'Jack of Diamonds', checked: true })
+  );
+  expect(onChange).not.toHaveBeenCalled();
+});
+
+test('does not fire onChange when re-selecting current option (touchscreen)', () => {
+  const onChange = vi.fn();
+
+  render(
+    <RadioGroup
+      label="Pick a card:"
+      onChange={onChange}
+      options={[
+        { value: 'hearts-4', label: 'Four of Hearts' },
+        { value: 'diamonds-jack', label: 'Jack of Diamonds' },
+      ]}
+      value="diamonds-jack"
+    />,
+    { vxTheme: { screenType: 'elo15' } }
+  );
+
+  userEvent.click(screen.getButton('Jack of Diamonds'));
+  expect(onChange).not.toHaveBeenCalled();
+});

--- a/libs/ui/src/radio_group.tsx
+++ b/libs/ui/src/radio_group.tsx
@@ -158,7 +158,11 @@ export function RadioOption<T extends RadioGroupValue>(
         // Keyboard navigation will be handled by the radio input,
         // when `shouldUseNativeRadioInteraction === true`:
         tabIndex={shouldUseNativeRadioInteraction ? -1 : undefined}
-        onPress={(newValue: T) => onChange(newValue)}
+        onPress={(newValue: T) => {
+          // Skip onChange when re-selecting the current option to match
+          // native radio input behavior.
+          if (!isSelected) onChange(newValue);
+        }}
         value={value}
       >
         {label}


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

On touchscreen themes, `RadioGroup` falls back to button-based input
because the native radio input is incompatible with our accessible
controllers and screen reader. The fallback's `onPress` fires on every
tap — including taps on the currently-selected option — which doesn't
match how a native HTML radio behaves.

This caused a real bug downstream: in the open-primary party-selection
screen on #8326, re-tapping the same party would call `selectParty`
again, which clears all votes. Gating `onChange` to fire only when the
value actually changes makes touchscreen behavior match the native path
and removes that footgun for all current and future consumers.

## Demo Video or Screenshot

N/A

## Testing Plan

- New unit tests parameterized over native and touchscreen interaction
  paths verify `onChange` is not fired when re-selecting the current
  option.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
