### PR TITLE
[libs/ui] Extract shared write-in report styles

### DIFF
--- a/libs/ui/src/reports/precinct_scanner_write_in_image_report.tsx
+++ b/libs/ui/src/reports/precinct_scanner_write_in_image_report.tsx
@@ -10,6 +10,13 @@ import {
 } from '@votingworks/utils';
 import { DateTime } from 'luxon';
 import styled, { ThemeProvider } from 'styled-components';
+import {
+  ContestHeading,
+  ContestSection,
+  WriteInGrid,
+  WriteInImage,
+  WriteInTextBox,
+} from './write_in_report_styles';
 import { LogoMark } from '../logo_mark';
 import { Font } from '../typography';
 import { PrintedReport, printedReportThemeFn } from './layout';
@@ -50,35 +57,6 @@ interface PrecinctScannerWriteInImageReportProps {
 
 const PartyHeader = styled(ReportSubtitle)`
   margin-top: 1.5em;
-`;
-
-const ContestSection = styled.div`
-  margin-top: 1.5em;
-  page-break-inside: avoid;
-`;
-
-const ContestHeading = styled.h2`
-  margin-top: 0;
-  margin-bottom: 0.5em;
-  font-size: 1.1em;
-`;
-
-const WriteInGrid = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr;
-  gap: 0.3em;
-`;
-
-const WriteInImage = styled.img`
-  max-width: 100%;
-  border: 1px solid #ccc;
-  display: block;
-`;
-
-const WriteInTextBox = styled.div`
-  border: 1px solid #ccc;
-  padding: 0.4em 0.6em;
-  background-color: #f5f5f5;
 `;
 
 export function PrecinctScannerWriteInImageReport({

--- a/libs/ui/src/reports/write_in_report_styles.ts
+++ b/libs/ui/src/reports/write_in_report_styles.ts
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+
+export const ContestSection = styled.div`
+  margin-top: 1.5em;
+  page-break-inside: avoid;
+`;
+
+export const ContestHeading = styled.h2`
+  margin-top: 0;
+  margin-bottom: 0.5em;
+  font-size: 1.1em;
+`;
+
+export const WriteInGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  gap: 0.3em;
+`;
+
+export const WriteInImage = styled.img`
+  max-width: 100%;
+  border: 1px solid #ccc;
+  display: block;
+`;
+
+export const WriteInTextBox = styled.div`
+  border: 1px solid #ccc;
+  padding: 0.4em 0.6em;
+  background-color: #f5f5f5;
+`;


### PR DESCRIPTION
Move styled components to be shared between write-in image report components into a new write_in_report_styles.ts module. Currently only used by VxScan's report but will be used by VxAdmin's in future PRs. No behavior changes.

## Overview

Relates to https://github.com/votingworks/vxsuite/issues/8077

## Demo Video or Screenshot

No changes

## Testing Plan

Relies on existing snapshot tests for VxScan write-in image reports

## Checklist
N/A

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
