### PR TITLE
VxAdmin: Use JSON for group keys

### DIFF
--- a/apps/admin/backend/src/tabulation/card_counts.test.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.test.ts
@@ -12,9 +12,9 @@ import {
 } from '@votingworks/types';
 import {
   BooleanEnvironmentVariableName,
-  GROUP_KEY_ROOT,
   buildManualResultsFixture,
   getFeatureFlagMock,
+  getGroupKey,
   groupMapToGroupList,
 } from '@votingworks/utils';
 import { Store } from '../store';
@@ -119,54 +119,54 @@ test('tabulateScannedCardCounts - grouping', () => {
   }> = [
     // no filter case
     {
-      expected: [['root', 83]],
+      expected: [['{}', 83]],
     },
     // each group case
     {
       groupBy: { groupByBallotStyle: true },
       expected: [
-        ['root&ballotStyleGroupId=1M', 45],
-        ['root&ballotStyleGroupId=2F', 38],
+        ['{"ballotStyleGroupId":"1M"}', 45],
+        ['{"ballotStyleGroupId":"2F"}', 38],
       ],
     },
     {
       groupBy: { groupByParty: true },
       expected: [
-        ['root&partyId=0', 45],
-        ['root&partyId=1', 38],
+        ['{"partyId":"0"}', 45],
+        ['{"partyId":"1"}', 38],
       ],
     },
     {
       groupBy: { groupByBatch: true },
       expected: [
-        ['root&batchId=batch-1-1', 11],
-        ['root&batchId=batch-1-2', 17],
-        ['root&batchId=batch-2-1', 9],
-        ['root&batchId=batch-2-2', 12],
-        ['root&batchId=batch-3-1', 34],
+        ['{"batchId":"batch-1-1"}', 11],
+        ['{"batchId":"batch-1-2"}', 17],
+        ['{"batchId":"batch-2-1"}', 9],
+        ['{"batchId":"batch-2-2"}', 12],
+        ['{"batchId":"batch-3-1"}', 34],
       ],
     },
     {
       groupBy: { groupByScanner: true },
       expected: [
-        ['root&scannerId=scanner-1', 28],
-        ['root&scannerId=scanner-2', 21],
-        ['root&scannerId=scanner-3', 34],
+        ['{"scannerId":"scanner-1"}', 28],
+        ['{"scannerId":"scanner-2"}', 21],
+        ['{"scannerId":"scanner-3"}', 34],
       ],
     },
     {
       groupBy: { groupByPrecinct: true },
       expected: [
-        ['root&precinctId=precinct-1', 28],
-        ['root&precinctId=precinct-2', 55],
+        ['{"precinctId":"precinct-1"}', 28],
+        ['{"precinctId":"precinct-2"}', 55],
       ],
     },
     {
       groupBy: { groupByVotingMethod: true },
       expected: [
-        ['root&votingMethod=early_voting', 0],
-        ['root&votingMethod=precinct', 68],
-        ['root&votingMethod=absentee', 15],
+        ['{"votingMethod":"early_voting"}', 0],
+        ['{"votingMethod":"precinct"}', 68],
+        ['{"votingMethod":"absentee"}', 15],
       ],
     },
   ];
@@ -280,19 +280,19 @@ test('tabulateScannedCardCounts - groupByBatchDate', () => {
     groupBy: { groupByBatchDate: true },
   });
 
-  expect(groupedCardCounts['root&batchDate=2024-11-05']).toEqual({
+  expect(groupedCardCounts['{"batchDate":"2024-11-05"}']).toEqual({
     bmd: [25],
     hmpb: [],
   });
-  expect(groupedCardCounts['root&batchDate=2024-11-06']).toEqual({
+  expect(groupedCardCounts['{"batchDate":"2024-11-06"}']).toEqual({
     bmd: [7],
     hmpb: [],
   });
   expect(Object.values(groupedCardCounts)).toHaveLength(2);
   // Verify chronological sort order (oldest date first)
   expect(Object.keys(groupedCardCounts)).toEqual([
-    'root&batchDate=2024-11-05',
-    'root&batchDate=2024-11-06',
+    '{"batchDate":"2024-11-05"}',
+    '{"batchDate":"2024-11-06"}',
   ]);
 });
 
@@ -423,12 +423,13 @@ test('tabulateScannedCardCounts - merging card tallies', () => {
   ];
   addMockCvrFileToStore({ electionId, mockCastVoteRecordFile, store });
 
+  const groupKey = getGroupKey({}, {});
   expect(
     tabulateScannedCardCounts({
       electionId,
       election,
       store,
-    })[GROUP_KEY_ROOT]
+    })[groupKey]
   ).toEqual({
     bmd: [5],
     hmpb: [6, 7],
@@ -440,7 +441,7 @@ test('tabulateScannedCardCounts - merging card tallies', () => {
       election,
       store,
       groupBy: { groupByScanner: true },
-    })['root&scannerId=scanner-1']
+    })['{"scannerId":"scanner-1"}']
   ).toEqual({
     bmd: [5],
     hmpb: [6, 7],

--- a/apps/admin/backend/src/tabulation/card_counts.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.ts
@@ -1,6 +1,5 @@
 import { Admin, Election, Id, Tabulation } from '@votingworks/types';
 import {
-  GROUP_KEY_ROOT,
   getEmptyCardCounts,
   getGroupKey,
   groupBySupportsZeroSplits,
@@ -80,7 +79,8 @@ export function tabulateScannedCardCounts({
         cardTally,
       });
     }
-    cardCountsGroupMap[GROUP_KEY_ROOT] = cardCounts;
+    const groupKey = getGroupKey({}, {});
+    cardCountsGroupMap[groupKey] = cardCounts;
     return cardCountsGroupMap;
   }
 

--- a/apps/admin/backend/src/tabulation/full_results.test.ts
+++ b/apps/admin/backend/src/tabulation/full_results.test.ts
@@ -7,10 +7,10 @@ import {
 } from '@votingworks/fixtures';
 import {
   BooleanEnvironmentVariableName,
-  GROUP_KEY_ROOT,
   buildElectionResultsFixture,
   buildManualResultsFixture,
   getFeatureFlagMock,
+  getGroupKey,
 } from '@votingworks/utils';
 import { assert } from '@votingworks/basics';
 import {
@@ -31,6 +31,8 @@ import {
 } from '../../test/mock_cvr_file';
 import { adjudicateCvr } from '../adjudication';
 import { AdjudicatedContestOption, WriteInRecord } from '../types';
+
+const GROUP_KEY = getGroupKey({}, {});
 
 // mock SKIP_CVR_BALLOT_HASH_CHECK to allow us to use old cvr fixtures
 const featureFlagMock = getFeatureFlagMock();
@@ -202,89 +204,89 @@ test('tabulateCastVoteRecords', async () => {
   }> = [
     // no filter case
     {
-      expected: [['root', 83]],
+      expected: [['{}', 83]],
     },
     // each filter case
     {
       filter: { precinctIds: ['precinct-2'] },
-      expected: [['root', 55]],
+      expected: [['{}', 55]],
     },
     {
       filter: { scannerIds: ['scanner-2'] },
-      expected: [['root', 21]],
+      expected: [['{}', 21]],
     },
     {
       filter: { batchIds: ['batch-2-1', 'batch-3-1'] },
-      expected: [['root', 43]],
+      expected: [['{}', 43]],
     },
     {
       filter: { votingMethods: ['precinct'] },
-      expected: [['root', 68]],
+      expected: [['{}', 68]],
     },
     {
       filter: { ballotStyleGroupIds: ['1M'] as BallotStyleGroupId[] },
-      expected: [['root', 45]],
+      expected: [['{}', 45]],
     },
     {
       filter: { partyIds: ['0'] },
-      expected: [['root', 45]],
+      expected: [['{}', 45]],
     },
     // empty filter case
     {
       filter: { partyIds: [] },
-      expected: [['root', 0]],
+      expected: [['{}', 0]],
     },
     // trivial filter case
     {
       filter: { partyIds: ['0', '1'] },
-      expected: [['root', 83]],
+      expected: [['{}', 83]],
     },
     // each group case
     {
       groupBy: { groupByBallotStyle: true },
       expected: [
-        ['root&ballotStyleGroupId=1M', 45],
-        ['root&ballotStyleGroupId=2F', 38],
+        ['{"ballotStyleGroupId":"1M"}', 45],
+        ['{"ballotStyleGroupId":"2F"}', 38],
       ],
     },
     {
       groupBy: { groupByParty: true },
       expected: [
-        ['root&partyId=0', 45],
-        ['root&partyId=1', 38],
+        ['{"partyId":"0"}', 45],
+        ['{"partyId":"1"}', 38],
       ],
     },
     {
       groupBy: { groupByBatch: true },
       expected: [
-        ['root&batchId=batch-1-1', 11],
-        ['root&batchId=batch-1-2', 17],
-        ['root&batchId=batch-2-1', 9],
-        ['root&batchId=batch-2-2', 12],
-        ['root&batchId=batch-3-1', 34],
+        ['{"batchId":"batch-1-1"}', 11],
+        ['{"batchId":"batch-1-2"}', 17],
+        ['{"batchId":"batch-2-1"}', 9],
+        ['{"batchId":"batch-2-2"}', 12],
+        ['{"batchId":"batch-3-1"}', 34],
       ],
     },
     {
       groupBy: { groupByScanner: true },
       expected: [
-        ['root&scannerId=scanner-1', 28],
-        ['root&scannerId=scanner-2', 21],
-        ['root&scannerId=scanner-3', 34],
+        ['{"scannerId":"scanner-1"}', 28],
+        ['{"scannerId":"scanner-2"}', 21],
+        ['{"scannerId":"scanner-3"}', 34],
       ],
     },
     {
       groupBy: { groupByPrecinct: true },
       expected: [
-        ['root&precinctId=precinct-1', 28],
-        ['root&precinctId=precinct-2', 55],
+        ['{"precinctId":"precinct-1"}', 28],
+        ['{"precinctId":"precinct-2"}', 55],
       ],
     },
     {
       groupBy: { groupByVotingMethod: true },
       expected: [
-        ['root&votingMethod=early_voting', 0],
-        ['root&votingMethod=precinct', 68],
-        ['root&votingMethod=absentee', 15],
+        ['{"votingMethod":"early_voting"}', 0],
+        ['{"votingMethod":"precinct"}', 68],
+        ['{"votingMethod":"absentee"}', 15],
       ],
     },
   ];
@@ -324,12 +326,12 @@ test('tabulateElectionResults - includes empty groups', async () => {
     groupBy: { groupByPrecinct: true, groupByVotingMethod: true },
   });
   expect(Object.keys(groupedElectionResults)).toEqual([
-    'root&precinctId=precinct-1&votingMethod=early_voting',
-    'root&precinctId=precinct-1&votingMethod=precinct',
-    'root&precinctId=precinct-1&votingMethod=absentee',
-    'root&precinctId=precinct-2&votingMethod=early_voting',
-    'root&precinctId=precinct-2&votingMethod=precinct',
-    'root&precinctId=precinct-2&votingMethod=absentee',
+    '{"precinctId":"precinct-1","votingMethod":"early_voting"}',
+    '{"precinctId":"precinct-1","votingMethod":"precinct"}',
+    '{"precinctId":"precinct-1","votingMethod":"absentee"}',
+    '{"precinctId":"precinct-2","votingMethod":"early_voting"}',
+    '{"precinctId":"precinct-2","votingMethod":"precinct"}',
+    '{"precinctId":"precinct-2","votingMethod":"absentee"}',
   ]);
 });
 
@@ -370,7 +372,7 @@ test('tabulateElectionResults - write-in handling', async () => {
       electionId,
       store,
     })
-  )[GROUP_KEY_ROOT];
+  )[GROUP_KEY];
   assert(overallResultsPreAdjudication);
 
   const partialExpectedResultsPreAdjudication = buildElectionResultsFixture({
@@ -490,7 +492,7 @@ test('tabulateElectionResults - write-in handling', async () => {
       electionId,
       store,
     })
-  )[GROUP_KEY_ROOT];
+  )[GROUP_KEY];
   assert(overallResultsScreenWiaNoDetail);
   const partialExpectedResultsScreenWiaNoDetail = buildElectionResultsFixture({
     election,
@@ -534,7 +536,7 @@ test('tabulateElectionResults - write-in handling', async () => {
       store,
       includeWriteInAdjudicationResults: true,
     })
-  )[GROUP_KEY_ROOT];
+  )[GROUP_KEY];
   assert(overallResultsScreenWiaDetail);
 
   const partialExpectedResultsScreenWiaDetail = buildElectionResultsFixture({
@@ -633,7 +635,7 @@ test('tabulateElectionResults - write-in handling', async () => {
       includeWriteInAdjudicationResults: true,
       includeManualResults: true,
     })
-  )[GROUP_KEY_ROOT];
+  )[GROUP_KEY];
   assert(overallResultsScreenAndManualWiaDetail);
 
   const partialExpectedResultsScreenAndManualWiaDetail =
@@ -704,7 +706,7 @@ test('tabulateElectionResults - write-in handling', async () => {
       store,
       includeManualResults: true,
     })
-  )[GROUP_KEY_ROOT];
+  )[GROUP_KEY];
   assert(overallResultsScreenAndManualWiaNoDetail);
 
   const partialExpectedResultsScreenAndManualWiaNoDetail =
@@ -796,7 +798,7 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
       filter: { votingMethods: ['absentee'] },
       includeWriteInAdjudicationResults: true,
     })
-  )[GROUP_KEY_ROOT];
+  )[GROUP_KEY];
   assert(absenteeResults);
 
   const partialExpectedResults = buildElectionResultsFixture({
@@ -839,7 +841,7 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
       filter: { votingMethods: ['precinct'] },
       includeWriteInAdjudicationResults: true,
     })
-  )[GROUP_KEY_ROOT];
+  )[GROUP_KEY];
   assert(precinctResults);
 
   expect(precinctResults.cardCounts).toEqual(partialExpectedResults.cardCounts);
@@ -854,8 +856,8 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
     groupBy: { groupByVotingMethod: true },
     includeWriteInAdjudicationResults: true,
   });
-  const absenteeResultsGroup = groupedResults['root&votingMethod=absentee'];
-  const precinctResultsGroup = groupedResults['root&votingMethod=precinct'];
+  const absenteeResultsGroup = groupedResults['{"votingMethod":"absentee"}'];
+  const precinctResultsGroup = groupedResults['{"votingMethod":"precinct"}'];
   assert(absenteeResultsGroup && precinctResultsGroup);
 
   expect(absenteeResultsGroup.cardCounts).toEqual(
@@ -904,7 +906,7 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
       includeWriteInAdjudicationResults: true,
       includeManualResults: true,
     })
-  )[GROUP_KEY_ROOT];
+  )[GROUP_KEY];
   assert(absenteeResultsWithManual);
 
   const partialExpectedResultsWithManual = buildElectionResultsFixture({
@@ -951,7 +953,7 @@ test('tabulateElectionResults - group and filter by voting method', async () => 
       includeWriteInAdjudicationResults: true,
       includeManualResults: true,
     })
-  )[GROUP_KEY_ROOT];
+  )[GROUP_KEY];
   assert(precinctResultsWithManual);
 
   expect(precinctResultsWithManual.cardCounts).toEqual({

--- a/apps/admin/backend/src/tabulation/manual_results.test.ts
+++ b/apps/admin/backend/src/tabulation/manual_results.test.ts
@@ -176,24 +176,24 @@ describe('tabulateManualResults & tabulateManualBallotCounts', () => {
     }> = [
       // no filter or group case
       {
-        expected: [['root', 114]],
+        expected: [['{}', 114]],
       },
       // each filter case
       {
         filter: { precinctIds: ['precinct-1'] },
-        expected: [['root', 36]],
+        expected: [['{}', 36]],
       },
       {
         filter: { ballotStyleGroupIds: ['1M'] as BallotStyleGroupId[] },
-        expected: [['root', 47]],
+        expected: [['{}', 47]],
       },
       {
         filter: { partyIds: ['0'] },
-        expected: [['root', 47]],
+        expected: [['{}', 47]],
       },
       {
         filter: { votingMethods: ['precinct'] },
-        expected: [['root', 50]],
+        expected: [['{}', 50]],
       },
       // empty filter case
       {
@@ -203,66 +203,66 @@ describe('tabulateManualResults & tabulateManualBallotCounts', () => {
       // trivial filter case
       {
         filter: { votingMethods: ['precinct', 'absentee'] },
-        expected: [['root', 114]],
+        expected: [['{}', 114]],
       },
       // each grouping case
       {
         groupBy: { groupByBallotStyle: true },
         expected: [
-          ['root&ballotStyleGroupId=1M', 47],
-          ['root&ballotStyleGroupId=2F', 67],
+          ['{"ballotStyleGroupId":"1M"}', 47],
+          ['{"ballotStyleGroupId":"2F"}', 67],
         ],
       },
       {
         groupBy: { groupByParty: true },
         expected: [
-          ['root&partyId=0', 47],
-          ['root&partyId=1', 67],
+          ['{"partyId":"0"}', 47],
+          ['{"partyId":"1"}', 67],
         ],
       },
       {
         groupBy: { groupByPrecinct: true },
         expected: [
-          ['root&precinctId=precinct-1', 36],
-          ['root&precinctId=precinct-2', 78],
+          ['{"precinctId":"precinct-1"}', 36],
+          ['{"precinctId":"precinct-2"}', 78],
         ],
       },
       {
         groupBy: { groupByVotingMethod: true },
         expected: [
-          ['root&votingMethod=precinct', 50],
-          ['root&votingMethod=absentee', 64],
+          ['{"votingMethod":"precinct"}', 50],
+          ['{"votingMethod":"absentee"}', 64],
         ],
       },
       // composite filter & group cases
       {
         groupBy: { groupByVotingMethod: true, groupByPrecinct: true },
         expected: [
-          ['root&precinctId=precinct-1&votingMethod=precinct', 11],
-          ['root&precinctId=precinct-1&votingMethod=absentee', 25],
-          ['root&precinctId=precinct-2&votingMethod=precinct', 39],
-          ['root&precinctId=precinct-2&votingMethod=absentee', 39],
+          ['{"precinctId":"precinct-1","votingMethod":"precinct"}', 11],
+          ['{"precinctId":"precinct-1","votingMethod":"absentee"}', 25],
+          ['{"precinctId":"precinct-2","votingMethod":"precinct"}', 39],
+          ['{"precinctId":"precinct-2","votingMethod":"absentee"}', 39],
         ],
       },
       {
         filter: { ballotStyleGroupIds: ['1M'] as BallotStyleGroupId[] },
         groupBy: { groupByVotingMethod: true, groupByPrecinct: true },
         expected: [
-          ['root&precinctId=precinct-1&votingMethod=precinct', 3],
-          ['root&precinctId=precinct-1&votingMethod=absentee', 11],
-          ['root&precinctId=precinct-2&votingMethod=precinct', 18],
-          ['root&precinctId=precinct-2&votingMethod=absentee', 15],
+          ['{"precinctId":"precinct-1","votingMethod":"precinct"}', 3],
+          ['{"precinctId":"precinct-1","votingMethod":"absentee"}', 11],
+          ['{"precinctId":"precinct-2","votingMethod":"precinct"}', 18],
+          ['{"precinctId":"precinct-2","votingMethod":"absentee"}', 15],
         ],
       },
       {
         groupBy: { groupByPrecinct: true, groupByBatch: true },
         expected: [
           [
-            `root&batchId=${Tabulation.MANUAL_BATCH_ID}&precinctId=precinct-1`,
+            `{"batchId":"${Tabulation.MANUAL_BATCH_ID}","precinctId":"precinct-1"}`,
             36,
           ],
           [
-            `root&batchId=${Tabulation.MANUAL_BATCH_ID}&precinctId=precinct-2`,
+            `{"batchId":"${Tabulation.MANUAL_BATCH_ID}","precinctId":"precinct-2"}`,
             78,
           ],
         ],
@@ -271,11 +271,11 @@ describe('tabulateManualResults & tabulateManualBallotCounts', () => {
         groupBy: { groupByPrecinct: true, groupByScanner: true },
         expected: [
           [
-            `root&precinctId=precinct-1&scannerId=${Tabulation.MANUAL_SCANNER_ID}`,
+            `{"precinctId":"precinct-1","scannerId":"${Tabulation.MANUAL_SCANNER_ID}"}`,
             36,
           ],
           [
-            `root&precinctId=precinct-2&scannerId=${Tabulation.MANUAL_SCANNER_ID}`,
+            `{"precinctId":"precinct-2","scannerId":"${Tabulation.MANUAL_SCANNER_ID}"}`,
             78,
           ],
         ],

--- a/apps/admin/backend/src/tabulation/write_ins.test.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.test.ts
@@ -270,88 +270,88 @@ test('tabulateWriteInTallies', () => {
   }> = [
     // no filter case
     {
-      expected: [['root', 83, 1]],
+      expected: [['{}', 83, 1]],
     },
     // each filter case
     {
       filter: { precinctIds: ['precinct-2'] },
-      expected: [['root', 55, 1]],
+      expected: [['{}', 55, 1]],
     },
     {
       filter: { scannerIds: ['scanner-2'] },
-      expected: [['root', 21, 0]],
+      expected: [['{}', 21, 0]],
     },
     {
       filter: { batchIds: ['batch-2-1', 'batch-3-1'] },
-      expected: [['root', 43, 1]],
+      expected: [['{}', 43, 1]],
     },
     {
       filter: { votingMethods: ['precinct'] },
-      expected: [['root', 68, 1]],
+      expected: [['{}', 68, 1]],
     },
     {
       filter: { ballotStyleGroupIds: ['1M'] as BallotStyleGroupId[] },
-      expected: [['root', 45, 1]],
+      expected: [['{}', 45, 1]],
     },
     {
       filter: { partyIds: ['0'] },
-      expected: [['root', 45, 1]],
+      expected: [['{}', 45, 1]],
     },
     // empty filter case
     {
       filter: { partyIds: [] },
-      expected: [['root', 0, 0]],
+      expected: [['{}', 0, 0]],
     },
     // trivial filter case
     {
       filter: { partyIds: ['0', '1'] },
-      expected: [['root', 83, 1]],
+      expected: [['{}', 83, 1]],
     },
     // each group case
     {
       groupBy: { groupByBallotStyle: true },
       expected: [
-        ['root&ballotStyleGroupId=1M', 45, 1],
-        ['root&ballotStyleGroupId=2F', 38, 0],
+        ['{"ballotStyleGroupId":"1M"}', 45, 1],
+        ['{"ballotStyleGroupId":"2F"}', 38, 0],
       ],
     },
     {
       groupBy: { groupByParty: true },
       expected: [
-        ['root&partyId=0', 45, 1],
-        ['root&partyId=1', 38, 0],
+        ['{"partyId":"0"}', 45, 1],
+        ['{"partyId":"1"}', 38, 0],
       ],
     },
     {
       groupBy: { groupByBatch: true },
       expected: [
-        ['root&batchId=batch-1-1', 11, 0],
-        ['root&batchId=batch-1-2', 17, 0],
-        ['root&batchId=batch-2-1', 9, 0],
-        ['root&batchId=batch-2-2', 12, 0],
-        ['root&batchId=batch-3-1', 34, 1],
+        ['{"batchId":"batch-1-1"}', 11, 0],
+        ['{"batchId":"batch-1-2"}', 17, 0],
+        ['{"batchId":"batch-2-1"}', 9, 0],
+        ['{"batchId":"batch-2-2"}', 12, 0],
+        ['{"batchId":"batch-3-1"}', 34, 1],
       ],
     },
     {
       groupBy: { groupByScanner: true },
       expected: [
-        ['root&scannerId=scanner-1', 28, 0],
-        ['root&scannerId=scanner-2', 21, 0],
-        ['root&scannerId=scanner-3', 34, 1],
+        ['{"scannerId":"scanner-1"}', 28, 0],
+        ['{"scannerId":"scanner-2"}', 21, 0],
+        ['{"scannerId":"scanner-3"}', 34, 1],
       ],
     },
     {
       groupBy: { groupByPrecinct: true },
       expected: [
-        ['root&precinctId=precinct-1', 28, 0],
-        ['root&precinctId=precinct-2', 55, 1],
+        ['{"precinctId":"precinct-1"}', 28, 0],
+        ['{"precinctId":"precinct-2"}', 55, 1],
       ],
     },
     {
       groupBy: { groupByVotingMethod: true },
       expected: [
-        ['root&votingMethod=precinct', 68, 1],
-        ['root&votingMethod=absentee', 15, 0],
+        ['{"votingMethod":"precinct"}', 68, 1],
+        ['{"votingMethod":"absentee"}', 15, 0],
       ],
     },
   ];
@@ -512,7 +512,7 @@ test('tabulateWriteInTallies in qualified mode - unadjudicated qualified candida
 
   const summaries = tabulateWriteInTallies({ electionId, store });
   const contestSummary = assertDefined(
-    assertDefined(summaries['root']).contestWriteInSummaries[contestId]
+    assertDefined(summaries['{}']).contestWriteInSummaries[contestId]
   );
 
   // Both qualified candidates show up with tally: 0
@@ -595,7 +595,7 @@ test('tabulateWriteInTallies in qualified mode - preserves adjudicated tallies w
 
   const summaries = tabulateWriteInTallies({ electionId, store });
   const contestSummary = assertDefined(
-    assertDefined(summaries['root']).contestWriteInSummaries[contestId]
+    assertDefined(summaries['{}']).contestWriteInSummaries[contestId]
   );
 
   // Chimera keeps its adjudicated tally (2); Unicorn is injected with tally: 0.

--- a/apps/admin/backend/src/tabulation/write_ins.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.ts
@@ -8,7 +8,6 @@ import {
 } from '@votingworks/types';
 import {
   CachedElectionLookups,
-  GROUP_KEY_ROOT,
   extractGroupSpecifier,
   getGroupKey,
   hasCrossoverVote,
@@ -271,7 +270,8 @@ export function tabulateWriteInTallies({
         includeUnallocablePendingWriteInsAsPending,
       });
     }
-    electionWriteInSummaryGroupMap[GROUP_KEY_ROOT] = electionWriteInSummary;
+    const groupKey = getGroupKey({}, {});
+    electionWriteInSummaryGroupMap[groupKey] = electionWriteInSummary;
   } else {
     // general case, grouping results by specified group by clause
     for (const writeIn of writeIns) {

--- a/libs/utils/src/tabulation/tabulation.test.ts
+++ b/libs/utils/src/tabulation/tabulation.test.ts
@@ -26,7 +26,6 @@ import {
   getEmptyElectionResults,
   extractGroupSpecifier,
   tabulateCastVoteRecords,
-  GROUP_KEY_ROOT,
   getOfficialCandidateNameLookup,
   getEmptyManualElectionResults,
   combineManualElectionResults,
@@ -63,6 +62,8 @@ import {
   ALL_PRECINCTS_SELECTION,
   singlePrecinctSelectionFor,
 } from '../precinct_selection';
+
+const GROUP_KEY = getGroupKey({}, {});
 
 function castVoteRecordToTabulationCastVoteRecord(
   castVoteRecord: CVR.CVR
@@ -739,31 +740,31 @@ test('mapping from group keys to and from group specifiers', () => {
     precinctId: 'precinct-1',
   });
 
-  // with escaped characters
+  // with characters that need JSON escaping
   expect(
     getGroupKey(
       {
-        ballotStyleGroupId: '=\\1M&',
+        ballotStyleGroupId: '"\\1M',
         batchId: 'batch-1',
       },
       { groupByBatch: true, groupByBallotStyle: true }
     )
-  ).toEqual('root&ballotStyleGroupId=\\=\\\\1M\\&&batchId=batch-1');
+  ).toEqual('{"ballotStyleGroupId":"\\"\\\\1M","batchId":"batch-1"}');
 
   maintainsGroupSpecifier({
-    ballotStyleGroupId: '=\\1M&',
+    ballotStyleGroupId: '"\\1M',
     batchId: 'batch-1',
   });
 
   // groupByParty with undefined partyId (open primary CVRs whose party
   // can't be inferred) omits the partyId key.
-  expect(getGroupKey({}, { groupByParty: true })).toEqual('root');
+  expect(getGroupKey({}, { groupByParty: true })).toEqual('{}');
   expect(
     getGroupKey(
       { precinctId: 'precinct-1' },
       { groupByParty: true, groupByPrecinct: true }
     )
-  ).toEqual('root&precinctId=precinct-1');
+  ).toEqual('{"precinctId":"precinct-1"}');
 });
 
 type ObjectWithGroupSpecifier = {
@@ -815,9 +816,7 @@ describe('tabulateCastVoteRecords', () => {
     // empty election
     const emptyResults = await tabulateCastVoteRecords({ cvrs: [], election });
     expect(Object.values(emptyResults)).toHaveLength(1);
-    expect(emptyResults[GROUP_KEY_ROOT]).toEqual(
-      getEmptyElectionResults(election)
-    );
+    expect(emptyResults[GROUP_KEY]).toEqual(getEmptyElectionResults(election));
 
     const someMetadata = {
       ballotStyleGroupId: '1M' as BallotStyleGroupId,
@@ -880,7 +879,7 @@ describe('tabulateCastVoteRecords', () => {
         ],
         election,
       })
-    )[GROUP_KEY_ROOT];
+    )[GROUP_KEY];
 
     assert(electionResult);
     expect(electionResult).toEqual(
@@ -1015,7 +1014,7 @@ describe('tabulateCastVoteRecords', () => {
         cvrs: [multiPageCvr1Page1, singlePageCvr],
         election,
       })
-    )[GROUP_KEY_ROOT];
+    )[GROUP_KEY];
 
     assert(resultsOnlyPage1);
     // Card counts: 1 single-page BMD + 1 multi-page BMD page-1 = 2 at index 0
@@ -1050,7 +1049,7 @@ describe('tabulateCastVoteRecords', () => {
         cvrs: [multiPageCvr1Page1, multiPageCvr1Page2, singlePageCvr],
         election,
       })
-    )[GROUP_KEY_ROOT];
+    )[GROUP_KEY];
 
     assert(resultsBothPages);
     // Card counts: 1 single-page + 1 multi-page page-1 = 2 at index 0, 1 multi-page page-2 at index 1
@@ -1089,8 +1088,8 @@ describe('tabulateCastVoteRecords', () => {
     // should be two result groups of equal size, one for each ballot style'
     expect(Object.keys(resultsByBallotStyle)).toMatchObject(
       expect.arrayContaining([
-        'root&ballotStyleGroupId=1M',
-        'root&ballotStyleGroupId=2F',
+        '{"ballotStyleGroupId":"1M"}',
+        '{"ballotStyleGroupId":"2F"}',
       ])
     );
     expect(
@@ -1109,7 +1108,7 @@ describe('tabulateCastVoteRecords', () => {
 
     // should be two result groups of equal size, one for each party
     expect(Object.keys(resultsByParty)).toMatchObject(
-      expect.arrayContaining(['root&partyId=0', 'root&partyId=1'])
+      expect.arrayContaining(['{"partyId":"0"}', '{"partyId":"1"}'])
     );
     expect(
       Object.values(resultsByParty).map((results) =>
@@ -1120,11 +1119,11 @@ describe('tabulateCastVoteRecords', () => {
     // for the current election, results by party and ballot style should be identical
     // save for the identifiers
     expect(
-      resultsByBallotStyle['root&ballotStyleGroupId=1M']?.contestResults
-    ).toEqual(resultsByParty['root&partyId=0']?.contestResults);
+      resultsByBallotStyle['{"ballotStyleGroupId":"1M"}']?.contestResults
+    ).toEqual(resultsByParty['{"partyId":"0"}']?.contestResults);
     expect(
-      resultsByBallotStyle['root&ballotStyleGroupId=2F']?.contestResults
-    ).toEqual(resultsByParty['root&partyId=1']?.contestResults);
+      resultsByBallotStyle['{"ballotStyleGroupId":"2F"}']?.contestResults
+    ).toEqual(resultsByParty['{"partyId":"1"}']?.contestResults);
   });
 
   test('by batch and scanner', async () => {
@@ -1140,12 +1139,12 @@ describe('tabulateCastVoteRecords', () => {
     expect(Object.values(resultsByBatchAndScanner)).toHaveLength(1);
     const results =
       resultsByBatchAndScanner[
-        `root&batchId=9af15b336e&scannerId=${DEV_MACHINE_ID}`
+        `{"batchId":"9af15b336e","scannerId":"${DEV_MACHINE_ID}"}`
       ]!;
 
     // use ungrouped results, verified in previous test, to compare against for grouped results
     expect(results).toMatchObject(
-      (await tabulateCastVoteRecords({ cvrs, election }))[GROUP_KEY_ROOT]!
+      (await tabulateCastVoteRecords({ cvrs, election }))[GROUP_KEY]!
     );
   });
 
@@ -1168,10 +1167,10 @@ describe('tabulateCastVoteRecords', () => {
 
     expect(Object.keys(resultsByMethodAndPrecinct)).toMatchObject(
       expect.arrayContaining([
-        'root&precinctId=precinct-1&votingMethod=precinct',
-        'root&precinctId=precinct-1&votingMethod=absentee',
-        'root&precinctId=precinct-2&votingMethod=precinct',
-        'root&precinctId=precinct-2&votingMethod=absentee',
+        '{"precinctId":"precinct-1","votingMethod":"precinct"}',
+        '{"precinctId":"precinct-1","votingMethod":"absentee"}',
+        '{"precinctId":"precinct-2","votingMethod":"precinct"}',
+        '{"precinctId":"precinct-2","votingMethod":"absentee"}',
       ])
     );
 
@@ -1312,10 +1311,10 @@ describe('tabulateCastVoteRecords', () => {
 
     // keys should be ordered as the groups were passed in
     expect(Object.keys(resultsByMethodAndPrecinct)).toEqual([
-      'root&precinctId=precinct-1&votingMethod=absentee',
-      'root&precinctId=precinct-2&votingMethod=absentee',
-      'root&precinctId=precinct-1&votingMethod=precinct',
-      'root&precinctId=precinct-2&votingMethod=precinct',
+      '{"precinctId":"precinct-1","votingMethod":"absentee"}',
+      '{"precinctId":"precinct-2","votingMethod":"absentee"}',
+      '{"precinctId":"precinct-1","votingMethod":"precinct"}',
+      '{"precinctId":"precinct-2","votingMethod":"precinct"}',
     ]);
   });
 });
@@ -1346,7 +1345,7 @@ describe('open primaries', () => {
           },
         ],
       })
-    )[GROUP_KEY_ROOT];
+    )[GROUP_KEY];
     assert(results);
 
     expect(results.contestResults['governor-democratic']).toMatchObject({
@@ -1406,26 +1405,26 @@ describe('open primaries', () => {
     });
 
     expect(Object.keys(groupedResults).sort()).toEqual([
-      GROUP_KEY_ROOT,
-      `${GROUP_KEY_ROOT}&partyId=${democraticPartyId}`,
-      `${GROUP_KEY_ROOT}&partyId=${republicanPartyId}`,
+      `{"partyId":"${democraticPartyId}"}`,
+      `{"partyId":"${republicanPartyId}"}`,
+      '{}',
     ]);
     expect(
-      groupedResults[`${GROUP_KEY_ROOT}&partyId=${democraticPartyId}`]
-        ?.contestResults['governor-democratic']
+      groupedResults[`{"partyId":"${democraticPartyId}"}`]?.contestResults[
+        'governor-democratic'
+      ]
     ).toMatchObject({ ballots: 1 });
     expect(
-      groupedResults[`${GROUP_KEY_ROOT}&partyId=${republicanPartyId}`]
-        ?.contestResults['governor-republican']
+      groupedResults[`{"partyId":"${republicanPartyId}"}`]?.contestResults[
+        'governor-republican'
+      ]
     ).toMatchObject({ ballots: 1 });
     // The two CVRs with undefined partyId share the root group; their
     // partisan votes are voided (crossover) or empty, but the nonpartisan
     // ballot-measure-1 vote from the crossover ballot still tallies.
-    expect(getBallotCount(groupedResults[GROUP_KEY_ROOT]!.cardCounts)).toEqual(
-      2
-    );
+    expect(getBallotCount(groupedResults[GROUP_KEY]!.cardCounts)).toEqual(2);
     expect(
-      groupedResults[GROUP_KEY_ROOT]?.contestResults['ballot-measure-1']
+      groupedResults[GROUP_KEY]?.contestResults['ballot-measure-1']
     ).toMatchObject({ ballots: 2, yesTally: 2 });
   });
 
@@ -1444,7 +1443,7 @@ describe('open primaries', () => {
           },
         ],
       })
-    )[GROUP_KEY_ROOT];
+    )[GROUP_KEY];
     assert(results);
 
     expect(results.contestResults['governor-democratic']).toMatchObject({

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -1,9 +1,4 @@
-import {
-  assert,
-  assertDefined,
-  iter,
-  throwIllegalValue,
-} from '@votingworks/basics';
+import { assert, assertDefined, iter } from '@votingworks/basics';
 import {
   AnyContest,
   BallotStyleGroupId,
@@ -271,127 +266,34 @@ function getCastVoteRecordGroupSpecifier(
   };
 }
 
-export const GROUP_KEY_ROOT: Tabulation.GroupKey = 'root';
-type GroupKeyPartType =
-  | 'ballotStyleGroupId'
-  | 'batchDate'
-  | 'batchId'
-  | 'partyId'
-  | 'precinctId'
-  | 'scannerId'
-  | 'votingMethod';
-
-function escapeGroupKeyValue(groupKeyValue: string): string {
-  return groupKeyValue
-    .replaceAll('\\', '\\\\')
-    .replaceAll('&', '\\&')
-    .replaceAll('=', '\\=');
-}
-
-function unescapeGroupKeyValue(groupKeyValue: string): string {
-  return groupKeyValue
-    .replaceAll('\\=', '=')
-    .replaceAll('\\&', '&')
-    .replaceAll('\\\\', '\\');
-}
-
-function getGroupKeyPart(key: GroupKeyPartType, value?: string): string {
-  assert(value !== undefined);
-  return `${key}=${escapeGroupKeyValue(value)}`;
-}
-
 /**
  * Based on a group's attributes, defines a key which is used to
  * look up and uniquely identify tabulation objects within a grouping.
- *
- * Adds key parts in alphabetical order for consistency.
  */
 export function getGroupKey(
   groupSpecifier: Tabulation.GroupSpecifier,
   groupBy: Tabulation.GroupBy
 ): Tabulation.GroupKey {
-  const keyParts: string[] = [GROUP_KEY_ROOT];
-  if (groupBy.groupByBallotStyle) {
-    keyParts.push(
-      getGroupKeyPart('ballotStyleGroupId', groupSpecifier.ballotStyleGroupId)
-    );
-  }
-
-  if (groupBy.groupByBatch) {
-    keyParts.push(getGroupKeyPart('batchId', groupSpecifier.batchId));
-  }
-
-  if (groupBy.groupByBatchDate) {
-    keyParts.push(getGroupKeyPart('batchDate', groupSpecifier.batchDate));
-  }
-
-  // For open primaries, CVR.partyId might be undefined if we can't infer the
-  // voter's party (e.g. if they didn't vote for partisan contests). If so,
-  // omit the partyId from the group key to create a nonpartisan group.
-  if (groupBy.groupByParty && groupSpecifier.partyId !== undefined) {
-    keyParts.push(getGroupKeyPart('partyId', groupSpecifier.partyId));
-  }
-
-  if (groupBy.groupByPrecinct) {
-    keyParts.push(getGroupKeyPart('precinctId', groupSpecifier.precinctId));
-  }
-
-  if (groupBy.groupByScanner) {
-    keyParts.push(getGroupKeyPart('scannerId', groupSpecifier.scannerId));
-  }
-
-  if (groupBy.groupByVotingMethod) {
-    keyParts.push(getGroupKeyPart('votingMethod', groupSpecifier.votingMethod));
-  }
-
-  return keyParts.join('&');
+  const filteredGroupSpecifier: Tabulation.GroupSpecifier = {
+    ballotStyleGroupId: groupBy.groupByBallotStyle
+      ? groupSpecifier.ballotStyleGroupId
+      : undefined,
+    batchDate: groupBy.groupByBatchDate ? groupSpecifier.batchDate : undefined,
+    batchId: groupBy.groupByBatch ? groupSpecifier.batchId : undefined,
+    partyId: groupBy.groupByParty ? groupSpecifier.partyId : undefined,
+    precinctId: groupBy.groupByPrecinct ? groupSpecifier.precinctId : undefined,
+    scannerId: groupBy.groupByScanner ? groupSpecifier.scannerId : undefined,
+    votingMethod: groupBy.groupByVotingMethod
+      ? groupSpecifier.votingMethod
+      : undefined,
+  };
+  return JSON.stringify(filteredGroupSpecifier);
 }
 
 export function getGroupSpecifierFromGroupKey(
   groupKey: Tabulation.GroupKey
 ): Tabulation.GroupSpecifier {
-  const parts = groupKey.split(/(?<!\\)&/);
-  const groupSpecifier: Tabulation.GroupSpecifier = {};
-  for (const part of parts) {
-    if (part === GROUP_KEY_ROOT) {
-      continue;
-    }
-
-    const [key, escapedValue] = part.split(/(?<!\\)=/) as [
-      GroupKeyPartType,
-      string,
-    ];
-    const value = unescapeGroupKeyValue(escapedValue);
-    switch (key) {
-      case 'ballotStyleGroupId':
-        groupSpecifier.ballotStyleGroupId = unescapeGroupKeyValue(value);
-        break;
-      case 'partyId':
-        groupSpecifier.partyId = unescapeGroupKeyValue(value);
-        break;
-      case 'batchDate':
-        groupSpecifier.batchDate = unescapeGroupKeyValue(value);
-        break;
-      case 'batchId':
-        groupSpecifier.batchId = unescapeGroupKeyValue(value);
-        break;
-      case 'scannerId':
-        groupSpecifier.scannerId = unescapeGroupKeyValue(value);
-        break;
-      case 'precinctId':
-        groupSpecifier.precinctId = unescapeGroupKeyValue(value);
-        break;
-      case 'votingMethod':
-        groupSpecifier.votingMethod = unescapeGroupKeyValue(
-          value
-        ) as Tabulation.VotingMethod;
-        break;
-      /* istanbul ignore next */
-      default:
-        throwIllegalValue(key);
-    }
-  }
-  return groupSpecifier;
+  return JSON.parse(groupKey) as Tabulation.GroupSpecifier;
 }
 
 /**
@@ -452,7 +354,8 @@ export async function tabulateCastVoteRecords({
         await yieldToEventLoop();
       }
     }
-    groupedElectionResults[GROUP_KEY_ROOT] = electionResults;
+    const groupKey = getGroupKey({}, {});
+    groupedElectionResults[groupKey] = electionResults;
     return groupedElectionResults;
   }
 

--- a/libs/utils/src/tabulation/transformations.test.ts
+++ b/libs/utils/src/tabulation/transformations.test.ts
@@ -57,16 +57,16 @@ test('mergeTabulationGroups', () => {
 test('groupMapToGroupList', () => {
   expect(
     groupMapToGroupList({
-      'root&ballotStyleGroupId=1M&batchId=batch-1': {
+      '{"ballotStyleGroupId":"1M","batchId":"batch-1"}': {
         ballotCount: 1,
       },
-      'root&ballotStyleGroupId=1M&batchId=batch-2': {
+      '{"ballotStyleGroupId":"1M","batchId":"batch-2"}': {
         ballotCount: 2,
       },
-      'root&ballotStyleGroupId=2F&batchId=batch-1': {
+      '{"ballotStyleGroupId":"2F","batchId":"batch-1"}': {
         ballotCount: 3,
       },
-      'root&ballotStyleGroupId=2F&batchId=batch-2': {
+      '{"ballotStyleGroupId":"2F","batchId":"batch-2"}': {
         ballotCount: 4,
       },
     })


### PR DESCRIPTION

## Overview

<!-- Add a link to a GitHub issue here -->
As pointed out on a previous PR, the custom serialization of group keys seemed a bit unnecessary. In preparation for an upcoming change to add a custom type-safe sentinel value for "no party" groups, I realized I would have to modify this serialization to handle that special value. Change to JSON seemed like the better route overall.


## Demo Video or Screenshot
N/A

## Testing Plan
Updated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
