### PR TITLE
VxAdmin: Add back machine id and version to lock footer

### DIFF
--- a/apps/admin/frontend/src/client/client_app_root.test.tsx
+++ b/apps/admin/frontend/src/client/client_app_root.test.tsx
@@ -6,7 +6,7 @@ import {
   mockSessionExpiresAt,
   mockSystemAdministratorUser,
 } from '@votingworks/test-utils';
-import { constructElectionKey } from '@votingworks/types';
+import { constructElectionKey, DEV_MACHINE_ID } from '@votingworks/types';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import { QueryClient } from '@tanstack/react-query';
 import { SystemCallContextProvider } from '@votingworks/ui';
@@ -114,6 +114,7 @@ test('warns when connected to an unconfigured host', async () => {
   await screen.findByText('Insert system administrator card to unlock.');
   await screen.findByText('The host is not configured with an election');
   expect(screen.queryByTestId('electionInfoBar')).toBeNull();
+  screen.getByText(DEV_MACHINE_ID);
 });
 
 test('shows election info when connected to a configured host', async () => {
@@ -126,6 +127,7 @@ test('shows election info when connected to a configured host', async () => {
   await screen.findByText('Adjudication Station Locked');
   const electionInfo = await screen.findByTestId('electionInfoBar');
   within(electionInfo).getByText(electionDefinition.election.title);
+  within(electionInfo).getByText(DEV_MACHINE_ID);
 });
 
 test('warns when no host is detected', async () => {
@@ -137,6 +139,7 @@ test('warns when no host is detected', async () => {
   renderClientApp({ withElection: true });
   await screen.findByText('Adjudication Station Locked');
   await screen.findByText('No host detected');
+  screen.getByText(DEV_MACHINE_ID);
 });
 
 test('warns when multiple hosts detected', async () => {
@@ -148,6 +151,7 @@ test('warns when multiple hosts detected', async () => {
   renderClientApp();
   await screen.findByText('Adjudication Station Locked');
   await screen.findByText('Multiple hosts detected on the network');
+  screen.getByText(DEV_MACHINE_ID);
 });
 
 test('warns when host has incompatible software version', async () => {
@@ -161,6 +165,7 @@ test('warns when host has incompatible software version', async () => {
   await screen.findByText(
     /software version of this adjudication station does not match/
   );
+  screen.getByText(DEV_MACHINE_ID);
 });
 
 test('warns when there is no network connection', async () => {
@@ -172,6 +177,7 @@ test('warns when there is no network connection', async () => {
   renderClientApp();
   await screen.findByText('Adjudication Station Locked');
   await screen.findByText('No network connection');
+  screen.getByText(DEV_MACHINE_ID);
 });
 
 test('shows invalid card screen without election', async () => {

--- a/apps/admin/frontend/src/client/screens/client_machine_locked_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_machine_locked_screen.tsx
@@ -5,6 +5,7 @@ import {
   InfoBar,
   Main,
   Screen,
+  SystemInfo,
   H1,
   H3,
 } from '@votingworks/ui';
@@ -43,6 +44,11 @@ function LockScreenFooter(): JSX.Element | null {
   return (
     <InfoBar>
       <UnconfiguredNetworkStatusIndicator status={status} />
+      <SystemInfo
+        mode="admin"
+        codeVersion={machineConfig.codeVersion}
+        machineId={machineConfig.machineId}
+      />
     </InfoBar>
   );
 }


### PR DESCRIPTION
## Overview
Accidently removed the machine id and version when I added the network status. This adds them back. 
<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot
<img width="943" height="616" alt="Screenshot 2026-06-01 at 1 42 47 PM" src="https://github.com/user-attachments/assets/5f7bfb85-ecbc-4e66-a0cd-e91fc7042e1a" />

<img width="986" height="625" alt="Screenshot 2026-06-01 at 1 46 53 PM" src="https://github.com/user-attachments/assets/a3fe8a04-b0d7-4490-a956-2788f5c7bf2a" />

## Testing Plan
Viewed screen.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
