### PR TITLE
types: Add actual ballot hash to InvalidSheet interpretation

### DIFF
--- a/apps/scan/backend/src/app_scanning.test.ts
+++ b/apps/scan/backend/src/app_scanning.test.ts
@@ -93,7 +93,7 @@ test('scanBatch with streaked page', async () => {
         state: 'rejecting',
         interpretation: {
           type: 'InvalidSheet',
-          reason: 'vertical_streaks_detected',
+          reason: { type: 'vertical_streaks_detected' },
         },
       });
     }

--- a/apps/scan/backend/src/scanner.ts
+++ b/apps/scan/backend/src/scanner.ts
@@ -4,7 +4,6 @@ import {
   assertDefined,
   extractErrorMessage,
   Result,
-  throwIllegalValue,
 } from '@votingworks/basics';
 import { Logger, LogEventId, LogLine } from '@votingworks/logging';
 import {
@@ -1607,23 +1606,9 @@ export function createPrecinctScannerStateMachine({
       // Remove interpretation details that are only used internally (e.g. sheetId, pages)
       const interpretationResult: SheetInterpretation | undefined = (() => {
         if (!interpretation) return undefined;
-        switch (interpretation.type) {
-          case 'ValidSheet':
-            return { type: interpretation.type };
-          case 'InvalidSheet':
-            return {
-              type: interpretation.type,
-              reason: interpretation.reason,
-            };
-          case 'NeedsReviewSheet':
-            return {
-              type: interpretation.type,
-              reasons: interpretation.reasons,
-            };
-          /* istanbul ignore next - @preserve */
-          default:
-            return throwIllegalValue(interpretation, 'type');
-        }
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { sheetId, pages, ...rest } = interpretation;
+        return rest;
       })();
 
       const stateNeedsErrorDetails = [

--- a/apps/scan/backend/src/scanner_scan.test.ts
+++ b/apps/scan/backend/src/scanner_scan.test.ts
@@ -308,7 +308,10 @@ test('ballot with wrong election rejected', async () => {
 
       const interpretation: SheetInterpretation = {
         type: 'InvalidSheet',
-        reason: 'invalid_ballot_hash',
+        reason: {
+          type: 'invalid_ballot_hash',
+          actualBallotHash: expect.any(String) as unknown as string,
+        },
       };
       await waitForStatus(apiClient, { state: 'rejecting', interpretation });
       expect(mockScanner.client.ejectDocument).toHaveBeenCalledWith(
@@ -351,7 +354,7 @@ test('ballot with wrong precinct rejected (polling places disabled)', async () =
 
       const interpretation: SheetInterpretation = {
         type: 'InvalidSheet',
-        reason: 'invalid_precinct',
+        reason: { type: 'invalid_precinct' },
       };
       await waitForStatus(apiClient, { state: 'rejecting', interpretation });
       expect(mockScanner.client.ejectDocument).toHaveBeenCalledWith(
@@ -386,7 +389,7 @@ test('ballot with wrong precinct rejected', async () => {
 
       const interpretation: SheetInterpretation = {
         type: 'InvalidSheet',
-        reason: 'invalid_precinct',
+        reason: { type: 'invalid_precinct' },
       };
       await waitForStatus(apiClient, { state: 'rejecting', interpretation });
       expect(mockScanner.client.ejectDocument).toHaveBeenCalledWith(
@@ -425,7 +428,7 @@ test('BMD ballot rejected when BMD ballot scanning disabled', async () => {
 
       const interpretation: SheetInterpretation = {
         type: 'InvalidSheet',
-        reason: 'bmd_ballot_scanning_disabled',
+        reason: { type: 'bmd_ballot_scanning_disabled' },
       };
       await waitForStatus(apiClient, { state: 'rejecting', interpretation });
       expect(mockScanner.client.ejectDocument).toHaveBeenCalledWith(
@@ -464,7 +467,7 @@ test('ballot printed at an invalid scale is rejected', async () => {
 
       const interpretation: SheetInterpretation = {
         type: 'InvalidSheet',
-        reason: 'invalid_scale',
+        reason: { type: 'invalid_scale' },
       };
       await waitForStatus(apiClient, { state: 'rejecting', interpretation });
       expect(mockScanner.client.ejectDocument).toHaveBeenCalledWith(
@@ -494,7 +497,7 @@ test('blank sheet rejected', async () => {
 
       const interpretation: SheetInterpretation = {
         type: 'InvalidSheet',
-        reason: 'unreadable',
+        reason: { type: 'unreadable' },
       };
       await waitForStatus(apiClient, { state: 'rejecting', interpretation });
       expect(mockScanner.client.ejectDocument).toHaveBeenCalledWith(

--- a/apps/scan/backend/src/scanner_scan_disconnect.test.ts
+++ b/apps/scan/backend/src/scanner_scan_disconnect.test.ts
@@ -292,7 +292,10 @@ test('scanner disconnected while rejecting', async () => {
 
       const interpretation: SheetInterpretation = {
         type: 'InvalidSheet',
-        reason: 'invalid_ballot_hash',
+        reason: {
+          type: 'invalid_ballot_hash',
+          actualBallotHash: expect.any(String) as unknown as string,
+        },
       };
       await waitForStatus(apiClient, { state: 'rejecting', interpretation });
 
@@ -408,7 +411,10 @@ test('scanner disconnected after rejecting', async () => {
 
       const interpretation: SheetInterpretation = {
         type: 'InvalidSheet',
-        reason: 'invalid_ballot_hash',
+        reason: {
+          type: 'invalid_ballot_hash',
+          actualBallotHash: expect.any(String) as unknown as string,
+        },
       };
       await waitForStatus(apiClient, { state: 'rejecting', interpretation });
 

--- a/apps/scan/backend/src/scanner_scan_jam.test.ts
+++ b/apps/scan/backend/src/scanner_scan_jam.test.ts
@@ -202,7 +202,10 @@ test('jam while rejecting', async () => {
 
       const interpretation: SheetInterpretation = {
         type: 'InvalidSheet',
-        reason: 'invalid_ballot_hash',
+        reason: {
+          type: 'invalid_ballot_hash',
+          actualBallotHash: expect.any(String) as unknown as string,
+        },
       };
       const deferredEject = deferred<Result<void, ScannerError>>();
       mockScanner.client.ejectDocument.mockReturnValueOnce(

--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -532,7 +532,10 @@ test('voter tries to cast ballot that is rejected', async () => {
       state: 'rejected',
       interpretation: {
         type: 'InvalidSheet',
-        reason: 'invalid_ballot_hash',
+        reason: {
+          type: 'invalid_ballot_hash',
+          actualBallotHash: 'mock-actual-hash',
+        },
       },
     })
   );

--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -152,7 +152,7 @@ export function VoterScreen({
         <ScanErrorScreen
           error={
             scannerStatus.interpretation?.type === 'InvalidSheet'
-              ? scannerStatus.interpretation.reason
+              ? scannerStatus.interpretation.reason.type
               : scannerStatus.error
           }
           {...sharedScreenProps}

--- a/libs/ballot-interpreter/src/combine_page_interpretations_for_sheet.test.ts
+++ b/libs/ballot-interpreter/src/combine_page_interpretations_for_sheet.test.ts
@@ -265,7 +265,7 @@ test('treats either page being an invalid ballot hash as an invalid sheet', () =
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
-    reason: 'invalid_ballot_hash',
+    reason: { type: 'invalid_ballot_hash', actualBallotHash: 'actual' },
   });
   expect(
     combinePageInterpretationsForSheet(
@@ -274,7 +274,7 @@ test('treats either page being an invalid ballot hash as an invalid sheet', () =
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
-    reason: 'invalid_ballot_hash',
+    reason: { type: 'invalid_ballot_hash', actualBallotHash: 'actual' },
   });
 });
 
@@ -290,7 +290,7 @@ test('treats either page being an invalid test mode as an invalid sheet', () => 
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
-    reason: 'invalid_test_mode',
+    reason: { type: 'invalid_test_mode' },
   });
   expect(
     combinePageInterpretationsForSheet(
@@ -299,7 +299,7 @@ test('treats either page being an invalid test mode as an invalid sheet', () => 
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
-    reason: 'invalid_test_mode',
+    reason: { type: 'invalid_test_mode' },
   });
 });
 
@@ -315,7 +315,7 @@ test('treats either page being an invalid precinct as an invalid sheet', () => {
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
-    reason: 'invalid_precinct',
+    reason: { type: 'invalid_precinct' },
   });
   expect(
     combinePageInterpretationsForSheet(
@@ -324,7 +324,7 @@ test('treats either page being an invalid precinct as an invalid sheet', () => {
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
-    reason: 'invalid_precinct',
+    reason: { type: 'invalid_precinct' },
   });
 });
 
@@ -340,7 +340,7 @@ test('treats either page having invalid scale as an invalid sheet', () => {
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
-    reason: 'invalid_scale',
+    reason: { type: 'invalid_scale' },
   });
   expect(
     combinePageInterpretationsForSheet(
@@ -349,7 +349,7 @@ test('treats either page having invalid scale as an invalid sheet', () => {
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
-    reason: 'invalid_scale',
+    reason: { type: 'invalid_scale' },
   });
 });
 
@@ -365,7 +365,7 @@ test('treats either page having BMD ballot scanning disabled as an invalid sheet
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
-    reason: 'bmd_ballot_scanning_disabled',
+    reason: { type: 'bmd_ballot_scanning_disabled' },
   });
   expect(
     combinePageInterpretationsForSheet(
@@ -374,7 +374,7 @@ test('treats either page having BMD ballot scanning disabled as an invalid sheet
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
-    reason: 'bmd_ballot_scanning_disabled',
+    reason: { type: 'bmd_ballot_scanning_disabled' },
   });
 });
 
@@ -390,7 +390,7 @@ test('treats either page having vertical streaks as an invalid sheet', () => {
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
-    reason: 'vertical_streaks_detected',
+    reason: { type: 'vertical_streaks_detected' },
   });
   expect(
     combinePageInterpretationsForSheet(
@@ -399,7 +399,7 @@ test('treats either page having vertical streaks as an invalid sheet', () => {
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
-    reason: 'vertical_streaks_detected',
+    reason: { type: 'vertical_streaks_detected' },
   });
 });
 
@@ -411,20 +411,17 @@ test('treats unreadable pages as an invalid sheet', () => {
     )
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
-    reason: 'unreadable',
+    reason: { type: 'unreadable' },
   });
 });
 
 test('treats unmatched page combinations as unknown invalid sheet', () => {
   // Both blank doesn't match any specific case.
   expect(
-    combinePageInterpretationsForSheet(
-      [blankPage, blankPage],
-      election
-    )
+    combinePageInterpretationsForSheet([blankPage, blankPage], election)
   ).toEqual<SheetInterpretation>({
     type: 'InvalidSheet',
-    reason: 'unknown',
+    reason: { type: 'unknown' },
   });
 });
 
@@ -444,10 +441,7 @@ test('flags crossover voting in open primaries', () => {
     },
   });
   expect(
-    combinePageInterpretationsForSheet(
-      [front, back],
-      openPrimaryElection
-    )
+    combinePageInterpretationsForSheet([front, back], openPrimaryElection)
   ).toEqual<SheetInterpretation>({
     type: 'NeedsReviewSheet',
     reasons: [{ type: AdjudicationReason.CrossoverVoting }],
@@ -479,10 +473,7 @@ test('combines crossover voting with other adjudication reasons', () => {
     },
   });
   expect(
-    combinePageInterpretationsForSheet(
-      [front, back],
-      openPrimaryElection
-    )
+    combinePageInterpretationsForSheet([front, back], openPrimaryElection)
   ).toEqual<SheetInterpretation>({
     type: 'NeedsReviewSheet',
     reasons: [overvoteReason, { type: AdjudicationReason.CrossoverVoting }],
@@ -505,10 +496,7 @@ test('treats single-party open primary voting as valid', () => {
     },
   });
   expect(
-    combinePageInterpretationsForSheet(
-      [front, back],
-      openPrimaryElection
-    )
+    combinePageInterpretationsForSheet([front, back], openPrimaryElection)
   ).toEqual<SheetInterpretation>({
     type: 'ValidSheet',
   });

--- a/libs/ballot-interpreter/src/combine_page_interpretations_for_sheet.ts
+++ b/libs/ballot-interpreter/src/combine_page_interpretations_for_sheet.ts
@@ -4,6 +4,7 @@ import {
   Election,
   InterpretedBmdMultiPagePage,
   InterpretedBmdPage,
+  InvalidBallotHashPage,
   PageInterpretation,
   SheetInterpretation,
   SheetOf,
@@ -122,9 +123,15 @@ export function combinePageInterpretationsForSheet(
     frontType === 'InvalidBallotHashPage' ||
     backType === 'InvalidBallotHashPage'
   ) {
+    const invalidPage = (
+      front.type === 'InvalidBallotHashPage' ? front : back
+    ) as InvalidBallotHashPage;
     return {
       type: 'InvalidSheet',
-      reason: 'invalid_ballot_hash',
+      reason: {
+        type: 'invalid_ballot_hash',
+        actualBallotHash: invalidPage.actualBallotHash,
+      },
     };
   }
 
@@ -134,7 +141,7 @@ export function combinePageInterpretationsForSheet(
   ) {
     return {
       type: 'InvalidSheet',
-      reason: 'invalid_test_mode',
+      reason: { type: 'invalid_test_mode' },
     };
   }
 
@@ -144,7 +151,7 @@ export function combinePageInterpretationsForSheet(
   ) {
     return {
       type: 'InvalidSheet',
-      reason: 'invalid_precinct',
+      reason: { type: 'invalid_precinct' },
     };
   }
 
@@ -154,7 +161,7 @@ export function combinePageInterpretationsForSheet(
   ) {
     return {
       type: 'InvalidSheet',
-      reason: 'invalid_scale',
+      reason: { type: 'invalid_scale' },
     };
   }
 
@@ -166,7 +173,7 @@ export function combinePageInterpretationsForSheet(
   ) {
     return {
       type: 'InvalidSheet',
-      reason: 'bmd_ballot_scanning_disabled',
+      reason: { type: 'bmd_ballot_scanning_disabled' },
     };
   }
 
@@ -178,19 +185,19 @@ export function combinePageInterpretationsForSheet(
   ) {
     return {
       type: 'InvalidSheet',
-      reason: 'vertical_streaks_detected',
+      reason: { type: 'vertical_streaks_detected' },
     };
   }
 
   if (frontType === 'UnreadablePage' || backType === 'UnreadablePage') {
     return {
       type: 'InvalidSheet',
-      reason: 'unreadable',
+      reason: { type: 'unreadable' },
     };
   }
 
   return {
     type: 'InvalidSheet',
-    reason: 'unknown',
+    reason: { type: 'unknown' },
   };
 }

--- a/libs/types/src/interpretation.ts
+++ b/libs/types/src/interpretation.ts
@@ -193,15 +193,24 @@ export const BallotSheetInfoSchema: z.ZodSchema<BallotSheetInfo> = z.object({
   adjudicationReason: AdjudicationReasonSchema.optional(),
 });
 
+export type InvalidInterpretationReasonInfo =
+  | {
+      type: 'invalid_ballot_hash';
+      actualBallotHash: string;
+    }
+  | {
+      type:
+        | 'bmd_ballot_scanning_disabled'
+        | 'invalid_test_mode'
+        | 'invalid_precinct'
+        | 'vertical_streaks_detected'
+        | 'invalid_scale'
+        | 'unreadable'
+        | 'unknown';
+    };
+
 export type InvalidInterpretationReason =
-  | 'bmd_ballot_scanning_disabled'
-  | 'invalid_test_mode'
-  | 'invalid_ballot_hash'
-  | 'invalid_precinct'
-  | 'vertical_streaks_detected'
-  | 'invalid_scale'
-  | 'unreadable'
-  | 'unknown';
+  InvalidInterpretationReasonInfo['type'];
 
 export type SheetInterpretation =
   | {
@@ -209,7 +218,7 @@ export type SheetInterpretation =
     }
   | {
       type: 'InvalidSheet';
-      reason: InvalidInterpretationReason;
+      reason: InvalidInterpretationReasonInfo;
     }
   | {
       type: 'NeedsReviewSheet';


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

When adjudicating a ballot with the wrong ballot hash, VxCentralScan shows the actual ballot hash. To prep for switching VxCentralScan to use sheet interpretations instead of page interpretations, we need to carry the actual ballot hash along in the sheet interpretation. We follow the pattern that the NeedsReview sheet uses of having reason info objects that carry both the reason as well as additional data about it.

## Demo Video or Screenshot

N/A

## Testing Plan

Updated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
