### PR TITLE
perf: prefer zedbar over rqrr for HMPB QR code detection

### DIFF
--- a/libs/ballot-interpreter/Cargo.lock
+++ b/libs/ballot-interpreter/Cargo.lock
@@ -2625,9 +2625,9 @@ checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "zedbar"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd9c75343ffaf2a2fde468d8b8075c4e9f1b378882ce8e660f0fa8500139d12"
+checksum = "14bfeae54f360a7279c9e95827c8c893939fa2c6462798eaed7687545c969a3c"
 dependencies = [
  "encoding_rs",
  "rand 0.10.1",

--- a/libs/ballot-interpreter/Cargo.toml
+++ b/libs/ballot-interpreter/Cargo.toml
@@ -59,7 +59,7 @@ serde_json = "1.0.89"
 serde_with = { version = "3.14.0", features = ["macros"] }
 itertools = "0.12.1"
 rqrr = "0.7.1"
-zedbar = { version = "0.3.1", default-features = false, features = ["qrcode"] }
+zedbar = { version = "0.4.1", default-features = false, features = ["qrcode"] }
 base64 = "0.22.0"
 thiserror = "1.0.50"
 tokio = { version = "1.44.2", features = ["fs", "macros"] }

--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -49,7 +49,7 @@
     "debug": "4.3.4",
     "node-quirc": "^2.2.1",
     "tmp": "^0.2.1",
-    "zedbar": "^0.3.1"
+    "zedbar": "^0.4.1"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.5.1",

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
@@ -293,9 +293,16 @@ pub fn detect_with_strategy(
     strategy: SearchStrategy,
     debug: &ImageDebugWriter,
 ) -> Result {
+    // Cropping to the strategy's search areas is dramatically cheaper than
+    // scanning the whole image: both decoders scale poorly with image area,
+    // and the cost of producing the crops themselves is negligible.
     let areas = get_detection_areas_for_strategy(img, strategy);
-    let rqrr_result = rqrr::detect_in_areas(&areas);
-    let detect_result = rqrr_result.or_else(|_| zedbar::detect_in_areas(&areas));
+
+    // Try zedbar first because on representative ballot images it decodes
+    // more QR codes than rqrr and is faster per call. rqrr is kept as a
+    // fallback to catch the rare cases zedbar misses.
+    let zedbar_result = zedbar::detect_in_areas(&areas);
+    let detect_result = zedbar_result.or_else(|_| rqrr::detect_in_areas(&areas));
     let detection_areas = match detect_result {
         Ok(ref qr_code) => qr_code.detection_areas().to_vec(),
         Err(ref e) => e.detection_areas().to_vec(),
@@ -417,7 +424,7 @@ mod test {
                 0x00, 0x00, 0x03, 0x00
             ]
         );
-        assert_eq!(qr_code.bounds(), Rect::new(88, 1996, 123, 125));
+        assert_eq!(qr_code.bounds(), Rect::new(88, 1996, 118, 119));
         assert_eq!(qr_code.orientation(), Orientation::Portrait);
     }
 

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/zedbar.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/zedbar.rs
@@ -45,11 +45,14 @@ fn scan_image_for_qr_codes(
     let mut scanner = Scanner::with_config(config);
     let mut img = Image::from_gray(image.as_bytes(), image.width(), image.height())?;
     let symbols = scanner.scan(&mut img);
+    let crop_bounds = Rect::new(0, 0, image.width(), image.height());
     Ok(symbols
         .into_iter()
         .filter(|s| s.symbol_type() == SymbolType::QrCode)
         .map(|s| {
-            let bounds = Rect::new(0, 0, image.width(), image.height());
+            let bounds = s
+                .bounds()
+                .map_or(crop_bounds, |b| Rect::new(b.x, b.y, b.width, b.height));
             (s.data().to_vec(), bounds)
         })
         .collect())

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3647,8 +3647,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       zedbar:
-        specifier: ^0.3.1
-        version: 0.3.1
+        specifier: ^0.4.1
+        version: 0.4.1
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.5.1
@@ -22389,14 +22389,6 @@ packages:
       source-map-js: 1.2.1
     dev: false
 
-  /postcss@8.5.3:
-    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
-    engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   /postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -22404,7 +22396,6 @@ packages:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-    dev: true
 
   /postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
@@ -25423,31 +25414,6 @@ packages:
       teex: 1.0.1
     dev: false
 
-  /vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 6.3.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-    dev: true
-
   /vite-node@3.2.4(@types/node@20.17.31):
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -25507,56 +25473,6 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vite@6.3.1:
-    resolution: {integrity: sha512-kkzzkqtMESYklo96HKKPE5KKLkC1amlsqt+RjFMlX2AvbRB/0wghap19NdBxxwGZ+h/C6DLCrcEphPIItlGrRQ==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      jiti: '>=1.21.0'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-    dependencies:
-      esbuild: 0.25.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.8
-      rollup: 4.40.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
   /vite@6.3.1(@types/node@20.17.31):
     resolution: {integrity: sha512-kkzzkqtMESYklo96HKKPE5KKLkC1amlsqt+RjFMlX2AvbRB/0wghap19NdBxxwGZ+h/C6DLCrcEphPIItlGrRQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -25601,7 +25517,7 @@ packages:
       esbuild: 0.25.2
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.3
+      postcss: 8.5.8
       rollup: 4.40.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -25844,8 +25760,8 @@ packages:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.3.1
-      vite-node: 3.2.4
+      vite: 6.3.1(@types/node@20.17.31)
+      vite-node: 3.2.4(@types/node@20.17.31)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - jiti
@@ -26215,8 +26131,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  /zedbar@0.3.1:
-    resolution: {integrity: sha512-aC6bDKmKB2CEEo9vPDmRKuObvyzmTFYbJQQd0pCeMgulcR/tyMBPXDUSO0aAwuxWIoScFCgJVsM4P4334dFJAA==}
+  /zedbar@0.4.1:
+    resolution: {integrity: sha512-FfmsXIHizX7l4eRW6I/GGyIdHErGJgsdMW5TiQuLUwPi1wNdUipPhm15hRqVRyQek2pgaBVg5g+gT5HcYEvEmA==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     dev: false


### PR DESCRIPTION
## Overview
Swaps the order of QR code detectors used by `detect_with_strategy` so zedbar runs first and rqrr is kept as a fallback. Also uses the new `zedbar::Symbol::bounds()` API (in zedbar 0.4) to report the QR's actual location instead of the entire detection-area crop (only used in tests).

Testing before and after on the TRR corpus (~2.5k HMPB CVRs) shows zedbar 0.4.1 decodes all QR codes that rqrr can and is also faster. rqrr detected a single image that zedbar 0.4.0 missed, and the change in zedbar 0.4.1 was to address that image and ones like it. However, there may still be images in the future that rqrr handles that zedbar can't, so I think it's worth keeping rqrr around. It uses a different sort of algorithm than zedbar that has different failure scenarios.

## Demo Video or Screenshot
The single image rqrr can find the QR code where zedbar 0.4.0 can't (but 0.4.1 can):

<img width="1728" height="2307" alt="rqrr-winner" src="https://github.com/user-attachments/assets/77dc23f4-4ef8-4c4b-a35f-1e444129a233" />

## Testing Plan
Tested on the TRR corpus and found a very slight improvement in performance, most notably on ballots where previously rqrr failed and we had to fall back to zedbar.