### PR TITLE
VxPrint: Add missing startup and lifecycle logging

### DIFF
--- a/apps/print/backend/src/app.test.ts
+++ b/apps/print/backend/src/app.test.ts
@@ -287,6 +287,11 @@ test('configureElectionPackageFromUsb returns no_ballots error when election pac
 
   const result = await apiClient.configureElectionPackageFromUsb();
   expect(result).toEqual(err({ type: 'no_ballots' }));
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.ElectionConfigured,
+    expect.anything(),
+    expect.objectContaining({ disposition: 'failure' })
+  );
 });
 
 // [TODO] Update test name after migration to Polling Places.
@@ -471,6 +476,11 @@ test('unconfigureMachine clears election configuration', async () => {
   expect(await apiClient.getBallots({})).toEqual([]);
   expect(await apiClient.getTestMode()).toEqual(false);
   expect(workspace.store.getSystemSettings()).toBeUndefined();
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.ElectionUnconfigured,
+    expect.anything(),
+    expect.objectContaining({ disposition: 'success' })
+  );
 });
 
 test('printBallot logs when ballot is not found', async () => {

--- a/apps/print/backend/src/app.ts
+++ b/apps/print/backend/src/app.ts
@@ -105,6 +105,11 @@ export function buildApi(ctx: AppContext) {
         electionPackageResult.ok();
       const { electionDefinition, systemSettings, ballots } = electionPackage;
       if (!ballots || ballots.length === 0) {
+        await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
+          disposition: 'failure',
+          message: 'Error configuring machine: election package has no ballots.',
+          errorDetails: JSON.stringify({ type: 'no_ballots' }),
+        });
         return err({ type: 'no_ballots' });
       }
       assert(systemSettings);
@@ -215,8 +220,13 @@ export function buildApi(ctx: AppContext) {
       });
     },
 
-    unconfigureMachine(): void {
+    async unconfigureMachine(): Promise<void> {
       store.reset();
+      await logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
+        disposition: 'success',
+        message:
+          'User successfully unconfigured the machine to remove the current election and all current ballot data.',
+      });
     },
 
     /* istanbul ignore next - @preserve */
@@ -225,15 +235,22 @@ export function buildApi(ctx: AppContext) {
 
       const { codeVersion } = getMachineConfig();
       const electionRecord = store.getElectionRecord();
-      const qrCodeValue = await generateSignedHashValidationQrCodeValue({
-        electionRecord,
-        softwareVersion: codeVersion,
-      });
-
-      await logger.logAsCurrentRole(LogEventId.SignedHashValidationComplete, {
-        disposition: 'success',
-      });
-      return qrCodeValue;
+      try {
+        const qrCodeValue = await generateSignedHashValidationQrCodeValue({
+          electionRecord,
+          softwareVersion: codeVersion,
+        });
+        await logger.logAsCurrentRole(LogEventId.SignedHashValidationComplete, {
+          disposition: 'success',
+        });
+        return qrCodeValue;
+      } catch (error) {
+        await logger.logAsCurrentRole(LogEventId.SignedHashValidationComplete, {
+          disposition: 'failure',
+          message: (error as Error).message,
+        });
+        throw error;
+      }
     },
 
     ...createSystemCallApi({

--- a/apps/print/backend/src/server.test.ts
+++ b/apps/print/backend/src/server.test.ts
@@ -6,7 +6,7 @@ import {
   MockedFunction,
   afterEach,
 } from 'vitest';
-import { mockBaseLogger } from '@votingworks/logging';
+import { LogEventId, mockBaseLogger } from '@votingworks/logging';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
 import { buildMockDippedSmartCardAuth } from '@votingworks/auth';
 import { Application } from 'express';
@@ -53,4 +53,76 @@ test('start passes context to `buildApp`', () => {
     printer: expect.anything(),
   });
   expect(listen).toHaveBeenCalledWith(PORT, expect.any(Function));
+});
+
+test('logs ApplicationStartup success when server starts listening', () => {
+  const listen = vi.fn((_port: number, callback: () => unknown) => {
+    callback();
+    return { close: vi.fn() };
+  });
+  mockBuildApp.mockReturnValueOnce({ listen } as unknown as Application);
+
+  const baseLogger = mockBaseLogger({ fn: vi.fn });
+  workspace = createWorkspace(makeTemporaryDirectory(), baseLogger);
+  const auth = buildMockDippedSmartCardAuth(vi.fn);
+
+  start({ auth, baseLogger, workspace });
+
+  expect(baseLogger.log).toHaveBeenCalledWith(
+    LogEventId.ApplicationStartup,
+    'system',
+    {
+      message: expect.stringContaining('VxPrint backend running'),
+      disposition: 'success',
+    }
+  );
+});
+
+test('logs DataCheckOnStartup when printed ballot data is present', () => {
+  const listen = vi.fn((_port: number, callback: () => unknown) => {
+    callback();
+    return { close: vi.fn() };
+  });
+  mockBuildApp.mockReturnValueOnce({ listen } as unknown as Application);
+
+  const baseLogger = mockBaseLogger({ fn: vi.fn });
+  workspace = createWorkspace(makeTemporaryDirectory(), baseLogger);
+  vi.spyOn(workspace.store, 'getTotalBallotsPrinted').mockReturnValue(5);
+  const auth = buildMockDippedSmartCardAuth(vi.fn);
+
+  start({ auth, baseLogger, workspace });
+
+  expect(baseLogger.log).toHaveBeenCalledWith(
+    LogEventId.DataCheckOnStartup,
+    'system',
+    {
+      message:
+        'Printed ballot data is present in the database at machine startup.',
+      ballotsPrinted: 5,
+    }
+  );
+});
+
+test('logs DataCheckOnStartup when no printed ballot data is present', () => {
+  const listen = vi.fn((_port: number, callback: () => unknown) => {
+    callback();
+    return { close: vi.fn() };
+  });
+  mockBuildApp.mockReturnValueOnce({ listen } as unknown as Application);
+
+  const baseLogger = mockBaseLogger({ fn: vi.fn });
+  workspace = createWorkspace(makeTemporaryDirectory(), baseLogger);
+  const auth = buildMockDippedSmartCardAuth(vi.fn);
+
+  start({ auth, baseLogger, workspace });
+
+  expect(baseLogger.log).toHaveBeenCalledWith(
+    LogEventId.DataCheckOnStartup,
+    'system',
+    {
+      message:
+        'No printed ballot data is present in the database at machine startup.',
+      ballotsPrinted: 0,
+    }
+  );
 });

--- a/apps/print/backend/src/server.ts
+++ b/apps/print/backend/src/server.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { BaseLogger, Logger } from '@votingworks/logging';
+import { BaseLogger, Logger, LogEventId } from '@votingworks/logging';
 import { DippedSmartCardAuthApi } from '@votingworks/auth';
 import { detectUsbDrive } from '@votingworks/usb-drive';
 import { useDevDockRouter } from '@votingworks/dev-dock-backend';
@@ -38,6 +38,16 @@ export function start({ auth, baseLogger, workspace }: StartOptions): void {
     workspace,
     printer,
   };
+
+  const totalBallotsPrinted = workspace.store.getTotalBallotsPrinted();
+  baseLogger.log(LogEventId.DataCheckOnStartup, 'system', {
+    message:
+      totalBallotsPrinted > 0
+        ? 'Printed ballot data is present in the database at machine startup.'
+        : 'No printed ballot data is present in the database at machine startup.',
+    ballotsPrinted: totalBallotsPrinted,
+  });
+
   const app = buildApp(context);
 
   useDevDockRouter(app, express, { printerConfig: HP_LASER_PRINTER_CONFIG });
@@ -48,8 +58,10 @@ export function start({ auth, baseLogger, workspace }: StartOptions): void {
     PORT,
     /* istanbul ignore next - @preserve */
     () => {
-      // eslint-disable-next-line no-console
-      console.log(`VxPrint backend running at http://localhost:${PORT}/`);
+      void baseLogger.log(LogEventId.ApplicationStartup, 'system', {
+        message: `VxPrint backend running at http://localhost:${PORT}/`,
+        disposition: 'success',
+      });
     }
   );
 }

--- a/apps/print/backend/src/store.ts
+++ b/apps/print/backend/src/store.ts
@@ -317,6 +317,13 @@ export class Store {
     }
   }
 
+  getTotalBallotsPrinted(): number {
+    const result = this.client.one(
+      'select coalesce(sum(print_count), 0) as total from ballots'
+    ) as { total: number };
+    return result.total;
+  }
+
   getBallotPrintCounts({
     ballotMode,
   }: {


### PR DESCRIPTION
## Overview

Closes #8224

Adds missing log events to VxPrint to standardize logging with other apps
and meet certification requirements.

Changes:
- `DataCheckOnStartup` (Certification 1.1.1-F): logs count of printed
  ballots present in the database at machine startup
- `ApplicationStartup` success: logs when the server starts listening
- `ElectionUnconfigured`: logs when the machine is unconfigured
- `SignedHashValidationComplete` failure: logs when signed hash validation
  throws, in addition to the existing success log
- `ElectionConfigured` failure: logs when the election package has no
  ballots (previously silent)

## Demo Video or Screenshot

N/A — logging only, no UI changes

## Testing Plan

- Unit tests added/updated for all new log events in `server.test.ts`
  and `app.test.ts`
- No user-facing behavior changes