### PR TITLE
VxAdmin: fix bug with unclaimed ballot displayed after logout/in on client

### DIFF
--- a/apps/admin/backend/src/peer_app.test.ts
+++ b/apps/admin/backend/src/peer_app.test.ts
@@ -66,6 +66,82 @@ test('connectToHost persists status and authType and returns adjudication enable
   });
 });
 
+test("connectToHost releases the client's claims when it transitions to OnlineLocked", async () => {
+  const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
+  const electionDefinition =
+    electionTwoPartyPrimaryFixtures.readElectionDefinition();
+  const electionId = await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition
+  );
+  addTestCvrs(workspace.store, electionId, 2);
+
+  // Client logs in (Active) and claims a ballot.
+  await peerApiClient.connectToHost({
+    machineId: 'client-001',
+    status: Admin.ClientMachineStatus.Active,
+    authType: 'election_manager',
+  });
+  const cvrId = assertDefined(
+    await peerApiClient.claimBallot({ machineId: 'client-001' })
+  );
+
+  // Client transitions to OnlineLocked (logout / session expiry).
+  await peerApiClient.connectToHost({
+    machineId: 'client-001',
+    status: Admin.ClientMachineStatus.OnlineLocked,
+    authType: null,
+  });
+
+  // The claim should be released — another machine can now pick it up.
+  const result = await peerApiClient.claimBallot({ machineId: 'client-002' });
+  expect(result).toEqual(cvrId);
+});
+
+test('connectToHost does not release claims when status stays Active or transitions Active→Adjudicating', async () => {
+  const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
+  const electionDefinition =
+    electionTwoPartyPrimaryFixtures.readElectionDefinition();
+  const electionId = await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition
+  );
+  addTestCvrs(workspace.store, electionId, 1);
+
+  await peerApiClient.connectToHost({
+    machineId: 'client-001',
+    status: Admin.ClientMachineStatus.Active,
+    authType: 'election_manager',
+  });
+  const cvrId = assertDefined(
+    await peerApiClient.claimBallot({ machineId: 'client-001' })
+  );
+
+  // Repeated heartbeats with the same Active status should not release.
+  await peerApiClient.connectToHost({
+    machineId: 'client-001',
+    status: Admin.ClientMachineStatus.Active,
+    authType: 'election_manager',
+  });
+  // Another machine still cannot claim it.
+  expect(
+    await peerApiClient.claimBallot({ machineId: 'client-002' })
+  ).toBeUndefined();
+
+  // Active → Adjudicating must not release either.
+  await peerApiClient.connectToHost({
+    machineId: 'client-001',
+    status: Admin.ClientMachineStatus.Adjudicating,
+    authType: 'election_manager',
+  });
+  expect(
+    await peerApiClient.claimBallot({ machineId: 'client-002' })
+  ).toBeUndefined();
+  expect(cvrId).toBeDefined();
+});
+
 test('connectToHost updates store when client status changes', async () => {
   const { peerApiClient, workspace } = buildTestEnvironment();
 

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -77,6 +77,21 @@ function buildPeerApi({ workspace, logger }: PeerAppContext) {
           newAuthType: input.authType ?? 'none',
         });
       }
+      // When a client transitions to locked (manual logout or session expiry),
+      // release any ballot claims it still holds. Mirrors the disconnect-side
+      // cleanup in cleanupStaleMachines for the still-connected case.
+      if (
+        previous?.status !== Admin.ClientMachineStatus.OnlineLocked &&
+        input.status === Admin.ClientMachineStatus.OnlineLocked
+      ) {
+        const electionId = store.getCurrentElectionId();
+        if (electionId) {
+          store.releaseAllBallotClaimsForMachine({
+            electionId,
+            machineId: input.machineId,
+          });
+        }
+      }
       store.setNetworkedMachineStatus(
         input.machineId,
         'client',

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -3382,6 +3382,23 @@ export class Store implements BaseStore {
     );
   }
 
+  releaseAllBallotClaimsForMachine({
+    electionId,
+    machineId,
+  }: {
+    electionId: Id;
+    machineId: string;
+  }): void {
+    this.client.run(
+      `
+        delete from machine_ballot_adjudication_assignments
+        where election_id = ? and status = 'claimed' and machine_id = ?
+      `,
+      electionId,
+      machineId
+    );
+  }
+
   isCvrAdjudicated({ cvrId }: { cvrId: Id }): boolean {
     const row = this.client.one(
       `select is_adjudicated from cvrs where id = ?`,

--- a/apps/admin/frontend/src/client/client_app_root.test.tsx
+++ b/apps/admin/frontend/src/client/client_app_root.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, test } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import {
   mockElectionManagerUser,
@@ -18,6 +18,15 @@ import {
 import { ClientApp } from './client_app';
 import { createQueryClient, type ApiClient } from './api';
 import { SharedApiClientContext, systemCallApi } from '../shared_api';
+
+// Stub the ballot adjudication screen so the URL-clearing test doesn't have to
+// wire up its data-loader queries — the behavior under test lives in
+// ClientAppRoot.
+vi.mock('./screens/client_ballot_adjudication_screen', () => ({
+  ClientBallotAdjudicationScreen: () => (
+    <div>mock ballot adjudication screen</div>
+  ),
+}));
 
 let apiMock: ClientApiMock;
 let queryClient: QueryClient;
@@ -208,4 +217,23 @@ test('sysadmin sees settings and diagnostics tabs but not adjudication', async (
   screen.getByRole('button', { name: 'Diagnostics' });
   screen.getByRole('button', { name: 'Lock Machine' });
   expect(screen.queryByRole('button', { name: 'Adjudication' })).toBeNull();
+});
+
+test('logout while on a ballot adjudication URL replaces it with the home route', async () => {
+  // Seed the URL so the app starts on /adjudication/ballots/<cvrId>.
+  window.history.replaceState({}, '', '/adjudication/ballots/cvr-1');
+
+  setPollWorkerAuth();
+  renderClientApp({ withElection: true });
+  await screen.findByText('mock ballot adjudication screen');
+
+  // Logout (manual lock or session expiry while still connected). The
+  // transition useEffect should rewrite the URL to /adjudication so re-auth
+  // lands on the home screen instead of reopening the stale ballot.
+  apiMock.setAuthStatus({
+    status: 'logged_out',
+    reason: 'machine_locked_by_session_expiry',
+  });
+  await screen.findByText('VxAdmin Locked');
+  expect(window.location.pathname).toEqual('/adjudication');
 });

--- a/apps/admin/frontend/src/client/client_app_root.tsx
+++ b/apps/admin/frontend/src/client/client_app_root.tsx
@@ -1,4 +1,5 @@
-import { Redirect, Route, Switch } from 'react-router-dom';
+import { useEffect, useRef } from 'react';
+import { Redirect, Route, Switch, useHistory } from 'react-router-dom';
 import {
   InvalidCardScreen,
   RemoveCardScreen,
@@ -38,6 +39,21 @@ export function ClientAppRoot(): JSX.Element | null {
   const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
   const apiClient = useApiClient();
   const logOutMutation = logOut.useMutation();
+  const history = useHistory();
+  const previousAuthStatusRef = useRef<string | undefined>(undefined);
+
+  // On logout reset the url to the home screen so the session is cleared when logging back in.
+  useEffect(() => {
+    const currentStatus = authStatusQuery.data?.status;
+    const previousStatus = previousAuthStatusRef.current;
+    previousAuthStatusRef.current = currentStatus;
+
+    if (!currentStatus || !previousStatus) return;
+
+    if (previousStatus !== 'logged_out' && currentStatus === 'logged_out') {
+      history.replace(routerPaths.adjudication);
+    }
+  }, [authStatusQuery.data?.status, history]);
 
   if (
     !authStatusQuery.isSuccess ||

--- a/apps/admin/frontend/test/helpers/mock_client_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_client_api_client.ts
@@ -66,7 +66,7 @@ export function createClientApiMock(
         electionPackageHash?: string;
       } | null
     ) {
-      apiClient.getCurrentElectionMetadata.expectCallWith().resolves(
+      apiClient.getCurrentElectionMetadata.expectRepeatedCallsWith().resolves(
         metadata
           ? {
               id: 'election-id',


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/8407
With multi-station adjudication there was a bug in the following scenario: 

A client is adjudicated ballot A and holds a claim for it 
Due to a network interruption or session timeout the user is logged out 
In the network interruption scenario the claim will be cleaned up and released when the client is marked as disconnected, in the session expiry case its held indefinitely - probably not ideal as others could adjudicate at this point
The user logs back in (machine reconnects) and the ballot A adjudication screen is automatically opened upon log in 
No claim is re-grabbed by the client machine but it can adjudicate the ballot despite having no claim leading to various bad scenarios. 

To resolve I am doing a few things: 
- When the session expiry (or something else) forces a logout we clear the URL history and always log back into the home screen not an in-progress ballot adjudication. 
- On the host anytime we see a client with the status of "online locked" we clear all claims from that machine

This means for disconnects we will see: 
- Machine 1 holds claim for ballot A when disconnect occurs
- Machine 1 url history gets cleared
- When the host marks machine 1 as stale it clears its ballot claims
- When Machine 1 reconnects it sends an OnlineLocked status update - if we hadn't hit the above cleanup yet this will cleanup the released ballot claim 
- When a user logs back in on machine 1 they see the adjudication start button not a ballot already open, when they start adjudication they will get a fresh claim 


For session expirations we will see: 
- Machine 1 holds claim for ballot A when session expiration occurs
- Machine 1 url history gets cleared
- Host sess that machine is now "locked" and releases its ballot claims 
- When a user logs back in on machine 1 they see the adjudication start button not a ballot already open, when they start adjudication they will get a fresh claim 


## Demo Video or Screenshot
N/A

## Testing Plan
Tested both session expiration and disconnect paths 

## Checklist
- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
