### PR TITLE
[VxScan] Delay closing success screen until screen reader is done

### DIFF
--- a/apps/scan/frontend/src/app.test.tsx
+++ b/apps/scan/frontend/src/app.test.tsx
@@ -25,7 +25,7 @@ import type {
   PrecinctScannerStatus,
 } from '@votingworks/scan-backend';
 import { UsbDriveStatus } from '@votingworks/usb-drive';
-import { Keybinding } from '@votingworks/ui';
+import { Keybinding, useScreenReaderActive } from '@votingworks/ui';
 import {
   waitFor,
   screen,
@@ -79,6 +79,11 @@ vi.mock('@votingworks/utils', async () => ({
   ...(await vi.importActual('@votingworks/utils')),
   isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
     featureFlagMock.isEnabled(flag),
+}));
+
+vi.mock(import('@votingworks/ui'), async (importActual) => ({
+  ...(await importActual()),
+  useScreenReaderActive: vi.fn(),
 }));
 
 function renderApp(props: Partial<AppProps> = {}) {
@@ -464,6 +469,46 @@ test('voter can cast a ballot that scans successfully', async () => {
   await waitFor(() => {
     expect(screen.queryByText('Eject USB')).toBeNull();
   });
+});
+
+test('success screen stays visible until screen reader audio is done', async () => {
+  const electionDefinition = electionTwoPartyPrimaryDefinition;
+  const { election } = electionDefinition;
+  const [pollingPlace] = assertDefined(election.pollingPlaces);
+  apiMock.expectGetConfig({
+    electionDefinition,
+    pollingPlaceId: pollingPlace.id,
+  });
+  apiMock.expectGetPollsInfo('polls_open');
+  apiMock.expectGetUsbDriveStatus('mounted');
+  apiMock.expectGetScannerStatus(statusNoPaper);
+  apiMock.setPrinterStatus();
+
+  const mockUseScreenReaderActive = vi.mocked(useScreenReaderActive);
+  mockUseScreenReaderActive.mockReturnValue(false);
+
+  renderApp();
+  await screen.findByText(/Insert Your Ballot/i);
+
+  apiMock.expectGetScannerStatus(scannerStatus({ state: 'accepted' }));
+  apiMock.expectPlaySound('success');
+  apiMock.mockApiClient.readyForNextBallot.expectCallWith().resolves();
+  vi.advanceTimersByTime(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
+  await screen.findByText('Your ballot was counted!');
+
+  mockUseScreenReaderActive.mockReturnValue(true);
+
+  vi.advanceTimersByTime(DELAY_ACCEPTED_SCREEN_MS * 2);
+  screen.getByText('Your ballot was counted!');
+
+  mockUseScreenReaderActive.mockReturnValue(false);
+
+  // Trigger a re-render to pick up new hook value:
+  apiMock.expectGetScannerStatus(statusBallotCounted);
+  await vi.advanceTimersByTimeAsync(POLLING_INTERVAL_FOR_SCANNER_STATUS_MS);
+
+  await screen.findByText(/Insert Your Ballot/i);
+  expect(screen.getByTestId('ballot-count').textContent).toEqual('1');
 });
 
 test('voter can cast a ballot that needs review and adjudicate as desired', async () => {

--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -1,6 +1,6 @@
 import { ElectionDefinition, SystemSettings } from '@votingworks/types';
 import { assert, throwIllegalValue } from '@votingworks/basics';
-import { useQueryChangeListener } from '@votingworks/ui';
+import { useQueryChangeListener, useScreenReaderActive } from '@votingworks/ui';
 import { useEffect, useRef, useState } from 'react';
 import { getScannerStatus, readyForNextBallot, playSound } from '../api';
 import { POLLING_INTERVAL_FOR_SCANNER_STATUS_MS } from '../config/globals';
@@ -61,20 +61,27 @@ export function VoterScreen({
   // accepted screen.
   const readyForNextBallotMutation = readyForNextBallot.useMutation();
   const [isShowingAcceptedScreen, setIsShowingAcceptedScreen] = useState(false);
+  const [
+    acceptedScreenMinDurationElapsed,
+    setAcceptedScreenMinDurationElapsed,
+  ] = useState(false);
+
   const acceptedScreenTimeoutRef = useRef<number>();
   function clearTimeout() {
     if (acceptedScreenTimeoutRef.current) {
       window.clearTimeout(acceptedScreenTimeoutRef.current);
     }
   }
+
   useQueryChangeListener(scannerStatusQuery, {
     select: (status) => status.state,
     onChange: (newState) => {
       if (newState === 'accepted') {
         setIsShowingAcceptedScreen(true);
+        setAcceptedScreenMinDurationElapsed(false);
         clearTimeout();
         acceptedScreenTimeoutRef.current = window.setTimeout(
-          () => setIsShowingAcceptedScreen(false),
+          () => setAcceptedScreenMinDurationElapsed(true),
           DELAY_ACCEPTED_SCREEN_MS
         );
         readyForNextBallotMutation.mutate();
@@ -82,6 +89,24 @@ export function VoterScreen({
     },
   });
   useEffect(() => clearTimeout, []); // Cleanup on unmount
+
+  // Hold the accepted screen until the "Your ballot was counted" screen reader
+  // audio finishes playing — unmounting it sooner clears the audio queue and
+  // cuts off the announcement mid-sentence.
+  const isScreenReaderActive = useScreenReaderActive();
+  useEffect(() => {
+    if (
+      isShowingAcceptedScreen &&
+      acceptedScreenMinDurationElapsed &&
+      !isScreenReaderActive
+    ) {
+      setIsShowingAcceptedScreen(false);
+    }
+  }, [
+    isShowingAcceptedScreen,
+    acceptedScreenMinDurationElapsed,
+    isScreenReaderActive,
+  ]);
 
   if (!scannerStatusQuery.isSuccess) {
     return null;

--- a/libs/ui/src/hooks/use_audio_controls.test.tsx
+++ b/libs/ui/src/hooks/use_audio_controls.test.tsx
@@ -49,7 +49,7 @@ test('returns external-facing audio context API', () => {
         }}
       >
         <UiStringScreenReaderContext.Provider
-          value={{ ...mockScreenReaderContextControls }}
+          value={{ ...mockScreenReaderContextControls, isAudioActive: false }}
         >
           {children}
         </UiStringScreenReaderContext.Provider>

--- a/libs/ui/src/ui_strings/index.ts
+++ b/libs/ui/src/ui_strings/index.ts
@@ -11,6 +11,7 @@ export {
 export * from './number_string';
 export * from './read_on_load';
 export * from './toggle_audio_button';
+export { useScreenReaderActive } from './ui_string_screen_reader';
 export * from './ui_strings_context';
 export * from './ui_string';
 export * from './utils';

--- a/libs/ui/src/ui_strings/ui_string_screen_reader.test.tsx
+++ b/libs/ui/src/ui_strings/ui_string_screen_reader.test.tsx
@@ -9,6 +9,7 @@ import { AudioOnly } from './audio_only';
 import { LanguageOverride } from './language_override';
 import { Button } from '../button';
 import { AudioVolume } from './audio_volume';
+import { useScreenReaderActive } from './ui_string_screen_reader';
 
 vi.mock(import('./play_audio_clips.js'), async (importActual) => ({
   ...(await importActual()),
@@ -80,11 +81,14 @@ test('queues up audio for <UiString>s within focus/click event targets', async (
       <Button data-testid="focusTarget" onPress={() => undefined}>
         {appStrings.buttonDone()}
       </Button>
+      <AudioActiveHookClient />
     </div>
   );
 
   const clickTarget = await screen.findByTestId('clickTarget');
   act(() => getAudioContext()?.setIsEnabled(true));
+
+  expectAudioActiveHookValue(false);
 
   // Should trigger audio on click events:
   act(() => userEvent.click(clickTarget));
@@ -100,6 +104,7 @@ test('queues up audio for <UiString>s within focus/click event targets', async (
   expect(mockClipOutputs[2]).toHaveTextContent(
     getMockClipOutput({ audioId: '123', languageCode: SPANISH })
   );
+  expectAudioActiveHookValue(true);
 
   // Should trigger audio on focus events:
   const focusTarget = screen.getByTestId('focusTarget');
@@ -112,6 +117,7 @@ test('queues up audio for <UiString>s within focus/click event targets', async (
   expect(screen.getByTestId('mockClipOutput')).toHaveTextContent(
     getMockClipOutput({ audioId: 'abc', languageCode: ENGLISH })
   );
+  expectAudioActiveHookValue(true);
 });
 
 test('resumes paused audio when user switches focus', async () => {
@@ -157,7 +163,10 @@ test('clears audio queue on blur', async () => {
   });
 
   render(
-    <div data-testid="clickTarget">{appStrings.titleBmdReviewScreen()}</div>
+    <div>
+      <div data-testid="clickTarget">{appStrings.titleBmdReviewScreen()}</div>
+      <AudioActiveHookClient />
+    </div>
   );
 
   const clickTarget = await screen.findByTestId('clickTarget');
@@ -168,6 +177,7 @@ test('clears audio queue on blur', async () => {
   expect(mockClipOutput).toHaveTextContent(
     getMockClipOutput({ audioId: 'abc', languageCode: ENGLISH })
   );
+  expectAudioActiveHookValue(true);
 
   act(() => {
     clickTarget.dispatchEvent(new Event('blur', { bubbles: true }));
@@ -176,6 +186,7 @@ test('clears audio queue on blur', async () => {
   await waitFor(() =>
     expect(screen.queryByTestId('mockClipOutput')).not.toBeInTheDocument()
   );
+  expectAudioActiveHookValue(false);
 });
 
 test('triggers replay when user language is changed', async () => {
@@ -230,7 +241,10 @@ test('is a no-op when audio is disabled', async () => {
   });
 
   render(
-    <div data-testid="clickTarget">{appStrings.titleBmdReviewScreen()}</div>
+    <div>
+      <div data-testid="clickTarget">{appStrings.titleBmdReviewScreen()}</div>
+      <AudioActiveHookClient />
+    </div>
   );
 
   const clickTarget = await screen.findByTestId('clickTarget');
@@ -244,6 +258,7 @@ test('is a no-op when audio is disabled', async () => {
   });
 
   expect(screen.queryByTestId('mockClips')).not.toBeInTheDocument();
+  expectAudioActiveHookValue(false);
 });
 
 test('handles missing audio ID data', async () => {
@@ -347,3 +362,18 @@ test('volume control API', async () => {
   act(() => fireOnClipsDoneEvent?.());
   expect(screen.queryByTestId('mockClipOutput')).not.toBeInTheDocument();
 });
+
+type AudioStatus = 'active' | 'inactive';
+const AUDIO_STATUS_TEST_ID = 'AudioActiveHookClient';
+
+function expectAudioActiveHookValue(active: boolean) {
+  const current = screen.getByTestId(AUDIO_STATUS_TEST_ID).textContent;
+  expect(current).toEqual<AudioStatus>(active ? 'active' : 'inactive');
+}
+
+function AudioActiveHookClient(): JSX.Element {
+  const audioActive = useScreenReaderActive();
+  const status: AudioStatus = audioActive ? 'active' : 'inactive';
+
+  return <div data-testid={AUDIO_STATUS_TEST_ID}>{status}</div>;
+}

--- a/libs/ui/src/ui_strings/ui_string_screen_reader.tsx
+++ b/libs/ui/src/ui_strings/ui_string_screen_reader.tsx
@@ -29,6 +29,7 @@ export interface UiStringScreenReaderContextInterface {
   cycleVolume: () => void;
   decreaseVolume: () => void;
   increaseVolume: () => void;
+  isAudioActive: boolean;
   /** Replays audio for any `UiString`s currently under focus. */
   replay: () => void;
 }
@@ -40,6 +41,15 @@ export const UiStringScreenReaderContext =
 
 export function useUiStringScreenReaderContext(): Optional<UiStringScreenReaderContextInterface> {
   return React.useContext(UiStringScreenReaderContext);
+}
+
+/**
+ * True when audio is enabled and the screen reader has clips queued for
+ * playback (either UI string readout or audio feedback).
+ */
+export function useScreenReaderActive(): boolean {
+  const ctx = useUiStringScreenReaderContext();
+  return ctx?.isAudioActive ?? false;
 }
 
 function useVolumeControls(params: {
@@ -274,9 +284,17 @@ export function UiStringScreenReader(
     setAudioFeedbackQueue(undefined);
   }, []);
 
+  const isAudioActive = isEnabled && clipQueue.length > 0;
+
   return (
     <UiStringScreenReaderContext.Provider
-      value={{ cycleVolume, decreaseVolume, increaseVolume, replay }}
+      value={{
+        cycleVolume,
+        decreaseVolume,
+        increaseVolume,
+        isAudioActive,
+        replay,
+      }}
     >
       {isEnabled && (
         <PlayAudioClips clips={memoizedClipQueue} onDone={onDone} />


### PR DESCRIPTION
## Overview

When the screen reader is enabled, the default delay before closing the scan success screen is not long enough for the screen reader to finish playing the relevant audio, causing it to get cut off when the app switches back to the ballot insertion screen.

To address this:
- Exposing a hook into the shared screen reader to determine whether or not any audio is currently playing.
- Blocking the change from success screen to ballot insertion screen in VxScan until all screen reader audio is done playing.

## Demo Video or Screenshot

### Before (with artificially short 1s timeout):

https://github.com/user-attachments/assets/d38f74d9-e204-4603-a8c4-3b4b88e75a93

### After (also 1s timeout):

https://github.com/user-attachments/assets/d152e4de-65d9-4b88-826c-2220291f0c98

## Testing Plan
- Unit tests + manual verification (with a hack to show the success screen immediately, but it's representative of actual flow).

## Checklist

- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
