### PR TITLE
VxMark/VxMarkScan: Fix open primary ballot contest count on start page

### DIFF
--- a/apps/mark-scan/frontend/src/pages/start_screen.test.tsx
+++ b/apps/mark-scan/frontend/src/pages/start_screen.test.tsx
@@ -41,7 +41,7 @@ test('renders StartScreen', () => {
   screen.getByRole('heading', { name: /Example Primary Election/ });
   screen.getByText('September 8, 2021');
   screen.getByText(
-    hasTextAcrossElements('Number of contests on your ballot: 7')
+    hasTextAcrossElements('Number of contests on your ballot: 4')
   );
 });
 
@@ -61,7 +61,7 @@ test('renders StartScreen in Landscape Orientation', () => {
   });
   screen.getByText('September 8, 2021');
   screen.getByText(
-    hasTextAcrossElements('Number of contests on your ballot: 7')
+    hasTextAcrossElements('Number of contests on your ballot: 4')
   );
   expect(
     heading.parentElement!.parentElement!.getElementsByTagName('img')

--- a/apps/mark-scan/frontend/src/pages/start_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/start_screen.tsx
@@ -10,7 +10,7 @@ import { useVoterHelpScreen } from './use_voter_help_screen';
 
 export function StartScreen(): JSX.Element {
   const history = useHistory();
-  const { ballotStyleId, contests, electionDefinition, precinctId } =
+  const { ballotStyleId, electionDefinition, precinctId } =
     useContext(BallotContext);
   const VoterHelpScreen = useVoterHelpScreen('StartScreen');
 
@@ -24,7 +24,6 @@ export function StartScreen(): JSX.Element {
 
   return (
     <StartPage
-      contests={contests}
       onStart={onStart}
       ballotStyleId={ballotStyleId}
       electionDefinition={electionDefinition}

--- a/apps/mark/frontend/src/pages/start_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/start_screen.test.tsx
@@ -29,12 +29,33 @@ test('renders StartScreen', () => {
   screen.getByText('September 8, 2021');
   screen.getByText(hasTextAcrossElements('Sample County, State of Sample'));
   screen.getByText('Precinct 1');
+  // Ballot style 1M is the Mammal Party ballot: 2 Mammal contests, the merged
+  // either-neither ballot measure, and the fishing ballot measure.
   screen.getByText(
-    hasTextAcrossElements('Number of contests on your ballot: 7')
+    hasTextAcrossElements('Number of contests on your ballot: 4')
   );
   expect(
     heading.parentElement!.parentElement!.getElementsByTagName('img')
   ).toHaveLength(1); // Seal
+});
+
+test('counts nonpartisan plus one party of contests for open primaries', () => {
+  const electionDefinition =
+    electionOpenPrimaryFixtures.readElectionDefinition();
+
+  render(<Route path="/" component={StartScreen} />, {
+    ballotStyleId: 'ballot-style-1',
+    electionDefinition,
+    precinctId: 'precinct-1',
+    route: '/',
+  });
+
+  // ballot-style-1 has 6 nonpartisan contests and 7 partisan contests per
+  // party. A voter only votes one party's contests, so the count is 6 + 7,
+  // independent of the (not-yet-made) party selection.
+  screen.getByText(
+    hasTextAcrossElements('Number of contests on your ballot: 13')
+  );
 });
 
 test('renders as voter screen', () => {

--- a/apps/mark/frontend/src/pages/start_screen.tsx
+++ b/apps/mark/frontend/src/pages/start_screen.tsx
@@ -8,7 +8,7 @@ import { BallotContext } from '../contexts/ballot_context';
 
 export function StartScreen(): JSX.Element {
   const history = useHistory();
-  const { ballotStyleId, contests, electionDefinition, precinctId } =
+  const { ballotStyleId, electionDefinition, precinctId } =
     React.useContext(BallotContext);
 
   function onStart() {
@@ -21,7 +21,6 @@ export function StartScreen(): JSX.Element {
 
   return (
     <StartPage
-      contests={contests}
       onStart={onStart}
       ballotStyleId={ballotStyleId}
       electionDefinition={electionDefinition}

--- a/libs/mark-flow-ui/src/index.ts
+++ b/libs/mark-flow-ui/src/index.ts
@@ -22,3 +22,4 @@ export * from './pages/print_page';
 export * from './pages/review_page';
 export * from './pages/start_page';
 export * from './utils/ms_either_neither_contests';
+export * from './utils/num_ballot_contests';

--- a/libs/mark-flow-ui/src/pages/start_page.tsx
+++ b/libs/mark-flow-ui/src/pages/start_page.tsx
@@ -21,11 +21,13 @@ import {
   BallotStyleId,
   ElectionDefinition,
   getBallotStyle,
+  getContests,
   getPartyForBallotStyle,
   PrecinctId,
 } from '@votingworks/types';
 import { getPrecinctsAndSplitsForBallotStyle } from '@votingworks/utils';
-import { ContestsWithMsEitherNeither } from '../utils/ms_either_neither_contests';
+import { mergeMsEitherNeitherContests } from '../utils/ms_either_neither_contests';
+import { getNumBallotContests } from '../utils/num_ballot_contests';
 import { VoterHelpScreenType, VoterScreen } from '../components/voter_screen';
 
 const wobbleKeyframes = keyframes`
@@ -65,7 +67,6 @@ export interface StartPageProps {
    */
   repeatIntroAudioPrompt?: React.ReactNode;
   ballotStyleId?: BallotStyleId;
-  contests: ContestsWithMsEitherNeither;
   electionDefinition?: ElectionDefinition;
   onStart: () => void;
   precinctId?: PrecinctId;
@@ -75,7 +76,6 @@ export interface StartPageProps {
 export function StartPage(props: StartPageProps): JSX.Element {
   const {
     ballotStyleId,
-    contests,
     electionDefinition,
     introAudioText,
     repeatIntroAudioPrompt,
@@ -112,6 +112,14 @@ export function StartPage(props: StartPageProps): JSX.Element {
 
   const party = getPartyForBallotStyle({ ballotStyleId, election });
 
+  // Compute the contest count from the full ballot style rather than the
+  // contests currently being shown: in open primaries, the displayed contests
+  // depend on the voter's (not-yet-made) party selection.
+  const numBallotContests = getNumBallotContests(
+    election,
+    mergeMsEitherNeitherContests(getContests({ election, ballotStyle }))
+  );
+
   const electionInfo = (
     <ElectionInfo>
       <Seal
@@ -135,7 +143,7 @@ export function StartPage(props: StartPageProps): JSX.Element {
           <br />
           <Caption>
             {appStrings.labelNumBallotContests()}{' '}
-            <NumberString value={contests.length} />
+            <NumberString value={numBallotContests} />
           </Caption>
         </P>
       </div>

--- a/libs/mark-flow-ui/src/utils/num_ballot_contests.test.ts
+++ b/libs/mark-flow-ui/src/utils/num_ballot_contests.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from 'vitest';
+import { assertDefined } from '@votingworks/basics';
+import {
+  electionOpenPrimaryFixtures,
+  readElectionGeneral,
+  readElectionTwoPartyPrimary,
+} from '@votingworks/fixtures';
+import { BallotStyleId, getBallotStyle, getContests } from '@votingworks/types';
+import { getNumBallotContests } from './num_ballot_contests';
+import { mergeMsEitherNeitherContests } from './ms_either_neither_contests';
+
+function contestsForBallotStyle(
+  election: Parameters<typeof getContests>[0]['election'],
+  ballotStyleId: BallotStyleId
+) {
+  const ballotStyle = assertDefined(
+    getBallotStyle({ election, ballotStyleId })
+  );
+  return mergeMsEitherNeitherContests(getContests({ election, ballotStyle }));
+}
+
+test('returns the contest count directly for general elections', () => {
+  const election = readElectionGeneral();
+  const contests = contestsForBallotStyle(election, '12');
+  expect(getNumBallotContests(election, contests)).toEqual(contests.length);
+});
+
+test('returns the contest count directly for closed primaries', () => {
+  const election = readElectionTwoPartyPrimary();
+  const contests = contestsForBallotStyle(election, '1M');
+  expect(getNumBallotContests(election, contests)).toEqual(contests.length);
+});
+
+test('counts nonpartisan plus a single party for open primaries', () => {
+  const election = electionOpenPrimaryFixtures.readElection();
+  // The full contest list contains every party's partisan contests, since the
+  // voter hasn't selected a party yet.
+  const contests = contestsForBallotStyle(election, 'ballot-style-1');
+
+  // ballot-style-1: 21 partisan contests (7 per party across 3 parties) and 6
+  // nonpartisan contests.
+  expect(contests).toHaveLength(27);
+  expect(getNumBallotContests(election, contests)).toEqual(6 + 7);
+});
+
+test('counts all contests for an open primary with no partisan contests', () => {
+  const election = electionOpenPrimaryFixtures.readElection();
+  const nonpartisanContests = contestsForBallotStyle(
+    election,
+    'ballot-style-1'
+  ).filter(
+    (contest) =>
+      !(contest.type === 'candidate' && contest.partyId !== undefined)
+  );
+
+  expect(getNumBallotContests(election, nonpartisanContests)).toEqual(
+    nonpartisanContests.length
+  );
+});

--- a/libs/mark-flow-ui/src/utils/num_ballot_contests.ts
+++ b/libs/mark-flow-ui/src/utils/num_ballot_contests.ts
@@ -1,0 +1,40 @@
+import { groupBy } from '@votingworks/basics';
+import { CandidateContest, Election, isOpenPrimary } from '@votingworks/types';
+import { ContestsWithMsEitherNeither } from './ms_either_neither_contests';
+
+/**
+ * Computes the number of contests a voter will see on their ballot, for display
+ * on the start page.
+ *
+ * For open primaries, the provided contest list contains the partisan contests
+ * for *every* party, since the voter hasn't yet selected a party. A voter only
+ * votes in a single party's contests, so the correct count is the number of
+ * nonpartisan contests plus the number of partisan contests for a single party
+ * (every party has the same number of partisan contests). For all other
+ * elections the contest list already reflects the voter's ballot, so we use its
+ * length directly.
+ */
+export function getNumBallotContests(
+  election: Election,
+  contests: ContestsWithMsEitherNeither
+): number {
+  if (!isOpenPrimary(election)) {
+    return contests.length;
+  }
+
+  const partisanContests = contests.filter(
+    (contest): contest is CandidateContest =>
+      contest.type === 'candidate' && contest.partyId !== undefined
+  );
+  if (partisanContests.length === 0) {
+    return contests.length;
+  }
+
+  const nonpartisanContestCount = contests.length - partisanContests.length;
+  const partisanContestCountsByParty = groupBy(
+    partisanContests,
+    (contest) => contest.partyId
+  ).map(([, partyContests]) => partyContests.length);
+
+  return nonpartisanContestCount + Math.max(...partisanContestCountsByParty);
+}


### PR DESCRIPTION
## Overview

The "Number of contests on your ballot" count on the BMD start page was wrong for open primaries. Since #8616, before a voter selects a party the displayed contest list contains only the nonpartisan contests, so the count reflected only those.

A voter's open-primary ballot is the nonpartisan contests plus a single party's partisan contests (every party has the same number of partisan contests). This PR computes the count in `StartPage` from the full ballot style (via `getContests` + `mergeMsEitherNeitherContests`) rather than the contests currently shown — which depend on the not-yet-made party selection.

- Add `getNumBallotContests`, which returns nonpartisan + one party's partisan count for open primaries, and the contest count directly otherwise.
- `StartPage` computes the count from the election + ballot style, so the displayed number no longer depends on party-selection state. The now-redundant `contests` prop was dropped from `StartPage` and its two callers.

For `electionOpenPrimary` `ballot-style-1` the count is now 6 nonpartisan + 7 partisan = **13** (previously only the 6 nonpartisan contests were counted).

## Demo Video or Screenshot

n/a — text-only count fix; covered by tests.

## Testing Plan

- New unit tests for `getNumBallotContests` (general, closed primary, open primary, open primary with no partisan contests).
- New open-primary integration case in mark's `start_screen.test.tsx` asserting the count is 13.
- Verified mark-flow-ui suite, mark + mark-scan `start_screen`, `app_cardless_voting`, and `app_open_primary` tests pass; lint + typecheck clean.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.