### PR TITLE
grout: Preserve `undefined` in arrays and objects

### DIFF
--- a/libs/grout/src/serialization.test.ts
+++ b/libs/grout/src/serialization.test.ts
@@ -49,11 +49,18 @@ test('JSON serialization/deserialization', () => {
     ])
   );
   expectToBePreservedExactly(new Map([['a', new Map([['b', 2]])]]));
+  expectToBePreservedExactly(
+    new Map([
+      ['a', 1],
+      ['b', undefined],
+    ])
+  );
   // Basic sets
   expectToBePreservedExactly(new Set());
   expectToBePreservedExactly(new Set([1]));
   expectToBePreservedExactly(new Set([1, 2]));
   expectToBePreservedExactly(new Set([new Set([1, 2])]));
+  expectToBePreservedExactly(new Set([1, undefined]));
   // Nested data
   expectToBePreservedExactly({
     name: 'John',
@@ -94,18 +101,20 @@ test('JSON serialization/deserialization', () => {
   expectToBePreservedExactly(err('some error'));
   expectToBePreservedExactly(err(new Error('some error')));
 
-  function expectToBePreservedSemantically(value: any) {
-    expect(deserialize(serialize(value))).toEqual(value);
-  }
+  // JSON.parse by default removes fields with undefined values from objects,
+  // but we want exactly the same set of fields to be present.
+  expectToBePreservedExactly({ a: undefined });
+  expectToBePreservedExactly({ a: undefined, b: undefined });
+  expectToBePreservedExactly({ a: { b: undefined } });
+  expectToBePreservedExactly({ a: undefined, b: 1 });
 
-  // JSON.parse removes undefined values from objects by default. Since
-  // that's semantically equivalent in TS, we're fine with that.
-  expectToBePreservedSemantically({ a: undefined });
-  // Our serialization/deserialization for an array with an undefined value in
-  // it puts a hole in the array, which isn't strictly equal but is functionally
-  // the same.
-  expectToBePreservedSemantically([undefined]);
-  expectToBePreservedSemantically([1, undefined, 3]);
+  // JSON.parse by default converts undefined values to empty holes in arrays,
+  // but we want undefined values specifically.
+  expectToBePreservedExactly([undefined]);
+  expectToBePreservedExactly([1, undefined, 3]);
+  expectToBePreservedExactly([undefined, undefined]);
+  expectToBePreservedExactly([[undefined]]);
+  expectToBePreservedExactly({ a: [undefined] });
 
   function expectToBeRejected(value: any) {
     expect(() => serialize(value)).toThrow(/Cannot serialize value to JSON/);

--- a/libs/grout/src/serialization.ts
+++ b/libs/grout/src/serialization.ts
@@ -73,7 +73,10 @@ const undefinedTagger: Tagger<undefined, 'undefined'> = {
   tag: 'undefined',
   shouldTag: (value): value is undefined => value === undefined,
   serialize: () => 'undefined',
-  deserialize: () => undefined,
+  deserialize: () => {
+    /* istanbul ignore next - @preserve */
+    throw new Error('not used');
+  },
 };
 
 const dateTagger: Tagger<Date, string> = {
@@ -181,6 +184,11 @@ function tagValueIfNeeded(value: unknown): TaggedValue | unknown {
 }
 
 /* eslint-disable no-underscore-dangle */
+function isTaggedUndefined(value: unknown) {
+  return isTaggedValue(value) && value.__grout_type === undefinedTagger.tag;
+}
+
+/* eslint-disable no-underscore-dangle */
 function untagValueIfNeeded(value: JsonBuiltInValue): unknown {
   if (!isTaggedValue(value)) return value;
   const tagger = taggers.find((t) => t.tag === value.__grout_type);
@@ -238,5 +246,31 @@ export function serialize(rootValue: unknown): string {
  * Deserializes a value that was serialized by `serialize`.
  */
 export function deserialize(valueString: string): unknown {
-  return JSON.parse(valueString, (_key, value) => untagValueIfNeeded(value));
+  const result = JSON.parse(valueString, (_key, value) => {
+    // Since JSON doesn't support `undefined`, JSON.parse does some odd things
+    // when the reviver function returns undefined.
+    // - In an array, it replaces undefined with a "hole" in the array
+    // - In an object, it drops a field if it has an undefined value
+    // We want to preserve undefined in those cases, so we don't untag it.
+    // Instead, we untag it inside arrays/objects after parsing their values.
+    if (isTaggedUndefined(value)) return value;
+
+    const valueUntagged = untagValueIfNeeded(value);
+
+    if (isArray(valueUntagged)) {
+      for (const i of valueUntagged.keys()) {
+        if (isTaggedUndefined(valueUntagged[i])) {
+          valueUntagged[i] = undefined;
+        }
+      }
+    } else if (isPlainObject(valueUntagged)) {
+      for (const key of Object.keys(valueUntagged)) {
+        if (isTaggedUndefined(valueUntagged[key])) {
+          valueUntagged[key] = undefined;
+        }
+      }
+    }
+    return valueUntagged;
+  });
+  return isTaggedUndefined(result) ? undefined : result;
 }


### PR DESCRIPTION


## Overview

<!-- Add a link to a GitHub issue here -->
Previously, we let JSON.parse's default behavior deserialize `undefined` values in arrays as "holes" (i.e. a sparse array). This is mostly equivalent, except when it's not (e.g. `map` skips holes). Similarly, fields with undefined values in objects were getting removed, which is mostly equivalent except when it's not (e.g. calling Object.keys).

This PR adds some extra logic to work around this behavior and preserve the `undefined` values.

## Demo Video or Screenshot
N/A

## Testing Plan
Updated unit tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
