### PR TITLE
ci: update `circleci/path-filtering` to v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 setup: true
 
 orbs:
-  path-filtering: circleci/path-filtering@1
+  path-filtering: circleci/path-filtering@2
 
 executors:
   nodejs:

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -329,7 +329,7 @@ version: 2.1
 setup: true
 
 orbs:
-  path-filtering: circleci/path-filtering@1
+  path-filtering: circleci/path-filtering@2
 
 executors:
   nodejs:


### PR DESCRIPTION
v1 broke due to the pip bootstrap script now requring python 3.10, but the orb uses python 3.9. v2 should fix this since it removes the pip bootstrap part altogether.