### PR TITLE
[VxPrint] Fix configuration screen copy in unconfigured state

### DIFF
--- a/apps/print/frontend/src/screens/machine_locked_screen.tsx
+++ b/apps/print/frontend/src/screens/machine_locked_screen.tsx
@@ -68,9 +68,9 @@ export function MachineLockedScreen(): JSX.Element | null {
           <Font align="center">
             <InsertCardImage cardInsertionDirection="right" />
             <H1 style={{ maxWidth: '27rem', marginTop: '0' }}>
-              {requiresLocationSelection
-                ? `Insert an election manager card to select a ${locationType}.`
-                : 'Insert an election manager card to configure VxPrint.'}
+              {requiresElectionConfiguration
+                ? 'Insert an election manager card to configure VxPrint.'
+                : `Insert an election manager card to select a ${locationType}.`}
             </H1>
           </Font>
         )}


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/8098

Noticed while testing that the "select a polling place" message incorrectly takes precedence over the "configure VxPrint" one when in the unconfigured state. Updating the conditional to swap the order of precedence.

## Demo Video or Screenshot

| Before | After |
| - | - |
| <img width="1920" height="1081" alt="vxprint-unconfigured-before" src="https://github.com/user-attachments/assets/f57f46dd-1b5f-432c-a653-ad1bab19be7d" /> | <img width="1920" height="1081" alt="vxprint-unconfigured-after" src="https://github.com/user-attachments/assets/496c55e7-46de-43a3-933e-3203e444f320" /> |

## Testing Plan
- Manual for now. We have backlog of FE tests in VxPrint - will try to squeeze in a task to set up scaffolding as part of cleanup for this project.

