### PR TITLE
VxAdmin: Don't consider auto write-in invalidations as user adjudications when displaying discard changes modal

### DIFF
--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -1592,6 +1592,57 @@ test('auto-resolves a write-in-only contest with no qualified candidates', async
     .resolves();
 });
 
+test('auto-resolved write-in does not trigger discard modal', async () => {
+  const contestId = 'zoo-council-mammal';
+  const contest = makeContestAdjudicationData(
+    contestId,
+    makeContestTag({ hasWriteIn: true })
+  );
+  addPendingWriteIns(contest, 3, [0]);
+  const adjData1 = makeBallotAdjudicationData(CVR_ID_1, [contest]);
+  const adjData2 = makeBallotAdjudicationData(CVR_ID_2, [
+    makeContestAdjudicationData(
+      contestId,
+      makeContestTag({ hasOvervote: true })
+    ),
+  ]);
+
+  apiMock.expectAdjudicationScreenQueries();
+  apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2]);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
+  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_1 }, adjData1);
+  apiMock.apiClient.getBallotImages
+    .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves(makeHmpbBallotImages(CVR_ID_1));
+  apiMock.apiClient.getBallotImages
+    .expectRepeatedCallsWith({ cvrId: CVR_ID_2 })
+    .resolves(makeHmpbBallotImages(CVR_ID_2));
+  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetSystemSettings(QUALIFIED_SYSTEM_SETTINGS);
+  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_1 });
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /Accept/ })).toBeEnabled();
+  });
+
+  apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_1 });
+  apiMock.expectClaimBallotForAdjudication({ cvrId: CVR_ID_2 });
+  apiMock.expectGetBallotAdjudicationData({ cvrId: CVR_ID_2 }, adjData2);
+
+  userEvent.click(screen.getByRole('button', { name: /Skip/ }));
+  await screen.findByText('Ballot 2 of 2');
+  expect(screen.queryByText('Unsaved Changes')).toBeNull();
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_2 })
+    .resolves();
+});
+
 test('auto-resolves contests flagged with hasUnmarkedWriteIn', async () => {
   const contestId = 'zoo-council-mammal';
   const contest = makeContestAdjudicationData(

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -493,13 +493,14 @@ export function BallotAdjudicationScreen({
     action: () => void;
   } | null>(null);
 
-  // Initialize adjudicatedContestsBaseline from persisted adjudications.
+  // Derives the baseline adjudication state from persisted adjudications.
   // In qualified-write-in mode, auto-resolve contests whose only adjudication
   // reason is write-ins when the contest has no qualified candidates: every
-  // write-in must be invalid, so the user has nothing to decide
-  const [adjudicatedContestsBaseline] = useState<
-    Map<ContestId, AdjudicatedCvrContest>
-  >(() => {
+  // write-in must be invalid, so the user has nothing to decide.
+  function adjudicatedContestsBaseline(): Map<
+    ContestId,
+    AdjudicatedCvrContest
+  > {
     const baseline = new Map<ContestId, AdjudicatedCvrContest>(
       ballotAdjudicationData.adjudicatedContests.map((c) => [c.contestId, c])
     );
@@ -543,7 +544,7 @@ export function BallotAdjudicationScreen({
       });
     }
     return baseline;
-  });
+  }
 
   const [adjudicatedContests, setAdjudicatedContests] = useState<
     Map<ContestId, AdjudicatedCvrContest>
@@ -555,7 +556,7 @@ export function BallotAdjudicationScreen({
 
   function onNavigation(action: () => void): () => void {
     return () => {
-      if (!deepEqual(adjudicatedContests, adjudicatedContestsBaseline)) {
+      if (!deepEqual(adjudicatedContests, adjudicatedContestsBaseline())) {
         setPendingDiscard({ action });
       } else {
         action();

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -492,21 +492,22 @@ export function BallotAdjudicationScreen({
   const [pendingDiscard, setPendingDiscard] = useState<{
     action: () => void;
   } | null>(null);
-  // Initialize from persisted adjudications. In qualified-write-in mode, also
-  // auto-resolve contests whose only adjudication reason is write-ins when the
-  // contest has no qualified candidates: every write-in must be invalid, so
-  // the user has nothing to decide.
-  const [adjudicatedContests, setAdjudicatedContests] = useState<
+
+  // Initialize adjudicatedContestsBaseline from persisted adjudications.
+  // In qualified-write-in mode, auto-resolve contests whose only adjudication
+  // reason is write-ins when the contest has no qualified candidates: every
+  // write-in must be invalid, so the user has nothing to decide
+  const [adjudicatedContestsBaseline] = useState<
     Map<ContestId, AdjudicatedCvrContest>
   >(() => {
-    const initial = new Map<ContestId, AdjudicatedCvrContest>(
+    const baseline = new Map<ContestId, AdjudicatedCvrContest>(
       ballotAdjudicationData.adjudicatedContests.map((c) => [c.contestId, c])
     );
     if (
       !systemSettings.areWriteInCandidatesQualified ||
       ballotAdjudicationData.isResolved
     ) {
-      return initial;
+      return baseline;
     }
     const contestIdsWithQualified = new Set(
       writeInCandidates.map((c) => c.contestId)
@@ -516,7 +517,7 @@ export function BallotAdjudicationScreen({
       ...frontContests,
       ...backContests,
     ]) {
-      if (initial.has(contest.contestId)) continue;
+      if (baseline.has(contest.contestId)) continue;
       const { tag } = contest;
       if (!tag) continue;
       const hasWriteInFlag = tag.hasWriteIn || tag.hasUnmarkedWriteIn;
@@ -536,24 +537,25 @@ export function BallotAdjudicationScreen({
           ? { type: 'write-in-option', hasVote: false }
           : { type: 'official-option', hasVote: option.scannedVote };
       }
-      initial.set(contest.contestId, {
+      baseline.set(contest.contestId, {
         contestId: contest.contestId,
         adjudicatedContestOptionById,
       });
     }
-
-    return initial;
+    return baseline;
   });
+
+  const [adjudicatedContests, setAdjudicatedContests] = useState<
+    Map<ContestId, AdjudicatedCvrContest>
+  >(adjudicatedContestsBaseline);
+
   const [selectedSide, setSelectedSide] = useState<Side>(() =>
     getDefaultSide(adjudicatedContests)
   );
 
   function onNavigation(action: () => void): () => void {
     return () => {
-      const baseline = new Map(
-        ballotAdjudicationData.adjudicatedContests.map((c) => [c.contestId, c])
-      );
-      if (!deepEqual(adjudicatedContests, baseline)) {
+      if (!deepEqual(adjudicatedContests, adjudicatedContestsBaseline)) {
         setPendingDiscard({ action });
       } else {
         action();


### PR DESCRIPTION
## Overview

We should include auto-invalidated write-ins in the baseline, otherwise they can trigger the discard changes modal on navigation.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/dea21844-a8a8-4882-9369-4dcefff305b9

## Testing Plan

Manual + automated

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
