### PR TITLE
[VxAdmin] Do not connect machines for adjudication networking with different code versions

### DIFF
--- a/apps/admin/backend/src/client_app.test.ts
+++ b/apps/admin/backend/src/client_app.test.ts
@@ -200,6 +200,13 @@ test('getNetworkConnectionStatus returns current status from client store', asyn
   expect(await env.apiClient.getNetworkConnectionStatus()).toEqual({
     status: 'online-multiple-hosts-detected',
   });
+
+  env.workspace.clientStore.setConnection(
+    ClientConnectionStatus.OnlineIncompatibleHostVersion
+  );
+  expect(await env.apiClient.getNetworkConnectionStatus()).toEqual({
+    status: 'online-incompatible-host-version',
+  });
 });
 
 test('getCurrentElectionMetadata returns null when no cached data', async () => {

--- a/apps/admin/backend/src/client_app.ts
+++ b/apps/admin/backend/src/client_app.ts
@@ -55,7 +55,8 @@ export type NetworkConnectionStatus =
   | { status: 'offline' }
   | { status: 'online-waiting-for-host' }
   | { status: 'online-connected-to-host'; hostMachineId: string }
-  | { status: 'online-multiple-hosts-detected' };
+  | { status: 'online-multiple-hosts-detected' }
+  | { status: 'online-incompatible-host-version' };
 
 /**
  * Wraps a proxy call to the host, catching connection and network errors
@@ -202,6 +203,8 @@ function buildClientApi({
         }
         case ClientConnectionStatus.OnlineMultipleHostsDetected:
           return { status: 'online-multiple-hosts-detected' };
+        case ClientConnectionStatus.OnlineIncompatibleHostVersion:
+          return { status: 'online-incompatible-host-version' };
         default:
           /* istanbul ignore next - @preserve */
           throwIllegalValue(status);

--- a/apps/admin/backend/src/networking.test.ts
+++ b/apps/admin/backend/src/networking.test.ts
@@ -825,9 +825,56 @@ describe('startClientNetworking', () => {
 
     expect(mockClient.connectToHost).toHaveBeenCalledWith({
       machineId: '0002',
+      codeVersion: 'dev',
       status: Admin.ClientMachineStatus.OnlineLocked,
       authType: null,
     });
+  });
+
+  test('does not connect to a host running an incompatible code version', async () => {
+    vi.mocked(hasOnlineInterface).mockResolvedValue(true);
+    vi.mocked(AvahiService.discoverHttpServices).mockResolvedValue([
+      {
+        name: 'VxAdmin-HOST1',
+        host: 'host.local',
+        resolvedIp: '192.168.1.10',
+        port: '3002',
+      },
+    ]);
+    const mockClient = createMockPeerClient({
+      connectToHost: vi.fn().mockResolvedValue({
+        machineId: 'HOST1',
+        codeVersion: 'a-different-version',
+        isClientAdjudicationEnabled: true,
+      }),
+    });
+    vi.mocked(grout.createClient).mockReturnValue(mockClient);
+
+    const clientStore = createClientStore();
+    const testLogger = mockBaseLogger({ fn: vi.fn });
+    startClientNetworking({
+      machineId: '0002incompat',
+      clientStore,
+      auth: createMockAuth(),
+      logger: testLogger,
+    });
+    await advancePollingInterval();
+
+    expect(clientStore.getConnectionStatus()).toEqual(
+      ClientConnectionStatus.OnlineIncompatibleHostVersion
+    );
+    // The client must not treat itself as connected or enable adjudication.
+    expect(clientStore.getHostConnection()).toBeUndefined();
+    expect(clientStore.getIsClientAdjudicationEnabled()).toEqual(false);
+    expect(testLogger.log).toHaveBeenCalledWith(
+      expect.anything(),
+      'system',
+      expect.objectContaining({
+        newStatus: ClientConnectionStatus.OnlineIncompatibleHostVersion,
+        hostCodeVersion: 'a-different-version',
+        clientCodeVersion: 'dev',
+      })
+    );
   });
 
   test('sends active status and auth type when logged in', async () => {
@@ -861,6 +908,7 @@ describe('startClientNetworking', () => {
 
     expect(mockClient.connectToHost).toHaveBeenCalledWith({
       machineId: '0002b',
+      codeVersion: 'dev',
       status: Admin.ClientMachineStatus.Active,
       authType: 'election_manager',
     });

--- a/apps/admin/backend/src/networking.ts
+++ b/apps/admin/backend/src/networking.ts
@@ -17,6 +17,7 @@ import type { PeerApi } from './peer_app';
 import type { Store } from './store';
 import type { ClientStore, HostConnection } from './client_store';
 import { ClientConnectionStatus } from './types';
+import { getMachineConfig } from './machine_config';
 import { constructAuthMachineState } from './util/auth';
 import { rootDebug } from './util/debug';
 import {
@@ -193,6 +194,7 @@ export function startClientNetworking({
   auth: DippedSmartCardAuthApi;
   logger: BaseLogger;
 }): void {
+  const { codeVersion } = getMachineConfig();
   debug('Starting client networking for machine %s', machineId);
   logger.log(LogEventId.AdminNetworkStatus, 'system', {
     message: `Starting client networking for machine ${machineId}.`,
@@ -337,9 +339,33 @@ export function startClientNetworking({
           const { status, authType } = getClientMachineStatus(authStatus);
           const hostConfig = await apiClient.connectToHost({
             machineId,
+            codeVersion,
             status,
             authType,
           });
+          if (codeVersion !== hostConfig.codeVersion) {
+            debug(
+              'Host at %s runs incompatible code version %s (client is %s), refusing to connect',
+              hostAddress,
+              hostConfig.codeVersion,
+              codeVersion
+            );
+            logStatusTransition(
+              {
+                connectionStatus:
+                  ClientConnectionStatus.OnlineIncompatibleHostVersion,
+              },
+              {
+                hostMachineId: hostConfig.machineId,
+                hostCodeVersion: hostConfig.codeVersion,
+                clientCodeVersion: codeVersion,
+              }
+            );
+            clientStore.setConnection(
+              ClientConnectionStatus.OnlineIncompatibleHostVersion
+            );
+            return;
+          }
           logStatusTransition(
             {
               connectionStatus: ClientConnectionStatus.OnlineConnectedToHost,

--- a/apps/admin/backend/src/peer_app.test.ts
+++ b/apps/admin/backend/src/peer_app.test.ts
@@ -28,6 +28,7 @@ test('connectToHost registers client and returns host machine config with adjudi
   const { peerApiClient, workspace } = buildTestEnvironment();
   const result = await peerApiClient.connectToHost({
     machineId: 'client-001',
+    codeVersion: 'dev',
     status: Admin.ClientMachineStatus.OnlineLocked,
     authType: null,
   });
@@ -47,12 +48,36 @@ test('connectToHost registers client and returns host machine config with adjudi
   });
 });
 
+test('connectToHost rejects a client running an incompatible code version', async () => {
+  const { peerApiClient, workspace } = buildTestEnvironment();
+  workspace.store.setIsClientAdjudicationEnabled(true);
+
+  const result = await peerApiClient.connectToHost({
+    machineId: 'client-001',
+    codeVersion: 'an-incompatible-version',
+    status: Admin.ClientMachineStatus.Active,
+    authType: 'election_manager',
+  });
+
+  // Host reports its own version and never enables adjudication for an
+  // incompatible client.
+  expect(result).toEqual({
+    machineId: DEV_MACHINE_ID,
+    codeVersion: 'dev',
+    isClientAdjudicationEnabled: false,
+  });
+
+  // The incompatible client must not be registered as a connected machine.
+  expect(workspace.store.getMachines()).toHaveLength(0);
+});
+
 test('connectToHost persists status and authType and returns adjudication enabled', async () => {
   const { peerApiClient, workspace } = buildTestEnvironment();
 
   workspace.store.setIsClientAdjudicationEnabled(true);
   const result = await peerApiClient.connectToHost({
     machineId: 'client-001',
+    codeVersion: 'dev',
     status: Admin.ClientMachineStatus.Active,
     authType: 'election_manager',
   });
@@ -80,6 +105,7 @@ test("connectToHost releases the client's claims when it transitions to OnlineLo
   // Client logs in (Active) and claims a ballot.
   await peerApiClient.connectToHost({
     machineId: 'client-001',
+    codeVersion: 'dev',
     status: Admin.ClientMachineStatus.Active,
     authType: 'election_manager',
   });
@@ -90,6 +116,7 @@ test("connectToHost releases the client's claims when it transitions to OnlineLo
   // Client transitions to OnlineLocked (logout / session expiry).
   await peerApiClient.connectToHost({
     machineId: 'client-001',
+    codeVersion: 'dev',
     status: Admin.ClientMachineStatus.OnlineLocked,
     authType: null,
   });
@@ -112,6 +139,7 @@ test('connectToHost does not release claims when status stays Active or transiti
 
   await peerApiClient.connectToHost({
     machineId: 'client-001',
+    codeVersion: 'dev',
     status: Admin.ClientMachineStatus.Active,
     authType: 'election_manager',
   });
@@ -122,6 +150,7 @@ test('connectToHost does not release claims when status stays Active or transiti
   // Repeated heartbeats with the same Active status should not release.
   await peerApiClient.connectToHost({
     machineId: 'client-001',
+    codeVersion: 'dev',
     status: Admin.ClientMachineStatus.Active,
     authType: 'election_manager',
   });
@@ -133,6 +162,7 @@ test('connectToHost does not release claims when status stays Active or transiti
   // Active → Adjudicating must not release either.
   await peerApiClient.connectToHost({
     machineId: 'client-001',
+    codeVersion: 'dev',
     status: Admin.ClientMachineStatus.Adjudicating,
     authType: 'election_manager',
   });
@@ -148,6 +178,7 @@ test('connectToHost updates store when client status changes', async () => {
   // First call: new client
   await peerApiClient.connectToHost({
     machineId: 'client-002',
+    codeVersion: 'dev',
     status: Admin.ClientMachineStatus.OnlineLocked,
     authType: null,
   });
@@ -159,6 +190,7 @@ test('connectToHost updates store when client status changes', async () => {
   // Second call: status changes
   await peerApiClient.connectToHost({
     machineId: 'client-002',
+    codeVersion: 'dev',
     status: Admin.ClientMachineStatus.Active,
     authType: 'election_manager',
   });

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -52,9 +52,22 @@ function buildPeerApi({ workspace, logger }: PeerAppContext) {
   return grout.createApi({
     connectToHost(input: {
       machineId: string;
+      codeVersion: string;
       status: Admin.ClientMachineStatus;
       authType: UserRole | null;
     }): MachineConfig & { isClientAdjudicationEnabled: boolean } {
+      const machineConfig = getMachineConfig();
+      // Refuse to register a client running a different code version.
+      if (input.codeVersion !== machineConfig.codeVersion) {
+        logger.log(LogEventId.AdminNetworkStatus, 'system', {
+          message: `Rejected connection from client ${input.machineId}: incompatible software version (client ${input.codeVersion}, host ${machineConfig.codeVersion}).`,
+          disposition: 'failure',
+          clientMachineId: input.machineId,
+          clientCodeVersion: input.codeVersion,
+          hostCodeVersion: machineConfig.codeVersion,
+        });
+        return { ...machineConfig, isClientAdjudicationEnabled: false };
+      }
       debug(
         'Client %s connected to host (election: %s, status: %s)',
         input.machineId,
@@ -99,7 +112,7 @@ function buildPeerApi({ workspace, logger }: PeerAppContext) {
         input.authType
       );
       return {
-        ...getMachineConfig(),
+        ...machineConfig,
         isClientAdjudicationEnabled: store.getIsClientAdjudicationEnabled(),
       };
     },

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -46,6 +46,7 @@ export enum ClientConnectionStatus {
   OnlineWaitingForHost = 'online-waiting-for-host',
   OnlineConnectedToHost = 'online-connected-to-host',
   OnlineMultipleHostsDetected = 'online-multiple-hosts-detected',
+  OnlineIncompatibleHostVersion = 'online-incompatible-host-version',
 }
 
 /** A record of a machine in the multi-station machines table. */

--- a/apps/admin/frontend/src/client/screens/client_settings_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_settings_screen.test.tsx
@@ -122,6 +122,16 @@ test('shows multiple hosts detected warning', async () => {
   await screen.findByText(/Multiple hosts detected/);
 });
 
+test('shows incompatible host version warning', async () => {
+  apiMock.expectGetUsbPortStatus();
+  apiMock.expectGetNetworkConnectionStatus('online-incompatible-host-version');
+  renderInClientContext(<ClientSettingsScreen />, {
+    auth: sysAdminAuth,
+    apiMock,
+  });
+  await screen.findByText(/incompatible software version/);
+});
+
 test('shows restart screen after switching to host mode', async () => {
   apiMock.expectGetUsbPortStatus();
   apiMock.expectGetNetworkConnectionStatus('online-connected-to-host');

--- a/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
@@ -56,6 +56,14 @@ function NetworkStatusSection(): JSX.Element {
             </span>
           )}
         {networkStatusQuery.isSuccess &&
+          networkStatusQuery.data.status ===
+            'online-incompatible-host-version' && (
+            <span>
+              <Icons.Danger color="danger" /> Host machine with incompatible
+              software version detected.
+            </span>
+          )}
+        {networkStatusQuery.isSuccess &&
           networkStatusQuery.data.status === 'offline' && (
             <span>
               <Icons.Danger color="danger" /> Offline — no network connection

--- a/apps/admin/frontend/test/helpers/mock_client_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_client_api_client.ts
@@ -96,7 +96,8 @@ export function createClientApiMock(
         | 'offline'
         | 'online-waiting-for-host'
         | 'online-connected-to-host'
-        | 'online-multiple-hosts-detected',
+        | 'online-multiple-hosts-detected'
+        | 'online-incompatible-host-version',
       hostMachineId?: string
     ): void {
       const value =


### PR DESCRIPTION
## Overview
Similar to pollbook, adds a check for mismatched code versions when connecting clients to hosts. The client will show an error/warning if the host is a different code version, the host will log and ignore misversioned clients. 

## Demo Video or Screenshot
<img width="1505" height="968" alt="Screenshot 2026-05-28 at 7 37 07 AM" src="https://github.com/user-attachments/assets/1ffd3f16-e834-4641-8128-0adbddf4a4ef" />


## Testing Plan
Ran tests, manually changed code version on one machine and tested manually that the host logged the rejection and the client showed an error. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
