### PR TITLE
VxAdmin: Refactor adjudication frontend components

### DIFF
--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -22,7 +22,7 @@ import {
   AdjudicatedContests,
   ContestListItem,
   contestPartyLabel,
-  CrossoverVoteStatus,
+  BallotCrossoverVoteStatus,
   getCurrentVote,
   isContestTagOnlyUndervote,
 } from '../utils/adjudication';
@@ -326,7 +326,7 @@ function CrossoverVoteStatusLine({
   crossoverVoteStatus,
 }: {
   contestId: ContestId;
-  crossoverVoteStatus: CrossoverVoteStatus;
+  crossoverVoteStatus: BallotCrossoverVoteStatus;
 }) {
   const { isBallotResolved, ballotHasScannedCrossoverVote } =
     crossoverVoteStatus;
@@ -387,7 +387,7 @@ function BallotSideContestList({
   showUndervoteStatus: boolean;
   title: string;
   cvrTag: CvrTag;
-  crossoverVoteStatus: CrossoverVoteStatus;
+  crossoverVoteStatus: BallotCrossoverVoteStatus;
 }): React.ReactNode {
   return (
     <React.Fragment>
@@ -480,7 +480,7 @@ export interface AdjudicationContestListProps {
   onSelectSide: (side: Side) => void;
   selectedSide: Side;
   showUndervoteStatus: boolean;
-  crossoverVoteStatus: CrossoverVoteStatus;
+  crossoverVoteStatus: BallotCrossoverVoteStatus;
 }
 
 export function AdjudicationContestList({
@@ -636,7 +636,7 @@ function BlankBallotCallout({
 function CrossoverVotingCallout({
   ballotHasCrossoverVoteAfterAdjudication,
   isBallotResolved,
-}: CrossoverVoteStatus): JSX.Element | null {
+}: BallotCrossoverVoteStatus): JSX.Element | null {
   const { title, description } = (() => {
     if (!ballotHasCrossoverVoteAfterAdjudication) {
       return {

--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -509,6 +509,7 @@ function BallotSideContestList({
 export interface AdjudicationContestListProps {
   adjudicatedContests: ReadonlyMap<ContestId, AdjudicatedCvrContest>;
   contestItems: ContestListItem[];
+  firstUnresolvedContestId?: ContestId;
   cvrTag: CvrTag;
   election: Election;
   isBallotResolved: boolean;
@@ -522,6 +523,7 @@ export interface AdjudicationContestListProps {
 export function AdjudicationContestList({
   adjudicatedContests,
   contestItems,
+  firstUnresolvedContestId,
   cvrTag,
   election,
   isBallotResolved,
@@ -531,14 +533,6 @@ export function AdjudicationContestList({
   selectedSide,
   showUndervoteStatus,
 }: AdjudicationContestListProps): React.ReactNode {
-  const firstUnresolvedContestId =
-    cvrTag.isBlankBallot || cvrTag.hasCrossoverVote
-      ? undefined
-      : contestItems.find(
-          (item) =>
-            !isContestResolved(item.adjudicationData, adjudicatedContests)
-        )?.contest.id;
-
   const blankBallotHasAnyAdjudicatedVote =
     cvrTag.isBlankBallot &&
     contestItems.some((item) =>

--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -16,15 +16,13 @@ import type {
 } from '@votingworks/admin-backend';
 import { find, iter } from '@votingworks/basics';
 import { Button, Callout, Caption, FontProps, Icons, P } from '@votingworks/ui';
-import { hasCrossoverVote } from '@votingworks/utils';
 import pluralize from 'pluralize';
 import { EntityList } from './entity_list';
 import {
-  adjudicatedVotes,
   ContestListItem,
   contestPartyLabel,
+  CrossoverVoteStatus,
   getCurrentVote,
-  isContestCrossoverVoted,
   isContestTagOnlyUndervote,
 } from '../utils/adjudication';
 
@@ -322,21 +320,20 @@ function ContestAdjudicationSummary({
   );
 }
 
-function CrossoverVoteStatus({
-  ballotHasScannedCrossoverVote,
-  contestHasScannedCrossoverVote,
-  contestHasCrossoverVoteAfterAdjudication,
-  isBallotResolved,
+function CrossoverVoteStatusLine({
+  contestId,
+  crossoverVoteStatus,
 }: {
-  ballotHasScannedCrossoverVote: boolean;
-  contestHasScannedCrossoverVote: boolean;
-  contestHasCrossoverVoteAfterAdjudication: boolean;
-  isBallotResolved: boolean;
+  contestId: ContestId;
+  crossoverVoteStatus: CrossoverVoteStatus;
 }) {
+  const { isBallotResolved, ballotHasScannedCrossoverVote } =
+    crossoverVoteStatus;
+  const contestStatus = crossoverVoteStatus.statusByContest[contestId];
   const warningIcon = <Icons.Crossover color="warning" fixedWidth />;
   const primaryIcon = <Icons.Crossover color="primary" fixedWidth />;
   if (ballotHasScannedCrossoverVote) {
-    if (contestHasCrossoverVoteAfterAdjudication) {
+    if (contestStatus.hasCrossoverVoteAfterAdjudication) {
       if (isBallotResolved) {
         return (
           <StatusLine icon={primaryIcon} color="primary">
@@ -348,11 +345,11 @@ function CrossoverVoteStatus({
         <StatusLine icon={warningIcon}>Crossover vote detected</StatusLine>
       );
     }
-    if (contestHasScannedCrossoverVote) {
+    if (contestStatus.hasScannedCrossoverVote) {
       return <StatusLineConfirmed>Crossover vote resolved</StatusLineConfirmed>;
     }
   }
-  if (contestHasCrossoverVoteAfterAdjudication) {
+  if (contestStatus.hasCrossoverVoteAfterAdjudication) {
     return (
       <StatusLine
         icon={isBallotResolved ? primaryIcon : warningIcon}
@@ -376,8 +373,7 @@ function BallotSideContestList({
   showUndervoteStatus,
   title,
   cvrTag,
-  ballotHasCrossoverVoteAfterAdjudication,
-  isBallotResolved,
+  crossoverVoteStatus,
 }: {
   adjudicatedContests: ReadonlyMap<ContestId, AdjudicatedCvrContest>;
   contests: ContestListItem[];
@@ -390,8 +386,7 @@ function BallotSideContestList({
   showUndervoteStatus: boolean;
   title: string;
   cvrTag: CvrTag;
-  ballotHasCrossoverVoteAfterAdjudication: boolean;
-  isBallotResolved: boolean;
+  crossoverVoteStatus: CrossoverVoteStatus;
 }): React.ReactNode {
   return (
     <React.Fragment>
@@ -419,8 +414,6 @@ function BallotSideContestList({
           const { contest, adjudicationData, isResolved } = item;
           const { tag } = adjudicationData;
           const adjudicatedContest = adjudicatedContests.get(contest.id);
-
-          const isPending = !isResolved;
           const isFirstUnresolved = contest.id === firstUnresolvedContestId;
           const isOnlyUndervote = tag && isContestTagOnlyUndervote(tag);
 
@@ -428,21 +421,6 @@ function BallotSideContestList({
             cvrTag.isBlankBallot &&
             isOnlyUndervote &&
             adjudicatedContest === undefined;
-
-          const contestHasScannedCrossoverVote = isContestCrossoverVoted(
-            cvrTag.hasCrossoverVote,
-            item
-          );
-          const contestHasCrossoverVoteAfterAdjudication =
-            isContestCrossoverVoted(
-              ballotHasCrossoverVoteAfterAdjudication,
-              item,
-              adjudicatedContests.get(contest.id)
-            );
-          const crossoverVoteIsPending =
-            contestHasScannedCrossoverVote &&
-            contestHasCrossoverVoteAfterAdjudication &&
-            !isBallotResolved;
 
           const partyLabel = contestPartyLabel(election, contest);
 
@@ -454,8 +432,8 @@ function BallotSideContestList({
               onHover={onHover}
               autoScrollIntoView={isFirstUnresolved}
               hasWarning={
-                (isPending && !suppressContestAdjudicationInfo) ||
-                crossoverVoteIsPending
+                (!isResolved && !suppressContestAdjudicationInfo) ||
+                crossoverVoteStatus.statusByContest[contest.id].isUnresolved
               }
             >
               <Column>
@@ -469,15 +447,9 @@ function BallotSideContestList({
                 >
                   {contest.title}
                 </EntityList.Label>
-                <CrossoverVoteStatus
-                  contestHasScannedCrossoverVote={
-                    contestHasScannedCrossoverVote
-                  }
-                  contestHasCrossoverVoteAfterAdjudication={
-                    contestHasCrossoverVoteAfterAdjudication
-                  }
-                  ballotHasScannedCrossoverVote={cvrTag.hasCrossoverVote}
-                  isBallotResolved={isBallotResolved}
+                <CrossoverVoteStatusLine
+                  contestId={contest.id}
+                  crossoverVoteStatus={crossoverVoteStatus}
                 />
                 {!suppressContestAdjudicationInfo && (
                   <ContestAdjudicationSummary
@@ -507,6 +479,7 @@ export interface AdjudicationContestListProps {
   onSelectSide: (side: Side) => void;
   selectedSide: Side;
   showUndervoteStatus: boolean;
+  crossoverVoteStatus: CrossoverVoteStatus;
 }
 
 export function AdjudicationContestList({
@@ -521,6 +494,7 @@ export function AdjudicationContestList({
   onSelectSide,
   selectedSide,
   showUndervoteStatus,
+  crossoverVoteStatus,
 }: AdjudicationContestListProps): React.ReactNode {
   const blankBallotHasAnyAdjudicatedVote =
     cvrTag.isBlankBallot &&
@@ -543,11 +517,6 @@ export function AdjudicationContestList({
       ? 'Blank Ballot Confirmed'
       : 'Blank Ballot Detected';
   })();
-
-  const ballotHasCrossoverVoteAfterAdjudication = hasCrossoverVote(
-    election,
-    adjudicatedVotes(contestItems, adjudicatedContests)
-  );
 
   const [frontContests, backContests] = iter(contestItems).partition(
     (item) => item.side === 'front'
@@ -605,12 +574,7 @@ export function AdjudicationContestList({
         </CalloutContainer>
       )}
       {cvrTag.hasCrossoverVote && (
-        <CrossoverVotingCallout
-          ballotHasCrossoverVoteAfterAdjudication={
-            ballotHasCrossoverVoteAfterAdjudication
-          }
-          isBallotResolved={isBallotResolved}
-        />
+        <CrossoverVotingCallout {...crossoverVoteStatus} />
       )}
       {frontContests.length > 0 && (
         <BallotSideContestList
@@ -625,10 +589,7 @@ export function AdjudicationContestList({
           showUndervoteStatus={showUndervoteStatus}
           title="Front"
           cvrTag={cvrTag}
-          ballotHasCrossoverVoteAfterAdjudication={
-            ballotHasCrossoverVoteAfterAdjudication
-          }
-          isBallotResolved={isBallotResolved}
+          crossoverVoteStatus={crossoverVoteStatus}
         />
       )}
       {backContests.length > 0 && (
@@ -644,10 +605,7 @@ export function AdjudicationContestList({
           showUndervoteStatus={showUndervoteStatus}
           title="Back"
           cvrTag={cvrTag}
-          ballotHasCrossoverVoteAfterAdjudication={
-            ballotHasCrossoverVoteAfterAdjudication
-          }
-          isBallotResolved={isBallotResolved}
+          crossoverVoteStatus={crossoverVoteStatus}
         />
       )}
     </EntityList.Box>
@@ -657,10 +615,7 @@ export function AdjudicationContestList({
 function CrossoverVotingCallout({
   ballotHasCrossoverVoteAfterAdjudication,
   isBallotResolved,
-}: {
-  ballotHasCrossoverVoteAfterAdjudication: boolean;
-  isBallotResolved: boolean;
-}): JSX.Element | null {
+}: CrossoverVoteStatus): JSX.Element | null {
   const { title, description } = (() => {
     if (!ballotHasCrossoverVoteAfterAdjudication) {
       return {

--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -11,7 +11,6 @@ import {
 import type {
   AdjudicatedContestOption,
   AdjudicatedCvrContest,
-  ContestAdjudicationData,
   ContestOptionAdjudicationData,
   CvrTag,
 } from '@votingworks/admin-backend';
@@ -22,10 +21,10 @@ import pluralize from 'pluralize';
 import { EntityList } from './entity_list';
 import {
   adjudicatedVotes,
+  ContestListItem,
   contestPartyLabel,
   getCurrentVote,
   isContestCrossoverVoted,
-  isContestResolved,
   isContestTagOnlyUndervote,
 } from '../utils/adjudication';
 
@@ -133,12 +132,6 @@ function getVoteStatus(voteCount: number, votesAllowed: number): VoteStatus {
   if (voteCount > votesAllowed) return 'overvote';
   if (voteCount < votesAllowed) return 'undervote';
   return 'normal';
-}
-
-export interface ContestListItem {
-  side: Side;
-  contest: AnyContest;
-  adjudicationData: ContestAdjudicationData;
 }
 
 function getAdjudicatedContestStatusLine(
@@ -423,14 +416,10 @@ function BallotSideContestList({
       </EntityList.Header>
       <EntityList.Items>
         {contests.map((item) => {
-          const { contest, adjudicationData } = item;
+          const { contest, adjudicationData, isResolved } = item;
           const { tag } = adjudicationData;
           const adjudicatedContest = adjudicatedContests.get(contest.id);
 
-          const isResolved = isContestResolved(
-            adjudicationData,
-            adjudicatedContests
-          );
           const isPending = !isResolved;
           const isFirstUnresolved = contest.id === firstUnresolvedContestId;
           const isOnlyUndervote = tag && isContestTagOnlyUndervote(tag);

--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -376,7 +376,7 @@ function BallotSideContestList({
   cvrTag,
   crossoverVoteStatus,
 }: {
-  adjudicatedContests: ReadonlyMap<ContestId, AdjudicatedCvrContest>;
+  adjudicatedContests: AdjudicatedContests;
   contests: ContestListItem[];
   election: Election;
   firstUnresolvedContestId?: ContestId;
@@ -469,7 +469,7 @@ function BallotSideContestList({
 }
 
 export interface AdjudicationContestListProps {
-  adjudicatedContests: ReadonlyMap<ContestId, AdjudicatedCvrContest>;
+  adjudicatedContests: AdjudicatedContests;
   contestItems: ContestListItem[];
   firstUnresolvedContestId?: ContestId;
   cvrTag: CvrTag;

--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -15,7 +15,7 @@ import type {
   ContestOptionAdjudicationData,
   CvrTag,
 } from '@votingworks/admin-backend';
-import { find } from '@votingworks/basics';
+import { find, iter } from '@votingworks/basics';
 import { Button, Callout, Caption, FontProps, Icons, P } from '@votingworks/ui';
 import { hasCrossoverVote } from '@votingworks/utils';
 import pluralize from 'pluralize';
@@ -136,6 +136,7 @@ function getVoteStatus(voteCount: number, votesAllowed: number): VoteStatus {
 }
 
 export interface ContestListItem {
+  side: Side;
   contest: AnyContest;
   adjudicationData: ContestAdjudicationData;
 }
@@ -507,10 +508,9 @@ function BallotSideContestList({
 
 export interface AdjudicationContestListProps {
   adjudicatedContests: ReadonlyMap<ContestId, AdjudicatedCvrContest>;
-  backContests: ContestListItem[];
+  contestItems: ContestListItem[];
   cvrTag: CvrTag;
   election: Election;
-  frontContests: ContestListItem[];
   isBallotResolved: boolean;
   onHover: (contestId: ContestId | null) => void;
   onSelect: (contestId: ContestId) => void;
@@ -521,10 +521,9 @@ export interface AdjudicationContestListProps {
 
 export function AdjudicationContestList({
   adjudicatedContests,
-  backContests,
+  contestItems,
   cvrTag,
   election,
-  frontContests,
   isBallotResolved,
   onHover,
   onSelect,
@@ -532,18 +531,17 @@ export function AdjudicationContestList({
   selectedSide,
   showUndervoteStatus,
 }: AdjudicationContestListProps): React.ReactNode {
-  const allContests = [...frontContests, ...backContests];
   const firstUnresolvedContestId =
     cvrTag.isBlankBallot || cvrTag.hasCrossoverVote
       ? undefined
-      : allContests.find(
+      : contestItems.find(
           (item) =>
             !isContestResolved(item.adjudicationData, adjudicatedContests)
         )?.contest.id;
 
   const blankBallotHasAnyAdjudicatedVote =
     cvrTag.isBlankBallot &&
-    allContests.some((item) =>
+    contestItems.some((item) =>
       item.adjudicationData.options.some((o) =>
         getCurrentVote(
           o,
@@ -565,7 +563,11 @@ export function AdjudicationContestList({
 
   const ballotHasCrossoverVoteAfterAdjudication = hasCrossoverVote(
     election,
-    adjudicatedVotes(allContests, adjudicatedContests)
+    adjudicatedVotes(contestItems, adjudicatedContests)
+  );
+
+  const [frontContests, backContests] = iter(contestItems).partition(
+    (item) => item.side === 'front'
   );
 
   return (

--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -19,6 +19,7 @@ import { Button, Callout, Caption, FontProps, Icons, P } from '@votingworks/ui';
 import pluralize from 'pluralize';
 import { EntityList } from './entity_list';
 import {
+  AdjudicatedContests,
   ContestListItem,
   contestPartyLabel,
   CrossoverVoteStatus,
@@ -496,28 +497,6 @@ export function AdjudicationContestList({
   showUndervoteStatus,
   crossoverVoteStatus,
 }: AdjudicationContestListProps): React.ReactNode {
-  const blankBallotHasAnyAdjudicatedVote =
-    cvrTag.isBlankBallot &&
-    contestItems.some((item) =>
-      item.adjudicationData.options.some((o) =>
-        getCurrentVote(
-          o,
-          adjudicatedContests.get(item.contest.id)
-            ?.adjudicatedContestOptionById[o.definition.id]
-        )
-      )
-    );
-
-  const blankBallotCalloutTitle = (() => {
-    if (!cvrTag.isBlankBallot) return undefined;
-    if (blankBallotHasAnyAdjudicatedVote) {
-      return 'Blank Ballot Resolved';
-    }
-    return isBallotResolved
-      ? 'Blank Ballot Confirmed'
-      : 'Blank Ballot Detected';
-  })();
-
   const [frontContests, backContests] = iter(contestItems).partition(
     (item) => item.side === 'front'
   );
@@ -525,53 +504,13 @@ export function AdjudicationContestList({
   return (
     <EntityList.Box>
       {cvrTag.isBlankBallot && (
-        <CalloutContainer>
-          <Callout
-            color={
-              blankBallotHasAnyAdjudicatedVote
-                ? 'neutral'
-                : !isBallotResolved
-                ? 'warning'
-                : 'primary'
-            }
-          >
-            <CalloutContent>
-              <P aria-hidden style={{ lineHeight: 1, marginBottom: 0 }}>
-                {isBallotResolved || blankBallotHasAnyAdjudicatedVote ? (
-                  <Icons.Done
-                    color={
-                      blankBallotHasAnyAdjudicatedVote ? 'neutral' : 'primary'
-                    }
-                  />
-                ) : (
-                  <Icons.Warning color="warning" />
-                )}
-              </P>
-              <CalloutBody>
-                <CalloutTitleContainer>
-                  <CalloutTitle weight="bold">
-                    {blankBallotCalloutTitle}
-                  </CalloutTitle>
-                  {blankBallotHasAnyAdjudicatedVote && (
-                    <Caption weight="regular" style={{ lineHeight: 1 }}>
-                      At least one contest now has a valid vote
-                    </Caption>
-                  )}
-                </CalloutTitleContainer>
-                {!blankBallotHasAnyAdjudicatedVote && (
-                  <ViewSideButton
-                    onPress={() =>
-                      onSelectSide(selectedSide === 'front' ? 'back' : 'front')
-                    }
-                    icon="Search"
-                  >
-                    View {selectedSide === 'front' ? 'Back' : 'Front'}
-                  </ViewSideButton>
-                )}
-              </CalloutBody>
-            </CalloutContent>
-          </Callout>
-        </CalloutContainer>
+        <BlankBallotCallout
+          contestItems={contestItems}
+          adjudicatedContests={adjudicatedContests}
+          isBallotResolved={isBallotResolved}
+          selectedSide={selectedSide}
+          onSelectSide={onSelectSide}
+        />
       )}
       {cvrTag.hasCrossoverVote && (
         <CrossoverVotingCallout {...crossoverVoteStatus} />
@@ -609,6 +548,88 @@ export function AdjudicationContestList({
         />
       )}
     </EntityList.Box>
+  );
+}
+
+function BlankBallotCallout({
+  contestItems,
+  adjudicatedContests,
+  isBallotResolved,
+  selectedSide,
+  onSelectSide,
+}: {
+  contestItems: ContestListItem[];
+  adjudicatedContests: AdjudicatedContests;
+  isBallotResolved: boolean;
+  selectedSide: Side;
+  onSelectSide: (side: Side) => void;
+}): JSX.Element {
+  const ballotHasAnyAdjudicatedVote = contestItems.some((item) =>
+    item.adjudicationData.options.some((o) =>
+      getCurrentVote(
+        o,
+        adjudicatedContests.get(item.contest.id)?.adjudicatedContestOptionById[
+          o.definition.id
+        ]
+      )
+    )
+  );
+
+  const blankBallotCalloutTitle = (() => {
+    if (ballotHasAnyAdjudicatedVote) {
+      return 'Blank Ballot Resolved';
+    }
+    return isBallotResolved
+      ? 'Blank Ballot Confirmed'
+      : 'Blank Ballot Detected';
+  })();
+
+  return (
+    <CalloutContainer>
+      <Callout
+        color={
+          ballotHasAnyAdjudicatedVote
+            ? 'neutral'
+            : !isBallotResolved
+            ? 'warning'
+            : 'primary'
+        }
+      >
+        <CalloutContent>
+          <P aria-hidden style={{ lineHeight: 1, marginBottom: 0 }}>
+            {isBallotResolved || ballotHasAnyAdjudicatedVote ? (
+              <Icons.Done
+                color={ballotHasAnyAdjudicatedVote ? 'neutral' : 'primary'}
+              />
+            ) : (
+              <Icons.Warning color="warning" />
+            )}
+          </P>
+          <CalloutBody>
+            <CalloutTitleContainer>
+              <CalloutTitle weight="bold">
+                {blankBallotCalloutTitle}
+              </CalloutTitle>
+              {ballotHasAnyAdjudicatedVote && (
+                <Caption weight="regular" style={{ lineHeight: 1 }}>
+                  At least one contest now has a valid vote
+                </Caption>
+              )}
+            </CalloutTitleContainer>
+            {!ballotHasAnyAdjudicatedVote && (
+              <ViewSideButton
+                onPress={() =>
+                  onSelectSide(selectedSide === 'front' ? 'back' : 'front')
+                }
+                icon="Search"
+              >
+                View {selectedSide === 'front' ? 'Back' : 'Front'}
+              </ViewSideButton>
+            )}
+          </CalloutBody>
+        </CalloutContent>
+      </Callout>
+    </CalloutContainer>
   );
 }
 

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -573,15 +573,6 @@ export function BallotAdjudicationScreen(
     writeInCandidates,
     isClaimed,
   } = props;
-  const { electionDefinition } = useContext(AppContext);
-  const { election } = assertDefined(electionDefinition);
-  const contestAdjudicationData = ballotAdjudicationData.contests;
-  const { frontContests, backContests } = groupContestsBySide(
-    ballotImages,
-    contestAdjudicationData,
-    election
-  );
-
   const [selectedContestId, setSelectedContestId] = useState<ContestId | null>(
     null
   );
@@ -602,14 +593,9 @@ export function BallotAdjudicationScreen(
           systemSettings.areWriteInCandidatesQualified ?? false
         }
         cvrId={cvrId}
-        side={
-          frontContests.some((item) => item.contest.id === selectedContestId)
-            ? 'front'
-            : 'back'
-        }
         onClose={() => setSelectedContestId(null)}
         contestAdjudicationData={find(
-          contestAdjudicationData,
+          ballotAdjudicationData.contests,
           (c) => c.contestId === selectedContestId
         )}
         adjudicatedOptions={
@@ -634,8 +620,6 @@ export function BallotAdjudicationScreen(
   return (
     <BallotView
       adjudicatedContests={adjudicatedContests}
-      frontContests={frontContests}
-      backContests={backContests}
       setSelectedContestId={setSelectedContestId}
       {...props}
     />
@@ -644,8 +628,6 @@ export function BallotAdjudicationScreen(
 
 function BallotView({
   adjudicatedContests,
-  frontContests,
-  backContests,
   setSelectedContestId,
   cvrId,
   ballotAdjudicationData,
@@ -663,14 +645,17 @@ function BallotView({
   onExit,
 }: {
   adjudicatedContests: Map<ContestId, AdjudicatedCvrContest>;
-  frontContests: ContestListItem[];
-  backContests: ContestListItem[];
   setSelectedContestId: (contestId: ContestId | null) => void;
 } & BallotAdjudicationScreenProps): React.ReactNode {
   const { electionDefinition } = useContext(AppContext);
   const { election } = assertDefined(electionDefinition);
-  const allContests = [...frontContests, ...backContests];
   const contestAdjudicationData = ballotAdjudicationData.contests;
+  const { frontContests, backContests } = groupContestsBySide(
+    ballotImages,
+    contestAdjudicationData,
+    election
+  );
+  const allContests = [...frontContests, ...backContests];
 
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [pendingDiscard, setPendingDiscard] = useState<{

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -144,34 +144,28 @@ const ClaimedBallotOverlay = styled.div`
   opacity: 0.8;
 `;
 
-function groupContestsBySide(
+function contestListItems(
   ballotImages: BallotImages,
   contestAdjudicationData: ContestAdjudicationData[],
   election: Election
-): { frontContests: ContestListItem[]; backContests: ContestListItem[] } {
+): ContestListItem[] {
   const contestsById = new Map(election.contests.map((c) => [c.id, c]));
-  const items: ContestListItem[] = contestAdjudicationData.map((data) => ({
+  const baseItems = contestAdjudicationData.map((data) => ({
     contest: assertDefined(contestsById.get(data.contestId)),
     adjudicationData: data,
   }));
   const { front, back } = ballotImages;
   if (front.type === 'bmd') {
-    return { frontContests: items, backContests: [] };
+    return baseItems.map((item) => ({ ...item, side: 'front' }));
   }
   assert(back.type === 'hmpb');
   const frontContestIds = new Set(
     front.layout.contests.map((c) => c.contestId)
   );
-  const frontContests: ContestListItem[] = [];
-  const backContests: ContestListItem[] = [];
-  for (const item of items) {
-    if (frontContestIds.has(item.contest.id)) {
-      frontContests.push(item);
-    } else {
-      backContests.push(item);
-    }
-  }
-  return { frontContests, backContests };
+  return baseItems.map((item) => ({
+    ...item,
+    side: frontContestIds.has(item.contest.id) ? 'front' : 'back',
+  }));
 }
 
 export function BallotAdjudicationScreenWrapper(): JSX.Element {
@@ -650,12 +644,11 @@ function BallotView({
   const { electionDefinition } = useContext(AppContext);
   const { election } = assertDefined(electionDefinition);
   const contestAdjudicationData = ballotAdjudicationData.contests;
-  const { frontContests, backContests } = groupContestsBySide(
+  const contestItems = contestListItems(
     ballotImages,
     contestAdjudicationData,
     election
   );
-  const allContests = [...frontContests, ...backContests];
 
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [pendingDiscard, setPendingDiscard] = useState<{
@@ -665,13 +658,11 @@ function BallotView({
     null
   );
   const [selectedSide, setSelectedSide] = useState<Side>(() => {
-    const backIds = new Set(backContests.map((item) => item.contest.id));
-    const firstPending = contestAdjudicationData
-      .filter((c) => c.tag !== null)
-      .find((c) => !isContestResolved(c, adjudicatedContests));
-    return firstPending && backIds.has(firstPending.contestId)
-      ? 'back'
-      : 'front';
+    const firstPending = contestItems.find(
+      (contest) =>
+        !isContestResolved(contest.adjudicationData, adjudicatedContests)
+    );
+    return firstPending?.side ?? 'front';
   });
 
   function onNavigation(action: () => void): () => void {
@@ -706,7 +697,7 @@ function BallotView({
 
   const ballotHasCrossoverVoteAfterAdjudication = hasCrossoverVote(
     election,
-    adjudicatedVotes(allContests, adjudicatedContests)
+    adjudicatedVotes(contestItems, adjudicatedContests)
   );
 
   const allContestAdjudicationsResolved =
@@ -759,7 +750,7 @@ function BallotView({
 
   const hoveredContestHasWarning = (() => {
     if (!hoveredContestId) return false;
-    const item = find(allContests, (i) => i.contest.id === hoveredContestId);
+    const item = find(contestItems, (i) => i.contest.id === hoveredContestId);
     if (!isContestResolved(item.adjudicationData, adjudicatedContests)) {
       return true;
     }
@@ -825,10 +816,9 @@ function BallotView({
             <AdjudicationContestList
               key={cvrId}
               adjudicatedContests={adjudicatedContests}
-              backContests={backContests}
+              contestItems={contestItems}
               cvrTag={cvrTag}
               election={election}
-              frontContests={frontContests}
               isBallotResolved={ballotAdjudicationData.isResolved}
               onHover={(contestId) => setHoveredContestId(contestId)}
               onSelect={(contestId) => setSelectedContestId(contestId)}

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -492,8 +492,8 @@ function adjudicatedContestsBaseline(
   ballotAdjudicationData: BallotAdjudicationData,
   systemSettings: SystemSettings,
   writeInCandidates: WriteInCandidateRecord[]
-): Map<ContestId, AdjudicatedCvrContest> {
-  const baseline = new Map<ContestId, AdjudicatedCvrContest>(
+): AdjudicatedContests {
+  const baseline: AdjudicatedContests = new Map(
     ballotAdjudicationData.adjudicatedContests.map((c) => [c.contestId, c])
   );
   if (
@@ -569,15 +569,14 @@ export function BallotAdjudicationScreen(
   const [selectedContestId, setSelectedContestId] = useState<ContestId | null>(
     null
   );
-  const [adjudicatedContests, setAdjudicatedContests] = useState<
-    Map<ContestId, AdjudicatedCvrContest>
-  >(
-    adjudicatedContestsBaseline(
-      ballotAdjudicationData,
-      systemSettings,
-      writeInCandidates
-    )
-  );
+  const [adjudicatedContests, setAdjudicatedContests] =
+    useState<AdjudicatedContests>(
+      adjudicatedContestsBaseline(
+        ballotAdjudicationData,
+        systemSettings,
+        writeInCandidates
+      )
+    );
 
   if (selectedContestId && !isClaimed) {
     return (
@@ -637,7 +636,7 @@ function BallotView({
   onBack,
   onExit,
 }: {
-  adjudicatedContests: Map<ContestId, AdjudicatedCvrContest>;
+  adjudicatedContests: AdjudicatedContests;
   setSelectedContestId: (contestId: ContestId | null) => void;
 } & BallotAdjudicationScreenProps): React.ReactNode {
   const { electionDefinition } = useContext(AppContext);

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -643,12 +643,20 @@ function BallotView({
 } & BallotAdjudicationScreenProps): React.ReactNode {
   const { electionDefinition } = useContext(AppContext);
   const { election } = assertDefined(electionDefinition);
-  const contestAdjudicationData = ballotAdjudicationData.contests;
+  const { tag: cvrTag, contests: contestAdjudicationData } =
+    ballotAdjudicationData;
   const contestItems = contestListItems(
     ballotImages,
     contestAdjudicationData,
     election
   );
+  const firstUnresolvedContest =
+    cvrTag.isBlankBallot || cvrTag.hasCrossoverVote
+      ? undefined
+      : contestItems.find(
+          (item) =>
+            !isContestResolved(item.adjudicationData, adjudicatedContests)
+        );
 
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [pendingDiscard, setPendingDiscard] = useState<{
@@ -657,13 +665,9 @@ function BallotView({
   const [hoveredContestId, setHoveredContestId] = useState<ContestId | null>(
     null
   );
-  const [selectedSide, setSelectedSide] = useState<Side>(() => {
-    const firstPending = contestItems.find(
-      (contest) =>
-        !isContestResolved(contest.adjudicationData, adjudicatedContests)
-    );
-    return firstPending?.side ?? 'front';
-  });
+  const [selectedSide, setSelectedSide] = useState<Side>(
+    firstUnresolvedContest?.side ?? 'front'
+  );
 
   function onNavigation(action: () => void): () => void {
     return () => {
@@ -687,7 +691,6 @@ function BallotView({
   const onBackGuarded = onBack && onNavigation(onBack);
   const onExitGuarded = onNavigation(onExit);
 
-  const cvrTag = ballotAdjudicationData.tag;
   const { front, back } = ballotImages;
   const visibleImage = selectedSide === 'front' ? front : back;
 
@@ -816,6 +819,7 @@ function BallotView({
             <AdjudicationContestList
               key={cvrId}
               adjudicatedContests={adjudicatedContests}
+              firstUnresolvedContestId={firstUnresolvedContest?.contest.id}
               contestItems={contestItems}
               cvrTag={cvrTag}
               election={election}

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -10,7 +10,7 @@ import {
   Side,
   SystemSettings,
 } from '@votingworks/types';
-import { format, hasCrossoverVote } from '@votingworks/utils';
+import { format } from '@votingworks/utils';
 import type {
   AdjudicatedContestOption,
   AdjudicatedCvrContest,
@@ -43,9 +43,8 @@ import { AppContext } from '../contexts/app_context';
 import { ContestAdjudicationScreen } from './contest_adjudication_screen';
 import {
   AdjudicatedContests,
-  adjudicatedVotes,
   ContestListItem,
-  isContestCrossoverVoted,
+  deriveCrossoverVoteStatus,
   isContestTagOnlyUndervote,
 } from '../utils/adjudication';
 import { DiscardChangesModal } from '../components/discard_changes_modal';
@@ -696,11 +695,6 @@ function BallotView({
     AdjudicationReason.Undervote
   );
 
-  const ballotHasCrossoverVoteAfterAdjudication = hasCrossoverVote(
-    election,
-    adjudicatedVotes(contestItems, adjudicatedContests)
-  );
-
   const allContestAdjudicationsResolved =
     contestItems.every((contest) => contest.isResolved) ||
     (cvrTag.isBlankBallot &&
@@ -737,6 +731,14 @@ function BallotView({
     }
   }
 
+  const crossoverVoteStatus = deriveCrossoverVoteStatus(
+    election,
+    contestItems,
+    adjudicatedContests,
+    cvrTag.hasCrossoverVote,
+    ballotAdjudicationData.isResolved
+  );
+
   const hoveredContestBounds = (() => {
     if (hoveredContestId && visibleImage.type === 'hmpb') {
       return visibleImage.layout.contests.find(
@@ -749,23 +751,10 @@ function BallotView({
   const hoveredContestHasWarning = (() => {
     if (!hoveredContestId) return false;
     const item = find(contestItems, (i) => i.contest.id === hoveredContestId);
-    if (!item.isResolved) {
-      return true;
-    }
-    const contestHasScannedCrossoverVote = isContestCrossoverVoted(
-      cvrTag.hasCrossoverVote,
-      item
+    return (
+      !item.isResolved ||
+      crossoverVoteStatus.statusByContest[hoveredContestId].isUnresolved
     );
-    const contestHasCrossoverVoteAfterAdjudication = isContestCrossoverVoted(
-      ballotHasCrossoverVoteAfterAdjudication,
-      item,
-      adjudicatedContests.get(item.contest.id)
-    );
-    const crossoverVoteIsPending =
-      contestHasScannedCrossoverVote &&
-      contestHasCrossoverVoteAfterAdjudication &&
-      !ballotAdjudicationData.isResolved;
-    return crossoverVoteIsPending;
   })();
 
   return (
@@ -824,6 +813,7 @@ function BallotView({
               onSelectSide={setSelectedSide}
               selectedSide={selectedSide}
               showUndervoteStatus={showUndervoteStatus}
+              crossoverVoteStatus={crossoverVoteStatus}
             />
           )}
           <PanelFooter>

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -38,16 +38,14 @@ import {
   BallotStaticImageViewer,
   UnableToLoadImageCallout,
 } from '../components/adjudication_ballot_image_viewer';
-import {
-  AdjudicationContestList,
-  ContestListItem,
-} from '../components/adjudication_contest_list';
+import { AdjudicationContestList } from '../components/adjudication_contest_list';
 import { AppContext } from '../contexts/app_context';
 import { ContestAdjudicationScreen } from './contest_adjudication_screen';
 import {
+  AdjudicatedContests,
   adjudicatedVotes,
+  ContestListItem,
   isContestCrossoverVoted,
-  isContestResolved,
   isContestTagOnlyUndervote,
 } from '../utils/adjudication';
 import { DiscardChangesModal } from '../components/discard_changes_modal';
@@ -147,12 +145,14 @@ const ClaimedBallotOverlay = styled.div`
 function contestListItems(
   ballotImages: BallotImages,
   contestAdjudicationData: ContestAdjudicationData[],
+  adjudicatedContests: AdjudicatedContests,
   election: Election
 ): ContestListItem[] {
   const contestsById = new Map(election.contests.map((c) => [c.id, c]));
   const baseItems = contestAdjudicationData.map((data) => ({
     contest: assertDefined(contestsById.get(data.contestId)),
     adjudicationData: data,
+    isResolved: !data.tag || adjudicatedContests.has(data.contestId),
   }));
   const { front, back } = ballotImages;
   if (front.type === 'bmd') {
@@ -648,15 +648,13 @@ function BallotView({
   const contestItems = contestListItems(
     ballotImages,
     contestAdjudicationData,
+    adjudicatedContests,
     election
   );
   const firstUnresolvedContest =
     cvrTag.isBlankBallot || cvrTag.hasCrossoverVote
       ? undefined
-      : contestItems.find(
-          (item) =>
-            !isContestResolved(item.adjudicationData, adjudicatedContests)
-        );
+      : contestItems.find((contest) => !contest.isResolved);
 
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [pendingDiscard, setPendingDiscard] = useState<{
@@ -704,22 +702,19 @@ function BallotView({
   );
 
   const allContestAdjudicationsResolved =
-    contestAdjudicationData.every((c) =>
-      isContestResolved(c, adjudicatedContests)
-    ) ||
+    contestItems.every((contest) => contest.isResolved) ||
     (cvrTag.isBlankBallot &&
-      contestAdjudicationData.every(
-        (c) =>
-          isContestResolved(c, adjudicatedContests) ||
-          (c.tag && isContestTagOnlyUndervote(c.tag))
+      contestItems.every(
+        (contest) =>
+          contest.isResolved ||
+          (contest.adjudicationData.tag &&
+            isContestTagOnlyUndervote(contest.adjudicationData.tag))
       ));
 
-  const hasUnresolvedWriteIns = contestAdjudicationData.some(
-    (c) =>
-      c.tag &&
-      !isContestResolved(c, adjudicatedContests) &&
-      (c.tag.hasWriteIn || c.tag.hasUnmarkedWriteIn)
-  );
+  const hasUnresolvedWriteIns = contestItems.some((contest) => {
+    const { tag } = contest.adjudicationData;
+    return !contest.isResolved && (tag?.hasWriteIn || tag?.hasUnmarkedWriteIn);
+  });
 
   function onAcceptAndNext(): void {
     if (!allContestAdjudicationsResolved) {
@@ -754,7 +749,7 @@ function BallotView({
   const hoveredContestHasWarning = (() => {
     if (!hoveredContestId) return false;
     const item = find(contestItems, (i) => i.contest.id === hoveredContestId);
-    if (!isContestResolved(item.adjudicationData, adjudicatedContests)) {
+    if (!item.isResolved) {
       return true;
     }
     const contestHasScannedCrossoverVote = isContestCrossoverVoted(

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -491,6 +491,57 @@ function HostBallotAdjudicationScreenDataLoader({
   );
 }
 
+// Derives the baseline adjudication state from persisted adjudications.
+// In qualified-write-in mode, auto-resolve contests whose only adjudication
+// reason is write-ins when the contest has no qualified candidates: every
+// write-in must be invalid, so the user has nothing to decide.
+function adjudicatedContestsBaseline(
+  ballotAdjudicationData: BallotAdjudicationData,
+  systemSettings: SystemSettings,
+  writeInCandidates: WriteInCandidateRecord[]
+): Map<ContestId, AdjudicatedCvrContest> {
+  const baseline = new Map<ContestId, AdjudicatedCvrContest>(
+    ballotAdjudicationData.adjudicatedContests.map((c) => [c.contestId, c])
+  );
+  if (
+    !systemSettings.areWriteInCandidatesQualified ||
+    ballotAdjudicationData.isResolved
+  ) {
+    return baseline;
+  }
+  const contestIdsWithQualified = new Set(
+    writeInCandidates.map((c) => c.contestId)
+  );
+
+  for (const contest of ballotAdjudicationData.contests) {
+    if (baseline.has(contest.contestId)) continue;
+    const { tag } = contest;
+    if (!tag) continue;
+    const hasWriteInFlag = tag.hasWriteIn || tag.hasUnmarkedWriteIn;
+    const hasOtherFlag =
+      tag.hasOvervote || tag.hasUndervote || tag.hasMarginalMark;
+    if (!hasWriteInFlag || hasOtherFlag) continue;
+    if (contestIdsWithQualified.has(contest.contestId)) continue;
+
+    const adjudicatedContestOptionById: Record<
+      ContestOptionId,
+      AdjudicatedContestOption
+    > = {};
+    for (const option of contest.options) {
+      const isWriteIn =
+        option.definition.type === 'candidate' && option.definition.isWriteIn;
+      adjudicatedContestOptionById[option.definition.id] = isWriteIn
+        ? { type: 'write-in-option', hasVote: false }
+        : { type: 'official-option', hasVote: option.scannedVote };
+    }
+    baseline.set(contest.contestId, {
+      contestId: contest.contestId,
+      adjudicatedContestOptionById,
+    });
+  }
+  return baseline;
+}
+
 export interface BallotAdjudicationScreenProps {
   cvrId: Id;
   ballotAdjudicationData: BallotAdjudicationData;
@@ -511,7 +562,91 @@ export interface BallotAdjudicationScreenProps {
   onExit: () => void;
 }
 
-export function BallotAdjudicationScreen({
+export function BallotAdjudicationScreen(
+  props: BallotAdjudicationScreenProps
+): JSX.Element {
+  const {
+    cvrId,
+    ballotAdjudicationData,
+    ballotImages,
+    systemSettings,
+    writeInCandidates,
+    isClaimed,
+  } = props;
+  const { electionDefinition } = useContext(AppContext);
+  const { election } = assertDefined(electionDefinition);
+  const contestAdjudicationData = ballotAdjudicationData.contests;
+  const { frontContests, backContests } = groupContestsBySide(
+    ballotImages,
+    contestAdjudicationData,
+    election
+  );
+
+  const [selectedContestId, setSelectedContestId] = useState<ContestId | null>(
+    null
+  );
+  const [adjudicatedContests, setAdjudicatedContests] = useState<
+    Map<ContestId, AdjudicatedCvrContest>
+  >(
+    adjudicatedContestsBaseline(
+      ballotAdjudicationData,
+      systemSettings,
+      writeInCandidates
+    )
+  );
+
+  if (selectedContestId && !isClaimed) {
+    return (
+      <ContestAdjudicationScreen
+        areWriteInCandidatesQualified={
+          systemSettings.areWriteInCandidatesQualified ?? false
+        }
+        cvrId={cvrId}
+        side={
+          frontContests.some((item) => item.contest.id === selectedContestId)
+            ? 'front'
+            : 'back'
+        }
+        onClose={() => setSelectedContestId(null)}
+        contestAdjudicationData={find(
+          contestAdjudicationData,
+          (c) => c.contestId === selectedContestId
+        )}
+        adjudicatedOptions={
+          adjudicatedContests.get(selectedContestId)
+            ?.adjudicatedContestOptionById
+        }
+        ballotImages={ballotImages}
+        writeInCandidates={writeInCandidates.filter(
+          (c) => c.contestId === selectedContestId
+        )}
+        onConfirmContest={(input) => {
+          const updated = new Map(adjudicatedContests).set(
+            input.contestId,
+            input
+          );
+          setAdjudicatedContests(updated);
+        }}
+      />
+    );
+  }
+
+  return (
+    <BallotView
+      adjudicatedContests={adjudicatedContests}
+      frontContests={frontContests}
+      backContests={backContests}
+      setSelectedContestId={setSelectedContestId}
+      {...props}
+    />
+  );
+}
+
+function BallotView({
+  adjudicatedContests,
+  frontContests,
+  backContests,
+  setSelectedContestId,
   cvrId,
   ballotAdjudicationData,
   ballotImages,
@@ -526,21 +661,25 @@ export function BallotAdjudicationScreen({
   onSkip,
   onBack,
   onExit,
-}: BallotAdjudicationScreenProps): JSX.Element {
+}: {
+  adjudicatedContests: Map<ContestId, AdjudicatedCvrContest>;
+  frontContests: ContestListItem[];
+  backContests: ContestListItem[];
+  setSelectedContestId: (contestId: ContestId | null) => void;
+} & BallotAdjudicationScreenProps): React.ReactNode {
   const { electionDefinition } = useContext(AppContext);
-  const election = assertDefined(electionDefinition?.election);
-
-  const contestAdjudicationData = ballotAdjudicationData.contests;
-  const { frontContests, backContests } = groupContestsBySide(
-    ballotImages,
-    contestAdjudicationData,
-    election
-  );
+  const { election } = assertDefined(electionDefinition);
   const allContests = [...frontContests, ...backContests];
+  const contestAdjudicationData = ballotAdjudicationData.contests;
 
-  function getDefaultSide(
-    adjudicatedContests: ReadonlyMap<ContestId, AdjudicatedCvrContest>
-  ): Side {
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [pendingDiscard, setPendingDiscard] = useState<{
+    action: () => void;
+  } | null>(null);
+  const [hoveredContestId, setHoveredContestId] = useState<ContestId | null>(
+    null
+  );
+  const [selectedSide, setSelectedSide] = useState<Side>(() => {
     const backIds = new Set(backContests.map((item) => item.contest.id));
     const firstPending = contestAdjudicationData
       .filter((c) => c.tag !== null)
@@ -548,80 +687,20 @@ export function BallotAdjudicationScreen({
     return firstPending && backIds.has(firstPending.contestId)
       ? 'back'
       : 'front';
-  }
-
-  const [selectedContestId, setSelectedContestId] = useState<ContestId | null>(
-    null
-  );
-  const [hoveredContestId, setHoveredContestId] = useState<ContestId | null>(
-    null
-  );
-  const [showConfirmModal, setShowConfirmModal] = useState(false);
-  const [pendingDiscard, setPendingDiscard] = useState<{
-    action: () => void;
-  } | null>(null);
-
-  // Derives the baseline adjudication state from persisted adjudications.
-  // In qualified-write-in mode, auto-resolve contests whose only adjudication
-  // reason is write-ins when the contest has no qualified candidates: every
-  // write-in must be invalid, so the user has nothing to decide.
-  function adjudicatedContestsBaseline(): Map<
-    ContestId,
-    AdjudicatedCvrContest
-  > {
-    const baseline = new Map<ContestId, AdjudicatedCvrContest>(
-      ballotAdjudicationData.adjudicatedContests.map((c) => [c.contestId, c])
-    );
-    if (
-      !systemSettings.areWriteInCandidatesQualified ||
-      ballotAdjudicationData.isResolved
-    ) {
-      return baseline;
-    }
-    const contestIdsWithQualified = new Set(
-      writeInCandidates.map((c) => c.contestId)
-    );
-
-    for (const { adjudicationData: contest } of allContests) {
-      if (baseline.has(contest.contestId)) continue;
-      const { tag } = contest;
-      if (!tag) continue;
-      const hasWriteInFlag = tag.hasWriteIn || tag.hasUnmarkedWriteIn;
-      const hasOtherFlag =
-        tag.hasOvervote || tag.hasUndervote || tag.hasMarginalMark;
-      if (!hasWriteInFlag || hasOtherFlag) continue;
-      if (contestIdsWithQualified.has(contest.contestId)) continue;
-
-      const adjudicatedContestOptionById: Record<
-        ContestOptionId,
-        AdjudicatedContestOption
-      > = {};
-      for (const option of contest.options) {
-        const isWriteIn =
-          option.definition.type === 'candidate' && option.definition.isWriteIn;
-        adjudicatedContestOptionById[option.definition.id] = isWriteIn
-          ? { type: 'write-in-option', hasVote: false }
-          : { type: 'official-option', hasVote: option.scannedVote };
-      }
-      baseline.set(contest.contestId, {
-        contestId: contest.contestId,
-        adjudicatedContestOptionById,
-      });
-    }
-    return baseline;
-  }
-
-  const [adjudicatedContests, setAdjudicatedContests] = useState<
-    Map<ContestId, AdjudicatedCvrContest>
-  >(adjudicatedContestsBaseline);
-
-  const [selectedSide, setSelectedSide] = useState<Side>(() =>
-    getDefaultSide(adjudicatedContests)
-  );
+  });
 
   function onNavigation(action: () => void): () => void {
     return () => {
-      if (!deepEqual(adjudicatedContests, adjudicatedContestsBaseline())) {
+      if (
+        !deepEqual(
+          adjudicatedContests,
+          adjudicatedContestsBaseline(
+            ballotAdjudicationData,
+            systemSettings,
+            writeInCandidates
+          )
+        )
+      ) {
         setPendingDiscard({ action });
       } else {
         action();
@@ -684,15 +763,6 @@ export function BallotAdjudicationScreen({
     }
   }
 
-  function onCloseContest(): void {
-    setSelectedContestId(null);
-    setHoveredContestId(null);
-  }
-
-  function onContestHover(contestId: ContestId | null): void {
-    setHoveredContestId(contestId);
-  }
-
   const hoveredContestBounds = (() => {
     if (hoveredContestId && visibleImage.type === 'hmpb') {
       return visibleImage.layout.contests.find(
@@ -723,43 +793,6 @@ export function BallotAdjudicationScreen({
       !ballotAdjudicationData.isResolved;
     return crossoverVoteIsPending;
   })();
-
-  if (selectedContestId && !isClaimed) {
-    return (
-      <ContestAdjudicationScreen
-        areWriteInCandidatesQualified={
-          systemSettings.areWriteInCandidatesQualified ?? false
-        }
-        cvrId={cvrId}
-        side={
-          frontContests.some((item) => item.contest.id === selectedContestId)
-            ? 'front'
-            : 'back'
-        }
-        onClose={onCloseContest}
-        contestAdjudicationData={find(
-          contestAdjudicationData,
-          (c) => c.contestId === selectedContestId
-        )}
-        adjudicatedOptions={
-          adjudicatedContests.get(selectedContestId)
-            ?.adjudicatedContestOptionById
-        }
-        ballotImages={ballotImages}
-        writeInCandidates={writeInCandidates.filter(
-          (c) => c.contestId === selectedContestId
-        )}
-        onConfirmContest={(input) => {
-          const updated = new Map(adjudicatedContests).set(
-            input.contestId,
-            input
-          );
-          setAdjudicatedContests(updated);
-          setSelectedSide(getDefaultSide(updated));
-        }}
-      />
-    );
-  }
 
   return (
     <Screen>
@@ -812,7 +845,7 @@ export function BallotAdjudicationScreen({
               election={election}
               frontContests={frontContests}
               isBallotResolved={ballotAdjudicationData.isResolved}
-              onHover={onContestHover}
+              onHover={(contestId) => setHoveredContestId(contestId)}
               onSelect={(contestId) => setSelectedContestId(contestId)}
               onSelectSide={setSelectedSide}
               selectedSide={selectedSide}

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
@@ -253,7 +253,6 @@ function renderScreen(
   {
     areWriteInCandidatesQualified = false,
     ballotImages,
-    side = 'front',
     electionDef = electionDefinition,
     onClose = vi.fn(),
     writeInCandidates = [] as WriteInCandidateRecord[],
@@ -283,7 +282,6 @@ function renderScreen(
         cvrId={cvrId}
         onClose={onClose}
         ballotImages={images}
-        side={side}
         writeInCandidates={writeInCandidates}
         onConfirmContest={onConfirmContest}
         adjudicatedOptions={adjudicatedOptions}

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
@@ -12,7 +12,6 @@ import {
   CandidateContestOption,
   getContestDistrictName,
   Id,
-  Side,
 } from '@votingworks/types';
 import { Button, Main, Screen, Icons, H2, H1, P } from '@votingworks/ui';
 import { assert, assertDefined, find } from '@votingworks/basics';
@@ -205,7 +204,6 @@ interface ContestAdjudicationScreenProps {
   cvrId: Id;
   onClose: () => void;
   onConfirmContest: (input: AdjudicatedCvrContest) => void;
-  side: Side;
   adjudicatedOptions?: AdjudicatedContestOptions;
   writeInCandidates: WriteInCandidateRecord[];
 }
@@ -217,7 +215,6 @@ export function ContestAdjudicationScreen({
   cvrId,
   onClose,
   onConfirmContest,
-  side,
   adjudicatedOptions,
   writeInCandidates,
 }: ContestAdjudicationScreenProps): JSX.Element {
@@ -340,7 +337,12 @@ export function ContestAdjudicationScreen({
 
   const isHmpb = ballotImages.front.type === 'hmpb';
   const isBmd = ballotImages.front.type === 'bmd';
-  const ballotImage = ballotImages[side];
+  const ballotImage = isBmd
+    ? ballotImages.front
+    : find(
+        [ballotImages.front, ballotImages.back as HmpbBallotPageImage],
+        ({ layout }) => layout.contests.some((c) => c.contestId === contestId)
+      );
 
   const focusedCoordinates =
     focusedOptionId && isHmpb

--- a/apps/admin/frontend/src/utils/adjudication.ts
+++ b/apps/admin/frontend/src/utils/adjudication.ts
@@ -14,9 +14,19 @@ import {
   Election,
   isOpenPrimary,
   Rect,
+  Side,
   Vote,
   VotesDict,
 } from '@votingworks/types';
+
+export type AdjudicatedContests = Map<ContestId, AdjudicatedCvrContest>;
+
+export interface ContestListItem {
+  side: Side;
+  contest: AnyContest;
+  adjudicationData: ContestAdjudicationData;
+  isResolved: boolean;
+}
 
 export function normalizeWriteInName(name: string): string {
   return name.toLowerCase().trim().replace(/\s+/, ' ');
@@ -47,14 +57,6 @@ export function isContestTagOnlyUndervote(tag: CvrContestTag): boolean {
   );
 }
 
-export function isContestResolved(
-  contest: ContestAdjudicationData,
-  adjudicatedContests: ReadonlyMap<ContestId, AdjudicatedCvrContest>
-): boolean {
-  if (!contest.tag) return true;
-  return adjudicatedContests.has(contest.contestId);
-}
-
 export function getCurrentVote(
   option: ContestOptionAdjudicationData,
   adjudicatedOption?: AdjudicatedContestOption
@@ -83,11 +85,8 @@ export function isContestCrossoverVoted(
 }
 
 export function adjudicatedVotes(
-  contests: ReadonlyArray<{
-    contest: AnyContest;
-    adjudicationData: ContestAdjudicationData;
-  }>,
-  adjudicatedContests: ReadonlyMap<ContestId, AdjudicatedCvrContest>
+  contests: ContestListItem[],
+  adjudicatedContests: AdjudicatedContests
 ): VotesDict {
   return Object.fromEntries(
     contests.map(({ contest, adjudicationData }): [string, Vote] => {

--- a/apps/admin/frontend/src/utils/adjudication.ts
+++ b/apps/admin/frontend/src/utils/adjudication.ts
@@ -20,7 +20,7 @@ import {
 } from '@votingworks/types';
 import { hasCrossoverVote } from '@votingworks/utils';
 
-export type AdjudicatedContests = ReadonlyMap<ContestId, AdjudicatedCvrContest>;
+export type AdjudicatedContests = Map<ContestId, AdjudicatedCvrContest>;
 
 export interface ContestListItem {
   side: Side;

--- a/apps/admin/frontend/src/utils/adjudication.ts
+++ b/apps/admin/frontend/src/utils/adjudication.ts
@@ -138,7 +138,7 @@ export type CrossoverVoteStatusByContest = Record<
   ContestId,
   ContestCrossoverVoteStatus
 >;
-export interface CrossoverVoteStatus {
+export interface BallotCrossoverVoteStatus {
   ballotHasScannedCrossoverVote: boolean;
   ballotHasCrossoverVoteAfterAdjudication: boolean;
   statusByContest: Record<ContestId, ContestCrossoverVoteStatus>;
@@ -151,7 +151,7 @@ export function deriveCrossoverVoteStatus(
   adjudicatedContests: AdjudicatedContests,
   ballotHasScannedCrossoverVote: boolean,
   isBallotResolved: boolean
-): CrossoverVoteStatus {
+): BallotCrossoverVoteStatus {
   const ballotHasCrossoverVoteAfterAdjudication = hasCrossoverVote(
     election,
     adjudicatedVotes(contestItems, adjudicatedContests)

--- a/apps/admin/frontend/src/utils/adjudication.ts
+++ b/apps/admin/frontend/src/utils/adjudication.ts
@@ -18,8 +18,9 @@ import {
   Vote,
   VotesDict,
 } from '@votingworks/types';
+import { hasCrossoverVote } from '@votingworks/utils';
 
-export type AdjudicatedContests = Map<ContestId, AdjudicatedCvrContest>;
+export type AdjudicatedContests = ReadonlyMap<ContestId, AdjudicatedCvrContest>;
 
 export interface ContestListItem {
   side: Side;
@@ -126,6 +127,64 @@ export function adjudicatedVotes(
       }
     })
   );
+}
+
+export interface ContestCrossoverVoteStatus {
+  hasScannedCrossoverVote: boolean;
+  hasCrossoverVoteAfterAdjudication: boolean;
+  isUnresolved: boolean;
+}
+export type CrossoverVoteStatusByContest = Record<
+  ContestId,
+  ContestCrossoverVoteStatus
+>;
+export interface CrossoverVoteStatus {
+  ballotHasScannedCrossoverVote: boolean;
+  ballotHasCrossoverVoteAfterAdjudication: boolean;
+  statusByContest: Record<ContestId, ContestCrossoverVoteStatus>;
+  isBallotResolved: boolean;
+}
+
+export function deriveCrossoverVoteStatus(
+  election: Election,
+  contestItems: ContestListItem[],
+  adjudicatedContests: AdjudicatedContests,
+  ballotHasScannedCrossoverVote: boolean,
+  isBallotResolved: boolean
+): CrossoverVoteStatus {
+  const ballotHasCrossoverVoteAfterAdjudication = hasCrossoverVote(
+    election,
+    adjudicatedVotes(contestItems, adjudicatedContests)
+  );
+  return {
+    ballotHasScannedCrossoverVote,
+    ballotHasCrossoverVoteAfterAdjudication,
+    isBallotResolved,
+    statusByContest: Object.fromEntries(
+      contestItems.map((contestItem) => {
+        const hasScannedCrossoverVote = isContestCrossoverVoted(
+          ballotHasScannedCrossoverVote,
+          contestItem
+        );
+        const hasCrossoverVoteAfterAdjudication = isContestCrossoverVoted(
+          ballotHasCrossoverVoteAfterAdjudication,
+          contestItem,
+          adjudicatedContests.get(contestItem.contest.id)
+        );
+        return [
+          contestItem.contest.id,
+          {
+            hasScannedCrossoverVote,
+            hasCrossoverVoteAfterAdjudication,
+            isUnresolved:
+              hasScannedCrossoverVote &&
+              hasCrossoverVoteAfterAdjudication &&
+              !isBallotResolved,
+          },
+        ];
+      })
+    ),
+  };
 }
 
 export function contestPartyLabel(


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->
Adding crossover voting to the adjudication flow introduced some added complexity. This PR does some refactoring to simplify the component hierarchy and data flow, encapsulating crossover voting information as much as possible. See commits for details 

## Demo Video or Screenshot
N/A
## Testing Plan
Existing automated tests
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
