### PR TITLE
Avoid TOCTOU issues between reading card details and checking card PINs

### DIFF
--- a/libs/auth/src/java_card.test.ts
+++ b/libs/auth/src/java_card.test.ts
@@ -1549,6 +1549,7 @@ test('TOCTOU regression test: Card validation stashes the identity cert for use 
       cardDetails: { user: systemAdministratorUser },
     });
   });
+  mockCardReader.transmit.assertComplete();
 
   // No card identity cert retrieval is mocked. If checkPin re-fetched the cert from the card
   // instead of using the stashed one, the mock would fail with an unexpected-call error.
@@ -1589,6 +1590,7 @@ test.each<{
     );
 
     mockCardReader.setReaderStatus(status);
+    mockCardReader.transmit.assertComplete();
 
     mockCardAppletSelectionRequest();
     await expect(javaCard.checkPin('123456')).rejects.toThrow(
@@ -1643,6 +1645,7 @@ test('TOCTOU regression test: Programming stashes the new identity cert for use 
   );
 
   await javaCard.program({ user: systemAdministratorUser, pin: '123456' });
+  mockCardReader.transmit.assertComplete();
 
   // No card identity cert retrieval is mocked. If checkPin re-fetched the cert from the card
   // instead of using the stashed one, the mock would fail with an unexpected-call error.
@@ -1686,6 +1689,7 @@ test('TOCTOU regression test: Unprogramming clears the stashed identity cert', a
   }
 
   await javaCard.unprogram();
+  mockCardReader.transmit.assertComplete();
 
   mockCardAppletSelectionRequest();
   await expect(javaCard.checkPin('123456')).rejects.toThrow(

--- a/libs/auth/src/java_card.test.ts
+++ b/libs/auth/src/java_card.test.ts
@@ -836,21 +836,22 @@ test.each<{
     expectedResponse,
   }) => {
     const javaCard = new TestJavaCard(config);
-    javaCard.setCardStatus({
-      status: 'ready',
-      cardDetails: {
-        user: electionManagerUser,
+    javaCard.setCardStatus(
+      {
+        status: 'ready',
+        cardDetails: {
+          user: electionManagerUser,
+        },
       },
-    });
+      fs.readFileSync(
+        getTestFilePath({
+          fileType: 'card-identity-cert.der',
+          cardType: 'system-administrator',
+        })
+      )
+    );
 
     mockCardAppletSelectionRequest();
-    mockCardCertRetrievalRequest(
-      CARD_IDENTITY_CERT.OBJECT_ID,
-      getTestFilePath({
-        fileType: 'card-identity-cert.der',
-        cardType: 'system-administrator',
-      })
-    );
     mockCardPinVerificationRequest('123456', cardPinVerificationRequestError);
     if (!cardPinVerificationRequestError) {
       await mockCardSignatureRequest(

--- a/libs/auth/src/java_card.test.ts
+++ b/libs/auth/src/java_card.test.ts
@@ -85,7 +85,7 @@ vi.mock(
 let mockCardReader: MockCardReader;
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
   vi.mocked(CardReader).mockImplementation((...params) => {
     mockCardReader = new MockCardReader(...params);
     return mockCardReader as unknown as CardReader;
@@ -1465,9 +1465,6 @@ test('Programming vendor card with remote key', async () => {
     fileType: 'card-identity-cert.der',
     cardType: 'vendor',
   });
-  vi.mocked(createCert).mockImplementationOnce(() =>
-    certDerToPem(fs.readFileSync(cardIdentityCertPath))
-  );
   mockCardCertStorageRequest(
     CARD_IDENTITY_CERT.OBJECT_ID,
     cardIdentityCertPath
@@ -1509,5 +1506,189 @@ Place that file in ${workingDirectory} and press enter. `
   expect(mockQuestion).toHaveBeenNthCalledWith(
     2,
     `No ${certPath} file found. Make sure that it exists and press enter to try again. `
+  );
+});
+
+test('TOCTOU regression test: Card validation stashes the identity cert for use by checkPin', async () => {
+  const javaCard = new JavaCard(config);
+
+  mockCardAppletSelectionRequest();
+  mockCardCertRetrievalRequest(
+    CARD_VX_CERT.OBJECT_ID,
+    getTestFilePath({
+      fileType: 'card-vx-cert.der',
+      cardType: 'system-administrator',
+    })
+  );
+  mockCardCertRetrievalRequest(
+    CARD_IDENTITY_CERT.OBJECT_ID,
+    getTestFilePath({
+      fileType: 'card-identity-cert.der',
+      cardType: 'system-administrator',
+    })
+  );
+  mockCardCertRetrievalRequest(
+    PROGRAMMING_MACHINE_CERT_AUTHORITY_CERT.OBJECT_ID,
+    getTestFilePath({
+      fileType: 'vx-admin-cert-authority-cert.der',
+    })
+  );
+  await mockCardSignatureRequest(
+    CARD_VX_CERT.PRIVATE_KEY_ID,
+    getTestFilePath({
+      fileType: 'card-vx-private-key.pem',
+      cardType: 'system-administrator',
+    })
+  );
+  mockCardGetNumRemainingPinAttemptsRequest(MAX_NUM_INCORRECT_PIN_ATTEMPTS);
+
+  mockCardReader.setReaderStatus('ready');
+  await waitForExpect(async () => {
+    expect(await javaCard.getCardStatus()).toEqual({
+      status: 'ready',
+      cardDetails: { user: systemAdministratorUser },
+    });
+  });
+
+  // No card identity cert retrieval is mocked. If checkPin re-fetched the cert from the card
+  // instead of using the stashed one, the mock would fail with an unexpected-call error.
+  mockCardAppletSelectionRequest();
+  mockCardPinVerificationRequest('123456');
+  await mockCardSignatureRequest(
+    CARD_IDENTITY_CERT.PRIVATE_KEY_ID,
+    getTestFilePath({
+      fileType: 'card-identity-private-key.pem',
+      cardType: 'system-administrator',
+    })
+  );
+  expect(await javaCard.checkPin('123456')).toEqual({ response: 'correct' });
+});
+
+test.each<{
+  status: 'no_card_reader' | 'no_card' | 'card_error' | 'unknown_error';
+}>([
+  { status: 'no_card_reader' },
+  { status: 'no_card' },
+  { status: 'card_error' },
+  { status: 'unknown_error' },
+])(
+  'TOCTOU regression test: Stashed card identity cert is cleared on $status transition',
+  async ({ status }) => {
+    const javaCard = new TestJavaCard(config);
+    javaCard.setCardStatus(
+      {
+        status: 'ready',
+        cardDetails: { user: systemAdministratorUser },
+      },
+      fs.readFileSync(
+        getTestFilePath({
+          fileType: 'card-identity-cert.der',
+          cardType: 'system-administrator',
+        })
+      )
+    );
+
+    mockCardReader.setReaderStatus(status);
+
+    mockCardAppletSelectionRequest();
+    await expect(javaCard.checkPin('123456')).rejects.toThrow(
+      'Card identity cert must be validated first'
+    );
+  }
+);
+
+test('TOCTOU regression test: Programming stashes the new identity cert for use by checkPin', async () => {
+  const javaCard = new JavaCard(configWithVxAdminCardProgrammingConfig);
+
+  mockCardAppletSelectionRequest();
+  mockCardCertRetrievalRequest(
+    CARD_VX_CERT.OBJECT_ID,
+    getTestFilePath({
+      fileType: 'card-vx-cert.der',
+      cardType: 'system-administrator',
+    })
+  );
+  await mockCardSignatureRequest(
+    CARD_VX_CERT.PRIVATE_KEY_ID,
+    getTestFilePath({
+      fileType: 'card-vx-private-key.pem',
+      cardType: 'system-administrator',
+    })
+  );
+  mockCardPinResetRequest('123456');
+  mockCardPinVerificationRequest('123456');
+  mockCardKeyPairGenerationRequest(
+    CARD_IDENTITY_CERT.PRIVATE_KEY_ID,
+    getTestFilePath({
+      fileType: 'card-identity-public-key.der',
+      cardType: 'system-administrator',
+    })
+  );
+  const cardIdentityCertPath = getTestFilePath({
+    fileType: 'card-identity-cert.der',
+    cardType: 'system-administrator',
+  });
+  vi.mocked(createCert).mockImplementationOnce(() =>
+    certDerToPem(fs.readFileSync(cardIdentityCertPath))
+  );
+  mockCardCertStorageRequest(
+    CARD_IDENTITY_CERT.OBJECT_ID,
+    cardIdentityCertPath
+  );
+  mockCardCertStorageRequest(
+    PROGRAMMING_MACHINE_CERT_AUTHORITY_CERT.OBJECT_ID,
+    getTestFilePath({
+      fileType: 'vx-admin-cert-authority-cert.der',
+    })
+  );
+
+  await javaCard.program({ user: systemAdministratorUser, pin: '123456' });
+
+  // No card identity cert retrieval is mocked. If checkPin re-fetched the cert from the card
+  // instead of using the stashed one, the mock would fail with an unexpected-call error.
+  mockCardAppletSelectionRequest();
+  mockCardPinVerificationRequest('123456');
+  await mockCardSignatureRequest(
+    CARD_IDENTITY_CERT.PRIVATE_KEY_ID,
+    getTestFilePath({
+      fileType: 'card-identity-private-key.pem',
+      cardType: 'system-administrator',
+    })
+  );
+  expect(await javaCard.checkPin('123456')).toEqual({ response: 'correct' });
+});
+
+test('TOCTOU regression test: Unprogramming clears the stashed identity cert', async () => {
+  const javaCard = new TestJavaCard(configWithVxAdminCardProgrammingConfig);
+  javaCard.setCardStatus(
+    {
+      status: 'ready',
+      cardDetails: { user: systemAdministratorUser },
+    },
+    fs.readFileSync(
+      getTestFilePath({
+        fileType: 'card-identity-cert.der',
+        cardType: 'system-administrator',
+      })
+    )
+  );
+
+  mockCardAppletSelectionRequest();
+  mockCardPinResetRequest(DEFAULT_PIN);
+  mockCardPutDataRequest(CARD_IDENTITY_CERT.OBJECT_ID, Buffer.of());
+  mockCardPutDataRequest(
+    PROGRAMMING_MACHINE_CERT_AUTHORITY_CERT.OBJECT_ID,
+    Buffer.of()
+  );
+  mockCardAppletSelectionRequest();
+  for (const objectId of GENERIC_STORAGE_SPACE.OBJECT_IDS) {
+    mockCardPutDataRequest(objectId, Buffer.of());
+  }
+
+  await javaCard.unprogram();
+
+  mockCardAppletSelectionRequest();
+  await expect(javaCard.checkPin('123456')).rejects.toThrow(
+    'Card identity cert must be validated first'
   );
 });

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -260,25 +260,22 @@ export class JavaCard implements Card {
 
     this.cardReader = new CardReader({
       onReaderStatusChange: async (readerStatus) => {
+        this.lastValidatedCardIdentityCert = undefined;
         switch (readerStatus) {
           case 'no_card_reader': {
             this.cardStatus = { status: 'no_card_reader' };
-            this.lastValidatedCardIdentityCert = undefined;
             return;
           }
           case 'no_card': {
             this.cardStatus = { status: 'no_card' };
-            this.lastValidatedCardIdentityCert = undefined;
             return;
           }
           case 'card_error': {
             this.cardStatus = { status: 'card_error' };
-            this.lastValidatedCardIdentityCert = undefined;
             return;
           }
           case 'unknown_error': {
             this.cardStatus = { status: 'unknown_error' };
-            this.lastValidatedCardIdentityCert = undefined;
             return;
           }
           case 'ready': {

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -8,6 +8,7 @@ import * as path from 'node:path';
 import readline from 'node:readline/promises';
 import {
   assert,
+  assertDefined,
   extractErrorMessage,
   throwIllegalValue,
 } from '@votingworks/basics';
@@ -225,10 +226,20 @@ Place that file in ${workingDirectory} and press enter. `);
 export class JavaCard implements Card {
   private readonly cardProgrammingConfig?: CardProgrammingConfig;
   private readonly cardReader: CardReader;
-  // See TestJavaCard in test/utils.ts to understand why this is protected instead of private
-  protected cardStatus: CardStatus;
   private readonly generateChallenge: () => string;
   private readonly vxCertAuthorityCertPath: string;
+
+  //
+  // See TestJavaCard in test/utils.ts to understand why the fields below are protected instead of
+  // private. Protected fields can be accessed by extensions of this class; private fields cannot.
+  //
+
+  protected cardStatus: CardStatus;
+  /**
+   * Avoid TOCTOU (time-of-check to time-of-use) issues between reading card details and checking
+   * card PINs by persisting validated card identity certs in state
+   */
+  protected lastValidatedCardIdentityCert?: Buffer;
 
   constructor(
     // Support specifying a custom config for tests
@@ -252,18 +263,22 @@ export class JavaCard implements Card {
         switch (readerStatus) {
           case 'no_card_reader': {
             this.cardStatus = { status: 'no_card_reader' };
+            this.lastValidatedCardIdentityCert = undefined;
             return;
           }
           case 'no_card': {
             this.cardStatus = { status: 'no_card' };
+            this.lastValidatedCardIdentityCert = undefined;
             return;
           }
           case 'card_error': {
             this.cardStatus = { status: 'card_error' };
+            this.lastValidatedCardIdentityCert = undefined;
             return;
           }
           case 'unknown_error': {
             this.cardStatus = { status: 'unknown_error' };
+            this.lastValidatedCardIdentityCert = undefined;
             return;
           }
           case 'ready': {
@@ -287,8 +302,9 @@ export class JavaCard implements Card {
   async checkPin(pin: string): Promise<CheckPinResponse> {
     await this.selectApplet();
 
-    const cardIdentityCert = await this.retrieveCert(
-      CARD_IDENTITY_CERT.OBJECT_ID
+    const cardIdentityCert = assertDefined(
+      this.lastValidatedCardIdentityCert,
+      'Card identity cert must be validated first'
     );
     try {
       // Verify that the card has a private key that corresponds to the public key in the card
@@ -475,6 +491,7 @@ export class JavaCard implements Card {
     }
 
     this.cardStatus = { status: 'ready', cardDetails };
+    this.lastValidatedCardIdentityCert = cardIdentityCert;
   }
 
   async unprogram(): Promise<void> {
@@ -494,6 +511,7 @@ export class JavaCard implements Card {
         reason: 'unprogrammed_or_invalid_card',
       },
     };
+    this.lastValidatedCardIdentityCert = undefined;
   }
 
   async readData(): Promise<Buffer> {
@@ -666,6 +684,8 @@ export class JavaCard implements Card {
         DEFAULT_PIN
       );
     }
+
+    this.lastValidatedCardIdentityCert = cardIdentityCert;
 
     const numIncorrectPinAttempts = cardDoesNotHavePin
       ? undefined

--- a/libs/auth/test/utils.ts
+++ b/libs/auth/test/utils.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-classes-per-file */
+import { Buffer } from 'node:buffer';
 import path from 'node:path';
 import { MockFunction, mockFunction } from '@votingworks/test-utils';
 
@@ -80,8 +81,12 @@ export function mockCardAssertComplete(mockCard: MockCard): void {
  * simplify setup for Java Card tests that require the card to be in a specific starting state
  */
 export class TestJavaCard extends JavaCard {
-  setCardStatus(cardStatus: CardStatus): void {
+  setCardStatus(
+    cardStatus: CardStatus,
+    lastValidatedCardIdentityCert?: Buffer
+  ): void {
     this.cardStatus = cardStatus;
+    this.lastValidatedCardIdentityCert = lastValidatedCardIdentityCert;
   }
 }
 


### PR DESCRIPTION
## Overview

This PR avoids TOCTOU (time-of-check to time-of-use) issues between reading card details and checking card PINs by persisting validated card identity certs in state.

## Testing Plan

- [x] Updated existing tests
- [x] Added regression tests
- [x] Manually tested that Java Card auth still works - TODO, won't merge until I do this

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [ ] ~I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~