### PR TITLE
VxCentralScan: Drop unused adjudicated count from adjudicationStatus store method

### DIFF
--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -325,8 +325,7 @@ export class Importer {
       const sheetId = await this.sheetAdded(sheet, currentBatch.batchId);
       debug('got a ballot card: %o, %s', sheet, sheetId);
 
-      const adjudicationStatus = this.workspace.store.adjudicationStatus();
-      if (adjudicationStatus.remaining === 0) {
+      if (this.workspace.store.adjudicationsRemaining() === 0) {
         this.continueImport({ forceAccept: false });
       }
     }
@@ -445,8 +444,7 @@ export class Importer {
    */
   async waitForEndOfBatchOrScanningPause(): Promise<void> {
     while (this.currentBatch) {
-      const adjudicationStatus = this.workspace.store.adjudicationStatus();
-      if (adjudicationStatus.remaining > 0) {
+      if (this.workspace.store.adjudicationsRemaining() > 0) {
         break;
       }
 
@@ -475,8 +473,7 @@ export class Importer {
     return {
       isScannerAttached: this.scanner.isAttached(),
       ongoingBatchId: this.currentBatch?.batchId,
-      adjudicationsRemaining:
-        this.workspace.store.adjudicationStatus().remaining,
+      adjudicationsRemaining: this.workspace.store.adjudicationsRemaining(),
       batches: this.workspace.store.getBatches(),
       canUnconfigure: this.workspace.store.getCanUnconfigure(),
     };

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -4,7 +4,6 @@
 
 import { Client as DbClient } from '@votingworks/db';
 import {
-  AdjudicationStatus,
   HmpbBallotPaperSize,
   BallotSheetInfo,
   BatchInfo,
@@ -819,9 +818,9 @@ export class Store {
   }
 
   /**
-   * Gets adjudication status.
+   * Counts sheets awaiting adjudication.
    */
-  adjudicationStatus(): AdjudicationStatus {
+  adjudicationsRemaining(): number {
     const { remaining } = this.client.one(`
         select count(*) as remaining
         from sheets
@@ -830,14 +829,7 @@ export class Store {
           and deleted_at is null
           and finished_adjudication_at is null
       `) as { remaining: number };
-    const { adjudicated } = this.client.one(`
-        select count(*) as adjudicated
-        from sheets
-        where
-          requires_adjudication = 1
-          and finished_adjudication_at is not null
-      `) as { adjudicated: number };
-    return { adjudicated, remaining };
+    return remaining;
   }
 
   /**

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -1369,17 +1369,6 @@ export const AdjudicationInfoSchema: z.ZodSchema<AdjudicationInfo> = z.object({
   ignoredReasonInfos: z.array(AdjudicationReasonInfoSchema),
 });
 
-export interface AdjudicationStatus {
-  adjudicated: number;
-  remaining: number;
-}
-
-export const AdjudicationStatusSchema: z.ZodSchema<AdjudicationStatus> =
-  z.object({
-    adjudicated: z.number(),
-    remaining: z.number(),
-  });
-
 export type Side = 'front' | 'back';
 export const SideSchema = z.union([z.literal('front'), z.literal('back')]);
 


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

The central-scan store's `adjudicationStatus()` returned `{ adjudicated, remaining }` but no caller ever read `adjudicated`. This drops the dead field, renames the method to `adjudicationsRemaining(): number`, and deletes the now-unused `AdjudicationStatus` interface and schema from `libs/types`.

## Demo Video or Screenshot

N/A

## Testing Plan

Existing tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
