### PR TITLE
ci: re-sync coverage thresholds after #8551

### DIFF
--- a/apps/admin/frontend/vitest.config.ts
+++ b/apps/admin/frontend/vitest.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
 
     coverage: {
       thresholds: {
-        lines: -114,
-        branches: -134,
+        lines: -115,
+        branches: -135,
       },
       exclude: [
         'src/config',


### PR DESCRIPTION
## Overview
#8551 was based on a commit before #8558, which tightened the thresholds across the repo. #8551 slightly reduced coverage in apps/admin/frontend but only in such a way that it was within the coverage threshold from the point it branched from `main`.

## Demo Video or Screenshot
n/a

## Testing Plan
CI