### PR TITLE
VxAdmin: Polish adjudication status captions

### DIFF
--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -16,15 +16,7 @@ import type {
   CvrTag,
 } from '@votingworks/admin-backend';
 import { find } from '@votingworks/basics';
-import {
-  Button,
-  Callout,
-  Caption,
-  Font,
-  FontProps,
-  Icons,
-  P,
-} from '@votingworks/ui';
+import { Button, Callout, Caption, FontProps, Icons, P } from '@votingworks/ui';
 import { hasCrossoverVote } from '@votingworks/utils';
 import pluralize from 'pluralize';
 import { EntityList } from './entity_list';
@@ -91,7 +83,6 @@ function StatusLine({
   icon,
   children,
   color,
-  weight = 'semiBold',
   ...fontProps
 }: FontProps &
   React.PropsWithChildren<{
@@ -99,7 +90,7 @@ function StatusLine({
     color?: 'primary';
   }>) {
   return (
-    <StatusCaption color={color} weight={weight} {...fontProps}>
+    <StatusCaption color={color} {...fontProps}>
       {icon} {children}
     </StatusCaption>
   );
@@ -172,10 +163,10 @@ function getAdjudicatedContestStatusLine(
 
   if (originalStatus === adjudicatedStatus) {
     if (originalStatus === 'overvote') {
-      return <StatusLineConfirmed>Overvote Confirmed</StatusLineConfirmed>;
+      return <StatusLineConfirmed>Overvote confirmed</StatusLineConfirmed>;
     }
     if (originalStatus === 'undervote' && showUndervoteStatus) {
-      return <StatusLineConfirmed>Undervote Confirmed</StatusLineConfirmed>;
+      return <StatusLineConfirmed>Undervote confirmed</StatusLineConfirmed>;
     }
     return null;
   }
@@ -185,24 +176,24 @@ function getAdjudicatedContestStatusLine(
     if (adjudicatedStatus === 'undervote' && showUndervoteStatus) {
       return (
         <StatusLineWarning>
-          Overvote Resolved; Undervote Created
+          Overvote resolved; undervote created
         </StatusLineWarning>
       );
     }
-    return <StatusLineConfirmed>Overvote Resolved</StatusLineConfirmed>;
+    return <StatusLineConfirmed>Overvote resolved</StatusLineConfirmed>;
   }
 
   // New overvote
   if (adjudicatedStatus === 'overvote') {
-    return <StatusLineWarning>Overvote Created</StatusLineWarning>;
+    return <StatusLineWarning>Overvote created</StatusLineWarning>;
   }
 
   // Undervote transitions only if enabled
   if (showUndervoteStatus) {
     if (originalStatus === 'undervote' && adjudicatedStatus !== 'undervote') {
-      return <StatusLineConfirmed>Undervote Resolved</StatusLineConfirmed>;
+      return <StatusLineConfirmed>Undervote resolved</StatusLineConfirmed>;
     }
-    return <StatusLineWarning>Undervote Created</StatusLineWarning>;
+    return <StatusLineWarning>Undervote created</StatusLineWarning>;
   }
 }
 
@@ -233,21 +224,19 @@ function getAdjudicatedOptionStatusLine(
       writeInRecord.isUnmarked ||
       writeInRecord.isUndetected ||
       hasMarginalMark
-        ? 'Ambiguous Write-In'
-        : 'Write-In';
+        ? 'Ambiguous write-in'
+        : 'Write-in';
 
     if (candidateName) {
       return (
         <StatusLineAdjudicated>
-          <Font weight="semiBold">{writeInPrefix} </Font>adjudicated for
-          <Font weight="semiBold"> {candidateName}</Font>
+          {writeInPrefix} adjudicated for {candidateName}
         </StatusLineAdjudicated>
       );
     }
     return (
       <StatusLineAdjudicated>
-        <Font weight="semiBold">{writeInPrefix} </Font>adjudicated as
-        <Font weight="semiBold"> Invalid</Font>
+        {writeInPrefix} adjudicated as invalid
       </StatusLineAdjudicated>
     );
   }
@@ -255,26 +244,20 @@ function getAdjudicatedOptionStatusLine(
   const currentVote = getCurrentVote(option, adjudicatedOption);
 
   if (hasMarginalMark) {
-    const newValue = currentVote ? 'Valid' : 'Invalid';
+    const newValue = currentVote ? 'valid' : 'invalid';
     return (
       <StatusLineAdjudicated>
-        <Font weight="semiBold">Marginal Mark </Font>for
-        <Font weight="semiBold"> {definition.name} </Font>
-        adjudicated as
-        <Font weight="semiBold"> {newValue}</Font>
+        Marginal mark for {definition.name} adjudicated as {newValue}
       </StatusLineAdjudicated>
     );
   }
 
   if (currentVote !== scannedVote) {
-    const preface = currentVote ? 'Undetected Mark' : 'Mark';
-    const newValue = currentVote ? 'Valid' : 'Invalid';
+    const preface = currentVote ? 'Undetected mark' : 'Mark';
+    const newValue = currentVote ? 'valid' : 'invalid';
     return (
       <StatusLineAdjudicated>
-        <Font weight="semiBold">{preface} </Font>for
-        <Font weight="semiBold"> {definition.name} </Font>
-        adjudicated as
-        <Font weight="semiBold"> {newValue}</Font>
+        {preface} for {definition.name} adjudicated as {newValue}
       </StatusLineAdjudicated>
     );
   }

--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -97,28 +97,27 @@ function StatusLine({
 }
 
 const StatusLineNeedsAdjudication = styled(StatusLine).attrs({
-  icon: <Icons.PenToSquare color="warning" />,
+  icon: <Icons.PenToSquare color="warning" fixedWidth />,
 })`
   /* stylelint-disable-next-line no-empty-source */
 `;
 
 const StatusLineWarning = styled(StatusLine).attrs({
-  icon: <Icons.Warning color="warning" />,
+  icon: <Icons.Warning color="warning" fixedWidth />,
   color: 'primary',
 })`
   /* stylelint-disable-next-line no-empty-source */
 `;
 
 const StatusLineConfirmed = styled(StatusLine).attrs({
-  icon: <Icons.Done />,
+  icon: <Icons.Done fixedWidth />,
   color: 'primary',
 })`
   /* stylelint-disable-next-line no-empty-source */
 `;
 
 const StatusLineAdjudicated = styled(StatusLine).attrs({
-  icon: <Icons.PenToSquare />,
-  weight: 'regular',
+  icon: <Icons.PenToSquare fixedWidth />,
   color: 'primary',
 })`
   /* stylelint-disable-next-line no-empty-source */
@@ -340,8 +339,8 @@ function CrossoverVoteStatus({
   contestHasCrossoverVoteAfterAdjudication: boolean;
   isBallotResolved: boolean;
 }) {
-  const warningIcon = <Icons.Crossover color="warning" />;
-  const primaryIcon = <Icons.Crossover color="primary" />;
+  const warningIcon = <Icons.Crossover color="warning" fixedWidth />;
+  const primaryIcon = <Icons.Crossover color="primary" fixedWidth />;
   if (ballotHasScannedCrossoverVote) {
     if (contestHasCrossoverVoteAfterAdjudication) {
       if (isBallotResolved) {

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -1191,30 +1191,30 @@ test('contest list shows correct status line captions', async () => {
     return screen.getAllByText(name).map((el) => within(el.closest('li')!));
   }
 
-  // best-animal-mammal: Overvote Confirmed
+  // best-animal-mammal: Overvote confirmed
   const [bestAnimalMammal, bestAnimalFish] = contestItems('Best Animal');
-  bestAnimalMammal.getByText('Overvote Confirmed');
+  bestAnimalMammal.getByText('Overvote confirmed');
 
-  // best-animal-fish: Undervote Confirmed
-  bestAnimalFish.getByText('Undervote Confirmed');
+  // best-animal-fish: Undervote confirmed
+  bestAnimalFish.getByText('Undervote confirmed');
 
-  // zoo-council-mammal: Overvote Resolved
+  // zoo-council-mammal: Overvote resolved
   const [zooCouncil, aquariumCouncil] = contestItems('Zoo Council');
-  zooCouncil.getByText('Overvote Resolved');
+  zooCouncil.getByText('Overvote resolved');
 
-  // aquarium-council-fish: Overvote Resolved; Undervote Created
-  aquariumCouncil.getByText('Overvote Resolved; Undervote Created');
+  // aquarium-council-fish: Overvote resolved; undervote created
+  aquariumCouncil.getByText('Overvote resolved; undervote created');
 
-  // new-zoo-either: Overvote Created
-  getContestListItem('Ballot Measure 1 - Part 1').getByText('Overvote Created');
+  // new-zoo-either: Overvote created
+  getContestListItem('Ballot Measure 1 - Part 1').getByText('Overvote created');
 
-  // new-zoo-pick: Undervote Resolved
+  // new-zoo-pick: Undervote resolved
   getContestListItem('Ballot Measure 1 - Part 2').getByText(
-    'Undervote Resolved'
+    'Undervote resolved'
   );
 
-  // fishing: Undervote Created
-  getContestListItem('Ballot Measure 3').getByText('Undervote Created');
+  // fishing: Undervote created
+  getContestListItem('Ballot Measure 3').getByText('Undervote created');
   apiMock.apiClient.releaseBallotAdjudicationClaim
     .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves();
@@ -1259,16 +1259,16 @@ test('contest list suppresses undervote captions when not in system settings', a
   await screen.findByText('Best Animal');
 
   // Overvote caption still shows
-  getContestListItem('Best Animal').getByText('Overvote Confirmed');
+  getContestListItem('Best Animal').getByText('Overvote confirmed');
 
   // Undervote captions are suppressed
   expect(
     getContestListItem('Ballot Measure 1 - Part 2').queryByText(
-      'Undervote Resolved'
+      'Undervote resolved'
     )
   ).toBeNull();
   expect(
-    getContestListItem('Ballot Measure 3').queryByText('Undervote Created')
+    getContestListItem('Ballot Measure 3').queryByText('Undervote created')
   ).toBeNull();
   apiMock.apiClient.releaseBallotAdjudicationClaim
     .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
@@ -1473,30 +1473,30 @@ test('contest list shows correct option resolution bullets', async () => {
   }
 
   // Zoo Council: write-in bullets
-  findTextInContest('Zoo Council', 'Write-In adjudicated for Zebra');
+  findTextInContest('Zoo Council', 'Write-in adjudicated for Zebra');
   findTextInContest(
     'Zoo Council',
-    `Write-In adjudicated for ${WRITE_IN_CANDIDATE_NAME}`
+    `Write-in adjudicated for ${WRITE_IN_CANDIDATE_NAME}`
   );
-  findTextInContest('Zoo Council', 'Write-In adjudicated as Invalid');
-  findTextInContest('Zoo Council', 'Ambiguous Write-In adjudicated as Invalid');
+  findTextInContest('Zoo Council', 'Write-in adjudicated as invalid');
+  findTextInContest('Zoo Council', 'Ambiguous write-in adjudicated as invalid');
 
   // Zoo Council: marginal mark bullets
   findTextInContest(
     'Zoo Council',
-    'Marginal Mark for Zebra adjudicated as Valid'
+    'Marginal mark for Zebra adjudicated as valid'
   );
   findTextInContest(
     'Zoo Council',
-    'Marginal Mark for Lion adjudicated as Invalid'
+    'Marginal mark for Lion adjudicated as invalid'
   );
 
   // Best Animal: vote adjudication bullets
   findTextInContest(
     'Best Animal',
-    'Undetected Mark for Horse adjudicated as Valid'
+    'Undetected mark for Horse adjudicated as valid'
   );
-  findTextInContest('Best Animal', 'Mark for Otter adjudicated as Invalid');
+  findTextInContest('Best Animal', 'Mark for Otter adjudicated as invalid');
   apiMock.apiClient.releaseBallotAdjudicationClaim
     .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
     .resolves();

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
@@ -14,7 +14,7 @@ import {
   Id,
   Side,
 } from '@votingworks/types';
-import { Button, Main, Screen, Font, Icons, H2, H1, P } from '@votingworks/ui';
+import { Button, Main, Screen, Icons, H2, H1, P } from '@votingworks/ui';
 import { assert, assertDefined, find } from '@votingworks/basics';
 import type {
   AdjudicatedContestOptions,
@@ -177,24 +177,23 @@ function renderContestOptionButtonCaption({
         marginalMarkStatus === 'resolved') &&
         !isWriteInPending(writeInStatus));
     if (isAmbiguousAndAdjudicated) {
-      originalValueStr = 'Ambiguous Write-In';
+      originalValueStr = 'Ambiguous write-in';
     } else if (scannedVote && isWriteInInvalid(writeInStatus)) {
-      originalValueStr = 'Write-In';
+      originalValueStr = 'Write-in';
     }
   } else if (marginalMarkStatus === 'resolved') {
-    originalValueStr = 'Marginal Mark';
+    originalValueStr = 'Marginal mark';
   } else if (scannedVote !== currentVote) {
-    originalValueStr = scannedVote ? 'Mark' : 'Undetected Mark';
+    originalValueStr = scannedVote ? 'Mark' : 'Undetected mark';
   }
 
   if (!originalValueStr) {
     return null;
   }
-  const newValueStr = currentVote ? 'Valid' : 'Invalid';
+  const newValueStr = currentVote ? 'valid' : 'invalid';
   return (
     <ContestOptionButtonCaption>
-      <Font weight="semiBold">{originalValueStr} </Font>adjudicated as
-      <Font weight="semiBold"> {newValueStr}</Font>
+      {originalValueStr} adjudicated as {newValueStr}
     </ContestOptionButtonCaption>
   );
 }

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -128,6 +128,7 @@ export type IconColor = (typeof ICON_COLORS)[number];
 export interface IconProps {
   className?: string;
   color?: IconColor;
+  fixedWidth?: boolean;
   style?: React.CSSProperties;
 }
 
@@ -164,7 +165,7 @@ function iconColor(theme: UiTheme, color?: IconColor) {
 }
 
 function FaIcon(props: InnerProps): JSX.Element {
-  const { className, pulse, spin, type, color, style = {} } = props;
+  const { className, pulse, spin, type, color, fixedWidth, style = {} } = props;
   const theme = useTheme();
 
   /**
@@ -221,6 +222,7 @@ function FaIcon(props: InnerProps): JSX.Element {
       icon={type}
       spin={spin}
       pulse={pulse}
+      fixedWidth={fixedWidth}
       style={{
         color: iconColor(theme, color),
         ...style,


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

<!-- Add a link to a GitHub issue here -->
Makes the status lines consistent in style now that we've added crossover voting status lines.
- Makes adjudication status captions all sentence case and regular font weight
- Aligns icons by making them fixed width
- Adds a matching icon to the status lines on the contest screen

## Demo Video or Screenshot
<img width="961" height="603" alt="Screenshot 2026-06-03 at 12 44 52 PM" src="https://github.com/user-attachments/assets/dc1e60cb-0d8f-4e50-8bba-2c9764ba57e9" />

<img width="961" height="603" alt="Screenshot 2026-06-03 at 12 47 29 PM" src="https://github.com/user-attachments/assets/e8f996cf-29df-4acc-9247-91b7a0e16731" />

## Testing Plan
Updated automated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
