### PR TITLE
VxAdmin: CSV tally reports for open primaries

### DIFF
--- a/apps/admin/backend/src/app.tally_report_csv.test.ts
+++ b/apps/admin/backend/src/app.tally_report_csv.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import {
   electionGridLayoutNewHampshireTestBallotFixtures,
+  electionOpenPrimaryFixtures,
   electionPrimaryPrecinctSplitsFixtures,
   electionTwoPartyPrimaryFixtures,
 } from '@votingworks/fixtures';
@@ -26,6 +27,7 @@ import {
   MockCastVoteRecordFile,
   addMockCvrFileToStore,
 } from '../test/mock_cvr_file';
+import { seedOpenPrimaryCvrsAndAdjudications } from '../test/open_primary_fixture';
 import { Api } from './app';
 import { AdjudicatedCvrContest } from './types';
 import { generateReportPath } from './util/filenames';
@@ -203,6 +205,88 @@ test('logs failure if export fails for some reason', async () => {
       message: `Failed to save tally report CSV file to ${usbRelativeReportPath} on the USB drive.`,
     }
   );
+});
+
+test('open primary: crossover, nonpartisan-only, and adjudicated ballots', async () => {
+  const electionDefinition =
+    electionOpenPrimaryFixtures.readElectionDefinition();
+  const { apiClient, auth, workspace, mockUsbDrive } = buildTestEnvironment();
+  const electionId = await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition
+  );
+  mockElectionManagerAuth(auth, electionDefinition.election);
+  mockUsbDrive.insertUsbDrive({});
+
+  await seedOpenPrimaryCvrsAndAdjudications({
+    apiClient,
+    electionId,
+    store: workspace.store,
+  });
+
+  const { headers, rows } = await getParsedExport({
+    apiClient,
+    mockUsbDrive,
+    filter: {},
+    groupBy: {},
+  });
+  expect(headers).toEqual([
+    'Contest',
+    'Contest ID',
+    'Selection',
+    'Selection ID',
+    'Total Votes',
+  ]);
+
+  function totalVotesBySelectionId(contestId: string): Record<string, string> {
+    return Object.fromEntries(
+      rows
+        .filter((row) => row['Contest ID'] === contestId)
+        .map((row) => [row['Selection ID'], row['Total Votes']])
+    );
+  }
+
+  // 3 happy Dem (alice-jones) + 1 resolved crossover (bob-smith)
+  // + 1 flipped Dem (now nonpartisan, gov-dem undervoted)
+  // Unresolved crossover's gov-dem vote is voided.
+  expect(totalVotesBySelectionId('governor-democratic')).toEqual({
+    'alice-jones': '3',
+    'bob-smith': '1',
+    'carol-white': '0',
+    'dan-rivera': '0',
+    'emily-tran': '0',
+    overvotes: '0',
+    undervotes: '1',
+    'ballots-cast': '5',
+  });
+  // 2 happy Rep + 1 resolved crossover (gov-rep now empty → undervote).
+  // Unresolved crossover's gov-rep vote is voided.
+  expect(totalVotesBySelectionId('governor-republican')).toEqual({
+    'dave-wilson': '2',
+    'ellen-brown': '0',
+    'frank-lee': '0',
+    overvotes: '0',
+    undervotes: '1',
+    'ballots-cast': '3',
+  });
+  expect(totalVotesBySelectionId('governor-libertarian')).toEqual({
+    'grace-kim': '1',
+    'henry-park': '0',
+    overvotes: '0',
+    undervotes: '0',
+    'ballots-cast': '1',
+  });
+  // Every one of the 10 ballots — single-party, nonpartisan-only,
+  // crossover (resolved + unresolved), and flipped — votes nonpartisan.
+  expect(totalVotesBySelectionId('circuit-court-judge')).toEqual({
+    'margaret-chen': '10',
+    'donald-harper': '0',
+    'lisa-ramirez': '0',
+    overvotes: '0',
+    undervotes: '0',
+    'ballots-cast': '10',
+  });
 });
 
 test('rejects party filter or party grouping', async () => {

--- a/apps/admin/backend/src/app.tally_report_data.test.ts
+++ b/apps/admin/backend/src/app.tally_report_data.test.ts
@@ -25,6 +25,7 @@ import {
   MockCastVoteRecordFile,
   addMockCvrFileToStore,
 } from '../test/mock_cvr_file';
+import { seedOpenPrimaryCvrsAndAdjudications } from '../test/open_primary_fixture';
 import { AdjudicatedContestOption } from './types';
 
 vi.setConfig({
@@ -1014,127 +1015,11 @@ test('open primary, full election with crossover and adjudications', async () =>
   );
   mockElectionManagerAuth(auth, election);
 
-  // Seed 10 CVRs. Edge-case ballots vote for different candidates from the
-  // happy-path ballots so per-candidate tallies isolate each behavior:
-  //   3x Dem-only           — gov-dem: alice-jones, nonpartisan
-  //   2x Rep-only           — gov-rep: dave-wilson, nonpartisan
-  //   1x Lib-only           — gov-lib: grace-kim, nonpartisan
-  //   1x Nonpartisan-only   — nonpartisan only
-  //   1x Crossover (resolve via adjudication)
-  //                         — gov-dem: bob-smith + gov-rep: ellen-brown + nonpartisan
-  //   1x Crossover (stays)  — gov-dem: carol-white + gov-rep: frank-lee + nonpartisan
-  //   1x Dem-only (flip via adjudication)
-  //                         — gov-dem: dan-rivera + nonpartisan
-  const baseCvr: Omit<MockCastVoteRecordFile[number], 'votes'> = {
-    ballotStyleGroupId: 'ballot-style-1',
-    batchId: 'batch-1',
-    scannerId: 'scanner-1',
-    precinctId: 'precinct-1',
-    votingMethod: 'precinct',
-    card: { type: 'hmpb', sheetNumber: 1 },
-  };
-  const mockCastVoteRecordFile: MockCastVoteRecordFile = [
-    {
-      ...baseCvr,
-      votes: {
-        'governor-democratic': ['alice-jones'],
-        'circuit-court-judge': ['margaret-chen'],
-      },
-      multiplier: 3,
-    },
-    {
-      ...baseCvr,
-      votes: {
-        'governor-republican': ['dave-wilson'],
-        'circuit-court-judge': ['margaret-chen'],
-      },
-      multiplier: 2,
-    },
-    {
-      ...baseCvr,
-      votes: {
-        'governor-libertarian': ['grace-kim'],
-        'circuit-court-judge': ['margaret-chen'],
-      },
-    },
-    {
-      ...baseCvr,
-      votes: { 'circuit-court-judge': ['margaret-chen'] },
-    },
-    {
-      ...baseCvr,
-      votes: {
-        'governor-democratic': ['bob-smith'],
-        'governor-republican': ['ellen-brown'],
-        'circuit-court-judge': ['margaret-chen'],
-      },
-    },
-    {
-      ...baseCvr,
-      votes: {
-        'governor-democratic': ['carol-white'],
-        'governor-republican': ['frank-lee'],
-        'circuit-court-judge': ['margaret-chen'],
-      },
-    },
-    {
-      ...baseCvr,
-      votes: {
-        'governor-democratic': ['dan-rivera'],
-        'circuit-court-judge': ['margaret-chen'],
-      },
-    },
-  ];
-  const cvrIds = addMockCvrFileToStore({
+  await seedOpenPrimaryCvrsAndAdjudications({
+    apiClient,
     electionId,
-    mockCastVoteRecordFile,
     store: workspace.store,
   });
-  // multiplier expands rows in order, so:
-  //   cvrIds[0..2] = Dem-only
-  //   cvrIds[3..4] = Rep-only
-  //   cvrIds[5]    = Lib-only
-  //   cvrIds[6]    = Nonpartisan-only
-  //   cvrIds[7]    = Crossover (will be resolved)
-  //   cvrIds[8]    = Crossover (stays)
-  //   cvrIds[9]    = Dem-only (will be flipped to nonpartisan)
-  const crossoverToResolveCvrId = cvrIds[7]!;
-  const demToFlipCvrId = cvrIds[9]!;
-
-  // Resolve a crossover by removing the gov-republican vote → ballot becomes
-  // Dem-only, restoring its gov-democratic vote (bob-smith).
-  await apiClient.claimBallotForAdjudication({
-    cvrId: crossoverToResolveCvrId,
-  });
-  (
-    await apiClient.adjudicateCvr({
-      cvrId: crossoverToResolveCvrId,
-      contests: [
-        {
-          contestId: 'governor-republican',
-          adjudicatedContestOptionById: {
-            'ellen-brown': { type: 'official-option', hasVote: false },
-          },
-        },
-      ],
-    })
-  ).assertOk('failed to adjudicate crossover');
-  // Flip a Dem-only ballot by removing its gov-democratic vote (dan-rivera)
-  // → ballot becomes nonpartisan-only.
-  await apiClient.claimBallotForAdjudication({ cvrId: demToFlipCvrId });
-  (
-    await apiClient.adjudicateCvr({
-      cvrId: demToFlipCvrId,
-      contests: [
-        {
-          contestId: 'governor-democratic',
-          adjudicatedContestOptionById: {
-            'dan-rivera': { type: 'official-option', hasVote: false },
-          },
-        },
-      ],
-    })
-  ).assertOk('failed to flip dem ballot');
 
   const tallyReports = await apiClient.getResultsForTallyReports();
   expect(tallyReports).toHaveLength(1);

--- a/apps/admin/backend/test/open_primary_fixture.ts
+++ b/apps/admin/backend/test/open_primary_fixture.ts
@@ -1,0 +1,145 @@
+import { Id } from '@votingworks/types';
+import * as grout from '@votingworks/grout';
+import { assertDefined } from '@votingworks/basics';
+import { Store } from '../src/store';
+import { Api } from '../src/app';
+import { MockCastVoteRecordFile, addMockCvrFileToStore } from './mock_cvr_file';
+
+export interface OpenPrimaryFixtureResult {
+  cvrIds: string[];
+  // Crossover ballot whose Republican vote was adjudicated away → now Dem-only.
+  resolvedCrossoverCvrId: string;
+  // Dem ballot whose Democratic vote was adjudicated away → now nonpartisan-only.
+  flippedToNoPartyCvrId: string;
+}
+
+/**
+ * Seeds the store with 10 open-primary CVRs covering every party-inference
+ * path (single-party, nonpartisan-only, crossover) and applies two
+ * adjudications: resolving one crossover and flipping a single-party ballot
+ * to nonpartisan.
+ */
+export async function seedOpenPrimaryCvrsAndAdjudications({
+  apiClient,
+  electionId,
+  store,
+}: {
+  apiClient: grout.Client<Api>;
+  electionId: Id;
+  store: Store;
+}): Promise<OpenPrimaryFixtureResult> {
+  const baseCvr: Omit<MockCastVoteRecordFile[number], 'votes'> = {
+    ballotStyleGroupId: 'ballot-style-1',
+    batchId: 'batch-1',
+    scannerId: 'scanner-1',
+    precinctId: 'precinct-1',
+    votingMethod: 'precinct',
+    card: { type: 'hmpb', sheetNumber: 1 },
+  };
+  const mockCastVoteRecordFile: MockCastVoteRecordFile = [
+    {
+      ...baseCvr,
+      votes: {
+        'governor-democratic': ['alice-jones'],
+        'circuit-court-judge': ['margaret-chen'],
+      },
+      multiplier: 3,
+    },
+    {
+      ...baseCvr,
+      votes: {
+        'governor-republican': ['dave-wilson'],
+        'circuit-court-judge': ['margaret-chen'],
+      },
+      multiplier: 2,
+    },
+    {
+      ...baseCvr,
+      votes: {
+        'governor-libertarian': ['grace-kim'],
+        'circuit-court-judge': ['margaret-chen'],
+      },
+    },
+    {
+      ...baseCvr,
+      votes: { 'circuit-court-judge': ['margaret-chen'] },
+    },
+    {
+      ...baseCvr,
+      votes: {
+        'governor-democratic': ['bob-smith'],
+        'governor-republican': ['ellen-brown'],
+        'circuit-court-judge': ['margaret-chen'],
+      },
+    },
+    {
+      ...baseCvr,
+      votes: {
+        'governor-democratic': ['carol-white'],
+        'governor-republican': ['frank-lee'],
+        'circuit-court-judge': ['margaret-chen'],
+      },
+    },
+    {
+      ...baseCvr,
+      votes: {
+        'governor-democratic': ['dan-rivera'],
+        'circuit-court-judge': ['margaret-chen'],
+      },
+    },
+  ];
+  const cvrIds = addMockCvrFileToStore({
+    electionId,
+    mockCastVoteRecordFile,
+    store,
+  });
+  // Multiplier expands rows in order, so:
+  //   cvrIds[0..2] = Dem-only
+  //   cvrIds[3..4] = Rep-only
+  //   cvrIds[5]    = Lib-only
+  //   cvrIds[6]    = Nonpartisan-only
+  //   cvrIds[7]    = Crossover (will be resolved)
+  //   cvrIds[8]    = Crossover (stays)
+  //   cvrIds[9]    = Dem-only (will be flipped to nonpartisan)
+  const resolvedCrossoverCvrId = assertDefined(cvrIds[7]);
+  const flippedToNoPartyCvrId = assertDefined(cvrIds[9]);
+
+  // Resolve a crossover by removing the gov-republican vote → ballot becomes
+  // Dem-only, restoring its gov-democratic vote (bob-smith).
+  await apiClient.claimBallotForAdjudication({
+    cvrId: resolvedCrossoverCvrId,
+  });
+  (
+    await apiClient.adjudicateCvr({
+      cvrId: resolvedCrossoverCvrId,
+      contests: [
+        {
+          contestId: 'governor-republican',
+          adjudicatedContestOptionById: {
+            'ellen-brown': { type: 'official-option', hasVote: false },
+          },
+        },
+      ],
+    })
+  ).assertOk('failed to adjudicate crossover');
+  // Flip a Dem-only ballot by removing its gov-democratic vote (dan-rivera)
+  // → ballot becomes nonpartisan-only.
+  await apiClient.claimBallotForAdjudication({
+    cvrId: flippedToNoPartyCvrId,
+  });
+  (
+    await apiClient.adjudicateCvr({
+      cvrId: flippedToNoPartyCvrId,
+      contests: [
+        {
+          contestId: 'governor-democratic',
+          adjudicatedContestOptionById: {
+            'dan-rivera': { type: 'official-option', hasVote: false },
+          },
+        },
+      ],
+    })
+  ).assertOk('failed to flip dem ballot');
+
+  return { cvrIds, resolvedCrossoverCvrId, flippedToNoPartyCvrId };
+}


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Turned out the basic CSV generation logic worked well already, since we already updated the results tabulation logic. So this PR just adds test coverage for tally report CSVs in open primary elections, matching the behavior of the tally report PDFs. 

## Demo Video or Screenshot

Example report CSV
[unofficial-full-election-tally-report__2026-05-12_13-20-55.csv](https://github.com/user-attachments/files/27660880/unofficial-full-election-tally-report__2026-05-12_13-20-55.csv)



## Testing Plan

- Added test
- Basic manual test

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
