### PR TITLE
VxMark: Add party label to partisan contests on summary ballots in open primaries

### DIFF
--- a/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
@@ -133,7 +133,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 class="sc-cWSHoV dUXOXi"
               >
                 <span
-                  class="sc-fhzFiK ceOrAW"
+                  class="sc-jxOSlx euoqcA"
                 >
                   <span>
                     President
@@ -141,7 +141,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 </span>
               </div>
               <span
-                class="sc-eBMEME cUwJQa"
+                class="sc-dCFHLb RAqQW"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -161,7 +161,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 class="sc-cWSHoV dUXOXi"
               >
                 <span
-                  class="sc-fhzFiK ceOrAW"
+                  class="sc-jxOSlx euoqcA"
                 >
                   <span>
                     Senate 
@@ -169,7 +169,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 </span>
               </div>
               <span
-                class="sc-eBMEME cUwJQa"
+                class="sc-dCFHLb RAqQW"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -189,7 +189,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 class="sc-cWSHoV dUXOXi"
               >
                 <span
-                  class="sc-fhzFiK ceOrAW"
+                  class="sc-jxOSlx euoqcA"
                 >
                   <span>
                     1st Congressional District
@@ -197,7 +197,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 </span>
               </div>
               <span
-                class="sc-eBMEME cUwJQa"
+                class="sc-dCFHLb RAqQW"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -217,7 +217,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 class="sc-cWSHoV dUXOXi"
               >
                 <span
-                  class="sc-fhzFiK ceOrAW"
+                  class="sc-jxOSlx euoqcA"
                 >
                   <span>
                     Supreme Court District 3(Northern) Position 3
@@ -225,7 +225,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 </span>
               </div>
               <span
-                class="sc-eBMEME cUwJQa"
+                class="sc-dCFHLb RAqQW"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -245,7 +245,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 class="sc-cWSHoV dUXOXi"
               >
                 <span
-                  class="sc-fhzFiK ceOrAW"
+                  class="sc-jxOSlx euoqcA"
                 >
                   <span>
                     Election Commissioner 04
@@ -253,7 +253,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 </span>
               </div>
               <span
-                class="sc-eBMEME cUwJQa"
+                class="sc-dCFHLb RAqQW"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -273,7 +273,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 class="sc-cWSHoV dUXOXi"
               >
                 <span
-                  class="sc-fhzFiK ceOrAW"
+                  class="sc-jxOSlx euoqcA"
                 >
                   <span>
                     Ballot Measure 2
@@ -282,7 +282,7 @@ House Concurrent Resolution No. 47
                 </span>
               </div>
               <span
-                class="sc-eBMEME cUwJQa"
+                class="sc-dCFHLb RAqQW"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -302,7 +302,7 @@ House Concurrent Resolution No. 47
                 class="sc-cWSHoV dUXOXi"
               >
                 <span
-                  class="sc-fhzFiK ceOrAW"
+                  class="sc-jxOSlx euoqcA"
                 >
                   <span>
                     Ballot Measure 3
@@ -311,7 +311,7 @@ House Bill 1796 - Flag Referendum
                 </span>
               </div>
               <span
-                class="sc-eBMEME cUwJQa"
+                class="sc-dCFHLb RAqQW"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -331,7 +331,7 @@ House Bill 1796 - Flag Referendum
                 class="sc-cWSHoV dUXOXi"
               >
                 <span
-                  class="sc-fhzFiK ceOrAW"
+                  class="sc-jxOSlx euoqcA"
                 >
                   <span>
                     Ballot Measure 1
@@ -339,7 +339,7 @@ House Bill 1796 - Flag Referendum
                 </span>
               </div>
               <span
-                class="sc-eBMEME cUwJQa"
+                class="sc-dCFHLb RAqQW"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -359,7 +359,7 @@ House Bill 1796 - Flag Referendum
                 class="sc-cWSHoV dUXOXi"
               >
                 <span
-                  class="sc-fhzFiK ceOrAW"
+                  class="sc-jxOSlx euoqcA"
                 >
                   <span>
                     Ballot Measure 1 - Part 2
@@ -367,7 +367,7 @@ House Bill 1796 - Flag Referendum
                 </span>
               </div>
               <span
-                class="sc-eBMEME cUwJQa"
+                class="sc-dCFHLb RAqQW"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -514,7 +514,7 @@ House Bill 1796 - Flag Referendum
               class="sc-cWSHoV dUXOXi"
             >
               <span
-                class="sc-fhzFiK ceOrAW"
+                class="sc-jxOSlx euoqcA"
               >
                 <span>
                   President
@@ -522,7 +522,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-eBMEME cUwJQa"
+              class="sc-dCFHLb RAqQW"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -542,7 +542,7 @@ House Bill 1796 - Flag Referendum
               class="sc-cWSHoV dUXOXi"
             >
               <span
-                class="sc-fhzFiK ceOrAW"
+                class="sc-jxOSlx euoqcA"
               >
                 <span>
                   Senate 
@@ -550,7 +550,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-eBMEME cUwJQa"
+              class="sc-dCFHLb RAqQW"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -570,7 +570,7 @@ House Bill 1796 - Flag Referendum
               class="sc-cWSHoV dUXOXi"
             >
               <span
-                class="sc-fhzFiK ceOrAW"
+                class="sc-jxOSlx euoqcA"
               >
                 <span>
                   1st Congressional District
@@ -578,7 +578,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-eBMEME cUwJQa"
+              class="sc-dCFHLb RAqQW"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -598,7 +598,7 @@ House Bill 1796 - Flag Referendum
               class="sc-cWSHoV dUXOXi"
             >
               <span
-                class="sc-fhzFiK ceOrAW"
+                class="sc-jxOSlx euoqcA"
               >
                 <span>
                   Supreme Court District 3(Northern) Position 3
@@ -606,7 +606,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-eBMEME cUwJQa"
+              class="sc-dCFHLb RAqQW"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -626,7 +626,7 @@ House Bill 1796 - Flag Referendum
               class="sc-cWSHoV dUXOXi"
             >
               <span
-                class="sc-fhzFiK ceOrAW"
+                class="sc-jxOSlx euoqcA"
               >
                 <span>
                   Election Commissioner 04
@@ -634,7 +634,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-eBMEME cUwJQa"
+              class="sc-dCFHLb RAqQW"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -654,7 +654,7 @@ House Bill 1796 - Flag Referendum
               class="sc-cWSHoV dUXOXi"
             >
               <span
-                class="sc-fhzFiK ceOrAW"
+                class="sc-jxOSlx euoqcA"
               >
                 <span>
                   Ballot Measure 2
@@ -663,7 +663,7 @@ House Concurrent Resolution No. 47
               </span>
             </div>
             <span
-              class="sc-eBMEME cUwJQa"
+              class="sc-dCFHLb RAqQW"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -683,7 +683,7 @@ House Concurrent Resolution No. 47
               class="sc-cWSHoV dUXOXi"
             >
               <span
-                class="sc-fhzFiK ceOrAW"
+                class="sc-jxOSlx euoqcA"
               >
                 <span>
                   Ballot Measure 3
@@ -692,7 +692,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-eBMEME cUwJQa"
+              class="sc-dCFHLb RAqQW"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -712,7 +712,7 @@ House Bill 1796 - Flag Referendum
               class="sc-cWSHoV dUXOXi"
             >
               <span
-                class="sc-fhzFiK ceOrAW"
+                class="sc-jxOSlx euoqcA"
               >
                 <span>
                   Ballot Measure 1
@@ -720,7 +720,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-eBMEME cUwJQa"
+              class="sc-dCFHLb RAqQW"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -740,7 +740,7 @@ House Bill 1796 - Flag Referendum
               class="sc-cWSHoV dUXOXi"
             >
               <span
-                class="sc-fhzFiK ceOrAW"
+                class="sc-jxOSlx euoqcA"
               >
                 <span>
                   Ballot Measure 1 - Part 2
@@ -748,7 +748,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-eBMEME cUwJQa"
+              class="sc-dCFHLb RAqQW"
             >
               <span
                 class="sc-gEvEer hUnYwC"

--- a/libs/ui/src/bmd_paper_ballot.test.tsx
+++ b/libs/ui/src/bmd_paper_ballot.test.tsx
@@ -14,6 +14,7 @@ import {
   readElectionGeneralDefinition,
   readElectionTwoPartyPrimaryDefinition,
   readElectionWithMsEitherNeitherDefinition,
+  electionOpenPrimaryFixtures,
   electionPrimaryPrecinctSplitsFixtures,
   electionFamousNames2021Fixtures,
 } from '@votingworks/fixtures';
@@ -136,6 +137,30 @@ test('BmdPaperBallot includes ballot style and language metadata - primary elect
   ).getByText(hasTextAcrossElements('Precinct 1 - Mammal'));
   within(screen.getByText('Language').parentElement!.parentElement!).getByText(
     'Spanish (US)'
+  );
+  // The party short name 'Mammal' is shown only in the ballot-style line,
+  // not as a per-contest label (like in open primaries).
+  expect(screen.getAllByText('Mammal')).toHaveLength(1);
+});
+
+test('BmdPaperBallot labels each partisan contest with its party in open primaries', () => {
+  const electionDefinition =
+    electionOpenPrimaryFixtures.readElectionDefinition();
+  renderBmdPaperBallot({
+    electionDefinition,
+    ballotStyleId: 'ballot-style-1' as BallotStyleId,
+    precinctId: 'precinct-1',
+    votes: {},
+  });
+
+  // Each Governor contest is labeled with its party. The contest titles
+  // are shared across parties, so the label disambiguates them.
+  screen.getByText(hasTextAcrossElements(/^Democratic[\s\S]*Governor/));
+  screen.getByText(hasTextAcrossElements(/^Republican[\s\S]*Governor/));
+  screen.getByText(hasTextAcrossElements(/^Libertarian[\s\S]*Governor/));
+  // Spot-check another contest title.
+  screen.getByText(
+    hasTextAcrossElements(/^Democratic[\s\S]*Secretary of State/)
   );
 });
 

--- a/libs/ui/src/bmd_paper_ballot.tsx
+++ b/libs/ui/src/bmd_paper_ballot.tsx
@@ -20,6 +20,7 @@ import {
   getCandidateVoteSortedForBallotStyleRotation,
   getContests,
   getPartyForBallotStyle,
+  isOpenPrimary,
   OptionalYesNoVote,
   PrecinctId,
   VotesDict,
@@ -424,6 +425,11 @@ const ContestTitle = styled.div`
   margin-bottom: 0.25em;
 `;
 
+const ContestParty = styled.div`
+  font-size: 0.75em;
+  margin-bottom: 0.1em;
+`;
+
 const VoteLine = styled.span`
   display: block;
 
@@ -750,6 +756,8 @@ export function BmdPaperBallot({
 
   const numColumns = Math.ceil(contests.length / ballotLayout.maxRows);
 
+  const isOpenPrimaryElection = isOpenPrimary(election);
+
   return withPrintTheme(
     <LanguageOverride languageCode={primaryBallotLanguage}>
       <Ballot sheetSize={sheetSize} aria-hidden>
@@ -860,44 +868,62 @@ export function BmdPaperBallot({
         </Header>
         <Content layout={ballotLayout}>
           <BallotSelections numColumns={numColumns}>
-            {contests.map((contest) => (
-              <Contest key={contest.id}>
-                <ContestTitle>
-                  <DualLanguageText
-                    primaryLanguage={primaryBallotLanguage}
-                    englishTextWrapper={AdjacentText}
-                  >
-                    <InlineBlockSpan>
-                      {electionStrings.contestTitle(contest)}
-                      {contest.type === 'candidate' &&
-                        contest.termDescription && (
-                          <React.Fragment>
-                            {' '}
-                            | {electionStrings.contestTerm(contest)}
-                          </React.Fragment>
-                        )}
-                    </InlineBlockSpan>
-                  </DualLanguageText>
-                </ContestTitle>
-                {contest.type === 'candidate' && (
-                  <CandidateContestResult
-                    contest={contest}
-                    election={election}
-                    layout={ballotLayout}
-                    primaryBallotLanguage={primaryBallotLanguage}
-                    vote={votes[contest.id] as CandidateVote}
-                    ballotStyle={ballotStyle}
-                  />
-                )}
-                {contest.type === 'yesno' && (
-                  <YesNoContestResult
-                    contest={contest}
-                    primaryBallotLanguage={primaryBallotLanguage}
-                    vote={votes[contest.id] as YesNoVote}
-                  />
-                )}
-              </Contest>
-            ))}
+            {contests.map((contest) => {
+              const contestParty =
+                isOpenPrimaryElection &&
+                contest.type === 'candidate' &&
+                contest.partyId
+                  ? find(election.parties, (p) => p.id === contest.partyId)
+                  : undefined;
+              return (
+                <Contest key={contest.id}>
+                  {contestParty && (
+                    <ContestParty>
+                      <DualLanguageText
+                        primaryLanguage={primaryBallotLanguage}
+                        englishTextWrapper={AdjacentText}
+                      >
+                        {electionStrings.partyName(contestParty)}
+                      </DualLanguageText>
+                    </ContestParty>
+                  )}
+                  <ContestTitle>
+                    <DualLanguageText
+                      primaryLanguage={primaryBallotLanguage}
+                      englishTextWrapper={AdjacentText}
+                    >
+                      <InlineBlockSpan>
+                        {electionStrings.contestTitle(contest)}
+                        {contest.type === 'candidate' &&
+                          contest.termDescription && (
+                            <React.Fragment>
+                              {' '}
+                              | {electionStrings.contestTerm(contest)}
+                            </React.Fragment>
+                          )}
+                      </InlineBlockSpan>
+                    </DualLanguageText>
+                  </ContestTitle>
+                  {contest.type === 'candidate' && (
+                    <CandidateContestResult
+                      contest={contest}
+                      election={election}
+                      layout={ballotLayout}
+                      primaryBallotLanguage={primaryBallotLanguage}
+                      vote={votes[contest.id] as CandidateVote}
+                      ballotStyle={ballotStyle}
+                    />
+                  )}
+                  {contest.type === 'yesno' && (
+                    <YesNoContestResult
+                      contest={contest}
+                      primaryBallotLanguage={primaryBallotLanguage}
+                      vote={votes[contest.id] as YesNoVote}
+                    />
+                  )}
+                </Contest>
+              );
+            })}
           </BallotSelections>
         </Content>
       </Ballot>


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Task: #8229. Stacked on #8336.

In an open primary, the BMD summary ballot lists every party's partisan contests. This PR adds a small party-name label above each partisan contest title to disambiguate each party's contests. Closed primaries are unchanged (party still shown only in the header).

## Demo Video or Screenshot

[example ballot](https://github.com/user-attachments/files/27144338/print-job-2026-04-27T22.20.39.922Z.pdf)



## Testing Plan

- Updated automated test
- Basic manual test

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
