### PR TITLE
VxDesign: Inject auto-generated polling places for test decks

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -18,6 +18,7 @@ import {
   electionFamousNames2021Fixtures,
   electionOpenPrimaryFixtures,
   electionPrimaryPrecinctSplitsFixtures,
+  electionSimpleSinglePrecinctFixtures,
   makeTemporaryPath,
   readElectionTwoPartyPrimaryDefinition,
 } from '@votingworks/fixtures';
@@ -4318,79 +4319,96 @@ test.each([
   }
 );
 
-test('Consistency of ballot hash across exports', async () => {
-  const baseElectionDefinition =
-    electionFamousNames2021Fixtures.readElectionDefinition();
-  const { apiClient, workspace, fileStorageClient, auth0 } = await setupApp({
-    organizations,
-    jurisdictions,
-    users,
-  });
+test.each([
+  {
+    label: 'EDIT_POLLING_PLACES true (DEMO)',
+    jurisdiction: nonVxJurisdiction,
+    user: nonVxUser,
+    fixture: electionFamousNames2021Fixtures,
+  },
+  {
+    label: 'EDIT_POLLING_PLACES falsy (MS)',
+    jurisdiction: msJurisdiction,
+    user: anotherNonVxUser,
+    fixture: electionSimpleSinglePrecinctFixtures,
+  },
+])(
+  'Consistency of ballot hash across exports: $label',
+  async ({ jurisdiction, user, fixture }) => {
+    const baseElectionDefinition = fixture.readElectionDefinition();
+    const { apiClient, workspace, fileStorageClient, auth0 } = await setupApp({
+      organizations,
+      jurisdictions,
+      users,
+    });
 
-  auth0.setLoggedInUser(nonVxUser);
-  const electionId = (
-    await apiClient.loadElection({
-      newId: 'new-election-id',
-      jurisdictionId: nonVxJurisdiction.id,
-      upload: {
-        format: 'vxf',
-        electionFileContents: baseElectionDefinition.electionData,
-      },
-    })
-  ).unsafeUnwrap();
+    auth0.setLoggedInUser(user);
+    const electionId = (
+      await apiClient.loadElection({
+        newId: 'new-election-id',
+        jurisdictionId: jurisdiction.id,
+        upload: {
+          format: 'vxf',
+          electionFileContents: baseElectionDefinition.electionData,
+        },
+      })
+    ).unsafeUnwrap();
 
-  const testDecksFilePath = await exportTestDecks({
-    fileStorageClient,
-    apiClient,
-    electionId,
-    workspace,
-    electionSerializationFormat: 'vxf',
-  });
+    const testDecksFilePath = await exportTestDecks({
+      fileStorageClient,
+      apiClient,
+      electionId,
+      workspace,
+      electionSerializationFormat: 'vxf',
+    });
 
-  const exportMeta = await exportElectionPackage({
-    fileStorageClient,
-    apiClient,
-    electionId,
-    workspace,
-    electionSerializationFormat: 'vxf',
-    shouldExportAudio: false,
-    shouldExportSampleBallots: true,
-    shouldExportTestBallots: false,
-    numAuditIdBallots: undefined,
-  });
+    const exportMeta = await exportElectionPackage({
+      fileStorageClient,
+      apiClient,
+      electionId,
+      workspace,
+      electionSerializationFormat: 'vxf',
+      shouldExportAudio: false,
+      shouldExportSampleBallots: true,
+      shouldExportTestBallots: false,
+      numAuditIdBallots: undefined,
+    });
 
-  const electionPackageContents = getExportedFile({
-    storage: fileStorageClient,
-    jurisdictionId: nonVxJurisdiction.id,
-    url: exportMeta.electionPackageUrl,
-  });
+    const electionPackageContents = getExportedFile({
+      storage: fileStorageClient,
+      jurisdictionId: jurisdiction.id,
+      url: exportMeta.electionPackageUrl,
+    });
 
-  const { electionDefinition } = (
-    await readElectionPackageFromBuffer(electionPackageContents)
-  ).unsafeUnwrap().electionPackage;
+    const { electionDefinition } = (
+      await readElectionPackageFromBuffer(electionPackageContents)
+    ).unsafeUnwrap().electionPackage;
 
-  const electionPackageFileName = assertDefined(exportMeta.electionPackageUrl);
-  const electionPackageZipBallotHash = electionPackageFileName.match(
-    'election-package-(.*)-.*.zip'
-  )![1];
+    const electionPackageFileName = assertDefined(
+      exportMeta.electionPackageUrl
+    );
+    const electionPackageZipBallotHash = electionPackageFileName.match(
+      'election-package-(.*)-.*.zip'
+    )![1];
 
-  const ballotsFileName = assertDefined(exportMeta.officialBallotsUrl);
-  const ballotsZipBallotHash = ballotsFileName.match(
-    'official-ballots-(.*).zip'
-  )![1];
-  const testDecksBallotHash = testDecksFilePath.match(
-    'test-decks-(.*).zip'
-  )![1];
+    const ballotsFileName = assertDefined(exportMeta.officialBallotsUrl);
+    const ballotsZipBallotHash = ballotsFileName.match(
+      'official-ballots-(.*).zip'
+    )![1];
+    const testDecksBallotHash = testDecksFilePath.match(
+      'test-decks-(.*).zip'
+    )![1];
 
-  // Test decks only report the shortened formatted version
-  expect(formatBallotHash(electionDefinition.ballotHash)).toEqual(
-    testDecksBallotHash
-  );
-  expect(electionPackageZipBallotHash).toEqual(ballotsZipBallotHash);
-  expect(formatBallotHash(electionDefinition.ballotHash)).toEqual(
-    electionPackageZipBallotHash
-  );
-});
+    // Test decks only report the shortened formatted version
+    expect(formatBallotHash(electionDefinition.ballotHash)).toEqual(
+      testDecksBallotHash
+    );
+    expect(electionPackageZipBallotHash).toEqual(ballotsZipBallotHash);
+    expect(formatBallotHash(electionDefinition.ballotHash)).toEqual(
+      electionPackageZipBallotHash
+    );
+  }
+);
 
 test('Election package generation is deterministic', async () => {
   const baseElectionDefinition =

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -3,6 +3,7 @@ import {
   BaseBallotProps,
   Election,
   hasSplits,
+  pollingPlacesGenerateFromPrecincts,
   UiStringsPackage,
   YesNoContest,
 } from '@votingworks/types';
@@ -16,6 +17,7 @@ import {
 import { assert, find, throwIllegalValue } from '@votingworks/basics';
 import { sha256 } from 'js-sha256';
 import { ballotStyleHasPrecinctOrSplit } from '@votingworks/utils';
+import { getStateFeaturesConfig } from './features';
 import { Jurisdiction } from './types';
 
 export function defaultBallotTemplate(
@@ -35,6 +37,24 @@ export function defaultBallotTemplate(
       throwIllegalValue(jurisdiction.stateCode);
     }
   }
+}
+
+export function addPollingPlacesForExport(
+  election: Election,
+  jurisdiction: Jurisdiction
+): Election {
+  const stateFeatures = getStateFeaturesConfig(jurisdiction);
+  if (stateFeatures.EDIT_POLLING_PLACES) {
+    return election;
+  }
+  return {
+    ...election,
+    pollingPlaces: pollingPlacesGenerateFromPrecincts(
+      election.precincts,
+      'election_day',
+      (p) => `${p.id}-polling-place`
+    ),
+  };
 }
 
 export function formatElectionForExport(

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -14,8 +14,6 @@ import {
   ElectionSerializationFormatSchema,
   EncodedBallotEntry,
   BaseBallotProps,
-  Election,
-  pollingPlacesGenerateFromPrecincts,
 } from '@votingworks/types';
 import {
   hmpbStringsCatalog,
@@ -40,6 +38,7 @@ import { Readable } from 'node:stream';
 import { randomUUID as uuid } from 'node:crypto';
 import { EmitProgressFunction, WorkerContext } from './context';
 import {
+  addPollingPlacesForExport,
   createBallotPropsForTemplate,
   formatElectionForExport,
 } from '../ballots';
@@ -60,7 +59,6 @@ import {
 } from '../globals';
 import { Store } from '../store';
 import { rootDebug } from '../debug';
-import { getStateFeaturesConfig } from '../features';
 
 const debug = rootDebug.extend('export-qa');
 
@@ -266,17 +264,10 @@ export async function generateElectionPackageAndBallots(
   );
 
   const jurisdiction = await store.getJurisdiction(jurisdictionId);
-  const stateFeatures = getStateFeaturesConfig(jurisdiction);
-  const election: Election = stateFeatures.EDIT_POLLING_PLACES
-    ? electionRecord.election
-    : {
-        ...electionRecord.election,
-        pollingPlaces: pollingPlacesGenerateFromPrecincts(
-          electionRecord.election.precincts,
-          'election_day',
-          (p) => `${p.id}-polling-place`
-        ),
-      };
+  const election = addPollingPlacesForExport(
+    electionRecord.election,
+    jurisdiction
+  );
 
   const [appStrings, hmpbStrings, electionStrings] =
     await getAllStringsForElectionPackage(

--- a/apps/design/backend/src/worker/generate_test_decks.ts
+++ b/apps/design/backend/src/worker/generate_test_decks.ts
@@ -21,6 +21,7 @@ import z from 'zod/v4';
 import { generateTestDeckBallots, TestDeckBallot } from '@votingworks/utils';
 import { EmitProgressFunction, WorkerContext } from './context';
 import {
+  addPollingPlacesForExport,
   createBallotPropsForTemplate,
   formatElectionForExport,
 } from '../ballots';
@@ -47,13 +48,18 @@ export async function generateTestDecks(
   emitProgress: EmitProgressFunction
 ): Promise<void> {
   const { store } = workspace;
+  const electionRecord = await store.getElection(electionId);
   const {
-    election,
     ballotLanguageConfigs,
     ballotTemplateId,
     jurisdictionId,
     systemSettings,
-  } = await store.getElection(electionId);
+  } = electionRecord;
+  const jurisdiction = await store.getJurisdiction(jurisdictionId);
+  const election = addPollingPlacesForExport(
+    electionRecord.election,
+    jurisdiction
+  );
   const { compact } = await store.getBallotLayoutSettings(electionId);
 
   // Check if summary BMD ballots should be generated


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

We recently added logic to inject polling places into the exported election when the `EDIT_POLLING_PLACES` state feature flag is turned off. However, we didn't add the same logic to the test decks export code path, which means that the test decks would end up with a different ballot hash (so they can't be scanned). This PR fixes this by factoring out a helper function and calling it in both paths.

## Demo Video or Screenshot

N/A

## Testing Plan

Updated automated tests with regression test

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
