### PR TITLE
[VxAdmin] Client - Add network status indicator to lock screen

### DIFF
--- a/apps/admin/frontend/src/client/client_app_root.test.tsx
+++ b/apps/admin/frontend/src/client/client_app_root.test.tsx
@@ -103,33 +103,75 @@ test('shows setup card reader page when no card reader', async () => {
   await screen.findByText('Card Reader Not Detected');
 });
 
-test('shows locked screen when machine is locked without election', async () => {
+test('warns when connected to an unconfigured host', async () => {
   apiMock.setAuthStatus({
     status: 'logged_out',
     reason: 'machine_locked',
   });
+  apiMock.expectGetNetworkConnectionStatus('online-connected-to-host');
   renderClientApp();
   await screen.findByText('Adjudication Station Locked');
   await screen.findByText('Insert system administrator card to unlock.');
+  await screen.findByText('The host is not configured with an election');
+  expect(screen.queryByTestId('electionInfoBar')).toBeNull();
 });
 
-test('shows locked screen with election info when election is loaded', async () => {
+test('shows election info when connected to a configured host', async () => {
   apiMock.setAuthStatus({
     status: 'logged_out',
     reason: 'machine_locked',
   });
+  apiMock.expectGetNetworkConnectionStatus('online-connected-to-host');
   renderClientApp({ withElection: true });
   await screen.findByText('Adjudication Station Locked');
-  screen.getByText(electionDefinition.election.title);
+  const electionInfo = await screen.findByTestId('electionInfoBar');
+  within(electionInfo).getByText(electionDefinition.election.title);
 });
 
-test('shows locked screen on session expiry', async () => {
+test('warns when no host is detected', async () => {
+  apiMock.setAuthStatus({
+    status: 'logged_out',
+    reason: 'machine_locked',
+  });
+  apiMock.expectGetNetworkConnectionStatus('online-waiting-for-host');
+  renderClientApp({ withElection: true });
+  await screen.findByText('Adjudication Station Locked');
+  await screen.findByText('No host detected');
+});
+
+test('warns when multiple hosts detected', async () => {
+  apiMock.setAuthStatus({
+    status: 'logged_out',
+    reason: 'machine_locked',
+  });
+  apiMock.expectGetNetworkConnectionStatus('online-multiple-hosts-detected');
+  renderClientApp();
+  await screen.findByText('Adjudication Station Locked');
+  await screen.findByText('Multiple hosts detected on the network');
+});
+
+test('warns when host has incompatible software version', async () => {
+  apiMock.setAuthStatus({
+    status: 'logged_out',
+    reason: 'machine_locked',
+  });
+  apiMock.expectGetNetworkConnectionStatus('online-incompatible-host-version');
+  renderClientApp();
+  await screen.findByText('Adjudication Station Locked');
+  await screen.findByText(
+    /software version of this adjudication station does not match/
+  );
+});
+
+test('warns when there is no network connection', async () => {
   apiMock.setAuthStatus({
     status: 'logged_out',
     reason: 'machine_locked_by_session_expiry',
   });
+  apiMock.expectGetNetworkConnectionStatus('offline');
   renderClientApp();
   await screen.findByText('Adjudication Station Locked');
+  await screen.findByText('No network connection');
 });
 
 test('shows invalid card screen without election', async () => {
@@ -250,6 +292,7 @@ test('logout while on a ballot adjudication URL replaces it with the home route'
   window.history.replaceState({}, '', '/adjudication/ballots');
 
   setPollWorkerAuth();
+  apiMock.expectGetNetworkConnectionStatus('online-connected-to-host');
   renderClientApp({ withElection: true });
   await screen.findByText('mock ballot adjudication screen');
 

--- a/apps/admin/frontend/src/client/components/unconfigured_network_status_indicator.tsx
+++ b/apps/admin/frontend/src/client/components/unconfigured_network_status_indicator.tsx
@@ -1,0 +1,66 @@
+import { Icons } from '@votingworks/ui';
+import styled from 'styled-components';
+import { throwIllegalValue } from '@votingworks/basics';
+import type { NetworkConnectionStatus } from '@votingworks/admin-backend';
+
+const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  align-items: center;
+`;
+
+/**
+ * Surfaces why an adjudication station isn't ready to adjudicate. Only meant
+ * to render when something needs the user's attention
+ *
+ * For the `online-connected-to-host` status this assumes the host has no
+ * election configured.
+ */
+export function UnconfiguredNetworkStatusIndicator({
+  status,
+}: {
+  status: NetworkConnectionStatus;
+}): JSX.Element {
+  switch (status.status) {
+    case 'online-connected-to-host':
+      return (
+        <Row>
+          <Icons.Warning color="warning" />
+          The host is not configured with an election
+        </Row>
+      );
+    case 'online-waiting-for-host':
+      return (
+        <Row>
+          <Icons.Warning color="warning" />
+          No host detected
+        </Row>
+      );
+    case 'online-multiple-hosts-detected':
+      return (
+        <Row>
+          <Icons.Danger color="danger" />
+          Multiple hosts detected on the network
+        </Row>
+      );
+    case 'online-incompatible-host-version':
+      return (
+        <Row>
+          <Icons.Danger color="danger" />
+          The software version of this adjudication station does not match the
+          software version of the host
+        </Row>
+      );
+    case 'offline':
+      return (
+        <Row>
+          <Icons.Danger color="danger" />
+          No network connection
+        </Row>
+      );
+    default:
+      /* istanbul ignore next  - @preserve */
+      throwIllegalValue(status);
+  }
+}

--- a/apps/admin/frontend/src/client/screens/client_machine_locked_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_machine_locked_screen.tsx
@@ -1,7 +1,16 @@
 import { useContext } from 'react';
 import styled from 'styled-components';
-import { ElectionInfoBar, Main, Screen, H1, H3 } from '@votingworks/ui';
+import {
+  ElectionInfoBar,
+  InfoBar,
+  Main,
+  Screen,
+  H1,
+  H3,
+} from '@votingworks/ui';
 import { AppContext } from '../../contexts/app_context';
+import { getNetworkConnectionStatus } from '../api';
+import { UnconfiguredNetworkStatusIndicator } from '../components/unconfigured_network_status_indicator';
 
 const LockedImage = styled.img`
   margin-right: auto;
@@ -10,9 +19,36 @@ const LockedImage = styled.img`
   height: 20vw;
 `;
 
-export function ClientMachineLockedScreen(): JSX.Element {
+function LockScreenFooter(): JSX.Element | null {
   const { electionDefinition, electionPackageHash, machineConfig } =
     useContext(AppContext);
+  const networkStatusQuery = getNetworkConnectionStatus.useQuery();
+  if (!networkStatusQuery.isSuccess) return null;
+
+  const status = networkStatusQuery.data;
+  // When connected to a configured host, surface the election info instead
+  // of the network indicator — the connection itself is implied by the
+  // election data being present.
+  if (status.status === 'online-connected-to-host' && electionDefinition) {
+    return (
+      <ElectionInfoBar
+        mode="admin"
+        electionDefinition={electionDefinition}
+        electionPackageHash={electionPackageHash}
+        codeVersion={machineConfig.codeVersion}
+        machineId={machineConfig.machineId}
+      />
+    );
+  }
+  return (
+    <InfoBar>
+      <UnconfiguredNetworkStatusIndicator status={status} />
+    </InfoBar>
+  );
+}
+
+export function ClientMachineLockedScreen(): JSX.Element {
+  const { electionDefinition } = useContext(AppContext);
   return (
     <Screen>
       <Main centerChild>
@@ -26,13 +62,7 @@ export function ClientMachineLockedScreen(): JSX.Element {
           </H3>
         </div>
       </Main>
-      <ElectionInfoBar
-        mode="admin"
-        electionDefinition={electionDefinition}
-        electionPackageHash={electionPackageHash}
-        codeVersion={machineConfig.codeVersion}
-        machineId={machineConfig.machineId}
-      />
+      <LockScreenFooter />
     </Screen>
   );
 }


### PR DESCRIPTION
## Overview
Adds a network indication line on the client lock screen when the client is not configured for an election. If the client is configured for an election they are inherently connected to a properly configured host and the election information replaces this information in the footer. 

## Demo Video or Screenshot
<img width="975" height="617" alt="Screenshot 2026-06-01 at 11 27 04 AM" src="https://github.com/user-attachments/assets/03ca7ca1-6dde-4d47-ac98-8a78aafbb065" />
<img width="971" height="614" alt="Screenshot 2026-06-01 at 11 26 40 AM" src="https://github.com/user-attachments/assets/1b5bbfb3-c83b-4882-b70a-72bece29f858" />
<img width="986" height="621" alt="Screenshot 2026-06-01 at 10 49 31 AM" src="https://github.com/user-attachments/assets/b0b8c472-d157-44e5-8de1-7747149a9839" />
<img width="985" height="633" alt="Screenshot 2026-06-01 at 10 48 47 AM" src="https://github.com/user-attachments/assets/65ccea9b-98f7-4253-961b-cd5a7975fb53" />
<img width="981" height="623" alt="Screenshot 2026-06-01 at 10 47 42 AM" src="https://github.com/user-attachments/assets/33cfccfb-4e6b-4270-b55b-1dcd4eb87582" />

## Testing Plan
See above

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
