### PR TITLE
VxAdmin: Disallow official candidate selection for write-ins when in qualified mode

### DIFF
--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
@@ -641,7 +641,7 @@ describe('hmpb write-in adjudication', () => {
     );
   });
 
-  test('qualified write-in mode does not allow adding new write-in candidates', async () => {
+  test('qualified write-in mode does not allow new or official candidates', async () => {
     const data = buildContestAdjudicationData({
       contestId,
       votes: ['kangaroo', 'write-in-0'],
@@ -656,6 +656,14 @@ describe('hmpb write-in adjudication', () => {
     await waitForBallotById('id-174');
     const writeInSearchSelect = screen.getByRole('combobox');
     fireEvent.keyDown(writeInSearchSelect, { key: 'ArrowDown' });
+
+    // Official candidates should not be selectable in qualified mode
+    expect(
+      screen.queryByRole('option', { name: 'Lion' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: 'Elephant' })
+    ).not.toBeInTheDocument();
 
     // Type a name that doesn't match any existing candidate
     userEvent.type(writeInSearchSelect, 'NewCandidate');

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
@@ -568,12 +568,16 @@ export function ContestAdjudicationScreen({
                         resolveOptionMarginalMark(optionId);
                       }
                     }}
-                    officialCandidates={(officialOptions as Candidate[]).filter(
-                      (c) =>
-                        !selectedCandidateNames.includes(c.name) ||
-                        (isValidCandidate(writeInStatus) &&
-                          writeInStatus.name === c.name)
-                    )}
+                    officialCandidates={
+                      areWriteInCandidatesQualified
+                        ? []
+                        : (officialOptions as Candidate[]).filter(
+                            (c) =>
+                              !selectedCandidateNames.includes(c.name) ||
+                              (isValidCandidate(writeInStatus) &&
+                                writeInStatus.name === c.name)
+                          )
+                    }
                     writeInCandidates={writeInCandidates.filter(
                       (c) =>
                         !selectedCandidateNames.includes(c.name) ||


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/8328

Prevent adjudicating for official candidates when in qualified write-in mode

## Demo Video or Screenshot

https://github.com/user-attachments/assets/87d4f2d5-0801-4abc-9984-c22d7a26f1d5

## Testing Plan

Extended automated test

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
