### PR TITLE
VxAdmin: Filter by party in custom ballot count reports

### DIFF
--- a/apps/admin/backend/src/app.ballot_count_report_csv.test.ts
+++ b/apps/admin/backend/src/app.ballot_count_report_csv.test.ts
@@ -396,3 +396,76 @@ test('open primary: groups by inferred party with a No Party row', async () => {
     ],
   });
 });
+
+test('open primary: groupByParty with No Party filter', async () => {
+  const electionDefinition =
+    electionOpenPrimaryFixtures.readElectionDefinition();
+  const { apiClient, auth, mockUsbDrive, workspace } = buildTestEnvironment();
+  const electionId = await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition
+  );
+  mockElectionManagerAuth(auth, electionDefinition.election);
+
+  await seedOpenPrimaryCvrsAndAdjudications({
+    apiClient,
+    electionId,
+    store: workspace.store,
+  });
+
+  mockUsbDrive.insertUsbDrive({});
+
+  // partyIds: [NO_PARTY_ID] — only the No Party row. 2 = the crossover and
+  // flipped-Dem HMPB sheet 1 ballots (the nonpartisan-only sheet 2 ballot
+  // is excluded from Total).
+  expect(
+    await getParsedExport({
+      apiClient,
+      mockUsbDrive,
+      filter: { partyIds: [Tabulation.NO_PARTY_ID] },
+      groupBy: { groupByParty: true },
+    })
+  ).toEqual({
+    metadata: {
+      title: 'test-file-name',
+      ballotHash: formatBallotHash(electionDefinition.ballotHash),
+    },
+    headers: ['Party', 'Party ID', 'Total'],
+    rows: [
+      {
+        Party: 'No Party',
+        'Party ID': '',
+        Total: '2',
+      },
+    ],
+  });
+
+  // partyIds: ['democratic-party', NO_PARTY_ID] — Dem + No Party rows.
+  expect(
+    await getParsedExport({
+      apiClient,
+      mockUsbDrive,
+      filter: { partyIds: ['democratic-party', Tabulation.NO_PARTY_ID] },
+      groupBy: { groupByParty: true },
+    })
+  ).toEqual({
+    metadata: {
+      title: 'test-file-name',
+      ballotHash: formatBallotHash(electionDefinition.ballotHash),
+    },
+    headers: ['Party', 'Party ID', 'Total'],
+    rows: [
+      {
+        Party: 'Democratic',
+        'Party ID': 'democratic-party',
+        Total: '4',
+      },
+      {
+        Party: 'No Party',
+        'Party ID': '',
+        Total: '2',
+      },
+    ],
+  });
+});

--- a/apps/admin/backend/src/app.ballot_count_report_data.test.ts
+++ b/apps/admin/backend/src/app.ballot_count_report_data.test.ts
@@ -464,3 +464,141 @@ test('open primary: card counts with party inferred from votes', async () => {
     },
   ]);
 });
+
+test('open primary: card counts with partyIds filter', async () => {
+  const electionDefinition =
+    electionOpenPrimaryFixtures.readElectionDefinition();
+  const { apiClient, auth, workspace } = buildTestEnvironment();
+  const electionId = await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition
+  );
+  mockElectionManagerAuth(auth, electionDefinition.election);
+
+  await seedOpenPrimaryCvrsAndAdjudications({
+    apiClient,
+    electionId,
+    store: workspace.store,
+  });
+
+  // Filter to a single party — only ballots whose inferred party matches.
+  // Dem inferred ballots: 3 HMPB sheet 1 (2 happy-path + 1 resolved crossover)
+  // + 1 BMD. Crossover ballots and the flipped-to-no-party ballot
+  // are excluded.
+  expect(
+    await apiClient.getCardCounts({
+      filter: { partyIds: ['democratic-party'] },
+      groupBy: {},
+    })
+  ).toEqual([{ bmd: [1], hmpb: [3], manual: 0 }]);
+
+  expect(
+    await apiClient.getCardCounts({
+      filter: { partyIds: ['republican-party'] },
+      groupBy: {},
+    })
+  ).toEqual([{ bmd: [], hmpb: [2], manual: 0 }]);
+
+  // Multi-party filter — union of matching ballots.
+  expect(
+    await apiClient.getCardCounts({
+      filter: { partyIds: ['democratic-party', 'libertarian-party'] },
+      groupBy: {},
+    })
+  ).toEqual([{ bmd: [2], hmpb: [3], manual: 0 }]);
+
+  // Combined with groupByPrecinct — only precinct-1 has matching ballots;
+  // precinct-2 has zero.
+  expect(
+    await apiClient.getCardCounts({
+      filter: { partyIds: ['democratic-party'] },
+      groupBy: { groupByPrecinct: true },
+    })
+  ).toEqual([
+    {
+      precinctId: 'precinct-1',
+      bmd: [1],
+      hmpb: [3],
+      manual: 0,
+    },
+    {
+      precinctId: 'precinct-2',
+      bmd: [],
+      hmpb: [],
+      manual: 0,
+    },
+  ]);
+
+  // Combined with groupByParty — the group expansion should only include the
+  // filtered party, not the full set.
+  expect(
+    await apiClient.getCardCounts({
+      filter: { partyIds: ['democratic-party'] },
+      groupBy: { groupByParty: true },
+    })
+  ).toEqual([
+    {
+      partyId: 'democratic-party',
+      bmd: [1],
+      hmpb: [3],
+      manual: 0,
+    },
+  ]);
+
+  // "No Party" filter — matches ballots with no inferred party. After
+  // adjudication, these are: 1 unresolved crossover (HMPB sheet 1) +
+  // 1 flipped-Dem (HMPB sheet 1) + 1 nonpartisan-only (HMPB sheet 2).
+  expect(
+    await apiClient.getCardCounts({
+      filter: { partyIds: [Tabulation.NO_PARTY_ID] },
+      groupBy: {},
+    })
+  ).toEqual([{ bmd: [], hmpb: [2, 1], manual: 0 }]);
+
+  // Real party + "No Party" — union of Dem (4) + No Party (3)
+  expect(
+    await apiClient.getCardCounts({
+      filter: { partyIds: ['democratic-party', Tabulation.NO_PARTY_ID] },
+      groupBy: {},
+    })
+  ).toEqual([{ bmd: [1], hmpb: [5, 1], manual: 0 }]);
+
+  // "No Party" filter combined with groupByParty — only the "No Party" group
+  // appears.
+  expect(
+    await apiClient.getCardCounts({
+      filter: { partyIds: [Tabulation.NO_PARTY_ID] },
+      groupBy: { groupByParty: true },
+    })
+  ).toEqual([
+    {
+      partyId: Tabulation.NO_PARTY_ID,
+      bmd: [],
+      hmpb: [2, 1],
+      manual: 0,
+    },
+  ]);
+
+  // Real party + "No Party" with groupByParty — both groups appear, real
+  // parties not in the filter are omitted.
+  expect(
+    await apiClient.getCardCounts({
+      filter: { partyIds: ['democratic-party', Tabulation.NO_PARTY_ID] },
+      groupBy: { groupByParty: true },
+    })
+  ).toEqual([
+    {
+      partyId: 'democratic-party',
+      bmd: [1],
+      hmpb: [3],
+      manual: 0,
+    },
+    {
+      partyId: Tabulation.NO_PARTY_ID,
+      bmd: [],
+      hmpb: [2, 1],
+      manual: 0,
+    },
+  ]);
+});

--- a/apps/admin/backend/src/reports/titles.test.ts
+++ b/apps/admin/backend/src/reports/titles.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from 'vitest';
 import { err, ok } from '@votingworks/basics';
-import { readElectionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
+import {
+  electionOpenPrimaryFixtures,
+  readElectionTwoPartyPrimaryDefinition,
+} from '@votingworks/fixtures';
 import { Admin, BallotStyleGroupId, Tabulation } from '@votingworks/types';
 import { generateTitleForReport } from './titles';
 import { ScannerBatch } from '../types';
@@ -52,6 +55,9 @@ test('generateTitleForReport', () => {
     },
     {
       partyIds: ['0', '1'],
+    },
+    {
+      partyIds: ['0', Tabulation.NO_PARTY_ID],
     },
     {
       precinctIds: ['precinct-1'],
@@ -204,4 +210,23 @@ test('generateTitleForReport', () => {
       })
     ).toEqual(ok(title));
   }
+
+  const openPrimaryElectionDefinition =
+    electionOpenPrimaryFixtures.readElectionDefinition();
+  expect(
+    generateTitleForReport({
+      filter: { partyIds: [Tabulation.NO_PARTY_ID] },
+      electionDefinition: openPrimaryElectionDefinition,
+      scannerBatches: MOCK_SCANNER_BATCHES,
+      reportType: 'Ballot Count',
+    })
+  ).toEqual(ok('Ballot Count Report • No Party'));
+  expect(
+    generateTitleForReport({
+      filter: { partyIds: ['democratic-party'] },
+      electionDefinition: openPrimaryElectionDefinition,
+      scannerBatches: MOCK_SCANNER_BATCHES,
+      reportType: 'Ballot Count',
+    })
+  ).toEqual(ok('Ballot Count Report • Democratic Party'));
 });

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -13,6 +13,7 @@ import {
   DateWithoutTime,
   assertDefined,
   unique,
+  deepEqual,
 } from '@votingworks/basics';
 import { Bindable, Client as DbClient, Statement } from '@votingworks/db';
 import {
@@ -758,8 +759,8 @@ export class Store implements BaseStore {
       );
       params.push(...filter.ballotStyleGroupIds);
     }
-    if (filter.partyIds) {
-      assert(!isOpenPrimary(election));
+    // Open primaries handled below
+    if (filter.partyIds && !isOpenPrimary(election)) {
       assertFilterDoesNotContainNoPartyId(filter.partyIds);
       whereParts.push(
         `ballot_styles.party_id in ${asQueryPlaceholders(filter.partyIds)}`
@@ -843,13 +844,17 @@ export class Store implements BaseStore {
     // Instead, each CVR's party is inferred from its votes. So we need to
     // manually create group specifiers for each party.
     if (isOpenPrimary(election) && groupBy.groupByParty) {
-      const partyIds = unique(
-        partisanContests(election).map((contest) => contest.partyId)
+      const partyIds = [
+        ...unique(partisanContests(election).map((contest) => contest.partyId)),
+        Tabulation.NO_PARTY_ID,
+      ].filter(
+        (partyId) =>
+          !filter.partyIds ||
+          filter.partyIds.some((id) => deepEqual(id, partyId))
       );
-      return groups.flatMap((group) => [
-        ...partyIds.map((partyId) => ({ ...group, partyId })),
-        { ...group, partyId: Tabulation.NO_PARTY_ID },
-      ]);
+      return groups.flatMap((group) =>
+        partyIds.map((partyId) => ({ ...group, partyId }))
+      );
     }
     return groups;
   }
@@ -1677,7 +1682,7 @@ export class Store implements BaseStore {
   }): Generator<Tabulation.GroupOf<CardTally>> {
     // In open primaries, we have to infer a CVR's party from its votes,
     // which we can't do via the db, so we divert and do the counting in JS.
-    if (isOpenPrimary(election) && groupBy.groupByParty) {
+    if (isOpenPrimary(election) && (groupBy.groupByParty || filter.partyIds)) {
       yield* this.getOpenPrimaryCardTallies({
         electionId,
         election,
@@ -1801,7 +1806,7 @@ export class Store implements BaseStore {
     filter: Admin.ReportingFilter;
     groupBy: Tabulation.GroupBy;
   }): Generator<Tabulation.GroupOf<CardTally>> {
-    assert(groupBy.groupByParty);
+    assert(groupBy.groupByParty || filter.partyIds);
     const batchDatesByBatchId = groupBy.groupByBatchDate
       ? new Map(
           (
@@ -1819,16 +1824,23 @@ export class Store implements BaseStore {
 
     const aggregator = new Map<string, Tabulation.GroupOf<CardTally>>();
 
+    // Don't pass partyIds filter to getCastVoteRecords (since that would try to
+    // filter on ballot_style.party_id)
+    const { partyIds, ...restFilter } = filter;
+
     for (const cvr of this.getCastVoteRecords({
       electionId,
       election,
-      filter,
+      filter: restFilter,
     })) {
+      if (partyIds && !partyIds.some((id) => deepEqual(id, cvr.partyId))) {
+        continue;
+      }
       const groupSpecifier: Tabulation.GroupSpecifier = {
         ballotStyleGroupId: groupBy.groupByBallotStyle
           ? cvr.ballotStyleGroupId
           : undefined,
-        partyId: cvr.partyId,
+        partyId: groupBy.groupByParty ? cvr.partyId : undefined,
         batchId: groupBy.groupByBatch ? cvr.batchId : undefined,
         batchDate: groupBy.groupByBatchDate
           ? assertDefined(assertDefined(batchDatesByBatchId).get(cvr.batchId))
@@ -2921,8 +2933,7 @@ export class Store implements BaseStore {
       params.push(...precinctIds);
     }
 
-    if (partyIds) {
-      assert(!isOpenPrimary(election));
+    if (partyIds && !isOpenPrimary(election)) {
       assertFilterDoesNotContainNoPartyId(partyIds);
       whereParts.push(
         `ballot_styles.party_id in ${asQueryPlaceholders(partyIds)}`

--- a/apps/admin/frontend/src/components/reporting/filter_editor.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.test.tsx
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { readElectionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
+import {
+  readElectionOpenPrimaryDefinition,
+  readElectionTwoPartyPrimaryDefinition,
+} from '@votingworks/fixtures';
+import { Tabulation } from '@votingworks/types';
 import userEvent from '@testing-library/user-event';
 import { renderInAppContext } from '../../../test/render_in_app_context';
 import { FilterEditor } from './filter_editor';
@@ -8,6 +12,7 @@ import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client';
 
 const electionTwoPartyPrimaryDefinition =
   readElectionTwoPartyPrimaryDefinition();
+const electionOpenPrimaryDefinition = readElectionOpenPrimaryDefinition();
 
 let apiMock: ApiMock;
 
@@ -192,8 +197,39 @@ test('party selection', () => {
   userEvent.click(screen.getByLabelText('Select Filter Values'));
   screen.getByText('Mammal');
   screen.getByText('Fish');
+  expect(screen.queryByText('No Party')).toBeNull();
   userEvent.click(screen.getByText('Mammal'));
   expect(onChange).toHaveBeenNthCalledWith(2, { partyIds: ['0'] });
+});
+
+test('open primary party selection includes "No Party"', () => {
+  const { election } = electionOpenPrimaryDefinition;
+  const onChange = vi.fn();
+
+  apiMock.expectGetScannerBatches([]);
+  renderInAppContext(
+    <FilterEditor
+      election={election}
+      onChange={onChange}
+      allowedFilters={['party']}
+    />,
+    {
+      apiMock,
+    }
+  );
+
+  userEvent.click(screen.getButton('Add Filter'));
+  userEvent.click(screen.getByLabelText('Select New Filter Type'));
+  userEvent.click(screen.getByText('Party'));
+  expect(onChange).toHaveBeenNthCalledWith(1, { partyIds: [] });
+  userEvent.click(screen.getByLabelText('Select Filter Values'));
+  screen.getByText('Democratic');
+  screen.getByText('Republican');
+  screen.getByText('Libertarian');
+  userEvent.click(screen.getByText('No Party'));
+  expect(onChange).toHaveBeenNthCalledWith(2, {
+    partyIds: [Tabulation.NO_PARTY_ID],
+  });
 });
 
 test('adjudication status selection', () => {

--- a/apps/admin/frontend/src/components/reporting/filter_editor.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.tsx
@@ -4,7 +4,7 @@ import {
   typedAs,
   unique,
 } from '@votingworks/basics';
-import { Admin, Election, Tabulation } from '@votingworks/types';
+import { Admin, Election, isOpenPrimary, Tabulation } from '@votingworks/types';
 import { useState } from 'react';
 import styled from 'styled-components';
 import {
@@ -85,6 +85,8 @@ const FILTER_TYPE_LABELS: Record<FilterType, string> = {
   district: 'District',
 };
 
+const NO_PARTY_FILTER_VALUE = '__NO_PARTY_FILTER__';
+
 function getFilterTypeOption(filterType: FilterType): SelectOption<FilterType> {
   return {
     value: filterType,
@@ -115,11 +117,21 @@ function generateOptionsForFilter({
         })
       );
     }
-    case 'party':
-      return getPartiesWithPrimaryElections(election).map((party) => ({
-        value: party.id,
-        label: party.name,
-      }));
+    case 'party': {
+      const partyOptions = getPartiesWithPrimaryElections(election).map(
+        (party) => ({
+          value: party.id,
+          label: party.name,
+        })
+      );
+      if (isOpenPrimary(election)) {
+        partyOptions.push({
+          value: NO_PARTY_FILTER_VALUE,
+          label: 'No Party',
+        });
+      }
+      return partyOptions;
+    }
     case 'voting-method':
       return typedAs<Array<SelectOption<Tabulation.VotingMethod>>>([
         ...(isFeatureFlagEnabled(BooleanEnvironmentVariableName.EARLY_VOTING)
@@ -190,7 +202,9 @@ function convertFilterRowsToTabulationFilter(
         filter.ballotStyleGroupIds = filterValues;
         break;
       case 'party':
-        filter.partyIds = filterValues;
+        filter.partyIds = filterValues.map((value) =>
+          value === NO_PARTY_FILTER_VALUE ? Tabulation.NO_PARTY_ID : value
+        );
         break;
       case 'scanner':
         filter.scannerIds = filterValues;

--- a/apps/admin/frontend/src/utils/election.ts
+++ b/apps/admin/frontend/src/utils/election.ts
@@ -1,7 +1,18 @@
-import { Election, Party, PartyId, District } from '@votingworks/types';
+import {
+  Election,
+  Party,
+  PartyId,
+  District,
+  isOpenPrimary,
+} from '@votingworks/types';
 import { find, unique } from '@votingworks/basics';
 
-export function getPartiesWithPrimaryElections(election: Election): Party[] {
+export function getPartiesWithPrimaryElections(
+  election: Election
+): readonly Party[] {
+  if (isOpenPrimary(election)) {
+    return election.parties;
+  }
   const partyIds = election.ballotStyles
     .map((bs) => bs.partyId)
     .filter((id): id is PartyId => id !== undefined);

--- a/apps/admin/frontend/src/utils/reporting.test.ts
+++ b/apps/admin/frontend/src/utils/reporting.test.ts
@@ -127,6 +127,17 @@ test('generateBallotCountReportPdfFilename', () => {
       expectedFilename:
         'TEST-unofficial-write-in-ballot-count-report__2023-12-09_15-59-32.pdf',
     },
+    {
+      // No Party filter combined with two other dimensions: should be
+      // treated as a 3-dimension custom filter, not under-counted as 2.
+      filter: {
+        partyIds: [Tabulation.NO_PARTY_ID],
+        precinctIds: ['precinct-1'],
+        votingMethods: ['absentee'],
+      },
+      expectedFilename:
+        'unofficial-custom-ballot-count-report__2023-12-09_15-59-32.pdf',
+    },
   ];
 
   for (const testCase of testCases) {


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->
Adds some missing logic to allow filtering by party in the custom ballot count report builder. Fixes the backend to enable filtering by party using a CVR's inferred party. Fixes the frontend to allow filtering to just the "No Party" ballots and also correctly populate the list of parties in the filter dropdown.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/882e4d96-d81e-4f3b-bfaf-fbb1acd6914b



## Testing Plan
- Updated automated tests
- Basic manual test

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
