### PR TITLE
VxAdmin: Allow getManualResultsMetadata in open primaries

### DIFF
--- a/apps/admin/backend/src/app.manual_results.test.ts
+++ b/apps/admin/backend/src/app.manual_results.test.ts
@@ -519,10 +519,11 @@ test('manual results APIs reject reads/writes for open primary elections', async
     })
   ).rejects.toThrow();
 
-  // Reads: assert too — nothing should be reading manual data on open
-  // primary since the UI is hidden and the tabulation paths short-circuit.
+  // getManualResults is used on the manual tallies form, which is hidden
   await expect(apiClient.getManualResults(identifier)).rejects.toThrow();
-  await expect(apiClient.getManualResultsMetadata()).rejects.toThrow();
+  // getManualResultsMetadata is used in a few places to see if manual results
+  // exist or not, so we leave that enabled.
+  expect(await apiClient.getManualResultsMetadata()).toEqual([]);
 
   // Deletes are no-ops (no data exists to delete), so they succeed silently.
   await expect(

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -945,7 +945,6 @@ function buildApi({
       const {
         electionDefinition: { election },
       } = assertDefined(store.getElection(electionId));
-      assert(!isOpenPrimary(election));
       const manualResultsRecords = store.getManualResults({
         election,
         electionId,


### PR DESCRIPTION


## Overview

The Mark Official button calls getManualResultsMetadata to check whether manual tallies exist. The assert I added in #8473 thus caused the frontend to crash. Whoops.

## Demo Video or Screenshot
N/A
## Testing Plan
Manual test
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
