### PR TITLE
VxAdmin: Maintain qualified write-in candidates when clearing CVRs

### DIFF
--- a/apps/admin/backend/src/app.adjudication.test.ts
+++ b/apps/admin/backend/src/app.adjudication.test.ts
@@ -1599,6 +1599,11 @@ test('qualified write-in candidate management', async () => {
   const bobCandidate = assertDefined(remainingCandidates[0]);
   expect(bobCandidate.name).toEqual('Bob');
 
+  // Clearing CVRs should not wipe qualified candidates
+  await apiClient.clearCastVoteRecordFiles();
+  const writeInCandidates = await apiClient.getQualifiedWriteInCandidates();
+  expect(writeInCandidates.map((c) => c.name)).toEqual(['Bob']);
+
   // Delete via batch endpoint
   const directDeleteResult = await apiClient.updateQualifiedWriteInCandidates({
     newCandidates: [],

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -1901,13 +1901,15 @@ export class Store implements BaseStore {
           )
         `
       );
-      this.client.run(
-        `
-          delete from write_in_candidates
-          where election_id = ?
-        `,
-        electionId
-      );
+      if (!this.getSystemSettings(electionId).areWriteInCandidatesQualified) {
+        this.client.run(
+          `
+            delete from write_in_candidates
+            where election_id = ?
+          `,
+          electionId
+        );
+      }
       this.deleteEmptyScannerBatches(electionId);
     });
 

--- a/apps/admin/frontend/src/screens/adjudication_start_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/adjudication_start_screen.test.tsx
@@ -270,7 +270,7 @@ describe('multi-station adjudication', () => {
       apiMock,
     });
 
-    await screen.findByText('Online · Clients Can Adjudicate Ballots');
+    await screen.findByText('Online · Clients can adjudicate');
     screen.getByRole('table');
   });
 
@@ -288,7 +288,7 @@ describe('multi-station adjudication', () => {
     });
 
     await screen.findByRole('button', { name: 'Enable Multi-Station' });
-    screen.getByText('Off · Clients Cannot Adjudicate Ballots');
+    screen.getByText('Off · Clients cannot adjudicate');
     screen.getByRole('table');
   });
 });

--- a/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
+++ b/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
@@ -414,12 +414,11 @@ function MultiStationCard(): JSX.Element {
             </InlineStatus>
           ) : isEnabled ? (
             <InlineStatus>
-              <StatusDot color="success" /> Online · Clients Can Adjudicate
-              Ballots
+              <StatusDot color="success" /> Online · Clients can adjudicate
             </InlineStatus>
           ) : (
             <InlineStatus>
-              <StatusDot /> Off · Clients Cannot Adjudicate Ballots
+              <StatusDot /> Off · Clients cannot adjudicate
             </InlineStatus>
           )}
           {isOnline && (


### PR DESCRIPTION
## Overview

Before qualified write-in candidates, write-in candidates were always entered while adjudicating specific CVRs. So, when CVRs were all deleted, all write-in candidates could be deleted too. But, now qualified candidates are entered separately than CVRs, so they shouldn't be deleted alongside them.

I also fixed a line of copy to match the sentence case of the rest of the screen.

## Demo Video or Screenshot


https://github.com/user-attachments/assets/64ae4036-0d84-41c0-a90c-d5cbee0ffa84

**Before copy change**
<img width="1082" height="691" alt="Screenshot 2026-05-28 at 2 35 36 PM" src="https://github.com/user-attachments/assets/4148d212-c4c8-4c11-ad4f-74b35d3d61b4" />

**After copy change**
<img width="1089" height="699" alt="Screenshot 2026-05-28 at 2 35 28 PM" src="https://github.com/user-attachments/assets/7e98d5ab-ca13-4a0f-8ab9-6c34b0ad6556" />

## Testing Plan

Test extended

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
