### PR TITLE
[VxAdmin] Multi-Station Mode switch - tweak restart button ui

### DIFF
--- a/apps/admin/frontend/src/client/screens/client_settings_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_settings_screen.test.tsx
@@ -144,8 +144,7 @@ test('shows restart screen after switching to host mode', async () => {
   });
   apiMock.apiClient.setMachineMode.expectCallWith({ mode: 'host' }).resolves();
   userEvent.click(switchButton);
-  await screen.findByText(
-    'VxAdmin switched to host mode. Restart VxAdmin to continue.'
-  );
+  await screen.findByText(/VxAdmin switched to host mode\./);
+  screen.getByText(/Restart VxAdmin to continue\./);
   screen.getByRole('button', { name: 'Restart' });
 });

--- a/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
@@ -89,16 +89,15 @@ export function ClientSettingsScreen(): JSX.Element | null {
       <Screen>
         <Main centerChild>
           <FullScreenMessage title="VxAdmin switched to host mode. Restart VxAdmin to continue.">
-            <P align="center">
-              <Button
-                onPress={
-                  /* istanbul ignore next - no-op in tests */
-                  () => rebootMutation.mutate()
-                }
-              >
-                Restart
-              </Button>
-            </P>
+            <Button
+              variant="primary"
+              onPress={
+                /* istanbul ignore next - no-op in tests @preserve */
+                () => rebootMutation.mutate()
+              }
+            >
+              Restart
+            </Button>
           </FullScreenMessage>
         </Main>
       </Screen>

--- a/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
@@ -108,7 +108,7 @@ export function ClientSettingsScreen(): JSX.Element | null {
               <Button
                 variant="primary"
                 onPress={
-                  /* istanbul ignore next - no-op in tests @preserve */
+                  /* istanbul ignore next - no-op in tests */
                   () => rebootMutation.mutate()
                 }
               >

--- a/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
@@ -4,10 +4,12 @@ import {
   CurrentDateAndTime,
   ExportLogsButton,
   FormatUsbButton,
+  FullScreenIconWrapper,
   FullScreenMessage,
   H2,
   Icons,
   Main,
+  MainContent,
   P,
   Screen,
   SetClockButton,
@@ -87,18 +89,33 @@ export function ClientSettingsScreen(): JSX.Element | null {
   if (setMachineModeMutation.isSuccess) {
     return (
       <Screen>
-        <Main centerChild>
-          <FullScreenMessage title="VxAdmin switched to host mode. Restart VxAdmin to continue.">
-            <Button
-              variant="primary"
-              onPress={
-                /* istanbul ignore next - no-op in tests @preserve */
-                () => rebootMutation.mutate()
+        <Main flexColumn>
+          <MainContent style={{ display: 'flex', justifyContent: 'center' }}>
+            <FullScreenMessage
+              title={
+                <React.Fragment>
+                  VxAdmin switched to host mode.
+                  <br />
+                  Restart VxAdmin to continue.
+                </React.Fragment>
+              }
+              image={
+                <FullScreenIconWrapper>
+                  <Icons.Rotate />
+                </FullScreenIconWrapper>
               }
             >
-              Restart
-            </Button>
-          </FullScreenMessage>
+              <Button
+                variant="primary"
+                onPress={
+                  /* istanbul ignore next - no-op in tests @preserve */
+                  () => rebootMutation.mutate()
+                }
+              >
+                Restart
+              </Button>
+            </FullScreenMessage>
+          </MainContent>
         </Main>
       </Screen>
     );

--- a/apps/admin/frontend/src/screens/settings_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.test.tsx
@@ -180,9 +180,8 @@ describe('multi-station mode', () => {
         name: 'Switch to Adjudication Station Mode',
       })
     );
-    await screen.findByText(
-      'VxAdmin switched to adjudication station mode. Restart VxAdmin to continue.'
-    );
+    await screen.findByText(/VxAdmin switched to adjudication station mode\./);
+    screen.getByText(/Restart VxAdmin to continue\./);
     screen.getByRole('button', { name: 'Restart' });
   });
 });

--- a/apps/admin/frontend/src/screens/settings_screen.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.tsx
@@ -45,16 +45,15 @@ export function SettingsScreen(): JSX.Element | null {
       <Screen>
         <Main centerChild>
           <FullScreenMessage title="VxAdmin switched to adjudication station mode. Restart VxAdmin to continue.">
-            <P align="center">
-              <Button
-                onPress={
-                  /* istanbul ignore next - no-op in tests */
-                  () => rebootMutation.mutate()
-                }
-              >
-                Restart
-              </Button>
-            </P>
+            <Button
+              variant="primary"
+              onPress={
+                /* istanbul ignore next - no-op in tests @preserve */
+                () => rebootMutation.mutate()
+              }
+            >
+              Restart
+            </Button>
           </FullScreenMessage>
         </Main>
       </Screen>

--- a/apps/admin/frontend/src/screens/settings_screen.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.tsx
@@ -4,10 +4,12 @@ import {
   CurrentDateAndTime,
   ExportLogsButton,
   FormatUsbButton,
+  FullScreenIconWrapper,
   FullScreenMessage,
   H2,
   Icons,
   Main,
+  MainContent,
   P,
   Screen,
   SetClockButton,
@@ -43,18 +45,33 @@ export function SettingsScreen(): JSX.Element | null {
   if (setMachineModeMutation.isSuccess) {
     return (
       <Screen>
-        <Main centerChild>
-          <FullScreenMessage title="VxAdmin switched to adjudication station mode. Restart VxAdmin to continue.">
-            <Button
-              variant="primary"
-              onPress={
-                /* istanbul ignore next - no-op in tests @preserve */
-                () => rebootMutation.mutate()
+        <Main flexColumn>
+          <MainContent style={{ display: 'flex', justifyContent: 'center' }}>
+            <FullScreenMessage
+              title={
+                <React.Fragment>
+                  VxAdmin switched to adjudication station mode.
+                  <br />
+                  Restart VxAdmin to continue.
+                </React.Fragment>
+              }
+              image={
+                <FullScreenIconWrapper>
+                  <Icons.Rotate />
+                </FullScreenIconWrapper>
               }
             >
-              Restart
-            </Button>
-          </FullScreenMessage>
+              <Button
+                variant="primary"
+                onPress={
+                  /* istanbul ignore next - no-op in tests @preserve */
+                  () => rebootMutation.mutate()
+                }
+              >
+                Restart
+              </Button>
+            </FullScreenMessage>
+          </MainContent>
         </Main>
       </Screen>
     );

--- a/apps/admin/frontend/src/screens/settings_screen.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.tsx
@@ -64,7 +64,7 @@ export function SettingsScreen(): JSX.Element | null {
               <Button
                 variant="primary"
                 onPress={
-                  /* istanbul ignore next - no-op in tests @preserve */
+                  /* istanbul ignore next - n-op in tests */
                   () => rebootMutation.mutate()
                 }
               >


### PR DESCRIPTION
## Overview
Redesigns layout and button placement of machine mode change restart screen. See screenshots. 

## Demo Video or Screenshot
Before
<img width="995" height="629" alt="Screenshot 2026-06-01 at 10 54 00 AM" src="https://github.com/user-attachments/assets/0bfd22da-0b47-4df5-b90c-4e915d399211" />

After

<img width="991" height="636" alt="Screenshot 2026-06-01 at 1 54 34 PM" src="https://github.com/user-attachments/assets/cae6ad91-96c9-426f-b210-72aa4592493d" />

<img width="981" height="614" alt="Screenshot 2026-06-01 at 1 58 36 PM" src="https://github.com/user-attachments/assets/9c559207-c2d0-408f-9923-c077b73c3237" />


## Testing Plan
See above

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
