### PR TITLE
Defense-in-depth: Assert vendor card auth in backend endpoint for rebooting to vendor menu

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -1428,6 +1428,8 @@ function buildApi({
       machineId: getMachineConfig().machineId,
       codeVersion: getMachineConfig().codeVersion,
       workspacePath: workspace.path,
+      getAuthStatus: /* istanbul ignore next - @preserve */ () =>
+        auth.getAuthStatus(constructAuthMachineState(workspace.store)),
     }),
   });
 }

--- a/apps/admin/backend/src/client_app.ts
+++ b/apps/admin/backend/src/client_app.ts
@@ -381,6 +381,8 @@ function buildClientApi({
       machineId: getMachineConfig().machineId,
       codeVersion: getMachineConfig().codeVersion,
       workspacePath: workspace.path,
+      getAuthStatus: /* istanbul ignore next - @preserve */ () =>
+        auth.getAuthStatus(constructAuthMachineState(clientStore)),
     }),
   });
 }

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -400,6 +400,8 @@ function buildApi({
       machineId: getMachineConfig().machineId,
       codeVersion: getMachineConfig().codeVersion,
       workspacePath: workspace.path,
+      getAuthStatus: /* istanbul ignore next - @preserve */ () =>
+        auth.getAuthStatus(constructAuthMachineState(workspace)),
     }),
   });
 }

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -327,6 +327,8 @@ export function buildApi(
       machineId: getMachineConfig().machineId,
       codeVersion: getMachineConfig().codeVersion,
       workspacePath: workspace.path,
+      getAuthStatus: /* istanbul ignore next - @preserve */ () =>
+        auth.getAuthStatus(constructAuthMachineState(workspace)),
     }),
 
     async setPollsState(input: { pollsState: PollsState }) {

--- a/apps/mark-scan/backend/src/electrical_testing/app.ts
+++ b/apps/mark-scan/backend/src/electrical_testing/app.ts
@@ -106,6 +106,7 @@ function buildApi({
       machineId: getMachineConfig().machineId,
       codeVersion: getMachineConfig().codeVersion,
       workspacePath: workspace.path,
+      getAuthStatus: () => null,
     }),
   });
 }

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -281,6 +281,8 @@ export function buildApi(ctx: Context) {
       machineId: getMachineConfig().machineId,
       codeVersion: getMachineConfig().codeVersion,
       workspacePath: workspace.path,
+      getAuthStatus: /* istanbul ignore next - @preserve */ () =>
+        auth.getAuthStatus(constructAuthMachineState(workspace)),
     }),
 
     async printBallot(input: PrintBallotProps) {

--- a/apps/mark/backend/src/electrical_testing/app.ts
+++ b/apps/mark/backend/src/electrical_testing/app.ts
@@ -193,6 +193,7 @@ function buildApi({
       machineId: getMachineConfig().machineId,
       codeVersion: getMachineConfig().codeVersion,
       workspacePath: workspace.path,
+      getAuthStatus: () => null,
     }),
   });
 }

--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -771,6 +771,8 @@ function buildApi({ context, logger, barcodeScannerClient }: BuildAppParams) {
       machineId,
       codeVersion,
       workspacePath: workspace.path,
+      getAuthStatus: /* istanbul ignore next - @preserve */ () =>
+        auth.getAuthStatus(constructAuthMachineState(workspace)),
     }),
   } as const;
   return grout.createApi(methods, middlewares);

--- a/apps/print/backend/src/app.ts
+++ b/apps/print/backend/src/app.ts
@@ -242,6 +242,8 @@ export function buildApi(ctx: AppContext) {
       machineId: getMachineConfig().machineId,
       codeVersion: getMachineConfig().codeVersion,
       workspacePath: workspace.path,
+      getAuthStatus: /* istanbul ignore next - @preserve */ () =>
+        auth.getAuthStatus(constructAuthMachineState(workspace.store)),
     }),
 
     getBallots(input: {

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -708,6 +708,8 @@ export function buildApi({
       machineId: getMachineConfig().machineId,
       codeVersion: getMachineConfig().codeVersion,
       workspacePath: workspace.path,
+      getAuthStatus: /* istanbul ignore next - @preserve */ () =>
+        auth.getAuthStatus(constructAuthMachineState(workspace.store)),
     }),
   });
 }

--- a/apps/scan/backend/src/electrical_testing/app.ts
+++ b/apps/scan/backend/src/electrical_testing/app.ts
@@ -172,6 +172,7 @@ function buildApi({
       machineId: getMachineConfig().machineId,
       codeVersion: getMachineConfig().codeVersion,
       workspacePath: workspace.path,
+      getAuthStatus: () => null,
     }),
   });
 }

--- a/libs/backend/src/system_call/api.test.ts
+++ b/libs/backend/src/system_call/api.test.ts
@@ -5,6 +5,7 @@ import { MockUsbDrive, createMockUsbDrive } from '@votingworks/usb-drive';
 import { LogEventId, MockLogger, mockLogger } from '@votingworks/logging';
 import type { DiskSpaceSummary } from '@votingworks/utils';
 import { SystemCallApiMethods, createSystemCallApi } from './api';
+import { GetAuthStatus } from './auth';
 import { execFile } from '../exec';
 import { AudioInfo, getAudioInfo } from './get_audio_info';
 import { BatteryInfo, getBatteryInfo } from './get_battery_info';
@@ -30,8 +31,16 @@ vi.mock(import('./get_disk_space_summary.js'));
 
 const actualTimezone = process.env.TZ;
 
+const vendorUser = { role: 'vendor', jurisdiction: '*' } as const;
+const systemAdministratorUser = {
+  role: 'system_administrator',
+  jurisdiction: 'vx.test',
+  programmingMachineType: 'admin',
+} as const;
+
 let mockUsbDrive: MockUsbDrive;
 let logger: MockLogger;
+let mockGetAuthStatus: ReturnType<typeof vi.fn<GetAuthStatus>>;
 let api: SystemCallApiMethods;
 
 beforeEach(() => {
@@ -39,12 +48,20 @@ beforeEach(() => {
   (process.env.VX_CONFIG_ROOT as string) = '/vx/config';
   mockUsbDrive = createMockUsbDrive();
   logger = mockLogger({ fn: vi.fn });
+  mockGetAuthStatus = vi.fn<GetAuthStatus>(() =>
+    Promise.resolve({
+      status: 'logged_in',
+      user: vendorUser,
+      sessionExpiresAt: new Date(),
+    })
+  );
   api = createSystemCallApi({
     usbDrive: mockUsbDrive.usbDrive,
     logger,
     machineId: 'TEST-MACHINE-ID',
     codeVersion: 'TEST-CODE-VERSION',
     workspacePath: 'TEST-WORKSPACE-PATH',
+    getAuthStatus: mockGetAuthStatus,
   });
 });
 
@@ -78,6 +95,25 @@ test('rebootToVendorMenu', async () => {
     ),
     '/vx/config/app-flags',
   ]);
+});
+
+test('rebootToVendorMenu requires vendor auth', async () => {
+  mockGetAuthStatus.mockResolvedValue({
+    status: 'logged_out',
+    reason: 'no_card',
+  });
+  await expect(api.rebootToVendorMenu()).rejects.toThrow();
+  expect(logger.logAsCurrentRole).not.toHaveBeenCalled();
+  expect(execFile).not.toHaveBeenCalled();
+
+  mockGetAuthStatus.mockResolvedValue({
+    status: 'logged_in',
+    user: systemAdministratorUser,
+    sessionExpiresAt: new Date(),
+  });
+  await expect(api.rebootToVendorMenu()).rejects.toThrow();
+  expect(logger.logAsCurrentRole).not.toHaveBeenCalled();
+  expect(execFile).not.toHaveBeenCalled();
 });
 
 test('rebootToVendorMenu in dev', async () => {

--- a/libs/backend/src/system_call/api.ts
+++ b/libs/backend/src/system_call/api.ts
@@ -1,7 +1,8 @@
 import { UsbDrive } from '@votingworks/usb-drive';
-
 import { LogExportFormat, Logger, LogEventId } from '@votingworks/logging';
 import { getLowDiskSpaceWarningMessage } from '@votingworks/utils';
+
+import { GetAuthStatus } from './auth';
 import { exportLogsToUsb } from './export_logs_to_usb';
 import { rebootToVendorMenu } from './reboot_to_vendor_menu';
 import { powerDown } from './power_down';
@@ -22,12 +23,14 @@ function buildApi({
   machineId,
   codeVersion,
   workspacePath,
+  getAuthStatus,
 }: {
   usbDrive: UsbDrive;
   logger: Logger;
   machineId: string;
   codeVersion: string;
   workspacePath: string;
+  getAuthStatus: GetAuthStatus;
 }) {
   return {
     exportLogsToUsb: async (input: { format: LogExportFormat }) =>
@@ -38,7 +41,8 @@ function buildApi({
         machineId,
         codeVersion,
       }),
-    rebootToVendorMenu: async () => rebootToVendorMenu(logger),
+    rebootToVendorMenu: async () =>
+      rebootToVendorMenu({ getAuthStatus, logger }),
     powerDown: async () => powerDown(logger),
     setClock,
     getBatteryInfo: async () => getBatteryInfo({ logger }),
@@ -70,12 +74,21 @@ export function createSystemCallApi({
   machineId,
   codeVersion,
   workspacePath,
+  getAuthStatus,
 }: {
   usbDrive: UsbDrive;
   logger: Logger;
   machineId: string;
   codeVersion: string;
   workspacePath: string;
+  getAuthStatus: GetAuthStatus;
 }): SystemCallApiMethods {
-  return buildApi({ usbDrive, logger, machineId, codeVersion, workspacePath });
+  return buildApi({
+    usbDrive,
+    logger,
+    machineId,
+    codeVersion,
+    workspacePath,
+    getAuthStatus,
+  });
 }

--- a/libs/backend/src/system_call/auth.ts
+++ b/libs/backend/src/system_call/auth.ts
@@ -1,0 +1,6 @@
+import { DippedSmartCardAuth, InsertedSmartCardAuth } from '@votingworks/types';
+
+/** A type for a closure that returns the current auth status */
+export type GetAuthStatus = () => Promise<
+  DippedSmartCardAuth.AuthStatus | InsertedSmartCardAuth.AuthStatus
+> | null;

--- a/libs/backend/src/system_call/reboot_to_vendor_menu.ts
+++ b/libs/backend/src/system_call/reboot_to_vendor_menu.ts
@@ -1,13 +1,26 @@
 import path from 'node:path';
+import { assert, assertDefined } from '@votingworks/basics';
 import { LogEventId, Logger } from '@votingworks/logging';
 
 import { execFile } from '../exec';
 import { intermediateScript } from '../intermediate_scripts';
+import { GetAuthStatus } from './auth';
 
 /**
  * Reboots the machine into the vendor menu.
  */
-export async function rebootToVendorMenu(logger: Logger): Promise<void> {
+export async function rebootToVendorMenu({
+  getAuthStatus,
+  logger,
+}: {
+  getAuthStatus: GetAuthStatus;
+  logger: Logger;
+}): Promise<void> {
+  const authStatus = assertDefined(await getAuthStatus());
+  assert(
+    authStatus.status === 'logged_in' && authStatus.user.role === 'vendor'
+  );
+
   await logger.logAsCurrentRole(LogEventId.RebootMachine, {
     message: 'Vendor rebooted the machine into the vendor menu.',
   });


### PR DESCRIPTION
## Overview

As a matter of defense-in-depth, this PR asserts vendor card auth in the backend endpoint for rebooting to the vendor menu. This check is only be relevant in the event of a hypothetical kiosk breakout where an attacker is then able to make API requests outside the confines of the UI.

There's a much bigger task here to add checks to all API endpoints as a matter of defense-in-depth, but we should think through how to do that with good ergonomics. For now, I'm just adding this check to one of the more sensitive endpoints.

## Testing Plan

- [x] Updated automated tests

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [ ] ~I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~
