### PR TITLE
Reorganize VxAdmin reports screen

### DIFF
--- a/apps/admin/frontend/src/screens/reporting/reports_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.test.tsx
@@ -220,6 +220,22 @@ describe('showing WIA report link', () => {
     await screen.findButton(BUTTON_TEXT);
   });
 
+  test('heading shows Official prefix when results are official', async () => {
+    apiMock.expectGetCastVoteRecordFileMode('official');
+    apiMock.expectGetManualResultsMetadata([]);
+    apiMock.expectGetTotalBallotCount(3000);
+    apiMock.expectGetRegisteredVoterCounts(null);
+    apiMock.expectGetSystemSettings();
+
+    renderInAppContext(<ReportsScreen />, {
+      electionDefinition,
+      apiMock,
+      isOfficialResults: true,
+    });
+
+    await screen.findByRole('heading', { name: 'Official Write-In Reports' });
+  });
+
   test('not shown when election does not have write-in contests', async () => {
     apiMock.expectGetCastVoteRecordFileMode('test');
     apiMock.expectGetManualResultsMetadata([]);

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.test.tsx
@@ -203,7 +203,7 @@ describe('voter turnout report link', () => {
 });
 
 describe('showing WIA report link', () => {
-  const BUTTON_TEXT = 'Unofficial Write-In Adjudication Report';
+  const BUTTON_TEXT = 'Write-In Adjudication Report';
 
   test('shown when election has write-in contests', async () => {
     apiMock.expectGetCastVoteRecordFileMode('test');
@@ -398,9 +398,7 @@ describe('polls close time enforcement', () => {
 
     await screen.findButton('Full Election Tally Report');
     expect(screen.getButton('Full Election Tally Report')).toBeEnabled();
-    expect(
-      screen.getButton('Unofficial Write-In Adjudication Report')
-    ).toBeEnabled();
+    expect(screen.getButton('Write-In Adjudication Report')).toBeEnabled();
     expect(screen.getButton('Mark Election Results as Official')).toBeEnabled();
     screen.getByText(/Test cast vote records are currently loaded/);
     expect(

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
@@ -209,30 +209,28 @@ export function ReportsScreen(): JSX.Element {
       </Section>
       {!closedPollsActionsBlocked && electionHasWriteInContest && (
         <Section>
-          <H2>Write-In Reports</H2>
+          <H2>{statusPrefix} Write-In Reports</H2>
+          {electionHasWriteInContest && (
+            <P>
+              <LinkButton
+                to={routerPaths.tallyWriteInReport}
+                disabled={closedPollsActionsBlocked}
+              >
+                {statusPrefix} Write-In Adjudication Report
+              </LinkButton>
+            </P>
+          )}
           <P>
             <LinkButton to={routerPaths.writeInImageReport}>
-              Single Contest Write-In Image Report
+              Write-In Image Report
             </LinkButton>
           </P>
         </Section>
       )}
       {!closedPollsActionsBlocked &&
-        (electionHasWriteInContest ||
-          voterTurnoutReportEnabled ||
-          isLiveResultsReportingEnabled) && (
+        (voterTurnoutReportEnabled || isLiveResultsReportingEnabled) && (
           <Section>
-            <H2>Other Reports</H2>
-            {electionHasWriteInContest && (
-              <P>
-                <LinkButton
-                  to={routerPaths.tallyWriteInReport}
-                  disabled={closedPollsActionsBlocked}
-                >
-                  {statusPrefix} Write-In Adjudication Report
-                </LinkButton>
-              </P>
-            )}
+            <H2>Live Reports</H2>
             {voterTurnoutReportEnabled && (
               <P>
                 <LinkButton to={routerPaths.voterTurnoutReport}>

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
@@ -210,17 +210,13 @@ export function ReportsScreen(): JSX.Element {
       {!closedPollsActionsBlocked && electionHasWriteInContest && (
         <Section>
           <H2>{statusPrefix} Write-In Reports</H2>
-          {electionHasWriteInContest && (
-            <P>
-              <LinkButton
-                to={routerPaths.tallyWriteInReport}
-                disabled={closedPollsActionsBlocked}
-              >
-                {statusPrefix} Write-In Adjudication Report
-              </LinkButton>
-            </P>
-          )}
           <P>
+            <LinkButton
+              to={routerPaths.tallyWriteInReport}
+              disabled={closedPollsActionsBlocked}
+            >
+              Write-In Adjudication Report
+            </LinkButton>{' '}
             <LinkButton to={routerPaths.writeInImageReport}>
               Write-In Image Report
             </LinkButton>
@@ -230,7 +226,7 @@ export function ReportsScreen(): JSX.Element {
       {!closedPollsActionsBlocked &&
         (voterTurnoutReportEnabled || isLiveResultsReportingEnabled) && (
           <Section>
-            <H2>Live Reports</H2>
+            <H2>Other Reports</H2>
             {voterTurnoutReportEnabled && (
               <P>
                 <LinkButton to={routerPaths.voterTurnoutReport}>

--- a/apps/admin/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/admin/integration-testing/e2e/screenshots.spec.ts
@@ -536,7 +536,7 @@ test('results', async ({ page }) => {
   });
 
   await page.getByRole('button', { name: 'Reports' }).click();
-  await page.getByText('Unofficial Write-In Adjudication Report').click();
+  await page.getByText('Write-In Adjudication Report').click();
   await page
     .getByRole('heading', { name: 'Write-In Adjudication Report' })
     .waitFor();


### PR DESCRIPTION
## Overview

Just some small tweaks to the VxAdmin reports screen per discussion in https://votingworks.slack.com/archives/CEL6D3GAD/p1779908241559839

Changes include:

* Grouping write-in reports
* Shortening "Single-Conest Write-In Image Report" down to "Write-In Image Report"
* Moving the Official/Unofficial modifier out of the "Write-In Adjudication Report" button and into the corresponding header for consistency with other sections

## Demo Video or Screenshot

### Unofficial

| Before | After |
| - | - |
| <img width="400" alt="unofficial-before" src="https://github.com/user-attachments/assets/267c2b3e-b6d9-4b71-8a49-f32367a8c454" /> | <img width="400" alt="unofficial-after" src="https://github.com/user-attachments/assets/430d592c-1ef0-44f5-8afd-af82e8be40c3" /> |

### Official

| Before | After |
| - | - |
| <img width="400" alt="official-before" src="https://github.com/user-attachments/assets/b7e8f006-1571-47cc-8ddf-2750d2c1f0d9" /> | <img width="400" alt="official-after" src="https://github.com/user-attachments/assets/702de637-4502-4d8b-aa82-915b74308f00" /> |

## Testing Plan

- [x] Automated tests
- [x] Manual

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.