### PR TITLE
VxDesign: Store polls close as time only

### DIFF
--- a/apps/design/frontend/src/system_settings_screen.test.tsx
+++ b/apps/design/frontend/src/system_settings_screen.test.tsx
@@ -523,7 +523,7 @@ test('cancelling', async () => {
 test('all controls are disabled until clicking "Edit"', async () => {
   const systemSettings: SystemSettings = {
     ...electionRecord.systemSettings,
-    electionDayPollsCloseTime: '2026-11-03T20:00:00',
+    electionDayPollsCloseTime: '20:00:00',
   };
   apiMock.getSystemSettings
     .expectCallWith({ electionId })
@@ -535,7 +535,7 @@ test('all controls are disabled until clicking "Edit"', async () => {
   const allTextBoxes = document.body.querySelectorAll('input');
 
   for (const textbox of allTextBoxes) {
-    expect(textbox.type).toMatch(/^text|number|datetime-local$/);
+    expect(textbox.type).toMatch(/^text|number|time$/);
   }
 
   const allCheckboxes = document.body.querySelectorAll('[role=checkbox]');
@@ -549,7 +549,13 @@ test('all controls are disabled until clicking "Edit"', async () => {
 
   userEvent.click(screen.getByRole('button', { name: 'Edit' }));
 
-  for (const control of allControls) {
+  // Re-query for all controls because the Polls Closed input is
+  // re-rendered after clicking "Edit"
+  const allControlsAfterEdit = [
+    ...document.body.querySelectorAll('input'),
+    ...document.body.querySelectorAll('[role=checkbox]'),
+  ];
+  for (const control of allControlsAfterEdit) {
     expect(control).not.toBeDisabled();
   }
 });
@@ -805,7 +811,7 @@ describe('election day polls close time', () => {
 
     // Setting a close time enables the checkboxes
     fireEvent.change(screen.getByLabelText('Election Day Polls Close Time'), {
-      target: { value: '2026-11-03T20:00' },
+      target: { value: '20:00' },
     });
     expect(
       screen.getByRole('checkbox', {
@@ -822,7 +828,7 @@ describe('election day polls close time', () => {
   test('disallow closing polls before close time', async () => {
     const initialSettings: SystemSettings = {
       ...electionRecord.systemSettings,
-      electionDayPollsCloseTime: '2026-11-03T20:00:00',
+      electionDayPollsCloseTime: '20:00:00',
     };
     apiMock.getSystemSettings
       .expectCallWith({ electionId })
@@ -859,7 +865,7 @@ describe('election day polls close time', () => {
   test('disallow VxAdmin tabulation before close time', async () => {
     const initialSettings: SystemSettings = {
       ...electionRecord.systemSettings,
-      electionDayPollsCloseTime: '2026-11-03T20:00:00',
+      electionDayPollsCloseTime: '20:00:00',
     };
     apiMock.getSystemSettings
       .expectCallWith({ electionId })
@@ -896,7 +902,7 @@ describe('election day polls close time', () => {
   test('can set and update polls close time', async () => {
     const initialSettings: SystemSettings = {
       ...electionRecord.systemSettings,
-      electionDayPollsCloseTime: '2026-11-03T20:00:00',
+      electionDayPollsCloseTime: '20:00:00',
     };
     apiMock.getSystemSettings
       .expectCallWith({ electionId })
@@ -908,17 +914,20 @@ describe('election day polls close time', () => {
       'Election Day Polls Close Time'
     );
     expect(input).toBeDisabled();
-    expect(input).toHaveValue('2026-11-03T20:00');
+    expect(input).toHaveValue('20:00');
 
     userEvent.click(screen.getByRole('button', { name: 'Edit' }));
-    expect(input).not.toBeDisabled();
+    const inputAfterEdit = screen.getByLabelText<HTMLInputElement>(
+      'Election Day Polls Close Time'
+    );
+    expect(inputAfterEdit).not.toBeDisabled();
 
-    fireEvent.change(input, { target: { value: '2026-11-03T21:30' } });
-    expect(input).toHaveValue('2026-11-03T21:30');
+    fireEvent.change(inputAfterEdit, { target: { value: '21:30' } });
+    expect(inputAfterEdit).toHaveValue('21:30');
 
     const updatedSettings: SystemSettings = {
       ...initialSettings,
-      electionDayPollsCloseTime: '2026-11-03T21:30:00',
+      electionDayPollsCloseTime: '21:30:00',
     };
     apiMock.updateSystemSettings
       .expectCallWith({ electionId, systemSettings: updatedSettings })
@@ -929,13 +938,15 @@ describe('election day polls close time', () => {
 
     userEvent.click(screen.getByRole('button', { name: 'Save' }));
     await screen.findByRole('button', { name: 'Edit' });
-    expect(input).toHaveValue('2026-11-03T21:30');
+    expect(
+      screen.getByLabelText<HTMLInputElement>('Election Day Polls Close Time')
+    ).toHaveValue('21:30');
   });
 
   test('clears to undefined when emptied', async () => {
     const initialSettings: SystemSettings = {
       ...electionRecord.systemSettings,
-      electionDayPollsCloseTime: '2026-11-03T20:00:00',
+      electionDayPollsCloseTime: '20:00:00',
     };
     apiMock.getSystemSettings
       .expectCallWith({ electionId })
@@ -967,7 +978,7 @@ describe('election day polls close time', () => {
   test('clearing close time also unchecks enforcement options', async () => {
     const initialSettings: SystemSettings = {
       ...electionRecord.systemSettings,
-      electionDayPollsCloseTime: '2026-11-03T20:00:00',
+      electionDayPollsCloseTime: '20:00:00',
       disallowClosingPollsBeforeElectionDayPollsCloseTime: true,
       disallowVxAdminTabulationBeforeElectionDayPollsCloseTime: true,
     };
@@ -1025,7 +1036,7 @@ describe('election day polls close time', () => {
   test('shows confirmation modal when polls close time is in the morning', async () => {
     const initialSettings: SystemSettings = {
       ...electionRecord.systemSettings,
-      electionDayPollsCloseTime: '2026-11-03T20:00:00',
+      electionDayPollsCloseTime: '20:00:00',
     };
     apiMock.getSystemSettings
       .expectCallWith({ electionId })
@@ -1035,7 +1046,7 @@ describe('election day polls close time', () => {
 
     userEvent.click(screen.getByRole('button', { name: 'Edit' }));
     const input = screen.getByLabelText('Election Day Polls Close Time');
-    fireEvent.change(input, { target: { value: '2026-11-03T08:00' } });
+    fireEvent.change(input, { target: { value: '08:00' } });
 
     userEvent.click(screen.getByRole('button', { name: 'Save' }));
     await screen.findByRole('heading', {
@@ -1058,7 +1069,7 @@ describe('election day polls close time', () => {
 
     const updatedSettings: SystemSettings = {
       ...initialSettings,
-      electionDayPollsCloseTime: '2026-11-03T08:00:00',
+      electionDayPollsCloseTime: '08:00:00',
     };
     apiMock.updateSystemSettings
       .expectCallWith({ electionId, systemSettings: updatedSettings })
@@ -1071,27 +1082,6 @@ describe('election day polls close time', () => {
       screen.getByRole('button', { name: 'Save', hidden: false })
     );
     await screen.findByRole('button', { name: 'Edit' });
-  });
-
-  test('rejects polls close time in the past', async () => {
-    apiMock.getSystemSettings
-      .expectCallWith({ electionId })
-      .resolves(electionRecord.systemSettings);
-    renderScreen();
-    await screen.findByRole('heading', { name: 'System Settings' });
-
-    userEvent.click(screen.getByRole('button', { name: 'Edit' }));
-    const input = screen.getByLabelText<HTMLInputElement>(
-      'Election Day Polls Close Time'
-    );
-
-    fireEvent.change(input, { target: { value: '2000-01-01T08:00' } });
-    expect(input.validity.valid).toEqual(false);
-    expect(input.validationMessage).toContain('must be in the future');
-
-    // Form submission is blocked — updateSystemSettings should never be called
-    userEvent.click(screen.getByRole('button', { name: 'Save' }));
-    // (apiMock.assertComplete() in afterEach will catch any unexpected calls)
   });
 });
 

--- a/apps/design/frontend/src/system_settings_screen.tsx
+++ b/apps/design/frontend/src/system_settings_screen.tsx
@@ -131,7 +131,6 @@ export function SystemSettingsForm({
 
   const maxCumulativeStreakWidthInputRef = useRef<HTMLInputElement>(null);
   const retryStreakWidthThresholdInputRef = useRef<HTMLInputElement>(null);
-  const electionDayPollsCloseTimeInputRef = useRef<HTMLInputElement>(null);
 
   function validateStreakSettings(settings: SystemSettings) {
     const parseResult = safeParse(SystemSettingsSchema, settings);
@@ -178,16 +177,6 @@ export function SystemSettingsForm({
   }
   const features = getUserFeaturesQuery.data;
 
-  function validatePollsCloseTime(closeTime?: string) {
-    const input = electionDayPollsCloseTimeInputRef.current;
-    if (!input) return;
-    if (closeTime && new Date(closeTime) <= new Date()) {
-      input.setCustomValidity('Polls close time must be in the future.');
-    } else {
-      input.setCustomValidity('');
-    }
-  }
-
   function saveSettings() {
     updateSystemSettingsMutation.mutate(
       { electionId, systemSettings },
@@ -198,7 +187,8 @@ export function SystemSettingsForm({
   function onSubmit() {
     const { electionDayPollsCloseTime } = systemSettings;
     if (electionDayPollsCloseTime) {
-      const hour = new Date(electionDayPollsCloseTime).getHours();
+      const hour =
+        safeParseInt(electionDayPollsCloseTime.split(':')[0]).ok() ?? 0;
       if (hour < 12) {
         setIsConfirmingMorningPollsCloseTime(true);
         return;
@@ -244,7 +234,6 @@ export function SystemSettingsForm({
       onReset={(e) => {
         e.preventDefault();
         setSystemSettings(savedSystemSettings);
-        validatePollsCloseTime(savedSystemSettings.electionDayPollsCloseTime);
         setIsEditing(false);
       }}
     >
@@ -594,17 +583,19 @@ export function SystemSettingsForm({
           <Column style={{ gap: '1.5rem' }}>
             <InputGroup label="Election Day Polls Close Time">
               <input
-                ref={electionDayPollsCloseTimeInputRef}
-                type="datetime-local"
+                // Force remount when edit mode is toggled to clear stale, partial, unsaved input state
+                key={String(isEditing)}
+                type="time"
                 aria-label="Election Day Polls Close Time"
                 value={
-                  systemSettings.electionDayPollsCloseTime?.slice(0, 16) ?? ''
+                  systemSettings.electionDayPollsCloseTime
+                    ? systemSettings.electionDayPollsCloseTime.substring(0, 5)
+                    : ''
                 }
                 onChange={(e) => {
                   const closeTime = e.target.value
                     ? `${e.target.value}:00`
                     : undefined;
-                  validatePollsCloseTime(closeTime);
                   setSystemSettings({
                     ...systemSettings,
                     electionDayPollsCloseTime: closeTime,

--- a/libs/types/src/system_settings.ts
+++ b/libs/types/src/system_settings.ts
@@ -209,11 +209,12 @@ export const SystemSettingsSchema = z
     precinctScanDisableScreenReaderAudio: z.boolean().optional(),
 
     /**
-     * The date and time at which polls close on election day, stored as a
-     * timezone-agnostic ISO 8601 datetime string (e.g. "2026-11-03T20:00:00").
+     * The date and time at which polls close on election day, stored as an
+     * ISO 8601 time string.
+     * The date is assumed to be the election definition's election day.
      * Interpreted in the local time of the machine.
      */
-    electionDayPollsCloseTime: z.string().datetime({ local: true }).optional(),
+    electionDayPollsCloseTime: z.iso.time().optional(),
 
     /**
      * When true, machines with a close-polls action (VxScan, VxMark, VxMarkScan)


### PR DESCRIPTION
## Overview

Per feedback on https://github.com/votingworks/vxsuite/pull/8316, changes VxDesign and the system settings schema to store and expect timestring only (no date) for polls close time.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/bd7b52cc-6e85-45e3-a5ff-150f47db114f



https://github.com/user-attachments/assets/a02164b0-b96b-49a1-9e47-8300b6d19633



## Testing Plan

- manually tested
- updated automated tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
