### PR TITLE
perf(ballot-interpreter): cache the bubble scan template image

### DIFF
--- a/libs/ballot-interpreter/benches/main.rs
+++ b/libs/ballot-interpreter/benches/main.rs
@@ -42,7 +42,7 @@ impl InterpretFixture {
             None,
             DEFAULT_MAX_CUMULATIVE_STREAK_WIDTH,
             DEFAULT_RETRY_STREAK_WIDTH_THRESHOLD,
-        )?;
+        );
         let side_a_path = fixture_path
             .join(self.election)
             .join(format!("{}-front{}", self.name, self.extension));

--- a/libs/ballot-interpreter/bin/interpret.rs
+++ b/libs/ballot-interpreter/bin/interpret.rs
@@ -394,7 +394,7 @@ fn interpret_bubble_ballot(
         options.minimum_detected_scale,
         options.max_cumulative_streak_width,
         options.retry_streak_width_threshold,
-    )?;
+    );
 
     let bottom_image = options
         .load_bottom_image()?

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/ballot_card.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/ballot_card.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, io, mem::swap, ops::Range, path::PathBuf};
+use std::{cmp::Ordering, io, mem::swap, ops::Range, path::PathBuf, sync::LazyLock};
 
 use crate::{
     image_utils::{otsu_level, threshold},
@@ -974,16 +974,24 @@ pub fn get_matching_paper_info_for_image_size(
         .map(|(paper_info, _)| *paper_info)
 }
 
-/// Load the ballot scan bubble image.
+/// Returns the ballot scan bubble template image, decoding and preprocessing it
+/// on first call and caching the result for subsequent calls.
 ///
-/// # Errors
+/// # Panics
 ///
-/// Returns an error if the image cannot be loaded or converted to grayscale.
-pub fn load_ballot_scan_bubble_image() -> Result<GrayImage, image::ImageError> {
-    let bubble_image_bytes = include_bytes!("../../data/bubble_scan.png");
-    let inner = io::Cursor::new(bubble_image_bytes);
-    let image = image::load(inner, image::ImageFormat::Png).map(|image| image.to_luma8())?;
-    Ok(bleed(&threshold(&image, otsu_level(&image)), BLACK))
+/// Panics if the embedded `bubble_scan.png` cannot be decoded — this would be a
+/// build-time bug, not a runtime condition.
+#[must_use]
+pub fn ballot_scan_bubble_image() -> &'static GrayImage {
+    static TEMPLATE: LazyLock<GrayImage> = LazyLock::new(|| {
+        let bubble_image_bytes = include_bytes!("../../data/bubble_scan.png");
+        let inner = io::Cursor::new(bubble_image_bytes);
+        let image = image::load(inner, image::ImageFormat::Png)
+            .map(|image| image.to_luma8())
+            .expect("decoding embedded bubble_scan.png always succeeds");
+        bleed(&threshold(&image, otsu_level(&image)), BLACK)
+    });
+    &TEMPLATE
 }
 
 #[cfg(test)]
@@ -1057,6 +1065,6 @@ mod tests {
 
     #[test]
     fn test_load_bubble_template() {
-        load_ballot_scan_bubble_image().unwrap();
+        let _ = ballot_scan_bubble_image();
     }
 }

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/diagnostic.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/diagnostic.rs
@@ -5,7 +5,7 @@ use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use types_rs::geometry::Rect;
 
 use crate::{
-    ballot_card::{load_ballot_scan_bubble_image, BallotImage},
+    ballot_card::{ballot_scan_bubble_image, BallotImage},
     debug::draw_diagnostic_cells,
     image_utils::{count_pixels, threshold, BLACK},
 };
@@ -75,7 +75,7 @@ fn inspect_cells(ballot_image: &BallotImage, cells: &[Rect]) -> (Vec<Rect>, Vec<
 }
 
 pub fn blank_paper(img: GrayImage, debug_path: Option<PathBuf>) -> bool {
-    let bubble_img = load_ballot_scan_bubble_image().expect("loaded bubble image");
+    let bubble_img = ballot_scan_bubble_image();
     let cell_width = bubble_img.width();
     let cell_height = bubble_img.height();
 

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
@@ -13,7 +13,7 @@ use types_rs::geometry::PixelPosition;
 use types_rs::geometry::{PixelUnit, Size};
 use types_rs::pair::Pair;
 
-use crate::ballot_card::load_ballot_scan_bubble_image;
+use crate::ballot_card::ballot_scan_bubble_image;
 use crate::ballot_card::BallotCard;
 use crate::ballot_card::BallotPage;
 use crate::ballot_card::Geometry;
@@ -40,7 +40,7 @@ pub const DEFAULT_RETRY_STREAK_WIDTH_THRESHOLD: PixelUnit = 1;
 #[derive(Debug, Clone)]
 pub struct Options {
     pub election: Election,
-    pub bubble_template: GrayImage,
+    pub bubble_template: &'static GrayImage,
     pub debug_side_a_base: Option<PathBuf>,
     pub debug_side_b_base: Option<PathBuf>,
     pub write_in_scoring: WriteInScoring,
@@ -252,7 +252,7 @@ pub struct ScanInterpreter {
     election: Election,
     write_in_scoring: WriteInScoring,
     vertical_streak_detection: VerticalStreakDetection,
-    bubble_template_image: GrayImage,
+    bubble_template_image: &'static GrayImage,
     minimum_detected_scale: Option<f32>,
     max_cumulative_streak_width: PixelUnit,
     retry_streak_width_threshold: PixelUnit,
@@ -260,10 +260,7 @@ pub struct ScanInterpreter {
 
 impl ScanInterpreter {
     /// Creates a new `ScanInterpreter` with the given configuration.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the bubble template image could not be loaded.
+    #[must_use]
     pub fn new(
         election: Election,
         write_in_scoring: WriteInScoring,
@@ -271,17 +268,16 @@ impl ScanInterpreter {
         minimum_detected_scale: Option<f32>,
         max_cumulative_streak_width: PixelUnit,
         retry_streak_width_threshold: PixelUnit,
-    ) -> Result<Self, image::ImageError> {
-        let bubble_template_image = load_ballot_scan_bubble_image()?;
-        Ok(Self {
+    ) -> Self {
+        Self {
             election,
             write_in_scoring,
             vertical_streak_detection,
-            bubble_template_image,
+            bubble_template_image: ballot_scan_bubble_image(),
             minimum_detected_scale,
             max_cumulative_streak_width,
             retry_streak_width_threshold,
-        })
+        }
     }
 
     /// Interprets a pair of ballot card images.
@@ -299,7 +295,7 @@ impl ScanInterpreter {
     ) -> Result<InterpretedBallotCard> {
         let options = Options {
             election: self.election.clone(),
-            bubble_template: self.bubble_template_image.clone(),
+            bubble_template: self.bubble_template_image,
             debug_side_a_base: debug_side_a_base.into(),
             debug_side_b_base: debug_side_b_base.into(),
             write_in_scoring: self.write_in_scoring,
@@ -457,7 +453,7 @@ pub fn ballot_card(
         || -> Result<ScoringPairs> {
             let scored_bubble_marks = ballot_card.score_bubble_marks(
                 &timing_marks,
-                &options.bubble_template,
+                options.bubble_template,
                 grid_layout,
                 &detected_vertical_streaks,
                 sheet_number,
@@ -544,7 +540,7 @@ mod test {
     };
 
     use crate::{
-        ballot_card::load_ballot_scan_bubble_image, debug::ImageDebugWriter, qr_code,
+        ballot_card::ballot_scan_bubble_image, debug::ImageDebugWriter, qr_code,
         scoring::UnitIntervalScore, timing_marks::TimingMarks,
     };
 
@@ -570,7 +566,7 @@ mod test {
         let election_path = fixture_path.join(fixture_name).join("election.json");
         let election: Election =
             serde_json::from_reader(BufReader::new(File::open(election_path).unwrap())).unwrap();
-        let bubble_template = load_ballot_scan_bubble_image().unwrap();
+        let bubble_template = ballot_scan_bubble_image();
         let side_a_path = fixture_path.join(fixture_name).join(side_a_name);
         let side_b_path = fixture_path.join(fixture_name).join(side_b_name);
         let (side_a_image, side_b_image) = load_ballot_card_images(&side_a_path, &side_b_path);
@@ -599,7 +595,7 @@ mod test {
         let election =
             serde_json::from_reader(BufReader::new(File::open(election_path).unwrap())).unwrap();
 
-        let bubble_template = load_ballot_scan_bubble_image().unwrap();
+        let bubble_template = ballot_scan_bubble_image();
         let side_a_path = fixture_path.join(format!("blank-ballot-p{starting_page_number}.jpg"));
         let side_b_path =
             fixture_path.join(format!("blank-ballot-p{}.jpg", starting_page_number + 1));

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/js/mod.rs
@@ -15,7 +15,7 @@ use types_rs::bmd::multi_page::MultiPageCastVoteRecord;
 use types_rs::coding;
 use types_rs::election::Election;
 
-use crate::ballot_card::{load_ballot_scan_bubble_image, BallotPage, PaperInfo};
+use crate::ballot_card::{ballot_scan_bubble_image, BallotPage, PaperInfo};
 use crate::interpret::{
     self, ballot_card, InterpretedBallotCard, Options, VerticalStreakDetection, WriteInScoring,
 };
@@ -72,7 +72,7 @@ fn interpret(
         None => None,
     };
 
-    let bubble_template = load_ballot_scan_bubble_image().expect("failed to load bubble template");
+    let bubble_template = ballot_scan_bubble_image();
     let interpret_result = ballot_card(
         side_a_image,
         side_b_image,


### PR DESCRIPTION
## Overview

This is really more of a refactor than a performance improvement, but it should have some (very) small effect. I mostly wanted to simplify the API as a precursor to simplifying the `interpret::Options` struct and its users.

Some notes on the implementation:
- Interpreter only need a reference to a `GrayImage`, not its own copy.
- `&' static GrayImage` is a reference to a `GrayImage` that lives as long as the program is running.
- `LazyLock` ensures that the image is loaded exactly once when it's needed, and we then return the static reference.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated tests.