### PR TITLE
VxDesign: Enable polling place editing for MI state

### DIFF
--- a/apps/design/backend/src/features.ts
+++ b/apps/design/backend/src/features.ts
@@ -208,6 +208,7 @@ export const stateFeatureConfigs: Record<StateCode, StateFeaturesConfig> = {
   },
 
   MI: {
+    EDIT_POLLING_PLACES: true,
     OPEN_PRIMARIES: true,
   },
 


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7870

Adding the `EDIT_POLLING_PLACES` feature to the new `MI` state to enable editing in VxDesign.

The use of polling places in the certified system is still behind a separate feature flag that will be enabled later, once end-to-end verification is done.

## Demo Video or Screenshot

<img width="1921" height="1079" alt="hub-mi-polling-places" src="https://github.com/user-attachments/assets/4edb6776-a7dd-415b-a92e-fe25c40fb1f6" />

## Testing Plan
- Manual

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
