### PR TITLE
[VxPrint] scan check-in receipt QR code to auto-populate ballot style

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,6 +1143,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "print-barcode-scanner-daemon"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "color-eyre",
+ "nix 0.26.4",
+ "nusb",
+ "proptest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-serial",
+ "tokio-test",
+ "vx-logging",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "apps/mark-scan/fai-100-controller",
   "apps/mark-scan/pat-device-input",
   "apps/pollbook/barcode-scanner-daemon",
+  "apps/print/barcode-scanner-daemon",
   "libs/logging",
   "libs/logging-utils",
 ]

--- a/apps/print/backend/src/app.ts
+++ b/apps/print/backend/src/app.ts
@@ -1,7 +1,14 @@
 import * as grout from '@votingworks/grout';
 import { Buffer } from 'node:buffer';
 import express, { Application } from 'express';
-import { assert, assertDefined, err, ok, Result } from '@votingworks/basics';
+import {
+  assert,
+  assertDefined,
+  err,
+  ok,
+  Optional,
+  Result,
+} from '@votingworks/basics';
 import { LogEventId } from '@votingworks/logging';
 import {
   DiagnosticRecord,
@@ -47,7 +54,8 @@ import { findBallotStyleId } from './util/ballot_styles';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function buildApi(ctx: AppContext) {
-  const { auth, usbDrive, logger, workspace, printer } = ctx;
+  const { auth, usbDrive, logger, workspace, printer, barcodeScannerClient } =
+    ctx;
   const { store } = workspace;
 
   function printBallots(
@@ -63,6 +71,20 @@ export function buildApi(ctx: AppContext) {
 
   const methods = {
     getMachineConfig,
+
+    getLastBarcodePayload(): Result<Optional<string>, Error> {
+      const payload = barcodeScannerClient.readPayload();
+      if (payload) {
+        void logger.logAsCurrentRole(LogEventId.BarcodeScanned, {
+          message: 'Barcode scanned',
+          payload: JSON.stringify(payload),
+        });
+      }
+      if (payload && 'error' in payload) {
+        return err(new Error(payload.error));
+      }
+      return ok(payload ? payload.ballotStyleId : undefined);
+    },
 
     getAuthStatus() {
       return auth.getAuthStatus(constructAuthMachineState(store));

--- a/apps/print/backend/src/barcode_scanner/client.ts
+++ b/apps/print/backend/src/barcode_scanner/client.ts
@@ -1,0 +1,206 @@
+import * as net from 'node:net';
+import { lines, Optional, Result, err, ok, sleep } from '@votingworks/basics';
+import {
+  Logger,
+  LogEventId,
+  LogDispositionStandardTypes,
+} from '@votingworks/logging';
+import { lstat } from 'node:fs/promises';
+import { BallotStyleQrCode, BallotStyleQrCodeSchema } from '@votingworks/types';
+import { BarcodeScannerError, BarcodeScannerErrorSchema } from '../types';
+import { tryConnect } from './unix_socket';
+
+export const UDS_CONNECTION_ATTEMPT_DELAY_MS = 1000;
+export const UDS_CONNECTION_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour
+const DEVICE_PATH = '/dev/barcode_scanner';
+
+// The time scan data will live before it's cleaned up.
+// Because only certain pages in the frontend handle barcode scans,
+// we don't want stale scans to sit around in memory to be read
+// later when the user has no context on the scan.
+// The duration should be >= client polling interval for scan data
+export const SCAN_DATA_TTL_MS = 1000;
+
+export type BarcodeScannerPayload = BallotStyleQrCode | BarcodeScannerError;
+
+function parseBarcodeScannerLine(
+  line: string
+): Result<BarcodeScannerPayload, Error> {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(line);
+  } catch (e) {
+    return err(new Error(`Invalid JSON: ${(e as Error).message}`));
+  }
+
+  const infoResult = BallotStyleQrCodeSchema.safeParse(raw);
+  if (infoResult.success) {
+    return ok(infoResult.data);
+  }
+
+  const errorResult = BarcodeScannerErrorSchema.safeParse(raw);
+  if (errorResult.success) {
+    return ok(errorResult.data);
+  }
+
+  return err(
+    new Error(
+      `Does not match BallotStyleQrCode or error: ${infoResult.error.message}`
+    )
+  );
+}
+
+function isBarcodeScannerError(
+  payload: BarcodeScannerPayload
+): payload is BarcodeScannerError {
+  return BarcodeScannerErrorSchema.safeParse(payload).success;
+}
+
+/**
+ * Attempts to connect to the barcode scanner Unix socket within a retry loop.
+ * Allows failure to connect so the app can fall back gracefully.
+ */
+export async function connectToBarcodeScannerSocket(
+  logger: Logger,
+  timeoutMs: number = UDS_CONNECTION_TIMEOUT_MS
+): Promise<Optional<net.Socket>> {
+  await logger.logAsCurrentRole(LogEventId.SocketClientConnectInit, {
+    message: 'Connection to barcode scanner daemon UDS initiated',
+  });
+  const connectStart = new Date();
+  while (new Date().getTime() - connectStart.getTime() < timeoutMs) {
+    try {
+      return await tryConnect(logger);
+    } catch {
+      await sleep(UDS_CONNECTION_ATTEMPT_DELAY_MS);
+    }
+  }
+
+  await logger.logAsCurrentRole(LogEventId.SocketClientConnected, {
+    message: 'Exhausted UDS connection attempts',
+    disposition: LogDispositionStandardTypes.Failure,
+  });
+}
+
+/**
+ * Manages the connection to the barcode scanner daemon.
+ */
+export class BarcodeScannerClient {
+  constructor(
+    private readonly logger: Logger,
+    private scannedInfo: Optional<BallotStyleQrCode> = undefined,
+    private error: Optional<BarcodeScannerError> = undefined,
+    private connectedToDaemon = false,
+    private readonly devicePath = DEVICE_PATH,
+    private ttlTimeout: Optional<ReturnType<typeof setTimeout>> = undefined
+  ) {}
+
+  // Returns the latest payload from the barcode scanner daemon, consuming it in the process,
+  // or undefined if there isn't one.
+  readPayload(): Optional<BarcodeScannerPayload> {
+    if (this.ttlTimeout) {
+      clearTimeout(this.ttlTimeout);
+      this.ttlTimeout = undefined;
+    }
+    const payload = this.scannedInfo ?? this.error ?? undefined;
+    if (payload) {
+      this.logger.log(LogEventId.Info, 'system', {
+        message: `Barcode scanner readPayload method read: ${JSON.stringify(
+          payload
+        )}`,
+        disposition: LogDispositionStandardTypes.Success,
+      });
+      this.scannedInfo = undefined;
+      this.error = undefined;
+    }
+    return payload;
+  }
+
+  scheduleCleanup(): void {
+    this.ttlTimeout = setTimeout(() => {
+      this.scannedInfo = undefined;
+      this.error = undefined;
+    }, SCAN_DATA_TTL_MS);
+  }
+
+  async isConnected(): Promise<boolean> {
+    try {
+      // udev rule sets up an alias for the serial USB device. Each time the device
+      // is connected a symlink is created at this path and each time it's disconnected
+      // the symlink is deleted. Therefore we can check for existence of the symlink
+      // to know whether the device is plugged in.
+      const deviceFound = !!(await lstat(this.devicePath));
+      return deviceFound && this.connectedToDaemon;
+    } catch (e: unknown) {
+      const typedError = e as NodeJS.ErrnoException;
+      /* istanbul ignore next - @preserve */
+      if (typedError.code !== 'ENOENT') {
+        await this.logger.logAsCurrentRole(LogEventId.UnknownError, {
+          message: 'Unknown error trying to lstat barcode scanner',
+          error: (e as Error).message,
+        });
+      }
+
+      return false;
+    }
+  }
+
+  private scheduleReconnect(): void {
+    setTimeout(() => this.listen(), UDS_CONNECTION_ATTEMPT_DELAY_MS);
+  }
+
+  /**
+   * Opens the UDS connection, reads scan lines, and stores the latest payload.
+   */
+  async listen(): Promise<void> {
+    const udsClient = await connectToBarcodeScannerSocket(this.logger);
+    if (!udsClient) {
+      return;
+    }
+
+    this.connectedToDaemon = true;
+
+    // 'close' event covers both clean socket shutdown and close due to error
+    udsClient.on('close', () => {
+      this.logger.log(LogEventId.SocketClientDisconnected, 'system', {
+        message: 'UDS socket closed',
+        disposition: LogDispositionStandardTypes.Success,
+      });
+      this.connectedToDaemon = false;
+      this.scheduleReconnect();
+    });
+
+    try {
+      for await (const line of lines(udsClient)) {
+        this.logger.log(LogEventId.Info, 'system', {
+          message: `Received line from barcode scanner daemon UDS: ${line}`,
+          disposition: LogDispositionStandardTypes.Success,
+        });
+
+        const result = parseBarcodeScannerLine(line);
+        if (result.isErr()) {
+          await this.logger.logAsCurrentRole(LogEventId.ParseError, {
+            message: 'Could not parse barcode scanner message',
+            error: result.err().message,
+          });
+          continue;
+        }
+
+        const parsed = result.ok();
+        if (isBarcodeScannerError(parsed)) {
+          this.error = parsed;
+        } else {
+          this.scannedInfo = parsed;
+        }
+
+        this.scheduleCleanup();
+      }
+    } catch (error) {
+      /* istanbul ignore next - @preserve */
+      await this.logger.logAsCurrentRole(LogEventId.ParseError, {
+        message: 'Could not read line from barcode scanner daemon UDS',
+        error: (error as Error).message,
+      });
+    }
+  }
+}

--- a/apps/print/backend/src/barcode_scanner/unix_socket.ts
+++ b/apps/print/backend/src/barcode_scanner/unix_socket.ts
@@ -1,0 +1,52 @@
+import {
+  LogDispositionStandardTypes,
+  LogEventId,
+  Logger,
+} from '@votingworks/logging';
+import * as net from 'node:net';
+
+const UDS_PATH = '/tmp/barcodescannerd.sock';
+
+/*
+ * Attempts to connect to the barcode scanner Unix socket once. Resolves with
+ * the socket client if successful or rejects with an error.
+ */
+export function tryConnect(logger: Logger): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const client = net.createConnection({
+      path: UDS_PATH,
+    });
+
+    client.once('connect', () => {
+      client.setEncoding('utf8');
+
+      client.on('error', (err) => {
+        logger.log(LogEventId.SocketClientError, 'system', {
+          message: 'VxPrint UDS client received an error',
+          error: err.message,
+          disposition: LogDispositionStandardTypes.Failure,
+        });
+      });
+
+      logger.log(LogEventId.SocketClientConnected, 'system', {
+        message: 'VxPrint backend connected to barcode scanner Unix socket',
+        disposition: LogDispositionStandardTypes.Success,
+      });
+
+      resolve(client);
+    });
+
+    client.once('error', (err) => {
+      const message = `VxPrint backend failed to connect to barcode scanner Unix socket: ${err.message}`;
+      if (!err.message.match(/ECONNREFUSED/) && !err.message.match(/ENOENT/)) {
+        logger.log(LogEventId.SocketClientConnected, 'system', {
+          message,
+          disposition: LogDispositionStandardTypes.Failure,
+        });
+      }
+
+      client.destroy();
+      reject(new Error(message));
+    });
+  });
+}

--- a/apps/print/backend/src/context.ts
+++ b/apps/print/backend/src/context.ts
@@ -3,6 +3,7 @@ import { Logger } from '@votingworks/logging';
 import { UsbDrive } from '@votingworks/usb-drive';
 import { Printer } from '@votingworks/printing';
 import { Workspace } from './util/workspace';
+import { BarcodeScannerClient } from './barcode_scanner/client';
 
 export interface AppContext {
   auth: DippedSmartCardAuthApi;
@@ -10,4 +11,5 @@ export interface AppContext {
   logger: Logger;
   workspace: Workspace;
   printer: Printer;
+  barcodeScannerClient: BarcodeScannerClient;
 }

--- a/apps/print/backend/src/server.test.ts
+++ b/apps/print/backend/src/server.test.ts
@@ -51,6 +51,7 @@ test('start passes context to `buildApp`', () => {
     logger: expect.anything(),
     usbDrive: expect.anything(),
     printer: expect.anything(),
+    barcodeScannerClient: expect.anything(),
   });
   expect(listen).toHaveBeenCalledWith(PORT, expect.any(Function));
 

--- a/apps/print/backend/src/server.ts
+++ b/apps/print/backend/src/server.ts
@@ -10,6 +10,7 @@ import { PORT } from './globals';
 import { Workspace } from './util/workspace';
 import { getDefaultAuth, getUserRole } from './util/auth';
 import { AppContext } from './context';
+import { BarcodeScannerClient } from './barcode_scanner/client';
 
 export interface StartOptions {
   auth?: DippedSmartCardAuthApi;
@@ -30,6 +31,8 @@ export function start({ auth, baseLogger, workspace }: StartOptions): void {
   );
   const usbDrive = detectUsbDrive(logger);
   const printer = detectPrinter(logger);
+  const barcodeScannerClient = new BarcodeScannerClient(logger);
+  void barcodeScannerClient.listen();
 
   const context: AppContext = {
     auth: resolvedAuth,
@@ -37,6 +40,7 @@ export function start({ auth, baseLogger, workspace }: StartOptions): void {
     usbDrive,
     workspace,
     printer,
+    barcodeScannerClient,
   };
 
   const ballotPrintCount = workspace.store.getTotalBallotPrintCount();

--- a/apps/print/backend/src/types.ts
+++ b/apps/print/backend/src/types.ts
@@ -4,8 +4,16 @@ import {
   PrinterStatus,
   BallotMode as FullBallotMode,
 } from '@votingworks/types';
+import { z } from 'zod';
 import { BatteryInfo } from '@votingworks/backend';
 import { UsbDriveStatus } from '@votingworks/usb-drive';
+
+export interface BarcodeScannerError {
+  error: string;
+}
+
+export const BarcodeScannerErrorSchema: z.ZodSchema<BarcodeScannerError> =
+  z.strictObject({ error: z.string() });
 
 export interface BallotPrintEntry extends EncodedBallotEntry {
   ballotPrintId: Id;

--- a/apps/print/backend/test/app.ts
+++ b/apps/print/backend/test/app.ts
@@ -39,6 +39,7 @@ import { getUserRole } from '../src/util/auth';
 import { createWorkspace, Workspace } from '../src/util/workspace';
 import { buildApp } from '../src/app';
 import { Api } from '../src';
+import { BarcodeScannerClient } from '../src/barcode_scanner/client';
 
 async function getFamousNamesBallotPdfBase64s(): Promise<
   readonly [string, string, string, string]
@@ -201,6 +202,7 @@ export function buildTestEnvironment(): {
     logger,
     usbDrive: mockUsbDrive.usbDrive,
     printer: mockPrinterHandler.printer,
+    barcodeScannerClient: new BarcodeScannerClient(logger),
   });
 
   // port 0 binds to a random, free port assigned by the OS

--- a/apps/print/backend/vitest.config.ts
+++ b/apps/print/backend/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 97,
-        branches: -8,
+        lines: 84,
+        branches: -33,
       },
       exclude: [
         '**/node_modules/**',

--- a/apps/print/barcode-scanner-daemon/Cargo.toml
+++ b/apps/print/barcode-scanner-daemon/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "print-barcode-scanner-daemon"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+
+[[bin]]
+name = "barcodescannerd"
+path = "src/cino_s680_daemon.rs"
+
+[dependencies]
+chrono = { workspace = true, features = ["serde"] }
+color-eyre = { workspace = true }
+nix = { workspace = true }
+nusb = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tokio-serial = { workspace = true }
+thiserror = { workspace = true }
+vx-logging = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+tokio-test = { workspace = true }
+
+[lints]
+workspace = true

--- a/apps/print/barcode-scanner-daemon/Makefile
+++ b/apps/print/barcode-scanner-daemon/Makefile
@@ -1,0 +1,9 @@
+# a phony dependency that can be used as a dependency to force builds
+FORCE:
+
+build: FORCE
+	mkdir -p target && cargo build --release --target-dir target/.
+
+run:
+	./target/release/barcodescannerd
+

--- a/apps/print/barcode-scanner-daemon/README.md
+++ b/apps/print/barcode-scanner-daemon/README.md
@@ -1,0 +1,56 @@
+# Cino Fuzzyscan S680 Barcode Scanner Daemon
+
+## Usage
+
+Running the first time requires [device configuration](#Device Configuration)
+and [permission configuration](#Permission Configuration).
+
+```
+make build
+make run
+```
+
+## Permission Configuration
+
+Add these `udev` rules to `/etc/udev/rules`. These will give the `plugdev` and
+`dialout` groups access to the barcode scanner device.
+
+```
+# /etc/udev/rules.d/70-plugdev-usb.rules
+# Needed for `nusb` crate to access device.
+SUBSYSTEM=="usb", MODE="0660", GROUP="plugdev", ATTRS{idVendor}=="1fbb", ATTRS{idProduct}=="3850"
+```
+
+```
+# /etc/udev/rules.d/99-cino-s680-barcode-scanner.rules
+# Creates a stable address for the serialport device at `/dev/barcode_scanner`. Needed for `serialport` crate to access device.
+SUBSYSTEM=="tty", ACTION=="add", KERNEL=="ttyACM[0-9]*", ATTRS{idVendor}=="1fbb", ATTRS{idProduct}=="3850", MODE="0660", GROUP="dialout", SYMLINK+="barcode_scanner"
+```
+
+Apply the `udev` rules:
+
+```
+sudo udevadm control --reload-rules && sudo udevadm trigger
+```
+
+Add your user to the `plugdev` and `dialout` groups:
+
+```
+sudo usermod -a -G plugdev $USER
+sudo usermod -a -G dialout $USER
+# Apply group changes, or log out and log in again
+su - $USER
+```
+
+## Overview
+
+At a high level the daemon
+
+1. Resets the device
+2. Connects to the device
+3. Opens a Unix domain socket (UDS) to communicate scan data to the app's `node`
+   backend
+4. Reads data from the device, parses to
+   [AAMVA](https://www.aamva.org/getmedia/99ac7057-0f4d-4461-b0a2-3a5532e1b35c/AAMVA-2020-DLID-Card-Design-Standard.pdf)
+   format, and writes serialized JSON to the UDS for consumption by the app
+   backend

--- a/apps/print/barcode-scanner-daemon/src/cino_s680_daemon.rs
+++ b/apps/print/barcode-scanner-daemon/src/cino_s680_daemon.rs
@@ -1,0 +1,383 @@
+use color_eyre::eyre::Context;
+use nusb::DeviceInfo;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{self, Error, ErrorKind};
+use std::os::unix::fs::PermissionsExt;
+use std::str::from_utf8;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::Mutex;
+use tokio::time::{sleep, Duration};
+use tokio_serial::{DataBits, FlowControl, Parity, SerialPortBuilderExt, SerialStream, StopBits};
+use vx_logging::{log, set_source, Disposition, EventId, EventType, Source};
+
+mod fsc_protocol;
+
+/*
+ * Logging config
+ */
+const SOURCE: Source = Source::VxPrintBarcodeScannerDaemon;
+/// How often the daemon logs its heartbeat.
+const HEARTBEAT_LOG_INTERVAL: Duration = Duration::from_secs(60);
+/// Interval for general polling
+const POLLING_INTERVAL: Duration = Duration::from_millis(1000);
+
+/*
+ * Unix domain socket config
+ */
+/// Path of the Unix domain socket used to communicate data between daemon and app backend.
+const UDS_PATH: &str = "/tmp/barcodescannerd.sock";
+
+/*
+ * Barcode scanner config
+ */
+/// Vendor ID for Fuzzyscan S680 barcode scanner manufacturer
+const CINO_VENDOR_ID: u16 = 0x1fbb;
+/// Product ID for Fuzzyscan S680 barcode scanner
+const FUZZYSCAN_S680_PRODUCT_ID: u16 = 0x3850;
+/// Path to serialport device as set by udev rule
+const S680_PORT_NAME: &str = "/dev/barcode_scanner";
+/// Default baud rate, used for connecting to serialport device
+const S680_BAUD_RATE: u32 = 115_200;
+/// Character at the end of each data chunk sent by the S680
+const S680_DATA_TERMINATOR: u8 = b'\r';
+
+#[derive(Serialize, Deserialize)]
+struct BallotStyleQrCode {
+    #[serde(rename = "ballotStyleId")]
+    ballot_style_id: String,
+}
+
+// Resets the S680 barcode scanner
+async fn reset_scanner(device: DeviceInfo) -> Result<(), nusb::Error> {
+    device.open()?.reset()?;
+    sleep(std::time::Duration::from_millis(500)).await;
+    Ok(())
+}
+
+// Connects to S680 barcode scanner
+async fn init_port(port_name: &str, baud_rate: u32) -> color_eyre::Result<SerialStream> {
+    match nusb::list_devices()?.find(|dev| {
+        dev.vendor_id() == CINO_VENDOR_ID && dev.product_id() == FUZZYSCAN_S680_PRODUCT_ID
+    }) {
+        Some(device) => {
+            // We have experienced difficulty reconnecting the scanner when the daemon
+            // is stopped and started multiple times. Resetting the scanner solves the issue.
+            // Configuration such as USB COM Port Emulation persists between resets.
+            // Wait because attempting reset immediately after connection can fail.
+            sleep(std::time::Duration::from_millis(1000)).await;
+            match reset_scanner(device).await {
+                Ok(()) => {
+                    log!(
+                        event_id: EventId::UsbDeviceReconnectAttempted,
+                        message: "Barcode scanner reset succeeded".to_owned(),
+                        event_type: EventType::SystemAction,
+                        disposition: Disposition::Success
+                    );
+                }
+                Err(err) => {
+                    log!(
+                        event_id: EventId::UsbDeviceReconnectAttempted,
+                        message: format!("Barcode scanner reset failed: {err}"),
+                        event_type: EventType::SystemAction,
+                        disposition: Disposition::Failure
+                    );
+                    return Err(err.into());
+                }
+            }
+
+            tokio_serial::new(port_name, baud_rate)
+                .data_bits(DataBits::Eight)
+                .parity(Parity::None)
+                .stop_bits(StopBits::One)
+                .flow_control(FlowControl::None)
+                .timeout(Duration::from_millis(500))
+                .open_native_async()
+                .with_context(|| format!("Failed to open serial port {port_name}"))
+        }
+        None => Err(Error::new(ErrorKind::NotFound, "No device found").into()),
+    }
+}
+
+#[derive(Serialize)]
+struct ErrorMessage {
+    error: String,
+}
+
+async fn write_json<T: Serialize>(stream: &mut UnixStream, value: &T) -> io::Result<()> {
+    let mut buf = Vec::new();
+    serde_json::to_writer(&mut buf, value)?;
+    buf.push(b'\n');
+
+    stream.write_all(&buf).await?;
+    stream.flush().await?;
+    Ok(())
+}
+
+/// Writes data to every client in the mutex. Drops any connections that error.
+async fn broadcast_to_clients<T: Serialize>(
+    clients: &Arc<Mutex<Vec<UnixStream>>>,
+    message: &T,
+) -> io::Result<()> {
+    let mut guard = clients.lock().await;
+
+    let streams = std::mem::take(&mut *guard);
+    drop(guard);
+
+    let mut alive = Vec::with_capacity(streams.len());
+    for mut stream in streams {
+        match write_json(&mut stream, message).await {
+            Ok(()) => alive.push(stream),
+            Err(err) => log!(
+                EventId::SocketClientDisconnected,
+                "Dropping unreachable UDS client due to error: {err}",
+            ),
+        }
+    }
+
+    let mut guard = clients.lock().await;
+    *guard = alive;
+    Ok(())
+}
+
+fn open_socket() -> Result<UnixListener, Error> {
+    // Unlink old socket if it exists
+    let _ = fs::remove_file(UDS_PATH);
+    // Assign address to socket
+    let listener = UnixListener::bind(UDS_PATH)?;
+    fs::set_permissions(UDS_PATH, fs::Permissions::from_mode(0o660))?;
+    log!(
+        event_id: EventId::SocketServerBind,
+        message: format!("UDS bound on {UDS_PATH}"),
+        disposition: Disposition::Success
+    );
+
+    Ok(listener)
+}
+
+/// Reads from any `BufRead`, parses QR code JSON, and writes JSON+"\n" to any Write.
+/// # Errors
+///
+/// Will return `Err` if an error occurs while reading from USB device.
+pub async fn run_read_write_loop<R>(
+    raw_port: R,
+    clients: Arc<Mutex<Vec<UnixStream>>>,
+) -> Result<(), Error>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    let mut buf = Vec::new();
+    let mut reader = BufReader::new(raw_port);
+
+    tokio::spawn(async move {
+        loop {
+            sleep(HEARTBEAT_LOG_INTERVAL).await;
+            log!(EventId::Heartbeat; EventType::SystemStatus);
+        }
+    });
+
+    loop {
+        buf.clear();
+
+        match reader.read_until(S680_DATA_TERMINATOR, &mut buf).await {
+            Ok(0) => {
+                // EOF; it's possible connection to scanner was lost
+                return Err(Error::new(ErrorKind::BrokenPipe, "Scanner disconnected"));
+            }
+            Ok(_) => {
+                buf.pop();
+
+                if buf.is_empty() {
+                    continue;
+                }
+
+                let str = match from_utf8(&buf) {
+                    Ok(str) => str,
+                    Err(e) => {
+                        log!(
+                            event_id: EventId::ParseError,
+                            message: format!("Error parsing read bytes as UTF-8: {e}")
+                        );
+                        continue;
+                    }
+                };
+
+                // Skip data with no '{' — can't be JSON. This silently discards
+                // scanner ACK packets sent in response to configuration commands
+                // (e.g. set_symbology_qr_code_only) that arrive in the read buffer
+                // before the first real scan.
+                let Some(json_start) = str.find('{') else {
+                    continue;
+                };
+                let json_str = &str[json_start..];
+
+                // Use Deserializer rather than from_str so trailing bytes after the
+                // first JSON object (e.g. the scanner's double-payload framing) are
+                // ignored instead of causing a parse error.
+                let mut de = serde_json::Deserializer::from_str(json_str);
+                match BallotStyleQrCode::deserialize(&mut de) {
+                    Ok(info) => {
+                        log!(
+                            event_id: EventId::BarcodeScanned,
+                            message: "QR code with BallotStyleQrCode successfully scanned"
+                                .to_owned(),
+                            event_type: EventType::SystemAction,
+                            disposition: Disposition::Success
+                        );
+                        if let Err(err) = broadcast_to_clients(&clients, &info).await {
+                            log!(
+                                EventId::SocketServerError,
+                                "Failed to write scan to clients: {err}"
+                            );
+                        }
+                    }
+                    Err(err) => {
+                        log!(
+                            event_id: EventId::ParseError,
+                            message: format!(
+                                "Failed to parse scanned data as BallotStyleQrCode: {err}"
+                            ),
+                            event_type: EventType::SystemAction,
+                            disposition: Disposition::Failure
+                        );
+                        let error = ErrorMessage {
+                            error: "unknown_document_type".to_owned(),
+                        };
+                        if let Err(err) = broadcast_to_clients(&clients, &error).await {
+                            log!(
+                                EventId::SocketServerError,
+                                "Failed to write parse error to clients: {err}"
+                            );
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                return Err(std::io::Error::new(
+                    e.kind(),
+                    format!("Error reading from USB device: {e}"),
+                ));
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> color_eyre::Result<()> {
+    color_eyre::install()?;
+
+    set_source(SOURCE);
+    log!(
+        EventId::ProcessStarted;
+        EventType::SystemAction
+    );
+
+    // Open Unix domain socket and get back a handle to the socket
+    let listener = open_socket()?;
+    // A task-safe list of all currently-connected clients
+    let clients = Arc::new(Mutex::new(Vec::<UnixStream>::new()));
+
+    // Spawn task to accept clients
+    tokio::spawn({
+        let clients = clients.clone();
+        async move {
+            loop {
+                if let Ok((stream, _addr)) = listener.accept().await {
+                    let mut guard = clients.lock().await;
+                    log!(EventId::SocketClientConnected);
+                    guard.push(stream);
+                }
+            }
+        }
+    });
+
+    let signal = tokio::signal::ctrl_c();
+    tokio::pin!(signal);
+
+    // Connect to barcode scanner device
+    loop {
+        // Race opening the port against user hitting ctrl+c
+        let maybe_port = tokio::select! {
+            port_result = init_port(S680_PORT_NAME, S680_BAUD_RATE) => {
+                Some(port_result)
+            }
+            _ = &mut signal => None,
+        };
+
+        let mut port = match maybe_port {
+            // If ctrl+c, exit
+            None => break,
+            // If couldn't get device, retry
+            Some(Err(e)) => {
+                log!(
+                    event_id: EventId::DeviceAttached,
+                    message: format!("Failed to connect to USB barcode scanner: {e}"),
+                    event_type: EventType::SystemStatus,
+                    disposition: Disposition::Failure
+                );
+                sleep(POLLING_INTERVAL).await;
+                continue;
+            }
+            // Successfully got device
+            Some(Ok(p)) => p,
+        };
+
+        log!(
+            event_id: EventId::DeviceAttached,
+            message: format!("Connected to S680 barcode scanner at {S680_PORT_NAME}..."),
+            event_type: EventType::SystemStatus,
+            disposition: Disposition::Success
+        );
+
+        // Configure scanner. These configurations are nice-to-have so failures
+        // are logged but don't stop execution
+        let mut scanner = fsc_protocol::Scanner::new(&mut port);
+
+        if let Err(e) = scanner.set_buzzer_volume_low().await {
+            log!(
+                event_id: EventId::Info,
+                message: format!("Failed to set buzzer volume: {e}"),
+                event_type: EventType::SystemAction,
+                disposition: Disposition::Failure
+            );
+        }
+
+        if let Err(e) = scanner.set_symbology_qr_code_only().await {
+            log!(
+                event_id: EventId::Info,
+                message: format!("Failed to set symbology to QR code: {e}"),
+                event_type: EventType::SystemAction,
+                disposition: Disposition::Failure
+            );
+        }
+
+        // Race infinite read/write loop against ctrl+c
+        let read_result = tokio::select! {
+            result = run_read_write_loop(port, clients.clone()) => Some(result),
+            _ = &mut signal => None,
+        };
+
+        match read_result {
+            Some(Ok(())) => log!(EventId::Info, "Read/write loop ended without error"),
+            Some(Err(err)) => {
+                // Wait if we error due to scanner disconnection, giving the OS time to clean up the device node.
+                // Reconnecting too quickly may result in attempting to open the stale serial port path of the device
+                // we just disconnected.
+                sleep(POLLING_INTERVAL).await;
+                log!(EventId::UnknownError, "Error in read/write loop: {err}");
+            }
+            None => break,
+        }
+    }
+
+    let _ = fs::remove_file(UDS_PATH);
+
+    log!(
+        EventId::ProcessTerminated;
+        EventType::SystemAction
+    );
+
+    Ok(())
+}

--- a/apps/print/barcode-scanner-daemon/src/fsc_protocol.rs
+++ b/apps/print/barcode-scanner-daemon/src/fsc_protocol.rs
@@ -1,0 +1,464 @@
+use std::io::Error;
+use tokio::io::AsyncWriteExt;
+use tokio::time::{sleep, Duration};
+use tokio_serial::SerialStream;
+
+/// `FuzzyScan` Serial Command packet delimiter (prefix and suffix)
+const FSC_PACKET_DELIMITER: u8 = 0x7E;
+
+/// Escape prefix for special characters in FSC protocol
+const FSC_ESCAPE_PREFIX: u8 = 0x5C;
+
+const COMMAND_DELAY: Duration = Duration::from_millis(100);
+
+trait FscEscape {
+    fn escape_push(&mut self, byte: u8);
+}
+
+/// Escape a byte if needed and push to buffer. Generally, in the command parameters
+/// we need to escape reserved byte sequences defined in FSC Manual p.12 "Escape Sequence".
+impl FscEscape for Vec<u8> {
+    fn escape_push(&mut self, byte: u8) {
+        match byte {
+            FSC_PACKET_DELIMITER => self.extend_from_slice(&[FSC_ESCAPE_PREFIX, 0x00]),
+            FSC_ESCAPE_PREFIX => self.extend_from_slice(&[FSC_ESCAPE_PREFIX, 0x01]),
+            0x06 => self.extend_from_slice(&[FSC_ESCAPE_PREFIX, 0x02]),
+            0x15 => self.extend_from_slice(&[FSC_ESCAPE_PREFIX, 0x03]),
+            0x11 => self.extend_from_slice(&[FSC_ESCAPE_PREFIX, 0x04]),
+            0x13 => self.extend_from_slice(&[FSC_ESCAPE_PREFIX, 0x05]),
+            _ => self.push(byte),
+        }
+    }
+}
+
+/// Build a `FuzzyScan` Serial Command packet
+fn build_command(opcode: [u8; 3], status: u8, parameters: &[u8]) -> Vec<u8> {
+    let length = u16::try_from(parameters.len())
+        .expect("Parameter length should be within bounds of max u16");
+    let length_bytes = [(length >> 8) as u8, (length & 0xFF) as u8];
+
+    // Calculate LRC: XOR of opcode, status, length, and parameters
+    let mut lrc: u8 = 0;
+    for &b in &opcode {
+        lrc ^= b;
+    }
+    lrc ^= status;
+    for &b in &length_bytes {
+        lrc ^= b;
+    }
+    for &b in parameters {
+        lrc ^= b;
+    }
+
+    // Prefix
+    let mut packet = vec![FSC_PACKET_DELIMITER];
+    // These bytes not escaped; we expect them to use the reserved byte sequences
+    packet.extend_from_slice(&opcode);
+    packet.push(status);
+
+    // Params etc. are escaped
+    for &b in &length_bytes {
+        packet.escape_push(b);
+    }
+    for &b in parameters {
+        packet.escape_push(b);
+    }
+    packet.escape_push(lrc);
+
+    packet.push(FSC_PACKET_DELIMITER); // Suffix
+    packet
+}
+
+/// Send a command to the scanner and wait for it to process
+async fn send_command(port: &mut SerialStream, command: &[u8]) -> Result<(), Error> {
+    port.write_all(command).await?;
+    port.flush().await?;
+    sleep(COMMAND_DELAY).await;
+    Ok(())
+}
+
+/// Commands that can be sent to the scanner
+pub mod commands {
+    use super::build_command;
+
+    /// Build a Buzzer Volume command to set volume to low
+    pub fn set_buzzer_volume_low() -> Vec<u8> {
+        let opcode = [0x80, 0x01, 0x03];
+        let parameters: &[u8] = &[0x00]; // Low volume
+        build_command(opcode, 0x00, parameters)
+    }
+
+    /// Build a command to enable QR Code and disable all other common symbologies
+    pub fn set_symbology_qr_code_only() -> Vec<u8> {
+        let opcode = [0x85, 0x00, 0x00];
+        let parameters: &[u8] = &[
+            // PDF417/MicroPDF417 - disable both
+            0x22, 0x00, // PID
+            0x00, 0x02, // Size: 2 bytes
+            0x00, 0x00, // Option: disable PDF417, disable MicroPDF417
+            //
+            // 1D barcodes
+            //
+            0x00, 0x00, 0x00, 0x01, 0x00, // Code 39 - disable
+            0x01, 0x00, 0x00, 0x01, 0x00, // Codabar - disable
+            0x02, 0x00, 0x00, 0x02, 0x00, 0x00, // UPC-A/UPC-E - disable both
+            0x03, 0x00, 0x00, 0x02, 0x00, 0x00, // EAN-13/EAN-8 - disable both
+            0x04, 0x02, 0x00, 0x01, 0x00, // Interleaved 2 of 5 - disable
+            0x06, 0x00, 0x00, 0x01, 0x00, // Code 93 - disable
+            0x08, 0x00, 0x00, 0x01, 0x00, // Code 128 - disable
+            0x08, 0x04, 0x00, 0x01, 0x00, // GS1-128 - disable
+            // 2D barcodes
+            // GS1 DataBar - disable (3-byte option)
+            0x20, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00,
+            //
+            // Enable QR code, disable other 2D barcodes
+            //
+            0x30, 0x00, 0x00, 0x01, 0x01, // QR Code - enable
+            0x30, 0x01, 0x00, 0x01, 0x01, // Micro QR Code - enable
+            0x31, 0x00, 0x00, 0x01, 0x00, // Data Matrix - disable
+            0x33, 0x00, 0x00, 0x01, 0x00, // Aztec Code - disable
+        ];
+        build_command(opcode, 0x00, parameters)
+    }
+}
+
+/// High-level scanner operations
+pub struct Scanner<'a> {
+    port: &'a mut SerialStream,
+}
+
+impl<'a> Scanner<'a> {
+    pub fn new(port: &'a mut SerialStream) -> Self {
+        Self { port }
+    }
+
+    /// Set buzzer volume to low
+    pub async fn set_buzzer_volume_low(&mut self) -> Result<(), Error> {
+        let command = commands::set_buzzer_volume_low();
+        send_command(self.port, &command).await
+    }
+
+    /// Set symbology to QR Code only, disabling all other common symbologies
+    pub async fn set_symbology_qr_code_only(&mut self) -> Result<(), Error> {
+        let command = commands::set_symbology_qr_code_only();
+        send_command(self.port, &command).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_push_does_not_escape_regular_bytes() {
+        let mut buf = Vec::new();
+        buf.escape_push(0x42);
+        assert_eq!(buf, vec![0x42]);
+    }
+
+    #[test]
+    fn escape_push_escapes_packet_delimiter() {
+        let mut buf = Vec::new();
+        buf.escape_push(FSC_PACKET_DELIMITER);
+        assert_eq!(buf, vec![FSC_ESCAPE_PREFIX, 0x00]);
+    }
+
+    #[test]
+    fn escape_push_escapes_escape_prefix() {
+        let mut buf = Vec::new();
+        buf.escape_push(FSC_ESCAPE_PREFIX);
+        assert_eq!(buf, vec![FSC_ESCAPE_PREFIX, 0x01]);
+    }
+
+    #[test]
+    fn escape_push_escapes_ack() {
+        let mut buf = Vec::new();
+        buf.escape_push(0x06);
+        assert_eq!(buf, vec![FSC_ESCAPE_PREFIX, 0x02]);
+    }
+
+    #[test]
+    fn escape_push_escapes_nak() {
+        let mut buf = Vec::new();
+        buf.escape_push(0x15);
+        assert_eq!(buf, vec![FSC_ESCAPE_PREFIX, 0x03]);
+    }
+
+    #[test]
+    fn escape_push_escapes_xon() {
+        let mut buf = Vec::new();
+        buf.escape_push(0x11);
+        assert_eq!(buf, vec![FSC_ESCAPE_PREFIX, 0x04]);
+    }
+
+    #[test]
+    fn escape_push_escapes_xoff() {
+        let mut buf = Vec::new();
+        buf.escape_push(0x13);
+        assert_eq!(buf, vec![FSC_ESCAPE_PREFIX, 0x05]);
+    }
+
+    #[test]
+    fn escape_push_appends_to_existing_buffer() {
+        let mut buf = vec![0x01, 0x02];
+        buf.escape_push(0x03);
+        assert_eq!(buf, vec![0x01, 0x02, 0x03]);
+    }
+
+    #[test]
+    fn escape_push_appends_escaped_sequence_to_existing_buffer() {
+        let mut buf = vec![0x01, 0x02];
+        buf.escape_push(FSC_PACKET_DELIMITER);
+        assert_eq!(buf, vec![0x01, 0x02, FSC_ESCAPE_PREFIX, 0x00]);
+    }
+
+    #[test]
+    fn build_command_starts_with_packet_delimiter() {
+        let packet = build_command([0x80, 0x00, 0x00], 0x00, &[]);
+        assert_eq!(packet[0], FSC_PACKET_DELIMITER);
+    }
+
+    #[test]
+    fn build_command_ends_with_packet_delimiter() {
+        let packet = build_command([0x80, 0x00, 0x00], 0x00, &[]);
+        assert_eq!(packet[packet.len() - 1], FSC_PACKET_DELIMITER);
+    }
+
+    #[test]
+    fn build_command_includes_opcode_after_prefix() {
+        let packet = build_command([0x85, 0x01, 0x03], 0x00, &[]);
+        assert_eq!(&packet[1..4], &[0x85, 0x01, 0x03]);
+    }
+
+    #[test]
+    fn build_command_includes_status_after_opcode() {
+        let packet = build_command([0x80, 0x00, 0x00], 0x04, &[]);
+        assert_eq!(packet[4], 0x04);
+    }
+
+    #[test]
+    fn build_command_includes_length_as_big_endian() {
+        let packet = build_command([0x80, 0x00, 0x00], 0x00, &[0xAA, 0xBB, 0xCC]);
+        assert_eq!(&packet[5..7], &[0x00, 0x03]);
+    }
+
+    #[test]
+    fn build_command_includes_parameters_after_length() {
+        let packet = build_command([0x80, 0x00, 0x00], 0x00, &[0xAA, 0xBB]);
+        assert_eq!(&packet[7..9], &[0xAA, 0xBB]);
+    }
+
+    #[test]
+    fn build_command_calculates_correct_lrc() {
+        // Known good from manual: Buzzer Volume Low
+        // LRC = 0x80 ^ 0x01 ^ 0x03 ^ 0x00 ^ 0x00 ^ 0x01 ^ 0x00 = 0x83
+        let packet = build_command([0x80, 0x01, 0x03], 0x00, &[0x00]);
+        let lrc_index = packet.len() - 2;
+        assert_eq!(packet[lrc_index], 0x83);
+    }
+
+    #[test]
+    fn build_command_escapes_special_bytes_in_parameters() {
+        let packet = build_command([0x80, 0x00, 0x00], 0x00, &[0x06]);
+        assert!(packet.windows(2).any(|w| w == [FSC_ESCAPE_PREFIX, 0x02]));
+    }
+
+    #[test]
+    fn build_command_escapes_special_bytes_in_lrc() {
+        // Craft a command where LRC equals 0x7E (packet delimiter)
+        // LRC = 0x7E ^ 0x00 ^ 0x00 ^ 0x00 ^ 0x00 = 0x7E
+        let packet = build_command([0x7E, 0x00, 0x00], 0x00, &[]);
+        let before_suffix = &packet[..packet.len() - 1];
+        assert!(
+            before_suffix.ends_with(&[FSC_ESCAPE_PREFIX, 0x00]),
+            "LRC 0x7E should be escaped"
+        );
+    }
+
+    #[test]
+    fn build_command_handles_empty_parameters() {
+        let packet = build_command([0x80, 0x03, 0x00], 0x00, &[]);
+        assert_eq!(&packet[5..7], &[0x00, 0x00]);
+    }
+
+    #[test]
+    fn set_buzzer_volume_low_matches_manual() {
+        let command = commands::set_buzzer_volume_low();
+        let expected = vec![0x7E, 0x80, 0x01, 0x03, 0x00, 0x00, 0x01, 0x00, 0x83, 0x7E];
+        assert_eq!(command, expected);
+    }
+
+    #[test]
+    fn set_symbology_qr_code_only_has_correct_framing() {
+        let command = commands::set_symbology_qr_code_only();
+        assert_eq!(command[0], FSC_PACKET_DELIMITER);
+        assert_eq!(command[command.len() - 1], FSC_PACKET_DELIMITER);
+    }
+
+    #[test]
+    fn set_symbology_qr_code_only_has_correct_opcode() {
+        let command = commands::set_symbology_qr_code_only();
+        assert_eq!(&command[1..4], &[0x85, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn set_symbology_qr_code_only_enables_qr() {
+        let command = commands::set_symbology_qr_code_only();
+        let qr_enable = [0x30, 0x00, 0x00, 0x01, 0x01];
+        assert!(
+            command.windows(qr_enable.len()).any(|w| w == qr_enable),
+            "Should contain QR Code enable sequence"
+        );
+    }
+
+    #[test]
+    fn set_symbology_qr_code_only_enables_micro_qr() {
+        let command = commands::set_symbology_qr_code_only();
+        let micro_qr_enable = [0x30, 0x01, 0x00, 0x01, 0x01];
+        assert!(
+            command
+                .windows(micro_qr_enable.len())
+                .any(|w| w == micro_qr_enable),
+            "Should contain Micro QR Code enable sequence"
+        );
+    }
+
+    #[test]
+    fn set_symbology_qr_code_only_disables_pdf417() {
+        let command = commands::set_symbology_qr_code_only();
+        let pdf417_disable = [0x22, 0x00, 0x00, 0x02, 0x00, 0x00];
+        assert!(
+            command
+                .windows(pdf417_disable.len())
+                .any(|w| w == pdf417_disable),
+            "Should contain PDF417 disable sequence"
+        );
+    }
+
+    #[test]
+    fn set_symbology_qr_code_only_disables_code39() {
+        let command = commands::set_symbology_qr_code_only();
+        let code39_disable = [0x00, 0x00, 0x00, 0x01, 0x00];
+        assert!(
+            command
+                .windows(code39_disable.len())
+                .any(|w| w == code39_disable),
+            "Should contain Code 39 disable sequence"
+        );
+    }
+
+    #[test]
+    fn set_symbology_qr_code_only_disables_codabar() {
+        let command = commands::set_symbology_qr_code_only();
+        let codabar_disable = [0x01, 0x00, 0x00, 0x01, 0x00];
+        assert!(
+            command
+                .windows(codabar_disable.len())
+                .any(|w| w == codabar_disable),
+            "Should contain Codabar disable sequence"
+        );
+    }
+
+    #[test]
+    fn set_symbology_qr_code_only_disables_upc() {
+        let command = commands::set_symbology_qr_code_only();
+        let upc_disable = [0x02, 0x00, 0x00, 0x02, 0x00, 0x00];
+        assert!(
+            command.windows(upc_disable.len()).any(|w| w == upc_disable),
+            "Should contain UPC disable sequence"
+        );
+    }
+
+    #[test]
+    fn set_symbology_qr_code_only_disables_ean() {
+        let command = commands::set_symbology_qr_code_only();
+        let ean_disable = [0x03, 0x00, 0x00, 0x02, 0x00, 0x00];
+        assert!(
+            command.windows(ean_disable.len()).any(|w| w == ean_disable),
+            "Should contain EAN disable sequence"
+        );
+    }
+
+    #[test]
+    fn set_symbology_qr_code_only_disables_interleaved_2of5() {
+        let command = commands::set_symbology_qr_code_only();
+        let i2of5_disable = [0x04, 0x02, 0x00, 0x01, 0x00];
+        assert!(
+            command
+                .windows(i2of5_disable.len())
+                .any(|w| w == i2of5_disable),
+            "Should contain Interleaved 2 of 5 disable sequence"
+        );
+    }
+
+    #[test]
+    fn set_symbology_qr_code_only_disables_code93() {
+        let command = commands::set_symbology_qr_code_only();
+        // 0x06 gets escaped to [0x5C, 0x02]
+        let code93_disable = [0x5C, 0x02, 0x00, 0x00, 0x01, 0x00];
+        assert!(
+            command
+                .windows(code93_disable.len())
+                .any(|w| w == code93_disable),
+            "Should contain Code 93 disable sequence"
+        );
+    }
+
+    #[test]
+    fn set_symbology_qr_code_only_disables_code128() {
+        let command = commands::set_symbology_qr_code_only();
+        let code128_disable = [0x08, 0x00, 0x00, 0x01, 0x00];
+        assert!(
+            command
+                .windows(code128_disable.len())
+                .any(|w| w == code128_disable),
+            "Should contain Code 128 disable sequence"
+        );
+    }
+
+    #[test]
+    fn set_symbology_qr_code_only_disables_gs1_128() {
+        let command = commands::set_symbology_qr_code_only();
+        let gs1_128_disable = [0x08, 0x04, 0x00, 0x01, 0x00];
+        assert!(
+            command
+                .windows(gs1_128_disable.len())
+                .any(|w| w == gs1_128_disable),
+            "Should contain GS1-128 disable sequence"
+        );
+    }
+
+    #[test]
+    fn set_symbology_qr_code_only_disables_gs1_databar() {
+        let command = commands::set_symbology_qr_code_only();
+        let gs1_databar_disable = [0x20, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00];
+        assert!(
+            command
+                .windows(gs1_databar_disable.len())
+                .any(|w| w == gs1_databar_disable),
+            "Should contain GS1 DataBar disable sequence"
+        );
+    }
+
+    #[test]
+    fn set_symbology_qr_code_only_disables_data_matrix() {
+        let command = commands::set_symbology_qr_code_only();
+        let dm_disable = [0x31, 0x00, 0x00, 0x01, 0x00];
+        assert!(
+            command.windows(dm_disable.len()).any(|w| w == dm_disable),
+            "Should contain Data Matrix disable sequence"
+        );
+    }
+
+    #[test]
+    fn set_symbology_qr_code_only_disables_aztec() {
+        let command = commands::set_symbology_qr_code_only();
+        let aztec_disable = [0x33, 0x00, 0x00, 0x01, 0x00];
+        assert!(
+            command
+                .windows(aztec_disable.len())
+                .any(|w| w == aztec_disable),
+            "Should contain Aztec Code disable sequence"
+        );
+    }
+}

--- a/apps/print/frontend/src/api.ts
+++ b/apps/print/frontend/src/api.ts
@@ -321,6 +321,20 @@ export const exportBallotsPrintedReportPdf = {
   },
 } as const;
 
+export const BARCODE_SCANNER_POLLING_INTERVAL_MS = 250;
+
+export const getLastBarcodePayload = {
+  queryKey(): QueryKey {
+    return ['getLastBarcodePayload'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () => apiClient.getLastBarcodePayload(), {
+      refetchInterval: BARCODE_SCANNER_POLLING_INTERVAL_MS,
+    });
+  },
+} as const;
+
 export const systemCallApi = createSystemCallApi(useApiClient);
 
 export const getMostRecentPrinterDiagnostic = {

--- a/apps/print/frontend/src/components/expanded_select.tsx
+++ b/apps/print/frontend/src/components/expanded_select.tsx
@@ -104,12 +104,14 @@ export function ExpandedSelect({
   options,
   onSelect,
   onSearch,
+  searchValue,
   style,
 }: {
   selectedValue: string;
   options: Array<{ value: string; label: string }>;
   onSelect: (selected: string) => void;
   onSearch?: (value: string) => void;
+  searchValue?: string;
   style?: React.CSSProperties;
 }): JSX.Element {
   const optionListRef = useRef<HTMLDivElement>(null);
@@ -144,11 +146,11 @@ export function ExpandedSelect({
             // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              const newSearchString = (event.target.value || '').trim();
-              onSearch(newSearchString);
+              onSearch(event.target.value || '');
             }}
             placeholder="Search"
             type="text"
+            value={searchValue}
           />
         </SearchBox>
       )}

--- a/apps/print/frontend/src/poll_worker_app.tsx
+++ b/apps/print/frontend/src/poll_worker_app.tsx
@@ -1,17 +1,50 @@
-import { Redirect, Route, Switch } from 'react-router-dom';
-import React from 'react';
+import { Redirect, Route, Switch, useHistory } from 'react-router-dom';
+import React, { useState, useEffect, useCallback } from 'react';
 import { PrintScreen } from './screens/print_screen';
 import { ReportScreen } from './screens/report_screen';
 import { pollWorkerRoutes } from './routes';
 import { PrinterAlertWrapper } from './components/printer_alert_wrapper';
+import { getLastBarcodePayload } from './api';
 
 export function PollWorkerApp(): JSX.Element {
+  const history = useHistory();
+  const lastBarcodePayloadQuery = getLastBarcodePayload.useQuery();
+  const [pendingBarcodeScan, setPendingBarcodeScan] = useState<
+    string | undefined
+  >();
+
+  useEffect(() => {
+    const result = lastBarcodePayloadQuery.data;
+    if (!result) {
+      return;
+    }
+    if (result.isErr()) {
+      return;
+    }
+    const info = result.ok();
+    if (!info) {
+      return;
+    }
+
+    setPendingBarcodeScan(info);
+  }, [lastBarcodePayloadQuery.data, history]);
+
+  const onBarcodeScanConsumed = useCallback(
+    () => setPendingBarcodeScan(undefined),
+    []
+  );
+
   return (
     <React.Fragment>
       <Switch>
         <Route
           path={pollWorkerRoutes.print.path}
-          render={() => <PrintScreen />}
+          render={() => (
+            <PrintScreen
+              pendingBarcodeScan={pendingBarcodeScan}
+              onBarcodeScanConsumed={onBarcodeScanConsumed}
+            />
+          )}
         />
         <Route
           path={pollWorkerRoutes.reports.path}

--- a/apps/print/frontend/src/screens/print_screen.tsx
+++ b/apps/print/frontend/src/screens/print_screen.tsx
@@ -1,14 +1,16 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 
 import {
   BooleanEnvironmentVariableName as Feature,
   format,
   getLanguageOptions,
+  getPrecinctsAndSplitsForBallotStyle,
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
 import {
   BallotType,
+  getBallotStyle,
   hasSplits,
   Id,
   LanguageCode,
@@ -120,8 +122,12 @@ const PrintButton = styled(Button)`
 
 export function PrintScreen({
   isElectionManagerAuth,
+  pendingBarcodeScan,
+  onBarcodeScanConsumed,
 }: {
   isElectionManagerAuth?: boolean;
+  pendingBarcodeScan?: string;
+  onBarcodeScanConsumed?: () => void;
 }): JSX.Element | null {
   const [numCopies, setNumCopies] = useState(1);
   const [searchValue, setSearchValue] = useState<string>('');
@@ -141,6 +147,48 @@ export function PrintScreen({
   const pollingPlaceId = getPollingPlaceId.useQuery().data;
 
   const [isShowingPrintingModal, setIsShowingPrintingModal] = useState(false);
+
+  useEffect(() => {
+    if (!pendingBarcodeScan) {
+      return;
+    }
+    const electionRecord = getElectionRecordQuery.data;
+    if (!electionRecord) {
+      return;
+    }
+
+    const { election } = electionRecord.electionDefinition;
+    const ballotStyle = getBallotStyle({
+      ballotStyleId: pendingBarcodeScan,
+      election,
+    });
+    if (!ballotStyle) {
+      return;
+    }
+
+    const [precinctOrSplit] = getPrecinctsAndSplitsForBallotStyle({
+      election,
+      ballotStyle,
+    });
+    const precinctId = precinctOrSplit?.precinct.id ?? ballotStyle.precincts[0];
+    const splitId = precinctOrSplit?.split?.id ?? '';
+    const precinct = precinctId
+      ? election.precincts.find((p) => p.id === precinctId)
+      : undefined;
+    setSelectedPrecinctId(precinctId ?? '');
+    setSearchValue(precinct?.name ?? '');
+    setSelectedSplitId(splitId);
+
+    if (ballotStyle.partyId) {
+      setSelectedPartyId(ballotStyle.partyId);
+    }
+
+    if (ballotStyle.languages?.[0]) {
+      setSelectedLanguageCode(ballotStyle.languages[0] as LanguageCode);
+    }
+
+    onBarcodeScanConsumed?.();
+  }, [pendingBarcodeScan, getElectionRecordQuery.data, onBarcodeScanConsumed]);
 
   const precincts = React.useMemo(() => {
     if (!getElectionRecordQuery.data) return [];
@@ -246,11 +294,15 @@ export function PrintScreen({
                   .filter(
                     (p) =>
                       !searchValue ||
-                      p.name.toLowerCase().includes(searchValue.toLowerCase())
+                      p.name
+                        .toLowerCase()
+                        .includes(searchValue.trim().toLowerCase())
                   )
                   .map((p) => ({ value: p.id, label: p.name }))}
+                searchValue={searchValue}
                 onSearch={setSearchValue}
                 onSelect={(value) => {
+                  setSearchValue('');
                   if (value !== selectedPrecinctId) {
                     setSelectedPrecinctId(value);
                     setSelectedSplitId('');

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -100,6 +100,9 @@ source = 'vx-pollbook-backend'
 [LogSources.VxPollBookBarcodeScannerDaemon]
 source = 'vx-pollbook-barcode-scanner-daemon'
 
+[LogSources.VxPrintBarcodeScannerDaemon]
+source = 'vx-print-barcode-scanner-daemon'
+
 [LogSources.VxPrintFrontend]
 source = 'vx-print-frontend'
 

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -55,6 +55,7 @@ export enum LogSource {
   VxPollBookFrontend = 'vx-pollbook-frontend',
   VxPollBookBackend = 'vx-pollbook-backend',
   VxPollBookBarcodeScannerDaemon = 'vx-pollbook-barcode-scanner-daemon',
+  VxPrintBarcodeScannerDaemon = 'vx-print-barcode-scanner-daemon',
   VxPrintFrontend = 'vx-print-frontend',
   VxPrintBackend = 'vx-print-backend',
 }

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -89,6 +89,8 @@ pub enum Source {
     VxPollBookBackend,
     #[serde(rename = "vx-pollbook-barcode-scanner-daemon")]
     VxPollBookBarcodeScannerDaemon,
+    #[serde(rename = "vx-print-barcode-scanner-daemon")]
+    VxPrintBarcodeScannerDaemon,
     #[serde(rename = "vx-print-frontend")]
     VxPrintFrontend,
     #[serde(rename = "vx-print-backend")]

--- a/libs/types/src/print.ts
+++ b/libs/types/src/print.ts
@@ -1,5 +1,16 @@
+import z from 'zod/v4';
 import { Id } from './generic';
 import { LanguageCode } from './language_code';
+
+export interface BallotStyleQrCode {
+  ballotStyleId: string;
+}
+
+export const BallotStyleQrCodeSchema: z.ZodSchema<BallotStyleQrCode> = z.object(
+  {
+    ballotStyleId: z.string(),
+  }
+);
 
 export interface BallotPrintCount {
   ballotStyleId: Id;


### PR DESCRIPTION
## Overview

Proof of concept for https://github.com/votingworks/vxsuite/issues/7900

Adds support for the Cino barcode scanner in VxPrint. The implementation expects a QR code with encoded data in the format `{"ballotStyleId":"<ballot style ID>"}` eg. `{"ballotStyleId":"3-Li_en"}` where `Li` is party abbreviation and `en` is language code.

## Demo Video or Screenshot

See https://votingworks.slack.com/archives/CEL6D3GAD/p1780078934726619?thread_ts=1780002630.402699&cid=CEL6D3GAD

## Testing Plan

Manual testing