### PR TITLE
VxAdmin: Show status lines for adjudications that are needed

### DIFF
--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -20,11 +20,12 @@ import {
   Button,
   Callout,
   Caption,
-  DesktopPalette,
   Font,
+  FontProps,
   Icons,
   P,
 } from '@votingworks/ui';
+import pluralize from 'pluralize';
 import { EntityList } from './entity_list';
 import {
   isContestResolved,
@@ -71,14 +72,52 @@ const CalloutTitle = styled(P)`
   margin-bottom: 0;
 `;
 
-const ResolvedCaption = styled(EntityList.Caption)`
-  color: ${DesktopPalette.Purple70};
+const StatusCaption = styled(EntityList.Caption)`
+  align-items: center;
+  display: flex;
+  gap: 0.25rem;
 `;
 
-const StatusLine = styled.span`
-  align-items: center;
-  display: inline-flex;
-  gap: 0.25rem;
+function StatusLine({
+  icon,
+  children,
+  ...fontProps
+}: FontProps &
+  React.PropsWithChildren<{
+    icon: JSX.Element;
+  }>) {
+  return (
+    <StatusCaption {...fontProps}>
+      {icon} {children}
+    </StatusCaption>
+  );
+}
+
+const StatusLineNeedsAdjudication = styled(StatusLine).attrs({
+  icon: <Icons.PenToSquare color="warning" />,
+  weight: 'semiBold',
+})`
+  color: ${(p) => p.theme.colors.onBackground};
+`;
+
+const StatusLineWarning = styled(StatusLine).attrs({
+  icon: <Icons.Warning color="warning" />,
+  weight: 'semiBold',
+})`
+  color: ${(p) => p.theme.colors.primary};
+`;
+
+const StatusLineConfirmed = styled(StatusLine).attrs({
+  icon: <Icons.Done />,
+  weight: 'semiBold',
+})`
+  color: ${(p) => p.theme.colors.primary};
+`;
+
+const StatusLineAdjudicated = styled(StatusLine).attrs({
+  icon: <Icons.PenToSquare />,
+})`
+  color: ${(p) => p.theme.colors.primary};
 `;
 
 function getVotesAllowed(contest: AnyContest): number {
@@ -105,7 +144,7 @@ export interface ContestListItem {
   adjudicationData: ContestAdjudicationData;
 }
 
-function getStatusLine(
+function getAdjudicatedContestStatusLine(
   item: ContestListItem,
   showUndervoteStatus: boolean,
   adjudicatedContest: AdjudicatedCvrContest
@@ -127,10 +166,10 @@ function getStatusLine(
 
   if (originalStatus === adjudicatedStatus) {
     if (originalStatus === 'overvote') {
-      return 'Overvote Confirmed';
+      return <StatusLineConfirmed>Overvote Confirmed</StatusLineConfirmed>;
     }
     if (originalStatus === 'undervote' && showUndervoteStatus) {
-      return 'Undervote Confirmed';
+      return <StatusLineConfirmed>Undervote Confirmed</StatusLineConfirmed>;
     }
     return null;
   }
@@ -139,46 +178,33 @@ function getStatusLine(
   if (originalStatus === 'overvote' && adjudicatedStatus !== 'overvote') {
     if (adjudicatedStatus === 'undervote' && showUndervoteStatus) {
       return (
-        <StatusLine>
-          <Icons.Warning color="warning" />
+        <StatusLineWarning>
           Overvote Resolved; Undervote Created
-        </StatusLine>
+        </StatusLineWarning>
       );
     }
-    return 'Overvote Resolved';
+    return <StatusLineConfirmed>Overvote Resolved</StatusLineConfirmed>;
   }
 
   // New overvote
   if (adjudicatedStatus === 'overvote') {
-    return (
-      <StatusLine>
-        <Icons.Warning color="warning" />
-        Overvote Created
-      </StatusLine>
-    );
+    return <StatusLineWarning>Overvote Created</StatusLineWarning>;
   }
 
   // Undervote transitions only if enabled
   if (showUndervoteStatus) {
     if (originalStatus === 'undervote' && adjudicatedStatus !== 'undervote') {
-      return 'Undervote Resolved';
+      return <StatusLineConfirmed>Undervote Resolved</StatusLineConfirmed>;
     }
-    return (
-      <StatusLine>
-        <Icons.Warning color="warning" />
-        Undervote Created
-      </StatusLine>
-    );
+    return <StatusLineWarning>Undervote Created</StatusLineWarning>;
   }
-
-  return null;
 }
 
-function getOptionResolutionLine(
+function getAdjudicatedOptionStatusLine(
   option: ContestOptionAdjudicationData,
   contest: AnyContest,
   adjudicatedOption?: AdjudicatedContestOption
-): React.ReactNode | undefined {
+): React.ReactNode {
   const { definition, scannedVote, hasMarginalMark, writeInRecord } = option;
 
   if (
@@ -206,17 +232,17 @@ function getOptionResolutionLine(
 
     if (candidateName) {
       return (
-        <span>
+        <StatusLineAdjudicated>
           <Font weight="semiBold">{writeInPrefix} </Font>adjudicated for
           <Font weight="semiBold"> {candidateName}</Font>
-        </span>
+        </StatusLineAdjudicated>
       );
     }
     return (
-      <span>
+      <StatusLineAdjudicated>
         <Font weight="semiBold">{writeInPrefix} </Font>adjudicated as
         <Font weight="semiBold"> Invalid</Font>
-      </span>
+      </StatusLineAdjudicated>
     );
   }
 
@@ -225,12 +251,12 @@ function getOptionResolutionLine(
   if (hasMarginalMark) {
     const newValue = currentVote ? 'Valid' : 'Invalid';
     return (
-      <span>
+      <StatusLineAdjudicated>
         <Font weight="semiBold">Marginal Mark </Font>for
         <Font weight="semiBold"> {definition.name} </Font>
         adjudicated as
         <Font weight="semiBold"> {newValue}</Font>
-      </span>
+      </StatusLineAdjudicated>
     );
   }
 
@@ -238,16 +264,14 @@ function getOptionResolutionLine(
     const preface = currentVote ? 'Undetected Mark' : 'Mark';
     const newValue = currentVote ? 'Valid' : 'Invalid';
     return (
-      <span>
+      <StatusLineAdjudicated>
         <Font weight="semiBold">{preface} </Font>for
         <Font weight="semiBold"> {definition.name} </Font>
         adjudicated as
         <Font weight="semiBold"> {newValue}</Font>
-      </span>
+      </StatusLineAdjudicated>
     );
   }
-
-  return undefined;
 }
 
 function ContestAdjudicationSummary({
@@ -257,34 +281,50 @@ function ContestAdjudicationSummary({
 }: {
   item: ContestListItem;
   showUndervoteStatus: boolean;
-  adjudicatedContest: AdjudicatedCvrContest;
+  adjudicatedContest?: AdjudicatedCvrContest;
 }): JSX.Element | null {
-  const statusLine = getStatusLine(
+  if (!adjudicatedContest) {
+    const writeIns = item.adjudicationData.options.filter(
+      (option) => option.writeInRecord
+    ).length;
+    const marginalMarks = item.adjudicationData.options.filter(
+      (option) => option.hasMarginalMark
+    ).length;
+    return (
+      <React.Fragment>
+        {writeIns > 0 && (
+          <StatusLineNeedsAdjudication>
+            {writeIns} {pluralize('write-in', writeIns)} to adjudicate
+          </StatusLineNeedsAdjudication>
+        )}
+        {marginalMarks > 0 && (
+          <StatusLineNeedsAdjudication>
+            {marginalMarks} {pluralize('marginal mark', marginalMarks)} to
+            adjudicate
+          </StatusLineNeedsAdjudication>
+        )}
+      </React.Fragment>
+    );
+  }
+
+  const contestLine = getAdjudicatedContestStatusLine(
     item,
     showUndervoteStatus,
     adjudicatedContest
   );
-  const bullets = item.adjudicationData.options
-    .map((option) =>
-      getOptionResolutionLine(
+  const optionLines = item.adjudicationData.options.map((option) => (
+    <React.Fragment key={option.definition.id}>
+      {getAdjudicatedOptionStatusLine(
         option,
         item.contest,
         adjudicatedContest.adjudicatedContestOptionById[option.definition.id]
-      )
-    )
-    .filter((desc): desc is React.ReactNode => desc !== undefined);
-
-  if (!statusLine && bullets.length === 0) return null;
-
+      )}
+    </React.Fragment>
+  ));
   return (
     <React.Fragment>
-      {statusLine && (
-        <ResolvedCaption weight="semiBold">{statusLine}</ResolvedCaption>
-      )}
-      {bullets.map((bullet, i) => (
-        // eslint-disable-next-line react/no-array-index-key
-        <ResolvedCaption key={i}>&bull; {bullet}</ResolvedCaption>
-      ))}
+      {contestLine}
+      {optionLines}
     </React.Fragment>
   );
 }
@@ -372,7 +412,7 @@ function BallotSideContestList({
                 >
                   {contest.title}
                 </EntityList.Label>
-                {adjudicatedContest && !suppressContestAdjudicationInfo && (
+                {!suppressContestAdjudicationInfo && (
                   <ContestAdjudicationSummary
                     item={item}
                     showUndervoteStatus={showUndervoteStatus}
@@ -380,9 +420,6 @@ function BallotSideContestList({
                   />
                 )}
               </Column>
-              {isPending && !suppressContestAdjudicationInfo && (
-                <Icons.Warning color="warning" />
-              )}
             </EntityList.Item>
           );
         })}

--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -284,6 +284,7 @@ function ContestAdjudicationSummary({
   adjudicatedContest?: AdjudicatedCvrContest;
 }): JSX.Element | null {
   if (!adjudicatedContest) {
+    const { tag } = item.adjudicationData;
     const writeIns = item.adjudicationData.options.filter(
       (option) => option.writeInRecord
     ).length;
@@ -292,12 +293,22 @@ function ContestAdjudicationSummary({
     ).length;
     return (
       <React.Fragment>
+        {tag?.hasOvervote && (
+          <StatusLineNeedsAdjudication>
+            Overvote to adjudicate
+          </StatusLineNeedsAdjudication>
+        )}
+        {tag?.hasUndervote && (
+          <StatusLineNeedsAdjudication>
+            Undervote to adjudicate
+          </StatusLineNeedsAdjudication>
+        )}
         {writeIns > 0 && (
           <StatusLineNeedsAdjudication>
             {writeIns} {pluralize('write-in', writeIns)} to adjudicate
           </StatusLineNeedsAdjudication>
         )}
-        {marginalMarks > 0 && (
+        {tag?.hasMarginalMark && (
           <StatusLineNeedsAdjudication>
             {marginalMarks} {pluralize('marginal mark', marginalMarks)} to
             adjudicate

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -1366,7 +1366,8 @@ test('contest list shows correct option resolution bullets', async () => {
     .resolves();
 });
 
-test('contest list shows pending write-in and marginal mark counts before adjudication', async () => {
+test('contest list shows pending status lines before adjudication', async () => {
+  // zoo-council-mammal: one pending write-in and two marginal marks.
   const zooCouncil = makeContestAdjudicationData(
     'zoo-council-mammal',
     makeContestTag({ hasWriteIn: true, hasMarginalMark: true })
@@ -1397,7 +1398,23 @@ test('contest list shows pending write-in and marginal mark counts before adjudi
     },
   });
 
-  const adjData = makeBallotAdjudicationData(CVR_ID_1, [zooCouncil]);
+  // best-animal-mammal: tagged for overvote -> "Overvote to adjudicate"
+  const overvoted = makeContestAdjudicationData(
+    'best-animal-mammal',
+    makeContestTag({ hasOvervote: true, hasWriteIn: false })
+  );
+
+  // best-animal-fish: tagged for undervote -> "Undervote to adjudicate"
+  const undervoted = makeContestAdjudicationData(
+    'best-animal-fish',
+    makeContestTag({ hasUndervote: true, hasWriteIn: false })
+  );
+
+  const adjData = makeBallotAdjudicationData(CVR_ID_1, [
+    zooCouncil,
+    overvoted,
+    undervoted,
+  ]);
   setupBasicMocks({ adjudicationData: adjData });
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
@@ -1405,10 +1422,68 @@ test('contest list shows pending write-in and marginal mark counts before adjudi
     apiMock,
   });
 
-  await screen.findByText('Zoo Council');
-  const zooCouncilItem = within(screen.getByText('Zoo Council').closest('li')!);
+  const zooCouncilItem = within(
+    (await screen.findByText('Zoo Council')).closest('li')!
+  );
   zooCouncilItem.getByText('1 write-in to adjudicate');
   zooCouncilItem.getByText('2 marginal marks to adjudicate');
+
+  const [bestAnimalMammal, bestAnimalFish] = screen
+    .getAllByText('Best Animal')
+    .map((el) => within(el.closest('li')!));
+  bestAnimalMammal.getByText('Overvote to adjudicate');
+  bestAnimalFish.getByText('Undervote to adjudicate');
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves();
+});
+
+test('contest list only shows overvote/undervote/marginal status lines present in the contest tag', async () => {
+  // best-animal-mammal: 1 seat. A marked official candidate plus a marked
+  // write-in is an overvote by raw count, and one option has a marginal mark,
+  // but the contest is tagged only for the write-in (overvote and marginal-mark
+  // adjudication disabled). Only the write-in line should show.
+  const writeInOnly = makeContestAdjudicationData(
+    'best-animal-mammal',
+    makeContestTag({ hasWriteIn: true })
+  );
+  writeInOnly.options[0].scannedVote = true;
+  writeInOnly.options[1].hasMarginalMark = true;
+  writeInOnly.options.push({
+    definition: {
+      id: 'write-in-0',
+      contestId: 'best-animal-mammal',
+      name: 'Write-In #1',
+      type: 'candidate' as const,
+      isWriteIn: true,
+    },
+    scannedVote: true,
+    hasMarginalMark: false,
+    writeInRecord: {
+      id: 'wr-0',
+      optionId: 'write-in-0',
+      contestId: 'best-animal-mammal',
+      cvrId: CVR_ID_1,
+      electionId: 'e',
+      status: 'pending' as const,
+    },
+  });
+
+  const adjData = makeBallotAdjudicationData(CVR_ID_1, [writeInOnly]);
+  setupBasicMocks({ adjudicationData: adjData });
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  const bestAnimal = within(
+    (await screen.findByText('Best Animal')).closest('li')!
+  );
+  bestAnimal.getByText('1 write-in to adjudicate');
+  expect(bestAnimal.queryByText('Overvote to adjudicate')).toBeNull();
+  expect(bestAnimal.queryByText(/marginal mark/)).toBeNull();
 
   apiMock.apiClient.releaseBallotAdjudicationClaim
     .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -1333,7 +1333,7 @@ test('contest list shows correct option resolution bullets', async () => {
 
   function findTextInContest(contestName: string, expectedText: string) {
     const item = within(screen.getByText(contestName).closest('li')!);
-    item.getByText((_c, node) => node?.textContent === expectedText);
+    item.getByText((_c, node) => node?.textContent?.trim() === expectedText);
   }
 
   // Zoo Council: write-in bullets
@@ -1361,6 +1361,55 @@ test('contest list shows correct option resolution bullets', async () => {
     'Undetected Mark for Horse adjudicated as Valid'
   );
   findTextInContest('Best Animal', 'Mark for Otter adjudicated as Invalid');
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves();
+});
+
+test('contest list shows pending write-in and marginal mark counts before adjudication', async () => {
+  const zooCouncil = makeContestAdjudicationData(
+    'zoo-council-mammal',
+    makeContestTag({ hasWriteIn: true, hasMarginalMark: true })
+  );
+
+  // Two marginal marks on official candidates -> "2 marginal marks to adjudicate"
+  zooCouncil.options[0].hasMarginalMark = true;
+  zooCouncil.options[1].hasMarginalMark = true;
+
+  // One pending write-in -> "1 write-in to adjudicate"
+  zooCouncil.options.push({
+    definition: {
+      id: 'write-in-0',
+      contestId: 'zoo-council-mammal',
+      name: 'Write-In #1',
+      type: 'candidate' as const,
+      isWriteIn: true,
+    },
+    scannedVote: true,
+    hasMarginalMark: false,
+    writeInRecord: {
+      id: 'wr-0',
+      optionId: 'write-in-0',
+      contestId: 'zoo-council-mammal',
+      cvrId: CVR_ID_1,
+      electionId: 'e',
+      status: 'pending' as const,
+    },
+  });
+
+  const adjData = makeBallotAdjudicationData(CVR_ID_1, [zooCouncil]);
+  setupBasicMocks({ adjudicationData: adjData });
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('Zoo Council');
+  const zooCouncilItem = within(screen.getByText('Zoo Council').closest('li')!);
+  zooCouncilItem.getByText('1 write-in to adjudicate');
+  zooCouncilItem.getByText('2 marginal marks to adjudicate');
+
   apiMock.apiClient.releaseBallotAdjudicationClaim
     .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves();

--- a/apps/admin/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/admin/integration-testing/e2e/screenshots.spec.ts
@@ -48,7 +48,10 @@ import {
   logInAsSystemAdministrator,
   logOut,
 } from './support/auth';
-import { adjudicateAllWriteIns } from './support/write_in_adjudication';
+import {
+  adjudicateAllWriteIns,
+  getPendingContestItems,
+} from './support/write_in_adjudication';
 import {
   getPrimaryButton,
   openDropdown,
@@ -638,11 +641,7 @@ test('adjudication', async ({ page }) => {
   await screenshot('adjudication-view');
 
   // Click the Governor contest (has write-in + marginal mark)
-  await page
-    .getByRole('listitem')
-    .filter({ has: page.locator('svg[data-icon="triangle-exclamation"]') })
-    .first()
-    .click();
+  await getPendingContestItems(page).first().click();
   await page.getByRole('button', { name: 'Confirm' }).waitFor();
   await page.getByText('Zoom Out').click();
   await expect(page.getByText('Zoom In')).toBeEnabled();

--- a/apps/admin/integration-testing/e2e/support/write_in_adjudication.ts
+++ b/apps/admin/integration-testing/e2e/support/write_in_adjudication.ts
@@ -78,12 +78,8 @@ async function adjudicateWriteIn(
   }
 }
 
-function getPendingContestItems(page: Page): Locator {
-  // Pending contests render a warning icon as a child of the list item.
-  // Resolved contests do not.
-  return page
-    .getByRole('listitem')
-    .filter({ has: page.locator('svg[data-icon="triangle-exclamation"]') });
+export function getPendingContestItems(page: Page): Locator {
+  return page.getByRole('listitem').filter({ hasText: /to adjudicate/i });
 }
 
 export async function adjudicateAllWriteIns(page: Page): Promise<void> {
@@ -105,12 +101,12 @@ export async function adjudicateAllWriteIns(page: Page): Promise<void> {
     }
 
     // Wait for at least one pending contest to appear — every ballot in the
-    // adjudication queue has at least one unresolved contest, but the warning
-    // icons render asynchronously after the ballot data loads.
+    // adjudication queue has at least one unresolved contest, but the status
+    // lines render asynchronously after the ballot data loads.
     await expect(getPendingContestItems(page).first()).toBeVisible();
 
     // Adjudicate all pending contests on this ballot. After each contest
-    // confirmation, we wait for the warning icon count to decrease before
+    // confirmation, we wait for the pending contest count to decrease before
     // checking for the next pending contest.
     let pendingCount = await getPendingContestItems(page).count();
     while (pendingCount > 0) {
@@ -132,7 +128,7 @@ export async function adjudicateAllWriteIns(page: Page): Promise<void> {
       await page.getByRole('button', { name: 'Confirm' }).click();
 
       // Wait for the ballot view to return and the data to refetch
-      // (the warning icon on the just-adjudicated contest should disappear)
+      // (the "to adjudicate" line on the just-resolved contest should disappear)
       const expectedCount = pendingCount - 1;
       if (expectedCount > 0) {
         await expect(getPendingContestItems(page)).toHaveCount(expectedCount);


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

<!-- Add a link to a GitHub issue here -->
Instead of just showing a warning icon when a contest needs adjudication, use explicit text annotations with icons to enumerate the needed adjudications. This mirrors the annotations shown after adjudication. It also lays the groundwork for adding in information about crossover votes for open primaries.

## Demo Video or Screenshot
<img width="961" height="602" alt="Screenshot 2026-05-28 at 3 13 39 PM" src="https://github.com/user-attachments/assets/8223f4d1-9929-43ee-aabe-71d04cc5049a" />

<img width="961" height="602" alt="Screenshot 2026-05-28 at 3 13 58 PM" src="https://github.com/user-attachments/assets/8ead0852-0c8f-4622-a942-a3f4dba66c01" />
<img width="961" height="602" alt="Screenshot 2026-05-28 at 3 14 07 PM" src="https://github.com/user-attachments/assets/4fcc4d6e-4c5b-4c99-9a9e-2c5f66376979" />


## Testing Plan
- Basic manual testing with write-ins/overvotes
- Automated testing to cover the rest of the cases
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
