### PR TITLE
VxMark/Scan: Make contest information FocusableAudio

### DIFF
--- a/apps/mark-scan/frontend/src/lib/assistive_technology.test.tsx
+++ b/apps/mark-scan/frontend/src/lib/assistive_technology.test.tsx
@@ -12,6 +12,7 @@ import {
   contest0,
   contest0candidate0,
   contest0candidate1,
+  contest1,
   contest1candidate0,
 } from '../../test/helpers/election';
 
@@ -62,7 +63,11 @@ test('accessible controller handling works', async () => {
   // Confirm first contest only has 1 seat
   expect(contest0.seats).toEqual(1);
 
-  // Test navigation by accessible controller keyboard event interface
+  // Test navigation by accessible controller keyboard event interface. The
+  // first focusable element is the contest metadata, which voters can navigate
+  // to in order to replay the contest information audio.
+  simulateKeyPress(Keybinding.FOCUS_NEXT);
+  expect(getActiveElement()).toHaveTextContent(contest0.title);
   simulateKeyPress(Keybinding.FOCUS_NEXT);
   expect(getActiveElement()).toHaveTextContent(contest0candidate0.name);
   simulateKeyPress(Keybinding.FOCUS_NEXT);
@@ -82,14 +87,20 @@ test('accessible controller handling works', async () => {
 
   simulateKeyPress(Keybinding.PAGE_NEXT);
   await advanceTimersAndPromises();
-  // go up first without focus, then down once, should be same as down once.
+  // Go up first without focus, then down once, should be same as down once:
+  // both land on the contest metadata (the first focusable element).
   simulateKeyPress(Keybinding.FOCUS_PREVIOUS);
+  simulateKeyPress(Keybinding.FOCUS_NEXT);
+  expect(getActiveElement()).toHaveTextContent(contest1.title);
+  // Navigating down once more reaches the first contest option.
   simulateKeyPress(Keybinding.FOCUS_NEXT);
   expect(getActiveElement()).toHaveTextContent(contest1candidate0.name);
   simulateKeyPress(Keybinding.PAGE_PREVIOUS);
   await advanceTimersAndPromises();
 
-  // Get focus again
+  // Get focus again, past the contest metadata, onto the first option.
+  simulateKeyPress(Keybinding.FOCUS_NEXT);
+  expect(getActiveElement()).toHaveTextContent(contest0.title);
   simulateKeyPress(Keybinding.FOCUS_NEXT);
   expect(getActiveElement()).toHaveTextContent(contest0candidate0.name);
 
@@ -142,7 +153,10 @@ test('auto-focuses "next" button on contest screen after voting', async () => {
   // Confirm first contest only has 1 seat
   expect(contest0.seats).toEqual(1);
 
-  // Test navigation by PAT input keyboard event interface
+  // Test navigation by PAT input keyboard event interface. The first focusable
+  // element is the contest metadata, followed by the contest options.
+  simulateKeyPress(Keybinding.PAT_MOVE);
+  expect(getActiveElement()).toHaveTextContent(contest0.title);
   simulateKeyPress(Keybinding.PAT_MOVE);
   expect(getActiveElement()).toHaveTextContent(contest0candidate0.name);
   simulateKeyPress(Keybinding.PAT_MOVE);

--- a/libs/mark-flow-ui/src/components/candidate_contest.tsx
+++ b/libs/mark-flow-ui/src/components/candidate_contest.tsx
@@ -45,7 +45,7 @@ import { UpdateVoteFunction } from '../config/types';
 
 import { WRITE_IN_CANDIDATE_MAX_LENGTH } from '../config/globals';
 import { ChoicesGrid } from './contest_screen_layout';
-import { BreadcrumbMetadata, ContestHeader } from './contest_header';
+import { ContestHeader } from './contest_header';
 import { WriteInCandidateName } from './write_in_candidate_name';
 import { numVotesRemaining } from '../utils/vote';
 
@@ -55,7 +55,6 @@ export interface WriteInCharacterLimitAcrossContests {
 }
 
 interface Props {
-  breadcrumbs?: BreadcrumbMetadata;
   ballotStyleId: BallotStyleId;
   election: Election;
   contest: CandidateContestInterface;
@@ -110,7 +109,6 @@ function normalizeCandidateName(name: string) {
 }
 
 export function CandidateContest({
-  breadcrumbs,
   ballotStyleId,
   election,
   contest,
@@ -352,11 +350,7 @@ export function CandidateContest({
   return (
     <React.Fragment>
       <Main flexColumn>
-        <ContestHeader
-          breadcrumbs={breadcrumbs}
-          contest={contest}
-          district={district}
-        >
+        <ContestHeader contest={contest} district={district}>
           {contest.termDescription && (
             <Font style={{ display: 'block' }} weight="bold">
               {electionStrings.contestTerm(contest)}

--- a/libs/mark-flow-ui/src/components/contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/contest.test.tsx
@@ -156,19 +156,3 @@ test('renders ms-either-neither contests', () => {
   ]);
   // Tested further in ms_either_neither_contest.test.tsx
 });
-
-test('renders breadcrumbs', () => {
-  render(
-    <Contest
-      ballotStyleId={electionGeneral.ballotStyles[0].id}
-      breadcrumbs={{ ballotContestCount: 15, contestNumber: 3 }}
-      contest={yesnoContest}
-      election={electionGeneral}
-      updateVote={vi.fn()}
-      votes={{}}
-    />
-  );
-
-  screen.getByText(hasTextAcrossElements(/contest number: 3/i));
-  screen.getByText(hasTextAcrossElements(/total contests: 15/i));
-});

--- a/libs/mark-flow-ui/src/components/contest.tsx
+++ b/libs/mark-flow-ui/src/components/contest.tsx
@@ -11,14 +11,8 @@ import { MsEitherNeitherContest } from './ms_either_neither_contest';
 import { YesNoContest } from './yes_no_contest';
 import { ContestsWithMsEitherNeither } from '../utils/ms_either_neither_contests';
 import { UpdateVoteFunction } from '../config/types';
-import { BreadcrumbMetadata } from './contest_header';
 
 export interface ContestProps {
-  /**
-   * Optional data for displaying the contest's position on the ballot.
-   */
-  breadcrumbs?: BreadcrumbMetadata;
-
   /**
    * The ballot style for the voter.
    */
@@ -68,7 +62,6 @@ function countNumWriteInCharactersUsedAcrossContests(votes: VotesDict): number {
 }
 
 export function Contest({
-  breadcrumbs,
   ballotStyleId,
   election,
   contest,
@@ -91,7 +84,6 @@ export function Contest({
       {contest.type === 'candidate' && (
         <CandidateContest
           aria-live="assertive"
-          breadcrumbs={breadcrumbs}
           ballotStyleId={ballotStyleId}
           election={election}
           contest={contest}
@@ -111,7 +103,6 @@ export function Contest({
       )}
       {contest.type === 'yesno' && (
         <YesNoContest
-          breadcrumbs={breadcrumbs}
           election={election}
           contest={contest}
           vote={vote as OptionalYesNoVote}
@@ -121,7 +112,6 @@ export function Contest({
       )}
       {contest.type === 'ms-either-neither' && (
         <MsEitherNeitherContest
-          breadcrumbs={breadcrumbs}
           election={election}
           contest={contest}
           eitherNeitherContestVote={

--- a/libs/mark-flow-ui/src/components/contest_header.test.tsx
+++ b/libs/mark-flow-ui/src/components/contest_header.test.tsx
@@ -1,0 +1,29 @@
+import { expect, test } from 'vitest';
+import { readElectionGeneral } from '@votingworks/fixtures';
+import { getContestDistrict } from '@votingworks/types';
+import { FOCUSABLE_AUDIO_CLASS_NAME } from '@votingworks/ui';
+import { hasTextAcrossElements } from '@votingworks/test-utils';
+import { screen, render } from '../../test/react_testing_library';
+import { Breadcrumbs, ContestHeader } from './contest_header';
+
+const electionGeneral = readElectionGeneral();
+const contest = electionGeneral.contests[0];
+const district = getContestDistrict(electionGeneral, contest);
+
+test('renders contest metadata in a focusable, read-on-load block', () => {
+  render(<ContestHeader contest={contest} district={district} />);
+
+  const title = screen.getByRole('heading', { name: contest.title });
+  screen.getByText(district.name);
+
+  const focusableBlock = title.closest(`.${FOCUSABLE_AUDIO_CLASS_NAME}`);
+  expect(focusableBlock).toBeInTheDocument();
+  expect(focusableBlock).toHaveAttribute('tabindex', '0');
+});
+
+test('Breadcrumbs renders the contest position', () => {
+  render(<Breadcrumbs ballotContestCount={15} contestNumber={3} />);
+
+  screen.getByText(hasTextAcrossElements(/contest number: 3/i));
+  screen.getByText(hasTextAcrossElements(/total contests: 15/i));
+});

--- a/libs/mark-flow-ui/src/components/contest_header.tsx
+++ b/libs/mark-flow-ui/src/components/contest_header.tsx
@@ -66,7 +66,7 @@ export function ContestHeader(props: ContestHeaderProps): JSX.Element {
        * navigation order and voters can navigate back to it to replay the audio
        * without leaving and re-entering the contest.
        */}
-      <FocusableAudio readOnLoad showFocusIndicator>
+      <FocusableAudio readOnLoad replayOnClick showFocusIndicator>
         <div>
           <Caption weight="semiBold">
             {electionStrings.districtName(district)}

--- a/libs/mark-flow-ui/src/components/contest_header.tsx
+++ b/libs/mark-flow-ui/src/components/contest_header.tsx
@@ -2,11 +2,10 @@ import React from 'react';
 import styled from 'styled-components';
 
 import {
-  AudioOnly,
   Caption,
+  FocusableAudio,
   H2,
   NumberString,
-  ReadOnLoad,
   appStrings,
   electionStrings,
 } from '@votingworks/ui';
@@ -14,7 +13,6 @@ import { Contest, District } from '@votingworks/types';
 import { MsEitherNeitherContest } from '../utils/ms_either_neither_contests';
 
 export interface ContestHeaderProps {
-  breadcrumbs?: BreadcrumbMetadata;
   children?: React.ReactNode;
   contest: Contest | MsEitherNeitherContest;
   district: District;
@@ -58,21 +56,17 @@ export function Breadcrumbs(props: BreadcrumbMetadata): React.ReactNode {
 }
 
 export function ContestHeader(props: ContestHeaderProps): JSX.Element {
-  const { breadcrumbs, children, contest, district, className } = props;
+  const { children, contest, district, className } = props;
 
   return (
     <Container id="contest-header" className={className}>
-      <ReadOnLoad>
-        {/*
-         * NOTE: This is visually rendered elsewhere in the screen footer, but
-         * needs to be spoken on contest navigation for the benefit of
-         * vision-impaired voters:
-         */}
-        {breadcrumbs && (
-          <AudioOnly>
-            <Breadcrumbs {...breadcrumbs} />
-          </AudioOnly>
-        )}
+      {/*
+       * Rendered as a `FocusableAudio` block so that, in addition to being read
+       * on contest navigation, the contest metadata stays in the accessible
+       * navigation order and voters can navigate back to it to replay the audio
+       * without leaving and re-entering the contest.
+       */}
+      <FocusableAudio readOnLoad showFocusIndicator>
         <div>
           <Caption weight="semiBold">
             {electionStrings.districtName(district)}
@@ -82,7 +76,7 @@ export function ContestHeader(props: ContestHeaderProps): JSX.Element {
           <Title>{electionStrings.contestTitle(contest)}</Title>
         </div>
         {children}
-      </ReadOnLoad>
+      </FocusableAudio>
     </Container>
   );
 }

--- a/libs/mark-flow-ui/src/components/ms_either_neither_contest.tsx
+++ b/libs/mark-flow-ui/src/components/ms_either_neither_contest.tsx
@@ -4,7 +4,6 @@ import {
   ContestChoiceButton,
   Main,
   Caption,
-  WithScrollButtons,
   appStrings,
   AudioOnly,
   electionStrings,
@@ -21,7 +20,7 @@ import {
 
 import { UpdateVoteFunction } from '../config/types';
 import { MsEitherNeitherContest as MsEitherNeitherContestInterface } from '../utils/ms_either_neither_contests';
-import { BreadcrumbMetadata, ContestHeader } from './contest_header';
+import { ContestHeader } from './contest_header';
 
 const ChoicesGrid = styled.div`
   display: grid;
@@ -51,7 +50,6 @@ const Divider = styled.div`
 `;
 
 interface Props {
-  breadcrumbs?: BreadcrumbMetadata;
   election: Election;
   contest: MsEitherNeitherContestInterface;
   eitherNeitherContestVote?: YesNoVote;
@@ -87,7 +85,6 @@ function getVoteStatusText(
 }
 
 export function MsEitherNeitherContest({
-  breadcrumbs,
   election,
   contest,
   eitherNeitherContestVote,
@@ -166,16 +163,14 @@ export function MsEitherNeitherContest({
 
   return (
     <Main flexColumn>
-      <ContestHeader
-        breadcrumbs={breadcrumbs}
-        contest={contest}
-        district={district}
-      >
+      <ContestHeader contest={contest} district={district}>
         <Caption>
           {getVoteStatusText(contest, { eitherNeitherVote, pickOneVote })}
         </Caption>
+        <RichText>
+          {electionStrings.contestDescription(contest.eitherNeitherContest)}
+        </RichText>
         <AudioOnly>
-          {electionStrings.contestDescription(contest.eitherNeitherContest)}{' '}
           <AssistiveTechInstructions
             controllerString={
               isReviewMode
@@ -190,11 +185,6 @@ export function MsEitherNeitherContest({
           />
         </AudioOnly>
       </ContestHeader>
-      <WithScrollButtons>
-        <RichText>
-          {electionStrings.contestDescription(contest.eitherNeitherContest)}
-        </RichText>
-      </WithScrollButtons>
       <ChoicesGrid data-testid="contest-choices">
         <GridLabel
           style={{

--- a/libs/mark-flow-ui/src/components/voter_screen.tsx
+++ b/libs/mark-flow-ui/src/components/voter_screen.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import styled, { DefaultTheme } from 'styled-components';
 
 import {
+  FocusableAudio,
   LanguageSettingsButton,
   LanguageSettingsScreen,
   Main,
@@ -148,7 +149,9 @@ export function VoterScreen(props: VoterScreenProps): JSX.Element {
   }
 
   const optionalBreadcrumbs = breadcrumbs && (
-    <BreadcrumbsContainer>{breadcrumbs}</BreadcrumbsContainer>
+    <BreadcrumbsContainer>
+      <FocusableAudio showFocusIndicator>{breadcrumbs}</FocusableAudio>
+    </BreadcrumbsContainer>
   );
 
   const menuButtons = (

--- a/libs/mark-flow-ui/src/components/voter_screen.tsx
+++ b/libs/mark-flow-ui/src/components/voter_screen.tsx
@@ -150,7 +150,9 @@ export function VoterScreen(props: VoterScreenProps): JSX.Element {
 
   const optionalBreadcrumbs = breadcrumbs && (
     <BreadcrumbsContainer>
-      <FocusableAudio showFocusIndicator>{breadcrumbs}</FocusableAudio>
+      <FocusableAudio replayOnClick showFocusIndicator>
+        {breadcrumbs}
+      </FocusableAudio>
     </BreadcrumbsContainer>
   );
 

--- a/libs/mark-flow-ui/src/components/yes_no_contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/yes_no_contest.test.tsx
@@ -53,11 +53,13 @@ test('voting for both yes and no', () => {
 
   screen.getByRole('heading', { name: contest.title });
 
+  // The description is rendered once, inside the focusable header block; it
+  // serves as both the visual text and the audio source (no separate
+  // audio-only copy).
   const descriptions = within(
     screen.getByTestId(MOCK_WITH_SCROLL_BUTTONS_TEST_ID)
   ).getAllByText(contest.description);
-  // Expect once for AudioOnly component and once for visual component
-  expect(descriptions.length).toEqual(2);
+  expect(descriptions.length).toEqual(1);
 
   const contestChoices = screen.getByTestId('contest-choices');
   userEvent.click(within(contestChoices).getByText('YES').closest('button')!);

--- a/libs/mark-flow-ui/src/components/yes_no_contest.tsx
+++ b/libs/mark-flow-ui/src/components/yes_no_contest.tsx
@@ -12,7 +12,6 @@ import {
   Main,
   Modal,
   P,
-  Caption,
   WithScrollButtons,
   AudioOnly,
   electionStrings,
@@ -27,11 +26,10 @@ import { getSingleYesNoVote } from '@votingworks/utils';
 import { Optional } from '@votingworks/basics';
 
 import { ContestFooter, ChoicesGrid } from './contest_screen_layout';
-import { BreadcrumbMetadata, ContestHeader } from './contest_header';
+import { ContestHeader } from './contest_header';
 import { UpdateVoteFunction } from '../config/types';
 
 interface Props {
-  breadcrumbs?: BreadcrumbMetadata;
   election: Election;
   contest: YesNoContestInterface;
   vote?: YesNoVote;
@@ -40,7 +38,6 @@ interface Props {
 }
 
 export function YesNoContest({
-  breadcrumbs,
   election,
   contest,
   vote,
@@ -84,30 +81,26 @@ export function YesNoContest({
       <Main flexColumn>
         <WithScrollButtons focusable={isPatDeviceConnected}>
           <ContestHeader
-            breadcrumbs={breadcrumbs}
             contest={contest}
             district={district}
             className="no-horizontal-padding"
           >
-            <Caption>
-              <AudioOnly>
-                {electionStrings.contestDescription(contest)}
-                <AssistiveTechInstructions
-                  controllerString={
-                    isReviewMode
-                      ? appStrings.instructionsBmdContestNavigationReviewMode()
-                      : appStrings.instructionsBmdContestNavigation()
-                  }
-                  patDeviceString={
-                    isReviewMode
-                      ? appStrings.instructionsBmdContestNavigationReviewModePatDevice()
-                      : appStrings.instructionsBmdContestNavigationPatDevice()
-                  }
-                />
-              </AudioOnly>
-            </Caption>
+            <RichText>{electionStrings.contestDescription(contest)}</RichText>
+            <AudioOnly>
+              <AssistiveTechInstructions
+                controllerString={
+                  isReviewMode
+                    ? appStrings.instructionsBmdContestNavigationReviewMode()
+                    : appStrings.instructionsBmdContestNavigation()
+                }
+                patDeviceString={
+                  isReviewMode
+                    ? appStrings.instructionsBmdContestNavigationReviewModePatDevice()
+                    : appStrings.instructionsBmdContestNavigationPatDevice()
+                }
+              />
+            </AudioOnly>
           </ContestHeader>
-          <RichText>{electionStrings.contestDescription(contest)}</RichText>
         </WithScrollButtons>
         <ContestFooter>
           <ChoicesGrid data-testid="contest-choices">

--- a/libs/mark-flow-ui/src/pages/contest_page.tsx
+++ b/libs/mark-flow-ui/src/pages/contest_page.tsx
@@ -211,7 +211,6 @@ export function ContestPage(props: ContestPageProps): JSX.Element {
         key={contest.id} // Force a re-mount for every contest to reset scroll state.
         ballotStyleId={ballotStyleId}
         election={electionDefinition.election}
-        breadcrumbs={breadcrumbsMetadata}
         contest={contest}
         votes={votes}
         updateVote={handleUpdateVote}

--- a/libs/mark-flow-ui/src/pages/review_page.tsx
+++ b/libs/mark-flow-ui/src/pages/review_page.tsx
@@ -127,7 +127,7 @@ export function ReviewPage(props: ReviewPageProps): JSX.Element {
       }
       VoterHelpScreen={VoterHelpScreen}
     >
-      <ContentHeader readOnLoad showFocusIndicator>
+      <ContentHeader readOnLoad replayOnClick showFocusIndicator>
         <H1>{appStrings.titleBmdReviewScreen()}</H1>
         <AudioOnly>
           <AssistiveTechInstructions

--- a/libs/mark-flow-ui/src/pages/review_page.tsx
+++ b/libs/mark-flow-ui/src/pages/review_page.tsx
@@ -10,7 +10,7 @@ import {
   WithScrollButtons,
   appStrings,
   AudioOnly,
-  ReadOnLoad,
+  FocusableAudio,
   PageNavigationButtonId,
   AssistiveTechInstructions,
   WithAltAudio,
@@ -30,7 +30,7 @@ import { Review, ReviewProps } from '../components/review';
 import { ContestsWithMsEitherNeither } from '../utils/ms_either_neither_contests';
 import { VoterHelpScreenType, VoterScreen } from '../components/voter_screen';
 
-const ContentHeader = styled(ReadOnLoad)`
+const ContentHeader = styled(FocusableAudio)`
   padding: 0.5rem 0.75rem 0;
 `;
 
@@ -127,7 +127,7 @@ export function ReviewPage(props: ReviewPageProps): JSX.Element {
       }
       VoterHelpScreen={VoterHelpScreen}
     >
-      <ContentHeader>
+      <ContentHeader readOnLoad showFocusIndicator>
         <H1>{appStrings.titleBmdReviewScreen()}</H1>
         <AudioOnly>
           <AssistiveTechInstructions

--- a/libs/ui/src/focusable_audio.test.tsx
+++ b/libs/ui/src/focusable_audio.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import { render, screen } from '../test/react_testing_library.js';
+import { fireEvent, render, screen } from '../test/react_testing_library.js';
 import { FocusableAudio } from './focusable_audio';
 import { ReadOnLoad, ReadOnLoadProps } from './ui_strings/read_on_load';
 
@@ -34,4 +34,43 @@ test('renders without <ReadOnLoad> when `readOnLoad === false`', () => {
 
   const readOnLoadContainer = screen.queryByTestId(MOCK_READ_ON_LOAD_TEST_ID);
   expect(readOnLoadContainer).not.toBeInTheDocument();
+});
+
+test('suppresses the focus outline by default', () => {
+  render(<FocusableAudio>some audio content</FocusableAudio>);
+
+  expect(screen.getByText('some audio content')).toHaveStyle({
+    outline: 'none',
+  });
+});
+
+test('shows the focus outline when `showFocusIndicator` is set', () => {
+  render(
+    <FocusableAudio showFocusIndicator style={{ color: 'red' }}>
+      some audio content
+    </FocusableAudio>
+  );
+
+  const container = screen.getByText('some audio content');
+  expect(container).not.toHaveStyle({ outline: 'none' });
+  // Caller-provided styles are preserved.
+  expect(container).toHaveStyle({ color: 'red' });
+});
+
+test('suppresses the outline during the read-on-load focus, then enables it', () => {
+  render(
+    <FocusableAudio readOnLoad showFocusIndicator>
+      some audio content
+    </FocusableAudio>
+  );
+
+  // The block grabs focus on mount to read its audio; the outline is suppressed
+  // for that initial focus so it doesn't flash on page load.
+  const container = screen.getByTestId(MOCK_READ_ON_LOAD_TEST_ID);
+  expect(container).toHaveStyle({ outline: 'none' });
+
+  // Once focus leaves the block, subsequent (user-driven) focus shows the
+  // indicator.
+  fireEvent.blur(container);
+  expect(container).not.toHaveStyle({ outline: 'none' });
 });

--- a/libs/ui/src/focusable_audio.test.tsx
+++ b/libs/ui/src/focusable_audio.test.tsx
@@ -1,7 +1,8 @@
 import { beforeEach, expect, test, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
 
 import { fireEvent, render, screen } from '../test/react_testing_library.js';
-import { FocusableAudio } from './focusable_audio';
+import { FocusableAudio, FOCUSABLE_AUDIO_CLASS_NAME } from './focusable_audio';
 import { ReadOnLoad, ReadOnLoadProps } from './ui_strings/read_on_load';
 
 vi.mock(import('./ui_strings/read_on_load.js'), async (importActual) => ({
@@ -57,6 +58,20 @@ test('shows the focus outline when `showFocusIndicator` is set', () => {
   expect(container).toHaveStyle({ color: 'red' });
 });
 
+function trackBlockFocusTargets(block: Element): EventTarget[] {
+  const focusTargets: EventTarget[] = [];
+  block.addEventListener(
+    'focus',
+    (event) => {
+      if (event.target) {
+        focusTargets.push(event.target);
+      }
+    },
+    { capture: true }
+  );
+  return focusTargets;
+}
+
 test('suppresses the outline during the read-on-load focus, then enables it', () => {
   render(
     <FocusableAudio readOnLoad showFocusIndicator>
@@ -73,4 +88,34 @@ test('suppresses the outline during the read-on-load focus, then enables it', ()
   // indicator.
   fireEvent.blur(container);
   expect(container).not.toHaveStyle({ outline: 'none' });
+});
+
+test('replays the whole block on click when `replayOnClick` is set', () => {
+  render(
+    <FocusableAudio replayOnClick>
+      <button type="button">child</button>
+    </FocusableAudio>
+  );
+
+  const block = document.querySelector(`.${FOCUSABLE_AUDIO_CLASS_NAME}`)!;
+  const focusTargets = trackBlockFocusTargets(block);
+
+  // Clicking a descendant re-targets a focus event at the block itself, so the
+  // screen reader reads the whole block rather than just the clicked element.
+  userEvent.click(screen.getButton('child'));
+  expect(focusTargets).toContain(block);
+});
+
+test('does not re-target focus on click without `replayOnClick`', () => {
+  render(
+    <FocusableAudio>
+      <button type="button">child</button>
+    </FocusableAudio>
+  );
+
+  const block = document.querySelector(`.${FOCUSABLE_AUDIO_CLASS_NAME}`)!;
+  const focusTargets = trackBlockFocusTargets(block);
+
+  userEvent.click(screen.getButton('child'));
+  expect(focusTargets).not.toContain(block);
 });

--- a/libs/ui/src/focusable_audio.tsx
+++ b/libs/ui/src/focusable_audio.tsx
@@ -4,6 +4,7 @@ import {
   ComponentPropsWithoutRef,
   CSSProperties,
   ElementType,
+  MouseEvent,
   useState,
 } from 'react';
 import { ReadOnLoad } from './ui_strings/read_on_load';
@@ -22,6 +23,12 @@ export type FocusableAudioProps<T extends ElementType> = Omit<
    * focused. Defaults to `false`, which suppresses the outline.
    */
   showFocusIndicator?: boolean;
+
+  /**
+   * When `true`, clicking or tapping anywhere within the block replays the
+   * entire block's audio, matching the readout triggered when the block
+   * receives focus. */
+  replayOnClick?: boolean;
 };
 
 const DefaultContainer = styled.div`
@@ -47,6 +54,7 @@ export function FocusableAudio<T extends ElementType = 'div'>(
     children,
     className,
     readOnLoad,
+    replayOnClick,
     showFocusIndicator,
     style,
     ...rest
@@ -62,6 +70,17 @@ export function FocusableAudio<T extends ElementType = 'div'>(
 
   const Container = readOnLoad ? ReadOnLoad : DefaultContainer;
 
+  function handleClick(event: MouseEvent<HTMLElement>) {
+    if (!replayOnClick) {
+      return;
+    }
+
+    // Re-target the screen reader at the whole block, so clicking any
+    // descendant replays the entire block's audio rather than just the clicked
+    // element.
+    event.currentTarget.dispatchEvent(new Event('focus', { bubbles: true }));
+  }
+
   function handleBlur() {
     setOutlineEnabled(true);
   }
@@ -72,6 +91,7 @@ export function FocusableAudio<T extends ElementType = 'div'>(
       as={as}
       className={`${className || ''} ${FOCUSABLE_AUDIO_CLASS_NAME}`}
       onBlur={handleBlur}
+      onClick={handleClick}
       // Suppress the focus outline unless explicitly enabled.
       style={showOutline ? baseStyle : { ...baseStyle, outline: 'none' }}
       tabIndex={0}

--- a/libs/ui/src/focusable_audio.tsx
+++ b/libs/ui/src/focusable_audio.tsx
@@ -1,6 +1,11 @@
 import styled from 'styled-components';
 
-import { ComponentPropsWithoutRef, ElementType } from 'react';
+import {
+  ComponentPropsWithoutRef,
+  CSSProperties,
+  ElementType,
+  useState,
+} from 'react';
 import { ReadOnLoad } from './ui_strings/read_on_load';
 
 export const FOCUSABLE_AUDIO_CLASS_NAME = 'FocusableAudio';
@@ -11,6 +16,12 @@ export type FocusableAudioProps<T extends ElementType> = Omit<
 > & {
   as?: T;
   readOnLoad?: boolean;
+
+  /**
+   * When `true`, displays the standard focus outline while the block is
+   * focused. Defaults to `false`, which suppresses the outline.
+   */
+  showFocusIndicator?: boolean;
 };
 
 const DefaultContainer = styled.div`
@@ -27,27 +38,42 @@ const DefaultContainer = styled.div`
  * the {@link ReadOnLoad} component, in that it automatically takes focus when
  * it's first mounted, triggering a screen reader readout of its contents.
  *
- * NOTE: This is not yet fully ready for use with audio-only blocks, since they
- * are rendered off-screen and won't have a visible focus indicator. We need to
- * think through how to indicate to controller-and-video voters that the focus
- * is currently on an audio-only element.
  */
 export function FocusableAudio<T extends ElementType = 'div'>(
   props: FocusableAudioProps<T>
 ): JSX.Element {
-  const { as = 'div', children, className, readOnLoad, ...rest } = props;
+  const {
+    as = 'div',
+    children,
+    className,
+    readOnLoad,
+    showFocusIndicator,
+    style,
+    ...rest
+  } = props;
+
+  // `readOnLoad` blocks grab focus automatically on mount to trigger their
+  // audio readout. Suppress the focus outline for that initial programmatic
+  // focus, and only enable it once focus has left the block then returned
+  const [outlineEnabled, setOutlineEnabled] = useState(!readOnLoad);
+
+  const baseStyle: CSSProperties = style ?? {};
+  const showOutline = showFocusIndicator && outlineEnabled;
 
   const Container = readOnLoad ? ReadOnLoad : DefaultContainer;
+
+  function handleBlur() {
+    setOutlineEnabled(true);
+  }
 
   return (
     <Container
       {...rest}
       as={as}
       className={`${className || ''} ${FOCUSABLE_AUDIO_CLASS_NAME}`}
-      // [TODO] Make this configurable, if/when this component is extended for
-      // use in VxMark. As noted above, we'll need to come up with a focus
-      // indicator that works for both on and off-screen elements.
-      style={{ outline: 'none' }}
+      onBlur={handleBlur}
+      // Suppress the focus outline unless explicitly enabled.
+      style={showOutline ? baseStyle : { ...baseStyle, outline: 'none' }}
       tabIndex={0}
     >
       {children}


### PR DESCRIPTION
## Overview
Closes #8402 
Updates VxMark/VxMarkScan in the following ways 
- Removes the "contest number: n contests: k" audio only reading from the read on load handler on contest pages 
- Makes both the readOnLoad contest information and the contest number metadata above FocusableAudio elements that re-read the text when re-focused
- Moves the yes/no and either/neither contest description text into the same FocusableAudio element as the contest title. 
- Adds a showFocusIndicator option to FocusableAudio that is used in VxMark cases 
- Adds a replayOnClick option to FocusableAudio that is used in VxMark cases (should this not be an option and just used everywhere?) , this replays the entier FocusableAudio text if any sub-element inside of the FocusableAudio element is clicked (previously just the sub element would be reread) 

## Demo Video or Screenshot
Primary Flows

https://github.com/user-attachments/assets/a49f67e7-7b51-4bb4-a376-56b3c64deae6


Yes/No with scroll buttons
<img width="1335" height="1081" alt="Screenshot 2026-06-08 at 1 17 22 PM" src="https://github.com/user-attachments/assets/8f267357-2545-473d-81cc-3e0c72055093" />

## Testing Plan
See above, ran through manual testing with audio using keyboard as ATI interface. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
