### PR TITLE
[libs/logging] [Polling Places] Replace old precinct selection event ID

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ pnpm-lock.yaml
 .github/pull_request_template.md
 libs/logging-utils/index.d.ts
 libs/logging-utils/index.js
+libs/logging/VotingWorksLoggingDocumentation.md

--- a/apps/mark-scan/backend/src/app.test.ts
+++ b/apps/mark-scan/backend/src/app.test.ts
@@ -477,7 +477,7 @@ test('setting precinct', async () => {
     precinctSelection: singlePrecinctSelection,
   });
   expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
-    LogEventId.PrecinctConfigurationChanged,
+    LogEventId.PollingPlaceChanged,
     {
       disposition: 'success',
       message: 'User set the precinct for the machine to North Lincoln',
@@ -499,7 +499,7 @@ test('set polling place', async () => {
   await expectElectionState({ pollingPlaceId: place.id });
 
   expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
-    LogEventId.PrecinctConfigurationChanged,
+    LogEventId.PollingPlaceChanged,
     {
       disposition: 'success',
       message: `User set the polling place for the machine to ${place.name}`,

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -407,7 +407,7 @@ export function buildApi(
     }): Promise<void> {
       const { electionDefinition } = assertDefined(store.getElectionRecord());
       store.setPrecinctSelection(input.precinctSelection);
-      await logger.logAsCurrentRole(LogEventId.PrecinctConfigurationChanged, {
+      await logger.logAsCurrentRole(LogEventId.PollingPlaceChanged, {
         disposition: 'success',
         message: `User set the precinct for the machine to ${getPrecinctSelectionName(
           electionDefinition.election.precincts,
@@ -428,7 +428,7 @@ export function buildApi(
       store.setPollingPlaceId(input.id);
       store.setBallotsPrintedCount(0);
 
-      void logger.logAsCurrentRole(LogEventId.PrecinctConfigurationChanged, {
+      void logger.logAsCurrentRole(LogEventId.PollingPlaceChanged, {
         disposition: 'success',
         message: `User set the polling place for the machine to ${name}`,
       });

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -504,7 +504,7 @@ test('setting precinct', async () => {
     precinctSelection: singlePrecinctSelection,
   });
   expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
-    LogEventId.PrecinctConfigurationChanged,
+    LogEventId.PollingPlaceChanged,
     {
       disposition: 'success',
       message: 'User set the precinct for the machine to North Lincoln',
@@ -526,7 +526,7 @@ test('set polling place', async () => {
   await expectElectionState({ pollingPlaceId: place.id });
 
   expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
-    LogEventId.PrecinctConfigurationChanged,
+    LogEventId.PollingPlaceChanged,
     {
       disposition: 'success',
       message: `User set the polling place for the machine to ${place.name}`,

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -340,7 +340,7 @@ export function buildApi(ctx: Context) {
       const { electionDefinition } = assertDefined(store.getElectionRecord());
       store.setPrecinctSelection(input.precinctSelection);
       store.setBallotsPrintedCount(0);
-      await logger.logAsCurrentRole(LogEventId.PrecinctConfigurationChanged, {
+      await logger.logAsCurrentRole(LogEventId.PollingPlaceChanged, {
         disposition: 'success',
         message: `User set the precinct for the machine to ${getPrecinctSelectionName(
           electionDefinition.election.precincts,
@@ -361,7 +361,7 @@ export function buildApi(ctx: Context) {
       store.setPollingPlaceId(input.id);
       store.setBallotsPrintedCount(0);
 
-      void logger.logAsCurrentRole(LogEventId.PrecinctConfigurationChanged, {
+      void logger.logAsCurrentRole(LogEventId.PollingPlaceChanged, {
         disposition: 'success',
         message: `User set the polling place for the machine to ${name}`,
       });

--- a/apps/print/backend/src/app.test.ts
+++ b/apps/print/backend/src/app.test.ts
@@ -367,7 +367,7 @@ test('setting precinct', async () => {
     singlePrecinctSelection
   );
   expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
-    LogEventId.PrecinctConfigurationChanged,
+    LogEventId.PollingPlaceChanged,
     expect.objectContaining({
       disposition: 'success',
       message: expect.stringContaining('User set the precinct for the machine'),
@@ -400,7 +400,7 @@ test('set polling place', async () => {
   expect(await apiClient.getPollingPlaceId()).toEqual(place.id);
 
   expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
-    LogEventId.PrecinctConfigurationChanged,
+    LogEventId.PollingPlaceChanged,
     {
       disposition: 'success',
       message: `User set the polling place for the machine to ${place.name}`,

--- a/apps/print/backend/src/app.ts
+++ b/apps/print/backend/src/app.ts
@@ -175,7 +175,7 @@ export function buildApi(ctx: AppContext) {
     }): Promise<void> {
       const { electionDefinition } = assertDefined(store.getElectionRecord());
       store.setPrecinctSelection(input.precinctSelection);
-      await logger.logAsCurrentRole(LogEventId.PrecinctConfigurationChanged, {
+      await logger.logAsCurrentRole(LogEventId.PollingPlaceChanged, {
         disposition: 'success',
         message: `User set the precinct for the machine to ${getPrecinctSelectionName(
           electionDefinition.election.precincts,
@@ -199,7 +199,7 @@ export function buildApi(ctx: AppContext) {
 
       store.setPollingPlaceId(input.id);
 
-      void logger.logAsCurrentRole(LogEventId.PrecinctConfigurationChanged, {
+      void logger.logAsCurrentRole(LogEventId.PollingPlaceChanged, {
         disposition: 'success',
         message: `User set the polling place for the machine to ${name}`,
       });

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -295,7 +295,7 @@ export function buildApi({
       );
       store.setPrecinctSelection(input.precinctSelection);
       workspace.resetElectionSession();
-      await logger.logAsCurrentRole(LogEventId.PrecinctConfigurationChanged, {
+      await logger.logAsCurrentRole(LogEventId.PollingPlaceChanged, {
         disposition: 'success',
         message: `User set the precinct for the machine to ${getPrecinctSelectionName(
           electionDefinition.election.precincts,
@@ -324,7 +324,7 @@ export function buildApi({
       store.setPollingPlaceId(input.id);
       workspace.resetElectionSession();
 
-      void logger.logAsCurrentRole(LogEventId.PrecinctConfigurationChanged, {
+      void logger.logAsCurrentRole(LogEventId.PollingPlaceChanged, {
         disposition: 'success',
         message: `User set the polling place for the machine to ${name}`,
       });

--- a/apps/scan/backend/src/app_config.test.ts
+++ b/apps/scan/backend/src/app_config.test.ts
@@ -203,7 +203,7 @@ test('setPrecinctSelection will reset polls to closed', async () => {
       pollsState: 'polls_closed_initial',
     });
     expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
-      LogEventId.PrecinctConfigurationChanged,
+      LogEventId.PollingPlaceChanged,
       {
         disposition: 'success',
         message: 'User set the precinct for the machine to East Lincoln',
@@ -235,7 +235,7 @@ test('setPollingPlaceId will reset polls to closed', async () => {
       pollsState: 'polls_closed_initial',
     });
     expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
-      LogEventId.PrecinctConfigurationChanged,
+      LogEventId.PollingPlaceChanged,
       {
         disposition: 'success',
         message: `User set the polling place for the machine to ${place.name}`,

--- a/libs/logging/.eslintignore
+++ b/libs/logging/.eslintignore
@@ -1,3 +1,4 @@
 build
 coverage
 vitest.config.ts
+*.md

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -450,9 +450,9 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)
 **Description:** Poll worker confirmed that they emptied the ballot box.
 **Machines:** vx-mark-scan
-### precinct-configuration-changed
+### polling-place-changed
 **Type:** [user-action](#user-action)
-**Description:** User has changed the precinct setting.
+**Description:** User has changed the polling place setting.
 **Machines:** vx-mark, vx-scan, vx-mark-scan
 ### scanner-batch-started
 **Type:** [system-action](#system-action)

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -746,10 +746,10 @@ eventType = "user-action"
 documentationMessage = "Poll worker confirmed that they emptied the ballot box."
 restrictInDocumentationToApps = ["vx-mark-scan"]
 
-[Events.PrecinctConfigurationChanged]
-eventId = "precinct-configuration-changed"
+[Events.PollingPlaceChanged]
+eventId = "polling-place-changed"
 eventType = "user-action"
-documentationMessage = "User has changed the precinct setting."
+documentationMessage = "User has changed the polling place setting."
 restrictInDocumentationToApps = ["vx-mark", "vx-scan", "vx-mark-scan"]
 
 # VxScan specific logs

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -175,7 +175,7 @@ export enum LogEventId {
   PollsClosed = 'polls-closed',
   ResetPollsToPaused = 'reset-polls-to-paused',
   BallotBoxEmptied = 'ballot-box-emptied',
-  PrecinctConfigurationChanged = 'precinct-configuration-changed',
+  PollingPlaceChanged = 'polling-place-changed',
   ScannerBatchStarted = 'scanner-batch-started',
   ScannerBatchEnded = 'scanner-batch-ended',
   ScannerEvent = 'scanner-state-machine-event',
@@ -1046,10 +1046,10 @@ const BallotBoxEmptied: LogDetails = {
   restrictInDocumentationToApps: [AppName.VxMarkScan],
 };
 
-const PrecinctConfigurationChanged: LogDetails = {
-  eventId: LogEventId.PrecinctConfigurationChanged,
+const PollingPlaceChanged: LogDetails = {
+  eventId: LogEventId.PollingPlaceChanged,
   eventType: LogEventType.UserAction,
-  documentationMessage: 'User has changed the precinct setting.',
+  documentationMessage: 'User has changed the polling place setting.',
   restrictInDocumentationToApps: [
     AppName.VxMark,
     AppName.VxScan,
@@ -1741,8 +1741,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return ResetPollsToPaused;
     case LogEventId.BallotBoxEmptied:
       return BallotBoxEmptied;
-    case LogEventId.PrecinctConfigurationChanged:
-      return PrecinctConfigurationChanged;
+    case LogEventId.PollingPlaceChanged:
+      return PollingPlaceChanged;
     case LogEventId.ScannerBatchStarted:
       return ScannerBatchStarted;
     case LogEventId.ScannerBatchEnded:

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -333,8 +333,8 @@ pub enum EventId {
     ResetPollsToPaused,
     #[serde(rename = "ballot-box-emptied")]
     BallotBoxEmptied,
-    #[serde(rename = "precinct-configuration-changed")]
-    PrecinctConfigurationChanged,
+    #[serde(rename = "polling-place-changed")]
+    PollingPlaceChanged,
     #[serde(rename = "scanner-batch-started")]
     ScannerBatchStarted,
     #[serde(rename = "scanner-batch-ended")]


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/8381

Replacing the `PrecinctConfigurationChanged` event ID with `PollingPlaceChanged` to reflect the new polling-place-based configuration flow, now that the polling places feature is turned on by default.

The old code paths that log with a precinct-specific message will be removed up eventually in upcoming cleanup.

## Demo Video or Screenshot
N/A

## Testing Plan
- Existing test references updated

