### PR TITLE
VxAdmin: Fix flaky tests from polled query

### DIFF
--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -373,7 +373,7 @@ export function createApiMock(
 
     expectGetNextCvrIdForBallotAdjudication(cvrId: Id | null) {
       apiClient.getNextCvrIdForBallotAdjudication
-        .expectCallWith()
+        .expectRepeatedCallsWith()
         .resolves(cvrId);
     },
 


### PR DESCRIPTION
## Overview

Noticed some [test flakes](https://app.circleci.com/pipelines/github/votingworks/vxsuite/25795/workflows/a9b54606-c0e5-436d-8384-12038162df7f/jobs/1180796) due to mismatched calls for `getNextCvrId...`. Seems when CI is running and takes a bit longer, some tests have this query called multiple times. I _think_ this is the fix for that.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
