### PR TITLE
VxMark: Skip printer warning when polls are closed final

### DIFF
--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -582,7 +582,7 @@ export function AppRoot(): JSX.Element | null {
       );
     }
 
-    if (!hasPrinterAttached) {
+    if (!hasPrinterAttached && pollsState !== 'polls_closed_final') {
       return (
         <SetupPrinterPage
           isPollWorkerAuth={isPollWorkerAuth(authStatus)}

--- a/apps/mark/frontend/src/app_setup_errors.test.tsx
+++ b/apps/mark/frontend/src/app_setup_errors.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
@@ -162,6 +162,23 @@ describe('Displays setup warning messages and errors screens', () => {
 
     // expect to see election manager screen
     await screen.findByRole('heading', { name: 'Election Manager Menu' });
+  });
+
+  test('Does not show "No Printer Detected" when polls are closed final', async () => {
+    apiMock.expectGetMachineConfig();
+    apiMock.expectGetElectionRecord(electionGeneralDefinition);
+    apiMock.expectGetElectionState({
+      precinctSelection: ALL_PRECINCTS_SELECTION,
+      pollsState: 'polls_closed_final',
+    });
+    apiMock.setPrinterStatus({ connected: false });
+
+    render(<App apiClient={apiMock.mockApiClient} />);
+
+    await screen.findByRole('heading', { name: 'Polls Closed' });
+    expect(
+      screen.queryByRole('heading', { name: 'No Printer Detected' })
+    ).toBeNull();
   });
 
   test('Displays internal connection problem when Barcode Reader connection is lost', async () => {

--- a/apps/mark/frontend/src/app_setup_errors.test.tsx
+++ b/apps/mark/frontend/src/app_setup_errors.test.tsx
@@ -11,6 +11,8 @@ import { advanceTimersAndPromises } from '../test/helpers/timers';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 import { INTERNAL_HARDWARE_POLLING_INTERVAL_MS } from './api';
 
+const NO_PRINTER_DETECTED_TEXT = 'No Printer Detected';
+
 const electionGeneralDefinition = readElectionGeneralDefinition();
 
 let apiMock: ApiMock;
@@ -154,7 +156,7 @@ describe('Displays setup warning messages and errors screens', () => {
     });
     await advanceTimersAndPromises();
     // When polls are open but no cardless voter session is active, non-voter-facing message
-    await screen.findByRole('heading', { name: 'No Printer Detected' });
+    await screen.findByRole('heading', { name: NO_PRINTER_DETECTED_TEXT });
     await screen.findByText('Please ask a poll worker for help.');
 
     // Insert election manager card
@@ -177,7 +179,7 @@ describe('Displays setup warning messages and errors screens', () => {
 
     await screen.findByRole('heading', { name: 'Polls Closed' });
     expect(
-      screen.queryByRole('heading', { name: 'No Printer Detected' })
+      screen.queryByRole('heading', { name: NO_PRINTER_DETECTED_TEXT })
     ).toBeNull();
   });
 


### PR DESCRIPTION
## Overview

When polls are in the `polls_closed_final` state, VxMark no longer needs to print ballots, so the "No Printer Detected" screen is unnecessary noise. This change skips the printer check in that state and falls through to the existing "Polls Closed" insert-card screen.

The printer check still fires for `polls_open`, `polls_closed_initial`, and `polls_paused` — the latter two because we normally still want to encourage the poll worker to connect the printer in those states. We don't want a situation where the poll worker is not prompted and then, when polls are opened, they realize they have no printer.

## Testing Plan

- Added a test in `app_setup_errors.test.tsx` confirming that `polls_closed_final` + no printer shows the "Polls Closed" heading and not "No Printer Detected"
- All existing tests pass

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.