### PR TITLE
[Scan] Include configured polling place ID in CVR exports

### DIFF
--- a/apps/scan/backend/schema.sql
+++ b/apps/scan/backend/schema.sql
@@ -26,6 +26,7 @@ create table batches (
   started_at datetime default current_timestamp not null,
   ended_at datetime,
   ballot_casting_mode text,
+  polling_place_id text, -- [TODO] Make this required.
   error varchar(4000)
 );
 

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -14,6 +14,7 @@ import {
   AdjudicationReason,
   BallotMetadata,
   BallotType,
+  BatchInfo,
   InterpretedHmpbPage,
   mapSheet,
   PageInterpretationWithFiles,
@@ -337,6 +338,7 @@ test('get/set polls state', () => {
 
 test('getBatches', () => {
   const store = Store.memoryStore(mockBaseLogger({ fn: vi.fn }));
+  const { pollingPlace } = configureElectionNh(store);
 
   const batchId = store.addBatch();
 
@@ -376,20 +378,24 @@ test('getBatches', () => {
     ],
     isAccepted: false,
   });
+
   batches = store.getBatches();
-  expect(batches).toHaveLength(1);
-  expect(batches[0].count).toEqual(1);
+  expect(batches).toEqual<BatchInfo[]>([
+    {
+      batchNumber: 1,
+      count: 1,
+      id: batchId,
+      label: `Batch 1`,
+      startedAt: expect.any(String),
+      ballotCastingMode: 'election_day',
+      pollingPlaceId: pollingPlace.id,
+    },
+  ]);
 });
 
 test('iterating over sheets', () => {
   const store = Store.memoryStore(mockBaseLogger({ fn: vi.fn }));
-  store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition()
-        .electionData,
-    jurisdiction,
-    electionPackageHash,
-  });
+  configureElectionNh(store);
 
   expect(Array.from(store.forEachAcceptedSheet())).toEqual([]);
   expect(Array.from(store.forEachSheet())).toEqual([]);
@@ -485,6 +491,8 @@ test('iterating over sheets', () => {
 
 test('getSheet', () => {
   const store = Store.memoryStore(mockBaseLogger({ fn: vi.fn }));
+  configureElectionNh(store);
+
   const batchId = store.addBatch();
 
   // Accepted sheet
@@ -528,13 +536,8 @@ test('getSheet', () => {
 test('resetElectionSession', async () => {
   const dbFile = makeTemporaryFile();
   const store = Store.fileStore(dbFile, mockBaseLogger({ fn: vi.fn }));
-  store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition()
-        .electionData,
-    jurisdiction,
-    electionPackageHash,
-  });
+  configureElectionNh(store);
+
   const mockUsbDrive = createMockUsbDrive();
   mockUsbDrive.insertUsbDrive({});
   const mockUsbDriveStatus = await mockUsbDrive.usbDrive.status();
@@ -600,6 +603,7 @@ test('resetElectionSession', async () => {
 
 test('getBallotsCounted', () => {
   const store = Store.memoryStore(mockBaseLogger({ fn: vi.fn }));
+  configureElectionNh(store);
 
   expect(store.getBallotsCounted()).toEqual(0);
 
@@ -746,6 +750,7 @@ test(
 
 test('forEachSheetPendingContinuousExport', () => {
   const store = Store.memoryStore(mockBaseLogger({ fn: vi.fn }));
+  configureElectionNh(store);
 
   const batchId = store.addBatch();
 
@@ -873,3 +878,19 @@ test('getElectricalTestingStatusMessages and setElectricalTestingStatusMessage',
     },
   ]);
 });
+
+function configureElectionNh(store: Store) {
+  const fixtures = electionGridLayoutNewHampshireTestBallotFixtures;
+  const electionDefinition = fixtures.readElectionDefinition();
+  const { election, electionData } = electionDefinition;
+  const pollingPlace = assertDefined(election.pollingPlaces)[0];
+
+  store.setElectionAndJurisdiction({
+    electionData,
+    jurisdiction,
+    electionPackageHash,
+  });
+  store.setPollingPlaceId(pollingPlace.id);
+
+  return { electionDefinition, pollingPlace };
+}

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -620,16 +620,28 @@ export class Store {
     const id = uuid();
     const ballotCastingMode = this.getBallotCastingMode();
     const startedAt = new Date(getCurrentTime()).toISOString();
+    const pollingPlaceId = this.getPollingPlaceId() || null;
+
     this.client.run(
-      'insert into batches (id, started_at) values (?, ?)',
+      `
+        insert into batches (
+          id,
+          ballot_casting_mode,
+          polling_place_id,
+          started_at
+        ) values (?, ?, ?, ?)
+      `,
       id,
+      ballotCastingMode,
+      pollingPlaceId,
       startedAt
     );
+
     this.client.run(
-      `update batches set label = 'Batch ' || batch_number, ballot_casting_mode = ? WHERE id = ?`,
-      ballotCastingMode,
+      `update batches set label = 'Batch ' || batch_number WHERE id = ?`,
       id
     );
+
     return id;
   }
 
@@ -762,13 +774,16 @@ export class Store {
       endedAt: string | null;
       error: string | null;
       count: number;
+      pollingPlaceId: string | null;
     }
+
     const batchInfo = this.client.all(`
       select
         batches.id as id,
         batches.batch_number as batchNumber,
         batches.label as label,
         batches.ballot_casting_mode as ballotCastingMode,
+        batches.polling_place_id as pollingPlaceId,
         strftime('%s', started_at) as startedAt,
         (case when ended_at is null then ended_at else strftime('%s', ended_at) end) as endedAt,
         error,
@@ -787,19 +802,22 @@ export class Store {
       order by
         batches.started_at desc
     `) as SqliteBatchInfo[];
+
+    function isoDateFromSeconds(seconds: string) {
+      // eslint-disable-next-line vx/gts-safe-number-parse
+      return DateTime.fromSeconds(Number(seconds)).toISO();
+    }
+
     return batchInfo.map((info) => ({
       id: info.id,
       batchNumber: info.batchNumber,
       label: info.label,
       ballotCastingMode: info.ballotCastingMode,
-      // eslint-disable-next-line vx/gts-safe-number-parse
-      startedAt: DateTime.fromSeconds(Number(info.startedAt)).toISO(),
-      endedAt:
-        // eslint-disable-next-line vx/gts-safe-number-parse
-        (info.endedAt && DateTime.fromSeconds(Number(info.endedAt)).toISO()) ||
-        undefined,
+      startedAt: isoDateFromSeconds(info.startedAt),
+      endedAt: info.endedAt ? isoDateFromSeconds(info.endedAt) : undefined,
       error: info.error || undefined,
       count: info.count,
+      pollingPlaceId: info.pollingPlaceId || undefined,
     }));
   }
 

--- a/libs/backend/src/cast_vote_records/build_report_metadata.test.ts
+++ b/libs/backend/src/cast_vote_records/build_report_metadata.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, expect, test, vi } from 'vitest';
 import { assert, find, iter } from '@votingworks/basics';
 import { readElectionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
-import { CandidateContest, CVR, YesNoContest } from '@votingworks/types';
+import {
+  CandidateContest,
+  CastVoteRecordBatchMetadata,
+  CVR,
+  YesNoContest,
+} from '@votingworks/types';
 import {
   buildBatchManifest,
   buildCastVoteRecordReportMetadata,
@@ -253,7 +258,7 @@ test('still includes the generating device id in the device list if it is not th
 test('buildBatchManifest', () => {
   expect(
     buildBatchManifest({
-      batchInfo: [
+      batches: [
         {
           id: 'batch-1',
           batchNumber: 1,
@@ -261,17 +266,47 @@ test('buildBatchManifest', () => {
           startedAt: new Date(1989, 11, 13).toISOString(),
           endedAt: new Date(1989, 11, 14).toISOString(),
           count: 2,
-          scannerId,
+          ballotCastingMode: 'early_voting',
+          pollingPlaceId: 'polling-place-1',
         },
       ],
+      scannerId,
     })
-  ).toEqual([
+  ).toEqual<CastVoteRecordBatchMetadata[]>([
     {
       id: 'batch-1',
       label: 'Batch 1',
       batchNumber: 1,
       startTime: new Date(1989, 11, 13).toISOString(),
       endTime: new Date(1989, 11, 14).toISOString(),
+      sheetCount: 2,
+      scannerId,
+      ballotCastingMode: 'early_voting',
+      pollingPlaceId: 'polling-place-1',
+    },
+  ]);
+});
+
+test('buildBatchManifest - optional fields omitted', () => {
+  expect(
+    buildBatchManifest({
+      batches: [
+        {
+          id: 'batch-1',
+          batchNumber: 1,
+          label: 'Batch 1',
+          startedAt: new Date(1989, 11, 13).toISOString(),
+          count: 2,
+        },
+      ],
+      scannerId,
+    })
+  ).toEqual<CastVoteRecordBatchMetadata[]>([
+    {
+      id: 'batch-1',
+      label: 'Batch 1',
+      batchNumber: 1,
+      startTime: new Date(1989, 11, 13).toISOString(),
       sheetCount: 2,
       scannerId,
     },

--- a/libs/backend/src/cast_vote_records/build_report_metadata.ts
+++ b/libs/backend/src/cast_vote_records/build_report_metadata.ts
@@ -223,19 +223,19 @@ export function buildCastVoteRecordReportMetadata({
 /**
  * Build that batch manifest that is included in the cast vote record export metadata file.
  */
-export function buildBatchManifest({
-  batchInfo,
-}: {
-  batchInfo: Array<BatchInfo & { scannerId: string }>;
+export function buildBatchManifest(p: {
+  batches: BatchInfo[];
+  scannerId: string;
 }): CastVoteRecordBatchMetadata[] {
-  return batchInfo.map((batch) => ({
+  return p.batches.map((batch) => ({
     id: batch.id,
     label: batch.label,
     batchNumber: batch.batchNumber,
     startTime: batch.startedAt,
     endTime: batch.endedAt,
     sheetCount: batch.count,
-    scannerId: batch.scannerId,
+    scannerId: p.scannerId,
     ballotCastingMode: batch.ballotCastingMode,
+    pollingPlaceId: batch.pollingPlaceId,
   }));
 }

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -387,8 +387,8 @@ async function buildCastVoteRecord(
 /**
  * Exports the following for a single cast vote record:
  * - The cast vote record report (JSON)
- * - The front image (JPEG)
- * - The back image (JPEG)
+ * - The front image (PNG)
+ * - The back image (PNG)
  * - If an HMPB, the front interpretation layout (JSON)
  * - If an HMPB, the back interpretation layout (JSON)
  *
@@ -557,10 +557,8 @@ async function exportMetadataFileToUsbDrive(
       buildCastVoteRecordReportMetadata(exportContext),
     castVoteRecordRootHash,
     batchManifest: buildBatchManifest({
-      batchInfo: exportContext.scannerState.batches.map((batch) => ({
-        ...batch,
-        scannerId: VX_MACHINE_ID,
-      })),
+      batches: exportContext.scannerState.batches,
+      scannerId: VX_MACHINE_ID,
     }),
   };
   const metadataFileContents = JSON.stringify(metadata);

--- a/libs/fixture-generators/src/cli/generate-cvrs/main.ts
+++ b/libs/fixture-generators/src/cli/generate-cvrs/main.ts
@@ -201,16 +201,21 @@ export async function main(
   }
 
   const { election, ballotHash } = electionDefinition;
-  const batchInfo: Array<BatchInfo & { scannerId: string }> = scannerIds.map(
-    (scannerId) => ({
-      id: getBatchIdForScannerId(scannerId),
-      batchNumber: 1,
-      label: getBatchIdForScannerId(scannerId),
-      startedAt: new Date().toISOString(),
-      count: castVoteRecords.length / scannerIds.length,
-      scannerId,
-    })
-  );
+  const batchesByScannerId: Array<{
+    scannerId: string;
+    batches: BatchInfo[];
+  }> = scannerIds.map((scannerId) => ({
+    scannerId,
+    batches: [
+      {
+        id: getBatchIdForScannerId(scannerId),
+        batchNumber: 1,
+        label: getBatchIdForScannerId(scannerId),
+        startedAt: new Date().toISOString(),
+        count: castVoteRecords.length / scannerIds.length,
+      },
+    ],
+  }));
   const reportMetadata = buildCastVoteRecordReportMetadata({
     election,
     electionId: ballotHash,
@@ -218,7 +223,7 @@ export async function main(
     scannerIds,
     reportTypes: [CVR.ReportType.OriginatingDeviceExport],
     isTestMode: testMode,
-    batchInfo,
+    batchInfo: batchesByScannerId.flatMap(({ batches }) => batches),
   });
 
   // make the parent folder if it does not exist
@@ -308,7 +313,7 @@ export async function main(
     castVoteRecordReportMetadata: reportMetadata,
     castVoteRecordRootHash:
       await computeCastVoteRecordRootHashFromScratch(outputPath),
-    batchManifest: buildBatchManifest({ batchInfo }),
+    batchManifest: batchesByScannerId.flatMap((b) => buildBatchManifest(b)),
   };
   const metadataFileContents = JSON.stringify(castVoteRecordExportMetadata);
   await fs.writeFile(

--- a/libs/types/src/cast_vote_records.ts
+++ b/libs/types/src/cast_vote_records.ts
@@ -54,6 +54,7 @@ export interface CastVoteRecordBatchMetadata {
   readonly sheetCount: number;
   readonly scannerId: string;
   readonly ballotCastingMode?: BallotCastingMode;
+  readonly pollingPlaceId?: string;
 }
 
 export const CastVoteRecordBatchMetadataSchema: z.ZodSchema<CastVoteRecordBatchMetadata> =
@@ -66,6 +67,7 @@ export const CastVoteRecordBatchMetadataSchema: z.ZodSchema<CastVoteRecordBatchM
     sheetCount: z.number(),
     scannerId: z.string(),
     ballotCastingMode: z.enum(['early_voting', 'election_day']).optional(),
+    pollingPlaceId: z.string().optional(),
   });
 
 /**

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -1361,6 +1361,7 @@ export interface BatchInfo {
   error?: string;
   count: number;
   ballotCastingMode?: BallotCastingMode;
+  pollingPlaceId?: string;
 }
 
 export const BallotCastingModeSchema = z.enum(['early_voting', 'election_day']);
@@ -1375,6 +1376,7 @@ export const BatchInfoSchema: z.ZodSchema<BatchInfo> = z.object({
   error: z.optional(z.string()),
   count: z.number().nonnegative(),
   ballotCastingMode: z.optional(BallotCastingModeSchema),
+  pollingPlaceId: IdSchema.optional(),
 });
 
 export interface CompletedBallot {


### PR DESCRIPTION
## Overview

To support more detailed election progress reporting in VxAdmin, we're including the currently selected polling place ID in the CVR export.

Each individual CVR includes an associated precinct ID for the specific ballot style scanned. The polling place is assigned at a batch level instead, since it's set once when configuring the machine. A per-batch field also allows for flexibility with future planned combined exports from VxAdmin, which could theoretically include batches from multiple polling places.

Not yet adding polling places to the CVR fixtures, as initial usage will be for upcoming demos of the updated VxAdmin CVR upload/management flow. Will fill those in later, as part of the polling place dev feature flag cleanup pass.

## Demo Video or Screenshot

### Sample metadata.json in CVR export:
<img width="954" height="754" alt="cvr-polling-place" src="https://github.com/user-attachments/assets/b1ff3ebc-ed65-4401-a0be-8db89784fc4f" />

## Testing Plan
- Unit + manual

