### PR TITLE
fix(usb-drive): properly handle `/dev/sdp` devices

### DIFF
--- a/libs/usb-drive/src/block_devices.test.ts
+++ b/libs/usb-drive/src/block_devices.test.ts
@@ -381,6 +381,45 @@ describe('getAllUsbDrives', () => {
     ]);
   });
 
+  test('derives parent disk path for orphan partition on a p-suffixed disk', async () => {
+    // /dev/nvme0p1 → /dev/nvme0 is right, but /dev/sdp1 → /dev/sd is not.
+    execMock.mockResolvedValueOnce({
+      stdout: exportDbEntry({
+        devname: '/dev/sdp1',
+        devtype: 'partition',
+        fstype: 'vfat',
+        fsver: 'FAT32',
+        label: 'VxUSB-ABCDE',
+      }),
+      stderr: '',
+    });
+    readFileMock.mockResolvedValueOnce(
+      procMountsContent([
+        { device: '/dev/sdp1', mountpoint: '/media/vx/usb-drive-sdp1' },
+      ])
+    );
+
+    const result = await getAllUsbDrives();
+
+    expect(result).toEqual<UsbDiskDeviceInfo[]>([
+      {
+        devPath: '/dev/sdp',
+        vendor: undefined,
+        model: undefined,
+        serial: undefined,
+        partitions: [
+          {
+            devPath: '/dev/sdp1',
+            mountpoint: '/media/vx/usb-drive-sdp1',
+            fstype: 'vfat',
+            fsver: 'FAT32',
+            label: 'VxUSB-ABCDE',
+          },
+        ],
+      },
+    ]);
+  });
+
   test('excludes orphan partition with no parent disk that fails isDataUsbDrive', async () => {
     // Some USB card readers expose only a partition entry (not a parent disk)
     // in the udev database. If the partition is mounted outside /media, it

--- a/libs/usb-drive/src/block_devices.ts
+++ b/libs/usb-drive/src/block_devices.ts
@@ -227,7 +227,7 @@ export async function getAllUsbDrives(): Promise<UsbDiskDeviceInfo[]> {
   // the disk path by stripping the partition suffix and synthesize a disk entry.
   const diskDevPaths = new Set(diskDevices.map((d) => d.devname));
   for (const partition of partitionDevices) {
-    const diskDevPath = partition.devname.replace(/(p\d+|\d+)$/, '');
+    const diskDevPath = partition.devname.replace(/(?<=\d)p\d+$|\d+$/, '');
     if (diskDevPaths.has(diskDevPath)) continue;
 
     const partitionInfo: BlockDeviceInfo = {


### PR DESCRIPTION
## Overview
The regex to turn a device name into a partition name was over-eager in stripping a trailing `p\d` without checking that the `p` was part of an nvme-style device name e.g. `/dev/nvme0p1`. This change fixes it by looking for a preceding digit before matching the `p\d`.

## Demo Video or Screenshot
```json
# previously
$ ./bin/usb-drive status
[
  {
    "devPath": "/dev/sdp",
    "vendor": "QEMU",
    "model": "QEMU_HARDDISK",
    "serial": "1-0000:00:02.1:00.0-4",
    "partitions": [
      {
        "devPath": "/dev/sdp1",
        "label": "VxUSB-IFFA9",
        "fstype": "ext4",
        "fsver": "1.0",
        "mount": {
          "type": "mounted",
          "mountPoint": "/media/vx/usb-drive-sdp1"
        }
      }
    ]
  },
  {
    "devPath": "/dev/sd",
    "partitions": [
      {
        "devPath": "/dev/sdp1",
        "label": "VxUSB-IFFA9",
        "fstype": "ext4",
        "fsver": "1.0",
        "mount": {
          "type": "mounted",
          "mountPoint": "/media/vx/usb-drive-sdp1"
        }
      }
    ]
  }
]

# now
$ ./bin/usb-drive status
[
  {
    "devPath": "/dev/sdp",
    "vendor": "QEMU",
    "model": "QEMU_HARDDISK",
    "serial": "1-0000:00:02.1:00.0-4",
    "partitions": [
      {
        "devPath": "/dev/sdp1",
        "label": "VxUSB-IFFA9",
        "fstype": "ext4",
        "fsver": "1.0",
        "mount": {
          "type": "mounted",
          "mountPoint": "/media/vx/usb-drive-sdp1"
        }
      }
    ]
  }
]
```

## Testing Plan
Added automated regression test. Verified manually with a `/dev/sdp` device present.