### PR TITLE
Straight party live reporting and open primary tabulation updates

### DIFF
--- a/apps/admin/backend/src/app.tally_report_csv.test.ts
+++ b/apps/admin/backend/src/app.tally_report_csv.test.ts
@@ -248,9 +248,10 @@ test('open primary: crossover, nonpartisan-only, and adjudicated ballots', async
     );
   }
 
-  // 3 happy Dem (alice-jones) + 1 resolved crossover (bob-smith)
-  // + 1 flipped Dem (now nonpartisan, gov-dem undervoted)
-  // Unresolved crossover's gov-dem vote is voided.
+  // 3 happy Dem (alice-jones) + 1 resolved crossover (bob-smith).
+  // The unresolved crossover's gov-dem vote is voided, and the flipped ballot
+  // (now nonpartisan) no longer counts toward the Dem contest at all — its
+  // empty gov-dem selection is omitted rather than counted as an undervote.
   expect(totalVotesBySelectionId('governor-democratic')).toEqual({
     'alice-jones': '3',
     'bob-smith': '1',
@@ -258,18 +259,19 @@ test('open primary: crossover, nonpartisan-only, and adjudicated ballots', async
     'dan-rivera': '0',
     'emily-tran': '0',
     overvotes: '0',
-    undervotes: '1',
-    'ballots-cast': '5',
+    undervotes: '0',
+    'ballots-cast': '4',
   });
-  // 2 happy Rep + 1 resolved crossover (gov-rep now empty → undervote).
-  // Unresolved crossover's gov-rep vote is voided.
+  // 2 happy Rep. The resolved crossover inferred to Dem, so its empty gov-rep
+  // selection is omitted (not an undervote), and the unresolved crossover's
+  // gov-rep vote is voided.
   expect(totalVotesBySelectionId('governor-republican')).toEqual({
     'dave-wilson': '2',
     'ellen-brown': '0',
     'frank-lee': '0',
     overvotes: '0',
-    undervotes: '1',
-    'ballots-cast': '3',
+    undervotes: '0',
+    'ballots-cast': '2',
   });
   expect(totalVotesBySelectionId('governor-libertarian')).toEqual({
     'grace-kim': '1',

--- a/apps/design/frontend/src/live_reports_screen.tsx
+++ b/apps/design/frontend/src/live_reports_screen.tsx
@@ -1032,7 +1032,9 @@ function LiveReportsResultsScreen({
   const contests = getContestsForPrecinctAndElection(
     aggregatedResults.election,
     precinctSelection
-  );
+    // Straight party voting results are not submitted for live reporting, so
+    // we exclude the contest here to avoid misleadingly displaying all zeros
+  ).filter((contest) => contest.type !== 'straight-party');
   const contestsByParty = groupContestsByParty(
     aggregatedResults.election,
     contests

--- a/libs/utils/src/tabulation/tabulation.test.ts
+++ b/libs/utils/src/tabulation/tabulation.test.ts
@@ -1475,6 +1475,71 @@ describe('open primaries', () => {
       expect(results.contestResults[contest.id]?.ballots).toEqual(0);
     }
   });
+
+  test("consolidated ballots omit other parties' contests rather than counting undervotes", async () => {
+    // Consolidated open primary ballots include every party's contests, so the
+    // interpreter records empty selections for the parties the voter didn't
+    // vote. Those empty other-party contests must be omitted entirely, not
+    // counted as undervotes.
+    const results = (
+      await tabulateCastVoteRecords({
+        election: openPrimaryElection,
+        cvrs: [
+          // Red (republican) ballot
+          {
+            ...baseCvrMetadata,
+            votes: {
+              'governor-democratic': [],
+              'governor-republican': ['dave-wilson'],
+              'governor-libertarian': [],
+              'ballot-measure-1': ['ballot-measure-1-yes'],
+            },
+          },
+          // Blue (democratic) ballot
+          {
+            ...baseCvrMetadata,
+            votes: {
+              'governor-democratic': ['alice-jones'],
+              'governor-republican': [],
+              'governor-libertarian': [],
+              'ballot-measure-1': ['ballot-measure-1-yes'],
+            },
+          },
+          // Crossover ballot
+          {
+            ...baseCvrMetadata,
+            votes: {
+              'governor-democratic': ['alice-jones'],
+              'governor-republican': ['dave-wilson'],
+              'governor-libertarian': [],
+              'ballot-measure-1': ['ballot-measure-1-yes'],
+            },
+          },
+        ],
+      })
+    )[GROUP_KEY];
+    assert(results);
+
+    // Each single-party contest counts exactly one ballot, with no undervotes
+    // leaking in from the other ballots' empty selections.
+    expect(results.contestResults['governor-democratic']).toMatchObject({
+      ballots: 1,
+      undervotes: 0,
+    });
+    expect(results.contestResults['governor-republican']).toMatchObject({
+      ballots: 1,
+      undervotes: 0,
+    });
+    expect(results.contestResults['governor-libertarian']).toMatchObject({
+      ballots: 0,
+      undervotes: 0,
+    });
+    // The nonpartisan contest counts all three ballots.
+    expect(results.contestResults['ballot-measure-1']).toMatchObject({
+      ballots: 3,
+      yesTally: 3,
+    });
+  });
 });
 
 test('getOfficialCandidateNameLookup', () => {

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -8,6 +8,7 @@ import {
   ContestOptionId,
   Election,
   Id,
+  isOpenPrimary,
   PartyId,
   PrecinctSelection,
   getStraightPartyContestOptions,
@@ -18,7 +19,7 @@ import {
 import { isGroupByEmpty } from './arguments';
 import { getGroupedBallotStyles } from '../ballot_styles';
 import { readV0CompressedTallyAsContestResults } from './compressed_tallies';
-import { hasCrossoverVote, partisanContests } from './open_primary';
+import { inferPartyFromVotes, partisanContests } from './open_primary';
 
 export function getEmptyYesNoContestResults(
   contest: YesNoContest
@@ -177,13 +178,23 @@ function addCastVoteRecordToElectionResult(
       (cardCounts.hmpb[cvr.card.sheetNumber - 1] ?? 0) + 1;
   }
 
-  // In open primary elections, crossover voting is not allowed (i.e. a voter
-  // may not vote for partisan contests from multiple parties). If that happens,
-  // all of their partisan contest votes are void. Their nonpartisan contest
-  // votes still count.
-  const voidedContestIds = hasCrossoverVote(election, cvr.votes)
-    ? new Set(partisanContests(election).map((contest) => contest.id))
-    : undefined;
+  // In open primary elections, a voter receives a consolidated ballot
+  // containing every party's partisan contests, but only the contests matching
+  // the voter's party should count. We infer the voter's party from their
+  // partisan selections and void every partisan contest that doesn't match it,
+  // so other parties' contests are omitted entirely rather than counted as
+  // undervotes. Crossover ballots (selections for more than one party) and
+  // ballots with no partisan selections infer to NO_PARTY_ID, which voids all
+  // partisan contests. Nonpartisan contest votes always count.
+  let voidedContestIds: Set<ContestId> | undefined;
+  if (isOpenPrimary(election)) {
+    const inferredPartyId = inferPartyFromVotes(election, cvr.votes);
+    voidedContestIds = new Set(
+      partisanContests(election)
+        .filter((contest) => contest.partyId !== inferredPartyId)
+        .map((contest) => contest.id)
+    );
+  }
 
   for (const [contestId, optionIds] of Object.entries(cvr.votes)) {
     if (voidedContestIds?.has(contestId)) {


### PR DESCRIPTION
Two changes here, with Claude's help. Basic manual testing done but will test more holistically as well.

First: We're dropping the straight party contest from the live reporting UI to reflect the fact that it's not a real contest and live reporting code on machines doesn't submit results for it.

Second: I'm fixing open primary tabulation on VxAdmin and in live reports (currently fine on VxScan).

My quick summary of the issue:

Valid ballots for the other party are contributing undervotes to the contests for the first party, when they should just be filtered out. VxScan tabulates in such a way that ballots are prefiltered/grouped by party, masking the bug. VxAdmin (and live reports) also generate per-party reports but the filtering/grouping happens at a later stage such that the bug still manifests.

Additional context from Claude on the second:

> Short answer
> 
>   All three — VxScan, VxAdmin reports, and live reports — call the same shared tabulation code (tabulateCastVoteRecords →
>   addCastVoteRecordToElectionResult in libs/utils/src/tabulation/tabulation.ts). The bug lived there, so none of them were truly immune. What differed
>   was whether tabulation is grouped by inferred party, and that's what made the bug invisible on VxScan but visible everywhere else.
>   
>   The bug
> 
>   A consolidated open-primary ballot contains every party's partisan contests. The interpreter records empty selections for the parties the voter
>   skipped. The old code only voided partisan contests on an actual crossover:
> 
> ```
>   const voidedContestIds = hasCrossoverVote(election, cvr.votes)
>     ? new Set(partisanContests(election).map((c) => c.id))
>     : undefined;'
> ```
> 
>   So for a clean Republican ballot, the empty governor-democratic and governor-libertarian selections fell through and were tallied as undervotes in
>   those contests — inflating each contest's ballots and undervotes.
> 
>   Where the paths diverge
> 
>   VxScan — tabulates grouped by inferred party (bug masked):
> 
>   apps/scan/backend/src/util/results.ts
>   - buildCvr sets partyId: inferPartyFromVotes(election, votes) (line 109-111)
>   - getScannerResults passes groupBy: { groupByParty: true } (line 209)
>   
>   So a Republican ballot's results land entirely in the Republican bucket. The phantom governor-democratic undervote was still miscounted — but it sat
>   inside the Republican group. When scan prints its per-party report section, groupContestsByParty
>   (libs/utils/src/tabulation/contest_filtering.ts:111) filters each section to only that party's candidate contests (c.partyId === partyId), so a
>   stray Democratic undervote inside the Republican group is never rendered. Net: scan's displayed numbers looked right.
>   
>   VxAdmin reports / CSV — tabulates without party grouping (bug visible):
> 
>   apps/admin/backend/src/app.ts:1195 explicitly forbids it:
>   assert(!input.groupBy.groupByParty, 'Group by party not supported in CSV export');
>   The CSV shows every contest's total across all ballots, so governor-democratic absorbed phantom undervotes from Republican, crossover, and
>   nonpartisan-only ballots — exactly what the test diff shows (ballots-cast 5→4, undervotes 1→0).
> 
>   Live reports — flat aggregate, party only affects layout (bug visible):
> 
>   apps/design/frontend/src/live_reports_screen.tsx uses a single flat aggregatedResults.contestResults[contest.id] (line 1103). contestsByParty groups
>   contests for display sections only — it does not re-tabulate per party. So the Democratic section displays governor-democratic's flat aggregate,
>   which still includes the phantom other-party undervotes. (This is why "filters contests by party" wasn't enough to save it — the counts were already
>   contaminated upstream.)
> 
>   The fix
> 
>   Moves the correction to the per-CVR level, so it's grouping-independent:
> 
> ```
>   let voidedContestIds: Set<ContestId> | undefined;
>   if (isOpenPrimary(election)) {
>     const inferredPartyId = inferPartyFromVotes(election, cvr.votes);
>     voidedContestIds = new Set(
>       partisanContests(election)
>         .filter((contest) => contest.partyId !== inferredPartyId)
>         .map((contest) => contest.id)
>     );
>   }
> ```
> 
>   Now every partisan contest not matching the ballot's inferred party is dropped at tabulation time. Scan's per-party buckets, VxAdmin's ungrouped
>   totals, and live reports' flat aggregate all produce the same correct numbers.
> 
>   So the divergence wasn't in the tabulation function — it was the groupBy argument and the rendering around it: VxScan's by-party grouping +
>   per-party contest filtering hid the defect; the ungrouped/flat consumers surfaced it.