### PR TITLE
VxAdmin: Crossover vote filter in ballot count report builder for open primaries

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -150,6 +150,7 @@ create table cvrs (
   has_undervote boolean not null,
   has_write_in boolean not null,
   has_marginal_mark boolean not null default false,
+  has_crossover_vote boolean not null,
   is_adjudicated boolean not null default false,
   created_at timestamp not null default current_timestamp,
   foreign key (election_id) references elections(id)

--- a/apps/admin/backend/src/reports/titles.test.ts
+++ b/apps/admin/backend/src/reports/titles.test.ts
@@ -198,6 +198,12 @@ test('generateTitleForReport', () => {
       },
       'Ballot Count Report • Ballots With Marginal Marks',
     ],
+    [
+      {
+        adjudicationFlags: ['hasCrossoverVote'],
+      },
+      'Ballot Count Report • Ballots With Crossover Votes',
+    ],
   ];
 
   for (const [filter, title] of ballotCountFilters) {

--- a/apps/admin/backend/src/reports/titles.ts
+++ b/apps/admin/backend/src/reports/titles.ts
@@ -136,6 +136,8 @@ export function generateTitleForReport({
           return 'Ballots With Write-Ins';
         case 'hasMarginalMark':
           return 'Ballots With Marginal Marks';
+        case 'hasCrossoverVote':
+          return 'Ballots With Crossover Votes';
         default: {
           /* istanbul ignore next */
           throwIllegalValue(adjudicationFlag);

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -1140,9 +1140,10 @@ export class Store implements BaseStore {
           has_overvote,
           has_undervote,
           has_write_in,
-          has_marginal_mark
+          has_marginal_mark,
+          has_crossover_vote
         ) values (
-          ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+          ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
         )
       `,
         cvrId,
@@ -1160,7 +1161,8 @@ export class Store implements BaseStore {
         asSqliteBool(adjudicationFlags.hasOvervote),
         asSqliteBool(adjudicationFlags.hasUndervote),
         asSqliteBool(adjudicationFlags.hasWriteIn),
-        asSqliteBool(adjudicationFlags.hasMarginalMark)
+        asSqliteBool(adjudicationFlags.hasMarginalMark),
+        asSqliteBool(adjudicationFlags.hasCrossoverVote)
       );
     }
 
@@ -1542,27 +1544,20 @@ export class Store implements BaseStore {
     }
 
     if (filter.adjudicationFlags) {
-      const { adjudicationFlags: flags } = filter;
-
-      if (flags.includes('isBlank')) {
-        whereParts.push('cvrs.is_blank = 1');
-      }
-
-      if (flags.includes('hasOvervote')) {
-        whereParts.push('cvrs.has_overvote = 1');
-      }
-
-      if (flags.includes('hasUndervote')) {
-        whereParts.push('cvrs.has_undervote = 1');
-      }
-
-      if (flags.includes('hasWriteIn')) {
-        whereParts.push('cvrs.has_write_in = 1');
-      }
-
-      if (flags.includes('hasMarginalMark')) {
-        whereParts.push('cvrs.has_marginal_mark = 1');
-      }
+      const flagToColumn: Record<Admin.CastVoteRecordAdjudicationFlag, string> =
+        {
+          isBlank: 'is_blank',
+          hasOvervote: 'has_overvote',
+          hasUndervote: 'has_undervote',
+          hasWriteIn: 'has_write_in',
+          hasMarginalMark: 'has_marginal_mark',
+          hasCrossoverVote: 'has_crossover_vote',
+        };
+      whereParts.push(
+        ...filter.adjudicationFlags.map(
+          (flag) => `cvrs.${flagToColumn[flag]} = 1`
+        )
+      );
     }
 
     return [whereParts, params];

--- a/apps/admin/backend/src/tabulation/card_counts.test.ts
+++ b/apps/admin/backend/src/tabulation/card_counts.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest';
 import { Buffer } from 'node:buffer';
 import {
+  electionOpenPrimaryFixtures,
   electionTwoPartyPrimaryFixtures,
   makeTemporaryDirectory,
 } from '@votingworks/fixtures';
@@ -710,4 +711,84 @@ test('tabulateFullCardCounts - blankBallots', () => {
       expect(cardCounts?.hmpb).toEqual([testCase.expectedHmpb]);
     }
   }
+});
+
+test('tabulateFullCardCounts - hasCrossoverVote filter (open primary)', () => {
+  const store = Store.memoryStore(makeTemporaryDirectory());
+  const { election, electionData } =
+    electionOpenPrimaryFixtures.readElectionDefinition();
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
+    electionPackageHash: 'test-election-package-hash',
+  });
+  store.setCurrentElectionId(electionId);
+
+  const cvrMetadata = {
+    ballotStyleGroupId: 'ballot-style-1' as BallotStyleGroupId,
+    batchId: 'batch-1',
+    scannerId: 'scanner-1',
+    precinctId: 'precinct-1',
+    votingMethod: 'precinct',
+    card: { type: 'bmd' },
+  } as const;
+
+  const mockCastVoteRecordFile: MockCastVoteRecordFile = [
+    {
+      ...cvrMetadata,
+      // Single-party Dem
+      votes: {
+        'governor-democratic': ['alice-jones'],
+        'circuit-court-judge': ['margaret-chen'],
+      },
+      multiplier: 3,
+    },
+    {
+      ...cvrMetadata,
+      // Single-party Rep
+      votes: {
+        'governor-republican': ['dave-wilson'],
+        'circuit-court-judge': ['margaret-chen'],
+      },
+      multiplier: 2,
+    },
+    {
+      ...cvrMetadata,
+      // Nonpartisan-only
+      votes: { 'circuit-court-judge': ['margaret-chen'] },
+      multiplier: 1,
+    },
+    {
+      ...cvrMetadata,
+      // Crossover
+      votes: {
+        'governor-democratic': ['alice-jones'],
+        'governor-republican': ['dave-wilson'],
+        'circuit-court-judge': ['margaret-chen'],
+      },
+      multiplier: 4,
+    },
+  ];
+  addMockCvrFileToStore({ electionId, mockCastVoteRecordFile, store });
+
+  const [crossoverCounts] = groupMapToGroupList(
+    tabulateFullCardCounts({
+      electionId,
+      election,
+      store,
+      filter: { adjudicationFlags: ['hasCrossoverVote'] },
+    })
+  );
+  expect(crossoverCounts?.bmd).toEqual([4]);
+
+  const [allCounts] = groupMapToGroupList(
+    tabulateFullCardCounts({
+      electionId,
+      election,
+      store,
+      filter: { adjudicationFlags: [] },
+    })
+  );
+  expect(allCounts?.bmd).toEqual([10]);
 });

--- a/apps/admin/backend/src/util/cast_vote_records.test.ts
+++ b/apps/admin/backend/src/util/cast_vote_records.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from 'vitest';
-import { electionTwoPartyPrimaryFixtures } from '@votingworks/fixtures';
+import {
+  electionOpenPrimaryFixtures,
+  electionTwoPartyPrimaryFixtures,
+} from '@votingworks/fixtures';
 import {
   AdjudicationReason,
   MarkThresholds,
@@ -53,6 +56,7 @@ test('blank ballot', () => {
     hasOvervote: false,
     hasWriteIn: false,
     hasMarginalMark: false,
+    hasCrossoverVote: false,
   });
 });
 
@@ -65,6 +69,7 @@ test('no status ballot', () => {
     hasOvervote: false,
     hasWriteIn: false,
     hasMarginalMark: false,
+    hasCrossoverVote: false,
   });
 });
 
@@ -81,6 +86,7 @@ test('undervote yes-no', () => {
     hasOvervote: false,
     hasWriteIn: false,
     hasMarginalMark: false,
+    hasCrossoverVote: false,
   });
 });
 
@@ -97,6 +103,7 @@ test('undervote candidate', () => {
     hasOvervote: false,
     hasWriteIn: false,
     hasMarginalMark: false,
+    hasCrossoverVote: false,
   });
 });
 
@@ -113,6 +120,7 @@ test('overvote yes-no', () => {
     hasOvervote: true,
     hasWriteIn: false,
     hasMarginalMark: false,
+    hasCrossoverVote: false,
   });
 });
 
@@ -131,6 +139,7 @@ test('overvote candidate', () => {
     hasOvervote: true,
     hasWriteIn: false,
     hasMarginalMark: false,
+    hasCrossoverVote: false,
   });
 });
 
@@ -149,6 +158,7 @@ test('write-in', () => {
     hasOvervote: false,
     hasWriteIn: true,
     hasMarginalMark: false,
+    hasCrossoverVote: false,
   });
 });
 
@@ -161,6 +171,7 @@ test('unmarked write-in sets hasWriteIn', () => {
     hasOvervote: false,
     hasWriteIn: true,
     hasMarginalMark: false,
+    hasCrossoverVote: false,
   });
 });
 
@@ -180,6 +191,7 @@ test('multiple flags', () => {
     hasOvervote: true,
     hasWriteIn: true,
     hasMarginalMark: false,
+    hasCrossoverVote: false,
   });
 });
 
@@ -198,6 +210,7 @@ test('marginal mark', () => {
     hasOvervote: false,
     hasWriteIn: false,
     hasMarginalMark: true,
+    hasCrossoverVote: false,
   });
 });
 
@@ -216,7 +229,35 @@ test('no marginal mark when scores are above definite', () => {
     hasOvervote: false,
     hasWriteIn: false,
     hasMarginalMark: false,
+    hasCrossoverVote: false,
   });
+});
+
+test('open primary - crossover vote', () => {
+  const openPrimaryElectionDefinition =
+    electionOpenPrimaryFixtures.readElectionDefinition();
+  expect(
+    getCastVoteRecordAdjudicationFlags(
+      openPrimaryElectionDefinition,
+      {
+        'governor-democratic': ['alice-jones'],
+        'governor-republican': ['dave-wilson'],
+        'circuit-court-judge': ['margaret-chen'],
+      },
+      0
+    ).hasCrossoverVote
+  ).toEqual(true);
+
+  expect(
+    getCastVoteRecordAdjudicationFlags(
+      openPrimaryElectionDefinition,
+      {
+        'governor-democratic': ['alice-jones'],
+        'circuit-court-judge': ['margaret-chen'],
+      },
+      0
+    ).hasCrossoverVote
+  ).toEqual(false);
 });
 
 const candidateContest = assertDefined(
@@ -313,6 +354,7 @@ const NO_FLAGS: CastVoteRecordAdjudicationFlags = {
   hasUndervote: false,
   hasWriteIn: false,
   hasMarginalMark: false,
+  hasCrossoverVote: false,
 };
 
 test('doesCvrNeedAdjudication - write-in always needs adjudication', () => {

--- a/apps/admin/backend/src/util/cast_vote_records.ts
+++ b/apps/admin/backend/src/util/cast_vote_records.ts
@@ -6,7 +6,7 @@ import {
   MarkThresholds,
   Tabulation,
 } from '@votingworks/types';
-import { CachedElectionLookups } from '@votingworks/utils';
+import { CachedElectionLookups, hasCrossoverVote } from '@votingworks/utils';
 import {
   CastVoteRecordAdjudicationFlags,
   CvrContestTag,
@@ -79,6 +79,7 @@ export function getCastVoteRecordAdjudicationFlags(
     hasOvervote,
     hasWriteIn,
     hasMarginalMark,
+    hasCrossoverVote: hasCrossoverVote(electionDefinition.election, votes),
   };
 }
 

--- a/apps/admin/frontend/src/components/reporting/filter_editor.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.test.tsx
@@ -258,9 +258,36 @@ test('adjudication status selection', () => {
   screen.getByText('Overvote');
   screen.getByText('Undervote');
   screen.getByText('Write-In');
+  expect(screen.queryByText('Crossover Vote')).toBeNull();
   userEvent.click(screen.getByText('Blank Ballot'));
   expect(onChange).toHaveBeenNthCalledWith(2, {
     adjudicationFlags: ['isBlank'],
+  });
+});
+
+test('adjudication status selection includes "Crossover Vote" in open primary', () => {
+  const { election } = readElectionOpenPrimaryDefinition();
+  const onChange = vi.fn();
+
+  apiMock.expectGetScannerBatches([]);
+  renderInAppContext(
+    <FilterEditor
+      election={election}
+      onChange={onChange}
+      allowedFilters={['adjudication-status']}
+    />,
+    {
+      apiMock,
+    }
+  );
+
+  userEvent.click(screen.getButton('Add Filter'));
+  userEvent.click(screen.getByLabelText('Select New Filter Type'));
+  userEvent.click(screen.getByText('Adjudication Status'));
+  userEvent.click(screen.getByLabelText('Select Filter Values'));
+  userEvent.click(screen.getByText('Crossover Vote'));
+  expect(onChange).toHaveBeenLastCalledWith({
+    adjudicationFlags: ['hasCrossoverVote'],
   });
 });
 

--- a/apps/admin/frontend/src/components/reporting/filter_editor.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.tsx
@@ -164,12 +164,14 @@ function generateOptionsForFilter({
         label: `Scanner ${sb.scannerId}, ${sb.label}`,
       }));
     case 'adjudication-status':
-      return Object.entries(Admin.ADJUDICATION_FLAG_LABELS).map(
-        ([value, label]) => ({
+      return Object.entries(Admin.ADJUDICATION_FLAG_LABELS)
+        .filter(
+          ([flag]) => isOpenPrimary(election) || flag !== 'hasCrossoverVote'
+        )
+        .map(([value, label]) => ({
           value,
           label,
-        })
-      );
+        }));
     case 'district':
       return getValidDistricts(election).map((district) => ({
         value: district.id,

--- a/apps/admin/frontend/src/utils/reporting.test.ts
+++ b/apps/admin/frontend/src/utils/reporting.test.ts
@@ -128,6 +128,14 @@ test('generateBallotCountReportPdfFilename', () => {
         'TEST-unofficial-write-in-ballot-count-report__2023-12-09_15-59-32.pdf',
     },
     {
+      filter: {
+        adjudicationFlags: ['hasCrossoverVote'],
+      },
+      isTestMode: true,
+      expectedFilename:
+        'TEST-unofficial-crossover-voted-ballot-count-report__2023-12-09_15-59-32.pdf',
+    },
+    {
       // No Party filter combined with two other dimensions: should be
       // treated as a 3-dimension custom filter, not under-counted as 2.
       filter: {

--- a/apps/admin/frontend/src/utils/reporting.ts
+++ b/apps/admin/frontend/src/utils/reporting.ts
@@ -197,6 +197,9 @@ function generateReportFilenameFilterPrefix({
       case 'hasMarginalMark':
         filterPrefixes.push(`marginal-mark`);
         break;
+      case 'hasCrossoverVote':
+        filterPrefixes.push('crossover-voted');
+        break;
       // istanbul ignore next
       default:
         throwIllegalValue(adjudicationFlag);

--- a/libs/types/src/admin/reporting.ts
+++ b/libs/types/src/admin/reporting.ts
@@ -7,6 +7,7 @@ export const ADJUDICATION_FLAGS = [
   'hasUndervote',
   'hasWriteIn',
   'hasMarginalMark',
+  'hasCrossoverVote',
 ] as const;
 
 export type CastVoteRecordAdjudicationFlag =
@@ -21,6 +22,7 @@ export const ADJUDICATION_FLAG_LABELS: Record<
   hasUndervote: 'Undervote',
   hasWriteIn: 'Write-In',
   hasMarginalMark: 'Marginal Mark',
+  hasCrossoverVote: 'Crossover Vote',
 };
 
 /**


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

<!-- Add a link to a GitHub issue here -->
Adds a "Crossover Vote" option to the adjudication status filter options in the ballot count report builder. Follows the existing pattern of setting a flag in the db on CVR import, then querying on that flag to filter the CVRs when reporting.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/5635b6a7-c0c0-4d2d-b38d-57d0c7ee0cf6


## Testing Plan
Updated automated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
