### PR TITLE
VxAdmin: Filter getWriteInCandidates api on contestIds

### DIFF
--- a/apps/admin/backend/src/adjudication.test.ts
+++ b/apps/admin/backend/src/adjudication.test.ts
@@ -618,7 +618,7 @@ test('adjudicateCvr adjudicates contest and resolves tags', () => {
   const newWriteInCandidate = store
     .getWriteInCandidates({
       electionId,
-      contestId,
+      contestIds: [contestId],
     })
     .find((c) => c.name === 'siena');
   assert(newWriteInCandidate !== undefined);

--- a/apps/admin/backend/src/adjudication.ts
+++ b/apps/admin/backend/src/adjudication.ts
@@ -208,7 +208,7 @@ function applyAdjudicatedCvrContest(
   });
   const contestWriteInCandidates = store.getWriteInCandidates({
     electionId,
-    contestId,
+    contestIds: [contestId],
   });
 
   const adjudicatedVotes = new Set(existingContestVotes);

--- a/apps/admin/backend/src/app.adjudication.test.ts
+++ b/apps/admin/backend/src/app.adjudication.test.ts
@@ -1450,7 +1450,9 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
   });
 
   // write-in candidate should be deleted as they are no longer referenced
-  expect(await apiClient.getWriteInCandidates({ contestId })).toEqual([]);
+  expect(
+    await apiClient.getWriteInCandidates({ contestIds: [contestId] })
+  ).toEqual([]);
 });
 
 test('peer API: claim, adjudicate, and resolve a ballot with real CVR fixtures', async () => {
@@ -1500,7 +1502,9 @@ test('peer API: claim, adjudicate, and resolve a ballot with real CVR fixtures',
   expect(images.cvrId).toEqual(cvrId1);
 
   // Client 1 fetches write-in candidates via peer API
-  const writeInCandidates = await peerApiClient.getWriteInCandidates();
+  const writeInCandidates = await peerApiClient.getWriteInCandidates({
+    contestIds: ballotData.contests.map((c) => c.contestId),
+  });
   expect(writeInCandidates).toEqual([]);
 
   // Client 1 adjudicates all contests on their claimed ballot in a single call

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -772,7 +772,7 @@ function buildApi({
 
     getWriteInCandidates(
       input: {
-        contestId?: ContestId;
+        contestIds?: ContestId[];
       } = {}
     ): WriteInCandidateRecord[] {
       return store.getWriteInCandidates({

--- a/apps/admin/backend/src/client_app.test.ts
+++ b/apps/admin/backend/src/client_app.test.ts
@@ -351,7 +351,7 @@ test('proxy endpoints return host-disconnect error when not connected', async ()
   expect(await env.apiClient.getBallotImages({ cvrId: 'cvr-1' })).toEqual(
     err({ type: 'host-disconnect' })
   );
-  expect(await env.apiClient.getWriteInCandidates()).toEqual(
+  expect(await env.apiClient.getWriteInCandidates({ contestIds: [] })).toEqual(
     err({ type: 'host-disconnect' })
   );
   expect(
@@ -459,7 +459,7 @@ test('getWriteInCandidates proxies to host peer API', async () => {
   const { mockPeerApi } = connectToMockHost();
   mockPeerApi.getWriteInCandidates.mockResolvedValue([]);
 
-  const result = await env.apiClient.getWriteInCandidates();
+  const result = await env.apiClient.getWriteInCandidates({ contestIds: [] });
   expect(result).toEqual(ok([]));
 });
 

--- a/apps/admin/backend/src/client_app.ts
+++ b/apps/admin/backend/src/client_app.ts
@@ -291,9 +291,9 @@ function buildClientApi({
       );
     },
 
-    async getWriteInCandidates(
-      input: { contestId?: ContestId } = {}
-    ): Promise<Result<WriteInCandidateRecord[], AdjudicationError>> {
+    async getWriteInCandidates(input: {
+      contestIds: ContestId[];
+    }): Promise<Result<WriteInCandidateRecord[], AdjudicationError>> {
       return proxy(
         'fetch write-in candidates',
         async ({ apiClient: peerApi }) => peerApi.getWriteInCandidates(input)

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -189,9 +189,9 @@ function buildPeerApi({ workspace, logger }: PeerAppContext) {
       });
     },
 
-    getWriteInCandidates(
-      input: { contestId?: ContestId } = {}
-    ): WriteInCandidateRecord[] {
+    getWriteInCandidates(input: {
+      contestIds: ContestId[];
+    }): WriteInCandidateRecord[] {
       const electionId = assertDefined(store.getCurrentElectionId());
       return store.getWriteInCandidates({ electionId, ...input });
     },

--- a/apps/admin/backend/src/reports/write_in_image_report.ts
+++ b/apps/admin/backend/src/reports/write_in_image_report.ts
@@ -104,7 +104,7 @@ export async function buildAdminContestWriteIns(
   const writeInRecords = store.getWriteInRecords({ electionId, contestId });
   const writeInCandidates = store.getWriteInCandidates({
     electionId,
-    contestId,
+    contestIds: [contestId],
   });
   const writeInCandidatesById = new Map(
     writeInCandidates.map((c) => [c.id, c])

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -247,6 +247,27 @@ test('scanner batches', () => {
   expect(store.getScannerBatches(electionId)).toEqual([]);
 });
 
+test('getWriteInCandidates returns no candidates for an empty contestIds filter', () => {
+  const store = Store.memoryStore(makeTemporaryDirectory());
+  const electionId = store.addElection({
+    electionData: electionTwoPartyPrimaryFixtures.electionJson.asText(),
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
+    electionPackageHash: 'test-election-package-hash',
+  });
+
+  store.addWriteInCandidate({
+    electionId,
+    contestId: 'zoo-council-mammal',
+    name: 'Mr. Pickles',
+  });
+
+  expect(store.getWriteInCandidates({ electionId })).toHaveLength(1);
+  expect(store.getWriteInCandidates({ electionId, contestIds: [] })).toEqual(
+    []
+  );
+});
+
 test('manual results', () => {
   const electionDefinition =
     electionTwoPartyPrimaryFixtures.readElectionDefinition();

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -1945,7 +1945,6 @@ export class Store implements BaseStore {
     const params: Bindable[] = [electionId];
 
     if (contestIds) {
-      /* istanbul ignore next - @preserve */
       if (contestIds.length === 0) {
         return [];
       }

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -1936,17 +1936,23 @@ export class Store implements BaseStore {
 
   getWriteInCandidates({
     electionId,
-    contestId,
+    contestIds,
   }: {
     electionId: Id;
-    contestId?: ContestId;
+    contestIds?: ContestId[];
   }): WriteInCandidateRecord[] {
     const whereParts: string[] = ['election_id = ?'];
     const params: Bindable[] = [electionId];
 
-    if (contestId) {
-      whereParts.push('contest_id = ?');
-      params.push(contestId);
+    if (contestIds) {
+      /* istanbul ignore next - @preserve */
+      if (contestIds.length === 0) {
+        return [];
+      }
+      whereParts.push(
+        `contest_id IN (${contestIds.map(() => '?').join(', ')})`
+      );
+      params.push(...contestIds);
     }
 
     const rows = this.client.all(

--- a/apps/admin/backend/src/tabulation/full_results.test.ts
+++ b/apps/admin/backend/src/tabulation/full_results.test.ts
@@ -478,11 +478,11 @@ test('tabulateElectionResults - write-in handling', async () => {
     },
   });
   const writeInCandidate1 = store
-    .getWriteInCandidates({ electionId, contestId: candidateContestId })
+    .getWriteInCandidates({ electionId, contestIds: [candidateContestId] })
     .find((c) => c.name === 'Mr. Pickles');
   assert(writeInCandidate1 !== undefined);
   const writeInCandidate2 = store
-    .getWriteInCandidates({ electionId, contestId: candidateContestId })
+    .getWriteInCandidates({ electionId, contestIds: [candidateContestId] })
     .find((c) => c.name === 'Ms. Tomato');
   assert(writeInCandidate2 !== undefined);
 

--- a/apps/admin/backend/src/util/manual_results.ts
+++ b/apps/admin/backend/src/util/manual_results.ts
@@ -57,7 +57,7 @@ function handleEnteredWriteInCandidateData({
             // this check should no-op for manual results entered through the VxAdmin UI.
             const existingWriteInCandidateRecords = store.getWriteInCandidates({
               electionId,
-              contestId,
+              contestIds: [contestId],
             });
 
             const matchingRecord = existingWriteInCandidateRecords.find(

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -400,7 +400,10 @@ export const getWriteInCandidates = {
   queryKey(input?: GetWriteInCandidatesInput): QueryKey {
     return input ? ['getWriteInCandidates', input] : ['getWriteInCandidates'];
   },
-  useQuery(input?: GetWriteInCandidatesInput) {
+  useQuery(
+    input?: GetWriteInCandidatesInput,
+    options: { enabled: boolean } = { enabled: true }
+  ) {
     const apiClient = useApiClient();
     return useQuery(
       this.queryKey(input),
@@ -408,6 +411,7 @@ export const getWriteInCandidates = {
       {
         staleTime: 0,
         refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL,
+        ...options,
       }
     );
   },

--- a/apps/admin/frontend/src/client/api.ts
+++ b/apps/admin/frontend/src/client/api.ts
@@ -273,14 +273,14 @@ export const getBallotImages = {
 } as const;
 
 export const getWriteInCandidates = {
-  queryKey(contestId?: string): QueryKey {
-    return ['getWriteInCandidates', contestId];
+  queryKey(contestIds: string[]): QueryKey {
+    return ['getWriteInCandidates', contestIds];
   },
-  useQuery(contestId?: string) {
+  useQuery(contestIds: string[]) {
     const apiClient = useApiClient();
     return useQuery(
-      this.queryKey(contestId),
-      () => apiClient.getWriteInCandidates({ contestId }),
+      this.queryKey(contestIds),
+      () => apiClient.getWriteInCandidates({ contestIds }),
       { staleTime: 0, refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL }
     );
   },
@@ -296,7 +296,7 @@ export const adjudicateCvr = {
           queryClient.invalidateQueries(
             getBallotAdjudicationData.queryKey(variables.cvrId)
           ),
-          queryClient.invalidateQueries(getWriteInCandidates.queryKey()),
+          queryClient.invalidateQueries(['getWriteInCandidates']),
         ]);
       },
     });

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
@@ -155,7 +155,7 @@ function expectDataLoaderQueries(cvrId: string): void {
 // One-shot setup for the cvrId-independent queries the data loader fires.
 function expectGlobalDataLoaderQueries(): void {
   apiMock.apiClient.getWriteInCandidates
-    .expectRepeatedCallsWith({ contestId: undefined })
+    .expectRepeatedCallsWith({ contestIds: [] })
     .resolves(ok([]));
   apiMock.apiClient.getSystemSettings
     .expectRepeatedCallsWith()

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.tsx
@@ -179,7 +179,9 @@ function ClientBallotAdjudicationDataLoader({
 }): JSX.Element {
   const history = useHistory();
   const ballotImagesQuery = getBallotImages.useQuery(cvrId);
-  const writeInCandidatesQuery = getWriteInCandidates.useQuery();
+  const writeInCandidatesQuery = getWriteInCandidates.useQuery(
+    ballotData.contests.map((c) => c.contestId)
+  );
   const systemSettingsQuery = getSystemSettings.useQuery();
   const { mutateAsync: adjudicateCvrAsync } = adjudicateCvr.useMutation();
   const [mutationError, setMutationError] = useState<AdjudicationError>();

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -158,7 +158,10 @@ function setupBasicMocks({
     adjudicationData
   );
   apiMock.expectGetBallotImages({ cvrId: adjudicationData.cvrId }, isBmd);
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjudicationData.contests.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings();
 }
 
@@ -246,7 +249,10 @@ test('ballot navigation supports back, skip, exit, and side switching', async ()
   // initial load
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2, CVR_ID_3]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    contestData.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings();
 
   apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData1);
@@ -345,7 +351,10 @@ test('opens to the back side when the only pending contest is on the back', asyn
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves(makeHmpbBallotImages(CVR_ID_1));
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjData.contests.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings();
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
@@ -384,7 +393,10 @@ test('default side flips to next pending after confirming a contest', async () =
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves(makeHmpbBallotImages(CVR_ID_1));
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjData.contests.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings();
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
@@ -449,7 +461,10 @@ test('skip / back / exit prompt to discard when the user has unsaved adjudicatio
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves(makeHmpbBallotImages(CVR_ID_1));
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjData2.contests.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings();
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
@@ -510,7 +525,10 @@ test('re-opening a Confirmed contest preserves the in-progress adjudication', as
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves(makeHmpbBallotImages(CVR_ID_1));
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjData.contests.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings();
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
     electionDefinition,
@@ -599,7 +617,10 @@ test('confirmation modal back returns and accept anyway resolves and navigates t
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
   apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjData.contests.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings();
 
   renderInAppContext(
@@ -688,7 +709,10 @@ test('clicking a contest opens contest adjudication screen', async () => {
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves(makeHmpbBallotImages(CVR_ID_1));
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjData.contests.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings();
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
@@ -786,7 +810,10 @@ test('contest hover highlights pending yellow, resolved purple, and back-side no
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves(ballotImages);
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjData.contests.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings();
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
@@ -885,7 +912,10 @@ test('accept advances to next ballot and blank ballot callout states', async () 
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2, CVR_ID_3]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
   apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData1);
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjData1.contests.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings();
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
@@ -985,7 +1015,10 @@ test('accept on the last ballot wraps back to an earlier unresolved ballot', asy
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves(bmdImages(CVR_ID_1));
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjData2.contests.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings();
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
@@ -1051,7 +1084,10 @@ test('contest list shows correct status line captions', async () => {
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
   apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjData.contests.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings({
     ...DEFAULT_SYSTEM_SETTINGS,
     adminAdjudicationReasons: [AdjudicationReason.Undervote],
@@ -1122,7 +1158,10 @@ test('contest list suppresses undervote captions when not in system settings', a
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
   apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjData.contests.map((c) => c.contestId)
+  );
   // Default system settings — no AdjudicationReason.Undervote
   apiMock.expectGetSystemSettings();
 
@@ -1324,14 +1363,17 @@ test('contest list shows correct option resolution bullets', async () => {
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
   apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
-  apiMock.expectGetWriteInCandidates([
-    {
-      id: WRITE_IN_CANDIDATE_ID,
-      electionId: 'e',
-      contestId: 'zoo-council-mammal',
-      name: WRITE_IN_CANDIDATE_NAME,
-    },
-  ]);
+  apiMock.expectGetWriteInCandidates(
+    [
+      {
+        id: WRITE_IN_CANDIDATE_ID,
+        electionId: 'e',
+        contestId: 'zoo-council-mammal',
+        name: WRITE_IN_CANDIDATE_NAME,
+      },
+    ],
+    adjData.contests.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings();
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
@@ -1393,7 +1435,10 @@ test('multi-station mode claims ballots on mount and releases on navigation', as
   // Data loader queries for ballot 1
   apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData1);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    contestData.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings();
 
   // Initial mount claims CVR_ID_1
@@ -1433,7 +1478,13 @@ test('Skip onto a ballot claimed by another machine shows read-only overlay and 
   // CLAIMED_CVR_ID is claimed by another machine; queue is [first, claimed].
   apiMock.expectGetBallotAdjudicationQueue([FIRST_CVR_ID, CLAIMED_CVR_ID]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(FIRST_CVR_ID);
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    contestData.map((c) => c.contestId)
+  );
+  // After Skip lands on the claim-failed placeholder (empty contests),
+  // the data loader re-queries with an empty contestIds list.
+  apiMock.expectGetWriteInCandidates([], []);
   apiMock.expectGetSystemSettings();
 
   // Initial mount on FIRST_CVR_ID.
@@ -1480,7 +1531,6 @@ test('shows an error with exit when the claim+load fails', async () => {
     .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves(err({ type: 'host-disconnect' }));
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
-  apiMock.expectGetWriteInCandidates([]);
   apiMock.expectGetSystemSettings();
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
@@ -1561,7 +1611,10 @@ test('auto-resolves a write-in-only contest with no qualified candidates', async
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_2 })
     .resolves(makeHmpbBallotImages(CVR_ID_2));
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjData.contests.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings(QUALIFIED_SYSTEM_SETTINGS);
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
@@ -1626,7 +1679,10 @@ test('auto-resolved write-in does not trigger discard modal', async () => {
   apiMock.apiClient.getBallotImages
     .expectRepeatedCallsWith({ cvrId: CVR_ID_2 })
     .resolves(makeHmpbBallotImages(CVR_ID_2));
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjData1.contests.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings(QUALIFIED_SYSTEM_SETTINGS);
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
@@ -1666,7 +1722,10 @@ test('auto-resolves contests flagged with hasUnmarkedWriteIn', async () => {
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
   apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjData.contests.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings(QUALIFIED_SYSTEM_SETTINGS);
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
@@ -1702,7 +1761,10 @@ test.each([
     apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
     apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
     apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
-    apiMock.expectGetWriteInCandidates([]);
+    apiMock.expectGetWriteInCandidates(
+      [],
+      adjData.contests.map((c) => c.contestId)
+    );
     apiMock.expectGetSystemSettings(QUALIFIED_SYSTEM_SETTINGS);
 
     renderInAppContext(<BallotAdjudicationScreenWrapper />, {
@@ -1732,9 +1794,10 @@ test('does not auto-resolve when qualified candidates exist for the contest', as
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
   apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
-  apiMock.expectGetWriteInCandidates([
-    { id: 'qual-1', name: 'Qualified Person', electionId: 'e', contestId },
-  ]);
+  apiMock.expectGetWriteInCandidates(
+    [{ id: 'qual-1', name: 'Qualified Person', electionId: 'e', contestId }],
+    adjData.contests.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings(QUALIFIED_SYSTEM_SETTINGS);
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {
@@ -1763,7 +1826,10 @@ test('does not auto-resolve when areWriteInCandidatesQualified is false', async 
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
   apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
   apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
-  apiMock.expectGetWriteInCandidates([]);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjData.contests.map((c) => c.contestId)
+  );
   apiMock.expectGetSystemSettings(); // qualified mode off (default)
 
   renderInAppContext(<BallotAdjudicationScreenWrapper />, {

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -407,7 +407,12 @@ function HostBallotAdjudicationScreenDataLoader({
   onExit: () => void;
 }): JSX.Element {
   const ballotImagesQuery = getBallotImages.useQuery({ cvrId });
-  const writeInCandidatesQuery = getWriteInCandidates.useQuery();
+  const writeInCandidatesQuery = getWriteInCandidates.useQuery(
+    ballotData
+      ? { contestIds: ballotData.contests.map((c) => c.contestId) }
+      : undefined,
+    { enabled: !!ballotData }
+  );
   const systemSettingsQuery = getSystemSettings.useQuery();
 
   const { mutateAsync: adjudicateCvrMutation } = adjudicateCvr.useMutation();

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -360,11 +360,11 @@ export function createApiMock(
 
     expectGetWriteInCandidates(
       writeInCandidates: WriteInCandidateRecord[],
-      contestId?: ContestId
+      contestIds?: ContestId[]
     ) {
-      if (contestId) {
+      if (contestIds) {
         apiClient.getWriteInCandidates
-          .expectRepeatedCallsWith({ contestId })
+          .expectRepeatedCallsWith({ contestIds })
           .resolves(writeInCandidates);
       } else {
         apiClient.getWriteInCandidates


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/8271

It felt wasteful to have adjudication screens on the host and client machines to fetch all write-in candidates, rather than just filtering based on the contestIds that are being reviewed. This probably isn't much of an issue now, but felt like for really large elections with a lot of write-in candidates, that this could be worth it. Open to input

The most improved case is `BallotAdjudicationScreen`. We invalidate `writeInCandidates` on every ballot adjudication, so it ends up being a non-trivial amount of data flowing around for large multi-station elections.

Haven't updated manual tallies, but we could do that too. 

## Demo Video or Screenshot

NA

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
