### PR TITLE
refactor: replace `chalk` with `node:util`'s `styleText`

### DIFF
--- a/apps/mark-scan/frontend/package.json
+++ b/apps/mark-scan/frontend/package.json
@@ -99,7 +99,6 @@
     "@votingworks/mark-scan-backend": "workspace:*",
     "@votingworks/monorepo-utils": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
-    "chalk": "4.1.2",
     "concurrently": "7.6.0",
     "eslint-plugin-vx": "workspace:*",
     "fetch-mock": "9.11.0",

--- a/apps/mark/frontend/package.json
+++ b/apps/mark/frontend/package.json
@@ -99,7 +99,6 @@
     "@votingworks/grout-test-utils": "workspace:*",
     "@votingworks/monorepo-utils": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
-    "chalk": "4.1.2",
     "concurrently": "7.6.0",
     "eslint-plugin-vx": "workspace:*",
     "fetch-mock": "9.11.0",

--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -45,7 +45,6 @@
     "@votingworks/utils": "workspace:*",
     "better-sqlite3": "8.2.0",
     "canvas": "2.11.2",
-    "chalk": "4.1.2",
     "debug": "4.3.4",
     "node-quirc": "^2.2.1",
     "tmp": "^0.2.1",
@@ -54,7 +53,6 @@
   "devDependencies": {
     "@napi-rs/cli": "^3.5.1",
     "@types/better-sqlite3": "7.6.3",
-    "@types/chalk": "^2.2.0",
     "@types/debug": "4.1.12",
     "@types/fs-extra": "11.0.1",
     "@types/jest-image-snapshot": "^6.4.0",

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/cli.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/cli.ts
@@ -21,10 +21,10 @@ import {
 } from '@votingworks/types';
 import { jsonStream } from '@votingworks/utils';
 import Sqlite3 from 'better-sqlite3';
-import chalk from 'chalk';
 import { promises as fs } from 'node:fs';
 import { basename, dirname, isAbsolute, join } from 'node:path';
 import { once } from 'node:stream';
+import { styleText } from 'node:util';
 import { interpret } from './interpret';
 import { InterpretedBallotCard, InterpretError } from './types';
 
@@ -35,7 +35,8 @@ interface IO {
 
 function usage(out: NodeJS.WritableStream): void {
   out.write(
-    `${chalk.bold(
+    `${styleText(
+      'bold',
       'Usage:'
     )} interpret [options] <election-definition-path> <system-settings-path> <image-path> <image-path>\n`
   );
@@ -46,7 +47,7 @@ function usage(out: NodeJS.WritableStream): void {
     `       interpret [options] <election-definition-path> <system-settings-path> <cast-vote-record-folder-path>\n`
   );
   out.write(`\n`);
-  out.write(chalk.bold(`Options:\n`));
+  out.write(styleText('bold', `Options:\n`));
   out.write('  -h, --help                Show this help text.\n');
   out.write('  -w, --write-ins           Score write-in areas.\n');
   out.write(
@@ -68,21 +69,27 @@ function usage(out: NodeJS.WritableStream): void {
     '  --minimum-detected-scale SCALE                 Reject ballots with detected scale less than SCALE.\n'
   );
   out.write(`\n`);
-  out.write(chalk.bold('Examples:\n'));
-  out.write(chalk.dim(`  # Interpret a single ballot\n`));
+  out.write(styleText('bold', 'Examples:\n'));
+  out.write(styleText('dim', `  # Interpret a single ballot\n`));
   out.write(
     `  interpret election.json system-settings.json ballot-side-a.jpeg ballot-side-b.jpeg\n`
   );
   out.write(`\n`);
-  out.write(chalk.dim(`  # Interpret all ballots in a scan workspace\n`));
+  out.write(
+    styleText('dim', `  # Interpret all ballots in a scan workspace\n`)
+  );
   out.write(`  interpret path/to/workspace\n`);
   out.write(`\n`);
-  out.write(chalk.dim(`  # Interpret specific sheets in a scan workspace\n`));
+  out.write(
+    styleText('dim', `  # Interpret specific sheets in a scan workspace\n`)
+  );
   out.write(`  interpret path/to/workspace d34d-b33f\n`);
   out.write(`\n`);
-  out.write(chalk.dim(`  # Write debug images alongside input images\n`));
   out.write(
-    chalk.dim(`  # (i.e. ballot-side-a_debug_scored_bubble_marks.png)\n`)
+    styleText('dim', `  # Write debug images alongside input images\n`)
+  );
+  out.write(
+    styleText('dim', `  # (i.e. ballot-side-a_debug_scored_bubble_marks.png)\n`)
   );
   out.write(
     `  interpret -d election.json system-settings.json ballot-side-a.jpeg ballot-side-b.jpeg\n`
@@ -118,7 +125,7 @@ function prettyPrintInterpretation({
   stdout: NodeJS.WritableStream;
   interpretedBallotCard: InterpretedBallotCard;
 }) {
-  stdout.write(`${chalk.bold('Paths:')}\n`);
+  stdout.write(`${styleText('bold', 'Paths:')}\n`);
   stdout.write(`- ${paths[0]}\n`);
   stdout.write(`- ${paths[1]}\n`);
   stdout.write(`\n`);
@@ -132,7 +139,7 @@ function prettyPrintInterpretation({
       electionDefinition.election.contests,
       (c) => c.id === contestId
     );
-    stdout.write(`${chalk.italic(contest.title)}\n`);
+    stdout.write(`${styleText('italic', contest.title)}\n`);
 
     for (const [gridPosition, scoredMark] of marks) {
       const candidate =
@@ -162,7 +169,8 @@ function prettyPrintInterpretation({
             : '✅'
         } ${
           scoredMark
-            ? chalk.dim(
+            ? styleText(
+                'dim',
                 `(${(scoredMark.fillScore * 100).toFixed(2).padStart(5)}%)`
               )
             : ''
@@ -210,7 +218,7 @@ async function interpretFiles(
   });
 
   if (result.isErr()) {
-    stderr.write(chalk.red(`Error interpreting ballot:\n`));
+    stderr.write(styleText('red', `Error interpreting ballot:\n`));
     await writeIterToStream(
       jsonStream<InterpretError>(result.err(), { compact: false }),
       stderr
@@ -413,7 +421,7 @@ async function interpretWorkspace(
   let errorCount = 0;
 
   for (const { id, frontPath, backPath } of sheets) {
-    stdout.write(`${chalk.bold('Sheet ID:')} ${id}\n`);
+    stdout.write(`${styleText('bold', 'Sheet ID:')} ${id}\n`);
 
     const correctionResult = await correctBallotImagePaths([
       frontPath,
@@ -422,7 +430,7 @@ async function interpretWorkspace(
 
     if (correctionResult.isErr()) {
       stderr.write(
-        chalk.red(`Error finding ballot images; attempted paths:\n`)
+        styleText('red', `Error finding ballot images; attempted paths:\n`)
       );
       for (const path of correctionResult.err().attemptedPaths) {
         stderr.write(`- ${path}\n`);
@@ -453,8 +461,8 @@ async function interpretWorkspace(
   }
 
   stdout.write(
-    `\n${chalk.bold('Summary:')} ${count} sheets${
-      errorCount > 0 ? `, ${chalk.red(`${errorCount} errors`)}` : ''
+    `\n${styleText('bold', 'Summary:')} ${count} sheets${
+      errorCount > 0 ? `, ${styleText('red', `${errorCount} errors`)}` : ''
     }\n`
   );
 

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/diagnostic_cli.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/diagnostic_cli.ts
@@ -1,11 +1,13 @@
-import chalk from 'chalk';
 import { promises as fs } from 'node:fs';
+import { styleText } from 'node:util';
 import { runBlankPaperDiagnostic } from './diagnostic';
 
 function usage(out: NodeJS.WritableStream): void {
-  out.write(`${chalk.bold('Usage:')} diagnostic [options] <image-path>\n`);
+  out.write(
+    `${styleText('bold', 'Usage:')} diagnostic [options] <image-path>\n`
+  );
   out.write(`\n`);
-  out.write(chalk.bold(`Options:\n`));
+  out.write(styleText('bold', `Options:\n`));
   out.write('  -h, --help       Show this help text.\n');
   out.write(
     `  -d, --debug  Output debug information (images alongside inputs).\n`
@@ -55,10 +57,10 @@ export async function main(args: string[]): Promise<number> {
       debug ? imagePath : undefined
     );
     if (didPass) {
-      stdout.write(chalk.green('PASSED'));
+      stdout.write(styleText('green', 'PASSED'));
       stdout.write(' - no significant shading detected in image\n');
     } else {
-      stdout.write(chalk.red('FAILED'));
+      stdout.write(styleText('red', 'FAILED'));
       stdout.write(' - significant shading detected in image\n');
     }
     return 0;

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -30,7 +30,6 @@
     "@votingworks/basics": "workspace:*",
     "@votingworks/types": "workspace:*",
     "buffer": "^6.0.3",
-    "chalk": "4.1.2",
     "fast-check": "2.23.2",
     "jest-diff": "^29.6.2",
     "js-sha256": "^0.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1738,9 +1738,6 @@ importers:
       '@votingworks/test-utils':
         specifier: workspace:*
         version: link:../../../libs/test-utils
-      chalk:
-        specifier: 4.1.2
-        version: 4.1.2
       concurrently:
         specifier: 7.6.0
         version: 7.6.0
@@ -2125,9 +2122,6 @@ importers:
       '@votingworks/test-utils':
         specifier: workspace:*
         version: link:../../../libs/test-utils
-      chalk:
-        specifier: 4.1.2
-        version: 4.1.2
       concurrently:
         specifier: 7.6.0
         version: 7.6.0
@@ -3634,9 +3628,6 @@ importers:
       canvas:
         specifier: 2.11.2
         version: 2.11.2
-      chalk:
-        specifier: 4.1.2
-        version: 4.1.2
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
@@ -3656,9 +3647,6 @@ importers:
       '@types/better-sqlite3':
         specifier: 7.6.3
         version: 7.6.3
-      '@types/chalk':
-        specifier: ^2.2.0
-        version: 2.2.0
       '@types/debug':
         specifier: 4.1.12
         version: 4.1.12
@@ -5344,9 +5332,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      chalk:
-        specifier: 4.1.2
-        version: 4.1.2
       fast-check:
         specifier: 2.23.2
         version: 2.23.2
@@ -13978,13 +13963,6 @@ packages:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
-
-  /@types/chalk@2.2.0:
-    resolution: {integrity: sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==}
-    deprecated: This is a stub types definition for chalk (https://github.com/chalk/chalk). chalk provides its own type definitions, so you don't need @types/chalk installed!
-    dependencies:
-      chalk: 4.1.2
-    dev: true
 
   /@types/combined-stream@1.0.3:
     resolution: {integrity: sha512-rU54Qy0+23b3xsXhBtHfx+M4lsRLllU2bnUnkS9hm3HAQ2Xt9q3QCYFxYVeaSG2mpCD8uuOGIEpcXHXDNZTa9w==}


### PR DESCRIPTION
## Overview
Removes our uses of `chalk`. It's still a transitive dependency, so it doesn't actually get removed. This is just part of a side quest I have to replace dependencies with `node:*` or Rust stdlib code.

## Demo Video or Screenshot
Styled text still works:
<img width="1355" height="706" alt="image" src="https://github.com/user-attachments/assets/b9686480-5a51-400a-9634-da9672f8f5b2" />

## Testing Plan
Tested manually as above.
