### PR TITLE
hmpb: Refactor layoutInColumns function to return leftover elements

### DIFF
--- a/libs/hmpb/src/ballot_templates/ms_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/ms_ballot_template.tsx
@@ -569,9 +569,9 @@ async function BallotPageContent(
     const measuredContests = iter(contestElements)
       .zip(contestMeasurements)
       .map(([element, measurements]) => ({ element, ...measurements }))
-      .async();
+      .toArray();
 
-    const { columns, height } = await layOutInColumns({
+    const { columns, height, leftoverElements } = layOutInColumns({
       elements: measuredContests,
       numColumns,
       maxColumnHeight: dimensions.height - heightUsed,
@@ -579,9 +579,8 @@ async function BallotPageContent(
     });
 
     // Put contests we didn't lay out back on the front of the queue
-    const numElementsUsed = columns.flat().length;
-    if (numElementsUsed < section.length) {
-      contestSections.unshift(section.slice(numElementsUsed));
+    if (leftoverElements.length > 0) {
+      contestSections.unshift(section.slice(-leftoverElements.length));
     }
 
     // If there wasn't enough room left for any contests, go to the next page

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -955,9 +955,9 @@ async function BallotPageContent(
     const measuredContests = iter(contestElements)
       .zip(contestMeasurements)
       .map(([element, measurements]) => ({ element, ...measurements }))
-      .async();
+      .toArray();
 
-    const { columns, height } = await layOutInColumns({
+    const { columns, height, leftoverElements } = layOutInColumns({
       elements: measuredContests,
       numColumns,
       maxColumnHeight: dimensions.height - heightUsed,
@@ -965,9 +965,8 @@ async function BallotPageContent(
     });
 
     // Put contests we didn't lay out back on the front of the queue
-    const numElementsUsed = columns.flat().length;
-    if (numElementsUsed < section.length) {
-      contestSections.unshift(section.slice(numElementsUsed));
+    if (leftoverElements.length > 0) {
+      contestSections.unshift(section.slice(-leftoverElements.length));
     }
 
     // If there wasn't enough room left for any contests, go to the next page

--- a/libs/hmpb/src/ballot_templates/nh_state_general_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_state_general_ballot_template.tsx
@@ -733,28 +733,22 @@ export async function BallotPageContent(
     const measuredContests = iter(contestElements)
       .zip(contestMeasurements)
       .map(([element, measurements]) => ({ element, ...measurements }))
-      .async();
+      .toArray();
 
-    const { columns, height } = await layOutInColumns({
+    const { columns, height, leftoverElements } = layOutInColumns({
       elements: measuredContests,
       numColumns: 1,
       maxColumnHeight: dimensions.height - heightUsed,
     });
 
     // Put contests we didn't lay out back on the front of the queue
-    const numElementsUsed = Math.max(
-      0,
-      columns.flat().length - 1 // -1 for the header
-    );
-    if (numElementsUsed < section.length) {
-      contestSections.unshift(section.slice(numElementsUsed));
+    if (leftoverElements.length > 0) {
+      contestSections.unshift(section.slice(-leftoverElements.length));
     }
 
     // If there wasn't enough room left for any contests, go to the next page
-    if (
-      height === 0 ||
-      numElementsUsed === 0 // Only the header fit
-    ) {
+    const onlyHeaderFit = leftoverElements.length === section.length;
+    if (height === 0 || onlyHeaderFit) {
       break;
     }
 

--- a/libs/hmpb/src/ballot_templates/nh_state_primary_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_state_primary_ballot_template.tsx
@@ -613,14 +613,13 @@ export async function BallotPageContent(
     .filter((section) => section.length > 0);
 
   // Add as many contests on this page as will fit.
-  const contestSectionsLeftToLayout = contestSections;
   const pageSections: JSX.Element[] = [];
   const sectionGapPx = 5;
   let heightUsed = 0;
 
   const horizontalGapPx = 5;
   while (contestSections.length > 0 && heightUsed < dimensions.height) {
-    const section = assertDefined(contestSectionsLeftToLayout.shift());
+    const section = assertDefined(contestSections.shift());
     const contestElements = section.map((contest) => (
       <Contest
         key={contest.id}
@@ -655,18 +654,17 @@ export async function BallotPageContent(
     const measuredContests = iter(contestElements)
       .zip(contestMeasurements)
       .map(([element, measurements]) => ({ element, ...measurements }))
-      .async();
+      .toArray();
 
-    const { columns, height } = await layOutInColumns({
+    const { columns, height, leftoverElements } = layOutInColumns({
       elements: measuredContests,
       numColumns,
       maxColumnHeight: dimensions.height - heightUsed,
     });
 
     // Put contests we didn't lay out back on the front of the queue
-    const numElementsUsed = columns.flat().length;
-    if (numElementsUsed < section.length) {
-      contestSectionsLeftToLayout.unshift(section.slice(numElementsUsed));
+    if (leftoverElements.length > 0) {
+      contestSections.unshift(section.slice(-leftoverElements.length));
     }
 
     // If there wasn't enough room left for any contests, go to the next page
@@ -700,7 +698,7 @@ export async function BallotPageContent(
     );
   }
 
-  const contestsLeftToLayout = contestSectionsLeftToLayout.flat();
+  const contestsLeftToLayout = contestSections.flat();
   if (heightUsed === 0) {
     return err({
       error: 'contestTooLong',
@@ -723,13 +721,13 @@ export async function BallotPageContent(
       <React.Fragment />
     );
   const nextPageProps =
-    contestSectionsLeftToLayout.length > 0
+    contestSections.length > 0
       ? {
           ...restProps,
           ballotStyleId,
           election: {
             ...election,
-            contests: contestSectionsLeftToLayout.flat(),
+            contests: contestSections.flat(),
           },
         }
       : undefined;

--- a/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
@@ -521,9 +521,9 @@ async function BallotPageContent(
     const measuredContests = iter(contestElements)
       .zip(contestMeasurements)
       .map(([element, measurements]) => ({ element, ...measurements }))
-      .async();
+      .toArray();
 
-    const { columns, height } = await layOutInColumns({
+    const { columns, height, leftoverElements } = layOutInColumns({
       elements: measuredContests,
       numColumns,
       maxColumnHeight: dimensions.height - heightUsed,
@@ -531,9 +531,8 @@ async function BallotPageContent(
     });
 
     // Put contests we didn't lay out back on the front of the queue
-    const numElementsUsed = columns.flat().length;
-    if (numElementsUsed < section.length) {
-      contestSections.unshift(section.slice(numElementsUsed));
+    if (leftoverElements.length > 0) {
+      contestSections.unshift(section.slice(-leftoverElements.length));
     }
 
     // If there wasn't enough room left for any contests, go to the next page

--- a/libs/hmpb/src/layout_in_columns.test.ts
+++ b/libs/hmpb/src/layout_in_columns.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import * as fc from 'fast-check';
 import { iter, range } from '@votingworks/basics';
 import {
@@ -19,198 +19,186 @@ describe('layOutInColumns', () => {
   const c2: TestElement = { id: 'c', height: 2 };
   const d2: TestElement = { id: 'd', height: 2 };
 
-  test('lays out as many elements as possible, minimizing column height', async () => {
+  test('lays out as many elements as possible, minimizing column height', () => {
     expect(
-      await layOutInColumns({
-        elements: iter([]).async(),
+      layOutInColumns({
+        elements: [],
         numColumns: 1,
         maxColumnHeight: 1,
       })
     ).toEqual({
       columns: [[]],
       height: 0,
+      leftoverElements: [],
     });
 
     expect(
-      await layOutInColumns({
-        elements: iter([a1]).async(),
+      layOutInColumns({
+        elements: [a1],
         numColumns: 1,
         maxColumnHeight: 1,
       })
     ).toEqual({
       columns: [[a1]],
       height: 1,
+      leftoverElements: [],
     });
 
     expect(
-      await layOutInColumns({
-        elements: iter([a1]).async(),
+      layOutInColumns({
+        elements: [a1],
         numColumns: 2,
         maxColumnHeight: 1,
       })
     ).toEqual({
       columns: [[a1], []],
       height: 1,
+      leftoverElements: [],
     });
 
     expect(
-      await layOutInColumns({
-        elements: iter([a1, b1]).async(),
+      layOutInColumns({
+        elements: [a1, b1],
         numColumns: 1,
         maxColumnHeight: 1,
       })
     ).toEqual({
       columns: [[a1]],
       height: 1,
+      leftoverElements: [b1],
     });
 
     expect(
-      await layOutInColumns({
-        elements: iter([a1, b1]).async(),
+      layOutInColumns({
+        elements: [a1, b1],
         numColumns: 2,
         maxColumnHeight: 1,
       })
     ).toEqual({
       columns: [[a1], [b1]],
       height: 1,
+      leftoverElements: [],
     });
 
     expect(
-      await layOutInColumns({
-        elements: iter([a1, b1]).async(),
+      layOutInColumns({
+        elements: [a1, b1],
         numColumns: 1,
         maxColumnHeight: 2,
       })
     ).toEqual({
       columns: [[a1, b1]],
       height: 2,
+      leftoverElements: [],
     });
 
     expect(
-      await layOutInColumns({
-        elements: iter([a1, b1]).async(),
+      layOutInColumns({
+        elements: [a1, b1],
         numColumns: 2,
         maxColumnHeight: 2,
       })
     ).toEqual({
       columns: [[a1], [b1]],
       height: 1,
+      leftoverElements: [],
     });
 
     expect(
-      await layOutInColumns({
-        elements: iter([a1, b1]).async(),
+      layOutInColumns({
+        elements: [a1, b1],
         numColumns: 3,
         maxColumnHeight: 1,
       })
     ).toEqual({
       columns: [[a1], [b1], []],
       height: 1,
+      leftoverElements: [],
     });
 
     expect(
-      await layOutInColumns({
-        elements: iter([a1, b1, c2]).async(),
+      layOutInColumns({
+        elements: [a1, b1, c2],
         numColumns: 1,
         maxColumnHeight: 1,
       })
     ).toEqual({
       columns: [[a1]],
       height: 1,
+      leftoverElements: [b1, c2],
     });
 
     expect(
-      await layOutInColumns({
-        elements: iter([a1, b1, c2]).async(),
+      layOutInColumns({
+        elements: [a1, b1, c2],
         numColumns: 1,
         maxColumnHeight: 2,
       })
     ).toEqual({
       columns: [[a1, b1]],
       height: 2,
+      leftoverElements: [c2],
     });
 
     expect(
-      await layOutInColumns({
-        elements: iter([a1, b1, c2]).async(),
+      layOutInColumns({
+        elements: [a1, b1, c2],
         numColumns: 2,
         maxColumnHeight: 1,
       })
     ).toEqual({
       columns: [[a1], [b1]],
       height: 1,
+      leftoverElements: [c2],
     });
 
     expect(
-      await layOutInColumns({
-        elements: iter([a1, b1, c2]).async(),
+      layOutInColumns({
+        elements: [a1, b1, c2],
         numColumns: 2,
         maxColumnHeight: 2,
       })
     ).toEqual({
       columns: [[a1, b1], [c2]],
       height: 2,
+      leftoverElements: [],
     });
 
     expect(
-      await layOutInColumns({
-        elements: iter([a1, b1, c2]).async(),
+      layOutInColumns({
+        elements: [a1, b1, c2],
         numColumns: 3,
         maxColumnHeight: 1,
       })
     ).toEqual({
       columns: [[a1], [b1], []],
       height: 1,
+      leftoverElements: [c2],
     });
 
     expect(
-      await layOutInColumns({
-        elements: iter([a1, b1, c2]).async(),
+      layOutInColumns({
+        elements: [a1, b1, c2],
         numColumns: 3,
         maxColumnHeight: 2,
       })
     ).toEqual({
       columns: [[a1], [b1], [c2]],
       height: 2,
+      leftoverElements: [],
     });
 
     expect(
-      await layOutInColumns({
-        elements: iter([c2, a1, b1, d2]).async(),
+      layOutInColumns({
+        elements: [c2, a1, b1, d2],
         maxColumnHeight: 2,
         numColumns: 3,
       })
     ).toEqual({
       columns: [[c2], [a1, b1], [d2]],
       height: 2,
+      leftoverElements: [],
     });
-  });
-
-  test('doesnt access elements until needed', async () => {
-    const a1Fn = vi.fn().mockResolvedValueOnce(a1);
-    const b1Fn = vi.fn().mockResolvedValueOnce(b1);
-    const c2Fn = vi.fn().mockResolvedValueOnce(c2);
-    const d2Fn = vi.fn().mockResolvedValueOnce(d2);
-    const elements = iter([a1Fn, b1Fn, c2Fn, d2Fn])
-      .map((fn) => fn())
-      .async();
-
-    expect(
-      await layOutInColumns({
-        elements,
-        numColumns: 2,
-        maxColumnHeight: 1,
-      })
-    ).toEqual({
-      columns: [[a1], [b1]],
-      height: 1,
-    });
-
-    expect(a1Fn).toHaveBeenCalledTimes(1);
-    expect(b1Fn).toHaveBeenCalledTimes(1);
-    // Needs to check c2 to know it can't fit
-    expect(c2Fn).toHaveBeenCalledTimes(1);
-    expect(d2Fn).not.toHaveBeenCalled();
   });
 });
 

--- a/libs/hmpb/src/layout_in_columns.ts
+++ b/libs/hmpb/src/layout_in_columns.ts
@@ -47,21 +47,22 @@ function columnHeight<Element extends ElementWithHeight>(
  * - If there are multiple ways to shorten the columns, choose the one that
  * looks the most balanced
  */
-export async function layOutInColumns<Element extends ElementWithHeight>({
+export function layOutInColumns<Element extends ElementWithHeight>({
   elements,
   numColumns,
   maxColumnHeight,
   elementGap = 0,
 }: {
-  elements: AsyncIterable<Element>;
+  elements: Element[];
   numColumns: number;
   maxColumnHeight: number;
   // Spacing between elements within a column
   elementGap?: number;
-}): Promise<{
+}): {
   columns: Array<Column<Element>>;
   height: number;
-}> {
+  leftoverElements: Element[];
+} {
   function emptyColumns(): Array<Column<Element>> {
     return range(0, numColumns).map(() => []);
   }
@@ -77,27 +78,28 @@ export async function layOutInColumns<Element extends ElementWithHeight>({
   // First, try a greedy approach of filling columns to the max height
   const greedyColumns = emptyColumns();
   let currentColumnIndex = 0;
-  const elementIterator = elements[Symbol.asyncIterator]();
-  let element = await elementIterator.next();
-  while (!element.done && currentColumnIndex < numColumns) {
+  let elementIndex = 0;
+  while (elementIndex < elements.length && currentColumnIndex < numColumns) {
+    const element = elements[elementIndex];
     if (
-      isColumnOverflowing(
-        greedyColumns[currentColumnIndex].concat([element.value])
-      )
+      isColumnOverflowing(greedyColumns[currentColumnIndex].concat([element]))
     ) {
       currentColumnIndex += 1;
     } else {
-      greedyColumns[currentColumnIndex].push(element.value);
-      element = await elementIterator.next();
+      greedyColumns[currentColumnIndex].push(element);
+      elementIndex += 1;
     }
   }
 
+  const leftoverElements = elements.slice(elementIndex);
+
   // If the greedy approach didn't use up all the elements, then we won't be
   // able to shorten the columns, so we're done.
-  if (!element.done) {
+  if (leftoverElements.length > 0) {
     return {
       columns: greedyColumns,
       height: heightOfTallestColumn(greedyColumns),
+      leftoverElements,
     };
   }
 
@@ -166,6 +168,7 @@ export async function layOutInColumns<Element extends ElementWithHeight>({
   return {
     columns: bestColumns,
     height: heightOfTallestColumn(bestColumns),
+    leftoverElements,
   };
 }
 

--- a/libs/hmpb/src/layout_in_columns.ts
+++ b/libs/hmpb/src/layout_in_columns.ts
@@ -53,7 +53,7 @@ export function layOutInColumns<Element extends ElementWithHeight>({
   maxColumnHeight,
   elementGap = 0,
 }: {
-  elements: Element[];
+  elements: readonly Element[];
   numColumns: number;
   maxColumnHeight: number;
   // Spacing between elements within a column


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->
Inspired by [this PR comment](https://github.com/votingworks/vxsuite/pull/8498#discussion_r3305704961), I refactored `layoutInColumns` to return a list of leftover elements (that didn't fit in the columns). This mirrors the behavior of the newer `layoutSectionsInColumns` function. I also removed its ability to process elements asynchronously, which I believe I added aspirationally at one point to prevent measuring more contest elements than were necessary, but that never panned out due to the bulk measurement API.

## Demo Video or Screenshot
N/A
## Testing Plan
Updated existing tests
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
