### PR TITLE
VxAdmin: Remove ballotData queries instead of invalidate when qualified candidate is deleted

### DIFF
--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -451,9 +451,7 @@ export const updateQualifiedWriteInCandidates = {
         await queryClient.invalidateQueries(
           getBallotAdjudicationQueue.queryKey()
         );
-        await queryClient.invalidateQueries(
-          getBallotAdjudicationData.queryKey()
-        );
+        queryClient.removeQueries(getBallotAdjudicationData.queryKey());
         await queryClient.invalidateQueries(
           getNextCvrIdForBallotAdjudication.queryKey()
         );

--- a/apps/admin/frontend/src/screens/write_in_candidates_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_in_candidates_screen.tsx
@@ -376,7 +376,7 @@ function CandidatesForm({ contestId }: { contestId: ContestId }): JSX.Element {
             savedCandidates.length === 0 && (
               <Callout icon="Info" color="neutral">
                 You have not added any write-in candidates for this contest.
-                Write-ins for this contest will be counted as undervotes.
+                Write-ins for this contest will be counted as invalid.
               </Callout>
             )}
         </FormBody>


### PR DESCRIPTION
## Overview

When I made the refactor to manage the state of adjudicated contests on the ballot adjudication screen, it broke the edge case of deleting a qualified candidate resetting adjudications for a contest, at least in the UI. 

Because we have `keepPreviousData` on the `ballotAdjudicationData`, even though the query is invalidated when a qualified candidate is deleted, that only triggers a new fetch, but it doesn't delete the previous data. So when the ballot adjudication screen loads, we initialize the `adjudicatedContests` state with the stale `ballotAdjudicationData`, which still holds the old write-in adjudication. This PR fixes this edge case by removing the `ballotAdjudicationData` instead of just deleting it.

I also added in the copy change you suggested. `Invalid` is clearer than `undervote` when speaking of an individual `write-in`.

## Demo Video or Screenshot

**Previous**

https://github.com/user-attachments/assets/eb3ae2b9-cb77-413b-b294-030bf80fcbc5

**Fixed**

https://github.com/user-attachments/assets/436b1ced-b337-4e6e-89f0-cfc9f0fc44aa

**Copy change**
<img width="1085" height="706" alt="Screenshot 2026-05-28 at 2 29 38 PM" src="https://github.com/user-attachments/assets/1af15bfd-4faa-48c8-823b-f758737a76dc" />


## Testing Plan

Manually tested

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
