### PR TITLE
fix: make `mount.sh` safer

### DIFF
--- a/libs/usb-drive/README.md
+++ b/libs/usb-drive/README.md
@@ -12,17 +12,37 @@ A few things to note:
 ## Setup
 
 In order for this library to work, it will need `sudo` access to two scripts:
-`src/mount.sh` and `src/unmount.sh`. You can set this up by adding the following
-to your `/etc/sudoers` file:
+`scripts/mount.sh` and `scripts/unmount.sh`. You can set this up by adding the
+following to your `/etc/sudoers` file:
 
 ```
-<username> ALL=(root:ALL) NOPASSWD: /path/to/vxsuite/libs/usb-drive/src/*.sh
+<username> ALL=(root:ALL) NOPASSWD: /path/to/vxsuite/libs/usb-drive/scripts/*.sh
 ```
 
 If you are using this with a typical Linux desktop environment like Gnome or
 KDE, you'll likely want to run `sudo scripts/disable_automount.sh` to prevent
 the desktop environment from mounting disks in a way that interferes with
 VxSuite's automatic USB disk handling.
+
+You'll also want to create the `vx-services` user and `vx-group` group like so:
+
+```sh
+# 1. Group first
+getent group vx-group >/dev/null || sudo groupadd --system vx-group
+
+# 2. System user — no home, no login shell
+getent passwd vx-services >/dev/null || \
+  sudo useradd --system --no-create-home --shell /usr/sbin/nologin vx-services
+
+# 3. Put vx-services in vx-group
+sudo usermod -aG vx-group vx-services
+
+# 4. Put yourself in vx-group so the dev backend (running as $USER) can
+#    read/write USB contents
+sudo usermod -aG vx-group "$USER"
+```
+
+Be sure to log out and back in after running those commands.
 
 ## CLI
 

--- a/libs/usb-drive/scripts/format_ext4.sh
+++ b/libs/usb-drive/scripts/format_ext4.sh
@@ -2,9 +2,9 @@
 
 set -euo pipefail
 
-usage () {
-    echo 'Usage: format_ext4.sh <device> <label>'
-    exit 1
+usage() {
+  echo 'Usage: format_ext4.sh <device> <label>'
+  exit 1
 }
 
 DISK_DEVICE_REGEX='^/dev/(sd[a-z]+|nvme[0-9]+n[0-9]+|mmcblk[0-9]+)$'
@@ -13,24 +13,34 @@ DEVICE=${1:-}
 LABEL=${2:-}
 
 if [[ -z $DEVICE || -z $LABEL ]]; then
-    usage
+  usage
 fi
 
 if ! [[ $DEVICE =~ $DISK_DEVICE_REGEX ]]; then
-    echo "error: \"${DEVICE}\" is not a recognized disk device"
-    exit 1
+  echo "error: \"${DEVICE}\" is not a recognized disk device"
+  exit 1
 fi
 
 if [[ ${#LABEL} -gt 16 ]]; then
-    echo "error: \"${LABEL}\" has more than the allowed 16 characters for an ext4 volume label"
-    exit 1
+  echo "error: \"${LABEL}\" has more than the allowed 16 characters for an ext4 volume label"
+  exit 1
+fi
+
+if ! getent passwd vx-services >/dev/null; then
+  echo "error: required user 'vx-services' does not exist"
+  exit 1
+fi
+
+if ! getent group vx-group >/dev/null; then
+  echo "error: required group 'vx-group' does not exist"
+  exit 1
 fi
 
 # Derive first partition path: nvme and mmcblk use a "p" separator
 if [[ $DEVICE =~ (nvme|mmcblk) ]]; then
-    PARTITION="${DEVICE}p1"
+  PARTITION="${DEVICE}p1"
 else
-    PARTITION="${DEVICE}1"
+  PARTITION="${DEVICE}1"
 fi
 
 # set the partition table type to dos
@@ -54,18 +64,20 @@ partprobe
 # mount temporarily, chown, unmount. trap ensures cleanup on failure.
 CHOWN_TMPDIR=""
 cleanup_tmp_mount() {
-    if [[ -n "$CHOWN_TMPDIR" && -d "$CHOWN_TMPDIR" ]]; then
-        if mountpoint -q "$CHOWN_TMPDIR"; then
-            umount "$CHOWN_TMPDIR" || true
-        fi
-        rmdir "$CHOWN_TMPDIR" || true
+  if [[ -n "$CHOWN_TMPDIR" && -d "$CHOWN_TMPDIR" ]]; then
+    if mountpoint -q "$CHOWN_TMPDIR"; then
+      umount "$CHOWN_TMPDIR" || true
     fi
+    rmdir "$CHOWN_TMPDIR" || true
+  fi
 }
 trap cleanup_tmp_mount EXIT
 
 CHOWN_TMPDIR=$(mktemp -d)
 mount -o nosuid,nodev,noexec "${PARTITION}" "$CHOWN_TMPDIR"
-chown vx:vx "$CHOWN_TMPDIR"
+chown vx-services:vx-group "$CHOWN_TMPDIR"
+# 0775 matches the FAT mount's dmask=002; setgid makes new entries inherit vx-group
+chmod 02775 "$CHOWN_TMPDIR"
 umount "$CHOWN_TMPDIR"
 rmdir "$CHOWN_TMPDIR"
 CHOWN_TMPDIR=""

--- a/libs/usb-drive/scripts/mount.sh
+++ b/libs/usb-drive/scripts/mount.sh
@@ -18,6 +18,16 @@ if ! [[ $1 =~ $PARTITION_DEVICE_REGEX ]]; then
   exit 1
 fi
 
+if ! getent passwd vx-services >/dev/null; then
+  echo "mount.sh: required user 'vx-services' does not exist"
+  exit 1
+fi
+
+if ! getent group vx-group >/dev/null; then
+  echo "mount.sh: required group 'vx-group' does not exist"
+  exit 1
+fi
+
 DEVICE=$1
 DEVNAME=$(basename "$1")
 
@@ -39,7 +49,7 @@ fi
 FSTYPE=$(blkid -o value -s TYPE "$DEVICE" 2>/dev/null || echo "")
 
 if [[ "$FSTYPE" == "ext4" ]]; then
-  mount -w -o nosuid,nodev,noexec "$DEVICE" "$MOUNTPOINT"
+  mount -t ext4 -w -o nosuid,nodev,noexec,nosymfollow "$DEVICE" "$MOUNTPOINT"
 else
-  mount -w -o umask=000,nosuid,nodev,noexec "$DEVICE" "$MOUNTPOINT"
+  mount -t vfat -w -o uid=vx-services,gid=vx-group,fmask=113,dmask=002,nosuid,nodev,noexec,nosymfollow "$DEVICE" "$MOUNTPOINT"
 fi


### PR DESCRIPTION
## Overview

Fixes https://github.com/votingworks/vxsuite-security/issues/98

We should:
- specify the type of file system we're expecting
- specify restrictive ownership (`vx-services` user and `vx-group` group) & permission values
- prevent following symlinks

These restrictions augment the existing ones and make it harder for a malicious drive to compromise the system. I chose to make the FAT-32 permissions end up being 755 for directories and 654 for files so that they can still be traversed and read by other users and written by users within the group. This may not be the right long-term solution, but for development we still do not have a very production-like user/group setup and so this is the pragmatic choice.

## Demo Video or Screenshot
```
❯ whoami
vx
❯ groups
vx cdrom floppy sudo audio dip video plugdev users netdev bluetooth lpadmin scanner docker vx-group
❯ cd /var/vx/usb-drives/usb-drive-sda1
❯ touch test.txt
❯ ls -lg test.txt
.rw-rw-r-- 0 vx-services vx-group 20 May 14:32 test.txt
❯ rm test.txt
❯ mkdir cast-vote-records
❯ touch cast-vote-records/test.zip
❯ cd cast-vote-records/
❯ ls -lg
.rw-rw-r-- 0 vx-services vx-group 20 May 14:33 test.zip
```

## Testing Plan
The above shell session was after mounting a FAT-32 drive using VxAdmin. 