### PR TITLE
types: Refactor ballot metadata types

### DIFF
--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -1205,41 +1205,40 @@ export const BallotIdSchema = z
     'Ballot IDs must not start with an underscore'
   ) as unknown as z.ZodSchema<BallotId>;
 
-export interface HmpbBallotPageMetadata {
+export interface BallotMetadata {
   ballotHash: string; // a hexadecimal string
   precinctId: PrecinctId;
   ballotStyleId: BallotStyleId;
-  pageNumber: number;
   isTestMode: boolean;
   ballotType: BallotType;
+}
+export const BallotMetadataSchema = z.object({
+  ballotHash: Sha256Hash,
+  precinctId: PrecinctIdSchema,
+  ballotStyleId: BallotStyleIdSchema,
+  isTestMode: z.boolean(),
+  ballotType: BallotTypeSchema,
+}) satisfies z.ZodType<BallotMetadata>;
+
+export interface HmpbBallotPageMetadata extends BallotMetadata {
+  pageNumber: number;
   /**
    * Only used when SystemSettings.precinctScanEnableBallotAuditIds feature is enabled.
    */
   ballotAuditId?: BallotId;
 }
-export const HmpbBallotPageMetadataSchema: z.ZodSchema<HmpbBallotPageMetadata> =
-  z.object({
-    ballotHash: Sha256Hash,
-    precinctId: PrecinctIdSchema,
-    ballotStyleId: BallotStyleIdSchema,
-    pageNumber: z.number(),
-    isTestMode: z.boolean(),
-    ballotType: BallotTypeSchema,
-    ballotAuditId: BallotIdSchema.optional(),
-  });
+export const HmpbBallotPageMetadataSchema = BallotMetadataSchema.extend({
+  pageNumber: z.number(),
+  ballotAuditId: BallotIdSchema.optional(),
+}) satisfies z.ZodType<HmpbBallotPageMetadata>;
 
 /**
  * Metadata for a single page of a multi-page BMD summary ballot.
  * Used when VxMark prints ballots that span multiple pages.
  */
-export interface BmdMultiPageBallotPageMetadata {
-  ballotHash: string; // a hexadecimal string
-  precinctId: PrecinctId;
-  ballotStyleId: BallotStyleId;
+export interface BmdMultiPageBallotPageMetadata extends BallotMetadata {
   pageNumber: number;
   totalPages: number;
-  isTestMode: boolean;
-  ballotType: BallotType;
   /**
    * Required for multi-page BMD ballots to correlate pages during scanning.
    */
@@ -1249,30 +1248,14 @@ export interface BmdMultiPageBallotPageMetadata {
    */
   contestIds: ContestId[];
 }
-export const BmdMultiPageBallotPageMetadataSchema: z.ZodSchema<BmdMultiPageBallotPageMetadata> =
-  z.object({
-    ballotHash: Sha256Hash,
-    precinctId: PrecinctIdSchema,
-    ballotStyleId: BallotStyleIdSchema,
+export const BmdMultiPageBallotPageMetadataSchema = BallotMetadataSchema.extend(
+  {
     pageNumber: z.number(),
     totalPages: z.number(),
-    isTestMode: z.boolean(),
-    ballotType: BallotTypeSchema,
     ballotAuditId: BallotIdSchema,
     contestIds: z.array(ContestIdSchema),
-  });
-
-export type BallotMetadata = Omit<
-  HmpbBallotPageMetadata,
-  'pageNumber' | 'ballotAuditId'
->;
-export const BallotMetadataSchema: z.ZodSchema<BallotMetadata> = z.object({
-  ballotHash: Sha256Hash,
-  precinctId: PrecinctIdSchema,
-  ballotStyleId: BallotStyleIdSchema,
-  isTestMode: z.boolean(),
-  ballotType: BallotTypeSchema,
-});
+  }
+) satisfies z.ZodType<BmdMultiPageBallotPageMetadata>;
 
 export interface TargetShape {
   bounds: Rect;


### PR DESCRIPTION
## Overview

🤖 Co-authored with Claude Code

First of two PRs in a project to merge the single-page and multi-page BMD ballot types into a unified representation.

Rearranges the relationship between the three ballot metadata types so
that `BallotMetadata` is the shared base for the HMPB and multi-page BMD
metdata types.

Currently, `BallotMetadata` is used both as the single-page BMD metadata
type and as the generic type for "either type of ballot metadata, I
only care about the fields they have in common". This change prioritizes
the latter case, as the single case will become irrelevant when we
remove the single-page BMD metadata use case (by using the multi-page
one instead).

## Demo Video or Screenshot

N/A

## Testing Plan

Existing tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
