### PR TITLE
[VxAdmin] Change "Power Down" to "Restart" after changing machine mode

### DIFF
--- a/apps/admin/frontend/src/client/screens/client_settings_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_settings_screen.test.tsx
@@ -137,5 +137,5 @@ test('shows restart screen after switching to host mode', async () => {
   await screen.findByText(
     'Machine mode changed, restart the machine to continue.'
   );
-  screen.getByRole('button', { name: 'Power Down' });
+  screen.getByRole('button', { name: 'Restart' });
 });

--- a/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
@@ -80,7 +80,7 @@ export function ClientSettingsScreen(): JSX.Element | null {
       <Screen>
         <Main centerChild>
           <FullScreenMessage title="Machine mode changed, restart the machine to continue.">
-            <P>
+            <P align="center">
               <Button
                 onPress={
                   /* istanbul ignore next - no-op in tests @preserve */

--- a/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
@@ -73,7 +73,7 @@ export function ClientSettingsScreen(): JSX.Element | null {
   const logOutMutation = logOut.useMutation();
   const formatUsbDriveMutation = formatUsbDrive.useMutation();
   const setMachineModeMutation = setMachineMode.useMutation();
-  const powerDownMutation = useSystemCallApi().powerDown.useMutation();
+  const rebootMutation = useSystemCallApi().reboot.useMutation();
 
   if (setMachineModeMutation.isSuccess) {
     return (
@@ -84,10 +84,10 @@ export function ClientSettingsScreen(): JSX.Element | null {
               <Button
                 onPress={
                   /* istanbul ignore next - no-op in tests @preserve */
-                  () => powerDownMutation.mutate()
+                  () => rebootMutation.mutate()
                 }
               >
-                Power Down
+                Restart
               </Button>
             </P>
           </FullScreenMessage>

--- a/apps/admin/frontend/src/screens/settings_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.test.tsx
@@ -179,7 +179,7 @@ describe('multi-station mode', () => {
     await screen.findByText(
       'Machine mode changed, restart the machine to continue.'
     );
-    screen.getByRole('button', { name: 'Power Down' });
+    screen.getByRole('button', { name: 'Restart' });
   });
 });
 

--- a/apps/admin/frontend/src/screens/settings_screen.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.tsx
@@ -45,7 +45,7 @@ export function SettingsScreen(): JSX.Element | null {
       <Screen>
         <Main centerChild>
           <FullScreenMessage title="Machine mode changed, restart the machine to continue.">
-            <P>
+            <P align="center">
               <Button
                 onPress={
                   /* istanbul ignore next - no-op in tests @preserve */

--- a/apps/admin/frontend/src/screens/settings_screen.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.tsx
@@ -35,7 +35,7 @@ export function SettingsScreen(): JSX.Element | null {
   const setMachineModeMutation = setMachineMode.useMutation();
   const isMultiStationEnabled =
     isMultiStationAdjudicationEnabled.useQuery().data ?? false;
-  const powerDownMutation = useSystemCallApi().powerDown.useMutation();
+  const rebootMutation = useSystemCallApi().reboot.useMutation();
   const networkStatusQuery = getNetworkStatus.useQuery({
     enabled: isMultiStationEnabled,
   });
@@ -49,10 +49,10 @@ export function SettingsScreen(): JSX.Element | null {
               <Button
                 onPress={
                   /* istanbul ignore next - no-op in tests @preserve */
-                  () => powerDownMutation.mutate()
+                  () => rebootMutation.mutate()
                 }
               >
-                Power Down
+                Restart
               </Button>
             </P>
           </FullScreenMessage>

--- a/libs/backend/src/system_call/api.test.ts
+++ b/libs/backend/src/system_call/api.test.ts
@@ -149,6 +149,21 @@ test('powerDown', async () => {
   ]);
 });
 
+test('reboot', async () => {
+  await api.reboot();
+  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+    LogEventId.RebootMachine,
+    {
+      message: 'User rebooted the machine.',
+    }
+  );
+  expect(execFile).toHaveBeenCalledWith('sudo', [
+    expect.stringMatching(
+      new RegExp('^/.*/libs/backend/intermediate-scripts/reboot$')
+    ),
+  ]);
+});
+
 test('setClock', async () => {
   await api.setClock({
     isoDatetime: '2020-11-03T15:00Z',

--- a/libs/backend/src/system_call/api.ts
+++ b/libs/backend/src/system_call/api.ts
@@ -4,6 +4,7 @@ import { getLowDiskSpaceWarningMessage } from '@votingworks/utils';
 
 import { GetAuthStatus } from './auth';
 import { exportLogsToUsb } from './export_logs_to_usb';
+import { reboot } from './reboot';
 import { rebootToVendorMenu } from './reboot_to_vendor_menu';
 import { powerDown } from './power_down';
 import { setClock } from './set_clock';
@@ -41,6 +42,7 @@ function buildApi({
         machineId,
         codeVersion,
       }),
+    reboot: async () => reboot(logger),
     rebootToVendorMenu: async () =>
       rebootToVendorMenu({ getAuthStatus, logger }),
     powerDown: async () => powerDown(logger),

--- a/libs/backend/src/system_call/reboot.ts
+++ b/libs/backend/src/system_call/reboot.ts
@@ -1,0 +1,14 @@
+import { LogEventId, Logger } from '@votingworks/logging';
+import { execFile } from '../exec';
+import { intermediateScript } from '../intermediate_scripts';
+
+/**
+ * Reboots the machine.
+ */
+export async function reboot(logger: Logger): Promise<void> {
+  await logger.logAsCurrentRole(LogEventId.RebootMachine, {
+    message: 'User rebooted the machine.',
+  });
+
+  void execFile('sudo', [intermediateScript('reboot')]);
+}

--- a/libs/ui/src/system_call_api.test.tsx
+++ b/libs/ui/src/system_call_api.test.tsx
@@ -24,6 +24,7 @@ function QueryWrapper(props: { children: React.ReactNode }) {
 }
 
 const mockApiClient: Mocked<SystemCallApiClient> = {
+  reboot: vi.fn(),
   rebootToVendorMenu: vi.fn(),
   powerDown: vi.fn(),
   setClock: vi.fn(),
@@ -48,6 +49,15 @@ describe('React Query API calls the right client methods', () => {
     mockApiClient.powerDown.mockResolvedValueOnce(undefined);
     await mutation.current.mutateAsync();
     expect(mockApiClient.powerDown).toHaveBeenCalledTimes(1);
+  });
+
+  test('reboot', async () => {
+    const { result: mutation } = renderHook(() => api.reboot.useMutation(), {
+      wrapper: QueryWrapper,
+    });
+    mockApiClient.reboot.mockResolvedValueOnce(undefined);
+    await mutation.current.mutateAsync();
+    expect(mockApiClient.reboot).toHaveBeenCalledTimes(1);
   });
 
   test('setClock', async () => {

--- a/libs/ui/src/system_call_api.tsx
+++ b/libs/ui/src/system_call_api.tsx
@@ -34,6 +34,12 @@ function createReactQueryApi(getApiClient: () => SystemCallApiClient) {
         return useMutation(async(apiClient.powerDown));
       },
     },
+    reboot: {
+      useMutation: () => {
+        const apiClient = getApiClient();
+        return useMutation(async(apiClient.reboot));
+      },
+    },
     setClock: {
       useMutation: () => {
         const apiClient = getApiClient();

--- a/libs/ui/test/test_context.tsx
+++ b/libs/ui/test/test_context.tsx
@@ -87,6 +87,7 @@ export function newTestContext(
   mockUiStringsApiClient.getAudioClips.mockResolvedValue([]);
 
   const mockSystemCallApiClient: Mocked<SystemCallApiClient> = {
+    reboot: vi.fn(),
     rebootToVendorMenu: vi.fn(),
     powerDown: vi.fn(),
     setClock: vi.fn(),


### PR DESCRIPTION
## Overview
Updates the power down button to "restart" after changing a machine mode, this was just a shortcut I took previously. The only place we restart in vxsuite today is to the vendor menu so this involved wiring up restart to the shared system call api. Probably from some point in the past when we had restart the intermediate script and some of the code in libs/backend was already there. 

Open to suggestion on the copy


## Demo Video or Screenshot
<img width="1920" height="1080" alt="Screenshot 2026-05-28 at 9 47 21 AM" src="https://github.com/user-attachments/assets/956df54e-5916-4d40-9cc4-fa65bae4a288" />


## Testing Plan
Changed mode, clicked restart, observed machine restarting. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
