### PR TITLE
fix(usb-drive): handle `/media/vx` being a symlink

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -65,6 +65,7 @@ import {
   ListDirectoryOnUsbDriveError,
   listDirectoryOnUsbDrive,
   MultiUsbDrive,
+  REAL_USB_DRIVE_GLOB_PATTERN,
   UsbDriveStatus,
   createUsbDriveAdapter,
 } from '@votingworks/usb-drive';
@@ -123,7 +124,7 @@ import {
   generateAdminLiveResultsReportingUrls,
   getMatchingAbsenteePollingPlaces,
 } from './live_results_reporting';
-import { NODE_ENV, REAL_USB_DRIVE_GLOB_PATTERN } from './globals';
+import { NODE_ENV } from './globals';
 import {
   exportWriteInAdjudicationReportPdf,
   generateWriteInAdjudicationReportPreview,

--- a/apps/admin/backend/src/globals.ts
+++ b/apps/admin/backend/src/globals.ts
@@ -1,5 +1,8 @@
 import { unsafeParse } from '@votingworks/types';
-import { DEV_MOCK_USB_DRIVE_GLOB_PATTERN } from '@votingworks/usb-drive';
+import {
+  DEV_MOCK_USB_DRIVE_GLOB_PATTERN,
+  REAL_USB_DRIVE_GLOB_PATTERN,
+} from '@votingworks/usb-drive';
 import { isIntegrationTest } from '@votingworks/utils';
 import { join } from 'node:path';
 import { z } from 'zod/v4';
@@ -38,11 +41,6 @@ export const PORT = Number(process.env.FRONTEND_PORT || 3000) + 1;
  */
 // eslint-disable-next-line vx/gts-safe-number-parse
 export const PEER_PORT = Number(process.env['PEER_PORT'] || PORT + 1);
-
-/**
- * A glob pattern for USB drives (real and not dev mock)
- */
-export const REAL_USB_DRIVE_GLOB_PATTERN = '/media/**/*';
 
 /**  How often to poll the network for changes (in milliseconds) */
 export const NETWORK_POLLING_INTERVAL_MS = 2 * 1000;

--- a/apps/print/backend/src/globals.ts
+++ b/apps/print/backend/src/globals.ts
@@ -1,6 +1,9 @@
 /* istanbul ignore file - @preserve */
 import { unsafeParse } from '@votingworks/types';
-import { DEV_MOCK_USB_DRIVE_GLOB_PATTERN } from '@votingworks/usb-drive';
+import {
+  DEV_MOCK_USB_DRIVE_GLOB_PATTERN,
+  REAL_USB_DRIVE_GLOB_PATTERN,
+} from '@votingworks/usb-drive';
 import { isIntegrationTest } from '@votingworks/utils';
 import { z } from 'zod/v4';
 
@@ -21,8 +24,6 @@ const NODE_ENV = unsafeParse(
   NodeEnvSchema,
   process.env['NODE_ENV'] ?? 'development'
 );
-
-const REAL_USB_DRIVE_GLOB_PATTERN = '/media/**/*';
 
 export const PRINT_ALLOWED_EXPORT_PATTERNS =
   NODE_ENV === 'production'

--- a/libs/backend/src/scan_globals.test.ts
+++ b/libs/backend/src/scan_globals.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { DEV_MOCK_USB_DRIVE_GLOB_PATTERN } from '@votingworks/usb-drive';
-
-const REAL_USB_DRIVE_GLOB_PATTERN = '/media/**/*';
+import {
+  DEV_MOCK_USB_DRIVE_GLOB_PATTERN,
+  REAL_USB_DRIVE_GLOB_PATTERN,
+} from '@votingworks/usb-drive';
 
 beforeEach(() => {
   vi.unstubAllEnvs();

--- a/libs/backend/src/scan_globals.ts
+++ b/libs/backend/src/scan_globals.ts
@@ -1,5 +1,8 @@
 import { DEV_MACHINE_ID, unsafeParse } from '@votingworks/types';
-import { DEV_MOCK_USB_DRIVE_GLOB_PATTERN } from '@votingworks/usb-drive';
+import {
+  DEV_MOCK_USB_DRIVE_GLOB_PATTERN,
+  REAL_USB_DRIVE_GLOB_PATTERN,
+} from '@votingworks/usb-drive';
 import { isIntegrationTest } from '@votingworks/utils';
 import { z } from 'zod/v4';
 
@@ -21,8 +24,6 @@ export const NODE_ENV = unsafeParse(
   NodeEnvSchema,
   process.env.NODE_ENV ?? 'development'
 );
-
-const REAL_USB_DRIVE_GLOB_PATTERN = '/media/**/*';
 
 const DEFAULT_ALLOWED_EXPORT_PATTERNS =
   NODE_ENV === 'production'

--- a/libs/usb-drive/scripts/mount.sh
+++ b/libs/usb-drive/scripts/mount.sh
@@ -2,45 +2,44 @@
 
 set -euo pipefail
 
-usage () {
-    echo 'Usage: mount.sh <device>'
-    exit 1
+usage() {
+  echo 'Usage: mount.sh <device>'
+  exit 1
 }
 
 if ! [[ $# -eq 1 ]]; then
-    usage
+  usage
 fi
 
 PARTITION_DEVICE_REGEX='^/dev/(sd[a-z]+[0-9]+|nvme[0-9]+n[0-9]+p[0-9]+|mmcblk[0-9]+p[0-9]+)$'
 
 if ! [[ $1 =~ $PARTITION_DEVICE_REGEX ]]; then
-    echo "mount.sh: \"${1}\" is not a recognized partition device"
-    exit 1
+  echo "mount.sh: \"${1}\" is not a recognized partition device"
+  exit 1
 fi
 
 DEVICE=$1
 DEVNAME=$(basename "$1")
-MOUNTPOINT=/media/vx/usb-drive-${DEVNAME}
 
-# If a drive was previously removed without being ejected first, it may leave a
-# "phantom" mounted drive - a mount entry for an inaccessible file system. Although
-# "phantom" drives do not cause problems for our application code, the system's
-# file picker will confusingly show multiple drives with the same name. Thus,
-# before mounting, we check for a (probably "phantom") mounted drive and
-# unmount it if it exists.
-if [[  $(findmnt) =~ ${MOUNTPOINT} ]]; then
-    SCRIPTS_DIRECTORY="$(dirname "${BASH_SOURCE[0]}")"
-    "${SCRIPTS_DIRECTORY}/unmount.sh" "$MOUNTPOINT"
+# Resolve symlinks once so the mountpoint matches what /proc/self/mountinfo
+# reports. unmount.sh requires the canonical form.
+MOUNTPOINT=$(realpath -m "/media/vx/usb-drive-${DEVNAME}")
+
+# A drive removed without ejecting first leaves a "phantom" mount entry for
+# an inaccessible filesystem. Detect and clean it up before mounting fresh.
+if findmnt --mountpoint "$MOUNTPOINT" >/dev/null; then
+  SCRIPTS_DIRECTORY="$(dirname "${BASH_SOURCE[0]}")"
+  "${SCRIPTS_DIRECTORY}/unmount.sh" "$MOUNTPOINT"
 fi
 
 # The mount point will already exist in production but possibly not in development
 if ! [[ -e $MOUNTPOINT ]]; then
-    mkdir -p $MOUNTPOINT
+  mkdir -p "$MOUNTPOINT"
 fi
 FSTYPE=$(blkid -o value -s TYPE "$DEVICE" 2>/dev/null || echo "")
 
 if [[ "$FSTYPE" == "ext4" ]]; then
-    mount -w -o nosuid,nodev,noexec $DEVICE $MOUNTPOINT
+  mount -w -o nosuid,nodev,noexec "$DEVICE" "$MOUNTPOINT"
 else
-    mount -w -o umask=000,nosuid,nodev,noexec $DEVICE $MOUNTPOINT
+  mount -w -o umask=000,nosuid,nodev,noexec "$DEVICE" "$MOUNTPOINT"
 fi

--- a/libs/usb-drive/scripts/unmount.sh
+++ b/libs/usb-drive/scripts/unmount.sh
@@ -2,26 +2,34 @@
 
 set -euo pipefail
 
-usage () {
-    echo 'Usage: unmount.sh <mount-point>'
-    exit 1
+usage() {
+  echo 'Usage: unmount.sh <mount-point>'
+  exit 1
 }
 
 if ! [[ $# -eq 1 ]]; then
-    usage
+  usage
 fi
 
 MOUNTPOINT=$1
 
-MOUNTPOINT_REGEX='^/media/[[:alnum:]\ -_]+/[[:alnum:]\ -_]+$'
+# /media/vx may be a symlink and /proc/mounts reports the canonical path the
+# kernel received, so resolve our expected prefix to match. `-m` lets this
+# work on dev machines where /media/vx may not exist.
+MEDIA_DIR=$(realpath -m /media/vx)
 
-if ! [[ "$MOUNTPOINT" =~ $MOUNTPOINT_REGEX ]]; then
-    echo "unmount.sh: mount point \"${MOUNTPOINT}\" is not a valid mounted USB drive"
-    exit 1
+# Lock down to exactly what mount.sh produces: <MEDIA_DIR>/usb-drive-<part>,
+# where <part> matches mount.sh's PARTITION_DEVICE_REGEX. Keep this regex in
+# sync with mount.sh.
+LABEL_REGEX='^usb-drive-(sd[a-z]+[0-9]+|nvme[0-9]+n[0-9]+p[0-9]+|mmcblk[0-9]+p[0-9]+)$'
+PARENT=$(dirname "$MOUNTPOINT")
+LABEL=$(basename "$MOUNTPOINT")
+if [[ "$PARENT" != "$MEDIA_DIR" ]] || ! [[ "$LABEL" =~ $LABEL_REGEX ]]; then
+  echo "unmount.sh: mount point \"${MOUNTPOINT}\" was not produced by mount.sh"
+  exit 1
 fi
 
-# Run sync before unmounting to force any cached file data to be flushed to the
-# removable drive. Used to prevent incomplete file transfers.
+# Flush cached file data so the drive is safe to remove.
 sync -f "$MOUNTPOINT"
 
 umount "$MOUNTPOINT"

--- a/libs/usb-drive/src/block_devices.test.ts
+++ b/libs/usb-drive/src/block_devices.test.ts
@@ -25,6 +25,14 @@ vi.mock(
   }
 );
 
+// Pin the resolved media mount dir so tests don't depend on the host
+// filesystem (e.g., whether /media/vx exists on the CI runner).
+vi.mock(import('./media_mount_dir.js'), () => ({
+  MEDIA_MOUNT_DIR: '/media/vx',
+  RESOLVED_MEDIA_MOUNT_DIR: '/media/vx',
+  REAL_USB_DRIVE_GLOB_PATTERN: '/media/vx/**/*',
+}));
+
 vi.mock(
   import('./exec.js'),
   async (importActual): Promise<typeof import('./exec')> => ({
@@ -418,6 +426,30 @@ describe('getAllUsbDrives', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]?.partitions[0]).toMatchObject({ mountpoint: undefined });
+  });
+
+  test('does not match mountpoints that merely share a prefix with the media dir', async () => {
+    // /media/vxfoo must NOT match /media/vx — the check requires a trailing
+    // separator.
+    execMock.mockResolvedValueOnce({
+      stdout: [
+        exportDbEntry({ devname: '/dev/sdb', devtype: 'disk' }),
+        exportDbEntry({
+          devname: '/dev/sdb1',
+          devtype: 'partition',
+          fstype: 'vfat',
+          fsver: 'FAT32',
+        }),
+      ].join('\n\n'),
+      stderr: '',
+    });
+    readFileMock.mockResolvedValueOnce(
+      procMountsContent([
+        { device: '/dev/sdb1', mountpoint: '/media/vxfoo/something' },
+      ])
+    );
+
+    expect(await getAllUsbDrives()).toEqual([]);
   });
 });
 

--- a/libs/usb-drive/src/block_devices.ts
+++ b/libs/usb-drive/src/block_devices.ts
@@ -4,6 +4,7 @@ import { promises as fs } from 'node:fs';
 import { basename } from 'node:path';
 import { assert, Optional } from '@votingworks/basics';
 import { exec, spawn } from './exec';
+import { RESOLVED_MEDIA_MOUNT_DIR } from './media_mount_dir';
 
 const debug = makeDebug('usb-drive');
 
@@ -84,14 +85,12 @@ function parseExportDb(output: string): UsbBlockDevice[] {
   return devices;
 }
 
-const DEFAULT_MEDIA_MOUNT_DIR = '/media';
-
 function isDataUsbDrive(blockDeviceInfo: BlockDeviceInfo): boolean {
   return (
     (blockDeviceInfo.type === 'part' || blockDeviceInfo.type === 'disk') &&
     !blockDeviceInfo.fstype?.includes('LVM') && // no partitions acting as LVMs
     (!blockDeviceInfo.mountpoint ||
-      blockDeviceInfo.mountpoint.startsWith(DEFAULT_MEDIA_MOUNT_DIR))
+      blockDeviceInfo.mountpoint.startsWith(`${RESOLVED_MEDIA_MOUNT_DIR}/`))
   );
 }
 

--- a/libs/usb-drive/src/index.ts
+++ b/libs/usb-drive/src/index.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 export * from './list_directory_on_usb_drive';
+export * from './media_mount_dir';
 export * from './mocks/memory_usb_drive';
 export * from './mocks/mock_multi_usb_drive';
 export * from './mocks/file_usb_drive';

--- a/libs/usb-drive/src/media_mount_dir.test.ts
+++ b/libs/usb-drive/src/media_mount_dir.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.unstubAllGlobals();
+});
+
+afterEach(() => {
+  vi.doUnmock('node:fs');
+});
+
+async function importMediaMountDir() {
+  return import('./media_mount_dir.js');
+}
+
+test('RESOLVED_MEDIA_MOUNT_DIR returns the realpath of /media/vx', async () => {
+  vi.doMock('node:fs', async (importActual) => {
+    const actual = await importActual<typeof import('node:fs')>();
+    return {
+      ...actual,
+      realpathSync: vi.fn((p: string) => {
+        if (p === '/media/vx') return '/var/vx/usb-drives';
+        return actual.realpathSync(p);
+      }),
+    };
+  });
+
+  const { MEDIA_MOUNT_DIR, RESOLVED_MEDIA_MOUNT_DIR, REAL_USB_DRIVE_GLOB_PATTERN } =
+    await importMediaMountDir();
+
+  expect(MEDIA_MOUNT_DIR).toEqual('/media/vx');
+  expect(RESOLVED_MEDIA_MOUNT_DIR).toEqual('/var/vx/usb-drives');
+  expect(REAL_USB_DRIVE_GLOB_PATTERN).toEqual('/var/vx/usb-drives/**/*');
+});
+
+test('RESOLVED_MEDIA_MOUNT_DIR falls back to the literal path when realpathSync throws', async () => {
+  vi.doMock('node:fs', async (importActual) => {
+    const actual = await importActual<typeof import('node:fs')>();
+    return {
+      ...actual,
+      realpathSync: vi.fn(() => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      }),
+    };
+  });
+
+  const { MEDIA_MOUNT_DIR, RESOLVED_MEDIA_MOUNT_DIR, REAL_USB_DRIVE_GLOB_PATTERN } =
+    await importMediaMountDir();
+
+  expect(RESOLVED_MEDIA_MOUNT_DIR).toEqual(MEDIA_MOUNT_DIR);
+  expect(REAL_USB_DRIVE_GLOB_PATTERN).toEqual('/media/vx/**/*');
+});

--- a/libs/usb-drive/src/media_mount_dir.ts
+++ b/libs/usb-drive/src/media_mount_dir.ts
@@ -1,0 +1,33 @@
+import { realpathSync } from 'node:fs';
+
+/**
+ * The conventional mount root for VotingWorks USB drives. May be a symbolic
+ * link in production (e.g., pointing into `/var/vx/usb-drives`).
+ */
+export const MEDIA_MOUNT_DIR: string = '/media/vx';
+
+/**
+ * The canonical (symlink-resolved) form of {@link MEDIA_MOUNT_DIR}. Resolved
+ * once at module load — the mount root doesn't change at runtime, and several
+ * call sites (shell scripts, export-path glob patterns, mountpoint filtering)
+ * need a consistent value.
+ *
+ * Falls back to the literal path if `/media/vx` doesn't exist (e.g., dev
+ * machines, CI). `/proc/mounts` and `findmnt` report the canonical path the
+ * `mount(2)` syscall received, so callers comparing against this value should
+ * see consistent results in production.
+ */
+export const RESOLVED_MEDIA_MOUNT_DIR: string = (() => {
+  try {
+    return realpathSync(MEDIA_MOUNT_DIR);
+  } catch {
+    return MEDIA_MOUNT_DIR;
+  }
+})();
+
+/**
+ * Glob pattern for files written to real (non-mock) USB drives. Uses the
+ * resolved mount root so it matches the canonical paths reported by
+ * `/proc/mounts`.
+ */
+export const REAL_USB_DRIVE_GLOB_PATTERN = `${RESOLVED_MEDIA_MOUNT_DIR}/**/*`;

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -292,6 +292,15 @@ export function detectMultiUsbDrive(
       });
   }
 
+  function findPartitionMountpoint(
+    diskDevPath: string,
+    partitionDevPath: string
+  ): Optional<string> {
+    return cachedDrives
+      .find((d) => d.devPath === diskDevPath)
+      ?.partitions.find((p) => p.devPath === partitionDevPath)?.mountpoint;
+  }
+
   async function doMountPartitionWithRetry(
     diskDevPath: string,
     partitionDevPath: string
@@ -299,31 +308,29 @@ export function detectMultiUsbDrive(
     try {
       await logger.logAsCurrentRole(LogEventId.UsbDriveMountInit);
       await mountPartition(partitionDevPath);
-      // Poll for mount point to register
-      const start = Date.now();
-      while (!stopped && Date.now() - start < MOUNT_TIMEOUT_MS) {
+
+      let mountPoint: Optional<string>;
+      const deadline = Date.now() + MOUNT_TIMEOUT_MS;
+      while (!stopped && Date.now() < deadline) {
         await doRefresh();
-        const updated = cachedDrives
-          .find((d) => d.devPath === diskDevPath)
-          ?.partitions.find((p) => p.devPath === partitionDevPath);
-        if (updated?.mountpoint) break;
+        mountPoint = findPartitionMountpoint(diskDevPath, partitionDevPath);
+        if (mountPoint) break;
         await sleep(MOUNT_RETRY_INTERVAL_MS);
       }
-      const foundMountPoint = cachedDrives
-        .find((d) => d.devPath === diskDevPath)
-        ?.partitions.find((p) => p.devPath === partitionDevPath)?.mountpoint;
-      if (foundMountPoint) {
-        await logger.logAsCurrentRole(LogEventId.UsbDriveMounted, {
-          disposition: 'success',
-          message: `USB drive partition ${partitionDevPath} successfully auto-mounted at ${foundMountPoint}.`,
-        });
-      } else {
-        await logger.logAsCurrentRole(LogEventId.UsbDriveMounted, {
-          disposition: 'failure',
-          message: `Timed out waiting for USB drive partition ${partitionDevPath} to mount.`,
-          result: 'USB drive partition not mounted.',
-        });
-      }
+
+      await logger.logAsCurrentRole(
+        LogEventId.UsbDriveMounted,
+        mountPoint
+          ? {
+              disposition: 'success',
+              message: `USB drive partition ${partitionDevPath} successfully auto-mounted at ${mountPoint}.`,
+            }
+          : {
+              disposition: 'failure',
+              message: `Timed out waiting for USB drive partition ${partitionDevPath} to mount.`,
+              result: 'USB drive partition not mounted.',
+            }
+      );
     } catch (error) {
       debug(`auto-mount failed for ${partitionDevPath}: ${error}`);
       await logger.logAsCurrentRole(LogEventId.UsbDriveMounted, {


### PR DESCRIPTION
## Overview
In production we currently symlink `/media/vx` to `/var/vx/usb-drives`. That means the mountpoints returned by the system for the USB drives start with `/var/vx/usb-drives` instead of `/media/vx`, breaking our `mountpoint.startsWith('/media')` check and causing drives to appear never to mount. This change resolves `/media/vx` when listing drives so we can properly filter partitions mounted outside the actual mount location.

## Demo Video or Screenshot
Locally on `main` after pointing `/media/vx` to `/var/vx/usb-drives`:

```
[backend:run] {"source":"vx-admin-service","eventId":"usb-drive-mount-init","eventType":"application-action","user":"system_administrator","message":"Application is attempting to mount a USB drive...","disposition":"na"}
[backend:run] {"source":"vx-admin-service","eventId":"usb-drive-mount-complete","eventType":"application-status","user":"system_administrator","message":"Timed out waiting for USB drive partition /dev/sda1 to mount.","disposition":"failure","result":"USB drive partition not mounted."}
```

And after applying the changes in this PR:

```
[backend:run] {"source":"vx-admin-service","eventId":"usb-drive-mount-init","eventType":"application-action","user":"unknown","message":"Application is attempting to mount a USB drive...","disposition":"na"}
[backend:run] {"source":"vx-admin-service","eventId":"usb-drive-mount-complete","eventType":"application-status","user":"unknown","message":"USB drive partition /dev/sdb1 successfully auto-mounted at /media/vx/usb-drive-sdb1.","disposition":"success"}
```

## Testing Plan
Tested manually as above, verifying that a FAT32 drive shows up in the VxAdmin UI. Added new automated tests.