### PR TITLE
VxMarkScan: Port VxMark open primary changes

### DIFF
--- a/apps/mark-scan/frontend/src/app_open_primary.test.tsx
+++ b/apps/mark-scan/frontend/src/app_open_primary.test.tsx
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { singlePrecinctSelectionFor } from '@votingworks/utils';
+import { electionOpenPrimaryFixtures } from '@votingworks/fixtures';
+import userEvent from '@testing-library/user-event';
+import { BallotStyleId, CandidateContest } from '@votingworks/types';
+import { find } from '@votingworks/basics';
+import { hasTextAcrossElements } from '@votingworks/test-utils';
+import { render, screen } from '../test/react_testing_library';
+
+import { App } from './app';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+const BALLOT_STYLE_ID = 'ballot-style-1' as BallotStyleId;
+const PRECINCT_ID = 'precinct-1';
+const PRECINCT_NAME = 'Precinct 1';
+const PRECINCT_SELECTION = singlePrecinctSelectionFor(PRECINCT_ID);
+const electionDefinition = electionOpenPrimaryFixtures.readElectionDefinition();
+const { election } = electionDefinition;
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  apiMock = createApiMock();
+  apiMock.expectGetMachineConfig();
+  apiMock.expectGetSystemSettings();
+  apiMock.expectGetElectionRecord(electionDefinition);
+  apiMock.expectGetElectionState({
+    precinctSelection: PRECINCT_SELECTION,
+    pollsState: 'polls_open',
+  });
+  apiMock.setPaperHandlerState('not_accepting_paper');
+});
+
+afterEach(() => {
+  apiMock.mockApiClient.assertComplete();
+});
+
+async function activateCardlessVoterSession() {
+  // Poll worker logs in to activate a cardless voter session.
+  apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
+  await screen.findByText('Start a New Voting Session');
+
+  apiMock.mockApiClient.startCardlessVoterSession
+    .expectCallWith({
+      ballotStyleId: BALLOT_STYLE_ID,
+      precinctId: PRECINCT_ID,
+    })
+    .resolves();
+  apiMock.expectSetAcceptingPaperState();
+  userEvent.click(
+    screen.getByText(
+      hasTextAcrossElements(`Start Voting Session: ${PRECINCT_NAME}`)
+    )
+  );
+
+  apiMock.setPaperHandlerState('accepting_paper');
+  apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
+    cardlessVoterUserParams: {
+      ballotStyleId: BALLOT_STYLE_ID,
+      precinctId: PRECINCT_ID,
+    },
+  });
+  await screen.findByText('Load Ballot Sheet');
+  apiMock.setPaperHandlerState('waiting_for_ballot_data');
+
+  // Poll worker removes card; voter takes over.
+  apiMock.setAuthStatusCardlessVoterLoggedIn({
+    ballotStyleId: BALLOT_STYLE_ID,
+    precinctId: PRECINCT_ID,
+  });
+  await screen.findByText('Start Voting');
+}
+
+test('poll worker activates session, voter picks party and walks through ballot', async () => {
+  render(<App apiClient={apiMock.mockApiClient} />);
+  await screen.findByText('Insert Card');
+
+  await activateCardlessVoterSession();
+
+  // Start screen -> party selection
+  userEvent.click(screen.getByText('Start Voting'));
+  await screen.findByRole('heading', { name: 'Choose Your Party' });
+
+  // Next disabled until a party is selected
+  expect(screen.getButton(/next/i)).toBeDisabled();
+
+  // Select Democratic
+  userEvent.click(screen.getButton('Democratic Party'));
+  expect(screen.getButton(/next/i)).toBeEnabled();
+
+  // Advance to the first contest — only Democratic + nonpartisan contests appear.
+  userEvent.click(screen.getButton(/next/i));
+  await screen.findByRole('heading', { name: 'Governor' });
+
+  // Walk through all contests to review. The voter should see exactly the
+  // Democratic partisan contests + all nonpartisan contests for
+  // ballot-style-1 — and none of the Republican or Libertarian partisan
+  // contests.
+  const expectedContestTitles = [
+    'Governor',
+    'Secretary of State',
+    'Attorney General',
+    'Representative in Congress',
+    'State Representative',
+    'County Commissioner',
+    'Delegate to County Convention',
+    'Circuit Court Judge',
+    'Probate Court Judge',
+    'Board of Education Member',
+    'County Road Millage Renewal',
+    'Public Safety Millage',
+    'Library Millage Renewal',
+  ];
+  for (const title of expectedContestTitles) {
+    await screen.findByRole('heading', { name: title });
+    userEvent.click(screen.getButton(/next/i));
+  }
+  await screen.findByRole('heading', { name: /review your votes/i });
+
+  // From the review screen, "Change Party" lands on party selection in
+  // review mode with a Review button to return.
+  userEvent.click(screen.getButton(/change party/i));
+  await screen.findByRole('heading', { name: 'Choose Your Party' });
+  userEvent.click(screen.getButton(/review/i));
+  await screen.findByRole('heading', { name: /review your votes/i });
+});
+
+test('switching party clears votes from the previous party', async () => {
+  render(<App apiClient={apiMock.mockApiClient} />);
+  await screen.findByText('Insert Card');
+
+  await activateCardlessVoterSession();
+
+  // Pick Democratic and vote for a Democratic Governor candidate
+  userEvent.click(screen.getByText('Start Voting'));
+  await screen.findByRole('heading', { name: 'Choose Your Party' });
+  userEvent.click(screen.getButton('Democratic Party'));
+  userEvent.click(screen.getButton(/next/i));
+  await screen.findByRole('heading', { name: 'Governor' });
+
+  const demGovernorContest = find(
+    election.contests,
+    (c): c is CandidateContest => c.id === 'governor-democratic'
+  );
+  const demGovernorCandidate = demGovernorContest.candidates[0];
+  userEvent.click(screen.getByText(demGovernorCandidate.name));
+
+  // Back to party selection, switch to Republican (clears votes), then back
+  // to Democratic. The Democratic vote from earlier should be gone.
+  userEvent.click(screen.getButton(/back/i));
+  await screen.findByRole('heading', { name: 'Choose Your Party' });
+  userEvent.click(screen.getButton('Republican Party'));
+  // Confirm the change-party modal that appears because there are votes.
+  userEvent.click(
+    await screen.findByRole('button', { name: /^change party/i })
+  );
+  userEvent.click(screen.getButton(/next/i));
+  await screen.findByRole('heading', { name: 'Governor' });
+
+  // The Republican Governor candidates are shown, not the Democratic ones.
+  const repGovernorContest = find(
+    election.contests,
+    (c): c is CandidateContest => c.id === 'governor-republican'
+  );
+  screen.getByText(repGovernorContest.candidates[0].name);
+  expect(screen.queryByText(demGovernorCandidate.name)).toBeNull();
+
+  userEvent.click(screen.getButton(/back/i));
+  await screen.findByRole('heading', { name: 'Choose Your Party' });
+  userEvent.click(screen.getButton('Democratic Party'));
+  userEvent.click(screen.getButton(/next/i));
+  await screen.findByRole('heading', { name: 'Governor' });
+
+  // Jump to the review screen to inspect the Democratic Governor contest
+  userEvent.click(screen.getButton(/view all/i));
+  await screen.findByRole('heading', { name: /review your votes/i });
+
+  // The Democratic Governor candidate the voter previously selected should
+  // no longer appear on the review — vote was cleared by the party switch.
+  expect(screen.queryByText(demGovernorCandidate.name)).toBeNull();
+});

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -5,6 +5,8 @@ import {
   getBallotStyle,
   getContests,
   ContestId,
+  isOpenPrimary,
+  PartyId,
   PrecinctId,
   BallotStyleId,
   InsertedSmartCardAuth,
@@ -100,6 +102,8 @@ export const POLL_WORKER_AUTH_REQUIRED_STATES: Readonly<
 
 interface VotingState {
   votes?: VotesDict;
+  // Only set for open primary elections; see BallotContextInterface.
+  selectedPartyId?: PartyId;
 }
 
 export const blankBallotVotes: VotesDict = {};
@@ -113,6 +117,7 @@ export const initialElectionState: Readonly<ElectionState> = {
 
 const initialVotingState: Readonly<VotingState> = {
   votes: undefined,
+  selectedPartyId: undefined,
 };
 
 // Sets State. All side effects done outside: storage, fetching, etc
@@ -120,7 +125,8 @@ type VotingAction =
   | { type: 'unconfigure' }
   | { type: 'setVotes'; votes: VotesDict }
   | { type: 'updateVote'; contestId: ContestId; vote: OptionalVote }
-  | { type: 'resetBallot' };
+  | { type: 'resetBallot' }
+  | { type: 'selectParty'; partyId: PartyId };
 
 function votingStateReducer(
   state: VotingState,
@@ -152,6 +158,13 @@ function votingStateReducer(
         ...state,
         ...initialVotingState,
       };
+    case 'selectParty':
+      return {
+        ...state,
+        selectedPartyId: action.partyId,
+        // Clear votes on party change to prevent crossover voting
+        votes: {},
+      };
     default: {
       /* istanbul ignore next - compile time check for completeness @preserve */
       throwIllegalValue(action);
@@ -164,7 +177,7 @@ export function AppRoot(): JSX.Element | null {
     votingStateReducer,
     initialVotingState
   );
-  const { votes } = votingState;
+  const { votes, selectedPartyId } = votingState;
 
   const history = useHistory();
 
@@ -236,6 +249,16 @@ export function AppRoot(): JSX.Element | null {
             ballotStyle,
           })
         )
+          // For open primaries, show only partisan contests for the party
+          // selected by the user + nonpartisan contests.
+          .filter((contest) => {
+            if (isOpenPrimary(electionDefinition.election) && selectedPartyId) {
+              return contest.type === 'candidate'
+                ? !contest.partyId || contest.partyId === selectedPartyId
+                : true;
+            }
+            return true;
+          })
       : [];
 
   const { onSessionEnd } = useSessionSettingsManager({ authStatus });
@@ -278,6 +301,10 @@ export function AppRoot(): JSX.Element | null {
 
   const updateVote = useCallback((contestId: ContestId, vote: OptionalVote) => {
     dispatchVotingState({ type: 'updateVote', contestId, vote });
+  }, []);
+
+  const selectParty = useCallback((partyId: PartyId) => {
+    dispatchVotingState({ type: 'selectParty', partyId });
   }, []);
 
   const resetPollsToPaused = useCallback(async () => {
@@ -580,6 +607,8 @@ export function AppRoot(): JSX.Element | null {
             machineConfig={machineConfig}
             precinctId={precinctId}
             resetBallot={resetBallot}
+            selectedPartyId={selectedPartyId}
+            selectParty={selectParty}
             stateMachineState={stateMachineState}
             updateVote={updateVote}
             votes={votes ?? blankBallotVotes}

--- a/apps/mark-scan/frontend/src/components/ballot.tsx
+++ b/apps/mark-scan/frontend/src/components/ballot.tsx
@@ -9,6 +9,7 @@ import {
 import { IDLE_TIMEOUT_SECONDS } from '@votingworks/mark-flow-ui';
 import { ContestScreen } from '../pages/contest_screen';
 import { IdlePage } from '../pages/idle_page';
+import { PartySelectionScreen } from '../pages/party_selection_screen';
 import { PrintPage } from '../pages/print_page';
 import { ReviewScreen } from '../pages/review_screen';
 import { StartScreen } from '../pages/start_screen';
@@ -53,6 +54,9 @@ export function Ballot(): JSX.Element {
         <Switch>
           <Route path="/" exact>
             <StartScreen />
+          </Route>
+          <Route path="/party-selection">
+            <PartySelectionScreen />
           </Route>
           <Route path="/ready-to-review">
             {/* This page renders a button that lets the voter navigate to /review.

--- a/apps/mark-scan/frontend/src/config/types.ts
+++ b/apps/mark-scan/frontend/src/config/types.ts
@@ -1,6 +1,7 @@
 import {
   BallotStyleId,
   ElectionDefinition,
+  PartyId,
   PrecinctId,
   VotesDict,
 } from '@votingworks/types';
@@ -21,6 +22,12 @@ export interface BallotContextInterface {
   endVoterSession: () => Promise<void>;
   precinctId?: PrecinctId;
   resetBallot: (showPostVotingInstructions?: boolean) => void;
+  // `selectedPartyId` and `selectParty` apply only to open primaries, where the
+  // voter picks a party at the start of their session. In closed primaries the
+  // party is determined by the ballot style; in general elections there is no
+  // party. `selectedPartyId` is undefined until the voter makes a selection.
+  selectedPartyId?: PartyId;
+  selectParty: (partyId: PartyId) => void;
   updateVote: UpdateVoteFunction;
   votes: VotesDict;
 }

--- a/apps/mark-scan/frontend/src/contexts/ballot_context.ts
+++ b/apps/mark-scan/frontend/src/contexts/ballot_context.ts
@@ -13,6 +13,7 @@ const ballot: BallotContextInterface = {
   isLiveMode: false,
   endVoterSession: () => Promise.resolve(),
   resetBallot: () => undefined,
+  selectParty: () => undefined,
   updateVote: () => undefined,
   votes: {},
 };

--- a/apps/mark-scan/frontend/src/pages/contest_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/contest_screen.tsx
@@ -25,16 +25,13 @@ function getReviewPageUrl(contestId?: ContestId) {
   return '/review';
 }
 
-function getStartPageUrl() {
-  return '/';
-}
-
 export function ContestScreen(): JSX.Element {
   const {
     ballotStyleId,
     contests,
     electionDefinition,
     precinctId,
+    selectedPartyId,
     updateVote,
     votes,
   } = React.useContext(BallotContext);
@@ -46,6 +43,13 @@ export function ContestScreen(): JSX.Element {
   const isPatDeviceConnected = Boolean(
     api.getIsPatDeviceConnected.useQuery().data
   );
+
+  // In open primaries, Back from the first contest returns to party selection so the
+  // voter can change their party. `selectedPartyId` being set implies the
+  // voter came from the party selection screen.
+  function getStartPageUrl() {
+    return selectedPartyId ? '/party-selection' : '/';
+  }
 
   return (
     <ContestPage

--- a/apps/mark-scan/frontend/src/pages/party_selection_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/party_selection_screen.test.tsx
@@ -1,0 +1,167 @@
+import { expect, test, vi } from 'vitest';
+import { Route } from 'react-router-dom';
+import { electionOpenPrimaryFixtures } from '@votingworks/fixtures';
+import { createMemoryHistory } from 'history';
+import { MARK_FLOW_UI_VOTER_SCREEN_TEST_ID } from '@votingworks/mark-flow-ui';
+import userEvent from '@testing-library/user-event';
+import { CandidateContest, PartyId, VotesDict } from '@votingworks/types';
+import { screen, within } from '../../test/react_testing_library';
+import { render } from '../../test/test_utils';
+import { PartySelectionScreen } from './party_selection_screen';
+
+const electionDefinition = electionOpenPrimaryFixtures.readElectionDefinition();
+const democraticGovernor = electionDefinition.election.contests.find(
+  (c): c is CandidateContest => c.id === 'governor-democratic'
+)!;
+
+test('renders as voter screen with party options', () => {
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    route: '/party-selection',
+  });
+
+  screen.getByTestId(MARK_FLOW_UI_VOTER_SCREEN_TEST_ID);
+  screen.getByRole('heading', { name: 'Choose Your Party' });
+  screen.getByRole('radio', { name: 'Democratic Party' });
+  screen.getByRole('radio', { name: 'Republican Party' });
+  screen.getByRole('radio', { name: 'Libertarian Party' });
+});
+
+test('Next button disabled until a party is selected', () => {
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    route: '/party-selection',
+  });
+
+  expect(screen.getButton(/next/i)).toBeDisabled();
+});
+
+test('Next button enabled once a party is selected', () => {
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    route: '/party-selection',
+    selectedPartyId: 'democratic-party' as PartyId,
+  });
+
+  expect(screen.getButton(/next/i)).toBeEnabled();
+});
+
+test('selecting a party calls selectParty with the party id', () => {
+  const selectParty = vi.fn();
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    route: '/party-selection',
+    selectParty,
+  });
+
+  userEvent.click(screen.getByRole('radio', { name: 'Republican Party' }));
+  expect(selectParty).toHaveBeenCalledWith('republican-party');
+});
+
+test('Back button navigates to start screen', () => {
+  const history = createMemoryHistory({ initialEntries: ['/party-selection'] });
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    history,
+    route: '/party-selection',
+  });
+
+  userEvent.click(screen.getButton(/back/i));
+  expect(history.location.pathname).toEqual('/');
+});
+
+test('Next button navigates to first contest when a party is selected', () => {
+  const history = createMemoryHistory({ initialEntries: ['/party-selection'] });
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    history,
+    route: '/party-selection',
+    selectedPartyId: 'democratic-party' as PartyId,
+  });
+
+  userEvent.click(screen.getButton(/next/i));
+  expect(history.location.pathname).toEqual('/contests/0');
+});
+
+test('changing party with votes cast prompts confirmation before clearing votes', () => {
+  const selectParty = vi.fn();
+  const votes: VotesDict = {
+    [democraticGovernor.id]: [democraticGovernor.candidates[0]],
+  };
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    route: '/party-selection',
+    selectedPartyId: 'democratic-party' as PartyId,
+    selectParty,
+    votes,
+  });
+
+  // Tapping a different party opens the modal without changing the party yet.
+  userEvent.click(screen.getByRole('radio', { name: 'Republican Party' }));
+  let modal = screen.getByRole('alertdialog');
+  within(modal).getByText(/clear all of your votes/i);
+  expect(selectParty).not.toHaveBeenCalled();
+
+  // Cancel closes the modal and leaves the party unchanged.
+  userEvent.click(within(modal).getButton(/cancel/i));
+  expect(screen.queryByRole('alertdialog')).toBeNull();
+  expect(selectParty).not.toHaveBeenCalled();
+
+  // Reopening and confirming applies the new party.
+  userEvent.click(screen.getByRole('radio', { name: 'Republican Party' }));
+  modal = screen.getByRole('alertdialog');
+  userEvent.click(within(modal).getButton(/^change party/i));
+  expect(selectParty).toHaveBeenCalledWith('republican-party');
+  expect(screen.queryByRole('alertdialog')).toBeNull();
+});
+
+test('changing party with no votes cast skips the confirmation modal', () => {
+  const selectParty = vi.fn();
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    route: '/party-selection',
+    selectedPartyId: 'democratic-party' as PartyId,
+    selectParty,
+  });
+
+  userEvent.click(screen.getByRole('radio', { name: 'Republican Party' }));
+  expect(screen.queryByRole('alertdialog')).toBeNull();
+  expect(selectParty).toHaveBeenCalledWith('republican-party');
+});
+
+test('entering from review shows a Review button until a vote-clearing change is confirmed', () => {
+  const selectParty = vi.fn();
+  const votes: VotesDict = {
+    [democraticGovernor.id]: [democraticGovernor.candidates[0]],
+  };
+  const history = createMemoryHistory({
+    initialEntries: ['/party-selection#review'],
+  });
+  render(<Route path="/party-selection" component={PartySelectionScreen} />, {
+    electionDefinition,
+    history,
+    route: '/party-selection#review',
+    selectedPartyId: 'democratic-party' as PartyId,
+    selectParty,
+    votes,
+  });
+
+  // From review: only the Review button is shown (no Back/Next).
+  expect(screen.queryButton(/^back$/i)).toBeNull();
+  expect(screen.queryButton(/^next$/i)).toBeNull();
+
+  // Cancelling a vote-clearing change keeps review mode.
+  userEvent.click(screen.getByRole('radio', { name: 'Republican Party' }));
+  userEvent.click(within(screen.getByRole('alertdialog')).getButton(/cancel/i));
+  screen.getButton(/review/i);
+
+  // Confirming the change clears votes and switches to the standard footer.
+  userEvent.click(screen.getByRole('radio', { name: 'Republican Party' }));
+  userEvent.click(
+    within(screen.getByRole('alertdialog')).getButton(/^change party/i)
+  );
+  expect(selectParty).toHaveBeenCalledWith('republican-party');
+  expect(screen.queryButton(/review/i)).toBeNull();
+  screen.getButton(/^back$/i);
+  screen.getButton(/^next$/i);
+});

--- a/apps/mark-scan/frontend/src/pages/party_selection_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/party_selection_screen.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import styled from 'styled-components';
+import { assertDefined } from '@votingworks/basics';
+import { PartyId } from '@votingworks/types';
+import {
+  appStrings,
+  AssistiveTechInstructions,
+  AudioOnly,
+  Button,
+  Caption,
+  electionStrings,
+  H2,
+  LinkButton,
+  Modal,
+  P,
+  PageNavigationButtonId,
+  RadioGroup,
+  ReadOnLoad,
+  WithScrollButtons,
+} from '@votingworks/ui';
+import { useIsReviewMode, VoterScreen } from '@votingworks/mark-flow-ui';
+import { BallotContext } from '../contexts/ballot_context';
+
+const Header = styled.div`
+  padding: 0.5rem;
+`;
+
+const OptionRadioGroup = styled(RadioGroup<PartyId>)`
+  button {
+    font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
+  }
+`;
+
+export function PartySelectionScreen(): JSX.Element {
+  const { electionDefinition, selectParty, selectedPartyId, votes } =
+    React.useContext(BallotContext);
+  const { election } = assertDefined(electionDefinition);
+  const [partyIdToConfirm, setPartyIdToConfirm] = React.useState<PartyId>();
+  // Snapshot the initial review mode state so that we can flip it off if the
+  // voter changes their party
+  const [isReviewMode, setIsReviewMode] = React.useState(useIsReviewMode());
+
+  function handleSelect(partyId: PartyId) {
+    if (
+      partyId !== selectedPartyId &&
+      Object.values(votes).some(
+        (contestVotes) => contestVotes && contestVotes.length > 0
+      )
+    ) {
+      setPartyIdToConfirm(partyId);
+    } else {
+      selectParty(partyId);
+    }
+  }
+
+  return (
+    <VoterScreen
+      actionButtons={
+        isReviewMode ? (
+          <LinkButton
+            icon="Previous"
+            id={PageNavigationButtonId.NEXT}
+            variant="primary"
+            to="/review"
+          >
+            {appStrings.buttonReview()}
+          </LinkButton>
+        ) : (
+          <React.Fragment>
+            <LinkButton
+              icon="Previous"
+              id={PageNavigationButtonId.PREVIOUS}
+              to="/"
+            >
+              {appStrings.buttonBack()}
+            </LinkButton>
+            <LinkButton
+              rightIcon="Next"
+              id={PageNavigationButtonId.NEXT}
+              variant={selectedPartyId ? 'primary' : 'neutral'}
+              to={selectedPartyId ? '/contests/0' : undefined}
+              disabled={!selectedPartyId}
+            >
+              {appStrings.buttonNext()}
+            </LinkButton>
+          </React.Fragment>
+        )
+      }
+    >
+      <Header>
+        <ReadOnLoad>
+          <H2>{appStrings.titleBmdPartySelectionScreen()}</H2>
+          <Caption>
+            {appStrings.instructionsBmdPartySelection()}
+            <AudioOnly>
+              <AssistiveTechInstructions
+                controllerString={appStrings.instructionsBmdPartySelectionNavigation()}
+                patDeviceString={appStrings.instructionsBmdPartySelectionNavigationPatDevice()}
+              />
+            </AudioOnly>
+          </Caption>
+        </ReadOnLoad>
+      </Header>
+      <WithScrollButtons>
+        <OptionRadioGroup
+          label="Party"
+          hideLabel
+          options={election.parties.map((party) => {
+            const isSelected = party.id === selectedPartyId;
+            return {
+              value: party.id,
+              label: (
+                <React.Fragment>
+                  {isSelected && (
+                    <AudioOnly>{appStrings.labelSelected()}</AudioOnly>
+                  )}
+                  {electionStrings.partyFullName(party)}
+                  {isSelected && !isReviewMode && (
+                    <AudioOnly>
+                      {appStrings.noteBmdPartySelectionCompleted()}
+                    </AudioOnly>
+                  )}
+                </React.Fragment>
+              ),
+            };
+          })}
+          value={selectedPartyId}
+          onChange={handleSelect}
+        />
+      </WithScrollButtons>
+      {partyIdToConfirm && (
+        <Modal
+          title={appStrings.titleBmdConfirmPartyChange()}
+          content={<P>{appStrings.warningBmdPartyChangeClearsVotes()}</P>}
+          actions={
+            <React.Fragment>
+              <Button
+                id={PageNavigationButtonId.NEXT_AFTER_CONFIRM}
+                variant="primary"
+                onPress={() => {
+                  selectParty(partyIdToConfirm);
+                  setPartyIdToConfirm(undefined);
+                  setIsReviewMode(false);
+                }}
+              >
+                {appStrings.buttonChangeParty()}
+                <AudioOnly>
+                  <AssistiveTechInstructions
+                    controllerString={appStrings.instructionsBmdSelectToConfirm()}
+                    patDeviceString={appStrings.instructionsBmdSelectToConfirmPatDevice()}
+                  />
+                </AudioOnly>
+              </Button>
+              <Button
+                id={PageNavigationButtonId.PREVIOUS}
+                onPress={() => setPartyIdToConfirm(undefined)}
+              >
+                {appStrings.buttonCancel()}
+              </Button>
+            </React.Fragment>
+          }
+          onOverlayClick={
+            /* istanbul ignore next - @preserve */
+            () => setPartyIdToConfirm(undefined)
+          }
+        />
+      )}
+    </VoterScreen>
+  );
+}

--- a/apps/mark-scan/frontend/src/pages/party_selection_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/party_selection_screen.tsx
@@ -1,170 +1,22 @@
 import React from 'react';
-import styled from 'styled-components';
 import { assertDefined } from '@votingworks/basics';
-import { PartyId } from '@votingworks/types';
-import {
-  appStrings,
-  AssistiveTechInstructions,
-  AudioOnly,
-  Button,
-  Caption,
-  electionStrings,
-  H2,
-  LinkButton,
-  Modal,
-  P,
-  PageNavigationButtonId,
-  RadioGroup,
-  ReadOnLoad,
-  WithScrollButtons,
-} from '@votingworks/ui';
-import { useIsReviewMode, VoterScreen } from '@votingworks/mark-flow-ui';
+import { PartySelectionPage } from '@votingworks/mark-flow-ui';
 import { BallotContext } from '../contexts/ballot_context';
-
-const Header = styled.div`
-  padding: 0.5rem;
-`;
-
-const OptionRadioGroup = styled(RadioGroup<PartyId>)`
-  button {
-    font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
-  }
-`;
 
 export function PartySelectionScreen(): JSX.Element {
   const { electionDefinition, selectParty, selectedPartyId, votes } =
     React.useContext(BallotContext);
   const { election } = assertDefined(electionDefinition);
-  const [partyIdToConfirm, setPartyIdToConfirm] = React.useState<PartyId>();
-  // Snapshot the initial review mode state so that we can flip it off if the
-  // voter changes their party
-  const [isReviewMode, setIsReviewMode] = React.useState(useIsReviewMode());
-
-  function handleSelect(partyId: PartyId) {
-    if (
-      partyId !== selectedPartyId &&
-      Object.values(votes).some(
-        (contestVotes) => contestVotes && contestVotes.length > 0
-      )
-    ) {
-      setPartyIdToConfirm(partyId);
-    } else {
-      selectParty(partyId);
-    }
-  }
 
   return (
-    <VoterScreen
-      actionButtons={
-        isReviewMode ? (
-          <LinkButton
-            icon="Previous"
-            id={PageNavigationButtonId.NEXT}
-            variant="primary"
-            to="/review"
-          >
-            {appStrings.buttonReview()}
-          </LinkButton>
-        ) : (
-          <React.Fragment>
-            <LinkButton
-              icon="Previous"
-              id={PageNavigationButtonId.PREVIOUS}
-              to="/"
-            >
-              {appStrings.buttonBack()}
-            </LinkButton>
-            <LinkButton
-              rightIcon="Next"
-              id={PageNavigationButtonId.NEXT}
-              variant={selectedPartyId ? 'primary' : 'neutral'}
-              to={selectedPartyId ? '/contests/0' : undefined}
-              disabled={!selectedPartyId}
-            >
-              {appStrings.buttonNext()}
-            </LinkButton>
-          </React.Fragment>
-        )
-      }
-    >
-      <Header>
-        <ReadOnLoad>
-          <H2>{appStrings.titleBmdPartySelectionScreen()}</H2>
-          <Caption>
-            {appStrings.instructionsBmdPartySelection()}
-            <AudioOnly>
-              <AssistiveTechInstructions
-                controllerString={appStrings.instructionsBmdPartySelectionNavigation()}
-                patDeviceString={appStrings.instructionsBmdPartySelectionNavigationPatDevice()}
-              />
-            </AudioOnly>
-          </Caption>
-        </ReadOnLoad>
-      </Header>
-      <WithScrollButtons>
-        <OptionRadioGroup
-          label="Party"
-          hideLabel
-          options={election.parties.map((party) => {
-            const isSelected = party.id === selectedPartyId;
-            return {
-              value: party.id,
-              label: (
-                <React.Fragment>
-                  {isSelected && (
-                    <AudioOnly>{appStrings.labelSelected()}</AudioOnly>
-                  )}
-                  {electionStrings.partyFullName(party)}
-                  {isSelected && !isReviewMode && (
-                    <AudioOnly>
-                      {appStrings.noteBmdPartySelectionCompleted()}
-                    </AudioOnly>
-                  )}
-                </React.Fragment>
-              ),
-            };
-          })}
-          value={selectedPartyId}
-          onChange={handleSelect}
-        />
-      </WithScrollButtons>
-      {partyIdToConfirm && (
-        <Modal
-          title={appStrings.titleBmdConfirmPartyChange()}
-          content={<P>{appStrings.warningBmdPartyChangeClearsVotes()}</P>}
-          actions={
-            <React.Fragment>
-              <Button
-                id={PageNavigationButtonId.NEXT_AFTER_CONFIRM}
-                variant="primary"
-                onPress={() => {
-                  selectParty(partyIdToConfirm);
-                  setPartyIdToConfirm(undefined);
-                  setIsReviewMode(false);
-                }}
-              >
-                {appStrings.buttonChangeParty()}
-                <AudioOnly>
-                  <AssistiveTechInstructions
-                    controllerString={appStrings.instructionsBmdSelectToConfirm()}
-                    patDeviceString={appStrings.instructionsBmdSelectToConfirmPatDevice()}
-                  />
-                </AudioOnly>
-              </Button>
-              <Button
-                id={PageNavigationButtonId.PREVIOUS}
-                onPress={() => setPartyIdToConfirm(undefined)}
-              >
-                {appStrings.buttonCancel()}
-              </Button>
-            </React.Fragment>
-          }
-          onOverlayClick={
-            /* istanbul ignore next - @preserve */
-            () => setPartyIdToConfirm(undefined)
-          }
-        />
-      )}
-    </VoterScreen>
+    <PartySelectionPage
+      election={election}
+      selectedPartyId={selectedPartyId}
+      selectParty={selectParty}
+      votes={votes}
+      startPageUrl="/"
+      contestsPageUrl="/contests/0"
+      reviewPageUrl="/review"
+    />
   );
 }

--- a/apps/mark-scan/frontend/src/pages/review_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/review_screen.tsx
@@ -10,14 +10,23 @@ import { useVoterHelpScreen } from './use_voter_help_screen';
 export function ReviewScreen(): JSX.Element {
   const history = useHistory();
   const location = useLocation();
-  const { contests, electionDefinition, ballotStyleId, precinctId, votes } =
-    useContext(BallotContext);
+  const {
+    contests,
+    electionDefinition,
+    ballotStyleId,
+    precinctId,
+    selectedPartyId,
+    votes,
+  } = useContext(BallotContext);
   const VoterHelpScreen = useVoterHelpScreen('PrePrintReviewScreen');
 
   const searchParams = new URLSearchParams(location.search);
   const fromContest = searchParams.get('fromContest');
   const isViewAllMode = !!fromContest;
   const backUrl = fromContest ? `/contests/${fromContest}` : undefined;
+  const partySelectionScreenUrl = selectedPartyId
+    ? `/party-selection${!isViewAllMode ? '#review' : ''}`
+    : undefined;
 
   return (
     <ReviewPage
@@ -36,6 +45,8 @@ export function ReviewScreen(): JSX.Element {
         );
       }}
       votes={votes}
+      selectedPartyId={selectedPartyId}
+      partySelectionScreenUrl={partySelectionScreenUrl}
       VoterHelpScreen={VoterHelpScreen}
     />
   );

--- a/apps/mark-scan/frontend/src/pages/start_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/start_screen.tsx
@@ -3,6 +3,8 @@ import { useHistory } from 'react-router-dom';
 
 import { StartPage } from '@votingworks/mark-flow-ui';
 import { AssistiveTechInstructions, appStrings } from '@votingworks/ui';
+import { isOpenPrimary } from '@votingworks/types';
+import { assertDefined } from '@votingworks/basics';
 import { BallotContext } from '../contexts/ballot_context';
 import { useVoterHelpScreen } from './use_voter_help_screen';
 
@@ -13,7 +15,11 @@ export function StartScreen(): JSX.Element {
   const VoterHelpScreen = useVoterHelpScreen('StartScreen');
 
   function onStart() {
-    history.push('/contests/0');
+    if (isOpenPrimary(assertDefined(electionDefinition).election)) {
+      history.push('/party-selection');
+    } else {
+      history.push('/contests/0');
+    }
   }
 
   return (

--- a/apps/mark-scan/frontend/src/voter_flow.test.tsx
+++ b/apps/mark-scan/frontend/src/voter_flow.test.tsx
@@ -83,6 +83,7 @@ const TEST_VOTER_FLOW_PROPS: VoterFlowProps = {
   isLiveMode: true,
   machineConfig: mockMachineConfig(),
   resetBallot: vi.fn(),
+  selectParty: vi.fn(),
   stateMachineState: 'waiting_for_ballot_data',
   updateVote: vi.fn(),
   votes: {},

--- a/apps/mark-scan/frontend/src/voter_flow.tsx
+++ b/apps/mark-scan/frontend/src/voter_flow.tsx
@@ -7,6 +7,7 @@ import {
 import {
   BallotStyleId,
   ElectionDefinition,
+  PartyId,
   PrecinctId,
   VotesDict,
 } from '@votingworks/types';
@@ -38,6 +39,8 @@ export interface VoterFlowProps {
   endVoterSession: () => Promise<void>;
   stateMachineState: SimpleServerStatus;
   votes: VotesDict;
+  selectedPartyId?: PartyId;
+  selectParty: (partyId: PartyId) => void;
 }
 
 export function VoterFlow(props: VoterFlowProps): React.ReactNode {

--- a/apps/mark-scan/frontend/test/test_utils.tsx
+++ b/apps/mark-scan/frontend/test/test_utils.tsx
@@ -6,6 +6,7 @@ import {
   BallotStyleId,
   Contests,
   ElectionDefinition,
+  PartyId,
   PrecinctId,
   VotesDict,
 } from '@votingworks/types';
@@ -33,6 +34,8 @@ export function render(
     machineConfig = mockMachineConfig(),
     precinctId,
     resetBallot = vi.fn(),
+    selectParty = vi.fn(),
+    selectedPartyId,
     updateVote = vi.fn(),
     votes = {},
     apiMock = createApiMock(),
@@ -48,6 +51,8 @@ export function render(
     machineConfig?: MachineConfig;
     precinctId?: PrecinctId;
     resetBallot?(): void;
+    selectedPartyId?: PartyId;
+    selectParty?(partyId: PartyId): void;
     setUserSettings?(): void;
     updateTally?(): void;
     updateVote?(): void;
@@ -69,6 +74,8 @@ export function render(
             endVoterSession,
             precinctId,
             resetBallot,
+            selectParty,
+            selectedPartyId,
             updateVote,
             votes,
           }}

--- a/apps/mark/frontend/src/pages/party_selection_screen.tsx
+++ b/apps/mark/frontend/src/pages/party_selection_screen.tsx
@@ -1,170 +1,22 @@
 import React from 'react';
-import styled from 'styled-components';
 import { assertDefined } from '@votingworks/basics';
-import { PartyId } from '@votingworks/types';
-import {
-  appStrings,
-  AssistiveTechInstructions,
-  AudioOnly,
-  Button,
-  Caption,
-  electionStrings,
-  H2,
-  LinkButton,
-  Modal,
-  P,
-  PageNavigationButtonId,
-  RadioGroup,
-  ReadOnLoad,
-  WithScrollButtons,
-} from '@votingworks/ui';
-import { useIsReviewMode, VoterScreen } from '@votingworks/mark-flow-ui';
+import { PartySelectionPage } from '@votingworks/mark-flow-ui';
 import { BallotContext } from '../contexts/ballot_context';
-
-const Header = styled.div`
-  padding: 0.5rem;
-`;
-
-const OptionRadioGroup = styled(RadioGroup<PartyId>)`
-  button {
-    font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
-  }
-`;
 
 export function PartySelectionScreen(): JSX.Element {
   const { electionDefinition, selectParty, selectedPartyId, votes } =
     React.useContext(BallotContext);
   const { election } = assertDefined(electionDefinition);
-  const [partyIdToConfirm, setPartyIdToConfirm] = React.useState<PartyId>();
-  // Snapshot the initial review mode state so that we can flip it off if the
-  // voter changes their party
-  const [isReviewMode, setIsReviewMode] = React.useState(useIsReviewMode());
-
-  function handleSelect(partyId: PartyId) {
-    if (
-      partyId !== selectedPartyId &&
-      Object.values(votes).some(
-        (contestVotes) => contestVotes && contestVotes.length > 0
-      )
-    ) {
-      setPartyIdToConfirm(partyId);
-    } else {
-      selectParty(partyId);
-    }
-  }
 
   return (
-    <VoterScreen
-      actionButtons={
-        isReviewMode ? (
-          <LinkButton
-            icon="Previous"
-            id={PageNavigationButtonId.NEXT}
-            variant="primary"
-            to="/review"
-          >
-            {appStrings.buttonReview()}
-          </LinkButton>
-        ) : (
-          <React.Fragment>
-            <LinkButton
-              icon="Previous"
-              id={PageNavigationButtonId.PREVIOUS}
-              to="/"
-            >
-              {appStrings.buttonBack()}
-            </LinkButton>
-            <LinkButton
-              rightIcon="Next"
-              id={PageNavigationButtonId.NEXT}
-              variant={selectedPartyId ? 'primary' : 'neutral'}
-              to={selectedPartyId ? '/contests/0' : undefined}
-              disabled={!selectedPartyId}
-            >
-              {appStrings.buttonNext()}
-            </LinkButton>
-          </React.Fragment>
-        )
-      }
-    >
-      <Header>
-        <ReadOnLoad>
-          <H2>{appStrings.titleBmdPartySelectionScreen()}</H2>
-          <Caption>
-            {appStrings.instructionsBmdPartySelection()}
-            <AudioOnly>
-              <AssistiveTechInstructions
-                controllerString={appStrings.instructionsBmdPartySelectionNavigation()}
-                patDeviceString={appStrings.instructionsBmdPartySelectionNavigationPatDevice()}
-              />
-            </AudioOnly>
-          </Caption>
-        </ReadOnLoad>
-      </Header>
-      <WithScrollButtons>
-        <OptionRadioGroup
-          label="Party"
-          hideLabel
-          options={election.parties.map((party) => {
-            const isSelected = party.id === selectedPartyId;
-            return {
-              value: party.id,
-              label: (
-                <React.Fragment>
-                  {isSelected && (
-                    <AudioOnly>{appStrings.labelSelected()}</AudioOnly>
-                  )}
-                  {electionStrings.partyFullName(party)}
-                  {isSelected && !isReviewMode && (
-                    <AudioOnly>
-                      {appStrings.noteBmdPartySelectionCompleted()}
-                    </AudioOnly>
-                  )}
-                </React.Fragment>
-              ),
-            };
-          })}
-          value={selectedPartyId}
-          onChange={handleSelect}
-        />
-      </WithScrollButtons>
-      {partyIdToConfirm && (
-        <Modal
-          title={appStrings.titleBmdConfirmPartyChange()}
-          content={<P>{appStrings.warningBmdPartyChangeClearsVotes()}</P>}
-          actions={
-            <React.Fragment>
-              <Button
-                id={PageNavigationButtonId.NEXT_AFTER_CONFIRM}
-                variant="primary"
-                onPress={() => {
-                  selectParty(partyIdToConfirm);
-                  setPartyIdToConfirm(undefined);
-                  setIsReviewMode(false);
-                }}
-              >
-                {appStrings.buttonChangeParty()}
-                <AudioOnly>
-                  <AssistiveTechInstructions
-                    controllerString={appStrings.instructionsBmdSelectToConfirm()}
-                    patDeviceString={appStrings.instructionsBmdSelectToConfirmPatDevice()}
-                  />
-                </AudioOnly>
-              </Button>
-              <Button
-                id={PageNavigationButtonId.PREVIOUS}
-                onPress={() => setPartyIdToConfirm(undefined)}
-              >
-                {appStrings.buttonCancel()}
-              </Button>
-            </React.Fragment>
-          }
-          onOverlayClick={
-            /* istanbul ignore next - @preserve */
-            () => setPartyIdToConfirm(undefined)
-          }
-        />
-      )}
-    </VoterScreen>
+    <PartySelectionPage
+      election={election}
+      selectedPartyId={selectedPartyId}
+      selectParty={selectParty}
+      votes={votes}
+      startPageUrl="/"
+      contestsPageUrl="/contests/0"
+      reviewPageUrl="/review"
+    />
   );
 }

--- a/libs/mark-flow-ui/src/index.ts
+++ b/libs/mark-flow-ui/src/index.ts
@@ -17,6 +17,7 @@ export * from './hooks/use_session_settings_manager';
 export * from './pages/cast_ballot_page';
 export * from './pages/contest_page';
 export * from './pages/idle_page';
+export * from './pages/party_selection_page';
 export * from './pages/print_page';
 export * from './pages/review_page';
 export * from './pages/start_page';

--- a/libs/mark-flow-ui/src/pages/party_selection_page.tsx
+++ b/libs/mark-flow-ui/src/pages/party_selection_page.tsx
@@ -1,0 +1,185 @@
+/* istanbul ignore file - @preserve - tested via Mark/Mark-Scan */
+import React from 'react';
+import styled from 'styled-components';
+import { Election, PartyId, VotesDict } from '@votingworks/types';
+import {
+  appStrings,
+  AssistiveTechInstructions,
+  AudioOnly,
+  Button,
+  Caption,
+  electionStrings,
+  H2,
+  LinkButton,
+  Modal,
+  P,
+  PageNavigationButtonId,
+  RadioGroup,
+  ReadOnLoad,
+  WithScrollButtons,
+} from '@votingworks/ui';
+import { VoterScreen } from '../components/voter_screen';
+import { useIsReviewMode } from './contest_page';
+
+const Header = styled.div`
+  padding: 0.5rem;
+`;
+
+const OptionRadioGroup = styled(RadioGroup<PartyId>)`
+  button {
+    font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
+  }
+`;
+
+export interface PartySelectionPageProps {
+  election: Election;
+  selectedPartyId?: PartyId;
+  selectParty: (partyId: PartyId) => void;
+  votes: VotesDict;
+  startPageUrl: string;
+  contestsPageUrl: string;
+  reviewPageUrl: string;
+}
+
+export function PartySelectionPage({
+  election,
+  selectedPartyId,
+  selectParty,
+  votes,
+  startPageUrl,
+  contestsPageUrl,
+  reviewPageUrl,
+}: PartySelectionPageProps): JSX.Element {
+  const [partyIdToConfirm, setPartyIdToConfirm] = React.useState<PartyId>();
+  // Snapshot the initial review mode state so that we can flip it off if the
+  // voter changes their party
+  const [isReviewMode, setIsReviewMode] = React.useState(useIsReviewMode());
+
+  function handleSelect(partyId: PartyId) {
+    if (
+      partyId !== selectedPartyId &&
+      Object.values(votes).some(
+        (contestVotes) => contestVotes && contestVotes.length > 0
+      )
+    ) {
+      setPartyIdToConfirm(partyId);
+    } else {
+      selectParty(partyId);
+    }
+  }
+
+  return (
+    <VoterScreen
+      actionButtons={
+        isReviewMode ? (
+          <LinkButton
+            icon="Previous"
+            id={PageNavigationButtonId.NEXT}
+            variant="primary"
+            to={reviewPageUrl}
+          >
+            {appStrings.buttonReview()}
+          </LinkButton>
+        ) : (
+          <React.Fragment>
+            <LinkButton
+              icon="Previous"
+              id={PageNavigationButtonId.PREVIOUS}
+              to={startPageUrl}
+            >
+              {appStrings.buttonBack()}
+            </LinkButton>
+            <LinkButton
+              rightIcon="Next"
+              id={PageNavigationButtonId.NEXT}
+              variant={selectedPartyId ? 'primary' : 'neutral'}
+              to={selectedPartyId ? contestsPageUrl : undefined}
+              disabled={!selectedPartyId}
+            >
+              {appStrings.buttonNext()}
+            </LinkButton>
+          </React.Fragment>
+        )
+      }
+    >
+      <Header>
+        <ReadOnLoad>
+          <H2>{appStrings.titleBmdPartySelectionScreen()}</H2>
+          <Caption>
+            {appStrings.instructionsBmdPartySelection()}
+            <AudioOnly>
+              <AssistiveTechInstructions
+                controllerString={appStrings.instructionsBmdPartySelectionNavigation()}
+                patDeviceString={appStrings.instructionsBmdPartySelectionNavigationPatDevice()}
+              />
+            </AudioOnly>
+          </Caption>
+        </ReadOnLoad>
+      </Header>
+      <WithScrollButtons>
+        <OptionRadioGroup
+          label="Party"
+          hideLabel
+          options={election.parties.map((party) => {
+            const isSelected = party.id === selectedPartyId;
+            return {
+              value: party.id,
+              label: (
+                <React.Fragment>
+                  {isSelected && (
+                    <AudioOnly>{appStrings.labelSelected()}</AudioOnly>
+                  )}
+                  {electionStrings.partyFullName(party)}
+                  {isSelected && !isReviewMode && (
+                    <AudioOnly>
+                      {appStrings.noteBmdPartySelectionCompleted()}
+                    </AudioOnly>
+                  )}
+                </React.Fragment>
+              ),
+            };
+          })}
+          value={selectedPartyId}
+          onChange={handleSelect}
+        />
+      </WithScrollButtons>
+      {partyIdToConfirm && (
+        <Modal
+          title={appStrings.titleBmdConfirmPartyChange()}
+          content={<P>{appStrings.warningBmdPartyChangeClearsVotes()}</P>}
+          actions={
+            <React.Fragment>
+              <Button
+                id={PageNavigationButtonId.NEXT_AFTER_CONFIRM}
+                variant="primary"
+                onPress={() => {
+                  selectParty(partyIdToConfirm);
+                  setPartyIdToConfirm(undefined);
+                  setIsReviewMode(false);
+                }}
+              >
+                {appStrings.buttonChangeParty()}
+                <AudioOnly>
+                  <AssistiveTechInstructions
+                    controllerString={appStrings.instructionsBmdSelectToConfirm()}
+                    patDeviceString={appStrings.instructionsBmdSelectToConfirmPatDevice()}
+                  />
+                </AudioOnly>
+              </Button>
+              <Button
+                id={PageNavigationButtonId.PREVIOUS}
+                onPress={() => setPartyIdToConfirm(undefined)}
+              >
+                {appStrings.buttonCancel()}
+              </Button>
+            </React.Fragment>
+          }
+          onOverlayClick={
+            /* istanbul ignore next - @preserve */
+            () => setPartyIdToConfirm(undefined)
+          }
+        />
+      )}
+    </VoterScreen>
+  );
+}


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Ports the VxMark open primary changes (#8326, #8336, #8337, #8350) to VxMarkScan, then factors out the party selection screen into a shared component.

Task: #7823

## Demo Video or Screenshot

I promise this is a new video 😆 

https://github.com/user-attachments/assets/721e1b04-20aa-4b8c-8d1a-8cad23d7d135



## Testing Plan

- Added automated tests
- Manual walkthrough to confirm audio

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
