### PR TITLE
VxAdmin: Multi-Sttion: auto skip claimed ballots on host when paging forward/backword

### DIFF
--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -1410,7 +1410,7 @@ test('multi-station mode claims ballots on mount and releases on navigation', as
     .resolves();
 });
 
-test('navigation skips ballots claimed by other machines', async () => {
+test('Skip jumps past claimed ballots; Back still steps onto them as read-only', async () => {
   const CVR_ID_3 = 'cvr-id-3';
   const contestData = [
     makeContestAdjudicationData(
@@ -1419,6 +1419,7 @@ test('navigation skips ballots claimed by other machines', async () => {
     ),
   ];
   const adjData1 = makeBallotAdjudicationData(CVR_ID_1, contestData);
+  const adjData2 = makeBallotAdjudicationData(CVR_ID_2, contestData);
   const adjData3 = makeBallotAdjudicationData(CVR_ID_3, contestData);
 
   // CVR_ID_2 is claimed by another machine; queue is [1, 2, 3].
@@ -1442,7 +1443,7 @@ test('navigation skips ballots claimed by other machines', async () => {
   });
 
   await screen.findByText('Ballot 1 of 3');
-  // No Back button: there is no unclaimed ballot before CVR_ID_1.
+  // No Back button on the first ballot.
   expect(screen.queryByRole('button', { name: /Back/ })).toBeNull();
 
   // Skip from CVR_ID_1 should jump past the claimed CVR_ID_2 to CVR_ID_3.
@@ -1454,8 +1455,21 @@ test('navigation skips ballots claimed by other machines', async () => {
   userEvent.click(screen.getByRole('button', { name: /Skip/ }));
   await screen.findByText('Ballot 3 of 3');
 
-  // Back from CVR_ID_3 should jump past CVR_ID_2 to CVR_ID_1.
+  // Back from CVR_ID_3 lands on CVR_ID_2 — visible but read-only since another
+  // machine still holds the claim. Releases CVR_ID_3 but does not attempt to
+  // claim CVR_ID_2 (the claimedCvrIds set short-circuits the claim mutation).
   apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_3 });
+  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_2 }, adjData2);
+  apiMock.expectGetBallotImages({ cvrId: CVR_ID_2 }, true);
+
+  userEvent.click(screen.getByRole('button', { name: /Back/ }));
+  await screen.findByText('Ballot 2 of 3');
+  await screen.findByText(
+    'This ballot is currently being adjudicated by another machine.'
+  );
+
+  // Back again steps onto CVR_ID_1 and re-claims it (CVR_ID_2 was never
+  // claimed by this machine, so nothing to release).
   apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
   apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData1);
 

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -279,9 +279,7 @@ test('ballot navigation supports back, skip, exit, and side switching', async ()
   // starts on first ballot showing front image, no Back button on first ballot
   await screen.findByText(/Ballot ID: cvr-/);
   screen.getByText('Ballot 1 of 3');
-  expect(
-    screen.queryByRole('button', { name: /Back/ })
-  ).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /Back/ })).toBeNull();
   const ballotImage = screen.getByRole('img', { name: /ballot/i });
   expect(ballotImage.style.backgroundImage).toContain(
     `mock-front-image-${CVR_ID_1}`
@@ -656,9 +654,7 @@ test('confirmation modal back returns and accept anyway resolves and navigates t
   const modal = screen.getByRole('alertdialog');
   userEvent.click(within(modal).getByRole('button', { name: 'Back' }));
   await waitFor(() => {
-    expect(
-      screen.queryByText('Incomplete Adjudication')
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Incomplete Adjudication')).toBeNull();
   });
   screen.getByText(/Ballot ID/);
 
@@ -837,26 +833,26 @@ test('contest hover highlights pending yellow, resolved purple, and back-side no
   }
 
   // no highlight initially
-  expect(getHighlightOverlay()).not.toBeInTheDocument();
+  expect(getHighlightOverlay()).toBeNull();
 
   // hover over pending front contest -> orange/warning highlight
   const zooCouncilItem = screen.getByText('Zoo Council').closest('li')!;
   fireEvent.mouseEnter(zooCouncilItem);
   const warningHighlight = getHighlightOverlay();
-  expect(warningHighlight).toBeInTheDocument();
+  expect(warningHighlight).not.toBeNull();
   expect(warningHighlight).toHaveStyle({
     background: HIGHLIGHT_WARNING_BACKGROUND,
   });
 
   // mouse leave clears highlight
   fireEvent.mouseLeave(zooCouncilItem);
-  expect(getHighlightOverlay()).not.toBeInTheDocument();
+  expect(getHighlightOverlay()).toBeNull();
 
   // hover over resolved front contest -> purple highlight
   const bestAnimalItem = screen.getByText('Best Animal').closest('li')!;
   fireEvent.mouseEnter(bestAnimalItem);
   const resolvedHighlight = getHighlightOverlay();
-  expect(resolvedHighlight).toBeInTheDocument();
+  expect(resolvedHighlight).not.toBeNull();
   expect(resolvedHighlight).toHaveStyle({
     background: HIGHLIGHT_PRIMARY_BACKGROUND,
   });
@@ -867,7 +863,7 @@ test('contest hover highlights pending yellow, resolved purple, and back-side no
     .getByText('Ballot Measure 1 - Part 1')
     .closest('li')!;
   fireEvent.mouseEnter(ballotMeasureItem);
-  expect(getHighlightOverlay()).not.toBeInTheDocument();
+  expect(getHighlightOverlay()).toBeNull();
   fireEvent.mouseLeave(ballotMeasureItem);
   apiMock.apiClient.releaseBallotAdjudicationClaim
     .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
@@ -950,7 +946,7 @@ test('accept advances to next ballot and blank ballot callout states', async () 
 
   // Ballot 1: resolved non-blank, accept advances to ballot 2
   await screen.findByText('Ballot 1 of 3');
-  expect(screen.queryByText(/Blank Ballot/)).not.toBeInTheDocument();
+  expect(screen.queryByText(/Blank Ballot/)).toBeNull();
 
   apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_1 });
   apiMock.expectAdjudicateCvr({ cvrId: CVR_ID_1, contests: [] });
@@ -1135,10 +1131,10 @@ test('contest list suppresses undervote captions when not in system settings', a
   // Undervote captions are suppressed
   expect(
     contestItem('Ballot Measure 1 - Part 2').queryByText('Undervote Resolved')
-  ).not.toBeInTheDocument();
+  ).toBeNull();
   expect(
     contestItem('Ballot Measure 3').queryByText('Undervote Created')
-  ).not.toBeInTheDocument();
+  ).toBeNull();
   apiMock.apiClient.releaseBallotAdjudicationClaim
     .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves();
@@ -1412,6 +1408,64 @@ test('multi-station mode claims ballots on mount and releases on navigation', as
   apiMock.apiClient.releaseBallotAdjudicationClaim
     .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_2 })
     .resolves();
+});
+
+test('navigation skips ballots claimed by other machines', async () => {
+  const CVR_ID_3 = 'cvr-id-3';
+  const contestData = [
+    makeContestAdjudicationData(
+      'zoo-council-mammal',
+      makeContestTag({ hasWriteIn: true })
+    ),
+  ];
+  const adjData1 = makeBallotAdjudicationData(CVR_ID_1, contestData);
+  const adjData3 = makeBallotAdjudicationData(CVR_ID_3, contestData);
+
+  // CVR_ID_2 is claimed by another machine; queue is [1, 2, 3].
+  apiMock.expectAdjudicationScreenQueries({ claimedCvrIds: [CVR_ID_2] });
+  apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2, CVR_ID_3]);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
+  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetSystemSettings();
+
+  // Prevent refetchInterval-driven re-fetches mid-test.
+  vi.useFakeTimers({ shouldAdvanceTime: true, advanceTimeDelta: 1 });
+
+  // Initial mount on CVR_ID_1.
+  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData1);
+  apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
+  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('Ballot 1 of 3');
+  // No Back button: there is no unclaimed ballot before CVR_ID_1.
+  expect(screen.queryByRole('button', { name: /Back/ })).toBeNull();
+
+  // Skip from CVR_ID_1 should jump past the claimed CVR_ID_2 to CVR_ID_3.
+  apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_1 });
+  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_3 });
+  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_3 }, adjData3);
+  apiMock.expectGetBallotImages({ cvrId: CVR_ID_3 }, true);
+
+  userEvent.click(screen.getByRole('button', { name: /Skip/ }));
+  await screen.findByText('Ballot 3 of 3');
+
+  // Back from CVR_ID_3 should jump past CVR_ID_2 to CVR_ID_1.
+  apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_3 });
+  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
+  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData1);
+
+  userEvent.click(screen.getByRole('button', { name: /Back/ }));
+  await screen.findByText('Ballot 1 of 3');
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves();
+  vi.useRealTimers();
 });
 
 function makePendingWriteInRecord(

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -1429,9 +1429,6 @@ test('Skip jumps past claimed ballots; Back still steps onto them as read-only',
   apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings();
 
-  // Prevent refetchInterval-driven re-fetches mid-test.
-  vi.useFakeTimers({ shouldAdvanceTime: true, advanceTimeDelta: 1 });
-
   // Initial mount on CVR_ID_1.
   apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData1);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
@@ -1479,7 +1476,6 @@ test('Skip jumps past claimed ballots; Back still steps onto them as read-only',
   apiMock.apiClient.releaseBallotAdjudicationClaim
     .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves();
-  vi.useRealTimers();
 });
 
 function makePendingWriteInRecord(

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -280,6 +280,22 @@ function HostBallotAdjudicationScreen({
     );
   }
 
+  function findNextAvailableIndex(
+    direction: 1 | -1,
+    fromIndex: number
+  ): number | undefined {
+    for (
+      let i = fromIndex + direction;
+      i >= 0 && i < queue.length;
+      i += direction
+    ) {
+      if (!claimedCvrIds.has(queue[i])) {
+        return i;
+      }
+    }
+    return undefined;
+  }
+
   async function navigateTo(nextIndex: number): Promise<void> {
     setIsClaimInFlight(true);
     try {
@@ -292,14 +308,17 @@ function HostBallotAdjudicationScreen({
     }
   }
 
+  const nextAvailableIndex = findNextAvailableIndex(1, queueIndex);
+  const previousAvailableIndex = findNextAvailableIndex(-1, queueIndex);
+
   async function navigateNext(): Promise<void> {
     setIsClaimInFlight(true);
     try {
-      if (queueIndex >= queue.length - 1) {
+      if (nextAvailableIndex === undefined) {
         await claimAndRelease();
         history.push(routerPaths.adjudication);
       } else {
-        await navigateTo(queueIndex + 1);
+        await navigateTo(nextAvailableIndex);
       }
     } finally {
       setIsClaimInFlight(false);
@@ -327,10 +346,14 @@ function HostBallotAdjudicationScreen({
       statusText={statusText}
       isClaimed={isClaimed}
       isClaimInFlight={isClaimInFlight}
-      isLastBallot={queueIndex >= queue.length - 1}
+      isLastBallot={nextAvailableIndex === undefined}
       onAcceptDone={navigateNext}
       onSkip={navigateNext}
-      onBack={queueIndex > 0 ? () => navigateTo(queueIndex - 1) : undefined}
+      onBack={
+        previousAvailableIndex !== undefined
+          ? () => navigateTo(previousAvailableIndex)
+          : undefined
+      }
       onExit={navigateExit}
     />
   );

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -280,15 +280,8 @@ function HostBallotAdjudicationScreen({
     );
   }
 
-  function findNextAvailableIndex(
-    direction: 1 | -1,
-    fromIndex: number
-  ): number | undefined {
-    for (
-      let i = fromIndex + direction;
-      i >= 0 && i < queue.length;
-      i += direction
-    ) {
+  function findNextUnclaimedIndex(fromIndex: number): number | undefined {
+    for (let i = fromIndex + 1; i < queue.length; i += 1) {
       if (!claimedCvrIds.has(queue[i])) {
         return i;
       }
@@ -308,17 +301,16 @@ function HostBallotAdjudicationScreen({
     }
   }
 
-  const nextAvailableIndex = findNextAvailableIndex(1, queueIndex);
-  const previousAvailableIndex = findNextAvailableIndex(-1, queueIndex);
+  const nextUnclaimedIndex = findNextUnclaimedIndex(queueIndex);
 
   async function navigateNext(): Promise<void> {
     setIsClaimInFlight(true);
     try {
-      if (nextAvailableIndex === undefined) {
+      if (nextUnclaimedIndex === undefined) {
         await claimAndRelease();
         history.push(routerPaths.adjudication);
       } else {
-        await navigateTo(nextAvailableIndex);
+        await navigateTo(nextUnclaimedIndex);
       }
     } finally {
       setIsClaimInFlight(false);
@@ -346,14 +338,10 @@ function HostBallotAdjudicationScreen({
       statusText={statusText}
       isClaimed={isClaimed}
       isClaimInFlight={isClaimInFlight}
-      isLastBallot={nextAvailableIndex === undefined}
+      isLastBallot={nextUnclaimedIndex === undefined}
       onAcceptDone={navigateNext}
       onSkip={navigateNext}
-      onBack={
-        previousAvailableIndex !== undefined
-          ? () => navigateTo(previousAvailableIndex)
-          : undefined
-      }
+      onBack={queueIndex > 0 ? () => navigateTo(queueIndex - 1) : undefined}
       onExit={navigateExit}
     />
   );


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/8264
Makes it so that the host will skip held ballots when paging next/back in its adjudication queue. The getClaimedCvrs query is on a refetch interval so this should be up to date if the host is slowly adjudicating, its still possible in a race condition to hit a claimed ballot and in that situation the previous UI will be shown. 

## Demo Video or Screenshot
N/A

## Testing Plan
Opened host and client
Claimed first ballot as client
Opened host queue - no option to go back 
Adjudicated first ballot as client and then claimed third ballot (second held by host) 
Clicking next on the host skips to 4th ballot, back can now see first 

## Checklist
- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
