### PR TITLE
VxAdmin: Use sentinel value for open primary "no party" groups/filters

### DIFF
--- a/apps/admin/backend/src/app.ballot_count_report_data.test.ts
+++ b/apps/admin/backend/src/app.ballot_count_report_data.test.ts
@@ -8,7 +8,7 @@ import {
   buildManualResultsFixture,
   getFeatureFlagMock,
 } from '@votingworks/utils';
-import { BallotStyleGroupId } from '@votingworks/types';
+import { BallotStyleGroupId, Tabulation } from '@votingworks/types';
 import {
   buildTestEnvironment,
   configureMachine,
@@ -155,7 +155,7 @@ test('open primary: card counts with party inferred from votes', async () => {
   ]);
 
   // Group by party only — collapses unassigned ballots into a single
-  // partyId: undefined row (rendered as "No Party").
+  // NO_PARTY_ID row (rendered as "No Party").
   expect(
     await apiClient.getCardCounts({
       filter: {},
@@ -181,7 +181,7 @@ test('open primary: card counts with party inferred from votes', async () => {
       manual: 0,
     },
     {
-      partyId: undefined,
+      partyId: Tabulation.NO_PARTY_ID,
       bmd: [],
       hmpb: [2, 1],
       manual: 0,
@@ -220,7 +220,7 @@ test('open primary: card counts with party inferred from votes', async () => {
     },
     {
       precinctId: 'precinct-1',
-      partyId: undefined,
+      partyId: Tabulation.NO_PARTY_ID,
       bmd: [],
       hmpb: [2, 1],
       manual: 0,
@@ -248,7 +248,7 @@ test('open primary: card counts with party inferred from votes', async () => {
     },
     {
       precinctId: 'precinct-2',
-      partyId: undefined,
+      partyId: Tabulation.NO_PARTY_ID,
       bmd: [],
       hmpb: [],
       manual: 0,
@@ -287,7 +287,7 @@ test('open primary: card counts with party inferred from votes', async () => {
     },
     {
       votingMethod: 'precinct',
-      partyId: undefined,
+      partyId: Tabulation.NO_PARTY_ID,
       bmd: [],
       hmpb: [2, 1],
       manual: 0,
@@ -315,7 +315,7 @@ test('open primary: card counts with party inferred from votes', async () => {
     },
     {
       votingMethod: 'absentee',
-      partyId: undefined,
+      partyId: Tabulation.NO_PARTY_ID,
       bmd: [],
       hmpb: [],
       manual: 0,
@@ -377,7 +377,7 @@ test('open primary: card counts with party inferred from votes', async () => {
     },
     {
       ballotStyleGroupId: 'ballot-style-1',
-      partyId: undefined,
+      partyId: Tabulation.NO_PARTY_ID,
       bmd: [],
       hmpb: [2, 1],
       manual: 0,
@@ -405,7 +405,7 @@ test('open primary: card counts with party inferred from votes', async () => {
     },
     {
       ballotStyleGroupId: 'ballot-style-2',
-      partyId: undefined,
+      partyId: Tabulation.NO_PARTY_ID,
       bmd: [],
       hmpb: [],
       manual: 0,
@@ -454,7 +454,7 @@ test('open primary: card counts with party inferred from votes', async () => {
       manual: 0,
     },
     {
-      partyId: undefined,
+      partyId: Tabulation.NO_PARTY_ID,
       batchId: 'batch-1',
       batchDate: expect.any(String),
       scannerId: 'scanner-1',

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -921,8 +921,13 @@ function buildApi({
     getManualResults(
       input: ManualResultsIdentifier
     ): ManualResultsRecord | null {
+      const electionId = loadCurrentElectionIdOrThrow(workspace);
+      const {
+        electionDefinition: { election },
+      } = assertDefined(store.getElection(electionId));
       const [manualResultsRecord] = store.getManualResults({
-        electionId: loadCurrentElectionIdOrThrow(workspace),
+        election,
+        electionId,
         filter: {
           precinctIds: [input.precinctId],
           ballotStyleGroupIds: [input.ballotStyleGroupId],
@@ -935,12 +940,13 @@ function buildApi({
 
     getManualResultsMetadata(): ManualResultsMetadata[] {
       const electionId = loadCurrentElectionIdOrThrow(workspace);
-      const manualResultsRecords = store.getManualResults({
-        electionId,
-      });
       const {
         electionDefinition: { election },
       } = assertDefined(store.getElection(electionId));
+      const manualResultsRecords = store.getManualResults({
+        election,
+        electionId,
+      });
       return manualResultsRecords.map((record) => {
         const { manualResults, ...metadata } = record;
         return {

--- a/apps/admin/backend/src/exports/csv_ballot_count_report.ts
+++ b/apps/admin/backend/src/exports/csv_ballot_count_report.ts
@@ -173,7 +173,7 @@ export function* generateBallotCountReportCsv({
     })
   );
   const hasManualTallies = // has any manual tallies for entire election, not just for this export
-    store.getManualResultsMetadata({ electionId }).length > 0;
+    store.getManualResultsMetadata({ election, electionId }).length > 0;
 
   const maxSheetsPerBallot = includeSheetCounts
     ? getMaxSheetsPerBallot(election)

--- a/apps/admin/backend/src/exports/csv_shared.ts
+++ b/apps/admin/backend/src/exports/csv_shared.ts
@@ -303,7 +303,8 @@ export function getCsvMetadataRowValues({
       assertDefined(filter.partyIds)
         .map((partyId) =>
           Tabulation.isNoPartyId(partyId)
-            ? 'No Party'
+            ? /* istanbul ignore next - TODO: cover in upcoming PR for custom report builder @preserve */
+              'No Party'
             : CachedElectionLookups.getPartyById(electionDefinition, partyId)
                 .name
         )

--- a/apps/admin/backend/src/exports/csv_shared.ts
+++ b/apps/admin/backend/src/exports/csv_shared.ts
@@ -41,6 +41,8 @@ export const CSV_METADATA_ATTRIBUTE_MULTI_LABEL: Record<
   batch: 'Batches',
 };
 
+const NO_PARTY_LABEL = 'No Party';
+
 /**
  * Separator between values in compound metadata filter columns.
  */
@@ -236,7 +238,7 @@ export function getCsvMetadataRowValues({
     })();
 
     if (Tabulation.isNoPartyId(partyId)) {
-      values.push('No Party');
+      values.push(NO_PARTY_LABEL);
       values.push('');
     } else {
       values.push(
@@ -304,7 +306,7 @@ export function getCsvMetadataRowValues({
         .map((partyId) =>
           Tabulation.isNoPartyId(partyId)
             ? /* istanbul ignore next - TODO: cover in upcoming PR for custom report builder @preserve */
-              'No Party'
+              NO_PARTY_LABEL
             : CachedElectionLookups.getPartyById(electionDefinition, partyId)
                 .name
         )

--- a/apps/admin/backend/src/exports/csv_shared.ts
+++ b/apps/admin/backend/src/exports/csv_shared.ts
@@ -223,10 +223,7 @@ export function getCsvMetadataRowValues({
   ) {
     const partyId = (() => {
       if (metadataStructure.party === 'single') {
-        // In open primaries, filter.partyIds may be undefined for the section
-        // of CVRs with no party. Otherwise, there should be exactly one party
-        // ID in the filter.
-        return filter.partyIds ? assertOnlyElement(filter.partyIds) : undefined;
+        return assertOnlyElement(filter.partyIds);
       }
 
       const ballotStyleGroupId = assertOnlyElement(filter.ballotStyleGroupIds);
@@ -238,7 +235,7 @@ export function getCsvMetadataRowValues({
       );
     })();
 
-    if (partyId === undefined) {
+    if (Tabulation.isNoPartyId(partyId)) {
       values.push('No Party');
       values.push('');
     } else {
@@ -304,9 +301,11 @@ export function getCsvMetadataRowValues({
   if (metadataStructure.party === 'multi') {
     values.push(
       assertDefined(filter.partyIds)
-        .map(
-          (id) =>
-            CachedElectionLookups.getPartyById(electionDefinition, id).name
+        .map((partyId) =>
+          Tabulation.isNoPartyId(partyId)
+            ? 'No Party'
+            : CachedElectionLookups.getPartyById(electionDefinition, partyId)
+                .name
         )
         .join(CSV_MULTI_VALUE_SEPARATOR)
     );

--- a/apps/admin/backend/src/exports/csv_tally_report.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.ts
@@ -130,6 +130,7 @@ function* generateDataRows({
     });
     const contestIds = new Set(
       store.getFilteredContests({
+        election,
         electionId,
         filter: groupFilter,
       })

--- a/apps/admin/backend/src/reports/titles.test.ts
+++ b/apps/admin/backend/src/reports/titles.test.ts
@@ -111,6 +111,12 @@ test('generateTitleForReport', () => {
     ],
     [
       {
+        partyIds: [Tabulation.NO_PARTY_ID],
+      },
+      'Tally Report • No Party',
+    ],
+    [
+      {
         batchIds: ['12345678-0000-0000-0000-000000000000'],
       },
       'Tally Report • Scanner VX-00-001, Batch 1',

--- a/apps/admin/backend/src/reports/titles.ts
+++ b/apps/admin/backend/src/reports/titles.ts
@@ -118,8 +118,10 @@ export function generateTitleForReport({
     }
 
     if (partyId) {
-      return CachedElectionLookups.getPartyById(electionDefinition, partyId)
-        .fullName;
+      return Tabulation.isNoPartyId(partyId)
+        ? 'No Party'
+        : CachedElectionLookups.getPartyById(electionDefinition, partyId)
+            .fullName;
     }
 
     if (adjudicationFlag) {

--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -25,7 +25,7 @@ import {
 } from '@votingworks/printing';
 import { detectDevices, startCpuMetricsLogging } from '@votingworks/backend';
 import { useDevDockRouter } from '@votingworks/dev-dock-backend';
-import { assert, throwIllegalValue } from '@votingworks/basics';
+import { assert, assertDefined, throwIllegalValue } from '@votingworks/basics';
 import { resolve } from 'node:path';
 import { ADMIN_WORKSPACE, PEER_PORT, PORT } from './globals';
 import { createWorkspace, createClientWorkspace } from './util/workspace';
@@ -170,11 +170,17 @@ export async function start(options: StartOptions = {}): Promise<Server> {
 
       // Log election results data check at startup
       const electionId = workspace.store.getCurrentElectionId();
+      const electionRecord = electionId
+        ? assertDefined(workspace.store.getElection(electionId))
+        : undefined;
       const cvrFileEntries = electionId
         ? workspace.store.getCvrFiles(electionId)
         : [];
       const manualResults = electionId
-        ? workspace.store.getManualResults({ electionId })
+        ? workspace.store.getManualResults({
+            election: assertDefined(electionRecord).electionDefinition.election,
+            electionId,
+          })
         : [];
 
       const message =

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -304,11 +304,12 @@ test('manual results', () => {
     votingMethod,
     manualResults,
   });
-  expect(store.getManualResults({ electionId })).toMatchObject([
+  expect(store.getManualResults({ election, electionId })).toMatchObject([
     { precinctId, ballotStyleGroupId, votingMethod, manualResults },
   ]);
   expect(
     store.getManualResults({
+      election,
       electionId,
       filter: {
         precinctIds: [precinctId],
@@ -333,7 +334,7 @@ test('manual results', () => {
     votingMethod,
     manualResults: editedManualResults,
   });
-  expect(store.getManualResults({ electionId })).toMatchObject([
+  expect(store.getManualResults({ election, electionId })).toMatchObject([
     {
       precinctId,
       ballotStyleGroupId,
@@ -361,7 +362,7 @@ test('manual results', () => {
     votingMethod,
     manualResults: noWriteInManualResults,
   });
-  expect(store.getManualResults({ electionId })).toMatchObject([
+  expect(store.getManualResults({ election, electionId })).toMatchObject([
     {
       precinctId,
       ballotStyleGroupId,
@@ -373,13 +374,13 @@ test('manual results', () => {
   expect(store.getWriteInCandidates({ electionId })).toHaveLength(0);
 
   store.deleteAllManualResults({ electionId });
-  expect(store.getManualResults({ electionId })).toEqual([]);
+  expect(store.getManualResults({ election, electionId })).toEqual([]);
 });
 
 test('manual results - early_voting is a valid votingMethod', () => {
   const electionDefinition =
     electionTwoPartyPrimaryFixtures.readElectionDefinition();
-  const { electionData } = electionDefinition;
+  const { electionData, election } = electionDefinition;
 
   const store = Store.memoryStore(makeTemporaryDirectory());
   const electionId = store.addElection({
@@ -413,6 +414,7 @@ test('manual results - early_voting is a valid votingMethod', () => {
 
   expect(
     store.getManualResults({
+      election,
       electionId,
       filter: { votingMethods: ['precinct'] },
     })
@@ -422,6 +424,7 @@ test('manual results - early_voting is a valid votingMethod', () => {
 
   expect(
     store.getManualResults({
+      election,
       electionId,
       filter: { votingMethods: ['early_voting'] },
     })
@@ -658,7 +661,7 @@ describe('getFilteredContests', () => {
 
   test('no filter', () => {
     expectArrayMatch(
-      store.getFilteredContests({ electionId }),
+      store.getFilteredContests({ election, electionId }),
       election.contests.map((c) => c.id)
     );
   });
@@ -666,6 +669,7 @@ describe('getFilteredContests', () => {
   test('precinct filter', () => {
     expectArrayMatch(
       store.getFilteredContests({
+        election,
         electionId,
         filter: {
           precinctIds: ['precinct-c1-w2'],
@@ -684,6 +688,7 @@ describe('getFilteredContests', () => {
   test('ballot style filter', () => {
     expectArrayMatch(
       store.getFilteredContests({
+        election,
         electionId,
         filter: {
           ballotStyleGroupIds: ['1-Ma'] as BallotStyleGroupId[],
@@ -696,6 +701,7 @@ describe('getFilteredContests', () => {
   test('party filter', () => {
     expectArrayMatch(
       store.getFilteredContests({
+        election,
         electionId,
         filter: {
           partyIds: ['0'],
@@ -714,6 +720,7 @@ describe('getFilteredContests', () => {
   test('impossible cross-filter, no matches', () => {
     expectArrayMatch(
       store.getFilteredContests({
+        election,
         electionId,
         filter: {
           partyIds: ['0'],
@@ -727,6 +734,7 @@ describe('getFilteredContests', () => {
   test('party + ballot style cross-filter', () => {
     expectArrayMatch(
       store.getFilteredContests({
+        election,
         electionId,
         filter: {
           partyIds: ['1'],
@@ -740,6 +748,7 @@ describe('getFilteredContests', () => {
   test('party + precinct cross-filter', () => {
     expectArrayMatch(
       store.getFilteredContests({
+        election,
         electionId,
         filter: {
           partyIds: ['1'],

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -50,6 +50,7 @@ import {
   ElectionRegisteredVotersCountsSchema,
   UserRole,
   isOpenPrimary,
+  PartyId,
 } from '@votingworks/types';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, sep } from 'node:path';
@@ -137,6 +138,12 @@ function convertSqliteTimestampToIso8601(
 function asQueryPlaceholders(list: unknown[]): string {
   const questionMarks = list.map(() => '?');
   return `(${questionMarks.join(', ')})`;
+}
+
+function assertFilterDoesNotContainNoPartyId(
+  partyIds: NonNullable<Tabulation.Filter['partyIds']>
+): asserts partyIds is PartyId[] {
+  assert(!partyIds.some(Tabulation.isNoPartyId));
 }
 
 /**
@@ -752,6 +759,8 @@ export class Store implements BaseStore {
       params.push(...filter.ballotStyleGroupIds);
     }
     if (filter.partyIds) {
+      assert(!isOpenPrimary(election));
+      assertFilterDoesNotContainNoPartyId(filter.partyIds);
       whereParts.push(
         `ballot_styles.party_id in ${asQueryPlaceholders(filter.partyIds)}`
       );
@@ -850,9 +859,11 @@ export class Store implements BaseStore {
    * included on possible ballots.
    */
   getFilteredContests({
+    election,
     electionId,
     filter = {},
   }: {
+    election: Election;
     electionId: Id;
     filter?: Tabulation.Filter;
   }): ContestId[] {
@@ -867,6 +878,8 @@ export class Store implements BaseStore {
       ballotStyleParams.push(...filter.ballotStyleGroupIds);
     }
     if (filter.partyIds) {
+      assert(!isOpenPrimary(election));
+      assertFilterDoesNotContainNoPartyId(filter.partyIds);
       whereParts.push(
         `ballot_styles.party_id in ${asQueryPlaceholders(filter.partyIds)}`
       );
@@ -1451,6 +1464,7 @@ export class Store implements BaseStore {
   }
 
   private getTabulationFilterAsSql(
+    election: Election,
     electionId: Id,
     filter: Admin.ReportingFilter
   ): [whereParts: string[], params: Bindable[]] {
@@ -1467,6 +1481,8 @@ export class Store implements BaseStore {
     }
 
     if (filter.partyIds) {
+      assert(!isOpenPrimary(election));
+      assertFilterDoesNotContainNoPartyId(filter.partyIds);
       whereParts.push(
         `ballot_styles.party_id in ${asQueryPlaceholders(filter.partyIds)}`
       );
@@ -1585,6 +1601,7 @@ export class Store implements BaseStore {
     cvrId?: Id;
   }): Generator<Tabulation.CastVoteRecord> {
     const [whereParts, params] = this.getTabulationFilterAsSql(
+      election,
       electionId,
       filter
     );
@@ -1671,6 +1688,7 @@ export class Store implements BaseStore {
     }
 
     const [whereParts, params] = this.getTabulationFilterAsSql(
+      election,
       electionId,
       filter
     );
@@ -2368,6 +2386,7 @@ export class Store implements BaseStore {
     groupBy?: Tabulation.GroupBy;
   }): Generator<Tabulation.GroupOf<WriteInForTally>> {
     const [whereParts, params] = this.getTabulationFilterAsSql(
+      election,
       electionId,
       filter
     );
@@ -2864,6 +2883,7 @@ export class Store implements BaseStore {
   }
 
   private getManualResultsFilterAsSql(
+    election: Election,
     electionId: Id,
     filter: ManualResultsFilter
   ): [whereParts: string[], params: Bindable[]] {
@@ -2880,6 +2900,8 @@ export class Store implements BaseStore {
     }
 
     if (partyIds) {
+      assert(!isOpenPrimary(election));
+      assertFilterDoesNotContainNoPartyId(partyIds);
       whereParts.push(
         `ballot_styles.party_id in ${asQueryPlaceholders(partyIds)}`
       );
@@ -2906,13 +2928,16 @@ export class Store implements BaseStore {
   }
 
   getManualResults({
+    election,
     electionId,
     filter = {},
   }: {
+    election: Election;
     electionId: Id;
     filter?: ManualResultsFilter;
   }): ManualResultsRecord[] {
     const [whereParts, params] = this.getManualResultsFilterAsSql(
+      election,
       electionId,
       filter
     );
@@ -2956,13 +2981,16 @@ export class Store implements BaseStore {
   }
 
   getManualResultsMetadata({
+    election,
     electionId,
     filter = {},
   }: {
+    election: Election;
     electionId: Id;
     filter?: ManualResultsFilter;
   }): ManualResultsMetadataRecord[] {
     const [whereParts, params] = this.getManualResultsFilterAsSql(
+      election,
       electionId,
       filter
     );

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -2398,7 +2398,12 @@ export class Store implements BaseStore {
     }
 
     if (groupBy.groupByParty) {
-      selectParts.push('ballot_styles.party_id as partyId');
+      if (isOpenPrimary(election)) {
+        selectParts.push('cvrs.votes as votes');
+        selectParts.push('cvrs.adjudicated_votes as adjudicatedVotes');
+      } else {
+        selectParts.push('ballot_styles.party_id as partyId');
+      }
     }
 
     if (groupBy.groupByBatch) {
@@ -2444,16 +2449,28 @@ export class Store implements BaseStore {
           order by write_ins.id
         `,
       ...params
-    ) as Iterable<WriteInForTally & Partial<StoreCastVoteRecordAttributes>>) {
+    ) as Iterable<
+      WriteInForTally &
+        Partial<StoreCastVoteRecordAttributes> & {
+          votes: string | null;
+          adjudicatedVotes: string | null;
+        }
+    >) {
       const groupSpecifier: Tabulation.GroupSpecifier = {
         ballotStyleGroupId: groupBy.groupByBallotStyle
           ? row.ballotStyleGroupId
           : undefined,
-        partyId:
-          /* istanbul ignore next - edge case coverage needed for bad party grouping in general election */
-          groupBy.groupByParty && row.partyId !== null
-            ? row.partyId
-            : undefined,
+        partyId: groupBy.groupByParty
+          ? isOpenPrimary(election)
+            ? inferPartyFromVotes(
+                election,
+                this.applyAdjudicatedVotes({
+                  votesString: assertDefined(row.votes),
+                  adjudicatedVotesString: row.adjudicatedVotes,
+                })
+              )
+            : assertDefined(row.partyId)
+          : undefined,
         batchId: groupBy.groupByBatch ? row.batchId : undefined,
         scannerId: groupBy.groupByScanner ? row.scannerId : undefined,
         precinctId: groupBy.groupByPrecinct ? row.precinctId : undefined,

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -839,7 +839,7 @@ export class Store implements BaseStore {
       );
       return groups.flatMap((group) => [
         ...partyIds.map((partyId) => ({ ...group, partyId })),
-        { ...group, partyId: undefined },
+        { ...group, partyId: Tabulation.NO_PARTY_ID },
       ]);
     }
     return groups;

--- a/apps/admin/backend/src/tabulation/manual_results.ts
+++ b/apps/admin/backend/src/tabulation/manual_results.ts
@@ -117,6 +117,7 @@ export function tabulateManualResults({
   } = assertDefined(store.getElection(electionId));
 
   const manualResultsRecords = store.getManualResults({
+    election,
     electionId,
     filter,
   });
@@ -155,6 +156,7 @@ export function tabulateManualBallotCounts({
   const ballotStyleIdPartyIdLookup = getBallotStyleIdPartyIdLookup(election);
 
   const manualResultsMetadataRecords = store.getManualResultsMetadata({
+    election,
     electionId,
     filter,
   });

--- a/apps/admin/backend/src/tabulation/tally_reports.ts
+++ b/apps/admin/backend/src/tabulation/tally_reports.ts
@@ -1,4 +1,4 @@
-import { Admin, Id, Tabulation } from '@votingworks/types';
+import { Admin, Election, Id, Tabulation } from '@votingworks/types';
 import { assert, assertDefined } from '@votingworks/basics';
 import {
   coalesceGroupsAcrossParty,
@@ -21,16 +21,19 @@ function addContestIdsToReports<U>({
   reports,
   overallFilter,
   store,
+  election,
   electionId,
 }: {
   reports: Tabulation.GroupList<U>;
   overallFilter: Tabulation.Filter;
   store: Store;
+  election: Election;
   electionId: Id;
 }): Tabulation.GroupList<U & { contestIds: Id[] }> {
   return reports.map((report) => {
     const contestIds = store.getFilteredContests({
       electionId,
+      election,
       filter: combineGroupSpecifierAndFilter(report, overallFilter),
     });
     return {
@@ -116,6 +119,7 @@ export async function tabulateTallyReportResults(params: {
       reports: allSingleTallyReportResultsWithoutContestIds,
       overallFilter: filter,
       store,
+      election,
       electionId,
     });
   }
@@ -182,6 +186,7 @@ export async function tabulateTallyReportResults(params: {
     reports: allPartySplitReportResultsWithoutContestIds,
     overallFilter: filter,
     store,
+    election,
     electionId,
   });
 }

--- a/apps/admin/backend/src/tabulation/tally_reports.ts
+++ b/apps/admin/backend/src/tabulation/tally_reports.ts
@@ -153,10 +153,11 @@ export async function tabulateTallyReportResults(params: {
       // maintain split for card counts
       const cardCountsByParty: Admin.CardCountsByParty = reportsByParty.reduce(
         (ccByParty, partyTallyReportResults) => {
+          assert(partyTallyReportResults.partyId !== undefined);
           // In open primaries, CVRs have a partyId inferred from votes, and it
-          // may be undefined if there were no partisan contest votes. These
+          // may be NO_PARTY_ID if there were no partisan contest votes. These
           // nonpartisan-voted CVRs are excluded from cardCountsByParty.
-          if (partyTallyReportResults.partyId === undefined) {
+          if (Tabulation.isNoPartyId(partyTallyReportResults.partyId)) {
             return ccByParty;
           }
           return {

--- a/apps/design/backend/src/test_decks.ts
+++ b/apps/design/backend/src/test_decks.ts
@@ -377,7 +377,7 @@ export async function getTallyReportResults(
   const cardCountsByParty: Admin.CardCountsByParty = {};
   for (const partyElectionResults of electionResultsByParty) {
     const { partyId } = partyElectionResults;
-    assert(partyId !== undefined);
+    assert(partyId !== undefined && !Tabulation.isNoPartyId(partyId));
     cardCountsByParty[partyId] = partyElectionResults.cardCounts;
   }
 

--- a/apps/scan/backend/src/util/results.test.ts
+++ b/apps/scan/backend/src/util/results.test.ts
@@ -11,11 +11,13 @@ import {
   BallotType,
   CandidateContest,
   PartyId,
+  Tabulation,
   TEST_JURISDICTION,
   PageInterpretation,
   VotesDict,
   YesNoContest,
 } from '@votingworks/types';
+import { deepEqual } from '@votingworks/basics';
 import { Store } from '../store';
 import { makeHmpbSheet } from '../../test/helpers/shared_helpers';
 import {
@@ -207,15 +209,15 @@ test('getScannerResults groups by inferred party for an open primary', async () 
 
   const results = await getScannerResultsMemoized({ store });
 
-  function findGroup(partyId?: PartyId) {
-    return results.find((r) => r.partyId === partyId);
+  function findGroup(partyId: PartyId | Tabulation.NoPartyId) {
+    return results.find((r) => deepEqual(r.partyId, partyId));
   }
   expect(findGroup(democraticPartyId)?.cardCounts.hmpb[0]).toEqual(2);
   expect(findGroup(republicanPartyId)?.cardCounts.hmpb[0]).toEqual(1);
-  // Crossover and nonpartisan-only ballots end up in a group with no partyId.
+  // Crossover and nonpartisan-only ballots end up in the NO_PARTY_ID group.
   // Crossover ballots' partisan votes are voided, but their nonpartisan votes
   // count — both ballots' yes vote on the nonpartisan contest tally here.
-  const noPartyGroup = findGroup(undefined);
+  const noPartyGroup = findGroup(Tabulation.NO_PARTY_ID);
   expect(noPartyGroup?.cardCounts.hmpb[0]).toEqual(2);
   expect(noPartyGroup?.contestResults[nonpartisanContest.id]).toMatchObject({
     ballots: 2,

--- a/libs/types/src/tabulation.test.ts
+++ b/libs/types/src/tabulation.test.ts
@@ -14,3 +14,8 @@ test('formatBatchId returns the ID unchanged when there are no hyphens', () => {
 test('formatBatchId returns first and last segments for a two-part ID', () => {
   expect(Tabulation.formatBatchId('batch-1')).toEqual('batch-1');
 });
+
+test('isNoPartyId', () => {
+  expect(Tabulation.isNoPartyId(Tabulation.NO_PARTY_ID)).toEqual(true);
+  expect(Tabulation.isNoPartyId('some-party-id')).toEqual(false);
+});

--- a/libs/types/src/tabulation.ts
+++ b/libs/types/src/tabulation.ts
@@ -7,6 +7,7 @@ import {
   CandidateId,
   ContestId,
   ContestOptionId,
+  PartyId,
   PrecinctId,
 } from './election';
 import { Id } from './generic';
@@ -61,6 +62,22 @@ export const VOTING_METHOD_LABELS: Record<VotingMethod, string> = {
 };
 
 /**
+ * Type-safe sentinel value for grouping/filtering "No Party" ballots in open primaries.
+ * */
+export const NO_PARTY_ID = { noParty: true } as const;
+/**
+ * Type of {@link NO_PARTY_ID}, the type-safe sentinel value for
+ * grouping/filtering "No Party" ballots in open primaries.
+ */
+export type NoPartyId = typeof NO_PARTY_ID;
+/**
+ * Type guard for {@link NO_PARTY_ID}.
+ */
+export function isNoPartyId(value: PartyId | NoPartyId): value is NoPartyId {
+  return typeof value === 'object';
+}
+
+/**
  * Indicates what cast vote records to include when calculating results.
  * Omission of a filter attribute indicates *not* filtering on it at all.
  * So an empty `Filter` of `{}` would indicate including all cast
@@ -68,7 +85,7 @@ export const VOTING_METHOD_LABELS: Record<VotingMethod, string> = {
  */
 export interface Filter {
   readonly ballotStyleGroupIds?: BallotStyleGroupId[];
-  readonly partyIds?: Id[];
+  readonly partyIds?: Array<PartyId | NoPartyId>;
   readonly precinctIds?: PrecinctId[];
   readonly votingMethods?: VotingMethod[];
   readonly batchIds?: Id[];
@@ -84,7 +101,7 @@ export interface CastVoteRecordAttributes {
   readonly votingMethod: VotingMethod;
   readonly batchId: Id;
   readonly scannerId: Id;
-  readonly partyId?: Id;
+  readonly partyId?: PartyId | NoPartyId;
   readonly ballotCastingMode?: BallotCastingMode;
   readonly batchDate?: string;
 }

--- a/libs/ui/src/reports/ballot_count_report.tsx
+++ b/libs/ui/src/reports/ballot_count_report.tsx
@@ -385,8 +385,10 @@ function getCellContent({
         case 'ballot-style':
           return assertDefined(cardCounts.ballotStyleGroupId);
         case 'party': {
-          const partyId = determinePartyId(electionDefinition, cardCounts);
-          if (partyId === undefined) return 'No Party';
+          const partyId = assertDefined(
+            determinePartyId(electionDefinition, cardCounts)
+          );
+          if (Tabulation.isNoPartyId(partyId)) return 'No Party';
           return CachedElectionLookups.getPartyById(electionDefinition, partyId)
             .name;
         }

--- a/libs/ui/src/reports/custom_filter_summary.tsx
+++ b/libs/ui/src/reports/custom_filter_summary.tsx
@@ -131,10 +131,13 @@ export function CustomFilterSummary({
             {pluralize('Party', filter.partyIds.length)}:
           </Font>{' '}
           {filter.partyIds
-            .map(
-              (partyId) =>
-                CachedElectionLookups.getPartyById(electionDefinition, partyId)
-                  .fullName
+            .map((partyId) =>
+              Tabulation.isNoPartyId(partyId)
+                ? 'No Party'
+                : CachedElectionLookups.getPartyById(
+                    electionDefinition,
+                    partyId
+                  ).fullName
             )
             .join(', ')}
         </FilterDisplayRow>

--- a/libs/utils/src/ballot_styles.ts
+++ b/libs/utils/src/ballot_styles.ts
@@ -18,6 +18,7 @@ import {
   hasSplits,
   ElectionDefinition,
   Tabulation,
+  PartyId,
 } from '@votingworks/types';
 
 const ID_LANGUAGES_SEPARATOR = '_';
@@ -223,7 +224,7 @@ export function getPrecinctsAndSplitsForBallotStyle({
 export function determinePartyId<T>(
   electionDefinition: ElectionDefinition,
   group: Tabulation.GroupOf<T>
-): Optional<string> {
+): Optional<PartyId | Tabulation.NoPartyId> {
   if (group.partyId) return group.partyId;
   if (!group.ballotStyleGroupId) return undefined;
   const ballotStyleGroup = getBallotStyleGroup({

--- a/libs/utils/src/tabulation/open_primary.test.ts
+++ b/libs/utils/src/tabulation/open_primary.test.ts
@@ -5,6 +5,7 @@ import {
   readElectionOpenPrimary,
   readElectionTwoPartyPrimary,
 } from '@votingworks/fixtures';
+import { Tabulation } from '@votingworks/types';
 import {
   hasCrossoverVote,
   inferPartyFromVotes,
@@ -186,32 +187,15 @@ describe('hasCrossoverVote', () => {
 });
 
 describe('inferPartyFromVotes', () => {
-  test('undefined for general election', () => {
-    const candidateContest = generalElection.contests.find(
-      (c): c is CandidateContest => c.type === 'candidate'
-    )!;
-    expect(
-      inferPartyFromVotes(generalElection, {
-        [candidateContest.id]: [candidateContest.candidates[0]!.id],
-      })
-    ).toBeUndefined();
-  });
-
-  test('undefined for closed primary', () => {
-    expect(
-      inferPartyFromVotes(closedPrimary, {
-        'best-animal-mammal': ['horse'],
-      })
-    ).toBeUndefined();
-  });
-
-  test('undefined for open primary with no partisan votes', () => {
-    expect(inferPartyFromVotes(openPrimary, {})).toBeUndefined();
+  test('NO_PARTY_ID for open primary with no partisan votes', () => {
+    expect(inferPartyFromVotes(openPrimary, {})).toEqual(
+      Tabulation.NO_PARTY_ID
+    );
     expect(
       inferPartyFromVotes(openPrimary, {
         [nonpartisanContest.id]: [nonpartisanContest.yesOption.id],
       })
-    ).toBeUndefined();
+    ).toEqual(Tabulation.NO_PARTY_ID);
   });
 
   test('returns party for open primary single-party votes', () => {
@@ -222,12 +206,12 @@ describe('inferPartyFromVotes', () => {
     ).toEqual(democraticPartyId);
   });
 
-  test('undefined for open primary crossover votes', () => {
+  test('NO_PARTY_ID for open primary crossover votes', () => {
     expect(
       inferPartyFromVotes(openPrimary, {
         [democraticContest.id]: [democraticContest.candidates[0]!.id],
         [republicanContest.id]: [republicanContest.candidates[0]!.id],
       })
-    ).toBeUndefined();
+    ).toEqual(Tabulation.NO_PARTY_ID);
   });
 });

--- a/libs/utils/src/tabulation/open_primary.ts
+++ b/libs/utils/src/tabulation/open_primary.ts
@@ -1,4 +1,9 @@
-import { memoizeByObject, unique } from '@votingworks/basics';
+import {
+  assert,
+  assertDefined,
+  memoizeByObject,
+  unique,
+} from '@votingworks/basics';
 import {
   CandidateContest,
   Election,
@@ -51,15 +56,16 @@ export function hasCrossoverVote(
 
 /**
  * In open primary elections only, infers the voter's party from their partisan
- * contest selections. Returns undefined when the ballot has no partisan votes
+ * contest selections. Returns NO_PARTY_ID when the ballot has no partisan votes
  * or has crossover votes.
  */
 export function inferPartyFromVotes(
   election: Election,
   votes: Tabulation.Votes
-): PartyId | undefined {
-  // Short circuit to avoid doing extra work if it's not an open primary
-  if (!isOpenPrimary(election)) return undefined;
+): PartyId | Tabulation.NoPartyId {
+  assert(isOpenPrimary(election));
   const parties = votedPartyIds(election, votes);
-  return parties.length === 1 ? parties[0] : undefined;
+  return parties.length === 1
+    ? assertDefined(parties[0])
+    : Tabulation.NO_PARTY_ID;
 }

--- a/libs/utils/src/tabulation/tabulation.test.ts
+++ b/libs/utils/src/tabulation/tabulation.test.ts
@@ -20,6 +20,7 @@ import {
 } from '@votingworks/types';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { NO_PARTY_ID } from '@votingworks/types/src/tabulation';
 import {
   getBallotCount,
   getBallotStyleIdPartyIdLookup,
@@ -756,9 +757,9 @@ test('mapping from group keys to and from group specifiers', () => {
     batchId: 'batch-1',
   });
 
-  // groupByParty with undefined partyId (open primary CVRs whose party
-  // can't be inferred) omits the partyId key.
-  expect(getGroupKey({}, { groupByParty: true })).toEqual('{}');
+  expect(getGroupKey({ partyId: NO_PARTY_ID }, { groupByParty: true })).toEqual(
+    '{"partyId":{"noParty":true}}'
+  );
   expect(
     getGroupKey(
       { precinctId: 'precinct-1' },

--- a/libs/utils/src/tabulation/tabulation.test.ts
+++ b/libs/utils/src/tabulation/tabulation.test.ts
@@ -20,7 +20,6 @@ import {
 } from '@votingworks/types';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { NO_PARTY_ID } from '@votingworks/types/src/tabulation';
 import {
   getBallotCount,
   getBallotStyleIdPartyIdLookup,
@@ -757,9 +756,9 @@ test('mapping from group keys to and from group specifiers', () => {
     batchId: 'batch-1',
   });
 
-  expect(getGroupKey({ partyId: NO_PARTY_ID }, { groupByParty: true })).toEqual(
-    '{"partyId":{"noParty":true}}'
-  );
+  expect(
+    getGroupKey({ partyId: Tabulation.NO_PARTY_ID }, { groupByParty: true })
+  ).toEqual('{"partyId":{"noParty":true}}');
   expect(
     getGroupKey(
       { precinctId: 'precinct-1' },


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->
In tabulation, instead of representing open primary ballots with no inferred party by `undefined`, use a sentinel object value. We use an object instead of a string because party IDs are already strings, so this object allows the type system to ensure we handle it exhaustively.

The motivation for this change is twofold:
- It was getting confusing tracking when partyId was undefined intentionally (meaning "no party") or for other reasons
- While adding the ability to build custom reports that filter to only the "no party" ballots, I realized that we needed some way to distinguish the absence of a party filter (which is currently represented by partyId `undefined`) from filtering to "no party" ballots. While there were other ways to hack around this, being more explicit seemed best.

## Demo Video or Screenshot
N/A
## Testing Plan
Automated tests
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
