### PR TITLE
test(admin): suppress error stack trace for expected failure

### DIFF
--- a/apps/admin/backend/src/client_app.test.ts
+++ b/apps/admin/backend/src/client_app.test.ts
@@ -11,6 +11,7 @@ import {
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import { err, ok, typedAs } from '@votingworks/basics';
 import { createMockMultiUsbDrive } from '@votingworks/usb-drive';
+import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import { buildClientApp, ClientApi } from './client_app';
 import { isMultiStationAdjudicationEnabled } from './multi_station_config';
 import type { PeerApi } from './peer_app';
@@ -106,8 +107,10 @@ test('setMachineMode throws when election is configured', async () => {
     electionPackageHash: 'test-hash',
   };
   env.workspace.clientStore.setCachedElectionRecord(mockRecord);
-  await expect(env.apiClient.setMachineMode({ mode: 'host' })).rejects.toThrow(
-    'Cannot change machine mode while an election is configured.'
+  await suppressingConsoleOutput(() =>
+    expect(env.apiClient.setMachineMode({ mode: 'host' })).rejects.toThrow(
+      'Cannot change machine mode while an election is configured.'
+    )
   );
 });
 


### PR DESCRIPTION
## Overview
`setMachineMode throws when election is configured` is supposed to trigger an assertion failure, but we still print the stack trace in the test output. This prevents the output from being printed.

## Demo Video or Screenshot
n/a

## Testing Plan
Ran locally, verified the stack trace is no longer printed.