### PR TITLE
Screenshots, VxMarkScan - Reorganize screenshot tests to parallel VxMark

### DIFF
--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -52,6 +52,7 @@ import {
   getPrecinctSelectionIds,
   isCardlessVoterAuth,
   isFeatureFlagEnabled,
+  isIntegrationTest,
   isPollWorkerAuth,
   isSystemAdministratorAuth,
 } from '@votingworks/utils';
@@ -299,7 +300,7 @@ export interface Delays {
   DELAY_NOTIFICATION_DURATION_MS: number;
 }
 
-export const delays = {
+const PRODUCTION_DELAYS = {
   DELAY_PAPER_HANDLER_STATUS_POLLING_INTERVAL_MS: 200,
   DELAY_PAT_CONNECTION_STATUS_POLLING_INTERVAL_MS: 500,
   DELAY_AUTH_STATUS_POLLING_INTERVAL_MS: 200,
@@ -308,6 +309,20 @@ export const delays = {
   DELAY_BEFORE_DECLARING_REAR_JAM_MS: 7_000,
   DELAY_NOTIFICATION_DURATION_MS: 5_000,
 } satisfies Delays;
+
+// Integration tests step through every notification screen, so the production
+// notification dwell would dominate the suite runtime. Shorten just that delay
+// (kept long enough to reliably screenshot each notification state); all other
+// delays match production.
+const INTEGRATION_TEST_DELAYS = {
+  ...PRODUCTION_DELAYS,
+  DELAY_NOTIFICATION_DURATION_MS: 1_000,
+} satisfies Delays;
+
+/* istanbul ignore next - integration-test delays are covered by integration testing */
+export const delays = isIntegrationTest()
+  ? INTEGRATION_TEST_DELAYS
+  : PRODUCTION_DELAYS;
 
 function createPollingChildMachine(
   id: string,

--- a/apps/mark-scan/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/mark-scan/integration-testing/e2e/screenshots.spec.ts
@@ -6,6 +6,7 @@ import {
   setupTemporaryRootDir,
 } from '@votingworks/fixtures';
 import {
+  MULTI_LANGUAGE_UI_STRINGS,
   buildIntegrationTestHelper,
   createScreenshotCounter,
 } from '@votingworks/integration-test-utils';
@@ -21,10 +22,7 @@ import {
   logInAsPollWorker,
   logInAsSystemAdministrator,
 } from './support/auth';
-import {
-  getFamousNamesElectionDefinition,
-  MULTI_LANGUAGE_UI_STRINGS,
-} from './support/election';
+import { getFamousNamesElectionDefinition } from './support/election';
 import {
   configureMachine,
   insertBlankBallotSheet,

--- a/apps/mark-scan/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/mark-scan/integration-testing/e2e/screenshots.spec.ts
@@ -22,7 +22,7 @@ import {
   logInAsSystemAdministrator,
 } from './support/auth';
 import {
-  getMultiLanguageFamousNamesElectionDefinition,
+  getFamousNamesElectionDefinition,
   MULTI_LANGUAGE_UI_STRINGS,
 } from './support/election';
 import {
@@ -59,8 +59,8 @@ async function buildElectionPackage(electionDefinition: ElectionDefinition) {
       // Hide the voter help button to keep voter screens uncluttered.
       disableVoterHelpButtons: true,
     },
-    // Registers the language codes; the display names come from the election's
-    // ballotStrings (see getMultiLanguageFamousNamesElectionDefinition).
+    // Registers the supported languages and their native display names so the
+    // voter language selector renders (see MULTI_LANGUAGE_UI_STRINGS).
     uiStrings: MULTI_LANGUAGE_UI_STRINGS,
   });
 }
@@ -142,7 +142,7 @@ async function voteAndCaptureContests(
 }
 
 test('basic election flow', async ({ page }) => {
-  const electionDefinition = getMultiLanguageFamousNamesElectionDefinition();
+  const electionDefinition = getFamousNamesElectionDefinition();
   const { election } = electionDefinition;
   const usbHandler = getMockFileUsbDriveHandler();
   const helper = buildIntegrationTestHelper(page, screenshotCounter);
@@ -310,7 +310,7 @@ test('basic election flow', async ({ page }) => {
 });
 
 test('additional options', async ({ page }) => {
-  const electionDefinition = getMultiLanguageFamousNamesElectionDefinition();
+  const electionDefinition = getFamousNamesElectionDefinition();
   const { election } = electionDefinition;
   const helper = buildIntegrationTestHelper(page, screenshotCounter);
   const {
@@ -438,11 +438,11 @@ test('additional options', async ({ page }) => {
 });
 
 test('voter settings', async ({ page }) => {
-  // Use the same single-precinct famous-names election as the basic flow (its
-  // injected multi-language ballot strings still drive the language selector).
-  // We don't capture a printed multi-language ballot here, so the heavier
-  // electionGeneral isn't needed.
-  const electionDefinition = getMultiLanguageFamousNamesElectionDefinition();
+  // Use the same single-precinct famous-names election as the basic flow (the
+  // registered uiStrings drive the language selector). We don't capture a
+  // printed multi-language ballot here, so the heavier electionGeneral isn't
+  // needed.
+  const electionDefinition = getFamousNamesElectionDefinition();
   const { election } = electionDefinition;
   const helper = buildIntegrationTestHelper(page, screenshotCounter);
   const { screenshot, screenshotWithLocatorHighlight } = helper;

--- a/apps/mark-scan/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/mark-scan/integration-testing/e2e/screenshots.spec.ts
@@ -1,27 +1,39 @@
-import { test } from '@playwright/test';
+import { Page, test } from '@playwright/test';
+import { mockCardRemoval } from '@votingworks/auth';
+import { mockElectionPackageFileTree } from '@votingworks/backend';
 import {
   clearTemporaryRootDir,
-  electionFamousNames2021Fixtures,
-  electionPrimaryPrecinctSplitsFixtures,
   setupTemporaryRootDir,
 } from '@votingworks/fixtures';
-import { getMockFileUsbDriveHandler } from '@votingworks/usb-drive';
-import {
-  mockCardRemoval,
-  mockPollWorkerCardInsertion,
-} from '@votingworks/auth';
-import { mockElectionPackageFileTree } from '@votingworks/backend';
 import {
   buildIntegrationTestHelper,
   createScreenshotCounter,
 } from '@votingworks/integration-test-utils';
-import { DEFAULT_SYSTEM_SETTINGS, safeParseInt } from '@votingworks/types';
-import { assert } from '@votingworks/basics';
+import {
+  DEFAULT_SYSTEM_SETTINGS,
+  Election,
+  ElectionDefinition,
+} from '@votingworks/types';
+import { getMockFileUsbDriveHandler } from '@votingworks/usb-drive';
 import {
   forceLogOutAndResetElectionDefinition,
   logInAsElectionManager,
+  logInAsPollWorker,
   logInAsSystemAdministrator,
-} from '../support/auth';
+} from './support/auth';
+import {
+  getMultiLanguageFamousNamesElectionDefinition,
+  MULTI_LANGUAGE_UI_STRINGS,
+} from './support/election';
+import {
+  configureMachine,
+  insertBlankBallotSheet,
+  openPolls,
+  startVotingSession,
+} from './support/flows';
+import { captureReadinessReport } from './support/reports';
+
+const POLLING_PLACE_NAME = 'North Lincoln';
 
 const screenshotCounter = createScreenshotCounter();
 
@@ -30,460 +42,484 @@ test.afterAll(clearTemporaryRootDir);
 
 test.beforeEach(async ({ page }) => {
   getMockFileUsbDriveHandler().cleanup();
-  await page.clock.install();
   await forceLogOutAndResetElectionDefinition(page);
 });
 
-test('everything but voting', async ({ page }) => {
-  const usbHandler = getMockFileUsbDriveHandler();
-  const fixtureSet = electionFamousNames2021Fixtures;
-  const electionDefinition = fixtureSet.readElectionDefinition();
-  const { election } = electionDefinition;
-
-  const {
-    screenshot,
-    screenshotWithButtonHighlight,
-    withContainerVerticallyExpanded,
-    clickModalButton,
-  } = buildIntegrationTestHelper(page, screenshotCounter);
-
-  usbHandler.insert();
-
-  await page.goto('/');
-  await page
-    .getByText('Insert an election manager card to configure VxMarkScan')
-    .waitFor();
-
-  await logInAsSystemAdministrator(page);
-  await screenshot('sa-menu');
-  await screenshotWithButtonHighlight(
-    'Diagnostics',
-    'sa-menu-diagnostics-button'
-  );
-  await screenshotWithButtonHighlight('Save Logs', 'sa-menu-save-logs-button');
-
-  await page.getByText('Diagnostics').click();
-
-  // Screenshot the full scrollable main element
-  await page.locator('main').waitFor();
-  await withContainerVerticallyExpanded('main', async () => {
-    await screenshot('diagnostics-menu-full');
-  });
-
-  await page.getByText('Test Accessible Controller').click();
-  await page.getByText('Accessible Controller Test').waitFor();
-  await screenshot('accessible-controller-test');
-
-  await page.getByText('Cancel Test').click();
-  await page.getByText('Test Printer-Scanner').click();
-  await page.getByRole('heading', { name: 'Printer-Scanner Test' }).waitFor();
-  await screenshot('printer-scanner-test');
-
-  await page.getByText('Cancel Test').click();
-  await page.getByText('Test PAT Input').click();
-  await page.getByText('Connect PAT Device').waitFor();
-  await screenshot('pat-test');
-
-  await page.getByText('Cancel Test').click();
-  await page.getByText('Test Front Headphone Input').click();
-  await page.getByText('Front Headphone Input Test').waitFor();
-  await screenshot('front-headphone-test');
-
-  await page.getByText('Sound is Audible').click();
-  await page.getByText('Test Uninterruptible Power Supply').click();
-  await page.getByText('Uninterruptible Power Supply Test').waitFor();
-  await screenshot('ups-test');
-
-  await page.getByText('UPS Is Fully Charged').click();
-  await page.getByText('Save Readiness Report').click();
-  await screenshot('save-readiness-report-prompt');
-  await page.getByText('Save', { exact: true }).click();
-  await page.getByText('Readiness Report Saved').waitFor();
-  await screenshot('save-readiness-report-done');
-  await page.getByText('Close').click();
-  usbHandler.remove();
-
-  await page.getByText('Back').click();
-  mockCardRemoval();
-  await page.getByText(/election manager card/).waitFor();
-  await screenshot('em-insert-card');
-
-  await logInAsElectionManager(page, election);
-  await page.getByText(/a USB drive/).waitFor();
-  await screenshot('em-insert-usb');
-
-  usbHandler.insert(
-    await mockElectionPackageFileTree(
-      fixtureSet.toElectionPackage({
-        ...DEFAULT_SYSTEM_SETTINGS,
-        disableVoterHelpButtons: true,
-      })
-    )
-  );
-  await page.getByText('Election Manager Menu').waitFor();
-  await screenshot('em-menu');
-  await screenshotWithButtonHighlight(
-    'Diagnostics',
-    'em-menu-diagnostics-button'
-  );
-  await screenshotWithButtonHighlight('Save Logs', 'em-menu-save-logs-button');
-  await screenshotWithButtonHighlight(
-    'Unconfigure Machine',
-    'em-menu-unconfigure-machine-button'
-  );
-  await screenshotWithButtonHighlight(
-    'Official Ballot Mode',
-    'em-menu-official-ballot-mode-button'
-  );
-
-  // Select precinct and capture screenshot in test mode
-  await page.getByText(/select a polling place/i).click({ force: true });
-  await page.getByText('North Lincoln', { exact: true }).click();
-  mockCardRemoval();
-  await page.getByText(/poll worker card/).waitFor();
-  await screenshot('pw-insert-card-test-mode');
-
-  // Re-login as EM and toggle to official mode
-  await logInAsElectionManager(page, election);
-  await page.getByText('Election Manager Menu').waitFor();
-  await page.getByText('Official Ballot Mode').click();
-  await screenshotWithButtonHighlight(
-    'Test Ballot Mode',
-    'em-menu-test-ballot-mode-button'
-  );
-
-  mockCardRemoval();
-  await page.getByText(/poll worker card/).waitFor();
-  await screenshot('pw-insert-card-closed-initial');
-
-  // opening, pausing, and resuming
-  mockPollWorkerCardInsertion({ election });
-  await page.getByText('Poll Worker Menu').waitFor();
-  await screenshot('pw-menu-closed-initial');
-
-  await screenshotWithButtonHighlight(
-    'Open Polls',
-    'pw-menu-open-polls-button'
-  );
-
-  await page.getByText('Open Polls').click();
-  await screenshotWithButtonHighlight(
-    'Open Polls',
-    'pw-menu-open-polls-confirm-button'
-  );
-
-  await clickModalButton('Open Polls');
-  await page.getByText('Close Polls').waitFor();
-  await screenshot('pw-menu-opened-polls');
-  await screenshotWithButtonHighlight(
-    'Pause Voting',
-    'pw-menu-pause-voting-button'
-  );
-
-  await page.getByText('Pause Voting').click();
-  await screenshotWithButtonHighlight(
-    'Pause Voting',
-    'pw-menu-pause-voting-confirm-button'
-  );
-
-  await clickModalButton('Pause Voting');
-  await page.getByText('Resume Voting').waitFor();
-  await screenshot('pw-menu-paused-voting');
-  await screenshotWithButtonHighlight(
-    'Resume Voting',
-    'pw-menu-resume-voting-button'
-  );
-
-  await page.getByText('Resume Voting').click();
-  await screenshotWithButtonHighlight(
-    'Resume Voting',
-    'pw-menu-resume-voting-confirm-button'
-  );
-  await clickModalButton('Resume Voting');
-
-  // poll worker starts voting session
-  await screenshotWithButtonHighlight(
-    /Start Voting Session/,
-    'pw-ballot-style-selection'
-  );
-  await page.getByText(/Start Voting Session/).click();
-  await page.getByText('Load Ballot Sheet').waitFor();
-  await screenshot('pw-load-ballot-sheet');
-  await page.getByText('Loading Sheet').waitFor();
-  await screenshot('pw-loading-sheet');
-  await page.getByText(/Remove Card/).waitFor();
-  await screenshot('pw-remove-card-to-vote');
-  mockCardRemoval();
-
-  // voting session screenshots handled in separate test
-  await page.getByRole('button', { name: 'Start Voting' }).waitFor();
-  await screenshot('voting-start-screen');
-  mockPollWorkerCardInsertion({ election });
-  await page.getByText('Cancel Voting Session').click();
-
-  // closing
-  await page.getByText('Close Polls').waitFor();
-  await screenshotWithButtonHighlight(
-    'Close Polls',
-    'pw-menu-close-polls-button'
-  );
-
-  await page.getByText('Close Polls').click();
-  await screenshotWithButtonHighlight(
-    'Close Polls',
-    'pw-menu-close-polls-confirm-button'
-  );
-
-  await clickModalButton('Close Polls');
-  await page.getByText('Polls: Closed').waitFor();
-  mockCardRemoval();
+// Leave the machine unconfigured and logged out so the next test file inherits
+// a clean backend (these tests can end mid-voting-session with polls open).
+test.afterEach(async ({ page }) => {
+  await forceLogOutAndResetElectionDefinition(page);
 });
 
-test('voting session', async ({ page }) => {
-  const usbHandler = getMockFileUsbDriveHandler();
-  const fixtureSet = electionPrimaryPrecinctSplitsFixtures;
-  const electionDefinition = fixtureSet.readElectionDefinition();
-  const { election } = electionDefinition;
+async function buildElectionPackage(electionDefinition: ElectionDefinition) {
+  return mockElectionPackageFileTree({
+    electionDefinition,
+    systemSettings: {
+      ...DEFAULT_SYSTEM_SETTINGS,
+      // Hide the voter help button to keep voter screens uncluttered.
+      disableVoterHelpButtons: true,
+    },
+    // Registers the language codes; the display names come from the election's
+    // ballotStrings (see getMultiLanguageFamousNamesElectionDefinition).
+    uiStrings: MULTI_LANGUAGE_UI_STRINGS,
+  });
+}
 
-  const { screenshot, screenshotWithButtonHighlight, clickModalButton } =
-    buildIntegrationTestHelper(page, screenshotCounter);
-
-  // Helper: Get contest metadata from UI
-  async function getContestInfo(): Promise<{ current: number; total: number }> {
-    const contestText = await page
-      .getByText(/Contest number: \d+ \| Total contests: \d+/)
-      .first()
-      .textContent();
-
-    // Extract "Contest number: X | Total contests: Y" format
-    const match = contestText?.match(
-      /Contest number: (\d+) \| Total contests: (\d+)/
-    );
-    const current = safeParseInt(match?.[1] ?? '0').unsafeUnwrap();
-    const total = safeParseInt(match?.[2] ?? '0').unsafeUnwrap();
-
-    return { current, total };
-  }
-
-  await page.goto('/');
-  await page
-    .getByText('Insert an election manager card to configure VxMarkScan')
-    .waitFor();
-
-  // Configure machine as Election Manager
-  await logInAsElectionManager(page, election);
-  await page.getByText(/a USB drive/).waitFor();
-
-  usbHandler.insert(
-    await mockElectionPackageFileTree(
-      fixtureSet.toElectionPackage({
-        ...DEFAULT_SYSTEM_SETTINGS,
-        disableVoterHelpButtons: true,
-      })
-    )
-  );
-  await page.getByText('Election Manager Menu').waitFor();
-
-  await page.getByText('Official Ballot Mode').click();
-  await page.getByText(/select a polling place/i).click({ force: true });
-  await page.getByText('Precinct 1', { exact: true }).click();
-
-  // Open polls as Poll Worker
-  mockCardRemoval();
-  await page.getByText(/poll worker card/).waitFor();
-
-  mockPollWorkerCardInsertion({ election });
-  await page.getByText('Poll Worker Menu').waitFor();
-
-  await page.getByText('Open Polls').click();
-  await clickModalButton('Open Polls');
-  await page.getByText('Close Polls').waitFor();
-
-  // Start voting session - select Fish party
-  await page.getByText('Fish').click();
-  await page.getByText(/Remove Card/).waitFor();
-  mockCardRemoval();
-
-  /**
-   * Initiate Voting Session
-   */
-  await page.getByRole('button', { name: 'Start Voting' }).waitFor();
-  await screenshot('voting-start-screen');
+/**
+ * Casts a full ballot via the voter flow, capturing the contest, write-in, and
+ * review screenshots. Selections are derived from the election definition
+ * rather than hardcoded candidate names. Assumes the voter is on the "Start
+ * Voting" screen.
+ */
+async function voteAndCaptureContests(
+  page: Page,
+  election: Election,
+  helper: ReturnType<typeof buildIntegrationTestHelper>
+): Promise<void> {
+  const { screenshot, screenshotWithButtonHighlight } = helper;
+  const { contests } = election;
 
   await page.getByRole('button', { name: 'Start Voting' }).click();
 
-  // Wait for contest metadata to appear
-  await page
-    .getByText(/Contest number: \d+ \| Total contests: \d+/)
-    .first()
-    .waitFor();
-
-  // Get total number of contests
-  const { total: totalContests } = await getContestInfo();
-
-  /**
-   * Language Selection
-   */
-  await screenshotWithButtonHighlight(/English/, 'voting-language-button');
-  await page.getByRole('button', { name: /English/ }).click();
-  await screenshot('voting-languages');
-
-  const spanishOption = page.getByText(/Español/i);
-  assert((await spanishOption.count()) > 0);
-  await screenshotWithButtonHighlight(
-    /Español/i,
-    'voting-language-spanish-option'
-  );
-  await spanishOption.click();
-  await page.getByText('Done', { exact: true }).click();
-  await screenshot('voting-in-spanish');
-
-  // Revert to English
-  await page.getByRole('button', { name: /Español/i }).click();
-  await page.getByText(/English/i).click();
-  await page.getByText('Done', { exact: true }).click();
-
-  // Wait for contest to be back in English
-  await page
-    .getByText(/Contest number: \d+ \| Total contests: \d+/)
-    .first()
-    .waitFor();
-
-  /**
-   * Accessibility Settings
-   */
-  await page.getByRole('button', { name: /Settings/i }).waitFor();
-  await screenshotWithButtonHighlight(/Settings/i, 'voting-settings-button');
-  await page.getByRole('button', { name: /Settings/i }).click();
-  await screenshot('voting-settings-color');
-
-  // Capture all color theme options
-  const colorThemeOptions = page.getByRole('button').getByText(/background/);
-  const colorThemeCount = await colorThemeOptions.count();
-
-  for (let i = 0; i < colorThemeCount; i += 1) {
-    await colorThemeOptions.nth(i).click();
-    await screenshot(`voting-settings-color-theme-${i + 1}`);
-  }
-
-  // Reset to defaults
-  await page.getByText('Reset', { exact: true }).click();
-
-  // Test text size
-  await page.getByText('Text Size', { exact: true }).click();
-  await screenshot('voting-settings-text-size');
-
-  // Capture all text size options
-  const textSizeOptions = page.getByText(/Aa/);
-  const textSizeCount = await textSizeOptions.count();
-
-  for (let i = 0; i < textSizeCount; i += 1) {
-    await textSizeOptions.nth(i).click();
-    await screenshot(`voting-settings-text-size-${i + 1}`);
-  }
-
-  // Reset to defaults and close
-  await page.getByText('Reset', { exact: true }).click();
-
-  await page.getByText('Audio').click();
-  await screenshot('voting-settings-audio');
-  await screenshotWithButtonHighlight(
-    'Mute Audio',
-    'voting-settings-mute-audio-button'
-  );
-  await screenshotWithButtonHighlight(
-    'Enable Audio-Only Mode',
-    'voting-settings-mute-audio-button'
-  );
-  await page.getByText('Enable Audio-Only Mode').click();
-  await screenshot('voting-settings-audio-only-mode');
-  await page.getByText('Exit Audio-Only Mode').click();
-
-  /**
-   * Navigate Contests
-   */
-
-  // Track whether we've captured the next screenshot
-  let capturedNextButton = false;
+  let capturedSingleSeat = false;
+  let capturedMultiSeat = false;
   let capturedWriteIn = false;
 
-  // Navigate through all contests
-  for (let contestNum = 1; contestNum <= totalContests; contestNum += 1) {
-    const { current } = await getContestInfo();
-    // Verify we're on the expected contest
-    if (current !== contestNum) {
-      throw new Error(
-        `Expected contest ${contestNum} but on contest ${current}`
-      );
-    }
+  for (let i = 0; i < contests.length; i += 1) {
+    const contest = contests[i];
+    await page.getByRole('heading', { name: contest.title }).first().waitFor();
 
-    // Capture write-in flow on first contest that supports it
-    const writeInButton = page.getByText('add write-in candidate');
-    if (!capturedWriteIn && (await writeInButton.isVisible())) {
-      await screenshotWithButtonHighlight(
-        'add write-in candidate',
-        'voting-write-in-button'
-      );
+    if (contest.type === 'candidate') {
+      const candidateContest = contest;
+      const isMultiSeat = candidateContest.seats > 1;
 
-      await writeInButton.click();
-      await page.getByRole('alertdialog').waitFor();
-      const dialog = page.getByRole('alertdialog');
-      for (const letter of 'NEMO') {
-        await dialog
-          // Button names are doubled for some reason, e.g., "A A"
-          .getByRole('button', { name: `${letter} ${letter}` })
-          .click();
+      // Capture the write-in flow on the first single-seat write-in contest,
+      // once a plain single-seat selection has already been captured.
+      if (
+        candidateContest.allowWriteIns &&
+        !capturedWriteIn &&
+        capturedSingleSeat &&
+        !isMultiSeat
+      ) {
+        await screenshotWithButtonHighlight(
+          'add write-in candidate',
+          'voting-write-in-button'
+        );
+        await page.getByText('add write-in candidate').click();
+        const dialog = page.getByRole('alertdialog');
+        await dialog.waitFor();
+        for (const letter of 'NEMO') {
+          // Virtual keyboard button names are doubled, e.g. "N N".
+          await dialog
+            .getByRole('button', { name: `${letter} ${letter}` })
+            .click();
+        }
+        await screenshot('voting-write-in-keyboard');
+        await dialog.getByRole('button', { name: 'Accept' }).click();
+        await dialog.waitFor({ state: 'hidden' });
+        await screenshot('voting-write-in-accepted');
+        capturedWriteIn = true;
+      } else {
+        const options = page.getByRole('option');
+        const numToSelect = isMultiSeat ? candidateContest.seats : 1;
+        for (let s = 0; s < numToSelect; s += 1) {
+          await options.nth(s).click();
+        }
+        if (!isMultiSeat && !capturedSingleSeat) {
+          await screenshot('voting-single-seat-selection');
+          capturedSingleSeat = true;
+        }
+        if (isMultiSeat && !capturedMultiSeat) {
+          await screenshot('voting-multi-seat-selections');
+          capturedMultiSeat = true;
+        }
       }
-      await screenshot('voting-write-in-entry');
-
-      await page.getByRole('button', { name: 'Accept' }).click();
-      await page.getByRole('alertdialog').waitFor({ state: 'hidden' });
-      await screenshot('voting-write-in-selected');
-
-      capturedWriteIn = true;
-    } else {
-      const optionCount = await page.getByRole('option').count();
-      const options = page.getByRole('option');
-
-      // Make selection deterministically (use modulo for index)
-      const selectionIndex = contestNum % optionCount;
-      await options.nth(selectionIndex).click();
-      await page.waitForTimeout(100);
     }
 
-    // Screenshot the contest with selections
-    await screenshot(`voting-contest-${contestNum}`);
-
-    // Capture Next button on first contest
-    if (!capturedNextButton && contestNum < totalContests) {
-      await screenshotWithButtonHighlight(/Next/, 'voting-contest-next-button');
-      capturedNextButton = true;
-    }
-
-    await page.getByRole('button', { name: /Next/ }).click();
-    await page.waitForTimeout(100); // Brief wait for navigation
+    // The "Next" button navigates to the review screen after the last contest.
+    await page.getByRole('button', { name: 'Next' }).click();
   }
+}
 
-  // Pre-Print Review screen
-  await page.getByText('Print My Ballot').waitFor();
-  await screenshot('voting-pre-print-review');
+test('basic election flow', async ({ page }) => {
+  const electionDefinition = getMultiLanguageFamousNamesElectionDefinition();
+  const { election } = electionDefinition;
+  const usbHandler = getMockFileUsbDriveHandler();
+  const helper = buildIntegrationTestHelper(page, screenshotCounter);
+  const {
+    screenshot,
+    screenshotWithButtonHighlight,
+    screenshotWithLocatorHighlight,
+    clickModalButton,
+  } = helper;
+  const electionPackage = await buildElectionPackage(electionDefinition);
 
-  // Print ballot
-  await page.getByText('Print My Ballot').click();
+  // Initial configuration screen.
+  await page
+    .getByText('Insert an election manager card to configure VxMarkScan')
+    .waitFor();
+  await screenshot('unconfigured-screen');
+
+  // Insert election manager card, then prompt for USB.
+  await logInAsElectionManager(page, election);
+  await page.getByText(/USB drive/).waitFor();
+  await screenshot('em-insert-usb');
+
+  // Insert USB containing the election package.
+  usbHandler.insert(electionPackage);
+  await page.getByText('Election Manager Menu').waitFor();
+  await screenshot('em-menu-no-polling-place');
+
+  // Select a polling place.
+  await page.getByText(/select a polling place/i).click({ force: true });
+  await page.getByText(POLLING_PLACE_NAME, { exact: true }).click();
+  await screenshot('em-menu-polling-place-selected');
+
+  // Ballot mode: official highlighted (not selected), select it, then test
+  // highlighted (not selected).
+  await screenshotWithButtonHighlight(
+    'Official Ballot Mode',
+    'em-menu-official-ballot-mode-highlighted'
+  );
+  await page.getByRole('option', { name: 'Official Ballot Mode' }).click();
+  await page
+    .getByRole('option', { name: 'Official Ballot Mode', selected: true })
+    .waitFor();
+  await screenshotWithButtonHighlight(
+    'Test Ballot Mode',
+    'em-menu-test-ballot-mode-highlighted'
+  );
+
+  // Remove card → unauthenticated pre-polls-opened screen.
+  mockCardRemoval();
+  await page.getByText('Insert a poll worker card to open.').waitFor();
+  await screenshot('unauthenticated-polls-closed');
+
+  // Poll worker opens polls.
+  logInAsPollWorker(election);
+  await page.getByText('Poll Worker Menu').waitFor();
+  await screenshot('pw-menu-polls-closed');
+  await screenshotWithButtonHighlight(
+    'Open Polls',
+    'pw-menu-open-polls-highlighted'
+  );
+  await screenshotWithButtonHighlight(
+    'Signed Hash Validation',
+    'pw-menu-signed-hash-validation-highlighted'
+  );
+  await page.getByText('Open Polls').click();
+  await page.getByRole('alertdialog').waitFor();
+  await screenshotWithButtonHighlight('Open Polls', 'pw-open-polls-modal');
+  await clickModalButton('Open Polls');
+  await page.getByText('Close Polls').waitFor();
+
+  // Remove card → unauthenticated polls-opened screen.
+  mockCardRemoval();
+  await page.getByText('Insert Card').waitFor();
+  await screenshot('unauthenticated-polls-opened');
+  await screenshotWithLocatorHighlight(
+    page.getByTestId('electionInfoBar'),
+    'unauthenticated-polls-opened-election-info'
+  );
+
+  // Poll worker starts a voting session. Unique to VxMarkScan: starting a
+  // session loads the voter's blank ballot sheet into the printer-scanner.
+  logInAsPollWorker(election);
+  await page.getByText('Poll Worker Menu').waitFor();
+  await screenshot('pw-menu-polls-open');
+  await screenshotWithButtonHighlight(
+    /Start Voting Session/,
+    'pw-start-voting-session-button'
+  );
+  await page.getByText(/Start Voting Session/).click();
+  await insertBlankBallotSheet(page);
+  await page.getByText(/Remove Card/).waitFor();
+  await screenshot('pw-remove-card-to-vote');
+
+  // Remove card → voter "Start Voting" screen.
+  mockCardRemoval();
+  await page.getByRole('button', { name: 'Start Voting' }).waitFor();
+  await screenshot('voting-start-screen');
+
+  // Vote and capture contest screenshots.
+  await voteAndCaptureContests(page, election, helper);
+
+  // Review screen.
+  await page.getByRole('heading', { name: 'Review Your Votes' }).waitFor();
+  await screenshot('voting-review');
+
+  // Print ballot.
+  await page.getByRole('button', { name: 'Print My Ballot' }).click();
   await page.getByText(/Printing/).waitFor();
   await screenshot('voting-printing');
 
-  // Post-Print Cast instructions
-  await page.getByText('Cast My Ballot').waitFor();
+  // Post-print review: the printed ballot is presented for the voter to cast.
+  await page.getByText('Cast My Ballot').waitFor({ timeout: 30000 });
   await screenshot('voting-post-print-review');
 
+  // Cast the ballot.
   await page.getByText('Cast My Ballot').click();
   await page.getByText(/Casting/).waitFor();
   await screenshot('voting-casting-ballot');
 
-  await page.getByText('Thank you for voting.').waitFor();
+  await page.getByText('Thank you for voting.').waitFor({ timeout: 30000 });
   await screenshot('voting-ballot-cast');
 
-  await page.clock.fastForward(5_000);
+  // The "thank you" screen auto-returns to the idle screen after a short delay.
   await page.getByText('Insert Card').waitFor();
+
+  // Poll worker closes polls.
+  logInAsPollWorker(election);
+  await page.getByText('Poll Worker Menu').waitFor();
+  await screenshotWithButtonHighlight(
+    'Close Polls',
+    'pw-menu-close-polls-highlighted'
+  );
+  await page.getByText('Close Polls').click();
+  await page.getByRole('alertdialog').waitFor();
+  await screenshotWithButtonHighlight('Close Polls', 'pw-close-polls-modal');
+  await clickModalButton('Close Polls');
+  await page.getByRole('alertdialog').waitFor({ state: 'hidden' });
+  await screenshot('pw-menu-polls-closed-final');
+
+  // Remove card → unauthenticated polls-closed screen.
+  mockCardRemoval();
+  await page.getByText('Voting is complete.').waitFor();
+  await screenshot('unauthenticated-polls-closed-final');
+
+  // Election manager unconfigures the machine.
+  await logInAsElectionManager(page, election);
+  await page.getByText('Election Manager Menu').waitFor();
+  await screenshotWithButtonHighlight(
+    'Unconfigure Machine',
+    'em-menu-unconfigure-highlighted'
+  );
+  await page.getByRole('button', { name: 'Unconfigure Machine' }).click();
+  await page.getByRole('alertdialog').waitFor();
+  await screenshot('em-unconfigure-modal');
+  await page
+    .getByRole('alertdialog')
+    .getByRole('button', { name: 'Delete All Election Data' })
+    .click();
+
+  // Remove card → back to unconfigured.
+  mockCardRemoval();
+  await page
+    .getByText('Insert an election manager card to configure VxMarkScan')
+    .waitFor();
+});
+
+test('additional options', async ({ page }) => {
+  const electionDefinition = getMultiLanguageFamousNamesElectionDefinition();
+  const { election } = electionDefinition;
+  const helper = buildIntegrationTestHelper(page, screenshotCounter);
+  const {
+    screenshot,
+    screenshotWithButtonHighlight,
+    clickModalButton,
+    withContainerVerticallyExpanded,
+  } = helper;
+  const electionPackage = await buildElectionPackage(electionDefinition);
+
+  await page
+    .getByText('Insert an election manager card to configure VxMarkScan')
+    .waitFor();
+  await configureMachine(page, {
+    election,
+    electionPackage,
+    pollingPlaceName: POLLING_PLACE_NAME,
+  });
+
+  // Election manager menu system buttons.
+  await screenshotWithButtonHighlight(
+    'Diagnostics',
+    'em-menu-diagnostics-highlighted'
+  );
+  await screenshotWithButtonHighlight(
+    'Save Logs',
+    'em-menu-save-logs-highlighted'
+  );
+  await screenshotWithButtonHighlight(
+    'Set Date and Time',
+    'em-menu-set-date-time-highlighted'
+  );
+  await screenshotWithButtonHighlight(
+    'Signed Hash Validation',
+    'em-menu-signed-hash-validation-highlighted'
+  );
+
+  // Diagnostics screen (full height).
+  await page.getByRole('button', { name: 'Diagnostics' }).click();
+  await page.getByRole('heading', { name: 'Diagnostics' }).waitFor();
+  await withContainerVerticallyExpanded('main', async () => {
+    await screenshot('em-diagnostics-full');
+  });
+
+  // Save the readiness report to the USB drive, then capture the saved PDF.
+  await page.getByRole('button', { name: 'Save Readiness Report' }).click();
+  await page
+    .getByRole('alertdialog')
+    .getByRole('button', { name: 'Save' })
+    .click();
+  await page.getByText('Readiness Report Saved').waitFor();
+  await captureReadinessReport('readiness-report', screenshotCounter);
+  await page
+    .getByRole('alertdialog')
+    .getByRole('button', { name: 'Close' })
+    .click();
+  await page.getByRole('alertdialog').waitFor({ state: 'hidden' });
+
+  await page.getByRole('button', { name: 'Back' }).click();
+  await page.getByText('Election Manager Menu').waitFor();
+
+  // Open polls.
+  mockCardRemoval();
+  await page.getByText('Insert a poll worker card to open.').waitFor();
+  await openPolls(page, election);
+
+  // Pause voting.
+  await screenshotWithButtonHighlight(
+    'Pause Voting',
+    'pw-menu-pause-voting-highlighted'
+  );
+  await page.getByText('Pause Voting').click();
+  await page.getByRole('alertdialog').waitFor();
+  await screenshotWithButtonHighlight('Pause Voting', 'pw-pause-voting-modal');
+  await clickModalButton('Pause Voting');
+  await page.getByText('Resume Voting').waitFor();
+
+  // Remove card → unauthenticated polls-paused screen.
+  mockCardRemoval();
+  await page.getByText('Insert a poll worker card to resume voting.').waitFor();
+  await screenshot('unauthenticated-polls-paused');
+
+  // Poll worker menu while paused.
+  logInAsPollWorker(election);
+  await page.getByText('Poll Worker Menu').waitFor();
+  await screenshot('pw-menu-polls-paused');
+  await screenshotWithButtonHighlight(
+    'Resume Voting',
+    'pw-menu-resume-voting-highlighted'
+  );
+  await page.getByText('Resume Voting').click();
+  await page.getByRole('alertdialog').waitFor();
+  await screenshotWithButtonHighlight(
+    'Resume Voting',
+    'pw-resume-voting-modal'
+  );
+
+  // Back out of the resume modal and close polls instead.
+  await page
+    .getByRole('alertdialog')
+    .getByRole('button', { name: 'Cancel' })
+    .click();
+  await page.getByRole('alertdialog').waitFor({ state: 'hidden' });
+  await page.getByText('Close Polls').click();
+  await page.getByRole('alertdialog').waitFor();
+  await clickModalButton('Close Polls');
+  await page.getByRole('alertdialog').waitFor({ state: 'hidden' });
+
+  // Remove card → system administrator menu.
+  mockCardRemoval();
+  await page.getByText('Voting is complete.').waitFor();
+  await logInAsSystemAdministrator(page);
+  await screenshotWithButtonHighlight(
+    'Diagnostics',
+    'sa-menu-diagnostics-highlighted'
+  );
+  await screenshotWithButtonHighlight(
+    'Save Logs',
+    'sa-menu-save-logs-highlighted'
+  );
+  await screenshotWithButtonHighlight(
+    'Reset Polls to Paused',
+    'sa-menu-reset-polls-to-paused-highlighted'
+  );
+});
+
+test('voter settings', async ({ page }) => {
+  // Use the same single-precinct famous-names election as the basic flow (its
+  // injected multi-language ballot strings still drive the language selector).
+  // We don't capture a printed multi-language ballot here, so the heavier
+  // electionGeneral isn't needed.
+  const electionDefinition = getMultiLanguageFamousNamesElectionDefinition();
+  const { election } = electionDefinition;
+  const helper = buildIntegrationTestHelper(page, screenshotCounter);
+  const { screenshot, screenshotWithLocatorHighlight } = helper;
+  const electionPackage = await buildElectionPackage(electionDefinition);
+
+  await page
+    .getByText('Insert an election manager card to configure VxMarkScan')
+    .waitFor();
+  await configureMachine(page, {
+    election,
+    electionPackage,
+    pollingPlaceName: POLLING_PLACE_NAME,
+  });
+
+  // Open polls and start a voting session.
+  mockCardRemoval();
+  await page.getByText('Insert a poll worker card to open.').waitFor();
+  await openPolls(page, election);
+  await startVotingSession(page);
+  await page.getByRole('button', { name: 'Start Voting' }).click();
+
+  // Voter is on the first contest; the language and settings menu buttons are
+  // always present on voter screens.
+  await page.getByRole('button', { name: 'Settings' }).waitFor();
+
+  // Highlight the language + settings menu buttons together.
+  await screenshotWithLocatorHighlight(
+    page.getByRole('button', { name: 'Settings' }).locator('..'),
+    'voting-language-and-settings-highlighted'
+  );
+
+  // Language settings screen.
+  await page.getByRole('button', { name: /English/ }).click();
+  await page
+    .getByRole('heading', { name: 'Select Your Ballot Language' })
+    .waitFor();
+  await screenshot('voting-language-settings');
+  await page.getByRole('button', { name: 'Done' }).click();
+  await page.getByRole('button', { name: 'Settings' }).waitFor();
+
+  // Voter settings — color. Select each contrast option by its visible label.
+  await page.getByRole('button', { name: 'Settings' }).click();
+  await page.getByRole('tab', { name: 'Color' }).waitFor();
+  const colorSettingLabels = [
+    'White text, black background',
+    'Gray text, dark background',
+    'Dark text, light background',
+    'Black text, white background',
+  ];
+  for (const [i, label] of colorSettingLabels.entries()) {
+    await page.getByText(label, { exact: true }).click();
+    await screenshot(`voting-settings-color-${i + 1}`);
+  }
+  // Reset to the default color so later screenshots aren't affected.
+  await page.getByRole('button', { name: 'Reset', exact: true }).click();
+
+  // Voter settings — text size. Select each size option by its visible label.
+  await page.getByRole('tab', { name: 'Text Size' }).click();
+  await page.getByRole('tab', { name: 'Text Size', selected: true }).waitFor();
+  const textSizeLabels = ['Small', 'Medium', 'Large', 'Extra-Large'];
+  for (const [i, label] of textSizeLabels.entries()) {
+    await page.getByText(label, { exact: true }).click();
+    await screenshot(`voting-settings-text-size-${i + 1}`);
+  }
+  // Reset to the default text size so later screenshots aren't affected.
+  await page.getByRole('button', { name: 'Reset', exact: true }).click();
+
+  // Voter settings — audio.
+  await page.getByRole('tab', { name: 'Audio' }).click();
+  await page.getByRole('tab', { name: 'Audio', selected: true }).waitFor();
+  await screenshot('voting-settings-audio');
+
+  // Audio-only mode. Enabling it closes the settings and shows a full-screen
+  // overlay; exit it afterward. The overlay is aria-hidden, so locate the exit
+  // button by its text.
+  await page.getByRole('button', { name: 'Enable Audio-Only Mode' }).click();
+  await page.getByText('Exit Audio-Only Mode').waitFor();
+  await screenshot('voting-settings-audio-only-mode');
+  await page.getByText('Exit Audio-Only Mode').click();
 });

--- a/apps/mark-scan/integration-testing/e2e/support/auth.ts
+++ b/apps/mark-scan/integration-testing/e2e/support/auth.ts
@@ -1,9 +1,14 @@
 import { buildInsertedSmartCardAuthHelpers } from '@votingworks/integration-test-utils';
 
-/** VxMarkScan auth helpers for integration tests (inserted smart-card auth). */
+/**
+ * VxMarkScan auth helpers for integration tests (inserted smart-card auth).
+ * VxMarkScan renders the PIN-pad digits as plain text rather than buttons.
+ */
 export const {
+  enterPin,
   logInAsSystemAdministrator,
   logInAsElectionManager,
+  logInAsPollWorker,
   forceLogOutAndResetElectionDefinition,
 } = buildInsertedSmartCardAuthHelpers({
   appName: 'VxMarkScan',

--- a/apps/mark-scan/integration-testing/e2e/support/election.ts
+++ b/apps/mark-scan/integration-testing/e2e/support/election.ts
@@ -1,0 +1,84 @@
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import {
+  Election,
+  ElectionDefinition,
+  LanguageCode,
+  UiStringTranslations,
+  safeParseElectionDefinition,
+} from '@votingworks/types';
+
+// Inject multi-language ballot strings so the voter language selector appears.
+// Each language needs its own name in its own script; other languages fall back
+// to English display names via the Intl API. Mirrors the scan integration
+// tests. The Record types ensure every supported language has a display name in
+// every other language.
+const multiLangBallotStrings: Record<
+  LanguageCode,
+  { ballotLanguage: Record<LanguageCode, string> }
+> = {
+  en: {
+    ballotLanguage: {
+      en: 'English',
+      'es-US': 'Spanish',
+      'zh-Hans': 'Simplified Chinese',
+      'zh-Hant': 'Traditional Chinese',
+    },
+  },
+  // spell-checker: disable-next-line
+  'es-US': {
+    ballotLanguage: {
+      en: 'inglés',
+      'es-US': 'español',
+      'zh-Hans': 'chino simplificado',
+      'zh-Hant': 'chino tradicional',
+    },
+  },
+  'zh-Hans': {
+    ballotLanguage: {
+      en: '英语',
+      'es-US': '西班牙语',
+      'zh-Hans': '简体中文',
+      'zh-Hant': '繁体中文',
+    },
+  },
+  'zh-Hant': {
+    ballotLanguage: {
+      en: '英文',
+      'es-US': '西班牙文',
+      'zh-Hans': '簡體中文',
+      'zh-Hant': '繁體中文',
+    },
+  },
+};
+
+/**
+ * The famous-names election patched with multi-language ballot strings so the
+ * voter-facing language selector renders. The `uiStrings` registered in the
+ * election package (see callers) supply the language codes; the display names
+ * come from these `ballotStrings`.
+ */
+export function getMultiLanguageFamousNamesElectionDefinition(): ElectionDefinition {
+  const baseElectionDefinition =
+    electionFamousNames2021Fixtures.readElectionDefinition();
+  const patchedElection: Election = {
+    ...baseElectionDefinition.election,
+    ballotStrings: {
+      ...baseElectionDefinition.election.ballotStrings,
+      ...multiLangBallotStrings,
+    },
+  };
+  return safeParseElectionDefinition(
+    JSON.stringify(patchedElection)
+  ).unsafeUnwrap();
+}
+
+/** The set of language codes registered alongside the patched election. */
+export const MULTI_LANGUAGE_UI_STRINGS: Record<
+  LanguageCode,
+  UiStringTranslations
+> = {
+  en: {},
+  'es-US': {},
+  'zh-Hans': {},
+  'zh-Hant': {},
+};

--- a/apps/mark-scan/integration-testing/e2e/support/election.ts
+++ b/apps/mark-scan/integration-testing/e2e/support/election.ts
@@ -1,84 +1,51 @@
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import {
-  Election,
   ElectionDefinition,
+  ElectionStringKey,
   LanguageCode,
   UiStringTranslations,
-  safeParseElectionDefinition,
 } from '@votingworks/types';
+import { format } from '@votingworks/utils';
 
-// Inject multi-language ballot strings so the voter language selector appears.
-// Each language needs its own name in its own script; other languages fall back
-// to English display names via the Intl API. Mirrors the scan integration
-// tests. The Record types ensure every supported language has a display name in
-// every other language.
-const multiLangBallotStrings: Record<
-  LanguageCode,
-  { ballotLanguage: Record<LanguageCode, string> }
-> = {
-  en: {
-    ballotLanguage: {
-      en: 'English',
-      'es-US': 'Spanish',
-      'zh-Hans': 'Simplified Chinese',
-      'zh-Hant': 'Traditional Chinese',
-    },
-  },
-  // spell-checker: disable-next-line
-  'es-US': {
-    ballotLanguage: {
-      en: 'inglés',
-      'es-US': 'español',
-      'zh-Hans': 'chino simplificado',
-      'zh-Hant': 'chino tradicional',
-    },
-  },
-  'zh-Hans': {
-    ballotLanguage: {
-      en: '英语',
-      'es-US': '西班牙语',
-      'zh-Hans': '简体中文',
-      'zh-Hant': '繁体中文',
-    },
-  },
-  'zh-Hant': {
-    ballotLanguage: {
-      en: '英文',
-      'es-US': '西班牙文',
-      'zh-Hans': '簡體中文',
-      'zh-Hant': '繁體中文',
-    },
-  },
-};
-
-/**
- * The famous-names election patched with multi-language ballot strings so the
- * voter-facing language selector renders. The `uiStrings` registered in the
- * election package (see callers) supply the language codes; the display names
- * come from these `ballotStrings`.
- */
-export function getMultiLanguageFamousNamesElectionDefinition(): ElectionDefinition {
-  const baseElectionDefinition =
-    electionFamousNames2021Fixtures.readElectionDefinition();
-  const patchedElection: Election = {
-    ...baseElectionDefinition.election,
-    ballotStrings: {
-      ...baseElectionDefinition.election.ballotStrings,
-      ...multiLangBallotStrings,
-    },
-  };
-  return safeParseElectionDefinition(
-    JSON.stringify(patchedElection)
-  ).unsafeUnwrap();
+/** The famous-names election used by the screenshot tests. */
+export function getFamousNamesElectionDefinition(): ElectionDefinition {
+  return electionFamousNames2021Fixtures.readElectionDefinition();
 }
 
-/** The set of language codes registered alongside the patched election. */
+// The ballotLanguage strings for a single display language: every supported
+// language's name as rendered in `displayLanguageCode`. The display names are
+// sourced from the Intl API — the same way VxDesign generates them when
+// building an election package (see the ballotLanguage extractor in
+// libs/types/src/cdf/ballot-definition/convert.ts).
+function ballotLanguageNames(
+  displayLanguageCode: LanguageCode
+): UiStringTranslations {
+  return {
+    [ElectionStringKey.BALLOT_LANGUAGE]: Object.fromEntries(
+      Object.values(LanguageCode).map((languageCode) => [
+        languageCode,
+        format.languageDisplayName({ languageCode, displayLanguageCode }),
+      ])
+    ),
+  };
+}
+
+/**
+ * Registered in the election package's uiStrings so the voter language selector
+ * lists each language and renders its name in its own language (e.g. "español",
+ * "简体中文"). The explicit `Record<LanguageCode, ...>` makes the type checker flag
+ * a missing entry whenever a new language is added.
+ */
 export const MULTI_LANGUAGE_UI_STRINGS: Record<
   LanguageCode,
   UiStringTranslations
 > = {
-  en: {},
-  'es-US': {},
-  'zh-Hans': {},
-  'zh-Hant': {},
+  [LanguageCode.ENGLISH]: ballotLanguageNames(LanguageCode.ENGLISH),
+  [LanguageCode.SPANISH]: ballotLanguageNames(LanguageCode.SPANISH),
+  [LanguageCode.CHINESE_SIMPLIFIED]: ballotLanguageNames(
+    LanguageCode.CHINESE_SIMPLIFIED
+  ),
+  [LanguageCode.CHINESE_TRADITIONAL]: ballotLanguageNames(
+    LanguageCode.CHINESE_TRADITIONAL
+  ),
 };

--- a/apps/mark-scan/integration-testing/e2e/support/election.ts
+++ b/apps/mark-scan/integration-testing/e2e/support/election.ts
@@ -1,51 +1,7 @@
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
-import {
-  ElectionDefinition,
-  ElectionStringKey,
-  LanguageCode,
-  UiStringTranslations,
-} from '@votingworks/types';
-import { format } from '@votingworks/utils';
+import { ElectionDefinition } from '@votingworks/types';
 
 /** The famous-names election used by the screenshot tests. */
 export function getFamousNamesElectionDefinition(): ElectionDefinition {
   return electionFamousNames2021Fixtures.readElectionDefinition();
 }
-
-// The ballotLanguage strings for a single display language: every supported
-// language's name as rendered in `displayLanguageCode`. The display names are
-// sourced from the Intl API — the same way VxDesign generates them when
-// building an election package (see the ballotLanguage extractor in
-// libs/types/src/cdf/ballot-definition/convert.ts).
-function ballotLanguageNames(
-  displayLanguageCode: LanguageCode
-): UiStringTranslations {
-  return {
-    [ElectionStringKey.BALLOT_LANGUAGE]: Object.fromEntries(
-      Object.values(LanguageCode).map((languageCode) => [
-        languageCode,
-        format.languageDisplayName({ languageCode, displayLanguageCode }),
-      ])
-    ),
-  };
-}
-
-/**
- * Registered in the election package's uiStrings so the voter language selector
- * lists each language and renders its name in its own language (e.g. "español",
- * "简体中文"). The explicit `Record<LanguageCode, ...>` makes the type checker flag
- * a missing entry whenever a new language is added.
- */
-export const MULTI_LANGUAGE_UI_STRINGS: Record<
-  LanguageCode,
-  UiStringTranslations
-> = {
-  [LanguageCode.ENGLISH]: ballotLanguageNames(LanguageCode.ENGLISH),
-  [LanguageCode.SPANISH]: ballotLanguageNames(LanguageCode.SPANISH),
-  [LanguageCode.CHINESE_SIMPLIFIED]: ballotLanguageNames(
-    LanguageCode.CHINESE_SIMPLIFIED
-  ),
-  [LanguageCode.CHINESE_TRADITIONAL]: ballotLanguageNames(
-    LanguageCode.CHINESE_TRADITIONAL
-  ),
-};

--- a/apps/mark-scan/integration-testing/e2e/support/flows.ts
+++ b/apps/mark-scan/integration-testing/e2e/support/flows.ts
@@ -1,0 +1,110 @@
+import { Page, expect } from '@playwright/test';
+import { mockCardRemoval } from '@votingworks/auth';
+import { mockElectionPackageFileTree } from '@votingworks/backend';
+import { Election } from '@votingworks/types';
+import { getMockFileUsbDriveHandler } from '@votingworks/usb-drive';
+import { logInAsElectionManager, logInAsPollWorker } from './auth';
+
+async function postToApi(page: Page, method: string, input: object = {}) {
+  return page.request.post(`/api/${method}`, {
+    data: JSON.stringify(input),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/**
+ * Simulates a voter inserting a blank ballot sheet to start a voting session.
+ * VxMarkScan's mock paper handler does not physically feed paper. The frontend
+ * has a dev-only auto-insert effect, but it fires unreliably under test, so we
+ * drive the mock directly: once the session has begun, if the machine is still
+ * waiting for a sheet, mark one as inserted so the state machine loads it. If
+ * the auto-insert effect already advanced the flow, this is a no-op.
+ */
+export async function insertBlankBallotSheet(page: Page): Promise<void> {
+  await expect
+    .poll(async () => (await postToApi(page, 'getPaperHandlerState')).text(), {
+      timeout: 10_000,
+    })
+    .not.toContain('not_accepting_paper');
+  const state = await (await postToApi(page, 'getPaperHandlerState')).text();
+  if (state.includes('accepting_paper')) {
+    await postToApi(page, 'setMockPaperHandlerStatus', {
+      mockStatus: 'paperInserted',
+    });
+  }
+}
+
+type ElectionPackageFileTree = Awaited<
+  ReturnType<typeof mockElectionPackageFileTree>
+>;
+
+/**
+ * Configures the machine from the unconfigured state: logs in as election
+ * manager, inserts a USB drive containing the given election package, selects
+ * the given polling place, and switches to official ballot mode. Leaves the
+ * election manager card inserted.
+ */
+export async function configureMachine(
+  page: Page,
+  options: {
+    election: Election;
+    electionPackage: ElectionPackageFileTree;
+    pollingPlaceName: string;
+  }
+): Promise<void> {
+  const { election, electionPackage, pollingPlaceName } = options;
+  const usbHandler = getMockFileUsbDriveHandler();
+
+  await logInAsElectionManager(page, election);
+  await page.getByText(/USB drive/).waitFor();
+
+  usbHandler.insert(electionPackage);
+  await page.getByText('Election Manager Menu').waitFor();
+
+  await page.getByText(/select a polling place/i).click({ force: true });
+  await page.getByText(pollingPlaceName, { exact: true }).click();
+
+  await page.getByRole('option', { name: 'Official Ballot Mode' }).click();
+  await page
+    .getByRole('option', { name: 'Official Ballot Mode', selected: true })
+    .waitFor();
+}
+
+/**
+ * Opens the polls as a poll worker, then leaves the card inserted. Assumes the
+ * machine is configured and showing the unauthenticated "insert poll worker
+ * card to open polls" screen.
+ */
+export async function openPolls(page: Page, election: Election): Promise<void> {
+  logInAsPollWorker(election);
+  await page.getByText('Poll Worker Menu').waitFor();
+  await page.getByText('Open Polls').click();
+  await page
+    .getByRole('alertdialog')
+    .getByRole('button', { name: 'Open Polls' })
+    .click();
+  // Wait for the confirmation modal to fully close before returning, so a
+  // following click (e.g. "Start Voting Session") isn't swallowed by the
+  // closing dialog.
+  await page.getByRole('alertdialog').waitFor({ state: 'hidden' });
+  await page.getByText('Close Polls').waitFor();
+}
+
+/**
+ * Starts a voter session as a poll worker and drives the paper-handler load
+ * sequence (unique to VxMarkScan: the voter's blank ballot sheet is loaded into
+ * the printer-scanner before voting begins). The mock paper handler advances the
+ * mechanical states automatically, so no paper status needs to be set. Removes
+ * the poll worker card and leaves the voter on the "Start Voting" screen.
+ */
+export async function startVotingSession(page: Page): Promise<void> {
+  const startButton = page.getByRole('button', {
+    name: /Start Voting Session/,
+  });
+  await startButton.waitFor();
+  await startButton.click();
+  await insertBlankBallotSheet(page);
+  await page.getByText(/Remove Card/).waitFor();
+  mockCardRemoval();
+  await page.getByRole('button', { name: 'Start Voting' }).waitFor();
+}

--- a/apps/mark-scan/integration-testing/e2e/support/reports.ts
+++ b/apps/mark-scan/integration-testing/e2e/support/reports.ts
@@ -1,0 +1,27 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { assertDefined } from '@votingworks/basics';
+import {
+  capturePdfScreenshots,
+  type ScreenshotCounter,
+} from '@votingworks/integration-test-utils';
+import { getMockFileUsbDriveHandler } from '@votingworks/usb-drive';
+
+/**
+ * Captures the readiness report PDF that was saved to the mock USB drive.
+ */
+export async function captureReadinessReport(
+  name: string,
+  counter: ScreenshotCounter
+): Promise<void> {
+  const dataPath = assertDefined(getMockFileUsbDriveHandler().getDataPath());
+  const reportFilename = assertDefined(
+    readdirSync(dataPath).find(
+      (filename) =>
+        filename.startsWith('readiness-report__') && filename.endsWith('.pdf')
+    ),
+    'expected a readiness report PDF on the mock USB drive'
+  );
+  const pdfBytes = new Uint8Array(readFileSync(join(dataPath, reportFilename)));
+  await capturePdfScreenshots(pdfBytes, name, counter);
+}

--- a/apps/mark-scan/integration-testing/package.json
+++ b/apps/mark-scan/integration-testing/package.json
@@ -22,6 +22,7 @@
     "@votingworks/integration-test-utils": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/usb-drive": "workspace:*",
+    "@votingworks/utils": "workspace:*",
     "concurrently": "7.6.0",
     "dotenv": "16.3.1"
   },

--- a/apps/mark-scan/integration-testing/package.json
+++ b/apps/mark-scan/integration-testing/package.json
@@ -22,7 +22,6 @@
     "@votingworks/integration-test-utils": "workspace:*",
     "@votingworks/types": "workspace:*",
     "@votingworks/usb-drive": "workspace:*",
-    "@votingworks/utils": "workspace:*",
     "concurrently": "7.6.0",
     "dotenv": "16.3.1"
   },

--- a/apps/mark/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/mark/integration-testing/e2e/screenshots.spec.ts
@@ -7,6 +7,7 @@ import {
   setupTemporaryRootDir,
 } from '@votingworks/fixtures';
 import {
+  MULTI_LANGUAGE_UI_STRINGS,
   buildIntegrationTestHelper,
   captureReadinessReport,
   createScreenshotCounter,
@@ -28,9 +29,8 @@ import {
   logInAsSystemAdministrator,
 } from './support/auth';
 import {
-  getMultiLanguageFamousNamesElectionDefinition,
+  getFamousNamesElectionDefinition,
   getMultiLanguageGeneralElectionDefinition,
-  MULTI_LANGUAGE_UI_STRINGS,
 } from './support/election';
 import { configureMachine, openPolls, voteFullBallot } from './support/flows';
 import { capturePrintedBallot } from './support/reports';
@@ -62,8 +62,8 @@ async function buildElectionPackage(electionDefinition: ElectionDefinition) {
       // Hide the voter help button to keep voter screens uncluttered.
       disableVoterHelpButtons: true,
     },
-    // Registers the language codes; the display names come from the election's
-    // ballotStrings (see getMultiLanguageFamousNamesElectionDefinition).
+    // Registers the supported languages and their native display names so the
+    // voter language selector renders (see MULTI_LANGUAGE_UI_STRINGS).
     uiStrings: MULTI_LANGUAGE_UI_STRINGS,
   });
 }
@@ -145,7 +145,7 @@ async function voteAndCaptureContests(
 }
 
 test('basic election flow', async ({ page }) => {
-  const electionDefinition = getMultiLanguageFamousNamesElectionDefinition();
+  const electionDefinition = getFamousNamesElectionDefinition();
   const { election } = electionDefinition;
   const usbHandler = getMockFileUsbDriveHandler();
   const helper = buildIntegrationTestHelper(page, screenshotCounter);
@@ -313,7 +313,7 @@ test('basic election flow', async ({ page }) => {
 });
 
 test('additional options', async ({ page }) => {
-  const electionDefinition = getMultiLanguageFamousNamesElectionDefinition();
+  const electionDefinition = getFamousNamesElectionDefinition();
   const { election } = electionDefinition;
   const helper = buildIntegrationTestHelper(page, screenshotCounter);
   const {

--- a/apps/mark/integration-testing/e2e/support/election.ts
+++ b/apps/mark/integration-testing/e2e/support/election.ts
@@ -6,73 +6,12 @@ import {
   Election,
   ElectionDefinition,
   LanguageCode,
-  UiStringTranslations,
   safeParseElectionDefinition,
 } from '@votingworks/types';
 
-// Inject multi-language ballot strings so the voter language selector appears.
-// Each language needs its own name in its own script; other languages fall back
-// to English display names via the Intl API. Mirrors the scan integration
-// tests. The Record types ensure every supported language has a display name in
-// every other language.
-const multiLangBallotStrings: Record<
-  LanguageCode,
-  { ballotLanguage: Record<LanguageCode, string> }
-> = {
-  en: {
-    ballotLanguage: {
-      en: 'English',
-      'es-US': 'Spanish',
-      'zh-Hans': 'Simplified Chinese',
-      'zh-Hant': 'Traditional Chinese',
-    },
-  },
-  // spell-checker: disable-next-line
-  'es-US': {
-    ballotLanguage: {
-      en: 'inglés',
-      'es-US': 'español',
-      'zh-Hans': 'chino simplificado',
-      'zh-Hant': 'chino tradicional',
-    },
-  },
-  'zh-Hans': {
-    ballotLanguage: {
-      en: '英语',
-      'es-US': '西班牙语',
-      'zh-Hans': '简体中文',
-      'zh-Hant': '繁体中文',
-    },
-  },
-  'zh-Hant': {
-    ballotLanguage: {
-      en: '英文',
-      'es-US': '西班牙文',
-      'zh-Hans': '簡體中文',
-      'zh-Hant': '繁體中文',
-    },
-  },
-};
-
-/**
- * The famous-names election patched with multi-language ballot strings so the
- * voter-facing language selector renders. The `uiStrings` registered in the
- * election package (see callers) supply the language codes; the display names
- * come from these `ballotStrings`.
- */
-export function getMultiLanguageFamousNamesElectionDefinition(): ElectionDefinition {
-  const baseElectionDefinition =
-    electionFamousNames2021Fixtures.readElectionDefinition();
-  const patchedElection: Election = {
-    ...baseElectionDefinition.election,
-    ballotStrings: {
-      ...baseElectionDefinition.election.ballotStrings,
-      ...multiLangBallotStrings,
-    },
-  };
-  return safeParseElectionDefinition(
-    JSON.stringify(patchedElection)
-  ).unsafeUnwrap();
+/** The famous-names election used by the screenshot tests. */
+export function getFamousNamesElectionDefinition(): ElectionDefinition {
+  return electionFamousNames2021Fixtures.readElectionDefinition();
 }
 
 // Languages to generate ballot-style variants for, matching electionGeneral's
@@ -110,14 +49,3 @@ export function getMultiLanguageGeneralElectionDefinition(): ElectionDefinition 
     JSON.stringify(patchedElection)
   ).unsafeUnwrap();
 }
-
-/** The set of language codes registered alongside the patched election. */
-export const MULTI_LANGUAGE_UI_STRINGS: Record<
-  LanguageCode,
-  UiStringTranslations
-> = {
-  en: {},
-  'es-US': {},
-  'zh-Hans': {},
-  'zh-Hant': {},
-};

--- a/apps/scan/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/scan/integration-testing/e2e/screenshots.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '@votingworks/fixtures';
 import { getMockFileFujitsuPrinterHandler } from '@votingworks/fujitsu-thermal-printer';
 import {
+  MULTI_LANGUAGE_UI_STRINGS,
   buildIntegrationTestHelper,
   createFullyVotedBallot,
   createScreenshotCounter,
@@ -19,12 +20,8 @@ import {
   AdjudicationReason,
   CandidateContest,
   DEFAULT_SYSTEM_SETTINGS,
-  Election,
-  ElectionDefinition,
-  LanguageCode,
   SystemSettings,
   VotesDict,
-  safeParseElectionDefinition,
 } from '@votingworks/types';
 import { getMockFileUsbDriveHandler } from '@votingworks/usb-drive';
 import {
@@ -197,58 +194,7 @@ test('configuration', async ({ page }) => {
 
 test('voting', async ({ page }) => {
   const fixtureSet = electionFamousNames2021Fixtures;
-  const baseElectionDefinition = fixtureSet.readElectionDefinition();
-  // Inject multi-language ballot strings so the language selector appears.
-  // Each language needs its own name in its own script; other languages fall
-  // back to English display names via the Intl API.
-  const multiLangBallotStrings: Record<
-    LanguageCode,
-    { ballotLanguage: Record<LanguageCode, string> }
-  > = {
-    en: {
-      ballotLanguage: {
-        en: 'English',
-        'es-US': 'Spanish',
-        'zh-Hans': 'Simplified Chinese',
-        'zh-Hant': 'Traditional Chinese',
-      },
-    },
-    // spell-checker: disable-next-line
-    'es-US': {
-      ballotLanguage: {
-        en: 'inglés',
-        'es-US': 'español',
-        'zh-Hans': 'chino simplificado',
-        'zh-Hant': 'chino tradicional',
-      },
-    },
-    'zh-Hans': {
-      ballotLanguage: {
-        en: '英语',
-        'es-US': '西班牙语',
-        'zh-Hans': '简体中文',
-        'zh-Hant': '繁体中文',
-      },
-    },
-    'zh-Hant': {
-      ballotLanguage: {
-        en: '英文',
-        'es-US': '西班牙文',
-        'zh-Hans': '簡體中文',
-        'zh-Hant': '繁體中文',
-      },
-    },
-  };
-  const patchedElection: Election = {
-    ...baseElectionDefinition.election,
-    ballotStrings: {
-      ...baseElectionDefinition.election.ballotStrings,
-      ...multiLangBallotStrings,
-    },
-  };
-  const electionDefinition: ElectionDefinition = safeParseElectionDefinition(
-    JSON.stringify(patchedElection)
-  ).unsafeUnwrap();
+  const electionDefinition = fixtureSet.readElectionDefinition();
   const { election } = electionDefinition;
   const usbHandler = getMockFileUsbDriveHandler();
   const {
@@ -328,9 +274,9 @@ test('voting', async ({ page }) => {
     await mockElectionPackageFileTree({
       electionDefinition,
       systemSettings,
-      // uiStrings registers the language codes; ballotLanguage strings come
-      // from electionDefinition.election.ballotStrings (merged on load).
-      uiStrings: { en: {}, 'es-US': {}, 'zh-Hans': {}, 'zh-Hant': {} },
+      // Registers the supported languages and their native display names so the
+      // voter language selector renders (see MULTI_LANGUAGE_UI_STRINGS).
+      uiStrings: MULTI_LANGUAGE_UI_STRINGS,
     })
   );
   await page.getByText('Election Manager Menu').waitFor();

--- a/libs/custom-paper-handler/src/driver/mock_driver.ts
+++ b/libs/custom-paper-handler/src/driver/mock_driver.ts
@@ -218,6 +218,10 @@ export class MockPaperHandlerDriver implements PaperHandlerDriverInterface {
 
   async ejectBallotToRear(): Promise<boolean> {
     this.setMockStatus('noPaper');
+    // The ballot has left the machine into the ballot box, so any printed
+    // contents are gone. Clearing them ensures a subsequently loaded blank
+    // sheet scans as blank rather than re-reading the cast ballot.
+    this.mockPaperContents = undefined;
 
     return Promise.resolve(true);
   }

--- a/libs/integration-test-utils/package.json
+++ b/libs/integration-test-utils/package.json
@@ -33,7 +33,8 @@
     "@votingworks/hmpb": "workspace:*",
     "@votingworks/image-utils": "workspace:*",
     "@votingworks/types": "workspace:*",
-    "@votingworks/usb-drive": "workspace:*"
+    "@votingworks/usb-drive": "workspace:*",
+    "@votingworks/utils": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "20.17.31",

--- a/libs/integration-test-utils/src/index.ts
+++ b/libs/integration-test-utils/src/index.ts
@@ -5,3 +5,4 @@ export * from './screenshots';
 export * from './pdf';
 export * from './playwright_config';
 export * from './reports';
+export * from './ui_strings';

--- a/libs/integration-test-utils/src/ui_strings.ts
+++ b/libs/integration-test-utils/src/ui_strings.ts
@@ -1,0 +1,45 @@
+import {
+  ElectionStringKey,
+  LanguageCode,
+  UiStringTranslations,
+} from '@votingworks/types';
+import { format } from '@votingworks/utils';
+
+// The ballotLanguage strings for a single display language: every supported
+// language's name as rendered in `displayLanguageCode`. Unlike most election
+// strings, these aren't machine-translated via the cloud translator; VxDesign
+// generates them from the Intl API via the same `format.languageDisplayName`
+// util we use here.
+function ballotLanguageNames(
+  displayLanguageCode: LanguageCode
+): UiStringTranslations {
+  return {
+    [ElectionStringKey.BALLOT_LANGUAGE]: Object.fromEntries(
+      Object.values(LanguageCode).map((languageCode) => [
+        languageCode,
+        format.languageDisplayName({ languageCode, displayLanguageCode }),
+      ])
+    ),
+  };
+}
+
+/**
+ * Registered in an election package's uiStrings (for the integration-test
+ * screenshot suites) so the voter language selector lists each language and
+ * renders its name in its own language (e.g. "español", "简体中文"). The explicit
+ * `Record<LanguageCode, ...>` makes the type checker flag a missing entry
+ * whenever a new language is added.
+ */
+export const MULTI_LANGUAGE_UI_STRINGS: Record<
+  LanguageCode,
+  UiStringTranslations
+> = {
+  [LanguageCode.ENGLISH]: ballotLanguageNames(LanguageCode.ENGLISH),
+  [LanguageCode.SPANISH]: ballotLanguageNames(LanguageCode.SPANISH),
+  [LanguageCode.CHINESE_SIMPLIFIED]: ballotLanguageNames(
+    LanguageCode.CHINESE_SIMPLIFIED
+  ),
+  [LanguageCode.CHINESE_TRADITIONAL]: ballotLanguageNames(
+    LanguageCode.CHINESE_TRADITIONAL
+  ),
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1813,6 +1813,9 @@ importers:
       '@votingworks/usb-drive':
         specifier: workspace:*
         version: link:../../../libs/usb-drive
+      '@votingworks/utils':
+        specifier: workspace:*
+        version: link:../../../libs/utils
       concurrently:
         specifier: 7.6.0
         version: 7.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1813,9 +1813,6 @@ importers:
       '@votingworks/usb-drive':
         specifier: workspace:*
         version: link:../../../libs/usb-drive
-      '@votingworks/utils':
-        specifier: workspace:*
-        version: link:../../../libs/utils
       concurrently:
         specifier: 7.6.0
         version: 7.6.0
@@ -4883,6 +4880,9 @@ importers:
       '@votingworks/usb-drive':
         specifier: workspace:*
         version: link:../usb-drive
+      '@votingworks/utils':
+        specifier: workspace:*
+        version: link:../utils
     devDependencies:
       '@types/node':
         specifier: 20.17.31


### PR DESCRIPTION
## Overview

Reorganizes the VxMarkScan automated screenshot integration tests to mirror the more recent, more polished VxMark suite, so the two apps stay structurally similar and easier to maintain together.

- Adds an `e2e/support/` layer (`auth`, `election`, `flows`, `reports`) matching VxMark, moving `auth.ts` from `support/` into `e2e/support/`.
- Rewrites `screenshots.spec.ts` into the same three tests as VxMark — **basic election flow**, **additional options**, **voter settings** — folding in the behavior unique to VxMarkScan: the paper-handler load on session start and the Print → Cast → "Thank you" flow (vs VxMark's print-and-done).
- Scope intentionally trimmed: diagnostics captures only the Diagnostics-button highlight + full diagnostics page (no per-peripheral hardware screens); the PAT calibration tutorial is omitted (identical shared `mark-flow-ui`); no printed-ballot capture; uses the famous-names e-def instead of a multilingual general election.

Two supporting fixes the reorg surfaced (both in shared/production code, flagged for review):

- **Mock paper handler** (`libs/custom-paper-handler`): clear printed contents when a ballot is ejected to the rear (cast). A cast ballot physically leaves into the ballot box, so a subsequently loaded blank sheet should scan as blank rather than re-reading the previously cast ballot. Without this, an earlier test's printed ballot lingered on the shared backend and made a later session misread it as a pre-printed ballot.
- **mark-scan state machine**: parameterize `DELAY_NOTIFICATION_DURATION_MS` via `isIntegrationTest()` (1s in tests vs 5s in production) to keep the suite fast (~34s).

The test drives the mock paper handler directly to insert a blank sheet rather than relying on the frontend's dev-only auto-insert effect (which is unreliable under test and has a `TODO(kofi)` to be removed).

## Demo Video or Screenshot

Generates 60 screenshots covering configuration, polls open/pause/resume/close, the full vote → print → cast flow, write-ins, voter color/text-size/audio settings, readiness report, and the EM/SA/PW menus.

## Testing Plan

- `pnpm test` in `apps/mark-scan/integration-testing` — all 4 specs pass (~34s), reliably across runs.
- Backend unit tests unaffected by the shared changes: `state_machine.test.ts` (61), `mock_driver.test.ts` (17), `app.test.ts` (29) all pass; backend type-checks clean.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products. (N/A — VxMarkScan)
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)