### PR TITLE
[VxScan] Allow PAT-based replay of audio for non-interactive elements

### DIFF
--- a/apps/scan/frontend/src/components/layout.tsx
+++ b/apps/scan/frontend/src/components/layout.tsx
@@ -10,7 +10,6 @@ import {
   Icons,
   LanguageSettingsButton,
   LanguageSettingsScreen,
-  ReadOnLoad,
   AudioOnly,
   TestModeBanner,
   VoterHelpButton,
@@ -18,6 +17,7 @@ import {
   Button,
   appStrings,
   ElectionInfoBarProps,
+  FocusableAudio,
 } from '@votingworks/ui';
 import styled, { DefaultTheme, ThemeContext } from 'styled-components';
 import { SizeMode } from '@votingworks/types';
@@ -255,11 +255,16 @@ export function Screen(props: ScreenProps): JSX.Element | null {
         <TitleContainer>{title && <H1>{title}</H1>}</TitleContainer>
         {!voterFacing && ballotCountElement}
       </HeaderRow>
-      {voterFacing && !disableReadOnLoad ? (
-        <ReadOnLoad as={Main} centerChild={centerContent} padded={padded}>
+      {voterFacing ? (
+        <FocusableAudio
+          as={Main}
+          centerChild={centerContent}
+          padded={padded}
+          readOnLoad={!disableReadOnLoad}
+        >
           {title && <AudioOnly>{title}</AudioOnly>}
           {children}
-        </ReadOnLoad>
+        </FocusableAudio>
       ) : (
         <Main centerChild={centerContent} padded={padded}>
           {children}

--- a/apps/scan/frontend/src/components/misvote_warnings/warning_details_modal_button.test.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/warning_details_modal_button.test.tsx
@@ -1,5 +1,8 @@
 import { afterEach, expect, test, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
+import { within } from '@testing-library/react';
+import { assert } from '@votingworks/basics';
+import { FOCUSABLE_AUDIO_CLASS_NAME } from '@votingworks/ui';
 import { render, screen } from '../../../test/react_testing_library';
 import { WarningDetails } from './warning_details';
 import { generateContests } from './test_utils.test';
@@ -40,6 +43,28 @@ test('renders modal on button press', () => {
     { blankContests, overvoteContests, partiallyVotedContests },
     {}
   );
+});
+
+test('renders modal with focusable audio content', () => {
+  vi.mocked(WarningDetails).mockImplementation(() => (
+    <div data-testid="mockWarningDetails" />
+  ));
+
+  render(
+    <WarningDetailsModalButton
+      blankContests={[]}
+      overvoteContests={[]}
+      partiallyVotedContests={[]}
+    />
+  );
+
+  userEvent.click(screen.getButton(/view contests/i));
+
+  const focusableAudioEl = document.getElementsByClassName(
+    FOCUSABLE_AUDIO_CLASS_NAME
+  )?.[0];
+  assert(focusableAudioEl instanceof HTMLElement);
+  within(focusableAudioEl).getByTestId('mockWarningDetails');
 });
 
 test('closes modal', () => {

--- a/apps/scan/frontend/src/components/misvote_warnings/warning_details_modal_button.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/warning_details_modal_button.tsx
@@ -20,6 +20,7 @@ export function WarningDetailsModalButton(
     return (
       <Modal
         modalWidth={ModalWidth.Wide}
+        focusableAudioContent
         content={
           // TODO: Check whether the accessible input is a tactile controller vs. a PAT device and
           // only make the scroll buttons focusable when using a PAT device

--- a/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/bmd_paper_ballot.test.tsx.snap
@@ -7,10 +7,10 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
     <div>
       <div
         aria-hidden="true"
-        class="sc-bmzYkS bsILDd"
+        class="sc-iHGNWf gprKmk"
       >
         <div
-          class="sc-iHGNWf erXvsP"
+          class="sc-dtBdUo iVBMDq"
           data-testid="header"
         >
           <img
@@ -60,7 +60,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
             </p>
           </div>
           <div
-            class="sc-dtBdUo eocoyJ"
+            class="sc-kOHTFB hSzMPF"
           >
             <div>
               <div>
@@ -121,19 +121,19 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
           </div>
         </div>
         <div
-          class="sc-kOHTFB hrDtiZ"
+          class="sc-dtInlm bQdwfL"
         >
           <div
-            class="sc-dtInlm dTZmnn"
+            class="sc-kOPcWz kgDZPz"
           >
             <div
-              class="sc-kOPcWz gSnSrZ"
+              class="sc-cWSHoV gWDGBV"
             >
               <div
-                class="sc-cWSHoV dUXOXi"
+                class="sc-eBMEME gYQNPj"
               >
                 <span
-                  class="sc-jxOSlx euoqcA"
+                  class="sc-lcIPJg gOhCuZ"
                 >
                   <span>
                     President
@@ -141,7 +141,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 </span>
               </div>
               <span
-                class="sc-dCFHLb RAqQW"
+                class="sc-fhzFiK hCkRJd"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -155,13 +155,13 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
               </span>
             </div>
             <div
-              class="sc-kOPcWz gSnSrZ"
+              class="sc-cWSHoV gWDGBV"
             >
               <div
-                class="sc-cWSHoV dUXOXi"
+                class="sc-eBMEME gYQNPj"
               >
                 <span
-                  class="sc-jxOSlx euoqcA"
+                  class="sc-lcIPJg gOhCuZ"
                 >
                   <span>
                     Senate 
@@ -169,7 +169,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 </span>
               </div>
               <span
-                class="sc-dCFHLb RAqQW"
+                class="sc-fhzFiK hCkRJd"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -183,13 +183,13 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
               </span>
             </div>
             <div
-              class="sc-kOPcWz gSnSrZ"
+              class="sc-cWSHoV gWDGBV"
             >
               <div
-                class="sc-cWSHoV dUXOXi"
+                class="sc-eBMEME gYQNPj"
               >
                 <span
-                  class="sc-jxOSlx euoqcA"
+                  class="sc-lcIPJg gOhCuZ"
                 >
                   <span>
                     1st Congressional District
@@ -197,7 +197,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 </span>
               </div>
               <span
-                class="sc-dCFHLb RAqQW"
+                class="sc-fhzFiK hCkRJd"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -211,13 +211,13 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
               </span>
             </div>
             <div
-              class="sc-kOPcWz gSnSrZ"
+              class="sc-cWSHoV gWDGBV"
             >
               <div
-                class="sc-cWSHoV dUXOXi"
+                class="sc-eBMEME gYQNPj"
               >
                 <span
-                  class="sc-jxOSlx euoqcA"
+                  class="sc-lcIPJg gOhCuZ"
                 >
                   <span>
                     Supreme Court District 3(Northern) Position 3
@@ -225,7 +225,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 </span>
               </div>
               <span
-                class="sc-dCFHLb RAqQW"
+                class="sc-fhzFiK hCkRJd"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -239,13 +239,13 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
               </span>
             </div>
             <div
-              class="sc-kOPcWz gSnSrZ"
+              class="sc-cWSHoV gWDGBV"
             >
               <div
-                class="sc-cWSHoV dUXOXi"
+                class="sc-eBMEME gYQNPj"
               >
                 <span
-                  class="sc-jxOSlx euoqcA"
+                  class="sc-lcIPJg gOhCuZ"
                 >
                   <span>
                     Election Commissioner 04
@@ -253,7 +253,7 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
                 </span>
               </div>
               <span
-                class="sc-dCFHLb RAqQW"
+                class="sc-fhzFiK hCkRJd"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -267,13 +267,13 @@ exports[`BmdPaperBallot accepts a layout override 1`] = `
               </span>
             </div>
             <div
-              class="sc-kOPcWz gSnSrZ"
+              class="sc-cWSHoV gWDGBV"
             >
               <div
-                class="sc-cWSHoV dUXOXi"
+                class="sc-eBMEME gYQNPj"
               >
                 <span
-                  class="sc-jxOSlx euoqcA"
+                  class="sc-lcIPJg gOhCuZ"
                 >
                   <span>
                     Ballot Measure 2
@@ -282,7 +282,7 @@ House Concurrent Resolution No. 47
                 </span>
               </div>
               <span
-                class="sc-dCFHLb RAqQW"
+                class="sc-fhzFiK hCkRJd"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -296,13 +296,13 @@ House Concurrent Resolution No. 47
               </span>
             </div>
             <div
-              class="sc-kOPcWz gSnSrZ"
+              class="sc-cWSHoV gWDGBV"
             >
               <div
-                class="sc-cWSHoV dUXOXi"
+                class="sc-eBMEME gYQNPj"
               >
                 <span
-                  class="sc-jxOSlx euoqcA"
+                  class="sc-lcIPJg gOhCuZ"
                 >
                   <span>
                     Ballot Measure 3
@@ -311,7 +311,7 @@ House Bill 1796 - Flag Referendum
                 </span>
               </div>
               <span
-                class="sc-dCFHLb RAqQW"
+                class="sc-fhzFiK hCkRJd"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -325,13 +325,13 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <div
-              class="sc-kOPcWz gSnSrZ"
+              class="sc-cWSHoV gWDGBV"
             >
               <div
-                class="sc-cWSHoV dUXOXi"
+                class="sc-eBMEME gYQNPj"
               >
                 <span
-                  class="sc-jxOSlx euoqcA"
+                  class="sc-lcIPJg gOhCuZ"
                 >
                   <span>
                     Ballot Measure 1
@@ -339,7 +339,7 @@ House Bill 1796 - Flag Referendum
                 </span>
               </div>
               <span
-                class="sc-dCFHLb RAqQW"
+                class="sc-fhzFiK hCkRJd"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -353,13 +353,13 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <div
-              class="sc-kOPcWz gSnSrZ"
+              class="sc-cWSHoV gWDGBV"
             >
               <div
-                class="sc-cWSHoV dUXOXi"
+                class="sc-eBMEME gYQNPj"
               >
                 <span
-                  class="sc-jxOSlx euoqcA"
+                  class="sc-lcIPJg gOhCuZ"
                 >
                   <span>
                     Ballot Measure 1 - Part 2
@@ -367,7 +367,7 @@ House Bill 1796 - Flag Referendum
                 </span>
               </div>
               <span
-                class="sc-dCFHLb RAqQW"
+                class="sc-fhzFiK hCkRJd"
               >
                 <span
                   class="sc-gEvEer hUnYwC"
@@ -388,10 +388,10 @@ House Bill 1796 - Flag Referendum
   "container": <div>
     <div
       aria-hidden="true"
-      class="sc-bmzYkS bsILDd"
+      class="sc-iHGNWf gprKmk"
     >
       <div
-        class="sc-iHGNWf erXvsP"
+        class="sc-dtBdUo iVBMDq"
         data-testid="header"
       >
         <img
@@ -441,7 +441,7 @@ House Bill 1796 - Flag Referendum
           </p>
         </div>
         <div
-          class="sc-dtBdUo eocoyJ"
+          class="sc-kOHTFB hSzMPF"
         >
           <div>
             <div>
@@ -502,19 +502,19 @@ House Bill 1796 - Flag Referendum
         </div>
       </div>
       <div
-        class="sc-kOHTFB hrDtiZ"
+        class="sc-dtInlm bQdwfL"
       >
         <div
-          class="sc-dtInlm dTZmnn"
+          class="sc-kOPcWz kgDZPz"
         >
           <div
-            class="sc-kOPcWz gSnSrZ"
+            class="sc-cWSHoV gWDGBV"
           >
             <div
-              class="sc-cWSHoV dUXOXi"
+              class="sc-eBMEME gYQNPj"
             >
               <span
-                class="sc-jxOSlx euoqcA"
+                class="sc-lcIPJg gOhCuZ"
               >
                 <span>
                   President
@@ -522,7 +522,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-dCFHLb RAqQW"
+              class="sc-fhzFiK hCkRJd"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -536,13 +536,13 @@ House Bill 1796 - Flag Referendum
             </span>
           </div>
           <div
-            class="sc-kOPcWz gSnSrZ"
+            class="sc-cWSHoV gWDGBV"
           >
             <div
-              class="sc-cWSHoV dUXOXi"
+              class="sc-eBMEME gYQNPj"
             >
               <span
-                class="sc-jxOSlx euoqcA"
+                class="sc-lcIPJg gOhCuZ"
               >
                 <span>
                   Senate 
@@ -550,7 +550,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-dCFHLb RAqQW"
+              class="sc-fhzFiK hCkRJd"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -564,13 +564,13 @@ House Bill 1796 - Flag Referendum
             </span>
           </div>
           <div
-            class="sc-kOPcWz gSnSrZ"
+            class="sc-cWSHoV gWDGBV"
           >
             <div
-              class="sc-cWSHoV dUXOXi"
+              class="sc-eBMEME gYQNPj"
             >
               <span
-                class="sc-jxOSlx euoqcA"
+                class="sc-lcIPJg gOhCuZ"
               >
                 <span>
                   1st Congressional District
@@ -578,7 +578,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-dCFHLb RAqQW"
+              class="sc-fhzFiK hCkRJd"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -592,13 +592,13 @@ House Bill 1796 - Flag Referendum
             </span>
           </div>
           <div
-            class="sc-kOPcWz gSnSrZ"
+            class="sc-cWSHoV gWDGBV"
           >
             <div
-              class="sc-cWSHoV dUXOXi"
+              class="sc-eBMEME gYQNPj"
             >
               <span
-                class="sc-jxOSlx euoqcA"
+                class="sc-lcIPJg gOhCuZ"
               >
                 <span>
                   Supreme Court District 3(Northern) Position 3
@@ -606,7 +606,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-dCFHLb RAqQW"
+              class="sc-fhzFiK hCkRJd"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -620,13 +620,13 @@ House Bill 1796 - Flag Referendum
             </span>
           </div>
           <div
-            class="sc-kOPcWz gSnSrZ"
+            class="sc-cWSHoV gWDGBV"
           >
             <div
-              class="sc-cWSHoV dUXOXi"
+              class="sc-eBMEME gYQNPj"
             >
               <span
-                class="sc-jxOSlx euoqcA"
+                class="sc-lcIPJg gOhCuZ"
               >
                 <span>
                   Election Commissioner 04
@@ -634,7 +634,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-dCFHLb RAqQW"
+              class="sc-fhzFiK hCkRJd"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -648,13 +648,13 @@ House Bill 1796 - Flag Referendum
             </span>
           </div>
           <div
-            class="sc-kOPcWz gSnSrZ"
+            class="sc-cWSHoV gWDGBV"
           >
             <div
-              class="sc-cWSHoV dUXOXi"
+              class="sc-eBMEME gYQNPj"
             >
               <span
-                class="sc-jxOSlx euoqcA"
+                class="sc-lcIPJg gOhCuZ"
               >
                 <span>
                   Ballot Measure 2
@@ -663,7 +663,7 @@ House Concurrent Resolution No. 47
               </span>
             </div>
             <span
-              class="sc-dCFHLb RAqQW"
+              class="sc-fhzFiK hCkRJd"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -677,13 +677,13 @@ House Concurrent Resolution No. 47
             </span>
           </div>
           <div
-            class="sc-kOPcWz gSnSrZ"
+            class="sc-cWSHoV gWDGBV"
           >
             <div
-              class="sc-cWSHoV dUXOXi"
+              class="sc-eBMEME gYQNPj"
             >
               <span
-                class="sc-jxOSlx euoqcA"
+                class="sc-lcIPJg gOhCuZ"
               >
                 <span>
                   Ballot Measure 3
@@ -692,7 +692,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-dCFHLb RAqQW"
+              class="sc-fhzFiK hCkRJd"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -706,13 +706,13 @@ House Bill 1796 - Flag Referendum
             </span>
           </div>
           <div
-            class="sc-kOPcWz gSnSrZ"
+            class="sc-cWSHoV gWDGBV"
           >
             <div
-              class="sc-cWSHoV dUXOXi"
+              class="sc-eBMEME gYQNPj"
             >
               <span
-                class="sc-jxOSlx euoqcA"
+                class="sc-lcIPJg gOhCuZ"
               >
                 <span>
                   Ballot Measure 1
@@ -720,7 +720,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-dCFHLb RAqQW"
+              class="sc-fhzFiK hCkRJd"
             >
               <span
                 class="sc-gEvEer hUnYwC"
@@ -734,13 +734,13 @@ House Bill 1796 - Flag Referendum
             </span>
           </div>
           <div
-            class="sc-kOPcWz gSnSrZ"
+            class="sc-cWSHoV gWDGBV"
           >
             <div
-              class="sc-cWSHoV dUXOXi"
+              class="sc-eBMEME gYQNPj"
             >
               <span
-                class="sc-jxOSlx euoqcA"
+                class="sc-lcIPJg gOhCuZ"
               >
                 <span>
                   Ballot Measure 1 - Part 2
@@ -748,7 +748,7 @@ House Bill 1796 - Flag Referendum
               </span>
             </div>
             <span
-              class="sc-dCFHLb RAqQW"
+              class="sc-fhzFiK hCkRJd"
             >
               <span
                 class="sc-gEvEer hUnYwC"

--- a/libs/ui/src/__snapshots__/modal.test.tsx.snap
+++ b/libs/ui/src/__snapshots__/modal.test.tsx.snap
@@ -4,13 +4,13 @@ exports[`Modal > can configure a wider max width 1`] = `
 <div
   aria-label="Alert Modal"
   aria-modal="true"
-  class="sc-jlZhew gqRxOR ReactModal__Content _"
+  class="sc-cwHptR knvQFR ReactModal__Content _"
   data-testid="modal"
   role="alertdialog"
   tabindex="-1"
 >
   <div
-    class="sc-cPiKLX dzQCTS"
+    class="sc-dLMFU ggbOHV"
   >
     Do you want to do the thing?
   </div>
@@ -21,13 +21,13 @@ exports[`Modal > can configure fullscreen 1`] = `
 <div
   aria-label="Alert Modal"
   aria-modal="true"
-  class="sc-jlZhew jakLHR ReactModal__Content _"
+  class="sc-cwHptR dkTQmZ ReactModal__Content _"
   data-testid="modal"
   role="alertdialog"
   tabindex="-1"
 >
   <div
-    class="sc-cPiKLX fLrXtF"
+    class="sc-dLMFU jCxQay"
   >
     Do you want to do the thing?
   </div>

--- a/libs/ui/src/accessible_controllers/navigation.test.tsx
+++ b/libs/ui/src/accessible_controllers/navigation.test.tsx
@@ -6,6 +6,7 @@ import {
   advanceElementFocus,
   triggerPageNavigationButton,
 } from './navigation';
+import { FocusableAudio } from '../focusable_audio';
 
 const TestButton = styled.button.attrs({ type: 'button' })`
   /* stylelint-disable no-empty-source */
@@ -21,6 +22,8 @@ test('advanceElementFocus', () => {
       <div data-testid="focusableButtonDiv" role="button" tabIndex={0} />
       <div data-testid="nonFocusableButtonDiv" role="button" tabIndex={-1} />
       <div data-testid="hiddenButtonDiv" role="button" aria-hidden />
+      <FocusableAudio data-testid="focusableAudioBlock" />
+      <FocusableAudio data-testid="hiddenFocusableAudioBlock" aria-hidden />
       <div aria-hidden>
         <TestButton data-testid="focusableButtonInHiddenBlock" />
         <div
@@ -40,17 +43,23 @@ test('advanceElementFocus', () => {
   expect(screen.getByTestId('focusableButtonDiv')).toHaveFocus();
 
   act(() => advanceElementFocus(1));
+  expect(screen.getByTestId('focusableAudioBlock')).toHaveFocus();
+
+  act(() => advanceElementFocus(1));
   expect(screen.getByTestId('focusableButton')).toHaveFocus();
 
   // Expect to move backwards and wrap to end:
   act(() => advanceElementFocus(-1));
+  expect(screen.getByTestId('focusableAudioBlock')).toHaveFocus();
+
+  act(() => advanceElementFocus(-1));
   expect(screen.getByTestId('focusableButtonDiv')).toHaveFocus();
 
   act(() => advanceElementFocus(-1));
   expect(screen.getByTestId('focusableButton')).toHaveFocus();
 
   act(() => advanceElementFocus(-1));
-  expect(screen.getByTestId('focusableButtonDiv')).toHaveFocus();
+  expect(screen.getByTestId('focusableAudioBlock')).toHaveFocus();
 });
 
 test('advanceElementFocus - is no-op when no focusable elements present', () => {

--- a/libs/ui/src/accessible_controllers/navigation.ts
+++ b/libs/ui/src/accessible_controllers/navigation.ts
@@ -1,3 +1,5 @@
+import { FOCUSABLE_AUDIO_CLASS_NAME } from '../focusable_audio';
+
 export enum PageNavigationButtonId {
   NEXT = 'next',
   NEXT_AFTER_CONFIRM = 'next_after_confirm',
@@ -8,6 +10,7 @@ export enum PageNavigationButtonId {
 const TAB_ENABLED_ELEMENT_SELECTORS = [
   'button:not([aria-hidden="true"]):not([disabled]):not([tabindex="-1"])',
   '[role="button"]:not([aria-hidden="true"]):not([disabled]):not([tabindex="-1"])',
+  `.${FOCUSABLE_AUDIO_CLASS_NAME}:not([aria-hidden="true"])`,
 ].join(', ');
 
 /**
@@ -17,6 +20,7 @@ const TAB_ENABLED_ELEMENT_SELECTORS = [
 const TAB_ENABLED_ELEMENT_IN_HIDDEN_BLOCK_SELECTORS = [
   '[aria-hidden="true"] button',
   '[aria-hidden="true"] [role="button"]',
+  `[aria-hidden="true"] .${FOCUSABLE_AUDIO_CLASS_NAME}`,
 ].join(', ');
 
 function getTabEnabledElementsInHiddenBlocks() {
@@ -57,7 +61,7 @@ export function advanceElementFocus(direction: 1 | -1): void {
 
 /**
  * Looks for all page navigation elements with the specified
- * {@link navigationId} or {@link nagivationOnConfirmId} (if provided). If a
+ * {@link navigationId} or {@link navigationOnConfirmId} (if provided). If a
  * visible {@link navigationId} is found, the first element is clicked.
  * Otherwise if a visible {@link navigationOnConfirmId} is found, the first
  * element is focused.

--- a/libs/ui/src/focusable_audio.test.tsx
+++ b/libs/ui/src/focusable_audio.test.tsx
@@ -1,0 +1,37 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { render, screen } from '../test/react_testing_library.js';
+import { FocusableAudio } from './focusable_audio';
+import { ReadOnLoad, ReadOnLoadProps } from './ui_strings/read_on_load';
+
+vi.mock(import('./ui_strings/read_on_load.js'), async (importActual) => ({
+  ...(await importActual()),
+  ReadOnLoad: vi.fn(),
+}));
+
+const mockReadOnLoad = vi.mocked(ReadOnLoad);
+const MOCK_READ_ON_LOAD_TEST_ID = 'mockReadOnLoad';
+
+beforeEach(() => {
+  mockReadOnLoad.mockImplementation((props: ReadOnLoadProps) => (
+    <div data-testid={MOCK_READ_ON_LOAD_TEST_ID} {...props} />
+  ));
+});
+
+test('renders with <ReadOnLoad> when `readOnLoad === true`', () => {
+  render(<FocusableAudio readOnLoad>some audio content</FocusableAudio>);
+
+  const readOnLoadContainer = screen.getByTestId(MOCK_READ_ON_LOAD_TEST_ID);
+  expect(readOnLoadContainer).toHaveTextContent('some audio content');
+  expect(readOnLoadContainer).toHaveAttribute('tabindex', '0');
+});
+
+test('renders without <ReadOnLoad> when `readOnLoad === false`', () => {
+  render(<FocusableAudio>some audio content</FocusableAudio>);
+
+  const container = screen.getByText('some audio content');
+  expect(container).toHaveAttribute('tabindex', '0');
+
+  const readOnLoadContainer = screen.queryByTestId(MOCK_READ_ON_LOAD_TEST_ID);
+  expect(readOnLoadContainer).not.toBeInTheDocument();
+});

--- a/libs/ui/src/focusable_audio.tsx
+++ b/libs/ui/src/focusable_audio.tsx
@@ -1,0 +1,52 @@
+import styled from 'styled-components';
+
+import { ComponentPropsWithoutRef, ElementType } from 'react';
+import { ReadOnLoad } from './ui_strings/read_on_load';
+
+export const FOCUSABLE_AUDIO_CLASS_NAME = 'FocusableAudio';
+
+export type FocusableAudioProps<T extends ElementType> = Omit<
+  ComponentPropsWithoutRef<T>,
+  'as'
+> & {
+  as?: T;
+  readOnLoad?: boolean;
+};
+
+const DefaultContainer = styled.div`
+  /* stylelint-disable no-empty-source */
+`;
+
+/**
+ * Renders a screen-reader-compatible focusable block that is inserted into the
+ * browser tabbing order. This allows voters to replay screen reader audio for
+ * non-interactive elements, like screen titles/preambles and accessible
+ * navigation instructions, by tabbing (back) to the block.
+ *
+ * When the `readOnLoad` flag is specified, this also takes on the behavior of
+ * the {@link ReadOnLoad} component, in that it automatically takes focus when
+ * it's first mounted, triggering a screen reader readout of its contents.
+ *
+ * NOTE: This is not yet fully ready for use with audio-only blocks, since they
+ * are rendered off-screen and won't have a visible focus indicator. We need to
+ * think through how to indicate to controller-and-video voters that the focus
+ * is currently on an audio-only element.
+ */
+export function FocusableAudio<T extends ElementType = 'div'>(
+  props: FocusableAudioProps<T>
+): JSX.Element {
+  const { as = 'div', children, className, readOnLoad, ...rest } = props;
+
+  const Container = readOnLoad ? ReadOnLoad : DefaultContainer;
+
+  return (
+    <Container
+      {...rest}
+      as={as}
+      className={`${className || ''} ${FOCUSABLE_AUDIO_CLASS_NAME}`}
+      tabIndex={0}
+    >
+      {children}
+    </Container>
+  );
+}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -29,6 +29,7 @@ export * from './diagnostics';
 export * from './error_boundary';
 export * from './election_info_bar';
 export * from './electrical_testing_screen';
+export * from './focusable_audio';
 export * from './file_input_button';
 export * from './input_controls';
 export * from './fonts/font_family';

--- a/libs/ui/src/modal.test.tsx
+++ b/libs/ui/src/modal.test.tsx
@@ -10,6 +10,7 @@ import {
   UiStringsReactQueryApi,
   createUiStringsApi,
 } from './hooks/ui_strings_api';
+import { FocusableAudio, FocusableAudioProps } from './focusable_audio';
 
 vi.mock(import('./ui_strings/read_on_load.js'), async (importActual) => ({
   ...(await importActual()),
@@ -19,10 +20,23 @@ vi.mock(import('./ui_strings/read_on_load.js'), async (importActual) => ({
 const mockReadOnLoad = vi.mocked(ReadOnLoad);
 const MOCK_READ_ON_LOAD_TEST_ID = 'mockReadOnLoad';
 
+vi.mock(import('./focusable_audio.js'), async (importActual) => ({
+  ...(await importActual()),
+  FocusableAudio: vi.fn(),
+}));
+
+const mockFocusableAudio = vi.mocked(FocusableAudio<'div'>);
+const MOCK_FOCUSABLE_AUDIO_TEST_ID = 'mockFocusableAudio';
+
 beforeEach(() => {
   mockReadOnLoad.mockImplementation((props: ReadOnLoadProps) => (
     <div data-testid={MOCK_READ_ON_LOAD_TEST_ID} {...props} />
   ));
+
+  mockFocusableAudio.mockImplementation((props: FocusableAudioProps<'div'>) => {
+    const { as: _unused1, readOnLoad: _unused2, ...rest } = props;
+    return <div data-testid={MOCK_FOCUSABLE_AUDIO_TEST_ID} {...rest} />;
+  });
 });
 
 describe('Modal', () => {
@@ -147,6 +161,10 @@ describe('when in voter audio context', () => {
     const readOnLoadElement = screen.getByTestId(MOCK_READ_ON_LOAD_TEST_ID);
 
     expect(readOnLoadElement).toHaveTextContent(/^TITLE.?Content!$/);
+
+    expect(
+      screen.queryByTestId(MOCK_FOCUSABLE_AUDIO_TEST_ID)
+    ).not.toBeInTheDocument();
   });
 
   test("doesn't trigger screen reader when autoplay is disabled", () => {
@@ -164,8 +182,67 @@ describe('when in voter audio context', () => {
     expect(
       screen.queryByTestId(MOCK_READ_ON_LOAD_TEST_ID)
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(MOCK_FOCUSABLE_AUDIO_TEST_ID)
+    ).not.toBeInTheDocument();
     screen.getByText('TITLE');
     screen.getByText('Content!');
+  });
+});
+
+describe('when focusable audio content is enabled', () => {
+  const mockUiStringsApi: UiStringsReactQueryApi = createUiStringsApi(() => ({
+    getAudioClips: vi.fn(),
+    getAvailableLanguages: vi.fn(),
+    getUiStringAudioIds: vi.fn(),
+    getUiStrings: vi.fn(),
+  }));
+
+  test('renders content in focusable block', () => {
+    render(
+      <UiStringsAudioContextProvider api={mockUiStringsApi}>
+        <Modal
+          focusableAudioContent
+          title={<span>TITLE</span>}
+          content={<span>Content</span>}
+          actions={<span>Do not read this</span>}
+        />
+      </UiStringsAudioContextProvider>
+    );
+
+    const readOnLoadElement = screen.getByTestId(MOCK_FOCUSABLE_AUDIO_TEST_ID);
+    expect(readOnLoadElement).toHaveTextContent(/^TITLE.?Content$/);
+
+    const props = mockFocusableAudio.mock.lastCall?.[0];
+    expect(props).toEqual<FocusableAudioProps<'div'>>(
+      expect.objectContaining({
+        readOnLoad: true,
+      })
+    );
+  });
+
+  test("doesn't trigger screen reader when autoplay is disabled", () => {
+    render(
+      <UiStringsAudioContextProvider api={mockUiStringsApi}>
+        <Modal
+          disableAutoplayAudio
+          focusableAudioContent
+          title={<span>TITLE</span>}
+          content={<span>Content</span>}
+          actions={<span>Do not read this</span>}
+        />
+      </UiStringsAudioContextProvider>
+    );
+
+    const readOnLoadElement = screen.getByTestId(MOCK_FOCUSABLE_AUDIO_TEST_ID);
+    expect(readOnLoadElement).toHaveTextContent(/^TITLE.?Content$/);
+
+    const props = mockFocusableAudio.mock.lastCall?.[0];
+    expect(props).toEqual<FocusableAudioProps<'div'>>(
+      expect.objectContaining({
+        readOnLoad: false,
+      })
+    );
   });
 });
 

--- a/libs/ui/src/modal.tsx
+++ b/libs/ui/src/modal.tsx
@@ -9,6 +9,7 @@ import { SizeMode } from '@votingworks/types';
 import { H2 } from './typography';
 import { ReadOnLoad } from './ui_strings/read_on_load';
 import { useAudioContext } from './ui_strings/audio_context';
+import { FocusableAudio } from './focusable_audio';
 
 /**
  * Controls the maximum width the modal can expand to.
@@ -131,7 +132,7 @@ const ModalContent = styled('div')<ModalContentInterface>`
   padding: ${(p) => (p.fullscreen ? 0 : getSpacingValueRem(p))}rem;
 `;
 
-const ReadOnOpen = styled(ReadOnLoad)`
+const AudioContent = styled.div`
   align-items: inherit;
   display: flex;
   flex-direction: column;
@@ -172,6 +173,7 @@ export interface ModalProps {
   onAfterOpen?: () => void;
   onAfterClose?: () => void;
   onOverlayClick?: () => void;
+  focusableAudioContent?: boolean;
   fullscreen?: boolean;
   modalWidth?: ModalWidth;
   title?: ReactNode;
@@ -184,6 +186,7 @@ export function Modal({
   centerContent,
   content,
   disableAutoplayAudio,
+  focusableAudioContent,
   fullscreen = false,
   ariaHideApp = true,
   onAfterOpen,
@@ -196,12 +199,22 @@ export function Modal({
   const isInVoterAudioContext = !!useAudioContext();
   const shouldPlayAudioOnOpen = isInVoterAudioContext && !disableAutoplayAudio;
 
-  const modalContent = (
+  let modalContent = (
     <React.Fragment>
       {title && <H2 as="h1">{title}</H2>}
       {content}
     </React.Fragment>
   );
+
+  if (focusableAudioContent) {
+    modalContent = (
+      <FocusableAudio as={AudioContent} readOnLoad={shouldPlayAudioOnOpen}>
+        {modalContent}
+      </FocusableAudio>
+    );
+  } else if (shouldPlayAudioOnOpen) {
+    modalContent = <ReadOnLoad as={AudioContent}>{modalContent}</ReadOnLoad>;
+  }
 
   /* istanbul ignore next - can't get document.getElementById working in test - @preserve */
   const appElement = useMemo(
@@ -245,11 +258,7 @@ export function Modal({
       overlayClassName="_"
     >
       <ModalContent centerContent={centerContent} fullscreen={fullscreen}>
-        {shouldPlayAudioOnOpen ? (
-          <ReadOnOpen>{modalContent}</ReadOnOpen>
-        ) : (
-          modalContent
-        )}
+        {modalContent}
       </ModalContent>
       {actions && <ButtonBar as="div">{actions}</ButtonBar>}
     </ReactModal>

--- a/libs/ui/src/with_scroll_buttons.tsx
+++ b/libs/ui/src/with_scroll_buttons.tsx
@@ -191,6 +191,10 @@ export function WithScrollButtons(props: WithScrollButtonsProps): JSX.Element {
         scrollEnabled={scrollEnabled}
         onScroll={updateScrollState}
         noPadding={noPadding}
+        // Chromium inserts scrollable containers into the tab order by default.
+        // This avoids the container taking focus before the scroll buttons when
+        // using an ATI controller/PAT device.
+        tabIndex={-1}
       >
         {children}
       </Content>


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/8419

Currently, introductory audio for screens/modals play once, with no way to replay them using the PAT device, since there's no way to return focus to those elements and re-trigger the screen reader.

Adding a `FocusableAudio` block component for wrapping audio-enabled content in a way that supports replay (by navigating back to those elements). Mostly follows the pattern used in the older `ReadOnLoad` component, which automatically triggers the screen reader when opening a screen/modal.

This is currently only used in VxScan. It will also be useful to voters on VxMark, but we'll first need to sort out how to visually indicate where the focus is in cases where the focusable audio is "audio-only" and rendered off-screen (like audio/controller-only instructions).

### TODO
- Due to the structure of the shared screen layout component, the screen title on some screens is rendered outside the focus indicator, even though the audio equivalent of the title is contained within the focus area. Will open up a follow-up task to clean this up - might require making some wider changes and verifying affected screens aren't broken as a result.
- Also opening up a task to add more descriptive audio to a few on-screen controls that haven't been updated since adding screen reader audio to VxScan (the "More" button in the scroll container, the "Close" button in the warnings modal, etc)

## Demo Video or Screenshot

### Warnings Screen/Modal

https://github.com/user-attachments/assets/1a0900ee-6ef9-4d55-aeb7-bdf898398029

### Main Voter Screen 

https://github.com/user-attachments/assets/d13dd52a-e117-41ab-82de-71a49d0697e1

## Testing Plan
- Unit tests for the new component and its usage in libs/ui & VxScan
- Manual verification with audio-enabled election

## Checklist

- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
