### PR TITLE
VxCentralScan: Add crossover voting warning to adjudication screen

### DIFF
--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
@@ -259,6 +259,31 @@ test('says the ballot sheet is blank if it is', async () => {
   userEvent.click(screen.getByText('Tabulate Ballot'));
 });
 
+test('says the ballot sheet has crossover voting if it does', async () => {
+  apiMock.expectGetNextReviewSheet(
+    buildNextReviewSheet({
+      type: 'NeedsReviewSheet',
+      reasons: [{ type: AdjudicationReason.CrossoverVoting }],
+    })
+  );
+
+  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
+
+  await screen.findByText('Crossover Voting');
+  screen.getByText(
+    'The last scanned ballot was not tabulated because votes were detected in contests for more than one party. If tabulated, those votes will not be counted.'
+  );
+  screen.getByText(
+    'Remove the ballot for manual adjudication or choose to tabulate it anyway.'
+  );
+
+  apiMock.expectContinueScanning({ forceAccept: false });
+  userEvent.click(screen.getByText('Confirm Ballot Removed'));
+
+  apiMock.expectContinueScanning({ forceAccept: true });
+  userEvent.click(screen.getByText('Tabulate Ballot'));
+});
+
 test('calls out official ballot sheets in test mode', async () => {
   apiMock.expectGetNextReviewSheet(
     buildNextReviewSheet({

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
@@ -205,6 +205,20 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
     assert(sheetInterpretation.type === 'NeedsReviewSheet');
     const { reasons } = sheetInterpretation;
 
+    if (reasons.some((r) => r.type === AdjudicationReason.CrossoverVoting)) {
+      return {
+        header: 'Crossover Voting',
+        body: (
+          <P>
+            The last scanned ballot was not tabulated because votes were
+            detected in contests for more than one party. If tabulated, those
+            votes will not be counted.
+          </P>
+        ),
+        allowBallotDuplication: true,
+      };
+    }
+
     if (reasons.some((r) => r.type === AdjudicationReason.Overvote)) {
       return {
         header: 'Overvote',


### PR DESCRIPTION

## Overview

<!-- Add a link to a GitHub issue here -->
Adds handling for the `CrossoverVoting` adjudication reason, following existing patterns to show a warning and option to remove or tabulate.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/e874c3c6-c73c-4d15-a493-e5fbab6cc479


## Testing Plan
- Added test case
- Manual test


## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
