### PR TITLE
[Mark/MarkScan] Remove old condition for LocationPicker rendering

### DIFF
--- a/apps/mark-scan/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.tsx
@@ -114,18 +114,16 @@ export function AdminScreen({
           {format.count(ballotsPrintedCount)}
         </P>
         <H3 as="h2">Configuration</H3>
-        {election.precincts.length > 1 && (
-          <P>
-            <LocationPicker
-              appPrecinct={appPrecinct}
-              election={election}
-              pollsState={pollsState}
-              pollingPlaceId={pollingPlaceId}
-              selectPollingPlace={(id) => selectPollingPlace({ id })}
-              selectPrecinct={(p) => selectPrecinct({ precinctSelection: p })}
-            />
-          </P>
-        )}
+        <P>
+          <LocationPicker
+            appPrecinct={appPrecinct}
+            election={election}
+            pollsState={pollsState}
+            pollingPlaceId={pollingPlaceId}
+            selectPollingPlace={(id) => selectPollingPlace({ id })}
+            selectPrecinct={(p) => selectPrecinct({ precinctSelection: p })}
+          />
+        </P>
         <P>
           <SegmentedButton
             label="Ballot Mode"

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -123,18 +123,16 @@ export function AdminScreen({
           {format.count(ballotsPrintedCount)}
         </P>
         <H3 as="h2">Configuration</H3>
-        {election.precincts.length > 1 && (
-          <P>
-            <LocationPicker
-              appPrecinct={appPrecinct}
-              election={election}
-              pollsState={pollsState}
-              pollingPlaceId={pollingPlaceId}
-              selectPollingPlace={(id) => selectPollingPlace({ id })}
-              selectPrecinct={(p) => selectPrecinct({ precinctSelection: p })}
-            />
-          </P>
-        )}
+        <P>
+          <LocationPicker
+            appPrecinct={appPrecinct}
+            election={election}
+            pollsState={pollsState}
+            pollingPlaceId={pollingPlaceId}
+            selectPollingPlace={(id) => selectPollingPlace({ id })}
+            selectPrecinct={(p) => selectPrecinct({ precinctSelection: p })}
+          />
+        </P>
         <P>
           <SegmentedButton
             label="Ballot Mode"


### PR DESCRIPTION
## Overview

This was previously based on the election's precinct count and should have been dropped in the migration to polling places, since the `LocationPicker` now handles the conditional rendering base on location count internally.