### PR TITLE
build: ensure `install:rust-addon` runs `cargo fetch` in all NAPI crates

### DIFF
--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -23,6 +23,7 @@
     "build:ts": "tsgo --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "cargo clean --release --package ballot-interpreter && rm -rf build && tsgo --build --clean tsconfig.build.json",
+    "install:rust-addon": "cargo fetch",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "pnpm test:rust-addon && pnpm test:ts",

--- a/libs/logging-utils/package.json
+++ b/libs/logging-utils/package.json
@@ -12,6 +12,7 @@
     "build:watch": "nodemon -x 'pnpm build:self' -w src -w test -e rs",
     "build:self": "napi build --platform --release",
     "build:debug": "napi build --platform",
+    "install:rust-addon": "cargo fetch",
     "prepublishOnly": "napi prepublish -t npm",
     "lint": "cargo clippy",
     "test": "is-ci test:ci test:watch",

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -21,6 +21,7 @@
     "build:generate-types": "pnpm build:generate-typescript-types && pnpm build:generate-rust-types",
     "clean": "pnpm --filter $npm_package_name... clean:self",
     "clean:self": "rm -rf build && tsgo --build --clean tsconfig.build.json",
+    "install:rust-addon": "cargo fetch",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/pdi-scanner/package.json
+++ b/libs/pdi-scanner/package.json
@@ -13,7 +13,7 @@
     "build": "is-ci build:ci build:dev",
     "build:ci": "pnpm --filter $npm_package_name... --sequential build:self",
     "build:dev": "pnpm --filter $npm_package_name... build:self",
-    "build:self": "pnpm install:rust-addon && pnpm build:rust-addon && pnpm build:ts",
+    "build:self": "pnpm build:rust-addon && pnpm build:ts",
     "build:ts": "tsgo --build tsconfig.build.json",
     "build:rust-addon": "cargo build --release --offline",
     "clean": "pnpm --filter $npm_package_name... clean:self",


### PR DESCRIPTION
## Overview

This was broken by #8208 and possibly aggravated by the partitioning of the cargo workspace into multiple workspaces. This should fix the issue of not fetching all the crates needed for offline building during the online build phase.

## Demo Video or Screenshot
n/a

## Testing Plan
@amcmanus to test manually as part of the trusted build process.