### PR TITLE
VxAdmin: Disable manual tallies for open primaries

### DIFF
--- a/apps/admin/backend/src/app.manual_results.test.ts
+++ b/apps/admin/backend/src/app.manual_results.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, expect, test, vi } from 'vitest';
-import { electionTwoPartyPrimaryFixtures } from '@votingworks/fixtures';
+import {
+  electionOpenPrimaryFixtures,
+  electionTwoPartyPrimaryFixtures,
+} from '@votingworks/fixtures';
 
 import { BallotStyleGroupId, PrecinctId, Tabulation } from '@votingworks/types';
 import { buildManualResultsFixture } from '@votingworks/utils';
@@ -488,4 +491,42 @@ test('removes write-in candidates not referenced anymore', async () => {
       })
     )?.manualResults
   ).toEqual(manualResultsWithWriteInRemoved);
+});
+
+test('manual results APIs reject reads/writes for open primary elections', async () => {
+  const openPrimaryElectionDefinition =
+    electionOpenPrimaryFixtures.readElectionDefinition();
+  const { apiClient, auth } = buildTestEnvironment();
+  await configureMachine(apiClient, auth, openPrimaryElectionDefinition);
+  mockElectionManagerAuth(auth, openPrimaryElectionDefinition.election);
+
+  const identifier: ManualResultsIdentifier = {
+    precinctId: openPrimaryElectionDefinition.election.precincts[0]!.id,
+    votingMethod: 'precinct',
+    ballotStyleGroupId:
+      openPrimaryElectionDefinition.election.ballotStyles[0]!.groupId,
+  };
+
+  // Writes that would create data: asserts.
+  await expect(
+    apiClient.setManualResults({
+      ...identifier,
+      manualResults: buildManualResultsFixture({
+        election: openPrimaryElectionDefinition.election,
+        ballotCount: 1,
+        contestResultsSummaries: {},
+      }),
+    })
+  ).rejects.toThrow();
+
+  // Reads: assert too — nothing should be reading manual data on open
+  // primary since the UI is hidden and the tabulation paths short-circuit.
+  await expect(apiClient.getManualResults(identifier)).rejects.toThrow();
+  await expect(apiClient.getManualResultsMetadata()).rejects.toThrow();
+
+  // Deletes are no-ops (no data exists to delete), so they succeed silently.
+  await expect(
+    apiClient.deleteManualResults(identifier)
+  ).resolves.toBeUndefined();
+  await expect(apiClient.deleteAllManualResults()).resolves.toBeUndefined();
 });

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -16,6 +16,7 @@ import {
   Tabulation,
   convertElectionResultsReportingReportToVxManualResults,
   getContests,
+  isOpenPrimary,
 } from '@votingworks/types';
 import {
   assert,
@@ -925,6 +926,7 @@ function buildApi({
       const {
         electionDefinition: { election },
       } = assertDefined(store.getElection(electionId));
+      assert(!isOpenPrimary(election));
       const [manualResultsRecord] = store.getManualResults({
         election,
         electionId,
@@ -943,6 +945,7 @@ function buildApi({
       const {
         electionDefinition: { election },
       } = assertDefined(store.getElection(electionId));
+      assert(!isOpenPrimary(election));
       const manualResultsRecords = store.getManualResults({
         election,
         electionId,

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -2826,6 +2826,11 @@ export class Store implements BaseStore {
     electionId: Id;
     manualResults: Tabulation.ManualElectionResults;
   }): void {
+    const {
+      electionDefinition: { election },
+    } = assertDefined(this.getElection(electionId));
+    assert(!isOpenPrimary(election));
+
     const { ballotCount } = manualResults;
     const serializedContestResults = JSON.stringify(
       manualResults.contestResults

--- a/apps/admin/frontend/src/screens/tally/tally_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/tally_screen.test.tsx
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { readElectionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
+import {
+  readElectionOpenPrimaryDefinition,
+  readElectionTwoPartyPrimaryDefinition,
+} from '@votingworks/fixtures';
 
 import userEvent from '@testing-library/user-event';
 import { screen } from '../../../test/react_testing_library';
@@ -46,4 +49,32 @@ test('has tabs for CVRs and Manual Tallies', async () => {
 
   userEvent.click(screen.getByRole('tab', { name: 'Manual Tallies' }));
   await screen.findByText('No manual tallies entered.');
+});
+
+test('hides Manual Tallies tab for open primary elections', async () => {
+  apiMock.expectGetCastVoteRecordFileMode('unlocked');
+  apiMock.expectGetCastVoteRecordFiles([]);
+  renderInAppContext(<TallyScreen />, {
+    electionDefinition: readElectionOpenPrimaryDefinition(),
+    apiMock,
+    route: '/tally',
+  });
+  await screen.findByRole('heading', { name: 'Tally' });
+
+  screen.getByRole('tab', { name: 'Cast Vote Records (CVRs)' });
+  expect(
+    screen.queryByRole('tab', { name: 'Manual Tallies' })
+  ).not.toBeInTheDocument();
+});
+
+test('redirects /tally/manual to CVRs tab for open primary elections', async () => {
+  apiMock.expectGetCastVoteRecordFileMode('unlocked');
+  apiMock.expectGetCastVoteRecordFiles([]);
+  renderInAppContext(<TallyScreen />, {
+    electionDefinition: readElectionOpenPrimaryDefinition(),
+    apiMock,
+    route: '/tally/manual',
+  });
+  await screen.findByRole('heading', { name: 'Tally' });
+  await screen.findByText('No CVRs loaded.');
 });

--- a/apps/admin/frontend/src/screens/tally/tally_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/tally_screen.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useState } from 'react';
 import { isElectionManagerAuth } from '@votingworks/utils';
 import { assert } from '@votingworks/basics';
+import { isOpenPrimary } from '@votingworks/types';
 import { Button, Icons, H3, RouterTabBar } from '@votingworks/ui';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { AppContext } from '../../contexts/app_context';
@@ -21,6 +22,8 @@ export function TallyScreen(): JSX.Element | null {
     isConfirmRemoveAllResultsModalOpen,
     setIsConfirmRemoveAllResultsModalOpen,
   ] = useState(false);
+
+  const manualTalliesEnabled = !isOpenPrimary(electionDefinition.election);
 
   return (
     <React.Fragment>
@@ -47,10 +50,14 @@ export function TallyScreen(): JSX.Element | null {
               title: 'Cast Vote Records (CVRs)',
               path: routerPaths.tallyCvrs,
             },
-            {
-              title: 'Manual Tallies',
-              path: routerPaths.tallyManual,
-            },
+            ...(manualTalliesEnabled
+              ? [
+                  {
+                    title: 'Manual Tallies',
+                    path: routerPaths.tallyManual,
+                  },
+                ]
+              : []),
           ]}
         />
 
@@ -60,11 +67,13 @@ export function TallyScreen(): JSX.Element | null {
             path={routerPaths.tallyCvrs}
             component={CastVoteRecordsTab}
           />
-          <Route
-            exact
-            path={routerPaths.tallyManual}
-            component={ManualTalliesTab}
-          />
+          {manualTalliesEnabled && (
+            <Route
+              exact
+              path={routerPaths.tallyManual}
+              component={ManualTalliesTab}
+            />
+          )}
           <Redirect from={routerPaths.tally} to={routerPaths.tallyCvrs} />
         </Switch>
       </NavigationScreen>


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Manual tallies are currently entered per ballot style, but since ballot styles in open primaries contain contests for multiple parties, it wasn't so clear how to group/filter tallies by party (since manual tallies aggregate individual ballots that are each for a party). We have some ideas about how we might want to handle this in the future, but for now, we don't actually need this feature turned on, so we just disable it to simplify.

## Demo Video or Screenshot
It's a little weird to have just the single tab, but the alternative of hiding the tab bar entirely is also weird because then we don't have the "Cast Vote Records" copy anywhere on screen. I think because we'll eventually probably add the manual tallies tab back in, I'm ok with this for now.
<img width="962" height="602" alt="Screenshot 2026-05-19 at 4 08 14 PM" src="https://github.com/user-attachments/assets/6f5bba37-361e-46f3-b9cb-2e0ecc74a546" />


## Testing Plan
Updated automated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
