### PR TITLE
fix(scan): check ballot hash earlier in interpretation

### DIFF
--- a/libs/ballot-encoder/src/index.test.ts
+++ b/libs/ballot-encoder/src/index.test.ts
@@ -59,7 +59,8 @@ test('can detect an encoded ballot', () => {
 });
 
 test('encodes & decodes with Uint8Array as the standard encoding interface', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const precinct = election.precincts[0]!;
   const ballotStyleId = ballotStyle.id;
@@ -75,14 +76,17 @@ test('encodes & decodes with Uint8Array as the standard encoding interface', () 
     ballotType: BallotType.Precinct,
   };
 
-  expect(decodeBallot(election, encodeBallot(election, ballot))).toEqual({
+  expect(
+    decodeBallot(electionDefinition, encodeBallot(election, ballot))
+  ).toEqual({
     ...ballot,
     ballotHash: ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH),
   });
 });
 
 test('encodes & decodes empty votes correctly', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const precinct = election.precincts[0]!;
   const ballotStyleId = ballotStyle.id;
@@ -122,14 +126,15 @@ test('encodes & decodes empty votes correctly', () => {
     .toUint8Array();
 
   expect(encodeBallot(election, ballot)).toEqualBits(encodedBallot);
-  expect(decodeBallot(election, encodedBallot)).toEqual({
+  expect(decodeBallot(electionDefinition, encodedBallot)).toEqual({
     ...ballot,
     ballotHash: ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH),
   });
 });
 
 test('encodes & decodes whether it is a test ballot', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const precinct = election.precincts[0]!;
   const ballotStyleId = ballotStyle.id;
@@ -169,14 +174,15 @@ test('encodes & decodes whether it is a test ballot', () => {
     .toUint8Array();
 
   expect(encodeBallot(election, ballot)).toEqualBits(encodedBallot);
-  expect(decodeBallot(election, encodedBallot)).toEqual({
+  expect(decodeBallot(electionDefinition, encodedBallot)).toEqual({
     ...ballot,
     ballotHash: ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH),
   });
 });
 
 test('encodes & decodes the ballot type', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const precinct = election.precincts[0]!;
   const ballotStyleId = ballotStyle.id;
@@ -219,14 +225,15 @@ test('encodes & decodes the ballot type', () => {
     .toUint8Array();
 
   expect(encodeBallot(election, ballot)).toEqualBits(encodedBallot);
-  expect(decodeBallot(election, encodedBallot)).toEqual({
+  expect(decodeBallot(electionDefinition, encodedBallot)).toEqual({
     ...ballot,
     ballotHash: ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH),
   });
 });
 
 test('encodes & decodes yesno votes correctly', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const precinct = election.precincts[0]!;
   const ballotStyleId = ballotStyle.id;
@@ -285,13 +292,14 @@ test('encodes & decodes yesno votes correctly', () => {
     .toUint8Array();
 
   expect(encodeBallot(election, ballot)).toEqualBits(encodedBallot);
-  expect(encodeBallot(election, decodeBallot(election, encodedBallot))).toEqual(
-    encodedBallot
-  );
+  expect(
+    encodeBallot(election, decodeBallot(electionDefinition, encodedBallot))
+  ).toEqual(encodedBallot);
 });
 
 test('throws on invalid precinct', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const ballotStyleId = ballotStyle.id;
   const precinctId = 'not-a-precinct';
@@ -332,7 +340,8 @@ test('throws on invalid ballot style', () => {
 });
 
 test('throws on trying to encode a bad yes/no vote', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const precinct = election.precincts[0]!;
   const ballotStyleId = ballotStyle.id;
@@ -365,7 +374,8 @@ test('throws on trying to encode a bad yes/no vote', () => {
 });
 
 test('throws on trying to encode a ballot style', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const precinct = election.precincts[0]!;
   const ballotStyleId = `${ballotStyle.id}-CORRUPTED`;
@@ -386,7 +396,8 @@ test('throws on trying to encode a ballot style', () => {
 });
 
 test('encodes & decodes candidate choice votes correctly', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const precinct = election.precincts[0]!;
   const ballotStyleId = ballotStyle.id;
@@ -470,14 +481,15 @@ test('encodes & decodes candidate choice votes correctly', () => {
     .toUint8Array();
 
   expect(encodeBallot(election, ballot)).toEqualBits(encodedBallot);
-  expect(decodeBallot(election, encodedBallot)).toEqual({
+  expect(decodeBallot(electionDefinition, encodedBallot)).toEqual({
     ...ballot,
     ballotHash: ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH),
   });
 });
 
 test('encodes & decodes write-in votes correctly', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const precinct = election.precincts[0]!;
   const ballotStyleId = ballotStyle.id;
@@ -532,27 +544,28 @@ test('encodes & decodes write-in votes correctly', () => {
     .toUint8Array();
 
   expect(encodeBallot(election, ballot)).toEqualBits(encodedBallot);
-  expect(decodeBallot(election, encodedBallot)).toEqual({
+  expect(decodeBallot(electionDefinition, encodedBallot)).toEqual({
     ...ballot,
     ballotHash: ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH),
   });
 });
 
 test('cannot decode a ballot without the prelude', () => {
-  const { election } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
   const encodedBallot = new BitWriter()
     // prelude + version number
     .writeString('XV', { includeLength: false, length: 2 })
     .writeUint8(2)
     .toUint8Array();
 
-  expect(() => decodeBallot(election, encodedBallot)).toThrowError(
+  expect(() => decodeBallot(electionDefinition, encodedBallot)).toThrowError(
     "expected leading prelude 'V' 'X' 0b00000002 but it was not found"
   );
 });
 
 test('cannot decode a ballot that includes extra data at the end', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const precinct = election.precincts[0]!;
   const ballotStyleId = ballotStyle.id;
@@ -574,13 +587,14 @@ test('cannot decode a ballot that includes extra data at the end', () => {
 
   const corruptedBallot = writer.writeBoolean(true).toUint8Array();
 
-  expect(() => decodeBallot(election, corruptedBallot)).toThrowError(
+  expect(() => decodeBallot(electionDefinition, corruptedBallot)).toThrowError(
     'unexpected data found while reading padding, expected EOF'
   );
 });
 
 test('cannot decode a ballot that includes too much padding at the end', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const precinct = election.precincts[0]!;
   const ballotStyleId = ballotStyle.id;
@@ -602,13 +616,14 @@ test('cannot decode a ballot that includes too much padding at the end', () => {
 
   const corruptedBallot = writer.writeUint8(0).toUint8Array();
 
-  expect(() => decodeBallot(election, corruptedBallot)).toThrowError(
+  expect(() => decodeBallot(electionDefinition, corruptedBallot)).toThrowError(
     'unexpected data found while reading padding, expected EOF'
   );
 });
 
 test('decode ballot hash from BMD metadata', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const precinct = election.precincts[0]!;
   const ballotStyleId = ballotStyle.id;
@@ -659,7 +674,8 @@ test('encode HMPB ballot page metadata', () => {
 });
 
 test('encode HMPB ballot page metadata with bad precinct fails', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotMetadata: HmpbBallotPageMetadata = {
     ballotHash,
     precinctId: 'SanDimas', // not an actual precinct ID
@@ -675,7 +691,8 @@ test('encode HMPB ballot page metadata with bad precinct fails', () => {
 });
 
 test('encode HMPB ballot page metadata with bad ballot style fails', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotMetadata: HmpbBallotPageMetadata = {
     ballotHash,
     precinctId: election.ballotStyles[0]!.precincts[0]!,
@@ -704,7 +721,8 @@ test('can detect a multi-page BMD ballot', () => {
 });
 
 test('multi-page BMD ballot is still detected as VX ballot', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const precinct = election.precincts[0]!;
   const contests = getContests({ election, ballotStyle });
@@ -727,7 +745,8 @@ test('multi-page BMD ballot is still detected as VX ballot', () => {
 });
 
 test('encodes & decodes multi-page BMD ballot with empty votes', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const precinct = election.precincts[0]!;
   const contests = getContests({ election, ballotStyle });
@@ -748,7 +767,7 @@ test('encodes & decodes multi-page BMD ballot with empty votes', () => {
   };
 
   const encoded = encodeBmdMultiPageBallot(election, page);
-  const decoded = decodeBmdMultiPageBallot(election, encoded);
+  const decoded = decodeBmdMultiPageBallot(electionDefinition, encoded);
 
   expect(decoded.metadata.ballotHash).toEqual(
     ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH)
@@ -765,7 +784,8 @@ test('encodes & decodes multi-page BMD ballot with empty votes', () => {
 });
 
 test('encodes & decodes multi-page BMD ballot with votes', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const precinct = election.precincts[0]!;
   const contests = getContests({ election, ballotStyle });
@@ -789,7 +809,7 @@ test('encodes & decodes multi-page BMD ballot with votes', () => {
   };
 
   const encoded = encodeBmdMultiPageBallot(election, page);
-  const decoded = decodeBmdMultiPageBallot(election, encoded);
+  const decoded = decodeBmdMultiPageBallot(electionDefinition, encoded);
 
   expect(decoded.metadata.isTestMode).toEqual(true);
   expect(decoded.metadata.ballotType).toEqual(BallotType.Absentee);
@@ -800,7 +820,8 @@ test('encodes & decodes multi-page BMD ballot with votes', () => {
 });
 
 test('encodes & decodes multi-page BMD ballot with write-in votes', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const precinct = election.precincts[0]!;
   const contests = getContests({ election, ballotStyle });
@@ -828,7 +849,7 @@ test('encodes & decodes multi-page BMD ballot with write-in votes', () => {
   };
 
   const encoded = encodeBmdMultiPageBallot(election, page);
-  const decoded = decodeBmdMultiPageBallot(election, encoded);
+  const decoded = decodeBmdMultiPageBallot(electionDefinition, encoded);
 
   expect(decoded.metadata.pageNumber).toEqual(1);
   expect(decoded.metadata.totalPages).toEqual(1);
@@ -838,7 +859,8 @@ test('encodes & decodes multi-page BMD ballot with write-in votes', () => {
 });
 
 test('decode ballot hash from multi-page BMD metadata', () => {
-  const { election, ballotHash } = readElectionDefinition();
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
   const ballotStyle = election.ballotStyles[0]!;
   const precinct = election.precincts[0]!;
   const contests = getContests({ election, ballotStyle });

--- a/libs/ballot-encoder/src/index.ts
+++ b/libs/ballot-encoder/src/index.ts
@@ -11,6 +11,7 @@ import {
   ContestId,
   Contests,
   Election,
+  ElectionDefinition,
   getBallotStyle,
   getContests,
   getPrecinctById,
@@ -458,7 +459,7 @@ function decodeBallotVotes(contests: Contests, bits: BitReader): VotesDict {
  * Decodes a completed ballot, including metadata and votes, from a bit reader.
  */
 export function decodeBallotFromReader(
-  election: Election,
+  electionDefinition: ElectionDefinition,
   bits: BitReader
 ): CompletedBallot {
   if (!bits.skipUint8(...BmdPrelude)) {
@@ -472,6 +473,12 @@ export function decodeBallotFromReader(
     length: BALLOT_HASH_ENCODING_LENGTH,
   });
 
+  assert(
+    ballotHash === sliceBallotHashForEncoding(electionDefinition.ballotHash),
+    `unexpected ballot hash '${ballotHash}' (expected '${electionDefinition.ballotHash}')`
+  );
+
+  const { election } = electionDefinition;
   const { ballotStyleId, ballotType, isTestMode, precinctId } =
     decodeBallotConfigFromReader(election, bits);
   const ballotStyle = getBallotStyle({ ballotStyleId, election });
@@ -499,10 +506,10 @@ export function decodeBallotFromReader(
  * Decodes a completed ballot, including metadata and votes, from a byte array.
  */
 export function decodeBallot(
-  election: Election,
+  electionDefinition: ElectionDefinition,
   data: Uint8Array
 ): CompletedBallot {
-  return decodeBallotFromReader(election, new BitReader(data));
+  return decodeBallotFromReader(electionDefinition, new BitReader(data));
 }
 
 /**
@@ -774,7 +781,7 @@ export interface DecodedBmdMultiPageBallotPage {
  * Decodes a single page of a multi-page BMD ballot from a bit reader.
  */
 export function decodeBmdMultiPageBallotFromReader(
-  election: Election,
+  electionDefinition: ElectionDefinition,
   bits: BitReader
 ): DecodedBmdMultiPageBallotPage {
   assert(
@@ -787,6 +794,12 @@ export function decodeBmdMultiPageBallotFromReader(
     length: BALLOT_HASH_ENCODING_LENGTH,
   });
 
+  assert(
+    ballotHash === sliceBallotHashForEncoding(electionDefinition.ballotHash),
+    `unexpected ballot hash '${ballotHash}' (expected '${electionDefinition.ballotHash}')`
+  );
+
+  const { election } = electionDefinition;
   const config = decodeBmdMultiPageBallotConfigFromReader(election, bits);
   const { ballotStyleId } = config;
 
@@ -824,8 +837,11 @@ export function decodeBmdMultiPageBallotFromReader(
  * Decodes a single page of a multi-page BMD ballot from a byte array.
  */
 export function decodeBmdMultiPageBallot(
-  election: Election,
+  electionDefinition: ElectionDefinition,
   data: Uint8Array
 ): DecodedBmdMultiPageBallotPage {
-  return decodeBmdMultiPageBallotFromReader(election, new BitReader(data));
+  return decodeBmdMultiPageBallotFromReader(
+    electionDefinition,
+    new BitReader(data)
+  );
 }

--- a/libs/ballot-interpreter/Cargo.lock
+++ b/libs/ballot-interpreter/Cargo.lock
@@ -228,6 +228,7 @@ dependencies = [
  "color-eyre",
  "crossterm",
  "divan",
+ "hex",
  "image",
  "itertools 0.12.1",
  "log",
@@ -240,6 +241,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sha2",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -287,6 +289,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
 dependencies = [
  "core2",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -338,7 +349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -460,6 +471,15 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -533,6 +553,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "ctor"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +620,16 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -872,6 +912,16 @@ name = "g2poly"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312d2295c7302019c395cfb90dacd00a82a2eabd700429bba9c7a3f38dbbe11b"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -1929,6 +1979,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2202,6 +2263,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "types-rs"
 version = "0.1.0"
 dependencies = [
@@ -2260,6 +2327,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/libs/ballot-interpreter/Cargo.toml
+++ b/libs/ballot-interpreter/Cargo.toml
@@ -57,6 +57,8 @@ rayon = "1.5.3"
 serde = { version = "1.0.150", features = ["derive"] }
 serde_json = "1.0.89"
 serde_with = { version = "3.14.0", features = ["macros"] }
+sha2 = "0.10"
+hex = "0.4.3"
 itertools = "0.12.1"
 rqrr = "0.7.1"
 zedbar = { version = "0.4.1", default-features = false, features = ["qrcode"] }

--- a/libs/ballot-interpreter/benches/main.rs
+++ b/libs/ballot-interpreter/benches/main.rs
@@ -13,8 +13,7 @@ use ballot_interpreter::{
 use divan::{black_box, Bencher};
 use image::GrayImage;
 use types_rs::{
-    bubble_ballot::{Metadata, PartialBallotHash},
-    coding,
+    bubble_ballot::{PartialBallotHash, PARTIAL_BALLOT_HASH_BYTE_LENGTH, PRELUDE},
     election::Election,
 };
 
@@ -59,7 +58,7 @@ impl InterpretFixture {
         // the hash baked into the ballot QR codes, and we don't want benchmark
         // setup to fail on those. The hash check itself is exercised by unit
         // tests; here we just want to time interpretation.
-        let expected_ballot_hash = decode_ballot_hash_from_image(&side_a_image, &election);
+        let expected_ballot_hash = decode_ballot_hash_from_image(&side_a_image);
 
         let interpreter = ScanInterpreter::new(
             election,
@@ -76,15 +75,17 @@ impl InterpretFixture {
 
 /// Pulls the partial ballot hash out of a ballot image's QR code. See the
 /// equivalent helper in `interpret::test` for context.
-fn decode_ballot_hash_from_image(image: &GrayImage, election: &Election) -> PartialBallotHash {
+fn decode_ballot_hash_from_image(image: &GrayImage) -> PartialBallotHash {
     let qr = qr_code::detect_with_strategy(
         image,
         qr_code::SearchStrategy::BubbleCorners,
         &ImageDebugWriter::disabled(),
     )
     .unwrap();
-    let metadata: Metadata = coding::decode_with(qr.bytes(), election).unwrap();
-    metadata.ballot_hash
+    let (prelude, payload) = qr.bytes().split_at(PRELUDE.len());
+    assert_eq!(prelude, PRELUDE);
+    let (ballot_hash, _) = payload.split_at(PARTIAL_BALLOT_HASH_BYTE_LENGTH);
+    ballot_hash.try_into().unwrap()
 }
 
 impl Display for InterpretFixture {

--- a/libs/ballot-interpreter/benches/main.rs
+++ b/libs/ballot-interpreter/benches/main.rs
@@ -2,12 +2,21 @@
 
 use std::{fmt::Display, fs::File, io::BufReader, path::PathBuf};
 
-use ballot_interpreter::interpret::{
-    ScanInterpreter, VerticalStreakDetection, WriteInScoring, DEFAULT_MAX_CUMULATIVE_STREAK_WIDTH,
-    DEFAULT_RETRY_STREAK_WIDTH_THRESHOLD,
+use ballot_interpreter::{
+    debug::ImageDebugWriter,
+    interpret::{
+        ScanInterpreter, VerticalStreakDetection, WriteInScoring,
+        DEFAULT_MAX_CUMULATIVE_STREAK_WIDTH, DEFAULT_RETRY_STREAK_WIDTH_THRESHOLD,
+    },
+    qr_code,
 };
 use divan::{black_box, Bencher};
 use image::GrayImage;
+use types_rs::{
+    bubble_ballot::{Metadata, PartialBallotHash},
+    coding,
+    election::Election,
+};
 
 fn main() {
     // Run registered benchmarks.
@@ -33,28 +42,49 @@ impl InterpretFixture {
     fn load(&self) -> color_eyre::Result<(GrayImage, GrayImage, ScanInterpreter)> {
         let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test/fixtures");
         let election_path = fixture_path.join(self.election).join("election.json");
-        let election: types_rs::election::Election =
+        let election: Election =
             serde_json::from_reader(BufReader::new(File::open(election_path)?))?;
-        let interpreter = ScanInterpreter::new(
-            election,
-            WriteInScoring::Enabled,
-            VerticalStreakDetection::default(),
-            None,
-            DEFAULT_MAX_CUMULATIVE_STREAK_WIDTH,
-            DEFAULT_RETRY_STREAK_WIDTH_THRESHOLD,
-        );
         let side_a_path = fixture_path
             .join(self.election)
             .join(format!("{}-front{}", self.name, self.extension));
         let side_b_path = fixture_path
             .join(self.election)
             .join(format!("{}-back{}", self.name, self.extension));
-        Ok((
-            image::open(&side_a_path)?.to_luma8(),
-            image::open(&side_b_path)?.to_luma8(),
-            interpreter,
-        ))
+        let side_a_image = image::open(&side_a_path)?.to_luma8();
+        let side_b_image = image::open(&side_b_path)?.to_luma8();
+
+        // Pull the expected ballot hash out of side A's QR code rather than
+        // hashing election.json bytes. Some bench fixtures (e.g.
+        // `vxqa-2024-10`) ship an election.json whose SHA-256 doesn't match
+        // the hash baked into the ballot QR codes, and we don't want benchmark
+        // setup to fail on those. The hash check itself is exercised by unit
+        // tests; here we just want to time interpretation.
+        let expected_ballot_hash = decode_ballot_hash_from_image(&side_a_image, &election);
+
+        let interpreter = ScanInterpreter::new(
+            election,
+            expected_ballot_hash,
+            WriteInScoring::Enabled,
+            VerticalStreakDetection::default(),
+            None,
+            DEFAULT_MAX_CUMULATIVE_STREAK_WIDTH,
+            DEFAULT_RETRY_STREAK_WIDTH_THRESHOLD,
+        );
+        Ok((side_a_image, side_b_image, interpreter))
     }
+}
+
+/// Pulls the partial ballot hash out of a ballot image's QR code. See the
+/// equivalent helper in `interpret::test` for context.
+fn decode_ballot_hash_from_image(image: &GrayImage, election: &Election) -> PartialBallotHash {
+    let qr = qr_code::detect_with_strategy(
+        image,
+        qr_code::SearchStrategy::BubbleCorners,
+        &ImageDebugWriter::disabled(),
+    )
+    .unwrap();
+    let metadata: Metadata = coding::decode_with(qr.bytes(), election).unwrap();
+    metadata.ballot_hash
 }
 
 impl Display for InterpretFixture {

--- a/libs/ballot-interpreter/bin/interpret.rs
+++ b/libs/ballot-interpreter/bin/interpret.rs
@@ -460,7 +460,7 @@ fn interpret_bubble_ballot(
         }
 
         Err(err) => {
-            eprintln!("Error: {err:#?}");
+            eprintln!("Error: {err}");
             Ok(1)
         }
     }

--- a/libs/ballot-interpreter/bin/interpret.rs
+++ b/libs/ballot-interpreter/bin/interpret.rs
@@ -16,6 +16,7 @@ use ballot_interpreter::{
 };
 use clap::Parser;
 use crossterm::style::Stylize;
+use sha2::{Digest, Sha256};
 use types_rs::{
     ballot_card::BallotType,
     bmd::{
@@ -24,6 +25,7 @@ use types_rs::{
         multi_page::MultiPageCastVoteRecord,
         votes::{CandidateVote, ContestVote},
     },
+    bubble_ballot::PartialBallotHash,
     coding,
     election::{BallotStyleId, Candidate, Contest, ContestId, Election, PrecinctId},
 };
@@ -73,10 +75,19 @@ struct Options {
 }
 
 impl Options {
-    fn load_election(&self) -> color_eyre::Result<Election> {
-        let file = std::fs::File::open(&self.election_path)?;
-        let reader = std::io::BufReader::new(file);
-        Ok(serde_json::from_reader(reader)?)
+    /// Reads the election file as bytes, computes the partial ballot hash
+    /// from those bytes, and deserializes the election. The hash is computed
+    /// over the raw file bytes (matching the TS `sha256(electionData)`
+    /// convention) so it agrees with the hash encoded into ballot QR codes
+    /// for this election.
+    fn load_election(&self) -> color_eyre::Result<(Election, PartialBallotHash)> {
+        let bytes = std::fs::read(&self.election_path)?;
+        let election: Election = serde_json::from_slice(&bytes)?;
+        let digest = Sha256::digest(&bytes);
+        let mut hash = PartialBallotHash::default();
+        let len = hash.len();
+        hash.copy_from_slice(&digest[..len]);
+        Ok((election, hash))
     }
 
     fn load_top_image(&self) -> color_eyre::Result<image::DynamicImage> {
@@ -93,7 +104,7 @@ impl Options {
 
 fn main() -> color_eyre::Result<()> {
     let options = Options::parse();
-    let election = options.load_election()?;
+    let (election, expected_ballot_hash) = options.load_election()?;
 
     let start = Instant::now();
     let top_image = options.load_top_image()?.into_luma8();
@@ -130,7 +141,7 @@ fn main() -> color_eyre::Result<()> {
                 eprintln!("Error: no summary ballot QR code detected");
                 1
             } else {
-                interpret_bubble_ballot(&options, election, top_image)?
+                interpret_bubble_ballot(&options, election, expected_ballot_hash, top_image)?
             }
         }
     };
@@ -382,10 +393,12 @@ fn pretty_print_contest_vote(contest: &Contest, vote: &ContestVote) {
 fn interpret_bubble_ballot(
     options: &Options,
     election: Election,
+    expected_ballot_hash: PartialBallotHash,
     top_image: image::GrayImage,
 ) -> color_eyre::Result<i32> {
     let interpreter = ScanInterpreter::new(
         election,
+        expected_ballot_hash,
         if options.score_write_ins {
             WriteInScoring::Enabled
         } else {

--- a/libs/ballot-interpreter/dts-header.d.ts
+++ b/libs/ballot-interpreter/dts-header.d.ts
@@ -8,6 +8,11 @@ import type {
 import type { Election } from '@votingworks/types';
 
 export interface BridgeInterpretOptions {
+  /**
+   * Expected ballot hash as a hex string. The Rust interpreter slices it to
+   * the partial-hash length and rejects ballots whose QR-decoded hash differs.
+   */
+  expectedBallotHash: string;
   frontNormalizedImageOutputPath?: string;
   backNormalizedImageOutputPath?: string;
   debugBasePathSideA?: string;

--- a/libs/ballot-interpreter/index.d.ts
+++ b/libs/ballot-interpreter/index.d.ts
@@ -8,6 +8,11 @@ import type {
 import type { Election } from '@votingworks/types';
 
 export interface BridgeInterpretOptions {
+  /**
+   * Expected ballot hash as a hex string. The Rust interpreter slices it to
+   * the partial-hash length and rejects ballots whose QR-decoded hash differs.
+   */
+  expectedBallotHash: string;
   frontNormalizedImageOutputPath?: string;
   backNormalizedImageOutputPath?: string;
   debugBasePathSideA?: string;

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/ballot_card.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/ballot_card.rs
@@ -525,15 +525,20 @@ impl BallotCard {
                     label: ballot_page.label().to_owned(),
                     message: e.to_string(),
                 })?;
-                let metadata = coding::decode_with(qr_code.bytes(), election).map_err(|e| {
-                    Error::InvalidQrCodeMetadata {
-                        label: ballot_page.label().to_owned(),
-                        message: format!(
-                            "Unable to decode QR code bytes: {e} (bytes={bytes:?})",
-                            bytes = qr_code.bytes()
-                        ),
-                    }
-                })?;
+                let metadata =
+                    coding::decode_with(qr_code.bytes(), &(election, *expected_ballot_hash))
+                        .map_err(|e| match e {
+                            bubble_ballot::Error::InvalidBallotHash { expected, actual } => {
+                                Error::InvalidBallotHash { expected, actual }
+                            }
+                            _ => Error::InvalidQrCodeMetadata {
+                                label: ballot_page.label().to_owned(),
+                                message: format!(
+                                    "Unable to decode QR code bytes: {e} (bytes={bytes:?})",
+                                    bytes = qr_code.bytes()
+                                ),
+                            },
+                        })?;
                 Ok((metadata, qr_code.orientation()))
             })
             .join(|decode_front_result, decode_back_result| {

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/ballot_card.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/ballot_card.rs
@@ -25,7 +25,8 @@ use crate::{
 
 use types_rs::{
     ballot_card::{BallotSide, PaperSize},
-    bubble_ballot, coding,
+    bubble_ballot::{self, PartialBallotHash},
+    coding,
     election::{Election, GridLayout},
     geometry::{GridUnit, Inch, PixelPosition, PixelUnit, Rect, Size, SubPixelUnit},
     pair::Pair,
@@ -498,15 +499,20 @@ impl BallotCard {
 
     /// Detects and decodes barcodes on the ballot pages and returns the decoded
     /// data. Uses the position of the detected barcodes to determine the
-    /// orientation of the ballot pages.
+    /// orientation of the ballot pages. Verifies the decoded ballot hash
+    /// against `expected_ballot_hash` (pre-sliced to
+    /// [`PARTIAL_BALLOT_HASH_BYTE_LENGTH`] bytes).
     ///
     /// # Errors
     ///
-    /// Fails if the barcodes cannot be located or cannot be decoded.
+    /// Fails if the barcodes cannot be located or cannot be decoded, if the
+    /// two sides' metadata disagree, or if the decoded ballot hash doesn't
+    /// match `expected_ballot_hash`.
     #[allow(clippy::result_large_err)]
     pub fn decode_ballot_barcodes(
         &self,
         election: &Election,
+        expected_ballot_hash: &PartialBallotHash,
     ) -> Result<Pair<(bubble_ballot::Metadata, Orientation)>> {
         self.as_pair()
             .par_map(|ballot_page| {
@@ -570,6 +576,15 @@ impl BallotCard {
                             side_a: front_metadata,
                             side_b: back_metadata,
                             mismatches,
+                        });
+                    }
+
+                    // After `match_sheet_with_metadata`, both sides agree on
+                    // the ballot hash, so checking the front is enough.
+                    if front_metadata.ballot_hash != *expected_ballot_hash {
+                        return Err(Error::InvalidBallotHash {
+                            expected: *expected_ballot_hash,
+                            actual: front_metadata.ballot_hash,
                         });
                     }
 

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/ballot_card.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/ballot_card.rs
@@ -563,22 +563,13 @@ impl BallotCard {
             .join(
                 // Do some validation to check that the two sides agree.
                 |(front_metadata, front_orientation), (back_metadata, back_orientation)| {
-                    if front_metadata.precinct_id != back_metadata.precinct_id {
-                        return Err(Error::MismatchedPrecincts {
-                            side_a: front_metadata.precinct_id,
-                            side_b: back_metadata.precinct_id,
-                        });
-                    }
-                    if front_metadata.ballot_style_id != back_metadata.ballot_style_id {
-                        return Err(Error::MismatchedBallotStyles {
-                            side_a: front_metadata.ballot_style_id,
-                            side_b: back_metadata.ballot_style_id,
-                        });
-                    }
-                    if front_metadata.page_number.opposite() != back_metadata.page_number {
-                        return Err(Error::NonConsecutivePageNumbers {
-                            side_a: front_metadata.page_number.get(),
-                            side_b: back_metadata.page_number.get(),
+                    let mismatches = front_metadata.match_sheet_with_metadata(&back_metadata);
+
+                    if !mismatches.is_empty() {
+                        return Err(Error::MismatchedBallotMetadata {
+                            side_a: front_metadata,
+                            side_b: back_metadata,
+                            mismatches,
                         });
                     }
 

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
@@ -9,9 +9,9 @@ use serde::Serialize;
 use serde_with::DeserializeFromStr;
 use types_rs::ballot_card::BallotSide;
 use types_rs::bubble_ballot::{self, Metadata, MetadataMismatch, PartialBallotHash};
-use types_rs::election::Election;
+use types_rs::election::{ContestId, Election};
 use types_rs::geometry::PixelPosition;
-use types_rs::geometry::{PixelUnit, Size};
+use types_rs::geometry::{PixelUnit, Size, SubGridUnit};
 use types_rs::pair::Pair;
 
 use crate::ballot_card::ballot_scan_bubble_image;
@@ -214,6 +214,18 @@ pub enum Error {
     #[error("could not compute layout for {side:?}")]
     CouldNotComputeLayout { side: BallotSide },
 
+    #[error(
+        "grid position for contest {contest_id} at (column {column}, row {row}) \
+         falls outside the detected timing-mark grid for {label}"
+    )]
+    #[serde(rename_all = "camelCase")]
+    GridPositionOutsideTimingMarkGrid {
+        label: String,
+        contest_id: ContestId,
+        column: SubGridUnit,
+        row: SubGridUnit,
+    },
+
     #[error("vertical streaks detected on {label} (found {})", x_coordinates.len())]
     #[serde(rename_all = "camelCase")]
     VerticalStreaksDetected {
@@ -240,6 +252,7 @@ impl Error {
                 | Self::InvalidBallotHash { .. }
                 | Self::MissingGridLayout { .. }
                 | Self::CouldNotComputeLayout { .. }
+                | Self::GridPositionOutsideTimingMarkGrid { .. }
                 // InvalidScale is only reachable after find_timing_marks()
                 // succeeds, which requires bubble-ballot-specific timing marks.
                 | Self::InvalidScale { .. }
@@ -1154,6 +1167,45 @@ mod test {
             Err(Error::InvalidBallotHash { expected, actual }) => {
                 assert_eq!(expected, bogus);
                 assert_eq!(actual, actual_ballot_hash);
+            }
+            Err(err) => panic!("unexpected error: {err:?}"),
+            Ok(_) => panic!("interpretation unexpectedly succeeded"),
+        }
+    }
+
+    /// Defends against the failure mode from issue #8426 in the layer where it
+    /// actually breaks. If a ballot somehow gets past the hash check but its
+    /// detected timing-mark grid is shorter than the configured election's
+    /// `gridLayouts` expect (e.g., a letter-sized ballot scored against a
+    /// `custom-8.5x17` election), some gridPositions land outside the detected
+    /// grid.
+    #[test]
+    fn test_rejects_ballot_with_grid_position_outside_timing_mark_grid() {
+        // Letter-sized ballot images (the physical paper we'll scan).
+        let (side_a_image, side_b_image, mut options) =
+            load_hmpb_fixture("vx-general-election/letter", 1);
+        // Override the election with the 17"-tall variant's election.json,
+        // which has gridLayouts placing contests at rows that don't exist on
+        // a letter-sized ballot's timing-mark grid. Keep the letter ballot's
+        // hash so the hash check passes — we want to exercise the
+        // scoring-time check, not the hash check.
+        let custom_election_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../hmpb/fixtures/vx-general-election/custom-8.5x17/election.json");
+        let (custom_election, _) = load_election_and_ballot_hash(&custom_election_path);
+        options.election = custom_election;
+
+        match ballot_card(side_a_image, side_b_image, &options) {
+            Err(Error::GridPositionOutsideTimingMarkGrid {
+                label,
+                contest_id: _,
+                column: _,
+                row,
+            }) => {
+                assert_eq!(label, SIDE_A_LABEL);
+                // The 17" gridLayout puts contests beyond what fits on letter,
+                // so the offending row should be well past where the letter
+                // ballot's grid ends.
+                assert!(row > 10.0, "row was unexpectedly small: {row}");
             }
             Err(err) => panic!("unexpected error: {err:?}"),
             Ok(_) => panic!("interpretation unexpectedly succeeded"),

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
@@ -561,7 +561,7 @@ mod test {
     use itertools::Itertools;
     use sha2::{Digest, Sha256};
     use types_rs::{
-        bmd::PartialBallotHash,
+        bubble_ballot::{PartialBallotHash, PARTIAL_BALLOT_HASH_BYTE_LENGTH, PRELUDE},
         election::{ContestId, OptionId},
         geometry::{PixelPosition, Rect},
     };
@@ -610,7 +610,6 @@ mod test {
     /// source of truth for which hash the ballot was generated with.
     fn decode_ballot_hash_from_image(
         image: &GrayImage,
-        election: &Election,
     ) -> types_rs::bubble_ballot::PartialBallotHash {
         use crate::debug::ImageDebugWriter;
         use crate::qr_code;
@@ -620,9 +619,10 @@ mod test {
             &ImageDebugWriter::disabled(),
         )
         .unwrap();
-        let metadata: types_rs::bubble_ballot::Metadata =
-            types_rs::coding::decode_with(qr.bytes(), election).unwrap();
-        metadata.ballot_hash
+        let (prelude, payload) = qr.bytes().split_at(PRELUDE.len());
+        assert_eq!(prelude, PRELUDE);
+        let (ballot_hash, _) = payload.split_at(PARTIAL_BALLOT_HASH_BYTE_LENGTH);
+        ballot_hash.try_into().unwrap()
     }
 
     fn load_ballot_card_fixture(
@@ -961,8 +961,7 @@ mod test {
         // These rotated ballots were generated against a different bytes
         // version of the election than the one in `hmpb/fixtures/...`. Use the
         // hash baked into the QR code as the ground truth.
-        options.expected_ballot_hash =
-            decode_ballot_hash_from_image(&side_a_image_rotated, &options.election);
+        options.expected_ballot_hash = decode_ballot_hash_from_image(&side_a_image_rotated);
 
         let interpretation =
             ballot_card(side_a_image_rotated, side_b_image_rotated, &options).unwrap();
@@ -986,8 +985,7 @@ mod test {
             load_ballot_card_fixture("vxqa-2024-10", ("rotation-front.png", "rotation-back.png"));
         // These fixtures have an election.json whose SHA-256 doesn't match the
         // QR-encoded hash; use the QR's hash as ground truth.
-        options.expected_ballot_hash =
-            decode_ballot_hash_from_image(&side_a_image, &options.election);
+        options.expected_ballot_hash = decode_ballot_hash_from_image(&side_a_image);
         let interpretation =
             ballot_card(side_a_image.clone(), side_b_image.clone(), &options).unwrap();
 
@@ -1018,8 +1016,7 @@ mod test {
     fn test_high_skew_is_rejected() {
         let (mut side_a_image, side_b_image, mut options) =
             load_ballot_card_fixture("vxqa-2024-10", ("skew-front.png", "skew-back.png"));
-        options.expected_ballot_hash =
-            decode_ballot_hash_from_image(&side_a_image, &options.election);
+        options.expected_ballot_hash = decode_ballot_hash_from_image(&side_a_image);
         let interpretation =
             ballot_card(side_a_image.clone(), side_b_image.clone(), &options).unwrap();
 
@@ -1047,8 +1044,7 @@ mod test {
             "104h-2025-04",
             ("imprinter-front.png", "imprinter-back.png"),
         );
-        options.expected_ballot_hash =
-            decode_ballot_hash_from_image(&side_a_image, &options.election);
+        options.expected_ballot_hash = decode_ballot_hash_from_image(&side_a_image);
         let interpretation =
             ballot_card(side_a_image.clone(), side_b_image.clone(), &options).unwrap();
 
@@ -1101,8 +1097,7 @@ mod test {
                 "fold-through-timing-mark-back.png",
             ),
         );
-        options.expected_ballot_hash =
-            decode_ballot_hash_from_image(&side_a_image, &options.election);
+        options.expected_ballot_hash = decode_ballot_hash_from_image(&side_a_image);
         let interpretation =
             ballot_card(side_a_image.clone(), side_b_image.clone(), &options).unwrap();
 
@@ -1145,8 +1140,7 @@ mod test {
                 "best-fit-line-regression-test-back.png",
             ),
         );
-        options.expected_ballot_hash =
-            decode_ballot_hash_from_image(&side_a_image, &options.election);
+        options.expected_ballot_hash = decode_ballot_hash_from_image(&side_a_image);
         ballot_card(side_a_image, side_b_image, &options).unwrap();
     }
 

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
@@ -8,7 +8,7 @@ use image::GrayImage;
 use serde::Serialize;
 use serde_with::DeserializeFromStr;
 use types_rs::ballot_card::BallotSide;
-use types_rs::bubble_ballot::{Metadata, MetadataMismatch};
+use types_rs::bubble_ballot::{self, Metadata, MetadataMismatch, PartialBallotHash};
 use types_rs::election::Election;
 use types_rs::geometry::PixelPosition;
 use types_rs::geometry::{PixelUnit, Size};
@@ -41,6 +41,11 @@ pub const DEFAULT_RETRY_STREAK_WIDTH_THRESHOLD: PixelUnit = 1;
 #[derive(Debug, Clone)]
 pub struct Options {
     pub election: Election,
+    /// Partial ballot hash to compare against the QR-decoded hash on each
+    /// side. Already sliced to [`PARTIAL_BALLOT_HASH_BYTE_LENGTH`] bytes;
+    /// callers slice the full 32-byte election hash before constructing
+    /// `Options`.
+    pub expected_ballot_hash: PartialBallotHash,
     pub bubble_template: &'static GrayImage,
     pub debug_side_a_base: Option<PathBuf>,
     pub debug_side_b_base: Option<PathBuf>,
@@ -176,6 +181,15 @@ pub enum Error {
         mismatches: Vec<MetadataMismatch>,
     },
 
+    #[error("invalid ballot hash: expected {expected:?}, actual {actual:?}")]
+    #[serde(rename_all = "camelCase")]
+    InvalidBallotHash {
+        #[serde(with = "bubble_ballot::ballot_hash_serde")]
+        expected: PartialBallotHash,
+        #[serde(with = "bubble_ballot::ballot_hash_serde")]
+        actual: PartialBallotHash,
+    },
+
     #[error("missing grid layout: front: {front:?}, back: {back:?}")]
     MissingGridLayout {
         front: BallotPageMetadata,
@@ -223,6 +237,7 @@ impl Error {
             // These errors occur after both QR codes were successfully decoded
             // as bubble ballot (HMPB) metadata.
             Self::MismatchedBallotMetadata { .. }
+                | Self::InvalidBallotHash { .. }
                 | Self::MissingGridLayout { .. }
                 | Self::CouldNotComputeLayout { .. }
                 // InvalidScale is only reachable after find_timing_marks()
@@ -239,6 +254,7 @@ pub const SIDE_B_LABEL: &str = "side B";
 
 pub struct ScanInterpreter {
     election: Election,
+    expected_ballot_hash: PartialBallotHash,
     write_in_scoring: WriteInScoring,
     vertical_streak_detection: VerticalStreakDetection,
     bubble_template_image: &'static GrayImage,
@@ -249,9 +265,14 @@ pub struct ScanInterpreter {
 
 impl ScanInterpreter {
     /// Creates a new `ScanInterpreter` with the given configuration.
+    ///
+    /// `expected_ballot_hash` is already sliced to
+    /// [`PARTIAL_BALLOT_HASH_BYTE_LENGTH`] bytes (see
+    /// [`bubble_ballot::PartialBallotHash`]).
     #[must_use]
     pub fn new(
         election: Election,
+        expected_ballot_hash: PartialBallotHash,
         write_in_scoring: WriteInScoring,
         vertical_streak_detection: VerticalStreakDetection,
         minimum_detected_scale: Option<UnitIntervalScore>,
@@ -260,6 +281,7 @@ impl ScanInterpreter {
     ) -> Self {
         Self {
             election,
+            expected_ballot_hash,
             write_in_scoring,
             vertical_streak_detection,
             bubble_template_image: ballot_scan_bubble_image(),
@@ -284,6 +306,7 @@ impl ScanInterpreter {
     ) -> Result<InterpretedBallotCard> {
         let options = Options {
             election: self.election.clone(),
+            expected_ballot_hash: self.expected_ballot_hash,
             bubble_template: self.bubble_template_image,
             debug_side_a_base: debug_side_a_base.into(),
             debug_side_b_base: debug_side_b_base.into(),
@@ -357,7 +380,7 @@ pub fn ballot_card(
                 ballot_card.geometry(),
             ))
         },
-        || ballot_card.decode_ballot_barcodes(&options.election),
+        || ballot_card.decode_ballot_barcodes(&options.election, &options.expected_ballot_hash),
     );
 
     let mut timing_marks = match timing_marks_result {
@@ -519,15 +542,13 @@ pub fn ballot_card(
 #[cfg(test)]
 #[allow(clippy::similar_names, clippy::unwrap_used)]
 mod test {
-    use std::{
-        fs::File,
-        io::BufReader,
-        path::{Path, PathBuf},
-    };
+    use std::path::{Path, PathBuf};
 
     use image::{imageops::FilterType, DynamicImage, GenericImage, Luma, Rgb};
     use itertools::Itertools;
+    use sha2::{Digest, Sha256};
     use types_rs::{
+        bmd::PartialBallotHash,
         election::{ContestId, OptionId},
         geometry::{PixelPosition, Rect},
     };
@@ -555,14 +576,49 @@ mod test {
             .into()
     }
 
+    /// Reads an election.json file as bytes, deserializes it, and computes the
+    /// partial ballot hash from those same bytes. The hash must come from the
+    /// raw bytes (matching the TS `sha256(electionData)` convention) so that
+    /// `expected_ballot_hash` agrees with the hash QR-encoded in the ballot.
+    fn load_election_and_ballot_hash(election_path: &Path) -> (Election, PartialBallotHash) {
+        let bytes = std::fs::read(election_path).unwrap();
+        let election: Election = serde_json::from_slice(&bytes).unwrap();
+        let digest = Sha256::digest(&bytes);
+        let mut hash = PartialBallotHash::default();
+        let len = hash.len();
+        hash.copy_from_slice(&digest[..len]);
+        (election, hash)
+    }
+
+    /// Pulls the partial ballot hash out of a ballot image's QR code. Used by
+    /// tests whose ballot images were not generated from the election.json
+    /// bytes in the fixture directory (so `sha256(electionData)` doesn't
+    /// match the QR-encoded hash). For those fixtures, the QR code is the
+    /// source of truth for which hash the ballot was generated with.
+    fn decode_ballot_hash_from_image(
+        image: &GrayImage,
+        election: &Election,
+    ) -> types_rs::bubble_ballot::PartialBallotHash {
+        use crate::debug::ImageDebugWriter;
+        use crate::qr_code;
+        let qr = qr_code::detect_with_strategy(
+            image,
+            qr_code::SearchStrategy::BubbleCorners,
+            &ImageDebugWriter::disabled(),
+        )
+        .unwrap();
+        let metadata: types_rs::bubble_ballot::Metadata =
+            types_rs::coding::decode_with(qr.bytes(), election).unwrap();
+        metadata.ballot_hash
+    }
+
     fn load_ballot_card_fixture(
         fixture_name: &str,
         (side_a_name, side_b_name): (&str, &str),
     ) -> (GrayImage, GrayImage, Options) {
         let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test/fixtures");
         let election_path = fixture_path.join(fixture_name).join("election.json");
-        let election: Election =
-            serde_json::from_reader(BufReader::new(File::open(election_path).unwrap())).unwrap();
+        let (election, expected_ballot_hash) = load_election_and_ballot_hash(&election_path);
         let bubble_template = ballot_scan_bubble_image();
         let side_a_path = fixture_path.join(fixture_name).join(side_a_name);
         let side_b_path = fixture_path.join(fixture_name).join(side_b_name);
@@ -572,6 +628,7 @@ mod test {
             debug_side_b_base: None,
             bubble_template,
             election,
+            expected_ballot_hash,
             write_in_scoring: WriteInScoring::Enabled,
             vertical_streak_detection: VerticalStreakDetection::default(),
             minimum_detected_scale: None,
@@ -589,8 +646,7 @@ mod test {
             .join("../hmpb/fixtures/")
             .join(fixture_name);
         let election_path = fixture_path.join("election.json");
-        let election =
-            serde_json::from_reader(BufReader::new(File::open(election_path).unwrap())).unwrap();
+        let (election, expected_ballot_hash) = load_election_and_ballot_hash(&election_path);
 
         let bubble_template = ballot_scan_bubble_image();
         let side_a_path = fixture_path.join(format!("blank-ballot-p{starting_page_number}.jpg"));
@@ -602,6 +658,7 @@ mod test {
             debug_side_b_base: None,
             bubble_template,
             election,
+            expected_ballot_hash,
             write_in_scoring: WriteInScoring::Enabled,
             vertical_streak_detection: VerticalStreakDetection::default(),
             minimum_detected_scale: None,
@@ -881,13 +938,18 @@ mod test {
 
     #[test]
     fn test_rotated_ballot_scoring_write_in_areas_no_write_ins() {
-        let (_, _, options) = load_hmpb_fixture("vx-general-election/letter", 3);
+        let (_, _, mut options) = load_hmpb_fixture("vx-general-election/letter", 3);
         let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("test/fixtures/vx-general-election-letter");
         let (side_a_image_rotated, side_b_image_rotated) = load_ballot_card_images(
             &fixture_path.join("blank-ballot-p3-rotated-1deg.jpg"),
             &fixture_path.join("blank-ballot-p4-rotated-1deg.jpg"),
         );
+        // These rotated ballots were generated against a different bytes
+        // version of the election than the one in `hmpb/fixtures/...`. Use the
+        // hash baked into the QR code as the ground truth.
+        options.expected_ballot_hash =
+            decode_ballot_hash_from_image(&side_a_image_rotated, &options.election);
 
         let interpretation =
             ballot_card(side_a_image_rotated, side_b_image_rotated, &options).unwrap();
@@ -907,8 +969,12 @@ mod test {
 
     #[test]
     fn test_high_rotation_is_rejected() {
-        let (mut side_a_image, side_b_image, options) =
+        let (mut side_a_image, side_b_image, mut options) =
             load_ballot_card_fixture("vxqa-2024-10", ("rotation-front.png", "rotation-back.png"));
+        // These fixtures have an election.json whose SHA-256 doesn't match the
+        // QR-encoded hash; use the QR's hash as ground truth.
+        options.expected_ballot_hash =
+            decode_ballot_hash_from_image(&side_a_image, &options.election);
         let interpretation =
             ballot_card(side_a_image.clone(), side_b_image.clone(), &options).unwrap();
 
@@ -937,8 +1003,10 @@ mod test {
 
     #[test]
     fn test_high_skew_is_rejected() {
-        let (mut side_a_image, side_b_image, options) =
+        let (mut side_a_image, side_b_image, mut options) =
             load_ballot_card_fixture("vxqa-2024-10", ("skew-front.png", "skew-back.png"));
+        options.expected_ballot_hash =
+            decode_ballot_hash_from_image(&side_a_image, &options.election);
         let interpretation =
             ballot_card(side_a_image.clone(), side_b_image.clone(), &options).unwrap();
 
@@ -962,10 +1030,12 @@ mod test {
 
     #[test]
     fn test_imprinting_over_timing_marks() {
-        let (side_a_image, side_b_image, options) = load_ballot_card_fixture(
+        let (side_a_image, side_b_image, mut options) = load_ballot_card_fixture(
             "104h-2025-04",
             ("imprinter-front.png", "imprinter-back.png"),
         );
+        options.expected_ballot_hash =
+            decode_ballot_hash_from_image(&side_a_image, &options.election);
         let interpretation =
             ballot_card(side_a_image.clone(), side_b_image.clone(), &options).unwrap();
 
@@ -1011,13 +1081,15 @@ mod test {
 
     #[test]
     fn test_fold_through_timing_mark() {
-        let (side_a_image, side_b_image, options) = load_ballot_card_fixture(
+        let (side_a_image, side_b_image, mut options) = load_ballot_card_fixture(
             "104h-2025-04",
             (
                 "fold-through-timing-mark-front.png",
                 "fold-through-timing-mark-back.png",
             ),
         );
+        options.expected_ballot_hash =
+            decode_ballot_hash_from_image(&side_a_image, &options.election);
         let interpretation =
             ballot_card(side_a_image.clone(), side_b_image.clone(), &options).unwrap();
 
@@ -1053,14 +1125,39 @@ mod test {
     /// marks along the edge we're looking for, it doesn't have to pass
     /// through exactly the corner's centers like the previous one did.
     fn test_best_fit_line_regression() {
-        let (side_a_image, side_b_image, options) = load_ballot_card_fixture(
+        let (side_a_image, side_b_image, mut options) = load_ballot_card_fixture(
             "vxqa-2024-10",
             (
                 "best-fit-line-regression-test-front.png",
                 "best-fit-line-regression-test-back.png",
             ),
         );
+        options.expected_ballot_hash =
+            decode_ballot_hash_from_image(&side_a_image, &options.election);
         ballot_card(side_a_image, side_b_image, &options).unwrap();
+    }
+
+    #[test]
+    fn test_rejects_ballot_with_unexpected_ballot_hash() {
+        let (side_a_image, side_b_image, mut options) =
+            load_hmpb_fixture("vx-general-election/letter", 1);
+
+        // The fixture's default `expected_ballot_hash` matches the QR-encoded
+        // hash, so interpretation succeeds.
+        let actual_ballot_hash = options.expected_ballot_hash;
+
+        // Override with a hash that definitely does not match: flip every bit.
+        let bogus = actual_ballot_hash.map(|b| !b);
+        options.expected_ballot_hash = bogus;
+
+        match ballot_card(side_a_image, side_b_image, &options) {
+            Err(Error::InvalidBallotHash { expected, actual }) => {
+                assert_eq!(expected, bogus);
+                assert_eq!(actual, actual_ballot_hash);
+            }
+            Err(err) => panic!("unexpected error: {err:?}"),
+            Ok(_) => panic!("interpretation unexpectedly succeeded"),
+        }
     }
 
     #[test]

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
@@ -181,7 +181,7 @@ pub enum Error {
         mismatches: Vec<MetadataMismatch>,
     },
 
-    #[error("invalid ballot hash: expected {expected:?}, actual {actual:?}")]
+    #[error("invalid ballot hash: expected {expected:02x?}, actual {actual:02x?}")]
     #[serde(rename_all = "camelCase")]
     InvalidBallotHash {
         #[serde(with = "bubble_ballot::ballot_hash_serde")]

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
@@ -8,7 +8,8 @@ use image::GrayImage;
 use serde::Serialize;
 use serde_with::DeserializeFromStr;
 use types_rs::ballot_card::BallotSide;
-use types_rs::election::{BallotStyleId, Election, PrecinctId};
+use types_rs::bubble_ballot::{Metadata, MetadataMismatch};
+use types_rs::election::Election;
 use types_rs::geometry::PixelPosition;
 use types_rs::geometry::{PixelUnit, Size};
 use types_rs::pair::Pair;
@@ -156,26 +157,6 @@ pub enum Error {
     #[error("invalid QR code metadata for {label}: {message}")]
     InvalidQrCodeMetadata { label: String, message: String },
 
-    #[error("mismatched precincts: {SIDE_A_LABEL}: {side_a:?}, {SIDE_B_LABEL}: {side_b:?}")]
-    #[serde(rename_all = "camelCase")]
-    MismatchedPrecincts {
-        side_a: PrecinctId,
-        side_b: PrecinctId,
-    },
-
-    #[error("mismatched ballot styles: {SIDE_A_LABEL}: {side_a:?}, {SIDE_B_LABEL}: {side_b:?}")]
-    #[serde(rename_all = "camelCase")]
-    MismatchedBallotStyles {
-        side_a: BallotStyleId,
-        side_b: BallotStyleId,
-    },
-
-    #[error(
-        "non-consecutive page numbers: {SIDE_A_LABEL}: {side_a:?}, {SIDE_B_LABEL}: {side_b:?}"
-    )]
-    #[serde(rename_all = "camelCase")]
-    NonConsecutivePageNumbers { side_a: u8, side_b: u8 },
-
     #[error(
         "mismatched ballot card geometries: {SIDE_A_LABEL}: {side_a:?}, {SIDE_B_LABEL}: {side_b:?}"
     )]
@@ -183,6 +164,16 @@ pub enum Error {
     MismatchedBallotCardGeometries {
         side_a: BallotPageAndGeometry,
         side_b: BallotPageAndGeometry,
+    },
+
+    #[error(
+        "mismatched ballot card metadata: {SIDE_A_LABEL}: {side_a:?}, {SIDE_B_LABEL}: {side_b:?}, mismatches: {mismatches:?}"
+    )]
+    #[serde(rename_all = "camelCase")]
+    MismatchedBallotMetadata {
+        side_a: Metadata,
+        side_b: Metadata,
+        mismatches: Vec<MetadataMismatch>,
     },
 
     #[error("missing grid layout: front: {front:?}, back: {back:?}")]
@@ -231,9 +222,7 @@ impl Error {
             self,
             // These errors occur after both QR codes were successfully decoded
             // as bubble ballot (HMPB) metadata.
-            Self::MismatchedPrecincts { .. }
-                | Self::MismatchedBallotStyles { .. }
-                | Self::NonConsecutivePageNumbers { .. }
+            Self::MismatchedBallotMetadata { .. }
                 | Self::MissingGridLayout { .. }
                 | Self::CouldNotComputeLayout { .. }
                 // InvalidScale is only reachable after find_timing_marks()

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/js/mod.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 use types_rs::bmd::cvr::CastVoteRecord;
 use types_rs::bmd::multi_page::MultiPageCastVoteRecord;
+use types_rs::bubble_ballot::{PartialBallotHash, PARTIAL_BALLOT_HASH_BYTE_LENGTH};
 use types_rs::coding;
 use types_rs::election::Election;
 
@@ -25,6 +26,10 @@ use crate::timing_marks::{self, DefaultForGeometry, TimingMarks};
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct JsInterpretOptions {
+    /// Expected ballot hash as a hex string. Production callers always have
+    /// the election definition's `ballotHash` available and pass it through.
+    /// Decoded into a `PartialBallotHash` at the bridge boundary.
+    expected_ballot_hash: String,
     front_normalized_image_output_path: Option<String>,
     back_normalized_image_output_path: Option<String>,
     debug_base_path_side_a: Option<String>,
@@ -34,6 +39,25 @@ struct JsInterpretOptions {
     disable_vertical_streak_detection: Option<bool>,
     max_cumulative_streak_width: u32,
     retry_streak_width_threshold: u32,
+}
+
+/// Decodes a hex ballot hash string into a [`PartialBallotHash`]. Accepts
+/// strings of any length and slices them to the partial-hash length, matching
+/// the TS `sliceBallotHashForEncoding` convention.
+fn decode_partial_ballot_hash(hex: &str) -> Result<PartialBallotHash, napi::Error> {
+    let bytes = hex::decode(hex).map_err(|err| {
+        napi::Error::from_reason(format!("expectedBallotHash is not valid hex: {err}"))
+    })?;
+    if bytes.len() < PARTIAL_BALLOT_HASH_BYTE_LENGTH {
+        return Err(napi::Error::from_reason(format!(
+            "expectedBallotHash must be at least {} hex characters",
+            PARTIAL_BALLOT_HASH_BYTE_LENGTH * 2
+        )));
+    }
+    let mut hash = PartialBallotHash::default();
+    let len = hash.len();
+    hash.copy_from_slice(&bytes[..len]);
+    Ok(hash)
 }
 
 /// Wraps an interpret error with a pre-computed `is_bubble_ballot` flag so
@@ -72,12 +96,15 @@ fn interpret(
         None => None,
     };
 
+    let expected_ballot_hash = decode_partial_ballot_hash(&options.expected_ballot_hash)?;
+
     let bubble_template = ballot_scan_bubble_image();
     let interpret_result = ballot_card(
         side_a_image,
         side_b_image,
         &Options {
             election,
+            expected_ballot_hash,
             bubble_template,
             debug_side_a_base: options.debug_base_path_side_a.map(PathBuf::from),
             debug_side_b_base: options.debug_base_path_side_b.map(PathBuf::from),

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
@@ -211,7 +211,7 @@ impl Detected {
 
     /// Gets the data decoded from the detected QR code.
     #[must_use]
-    pub fn bytes(&self) -> &Vec<u8> {
+    pub fn bytes(&self) -> &[u8] {
         self.bytes.as_ref()
     }
 
@@ -273,7 +273,7 @@ pub type Result = std::result::Result<Detected, Error>;
 fn base64_decode_if_possible(detected: &Detected) -> Detected {
     let bytes = STANDARD
         .decode(detected.bytes())
-        .unwrap_or_else(|_| detected.bytes().clone());
+        .unwrap_or_else(|_| detected.bytes().to_vec());
     Detected::new(
         detected.detector(),
         detected.detection_areas().to_vec(),
@@ -418,7 +418,7 @@ mod test {
         )
         .unwrap();
         assert_eq!(
-            qr_code.bytes().clone(),
+            qr_code.bytes(),
             vec![
                 0x56, 0x50, 0x02, 0xf1, 0x3f, 0x4a, 0xb3, 0x76, 0xfb, 0xaa, 0xf9, 0x14, 0x37, 0x00,
                 0x00, 0x00, 0x03, 0x00

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/scoring.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/scoring.rs
@@ -8,9 +8,7 @@ use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use serde::Serialize;
 use types_rs::ballot_card::BallotSide;
 use types_rs::election::{GridLayout, GridLocation, GridPosition, UnitIntervalValue};
-use types_rs::geometry::{
-    PixelPosition, PixelUnit, Point, Quadrilateral, Rect, SubGridUnit, SubPixelUnit,
-};
+use types_rs::geometry::{PixelPosition, PixelUnit, Point, Quadrilateral, Rect, SubPixelUnit};
 
 use crate::ballot_card::BallotImage;
 use crate::debug;
@@ -147,8 +145,27 @@ pub(crate) fn score_bubble_marks_from_grid_layout(
                 return None;
             }
 
-            let expected_bubble_center = timing_marks
-                .point_for_location(location.column as SubGridUnit, location.row as SubGridUnit)?;
+            // If a grid position can't be located within the detected
+            // timing-mark grid, fail loudly rather than silently dropping the
+            // position. Dropping leaves `marks` as a partial subset of the
+            // gridLayout, which downstream TS interpretation assumes is
+            // complete — see `getAllPossibleAdjudicationReasons` in
+            // `libs/ballot-interpreter/src/adjudication_reasons.ts`. The
+            // expected_ballot_hash check earlier in the pipeline catches the
+            // realistic ways this would otherwise happen (a ballot from a
+            // different election or paper size), but we surface a typed error
+            // here as a defense-in-depth so any future invariant break is
+            // visible rather than producing a crash deep in TS.
+            let Some(expected_bubble_center) =
+                timing_marks.point_for_location(location.column, location.row)
+            else {
+                return Some(Err(Error::GridPositionOutsideTimingMarkGrid {
+                    label: label.to_owned(),
+                    contest_id: grid_position.contest_id(),
+                    column: location.column,
+                    row: location.row,
+                }));
+            };
 
             let scored_bubble_mark = score_bubble_mark(
                 ballot_image,
@@ -158,9 +175,9 @@ pub(crate) fn score_bubble_marks_from_grid_layout(
                 DEFAULT_MAXIMUM_SEARCH_DISTANCE,
             );
 
-            Some((grid_position.clone(), scored_bubble_mark))
+            Some(Ok((grid_position.clone(), scored_bubble_mark)))
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>>>()?;
 
     // Check for vertical streaks after collecting
     for (_, scored_bubble_mark) in &scored_bubbles {

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/interpret.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/interpret.ts
@@ -1,4 +1,5 @@
 import { assert, err, ok } from '@votingworks/basics';
+import { sliceBallotHashForEncoding } from '@votingworks/ballot-encoder';
 import { ImageData } from 'canvas';
 import {
   ElectionDefinition,
@@ -72,6 +73,9 @@ function buildBridgeOptions(options: InterpretOptions): BridgeInterpretOptions {
   }
 
   return {
+    expectedBallotHash: sliceBallotHashForEncoding(
+      options.electionDefinition.ballotHash
+    ),
     debugBasePathSideA,
     debugBasePathSideB,
     scoreWriteIns: options.scoreWriteIns,

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/types.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/types.ts
@@ -5,6 +5,7 @@ import {
   PrecinctId,
   BallotStyleId,
   Side,
+  BallotType,
 } from '@votingworks/types';
 import { Optional, Result } from '@votingworks/basics';
 
@@ -317,6 +318,23 @@ export interface Size<T> {
 }
 
 /**
+ * Identifies a single field that differs between the two sides of a bubble
+ * ballot sheet, carrying the value found on each side.
+ */
+export type MetadataMismatch =
+  | { type: 'ballotHash'; sideA: string; sideB: string }
+  | { type: 'precinctId'; sideA: PrecinctId; sideB: PrecinctId }
+  | { type: 'ballotStyleId'; sideA: BallotStyleId; sideB: BallotStyleId }
+  | { type: 'pageNumber'; sideA: number; sideB: number }
+  | { type: 'isTestMode'; sideA: boolean; sideB: boolean }
+  | { type: 'ballotType'; sideA: BallotType; sideB: BallotType }
+  | {
+      type: 'ballotAuditId';
+      sideA: string | null;
+      sideB: string | null;
+    };
+
+/**
  * Possible errors that can occur when interpreting a ballot card.
  *
  * `isBubbleBallot` is set by the Rust interpreter and is true when the error
@@ -326,13 +344,12 @@ export interface Size<T> {
 export type InterpretError = { isBubbleBallot: boolean } & (
   | { type: 'borderInsetNotFound'; path: string }
   | { type: 'invalidQrCodeMetadata'; label: string; message: string }
-  | { type: 'mismatchedPrecincts'; sideA: PrecinctId; sideB: PrecinctId }
   | {
-      type: 'mismatchedBallotStyles';
-      sideA: BallotStyleId;
-      sideB: BallotStyleId;
+      type: 'mismatchedBallotMetadata';
+      sideA: HmpbBallotPageMetadata;
+      sideB: HmpbBallotPageMetadata;
+      mismatches: MetadataMismatch[];
     }
-  | { type: 'nonConsecutivePageNumbers'; sideA: number; sideB: number }
   | {
       type: 'mismatchedBallotCardGeometries';
       side_a: BallotPagePathAndGeometry;

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/types.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/types.ts
@@ -350,6 +350,7 @@ export type InterpretError = { isBubbleBallot: boolean } & (
       sideB: HmpbBallotPageMetadata;
       mismatches: MetadataMismatch[];
     }
+  | { type: 'invalidBallotHash'; expected: string; actual: string }
   | {
       type: 'mismatchedBallotCardGeometries';
       side_a: BallotPagePathAndGeometry;

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/types.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/types.ts
@@ -6,6 +6,7 @@ import {
   BallotStyleId,
   Side,
   BallotType,
+  ContestId,
 } from '@votingworks/types';
 import { Optional, Result } from '@votingworks/basics';
 
@@ -57,6 +58,12 @@ export type PixelUnit = u32;
  * with the same underlying representation is not used.
  */
 export type SubPixelUnit = f32;
+
+/**
+ * A fractional position in the timing-mark grid (e.g. a bubble that sits
+ * partway between two rows). Mirrors the Rust `SubGridUnit` type alias.
+ */
+export type SubGridUnit = f32;
 
 /**
  * Angle in radians.
@@ -365,6 +372,13 @@ export type InterpretError = { isBubbleBallot: boolean } & (
   | { type: 'unexpectedDimensions'; label: string; dimensions: Size<PixelUnit> }
   | { type: 'invalidScale'; label: string; scale: number }
   | { type: 'couldNotComputeLayout'; side: Side }
+  | {
+      type: 'gridPositionOutsideTimingMarkGrid';
+      label: string;
+      contestId: ContestId;
+      column: SubGridUnit;
+      row: SubGridUnit;
+    }
   | {
       type: 'verticalStreaksDetected';
       label: string;

--- a/libs/ballot-interpreter/src/cross_language_bmd.test.ts
+++ b/libs/ballot-interpreter/src/cross_language_bmd.test.ts
@@ -356,12 +356,8 @@ test('single-page BMD ballot: Rust encode matches TS decode', async () => {
         BallotType.Provisional
       ),
       fc.boolean(),
-      async (
-        { election, ballotHash },
-        isTestMode,
-        ballotType,
-        includeWriteIns
-      ) => {
+      async (electionDefinition, isTestMode, ballotType, includeWriteIns) => {
+        const { election, ballotHash } = electionDefinition;
         const ballotStyle = election.ballotStyles[0];
         if (!ballotStyle) return;
         const precinct = election.precincts.find((p) =>
@@ -389,7 +385,10 @@ test('single-page BMD ballot: Rust encode matches TS decode', async () => {
 
         const encoded = await napi.encodeBmdBallotData(election, rustRecord);
 
-        const decoded = decodeBallot(election, new Uint8Array(encoded));
+        const decoded = decodeBallot(
+          electionDefinition,
+          new Uint8Array(encoded)
+        );
 
         expect(decoded.ballotStyleId).toEqual(ballotStyle.id);
         expect(decoded.precinctId).toEqual(precinct.id);
@@ -418,13 +417,14 @@ test('multi-page BMD ballot: Rust encode matches TS decode', async () => {
       arbitraryBallotId(),
       fc.boolean(),
       async (
-        { election, ballotHash },
+        electionDefinition,
         isTestMode,
         ballotType,
         totalPages,
         ballotAuditId,
         includeWriteIns
       ) => {
+        const { election, ballotHash } = electionDefinition;
         const ballotStyle = election.ballotStyles[0];
         if (!ballotStyle) return;
         const precinct = election.precincts.find((p) =>
@@ -466,7 +466,7 @@ test('multi-page BMD ballot: Rust encode matches TS decode', async () => {
           const encoded = await napi.encodeBmdBallotData(election, rustRecord);
 
           const decoded = decodeBmdMultiPageBallot(
-            election,
+            electionDefinition,
             new Uint8Array(encoded)
           );
 

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -1,4 +1,3 @@
-import { sliceBallotHashForEncoding } from '@votingworks/ballot-encoder';
 import {
   assert,
   assertDefined,
@@ -30,7 +29,6 @@ import {
   GridPosition,
   Id,
   InterpretedHmpbPage,
-  InvalidBallotHashPage,
   InvalidPrecinctPage,
   InvalidTestModePage,
   mapSheet,
@@ -484,13 +482,27 @@ export function convertRustInterpretResult(
 ): InterpretResult {
   /* istanbul ignore next - @preserve */
   if (result.isErr()) {
+    const error = result.err();
+    if (error.type === 'invalidBallotHash') {
+      return ok(
+        mapSheet(
+          sheet,
+          () =>
+            ({
+              type: 'InvalidBallotHashPage',
+              expectedBallotHash: error.expected,
+              actualBallotHash: error.actual,
+            }) as const
+        )
+      );
+    }
     return ok(
       mapSheet(
         sheet,
         () =>
           ({
             type: 'UnreadablePage',
-            reason: result.err().type,
+            reason: error.type,
           }) as const
       )
     );
@@ -523,11 +535,7 @@ function validateInterpretResults(
   results: SheetOf<PageInterpretation>,
   options: InterpreterOptions
 ): SheetOf<PageInterpretation> {
-  const {
-    electionDefinition: { ballotHash },
-    validPrecinctIds,
-    testMode,
-  } = options;
+  const { validPrecinctIds, testMode } = options;
 
   return mapSheet(results, (result) => {
     const interpretation = normalizeBallotMode(result, options);
@@ -552,19 +560,9 @@ function validateInterpretResults(
       });
     }
 
-    // metadata.ballotHash may be a sliced hash or a full hash, so we need to
-    // slice both hashes before comparing them.
-    if (
-      sliceBallotHashForEncoding(metadata.ballotHash) !==
-      sliceBallotHashForEncoding(ballotHash)
-    ) {
-      return typedAs<InvalidBallotHashPage>({
-        type: 'InvalidBallotHashPage',
-        expectedBallotHash: sliceBallotHashForEncoding(ballotHash),
-        actualBallotHash: sliceBallotHashForEncoding(metadata.ballotHash),
-      });
-    }
-
+    // The ballot-hash check is enforced by the Rust interpreter and surfaced
+    // as `InvalidBallotHashPage` directly in `convertRustInterpretResult`, so
+    // there's no TS-side hash validation here.
     return interpretation;
   });
 }

--- a/libs/ballot-interpreter/src/interpret_vx_bubble_ballot.test.ts
+++ b/libs/ballot-interpreter/src/interpret_vx_bubble_ballot.test.ts
@@ -600,11 +600,11 @@ describe('HMPB - VX primary election', () => {
 
     expect(frontResult).toEqual<PageInterpretation>({
       type: 'UnreadablePage',
-      reason: 'mismatchedPrecincts',
+      reason: 'mismatchedBallotMetadata',
     });
     expect(backResult).toEqual<PageInterpretation>({
       type: 'UnreadablePage',
-      reason: 'mismatchedPrecincts',
+      reason: 'mismatchedBallotMetadata',
     });
   });
 
@@ -631,11 +631,11 @@ describe('HMPB - VX primary election', () => {
 
     expect(frontResult).toEqual<PageInterpretation>({
       type: 'UnreadablePage',
-      reason: 'mismatchedBallotStyles',
+      reason: 'mismatchedBallotMetadata',
     });
     expect(backResult).toEqual<PageInterpretation>({
       type: 'UnreadablePage',
-      reason: 'mismatchedBallotStyles',
+      reason: 'mismatchedBallotMetadata',
     });
   });
 });
@@ -747,11 +747,11 @@ test('Non-consecutive page numbers', async () => {
 
   expect(frontResult).toEqual<PageInterpretation>({
     type: 'UnreadablePage',
-    reason: 'nonConsecutivePageNumbers',
+    reason: 'mismatchedBallotMetadata',
   });
   expect(backResult).toEqual<PageInterpretation>({
     type: 'UnreadablePage',
-    reason: 'nonConsecutivePageNumbers',
+    reason: 'mismatchedBallotMetadata',
   });
 });
 

--- a/libs/ballot-interpreter/src/interpret_vx_bubble_ballot.test.ts
+++ b/libs/ballot-interpreter/src/interpret_vx_bubble_ballot.test.ts
@@ -149,7 +149,8 @@ describe('HMPB - VX Famous Names', () => {
         {
           electionDefinition: {
             ...electionDefinition,
-            ballotHash: 'wrong ballot hash',
+            // Valid-hex but deliberately wrong hash.
+            ballotHash: 'f'.repeat(64),
           },
           validPrecinctIds: new Set([precinctId]),
           testMode: true,

--- a/libs/ballot-interpreter/src/interpret_vx_bubble_ballot.test.ts
+++ b/libs/ballot-interpreter/src/interpret_vx_bubble_ballot.test.ts
@@ -756,6 +756,66 @@ test('Non-consecutive page numbers', async () => {
   });
 });
 
+// Defense-in-depth check for issue #8426. The Rust hash check is the primary
+// gate against scanning a ballot whose physical grid doesn't match the
+// configured election's gridLayouts. If a ballot somehow gets past the hash
+// gate while still failing the gridLayout-shape invariant — e.g. someone hand-
+// crafted an election whose hash matches but whose gridLayouts overshoot the
+// ballot — Rust now surfaces a typed `gridPositionOutsideTimingMarkGrid`
+// error instead of silently dropping gridPositions and crashing in TS's
+// `getAllPossibleAdjudicationReasons`. This test spoofs the ballot hash so
+// that the second-layer check is actually exercised.
+test('Spoofed-hash ballot whose grid exceeds detected timing-mark grid is rejected', async () => {
+  const letterSpec = find(
+    vxGeneralElectionFixtures.fixtureSpecs,
+    (s) => s.paperSize === HmpbBallotPaperSize.Letter && s.languageCode === 'en'
+  );
+  const longerSpec = find(
+    vxGeneralElectionFixtures.fixtureSpecs,
+    (s) =>
+      s.paperSize === HmpbBallotPaperSize.Custom17 && s.languageCode === 'en'
+  );
+
+  const letterDef = (
+    await readElection(letterSpec.electionPath)
+  ).unsafeUnwrap();
+  const longerDef = (
+    await readElection(longerSpec.electionPath)
+  ).unsafeUnwrap();
+  // Take just the first sheet — the letter ballot may have multiple sheets.
+  const letterImages = asSheet(
+    await pdfToPageImages(letterSpec.blankBallotPath).take(2).toArray()
+  );
+
+  // Use the 17"-tall election's contests/gridLayouts (so positions extend
+  // past where letter timing-mark grids can reach), but carry the letter
+  // election's hash so the Rust hash check accepts the ballot.
+  const spoofed: ElectionDefinition = {
+    ...longerDef,
+    ballotHash: letterDef.ballotHash,
+  };
+
+  const [frontResult, backResult] = await interpretSheet(
+    {
+      electionDefinition: spoofed,
+      validPrecinctIds: allPrecinctIds(spoofed),
+      testMode: false,
+      markThresholds: DEFAULT_MARK_THRESHOLDS,
+      adjudicationReasons: [],
+    },
+    letterImages
+  );
+
+  expect(frontResult).toEqual<PageInterpretation>({
+    type: 'UnreadablePage',
+    reason: 'gridPositionOutsideTimingMarkGrid',
+  });
+  expect(backResult).toEqual<PageInterpretation>({
+    type: 'UnreadablePage',
+    reason: 'gridPositionOutsideTimingMarkGrid',
+  });
+});
+
 test('Ballot audit IDs', async () => {
   const electionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();

--- a/libs/ballot-interpreter/src/summary-ballot/interpret.ts
+++ b/libs/ballot-interpreter/src/summary-ballot/interpret.ts
@@ -142,7 +142,7 @@ export async function interpret(
   // Check if this is a multi-page BMD ballot
   if (isBmdMultiPageBallot(foundQrCode.data)) {
     const decoded = decodeBmdMultiPageBallot(
-      electionDefinition.election,
+      electionDefinition,
       foundQrCode.data
     );
     return ok({
@@ -157,7 +157,7 @@ export async function interpret(
   // Single-page BMD ballot
   return ok({
     type: 'single-page',
-    ballot: decodeBallot(electionDefinition.election, foundQrCode.data),
+    ballot: decodeBallot(electionDefinition, foundQrCode.data),
     summaryBallotImage,
     blankPageImage,
   });

--- a/libs/types-rs/src/bubble_ballot.rs
+++ b/libs/types-rs/src/bubble_ballot.rs
@@ -199,6 +199,12 @@ pub enum Error {
     #[error("Invalid ballot type: {0}")]
     InvalidBallotType(#[from] BallotTypeCodingError),
 
+    #[error("Invalid ballot hash: {actual:02x?} (expected {expected:02x?})")]
+    InvalidBallotHash {
+        expected: PartialBallotHash,
+        actual: PartialBallotHash,
+    },
+
     #[error("Index error: {0}")]
     Index(#[from] IndexError),
 
@@ -228,13 +234,13 @@ impl From<coding::Error> for Error {
     }
 }
 
-impl FromBitStreamWith<'_> for Metadata {
-    type Context = Election;
+impl<'a> FromBitStreamWith<'a> for Metadata {
+    type Context = (&'a Election, PartialBallotHash);
     type Error = Error;
 
     fn from_reader<R: bitstream_io::BitRead + ?Sized>(
         r: &mut R,
-        election: &Self::Context,
+        (election, expected_ballot_hash): &Self::Context,
     ) -> Result<Self, Self::Error>
     where
         Self: Sized,
@@ -245,8 +251,15 @@ impl FromBitStreamWith<'_> for Metadata {
         }
 
         let ballot_hash: PartialBallotHash = r.read_to()?;
-        let precinct_index: PrecinctByIndex = r.parse_with(election)?;
-        let ballot_style_index: BallotStyleByIndex = r.parse_with(election)?;
+        if ballot_hash != *expected_ballot_hash {
+            return Err(Error::InvalidBallotHash {
+                expected: *expected_ballot_hash,
+                actual: ballot_hash,
+            });
+        }
+
+        let precinct_index: PrecinctByIndex = r.parse_with(*election)?;
+        let ballot_style_index: BallotStyleByIndex = r.parse_with(*election)?;
         let page_number: PageNumber = r.parse()?;
         let is_test_mode = r.read_bit()?;
         let ballot_type: BallotType = r.parse()?;
@@ -391,15 +404,19 @@ mod test {
         let election: Election =
             serde_json::from_reader(BufReader::new(File::open(election_path).unwrap())).unwrap();
         let ballot_audit_id = "test-audit-ballot-id";
+        let ballot_hash: PartialBallotHash =
+            [0x2b, 0xad, 0x6b, 0xe9, 0x35, 0xdd, 0x46, 0xb1, 0x0c, 0x5f];
 
-        #[rustfmt::skip]
-        let bytes = [
+        let mut bytes = vec![
             // 3-byte prelude
             b'V', b'P', 2,
+        ];
 
-            // 10-byte ballot hash
-            0x2b, 0xad, 0x6b, 0xe9, 0x35, 0xdd, 0x46, 0xb1, 0x0c, 0x5f,
+        // 10-byte ballot hash
+        bytes.extend_from_slice(&ballot_hash);
 
+        #[rustfmt::skip]
+        bytes.extend_from_slice(&[
             // 8 bits for precinct index
             0b0000_0000,
             //PPPP PPPP
@@ -426,10 +443,10 @@ mod test {
 
             // Rest of ballot audit ID
             163, 43, 155, 161, 107, 11, 171, 35, 75, 161, 107, 19, 11, 99, 99, 123, 161, 107, 75, 32
-        ];
+        ]);
 
         let mut reader = BitReader::endian(Cursor::new(&bytes), BigEndian);
-        let metadata: Metadata = reader.parse_with(&election).unwrap();
+        let metadata: Metadata = reader.parse_with(&(&election, ballot_hash)).unwrap();
         assert_eq!(
             metadata,
             Metadata {
@@ -457,7 +474,7 @@ mod test {
 
         // TODO: use `assert_matches!` once that API is stable.
         assert!(matches!(
-            reader.parse_with::<Metadata>(&election),
+            reader.parse_with::<Metadata>(&(&election, PartialBallotHash::default())),
             Err(Error::Io(_))
         ));
     }
@@ -473,7 +490,7 @@ mod test {
 
         // TODO: use `assert_matches!` once that API is stable.
         assert!(matches!(
-            reader.parse_with::<Metadata>(&election),
+            reader.parse_with::<Metadata>(&(&election, PartialBallotHash::default())),
             Err(Error::InvalidPrelude([b'N', b'O', b'T']))
         ));
     }
@@ -485,15 +502,19 @@ mod test {
         let election_path = fixture_path.join("election.json");
         let election: Election =
             serde_json::from_reader(BufReader::new(File::open(election_path).unwrap())).unwrap();
+        let ballot_hash: PartialBallotHash =
+            [0x2b, 0xad, 0x6b, 0xe9, 0x35, 0xdd, 0x46, 0xb1, 0x0c, 0x5f];
 
-        #[rustfmt::skip]
-        let bytes = [
+        let mut bytes = vec![
             // 3-byte prelude
             b'V', b'P', 2,
+        ];
 
-            // 10-byte ballot hash
-            0x2b, 0xad, 0x6b, 0xe9, 0x35, 0xdd, 0x46, 0xb1, 0x0c, 0x5f,
+        // 10-byte ballot hash
+        bytes.extend_from_slice(&ballot_hash);
 
+        #[rustfmt::skip]
+        bytes.extend_from_slice(&[
             // 8 bits for precinct index
             0b0000_0000,
             //PPPP PPPP
@@ -513,10 +534,10 @@ mod test {
             // 4 bits for ballot type, 1 bit for ballot audit ID flag, 3 bits padding
             0b0000_0000,
             //TTTT F---
-        ];
+        ]);
 
         let mut reader = BitReader::endian(Cursor::new(&bytes), BigEndian);
-        let result = reader.parse_with::<Metadata>(&election);
+        let result = reader.parse_with::<Metadata>(&(&election, ballot_hash));
         assert!(
             matches!(result, Err(Error::Index(IndexError::Precinct(index))) if index.get() == 17),
             "Result is wrong: {result:?}"
@@ -531,14 +552,18 @@ mod test {
         let election: Election =
             serde_json::from_reader(BufReader::new(File::open(election_path).unwrap())).unwrap();
 
-        #[rustfmt::skip]
-        let bytes = [
+        let ballot_hash = [0x2b, 0xad, 0x6b, 0xe9, 0x35, 0xdd, 0x46, 0xb1, 0x0c, 0x5f];
+
+        let mut bytes = vec![
             // 3-byte prelude
             b'V', b'P', 2,
+        ];
 
-            // 10-byte ballot hash
-            0x2b, 0xad, 0x6b, 0xe9, 0x35, 0xdd, 0x46, 0xb1, 0x0c, 0x5f,
+        // 10-byte ballot hash
+        bytes.extend_from_slice(&ballot_hash);
 
+        #[rustfmt::skip]
+        bytes.extend_from_slice(&[
             // 8 bits for precinct index
             0b0000_0000,
             //PPPP PPPP
@@ -558,10 +583,10 @@ mod test {
             // 4 bits for ballot type, 1 bit for ballot audit ID flag, 3 bits padding
             0b0000_0000,
             //TTTT F---
-        ];
+        ]);
 
         let mut reader = BitReader::endian(Cursor::new(&bytes), BigEndian);
-        let result = reader.parse_with::<Metadata>(&election);
+        let result = reader.parse_with::<Metadata>(&(&election, ballot_hash));
 
         // TODO: use `assert_matches!` once that API is stable.
         assert!(
@@ -580,15 +605,18 @@ mod test {
         let election_path = fixture_path.join("election.json");
         let election: Election =
             serde_json::from_reader(BufReader::new(File::open(election_path).unwrap())).unwrap();
+        let ballot_hash = [0x2b, 0xad, 0x6b, 0xe9, 0x35, 0xdd, 0x46, 0xb1, 0x0c, 0x5f];
 
-        #[rustfmt::skip]
-        let bytes = [
+        let mut bytes = vec![
             // 3-byte prelude
             b'V', b'P', 2,
+        ];
 
-            // 10-byte ballot hash
-            0x2b, 0xad, 0x6b, 0xe9, 0x35, 0xdd, 0x46, 0xb1, 0x0c, 0x5f,
+        // 10-byte ballot hash
+        bytes.extend_from_slice(&ballot_hash);
 
+        #[rustfmt::skip]
+        bytes.extend_from_slice(&[
             // 8 bits for precinct index
             0b0000_0000,
             //PPPP PPPP
@@ -608,10 +636,10 @@ mod test {
             // 4 bits for ballot type, 1 bit for ballot audit ID flag, 3 bits padding
             0b1111_0000,
             //TTTT F---
-        ];
+        ]);
 
         let mut reader = BitReader::endian(Cursor::new(&bytes), BigEndian);
-        let result = reader.parse_with::<Metadata>(&election);
+        let result = reader.parse_with::<Metadata>(&(&election, ballot_hash));
 
         // TODO: use `assert_matches!` once that API is stable.
         assert!(
@@ -632,15 +660,18 @@ mod test {
         let election_path = fixture_path.join("election.json");
         let election: Election =
             serde_json::from_reader(BufReader::new(File::open(election_path).unwrap())).unwrap();
+        let ballot_hash = [0x2b, 0xad, 0x6b, 0xe9, 0x35, 0xdd, 0x46, 0xb1, 0x0c, 0x5f];
 
-        #[rustfmt::skip]
-        let bytes = [
+        let mut bytes = vec![
             // 3-byte prelude
             b'V', b'P', 2,
+        ];
 
-            // 10-byte ballot hash
-            0x2b, 0xad, 0x6b, 0xe9, 0x35, 0xdd, 0x46, 0xb1, 0x0c, 0x5f,
+        // 10-byte ballot hash
+        bytes.extend_from_slice(&ballot_hash);
 
+        #[rustfmt::skip]
+        bytes.extend_from_slice(&[
             // 8 bits for precinct index
             0b0000_0000,
             //PPPP PPPP
@@ -660,10 +691,10 @@ mod test {
             // 4 bits for ballot type, 1 bit for ballot audit ID flag, 3 bits padding
             0b0000_0000,
             //TTTT F---
-        ];
+        ]);
 
         let mut reader = BitReader::endian(Cursor::new(&bytes), BigEndian);
-        let result = reader.parse_with::<Metadata>(&election);
+        let result = reader.parse_with::<Metadata>(&(&election, ballot_hash));
 
         // TODO: use `assert_matches!` once that API is stable.
         assert!(matches!(result, Err(Error::Coding(coding::Error::InvalidValue(v))) if v == "31"));
@@ -676,15 +707,18 @@ mod test {
         let election_path = fixture_path.join("election.json");
         let election: Election =
             serde_json::from_reader(BufReader::new(File::open(election_path).unwrap())).unwrap();
+        let ballot_hash = [0x2b, 0xad, 0x6b, 0xe9, 0x35, 0xdd, 0x46, 0xb1, 0x0c, 0x5f];
 
-        #[rustfmt::skip]
-        let bytes = [
+        let mut bytes = vec![
             // 3-byte prelude
             b'V', b'P', 2,
+        ];
 
-            // 10-byte ballot hash
-            0x2b, 0xad, 0x6b, 0xe9, 0x35, 0xdd, 0x46, 0xb1, 0x0c, 0x5f,
+        // 10-byte ballot hash
+        bytes.extend_from_slice(&ballot_hash);
 
+        #[rustfmt::skip]
+        bytes.extend_from_slice(&[
             // 8 bits for precinct index
             0b0000_0000,
             //PPPP PPPP
@@ -711,10 +745,10 @@ mod test {
 
             // Rest of ballot audit ID (with invalid UTF-8 char at beginning)
             255, 43, 155, 161, 107, 11, 171, 35, 75, 161, 107, 19, 11, 99, 99, 123, 161, 107, 75, 32
-        ];
+        ]);
 
         let mut reader = BitReader::endian(Cursor::new(&bytes), BigEndian);
-        let result = reader.parse_with::<Metadata>(&election);
+        let result = reader.parse_with::<Metadata>(&(&election, ballot_hash));
 
         // TODO: use `assert_matches!` once that API is stable.
         assert!(matches!(result, Err(Error::InvalidBallotAuditId(_))));

--- a/libs/types-rs/src/bubble_ballot.rs
+++ b/libs/types-rs/src/bubble_ballot.rs
@@ -114,7 +114,10 @@ pub enum MetadataMismatch {
         side_b: BallotStyleId,
     },
     #[serde(rename_all = "camelCase")]
-    PageNumber { side_a: PageNumber, side_b: PageNumber },
+    PageNumber {
+        side_a: PageNumber,
+        side_b: PageNumber,
+    },
     #[serde(rename_all = "camelCase")]
     IsTestMode { side_a: bool, side_b: bool },
     #[serde(rename_all = "camelCase")]

--- a/libs/types-rs/src/bubble_ballot.rs
+++ b/libs/types-rs/src/bubble_ballot.rs
@@ -30,6 +30,105 @@ pub struct Metadata {
     pub ballot_audit_id: Option<String>,
 }
 
+impl Metadata {
+    /// Returns the list of fields whose values differ between `self` and
+    /// `other` when interpreted as the two sides of a single bubble ballot
+    /// sheet. An empty list means the two sides are consistent.
+    #[must_use]
+    pub fn match_sheet_with_metadata(&self, other: &Self) -> Vec<MetadataMismatch> {
+        let mut mismatches = vec![];
+
+        if self.ballot_hash != other.ballot_hash {
+            mismatches.push(MetadataMismatch::BallotHash {
+                side_a: self.ballot_hash,
+                side_b: other.ballot_hash,
+            });
+        }
+
+        if self.precinct_id != other.precinct_id {
+            mismatches.push(MetadataMismatch::PrecinctId {
+                side_a: self.precinct_id.clone(),
+                side_b: other.precinct_id.clone(),
+            });
+        }
+
+        if self.ballot_style_id != other.ballot_style_id {
+            mismatches.push(MetadataMismatch::BallotStyleId {
+                side_a: self.ballot_style_id.clone(),
+                side_b: other.ballot_style_id.clone(),
+            });
+        }
+
+        if self.page_number != other.page_number.opposite() {
+            mismatches.push(MetadataMismatch::PageNumber {
+                side_a: self.page_number,
+                side_b: other.page_number,
+            });
+        }
+
+        if self.is_test_mode != other.is_test_mode {
+            mismatches.push(MetadataMismatch::IsTestMode {
+                side_a: self.is_test_mode,
+                side_b: other.is_test_mode,
+            });
+        }
+
+        if self.ballot_type != other.ballot_type {
+            mismatches.push(MetadataMismatch::BallotType {
+                side_a: self.ballot_type,
+                side_b: other.ballot_type,
+            });
+        }
+
+        if self.ballot_audit_id != other.ballot_audit_id {
+            mismatches.push(MetadataMismatch::BallotAuditId {
+                side_a: self.ballot_audit_id.clone(),
+                side_b: other.ballot_audit_id.clone(),
+            });
+        }
+
+        mismatches
+    }
+}
+
+/// Identifies a single field that differs between the two sides of a bubble
+/// ballot sheet, carrying the value found on each side.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum MetadataMismatch {
+    #[serde(rename_all = "camelCase")]
+    BallotHash {
+        #[serde(with = "ballot_hash_serde")]
+        side_a: PartialBallotHash,
+        #[serde(with = "ballot_hash_serde")]
+        side_b: PartialBallotHash,
+    },
+    #[serde(rename_all = "camelCase")]
+    PrecinctId {
+        side_a: PrecinctId,
+        side_b: PrecinctId,
+    },
+    #[serde(rename_all = "camelCase")]
+    BallotStyleId {
+        side_a: BallotStyleId,
+        side_b: BallotStyleId,
+    },
+    #[serde(rename_all = "camelCase")]
+    PageNumber { side_a: PageNumber, side_b: PageNumber },
+    #[serde(rename_all = "camelCase")]
+    IsTestMode { side_a: bool, side_b: bool },
+    #[serde(rename_all = "camelCase")]
+    BallotType {
+        side_a: BallotType,
+        side_b: BallotType,
+    },
+    #[serde(rename_all = "camelCase")]
+    BallotAuditId {
+        side_a: Option<String>,
+        side_b: Option<String>,
+    },
+}
+
 /// Provides serialization and deserialization for [`PartialBallotHash`],
 /// primarily for serializing to JSON as a hex string.
 ///
@@ -267,6 +366,18 @@ mod test {
 
     fn arbitrary_page_number() -> impl Strategy<Value = PageNumber> {
         (PageNumber::MIN_VALUE..=PageNumber::MAX_VALUE).prop_map(PageNumber::new_unchecked)
+    }
+
+    fn sample_metadata() -> Metadata {
+        Metadata {
+            ballot_hash: [0; PARTIAL_BALLOT_HASH_BYTE_LENGTH],
+            precinct_id: PrecinctId::from("precinct-1".to_owned()),
+            ballot_style_id: BallotStyleId::from("ballot-style-1".to_owned()),
+            page_number: PageNumber::new_unchecked(1),
+            is_test_mode: false,
+            ballot_type: BallotType::Precinct,
+            ballot_audit_id: None,
+        }
     }
 
     #[test]
@@ -614,6 +725,198 @@ mod test {
         ]
     }
 
+    #[test]
+    fn test_match_sheet_with_metadata_no_mismatches() {
+        let front = sample_metadata();
+        let back = Metadata {
+            page_number: front.page_number.opposite(),
+            ..front.clone()
+        };
+        assert!(front.match_sheet_with_metadata(&back).is_empty());
+        // The relation is symmetric: it doesn't matter which side calls.
+        assert!(back.match_sheet_with_metadata(&front).is_empty());
+    }
+
+    #[test]
+    fn test_match_sheet_with_metadata_identical_sides_only_mismatch_page_number() {
+        // Identical metadata fails only the page-number check, because both
+        // sides claim the same page number rather than opposite ones.
+        let m = sample_metadata();
+        let mismatches = m.match_sheet_with_metadata(&m);
+        assert!(
+            matches!(
+                mismatches.as_slice(),
+                [MetadataMismatch::PageNumber { side_a, side_b }]
+                    if *side_a == m.page_number && *side_b == m.page_number
+            ),
+            "unexpected mismatches: {mismatches:?}"
+        );
+    }
+
+    #[test]
+    fn test_match_sheet_with_metadata_ballot_hash_mismatch() {
+        let front = sample_metadata();
+        let back = Metadata {
+            ballot_hash: [0xff; PARTIAL_BALLOT_HASH_BYTE_LENGTH],
+            page_number: front.page_number.opposite(),
+            ..front.clone()
+        };
+        let mismatches = front.match_sheet_with_metadata(&back);
+        assert!(
+            matches!(
+                mismatches.as_slice(),
+                [MetadataMismatch::BallotHash { side_a, side_b }]
+                    if *side_a == front.ballot_hash && *side_b == back.ballot_hash
+            ),
+            "unexpected mismatches: {mismatches:?}"
+        );
+    }
+
+    #[test]
+    fn test_match_sheet_with_metadata_precinct_id_mismatch() {
+        let front = sample_metadata();
+        let back = Metadata {
+            precinct_id: PrecinctId::from("precinct-2".to_owned()),
+            page_number: front.page_number.opposite(),
+            ..front.clone()
+        };
+        let mismatches = front.match_sheet_with_metadata(&back);
+        assert!(
+            matches!(
+                mismatches.as_slice(),
+                [MetadataMismatch::PrecinctId { side_a, side_b }]
+                    if *side_a == front.precinct_id && *side_b == back.precinct_id
+            ),
+            "unexpected mismatches: {mismatches:?}"
+        );
+    }
+
+    #[test]
+    fn test_match_sheet_with_metadata_ballot_style_id_mismatch() {
+        let front = sample_metadata();
+        let back = Metadata {
+            ballot_style_id: BallotStyleId::from("ballot-style-2".to_owned()),
+            page_number: front.page_number.opposite(),
+            ..front.clone()
+        };
+        let mismatches = front.match_sheet_with_metadata(&back);
+        assert!(
+            matches!(
+                mismatches.as_slice(),
+                [MetadataMismatch::BallotStyleId { side_a, side_b }]
+                    if *side_a == front.ballot_style_id && *side_b == back.ballot_style_id
+            ),
+            "unexpected mismatches: {mismatches:?}"
+        );
+    }
+
+    #[test]
+    fn test_match_sheet_with_metadata_page_number_from_different_sheets() {
+        // Front is page 1 (sheet 1), back is page 4 (sheet 2): not opposite.
+        let front = sample_metadata();
+        let back = Metadata {
+            page_number: PageNumber::new_unchecked(4),
+            ..front.clone()
+        };
+        let mismatches = front.match_sheet_with_metadata(&back);
+        assert!(
+            matches!(
+                mismatches.as_slice(),
+                [MetadataMismatch::PageNumber { side_a, side_b }]
+                    if *side_a == front.page_number && *side_b == back.page_number
+            ),
+            "unexpected mismatches: {mismatches:?}"
+        );
+    }
+
+    #[test]
+    fn test_match_sheet_with_metadata_is_test_mode_mismatch() {
+        let front = sample_metadata();
+        let back = Metadata {
+            is_test_mode: !front.is_test_mode,
+            page_number: front.page_number.opposite(),
+            ..front.clone()
+        };
+        let mismatches = front.match_sheet_with_metadata(&back);
+        assert!(
+            matches!(
+                mismatches.as_slice(),
+                [MetadataMismatch::IsTestMode { side_a, side_b }]
+                    if *side_a == front.is_test_mode && *side_b == back.is_test_mode
+            ),
+            "unexpected mismatches: {mismatches:?}"
+        );
+    }
+
+    #[test]
+    fn test_match_sheet_with_metadata_ballot_type_mismatch() {
+        let front = sample_metadata();
+        let back = Metadata {
+            ballot_type: BallotType::Absentee,
+            page_number: front.page_number.opposite(),
+            ..front.clone()
+        };
+        let mismatches = front.match_sheet_with_metadata(&back);
+        assert!(
+            matches!(
+                mismatches.as_slice(),
+                [MetadataMismatch::BallotType { side_a, side_b }]
+                    if *side_a == front.ballot_type && *side_b == back.ballot_type
+            ),
+            "unexpected mismatches: {mismatches:?}"
+        );
+    }
+
+    #[test]
+    fn test_match_sheet_with_metadata_ballot_audit_id_mismatch() {
+        let front = sample_metadata();
+        let back = Metadata {
+            ballot_audit_id: Some("audit-id".to_owned()),
+            page_number: front.page_number.opposite(),
+            ..front.clone()
+        };
+        let mismatches = front.match_sheet_with_metadata(&back);
+        assert!(
+            matches!(
+                mismatches.as_slice(),
+                [MetadataMismatch::BallotAuditId { side_a, side_b }]
+                    if *side_a == front.ballot_audit_id && *side_b == back.ballot_audit_id
+            ),
+            "unexpected mismatches: {mismatches:?}"
+        );
+    }
+
+    #[test]
+    fn test_match_sheet_with_metadata_accumulates_mismatches_in_declaration_order() {
+        let front = sample_metadata();
+        let back = Metadata {
+            ballot_hash: [0xff; PARTIAL_BALLOT_HASH_BYTE_LENGTH],
+            precinct_id: PrecinctId::from("precinct-other".to_owned()),
+            ballot_style_id: BallotStyleId::from("ballot-style-other".to_owned()),
+            // Page 5 is on sheet 3; not opposite of page 1.
+            page_number: PageNumber::new_unchecked(5),
+            is_test_mode: !front.is_test_mode,
+            ballot_type: BallotType::Absentee,
+            ballot_audit_id: Some("audit-id".to_owned()),
+        };
+        let mismatches = front.match_sheet_with_metadata(&back);
+        assert!(
+            matches!(
+                mismatches.as_slice(),
+                [
+                    MetadataMismatch::BallotHash { .. },
+                    MetadataMismatch::PrecinctId { .. },
+                    MetadataMismatch::BallotStyleId { .. },
+                    MetadataMismatch::PageNumber { .. },
+                    MetadataMismatch::IsTestMode { .. },
+                    MetadataMismatch::BallotType { .. },
+                    MetadataMismatch::BallotAuditId { .. },
+                ]
+            ),
+            "unexpected mismatches: {mismatches:?}"
+        );
+    }
+
     proptest! {
         #[test]
         fn test_ballot_audit_id_coding(ballot_audit_id in "[0-9a-z-]{1,100}") {
@@ -661,6 +964,35 @@ mod test {
             assert_eq!(inferred_metadata.is_test_mode, detected_metadata.is_test_mode);
             assert_eq!(inferred_metadata.ballot_type, detected_metadata.ballot_type);
             assert_eq!(inferred_metadata.ballot_audit_id, detected_metadata.ballot_audit_id);
+        }
+
+        /// Metadata inferred from the other side of a sheet must always be
+        /// considered compatible by `match_sheet_with_metadata`. This ties the
+        /// two helpers together: if `infer_missing_page_metadata` ever drifts
+        /// from the fields that `match_sheet_with_metadata` checks, this test
+        /// catches it.
+        #[test]
+        fn test_match_sheet_with_inferred_metadata_has_no_mismatches(
+            page_number in arbitrary_page_number(),
+            ballot_hash: PartialBallotHash,
+            precinct_id in "[0-9a-z-]{1,100}",
+            ballot_style_id in "[0-9a-z-]{1,100}",
+            is_test_mode in proptest::bool::ANY,
+            ballot_type in arbitrary_ballot_type(),
+            ballot_audit_id in proptest::option::of("[0-9a-z-]{1,100}"),
+        ) {
+            let detected = Metadata {
+                ballot_hash,
+                precinct_id: PrecinctId::from(precinct_id),
+                ballot_style_id: BallotStyleId::from(ballot_style_id),
+                page_number,
+                is_test_mode,
+                ballot_type,
+                ballot_audit_id,
+            };
+            let inferred = infer_missing_page_metadata(&detected);
+            assert!(detected.match_sheet_with_metadata(&inferred).is_empty());
+            assert!(inferred.match_sheet_with_metadata(&detected).is_empty());
         }
     }
 }


### PR DESCRIPTION
## Overview
Fixes #8426 

We prevent ballots from being counted when the ballot hash in the QR code does not match the election the machine is configured for. However, we did still interpret such ballots in the Rust side because we used to support both VotingWorks ballots with QR codes and AccuVote ballots with their metadata encoded in timing marks. Since not all ballots had a ballot hash, we just checked it outside the interpreter. However, this means that we would still _do_ the interpretation against a known-incorrect election definition.

The original error occurred because `getAllPossibleAdjudicationReasons` was passed a list of scored contest options that did not have at least one entry for all contest options since the mark data returned from the interpreter was incomplete. This happened because `TimingMarks::point_for_location` returns `None` when there is no point for the grid coordinates, and we just ignored it via `flat_map` when processing it. 528451c fixes this by adding an error specific to this case. This was the ultimate cause of #8426 since the 11" ballot didn't have some of the grid positions from the 17" ballot's election definition.

## Demo Video or Screenshot
```
❯ ./target/release/interpret ../../.mock-state/development/election.json ~/code/election-definitions/v4.0.2/2025-07-07-cert-testing/functional-testing-primary/official-precinct-ballot-Precinct_1-1-D_en-p{1,2}.jpg
Error: invalid ballot hash: expected [5b, 45, b9, ba, 26, fd, fb, f0, 81, e9], actual [3c, ac, 29, 0a, 3a, 06, f0, d1, 77, d9]
⚡ 79.92ms
```

## Testing Plan
New automated tests, manually tested that the ballot is rejected instead of triggering a crash.