### PR TITLE
VxAdmin: Open primary write-in adjudication report

### DIFF
--- a/apps/admin/backend/src/app.tally_report_data.test.ts
+++ b/apps/admin/backend/src/app.tally_report_data.test.ts
@@ -25,7 +25,10 @@ import {
   MockCastVoteRecordFile,
   addMockCvrFileToStore,
 } from '../test/mock_cvr_file';
-import { seedOpenPrimaryCvrsAndAdjudications } from '../test/open_primary_fixture';
+import {
+  seedOpenPrimaryCvrsAndAdjudications,
+  seedOpenPrimaryWriteIns,
+} from '../test/open_primary_fixture';
 import { AdjudicatedContestOption } from './types';
 
 vi.setConfig({
@@ -1247,4 +1250,45 @@ test('open primary, grouped by precinct', async () => {
       'margaret-chen': { tally: 5 },
     },
   });
+});
+
+test('open primary, crossover ballots write-ins excluded from partisan tallies', async () => {
+  const electionDefinition =
+    electionOpenPrimaryFixtures.readElectionDefinition();
+  const { apiClient, auth, workspace } = buildTestEnvironment();
+  const electionId = await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition
+  );
+  mockElectionManagerAuth(auth, electionDefinition.election);
+
+  const { demCandidate, repCandidate } = await seedOpenPrimaryWriteIns({
+    apiClient,
+    electionId,
+    store: workspace.store,
+  });
+
+  const tallyReports = await apiClient.getResultsForTallyReports();
+  const [report] = tallyReports;
+  assert(report);
+  assert(report.hasPartySplits);
+
+  // The Dem voter's write-in shows up in the governor-democratic tally.
+  expect(
+    report.scannedResults.contestResults['governor-democratic']
+  ).toMatchObject({
+    tallies: {
+      [demCandidate.id]: { tally: 1 },
+    },
+  });
+
+  // The two crossover ballots' votes for governor-republican are all voided —
+  // no ballots get counted toward the contest, and the write-in candidate
+  // never gets added to the contest's tallies map.
+  const repContest =
+    report.scannedResults.contestResults['governor-republican'];
+  assert(repContest?.contestType === 'candidate');
+  expect(repContest.ballots).toEqual(0);
+  expect(repContest.tallies[repCandidate.id]).toBeUndefined();
 });

--- a/apps/admin/backend/src/app.write_in_adjudication_report_pdf.test.ts
+++ b/apps/admin/backend/src/app.write_in_adjudication_report_pdf.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import {
   electionGridLayoutNewHampshireTestBallotFixtures,
+  electionOpenPrimaryFixtures,
   electionTwoPartyPrimaryFixtures,
 } from '@votingworks/fixtures';
 import {
@@ -18,6 +19,7 @@ import {
   mockElectionManagerAuth,
 } from '../test/app';
 import { mockFileName } from '../test/csv';
+import { seedOpenPrimaryWriteIns } from '../test/open_primary_fixture';
 import { generateReportPath } from './util/filenames';
 import { AdjudicatedContestOption } from './types';
 
@@ -326,5 +328,61 @@ test('write-in adjudication report warning', async () => {
   expect(await apiClient.getWriteInAdjudicationReportPreview()).toEqual({
     pdf: undefined,
     warning: { type: 'content-too-large' },
+  });
+});
+
+test('open primary: crossover ballots write-ins on partisan contests are excluded', async () => {
+  const electionDefinition =
+    electionOpenPrimaryFixtures.readElectionDefinition();
+  const { apiClient, auth, workspace } = buildTestEnvironment();
+  const electionId = await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition
+  );
+  mockElectionManagerAuth(auth, electionDefinition.election);
+
+  const { demCandidate, repCandidate, nonpartisanCandidate } =
+    await seedOpenPrimaryWriteIns({
+      apiClient,
+      electionId,
+      store: workspace.store,
+    });
+
+  const summary = await apiClient.getElectionWriteInSummary();
+
+  // Dem-only voter's write-in on governor-democratic counts.
+  expect(
+    summary.contestWriteInSummaries['governor-democratic']?.candidateTallies[
+      demCandidate.id
+    ]
+  ).toEqual({
+    id: demCandidate.id,
+    name: 'Dem Write-In',
+    tally: 1,
+    isWriteIn: true,
+  });
+
+  // Crossover voter's write-in on governor-republican does NOT count, because
+  // crossover ballots' partisan votes are invalidated. The write-in candidate
+  // never gets a tally entry (write-in candidates only appear when they have
+  // at least one vote).
+  expect(
+    summary.contestWriteInSummaries['governor-republican']?.candidateTallies[
+      repCandidate.id
+    ]
+  ).toBeUndefined();
+
+  // Nonpartisan write-ins always count, regardless of whether the ballot is
+  // crossover (one nonpartisan-only voter + one crossover voter).
+  expect(
+    summary.contestWriteInSummaries['circuit-court-judge']?.candidateTallies[
+      nonpartisanCandidate.id
+    ]
+  ).toEqual({
+    id: nonpartisanCandidate.id,
+    name: 'Nonpartisan Write-In',
+    tally: 2,
+    isWriteIn: true,
   });
 });

--- a/apps/admin/backend/src/tabulation/write_ins.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.ts
@@ -11,6 +11,7 @@ import {
   GROUP_KEY_ROOT,
   extractGroupSpecifier,
   getGroupKey,
+  hasCrossoverVote,
   isGroupByEmpty,
 } from '@votingworks/utils';
 import { assert, assertDefined } from '@votingworks/basics';
@@ -151,13 +152,24 @@ function addWriteInToElectionWriteInSummary({
     cvrId,
     filter: {},
   });
-  const votes = assertDefined(assertDefined(cvr).votes[contestId]);
-
+  assert(cvr !== undefined);
   const contest = CachedElectionLookups.getContestById(
     electionDefinition,
     contestId
   );
   assert(contest.type === 'candidate');
+
+  // If the ballot has a crossover vote and the write-in was for a partisan
+  // contest, it doesn't count
+  if (
+    hasCrossoverVote(electionDefinition.election, cvr.votes) &&
+    contest.partyId
+  ) {
+    contestWriteInSummary.invalidTally += 1;
+    return electionWriteInSummary;
+  }
+
+  const votes = assertDefined(cvr.votes[contestId]);
 
   const isPending = officialCandidateId === null && writeInCandidateId === null;
   const isOvervote = votes.length > contest.seats;

--- a/apps/admin/backend/test/open_primary_fixture.ts
+++ b/apps/admin/backend/test/open_primary_fixture.ts
@@ -5,6 +5,15 @@ import { Store } from '../src/store';
 import { Api } from '../src/app';
 import { MockCastVoteRecordFile, addMockCvrFileToStore } from './mock_cvr_file';
 
+const baseCvr: Omit<MockCastVoteRecordFile[number], 'card' | 'votes'> = {
+  ballotStyleGroupId: 'ballot-style-1',
+  batchId: 'batch-1',
+  scannerId: 'scanner-1',
+  precinctId: 'precinct-1',
+  votingMethod: 'precinct',
+};
+const hmpbSheet1: Tabulation.Card = { type: 'hmpb', sheetNumber: 1 };
+
 export interface OpenPrimaryFixtureResult {
   cvrIds: string[];
   // Crossover ballot whose Republican vote was adjudicated away → now Dem-only.
@@ -28,14 +37,6 @@ export async function seedOpenPrimaryCvrsAndAdjudications({
   electionId: Id;
   store: Store;
 }): Promise<OpenPrimaryFixtureResult> {
-  const baseCvr: Omit<MockCastVoteRecordFile[number], 'card' | 'votes'> = {
-    ballotStyleGroupId: 'ballot-style-1',
-    batchId: 'batch-1',
-    scannerId: 'scanner-1',
-    precinctId: 'precinct-1',
-    votingMethod: 'precinct',
-  };
-  const hmpbSheet1: Tabulation.Card = { type: 'hmpb', sheetNumber: 1 };
   const mockCastVoteRecordFile: MockCastVoteRecordFile = [
     {
       ...baseCvr,
@@ -162,4 +163,137 @@ export async function seedOpenPrimaryCvrsAndAdjudications({
   ).assertOk('failed to flip dem ballot');
 
   return { cvrIds, resolvedCrossoverCvrId, flippedToNoPartyCvrId };
+}
+
+export interface OpenPrimaryWriteInsFixtureResult {
+  demCandidate: { id: string; name: string };
+  repCandidate: { id: string; name: string };
+  nonpartisanCandidate: { id: string; name: string };
+}
+
+/**
+ * Seeds 4 open-primary ballots, each with one write-in mark, and adjudicates
+ * each write-in to a write-in candidate.
+ *
+ *   cvrIds[0] = Dem-only voter, write-in on governor-democratic       → counts
+ *   cvrIds[1] = Crossover voter, write-in on governor-republican      → does NOT count
+ *   cvrIds[2] = Nonpartisan-only voter, write-in on circuit-court-judge → counts
+ *   cvrIds[3] = Crossover voter, write-in on circuit-court-judge      → counts
+ *                (nonpartisan write-ins count regardless of crossover)
+ */
+export async function seedOpenPrimaryWriteIns({
+  apiClient,
+  electionId,
+  store,
+}: {
+  apiClient: grout.Client<Api>;
+  electionId: Id;
+  store: Store;
+}): Promise<OpenPrimaryWriteInsFixtureResult> {
+  const file: MockCastVoteRecordFile = [
+    {
+      ...baseCvr,
+      card: hmpbSheet1,
+      votes: {
+        'governor-democratic': ['write-in-0'],
+        'circuit-court-judge': ['margaret-chen'],
+      },
+    },
+    {
+      ...baseCvr,
+      card: hmpbSheet1,
+      // Crossover: voted in both Dem and Rep partisan contests, with the Rep
+      // contest selection being a write-in.
+      votes: {
+        'governor-democratic': ['alice-jones'],
+        'governor-republican': ['write-in-0'],
+        'circuit-court-judge': ['margaret-chen'],
+      },
+    },
+    {
+      ...baseCvr,
+      card: hmpbSheet1,
+      // Nonpartisan-only voter: no partisan votes, write-in on nonpartisan.
+      votes: { 'circuit-court-judge': ['write-in-0'] },
+    },
+    {
+      ...baseCvr,
+      card: hmpbSheet1,
+      // Crossover voter (Dem + Rep partisan votes) with a write-in on the
+      // nonpartisan contest. The crossover voids the partisan votes but the
+      // nonpartisan write-in must still count.
+      votes: {
+        'governor-democratic': ['alice-jones'],
+        'governor-republican': ['dave-wilson'],
+        'circuit-court-judge': ['write-in-0'],
+      },
+    },
+  ];
+  const cvrIds = addMockCvrFileToStore({
+    electionId,
+    mockCastVoteRecordFile: file,
+    store,
+  });
+
+  const demCandidate = await apiClient.addWriteInCandidate({
+    contestId: 'governor-democratic',
+    name: 'Dem Write-In',
+  });
+  const repCandidate = await apiClient.addWriteInCandidate({
+    contestId: 'governor-republican',
+    name: 'Rep Write-In',
+  });
+  const nonpartisanCandidate = await apiClient.addWriteInCandidate({
+    contestId: 'circuit-court-judge',
+    name: 'Nonpartisan Write-In',
+  });
+
+  async function adjudicate(
+    cvrId: string,
+    contestId: string,
+    candidateName: string
+  ) {
+    await apiClient.claimBallotForAdjudication({ cvrId });
+    (
+      await apiClient.adjudicateCvr({
+        cvrId,
+        contests: [
+          {
+            contestId,
+            adjudicatedContestOptionById: {
+              'write-in-0': {
+                type: 'write-in-option',
+                candidateName,
+                candidateType: 'write-in-candidate',
+                hasVote: true,
+              },
+            },
+          },
+        ],
+      })
+    ).assertOk(`failed to adjudicate ${contestId}`);
+  }
+
+  await adjudicate(
+    assertDefined(cvrIds[0]),
+    'governor-democratic',
+    demCandidate.name
+  );
+  await adjudicate(
+    assertDefined(cvrIds[1]),
+    'governor-republican',
+    repCandidate.name
+  );
+  await adjudicate(
+    assertDefined(cvrIds[2]),
+    'circuit-court-judge',
+    nonpartisanCandidate.name
+  );
+  await adjudicate(
+    assertDefined(cvrIds[3]),
+    'circuit-court-judge',
+    nonpartisanCandidate.name
+  );
+
+  return { demCandidate, repCandidate, nonpartisanCandidate };
 }

--- a/libs/ui/src/reports/write_in_adjudication_report.test.tsx
+++ b/libs/ui/src/reports/write_in_adjudication_report.test.tsx
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest';
 import {
   electionFamousNames2021Fixtures,
+  electionOpenPrimaryFixtures,
   readElectionTwoPartyPrimaryDefinition,
 } from '@votingworks/fixtures';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
@@ -107,6 +108,62 @@ test('primary', () => {
 
   // no other sections
   expect(screen.getAllByTestId(/write-in-tally-report-/)).toHaveLength(2);
+});
+
+test('open primary: partisan contests get party labels; nonpartisan contests get a "Nonpartisan Contests" label', () => {
+  const electionDefinition =
+    electionOpenPrimaryFixtures.readElectionDefinition();
+  render(
+    <WriteInAdjudicationReport
+      electionDefinition={electionDefinition}
+      electionPackageHash="test-election-package-hash"
+      electionWriteInSummary={{
+        contestWriteInSummaries: {
+          'governor-democratic': {
+            contestId: 'governor-democratic',
+            totalTally: 1,
+            pendingTally: 0,
+            invalidTally: 0,
+            candidateTallies: {
+              'dem-write-in': {
+                id: 'dem-write-in',
+                name: 'Dem Write-In',
+                tally: 1,
+                isWriteIn: true,
+              },
+            },
+          },
+          'circuit-court-judge': {
+            contestId: 'circuit-court-judge',
+            totalTally: 1,
+            pendingTally: 0,
+            invalidTally: 0,
+            candidateTallies: {
+              'nonpartisan-write-in': {
+                id: 'nonpartisan-write-in',
+                name: 'Nonpartisan Write-In',
+                tally: 1,
+                isWriteIn: true,
+              },
+            },
+          },
+        },
+      }}
+      isOfficial
+      isTest={false}
+      generatedAtTime={new Date(2020, 0, 1, 0, 0, 0)}
+    />
+  );
+
+  // Democratic section labeled with party fullName.
+  const demSection = screen.getByTestId(
+    'write-in-tally-report-democratic-party'
+  );
+  within(demSection).getByText('Democratic Party');
+
+  // Nonpartisan section labeled "Nonpartisan Contests".
+  const nonpartisanSection = screen.getByTestId('write-in-tally-report-none');
+  within(nonpartisanSection).getByText('Nonpartisan Contests');
 });
 
 test('general', () => {

--- a/libs/ui/src/reports/write_in_adjudication_report.tsx
+++ b/libs/ui/src/reports/write_in_adjudication_report.tsx
@@ -69,9 +69,12 @@ export function WriteInAdjudicationReport({
       <div data-testid="write-in-tally-report">
         {relevantPartyIds.map((partyId) => {
           const partyLabel =
-            partyId &&
-            CachedElectionLookups.getPartyById(electionDefinition, partyId)
-              .fullName;
+            election.type !== 'primary'
+              ? undefined
+              : partyId
+              ? CachedElectionLookups.getPartyById(electionDefinition, partyId)
+                  .fullName
+              : 'Nonpartisan Contests';
           const partyWriteInContests = allWriteInContests.filter(
             (c) => c.partyId === partyId
           );


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Task: #8229

This PR is mainly about making the write-in adjudication report work for open primaries. The main change necessary was to make sure that write-ins for partisan contests are voided when there's crossover voting. This also impacts the tally reports, which previously incorrectly included these write-ins.

I also tweaked the report to use the "Nonpartisan Contests" section label when grouping by party like other reports do.

## Demo Video or Screenshot
Example report with one valid write-in and one write-in from a crossover voted ballot (shown as invalid)
[unofficial-full-election-write-in-adjudication-report__2026-05-13_12-44-19.pdf](https://github.com/user-attachments/files/27729925/unofficial-full-election-write-in-adjudication-report__2026-05-13_12-44-19.pdf)



## Testing Plan

Added new test coverage

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
