### PR TITLE
VxScan: Detect crossover voting in open primaries

### DIFF
--- a/apps/scan/backend/src/interpret.test.ts
+++ b/apps/scan/backend/src/interpret.test.ts
@@ -9,10 +9,12 @@ import { vxFamousNamesFixtures } from '@votingworks/hmpb';
 import { ImageData, pdfToImages } from '@votingworks/image-utils';
 import {
   AdjudicationReason,
+  AdjudicationReasonInfo,
   BallotType,
   DEFAULT_MARK_THRESHOLDS,
   ElectionDefinition,
   HmpbBallotPageMetadata,
+  InterpretedBmdMultiPagePage,
   InterpretedHmpbPage,
   PageInterpretation,
   SheetInterpretation,
@@ -126,101 +128,6 @@ test('respects adjudication reasons for a BMD ballot on the front side', async (
   }
 });
 
-test('treats either page being an invalid test mode as an invalid sheet', () => {
-  const { election } = vxFamousNamesFixtures;
-  const invalidTestModePageInterpretation: PageInterpretation = {
-    type: 'InvalidTestModePage',
-    metadata: {
-      ballotStyleId: election.ballotStyles[0].id,
-      precinctId: election.ballotStyles[0].precincts[0],
-      ballotType: BallotType.Precinct,
-      ballotHash: vxFamousNamesFixtures.electionDefinition.ballotHash,
-      isTestMode: false,
-      pageNumber: 1,
-    },
-  };
-  const unreadablePage: PageInterpretation = {
-    type: 'UnreadablePage',
-  };
-
-  expect(
-    combinePageInterpretationsForSheet([
-      {
-        imagePath: 'front.jpeg',
-        interpretation: invalidTestModePageInterpretation,
-      },
-      {
-        imagePath: 'back.jpeg',
-        interpretation: unreadablePage,
-      },
-    ])
-  ).toEqual<SheetInterpretation>({
-    type: 'InvalidSheet',
-    reason: 'invalid_test_mode',
-  });
-  expect(
-    combinePageInterpretationsForSheet([
-      {
-        imagePath: 'front.jpeg',
-        interpretation: unreadablePage,
-      },
-      {
-        imagePath: 'back.jpeg',
-        interpretation: invalidTestModePageInterpretation,
-      },
-    ])
-  ).toEqual<SheetInterpretation>({
-    type: 'InvalidSheet',
-    reason: 'invalid_test_mode',
-  });
-});
-
-test('differentiates vertical streaks detected from other unreadable errors', () => {
-  // The HMPB interpreter returns the same error for each page
-  const verticalStreaksPageInterpretation: PageInterpretation = {
-    type: 'UnreadablePage',
-    reason: 'verticalStreaksDetected',
-  };
-  expect(
-    combinePageInterpretationsForSheet([
-      {
-        imagePath: 'front.jpeg',
-        interpretation: verticalStreaksPageInterpretation,
-      },
-      {
-        imagePath: 'back.jpeg',
-        interpretation: verticalStreaksPageInterpretation,
-      },
-    ])
-  ).toEqual<SheetInterpretation>({
-    type: 'InvalidSheet',
-    reason: 'vertical_streaks_detected',
-  });
-});
-
-test('differentiates BMD ballot scanning disabled from other unreadable errors', () => {
-  const bmdPageWhenBmdBallotScanningDisabledInterpretation: PageInterpretation =
-    {
-      type: 'UnreadablePage',
-      reason: 'bmdBallotScanningDisabled',
-    };
-  expect(
-    combinePageInterpretationsForSheet([
-      {
-        imagePath: 'front.jpeg',
-        interpretation: bmdPageWhenBmdBallotScanningDisabledInterpretation,
-      },
-      {
-        imagePath: 'back.jpeg',
-        interpretation: bmdPageWhenBmdBallotScanningDisabledInterpretation,
-      },
-    ])
-  ).toEqual<SheetInterpretation>({
-    type: 'InvalidSheet',
-    reason: 'bmd_ballot_scanning_disabled',
-  });
-});
-
 test('NH interpreter of overvote yields a sheet that needs to be reviewed', async () => {
   const result = await interpret('foo-sheet-id', ballotImages.overvoteBallot, {
     electionDefinition: vxFamousNamesFixtures.electionDefinition,
@@ -263,3 +170,317 @@ test('NH interpreter with testMode=true', async () => {
 function allPrecinctIds(electionDef: ElectionDefinition) {
   return new Set(electionDef.election.precincts.map((p) => p.id));
 }
+
+function mockHmpbPage({
+  numMarks = 1,
+  requiresAdjudication = false,
+  enabledReasonInfos = [],
+}: {
+  numMarks?: number;
+  requiresAdjudication?: boolean;
+  enabledReasonInfos?: AdjudicationReasonInfo[];
+} = {}): InterpretedHmpbPage {
+  // Just mock the fields needed for combinePageInterpretationsForSheet
+  // (bypassing the type system)
+  return {
+    type: 'InterpretedHmpbPage',
+    markInfo: { marks: Array.from({ length: numMarks }, () => ({})) },
+    adjudicationInfo: {
+      requiresAdjudication,
+      enabledReasons: [],
+      enabledReasonInfos,
+      ignoredReasonInfos: [],
+    },
+  } as unknown as InterpretedHmpbPage;
+}
+
+function mockBmdMultiPagePage({
+  requiresAdjudication = false,
+  enabledReasonInfos = [],
+}: {
+  requiresAdjudication?: boolean;
+  enabledReasonInfos?: AdjudicationReasonInfo[];
+} = {}): InterpretedBmdMultiPagePage {
+  // Just mock the fields needed for combinePageInterpretationsForSheet
+  // (bypassing the type system)
+  return {
+    type: 'InterpretedBmdMultiPagePage',
+    adjudicationInfo: {
+      requiresAdjudication,
+      enabledReasons: [],
+      enabledReasonInfos,
+      ignoredReasonInfos: [],
+    },
+  } as unknown as InterpretedBmdMultiPagePage;
+}
+
+const blankPage: PageInterpretation = { type: 'BlankPage' };
+
+function mockSheet(
+  front: PageInterpretation,
+  back: PageInterpretation
+): Parameters<typeof combinePageInterpretationsForSheet>[0] {
+  return [
+    { imagePath: 'front.jpeg', interpretation: front },
+    { imagePath: 'back.jpeg', interpretation: back },
+  ];
+}
+
+test('treats multi-page BMD ballot with one blank side as valid', () => {
+  const printed = mockBmdMultiPagePage();
+  expect(
+    combinePageInterpretationsForSheet(mockSheet(printed, blankPage))
+  ).toEqual<SheetInterpretation>({
+    type: 'ValidSheet',
+  });
+  expect(
+    combinePageInterpretationsForSheet(mockSheet(blankPage, printed))
+  ).toEqual<SheetInterpretation>({
+    type: 'ValidSheet',
+  });
+});
+
+test('respects adjudication reasons for a multi-page BMD ballot', () => {
+  const reasons: AdjudicationReasonInfo[] = [
+    {
+      type: AdjudicationReason.Undervote,
+      contestId: 'contest-1',
+      expected: 1,
+      optionIds: [],
+    },
+  ];
+  const printed = mockBmdMultiPagePage({
+    requiresAdjudication: true,
+    enabledReasonInfos: reasons,
+  });
+  expect(
+    combinePageInterpretationsForSheet(mockSheet(printed, blankPage))
+  ).toEqual<SheetInterpretation>({
+    type: 'NeedsReviewSheet',
+    reasons,
+  });
+});
+
+test('treats HMPB ballot with both sides marked blank as a blank ballot', () => {
+  const blankReason: AdjudicationReasonInfo = {
+    type: AdjudicationReason.BlankBallot,
+  };
+  const front = mockHmpbPage({
+    requiresAdjudication: true,
+    enabledReasonInfos: [blankReason],
+  });
+  const back = mockHmpbPage({
+    requiresAdjudication: true,
+    enabledReasonInfos: [blankReason],
+  });
+  expect(
+    combinePageInterpretationsForSheet(mockSheet(front, back))
+  ).toEqual<SheetInterpretation>({
+    type: 'NeedsReviewSheet',
+    reasons: [{ type: AdjudicationReason.BlankBallot }],
+  });
+});
+
+test('treats HMPB ballot with no marks on either side as a blank ballot', () => {
+  const front = mockHmpbPage({ numMarks: 0, requiresAdjudication: true });
+  const back = mockHmpbPage({ numMarks: 0, requiresAdjudication: true });
+  expect(
+    combinePageInterpretationsForSheet(mockSheet(front, back))
+  ).toEqual<SheetInterpretation>({
+    type: 'NeedsReviewSheet',
+    reasons: [{ type: AdjudicationReason.BlankBallot }],
+  });
+});
+
+test('drops blank reason from one side when other side has non-blank reasons', () => {
+  const overvoteReason: AdjudicationReasonInfo = {
+    type: AdjudicationReason.Overvote,
+    contestId: 'contest-1',
+    expected: 1,
+    optionIds: ['a', 'b'],
+  };
+  const front = mockHmpbPage({
+    numMarks: 0,
+    requiresAdjudication: true,
+    enabledReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
+  });
+  const back = mockHmpbPage({
+    requiresAdjudication: true,
+    enabledReasonInfos: [overvoteReason],
+  });
+  expect(
+    combinePageInterpretationsForSheet(mockSheet(front, back))
+  ).toEqual<SheetInterpretation>({
+    type: 'NeedsReviewSheet',
+    reasons: [overvoteReason],
+  });
+});
+
+test('treats either page being an invalid ballot hash as an invalid sheet', () => {
+  const invalidBallotHashPage: PageInterpretation = {
+    type: 'InvalidBallotHashPage',
+    expectedBallotHash: 'expected',
+    actualBallotHash: 'actual',
+  };
+  expect(
+    combinePageInterpretationsForSheet(
+      mockSheet(invalidBallotHashPage, { type: 'UnreadablePage' })
+    )
+  ).toEqual<SheetInterpretation>({
+    type: 'InvalidSheet',
+    reason: 'invalid_ballot_hash',
+  });
+  expect(
+    combinePageInterpretationsForSheet(
+      mockSheet({ type: 'UnreadablePage' }, invalidBallotHashPage)
+    )
+  ).toEqual<SheetInterpretation>({
+    type: 'InvalidSheet',
+    reason: 'invalid_ballot_hash',
+  });
+});
+
+const invalidPageMetadata: HmpbBallotPageMetadata = {
+  ballotStyleId: vxFamousNamesFixtures.election.ballotStyles[0].id,
+  precinctId: vxFamousNamesFixtures.election.ballotStyles[0].precincts[0],
+  ballotType: BallotType.Precinct,
+  ballotHash: vxFamousNamesFixtures.electionDefinition.ballotHash,
+  isTestMode: false,
+  pageNumber: 1,
+};
+
+test('treats either page being an invalid test mode as an invalid sheet', () => {
+  const invalidTestModePage: PageInterpretation = {
+    type: 'InvalidTestModePage',
+    metadata: invalidPageMetadata,
+  };
+  expect(
+    combinePageInterpretationsForSheet(
+      mockSheet(invalidTestModePage, { type: 'UnreadablePage' })
+    )
+  ).toEqual<SheetInterpretation>({
+    type: 'InvalidSheet',
+    reason: 'invalid_test_mode',
+  });
+  expect(
+    combinePageInterpretationsForSheet(
+      mockSheet({ type: 'UnreadablePage' }, invalidTestModePage)
+    )
+  ).toEqual<SheetInterpretation>({
+    type: 'InvalidSheet',
+    reason: 'invalid_test_mode',
+  });
+});
+
+test('treats either page being an invalid precinct as an invalid sheet', () => {
+  const invalidPrecinctPage: PageInterpretation = {
+    type: 'InvalidPrecinctPage',
+    metadata: invalidPageMetadata,
+  };
+  expect(
+    combinePageInterpretationsForSheet(
+      mockSheet(invalidPrecinctPage, { type: 'UnreadablePage' })
+    )
+  ).toEqual<SheetInterpretation>({
+    type: 'InvalidSheet',
+    reason: 'invalid_precinct',
+  });
+  expect(
+    combinePageInterpretationsForSheet(
+      mockSheet({ type: 'UnreadablePage' }, invalidPrecinctPage)
+    )
+  ).toEqual<SheetInterpretation>({
+    type: 'InvalidSheet',
+    reason: 'invalid_precinct',
+  });
+});
+
+test('treats either page having invalid scale as an invalid sheet', () => {
+  const invalidScalePage: PageInterpretation = {
+    type: 'UnreadablePage',
+    reason: 'invalidScale',
+  };
+  expect(
+    combinePageInterpretationsForSheet(
+      mockSheet(invalidScalePage, { type: 'UnreadablePage' })
+    )
+  ).toEqual<SheetInterpretation>({
+    type: 'InvalidSheet',
+    reason: 'invalid_scale',
+  });
+  expect(
+    combinePageInterpretationsForSheet(
+      mockSheet({ type: 'UnreadablePage' }, invalidScalePage)
+    )
+  ).toEqual<SheetInterpretation>({
+    type: 'InvalidSheet',
+    reason: 'invalid_scale',
+  });
+});
+
+test('treats either page having BMD ballot scanning disabled as an invalid sheet', () => {
+  const bmdDisabledPage: PageInterpretation = {
+    type: 'UnreadablePage',
+    reason: 'bmdBallotScanningDisabled',
+  };
+  expect(
+    combinePageInterpretationsForSheet(
+      mockSheet(bmdDisabledPage, { type: 'UnreadablePage' })
+    )
+  ).toEqual<SheetInterpretation>({
+    type: 'InvalidSheet',
+    reason: 'bmd_ballot_scanning_disabled',
+  });
+  expect(
+    combinePageInterpretationsForSheet(
+      mockSheet({ type: 'UnreadablePage' }, bmdDisabledPage)
+    )
+  ).toEqual<SheetInterpretation>({
+    type: 'InvalidSheet',
+    reason: 'bmd_ballot_scanning_disabled',
+  });
+});
+
+test('treats either page having vertical streaks as an invalid sheet', () => {
+  const verticalStreaksPage: PageInterpretation = {
+    type: 'UnreadablePage',
+    reason: 'verticalStreaksDetected',
+  };
+  expect(
+    combinePageInterpretationsForSheet(
+      mockSheet(verticalStreaksPage, { type: 'UnreadablePage' })
+    )
+  ).toEqual<SheetInterpretation>({
+    type: 'InvalidSheet',
+    reason: 'vertical_streaks_detected',
+  });
+  expect(
+    combinePageInterpretationsForSheet(
+      mockSheet({ type: 'UnreadablePage' }, verticalStreaksPage)
+    )
+  ).toEqual<SheetInterpretation>({
+    type: 'InvalidSheet',
+    reason: 'vertical_streaks_detected',
+  });
+});
+
+test('treats unreadable pages as an invalid sheet', () => {
+  expect(
+    combinePageInterpretationsForSheet(
+      mockSheet({ type: 'UnreadablePage' }, { type: 'UnreadablePage' })
+    )
+  ).toEqual<SheetInterpretation>({
+    type: 'InvalidSheet',
+    reason: 'unreadable',
+  });
+});
+
+test('treats unmatched page combinations as unknown invalid sheet', () => {
+  // Both blank doesn't match any specific case.
+  expect(
+    combinePageInterpretationsForSheet(mockSheet(blankPage, blankPage))
+  ).toEqual<SheetInterpretation>({
+    type: 'InvalidSheet',
+    reason: 'unknown',
+  });
+});

--- a/apps/scan/backend/src/interpret.test.ts
+++ b/apps/scan/backend/src/interpret.test.ts
@@ -19,17 +19,33 @@ import {
   PageInterpretation,
   SheetInterpretation,
   SheetOf,
+  VotesDict,
   asSheet,
 } from '@votingworks/types';
 import { assert } from 'node:console';
 import * as fs from 'node:fs/promises';
-import { makeTemporaryDirectory } from '@votingworks/fixtures';
+import {
+  electionOpenPrimaryFixtures,
+  makeTemporaryDirectory,
+} from '@votingworks/fixtures';
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 import { combinePageInterpretationsForSheet, interpret } from './interpret';
 
 if (process.env.CI) {
   vi.setConfig({ testTimeout: 20_000 });
 }
+
+const { election, electionDefinition } = vxFamousNamesFixtures;
+const openPrimaryElection = electionOpenPrimaryFixtures.readElection();
+
+const invalidPageMetadata: HmpbBallotPageMetadata = {
+  ballotStyleId: election.ballotStyles[0].id,
+  precinctId: election.ballotStyles[0].precincts[0],
+  ballotType: BallotType.Precinct,
+  ballotHash: electionDefinition.ballotHash,
+  isTestMode: false,
+  pageNumber: 1,
+};
 
 let ballotImages: {
   overvoteBallot: SheetOf<ImageData>;
@@ -56,13 +72,11 @@ beforeAll(async () => {
       Uint8Array.from(await fs.readFile(vxFamousNamesFixtures.blankBallotPath))
     ),
     normalBmdBallot: await ballotAsSheet(
-      await renderBmdBallotFixture({
-        electionDefinition: vxFamousNamesFixtures.electionDefinition,
-      })
+      await renderBmdBallotFixture({ electionDefinition })
     ),
     undervoteBmdBallot: await ballotAsSheet(
       await renderBmdBallotFixture({
-        electionDefinition: vxFamousNamesFixtures.electionDefinition,
+        electionDefinition,
         precinctId: DEFAULT_FAMOUS_NAMES_PRECINCT_ID,
         ballotStyleId: DEFAULT_FAMOUS_NAMES_BALLOT_STYLE_ID,
         votes: {
@@ -87,8 +101,8 @@ afterEach(async () => {
 
 test('treats BMD ballot with one blank side as valid', async () => {
   const result = await interpret('foo-sheet-id', ballotImages.normalBmdBallot, {
-    electionDefinition: vxFamousNamesFixtures.electionDefinition,
-    validPrecinctIds: allPrecinctIds(vxFamousNamesFixtures.electionDefinition),
+    electionDefinition,
+    validPrecinctIds: allPrecinctIds(electionDefinition),
     ballotImagesPath,
     testMode: true,
     markThresholds: DEFAULT_MARK_THRESHOLDS,
@@ -102,10 +116,8 @@ test('respects adjudication reasons for a BMD ballot on the front side', async (
     'foo-sheet-id',
     ballotImages.undervoteBmdBallot,
     {
-      electionDefinition: vxFamousNamesFixtures.electionDefinition,
-      validPrecinctIds: allPrecinctIds(
-        vxFamousNamesFixtures.electionDefinition
-      ),
+      electionDefinition,
+      validPrecinctIds: allPrecinctIds(electionDefinition),
       ballotImagesPath,
       testMode: true,
       markThresholds: DEFAULT_MARK_THRESHOLDS,
@@ -130,8 +142,8 @@ test('respects adjudication reasons for a BMD ballot on the front side', async (
 
 test('NH interpreter of overvote yields a sheet that needs to be reviewed', async () => {
   const result = await interpret('foo-sheet-id', ballotImages.overvoteBallot, {
-    electionDefinition: vxFamousNamesFixtures.electionDefinition,
-    validPrecinctIds: allPrecinctIds(vxFamousNamesFixtures.electionDefinition),
+    electionDefinition,
+    validPrecinctIds: allPrecinctIds(electionDefinition),
     ballotImagesPath,
     testMode: true,
     markThresholds: DEFAULT_MARK_THRESHOLDS,
@@ -143,10 +155,8 @@ test('NH interpreter of overvote yields a sheet that needs to be reviewed', asyn
 test('NH interpreter with testMode=true', async () => {
   const sheet = (
     await interpret('foo-sheet-id', ballotImages.normalBallot, {
-      electionDefinition: vxFamousNamesFixtures.electionDefinition,
-      validPrecinctIds: allPrecinctIds(
-        vxFamousNamesFixtures.electionDefinition
-      ),
+      electionDefinition,
+      validPrecinctIds: allPrecinctIds(electionDefinition),
       ballotImagesPath,
       testMode: true,
       markThresholds: DEFAULT_MARK_THRESHOLDS,
@@ -175,16 +185,19 @@ function mockHmpbPage({
   numMarks = 1,
   requiresAdjudication = false,
   enabledReasonInfos = [],
+  votes = {},
 }: {
   numMarks?: number;
   requiresAdjudication?: boolean;
   enabledReasonInfos?: AdjudicationReasonInfo[];
+  votes?: VotesDict;
 } = {}): InterpretedHmpbPage {
   // Just mock the fields needed for combinePageInterpretationsForSheet
   // (bypassing the type system)
   return {
     type: 'InterpretedHmpbPage',
     markInfo: { marks: Array.from({ length: numMarks }, () => ({})) },
+    votes,
     adjudicationInfo: {
       requiresAdjudication,
       enabledReasons: [],
@@ -229,12 +242,12 @@ function mockSheet(
 test('treats multi-page BMD ballot with one blank side as valid', () => {
   const printed = mockBmdMultiPagePage();
   expect(
-    combinePageInterpretationsForSheet(mockSheet(printed, blankPage))
+    combinePageInterpretationsForSheet(mockSheet(printed, blankPage), election)
   ).toEqual<SheetInterpretation>({
     type: 'ValidSheet',
   });
   expect(
-    combinePageInterpretationsForSheet(mockSheet(blankPage, printed))
+    combinePageInterpretationsForSheet(mockSheet(blankPage, printed), election)
   ).toEqual<SheetInterpretation>({
     type: 'ValidSheet',
   });
@@ -254,7 +267,7 @@ test('respects adjudication reasons for a multi-page BMD ballot', () => {
     enabledReasonInfos: reasons,
   });
   expect(
-    combinePageInterpretationsForSheet(mockSheet(printed, blankPage))
+    combinePageInterpretationsForSheet(mockSheet(printed, blankPage), election)
   ).toEqual<SheetInterpretation>({
     type: 'NeedsReviewSheet',
     reasons,
@@ -274,7 +287,7 @@ test('treats HMPB ballot with both sides marked blank as a blank ballot', () => 
     enabledReasonInfos: [blankReason],
   });
   expect(
-    combinePageInterpretationsForSheet(mockSheet(front, back))
+    combinePageInterpretationsForSheet(mockSheet(front, back), election)
   ).toEqual<SheetInterpretation>({
     type: 'NeedsReviewSheet',
     reasons: [{ type: AdjudicationReason.BlankBallot }],
@@ -285,7 +298,7 @@ test('treats HMPB ballot with no marks on either side as a blank ballot', () => 
   const front = mockHmpbPage({ numMarks: 0, requiresAdjudication: true });
   const back = mockHmpbPage({ numMarks: 0, requiresAdjudication: true });
   expect(
-    combinePageInterpretationsForSheet(mockSheet(front, back))
+    combinePageInterpretationsForSheet(mockSheet(front, back), election)
   ).toEqual<SheetInterpretation>({
     type: 'NeedsReviewSheet',
     reasons: [{ type: AdjudicationReason.BlankBallot }],
@@ -309,7 +322,7 @@ test('drops blank reason from one side when other side has non-blank reasons', (
     enabledReasonInfos: [overvoteReason],
   });
   expect(
-    combinePageInterpretationsForSheet(mockSheet(front, back))
+    combinePageInterpretationsForSheet(mockSheet(front, back), election)
   ).toEqual<SheetInterpretation>({
     type: 'NeedsReviewSheet',
     reasons: [overvoteReason],
@@ -324,7 +337,8 @@ test('treats either page being an invalid ballot hash as an invalid sheet', () =
   };
   expect(
     combinePageInterpretationsForSheet(
-      mockSheet(invalidBallotHashPage, { type: 'UnreadablePage' })
+      mockSheet(invalidBallotHashPage, { type: 'UnreadablePage' }),
+      election
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
@@ -332,22 +346,14 @@ test('treats either page being an invalid ballot hash as an invalid sheet', () =
   });
   expect(
     combinePageInterpretationsForSheet(
-      mockSheet({ type: 'UnreadablePage' }, invalidBallotHashPage)
+      mockSheet({ type: 'UnreadablePage' }, invalidBallotHashPage),
+      election
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
     reason: 'invalid_ballot_hash',
   });
 });
-
-const invalidPageMetadata: HmpbBallotPageMetadata = {
-  ballotStyleId: vxFamousNamesFixtures.election.ballotStyles[0].id,
-  precinctId: vxFamousNamesFixtures.election.ballotStyles[0].precincts[0],
-  ballotType: BallotType.Precinct,
-  ballotHash: vxFamousNamesFixtures.electionDefinition.ballotHash,
-  isTestMode: false,
-  pageNumber: 1,
-};
 
 test('treats either page being an invalid test mode as an invalid sheet', () => {
   const invalidTestModePage: PageInterpretation = {
@@ -356,7 +362,8 @@ test('treats either page being an invalid test mode as an invalid sheet', () => 
   };
   expect(
     combinePageInterpretationsForSheet(
-      mockSheet(invalidTestModePage, { type: 'UnreadablePage' })
+      mockSheet(invalidTestModePage, { type: 'UnreadablePage' }),
+      election
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
@@ -364,7 +371,8 @@ test('treats either page being an invalid test mode as an invalid sheet', () => 
   });
   expect(
     combinePageInterpretationsForSheet(
-      mockSheet({ type: 'UnreadablePage' }, invalidTestModePage)
+      mockSheet({ type: 'UnreadablePage' }, invalidTestModePage),
+      election
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
@@ -379,7 +387,8 @@ test('treats either page being an invalid precinct as an invalid sheet', () => {
   };
   expect(
     combinePageInterpretationsForSheet(
-      mockSheet(invalidPrecinctPage, { type: 'UnreadablePage' })
+      mockSheet(invalidPrecinctPage, { type: 'UnreadablePage' }),
+      election
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
@@ -387,7 +396,8 @@ test('treats either page being an invalid precinct as an invalid sheet', () => {
   });
   expect(
     combinePageInterpretationsForSheet(
-      mockSheet({ type: 'UnreadablePage' }, invalidPrecinctPage)
+      mockSheet({ type: 'UnreadablePage' }, invalidPrecinctPage),
+      election
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
@@ -402,7 +412,8 @@ test('treats either page having invalid scale as an invalid sheet', () => {
   };
   expect(
     combinePageInterpretationsForSheet(
-      mockSheet(invalidScalePage, { type: 'UnreadablePage' })
+      mockSheet(invalidScalePage, { type: 'UnreadablePage' }),
+      election
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
@@ -410,7 +421,8 @@ test('treats either page having invalid scale as an invalid sheet', () => {
   });
   expect(
     combinePageInterpretationsForSheet(
-      mockSheet({ type: 'UnreadablePage' }, invalidScalePage)
+      mockSheet({ type: 'UnreadablePage' }, invalidScalePage),
+      election
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
@@ -425,7 +437,8 @@ test('treats either page having BMD ballot scanning disabled as an invalid sheet
   };
   expect(
     combinePageInterpretationsForSheet(
-      mockSheet(bmdDisabledPage, { type: 'UnreadablePage' })
+      mockSheet(bmdDisabledPage, { type: 'UnreadablePage' }),
+      election
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
@@ -433,7 +446,8 @@ test('treats either page having BMD ballot scanning disabled as an invalid sheet
   });
   expect(
     combinePageInterpretationsForSheet(
-      mockSheet({ type: 'UnreadablePage' }, bmdDisabledPage)
+      mockSheet({ type: 'UnreadablePage' }, bmdDisabledPage),
+      election
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
@@ -448,7 +462,8 @@ test('treats either page having vertical streaks as an invalid sheet', () => {
   };
   expect(
     combinePageInterpretationsForSheet(
-      mockSheet(verticalStreaksPage, { type: 'UnreadablePage' })
+      mockSheet(verticalStreaksPage, { type: 'UnreadablePage' }),
+      election
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
@@ -456,7 +471,8 @@ test('treats either page having vertical streaks as an invalid sheet', () => {
   });
   expect(
     combinePageInterpretationsForSheet(
-      mockSheet({ type: 'UnreadablePage' }, verticalStreaksPage)
+      mockSheet({ type: 'UnreadablePage' }, verticalStreaksPage),
+      election
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
@@ -467,7 +483,8 @@ test('treats either page having vertical streaks as an invalid sheet', () => {
 test('treats unreadable pages as an invalid sheet', () => {
   expect(
     combinePageInterpretationsForSheet(
-      mockSheet({ type: 'UnreadablePage' }, { type: 'UnreadablePage' })
+      mockSheet({ type: 'UnreadablePage' }, { type: 'UnreadablePage' }),
+      election
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
@@ -478,9 +495,98 @@ test('treats unreadable pages as an invalid sheet', () => {
 test('treats unmatched page combinations as unknown invalid sheet', () => {
   // Both blank doesn't match any specific case.
   expect(
-    combinePageInterpretationsForSheet(mockSheet(blankPage, blankPage))
+    combinePageInterpretationsForSheet(
+      mockSheet(blankPage, blankPage),
+      election
+    )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
     reason: 'unknown',
+  });
+});
+
+test('flags crossover voting in open primaries', () => {
+  const front = mockHmpbPage({
+    votes: {
+      'governor-democratic': [
+        { id: 'alice-jones', name: 'Alice Jones', partyIds: undefined },
+      ],
+    },
+  });
+  const back = mockHmpbPage({
+    votes: {
+      'governor-republican': [
+        { id: 'dave-wilson', name: 'Dave Wilson', partyIds: undefined },
+      ],
+    },
+  });
+  expect(
+    combinePageInterpretationsForSheet(
+      mockSheet(front, back),
+      openPrimaryElection
+    )
+  ).toEqual<SheetInterpretation>({
+    type: 'NeedsReviewSheet',
+    reasons: [{ type: AdjudicationReason.CrossoverVoting }],
+  });
+});
+
+test('combines crossover voting with other adjudication reasons', () => {
+  const overvoteReason: AdjudicationReasonInfo = {
+    type: AdjudicationReason.Overvote,
+    contestId: 'governor-democratic',
+    expected: 1,
+    optionIds: ['alice-jones', 'jane-smith'],
+  };
+  const front = mockHmpbPage({
+    requiresAdjudication: true,
+    enabledReasonInfos: [overvoteReason],
+    votes: {
+      'governor-democratic': [
+        { id: 'alice-jones', name: 'Alice Jones', partyIds: undefined },
+        { id: 'jane-smith', name: 'Jane Smith', partyIds: undefined },
+      ],
+    },
+  });
+  const back = mockHmpbPage({
+    votes: {
+      'governor-republican': [
+        { id: 'dave-wilson', name: 'Dave Wilson', partyIds: undefined },
+      ],
+    },
+  });
+  expect(
+    combinePageInterpretationsForSheet(
+      mockSheet(front, back),
+      openPrimaryElection
+    )
+  ).toEqual<SheetInterpretation>({
+    type: 'NeedsReviewSheet',
+    reasons: [overvoteReason, { type: AdjudicationReason.CrossoverVoting }],
+  });
+});
+
+test('treats single-party open primary voting as valid', () => {
+  const front = mockHmpbPage({
+    votes: {
+      'governor-democratic': [
+        { id: 'alice-jones', name: 'Alice Jones', partyIds: undefined },
+      ],
+    },
+  });
+  const back = mockHmpbPage({
+    votes: {
+      'secretary-of-state-democratic': [
+        { id: 'james-martin', name: 'James Martin', partyIds: undefined },
+      ],
+    },
+  });
+  expect(
+    combinePageInterpretationsForSheet(
+      mockSheet(front, back),
+      openPrimaryElection
+    )
+  ).toEqual<SheetInterpretation>({
+    type: 'ValidSheet',
   });
 });

--- a/apps/scan/backend/src/interpret.ts
+++ b/apps/scan/backend/src/interpret.ts
@@ -6,6 +6,7 @@ import { ok, Result } from '@votingworks/basics';
 import {
   AdjudicationReason,
   AdjudicationReasonInfo,
+  Election,
   InterpretedBmdMultiPagePage,
   InterpretedBmdPage,
   PageInterpretationWithFiles,
@@ -13,12 +14,13 @@ import {
   SheetInterpretationWithPages,
   SheetOf,
 } from '@votingworks/types';
-import { time } from '@votingworks/utils';
+import { hasCrossoverVote, time } from '@votingworks/utils';
 import { ImageData } from 'canvas';
 import { rootDebug } from './util/debug';
 
 export function combinePageInterpretationsForSheet(
-  pages: SheetOf<PageInterpretationWithFiles>
+  pages: SheetOf<PageInterpretationWithFiles>,
+  election: Election
 ): SheetInterpretation {
   const [front, back] = pages;
   const frontType = front.interpretation.type;
@@ -70,41 +72,49 @@ export function combinePageInterpretationsForSheet(
   ) {
     const frontAdjudication = front.interpretation.adjudicationInfo;
     const backAdjudication = back.interpretation.adjudicationInfo;
+    const reasons: AdjudicationReasonInfo[] = [];
 
     if (
-      !(
-        frontAdjudication.requiresAdjudication ||
-        backAdjudication.requiresAdjudication
-      )
+      frontAdjudication.requiresAdjudication ||
+      backAdjudication.requiresAdjudication
     ) {
-      return { type: 'ValidSheet' };
+      const frontReasons = frontAdjudication.enabledReasonInfos;
+      const backReasons = backAdjudication.enabledReasonInfos;
+
+      // If both sides are blank, the ballot is blank
+      if (
+        (frontReasons.some(
+          (reason) => reason.type === AdjudicationReason.BlankBallot
+        ) ||
+          front.interpretation.markInfo.marks.length === 0) &&
+        (backReasons.some(
+          (reason) => reason.type === AdjudicationReason.BlankBallot
+        ) ||
+          back.interpretation.markInfo.marks.length === 0)
+      ) {
+        reasons.push({ type: AdjudicationReason.BlankBallot });
+      }
+      // Otherwise, we can ignore blank sides
+      else {
+        reasons.push(
+          ...[...frontReasons, ...backReasons].filter(
+            (reason) => reason.type !== AdjudicationReason.BlankBallot
+          )
+        );
+      }
     }
 
-    const frontReasons = frontAdjudication.enabledReasonInfos;
-    const backReasons = backAdjudication.enabledReasonInfos;
-
-    let reasons: AdjudicationReasonInfo[];
-    // If both sides are blank, the ballot is blank
+    // Crossover voting always triggers review in open primaries; it is not
+    // gated on the configured adjudicationReasons.
     if (
-      (frontReasons.some(
-        (reason) => reason.type === AdjudicationReason.BlankBallot
-      ) ||
-        front.interpretation.markInfo.marks.length === 0) &&
-      (backReasons.some(
-        (reason) => reason.type === AdjudicationReason.BlankBallot
-      ) ||
-        back.interpretation.markInfo.marks.length === 0)
+      hasCrossoverVote(election, {
+        ...front.interpretation.votes,
+        ...back.interpretation.votes,
+      })
     ) {
-      reasons = [{ type: AdjudicationReason.BlankBallot }];
-    }
-    // Otherwise, we can ignore blank sides
-    else {
-      reasons = [...frontReasons, ...backReasons].filter(
-        (reason) => reason.type !== AdjudicationReason.BlankBallot
-      );
+      reasons.push({ type: AdjudicationReason.CrossoverVoting });
     }
 
-    // If there are any non-blank reasons, they should be reviewed
     if (reasons.length > 0) {
       return {
         type: 'NeedsReviewSheet',
@@ -210,7 +220,10 @@ export async function interpret(
   timer.end();
 
   return ok({
-    ...combinePageInterpretationsForSheet(pageInterpretations),
+    ...combinePageInterpretationsForSheet(
+      pageInterpretations,
+      options.electionDefinition.election
+    ),
     pages: pageInterpretations,
   });
 }

--- a/apps/scan/backend/vitest.config.ts
+++ b/apps/scan/backend/vitest.config.ts
@@ -10,8 +10,8 @@ export default defineConfig({
     ],
     coverage: {
       thresholds: {
-        lines: -50,
-        branches: -50,
+        lines: -38,
+        branches: -38,
       },
       exclude: [
         '**/node_modules/**',

--- a/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
@@ -150,6 +150,36 @@ test('overvote when casting overvotes is disallowed', async () => {
   userEvent.click(screen.getByRole('button', { name: 'Return Ballot' }));
 });
 
+test('crossover voting (cast ballot)', async () => {
+  apiMock.mockApiClient.acceptBallot.expectCallWith().resolves();
+  renderScreen({
+    adjudicationReasonInfo: [{ type: AdjudicationReason.CrossoverVoting }],
+  });
+
+  await screen.findByRole('heading', { name: 'Review Your Ballot' });
+  screen.getByText(
+    'You voted in contests for more than one party. ' +
+      'If you cast this ballot, only your nonpartisan votes will count.'
+  );
+  const castBallotButton = screen.getButton('Cast Ballot');
+  const returnBallotButton = screen.getButton('Return Ballot');
+  expect(isButtonVariantPrimary(returnBallotButton)).toEqual(true);
+  expect(isButtonVariantPrimary(castBallotButton)).toEqual(false);
+  userEvent.click(castBallotButton);
+  expect(castBallotButton).toBeDisabled();
+  expect(returnBallotButton).toBeDisabled();
+});
+
+test('crossover voting (return ballot)', async () => {
+  apiMock.mockApiClient.returnBallot.expectCallWith().resolves();
+  renderScreen({
+    adjudicationReasonInfo: [{ type: AdjudicationReason.CrossoverVoting }],
+  });
+
+  await screen.findByRole('heading', { name: 'Review Your Ballot' });
+  userEvent.click(screen.getByRole('button', { name: 'Return Ballot' }));
+});
+
 test('blank ballot', async () => {
   apiMock.mockApiClient.acceptBallot.expectCallWith().resolves();
   renderScreen({

--- a/apps/scan/frontend/src/screens/scan_warning_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.tsx
@@ -207,6 +207,66 @@ function BlankBallotWarningScreen({
   );
 }
 
+interface CrossoverVotingWarningScreenProps {
+  isTestMode: boolean;
+  isEarlyVotingMode: boolean;
+}
+
+function CrossoverVotingWarningScreen({
+  isTestMode,
+  isEarlyVotingMode,
+}: CrossoverVotingWarningScreenProps): JSX.Element {
+  const returnBallotMutation = returnBallot.useMutation();
+  const acceptBallotMutation = acceptBallot.useMutation();
+  const [hasCastBallot, setHasCastBallot] = React.useState(false);
+
+  function onCastBallot() {
+    setHasCastBallot(true);
+    acceptBallotMutation.mutate();
+  }
+
+  return (
+    <Screen
+      actionButtons={
+        <React.Fragment>
+          <Button
+            id={PageNavigationButtonId.PREVIOUS_AFTER_CONFIRM}
+            variant="primary"
+            onPress={() => returnBallotMutation.mutate()}
+            disabled={hasCastBallot}
+          >
+            {appStrings.buttonReturnBallot()}
+          </Button>
+          <Button
+            id={PageNavigationButtonId.NEXT_AFTER_CONFIRM}
+            onPress={onCastBallot}
+            disabled={hasCastBallot}
+          >
+            {appStrings.buttonCastBallot()}
+          </Button>
+        </React.Fragment>
+      }
+      centerContent
+      padded
+      voterFacing
+      showTestModeBanner={isTestMode}
+      showEarlyVotingBanner={isEarlyVotingMode}
+    >
+      <FullScreenPromptLayout
+        title={appStrings.titleScannerBallotWarningsScreen()}
+        image={
+          <FullScreenIconWrapper>
+            <Icons.Warning color="warning" />
+          </FullScreenIconWrapper>
+        }
+      >
+        <P>{appStrings.warningScannerCrossoverVoting()}</P>
+        <Caption>{appStrings.noteAskPollWorkerForHelp()}</Caption>
+      </FullScreenPromptLayout>
+    </Screen>
+  );
+}
+
 interface OtherReasonWarningScreenProps {
   isTestMode: boolean;
   isEarlyVotingMode: boolean;
@@ -283,17 +343,29 @@ export function ScanWarningScreen({
   isEarlyVotingMode,
 }: Props): JSX.Element {
   let isBlank = false;
+  let isCrossover = false;
   const overvoteReasons: OvervoteAdjudicationReasonInfo[] = [];
   const undervoteReasons: UndervoteAdjudicationReasonInfo[] = [];
 
   for (const reason of adjudicationReasonInfo) {
     if (reason.type === AdjudicationReason.BlankBallot) {
       isBlank = true;
+    } else if (reason.type === AdjudicationReason.CrossoverVoting) {
+      isCrossover = true;
     } else if (reason.type === AdjudicationReason.Overvote) {
       overvoteReasons.push(reason);
     } else if (reason.type === AdjudicationReason.Undervote) {
       undervoteReasons.push(reason);
     }
+  }
+
+  if (isCrossover) {
+    return (
+      <CrossoverVotingWarningScreen
+        isTestMode={isTestMode}
+        isEarlyVotingMode={isEarlyVotingMode}
+      />
+    );
   }
 
   if (isBlank) {
@@ -501,6 +573,26 @@ export function MixedOvervotesAndUndervotesPreview(): JSX.Element {
           expected: c.seats,
         })),
       ]}
+      isTestMode={false}
+      isEarlyVotingMode={false}
+    />
+  );
+}
+
+/* istanbul ignore next - @preserve */
+export function CrossoverVotingPreview(): JSX.Element {
+  const configQuery = getConfig.useQuery();
+  const electionDefinition = configQuery.data?.electionDefinition;
+
+  if (!electionDefinition) {
+    return <P>Loading…</P>;
+  }
+
+  return (
+    <ScanWarningScreen
+      electionDefinition={electionDefinition}
+      systemSettings={DEFAULT_SYSTEM_SETTINGS}
+      adjudicationReasonInfo={[{ type: AdjudicationReason.CrossoverVoting }]}
       isTestMode={false}
       isEarlyVotingMode={false}
     />

--- a/libs/ballot-interpreter/src/adjudication_reasons.test.ts
+++ b/libs/ballot-interpreter/src/adjudication_reasons.test.ts
@@ -12,10 +12,7 @@ import {
 import { readElectionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
 import { assert, find } from '@votingworks/basics';
 import { allContestOptions } from '@votingworks/utils';
-import {
-  getAllPossibleAdjudicationReasons,
-  adjudicationReasonDescription,
-} from './adjudication_reasons';
+import { getAllPossibleAdjudicationReasons } from './adjudication_reasons';
 
 const electionTwoPartyPrimaryDefinition =
   readElectionTwoPartyPrimaryDefinition();
@@ -110,10 +107,6 @@ test('a ballot with marginal marks', () => {
       optionId: bestAnimalMammalCandidate2.id,
     },
   ]);
-
-  expect(reasons.map(adjudicationReasonDescription)).toEqual([
-    "Contest 'best-animal-mammal' has a marginal mark for option 'otter'.",
-  ]);
 });
 
 test('a ballot with no marks', () => {
@@ -133,11 +126,6 @@ test('a ballot with no marks', () => {
     {
       type: AdjudicationReason.BlankBallot,
     },
-  ]);
-
-  expect(reasons.map(adjudicationReasonDescription)).toEqual([
-    "Contest 'best-animal-mammal' is undervoted, expected 1 but got none.",
-    'Ballot has no votes.',
   ]);
 });
 
@@ -165,10 +153,6 @@ test('a ballot with too many marks', () => {
       optionIds: [bestAnimalMammalCandidate1.id, bestAnimalMammalCandidate2.id],
       expected: 1,
     },
-  ]);
-
-  expect(reasons.map(adjudicationReasonDescription)).toEqual([
-    "Contest 'best-animal-mammal' is overvoted, expected 1 but got 2: 'horse', 'otter'.",
   ]);
 });
 
@@ -213,12 +197,6 @@ test('multiple contests with issues', () => {
       expected: 3,
     },
   ]);
-
-  expect(reasons.map(adjudicationReasonDescription)).toEqual([
-    "Contest 'best-animal-mammal' has a marginal mark for option 'horse'.",
-    "Contest 'best-animal-mammal' is undervoted, expected 1 but got none.",
-    "Contest 'zoo-council-mammal' is overvoted, expected 3 but got 4: 'zebra', 'lion', 'kangaroo', 'elephant'.",
-  ]);
 });
 
 test('yesno contest overvotes', () => {
@@ -238,10 +216,6 @@ test('yesno contest overvotes', () => {
       optionIds: [ballotMeasure3.yesOption.id, ballotMeasure3.noOption.id],
       expected: 1,
     },
-  ]);
-
-  expect(reasons.map(adjudicationReasonDescription)).toEqual([
-    "Contest 'fishing' is overvoted, expected 1 but got 2: 'ban-fishing', 'allow-fishing'.",
   ]);
 });
 

--- a/libs/ballot-interpreter/src/adjudication_reasons.ts
+++ b/libs/ballot-interpreter/src/adjudication_reasons.ts
@@ -5,7 +5,6 @@ import {
   BallotStyle,
   CandidateVote,
   ContestOption,
-  ContestOptionId,
   Contests,
   MarkStatus,
   VotesDict,
@@ -226,36 +225,4 @@ export function getAllPossibleAdjudicationReasons(
   }
 
   return reasons;
-}
-
-function optionIdsAsSentence(optionIds: readonly ContestOptionId[]) {
-  return optionIds.length
-    ? `${optionIds.length}: ${optionIds.map((id) => `'${id}'`).join(', ')}`
-    : 'none';
-}
-
-export function adjudicationReasonDescription(
-  reason: AdjudicationReasonInfo
-): string {
-  switch (reason.type) {
-    case AdjudicationReason.MarginalMark:
-      return `Contest '${reason.contestId}' has a marginal mark for option '${reason.optionId}'.`;
-
-    case AdjudicationReason.Overvote:
-      return `Contest '${reason.contestId}' is overvoted, expected ${
-        reason.expected
-      } but got ${optionIdsAsSentence(reason.optionIds)}.`;
-
-    case AdjudicationReason.Undervote:
-      return `Contest '${reason.contestId}' is undervoted, expected ${
-        reason.expected
-      } but got ${optionIdsAsSentence(reason.optionIds)}.`;
-
-    case AdjudicationReason.BlankBallot:
-      return `Ballot has no votes.`;
-
-    // istanbul ignore next
-    default:
-      throwIllegalValue(reason);
-  }
 }

--- a/libs/types/src/__snapshots__/system_settings.test.ts.snap
+++ b/libs/types/src/__snapshots__/system_settings.test.ts.snap
@@ -34,13 +34,14 @@ exports[`disallows invalid adjudication reasons 1`] = `
       "Overvote",
       "Undervote",
       "BlankBallot",
-      "UnmarkedWriteIn"
+      "UnmarkedWriteIn",
+      "CrossoverVoting"
     ],
     "path": [
       "adminAdjudicationReasons",
       0
     ],
-    "message": "Invalid option: expected one of \\"UninterpretableBallot\\"|\\"MarginalMark\\"|\\"Overvote\\"|\\"Undervote\\"|\\"BlankBallot\\"|\\"UnmarkedWriteIn\\""
+    "message": "Invalid option: expected one of \\"UninterpretableBallot\\"|\\"MarginalMark\\"|\\"Overvote\\"|\\"Undervote\\"|\\"BlankBallot\\"|\\"UnmarkedWriteIn\\"|\\"CrossoverVoting\\""
   },
   {
     "code": "invalid_value",
@@ -50,13 +51,14 @@ exports[`disallows invalid adjudication reasons 1`] = `
       "Overvote",
       "Undervote",
       "BlankBallot",
-      "UnmarkedWriteIn"
+      "UnmarkedWriteIn",
+      "CrossoverVoting"
     ],
     "path": [
       "centralScanAdjudicationReasons",
       0
     ],
-    "message": "Invalid option: expected one of \\"UninterpretableBallot\\"|\\"MarginalMark\\"|\\"Overvote\\"|\\"Undervote\\"|\\"BlankBallot\\"|\\"UnmarkedWriteIn\\""
+    "message": "Invalid option: expected one of \\"UninterpretableBallot\\"|\\"MarginalMark\\"|\\"Overvote\\"|\\"Undervote\\"|\\"BlankBallot\\"|\\"UnmarkedWriteIn\\"|\\"CrossoverVoting\\""
   },
   {
     "code": "invalid_value",
@@ -66,13 +68,14 @@ exports[`disallows invalid adjudication reasons 1`] = `
       "Overvote",
       "Undervote",
       "BlankBallot",
-      "UnmarkedWriteIn"
+      "UnmarkedWriteIn",
+      "CrossoverVoting"
     ],
     "path": [
       "precinctScanAdjudicationReasons",
       0
     ],
-    "message": "Invalid option: expected one of \\"UninterpretableBallot\\"|\\"MarginalMark\\"|\\"Overvote\\"|\\"Undervote\\"|\\"BlankBallot\\"|\\"UnmarkedWriteIn\\""
+    "message": "Invalid option: expected one of \\"UninterpretableBallot\\"|\\"MarginalMark\\"|\\"Overvote\\"|\\"Undervote\\"|\\"BlankBallot\\"|\\"UnmarkedWriteIn\\"|\\"CrossoverVoting\\""
   }
 ]]
 `;

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -7,7 +7,6 @@ import {
 import { sha256 } from 'js-sha256';
 import { z } from 'zod/v4';
 import {
-  Dictionary,
   Sha256Hash,
   Id,
   IdSchema,
@@ -1123,7 +1122,7 @@ export const VoteSchema: z.ZodSchema<Vote> = z.union([
 export type OptionalVote = Optional<Vote>;
 export const OptionalVoteSchema: z.ZodSchema<OptionalVote> =
   VoteSchema.optional();
-export type VotesDict = Dictionary<Vote>;
+export type VotesDict = Record<ContestId, Optional<Vote>>;
 export const VotesDictSchema: z.ZodSchema<VotesDict> = z.record(
   z.string(),
   VoteSchema

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -540,6 +540,7 @@ export enum AdjudicationReason {
   Undervote = 'Undervote',
   BlankBallot = 'BlankBallot',
   UnmarkedWriteIn = 'UnmarkedWriteIn',
+  CrossoverVoting = 'CrossoverVoting',
 }
 export const AdjudicationReasonSchema: z.ZodSchema<AdjudicationReason> =
   z.enum(AdjudicationReason);
@@ -1176,17 +1177,27 @@ export const BlankBallotAdjudicationReasonInfoSchema: z.ZodSchema<BlankBallotAdj
     type: z.literal(AdjudicationReason.BlankBallot),
   });
 
+export interface CrossoverVotingAdjudicationReasonInfo {
+  type: AdjudicationReason.CrossoverVoting;
+}
+export const CrossoverVotingAdjudicationReasonInfoSchema: z.ZodSchema<CrossoverVotingAdjudicationReasonInfo> =
+  z.object({
+    type: z.literal(AdjudicationReason.CrossoverVoting),
+  });
+
 export type AdjudicationReasonInfo =
   | MarginalMarkAdjudicationReasonInfo
   | OvervoteAdjudicationReasonInfo
   | UndervoteAdjudicationReasonInfo
-  | BlankBallotAdjudicationReasonInfo;
+  | BlankBallotAdjudicationReasonInfo
+  | CrossoverVotingAdjudicationReasonInfo;
 export const AdjudicationReasonInfoSchema: z.ZodSchema<AdjudicationReasonInfo> =
   z.union([
     MarginalMarkAdjudicationReasonInfoSchema,
     OvervoteAdjudicationReasonInfoSchema,
     UndervoteAdjudicationReasonInfoSchema,
     BlankBallotAdjudicationReasonInfoSchema,
+    CrossoverVotingAdjudicationReasonInfoSchema,
   ]);
 
 export type BallotId = string;

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -1775,6 +1775,13 @@ export const appStrings = {
     </UiString>
   ),
 
+  warningScannerCrossoverVoting: () => (
+    <UiString uiStringKey="warningScannerCrossoverVoting">
+      You voted in contests for more than one party. If you cast this ballot,
+      only your nonpartisan votes will count.
+    </UiString>
+  ),
+
   warningScannerNoVotesFound: () => (
     <UiString uiStringKey="warningScannerNoVotesFound">
       No votes were found when scanning this ballot.

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -523,6 +523,7 @@
   "warningScannerAnotherScanInProgress": "Another ballot is being scanned.",
   "warningScannerBlankBallotSubmission": "No votes will be counted from this ballot.",
   "warningScannerBmdBallotScanningDisabled": "The scanner cannot scan BMD ballots. Use a central scanner instead.",
+  "warningScannerCrossoverVoting": "You voted in contests for more than one party. If you cast this ballot, only your nonpartisan votes will count.",
   "warningScannerMismatchedElection": "The scanner is configured for an election that does not match the ballot.",
   "warningScannerMismatchedPrecinct": "The scanner is configured for a precinct that does not match the ballot.",
   "warningScannerNeedsCleaning": "The ballot was not counted. Scan it again after cleaning.",

--- a/libs/utils/src/tabulation/open_primary.ts
+++ b/libs/utils/src/tabulation/open_primary.ts
@@ -3,7 +3,7 @@ import {
   CandidateContest,
   Election,
   PartyId,
-  Tabulation,
+  VotesDict,
   isOpenPrimary,
 } from '@votingworks/types';
 
@@ -24,10 +24,7 @@ export const partisanContests = memoizeByObject(
 /**
  * Returns the party IDs of the partisan contests a voter voted in.
  */
-export function votedPartyIds(
-  election: Election,
-  votes: Tabulation.Votes
-): PartyId[] {
+export function votedPartyIds(election: Election, votes: VotesDict): PartyId[] {
   return unique(
     partisanContests(election)
       .filter((contest) => (votes[contest.id]?.length ?? 0) > 0)
@@ -41,7 +38,7 @@ export function votedPartyIds(
  */
 export function hasCrossoverVote(
   election: Election,
-  votes: Tabulation.Votes
+  votes: VotesDict
 ): boolean {
   // Short circuit to avoid doing extra work if it's not an open primary, even
   // though crossover votes aren't possible in general elections/closed primaries.


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

This PR adds crossover voting detection to VxScan. When a voter scans a ballot with crossover votes, they are shown a warning screen and can return the ballot to fix it or cast it anyway (the usual flow).

## Demo Video or Screenshot


https://github.com/user-attachments/assets/d3c080fb-1895-4f05-97ae-b9bc041f03b5



## Testing Plan

- Updated automated tests
- Manual test, including audio

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
