### PR TITLE
[VxMark] Don't read precinct name when poll worker selects ballot style

### DIFF
--- a/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.tsx
@@ -14,6 +14,7 @@ import {
   Font,
   P,
   SearchSelect,
+  TextOnly,
 } from '@votingworks/ui';
 import { getBallotStyleGroupsForPrecinctOrSplit } from '@votingworks/utils';
 import { useState } from 'react';
@@ -66,7 +67,8 @@ export function BallotStyleSelect(props: BallotStyleSelectProps): JSX.Element {
           rightIcon="Next"
           disabled={disabled}
         >
-          Start Voting Session: {electionStrings.precinctName(precinct)}
+          Start Voting Session:{' '}
+          <TextOnly>{electionStrings.precinctName(precinct)}</TextOnly>
         </Button>
       );
     }


### PR DESCRIPTION
## Overview

Closes #8406

When the poll worker clicks "Start Voting Session: [precinct name]", the `UiStringScreenReader` captures the click event and reads any `UiString` elements found within the button target. The button label used `electionStrings.precinctName(precinct)`, which renders a `UiString`/`WithAudio` component that adds `data-i18n-key` attributes — causing the precinct name to be read aloud.

The fix wraps just the `electionStrings.precinctName()` call in `TextOnly`, which sets `UiStringsAudioContext` to `undefined` so `WithAudio` skips adding audio data attributes. The visual rendering is unchanged.

Maybe this is indicative of a larger problem. Should the screen reader be disabled on poll worker screens? Should we not be using electionStrings on the poll worker screen, but some other simpler helper? In any case, this quick fix addresses the issue with existing helpers in a few lines of code.

## Demo Video or Screenshot

## Testing Plan

- [x] Confirmed existing tests pass: `pnpm test:run` in `libs/mark-flow-ui`
- [x] Manual test on VxMark with headphones connected: clicking "Start Voting Session" should no longer read the precinct name aloud

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.