### PR TITLE
[VxAdminClient] add low disk space and battery warnings

### DIFF
--- a/apps/admin/frontend/src/client/client_app.tsx
+++ b/apps/admin/frontend/src/client/client_app.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
+import { BatteryLowAlert, LowDiskSpaceWarning } from '@votingworks/ui';
 import { ClientAppRoot } from './client_app_root';
 import {
   ApiClient,
@@ -27,6 +28,8 @@ export function ClientApp({
           <BrowserRouter>
             <ClientAppRoot />
             <SessionTimeLimitTracker />
+            <LowDiskSpaceWarning />
+            <BatteryLowAlert />
           </BrowserRouter>
         </QueryClientProvider>
       </SharedApiClientContext.Provider>

--- a/apps/admin/frontend/src/client/client_app_root.test.tsx
+++ b/apps/admin/frontend/src/client/client_app_root.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { cleanup } from '@testing-library/react';
+import { cleanup, within } from '@testing-library/react';
 import {
   mockElectionManagerUser,
   mockPollWorkerUser,
@@ -217,6 +217,32 @@ test('sysadmin sees settings and diagnostics tabs but not adjudication', async (
   screen.getByRole('button', { name: 'Diagnostics' });
   screen.getByRole('button', { name: 'Lock Machine' });
   expect(screen.queryByRole('button', { name: 'Adjudication' })).toBeNull();
+});
+
+test('shows low battery alert when battery is low and discharging', async () => {
+  setSystemAdminAuth();
+  apiMock.expectGetNetworkConnectionStatus('online-connected-to-host');
+  apiMock.expectGetUsbPortStatus();
+  apiMock.setBatteryInfo({ level: 0.1, discharging: true });
+  renderClientApp();
+
+  const warning = await screen.findByRole('alertdialog');
+  within(warning).getByText('Low Battery');
+});
+
+test('shows low disk space warning when disk space is low', async () => {
+  setSystemAdminAuth();
+  apiMock.expectGetNetworkConnectionStatus('online-connected-to-host');
+  apiMock.expectGetUsbPortStatus();
+  apiMock.setDiskSpaceSummary({
+    total: 100_000_000,
+    used: 99_900_000,
+    available: 100_000,
+  });
+  renderClientApp();
+
+  const warning = await screen.findByRole('alertdialog');
+  within(warning).getByText('Low Disk Space');
 });
 
 test('logout while on a ballot adjudication URL replaces it with the home route', async () => {

--- a/apps/admin/frontend/test/helpers/mock_client_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_client_api_client.ts
@@ -10,6 +10,8 @@ import {
 } from '@votingworks/types';
 import { mockUsbDriveStatus } from '@votingworks/ui';
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
+import type { BatteryInfo } from '@votingworks/backend';
+import type { DiskSpaceSummary } from '@votingworks/utils';
 import { Mock, vi } from 'vitest';
 
 type MockClientApiClient = Omit<
@@ -120,6 +122,20 @@ export function createClientApiMock(
       apiClient.getSystemSettings
         .expectRepeatedCallsWith()
         .resolves(systemSettings);
+    },
+
+    setBatteryInfo(batteryInfo?: Partial<BatteryInfo>) {
+      apiClient.getBatteryInfo.mockResolvedValue({
+        level: 0.5,
+        discharging: false,
+        ...(batteryInfo || {}),
+      });
+    },
+
+    setDiskSpaceSummary(summary?: DiskSpaceSummary) {
+      apiClient.getDiskSpaceSummary.mockResolvedValue(
+        summary ?? { total: 3, used: 2, available: 1 }
+      );
     },
   };
 }


### PR DESCRIPTION
## Overview
Closes #8413 
Missed these in the original implementation. 

## Demo Video or Screenshot
N/A

## Testing Plan
Mocked low battery and low disk space states and saw client machine render the modal 

## Checklist
- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
