### PR TITLE
VxCentralScan: Use sheet-level interpretation in adjudication screen

### DIFF
--- a/apps/central-scan/backend/src/app.grout.test.ts
+++ b/apps/central-scan/backend/src/app.grout.test.ts
@@ -391,7 +391,7 @@ test('get next sheet returns null when no adjudication sheet', async () => {
   });
 });
 
-test('getNextReviewSheet includes images', async () => {
+test('getNextReviewSheet returns interpretation and image data for uninterpretable sheets', async () => {
   const electionDefinition =
     electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
 
@@ -414,89 +414,25 @@ test('getNextReviewSheet includes images', async () => {
       type: 'InvalidSheet',
       reason: { type: 'unknown' },
     });
+
     const [frontImage, backImage] = result!.images;
-    expect(frontImage).toMatchObject({
-      imageUrl: expect.stringMatching(/^data:image\//),
-      ballotBounds: {
-        x: 0,
-        y: 0,
-        width: expect.any(Number),
-        height: expect.any(Number),
-      },
-    });
-    expect(backImage).toMatchObject({
-      imageUrl: expect.stringMatching(/^data:image\//),
-      ballotBounds: {
-        x: 0,
-        y: 0,
-        width: expect.any(Number),
-        height: expect.any(Number),
-      },
-    });
+    for (const image of [frontImage, backImage]) {
+      expect(image).toMatchObject({
+        imageUrl: expect.stringMatching(/^data:image\//),
+        ballotBounds: {
+          x: 0,
+          y: 0,
+          width: expect.any(Number),
+          height: expect.any(Number),
+        },
+      });
+    }
     expect(frontImage.layout).toBeUndefined();
     expect(backImage.layout).toBeUndefined();
   });
 });
 
-test('getNextReviewSheet includes layouts for HMPB pages', async () => {
-  const electionDefinition =
-    electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
-
-  await withApp(async ({ apiClient, importer, workspace }) => {
-    importer.configure(
-      electionDefinition,
-      jurisdiction,
-      'test-election-package-hash'
-    );
-    const batchId = workspace.store.addBatch();
-
-    const metadata: BallotMetadata = {
-      ballotHash: electionDefinition.ballotHash,
-      ballotType: BallotType.Precinct,
-      ballotStyleId: 'card-number-3' as BallotStyleId,
-      precinctId: 'town-id-00701-precinct-id-default',
-      isTestMode: false,
-    };
-    const hmpbInterpretation: InterpretedHmpbPage = {
-      type: 'InterpretedHmpbPage',
-      metadata: { ...metadata, pageNumber: 1 },
-      markInfo: { ballotSize: { width: 1, height: 1 }, marks: [] },
-      adjudicationInfo: {
-        requiresAdjudication: true,
-        enabledReasons: [AdjudicationReason.Overvote],
-        enabledReasonInfos: [
-          {
-            type: AdjudicationReason.Overvote,
-            contestId: 'contest-id',
-            expected: 1,
-            optionIds: ['option-id', 'option-id-2'],
-          },
-        ],
-        ignoredReasonInfos: [],
-      },
-      votes: {},
-      layout: {
-        pageSize: { width: 1, height: 1 },
-        metadata: { ...metadata, pageNumber: 1 },
-        contests: [],
-      },
-    };
-
-    workspace.store.addSheet(electionDefinition.election, uuid(), batchId, [
-      { imagePath: frontImagePath, interpretation: hmpbInterpretation },
-      { imagePath: backImagePath, interpretation: { type: 'BlankPage' } },
-    ]);
-    workspace.store.finishBatch({ batchId });
-
-    const result = await apiClient.getNextReviewSheet();
-    expect(result).toBeDefined();
-    const [frontImage, backImage] = result!.images;
-    expect(frontImage.layout).toEqual(hmpbInterpretation.layout);
-    expect(backImage.layout).toBeUndefined();
-  });
-});
-
-test('getNextReviewSheet includes sheet interpretation', async () => {
+test('getNextReviewSheet returns interpretation, image data, and layouts for interpretable sheets', async () => {
   const electionDefinition =
     electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
 
@@ -543,13 +479,12 @@ test('getNextReviewSheet includes sheet interpretation', async () => {
       expected: 1,
       optionIds: ['option-id', 'option-id-2'],
     };
+    const frontPage = buildHmpbPage(1, [overvoteReason]);
+    const backPage = buildHmpbPage(2);
 
     workspace.store.addSheet(electionDefinition.election, uuid(), batchId, [
-      {
-        imagePath: frontImagePath,
-        interpretation: buildHmpbPage(1, [overvoteReason]),
-      },
-      { imagePath: backImagePath, interpretation: buildHmpbPage(2) },
+      { imagePath: frontImagePath, interpretation: frontPage },
+      { imagePath: backImagePath, interpretation: backPage },
     ]);
     workspace.store.finishBatch({ batchId });
 
@@ -558,5 +493,8 @@ test('getNextReviewSheet includes sheet interpretation', async () => {
       type: 'NeedsReviewSheet',
       reasons: [overvoteReason],
     });
+    const [frontImage, backImage] = result!.images;
+    expect(frontImage.layout).toEqual(frontPage.layout);
+    expect(backImage.layout).toEqual(backPage.layout);
   });
 });

--- a/apps/central-scan/backend/src/app.grout.test.ts
+++ b/apps/central-scan/backend/src/app.grout.test.ts
@@ -10,6 +10,7 @@ import { LogEventId } from '@votingworks/logging';
 import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import {
   AdjudicationReason,
+  AdjudicationReasonInfo,
   BallotMetadata,
   BallotStyleId,
   BallotType,
@@ -401,26 +402,18 @@ test('getNextReviewSheet includes images', async () => {
       'test-election-package-hash'
     );
     const batchId = workspace.store.addBatch();
-    const sheetId = workspace.store.addSheet(
-      electionDefinition.election,
-      uuid(),
-      batchId,
-      sheet
-    );
+    workspace.store.addSheet(electionDefinition.election, uuid(), batchId, [
+      { imagePath: frontImagePath, interpretation: { type: 'BlankPage' } },
+      { imagePath: backImagePath, interpretation: { type: 'BlankPage' } },
+    ]);
     workspace.store.finishBatch({ batchId });
-
-    vi.spyOn(workspace.store, 'getNextAdjudicationSheet').mockReturnValueOnce({
-      id: sheetId,
-      front: {
-        interpretation: { type: 'BlankPage' },
-      },
-      back: {
-        interpretation: { type: 'BlankPage' },
-      },
-    });
 
     const result = await apiClient.getNextReviewSheet();
     expect(result).toBeDefined();
+    expect(result!.sheetInterpretation).toEqual({
+      type: 'InvalidSheet',
+      reason: { type: 'unknown' },
+    });
     const [frontImage, backImage] = result!.images;
     expect(frontImage).toMatchObject({
       imageUrl: expect.stringMatching(/^data:image\//),
@@ -456,16 +449,9 @@ test('getNextReviewSheet includes layouts for HMPB pages', async () => {
       'test-election-package-hash'
     );
     const batchId = workspace.store.addBatch();
-    const sheetId = workspace.store.addSheet(
-      electionDefinition.election,
-      uuid(),
-      batchId,
-      sheet
-    );
-    workspace.store.finishBatch({ batchId });
 
     const metadata: BallotMetadata = {
-      ballotHash: 'abcdef',
+      ballotHash: electionDefinition.ballotHash,
       ballotType: BallotType.Precinct,
       ballotStyleId: 'card-number-3' as BallotStyleId,
       precinctId: 'town-id-00701-precinct-id-default',
@@ -496,16 +482,81 @@ test('getNextReviewSheet includes layouts for HMPB pages', async () => {
       },
     };
 
-    vi.spyOn(workspace.store, 'getNextAdjudicationSheet').mockReturnValueOnce({
-      id: sheetId,
-      front: { interpretation: hmpbInterpretation },
-      back: { interpretation: { type: 'BlankPage' } },
-    });
+    workspace.store.addSheet(electionDefinition.election, uuid(), batchId, [
+      { imagePath: frontImagePath, interpretation: hmpbInterpretation },
+      { imagePath: backImagePath, interpretation: { type: 'BlankPage' } },
+    ]);
+    workspace.store.finishBatch({ batchId });
 
     const result = await apiClient.getNextReviewSheet();
     expect(result).toBeDefined();
     const [frontImage, backImage] = result!.images;
     expect(frontImage.layout).toEqual(hmpbInterpretation.layout);
     expect(backImage.layout).toBeUndefined();
+  });
+});
+
+test('getNextReviewSheet includes sheet interpretation', async () => {
+  const electionDefinition =
+    electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
+
+  await withApp(async ({ apiClient, importer, workspace }) => {
+    importer.configure(
+      electionDefinition,
+      jurisdiction,
+      'test-election-package-hash'
+    );
+    const batchId = workspace.store.addBatch();
+
+    const metadata: BallotMetadata = {
+      ballotHash: electionDefinition.ballotHash,
+      ballotType: BallotType.Precinct,
+      ballotStyleId: 'card-number-3' as BallotStyleId,
+      precinctId: 'town-id-00701-precinct-id-default',
+      isTestMode: false,
+    };
+    function buildHmpbPage(
+      pageNumber: number,
+      reasonInfos: AdjudicationReasonInfo[] = []
+    ): InterpretedHmpbPage {
+      return {
+        type: 'InterpretedHmpbPage',
+        metadata: { ...metadata, pageNumber },
+        markInfo: { ballotSize: { width: 1, height: 1 }, marks: [] },
+        adjudicationInfo: {
+          requiresAdjudication: reasonInfos.length > 0,
+          enabledReasons: reasonInfos.map((r) => r.type),
+          enabledReasonInfos: reasonInfos,
+          ignoredReasonInfos: [],
+        },
+        votes: {},
+        layout: {
+          pageSize: { width: 1, height: 1 },
+          metadata: { ...metadata, pageNumber },
+          contests: [],
+        },
+      };
+    }
+    const overvoteReason: AdjudicationReasonInfo = {
+      type: AdjudicationReason.Overvote,
+      contestId: 'contest-id',
+      expected: 1,
+      optionIds: ['option-id', 'option-id-2'],
+    };
+
+    workspace.store.addSheet(electionDefinition.election, uuid(), batchId, [
+      {
+        imagePath: frontImagePath,
+        interpretation: buildHmpbPage(1, [overvoteReason]),
+      },
+      { imagePath: backImagePath, interpretation: buildHmpbPage(2) },
+    ]);
+    workspace.store.finishBatch({ batchId });
+
+    const result = await apiClient.getNextReviewSheet();
+    expect(result!.sheetInterpretation).toEqual({
+      type: 'NeedsReviewSheet',
+      reasons: [overvoteReason],
+    });
   });
 });

--- a/apps/central-scan/backend/src/app.scanning.test.ts
+++ b/apps/central-scan/backend/src/app.scanning.test.ts
@@ -7,9 +7,9 @@ import { vxFamousNamesFixtures } from '@votingworks/hmpb';
 import { pdfToImages, writeImageData } from '@votingworks/image-utils';
 import {
   asSheet,
-  BallotPageInfo,
   BatchInfo,
   DEFAULT_SYSTEM_SETTINGS,
+  PageInterpretation,
   TEST_JURISDICTION,
 } from '@votingworks/types';
 import { readFile } from 'node:fs/promises';
@@ -183,14 +183,12 @@ test('scanBatch with streaked page', async () => {
     const nextAdjudicationSheet = workspace.store.getNextAdjudicationSheet();
 
     // adjudication should be needed because of the vertical streak
-    expect(nextAdjudicationSheet?.front).toMatchObject<Partial<BallotPageInfo>>(
-      {
-        interpretation: {
-          type: 'UnreadablePage',
-          reason: 'verticalStreaksDetected',
-        },
-      }
-    );
+    expect(nextAdjudicationSheet?.pages[0]).toMatchObject<
+      Partial<PageInterpretation>
+    >({
+      type: 'UnreadablePage',
+      reason: 'verticalStreaksDetected',
+    });
   });
 
   // try again with vertical streak detection disabled

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -16,12 +16,13 @@ import {
   SystemSettings,
   ExportCastVoteRecordsToUsbDriveError,
   DiagnosticRecord,
-  BallotSheetInfo,
   DiagnosticOutcome,
   Rect,
   mapSheet,
+  SheetInterpretation,
   SheetOf,
 } from '@votingworks/types';
+import { combinePageInterpretationsForSheet } from '@votingworks/ballot-interpreter';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import express, { Application } from 'express';
 import * as grout from '@votingworks/grout';
@@ -210,7 +211,7 @@ function buildApi({
     },
 
     async getNextReviewSheet(): Promise<{
-      interpreted: BallotSheetInfo;
+      sheetInterpretation: SheetInterpretation;
       images: SheetOf<BallotImage>;
     } | null> {
       const sheet = store.getNextAdjudicationSheet();
@@ -218,6 +219,14 @@ function buildApi({
       if (!sheet) {
         return null;
       }
+
+      const { election } = assertDefined(
+        store.getElectionRecord()
+      ).electionDefinition;
+      const sheetInterpretation = combinePageInterpretationsForSheet(
+        [sheet.front.interpretation, sheet.back.interpretation],
+        election
+      );
 
       const images = await mapSheet(
         [sheet.front, sheet.back],
@@ -246,7 +255,7 @@ function buildApi({
       );
 
       return {
-        interpreted: sheet,
+        sheetInterpretation,
         images,
       };
     },

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -224,13 +224,13 @@ function buildApi({
         store.getElectionRecord()
       ).electionDefinition;
       const sheetInterpretation = combinePageInterpretationsForSheet(
-        [sheet.front.interpretation, sheet.back.interpretation],
+        sheet.pages,
         election
       );
 
       const images = await mapSheet(
-        [sheet.front, sheet.back],
-        async (info, side): Promise<BallotImage> => {
+        sheet.pages,
+        async (interpretation, side): Promise<BallotImage> => {
           const imagePath = assertDefined(
             store.getBallotImagePath(sheet.id, side)
           );
@@ -247,8 +247,8 @@ function buildApi({
             imageUrl,
             ballotBounds,
             layout:
-              info.interpretation.type === 'InterpretedHmpbPage'
-                ? info.interpretation.layout
+              interpretation.type === 'InterpretedHmpbPage'
+                ? interpretation.layout
                 : undefined,
           };
         }

--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -31,7 +31,11 @@ import {
   describeValidationError,
   validateSheetInterpretation,
 } from './validation';
-import { logBatchComplete, logScanSheetSuccess } from './util/logging';
+import {
+  logBatchComplete,
+  logScanSheetSuccess,
+  logSheetAdjudicationInfo,
+} from './util/logging';
 import { ScanStatus } from './types';
 
 const debug = makeDebug('scan:importer');
@@ -198,6 +202,11 @@ export class Importer {
       backInterpretation,
       ballotAuditId
     );
+
+    await logSheetAdjudicationInfo(this.logger, [
+      frontInterpretation,
+      backInterpretation,
+    ]);
 
     const batch = this.workspace.store.getBatch(batchId);
     await logScanSheetSuccess(this.logger, batch);

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -5,10 +5,10 @@
 import { Client as DbClient } from '@votingworks/db';
 import {
   HmpbBallotPaperSize,
-  BallotSheetInfo,
   BatchInfo,
   Iso8601Timestamp,
   mapSheet,
+  PageInterpretation,
   PageInterpretationSchema,
   PageInterpretationWithFiles,
   PollsState as PollsStateType,
@@ -676,14 +676,15 @@ export class Store {
     return normalizeAndJoin(dirname(this.getDbPath()), row.imagePath);
   }
 
-  getNextAdjudicationSheet(): BallotSheetInfo | undefined {
+  getNextAdjudicationSheet():
+    | { id: string; pages: SheetOf<PageInterpretation> }
+    | undefined {
     const row = this.client.one(
       `
       select
         id,
         front_interpretation_json as frontInterpretationJson,
-        back_interpretation_json as backInterpretationJson,
-        finished_adjudication_at as finishedAdjudicationAt
+        back_interpretation_json as backInterpretationJson
       from sheets
       where
         requires_adjudication = 1 and
@@ -697,7 +698,6 @@ export class Store {
           id: string;
           frontInterpretationJson: string;
           backInterpretationJson: string;
-          finishedAdjudicationAt: string | null;
         }
       | undefined;
 
@@ -705,14 +705,10 @@ export class Store {
       debug('got next review sheet requiring adjudication (id=%s)', row.id);
       return {
         id: row.id,
-        front: {
-          interpretation: JSON.parse(row.frontInterpretationJson),
-          adjudicationFinishedAt: row.finishedAdjudicationAt ?? undefined,
-        },
-        back: {
-          interpretation: JSON.parse(row.backInterpretationJson),
-          adjudicationFinishedAt: row.finishedAdjudicationAt ?? undefined,
-        },
+        pages: [
+          JSON.parse(row.frontInterpretationJson),
+          JSON.parse(row.backInterpretationJson),
+        ],
       };
     }
     debug('no review sheets requiring adjudication');

--- a/apps/central-scan/backend/src/util/logging.test.ts
+++ b/apps/central-scan/backend/src/util/logging.test.ts
@@ -1,0 +1,88 @@
+import { expect, test, vi } from 'vitest';
+import { LogEventId, mockLogger } from '@votingworks/logging';
+import {
+  AdjudicationReason,
+  BallotMetadata,
+  BallotStyleId,
+  BallotType,
+  InterpretedHmpbPage,
+} from '@votingworks/types';
+import { logSheetAdjudicationInfo } from './logging';
+
+const metadata: BallotMetadata = {
+  ballotStyleId: '12' as BallotStyleId,
+  ballotType: BallotType.Precinct,
+  ballotHash: 'abcdef',
+  isTestMode: false,
+  precinctId: '23',
+};
+
+function hmpbPage(
+  enabledReasons: AdjudicationReason[],
+  requiresAdjudication: boolean
+): InterpretedHmpbPage {
+  return {
+    type: 'InterpretedHmpbPage',
+    metadata: { ...metadata, pageNumber: 1 },
+    markInfo: { ballotSize: { width: 1, height: 1 }, marks: [] },
+    adjudicationInfo: {
+      enabledReasons,
+      enabledReasonInfos: [],
+      ignoredReasonInfos: [],
+      requiresAdjudication,
+    },
+    votes: {},
+    layout: {
+      pageSize: { width: 1, height: 1 },
+      metadata: { ...metadata, pageNumber: 1 },
+      contests: [],
+    },
+  };
+}
+
+test('logs error page types when present', async () => {
+  const logger = mockLogger({ fn: vi.fn });
+  await logSheetAdjudicationInfo(logger, [
+    {
+      type: 'InvalidBallotHashPage',
+      actualBallotHash: 'a',
+      expectedBallotHash: 'b',
+    },
+    { type: 'BlankPage' },
+  ]);
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.ScanAdjudicationInfo,
+    'unknown',
+    {
+      message:
+        'Sheet scanned that has unresolvable errors. Sheet must be removed to continue scanning.',
+      adjudicationTypes: 'InvalidBallotHashPage, BlankPage',
+    }
+  );
+});
+
+test('logs deduplicated enabled reasons across both HMPB pages', async () => {
+  const logger = mockLogger({ fn: vi.fn });
+  await logSheetAdjudicationInfo(logger, [
+    hmpbPage([AdjudicationReason.Overvote, AdjudicationReason.Undervote], true),
+    hmpbPage([AdjudicationReason.Overvote], true),
+  ]);
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.ScanAdjudicationInfo,
+    'unknown',
+    {
+      message:
+        'Sheet scanned has warnings (ex: undervotes or overvotes). The user can either tabulate it as is or remove the ballot to continue scanning.',
+      adjudicationTypes: 'Overvote, Undervote',
+    }
+  );
+});
+
+test('does not log for HMPB pages that do not require adjudication', async () => {
+  const logger = mockLogger({ fn: vi.fn });
+  await logSheetAdjudicationInfo(logger, [
+    hmpbPage([AdjudicationReason.Overvote], false),
+    hmpbPage([AdjudicationReason.Overvote], false),
+  ]);
+  expect(logger.log).not.toHaveBeenCalled();
+});

--- a/apps/central-scan/backend/src/util/logging.ts
+++ b/apps/central-scan/backend/src/util/logging.ts
@@ -1,5 +1,10 @@
 import { LogEventId, Logger } from '@votingworks/logging';
-import { BatchInfo } from '@votingworks/types';
+import {
+  AdjudicationReason,
+  BatchInfo,
+  PageInterpretation,
+  SheetOf,
+} from '@votingworks/types';
 
 export function logBatchComplete(
   logger: Logger,
@@ -67,5 +72,49 @@ export function logScanSheetSuccess(
     message: `Sheet number ${batch.count} in batch ${batch.id} scanned successfully`,
     batchId: batch.id,
     sheetCount: batch.count,
+  });
+}
+
+const SHEET_ADJUDICATION_ERRORS: ReadonlyArray<PageInterpretation['type']> = [
+  'InvalidTestModePage',
+  'InvalidBallotHashPage',
+  'UnreadablePage',
+  'BlankPage',
+];
+
+export async function logSheetAdjudicationInfo(
+  logger: Logger,
+  [front, back]: SheetOf<PageInterpretation>
+): Promise<void> {
+  const errorInterpretations = SHEET_ADJUDICATION_ERRORS.filter(
+    (e) => e === front.type || e === back.type
+  );
+  if (errorInterpretations.length > 0) {
+    await logger.logAsCurrentRole(LogEventId.ScanAdjudicationInfo, {
+      message:
+        'Sheet scanned that has unresolvable errors. Sheet must be removed to continue scanning.',
+      adjudicationTypes: errorInterpretations.join(', '),
+    });
+    return;
+  }
+
+  const adjudicationTypes = new Set<AdjudicationReason>();
+  for (const page of [front, back]) {
+    if (
+      page.type === 'InterpretedHmpbPage' &&
+      page.adjudicationInfo.requiresAdjudication
+    ) {
+      for (const reason of page.adjudicationInfo.enabledReasons) {
+        adjudicationTypes.add(reason);
+      }
+    }
+  }
+  if (adjudicationTypes.size === 0) {
+    return;
+  }
+  await logger.logAsCurrentRole(LogEventId.ScanAdjudicationInfo, {
+    message:
+      'Sheet scanned has warnings (ex: undervotes or overvotes). The user can either tabulate it as is or remove the ballot to continue scanning.',
+    adjudicationTypes: [...adjudicationTypes].join(', '),
   });
 }

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
@@ -806,6 +806,41 @@ test('says the scanner needs cleaning if a streak is detected', async () => {
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 });
 
+test('falls through to "Unreadable" for an UnreadablePage with an unrecognized reason', async () => {
+  apiMock.expectGetNextReviewSheet(
+    buildNextReviewSheet({
+      id: 'mock-sheet-id',
+      front: {
+        interpretation: {
+          type: 'UnreadablePage',
+          reason: 'some-other-reason',
+        },
+      },
+      back: {
+        interpretation: {
+          type: 'UnreadablePage',
+          reason: 'some-other-reason',
+        },
+      },
+    })
+  );
+
+  const logger = mockBaseLogger({ fn: vi.fn });
+
+  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
+
+  await screen.findByText('Unreadable');
+  screen.getByText(
+    'The last scanned ballot was not tabulated because there was a problem reading the ballot.'
+  );
+  expect(screen.getByRole('button').textContent).toEqual(
+    'Confirm Ballot Removed'
+  );
+
+  apiMock.expectContinueScanning({ forceAccept: false });
+  userEvent.click(screen.getByText('Confirm Ballot Removed'));
+});
+
 test('ballot with invalid scale', async () => {
   apiMock.expectGetNextReviewSheet(
     buildNextReviewSheet({

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
@@ -1,5 +1,4 @@
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { mockBaseLogger, LogEventId } from '@votingworks/logging';
+import { afterEach, beforeEach, expect, test } from 'vitest';
 import {
   AdjudicationReason,
   BallotMetadata,
@@ -98,9 +97,7 @@ test('says the sheet is unreadable if it is', async () => {
     })
   );
 
-  const logger = mockBaseLogger({ fn: vi.fn });
-
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
+  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
 
   await screen.findByText('Unreadable');
   screen.getByText(
@@ -113,13 +110,6 @@ test('says the sheet is unreadable if it is', async () => {
     'Confirm Ballot Removed'
   );
 
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ScanAdjudicationInfo,
-    'election_manager',
-    expect.objectContaining({
-      adjudicationTypes: 'BlankPage',
-    })
-  );
   apiMock.expectContinueScanning({ forceAccept: false });
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 });
@@ -182,9 +172,7 @@ test('says the ballot sheet is overvoted if it is', async () => {
     })
   );
 
-  const logger = mockBaseLogger({ fn: vi.fn });
-
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
+  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
 
   await screen.findByText('Overvote');
   screen.getByText(
@@ -192,15 +180,6 @@ test('says the ballot sheet is overvoted if it is', async () => {
   );
   screen.getByText(
     'Remove the ballot for manual adjudication or choose to tabulate it anyway.'
-  );
-
-  expect(logger.log).toHaveBeenCalledTimes(1);
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ScanAdjudicationInfo,
-    'election_manager',
-    expect.objectContaining({
-      adjudicationTypes: 'Overvote',
-    })
   );
 
   apiMock.expectContinueScanning({ forceAccept: false });
@@ -308,9 +287,7 @@ test('renders both ballot images with highlights on overvoted contests', async (
     ] as const,
   });
 
-  const logger = mockBaseLogger({ fn: vi.fn });
-
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
+  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
 
   await screen.findByText('Overvote');
 
@@ -392,9 +369,7 @@ test('says the ballot sheet is undervoted if it is', async () => {
     })
   );
 
-  const logger = mockBaseLogger({ fn: vi.fn });
-
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
+  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
 
   await screen.findByText('Undervote');
   screen.getByText(
@@ -402,15 +377,6 @@ test('says the ballot sheet is undervoted if it is', async () => {
   );
   screen.getByText(
     'Remove the ballot for manual adjudication or choose to tabulate it anyway.'
-  );
-
-  expect(logger.log).toHaveBeenCalledTimes(1);
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ScanAdjudicationInfo,
-    'election_manager',
-    expect.objectContaining({
-      adjudicationTypes: 'Undervote',
-    })
   );
 
   apiMock.expectContinueScanning({ forceAccept: false });
@@ -485,9 +451,7 @@ test('says the ballot sheet is blank if it is', async () => {
     })
   );
 
-  const logger = mockBaseLogger({ fn: vi.fn });
-
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
+  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
 
   await screen.findByText('Blank Ballot');
   screen.getByText(
@@ -495,15 +459,6 @@ test('says the ballot sheet is blank if it is', async () => {
   );
   screen.getByText(
     'Remove the ballot for manual adjudication or choose to tabulate it anyway.'
-  );
-
-  expect(logger.log).toHaveBeenCalledTimes(1);
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ScanAdjudicationInfo,
-    'election_manager',
-    expect.objectContaining({
-      adjudicationTypes: 'BlankBallot, Undervote',
-    })
   );
 
   apiMock.expectContinueScanning({ forceAccept: false });
@@ -538,9 +493,7 @@ test('calls out official ballot sheets in test mode', async () => {
     })
   );
 
-  const logger = mockBaseLogger({ fn: vi.fn });
-
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
+  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
 
   await screen.findByText('Official Ballot');
   screen.getByText(
@@ -549,15 +502,6 @@ test('calls out official ballot sheets in test mode', async () => {
   screen.getByText('Remove the ballot before continuing.');
   expect(screen.getByRole('button').textContent).toEqual(
     'Confirm Ballot Removed'
-  );
-
-  expect(logger.log).toHaveBeenCalledTimes(1);
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ScanAdjudicationInfo,
-    'election_manager',
-    expect.objectContaining({
-      adjudicationTypes: 'InvalidTestModePage',
-    })
   );
 
   apiMock.expectContinueScanning({ forceAccept: false });
@@ -589,12 +533,7 @@ test('calls out test ballot sheets in live mode', async () => {
     })
   );
 
-  const logger = mockBaseLogger({ fn: vi.fn });
-
-  renderInAppContext(<BallotEjectScreen isTestMode={false} />, {
-    apiMock,
-    logger,
-  });
+  renderInAppContext(<BallotEjectScreen isTestMode={false} />, { apiMock });
 
   await screen.findByText('Test Ballot');
   screen.getByText(
@@ -603,15 +542,6 @@ test('calls out test ballot sheets in live mode', async () => {
   screen.getByText('Remove the ballot before continuing.');
   expect(screen.getByRole('button').textContent).toEqual(
     'Confirm Ballot Removed'
-  );
-
-  expect(logger.log).toHaveBeenCalledTimes(1);
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ScanAdjudicationInfo,
-    'election_manager',
-    expect.objectContaining({
-      adjudicationTypes: 'InvalidTestModePage',
-    })
   );
 
   apiMock.expectContinueScanning({ forceAccept: false });
@@ -635,12 +565,7 @@ test('shows invalid election screen when appropriate', async () => {
     })
   );
 
-  const logger = mockBaseLogger({ fn: vi.fn });
-
-  renderInAppContext(<BallotEjectScreen isTestMode={false} />, {
-    apiMock,
-    logger,
-  });
+  renderInAppContext(<BallotEjectScreen isTestMode={false} />, { apiMock });
 
   await screen.findByText('Wrong Election');
   screen.getByText('Ballot Election ID');
@@ -651,14 +576,6 @@ test('shows invalid election screen when appropriate', async () => {
   );
 
   expect(screen.queryAllByText('Tabulate Ballot').length).toEqual(0);
-  expect(logger.log).toHaveBeenCalledTimes(1);
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ScanAdjudicationInfo,
-    'election_manager',
-    expect.objectContaining({
-      adjudicationTypes: 'InvalidBallotHashPage, BlankPage',
-    })
-  );
 
   apiMock.expectContinueScanning({ forceAccept: false });
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
@@ -747,9 +664,7 @@ test('does not allow tabulating the overvote if disallowCastingOvervotes is set'
     })
   );
 
-  const logger = mockBaseLogger({ fn: vi.fn });
-
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
+  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
 
   await screen.findByText('Overvote');
   screen.getByText(
@@ -781,9 +696,7 @@ test('says the scanner needs cleaning if a streak is detected', async () => {
     })
   );
 
-  const logger = mockBaseLogger({ fn: vi.fn });
-
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
+  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
 
   await screen.findByText('Streak Detected');
   screen.getByText(
@@ -794,14 +707,6 @@ test('says the scanner needs cleaning if a streak is detected', async () => {
     'Confirm Ballot Removed'
   );
 
-  expect(logger.log).toHaveBeenCalledTimes(1);
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ScanAdjudicationInfo,
-    'election_manager',
-    expect.objectContaining({
-      adjudicationTypes: 'UnreadablePage',
-    })
-  );
   apiMock.expectContinueScanning({ forceAccept: false });
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 });
@@ -825,9 +730,7 @@ test('falls through to "Unreadable" for an UnreadablePage with an unrecognized r
     })
   );
 
-  const logger = mockBaseLogger({ fn: vi.fn });
-
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
+  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
 
   await screen.findByText('Unreadable');
   screen.getByText(
@@ -860,9 +763,7 @@ test('ballot with invalid scale', async () => {
     })
   );
 
-  const logger = mockBaseLogger({ fn: vi.fn });
-
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock, logger });
+  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
 
   await screen.findByText('Invalid Scale');
   screen.getByText('The last scanned ballot was printed at an invalid scale.');
@@ -871,14 +772,6 @@ test('ballot with invalid scale', async () => {
     'Confirm Ballot Removed'
   );
 
-  expect(logger.log).toHaveBeenCalledTimes(1);
-  expect(logger.log).toHaveBeenCalledWith(
-    LogEventId.ScanAdjudicationInfo,
-    'election_manager',
-    expect.objectContaining({
-      adjudicationTypes: 'UnreadablePage',
-    })
-  );
   apiMock.expectContinueScanning({ forceAccept: false });
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 });

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
@@ -1,13 +1,11 @@
 import { afterEach, beforeEach, expect, test } from 'vitest';
 import {
   AdjudicationReason,
-  BallotMetadata,
   BallotPageMetadata,
-  BallotSheetInfo,
-  BallotStyleId,
   BallotType,
   DEFAULT_SYSTEM_SETTINGS,
   formatBallotHash,
+  SheetInterpretation,
 } from '@votingworks/types';
 import userEvent from '@testing-library/user-event';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
@@ -23,16 +21,6 @@ type NextReviewSheet = Awaited<
   ReturnType<(typeof apiMock.apiClient)['getNextReviewSheet']>
 >;
 
-function buildBmdMetadata(): BallotMetadata {
-  return {
-    ballotStyleId: '1',
-    precinctId: '1',
-    ballotType: BallotType.Precinct,
-    ballotHash: 'abcde',
-    isTestMode: false,
-  };
-}
-
 function buildHmpMetadataWithPage(pageNumber: number): BallotPageMetadata {
   return {
     ballotStyleId: '1',
@@ -45,33 +33,22 @@ function buildHmpMetadataWithPage(pageNumber: number): BallotPageMetadata {
 }
 
 function buildNextReviewSheet(
-  ballotSheetInfo: BallotSheetInfo
+  sheetInterpretation: SheetInterpretation
 ): NextReviewSheet {
-  const frontMetadata: BallotMetadata | BallotPageMetadata =
-    'metadata' in ballotSheetInfo.front.interpretation
-      ? ballotSheetInfo.front.interpretation.metadata
-      : buildHmpMetadataWithPage(1);
-  const backMetadata: BallotMetadata | BallotPageMetadata =
-    'metadata' in ballotSheetInfo.back.interpretation
-      ? ballotSheetInfo.back.interpretation.metadata
-      : buildHmpMetadataWithPage(2);
-  function buildImage(metadata: BallotMetadata | BallotPageMetadata) {
+  function buildImage(pageNumber: number) {
     return {
       imageUrl: 'data:image/png;base64,',
       ballotBounds: { x: 0, y: 0, width: 1700, height: 2200 },
-      layout:
-        'pageNumber' in metadata
-          ? {
-              contests: [],
-              metadata,
-              pageSize: { width: 1, height: 1 },
-            }
-          : undefined,
+      layout: {
+        contests: [],
+        metadata: buildHmpMetadataWithPage(pageNumber),
+        pageSize: { width: 1, height: 1 },
+      },
     };
   }
   return {
-    interpreted: ballotSheetInfo,
-    images: [buildImage(frontMetadata), buildImage(backMetadata)] as const,
+    sheetInterpretation,
+    images: [buildImage(1), buildImage(2)] as const,
   };
 }
 
@@ -87,13 +64,8 @@ afterEach(() => {
 test('says the sheet is unreadable if it is', async () => {
   apiMock.expectGetNextReviewSheet(
     buildNextReviewSheet({
-      id: 'mock-sheet-id',
-      front: {
-        interpretation: { type: 'BlankPage' },
-      },
-      back: {
-        interpretation: { type: 'BlankPage' },
-      },
+      type: 'InvalidSheet',
+      reason: { type: 'unknown' },
     })
   );
 
@@ -117,58 +89,15 @@ test('says the sheet is unreadable if it is', async () => {
 test('says the ballot sheet is overvoted if it is', async () => {
   apiMock.expectGetNextReviewSheet(
     buildNextReviewSheet({
-      id: 'mock-sheet-id',
-      front: {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          markInfo: {
-            ballotSize: { width: 1, height: 1 },
-            marks: [],
-          },
-          metadata: buildHmpMetadataWithPage(1),
-          adjudicationInfo: {
-            requiresAdjudication: true,
-            enabledReasonInfos: [
-              {
-                type: AdjudicationReason.Overvote,
-                contestId: '1',
-                optionIds: ['1', '2'],
-                expected: 1,
-              },
-            ],
-            ignoredReasonInfos: [],
-            enabledReasons: [AdjudicationReason.Overvote],
-          },
-          votes: {},
-          layout: {
-            pageSize: { width: 1, height: 1 },
-            metadata: buildHmpMetadataWithPage(1),
-            contests: [],
-          },
+      type: 'NeedsReviewSheet',
+      reasons: [
+        {
+          type: AdjudicationReason.Overvote,
+          contestId: '1',
+          optionIds: ['1', '2'],
+          expected: 1,
         },
-      },
-      back: {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          markInfo: {
-            ballotSize: { width: 1, height: 1 },
-            marks: [],
-          },
-          metadata: buildHmpMetadataWithPage(2),
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-            enabledReasons: [AdjudicationReason.Overvote],
-          },
-          votes: {},
-          layout: {
-            pageSize: { width: 1, height: 1 },
-            metadata: buildHmpMetadataWithPage(2),
-            contests: [],
-          },
-        },
-      },
+      ],
     })
   );
 
@@ -194,53 +123,16 @@ test('renders both ballot images with highlights on overvoted contests', async (
   const CONTEST_BOUNDS = { x: 100, y: 200, width: 500, height: 300 } as const;
 
   apiMock.expectGetNextReviewSheet({
-    interpreted: {
-      id: 'mock-sheet-id',
-      front: {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          markInfo: { ballotSize: { width: 1, height: 1 }, marks: [] },
-          metadata: buildHmpMetadataWithPage(1),
-          adjudicationInfo: {
-            requiresAdjudication: true,
-            enabledReasonInfos: [
-              {
-                type: AdjudicationReason.Overvote,
-                contestId: 'contest-1',
-                optionIds: ['1', '2'],
-                expected: 1,
-              },
-            ],
-            ignoredReasonInfos: [],
-            enabledReasons: [AdjudicationReason.Overvote],
-          },
-          votes: {},
-          layout: {
-            pageSize: { width: 1, height: 1 },
-            metadata: buildHmpMetadataWithPage(1),
-            contests: [],
-          },
+    sheetInterpretation: {
+      type: 'NeedsReviewSheet',
+      reasons: [
+        {
+          type: AdjudicationReason.Overvote,
+          contestId: 'contest-1',
+          optionIds: ['1', '2'],
+          expected: 1,
         },
-      },
-      back: {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          markInfo: { ballotSize: { width: 1, height: 1 }, marks: [] },
-          metadata: buildHmpMetadataWithPage(2),
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-            enabledReasons: [AdjudicationReason.Overvote],
-          },
-          votes: {},
-          layout: {
-            pageSize: { width: 1, height: 1 },
-            metadata: buildHmpMetadataWithPage(2),
-            contests: [],
-          },
-        },
-      },
+      ],
     },
     images: [
       {
@@ -314,58 +206,15 @@ test('renders both ballot images with highlights on overvoted contests', async (
 test('says the ballot sheet is undervoted if it is', async () => {
   apiMock.expectGetNextReviewSheet(
     buildNextReviewSheet({
-      id: 'mock-sheet-id',
-      front: {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          markInfo: {
-            ballotSize: { width: 1, height: 1 },
-            marks: [],
-          },
-          metadata: buildHmpMetadataWithPage(1),
-          adjudicationInfo: {
-            requiresAdjudication: true,
-            enabledReasonInfos: [
-              {
-                type: AdjudicationReason.Undervote,
-                contestId: '1',
-                optionIds: [],
-                expected: 1,
-              },
-            ],
-            ignoredReasonInfos: [],
-            enabledReasons: [AdjudicationReason.Undervote],
-          },
-          votes: {},
-          layout: {
-            pageSize: { width: 1, height: 1 },
-            metadata: buildHmpMetadataWithPage(1),
-            contests: [],
-          },
+      type: 'NeedsReviewSheet',
+      reasons: [
+        {
+          type: AdjudicationReason.Undervote,
+          contestId: '1',
+          optionIds: [],
+          expected: 1,
         },
-      },
-      back: {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          markInfo: {
-            ballotSize: { width: 1, height: 1 },
-            marks: [],
-          },
-          metadata: buildHmpMetadataWithPage(2),
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-            enabledReasons: [AdjudicationReason.Overvote],
-          },
-          votes: {},
-          layout: {
-            pageSize: { width: 1, height: 1 },
-            metadata: buildHmpMetadataWithPage(2),
-            contests: [],
-          },
-        },
-      },
+      ],
     })
   );
 
@@ -389,65 +238,16 @@ test('says the ballot sheet is undervoted if it is', async () => {
 test('says the ballot sheet is blank if it is', async () => {
   apiMock.expectGetNextReviewSheet(
     buildNextReviewSheet({
-      id: 'mock-sheet-id',
-      front: {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          markInfo: {
-            ballotSize: { width: 1, height: 1 },
-            marks: [],
-          },
-          metadata: buildHmpMetadataWithPage(1),
-          adjudicationInfo: {
-            requiresAdjudication: true,
-            enabledReasonInfos: [
-              {
-                type: AdjudicationReason.Undervote,
-                contestId: '1',
-                expected: 1,
-                optionIds: [],
-              },
-              { type: AdjudicationReason.BlankBallot },
-            ],
-            ignoredReasonInfos: [],
-            enabledReasons: [
-              AdjudicationReason.BlankBallot,
-              AdjudicationReason.Undervote,
-            ],
-          },
-          votes: {},
-          layout: {
-            pageSize: { width: 1, height: 1 },
-            metadata: buildHmpMetadataWithPage(1),
-            contests: [],
-          },
+      type: 'NeedsReviewSheet',
+      reasons: [
+        {
+          type: AdjudicationReason.Undervote,
+          contestId: '1',
+          expected: 1,
+          optionIds: [],
         },
-      },
-      back: {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          markInfo: {
-            ballotSize: { width: 1, height: 1 },
-            marks: [],
-          },
-          metadata: buildHmpMetadataWithPage(2),
-          adjudicationInfo: {
-            requiresAdjudication: true,
-            enabledReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
-            ignoredReasonInfos: [],
-            enabledReasons: [
-              AdjudicationReason.BlankBallot,
-              AdjudicationReason.Undervote,
-            ],
-          },
-          votes: {},
-          layout: {
-            pageSize: { width: 1, height: 1 },
-            metadata: buildHmpMetadataWithPage(2),
-            contests: [],
-          },
-        },
-      },
+        { type: AdjudicationReason.BlankBallot },
+      ],
     })
   );
 
@@ -471,25 +271,8 @@ test('says the ballot sheet is blank if it is', async () => {
 test('calls out official ballot sheets in test mode', async () => {
   apiMock.expectGetNextReviewSheet(
     buildNextReviewSheet({
-      id: 'mock-sheet-id',
-      front: {
-        interpretation: {
-          type: 'InvalidTestModePage',
-          metadata: {
-            ...buildBmdMetadata(),
-            isTestMode: false,
-          },
-        },
-      },
-      back: {
-        interpretation: {
-          type: 'InvalidTestModePage',
-          metadata: {
-            ...buildBmdMetadata(),
-            isTestMode: false,
-          },
-        },
-      },
+      type: 'InvalidSheet',
+      reason: { type: 'invalid_test_mode' },
     })
   );
 
@@ -511,25 +294,8 @@ test('calls out official ballot sheets in test mode', async () => {
 test('calls out test ballot sheets in live mode', async () => {
   apiMock.expectGetNextReviewSheet(
     buildNextReviewSheet({
-      id: 'mock-sheet-id',
-      front: {
-        interpretation: {
-          type: 'InvalidTestModePage',
-          metadata: {
-            ...buildBmdMetadata(),
-            isTestMode: true,
-          },
-        },
-      },
-      back: {
-        interpretation: {
-          type: 'InvalidTestModePage',
-          metadata: {
-            ...buildBmdMetadata(),
-            isTestMode: true,
-          },
-        },
-      },
+      type: 'InvalidSheet',
+      reason: { type: 'invalid_test_mode' },
     })
   );
 
@@ -551,16 +317,10 @@ test('calls out test ballot sheets in live mode', async () => {
 test('shows invalid election screen when appropriate', async () => {
   apiMock.expectGetNextReviewSheet(
     buildNextReviewSheet({
-      id: 'mock-sheet-id',
-      front: {
-        interpretation: {
-          type: 'InvalidBallotHashPage',
-          actualBallotHash: 'this-is-a-hash-hooray',
-          expectedBallotHash: 'something',
-        },
-      },
-      back: {
-        interpretation: { type: 'BlankPage' },
+      type: 'InvalidSheet',
+      reason: {
+        type: 'invalid_ballot_hash',
+        actualBallotHash: 'this-is-a-hash-hooray',
       },
     })
   );
@@ -588,79 +348,17 @@ test('does not allow tabulating the overvote if disallowCastingOvervotes is set'
     ...DEFAULT_SYSTEM_SETTINGS,
     disallowCastingOvervotes: true,
   });
-  const metadata: BallotMetadata = {
-    ballotStyleId: '1' as BallotStyleId,
-    precinctId: '1',
-    ballotType: BallotType.Precinct,
-    ballotHash: 'abcde',
-    isTestMode: false,
-  };
   apiMock.expectGetNextReviewSheet(
     buildNextReviewSheet({
-      id: 'mock-sheet-id',
-      front: {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          markInfo: {
-            ballotSize: { width: 1, height: 1 },
-            marks: [],
-          },
-          metadata: {
-            ...metadata,
-            pageNumber: 1,
-          },
-          adjudicationInfo: {
-            requiresAdjudication: true,
-            enabledReasonInfos: [
-              {
-                type: AdjudicationReason.Overvote,
-                contestId: '1',
-                optionIds: ['1', '2'],
-                expected: 1,
-              },
-            ],
-            ignoredReasonInfos: [],
-            enabledReasons: [AdjudicationReason.Overvote],
-          },
-          votes: {},
-          layout: {
-            pageSize: { width: 1, height: 1 },
-            metadata: {
-              ...metadata,
-              pageNumber: 1,
-            },
-            contests: [],
-          },
+      type: 'NeedsReviewSheet',
+      reasons: [
+        {
+          type: AdjudicationReason.Overvote,
+          contestId: '1',
+          optionIds: ['1', '2'],
+          expected: 1,
         },
-      },
-      back: {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          markInfo: {
-            ballotSize: { width: 1, height: 1 },
-            marks: [],
-          },
-          metadata: {
-            ...metadata,
-            pageNumber: 2,
-          },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasonInfos: [],
-            ignoredReasonInfos: [],
-            enabledReasons: [AdjudicationReason.Overvote],
-          },
-          votes: {},
-          layout: {
-            pageSize: { width: 1, height: 1 },
-            metadata: {
-              ...metadata,
-              pageNumber: 2,
-            },
-            contests: [],
-          },
-        },
-      },
+      ],
     })
   );
 
@@ -680,19 +378,8 @@ test('does not allow tabulating the overvote if disallowCastingOvervotes is set'
 test('says the scanner needs cleaning if a streak is detected', async () => {
   apiMock.expectGetNextReviewSheet(
     buildNextReviewSheet({
-      id: 'mock-sheet-id',
-      front: {
-        interpretation: {
-          type: 'UnreadablePage',
-          reason: 'verticalStreaksDetected',
-        },
-      },
-      back: {
-        interpretation: {
-          type: 'UnreadablePage',
-          reason: 'verticalStreaksDetected',
-        },
-      },
+      type: 'InvalidSheet',
+      reason: { type: 'vertical_streaks_detected' },
     })
   );
 
@@ -714,19 +401,8 @@ test('says the scanner needs cleaning if a streak is detected', async () => {
 test('falls through to "Unreadable" for an UnreadablePage with an unrecognized reason', async () => {
   apiMock.expectGetNextReviewSheet(
     buildNextReviewSheet({
-      id: 'mock-sheet-id',
-      front: {
-        interpretation: {
-          type: 'UnreadablePage',
-          reason: 'some-other-reason',
-        },
-      },
-      back: {
-        interpretation: {
-          type: 'UnreadablePage',
-          reason: 'some-other-reason',
-        },
-      },
+      type: 'InvalidSheet',
+      reason: { type: 'unreadable' },
     })
   );
 
@@ -747,19 +423,8 @@ test('falls through to "Unreadable" for an UnreadablePage with an unrecognized r
 test('ballot with invalid scale', async () => {
   apiMock.expectGetNextReviewSheet(
     buildNextReviewSheet({
-      id: 'mock-sheet-id',
-      front: {
-        interpretation: {
-          type: 'UnreadablePage',
-          reason: 'invalidScale',
-        },
-      },
-      back: {
-        interpretation: {
-          type: 'UnreadablePage',
-          reason: 'invalidScale',
-        },
-      },
+      type: 'InvalidSheet',
+      reason: { type: 'invalid_scale' },
     })
   );
 

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
@@ -6,6 +6,7 @@ import {
   DEFAULT_SYSTEM_SETTINGS,
   formatBallotHash,
   SheetInterpretation,
+  SheetOf,
 } from '@votingworks/types';
 import userEvent from '@testing-library/user-event';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
@@ -33,22 +34,40 @@ function buildHmpMetadataWithPage(pageNumber: number): BallotPageMetadata {
 }
 
 function buildNextReviewSheet(
-  sheetInterpretation: SheetInterpretation
+  sheetInterpretation: SheetInterpretation,
+  contestIdsBySide: SheetOf<readonly string[]> = [[], []]
 ): NextReviewSheet {
-  function buildImage(pageNumber: number) {
+  function buildImage(pageNumber: number, contestIds: readonly string[]) {
     return {
-      imageUrl: 'data:image/png;base64,',
+      imageUrl: `mock-${pageNumber === 1 ? 'front' : 'back'}-image`,
       ballotBounds: { x: 0, y: 0, width: 1700, height: 2200 },
       layout: {
-        contests: [],
+        contests: contestIds.map((contestId, i) => {
+          const y = 200 + i * 400;
+          return {
+            contestId,
+            bounds: { x: 100, y, width: 500, height: 300 },
+            corners: [
+              { x: 100, y },
+              { x: 600, y },
+              { x: 100, y: y + 300 },
+              { x: 600, y: y + 300 },
+            ] as const,
+            options: [],
+          };
+        }),
         metadata: buildHmpMetadataWithPage(pageNumber),
-        pageSize: { width: 1, height: 1 },
+        pageSize: { width: 1700, height: 2200 },
       },
     };
   }
+  const [frontContestIds, backContestIds] = contestIdsBySide;
   return {
     sheetInterpretation,
-    images: [buildImage(1), buildImage(2)] as const,
+    images: [
+      buildImage(1, frontContestIds),
+      buildImage(2, backContestIds),
+    ] as const,
   };
 }
 
@@ -119,65 +138,22 @@ test('says the ballot sheet is overvoted if it is', async () => {
 });
 
 test('renders both ballot images with highlights on overvoted contests', async () => {
-  const BALLOT_BOUNDS = { x: 0, y: 0, width: 1700, height: 2200 } as const;
-  const CONTEST_BOUNDS = { x: 100, y: 200, width: 500, height: 300 } as const;
-
-  apiMock.expectGetNextReviewSheet({
-    sheetInterpretation: {
-      type: 'NeedsReviewSheet',
-      reasons: [
-        {
-          type: AdjudicationReason.Overvote,
-          contestId: 'contest-1',
-          optionIds: ['1', '2'],
-          expected: 1,
-        },
-      ],
-    },
-    images: [
+  apiMock.expectGetNextReviewSheet(
+    buildNextReviewSheet(
       {
-        imageUrl: 'mock-front-image',
-        ballotBounds: BALLOT_BOUNDS,
-        layout: {
-          pageSize: { width: 1700, height: 2200 },
-          metadata: buildHmpMetadataWithPage(1),
-          contests: [
-            {
-              contestId: 'contest-1',
-              bounds: CONTEST_BOUNDS,
-              corners: [
-                { x: 100, y: 200 },
-                { x: 600, y: 200 },
-                { x: 100, y: 500 },
-                { x: 600, y: 500 },
-              ],
-              options: [],
-            },
-            {
-              contestId: 'contest-2',
-              bounds: { x: 100, y: 600, width: 500, height: 300 },
-              corners: [
-                { x: 100, y: 600 },
-                { x: 600, y: 600 },
-                { x: 100, y: 900 },
-                { x: 600, y: 900 },
-              ],
-              options: [],
-            },
-          ],
-        },
+        type: 'NeedsReviewSheet',
+        reasons: [
+          {
+            type: AdjudicationReason.Overvote,
+            contestId: 'contest-1',
+            optionIds: ['1', '2'],
+            expected: 1,
+          },
+        ],
       },
-      {
-        imageUrl: 'mock-back-image',
-        ballotBounds: BALLOT_BOUNDS,
-        layout: {
-          pageSize: { width: 1700, height: 2200 },
-          metadata: buildHmpMetadataWithPage(2),
-          contests: [],
-        },
-      },
-    ] as const,
-  });
+      [['contest-1', 'contest-2'], []]
+    )
+  );
 
   renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
 
@@ -205,17 +181,20 @@ test('renders both ballot images with highlights on overvoted contests', async (
 
 test('says the ballot sheet is undervoted if it is', async () => {
   apiMock.expectGetNextReviewSheet(
-    buildNextReviewSheet({
-      type: 'NeedsReviewSheet',
-      reasons: [
-        {
-          type: AdjudicationReason.Undervote,
-          contestId: '1',
-          optionIds: [],
-          expected: 1,
-        },
-      ],
-    })
+    buildNextReviewSheet(
+      {
+        type: 'NeedsReviewSheet',
+        reasons: [
+          {
+            type: AdjudicationReason.Undervote,
+            contestId: '1',
+            optionIds: [],
+            expected: 1,
+          },
+        ],
+      },
+      [['1'], []]
+    )
   );
 
   renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
@@ -228,6 +207,10 @@ test('says the ballot sheet is undervoted if it is', async () => {
     'Remove the ballot for manual adjudication or choose to tabulate it anyway.'
   );
 
+  // Undervoted contest is highlighted on the front image
+  const ballotImages = screen.getAllByRole('img', { name: /ballot/i });
+  expect(ballotImages[0].querySelectorAll('div')).toHaveLength(1);
+
   apiMock.expectContinueScanning({ forceAccept: false });
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 
@@ -237,18 +220,21 @@ test('says the ballot sheet is undervoted if it is', async () => {
 
 test('says the ballot sheet is blank if it is', async () => {
   apiMock.expectGetNextReviewSheet(
-    buildNextReviewSheet({
-      type: 'NeedsReviewSheet',
-      reasons: [
-        {
-          type: AdjudicationReason.Undervote,
-          contestId: '1',
-          expected: 1,
-          optionIds: [],
-        },
-        { type: AdjudicationReason.BlankBallot },
-      ],
-    })
+    buildNextReviewSheet(
+      {
+        type: 'NeedsReviewSheet',
+        reasons: [
+          {
+            type: AdjudicationReason.Undervote,
+            contestId: '1',
+            expected: 1,
+            optionIds: [],
+          },
+          { type: AdjudicationReason.BlankBallot },
+        ],
+      },
+      [['1'], []]
+    )
   );
 
   renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
@@ -260,6 +246,11 @@ test('says the ballot sheet is blank if it is', async () => {
   screen.getByText(
     'Remove the ballot for manual adjudication or choose to tabulate it anyway.'
   );
+
+  // No highlights on a blank ballot — even though the layout has the
+  // undervoted contest, the Blank Ballot case suppresses highlighting.
+  const ballotImages = screen.getAllByRole('img', { name: /ballot/i });
+  expect(ballotImages[0].querySelector('div')).not.toBeInTheDocument();
 
   apiMock.expectContinueScanning({ forceAccept: false });
   userEvent.click(screen.getByText('Confirm Ballot Removed'));

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
@@ -1,8 +1,6 @@
-import { LogEventId } from '@votingworks/logging';
 import {
   AdjudicationReason,
   Contest,
-  PageInterpretation,
   Side,
   formatBallotHash,
   mapSheet,
@@ -65,18 +63,10 @@ interface EjectInformation {
   allowBallotDuplication: boolean;
 }
 
-const SHEET_ADJUDICATION_ERRORS: ReadonlyArray<PageInterpretation['type']> = [
-  'InvalidTestModePage',
-  'InvalidBallotHashPage',
-  'UnreadablePage',
-  'BlankPage',
-];
-
 export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
-  const { auth, logger, electionDefinition } = useContext(AppContext);
+  const { auth, electionDefinition } = useContext(AppContext);
   assert(electionDefinition);
   assert(isElectionManagerAuth(auth));
-  const userRole = auth.user.role;
 
   const systemSettingsQuery = getSystemSettings.useQuery();
   const getNextReviewSheetQuery = getNextReviewSheet.useQuery();
@@ -91,48 +81,6 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
   }
 
   const reviewInfo = getNextReviewSheetQuery.data;
-
-  // with new reviewInfo, mark each side done if nothing to actually adjudicate
-  if (reviewInfo) {
-    const frontInterpretation = reviewInfo.interpreted.front.interpretation;
-    const backInterpretation = reviewInfo.interpreted.back.interpretation;
-
-    const errorInterpretations = SHEET_ADJUDICATION_ERRORS.filter(
-      (e) => e === frontInterpretation.type || e === backInterpretation.type
-    );
-    if (errorInterpretations.length > 0) {
-      logger.log(LogEventId.ScanAdjudicationInfo, userRole, {
-        message:
-          'Sheet scanned that has unresolvable errors. Sheet must be removed to continue scanning.',
-        adjudicationTypes: errorInterpretations.join(', '),
-      });
-    } else {
-      const adjudicationTypes = new Set<AdjudicationReason>();
-      if (
-        frontInterpretation.type === 'InterpretedHmpbPage' &&
-        frontInterpretation.adjudicationInfo.requiresAdjudication
-      ) {
-        for (const reason of frontInterpretation.adjudicationInfo
-          .enabledReasons) {
-          adjudicationTypes.add(reason);
-        }
-      }
-      if (
-        backInterpretation.type === 'InterpretedHmpbPage' &&
-        backInterpretation.adjudicationInfo.requiresAdjudication
-      ) {
-        for (const reason of backInterpretation.adjudicationInfo
-          .enabledReasons) {
-          adjudicationTypes.add(reason);
-        }
-      }
-      logger.log(LogEventId.ScanAdjudicationInfo, userRole, {
-        message:
-          'Sheet scanned has warnings (ex: undervotes or overvotes). The user can either tabulate it as is or remove the ballot to continue scanning.',
-        adjudicationTypes: [...adjudicationTypes].join(', '),
-      });
-    }
-  }
 
   if (!reviewInfo || !systemSettingsQuery.isSuccess) {
     return null;

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
@@ -1,11 +1,10 @@
 import {
   AdjudicationReason,
-  Contest,
-  Side,
+  ContestId,
   formatBallotHash,
   mapSheet,
 } from '@votingworks/types';
-import { assert } from '@votingworks/basics';
+import { assert, throwIllegalValue } from '@votingworks/basics';
 import {
   BallotImage,
   BallotImageHighlight,
@@ -61,6 +60,7 @@ interface EjectInformation {
   header: string;
   body: React.ReactNode;
   allowBallotDuplication: boolean;
+  highlightedContestIds?: Set<ContestId>;
 }
 
 export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
@@ -87,174 +87,121 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
   }
 
   const { disallowCastingOvervotes } = systemSettingsQuery.data;
+  const { sheetInterpretation } = reviewInfo;
 
-  let isOvervotedSheet = false;
-  let isUndervotedSheet = false;
-  let verticalStreaksDetected = false;
-  let isFrontBlank = false;
-  let isBackBlank = false;
-  let isInvalidTestModeSheet = false;
-  let isInvalidBallotHashSheet = false;
-  let isInvalidScale = false;
-
-  let actualBallotHash: string | undefined;
-
-  const undervoteContestIds = new Set<Contest['id']>();
-  const overvoteContestIds = new Set<Contest['id']>();
-
-  for (const reviewPageInfo of [
-    {
-      side: 'front' as Side,
-      interpretation: reviewInfo.interpreted.front.interpretation,
-      adjudicationFinishedAt:
-        reviewInfo.interpreted.front.adjudicationFinishedAt,
-    },
-    {
-      side: 'back' as Side,
-      interpretation: reviewInfo.interpreted.back.interpretation,
-      adjudicationFinishedAt:
-        reviewInfo.interpreted.back.adjudicationFinishedAt,
-    },
-  ]) {
-    if (
-      reviewPageInfo.interpretation.type === 'UnreadablePage' &&
-      reviewPageInfo.interpretation.reason === 'verticalStreaksDetected'
-    ) {
-      verticalStreaksDetected = true;
-    } else if (
-      reviewPageInfo.interpretation.type === 'UnreadablePage' &&
-      reviewPageInfo.interpretation.reason === 'invalidScale'
-    ) {
-      isInvalidScale = true;
-    } else if (reviewPageInfo.interpretation.type === 'InvalidTestModePage') {
-      isInvalidTestModeSheet = true;
-    } else if (reviewPageInfo.interpretation.type === 'InvalidBallotHashPage') {
-      isInvalidBallotHashSheet = true;
-      actualBallotHash = reviewPageInfo.interpretation.actualBallotHash;
-    } else if (reviewPageInfo.interpretation.type === 'InterpretedHmpbPage') {
-      if (reviewPageInfo.interpretation.adjudicationInfo.requiresAdjudication) {
-        for (const adjudicationReason of reviewPageInfo.interpretation
-          .adjudicationInfo.enabledReasonInfos) {
-          if (adjudicationReason.type === AdjudicationReason.Overvote) {
-            isOvervotedSheet = true;
-            overvoteContestIds.add(adjudicationReason.contestId);
-          } else if (adjudicationReason.type === AdjudicationReason.Undervote) {
-            isUndervotedSheet = true;
-            undervoteContestIds.add(adjudicationReason.contestId);
-          } else if (
-            adjudicationReason.type === AdjudicationReason.BlankBallot
-          ) {
-            if (reviewPageInfo.side === 'front') {
-              isFrontBlank = true;
-            } else {
-              isBackBlank = true;
-            }
-          }
-        }
-      }
-    }
-  }
-
-  const backInterpretation = reviewInfo.interpreted.back.interpretation;
-  const isBackIntentionallyLeftBlank =
-    backInterpretation.type === 'InterpretedHmpbPage' &&
-    backInterpretation.markInfo.marks.length === 0;
-  const isBlankSheet =
-    isFrontBlank && (isBackBlank || isBackIntentionallyLeftBlank);
-
-  const highlightedContestIds = new Set<Contest['id']>();
-  if (isOvervotedSheet) {
-    for (const contestId of overvoteContestIds) {
-      highlightedContestIds.add(contestId);
-    }
-  } else if (isUndervotedSheet && !isBlankSheet) {
-    for (const contestId of undervoteContestIds) {
-      highlightedContestIds.add(contestId);
-    }
-  }
+  const unreadableEjectInfo: EjectInformation = {
+    header: 'Unreadable',
+    body: (
+      <React.Fragment>
+        <P>
+          The last scanned ballot was not tabulated because there was a problem
+          reading the ballot.
+        </P>
+        <P>
+          Remove the ballot and reload it into the scanner to try again. If the
+          error persists, remove the ballot for manual adjudication.
+        </P>
+      </React.Fragment>
+    ),
+    allowBallotDuplication: false,
+  };
 
   const ejectInfo: EjectInformation = (() => {
-    if (verticalStreaksDetected) {
-      return {
-        header: 'Streak Detected',
-        body: (
-          <React.Fragment>
-            <P>
-              The last scanned ballot was not tabulated because the scanner
-              needs to be cleaned.
-            </P>
-            <P>Clean the scanner before continuing to scan ballots.</P>
-          </React.Fragment>
-        ),
-        allowBallotDuplication: false,
-      };
-    }
-
-    if (isInvalidScale) {
-      return {
-        header: 'Invalid Scale',
-        body: (
-          <React.Fragment>
-            <P>The last scanned ballot was printed at an invalid scale.</P>
-            <P>Ballots must be printed full-scale.</P>
-          </React.Fragment>
-        ),
-        allowBallotDuplication: false,
-      };
-    }
-
-    if (isInvalidTestModeSheet) {
-      return isTestMode
-        ? {
-            header: 'Official Ballot',
+    if (sheetInterpretation.type === 'InvalidSheet') {
+      const { reason } = sheetInterpretation;
+      switch (reason.type) {
+        case 'vertical_streaks_detected':
+          return {
+            header: 'Streak Detected',
             body: (
               <React.Fragment>
                 <P>
-                  The last scanned ballot was not tabulated because it is an
-                  official ballot but the scanner is in test ballot mode.
+                  The last scanned ballot was not tabulated because the scanner
+                  needs to be cleaned.
                 </P>
-                <P>Remove the ballot before continuing.</P>
+                <P>Clean the scanner before continuing to scan ballots.</P>
               </React.Fragment>
             ),
             allowBallotDuplication: false,
-          }
-        : {
-            header: 'Test Ballot',
+          };
+
+        case 'invalid_scale':
+          return {
+            header: 'Invalid Scale',
+            body: (
+              <React.Fragment>
+                <P>The last scanned ballot was printed at an invalid scale.</P>
+                <P>Ballots must be printed full-scale.</P>
+              </React.Fragment>
+            ),
+            allowBallotDuplication: false,
+          };
+
+        case 'invalid_test_mode':
+          return isTestMode
+            ? {
+                header: 'Official Ballot',
+                body: (
+                  <React.Fragment>
+                    <P>
+                      The last scanned ballot was not tabulated because it is an
+                      official ballot but the scanner is in test ballot mode.
+                    </P>
+                    <P>Remove the ballot before continuing.</P>
+                  </React.Fragment>
+                ),
+                allowBallotDuplication: false,
+              }
+            : {
+                header: 'Test Ballot',
+                body: (
+                  <React.Fragment>
+                    <P>
+                      The last scanned ballot was not tabulated because it is a
+                      test ballot but the scanner is in official ballot mode.
+                    </P>
+                    <P>Remove the ballot before continuing.</P>
+                  </React.Fragment>
+                ),
+                allowBallotDuplication: false,
+              };
+
+        case 'invalid_ballot_hash':
+          return {
+            header: 'Wrong Election',
             body: (
               <React.Fragment>
                 <P>
-                  The last scanned ballot was not tabulated because it is a test
-                  ballot but the scanner is in official ballot mode.
+                  The last scanned ballot was not tabulated because it does not
+                  match the election this scanner is configured for.
                 </P>
+                <H6>Ballot Election ID</H6>
+                <P>{formatBallotHash(reason.actualBallotHash)}</P>
+                <H6>Scanner Election ID</H6>
+                <P>{formatBallotHash(electionDefinition.ballotHash)}</P>
+                <br />
                 <P>Remove the ballot before continuing.</P>
               </React.Fragment>
             ),
             allowBallotDuplication: false,
           };
+
+        case 'invalid_precinct':
+        case 'bmd_ballot_scanning_disabled':
+        case 'unreadable':
+        case 'unknown':
+          return unreadableEjectInfo;
+
+        // istanbul ignore next - @preserve
+        default:
+          throwIllegalValue(reason);
+      }
     }
 
-    if (isInvalidBallotHashSheet) {
-      return {
-        header: 'Wrong Election',
-        body: (
-          <React.Fragment>
-            <P>
-              The last scanned ballot was not tabulated because it does not
-              match the election this scanner is configured for.
-            </P>
-            <H6>Ballot Election ID</H6>
-            <P>{formatBallotHash(actualBallotHash ?? '')}</P>
-            <H6>Scanner Election ID</H6>
-            <P>{formatBallotHash(electionDefinition.ballotHash)}</P>
-            <br />
-            <P>Remove the ballot before continuing.</P>
-          </React.Fragment>
-        ),
-        allowBallotDuplication: false,
-      };
-    }
+    assert(sheetInterpretation.type === 'NeedsReviewSheet');
+    const { reasons } = sheetInterpretation;
 
-    if (isOvervotedSheet) {
+    if (reasons.some((r) => r.type === AdjudicationReason.Overvote)) {
       return {
         header: 'Overvote',
         body: (
@@ -264,10 +211,15 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
           </P>
         ),
         allowBallotDuplication: !disallowCastingOvervotes,
+        highlightedContestIds: new Set(
+          reasons
+            .filter((reason) => reason.type === AdjudicationReason.Overvote)
+            .map((reason) => reason.contestId)
+        ),
       };
     }
 
-    if (isBlankSheet) {
+    if (reasons.some((r) => r.type === AdjudicationReason.BlankBallot)) {
       return {
         header: 'Blank Ballot',
         body: (
@@ -280,7 +232,7 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
       };
     }
 
-    if (isUndervotedSheet) {
+    if (reasons.some((r) => r.type === AdjudicationReason.Undervote)) {
       return {
         header: 'Undervote',
         body: (
@@ -290,25 +242,15 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
           </P>
         ),
         allowBallotDuplication: true,
+        highlightedContestIds: new Set(
+          reasons
+            .filter((reason) => reason.type === AdjudicationReason.Undervote)
+            .map((reason) => reason.contestId)
+        ),
       };
     }
 
-    return {
-      header: 'Unreadable',
-      body: (
-        <React.Fragment>
-          <P>
-            The last scanned ballot was not tabulated because there was a
-            problem reading the ballot.
-          </P>
-          <P>
-            Remove the ballot and reload it into the scanner to try again. If
-            the error persists, remove the ballot for manual adjudication.
-          </P>
-        </React.Fragment>
-      ),
-      allowBallotDuplication: false,
-    };
+    return unreadableEjectInfo;
   })();
 
   return (
@@ -360,8 +302,9 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
         <BallotImagesContainer>
           {mapSheet(reviewInfo.images, (pageImage, side) => {
             const highlights = pageImage.layout?.contests
-              .filter((contestLayout) =>
-                highlightedContestIds.has(contestLayout.contestId)
+              .filter(
+                (contestLayout) =>
+                  ejectInfo.highlightedContestIds?.has(contestLayout.contestId)
               )
               .map(
                 (contestLayout): BallotImageHighlight => ({

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
@@ -106,6 +106,10 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
     allowBallotDuplication: false,
   };
 
+  // We handle both NeedsReviewSheet and InvalidSheet interpretations,
+  // since both need adjudication on the central scanner.
+  // (The distinction is for the precinct scanner, which rejects
+  // InvalidSheet and allows voter review for NeedsReviewSheet)
   const ejectInfo: EjectInformation = (() => {
     if (sheetInterpretation.type === 'InvalidSheet') {
       const { reason } = sheetInterpretation;

--- a/libs/types/src/interpretation.ts
+++ b/libs/types/src/interpretation.ts
@@ -2,9 +2,7 @@ import { z } from 'zod/v4';
 import {
   AdjudicationInfo,
   AdjudicationInfoSchema,
-  AdjudicationReason,
   AdjudicationReasonInfo,
-  AdjudicationReasonSchema,
   BallotMetadata,
   BallotMetadataSchema,
   BmdMultiPageBallotPageMetadata,
@@ -20,12 +18,6 @@ import {
   WriteInId,
   WriteInIdSchema,
 } from './election';
-import {
-  Id,
-  IdSchema,
-  Iso8601Timestamp,
-  Iso8601TimestampSchema,
-} from './generic';
 import { BallotPageLayout, BallotPageLayoutSchema, SheetOf } from './hmpb';
 
 export interface BlankPage {
@@ -170,28 +162,6 @@ export const PageInterpretationWithFilesSchema: z.ZodSchema<PageInterpretationWi
     imagePath: z.string(),
     interpretation: PageInterpretationSchema,
   });
-
-export interface BallotPageInfo {
-  interpretation: PageInterpretation;
-  adjudicationFinishedAt?: Iso8601Timestamp;
-}
-export const BallotPageInfoSchema: z.ZodSchema<BallotPageInfo> = z.object({
-  interpretation: PageInterpretationSchema,
-  adjudicationFinishedAt: Iso8601TimestampSchema.optional(),
-});
-
-export interface BallotSheetInfo {
-  id: Id;
-  front: BallotPageInfo;
-  back: BallotPageInfo;
-  adjudicationReason?: AdjudicationReason;
-}
-export const BallotSheetInfoSchema: z.ZodSchema<BallotSheetInfo> = z.object({
-  id: IdSchema,
-  front: BallotPageInfoSchema,
-  back: BallotPageInfoSchema,
-  adjudicationReason: AdjudicationReasonSchema.optional(),
-});
 
 export type InvalidInterpretationReasonInfo =
   | {


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

With central-scan now using the shared sheet-combination logic internally when determining if a sheet needs adjudication(#8390), this PR plumbs the sheet-level `SheetInterpretation` through to the adjudication screen so it can also use the same logic.

## Demo Video or Screenshot

N/A

## Testing Plan

Added coverage for more cases of BallotEjectScreen to ensure behavior wasn't changed

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.