### PR TITLE
[VxScan] Remove the focus outlines from FocusableAudio elements

### DIFF
--- a/libs/ui/src/focusable_audio.tsx
+++ b/libs/ui/src/focusable_audio.tsx
@@ -44,6 +44,10 @@ export function FocusableAudio<T extends ElementType = 'div'>(
       {...rest}
       as={as}
       className={`${className || ''} ${FOCUSABLE_AUDIO_CLASS_NAME}`}
+      // [TODO] Make this configurable, if/when this component is extended for
+      // use in VxMark. As noted above, we'll need to come up with a focus
+      // indicator that works for both on and off-screen elements.
+      style={{ outline: 'none' }}
       tabIndex={0}
     >
       {children}


### PR DESCRIPTION
## Overview

_More context in [Slack](https://votingworks.slack.com/archives/CEL6D3GAD/p1779307207570929?thread_ts=1779296630.012839&cid=CEL6D3GAD)_

Recently added text blocks to the tabbing order in https://github.com/votingworks/vxsuite/pull/8442, which enabled focus indicators for those blocks. This also results in the focus indicator showing up on initial screen render, since introductory audio is triggered by moving focus to the text automatically. Removing the focus outline for now, to avoid having it show up without any initial controller interaction.

### TODO
- A potential longer-term fix for the initial focus outline would be to add an option to skip the [focus step](https://github.com/votingworks/vxsuite/blob/b404c97/libs/ui/src/ui_strings/read_on_load.tsx#L68) in the `ReadOnLoad` component to use when we're rendering via `FocusableAudio`. The explicit focus might've been necessary for plain `ReadOnLoad` elements, which aren't in the browser tabbing order, but need more testing across Scan and Mark to be sure it's a safe change.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/960310e7-952b-497a-9bf2-246644ebc219

## Testing Plan
- Manual - reproduced the unwanted initial focus outline, verified it's gone after the change.

## Checklist

- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
