### PR TITLE
Replace uuid package with node:crypto.randomUUID

### DIFF
--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -57,7 +57,6 @@
     "object-hash": "^3.0.0",
     "react": "18.3.1",
     "tmp": "^0.2.1",
-    "uuid": "9.0.1",
     "zip-stream": "^4.1.0",
     "zod": "3.25.42"
   },
@@ -76,7 +75,6 @@
     "@types/react": "18.3.3",
     "@types/supertest": "^2.0.10",
     "@types/tmp": "0.2.4",
-    "@types/uuid": "9.0.5",
     "@types/zip-stream": "workspace:*",
     "@vitest/coverage-istanbul": "^3.1.4",
     "@votingworks/fixtures": "workspace:*",

--- a/apps/admin/backend/src/cast_vote_records.ts
+++ b/apps/admin/backend/src/cast_vote_records.ts
@@ -1,6 +1,6 @@
 import { sha256 } from 'js-sha256';
 import path from 'node:path';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import {
   isTestReport,
   readCastVoteRecordExport,

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -52,7 +52,7 @@ import {
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, sep } from 'node:path';
 import { Buffer } from 'node:buffer';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import {
   allContestOptions,
   asSqliteBool,

--- a/apps/admin/backend/test/mock_cvr_file.ts
+++ b/apps/admin/backend/test/mock_cvr_file.ts
@@ -6,7 +6,7 @@ import {
   Id,
   Tabulation,
 } from '@votingworks/types';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import { Buffer } from 'node:buffer';
 import { assertDefined } from '@votingworks/basics';
 import { Store } from '../src/store';

--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -86,7 +86,6 @@
     "styled-components": "^5.3.11",
     "use-interval": "1.4.0",
     "util": "^0.12.4",
-    "uuid": "9.0.1",
     "zod": "3.25.42"
   },
   "devDependencies": {
@@ -108,7 +107,6 @@
     "@types/readable-stream": "2.3.9",
     "@types/styled-components": "^5.1.26",
     "@types/testing-library__jest-dom": "^5.14.9",
-    "@types/uuid": "9.0.5",
     "@vitejs/plugin-react": "^1.3.2",
     "@vitest/coverage-istanbul": "^3.1.4",
     "@votingworks/admin-backend": "workspace:*",

--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -54,7 +54,6 @@
     "js-sha256": "^0.9.0",
     "luxon": "^3.0.0",
     "tmp": "^0.2.1",
-    "uuid": "9.0.1",
     "zod": "3.25.42"
   },
   "devDependencies": {
@@ -66,7 +65,6 @@
     "@types/node": "20.17.31",
     "@types/supertest": "^2.0.10",
     "@types/tmp": "0.2.4",
-    "@types/uuid": "9.0.5",
     "@vitest/coverage-istanbul": "^3.1.4",
     "@votingworks/bmd-ballot-fixtures": "workspace:*",
     "@votingworks/fixtures": "workspace:*",

--- a/apps/central-scan/backend/scripts/copy_batch.ts
+++ b/apps/central-scan/backend/scripts/copy_batch.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import path from 'node:path';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import { AcceptedSheet } from '@votingworks/backend';
 import {
   assert,

--- a/apps/central-scan/backend/src/app.grout.test.ts
+++ b/apps/central-scan/backend/src/app.grout.test.ts
@@ -25,7 +25,7 @@ import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
 } from '@votingworks/utils';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 import { mockElectionManagerAuth } from '../test/helpers/auth';
 import { withApp } from '../test/helpers/setup_app';

--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -16,7 +16,7 @@ import {
 import makeDebug from 'debug';
 import * as fsExtra from 'fs-extra';
 import { join } from 'node:path';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import { interpretSheetAndSaveImages } from '@votingworks/ballot-interpreter';
 import { LogEventId, Logger } from '@votingworks/logging';
 import { ImageData } from 'canvas';
@@ -142,7 +142,7 @@ export class Importer {
     backInputImageData: ImageData,
     ballotAuditId?: string
   ): Promise<string> {
-    let sheetId = uuid();
+    let sheetId: string = uuid();
     const electionDefinition = this.getElectionDefinition();
     const sheetInterpretation = await this.interpretSheet(
       electionDefinition,

--- a/apps/central-scan/backend/src/server.test.ts
+++ b/apps/central-scan/backend/src/server.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi } from 'vitest';
 import { buildMockDippedSmartCardAuth } from '@votingworks/auth';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import {
   electionGridLayoutNewHampshireTestBallotFixtures,
   makeTemporaryDirectory,

--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -12,7 +12,7 @@ import {
   TEST_JURISDICTION,
   YesNoContest,
 } from '@votingworks/types';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import { sleep } from '@votingworks/basics';
 import { AcceptedSheet, RejectedSheet } from '@votingworks/backend';
 import {

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -37,7 +37,7 @@ import {
 import makeDebug from 'debug';
 import { DateTime } from 'luxon';
 import { dirname, join } from 'node:path';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import {
   AcceptedSheet,
   ElectionRecord,

--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -80,7 +80,6 @@
     "pg": "^8.13.1",
     "react": "18.3.1",
     "tmp": "^0.2.1",
-    "uuid": "9.0.1",
     "zod": "3.25.42"
   },
   "devDependencies": {
@@ -93,7 +92,6 @@
     "@types/pg": "^8.11.10",
     "@types/react": "18.3.3",
     "@types/tmp": "0.2.4",
-    "@types/uuid": "9.0.5",
     "@vitest/coverage-istanbul": "^3.1.4",
     "@votingworks/ballot-interpreter": "workspace:*",
     "@votingworks/fixtures": "workspace:*",

--- a/apps/design/backend/src/app.qa_webhook.test.ts
+++ b/apps/design/backend/src/app.qa_webhook.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test, vi } from 'vitest';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import { ElectionId } from '@votingworks/types';
 import { testSetupHelpers } from '../test/helpers';
 import {

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -65,7 +65,7 @@ import {
   singlePrecinctSelectionFor,
   combineAndDecodeCompressedElectionResults,
 } from '@votingworks/utils';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import { BaseLogger } from '@votingworks/logging';
 import { BallotTemplateId, generateBallotStyles } from '@votingworks/hmpb';
 import { DatabaseError } from 'pg';

--- a/apps/design/backend/src/test_decks.ts
+++ b/apps/design/backend/src/test_decks.ts
@@ -1,5 +1,5 @@
 import { assert, assertDefined, find, uniqueBy } from '@votingworks/basics';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import {
   Admin,
   BallotStyleId,

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -39,7 +39,7 @@ import {
 } from '@votingworks/basics';
 import z from 'zod/v4';
 import { Readable } from 'node:stream';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import { EmitProgressFunction, WorkerContext } from './context';
 import {
   createBallotPropsForTemplate,

--- a/apps/design/backend/test/test_store.ts
+++ b/apps/design/backend/test/test_store.ts
@@ -1,5 +1,5 @@
 import { BaseLogger } from '@votingworks/logging';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import { Db } from '../src/db/db';
 import { Store } from '../src/store';
 

--- a/apps/mark-scan/backend/package.json
+++ b/apps/mark-scan/backend/package.json
@@ -54,7 +54,6 @@
     "node-hid": "^2.1.2",
     "react": "18.3.1",
     "tmp": "^0.2.1",
-    "uuid": "9.0.1",
     "xstate": "^4.33.0",
     "zod": "3.25.42"
   },
@@ -68,7 +67,6 @@
     "@types/node-hid": "^1.3.2",
     "@types/react": "18.3.3",
     "@types/tmp": "0.2.4",
-    "@types/uuid": "9.0.5",
     "@vitest/coverage-istanbul": "^3.1.4",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",

--- a/apps/mark/backend/package.json
+++ b/apps/mark/backend/package.json
@@ -49,7 +49,6 @@
     "node-hid": "^2.1.2",
     "react": "18.3.1",
     "tmp": "^0.2.1",
-    "uuid": "9.0.1",
     "zod": "3.25.42"
   },
   "devDependencies": {
@@ -62,7 +61,6 @@
     "@types/node-hid": "^1.3.2",
     "@types/react": "18.3.3",
     "@types/tmp": "0.2.4",
-    "@types/uuid": "9.0.5",
     "@vitest/coverage-istanbul": "^3.1.4",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",

--- a/apps/mark/backend/src/util/print_ballot.tsx
+++ b/apps/mark/backend/src/util/print_ballot.tsx
@@ -1,5 +1,5 @@
 import { Buffer } from 'node:buffer';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 
 import {
   getPdfPageCount,

--- a/apps/pollbook/backend/package.json
+++ b/apps/pollbook/backend/package.json
@@ -61,7 +61,6 @@
     "pdf-lib": "^1.17.1",
     "react": "18.3.1",
     "styled-components": "^5.3.11",
-    "uuid": "9.0.1",
     "vitest": "^3.1.4",
     "zod": "3.25.42"
   },
@@ -76,7 +75,6 @@
     "@types/react": "18.3.3",
     "@types/styled-components": "^5.1.26",
     "@types/tmp": "0.2.4",
-    "@types/uuid": "9.0.5",
     "@types/yargs": "17.0.22",
     "@vitest/coverage-istanbul": "^3.1.4",
     "@votingworks/fixtures": "workspace:*",

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -59,7 +59,6 @@
     "memoize-one": "^6.0.0",
     "pdfjs-dist": "3.11.174",
     "tmp": "^0.2.1",
-    "uuid": "9.0.1",
     "xstate": "^4.33.0",
     "zod": "3.25.42"
   },
@@ -72,7 +71,6 @@
     "@types/node": "20.17.31",
     "@types/supertest": "^2.0.10",
     "@types/tmp": "0.2.4",
-    "@types/uuid": "9.0.5",
     "@vitest/coverage-istanbul": "^3.1.4",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/hmpb": "workspace:*",

--- a/apps/scan/backend/scripts/copy_sheets.ts
+++ b/apps/scan/backend/scripts/copy_sheets.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import path from 'node:path';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import { AcceptedSheet } from '@votingworks/backend';
 import {
   assert,

--- a/apps/scan/backend/src/app_polls_reports.test.ts
+++ b/apps/scan/backend/src/app_polls_reports.test.ts
@@ -8,7 +8,7 @@ import {
   readElectionOpenPrimaryDefinition,
   readElectionTwoPartyPrimaryDefinition,
 } from '@votingworks/fixtures';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import {
   BallotMetadata,
   BallotType,
@@ -36,8 +36,10 @@ import { getScannerResults } from './util/results';
 // Adding calls to getCurrentTime() in the code may result in snapshot changes.
 let uuidCounter = 0;
 let timeCounter = 0;
-vi.mock('uuid', () => ({
-  v4: vi.fn(() => {
+vi.mock('node:crypto', async (importActual) => ({
+  ...(await importActual<typeof import('node:crypto')>()),
+  // eslint-disable-next-line vx/gts-identifiers
+  randomUUID: vi.fn(() => {
     uuidCounter += 1;
     return `00000000-0000-0000-0000-${String(uuidCounter).padStart(12, '0')}`;
   }),

--- a/apps/scan/backend/src/scanner.ts
+++ b/apps/scan/backend/src/scanner.ts
@@ -38,7 +38,7 @@ import {
 } from '@votingworks/utils';
 import { exportCastVoteRecordsToUsbDrive } from '@votingworks/backend';
 import { ImageData } from 'canvas';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import {
   ActorRef,
   BaseActionObject,

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -29,7 +29,7 @@ import {
 } from '@votingworks/utils';
 import { sha256 } from 'js-sha256';
 import { DateTime } from 'luxon';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import { expect, test, vi } from 'vitest';
 
 import { assertDefined } from '@votingworks/basics';

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -37,7 +37,7 @@ import {
 } from '@votingworks/basics';
 import { DateTime } from 'luxon';
 import { join } from 'node:path';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import {
   AcceptedSheet,
   ElectionRecord,

--- a/apps/scan/backend/src/util/results.test.ts
+++ b/apps/scan/backend/src/util/results.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable vx/no-expect-to-be */
 import { vi, expect, test } from 'vitest';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import { mockBaseLogger } from '@votingworks/logging';
 import {
   electionGridLayoutNewHampshireTestBallotFixtures,

--- a/apps/scan/backend/src/util/write_in_report.test.ts
+++ b/apps/scan/backend/src/util/write_in_report.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import { ok } from '@votingworks/basics';
 import { mockBaseLogger } from '@votingworks/logging';
 import {

--- a/apps/scan/backend/test/helpers/shared_helpers.ts
+++ b/apps/scan/backend/test/helpers/shared_helpers.ts
@@ -8,7 +8,7 @@ import {
   mockElectionManagerUser,
   mockSessionExpiresAt,
 } from '@votingworks/test-utils';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import {
   BallotMetadata,
   ElectionPackage,

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -37,7 +37,6 @@
     "node-fetch": "^2.6.0",
     "pcsclite": "^1.0.1",
     "tmp": "^0.2.1",
-    "uuid": "9.0.1",
     "yargs": "17.7.1",
     "zod": "3.25.42"
   },
@@ -47,7 +46,6 @@
     "@types/luxon": "^3.0.0",
     "@types/node-fetch": "^2.6.0",
     "@types/tmp": "0.2.4",
-    "@types/uuid": "9.0.5",
     "@types/yargs": "17.0.22",
     "@vitest/coverage-istanbul": "^3.1.4",
     "@votingworks/fixtures": "workspace:*",

--- a/libs/auth/src/cac/common_access_card.ts
+++ b/libs/auth/src/cac/common_access_card.ts
@@ -8,7 +8,7 @@ import {
 import { Byte } from '@votingworks/types';
 import { Buffer } from 'node:buffer';
 import { sha256 } from 'js-sha256';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import { FileKey, TpmKey } from '../keys';
 
 import {
@@ -214,7 +214,9 @@ export class CommonAccessCard implements CommonAccessCardCompatibleCard {
   private generateChallenge(): string {
     return (
       this.customChallengeGenerator?.() ??
-      `VotingWorks/${new Date().toISOString()}/${uuid()}`
+      `VotingWorks/${new Date().toISOString()}/${uuid({
+        disableEntropyCache: true,
+      })}`
     );
   }
 

--- a/libs/auth/src/inserted_smart_card_auth.ts
+++ b/libs/auth/src/inserted_smart_card_auth.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'node:buffer';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import {
   assert,
   deepEqual,
@@ -287,7 +287,7 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
     this.cardlessVoterUser = {
       ballotStyleId: input.ballotStyleId,
       precinctId: input.precinctId,
-      sessionId: uuid(),
+      sessionId: uuid({ disableEntropyCache: true }),
       role: 'cardless_voter',
     };
 

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -1,12 +1,11 @@
 import { sha256 } from 'js-sha256';
 import { Buffer } from 'node:buffer';
-import crypto from 'node:crypto';
+import crypto, { randomUUID as uuid } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import os from 'node:os';
 import * as path from 'node:path';
 import readline from 'node:readline/promises';
-import { v4 as uuid } from 'uuid';
 import {
   assert,
   extractErrorMessage,
@@ -243,7 +242,9 @@ export class JavaCard implements Card {
     this.generateChallenge =
       config.generateChallengeOverride ??
       /* istanbul ignore next - @preserve */ (() =>
-        `VotingWorks/${new Date().toISOString()}/${uuid()}`);
+        `VotingWorks/${new Date().toISOString()}/${uuid({
+          disableEntropyCache: true,
+        })}`);
     this.vxCertAuthorityCertPath = config.vxCertAuthorityCertPath;
 
     this.cardReader = new CardReader({

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "@google-cloud/text-to-speech": "^5.0.1",
     "@google-cloud/translate": "^8.0.2",
-    "@types/uuid": "9.0.5",
     "@votingworks/auth": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/db": "workspace:*",
@@ -55,7 +54,6 @@
     "stream-json": "^1.7.5",
     "tmp": "^0.2.1",
     "usb": "2.15.0",
-    "uuid": "9.0.1",
     "zod": "3.25.42"
   },
   "devDependencies": {

--- a/libs/backend/src/cast_vote_records/export.test.ts
+++ b/libs/backend/src/cast_vote_records/export.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import * as fs from 'node:fs';
 import path from 'node:path';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import { assert, assertDefined, err, ok, sleep } from '@votingworks/basics';
 import {
   makeTemporaryDirectory,

--- a/libs/fixture-generators/package.json
+++ b/libs/fixture-generators/package.json
@@ -42,7 +42,6 @@
     "js-sha256": "^0.9.0",
     "jszip": "^3.9.1",
     "nanoid": "^3.3.7",
-    "uuid": "9.0.1",
     "yargs": "17.7.1",
     "zod": "3.25.42"
   },
@@ -50,7 +49,6 @@
     "@types/debug": "4.1.12",
     "@types/node": "20.17.31",
     "@types/tmp": "0.2.4",
-    "@types/uuid": "9.0.5",
     "@types/yargs": "17.0.22",
     "@vitest/coverage-istanbul": "^3.1.4",
     "@votingworks/fixtures": "workspace:*",

--- a/libs/fixture-generators/src/generate-cvrs/generate_cvrs.ts
+++ b/libs/fixture-generators/src/generate-cvrs/generate_cvrs.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import {
   buildCVRContestsFromVotes,
   buildCvrImageData,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,9 +222,6 @@ importers:
       tmp:
         specifier: ^0.2.1
         version: 0.2.1
-      uuid:
-        specifier: 9.0.1
-        version: 9.0.1
       zip-stream:
         specifier: ^4.1.0
         version: 4.1.0
@@ -274,9 +271,6 @@ importers:
       '@types/tmp':
         specifier: 0.2.4
         version: 0.2.4
-      '@types/uuid':
-        specifier: 9.0.5
-        version: 9.0.5
       '@types/zip-stream':
         specifier: workspace:*
         version: link:../../../libs/@types/zip-stream
@@ -457,9 +451,6 @@ importers:
       util:
         specifier: ^0.12.4
         version: 0.12.4
-      uuid:
-        specifier: 9.0.1
-        version: 9.0.1
       zod:
         specifier: 3.25.42
         version: 3.25.42
@@ -518,9 +509,6 @@ importers:
       '@types/testing-library__jest-dom':
         specifier: ^5.14.9
         version: 5.14.9
-      '@types/uuid':
-        specifier: 9.0.5
-        version: 9.0.5
       '@vitejs/plugin-react':
         specifier: ^1.3.2
         version: 1.3.2
@@ -723,9 +711,6 @@ importers:
       tmp:
         specifier: ^0.2.1
         version: 0.2.1
-      uuid:
-        specifier: 9.0.1
-        version: 9.0.1
       zod:
         specifier: 3.25.42
         version: 3.25.42
@@ -754,9 +739,6 @@ importers:
       '@types/tmp':
         specifier: 0.2.4
         version: 0.2.4
-      '@types/uuid':
-        specifier: 9.0.5
-        version: 9.0.5
       '@vitest/coverage-istanbul':
         specifier: ^3.1.4
         version: 3.2.4(vitest@3.2.4)
@@ -1137,9 +1119,6 @@ importers:
       tmp:
         specifier: ^0.2.1
         version: 0.2.1
-      uuid:
-        specifier: 9.0.1
-        version: 9.0.1
       zod:
         specifier: 3.25.42
         version: 3.25.42
@@ -1171,9 +1150,6 @@ importers:
       '@types/tmp':
         specifier: 0.2.4
         version: 0.2.4
-      '@types/uuid':
-        specifier: 9.0.5
-        version: 9.0.5
       '@vitest/coverage-istanbul':
         specifier: ^3.1.4
         version: 3.2.4(vitest@3.2.4)
@@ -1523,9 +1499,6 @@ importers:
       tmp:
         specifier: ^0.2.1
         version: 0.2.1
-      uuid:
-        specifier: 9.0.1
-        version: 9.0.1
       xstate:
         specifier: ^4.33.0
         version: 4.33.0
@@ -1560,9 +1533,6 @@ importers:
       '@types/tmp':
         specifier: 0.2.4
         version: 0.2.4
-      '@types/uuid':
-        specifier: 9.0.5
-        version: 9.0.5
       '@vitest/coverage-istanbul':
         specifier: ^3.1.4
         version: 3.2.4(vitest@3.2.4)
@@ -1919,9 +1889,6 @@ importers:
       tmp:
         specifier: ^0.2.1
         version: 0.2.1
-      uuid:
-        specifier: 9.0.1
-        version: 9.0.1
       zod:
         specifier: 3.25.42
         version: 3.25.42
@@ -1953,9 +1920,6 @@ importers:
       '@types/tmp':
         specifier: 0.2.4
         version: 0.2.4
-      '@types/uuid':
-        specifier: 9.0.5
-        version: 9.0.5
       '@vitest/coverage-istanbul':
         specifier: ^3.1.4
         version: 3.2.4(vitest@3.2.4)
@@ -2342,9 +2306,6 @@ importers:
       styled-components:
         specifier: ^5.3.11
         version: 5.3.11(react-dom@18.3.1)(react-is@18.2.0)(react@18.3.1)
-      uuid:
-        specifier: 9.0.1
-        version: 9.0.1
       vitest:
         specifier: ^3.1.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@20.17.31)(jsdom@20.0.1)
@@ -2382,9 +2343,6 @@ importers:
       '@types/tmp':
         specifier: 0.2.4
         version: 0.2.4
-      '@types/uuid':
-        specifier: 9.0.5
-        version: 9.0.5
       '@types/yargs':
         specifier: 17.0.22
         version: 17.0.22
@@ -3030,9 +2988,6 @@ importers:
       tmp:
         specifier: ^0.2.1
         version: 0.2.1
-      uuid:
-        specifier: 9.0.1
-        version: 9.0.1
       xstate:
         specifier: ^4.33.0
         version: 4.33.0
@@ -3064,9 +3019,6 @@ importers:
       '@types/tmp':
         specifier: 0.2.4
         version: 0.2.4
-      '@types/uuid':
-        specifier: 9.0.5
-        version: 9.0.5
       '@vitest/coverage-istanbul':
         specifier: ^3.1.4
         version: 3.2.4(vitest@3.2.4)
@@ -3409,9 +3361,6 @@ importers:
       tmp:
         specifier: ^0.2.1
         version: 0.2.1
-      uuid:
-        specifier: 9.0.1
-        version: 9.0.1
       yargs:
         specifier: 17.7.1
         version: 17.7.1
@@ -3434,9 +3383,6 @@ importers:
       '@types/tmp':
         specifier: 0.2.4
         version: 0.2.4
-      '@types/uuid':
-        specifier: 9.0.5
-        version: 9.0.5
       '@types/yargs':
         specifier: 17.0.22
         version: 17.0.22
@@ -3479,9 +3425,6 @@ importers:
       '@google-cloud/translate':
         specifier: ^8.0.2
         version: 8.0.2
-      '@types/uuid':
-        specifier: 9.0.5
-        version: 9.0.5
       '@votingworks/auth':
         specifier: workspace:*
         version: link:../auth
@@ -3557,9 +3500,6 @@ importers:
       usb:
         specifier: 2.15.0
         version: 2.15.0
-      uuid:
-        specifier: 9.0.1
-        version: 9.0.1
       zod:
         specifier: 3.25.42
         version: 3.25.42
@@ -4318,9 +4258,6 @@ importers:
       nanoid:
         specifier: ^3.3.7
         version: 3.3.7
-      uuid:
-        specifier: 9.0.1
-        version: 9.0.1
       yargs:
         specifier: 17.7.1
         version: 17.7.1
@@ -4337,9 +4274,6 @@ importers:
       '@types/tmp':
         specifier: 0.2.4
         version: 0.2.4
-      '@types/uuid':
-        specifier: 9.0.5
-        version: 9.0.5
       '@types/yargs':
         specifier: 17.0.22
         version: 17.0.22
@@ -14656,9 +14590,6 @@ packages:
   /@types/use-sync-external-store@0.0.6:
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
     dev: false
-
-  /@types/uuid@9.0.5:
-    resolution: {integrity: sha512-xfHdwa1FMJ082prjSJpoEI57GZITiQz10r3vEJCHa2khEFQjKy91aWKz6+zybzssCvXUwE1LQWgWVwZ4nYUvHQ==}
 
   /@types/w3c-web-usb@1.0.8:
     resolution: {integrity: sha512-ouEoUTyB27wFXUUyl0uKIE6VkeCczDtazWTiZGD1M4onceJnp8KnHDf7CzLbpwzek2ZFWXTC5KrNDRc9q/Jf6Q==}


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Dependabot PR #8344 attempted to bump `uuid` from 9 to 14, but uuid went ESM-only at v13, which conflicts with our CommonJS build setup. Instead, we switch to Node's built-in `crypto.randomUUID` for UUID generation.

The 3 cryptographic uses in `libs/auth` (cardless voter `sessionId`, CAC and Java Card challenge generators) pass `{ disableEntropyCache: true }` to match `uuid.v4()`'s no-cache behavior — defense in depth against memory-disclosure side channels on Node's cached entropy pool.

## Demo Video or Screenshot

N/A

## Testing Plan

Automated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
