### PR TITLE
feat(test-utils): add `Mocked` for easier mock typing

### DIFF
--- a/libs/auth/src/dipped_smart_card_auth.test.ts
+++ b/libs/auth/src/dipped_smart_card_auth.test.ts
@@ -13,6 +13,7 @@ import {
   MockBaseLogger,
 } from '@votingworks/logging';
 import {
+  Mocked,
   mockElectionManagerUser,
   mockPollWorkerUser,
   mockSystemAdministratorUser,
@@ -32,8 +33,9 @@ import {
   getFeatureFlagMock,
 } from '@votingworks/utils';
 
-import { buildMockCard, MockCard, mockCardAssertComplete } from '../test/utils';
+import { buildMockCard, mockCardAssertComplete } from '../test/utils';
 import {
+  Card,
   CardDetails,
   CardStatus,
   ProgrammableCard,
@@ -60,7 +62,7 @@ vi.mock(
 const pin = '123456';
 const wrongPin = '654321';
 
-let mockCard: MockCard;
+let mockCard: Mocked<Card>;
 let mockLogger: MockBaseLogger;
 let mockTime: DateTime;
 

--- a/libs/auth/src/inserted_smart_card_auth.test.ts
+++ b/libs/auth/src/inserted_smart_card_auth.test.ts
@@ -15,6 +15,7 @@ import {
 } from '@votingworks/logging';
 import {
   mockCardlessVoterUser,
+  Mocked,
   mockElectionManagerUser,
   mockPollWorkerUser,
   mockSystemAdministratorUser,
@@ -34,8 +35,8 @@ import {
   getFeatureFlagMock,
 } from '@votingworks/utils';
 
-import { buildMockCard, MockCard, mockCardAssertComplete } from '../test/utils';
-import { CardDetails, CardStatus, ProgrammedCardDetails } from './card';
+import { buildMockCard, mockCardAssertComplete } from '../test/utils';
+import { Card, CardDetails, CardStatus, ProgrammedCardDetails } from './card';
 import { DippedSmartCardAuthMachineState } from './dipped_smart_card_auth_api';
 import { InsertedSmartCardAuth } from './inserted_smart_card_auth';
 import {
@@ -57,7 +58,7 @@ vi.mock(
 const pin = '123456';
 const wrongPin = '654321';
 
-let mockCard: MockCard;
+let mockCard: Mocked<Card>;
 let mockLogger: MockBaseLogger;
 let mockTime: DateTime;
 

--- a/libs/auth/test/utils.ts
+++ b/libs/auth/test/utils.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-classes-per-file */
 import { Buffer } from 'node:buffer';
 import path from 'node:path';
-import { MockFunction, mockFunction } from '@votingworks/test-utils';
+import { Mocked, MockFunction, mockFunction } from '@votingworks/test-utils';
 
 import { Card, CardStatus } from '../src/card';
 import {
@@ -28,50 +28,33 @@ export class MockCardReader implements Pick<CardReader, 'transmit'> {
 
   // eslint-disable-next-line vx/gts-no-public-class-fields
   disconnectCard: MockFunction<CardReader['disconnectCard']> =
-    mockFunction<CardReader['disconnectCard']>('disconnectCard');
+    mockFunction('disconnectCard');
 
   // eslint-disable-next-line vx/gts-no-public-class-fields
-  transmit: MockFunction<CardReader['transmit']> =
-    mockFunction<CardReader['transmit']>('transmit');
-}
-
-/**
- * The card API with all methods mocked using our custom libs/test-utils mocks
- */
-export interface MockCard {
-  getCardStatus: MockFunction<Card['getCardStatus']>;
-  checkPin: MockFunction<Card['checkPin']>;
-  program: MockFunction<Card['program']>;
-  readData: MockFunction<Card['readData']>;
-  writeData: MockFunction<Card['writeData']>;
-  clearData: MockFunction<Card['clearData']>;
-  unprogram: MockFunction<Card['unprogram']>;
-  disconnect: MockFunction<Card['disconnect']>;
+  transmit: MockFunction<CardReader['transmit']> = mockFunction('transmit');
 }
 
 /**
  * Builds a mock card instance
  */
-export function buildMockCard(): MockCard {
+export function buildMockCard(): Mocked<Card> {
   return {
-    getCardStatus: mockFunction<Card['getCardStatus']>('getCardStatus'),
-    checkPin: mockFunction<Card['checkPin']>('checkPin'),
-    program: mockFunction<Card['program']>('program'),
-    readData: mockFunction<Card['readData']>('readData'),
-    writeData: mockFunction<Card['writeData']>('writeData'),
-    clearData: mockFunction<Card['clearData']>('clearData'),
-    unprogram: mockFunction<Card['unprogram']>('unprogram'),
-    disconnect: mockFunction<Card['disconnect']>('disconnect'),
+    getCardStatus: mockFunction('getCardStatus'),
+    checkPin: mockFunction('checkPin'),
+    program: mockFunction('program'),
+    readData: mockFunction('readData'),
+    writeData: mockFunction('writeData'),
+    clearData: mockFunction('clearData'),
+    unprogram: mockFunction('unprogram'),
+    disconnect: mockFunction('disconnect'),
   };
 }
 
 /**
  * Asserts that all the expected calls to all the methods of a mock card were made
  */
-export function mockCardAssertComplete(mockCard: MockCard): void {
-  for (const mockMethod of Object.values(mockCard) as Array<
-    MockCard[keyof MockCard]
-  >) {
+export function mockCardAssertComplete(mockCard: Mocked<Card>): void {
+  for (const mockMethod of Object.values(mockCard)) {
     mockMethod.assertComplete();
   }
 }

--- a/libs/test-utils/src/mock_function.test.ts
+++ b/libs/test-utils/src/mock_function.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { describe, expect, test } from 'vitest';
-import { mockFunction } from './mock_function';
+import { describe, expect, expectTypeOf, test } from 'vitest';
+import { Mocked, MockFunction, mockFunction } from './mock_function';
 
 describe('mockFunction', () => {
   function add(num1: number, num2: number): number {
@@ -340,5 +340,33 @@ describe('mockFunction', () => {
     addMock.reset();
 
     addMock.assertComplete();
+  });
+});
+
+describe('Mocked<T>', () => {
+  test('Mocked<T> extends T', () => {
+    interface A {
+      a(): void;
+    }
+
+    expectTypeOf<Mocked<A>>({
+      a: mockFunction('a'),
+    }).toExtend<A>();
+  });
+
+  test('Mocked<T> types methods as `MockFunction`, others are passed through', () => {
+    interface A {
+      a(): void;
+      b(x: string, y: number): symbol;
+      c: number;
+    }
+
+    expectTypeOf<Mocked<A>['a']>(mockFunction('a')).toExtend<
+      MockFunction<() => void>
+    >();
+    expectTypeOf<Mocked<A>['b']>(mockFunction('b')).toExtend<
+      MockFunction<(x: string, y: number) => symbol>
+    >();
+    expectTypeOf<Mocked<A>['c']>(1).toExtend<number>();
   });
 });

--- a/libs/test-utils/src/mock_function.ts
+++ b/libs/test-utils/src/mock_function.ts
@@ -57,6 +57,13 @@ export interface MockFunction<Func extends AnyFunc> {
   assertComplete(): void;
 }
 
+/**
+ * An object whose methods are all `MockFunction` mocks.
+ */
+export type Mocked<T> = {
+  [K in keyof T]: T[K] extends AnyFunc ? MockFunction<T[K]> : T[K];
+} & T;
+
 interface MockFunctionState<Func extends AnyFunc> {
   expectedCalls: Array<ExpectedCall<Func>>;
   actualCalls: Array<ActualCall<Func>>;

--- a/libs/usb-drive/src/mocks/memory_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/memory_usb_drive.ts
@@ -1,18 +1,14 @@
 import { getTemporaryRootDir } from '@votingworks/fixtures';
-import { MockFunction, mockFunction } from '@votingworks/test-utils';
+import { Mocked, mockFunction } from '@votingworks/test-utils';
 import tmp from 'tmp';
 import { MockFileTree, writeMockFileTree } from './helpers';
 import { UsbDrive } from '../types';
-
-type MockedUsbDrive = {
-  [Method in keyof UsbDrive]: MockFunction<UsbDrive[Method]>;
-};
 
 /**
  * A mock of the UsbDrive interface. See createMockUsbDrive for details.
  */
 export interface MockUsbDrive {
-  usbDrive: MockedUsbDrive;
+  usbDrive: Mocked<UsbDrive>;
   assertComplete(): void;
   insertUsbDrive(contents: MockFileTree): void;
   removeUsbDrive(): void;
@@ -34,7 +30,7 @@ export interface MockUsbDrive {
 export function createMockUsbDrive(): MockUsbDrive {
   let mockUsbTmpDir: tmp.DirResult | undefined;
 
-  const usbDrive: MockedUsbDrive = {
+  const usbDrive: Mocked<UsbDrive> = {
     status: mockFunction('status'),
     eject: mockFunction('eject'),
     format: mockFunction('format'),

--- a/libs/usb-drive/src/mocks/mock_multi_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/mock_multi_usb_drive.ts
@@ -1,4 +1,4 @@
-import { MockFunction, mockFunction } from '@votingworks/test-utils';
+import { Mocked, mockFunction } from '@votingworks/test-utils';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
 import {
   MultiUsbDrive,
@@ -9,15 +9,11 @@ import { UsbDrive } from '../types';
 import { createUsbDriveAdapter } from '../usb_drive_adapter';
 import { MockFileTree, writeMockFileTree } from './helpers';
 
-type MockedMultiUsbDrive = {
-  [Method in keyof MultiUsbDrive]: MockFunction<MultiUsbDrive[Method]>;
-};
-
 const MOCK_DISK_DEV_PATH = '/dev/sdb';
 const MOCK_PARTITION_DEV_PATH = '/dev/sdb1';
 
 export interface MockMultiUsbDrive {
-  multiUsbDrive: MockedMultiUsbDrive;
+  multiUsbDrive: Mocked<MultiUsbDrive>;
   /**
    * A UsbDrive adapter backed by the multiUsbDrive mock. Useful for passing
    * directly to functions that accept a UsbDrive interface.
@@ -54,7 +50,7 @@ export interface MockMultiUsbDrive {
 export function createMockMultiUsbDrive(): MockMultiUsbDrive {
   let mockUsbTmpDir: string | undefined;
 
-  const multiUsbDrive: MockedMultiUsbDrive = {
+  const multiUsbDrive: Mocked<MultiUsbDrive> = {
     getDrives: mockFunction('getDrives'),
     refresh: mockFunction('refresh'),
     ejectDrive: mockFunction('ejectDrive'),


### PR DESCRIPTION
## Overview
We had a couple places where we manually constructed mock types. This follows essentially the same pattern used by vitest's `Mocked`. I decided to try this after noticing we had a `MockMultiUsbDrive` and a `MockedMultiUsbDrive` where one contained the other :dizzy_face: 

## Demo Video or Screenshot
```ts
function buildMockThing(): Mocked<Thing> {
  return { doThing: mockFunction('doThing') };
}
```

## Testing Plan
Added type-based tests and updated a couple locations that manually constructed type-alike mocks.