### PR TITLE
VxAdmin: Auto-adjudicate contests with no qualified write-ins

### DIFF
--- a/apps/admin/backend/src/adjudication.test.ts
+++ b/apps/admin/backend/src/adjudication.test.ts
@@ -876,10 +876,11 @@ test('adjudicateCvr applies multiple contests in a single transaction and marks 
     electionPackageHash: 'test-election-package-hash',
   });
   store.setCurrentElectionId(electionId);
+  const { election } = store.getElection(electionId)!.electionDefinition;
 
   const mockCastVoteRecordFile: MockCastVoteRecordFile = [
     {
-      ballotStyleGroupId: '1M' as BallotStyleGroupId,
+      ballotStyleGroupId: '1M',
       batchId: 'batch-1-1',
       scannerId: 'scanner-1',
       precinctId: 'precinct-1',
@@ -933,7 +934,9 @@ test('adjudicateCvr applies multiple contests in a single transaction and marks 
   );
 
   // Both contests' adjudicated_votes are written.
-  const [cvr] = [...store.getCastVoteRecords({ electionId, filter: {} })];
+  const [cvr] = [
+    ...store.getCastVoteRecords({ electionId, election, filter: {} }),
+  ];
   assert(cvr);
   expect(new Set(cvr.votes['zoo-council-mammal'])).toEqual(
     new Set(['lion', 'kangaroo'])

--- a/apps/admin/backend/src/app.tally_report_data.test.ts
+++ b/apps/admin/backend/src/app.tally_report_data.test.ts
@@ -1107,26 +1107,32 @@ test('open primary, full election with crossover and adjudications', async () =>
     cvrId: crossoverToResolveCvrId,
   });
   (
-    await apiClient.adjudicateCvrContest({
+    await apiClient.adjudicateCvr({
       cvrId: crossoverToResolveCvrId,
-      contestId: 'governor-republican',
-      side: 'front',
-      adjudicatedContestOptionById: {
-        'ellen-brown': { type: 'candidate-option', hasVote: false },
-      },
+      contests: [
+        {
+          contestId: 'governor-republican',
+          adjudicatedContestOptionById: {
+            'ellen-brown': { type: 'official-option', hasVote: false },
+          },
+        },
+      ],
     })
   ).assertOk('failed to adjudicate crossover');
   // Flip a Dem-only ballot by removing its gov-democratic vote (dan-rivera)
   // → ballot becomes nonpartisan-only.
   await apiClient.claimBallotForAdjudication({ cvrId: demToFlipCvrId });
   (
-    await apiClient.adjudicateCvrContest({
+    await apiClient.adjudicateCvr({
       cvrId: demToFlipCvrId,
-      contestId: 'governor-democratic',
-      side: 'front',
-      adjudicatedContestOptionById: {
-        'dan-rivera': { type: 'candidate-option', hasVote: false },
-      },
+      contests: [
+        {
+          contestId: 'governor-democratic',
+          adjudicatedContestOptionById: {
+            'dan-rivera': { type: 'official-option', hasVote: false },
+          },
+        },
+      ],
     })
   ).assertOk('failed to flip dem ballot');
 

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -1443,7 +1443,7 @@ function addPendingWriteIns(
         type: 'candidate' as const,
         isWriteIn: true,
       },
-      initialVote: recordedSlots.includes(i),
+      scannedVote: recordedSlots.includes(i),
       hasMarginalMark: false,
       writeInRecord: recordedSlots.includes(i)
         ? makePendingWriteInRecord(contest.contestId, `write-in-${i}`)
@@ -1461,7 +1461,7 @@ test('auto-resolves a write-in-only contest with no qualified candidates', async
   const contestId = 'zoo-council-mammal';
   const contest = makeContestAdjudicationData(
     contestId,
-    makeContestTag({ contestId, hasWriteIn: true })
+    makeContestTag({ hasWriteIn: true })
   );
   // Two of three write-in slots have a pending record.
   addPendingWriteIns(contest, 3, [0, 1]);
@@ -1470,7 +1470,7 @@ test('auto-resolves a write-in-only contest with no qualified candidates', async
   const adjData2 = makeBallotAdjudicationData(CVR_ID_2, [
     makeContestAdjudicationData(
       contestId,
-      makeContestTag({ contestId, cvrId: CVR_ID_2, hasOvervote: true })
+      makeContestTag({ hasOvervote: true })
     ),
   ]);
 
@@ -1533,7 +1533,6 @@ test('auto-resolves contests flagged with hasUnmarkedWriteIn', async () => {
   const contest = makeContestAdjudicationData(
     contestId,
     makeContestTag({
-      contestId,
       hasWriteIn: false,
       hasUnmarkedWriteIn: true,
     })
@@ -1574,7 +1573,7 @@ test.each([
     const contestId = 'zoo-council-mammal';
     const contest = makeContestAdjudicationData(
       contestId,
-      makeContestTag({ contestId, hasWriteIn: true, [flag]: true })
+      makeContestTag({ hasWriteIn: true, [flag]: true })
     );
     addPendingWriteIns(contest, 3, [0]);
     const adjData = makeBallotAdjudicationData(CVR_ID_1, [contest]);
@@ -1606,7 +1605,7 @@ test('does not auto-resolve when qualified candidates exist for the contest', as
   const contestId = 'zoo-council-mammal';
   const contest = makeContestAdjudicationData(
     contestId,
-    makeContestTag({ contestId, hasWriteIn: true })
+    makeContestTag({ hasWriteIn: true })
   );
   addPendingWriteIns(contest, 3, [0]);
   const adjData = makeBallotAdjudicationData(CVR_ID_1, [contest]);
@@ -1639,7 +1638,7 @@ test('does not auto-resolve when areWriteInCandidatesQualified is false', async 
   const contestId = 'zoo-council-mammal';
   const contest = makeContestAdjudicationData(
     contestId,
-    makeContestTag({ contestId, hasWriteIn: true })
+    makeContestTag({ hasWriteIn: true })
   );
   addPendingWriteIns(contest, 3, [0]);
   const adjData = makeBallotAdjudicationData(CVR_ID_1, [contest]);

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -4,6 +4,7 @@ import {
   AdjudicationReason,
   BallotType,
   DEFAULT_SYSTEM_SETTINGS,
+  SystemSettings,
 } from '@votingworks/types';
 import type { BallotPageLayout, Rect } from '@votingworks/types';
 import type {
@@ -14,6 +15,7 @@ import type {
   ContestAdjudicationData,
   CvrContestTag,
   CvrTag,
+  WriteInRecord,
 } from '@votingworks/admin-backend';
 import {
   HIGHLIGHT_PRIMARY_BACKGROUND,
@@ -1409,5 +1411,257 @@ test('multi-station mode claims ballots on mount and releases on navigation', as
   await screen.findByText('Ballot 2 of 2');
   apiMock.apiClient.releaseBallotAdjudicationClaim
     .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_2 })
+    .resolves();
+});
+
+function makePendingWriteInRecord(
+  contestId: string,
+  optionId: string,
+  cvrId: string = CVR_ID_1
+): WriteInRecord {
+  return {
+    status: 'pending',
+    id: `wir-${contestId}-${optionId}`,
+    cvrId,
+    contestId,
+    electionId: 'e',
+    optionId,
+  };
+}
+
+function addPendingWriteIns(
+  contest: ContestAdjudicationData,
+  numberOfWriteIns: number,
+  recordedSlots: number[]
+): void {
+  for (let i = 0; i < numberOfWriteIns; i += 1) {
+    contest.options.push({
+      definition: {
+        id: `write-in-${i}`,
+        contestId: contest.contestId,
+        name: `Write-In #${i + 1}`,
+        type: 'candidate' as const,
+        isWriteIn: true,
+      },
+      initialVote: recordedSlots.includes(i),
+      hasMarginalMark: false,
+      writeInRecord: recordedSlots.includes(i)
+        ? makePendingWriteInRecord(contest.contestId, `write-in-${i}`)
+        : undefined,
+    });
+  }
+}
+
+const QUALIFIED_SYSTEM_SETTINGS: SystemSettings = {
+  ...DEFAULT_SYSTEM_SETTINGS,
+  areWriteInCandidatesQualified: true,
+};
+
+test('auto-resolves a write-in-only contest with no qualified candidates', async () => {
+  const contestId = 'zoo-council-mammal';
+  const contest = makeContestAdjudicationData(
+    contestId,
+    makeContestTag({ contestId, hasWriteIn: true })
+  );
+  // Two of three write-in slots have a pending record.
+  addPendingWriteIns(contest, 3, [0, 1]);
+  const adjData = makeBallotAdjudicationData(CVR_ID_1, [contest]);
+  // Second ballot is just a destination to advance to after Accept.
+  const adjData2 = makeBallotAdjudicationData(CVR_ID_2, [
+    makeContestAdjudicationData(
+      contestId,
+      makeContestTag({ contestId, cvrId: CVR_ID_2, hasOvervote: true })
+    ),
+  ]);
+
+  apiMock.expectAdjudicationScreenQueries();
+  apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2]);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
+  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.apiClient.getBallotImages
+    .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves(makeHmpbBallotImages(CVR_ID_1));
+  apiMock.apiClient.getBallotImages
+    .expectRepeatedCallsWith({ cvrId: CVR_ID_2 })
+    .resolves(makeHmpbBallotImages(CVR_ID_2));
+  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetSystemSettings(QUALIFIED_SYSTEM_SETTINGS);
+  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  // Accept enables only when the contest list shows the contest as resolved.
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /Accept/ })).toBeEnabled();
+  });
+
+  const expectedAdjudication: AdjudicatedCvrContest = {
+    contestId,
+    adjudicatedContestOptionById: {
+      zebra: { type: 'official-option', hasVote: false },
+      lion: { type: 'official-option', hasVote: false },
+      kangaroo: { type: 'official-option', hasVote: false },
+      elephant: { type: 'official-option', hasVote: false },
+      'write-in-0': { type: 'write-in-option', hasVote: false },
+      'write-in-1': { type: 'write-in-option', hasVote: false },
+      'write-in-2': { type: 'write-in-option', hasVote: false },
+    },
+  };
+  apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_1 });
+  apiMock.expectAdjudicateCvr({
+    cvrId: CVR_ID_1,
+    contests: [expectedAdjudication],
+  });
+  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2]);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_2);
+  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_2 });
+  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_2 }, adjData2);
+
+  userEvent.click(screen.getByRole('button', { name: /Accept/ }));
+  await screen.findByText('Ballot 2 of 2');
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_2 })
+    .resolves();
+});
+
+test('auto-resolves contests flagged with hasUnmarkedWriteIn', async () => {
+  const contestId = 'zoo-council-mammal';
+  const contest = makeContestAdjudicationData(
+    contestId,
+    makeContestTag({
+      contestId,
+      hasWriteIn: false,
+      hasUnmarkedWriteIn: true,
+    })
+  );
+  addPendingWriteIns(contest, 3, [0]);
+  const adjData = makeBallotAdjudicationData(CVR_ID_1, [contest]);
+
+  apiMock.expectAdjudicationScreenQueries();
+  apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
+  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
+  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetSystemSettings(QUALIFIED_SYSTEM_SETTINGS);
+  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /Accept/ })).toBeEnabled();
+  });
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves();
+});
+
+test.each([
+  { flag: 'hasOvervote' as const, label: 'hasOvervote' },
+  { flag: 'hasUndervote' as const, label: 'hasUndervote' },
+  { flag: 'hasMarginalMark' as const, label: 'hasMarginalMark' },
+])(
+  'does not auto-resolve a contest also flagged with $label',
+  async ({ flag }) => {
+    const contestId = 'zoo-council-mammal';
+    const contest = makeContestAdjudicationData(
+      contestId,
+      makeContestTag({ contestId, hasWriteIn: true, [flag]: true })
+    );
+    addPendingWriteIns(contest, 3, [0]);
+    const adjData = makeBallotAdjudicationData(CVR_ID_1, [contest]);
+
+    apiMock.expectAdjudicationScreenQueries();
+    apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
+    apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
+    apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+    apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
+    apiMock.expectGetWriteInCandidates([]);
+    apiMock.expectGetSystemSettings(QUALIFIED_SYSTEM_SETTINGS);
+    apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
+
+    renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+      electionDefinition,
+      apiMock,
+    });
+
+    await screen.findByText(/Ballot ID/);
+    expect(screen.getByRole('button', { name: /Accept/ })).toBeDisabled();
+
+    apiMock.apiClient.releaseBallotAdjudicationClaim
+      .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+      .resolves();
+  }
+);
+
+test('does not auto-resolve when qualified candidates exist for the contest', async () => {
+  const contestId = 'zoo-council-mammal';
+  const contest = makeContestAdjudicationData(
+    contestId,
+    makeContestTag({ contestId, hasWriteIn: true })
+  );
+  addPendingWriteIns(contest, 3, [0]);
+  const adjData = makeBallotAdjudicationData(CVR_ID_1, [contest]);
+
+  apiMock.expectAdjudicationScreenQueries();
+  apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
+  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
+  apiMock.expectGetWriteInCandidates([
+    { id: 'qual-1', name: 'Qualified Person', electionId: 'e', contestId },
+  ]);
+  apiMock.expectGetSystemSettings(QUALIFIED_SYSTEM_SETTINGS);
+  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText(/Ballot ID/);
+  expect(screen.getByRole('button', { name: /Accept/ })).toBeDisabled();
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves();
+});
+
+test('does not auto-resolve when areWriteInCandidatesQualified is false', async () => {
+  const contestId = 'zoo-council-mammal';
+  const contest = makeContestAdjudicationData(
+    contestId,
+    makeContestTag({ contestId, hasWriteIn: true })
+  );
+  addPendingWriteIns(contest, 3, [0]);
+  const adjData = makeBallotAdjudicationData(CVR_ID_1, [contest]);
+
+  apiMock.expectAdjudicationScreenQueries();
+  apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
+  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
+  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetSystemSettings(); // qualified mode off (default)
+  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText(/Ballot ID/);
+  expect(screen.getByRole('button', { name: /Accept/ })).toBeDisabled();
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves();
 });

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -520,8 +520,7 @@ export function BallotAdjudicationScreen({
       > = {};
       for (const option of contest.options) {
         const isWriteIn =
-          option.definition.type === 'candidate' &&
-          option.definition.isWriteIn;
+          option.definition.type === 'candidate' && option.definition.isWriteIn;
         adjudicatedContestOptionById[option.definition.id] = isWriteIn
           ? { type: 'write-in-option', hasVote: false }
           : { type: 'official-option', hasVote: option.scannedVote };
@@ -645,7 +644,10 @@ export function BallotAdjudicationScreen({
           contestAdjudicationData,
           (c) => c.contestId === selectedContestId
         )}
-        adjudicatedContest={adjudicatedContests.get(selectedContestId)}
+        adjudicatedOptions={
+          adjudicatedContests.get(selectedContestId)
+            ?.adjudicatedContestOptionById
+        }
         ballotImages={ballotImages}
         writeInCandidates={writeInCandidates.filter(
           (c) => c.contestId === selectedContestId

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -4,6 +4,7 @@ import { Button, Loading, Main, Modal, P, Screen } from '@votingworks/ui';
 import {
   AdjudicationReason,
   ContestId,
+  ContestOptionId,
   Election,
   Id,
   Side,
@@ -11,6 +12,7 @@ import {
 } from '@votingworks/types';
 import { format } from '@votingworks/utils';
 import type {
+  AdjudicatedContestOption,
   AdjudicatedCvrContest,
   BallotAdjudicationData,
   BallotImages,
@@ -479,12 +481,59 @@ export function BallotAdjudicationScreen({
   const [pendingDiscard, setPendingDiscard] = useState<{
     action: () => void;
   } | null>(null);
-  const [adjudicatedContests, setAdjudicatedContests] = useState(
-    () =>
-      new Map(
-        ballotAdjudicationData.adjudicatedContests.map((c) => [c.contestId, c])
-      )
-  );
+  // Initialize from persisted adjudications. In qualified-write-in mode, also
+  // auto-resolve contests whose only adjudication reason is write-ins when the
+  // contest has no qualified candidates: every write-in must be invalid, so
+  // the user has nothing to decide.
+  const [adjudicatedContests, setAdjudicatedContests] = useState<
+    Map<ContestId, AdjudicatedCvrContest>
+  >(() => {
+    const initial = new Map<ContestId, AdjudicatedCvrContest>(
+      ballotAdjudicationData.adjudicatedContests.map((c) => [c.contestId, c])
+    );
+    if (
+      !systemSettings.areWriteInCandidatesQualified ||
+      ballotAdjudicationData.isResolved
+    ) {
+      return initial;
+    }
+    const contestIdsWithQualified = new Set(
+      writeInCandidates.map((c) => c.contestId)
+    );
+
+    for (const { adjudicationData: contest } of [
+      ...frontContests,
+      ...backContests,
+    ]) {
+      if (initial.has(contest.contestId)) continue;
+      const { tag } = contest;
+      if (!tag) continue;
+      const hasWriteInFlag = tag.hasWriteIn || tag.hasUnmarkedWriteIn;
+      const hasOtherFlag =
+        tag.hasOvervote || tag.hasUndervote || tag.hasMarginalMark;
+      if (!hasWriteInFlag || hasOtherFlag) continue;
+      if (contestIdsWithQualified.has(contest.contestId)) continue;
+
+      const adjudicatedContestOptionById: Record<
+        ContestOptionId,
+        AdjudicatedContestOption
+      > = {};
+      for (const option of contest.options) {
+        const isWriteIn =
+          option.definition.type === 'candidate' &&
+          option.definition.isWriteIn;
+        adjudicatedContestOptionById[option.definition.id] = isWriteIn
+          ? { type: 'write-in-option', hasVote: false }
+          : { type: 'official-option', hasVote: option.scannedVote };
+      }
+      initial.set(contest.contestId, {
+        contestId: contest.contestId,
+        adjudicatedContestOptionById,
+      });
+    }
+
+    return initial;
+  });
   const [selectedSide, setSelectedSide] = useState<Side>(() =>
     getDefaultSide(adjudicatedContests)
   );

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
@@ -642,6 +642,9 @@ describe('hmpb write-in adjudication', () => {
     });
     renderScreen(data, cvrId, {
       areWriteInCandidatesQualified: true,
+      writeInCandidates: [
+        { id: 'qual-1', name: 'Existing Qualified', electionId, contestId },
+      ],
       ballotImages: buildHmpbBallotImages(cvrId, contestId),
     });
 
@@ -1824,5 +1827,136 @@ describe('candidate ordering', () => {
       name: /Thomas Edison/i,
     });
     expect(edisonCheckboxes).toHaveLength(1);
+  });
+});
+
+describe('qualified write-in mode auto-invalidation', () => {
+  const contestId = 'zoo-council-mammal';
+  const cvrId = 'id-174';
+
+  function buildPendingWriteIn(optionId: string): WriteInRecord {
+    return {
+      status: 'pending',
+      id: `wir-${optionId}`,
+      cvrId,
+      contestId,
+      electionId,
+      optionId,
+    };
+  }
+
+  test('pre-marks write-ins as invalid and submits them on confirm', async () => {
+    const onConfirmContest = vi.fn().mockResolvedValue(undefined);
+    const tag: CvrContestTag = {
+      hasWriteIn: true,
+      hasUndervote: true,
+    };
+    const data = buildContestAdjudicationData({
+      contestId,
+      votes: ['write-in-0'],
+      writeInRecords: [buildPendingWriteIn('write-in-0')],
+      tag,
+    });
+    const { onClose } = renderScreen(data, cvrId, {
+      areWriteInCandidatesQualified: true,
+      writeInCandidates: [],
+      onConfirmContest,
+    });
+
+    await waitForBallotById('id-174');
+
+    // The write-in option flips to "Invalid" automatically
+    await screen.findByText(/invalid/i);
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+
+    const confirmButton = await waitFor(() => {
+      const button = getButtonByName('confirm');
+      expect(button).toBeEnabled();
+      return button;
+    });
+    userEvent.click(confirmButton);
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(onConfirmContest).toHaveBeenCalledWith(
+      formAdjudicatedCvrContest({})
+    );
+  });
+
+  test('pre-marking resolves a marginal mark on the same write-in option', async () => {
+    const onConfirmContest = vi.fn().mockResolvedValue(undefined);
+    const tag: CvrContestTag = {
+      hasWriteIn: true,
+      hasMarginalMark: true,
+    };
+    const data = buildContestAdjudicationData({
+      contestId,
+      votes: [],
+      writeInRecords: [buildPendingWriteIn('write-in-0')],
+      marginalMarkOptionIds: ['write-in-0'],
+      tag,
+    });
+    renderScreen(data, cvrId, {
+      areWriteInCandidatesQualified: true,
+      writeInCandidates: [],
+      onConfirmContest,
+    });
+
+    await waitForBallotById('id-174');
+
+    // Marginal mark prompt is gone because the auto-invalidation resolved it.
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/review marginal mark/i)
+      ).not.toBeInTheDocument()
+    );
+    expect(screen.queryByText(/invalid/i)).toBeInTheDocument();
+  });
+
+  test('does not pre-mark when qualified candidates exist for the contest', async () => {
+    const tag: CvrContestTag = {
+      hasWriteIn: true,
+    };
+    const data = buildContestAdjudicationData({
+      contestId,
+      votes: ['write-in-0'],
+      writeInRecords: [buildPendingWriteIn('write-in-0')],
+      tag,
+    });
+    renderScreen(data, cvrId, {
+      areWriteInCandidatesQualified: true,
+      writeInCandidates: [
+        { id: 'qual-1', name: 'Qualified Person', electionId, contestId },
+      ],
+    });
+
+    await waitForBallotById('id-174');
+
+    // No auto-invalidation: the write-in stays pending — combobox visible,
+    // confirm disabled.
+    expect(screen.queryByText(/invalid/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(getButtonByName('confirm')).toBeDisabled();
+  });
+
+  test('does not pre-mark when areWriteInCandidatesQualified is false', async () => {
+    const tag: CvrContestTag = {
+      hasWriteIn: true,
+    };
+    const data = buildContestAdjudicationData({
+      contestId,
+      votes: ['write-in-0'],
+      writeInRecords: [buildPendingWriteIn('write-in-0')],
+      tag,
+    });
+    renderScreen(data, cvrId, {
+      areWriteInCandidatesQualified: false,
+      writeInCandidates: [],
+    });
+
+    await waitForBallotById('id-174');
+
+    expect(screen.queryByText(/invalid/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(getButtonByName('confirm')).toBeDisabled();
   });
 });

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
@@ -21,6 +21,7 @@ import type {
 import userEvent from '@testing-library/user-event';
 import type {
   AdjudicatedContestOption,
+  AdjudicatedContestOptions,
   AdjudicatedCvrContest,
   BallotImages,
   ContestAdjudicationData,
@@ -257,7 +258,7 @@ function renderScreen(
     onClose = vi.fn(),
     writeInCandidates = [] as WriteInCandidateRecord[],
     onConfirmContest = vi.fn(),
-    adjudicatedContest,
+    adjudicatedOptions,
   }: {
     areWriteInCandidatesQualified?: boolean;
     ballotImages?: BallotImages;
@@ -266,7 +267,7 @@ function renderScreen(
     onClose?: () => void;
     writeInCandidates?: WriteInCandidateRecord[];
     onConfirmContest?: (input: AdjudicatedCvrContest) => void;
-    adjudicatedContest?: AdjudicatedCvrContest;
+    adjudicatedOptions?: AdjudicatedContestOptions;
   } = {}
 ) {
   const images =
@@ -285,7 +286,7 @@ function renderScreen(
         side={side}
         writeInCandidates={writeInCandidates}
         onConfirmContest={onConfirmContest}
-        adjudicatedContest={adjudicatedContest}
+        adjudicatedOptions={adjudicatedOptions}
       />,
       { electionDefinition: electionDef, apiMock }
     ),
@@ -785,16 +786,13 @@ describe('vote adjudication', () => {
       votes: ['kangaroo'],
       tag: cvrContestTag,
     });
-    const adjudicatedContest: AdjudicatedCvrContest = {
-      contestId,
-      adjudicatedContestOptionById: {
-        kangaroo: { type: 'official-option', hasVote: true },
-        lion: { type: 'official-option', hasVote: true },
-      },
+    const adjudicatedOptions: AdjudicatedContestOptions = {
+      kangaroo: { type: 'official-option', hasVote: true },
+      lion: { type: 'official-option', hasVote: true },
     };
     const { onClose } = renderScreen(data, cvrId, {
       onConfirmContest,
-      adjudicatedContest,
+      adjudicatedOptions,
     });
 
     await waitForBallotById('id-174');

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
@@ -207,7 +207,7 @@ interface ContestAdjudicationScreenProps {
   onClose: () => void;
   onConfirmContest: (input: AdjudicatedCvrContest) => void;
   side: Side;
-  adjudicatedContest?: AdjudicatedCvrContest;
+  adjudicatedOptions?: AdjudicatedContestOptions;
   writeInCandidates: WriteInCandidateRecord[];
 }
 
@@ -219,7 +219,7 @@ export function ContestAdjudicationScreen({
   onClose,
   onConfirmContest,
   side,
-  adjudicatedContest,
+  adjudicatedOptions,
   writeInCandidates,
 }: ContestAdjudicationScreenProps): JSX.Element {
   const { electionDefinition } = useContext(AppContext);
@@ -253,18 +253,18 @@ export function ContestAdjudicationScreen({
   // In qualified-write-in mode, when this contest has no qualified candidates,
   // every pending write-in must be invalid: pre-mark them so the user only has
   // to address the contest's other adjudication reasons.
-  function getInitialAdjudicatedOptions():
+  function preMarkInvalidQualifiedWriteIns():
     | AdjudicatedContestOptions
     | undefined {
-    if (adjudicatedContest) {
-      return adjudicatedContest.adjudicatedContestOptionById;
+    if (adjudicatedOptions) {
+      return adjudicatedOptions;
     }
     if (!areWriteInCandidatesQualified || writeInCandidates.length > 0) {
       return undefined;
     }
     const preMarked: AdjudicatedContestOptions = {};
     for (const option of contestAdjudicationData.options) {
-      if (option.writeInRecord?.status !== 'pending') continue;
+      if (!option.writeInRecord) continue;
       preMarked[option.definition.id] = {
         type: 'write-in-option',
         hasVote: false,
@@ -291,7 +291,7 @@ export function ContestAdjudicationScreen({
     contestAdjudicationData,
     writeInCandidates,
     isCandidateContest,
-    adjudicatedOptions: getInitialAdjudicatedOptions(),
+    adjudicatedOptions: preMarkInvalidQualifiedWriteIns(),
   });
 
   // Vote and write-in state for adjudication management
@@ -335,7 +335,7 @@ export function ContestAdjudicationScreen({
   const allowSaveWithoutChanges =
     tag !== undefined &&
     (tag.hasOvervote || tag.hasUndervote) &&
-    !adjudicatedContest &&
+    !adjudicatedOptions &&
     allAdjudicationsCompleted;
 
   const isHmpb = ballotImages.front.type === 'hmpb';

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
@@ -17,6 +17,7 @@ import {
 import { Button, Main, Screen, Font, Icons, H2, H1, P } from '@votingworks/ui';
 import { assert, assertDefined, find } from '@votingworks/basics';
 import type {
+  AdjudicatedContestOptions,
   AdjudicatedCvrContest,
   BallotImages,
   ContestAdjudicationData,
@@ -249,6 +250,29 @@ export function ContestAdjudicationScreen({
       .map((o) => o.definition.id);
   }, [contestOptions, isCandidateContest]);
 
+  // In qualified-write-in mode, when this contest has no qualified candidates,
+  // every pending write-in must be invalid: pre-mark them so the user only has
+  // to address the contest's other adjudication reasons.
+  function getInitialAdjudicatedOptions():
+    | AdjudicatedContestOptions
+    | undefined {
+    if (adjudicatedContest) {
+      return adjudicatedContest.adjudicatedContestOptionById;
+    }
+    if (!areWriteInCandidatesQualified || writeInCandidates.length > 0) {
+      return undefined;
+    }
+    const preMarked: AdjudicatedContestOptions = {};
+    for (const option of contestAdjudicationData.options) {
+      if (option.writeInRecord?.status !== 'pending') continue;
+      preMarked[option.definition.id] = {
+        type: 'write-in-option',
+        hasVote: false,
+      };
+    }
+    return Object.keys(preMarked).length > 0 ? preMarked : undefined;
+  }
+
   const {
     isModified,
     getOptionHasVote,
@@ -267,7 +291,7 @@ export function ContestAdjudicationScreen({
     contestAdjudicationData,
     writeInCandidates,
     isCandidateContest,
-    adjudicatedOptions: adjudicatedContest?.adjudicatedContestOptionById,
+    adjudicatedOptions: getInitialAdjudicatedOptions(),
   });
 
   // Vote and write-in state for adjudication management


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/8329

This PR adds automatic invalidating of write-ins when in qualified candidate mode, if the contest has no write-in candidates.

I chose to implement this in two ways:
- if the only adjudication reason is write-in, invalidate on ballot adjudication screen load. No more user input is needed, so we save them from clicking into the contest.
- if there is another adjudication reason, invalidate on contest adjudication screen load. The user still needs to click into the contest, so we avoid saving a partially adjudicated local state. We maintain the warning icon on the contest list item.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/1197cc79-3f96-4dc7-8aff-4cdc5ab4f4cf

## Testing Plan

Automated tests added.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
