### PR TITLE
VxDesign: Hide density options for NH state ballot template

### DIFF
--- a/apps/design/frontend/src/ballots_screen.test.tsx
+++ b/apps/design/frontend/src/ballots_screen.test.tsx
@@ -386,6 +386,26 @@ describe('Ballot layout tab', () => {
     ).not.toBeInTheDocument();
   });
 
+  test('hides density for NH state ballot template', async () => {
+    mockStateFeatures(apiMock, electionId, {});
+    apiMock.getBallotLayoutSettings.expectCallWith({ electionId }).resolves({
+      paperSize: election.ballotLayout.paperSize,
+      compact: false,
+    });
+    apiMock.getBallotTemplate
+      .expectCallWith({ electionId })
+      .resolves('NhStateBallot');
+    renderScreen(electionId);
+    await screen.findByRole('heading', { name: 'Proof Ballots' });
+
+    userEvent.click(screen.getByRole('tab', { name: 'Ballot Layout' }));
+
+    await screen.findByRole('radiogroup', { name: 'Paper Size' });
+    expect(
+      screen.queryByRole('radiogroup', { name: 'Density' })
+    ).not.toBeInTheDocument();
+  });
+
   test('cancelling', async () => {
     mockStateFeatures(apiMock, electionId, {});
     mockUserFeatures(apiMock, {});

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -107,31 +107,32 @@ function BallotDesignForm({
           disabled={!isEditing}
         />
       </div>
-      {ballotTemplateId !== 'MiBallot' && (
-        <div style={{ maxWidth: '16.5rem' }}>
-          <RadioGroup
-            label="Density"
-            options={[
-              {
-                label: 'Default',
-                value: 'default',
-              },
-              {
-                label: 'Compact',
-                value: 'compact',
-              },
-            ]}
-            value={layoutSettings.compact ? 'compact' : 'default'}
-            onChange={(value) =>
-              setLayoutSettings({
-                ...layoutSettings,
-                compact: value === 'compact',
-              })
-            }
-            disabled={!isEditing}
-          />
-        </div>
-      )}
+      {ballotTemplateId !== 'MiBallot' &&
+        ballotTemplateId !== 'NhStateBallot' && (
+          <div style={{ maxWidth: '16.5rem' }}>
+            <RadioGroup
+              label="Density"
+              options={[
+                {
+                  label: 'Default',
+                  value: 'default',
+                },
+                {
+                  label: 'Compact',
+                  value: 'compact',
+                },
+              ]}
+              value={layoutSettings.compact ? 'compact' : 'default'}
+              onChange={(value) =>
+                setLayoutSettings({
+                  ...layoutSettings,
+                  compact: value === 'compact',
+                })
+              }
+              disabled={!isEditing}
+            />
+          </div>
+        )}
       {isEditing ? (
         <FormActionsRow>
           <Button type="reset">Cancel</Button>


### PR DESCRIPTION


## Overview

<!-- Add a link to a GitHub issue here -->
The state ballot template doesn't support compact density.

## Demo Video or Screenshot
<img width="1312" height="730" alt="Screenshot 2026-05-26 at 12 41 33 PM" src="https://github.com/user-attachments/assets/7c0d63b8-4ded-4f7a-9453-86152b1eded5" />


## Testing Plan
Added automated test

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
