### PR TITLE
VxDesign: Use NavLink for All Elections nav item

### DIFF
--- a/apps/design/frontend/src/nav_screen.tsx
+++ b/apps/design/frontend/src/nav_screen.tsx
@@ -3,7 +3,6 @@ import { ElectionId } from '@votingworks/types';
 import {
   AppLogo,
   LeftNav as LeftNavBase,
-  LinkButton,
   Main,
   NavDivider,
   NavListItem,
@@ -166,14 +165,9 @@ export function ElectionNavScreen({
           )}
           <NavDivider />
           <NavListItem>
-            <LinkButton
-              to="/"
-              fill="transparent"
-              color="inverseNeutral"
-              icon="ChevronLeft"
-            >
+            <NavLink to="/" icon="ChevronLeft">
               All Elections
-            </LinkButton>
+            </NavLink>
           </NavListItem>
         </NavList>
       }

--- a/libs/ui/src/left_nav.tsx
+++ b/libs/ui/src/left_nav.tsx
@@ -53,7 +53,7 @@ export function NavLink({
   isActive,
   ...linkButtonProps
 }: {
-  isActive: boolean;
+  isActive?: boolean;
 } & LinkButtonProps): JSX.Element {
   return (
     <NavLinkButton


### PR DESCRIPTION


## Overview

<!-- Add a link to a GitHub issue here -->
Previously, we used LinkButton, which wasn't extending to the full width of the sidebar like the other nav items.

## Demo Video or Screenshot
Before
<img width="225" height="91" alt="Screenshot 2026-06-03 at 10 31 20 AM" src="https://github.com/user-attachments/assets/2bb0b9c8-c848-412d-9757-9cde8efe3944" />

After
<img width="228" height="127" alt="Screenshot 2026-06-03 at 10 31 10 AM" src="https://github.com/user-attachments/assets/52d44e6d-d405-4bf1-921f-51d2a684686c" />

## Testing Plan
Looked at it

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
