### PR TITLE
VxPollBook: add missing import

### DIFF
--- a/libs/utils/src/tabulation/open_primary.ts
+++ b/libs/utils/src/tabulation/open_primary.ts
@@ -3,6 +3,7 @@ import {
   CandidateContest,
   Election,
   PartyId,
+  Tabulation,
   VotesDict,
   isOpenPrimary,
 } from '@votingworks/types';


### PR DESCRIPTION
## Overview

Build on `main` is [broken](https://app.circleci.com/pipelines/github/votingworks/vxsuite/25838) due to missing import 

## Demo Video or Screenshot

N/A

## Testing Plan

N/A

