### PR TITLE
VxScan: Tweak crossover voting warning copy

### DIFF
--- a/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
@@ -159,7 +159,7 @@ test('crossover voting (cast ballot)', async () => {
   await screen.findByRole('heading', { name: 'Review Your Ballot' });
   screen.getByText(
     'You voted in contests for more than one party. ' +
-      'If you cast this ballot, only your nonpartisan votes will count.'
+      'If you cast this ballot, those votes will not be counted.'
   );
   const castBallotButton = screen.getButton('Cast Ballot');
   const returnBallotButton = screen.getButton('Return Ballot');

--- a/libs/ui/src/ui_strings/app_strings.tsx
+++ b/libs/ui/src/ui_strings/app_strings.tsx
@@ -1778,7 +1778,7 @@ export const appStrings = {
   warningScannerCrossoverVoting: () => (
     <UiString uiStringKey="warningScannerCrossoverVoting">
       You voted in contests for more than one party. If you cast this ballot,
-      only your nonpartisan votes will count.
+      those votes will not be counted.
     </UiString>
   ),
 

--- a/libs/ui/src/ui_strings/app_strings_catalog/latest.json
+++ b/libs/ui/src/ui_strings/app_strings_catalog/latest.json
@@ -523,7 +523,7 @@
   "warningScannerAnotherScanInProgress": "Another ballot is being scanned.",
   "warningScannerBlankBallotSubmission": "No votes will be counted from this ballot.",
   "warningScannerBmdBallotScanningDisabled": "The scanner cannot scan BMD ballots. Use a central scanner instead.",
-  "warningScannerCrossoverVoting": "You voted in contests for more than one party. If you cast this ballot, only your nonpartisan votes will count.",
+  "warningScannerCrossoverVoting": "You voted in contests for more than one party. If you cast this ballot, those votes will not be counted.",
   "warningScannerMismatchedElection": "The scanner is configured for an election that does not match the ballot.",
   "warningScannerMismatchedPrecinct": "The scanner is configured for a precinct that does not match the ballot.",
   "warningScannerNeedsCleaning": "The ballot was not counted. Scan it again after cleaning.",


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Tweak the VxScan crossover voting warning copy to use plainer language (mainly removing "nonpartisan", which I realized is pretty jargon-y)

## Demo Video or Screenshot

Skipped since no layout change

## Testing Plan

- Updated automated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
