### PR TITLE
[VxPrint] Support open primary (consolidated) ballots

### DIFF
--- a/apps/print/backend/src/app.test.ts
+++ b/apps/print/backend/src/app.test.ts
@@ -16,6 +16,7 @@ import {
 } from '@votingworks/types';
 import {
   electionFamousNames2021Fixtures,
+  electionOpenPrimaryFixtures,
   electionPrimaryPrecinctSplitsFixtures,
   electionTwoPartyPrimaryFixtures,
 } from '@votingworks/fixtures';
@@ -670,6 +671,93 @@ test('end-to-end printing flow updates getBallotPrintCounts for primary election
     languageCode: LanguageCode.ENGLISH,
     partyName: 'Fish',
   });
+});
+
+test('end-to-end printing flow handles open primary (consolidated ballots)', async () => {
+  // In an open primary, ballots are consolidated (all parties' contests on one
+  // ballot) and ballot styles have no partyId. VxPrint should print without a
+  // party selection, just like a general election.
+  const electionDefinition = getMockMultiLanguageElectionDefinition(
+    electionOpenPrimaryFixtures.readElectionDefinition(),
+    [LanguageCode.ENGLISH]
+  );
+
+  const ballots = await buildBallotsForElection({
+    electionDefinition,
+    ballotModes: ['official'],
+  });
+  await configureMachine({
+    electionDefinition,
+    ballots,
+    apiClient,
+    auth,
+    mockUsbDrive,
+  });
+  await apiClient.setPrecinctSelection({
+    precinctSelection: ALL_PRECINCTS_SELECTION,
+  });
+  mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
+
+  const { ballotStyles } = electionDefinition.election;
+  const ballotStyle = ballotStyles[0];
+  const precinctId = ballotStyle.precincts[0];
+
+  // Print with no partyId, matching what the frontend sends for open primaries.
+  await apiClient.printBallot({
+    precinctId,
+    languageCode: LanguageCode.ENGLISH,
+    ballotType: BallotType.Precinct,
+    copies: 2,
+  });
+
+  const counts = await apiClient.getBallotPrintCounts();
+  const row = counts.find(
+    (c) => c.ballotStyleId === ballotStyle.id && c.precinctId === precinctId
+  );
+  expect(row).toMatchObject({
+    ballotStyleId: ballotStyle.id,
+    precinctId,
+    precinctCount: 2,
+    absenteeCount: 0,
+    totalCount: 2,
+    languageCode: LanguageCode.ENGLISH,
+    partyName: undefined,
+  });
+});
+
+test('printAllBallotStyles works for open primary (consolidated ballots)', async () => {
+  const electionDefinition = getMockMultiLanguageElectionDefinition(
+    electionOpenPrimaryFixtures.readElectionDefinition(),
+    [LanguageCode.ENGLISH]
+  );
+
+  const ballots = await buildBallotsForElection({
+    electionDefinition,
+    ballotModes: ['official'],
+  });
+  await configureMachine({
+    electionDefinition,
+    ballots,
+    apiClient,
+    auth,
+    mockUsbDrive,
+  });
+  mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
+
+  await apiClient.printAllBallotStyles({
+    languageCode: LanguageCode.ENGLISH,
+    ballotType: BallotType.Precinct,
+    copiesPerStyle: 1,
+  });
+
+  const counts = await apiClient.getBallotPrintCounts();
+  expect(counts.length).toEqual(
+    electionDefinition.election.ballotStyles.length
+  );
+  for (const count of counts) {
+    expect(count.partyName).toBeUndefined();
+    expect(count.totalCount).toEqual(1);
+  }
 });
 
 test('end-to-end printing flow handles precinct splits correctly', async () => {

--- a/apps/print/backend/src/util/ballot_styles.ts
+++ b/apps/print/backend/src/util/ballot_styles.ts
@@ -13,7 +13,7 @@ import {
   find,
   throwIllegalValue,
 } from '@votingworks/basics';
-import { getAllPrecinctsAndSplits } from '@votingworks/types';
+import { getAllPrecinctsAndSplits, isOpenPrimary } from '@votingworks/types';
 import {
   getBallotStyleGroupsForPrecinctOrSplit,
   getPrecinctsAndSplitsForBallotStyle,
@@ -66,22 +66,32 @@ export function findBallotStyleId(
     precinctOrSplit,
   });
 
+  function findBallotStyleInSingleGroup(): BallotStyleId {
+    assert(
+      ballotStyleGroups.length === 1,
+      'Expected exactly one ballot style group per precinct or split'
+    );
+    const ballotStyle = ballotStyleGroups[0].ballotStyles.find((bs) =>
+      assertDefined(bs.languages).includes(languageCode)
+    );
+    assert(ballotStyle, `No ballot style found for language ${languageCode}`);
+    return ballotStyle.id;
+  }
+
   switch (election.type) {
     case 'general': {
-      assert(
-        ballotStyleGroups.length === 1,
-        'General elections should have exactly one ballot style group per precinct or split'
-      );
-      const ballotStyle = ballotStyleGroups[0].ballotStyles.find((bs) =>
-        assertDefined(bs.languages).includes(languageCode)
-      );
-      assert(ballotStyle, `No ballot style found for language ${languageCode}`);
-      return ballotStyle.id;
+      return findBallotStyleInSingleGroup();
     }
     case 'primary': {
+      // In an open primary, ballots are consolidated (all parties' contests on
+      // one ballot), so there is no party selection and a single ballot style
+      // group per precinct or split, just like a general election.
+      if (isOpenPrimary(election)) {
+        return findBallotStyleInSingleGroup();
+      }
       assert(
         partyId !== undefined,
-        'partyId is required for primary elections'
+        'partyId is required for closed primary elections'
       );
       const ballotStyleGroup = ballotStyleGroups.find(
         (bsg) => bsg.partyId === partyId
@@ -139,8 +149,9 @@ export function addBallotsPropsToPrintCountRow(
   const languageCode = assertDefined(ballotStyle.languages)[0] as LanguageCode;
 
   let partyName: string | undefined;
-  if (election.type === 'primary') {
-    assert(ballotStyle.partyId !== undefined);
+  // In an open primary, consolidated ballot styles have no partyId, so there is
+  // no party name to display.
+  if (election.type === 'primary' && ballotStyle.partyId !== undefined) {
     const party = election.parties.find((p) => p.id === ballotStyle.partyId);
     assert(party, `No party found with id ${ballotStyle.partyId}`);
     partyName = party.name;

--- a/apps/print/frontend/src/screens/print_screen.tsx
+++ b/apps/print/frontend/src/screens/print_screen.tsx
@@ -13,6 +13,7 @@ import {
   getBallotStyle,
   hasSplits,
   Id,
+  isOpenPrimary,
   LanguageCode,
   pollingPlaceFromElection,
   pollingPlacePrecinctIds,
@@ -233,7 +234,8 @@ export function PrintScreen({
 
   const parties = getPartyOptions(election);
   const { printer } = getDeviceStatusesQuery.data;
-  const hidePartySelection = election.type !== 'primary';
+  const hidePartySelection =
+    election.type !== 'primary' || isOpenPrimary(election);
 
   // If VxPrint is configured for a single precinct, hide the precinct
   // selection for Poll Workers and default to the configured precinct


### PR DESCRIPTION
## Overview

In primaries, VxPrint lets you select the party of the ballot to print. But in **open primaries**, ballots are *consolidated* — all parties' contests appear on a single ballot, and ballot styles carry **no `partyId`**. VxPrint was never updated for this: because it keyed all primary logic on `election.type === 'primary'`, an open primary rendered an empty "Party" section and left the Print button **permanently disabled**, waiting on a party selection that could never be made. The backend print paths would also have failed (assertions requiring a `partyId`).

This uses the existing `isOpenPrimary()` detector (already used by VxMark / mark-flow-ui) to make VxPrint treat an open primary like a general election: no party selection, one ballot style per precinct/split/language.

### Changes

- **Frontend** (`print_screen.tsx`): `hidePartySelection` now also hides for `isOpenPrimary(election)`, which removes the empty Party section and the disabling term from the Print button.
- **Backend** (`findBallotStyleId`): open primaries resolve like general elections (single ballot style group per precinct/split, found by language, no party). Shared logic factored into a small local helper; the closed-primary path is unchanged.
- **Backend** (`addBallotsPropsToPrintCountRow`, Print All flow): the party-name lookup only runs when `ballotStyle.partyId` is defined; open-primary rows get `partyName: undefined`, which the existing sort already handles.

Note: the frontend sends `partyId` as `''` (empty string) when no party is selected, so the backend detects open primaries via `isOpenPrimary(election)` rather than checking for an undefined `partyId`.

## Demo Video or Screenshot

_N/A — see testing plan._

## Testing Plan

- Added two end-to-end backend tests in `app.test.ts` using `electionOpenPrimaryFixtures`:
  - `printBallot` succeeds with no party and increments the right count (`partyName: undefined`).
  - `printAllBallotStyles` prints every consolidated style without throwing.
- All 19 `print-backend` `app.test.ts` tests pass; `ballot_styles.ts` at 100% line coverage, thresholds met.
- `tsgo` type-check and `lint`/`stylelint` pass for both `print-frontend` and `print-backend`.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions. (No new user actions; existing print logging covers this path.)
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)