### PR TITLE
fix(dev-dock): respect arePollWorkerCardPinsEnabled when mocking poll worker cards

### DIFF
--- a/libs/auth/scripts/src/mock_card.ts
+++ b/libs/auth/scripts/src/mock_card.ts
@@ -105,7 +105,11 @@ async function parseCommandLineArgs(
   }
 
   let electionKey: Optional<ElectionKey>;
-  if (['election-manager', 'poll-worker'].includes(parsedArgs.cardType)) {
+  if (
+    ['election-manager', 'poll-worker', 'poll-worker-with-pin'].includes(
+      parsedArgs.cardType
+    )
+  ) {
     if (!parsedArgs.electionDefinition) {
       throw new Error(
         `Must specify election-definition for election manager and poll worker cards\n\n${helpMessage}`

--- a/libs/dev-dock/backend/src/dev_dock_api.test.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.test.ts
@@ -29,7 +29,11 @@ import {
 } from '@votingworks/fixtures';
 import { Server } from 'node:http';
 import { assert, typedAs } from '@votingworks/basics';
-import { constructElectionKey, PrinterStatus } from '@votingworks/types';
+import {
+  constructElectionKey,
+  DEFAULT_SYSTEM_SETTINGS,
+  PrinterStatus,
+} from '@votingworks/types';
 import {
   getMockConnectedPrinterStatus,
   getMockFilePrinterHandler,
@@ -339,6 +343,59 @@ test('election loading from zip file', async () => {
         electionKey: constructElectionKey(election),
         jurisdiction: DEV_JURISDICTION,
       }),
+    },
+  });
+
+  // Without a systemSettings.json in the zip, the poll worker card defaults
+  // to no PIN.
+  expect(loadedElection?.arePollWorkerCardPinsEnabled).toEqual(false);
+  await apiClient.removeCard();
+  await apiClient.insertCard({ role: 'poll_worker' });
+  await expect(apiClient.getCardStatus()).resolves.toEqual({
+    status: 'ready',
+    cardDetails: {
+      user: mockPollWorkerUser({
+        electionKey: constructElectionKey(election),
+        jurisdiction: DEV_JURISDICTION,
+      }),
+      hasPin: false,
+    },
+  });
+});
+
+test('poll worker card has a PIN when the election package enables them', async () => {
+  const electionPackage = electionFamousNames2021Fixtures.toElectionPackage({
+    ...DEFAULT_SYSTEM_SETTINGS,
+    auth: {
+      ...DEFAULT_SYSTEM_SETTINGS.auth,
+      arePollWorkerCardPinsEnabled: true,
+    },
+  });
+  const { apiClient } = setup();
+
+  const usbDrive = getMockFileUsbDriveHandler();
+  usbDrive.insert(await mockElectionPackageFileTree(electionPackage));
+
+  const available = await apiClient.getAvailableElections();
+  const usbOption = available.find((e) => e.title.startsWith('USB '));
+  assert(usbOption !== undefined);
+  await apiClient.setElection({ inputPath: usbOption.inputPath });
+
+  const loadedElection = await apiClient.getElection();
+  expect(loadedElection?.arePollWorkerCardPinsEnabled).toEqual(true);
+
+  await apiClient.removeCard();
+  await apiClient.insertCard({ role: 'poll_worker' });
+  await expect(apiClient.getCardStatus()).resolves.toEqual({
+    status: 'ready',
+    cardDetails: {
+      user: mockPollWorkerUser({
+        electionKey: constructElectionKey(
+          electionPackage.electionDefinition.election
+        ),
+        jurisdiction: DEV_JURISDICTION,
+      }),
+      hasPin: true,
     },
   });
 });

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -13,9 +13,12 @@ import {
 import { Optional, assert, assertDefined, iter } from '@votingworks/basics';
 import {
   asSheet,
+  DEFAULT_SYSTEM_SETTINGS,
+  ElectionPackageFileName,
   PrinterConfig,
   PrinterStatus,
   safeParseElectionDefinition,
+  safeParseSystemSettings,
   SheetOf,
   UserRole,
 } from '@votingworks/types';
@@ -30,6 +33,7 @@ import {
   openZip,
   getEntries,
   getFileByName,
+  maybeGetFileByName,
   readTextEntry,
 } from '@votingworks/utils';
 import { getMostRecentElectionPackageFilepath } from '@votingworks/backend';
@@ -79,6 +83,13 @@ export interface DevDockElectionOption {
 export interface DevDockElectionInfo extends DevDockElectionOption {
   /** The path to a readable election.json file (extracted from zip if needed) */
   resolvedPath: string;
+  /**
+   * Whether the loaded election package requires poll worker card PINs. Read
+   * from the package's `systemSettings.json` when loading from a zip; defaults
+   * to `false` for bare-election-definition inputs (which carry no system
+   * settings).
+   */
+  arePollWorkerCardPinsEnabled: boolean;
 }
 
 export const DEFAULT_DEV_DOCK_ELECTION_INPUT_PATH =
@@ -166,6 +177,7 @@ async function setElection(
   const inputAbsolutePath = electionPathToAbsolute(inputPath);
   let electionData: string;
   let resolvedPath: string | undefined;
+  let systemSettings = DEFAULT_SYSTEM_SETTINGS;
 
   // Check if the file is a zip file
   if (extname(inputAbsolutePath).toLowerCase() === '.zip') {
@@ -177,10 +189,20 @@ async function setElection(
     // Find and read election.json from the zip
     const electionEntry = getFileByName(
       entries,
-      'election.json',
+      ElectionPackageFileName.ELECTION,
       inputAbsolutePath
     );
     electionData = await readTextEntry(electionEntry);
+
+    const systemSettingsEntry = maybeGetFileByName(
+      entries,
+      ElectionPackageFileName.SYSTEM_SETTINGS
+    );
+    if (systemSettingsEntry) {
+      const systemSettingsData = await readTextEntry(systemSettingsEntry);
+      systemSettings =
+        safeParseSystemSettings(systemSettingsData).unsafeUnwrap();
+    }
 
     // Extract election.json to a stable directory for use by other scripts
     const devDockElectionPath = join(devDockDir, DEV_DOCK_ELECTION_FILE_NAME);
@@ -198,6 +220,8 @@ async function setElection(
     title: electionDefinition.election.title,
     inputPath,
     resolvedPath,
+    arePollWorkerCardPinsEnabled:
+      systemSettings.auth.arePollWorkerCardPinsEnabled,
   };
 
   const devDockFilePath = join(devDockDir, DEV_DOCK_FILE_NAME);
@@ -317,9 +341,15 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
       const { electionInfo } = readDevDockFileContents(devDockFilePath);
       assert(electionInfo !== undefined);
 
+      const cardType =
+        input.role === 'poll_worker' &&
+        electionInfo.arePollWorkerCardPinsEnabled
+          ? 'poll-worker-with-pin'
+          : input.role.replace('_', '-');
+
       await execFile(MOCK_CARD_SCRIPT_PATH, [
         '--card-type',
-        input.role.replace('_', '-'),
+        cardType,
         '--electionDefinition',
         electionInfo.resolvedPath,
       ]);

--- a/libs/dev-dock/frontend/src/dev_dock.test.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.test.tsx
@@ -103,6 +103,7 @@ beforeEach(() => {
     title: 'Sample General Election',
     inputPath: './libs/fixtures/data/electionGeneral/election.json',
     resolvedPath: '/full-path',
+    arePollWorkerCardPinsEnabled: false,
   });
   featureFlagMock.enableFeatureFlag(
     BooleanEnvironmentVariableName.ENABLE_DEV_DOCK
@@ -258,6 +259,7 @@ test('election selector', async () => {
     title: 'Famous Names',
     inputPath: './libs/fixtures/data/electionFamousNames2021/election.json',
     resolvedPath: '/full-path',
+    arePollWorkerCardPinsEnabled: false,
   });
   userEvent.selectOptions(
     electionSelector,


### PR DESCRIPTION
## Overview

:robot: Co-authored by Claude Code

When the dev dock loaded an election package from a mock USB drive whose systemSettings.json had `arePollWorkerCardPinsEnabled: true`, inserting the mock poll worker card showed "Invalid Card" on the running machine with reason `unprogrammed_or_invalid_card`. The dev dock always invoked `mock-card --card-type poll-worker`, which hardcodes `hasPin: false`, but the configured machine state required `hasPin: true`, so the auth layer rejected the card.

- `setElection` now also reads `systemSettings.json` from the election package zip and records `arePollWorkerCardPinsEnabled` on `DevDockElectionInfo`. Bare election-definition inputs default to `false` (they carry no system settings).
- `insertCard` picks `--card-type poll-worker-with-pin` when the role is `poll_worker` and the loaded package enables PINs; otherwise unchanged.
- Fix a latent bug in `libs/auth/scripts/src/mock_card.ts`: the `poll-worker-with-pin` case body asserts `electionKey !== undefined`, but the arg-parsing gate that reads `--election-definition` only included `election-manager` and `poll-worker`. Calling the script with `--card-type poll-worker-with-pin --election-definition ...` silently dropped the election and then asserted. The gate now includes `poll-worker-with-pin`.

## Demo Video or Screenshot
**Before**

[Kooha-2026-05-12-11-39-22.webm](https://github.com/user-attachments/assets/8c6def93-ad97-47d7-bc11-5545e923efd1)

**After**

[Kooha-2026-05-12-13-04-53.webm](https://github.com/user-attachments/assets/7ec20928-9b45-4b0a-91ac-f9fc56e3121d)

## Testing Plan
Manually tested with an election requiring poll worker PINs.