### PR TITLE
VxAdmin: Crossover voting in adjudication

### DIFF
--- a/apps/admin/backend/src/adjudication.test.ts
+++ b/apps/admin/backend/src/adjudication.test.ts
@@ -8,6 +8,7 @@ import {
   Tabulation,
 } from '@votingworks/types';
 import {
+  electionOpenPrimaryFixtures,
   electionTwoPartyPrimaryFixtures,
   makeTemporaryDirectory,
 } from '@votingworks/fixtures';
@@ -945,4 +946,62 @@ test('adjudicateCvr applies multiple contests in a single transaction and marks 
 
   // The cvr is marked resolved.
   expect(store.isCvrAdjudicated({ cvrId })).toEqual(true);
+});
+
+test('open primary crossover vote', () => {
+  const store = Store.memoryStore(makeTemporaryDirectory());
+  const { electionData } = electionOpenPrimaryFixtures.readElectionDefinition();
+  const electionId = store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageFileContents: Buffer.of(),
+    electionPackageHash: 'test-election-package-hash',
+  });
+  store.setCurrentElectionId(electionId);
+
+  const cvrMetadata = {
+    ballotStyleGroupId: 'ballot-style-1',
+    batchId: 'batch-1',
+    scannerId: 'scanner-1',
+    precinctId: 'precinct-1',
+    votingMethod: 'precinct',
+    card: { type: 'bmd' },
+  } as const;
+
+  const mockCastVoteRecordFile: MockCastVoteRecordFile = [
+    {
+      ...cvrMetadata,
+      // Crossover: votes in both Dem and Rep partisan contests.
+      votes: {
+        'governor-democratic': ['alice-jones'],
+        'governor-republican': ['dave-wilson'],
+      },
+      multiplier: 1,
+    },
+    {
+      ...cvrMetadata,
+      // Single-party Dem.
+      votes: { 'governor-democratic': ['alice-jones'] },
+      multiplier: 1,
+    },
+  ];
+  const [crossoverCvrId, singlePartyCvrId] = addMockCvrFileToStore({
+    electionId,
+    mockCastVoteRecordFile,
+    store,
+  });
+  assert(crossoverCvrId !== undefined);
+  assert(singlePartyCvrId !== undefined);
+
+  const queue = store.getBallotAdjudicationQueue({ electionId });
+  expect(queue).toContain(crossoverCvrId);
+  expect(queue).not.toContain(singlePartyCvrId);
+  const metadata = store.getBallotAdjudicationQueueMetadata({ electionId });
+  expect(metadata).toEqual({ totalTally: 1, pendingTally: 1 });
+  expect(
+    store.getBallotAdjudicationData({ electionId, cvrId: crossoverCvrId }).tag
+  ).toEqual({ isBlankBallot: false, hasCrossoverVote: true });
+  expect(
+    store.getBallotAdjudicationData({ electionId, cvrId: singlePartyCvrId }).tag
+  ).toEqual({ isBlankBallot: false, hasCrossoverVote: false });
 });

--- a/apps/admin/backend/src/app.adjudication.test.ts
+++ b/apps/admin/backend/src/app.adjudication.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import {
   electionGridLayoutNewHampshireTestBallotFixtures,
+  electionOpenPrimaryFixtures,
   electionTwoPartyPrimaryFixtures,
 } from '@votingworks/fixtures';
 import { assert, assertDefined, err, find, ok } from '@votingworks/basics';
@@ -33,6 +34,7 @@ import {
   mockElectionManagerAuth,
   mockSystemAdministratorAuth,
 } from '../test/app';
+import { seedOpenPrimaryCvrsAndAdjudications } from '../test/open_primary_fixture';
 import {
   AdjudicatedContestOption,
   AdjudicatedCvrContest,
@@ -1971,4 +1973,47 @@ test('deleting a qualified write-in candidate preserves adjudicated votes on unr
       optionToFlip.definition.id
     ]?.hasVote
   ).toEqual(true);
+});
+
+test('open primary crossover votes', async () => {
+  const electionDefinition =
+    electionOpenPrimaryFixtures.readElectionDefinition();
+  const { election } = electionDefinition;
+
+  const { apiClient, auth, workspace } = buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  mockElectionManagerAuth(auth, election);
+
+  const { cvrIds, resolvedCrossoverCvrId } =
+    await seedOpenPrimaryCvrsAndAdjudications({
+      apiClient,
+      electionId: workspace.store.getCurrentElectionId()!,
+      store: workspace.store,
+    });
+  const unresolvedCrossoverCvrId = assertDefined(cvrIds[8]);
+
+  const queue = await apiClient.getBallotAdjudicationQueue();
+  expect(queue).toContain(resolvedCrossoverCvrId);
+  expect(queue).toContain(unresolvedCrossoverCvrId);
+  expect(
+    (
+      await apiClient.getBallotAdjudicationData({
+        cvrId: unresolvedCrossoverCvrId,
+      })
+    ).tag
+  ).toEqual({ isBlankBallot: false, hasCrossoverVote: true });
+  // Even after resolution, original adjudication flag is still preserved
+  expect(
+    (
+      await apiClient.getBallotAdjudicationData({
+        cvrId: resolvedCrossoverCvrId,
+      })
+    ).tag
+  ).toEqual({ isBlankBallot: false, hasCrossoverVote: true });
+
+  const images = await apiClient.getBallotImages({
+    cvrId: unresolvedCrossoverCvrId,
+  });
+  expect(images.front.type).toEqual('hmpb');
+  expect(images.back.type).toEqual('hmpb');
 });

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -2181,8 +2181,11 @@ export class Store implements BaseStore {
    */
   private getAdjudicationQueueFilter(electionId: Id): string {
     const { adminAdjudicationReasons } = this.getSystemSettings(electionId);
-    // Write-ins always need adjudication
-    const conditions: string[] = ['c.has_write_in = 1'];
+    // Write-ins and crossover votes always need adjudication
+    const conditions: string[] = [
+      'c.has_write_in = 1',
+      'c.has_crossover_vote = 1',
+    ];
     if (adminAdjudicationReasons.includes(AdjudicationReason.Overvote)) {
       conditions.push('c.has_overvote = 1');
     }
@@ -2258,12 +2261,24 @@ export class Store implements BaseStore {
     const { votes, markScores, ballotStyleGroupId } = cvrInfo;
 
     const cvrRow = this.client.one(
-      `select is_blank as isBlank, is_adjudicated as isResolved from cvrs where id = ?`,
+      `
+      select
+        is_blank as isBlank,
+        has_crossover_vote as hasCrossoverVote,
+        is_adjudicated as isResolved
+      from cvrs
+      where id = ?
+      `,
       cvrId
-    ) as { isBlank: SqliteBool; isResolved: SqliteBool };
+    ) as {
+      isBlank: SqliteBool;
+      hasCrossoverVote: SqliteBool;
+      isResolved: SqliteBool;
+    };
     const isResolved = fromSqliteBool(cvrRow.isResolved);
     const cvrTag: CvrTag = {
       isBlankBallot: fromSqliteBool(cvrRow.isBlank),
+      hasCrossoverVote: fromSqliteBool(cvrRow.hasCrossoverVote),
     };
 
     const adjudicatedVotes = this.getAdjudicatedVotes({ cvrId });

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -477,6 +477,7 @@ interface AdjudicatedWriteInFalse extends AdjudicatedWriteInBase {
  */
 export interface CvrTag {
   isBlankBallot: boolean;
+  hasCrossoverVote: boolean;
 }
 
 /**

--- a/apps/admin/backend/src/util/cast_vote_records.test.ts
+++ b/apps/admin/backend/src/util/cast_vote_records.test.ts
@@ -363,6 +363,12 @@ test('doesCvrNeedAdjudication - write-in always needs adjudication', () => {
   ).toEqual(true);
 });
 
+test('doesCvrNeedAdjudication - crossover vote always needs adjudication', () => {
+  expect(
+    doesCvrNeedAdjudication({ ...NO_FLAGS, hasCrossoverVote: true }, [])
+  ).toEqual(true);
+});
+
 test('doesCvrNeedAdjudication - marginal mark with reason enabled', () => {
   expect(
     doesCvrNeedAdjudication({ ...NO_FLAGS, hasMarginalMark: true }, [

--- a/apps/admin/backend/src/util/cast_vote_records.ts
+++ b/apps/admin/backend/src/util/cast_vote_records.ts
@@ -85,8 +85,8 @@ export function getCastVoteRecordAdjudicationFlags(
 
 /**
  * Determines whether a CVR needs adjudication based on its flags and the
- * election's adjudication reasons. Write-ins always need adjudication;
- * other flags are gated on system settings.
+ * election's adjudication reasons. Write-ins and crossover votes always need
+ * adjudication; other flags are gated on system settings.
  */
 export function doesCvrNeedAdjudication(
   adjudicationFlags: CastVoteRecordAdjudicationFlags,
@@ -94,6 +94,7 @@ export function doesCvrNeedAdjudication(
 ): boolean {
   return (
     adjudicationFlags.hasWriteIn ||
+    adjudicationFlags.hasCrossoverVote ||
     (adjudicationFlags.hasMarginalMark &&
       adminAdjudicationReasons.includes(AdjudicationReason.MarginalMark)) ||
     (adjudicationFlags.hasOvervote &&

--- a/apps/admin/backend/test/mock_cvr_file.ts
+++ b/apps/admin/backend/test/mock_cvr_file.ts
@@ -10,7 +10,10 @@ import { randomUUID as uuid } from 'node:crypto';
 import { Buffer } from 'node:buffer';
 import { assertDefined } from '@votingworks/basics';
 import { Store } from '../src/store';
-import { getCastVoteRecordAdjudicationFlags } from '../src/util/cast_vote_records';
+import {
+  doesCvrNeedAdjudication,
+  getCastVoteRecordAdjudicationFlags,
+} from '../src/util/cast_vote_records';
 
 export type MockCastVoteRecordFile = Array<
   Tabulation.CastVoteRecord & {
@@ -24,9 +27,9 @@ const mockPageLayout: BallotPageLayout = {
     height: 0,
   },
   metadata: {
-    ballotHash: '',
-    ballotStyleId: '',
-    precinctId: '',
+    ballotHash: 'abc123',
+    ballotStyleId: 'mock-ballot-style',
+    precinctId: 'mock-precinct',
     pageNumber: 1,
     isTestMode: true,
     ballotType: BallotType.Precinct,
@@ -124,25 +127,31 @@ export function addMockCvrFileToStore({
       const { cvrId } = addCastVoteRecordResult.unsafeUnwrap();
       cvrIds.push(cvrId);
 
-      // add write-ins, all on the "front"
-      if (writeIns.length) {
-        store.addBallotImage({
-          cvrId,
-          electionDefinitionId: electionDefinition.election.id,
-          imageData: Buffer.from([]),
-          pageLayout: mockPageLayout,
-          side: 'front',
-        });
-
-        for (const { contestId, optionId, isUnmarked } of writeIns) {
-          store.addWriteIn({
-            electionId,
-            castVoteRecordId: cvrId,
-            contestId,
-            optionId,
-            isUnmarked,
+      // Production stores both front + back ballot images for any CVR that
+      // needs adjudication. Mirror that here so getBallotImages works.
+      const { adminAdjudicationReasons } = store.getSystemSettings(electionId);
+      if (
+        doesCvrNeedAdjudication(adjudicationFlags, adminAdjudicationReasons)
+      ) {
+        for (const side of ['front', 'back'] as const) {
+          store.addBallotImage({
+            cvrId,
+            electionDefinitionId: electionDefinition.election.id,
+            imageData: Buffer.from([]),
+            pageLayout: isHmpb ? mockPageLayout : undefined,
+            side,
           });
         }
+      }
+
+      for (const { contestId, optionId, isUnmarked } of writeIns) {
+        store.addWriteIn({
+          electionId,
+          castVoteRecordId: cvrId,
+          contestId,
+          optionId,
+          isUnmarked,
+        });
       }
     }
   }

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
@@ -124,7 +124,7 @@ function expectAdjudicationEnabled(): void {
 function makeBallotData(cvrId: string) {
   return {
     cvrId,
-    tag: { isBlankBallot: false } as const,
+    tag: { isBlankBallot: false, hasCrossoverVote: false } as const,
     isResolved: false,
     contests: [],
     adjudicatedContests: [],

--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -25,9 +25,14 @@ import {
   Icons,
   P,
 } from '@votingworks/ui';
+import { hasCrossoverVote } from '@votingworks/utils';
 import pluralize from 'pluralize';
 import { EntityList } from './entity_list';
 import {
+  adjudicatedVotes,
+  contestPartyLabel,
+  getCurrentVote,
+  isContestCrossoverVoted,
   isContestResolved,
   isContestTagOnlyUndervote,
 } from '../utils/adjudication';
@@ -43,7 +48,7 @@ const ViewSideButton = styled(Button)`
   padding: 0.2rem 0.5rem;
 `;
 
-const BlankBallotCalloutContainer = styled.div`
+const CalloutContainer = styled.div`
   padding: 0.5rem;
   border-bottom: var(--entity-list-border);
 `;
@@ -72,22 +77,29 @@ const CalloutTitle = styled(P)`
   margin-bottom: 0;
 `;
 
-const StatusCaption = styled(EntityList.Caption)`
+const StatusCaption = styled(EntityList.Caption)<{ color?: 'primary' }>`
   align-items: center;
   display: flex;
   gap: 0.25rem;
+  color: ${(p) =>
+    p.color === 'primary'
+      ? p.theme.colors.primary
+      : p.theme.colors.onBackground};
 `;
 
 function StatusLine({
   icon,
   children,
+  color,
+  weight = 'semiBold',
   ...fontProps
 }: FontProps &
   React.PropsWithChildren<{
     icon: JSX.Element;
+    color?: 'primary';
   }>) {
   return (
-    <StatusCaption {...fontProps}>
+    <StatusCaption color={color} weight={weight} {...fontProps}>
       {icon} {children}
     </StatusCaption>
   );
@@ -95,40 +107,34 @@ function StatusLine({
 
 const StatusLineNeedsAdjudication = styled(StatusLine).attrs({
   icon: <Icons.PenToSquare color="warning" />,
-  weight: 'semiBold',
 })`
-  color: ${(p) => p.theme.colors.onBackground};
+  /* stylelint-disable-next-line no-empty-source */
 `;
 
 const StatusLineWarning = styled(StatusLine).attrs({
   icon: <Icons.Warning color="warning" />,
-  weight: 'semiBold',
+  color: 'primary',
 })`
-  color: ${(p) => p.theme.colors.primary};
+  /* stylelint-disable-next-line no-empty-source */
 `;
 
 const StatusLineConfirmed = styled(StatusLine).attrs({
   icon: <Icons.Done />,
-  weight: 'semiBold',
+  color: 'primary',
 })`
-  color: ${(p) => p.theme.colors.primary};
+  /* stylelint-disable-next-line no-empty-source */
 `;
 
 const StatusLineAdjudicated = styled(StatusLine).attrs({
   icon: <Icons.PenToSquare />,
+  weight: 'regular',
+  color: 'primary',
 })`
-  color: ${(p) => p.theme.colors.primary};
+  /* stylelint-disable-next-line no-empty-source */
 `;
 
 function getVotesAllowed(contest: AnyContest): number {
   return contest.type === 'yesno' ? 1 : contest.seats;
-}
-
-function getCurrentVote(
-  option: ContestOptionAdjudicationData,
-  adjudicatedOption?: AdjudicatedContestOption
-): boolean {
-  return adjudicatedOption?.hasVote ?? option.scannedVote;
 }
 
 type VoteStatus = 'overvote' | 'undervote' | 'normal';
@@ -340,30 +346,76 @@ function ContestAdjudicationSummary({
   );
 }
 
+function CrossoverVoteStatus({
+  ballotHasScannedCrossoverVote,
+  contestHasScannedCrossoverVote,
+  contestHasAdjudicatedCrossoverVote,
+  isBallotResolved,
+}: {
+  ballotHasScannedCrossoverVote?: boolean;
+  contestHasScannedCrossoverVote: boolean;
+  contestHasAdjudicatedCrossoverVote: boolean;
+  isBallotResolved: boolean;
+}) {
+  const warningIcon = <Icons.Crossover color="warning" />;
+  const primaryIcon = <Icons.Crossover color="primary" />;
+  if (ballotHasScannedCrossoverVote) {
+    if (contestHasAdjudicatedCrossoverVote) {
+      if (isBallotResolved) {
+        return (
+          <StatusLine icon={primaryIcon} color="primary">
+            Crossover vote confirmed
+          </StatusLine>
+        );
+      }
+      return (
+        <StatusLine icon={warningIcon}>Crossover vote detected</StatusLine>
+      );
+    }
+    if (contestHasScannedCrossoverVote) {
+      return <StatusLineConfirmed>Crossover vote resolved</StatusLineConfirmed>;
+    }
+  }
+  if (contestHasAdjudicatedCrossoverVote) {
+    return (
+      <StatusLine
+        icon={isBallotResolved ? primaryIcon : warningIcon}
+        color="primary"
+      >
+        Crossover vote created
+      </StatusLine>
+    );
+  }
+}
+
 function BallotSideContestList({
   adjudicatedContests,
   contests,
   election,
   firstUnresolvedContestId,
   isVisibleSide,
-  isBlankBallot,
   onHeaderClick,
   onHover,
   onSelect,
   showUndervoteStatus,
   title,
+  cvrTag,
+  ballotHasAdjudicatedCrossoverVote,
+  isBallotResolved,
 }: {
   adjudicatedContests: ReadonlyMap<ContestId, AdjudicatedCvrContest>;
   contests: ContestListItem[];
   election: Election;
   firstUnresolvedContestId?: ContestId;
   isVisibleSide: boolean;
-  isBlankBallot?: boolean;
   onHeaderClick: () => void;
   onHover: (contestId: ContestId | null) => void;
   onSelect: (contestId: ContestId) => void;
   showUndervoteStatus: boolean;
   title: string;
+  cvrTag?: CvrTag;
+  ballotHasAdjudicatedCrossoverVote: boolean;
+  isBallotResolved: boolean;
 }): React.ReactNode {
   return (
     <React.Fragment>
@@ -391,6 +443,7 @@ function BallotSideContestList({
           const { contest, adjudicationData } = item;
           const { tag } = adjudicationData;
           const adjudicatedContest = adjudicatedContests.get(contest.id);
+
           const isResolved = isContestResolved(
             adjudicationData,
             adjudicatedContests
@@ -400,9 +453,25 @@ function BallotSideContestList({
           const isOnlyUndervote = tag && isContestTagOnlyUndervote(tag);
 
           const suppressContestAdjudicationInfo =
-            isBlankBallot &&
+            cvrTag?.isBlankBallot &&
             isOnlyUndervote &&
             adjudicatedContest === undefined;
+
+          const contestHasScannedCrossoverVote = isContestCrossoverVoted(
+            cvrTag?.hasCrossoverVote,
+            item
+          );
+          const contestHasAdjudicatedCrossoverVote = isContestCrossoverVoted(
+            ballotHasAdjudicatedCrossoverVote,
+            item,
+            adjudicatedContests
+          );
+          const crossoverVoteIsPending =
+            contestHasScannedCrossoverVote &&
+            contestHasAdjudicatedCrossoverVote &&
+            !isBallotResolved;
+
+          const partyLabel = contestPartyLabel(election, contest);
 
           return (
             <EntityList.Item
@@ -411,11 +480,15 @@ function BallotSideContestList({
               onSelect={onSelect}
               onHover={onHover}
               autoScrollIntoView={isFirstUnresolved}
-              hasWarning={isPending && !suppressContestAdjudicationInfo}
+              hasWarning={
+                (isPending && !suppressContestAdjudicationInfo) ||
+                crossoverVoteIsPending
+              }
             >
               <Column>
                 <EntityList.Caption>
                   {getContestDistrictName(election, contest)}
+                  {partyLabel && ` — ${partyLabel}`}
                 </EntityList.Caption>
                 <EntityList.Label
                   weight="semiBold"
@@ -423,6 +496,16 @@ function BallotSideContestList({
                 >
                   {contest.title}
                 </EntityList.Label>
+                <CrossoverVoteStatus
+                  contestHasScannedCrossoverVote={
+                    contestHasScannedCrossoverVote
+                  }
+                  contestHasAdjudicatedCrossoverVote={
+                    contestHasAdjudicatedCrossoverVote
+                  }
+                  ballotHasScannedCrossoverVote={cvrTag?.hasCrossoverVote}
+                  isBallotResolved={isBallotResolved}
+                />
                 {!suppressContestAdjudicationInfo && (
                   <ContestAdjudicationSummary
                     item={item}
@@ -445,7 +528,7 @@ export interface AdjudicationContestListProps {
   cvrTag?: CvrTag;
   election: Election;
   frontContests: ContestListItem[];
-  isResolved: boolean;
+  isBallotResolved: boolean;
   onHover: (contestId: ContestId | null) => void;
   onSelect: (contestId: ContestId) => void;
   onSelectSide: (side: Side) => void;
@@ -459,7 +542,7 @@ export function AdjudicationContestList({
   cvrTag,
   election,
   frontContests,
-  isResolved,
+  isBallotResolved,
   onHover,
   onSelect,
   onSelectSide,
@@ -467,11 +550,13 @@ export function AdjudicationContestList({
   showUndervoteStatus,
 }: AdjudicationContestListProps): React.ReactNode {
   const allContests = [...frontContests, ...backContests];
-  const firstUnresolvedContestId = cvrTag?.isBlankBallot
-    ? undefined
-    : allContests.find(
-        (item) => !isContestResolved(item.adjudicationData, adjudicatedContests)
-      )?.contest.id;
+  const firstUnresolvedContestId =
+    cvrTag?.isBlankBallot || cvrTag?.hasCrossoverVote
+      ? undefined
+      : allContests.find(
+          (item) =>
+            !isContestResolved(item.adjudicationData, adjudicatedContests)
+        )?.contest.id;
 
   const blankBallotHasAnyAdjudicatedVote =
     cvrTag?.isBlankBallot &&
@@ -490,25 +575,32 @@ export function AdjudicationContestList({
     if (blankBallotHasAnyAdjudicatedVote) {
       return 'Blank Ballot Resolved';
     }
-    return isResolved ? 'Blank Ballot Confirmed' : 'Blank Ballot Detected';
+    return isBallotResolved
+      ? 'Blank Ballot Confirmed'
+      : 'Blank Ballot Detected';
   })();
+
+  const ballotHasAdjudicatedCrossoverVote = hasCrossoverVote(
+    election,
+    adjudicatedVotes(allContests, adjudicatedContests)
+  );
 
   return (
     <EntityList.Box>
       {cvrTag?.isBlankBallot && (
-        <BlankBallotCalloutContainer>
+        <CalloutContainer>
           <Callout
             color={
               blankBallotHasAnyAdjudicatedVote
                 ? 'neutral'
-                : !isResolved
+                : !isBallotResolved
                 ? 'warning'
                 : 'primary'
             }
           >
             <CalloutContent>
               <P aria-hidden style={{ lineHeight: 1, marginBottom: 0 }}>
-                {isResolved || blankBallotHasAnyAdjudicatedVote ? (
+                {isBallotResolved || blankBallotHasAnyAdjudicatedVote ? (
                   <Icons.Done
                     color={
                       blankBallotHasAnyAdjudicatedVote ? 'neutral' : 'primary'
@@ -542,7 +634,13 @@ export function AdjudicationContestList({
               </CalloutBody>
             </CalloutContent>
           </Callout>
-        </BlankBallotCalloutContainer>
+        </CalloutContainer>
+      )}
+      {cvrTag?.hasCrossoverVote && (
+        <CrossoverVotingCallout
+          ballotHasAdjudicatedCrossoverVote={ballotHasAdjudicatedCrossoverVote}
+          isBallotResolved={isBallotResolved}
+        />
       )}
       {frontContests.length > 0 && (
         <BallotSideContestList
@@ -550,13 +648,15 @@ export function AdjudicationContestList({
           contests={frontContests}
           election={election}
           firstUnresolvedContestId={firstUnresolvedContestId}
-          isBlankBallot={cvrTag?.isBlankBallot}
           isVisibleSide={selectedSide === 'front'}
           onHeaderClick={() => onSelectSide('front')}
           onHover={onHover}
           onSelect={onSelect}
           showUndervoteStatus={showUndervoteStatus}
           title="Front"
+          cvrTag={cvrTag}
+          ballotHasAdjudicatedCrossoverVote={ballotHasAdjudicatedCrossoverVote}
+          isBallotResolved={isBallotResolved}
         />
       )}
       {backContests.length > 0 && (
@@ -565,15 +665,69 @@ export function AdjudicationContestList({
           contests={backContests}
           election={election}
           firstUnresolvedContestId={firstUnresolvedContestId}
-          isBlankBallot={cvrTag?.isBlankBallot}
           isVisibleSide={selectedSide === 'back'}
           onHeaderClick={() => onSelectSide('back')}
           onHover={onHover}
           onSelect={onSelect}
           showUndervoteStatus={showUndervoteStatus}
           title="Back"
+          cvrTag={cvrTag}
+          ballotHasAdjudicatedCrossoverVote={ballotHasAdjudicatedCrossoverVote}
+          isBallotResolved={isBallotResolved}
         />
       )}
     </EntityList.Box>
+  );
+}
+
+function CrossoverVotingCallout({
+  ballotHasAdjudicatedCrossoverVote,
+  isBallotResolved,
+}: {
+  ballotHasAdjudicatedCrossoverVote: boolean;
+  isBallotResolved: boolean;
+}): JSX.Element | null {
+  const { title, description } = (() => {
+    if (!ballotHasAdjudicatedCrossoverVote) {
+      return {
+        title: 'Crossover Voting Resolved',
+        description: 'Ballot no longer has votes for multiple parties.',
+      };
+    }
+    if (isBallotResolved) {
+      return {
+        title: 'Crossover Voting Confirmed',
+        description: 'Votes in partisan contests will not be counted.',
+      };
+    }
+    return {
+      title: 'Crossover Voting Detected',
+      description:
+        'Votes detected for multiple parties. Votes in partisan contests will not be counted.',
+    };
+  })();
+  const isAdjudicated = !ballotHasAdjudicatedCrossoverVote || isBallotResolved;
+  return (
+    <CalloutContainer>
+      <Callout color={isAdjudicated ? 'primary' : 'warning'}>
+        <CalloutContent>
+          <P aria-hidden style={{ lineHeight: 1, marginBottom: 0 }}>
+            {isAdjudicated ? (
+              <Icons.Done color="primary" />
+            ) : (
+              <Icons.Crossover color="warning" />
+            )}
+          </P>
+          <CalloutBody>
+            <CalloutTitleContainer>
+              <CalloutTitle weight="bold">{title}</CalloutTitle>
+              <Caption weight="regular" style={{ lineHeight: 1 }}>
+                {description}
+              </Caption>
+            </CalloutTitleContainer>
+          </CalloutBody>
+        </CalloutContent>
+      </Callout>
+    </CalloutContainer>
   );
 }

--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -352,7 +352,7 @@ function CrossoverVoteStatus({
   contestHasAdjudicatedCrossoverVote,
   isBallotResolved,
 }: {
-  ballotHasScannedCrossoverVote?: boolean;
+  ballotHasScannedCrossoverVote: boolean;
   contestHasScannedCrossoverVote: boolean;
   contestHasAdjudicatedCrossoverVote: boolean;
   isBallotResolved: boolean;
@@ -413,7 +413,7 @@ function BallotSideContestList({
   onSelect: (contestId: ContestId) => void;
   showUndervoteStatus: boolean;
   title: string;
-  cvrTag?: CvrTag;
+  cvrTag: CvrTag;
   ballotHasAdjudicatedCrossoverVote: boolean;
   isBallotResolved: boolean;
 }): React.ReactNode {
@@ -453,12 +453,12 @@ function BallotSideContestList({
           const isOnlyUndervote = tag && isContestTagOnlyUndervote(tag);
 
           const suppressContestAdjudicationInfo =
-            cvrTag?.isBlankBallot &&
+            cvrTag.isBlankBallot &&
             isOnlyUndervote &&
             adjudicatedContest === undefined;
 
           const contestHasScannedCrossoverVote = isContestCrossoverVoted(
-            cvrTag?.hasCrossoverVote,
+            cvrTag.hasCrossoverVote,
             item
           );
           const contestHasAdjudicatedCrossoverVote = isContestCrossoverVoted(
@@ -503,7 +503,7 @@ function BallotSideContestList({
                   contestHasAdjudicatedCrossoverVote={
                     contestHasAdjudicatedCrossoverVote
                   }
-                  ballotHasScannedCrossoverVote={cvrTag?.hasCrossoverVote}
+                  ballotHasScannedCrossoverVote={cvrTag.hasCrossoverVote}
                   isBallotResolved={isBallotResolved}
                 />
                 {!suppressContestAdjudicationInfo && (
@@ -525,7 +525,7 @@ function BallotSideContestList({
 export interface AdjudicationContestListProps {
   adjudicatedContests: ReadonlyMap<ContestId, AdjudicatedCvrContest>;
   backContests: ContestListItem[];
-  cvrTag?: CvrTag;
+  cvrTag: CvrTag;
   election: Election;
   frontContests: ContestListItem[];
   isBallotResolved: boolean;
@@ -551,7 +551,7 @@ export function AdjudicationContestList({
 }: AdjudicationContestListProps): React.ReactNode {
   const allContests = [...frontContests, ...backContests];
   const firstUnresolvedContestId =
-    cvrTag?.isBlankBallot || cvrTag?.hasCrossoverVote
+    cvrTag.isBlankBallot || cvrTag.hasCrossoverVote
       ? undefined
       : allContests.find(
           (item) =>
@@ -559,7 +559,7 @@ export function AdjudicationContestList({
         )?.contest.id;
 
   const blankBallotHasAnyAdjudicatedVote =
-    cvrTag?.isBlankBallot &&
+    cvrTag.isBlankBallot &&
     allContests.some((item) =>
       item.adjudicationData.options.some((o) =>
         getCurrentVote(
@@ -571,7 +571,7 @@ export function AdjudicationContestList({
     );
 
   const blankBallotCalloutTitle = (() => {
-    if (!cvrTag?.isBlankBallot) return undefined;
+    if (!cvrTag.isBlankBallot) return undefined;
     if (blankBallotHasAnyAdjudicatedVote) {
       return 'Blank Ballot Resolved';
     }
@@ -587,7 +587,7 @@ export function AdjudicationContestList({
 
   return (
     <EntityList.Box>
-      {cvrTag?.isBlankBallot && (
+      {cvrTag.isBlankBallot && (
         <CalloutContainer>
           <Callout
             color={
@@ -636,7 +636,7 @@ export function AdjudicationContestList({
           </Callout>
         </CalloutContainer>
       )}
-      {cvrTag?.hasCrossoverVote && (
+      {cvrTag.hasCrossoverVote && (
         <CrossoverVotingCallout
           ballotHasAdjudicatedCrossoverVote={ballotHasAdjudicatedCrossoverVote}
           isBallotResolved={isBallotResolved}

--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -349,18 +349,18 @@ function ContestAdjudicationSummary({
 function CrossoverVoteStatus({
   ballotHasScannedCrossoverVote,
   contestHasScannedCrossoverVote,
-  contestHasAdjudicatedCrossoverVote,
+  contestHasCrossoverVoteAfterAdjudication,
   isBallotResolved,
 }: {
   ballotHasScannedCrossoverVote: boolean;
   contestHasScannedCrossoverVote: boolean;
-  contestHasAdjudicatedCrossoverVote: boolean;
+  contestHasCrossoverVoteAfterAdjudication: boolean;
   isBallotResolved: boolean;
 }) {
   const warningIcon = <Icons.Crossover color="warning" />;
   const primaryIcon = <Icons.Crossover color="primary" />;
   if (ballotHasScannedCrossoverVote) {
-    if (contestHasAdjudicatedCrossoverVote) {
+    if (contestHasCrossoverVoteAfterAdjudication) {
       if (isBallotResolved) {
         return (
           <StatusLine icon={primaryIcon} color="primary">
@@ -376,7 +376,7 @@ function CrossoverVoteStatus({
       return <StatusLineConfirmed>Crossover vote resolved</StatusLineConfirmed>;
     }
   }
-  if (contestHasAdjudicatedCrossoverVote) {
+  if (contestHasCrossoverVoteAfterAdjudication) {
     return (
       <StatusLine
         icon={isBallotResolved ? primaryIcon : warningIcon}
@@ -400,7 +400,7 @@ function BallotSideContestList({
   showUndervoteStatus,
   title,
   cvrTag,
-  ballotHasAdjudicatedCrossoverVote,
+  ballotHasCrossoverVoteAfterAdjudication,
   isBallotResolved,
 }: {
   adjudicatedContests: ReadonlyMap<ContestId, AdjudicatedCvrContest>;
@@ -414,7 +414,7 @@ function BallotSideContestList({
   showUndervoteStatus: boolean;
   title: string;
   cvrTag: CvrTag;
-  ballotHasAdjudicatedCrossoverVote: boolean;
+  ballotHasCrossoverVoteAfterAdjudication: boolean;
   isBallotResolved: boolean;
 }): React.ReactNode {
   return (
@@ -461,14 +461,15 @@ function BallotSideContestList({
             cvrTag.hasCrossoverVote,
             item
           );
-          const contestHasAdjudicatedCrossoverVote = isContestCrossoverVoted(
-            ballotHasAdjudicatedCrossoverVote,
-            item,
-            adjudicatedContests
-          );
+          const contestHasCrossoverVoteAfterAdjudication =
+            isContestCrossoverVoted(
+              ballotHasCrossoverVoteAfterAdjudication,
+              item,
+              adjudicatedContests.get(contest.id)
+            );
           const crossoverVoteIsPending =
             contestHasScannedCrossoverVote &&
-            contestHasAdjudicatedCrossoverVote &&
+            contestHasCrossoverVoteAfterAdjudication &&
             !isBallotResolved;
 
           const partyLabel = contestPartyLabel(election, contest);
@@ -500,8 +501,8 @@ function BallotSideContestList({
                   contestHasScannedCrossoverVote={
                     contestHasScannedCrossoverVote
                   }
-                  contestHasAdjudicatedCrossoverVote={
-                    contestHasAdjudicatedCrossoverVote
+                  contestHasCrossoverVoteAfterAdjudication={
+                    contestHasCrossoverVoteAfterAdjudication
                   }
                   ballotHasScannedCrossoverVote={cvrTag.hasCrossoverVote}
                   isBallotResolved={isBallotResolved}
@@ -580,7 +581,7 @@ export function AdjudicationContestList({
       : 'Blank Ballot Detected';
   })();
 
-  const ballotHasAdjudicatedCrossoverVote = hasCrossoverVote(
+  const ballotHasCrossoverVoteAfterAdjudication = hasCrossoverVote(
     election,
     adjudicatedVotes(allContests, adjudicatedContests)
   );
@@ -638,7 +639,9 @@ export function AdjudicationContestList({
       )}
       {cvrTag.hasCrossoverVote && (
         <CrossoverVotingCallout
-          ballotHasAdjudicatedCrossoverVote={ballotHasAdjudicatedCrossoverVote}
+          ballotHasCrossoverVoteAfterAdjudication={
+            ballotHasCrossoverVoteAfterAdjudication
+          }
           isBallotResolved={isBallotResolved}
         />
       )}
@@ -655,7 +658,9 @@ export function AdjudicationContestList({
           showUndervoteStatus={showUndervoteStatus}
           title="Front"
           cvrTag={cvrTag}
-          ballotHasAdjudicatedCrossoverVote={ballotHasAdjudicatedCrossoverVote}
+          ballotHasCrossoverVoteAfterAdjudication={
+            ballotHasCrossoverVoteAfterAdjudication
+          }
           isBallotResolved={isBallotResolved}
         />
       )}
@@ -672,7 +677,9 @@ export function AdjudicationContestList({
           showUndervoteStatus={showUndervoteStatus}
           title="Back"
           cvrTag={cvrTag}
-          ballotHasAdjudicatedCrossoverVote={ballotHasAdjudicatedCrossoverVote}
+          ballotHasCrossoverVoteAfterAdjudication={
+            ballotHasCrossoverVoteAfterAdjudication
+          }
           isBallotResolved={isBallotResolved}
         />
       )}
@@ -681,14 +688,14 @@ export function AdjudicationContestList({
 }
 
 function CrossoverVotingCallout({
-  ballotHasAdjudicatedCrossoverVote,
+  ballotHasCrossoverVoteAfterAdjudication,
   isBallotResolved,
 }: {
-  ballotHasAdjudicatedCrossoverVote: boolean;
+  ballotHasCrossoverVoteAfterAdjudication: boolean;
   isBallotResolved: boolean;
 }): JSX.Element | null {
   const { title, description } = (() => {
-    if (!ballotHasAdjudicatedCrossoverVote) {
+    if (!ballotHasCrossoverVoteAfterAdjudication) {
       return {
         title: 'Crossover Voting Resolved',
         description: 'Ballot no longer has votes for multiple parties.',
@@ -706,7 +713,8 @@ function CrossoverVotingCallout({
         'Votes detected for multiple parties. Votes in partisan contests will not be counted.',
     };
   })();
-  const isAdjudicated = !ballotHasAdjudicatedCrossoverVote || isBallotResolved;
+  const isAdjudicated =
+    !ballotHasCrossoverVoteAfterAdjudication || isBallotResolved;
   return (
     <CalloutContainer>
       <Callout color={isAdjudicated ? 'primary' : 'warning'}>

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, expect, test } from 'vitest';
-import { readElectionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
+import {
+  electionOpenPrimaryFixtures,
+  readElectionTwoPartyPrimaryDefinition,
+} from '@votingworks/fixtures';
 import {
   AdjudicationReason,
   BallotType,
   DEFAULT_SYSTEM_SETTINGS,
+  Election,
   SystemSettings,
 } from '@votingworks/types';
 import type { BallotPageLayout, Rect } from '@votingworks/types';
@@ -38,7 +42,10 @@ import { AdjudicationStartScreen } from './adjudication_start_screen';
 import { routerPaths } from '../router_paths';
 
 const electionDefinition = readElectionTwoPartyPrimaryDefinition();
-const { election } = electionDefinition;
+const { election: primaryElection } = electionDefinition;
+const openPrimaryDefinition =
+  electionOpenPrimaryFixtures.readElectionDefinition();
+const openPrimaryElection = openPrimaryDefinition.election;
 
 let apiMock: ApiMock;
 
@@ -67,7 +74,8 @@ function makeContestTag(overrides: Partial<CvrContestTag> = {}): CvrContestTag {
 
 function makeContestAdjudicationData(
   contestId: string,
-  tag?: CvrContestTag
+  tag?: CvrContestTag,
+  election: Election = primaryElection
 ): ContestAdjudicationData {
   const contest = election.contests.find((c) => c.id === contestId);
   if (!contest) {
@@ -110,7 +118,7 @@ function makeBallotAdjudicationData(
   cvrId: string,
   contests: ContestAdjudicationData[],
   {
-    tag = { isBlankBallot: false },
+    tag = { isBlankBallot: false, hasCrossoverVote: false },
     isResolved = false,
     adjudicatedContests = [],
   }: {
@@ -231,6 +239,10 @@ function makeContestWithVotes(
   }
   const adjudicated = makeAdjudicatedCvrContest(contestId, optionVotes);
   return { contest, adjudicated };
+}
+
+function getContestListItem(name: string | RegExp) {
+  return within(screen.getByText(name).closest('li')!);
 }
 
 test('ballot navigation supports back, skip, exit, and side switching', async () => {
@@ -868,6 +880,81 @@ test('contest hover highlights pending yellow, resolved purple, and back-side no
     .resolves();
 });
 
+test('hovering a crossover voted contest shows the warning highlight', async () => {
+  const demContest = makeContestAdjudicationData(
+    'governor-democratic',
+    undefined,
+    openPrimaryElection
+  );
+  demContest.options[0].scannedVote = true; // alice-jones
+  const repContest = makeContestAdjudicationData(
+    'governor-republican',
+    undefined,
+    openPrimaryElection
+  );
+  repContest.options[0].scannedVote = true; // dave-wilson
+  const adjData = makeBallotAdjudicationData(
+    CVR_ID_1,
+    [demContest, repContest],
+    { tag: { isBlankBallot: false, hasCrossoverVote: true } }
+  );
+
+  const ballotCoordinates: Rect = { x: 0, y: 0, width: 1000, height: 1000 };
+  const ballotImages: BallotImages = {
+    cvrId: CVR_ID_1,
+    front: {
+      type: 'hmpb' as const,
+      imageUrl: 'mock-front-image',
+      ballotCoordinates,
+      layout: makeHmpbPageLayout([
+        'governor-democratic',
+        'governor-republican',
+      ]),
+    },
+    back: {
+      type: 'hmpb' as const,
+      imageUrl: 'mock-back-image',
+      ballotCoordinates,
+      layout: makeHmpbPageLayout([]),
+    },
+  };
+
+  apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.apiClient.getBallotImages
+    .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves(ballotImages);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjData.contests.map((c) => c.contestId)
+  );
+  apiMock.expectGetSystemSettings();
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition: openPrimaryDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('Crossover Voting Detected');
+  const ballotImage = screen.getByRole('img', { name: /ballot/i });
+  function getHighlightOverlay(): HTMLElement | null {
+    return ballotImage.querySelector('div');
+  }
+
+  expect(getHighlightOverlay()).toBeNull();
+  const demGovernorItem = screen.getByText(/Democratic Party/).closest('li')!;
+  fireEvent.mouseEnter(demGovernorItem);
+  const highlight = getHighlightOverlay();
+  expect(highlight).not.toBeNull();
+  expect(highlight).toHaveStyle({ background: HIGHLIGHT_WARNING_BACKGROUND });
+  fireEvent.mouseLeave(demGovernorItem);
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves();
+});
+
 test('accept advances to next ballot and blank ballot callout states', async () => {
   const CVR_ID_3 = 'cvr-id-3';
 
@@ -890,7 +977,7 @@ test('accept advances to next ballot and blank ballot callout states', async () 
         })
       ),
     ],
-    { tag: { isBlankBallot: true } }
+    { tag: { isBlankBallot: true, hasCrossoverVote: false } }
   );
 
   // (Ballot 2's resolved form is no longer needed in this test — the
@@ -900,7 +987,7 @@ test('accept advances to next ballot and blank ballot callout states', async () 
   // Ballot 3: blank ballot with an adjudicated vote on one option
   const zooCouncilContest = makeContestAdjudicationData('zoo-council-mammal');
   const adjData3 = makeBallotAdjudicationData(CVR_ID_3, [zooCouncilContest], {
-    tag: { isBlankBallot: true },
+    tag: { isBlankBallot: true, hasCrossoverVote: false },
     isResolved: true,
     adjudicatedContests: [
       makeAdjudicatedCvrContest('zoo-council-mammal', {
@@ -1100,9 +1187,6 @@ test('contest list shows correct status line captions', async () => {
 
   await screen.findAllByText('Best Animal');
 
-  function contestItem(name: string) {
-    return within(screen.getByText(name).closest('li')!);
-  }
   function contestItems(name: string) {
     return screen.getAllByText(name).map((el) => within(el.closest('li')!));
   }
@@ -1122,13 +1206,15 @@ test('contest list shows correct status line captions', async () => {
   aquariumCouncil.getByText('Overvote Resolved; Undervote Created');
 
   // new-zoo-either: Overvote Created
-  contestItem('Ballot Measure 1 - Part 1').getByText('Overvote Created');
+  getContestListItem('Ballot Measure 1 - Part 1').getByText('Overvote Created');
 
   // new-zoo-pick: Undervote Resolved
-  contestItem('Ballot Measure 1 - Part 2').getByText('Undervote Resolved');
+  getContestListItem('Ballot Measure 1 - Part 2').getByText(
+    'Undervote Resolved'
+  );
 
   // fishing: Undervote Created
-  contestItem('Ballot Measure 3').getByText('Undervote Created');
+  getContestListItem('Ballot Measure 3').getByText('Undervote Created');
   apiMock.apiClient.releaseBallotAdjudicationClaim
     .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves();
@@ -1172,19 +1258,17 @@ test('contest list suppresses undervote captions when not in system settings', a
 
   await screen.findByText('Best Animal');
 
-  function contestItem(name: string) {
-    return within(screen.getByText(name).closest('li')!);
-  }
-
   // Overvote caption still shows
-  contestItem('Best Animal').getByText('Overvote Confirmed');
+  getContestListItem('Best Animal').getByText('Overvote Confirmed');
 
   // Undervote captions are suppressed
   expect(
-    contestItem('Ballot Measure 1 - Part 2').queryByText('Undervote Resolved')
+    getContestListItem('Ballot Measure 1 - Part 2').queryByText(
+      'Undervote Resolved'
+    )
   ).toBeNull();
   expect(
-    contestItem('Ballot Measure 3').queryByText('Undervote Created')
+    getContestListItem('Ballot Measure 3').queryByText('Undervote Created')
   ).toBeNull();
   apiMock.apiClient.releaseBallotAdjudicationClaim
     .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
@@ -1474,9 +1558,8 @@ test('contest list shows pending status lines before adjudication', async () => 
     apiMock,
   });
 
-  const zooCouncilItem = within(
-    (await screen.findByText('Zoo Council')).closest('li')!
-  );
+  await screen.findByText('Zoo Council');
+  const zooCouncilItem = getContestListItem('Zoo Council');
   zooCouncilItem.getByText('1 write-in to adjudicate');
   zooCouncilItem.getByText('2 marginal marks to adjudicate');
 
@@ -1530,9 +1613,8 @@ test('contest list only shows overvote/undervote/marginal status lines present i
     apiMock,
   });
 
-  const bestAnimal = within(
-    (await screen.findByText('Best Animal')).closest('li')!
-  );
+  await screen.findByText('Best Animal');
+  const bestAnimal = getContestListItem('Best Animal');
   bestAnimal.getByText('1 write-in to adjudicate');
   expect(bestAnimal.queryByText('Overvote to adjudicate')).toBeNull();
   expect(bestAnimal.queryByText(/marginal mark/)).toBeNull();
@@ -1963,6 +2045,239 @@ test('does not auto-resolve when areWriteInCandidatesQualified is false', async 
 
   await screen.findByText(/Ballot ID/);
   expect(screen.getByRole('button', { name: /Accept/ })).toBeDisabled();
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves();
+});
+
+test('crossover voting detected during scanning', async () => {
+  // Democratic + Republican governor contests both have crossover votes. Add a
+  // voted nonpartisan candidate contest, a voted ballot measure, and an unvoted
+  // partisan contest — none of which should show a crossover indicator.
+  const demContest = makeContestAdjudicationData(
+    'governor-democratic',
+    undefined,
+    openPrimaryElection
+  );
+  demContest.options[0].scannedVote = true; // alice-jones
+  const repContest = makeContestAdjudicationData(
+    'governor-republican',
+    undefined,
+    openPrimaryElection
+  );
+  repContest.options[0].scannedVote = true; // dave-wilson
+  const nonpartisanContest = makeContestAdjudicationData(
+    'circuit-court-judge',
+    undefined,
+    openPrimaryElection
+  );
+  nonpartisanContest.options[0].scannedVote = true; // margaret-chen
+  const ballotMeasure = makeContestAdjudicationData(
+    'ballot-measure-1',
+    undefined,
+    openPrimaryElection
+  );
+  ballotMeasure.options[0].scannedVote = true; // yes
+  const unvotedPartisanContest = makeContestAdjudicationData(
+    'governor-libertarian',
+    undefined,
+    openPrimaryElection
+  );
+  const data = makeBallotAdjudicationData(
+    CVR_ID_1,
+    [
+      demContest,
+      repContest,
+      nonpartisanContest,
+      ballotMeasure,
+      unvotedPartisanContest,
+    ],
+    { tag: { isBlankBallot: false, hasCrossoverVote: true } }
+  );
+  setupBasicMocks({ adjudicationData: data });
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition: openPrimaryDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('Crossover Voting Detected');
+  screen.getByText(
+    'Votes detected for multiple parties. Votes in partisan contests will not be counted.'
+  );
+
+  getContestListItem(/Democratic Party/).getByText('Crossover vote detected');
+  getContestListItem(/Republican Party/).getByText('Crossover vote detected');
+  expect(
+    getContestListItem(/Libertarian Party/).queryByText(
+      'Crossover vote detected'
+    )
+  ).toBeNull();
+  expect(
+    getContestListItem('Circuit Court Judge').queryByText(
+      'Crossover vote detected'
+    )
+  ).toBeNull();
+  expect(
+    getContestListItem('County Road Millage Renewal').queryByText(
+      'Crossover vote detected'
+    )
+  ).toBeNull();
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves();
+});
+
+test("crossover voting resolved when one party's vote is removed via adjudication", async () => {
+  // Democratic + Republican governor contests both have crossover votes. Then
+  // the republican contest's only effective vote (dave-wilson) is adjudicated
+  // away to resolve the crossover vote.
+  const demContest = makeContestAdjudicationData(
+    'governor-democratic',
+    undefined,
+    openPrimaryElection
+  );
+  demContest.options[0].scannedVote = true; // alice-jones
+  const repContest = makeContestAdjudicationData(
+    'governor-republican',
+    undefined,
+    openPrimaryElection
+  );
+  repContest.options[0].scannedVote = true; // dave-wilson
+  const data = makeBallotAdjudicationData(CVR_ID_1, [demContest, repContest], {
+    tag: { isBlankBallot: false, hasCrossoverVote: true },
+    adjudicatedContests: [
+      makeAdjudicatedCvrContest('governor-republican', {
+        'dave-wilson': false,
+      }),
+    ],
+  });
+  setupBasicMocks({ adjudicationData: data });
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition: openPrimaryDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('Crossover Voting Resolved');
+  screen.getByText('Ballot no longer has votes for multiple parties.');
+  getContestListItem(/Democratic Party/).getByText('Crossover vote resolved');
+  getContestListItem(/Republican Party/).getByText('Crossover vote resolved');
+  expect(screen.queryByText('Crossover vote detected')).toBeNull();
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves();
+});
+
+test('crossover voting confirmed when ballot is resolved without modifying the votes', async () => {
+  // Democratic + Republican governor contests both have crossover votes. Then
+  // the user marks the ballot resolved without changing the votes.
+  const demContest = makeContestAdjudicationData(
+    'governor-democratic',
+    undefined,
+    openPrimaryElection
+  );
+  demContest.options[0].scannedVote = true; // alice-jones
+  const repContest = makeContestAdjudicationData(
+    'governor-republican',
+    undefined,
+    openPrimaryElection
+  );
+  repContest.options[0].scannedVote = true; // dave-wilson
+  const data = makeBallotAdjudicationData(CVR_ID_1, [demContest, repContest], {
+    tag: { isBlankBallot: false, hasCrossoverVote: true },
+    isResolved: true,
+  });
+  setupBasicMocks({ adjudicationData: data });
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition: openPrimaryDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('Crossover Voting Confirmed');
+  screen.getByText('Votes in partisan contests will not be counted.');
+  getContestListItem(/Democratic Party/).getByText('Crossover vote confirmed');
+  getContestListItem(/Republican Party/).getByText('Crossover vote confirmed');
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves();
+});
+
+test('crossover vote created indicator when adjudication introduces a crossover vote', async () => {
+  // Scanned as a single-party (Democratic) ballot - not flagged crossover - but
+  // a Republican vote is adjudicated in, creating a crossover after the fact.
+  const demContest = makeContestAdjudicationData(
+    'governor-democratic',
+    undefined,
+    openPrimaryElection
+  );
+  demContest.options[0].scannedVote = true; // alice-jones
+  const repContest = makeContestAdjudicationData(
+    'governor-republican',
+    undefined,
+    openPrimaryElection
+  ); // no scanned vote
+  const data = makeBallotAdjudicationData(CVR_ID_1, [demContest, repContest], {
+    tag: { isBlankBallot: false, hasCrossoverVote: false },
+    adjudicatedContests: [
+      makeAdjudicatedCvrContest('governor-republican', { 'dave-wilson': true }),
+    ],
+  });
+  setupBasicMocks({ adjudicationData: data });
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition: openPrimaryDefinition,
+    apiMock,
+  });
+
+  await screen.findAllByText('Crossover vote created');
+  getContestListItem(/Democratic Party/).getByText('Crossover vote created');
+  getContestListItem(/Republican Party/).getByText('Crossover vote created');
+  // The ballot was not scanned as crossover, so the ballot-level crossover
+  // callout never renders.
+  expect(screen.queryByText(/Crossover Voting/)).toBeNull();
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves();
+});
+
+test('crossover voting created indicator persists when the ballot is resolved', async () => {
+  // Same as above, but the user has marked the ballot resolved.
+  const demContest = makeContestAdjudicationData(
+    'governor-democratic',
+    undefined,
+    openPrimaryElection
+  );
+  demContest.options[0].scannedVote = true; // alice-jones
+  const repContest = makeContestAdjudicationData(
+    'governor-republican',
+    undefined,
+    openPrimaryElection
+  ); // no scanned vote
+  const data = makeBallotAdjudicationData(CVR_ID_1, [demContest, repContest], {
+    tag: { isBlankBallot: false, hasCrossoverVote: false },
+    isResolved: true,
+    adjudicatedContests: [
+      makeAdjudicatedCvrContest('governor-republican', { 'dave-wilson': true }),
+    ],
+  });
+  setupBasicMocks({ adjudicationData: data });
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition: openPrimaryDefinition,
+    apiMock,
+  });
+
+  await screen.findAllByText('Crossover vote created');
+  getContestListItem(/Democratic Party/).getByText('Crossover vote created');
+  getContestListItem(/Republican Party/).getByText('Crossover vote created');
+  expect(screen.queryByText(/Crossover Voting/)).toBeNull();
 
   apiMock.apiClient.releaseBallotAdjudicationClaim
     .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -640,7 +640,7 @@ export function BallotAdjudicationScreen({
     AdjudicationReason.Undervote
   );
 
-  const hasCrossoverVoteWithAdjudication = hasCrossoverVote(
+  const ballotHasCrossoverVoteAfterAdjudication = hasCrossoverVote(
     election,
     adjudicatedVotes(allContests, adjudicatedContests)
   );
@@ -712,14 +712,14 @@ export function BallotAdjudicationScreen({
       cvrTag.hasCrossoverVote,
       item
     );
-    const contestHasAdjudicatedCrossoverVote = isContestCrossoverVoted(
-      hasCrossoverVoteWithAdjudication,
+    const contestHasCrossoverVoteAfterAdjudication = isContestCrossoverVoted(
+      ballotHasCrossoverVoteAfterAdjudication,
       item,
-      adjudicatedContests
+      adjudicatedContests.get(item.contest.id)
     );
     const crossoverVoteIsPending =
       contestHasScannedCrossoverVote &&
-      contestHasAdjudicatedCrossoverVote &&
+      contestHasCrossoverVoteAfterAdjudication &&
       !ballotAdjudicationData.isResolved;
     return crossoverVoteIsPending;
   })();

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -649,7 +649,7 @@ export function BallotAdjudicationScreen({
     contestAdjudicationData.every((c) =>
       isContestResolved(c, adjudicatedContests)
     ) ||
-    (cvrTag?.isBlankBallot &&
+    (cvrTag.isBlankBallot &&
       contestAdjudicationData.every(
         (c) =>
           isContestResolved(c, adjudicatedContests) ||
@@ -709,7 +709,7 @@ export function BallotAdjudicationScreen({
       return true;
     }
     const contestHasScannedCrossoverVote = isContestCrossoverVoted(
-      cvrTag?.hasCrossoverVote,
+      cvrTag.hasCrossoverVote,
       item
     );
     const contestHasAdjudicatedCrossoverVote = isContestCrossoverVoted(

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -10,7 +10,7 @@ import {
   Side,
   SystemSettings,
 } from '@votingworks/types';
-import { format } from '@votingworks/utils';
+import { format, hasCrossoverVote } from '@votingworks/utils';
 import type {
   AdjudicatedContestOption,
   AdjudicatedCvrContest,
@@ -45,6 +45,8 @@ import {
 import { AppContext } from '../contexts/app_context';
 import { ContestAdjudicationScreen } from './contest_adjudication_screen';
 import {
+  adjudicatedVotes,
+  isContestCrossoverVoted,
   isContestResolved,
   isContestTagOnlyUndervote,
 } from '../utils/adjudication';
@@ -251,7 +253,7 @@ function HostBallotAdjudicationScreen({
           setBallotData({
             cvrId: nextCvrId,
             contests: [],
-            tag: { isBlankBallot: false },
+            tag: { isBlankBallot: false, hasCrossoverVote: false },
             isResolved: false,
             adjudicatedContests: [],
           });
@@ -534,6 +536,7 @@ export function BallotAdjudicationScreen({
     contestAdjudicationData,
     election
   );
+  const allContests = [...frontContests, ...backContests];
 
   function getDefaultSide(
     adjudicatedContests: ReadonlyMap<ContestId, AdjudicatedCvrContest>
@@ -579,10 +582,7 @@ export function BallotAdjudicationScreen({
       writeInCandidates.map((c) => c.contestId)
     );
 
-    for (const { adjudicationData: contest } of [
-      ...frontContests,
-      ...backContests,
-    ]) {
+    for (const { adjudicationData: contest } of allContests) {
       if (baseline.has(contest.contestId)) continue;
       const { tag } = contest;
       if (!tag) continue;
@@ -640,7 +640,12 @@ export function BallotAdjudicationScreen({
     AdjudicationReason.Undervote
   );
 
-  const allResolved =
+  const hasCrossoverVoteWithAdjudication = hasCrossoverVote(
+    election,
+    adjudicatedVotes(allContests, adjudicatedContests)
+  );
+
+  const allContestAdjudicationsResolved =
     contestAdjudicationData.every((c) =>
       isContestResolved(c, adjudicatedContests)
     ) ||
@@ -659,7 +664,7 @@ export function BallotAdjudicationScreen({
   );
 
   function onAcceptAndNext(): void {
-    if (!allResolved) {
+    if (!allContestAdjudicationsResolved) {
       setShowConfirmModal(true);
       return;
     }
@@ -699,11 +704,24 @@ export function BallotAdjudicationScreen({
 
   const hoveredContestHasWarning = (() => {
     if (!hoveredContestId) return false;
-    const item = find(
-      [...frontContests, ...backContests],
-      (i) => i.contest.id === hoveredContestId
+    const item = find(allContests, (i) => i.contest.id === hoveredContestId);
+    if (!isContestResolved(item.adjudicationData, adjudicatedContests)) {
+      return true;
+    }
+    const contestHasScannedCrossoverVote = isContestCrossoverVoted(
+      cvrTag?.hasCrossoverVote,
+      item
     );
-    return !isContestResolved(item.adjudicationData, adjudicatedContests);
+    const contestHasAdjudicatedCrossoverVote = isContestCrossoverVoted(
+      hasCrossoverVoteWithAdjudication,
+      item,
+      adjudicatedContests
+    );
+    const crossoverVoteIsPending =
+      contestHasScannedCrossoverVote &&
+      contestHasAdjudicatedCrossoverVote &&
+      !ballotAdjudicationData.isResolved;
+    return crossoverVoteIsPending;
   })();
 
   if (selectedContestId && !isClaimed) {
@@ -793,7 +811,7 @@ export function BallotAdjudicationScreen({
               cvrTag={cvrTag}
               election={election}
               frontContests={frontContests}
-              isResolved={ballotAdjudicationData.isResolved}
+              isBallotResolved={ballotAdjudicationData.isResolved}
               onHover={onContestHover}
               onSelect={(contestId) => setSelectedContestId(contestId)}
               onSelectSide={setSelectedSide}
@@ -832,7 +850,9 @@ export function BallotAdjudicationScreen({
                     icon="Done"
                     onPress={onAcceptAndNext}
                     disabled={hasUnresolvedWriteIns || isClaimInFlight}
-                    variant={allResolved ? 'primary' : 'neutral'}
+                    variant={
+                      allContestAdjudicationsResolved ? 'primary' : 'neutral'
+                    }
                   >
                     Accept
                   </PrimaryNavButton>

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
@@ -34,7 +34,7 @@ import {
 } from '../components/adjudication_ballot_image_viewer';
 import { WriteInAdjudicationButton } from '../components/write_in_adjudication_button';
 import { ContestOptionButton } from '../components/contest_option_button';
-import { getOptionCoordinates } from '../utils/adjudication';
+import { contestPartyLabel, getOptionCoordinates } from '../utils/adjudication';
 import {
   DoubleVoteAlert,
   DoubleVoteAlertModal,
@@ -229,6 +229,7 @@ export function ContestAdjudicationScreen({
   const { options: contestOptions, contestId, tag } = contestAdjudicationData;
   const contest = find(election.contests, (c) => c.id === contestId);
   const isCandidateContest = contest.type === 'candidate';
+  const partyLabel = contestPartyLabel(election, contest);
 
   const officialOptions = useMemo(() => {
     const optionDefinitions = contestOptions.map((o) => o.definition);
@@ -400,7 +401,10 @@ export function ContestAdjudicationScreen({
         <AdjudicationPanel>
           {focusedOptionId && <AdjudicationPanelOverlay />}
           <ContestHeader>
-            <CompactH2>{getContestDistrictName(election, contest)}</CompactH2>
+            <CompactH2>
+              {getContestDistrictName(election, contest)}
+              {partyLabel && ` — ${partyLabel}`}
+            </CompactH2>
             <CompactH1>{contest.title}</CompactH1>
           </ContestHeader>
           <BallotVoteCount>

--- a/apps/admin/frontend/src/utils/adjudication.ts
+++ b/apps/admin/frontend/src/utils/adjudication.ts
@@ -63,7 +63,7 @@ export function getCurrentVote(
 }
 
 export function isContestCrossoverVoted(
-  ballotHasCrossoverVote: boolean | undefined,
+  ballotHasCrossoverVote: boolean,
   contestItem: {
     contest: AnyContest;
     adjudicationData: ContestAdjudicationData;

--- a/apps/admin/frontend/src/utils/adjudication.ts
+++ b/apps/admin/frontend/src/utils/adjudication.ts
@@ -1,13 +1,21 @@
 import type {
+  AdjudicatedContestOption,
   AdjudicatedCvrContest,
   ContestAdjudicationData,
+  ContestOptionAdjudicationData,
   CvrContestTag,
 } from '@votingworks/admin-backend';
+import { find, throwIllegalValue } from '@votingworks/basics';
 import {
+  AnyContest,
   BallotPageContestOptionLayout,
   ContestId,
   ContestOptionId,
+  Election,
+  isOpenPrimary,
   Rect,
+  Vote,
+  VotesDict,
 } from '@votingworks/types';
 
 export function normalizeWriteInName(name: string): string {
@@ -45,4 +53,90 @@ export function isContestResolved(
 ): boolean {
   if (!contest.tag) return true;
   return adjudicatedContests.has(contest.contestId);
+}
+
+export function getCurrentVote(
+  option: ContestOptionAdjudicationData,
+  adjudicatedOption?: AdjudicatedContestOption
+): boolean {
+  return adjudicatedOption?.hasVote ?? option.scannedVote;
+}
+
+export function isContestCrossoverVoted(
+  ballotHasCrossoverVote: boolean | undefined,
+  contestItem: {
+    contest: AnyContest;
+    adjudicationData: ContestAdjudicationData;
+  },
+  adjudicatedContests?: ReadonlyMap<ContestId, AdjudicatedCvrContest>
+): boolean {
+  if (!ballotHasCrossoverVote) return false;
+  const { contest, adjudicationData } = contestItem;
+  if (!(contest.type === 'candidate' && contest.partyId)) return false;
+  const adjudicatedContest = adjudicatedContests?.get(contest.id);
+  const hasVote = adjudicationData.options.some((option) =>
+    getCurrentVote(
+      option,
+      adjudicatedContest?.adjudicatedContestOptionById[option.definition.id]
+    )
+  );
+  return hasVote;
+}
+
+export function adjudicatedVotes(
+  contests: ReadonlyArray<{
+    contest: AnyContest;
+    adjudicationData: ContestAdjudicationData;
+  }>,
+  adjudicatedContests: ReadonlyMap<ContestId, AdjudicatedCvrContest>
+): VotesDict {
+  return Object.fromEntries(
+    contests.map(({ contest, adjudicationData }): [string, Vote] => {
+      const adjudicatedContest = adjudicatedContests.get(contest.id);
+      switch (contest.type) {
+        case 'candidate':
+          return [
+            contest.id,
+            adjudicationData.options.flatMap((option) =>
+              getCurrentVote(
+                option,
+                adjudicatedContest?.adjudicatedContestOptionById[
+                  option.definition.id
+                ]
+              )
+                ? [option.definition]
+                : []
+            ),
+          ];
+        case 'yesno':
+          return [
+            contest.id,
+            adjudicationData.options.flatMap((option) =>
+              getCurrentVote(
+                option,
+                adjudicatedContest?.adjudicatedContestOptionById[
+                  option.definition.id
+                ]
+              )
+                ? [option.definition.id]
+                : []
+            ),
+          ];
+        default:
+          /* istanbul ignore next */
+          return throwIllegalValue(contest);
+      }
+    })
+  );
+}
+
+export function contestPartyLabel(
+  election: Election,
+  contest: AnyContest
+): string | undefined {
+  return isOpenPrimary(election) &&
+    contest.type === 'candidate' &&
+    contest.partyId
+    ? find(election.parties, (p) => p.id === contest.partyId).fullName
+    : undefined;
 }

--- a/apps/admin/frontend/src/utils/adjudication.ts
+++ b/apps/admin/frontend/src/utils/adjudication.ts
@@ -68,12 +68,11 @@ export function isContestCrossoverVoted(
     contest: AnyContest;
     adjudicationData: ContestAdjudicationData;
   },
-  adjudicatedContests?: ReadonlyMap<ContestId, AdjudicatedCvrContest>
+  adjudicatedContest?: AdjudicatedCvrContest
 ): boolean {
   if (!ballotHasCrossoverVote) return false;
   const { contest, adjudicationData } = contestItem;
   if (!(contest.type === 'candidate' && contest.partyId)) return false;
-  const adjudicatedContest = adjudicatedContests?.get(contest.id);
   const hasVote = adjudicationData.options.some((option) =>
     getCurrentVote(
       option,

--- a/apps/admin/frontend/vitest.config.ts
+++ b/apps/admin/frontend/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: -115,
-        branches: -135,
+        branches: -137,
       },
       exclude: [
         'src/config',

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -92,6 +92,7 @@ import {
   faVolumeXmark,
   faXmark,
   faCircleUser,
+  faArrowRightArrowLeft,
   faArrowRightFromBracket,
   faArrowsSplitUpAndLeft,
   faChartLine,
@@ -376,6 +377,10 @@ export const Icons = {
 
   Copy(props) {
     return <FaIcon {...props} type={faCopy} />;
+  },
+
+  Crossover(props) {
+    return <FaIcon {...props} type={faArrowRightArrowLeft} />;
   },
 
   Danger(props) {


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

<!-- Add a link to a GitHub issue here -->
Closes: https://github.com/votingworks/vxsuite/issues/7885

Adds support for crossover voting in the ballot adjudication flow. Ballots are flagged for adjudication based on whether crossover voting is detected on CVR import.

In the UI, mirrors the approach for blank ballots, showing a ballot-level callout when there is crossover voting. Also adds a contest-level status line to indicate which contests are impacted. Note that the contest-level status also shows up when adjudicating votes introduces new crossover voting.

## Demo Video or Screenshot

Detected crossover votes



https://github.com/user-attachments/assets/f78cca81-a38f-4729-9270-1b6ffacf1aa7




Crossover votes from adjudication



https://github.com/user-attachments/assets/f247514a-f53e-4ddc-9260-b014454c37dd









## Testing Plan
- Manual testing
- Updated automated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
