### PR TITLE
[VxAdmin] Add write-in image report screen

### DIFF
--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -998,6 +998,47 @@ export const exportWriteInAdjudicationReportPdf = {
   },
 } as const;
 
+export const getWriteInImageReportPreview = {
+  queryKey(contestId: string): QueryKey {
+    return ['getWriteInImageReportPreview', contestId];
+  },
+  useQuery(contestId?: string) {
+    const apiClient = useApiClient();
+    return useQuery(
+      contestId ? this.queryKey(contestId) : ['getWriteInImageReportPreview'],
+      /* istanbul ignore next - @preserve */
+      () =>
+        contestId
+          ? apiClient.getWriteInImageReportPreview({ contestId })
+          : fail('contestId is required'),
+      {
+        enabled: !!contestId,
+        cacheTime: 0,
+        staleTime: 0,
+        refetchOnWindowFocus: false,
+      }
+    );
+  },
+} as const;
+
+export const printWriteInImageReport = {
+  useMutation() {
+    const apiClient = useApiClient();
+    return useMutation((input: { contestId: string }) =>
+      apiClient.printWriteInImageReport(input)
+    );
+  },
+} as const;
+
+export const exportWriteInImageReportPdf = {
+  useMutation() {
+    const apiClient = useApiClient();
+    return useMutation((input: { contestId: string; filename: string }) =>
+      apiClient.exportWriteInImageReportPdf(input)
+    );
+  },
+} as const;
+
 export const getRegisteredVoterCounts = {
   queryKey(): QueryKey {
     return ['getRegisteredVoterCounts'];

--- a/apps/admin/frontend/src/components/app_routes.tsx
+++ b/apps/admin/frontend/src/components/app_routes.tsx
@@ -21,6 +21,7 @@ import { ElectionScreen } from '../screens/election_screen';
 import { UnconfiguredScreen } from '../screens/unconfigured_screen';
 import { TallyScreen } from '../screens/tally/tally_screen';
 import { TallyWriteInReportScreen } from '../screens/reporting/write_in_adjudication_report_screen';
+import { WriteInImageReportScreen } from '../screens/reporting/write_in_image_report_screen';
 import { VoterTurnoutReportScreen } from '../screens/reporting/voter_turnout_report_screen';
 import { SendTallyReportsScreen } from '../screens/reporting/send_tally_reports_screen';
 import { ManualTalliesFormScreen } from '../screens/tally/manual_tallies_form_screen';
@@ -186,6 +187,9 @@ export function AppRoutes(): JSX.Element | null {
       </Route>
       <Route exact path={[routerPaths.tallyWriteInReport]}>
         <TallyWriteInReportScreen />
+      </Route>
+      <Route exact path={routerPaths.writeInImageReport}>
+        <WriteInImageReportScreen />
       </Route>
       <Route exact path={routerPaths.voterTurnoutReport}>
         <VoterTurnoutReportScreen />

--- a/apps/admin/frontend/src/components/reporting/pdf_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/pdf_viewer.tsx
@@ -69,6 +69,11 @@ interface PdfViewerProps {
 function PdfViewerHelper({
   pdfData,
   loading,
+  // SVG render mode is deprecated, but for some reason the PDF
+  // fonts are grainy in kiosk-browser. Because that's not the
+  // case in Chrome, hopefully it's a Chrome version issue and
+  // we can move to the "canvas" default and avoid the console
+  // warnings
   renderMode = 'svg',
 }: PdfViewerProps): JSX.Element {
   const [numPages, setNumPages] = useState<number>();
@@ -144,11 +149,6 @@ function PdfViewerHelper({
                   // ReactPDF renders at 3/4 of actual size for some reason
                   // https://github.com/wojtekmaj/react-pdf/issues/1219
                   scale={DEFAULT_ZOOM * (4 / 3)}
-                  // SVG render mode is deprecated, but for some reason the PDF
-                  // fonts are grainy in kiosk-browser. Because that's not the
-                  // case in Chrome, hopefully it's a Chrome version issue and
-                  // we can move to the "canvas" default and avoid the console
-                  // warnings
                   renderMode={renderMode}
                   pageNumber={pageNumber}
                   renderTextLayer={false}

--- a/apps/admin/frontend/src/components/reporting/pdf_viewer.tsx
+++ b/apps/admin/frontend/src/components/reporting/pdf_viewer.tsx
@@ -63,9 +63,14 @@ const DEFAULT_ZOOM = 1.8;
 interface PdfViewerProps {
   pdfData?: Uint8Array;
   loading?: boolean;
+  renderMode?: 'canvas' | 'svg';
 }
 
-function PdfViewerHelper({ pdfData, loading }: PdfViewerProps): JSX.Element {
+function PdfViewerHelper({
+  pdfData,
+  loading,
+  renderMode = 'svg',
+}: PdfViewerProps): JSX.Element {
   const [numPages, setNumPages] = useState<number>();
   const [currentPage, setCurrentPage] = useState(1);
   const file = useMemo(
@@ -144,7 +149,7 @@ function PdfViewerHelper({ pdfData, loading }: PdfViewerProps): JSX.Element {
                   // case in Chrome, hopefully it's a Chrome version issue and
                   // we can move to the "canvas" default and avoid the console
                   // warnings
-                  renderMode="svg"
+                  renderMode={renderMode}
                   pageNumber={pageNumber}
                   renderTextLayer={false}
                   renderAnnotationLayer={false}
@@ -161,13 +166,18 @@ function PdfViewerHelper({ pdfData, loading }: PdfViewerProps): JSX.Element {
   );
 }
 
-export function PdfViewer({ loading, pdfData }: PdfViewerProps): JSX.Element {
+export function PdfViewer({
+  loading,
+  pdfData,
+  renderMode,
+}: PdfViewerProps): JSX.Element {
   return (
     <PdfViewerHelper
       // Reset the page count state whenever we change the PDF data
       key={String(Boolean(pdfData))}
       loading={loading}
       pdfData={pdfData}
+      renderMode={renderMode}
     />
   );
 }

--- a/apps/admin/frontend/src/router_paths.ts
+++ b/apps/admin/frontend/src/router_paths.ts
@@ -33,6 +33,7 @@ export const routerPaths = {
   ballotCountReportPrecinct: '/reports/ballot-count/precinct',
   ballotCountReportVotingMethod: '/reports/ballot-count/voting-method',
   tallyWriteInReport: '/reports/tally-reports/writein',
+  writeInImageReport: '/reports/write-in-image',
   voterTurnoutReport: '/reports/voter-turnout',
   sendTallyReports: '/reports/send-tally',
   adjudication: '/adjudication',

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
@@ -207,6 +207,16 @@ export function ReportsScreen(): JSX.Element {
           </LinkButton>
         </P>
       </Section>
+      {!closedPollsActionsBlocked && electionHasWriteInContest && (
+        <Section>
+          <H2>Write-In Reports</H2>
+          <P>
+            <LinkButton to={routerPaths.writeInImageReport}>
+              Single Contest Write-In Image Report
+            </LinkButton>
+          </P>
+        </Section>
+      )}
       {!closedPollsActionsBlocked &&
         (electionHasWriteInContest ||
           voterTurnoutReportEnabled ||

--- a/apps/admin/frontend/src/screens/reporting/write_in_image_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/write_in_image_report_screen.test.tsx
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import userEvent from '@testing-library/user-event';
+import { ok } from '@votingworks/basics';
+import { mockUsbDriveStatus } from '@votingworks/ui';
+import { renderInAppContext } from '../../../test/render_in_app_context';
+import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client';
+import {
+  TITLE,
+  WriteInImageReportScreen,
+} from './write_in_image_report_screen';
+import { fireEvent, screen, within } from '../../../test/react_testing_library';
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  apiMock = createApiMock();
+});
+
+afterEach(() => {
+  apiMock.assertComplete();
+});
+
+const electionDefinition =
+  electionFamousNames2021Fixtures.readElectionDefinition();
+const MAYOR_CONTEST_ID = 'mayor';
+
+function selectContest(contestTitle: string) {
+  const select = screen.getByRole('combobox');
+  fireEvent.keyDown(select, { key: 'ArrowDown' });
+  fireEvent.click(screen.getByText(contestTitle));
+}
+
+test('initial state: no contest selected, no actions shown', async () => {
+  renderInAppContext(<WriteInImageReportScreen />, {
+    electionDefinition,
+    apiMock,
+    usbDriveStatus: mockUsbDriveStatus('mounted'),
+  });
+
+  await screen.findByRole('heading', { name: TITLE });
+  expect(
+    screen.queryByRole('button', { name: 'Print Report' })
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: 'Export Report PDF' })
+  ).not.toBeInTheDocument();
+});
+
+test('select contest → preview loads and actions appear', async () => {
+  apiMock.expectGetCastVoteRecordFileMode('official');
+  apiMock.setPrinterStatus({ connected: true });
+  apiMock.expectGetWriteInImageReportPreview(
+    MAYOR_CONTEST_ID,
+    'Mock Write-In Image Report'
+  );
+  renderInAppContext(<WriteInImageReportScreen />, {
+    electionDefinition,
+    apiMock,
+    usbDriveStatus: mockUsbDriveStatus('mounted'),
+  });
+
+  await screen.findByRole('heading', { name: TITLE });
+  selectContest('Mayor');
+
+  await screen.findByText('Mock Write-In Image Report');
+  screen.getByRole('button', { name: 'Print Report' });
+  screen.getByRole('button', { name: 'Export Report PDF' });
+});
+
+test('print report', async () => {
+  apiMock.expectGetCastVoteRecordFileMode('official');
+  apiMock.setPrinterStatus({ connected: true });
+  apiMock.expectGetWriteInImageReportPreview(
+    MAYOR_CONTEST_ID,
+    'Mock Write-In Image Report'
+  );
+  renderInAppContext(<WriteInImageReportScreen />, {
+    electionDefinition,
+    apiMock,
+    usbDriveStatus: mockUsbDriveStatus('mounted'),
+  });
+
+  selectContest('Mayor');
+  await screen.findByText('Mock Write-In Image Report');
+
+  apiMock.apiClient.printWriteInImageReport
+    .expectCallWith({ contestId: MAYOR_CONTEST_ID })
+    .resolves();
+  userEvent.click(screen.getButton('Print Report'));
+  await vi.runOnlyPendingTimersAsync();
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+});
+
+test('export report PDF', async () => {
+  apiMock.expectGetCastVoteRecordFileMode('official');
+  apiMock.setPrinterStatus({ connected: true });
+  apiMock.expectGetWriteInImageReportPreview(
+    MAYOR_CONTEST_ID,
+    'Mock Write-In Image Report'
+  );
+  renderInAppContext(<WriteInImageReportScreen />, {
+    electionDefinition,
+    apiMock,
+    usbDriveStatus: mockUsbDriveStatus('mounted'),
+  });
+
+  selectContest('Mayor');
+  await screen.findByText('Mock Write-In Image Report');
+
+  vi.setSystemTime(new Date('2021-01-01T00:00:00.000Z'));
+  apiMock.apiClient.exportWriteInImageReportPdf
+    .expectCallWith({
+      contestId: MAYOR_CONTEST_ID,
+      filename:
+        'unofficial-write-in-image-report-mayor-2021-01-01T00-00-00.pdf',
+    })
+    .resolves(ok([]));
+  userEvent.click(screen.getButton('Export Report PDF'));
+  const exportModal = await screen.findByRole('alertdialog');
+  userEvent.click(within(exportModal).getButton('Save'));
+  await screen.findByText('Write-In Image Report Saved');
+  userEvent.click(within(exportModal).getButton('Close'));
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+});
+
+test('shows warning and disables actions when PDF is too large', async () => {
+  apiMock.expectGetCastVoteRecordFileMode('official');
+  apiMock.setPrinterStatus({ connected: true });
+  apiMock.apiClient.getWriteInImageReportPreview
+    .expectCallWith({ contestId: MAYOR_CONTEST_ID })
+    .resolves({ pdf: undefined, warning: { type: 'content-too-large' } });
+  renderInAppContext(<WriteInImageReportScreen />, {
+    electionDefinition,
+    apiMock,
+    usbDriveStatus: mockUsbDriveStatus('mounted'),
+  });
+
+  selectContest('Mayor');
+  await screen.findByText('This report is too large to export.');
+  for (const buttonLabel of ['Print Report', 'Export Report PDF']) {
+    expect(screen.getButton(buttonLabel)).toBeDisabled();
+  }
+});

--- a/apps/admin/frontend/src/screens/reporting/write_in_image_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/write_in_image_report_screen.tsx
@@ -1,0 +1,128 @@
+import { useContext, useState } from 'react';
+import { SearchSelect } from '@votingworks/ui';
+import { assert } from '@votingworks/basics';
+import { isElectionManagerAuth } from '@votingworks/utils';
+import { CandidateContest } from '@votingworks/types';
+import styled from 'styled-components';
+import { AppContext } from '../../contexts/app_context';
+import { NavigationScreen } from '../../components/navigation_screen';
+import {
+  ExportActions,
+  reportParentRoutes,
+  ReportScreenContainer,
+  ReportWarning,
+} from '../../components/reporting/shared';
+import { PdfViewer } from '../../components/reporting/pdf_viewer';
+import { PrintButton } from '../../components/print_button';
+import { ExportFileButton } from '../../components/reporting/export_file_button';
+import {
+  exportWriteInImageReportPdf,
+  getWriteInImageReportPreview,
+  printWriteInImageReport,
+} from '../../api';
+
+export const TITLE = 'Single Contest Write-In Image Report';
+
+const SelectContestContainer = styled.div`
+  padding: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+
+  > span {
+    white-space: nowrap;
+  }
+`;
+
+export function WriteInImageReportScreen(): JSX.Element {
+  const { electionDefinition, auth } = useContext(AppContext);
+  assert(electionDefinition);
+  assert(isElectionManagerAuth(auth));
+  const { election } = electionDefinition;
+
+  const [contestId, setContestId] = useState<string>();
+
+  const writeInContests = election.contests.filter(
+    (c): c is CandidateContest => c.type === 'candidate' && c.allowWriteIns
+  );
+
+  const selectedContest = writeInContests.find((c) => c.id === contestId);
+
+  const previewQuery = getWriteInImageReportPreview.useQuery(contestId);
+  const printMutation = printWriteInImageReport.useMutation();
+  const exportMutation = exportWriteInImageReportPdf.useMutation();
+
+  const isPreviewLoading = !!contestId && previewQuery.isFetching;
+  // Clear pdfData while loading so the old contest's PDF is never shown
+  // during the transition to a new contest.
+  const pdfData = isPreviewLoading ? undefined : previewQuery.data?.pdf;
+  const disablePdfExport =
+    previewQuery.data?.warning?.type === 'content-too-large';
+  const actionsDisabled = !contestId || isPreviewLoading || disablePdfExport;
+
+  return (
+    <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes} noPadding>
+      <ReportScreenContainer>
+        <SelectContestContainer>
+          <SearchSelect
+            isMulti={false}
+            isSearchable
+            value={contestId}
+            options={writeInContests.map((c) => ({
+              value: c.id,
+              label: c.title,
+            }))}
+            onChange={(value) => setContestId(value)}
+            aria-label="Select Contest"
+            style={{ width: '30rem' }}
+            placeholder="Select a contest..."
+          />
+        </SelectContestContainer>
+        {contestId && (
+          <div style={{ padding: '1rem' }}>
+            <ExportActions>
+              <PrintButton
+                disabled={actionsDisabled}
+                print={() => printMutation.mutateAsync({ contestId })}
+                variant="primary"
+              >
+                Print Report
+              </PrintButton>{' '}
+              <ExportFileButton
+                buttonText="Export Report PDF"
+                exportMutation={exportMutation}
+                exportParameters={{ contestId }}
+                generateFilename={({ isTestMode, isOfficialResults, time }) => {
+                  const prefix = isTestMode ? 'test-' : '';
+                  const officiality = isOfficialResults
+                    ? 'official'
+                    : 'unofficial';
+                  const contestSlug = (selectedContest?.title ?? contestId)
+                    .toLowerCase()
+                    .replace(/\s+/g, '-');
+                  const timestamp = time
+                    .toISOString()
+                    .slice(0, 19)
+                    .replace(/:/g, '-');
+                  return `${prefix}${officiality}-write-in-image-report-${contestSlug}-${timestamp}.pdf`;
+                }}
+                fileType="write-in image report"
+                fileTypeTitle="Write-In Image Report"
+                disabled={actionsDisabled}
+              />
+            </ExportActions>
+            {previewQuery.data?.warning && (
+              <ReportWarning>This report is too large to export.</ReportWarning>
+            )}
+          </div>
+        )}
+        <PdfViewer
+          key={contestId ?? 'no-contest'}
+          loading={isPreviewLoading}
+          pdfData={pdfData}
+          renderMode="canvas"
+        />
+      </ReportScreenContainer>
+    </NavigationScreen>
+  );
+}

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -791,6 +791,19 @@ export function createApiMock(
       apiClient.exportVoterTurnoutReportPdf
     ),
 
+    expectGetWriteInImageReportPreview(contestId: string, pdfContent: string) {
+      apiClient.getWriteInImageReportPreview
+        .expectCallWith({ contestId })
+        .resolves({ pdf: Buffer.from(pdfContent) });
+    },
+
+    expectPrintWriteInImageReport: createDeferredMock(
+      apiClient.printWriteInImageReport
+    ),
+    expectExportWriteInImageReportPdf: createDeferredMock(
+      apiClient.exportWriteInImageReportPdf
+    ),
+
     expectRebootToVendorMenu() {
       apiClient.rebootToVendorMenu.expectCallWith().resolves();
     },


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/8077

Blocked by https://github.com/votingworks/vxsuite/pull/8503 and https://github.com/votingworks/vxsuite/pull/8506 (recommend reviewing those first)

Completes VxAdmin write-in image report changes. Adds a screen for VxAdmin users to generate write-in image reports for a single contest.

## Demo Video or Screenshot

On the reports page:

<img width="1776" height="1268" alt="Screenshot 2026-05-18 at 8 19 21 AM" src="https://github.com/user-attachments/assets/4da5c49e-e550-4ee8-b065-77a3a18a9ddb" />

**With adjudications, >0 valid write-ins**

<img width="2088" height="1306" alt="Screenshot 2026-05-19 at 9 54 36 AM" src="https://github.com/user-attachments/assets/1de930d5-5695-4797-be57-c47cbc201c4b" />


**With adjudications, all invalid write-ins**

<img width="1624" height="1056" alt="Screenshot 2026-05-20 at 10 23 19 AM" src="https://github.com/user-attachments/assets/a9877b93-eae6-48c9-ab2c-37dfa9736295" />


**Adjudication not finished, so write-ins are not considered invalid or valid**


<img width="2088" height="1306" alt="Screenshot 2026-05-19 at 9 52 16 AM" src="https://github.com/user-attachments/assets/6bed075b-70ef-408d-af11-e7ef8034a27d" />

**When the qualified write-in flag is off**

The only difference should be in the "no write-ins" copy. nb. this screenshot shows old custom styling for the text which have been replaced by `<P italics>` in the screenshot `**With adjudications, all invalid write-ins**` above.

<img width="2088" height="1306" alt="Screenshot 2026-05-19 at 11 00 27 AM" src="https://github.com/user-attachments/assets/477d1e7f-86f2-4a72-bb30-e5ba4f73cb5f" />

Other states (write-ins are adjudicated, write-ins are not adjudicated) remain the same

<img width="2088" height="1306" alt="Screenshot 2026-05-19 at 10 59 24 AM" src="https://github.com/user-attachments/assets/fa212b57-e6b7-4889-836d-0f37686d7766" />
<img width="2088" height="1306" alt="Screenshot 2026-05-19 at 10 59 03 AM" src="https://github.com/user-attachments/assets/5b86787d-8de5-4106-af31-86044fbd61e3" />



## Testing Plan
- added tests for component and frontend page

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
