### PR TITLE
VxMark: Add party row to review screen for open primaries

### DIFF
--- a/apps/mark-scan/frontend/src/pages/review_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/review_screen.tsx
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 
 import { ReviewPage } from '@votingworks/mark-flow-ui';
 import { useHistory, useLocation } from 'react-router-dom';
+import { assertDefined } from '@votingworks/basics';
 
 import { BallotContext } from '../contexts/ballot_context';
 import { useVoterHelpScreen } from './use_voter_help_screen';
@@ -22,7 +23,7 @@ export function ReviewScreen(): JSX.Element {
     <ReviewPage
       backUrl={backUrl}
       contests={contests}
-      electionDefinition={electionDefinition}
+      electionDefinition={assertDefined(electionDefinition)}
       precinctId={precinctId}
       ballotStyleId={ballotStyleId}
       printScreenUrl="/print"

--- a/apps/mark/frontend/src/app_open_primary.test.tsx
+++ b/apps/mark/frontend/src/app_open_primary.test.tsx
@@ -114,6 +114,13 @@ test('poll worker activates session, voter picks party and walks through ballot'
     userEvent.click(screen.getButton(/next/i));
   }
   await screen.findByRole('heading', { name: /review your votes/i });
+
+  // From the review screen, "Change Party" lands on party selection in
+  // review mode with a Review button to return
+  userEvent.click(screen.getButton(/change party/i));
+  await screen.findByRole('heading', { name: 'Choose Your Party' });
+  userEvent.click(screen.getButton(/review/i));
+  await screen.findByRole('heading', { name: /review your votes/i });
 });
 
 test('switching party clears votes from the previous party', async () => {

--- a/apps/mark/frontend/src/app_open_primary.test.tsx
+++ b/apps/mark/frontend/src/app_open_primary.test.tsx
@@ -145,6 +145,10 @@ test('switching party clears votes from the previous party', async () => {
   userEvent.click(screen.getButton(/back/i));
   await screen.findByRole('heading', { name: 'Choose Your Party' });
   userEvent.click(screen.getButton('Republican Party'));
+  // Confirm the change-party modal that appears because there are votes.
+  userEvent.click(
+    await screen.findByRole('button', { name: /^change party$/i })
+  );
   userEvent.click(screen.getButton(/next/i));
   await screen.findByRole('heading', { name: 'Governor' });
 

--- a/apps/mark/frontend/src/pages/party_selection_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/party_selection_screen.test.tsx
@@ -4,12 +4,15 @@ import { electionOpenPrimaryFixtures } from '@votingworks/fixtures';
 import { createMemoryHistory } from 'history';
 import { MARK_FLOW_UI_VOTER_SCREEN_TEST_ID } from '@votingworks/mark-flow-ui';
 import userEvent from '@testing-library/user-event';
-import { PartyId, VotesDict } from '@votingworks/types';
+import { CandidateContest, PartyId, VotesDict } from '@votingworks/types';
 import { screen, within } from '../../test/react_testing_library';
 import { render } from '../../test/test_utils';
 import { PartySelectionScreen } from './party_selection_screen';
 
 const electionDefinition = electionOpenPrimaryFixtures.readElectionDefinition();
+const democraticGovernor = electionDefinition.election.contests.find(
+  (c): c is CandidateContest => c.id === 'governor-democratic'
+)!;
 
 test('renders as voter screen with party options', () => {
   render(<Route path="/party-selection" component={PartySelectionScreen} />, {
@@ -82,14 +85,8 @@ test('Next button navigates to first contest when a party is selected', () => {
 
 test('changing party with votes cast prompts confirmation before clearing votes', () => {
   const selectParty = vi.fn();
-  const democraticGovernor = electionDefinition.election.contests.find(
-    (c) => c.id === 'governor-democratic'
-  );
-  if (democraticGovernor?.type !== 'candidate') {
-    throw new Error('expected governor-democratic to be a candidate contest');
-  }
   const votes: VotesDict = {
-    'governor-democratic': [democraticGovernor.candidates[0]],
+    [democraticGovernor.id]: [democraticGovernor.candidates[0]],
   };
   render(<Route path="/party-selection" component={PartySelectionScreen} />, {
     electionDefinition,
@@ -130,4 +127,41 @@ test('changing party with no votes cast skips the confirmation modal', () => {
   userEvent.click(screen.getByRole('radio', { name: 'Republican Party' }));
   expect(screen.queryByRole('alertdialog')).toBeNull();
   expect(selectParty).toHaveBeenCalledWith('republican-party');
+});
+
+test('entering from review shows a Review button until a vote-clearing change is confirmed', () => {
+  const selectParty = vi.fn();
+  const votes: VotesDict = {
+    [democraticGovernor.id]: [democraticGovernor.candidates[0]],
+  };
+  const history = createMemoryHistory({
+    initialEntries: ['/party-selection#review'],
+  });
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    history,
+    route: '/party-selection#review',
+    selectedPartyId: 'democratic-party' as PartyId,
+    selectParty,
+    votes,
+  });
+
+  // From review: only the Review button is shown (no Back/Next).
+  expect(screen.queryButton(/^back$/i)).toBeNull();
+  expect(screen.queryButton(/^next$/i)).toBeNull();
+
+  // Cancelling a vote-clearing change keeps review mode.
+  userEvent.click(screen.getByRole('radio', { name: 'Republican Party' }));
+  userEvent.click(within(screen.getByRole('alertdialog')).getButton(/cancel/i));
+  screen.getButton(/review/i);
+
+  // Confirming the change clears votes and switches to the standard footer.
+  userEvent.click(screen.getByRole('radio', { name: 'Republican Party' }));
+  userEvent.click(
+    within(screen.getByRole('alertdialog')).getButton(/^change party$/i)
+  );
+  expect(selectParty).toHaveBeenCalledWith('republican-party');
+  expect(screen.queryButton(/review/i)).toBeNull();
+  screen.getButton(/^back$/i);
+  screen.getButton(/^next$/i);
 });

--- a/apps/mark/frontend/src/pages/party_selection_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/party_selection_screen.test.tsx
@@ -4,8 +4,8 @@ import { electionOpenPrimaryFixtures } from '@votingworks/fixtures';
 import { createMemoryHistory } from 'history';
 import { MARK_FLOW_UI_VOTER_SCREEN_TEST_ID } from '@votingworks/mark-flow-ui';
 import userEvent from '@testing-library/user-event';
-import { PartyId } from '@votingworks/types';
-import { screen } from '../../test/react_testing_library';
+import { PartyId, VotesDict } from '@votingworks/types';
+import { screen, within } from '../../test/react_testing_library';
 import { render } from '../../test/test_utils';
 import { PartySelectionScreen } from './party_selection_screen';
 
@@ -78,4 +78,56 @@ test('Next button navigates to first contest when a party is selected', () => {
 
   userEvent.click(screen.getButton(/next/i));
   expect(history.location.pathname).toEqual('/contests/0');
+});
+
+test('changing party with votes cast prompts confirmation before clearing votes', () => {
+  const selectParty = vi.fn();
+  const democraticGovernor = electionDefinition.election.contests.find(
+    (c) => c.id === 'governor-democratic'
+  );
+  if (democraticGovernor?.type !== 'candidate') {
+    throw new Error('expected governor-democratic to be a candidate contest');
+  }
+  const votes: VotesDict = {
+    'governor-democratic': [democraticGovernor.candidates[0]],
+  };
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    route: '/party-selection',
+    selectedPartyId: 'democratic-party' as PartyId,
+    selectParty,
+    votes,
+  });
+
+  // Tapping a different party opens the modal without changing the party yet.
+  userEvent.click(screen.getByRole('radio', { name: 'Republican Party' }));
+  let modal = screen.getByRole('alertdialog');
+  within(modal).getByText(/clear all of your votes/i);
+  expect(selectParty).not.toHaveBeenCalled();
+
+  // Cancel closes the modal and leaves the party unchanged.
+  userEvent.click(within(modal).getButton(/cancel/i));
+  expect(screen.queryByRole('alertdialog')).toBeNull();
+  expect(selectParty).not.toHaveBeenCalled();
+
+  // Reopening and confirming applies the new party.
+  userEvent.click(screen.getByRole('radio', { name: 'Republican Party' }));
+  modal = screen.getByRole('alertdialog');
+  userEvent.click(within(modal).getButton(/^change party$/i));
+  expect(selectParty).toHaveBeenCalledWith('republican-party');
+  expect(screen.queryByRole('alertdialog')).toBeNull();
+});
+
+test('changing party with no votes cast skips the confirmation modal', () => {
+  const selectParty = vi.fn();
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    route: '/party-selection',
+    selectedPartyId: 'democratic-party' as PartyId,
+    selectParty,
+  });
+
+  userEvent.click(screen.getByRole('radio', { name: 'Republican Party' }));
+  expect(screen.queryByRole('alertdialog')).toBeNull();
+  expect(selectParty).toHaveBeenCalledWith('republican-party');
 });

--- a/apps/mark/frontend/src/pages/party_selection_screen.tsx
+++ b/apps/mark/frontend/src/pages/party_selection_screen.tsx
@@ -3,9 +3,12 @@ import styled from 'styled-components';
 import { assertDefined } from '@votingworks/basics';
 import { PartyId } from '@votingworks/types';
 import {
+  Button,
   Caption,
   H2,
   LinkButton,
+  Modal,
+  P,
   PageNavigationButtonId,
   RadioGroup,
   WithScrollButtons,
@@ -24,9 +27,23 @@ const OptionRadioGroup = styled(RadioGroup<PartyId>)`
 `;
 
 export function PartySelectionScreen(): JSX.Element {
-  const { electionDefinition, selectParty, selectedPartyId } =
+  const { electionDefinition, selectParty, selectedPartyId, votes } =
     React.useContext(BallotContext);
   const { election } = assertDefined(electionDefinition);
+  const [partyIdToConfirm, setPartyIdToConfirm] = React.useState<PartyId>();
+
+  function handleSelect(partyId: PartyId) {
+    if (
+      partyId !== selectedPartyId &&
+      Object.values(votes).some(
+        (contestVotes) => contestVotes && contestVotes.length > 0
+      )
+    ) {
+      setPartyIdToConfirm(partyId);
+    } else {
+      selectParty(partyId);
+    }
+  }
 
   return (
     <VoterScreen
@@ -67,9 +84,35 @@ export function PartySelectionScreen(): JSX.Element {
             label: party.fullName,
           }))}
           value={selectedPartyId}
-          onChange={(partyId) => selectParty(partyId)}
+          onChange={handleSelect}
         />
       </WithScrollButtons>
+      {partyIdToConfirm && (
+        <Modal
+          title="Change Party?"
+          content={<P>Changing your party will clear all of your votes.</P>}
+          actions={
+            <React.Fragment>
+              <Button
+                variant="primary"
+                onPress={() => {
+                  selectParty(partyIdToConfirm);
+                  setPartyIdToConfirm(undefined);
+                }}
+              >
+                Change Party
+              </Button>
+              <Button onPress={() => setPartyIdToConfirm(undefined)}>
+                Cancel
+              </Button>
+            </React.Fragment>
+          }
+          onOverlayClick={
+            /* istanbul ignore next - @preserve */
+            () => setPartyIdToConfirm(undefined)
+          }
+        />
+      )}
     </VoterScreen>
   );
 }

--- a/apps/mark/frontend/src/pages/party_selection_screen.tsx
+++ b/apps/mark/frontend/src/pages/party_selection_screen.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { assertDefined } from '@votingworks/basics';
 import { PartyId } from '@votingworks/types';
 import {
+  appStrings,
   Button,
   Caption,
   H2,
@@ -13,7 +14,7 @@ import {
   RadioGroup,
   WithScrollButtons,
 } from '@votingworks/ui';
-import { VoterScreen } from '@votingworks/mark-flow-ui';
+import { useIsReviewMode, VoterScreen } from '@votingworks/mark-flow-ui';
 import { BallotContext } from '../contexts/ballot_context';
 
 const Header = styled.div`
@@ -31,6 +32,9 @@ export function PartySelectionScreen(): JSX.Element {
     React.useContext(BallotContext);
   const { election } = assertDefined(electionDefinition);
   const [partyIdToConfirm, setPartyIdToConfirm] = React.useState<PartyId>();
+  // Snapshot the initial review mode state so that we can flip it off if the
+  // voter changes their party
+  const [isReviewMode, setIsReviewMode] = React.useState(useIsReviewMode());
 
   function handleSelect(partyId: PartyId) {
     if (
@@ -48,24 +52,35 @@ export function PartySelectionScreen(): JSX.Element {
   return (
     <VoterScreen
       actionButtons={
-        <React.Fragment>
+        isReviewMode ? (
           <LinkButton
             icon="Previous"
-            id={PageNavigationButtonId.PREVIOUS}
-            to="/"
-          >
-            Back
-          </LinkButton>
-          <LinkButton
-            rightIcon="Next"
             id={PageNavigationButtonId.NEXT}
-            variant={selectedPartyId ? 'primary' : 'neutral'}
-            to={selectedPartyId ? '/contests/0' : undefined}
-            disabled={!selectedPartyId}
+            variant="primary"
+            to="/review"
           >
-            Next
+            {appStrings.buttonReview()}
           </LinkButton>
-        </React.Fragment>
+        ) : (
+          <React.Fragment>
+            <LinkButton
+              icon="Previous"
+              id={PageNavigationButtonId.PREVIOUS}
+              to="/"
+            >
+              Back
+            </LinkButton>
+            <LinkButton
+              rightIcon="Next"
+              id={PageNavigationButtonId.NEXT}
+              variant={selectedPartyId ? 'primary' : 'neutral'}
+              to={selectedPartyId ? '/contests/0' : undefined}
+              disabled={!selectedPartyId}
+            >
+              Next
+            </LinkButton>
+          </React.Fragment>
+        )
       }
     >
       <Header>
@@ -89,7 +104,7 @@ export function PartySelectionScreen(): JSX.Element {
       </WithScrollButtons>
       {partyIdToConfirm && (
         <Modal
-          title="Change Party?"
+          title="Confirm Party Change"
           content={<P>Changing your party will clear all of your votes.</P>}
           actions={
             <React.Fragment>
@@ -98,6 +113,7 @@ export function PartySelectionScreen(): JSX.Element {
                 onPress={() => {
                   selectParty(partyIdToConfirm);
                   setPartyIdToConfirm(undefined);
+                  setIsReviewMode(false);
                 }}
               >
                 Change Party

--- a/apps/mark/frontend/src/pages/review_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/review_screen.test.tsx
@@ -8,7 +8,7 @@ import { createMemoryHistory } from 'history';
 import { MARK_FLOW_UI_VOTER_SCREEN_TEST_ID } from '@votingworks/mark-flow-ui';
 import userEvent from '@testing-library/user-event';
 import { BallotStyleId, PartyId } from '@votingworks/types';
-import { screen, within } from '../../test/react_testing_library';
+import { screen } from '../../test/react_testing_library';
 import { mockMachineConfig } from '../../test/helpers/mock_machine_config';
 
 import { render as renderWithBallotContext } from '../../test/test_utils';
@@ -115,7 +115,7 @@ test('renders as voter screen', () => {
   screen.getByTestId(MARK_FLOW_UI_VOTER_SCREEN_TEST_ID);
 });
 
-test('open primary review screen has party row and change-party flow', () => {
+test('open primary review screen shows party row and links to party selection', () => {
   const history = createMemoryHistory({ initialEntries: ['/review'] });
   renderWithBallotContext(<Route path="/review" component={ReviewScreen} />, {
     history,
@@ -130,19 +130,6 @@ test('open primary review screen has party row and change-party flow', () => {
   screen.getByText('Party');
   screen.getByText('Democratic Party');
 
-  // Change Party opens the confirmation modal warning votes will be cleared.
   userEvent.click(screen.getButton(/change party/i));
-  let modal = screen.getByRole('alertdialog');
-  within(modal).getByText(/clear all of your votes/i);
-
-  // Cancel closes the modal and stays on the review screen.
-  userEvent.click(within(modal).getButton(/cancel/i));
-  expect(screen.queryByRole('alertdialog')).toBeNull();
-  expect(history.location.pathname).toEqual('/review');
-
-  // Reopening and confirming navigates to the party selection screen.
-  userEvent.click(screen.getButton(/change party/i));
-  modal = screen.getByRole('alertdialog');
-  userEvent.click(within(modal).getButton(/^change party$/i));
   expect(history.location.pathname).toEqual('/party-selection');
 });

--- a/apps/mark/frontend/src/pages/review_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/review_screen.test.tsx
@@ -1,10 +1,14 @@
 import { expect, test, vi } from 'vitest';
 import { Route } from 'react-router-dom';
-import { readElectionGeneral } from '@votingworks/fixtures';
+import {
+  electionOpenPrimaryFixtures,
+  readElectionGeneral,
+} from '@votingworks/fixtures';
 import { createMemoryHistory } from 'history';
 import { MARK_FLOW_UI_VOTER_SCREEN_TEST_ID } from '@votingworks/mark-flow-ui';
 import userEvent from '@testing-library/user-event';
-import { screen } from '../../test/react_testing_library';
+import { BallotStyleId, PartyId } from '@votingworks/types';
+import { screen, within } from '../../test/react_testing_library';
 import { mockMachineConfig } from '../../test/helpers/mock_machine_config';
 
 import { render as renderWithBallotContext } from '../../test/test_utils';
@@ -12,6 +16,8 @@ import { render as renderWithBallotContext } from '../../test/test_utils';
 import { ReviewScreen } from './review_screen';
 
 const electionGeneral = readElectionGeneral();
+const electionOpenPrimaryDefinition =
+  electionOpenPrimaryFixtures.readElectionDefinition();
 
 vi.setConfig({
   testTimeout: 20_000,
@@ -27,6 +33,9 @@ test('Renders ReviewScreen with Print My Ballot in final review mode', () => {
   screen.getByText('Settings');
   screen.getButton(/print my ballot/i);
   expect(screen.queryButton(/back/i)).toBeNull();
+  // No party row for non-open-primary elections.
+  expect(screen.queryByText(/^party$/i)).toBeNull();
+  expect(screen.queryButton(/change party/i)).toBeNull();
 });
 
 test('Renders ReviewScreen in Landscape orientation', () => {
@@ -104,4 +113,36 @@ test('renders as voter screen', () => {
   });
 
   screen.getByTestId(MARK_FLOW_UI_VOTER_SCREEN_TEST_ID);
+});
+
+test('open primary review screen has party row and change-party flow', () => {
+  const history = createMemoryHistory({ initialEntries: ['/review'] });
+  renderWithBallotContext(<Route path="/review" component={ReviewScreen} />, {
+    history,
+    route: '/review',
+    electionDefinition: electionOpenPrimaryDefinition,
+    precinctId: 'precinct-1',
+    ballotStyleId: 'ballot-style-1' as BallotStyleId,
+    selectedPartyId: 'democratic-party' as PartyId,
+  });
+
+  // Party row shows the selected party.
+  screen.getByText('Party');
+  screen.getByText('Democratic Party');
+
+  // Change Party opens the confirmation modal warning votes will be cleared.
+  userEvent.click(screen.getButton(/change party/i));
+  let modal = screen.getByRole('alertdialog');
+  within(modal).getByText(/clear all of your votes/i);
+
+  // Cancel closes the modal and stays on the review screen.
+  userEvent.click(within(modal).getButton(/cancel/i));
+  expect(screen.queryByRole('alertdialog')).toBeNull();
+  expect(history.location.pathname).toEqual('/review');
+
+  // Reopening and confirming navigates to the party selection screen.
+  userEvent.click(screen.getButton(/change party/i));
+  modal = screen.getByRole('alertdialog');
+  userEvent.click(within(modal).getButton(/^change party$/i));
+  expect(history.location.pathname).toEqual('/party-selection');
 });

--- a/apps/mark/frontend/src/pages/review_screen.tsx
+++ b/apps/mark/frontend/src/pages/review_screen.tsx
@@ -9,13 +9,22 @@ import { BallotContext } from '../contexts/ballot_context';
 export function ReviewScreen(): JSX.Element {
   const history = useHistory();
   const location = useLocation();
-  const { contests, electionDefinition, precinctId, ballotStyleId, votes } =
-    useContext(BallotContext);
+  const {
+    contests,
+    electionDefinition,
+    precinctId,
+    ballotStyleId,
+    selectedPartyId,
+    votes,
+  } = useContext(BallotContext);
 
   const searchParams = new URLSearchParams(location.search);
   const fromContest = searchParams.get('fromContest');
   const isFinalReview = !fromContest;
   const backUrl = !isFinalReview ? `/contests/${fromContest}` : undefined;
+  const partySelectionScreenUrl = selectedPartyId
+    ? '/party-selection'
+    : undefined;
 
   return (
     <ReviewPage
@@ -34,6 +43,8 @@ export function ReviewScreen(): JSX.Element {
         );
       }}
       votes={votes}
+      selectedPartyId={selectedPartyId}
+      partySelectionScreenUrl={partySelectionScreenUrl}
     />
   );
 }

--- a/apps/mark/frontend/src/pages/review_screen.tsx
+++ b/apps/mark/frontend/src/pages/review_screen.tsx
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
 import { ReviewPage } from '@votingworks/mark-flow-ui';
+import { assertDefined } from '@votingworks/basics';
 
 import { BallotContext } from '../contexts/ballot_context';
 
@@ -21,7 +22,7 @@ export function ReviewScreen(): JSX.Element {
       backUrl={backUrl}
       ballotStyleId={ballotStyleId}
       contests={contests}
-      electionDefinition={electionDefinition}
+      electionDefinition={assertDefined(electionDefinition)}
       precinctId={precinctId}
       printScreenUrl="/print"
       returnToContest={(contestId) => {

--- a/apps/mark/frontend/src/pages/review_screen.tsx
+++ b/apps/mark/frontend/src/pages/review_screen.tsx
@@ -23,7 +23,7 @@ export function ReviewScreen(): JSX.Element {
   const isFinalReview = !fromContest;
   const backUrl = !isFinalReview ? `/contests/${fromContest}` : undefined;
   const partySelectionScreenUrl = selectedPartyId
-    ? '/party-selection'
+    ? `/party-selection${isFinalReview ? '#review' : ''}`
     : undefined;
 
   return (

--- a/libs/mark-flow-ui/src/pages/review_page.tsx
+++ b/libs/mark-flow-ui/src/pages/review_page.tsx
@@ -1,9 +1,15 @@
 /* istanbul ignore file - @preserve - tested via Mark/Mark-Scan */
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import {
+  Button,
+  Caption,
+  electionStrings,
+  Font,
   LinkButton,
   H1,
+  Modal,
+  P,
   WithScrollButtons,
   appStrings,
   AudioOnly,
@@ -12,11 +18,12 @@ import {
   AssistiveTechInstructions,
 } from '@votingworks/ui';
 
-import { assert } from '@votingworks/basics';
+import { assert, assertDefined, find } from '@votingworks/basics';
 
 import {
   BallotStyleId,
   ElectionDefinition,
+  PartyId,
   PrecinctId,
   VotesDict,
   getBallotStyle,
@@ -29,6 +36,14 @@ const ContentHeader = styled(ReadOnLoad)`
   padding: 0.5rem 0.75rem 0;
 `;
 
+const PartyRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 0.75rem;
+`;
+
 export interface ReviewPageProps {
   backUrl?: string;
   contests: ContestsWithMsEitherNeither;
@@ -39,6 +54,8 @@ export interface ReviewPageProps {
   returnToContest?: ReviewProps['returnToContest'];
   votes: VotesDict;
   VoterHelpScreen?: VoterHelpScreenType;
+  selectedPartyId?: PartyId;
+  partySelectionScreenUrl?: string;
 }
 
 export function ReviewPage(props: ReviewPageProps): JSX.Element {
@@ -52,7 +69,11 @@ export function ReviewPage(props: ReviewPageProps): JSX.Element {
     returnToContest,
     votes,
     VoterHelpScreen,
+    selectedPartyId,
+    partySelectionScreenUrl,
   } = props;
+
+  const [isChangePartyModalOpen, setIsChangePartyModalOpen] = useState(false);
 
   assert(
     typeof precinctId !== 'undefined',
@@ -62,8 +83,9 @@ export function ReviewPage(props: ReviewPageProps): JSX.Element {
     typeof ballotStyleId !== 'undefined',
     'ballotStyleId is required to render ReviewPage'
   );
+  const { election } = electionDefinition;
   const ballotStyle = getBallotStyle({
-    election: electionDefinition.election,
+    election,
     ballotStyleId,
   });
   assert(ballotStyle, `Ballot style with id ${ballotStyleId} not found`);
@@ -118,9 +140,29 @@ export function ReviewPage(props: ReviewPageProps): JSX.Element {
           />
         </AudioOnly>
       </ContentHeader>
+      {partySelectionScreenUrl && (
+        <PartyRow>
+          <div>
+            <Caption>Party</Caption>
+            <div>
+              <Font weight="bold">
+                {electionStrings.partyFullName(
+                  find(
+                    election.parties,
+                    (party) => party.id === assertDefined(selectedPartyId)
+                  )
+                )}
+              </Font>
+            </div>
+          </div>
+          <Button icon="Edit" onPress={() => setIsChangePartyModalOpen(true)}>
+            Change Party
+          </Button>
+        </PartyRow>
+      )}
       <WithScrollButtons>
         <Review
-          election={electionDefinition.election}
+          election={election}
           contests={contests}
           precinctId={precinctId}
           votes={votes}
@@ -128,6 +170,23 @@ export function ReviewPage(props: ReviewPageProps): JSX.Element {
           ballotStyle={ballotStyle}
         />
       </WithScrollButtons>
+      {isChangePartyModalOpen && (
+        <Modal
+          title="Change Party?"
+          content={<P>Changing your party will clear all of your votes.</P>}
+          actions={
+            <React.Fragment>
+              <LinkButton variant="primary" to={partySelectionScreenUrl}>
+                Change Party
+              </LinkButton>
+              <Button onPress={() => setIsChangePartyModalOpen(false)}>
+                Cancel
+              </Button>
+            </React.Fragment>
+          }
+          onOverlayClick={() => setIsChangePartyModalOpen(false)}
+        />
+      )}
     </VoterScreen>
   );
 }

--- a/libs/mark-flow-ui/src/pages/review_page.tsx
+++ b/libs/mark-flow-ui/src/pages/review_page.tsx
@@ -1,15 +1,12 @@
 /* istanbul ignore file - @preserve - tested via Mark/Mark-Scan */
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import {
-  Button,
   Caption,
   electionStrings,
   Font,
   LinkButton,
   H1,
-  Modal,
-  P,
   WithScrollButtons,
   appStrings,
   AudioOnly,
@@ -72,8 +69,6 @@ export function ReviewPage(props: ReviewPageProps): JSX.Element {
     selectedPartyId,
     partySelectionScreenUrl,
   } = props;
-
-  const [isChangePartyModalOpen, setIsChangePartyModalOpen] = useState(false);
 
   assert(
     typeof precinctId !== 'undefined',
@@ -155,9 +150,9 @@ export function ReviewPage(props: ReviewPageProps): JSX.Element {
               </Font>
             </div>
           </div>
-          <Button icon="Edit" onPress={() => setIsChangePartyModalOpen(true)}>
+          <LinkButton icon="Edit" to={partySelectionScreenUrl}>
             Change Party
-          </Button>
+          </LinkButton>
         </PartyRow>
       )}
       <WithScrollButtons>
@@ -170,23 +165,6 @@ export function ReviewPage(props: ReviewPageProps): JSX.Element {
           ballotStyle={ballotStyle}
         />
       </WithScrollButtons>
-      {isChangePartyModalOpen && (
-        <Modal
-          title="Change Party?"
-          content={<P>Changing your party will clear all of your votes.</P>}
-          actions={
-            <React.Fragment>
-              <LinkButton variant="primary" to={partySelectionScreenUrl}>
-                Change Party
-              </LinkButton>
-              <Button onPress={() => setIsChangePartyModalOpen(false)}>
-                Cancel
-              </Button>
-            </React.Fragment>
-          }
-          onOverlayClick={() => setIsChangePartyModalOpen(false)}
-        />
-      )}
     </VoterScreen>
   );
 }

--- a/libs/mark-flow-ui/src/pages/review_page.tsx
+++ b/libs/mark-flow-ui/src/pages/review_page.tsx
@@ -32,7 +32,7 @@ const ContentHeader = styled(ReadOnLoad)`
 export interface ReviewPageProps {
   backUrl?: string;
   contests: ContestsWithMsEitherNeither;
-  electionDefinition?: ElectionDefinition;
+  electionDefinition: ElectionDefinition;
   precinctId?: PrecinctId;
   ballotStyleId?: BallotStyleId;
   printScreenUrl: string;
@@ -54,10 +54,6 @@ export function ReviewPage(props: ReviewPageProps): JSX.Element {
     VoterHelpScreen,
   } = props;
 
-  assert(
-    electionDefinition,
-    'electionDefinition is required to render ReviewPage'
-  );
   assert(
     typeof precinctId !== 'undefined',
     'precinctId is required to render ReviewPage'


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Task: #7823. Stacked on #8326.

Adds a "Party: X" row to the top of the VxMark review screen for open primaries, with a "Change Party" button. Clicking it navigates back to the party selection screen. If you then select a new party, a confirmation modal pops up.

## Demo Video or Screenshot


https://github.com/user-attachments/assets/b258593c-74bf-4989-88ae-842ddf82d50c



## Testing Plan

- Updated automated test
- Manual testing

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
