### PR TITLE
[VxPrint] Use polling place for location configuration checks

### DIFF
--- a/apps/print/backend/src/auth.test.ts
+++ b/apps/print/backend/src/auth.test.ts
@@ -12,6 +12,7 @@ import {
   getFeatureFlagMock,
   singlePrecinctSelectionFor,
 } from '@votingworks/utils';
+import { assertDefined } from '@votingworks/basics';
 import {
   buildTestEnvironment,
   configureMachine,
@@ -44,6 +45,7 @@ beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(
     BooleanEnvironmentVariableName.SKIP_ELECTION_PACKAGE_AUTHENTICATION
   );
+  setPollingPlacesEnabled(false);
 });
 
 let server: Server | undefined;
@@ -75,6 +77,44 @@ test('getAuthStatus', async () => {
   await apiClient.getAuthStatus();
   expect(auth.getAuthStatus).toHaveBeenCalledTimes(1);
   expect(auth.getAuthStatus).toHaveBeenNthCalledWith(1, {
+    ...DEFAULT_SYSTEM_SETTINGS.auth,
+    electionKey,
+    jurisdiction,
+    machineType,
+    isConfigured: true,
+  });
+});
+
+test('getAuthStatus - configured state is based on polling place selection', async () => {
+  setPollingPlacesEnabled(true);
+
+  const env = buildTestEnvironment();
+  server = env.server;
+  const { apiClient, auth, mockUsbDrive } = env;
+
+  await configureMachine({
+    electionDefinition,
+    ballots,
+    apiClient,
+    auth,
+    mockUsbDrive,
+  });
+
+  await apiClient.getAuthStatus();
+  expect(auth.getAuthStatus).toHaveBeenLastCalledWith({
+    ...DEFAULT_SYSTEM_SETTINGS.auth,
+    electionKey,
+    jurisdiction,
+    machineType,
+    isConfigured: false,
+  });
+
+  const { election } = electionDefinition;
+  const [pollingPlace] = assertDefined(election.pollingPlaces);
+  await apiClient.setPollingPlaceId({ id: pollingPlace.id });
+
+  await apiClient.getAuthStatus();
+  expect(auth.getAuthStatus).toHaveBeenLastCalledWith({
     ...DEFAULT_SYSTEM_SETTINGS.auth,
     electionKey,
     jurisdiction,
@@ -173,3 +213,12 @@ test('updateSessionExpiry', async () => {
     { sessionExpiresAt: expect.any(Date) }
   );
 });
+
+function setPollingPlacesEnabled(enabled: boolean) {
+  const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
+  if (enabled) {
+    mockFeatureFlagger.enableFeatureFlag(ENABLE_POLLING_PLACES);
+  } else {
+    mockFeatureFlagger.disableFeatureFlag(ENABLE_POLLING_PLACES);
+  }
+}

--- a/apps/print/backend/src/util/auth.ts
+++ b/apps/print/backend/src/util/auth.ts
@@ -9,7 +9,7 @@ import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
 import { BaseLogger, LoggingUserRole } from '@votingworks/logging';
 import {
   isFeatureFlagEnabled,
-  BooleanEnvironmentVariableName,
+  BooleanEnvironmentVariableName as Feature,
   isIntegrationTest,
 } from '@votingworks/utils';
 import { Workspace } from './workspace';
@@ -19,8 +19,7 @@ import { Store } from '../store';
 export function getDefaultAuth(logger: BaseLogger): DippedSmartCardAuth {
   return new DippedSmartCardAuth({
     card:
-      isFeatureFlagEnabled(BooleanEnvironmentVariableName.USE_MOCK_CARDS) ||
-      isIntegrationTest()
+      isFeatureFlagEnabled(Feature.USE_MOCK_CARDS) || isIntegrationTest()
         ? new MockFileCard()
         : new JavaCard(),
     config: {
@@ -43,13 +42,17 @@ export function constructAuthMachineState(
   const machineType = 'print';
   const systemSettings = store.getSystemSettings() ?? DEFAULT_SYSTEM_SETTINGS;
   const jurisdiction = store.getJurisdiction();
-  const requiresPrecinctSelection = store.getPrecinctSelection() === undefined;
+
+  const locationConfigured = isFeatureFlagEnabled(Feature.ENABLE_POLLING_PLACES)
+    ? !!store.getPollingPlaceId()
+    : !!store.getPrecinctSelection();
+
   return {
     ...systemSettings.auth,
     electionKey,
     jurisdiction,
     machineType,
-    isConfigured: !!electionKey && !requiresPrecinctSelection,
+    isConfigured: !!electionKey && locationConfigured,
   };
 }
 

--- a/apps/print/frontend/src/app.tsx
+++ b/apps/print/frontend/src/app.tsx
@@ -19,7 +19,9 @@ import { BaseLogger, LogSource } from '@votingworks/logging';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import {
+  BooleanEnvironmentVariableName as Feature,
   isElectionManagerAuth,
+  isFeatureFlagEnabled,
   isPollWorkerAuth,
   isSystemAdministratorAuth,
   isVendorAuth,
@@ -102,12 +104,16 @@ function AppRoot({
       return <MachineLockedScreen />;
     }
 
+    const locationType = isFeatureFlagEnabled(Feature.ENABLE_POLLING_PLACES)
+      ? 'polling place'
+      : 'precinct';
+
     return (
       <InvalidCardScreen
         reasonAndContext={authStatus}
         recommendedAction={
           authStatus.reason === 'machine_not_configured'
-            ? 'Use an election manager card and select a precinct to finish configuration.'
+            ? `Use an election manager card and select a ${locationType} to finish configuration.`
             : 'Use a valid card.'
         }
         cardInsertionDirection="right"

--- a/apps/print/frontend/src/components/screen_wrapper.tsx
+++ b/apps/print/frontend/src/components/screen_wrapper.tsx
@@ -17,6 +17,7 @@ import { routeMap } from '../routes';
 import {
   getElectionRecord,
   getMachineConfig,
+  getPollingPlaceId,
   getPrecinctSelection,
 } from '../api';
 
@@ -33,11 +34,13 @@ export function ScreenWrapper({
   const getElectionRecordQuery = getElectionRecord.useQuery();
   const getMachineConfigQuery = getMachineConfig.useQuery();
   const getPrecinctSelectionQuery = getPrecinctSelection.useQuery();
+  const getPollingPlaceIdQuery = getPollingPlaceId.useQuery();
 
   if (
     !getElectionRecordQuery.isSuccess ||
     !getMachineConfigQuery.isSuccess ||
-    !getPrecinctSelectionQuery.isSuccess
+    !getPrecinctSelectionQuery.isSuccess ||
+    !getPollingPlaceIdQuery.isSuccess
   ) {
     return null;
   }
@@ -45,6 +48,7 @@ export function ScreenWrapper({
   const electionRecord = getElectionRecordQuery.data;
   const machineConfig = getMachineConfigQuery.data;
   const precinctSelection = getPrecinctSelectionQuery.data;
+  const pollingPlaceId = getPollingPlaceIdQuery.data;
 
   const showNavItems = electionRecord !== null || authType === 'system_admin';
 
@@ -76,6 +80,7 @@ export function ScreenWrapper({
             machineId={machineConfig.machineId}
             inverse
             precinctSelection={precinctSelection || undefined}
+            pollingPlaceId={pollingPlaceId || undefined}
           />
         </div>
       </LeftNav>

--- a/apps/print/frontend/src/election_manager_app.tsx
+++ b/apps/print/frontend/src/election_manager_app.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
+import {
+  BooleanEnvironmentVariableName as Feature,
+  isFeatureFlagEnabled,
+} from '@votingworks/utils';
 import { PrintScreen } from './screens/print_screen';
 import { SettingsScreen } from './screens/settings_screen';
 import { ReportScreen } from './screens/report_screen';
@@ -8,18 +12,31 @@ import { ElectionScreen } from './screens/election_screen';
 import { DiagnosticsScreen } from './screens/diagnostics_screen';
 import { electionManagerRoutes } from './routes';
 import { PrinterAlertWrapper } from './components/printer_alert_wrapper';
-import { getElectionRecord, getPrecinctSelection } from './api';
+import {
+  getElectionRecord,
+  getPollingPlaceId,
+  getPrecinctSelection,
+} from './api';
 
 export function ElectionManagerApp(): JSX.Element | null {
   const electionRecordQuery = getElectionRecord.useQuery();
   const precinctSelectionQuery = getPrecinctSelection.useQuery();
+  const pollingPlaceIdQuery = getPollingPlaceId.useQuery();
 
-  if (!electionRecordQuery.isSuccess || !precinctSelectionQuery.isSuccess) {
+  if (
+    !electionRecordQuery.isSuccess ||
+    !precinctSelectionQuery.isSuccess ||
+    !pollingPlaceIdQuery.isSuccess
+  ) {
     return null;
   }
 
+  const locationConfigured = isFeatureFlagEnabled(Feature.ENABLE_POLLING_PLACES)
+    ? pollingPlaceIdQuery.data !== null
+    : precinctSelectionQuery.data !== null;
+
   const isMachineConfigured =
-    electionRecordQuery.data !== null && precinctSelectionQuery.data !== null;
+    electionRecordQuery.data !== null && locationConfigured;
 
   return (
     <React.Fragment>

--- a/apps/print/frontend/src/screens/diagnostics_screen.tsx
+++ b/apps/print/frontend/src/screens/diagnostics_screen.tsx
@@ -1,9 +1,9 @@
 import {
   PrintReadinessReportContents,
   SaveReadinessReportButton,
+  Loading,
 } from '@votingworks/ui';
 import styled from 'styled-components';
-import { Loading } from '@votingworks/ui';
 import { ScreenWrapper } from '../components/screen_wrapper';
 import { TitleBar } from '../components/title_bar';
 import {
@@ -12,6 +12,7 @@ import {
   getDiskSpaceSummary,
   saveReadinessReport,
   getElectionRecord,
+  getPollingPlaceId,
 } from '../api';
 import { PrintTestPageButton } from '../components/print_test_page_button';
 
@@ -36,11 +37,13 @@ export function DiagnosticsScreen({
   const diagnosticRecordQuery = getMostRecentPrinterDiagnostic.useQuery();
   const saveReadinessReportMutation = saveReadinessReport.useMutation();
   const electionRecordQuery = getElectionRecord.useQuery();
+  const pollingPlaceIdQuery = getPollingPlaceId.useQuery();
 
   if (
     !deviceStatusesQuery.isSuccess ||
     !diagnosticRecordQuery.isSuccess ||
     !diskSpaceQuery.isSuccess ||
+    !pollingPlaceIdQuery.isSuccess ||
     !electionRecordQuery.isSuccess
   ) {
     return (
@@ -59,6 +62,7 @@ export function DiagnosticsScreen({
   const diskSpaceSummary = diskSpaceQuery.data;
   const mostRecentPrinterDiagnostic = diagnosticRecordQuery.data ?? undefined;
   const electionRecord = electionRecordQuery.data;
+  const pollingPlaceId = pollingPlaceIdQuery.data;
 
   return (
     <ScreenWrapper authType={authType}>
@@ -74,6 +78,7 @@ export function DiagnosticsScreen({
               electionDefinition={electionRecord?.electionDefinition}
               electionPackageHash={electionRecord?.electionPackageHash}
               printerDiagnosticUi={<PrintTestPageButton />}
+              pollingPlaceId={pollingPlaceId || undefined}
             />
           </div>
           <SaveReadinessReportButton

--- a/apps/print/frontend/src/screens/machine_locked_screen.tsx
+++ b/apps/print/frontend/src/screens/machine_locked_screen.tsx
@@ -9,8 +9,13 @@ import {
   Screen,
 } from '@votingworks/ui';
 import {
+  BooleanEnvironmentVariableName as Feature,
+  isFeatureFlagEnabled,
+} from '@votingworks/utils';
+import {
   getElectionRecord,
   getMachineConfig,
+  getPollingPlaceId,
   getPrecinctSelection,
 } from '../api';
 
@@ -22,14 +27,17 @@ const LockedImage = styled.img`
 `;
 
 export function MachineLockedScreen(): JSX.Element | null {
+  const usePollingPlaces = isFeatureFlagEnabled(Feature.ENABLE_POLLING_PLACES);
   const getElectionRecordQuery = getElectionRecord.useQuery();
   const getMachineConfigQuery = getMachineConfig.useQuery();
   const getPrecinctSelectionQuery = getPrecinctSelection.useQuery();
+  const getPollingPlaceIdQuery = getPollingPlaceId.useQuery();
 
   if (
     !getElectionRecordQuery.isSuccess ||
     !getMachineConfigQuery.isSuccess ||
-    !getPrecinctSelectionQuery.isSuccess
+    !getPrecinctSelectionQuery.isSuccess ||
+    !getPollingPlaceIdQuery.isSuccess
   ) {
     return null;
   }
@@ -37,10 +45,16 @@ export function MachineLockedScreen(): JSX.Element | null {
   const electionDefinition = getElectionRecordQuery.data?.electionDefinition;
   const electionPackageHash = getElectionRecordQuery.data?.electionPackageHash;
   const machineConfig = getMachineConfigQuery.data;
+  const pollingPlaceId = getPollingPlaceIdQuery.data;
   const requiresElectionConfiguration = !electionDefinition;
-  const requiresPrecinctSelection = !getPrecinctSelectionQuery.data;
+  const requiresLocationSelection = usePollingPlaces
+    ? !pollingPlaceId
+    : !getPrecinctSelectionQuery.data;
   const isConfigured =
-    !requiresElectionConfiguration && !requiresPrecinctSelection;
+    !requiresElectionConfiguration && !requiresLocationSelection;
+
+  const locationType = usePollingPlaces ? 'polling place' : 'precinct';
+
   return (
     <Screen>
       <Main centerChild>
@@ -54,8 +68,8 @@ export function MachineLockedScreen(): JSX.Element | null {
           <Font align="center">
             <InsertCardImage cardInsertionDirection="right" />
             <H1 style={{ maxWidth: '27rem', marginTop: '0' }}>
-              {requiresPrecinctSelection
-                ? 'Insert an election manager card to select a precinct.'
+              {requiresLocationSelection
+                ? `Insert an election manager card to select a ${locationType}.`
                 : 'Insert an election manager card to configure VxPrint.'}
             </H1>
           </Font>
@@ -65,6 +79,7 @@ export function MachineLockedScreen(): JSX.Element | null {
         mode="admin"
         electionDefinition={electionDefinition}
         electionPackageHash={electionPackageHash}
+        pollingPlaceId={pollingPlaceId ?? undefined}
         codeVersion={machineConfig.codeVersion}
         machineId={machineConfig.machineId}
       />


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7875

_Currently behind the `ENABLE_POLLING_PLACES` dev feature flag_

Last bits of wire-up for polling place support in VxPrint:
- When constructing the auth state in the server, use the polling place selection to determine whether or not the machine is fully configured.
- Use polling place selection for configuration checks in the client and update on-screen messaging accordingly.
- Pipe the selected polling ID through to subcomponents (election info bar and the in-app diagnostics).

## Demo Video or Screenshot

| | |
| - | - |
| Lock Screen | <img width="1438" height="809" alt="vxprint-no-location-config" src="https://github.com/user-attachments/assets/6ee101d3-fa45-4714-87d4-e67653bf3011" /> |
| Poll Worker Login | <img width="1438" height="809" alt="vxprint-poll-worker-login-no-location" src="https://github.com/user-attachments/assets/8a2dafb4-8a31-468a-b31e-d345f43eeee9" /> |
| Election Info Bar | <img width="1438" height="809" alt="vxprint-polling-place-in-election-info" src="https://github.com/user-attachments/assets/53e4a91d-535b-4399-8094-3dae3bdb53cf" /> |
| Diagnostics Screen | <img width="1438" height="809" alt="vxprint-polling-place-in-diagnostics-screen" src="https://github.com/user-attachments/assets/e6b4618e-d451-4055-820d-8f3bafe54f5f" /> |

## Testing Plan
- New unit test case for server auth changes
- Manual testing for UI changes for now
