### PR TITLE
hmpb: Add prop to allow hiding timing mark grid

### DIFF
--- a/libs/hmpb/src/all_bubble_ballot/template.tsx
+++ b/libs/hmpb/src/all_bubble_ballot/template.tsx
@@ -33,7 +33,6 @@ export function allBubbleBallotTemplate(
     election,
     pageNumber,
     totalPages,
-    ballotMode,
     children,
   }: BaseBallotProps & {
     pageNumber: number;
@@ -48,7 +47,7 @@ export function allBubbleBallotTemplate(
         dimensions={dimensions}
         margins={pageMarginsInches}
       >
-        <TimingMarkGrid pageDimensions={dimensions} ballotMode={ballotMode}>
+        <TimingMarkGrid pageDimensions={dimensions}>
           <div
             style={{
               flex: 1,

--- a/libs/hmpb/src/ballot_components.tsx
+++ b/libs/hmpb/src/ballot_components.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import React from 'react';
 import {
   BALLOT_HASH_DISPLAY_LENGTH,
-  BallotMode,
   BallotStyle,
   BallotStyleId,
   Election,
@@ -111,16 +110,15 @@ export function timingMarkCounts(pageDimensions: InchDimensions): {
 export function TimingMarkGrid({
   pageDimensions,
   children,
-  ballotMode,
+  hideTimingMarks,
   timingMarkStyle,
 }: {
   pageDimensions: InchDimensions;
   children: React.ReactNode;
-  ballotMode: BallotMode;
+  hideTimingMarks?: boolean;
   timingMarkStyle?: React.CSSProperties;
 }): JSX.Element {
   const markCounts = timingMarkCounts(pageDimensions);
-  const hideTimingMarks = ballotMode === 'sample';
 
   function TimingMarkRow() {
     return (

--- a/libs/hmpb/src/ballot_templates/mi_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/mi_ballot_template.tsx
@@ -226,7 +226,10 @@ function BallotPageFrame({
         margins={pageMarginsInches}
       >
         {watermark && <Watermark>{watermark}</Watermark>}
-        <TimingMarkGrid pageDimensions={pageDimensions} ballotMode={ballotMode}>
+        <TimingMarkGrid
+          pageDimensions={pageDimensions}
+          hideTimingMarks={ballotMode === 'sample'}
+        >
           <div
             style={{
               flex: 1,

--- a/libs/hmpb/src/ballot_templates/ms_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/ms_ballot_template.tsx
@@ -217,7 +217,10 @@ function BallotPageFrame({
         margins={pageMarginsInches}
       >
         {watermark && <Watermark>{watermark}</Watermark>}
-        <TimingMarkGrid pageDimensions={pageDimensions} ballotMode={ballotMode}>
+        <TimingMarkGrid
+          pageDimensions={pageDimensions}
+          hideTimingMarks={ballotMode === 'sample'}
+        >
           <div
             style={{
               flex: 1,

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -423,7 +423,10 @@ function BallotPageFrame({
         margins={pageMarginsInches}
       >
         {watermark && <Watermark>{watermark}</Watermark>}
-        <TimingMarkGrid pageDimensions={pageDimensions} ballotMode={ballotMode}>
+        <TimingMarkGrid
+          pageDimensions={pageDimensions}
+          hideTimingMarks={ballotMode === 'sample'}
+        >
           <div
             style={{
               flex: 1,

--- a/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
@@ -169,7 +169,10 @@ function BallotPageFrame({
         margins={pageMarginsInches}
       >
         {watermark && <Watermark>{watermark}</Watermark>}
-        <TimingMarkGrid pageDimensions={pageDimensions} ballotMode={ballotMode}>
+        <TimingMarkGrid
+          pageDimensions={pageDimensions}
+          hideTimingMarks={ballotMode === 'sample'}
+        >
           <div
             style={{
               flex: 1,

--- a/libs/hmpb/src/timing_mark_paper/template.tsx
+++ b/libs/hmpb/src/timing_mark_paper/template.tsx
@@ -24,7 +24,6 @@ export async function render(
     <Page pageNumber={1} dimensions={dimensions} margins={pageMarginsInches}>
       <TimingMarkGrid
         pageDimensions={dimensions}
-        ballotMode="test"
         timingMarkStyle={
           timingMarkPaperType === 'standard'
             ? undefined


### PR DESCRIPTION


## Overview

<!-- Add a link to a GitHub issue here -->
Previously, we had within the TimingMarkGrid component to always hide the timing mark grid for sample ballots. We still want that logic, but the upcoming NH state ballots also need to hide the timing mark grid in some other conditions. So we switch to a boolean prop that allows each template to control when the marks are hidden.
## Demo Video or Screenshot
N/A

## Testing Plan
Existing tests
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
