### PR TITLE
copy suggestions for #8542

### DIFF
--- a/apps/admin/frontend/src/client/screens/client_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_adjudication_screen.test.tsx
@@ -58,7 +58,7 @@ test('shows enabled start button when adjudication is enabled', async () => {
 test('shows waiting message and disabled button when adjudication not enabled', async () => {
   apiMock.expectGetAdjudicationSessionStatus(false);
   renderAdjudicationScreen(pollWorkerAuth, { withElection: true });
-  await screen.findByText('Waiting for VxAdmin to initiate adjudication.');
+  await screen.findByText('Waiting for host to initiate adjudication.');
   const startButton = screen.getByRole('button', {
     name: 'Start Adjudication',
   });

--- a/apps/admin/frontend/src/client/screens/client_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_adjudication_screen.tsx
@@ -24,7 +24,7 @@ export function ClientAdjudicationScreen(): JSX.Element {
         </Button>
       </P>
       {!isAdjudicationEnabled && (
-        <P>Waiting for VxAdmin to initiate adjudication.</P>
+        <P>Waiting for host to initiate adjudication.</P>
       )}
     </NavigationScreen>
   );

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
@@ -212,7 +212,7 @@ test('shows error screen when claim fails during accept', async () => {
     .expectCallWith({ afterCvrId: 'cvr-1' })
     .resolves(err({ type: 'host-disconnect' }));
   screen.getByText('Accept').click();
-  await screen.findByText('Disconnected from VxAdmin.');
+  await screen.findByText('Disconnected from host.');
   screen.getByText('Exit');
 });
 
@@ -295,7 +295,7 @@ test('shows host-disconnect error with exit button', async () => {
 
   renderScreen();
 
-  await screen.findByText('Disconnected from VxAdmin.');
+  await screen.findByText('Disconnected from host.');
   screen.getByText('Exit');
 });
 

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.tsx
@@ -25,7 +25,7 @@ function proxyErrorMessage(error: AdjudicationError): string {
     case 'claim-failed':
       return 'This machine no longer has an active claim on this ballot. Please try again.';
     case 'host-disconnect':
-      return 'Disconnected from VxAdmin.';
+      return 'Disconnected from host.';
     default:
       /* istanbul ignore next - @preserve */
       throwIllegalValue(error, 'type');

--- a/apps/admin/frontend/src/client/screens/client_settings_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_settings_screen.test.tsx
@@ -41,7 +41,7 @@ test('renders settings screen for system administrator', async () => {
   });
   await screen.findByRole('heading', { name: 'Settings' });
   screen.getByRole('heading', { name: 'Network' });
-  await screen.findByText(/Connected to VxAdmin 0001/);
+  await screen.findByText(/Connected to host 0001/);
   screen.getByRole('heading', { name: 'Logs' });
   screen.getByRole('heading', { name: 'Date and Time' });
   screen.getByRole('heading', { name: 'USB Formatting' });
@@ -94,7 +94,7 @@ test('shows searching for host status', async () => {
     auth: sysAdminAuth,
     apiMock,
   });
-  await screen.findByText(/Searching for VxAdmin/);
+  await screen.findByText(/Searching for host…/);
 });
 
 test('does not show Switch to Host Mode when election is configured', async () => {
@@ -119,7 +119,7 @@ test('shows multiple hosts detected warning', async () => {
     auth: sysAdminAuth,
     apiMock,
   });
-  await screen.findByText(/Multiple host VxAdmins detected/);
+  await screen.findByText(/Multiple hosts detected/);
 });
 
 test('shows incompatible host version warning', async () => {

--- a/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
@@ -61,7 +61,7 @@ function NetworkStatusSection(): JSX.Element {
             'online-incompatible-host-version' && (
             <span>
               <Icons.Danger color="danger" /> VxAdmin with incompatible software
-              version detected.
+              version detected on the network.
             </span>
           )}
         {networkStatusQuery.isSuccess &&

--- a/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
@@ -36,23 +36,23 @@ function NetworkStatusSection(): JSX.Element {
         {networkStatusQuery.isSuccess &&
           networkStatusQuery.data.status === 'online-connected-to-host' && (
             <span>
-              <Icons.Done color="success" /> Connected to VxAdmin{' '}
+              <Icons.Done color="success" /> Connected to host{' '}
               {networkStatusQuery.data.hostMachineId}
             </span>
           )}
         {networkStatusQuery.isSuccess &&
           networkStatusQuery.data.status === 'online-waiting-for-host' && (
             <span>
-              <Icons.Warning color="warning" /> Searching for VxAdmin
+              <Icons.Warning color="warning" /> Searching for host…
             </span>
           )}
         {networkStatusQuery.isSuccess &&
           networkStatusQuery.data.status ===
             'online-multiple-hosts-detected' && (
             <span>
-              <Icons.Danger color="danger" /> Multiple host VxAdmins detected on
-              the network. Only one host VxAdmin should be active at a time.
-              This adjudication station will not connect until the conflict is
+              <Icons.Danger color="danger" /> Multiple hosts detected on the
+              network. Only one host should be active at a time. This
+              adjudication station will not connect until the conflict is
               resolved.
             </span>
           )}
@@ -60,8 +60,8 @@ function NetworkStatusSection(): JSX.Element {
           networkStatusQuery.data.status ===
             'online-incompatible-host-version' && (
             <span>
-              <Icons.Danger color="danger" /> VxAdmin machine with incompatible
-              software version detected.
+              <Icons.Danger color="danger" /> VxAdmin with incompatible software
+              version detected.
             </span>
           )}
         {networkStatusQuery.isSuccess &&

--- a/apps/admin/frontend/src/components/sidebar.tsx
+++ b/apps/admin/frontend/src/components/sidebar.tsx
@@ -57,7 +57,7 @@ export function Sidebar(props: SidebarProps): JSX.Element {
     machineMode === 'client' ? (
       <React.Fragment>
         VxAdmin
-        <ClientLogoSubtitle>Adjudication</ClientLogoSubtitle>
+        <ClientLogoSubtitle>Adjudication Station</ClientLogoSubtitle>
       </React.Fragment>
     ) : (
       'VxAdmin'

--- a/apps/admin/frontend/src/screens/adjudication_start_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/adjudication_start_screen.test.tsx
@@ -270,9 +270,7 @@ describe('multi-station adjudication', () => {
       apiMock,
     });
 
-    await screen.findByText(
-      'Online · Adjudication Stations Can Adjudicate Ballots'
-    );
+    await screen.findByText('Online · Stations Can Adjudicate Ballots');
     screen.getByRole('table');
   });
 
@@ -290,7 +288,7 @@ describe('multi-station adjudication', () => {
     });
 
     await screen.findByRole('button', { name: 'Enable Multi-Station' });
-    screen.getByText('Off · Adjudication Stations Cannot Adjudicate Ballots');
+    screen.getByText('Off · Stations Cannot Adjudicate Ballots');
     screen.getByRole('table');
   });
 });

--- a/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
+++ b/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
@@ -442,8 +442,8 @@ function MultiStationCard(): JSX.Element {
         </CardRow>
         {multipleHostsDetected && (
           <P style={{ margin: 0 }}>
-            <Icons.Danger color="danger" /> Multiple host VxAdmins detected on
-            the network. Only one host VxAdmin should be active at a time.
+            <Icons.Danger color="danger" /> Multiple hosts detected on the
+            network. Only one host should be active at a time.
           </P>
         )}
         {isOnline && (

--- a/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
+++ b/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
@@ -415,13 +415,12 @@ function MultiStationCard(): JSX.Element {
             </InlineStatus>
           ) : isEnabled ? (
             <InlineStatus>
-              <StatusDot color="success" /> Online · Adjudication Stations Can
-              Adjudicate Ballots
+              <StatusDot color="success" /> Online · Stations Can Adjudicate
+              Ballots
             </InlineStatus>
           ) : (
             <InlineStatus>
-              <StatusDot /> Off · Adjudication Stations Cannot Adjudicate
-              Ballots
+              <StatusDot /> Off · Stations Cannot Adjudicate Ballots
             </InlineStatus>
           )}
           {isOnline && (

--- a/apps/admin/frontend/src/screens/settings_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.test.tsx
@@ -161,7 +161,7 @@ describe('multi-station mode', () => {
       auth,
       electionDefinition: null,
     });
-    await screen.findByText(/Multiple host VxAdmins detected/);
+    await screen.findByText(/Multiple hosts detected/);
   });
 
   test('shows restart screen after switching mode', async () => {

--- a/apps/admin/frontend/src/screens/settings_screen.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.tsx
@@ -71,10 +71,10 @@ export function SettingsScreen(): JSX.Element | null {
             {networkStatusQuery.isSuccess &&
               networkStatusQuery.data.multipleHostsDetected && (
                 <P>
-                  <Icons.Danger color="danger" /> Multiple host VxAdmins
-                  detected on the network. Only one host machine should be
-                  active at a time. Adjudication stations will not connect until
-                  the conflict is resolved.
+                  <Icons.Danger color="danger" /> Multiple hosts detected on the
+                  network. Only one host machine should be active at a time.
+                  Adjudication stations will not connect until the conflict is
+                  resolved.
                 </P>
               )}
             <P>


### PR DESCRIPTION
PR containing copy suggestions for #8542. 

1. Stick to "host" terminology. We had discussed using "VxAdmin" as a stand-in for "host" but, seeing it in practice, it seems clunky. At some points, "VxAdmin" wasn't clear enough so @carolinemodic needed to clarify by saying "host VxAdmin", which seemed evidence to me that it was too clunky. Reverted back to "host", which I think is slightly less confusing terminology than "client". 
2. Shortened the offline/online status text on the host screen which repeated "adjudicate"
3. Added a clarifying "on the network" preposition to the incompatible version copy.
4. I was worried "Adjudication Station" wouldn't fit as a subtitle under the logo. Since it does, I added in " Station". On the poll worker screen, with "VxAdmin", "Adjudication" and then the "Adjudication" nav list item below it, it looked a little too redundant.