### PR TITLE
[VxMark] Prevent duplicate ballot printing when poll worker interrupts print session

### DIFF
--- a/apps/mark/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark/frontend/src/app_cardless_voting.test.tsx
@@ -179,6 +179,76 @@ test('poll worker selects ballot style, voter votes', async () => {
   await screen.findByText('Insert Card');
 });
 
+test('poll worker card insertion during printing does not cause duplicate print', async () => {
+  const electionDefinition = readElectionGeneralDefinition();
+  apiMock.expectGetMachineConfig();
+  apiMock.expectGetSystemSettings();
+  apiMock.expectGetElectionRecord(electionDefinition);
+  apiMock.expectGetElectionState({
+    precinctSelection: CENTER_SPRINGFIELD_PRECINCT_SELECTION,
+    pollsState: 'polls_open',
+  });
+  render(<App apiClient={apiMock.mockApiClient} />);
+  const findByTextWithMarkup = withMarkup(screen.findByText);
+
+  // Activate voter session
+  apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
+    cardlessVoterUserParams: { ballotStyleId: '12', precinctId: '23' },
+  });
+  await screen.findByText('Remove Card to Begin Voting Session');
+
+  // Poll worker removes card
+  apiMock.setAuthStatusCardlessVoterLoggedIn({
+    ballotStyleId: '12',
+    precinctId: '23',
+  });
+  await findByTextWithMarkup('Number of contests on your ballot: 20');
+  userEvent.click(screen.getByText('Start Voting'));
+
+  // Voter makes a selection and navigates to review
+  for (let i = 0; i < voterContests.length; i += 1) {
+    const { title } = voterContests[i];
+    await screen.findByRole('heading', { name: title });
+    if (title === presidentContest.title) {
+      userEvent.click(screen.getByText(presidentContest.candidates[0].name));
+    }
+    userEvent.click(screen.getByText('Next'));
+  }
+
+  // Voter clicks print — only one printBallot call should ever be made
+  apiMock.expectPrintBallot({
+    ballotStyleId: '12',
+    precinctId: '23',
+    votes: { [presidentContest.id]: [presidentContest.candidates[0]] },
+  });
+  apiMock.expectGetElectionState({ ballotsPrintedCount: 1 });
+  userEvent.click(screen.getByText(/Print My ballot/i));
+  await screen.findByText(/Printing Your Ballot/i);
+
+  // Poll worker inserts card while ballot is printing
+  apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
+    cardlessVoterUserParams: { ballotStyleId: '12', precinctId: '23' },
+  });
+  await screen.findByText('Voting Session Paused');
+
+  // Poll worker removes card — voter session resumes at the print screen
+  apiMock.setAuthStatusCardlessVoterLoggedIn({
+    ballotStyleId: '12',
+    precinctId: '23',
+  });
+  // The print screen is shown again but no second printBallot call is made
+  await screen.findByText(/Printing Your Ballot/i);
+
+  // Normal session end after print timeout
+  await advanceTimersAndPromises(GLOBALS.BALLOT_PRINTING_TIMEOUT_SECONDS);
+  screen.getByText('You’re Almost Done');
+
+  apiMock.mockApiClient.endCardlessVoterSession.expectCallWith().resolves();
+  await advanceTimersAndPromises(GLOBALS.BALLOT_INSTRUCTIONS_TIMEOUT_SECONDS);
+  apiMock.setAuthStatusLoggedOut();
+  await screen.findByText('Insert Card');
+});
+
 test('in "All Precincts" mode, poll worker must select a precinct first', async () => {
   const electionDefinition = readElectionGeneralDefinition();
   apiMock.expectGetMachineConfig();

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -86,6 +86,7 @@ export interface VotingState {
   showPostVotingInstructions?: boolean;
   showingPatCalibration?: boolean;
   isPatCalibrationComplete?: boolean;
+  hasPrintedBallot?: boolean;
 }
 
 export const stateStorageKey = 'state';
@@ -104,6 +105,7 @@ const initialVotingState: Readonly<VotingState> = {
   showPostVotingInstructions: undefined,
   showingPatCalibration: undefined,
   isPatCalibrationComplete: undefined,
+  hasPrintedBallot: undefined,
 };
 
 // Sets State. All side effects done outside: storage, fetching, etc
@@ -113,7 +115,8 @@ type VotingAction =
   | { type: 'resetBallot'; showPostVotingInstructions?: boolean }
   | { type: 'selectParty'; partyId: PartyId }
   | { type: 'showPatCalibration' }
-  | { type: 'completePatCalibration' };
+  | { type: 'completePatCalibration' }
+  | { type: 'setPrintedBallot' };
 
 function votingStateReducer(
   state: VotingState,
@@ -158,6 +161,8 @@ function votingStateReducer(
         showingPatCalibration: false,
         isPatCalibrationComplete: true,
       };
+    case 'setPrintedBallot':
+      return { ...state, hasPrintedBallot: true };
     default: {
       /* istanbul ignore next - @preserve */
       throwIllegalValue(action);
@@ -177,6 +182,7 @@ export function AppRoot(): JSX.Element | null {
     selectedPartyId,
     showingPatCalibration,
     isPatCalibrationComplete,
+    hasPrintedBallot,
   } = votingState;
 
   const history = useHistory();
@@ -303,6 +309,10 @@ export function AppRoot(): JSX.Element | null {
       onSessionEnd,
     ]
   );
+
+  const setPrintedBallot = useCallback(() => {
+    dispatchVotingState({ type: 'setPrintedBallot' });
+  }, []);
 
   const hidePostVotingInstructions = useCallback(() => {
     clearTimeout(PostVotingInstructionsTimeout.current);
@@ -641,9 +651,11 @@ export function AppRoot(): JSX.Element | null {
               isCardlessVoter: isCardlessVoterAuth(authStatus),
               isLiveMode: !isTestMode,
               endVoterSession,
+              hasPrintedBallot: hasPrintedBallot ?? false,
               resetBallot,
               selectedPartyId,
               selectParty,
+              setPrintedBallot,
               updateVote,
               votes: votes ?? blankBallotVotes,
             }}

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -116,7 +116,7 @@ type VotingAction =
   | { type: 'selectParty'; partyId: PartyId }
   | { type: 'showPatCalibration' }
   | { type: 'completePatCalibration' }
-  | { type: 'setPrintedBallot' };
+  | { type: 'setHasPrintedBallot' };
 
 function votingStateReducer(
   state: VotingState,
@@ -161,7 +161,7 @@ function votingStateReducer(
         showingPatCalibration: false,
         isPatCalibrationComplete: true,
       };
-    case 'setPrintedBallot':
+    case 'setHasPrintedBallot':
       return { ...state, hasPrintedBallot: true };
     default: {
       /* istanbul ignore next - @preserve */
@@ -310,8 +310,8 @@ export function AppRoot(): JSX.Element | null {
     ]
   );
 
-  const setPrintedBallot = useCallback(() => {
-    dispatchVotingState({ type: 'setPrintedBallot' });
+  const setHasPrintedBallot = useCallback(() => {
+    dispatchVotingState({ type: 'setHasPrintedBallot' });
   }, []);
 
   const hidePostVotingInstructions = useCallback(() => {
@@ -655,7 +655,7 @@ export function AppRoot(): JSX.Element | null {
               resetBallot,
               selectedPartyId,
               selectParty,
-              setPrintedBallot,
+              setHasPrintedBallot,
               updateVote,
               votes: votes ?? blankBallotVotes,
             }}

--- a/apps/mark/frontend/src/config/types.ts
+++ b/apps/mark/frontend/src/config/types.ts
@@ -20,6 +20,8 @@ export interface BallotContextInterface {
   isCardlessVoter: boolean;
   isLiveMode: boolean;
   endVoterSession: () => Promise<void>;
+  hasPrintedBallot: boolean;
+  setPrintedBallot: () => void;
   precinctId?: PrecinctId;
   resetBallot: (showPostVotingInstructions?: boolean) => void;
   // `selectedPartyId` and `selectParty` apply only to open primaries, where the

--- a/apps/mark/frontend/src/config/types.ts
+++ b/apps/mark/frontend/src/config/types.ts
@@ -21,7 +21,7 @@ export interface BallotContextInterface {
   isLiveMode: boolean;
   endVoterSession: () => Promise<void>;
   hasPrintedBallot: boolean;
-  setPrintedBallot: () => void;
+  setHasPrintedBallot: () => void;
   precinctId?: PrecinctId;
   resetBallot: (showPostVotingInstructions?: boolean) => void;
   // `selectedPartyId` and `selectParty` apply only to open primaries, where the

--- a/apps/mark/frontend/src/contexts/ballot_context.ts
+++ b/apps/mark/frontend/src/contexts/ballot_context.ts
@@ -12,7 +12,7 @@ const ballot: BallotContextInterface = {
   isCardlessVoter: false,
   isLiveMode: false,
   hasPrintedBallot: false,
-  setPrintedBallot: () => undefined,
+  setHasPrintedBallot: () => undefined,
   endVoterSession: () => Promise.resolve(),
   resetBallot: () => undefined,
   selectParty: () => undefined,

--- a/apps/mark/frontend/src/contexts/ballot_context.ts
+++ b/apps/mark/frontend/src/contexts/ballot_context.ts
@@ -11,6 +11,8 @@ const ballot: BallotContextInterface = {
   contests: [],
   isCardlessVoter: false,
   isLiveMode: false,
+  hasPrintedBallot: false,
+  setPrintedBallot: () => undefined,
   endVoterSession: () => Promise.resolve(),
   resetBallot: () => undefined,
   selectParty: () => undefined,

--- a/apps/mark/frontend/src/pages/print_page.tsx
+++ b/apps/mark/frontend/src/pages/print_page.tsx
@@ -7,22 +7,36 @@ import { BALLOT_PRINTING_TIMEOUT_SECONDS } from '../config/globals';
 import { printBallot } from '../api';
 
 export function PrintPage(): JSX.Element {
-  const { ballotStyleId, precinctId, votes, resetBallot } =
-    useContext(BallotContext);
+  const {
+    ballotStyleId,
+    precinctId,
+    votes,
+    resetBallot,
+    hasPrintedBallot,
+    setPrintedBallot,
+  } = useContext(BallotContext);
   const languageCode = useCurrentLanguage();
   const printBallotMutation = printBallot.useMutation();
 
   const printerTimer = useRef(0);
 
   function print() {
-    assert(ballotStyleId !== undefined);
-    assert(precinctId !== undefined);
-    printBallotMutation.mutate({
-      languageCode,
-      precinctId,
-      ballotStyleId,
-      votes,
-    });
+    // We track the printed ballot state to avoid re-printing in the case where
+    // the voter flow is unmounted and re-mounted during ballot printing. This
+    // is an edge case that would require an authenticated user (e.g. poll
+    // worker) to log in and out during print. `print` is triggered by a
+    // downstream useEffect, which is why it can be called multiple times.
+    if (!hasPrintedBallot) {
+      assert(ballotStyleId !== undefined);
+      assert(precinctId !== undefined);
+      setPrintedBallot();
+      printBallotMutation.mutate({
+        languageCode,
+        precinctId,
+        ballotStyleId,
+        votes,
+      });
+    }
 
     printerTimer.current = window.setTimeout(() => {
       resetBallot(true);

--- a/apps/mark/frontend/src/pages/print_page.tsx
+++ b/apps/mark/frontend/src/pages/print_page.tsx
@@ -13,7 +13,7 @@ export function PrintPage(): JSX.Element {
     votes,
     resetBallot,
     hasPrintedBallot,
-    setPrintedBallot,
+    setHasPrintedBallot,
   } = useContext(BallotContext);
   const languageCode = useCurrentLanguage();
   const printBallotMutation = printBallot.useMutation();
@@ -29,7 +29,7 @@ export function PrintPage(): JSX.Element {
     if (!hasPrintedBallot) {
       assert(ballotStyleId !== undefined);
       assert(precinctId !== undefined);
-      setPrintedBallot();
+      setHasPrintedBallot();
       printBallotMutation.mutate({
         languageCode,
         precinctId,

--- a/apps/mark/frontend/test/test_utils.tsx
+++ b/apps/mark/frontend/test/test_utils.tsx
@@ -66,7 +66,7 @@ export function render(
           machineConfig,
           endVoterSession,
           hasPrintedBallot: false,
-          setPrintedBallot: () => undefined,
+          setHasPrintedBallot: () => undefined,
           precinctId,
           resetBallot,
           selectedPartyId,

--- a/apps/mark/frontend/test/test_utils.tsx
+++ b/apps/mark/frontend/test/test_utils.tsx
@@ -65,6 +65,8 @@ export function render(
           isLiveMode,
           machineConfig,
           endVoterSession,
+          hasPrintedBallot: false,
+          setPrintedBallot: () => undefined,
           precinctId,
           resetBallot,
           selectedPartyId,


### PR DESCRIPTION
## Overview

Fixes https://github.com/votingworks/vxsuite/issues/8392

When a poll worker inserts their card while a voter is on the "Printing Your Ballot" screen and then removes it, the `PrintPage` component unmounts and remounts — triggering a second `printBallot` call and printing a duplicate ballot.

**Root cause:** The guard against double-printing was a `useLock()` ref local to the `PrintPage` component instance. When `PrintPage` unmounts (because `isPollWorkerAuth` causes `AppRoot` to render `PollWorkerScreen` instead of `Ballot`), the lock ref is destroyed. On remount, a fresh lock allows `print()` to fire again.

**Fix:** Store a `hasPrintedBallot` flag in `VotingState` in `AppRoot`, which survives the unmount/remount cycle. `print()` checks the flag before issuing the API call — on remount it skips the print but still sets the session-end timer so the flow completes normally.

## Demo Video or Screenshot

N/A

## Testing Plan

- New regression test in `app_cardless_voting.test.tsx` covers the exact exploit sequence: voter reaches print screen → poll worker inserts card → poll worker removes card → verify only one `printBallot` call was made (enforced by `mockApiClient.assertComplete()` in `afterEach`)
- Confirmed the test fails without the fix and passes with it

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)