### PR TITLE
VxDesign: Remove voting type from live reports payload

### DIFF
--- a/apps/admin/backend/src/live_results_reporting.ts
+++ b/apps/admin/backend/src/live_results_reporting.ts
@@ -129,7 +129,6 @@ export async function generateAdminLiveResultsReportingUrls({
     pollingPlaceId,
     resultsByPrecinct,
     pollsTransitionType: 'close_polls',
-    votingType: 'absentee',
     pollsTransitionTimestamp,
   });
 }

--- a/apps/design/backend/src/app.results.test.ts
+++ b/apps/design/backend/src/app.results.test.ts
@@ -209,7 +209,6 @@ test('processQRCodeReport handles invalid payloads as expected', async () => {
       pageIndex: 0,
       pollingPlaceId: 'test-polling-place',
       ballotCount: 0,
-      votingType: 'election_day',
     })}`, // Bad data
   ];
   for (const payload of invalidPayloads) {
@@ -251,7 +250,6 @@ test('processQRCodeReport returns "invalid-signature" when authenticating the si
       pageIndex: 0,
       pollingPlaceId: 'test-polling-place',
       ballotCount: 0,
-      votingType: 'election_day',
     })}`,
     signature: 'test-signature',
     certificate: 'test-certificate',
@@ -284,7 +282,6 @@ test('processQRCodeReport returns no election found where there is no election f
       pageIndex: 0,
       pollingPlaceId: 'test-polling-place',
       ballotCount: 0,
-      votingType: 'election_day',
     })}`,
     signature: 'test-signature',
     certificate: 'test-certificate',
@@ -339,7 +336,6 @@ test('quick results reporting works e2e with all precinct reports', async () => 
       pageIndex: 0,
       pollingPlaceId: 'test-polling-place',
       ballotCount: 0,
-      votingType: 'election_day',
     })}`,
     signature: 'test-signature',
     certificate: 'test-certificate',
@@ -420,7 +416,6 @@ test('quick results reporting works e2e with all precinct reports', async () => 
       pageIndex: 0,
       pollingPlaceId: 'test-polling-place',
       ballotCount: 0,
-      votingType: 'election_day',
     })}`,
     signature: 'test-signature',
     certificate: 'test-certificate',
@@ -464,7 +459,6 @@ test('quick results reporting works e2e with all precinct reports', async () => 
       pageIndex: 0,
       pollingPlaceId: 'test-polling-place',
       ballotCount: 0,
-      votingType: 'election_day',
     })}`,
     signature: 'test-signature',
     certificate: 'test-certificate',
@@ -603,7 +597,6 @@ test('quick results reporting works e2e with all precinct reports', async () => 
       pageIndex: 0,
       pollingPlaceId: 'test-polling-place',
       ballotCount: 0,
-      votingType: 'election_day',
     })}`,
     signature: 'test-signature',
     certificate: 'test-certificate',
@@ -664,7 +657,6 @@ test('quick results reporting works for polls open reporting', async () => {
       pageIndex: 0,
       pollingPlaceId: 'test-polling-place',
       ballotCount: 0,
-      votingType: 'election_day',
     })}`,
     signature: 'test-signature',
     certificate: 'test-certificate',
@@ -680,7 +672,6 @@ test('quick results reporting works for polls open reporting', async () => {
         isLive: false,
         isPartial: false,
         ballotCount: 0,
-        votingType: 'election_day',
       })
     )
   );
@@ -697,7 +688,6 @@ test('quick results reporting works for polls open reporting', async () => {
         numPages: 1,
         pageIndex: 0,
         ballotCount: 0,
-        votingType: 'election_day',
       })}`,
       signature: 'test-signature',
       certificate: 'test-certificate',
@@ -800,7 +790,6 @@ test('quick results reporting works for polls open reporting', async () => {
       pageIndex: 0,
       pollingPlaceId: 'test-polling-place',
       ballotCount: 0,
-      votingType: 'election_day',
     })}`,
     signature: 'test-signature',
     certificate: 'test-certificate',
@@ -874,7 +863,6 @@ test('quick results reporting works for polls open reporting', async () => {
         pageIndex: 0,
         pollingPlaceId: 'test-polling-place',
         ballotCount: 0,
-        votingType: 'election_day',
       })}`,
       signature: 'test-signature',
       certificate: 'test-certificate',
@@ -895,7 +883,6 @@ test('quick results reporting works for polls open reporting', async () => {
       }),
       isPartial: false,
       ballotCount: 0,
-      votingType: 'election_day',
     })
   );
 
@@ -974,7 +961,6 @@ test('quick results reporting works for polls paused reporting', async () => {
       numPages: 1,
       pageIndex: 0,
       ballotCount: 0,
-      votingType: 'election_day',
     })}`,
     signature: 'test-signature',
     certificate: 'test-certificate',
@@ -1049,7 +1035,6 @@ test('quick results reporting works for voting resumed reporting', async () => {
       numPages: 1,
       pageIndex: 0,
       ballotCount: 50,
-      votingType: 'election_day',
     })}`,
     signature: 'test-signature',
     certificate: 'test-certificate',
@@ -1189,7 +1174,6 @@ test('quick results reporting works as expected end to end with single precinct 
         numPages: 1,
         pageIndex: 0,
         ballotCount: 0,
-        votingType: 'election_day',
       })}`,
       signature: 'test-signature',
       certificate: 'test-certificate',
@@ -1235,7 +1219,6 @@ test('quick results reporting works as expected end to end with single precinct 
         numPages: 1,
         pageIndex: 0,
         ballotCount: 0,
-        votingType: 'election_day',
       })}`,
       signature: 'test-signature',
       certificate: 'test-certificate',
@@ -1411,7 +1394,6 @@ test('deleteQuickReportingResults clears quick results data as expected', async 
       pageIndex: 0,
       pollingPlaceId: 'test-polling-place',
       ballotCount: 0,
-      votingType: 'election_day',
     })}`,
     signature: 'test-signature',
     certificate: 'test-certificate',
@@ -1454,7 +1436,6 @@ test('deleteQuickReportingResults clears quick results data as expected', async 
       pageIndex: 0,
       pollingPlaceId: 'test-polling-place',
       ballotCount: 0,
-      votingType: 'election_day',
     })}`,
     signature: 'test-signature',
     certificate: 'test-certificate',
@@ -1573,7 +1554,6 @@ test('quick results reporting supports paginated 2-page reports', async () => {
     pageIndex: 0,
     pollingPlaceId: 'test-polling-place',
     ballotCount: 0,
-    votingType: 'election_day',
   })}`;
 
   const r1 = await unauthenticatedApiClient.processQrCodeReport({
@@ -1624,7 +1604,6 @@ test('quick results reporting supports paginated 2-page reports', async () => {
     pageIndex: 1,
     pollingPlaceId: 'test-polling-place',
     ballotCount: 0,
-    votingType: 'election_day',
   })}`;
 
   auth0.logOut();
@@ -1659,7 +1638,6 @@ test('quick results reporting supports paginated 2-page reports', async () => {
         }),
       }),
       isPartial: false,
-      votingType: 'election_day',
     })
   );
 
@@ -1767,7 +1745,6 @@ test('quick results reporting clears previous partial reports on numPages change
     pageIndex: 0,
     pollingPlaceId: 'test-polling-place',
     ballotCount: 0,
-    votingType: 'election_day',
   })}`;
 
   const r1 = await unauthenticatedApiClient.processQrCodeReport({
@@ -1808,7 +1785,6 @@ test('quick results reporting clears previous partial reports on numPages change
     pageIndex: 1,
     pollingPlaceId: 'test-polling-place',
     ballotCount: 0,
-    votingType: 'election_day',
   })}`;
 
   const r2 = await unauthenticatedApiClient.processQrCodeReport({
@@ -1831,7 +1807,6 @@ test('quick results reporting clears previous partial reports on numPages change
       isLive: true,
       pollsTransitionTime: new Date('2024-01-01T12:00:01Z'),
       isPartial: true,
-      votingType: 'election_day',
     })
   );
 
@@ -1846,7 +1821,6 @@ test('quick results reporting clears previous partial reports on numPages change
     pageIndex: 2,
     pollingPlaceId: 'test-polling-place',
     ballotCount: 0,
-    votingType: 'election_day',
   })}`;
 
   const r3 = await unauthenticatedApiClient.processQrCodeReport({
@@ -1869,7 +1843,6 @@ test('quick results reporting clears previous partial reports on numPages change
       isLive: true,
       pollsTransitionTime: new Date('2024-01-01T12:00:02Z'),
       isPartial: true,
-      votingType: 'election_day',
     })
   );
 
@@ -1883,7 +1856,6 @@ test('quick results reporting clears previous partial reports on numPages change
     pageIndex: 0,
     pollingPlaceId: 'test-polling-place',
     ballotCount: 0,
-    votingType: 'election_day',
   })}`;
 
   expect(newPayloadPage1).not.toEqual(payloadPage1);
@@ -1913,7 +1885,6 @@ test('quick results reporting clears previous partial reports on numPages change
         ),
       },
       isPartial: false,
-      votingType: 'election_day',
     })
   );
 });
@@ -1966,7 +1937,6 @@ test('quick results clears previous partial reports when pollingPlaceId changes'
     numPages: 2,
     pageIndex: 0,
     ballotCount: 0,
-    votingType: 'election_day',
   })}`;
 
   const rA1 = await unauthenticatedApiClient.processQrCodeReport({
@@ -1978,7 +1948,6 @@ test('quick results clears previous partial reports when pollingPlaceId changes'
     ok(
       expect.objectContaining({
         isPartial: true,
-        votingType: 'election_day',
       })
     )
   );
@@ -2000,7 +1969,6 @@ test('quick results clears previous partial reports when pollingPlaceId changes'
     numPages: 2,
     pageIndex: 0,
     ballotCount: 0,
-    votingType: 'election_day',
   })}`;
 
   const rB1 = await unauthenticatedApiClient.processQrCodeReport({
@@ -2012,7 +1980,6 @@ test('quick results clears previous partial reports when pollingPlaceId changes'
     ok(
       expect.objectContaining({
         isPartial: true,
-        votingType: 'election_day',
       })
     )
   );
@@ -2028,7 +1995,6 @@ test('quick results clears previous partial reports when pollingPlaceId changes'
     pageIndex: 1,
     pollingPlaceId: 'test-polling-place',
     ballotCount: 0,
-    votingType: 'election_day',
   })}`;
 
   const rC1 = await unauthenticatedApiClient.processQrCodeReport({
@@ -2040,7 +2006,6 @@ test('quick results clears previous partial reports when pollingPlaceId changes'
     ok(
       expect.objectContaining({
         isPartial: true,
-        votingType: 'election_day',
       })
     )
   );
@@ -2055,7 +2020,6 @@ test('quick results clears previous partial reports when pollingPlaceId changes'
     ok(
       expect.objectContaining({
         isPartial: true,
-        votingType: 'election_day',
       })
     )
   );
@@ -2071,7 +2035,6 @@ test('quick results clears previous partial reports when pollingPlaceId changes'
     numPages: 2,
     pageIndex: 1,
     ballotCount: 0,
-    votingType: 'election_day',
   })}`;
 
   const rA2 = await unauthenticatedApiClient.processQrCodeReport({
@@ -2091,7 +2054,6 @@ test('quick results clears previous partial reports when pollingPlaceId changes'
             precinctA
           ),
         }),
-        votingType: 'election_day',
       })
     )
   );
@@ -2225,7 +2187,6 @@ test('LiveReports uses modified exported election, not original vxdesign electio
       pageIndex: 0,
       pollingPlaceId: 'test-polling-place',
       ballotCount: 0,
-      votingType: 'election_day',
     })}`,
     signature: 'test-signature',
     certificate: 'test-certificate',
@@ -2305,7 +2266,6 @@ async function sendTransitionReport(
       pageIndex: 0,
       pollingPlaceId,
       ballotCount,
-      votingType: 'election_day',
     })}`,
     signature: 'test-signature',
     certificate: 'test-certificate',

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -1289,7 +1289,6 @@ export function buildUnauthenticatedApi({ logger, workspace }: AppContext) {
           ballotCount,
           numPages,
           pageIndex,
-          votingType,
         } = decodeQuickResultsMessage(payload);
 
         const signedTimestamp = pollsTransitionTime;
@@ -1376,7 +1375,6 @@ export function buildUnauthenticatedApi({ logger, workspace }: AppContext) {
               numPages,
               pageIndex,
               isPartial: true,
-              votingType,
             });
           }
           // It should be impossible to have more than numPages partials
@@ -1428,7 +1426,6 @@ export function buildUnauthenticatedApi({ logger, workspace }: AppContext) {
             pollingPlaceId,
             election,
             isPartial: false,
-            votingType,
           });
         }
 
@@ -1467,7 +1464,6 @@ export function buildUnauthenticatedApi({ logger, workspace }: AppContext) {
               pollingPlaceId,
               election,
               isPartial: false,
-              votingType,
             });
           }
           case 'open_polls':
@@ -1494,7 +1490,6 @@ export function buildUnauthenticatedApi({ logger, workspace }: AppContext) {
               election,
               isPartial: false,
               ballotCount,
-              votingType,
             });
           }
           /* istanbul ignore next - @preserve */

--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -3,7 +3,6 @@ import {
   ElectionId,
   Election,
   ContestId,
-  LiveReportVotingType,
   PrecinctId,
   PollsTransitionType,
   ElectionTypeV4p1,
@@ -114,7 +113,6 @@ export interface ReceivedReportInfoBase {
   pollsTransitionTime: Date;
   election: Election;
   pollingPlaceId: string;
-  votingType: LiveReportVotingType;
 }
 
 export interface ReceivedPollsOpenReportInfo extends ReceivedReportInfoBase {

--- a/apps/design/frontend/src/reporting_results_confirmation_screen.test.tsx
+++ b/apps/design/frontend/src/reporting_results_confirmation_screen.test.tsx
@@ -18,6 +18,26 @@ const electionRecord = generalElectionRecord('test-jurisdiction');
 const { election } = electionRecord;
 const generalPollingPlaceId = assertDefined(election.pollingPlaces?.[0]).id;
 
+// Election with the first polling place re-typed as `absentee`, used to verify
+// that the close-polls confirmation screen titles itself "Tally Report" when
+// the polling place is absentee.
+const absenteeElection: Election = {
+  ...election,
+  pollingPlaces: assertDefined(election.pollingPlaces).map(
+    (p, i): PollingPlace => (i === 0 ? { ...p, type: 'absentee' } : p)
+  ),
+};
+
+// Election with the first polling place re-typed as `early_voting`, used to
+// verify that the voting-type label renders "Early Voting" for an early-voting
+// polling place.
+const earlyVotingElection: Election = {
+  ...election,
+  pollingPlaces: assertDefined(election.pollingPlaces).map(
+    (p, i): PollingPlace => (i === 0 ? { ...p, type: 'early_voting' } : p)
+  ),
+};
+
 let apiMock: MockUnauthenticatedApiClient;
 
 // Mock window.location.search
@@ -47,7 +67,6 @@ const mockPollsOpenReport: ReceivedReportInfo = {
 
   isPartial: false,
   ballotCount: 42,
-  votingType: 'election_day',
 };
 
 const mockPollsPausedReport: ReceivedReportInfo = {
@@ -56,12 +75,11 @@ const mockPollsPausedReport: ReceivedReportInfo = {
   machineId: 'VxScan-001',
   isLive: true,
   pollsTransitionTime: new Date('2024-11-05T12:00:00Z'),
-  election,
+  election: earlyVotingElection,
   pollingPlaceId: generalPollingPlaceId,
 
   isPartial: false,
   ballotCount: 108,
-  votingType: 'early_voting',
 };
 
 const mockVotingResumedReport: ReceivedReportInfo = {
@@ -75,7 +93,6 @@ const mockVotingResumedReport: ReceivedReportInfo = {
 
   isPartial: false,
   ballotCount: 150,
-  votingType: 'election_day',
 };
 
 const mockPollsClosedReportGeneral: ReceivedReportInfo = {
@@ -99,7 +116,6 @@ const mockPollsClosedReportGeneral: ReceivedReportInfo = {
     }).contestResults,
   },
   isPartial: false,
-  votingType: 'election_day',
 };
 
 const mockPollsClosedPartialReportGeneral: ReceivedReportInfo = {
@@ -114,7 +130,6 @@ const mockPollsClosedPartialReportGeneral: ReceivedReportInfo = {
   isPartial: true,
   numPages: 4,
   pageIndex: 1,
-  votingType: 'election_day',
 };
 
 const primaryElection = electionPrimaryPrecinctSplitsFixtures.readElection();
@@ -142,7 +157,6 @@ const mockPollsClosedReportPrimary: ReceivedReportInfo = {
     }).contestResults,
   },
   isPartial: false,
-  votingType: 'election_day',
 };
 
 beforeEach(() => {
@@ -453,7 +467,7 @@ describe('ReportingResultsConfirmationScreen with proper parameters', () => {
       .resolves(
         ok({
           ...mockPollsClosedReportGeneral,
-          votingType: 'absentee',
+          election: absenteeElection,
         })
       );
     render(
@@ -464,6 +478,8 @@ describe('ReportingResultsConfirmationScreen with proper parameters', () => {
       screen.getByRole('heading', { name: 'Tally Report Sent' });
       screen.getByText('The tally report has been sent to VxDesign.');
     });
+
+    screen.getByText('Absentee');
 
     expect(
       screen.queryByRole('heading', { name: 'Polls Closed Report Sent' })
@@ -480,7 +496,7 @@ describe('ReportingResultsConfirmationScreen with proper parameters', () => {
       .resolves(
         ok({
           ...mockPollsClosedPartialReportGeneral,
-          votingType: 'absentee',
+          election: absenteeElection,
         })
       );
     render(
@@ -516,6 +532,7 @@ describe('ReportingResultsConfirmationScreen with proper parameters', () => {
 
     screen.getByText('VxScan-001');
     screen.getByText(/abc123d/);
+    screen.getByText('Election Day');
 
     // Precinct heading for the single precinct in this polling place
     screen.getByRole('heading', { name: 'Center Springfield' });
@@ -621,7 +638,6 @@ describe('ReportingResultsConfirmationScreen with proper parameters', () => {
         [election.precincts[1].id]: emptyContestResults,
       },
       isPartial: false,
-      votingType: 'election_day',
     };
 
     apiMock.processQrCodeReport

--- a/apps/design/frontend/src/reporting_results_confirmation_screen.tsx
+++ b/apps/design/frontend/src/reporting_results_confirmation_screen.tsx
@@ -22,6 +22,8 @@ import {
   PollsTransitionType,
   Tabulation,
   ContestId,
+  pollingPlaceFromElection,
+  pollingPlacePrecinctIds,
 } from '@votingworks/types';
 import {
   formatFullDateTimeZone,
@@ -31,7 +33,6 @@ import {
   groupContestsByParty,
   singlePrecinctSelectionFor,
 } from '@votingworks/utils';
-import { pollingPlacePrecinctIds } from '@votingworks/types';
 import styled from 'styled-components';
 import { processQrCodeReport } from './public_api';
 
@@ -98,8 +99,7 @@ interface ReportDetailsProps {
   machineId: string;
   pollsTransitionTime: Date;
   election: Election;
-  pollingPlaceId?: string;
-  votingType: LiveReportVotingType;
+  pollingPlaceId: string;
   pollsTransitionType: PollsTransitionType;
 }
 
@@ -109,7 +109,6 @@ function ReportDetails({
   pollsTransitionTime,
   election,
   pollingPlaceId,
-  votingType,
   pollsTransitionType,
 }: ReportDetailsProps): JSX.Element {
   const pollingPlace = election.pollingPlaces?.find(
@@ -141,10 +140,12 @@ function ReportDetails({
             label="Election ID"
             value={formatBallotHash(ballotHash)}
           />
-          <LabeledValue
-            label="Voting Type"
-            value={getVotingTypeLabel(votingType)}
-          />
+          {pollingPlace && (
+            <LabeledValue
+              label="Voting Type"
+              value={getVotingTypeLabel(pollingPlace.type)}
+            />
+          )}
         </ColumnSpan>
       </ReportMetadata>
     </div>
@@ -214,7 +215,6 @@ function PollsOpenReportConfirmation({
   pollsTransitionTime,
   election,
   pollingPlaceId,
-  votingType,
   pollsTransitionType,
   ballotCount,
 }: ReportDetailsProps & {
@@ -232,7 +232,6 @@ function PollsOpenReportConfirmation({
           pollsTransitionTime={pollsTransitionTime}
           election={election}
           pollingPlaceId={pollingPlaceId}
-          votingType={votingType}
           pollsTransitionType={pollsTransitionType}
         />
         {ballotCount !== undefined && (
@@ -254,7 +253,6 @@ function PollsPausedReportConfirmation({
   pollsTransitionTime,
   election,
   pollingPlaceId,
-  votingType,
   pollsTransitionType,
   ballotCount,
 }: ReportDetailsProps & {
@@ -272,7 +270,6 @@ function PollsPausedReportConfirmation({
           pollsTransitionTime={pollsTransitionTime}
           election={election}
           pollingPlaceId={pollingPlaceId}
-          votingType={votingType}
           pollsTransitionType={pollsTransitionType}
         />
         {ballotCount !== undefined && (
@@ -294,7 +291,6 @@ function VotingResumedReportConfirmation({
   pollsTransitionTime,
   election,
   pollingPlaceId,
-  votingType,
   pollsTransitionType,
   ballotCount,
 }: ReportDetailsProps & {
@@ -312,7 +308,6 @@ function VotingResumedReportConfirmation({
           pollsTransitionTime={pollsTransitionTime}
           election={election}
           pollingPlaceId={pollingPlaceId}
-          votingType={votingType}
           pollsTransitionType={pollsTransitionType}
         />
         {ballotCount !== undefined && (
@@ -334,7 +329,6 @@ function PollsClosedPartialReportConfirmation({
   pollsTransitionTime,
   election,
   pollingPlaceId,
-  votingType,
   pollsTransitionType,
   numPages,
   pageIndex,
@@ -343,6 +337,10 @@ function PollsClosedPartialReportConfirmation({
   numPages: number;
   pageIndex: number;
 }): JSX.Element {
+  const { type: votingType } = pollingPlaceFromElection(
+    election,
+    pollingPlaceId
+  );
   const reportTitle = getCloseReportTitle(votingType);
   return (
     <ResultsScreen
@@ -361,7 +359,6 @@ function PollsClosedPartialReportConfirmation({
           pollsTransitionTime={pollsTransitionTime}
           election={election}
           pollingPlaceId={pollingPlaceId}
-          votingType={votingType}
           pollsTransitionType={pollsTransitionType}
         />
       </MainContent>
@@ -432,7 +429,6 @@ function PollsClosedReportConfirmation({
   pollsTransitionTime,
   election,
   pollingPlaceId,
-  votingType,
   pollsTransitionType,
   contestResultsByPrecinct,
 }: ReportDetailsProps & {
@@ -442,11 +438,10 @@ function PollsClosedReportConfirmation({
   >;
   isLive: boolean;
 }): JSX.Element {
-  const reportTitle = getCloseReportTitle(votingType);
-
   const pollingPlace = assertDefined(
     election.pollingPlaces?.find((p) => p.id === pollingPlaceId)
   );
+  const reportTitle = getCloseReportTitle(pollingPlace.type);
   const placePrecinctIds = pollingPlacePrecinctIds(pollingPlace);
   const orderedPrecincts = election.precincts.filter((p) =>
     placePrecinctIds.has(p.id)
@@ -462,7 +457,6 @@ function PollsClosedReportConfirmation({
           pollsTransitionTime={pollsTransitionTime}
           election={election}
           pollingPlaceId={pollingPlaceId}
-          votingType={votingType}
           pollsTransitionType={pollsTransitionType}
         />
         {orderedPrecincts.map((precinct) => (
@@ -578,7 +572,6 @@ export function ReportingResultsConfirmationScreen(): JSX.Element | null {
           election={reportData.election}
           pollingPlaceId={reportData.pollingPlaceId}
           ballotCount={reportData.ballotCount}
-          votingType={reportData.votingType}
           pollsTransitionType={reportData.pollsTransitionType}
         />
       );
@@ -592,7 +585,6 @@ export function ReportingResultsConfirmationScreen(): JSX.Element | null {
           election={reportData.election}
           pollingPlaceId={reportData.pollingPlaceId}
           ballotCount={reportData.ballotCount}
-          votingType={reportData.votingType}
           pollsTransitionType={reportData.pollsTransitionType}
         />
       );
@@ -606,7 +598,6 @@ export function ReportingResultsConfirmationScreen(): JSX.Element | null {
           election={reportData.election}
           pollingPlaceId={reportData.pollingPlaceId}
           ballotCount={reportData.ballotCount}
-          votingType={reportData.votingType}
           pollsTransitionType={reportData.pollsTransitionType}
         />
       );
@@ -621,7 +612,6 @@ export function ReportingResultsConfirmationScreen(): JSX.Element | null {
             election={reportData.election}
             pollingPlaceId={reportData.pollingPlaceId}
             contestResultsByPrecinct={reportData.contestResultsByPrecinct}
-            votingType={reportData.votingType}
             pollsTransitionType={reportData.pollsTransitionType}
           />
         );
@@ -636,7 +626,6 @@ export function ReportingResultsConfirmationScreen(): JSX.Element | null {
           pollingPlaceId={reportData.pollingPlaceId}
           numPages={reportData.numPages}
           pageIndex={reportData.pageIndex}
-          votingType={reportData.votingType}
           pollsTransitionType={reportData.pollsTransitionType}
         />
       );

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -692,7 +692,6 @@ export function buildApi({
           pollingPlaceId,
           resultsByPrecinct,
           pollsTransitionType: lastPollsTransition.type,
-          votingType: store.getBallotCastingMode(),
           pollsTransitionTimestamp: lastPollsTransition.time,
         });
       return signedQuickResultsReportingUrls;

--- a/libs/auth/src/signed_quick_results_reporting.test.ts
+++ b/libs/auth/src/signed_quick_results_reporting.test.ts
@@ -74,7 +74,6 @@ test.each<{ isLiveMode: boolean }>([
           signingMachineId: DEV_MACHINE_ID,
           pollingPlaceId: 'mockPollingPlaceId',
           pollsTransitionType: 'close_polls',
-          votingType: 'election_day',
           pollsTransitionTimestamp: new Date('2024-11-05T20:00:00Z').getTime(),
         },
         vxScanTestConfig
@@ -108,7 +107,6 @@ test.each<{ isLiveMode: boolean }>([
           signingMachineId: DEV_MACHINE_ID,
           pollingPlaceId: 'mockPollingPlaceId',
           pollsTransitionType: 'close_polls',
-          votingType: 'election_day',
           pollsTransitionTimestamp: new Date('2024-11-05T20:00:00Z').getTime(),
           maxQrCodeLength: 1000, // Force multi-part by setting a small max length
         },
@@ -138,7 +136,6 @@ test('If it is impossible to fit the signed quick results reporting URL within t
         signingMachineId: DEV_MACHINE_ID,
         pollingPlaceId: 'mockPollingPlaceId',
         pollsTransitionType: 'close_polls',
-        votingType: 'election_day',
         pollsTransitionTimestamp: new Date('2024-11-05T20:00:00Z').getTime(),
         maxQrCodeLength: 10, // impossible length
       },
@@ -161,7 +158,6 @@ test('generateSignedQuickResultsReportingUrl works for reporting polls open stat
         signingMachineId: DEV_MACHINE_ID,
         pollingPlaceId: 'mockPollingPlaceId',
         pollsTransitionType: 'open_polls',
-        votingType: 'election_day',
         pollsTransitionTimestamp: new Date('2024-11-05T08:00:00Z').getTime(),
       },
       vxScanTestConfig
@@ -189,7 +185,6 @@ test('generateSignedQuickResultsReportingUrl works for reporting polls open stat
         signingMachineId: DEV_MACHINE_ID,
         pollingPlaceId: 'mockPollingPlaceId',
         pollsTransitionType: 'open_polls',
-        votingType: 'early_voting',
         pollsTransitionTimestamp: new Date('2024-11-05T08:00:00Z').getTime(),
       },
       vxScanTestConfig
@@ -218,7 +213,6 @@ test('authenticateSignedQuickResultsReportingUrl - success case with real certif
       signingMachineId: DEV_MACHINE_ID,
       pollingPlaceId: 'mockPollingPlaceId',
       pollsTransitionType: 'close_polls',
-      votingType: 'election_day',
       pollsTransitionTimestamp: new Date('2024-11-05T20:00:00Z').getTime(),
     },
     vxScanTestConfig
@@ -257,7 +251,6 @@ test('authenticateSignedQuickResultsReportingUrl - invalid signature', async () 
       signingMachineId: DEV_MACHINE_ID,
       pollingPlaceId: 'mockPollingPlaceId',
       pollsTransitionType: 'close_polls',
-      votingType: 'election_day',
       pollsTransitionTimestamp: new Date('2024-11-05T20:00:00Z').getTime(),
     },
     vxScanTestConfig
@@ -312,7 +305,6 @@ test('authenticateSignedQuickResultsReportingUrl - tampered payload', async () =
       signingMachineId: DEV_MACHINE_ID,
       pollingPlaceId: 'mockPollingPlaceId',
       pollsTransitionType: 'close_polls',
-      votingType: 'election_day',
       pollsTransitionTimestamp: new Date('2024-11-05T20:00:00Z').getTime(),
     },
     vxScanTestConfig
@@ -363,7 +355,6 @@ test('decodeQuickResultsMessage throws error when given invalid payload', () => 
     numPages: 88,
     pageIndex: 77,
     ballotCount: 0,
-    votingType: 'election_day',
   });
   expect(() => {
     decodeQuickResultsMessage(
@@ -422,7 +413,7 @@ test('decodeQuickResultsMessage throws error when given invalid payload', () => 
   }).toThrow('Invalid timestamp format');
 });
 
-test('decodeQuickResultsMessage rejects invalid numPages, pageIndex, ballotCount, and votingType values', () => {
+test('decodeQuickResultsMessage rejects invalid numPages, pageIndex, and ballotCount values', () => {
   const SEP = '\x00'; // Null byte separator used in the QR message format
   const timestamp = (
     new Date('2024-01-01T00:00:00Z').getTime() / 1000
@@ -432,7 +423,6 @@ test('decodeQuickResultsMessage rejects invalid numPages, pageIndex, ballotCount
     numPages?: string;
     pageIndex?: string;
     ballotCount?: string;
-    votingType?: string;
   }): string {
     const parts = [
       'ballotHash',
@@ -444,7 +434,6 @@ test('decodeQuickResultsMessage rejects invalid numPages, pageIndex, ballotCount
       overrides.numPages ?? '1',
       overrides.pageIndex ?? '0',
       overrides.ballotCount ?? '0',
-      overrides.votingType ?? '0',
     ];
     return constructPrefixedMessage(QR_MESSAGE_FORMAT, parts.join(SEP));
   }
@@ -469,17 +458,6 @@ test('decodeQuickResultsMessage rejects invalid numPages, pageIndex, ballotCount
   expect(() =>
     decodeQuickResultsMessage(buildPayload({ ballotCount: '-1' }))
   ).toThrow('Invalid ballot count format');
-
-  // votingType must be a valid digit mapping to a known type
-  expect(() =>
-    decodeQuickResultsMessage(buildPayload({ votingType: 'abc' }))
-  ).toThrow('Invalid voting type format');
-  expect(() =>
-    decodeQuickResultsMessage(buildPayload({ votingType: '99' }))
-  ).toThrow('Invalid voting type format');
-  expect(() =>
-    decodeQuickResultsMessage(buildPayload({ votingType: '-1' }))
-  ).toThrow('Invalid voting type format');
 });
 
 test('encodeQuickResultsMessage and decodeQuickResultsMessage handle close_polls tally', () => {
@@ -496,7 +474,6 @@ test('encodeQuickResultsMessage and decodeQuickResultsMessage handle close_polls
         numPages: 1,
         pageIndex: 0,
         ballotCount: 42,
-        votingType: 'election_day',
       })
     )
   );
@@ -512,7 +489,6 @@ test('encodeQuickResultsMessage and decodeQuickResultsMessage handle close_polls
       "pollingPlaceId": "mockPollingPlaceId",
       "pollsTransitionTime": 2024-01-01T00:00:00.000Z,
       "pollsTransitionType": "close_polls",
-      "votingType": "election_day",
     }
   `);
 });
@@ -531,7 +507,6 @@ test('encodeQuickResultsMessage and decodeQuickResultsMessage handle proper payl
         numPages: 1,
         pageIndex: 0,
         ballotCount: 15,
-        votingType: 'early_voting',
       })
     )
   );
@@ -547,7 +522,6 @@ test('encodeQuickResultsMessage and decodeQuickResultsMessage handle proper payl
       "pollingPlaceId": "mockPollingPlaceId",
       "pollsTransitionTime": 2024-01-01T00:00:00.000Z,
       "pollsTransitionType": "close_polls",
-      "votingType": "early_voting",
     }
   `);
 });
@@ -563,7 +537,6 @@ test('generateSignedQuickResultsReportingUrl works for reporting polls paused st
         signingMachineId: DEV_MACHINE_ID,
         pollingPlaceId: 'mockPollingPlaceId',
         pollsTransitionType: 'pause_voting',
-        votingType: 'election_day',
         pollsTransitionTimestamp: new Date('2024-11-05T12:00:00Z').getTime(),
       },
       vxScanTestConfig
@@ -591,7 +564,6 @@ test('encodeQuickResultsMessage and decodeQuickResultsMessage handle reporting p
     numPages: 1,
     pageIndex: 0,
     ballotCount: 7,
-    votingType: 'election_day',
   });
 
   expect(encoded).toContain('open_polls');
@@ -610,7 +582,6 @@ test('encodeQuickResultsMessage and decodeQuickResultsMessage handle reporting p
       "pollingPlaceId": "mockPollingPlaceId",
       "pollsTransitionTime": 2024-01-01T00:00:00.000Z,
       "pollsTransitionType": "open_polls",
-      "votingType": "election_day",
     }
   `);
 });
@@ -626,7 +597,6 @@ test('encodeQuickResultsMessage and decodeQuickResultsMessage handle reporting p
     numPages: 1,
     pageIndex: 0,
     ballotCount: 99,
-    votingType: 'early_voting',
   });
 
   expect(encoded).toContain('pause_voting');
@@ -645,7 +615,6 @@ test('encodeQuickResultsMessage and decodeQuickResultsMessage handle reporting p
       "pollingPlaceId": "mockPollingPlaceId",
       "pollsTransitionTime": 2024-01-01T00:00:00.000Z,
       "pollsTransitionType": "pause_voting",
-      "votingType": "early_voting",
     }
   `);
 });
@@ -661,7 +630,6 @@ test('encodeQuickResultsMessage and decodeQuickResultsMessage handle resume_voti
     numPages: 1,
     pageIndex: 0,
     ballotCount: 50,
-    votingType: 'election_day',
   });
 
   expect(encoded).toContain('resume_voting');
@@ -680,12 +648,11 @@ test('encodeQuickResultsMessage and decodeQuickResultsMessage handle resume_voti
       "pollingPlaceId": "mockPollingPlaceId",
       "pollsTransitionTime": 2024-01-01T00:00:00.000Z,
       "pollsTransitionType": "resume_voting",
-      "votingType": "election_day",
     }
   `);
 });
 
-test('encodeQuickResultsMessage and decodeQuickResultsMessage handle absentee voting type', () => {
+test('encodeQuickResultsMessage and decodeQuickResultsMessage handle close_polls tally with absentee polling place id', () => {
   const decoded = decodeQuickResultsMessage(
     constructPrefixedMessage(
       QR_MESSAGE_FORMAT,
@@ -699,7 +666,6 @@ test('encodeQuickResultsMessage and decodeQuickResultsMessage handle absentee vo
         numPages: 1,
         pageIndex: 0,
         ballotCount: 5,
-        votingType: 'absentee',
       })
     )
   );
@@ -715,7 +681,6 @@ test('encodeQuickResultsMessage and decodeQuickResultsMessage handle absentee vo
       "pollingPlaceId": "mockPollingPlaceId",
       "pollsTransitionTime": 2024-01-01T00:00:00.000Z,
       "pollsTransitionType": "close_polls",
-      "votingType": "absentee",
     }
   `);
 });

--- a/libs/auth/src/signed_quick_results_reporting.ts
+++ b/libs/auth/src/signed_quick_results_reporting.ts
@@ -3,8 +3,6 @@ import * as fs from 'node:fs/promises';
 import { Buffer } from 'node:buffer';
 import {
   ElectionDefinition,
-  LIVE_REPORT_VOTING_TYPES,
-  LiveReportVotingType,
   PollsTransitionType,
   PrecinctId,
   Tabulation,
@@ -46,7 +44,6 @@ interface SignedQuickResultsReportingInput {
   signingMachineId: string;
   pollingPlaceId: string;
   pollsTransitionType: PollsTransitionType;
-  votingType: LiveReportVotingType;
   pollsTransitionTimestamp: number;
   maxQrCodeLength?: number; // Provided as a prop for ease in testing
 }
@@ -71,8 +68,9 @@ const CERT_PEM_FOOTER = '-----END CERTIFICATE-----';
 const SIGNED_QUICK_RESULTS_REPORTING_MESSAGE_PAYLOAD_SEPARATOR = '\x00';
 
 /**
- * The current message format (10 fields with pollingPlaceId in field 5,
- * V1 bitmap-format per-precinct tally data).
+ * The current message format (9 fields, V1 bitmap-format per-precinct tally
+ * data). `votingType` is derived from the polling place's `type` on the
+ * receiving side rather than being included in the payload.
  */
 export const QR_MESSAGE_FORMAT = 'qr3';
 
@@ -106,7 +104,6 @@ export function encodeQuickResultsMessage(components: {
   numPages: number;
   pageIndex: number;
   ballotCount: number;
-  votingType: LiveReportVotingType;
 }): string {
   const messagePayloadParts = [
     safeEncodeForUrl(components.ballotHash),
@@ -118,7 +115,6 @@ export function encodeQuickResultsMessage(components: {
     components.numPages.toString(),
     components.pageIndex.toString(),
     components.ballotCount.toString(),
-    LIVE_REPORT_VOTING_TYPES.indexOf(components.votingType).toString(),
   ];
 
   return messagePayloadParts.join(
@@ -140,7 +136,6 @@ interface DecodedBaseFields {
 interface DecodedFields extends DecodedBaseFields {
   pollsTransitionTime: Date;
   ballotCount: number;
-  votingType: LiveReportVotingType;
 }
 
 function parseRequiredInt(value: string, fieldName: string): number {
@@ -214,7 +209,7 @@ function decodeMessage(messagePayload: string): DecodedFields {
   const parts = messagePayload.split(
     SIGNED_QUICK_RESULTS_REPORTING_MESSAGE_PAYLOAD_SEPARATOR
   );
-  if (parts.length !== 10) {
+  if (parts.length !== 9) {
     throw new Error('Invalid message payload format');
   }
 
@@ -227,15 +222,7 @@ function decodeMessage(messagePayload: string): DecodedFields {
     throw new Error('Invalid ballot count format');
   }
 
-  const votingTypeDigitStr = parts[9];
-  assert(votingTypeDigitStr !== undefined);
-  const votingTypeDigit = parseRequiredInt(votingTypeDigitStr, 'voting type');
-  const votingType = LIVE_REPORT_VOTING_TYPES[votingTypeDigit];
-  if (!votingType) {
-    throw new Error('Invalid voting type format');
-  }
-
-  return { ...base, pollsTransitionTime: timestamp, ballotCount, votingType };
+  return { ...base, pollsTransitionTime: timestamp, ballotCount };
 }
 
 /**
@@ -316,7 +303,6 @@ export async function generateSignedQuickResultsReportingUrl(
     signingMachineId,
     pollingPlaceId,
     pollsTransitionType,
-    votingType,
     pollsTransitionTimestamp,
     maxQrCodeLength = MAXIMUM_BYTES_IN_MEDIUM_QR_CODE,
   }: SignedQuickResultsReportingInput,
@@ -352,7 +338,6 @@ export async function generateSignedQuickResultsReportingUrl(
             numPages: numPagesNeeded,
             pageIndex: encodedUrls.length,
             ballotCount,
-            votingType,
           });
           const message = constructPrefixedMessage(
             QR_MESSAGE_FORMAT,
@@ -391,7 +376,6 @@ export async function generateSignedQuickResultsReportingUrl(
         numPages: 1,
         pageIndex: 0,
         ballotCount,
-        votingType,
       });
       const message = constructPrefixedMessage(
         QR_MESSAGE_FORMAT,


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/8354 
Removes voting type from the live reports payload. The space used for this was negligible but its redudant with polling place now and confusing to have both. Was only used on the confirmation screen to show the "voting type" which is now derived from the polling place. 

Breaking change to live reports but nothing is currently released/deployed at the current live report format.

<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot
N/A

## Testing Plan
Ran tests, sanity local e2e flow 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
