### PR TITLE
VxPrint: Support open primary (consolidated) ballots

### DIFF
--- a/apps/print/backend/src/app.test.ts
+++ b/apps/print/backend/src/app.test.ts
@@ -16,6 +16,7 @@ import {
 } from '@votingworks/types';
 import {
   electionFamousNames2021Fixtures,
+  electionOpenPrimaryFixtures,
   electionPrimaryPrecinctSplitsFixtures,
   electionTwoPartyPrimaryFixtures,
 } from '@votingworks/fixtures';
@@ -670,6 +671,93 @@ test('end-to-end printing flow updates getBallotPrintCounts for primary election
     languageCode: LanguageCode.ENGLISH,
     partyName: 'Fish',
   });
+});
+
+test('end-to-end printing flow handles open primary (consolidated ballots)', async () => {
+  // In an open primary, ballots are consolidated (all parties' contests on one
+  // ballot) and ballot styles have no partyId. VxPrint should print without a
+  // party selection, just like a general election.
+  const electionDefinition = getMockMultiLanguageElectionDefinition(
+    electionOpenPrimaryFixtures.readElectionDefinition(),
+    [LanguageCode.ENGLISH]
+  );
+
+  const ballots = await buildBallotsForElection({
+    electionDefinition,
+    ballotModes: ['official'],
+  });
+  await configureMachine({
+    electionDefinition,
+    ballots,
+    apiClient,
+    auth,
+    mockUsbDrive,
+  });
+  await apiClient.setPrecinctSelection({
+    precinctSelection: ALL_PRECINCTS_SELECTION,
+  });
+  mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
+
+  const { ballotStyles } = electionDefinition.election;
+  const ballotStyle = ballotStyles[0];
+  const precinctId = ballotStyle.precincts[0];
+
+  // Print with no partyId, matching what the frontend sends for open primaries.
+  await apiClient.printBallot({
+    precinctId,
+    languageCode: LanguageCode.ENGLISH,
+    ballotType: BallotType.Precinct,
+    copies: 2,
+  });
+
+  const counts = await apiClient.getBallotPrintCounts();
+  const row = counts.find(
+    (c) => c.ballotStyleId === ballotStyle.id && c.precinctId === precinctId
+  );
+  expect(row).toMatchObject({
+    ballotStyleId: ballotStyle.id,
+    precinctId,
+    precinctCount: 2,
+    absenteeCount: 0,
+    totalCount: 2,
+    languageCode: LanguageCode.ENGLISH,
+    partyName: undefined,
+  });
+});
+
+test('printAllBallotStyles works for open primary (consolidated ballots)', async () => {
+  const electionDefinition = getMockMultiLanguageElectionDefinition(
+    electionOpenPrimaryFixtures.readElectionDefinition(),
+    [LanguageCode.ENGLISH]
+  );
+
+  const ballots = await buildBallotsForElection({
+    electionDefinition,
+    ballotModes: ['official'],
+  });
+  await configureMachine({
+    electionDefinition,
+    ballots,
+    apiClient,
+    auth,
+    mockUsbDrive,
+  });
+  mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
+
+  await apiClient.printAllBallotStyles({
+    languageCode: LanguageCode.ENGLISH,
+    ballotType: BallotType.Precinct,
+    copiesPerStyle: 1,
+  });
+
+  const counts = await apiClient.getBallotPrintCounts();
+  expect(counts.length).toEqual(
+    electionDefinition.election.ballotStyles.length
+  );
+  for (const count of counts) {
+    expect(count.partyName).toBeUndefined();
+    expect(count.totalCount).toEqual(1);
+  }
 });
 
 test('end-to-end printing flow handles precinct splits correctly', async () => {

--- a/apps/print/backend/src/util/ballot_styles.ts
+++ b/apps/print/backend/src/util/ballot_styles.ts
@@ -13,7 +13,7 @@ import {
   find,
   throwIllegalValue,
 } from '@votingworks/basics';
-import { getAllPrecinctsAndSplits } from '@votingworks/types';
+import { getAllPrecinctsAndSplits, isOpenPrimary } from '@votingworks/types';
 import {
   getBallotStyleGroupsForPrecinctOrSplit,
   getPrecinctsAndSplitsForBallotStyle,
@@ -66,22 +66,32 @@ export function findBallotStyleId(
     precinctOrSplit,
   });
 
+  function findBallotStyleInSingleGroup(): BallotStyleId {
+    assert(
+      ballotStyleGroups.length === 1,
+      'Expected exactly one ballot style group per precinct or split'
+    );
+    const ballotStyle = ballotStyleGroups[0].ballotStyles.find((bs) =>
+      assertDefined(bs.languages).includes(languageCode)
+    );
+    assert(ballotStyle, `No ballot style found for language ${languageCode}`);
+    return ballotStyle.id;
+  }
+
   switch (election.type) {
     case 'general': {
-      assert(
-        ballotStyleGroups.length === 1,
-        'General elections should have exactly one ballot style group per precinct or split'
-      );
-      const ballotStyle = ballotStyleGroups[0].ballotStyles.find((bs) =>
-        assertDefined(bs.languages).includes(languageCode)
-      );
-      assert(ballotStyle, `No ballot style found for language ${languageCode}`);
-      return ballotStyle.id;
+      return findBallotStyleInSingleGroup();
     }
     case 'primary': {
+      // In an open primary, ballots are consolidated (all parties' contests on
+      // one ballot), so there is no party selection and a single ballot style
+      // group per precinct or split, just like a general election.
+      if (isOpenPrimary(election)) {
+        return findBallotStyleInSingleGroup();
+      }
       assert(
         partyId !== undefined,
-        'partyId is required for primary elections'
+        'partyId is required for closed primary elections'
       );
       const ballotStyleGroup = ballotStyleGroups.find(
         (bsg) => bsg.partyId === partyId
@@ -139,7 +149,9 @@ export function addBallotsPropsToPrintCountRow(
   const languageCode = assertDefined(ballotStyle.languages)[0] as LanguageCode;
 
   let partyName: string | undefined;
-  if (election.type === 'primary') {
+  // In an open primary, consolidated ballot styles have no partyId, so there is
+  // no party name to display. Closed primaries are still expected to have one.
+  if (election.type === 'primary' && !isOpenPrimary(election)) {
     assert(ballotStyle.partyId !== undefined);
     const party = election.parties.find((p) => p.id === ballotStyle.partyId);
     assert(party, `No party found with id ${ballotStyle.partyId}`);

--- a/apps/print/frontend/src/screens/print_screen.tsx
+++ b/apps/print/frontend/src/screens/print_screen.tsx
@@ -11,6 +11,7 @@ import {
   BallotType,
   hasSplits,
   Id,
+  isOpenPrimary,
   LanguageCode,
   pollingPlaceFromElection,
   pollingPlacePrecinctIds,
@@ -185,7 +186,8 @@ export function PrintScreen({
 
   const parties = getPartyOptions(election);
   const { printer } = getDeviceStatusesQuery.data;
-  const hidePartySelection = election.type !== 'primary';
+  const hidePartySelection =
+    election.type !== 'primary' || isOpenPrimary(election);
 
   // If VxPrint is configured for a single precinct, hide the precinct
   // selection for Poll Workers and default to the configured precinct

--- a/libs/ui/src/reports/ballots_printed_report.test.tsx
+++ b/libs/ui/src/reports/ballots_printed_report.test.tsx
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest';
 import {
+  electionOpenPrimaryFixtures,
   electionPrimaryPrecinctSplitsFixtures,
   electionSimpleSinglePrecinctFixtures,
 } from '@votingworks/fixtures';
@@ -19,6 +20,8 @@ const electionDefinitionPrimary =
   electionPrimaryPrecinctSplitsFixtures.readElectionDefinition();
 const electionDefinitionSimple =
   electionSimpleSinglePrecinctFixtures.readElectionDefinition();
+const electionDefinitionOpenPrimary =
+  electionOpenPrimaryFixtures.readElectionDefinition();
 
 test('renders report with test mode banner', () => {
   render(
@@ -207,6 +210,44 @@ test('renders report for General Election with no parties, precincts, single lan
       })
     )
   ).not.toBeInTheDocument();
+  expect(screen.queryByText('Party')).not.toBeInTheDocument();
+});
+
+test('renders report for Open Primary Election without a party column', () => {
+  const { election } = electionDefinitionOpenPrimary;
+
+  const precinct = election.precincts[0];
+  const ballotStyleId = election.ballotStyles[0].id;
+
+  // In an open primary, consolidated ballot styles have no party, so rows have
+  // no partyName, just like a general election.
+  const ballotPrintCounts: BallotPrintCount[] = [
+    {
+      precinctId: precinct.id,
+      precinctOrSplitName: precinct.name,
+      ballotStyleId,
+      languageCode: LanguageCode.ENGLISH,
+      absenteeCount: 0,
+      precinctCount: 25,
+      totalCount: 25,
+    },
+  ];
+
+  render(
+    <BallotsPrintedReport
+      electionDefinition={electionDefinitionOpenPrimary}
+      electionPackageHash="test-election-package-hash"
+      generatedAtTime={new Date()}
+      printCounts={ballotPrintCounts}
+      isTestMode
+    />
+  );
+
+  screen.getByText(precinct.name);
+  // 25 appears in Precinct Count, Total Count, and in sum totals for both columns
+  expect(screen.getAllByText('25').length).toEqual(4);
+  screen.getByText('Sum Totals');
+  // The party column is not rendered for an open primary
   expect(screen.queryByText('Party')).not.toBeInTheDocument();
 });
 

--- a/libs/ui/src/reports/ballots_printed_report.tsx
+++ b/libs/ui/src/reports/ballots_printed_report.tsx
@@ -4,6 +4,7 @@ import {
   ElectionDefinition,
   hasSplits,
   BallotPrintCount,
+  isOpenPrimary,
 } from '@votingworks/types';
 import { format, getLanguageOptions } from '@votingworks/utils';
 import { assertDefined, throwIllegalValue } from '@votingworks/basics';
@@ -283,7 +284,10 @@ function BallotsPrintedTable({
     id: hasPrecinctSplits ? 'precinctSplitName' : 'precinctName',
   });
 
-  if (election.type === 'primary') {
+  // In an open primary, ballots are consolidated (all parties' contests on one
+  // ballot) with no party selection, so there is no party breakdown to show and
+  // the report behaves like a general election report.
+  if (election.type === 'primary' && !isOpenPrimary(election)) {
     columns.push({ type: 'attribute', id: 'party' });
   }
 


### PR DESCRIPTION
## Overview

Closes #8621.

In open primaries, ballots are consolidated so all parties' contests appear on a single ballot and ballot styles have no `partyId`. VxPrint keyed its primary logic on `election.type === 'primary'`, which caused it to render an empty Party selection and keep the Print button disabled forever; the backend print paths also asserted a `partyId` was present.

This uses the existing `isOpenPrimary()` detector to treat open primaries like general elections: no party selection, one ballot style per precinct/split/language.

It also fixes the **Ballots Printed Report**, which added a party column for every primary election and asserted each row had a party name. In an open primary, rows have no party name, so the report crashed while rendering. The party column is now gated on a closed primary (`election.type === 'primary' && !isOpenPrimary(election)`). The party-name assertion is intentionally kept to fail loudly for the non-real case of a fully-nonpartisan closed primary.

These changes are cherry-picked from the `mi-rfp-demo` work as part of upstreaming demo-branch changes onto `main`.

## Demo Video or Screenshot

_N/A_

## Testing Plan

- `apps/print/backend`: 19 tests pass (covers open-primary ballot style consolidation and the print paths that previously asserted a `partyId`).
- `libs/ui`: 7 Ballots Printed Report tests pass (covers open-primary rendering without a party column).
- Typecheck + lint green across `print-backend`, `print-frontend`, and `libs/ui`.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.