### PR TITLE
VxAdmin: Reorganize Adjudication Start Screen

### DIFF
--- a/apps/admin/frontend/src/components/app_routes.tsx
+++ b/apps/admin/frontend/src/components/app_routes.tsx
@@ -41,6 +41,7 @@ import { FullElectionTallyReportScreen } from '../screens/reporting/full_electio
 import { DiagnosticsScreen } from '../screens/diagnostics_screen';
 import { AdjudicationStartScreen } from '../screens/adjudication_start_screen';
 import { BallotAdjudicationScreenWrapper as BallotAdjudicationScreen } from '../screens/ballot_adjudication_screen';
+import { WriteInCandidatesScreen } from '../screens/write_in_candidates_screen';
 
 export function AppRoutes(): JSX.Element | null {
   const { electionDefinition, auth } = useContext(AppContext);
@@ -141,6 +142,13 @@ export function AppRoutes(): JSX.Element | null {
       ) && (
         <Route exact path={routerPaths.ballotAdjudication}>
           <BallotAdjudicationScreen />
+        </Route>
+      )}
+      {isFeatureFlagEnabled(
+        BooleanEnvironmentVariableName.WRITE_IN_ADJUDICATION
+      ) && (
+        <Route exact path={routerPaths.adjudicationCandidates}>
+          <WriteInCandidatesScreen />
         </Route>
       )}
       {isFeatureFlagEnabled(

--- a/apps/admin/frontend/src/components/navigation_screen.tsx
+++ b/apps/admin/frontend/src/components/navigation_screen.tsx
@@ -55,7 +55,7 @@ function NetworkStatusIndicator(): JSX.Element | null {
 
   return (
     <Row>
-      <Icons.Antenna color="inverse" />
+      <Icons.Sitemap color="inverse" />
       {isOnline ? (
         'Network Online'
       ) : (

--- a/apps/admin/frontend/src/screens/adjudication_start_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/adjudication_start_screen.test.tsx
@@ -2,9 +2,12 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { electionTwoPartyPrimaryFixtures } from '@votingworks/fixtures';
 import { sleep, typedAs } from '@votingworks/basics';
 import { BooleanEnvironmentVariableName } from '@votingworks/utils';
-import type { MachineRecord } from '@votingworks/admin-backend';
+import type {
+  MachineRecord,
+  QualifiedWriteInCandidateRecord,
+} from '@votingworks/admin-backend';
 import userEvent from '@testing-library/user-event';
-import { Admin } from '@votingworks/types';
+import { Admin, DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
 import { act, screen, within } from '../../test/react_testing_library';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { AdjudicationStartScreen } from './adjudication_start_screen';
@@ -43,6 +46,9 @@ afterEach(async () => {
 beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
+  apiMock.apiClient.getQualifiedWriteInCandidates
+    .expectRepeatedCallsWith()
+    .resolves([]);
 });
 
 test('No CVRs loaded', async () => {
@@ -71,19 +77,37 @@ test('No ballots flagged for adjudication', async () => {
   await screen.findByText('No ballots flagged for adjudication.');
 });
 
-test('When tally results already marked as official, shows disabled message', async () => {
+test('When tally results already marked as official, adjudication buttons are disabled and multi-station card is hidden', async () => {
+  apiMock = createApiMock();
+  apiMock.expectGetSystemSettings({
+    ...DEFAULT_SYSTEM_SETTINGS,
+    areWriteInCandidatesQualified: true,
+  });
+  apiMock.apiClient.getQualifiedWriteInCandidates
+    .expectRepeatedCallsWith()
+    .resolves([]);
   apiMock.expectGetBallotAdjudicationQueueMetadata({
     pendingTally: 3,
     totalTally: 5,
   });
   apiMock.expectGetCastVoteRecordFiles([mockCastVoteRecordFileRecord]);
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.ENABLE_MULTI_STATION_ADMIN
+  );
+  apiMock.expectGetNetworkStatus();
   renderInAppContext(<AdjudicationStartScreen />, {
     electionDefinition,
     isOfficialResults: true,
     apiMock,
   });
 
-  await screen.findByText(/Adjudication is disabled/);
+  expect(
+    await screen.findByRole('button', { name: 'Adjudicate' })
+  ).toBeDisabled();
+  expect(screen.getByRole('button', { name: 'Add Candidates' })).toBeDisabled();
+  expect(
+    screen.queryByRole('button', { name: 'Enable Multi-Station' })
+  ).not.toBeInTheDocument();
 });
 
 test('When ballots need adjudication, shows start button with counts', async () => {
@@ -97,9 +121,9 @@ test('When ballots need adjudication, shows start button with counts', async () 
     apiMock,
   });
 
-  await screen.findByText('Start Adjudicating');
-  screen.getByText('3 Ballots Awaiting Review');
-  screen.getByText('2 Ballots Completed');
+  await screen.findByRole('button', { name: 'Adjudicate' });
+  screen.getByText('3 ballots remaining');
+  screen.getByText('2 of 5 adjudicated · 40%');
 });
 
 describe('multi-station adjudication', () => {
@@ -107,44 +131,6 @@ describe('multi-station adjudication', () => {
     featureFlagMock.enableFeatureFlag(
       BooleanEnvironmentVariableName.ENABLE_MULTI_STATION_ADMIN
     );
-  });
-
-  test('shows toggle button and network section when enabled', async () => {
-    apiMock.expectGetBallotAdjudicationQueueMetadata({
-      pendingTally: 3,
-      totalTally: 5,
-    });
-    apiMock.expectGetCastVoteRecordFiles([mockCastVoteRecordFileRecord]);
-    apiMock.expectGetNetworkStatus();
-    apiMock.expectGetIsClientAdjudicationEnabled(false);
-    renderInAppContext(<AdjudicationStartScreen />, {
-      electionDefinition,
-      apiMock,
-    });
-
-    await screen.findByText('Start Adjudicating');
-    screen.getByRole('button', {
-      name: 'Enable Multi-Station',
-    });
-    screen.getByText('No clients have connected.');
-  });
-
-  test('shows disable button when adjudication is enabled', async () => {
-    apiMock.expectGetBallotAdjudicationQueueMetadata({
-      pendingTally: 3,
-      totalTally: 5,
-    });
-    apiMock.expectGetCastVoteRecordFiles([mockCastVoteRecordFileRecord]);
-    apiMock.expectGetNetworkStatus();
-    apiMock.expectGetIsClientAdjudicationEnabled(true);
-    renderInAppContext(<AdjudicationStartScreen />, {
-      electionDefinition,
-      apiMock,
-    });
-
-    await screen.findByRole('button', {
-      name: 'Disable Multi-Station',
-    });
   });
 
   test('toggles adjudication enabled state', async () => {
@@ -166,7 +152,10 @@ describe('multi-station adjudication', () => {
     apiMock.apiClient.setIsClientAdjudicationEnabled
       .expectCallWith({ enabled: true })
       .resolves();
+    apiMock.expectGetIsClientAdjudicationEnabled(true);
     userEvent.click(enableButton);
+
+    await screen.findByRole('button', { name: 'Disable' });
   });
 
   test('shows network offline status', async () => {
@@ -182,7 +171,11 @@ describe('multi-station adjudication', () => {
       apiMock,
     });
 
-    await screen.findByText('Multi-Station Adjudication');
+    await screen.findByRole('heading', { name: 'Multi-Station Adjudication' });
+    expect(
+      screen.queryByRole('button', { name: 'Enable Multi-Station' })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 
   test('shows connected clients table with status', async () => {
@@ -265,5 +258,149 @@ describe('multi-station adjudication', () => {
     });
 
     await screen.findByText('Load CVRs to begin adjudication.');
+    screen.getByRole('heading', { name: 'Multi-Station Adjudication' });
+  });
+
+  test('shows online status when enabled with no real clients', async () => {
+    apiMock.expectGetBallotAdjudicationQueueMetadata({
+      pendingTally: 3,
+      totalTally: 5,
+    });
+    apiMock.expectGetCastVoteRecordFiles([mockCastVoteRecordFileRecord]);
+    apiMock.expectGetNetworkStatus();
+    apiMock.expectGetIsClientAdjudicationEnabled(true);
+    renderInAppContext(<AdjudicationStartScreen />, {
+      electionDefinition,
+      apiMock,
+    });
+
+    await screen.findByText('Online · Clients Can Adjudicate Ballots');
+    screen.getByRole('table');
+  });
+
+  test('always shows the clients table even when disabled', async () => {
+    apiMock.expectGetBallotAdjudicationQueueMetadata({
+      pendingTally: 3,
+      totalTally: 5,
+    });
+    apiMock.expectGetCastVoteRecordFiles([mockCastVoteRecordFileRecord]);
+    apiMock.expectGetNetworkStatus();
+    apiMock.expectGetIsClientAdjudicationEnabled(false);
+    renderInAppContext(<AdjudicationStartScreen />, {
+      electionDefinition,
+      apiMock,
+    });
+
+    await screen.findByRole('button', { name: 'Enable Multi-Station' });
+    screen.getByText('Off · Clients Cannot Adjudicate Ballots');
+    screen.getByRole('table');
+  });
+});
+
+test('shows completed state when all ballots adjudicated', async () => {
+  apiMock.expectGetBallotAdjudicationQueueMetadata({
+    pendingTally: 0,
+    totalTally: 5,
+  });
+  apiMock.expectGetCastVoteRecordFiles([mockCastVoteRecordFileRecord]);
+  renderInAppContext(<AdjudicationStartScreen />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('All ballots adjudicated');
+  screen.getByRole('button', { name: 'Review' });
+});
+
+describe('qualified write-in candidates card', () => {
+  beforeEach(() => {
+    apiMock = createApiMock();
+    apiMock.expectGetSystemSettings({
+      ...DEFAULT_SYSTEM_SETTINGS,
+      areWriteInCandidatesQualified: true,
+    });
+  });
+
+  function expectGetQualifiedWriteInCandidates(
+    candidates: QualifiedWriteInCandidateRecord[]
+  ) {
+    apiMock.apiClient.getQualifiedWriteInCandidates
+      .expectRepeatedCallsWith()
+      .resolves(candidates);
+  }
+
+  test('shows empty state when no candidates have been added', async () => {
+    apiMock.expectGetBallotAdjudicationQueueMetadata({
+      pendingTally: 3,
+      totalTally: 5,
+    });
+    apiMock.expectGetCastVoteRecordFiles([mockCastVoteRecordFileRecord]);
+    expectGetQualifiedWriteInCandidates([]);
+    renderInAppContext(<AdjudicationStartScreen />, {
+      electionDefinition,
+      apiMock,
+    });
+
+    await screen.findByText(/Add qualified write-in candidates/);
+    screen.getByRole('button', { name: 'Add Candidates' });
+  });
+
+  test('shows partial state when some contests still need candidates', async () => {
+    apiMock.expectGetBallotAdjudicationQueueMetadata({
+      pendingTally: 3,
+      totalTally: 5,
+    });
+    apiMock.expectGetCastVoteRecordFiles([mockCastVoteRecordFileRecord]);
+    expectGetQualifiedWriteInCandidates([
+      {
+        id: 'c1',
+        electionId: 'e1',
+        contestId: 'zoo-council-mammal',
+        name: 'Aardvark',
+        hasAdjudicatedVotes: false,
+      },
+    ]);
+    renderInAppContext(<AdjudicationStartScreen />, {
+      electionDefinition,
+      apiMock,
+    });
+
+    await screen.findByText(
+      /1 of 2 write-in contests have qualified candidates/
+    );
+    screen.getByRole('button', { name: 'Edit Candidates' });
+  });
+
+  test('shows completed state when every write-in contest has candidates', async () => {
+    apiMock.expectGetBallotAdjudicationQueueMetadata({
+      pendingTally: 3,
+      totalTally: 5,
+    });
+    apiMock.expectGetCastVoteRecordFiles([mockCastVoteRecordFileRecord]);
+    expectGetQualifiedWriteInCandidates([
+      {
+        id: 'c1',
+        electionId: 'e1',
+        contestId: 'zoo-council-mammal',
+        name: 'Aardvark',
+        hasAdjudicatedVotes: false,
+      },
+      {
+        id: 'c2',
+        electionId: 'e1',
+        contestId: 'aquarium-council-fish',
+        name: 'Barracuda',
+        hasAdjudicatedVotes: false,
+      },
+    ]);
+    renderInAppContext(<AdjudicationStartScreen />, {
+      electionDefinition,
+      apiMock,
+    });
+
+    await screen.findByText(
+      /2 of 2 write-in contests have qualified candidates/
+    );
+    screen.getByRole('button', { name: 'Edit Candidates' });
   });
 });

--- a/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
+++ b/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
@@ -70,16 +70,9 @@ const CardHeader = styled(H3)`
 `;
 
 const LargeText = styled.div`
-  font-weight: 700;
+  font-weight: ${(p) => p.theme.sizes.fontWeight.bold};
   font-size: 1.5rem;
   line-height: 1;
-`;
-
-const SuccessProgressBar = styled.div`
-  height: 0.75rem;
-  width: 100%;
-  background-color: ${(p) => p.theme.colors.primary};
-  border-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
 `;
 
 const EmptyTableMessage = styled.div`
@@ -87,6 +80,7 @@ const EmptyTableMessage = styled.div`
   justify-content: center;
   align-items: center;
   gap: 0.5rem;
+  margin-top: 0.5rem;
   color: ${(p) => p.theme.colors.onBackgroundMuted};
 `;
 
@@ -94,18 +88,14 @@ const InlineStatus = styled.div`
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  font-weight: 500;
+  font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
 `;
 
-const SuccessInlineStatus = styled(InlineStatus)`
-  color: ${(p) => p.theme.colors.successAccent};
-`;
-
-const StatusDot = styled(Icons.Circle).attrs({ filled: true })`
+const StatusDot = styled(Icons.CircleSolid)`
   font-size: 0.625em;
 `;
 
-const FullWidthTableWrapper = styled.div`
+const TableWrapper = styled.div`
   & th,
   & td {
     padding: 0.625rem 1rem;
@@ -214,13 +204,11 @@ function WriteInCandidatesCard(): JSX.Element | null {
 
   const contestsWithCandidates =
     writeInContests.length - contestsNeedingCandidates.length;
-  const allHaveCandidates = contestsNeedingCandidates.length === 0;
   return (
     <Card>
       {header}
       <CardRow>
         <InlineStatus>
-          {allHaveCandidates && <Icons.Done color="success" />}
           {contestsWithCandidates} of {writeInContests.length} write-in contests
           have qualified candidates
         </InlineStatus>
@@ -312,7 +300,7 @@ function BallotAdjudicationCard({
           <InlineStatus>
             {completedCount} of {totalTally} adjudicated · {percentComplete}%
           </InlineStatus>
-          <SuccessProgressBar />
+          <ProgressBar progress={1} />
         </CardColumn>
       </Card>
     );
@@ -352,7 +340,7 @@ function MultiStationClientsTable({
   isEnabled: boolean;
 }): JSX.Element {
   return (
-    <FullWidthTableWrapper>
+    <TableWrapper>
       <Table>
         <thead>
           <tr>
@@ -393,7 +381,7 @@ function MultiStationClientsTable({
           )}
         </tbody>
       </Table>
-    </FullWidthTableWrapper>
+    </TableWrapper>
   );
 }
 
@@ -428,10 +416,10 @@ function MultiStationCard(): JSX.Element {
               <Icons.Warning color="warning" /> Network Offline
             </InlineStatus>
           ) : isEnabled ? (
-            <SuccessInlineStatus>
+            <InlineStatus>
               <StatusDot color="success" /> Online · Clients Can Adjudicate
               Ballots
-            </SuccessInlineStatus>
+            </InlineStatus>
           ) : (
             <InlineStatus>
               <StatusDot /> Off · Clients Cannot Adjudicate Ballots
@@ -439,7 +427,7 @@ function MultiStationCard(): JSX.Element {
           )}
           {isOnline && (
             <Button
-              icon={isEnabled ? <Icons.Square filled /> : 'Play'}
+              icon={isEnabled ? 'SquareSolid' : 'Play'}
               onPress={() =>
                 setAdjudicationEnabledMutation.mutate({ enabled: !isEnabled })
               }

--- a/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
+++ b/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
@@ -1,31 +1,28 @@
 import React, { useContext } from 'react';
 import styled from 'styled-components';
-import { Route, Switch } from 'react-router-dom';
 
 import {
   Button,
-  Callout,
-  Caption,
-  Font,
-  H2,
+  Card as UiCard,
+  H3,
   Icons,
   LinkButton,
   Loading,
   P,
-  RouterTabBar,
-  TabPanel,
+  ProgressBar,
   Table,
   TD,
   TH,
 } from '@votingworks/ui';
 import pluralize from 'pluralize';
-import { throwIllegalValue } from '@votingworks/basics';
+import { assertDefined, throwIllegalValue } from '@votingworks/basics';
 import {
   BooleanEnvironmentVariableName,
   format,
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
-import { Admin } from '@votingworks/types';
+import { Admin, CandidateContest } from '@votingworks/types';
+import type { MachineRecord } from '@votingworks/admin-backend';
 import { NavigationScreen } from '../components/navigation_screen';
 import { AppContext } from '../contexts/app_context';
 import {
@@ -33,52 +30,96 @@ import {
   getBallotAdjudicationQueueMetadata,
   getIsClientAdjudicationEnabled,
   getNetworkStatus,
+  getQualifiedWriteInCandidates,
   getSystemSettings,
   setIsClientAdjudicationEnabled,
 } from '../api';
 import { routerPaths } from '../router_paths';
-import { WriteInCandidatesTab } from './write_in_candidates_tab';
 
-const Column = styled.div`
+const CardStack = styled.div`
   display: flex;
-  gap: 1rem;
   flex-direction: column;
+  gap: 1rem;
 `;
 
-const Row = styled.div`
+const Card = styled(UiCard)`
+  overflow: hidden;
+`;
+
+const CardRow = styled.div`
   display: flex;
-  gap: 1rem;
+  justify-content: space-between;
   align-items: center;
-`;
-
-const Section = styled.section`
-  display: flex;
-  flex-direction: column;
   gap: 1rem;
 `;
 
-const InlineColumn = styled.div`
+const CardColumn = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 0.25rem;
+  gap: 1em;
+  flex: 1;
+  min-width: 0;
 `;
 
-const TabbedContent = styled.div`
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  padding: 1rem 1rem 0;
+const CardHeader = styled(H3)`
+  margin: -1rem -1rem 1rem;
+  background-color: ${(p) => p.theme.colors.containerLow};
+  border-bottom: ${(p) => p.theme.sizes.bordersRem.thin}rem solid
+    ${(p) => p.theme.colors.outline};
+  padding: 0.75rem 1rem;
 `;
 
-const CenteredContent = styled.div`
+const LargeText = styled.div`
+  font-weight: 700;
+  font-size: 1.5rem;
+  line-height: 1;
+`;
+
+const SuccessProgressBar = styled.div`
+  height: 0.75rem;
+  width: 100%;
+  background-color: ${(p) => p.theme.colors.primary};
+  border-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
+`;
+
+const EmptyTableMessage = styled.div`
   display: flex;
-  flex-direction: column;
   justify-content: center;
   align-items: center;
   gap: 0.5rem;
-  height: 100%;
-  padding-bottom: 2rem;
+  color: ${(p) => p.theme.colors.onBackgroundMuted};
+`;
+
+const InlineStatus = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+`;
+
+const SuccessInlineStatus = styled(InlineStatus)`
+  color: ${(p) => p.theme.colors.successAccent};
+`;
+
+const StatusDot = styled(Icons.Circle).attrs({ filled: true })`
+  font-size: 0.625em;
+`;
+
+const FullWidthTableWrapper = styled.div`
+  margin: 0 -1rem -1rem;
+
+  & thead {
+    background-color: ${(p) => p.theme.colors.container};
+  }
+
+  & th,
+  & td {
+    padding: 0.625rem 1rem;
+  }
+
+  & tbody tr:last-child td {
+    border-bottom: none;
+  }
 `;
 
 function formatAuthType(authType: string | null): string {
@@ -94,67 +135,229 @@ function formatAuthType(authType: string | null): string {
   }
 }
 
-function MultiStationToggleButton(): JSX.Element | null {
-  const adjudicationEnabledQuery = getIsClientAdjudicationEnabled.useQuery();
-  const networkStatusQuery = getNetworkStatus.useQuery();
-  const setAdjudicationEnabledMutation =
-    setIsClientAdjudicationEnabled.useMutation();
+function renderClientStatus(status: Admin.ClientMachineStatus): JSX.Element {
+  switch (status) {
+    case Admin.ClientMachineStatus.Offline:
+      return (
+        <React.Fragment>
+          <Icons.Danger color="danger" /> Disconnected
+        </React.Fragment>
+      );
+    case Admin.ClientMachineStatus.OnlineLocked:
+      return (
+        <React.Fragment>
+          <Icons.Lock /> Locked
+        </React.Fragment>
+      );
+    case Admin.ClientMachineStatus.Active:
+      return (
+        <React.Fragment>
+          <Icons.Done color="success" /> Active
+        </React.Fragment>
+      );
+    case Admin.ClientMachineStatus.Adjudicating:
+      return (
+        <React.Fragment>
+          <Icons.Done color="success" /> Adjudicating
+        </React.Fragment>
+      );
+    /* istanbul ignore next  - @preserve */
+    default:
+      throwIllegalValue(status);
+  }
+}
 
-  if (!adjudicationEnabledQuery.isSuccess || !networkStatusQuery.isSuccess) {
+function WriteInCandidatesCard(): JSX.Element | null {
+  const { electionDefinition, isOfficialResults } = useContext(AppContext);
+  const { election } = assertDefined(electionDefinition);
+  const candidatesQuery = getQualifiedWriteInCandidates.useQuery();
+
+  const writeInContests = election.contests.filter(
+    (c): c is CandidateContest => c.type === 'candidate' && c.allowWriteIns
+  );
+
+  const header = <CardHeader>Qualified Write-In Candidates</CardHeader>;
+
+  if (writeInContests.length === 0) {
     return null;
   }
 
-  const isEnabled = adjudicationEnabledQuery.data;
-  const { multipleHostsDetected } = networkStatusQuery.data;
+  if (!candidatesQuery.isSuccess) {
+    return (
+      <Card>
+        {header}
+        <Loading />
+      </Card>
+    );
+  }
 
+  const candidates = candidatesQuery.data;
+  const contestsNeedingCandidates = writeInContests.filter(
+    (c) => !candidates.some((qc) => qc.contestId === c.id)
+  );
+
+  if (candidates.length === 0) {
+    return (
+      <Card>
+        {header}
+        <CardRow>
+          <P style={{ margin: 0 }}>
+            Add qualified write-in candidates so they can be selected during
+            ballot adjudication.
+          </P>
+          <LinkButton
+            variant="primary"
+            icon="Add"
+            to={routerPaths.adjudicationCandidates}
+            disabled={isOfficialResults}
+          >
+            Add Candidates
+          </LinkButton>
+        </CardRow>
+      </Card>
+    );
+  }
+
+  const contestsWithCandidates =
+    writeInContests.length - contestsNeedingCandidates.length;
+  const allHaveCandidates = contestsNeedingCandidates.length === 0;
   return (
-    <Button
-      onPress={() =>
-        setAdjudicationEnabledMutation.mutate({
-          enabled: !isEnabled,
-        })
-      }
-      disabled={
-        setAdjudicationEnabledMutation.isLoading || multipleHostsDetected
-      }
-      style={{ height: '3rem', fontSize: '1.25rem' }}
-    >
-      {isEnabled ? 'Disable Multi-Station' : 'Enable Multi-Station'}
-    </Button>
+    <Card>
+      {header}
+      <CardRow>
+        <InlineStatus>
+          {allHaveCandidates && <Icons.Done color="success" />}
+          {contestsWithCandidates} of {writeInContests.length} write-in contests
+          have qualified candidates
+        </InlineStatus>
+        <LinkButton
+          icon="Edit"
+          to={routerPaths.adjudicationCandidates}
+          disabled={isOfficialResults}
+        >
+          Edit Candidates
+        </LinkButton>
+      </CardRow>
+    </Card>
   );
 }
 
-function NetworkSection(): JSX.Element {
-  const networkStatusQuery = getNetworkStatus.useQuery();
-  const adjudicationEnabledQuery = getIsClientAdjudicationEnabled.useQuery();
+function BallotAdjudicationCard(): JSX.Element {
+  const { isOfficialResults } = useContext(AppContext);
+  const queueMetadataQuery = getBallotAdjudicationQueueMetadata.useQuery();
+  const cvrFilesQuery = getCastVoteRecordFiles.useQuery();
+  const systemSettingsQuery = getSystemSettings.useQuery();
+  const candidatesQuery = getQualifiedWriteInCandidates.useQuery();
 
-  if (!networkStatusQuery.isSuccess || !adjudicationEnabledQuery.isSuccess) {
-    return <Loading />;
+  const header = <CardHeader>Ballot Adjudication</CardHeader>;
+
+  if (
+    !queueMetadataQuery.isSuccess ||
+    !cvrFilesQuery.isSuccess ||
+    !systemSettingsQuery.isSuccess ||
+    !candidatesQuery.isSuccess
+  ) {
+    return (
+      <Card>
+        {header}
+        <Loading />
+      </Card>
+    );
   }
 
-  const isEnabled = adjudicationEnabledQuery.data;
-  const { connectedClients, multipleHostsDetected } = networkStatusQuery.data;
+  const { totalTally, pendingTally } = queueMetadataQuery.data;
+
+  function renderInfoMessage(message: string) {
+    return (
+      <Card>
+        {header}
+        <InlineStatus>
+          <Icons.Info /> {message}
+        </InlineStatus>
+      </Card>
+    );
+  }
+
+  if (cvrFilesQuery.data.length === 0) {
+    return renderInfoMessage('Load CVRs to begin adjudication.');
+  }
+  if (totalTally === 0) {
+    return renderInfoMessage('No ballots flagged for adjudication.');
+  }
+
+  const completedCount = totalTally - pendingTally;
+  const percentComplete = Math.round((completedCount / totalTally) * 100);
+  const { areWriteInCandidatesQualified } = systemSettingsQuery.data;
+  const adjudicateButtonVariant =
+    !areWriteInCandidatesQualified || candidatesQuery.data.length > 0
+      ? 'primary'
+      : 'neutral';
+
+  if (pendingTally === 0) {
+    return (
+      <Card>
+        {header}
+        <CardColumn>
+          <CardRow>
+            <CardColumn>
+              <LargeText>
+                <Icons.Done color="success" /> All ballots adjudicated
+              </LargeText>
+              <div>
+                {completedCount} of {totalTally} adjudicated · {percentComplete}
+                %
+              </div>
+            </CardColumn>
+            <LinkButton
+              variant="primary"
+              icon="RotateRight"
+              to={routerPaths.ballotAdjudication}
+              disabled={isOfficialResults}
+            >
+              Review
+            </LinkButton>
+          </CardRow>
+          <SuccessProgressBar />
+        </CardColumn>
+      </Card>
+    );
+  }
 
   return (
-    <Section>
-      <H2 style={{ margin: 0 }}>Multi-Station Adjudication</H2>
-      <Row>
-        <MultiStationToggleButton />
-        <InlineColumn>
-          <Font weight="semiBold">Status: {isEnabled ? 'On' : 'Off'}</Font>
-          <Caption>
-            {isEnabled
-              ? 'Clients can adjudicate ballots'
-              : 'Clients cannot adjudicate ballots'}
-          </Caption>
-        </InlineColumn>
-      </Row>
-      {multipleHostsDetected && (
-        <P>
-          <Icons.Danger color="danger" /> Multiple hosts detected on the
-          network. Only one host machine should be active at a time.
-        </P>
-      )}
+    <Card>
+      {header}
+      <CardColumn>
+        <CardRow>
+          <LargeText>
+            {pendingTally} {pluralize('ballot', pendingTally)} remaining
+          </LargeText>
+          <LinkButton
+            variant={adjudicateButtonVariant}
+            icon="PenToSquare"
+            to={routerPaths.ballotAdjudication}
+            disabled={isOfficialResults}
+          >
+            Adjudicate
+          </LinkButton>
+        </CardRow>
+        <InlineStatus>
+          {completedCount} of {totalTally} adjudicated · {percentComplete}%
+        </InlineStatus>
+        <ProgressBar progress={completedCount / totalTally} />
+      </CardColumn>
+    </Card>
+  );
+}
+
+function MultiStationClientsTable({
+  clients,
+  isEnabled,
+}: {
+  clients: MachineRecord[];
+  isEnabled: boolean;
+}): JSX.Element {
+  return (
+    <FullWidthTableWrapper>
       <Table>
         <thead>
           <tr>
@@ -165,50 +368,28 @@ function NetworkSection(): JSX.Element {
           </tr>
         </thead>
         <tbody>
-          {connectedClients.length === 0 ? (
+          {clients.length === 0 ? (
             <tr>
-              <TD colSpan={4}>No clients have connected.</TD>
+              <TD colSpan={4}>
+                <EmptyTableMessage>
+                  {isEnabled ? (
+                    <React.Fragment>
+                      <Icons.Loading /> Waiting for clients to connect…
+                    </React.Fragment>
+                  ) : (
+                    'No clients have connected.'
+                  )}
+                </EmptyTableMessage>
+              </TD>
             </tr>
           ) : (
-            connectedClients.map((machine) => {
-              function renderStatus() {
-                switch (machine.status) {
-                  case Admin.ClientMachineStatus.Offline:
-                    return (
-                      <React.Fragment>
-                        <Icons.Danger color="danger" /> Disconnected
-                      </React.Fragment>
-                    );
-                  case Admin.ClientMachineStatus.OnlineLocked:
-                    return (
-                      <React.Fragment>
-                        <Icons.Lock /> Locked
-                      </React.Fragment>
-                    );
-                  case Admin.ClientMachineStatus.Active:
-                    return (
-                      <React.Fragment>
-                        <Icons.Done color="success" /> Active
-                      </React.Fragment>
-                    );
-                  case Admin.ClientMachineStatus.Adjudicating:
-                    return (
-                      <React.Fragment>
-                        <Icons.Done color="success" /> Adjudicating
-                      </React.Fragment>
-                    );
-                  /* istanbul ignore next  - @preserve */
-                  default:
-                    throwIllegalValue(machine.status);
-                }
-              }
-
+            clients.map((machine) => {
               const isOffline =
                 machine.status === Admin.ClientMachineStatus.Offline;
               return (
                 <tr key={machine.machineId}>
                   <TD>{machine.machineId}</TD>
-                  <TD>{renderStatus()}</TD>
+                  <TD>{renderClientStatus(machine.status)}</TD>
                   <TD>{isOffline ? '—' : formatAuthType(machine.authType)}</TD>
                   <TD>{format.relativeTime(machine.lastSeenAt)}</TD>
                 </tr>
@@ -217,135 +398,89 @@ function NetworkSection(): JSX.Element {
           )}
         </tbody>
       </Table>
-    </Section>
+    </FullWidthTableWrapper>
   );
 }
 
-function AdjudicateBallotsButton(): JSX.Element {
-  return (
-    <LinkButton
-      variant="primary"
-      to={routerPaths.ballotAdjudication}
-      style={{ height: '3rem', width: '14rem', fontSize: '1.25rem' }}
-    >
-      Start Adjudicating
-    </LinkButton>
-  );
-}
+function MultiStationCard(): JSX.Element {
+  const networkStatusQuery = getNetworkStatus.useQuery();
+  const adjudicationEnabledQuery = getIsClientAdjudicationEnabled.useQuery();
+  const setAdjudicationEnabledMutation =
+    setIsClientAdjudicationEnabled.useMutation();
 
-function PendingBallotCount({ count }: { count: number }): JSX.Element {
-  return (
-    <Font weight="semiBold">
-      {count} {pluralize('Ballot', count)} Awaiting Review
-    </Font>
-  );
-}
+  const header = <CardHeader>Multi-Station Adjudication</CardHeader>;
 
-function CompletedBallotCount({ count }: { count: number }): JSX.Element {
-  return (
-    <Caption>
-      {count} {pluralize('Ballot', count)} Completed
-    </Caption>
-  );
-}
-
-function BallotAdjudicationContent({
-  inQualifiedWriteInMode,
-}: {
-  inQualifiedWriteInMode: boolean;
-}): JSX.Element {
-  const { isOfficialResults } = useContext(AppContext);
-
-  const isMultiStationEnabled = isFeatureFlagEnabled(
-    BooleanEnvironmentVariableName.ENABLE_MULTI_STATION_ADMIN
-  );
-
-  const adjudicationQueueMetadataQuery =
-    getBallotAdjudicationQueueMetadata.useQuery();
-
-  const castVoteRecordFilesQuery = getCastVoteRecordFiles.useQuery();
-
-  if (
-    !adjudicationQueueMetadataQuery.isSuccess ||
-    !castVoteRecordFilesQuery.isSuccess
-  ) {
-    return <Loading isFullscreen />;
-  }
-
-  const queryMetadata = adjudicationQueueMetadataQuery.data;
-  function renderCallout() {
-    if (isOfficialResults) {
-      return (
-        <Callout icon="Info" color="neutral">
-          Adjudication is disabled because results were marked as official.
-        </Callout>
-      );
-    }
-
-    if (
-      castVoteRecordFilesQuery.isSuccess &&
-      castVoteRecordFilesQuery.data.length === 0
-    ) {
-      return (
-        <Callout icon="Info" color="neutral">
-          Load CVRs to begin adjudication.
-        </Callout>
-      );
-    }
-
-    if (queryMetadata.totalTally === 0) {
-      return (
-        <Callout icon="Info" color="neutral">
-          No ballots flagged for adjudication.
-        </Callout>
-      );
-    }
-    return null;
-  }
-
-  const callout = renderCallout();
-  if (callout) {
+  if (!networkStatusQuery.isSuccess || !adjudicationEnabledQuery.isSuccess) {
     return (
-      <Column>
-        {callout}
-        {isMultiStationEnabled && <NetworkSection />}
-      </Column>
+      <Card>
+        {header}
+        <Loading />
+      </Card>
     );
   }
 
-  const completedCount = queryMetadata.totalTally - queryMetadata.pendingTally;
+  const isEnabled = adjudicationEnabledQuery.data;
+  const { connectedClients, isOnline, multipleHostsDetected } =
+    networkStatusQuery.data;
 
-  if (isMultiStationEnabled) {
-    return (
-      <Column style={{ gap: inQualifiedWriteInMode ? '1rem' : '2rem' }}>
-        <Section>
-          {!inQualifiedWriteInMode && (
-            <H2 style={{ margin: 0 }}>Ballot Adjudication</H2>
+  return (
+    <Card>
+      {header}
+      <CardColumn>
+        <CardRow>
+          {!isOnline ? (
+            <InlineStatus>
+              <Icons.Warning color="warning" /> Network Offline
+            </InlineStatus>
+          ) : isEnabled ? (
+            <SuccessInlineStatus>
+              <StatusDot color="success" /> Online · Clients Can Adjudicate
+              Ballots
+            </SuccessInlineStatus>
+          ) : (
+            <InlineStatus>
+              <StatusDot /> Off · Clients Cannot Adjudicate Ballots
+            </InlineStatus>
           )}
-          <Row>
-            <AdjudicateBallotsButton />
-            <InlineColumn>
-              <PendingBallotCount count={queryMetadata.pendingTally} />
-              <CompletedBallotCount count={completedCount} />
-            </InlineColumn>
-          </Row>
-        </Section>
-        <NetworkSection />
-      </Column>
-    );
-  }
-
-  return (
-    <CenteredContent>
-      <AdjudicateBallotsButton />
-      <PendingBallotCount count={queryMetadata.pendingTally} />
-      <CompletedBallotCount count={completedCount} />
-    </CenteredContent>
+          {isOnline && (
+            <Button
+              icon={isEnabled ? <Icons.Square filled /> : 'Play'}
+              onPress={() =>
+                setAdjudicationEnabledMutation.mutate({ enabled: !isEnabled })
+              }
+              disabled={
+                setAdjudicationEnabledMutation.isLoading ||
+                multipleHostsDetected
+              }
+              variant={isEnabled ? 'neutral' : 'secondary'}
+            >
+              {isEnabled ? 'Disable' : 'Enable Multi-Station'}
+            </Button>
+          )}
+        </CardRow>
+        {multipleHostsDetected && (
+          <P style={{ margin: 0 }}>
+            <Icons.Danger color="danger" /> Multiple hosts detected on the
+            network. Only one host machine should be active at a time.
+          </P>
+        )}
+        {isOnline && (
+          <MultiStationClientsTable
+            clients={connectedClients}
+            isEnabled={isEnabled}
+          />
+        )}
+      </CardColumn>
+    </Card>
   );
 }
 
 export function AdjudicationStartScreen(): JSX.Element {
+  const { isOfficialResults } = useContext(AppContext);
   const systemSettingsQuery = getSystemSettings.useQuery();
+  const isMultiStationEnabled = isFeatureFlagEnabled(
+    BooleanEnvironmentVariableName.ENABLE_MULTI_STATION_ADMIN
+  );
 
   if (!systemSettingsQuery.isSuccess) {
     return (
@@ -355,49 +490,15 @@ export function AdjudicationStartScreen(): JSX.Element {
     );
   }
 
-  const { areWriteInCandidatesQualified: inQualifiedWriteInMode } =
-    systemSettingsQuery.data;
-
-  if (inQualifiedWriteInMode) {
-    return (
-      <NavigationScreen
-        title="Adjudication"
-        noPadding
-        style={{ overflow: 'hidden' }}
-      >
-        <TabbedContent>
-          <RouterTabBar
-            tabs={[
-              {
-                title: 'Ballot Adjudication',
-                path: routerPaths.adjudication,
-              },
-              {
-                title: 'Write-In Candidates',
-                path: routerPaths.adjudicationCandidates,
-              },
-            ]}
-          />
-          <Switch>
-            <Route
-              exact
-              path={routerPaths.adjudicationCandidates}
-              component={WriteInCandidatesTab}
-            />
-            <Route path={routerPaths.adjudication}>
-              <TabPanel style={{ paddingTop: '1rem' }}>
-                <BallotAdjudicationContent inQualifiedWriteInMode />
-              </TabPanel>
-            </Route>
-          </Switch>
-        </TabbedContent>
-      </NavigationScreen>
-    );
-  }
+  const { areWriteInCandidatesQualified } = systemSettingsQuery.data;
 
   return (
     <NavigationScreen title="Adjudication">
-      <BallotAdjudicationContent inQualifiedWriteInMode={false} />
+      <CardStack>
+        {areWriteInCandidatesQualified && <WriteInCandidatesCard />}
+        <BallotAdjudicationCard />
+        {isMultiStationEnabled && !isOfficialResults && <MultiStationCard />}
+      </CardStack>
     </NavigationScreen>
   );
 }

--- a/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
+++ b/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
@@ -106,12 +106,6 @@ const StatusDot = styled(Icons.Circle).attrs({ filled: true })`
 `;
 
 const FullWidthTableWrapper = styled.div`
-  margin: 0 -1rem -1rem;
-
-  & thead {
-    background-color: ${(p) => p.theme.colors.container};
-  }
-
   & th,
   & td {
     padding: 0.625rem 1rem;
@@ -242,14 +236,18 @@ function WriteInCandidatesCard(): JSX.Element | null {
   );
 }
 
-function BallotAdjudicationCard(): JSX.Element {
+function BallotAdjudicationCard({
+  showHeader,
+}: {
+  showHeader: boolean;
+}): JSX.Element {
   const { isOfficialResults } = useContext(AppContext);
   const queueMetadataQuery = getBallotAdjudicationQueueMetadata.useQuery();
   const cvrFilesQuery = getCastVoteRecordFiles.useQuery();
   const systemSettingsQuery = getSystemSettings.useQuery();
   const candidatesQuery = getQualifiedWriteInCandidates.useQuery();
 
-  const header = <CardHeader>Ballot Adjudication</CardHeader>;
+  const header = showHeader && <CardHeader>Ballot Adjudication</CardHeader>;
 
   if (
     !queueMetadataQuery.isSuccess ||
@@ -299,15 +297,9 @@ function BallotAdjudicationCard(): JSX.Element {
         {header}
         <CardColumn>
           <CardRow>
-            <CardColumn>
-              <LargeText>
-                <Icons.Done color="success" /> All ballots adjudicated
-              </LargeText>
-              <div>
-                {completedCount} of {totalTally} adjudicated · {percentComplete}
-                %
-              </div>
-            </CardColumn>
+            <LargeText>
+              <Icons.Done color="success" /> All ballots adjudicated
+            </LargeText>
             <LinkButton
               variant="primary"
               icon="RotateRight"
@@ -317,6 +309,9 @@ function BallotAdjudicationCard(): JSX.Element {
               Review
             </LinkButton>
           </CardRow>
+          <InlineStatus>
+            {completedCount} of {totalTally} adjudicated · {percentComplete}%
+          </InlineStatus>
           <SuccessProgressBar />
         </CardColumn>
       </Card>
@@ -491,13 +486,15 @@ export function AdjudicationStartScreen(): JSX.Element {
   }
 
   const { areWriteInCandidatesQualified } = systemSettingsQuery.data;
+  const showMultiStationCard = isMultiStationEnabled && !isOfficialResults;
+  const hasOtherCards = areWriteInCandidatesQualified || showMultiStationCard;
 
   return (
     <NavigationScreen title="Adjudication">
       <CardStack>
         {areWriteInCandidatesQualified && <WriteInCandidatesCard />}
-        <BallotAdjudicationCard />
-        {isMultiStationEnabled && !isOfficialResults && <MultiStationCard />}
+        <BallotAdjudicationCard showHeader={hasOtherCards} />
+        {showMultiStationCard && <MultiStationCard />}
       </CardStack>
     </NavigationScreen>
   );

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -477,12 +477,14 @@ test('confirmation modal back returns and accept anyway resolves and navigates t
       createdAt: new Date().toISOString(),
     },
   ]);
+  apiMock.apiClient.getQualifiedWriteInCandidates
+    .expectRepeatedCallsWith()
+    .resolves([]);
 
   userEvent.click(screen.getByRole('button', { name: 'Accept Anyway' }));
 
-  // verify start screen shows 1 Ballot Completed
-  await screen.findByText('1 Ballot Completed');
-  screen.getByText('0 Ballots Awaiting Review');
+  // verify start screen shows the completed state
+  await screen.findByText('All ballots adjudicated');
 });
 
 test('clicking a contest opens contest adjudication screen', async () => {

--- a/apps/admin/frontend/src/screens/write_in_candidates_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/write_in_candidates_screen.test.tsx
@@ -5,7 +5,7 @@ import type { QualifiedWriteInCandidateRecord } from '@votingworks/admin-backend
 import { Election } from '@votingworks/types';
 import { screen, within, waitFor } from '../../test/react_testing_library';
 import { renderInAppContext } from '../../test/render_in_app_context';
-import { WriteInCandidatesTab } from './write_in_candidates_tab';
+import { WriteInCandidatesScreen } from './write_in_candidates_screen';
 import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;
@@ -20,7 +20,7 @@ afterEach(() => {
 });
 
 function renderTab() {
-  return renderInAppContext(<WriteInCandidatesTab />, {
+  return renderInAppContext(<WriteInCandidatesScreen />, {
     apiMock,
   });
 }
@@ -70,7 +70,7 @@ describe('contest list', () => {
     const primaryElectionDefinition =
       electionTwoPartyPrimaryFixtures.readElectionDefinition();
     expectGetQualifiedWriteInCandidates();
-    renderInAppContext(<WriteInCandidatesTab />, {
+    renderInAppContext(<WriteInCandidatesScreen />, {
       electionDefinition: primaryElectionDefinition,
       apiMock,
     });
@@ -88,7 +88,7 @@ describe('contest list', () => {
         c.type === 'candidate' ? { ...c, allowWriteIns: false } : c
       ),
     };
-    renderInAppContext(<WriteInCandidatesTab />, {
+    renderInAppContext(<WriteInCandidatesScreen />, {
       electionDefinition: { ...electionDefinition, election },
       apiMock,
     });

--- a/apps/admin/frontend/src/screens/write_in_candidates_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_in_candidates_screen.tsx
@@ -7,15 +7,7 @@ import {
   Id,
 } from '@votingworks/types';
 import { assertDefined } from '@votingworks/basics';
-import {
-  Button,
-  Callout,
-  DesktopPalette,
-  Modal,
-  P,
-  TabPanel,
-  useCurrentTheme,
-} from '@votingworks/ui';
+import { Button, Callout, Modal, P, useCurrentTheme } from '@votingworks/ui';
 import type { QualifiedWriteInCandidateRecord } from '@votingworks/admin-backend';
 import { AppContext } from '../contexts/app_context';
 import { EntityList } from '../components/entity_list';
@@ -23,6 +15,8 @@ import {
   getQualifiedWriteInCandidates,
   updateQualifiedWriteInCandidates,
 } from '../api';
+import { NavigationScreen } from '../components/navigation_screen';
+import { routerPaths } from '../router_paths';
 
 const Container = styled.div`
   display: flex;
@@ -54,7 +48,7 @@ const ActionsRow = styled.div`
     ${(p) => p.theme.colors.outline};
   display: flex;
   gap: 0.5rem;
-  padding: 0.5rem 1rem;
+  padding: 1rem;
 `;
 
 const cssViewMode = css`
@@ -88,12 +82,11 @@ const FormBody = styled.div`
 
 const FormFooter = styled.div`
   border-top: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid
-    ${DesktopPalette.Gray30};
+    ${(p) => p.theme.colors.outline};
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin: 0 1rem;
-  padding: 1rem 0;
+  padding: 1rem;
 `;
 
 const CandidateList = styled.div`
@@ -431,7 +424,7 @@ function CandidatesForm({ contestId }: { contestId: ContestId }): JSX.Element {
   );
 }
 
-export function WriteInCandidatesTab(): JSX.Element {
+export function WriteInCandidatesScreen(): JSX.Element {
   const { electionDefinition } = useContext(AppContext);
   const { election } = assertDefined(electionDefinition);
 
@@ -444,13 +437,20 @@ export function WriteInCandidatesTab(): JSX.Element {
     ContestId | undefined
   >(writeInContests[0]?.id);
 
+  const parentRoutes = [
+    { title: 'Adjudication', path: routerPaths.adjudication },
+  ];
+
   if (writeInContests.length === 0) {
     return (
-      <TabPanel>
+      <NavigationScreen
+        title="Qualified Write-In Candidates"
+        parentRoutes={parentRoutes}
+      >
         <Callout icon="Info" color="neutral">
           No contests in this election allow write-in candidates.
         </Callout>
-      </TabPanel>
+      </NavigationScreen>
     );
   }
 
@@ -459,7 +459,12 @@ export function WriteInCandidatesTab(): JSX.Element {
   );
 
   return (
-    <TabPanel style={{ padding: 0, flex: 1, minHeight: 0 }}>
+    <NavigationScreen
+      title="Qualified Write-In Candidates"
+      parentRoutes={parentRoutes}
+      noPadding
+      style={{ overflow: 'hidden' }}
+    >
       <Container>
         <ContestListContainer>
           <EntityList.Box>
@@ -497,6 +502,6 @@ export function WriteInCandidatesTab(): JSX.Element {
           <CandidatesForm contestId={selectedContest.id} />
         </CandidatesContainer>
       </Container>
-    </TabPanel>
+    </NavigationScreen>
   );
 }

--- a/apps/admin/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/admin/integration-testing/e2e/screenshots.spec.ts
@@ -464,12 +464,12 @@ test('results', async ({ page }) => {
   await screenshot('tally-screen-with-cvrs');
 
   await page.getByText('Adjudication').click();
-  await page.getByText('Start Adjudicating').waitFor();
+  await page.getByRole('button', { name: 'Adjudicate' }).waitFor();
   await screenshot('adjudication-screen-pre-adjudication');
 
   await adjudicateAllWriteIns(page);
 
-  await page.getByText('Start Adjudicating').waitFor();
+  await page.getByRole('button', { name: 'Review' }).waitFor();
   await screenshot('adjudication-screen-post-adjudication');
 
   await page.getByText('Reports').click();
@@ -625,9 +625,9 @@ test('adjudication', async ({ page }) => {
   await page.getByText('Total CVR Count: 1').waitFor();
 
   await page.getByText('Adjudication').click();
-  await page.getByText('Start Adjudicating').waitFor();
+  await page.getByRole('button', { name: 'Adjudicate' }).waitFor();
 
-  await page.getByText('Start Adjudicating').click();
+  await page.getByRole('button', { name: 'Adjudicate' }).click();
   await page.getByText(/Ballot \d+ of \d+/).waitFor();
   await screenshot('adjudication-view');
 
@@ -653,7 +653,7 @@ test('adjudication', async ({ page }) => {
   // Exit to start screen
   await page.getByRole('button', { name: /Exit/ }).waitFor();
   await page.getByRole('button', { name: /Exit/ }).click();
-  await page.getByText('Start Adjudicating').waitFor();
+  await page.getByRole('button', { name: 'Adjudicate' }).waitFor();
 });
 
 test('manual results', async ({ page }) => {

--- a/apps/admin/integration-testing/e2e/support/write_in_adjudication.ts
+++ b/apps/admin/integration-testing/e2e/support/write_in_adjudication.ts
@@ -87,7 +87,7 @@ function getPendingContestItems(page: Page): Locator {
 }
 
 export async function adjudicateAllWriteIns(page: Page): Promise<void> {
-  await page.getByText('Start Adjudicating').click();
+  await page.getByRole('button', { name: 'Adjudicate' }).click();
   await page.getByText(/Ballot \d+ of \d+/).waitFor();
 
   let writeInIndex = 0;
@@ -95,8 +95,12 @@ export async function adjudicateAllWriteIns(page: Page): Promise<void> {
   // Process ballots until we return to the adjudication start screen
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    // If we've navigated back to the start screen, adjudication is complete
-    if (await page.getByText('Start Adjudicating').isVisible()) {
+    // If we've navigated back to the start screen, adjudication is complete.
+    if (
+      await page
+        .getByRole('heading', { name: 'Adjudication', level: 1 })
+        .isVisible()
+    ) {
       break;
     }
 

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -24,6 +24,8 @@ import {
   faGear,
   faBan,
   faCheckSquare as faCheckSquareSolid,
+  faCircle as faCircleSolid,
+  faSquare as faSquareSolid,
   faChevronCircleUp,
   faChevronCircleDown,
   faChevronRight,
@@ -64,11 +66,13 @@ import {
   faMouse,
   faPause,
   faPencil,
+  faPenToSquare,
   faPlay,
   faPowerOff,
   faPrint,
   faRotateRight,
   faSimCard,
+  faSitemap,
   faSort,
   faSortDown,
   faTowerBroadcast,
@@ -96,6 +100,7 @@ import {
   faVolumeDown,
   faClock,
   faHeadphones,
+  faUserPen,
 } from '@fortawesome/free-solid-svg-icons';
 import { faUsb } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -274,12 +279,17 @@ export const Icons = {
     return <FaIcon {...props} type={faSimCard} />;
   },
 
+  Sitemap(props) {
+    return <FaIcon {...props} type={faSitemap} />;
+  },
+
   CaretDown(props) {
     return <FaIcon {...props} type={faCaretDown} />;
   },
 
-  Circle(props) {
-    return <FaIcon {...props} type={faCircle} />;
+  Circle(props: IconProps & { filled?: boolean }) {
+    const { filled = false } = props;
+    return <FaIcon {...props} type={filled ? faCircleSolid : faCircle} />;
   },
 
   CircleDot(props) {
@@ -517,6 +527,10 @@ export const Icons = {
     return <FaIcon {...props} type={faPause} />;
   },
 
+  PenToSquare(props) {
+    return <FaIcon {...props} type={faPenToSquare} />;
+  },
+
   Print(props) {
     return <FaIcon {...props} type={faPrint} />;
   },
@@ -573,8 +587,9 @@ export const Icons = {
     return <FaIcon {...props} type={faArrowsSplitUpAndLeft} />;
   },
 
-  Square(props) {
-    return <FaIcon {...props} type={faSquare} />;
+  Square(props: IconProps & { filled?: boolean }) {
+    const { filled = false } = props;
+    return <FaIcon {...props} type={filled ? faSquareSolid : faSquare} />;
   },
 
   Strikethrough(props) {
@@ -599,6 +614,10 @@ export const Icons = {
 
   UsbDrive(props) {
     return <FaIcon {...props} type={faUsb} />;
+  },
+
+  UserPen(props) {
+    return <FaIcon {...props} type={faUserPen} />;
   },
 
   VolumeDown(props) {

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -100,7 +100,6 @@ import {
   faVolumeDown,
   faClock,
   faHeadphones,
-  faUserPen,
 } from '@fortawesome/free-solid-svg-icons';
 import { faUsb } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -290,6 +289,10 @@ export const Icons = {
   Circle(props: IconProps & { filled?: boolean }) {
     const { filled = false } = props;
     return <FaIcon {...props} type={filled ? faCircleSolid : faCircle} />;
+  },
+
+  CircleSolid(props) {
+    return <FaIcon {...props} type={faCircleSolid} />;
   },
 
   CircleDot(props) {
@@ -587,9 +590,12 @@ export const Icons = {
     return <FaIcon {...props} type={faArrowsSplitUpAndLeft} />;
   },
 
-  Square(props: IconProps & { filled?: boolean }) {
-    const { filled = false } = props;
-    return <FaIcon {...props} type={filled ? faSquareSolid : faSquare} />;
+  Square(props) {
+    return <FaIcon {...props} type={faSquare} />;
+  },
+
+  SquareSolid(props) {
+    return <FaIcon {...props} type={faSquareSolid} />;
   },
 
   Strikethrough(props) {
@@ -614,10 +620,6 @@ export const Icons = {
 
   UsbDrive(props) {
     return <FaIcon {...props} type={faUsb} />;
-  },
-
-  UserPen(props) {
-    return <FaIcon {...props} type={faUserPen} />;
   },
 
   VolumeDown(props) {


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7898

Designed with Claude Design

1. This PR reorganizes the adjudication start screen, removing the tab bar and adding cards that are conditionally shown. 
2. Updates the icon used for the network in the Toolbar, addressing feedback to ensure it doesn't look like Admin is Internet/Wifi connected

Two things that are added that I'm unsure if we will want to keep, so feedback is especially welcome here:
- All caps headers. Suggestion from Claude Design, I like how it looks but not needed
- Progress/complete states

## Demo Video or Screenshot

Qualified write-in candidates card:

https://github.com/user-attachments/assets/31767079-5d05-4e1f-b659-7ecb36f77c49

Ballot adjudication card:

https://github.com/user-attachments/assets/07fc7917-d2a9-4949-8986-a0cd3fb3bc3d

Multi-station card:

https://github.com/user-attachments/assets/5802564a-768b-4f14-8771-0c0fd6c77301


No qualified candidates, multi-station:
<img width="1080" height="676" alt="Screenshot 2026-04-28 at 12 18 25 PM" src="https://github.com/user-attachments/assets/c7d06ef0-8b36-4241-8809-564e43ba832a" />

No multi-station:
<img width="1086" height="681" alt="Screenshot 2026-04-28 at 12 17 57 PM" src="https://github.com/user-attachments/assets/91cc5071-2c1f-4473-b591-03a545cb00a2" />

Network offline: 
<img width="1077" height="678" alt="Screenshot 2026-04-28 at 12 03 01 PM" src="https://github.com/user-attachments/assets/3df26b9d-6780-4fc3-b628-1c81f9dafbbf" />

Info Message in adjudication card:
<img width="1094" height="700" alt="Screenshot 2026-04-28 at 12 33 42 PM" src="https://github.com/user-attachments/assets/6c7af4ab-56bc-4b62-932f-d71f988d6a46" />


## Testing Plan

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
