### PR TITLE
[VxAdmin] Multi-Station ballot claiming & navigation refactor

### DIFF
--- a/apps/admin/backend/src/app.adjudication.test.ts
+++ b/apps/admin/backend/src/app.adjudication.test.ts
@@ -763,9 +763,9 @@ test('adjudicateCvr requires active claim', async () => {
   const queue = await apiClient.getBallotAdjudicationQueue();
   const cvrId = assertDefined(queue[0]);
 
-  // adjudicateCvr without claim returns no-claim error
+  // adjudicateCvr without claim returns claim-failed error
   expect(await apiClient.adjudicateCvr({ cvrId, contests: [] })).toEqual(
-    err({ type: 'no-claim' })
+    err({ type: 'claim-failed' })
   );
 });
 

--- a/apps/admin/backend/src/app.adjudication.test.ts
+++ b/apps/admin/backend/src/app.adjudication.test.ts
@@ -691,7 +691,7 @@ test('getNextCvrIdForBallotAdjudication advances past the current ballot', async
 
   // With `currentCvrId` = first, returns the second eligible ballot.
   const second = await apiClient.getNextCvrIdForBallotAdjudication({
-    currentCvrId: adjudicationQueue[0],
+    afterCvrId: adjudicationQueue[0],
   });
   expect(second).toEqual(adjudicationQueue[1]);
 
@@ -700,7 +700,7 @@ test('getNextCvrIdForBallotAdjudication advances past the current ballot', async
   const lastInQueue = adjudicationQueue[adjudicationQueue.length - 1];
   expect(
     await apiClient.getNextCvrIdForBallotAdjudication({
-      currentCvrId: lastInQueue,
+      afterCvrId: lastInQueue,
     })
   ).toEqual(adjudicationQueue[0]);
 });

--- a/apps/admin/backend/src/app.adjudication.test.ts
+++ b/apps/admin/backend/src/app.adjudication.test.ts
@@ -1576,41 +1576,6 @@ test('peer API: claim, adjudicate, and resolve a ballot with real CVR fixtures',
   expect(cvrId4).not.toEqual(cvrId1); // cvrId1 was completed
 });
 
-test('host claim, release, and getClaimedBallotCvrIds', async () => {
-  const { auth, apiClient } = buildTestEnvironment();
-  const electionDefinition =
-    electionTwoPartyPrimaryFixtures.readElectionDefinition();
-  const { castVoteRecordExport } = electionTwoPartyPrimaryFixtures;
-  await configureMachine(apiClient, auth, electionDefinition);
-  await apiClient.setIsClientAdjudicationEnabled({ enabled: true });
-
-  (
-    await apiClient.addCastVoteRecordFile({
-      path: castVoteRecordExport.asDirectoryPath(),
-    })
-  ).unsafeUnwrap();
-
-  const queue = await apiClient.getBallotAdjudicationQueue();
-  expect(queue.length).toBeGreaterThan(0);
-  const cvrId = queue[0]!;
-
-  // Initially no claimed ballots
-  expect(await apiClient.getClaimedBallotCvrIds()).toEqual([]);
-
-  // Host claims a ballot
-  (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap();
-
-  // Host's own claim is excluded from getClaimedBallotCvrIds (it excludes
-  // the host's machineId), so still empty from the host's perspective
-  expect(await apiClient.getClaimedBallotCvrIds()).toEqual([]);
-
-  // Release the host claim
-  await apiClient.releaseBallotAdjudicationClaim({ cvrId });
-
-  // Still empty after release
-  expect(await apiClient.getClaimedBallotCvrIds()).toEqual([]);
-});
-
 test('qualified write-in candidate management', async () => {
   const { auth, apiClient } = buildTestEnvironment();
   const electionDefinition =

--- a/apps/admin/backend/src/app.adjudication.test.ts
+++ b/apps/admin/backend/src/app.adjudication.test.ts
@@ -47,6 +47,22 @@ vi.setConfig({
   testTimeout: 30_000,
 });
 
+// Test helper: wraps the unified claimAndLoadBallot endpoint and returns
+// just the claimed cvrId (or undefined)
+async function claimBallot(
+  peerApiClient: {
+    claimAndLoadBallot: (input: {
+      machineId: string;
+      cvrId?: string;
+      afterCvrId?: string;
+    }) => Promise<{ unsafeUnwrap(): { cvrId: string } | undefined }>;
+  },
+  input: { machineId: string; cvrId?: string; afterCvrId?: string }
+): Promise<string | undefined> {
+  const result = await peerApiClient.claimAndLoadBallot(input);
+  return result.unsafeUnwrap()?.cvrId;
+}
+
 // mock SKIP_CVR_BALLOT_HASH_CHECK to allow us to use old cvr fixtures
 const featureFlagMock = getFeatureFlagMock();
 vi.mock(import('@votingworks/utils'), async (importActual) => ({
@@ -606,7 +622,7 @@ test('getNextCvrIdForBallotAdjudication', async () => {
 
   async function adjudicateAtIndex(index: number) {
     const cvrId = adjudicationQueue[index] || '';
-    await apiClient.claimBallotForAdjudication({ cvrId });
+    (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap();
     const adjData = await apiClient.getBallotAdjudicationData({ cvrId });
     const contests = adjData.contests
       .filter((contest) => contest.tag)
@@ -642,6 +658,91 @@ test('getNextCvrIdForBallotAdjudication', async () => {
     await adjudicateAtIndex(i);
   }
   expect(await apiClient.getNextCvrIdForBallotAdjudication()).toEqual(null);
+});
+
+test('getNextCvrIdForBallotAdjudication advances past the current ballot', async () => {
+  const { auth, apiClient } = buildTestEnvironment();
+  const electionDefinition =
+    electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
+  const { castVoteRecordExport } =
+    electionGridLayoutNewHampshireTestBallotFixtures;
+  const systemSettings: SystemSettings = {
+    ...DEFAULT_SYSTEM_SETTINGS,
+    adminAdjudicationReasons: [AdjudicationReason.MarginalMark],
+  };
+  await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition,
+    undefined,
+    systemSettings
+  );
+  (
+    await apiClient.addCastVoteRecordFile({
+      path: castVoteRecordExport.asDirectoryPath(),
+    })
+  ).unsafeUnwrap();
+
+  const adjudicationQueue = await apiClient.getBallotAdjudicationQueue();
+  expect(adjudicationQueue.length).toBeGreaterThan(2);
+
+  // Without `currentCvrId`, returns the first eligible ballot.
+  const first = await apiClient.getNextCvrIdForBallotAdjudication();
+  expect(first).toEqual(adjudicationQueue[0]);
+
+  // With `currentCvrId` = first, returns the second eligible ballot.
+  const second = await apiClient.getNextCvrIdForBallotAdjudication({
+    currentCvrId: adjudicationQueue[0],
+  });
+  expect(second).toEqual(adjudicationQueue[1]);
+
+  // With `currentCvrId` = last queue entry, returns null (no more after).
+  const lastInQueue = adjudicationQueue[adjudicationQueue.length - 1];
+  expect(
+    await apiClient.getNextCvrIdForBallotAdjudication({
+      currentCvrId: lastInQueue,
+    })
+  ).toEqual(null);
+});
+
+test('host claimAndLoadBallot returns data and bypasses claim when multi-station is off', async () => {
+  const { auth, apiClient } = buildTestEnvironment();
+  const electionDefinition =
+    electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
+  const { castVoteRecordExport } =
+    electionGridLayoutNewHampshireTestBallotFixtures;
+  const systemSettings: SystemSettings = {
+    ...DEFAULT_SYSTEM_SETTINGS,
+    adminAdjudicationReasons: [AdjudicationReason.MarginalMark],
+  };
+  await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition,
+    undefined,
+    systemSettings
+  );
+  (
+    await apiClient.addCastVoteRecordFile({
+      path: castVoteRecordExport.asDirectoryPath(),
+    })
+  ).unsafeUnwrap();
+  const queue = await apiClient.getBallotAdjudicationQueue();
+  const cvrId = assertDefined(queue[0]);
+
+  // Multi-station is off — claimAndLoadBallot bypasses the claim system
+  // and just returns the data.
+  const result = (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap();
+  expect(result?.cvrId).toEqual(cvrId);
+  expect(result?.data.cvrId).toEqual(cvrId);
+
+  // Now turn on multi-station and re-claim — goes through the real claim
+  // flow and still succeeds because no other machine holds it.
+  await apiClient.setIsClientAdjudicationEnabled({ enabled: true });
+  const mResult = (
+    await apiClient.claimAndLoadBallot({ cvrId })
+  ).unsafeUnwrap();
+  expect(mResult?.cvrId).toEqual(cvrId);
 });
 
 test('adjudicateCvr requires active claim', async () => {
@@ -685,8 +786,11 @@ test('claim and release are no-ops when multi-station is disabled', async () => 
   const queue = await apiClient.getBallotAdjudicationQueue();
   const cvrId = assertDefined(queue[0]);
 
-  // claim always succeeds when multi-station is disabled
-  expect(await apiClient.claimBallotForAdjudication({ cvrId })).toEqual(true);
+  // claim succeeds and returns the ballot, bypassing the claim system when
+  // multi-station is disabled
+  expect(
+    (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap()?.cvrId
+  ).toEqual(cvrId);
 
   // release is a no-op
   await apiClient.releaseBallotAdjudicationClaim({ cvrId });
@@ -838,7 +942,7 @@ test('handling unmarked write-ins', async () => {
   assert(writeInOption.writeInRecord !== undefined);
   expect(writeInOption.writeInRecord.isUnmarked).toEqual(true);
 
-  await apiClient.claimBallotForAdjudication({ cvrId });
+  (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap();
   expect(
     await apiClient.adjudicateCvr({
       cvrId,
@@ -1070,7 +1174,7 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
   ).toEqual(false);
 
   // check the write-in being marked as invalid (false)
-  await apiClient.claimBallotForAdjudication({ cvrId });
+  (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap();
   expect(
     await apiClient.adjudicateCvr({
       cvrId,
@@ -1371,13 +1475,13 @@ test('peer API: claim, adjudicate, and resolve a ballot with real CVR fixtures',
   expect(metadataBefore.pendingTally).toEqual(metadataBefore.totalTally);
 
   // Two clients claim different ballots
-  const cvrId1 = await peerApiClient.claimBallot({
+  const cvrId1 = await claimBallot(peerApiClient, {
     machineId: 'client-001',
   });
   assert(cvrId1 !== undefined);
   expect(cvrId1).toEqual(queue[0]);
 
-  const cvrId2 = await peerApiClient.claimBallot({
+  const cvrId2 = await claimBallot(peerApiClient, {
     machineId: 'client-002',
   });
   assert(cvrId2 !== undefined);
@@ -1454,7 +1558,7 @@ test('peer API: claim, adjudicate, and resolve a ballot with real CVR fixtures',
 
   // Completed ballot is permanently removed from the claimable pool.
   // Client 3 claims next and gets queue[2] (queue[1] is still held by client 2).
-  const cvrId3 = await peerApiClient.claimBallot({
+  const cvrId3 = await claimBallot(peerApiClient, {
     machineId: 'client-003',
   });
   assert(cvrId3 !== undefined);
@@ -1463,27 +1567,13 @@ test('peer API: claim, adjudicate, and resolve a ballot with real CVR fixtures',
   // Release client 2's claim — the ballot returns to the pool.
   await peerApiClient.releaseBallot({ machineId: 'client-002', cvrId: cvrId2 });
 
-  // Client 4 claims with ballot style affinity for '2F'. The queue is ordered
-  // by ballot_style_group_id ('1M' before '2F'), but affinity should prefer
-  // a '2F' ballot over the next '1M' ballot in queue order.
-  const cvrId4 = await peerApiClient.claimBallot({
+  // Released ballot (cvrId2) is available again — another client can claim
+  const cvrId4 = await claimBallot(peerApiClient, {
     machineId: 'client-004',
-    currentBallotStyleId: '2F',
   });
   assert(cvrId4 !== undefined);
-
-  const claim4VoteInfo = await apiClient.getCastVoteRecordVoteInfo({
-    cvrId: cvrId4,
-  });
-  expect(claim4VoteInfo.ballotStyleGroupId).toEqual('2F');
-
-  // Released ballot (cvrId2) is available again — another client can claim
-  const cvrId5 = await peerApiClient.claimBallot({
-    machineId: 'client-005',
-  });
-  assert(cvrId5 !== undefined);
   // Should get an uncompleted, unclaimed ballot (could be cvrId2 or another)
-  expect(cvrId5).not.toEqual(cvrId1); // cvrId1 was completed
+  expect(cvrId4).not.toEqual(cvrId1); // cvrId1 was completed
 });
 
 test('host claim, release, and getClaimedBallotCvrIds', async () => {
@@ -1508,7 +1598,7 @@ test('host claim, release, and getClaimedBallotCvrIds', async () => {
   expect(await apiClient.getClaimedBallotCvrIds()).toEqual([]);
 
   // Host claims a ballot
-  await apiClient.claimBallotForAdjudication({ cvrId });
+  (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap();
 
   // Host's own claim is excluded from getClaimedBallotCvrIds (it excludes
   // the host's machineId), so still empty from the host's perspective

--- a/apps/admin/backend/src/app.adjudication.test.ts
+++ b/apps/admin/backend/src/app.adjudication.test.ts
@@ -53,14 +53,13 @@ async function claimBallot(
   peerApiClient: {
     claimAndLoadBallot: (input: {
       machineId: string;
-      cvrId?: string;
       afterCvrId?: string;
-    }) => Promise<{ unsafeUnwrap(): { cvrId: string } | undefined }>;
+    }) => Promise<{ cvrId: string } | undefined>;
   },
-  input: { machineId: string; cvrId?: string; afterCvrId?: string }
+  input: { machineId: string; afterCvrId?: string }
 ): Promise<string | undefined> {
   const result = await peerApiClient.claimAndLoadBallot(input);
-  return result.unsafeUnwrap()?.cvrId;
+  return result?.cvrId;
 }
 
 // mock SKIP_CVR_BALLOT_HASH_CHECK to allow us to use old cvr fixtures
@@ -696,13 +695,14 @@ test('getNextCvrIdForBallotAdjudication advances past the current ballot', async
   });
   expect(second).toEqual(adjudicationQueue[1]);
 
-  // With `currentCvrId` = last queue entry, returns null (no more after).
+  // With `currentCvrId` = last queue entry, the search wraps around to the
+  // first eligible ballot (nothing here is adjudicated yet).
   const lastInQueue = adjudicationQueue[adjudicationQueue.length - 1];
   expect(
     await apiClient.getNextCvrIdForBallotAdjudication({
       currentCvrId: lastInQueue,
     })
-  ).toEqual(null);
+  ).toEqual(adjudicationQueue[0]);
 });
 
 test('host claimAndLoadBallot returns data and bypasses claim when multi-station is off', async () => {

--- a/apps/admin/backend/src/app.caching.test.ts
+++ b/apps/admin/backend/src/app.caching.test.ts
@@ -145,7 +145,7 @@ test('uses and clears CVR tabulation cache appropriately', async () => {
   }
   assert(cvrId !== undefined);
   assert(writeIn !== undefined);
-  await apiClient.claimBallotForAdjudication({ cvrId });
+  (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap();
   expect(
     await apiClient.adjudicateCvr({
       cvrId,

--- a/apps/admin/backend/src/app.err_cdf_export.test.ts
+++ b/apps/admin/backend/src/app.err_cdf_export.test.ts
@@ -183,7 +183,9 @@ test('exports results and metadata accurately', async () => {
   assert(writeIn1 !== undefined);
   assert(writeIn2 !== undefined);
 
-  await apiClient.claimBallotForAdjudication({ cvrId: writeIn1.cvrId });
+  (
+    await apiClient.claimAndLoadBallot({ cvrId: writeIn1.cvrId })
+  ).unsafeUnwrap();
   expect(
     await apiClient.adjudicateCvr({
       cvrId: writeIn1.cvrId,
@@ -203,7 +205,9 @@ test('exports results and metadata accurately', async () => {
     })
   ).toEqual(ok());
 
-  await apiClient.claimBallotForAdjudication({ cvrId: writeIn2.cvrId });
+  (
+    await apiClient.claimAndLoadBallot({ cvrId: writeIn2.cvrId })
+  ).unsafeUnwrap();
   expect(
     await apiClient.adjudicateCvr({
       cvrId: writeIn2.cvrId,

--- a/apps/admin/backend/src/app.tally_report_csv.test.ts
+++ b/apps/admin/backend/src/app.tally_report_csv.test.ts
@@ -479,7 +479,7 @@ test('incorporates wia and manual data (grouping by voting method)', async () =>
       (c) => c.contestId === candidateContestId
     );
     if (!contest) continue;
-    await apiClient.claimBallotForAdjudication({ cvrId });
+    (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap();
     const contests: AdjudicatedCvrContest[] = contest.options
       .filter((option) => option.writeInRecord)
       .map((option) => ({

--- a/apps/admin/backend/src/app.tally_report_data.test.ts
+++ b/apps/admin/backend/src/app.tally_report_data.test.ts
@@ -146,7 +146,7 @@ test('general, full election, write in adjudication', async () => {
   const NUM_UNOFFICIAL = 56 - NUM_INVALID - NUM_OFFICIAL;
   for (const [i, writeIn] of writeIns.entries()) {
     const { cvrId, contestId, optionId } = writeIn;
-    await apiClient.claimBallotForAdjudication({ cvrId });
+    (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap();
     let optionAdjudication: AdjudicatedContestOption;
     if (i < NUM_INVALID) {
       optionAdjudication = {
@@ -965,7 +965,9 @@ test('primary, partial write-in adjudication uses correct unadjudicated label', 
   const NUM_ADJUDICATED = 3;
   for (const [i, writeIn] of writeIns.entries()) {
     if (i < NUM_ADJUDICATED) {
-      await apiClient.claimBallotForAdjudication({ cvrId: writeIn.cvrId });
+      (
+        await apiClient.claimAndLoadBallot({ cvrId: writeIn.cvrId })
+      ).unsafeUnwrap();
       expect(
         await apiClient.adjudicateCvr({
           cvrId: writeIn.cvrId,

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -828,13 +828,6 @@ function buildApi({
       });
     },
 
-    getClaimedBallotCvrIds(): Id[] {
-      return store.getClaimedBallotCvrIds({
-        electionId: loadCurrentElectionIdOrThrow(workspace),
-        excludeMachineId: getMachineConfig().machineId,
-      });
-    },
-
     /**
      * Atomically claim a ballot for adjudication and return its data,
      * both read under the same SQL transaction. The host always claims a

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -756,7 +756,7 @@ function buildApi({
           !store.isCvrAdjudicated({ cvrId: input.cvrId }) &&
           !store.hasBallotClaim({ electionId, cvrId: input.cvrId, machineId })
         ) {
-          return err({ type: 'no-claim' });
+          return err({ type: 'claim-failed' });
         }
       }
       adjudicateCvr(input, machineId, store, logger);

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -830,9 +830,7 @@ function buildApi({
 
     /**
      * Atomically claim a ballot for adjudication and return its data,
-     * both read under the same SQL transaction. The host always claims a
-     * specific cvrId from the queue. Returns `no-claim` if another machine
-     * holds the claim.
+     * both read under the same SQL transaction.
      */
     claimAndLoadBallot(input: {
       cvrId: Id;
@@ -867,13 +865,13 @@ function buildApi({
     },
 
     getNextCvrIdForBallotAdjudication(
-      input: { currentCvrId?: Id } = {}
+      input: { afterCvrId?: Id } = {}
     ): Id | null {
       return (
         store.getNextCvrIdForBallotAdjudication({
           electionId: loadCurrentElectionIdOrThrow(workspace),
           machineId: getMachineConfig().machineId,
-          afterCvrId: input.currentCvrId,
+          afterCvrId: input.afterCvrId,
         }) ?? null
       );
     },

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -835,10 +835,30 @@ function buildApi({
       });
     },
 
-    claimBallotForAdjudication(input: { cvrId: Id }): boolean {
-      if (!store.getIsClientAdjudicationEnabled()) return true;
-      return store.claimBallotForAdjudication({
-        electionId: loadCurrentElectionIdOrThrow(workspace),
+    /**
+     * Atomically claim a ballot for adjudication and return its data,
+     * both read under the same SQL transaction. The host always claims a
+     * specific cvrId from the queue. Returns `no-claim` if another machine
+     * holds the claim.
+     */
+    claimAndLoadBallot(input: {
+      cvrId: Id;
+    }): Result<
+      { cvrId: Id; data: BallotAdjudicationData } | undefined,
+      AdjudicationError
+    > {
+      const electionId = loadCurrentElectionIdOrThrow(workspace);
+      if (!store.getIsClientAdjudicationEnabled()) {
+        return ok({
+          cvrId: input.cvrId,
+          data: store.getBallotAdjudicationData({
+            electionId,
+            cvrId: input.cvrId,
+          }),
+        });
+      }
+      return store.claimAndLoadBallotData({
+        electionId,
         cvrId: input.cvrId,
         machineId: getMachineConfig().machineId,
       });
@@ -853,11 +873,14 @@ function buildApi({
       });
     },
 
-    getNextCvrIdForBallotAdjudication(): Id | null {
+    getNextCvrIdForBallotAdjudication(
+      input: { currentCvrId?: Id } = {}
+    ): Id | null {
       return (
         store.getNextCvrIdForBallotAdjudication({
           electionId: loadCurrentElectionIdOrThrow(workspace),
           machineId: getMachineConfig().machineId,
+          afterCvrId: input.currentCvrId,
         }) ?? null
       );
     },

--- a/apps/admin/backend/src/app.write_in_adjudication_report_pdf.test.ts
+++ b/apps/admin/backend/src/app.write_in_adjudication_report_pdf.test.ts
@@ -156,7 +156,7 @@ test('write-in adjudication report', async () => {
   // generate some adjudication information
   for (const [i, writeIn] of writeIns.entries()) {
     const { optionId, cvrId, contestId } = writeIn;
-    await apiClient.claimBallotForAdjudication({ cvrId });
+    (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap();
     let optionAdjudication: AdjudicatedContestOption;
     if (i < 24) {
       optionAdjudication = {

--- a/apps/admin/backend/src/client_app.test.ts
+++ b/apps/admin/backend/src/client_app.test.ts
@@ -375,15 +375,15 @@ test('proxy returns host-disconnect when peer API throws network error', async (
   expect(result).toEqual(err({ type: 'host-disconnect' }));
 });
 
-test('adjudicateCvr returns no-claim when host has no claim', async () => {
+test('adjudicateCvr returns claim-failed when host has no claim', async () => {
   const { mockPeerApi } = connectToMockHost();
-  mockPeerApi.adjudicateCvr.mockResolvedValue(err({ type: 'no-claim' }));
+  mockPeerApi.adjudicateCvr.mockResolvedValue(err({ type: 'claim-failed' }));
 
   const result = await env.apiClient.adjudicateCvr({
     cvrId: 'cvr-1',
     contests: [],
   });
-  expect(result).toEqual(err({ type: 'no-claim' }));
+  expect(result).toEqual(err({ type: 'claim-failed' }));
 });
 
 test('adjudicateCvr returns host-disconnect on network error', async () => {

--- a/apps/admin/backend/src/client_app.test.ts
+++ b/apps/admin/backend/src/client_app.test.ts
@@ -318,9 +318,10 @@ test('claimAndLoadBallot proxies to host peer API', async () => {
     contests: [],
     adjudicatedContests: [],
   } as const;
-  mockPeerApi.claimAndLoadBallot.mockResolvedValue(
-    ok({ cvrId: 'cvr-1', data: ballotData })
-  );
+  mockPeerApi.claimAndLoadBallot.mockResolvedValue({
+    cvrId: 'cvr-1',
+    data: ballotData,
+  });
 
   const result = await env.apiClient.claimAndLoadBallot({});
   expect(result).toEqual(ok({ cvrId: 'cvr-1', data: ballotData }));
@@ -331,18 +332,10 @@ test('claimAndLoadBallot proxies to host peer API', async () => {
 
 test('claimAndLoadBallot returns undefined when no ballots available', async () => {
   const { mockPeerApi } = connectToMockHost();
-  mockPeerApi.claimAndLoadBallot.mockResolvedValue(ok(undefined));
+  mockPeerApi.claimAndLoadBallot.mockResolvedValue(undefined);
 
   const result = await env.apiClient.claimAndLoadBallot({});
   expect(result).toEqual(ok(undefined));
-});
-
-test('claimAndLoadBallot surfaces a no-claim error from the host', async () => {
-  const { mockPeerApi } = connectToMockHost();
-  mockPeerApi.claimAndLoadBallot.mockResolvedValue(err({ type: 'no-claim' }));
-
-  const result = await env.apiClient.claimAndLoadBallot({ cvrId: 'cvr-1' });
-  expect(result).toEqual(err({ type: 'no-claim' }));
 });
 
 test('proxy endpoints return host-disconnect error when not connected', async () => {

--- a/apps/admin/backend/src/client_app.test.ts
+++ b/apps/admin/backend/src/client_app.test.ts
@@ -281,7 +281,7 @@ test('getBatteryInfo returns battery info', async () => {
 });
 
 interface MockPeerApi {
-  claimBallot: ReturnType<typeof vi.fn>;
+  claimAndLoadBallot: ReturnType<typeof vi.fn>;
   releaseBallot: ReturnType<typeof vi.fn>;
   getBallotAdjudicationData: ReturnType<typeof vi.fn>;
   getBallotImageMetadata: ReturnType<typeof vi.fn>;
@@ -291,7 +291,7 @@ interface MockPeerApi {
 
 function connectToMockHost(): { mockPeerApi: MockPeerApi } {
   const mockPeerApi: MockPeerApi = {
-    claimBallot: vi.fn(),
+    claimAndLoadBallot: vi.fn(),
     releaseBallot: vi.fn(),
     getBallotAdjudicationData: vi.fn(),
     getBallotImageMetadata: vi.fn(),
@@ -309,27 +309,44 @@ function connectToMockHost(): { mockPeerApi: MockPeerApi } {
   return { mockPeerApi };
 }
 
-test('claimBallot proxies to host peer API', async () => {
+test('claimAndLoadBallot proxies to host peer API', async () => {
   const { mockPeerApi } = connectToMockHost();
-  mockPeerApi.claimBallot.mockResolvedValue('cvr-1');
+  const ballotData = {
+    cvrId: 'cvr-1',
+    tag: { isBlankBallot: false },
+    isResolved: false,
+    contests: [],
+    adjudicatedContests: [],
+  } as const;
+  mockPeerApi.claimAndLoadBallot.mockResolvedValue(
+    ok({ cvrId: 'cvr-1', data: ballotData })
+  );
 
-  const result = await env.apiClient.claimBallot({});
-  expect(result).toEqual(ok('cvr-1'));
-  expect(mockPeerApi.claimBallot).toHaveBeenCalledWith(
+  const result = await env.apiClient.claimAndLoadBallot({});
+  expect(result).toEqual(ok({ cvrId: 'cvr-1', data: ballotData }));
+  expect(mockPeerApi.claimAndLoadBallot).toHaveBeenCalledWith(
     expect.objectContaining({ machineId: DEV_MACHINE_ID })
   );
 });
 
-test('claimBallot returns undefined when no ballots available', async () => {
+test('claimAndLoadBallot returns undefined when no ballots available', async () => {
   const { mockPeerApi } = connectToMockHost();
-  mockPeerApi.claimBallot.mockResolvedValue(undefined);
+  mockPeerApi.claimAndLoadBallot.mockResolvedValue(ok(undefined));
 
-  const result = await env.apiClient.claimBallot({});
+  const result = await env.apiClient.claimAndLoadBallot({});
   expect(result).toEqual(ok(undefined));
 });
 
+test('claimAndLoadBallot surfaces a no-claim error from the host', async () => {
+  const { mockPeerApi } = connectToMockHost();
+  mockPeerApi.claimAndLoadBallot.mockResolvedValue(err({ type: 'no-claim' }));
+
+  const result = await env.apiClient.claimAndLoadBallot({ cvrId: 'cvr-1' });
+  expect(result).toEqual(err({ type: 'no-claim' }));
+});
+
 test('proxy endpoints return host-disconnect error when not connected', async () => {
-  expect(await env.apiClient.claimBallot({})).toEqual(
+  expect(await env.apiClient.claimAndLoadBallot({})).toEqual(
     err({ type: 'host-disconnect' })
   );
   expect(await env.apiClient.releaseBallot({ cvrId: 'cvr-1' })).toEqual(
@@ -359,9 +376,9 @@ test('proxy endpoints return host-disconnect error when not connected', async ()
 
 test('proxy returns host-disconnect when peer API throws network error', async () => {
   const { mockPeerApi } = connectToMockHost();
-  mockPeerApi.claimBallot.mockRejectedValue(new Error('fetch failed'));
+  mockPeerApi.claimAndLoadBallot.mockRejectedValue(new Error('fetch failed'));
 
-  const result = await env.apiClient.claimBallot({});
+  const result = await env.apiClient.claimAndLoadBallot({});
   expect(result).toEqual(err({ type: 'host-disconnect' }));
 });
 

--- a/apps/admin/backend/src/client_app.ts
+++ b/apps/admin/backend/src/client_app.ts
@@ -253,21 +253,7 @@ function buildClientApi({
       );
     },
 
-    /**
-     * Atomically claim a ballot and load its adjudication data via the host
-     * in a single SQL transaction.
-     *
-     * - `cvrId` provided → claim that specific ballot (or confirm an
-     *   existing claim). `no-claim` if another machine holds it.
-     * - `afterCvrId` provided → find the next eligible ballot in queue
-     *   order strictly after this one and claim it. `ok(undefined)` if
-     *   none.
-     * - Neither → claim the first eligible ballot.
-     *
-     * `host-disconnect` if we can't reach the host.
-     */
     async claimAndLoadBallot(input: {
-      cvrId?: Id;
       afterCvrId?: Id;
     }): Promise<
       Result<
@@ -275,34 +261,24 @@ function buildClientApi({
         AdjudicationError
       >
     > {
-      const wrapped = await proxy(
+      const result = await proxy(
         'claim and load ballot',
         async ({ apiClient: peerApi }) =>
           peerApi.claimAndLoadBallot({
             machineId: getMachineConfig().machineId,
-            cvrId: input.cvrId,
             afterCvrId: input.afterCvrId,
           })
       );
-      // check if there was a transport error
-      if (wrapped.isErr()) return wrapped;
-      const inner = wrapped.ok();
-      // check if the endpoint itself returned an err value
-      if (inner.isErr()) {
-        await logger.logAsCurrentRole(LogEventId.AdminBallotClaimed, {
-          message: `Failed to claim ballot: ${inner.err().type}.`,
-          disposition: 'failure',
-        });
-        return inner;
+      if (result.isOk()) {
+        const value = result.ok();
+        if (value) {
+          await logger.logAsCurrentRole(LogEventId.AdminBallotClaimed, {
+            message: `Claimed ballot ${value.cvrId}.`,
+            disposition: 'success',
+          });
+        }
       }
-      const value = inner.ok();
-      if (value) {
-        await logger.logAsCurrentRole(LogEventId.AdminBallotClaimed, {
-          message: `Claimed ballot ${value.cvrId}.`,
-          disposition: 'success',
-        });
-      }
-      return inner;
+      return result;
     },
 
     async getBallotImages(input: {

--- a/apps/admin/backend/src/client_app.ts
+++ b/apps/admin/backend/src/client_app.ts
@@ -22,7 +22,6 @@ import {
   createUsbDriveAdapter,
 } from '@votingworks/usb-drive';
 import {
-  BallotStyleGroupId,
   ContestId,
   DEFAULT_SYSTEM_SETTINGS,
   Id,
@@ -232,26 +231,6 @@ function buildClientApi({
     // Return Result<T, AdjudicationError> so the frontend can handle
     // disconnect and claim errors without crashing to the error boundary.
 
-    async claimBallot(input: {
-      currentBallotStyleId?: BallotStyleGroupId;
-      excludeCvrIds?: Id[];
-    }): Promise<Result<Optional<Id>, AdjudicationError>> {
-      return proxy('claim ballot', async ({ apiClient: peerApi }) => {
-        const cvrId = await peerApi.claimBallot({
-          machineId: getMachineConfig().machineId,
-          currentBallotStyleId: input.currentBallotStyleId,
-          excludeCvrIds: input.excludeCvrIds,
-        });
-        if (cvrId) {
-          await logger.logAsCurrentRole(LogEventId.AdminBallotClaimed, {
-            message: `Claimed ballot ${cvrId}.`,
-            disposition: 'success',
-          });
-        }
-        return cvrId;
-      });
-    },
-
     async releaseBallot(input: {
       cvrId: Id;
     }): Promise<Result<void, AdjudicationError>> {
@@ -272,6 +251,58 @@ function buildClientApi({
       return proxy('fetch ballot data', async ({ apiClient: peerApi }) =>
         peerApi.getBallotAdjudicationData({ cvrId: input.cvrId })
       );
+    },
+
+    /**
+     * Atomically claim a ballot and load its adjudication data via the host
+     * in a single SQL transaction.
+     *
+     * - `cvrId` provided → claim that specific ballot (or confirm an
+     *   existing claim). `no-claim` if another machine holds it.
+     * - `afterCvrId` provided → find the next eligible ballot in queue
+     *   order strictly after this one and claim it. `ok(undefined)` if
+     *   none.
+     * - Neither → claim the first eligible ballot.
+     *
+     * `host-disconnect` if we can't reach the host.
+     */
+    async claimAndLoadBallot(input: {
+      cvrId?: Id;
+      afterCvrId?: Id;
+    }): Promise<
+      Result<
+        Optional<{ cvrId: Id; data: BallotAdjudicationData }>,
+        AdjudicationError
+      >
+    > {
+      const wrapped = await proxy(
+        'claim and load ballot',
+        async ({ apiClient: peerApi }) =>
+          peerApi.claimAndLoadBallot({
+            machineId: getMachineConfig().machineId,
+            cvrId: input.cvrId,
+            afterCvrId: input.afterCvrId,
+          })
+      );
+      // check if there was a transport error
+      if (wrapped.isErr()) return wrapped;
+      const inner = wrapped.ok();
+      // check if the endpoint itself returned an err value
+      if (inner.isErr()) {
+        await logger.logAsCurrentRole(LogEventId.AdminBallotClaimed, {
+          message: `Failed to claim ballot: ${inner.err().type}.`,
+          disposition: 'failure',
+        });
+        return inner;
+      }
+      const value = inner.ok();
+      if (value) {
+        await logger.logAsCurrentRole(LogEventId.AdminBallotClaimed, {
+          message: `Claimed ballot ${value.cvrId}.`,
+          disposition: 'success',
+        });
+      }
+      return inner;
     },
 
     async getBallotImages(input: {

--- a/apps/admin/backend/src/peer_app.test.ts
+++ b/apps/admin/backend/src/peer_app.test.ts
@@ -499,7 +499,7 @@ test('getBallotImageMetadata returns metadata with image URLs', async () => {
   });
 });
 
-test('adjudicateCvr returns no-claim when machine has no claim', async () => {
+test('adjudicateCvr returns claim-failed when machine has no claim', async () => {
   const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
   const electionDefinition =
     electionTwoPartyPrimaryFixtures.readElectionDefinition();
@@ -515,5 +515,5 @@ test('adjudicateCvr returns no-claim when machine has no claim', async () => {
     cvrId: cvrIds[0]!,
     contests: [],
   });
-  expect(result).toEqual(err({ type: 'no-claim' }));
+  expect(result).toEqual(err({ type: 'claim-failed' }));
 });

--- a/apps/admin/backend/src/peer_app.test.ts
+++ b/apps/admin/backend/src/peer_app.test.ts
@@ -27,14 +27,13 @@ async function claimBallot(
   peerApiClient: {
     claimAndLoadBallot: (input: {
       machineId: string;
-      cvrId?: string;
       afterCvrId?: string;
-    }) => Promise<{ unsafeUnwrap(): { cvrId: string } | undefined }>;
+    }) => Promise<{ cvrId: string } | undefined>;
   },
-  input: { machineId: string; cvrId?: string; afterCvrId?: string }
+  input: { machineId: string; afterCvrId?: string }
 ): Promise<string | undefined> {
   const result = await peerApiClient.claimAndLoadBallot(input);
-  return result.unsafeUnwrap()?.cvrId;
+  return result?.cvrId;
 }
 
 beforeEach(() => {
@@ -294,54 +293,6 @@ test('claimBallot claims an unresolved CVR', async () => {
 
   const result3 = await claimBallot(peerApiClient, { machineId: 'client-003' });
   expect(result3).toBeUndefined();
-});
-
-test('claimAndLoadBallot claims a specific cvrId and returns its data', async () => {
-  const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
-  const electionDefinition =
-    electionTwoPartyPrimaryFixtures.readElectionDefinition();
-  const electionId = await configureMachine(
-    apiClient,
-    auth,
-    electionDefinition
-  );
-  const cvrIds = addTestCvrs(workspace.store, electionId, 2);
-  const targetCvrId = cvrIds[0];
-
-  const result = await peerApiClient.claimAndLoadBallot({
-    machineId: 'client-001',
-    cvrId: targetCvrId,
-  });
-  const value = result.unsafeUnwrap();
-  expect(value).toBeDefined();
-  expect(value?.cvrId).toEqual(targetCvrId);
-  expect(value?.data.cvrId).toEqual(targetCvrId);
-});
-
-test('claimAndLoadBallot with cvrId returns no-claim when another machine holds it', async () => {
-  const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
-  const electionDefinition =
-    electionTwoPartyPrimaryFixtures.readElectionDefinition();
-  const electionId = await configureMachine(
-    apiClient,
-    auth,
-    electionDefinition
-  );
-  const cvrIds = addTestCvrs(workspace.store, electionId, 1);
-
-  // Client 1 takes the claim first.
-  const result1 = await peerApiClient.claimAndLoadBallot({
-    machineId: 'client-001',
-    cvrId: cvrIds[0],
-  });
-  expect(result1.unsafeUnwrap()?.cvrId).toEqual(cvrIds[0]);
-
-  // Client 2 tries to claim the same cvrId — gets no-claim.
-  const result2 = await peerApiClient.claimAndLoadBallot({
-    machineId: 'client-002',
-    cvrId: cvrIds[0],
-  });
-  expect(result2.err()).toEqual({ type: 'no-claim' });
 });
 
 test('releaseBallot frees a claimed CVR', async () => {

--- a/apps/admin/backend/src/peer_app.test.ts
+++ b/apps/admin/backend/src/peer_app.test.ts
@@ -20,6 +20,23 @@ import {
 
 vi.mock('./get_current_time');
 
+// Test helper: wraps the unified claimAndLoadBallot endpoint and returns
+// just the claimed cvrId (or undefined) to match the pre-collapse
+// claimBallot signature that these tests were written against.
+async function claimBallot(
+  peerApiClient: {
+    claimAndLoadBallot: (input: {
+      machineId: string;
+      cvrId?: string;
+      afterCvrId?: string;
+    }) => Promise<{ unsafeUnwrap(): { cvrId: string } | undefined }>;
+  },
+  input: { machineId: string; cvrId?: string; afterCvrId?: string }
+): Promise<string | undefined> {
+  const result = await peerApiClient.claimAndLoadBallot(input);
+  return result.unsafeUnwrap()?.cvrId;
+}
+
 beforeEach(() => {
   vi.mocked(getCurrentTime).mockImplementation(() => Date.now());
 });
@@ -110,7 +127,7 @@ test("connectToHost releases the client's claims when it transitions to OnlineLo
     authType: 'election_manager',
   });
   const cvrId = assertDefined(
-    await peerApiClient.claimBallot({ machineId: 'client-001' })
+    await claimBallot(peerApiClient, { machineId: 'client-001' })
   );
 
   // Client transitions to OnlineLocked (logout / session expiry).
@@ -122,7 +139,7 @@ test("connectToHost releases the client's claims when it transitions to OnlineLo
   });
 
   // The claim should be released — another machine can now pick it up.
-  const result = await peerApiClient.claimBallot({ machineId: 'client-002' });
+  const result = await claimBallot(peerApiClient, { machineId: 'client-002' });
   expect(result).toEqual(cvrId);
 });
 
@@ -144,7 +161,7 @@ test('connectToHost does not release claims when status stays Active or transiti
     authType: 'election_manager',
   });
   const cvrId = assertDefined(
-    await peerApiClient.claimBallot({ machineId: 'client-001' })
+    await claimBallot(peerApiClient, { machineId: 'client-001' })
   );
 
   // Repeated heartbeats with the same Active status should not release.
@@ -156,7 +173,7 @@ test('connectToHost does not release claims when status stays Active or transiti
   });
   // Another machine still cannot claim it.
   expect(
-    await peerApiClient.claimBallot({ machineId: 'client-002' })
+    await claimBallot(peerApiClient, { machineId: 'client-002' })
   ).toBeUndefined();
 
   // Active → Adjudicating must not release either.
@@ -167,7 +184,7 @@ test('connectToHost does not release claims when status stays Active or transiti
     authType: 'election_manager',
   });
   expect(
-    await peerApiClient.claimBallot({ machineId: 'client-002' })
+    await claimBallot(peerApiClient, { machineId: 'client-002' })
   ).toBeUndefined();
   expect(cvrId).toBeDefined();
 });
@@ -268,15 +285,63 @@ test('claimBallot claims an unresolved CVR', async () => {
   );
   const cvrIds = addTestCvrs(workspace.store, electionId, 2);
 
-  const result1 = await peerApiClient.claimBallot({ machineId: 'client-001' });
+  const result1 = await claimBallot(peerApiClient, { machineId: 'client-001' });
   expect(cvrIds).toContain(result1);
 
-  const result2 = await peerApiClient.claimBallot({ machineId: 'client-002' });
+  const result2 = await claimBallot(peerApiClient, { machineId: 'client-002' });
   expect(cvrIds).toContain(result2);
   expect(result2).not.toEqual(result1);
 
-  const result3 = await peerApiClient.claimBallot({ machineId: 'client-003' });
+  const result3 = await claimBallot(peerApiClient, { machineId: 'client-003' });
   expect(result3).toBeUndefined();
+});
+
+test('claimAndLoadBallot claims a specific cvrId and returns its data', async () => {
+  const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
+  const electionDefinition =
+    electionTwoPartyPrimaryFixtures.readElectionDefinition();
+  const electionId = await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition
+  );
+  const cvrIds = addTestCvrs(workspace.store, electionId, 2);
+  const targetCvrId = cvrIds[0];
+
+  const result = await peerApiClient.claimAndLoadBallot({
+    machineId: 'client-001',
+    cvrId: targetCvrId,
+  });
+  const value = result.unsafeUnwrap();
+  expect(value).toBeDefined();
+  expect(value?.cvrId).toEqual(targetCvrId);
+  expect(value?.data.cvrId).toEqual(targetCvrId);
+});
+
+test('claimAndLoadBallot with cvrId returns no-claim when another machine holds it', async () => {
+  const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
+  const electionDefinition =
+    electionTwoPartyPrimaryFixtures.readElectionDefinition();
+  const electionId = await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition
+  );
+  const cvrIds = addTestCvrs(workspace.store, electionId, 1);
+
+  // Client 1 takes the claim first.
+  const result1 = await peerApiClient.claimAndLoadBallot({
+    machineId: 'client-001',
+    cvrId: cvrIds[0],
+  });
+  expect(result1.unsafeUnwrap()?.cvrId).toEqual(cvrIds[0]);
+
+  // Client 2 tries to claim the same cvrId — gets no-claim.
+  const result2 = await peerApiClient.claimAndLoadBallot({
+    machineId: 'client-002',
+    cvrId: cvrIds[0],
+  });
+  expect(result2.err()).toEqual({ type: 'no-claim' });
 });
 
 test('releaseBallot frees a claimed CVR', async () => {
@@ -291,11 +356,11 @@ test('releaseBallot frees a claimed CVR', async () => {
   addTestCvrs(workspace.store, electionId, 1);
 
   const cvrId = assertDefined(
-    await peerApiClient.claimBallot({ machineId: 'client-001' })
+    await claimBallot(peerApiClient, { machineId: 'client-001' })
   );
   await peerApiClient.releaseBallot({ machineId: 'client-001', cvrId });
 
-  const result = await peerApiClient.claimBallot({ machineId: 'client-002' });
+  const result = await claimBallot(peerApiClient, { machineId: 'client-002' });
   expect(result).toEqual(cvrId);
 });
 
@@ -311,7 +376,7 @@ test('adjudicateCvr completes the ballot claim', async () => {
   const cvrIds = addTestCvrs(workspace.store, electionId, 2);
 
   const claimedCvrId = assertDefined(
-    await peerApiClient.claimBallot({ machineId: 'client-001' })
+    await claimBallot(peerApiClient, { machineId: 'client-001' })
   );
   (
     await peerApiClient.adjudicateCvr({
@@ -322,7 +387,7 @@ test('adjudicateCvr completes the ballot claim', async () => {
   ).unsafeUnwrap();
 
   // Claimed CVR is completed, not re-claimable; other CVR is next
-  const result = await peerApiClient.claimBallot({ machineId: 'client-002' });
+  const result = await claimBallot(peerApiClient, { machineId: 'client-002' });
   const otherCvrId = cvrIds.find((id) => id !== claimedCvrId);
   expect(result).toEqual(otherCvrId);
 });

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -138,51 +138,25 @@ function buildPeerApi({ workspace, logger }: PeerAppContext) {
       return store.getSystemSettings(currentElectionId);
     },
 
-    /**
-     * Atomically claim a ballot for adjudication and return its data in a
-     * single SQL transaction.
-     *
-     * - `cvrId` provided → claim that specific ballot (or confirm an
-     *   existing claim); `no-claim` if another machine holds it.
-     * - `afterCvrId` provided → find the next eligible ballot in queue
-     *   order strictly after this one and claim it; `ok(undefined)` if
-     *   none.
-     * - Neither → claim the first eligible ballot for this machine.
-     */
     claimAndLoadBallot(input: {
       machineId: string;
-      cvrId?: Id;
       afterCvrId?: Id;
-    }): Result<
-      { cvrId: Id; data: BallotAdjudicationData } | undefined,
-      AdjudicationError
-    > {
+    }): { cvrId: Id; data: BallotAdjudicationData } | undefined {
       const electionId = assertDefined(store.getCurrentElectionId());
       const result = store.claimAndLoadBallotData({
         electionId,
         machineId: input.machineId,
-        cvrId: input.cvrId,
         afterCvrId: input.afterCvrId,
       });
-      if (result.isOk()) {
-        const value = result.ok();
-        logger.log(LogEventId.AdminBallotClaimed, 'system', {
-          message: value
-            ? `Client ${input.machineId} claimed ballot ${value.cvrId}.`
-            : `Client ${input.machineId} requested a ballot but none available.`,
-          disposition: value ? 'success' : 'failure',
-          clientMachineId: input.machineId,
-        });
-      } else {
-        logger.log(LogEventId.AdminBallotClaimed, 'system', {
-          message: `Client ${input.machineId} could not claim a ballot: ${
-            result.err().type
-          }.`,
-          disposition: 'failure',
-          clientMachineId: input.machineId,
-        });
-      }
-      return result;
+      const value = result.unsafeUnwrap(); // error case is unreachable here.
+      logger.log(LogEventId.AdminBallotClaimed, 'system', {
+        message: value
+          ? `Client ${input.machineId} claimed ballot ${value.cvrId}.`
+          : `Client ${input.machineId} requested a ballot but none available.`,
+        disposition: value ? 'success' : 'failure',
+        clientMachineId: input.machineId,
+      });
+      return value;
     },
 
     releaseBallot(input: { machineId: string; cvrId: Id }): void {

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -10,7 +10,6 @@ import {
 } from '@votingworks/basics';
 import {
   Admin,
-  BallotStyleGroupId,
   ContestId,
   type Id,
   type Side,
@@ -139,26 +138,51 @@ function buildPeerApi({ workspace, logger }: PeerAppContext) {
       return store.getSystemSettings(currentElectionId);
     },
 
-    claimBallot(input: {
+    /**
+     * Atomically claim a ballot for adjudication and return its data in a
+     * single SQL transaction.
+     *
+     * - `cvrId` provided → claim that specific ballot (or confirm an
+     *   existing claim); `no-claim` if another machine holds it.
+     * - `afterCvrId` provided → find the next eligible ballot in queue
+     *   order strictly after this one and claim it; `ok(undefined)` if
+     *   none.
+     * - Neither → claim the first eligible ballot for this machine.
+     */
+    claimAndLoadBallot(input: {
       machineId: string;
-      currentBallotStyleId?: BallotStyleGroupId;
-      excludeCvrIds?: Id[];
-    }): Optional<Id> {
+      cvrId?: Id;
+      afterCvrId?: Id;
+    }): Result<
+      { cvrId: Id; data: BallotAdjudicationData } | undefined,
+      AdjudicationError
+    > {
       const electionId = assertDefined(store.getCurrentElectionId());
-      const cvrId = store.claimBallotForClient({
+      const result = store.claimAndLoadBallotData({
         electionId,
         machineId: input.machineId,
-        preferredBallotStyleId: input.currentBallotStyleId,
-        excludeCvrIds: input.excludeCvrIds,
+        cvrId: input.cvrId,
+        afterCvrId: input.afterCvrId,
       });
-      logger.log(LogEventId.AdminBallotClaimed, 'system', {
-        message: cvrId
-          ? `Client ${input.machineId} claimed ballot ${cvrId}.`
-          : `Client ${input.machineId} requested a ballot but none available.`,
-        disposition: cvrId ? 'success' : 'failure',
-        clientMachineId: input.machineId,
-      });
-      return cvrId;
+      if (result.isOk()) {
+        const value = result.ok();
+        logger.log(LogEventId.AdminBallotClaimed, 'system', {
+          message: value
+            ? `Client ${input.machineId} claimed ballot ${value.cvrId}.`
+            : `Client ${input.machineId} requested a ballot but none available.`,
+          disposition: value ? 'success' : 'failure',
+          clientMachineId: input.machineId,
+        });
+      } else {
+        logger.log(LogEventId.AdminBallotClaimed, 'system', {
+          message: `Client ${input.machineId} could not claim a ballot: ${
+            result.err().type
+          }.`,
+          disposition: 'failure',
+          clientMachineId: input.machineId,
+        });
+      }
+      return result;
     },
 
     releaseBallot(input: { machineId: string; cvrId: Id }): void {

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -207,7 +207,7 @@ function buildPeerApi({ workspace, logger }: PeerAppContext) {
           machineId: input.machineId,
         })
       ) {
-        return err({ type: 'no-claim' });
+        return err({ type: 'claim-failed' });
       }
       adjudicateCvr(input, input.machineId, store, logger);
       logger.log(LogEventId.AdminBallotAdjudicationComplete, 'system', {

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -785,6 +785,17 @@ describe('machine ballot adjudication assignments', () => {
     return assertDefined(cvrIds[0]);
   }
 
+  // Wraps the unified claimAndLoadBallotData "find next" path and returns just
+  // the claimed cvrId, mirroring the pre-refactor claimBallotForClient.
+  function claimNextForClient(
+    machineId: string,
+    afterCvrId?: string
+  ): string | undefined {
+    return store
+      .claimAndLoadBallotData({ electionId, machineId, afterCvrId })
+      .unsafeUnwrap()?.cvrId;
+  }
+
   beforeEach(() => {
     vi.mocked(getCurrentTime).mockImplementation(() => Date.now());
 
@@ -804,44 +815,29 @@ describe('machine ballot adjudication assignments', () => {
     const cvr1 = addCvrWithWriteIn();
     const cvr2 = addCvrWithWriteIn();
 
-    const first = store.claimBallotForClient({
-      electionId,
-      machineId: 'client-001',
-    });
+    const first = claimNextForClient('client-001');
     expect([cvr1, cvr2]).toContain(first);
 
-    const second = store.claimBallotForClient({
-      electionId,
-      machineId: 'client-002',
-    });
+    const second = claimNextForClient('client-002');
     expect([cvr1, cvr2]).toContain(second);
     expect(second).not.toEqual(first);
 
-    expect(
-      store.claimBallotForClient({ electionId, machineId: 'client-003' })
-    ).toBeUndefined();
+    expect(claimNextForClient('client-003')).toBeUndefined();
   });
 
   test('released ballot can be re-claimed', () => {
     const cvr1 = addCvrWithWriteIn();
-    expect(
-      store.claimBallotForClient({ electionId, machineId: 'client-001' })
-    ).toEqual(cvr1);
+    expect(claimNextForClient('client-001')).toEqual(cvr1);
 
     store.releaseBallotClaim({ electionId, cvrId: cvr1 });
 
-    expect(
-      store.claimBallotForClient({ electionId, machineId: 'client-002' })
-    ).toEqual(cvr1);
+    expect(claimNextForClient('client-002')).toEqual(cvr1);
   });
 
   test('completed ballot cannot be re-claimed', () => {
     const cvr1 = addCvrWithWriteIn();
     const cvr2 = addCvrWithWriteIn();
-    const first = store.claimBallotForClient({
-      electionId,
-      machineId: 'client-001',
-    });
+    const first = claimNextForClient('client-001');
     expect([cvr1, cvr2]).toContain(first);
 
     store.completeBallotClaim({
@@ -850,28 +846,23 @@ describe('machine ballot adjudication assignments', () => {
       machineId: 'client-001',
     });
 
-    const second = store.claimBallotForClient({
-      electionId,
-      machineId: 'client-002',
-    });
+    const second = claimNextForClient('client-002');
     expect([cvr1, cvr2]).toContain(second);
     expect(second).not.toEqual(first);
   });
 
   test('setCvrAdjudicated completes claim when machineId provided', () => {
     const cvr1 = addCvrWithWriteIn();
-    store.claimBallotForClient({ electionId, machineId: 'client-001' });
+    claimNextForClient('client-001');
     store.setCvrAdjudicated({ cvrId: cvr1, machineId: 'client-001' });
 
     // Claim should be completed — CVR is no longer claimable
-    expect(
-      store.claimBallotForClient({ electionId, machineId: 'client-002' })
-    ).toBeUndefined();
+    expect(claimNextForClient('client-002')).toBeUndefined();
   });
 
   test('setCvrAdjudicated skips claim completion when machineId omitted', () => {
     const cvr1 = addCvrWithWriteIn();
-    store.claimBallotForClient({ electionId, machineId: 'client-001' });
+    claimNextForClient('client-001');
     store.setCvrAdjudicated({ cvrId: cvr1 });
 
     // Claim should still be active (not completed) because no machineId
@@ -888,90 +879,42 @@ describe('machine ballot adjudication assignments', () => {
   test('releaseAllClaimsForMachine only releases that machines claims', () => {
     addCvrWithWriteIn();
     addCvrWithWriteIn();
-    const claimed1 = store.claimBallotForClient({
-      electionId,
-      machineId: 'client-001',
-    });
-    store.claimBallotForClient({ electionId, machineId: 'client-002' });
+    const claimed1 = claimNextForClient('client-001');
+    claimNextForClient('client-002');
 
     store.releaseAllClaimsForMachine({ electionId, machineId: 'client-001' });
 
-    expect(
-      store.claimBallotForClient({ electionId, machineId: 'client-003' })
-    ).toEqual(claimed1);
-    expect(
-      store.claimBallotForClient({ electionId, machineId: 'client-004' })
-    ).toBeUndefined();
+    expect(claimNextForClient('client-003')).toEqual(claimed1);
+    expect(claimNextForClient('client-004')).toBeUndefined();
   });
 
   test('releaseAllActiveClaims releases all claimed ballots', () => {
     const cvr1 = addCvrWithWriteIn();
     const cvr2 = addCvrWithWriteIn();
-    expect([cvr1, cvr2]).toContain(
-      store.claimBallotForClient({ electionId, machineId: 'client-001' })
-    );
-    expect([cvr1, cvr2]).toContain(
-      store.claimBallotForClient({ electionId, machineId: 'client-002' })
-    );
+    expect([cvr1, cvr2]).toContain(claimNextForClient('client-001'));
+    expect([cvr1, cvr2]).toContain(claimNextForClient('client-002'));
 
     store.releaseAllActiveClaims({ electionId });
 
-    expect([cvr1, cvr2]).toContain(
-      store.claimBallotForClient({
-        electionId,
-        machineId: 'client-003',
-      })
-    );
-    expect([cvr1, cvr2]).toContain(
-      store.claimBallotForClient({
-        electionId,
-        machineId: 'client-004',
-      })
-    );
+    expect([cvr1, cvr2]).toContain(claimNextForClient('client-003'));
+    expect([cvr1, cvr2]).toContain(claimNextForClient('client-004'));
   });
 
-  test('prefers matching ballot style when provided', () => {
-    const cvrA = addCvrWithWriteIn('1M');
-    const cvrB = addCvrWithWriteIn('2F');
-
-    expect(
-      store.claimBallotForClient({
-        electionId,
-        machineId: 'client-001',
-        preferredBallotStyleId: '2F',
-      })
-    ).toEqual(cvrB);
-    store.releaseAllActiveClaims({ electionId });
-
-    expect(
-      store.claimBallotForClient({
-        electionId,
-        machineId: 'client-001',
-        preferredBallotStyleId: '1M',
-      })
-    ).toEqual(cvrA);
-  });
-
-  test('excludes specified CVR IDs when claiming', () => {
+  test('afterCvrId cursor claims the ballot after the given one', () => {
     const cvr1 = addCvrWithWriteIn();
     const cvr2 = addCvrWithWriteIn();
 
-    expect(
-      store.claimBallotForClient({
-        electionId,
-        machineId: 'client-001',
-        excludeCvrIds: [cvr1],
-      })
-    ).toEqual(cvr2);
+    // Discover the canonical queue order, then release so both are claimable.
+    const first = claimNextForClient('client-001');
+    expect([cvr1, cvr2]).toContain(first);
+    store.releaseAllActiveClaims({ electionId });
+    const second = first === cvr1 ? cvr2 : cvr1;
 
-    store.releaseBallotClaim({ cvrId: cvr2, electionId });
-    expect(
-      store.claimBallotForClient({
-        electionId,
-        machineId: 'client-002',
-        excludeCvrIds: [cvr1, cvr2],
-      })
-    ).toBeUndefined();
+    // Claiming after the first ballot returns the second.
+    expect(claimNextForClient('client-002', first)).toEqual(second);
+
+    // Nothing comes after the last ballot.
+    expect(claimNextForClient('client-003', second)).toBeUndefined();
   });
 
   test('cleanupStaleMachines releases claims for stale machines', () => {
@@ -983,10 +926,7 @@ describe('machine ballot adjudication assignments', () => {
       'client',
       Admin.ClientMachineStatus.Active
     );
-    const claimed = store.claimBallotForClient({
-      electionId,
-      machineId: 'client-001',
-    });
+    const claimed = claimNextForClient('client-001');
 
     vi.mocked(getCurrentTime).mockImplementation(
       () => Date.now() + STALE_MACHINE_THRESHOLD_MS + 1
@@ -994,31 +934,24 @@ describe('machine ballot adjudication assignments', () => {
     store.cleanupStaleMachines();
 
     vi.mocked(getCurrentTime).mockImplementation(() => Date.now());
-    expect(
-      store.claimBallotForClient({ electionId, machineId: 'client-002' })
-    ).toEqual(claimed);
+    expect(claimNextForClient('client-002')).toEqual(claimed);
   });
 
   test('disabling client adjudication releases all active claims', () => {
     addCvrWithWriteIn();
     addCvrWithWriteIn();
-    store.claimBallotForClient({ electionId, machineId: 'client-001' });
-    store.claimBallotForClient({ electionId, machineId: 'client-002' });
+    claimNextForClient('client-001');
+    claimNextForClient('client-002');
 
     store.setIsClientAdjudicationEnabled(false);
 
-    expect(
-      store.claimBallotForClient({ electionId, machineId: 'client-003' })
-    ).toBeDefined();
+    expect(claimNextForClient('client-003')).toBeDefined();
   });
 
   test('host queue includes claimed CVRs for stable display', () => {
     const cvr1 = addCvrWithWriteIn();
     const cvr2 = addCvrWithWriteIn();
-    const claimed = store.claimBallotForClient({
-      electionId,
-      machineId: 'client-001',
-    });
+    const claimed = claimNextForClient('client-001');
     expect([cvr1, cvr2]).toContain(claimed);
 
     const queue = store.getBallotAdjudicationQueue({ electionId });
@@ -1039,16 +972,10 @@ describe('machine ballot adjudication assignments', () => {
 
     expect(store.getClaimedBallotCvrIds({ electionId })).toEqual([]);
 
-    const first = store.claimBallotForClient({
-      electionId,
-      machineId: 'client-001',
-    });
+    const first = claimNextForClient('client-001');
     expect(store.getClaimedBallotCvrIds({ electionId })).toEqual([first]);
 
-    const second = store.claimBallotForClient({
-      electionId,
-      machineId: 'client-002',
-    });
+    const second = claimNextForClient('client-002');
     expect(store.getClaimedBallotCvrIds({ electionId })).toHaveLength(2);
     expect(store.getClaimedBallotCvrIds({ electionId })).toContain(first);
     expect(store.getClaimedBallotCvrIds({ electionId })).toContain(second);
@@ -1067,10 +994,7 @@ describe('machine ballot adjudication assignments', () => {
       machineId: 'host-001',
     });
 
-    const clientClaim = store.claimBallotForClient({
-      electionId,
-      machineId: 'client-001',
-    });
+    const clientClaim = claimNextForClient('client-001');
     expect(clientClaim).not.toEqual(cvr1);
 
     // Duplicate claim by same machine is idempotent
@@ -1114,7 +1038,7 @@ describe('machine ballot adjudication assignments', () => {
       Admin.ClientMachineStatus.Active
     );
 
-    store.claimBallotForClient({ electionId, machineId: 'client-001' });
+    claimNextForClient('client-001');
 
     machines = store.getMachines();
     expect(machines.find((m) => m.machineId === 'client-001')?.status).toEqual(

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -966,24 +966,6 @@ describe('machine ballot adjudication assignments', () => {
     expect(next).not.toEqual(claimed);
   });
 
-  test('getClaimedBallotCvrIds returns actively claimed CVR IDs', () => {
-    addCvrWithWriteIn();
-    addCvrWithWriteIn();
-
-    expect(store.getClaimedBallotCvrIds({ electionId })).toEqual([]);
-
-    const first = claimNextForClient('client-001');
-    expect(store.getClaimedBallotCvrIds({ electionId })).toEqual([first]);
-
-    const second = claimNextForClient('client-002');
-    expect(store.getClaimedBallotCvrIds({ electionId })).toHaveLength(2);
-    expect(store.getClaimedBallotCvrIds({ electionId })).toContain(first);
-    expect(store.getClaimedBallotCvrIds({ electionId })).toContain(second);
-
-    store.releaseBallotClaim({ cvrId: first!, electionId });
-    expect(store.getClaimedBallotCvrIds({ electionId })).toEqual([second]);
-  });
-
   test('claimBallotForAdjudication claims a specific CVR for the host', () => {
     const cvr1 = addCvrWithWriteIn();
     addCvrWithWriteIn();

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -834,6 +834,37 @@ describe('machine ballot adjudication assignments', () => {
     expect(claimNextForClient('client-002')).toEqual(cvr1);
   });
 
+  test('no-cursor claim is idempotent — returns the existing claim', () => {
+    const cvr1 = addCvrWithWriteIn();
+    const cvr2 = addCvrWithWriteIn();
+
+    const first = claimNextForClient('client-001');
+    expect([cvr1, cvr2]).toContain(first);
+
+    // Calling again with no cursor returns the same ballot rather than
+    // grabbing a second one.
+    expect(claimNextForClient('client-001')).toEqual(first);
+
+    // The machine still holds exactly that one claim, so another machine can
+    // still take the other ballot.
+    const second = claimNextForClient('client-002');
+    expect([cvr1, cvr2]).toContain(second);
+    expect(second).not.toEqual(first);
+  });
+
+  test('claiming a specific cvrId held by another machine returns no-claim', () => {
+    const cvr1 = addCvrWithWriteIn();
+    expect(claimNextForClient('client-001')).toEqual(cvr1);
+
+    // A different machine asking for that exact cvrId is rejected.
+    const result = store.claimAndLoadBallotData({
+      electionId,
+      machineId: 'client-002',
+      cvrId: cvr1,
+    });
+    expect(result.err()).toEqual({ type: 'no-claim' });
+  });
+
   test('completed ballot cannot be re-claimed', () => {
     const cvr1 = addCvrWithWriteIn();
     const cvr2 = addCvrWithWriteIn();
@@ -900,7 +931,7 @@ describe('machine ballot adjudication assignments', () => {
     expect([cvr1, cvr2]).toContain(claimNextForClient('client-004'));
   });
 
-  test('afterCvrId cursor claims the ballot after the given one', () => {
+  test('afterCvrId cursor advances and wraps around the end of the queue', () => {
     const cvr1 = addCvrWithWriteIn();
     const cvr2 = addCvrWithWriteIn();
 
@@ -913,8 +944,9 @@ describe('machine ballot adjudication assignments', () => {
     // Claiming after the first ballot returns the second.
     expect(claimNextForClient('client-002', first)).toEqual(second);
 
-    // Nothing comes after the last ballot.
-    expect(claimNextForClient('client-003', second)).toBeUndefined();
+    // After the last ballot, the search wraps back to the still-unclaimed
+    // first ballot (client-002 still holds `second`).
+    expect(claimNextForClient('client-003', second)).toEqual(first);
   });
 
   test('cleanupStaleMachines releases claims for stale machines', () => {

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -852,7 +852,7 @@ describe('machine ballot adjudication assignments', () => {
     expect(second).not.toEqual(first);
   });
 
-  test('claiming a specific cvrId held by another machine returns no-claim', () => {
+  test('claiming a specific cvrId held by another machine returns claim-failed', () => {
     const cvr1 = addCvrWithWriteIn();
     expect(claimNextForClient('client-001')).toEqual(cvr1);
 
@@ -862,7 +862,7 @@ describe('machine ballot adjudication assignments', () => {
       machineId: 'client-002',
       cvrId: cvr1,
     });
-    expect(result.err()).toEqual({ type: 'no-claim' });
+    expect(result.err()).toEqual({ type: 'claim-failed' });
   });
 
   test('completed ballot cannot be re-claimed', () => {

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -3358,7 +3358,7 @@ export class Store implements BaseStore {
    * transaction.
    *
    * - `cvrId` supplied → claim that specific ballot (or confirm an existing
-   *   claim). Returns `no-claim` if another machine holds it.
+   *   claim). Returns `claim-failed` if another machine holds it.
    * - `afterCvrId` supplied → find the next eligible ballot in queue order
    *   strictly *after* this one and claim it. Returns `ok(undefined)` if
    *   none.
@@ -3406,7 +3406,7 @@ export class Store implements BaseStore {
           machineId,
         })
       ) {
-        return err({ type: 'no-claim' });
+        return err({ type: 'claim-failed' });
       }
       const data = this.getBallotAdjudicationData({
         electionId,

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -2374,17 +2374,18 @@ export class Store implements BaseStore {
     this.assertElectionExists(electionId);
     const filter = this.getAdjudicationQueueFilter(electionId);
     const sortKeys = adjudicationSortKeyExprs('c');
+    const sortKeyList = sortKeys.join(', ');
 
-    // afterCvrId uses a row-value comparison against the queue's canonical
-    // sort tuple so paging forward stays in canonical order — and since
-    // ballot_style_group_id is part of that tuple, ballots within a style
-    // naturally cluster, giving us implicit ballot-style grouping without
-    // needing a separate preference parameter.
-    const afterClause = afterCvrId
-      ? `and (${sortKeys.join(', ')}) > (
+    // When paging past `afterCvrId`, order ballots after it first (in
+    // canonical queue order), then wrap to those at or before it — so a single
+    // query returns the next ballot to adjudicate, wrapping around the end of
+    // the queue back to any earlier still-unresolved ballots. Returns
+    // undefined only when no ballot is eligible at all.
+    const wrapOrder = afterCvrId
+      ? `case when (${sortKeyList}) > (
             select ${adjudicationSortKeyExprs('cc').join(', ')}
             from cvrs cc where cc.id = ?
-          )`
+          ) then 0 else 1 end,`
       : '';
 
     const params: string[] = [machineId];
@@ -2400,8 +2401,7 @@ export class Store implements BaseStore {
         where (${filter})
           and c.is_adjudicated = 0
           and mba.cvr_id is null
-          ${afterClause}
-        order by ${sortKeys.join(', ')}
+        order by ${wrapOrder} ${sortKeyList}
         limit 1
       `,
       ...params
@@ -3334,6 +3334,30 @@ export class Store implements BaseStore {
   }
 
   /**
+   * Returns the cvrId of the ballot this machine currently holds an active
+   * ('claimed', not yet completed) claim on, if any.
+   */
+  private getActiveClaimForMachine({
+    electionId,
+    machineId,
+  }: {
+    electionId: Id;
+    machineId: string;
+  }): Optional<Id> {
+    const row = this.client.one(
+      `
+        select cvr_id
+        from machine_ballot_adjudication_assignments
+        where election_id = ? and machine_id = ? and status = 'claimed'
+        limit 1
+      `,
+      electionId,
+      machineId
+    ) as { cvr_id: Id } | undefined;
+    return row?.cvr_id;
+  }
+
+  /**
    * Atomically claim a ballot for adjudication and read its data in a single
    * transaction.
    *
@@ -3342,7 +3366,8 @@ export class Store implements BaseStore {
    * - `afterCvrId` supplied → find the next eligible ballot in queue order
    *   strictly *after* this one and claim it. Returns `ok(undefined)` if
    *   none.
-   * - Neither supplied → find the first eligible ballot and claim it.
+   * - Neither supplied → return the ballot this machine already holds, if
+   *   any, otherwise claim the first eligible ballot.
    *
    * On success the caller is guaranteed to hold the claim and receives the
    * resolved cvrId + data.
@@ -3363,42 +3388,35 @@ export class Store implements BaseStore {
   > {
     this.assertElectionExists(electionId);
     return this.withTransaction(() => {
-      let resolvedCvrId: Id;
-      if (cvrId) {
-        const claimed = this.claimBallotForAdjudication({
+      const cvrIdToClaim =
+        cvrId /* specific cvr passed in */ ??
+        this.getActiveClaimForMachine({
           electionId,
-          cvrId,
           machineId,
-        });
-        if (!claimed) {
-          return err({ type: 'no-claim' });
-        }
-        resolvedCvrId = cvrId;
-      } else {
-        const foundCvrId = this.getNextCvrIdForBallotAdjudication({
+        }) /* get machines current claim if it exists */ ??
+        this.getNextCvrIdForBallotAdjudication({
           electionId,
           machineId,
           afterCvrId,
         });
-        if (!foundCvrId) {
-          return ok(undefined);
-        }
-        const claimed = this.claimBallotForAdjudication({
+
+      if (!cvrIdToClaim) {
+        return ok(undefined);
+      }
+      if (
+        !this.claimBallotForAdjudication({
           electionId,
-          cvrId: foundCvrId,
+          cvrId: cvrIdToClaim,
           machineId,
-        });
-        /* istanbul ignore next - unreachable fail-safe within the atomic transaction @preserve */
-        if (!claimed) {
-          return err({ type: 'no-claim' });
-        }
-        resolvedCvrId = foundCvrId;
+        })
+      ) {
+        return err({ type: 'no-claim' });
       }
       const data = this.getBallotAdjudicationData({
         electionId,
-        cvrId: resolvedCvrId,
+        cvrId: cvrIdToClaim,
       });
-      return ok({ cvrId: resolvedCvrId, data });
+      return ok({ cvrId: cvrIdToClaim, data });
     });
   }
 

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -159,7 +159,7 @@ function adjudicationSortKeyExprs(alias: string): string[] {
     `coalesce(${alias}.ballot_style_group_id, '')`,
     `coalesce(${alias}.sheet_number, 0)`,
     `${alias}.id`,
-  ].join(', ');
+  ];
 }
 
 /**

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -3290,36 +3290,6 @@ export class Store implements BaseStore {
   // Client ballot adjudication assignments
   //
 
-  getClaimedBallotCvrIds({
-    electionId,
-    excludeMachineId,
-  }: {
-    electionId: Id;
-    excludeMachineId?: string;
-  }): Id[] {
-    this.assertElectionExists(electionId);
-    const rows = excludeMachineId
-      ? (this.client.all(
-          `
-            select cvr_id
-            from machine_ballot_adjudication_assignments
-            where election_id = ? and status = 'claimed'
-              and machine_id != ?
-          `,
-          electionId,
-          excludeMachineId
-        ) as Array<{ cvr_id: Id }>)
-      : (this.client.all(
-          `
-            select cvr_id
-            from machine_ballot_adjudication_assignments
-            where election_id = ? and status = 'claimed'
-          `,
-          electionId
-        ) as Array<{ cvr_id: Id }>);
-    return rows.map((r) => r.cvr_id);
-  }
-
   claimBallotForAdjudication({
     electionId,
     cvrId,

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -109,6 +109,7 @@ import {
   ContestAdjudicationData,
   ContestOptionAdjudicationData,
   AdjudicatedCvrContest,
+  AdjudicationError,
 } from './types';
 import { buildAdjudicatedContestOption } from './adjudication';
 import { deriveCvrContestTag } from './util/cast_vote_records';
@@ -145,6 +146,24 @@ function assertFilterDoesNotContainNoPartyId(
   partyIds: NonNullable<Tabulation.Filter['partyIds']>
 ): asserts partyIds is PartyId[] {
   assert(!partyIds.some(Tabulation.isNoPartyId));
+}
+
+/**
+ * The canonical sort-key expressions for the ballot adjudication queue, for
+ * the given `cvrs` table alias. The queue listing, the "next ballot" search,
+ * and the `afterCvrId` cursor all build their ordering from this single
+ * source so paging stays consistent with the queue — and the `coalesce`s
+ * keep null ballot styles / sheet numbers ordered identically in the
+ * row-value cursor comparison and the `order by`.
+ */
+function adjudicationSortKeyExprs(alias: string): string[] {
+  return [
+    `case when ${alias}.is_blank = 1 then 1 else 0 end`,
+    `case when ${alias}.card_type = 'bmd' then 1 else 0 end`,
+    `coalesce(${alias}.ballot_style_group_id, '')`,
+    `coalesce(${alias}.sheet_number, 0)`,
+    `${alias}.id`,
+  ];
 }
 
 /**
@@ -2190,12 +2209,7 @@ export class Store implements BaseStore {
         select c.id as cvr_id
         from cvrs c
         where (${filter})
-        order by
-          case when c.is_blank = 1 then 1 else 0 end,
-          case when c.card_type = 'bmd' then 1 else 0 end,
-          c.ballot_style_group_id,
-          c.sheet_number,
-          c.id
+        order by ${adjudicationSortKeyExprs('c').join(', ')}
       `
     ) as Array<{ cvr_id: Id }>;
     debug('queried ballot adjudication queue');
@@ -2351,32 +2365,46 @@ export class Store implements BaseStore {
   getNextCvrIdForBallotAdjudication({
     electionId,
     machineId,
+    afterCvrId,
   }: {
     electionId: Id;
     machineId: string;
+    afterCvrId?: Id;
   }): Optional<Id> {
     this.assertElectionExists(electionId);
     const filter = this.getAdjudicationQueueFilter(electionId);
+    const sortKeys = adjudicationSortKeyExprs('c');
+
+    // afterCvrId uses a row-value comparison against the queue's canonical
+    // sort tuple so paging forward stays in canonical order — and since
+    // ballot_style_group_id is part of that tuple, ballots within a style
+    // naturally cluster, giving us implicit ballot-style grouping without
+    // needing a separate preference parameter.
+    const afterClause = afterCvrId
+      ? `and (${sortKeys.join(', ')}) > (
+            select ${adjudicationSortKeyExprs('cc').join(', ')}
+            from cvrs cc where cc.id = ?
+          )`
+      : '';
+
+    const params: string[] = [machineId];
+    if (afterCvrId) params.push(afterCvrId);
 
     const row = this.client.one(
       `
         select c.id as cvr_id
         from cvrs c
         left join machine_ballot_adjudication_assignments mba
-          on mba.cvr_id = c.id and mba.status = 'claimed'
-          and mba.machine_id != ?
+          on mba.cvr_id = c.id
+          and (mba.status = 'completed' or mba.machine_id != ?)
         where (${filter})
           and c.is_adjudicated = 0
           and mba.cvr_id is null
-        order by
-          case when c.is_blank = 1 then 1 else 0 end,
-          case when c.card_type = 'bmd' then 1 else 0 end,
-          c.ballot_style_group_id,
-          c.sheet_number,
-          c.id
+          ${afterClause}
+        order by ${sortKeys.join(', ')}
         limit 1
       `,
-      machineId
+      ...params
     ) as { cvr_id: Id } | undefined;
 
     return row?.cvr_id;
@@ -3335,66 +3363,72 @@ export class Store implements BaseStore {
     }
   }
 
-  claimBallotForClient({
+  /**
+   * Atomically claim a ballot for adjudication and read its data in a single
+   * transaction.
+   *
+   * - `cvrId` supplied → claim that specific ballot (or confirm an existing
+   *   claim). Returns `no-claim` if another machine holds it.
+   * - `afterCvrId` supplied → find the next eligible ballot in queue order
+   *   strictly *after* this one and claim it. Returns `ok(undefined)` if
+   *   none.
+   * - Neither supplied → find the first eligible ballot and claim it.
+   *
+   * On success the caller is guaranteed to hold the claim and receives the
+   * resolved cvrId + data.
+   */
+  claimAndLoadBallotData({
     electionId,
     machineId,
-    preferredBallotStyleId,
-    excludeCvrIds,
+    cvrId,
+    afterCvrId,
   }: {
     electionId: Id;
     machineId: string;
-    preferredBallotStyleId?: BallotStyleGroupId;
-    excludeCvrIds?: Id[];
-  }): Id | undefined {
+    cvrId?: Id;
+    afterCvrId?: Id;
+  }): Result<
+    { cvrId: Id; data: BallotAdjudicationData } | undefined,
+    AdjudicationError
+  > {
     this.assertElectionExists(electionId);
-    const filter = this.getAdjudicationQueueFilter(electionId);
-
-    const excludePlaceholders =
-      excludeCvrIds && excludeCvrIds.length > 0
-        ? `and c.id not in (${excludeCvrIds.map(() => '?').join(', ')})`
-        : '';
-
-    return this.client.transaction(() => {
-      const row = this.client.one(
-        `
-          select c.id as cvr_id
-          from cvrs c
-          where (${filter})
-            and c.is_adjudicated = 0
-            and c.id not in (
-              select cvr_id from machine_ballot_adjudication_assignments
-              where election_id = ? and status in ('claimed', 'completed')
-            )
-            ${excludePlaceholders}
-          order by
-            case when c.ballot_style_group_id = ? then 0 else 1 end,
-            case when c.is_blank = 1 then 1 else 0 end,
-            case when c.card_type = 'bmd' then 1 else 0 end,
-            c.ballot_style_group_id,
-            c.sheet_number,
-            c.id
-          limit 1
-        `,
+    return this.withTransaction(() => {
+      let resolvedCvrId: Id;
+      if (cvrId) {
+        const claimed = this.claimBallotForAdjudication({
+          electionId,
+          cvrId,
+          machineId,
+        });
+        if (!claimed) {
+          return err({ type: 'no-claim' });
+        }
+        resolvedCvrId = cvrId;
+      } else {
+        const foundCvrId = this.getNextCvrIdForBallotAdjudication({
+          electionId,
+          machineId,
+          afterCvrId,
+        });
+        if (!foundCvrId) {
+          return ok(undefined);
+        }
+        const claimed = this.claimBallotForAdjudication({
+          electionId,
+          cvrId: foundCvrId,
+          machineId,
+        });
+        /* istanbul ignore next - unreachable fail-safe within the atomic transaction @preserve */
+        if (!claimed) {
+          return err({ type: 'no-claim' });
+        }
+        resolvedCvrId = foundCvrId;
+      }
+      const data = this.getBallotAdjudicationData({
         electionId,
-        ...(excludeCvrIds ?? []),
-        preferredBallotStyleId ?? null
-      ) as { cvr_id: Id } | undefined;
-
-      if (!row) return undefined;
-
-      this.client.run(
-        `
-          insert into machine_ballot_adjudication_assignments
-            (cvr_id, election_id, machine_id, claimed_at, status)
-          values (?, ?, ?, ?, 'claimed')
-        `,
-        row.cvr_id,
-        electionId,
-        machineId,
-        getCurrentTime()
-      );
-
-      return row.cvr_id;
+        cvrId: resolvedCvrId,
+      });
+      return ok({ cvrId: resolvedCvrId, data });
     });
   }
 

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -150,11 +150,7 @@ function assertFilterDoesNotContainNoPartyId(
 
 /**
  * The canonical sort-key expressions for the ballot adjudication queue, for
- * the given `cvrs` table alias. The queue listing, the "next ballot" search,
- * and the `afterCvrId` cursor all build their ordering from this single
- * source so paging stays consistent with the queue — and the `coalesce`s
- * keep null ballot styles / sheet numbers ordered identically in the
- * row-value cursor comparison and the `order by`.
+ * the given `cvrs` table alias.
  */
 function adjudicationSortKeyExprs(alias: string): string[] {
   return [
@@ -163,7 +159,7 @@ function adjudicationSortKeyExprs(alias: string): string[] {
     `coalesce(${alias}.ballot_style_group_id, '')`,
     `coalesce(${alias}.sheet_number, 0)`,
     `${alias}.id`,
-  ];
+  ].join(', ');
 }
 
 /**

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -690,4 +690,4 @@ export type ImportElectionResultsReportingError =
  */
 export type AdjudicationError =
   | { type: 'host-disconnect' }
-  | { type: 'no-claim' };
+  | { type: 'claim-failed' };

--- a/apps/admin/backend/test/open_primary_fixture.ts
+++ b/apps/admin/backend/test/open_primary_fixture.ts
@@ -127,9 +127,11 @@ export async function seedOpenPrimaryCvrsAndAdjudications({
 
   // Resolve a crossover by removing the gov-republican vote → ballot becomes
   // Dem-only, restoring its gov-democratic vote (bob-smith).
-  await apiClient.claimBallotForAdjudication({
-    cvrId: resolvedCrossoverCvrId,
-  });
+  (
+    await apiClient.claimAndLoadBallot({
+      cvrId: resolvedCrossoverCvrId,
+    })
+  ).assertOk('failed to claim crossover ballot');
   (
     await apiClient.adjudicateCvr({
       cvrId: resolvedCrossoverCvrId,
@@ -145,9 +147,11 @@ export async function seedOpenPrimaryCvrsAndAdjudications({
   ).assertOk('failed to adjudicate crossover');
   // Flip a Dem-only ballot by removing its gov-democratic vote (dan-rivera)
   // → ballot becomes nonpartisan-only.
-  await apiClient.claimBallotForAdjudication({
-    cvrId: flippedToNoPartyCvrId,
-  });
+  (
+    await apiClient.claimAndLoadBallot({
+      cvrId: flippedToNoPartyCvrId,
+    })
+  ).assertOk('failed to claim flipped ballot');
   (
     await apiClient.adjudicateCvr({
       cvrId: flippedToNoPartyCvrId,
@@ -253,7 +257,9 @@ export async function seedOpenPrimaryWriteIns({
     contestId: string,
     candidateName: string
   ) {
-    await apiClient.claimBallotForAdjudication({ cvrId });
+    (await apiClient.claimAndLoadBallot({ cvrId })).assertOk(
+      'failed to claim ballot'
+    );
     (
       await apiClient.adjudicateCvr({
         cvrId,

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -319,20 +319,6 @@ export const getBallotAdjudicationQueueMetadata = {
   },
 } as const;
 
-export const getClaimedBallotCvrIds = {
-  queryKey(): QueryKey {
-    return ['getClaimedBallotCvrIds'];
-  },
-  useQuery({ enabled }: { enabled?: boolean } = {}) {
-    const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getClaimedBallotCvrIds(), {
-      staleTime: 0,
-      refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL,
-      enabled,
-    });
-  },
-} as const;
-
 export const getNextCvrIdForBallotAdjudication = {
   queryKey(): QueryKey {
     return ['getNextCvrIdForBallotAdjudication'];
@@ -373,6 +359,7 @@ export const getBallotAdjudicationData = {
         enabled: !!input,
         keepPreviousData: true,
         staleTime: 0,
+        refetchOnMount: 'always',
       }
     );
   },
@@ -905,19 +892,25 @@ export const adjudicateCvr = {
           queryClient.invalidateQueries(
             getBallotAdjudicationQueueMetadata.queryKey()
           ),
-          queryClient.invalidateQueries(
-            getNextCvrIdForBallotAdjudication.queryKey()
-          ),
         ]);
       },
     });
   },
 } as const;
 
-export const claimBallotForAdjudication = {
+export const claimAndLoadBallot = {
   useMutation() {
     const apiClient = useApiClient();
-    return useMutation(apiClient.claimBallotForAdjudication);
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.claimAndLoadBallot, {
+      async onSuccess() {
+        // Keep the host's "next ballot" position query fresh after acquiring
+        // a claim.
+        await queryClient.invalidateQueries(
+          getNextCvrIdForBallotAdjudication.queryKey()
+        );
+      },
+    });
   },
 } as const;
 

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -901,16 +901,7 @@ export const adjudicateCvr = {
 export const claimAndLoadBallot = {
   useMutation() {
     const apiClient = useApiClient();
-    const queryClient = useQueryClient();
-    return useMutation(apiClient.claimAndLoadBallot, {
-      async onSuccess() {
-        // Keep the host's "next ballot" position query fresh after acquiring
-        // a claim.
-        await queryClient.invalidateQueries(
-          getNextCvrIdForBallotAdjudication.queryKey()
-        );
-      },
-    });
+    return useMutation(apiClient.claimAndLoadBallot, {});
   },
 } as const;
 

--- a/apps/admin/frontend/src/client/api.ts
+++ b/apps/admin/frontend/src/client/api.ts
@@ -227,10 +227,10 @@ export const formatUsbDrive = {
 
 // Adjudication proxy
 
-export const claimBallot = {
+export const claimAndLoadBallot = {
   useMutation() {
     const apiClient = useApiClient();
-    return useMutation(apiClient.claimBallot);
+    return useMutation(apiClient.claimAndLoadBallot);
   },
 } as const;
 
@@ -261,8 +261,13 @@ export const getBallotImages = {
   },
   useQuery(cvrId: string) {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(cvrId), () =>
-      apiClient.getBallotImages({ cvrId })
+    // keepPreviousData holds the previous ballot's images (isSuccess stays
+    // true) while the next ballot's images load, so paging via Skip/Accept
+    // doesn't flash the full-screen Loading state between ballots.
+    return useQuery(
+      this.queryKey(cvrId),
+      () => apiClient.getBallotImages({ cvrId }),
+      { keepPreviousData: true }
     );
   },
 } as const;

--- a/apps/admin/frontend/src/client/client_app_root.test.tsx
+++ b/apps/admin/frontend/src/client/client_app_root.test.tsx
@@ -246,8 +246,8 @@ test('shows low disk space warning when disk space is low', async () => {
 });
 
 test('logout while on a ballot adjudication URL replaces it with the home route', async () => {
-  // Seed the URL so the app starts on /adjudication/ballots/<cvrId>.
-  window.history.replaceState({}, '', '/adjudication/ballots/cvr-1');
+  // Seed the URL so the app starts on the ballot adjudication route.
+  window.history.replaceState({}, '', '/adjudication/ballots');
 
   setPollWorkerAuth();
   renderClientApp({ withElection: true });

--- a/apps/admin/frontend/src/client/client_app_root.tsx
+++ b/apps/admin/frontend/src/client/client_app_root.tsx
@@ -180,7 +180,7 @@ export function ClientAppRoot(): JSX.Element | null {
           <Route exact path={routerPaths.adjudication}>
             <ClientAdjudicationScreen />
           </Route>
-          <Route exact path={`${routerPaths.ballotAdjudication}/:cvrId`}>
+          <Route exact path={`${routerPaths.ballotAdjudication}/:cvrId?`}>
             <ClientBallotAdjudicationScreen />
           </Route>
           <Route exact path={routerPaths.settings}>
@@ -201,7 +201,7 @@ export function ClientAppRoot(): JSX.Element | null {
         <Route exact path={routerPaths.adjudication}>
           <ClientAdjudicationScreen />
         </Route>
-        <Route exact path={`${routerPaths.ballotAdjudication}/:cvrId`}>
+        <Route exact path={`${routerPaths.ballotAdjudication}/:cvrId?`}>
           <ClientBallotAdjudicationScreen />
         </Route>
         <Redirect to={routerPaths.adjudication} />

--- a/apps/admin/frontend/src/client/client_app_root.tsx
+++ b/apps/admin/frontend/src/client/client_app_root.tsx
@@ -180,7 +180,7 @@ export function ClientAppRoot(): JSX.Element | null {
           <Route exact path={routerPaths.adjudication}>
             <ClientAdjudicationScreen />
           </Route>
-          <Route exact path={`${routerPaths.ballotAdjudication}/:cvrId?`}>
+          <Route exact path={routerPaths.ballotAdjudication}>
             <ClientBallotAdjudicationScreen />
           </Route>
           <Route exact path={routerPaths.settings}>
@@ -201,7 +201,7 @@ export function ClientAppRoot(): JSX.Element | null {
         <Route exact path={routerPaths.adjudication}>
           <ClientAdjudicationScreen />
         </Route>
-        <Route exact path={`${routerPaths.ballotAdjudication}/:cvrId?`}>
+        <Route exact path={routerPaths.ballotAdjudication}>
           <ClientBallotAdjudicationScreen />
         </Route>
         <Redirect to={routerPaths.adjudication} />

--- a/apps/admin/frontend/src/client/screens/client_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_adjudication_screen.test.tsx
@@ -5,13 +5,13 @@ import {
 } from '@votingworks/test-utils';
 import { DippedSmartCardAuth, constructElectionKey } from '@votingworks/types';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
-import { err, ok } from '@votingworks/basics';
 import { screen } from '../../../test/react_testing_library';
 import {
   ClientApiMock,
   createClientApiMock,
 } from '../../../test/helpers/mock_client_api_client';
 import { renderInClientContext } from '../../../test/render_in_client_context';
+import { routerPaths } from '../../router_paths';
 import { ClientAdjudicationScreen } from './client_adjudication_screen';
 
 let apiMock: ClientApiMock;
@@ -65,9 +65,8 @@ test('shows waiting message and disabled button when adjudication not enabled', 
   expect(startButton).toBeDisabled();
 });
 
-test('start adjudication claims a ballot and navigates', async () => {
+test('start adjudication navigates to the ballot screen', async () => {
   apiMock.expectGetAdjudicationSessionStatus(true);
-  apiMock.apiClient.claimBallot.expectCallWith({}).resolves(ok('cvr-1'));
 
   renderAdjudicationScreen(pollWorkerAuth, { withElection: true });
   const startButton = await screen.findByRole('button', {
@@ -75,38 +74,5 @@ test('start adjudication claims a ballot and navigates', async () => {
   });
   startButton.click();
 
-  await screen.findByText('Claiming ballot…');
-});
-
-test('start adjudication shows error on host disconnect', async () => {
-  apiMock.expectGetAdjudicationSessionStatus(true);
-  apiMock.apiClient.claimBallot
-    .expectCallWith({})
-    .resolves(err({ type: 'host-disconnect' }));
-
-  renderAdjudicationScreen(pollWorkerAuth, { withElection: true });
-  const startButton = await screen.findByRole('button', {
-    name: 'Start Adjudication',
-  });
-  startButton.click();
-
-  await screen.findByText('Disconnected from host.');
-  expect(
-    screen.getByRole('button', { name: 'Start Adjudication' })
-  ).not.toBeDisabled();
-});
-
-test('start adjudication resets when no ballots available', async () => {
-  apiMock.expectGetAdjudicationSessionStatus(true);
-  apiMock.apiClient.claimBallot.expectCallWith({}).resolves(ok(undefined));
-
-  renderAdjudicationScreen(pollWorkerAuth, { withElection: true });
-  const startButton = await screen.findByRole('button', {
-    name: 'Start Adjudication',
-  });
-  startButton.click();
-
-  // Button should re-enable and message should appear
-  await screen.findByRole('button', { name: 'Start Adjudication' });
-  screen.getByText('No ballots available for adjudication.');
+  expect(window.location.pathname).toEqual(routerPaths.ballotAdjudication);
 });

--- a/apps/admin/frontend/src/client/screens/client_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_adjudication_screen.tsx
@@ -1,71 +1,31 @@
-import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { throwIllegalValue } from '@votingworks/basics';
-import type { AdjudicationError } from '@votingworks/admin-backend';
 import { Button, P } from '@votingworks/ui';
 import { NavigationScreen } from '../../components/navigation_screen';
-import { claimBallot, getAdjudicationSessionStatus } from '../api';
+import { getAdjudicationSessionStatus } from '../api';
 import { routerPaths } from '../../router_paths';
-
-function claimErrorMessage(error: AdjudicationError): string {
-  switch (error.type) {
-    case 'no-claim':
-      return 'Failed to claim a ballot. Please try again.';
-    case 'host-disconnect':
-      return 'Disconnected from host.';
-    default:
-      /* istanbul ignore next - @preserve */
-      throwIllegalValue(error, 'type');
-  }
-}
 
 export function ClientAdjudicationScreen(): JSX.Element {
   const history = useHistory();
   const adjudicationStatusQuery = getAdjudicationSessionStatus.useQuery();
-  const { mutateAsync: claimBallotAsync } = claimBallot.useMutation();
-  const [isClaiming, setIsClaiming] = useState(false);
-  const [noBallots, setNoBallots] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string>();
 
   const isAdjudicationEnabled =
     adjudicationStatusQuery.isSuccess &&
     adjudicationStatusQuery.data.isClientAdjudicationEnabled;
 
-  async function handleStartAdjudication(): Promise<void> {
-    setIsClaiming(true);
-    setNoBallots(false);
-    setErrorMessage(undefined);
-    const result = await claimBallotAsync({});
-    if (result.isErr()) {
-      setIsClaiming(false);
-      setErrorMessage(claimErrorMessage(result.err()));
-      return;
-    }
-    const cvrId = result.ok();
-    if (cvrId) {
-      history.push(`${routerPaths.ballotAdjudication}/${cvrId}`);
-    } else {
-      setIsClaiming(false);
-      setNoBallots(true);
-    }
-  }
-
   return (
     <NavigationScreen title="Adjudication">
       <P>
         <Button
-          disabled={!isAdjudicationEnabled || isClaiming}
-          onPress={handleStartAdjudication}
+          disabled={!isAdjudicationEnabled}
+          onPress={() => history.push(routerPaths.ballotAdjudication)}
           variant="primary"
         >
-          {isClaiming ? 'Claiming ballot…' : 'Start Adjudication'}
+          Start Adjudication
         </Button>
       </P>
       {!isAdjudicationEnabled && (
         <P>Waiting for host to initiate adjudication.</P>
       )}
-      {noBallots && <P>No ballots available for adjudication.</P>}
-      {errorMessage && <P>{errorMessage}</P>}
     </NavigationScreen>
   );
 }

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
@@ -273,12 +273,12 @@ test('exit releases ballot', async () => {
   });
 });
 
-test('shows no-claim error with exit button', async () => {
-  // Initial claim+load fails with no-claim — auxiliary data loader queries
+test('shows claim-failed error with exit button', async () => {
+  // Initial claim+load fails with claim-failed — auxiliary data loader queries
   // never run because we bail to the error screen first.
   apiMock.apiClient.claimAndLoadBallot
     .expectRepeatedCallsWith({})
-    .resolves(err({ type: 'no-claim' }));
+    .resolves(err({ type: 'claim-failed' }));
 
   renderScreen();
 
@@ -381,7 +381,7 @@ test('onAccept error shows error screen', async () => {
   const mockInput = { cvrId: 'cvr-1', contests: [] } as const;
   apiMock.apiClient.adjudicateCvr
     .expectCallWith(mockInput)
-    .resolves(err({ type: 'no-claim' }));
+    .resolves(err({ type: 'claim-failed' }));
   const onAccept = capturedProps['onAccept'] as (
     input: unknown
   ) => Promise<void>;

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
@@ -81,8 +81,11 @@ const pollWorkerAuth: DippedSmartCardAuth.PollWorkerLoggedIn = {
   sessionExpiresAt: mockSessionExpiresAt(),
 };
 
-function renderScreen(cvrId = 'cvr-1') {
+function renderScreen(cvrId?: string) {
   expectAdjudicationEnabled();
+  const pathname = cvrId
+    ? `${routerPaths.ballotAdjudication}/${cvrId}`
+    : routerPaths.ballotAdjudication;
   const clientApiClient = apiMock.apiClient as unknown as ClientApiClient;
   return render(
     <TestErrorBoundary>
@@ -101,12 +104,8 @@ function renderScreen(cvrId = 'cvr-1') {
                   electionPackageHash: 'test-hash',
                 }}
               >
-                <MemoryRouter
-                  initialEntries={[
-                    `${routerPaths.ballotAdjudication}/${cvrId}`,
-                  ]}
-                >
-                  <Route path={`${routerPaths.ballotAdjudication}/:cvrId`}>
+                <MemoryRouter initialEntries={[pathname]}>
+                  <Route path={`${routerPaths.ballotAdjudication}/:cvrId?`}>
                     <ClientBallotAdjudicationScreen />
                   </Route>
                 </MemoryRouter>
@@ -125,18 +124,20 @@ function expectAdjudicationEnabled(): void {
     .resolves({ isClientAdjudicationEnabled: true });
 }
 
+function makeBallotData(cvrId: string) {
+  return {
+    cvrId,
+    tag: { isBlankBallot: false } as const,
+    isResolved: false,
+    contests: [],
+    adjudicatedContests: [],
+  };
+}
+
+// Per-cvrId mocks the data loader runs once it has the ballot data.
+// Global mocks (write-in candidates, system settings) live in
+// `expectGlobalDataLoaderQueries` since they're cached across cvrIds.
 function expectDataLoaderQueries(cvrId: string): void {
-  apiMock.apiClient.getBallotAdjudicationData
-    .expectRepeatedCallsWith({ cvrId })
-    .resolves(
-      ok({
-        cvrId,
-        tag: { isBlankBallot: false },
-        isResolved: false,
-        contests: [],
-        adjudicatedContests: [],
-      })
-    );
   apiMock.apiClient.getBallotImages.expectRepeatedCallsWith({ cvrId }).resolves(
     ok({
       cvrId,
@@ -152,6 +153,10 @@ function expectDataLoaderQueries(cvrId: string): void {
       },
     })
   );
+}
+
+// One-shot setup for the cvrId-independent queries the data loader fires.
+function expectGlobalDataLoaderQueries(): void {
   apiMock.apiClient.getWriteInCandidates
     .expectRepeatedCallsWith({ contestId: undefined })
     .resolves(ok([]));
@@ -160,19 +165,52 @@ function expectDataLoaderQueries(cvrId: string): void {
     .resolves(DEFAULT_SYSTEM_SETTINGS);
 }
 
+// Sets up the initial-mount claim+load call for the cvrId in the URL.
+// Used by most tests; tests that want to override the initial result
+// (e.g. to test claim-failure flows) skip this and mock directly.
+function expectInitialClaimAndLoad(cvrId: string): void {
+  apiMock.apiClient.claimAndLoadBallot
+    .expectCallWith({ cvrId })
+    .resolves(ok({ cvrId, data: makeBallotData(cvrId) }));
+}
+
 test('renders adjudicating state with initial cvrId from route', async () => {
   expectDataLoaderQueries('cvr-1');
+  expectGlobalDataLoaderQueries();
+  expectInitialClaimAndLoad('cvr-1');
   renderScreen('cvr-1');
+  await screen.findByText('Adjudicating cvr-1');
+  expect(capturedProps['cvrId']).toEqual('cvr-1');
+});
+
+test('claims the next ballot when no cvrId is in the route', async () => {
+  // Arriving from "Start Adjudication" with no cvrId: the screen claims the
+  // next available ballot itself, so there is exactly one claim.
+  expectDataLoaderQueries('cvr-1');
+  expectGlobalDataLoaderQueries();
+  apiMock.apiClient.claimAndLoadBallot
+    .expectCallWith({})
+    .resolves(ok({ cvrId: 'cvr-1', data: makeBallotData('cvr-1') }));
+  renderScreen();
   await screen.findByText('Adjudicating cvr-1');
   expect(capturedProps['cvrId']).toEqual('cvr-1');
 });
 
 test('accept claims next ballot', async () => {
   expectDataLoaderQueries('cvr-1');
+  expectGlobalDataLoaderQueries();
+  expectInitialClaimAndLoad('cvr-1');
   renderScreen('cvr-1');
   await screen.findByText('Adjudicating cvr-1');
 
-  apiMock.apiClient.claimBallot.expectCallWith({}).resolves(ok(undefined));
+  // After accept on cvr-1, the screen looks for the next ballot after it,
+  // then falls back to searching from the beginning when nothing is found.
+  apiMock.apiClient.claimAndLoadBallot
+    .expectCallWith({ afterCvrId: 'cvr-1' })
+    .resolves(ok(undefined));
+  apiMock.apiClient.claimAndLoadBallot
+    .expectCallWith({})
+    .resolves(ok(undefined));
   screen.getByText('Accept').click();
   await screen.findByText('No more ballots available for adjudication.');
 
@@ -181,47 +219,54 @@ test('accept claims next ballot', async () => {
 
 test('shows error screen when claim fails during accept', async () => {
   expectDataLoaderQueries('cvr-1');
+  expectGlobalDataLoaderQueries();
+  expectInitialClaimAndLoad('cvr-1');
   renderScreen('cvr-1');
   await screen.findByText('Adjudicating cvr-1');
 
-  apiMock.apiClient.claimBallot
-    .expectCallWith({})
+  apiMock.apiClient.claimAndLoadBallot
+    .expectCallWith({ afterCvrId: 'cvr-1' })
     .resolves(err({ type: 'host-disconnect' }));
   screen.getByText('Accept').click();
   await screen.findByText('Disconnected from host.');
   screen.getByText('Exit');
 });
 
-test('skip releases ballot and claims next with exclusion', async () => {
+test('skip releases ballot and claims next after it', async () => {
   expectDataLoaderQueries('cvr-1');
+  expectDataLoaderQueries('cvr-2');
+  expectGlobalDataLoaderQueries();
+  expectInitialClaimAndLoad('cvr-1');
   renderScreen('cvr-1');
   await screen.findByText('Adjudicating cvr-1');
 
   apiMock.apiClient.releaseBallot
     .expectCallWith({ cvrId: 'cvr-1' })
     .resolves(ok());
-  apiMock.apiClient.claimBallot
-    .expectCallWith({ excludeCvrIds: ['cvr-1'] })
-    .resolves(ok('cvr-2'));
-  expectDataLoaderQueries('cvr-2');
+  apiMock.apiClient.claimAndLoadBallot
+    .expectCallWith({ afterCvrId: 'cvr-1' })
+    .resolves(ok({ cvrId: 'cvr-2', data: makeBallotData('cvr-2') }));
 
   screen.getByText('Skip').click();
   await screen.findByText('Adjudicating cvr-2');
 });
 
-test('skip clears exclusion set when no more ballots and retries', async () => {
+test('skip wraps to first eligible when nothing is available after current', async () => {
   expectDataLoaderQueries('cvr-1');
+  expectGlobalDataLoaderQueries();
+  expectInitialClaimAndLoad('cvr-1');
   renderScreen('cvr-1');
   await screen.findByText('Adjudicating cvr-1');
 
   apiMock.apiClient.releaseBallot
     .expectCallWith({ cvrId: 'cvr-1' })
     .resolves(ok());
-  apiMock.apiClient.claimBallot
-    .expectCallWith({ excludeCvrIds: ['cvr-1'] })
+  apiMock.apiClient.claimAndLoadBallot
+    .expectCallWith({ afterCvrId: 'cvr-1' })
     .resolves(ok(undefined));
-  apiMock.apiClient.claimBallot.expectCallWith({}).resolves(ok('cvr-1'));
-  expectDataLoaderQueries('cvr-1');
+  apiMock.apiClient.claimAndLoadBallot
+    .expectCallWith({})
+    .resolves(ok({ cvrId: 'cvr-1', data: makeBallotData('cvr-1') }));
 
   screen.getByText('Skip').click();
   await screen.findByText('Adjudicating cvr-1');
@@ -229,6 +274,8 @@ test('skip clears exclusion set when no more ballots and retries', async () => {
 
 test('exit releases ballot', async () => {
   expectDataLoaderQueries('cvr-1');
+  expectGlobalDataLoaderQueries();
+  expectInitialClaimAndLoad('cvr-1');
   renderScreen('cvr-1');
   await screen.findByText('Adjudicating cvr-1');
 
@@ -244,11 +291,9 @@ test('exit releases ballot', async () => {
 });
 
 test('shows no-claim error with exit button', async () => {
-  expectDataLoaderQueries('cvr-1');
-
-  // Override adjudication data to return an error
-  apiMock.apiClient.getBallotAdjudicationData.reset();
-  apiMock.apiClient.getBallotAdjudicationData
+  // Initial claim+load fails with no-claim — auxiliary data loader queries
+  // never run because we bail to the error screen first.
+  apiMock.apiClient.claimAndLoadBallot
     .expectRepeatedCallsWith({ cvrId: 'cvr-1' })
     .resolves(err({ type: 'no-claim' }));
 
@@ -261,11 +306,7 @@ test('shows no-claim error with exit button', async () => {
 });
 
 test('shows host-disconnect error with exit button', async () => {
-  expectDataLoaderQueries('cvr-1');
-
-  // Override adjudication data to return an error
-  apiMock.apiClient.getBallotAdjudicationData.reset();
-  apiMock.apiClient.getBallotAdjudicationData
+  apiMock.apiClient.claimAndLoadBallot
     .expectRepeatedCallsWith({ cvrId: 'cvr-1' })
     .resolves(err({ type: 'host-disconnect' }));
 
@@ -276,8 +317,10 @@ test('shows host-disconnect error with exit button', async () => {
 });
 
 test('redirects when host disables adjudication', async () => {
-  // Set up data loader queries (they fire before the redirect)
+  // Data loader queries fire before the redirect.
   expectDataLoaderQueries('cvr-1');
+  expectGlobalDataLoaderQueries();
+  expectInitialClaimAndLoad('cvr-1');
 
   // Override adjudication status to disabled
   apiMock.apiClient.getAdjudicationSessionStatus.reset();
@@ -306,10 +349,10 @@ test('redirects when host disables adjudication', async () => {
                 <MemoryRouter
                   initialEntries={[`${routerPaths.ballotAdjudication}/cvr-1`]}
                 >
-                  <Route path={`${routerPaths.ballotAdjudication}/:cvrId`}>
+                  <Route path={`${routerPaths.ballotAdjudication}/:cvrId?`}>
                     <ClientBallotAdjudicationScreen />
                   </Route>
-                  <Route path={routerPaths.adjudication}>
+                  <Route exact path={routerPaths.adjudication}>
                     <div>adjudication start</div>
                   </Route>
                 </MemoryRouter>
@@ -326,6 +369,8 @@ test('redirects when host disables adjudication', async () => {
 
 test('onAccept calls API and accept advances', async () => {
   expectDataLoaderQueries('cvr-1');
+  expectGlobalDataLoaderQueries();
+  expectInitialClaimAndLoad('cvr-1');
   renderScreen('cvr-1');
   await screen.findByText('Adjudicating cvr-1');
 
@@ -337,13 +382,20 @@ test('onAccept calls API and accept advances', async () => {
   await onAccept(mockInput);
 
   // Then accept advances to next (no more ballots)
-  apiMock.apiClient.claimBallot.expectCallWith({}).resolves(ok(undefined));
+  apiMock.apiClient.claimAndLoadBallot
+    .expectCallWith({ afterCvrId: 'cvr-1' })
+    .resolves(ok(undefined));
+  apiMock.apiClient.claimAndLoadBallot
+    .expectCallWith({})
+    .resolves(ok(undefined));
   screen.getByText('Accept').click();
   await screen.findByText('No more ballots available for adjudication.');
 });
 
 test('onAccept error shows error screen', async () => {
   expectDataLoaderQueries('cvr-1');
+  expectGlobalDataLoaderQueries();
+  expectInitialClaimAndLoad('cvr-1');
   renderScreen('cvr-1');
   await screen.findByText('Adjudicating cvr-1');
 

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
@@ -81,11 +81,8 @@ const pollWorkerAuth: DippedSmartCardAuth.PollWorkerLoggedIn = {
   sessionExpiresAt: mockSessionExpiresAt(),
 };
 
-function renderScreen(cvrId?: string) {
+function renderScreen() {
   expectAdjudicationEnabled();
-  const pathname = cvrId
-    ? `${routerPaths.ballotAdjudication}/${cvrId}`
-    : routerPaths.ballotAdjudication;
   const clientApiClient = apiMock.apiClient as unknown as ClientApiClient;
   return render(
     <TestErrorBoundary>
@@ -104,8 +101,8 @@ function renderScreen(cvrId?: string) {
                   electionPackageHash: 'test-hash',
                 }}
               >
-                <MemoryRouter initialEntries={[pathname]}>
-                  <Route path={`${routerPaths.ballotAdjudication}/:cvrId?`}>
+                <MemoryRouter initialEntries={[routerPaths.ballotAdjudication]}>
+                  <Route exact path={routerPaths.ballotAdjudication}>
                     <ClientBallotAdjudicationScreen />
                   </Route>
                 </MemoryRouter>
@@ -165,32 +162,22 @@ function expectGlobalDataLoaderQueries(): void {
     .resolves(DEFAULT_SYSTEM_SETTINGS);
 }
 
-// Sets up the initial-mount claim+load call for the cvrId in the URL.
-// Used by most tests; tests that want to override the initial result
-// (e.g. to test claim-failure flows) skip this and mock directly.
+// Sets up the initial-mount claim+load call. The client always claims the
+// next available ballot ({}); the host decides which cvrId that is, returned
+// here as `cvrId`. Tests that want to override the result (e.g. claim-failure
+// flows) skip this and mock directly.
 function expectInitialClaimAndLoad(cvrId: string): void {
   apiMock.apiClient.claimAndLoadBallot
-    .expectCallWith({ cvrId })
+    .expectCallWith({})
     .resolves(ok({ cvrId, data: makeBallotData(cvrId) }));
 }
 
-test('renders adjudicating state with initial cvrId from route', async () => {
+test('claims the next available ballot on mount', async () => {
+  // Arriving from "Start Adjudication", the screen claims the next available
+  // ballot ({}); the host returns which cvrId that is.
   expectDataLoaderQueries('cvr-1');
   expectGlobalDataLoaderQueries();
   expectInitialClaimAndLoad('cvr-1');
-  renderScreen('cvr-1');
-  await screen.findByText('Adjudicating cvr-1');
-  expect(capturedProps['cvrId']).toEqual('cvr-1');
-});
-
-test('claims the next ballot when no cvrId is in the route', async () => {
-  // Arriving from "Start Adjudication" with no cvrId: the screen claims the
-  // next available ballot itself, so there is exactly one claim.
-  expectDataLoaderQueries('cvr-1');
-  expectGlobalDataLoaderQueries();
-  apiMock.apiClient.claimAndLoadBallot
-    .expectCallWith({})
-    .resolves(ok({ cvrId: 'cvr-1', data: makeBallotData('cvr-1') }));
   renderScreen();
   await screen.findByText('Adjudicating cvr-1');
   expect(capturedProps['cvrId']).toEqual('cvr-1');
@@ -200,16 +187,13 @@ test('accept claims next ballot', async () => {
   expectDataLoaderQueries('cvr-1');
   expectGlobalDataLoaderQueries();
   expectInitialClaimAndLoad('cvr-1');
-  renderScreen('cvr-1');
+  renderScreen();
   await screen.findByText('Adjudicating cvr-1');
 
-  // After accept on cvr-1, the screen looks for the next ballot after it,
-  // then falls back to searching from the beginning when nothing is found.
+  // After accept on cvr-1, the screen asks for the next ballot after it; the
+  // backend wraps around and returns nothing when none remain.
   apiMock.apiClient.claimAndLoadBallot
     .expectCallWith({ afterCvrId: 'cvr-1' })
-    .resolves(ok(undefined));
-  apiMock.apiClient.claimAndLoadBallot
-    .expectCallWith({})
     .resolves(ok(undefined));
   screen.getByText('Accept').click();
   await screen.findByText('No more ballots available for adjudication.');
@@ -221,7 +205,7 @@ test('shows error screen when claim fails during accept', async () => {
   expectDataLoaderQueries('cvr-1');
   expectGlobalDataLoaderQueries();
   expectInitialClaimAndLoad('cvr-1');
-  renderScreen('cvr-1');
+  renderScreen();
   await screen.findByText('Adjudicating cvr-1');
 
   apiMock.apiClient.claimAndLoadBallot
@@ -237,7 +221,7 @@ test('skip releases ballot and claims next after it', async () => {
   expectDataLoaderQueries('cvr-2');
   expectGlobalDataLoaderQueries();
   expectInitialClaimAndLoad('cvr-1');
-  renderScreen('cvr-1');
+  renderScreen();
   await screen.findByText('Adjudicating cvr-1');
 
   apiMock.apiClient.releaseBallot
@@ -255,17 +239,16 @@ test('skip wraps to first eligible when nothing is available after current', asy
   expectDataLoaderQueries('cvr-1');
   expectGlobalDataLoaderQueries();
   expectInitialClaimAndLoad('cvr-1');
-  renderScreen('cvr-1');
+  renderScreen();
   await screen.findByText('Adjudicating cvr-1');
 
+  // Skip releases cvr-1, then asks for the next ballot after it. Nothing comes
+  // after, so the backend wraps around and hands cvr-1 back in one call.
   apiMock.apiClient.releaseBallot
     .expectCallWith({ cvrId: 'cvr-1' })
     .resolves(ok());
   apiMock.apiClient.claimAndLoadBallot
     .expectCallWith({ afterCvrId: 'cvr-1' })
-    .resolves(ok(undefined));
-  apiMock.apiClient.claimAndLoadBallot
-    .expectCallWith({})
     .resolves(ok({ cvrId: 'cvr-1', data: makeBallotData('cvr-1') }));
 
   screen.getByText('Skip').click();
@@ -276,7 +259,7 @@ test('exit releases ballot', async () => {
   expectDataLoaderQueries('cvr-1');
   expectGlobalDataLoaderQueries();
   expectInitialClaimAndLoad('cvr-1');
-  renderScreen('cvr-1');
+  renderScreen();
   await screen.findByText('Adjudicating cvr-1');
 
   apiMock.apiClient.releaseBallot
@@ -294,10 +277,10 @@ test('shows no-claim error with exit button', async () => {
   // Initial claim+load fails with no-claim — auxiliary data loader queries
   // never run because we bail to the error screen first.
   apiMock.apiClient.claimAndLoadBallot
-    .expectRepeatedCallsWith({ cvrId: 'cvr-1' })
+    .expectRepeatedCallsWith({})
     .resolves(err({ type: 'no-claim' }));
 
-  renderScreen('cvr-1');
+  renderScreen();
 
   await screen.findByText(
     'This machine no longer has an active claim on this ballot. Please try again.'
@@ -307,10 +290,10 @@ test('shows no-claim error with exit button', async () => {
 
 test('shows host-disconnect error with exit button', async () => {
   apiMock.apiClient.claimAndLoadBallot
-    .expectRepeatedCallsWith({ cvrId: 'cvr-1' })
+    .expectRepeatedCallsWith({})
     .resolves(err({ type: 'host-disconnect' }));
 
-  renderScreen('cvr-1');
+  renderScreen();
 
   await screen.findByText('Disconnected from host.');
   screen.getByText('Exit');
@@ -346,10 +329,8 @@ test('redirects when host disables adjudication', async () => {
                   electionPackageHash: 'test-hash',
                 }}
               >
-                <MemoryRouter
-                  initialEntries={[`${routerPaths.ballotAdjudication}/cvr-1`]}
-                >
-                  <Route path={`${routerPaths.ballotAdjudication}/:cvrId?`}>
+                <MemoryRouter initialEntries={[routerPaths.ballotAdjudication]}>
+                  <Route exact path={routerPaths.ballotAdjudication}>
                     <ClientBallotAdjudicationScreen />
                   </Route>
                   <Route exact path={routerPaths.adjudication}>
@@ -371,7 +352,7 @@ test('onAccept calls API and accept advances', async () => {
   expectDataLoaderQueries('cvr-1');
   expectGlobalDataLoaderQueries();
   expectInitialClaimAndLoad('cvr-1');
-  renderScreen('cvr-1');
+  renderScreen();
   await screen.findByText('Adjudicating cvr-1');
 
   const mockInput = { cvrId: 'cvr-1', contests: [] } as const;
@@ -381,12 +362,10 @@ test('onAccept calls API and accept advances', async () => {
   ) => Promise<void>;
   await onAccept(mockInput);
 
-  // Then accept advances to next (no more ballots)
+  // Then accept advances to next (no more ballots; backend wraps and finds
+  // none in one call)
   apiMock.apiClient.claimAndLoadBallot
     .expectCallWith({ afterCvrId: 'cvr-1' })
-    .resolves(ok(undefined));
-  apiMock.apiClient.claimAndLoadBallot
-    .expectCallWith({})
     .resolves(ok(undefined));
   screen.getByText('Accept').click();
   await screen.findByText('No more ballots available for adjudication.');
@@ -396,7 +375,7 @@ test('onAccept error shows error screen', async () => {
   expectDataLoaderQueries('cvr-1');
   expectGlobalDataLoaderQueries();
   expectInitialClaimAndLoad('cvr-1');
-  renderScreen('cvr-1');
+  renderScreen();
   await screen.findByText('Adjudicating cvr-1');
 
   const mockInput = { cvrId: 'cvr-1', contests: [] } as const;

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.tsx
@@ -22,7 +22,7 @@ import {
 
 function proxyErrorMessage(error: AdjudicationError): string {
   switch (error.type) {
-    case 'no-claim':
+    case 'claim-failed':
       return 'This machine no longer has an active claim on this ballot. Please try again.';
     case 'host-disconnect':
       return 'Disconnected from host.';

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.tsx
@@ -3,15 +3,17 @@ import { Button, Loading, Main, P, Screen } from '@votingworks/ui';
 import { useHistory, useParams } from 'react-router-dom';
 import { throwIllegalValue } from '@votingworks/basics';
 import { Id } from '@votingworks/types';
-import type { AdjudicationError } from '@votingworks/admin-backend';
+import type {
+  AdjudicationError,
+  BallotAdjudicationData,
+} from '@votingworks/admin-backend';
 import { BallotAdjudicationScreen } from '../../screens/ballot_adjudication_screen';
 import { NavigationScreen } from '../../components/navigation_screen';
 import { routerPaths } from '../../router_paths';
 import {
   adjudicateCvr,
-  claimBallot,
+  claimAndLoadBallot,
   getAdjudicationSessionStatus,
-  getBallotAdjudicationData,
   getBallotImages,
   getSystemSettings,
   getWriteInCandidates,
@@ -30,23 +32,29 @@ function proxyErrorMessage(error: AdjudicationError): string {
   }
 }
 
+// While claiming the next ballot, we stay on the previous `adjudicating`
+// state so the user keeps seeing the old ballot rather than a Loading
+// flicker. `initial-load` is only used on first mount, before we've ever
+// successfully claimed.
 type FlowState =
-  | { type: 'adjudicating'; cvrId: Id }
-  | { type: 'claiming' }
+  | { type: 'initial-load' }
+  | { type: 'adjudicating'; cvrId: Id; data: BallotAdjudicationData }
   | { type: 'done' }
   | { type: 'error'; error: AdjudicationError };
 
 export function ClientBallotAdjudicationScreen(): JSX.Element {
   const history = useHistory();
-  const { cvrId: initialCvrId } = useParams<{ cvrId: string }>();
+  // The cvrId is absent when arriving from "Start Adjudication" (claim the
+  // next available ballot) and present on refresh/direct navigation (reclaim
+  // that specific ballot).
+  const { cvrId: initialCvrId } = useParams<{ cvrId?: string }>();
   const adjudicationStatusQuery = getAdjudicationSessionStatus.useQuery();
-  const { mutateAsync: claimBallotAsync } = claimBallot.useMutation();
+  const { mutateAsync: claimAndLoadAsync } = claimAndLoadBallot.useMutation();
   const { mutateAsync: releaseBallotAsync } = releaseBallot.useMutation();
+
   const [flowState, setFlowState] = useState<FlowState>({
-    type: 'adjudicating',
-    cvrId: initialCvrId,
+    type: 'initial-load',
   });
-  const skippedCvrIdsRef = useRef<Set<Id>>(new Set());
 
   // Navigate back if the host disables adjudication mid-session
   const isAdjudicationEnabled =
@@ -64,38 +72,79 @@ export function ClientBallotAdjudicationScreen(): JSX.Element {
     [releaseBallotAsync]
   );
 
-  const claimNextBallot = useCallback(async (): Promise<void> => {
-    setFlowState({ type: 'claiming' });
+  // Initial load: claim+load a ballot — the specific one named in the URL, or
+  // the next available one when no cvrId is present. Runs once on mount; the ref guard makes the claim fire at
+  // most once even under StrictMode's double-invoke. We `history.replace` the
+  // resolved cvrId into the URL so a refresh reclaims the same ballot.
+  const hasClaimedOnMountRef = useRef(false);
+  useEffect(() => {
+    if (hasClaimedOnMountRef.current) return;
+    hasClaimedOnMountRef.current = true;
+    void (async () => {
+      const result = await claimAndLoadAsync(
+        initialCvrId ? { cvrId: initialCvrId } : {}
+      );
+      if (result.isErr()) {
+        setFlowState({ type: 'error', error: result.err() });
+        return;
+      }
+      const value = result.ok();
+      if (!value) {
+        setFlowState({ type: 'done' });
+        return;
+      }
+      // Only rewrite the URL when we arrived without a cvrId (from "Start
+      // Adjudication"); when one is already present the path is correct and
+      // replacing it could clobber a concurrent redirect.
+      if (!initialCvrId) {
+        history.replace(`${routerPaths.ballotAdjudication}/${value.cvrId}`);
+      }
+      setFlowState({
+        type: 'adjudicating',
+        cvrId: value.cvrId,
+        data: value.data,
+      });
+    })();
+  }, [claimAndLoadAsync, history, initialCvrId]);
 
-    const excludeCvrIds = [...skippedCvrIdsRef.current];
-    let result = await claimBallotAsync(
-      excludeCvrIds.length > 0 ? { excludeCvrIds } : {}
-    );
+  // Move forward past `afterCvrId` to the next eligible ballot. With no
+  // argument, restarts from the beginning of the queue (used as the
+  // wrap-around fallback when we've walked past the end mid-session).
+  const claimNextBallot = useCallback(
+    async (afterCvrId?: Id): Promise<void> => {
+      let result = await claimAndLoadAsync(afterCvrId ? { afterCvrId } : {});
 
-    if (result.isOk() && !result.ok() && excludeCvrIds.length > 0) {
-      skippedCvrIdsRef.current.clear();
-      result = await claimBallotAsync({});
-    }
+      // If nothing is available past `afterCvrId`, try once more without
+      // the cursor — there may be still-unresolved ballots earlier in the
+      // queue that we walked past via Skip.
+      if (result.isOk() && !result.ok() && afterCvrId) {
+        result = await claimAndLoadAsync({});
+      }
 
-    if (result.isErr()) {
-      setFlowState({ type: 'error', error: result.err() });
-      return;
-    }
+      if (result.isErr()) {
+        setFlowState({ type: 'error', error: result.err() });
+        return;
+      }
 
-    const cvrId = result.ok();
-    if (cvrId) {
-      history.replace(`${routerPaths.ballotAdjudication}/${cvrId}`);
-      setFlowState({ type: 'adjudicating', cvrId });
-    } else {
-      setFlowState({ type: 'done' });
-    }
-  }, [claimBallotAsync, history]);
+      const value = result.ok();
+      if (value) {
+        history.replace(`${routerPaths.ballotAdjudication}/${value.cvrId}`);
+        setFlowState({
+          type: 'adjudicating',
+          cvrId: value.cvrId,
+          data: value.data,
+        });
+      } else {
+        setFlowState({ type: 'done' });
+      }
+    },
+    [claimAndLoadAsync, history]
+  );
 
   const skipBallot = useCallback(
     async (cvrId: Id): Promise<void> => {
-      skippedCvrIdsRef.current.add(cvrId);
       await releaseClaim(cvrId);
-      await claimNextBallot();
+      await claimNextBallot(cvrId);
     },
     [releaseClaim, claimNextBallot]
   );
@@ -109,11 +158,11 @@ export function ClientBallotAdjudicationScreen(): JSX.Element {
   );
 
   switch (flowState.type) {
-    case 'claiming':
+    case 'initial-load':
       return (
         <Screen>
           <Main flexRow>
-            <Loading>Claiming next ballot…</Loading>
+            <Loading isFullscreen />
           </Main>
         </Screen>
       );
@@ -144,7 +193,8 @@ export function ClientBallotAdjudicationScreen(): JSX.Element {
       return (
         <ClientBallotAdjudicationDataLoader
           cvrId={flowState.cvrId}
-          onAcceptDone={() => void claimNextBallot()}
+          ballotData={flowState.data}
+          onAcceptDone={() => void claimNextBallot(flowState.cvrId)}
           onSkip={() => void skipBallot(flowState.cvrId)}
           onExit={() => void exitBallot(flowState.cvrId)}
         />
@@ -158,17 +208,18 @@ export function ClientBallotAdjudicationScreen(): JSX.Element {
 
 function ClientBallotAdjudicationDataLoader({
   cvrId,
+  ballotData,
   onAcceptDone,
   onSkip,
   onExit,
 }: {
   cvrId: Id;
+  ballotData: BallotAdjudicationData;
   onAcceptDone: () => void;
   onSkip: () => void;
   onExit: () => void;
 }): JSX.Element {
   const history = useHistory();
-  const adjudicationDataQuery = getBallotAdjudicationData.useQuery(cvrId);
   const ballotImagesQuery = getBallotImages.useQuery(cvrId);
   const writeInCandidatesQuery = getWriteInCandidates.useQuery();
   const systemSettingsQuery = getSystemSettings.useQuery();
@@ -176,7 +227,6 @@ function ClientBallotAdjudicationDataLoader({
   const [mutationError, setMutationError] = useState<AdjudicationError>();
 
   if (
-    !adjudicationDataQuery.isSuccess ||
     !ballotImagesQuery.isSuccess ||
     !writeInCandidatesQuery.isSuccess ||
     !systemSettingsQuery.isSuccess
@@ -190,17 +240,14 @@ function ClientBallotAdjudicationDataLoader({
     );
   }
 
-  const adjudicationData = adjudicationDataQuery.data;
   const ballotImages = ballotImagesQuery.data;
   const writeInCandidates = writeInCandidatesQuery.data;
   const systemSettings = systemSettingsQuery.data;
 
-  // Check for proxy errors in query results or mutations
+  // Auxiliary proxy results may still surface their own errors.
   const proxyError =
     mutationError ??
-    [adjudicationData, ballotImages, writeInCandidates]
-      .find((r) => r.isErr())
-      ?.err();
+    [ballotImages, writeInCandidates].find((r) => r.isErr())?.err();
   if (proxyError) {
     return (
       <NavigationScreen title="Adjudication">
@@ -212,16 +259,14 @@ function ClientBallotAdjudicationDataLoader({
     );
   }
 
-  // Unwrap ok values — systemSettings is not a Result (it reads from cache).
-  // We've already checked for errors above, so unsafeUnwrap is safe here.
-  const adjData = adjudicationData.unsafeUnwrap();
   const images = ballotImages.unsafeUnwrap();
   const candidates = writeInCandidates.unsafeUnwrap();
 
   return (
     <BallotAdjudicationScreen
+      key={cvrId}
       cvrId={cvrId}
-      ballotAdjudicationData={adjData}
+      ballotAdjudicationData={ballotData}
       ballotImages={images}
       writeInCandidates={candidates}
       systemSettings={systemSettings}

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Button, Loading, Main, P, Screen } from '@votingworks/ui';
-import { useHistory, useParams } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { throwIllegalValue } from '@votingworks/basics';
 import { Id } from '@votingworks/types';
 import type {
@@ -44,10 +44,6 @@ type FlowState =
 
 export function ClientBallotAdjudicationScreen(): JSX.Element {
   const history = useHistory();
-  // The cvrId is absent when arriving from "Start Adjudication" (claim the
-  // next available ballot) and present on refresh/direct navigation (reclaim
-  // that specific ballot).
-  const { cvrId: initialCvrId } = useParams<{ cvrId?: string }>();
   const adjudicationStatusQuery = getAdjudicationSessionStatus.useQuery();
   const { mutateAsync: claimAndLoadAsync } = claimAndLoadBallot.useMutation();
   const { mutateAsync: releaseBallotAsync } = releaseBallot.useMutation();
@@ -72,55 +68,13 @@ export function ClientBallotAdjudicationScreen(): JSX.Element {
     [releaseBallotAsync]
   );
 
-  // Initial load: claim+load a ballot — the specific one named in the URL, or
-  // the next available one when no cvrId is present. Runs once on mount; the ref guard makes the claim fire at
-  // most once even under StrictMode's double-invoke. We `history.replace` the
-  // resolved cvrId into the URL so a refresh reclaims the same ballot.
-  const hasClaimedOnMountRef = useRef(false);
-  useEffect(() => {
-    if (hasClaimedOnMountRef.current) return;
-    hasClaimedOnMountRef.current = true;
-    void (async () => {
-      const result = await claimAndLoadAsync(
-        initialCvrId ? { cvrId: initialCvrId } : {}
-      );
-      if (result.isErr()) {
-        setFlowState({ type: 'error', error: result.err() });
-        return;
-      }
-      const value = result.ok();
-      if (!value) {
-        setFlowState({ type: 'done' });
-        return;
-      }
-      // Only rewrite the URL when we arrived without a cvrId (from "Start
-      // Adjudication"); when one is already present the path is correct and
-      // replacing it could clobber a concurrent redirect.
-      if (!initialCvrId) {
-        history.replace(`${routerPaths.ballotAdjudication}/${value.cvrId}`);
-      }
-      setFlowState({
-        type: 'adjudicating',
-        cvrId: value.cvrId,
-        data: value.data,
-      });
-    })();
-  }, [claimAndLoadAsync, history, initialCvrId]);
-
-  // Move forward past `afterCvrId` to the next eligible ballot. With no
-  // argument, restarts from the beginning of the queue (used as the
-  // wrap-around fallback when we've walked past the end mid-session).
+  // Claim+load a ballot and reflect it in flow state. `afterCvrId` advances to
+  // the next eligible ballot, which the backend wraps around the end of the
+  // queue back to any earlier still-unresolved ballots; with no argument it
+  // claims a fresh ballot (used for the initial mount).
   const claimNextBallot = useCallback(
     async (afterCvrId?: Id): Promise<void> => {
-      let result = await claimAndLoadAsync(afterCvrId ? { afterCvrId } : {});
-
-      // If nothing is available past `afterCvrId`, try once more without
-      // the cursor — there may be still-unresolved ballots earlier in the
-      // queue that we walked past via Skip.
-      if (result.isOk() && !result.ok() && afterCvrId) {
-        result = await claimAndLoadAsync({});
-      }
-
+      const result = await claimAndLoadAsync(afterCvrId ? { afterCvrId } : {});
       if (result.isErr()) {
         setFlowState({ type: 'error', error: result.err() });
         return;
@@ -128,7 +82,6 @@ export function ClientBallotAdjudicationScreen(): JSX.Element {
 
       const value = result.ok();
       if (value) {
-        history.replace(`${routerPaths.ballotAdjudication}/${value.cvrId}`);
         setFlowState({
           type: 'adjudicating',
           cvrId: value.cvrId,
@@ -138,8 +91,13 @@ export function ClientBallotAdjudicationScreen(): JSX.Element {
         setFlowState({ type: 'done' });
       }
     },
-    [claimAndLoadAsync, history]
+    [claimAndLoadAsync]
   );
+
+  // Claim the first ballot on mount (no cursor → a fresh claim).
+  useEffect(() => {
+    void claimNextBallot();
+  }, [claimNextBallot]);
 
   const skipBallot = useCallback(
     async (cvrId: Id): Promise<void> => {
@@ -244,7 +202,7 @@ function ClientBallotAdjudicationDataLoader({
   const writeInCandidates = writeInCandidatesQuery.data;
   const systemSettings = systemSettingsQuery.data;
 
-  // Auxiliary proxy results may still surface their own errors.
+  // Check for proxy errors in query results or mutations.
   const proxyError =
     mutationError ??
     [ballotImages, writeInCandidates].find((r) => r.isErr())?.err();

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -1452,14 +1452,14 @@ test('Skip onto a ballot claimed by another machine shows read-only overlay and 
   await screen.findByText('Ballot ID: aaaa');
 
   // Skip from FIRST_CVR_ID advances by one position to CLAIMED_CVR_ID which
-  // is held by another machine — the wrapper surfaces a `no-claim` error so
+  // is held by another machine — the wrapper surfaces a `claim-failed` error so
   // the screen renders the "claimed by another machine" overlay. The header
   // should still update to the claimed ballot's ID even though we never
   // loaded its adjudication data.
   apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: FIRST_CVR_ID });
   apiMock.apiClient.claimAndLoadBallot
     .expectCallWith({ cvrId: CLAIMED_CVR_ID })
-    .resolves(err({ type: 'no-claim' }));
+    .resolves(err({ type: 'claim-failed' }));
   apiMock.expectGetBallotImages({ cvrId: CLAIMED_CVR_ID }, true);
 
   userEvent.click(screen.getByRole('button', { name: /Skip/ }));
@@ -1477,7 +1477,7 @@ test('Skip onto a ballot claimed by another machine shows read-only overlay and 
 test('shows an error with exit when the claim+load fails', async () => {
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
-  // The claim+load fails with a non-"no-claim" error (e.g. the host backend
+  // The claim+load fails with a non-"claim-failed" error (e.g. the host backend
   // errored), so there's no ballot data and no claimed-by-another overlay.
   apiMock.apiClient.claimAndLoadBallot
     .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -24,7 +24,7 @@ import {
 import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
 import { Route, Switch } from 'react-router-dom';
-import { assertDefined } from '@votingworks/basics';
+import { assertDefined, err } from '@votingworks/basics';
 import {
   fireEvent,
   screen,
@@ -151,20 +151,15 @@ function setupBasicMocks({
   adjudicationData: BallotAdjudicationData;
   isBmd?: boolean;
 }) {
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue(queue);
   apiMock.expectGetNextCvrIdForBallotAdjudication(nextCvrId);
-  apiMock.expectGetBallotAdjudicationData(
+  apiMock.expectClaimAndLoadBallot(
     { cvrId: adjudicationData.cvrId },
     adjudicationData
   );
   apiMock.expectGetBallotImages({ cvrId: adjudicationData.cvrId }, isBmd);
   apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings();
-
-  if (nextCvrId) {
-    apiMock.expectClaimBallotForAdjudication({ cvrId: nextCvrId });
-  }
 }
 
 function makeHmpbPageLayout(contestIds: string[]): BallotPageLayout {
@@ -249,13 +244,12 @@ test('ballot navigation supports back, skip, exit, and side switching', async ()
   const adjData3 = makeBallotAdjudicationData(CVR_ID_3, contestData);
 
   // initial load
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2, CVR_ID_3]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
   apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings();
 
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData1);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData1);
 
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
@@ -266,8 +260,6 @@ test('ballot navigation supports back, skip, exit, and side switching', async ()
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_3 })
     .resolves(makeHmpbBallotImages(CVR_ID_3));
-
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
 
   const history = createMemoryHistory();
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
@@ -312,23 +304,20 @@ test('ballot navigation supports back, skip, exit, and side switching', async ()
 
   // skip to second ballot
   apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_1 });
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_2 });
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_2 }, adjData2);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_2 }, adjData2);
   userEvent.click(screen.getByRole('button', { name: /Skip/ }));
   await screen.findByText('Ballot 2 of 3');
   expect(screen.getByRole('button', { name: /Back/ })).toBeEnabled();
 
   // skip to third (last) ballot
   apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_2 });
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_3 });
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_3 }, adjData3);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_3 }, adjData3);
   userEvent.click(screen.getByRole('button', { name: /Skip/ }));
   await screen.findByText('Ballot 3 of 3');
 
   // back to second ballot — staleTime: 0 triggers a refetch
   apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_3 });
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_2 });
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_2 }, adjData2);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_2 }, adjData2);
   userEvent.click(screen.getByRole('button', { name: /Back/ }));
   await screen.findByText('Ballot 2 of 3');
 
@@ -350,16 +339,14 @@ test('opens to the back side when the only pending contest is on the back', asyn
     ),
   ]);
 
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves(makeHmpbBallotImages(CVR_ID_1));
   apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings();
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,
@@ -391,16 +378,14 @@ test('default side flips to next pending after confirming a contest', async () =
     ),
   ]);
 
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves(makeHmpbBallotImages(CVR_ID_1));
   apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings();
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,
@@ -455,10 +440,9 @@ test('skip / back / exit prompt to discard when the user has unsaved adjudicatio
 
   // Start at ballot 2 of 2 so Skip, Back, and Exit are all visible
   // (Back only renders past the first ballot in the queue).
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_2);
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_2 }, adjData2);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_2 }, adjData2);
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_2 })
     .resolves(makeHmpbBallotImages(CVR_ID_2));
@@ -467,7 +451,6 @@ test('skip / back / exit prompt to discard when the user has unsaved adjudicatio
     .resolves(makeHmpbBallotImages(CVR_ID_1));
   apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings();
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_2 });
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,
@@ -502,8 +485,7 @@ test('skip / back / exit prompt to discard when the user has unsaved adjudicatio
   // Back triggers the prompt; this time Discard clears the buffer and
   // navigation proceeds to ballot 1.
   apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_2 });
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData1);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData1);
   userEvent.click(screen.getByRole('button', { name: /^Back$/ }));
   await screen.findByText('Unsaved Changes');
   userEvent.click(screen.getByRole('button', { name: /Discard/ }));
@@ -522,17 +504,14 @@ test('re-opening a Confirmed contest preserves the in-progress adjudication', as
     ),
   ]);
 
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves(makeHmpbBallotImages(CVR_ID_1));
   apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings();
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
-
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,
     apiMock,
@@ -588,7 +567,6 @@ test('accept button state depends on contest resolution', async () => {
     }
   );
   setupBasicMocks({ adjudicationData: resolvedAdjData, nextCvrId: null });
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,
@@ -617,14 +595,12 @@ test('confirmation modal back returns and accept anyway resolves and navigates t
     initialEntries: [routerPaths.ballotAdjudication],
   });
 
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
   apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings();
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
 
   renderInAppContext(
     <Switch>
@@ -666,13 +642,12 @@ test('confirmation modal back returns and accept anyway resolves and navigates t
   apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_1 });
   apiMock.expectAdjudicateCvr({ cvrId: CVR_ID_1, contests: [] });
   // invalidated queries refetch after resolve
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
   apiMock.expectGetBallotAdjudicationQueue([]);
   apiMock.expectGetBallotAdjudicationQueueMetadata({
     totalTally: 1,
     pendingTally: 0,
   });
-  apiMock.expectGetNextCvrIdForBallotAdjudication(null);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(null, CVR_ID_1);
   // start screen fetches
   apiMock.expectGetCastVoteRecordFiles([
     {
@@ -707,16 +682,14 @@ test('clicking a contest opens contest adjudication screen', async () => {
   ]);
 
   // Use HMPB images so zoo-council-mammal is on front, best-animal-mammal on back
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves(makeHmpbBallotImages(CVR_ID_1));
   apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings();
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,
@@ -807,16 +780,14 @@ test('contest hover highlights pending yellow, resolved purple, and back-side no
     },
   };
 
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves(ballotImages);
   apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings();
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,
@@ -895,20 +866,9 @@ test('accept advances to next ballot and blank ballot callout states', async () 
     { tag: { isBlankBallot: true } }
   );
 
-  // Ballot 2 after resolve: confirmed blank ballot
-  const adjData2Resolved = makeBallotAdjudicationData(
-    CVR_ID_2,
-    [
-      makeContestAdjudicationData(
-        'zoo-council-mammal',
-        makeContestTag({
-          hasWriteIn: false,
-          hasUndervote: true,
-        })
-      ),
-    ],
-    { tag: { isBlankBallot: true }, isResolved: true }
-  );
+  // (Ballot 2's resolved form is no longer needed in this test — the
+  // wrapper doesn't refetch it after adjudicate; navigateAcceptNext
+  // moves straight to ballot 3.)
 
   // Ballot 3: blank ballot with an adjudicated vote on one option
   const zooCouncilContest = makeContestAdjudicationData('zoo-council-mammal');
@@ -922,10 +882,9 @@ test('accept advances to next ballot and blank ballot callout states', async () 
     ],
   });
 
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2, CVR_ID_3]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData1);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData1);
   apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings();
   apiMock.apiClient.getBallotImages
@@ -937,7 +896,6 @@ test('accept advances to next ballot and blank ballot callout states', async () 
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_3 })
     .resolves(makeHmpbBallotImages(CVR_ID_3));
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,
@@ -950,14 +908,9 @@ test('accept advances to next ballot and blank ballot callout states', async () 
 
   apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_1 });
   apiMock.expectAdjudicateCvr({ cvrId: CVR_ID_1, contests: [] });
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData1);
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2, CVR_ID_3]);
-  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_2);
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_2 });
-  apiMock.expectGetBallotAdjudicationData(
-    { cvrId: CVR_ID_2 },
-    adjData2Unresolved
-  );
+  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_2, CVR_ID_1);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_2 }, adjData2Unresolved);
   userEvent.click(screen.getByRole('button', { name: /Accept/ }));
 
   // Ballot 2: blank, unresolved -> "Blank Ballot Detected"
@@ -982,14 +935,9 @@ test('accept advances to next ballot and blank ballot callout states', async () 
   // directly resolves without a confirmation modal
   apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_2 });
   apiMock.expectAdjudicateCvr({ cvrId: CVR_ID_2, contests: [] });
-  apiMock.expectGetBallotAdjudicationData(
-    { cvrId: CVR_ID_2 },
-    adjData2Resolved
-  );
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2, CVR_ID_3]);
-  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_3);
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_3 });
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_3 }, adjData3);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_3, CVR_ID_2);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_3 }, adjData3);
   userEvent.click(screen.getByRole('button', { name: /Accept/ }));
 
   // Ballot 3: blank with adjudicated vote -> "Blank Ballot Resolved"
@@ -998,6 +946,76 @@ test('accept advances to next ballot and blank ballot callout states', async () 
   screen.getByText('At least one contest now has a valid vote');
   apiMock.apiClient.releaseBallotAdjudicationClaim
     .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_3 })
+    .resolves();
+});
+
+test('accept on the last ballot wraps back to an earlier unresolved ballot', async () => {
+  // Two ballots in the queue, with the host positioned on the LAST one
+  // (CVR_ID_2). CVR_ID_1 was Skipped earlier, so it's still unresolved.
+  // Accepting the last ballot must loop back to CVR_ID_1 rather than exit.
+  function bmdImages(cvrId: string): BallotImages {
+    const ballotCoordinates: Rect = { x: 0, y: 0, width: 1000, height: 1000 };
+    return {
+      cvrId,
+      front: { type: 'bmd', imageUrl: `mock-${cvrId}`, ballotCoordinates },
+      back: { type: 'bmd', imageUrl: `mock-${cvrId}`, ballotCoordinates },
+    };
+  }
+
+  const adjData1 = makeBallotAdjudicationData(
+    CVR_ID_1,
+    [makeContestAdjudicationData('zoo-council-mammal')],
+    { isResolved: true }
+  );
+  const adjData2 = makeBallotAdjudicationData(
+    CVR_ID_2,
+    [makeContestAdjudicationData('zoo-council-mammal')],
+    { isResolved: true }
+  );
+
+  apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2]);
+  // The bare "next ballot" query positions the host on the last ballot.
+  apiMock.apiClient.getNextCvrIdForBallotAdjudication
+    .expectOptionalRepeatedCallsWith()
+    .resolves(CVR_ID_2);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_2 }, adjData2);
+  apiMock.apiClient.getBallotImages
+    .expectRepeatedCallsWith({ cvrId: CVR_ID_2 })
+    .resolves(bmdImages(CVR_ID_2));
+  apiMock.apiClient.getBallotImages
+    .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves(bmdImages(CVR_ID_1));
+  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetSystemSettings();
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('Ballot 2 of 2');
+
+  // Accept the last ballot. Nothing comes after it, but CVR_ID_1 is still
+  // unresolved, so navigateAcceptNext re-queries without a cursor and loops
+  // back to CVR_ID_1 instead of exiting adjudication.
+  apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_2 });
+  apiMock.expectAdjudicateCvr({ cvrId: CVR_ID_2, contests: [] });
+  apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2]);
+  // After-current finds nothing; the wrap-around (bare) call returns CVR_ID_1.
+  apiMock.apiClient.getNextCvrIdForBallotAdjudication
+    .expectCallWith({ currentCvrId: CVR_ID_2 })
+    .resolves(null);
+  apiMock.apiClient.getNextCvrIdForBallotAdjudication
+    .expectOptionalRepeatedCallsWith()
+    .resolves(CVR_ID_1);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData1);
+
+  userEvent.click(screen.getByRole('button', { name: /Accept/ }));
+
+  await screen.findByText('Ballot 1 of 2');
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves();
 });
 
@@ -1031,17 +1049,15 @@ test('contest list shows correct status line captions', async () => {
     { adjudicatedContests: contestEntries.map((e) => e.adjudicated) }
   );
 
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
   apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings({
     ...DEFAULT_SYSTEM_SETTINGS,
     adminAdjudicationReasons: [AdjudicationReason.Undervote],
   });
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,
@@ -1104,15 +1120,13 @@ test('contest list suppresses undervote captions when not in system settings', a
     { adjudicatedContests: contestEntries.map((e) => e.adjudicated) }
   );
 
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
   apiMock.expectGetWriteInCandidates([]);
   // Default system settings — no AdjudicationReason.Undervote
   apiMock.expectGetSystemSettings();
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,
@@ -1308,10 +1322,9 @@ test('contest list shows correct option resolution bullets', async () => {
     }
   );
 
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
   apiMock.expectGetWriteInCandidates([
     {
@@ -1322,7 +1335,6 @@ test('contest list shows correct option resolution bullets', async () => {
     },
   ]);
   apiMock.expectGetSystemSettings();
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,
@@ -1377,18 +1389,16 @@ test('multi-station mode claims ballots on mount and releases on navigation', as
   const adjData2 = makeBallotAdjudicationData(CVR_ID_2, contestData);
 
   // Wrapper-level queries
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
 
   // Data loader queries for ballot 1
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData1);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData1);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
   apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings();
 
   // Initial mount claims CVR_ID_1
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,
@@ -1399,8 +1409,7 @@ test('multi-station mode claims ballots on mount and releases on navigation', as
 
   // Navigate to next — releases CVR_ID_1, claims CVR_ID_2
   apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_1 });
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_2 });
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_2 }, adjData2);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_2 }, adjData2);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_2 }, true);
 
   userEvent.click(screen.getByRole('button', { name: /Skip/ }));
@@ -1410,71 +1419,57 @@ test('multi-station mode claims ballots on mount and releases on navigation', as
     .resolves();
 });
 
-test('Skip jumps past claimed ballots; Back still steps onto them as read-only', async () => {
-  const CVR_ID_3 = 'cvr-id-3';
+test('Skip onto a ballot claimed by another machine shows read-only overlay and the claimed ballot ID', async () => {
+  // Use distinct 4-char prefixes so the "Ballot ID: XXXX" header can be
+  // distinguished between the two ballots.
+  const FIRST_CVR_ID = 'aaaa-first';
+  const CLAIMED_CVR_ID = 'bbbb-claimed';
   const contestData = [
     makeContestAdjudicationData(
       'zoo-council-mammal',
       makeContestTag({ hasWriteIn: true })
     ),
   ];
-  const adjData1 = makeBallotAdjudicationData(CVR_ID_1, contestData);
-  const adjData2 = makeBallotAdjudicationData(CVR_ID_2, contestData);
-  const adjData3 = makeBallotAdjudicationData(CVR_ID_3, contestData);
+  const adjData1 = makeBallotAdjudicationData(FIRST_CVR_ID, contestData);
 
-  // CVR_ID_2 is claimed by another machine; queue is [1, 2, 3].
-  apiMock.expectAdjudicationScreenQueries({ claimedCvrIds: [CVR_ID_2] });
-  apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2, CVR_ID_3]);
-  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
+  // CLAIMED_CVR_ID is claimed by another machine; queue is [first, claimed].
+  apiMock.expectGetBallotAdjudicationQueue([FIRST_CVR_ID, CLAIMED_CVR_ID]);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(FIRST_CVR_ID);
   apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings();
 
-  // Initial mount on CVR_ID_1.
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData1);
-  apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
+  // Initial mount on FIRST_CVR_ID.
+  apiMock.expectClaimAndLoadBallot({ cvrId: FIRST_CVR_ID }, adjData1);
+  apiMock.expectGetBallotImages({ cvrId: FIRST_CVR_ID }, true);
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,
     apiMock,
   });
 
-  await screen.findByText('Ballot 1 of 3');
-  // No Back button on the first ballot.
-  expect(screen.queryByRole('button', { name: /Back/ })).toBeNull();
+  await screen.findByText('Ballot 1 of 2');
+  await screen.findByText('Ballot ID: aaaa');
 
-  // Skip from CVR_ID_1 should jump past the claimed CVR_ID_2 to CVR_ID_3.
-  apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_1 });
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_3 });
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_3 }, adjData3);
-  apiMock.expectGetBallotImages({ cvrId: CVR_ID_3 }, true);
+  // Skip from FIRST_CVR_ID advances by one position to CLAIMED_CVR_ID which
+  // is held by another machine — the wrapper surfaces a `no-claim` error so
+  // the screen renders the "claimed by another machine" overlay. The header
+  // should still update to the claimed ballot's ID even though we never
+  // loaded its adjudication data.
+  apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: FIRST_CVR_ID });
+  apiMock.apiClient.claimAndLoadBallot
+    .expectCallWith({ cvrId: CLAIMED_CVR_ID })
+    .resolves(err({ type: 'no-claim' }));
+  apiMock.expectGetBallotImages({ cvrId: CLAIMED_CVR_ID }, true);
 
   userEvent.click(screen.getByRole('button', { name: /Skip/ }));
-  await screen.findByText('Ballot 3 of 3');
-
-  // Back from CVR_ID_3 lands on CVR_ID_2 — visible but read-only since another
-  // machine still holds the claim. Releases CVR_ID_3 but does not attempt to
-  // claim CVR_ID_2 (the claimedCvrIds set short-circuits the claim mutation).
-  apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_3 });
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_2 }, adjData2);
-  apiMock.expectGetBallotImages({ cvrId: CVR_ID_2 }, true);
-
-  userEvent.click(screen.getByRole('button', { name: /Back/ }));
-  await screen.findByText('Ballot 2 of 3');
+  await screen.findByText('Ballot 2 of 2');
   await screen.findByText(
     'This ballot is currently being adjudicated by another machine.'
   );
-
-  // Back again steps onto CVR_ID_1 and re-claims it (CVR_ID_2 was never
-  // claimed by this machine, so nothing to release).
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData1);
-
-  userEvent.click(screen.getByRole('button', { name: /Back/ }));
-  await screen.findByText('Ballot 1 of 3');
+  await screen.findByText('Ballot ID: bbbb');
 
   apiMock.apiClient.releaseBallotAdjudicationClaim
-    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .expectOptionalRepeatedCallsWith({ cvrId: FIRST_CVR_ID })
     .resolves();
 });
 
@@ -1559,10 +1554,9 @@ test('auto-resolves a write-in-only contest with no qualified candidates', async
     ),
   ]);
 
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves(makeHmpbBallotImages(CVR_ID_1));
@@ -1571,7 +1565,6 @@ test('auto-resolves a write-in-only contest with no qualified candidates', async
     .resolves(makeHmpbBallotImages(CVR_ID_2));
   apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings(QUALIFIED_SYSTEM_SETTINGS);
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,
@@ -1600,11 +1593,9 @@ test('auto-resolves a write-in-only contest with no qualified candidates', async
     cvrId: CVR_ID_1,
     contests: [expectedAdjudication],
   });
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2]);
-  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_2);
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_2 });
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_2 }, adjData2);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_2, CVR_ID_1);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_2 }, adjData2);
 
   userEvent.click(screen.getByRole('button', { name: /Accept/ }));
   await screen.findByText('Ballot 2 of 2');
@@ -1625,14 +1616,12 @@ test('auto-resolves contests flagged with hasUnmarkedWriteIn', async () => {
   addPendingWriteIns(contest, 3, [0]);
   const adjData = makeBallotAdjudicationData(CVR_ID_1, [contest]);
 
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
   apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings(QUALIFIED_SYSTEM_SETTINGS);
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,
@@ -1663,14 +1652,12 @@ test.each([
     addPendingWriteIns(contest, 3, [0]);
     const adjData = makeBallotAdjudicationData(CVR_ID_1, [contest]);
 
-    apiMock.expectAdjudicationScreenQueries();
     apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
     apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
-    apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+    apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
     apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
     apiMock.expectGetWriteInCandidates([]);
     apiMock.expectGetSystemSettings(QUALIFIED_SYSTEM_SETTINGS);
-    apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
 
     renderInAppContext(<BallotAdjudicationScreenWrapper />, {
       electionDefinition,
@@ -1695,16 +1682,14 @@ test('does not auto-resolve when qualified candidates exist for the contest', as
   addPendingWriteIns(contest, 3, [0]);
   const adjData = makeBallotAdjudicationData(CVR_ID_1, [contest]);
 
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
   apiMock.expectGetWriteInCandidates([
     { id: 'qual-1', name: 'Qualified Person', electionId: 'e', contestId },
   ]);
   apiMock.expectGetSystemSettings(QUALIFIED_SYSTEM_SETTINGS);
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,
@@ -1728,14 +1713,12 @@ test('does not auto-resolve when areWriteInCandidatesQualified is false', async 
   addPendingWriteIns(contest, 3, [0]);
   const adjData = makeBallotAdjudicationData(CVR_ID_1, [contest]);
 
-  apiMock.expectAdjudicationScreenQueries();
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
-  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
   apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings(); // qualified mode off (default)
-  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -1004,10 +1004,7 @@ test('accept on the last ballot wraps back to an earlier unresolved ballot', asy
   // The backend wraps around, so the single after-current lookup returns
   // CVR_ID_1 directly.
   apiMock.apiClient.getNextCvrIdForBallotAdjudication
-    .expectCallWith({ currentCvrId: CVR_ID_2 })
-    .resolves(CVR_ID_1);
-  apiMock.apiClient.getNextCvrIdForBallotAdjudication
-    .expectOptionalRepeatedCallsWith()
+    .expectCallWith({ afterCvrId: CVR_ID_2 })
     .resolves(CVR_ID_1);
   apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData1);
 

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -1478,6 +1478,27 @@ test('Skip jumps past claimed ballots; Back still steps onto them as read-only',
     .resolves();
 });
 
+test('shows an error with exit when the claim+load fails', async () => {
+  apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
+  // The claim+load fails with a non-"no-claim" error (e.g. the host backend
+  // errored), so there's no ballot data and no claimed-by-another overlay.
+  apiMock.apiClient.claimAndLoadBallot
+    .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves(err({ type: 'host-disconnect' }));
+  apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
+  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetSystemSettings();
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('Unable to load ballot. Please try again.');
+  screen.getByRole('button', { name: 'Exit' });
+});
+
 function makePendingWriteInRecord(
   contestId: string,
   optionId: string,

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -1001,10 +1001,11 @@ test('accept on the last ballot wraps back to an earlier unresolved ballot', asy
   apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_2 });
   apiMock.expectAdjudicateCvr({ cvrId: CVR_ID_2, contests: [] });
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2]);
-  // After-current finds nothing; the wrap-around (bare) call returns CVR_ID_1.
+  // The backend wraps around, so the single after-current lookup returns
+  // CVR_ID_1 directly.
   apiMock.apiClient.getNextCvrIdForBallotAdjudication
     .expectCallWith({ currentCvrId: CVR_ID_2 })
-    .resolves(null);
+    .resolves(CVR_ID_1);
   apiMock.apiClient.getNextCvrIdForBallotAdjudication
     .expectOptionalRepeatedCallsWith()
     .resolves(CVR_ID_1);

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -14,6 +14,7 @@ import { format } from '@votingworks/utils';
 import type {
   AdjudicatedContestOption,
   AdjudicatedCvrContest,
+  AdjudicationError,
   BallotAdjudicationData,
   BallotImages,
   ContestAdjudicationData,
@@ -23,15 +24,14 @@ import { useHistory } from 'react-router-dom';
 import { assert, assertDefined, deepEqual, find } from '@votingworks/basics';
 import {
   adjudicateCvr,
-  claimBallotForAdjudication,
-  getBallotAdjudicationData,
+  claimAndLoadBallot,
   getBallotAdjudicationQueue,
   getBallotImages,
-  getClaimedBallotCvrIds,
   getNextCvrIdForBallotAdjudication,
   getSystemSettings,
   getWriteInCandidates,
   releaseBallotAdjudicationClaim,
+  useApiClient,
 } from '../api';
 import { routerPaths } from '../router_paths';
 import {
@@ -175,13 +175,8 @@ function groupContestsBySide(
 export function BallotAdjudicationScreenWrapper(): JSX.Element {
   const ballotQueueQuery = getBallotAdjudicationQueue.useQuery();
   const nextCvrIdQuery = getNextCvrIdForBallotAdjudication.useQuery();
-  const claimedCvrIdsQuery = getClaimedBallotCvrIds.useQuery();
 
-  if (
-    !ballotQueueQuery.isSuccess ||
-    !nextCvrIdQuery.isSuccess ||
-    !claimedCvrIdsQuery.isSuccess
-  ) {
+  if (!ballotQueueQuery.isSuccess || !nextCvrIdQuery.isSuccess) {
     return (
       <Screen>
         <Main flexRow>
@@ -193,7 +188,6 @@ export function BallotAdjudicationScreenWrapper(): JSX.Element {
 
   const queue = ballotQueueQuery.data;
   const nextCvrId = nextCvrIdQuery.data;
-  const claimedCvrIds = new Set(claimedCvrIdsQuery.data);
   const initialQueueIndex = nextCvrId
     ? Math.max(0, queue.indexOf(nextCvrId))
     : 0;
@@ -202,7 +196,6 @@ export function BallotAdjudicationScreenWrapper(): JSX.Element {
     <HostBallotAdjudicationScreen
       queue={queue}
       initialQueueIndex={initialQueueIndex}
-      claimedCvrIds={claimedCvrIds}
     />
   );
 }
@@ -210,26 +203,32 @@ export function BallotAdjudicationScreenWrapper(): JSX.Element {
 function HostBallotAdjudicationScreen({
   queue,
   initialQueueIndex,
-  claimedCvrIds,
 }: {
   queue: Id[];
   initialQueueIndex: number;
-  claimedCvrIds: Set<Id>;
 }): JSX.Element {
   const history = useHistory();
   const [queueIndex, setQueueIndex] = useState(initialQueueIndex);
-  const [claimFailed, setClaimFailed] = useState(false);
+  const [claimError, setClaimError] = useState<AdjudicationError | null>(null);
   const [isClaimInFlight, setIsClaimInFlight] = useState(true);
+  const [ballotData, setBallotData] = useState<BallotAdjudicationData | null>(
+    null
+  );
   const currentCvrId = queue[queueIndex];
-  const { mutateAsync: claimBallotMutation } =
-    claimBallotForAdjudication.useMutation();
+  const apiClient = useApiClient();
+  const { mutateAsync: claimAndLoadMutation } =
+    claimAndLoadBallot.useMutation();
   const { mutateAsync: releaseClaimMutation } =
     releaseBallotAdjudicationClaim.useMutation();
   const claimedCvrIdRef = useRef<Id | null>(null);
 
+  // Release the previous claim (if any) and then claim+load the
+  // next ballot in a single round trip. Returns whether the claim succeeded
+  // and updates ballot data state on success. The previous ballot stays
+  // visible until the new data lands (we set ballotData only after success).
   async function claimAndRelease(nextCvrId?: Id): Promise<boolean> {
     const prevCvrId = claimedCvrIdRef.current;
-    if (prevCvrId) {
+    if (prevCvrId && prevCvrId !== nextCvrId) {
       claimedCvrIdRef.current = null;
       try {
         await releaseClaimMutation({ cvrId: prevCvrId });
@@ -237,27 +236,38 @@ function HostBallotAdjudicationScreen({
         // Best-effort release
       }
     }
-    if (nextCvrId && !claimedCvrIds.has(nextCvrId)) {
-      try {
-        const claimed = await claimBallotMutation({ cvrId: nextCvrId });
-        if (claimed) {
-          claimedCvrIdRef.current = nextCvrId;
-          return true;
-        }
-        return false;
-      } catch {
+    if (!nextCvrId) {
+      return true;
+    }
+    try {
+      const result = await claimAndLoadMutation({ cvrId: nextCvrId });
+      if (result.isErr()) {
+        // Drop the previous ballot's data so the claimed-by-another overlay
+        // never renders over stale contests/derived state.
+        setBallotData(null);
+        setClaimError(result.err());
         return false;
       }
+      const value = result.ok();
+      if (value) {
+        claimedCvrIdRef.current = value.cvrId;
+        setBallotData(value.data);
+        setClaimError(null);
+        return true;
+      }
+      // Host returned ok(undefined) — no ballot. Treat as a failed claim
+      // so the caller can navigate away.
+      return false;
+    } catch {
+      return false;
     }
-    return !nextCvrId;
   }
 
-  // Claim the initial ballot on mount, release on unmount
+  // Claim+load the initial ballot on mount, release on unmount
   useEffect(() => {
     if (currentCvrId) {
       claimAndRelease(currentCvrId)
-        .then((success) => setClaimFailed(!success))
-        .catch(() => setClaimFailed(true))
+        .catch(() => setClaimError({ type: 'no-claim' }))
         .finally(() => setIsClaimInFlight(false));
     } else {
       setIsClaimInFlight(false);
@@ -280,38 +290,57 @@ function HostBallotAdjudicationScreen({
     );
   }
 
-  function findNextUnclaimedIndex(fromIndex: number): number | undefined {
-    for (let i = fromIndex + 1; i < queue.length; i += 1) {
-      if (!claimedCvrIds.has(queue[i])) {
-        return i;
-      }
-    }
-    return undefined;
-  }
-
   async function navigateTo(nextIndex: number): Promise<void> {
     setIsClaimInFlight(true);
     try {
       const nextId = queue[nextIndex];
-      const success = await claimAndRelease(nextId);
-      setClaimFailed(!success);
+      await claimAndRelease(nextId);
       setQueueIndex(nextIndex);
     } finally {
       setIsClaimInFlight(false);
     }
   }
 
-  const nextUnclaimedIndex = findNextUnclaimedIndex(queueIndex);
+  const isLastInQueue = queueIndex >= queue.length - 1;
 
-  async function navigateNext(): Promise<void> {
+  // Skip moves forward by exactly one position in the queue, regardless of
+  // whether the next ballot is claimed by another machine. The user can use
+  // Skip to page through the queue without re-querying the backend.
+  async function navigateSkip(): Promise<void> {
     setIsClaimInFlight(true);
     try {
-      if (nextUnclaimedIndex === undefined) {
+      if (isLastInQueue) {
         await claimAndRelease();
         history.push(routerPaths.adjudication);
-      } else {
-        await navigateTo(nextUnclaimedIndex);
+        return;
       }
+      await navigateTo(queueIndex + 1);
+    } finally {
+      setIsClaimInFlight(false);
+    }
+  }
+
+  async function navigateAcceptNext(): Promise<void> {
+    setIsClaimInFlight(true);
+    try {
+      const nextCvrId =
+        (await apiClient.getNextCvrIdForBallotAdjudication({ currentCvrId })) ??
+        (await apiClient.getNextCvrIdForBallotAdjudication());
+      if (!nextCvrId) {
+        await claimAndRelease();
+        history.push(routerPaths.adjudication);
+        return;
+      }
+      const nextIndex = queue.indexOf(nextCvrId);
+      if (nextIndex < 0) {
+        // The next ballot is no longer in our cached queue (likely
+        // invalidated by mutations). Drop back to the adjudication landing
+        // so the queue refetches fresh.
+        await claimAndRelease();
+        history.push(routerPaths.adjudication);
+        return;
+      }
+      await navigateTo(nextIndex);
     } finally {
       setIsClaimInFlight(false);
     }
@@ -327,7 +356,10 @@ function HostBallotAdjudicationScreen({
     }
   }
 
-  const isClaimed = claimedCvrIds.has(currentCvrId) || claimFailed;
+  // The current ballot is held by another machine when our atomic claim+load
+  // came back `no-claim`. The host always claims before displaying, so this
+  // mutation result is the authoritative claim status for the shown ballot.
+  const isClaimed = claimError?.type === 'no-claim';
   const statusText = `Ballot ${format.count(queueIndex + 1)} of ${format.count(
     queue.length
   )}`;
@@ -335,12 +367,13 @@ function HostBallotAdjudicationScreen({
   return (
     <HostBallotAdjudicationScreenDataLoader
       cvrId={currentCvrId}
+      ballotData={ballotData}
       statusText={statusText}
       isClaimed={isClaimed}
       isClaimInFlight={isClaimInFlight}
-      isLastBallot={nextUnclaimedIndex === undefined}
-      onAcceptDone={navigateNext}
-      onSkip={navigateNext}
+      isLastBallot={isLastInQueue}
+      onAcceptDone={navigateAcceptNext}
+      onSkip={navigateSkip}
       onBack={queueIndex > 0 ? () => navigateTo(queueIndex - 1) : undefined}
       onExit={navigateExit}
     />
@@ -349,11 +382,14 @@ function HostBallotAdjudicationScreen({
 
 function HostBallotAdjudicationScreenDataLoader({
   cvrId,
+  ballotData,
   onExit,
   isClaimInFlight,
+  isClaimed,
   ...rest
 }: {
   cvrId: Id;
+  ballotData: BallotAdjudicationData | null;
   statusText: string;
   isClaimed: boolean;
   isClaimInFlight: boolean;
@@ -363,9 +399,6 @@ function HostBallotAdjudicationScreenDataLoader({
   onBack?: () => void;
   onExit: () => void;
 }): JSX.Element {
-  const adjudicationDataQuery = getBallotAdjudicationData.useQuery({
-    cvrId,
-  });
   const ballotImagesQuery = getBallotImages.useQuery({ cvrId });
   const writeInCandidatesQuery = getWriteInCandidates.useQuery();
   const systemSettingsQuery = getSystemSettings.useQuery();
@@ -384,11 +417,28 @@ function HostBallotAdjudicationScreenDataLoader({
     );
   }
 
+  // Claiming has settled (no longer in flight) but produced neither this
+  // machine's ballot data nor a claimed-by-another overlay — i.e. the
+  // claim+load request failed. Surface an error with a way out instead of
+  // spinning on Loading forever.
+  if (!isClaimInFlight && !isClaimed && !ballotData) {
+    return (
+      <Screen>
+        <Main centerChild>
+          <P>Unable to load ballot. Please try again.</P>
+          <Button onPress={onExit}>Exit</Button>
+        </Main>
+      </Screen>
+    );
+  }
+
+  // Still resolving: the initial claim is in flight, or the auxiliary queries
+  // (images / write-ins / settings) haven't landed yet.
   if (
-    !adjudicationDataQuery.isSuccess ||
     !ballotImagesQuery.isSuccess ||
     !writeInCandidatesQuery.isSuccess ||
-    !systemSettingsQuery.isSuccess
+    !systemSettingsQuery.isSuccess ||
+    (!isClaimed && !ballotData)
   ) {
     return (
       <Screen>
@@ -399,20 +449,26 @@ function HostBallotAdjudicationScreenDataLoader({
     );
   }
 
+  // For a ballot claimed elsewhere there is no real adjudication data; use an
+  // empty placeholder so the claimed overlay renders without carrying over the
+  // previous ballot's contests or derived state.
+  const adjudicationData: BallotAdjudicationData = ballotData ?? {
+    cvrId,
+    contests: [],
+    tag: { isBlankBallot: false },
+    isResolved: false,
+    adjudicatedContests: [],
+  };
+
   return (
     <BallotAdjudicationScreen
-      // Use the query's cvrId as key/prop so the screen unmounts/remounts
-      // with the new data coming in. With the prop as the key, the component
-      // unmounts when the key changes, but the ballot data hasn't yet loaded,
-      // so there is a render where the cvrId shown on the screen to the user
-      // doesn't match the ballot data (since we use keepPreviousData=true on
-      // the query to avoid the Loading screen from flickering in between each ballot)
-      key={adjudicationDataQuery.data.cvrId}
-      cvrId={adjudicationDataQuery.data.cvrId}
-      ballotAdjudicationData={adjudicationDataQuery.data}
+      key={cvrId}
+      cvrId={cvrId}
+      ballotAdjudicationData={adjudicationData}
       ballotImages={ballotImagesQuery.data}
       writeInCandidates={writeInCandidatesQuery.data}
       systemSettings={systemSettingsQuery.data}
+      isClaimed={isClaimed}
       isClaimInFlight={isClaimInFlight}
       onAccept={async (input) => {
         const result = await adjudicateCvrMutation(input);

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -267,7 +267,7 @@ function HostBallotAdjudicationScreen({
   useEffect(() => {
     if (currentCvrId) {
       claimAndRelease(currentCvrId)
-        .catch(() => setClaimError({ type: 'no-claim' }))
+        .catch(() => setClaimError({ type: 'claim-failed' }))
         .finally(() => setIsClaimInFlight(false));
     } else {
       setIsClaimInFlight(false);
@@ -349,9 +349,9 @@ function HostBallotAdjudicationScreen({
   }
 
   // The current ballot is held by another machine when our atomic claim+load
-  // came back `no-claim`. The host always claims before displaying, so this
+  // came back `claim-failed`. The host always claims before displaying, so this
   // mutation result is the authoritative claim status for the shown ballot.
-  const isClaimed = claimError?.type === 'no-claim';
+  const isClaimed = claimError?.type === 'claim-failed';
   const statusText = `Ballot ${format.count(queueIndex + 1)} of ${format.count(
     queue.length
   )}`;

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -242,10 +242,25 @@ function HostBallotAdjudicationScreen({
     try {
       const result = await claimAndLoadMutation({ cvrId: nextCvrId });
       if (result.isErr()) {
-        // Drop the previous ballot's data so the claimed-by-another overlay
-        // never renders over stale contests/derived state.
-        setBallotData(null);
-        setClaimError(result.err());
+        const error = result.err();
+        if (error.type === 'claim-failed') {
+          // Another station owns this ballot. Hand the renderer an empty
+          // placeholder so the claimed-by-another overlay draws cleanly,
+          // without carrying over the previous ballot's contests/derived
+          // state.
+          setBallotData({
+            cvrId: nextCvrId,
+            contests: [],
+            tag: { isBlankBallot: false },
+            isResolved: false,
+            adjudicatedContests: [],
+          });
+        } else {
+          // Non-recoverable error (e.g. host disconnect). Clear ballot data
+          // so the parent routes to the "Unable to load ballot" screen.
+          setBallotData(null);
+        }
+        setClaimError(error);
         return false;
       }
       const value = result.ok();
@@ -441,16 +456,7 @@ function HostBallotAdjudicationScreenDataLoader({
     );
   }
 
-  // For a ballot claimed elsewhere there is no real adjudication data; use an
-  // empty placeholder so the claimed overlay renders without carrying over the
-  // previous ballot's contests or derived state.
-  const adjudicationData: BallotAdjudicationData = ballotData ?? {
-    cvrId,
-    contests: [],
-    tag: { isBlankBallot: false },
-    isResolved: false,
-    adjudicatedContests: [],
-  };
+  const adjudicationData = assertDefined(ballotData);
 
   return (
     <BallotAdjudicationScreen

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -304,8 +304,7 @@ function HostBallotAdjudicationScreen({
   const isLastInQueue = queueIndex >= queue.length - 1;
 
   // Skip moves forward by exactly one position in the queue, regardless of
-  // whether the next ballot is claimed by another machine. The user can use
-  // Skip to page through the queue without re-querying the backend.
+  // whether the next ballot is claimed by another machine.
   async function navigateSkip(): Promise<void> {
     setIsClaimInFlight(true);
     try {
@@ -323,10 +322,8 @@ function HostBallotAdjudicationScreen({
   async function navigateAcceptNext(): Promise<void> {
     setIsClaimInFlight(true);
     try {
-      // The backend wraps around the end of the queue, so a single lookup
-      // returns the next ballot to adjudicate (or null when none remain).
       const nextCvrId = await apiClient.getNextCvrIdForBallotAdjudication({
-        currentCvrId,
+        afterCvrId: currentCvrId,
       });
       const nextIndex = nextCvrId ? queue.indexOf(nextCvrId) : -1;
       if (nextIndex < 0) {
@@ -457,6 +454,12 @@ function HostBallotAdjudicationScreenDataLoader({
 
   return (
     <BallotAdjudicationScreen
+      // Use the query's cvrId as key/prop so the screen unmounts/remounts
+      // with the new data coming in. With the prop as the key, the component
+      // unmounts when the key changes, but the ballot data hasn't yet loaded,
+      // so there is a render where the cvrId shown on the screen to the user
+      // doesn't match the ballot data (since we use keepPreviousData=true on
+      // the query to avoid the Loading screen from flickering in between each ballot)
       key={cvrId}
       cvrId={cvrId}
       ballotAdjudicationData={adjudicationData}

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -323,19 +323,14 @@ function HostBallotAdjudicationScreen({
   async function navigateAcceptNext(): Promise<void> {
     setIsClaimInFlight(true);
     try {
-      const nextCvrId =
-        (await apiClient.getNextCvrIdForBallotAdjudication({ currentCvrId })) ??
-        (await apiClient.getNextCvrIdForBallotAdjudication());
-      if (!nextCvrId) {
-        await claimAndRelease();
-        history.push(routerPaths.adjudication);
-        return;
-      }
-      const nextIndex = queue.indexOf(nextCvrId);
+      // The backend wraps around the end of the queue, so a single lookup
+      // returns the next ballot to adjudicate (or null when none remain).
+      const nextCvrId = await apiClient.getNextCvrIdForBallotAdjudication({
+        currentCvrId,
+      });
+      const nextIndex = nextCvrId ? queue.indexOf(nextCvrId) : -1;
       if (nextIndex < 0) {
-        // The next ballot is no longer in our cached queue (likely
-        // invalidated by mutations). Drop back to the adjudication landing
-        // so the queue refetches fresh.
+        // No ballot left, or the next one isn't in our cached queue drop back to the landing screen
         await claimAndRelease();
         history.push(routerPaths.adjudication);
         return;

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -394,17 +394,28 @@ export function createApiMock(
       apiClient.getBallotAdjudicationQueue.expectCallWith().resolves(cvrIds);
     },
 
-    expectGetBallotAdjudicationData(
+    expectClaimAndLoadBallot(
       input: { cvrId: Id },
       data: BallotAdjudicationData
     ) {
-      apiClient.getBallotAdjudicationData.expectCallWith(input).resolves(data);
+      apiClient.claimAndLoadBallot
+        .expectCallWith({ cvrId: input.cvrId })
+        .resolves(ok({ cvrId: input.cvrId, data }));
     },
 
-    expectGetNextCvrIdForBallotAdjudication(cvrId: Id | null) {
-      apiClient.getNextCvrIdForBallotAdjudication
-        .expectRepeatedCallsWith()
-        .resolves(cvrId);
+    expectGetNextCvrIdForBallotAdjudication(cvrId: Id | null, afterCvrId?: Id) {
+      if (afterCvrId !== undefined) {
+        apiClient.getNextCvrIdForBallotAdjudication
+          .expectCallWith({ currentCvrId: afterCvrId })
+          .resolves(cvrId);
+        apiClient.getNextCvrIdForBallotAdjudication
+          .expectOptionalRepeatedCallsWith()
+          .resolves(cvrId);
+      } else {
+        apiClient.getNextCvrIdForBallotAdjudication
+          .expectOptionalRepeatedCallsWith()
+          .resolves(cvrId);
+      }
     },
 
     expectGetCastVoteRecordVoteInfo(
@@ -832,31 +843,8 @@ export function createApiMock(
         .resolves(enabled);
     },
 
-    expectGetClaimedBallotCvrIds(cvrIds: Id[] = []): void {
-      apiClient.getClaimedBallotCvrIds
-        .expectRepeatedCallsWith()
-        .resolves(cvrIds);
-    },
-
-    expectClaimBallotForAdjudication(
-      input: { cvrId: Id },
-      result = true
-    ): void {
-      apiClient.claimBallotForAdjudication
-        .expectCallWith(input)
-        .resolves(result);
-    },
-
     expectReleaseBallotAdjudicationClaim(input: { cvrId: Id }): void {
       apiClient.releaseBallotAdjudicationClaim.expectCallWith(input).resolves();
-    },
-
-    expectAdjudicationScreenQueries({
-      claimedCvrIds = [],
-    }: {
-      claimedCvrIds?: Id[];
-    } = {}): void {
-      this.expectGetClaimedBallotCvrIds(claimedCvrIds);
     },
   };
 }

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -406,10 +406,7 @@ export function createApiMock(
     expectGetNextCvrIdForBallotAdjudication(cvrId: Id | null, afterCvrId?: Id) {
       if (afterCvrId !== undefined) {
         apiClient.getNextCvrIdForBallotAdjudication
-          .expectCallWith({ currentCvrId: afterCvrId })
-          .resolves(cvrId);
-        apiClient.getNextCvrIdForBallotAdjudication
-          .expectOptionalRepeatedCallsWith()
+          .expectCallWith({ afterCvrId })
           .resolves(cvrId);
       } else {
         apiClient.getNextCvrIdForBallotAdjudication

--- a/specs/0002-multi-station-adjudication.md
+++ b/specs/0002-multi-station-adjudication.md
@@ -256,14 +256,14 @@ by contest) and `onAdjudicateCvrContest` as props — no internal data fetching.
 
 **Client error handling:** Client proxy endpoints return
 `Result<T, AdjudicationError>` where `AdjudicationError` is
-`{ type: 'host-disconnect' } | { type: 'no-claim' }`. When the host connection
-is unavailable, the proxy returns `err({ type: 'host-disconnect' })`. When the
-peer API rejects a mutation because the machine has no active claim (e.g. host
-disabled adjudication and released all claims), the proxy passes through the
-peer's `err({ type: 'no-claim' })`. The frontend checks these Results and
-renders a typed error screen with a message and Exit button — "Disconnected from
-host." for disconnects, "This machine no longer has an active claim on this
-ballot." for no-claim errors.
+`{ type: 'host-disconnect' } | { type: 'claim-failed' }`. When the host
+connection is unavailable, the proxy returns `err({ type: 'host-disconnect' })`.
+When the peer API rejects a mutation because the machine has no active claim
+(e.g. host disabled adjudication and released all claims), the proxy passes
+through the peer's `err({ type: 'claim-failed' })`. The frontend checks these
+Results and renders a typed error screen with a message and Exit button —
+"Disconnected from host." for disconnects, "This machine no longer has an active
+claim on this ballot." for claim-failed errors.
 
 **Client disconnect logout:** `ClientStore.setConnection()` fires an
 `onDisconnect` callback when transitioning away from `OnlineConnectedToHost`.
@@ -348,8 +348,8 @@ instance (single SQLite DB, no sync needed):
   2. **Adjudication proxy endpoints** — transparent forwarding to the host's
      peer API via a `grout.Client<PeerApi>`. Returns
      `Result<T, AdjudicationError>` for all proxy endpoints, mapping connection
-     failures to `host-disconnect` and passing through `no-claim` errors from
-     the peer API.
+     failures to `host-disconnect` and passing through `claim-failed` errors
+     from the peer API.
 
 #### Machine Mode
 


### PR DESCRIPTION
## Overview
I was debugging a particular race condition where the host could load a ballot just after a client submits adjudications and resolve the "claim this ballot" query successfully but have stale ballot adjudication data from before the clients submission. While this particular issue could be resolved with a refetch interval on that query it highlights a bigger flaw in the design that the hosts "get claim" and "get data" queries are NOT coupled, so even though the client writes both of these things in the same transacation, the results from the two queries can be misaligned. I refactored the hosts and clients claiming logic so that it revovles around a "claimBallotAndLoadData" function that will return the ballot adjudication data only if a claim is successfully made (when multi station is disabled this is just always true). I also reworked the client and host navigation to be more in sync with one another and resolve a few edge cases in differences. The state of things is: 

Client - Skip/Accept both follow same logic to get next available to claim CVR from the queue. If we run out of available CVRs in the in-order queue we wrap back around to the front. If all ballots are adjudicated we exit out. We no longer have a loading state flash when navigating between ballots. Queue order include ballot style id in the group by so we will inherently stay on the same ballot style when possible without needing special logic for that like we had before. 
Host - Back/Skip navigate simply forward/back in the stable queue order. Accept will get the next available ballot for adjudication in the in-order queue, if there are none left we wrap back to the start of the queue, if there are none at all we exit adjudication. 

## Demo Video or Screenshot
https://github.com/user-attachments/assets/7a238dff-6579-4161-bad5-71fb4a55f1f5


## Testing Plan
Tested various edge cases of submitting adjudication on a client then quickly navigating to that ballot from the host, making sure claims are held and released properly, etc. Plan to do more extensive multi-machine testing through VxDev in parallel with / after review. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
