### PR TITLE
VxAdmin: Client - Add session expiry logic

### DIFF
--- a/apps/admin/backend/src/client_app.test.ts
+++ b/apps/admin/backend/src/client_app.test.ts
@@ -154,6 +154,15 @@ test('logOut delegates to auth', async () => {
   expect(env.auth.logOut).toHaveBeenCalled();
 });
 
+test('updateSessionExpiry delegates to auth', async () => {
+  mockSystemAdministratorAuth(env.auth);
+  const sessionExpiresAt = new Date('2030-01-01T00:00:00Z');
+  await env.apiClient.updateSessionExpiry({ sessionExpiresAt });
+  expect(env.auth.updateSessionExpiry).toHaveBeenCalledWith(expect.anything(), {
+    sessionExpiresAt,
+  });
+});
+
 test('getNetworkConnectionStatus defaults to offline', async () => {
   expect(await env.apiClient.getNetworkConnectionStatus()).toEqual({
     status: 'offline',

--- a/apps/admin/backend/src/client_app.ts
+++ b/apps/admin/backend/src/client_app.ts
@@ -334,6 +334,13 @@ function buildClientApi({
       return auth.logOut(constructAuthMachineState(clientStore));
     },
 
+    updateSessionExpiry(input: { sessionExpiresAt: Date }) {
+      return auth.updateSessionExpiry(
+        constructAuthMachineState(clientStore),
+        input
+      );
+    },
+
     getUsbDriveStatus(): Promise<UsbDriveStatus> {
       return usbDriveAdapter.status();
     },

--- a/apps/admin/frontend/src/client/api.ts
+++ b/apps/admin/frontend/src/client/api.ts
@@ -151,6 +151,18 @@ export const logOut = {
   },
 } as const;
 
+export const updateSessionExpiry = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.updateSessionExpiry, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getAuthStatus.queryKey());
+      },
+    });
+  },
+} as const;
+
 // Election
 export const getCurrentElectionMetadata = {
   queryKey(): QueryKey {

--- a/apps/admin/frontend/src/client/client_app.tsx
+++ b/apps/admin/frontend/src/client/client_app.tsx
@@ -7,6 +7,7 @@ import {
   createApiClient,
   createQueryClient,
 } from './api';
+import { SessionTimeLimitTracker } from './components/session_time_limit_tracker';
 import { SharedApiClientContext } from '../shared_api';
 
 export interface ClientAppProps {
@@ -25,6 +26,7 @@ export function ClientApp({
         <QueryClientProvider client={queryClient}>
           <BrowserRouter>
             <ClientAppRoot />
+            <SessionTimeLimitTracker />
           </BrowserRouter>
         </QueryClientProvider>
       </SharedApiClientContext.Provider>

--- a/apps/admin/frontend/src/client/client_app_root.test.tsx
+++ b/apps/admin/frontend/src/client/client_app_root.test.tsx
@@ -72,6 +72,8 @@ function renderClientApp({
     withElection ? { electionDefinition } : null
   );
   apiMock.expectGetUsbDriveStatus('no_drive');
+  // Mounted by SessionTimeLimitTracker at ClientApp's root.
+  apiMock.expectGetSystemSettings();
 
   const clientApiClient = apiMock.apiClient as unknown as ApiClient;
   return render(

--- a/apps/admin/frontend/src/client/components/session_time_limit_tracker.tsx
+++ b/apps/admin/frontend/src/client/components/session_time_limit_tracker.tsx
@@ -1,0 +1,26 @@
+import { SessionTimeLimitTracker as SessionTimeLimitTrackerBase } from '@votingworks/ui';
+
+import {
+  getAuthStatus,
+  getSystemSettings,
+  logOut,
+  updateSessionExpiry,
+} from '../api';
+
+export function SessionTimeLimitTracker(): JSX.Element {
+  const authStatusQuery = getAuthStatus.useQuery();
+  const logOutMutation = logOut.useMutation();
+  const systemSettingsQuery = getSystemSettings.useQuery();
+  const updateSessionExpiryMutation = updateSessionExpiry.useMutation();
+
+  return (
+    <SessionTimeLimitTrackerBase
+      authStatus={authStatusQuery.data}
+      logOut={() => logOutMutation.mutate()}
+      systemSettings={systemSettingsQuery.data}
+      updateSessionExpiry={(sessionExpiresAt: Date) =>
+        updateSessionExpiryMutation.mutate({ sessionExpiresAt })
+      }
+    />
+  );
+}

--- a/apps/admin/frontend/test/helpers/mock_client_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_client_api_client.ts
@@ -1,10 +1,12 @@
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
 import type { ClientApi, MachineConfig } from '@votingworks/admin-backend';
 import {
+  DEFAULT_SYSTEM_SETTINGS,
   DippedSmartCardAuth,
   DEV_MACHINE_ID,
   ElectionDefinition,
   Id,
+  SystemSettings,
 } from '@votingworks/types';
 import { mockUsbDriveStatus } from '@votingworks/ui';
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
@@ -110,6 +112,14 @@ export function createClientApiMock(
       apiClient.getAdjudicationSessionStatus
         .expectRepeatedCallsWith()
         .resolves({ isClientAdjudicationEnabled });
+    },
+
+    expectGetSystemSettings(
+      systemSettings: SystemSettings = DEFAULT_SYSTEM_SETTINGS
+    ): void {
+      apiClient.getSystemSettings
+        .expectRepeatedCallsWith()
+        .resolves(systemSettings);
     },
   };
 }


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/8384
VxAdminClients were not properly logging people out when the session expiration was hit as I missed adding in the logic for that. This adds it in. 

## Demo Video or Screenshot
N/A equivalent to host mode 

## Testing Plan
Set up low expiration time, loaded a client, saw the warning modal load and eventually the session time out 

## Checklist
- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
