### PR TITLE
admin/backend: Disallow grouping/filtering CSV reports by party

### DIFF
--- a/apps/admin/backend/src/app.tally_report_csv.test.ts
+++ b/apps/admin/backend/src/app.tally_report_csv.test.ts
@@ -204,6 +204,31 @@ test('logs failure if export fails for some reason', async () => {
   );
 });
 
+test('rejects party filter or party grouping', async () => {
+  const electionDefinition =
+    electionTwoPartyPrimaryFixtures.readElectionDefinition();
+  const { apiClient, auth, mockUsbDrive } = buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  mockElectionManagerAuth(auth, electionDefinition.election);
+  mockUsbDrive.insertUsbDrive({});
+
+  await expect(
+    apiClient.exportTallyReportCsv({
+      filename: mockFileName(),
+      filter: { partyIds: ['0'] },
+      groupBy: {},
+    })
+  ).rejects.toThrow('Filter by party not supported in CSV export');
+
+  await expect(
+    apiClient.exportTallyReportCsv({
+      filename: mockFileName(),
+      filter: {},
+      groupBy: { groupByParty: true },
+    })
+  ).rejects.toThrow('Group by party not supported in CSV export');
+});
+
 test('incorporates wia and manual data (grouping by voting method)', async () => {
   const electionDefinition =
     electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -1133,6 +1133,15 @@ function buildApi({
         filename: string;
       }
     ): Promise<ExportDataResult> {
+      assert(
+        !input.filter.partyIds,
+        'Filter by party not supported in CSV export'
+      );
+      assert(
+        !input.groupBy.groupByParty,
+        'Group by party not supported in CSV export'
+      );
+
       debug('exporting tally report CSV file: %o', input);
       const electionRecord = assertDefined(getCurrentElectionRecord(workspace));
       const { electionDefinition } = electionRecord;

--- a/apps/admin/backend/src/exports/csv_ballot_count_report.test.ts
+++ b/apps/admin/backend/src/exports/csv_ballot_count_report.test.ts
@@ -137,6 +137,18 @@ test('uses appropriate headers', async () => {
         'Total',
       ],
     },
+    {
+      filter: { partyIds: ['0'] },
+      expectedHeaders: ['Party', 'Party ID', 'Manual', 'Scanned', 'Total'],
+    },
+    // multi filters
+    {
+      filter: { partyIds: ['0', '1'] },
+      expectedHeaders: ['Included Parties', 'Manual', 'Scanned', 'Total'],
+      additionalRowAttributes: {
+        'Included Parties': 'Mammal, Fish',
+      },
+    },
   ];
 
   for (const testCase of testCases) {

--- a/apps/admin/backend/src/exports/csv_tally_report.test.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.test.ts
@@ -8,7 +8,6 @@ import {
   BallotStyleGroupId,
   DEFAULT_SYSTEM_SETTINGS,
   formatBallotHash,
-  Tabulation,
 } from '@votingworks/types';
 import { find } from '@votingworks/basics';
 import { buildManualResultsFixture } from '@votingworks/utils';
@@ -16,7 +15,11 @@ import {
   MockCastVoteRecordFile,
   addMockCvrFileToStore,
 } from '../../test/mock_cvr_file';
-import { generateTallyReportCsv } from './csv_tally_report';
+import {
+  CsvTallyReportFilter,
+  CsvTallyReportGroupBy,
+  generateTallyReportCsv,
+} from './csv_tally_report';
 import { iterableToString, mockFileName, parseCsv } from '../../test/csv';
 import { Store } from '../store';
 
@@ -73,8 +76,8 @@ test('uses appropriate headers', async () => {
   };
 
   const testCases: Array<{
-    filter?: Tabulation.Filter;
-    groupBy?: Tabulation.GroupBy;
+    filter?: CsvTallyReportFilter;
+    groupBy?: CsvTallyReportGroupBy;
     additionalHeaders: string[];
     additionalRowAttributes?: Record<string, string>;
   }> = [
@@ -82,10 +85,6 @@ test('uses appropriate headers', async () => {
     {
       groupBy: { groupByPrecinct: true },
       additionalHeaders: ['Precinct', 'Precinct ID'],
-    },
-    {
-      groupBy: { groupByParty: true },
-      additionalHeaders: ['Party', 'Party ID'],
     },
     {
       groupBy: { groupByBallotStyle: true },
@@ -105,10 +104,6 @@ test('uses appropriate headers', async () => {
     },
     // redundant multiple groupings
     {
-      groupBy: { groupByParty: true, groupByBallotStyle: true },
-      additionalHeaders: ['Party', 'Party ID', 'Ballot Style ID'],
-    },
-    {
       groupBy: { groupByScanner: true, groupByBatch: true },
       additionalHeaders: ['Scanner ID', 'Batch', 'Batch ID'],
     },
@@ -121,10 +116,6 @@ test('uses appropriate headers', async () => {
     {
       filter: { ballotStyleGroupIds: ['1M'] as BallotStyleGroupId[] },
       additionalHeaders: ['Party', 'Party ID', 'Ballot Style ID'],
-    },
-    {
-      filter: { partyIds: ['0'] },
-      additionalHeaders: ['Party', 'Party ID'],
     },
     {
       filter: { scannerIds: ['scanner-1'] },
@@ -154,13 +145,6 @@ test('uses appropriate headers', async () => {
       additionalHeaders: ['Included Ballot Styles'],
       additionalRowAttributes: {
         'Included Ballot Styles': '1M, 2F',
-      },
-    },
-    {
-      filter: { partyIds: ['0', '1'] },
-      additionalHeaders: ['Included Parties'],
-      additionalRowAttributes: {
-        'Included Parties': 'Mammal, Fish',
       },
     },
     {

--- a/apps/admin/backend/src/exports/csv_tally_report.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.ts
@@ -27,6 +27,16 @@ import {
 } from './csv_shared';
 import { tabulateManualResults } from '../tabulation/manual_results';
 
+/**
+ * Filter by party is not supported for tally report CSV exports.
+ */
+export type CsvTallyReportFilter = Omit<Tabulation.Filter, 'partyIds'>;
+
+/**
+ * Group by party is not supported for tally report CSV exports.
+ */
+export type CsvTallyReportGroupBy = Omit<Tabulation.GroupBy, 'groupByParty'>;
+
 // eslint-disable-next-line vx/gts-no-return-type-only-generics
 function assertIsOptional<T>(_value?: unknown): asserts _value is Optional<T> {
   // noop
@@ -98,7 +108,7 @@ function* generateDataRows({
 }: {
   electionId: Id;
   electionDefinition: ElectionDefinition;
-  overallExportFilter: Tabulation.Filter;
+  overallExportFilter: CsvTallyReportFilter;
   resultGroups: Tabulation.GroupList<ScannedAndManualResults>;
   metadataStructure: CsvMetadataStructure;
   store: Store;
@@ -235,8 +245,8 @@ export async function* generateTallyReportCsv({
   filename,
 }: {
   store: Store;
-  filter?: Tabulation.Filter;
-  groupBy?: Tabulation.GroupBy;
+  filter?: CsvTallyReportFilter;
+  groupBy?: CsvTallyReportGroupBy;
   filename: string;
 }): AsyncGenerator<string> {
   const electionId = store.getCurrentElectionId();


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

The VxAdmin frontend tally report builder doesn't expose grouping or filtering by party. This adds some matching types/assertions to the backend for clarity (I was previously confused because I only looked at the backend code without realizing it was disabled on the frontend).

Note that ballot count CSV reports do support party filter/grouping, so this change only applies to tally reports.

## Demo Video or Screenshot

N/A

## Testing Plan

Updated automated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
