### PR TITLE
Tabulation: Invalidate crossover votes for open primaries

### DIFF
--- a/libs/basics/src/index.ts
+++ b/libs/basics/src/index.ts
@@ -11,6 +11,7 @@ export * from './errors';
 export * from './find';
 export * from './iterators';
 export * from './map_object';
+export * from './memoize';
 export * from './merge_objects';
 export * from './result';
 export * from './range';

--- a/libs/basics/src/memoize.test.ts
+++ b/libs/basics/src/memoize.test.ts
@@ -1,0 +1,69 @@
+import { expect, test, vi } from 'vitest';
+import fc from 'fast-check';
+import { memoizeByObject } from './memoize';
+
+interface Key {
+  id: number;
+}
+
+test('caches result per key object identity', () => {
+  const fn = vi.fn((obj: Key) => obj.id * 2);
+  const memoized = memoizeByObject(fn);
+
+  const a: Key = { id: 1 };
+  const b: Key = { id: 1 }; // same shape, different identity
+
+  expect(memoized(a)).toEqual(2);
+  expect(memoized(a)).toEqual(2);
+  expect(fn).toHaveBeenCalledTimes(1);
+
+  expect(memoized(b)).toEqual(2);
+  expect(fn).toHaveBeenCalledTimes(2);
+});
+
+test('caches undefined return values (does not recompute)', () => {
+  const fn = vi.fn((): undefined => undefined);
+  const memoized = memoizeByObject(fn);
+
+  const key: Key = { id: 0 };
+  expect(memoized(key)).toBeUndefined();
+  expect(memoized(key)).toBeUndefined();
+  expect(fn).toHaveBeenCalledTimes(1);
+});
+
+test('property: memoized output matches the underlying function and calls it once per distinct key', () => {
+  fc.assert(
+    fc.property(
+      // Generate a small pool of distinct key objects, then a sequence of
+      // indexes selecting which key to call with on each step.
+      fc.integer({ min: 1, max: 8 }).chain((numKeys) =>
+        fc.record({
+          numKeys: fc.constant(numKeys),
+          callIndexes: fc.array(fc.integer({ min: 0, max: numKeys - 1 }), {
+            minLength: 1,
+            maxLength: 50,
+          }),
+        })
+      ),
+      ({ numKeys, callIndexes }) => {
+        const keys: Key[] = Array.from({ length: numKeys }, (_, i) => ({
+          id: i,
+        }));
+        function compute(obj: Key): number {
+          return obj.id * 7 + 3;
+        }
+        const fn = vi.fn(compute);
+        const memoized = memoizeByObject(fn);
+
+        for (const i of callIndexes) {
+          const key = keys[i]!;
+          expect(memoized(key)).toEqual(compute(key));
+        }
+
+        // fn was called exactly once per distinct key actually used.
+        const distinctKeysUsed = new Set(callIndexes).size;
+        expect(fn).toHaveBeenCalledTimes(distinctKeysUsed);
+      }
+    )
+  );
+});

--- a/libs/basics/src/memoize.ts
+++ b/libs/basics/src/memoize.ts
@@ -1,0 +1,15 @@
+/**
+ * Memoizes a function that takes a single object argument, using a WeakMap to
+ * prevent memory leaks.
+ */
+export function memoizeByObject<K extends object, V>(
+  fn: (key: K) => V
+): (key: K) => V {
+  const cache = new WeakMap<K, V>();
+  return (key: K): V => {
+    if (!cache.has(key)) {
+      cache.set(key, fn(key));
+    }
+    return cache.get(key) as V;
+  };
+}

--- a/libs/utils/src/tabulation/index.ts
+++ b/libs/utils/src/tabulation/index.ts
@@ -4,6 +4,7 @@ export * from './convert';
 export * from './compressed_tallies';
 export * as CachedElectionLookups from './lookups';
 export * from './mock_tally_report_results';
+export * from './open_primary';
 export * from './tabulation';
 export * from './tally_reports';
 export * from './transformations';

--- a/libs/utils/src/tabulation/open_primary.test.ts
+++ b/libs/utils/src/tabulation/open_primary.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from 'vitest';
+import { CandidateContest, PartyId, YesNoContest } from '@votingworks/types';
+import {
+  readElectionGeneral,
+  readElectionOpenPrimary,
+  readElectionTwoPartyPrimary,
+} from '@votingworks/fixtures';
+import {
+  hasCrossoverVote,
+  partisanContests,
+  votedPartyIds,
+} from './open_primary';
+
+const openPrimary = readElectionOpenPrimary();
+const closedPrimary = readElectionTwoPartyPrimary();
+const generalElection = readElectionGeneral();
+
+const democraticPartyId = openPrimary.parties.find(
+  (p) => p.name === 'Democratic'
+)!.id;
+const republicanPartyId = openPrimary.parties.find(
+  (p) => p.name === 'Republican'
+)!.id;
+
+const democraticContest = openPrimary.contests.find(
+  (c): c is CandidateContest =>
+    c.type === 'candidate' && c.partyId === democraticPartyId
+)!;
+const republicanContest = openPrimary.contests.find(
+  (c): c is CandidateContest =>
+    c.type === 'candidate' && c.partyId === republicanPartyId
+)!;
+const nonpartisanContest = openPrimary.contests.find(
+  (c): c is YesNoContest => c.type === 'yesno'
+)!;
+
+describe('partisanContests', () => {
+  test('returns all partisan contests in an open primary', () => {
+    const result = partisanContests(openPrimary);
+
+    // Invariants:
+    // - Every returned contest is a candidate contest with a partyId.
+    // - No partisan contest in the election is missing from the result.
+    expect(result.every((c) => c.type === 'candidate')).toEqual(true);
+    expect(result.every((c) => c.partyId !== undefined)).toEqual(true);
+    const resultIds = new Set(result.map((c) => c.id));
+    const missingIds = openPrimary.contests
+      .filter((c) => c.type === 'candidate' && c.partyId !== undefined)
+      .map((c) => c.id)
+      .filter((id) => !resultIds.has(id));
+    expect(missingIds).toEqual([]);
+
+    expect(result.map((c) => c.id)).toMatchInlineSnapshot(`
+      [
+        "governor-democratic",
+        "governor-republican",
+        "governor-libertarian",
+        "secretary-of-state-democratic",
+        "secretary-of-state-republican",
+        "secretary-of-state-libertarian",
+        "attorney-general-democratic",
+        "attorney-general-republican",
+        "attorney-general-libertarian",
+        "us-rep-democratic",
+        "us-rep-republican",
+        "us-rep-libertarian",
+        "state-rep-democratic",
+        "state-rep-republican",
+        "state-rep-libertarian",
+        "county-commissioner-democratic",
+        "county-commissioner-republican",
+        "county-commissioner-libertarian",
+        "delegate-convention-democratic",
+        "delegate-convention-republican",
+        "delegate-convention-libertarian",
+        "county-commissioner-democratic-south",
+        "county-commissioner-republican-south",
+        "county-commissioner-libertarian-south",
+        "delegate-convention-democratic-south",
+        "delegate-convention-republican-south",
+        "delegate-convention-libertarian-south",
+      ]
+    `);
+  });
+
+  test('returns empty array for general election', () => {
+    expect(partisanContests(generalElection)).toEqual([]);
+  });
+});
+
+describe('votedPartyIds', () => {
+  test('returns empty array when no partisan contests have selections', () => {
+    expect(votedPartyIds(openPrimary, {})).toEqual([]);
+    expect(
+      votedPartyIds(openPrimary, {
+        [nonpartisanContest.id]: [nonpartisanContest.yesOption.id],
+      })
+    ).toEqual([]);
+    expect(
+      votedPartyIds(openPrimary, {
+        [democraticContest.id]: [],
+        [republicanContest.id]: [],
+      })
+    ).toEqual([]);
+  });
+
+  test('returns single party for single-party votes', () => {
+    expect(
+      votedPartyIds(openPrimary, {
+        [democraticContest.id]: [democraticContest.candidates[0]!.id],
+      })
+    ).toEqual([democraticPartyId]);
+  });
+
+  test('returns all voted parties for multi-party votes', () => {
+    const result = votedPartyIds(openPrimary, {
+      [democraticContest.id]: [democraticContest.candidates[0]!.id],
+      [republicanContest.id]: [republicanContest.candidates[0]!.id],
+    });
+    expect(new Set(result)).toEqual(
+      new Set([democraticPartyId, republicanPartyId] as PartyId[])
+    );
+  });
+
+  test('returns empty array for general election (no partisan contests)', () => {
+    const candidateContest = generalElection.contests.find(
+      (c): c is CandidateContest => c.type === 'candidate'
+    )!;
+    expect(
+      votedPartyIds(generalElection, {
+        [candidateContest.id]: [candidateContest.candidates[0]!.id],
+      })
+    ).toEqual([]);
+  });
+});
+
+describe('hasCrossoverVote', () => {
+  // It's impossible to have crossover votes in a closed primary, since
+  // each ballot style is only associated with one party, but we test it
+  // anyway.
+  test('false for closed primary', () => {
+    expect(
+      hasCrossoverVote(closedPrimary, {
+        'best-animal-mammal': ['horse'],
+        'zoo-council-mammal': ['zebra', 'lion'],
+      })
+    ).toEqual(false);
+  });
+
+  // It's also impossible to have crossover votes in a general election, since there
+  // are no partisan contests, but we test it anyway.
+  test('false for general election', () => {
+    expect(
+      hasCrossoverVote(generalElection, {
+        president: ['barchi-hallaren'],
+        senator: ['weiford'],
+      })
+    ).toEqual(false);
+  });
+
+  test('false for open primary single-party votes', () => {
+    expect(
+      hasCrossoverVote(openPrimary, {
+        [democraticContest.id]: [democraticContest.candidates[0]!.id],
+      })
+    ).toEqual(false);
+  });
+
+  test('false for open primary nonpartisan-only votes', () => {
+    expect(
+      hasCrossoverVote(openPrimary, {
+        [nonpartisanContest.id]: [nonpartisanContest.yesOption.id],
+      })
+    ).toEqual(false);
+  });
+
+  test('true for open primary multi-party votes', () => {
+    expect(
+      hasCrossoverVote(openPrimary, {
+        [democraticContest.id]: [democraticContest.candidates[0]!.id],
+        [republicanContest.id]: [republicanContest.candidates[0]!.id],
+      })
+    ).toEqual(true);
+  });
+});

--- a/libs/utils/src/tabulation/open_primary.ts
+++ b/libs/utils/src/tabulation/open_primary.ts
@@ -1,0 +1,52 @@
+import { memoizeByObject, unique } from '@votingworks/basics';
+import {
+  CandidateContest,
+  Election,
+  PartyId,
+  Tabulation,
+  isOpenPrimary,
+} from '@votingworks/types';
+
+type PartisanContest = CandidateContest & { partyId: PartyId };
+
+/**
+ * Returns all the partisan contests in the election, i.e. candidate contests
+ * with an associated party. Memoized per `Election` for usage in tabulation.
+ */
+export const partisanContests = memoizeByObject(
+  (election: Election): readonly PartisanContest[] =>
+    election.contests.filter(
+      (contest): contest is PartisanContest =>
+        contest.type === 'candidate' && contest.partyId !== undefined
+    )
+);
+
+/**
+ * Returns the party IDs of the partisan contests a voter voted in.
+ */
+export function votedPartyIds(
+  election: Election,
+  votes: Tabulation.Votes
+): PartyId[] {
+  return unique(
+    partisanContests(election)
+      .filter((contest) => (votes[contest.id]?.length ?? 0) > 0)
+      .map((contest) => contest.partyId)
+  );
+}
+
+/**
+ * In open primary elections only, returns true if the voter voted in partisan
+ * contests for more than one party.
+ */
+export function hasCrossoverVote(
+  election: Election,
+  votes: Tabulation.Votes
+): boolean {
+  // Short circuit to avoid doing extra work if it's not an open primary, even
+  // though crossover votes aren't possible in general elections/closed primaries.
+  if (!isOpenPrimary(election)) {
+    return false;
+  }
+  return votedPartyIds(election, votes).length > 1;
+}

--- a/libs/utils/src/tabulation/tabulation.test.ts
+++ b/libs/utils/src/tabulation/tabulation.test.ts
@@ -3,6 +3,7 @@ import {
   electionFamousNames2021Fixtures,
   electionTwoPartyPrimaryFixtures,
   electionWithMsEitherNeitherFixtures,
+  readElectionOpenPrimary,
 } from '@votingworks/fixtures';
 import { assert, assertDefined, find, typedAs } from '@votingworks/basics';
 import {
@@ -48,6 +49,7 @@ import {
   combineAndDecodeCompressedElectionResults,
   getScannedBallotCountForSheet,
 } from './tabulation';
+import { partisanContests } from './open_primary';
 import {
   convertCastVoteRecordMarkMetricsToMarkScores,
   convertCastVoteRecordVotesToTabulationVotes,
@@ -1305,6 +1307,93 @@ describe('tabulateCastVoteRecords', () => {
       'root&precinctId=precinct-1&votingMethod=precinct',
       'root&precinctId=precinct-2&votingMethod=precinct',
     ]);
+  });
+});
+
+describe('open primaries', () => {
+  const openPrimaryElection = readElectionOpenPrimary();
+
+  const baseCvrMetadata = {
+    card: { type: 'bmd' },
+    ballotStyleGroupId: 'ballot-style-1' as BallotStyleGroupId,
+    precinctId: 'precinct-1',
+    votingMethod: BallotType.Precinct,
+    batchId: 'batch-1',
+    scannerId: 'scanner-1',
+  } as const;
+
+  test('single-party ballot tallies partisan + nonpartisan contests normally', async () => {
+    const results = (
+      await tabulateCastVoteRecords({
+        election: openPrimaryElection,
+        cvrs: [
+          {
+            ...baseCvrMetadata,
+            votes: {
+              'governor-democratic': ['alice-jones'],
+              'ballot-measure-1': ['ballot-measure-1-yes'],
+            },
+          },
+        ],
+      })
+    )[GROUP_KEY_ROOT];
+    assert(results);
+
+    expect(results.contestResults['governor-democratic']).toMatchObject({
+      ballots: 1,
+      tallies: expect.objectContaining({
+        'alice-jones': expect.objectContaining({ tally: 1 }),
+      }),
+    });
+    expect(results.contestResults['ballot-measure-1']).toMatchObject({
+      ballots: 1,
+      yesTally: 1,
+      noTally: 0,
+    });
+  });
+
+  test('crossover voting — partisan contests skipped, nonpartisan tallied', async () => {
+    const results = (
+      await tabulateCastVoteRecords({
+        election: openPrimaryElection,
+        cvrs: [
+          {
+            ...baseCvrMetadata,
+            votes: {
+              'governor-democratic': ['alice-jones'],
+              'governor-republican': ['dave-wilson'],
+              'ballot-measure-1': ['ballot-measure-1-yes'],
+            },
+          },
+        ],
+      })
+    )[GROUP_KEY_ROOT];
+    assert(results);
+
+    expect(results.contestResults['governor-democratic']).toMatchObject({
+      ballots: 0,
+      tallies: expect.objectContaining({
+        'alice-jones': expect.objectContaining({ tally: 0 }),
+      }),
+    });
+    expect(results.contestResults['governor-republican']).toMatchObject({
+      ballots: 0,
+      tallies: expect.objectContaining({
+        'dave-wilson': expect.objectContaining({ tally: 0 }),
+      }),
+    });
+    expect(results.contestResults['ballot-measure-1']).toMatchObject({
+      ballots: 1,
+      yesTally: 1,
+      noTally: 0,
+    });
+    expect(getBallotCount(results.cardCounts)).toEqual(1);
+
+    // No partisan contest in the election should be counted on a
+    // crossover ballot.
+    for (const contest of partisanContests(openPrimaryElection)) {
+      expect(results.contestResults[contest.id]?.ballots).toEqual(0);
+    }
   });
 });
 

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -21,6 +21,7 @@ import {
 import { isGroupByEmpty } from './arguments';
 import { getGroupedBallotStyles } from '../ballot_styles';
 import { readV0CompressedTallyAsContestResults } from './compressed_tallies';
+import { hasCrossoverVote, partisanContests } from './open_primary';
 
 export function getEmptyYesNoContestResults(
   contest: YesNoContest
@@ -136,7 +137,8 @@ export function getEmptyManualElectionResults(
  */
 function addCastVoteRecordToElectionResult(
   electionResult: Tabulation.ElectionResults,
-  cvr: Tabulation.CastVoteRecord
+  cvr: Tabulation.CastVoteRecord,
+  election: Election
 ): Tabulation.ElectionResults {
   const { cardCounts } = electionResult;
   if (cvr.card.type === 'bmd') {
@@ -149,7 +151,19 @@ function addCastVoteRecordToElectionResult(
       (cardCounts.hmpb[cvr.card.sheetNumber - 1] ?? 0) + 1;
   }
 
+  // In open primary elections, crossover voting is not allowed (i.e. a voter
+  // may not vote for partisan contests from multiple parties). If that happens,
+  // all of their partisan contest votes are void. Their nonpartisan contest
+  // votes still count.
+  const voidedContestIds = hasCrossoverVote(election, cvr.votes)
+    ? new Set(partisanContests(election).map((contest) => contest.id))
+    : undefined;
+
   for (const [contestId, optionIds] of Object.entries(cvr.votes)) {
+    if (voidedContestIds?.has(contestId)) {
+      continue;
+    }
+
     const contestResult = assertDefined(
       electionResult.contestResults[contestId]
     );
@@ -428,7 +442,7 @@ export async function tabulateCastVoteRecords({
 
     let i = 0;
     for (const cvr of cvrs) {
-      addCastVoteRecordToElectionResult(electionResults, cvr);
+      addCastVoteRecordToElectionResult(electionResults, cvr, election);
 
       i += 1;
       if (i % YIELD_TO_EVENT_LOOP_EVERY_N_CVRS === 0) {
@@ -455,13 +469,13 @@ export async function tabulateCastVoteRecords({
     const existingElectionResult = groupedElectionResults[groupKey];
     if (expectedGroups) {
       assert(existingElectionResult);
-      addCastVoteRecordToElectionResult(existingElectionResult, cvr);
+      addCastVoteRecordToElectionResult(existingElectionResult, cvr, election);
     } else if (existingElectionResult) {
-      addCastVoteRecordToElectionResult(existingElectionResult, cvr);
+      addCastVoteRecordToElectionResult(existingElectionResult, cvr, election);
     } else {
       const electionResult: Tabulation.ElectionResults =
         getEmptyElectionResults(election);
-      addCastVoteRecordToElectionResult(electionResult, cvr);
+      addCastVoteRecordToElectionResult(electionResult, cvr, election);
       groupedElectionResults[groupKey] = electionResult;
     }
 


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Closes: https://github.com/votingworks/vxsuite/issues/7884

In an open primary, a voter who marks selections in partisan contests from more than one party has cast a "crossover" vote. Per the spec, all of their partisan contest votes are voided (no ballot count, no tallies), while their nonpartisan votes still count. The ballot itself still counts toward overall card counts.

This PR adds logic to the core tabulation function to detect crossover votes and void contests.

## Testing Plan

- New unit tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
