### PR TITLE
[VxMark] Remove old frontend code paths related to precinct selection

### DIFF
--- a/apps/mark/backend/src/app.diagnostics.test.ts
+++ b/apps/mark/backend/src/app.diagnostics.test.ts
@@ -259,8 +259,6 @@ test('saveReadinessReport - machine not configured', async () => {
 });
 
 test('saveReadinessReport - machine configured', async () => {
-  setPollingPlacesEnabled(true);
-
   const fixtures = electionFamousNames2021Fixtures;
   const electionDefinition = fixtures.readElectionDefinition();
 
@@ -350,11 +348,3 @@ test('clearLastBarcodeScan clears the scan data', async () => {
   // Verify it's cleared
   expect(await apiClient.getMostRecentBarcodeScan()).toBeNull();
 });
-
-function setPollingPlacesEnabled(enabled: boolean) {
-  if (enabled) {
-    mockFeatureFlagger.enableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  } else {
-    mockFeatureFlagger.disableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  }
-}

--- a/apps/mark/backend/src/readiness_report.ts
+++ b/apps/mark/backend/src/readiness_report.ts
@@ -37,7 +37,6 @@ export async function saveReadinessReport({
   const generatedAtTime = new Date(getCurrentTime());
   const { electionDefinition, electionPackageHash } =
     store.getElectionRecord() ?? {};
-  const precinctSelection = store.getPrecinctSelection();
   const pollingPlaceId = store.getPollingPlaceId();
   const printerStatus = await printer.status();
 
@@ -77,7 +76,6 @@ export async function saveReadinessReport({
     generatedAtTime,
     electionDefinition,
     electionPackageHash,
-    precinctSelection,
     pollingPlaceId,
   });
   // Readiness report PDF shouldn't be too long, so we don't expect a render error

--- a/apps/mark/frontend/src/api.ts
+++ b/apps/mark/frontend/src/api.ts
@@ -399,19 +399,6 @@ export const setTestMode = {
   },
 } as const;
 
-// [TODO] Remove after migration to polling places.
-export const setPrecinctSelection = {
-  useMutation() {
-    const apiClient = useApiClient();
-    const queryClient = useQueryClient();
-    return useMutation(apiClient.setPrecinctSelection, {
-      async onSuccess() {
-        await queryClient.invalidateQueries(getElectionState.queryKey());
-      },
-    });
-  },
-} as const;
-
 export const setPollingPlaceId = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/mark/frontend/src/apimachine_config.test.tsx
+++ b/apps/mark/frontend/src/apimachine_config.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, test } from 'vitest';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
-import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
+import { anyPollingPlace } from '@votingworks/types';
 import { render, screen } from '../test/react_testing_library';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 import { App } from './app';
@@ -16,15 +16,17 @@ afterEach(() => {
   apiMock.mockApiClient.assertComplete();
 });
 
+const fixtures = electionFamousNames2021Fixtures;
+const electionDefinition = fixtures.readElectionDefinition();
+const pollingPlace = anyPollingPlace(electionDefinition.election);
+
 test('machineConfig is fetched from api client by default', async () => {
   apiMock.expectGetMachineConfig({
     codeVersion: 'mock-code-version',
   });
-  const electionDefinition =
-    electionFamousNames2021Fixtures.readElectionDefinition();
   apiMock.expectGetElectionRecord(electionDefinition);
   apiMock.expectGetElectionState({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: pollingPlace.id,
   });
   render(<App apiClient={apiMock.mockApiClient} />);
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);

--- a/apps/mark/frontend/src/app.test.tsx
+++ b/apps/mark/frontend/src/app.test.tsx
@@ -8,7 +8,6 @@ import {
   useBallotStyleManager,
   useSessionSettingsManager,
 } from '@votingworks/mark-flow-ui';
-import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import userEvent from '@testing-library/user-event';
 import { screen } from '../test/react_testing_library';
 import { advanceTimersAndPromises } from '../test/helpers/timers';
@@ -138,21 +137,22 @@ test('uses ballot style management hook', async () => {
   );
 });
 
-const CENTER_SPRINGFIELD_PRECINCT_SELECTION = singlePrecinctSelectionFor('23');
+const precinctId = '23';
+const pollingPlaceId = `${precinctId}-polling-place`;
 
 test('PAT device tutorial is shown when PAT key is pressed during voter session', async () => {
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionRecord(electionGeneralDefinition);
   apiMock.expectGetElectionState({
-    precinctSelection: CENTER_SPRINGFIELD_PRECINCT_SELECTION,
+    pollingPlaceId,
     pollsState: 'polls_open',
   });
 
   // Start as cardless voter
   apiMock.setAuthStatusCardlessVoterLoggedIn({
     ballotStyleId: '12',
-    precinctId: '23',
+    precinctId,
   });
 
   render(<App apiClient={apiMock.mockApiClient} />);
@@ -179,14 +179,14 @@ test('PAT device tutorial can be skipped', async () => {
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionRecord(electionGeneralDefinition);
   apiMock.expectGetElectionState({
-    precinctSelection: CENTER_SPRINGFIELD_PRECINCT_SELECTION,
+    pollingPlaceId,
     pollsState: 'polls_open',
   });
 
   // Start as cardless voter
   apiMock.setAuthStatusCardlessVoterLoggedIn({
     ballotStyleId: '12',
-    precinctId: '23',
+    precinctId,
   });
 
   render(<App apiClient={apiMock.mockApiClient} />);
@@ -214,7 +214,7 @@ test('PAT device tutorial is not triggered when not in voter session', async () 
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionRecord(electionGeneralDefinition);
   apiMock.expectGetElectionState({
-    precinctSelection: CENTER_SPRINGFIELD_PRECINCT_SELECTION,
+    pollingPlaceId,
     pollsState: 'polls_open',
   });
 

--- a/apps/mark/frontend/src/app_card_unhappy_paths.test.tsx
+++ b/apps/mark/frontend/src/app_card_unhappy_paths.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, test } from 'vitest';
-import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
+import { anyPollingPlace } from '@votingworks/types';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import { render, screen } from '../test/react_testing_library';
 
@@ -18,11 +18,14 @@ afterEach(() => {
   apiMock.mockApiClient.assertComplete();
 });
 
+const electionDefinition = readElectionGeneralDefinition();
+const pollingPlace = anyPollingPlace(electionDefinition.election);
+
 test('Shows card backwards screen when card connection error occurs', async () => {
   apiMock.expectGetMachineConfig();
-  apiMock.expectGetElectionRecord(readElectionGeneralDefinition());
+  apiMock.expectGetElectionRecord(electionDefinition);
   apiMock.expectGetElectionState({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: pollingPlace.id,
     pollsState: 'polls_open',
   });
 
@@ -42,9 +45,9 @@ test('Shows card backwards screen when card connection error occurs', async () =
 
 test('Shows wrong election screen when election on card does not match that of machine config', async () => {
   apiMock.expectGetMachineConfig();
-  apiMock.expectGetElectionRecord(readElectionGeneralDefinition());
+  apiMock.expectGetElectionRecord(electionDefinition);
   apiMock.expectGetElectionState({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: pollingPlace.id,
     pollsState: 'polls_open',
   });
 

--- a/apps/mark/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark/frontend/src/app_cardless_voting.test.tsx
@@ -1,8 +1,4 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import {
-  ALL_PRECINCTS_SELECTION,
-  singlePrecinctSelectionFor,
-} from '@votingworks/utils';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
@@ -33,15 +29,16 @@ vi.setConfig({
   testTimeout: 30000,
 });
 
-const CENTER_SPRINGFIELD_PRECINCT_SELECTION = singlePrecinctSelectionFor('23');
+const precinctId = '23';
+const pollingPlaceId = `${precinctId}-polling-place`;
+const electionDefinition = readElectionGeneralDefinition();
 
 test('poll worker selects ballot style, voter votes', async () => {
-  const electionDefinition = readElectionGeneralDefinition();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionRecord(electionDefinition);
   apiMock.expectGetElectionState({
-    precinctSelection: CENTER_SPRINGFIELD_PRECINCT_SELECTION,
+    pollingPlaceId,
     pollsState: 'polls_open',
   });
   render(<App apiClient={apiMock.mockApiClient} />);
@@ -53,7 +50,7 @@ test('poll worker selects ballot style, voter votes', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
     cardlessVoterUserParams: {
       ballotStyleId: '12',
-      precinctId: '23',
+      precinctId,
     },
   });
   await screen.findByText('Remove Card to Begin Voting Session');
@@ -72,14 +69,14 @@ test('poll worker selects ballot style, voter votes', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
     cardlessVoterUserParams: {
       ballotStyleId: '12',
-      precinctId: '23',
+      precinctId,
     },
   });
 
   // Poll worker removes their card
   apiMock.setAuthStatusCardlessVoterLoggedIn({
     ballotStyleId: '12',
-    precinctId: '23',
+    precinctId,
   });
 
   // Voter Ballot Style is active
@@ -95,7 +92,7 @@ test('poll worker selects ballot style, voter votes', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
     cardlessVoterUserParams: {
       ballotStyleId: '12',
-      precinctId: '23',
+      precinctId,
     },
   });
   await screen.findByText('Voting Session Paused');
@@ -116,7 +113,7 @@ test('poll worker selects ballot style, voter votes', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
     cardlessVoterUserParams: {
       ballotStyleId: '12',
-      precinctId: '23',
+      precinctId,
     },
   });
   await screen.findByText('Remove Card to Begin Voting Session');
@@ -124,7 +121,7 @@ test('poll worker selects ballot style, voter votes', async () => {
   // Poll worker removes their card
   apiMock.setAuthStatusCardlessVoterLoggedIn({
     ballotStyleId: '12',
-    precinctId: '23',
+    precinctId,
   });
 
   // Voter Ballot Style is active
@@ -148,7 +145,7 @@ test('poll worker selects ballot style, voter votes', async () => {
   // Advance to print ballot
   apiMock.expectPrintBallot({
     ballotStyleId: '12',
-    precinctId: '23',
+    precinctId,
     votes: {
       [presidentContest.id]: [presidentContest.candidates[0]],
     },
@@ -180,12 +177,11 @@ test('poll worker selects ballot style, voter votes', async () => {
 });
 
 test('poll worker card insertion during printing does not cause duplicate print', async () => {
-  const electionDefinition = readElectionGeneralDefinition();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionRecord(electionDefinition);
   apiMock.expectGetElectionState({
-    precinctSelection: CENTER_SPRINGFIELD_PRECINCT_SELECTION,
+    pollingPlaceId,
     pollsState: 'polls_open',
   });
   render(<App apiClient={apiMock.mockApiClient} />);
@@ -200,7 +196,7 @@ test('poll worker card insertion during printing does not cause duplicate print'
   // Poll worker removes card
   apiMock.setAuthStatusCardlessVoterLoggedIn({
     ballotStyleId: '12',
-    precinctId: '23',
+    precinctId,
   });
   await findByTextWithMarkup('Number of contests on your ballot: 20');
   userEvent.click(screen.getByText('Start Voting'));
@@ -218,7 +214,7 @@ test('poll worker card insertion during printing does not cause duplicate print'
   // Voter clicks print — only one printBallot call should ever be made
   apiMock.expectPrintBallot({
     ballotStyleId: '12',
-    precinctId: '23',
+    precinctId,
     votes: { [presidentContest.id]: [presidentContest.candidates[0]] },
   });
   apiMock.expectGetElectionState({ ballotsPrintedCount: 1 });
@@ -234,7 +230,7 @@ test('poll worker card insertion during printing does not cause duplicate print'
   // Poll worker removes card — voter session resumes at the print screen
   apiMock.setAuthStatusCardlessVoterLoggedIn({
     ballotStyleId: '12',
-    precinctId: '23',
+    precinctId,
   });
   // The print screen is shown again but no second printBallot call is made
   await screen.findByText(/Printing Your Ballot/i);
@@ -250,12 +246,11 @@ test('poll worker card insertion during printing does not cause duplicate print'
 });
 
 test('in "All Precincts" mode, poll worker must select a precinct first', async () => {
-  const electionDefinition = readElectionGeneralDefinition();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionRecord(electionDefinition);
   apiMock.expectGetElectionState({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId,
     pollsState: 'polls_open',
   });
   render(<App apiClient={apiMock.mockApiClient} />);
@@ -269,7 +264,7 @@ test('in "All Precincts" mode, poll worker must select a precinct first', async 
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
     cardlessVoterUserParams: {
       ballotStyleId: '12',
-      precinctId: '23',
+      precinctId,
     },
   });
   await screen.findByText('Remove Card to Begin Voting Session');
@@ -280,7 +275,7 @@ test('in "All Precincts" mode, poll worker must select a precinct first', async 
   // Poll worker removes their card
   apiMock.setAuthStatusCardlessVoterLoggedIn({
     ballotStyleId: '12',
-    precinctId: '23',
+    precinctId,
   });
 
   // Voter Ballot Style is active

--- a/apps/mark/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark/frontend/src/app_cardless_voting.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
+import { PollingPlace } from '@votingworks/types';
 import { render, screen } from '../test/react_testing_library';
 import * as GLOBALS from './config/globals';
 
@@ -245,12 +246,30 @@ test('poll worker card insertion during printing does not cause duplicate print'
   await screen.findByText('Insert Card');
 });
 
-test('in "All Precincts" mode, poll worker must select a precinct first', async () => {
+test('in multi-precinct location, poll worker must select a precinct first', async () => {
+  const { election } = electionDefinition;
+
+  const multiPrecinctLocation: PollingPlace = {
+    id: 'multi-precinct-polling-place',
+    name: 'Springfield Community Center',
+    type: 'election_day',
+    precincts: {
+      [election.precincts[0].id]: { type: 'whole' },
+      [election.precincts[1].id]: { type: 'whole' },
+    },
+  };
+
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionRecord(electionDefinition);
+  apiMock.expectGetElectionRecord({
+    ...electionDefinition,
+    election: {
+      ...election,
+      pollingPlaces: [...(election.pollingPlaces ?? []), multiPrecinctLocation],
+    },
+  });
   apiMock.expectGetElectionState({
-    pollingPlaceId,
+    pollingPlaceId: multiPrecinctLocation.id,
     pollsState: 'polls_open',
   });
   render(<App apiClient={apiMock.mockApiClient} />);
@@ -261,6 +280,10 @@ test('in "All Precincts" mode, poll worker must select a precinct first', async 
   // ---------------
 
   // Activate Voter Session for Cardless Voter
+  apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
+  await screen.findByText('Start a New Voting Session');
+  userEvent.click(screen.getByText('Select ballot style…'));
+
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
     cardlessVoterUserParams: {
       ballotStyleId: '12',

--- a/apps/mark/frontend/src/app_contest_candidate_no_party.test.tsx
+++ b/apps/mark/frontend/src/app_contest_candidate_no_party.test.tsx
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, expect, test } from 'vitest';
-import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 
-import { CandidateContest, Election } from '@votingworks/types';
+import {
+  anyPollingPlace,
+  CandidateContest,
+  Election,
+} from '@votingworks/types';
 import {
   asElectionDefinition,
   readElectionGeneral,
@@ -33,6 +36,9 @@ const electionWithNoPartyCandidateContests: Election = {
   }),
 };
 
+const pollingPlace = anyPollingPlace(electionWithNoPartyCandidateContests);
+const [precinctId] = Object.keys(pollingPlace.precincts);
+
 beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
@@ -50,7 +56,7 @@ test('Single Seat Contest', async () => {
 
   apiMock.expectGetMachineConfig();
   apiMock.expectGetElectionState({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: pollingPlace.id,
     pollsState: 'polls_open',
   });
 
@@ -59,7 +65,7 @@ test('Single Seat Contest', async () => {
   // Start voter session
   apiMock.setAuthStatusCardlessVoterLoggedIn({
     ballotStyleId: '12',
-    precinctId: '23',
+    precinctId,
   });
 
   // Go to First Contest

--- a/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
+++ b/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import { getContestDistrictName } from '@votingworks/types';
 
 import { readElectionWithMsEitherNeitherDefinition } from '@votingworks/fixtures';
@@ -47,6 +46,7 @@ assert(eitherNeitherContest.type === 'yesno');
 assert(pickOneContest.type === 'yesno');
 
 const precinctId = '6526';
+const pollingPlaceId = `${precinctId}-polling-place`;
 
 test('Can vote on a Mississippi Either Neither Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
@@ -56,7 +56,7 @@ test('Can vote on a Mississippi Either Neither Contest', async () => {
   apiMock.expectGetElectionRecord(electionDefinition);
 
   apiMock.expectGetElectionState({
-    precinctSelection: singlePrecinctSelectionFor(precinctId),
+    pollingPlaceId,
     pollsState: 'polls_open',
   });
 

--- a/apps/mark/frontend/src/app_contest_multi_seat.test.tsx
+++ b/apps/mark/frontend/src/app_contest_multi_seat.test.tsx
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
+import { anyPollingPlace } from '@votingworks/types';
 import {
   fireEvent,
   render,
@@ -34,10 +34,15 @@ afterEach(() => {
 
 test('Single Seat Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
+
+  const electionDefinition = readElectionGeneralDefinition();
+  const pollingPlace = anyPollingPlace(electionDefinition.election);
+  const [precinctId] = Object.keys(pollingPlace.precincts);
+
   apiMock.expectGetMachineConfig();
   apiMock.expectGetElectionRecord(electionGeneralDefinition);
   apiMock.expectGetElectionState({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: pollingPlace.id,
     pollsState: 'polls_open',
   });
 
@@ -47,7 +52,7 @@ test('Single Seat Contest', async () => {
   // Start voter session
   apiMock.setAuthStatusCardlessVoterLoggedIn({
     ballotStyleId: '12',
-    precinctId: '23',
+    precinctId,
   });
 
   // Go to First Contest

--- a/apps/mark/frontend/src/app_contest_single_seat.test.tsx
+++ b/apps/mark/frontend/src/app_contest_single_seat.test.tsx
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, test, vi } from 'vitest';
-import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 
 import userEvent from '@testing-library/user-event';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
+import { anyPollingPlace } from '@votingworks/types';
 import {
   fireEvent,
   render,
@@ -36,10 +36,14 @@ afterEach(async () => {
 test('Single Seat Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
+  const electionDefinition = readElectionGeneralDefinition();
+  const pollingPlace = anyPollingPlace(electionDefinition.election);
+  const [precinctId] = Object.keys(pollingPlace.precincts);
+
   apiMock.expectGetMachineConfig();
   apiMock.expectGetElectionRecord(readElectionGeneralDefinition());
   apiMock.expectGetElectionState({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: pollingPlace.id,
     pollsState: 'polls_open',
   });
 
@@ -49,7 +53,7 @@ test('Single Seat Contest', async () => {
   // Start voter session
   apiMock.setAuthStatusCardlessVoterLoggedIn({
     ballotStyleId: '12',
-    precinctId: '23',
+    precinctId,
   });
 
   // Go to First Contest

--- a/apps/mark/frontend/src/app_contest_single_seat.test.tsx
+++ b/apps/mark/frontend/src/app_contest_single_seat.test.tsx
@@ -41,7 +41,7 @@ test('Single Seat Contest', async () => {
   const [precinctId] = Object.keys(pollingPlace.precincts);
 
   apiMock.expectGetMachineConfig();
-  apiMock.expectGetElectionRecord(readElectionGeneralDefinition());
+  apiMock.expectGetElectionRecord(electionDefinition);
   apiMock.expectGetElectionState({
     pollingPlaceId: pollingPlace.id,
     pollsState: 'polls_open',

--- a/apps/mark/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark/frontend/src/app_contest_write_in.test.tsx
@@ -80,7 +80,7 @@ test('Single Seat Contest with Write In', async () => {
   const [precinctId] = Object.keys(pollingPlace.precincts);
 
   apiMock.expectGetMachineConfig();
-  apiMock.expectGetElectionRecord(readElectionGeneralDefinition());
+  apiMock.expectGetElectionRecord(electionDefinition);
   apiMock.expectGetElectionState({
     pollingPlaceId: pollingPlace.id,
     pollsState: 'polls_open',

--- a/apps/mark/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark/frontend/src/app_contest_write_in.test.tsx
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import userEvent from '@testing-library/user-event';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import { ContestPage, ContestPageProps } from '@votingworks/mark-flow-ui';
-import { ContestId, OptionalVote, VotesDict } from '@votingworks/types';
+import {
+  anyPollingPlace,
+  ContestId,
+  OptionalVote,
+  VotesDict,
+} from '@votingworks/types';
 import { useHistory } from 'react-router-dom';
 import { act, fireEvent, render, screen } from '../test/react_testing_library';
 import { App } from './app';
@@ -71,10 +75,14 @@ afterEach(() => {
 test('Single Seat Contest with Write In', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
+  const electionDefinition = readElectionGeneralDefinition();
+  const pollingPlace = anyPollingPlace(electionDefinition.election);
+  const [precinctId] = Object.keys(pollingPlace.precincts);
+
   apiMock.expectGetMachineConfig();
   apiMock.expectGetElectionRecord(readElectionGeneralDefinition());
   apiMock.expectGetElectionState({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: pollingPlace.id,
     pollsState: 'polls_open',
     isTestMode: false,
   });
@@ -89,7 +97,7 @@ test('Single Seat Contest with Write In', async () => {
   // Start voter session
   apiMock.setAuthStatusCardlessVoterLoggedIn({
     ballotStyleId: '12',
-    precinctId: '23',
+    precinctId,
   });
 
   // Go to First Contest

--- a/apps/mark/frontend/src/app_contest_yes_no.test.tsx
+++ b/apps/mark/frontend/src/app_contest_yes_no.test.tsx
@@ -1,8 +1,7 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
-import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 
-import { getContestDistrictName } from '@votingworks/types';
+import { anyPollingPlace, getContestDistrictName } from '@votingworks/types';
 import userEvent from '@testing-library/user-event';
 import {
   fireEvent,
@@ -38,10 +37,13 @@ test('Single Seat Contest', async () => {
   // ====================== BEGIN CONTEST SETUP ====================== //
 
   const electionDefinition = readElectionGeneralDefinition();
+  const pollingPlace = anyPollingPlace(electionDefinition.election);
+  const [precinctId] = Object.keys(pollingPlace.precincts);
+
   apiMock.expectGetMachineConfig();
   apiMock.expectGetElectionRecord(electionDefinition);
   apiMock.expectGetElectionState({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: pollingPlace.id,
     pollsState: 'polls_open',
   });
 
@@ -50,7 +52,7 @@ test('Single Seat Contest', async () => {
   // Start voter session
   apiMock.setAuthStatusCardlessVoterLoggedIn({
     ballotStyleId: '12',
-    precinctId: '23',
+    precinctId,
   });
 
   // Go to First Contest

--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -49,8 +49,6 @@ vi.setConfig({
 
 // [TODO] Move to browser integration test.
 test('MarkAndPrint end-to-end flow', async () => {
-  setPollingPlacesEnabled(true);
-
   const logger = mockBaseLogger({ fn: vi.fn });
 
   const electionDefinition: ElectionDefinition = {
@@ -392,15 +390,4 @@ test('MarkAndPrint end-to-end flow', async () => {
   // Verify that machine was unconfigured even after election manager reauth
   apiMock.setAuthStatusElectionManagerLoggedIn(electionDefinition);
   await screen.findByText('Insert a USB drive containing an election package');
-
-  setPollingPlacesEnabled(false);
 });
-
-function setPollingPlacesEnabled(enabled: boolean) {
-  // The mock feature flagger doesn't seem to work when an external package
-  // (e.g. libs/ui) is checking for the flag. Need to modify the env var
-  // directly.
-  process.env['REACT_APP_VX_ENABLE_POLLING_PLACES'] = enabled
-    ? 'TRUE'
-    : 'FALSE';
-}

--- a/apps/mark/frontend/src/app_open_primary.test.tsx
+++ b/apps/mark/frontend/src/app_open_primary.test.tsx
@@ -1,8 +1,12 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import { electionOpenPrimaryFixtures } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
-import { BallotStyleId, CandidateContest } from '@votingworks/types';
+import {
+  anyPollingPlace,
+  BallotStyleId,
+  CandidateContest,
+  pollingPlaceMembers,
+} from '@votingworks/types';
 import { find } from '@votingworks/basics';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { render, screen } from '../test/react_testing_library';
@@ -12,12 +16,14 @@ import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
 vi.setConfig({ testTimeout: 30_000 });
 
-const BALLOT_STYLE_ID = 'ballot-style-1' as BallotStyleId;
-const PRECINCT_ID = 'precinct-1';
-const PRECINCT_NAME = 'Precinct 1';
-const PRECINCT_SELECTION = singlePrecinctSelectionFor(PRECINCT_ID);
 const electionDefinition = electionOpenPrimaryFixtures.readElectionDefinition();
 const { election } = electionDefinition;
+const pollingPlace = anyPollingPlace(election);
+const [precinctOrSplit] = pollingPlaceMembers(election, pollingPlace);
+
+const BALLOT_STYLE_ID = 'ballot-style-1' as BallotStyleId;
+const PRECINCT_ID = precinctOrSplit.precinct.id;
+const PRECINCT_NAME = precinctOrSplit.precinct.name;
 
 let apiMock: ApiMock;
 
@@ -28,7 +34,7 @@ beforeEach(() => {
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionRecord(electionDefinition);
   apiMock.expectGetElectionState({
-    precinctSelection: PRECINCT_SELECTION,
+    pollingPlaceId: pollingPlace.id,
     pollsState: 'polls_open',
   });
 });

--- a/apps/mark/frontend/src/app_polls_flows.test.tsx
+++ b/apps/mark/frontend/src/app_polls_flows.test.tsx
@@ -2,12 +2,13 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import userEvent from '@testing-library/user-event';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
-import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
+import { anyPollingPlace } from '@votingworks/types';
 import { screen, within } from '../test/react_testing_library';
 import { buildApp } from '../test/helpers/build_app';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
 const electionGeneralDefinition = readElectionGeneralDefinition();
+const pollingPlace = anyPollingPlace(electionGeneralDefinition.election);
 
 let apiMock: ApiMock;
 
@@ -34,7 +35,7 @@ test('full polls flow', async () => {
   apiMock.expectGetSystemSettings();
   apiMock.expectGetElectionRecord(electionGeneralDefinition);
   apiMock.expectGetElectionState({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: pollingPlace.id,
     pollsState: 'polls_closed_initial',
   });
   const { renderApp } = buildApp(apiMock);
@@ -105,7 +106,7 @@ test('can close polls from paused', async () => {
   const { renderApp } = buildApp(apiMock);
   apiMock.expectGetElectionRecord(electionGeneralDefinition);
   apiMock.expectGetElectionState({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: pollingPlace.id,
     pollsState: 'polls_paused',
   });
 
@@ -133,7 +134,7 @@ test('no buttons to change polls from closed final', async () => {
   const { renderApp } = buildApp(apiMock);
   apiMock.expectGetElectionRecord(electionGeneralDefinition);
   apiMock.expectGetElectionState({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: pollingPlace.id,
     pollsState: 'polls_closed_final',
   });
 
@@ -158,7 +159,7 @@ test('can reset polls to paused with system administrator card', async () => {
   const { renderApp } = buildApp(apiMock);
   apiMock.expectGetElectionRecord(electionGeneralDefinition);
   apiMock.expectGetElectionState({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: pollingPlace.id,
     pollsState: 'polls_closed_final',
   });
 

--- a/apps/mark/frontend/src/app_quit_on_idle.test.tsx
+++ b/apps/mark/frontend/src/app_quit_on_idle.test.tsx
@@ -35,7 +35,7 @@ test('Voter idle timeout', async () => {
   const pollingPlace = anyPollingPlace(electionDefinition.election);
 
   apiMock.expectGetMachineConfig();
-  apiMock.expectGetElectionRecord(readElectionGeneralDefinition());
+  apiMock.expectGetElectionRecord(electionDefinition);
   apiMock.expectGetElectionState({
     pollingPlaceId: pollingPlace.id,
     pollsState: 'polls_open',

--- a/apps/mark/frontend/src/app_quit_on_idle.test.tsx
+++ b/apps/mark/frontend/src/app_quit_on_idle.test.tsx
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
@@ -8,6 +7,7 @@ import {
   IDLE_RESET_TIMEOUT_SECONDS,
   IDLE_TIMEOUT_SECONDS,
 } from '@votingworks/mark-flow-ui';
+import { anyPollingPlace } from '@votingworks/types';
 import { render, screen } from '../test/react_testing_library';
 import { App } from './app';
 
@@ -31,10 +31,13 @@ afterEach(() => {
 });
 
 test('Voter idle timeout', async () => {
+  const electionDefinition = readElectionGeneralDefinition();
+  const pollingPlace = anyPollingPlace(electionDefinition.election);
+
   apiMock.expectGetMachineConfig();
   apiMock.expectGetElectionRecord(readElectionGeneralDefinition());
   apiMock.expectGetElectionState({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: pollingPlace.id,
     pollsState: 'polls_open',
   });
 

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -15,10 +15,8 @@ import {
 
 import { useHistory } from 'react-router-dom';
 import {
-  BooleanEnvironmentVariableName as Feature,
   isElectionManagerAuth,
   isCardlessVoterAuth,
-  isFeatureFlagEnabled,
   isPollWorkerAuth,
   isSystemAdministratorAuth,
   isVendorAuth,
@@ -93,7 +91,6 @@ export const stateStorageKey = 'state';
 export const blankBallotVotes: VotesDict = {};
 
 export const initialElectionState: Readonly<ElectionState> = {
-  precinctSelection: undefined,
   ballotsPrintedCount: 0,
   isTestMode: true,
   pollsState: 'polls_closed_initial',
@@ -234,15 +231,10 @@ export function AppRoot(): JSX.Element | null {
     getElectionRecordQuery.data ?? {};
 
   const electionStateQuery = getElectionState.useQuery();
-  const {
-    precinctSelection: appPrecinct,
-    pollingPlaceId,
-    ballotsPrintedCount,
-    isTestMode,
-    pollsState,
-  } = electionStateQuery.isSuccess
-    ? electionStateQuery.data
-    : initialElectionState;
+  const { pollingPlaceId, ballotsPrintedCount, isTestMode, pollsState } =
+    electionStateQuery.isSuccess
+      ? electionStateQuery.data
+      : initialElectionState;
 
   const precinctId = isCardlessVoterAuth(authStatus)
     ? authStatus.user.precinctId
@@ -535,7 +527,6 @@ export function AppRoot(): JSX.Element | null {
         electionDefinition={electionDefinition}
         electionPackageHash={electionPackageHash}
         usbDriveStatus={usbDriveStatus}
-        precinctSelection={appPrecinct}
         pollingPlaceId={pollingPlaceId}
       />
     );
@@ -563,7 +554,6 @@ export function AppRoot(): JSX.Element | null {
 
     return (
       <AdminScreen
-        appPrecinct={appPrecinct}
         ballotsPrintedCount={ballotsPrintedCount}
         electionDefinition={electionDefinition}
         electionPackageHash={assertDefined(electionPackageHash)}
@@ -577,13 +567,8 @@ export function AppRoot(): JSX.Element | null {
     );
   }
 
-  const usePollingPlaces = isFeatureFlagEnabled(Feature.ENABLE_POLLING_PLACES);
-  const locationConfigured = usePollingPlaces
-    ? !!pollingPlaceId
-    : !!appPrecinct;
-
   if (electionDefinition) {
-    if (!locationConfigured) {
+    if (!pollingPlaceId) {
       return (
         <UnconfiguredPollingPlaceScreen
           electionDefinition={electionDefinition}
@@ -608,7 +593,6 @@ export function AppRoot(): JSX.Element | null {
           pollWorkerAuth={authStatus}
           activateCardlessVoterSession={activateCardlessBallot}
           resetCardlessVoterSession={resetCardlessBallot}
-          appPrecinct={appPrecinct}
           pollingPlaceId={pollingPlaceId}
           electionDefinition={electionDefinition}
           electionPackageHash={assertDefined(electionPackageHash)}
@@ -672,7 +656,6 @@ export function AppRoot(): JSX.Element | null {
 
     return (
       <InsertCardScreen
-        appPrecinct={appPrecinct}
         electionDefinition={electionDefinition}
         electionPackageHash={assertDefined(electionPackageHash)}
         isLiveMode={!isTestMode}

--- a/apps/mark/frontend/src/app_setup_errors.test.tsx
+++ b/apps/mark/frontend/src/app_setup_errors.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
+import { anyPollingPlace } from '@votingworks/types';
 import { act, render, screen } from '../test/react_testing_library';
 
 import { App } from './app';
@@ -14,6 +14,7 @@ import { INTERNAL_HARDWARE_POLLING_INTERVAL_MS } from './api';
 const NO_PRINTER_DETECTED_TEXT = 'No Printer Detected';
 
 const electionGeneralDefinition = readElectionGeneralDefinition();
+const pollingPlace = anyPollingPlace(electionGeneralDefinition.election);
 
 let apiMock: ApiMock;
 
@@ -36,7 +37,7 @@ describe('Displays setup warning messages and errors screens', () => {
     apiMock.expectGetMachineConfig();
     apiMock.expectGetElectionRecord(electionGeneralDefinition);
     apiMock.expectGetElectionState({
-      precinctSelection: ALL_PRECINCTS_SELECTION,
+      pollingPlaceId: pollingPlace.id,
       pollsState: 'polls_open',
     });
 
@@ -72,7 +73,7 @@ describe('Displays setup warning messages and errors screens', () => {
     apiMock.expectGetMachineConfig();
     apiMock.expectGetElectionRecord(electionGeneralDefinition);
     apiMock.expectGetElectionState({
-      precinctSelection: ALL_PRECINCTS_SELECTION,
+      pollingPlaceId: pollingPlace.id,
       pollsState: 'polls_open',
     });
 
@@ -108,7 +109,7 @@ describe('Displays setup warning messages and errors screens', () => {
     apiMock.expectGetMachineConfig();
     apiMock.expectGetElectionRecord(electionGeneralDefinition);
     apiMock.expectGetElectionState({
-      precinctSelection: ALL_PRECINCTS_SELECTION,
+      pollingPlaceId: pollingPlace.id,
       pollsState: 'polls_open',
     });
 
@@ -132,7 +133,7 @@ describe('Displays setup warning messages and errors screens', () => {
     apiMock.expectGetMachineConfig();
     apiMock.expectGetElectionRecord(electionGeneralDefinition);
     apiMock.expectGetElectionState({
-      precinctSelection: ALL_PRECINCTS_SELECTION,
+      pollingPlaceId: pollingPlace.id,
       pollsState: 'polls_open',
     });
 
@@ -170,7 +171,7 @@ describe('Displays setup warning messages and errors screens', () => {
     apiMock.expectGetMachineConfig();
     apiMock.expectGetElectionRecord(electionGeneralDefinition);
     apiMock.expectGetElectionState({
-      precinctSelection: ALL_PRECINCTS_SELECTION,
+      pollingPlaceId: pollingPlace.id,
       pollsState: 'polls_closed_final',
     });
     apiMock.setPrinterStatus({ connected: false });
@@ -187,7 +188,7 @@ describe('Displays setup warning messages and errors screens', () => {
     apiMock.expectGetMachineConfig();
     apiMock.expectGetElectionRecord(electionGeneralDefinition);
     apiMock.expectGetElectionState({
-      precinctSelection: ALL_PRECINCTS_SELECTION,
+      pollingPlaceId: pollingPlace.id,
       pollsState: 'polls_open',
     });
 
@@ -224,7 +225,7 @@ describe('Displays setup warning messages and errors screens', () => {
     apiMock.expectGetMachineConfig();
     apiMock.expectGetElectionRecord(electionGeneralDefinition);
     apiMock.expectGetElectionState({
-      precinctSelection: ALL_PRECINCTS_SELECTION,
+      pollingPlaceId: pollingPlace.id,
       pollsState: 'polls_open',
     });
 

--- a/apps/mark/frontend/src/app_test_mode.test.tsx
+++ b/apps/mark/frontend/src/app_test_mode.test.tsx
@@ -4,8 +4,8 @@ import {
   asElectionDefinition,
   readElectionGeneral,
 } from '@votingworks/fixtures';
-import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import { DateWithoutTime } from '@votingworks/basics';
+import { anyPollingPlace } from '@votingworks/types';
 import { render, screen } from '../test/react_testing_library';
 
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
@@ -27,12 +27,13 @@ test('Prompts to change from test mode to live mode on election day', async () =
     ...readElectionGeneral(),
     date: DateWithoutTime.today(),
   });
+  const pollingPlace = anyPollingPlace(electionDefinition.election);
 
   apiMock.expectGetMachineConfig();
   apiMock.expectGetElectionRecord(electionDefinition);
   apiMock.expectGetElectionState({
     isTestMode: true,
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: pollingPlace.id,
   });
   render(<App apiClient={apiMock.mockApiClient} />);
 

--- a/apps/mark/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.test.tsx
@@ -1,13 +1,5 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import {
-  asElectionDefinition,
-  electionTwoPartyPrimaryFixtures,
-} from '@votingworks/fixtures';
-import {
-  ALL_PRECINCTS_SELECTION,
-  BooleanEnvironmentVariableName as Feature,
-  getFeatureFlagMock,
-} from '@votingworks/utils';
+import { asElectionDefinition } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
 import { mockUsbDriveStatus } from '@votingworks/ui';
 import { DEFAULT_SYSTEM_SETTINGS, PollsState } from '@votingworks/types';
@@ -24,13 +16,6 @@ import {
   createApiMock,
   provideApi,
 } from '../../test/helpers/mock_api_client';
-
-const featureFlagMock = getFeatureFlagMock();
-
-vi.mock(import('@votingworks/utils'), async (importActual) => ({
-  ...(await importActual()),
-  isFeatureFlagEnabled: (flag: Feature) => featureFlagMock.isEnabled(flag),
-}));
 
 vi.mock('@votingworks/mark-flow-ui', async (importActual) => ({
   ...(await importActual()),
@@ -55,7 +40,6 @@ beforeEach(() => {
 
 afterEach(() => {
   apiMock.mockApiClient.assertComplete();
-  featureFlagMock.resetFeatureFlags();
 });
 
 function renderScreen(props: Partial<AdminScreenProps> = {}) {
@@ -134,7 +118,6 @@ test('wires up location picker', async () => {
     election,
     pollsState,
     selectPollingPlace: expect.anything(),
-    selectPrecinct: expect.anything(),
     pollingPlaceId: place1.id,
   });
 
@@ -142,41 +125,6 @@ test('wires up location picker', async () => {
   client.setPollingPlaceId.expectCallWith({ id: place2.id }).resolves();
   await props.selectPollingPlace(place2.id);
   client.assertComplete();
-});
-
-test('can switch the precinct', async () => {
-  await useRealPrecinctPicker();
-  apiMock.expectGetSystemSettings();
-  apiMock.expectGetUsbPortStatus();
-  renderScreen();
-
-  apiMock.expectSetPrecinctSelection(ALL_PRECINCTS_SELECTION);
-  userEvent.click(screen.getByLabelText('Select a precinct…'));
-  userEvent.click(screen.getByText('All Precincts'));
-});
-
-test('precinct change disabled if polls closed', async () => {
-  await useRealPrecinctPicker();
-  apiMock.expectGetSystemSettings();
-  apiMock.expectGetUsbPortStatus();
-  renderScreen({ pollsState: 'polls_closed_final' });
-
-  const precinctSelect = screen.getByLabelText('Select a precinct…');
-  expect(precinctSelect).toBeDisabled();
-});
-
-test('precinct selection absent if single precinct election', async () => {
-  await useRealPrecinctPicker();
-  apiMock.expectGetSystemSettings();
-  apiMock.expectGetUsbPortStatus();
-  renderScreen({
-    electionDefinition:
-      electionTwoPartyPrimaryFixtures.makeSinglePrecinctElectionDefinition(),
-  });
-
-  screen.getByText('Election Manager Menu');
-  await screen.findByRole('heading', { name: 'Election Manager Menu' });
-  expect(screen.queryByLabelText('Select a precinct…')).not.toBeInTheDocument();
 });
 
 test('renders a save logs button with no usb', async () => {
@@ -298,7 +246,6 @@ test('navigates to diagnostics screen and back', async () => {
   apiMock.expectGetMachineConfig();
   apiMock.mockApiClient.getElectionRecord.expectCallWith().resolves(null);
   apiMock.mockApiClient.getElectionState.expectCallWith().resolves({
-    precinctSelection: undefined,
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
@@ -362,20 +309,3 @@ test('does not show enable USB ports button when USB ports are enabled', async (
     screen.queryByRole('button', { name: 'Enable USB Ports' })
   ).not.toBeInTheDocument();
 });
-
-async function useRealPrecinctPicker() {
-  const markFlowUi = await vi.importActual<
-    typeof import('@votingworks/mark-flow-ui')
-  >('@votingworks/mark-flow-ui');
-
-  setPollingPlacesEnabled(false);
-  MockLocationPicker.mockImplementation(markFlowUi.LocationPicker);
-}
-
-function setPollingPlacesEnabled(enabled: boolean) {
-  if (enabled) {
-    featureFlagMock.enableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  } else {
-    featureFlagMock.disableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  }
-}

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -18,22 +18,12 @@ import {
   Button,
   ToggleUsbPortsButton,
 } from '@votingworks/ui';
-import {
-  ElectionDefinition,
-  PollsState,
-  PrecinctSelection,
-} from '@votingworks/types';
+import { ElectionDefinition, PollsState } from '@votingworks/types';
 import type { MachineConfig } from '@votingworks/mark-backend';
 import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import { format } from '@votingworks/utils';
 import { LocationPicker } from '@votingworks/mark-flow-ui';
-import {
-  ejectUsbDrive,
-  logOut,
-  setPrecinctSelection,
-  setTestMode,
-  useApiClient,
-} from '../api';
+import { ejectUsbDrive, logOut, setTestMode, useApiClient } from '../api';
 import * as api from '../api';
 import { BubbleMarkCalibration } from '../components/bubble_mark_calibration';
 import { ConfirmSwitchModeModal } from '../components/confirm_switch_mode_modal';
@@ -59,7 +49,6 @@ const ButtonGrid = styled.div`
   margin-bottom: 0.5rem;
 `;
 export interface AdminScreenProps {
-  appPrecinct?: PrecinctSelection;
   ballotsPrintedCount: number;
   electionDefinition: ElectionDefinition;
   electionPackageHash: string;
@@ -72,7 +61,6 @@ export interface AdminScreenProps {
 }
 
 export function AdminScreen({
-  appPrecinct,
   ballotsPrintedCount,
   electionDefinition,
   electionPackageHash,
@@ -88,7 +76,6 @@ export function AdminScreen({
   const apiClient = useApiClient();
   const logOutMutation = logOut.useMutation();
   const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
-  const selectPrecinct = setPrecinctSelection.useMutation().mutateAsync;
   const selectPollingPlace = api.setPollingPlaceId.useMutation().mutateAsync;
   const setTestModeMutation = setTestMode.useMutation();
   const systemSettingsQuery = api.getSystemSettings.useQuery();
@@ -123,18 +110,14 @@ export function AdminScreen({
           {format.count(ballotsPrintedCount)}
         </P>
         <H3 as="h2">Configuration</H3>
-        {election.precincts.length > 1 && (
-          <P>
-            <LocationPicker
-              appPrecinct={appPrecinct}
-              election={election}
-              pollsState={pollsState}
-              pollingPlaceId={pollingPlaceId}
-              selectPollingPlace={(id) => selectPollingPlace({ id })}
-              selectPrecinct={(p) => selectPrecinct({ precinctSelection: p })}
-            />
-          </P>
-        )}
+        <P>
+          <LocationPicker
+            election={election}
+            pollsState={pollsState}
+            pollingPlaceId={pollingPlaceId}
+            selectPollingPlace={(id) => selectPollingPlace({ id })}
+          />
+        </P>
         <P>
           <SegmentedButton
             label="Ballot Mode"
@@ -191,7 +174,6 @@ export function AdminScreen({
         codeVersion={machineConfig.codeVersion}
         machineId={machineConfig.machineId}
         pollingPlaceId={pollingPlaceId}
-        precinctSelection={appPrecinct}
       />
       {isConfirmingModeSwitch && (
         <ConfirmSwitchModeModal

--- a/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
@@ -2,10 +2,7 @@ import { afterEach, beforeEach, test, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 import { mockUsbDriveStatus, Keybinding } from '@votingworks/ui';
-import {
-  BooleanEnvironmentVariableName as Feature,
-  getFeatureFlagMock,
-} from '@votingworks/utils';
+import { getFeatureFlagMock } from '@votingworks/utils';
 import { readElectionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
 import { assertDefined } from '@votingworks/basics';
 import {
@@ -34,11 +31,7 @@ function renderScreen(props: Partial<DiagnosticsScreenProps> = {}) {
     provideApi(
       apiMock,
       <MemoryRouter>
-        <DiagnosticsScreen
-          isFeatureEnabled={featureFlagMock.isEnabled}
-          onBackButtonPress={vi.fn()}
-          {...props}
-        />
+        <DiagnosticsScreen onBackButtonPress={vi.fn()} {...props} />
       </MemoryRouter>
     )
   );
@@ -70,7 +63,6 @@ test('renders diagnostics screen with all sections', async () => {
   apiMock.expectGetMachineConfig();
   apiMock.mockApiClient.getElectionRecord.expectCallWith().resolves(null);
   apiMock.mockApiClient.getElectionState.expectCallWith().resolves({
-    precinctSelection: undefined,
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
@@ -105,7 +97,6 @@ test('navigating to and from system audio diagnostic - pass', async () => {
   apiMock.expectGetMachineConfig();
   apiMock.mockApiClient.getElectionRecord.expectCallWith().resolves(null);
   apiMock.mockApiClient.getElectionState.expectCallWith().resolves({
-    precinctSelection: undefined,
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
@@ -142,7 +133,6 @@ test('navigating to and from system audio diagnostic - fail', async () => {
   apiMock.expectGetMachineConfig();
   apiMock.mockApiClient.getElectionRecord.expectCallWith().resolves(null);
   apiMock.mockApiClient.getElectionState.expectCallWith().resolves({
-    precinctSelection: undefined,
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
@@ -179,7 +169,6 @@ test('navigating to and from system audio diagnostic - cancel', async () => {
   apiMock.expectGetMachineConfig();
   apiMock.mockApiClient.getElectionRecord.expectCallWith().resolves(null);
   apiMock.mockApiClient.getElectionState.expectCallWith().resolves({
-    precinctSelection: undefined,
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
@@ -205,7 +194,6 @@ test('navigating to and from headphone input diagnostic - pass', async () => {
   apiMock.expectGetMachineConfig();
   apiMock.mockApiClient.getElectionRecord.expectCallWith().resolves(null);
   apiMock.mockApiClient.getElectionState.expectCallWith().resolves({
-    precinctSelection: undefined,
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
@@ -242,7 +230,6 @@ test('navigating to and from headphone input diagnostic - fail', async () => {
   apiMock.expectGetMachineConfig();
   apiMock.mockApiClient.getElectionRecord.expectCallWith().resolves(null);
   apiMock.mockApiClient.getElectionState.expectCallWith().resolves({
-    precinctSelection: undefined,
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
@@ -279,7 +266,6 @@ test('navigating to and from headphone input diagnostic - cancel', async () => {
   apiMock.expectGetMachineConfig();
   apiMock.mockApiClient.getElectionRecord.expectCallWith().resolves(null);
   apiMock.mockApiClient.getElectionState.expectCallWith().resolves({
-    precinctSelection: undefined,
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
@@ -305,7 +291,6 @@ test('navigating to and from PAT input diagnostic - pass', async () => {
   apiMock.expectGetMachineConfig();
   apiMock.mockApiClient.getElectionRecord.expectCallWith().resolves(null);
   apiMock.mockApiClient.getElectionState.expectCallWith().resolves({
-    precinctSelection: undefined,
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
@@ -355,7 +340,6 @@ test('navigating to and from PAT input diagnostic - cancel', async () => {
   apiMock.expectGetMachineConfig();
   apiMock.mockApiClient.getElectionRecord.expectCallWith().resolves(null);
   apiMock.mockApiClient.getElectionState.expectCallWith().resolves({
-    precinctSelection: undefined,
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
@@ -393,7 +377,6 @@ test('navigating to and from barcode reader diagnostic - fail', async () => {
   apiMock.expectGetMachineConfig();
   apiMock.mockApiClient.getElectionRecord.expectCallWith().resolves(null);
   apiMock.mockApiClient.getElectionState.expectCallWith().resolves({
-    precinctSelection: undefined,
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
@@ -436,7 +419,6 @@ test('navigating to and from barcode reader diagnostic - cancel', async () => {
   apiMock.expectGetMachineConfig();
   apiMock.mockApiClient.getElectionRecord.expectCallWith().resolves(null);
   apiMock.mockApiClient.getElectionState.expectCallWith().resolves({
-    precinctSelection: undefined,
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
@@ -465,7 +447,6 @@ test('UPS diagnostic - pass', async () => {
   apiMock.expectGetMachineConfig();
   apiMock.mockApiClient.getElectionRecord.expectCallWith().resolves(null);
   apiMock.mockApiClient.getElectionState.expectCallWith().resolves({
-    precinctSelection: undefined,
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
@@ -502,7 +483,6 @@ test('UPS diagnostic - fail', async () => {
   apiMock.expectGetMachineConfig();
   apiMock.mockApiClient.getElectionRecord.expectCallWith().resolves(null);
   apiMock.mockApiClient.getElectionState.expectCallWith().resolves({
-    precinctSelection: undefined,
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
@@ -536,8 +516,6 @@ test('UPS diagnostic - fail', async () => {
 });
 
 test('election configuration info', async () => {
-  setPollingPlacesEnabled(true);
-
   const { election } = electionDefinition;
   const [pollingPlace] = assertDefined(election.pollingPlaces);
 
@@ -553,11 +531,3 @@ test('election configuration info', async () => {
   screen.getByText(election.title, { exact: false });
   screen.getByText(pollingPlace.name, { exact: false });
 });
-
-function setPollingPlacesEnabled(enabled: boolean) {
-  if (enabled) {
-    featureFlagMock.enableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  } else {
-    featureFlagMock.disableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  }
-}

--- a/apps/mark/frontend/src/pages/diagnostics_screen.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.tsx
@@ -10,7 +10,6 @@ import {
   Screen,
   UpsDiagnosticModalButton,
 } from '@votingworks/ui';
-import { BooleanEnvironmentVariableName } from '@votingworks/utils';
 import {
   getAccessibleControllerConnected,
   getBarcodeConnected,
@@ -32,12 +31,10 @@ import { PrintTestPageButton } from '../components/print_test_page_button';
 import { SystemAudioDiagnosticScreen } from './system_audio_diagnostic_screen';
 
 export interface DiagnosticsScreenProps {
-  isFeatureEnabled?: (f: BooleanEnvironmentVariableName) => boolean;
   onBackButtonPress: () => void;
 }
 
 export function DiagnosticsScreen({
-  isFeatureEnabled,
   onBackButtonPress,
 }: DiagnosticsScreenProps): JSX.Element {
   const history = useHistory();
@@ -108,7 +105,7 @@ export function DiagnosticsScreen({
 
   const { electionDefinition, electionPackageHash } =
     electionRecordQuery.data ?? {};
-  const { precinctSelection, pollingPlaceId } = electionStateQuery.data;
+  const { pollingPlaceId } = electionStateQuery.data;
   const diskSpaceSummary = diskSpaceSummaryQuery.data;
   const usbDriveStatus = usbDriveStatusQuery.data;
   const printerStatus = printerStatusQuery.data;
@@ -151,8 +148,6 @@ export function DiagnosticsScreen({
             <MarkReadinessReportContents
               electionDefinition={electionDefinition}
               electionPackageHash={electionPackageHash}
-              isFeatureEnabled={isFeatureEnabled}
-              precinctSelection={precinctSelection}
               pollingPlaceId={pollingPlaceId}
               diskSpaceSummary={diskSpaceSummary}
               printerStatus={printerStatus}

--- a/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
@@ -10,7 +10,6 @@ import {
   InsertedSmartCardAuth,
 } from '@votingworks/types';
 
-import { singlePrecinctSelectionFor } from '@votingworks/utils';
 import {
   mockPollWorkerUser,
   mockSessionExpiresAt,
@@ -22,8 +21,6 @@ import { pollWorkerComponents } from '@votingworks/mark-flow-ui';
 import { act, fireEvent, screen } from '../../test/react_testing_library';
 
 import { render } from '../../test/test_utils';
-
-import { defaultPrecinctId } from '../../test/helpers/election';
 
 import { PollWorkerScreen, PollworkerScreenProps } from './poll_worker_screen';
 import { mockMachineConfig } from '../../test/helpers/mock_machine_config';
@@ -81,7 +78,6 @@ function renderScreen(
         pollWorkerAuth={pollWorkerAuth}
         activateCardlessVoterSession={vi.fn()}
         resetCardlessVoterSession={vi.fn()}
-        appPrecinct={singlePrecinctSelectionFor(defaultPrecinctId)}
         electionDefinition={electionDefinition}
         electionPackageHash="test-election-package-hash"
         hasVotes={false}
@@ -155,17 +151,14 @@ test('Shows election info', () => {
 });
 
 test('renders session start section', () => {
-  const [precinct] = election.precincts;
   const [pollingPlace] = assertDefined(election.pollingPlaces);
 
   const activateCardlessVoterSession = vi.fn();
-  const appPrecinct = singlePrecinctSelectionFor(precinct.id);
   const pollingPlaceId = pollingPlace.id;
 
   renderScreen({
     activateCardlessVoterSession,
     pollingPlaceId,
-    appPrecinct,
   });
 
   screen.getByTestId(MOCK_SECTION_SESSION_START_ID);
@@ -175,7 +168,6 @@ test('renders session start section', () => {
     election,
     onChooseBallotStyle: expect.any(Function),
     pollingPlaceId,
-    precinctSelection: appPrecinct,
   });
   expect(activateCardlessVoterSession).not.toHaveBeenCalled();
 

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -2,7 +2,6 @@ import {
   BallotStyleId,
   ElectionDefinition,
   PrecinctId,
-  PrecinctSelection,
   PollsState,
   InsertedSmartCardAuth,
 } from '@votingworks/types';
@@ -27,7 +26,6 @@ export interface PollworkerScreenProps {
     ballotStyleId: BallotStyleId
   ) => void;
   resetCardlessVoterSession: () => void;
-  appPrecinct?: PrecinctSelection;
   electionDefinition: ElectionDefinition;
   electionPackageHash: string;
   hasVotes: boolean;
@@ -42,7 +40,6 @@ export function PollWorkerScreen({
   pollWorkerAuth,
   activateCardlessVoterSession,
   resetCardlessVoterSession,
-  appPrecinct,
   electionDefinition,
   electionPackageHash,
   isLiveMode,
@@ -118,7 +115,6 @@ export function PollWorkerScreen({
               election={election}
               onChooseBallotStyle={onChooseBallotStyle}
               pollingPlaceId={pollingPlaceId}
-              precinctSelection={appPrecinct}
             />
           )}
           <SectionPollsState
@@ -144,7 +140,6 @@ export function PollWorkerScreen({
         codeVersion={machineConfig.codeVersion}
         machineId={machineConfig.machineId}
         pollingPlaceId={pollingPlaceId}
-        precinctSelection={appPrecinct}
       />
     </Screen>
   );

--- a/apps/mark/frontend/src/pages/system_administrator_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/system_administrator_screen.test.tsx
@@ -46,7 +46,6 @@ test('SystemAdministratorScreen renders expected contents', () => {
         machineConfig={mockMachineConfig({
           codeVersion: 'test', // Override default
         })}
-        precinctSelection={undefined}
       />
     )
   );
@@ -79,7 +78,6 @@ test('Can set date and time', async () => {
         machineConfig={mockMachineConfig({
           codeVersion: 'test', // Override default
         })}
-        precinctSelection={undefined}
       />
     )
   );
@@ -118,7 +116,6 @@ test('navigates to Diagnostics screen', () => {
         machineConfig={mockMachineConfig({
           codeVersion: 'test', // Override default
         })}
-        precinctSelection={undefined}
       />
     )
   );

--- a/apps/mark/frontend/src/pages/system_administrator_screen.tsx
+++ b/apps/mark/frontend/src/pages/system_administrator_screen.tsx
@@ -12,7 +12,7 @@ import {
 } from '@votingworks/ui';
 import { UsbDriveStatus } from '@votingworks/usb-drive';
 import type { MachineConfig } from '@votingworks/mark-backend';
-import { ElectionDefinition, PrecinctSelection } from '@votingworks/types';
+import { ElectionDefinition } from '@votingworks/types';
 import { logOut, useApiClient } from '../api';
 import { DiagnosticsScreen } from './diagnostics_screen';
 
@@ -28,7 +28,6 @@ interface Props {
   electionPackageHash?: string;
   machineConfig: MachineConfig;
   pollingPlaceId?: string;
-  precinctSelection?: PrecinctSelection;
 }
 
 /**
@@ -43,7 +42,6 @@ export function SystemAdministratorScreen({
   electionPackageHash,
   machineConfig,
   pollingPlaceId,
-  precinctSelection,
 }: Props): JSX.Element {
   const apiClient = useApiClient();
   const logOutMutation = logOut.useMutation();
@@ -93,7 +91,6 @@ export function SystemAdministratorScreen({
         codeVersion={machineConfig.codeVersion}
         machineId={machineConfig.machineId}
         pollingPlaceId={pollingPlaceId}
-        precinctSelection={precinctSelection}
       />
     </Screen>
   );

--- a/apps/mark/frontend/src/setupTests.tsx
+++ b/apps/mark/frontend/src/setupTests.tsx
@@ -8,6 +8,7 @@ import {
 } from '@votingworks/fixtures';
 import fetchMock from 'fetch-mock';
 import { TextDecoder, TextEncoder } from 'node:util';
+import { BooleanEnvironmentVariableName as Feature } from '@votingworks/utils';
 import { cleanup, configure } from '../test/react_testing_library';
 import './polyfills';
 
@@ -15,6 +16,9 @@ expect.extend(matchers);
 configure({ asyncUtilTimeout: 5_000 });
 
 beforeEach(() => {
+  // [TODO] Remove after full migration of mark-flow-ui.
+  process.env[Feature.ENABLE_POLLING_PLACES] = 'TRUE';
+
   globalThis.print = vi.fn(() => {
     throw new Error('globalThis.print() should never be called');
   });

--- a/apps/mark/frontend/test/helpers/mock_api_client.tsx
+++ b/apps/mark/frontend/test/helpers/mock_api_client.tsx
@@ -16,7 +16,6 @@ import {
   InsertedSmartCardAuth,
   PollsState,
   PrecinctId,
-  PrecinctSelection,
   SystemSettings,
   PrinterStatus,
   PrinterConfig,
@@ -328,12 +327,6 @@ export function createApiMock() {
 
     expectSetTestMode(isTestMode: boolean) {
       mockApiClient.setTestMode.expectCallWith({ isTestMode }).resolves();
-    },
-
-    expectSetPrecinctSelection(precinctSelection: PrecinctSelection) {
-      mockApiClient.setPrecinctSelection
-        .expectCallWith({ precinctSelection })
-        .resolves();
     },
 
     expectPrintBallot(

--- a/libs/fixtures/data/electionOpenPrimary/election.json
+++ b/libs/fixtures/data/electionOpenPrimary/election.json
@@ -811,6 +811,28 @@
       ]
     }
   ],
+  "pollingPlaces": [
+    {
+      "id": "precinct-1-polling-place",
+      "name": "Precinct 1",
+      "precincts": {
+        "precinct-1": {
+          "type": "whole"
+        }
+      },
+      "type": "election_day"
+    },
+    {
+      "id": "precinct-2-polling-place",
+      "name": "Precinct 2",
+      "precincts": {
+        "precinct-2": {
+          "type": "whole"
+        }
+      },
+      "type": "election_day"
+    }
+  ],
   "ballotStyles": [
     {
       "id": "ballot-style-1",

--- a/libs/mark-flow-ui/src/components/location_picker.tsx
+++ b/libs/mark-flow-ui/src/components/location_picker.tsx
@@ -1,3 +1,4 @@
+import { assertDefined } from '@votingworks/basics';
 import { PrecinctSelection, Election, PollsState } from '@votingworks/types';
 import {
   PollingPlacePickerMode,
@@ -18,7 +19,7 @@ export interface LocationPickerProps {
   pollingPlaceId?: string;
   pollsState: PollsState;
   selectPollingPlace: PollingPlacePickerProps['selectPlace'];
-  selectPrecinct: ChangePrecinctButtonProps['updatePrecinctSelection'];
+  selectPrecinct?: ChangePrecinctButtonProps['updatePrecinctSelection'];
 }
 
 export function LocationPicker(props: LocationPickerProps): React.ReactNode {
@@ -51,7 +52,7 @@ export function LocationPicker(props: LocationPickerProps): React.ReactNode {
         appPrecinctSelection={appPrecinct}
         election={election}
         mode={mode}
-        updatePrecinctSelection={selectPrecinct}
+        updatePrecinctSelection={assertDefined(selectPrecinct)}
       />
     );
   }

--- a/libs/types/src/polling_places.test.ts
+++ b/libs/types/src/polling_places.test.ts
@@ -13,6 +13,7 @@ import {
   PrecinctWithSplits,
 } from './election';
 import {
+  anyPollingPlace,
   pollingPlaceBallotStyles,
   pollingPlaceContests,
   pollingPlaceFromElection,
@@ -23,6 +24,19 @@ import {
   pollingPlacesGenerateFromPrecincts,
   pollingPlaceTypeName,
 } from './polling_places';
+
+test('anyPollingPlace', () => {
+  expect(() => anyPollingPlace(mockElection({}))).toThrow(/no polling places/i);
+  expect(() => anyPollingPlace(mockElection({ pollingPlaces: [] }))).toThrow(
+    /no polling places/i
+  );
+
+  const place1 = mockPollingPlace({ id: 'pp1' });
+  const place2 = mockPollingPlace({ id: 'pp2' });
+  const election = mockElection({ pollingPlaces: [place2, place1] });
+
+  expect(anyPollingPlace(election)).toEqual(place2);
+});
 
 test('pollingPlaceBallotStyles', () => {
   const precinct1 = mockPrecinctNoSplits({ id: 'p1' });

--- a/libs/types/src/polling_places.ts
+++ b/libs/types/src/polling_places.ts
@@ -1,4 +1,4 @@
-import { throwIllegalValue } from '@votingworks/basics';
+import { assertDefined, throwIllegalValue } from '@votingworks/basics';
 import {
   BallotStyle,
   Contests,
@@ -9,6 +9,13 @@ import {
   Precinct,
   PrecinctOrSplit,
 } from './election';
+
+export function anyPollingPlace(election: Election): PollingPlace {
+  const err = 'no polling places in election';
+  const places = assertDefined(election.pollingPlaces, err);
+
+  return assertDefined(places[0], err);
+}
 
 export function pollingPlaceBallotStyles(
   election: Election,

--- a/libs/ui/src/diagnostics/mark_readiness_report.tsx
+++ b/libs/ui/src/diagnostics/mark_readiness_report.tsx
@@ -1,15 +1,9 @@
 import { ThemeProvider } from 'styled-components';
 import {
-  BooleanEnvironmentVariableName,
-  isFeatureFlagEnabled,
-} from '@votingworks/utils';
-import {
   ConfigurationSection,
   ConfigurationSectionProps,
   PollingPlaceSection,
   PollingPlaceSectionProps,
-  PrecinctSelectionSection,
-  PrecinctSelectionSectionProps,
 } from './configuration_section';
 import { makeTheme } from '../themes/make_theme';
 import { PrintedReport } from '../reports/layout';
@@ -39,13 +33,11 @@ type AudioDeviceInputProps = Omit<
 
 interface ReportContentsProps
   extends ConfigurationSectionProps,
-    PrecinctSelectionSectionProps,
     PollingPlaceSectionProps,
     StorageSectionProps,
     PrinterSectionProps,
     UpsSectionProps {
   accessibleControllerProps: NonpresentationalSectionProps;
-  isFeatureEnabled?: (f: BooleanEnvironmentVariableName) => boolean;
   patInputProps: NonpresentationalSectionProps;
   barcodeReaderProps: NonpresentationalSectionProps;
   headphoneInputProps: AudioDeviceInputProps;
@@ -56,16 +48,13 @@ interface ReportContentsProps
 export function MarkReadinessReportContents(
   props: ReportContentsProps
 ): JSX.Element {
-  const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
   const {
     accessibleControllerProps,
     electionDefinition,
-    isFeatureEnabled = isFeatureFlagEnabled,
     patInputProps,
     barcodeReaderProps,
     headphoneInputProps,
     pollingPlaceId,
-    precinctSelection,
     systemAudioProps,
   } = props;
   const election = electionDefinition?.election;
@@ -73,17 +62,10 @@ export function MarkReadinessReportContents(
   return (
     <ReportContents>
       <ConfigurationSection {...props}>
-        {isFeatureEnabled(ENABLE_POLLING_PLACES) ? (
-          <PollingPlaceSection
-            election={election}
-            pollingPlaceId={pollingPlaceId}
-          />
-        ) : (
-          <PrecinctSelectionSection
-            election={election}
-            precinctSelection={precinctSelection}
-          />
-        )}
+        <PollingPlaceSection
+          election={election}
+          pollingPlaceId={pollingPlaceId}
+        />
       </ConfigurationSection>
       <StorageSection {...props} />
       <PrinterSection {...props} />


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/8381
_Also partially addresses to https://github.com/votingworks/vxsuite/issues/8593_

- Removing precinct-selection-based branches from the frontend and defaulting to using polling places.
- Updated tests that were previously configuring a precinct selection to configure a polling place instead.
- Setting the `ENABLE_POLLING_PLACES` flag for tests at the top level, since mark-flow-ui is still used by VxMarkScan and still has flag-based branching logic. Will do another pass later to clean up those last bits after cleaning up MarkScan and mark-flow-ui.

## Demo Video or Screenshot
N/A

## Testing Plan
- Existing tests + new unit test for the added `anyPollingPlace()` utility function
