### PR TITLE
[libs/ui] Vertical Election Bar: move seal above election info

### DIFF
--- a/libs/ui/src/election_info_bar.tsx
+++ b/libs/ui/src/election_info_bar.tsx
@@ -260,9 +260,8 @@ export function VerticalElectionInfoBar({
 
   return (
     <VerticalBar inverse={inverse}>
+      <Seal seal={seal} maxWidth="3rem" inverse={inverse} />
       <ElectionInfoContainer>
-        <Seal seal={seal} maxWidth="3rem" inverse={inverse} />
-
         <Caption weight="regular" align="left">
           <Font weight="bold" maxLines={4}>
             {electionStrings.electionTitle(election)}


### PR DESCRIPTION
## Overview

Bringing in a change made to the MI demo branch to stack the seal and election info vertically - initial motivation was to enable shrinking the width of the sidebar in VxAdmin and create a bit more horizontal space for the screen content (primarily the upcoming updated CVR management screen), but also thinking it just looks better overall.

## Demo Video or Screenshot
| Before | After |
| - | - |
| <img width="200" alt="v-election-bar-admin-old" src="https://github.com/user-attachments/assets/a1817fea-f92a-4648-90ca-733d89eab141" /> | <img width="200" alt="v-election-bar-admin" src="https://github.com/user-attachments/assets/79c6c23e-d607-491e-a837-2d1bc973bf82" /> |

### Samples of other usage of the shared component

<img width="200" alt="v-election-bar-centralscan" src="https://github.com/user-attachments/assets/fdfe77f9-5cf1-4292-95f8-ff973ec8405e" /> 
<img width="200" alt="v-election-bar-print" src="https://github.com/user-attachments/assets/b0abd548-801c-4d27-93c8-93b0a7a66373" />

## Testing Plan
- Visual

## Checklist

- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
