### PR TITLE
fix: restrict zedbar to only QR code symbology

### DIFF
--- a/libs/ballot-interpreter/Cargo.lock
+++ b/libs/ballot-interpreter/Cargo.lock
@@ -332,6 +332,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +456,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -874,6 +894,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -975,7 +996,6 @@ dependencies = [
  "bytemuck",
  "byteorder-lite",
  "exr",
- "image-webp",
  "moxcms",
  "num-traits",
  "png",
@@ -983,16 +1003,6 @@ dependencies = [
  "rayon",
  "zune-core",
  "zune-jpeg",
-]
-
-[[package]]
-name = "image-webp"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
-dependencies = [
- "byteorder-lite",
- "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -1518,8 +1528,8 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -1572,8 +1582,19 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1583,7 +1604,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1596,12 +1627,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1631,8 +1668,8 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand",
- "rand_chacha",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
  "v_frame",
@@ -2588,15 +2625,13 @@ checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "zedbar"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361e59098ff9eebf1089cdbe07133cb8cd902f85b0744b97d306449aa4475462"
+checksum = "c77baef3b8db427215e5f5907382b55870bdeb5c5d0f7bfeca080d31f3307f6e"
 dependencies = [
- "clap",
  "encoding_rs",
- "image",
- "rand",
- "rand_chacha",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "reed-solomon",
 ]
 

--- a/libs/ballot-interpreter/Cargo.toml
+++ b/libs/ballot-interpreter/Cargo.toml
@@ -59,7 +59,7 @@ serde_json = "1.0.89"
 serde_with = { version = "3.14.0", features = ["macros"] }
 itertools = "0.12.1"
 rqrr = "0.7.1"
-zedbar = "0.2.1"
+zedbar = { version = "0.3.0", default-features = false, features = ["qrcode"] }
 base64 = "0.22.0"
 thiserror = "1.0.50"
 tokio = { version = "1.44.2", features = ["fs", "macros"] }

--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -48,7 +48,7 @@
     "debug": "4.3.4",
     "node-quirc": "^2.2.1",
     "tmp": "^0.2.1",
-    "zedbar": "^0.2.1"
+    "zedbar": "^0.3.0"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.5.1",

--- a/libs/ballot-interpreter/src/summary-ballot/utils/qrcode.ts
+++ b/libs/ballot-interpreter/src/summary-ballot/utils/qrcode.ts
@@ -1,4 +1,4 @@
-import { scanGrayscale } from 'zedbar';
+import { ScanOptions, scanGrayscale } from 'zedbar';
 import { decode as quircDecode, QRCode } from 'node-quirc';
 import { isVxBallot } from '@votingworks/ballot-encoder';
 import { ImageData, RGBA_CHANNEL_COUNT, crop } from '@votingworks/image-utils';
@@ -34,7 +34,11 @@ function rgbaToGrayscale(
   height: number
 ): Uint8Array {
   const grayscale = new Uint8Array(width * height);
-  for (let rgbaIndex = 0, grayIndex = 0; rgbaIndex < data.length; rgbaIndex += RGBA_CHANNEL_COUNT, grayIndex += 1) {
+  for (
+    let rgbaIndex = 0, grayIndex = 0;
+    rgbaIndex < data.length;
+    rgbaIndex += RGBA_CHANNEL_COUNT, grayIndex += 1
+  ) {
     const r = data[rgbaIndex] as number;
     const g = data[rgbaIndex + 1] as number;
     const b = data[rgbaIndex + 2] as number;
@@ -119,7 +123,9 @@ export async function detect(
       name: 'zedbar',
       detect: ({ data, width, height }: ImageData): Buffer[] => {
         const grayscale = rgbaToGrayscale(data, width, height);
-        return scanGrayscale(grayscale, width, height).map((symbol) =>
+        const options = new ScanOptions();
+        options.symbologies = ['QR-Code'];
+        return scanGrayscale(grayscale, width, height, options).map((symbol) =>
           Buffer.from(symbol.data)
         );
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3707,8 +3707,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       zedbar:
-        specifier: ^0.2.1
-        version: 0.2.1
+        specifier: ^0.3.0
+        version: 0.3.0
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.5.1
@@ -26205,8 +26205,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  /zedbar@0.2.1:
-    resolution: {integrity: sha512-mElFgKSdo8idO4lj/VD+78e/ASOUzaHeptX2Gt8Ux6hiSCAvzzu2FoFkoFHNHX9YRLPu/jgGELl1x2O/AApICw==}
+  /zedbar@0.3.0:
+    resolution: {integrity: sha512-gq5erqyHiMVn0wHxneZyhZU7OVvfvBhyWfRr3y933l8BpR5/2glRBLVb3+slECkCVPvGo6Dfjfrl1mLSaWq6lg==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     dev: false


### PR DESCRIPTION
## Overview

Trail of Bits noted that zedbar by default enabled all symbologies. So while `DecoderConfig::new().enable(config::QrCode)` appeared to only enable QR codes, the `enable` call was actually a no-op. I updated zedbar in v0.3.0 to disable all symbologies by default when creating a scanner with a config value, so now the existing code _does_ behave as you'd expect. For the TS side we now specify the symbologies we want as well using a `ScanOptions` instance.

See https://github.com/eventualbuddha/zedbar/issues/47

## Demo Video or Screenshot
n/a

## Testing Plan
Existing automated tests.
