### PR TITLE
VxDesign: Edit and display multi-line contest titles naturally

### DIFF
--- a/apps/admin/frontend/src/screens/write_in_candidates_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/write_in_candidates_screen.test.tsx
@@ -78,6 +78,27 @@ describe('contest list', () => {
     screen.getByText('Mammal Party');
   });
 
+  test('renders <br/> line breaks in contest titles', () => {
+    const electionDefinition =
+      electionTwoPartyPrimaryFixtures.readElectionDefinition();
+    const election: Election = {
+      ...electionDefinition.election,
+      contests: electionDefinition.election.contests.map((c) =>
+        c.id === 'zoo-council-mammal'
+          ? { ...c, title: 'Zoo Council<br/>(Mammal Party)' }
+          : c
+      ),
+    };
+    expectGetQualifiedWriteInCandidates();
+    renderInAppContext(<WriteInCandidatesScreen />, {
+      electionDefinition: { ...electionDefinition, election },
+      apiMock,
+    });
+
+    const title = screen.getByText('Zoo Council(Mammal Party)');
+    expect(title.innerHTML).toContain('<br>');
+  });
+
   test('shows callout when no contests allow write-ins', () => {
     const electionDefinition =
       electionTwoPartyPrimaryFixtures.readElectionDefinition();

--- a/apps/admin/frontend/src/screens/write_in_candidates_screen.tsx
+++ b/apps/admin/frontend/src/screens/write_in_candidates_screen.tsx
@@ -7,7 +7,14 @@ import {
   Id,
 } from '@votingworks/types';
 import { assertDefined } from '@votingworks/basics';
-import { Button, Callout, Modal, P, useCurrentTheme } from '@votingworks/ui';
+import {
+  BallotText,
+  Button,
+  Callout,
+  Modal,
+  P,
+  useCurrentTheme,
+} from '@votingworks/ui';
 import type { QualifiedWriteInCandidateRecord } from '@votingworks/admin-backend';
 import { AppContext } from '../contexts/app_context';
 import { EntityList } from '../components/entity_list';
@@ -490,7 +497,9 @@ export function WriteInCandidatesScreen(): JSX.Element {
                       <EntityList.Caption>
                         {getContestDistrictName(election, contest)}
                       </EntityList.Caption>
-                      <EntityList.Label>{contest.title}</EntityList.Label>
+                      <EntityList.Label>
+                        <BallotText text={contest.title} />
+                      </EntityList.Label>
                     </div>
                   </EntityList.Item>
                 );

--- a/apps/design/frontend/src/ballot_audio/input_with_audio.test.tsx
+++ b/apps/design/frontend/src/ballot_audio/input_with_audio.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { assert } from '@votingworks/basics';
 import { render, screen } from '../../test/react_testing_library';
-import { InputWithAudio } from './input_with_audio';
+import { InputWithAudio, TextareaWithAudio } from './input_with_audio';
 import { AudioLinkButton, AudioLinkButtonProps } from './audio_link_button';
 
 vi.mock('./audio_link_button.js');
@@ -60,6 +60,69 @@ test('omits button when empty', () => {
       audioScreenUrl="/audio/edit"
       defaultValue=""
       editing={false}
+    />
+  );
+
+  screen.getByRole('textbox');
+  expect(screen.queryButton('Preview or Edit Audio')).not.toBeInTheDocument();
+});
+
+test('passes through textarea props and sizes rows to content', () => {
+  const onChange = vi.fn((event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    assert(event.target instanceof HTMLTextAreaElement);
+    expect(event.target.value).toEqual('line one\nline two!');
+  });
+
+  mockButtonComponent({
+    'aria-label': 'Preview or Edit Audio',
+    className: expect.any(String),
+    to: '/audio/edit',
+    tooltip: 'Preview/Edit Audio',
+    tooltipPlacement: 'bottom',
+  });
+
+  render(
+    <TextareaWithAudio
+      audioScreenUrl="/audio/edit"
+      editing={false}
+      name="test_textarea"
+      onChange={onChange}
+      title="test_textarea"
+      tooltipPlacement="bottom"
+      value={'line one\nline two'}
+    />
+  );
+
+  const textarea = screen.getByRole('textbox', { name: 'test_textarea' });
+  expect(textarea).toHaveValue('line one\nline two');
+  expect(textarea).toHaveAttribute('rows', '2');
+  userEvent.type(textarea, '!');
+  expect(onChange).toHaveBeenCalled();
+});
+
+test('textarea omits button when editing', () => {
+  render(
+    <TextareaWithAudio
+      audioScreenUrl="/audio/edit"
+      editing
+      readOnly
+      value="General Election"
+    />
+  );
+
+  const textarea = screen.getByRole('textbox');
+  expect(textarea).toHaveValue('General Election');
+  expect(textarea).toHaveAttribute('rows', '1');
+  expect(screen.queryButton('Preview or Edit Audio')).not.toBeInTheDocument();
+});
+
+test('textarea omits button when empty', () => {
+  render(
+    <TextareaWithAudio
+      audioScreenUrl="/audio/edit"
+      editing={false}
+      readOnly
+      value=""
     />
   );
 

--- a/apps/design/frontend/src/ballot_audio/input_with_audio.tsx
+++ b/apps/design/frontend/src/ballot_audio/input_with_audio.tsx
@@ -14,7 +14,8 @@ const InputWithAudioContainer = styled.div`
   display: flex;
   width: 100%;
 
-  > input {
+  > input,
+  > textarea {
     /*
      * Inputs have min widths set across the app at the moment. Disabling
      * for the audio-related UI updates to support responsive UI scaling, but
@@ -27,7 +28,12 @@ const InputWithAudioContainer = styled.div`
     width: 100%;
   }
 
-  > input:not(:last-child) {
+  > textarea {
+    resize: none;
+  }
+
+  > input:not(:last-child),
+  > textarea:not(:last-child) {
     border-bottom-right-radius: 0;
     border-right: 0;
     border-top-right-radius: 0;
@@ -60,6 +66,36 @@ export function InputWithAudio(props: InputWithAudioProps): React.ReactNode {
   return (
     <InputWithAudioContainer>
       <input {...rest} />
+
+      {audioEnabled && (
+        <AudioButton
+          aria-label="Preview or Edit Audio"
+          to={audioScreenUrl}
+          tooltip="Preview/Edit Audio"
+          tooltipPlacement={tooltipPlacement}
+        />
+      )}
+    </InputWithAudioContainer>
+  );
+}
+
+export type TextareaWithAudioProps = {
+  audioScreenUrl: string;
+  editing: boolean;
+  tooltipPlacement?: TooltipProps['attachTo'];
+  value: string;
+} & React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export function TextareaWithAudio(
+  props: TextareaWithAudioProps
+): React.ReactNode {
+  const { editing, audioScreenUrl, tooltipPlacement, ...rest } = props;
+
+  const audioEnabled = !editing && !!rest.value;
+
+  return (
+    <InputWithAudioContainer>
+      <textarea rows={rest.value.split('\n').length} {...rest} />
 
       {audioEnabled && (
         <AudioButton

--- a/apps/design/frontend/src/contest_form.tsx
+++ b/apps/design/frontend/src/contest_form.tsx
@@ -51,14 +51,23 @@ import {
 import { InputGroup, Row, FieldName, Column } from './layout';
 import { routes } from './routes';
 import { TooltipContainer, Tooltip } from './tooltip';
-import { generateId, replaceAtIndex } from './utils';
-import { InputWithAudio } from './ballot_audio/input_with_audio';
+import {
+  contestTitleToPlainText,
+  generateId,
+  plainTextToContestTitle,
+  replaceAtIndex,
+} from './utils';
+import {
+  InputWithAudio,
+  TextareaWithAudio,
+} from './ballot_audio/input_with_audio';
 import { AudioLinkButton } from './ballot_audio/audio_link_button';
 import { RichTextEditorWithAudio } from './ballot_audio/rich_text_editor_with_audio';
 
 const Form = styled(FormFixed)`
   .search-select,
-  input[type='text'] {
+  input[type='text'],
+  textarea {
     max-width: 20rem;
     min-width: 5rem;
     width: 100%;
@@ -319,7 +328,7 @@ export function ContestForm(props: ContestFormProps): React.ReactNode {
         <FormTitle>{title}</FormTitle>
 
         <InputGroup label="Title">
-          <InputWithAudio
+          <TextareaWithAudio
             audioScreenUrl={contestRoutes.audio({
               contestId: contest.id,
               stringKey: ElectionStringKey.CONTEST_TITLE,
@@ -327,11 +336,15 @@ export function ContestForm(props: ContestFormProps): React.ReactNode {
             })}
             disabled={disabled}
             editing={editing}
-            type="text"
             value={contest.title}
             onChange={(e) => setContest({ ...contest, title: e.target.value })}
             onBlur={(e) =>
-              setContest({ ...contest, title: e.target.value.trim() })
+              setContest({
+                ...contest,
+                title: contestTitleToPlainText(
+                  plainTextToContestTitle(e.target.value)
+                ),
+              })
             }
             autoComplete="off"
             required
@@ -998,15 +1011,18 @@ function draftCandidateFromCandidate(candidate: Candidate): DraftCandidate {
   };
 }
 
+// Multi-line contest titles are stored with <br/> line breaks, but edited in
+// the form as plain text with newlines.
 function draftContestFromContest(contest: AnyContest): DraftContest {
   switch (contest.type) {
     case 'candidate':
       return {
         ...contest,
+        title: contestTitleToPlainText(contest.title),
         candidates: contest.candidates.map(draftCandidateFromCandidate),
       };
     case 'yesno':
-      return { ...contest };
+      return { ...contest, title: contestTitleToPlainText(contest.title) };
     /* istanbul ignore next */
     case 'straight-party':
       throw new Error('Straight-party contests are not editable');
@@ -1023,6 +1039,7 @@ function tryContestFromDraftContest(
     case 'candidate':
       return safeParse(CandidateContestSchema, {
         ...draftContest,
+        title: plainTextToContestTitle(draftContest.title),
         candidates: draftContest.candidates.map((candidate) => ({
           ...candidate,
           name: joinCandidateName(candidate),
@@ -1030,7 +1047,10 @@ function tryContestFromDraftContest(
       });
 
     case 'yesno':
-      return safeParse(YesNoContestSchema, draftContest);
+      return safeParse(YesNoContestSchema, {
+        ...draftContest,
+        title: plainTextToContestTitle(draftContest.title),
+      });
 
     default: {
       /* istanbul ignore next */

--- a/apps/design/frontend/src/contest_list.test.tsx
+++ b/apps/design/frontend/src/contest_list.test.tsx
@@ -297,6 +297,36 @@ test('supports reordering', async () => {
   ]);
 });
 
+test('renders <br/> line breaks in contest titles as newlines', async () => {
+  mockApi = newMockApi({ districts: [district1] });
+  const multilineContest: AnyContest = {
+    ...candidateContest1,
+    title: 'County Commissioner<br>District 3<br />(Vote for Two)',
+  };
+
+  renderList(mockApi, newHistory(), {
+    straightPartyContests: [],
+    candidateContests: [multilineContest],
+    yesNoContests: [],
+    reorder: vi.fn(),
+    reordering: true,
+  });
+
+  await screen.findAllByText(district1.name);
+  mockApi.assertComplete();
+
+  const title = screen.getByText(
+    'County Commissioner District 3 (Vote for Two)'
+  );
+  expect(title.textContent).toEqual(
+    'County Commissioner\nDistrict 3\n(Vote for Two)'
+  );
+  expect(title).toHaveStyle({ whiteSpace: 'pre-line' });
+
+  // Reorder button labels use the plain-text title as well
+  screen.getButton('Move Up: County Commissioner\nDistrict 3\n(Vote for Two)');
+});
+
 function getHeading(name: string) {
   return screen.getByRole('heading', { name });
 }

--- a/apps/design/frontend/src/contest_list.tsx
+++ b/apps/design/frontend/src/contest_list.tsx
@@ -8,6 +8,7 @@ import { Column, Row } from './layout';
 import * as api from './api';
 import { ElectionIdParams, routes } from './routes';
 import { EntityList } from './entity_list';
+import { contestTitleToPlainText } from './utils';
 
 const CLASS_REORDER_BUTTON = 'contestReorderButton';
 
@@ -15,6 +16,11 @@ const Item = styled(EntityList.Item)`
   .${CLASS_REORDER_BUTTON} {
     padding: 0.55rem;
   }
+`;
+
+// Render <br/> line breaks in multi-line contest titles as newlines:
+const TitleLabel = styled(EntityList.Label)`
+  white-space: pre-line;
 `;
 
 const Items = styled(EntityList.Items)`
@@ -168,13 +174,13 @@ export function Sublist(props: {
                   </EntityList.Caption>
                 )}
 
-                <EntityList.Label>{c.title}</EntityList.Label>
+                <TitleLabel>{contestTitleToPlainText(c.title)}</TitleLabel>
               </Column>
 
               {reordering && (
                 <Row style={{ gap: '0.5rem', justifyContent: 'flex-end' }}>
                   <Button
-                    aria-label={`Move Up: ${c.title}`}
+                    aria-label={`Move Up: ${contestTitleToPlainText(c.title)}`}
                     icon="ChevronUp"
                     className={CLASS_REORDER_BUTTON}
                     disabled={index === 0}
@@ -183,7 +189,9 @@ export function Sublist(props: {
                     value={{ id: c.id, direction: -1 }}
                   />
                   <Button
-                    aria-label={`Move Down: ${c.title}`}
+                    aria-label={`Move Down: ${contestTitleToPlainText(
+                      c.title
+                    )}`}
                     icon="ChevronDown"
                     className={CLASS_REORDER_BUTTON}
                     disabled={index === contests.length - 1}

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -970,6 +970,77 @@ test('editing a ballot measure', async () => {
   expectContestListItems(updatedContestList);
 });
 
+test('multi-line titles are edited as plain text and saved with <br/> line breaks', async () => {
+  const electionRecord = generalElectionRecord(jurisdiction.id);
+  const { election } = electionRecord;
+  const electionId = election.id;
+  const savedContest: CandidateContest = {
+    ...find(
+      election.contests,
+      (contest): contest is CandidateContest => contest.type === 'candidate'
+    ),
+    title: 'County Commissioner<br>District 3<br />(Vote for Two)',
+  };
+  const contests = election.contests.map((contest) =>
+    contest.id === savedContest.id ? savedContest : contest
+  );
+
+  apiMock.listContests.expectCallWith({ electionId }).resolves(contests);
+  expectOtherElectionApiCalls(election);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+
+  const history = renderScreen(electionId);
+  await navigateToContestEdit(history, electionId, savedContest.id);
+
+  // Saved <br/> line breaks (in any form) are shown as newlines in the form
+  const titleInput = screen.getByLabelText('Title');
+  expect(titleInput).toHaveValue(
+    'County Commissioner\nDistrict 3\n(Vote for Two)'
+  );
+
+  // Blurring an empty title is a no-op
+  userEvent.clear(titleInput);
+  userEvent.tab();
+  expect(titleInput).toHaveValue('');
+
+  // Extra whitespace and blank leading/trailing lines are trimmed on blur
+  userEvent.type(
+    titleInput,
+    '{enter}  Mayor {enter}City of Springfield{enter}'
+  );
+  userEvent.tab();
+  expect(titleInput).toHaveValue('Mayor\nCity of Springfield');
+
+  const updatedContest: CandidateContest = {
+    ...savedContest,
+    title: 'Mayor<br/>City of Springfield',
+    // The form always includes a designation key for each candidate
+    candidates: savedContest.candidates.map((candidate) => ({
+      ...candidate,
+      designation: undefined,
+    })),
+  };
+  apiMock.updateContest
+    .expectCallWith({ electionId, updatedContest })
+    .resolves(ok());
+  const updatedContestList = contests.map((contest) =>
+    contest.id === savedContest.id ? updatedContest : contest
+  );
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(updatedContestList);
+  expectOtherElectionApiCalls(election);
+  userEvent.click(screen.getButton('Save'));
+
+  await screen.findByRole('heading', { name: 'Contest Info' });
+  expect(history.location.pathname).toEqual(
+    routes.election(electionId).contests.view(savedContest.id).path
+  );
+  expect(screen.getByLabelText('Title')).toHaveValue(
+    'Mayor\nCity of Springfield'
+  );
+});
+
 test('features.ADDITIONAL_BALLOT_MEASURE_OPTIONS enables adding/removing additional options', async () => {
   const electionRecord = generalElectionRecord(jurisdiction.id);
   const { election } = electionRecord;

--- a/apps/design/frontend/src/utils.ts
+++ b/apps/design/frontend/src/utils.ts
@@ -13,6 +13,30 @@ export function generateId(): string {
 }
 
 /**
+ * Multi-line contest titles are stored with `<br/>` line breaks (which the
+ * ballot renderer supports). Converts a stored title to plain text with
+ * newlines for editing and display.
+ */
+export function contestTitleToPlainText(title: string): string {
+  return title.replace(/<br\s*\/?>/gi, '\n');
+}
+
+/**
+ * Converts plain text with newlines to a stored contest title with `<br/>`
+ * line breaks, trimming each line and dropping leading/trailing blank lines.
+ */
+export function plainTextToContestTitle(text: string): string {
+  const lines = text.split('\n').map((line) => line.trim());
+  while (lines.length > 0 && lines[0] === '') {
+    lines.shift();
+  }
+  while (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+  return lines.join('<br/>');
+}
+
+/**
  * Returns a copy of the given array with the value at the specified index
  * replaced with the given value.
  */


### PR DESCRIPTION
## Overview

Multi-line contest titles are stored with `<br/>` line breaks, which the ballot renderer supports (via react-i18next's basic HTML node handling in `UiString`/`Trans`). Previously, users had to type `<br/>` literally into VxDesign's single-line Title input, and several screens displayed the markers as literal text.

This PR:

- **VxDesign contest form**: the Title field is now a textarea — users enter line breaks naturally with Enter. The form converts between the stored `<br/>` representation and plain text with newlines at the form boundary (lines trimmed, leading/trailing blank lines dropped on blur). The stored election data format is unchanged.
- **VxDesign contest list**: titles with `<br/>` now render as line breaks instead of literal text (including the reorder button labels).
- **VxAdmin write-in candidates screen**: renders titles with the existing `BallotText` component, matching the adjudication screens, instead of showing literal `<br/>`.

## Demo Video or Screenshot

## Testing Plan

- New unit tests: multi-line title editing round-trip in the contest form (`<br>`/`<br/>`/`<br />` all accepted, saved as `<br/>`), contest list line-break rendering, `TextareaWithAudio` component, write-in candidates screen line-break rendering.
- Full `design-frontend` suite passes (45/45 files) with coverage thresholds met; `admin-frontend` write-in candidates screen tests pass.
- Manually verified in VxDesign: entering a two-line title with Enter, saving, reopening, and previewing the ballot; existing `<br/>` titles load as multi-line text in the editor.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)