### PR TITLE
VxDesign: Store jurisdiction software version

### DIFF
--- a/apps/design/backend/migrations/1780954525182_jurisdiction-software-version.js
+++ b/apps/design/backend/migrations/1780954525182_jurisdiction-software-version.js
@@ -1,0 +1,20 @@
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  pgm.createType('software_version', ['v4.0', 'v4.1']);
+  pgm.addColumn('jurisdictions', {
+    software_version: {
+      type: 'software_version',
+    },
+  });
+  pgm.sql(`
+    UPDATE jurisdictions
+    SET software_version = 'v4.0'
+  `);
+  pgm.alterColumn('jurisdictions', 'software_version', {
+    notNull: true,
+  });
+};

--- a/apps/design/backend/scripts/README.md
+++ b/apps/design/backend/scripts/README.md
@@ -59,7 +59,7 @@ This will create a new jurisdiction and print out the new jurisdiction ID and
 name to the console:
 
 ```sh
-pnpm create-jurisdiction --organizationId="nfpn8pkbhr46" --stateCode="DEMO" "City of Vx"
+pnpm create-jurisdiction --organizationId="nfpn8pkbhr46" --stateCode="DEMO" --softwareVersion="v4.1" "City of Vx"
 ```
 
 ```sh
@@ -69,6 +69,7 @@ pnpm create-jurisdiction --organizationId="nfpn8pkbhr46" --stateCode="DEMO" "Cit
   id: 'TUPNZLFFyBgzxdeH',
   name: 'City of Vx',
   stateCode: 'DEMO',
+  softwareVersion: 'v4.1',
   organization: { id: 'nfpn8pkbhr46', name: 'VotingWorks' },
 }
 ```
@@ -87,12 +88,14 @@ pnpm list-jurisdictions
     id: 'TUPNZLFFyBgzxdeH',
     name: 'City of Vx',
     stateCode: 'DEMO',
+    softwareVersion: 'v4.1',
     organization: { id: 'nfpn8pkbhr46', name: 'VotingWorks' },
   },
   {
     id: 'Ug9eDziiLfqKelKi',
     name: 'VotingWorks',
     stateCode: 'DEMO',
+    softwareVersion: 'v4.1',
     organization: { id: 'nfpn8pkbhr46', name: 'VotingWorks' },
   },
 ]
@@ -147,6 +150,7 @@ pnpm list-user-jurisdictions "someone@example.com"
     id: 'TUPNZLFFyBgzxdeH',
     name: 'City of Vx',
     stateCode: 'DEMO',
+    softwareVersion: 'v4.1',
     organization: { id: 'nfpn8pkbhr46', name: 'VotingWorks' },
   }
 ]

--- a/apps/design/backend/scripts/create_jurisdiction.ts
+++ b/apps/design/backend/scripts/create_jurisdiction.ts
@@ -7,24 +7,29 @@ import { safeParse } from '@votingworks/types';
 import { createWorkspace } from '../src/workspace';
 import { WORKSPACE } from '../src/globals';
 import { generateId } from '../src/utils';
-import { Jurisdiction, StateCodeSchema } from '../src/types';
+import {
+  Jurisdiction,
+  SoftwareVersionSchema,
+  StateCodeSchema,
+} from '../src/types';
 
-const USAGE = `Usage: pnpm create-jurisdiction --organizationId=<organizationId> --stateCode=<stateCode> "<name>"`;
+const USAGE = `Usage: pnpm create-jurisdiction --organizationId=<organizationId> --stateCode=<stateCode> --softwareVersion=<softwareVersion> "<name>"`;
 
 async function main(): Promise<void> {
   loadEnvVarsFromDotenvFiles();
   const {
     positionals: [name],
-    values: { organizationId, stateCode },
+    values: { organizationId, stateCode, softwareVersion },
   } = util.parseArgs({
     allowPositionals: true,
     args: process.argv.slice(2),
     options: {
       organizationId: { type: 'string' },
       stateCode: { type: 'string' },
+      softwareVersion: { type: 'string' },
     },
   });
-  if (!(name && organizationId && stateCode)) {
+  if (!(name && organizationId && stateCode && softwareVersion)) {
     console.log(USAGE);
     process.exit(0);
   }
@@ -40,11 +45,17 @@ async function main(): Promise<void> {
     'Invalid state code'
   );
 
+  const softwareVersionParsed = safeParse(
+    SoftwareVersionSchema,
+    softwareVersion
+  ).assertOk('Invalid software version');
+
   const jurisdiction: Jurisdiction = {
     id: generateId(),
     name,
     stateCode: stateCodeParsed,
     organization,
+    softwareVersion: softwareVersionParsed,
   };
 
   await workspace.store.createJurisdiction(jurisdiction);

--- a/apps/design/backend/scripts/insert_dev_data.ts
+++ b/apps/design/backend/scripts/insert_dev_data.ts
@@ -5,7 +5,11 @@ import { BaseLogger, LogSource } from '@votingworks/logging';
 
 import { DEV_USER_ID } from '../src/auth0_client';
 import { NODE_ENV, votingWorksOrganizationId, WORKSPACE } from '../src/globals';
-import { Organization, StateCodes } from '../src/types';
+import {
+  LATEST_SOFTWARE_VERSION,
+  Organization,
+  StateCodes,
+} from '../src/types';
 import { createWorkspace } from '../src/workspace';
 
 /**
@@ -68,6 +72,7 @@ async function main(): Promise<void> {
         name: `Dev Jurisdiction - ${stateCode}`,
         stateCode,
         organization: votingWorksOrganization,
+        softwareVersion: LATEST_SOFTWARE_VERSION,
       };
       await workspace.store.createJurisdiction(jurisdictionWithStateCode);
       console.log(

--- a/apps/design/backend/src/convert_ms_election.test.ts
+++ b/apps/design/backend/src/convert_ms_election.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@votingworks/types';
 import { convertMsElection } from './convert_ms_election';
 import { TestStore } from '../test/test_store';
-import { Jurisdiction } from './types';
+import { Jurisdiction, LATEST_SOFTWARE_VERSION } from './types';
 import { readFixture } from '../test/helpers';
 import { vxOrganization } from '../test/mocks';
 import { defaultSystemSettings } from './system_settings';
@@ -19,6 +19,7 @@ const jurisdiction: Jurisdiction = {
   id: 'test-jurisdiction-id',
   name: 'Test Jurisdiction',
   stateCode: 'MS',
+  softwareVersion: LATEST_SOFTWARE_VERSION,
   organization: vxOrganization,
 };
 

--- a/apps/design/backend/src/store.test.ts
+++ b/apps/design/backend/src/store.test.ts
@@ -37,6 +37,7 @@ import {
   users,
   vxJurisdiction,
 } from '../test/mocks';
+import { LATEST_SOFTWARE_VERSION } from './types';
 
 const logger = mockBaseLogger({ fn: vi.fn });
 const testStore = new TestStore(logger);
@@ -414,6 +415,7 @@ describe('tts_strings', () => {
         id,
         name: id,
         stateCode: 'DEMO',
+        softwareVersion: LATEST_SOFTWARE_VERSION,
         organization: nonVxOrganization,
       });
     }

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -84,6 +84,7 @@ import {
   User,
   UserType,
   ElectionStatus,
+  SoftwareVersion,
 } from './types';
 import { Db } from './db/db';
 import { Bindable, Client } from './db/client';
@@ -530,6 +531,7 @@ const selectJurisdictionsBaseQuery = `
     jurisdictions.id,
     jurisdictions.name,
     state_code as "stateCode",
+    software_version as "softwareVersion",
     organizations.id as "organizationId",
     organizations.name as "organizationName"
   from jurisdictions
@@ -540,6 +542,7 @@ interface JurisdictionRow {
   id: string;
   name: string;
   stateCode: StateCode;
+  softwareVersion: SoftwareVersion;
   organizationId: string;
   organizationName: string;
 }
@@ -549,6 +552,7 @@ function rowToJurisdiction(row: JurisdictionRow): Jurisdiction {
     id: row.id,
     name: row.name,
     stateCode: row.stateCode,
+    softwareVersion: row.softwareVersion,
     organization: {
       id: row.organizationId,
       name: row.organizationName,
@@ -635,12 +639,13 @@ export class Store {
     await this.db.withClient(async (client) => {
       await client.query(
         `
-        insert into jurisdictions (id, name, state_code, organization_id)
-        values ($1, $2, $3, $4)
+        insert into jurisdictions (id, name, state_code, software_version, organization_id)
+        values ($1, $2, $3, $4, $5)
         `,
         jurisdiction.id,
         jurisdiction.name,
         jurisdiction.stateCode,
+        jurisdiction.softwareVersion,
         jurisdiction.organization.id
       );
     });

--- a/apps/design/backend/src/types.ts
+++ b/apps/design/backend/src/types.ts
@@ -16,6 +16,13 @@ export const StateCodes = ['DEMO', 'MI', 'MS', 'NH'] as const;
 export type StateCode = (typeof StateCodes)[number];
 export const StateCodeSchema: z.ZodType<StateCode> = z.enum(StateCodes);
 
+export const SoftwareVersions = ['v4.0', 'v4.1'] as const;
+export const LATEST_SOFTWARE_VERSION =
+  SoftwareVersions[SoftwareVersions.length - 1];
+export type SoftwareVersion = (typeof SoftwareVersions)[number];
+export const SoftwareVersionSchema: z.ZodType<SoftwareVersion> =
+  z.enum(SoftwareVersions);
+
 export interface Organization {
   id: string;
   name: string;
@@ -25,6 +32,7 @@ export interface Jurisdiction {
   id: string;
   name: string;
   stateCode: StateCode;
+  softwareVersion: SoftwareVersion;
   organization: Organization;
 }
 

--- a/apps/design/backend/test/mocks.ts
+++ b/apps/design/backend/test/mocks.ts
@@ -5,6 +5,7 @@ import {
   Organization,
   User,
   SupportUser,
+  LATEST_SOFTWARE_VERSION,
 } from '../src/types';
 import { votingWorksOrganizationId, sliOrganizationId } from '../src/globals';
 
@@ -25,6 +26,7 @@ export const vxJurisdiction: Jurisdiction = {
   id: 'vx-jurisdiction-id',
   name: 'VotingWorks',
   stateCode: 'DEMO',
+  softwareVersion: LATEST_SOFTWARE_VERSION,
   organization: vxOrganization,
 };
 export const vxUser: JurisdictionUser = {
@@ -39,12 +41,14 @@ export const nonVxJurisdiction: Jurisdiction = {
   id: 'other-jurisdiction-id',
   name: 'Other Jurisdiction',
   stateCode: 'DEMO',
+  softwareVersion: LATEST_SOFTWARE_VERSION,
   organization: nonVxOrganization,
 };
 export const nhJurisdiction: Jurisdiction = {
   id: 'nh-jurisdiction-id',
   name: 'New Hampshire Jurisdiction',
   stateCode: 'NH',
+  softwareVersion: LATEST_SOFTWARE_VERSION,
   organization: nonVxOrganization,
 };
 export const nonVxUser: JurisdictionUser = {
@@ -59,18 +63,21 @@ export const anotherNonVxJurisdiction: Jurisdiction = {
   id: 'another-jurisdiction-id',
   name: 'Another Jurisdiction',
   stateCode: 'DEMO',
+  softwareVersion: LATEST_SOFTWARE_VERSION,
   organization: nonVxOrganization,
 };
 export const msJurisdiction: Jurisdiction = {
   id: 'ms-jurisdiction-id',
   name: 'Mississippi Jurisdiction',
   stateCode: 'MS',
+  softwareVersion: LATEST_SOFTWARE_VERSION,
   organization: nonVxOrganization,
 };
 export const miJurisdiction: Jurisdiction = {
   id: 'mi-jurisdiction-id',
   name: 'Michigan Jurisdiction',
   stateCode: 'MI',
+  softwareVersion: LATEST_SOFTWARE_VERSION,
   organization: nonVxOrganization,
 };
 export const anotherNonVxUser: JurisdictionUser = {
@@ -90,6 +97,7 @@ export const sliJurisdiction: Jurisdiction = {
   id: 'sli-jurisdiction-id',
   name: 'SLI',
   stateCode: 'DEMO',
+  softwareVersion: LATEST_SOFTWARE_VERSION,
   organization: sliOrganization,
 };
 export const sliUser: JurisdictionUser = {

--- a/apps/design/frontend/src/load_election_button.test.tsx
+++ b/apps/design/frontend/src/load_election_button.test.tsx
@@ -60,6 +60,7 @@ const msJurisdiction: Jurisdiction = {
   id: 'ms-jurisdiction-1',
   name: 'Mississippi Jurisdiction',
   stateCode: 'MS',
+  softwareVersion: 'v4.1',
   organization,
 };
 

--- a/apps/design/frontend/test/api_helpers.tsx
+++ b/apps/design/frontend/test/api_helpers.tsx
@@ -89,6 +89,7 @@ export const jurisdiction: Jurisdiction = {
   id: 'jurisdiction1',
   name: 'Test Jurisdiction',
   stateCode: 'DEMO',
+  softwareVersion: 'v4.1',
   organization,
 };
 
@@ -96,6 +97,7 @@ export const jurisdiction2: Jurisdiction = {
   id: 'jurisdiction2',
   name: 'Another Jurisdiction',
   stateCode: 'NH',
+  softwareVersion: 'v4.1',
   organization,
 };
 


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->
[Spec](https://votingworks.slack.com/docs/TE6RHHERY/F0ASRLZU17H)
Adds a field to store the software version currently deployed for a given jurisdiction. This will allow us to tailor the exported election package to jurisdictions still using v4.0 after we making breaking changes for v4.1.

Currently, software version can only be set on jurisdiction creation, though I expect we will need to add a way to edit soon (just starting with the minimum known functionality for now).

## Demo Video or Screenshot
N/A

## Testing Plan
- Updated existing tests
- Manually tested create-jurisdiction script
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
