### PR TITLE
VxAdmin/VxDesign: Submit Live Results Reports from VxAdmin

### DIFF
--- a/apps/admin/backend/src/app.live_results_reporting.test.ts
+++ b/apps/admin/backend/src/app.live_results_reporting.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { electionTwoPartyPrimaryFixtures } from '@votingworks/fixtures';
+import {
+  BallotStyleGroupId,
+  DEFAULT_SYSTEM_SETTINGS,
+  Election,
+  PollingPlace,
+  safeParseElectionDefinition,
+} from '@votingworks/types';
+import {
+  BooleanEnvironmentVariableName,
+  getFeatureFlagMock,
+} from '@votingworks/utils';
+import {
+  buildTestEnvironment,
+  configureMachine,
+  mockElectionManagerAuth,
+} from '../test/app';
+import { addMockCvrFileToStore } from '../test/mock_cvr_file';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+const featureFlagMock = getFeatureFlagMock();
+vi.mock(import('@votingworks/utils'), async (importActual) => ({
+  ...(await importActual()),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
+
+beforeEach(() => {
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_CVR_BALLOT_HASH_CHECK
+  );
+});
+
+afterEach(() => {
+  featureFlagMock.resetFeatureFlags();
+});
+
+const COUNTY_ABSENTEE: PollingPlace = {
+  id: 'absentee-county',
+  name: 'County Absentee',
+  type: 'absentee',
+  precincts: {
+    'precinct-1': { type: 'whole' },
+    'precinct-2': { type: 'whole' },
+  },
+};
+
+function makeDefinition(pollingPlaces: PollingPlace[]) {
+  const baseDefinition =
+    electionTwoPartyPrimaryFixtures.readElectionDefinition();
+  const election: Election = {
+    ...baseDefinition.election,
+    pollingPlaces,
+  };
+  return safeParseElectionDefinition(JSON.stringify(election)).unsafeUnwrap();
+}
+
+test('getMatchingAbsenteePollingPlaces and getLiveResultsReportingUrl', async () => {
+  const electionDefinition = makeDefinition([COUNTY_ABSENTEE]);
+  const { apiClient, auth, workspace } = buildTestEnvironment();
+  const electionId = await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition,
+    undefined,
+    {
+      ...DEFAULT_SYSTEM_SETTINGS,
+      quickResultsReportingUrl: 'https://results.example.com/submit',
+    }
+  );
+  mockElectionManagerAuth(auth, electionDefinition.election);
+
+  // No CVRs loaded yet.
+  expect((await apiClient.getMatchingAbsenteePollingPlaces()).err()).toEqual(
+    'no-cvrs-loaded'
+  );
+
+  // Load some mock CVRs covering the absentee polling place's precincts.
+  addMockCvrFileToStore({
+    electionId,
+    store: workspace.store,
+    mockCastVoteRecordFile: [
+      {
+        ballotStyleGroupId: '1M' as BallotStyleGroupId,
+        batchId: 'batch-1',
+        scannerId: 'scanner-1',
+        precinctId: 'precinct-1',
+        votingMethod: 'absentee',
+        votes: { fishing: ['ban-fishing'] },
+        card: { type: 'bmd' },
+        multiplier: 2,
+      },
+    ],
+  });
+
+  const matching = (
+    await apiClient.getMatchingAbsenteePollingPlaces()
+  ).unsafeUnwrap();
+  expect(matching.map((p) => p.id)).toEqual([COUNTY_ABSENTEE.id]);
+
+  const urls = await apiClient.getLiveResultsReportingUrl({
+    pollingPlaceId: COUNTY_ABSENTEE.id,
+  });
+  expect(urls.length).toBeGreaterThanOrEqual(1);
+  for (const url of urls) {
+    expect(url).toMatch(
+      /^https:\/\/results\.example\.com\/submit\?p=[^&]+&s=[^&]+&c=[^&]+$/
+    );
+  }
+});

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_SYSTEM_SETTINGS,
   DiagnosticRecord,
   Id,
+  PollingPlace,
   PrinterStatus,
   SystemSettings,
   Tabulation,
@@ -117,6 +118,10 @@ import { adjudicateCvrContest } from './adjudication';
 import { convertFrontendFilter as convertFrontendFilterUtil } from './util/filters';
 import { buildElectionResultsReport } from './util/cdf_results';
 import { tabulateElectionResults } from './tabulation/full_results';
+import {
+  generateAdminLiveResultsReportingUrls,
+  getMatchingAbsenteePollingPlaces,
+} from './live_results_reporting';
 import { NODE_ENV, REAL_USB_DRIVE_GLOB_PATTERN } from './globals';
 import {
   exportWriteInAdjudicationReportPdf,
@@ -1388,6 +1393,34 @@ function buildApi({
         usbDrive: usbDriveAdapter,
         logger,
       });
+    },
+
+    getMatchingAbsenteePollingPlaces(): Result<
+      PollingPlace[],
+      'no-cvrs-loaded'
+    > {
+      const electionId = loadCurrentElectionIdOrThrow(workspace);
+      return getMatchingAbsenteePollingPlaces({ electionId, store });
+    },
+
+    async getLiveResultsReportingUrl(input: {
+      pollingPlaceId: string;
+    }): Promise<string[]> {
+      const electionId = loadCurrentElectionIdOrThrow(workspace);
+      const { machineId } = getMachineConfig();
+      const urls = await generateAdminLiveResultsReportingUrls({
+        electionId,
+        store,
+        pollingPlaceId: input.pollingPlaceId,
+        signingMachineId: machineId,
+        pollsTransitionTimestamp: Date.now(),
+      });
+      await logger.logAsCurrentRole(LogEventId.LiveReportingUrlViewer, {
+        message: `Generated signed live results reporting URL for polling place ${input.pollingPlaceId}.`,
+        disposition: 'success',
+        pollingPlaceId: input.pollingPlaceId,
+      });
+      return urls;
     },
 
     ...createSystemCallApi({

--- a/apps/admin/backend/src/live_results_reporting.test.ts
+++ b/apps/admin/backend/src/live_results_reporting.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { electionTwoPartyPrimaryFixtures } from '@votingworks/fixtures';
+import { makeTemporaryDirectory } from '@votingworks/fixtures';
+import {
+  BallotStyleGroupId,
+  DEFAULT_SYSTEM_SETTINGS,
+  Election,
+  PollingPlace,
+  safeParseElectionDefinition,
+  SystemSettings,
+} from '@votingworks/types';
+import {
+  BooleanEnvironmentVariableName,
+  getFeatureFlagMock,
+} from '@votingworks/utils';
+import { Buffer } from 'node:buffer';
+import { Store } from './store';
+import {
+  generateAdminLiveResultsReportingUrls,
+  getMatchingAbsenteePollingPlaces,
+} from './live_results_reporting';
+import {
+  addMockCvrFileToStore,
+  MockCastVoteRecordFile,
+} from '../test/mock_cvr_file';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+const featureFlagMock = getFeatureFlagMock();
+vi.mock(import('@votingworks/utils'), async (importActual) => ({
+  ...(await importActual()),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
+
+beforeEach(() => {
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_CVR_BALLOT_HASH_CHECK
+  );
+});
+
+afterEach(() => {
+  featureFlagMock.resetFeatureFlags();
+});
+
+const ABSENTEE_PLACE_ALL: PollingPlace = {
+  id: 'absentee-all',
+  name: 'County Absentee',
+  type: 'absentee',
+  precincts: {
+    'precinct-1': { type: 'whole' },
+    'precinct-2': { type: 'whole' },
+  },
+};
+
+const ABSENTEE_PLACE_PRECINCT_1: PollingPlace = {
+  id: 'absentee-precinct-1',
+  name: 'Precinct 1 Absentee',
+  type: 'absentee',
+  precincts: { 'precinct-1': { type: 'whole' } },
+};
+
+const ELECTION_DAY_PLACE: PollingPlace = {
+  id: 'election-day-precinct-1',
+  name: 'Precinct 1 Election Day',
+  type: 'election_day',
+  precincts: { 'precinct-1': { type: 'whole' } },
+};
+
+function makeElectionDefinitionWithPollingPlaces(
+  pollingPlaces: PollingPlace[]
+) {
+  const baseDefinition =
+    electionTwoPartyPrimaryFixtures.readElectionDefinition();
+  const election: Election = {
+    ...baseDefinition.election,
+    pollingPlaces,
+  };
+  return safeParseElectionDefinition(JSON.stringify(election)).unsafeUnwrap();
+}
+
+function setupStore(
+  pollingPlaces: PollingPlace[],
+  systemSettings: SystemSettings = DEFAULT_SYSTEM_SETTINGS,
+  cvrs: MockCastVoteRecordFile = []
+) {
+  const electionDefinition =
+    makeElectionDefinitionWithPollingPlaces(pollingPlaces);
+  const store = Store.memoryStore(makeTemporaryDirectory());
+  const electionId = store.addElection({
+    electionData: electionDefinition.electionData,
+    systemSettingsData: JSON.stringify(systemSettings),
+    electionPackageFileContents: Buffer.of(),
+    electionPackageHash: 'test-election-package-hash',
+  });
+  store.setCurrentElectionId(electionId);
+  if (cvrs.length > 0) {
+    addMockCvrFileToStore({
+      electionId,
+      mockCastVoteRecordFile: cvrs,
+      store,
+    });
+  }
+  return { store, electionId, electionDefinition };
+}
+
+test('returns signed QR URLs when results match polling place', async () => {
+  const cvrs: MockCastVoteRecordFile = [
+    {
+      ballotStyleGroupId: '1M' as BallotStyleGroupId,
+      batchId: 'batch-1',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'absentee',
+      votes: { fishing: ['ban-fishing'] },
+      card: { type: 'bmd' },
+      multiplier: 3,
+    },
+    {
+      ballotStyleGroupId: '2F' as BallotStyleGroupId,
+      batchId: 'batch-2',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-2',
+      votingMethod: 'absentee',
+      votes: { fishing: ['ban-fishing'] },
+      card: { type: 'bmd' },
+      multiplier: 4,
+    },
+  ];
+  const { store, electionId } = setupStore(
+    [ABSENTEE_PLACE_ALL],
+    {
+      ...DEFAULT_SYSTEM_SETTINGS,
+      quickResultsReportingUrl: 'https://results.example.com/submit',
+    },
+    cvrs
+  );
+
+  const urls = await generateAdminLiveResultsReportingUrls({
+    electionId,
+    store,
+    pollingPlaceId: ABSENTEE_PLACE_ALL.id,
+    signingMachineId: 'admin-machine-1',
+    pollsTransitionTimestamp: new Date('2024-11-05T20:00:00Z').getTime(),
+  });
+
+  expect(urls.length).toBeGreaterThanOrEqual(1);
+  for (const url of urls) {
+    expect(url).toMatch(
+      /^https:\/\/results\.example\.com\/submit\?p=[^&]+&s=[^&]+&c=[^&]+$/
+    );
+  }
+});
+
+test('getMatchingAbsenteePollingPlaces returns no-cvrs-loaded when no ballots', () => {
+  const { store, electionId } = setupStore([
+    ABSENTEE_PLACE_ALL,
+    ABSENTEE_PLACE_PRECINCT_1,
+    ELECTION_DAY_PLACE,
+  ]);
+
+  expect(getMatchingAbsenteePollingPlaces({ electionId, store }).err()).toEqual(
+    'no-cvrs-loaded'
+  );
+});
+
+test('getMatchingAbsenteePollingPlaces returns absentee places that cover all CVR precincts', () => {
+  const cvrs: MockCastVoteRecordFile = [
+    {
+      ballotStyleGroupId: '1M' as BallotStyleGroupId,
+      batchId: 'batch-1',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'absentee',
+      votes: { fishing: ['ban-fishing'] },
+      card: { type: 'bmd' },
+      multiplier: 2,
+    },
+  ];
+  const { store, electionId } = setupStore(
+    [ABSENTEE_PLACE_ALL, ABSENTEE_PLACE_PRECINCT_1, ELECTION_DAY_PLACE],
+    DEFAULT_SYSTEM_SETTINGS,
+    cvrs
+  );
+
+  const matches = getMatchingAbsenteePollingPlaces({
+    electionId,
+    store,
+  }).unsafeUnwrap();
+  expect(matches.map((p) => p.id).sort()).toEqual([
+    ABSENTEE_PLACE_ALL.id,
+    ABSENTEE_PLACE_PRECINCT_1.id,
+  ]);
+});
+
+test('getMatchingAbsenteePollingPlaces returns an empty list when no absentee place covers the CVR precincts', () => {
+  const cvrs: MockCastVoteRecordFile = [
+    {
+      ballotStyleGroupId: '2F' as BallotStyleGroupId,
+      batchId: 'batch-1',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-2',
+      votingMethod: 'absentee',
+      votes: { fishing: ['ban-fishing'] },
+      card: { type: 'bmd' },
+      multiplier: 2,
+    },
+  ];
+  const { store, electionId } = setupStore(
+    [ABSENTEE_PLACE_PRECINCT_1, ELECTION_DAY_PLACE],
+    DEFAULT_SYSTEM_SETTINGS,
+    cvrs
+  );
+
+  const matches = getMatchingAbsenteePollingPlaces({
+    electionId,
+    store,
+  }).unsafeUnwrap();
+  expect(matches).toEqual([]);
+});
+
+test('getMatchingAbsenteePollingPlaces excludes absentee places missing CVR precincts', () => {
+  const cvrs: MockCastVoteRecordFile = [
+    {
+      ballotStyleGroupId: '1M' as BallotStyleGroupId,
+      batchId: 'batch-1',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-1',
+      votingMethod: 'absentee',
+      votes: { fishing: ['ban-fishing'] },
+      card: { type: 'bmd' },
+      multiplier: 2,
+    },
+    {
+      ballotStyleGroupId: '2F' as BallotStyleGroupId,
+      batchId: 'batch-2',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-2',
+      votingMethod: 'absentee',
+      votes: { fishing: ['ban-fishing'] },
+      card: { type: 'bmd' },
+      multiplier: 3,
+    },
+  ];
+  const { store, electionId } = setupStore(
+    [ABSENTEE_PLACE_ALL, ABSENTEE_PLACE_PRECINCT_1, ELECTION_DAY_PLACE],
+    DEFAULT_SYSTEM_SETTINGS,
+    cvrs
+  );
+
+  const matches = getMatchingAbsenteePollingPlaces({
+    electionId,
+    store,
+  }).unsafeUnwrap();
+  expect(matches.map((p) => p.id)).toEqual([ABSENTEE_PLACE_ALL.id]);
+});

--- a/apps/admin/backend/src/live_results_reporting.ts
+++ b/apps/admin/backend/src/live_results_reporting.ts
@@ -1,0 +1,135 @@
+import { generateSignedQuickResultsReportingUrl } from '@votingworks/auth';
+import { assert, assertDefined, err, ok, Result } from '@votingworks/basics';
+import {
+  Id,
+  PollingPlace,
+  pollingPlaceFromElection,
+  pollingPlacePrecinctIds,
+  PrecinctId,
+  Tabulation,
+} from '@votingworks/types';
+import {
+  getBallotCount,
+  groupMapToGroupList,
+  mergeWriteInTallies,
+} from '@votingworks/utils';
+import { Store } from './store';
+import { tabulateElectionResults } from './tabulation/full_results';
+import { tabulateFullCardCounts } from './tabulation/card_counts';
+
+/**
+ * Returns the absentee polling places whose precinct coverage is a superset
+ * of the precincts that have at least one loaded CVR (or manual tally).
+ * Returns `err('no-cvrs-loaded')` if no precinct has any ballots.
+ */
+export function getMatchingAbsenteePollingPlaces({
+  electionId,
+  store,
+}: {
+  electionId: Id;
+  store: Store;
+}): Result<PollingPlace[], 'no-cvrs-loaded'> {
+  const { electionDefinition } = assertDefined(store.getElection(electionId));
+  const { election } = electionDefinition;
+
+  const cardCountsByPrecinct = groupMapToGroupList(
+    tabulateFullCardCounts({
+      electionId,
+      store,
+      groupBy: { groupByPrecinct: true },
+    })
+  );
+
+  const precinctsWithBallots = new Set<PrecinctId>();
+  for (const group of cardCountsByPrecinct) {
+    assert(group.precinctId !== undefined);
+    if (getBallotCount(group) > 0) {
+      precinctsWithBallots.add(group.precinctId);
+    }
+  }
+
+  if (precinctsWithBallots.size === 0) {
+    return err('no-cvrs-loaded');
+  }
+
+  const absenteePollingPlaces = (
+    election.pollingPlaces ?? /* istanbul ignore next - @preserve */ []
+  ).filter((place) => place.type === 'absentee');
+  const matches = absenteePollingPlaces.filter((place) => {
+    const placePrecinctIds = pollingPlacePrecinctIds(place);
+    for (const precinctId of precinctsWithBallots) {
+      if (!placePrecinctIds.has(precinctId)) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  return ok(matches);
+}
+
+/**
+ * Tabulates per-precinct results for the given absentee polling place and
+ * returns signed live results reporting URLs for QR code display. Callers
+ * are expected to pass a polling place returned from
+ * {@link getMatchingAbsenteePollingPlaces}; the screen that triggers this
+ * function is gated on `systemSettings.quickResultsReportingUrl` being set.
+ */
+export async function generateAdminLiveResultsReportingUrls({
+  electionId,
+  store,
+  pollingPlaceId,
+  signingMachineId,
+  pollsTransitionTimestamp,
+}: {
+  electionId: Id;
+  store: Store;
+  pollingPlaceId: string;
+  signingMachineId: string;
+  pollsTransitionTimestamp: number;
+}): Promise<string[]> {
+  const { electionDefinition } = assertDefined(store.getElection(electionId));
+  const { election } = electionDefinition;
+  const systemSettings = store.getSystemSettings(electionId);
+  assert(
+    systemSettings.quickResultsReportingUrl !== undefined,
+    'Live results reporting URL is not configured'
+  );
+
+  const pollingPlace = pollingPlaceFromElection(election, pollingPlaceId);
+  assert(pollingPlace.type === 'absentee');
+
+  const groupedResults = groupMapToGroupList(
+    await tabulateElectionResults({
+      electionId,
+      store,
+      groupBy: { groupByPrecinct: true },
+      includeWriteInAdjudicationResults: true,
+      includeManualResults: true,
+    })
+  );
+
+  const placePrecinctIds = pollingPlacePrecinctIds(pollingPlace);
+  const resultsByPrecinct: Record<PrecinctId, Tabulation.ElectionResults> = {};
+  for (const result of groupedResults) {
+    assert(result.precinctId !== undefined);
+    if (getBallotCount(result.cardCounts) === 0) continue;
+    assert(
+      placePrecinctIds.has(result.precinctId),
+      `Polling place ${pollingPlaceId} does not cover precinct ${result.precinctId}`
+    );
+    resultsByPrecinct[result.precinctId] = mergeWriteInTallies(result);
+  }
+
+  return generateSignedQuickResultsReportingUrl({
+    electionDefinition,
+    quickResultsReportingUrl: systemSettings.quickResultsReportingUrl,
+    signingMachineId,
+    isLiveMode: store.getCurrentCvrFileModeForElection(electionId) !== 'test',
+    pollingPlaceId,
+    resultsByPrecinct,
+    pollsTransitionType: 'close_polls',
+    votingType: 'absentee',
+    pollsTransitionTimestamp,
+  });
+}

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { deepEqual } from '@votingworks/basics';
+import { deepEqual, fail } from '@votingworks/basics';
 import type { Api } from '@votingworks/admin-backend';
 import {
   AUTH_STATUS_POLLING_INTERVAL_MS,
@@ -495,6 +495,42 @@ export const getSystemSettings = {
   },
 } as const;
 
+type GetLiveResultsReportingUrlInput = QueryInput<'getLiveResultsReportingUrl'>;
+export const getLiveResultsReportingUrl = {
+  queryKeyPrefix: 'getLiveResultsReportingUrl',
+  queryKey(input?: GetLiveResultsReportingUrlInput): QueryKey {
+    return input ? [this.queryKeyPrefix, input] : [this.queryKeyPrefix];
+  },
+  useQuery(input?: GetLiveResultsReportingUrlInput) {
+    const apiClient = useApiClient();
+    return useQuery(
+      this.queryKey(input),
+      input
+        ? () => apiClient.getLiveResultsReportingUrl(input)
+        : /* istanbul ignore next - @preserve */
+          () => fail('input is required'),
+      {
+        enabled: !!input,
+        // Handle signing failures (e.g. results too large for QR codes)
+        // inline on the screen instead of escalating to the error boundary.
+        useErrorBoundary: false,
+      }
+    );
+  },
+} as const;
+
+export const getMatchingAbsenteePollingPlaces = {
+  queryKey(): QueryKey {
+    return ['getMatchingAbsenteePollingPlaces'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () =>
+      apiClient.getMatchingAbsenteePollingPlaces()
+    );
+  },
+} as const;
+
 type GetManualResultsInput = QueryInput<'getManualResults'>;
 export const getManualResults = {
   queryKey(input?: GetManualResultsInput): QueryKey {
@@ -673,6 +709,11 @@ function invalidateCastVoteRecordQueries(queryClient: QueryClient) {
     // total ballot count may be affected
     queryClient.invalidateQueries(getTotalBallotCount.queryKey()),
 
+    // matching absentee polling places and any signed live-results URLs
+    // depend on which precincts have CVRs
+    queryClient.resetQueries(getMatchingAbsenteePollingPlaces.queryKey()),
+    queryClient.resetQueries(getLiveResultsReportingUrl.queryKey()),
+
     // ballot adjudication queues
     queryClient.invalidateQueries(getBallotAdjudicationQueue.queryKey()),
     queryClient.invalidateQueries(
@@ -699,6 +740,11 @@ function invalidateManualResultsQueries(queryClient: QueryClient) {
 
     // total ballot count may be affected
     queryClient.invalidateQueries(getTotalBallotCount.queryKey()),
+
+    // matching absentee polling places and any signed live-results URLs
+    // depend on which precincts have ballots
+    queryClient.resetQueries(getMatchingAbsenteePollingPlaces.queryKey()),
+    queryClient.resetQueries(getLiveResultsReportingUrl.queryKey()),
   ]);
 }
 

--- a/apps/admin/frontend/src/components/app_routes.tsx
+++ b/apps/admin/frontend/src/components/app_routes.tsx
@@ -25,6 +25,7 @@ import { UnconfiguredScreen } from '../screens/unconfigured_screen';
 import { TallyScreen } from '../screens/tally/tally_screen';
 import { TallyWriteInReportScreen } from '../screens/reporting/write_in_adjudication_report_screen';
 import { VoterTurnoutReportScreen } from '../screens/reporting/voter_turnout_report_screen';
+import { SendTallyReportsScreen } from '../screens/reporting/send_tally_reports_screen';
 import { ManualTalliesFormScreen } from '../screens/tally/manual_tallies_form_screen';
 import { SmartCardsScreen } from '../screens/smart_cards_screen';
 import { MachineLockedScreen } from '../screens/machine_locked_screen';
@@ -191,6 +192,9 @@ export function AppRoutes(): JSX.Element | null {
       </Route>
       <Route exact path={routerPaths.voterTurnoutReport}>
         <VoterTurnoutReportScreen />
+      </Route>
+      <Route exact path={routerPaths.sendTallyReports}>
+        <SendTallyReportsScreen />
       </Route>
       <Route exact path={routerPaths.settings}>
         <SettingsScreen />

--- a/apps/admin/frontend/src/router_paths.ts
+++ b/apps/admin/frontend/src/router_paths.ts
@@ -34,6 +34,7 @@ export const routerPaths = {
   ballotCountReportVotingMethod: '/reports/ballot-count/voting-method',
   tallyWriteInReport: '/reports/tally-reports/writein',
   voterTurnoutReport: '/reports/voter-turnout',
+  sendTallyReports: '/reports/send-tally',
   adjudication: '/adjudication',
   adjudicationCandidates: '/adjudication/candidates',
   ballotAdjudication: '/adjudication/ballots',

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.test.tsx
@@ -4,7 +4,10 @@ import {
   readElectionTwoPartyPrimaryDefinition,
 } from '@votingworks/fixtures';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
-import { ElectionDefinition } from '@votingworks/types';
+import {
+  DEFAULT_SYSTEM_SETTINGS,
+  ElectionDefinition,
+} from '@votingworks/types';
 import { isVoterTurnoutReportEnabled, ReportsScreen } from './reports_screen';
 import { renderInAppContext } from '../../../test/render_in_app_context';
 import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client';
@@ -100,6 +103,7 @@ describe('ballot count summary text', () => {
     apiMock.expectGetManualResultsMetadata([]);
     apiMock.expectGetTotalBallotCount(0);
     apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings();
 
     renderInAppContext(<ReportsScreen />, {
       electionDefinition,
@@ -114,6 +118,7 @@ describe('ballot count summary text', () => {
     apiMock.expectGetManualResultsMetadata([]);
     apiMock.expectGetTotalBallotCount(3000);
     apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings();
 
     renderInAppContext(<ReportsScreen />, {
       electionDefinition,
@@ -128,6 +133,7 @@ describe('ballot count summary text', () => {
     apiMock.expectGetManualResultsMetadata([]);
     apiMock.expectGetTotalBallotCount(3000);
     apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings();
 
     renderInAppContext(<ReportsScreen />, {
       electionDefinition,
@@ -147,6 +153,7 @@ describe('voter turnout report link', () => {
       'precinct-1': 100,
       'precinct-2': 200,
     });
+    apiMock.expectGetSystemSettings();
 
     renderInAppContext(<ReportsScreen />, {
       electionDefinition,
@@ -164,6 +171,7 @@ describe('voter turnout report link', () => {
       'precinct-1': 100,
       'precinct-2': 200,
     });
+    apiMock.expectGetSystemSettings();
 
     renderInAppContext(<ReportsScreen />, {
       electionDefinition,
@@ -179,6 +187,7 @@ describe('voter turnout report link', () => {
     apiMock.expectGetManualResultsMetadata([]);
     apiMock.expectGetTotalBallotCount(3000);
     apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings();
 
     renderInAppContext(<ReportsScreen />, {
       electionDefinition,
@@ -200,6 +209,7 @@ describe('showing WIA report link', () => {
     apiMock.expectGetManualResultsMetadata([]);
     apiMock.expectGetTotalBallotCount(3000);
     apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings();
 
     renderInAppContext(<ReportsScreen />, {
       electionDefinition,
@@ -214,6 +224,7 @@ describe('showing WIA report link', () => {
     apiMock.expectGetManualResultsMetadata([]);
     apiMock.expectGetTotalBallotCount(3000);
     apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings();
 
     const electionDefinitionWithoutWriteIns: ElectionDefinition = {
       ...electionDefinition,
@@ -239,5 +250,41 @@ describe('showing WIA report link', () => {
 
     await screen.findButton('Full Election Tally Report');
     expect(screen.queryByText(BUTTON_TEXT)).not.toBeInTheDocument();
+  });
+});
+
+describe('Send Tally Reports link', () => {
+  test('shown when quickResultsReportingUrl is configured', async () => {
+    apiMock.expectGetCastVoteRecordFileMode('test');
+    apiMock.expectGetManualResultsMetadata([]);
+    apiMock.expectGetTotalBallotCount(3000);
+    apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings({
+      ...DEFAULT_SYSTEM_SETTINGS,
+      quickResultsReportingUrl: 'https://results.example.com',
+    });
+
+    renderInAppContext(<ReportsScreen />, {
+      electionDefinition,
+      apiMock,
+    });
+
+    await screen.findButton('Send Tally Reports');
+  });
+
+  test('not shown when quickResultsReportingUrl is not configured', async () => {
+    apiMock.expectGetCastVoteRecordFileMode('test');
+    apiMock.expectGetManualResultsMetadata([]);
+    apiMock.expectGetTotalBallotCount(3000);
+    apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings();
+
+    renderInAppContext(<ReportsScreen />, {
+      electionDefinition,
+      apiMock,
+    });
+
+    await screen.findButton('Full Election Tally Report');
+    expect(screen.queryByText('Send Tally Reports')).not.toBeInTheDocument();
   });
 });

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
@@ -18,6 +18,7 @@ import {
   getTotalBallotCount,
   getCastVoteRecordFileMode,
   getRegisteredVoterCounts,
+  getSystemSettings,
 } from '../../api';
 import { MarkResultsOfficialButton } from '../../components/mark_official_button';
 import { OfficialResultsCard } from '../../components/official_results_card';
@@ -53,7 +54,11 @@ export function ReportsScreen(): JSX.Element {
   const totalBallotCountQuery = getTotalBallotCount.useQuery();
   const castVoteRecordFileModeQuery = getCastVoteRecordFileMode.useQuery();
   const registeredVoterCountsQuery = getRegisteredVoterCounts.useQuery();
+  const systemSettingsQuery = getSystemSettings.useQuery();
   const statusPrefix = isOfficialResults ? 'Official' : 'Unofficial';
+
+  const isLiveResultsReportingEnabled =
+    !!systemSettingsQuery.data?.quickResultsReportingUrl;
 
   const fileMode = castVoteRecordFileModeQuery.data;
 
@@ -132,7 +137,9 @@ export function ReportsScreen(): JSX.Element {
           </LinkButton>
         </P>
       </Section>
-      {(electionHasWriteInContest || voterTurnoutReportEnabled) && (
+      {(electionHasWriteInContest ||
+        voterTurnoutReportEnabled ||
+        isLiveResultsReportingEnabled) && (
         <Section>
           <H2>Other Reports</H2>
           {electionHasWriteInContest && (
@@ -146,6 +153,13 @@ export function ReportsScreen(): JSX.Element {
             <P>
               <LinkButton to={routerPaths.voterTurnoutReport}>
                 {statusPrefix} Voter Turnout Report
+              </LinkButton>
+            </P>
+          )}
+          {isLiveResultsReportingEnabled && (
+            <P>
+              <LinkButton to={routerPaths.sendTallyReports}>
+                Send Tally Reports
               </LinkButton>
             </P>
           )}

--- a/apps/admin/frontend/src/screens/reporting/send_tally_reports_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/send_tally_reports_screen.test.tsx
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, expect, test } from 'vitest';
+import { readElectionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
+import userEvent from '@testing-library/user-event';
+import { err, ok } from '@votingworks/basics';
+import { PollingPlace } from '@votingworks/types';
+import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client';
+import { renderInAppContext } from '../../../test/render_in_app_context';
+import { screen, within } from '../../../test/react_testing_library';
+import { SendTallyReportsScreen, TITLE } from './send_tally_reports_screen';
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  apiMock = createApiMock();
+});
+
+afterEach(() => {
+  apiMock.assertComplete();
+});
+
+const electionDefinition = readElectionTwoPartyPrimaryDefinition();
+
+const COUNTY_ABSENTEE: PollingPlace = {
+  id: 'absentee-county',
+  name: 'County Absentee',
+  type: 'absentee',
+  precincts: {
+    'precinct-1': { type: 'whole' },
+    'precinct-2': { type: 'whole' },
+  },
+};
+
+const REGIONAL_ABSENTEE: PollingPlace = {
+  id: 'absentee-regional',
+  name: 'Regional Absentee',
+  type: 'absentee',
+  precincts: {
+    'precinct-1': { type: 'whole' },
+    'precinct-2': { type: 'whole' },
+  },
+};
+
+test('renders title and parent route link', async () => {
+  apiMock.expectGetMatchingAbsenteePollingPlaces(err('no-cvrs-loaded'));
+
+  renderInAppContext(<SendTallyReportsScreen />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  screen.getByRole('heading', { name: TITLE });
+  expect(screen.getByRole('link', { name: 'Reports' })).toHaveAttribute(
+    'href',
+    '/reports'
+  );
+  await screen.findByText('Load CVRs to send results.');
+});
+
+test('shows info callout when no CVRs are loaded', async () => {
+  apiMock.expectGetMatchingAbsenteePollingPlaces(err('no-cvrs-loaded'));
+
+  renderInAppContext(<SendTallyReportsScreen />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('Load CVRs to send results.');
+});
+
+test('shows warning when no absentee polling place matches the loaded CVRs', async () => {
+  apiMock.expectGetMatchingAbsenteePollingPlaces(ok([]));
+
+  renderInAppContext(<SendTallyReportsScreen />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText(
+    'No absentee polling place covers the precincts in the loaded CVRs.'
+  );
+});
+
+test('auto-generates QR code when exactly one polling place matches', async () => {
+  apiMock.expectGetMatchingAbsenteePollingPlaces(ok([COUNTY_ABSENTEE]));
+  apiMock.expectGetLiveResultsReportingUrls(COUNTY_ABSENTEE.id, [
+    'https://example.com/results?p=AAA',
+  ]);
+
+  renderInAppContext(<SendTallyReportsScreen />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  const qrContainer = await screen.findByTestId('live-results-code');
+  expect(qrContainer.querySelector('[data-value]')).toHaveAttribute(
+    'data-value',
+    'https://example.com/results?p=AAA'
+  );
+  expect(
+    screen.queryByLabelText('Select absentee polling place')
+  ).not.toBeInTheDocument();
+});
+
+test('shows danger callout when the QR code cannot be generated', async () => {
+  apiMock.expectGetMatchingAbsenteePollingPlaces(ok([COUNTY_ABSENTEE]));
+  apiMock.expectGetLiveResultsReportingUrlsError(
+    COUNTY_ABSENTEE.id,
+    new Error('Unable to fit signed URL within QR size limits')
+  );
+
+  renderInAppContext(<SendTallyReportsScreen />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText(/Could not generate a QR code for County Absentee/);
+  expect(screen.queryByTestId('live-results-code')).not.toBeInTheDocument();
+});
+
+test('shows dropdown when multiple polling places match and locks after selection', async () => {
+  apiMock.expectGetMatchingAbsenteePollingPlaces(
+    ok([COUNTY_ABSENTEE, REGIONAL_ABSENTEE])
+  );
+  apiMock.expectGetLiveResultsReportingUrls(COUNTY_ABSENTEE.id, [
+    'https://example.com/results?p=AAA',
+    'https://example.com/results?p=BBB',
+  ]);
+
+  renderInAppContext(<SendTallyReportsScreen />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  const select = await screen.findByLabelText('Select absentee polling place');
+  userEvent.click(select);
+  userEvent.click(await screen.findByText('County Absentee'));
+
+  const qrContainer = await screen.findByTestId('live-results-code');
+  expect(within(qrContainer).getByText('1 / 2')).toBeInTheDocument();
+
+  // The dropdown is now locked.
+  expect(screen.getByLabelText('Select absentee polling place')).toBeDisabled();
+
+  userEvent.click(screen.getButton('Next'));
+  await within(qrContainer).findByText('2 / 2');
+  expect(qrContainer.querySelector('[data-value]')).toHaveAttribute(
+    'data-value',
+    'https://example.com/results?p=BBB'
+  );
+
+  userEvent.click(screen.getButton('Previous'));
+  await within(qrContainer).findByText('1 / 2');
+  expect(qrContainer.querySelector('[data-value]')).toHaveAttribute(
+    'data-value',
+    'https://example.com/results?p=AAA'
+  );
+});

--- a/apps/admin/frontend/src/screens/reporting/send_tally_reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/send_tally_reports_screen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import {
   Button,
   Callout,
@@ -10,6 +10,7 @@ import {
 } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 import styled from 'styled-components';
+import { PollingPlace } from '@votingworks/types';
 import { NavigationScreen } from '../../components/navigation_screen';
 import {
   reportParentRoutes,
@@ -45,66 +46,155 @@ const QrSection = styled.div`
   gap: 0.5rem;
 `;
 
+function ScreenWrapper({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes} noPadding>
+      <ReportScreenContainer>{children}</ReportScreenContainer>
+    </NavigationScreen>
+  );
+}
+
+function LiveResultsQrDisplay({
+  pollingPlace,
+}: {
+  pollingPlace: PollingPlace;
+}): JSX.Element {
+  const urlsQuery = getLiveResultsReportingUrl.useQuery({
+    pollingPlaceId: pollingPlace.id,
+  });
+  const [currentQrIndex, setCurrentQrIndex] = useState(0);
+
+  if (urlsQuery.isLoading) {
+    return <P>Generating QR code...</P>;
+  }
+
+  if (urlsQuery.isError || !urlsQuery.data || urlsQuery.data.length === 0) {
+    return (
+      <Callout icon="Danger" color="danger">
+        Could not generate a QR code for {pollingPlace.name}. The tally results
+        may be too large to encode.
+      </Callout>
+    );
+  }
+
+  const urls = urlsQuery.data;
+  return (
+    <div data-testid="live-results-code">
+      <P>
+        {urls.length === 1
+          ? `Scan the QR code to send the tally report for ${pollingPlace.name}.`
+          : `Scan all ${urls.length} QR codes to send the tally report for ${pollingPlace.name}.`}
+      </P>
+      <div data-value={urls[currentQrIndex]} style={{ width: '600px' }}>
+        <QrCode value={urls[currentQrIndex]} size={600} />
+      </div>
+      {urls.length > 1 && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+            marginTop: '1rem',
+          }}
+        >
+          <Button
+            onPress={() => setCurrentQrIndex((i) => Math.max(i - 1, 0))}
+            disabled={currentQrIndex === 0}
+          >
+            Previous
+          </Button>
+          <H6 style={{ margin: 0 }}>
+            {currentQrIndex + 1} / {urls.length}
+          </H6>
+          <Button
+            variant="primary"
+            onPress={() =>
+              setCurrentQrIndex((i) => Math.min(i + 1, urls.length - 1))
+            }
+            disabled={currentQrIndex >= urls.length - 1}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PollingPlaceSelector({
+  pollingPlaces,
+}: {
+  pollingPlaces: PollingPlace[];
+}): JSX.Element {
+  // Default to the only place when there's just one match.
+  const [pollingPlaceId, setPollingPlaceId] = useState<string | undefined>(
+    pollingPlaces.length === 1 ? pollingPlaces[0].id : undefined
+  );
+
+  const showPicker = pollingPlaces.length > 1;
+  const selectedPollingPlace = pollingPlaces.find(
+    (p) => p.id === pollingPlaceId
+  );
+
+  return (
+    <React.Fragment>
+      {showPicker && (
+        <SelectPollingPlaceContainer>
+          <SearchSelect
+            isMulti={false}
+            isSearchable
+            disabled={!!pollingPlaceId}
+            value={pollingPlaceId}
+            options={pollingPlaces.map((p) => ({
+              value: p.id,
+              label: p.name,
+            }))}
+            onChange={(value) => setPollingPlaceId(value)}
+            aria-label="Select absentee polling place"
+            style={{ width: '30rem' }}
+            placeholder="Select an absentee polling place."
+          />
+        </SelectPollingPlaceContainer>
+      )}
+      <QrSection>
+        {selectedPollingPlace && (
+          <LiveResultsQrDisplay
+            key={selectedPollingPlace.id}
+            pollingPlace={selectedPollingPlace}
+          />
+        )}
+      </QrSection>
+    </React.Fragment>
+  );
+}
+
 export function SendTallyReportsScreen(): JSX.Element {
   const matchesQuery = getMatchingAbsenteePollingPlaces.useQuery();
 
-  const [selectedPollingPlaceId, setSelectedPollingPlaceId] =
-    useState<string>();
-  const [currentQrIndex, setCurrentQrIndex] = useState(0);
-
-  // Pick the effective polling place each render: honor the user's pick
-  // only if it's still present in the latest matches (otherwise CVR
-  // changes could leave a stale selection driving the URL signing call),
-  // and fall back to auto-selecting when there is exactly one match.
-  const matches = matchesQuery.data?.ok();
-  const stillValidSelectedId = matches?.find(
-    (p) => p.id === selectedPollingPlaceId
-  )?.id;
-  const pollingPlaceId =
-    stillValidSelectedId ??
-    (matches && matches.length === 1 ? matches[0].id : undefined);
-
-  // Reset QR pagination whenever the selection changes.
-  useEffect(() => {
-    setCurrentQrIndex(0);
-  }, [pollingPlaceId]);
-
-  const urlsQuery = getLiveResultsReportingUrl.useQuery(
-    pollingPlaceId ? { pollingPlaceId } : undefined
-  );
-
   if (!matchesQuery.isSuccess) {
     return (
-      <NavigationScreen
-        title={TITLE}
-        parentRoutes={reportParentRoutes}
-        noPadding
-      >
-        <ReportScreenContainer>
-          <FullPageMessage>
-            <Loading />
-          </FullPageMessage>
-        </ReportScreenContainer>
-      </NavigationScreen>
+      <ScreenWrapper>
+        <FullPageMessage>
+          <Loading />
+        </FullPageMessage>
+      </ScreenWrapper>
     );
   }
 
   if (matchesQuery.data.isErr()) {
     assert(matchesQuery.data.err() === 'no-cvrs-loaded');
     return (
-      <NavigationScreen
-        title={TITLE}
-        parentRoutes={reportParentRoutes}
-        noPadding
-      >
-        <ReportScreenContainer>
-          <FullPageMessage>
-            <Callout icon="Info" color="neutral">
-              Load CVRs to send results.
-            </Callout>
-          </FullPageMessage>
-        </ReportScreenContainer>
-      </NavigationScreen>
+      <ScreenWrapper>
+        <FullPageMessage>
+          <Callout icon="Info" color="neutral">
+            Load CVRs to send results.
+          </Callout>
+        </FullPageMessage>
+      </ScreenWrapper>
     );
   }
 
@@ -112,102 +202,19 @@ export function SendTallyReportsScreen(): JSX.Element {
 
   if (pollingPlaces.length === 0) {
     return (
-      <NavigationScreen
-        title={TITLE}
-        parentRoutes={reportParentRoutes}
-        noPadding
-      >
-        <ReportScreenContainer>
-          <FullPageMessage>
-            <Callout icon="Warning" color="warning">
-              No absentee polling place covers the precincts in the loaded CVRs.
-            </Callout>
-          </FullPageMessage>
-        </ReportScreenContainer>
-      </NavigationScreen>
+      <ScreenWrapper>
+        <FullPageMessage>
+          <Callout icon="Warning" color="warning">
+            No absentee polling place covers the precincts in the loaded CVRs.
+          </Callout>
+        </FullPageMessage>
+      </ScreenWrapper>
     );
   }
 
-  const showPicker = pollingPlaces.length > 1;
-  const selectedPollingPlace = pollingPlaces.find(
-    (p) => p.id === pollingPlaceId
-  );
-  const urls = urlsQuery.data;
-
   return (
-    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes} noPadding>
-      <ReportScreenContainer>
-        {showPicker && (
-          <SelectPollingPlaceContainer>
-            <SearchSelect
-              isMulti={false}
-              isSearchable
-              disabled={!!pollingPlaceId}
-              value={pollingPlaceId}
-              options={pollingPlaces.map((p) => ({
-                value: p.id,
-                label: p.name,
-              }))}
-              onChange={(value) => setSelectedPollingPlaceId(value)}
-              aria-label="Select absentee polling place"
-              style={{ width: '30rem' }}
-              placeholder="Select an absentee polling place."
-            />
-          </SelectPollingPlaceContainer>
-        )}
-        <QrSection>
-          {urlsQuery.isLoading && pollingPlaceId && (
-            <P>Generating QR code...</P>
-          )}
-          {urlsQuery.isError && selectedPollingPlace && (
-            <Callout icon="Danger" color="danger">
-              Could not generate a QR code for {selectedPollingPlace.name}. The
-              tally results may be too large to encode.
-            </Callout>
-          )}
-          {urls && urls.length > 0 && selectedPollingPlace && (
-            <div data-testid="live-results-code">
-              <P>
-                {urls.length === 1
-                  ? `Scan the QR code to send the tally report for ${selectedPollingPlace.name}.`
-                  : `Scan all ${urls.length} QR codes to send the tally report for ${selectedPollingPlace.name}.`}
-              </P>
-              <div data-value={urls[currentQrIndex]} style={{ width: '600px' }}>
-                <QrCode value={urls[currentQrIndex]} size={600} />
-              </div>
-              {urls.length > 1 && (
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '0.5rem',
-                    marginTop: '1rem',
-                  }}
-                >
-                  <Button
-                    onPress={() => setCurrentQrIndex((i) => Math.max(i - 1, 0))}
-                    disabled={currentQrIndex === 0}
-                  >
-                    Previous
-                  </Button>
-                  <H6 style={{ margin: 0 }}>
-                    {currentQrIndex + 1} / {urls.length}
-                  </H6>
-                  <Button
-                    variant="primary"
-                    onPress={() =>
-                      setCurrentQrIndex((i) => Math.min(i + 1, urls.length - 1))
-                    }
-                    disabled={currentQrIndex >= urls.length - 1}
-                  >
-                    Next
-                  </Button>
-                </div>
-              )}
-            </div>
-          )}
-        </QrSection>
-      </ReportScreenContainer>
-    </NavigationScreen>
+    <ScreenWrapper>
+      <PollingPlaceSelector pollingPlaces={pollingPlaces} />
+    </ScreenWrapper>
   );
 }

--- a/apps/admin/frontend/src/screens/reporting/send_tally_reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/send_tally_reports_screen.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from 'react';
+import {
+  Button,
+  Callout,
+  H6,
+  Loading,
+  P,
+  QrCode,
+  SearchSelect,
+} from '@votingworks/ui';
+import { assert } from '@votingworks/basics';
+import styled from 'styled-components';
+import { NavigationScreen } from '../../components/navigation_screen';
+import {
+  reportParentRoutes,
+  ReportScreenContainer,
+} from '../../components/reporting/shared';
+import {
+  getMatchingAbsenteePollingPlaces,
+  getLiveResultsReportingUrl,
+} from '../../api';
+
+export const TITLE = 'Send Tally Reports';
+
+const SelectPollingPlaceContainer = styled.div`
+  padding: 1rem 1rem 0;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+
+  > span {
+    white-space: nowrap;
+  }
+`;
+
+const FullPageMessage = styled.div`
+  padding: 1rem;
+`;
+
+const QrSection = styled.div`
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+`;
+
+export function SendTallyReportsScreen(): JSX.Element {
+  const matchesQuery = getMatchingAbsenteePollingPlaces.useQuery();
+
+  const [selectedPollingPlaceId, setSelectedPollingPlaceId] =
+    useState<string>();
+  const [currentQrIndex, setCurrentQrIndex] = useState(0);
+
+  // Pick the effective polling place each render: honor the user's pick
+  // only if it's still present in the latest matches (otherwise CVR
+  // changes could leave a stale selection driving the URL signing call),
+  // and fall back to auto-selecting when there is exactly one match.
+  const matches = matchesQuery.data?.ok();
+  const stillValidSelectedId = matches?.find(
+    (p) => p.id === selectedPollingPlaceId
+  )?.id;
+  const pollingPlaceId =
+    stillValidSelectedId ??
+    (matches && matches.length === 1 ? matches[0].id : undefined);
+
+  // Reset QR pagination whenever the selection changes.
+  useEffect(() => {
+    setCurrentQrIndex(0);
+  }, [pollingPlaceId]);
+
+  const urlsQuery = getLiveResultsReportingUrl.useQuery(
+    pollingPlaceId ? { pollingPlaceId } : undefined
+  );
+
+  if (!matchesQuery.isSuccess) {
+    return (
+      <NavigationScreen
+        title={TITLE}
+        parentRoutes={reportParentRoutes}
+        noPadding
+      >
+        <ReportScreenContainer>
+          <FullPageMessage>
+            <Loading />
+          </FullPageMessage>
+        </ReportScreenContainer>
+      </NavigationScreen>
+    );
+  }
+
+  if (matchesQuery.data.isErr()) {
+    assert(matchesQuery.data.err() === 'no-cvrs-loaded');
+    return (
+      <NavigationScreen
+        title={TITLE}
+        parentRoutes={reportParentRoutes}
+        noPadding
+      >
+        <ReportScreenContainer>
+          <FullPageMessage>
+            <Callout icon="Info" color="neutral">
+              Load CVRs to send results.
+            </Callout>
+          </FullPageMessage>
+        </ReportScreenContainer>
+      </NavigationScreen>
+    );
+  }
+
+  const pollingPlaces = matchesQuery.data.ok();
+
+  if (pollingPlaces.length === 0) {
+    return (
+      <NavigationScreen
+        title={TITLE}
+        parentRoutes={reportParentRoutes}
+        noPadding
+      >
+        <ReportScreenContainer>
+          <FullPageMessage>
+            <Callout icon="Warning" color="warning">
+              No absentee polling place covers the precincts in the loaded CVRs.
+            </Callout>
+          </FullPageMessage>
+        </ReportScreenContainer>
+      </NavigationScreen>
+    );
+  }
+
+  const showPicker = pollingPlaces.length > 1;
+  const selectedPollingPlace = pollingPlaces.find(
+    (p) => p.id === pollingPlaceId
+  );
+  const urls = urlsQuery.data;
+
+  return (
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes} noPadding>
+      <ReportScreenContainer>
+        {showPicker && (
+          <SelectPollingPlaceContainer>
+            <SearchSelect
+              isMulti={false}
+              isSearchable
+              disabled={!!pollingPlaceId}
+              value={pollingPlaceId}
+              options={pollingPlaces.map((p) => ({
+                value: p.id,
+                label: p.name,
+              }))}
+              onChange={(value) => setSelectedPollingPlaceId(value)}
+              aria-label="Select absentee polling place"
+              style={{ width: '30rem' }}
+              placeholder="Select an absentee polling place."
+            />
+          </SelectPollingPlaceContainer>
+        )}
+        <QrSection>
+          {urlsQuery.isLoading && pollingPlaceId && (
+            <P>Generating QR code...</P>
+          )}
+          {urlsQuery.isError && selectedPollingPlace && (
+            <Callout icon="Danger" color="danger">
+              Could not generate a QR code for {selectedPollingPlace.name}. The
+              tally results may be too large to encode.
+            </Callout>
+          )}
+          {urls && urls.length > 0 && selectedPollingPlace && (
+            <div data-testid="live-results-code">
+              <P>
+                {urls.length === 1
+                  ? `Scan the QR code to send the tally report for ${selectedPollingPlace.name}.`
+                  : `Scan all ${urls.length} QR codes to send the tally report for ${selectedPollingPlace.name}.`}
+              </P>
+              <div data-value={urls[currentQrIndex]} style={{ width: '600px' }}>
+                <QrCode value={urls[currentQrIndex]} size={600} />
+              </div>
+              {urls.length > 1 && (
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.5rem',
+                    marginTop: '1rem',
+                  }}
+                >
+                  <Button
+                    onPress={() => setCurrentQrIndex((i) => Math.max(i - 1, 0))}
+                    disabled={currentQrIndex === 0}
+                  >
+                    Previous
+                  </Button>
+                  <H6 style={{ margin: 0 }}>
+                    {currentQrIndex + 1} / {urls.length}
+                  </H6>
+                  <Button
+                    variant="primary"
+                    onPress={() =>
+                      setCurrentQrIndex((i) => Math.min(i + 1, urls.length - 1))
+                    }
+                    disabled={currentQrIndex >= urls.length - 1}
+                  >
+                    Next
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </QrSection>
+      </ReportScreenContainer>
+    </NavigationScreen>
+  );
+}

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -45,6 +45,7 @@ import {
   constructElectionKey,
   ElectionDefinition,
   Id,
+  PollingPlace,
   PrinterConfig,
   PrinterStatus,
   Rect,
@@ -314,6 +315,29 @@ export function createApiMock(
       apiClient.getSystemSettings
         .expectCallWith()
         .resolves(systemSettings ?? DEFAULT_SYSTEM_SETTINGS);
+    },
+
+    expectGetLiveResultsReportingUrls(pollingPlaceId: string, urls: string[]) {
+      apiClient.getLiveResultsReportingUrl
+        .expectCallWith({ pollingPlaceId })
+        .resolves(urls);
+    },
+
+    expectGetLiveResultsReportingUrlsError(
+      pollingPlaceId: string,
+      error: Error
+    ) {
+      apiClient.getLiveResultsReportingUrl
+        .expectCallWith({ pollingPlaceId })
+        .throws(error);
+    },
+
+    expectGetMatchingAbsenteePollingPlaces(
+      result: Result<PollingPlace[], 'no-cvrs-loaded'>
+    ) {
+      apiClient.getMatchingAbsenteePollingPlaces
+        .expectCallWith()
+        .resolves(result);
     },
 
     expectGetCastVoteRecordFileMode(fileMode: CvrFileMode) {

--- a/apps/design/frontend/src/reporting_results_confirmation_screen.test.tsx
+++ b/apps/design/frontend/src/reporting_results_confirmation_screen.test.tsx
@@ -431,7 +431,7 @@ describe('ReportingResultsConfirmationScreen with proper parameters', () => {
         name: 'Polls Closed Report Part 2/4 Sent',
       });
       screen.getByText(
-        /Part 2\/4 of the polls closed report has been sent to VxDesign./
+        /Part 2\/4 of the polls closed report has been received\. Send the next part to continue\./
       );
     });
 
@@ -441,6 +441,60 @@ describe('ReportingResultsConfirmationScreen with proper parameters', () => {
     // Check that contest results tables are not rendered
     const tables = screen.queryAllByRole('table');
     expect(tables.length).toEqual(0);
+  });
+
+  test('displays "Tally Report" header for absentee polls closed reports', async () => {
+    apiMock.processQrCodeReport
+      .expectCallWith({
+        payload: 'test-payload',
+        signature: 'test-signature',
+        certificate: 'test-certificate',
+      })
+      .resolves(
+        ok({
+          ...mockPollsClosedReportGeneral,
+          votingType: 'absentee',
+        })
+      );
+    render(
+      provideUnauthenticatedApi(apiMock, <ReportingResultsConfirmationScreen />)
+    );
+
+    await waitFor(() => {
+      screen.getByRole('heading', { name: 'Tally Report Sent' });
+      screen.getByText('The tally report has been sent to VxDesign.');
+    });
+
+    expect(
+      screen.queryByRole('heading', { name: 'Polls Closed Report Sent' })
+    ).toBeNull();
+  });
+
+  test('displays "Tally Report" header for absentee partial polls closed reports', async () => {
+    apiMock.processQrCodeReport
+      .expectCallWith({
+        payload: 'test-payload',
+        signature: 'test-signature',
+        certificate: 'test-certificate',
+      })
+      .resolves(
+        ok({
+          ...mockPollsClosedPartialReportGeneral,
+          votingType: 'absentee',
+        })
+      );
+    render(
+      provideUnauthenticatedApi(apiMock, <ReportingResultsConfirmationScreen />)
+    );
+
+    await waitFor(() => {
+      screen.getByRole('heading', {
+        name: 'Tally Report Part 2/4 Sent',
+      });
+      screen.getByText(
+        /Part 2\/4 of the tally report has been received\. Send the next part to continue\./
+      );
+    });
   });
 
   test('displays polls closed report correctly - general election', async () => {

--- a/apps/design/frontend/src/reporting_results_confirmation_screen.tsx
+++ b/apps/design/frontend/src/reporting_results_confirmation_screen.tsx
@@ -73,6 +73,10 @@ function getVotingTypeLabel(votingType: LiveReportVotingType): string {
   }
 }
 
+function getCloseReportTitle(votingType: LiveReportVotingType): string {
+  return votingType === 'absentee' ? 'Tally Report' : 'Polls Closed Report';
+}
+
 function getTimestampLabel(pollsTransition: PollsTransitionType): string {
   switch (pollsTransition) {
     case 'open_polls':
@@ -132,7 +136,7 @@ function ReportDetails({
               })}
             />
           )}
-          <LabeledValue label="Scanner ID" value={machineId} />
+          <LabeledValue label="Machine ID" value={machineId} />
           <LabeledValue
             label="Election ID"
             value={formatBallotHash(ballotHash)}
@@ -191,9 +195,7 @@ function PartialReportHeader({
     <div style={{ flexDirection: 'column', gap: '1rem', display: 'flex' }}>
       <Callout icon="CircleDot" color="primary">
         Part {pageIndex + 1}/{numPages} of the {lowerCasedReportTitle} has been
-        sent to VxDesign.
-        <br />
-        <br /> Press &apos;Next&apos; on VxScan to send the next part.
+        received. Send the next part to continue.
       </Callout>
       {!isLive && (
         <div>
@@ -225,8 +227,8 @@ function PollsOpenReportConfirmation({
       <MainContent>
         <ReportHeader reportTitle={reportTitle} isLive={isLive} />
         <ReportDetails
-          ballotHash={ballotHash}
           machineId={machineId}
+          ballotHash={ballotHash}
           pollsTransitionTime={pollsTransitionTime}
           election={election}
           pollingPlaceId={pollingPlaceId}
@@ -265,8 +267,8 @@ function PollsPausedReportConfirmation({
       <MainContent>
         <ReportHeader reportTitle={reportTitle} isLive={isLive} />
         <ReportDetails
-          ballotHash={ballotHash}
           machineId={machineId}
+          ballotHash={ballotHash}
           pollsTransitionTime={pollsTransitionTime}
           election={election}
           pollingPlaceId={pollingPlaceId}
@@ -305,8 +307,8 @@ function VotingResumedReportConfirmation({
       <MainContent>
         <ReportHeader reportTitle={reportTitle} isLive={isLive} />
         <ReportDetails
-          ballotHash={ballotHash}
           machineId={machineId}
+          ballotHash={ballotHash}
           pollsTransitionTime={pollsTransitionTime}
           election={election}
           pollingPlaceId={pollingPlaceId}
@@ -341,7 +343,7 @@ function PollsClosedPartialReportConfirmation({
   numPages: number;
   pageIndex: number;
 }): JSX.Element {
-  const reportTitle = getPollsReportTitle('close_polls');
+  const reportTitle = getCloseReportTitle(votingType);
   return (
     <ResultsScreen
       screenTitle={`${reportTitle} Part ${pageIndex + 1}/${numPages} Sent`}
@@ -354,8 +356,8 @@ function PollsClosedPartialReportConfirmation({
           pageIndex={pageIndex}
         />
         <ReportDetails
-          ballotHash={ballotHash}
           machineId={machineId}
+          ballotHash={ballotHash}
           pollsTransitionTime={pollsTransitionTime}
           election={election}
           pollingPlaceId={pollingPlaceId}
@@ -440,7 +442,7 @@ function PollsClosedReportConfirmation({
   >;
   isLive: boolean;
 }): JSX.Element {
-  const reportTitle = getPollsReportTitle('close_polls');
+  const reportTitle = getCloseReportTitle(votingType);
 
   const pollingPlace = assertDefined(
     election.pollingPlaces?.find((p) => p.id === pollingPlaceId)
@@ -452,8 +454,8 @@ function PollsClosedReportConfirmation({
       <MainContent>
         <ReportHeader reportTitle={reportTitle} isLive={isLive} />
         <ReportDetails
-          ballotHash={ballotHash}
           machineId={machineId}
+          ballotHash={ballotHash}
           pollsTransitionTime={pollsTransitionTime}
           election={election}
           pollingPlaceId={pollingPlaceId}

--- a/apps/design/frontend/src/reporting_results_confirmation_screen.tsx
+++ b/apps/design/frontend/src/reporting_results_confirmation_screen.tsx
@@ -447,7 +447,10 @@ function PollsClosedReportConfirmation({
   const pollingPlace = assertDefined(
     election.pollingPlaces?.find((p) => p.id === pollingPlaceId)
   );
-  const pollingPlacePrecincts = [...pollingPlacePrecinctIds(pollingPlace)];
+  const placePrecinctIds = pollingPlacePrecinctIds(pollingPlace);
+  const orderedPrecincts = election.precincts.filter((p) =>
+    placePrecinctIds.has(p.id)
+  );
 
   return (
     <ResultsScreen screenTitle={`${reportTitle} Sent`}>
@@ -462,20 +465,15 @@ function PollsClosedReportConfirmation({
           votingType={votingType}
           pollsTransitionType={pollsTransitionType}
         />
-        {pollingPlacePrecincts.map((precinctId) => {
-          const precinct = assertDefined(
-            election.precincts.find((p) => p.id === precinctId)
-          );
-          return (
-            <PrecinctTallySection
-              key={precinctId}
-              election={election}
-              precinctId={precinctId}
-              precinctName={precinct.name}
-              contestResults={contestResultsByPrecinct[precinctId]}
-            />
-          );
-        })}
+        {orderedPrecincts.map((precinct) => (
+          <PrecinctTallySection
+            key={precinct.id}
+            election={election}
+            precinctId={precinct.id}
+            precinctName={precinct.name}
+            contestResults={contestResultsByPrecinct[precinct.id]}
+          />
+        ))}
       </MainContent>
     </ResultsScreen>
   );

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -702,3 +702,7 @@ IDs are logged with each log to identify the log being written.
 **Type:** [system-status](#system-status)
 **Description:** Free disk space is low.
 **Machines:** All
+### live-report-viewed
+**Type:** [application-action](#application-action)
+**Description:** A user viewed the live reporting QR Code.
+**Machines:** vx-admin, vx-scan

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -1115,3 +1115,9 @@ restrictInDocumentationToApps = ["vx-admin"]
 eventId = "low-disk-space"
 eventType = "system-status"
 documentationMessage = "Free disk space is low."
+
+[Events.LiveReportingUrlViewer]
+eventId = "live-report-viewed"
+eventType = "application-action"
+documentationMessage = "A user viewed the live reporting QR Code."
+restrictInDocumentationToApps = ["vx-admin", "vx-scan"]

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -238,6 +238,7 @@ export enum LogEventId {
   AdminAdjudicationProxyError = 'admin-adjudication-proxy-error',
   AdminContestAdjudicated = 'admin-contest-adjudicated',
   LowDiskSpace = 'low-disk-space',
+  LiveReportingUrlViewer = 'live-report-viewed',
 }
 
 const ElectionConfigured: LogDetails = {
@@ -1513,6 +1514,13 @@ const LowDiskSpace: LogDetails = {
   documentationMessage: 'Free disk space is low.',
 };
 
+const LiveReportingUrlViewer: LogDetails = {
+  eventId: LogEventId.LiveReportingUrlViewer,
+  eventType: LogEventType.ApplicationAction,
+  documentationMessage: 'A user viewed the live reporting QR Code.',
+  restrictInDocumentationToApps: [AppName.VxAdmin, AppName.VxScan],
+};
+
 export function getDetailsForEventId(eventId: LogEventId): LogDetails {
   switch (eventId) {
     case LogEventId.ElectionConfigured:
@@ -1859,6 +1867,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return AdminContestAdjudicated;
     case LogEventId.LowDiskSpace:
       return LowDiskSpace;
+    case LogEventId.LiveReportingUrlViewer:
+      return LiveReportingUrlViewer;
     default:
       throwIllegalValue(eventId);
   }

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -459,5 +459,7 @@ pub enum EventId {
     AdminContestAdjudicated,
     #[serde(rename = "low-disk-space")]
     LowDiskSpace,
+    #[serde(rename = "live-report-viewed")]
+    LiveReportingUrlViewer,
 }
 derive_display!(EventId);


### PR DESCRIPTION
Co-Authored with Claude 🤖 
## Overview
Adds a screen to VxAdmin to submit live reports data. See: https://votingworks.slack.com/archives/CEL6D3GAD/p1777399199256479 for conversation around polling place selection logic. 

Also updates the VxDesign report received flow to say "Tally Report Received" instead of "Polls Closed Report" in this case. 

I realized in the course of this that we still have voting type send on the live results url which is redudant with the polling place having an associated voting type, I'll clean this up in a seperate task/PR (made: https://github.com/issues/assigned?issue=votingworks%7Cvxsuite%7C8354 ) 

## Demo Video or Screens

https://github.com/user-attachments/assets/08609aa1-6ae2-48e7-87e4-073915f9c451


https://github.com/user-attachments/assets/172c6bb3-78f8-4b60-9c78-d2a5eda6574c


https://github.com/user-attachments/assets/79c14219-e973-4f79-97f4-7e543a3d89e6



## Testing Plan
- See videos for primary flows
- Tested artificially lowering threshold to break into multiple qr codes and test flow
- Tested adding adjudications and manual tallies and still seeing submitted results as you would expect to see. 


## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
