### PR TITLE
[VxAdmin] Add write-in image report backend

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -133,6 +133,12 @@ import {
   WriteInAdjudicationReportPreview,
 } from './reports/write_in_adjudication_report';
 import {
+  exportWriteInImageReportPdf,
+  generateWriteInImageReportPreview,
+  printWriteInImageReport,
+  WriteInImageReportPreview,
+} from './reports/write_in_image_report';
+import {
   exportVoterTurnoutReportPdf,
   generateVoterTurnoutReportPreview,
   printVoterTurnoutReport,
@@ -1330,6 +1336,40 @@ function buildApi({
       return exportWriteInAdjudicationReportPdf({
         store,
         electionWriteInSummary: getElectionWriteInSummary(),
+        usbDrive: usbDriveAdapter,
+        logger,
+        filename: input.filename,
+      });
+    },
+
+    async getWriteInImageReportPreview(input: {
+      contestId: ContestId;
+    }): Promise<WriteInImageReportPreview> {
+      return generateWriteInImageReportPreview({
+        store,
+        contestId: input.contestId,
+        logger,
+      });
+    },
+
+    async printWriteInImageReport(input: {
+      contestId: ContestId;
+    }): Promise<void> {
+      return printWriteInImageReport({
+        store,
+        contestId: input.contestId,
+        logger,
+        printer,
+      });
+    },
+
+    async exportWriteInImageReportPdf(input: {
+      contestId: ContestId;
+      filename: string;
+    }): Promise<ExportDataResult> {
+      return exportWriteInImageReportPdf({
+        store,
+        contestId: input.contestId,
         usbDrive: usbDriveAdapter,
         logger,
         filename: input.filename,

--- a/apps/admin/backend/src/app.write_in_image_report.test.ts
+++ b/apps/admin/backend/src/app.write_in_image_report.test.ts
@@ -1,0 +1,732 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { HP_LASER_PRINTER_CONFIG, renderToPdf } from '@votingworks/printing';
+import { assert, assertDefined, err, ok } from '@votingworks/basics';
+import {
+  createImageData,
+  crop,
+  loadImageData,
+  toDataUrl,
+} from '@votingworks/image-utils';
+import { BallotPageLayout, BallotType } from '@votingworks/types';
+import { LogEventId } from '@votingworks/logging';
+import { Buffer } from 'node:buffer';
+import {
+  BooleanEnvironmentVariableName,
+  getFeatureFlagMock,
+} from '@votingworks/utils';
+import {
+  buildTestEnvironment,
+  configureMachine,
+  expectUsbDriveSync,
+  mockElectionManagerAuth,
+} from '../test/app';
+import { mockFileName } from '../test/csv';
+import {
+  MockCastVoteRecordFile,
+  addMockCvrFileToStore,
+} from '../test/mock_cvr_file';
+import { Store } from './store';
+import { buildAdminContestWriteIns } from './reports/write_in_image_report';
+import { generateReportPath } from './util/filenames';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+vi.mock(import('./util/get_current_time.js'), async (importActual) => ({
+  ...(await importActual()),
+  getCurrentTime: () => new Date('2021-01-01T00:00:00.000').getTime(),
+}));
+
+vi.mock(import('@votingworks/types'), async (importActual) => {
+  const original = await importActual();
+  return {
+    ...original,
+    formatElectionHashes: vi.fn().mockReturnValue('1111111-0000000'),
+  };
+});
+
+const featureFlagMock = getFeatureFlagMock();
+vi.mock(import('@votingworks/utils'), async (importActual) => ({
+  ...(await importActual()),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
+
+vi.mock(import('@votingworks/printing'), async (importActual) => {
+  const original = await importActual();
+  return {
+    ...original,
+    renderToPdf: vi.fn(original.renderToPdf),
+  } as unknown as typeof import('@votingworks/printing');
+});
+
+vi.mock(import('@votingworks/image-utils'), async (importActual) => ({
+  ...(await importActual()),
+  loadImageData: vi.fn(),
+  crop: vi.fn(),
+  toDataUrl: vi.fn(),
+}));
+
+beforeEach(() => {
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_CVR_BALLOT_HASH_CHECK
+  );
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_CAST_VOTE_RECORDS_AUTHENTICATION
+  );
+});
+
+afterEach(() => {
+  featureFlagMock.resetFeatureFlags();
+});
+
+const electionDefinition =
+  electionFamousNames2021Fixtures.readElectionDefinition();
+const MAYOR_CONTEST_ID = 'mayor';
+const SHERLOCK_ID = 'sherlock-holmes';
+const WRITE_IN_OPTION_ID = 'write-in-0';
+const BOARD_CONTEST_ID = 'board-of-alderman';
+const HELEN_ID = 'helen-keller';
+const STEVE_ID = 'steve-jobs';
+
+const BASE_CVR: Omit<MockCastVoteRecordFile[number], 'card' | 'votes'> = {
+  ballotStyleGroupId: '1-2',
+  batchId: 'batch-1',
+  scannerId: 'scanner-1',
+  precinctId: '21',
+  votingMethod: 'precinct',
+};
+
+async function setup() {
+  const { apiClient, auth, workspace } = buildTestEnvironment();
+  const electionId = await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition
+  );
+  return { store: workspace.store, electionId };
+}
+
+function addHmpbWriteInCvr(
+  store: Store,
+  electionId: string
+): { cvrId: string; writeInId: string } {
+  const [cvrId] = addMockCvrFileToStore({
+    electionId,
+    mockCastVoteRecordFile: [
+      { ...BASE_CVR, card: { type: 'hmpb', sheetNumber: 1 }, votes: {} },
+    ],
+    store,
+  });
+  assert(cvrId !== undefined);
+  const { electionDefinition: ed } = assertDefined(
+    store.getElection(electionId)
+  );
+  store.addBallotImage({
+    cvrId,
+    electionDefinitionId: ed.election.id,
+    imageData: Buffer.from([]),
+    side: 'front',
+  });
+  store.addBallotImage({
+    cvrId,
+    electionDefinitionId: ed.election.id,
+    imageData: Buffer.from([]),
+    side: 'back',
+  });
+  const writeInId = store.addWriteIn({
+    electionId,
+    castVoteRecordId: cvrId,
+    contestId: MAYOR_CONTEST_ID,
+    optionId: WRITE_IN_OPTION_ID,
+  });
+  return { cvrId, writeInId };
+}
+
+function addBmdTextWriteIn(
+  store: Store,
+  electionId: string,
+  machineMarkedText: string
+): { cvrId: string; writeInId: string } {
+  const [cvrId] = addMockCvrFileToStore({
+    electionId,
+    mockCastVoteRecordFile: [{ ...BASE_CVR, card: { type: 'bmd' }, votes: {} }],
+    store,
+  });
+  assert(cvrId !== undefined);
+  const { electionDefinition: ed } = assertDefined(
+    store.getElection(electionId)
+  );
+  store.addBallotImage({
+    cvrId,
+    electionDefinitionId: ed.election.id,
+    imageData: Buffer.from([]),
+    side: 'front',
+  });
+  store.addBallotImage({
+    cvrId,
+    electionDefinitionId: ed.election.id,
+    imageData: Buffer.from([]),
+    side: 'back',
+  });
+  const writeInId = store.addWriteIn({
+    electionId,
+    castVoteRecordId: cvrId,
+    contestId: MAYOR_CONTEST_ID,
+    optionId: WRITE_IN_OPTION_ID,
+    machineMarkedText,
+  });
+  return { cvrId, writeInId };
+}
+
+async function getMayorResult(store: Store, electionId: string) {
+  const result = await buildAdminContestWriteIns(
+    store,
+    electionId,
+    MAYOR_CONTEST_ID
+  );
+  return assertDefined(result.get(MAYOR_CONTEST_ID));
+}
+
+test('BMD text write-in adjudicated to write-in candidate', async () => {
+  const { store, electionId } = await setup();
+  const { writeInId } = addBmdTextWriteIn(store, electionId, 'Jane Doe');
+  const { id: candidateId } = store.addWriteInCandidate({
+    electionId,
+    contestId: MAYOR_CONTEST_ID,
+    name: 'Jane Doe',
+  });
+  store.setWriteInRecordUnofficialCandidate({
+    type: 'write-in-candidate',
+    writeInId,
+    candidateId,
+  });
+
+  const { candidateGroups, unadjudicatedWriteIns } = await getMayorResult(
+    store,
+    electionId
+  );
+
+  expect(candidateGroups).toHaveLength(1);
+  expect(candidateGroups[0]).toMatchObject({
+    groupLabel: 'Jane Doe',
+    isQualified: true,
+    writeIns: [{ type: 'text', text: 'Jane Doe' }],
+  });
+  expect(unadjudicatedWriteIns).toEqual([]);
+  expect(loadImageData).not.toHaveBeenCalled();
+});
+
+test('HMPB write-in adjudicated to official candidate', async () => {
+  const { store, electionId } = await setup();
+  const { writeInId } = addHmpbWriteInCvr(store, electionId);
+  store.setWriteInRecordOfficialCandidate({
+    type: 'official-candidate',
+    writeInId,
+    candidateId: SHERLOCK_ID,
+  });
+
+  const { candidateGroups, unadjudicatedWriteIns } = await getMayorResult(
+    store,
+    electionId
+  );
+
+  expect(candidateGroups).toHaveLength(1);
+  expect(candidateGroups[0]).toMatchObject({
+    groupLabel: 'Sherlock Holmes',
+    isQualified: true,
+  });
+  expect(unadjudicatedWriteIns).toEqual([]);
+});
+
+test('pending BMD write-in goes to unadjudicatedWriteIns', async () => {
+  const { store, electionId } = await setup();
+  addBmdTextWriteIn(store, electionId, 'Pending Name');
+
+  const { candidateGroups, unadjudicatedWriteIns } = await getMayorResult(
+    store,
+    electionId
+  );
+
+  expect(candidateGroups).toHaveLength(0);
+  expect(unadjudicatedWriteIns).toEqual([
+    { type: 'text', text: 'Pending Name' },
+  ]);
+});
+
+test('pending HMPB write-in with no image entry not in unadjudicatedWriteIns', async () => {
+  const { store, electionId } = await setup();
+  addHmpbWriteInCvr(store, electionId);
+
+  const { candidateGroups, unadjudicatedWriteIns } = await getMayorResult(
+    store,
+    electionId
+  );
+
+  expect(candidateGroups).toHaveLength(0);
+  expect(unadjudicatedWriteIns).toEqual([]);
+});
+
+test('adjudicated invalid write-in creates invalid group', async () => {
+  const { store, electionId } = await setup();
+  const { writeInId } = addBmdTextWriteIn(store, electionId, 'Bad Name');
+  store.setWriteInRecordInvalid({ type: 'invalid', writeInId });
+
+  const { candidateGroups, unadjudicatedWriteIns } = await getMayorResult(
+    store,
+    electionId
+  );
+
+  expect(candidateGroups).toHaveLength(1);
+  expect(candidateGroups[0]).toMatchObject({
+    groupLabel: 'Invalid',
+    isQualified: false,
+  });
+  expect(unadjudicatedWriteIns).toEqual([]);
+});
+
+test('HMPB invalid write-in with no image entry not in invalid group', async () => {
+  const { store, electionId } = await setup();
+  const { writeInId } = addHmpbWriteInCvr(store, electionId);
+  store.setWriteInRecordInvalid({ type: 'invalid', writeInId });
+
+  const { candidateGroups } = await getMayorResult(store, electionId);
+
+  expect(candidateGroups).toHaveLength(0);
+});
+
+function makeLayoutForContest(
+  contestId: string,
+  optionId = WRITE_IN_OPTION_ID
+): BallotPageLayout {
+  return {
+    pageSize: { width: 600, height: 900 },
+    metadata: {
+      ballotHash: 'abc123def456abc1',
+      ballotStyleId: '1-2',
+      precinctId: '21',
+      pageNumber: 1,
+      isTestMode: true,
+      ballotType: BallotType.Precinct,
+    },
+    contests: [
+      {
+        contestId,
+        bounds: { x: 10, y: 100, width: 400, height: 200 },
+        corners: [
+          { x: 10, y: 100 },
+          { x: 410, y: 100 },
+          { x: 10, y: 300 },
+          { x: 410, y: 300 },
+        ],
+        options: [
+          {
+            definition: {
+              type: 'candidate',
+              id: optionId,
+              contestId,
+              name: 'Write-In',
+              isWriteIn: true,
+              writeInIndex: 0,
+            },
+            bounds: { x: 10, y: 230, width: 400, height: 60 },
+            target: {
+              bounds: { x: 10, y: 240, width: 20, height: 20 },
+              inner: { x: 12, y: 242, width: 16, height: 16 },
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function addHmpbCvrWithLayouts(
+  store: Store,
+  electionId: string,
+  frontLayout: BallotPageLayout,
+  backLayout?: BallotPageLayout
+): { writeInId: string } {
+  const [cvrId] = addMockCvrFileToStore({
+    electionId,
+    mockCastVoteRecordFile: [
+      { ...BASE_CVR, card: { type: 'hmpb', sheetNumber: 1 }, votes: {} },
+    ],
+    store,
+  });
+  assert(cvrId !== undefined);
+  const { electionDefinition: ed } = assertDefined(
+    store.getElection(electionId)
+  );
+  store.addBallotImage({
+    cvrId,
+    electionDefinitionId: ed.election.id,
+    imageData: Buffer.from([]),
+    pageLayout: frontLayout,
+    side: 'front',
+  });
+  store.addBallotImage({
+    cvrId,
+    electionDefinitionId: ed.election.id,
+    imageData: Buffer.from([]),
+    pageLayout: backLayout,
+    side: 'back',
+  });
+  const writeInId = store.addWriteIn({
+    electionId,
+    castVoteRecordId: cvrId,
+    contestId: MAYOR_CONTEST_ID,
+    optionId: WRITE_IN_OPTION_ID,
+  });
+  return { writeInId };
+}
+
+test('failed image load causes write-in entry to be skipped', async () => {
+  const { store, electionId } = await setup();
+  const { writeInId } = addHmpbCvrWithLayouts(
+    store,
+    electionId,
+    makeLayoutForContest(MAYOR_CONTEST_ID)
+  );
+  store.setWriteInRecordOfficialCandidate({
+    type: 'official-candidate',
+    writeInId,
+    candidateId: SHERLOCK_ID,
+  });
+
+  vi.mocked(loadImageData).mockResolvedValueOnce(
+    err({ type: 'invalid-image-file' as const, message: 'load failed' })
+  );
+
+  const { candidateGroups } = await getMayorResult(store, electionId);
+
+  expect(candidateGroups).toHaveLength(1);
+  expect(candidateGroups[0]!.writeIns).toHaveLength(0);
+});
+
+test('layout missing write-in option skips entry', async () => {
+  const { store, electionId } = await setup();
+  const { writeInId } = addHmpbCvrWithLayouts(
+    store,
+    electionId,
+    makeLayoutForContest(MAYOR_CONTEST_ID, 'write-in-1')
+  );
+  store.setWriteInRecordOfficialCandidate({
+    type: 'official-candidate',
+    writeInId,
+    candidateId: SHERLOCK_ID,
+  });
+
+  const { candidateGroups } = await getMayorResult(store, electionId);
+
+  expect(candidateGroups[0]!.writeIns).toHaveLength(0);
+});
+
+test('successful image crop produces image entry', async () => {
+  const { store, electionId } = await setup();
+  const { writeInId } = addHmpbCvrWithLayouts(
+    store,
+    electionId,
+    makeLayoutForContest(BOARD_CONTEST_ID),
+    makeLayoutForContest(MAYOR_CONTEST_ID)
+  );
+  store.setWriteInRecordOfficialCandidate({
+    type: 'official-candidate',
+    writeInId,
+    candidateId: SHERLOCK_ID,
+  });
+
+  const mockImage = createImageData(new Uint8ClampedArray(4), 1, 1);
+  vi.mocked(loadImageData).mockResolvedValueOnce(ok(mockImage));
+  vi.mocked(crop).mockReturnValueOnce(mockImage);
+  vi.mocked(toDataUrl).mockReturnValueOnce('data:image/png;base64,test');
+
+  const { candidateGroups } = await getMayorResult(store, electionId);
+
+  expect(candidateGroups[0]!.writeIns).toEqual([
+    { type: 'image', dataUrl: 'data:image/png;base64,test' },
+  ]);
+});
+
+test('candidate groups sorted alphabetically regardless of type', async () => {
+  const { store, electionId } = await setup();
+
+  const { writeInId: zaraWriteInId } = addBmdTextWriteIn(
+    store,
+    electionId,
+    'Zara Z'
+  );
+  const { id: zaraCandidateId } = store.addWriteInCandidate({
+    electionId,
+    contestId: MAYOR_CONTEST_ID,
+    name: 'Zara Z',
+  });
+  store.setWriteInRecordUnofficialCandidate({
+    type: 'write-in-candidate',
+    writeInId: zaraWriteInId,
+    candidateId: zaraCandidateId,
+  });
+
+  const { writeInId: sherlockWriteInId } = addHmpbWriteInCvr(store, electionId);
+  store.setWriteInRecordOfficialCandidate({
+    type: 'official-candidate',
+    writeInId: sherlockWriteInId,
+    candidateId: SHERLOCK_ID,
+  });
+
+  const { candidateGroups } = await getMayorResult(store, electionId);
+
+  expect(candidateGroups.map((g) => g.groupLabel)).toEqual([
+    'Sherlock Holmes',
+    'Zara Z',
+  ]);
+});
+
+test('invalid group is last in candidateGroups', async () => {
+  const { store, electionId } = await setup();
+
+  const { writeInId: invalidWriteInId } = addBmdTextWriteIn(
+    store,
+    electionId,
+    'Not Valid'
+  );
+  store.setWriteInRecordInvalid({
+    type: 'invalid',
+    writeInId: invalidWriteInId,
+  });
+
+  const { writeInId: qualifiedWriteInId } = addBmdTextWriteIn(
+    store,
+    electionId,
+    'Jane'
+  );
+  const { id: candidateId } = store.addWriteInCandidate({
+    electionId,
+    contestId: MAYOR_CONTEST_ID,
+    name: 'Jane',
+  });
+  store.setWriteInRecordUnofficialCandidate({
+    type: 'write-in-candidate',
+    writeInId: qualifiedWriteInId,
+    candidateId,
+  });
+
+  const { candidateGroups } = await getMayorResult(store, electionId);
+
+  expect(candidateGroups.map((g) => g.isQualified)).toEqual([true, false]);
+});
+
+test('no write-ins results in empty candidateGroups and unadjudicatedWriteIns', async () => {
+  const { store, electionId } = await setup();
+
+  const { candidateGroups, unadjudicatedWriteIns } = await getMayorResult(
+    store,
+    electionId
+  );
+
+  expect(candidateGroups).toEqual([]);
+  expect(unadjudicatedWriteIns).toEqual([]);
+});
+
+test('CVR image cache: getBallotImagesAndLayouts called once per CVR', async () => {
+  const { store, electionId } = await setup();
+
+  const [cvrId] = addMockCvrFileToStore({
+    electionId,
+    mockCastVoteRecordFile: [
+      { ...BASE_CVR, card: { type: 'hmpb', sheetNumber: 1 }, votes: {} },
+    ],
+    store,
+  });
+  assert(cvrId !== undefined);
+  const { electionDefinition: ed } = assertDefined(
+    store.getElection(electionId)
+  );
+  store.addBallotImage({
+    cvrId,
+    electionDefinitionId: ed.election.id,
+    imageData: Buffer.from([]),
+    side: 'front',
+  });
+  store.addBallotImage({
+    cvrId,
+    electionDefinitionId: ed.election.id,
+    imageData: Buffer.from([]),
+    side: 'back',
+  });
+  const firstWriteInId = store.addWriteIn({
+    electionId,
+    castVoteRecordId: cvrId,
+    contestId: BOARD_CONTEST_ID,
+    optionId: 'write-in-0',
+  });
+  const secondWriteInId = store.addWriteIn({
+    electionId,
+    castVoteRecordId: cvrId,
+    contestId: BOARD_CONTEST_ID,
+    optionId: 'write-in-1',
+  });
+  store.setWriteInRecordOfficialCandidate({
+    type: 'official-candidate',
+    writeInId: firstWriteInId,
+    candidateId: HELEN_ID,
+  });
+  store.setWriteInRecordOfficialCandidate({
+    type: 'official-candidate',
+    writeInId: secondWriteInId,
+    candidateId: STEVE_ID,
+  });
+
+  const spy = vi.spyOn(store, 'getBallotImagesAndLayouts');
+  await buildAdminContestWriteIns(store, electionId, BOARD_CONTEST_ID);
+  expect(spy).toHaveBeenCalledTimes(1);
+});
+
+test('two write-ins for same candidate reuse existing group', async () => {
+  const { store, electionId } = await setup();
+
+  const { writeInId: writeInId1 } = addBmdTextWriteIn(
+    store,
+    electionId,
+    'Sherlock Holmes'
+  );
+  const { writeInId: writeInId2 } = addBmdTextWriteIn(
+    store,
+    electionId,
+    'Sherlock Holmes'
+  );
+  store.setWriteInRecordOfficialCandidate({
+    type: 'official-candidate',
+    writeInId: writeInId1,
+    candidateId: SHERLOCK_ID,
+  });
+  store.setWriteInRecordOfficialCandidate({
+    type: 'official-candidate',
+    writeInId: writeInId2,
+    candidateId: SHERLOCK_ID,
+  });
+
+  const { candidateGroups } = await getMayorResult(store, electionId);
+
+  expect(candidateGroups).toHaveLength(1);
+  expect(candidateGroups[0]!.groupLabel).toEqual('Sherlock Holmes');
+  expect(candidateGroups[0]!.writeIns).toHaveLength(2);
+});
+
+test('write-in image report: preview, print, and export', async () => {
+  const { apiClient, auth, mockPrinterHandler, mockMultiUsbDrive } =
+    buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  mockElectionManagerAuth(auth, electionDefinition.election);
+
+  mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
+  mockMultiUsbDrive.insertUsbDrive({});
+  expectUsbDriveSync(mockMultiUsbDrive);
+
+  const preview = await apiClient.getWriteInImageReportPreview({
+    contestId: MAYOR_CONTEST_ID,
+  });
+  expect(preview.warning).toBeUndefined();
+  expect(preview.pdf).toBeDefined();
+
+  await apiClient.printWriteInImageReport({ contestId: MAYOR_CONTEST_ID });
+  expect(mockPrinterHandler.getLastPrintPath()).toBeDefined();
+
+  const filename = mockFileName('pdf');
+  const exportResult = await apiClient.exportWriteInImageReportPdf({
+    contestId: MAYOR_CONTEST_ID,
+    filename,
+  });
+  exportResult.assertOk('export should have succeeded');
+});
+
+test('write-in image report logging', async () => {
+  const { apiClient, auth, logger, mockPrinterHandler, mockUsbDrive } =
+    buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  mockElectionManagerAuth(auth, electionDefinition.election);
+
+  mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
+  mockUsbDrive.insertUsbDrive({});
+  expectUsbDriveSync(mockUsbDrive);
+
+  const validFilename = mockFileName('pdf');
+  (
+    await apiClient.exportWriteInImageReportPdf({
+      contestId: MAYOR_CONTEST_ID,
+      filename: validFilename,
+    })
+  ).assertOk('export should have succeeded');
+  const reportPath = generateReportPath(electionDefinition, validFilename);
+  expect(logger.log).lastCalledWith(LogEventId.FileSaved, 'election_manager', {
+    disposition: 'success',
+    message: `Saved write-in image report PDF file to ${reportPath} on the USB drive.`,
+    path: reportPath,
+  });
+
+  mockUsbDrive.removeUsbDrive();
+  const invalidFilename = mockFileName('pdf');
+  (
+    await apiClient.exportWriteInImageReportPdf({
+      contestId: MAYOR_CONTEST_ID,
+      filename: invalidFilename,
+    })
+  ).assertErr('export should have failed');
+  const invalidReportPath = generateReportPath(
+    electionDefinition,
+    invalidFilename
+  );
+  expect(logger.log).lastCalledWith(LogEventId.FileSaved, 'election_manager', {
+    disposition: 'failure',
+    message: `Failed to save write-in image report PDF file to ${invalidReportPath} on the USB drive.`,
+    path: invalidReportPath,
+  });
+
+  await apiClient.printWriteInImageReport({ contestId: MAYOR_CONTEST_ID });
+  expect(logger.log).lastCalledWith(
+    LogEventId.ElectionReportPrinted,
+    'election_manager',
+    {
+      message: `User printed the write-in image report.`,
+      disposition: 'success',
+    }
+  );
+
+  mockPrinterHandler.disconnectPrinter();
+  await apiClient.printWriteInImageReport({ contestId: MAYOR_CONTEST_ID });
+  expect(logger.log).lastCalledWith(
+    LogEventId.ElectionReportPrinted,
+    'election_manager',
+    {
+      message: `Error in attempting to print the write-in image report: cannot print without printer connected`,
+      disposition: 'failure',
+    }
+  );
+
+  mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
+  await apiClient.getWriteInImageReportPreview({ contestId: MAYOR_CONTEST_ID });
+  expect(logger.log).lastCalledWith(
+    LogEventId.ElectionReportPreviewed,
+    'election_manager',
+    {
+      message: `User previewed the write-in image report.`,
+      disposition: 'success',
+    }
+  );
+});
+
+test('write-in image report preview: content-too-large warning', async () => {
+  const { apiClient, auth } = buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  mockElectionManagerAuth(auth, electionDefinition.election);
+
+  vi.mocked(renderToPdf).mockResolvedValueOnce(err('content-too-large'));
+  expect(
+    await apiClient.getWriteInImageReportPreview({
+      contestId: MAYOR_CONTEST_ID,
+    })
+  ).toEqual({
+    pdf: undefined,
+    warning: { type: 'content-too-large' },
+  });
+});

--- a/apps/admin/backend/src/reports/write_in_adjudication_report.ts
+++ b/apps/admin/backend/src/reports/write_in_adjudication_report.ts
@@ -64,14 +64,12 @@ export async function generateWriteInAdjudicationReportPreview({
   logger,
   ...reportProps
 }: WriteInAdjudicationReportPreviewProps): Promise<WriteInAdjudicationReportPreview> {
-  const result = await (async () => {
-    const report = buildWriteInAdjudicationReport(reportProps);
-    const pdfResult = await renderToPdf({ document: report });
-    return {
-      pdf: pdfResult.ok(),
-      warning: pdfResult.isErr() ? { type: pdfResult.err() } : undefined,
-    };
-  })();
+  const report = buildWriteInAdjudicationReport(reportProps);
+  const pdfResult = await renderToPdf({ document: report });
+  const result: WriteInAdjudicationReportPreview = {
+    pdf: pdfResult.ok(),
+    warning: pdfResult.isErr() ? { type: pdfResult.err() } : undefined,
+  };
   await logger.logAsCurrentRole(LogEventId.ElectionReportPreviewed, {
     message: `User previewed the write-in adjudication report.${
       result.warning ? ` Warning: ${result.warning.type}` : ''

--- a/apps/admin/backend/src/reports/write_in_image_report.ts
+++ b/apps/admin/backend/src/reports/write_in_image_report.ts
@@ -1,0 +1,324 @@
+import { assert, assertDefined, throwIllegalValue } from '@votingworks/basics';
+import {
+  AdminContestWriteIns,
+  AdminWriteInImageReport,
+  CandidateGroupWriteIns,
+  WriteInEntry,
+} from '@votingworks/ui';
+import { crop, loadImageData, toDataUrl } from '@votingworks/image-utils';
+import { PdfError, Printer, renderToPdf } from '@votingworks/printing';
+import { LogEventId, Logger } from '@votingworks/logging';
+import {
+  BallotPageLayout,
+  CandidateContest,
+  ContestId,
+  SheetOf,
+} from '@votingworks/types';
+import { UsbDrive } from '@votingworks/usb-drive';
+import { join } from 'node:path';
+import { Buffer } from 'node:buffer';
+import { Store } from '../store';
+import { getCurrentTime } from '../util/get_current_time';
+import { ExportDataResult, WriteInRecord } from '../types';
+import { buildExporter } from '../util/exporter';
+import { generateReportsDirectoryPath } from '../util/filenames';
+import { rootDebug } from '../util/debug';
+
+const debug = rootDebug.extend('write-in-image-report');
+
+async function cropWriteInImage(
+  imageBuffer: Buffer,
+  layout: BallotPageLayout,
+  contestId: string,
+  optionId: string
+): Promise<WriteInEntry | undefined> {
+  const contestLayout = layout.contests.find(
+    (c) =>
+      c.contestId === contestId &&
+      c.options.some((o) => o.definition?.id === optionId)
+  );
+  if (!contestLayout) {
+    debug(
+      'no contest layout found for contest %s option %s',
+      contestId,
+      optionId
+    );
+    return undefined;
+  }
+  const optionLayout = assertDefined(
+    contestLayout.options.find((o) => o.definition?.id === optionId)
+  );
+
+  const imageResult = await loadImageData(imageBuffer);
+  if (imageResult.isErr()) {
+    debug('failed to load image: %O', imageResult.err());
+    return undefined;
+  }
+
+  const cropped = crop(imageResult.ok(), optionLayout.bounds);
+  return { type: 'image', dataUrl: toDataUrl(cropped, 'image/png') };
+}
+
+async function buildWriteInEntry(
+  record: WriteInRecord,
+  imagesAndLayouts: SheetOf<{ image: Buffer; layout?: BallotPageLayout }>
+): Promise<WriteInEntry | undefined> {
+  if (record.machineMarkedText) {
+    return { type: 'text', text: record.machineMarkedText };
+  }
+
+  for (const { image, layout } of imagesAndLayouts) {
+    if (!layout) continue;
+    const hasContest = layout.contests.some(
+      (c) => c.contestId === record.contestId
+    );
+    if (hasContest) {
+      return cropWriteInImage(image, layout, record.contestId, record.optionId);
+    }
+  }
+
+  debug(
+    'no page layout found for contest %s on cvr %s',
+    record.contestId,
+    record.cvrId
+  );
+  return undefined;
+}
+
+/** Builds write-in image data grouped by candidate for a single contest. */
+export async function buildAdminContestWriteIns(
+  store: Store,
+  electionId: string,
+  contestId: ContestId
+): Promise<Map<ContestId, AdminContestWriteIns>> {
+  const electionRecord = assertDefined(store.getElection(electionId));
+  const { election } = electionRecord.electionDefinition;
+
+  const contest = assertDefined(
+    election.contests.find(
+      (c): c is CandidateContest =>
+        c.type === 'candidate' && c.allowWriteIns && c.id === contestId
+    )
+  );
+
+  const writeInRecords = store.getWriteInRecords({ electionId, contestId });
+  const writeInCandidates = store.getWriteInCandidates({
+    electionId,
+    contestId,
+  });
+  const writeInCandidatesById = new Map(
+    writeInCandidates.map((c) => [c.id, c])
+  );
+
+  const imagesAndLayoutsByCvrId = new Map<
+    string,
+    SheetOf<{ image: Buffer; layout?: BallotPageLayout }>
+  >();
+
+  function getImagesAndLayouts(
+    cvrId: string
+  ): SheetOf<{ image: Buffer; layout?: BallotPageLayout }> {
+    const cached = imagesAndLayoutsByCvrId.get(cvrId);
+    if (cached) return cached;
+    const loaded = store.getBallotImagesAndLayouts({ cvrId });
+    imagesAndLayoutsByCvrId.set(cvrId, loaded);
+    return loaded;
+  }
+
+  const qualifiedCandidateGroups = new Map<string, CandidateGroupWriteIns>();
+  const invalidGroup: CandidateGroupWriteIns = {
+    groupLabel: 'Invalid',
+    isQualified: false,
+    writeIns: [],
+  };
+  const unadjudicatedWriteIns: WriteInEntry[] = [];
+
+  for (const record of writeInRecords) {
+    const entry = await buildWriteInEntry(
+      record,
+      getImagesAndLayouts(record.cvrId)
+    );
+
+    if (record.status === 'pending') {
+      if (entry) {
+        unadjudicatedWriteIns.push(entry);
+      }
+      continue;
+    }
+
+    switch (record.adjudicationType) {
+      case 'invalid':
+        if (entry) {
+          invalidGroup.writeIns.push(entry);
+        }
+        continue;
+      case 'write-in-candidate':
+      case 'official-candidate':
+        // Remaining adjudicationType is 'write-in-candidate' or 'official-candidate'
+        if (!qualifiedCandidateGroups.has(record.candidateId)) {
+          const candidateName =
+            record.adjudicationType === 'write-in-candidate'
+              ? assertDefined(writeInCandidatesById.get(record.candidateId))
+                  .name
+              : assertDefined(
+                  contest.candidates.find((c) => c.id === record.candidateId)
+                ).name;
+          qualifiedCandidateGroups.set(record.candidateId, {
+            groupLabel: candidateName,
+            isQualified: true,
+            writeIns: [],
+          });
+        }
+        if (entry) {
+          assertDefined(
+            qualifiedCandidateGroups.get(record.candidateId)
+          ).writeIns.push(entry);
+        }
+        continue;
+      /* istanbul ignore next - @preserve */
+      default:
+        throwIllegalValue(record);
+    }
+  }
+
+  const candidateGroups: CandidateGroupWriteIns[] = [
+    ...[...qualifiedCandidateGroups.values()].sort((a, b) =>
+      a.groupLabel.localeCompare(b.groupLabel)
+    ),
+    ...(invalidGroup.writeIns.length > 0 ? [invalidGroup] : []),
+  ];
+
+  return new Map([[contestId, { candidateGroups, unadjudicatedWriteIns }]]);
+}
+
+async function buildWriteInImageReport({
+  store,
+  contestId,
+}: {
+  store: Store;
+  contestId: ContestId;
+}): Promise<JSX.Element> {
+  const electionId = store.getCurrentElectionId();
+  assert(electionId !== undefined);
+  const electionRecord = store.getElection(electionId);
+  assert(electionRecord);
+  const { electionDefinition, electionPackageHash, isOfficialResults } =
+    electionRecord;
+  const { areWriteInCandidatesQualified } = store.getSystemSettings(electionId);
+
+  const contestWriteInsById = await buildAdminContestWriteIns(
+    store,
+    electionId,
+    contestId
+  );
+
+  return AdminWriteInImageReport({
+    electionDefinition,
+    electionPackageHash,
+    isOfficial: isOfficialResults,
+    generatedAtTime: new Date(getCurrentTime()),
+    contestWriteInsById,
+    qualifiedWriteInsEnabled: areWriteInCandidatesQualified ?? false,
+  });
+}
+
+interface WriteInImageReportProps {
+  store: Store;
+  contestId: ContestId;
+  logger: Logger;
+}
+
+interface WriteInImageReportWarning {
+  type: PdfError;
+}
+
+/** Preview data returned when generating the write-in image report. */
+export interface WriteInImageReportPreview {
+  pdf?: Uint8Array;
+  warning?: WriteInImageReportWarning;
+}
+
+/** Generates the write-in image report and returns a PDF preview. */
+export async function generateWriteInImageReportPreview({
+  logger,
+  ...reportProps
+}: WriteInImageReportProps): Promise<WriteInImageReportPreview> {
+  const result = await (async () => {
+    const report = await buildWriteInImageReport(reportProps);
+    const pdfResult = await renderToPdf({ document: report });
+    return {
+      pdf: pdfResult.ok(),
+      warning: pdfResult.isErr() ? { type: pdfResult.err() } : undefined,
+    };
+  })();
+  await logger.logAsCurrentRole(LogEventId.ElectionReportPreviewed, {
+    message: `User previewed the write-in image report.${
+      result.warning ? ` Warning: ${result.warning.type}` : ''
+    }`,
+    disposition: result.pdf ? 'success' : 'failure',
+  });
+  return result;
+}
+
+/** Generates the write-in image report and sends it to the printer. */
+export async function printWriteInImageReport({
+  printer,
+  logger,
+  ...reportProps
+}: WriteInImageReportProps & { printer: Printer }): Promise<void> {
+  const report = await buildWriteInImageReport(reportProps);
+  try {
+    const data = (await renderToPdf({ document: report })).unsafeUnwrap();
+    await printer.print({ data });
+    await logger.logAsCurrentRole(LogEventId.ElectionReportPrinted, {
+      message: `User printed the write-in image report.`,
+      disposition: 'success',
+    });
+  } catch (error) {
+    assert(error instanceof Error);
+    await logger.logAsCurrentRole(LogEventId.ElectionReportPrinted, {
+      message: `Error in attempting to print the write-in image report: ${error.message}`,
+      disposition: 'failure',
+    });
+  }
+}
+
+/** Generates the write-in image report and exports it as a PDF file on the USB drive. */
+export async function exportWriteInImageReportPdf({
+  filename,
+  usbDrive,
+  logger,
+  ...reportProps
+}: WriteInImageReportProps & {
+  filename: string;
+  usbDrive: UsbDrive;
+}): Promise<ExportDataResult> {
+  const report = await buildWriteInImageReport(reportProps);
+  const data = (await renderToPdf({ document: report })).unsafeUnwrap();
+
+  const { store } = reportProps;
+  const electionId = store.getCurrentElectionId();
+  assert(electionId !== undefined);
+  const electionRecord = store.getElection(electionId);
+  assert(electionRecord);
+  const { electionDefinition } = electionRecord;
+  const reportsDirectoryPath = generateReportsDirectoryPath(electionDefinition);
+
+  const exporter = buildExporter(usbDrive);
+  const exportFileResult = await exporter.exportDataToUsbDrive(
+    reportsDirectoryPath,
+    filename,
+    data
+  );
+
+  const reportPath = join(reportsDirectoryPath, filename);
+  await logger.logAsCurrentRole(LogEventId.FileSaved, {
+    disposition: exportFileResult.isOk() ? 'success' : 'failure',
+    message: `${
+      exportFileResult.isOk() ? 'Saved' : 'Failed to save'
+    } write-in image report PDF file to ${reportPath} on the USB drive.`,
+    path: reportPath,
+  });
+
+  return exportFileResult;
+}

--- a/apps/admin/backend/src/reports/write_in_image_report.ts
+++ b/apps/admin/backend/src/reports/write_in_image_report.ts
@@ -1,4 +1,4 @@
-import { assert, assertDefined, throwIllegalValue } from '@votingworks/basics';
+import { assert, assertDefined } from '@votingworks/basics';
 import {
   AdminContestWriteIns,
   AdminWriteInImageReport,
@@ -146,38 +146,29 @@ export async function buildAdminContestWriteIns(
       continue;
     }
 
-    switch (record.adjudicationType) {
-      case 'invalid':
-        if (entry) {
-          invalidGroup.writeIns.push(entry);
-        }
-        continue;
-      case 'write-in-candidate':
-      case 'official-candidate':
-        // Remaining adjudicationType is 'write-in-candidate' or 'official-candidate'
-        if (!qualifiedCandidateGroups.has(record.candidateId)) {
-          const candidateName =
-            record.adjudicationType === 'write-in-candidate'
-              ? assertDefined(writeInCandidatesById.get(record.candidateId))
-                  .name
-              : assertDefined(
-                  contest.candidates.find((c) => c.id === record.candidateId)
-                ).name;
-          qualifiedCandidateGroups.set(record.candidateId, {
-            groupLabel: candidateName,
-            isQualified: true,
-            writeIns: [],
-          });
-        }
-        if (entry) {
-          assertDefined(
-            qualifiedCandidateGroups.get(record.candidateId)
-          ).writeIns.push(entry);
-        }
-        continue;
-      /* istanbul ignore next - @preserve */
-      default:
-        throwIllegalValue(record);
+    if (record.adjudicationType === 'invalid') {
+      if (entry) {
+        invalidGroup.writeIns.push(entry);
+      }
+    } else {
+      if (!qualifiedCandidateGroups.has(record.candidateId)) {
+        const candidateName =
+          record.adjudicationType === 'write-in-candidate'
+            ? assertDefined(writeInCandidatesById.get(record.candidateId)).name
+            : assertDefined(
+                contest.candidates.find((c) => c.id === record.candidateId)
+              ).name;
+        qualifiedCandidateGroups.set(record.candidateId, {
+          groupLabel: candidateName,
+          isQualified: true,
+          writeIns: [],
+        });
+      }
+      if (entry) {
+        assertDefined(
+          qualifiedCandidateGroups.get(record.candidateId)
+        ).writeIns.push(entry);
+      }
     }
   }
 

--- a/apps/admin/backend/src/reports/write_in_image_report.ts
+++ b/apps/admin/backend/src/reports/write_in_image_report.ts
@@ -234,14 +234,12 @@ export async function generateWriteInImageReportPreview({
   logger,
   ...reportProps
 }: WriteInImageReportProps): Promise<WriteInImageReportPreview> {
-  const result = await (async () => {
-    const report = await buildWriteInImageReport(reportProps);
-    const pdfResult = await renderToPdf({ document: report });
-    return {
-      pdf: pdfResult.ok(),
-      warning: pdfResult.isErr() ? { type: pdfResult.err() } : undefined,
-    };
-  })();
+  const report = await buildWriteInImageReport(reportProps);
+  const pdfResult = await renderToPdf({ document: report });
+  const result: WriteInImageReportPreview = {
+    pdf: pdfResult.ok(),
+    warning: pdfResult.isErr() ? { type: pdfResult.err() } : undefined,
+  };
   await logger.logAsCurrentRole(LogEventId.ElectionReportPreviewed, {
     message: `User previewed the write-in image report.${
       result.warning ? ` Warning: ${result.warning.type}` : ''


### PR DESCRIPTION
## Overview

Relates to https://github.com/votingworks/vxsuite/pull/8461

Blocked by https://github.com/votingworks/vxsuite/pull/8503 (recommend reviewing that first)

Adds the backend to VxAdmin for generating, printing, and downloading write-in image reports.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
