### PR TITLE
VxDesign: NH state Federal Office Only ballots

### DIFF
--- a/apps/design/backend/src/app.state_nh.test.ts
+++ b/apps/design/backend/src/app.state_nh.test.ts
@@ -4,6 +4,7 @@ import {
   electionFamousNames2021Fixtures,
   electionGeneralFixtures,
 } from '@votingworks/fixtures';
+import { nhStateGeneralElectionFixtures } from '@votingworks/hmpb';
 import {
   Election,
   hasSplits,
@@ -317,4 +318,64 @@ test('ballot measure contest editing with additional contest options', async () 
   expect(updatedContest.additionalOptions).toEqual(
     expectedContest.additionalOptions
   );
+});
+
+test('getBallotPreviewPdf routes Federal Office Only ballots when isFederalOfficeOnly is true', async () => {
+  // Use the NH state general election fixture so the election has the contest
+  // titles that NhStateBallot's isFederalOfficeContest matcher recognizes
+  const { election } = nhStateGeneralElectionFixtures.allBallotProps[0];
+  const { apiClient, auth0 } = await setupApp({
+    organizations,
+    jurisdictions,
+    users,
+  });
+
+  auth0.setLoggedInUser(nhUser);
+  const electionId = (
+    await apiClient.loadElection({
+      newId: 'new-election-id',
+      jurisdictionId: nhJurisdiction.id,
+      upload: {
+        format: 'vxf',
+        electionFileContents: JSON.stringify(election),
+      },
+    })
+  ).unsafeUnwrap();
+
+  await apiClient.setBallotTemplate({
+    electionId,
+    ballotTemplateId: 'NhStateBallot',
+  });
+
+  const ballotStyles = await apiClient.listBallotStyles({ electionId });
+  const ballotStyle = assertDefined(
+    ballotStyles.find((style) =>
+      style.languages!.includes(LanguageCode.ENGLISH)
+    )
+  );
+  const precinct = (await apiClient.listPrecincts({ electionId }))[0];
+
+  const nonFooResult = (
+    await apiClient.getBallotPreviewPdf({
+      electionId,
+      precinctId: precinct.id,
+      ballotStyleId: ballotStyle.id,
+      ballotType: BallotType.Absentee,
+      ballotMode: 'official',
+      isFederalOfficeOnly: false,
+    })
+  ).unsafeUnwrap();
+  expect(nonFooResult.fileName).not.toMatch(/-foo\.pdf$/);
+
+  const fooResult = (
+    await apiClient.getBallotPreviewPdf({
+      electionId,
+      precinctId: precinct.id,
+      ballotStyleId: ballotStyle.id,
+      ballotType: BallotType.Absentee,
+      ballotMode: 'official',
+      isFederalOfficeOnly: true,
+    })
+  ).unsafeUnwrap();
+  expect(fooResult.fileName).toMatch(/-foo\.pdf$/);
 });

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -760,7 +760,28 @@ test('update election info', async () => {
     }
   );
 
-  // Change to NhBallot to test signature behavior
+  // NhStateBallot also includes the signature in the response
+  await apiClient.setBallotTemplate({
+    electionId,
+    ballotTemplateId: 'NhStateBallot',
+  });
+  expect(await apiClient.getElectionInfo({ electionId })).toEqual<ElectionInfo>(
+    {
+      jurisdictionId: nonVxJurisdiction.id,
+      electionId,
+      title: 'Updated Election',
+      countyName: 'New Hampshire',
+      state: 'NH',
+      seal: '\r\n<svg>updated seal</svg>\r\n',
+      type: 'closed-primary',
+      date: new DateWithoutTime('2022-01-01'),
+      languageCodes: [LanguageCode.ENGLISH, LanguageCode.SPANISH],
+      signatureCaption: 'New Caption',
+      signatureImage: '\r\n<svg>new signature</svg>\r\n',
+    }
+  );
+
+  // Change to VxDefaultBallot to test signature behavior
   await apiClient.setBallotTemplate({
     electionId,
     ballotTemplateId: 'VxDefaultBallot',

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -887,18 +887,9 @@ export function buildApi(ctx: AppContext) {
       }
       if (ballotPdf.isErr()) return ballotPdf;
 
-      const precinct = find(
-        election.precincts,
-        (p) => p.id === input.precinctId
-      );
       return ok({
         pdfData: ballotPdf.ok(),
-        fileName: `PROOF-${getBallotPdfFileName(
-          precinct.name,
-          input.ballotStyleId,
-          input.ballotType,
-          input.ballotMode
-        )}`,
+        fileName: `PROOF-${getBallotPdfFileName(ballotProps)}`,
       });
     },
 

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -65,6 +65,7 @@ import {
   ballotTemplates,
   createPlaywrightRenderer,
   hmpbStringsCatalog,
+  NhStateBallotProps,
   renderBallotPreviewToPdf,
 } from '@votingworks/hmpb';
 import { translateBallotStrings, execFile } from '@votingworks/backend';
@@ -841,6 +842,7 @@ export function buildApi(ctx: AppContext) {
       ballotStyleId: BallotStyleId;
       ballotType: BallotType;
       ballotMode: BallotMode;
+      isFederalOfficeOnly?: boolean;
     }): Promise<
       Result<{ pdfData: Uint8Array; fileName: string }, BallotLayoutError>
     > {
@@ -868,7 +870,11 @@ export function buildApi(ctx: AppContext) {
           props.precinctId === input.precinctId &&
           props.ballotStyleId === input.ballotStyleId &&
           props.ballotType === input.ballotType &&
-          props.ballotMode === input.ballotMode
+          props.ballotMode === input.ballotMode &&
+          (ballotTemplateId === 'NhStateBallot'
+            ? Boolean((props as NhStateBallotProps).isFederalOfficeOnly) ===
+              Boolean(input.isFederalOfficeOnly)
+            : true)
       );
       const renderer = await createPlaywrightRenderer();
       let ballotPdf: Result<Uint8Array, BallotLayoutError>;
@@ -878,7 +884,6 @@ export function buildApi(ctx: AppContext) {
           ballotTemplates[ballotTemplateId],
           // NOTE: Changing this text means you should also change the font size
           // of the <Watermark> component in the ballot template.
-
           { ...ballotProps, watermark: 'PROOF' }
         );
       } finally {

--- a/apps/design/backend/src/ballots.test.ts
+++ b/apps/design/backend/src/ballots.test.ts
@@ -9,8 +9,14 @@ import {
 } from '@votingworks/types';
 import { TestLanguageCode } from '@votingworks/test-utils';
 import { expect, test } from 'vitest';
-import { assert, assertDefined, find } from '@votingworks/basics';
-import { NhBallotProps } from '@votingworks/hmpb';
+import {
+  assert,
+  assertDefined,
+  deepEqual,
+  find,
+  iter,
+} from '@votingworks/basics';
+import { NhBallotProps, NhStateBallotProps } from '@votingworks/hmpb';
 import {
   createBallotPropsForTemplate,
   formatElectionForExport,
@@ -49,6 +55,28 @@ test('createBallotPropsForTemplate', () => {
       expect('electionSealOverride' in props).toEqual(true);
       expect('clerkSignatureImage' in props).toEqual(true);
       expect('clerkSignatureCaption' in props).toEqual(true);
+    }
+  }
+
+  const nhStateBallotProps: NhStateBallotProps[] = createBallotPropsForTemplate(
+    'NhStateBallot',
+    election,
+    false
+  );
+  const [allFooProps, allRegularProps] = iter(nhStateBallotProps).partition(
+    (props) => props.isFederalOfficeOnly
+  );
+  for (const regularProps of allRegularProps) {
+    const matchingFooProps = allFooProps.find((fooProps) =>
+      deepEqual(fooProps, { ...regularProps, isFederalOfficeOnly: true })
+    );
+    if (
+      regularProps.ballotMode === 'official' &&
+      regularProps.ballotType === BallotType.Absentee
+    ) {
+      expect(matchingFooProps).toBeDefined();
+    } else {
+      expect(matchingFooProps).toBeUndefined();
     }
   }
 });

--- a/apps/design/backend/src/ballots.test.ts
+++ b/apps/design/backend/src/ballots.test.ts
@@ -1,5 +1,7 @@
 import { readElectionGeneral } from '@votingworks/fixtures';
 import {
+  BallotType,
+  BaseBallotProps,
   ElectionStringKey,
   hasSplits,
   Precinct,
@@ -21,7 +23,7 @@ test('createBallotPropsForTemplate', () => {
     'VxDefaultBallot',
     election,
     false
-  );
+  ) as BaseBallotProps[];
   for (const props of vxDefaultBallotProps) {
     expect(props.compact).toEqual(false);
   }

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -1,4 +1,5 @@
 import {
+  BallotType,
   BaseBallotProps,
   Election,
   hasSplits,
@@ -10,6 +11,7 @@ import {
   AnyBallotProps,
   BallotTemplateId,
   NhBallotProps,
+  NhStateBallotProps,
 } from '@votingworks/hmpb';
 import { assert, find, throwIllegalValue } from '@votingworks/basics';
 import { sha256 } from 'js-sha256';
@@ -113,6 +115,18 @@ export function createBallotPropsForTemplate(
     };
   }
 
+  function buildNhStateBallotProps(
+    props: BaseBallotProps
+  ): NhStateBallotProps[] {
+    return [
+      props,
+      ...(props.ballotMode === 'official' &&
+      props.ballotType === BallotType.Absentee
+        ? [{ ...props, isFederalOfficeOnly: true }]
+        : []),
+    ];
+  }
+
   assert(election.ballotStyles.length > 0, 'Election has no ballot styles');
   const baseBallotProps = allBaseBallotProps(election).map((props) => ({
     ...props,
@@ -122,10 +136,12 @@ export function createBallotPropsForTemplate(
     case 'NhBallot':
       return baseBallotProps.map(buildNhBallotProps);
 
+    case 'NhStateBallot':
+      return baseBallotProps.flatMap(buildNhStateBallotProps);
+
     case 'MsBallot':
     case 'VxDefaultBallot':
     case 'MiBallot':
-    case 'NhStateBallot':
       return baseBallotProps;
 
     default: {

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -7,6 +7,7 @@ import {
 } from '@votingworks/types';
 import {
   allBaseBallotProps,
+  AnyBallotProps,
   BallotTemplateId,
   NhBallotProps,
 } from '@votingworks/hmpb';
@@ -90,7 +91,7 @@ export function createBallotPropsForTemplate(
   templateId: BallotTemplateId,
   election: Election,
   compact: boolean
-): BaseBallotProps[] {
+): AnyBallotProps[] {
   function buildNhBallotProps(props: BaseBallotProps): NhBallotProps {
     const precinct = find(election.precincts, (p) => p.id === props.precinctId);
     if (!hasSplits(precinct)) {

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -1172,7 +1172,6 @@ export class Store {
         },
         state: electionRow.state,
         seal: electionRow.seal,
-        // Only include signature for the NhBallot
         signature:
           electionRow.ballotTemplateId === 'NhBallot' ||
           electionRow.ballotTemplateId === 'NhStateBallot'

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -1174,7 +1174,8 @@ export class Store {
         seal: electionRow.seal,
         // Only include signature for the NhBallot
         signature:
-          electionRow.ballotTemplateId === 'NhBallot'
+          electionRow.ballotTemplateId === 'NhBallot' ||
+          electionRow.ballotTemplateId === 'NhStateBallot'
             ? electionRow.signature || undefined
             : undefined,
         districts,

--- a/apps/design/backend/src/utils.test.ts
+++ b/apps/design/backend/src/utils.test.ts
@@ -1,0 +1,37 @@
+import { readElectionGeneral } from '@votingworks/fixtures';
+import { BallotType } from '@votingworks/types';
+import { expect, test } from 'vitest';
+import { NhStateBallotProps } from '@votingworks/hmpb';
+import { getBallotPdfFileName } from './utils';
+
+const election = readElectionGeneral();
+
+const baseProps = {
+  election,
+  ballotStyleId: '12',
+  precinctId: '23',
+  ballotType: BallotType.Precinct,
+  ballotMode: 'official',
+} as const;
+
+test('getBallotPdfFileName base case replaces spaces in precinct name', () => {
+  expect(getBallotPdfFileName(baseProps)).toEqual(
+    'official-precinct-ballot-Center_Springfield-12.pdf'
+  );
+});
+
+test('getBallotPdfFileName includes ballotAuditId when present', () => {
+  expect(getBallotPdfFileName({ ...baseProps, ballotAuditId: '7' })).toEqual(
+    'official-precinct-ballot-Center_Springfield-12-7.pdf'
+  );
+});
+
+test('getBallotPdfFileName appends -foo when isFederalOfficeOnly is true', () => {
+  const props: NhStateBallotProps = {
+    ...baseProps,
+    isFederalOfficeOnly: true,
+  };
+  expect(getBallotPdfFileName(props)).toEqual(
+    'official-precinct-ballot-Center_Springfield-12-foo.pdf'
+  );
+});

--- a/apps/design/backend/src/utils.ts
+++ b/apps/design/backend/src/utils.ts
@@ -1,12 +1,10 @@
 import { assertDefined, throwIllegalValue } from '@votingworks/basics';
 import {
   AnyContest,
-  BallotMode,
-  BallotStyleId,
-  BallotType,
   Candidate,
   District,
   Election,
+  getPrecinctById,
   hasSplits,
   Party,
   PollingPlace,
@@ -17,24 +15,21 @@ import {
 } from '@votingworks/types';
 import { customAlphabet } from 'nanoid';
 import { Buffer } from 'node:buffer';
+import { AnyBallotProps } from '@votingworks/hmpb';
 import { MAX_POSTGRES_INDEX_KEY_BYTES } from './globals';
 import { Jurisdiction, User } from './types';
 import { type StateFeaturesConfig } from './features';
 
-export function getBallotPdfFileName(
-  precinctName: string,
-  ballotStyleId: BallotStyleId,
-  ballotType: BallotType,
-  ballotMode: BallotMode,
-  ballotAuditId?: string
-): string {
+export function getBallotPdfFileName(props: AnyBallotProps): string {
+  const precinct = assertDefined(getPrecinctById(props));
   const baseName = [
-    ballotMode,
-    ballotType,
+    props.ballotMode,
+    props.ballotType,
     'ballot',
-    precinctName.replaceAll(' ', '_'),
-    ballotStyleId,
-    ballotAuditId,
+    precinct.name.replaceAll(' ', '_'),
+    props.ballotStyleId,
+    props.ballotAuditId,
+    'isFederalOfficeOnly' in props && props.isFederalOfficeOnly && 'foo',
   ]
     .filter(Boolean)
     .join('-');

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -8,7 +8,6 @@ import {
   formatElectionHashes,
   LATEST_METADATA,
   ElectionId,
-  getPrecinctById,
   formatBallotHash,
   BallotType,
   ElectionIdSchema,
@@ -30,7 +29,6 @@ import {
   getAllStringsForElectionPackage,
 } from '@votingworks/backend';
 import {
-  assertDefined,
   extractErrorMessage,
   find,
   iter,
@@ -426,16 +424,7 @@ export async function generateElectionPackageAndBallots(
 
   // Add ballots to ZIP files, grouped by ballot type:
   for (const { props, ballotPdf } of normalizedBallotPdfs) {
-    const { precinctId, ballotStyleId, ballotType, ballotMode, ballotAuditId } =
-      props;
-    const precinct = assertDefined(getPrecinctById({ election, precinctId }));
-    const fileName = getBallotPdfFileName(
-      precinct.name,
-      ballotStyleId,
-      ballotType,
-      ballotMode,
-      ballotAuditId
-    );
+    const fileName = getBallotPdfFileName(props);
 
     switch (props.ballotMode) {
       case 'official':

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -338,12 +338,10 @@ export async function generateElectionPackageAndBallots(
         props.ballotMode === 'official' &&
         props.ballotType === BallotType.Precinct
     );
-    allBallotProps = range(1, numAuditIdBallots + 1).map(
-      (ballotIndex): BaseBallotProps => ({
-        ...officialPrecinctBallotProps,
-        ballotAuditId: String(ballotIndex),
-      })
-    );
+    allBallotProps = range(1, numAuditIdBallots + 1).map((ballotIndex) => ({
+      ...officialPrecinctBallotProps,
+      ballotAuditId: String(ballotIndex),
+    }));
   }
 
   const rendererPool = await createPlaywrightRendererPool();

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -788,6 +788,7 @@ interface GetBallotPreviewInput {
   ballotStyleId: BallotStyleId;
   ballotType: BallotType;
   ballotMode: BallotMode;
+  isFederalOfficeOnly?: boolean;
 }
 
 export const getBallotPreviewPdf = {

--- a/apps/design/frontend/src/ballot_screen.test.tsx
+++ b/apps/design/frontend/src/ballot_screen.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, test, vi, describe } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi, describe } from 'vitest';
 import { BallotType, CandidateContest, YesNoContest } from '@votingworks/types';
 import type { BallotTemplateId } from '@votingworks/design-backend';
 import { DocumentProps, PageProps } from 'react-pdf';
@@ -117,6 +117,7 @@ test('shows a PDF ballot preview', async () => {
       precinctId: precinct.id,
       ballotType: BallotType.Precinct,
       ballotMode: 'official',
+      isFederalOfficeOnly: undefined,
     })
     .resolves(
       ok({
@@ -180,6 +181,7 @@ test('changes ballot type', async () => {
       precinctId: precinct.id,
       ballotType: BallotType.Precinct,
       ballotMode: 'official',
+      isFederalOfficeOnly: undefined,
     })
     .resolves(
       ok({
@@ -210,6 +212,7 @@ test('changes ballot type', async () => {
       precinctId: precinct.id,
       ballotType: BallotType.Absentee,
       ballotMode: 'official',
+      isFederalOfficeOnly: undefined,
     })
     .resolves(
       ok({
@@ -230,6 +233,7 @@ test('changes tabulation mode', async () => {
       precinctId: precinct.id,
       ballotType: BallotType.Precinct,
       ballotMode: 'official',
+      isFederalOfficeOnly: undefined,
     })
     .resolves(
       ok({
@@ -264,6 +268,7 @@ test('changes tabulation mode', async () => {
       precinctId: precinct.id,
       ballotType: BallotType.Precinct,
       ballotMode: 'test',
+      isFederalOfficeOnly: undefined,
     })
     .resolves(
       ok({
@@ -274,6 +279,90 @@ test('changes tabulation mode', async () => {
   userEvent.click(testRadioOption);
   await screen.findByText('mock test ballot pdf');
   screen.getByRole('radio', { name: 'L&A Test Ballot', checked: true });
+});
+
+test('NhStateBallot template: Federal Office Only option locks mode to Official', async () => {
+  apiMock.getBallotTemplate.reset();
+  apiMock.getBallotTemplate
+    .expectCallWith({ electionId })
+    .resolves('NhStateBallot');
+  apiMock.getBallotPreviewPdf
+    .expectCallWith({
+      electionId,
+      ballotStyleId: ballotStyle.id,
+      precinctId: precinct.id,
+      ballotType: BallotType.Precinct,
+      ballotMode: 'official',
+      isFederalOfficeOnly: undefined,
+    })
+    .resolves(
+      ok({
+        pdfData: Buffer.from('mock precinct ballot pdf'),
+        fileName: 'mock precinct ballot.pdf',
+      })
+    );
+  renderScreen();
+
+  await screen.findByRole('heading', { name: 'View Ballot' });
+  await screen.findByText('mock precinct ballot pdf');
+
+  const ballotTypeRadioGroup = screen.getByRole('radiogroup', {
+    name: 'Ballot Type',
+  });
+  const tabulationModeRadioGroup = screen.getByRole('radiogroup', {
+    name: 'Tabulation Mode',
+  });
+  const fooRadioOption = within(ballotTypeRadioGroup).getByRole('radio', {
+    name: 'Federal Office Only',
+    checked: false,
+  });
+  const testRadioOption = within(tabulationModeRadioGroup).getByRole('radio', {
+    name: 'L&A Test Ballot',
+  });
+  expect(testRadioOption).toBeEnabled();
+
+  // Switch to test mode first so we can verify the FOO click forces it back to official.
+  apiMock.getBallotPreviewPdf
+    .expectCallWith({
+      electionId,
+      ballotStyleId: ballotStyle.id,
+      precinctId: precinct.id,
+      ballotType: BallotType.Precinct,
+      ballotMode: 'test',
+      isFederalOfficeOnly: undefined,
+    })
+    .resolves(
+      ok({
+        pdfData: Buffer.from('mock test ballot pdf'),
+        fileName: 'mock test ballot.pdf',
+      })
+    );
+  userEvent.click(testRadioOption);
+  await screen.findByText('mock test ballot pdf');
+
+  apiMock.getBallotPreviewPdf
+    .expectCallWith({
+      electionId,
+      ballotStyleId: ballotStyle.id,
+      precinctId: precinct.id,
+      ballotType: BallotType.Absentee,
+      ballotMode: 'official',
+      isFederalOfficeOnly: true,
+    })
+    .resolves(
+      ok({
+        pdfData: Buffer.from('mock foo ballot pdf'),
+        fileName: 'mock foo ballot.pdf',
+      })
+    );
+  userEvent.click(fooRadioOption);
+  await screen.findByText('mock foo ballot pdf');
+  screen.getByRole('radio', { name: 'Federal Office Only', checked: true });
+  expect(testRadioOption).toBeDisabled();
+  within(tabulationModeRadioGroup).getByRole('radio', {
+    name: 'Official Ballot',
+    checked: true,
+  });
 });
 
 describe('Ballot rendering error handling', () => {
@@ -290,6 +379,7 @@ describe('Ballot rendering error handling', () => {
         precinctId: precinct.id,
         ballotType: BallotType.Precinct,
         ballotMode: 'official',
+        isFederalOfficeOnly: undefined,
       })
       .resolves(
         err({
@@ -383,6 +473,7 @@ describe('Ballot rendering error handling', () => {
           precinctId: precinct.id,
           ballotType: BallotType.Precinct,
           ballotMode: 'official',
+          isFederalOfficeOnly: undefined,
         })
         .resolves(
           err({

--- a/apps/design/frontend/src/ballot_screen.tsx
+++ b/apps/design/frontend/src/ballot_screen.tsx
@@ -286,6 +286,7 @@ export function BallotScreen(): JSX.Element | null {
   const getBallotTemplateQuery = getBallotTemplate.useQuery(electionId);
   const [ballotType, setBallotType] = useState<BallotType>(BallotType.Precinct);
   const [ballotMode, setBallotMode] = useState<BallotMode>('official');
+  const [isFederalOfficeOnly, setIsFederalOfficeOnly] = useState<boolean>();
   const printIframeRef = useRef<HTMLIFrameElement>(null);
   const getBallotPreviewPdfQuery = getBallotPreviewPdf.useQuery({
     electionId,
@@ -293,6 +294,7 @@ export function BallotScreen(): JSX.Element | null {
     ballotStyleId,
     ballotType,
     ballotMode,
+    isFederalOfficeOnly,
   });
   const ballotPreview = getBallotPreviewPdfQuery.data?.ok();
 
@@ -336,6 +338,7 @@ export function BallotScreen(): JSX.Element | null {
   const parties = listPartiesQuery.data;
   const { paperSize } = getBallotLayoutSettingsQuery.data;
   const ballotTemplateId = getBallotTemplateQuery.data;
+  const enableFederalOfficeOnly = ballotTemplateId === 'NhStateBallot';
   const precinct = find(precincts, (p) => p.id === precinctId);
   const ballotStyle = find(ballotStyles, (bs) => bs.id === ballotStyleId);
 
@@ -438,16 +441,42 @@ export function BallotScreen(): JSX.Element | null {
             {paperSizeLabels[paperSize]}{' '}
           </div>
 
-          <RadioGroup
-            label="Ballot Type"
-            options={[
-              { value: BallotType.Precinct, label: 'Precinct' },
-              { value: BallotType.Absentee, label: 'Absentee' },
-            ]}
-            value={ballotType}
-            onChange={setBallotType}
-            inverse
-          />
+          {enableFederalOfficeOnly ? (
+            <RadioGroup
+              label="Ballot Type"
+              options={[
+                { value: BallotType.Precinct, label: 'Precinct' },
+                { value: BallotType.Absentee, label: 'Absentee' },
+                {
+                  value: 'federal-office-only',
+                  label: 'Federal Office Only',
+                },
+              ]}
+              value={isFederalOfficeOnly ? 'federal-office-only' : ballotType}
+              onChange={(value) => {
+                if (value === 'federal-office-only') {
+                  setIsFederalOfficeOnly(true);
+                  setBallotType(BallotType.Absentee);
+                  setBallotMode('official');
+                } else {
+                  setBallotType(value);
+                  setIsFederalOfficeOnly(false);
+                }
+              }}
+              inverse
+            />
+          ) : (
+            <RadioGroup
+              label="Ballot Type"
+              options={[
+                { value: BallotType.Precinct, label: 'Precinct' },
+                { value: BallotType.Absentee, label: 'Absentee' },
+              ]}
+              value={ballotType}
+              onChange={setBallotType}
+              inverse
+            />
+          )}
 
           <RadioGroup
             label="Tabulation Mode"
@@ -458,6 +487,7 @@ export function BallotScreen(): JSX.Element | null {
             ]}
             value={ballotMode}
             onChange={setBallotMode}
+            disabled={isFederalOfficeOnly}
             inverse
           />
 

--- a/apps/design/frontend/src/election_info_screen.test.tsx
+++ b/apps/design/frontend/src/election_info_screen.test.tsx
@@ -301,6 +301,30 @@ test('edit and save election - nhBallotTemplate signature upload', async () => {
   await screen.findByRole('button', { name: 'Edit' });
 });
 
+test('shows signature input for NhStateBallot template', async () => {
+  const electionRecord = generalElectionRecord(jurisdiction.id);
+  electionRecord.ballotTemplateId = 'NhStateBallot';
+  const { election } = electionRecord;
+  const electionId = election.id;
+  mockStateFeatures(apiMock, electionId);
+  apiMock.getSystemSettings
+    .expectCallWith({ electionId })
+    .resolves(DEFAULT_SYSTEM_SETTINGS);
+  apiMock.getElectionInfo
+    .expectCallWith({ electionId })
+    .resolves(electionInfoFromRecord(electionRecord));
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+  apiMock.getBallotTemplate
+    .expectCallWith({ electionId })
+    .resolves('NhStateBallot');
+  renderScreen(electionId);
+
+  await screen.findByRole('heading', { name: 'Election Info' });
+  screen.getByText('Signature');
+  screen.getByLabelText('Upload Signature Image');
+  screen.getByLabelText('Signature Caption');
+});
+
 test('cancel update', async () => {
   const electionRecord = generalElectionRecord(jurisdiction.id);
   const electionId = electionRecord.election.id;

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -87,7 +87,8 @@ function ElectionInfoForm({
   }
   const features = getStateFeaturesQuery.data;
   const ballotTemplateId = ballotTemplateIdQuery.data;
-  const showSignatureInput = ballotTemplateId === 'NhBallot';
+  const showSignatureInput =
+    ballotTemplateId === 'NhBallot' || ballotTemplateId === 'NhStateBallot';
 
   function onSubmit() {
     updateElectionInfoMutation.mutate(electionInfo, {

--- a/libs/hmpb/src/ballot_templates/index.ts
+++ b/libs/hmpb/src/ballot_templates/index.ts
@@ -1,3 +1,4 @@
+import { BallotPageTemplate } from '../render_ballot';
 import { miBallotTemplate } from './mi_ballot_template';
 import { msBallotTemplate } from './ms_ballot_template';
 import { nhBallotTemplate } from './nh_ballot_template';
@@ -26,3 +27,16 @@ export { getCandidateOrderingSetsForNhBallot as getAllOrderedContestSetsForNhBal
  * The ID of a ballot template.
  */
 export type BallotTemplateId = keyof typeof ballotTemplates;
+
+type BallotTemplateProps<Template> = Template extends BallotPageTemplate<
+  infer Props
+>
+  ? Props
+  : never;
+
+/**
+ * The union of possible props types across all ballot templates.
+ */
+export type AnyBallotProps = BallotTemplateProps<
+  (typeof ballotTemplates)[BallotTemplateId]
+>;

--- a/libs/hmpb/src/ballot_templates/index.ts
+++ b/libs/hmpb/src/ballot_templates/index.ts
@@ -6,6 +6,7 @@ import { nhStateBallotTemplate } from './nh_state_ballot_template';
 import { vxDefaultBallotTemplate } from './vx_default_ballot_template';
 
 export type { NhBallotProps } from './nh_ballot_template';
+export type { NhStateBallotProps } from './nh_state_ballot_template';
 
 /**
  * All ballot templates, indexed by ID.

--- a/libs/hmpb/src/ballot_templates/nh_state_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_state_ballot_template.tsx
@@ -42,6 +42,8 @@ const BallotPageContent: ContentComponent<NhStateBallotProps> = async (
   }
 };
 
+export type { NhStateBallotProps };
+
 export const nhStateBallotTemplate: BallotPageTemplate<NhStateBallotProps> = {
   frameComponent: BallotPageFrame,
   contentComponent: BallotPageContent,


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->
Adds support to VxDesign for Federal Office Only (FOO) ballots. These ballots filter contests to only the federal level, and are not scanned (so they have no QR code or timing marks). We include them in the ballot export and also support them in the proofing flow.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/926959e4-aff2-4a95-9b47-ab9ba7c2dce9



## Testing Plan
- Manual test
- Updated automated tests
## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
