### PR TITLE
test(admin): suppress console errors

### DIFF
--- a/apps/admin/backend/src/app.manual_results.test.ts
+++ b/apps/admin/backend/src/app.manual_results.test.ts
@@ -8,6 +8,7 @@ import { BallotStyleGroupId, PrecinctId, Tabulation } from '@votingworks/types';
 import { buildManualResultsFixture } from '@votingworks/utils';
 import { assert } from '@votingworks/basics';
 import { LogEventId } from '@votingworks/logging';
+import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import {
   buildTestEnvironment,
   configureMachine,
@@ -508,19 +509,23 @@ test('manual results APIs reject reads/writes for open primary elections', async
   };
 
   // Writes that would create data: asserts.
-  await expect(
-    apiClient.setManualResults({
-      ...identifier,
-      manualResults: buildManualResultsFixture({
-        election: openPrimaryElectionDefinition.election,
-        ballotCount: 1,
-        contestResultsSummaries: {},
-      }),
-    })
-  ).rejects.toThrow();
+  await suppressingConsoleOutput(() =>
+    expect(
+      apiClient.setManualResults({
+        ...identifier,
+        manualResults: buildManualResultsFixture({
+          election: openPrimaryElectionDefinition.election,
+          ballotCount: 1,
+          contestResultsSummaries: {},
+        }),
+      })
+    ).rejects.toThrow()
+  );
 
   // getManualResults is used on the manual tallies form, which is hidden
-  await expect(apiClient.getManualResults(identifier)).rejects.toThrow();
+  await suppressingConsoleOutput(() =>
+    expect(apiClient.getManualResults(identifier)).rejects.toThrow()
+  );
   // getManualResultsMetadata is used in a few places to see if manual results
   // exist or not, so we leave that enabled.
   expect(await apiClient.getManualResultsMetadata()).toEqual([]);

--- a/apps/admin/backend/src/app.tally_report_csv.test.ts
+++ b/apps/admin/backend/src/app.tally_report_csv.test.ts
@@ -16,6 +16,7 @@ import { formatBallotHash, Tabulation } from '@votingworks/types';
 import { Client } from '@votingworks/grout';
 import { assertDefined, err, ok } from '@votingworks/basics';
 import { MockMultiUsbDrive } from '@votingworks/usb-drive';
+import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import { mockFileName, parseCsv } from '../test/csv';
 import {
   buildTestEnvironment,
@@ -297,21 +298,23 @@ test('rejects party filter or party grouping', async () => {
   mockElectionManagerAuth(auth, electionDefinition.election);
   mockUsbDrive.insertUsbDrive({});
 
-  await expect(
-    apiClient.exportTallyReportCsv({
-      filename: mockFileName(),
-      filter: { partyIds: ['0'] },
-      groupBy: {},
-    })
-  ).rejects.toThrow('Filter by party not supported in CSV export');
+  await suppressingConsoleOutput(async () => {
+    await expect(
+      apiClient.exportTallyReportCsv({
+        filename: mockFileName(),
+        filter: { partyIds: ['0'] },
+        groupBy: {},
+      })
+    ).rejects.toThrow('Filter by party not supported in CSV export');
 
-  await expect(
-    apiClient.exportTallyReportCsv({
-      filename: mockFileName(),
-      filter: {},
-      groupBy: { groupByParty: true },
-    })
-  ).rejects.toThrow('Group by party not supported in CSV export');
+    await expect(
+      apiClient.exportTallyReportCsv({
+        filename: mockFileName(),
+        filter: {},
+        groupBy: { groupByParty: true },
+      })
+    ).rejects.toThrow('Group by party not supported in CSV export');
+  });
 });
 
 test('incorporates wia and manual data (grouping by voting method)', async () => {

--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -116,8 +116,10 @@ test('setMachineMode throws when election is configured', async () => {
   const electionDefinition = readElectionGeneralDefinition();
   await configureMachine(apiClient, auth, electionDefinition);
 
-  await expect(apiClient.setMachineMode({ mode: 'client' })).rejects.toThrow(
-    'Cannot change machine mode while an election is configured.'
+  await suppressingConsoleOutput(() =>
+    expect(apiClient.setMachineMode({ mode: 'client' })).rejects.toThrow(
+      'Cannot change machine mode while an election is configured.'
+    )
   );
 });
 


### PR DESCRIPTION
## Overview
Some recently updated tests produce noisy error output for expected errors. This quiets them back down.

## Demo Video or Screenshot
```
stderr | src/app.tally_report_csv.test.ts > rejects party filter or party grouping
Error: Group by party not supported in CSV export
    at assert (/home/vx/code/vxsuite/libs/basics/build/assert.js:14:15)
    at exportTallyReportCsv (/home/vx/code/vxsuite/apps/admin/backend/src/app.ts:1135:7)
    at /home/vx/code/vxsuite/libs/grout/build/server.js:153:32
    at Layer.handle [as handle_request] (/home/vx/code/vxsuite/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/router/layer.js:95:5)
```

## Testing Plan
Verified locally that the noisy errors no longer appear in `apps/admin/backend`'s tests.