### PR TITLE
feat(usb-drive): allow single-drive view interactions with non-FAT32 drives

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -66,6 +66,7 @@ import {
   readElection,
 } from '@votingworks/fs';
 import {
+  isFat32Partition,
   MultiUsbDrive,
   REAL_USB_DRIVE_GLOB_PATTERN,
   UsbDriveStatus,
@@ -204,8 +205,8 @@ function buildApi({
 
   const usbDriveAdapter = createUsbDriveAdapter(
     multiUsbDrive,
-    // return the first drive
-    (drives) => drives[0]?.devPath
+    // return the first FAT32 drive
+    (drives) => drives.find((d) => isFat32Partition(d.partitions[0]))?.devPath
   );
 
   function convertFrontendFilter(
@@ -390,7 +391,7 @@ function buildApi({
       }
 
       try {
-        await usbDriveAdapter.format();
+        await usbDriveAdapter.format('fat32');
         return ok();
       } catch (error) {
         return err(error as Error);

--- a/apps/admin/backend/src/client_app.ts
+++ b/apps/admin/backend/src/client_app.ts
@@ -17,6 +17,7 @@ import { createSystemCallApi } from '@votingworks/backend';
 import { Logger, LogEventId } from '@votingworks/logging';
 import { isSystemAdministratorAuth } from '@votingworks/utils';
 import {
+  isFat32Partition,
   MultiUsbDrive,
   UsbDriveStatus,
   createUsbDriveAdapter,
@@ -158,8 +159,8 @@ function buildClientApi({
 
   const usbDriveAdapter = createUsbDriveAdapter(
     multiUsbDrive,
-    // return the first drive
-    (drives) => drives[0]?.devPath
+    // return the first FAT32 drive
+    (drives) => drives.find((d) => isFat32Partition(d.partitions[0]))?.devPath
   );
 
   return grout.createApi({
@@ -370,7 +371,7 @@ function buildClientApi({
       }
 
       try {
-        await usbDriveAdapter.format();
+        await usbDriveAdapter.format('fat32');
         return ok();
       } catch (error) {
         return err(error as Error);

--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -173,7 +173,7 @@ function buildApi({ context, logger, barcodeScannerClient }: BuildAppParams) {
       }
 
       try {
-        await usbDrive.format();
+        await usbDrive.format('fat32');
         return ok();
       } catch (error) {
         return err(error as Error);

--- a/libs/usb-drive/src/mocks/file_usb_drive.test.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.test.ts
@@ -109,7 +109,7 @@ test('mock flow', async () => {
   const usbDrive = createMockFileUsbDrive();
   expect(await usbDrive.status()).toEqual({ status: 'no_drive' });
   await expect(usbDrive.eject()).resolves.toBeUndefined();
-  await expect(usbDrive.format()).resolves.toBeUndefined();
+  await expect(usbDrive.format('fat32')).resolves.toBeUndefined();
   expect(await usbDrive.status()).toEqual({ status: 'no_drive' });
 
   const handler = getMockFileUsbDriveHandler();

--- a/libs/usb-drive/src/mocks/file_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.ts
@@ -153,13 +153,13 @@ export function createMockFileUsbDrive(diskName = 'sdb'): UsbDrive {
       return Promise.resolve();
     },
 
-    format(): Promise<void> {
+    format(fstype): Promise<void> {
       ensureMockDriveState(diskName);
       const driveState = readMockDriveState(diskName);
       if (driveState.state === 'inserted') {
         writeMockDriveState(diskName, {
           state: 'ejected',
-          fstype: driveState.fstype,
+          fstype,
         });
       }
       return Promise.resolve();
@@ -182,8 +182,8 @@ export class MockFileUsbDrive implements UsbDrive {
     return this.usbDrive.eject();
   }
 
-  format(): Promise<void> {
-    return this.usbDrive.format();
+  format(fstype: UsbDriveFilesystemType): Promise<void> {
+    return this.usbDrive.format(fstype);
   }
 
   sync(): Promise<void> {

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -80,18 +80,18 @@ function generateVxUsbLabel(previousLabel?: string): string {
   return label;
 }
 
-export function isFat32Partition(partition: {
+export function isFat32Partition(partition?: {
   fstype?: string;
   fsver?: string;
 }): boolean {
-  return partition.fstype === 'vfat' && partition.fsver === 'FAT32';
+  return partition?.fstype === 'vfat' && partition.fsver === 'FAT32';
 }
 
-export function isExt4Partition(partition: { fstype?: string }): boolean {
-  return partition.fstype === 'ext4';
+export function isExt4Partition(partition?: { fstype?: string }): boolean {
+  return partition?.fstype === 'ext4';
 }
 
-function isSupportedPartition(partition: UsbPartitionDeviceInfo): boolean {
+function isSupportedPartition(partition?: UsbPartitionDeviceInfo): boolean {
   return isFat32Partition(partition) || isExt4Partition(partition);
 }
 

--- a/libs/usb-drive/src/types.ts
+++ b/libs/usb-drive/src/types.ts
@@ -1,3 +1,5 @@
+import { type UsbDriveFilesystemType } from './multi_usb_drive';
+
 export type UsbDriveStatus =
   | { status: 'no_drive' }
   | {
@@ -10,6 +12,6 @@ export type UsbDriveStatus =
 export interface UsbDrive {
   status(): Promise<UsbDriveStatus>;
   eject(): Promise<void>;
-  format(): Promise<void>;
+  format(fstype: UsbDriveFilesystemType): Promise<void>;
   sync(): Promise<void>;
 }

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -5,7 +5,7 @@ import {
 import { Logger } from '@votingworks/logging';
 import { UsbDrive } from './types';
 import { MockFileUsbDrive } from './mocks/file_usb_drive';
-import { detectMultiUsbDrive } from './multi_usb_drive';
+import { detectMultiUsbDrive, isFat32Partition } from './multi_usb_drive';
 import { createUsbDriveAdapter } from './usb_drive_adapter';
 
 export function detectUsbDrive(
@@ -16,5 +16,8 @@ export function detectUsbDrive(
     return new MockFileUsbDrive();
   }
   const multiUsbDrive = detectMultiUsbDrive(logger, { onChange: onRefresh });
-  return createUsbDriveAdapter(multiUsbDrive, (drives) => drives[0]?.devPath);
+  return createUsbDriveAdapter(
+    multiUsbDrive,
+    (drives) => drives.find((d) => isFat32Partition(d.partitions[0]))?.devPath
+  );
 }

--- a/libs/usb-drive/src/usb_drive_adapter.test.ts
+++ b/libs/usb-drive/src/usb_drive_adapter.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { createUsbDriveAdapter } from './usb_drive_adapter';
 import { createMockMultiUsbDrive } from './mocks/mock_multi_usb_drive';
 import { UsbDriveInfo } from './multi_usb_drive';
+import { UsbDriveStatus } from './types';
 
 function makeDriveInfo(overrides: Partial<UsbDriveInfo> = {}): UsbDriveInfo {
   return {
@@ -32,28 +33,65 @@ describe('createUsbDriveAdapter', () => {
 
     test('returns no_drive when drive not found in getDrives()', async () => {
       const { multiUsbDrive } = createMockMultiUsbDrive();
-      const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdb');
-      multiUsbDrive.getDrives.reset();
-
-      multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([]);
-      expect(await adapter.status()).toEqual({ status: 'no_drive' });
-    });
-
-    test('returns no_drive when drive has no partitions', async () => {
-      const { multiUsbDrive } = createMockMultiUsbDrive();
-      const adapter = createUsbDriveAdapter(
-        multiUsbDrive,
-        (drives) => drives[0]?.devPath
-      );
+      const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdz');
       multiUsbDrive.getDrives.reset();
 
       multiUsbDrive.getDrives
         .expectRepeatedCallsWith()
-        .returns([makeDriveInfo({ partitions: [] })]);
+        .returns([makeDriveInfo()]);
       expect(await adapter.status()).toEqual({ status: 'no_drive' });
     });
 
-    test('filters out non-FAT32 drives', async () => {
+    test('returns no_drive when no drive is selected', async () => {
+      const { multiUsbDrive } = createMockMultiUsbDrive();
+      const adapter = createUsbDriveAdapter(multiUsbDrive, () => undefined);
+      multiUsbDrive.getDrives.reset();
+
+      multiUsbDrive.getDrives
+        .expectRepeatedCallsWith()
+        .returns([makeDriveInfo()]);
+      expect(await adapter.status()).toEqual({ status: 'no_drive' });
+    });
+
+    test('only allows selecting a drive with a single partition', async () => {
+      const { multiUsbDrive } = createMockMultiUsbDrive();
+      const adapter = createUsbDriveAdapter(
+        multiUsbDrive,
+        vi.fn().mockThrow(new Error('should never be called'))
+      );
+      multiUsbDrive.getDrives.reset();
+
+      multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
+        makeDriveInfo({ partitions: [] }),
+        makeDriveInfo({
+          partitions: [
+            {
+              devPath: '/dev/sdb1',
+              label: 'VxUSB-ABCDE',
+              fstype: 'vfat',
+              fsver: 'FAT32',
+              mount: {
+                type: 'mounted',
+                mountPoint: '/media/vx/usb-drive-sdb1',
+              },
+            },
+            {
+              devPath: '/dev/sdb2',
+              label: 'VxUSB-ABCDE',
+              fstype: 'vfat',
+              fsver: 'FAT32',
+              mount: {
+                type: 'mounted',
+                mountPoint: '/media/vx/usb-drive-sdb2',
+              },
+            },
+          ],
+        }),
+      ]);
+      expect(await adapter.status()).toEqual({ status: 'no_drive' });
+    });
+
+    test('can see ext4 drives', async () => {
       const { multiUsbDrive } = createMockMultiUsbDrive();
       const adapter = createUsbDriveAdapter(
         multiUsbDrive,
@@ -75,7 +113,10 @@ describe('createUsbDriveAdapter', () => {
           ],
         }),
       ]);
-      expect(await adapter.status()).toEqual({ status: 'no_drive' });
+      expect(await adapter.status()).toEqual<UsbDriveStatus>({
+        status: 'mounted',
+        mountPoint: '/media/vx/usb-drive-sdb1',
+      });
     });
 
     test('returns no_drive when partition is mounting', async () => {
@@ -214,7 +255,7 @@ describe('createUsbDriveAdapter', () => {
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([]);
 
       multiUsbDrive.formatDrive.expectCallWith('/dev/sdb', 'fat32').resolves();
-      await adapter.format();
+      await adapter.format('fat32');
 
       assertComplete();
     });
@@ -225,7 +266,7 @@ describe('createUsbDriveAdapter', () => {
       multiUsbDrive.getDrives.reset();
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([]);
 
-      await adapter.format();
+      await adapter.format('fat32');
 
       assertComplete();
     });

--- a/libs/usb-drive/src/usb_drive_adapter.ts
+++ b/libs/usb-drive/src/usb_drive_adapter.ts
@@ -12,9 +12,10 @@ const debug = makeDebug('usb-drive:adapter');
 /**
  * Adapts a `MultiUsbDrive` instance to the single-drive `UsbDrive` interface.
  *
- * `getDriveDevPath` selects which drive to expose. The adapter maps the first
- * partition's mount state to `UsbDriveStatus` for backward-compatible consumers
- * such as `Exporter` and `createSystemCallApi`.
+ * `getDriveDevPath` selects which drive to expose from a list of drives with a
+ * single partition. The adapter maps the partition's mount state to
+ * `UsbDriveStatus` for backward-compatible consumers such as `Exporter` and
+ * `createSystemCallApi`.
  */
 export function createUsbDriveAdapter(
   multiUsbDrive: MultiUsbDrive,

--- a/libs/usb-drive/src/usb_drive_adapter.ts
+++ b/libs/usb-drive/src/usb_drive_adapter.ts
@@ -1,27 +1,16 @@
 import makeDebug from 'debug';
 import { assert } from '@votingworks/basics';
 import {
-  isFat32Partition,
   MultiUsbDrive,
   UsbDriveInfo,
+  UsbDriveFilesystemType,
 } from './multi_usb_drive';
 import { UsbDrive, UsbDriveStatus } from './types';
 
 const debug = makeDebug('usb-drive:adapter');
 
-function getFat32Drives(drives: readonly UsbDriveInfo[]): UsbDriveInfo[] {
-  return drives.filter((drive) => {
-    const [firstPartition] = drive.partitions;
-    return !!firstPartition && isFat32Partition(firstPartition);
-  });
-}
-
 /**
  * Adapts a `MultiUsbDrive` instance to the single-drive `UsbDrive` interface.
- *
- * Only FAT32 drives are visible to the adapter. The drive list is filtered
- * before being passed to `getDriveDevPath`, so callers do not need to account
- * for non-FAT32 drives in their selection logic.
  *
  * `getDriveDevPath` selects which drive to expose. The adapter maps the first
  * partition's mount state to `UsbDriveStatus` for backward-compatible consumers
@@ -33,14 +22,22 @@ export function createUsbDriveAdapter(
 ): UsbDrive {
   return {
     status(): Promise<UsbDriveStatus> {
-      const fat32Drives = getFat32Drives(multiUsbDrive.getDrives());
-      const driveDevPath = getDriveDevPath(fat32Drives);
+      const drives = multiUsbDrive
+        .getDrives()
+        .filter((d) => d.partitions.length === 1);
+
+      if (drives.length === 0) {
+        debug('adapter: no drives with a single partition, returning no_drive');
+        return Promise.resolve({ status: 'no_drive' });
+      }
+
+      const driveDevPath = getDriveDevPath(drives);
       if (!driveDevPath) {
         debug('adapter: no drive device path, returning no_drive');
         return Promise.resolve({ status: 'no_drive' });
       }
 
-      const drive = fat32Drives.find((d) => d.devPath === driveDevPath);
+      const drive = drives.find((d) => d.devPath === driveDevPath);
 
       if (!drive) {
         debug('adapter: drive not found in cache, returning no_drive');
@@ -48,7 +45,7 @@ export function createUsbDriveAdapter(
       }
 
       const [firstPartition] = drive.partitions;
-      assert(firstPartition && isFat32Partition(firstPartition));
+      assert(firstPartition, `No partitions found on disk '${driveDevPath}'`);
 
       const { mount } = firstPartition;
 
@@ -84,9 +81,7 @@ export function createUsbDriveAdapter(
     },
 
     async eject(): Promise<void> {
-      const driveDevPath = getDriveDevPath(
-        getFat32Drives(multiUsbDrive.getDrives())
-      );
+      const driveDevPath = getDriveDevPath(multiUsbDrive.getDrives());
       if (!driveDevPath) {
         debug('adapter: no drive to eject');
         return;
@@ -95,27 +90,25 @@ export function createUsbDriveAdapter(
       await multiUsbDrive.ejectDrive(driveDevPath);
     },
 
-    async format(): Promise<void> {
-      const driveDevPath = getDriveDevPath(
-        getFat32Drives(multiUsbDrive.getDrives())
-      );
+    async format(fstype: UsbDriveFilesystemType): Promise<void> {
+      const driveDevPath = getDriveDevPath(multiUsbDrive.getDrives());
       if (!driveDevPath) {
         debug('adapter: no drive to format');
         return;
       }
 
-      await multiUsbDrive.formatDrive(driveDevPath, 'fat32');
+      await multiUsbDrive.formatDrive(driveDevPath, fstype);
     },
 
     async sync(): Promise<void> {
-      const fat32Drives = getFat32Drives(multiUsbDrive.getDrives());
-      const driveDevPath = getDriveDevPath(fat32Drives);
+      const drives = multiUsbDrive.getDrives();
+      const driveDevPath = getDriveDevPath(drives);
       if (!driveDevPath) {
         debug('adapter: no drive to sync');
         return;
       }
 
-      const drive = fat32Drives.find((d) => d.devPath === driveDevPath);
+      const drive = drives.find((d) => d.devPath === driveDevPath);
       const mountedPartition = drive?.partitions.find(
         (p) => p.mount.type === 'mounted'
       );


### PR DESCRIPTION
## Overview
The underlying `detectUsbDrive` and `createUsbDriveAdapter` functions assumed FAT32. To bring us one step closer to using ext4 drives for backup, this allows `createUsbDriveAdapter` to select an ext4 drive.

This change also constrains the adapter to work with drives that have a single partition.

## Demo Video or Screenshot
In a future PR, I'll have `createUsbDriveAdapter(multiUsbDrive, (drives) => drives.find((d) => isExt4Partition(d.partitions[0]))?.devPath)` that selects the first ext4 drive for use by the backup/archive system.

## Testing Plan
Verified manually that USB drive interactions still work in VxAdmin.
