### PR TITLE
Clean up dead getBallotAdjudicationData code

### DIFF
--- a/apps/admin/backend/src/app.adjudication.test.ts
+++ b/apps/admin/backend/src/app.adjudication.test.ts
@@ -623,8 +623,9 @@ test('getNextCvrIdForBallotAdjudication', async () => {
 
   async function adjudicateAtIndex(index: number) {
     const cvrId = adjudicationQueue[index] || '';
-    (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap();
-    const adjData = await apiClient.getBallotAdjudicationData({ cvrId });
+    const { data: adjData } = assertDefined(
+      (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap()
+    );
     const contests = adjData.contests
       .filter((contest) => contest.tag)
       .map((contest) => ({
@@ -913,7 +914,9 @@ test('handling unmarked write-ins', async () => {
   let cvrId: string | undefined;
   let adjData: BallotAdjudicationData | undefined;
   for (const id of adjudicationQueue) {
-    const data = await apiClient.getBallotAdjudicationData({ cvrId: id });
+    const { data } = assertDefined(
+      (await apiClient.claimAndLoadBallot({ cvrId: id })).unsafeUnwrap()
+    );
     const contest = data.contests.find(
       (c) => c.contestId === WRITE_IN_CONTEST_ID
     );
@@ -1023,7 +1026,9 @@ test('handling unmarked write-ins', async () => {
     },
   });
 
-  const adjDataAfter = await apiClient.getBallotAdjudicationData({ cvrId });
+  const adjDataAfter = assertDefined(
+    (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap()
+  ).data;
   const contestDataAfter = find(
     adjDataAfter.contests,
     (c) => c.contestId === WRITE_IN_CONTEST_ID
@@ -1058,7 +1063,9 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
   // find a CVR that has a write-in record for the Governor contest
   let maybeCvrId: string | undefined;
   for (const id of cvrIds) {
-    const data = await apiClient.getBallotAdjudicationData({ cvrId: id });
+    const { data } = assertDefined(
+      (await apiClient.claimAndLoadBallot({ cvrId: id })).unsafeUnwrap()
+    );
     const contest = data.contests.find((c) => c.contestId === contestId);
     const option = contest?.options.find(
       (o) => o.definition.id === 'write-in-0'
@@ -1070,7 +1077,9 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
   }
   const cvrId = assertDefined(maybeCvrId);
 
-  const initialAdjData = await apiClient.getBallotAdjudicationData({ cvrId });
+  const initialAdjData = assertDefined(
+    (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap()
+  ).data;
   const initialContestData = find(
     initialAdjData.contests,
     (c) => c.contestId === contestId
@@ -1191,9 +1200,9 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
     })
   ).toEqual(ok());
 
-  const adjDataAfterInvalid = await apiClient.getBallotAdjudicationData({
-    cvrId,
-  });
+  const adjDataAfterInvalid = assertDefined(
+    (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap()
+  ).data;
   const contestDataAfterInvalid = find(
     adjDataAfterInvalid.contests,
     (c) => c.contestId === contestId
@@ -1267,9 +1276,9 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
       ],
     })
   ).toEqual(ok());
-  const adjDataAfterOfficial = await apiClient.getBallotAdjudicationData({
-    cvrId,
-  });
+  const adjDataAfterOfficial = assertDefined(
+    (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap()
+  ).data;
   const officialWriteInOption = find(
     find(adjDataAfterOfficial.contests, (c) => c.contestId === contestId)
       .options,
@@ -1336,9 +1345,9 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
       ],
     })
   ).toEqual(ok());
-  const adjDataAfterWriteIn = await apiClient.getBallotAdjudicationData({
-    cvrId,
-  });
+  const adjDataAfterWriteIn = assertDefined(
+    (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap()
+  ).data;
   const writeInCandidateOption = find(
     find(adjDataAfterWriteIn.contests, (c) => c.contestId === contestId)
       .options,
@@ -1403,9 +1412,9 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
       ],
     })
   ).toEqual(ok());
-  const adjDataAfterCircleBack = await apiClient.getBallotAdjudicationData({
-    cvrId,
-  });
+  const adjDataAfterCircleBack = assertDefined(
+    (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap()
+  ).data;
   const circleBackOption = find(
     find(adjDataAfterCircleBack.contests, (c) => c.contestId === contestId)
       .options,
@@ -1478,12 +1487,16 @@ test('peer API: claim, adjudicate, and resolve a ballot with real CVR fixtures',
   const metadataBefore = await apiClient.getBallotAdjudicationQueueMetadata();
   expect(metadataBefore.pendingTally).toEqual(metadataBefore.totalTally);
 
-  // Two clients claim different ballots
-  const cvrId1 = await claimBallot(peerApiClient, {
-    machineId: 'client-001',
-  });
-  assert(cvrId1 !== undefined);
+  // Two clients claim different ballots. Claiming returns the claimed ballot's
+  // adjudication data, mirroring the real client flow.
+  const client1Claim = assertDefined(
+    await peerApiClient.claimAndLoadBallot({ machineId: 'client-001' })
+  );
+  const cvrId1 = client1Claim.cvrId;
+  const ballotData = client1Claim.data;
   expect(cvrId1).toEqual(queue[0]);
+  expect(ballotData.cvrId).toEqual(cvrId1);
+  expect(ballotData.contests.length).toBeGreaterThan(0);
 
   const cvrId2 = await claimBallot(peerApiClient, {
     machineId: 'client-002',
@@ -1491,13 +1504,6 @@ test('peer API: claim, adjudicate, and resolve a ballot with real CVR fixtures',
   assert(cvrId2 !== undefined);
   expect(cvrId2).toEqual(queue[1]);
   expect(cvrId2).not.toEqual(cvrId1);
-
-  // Client 1 fetches ballot data via peer API
-  const ballotData = await peerApiClient.getBallotAdjudicationData({
-    cvrId: cvrId1,
-  });
-  expect(ballotData.cvrId).toEqual(cvrId1);
-  expect(ballotData.contests.length).toBeGreaterThan(0);
 
   // Client 1 fetches ballot image metadata via peer API
   const images = await peerApiClient.getBallotImageMetadata({ cvrId: cvrId1 });
@@ -1538,9 +1544,9 @@ test('peer API: claim, adjudicate, and resolve a ballot with real CVR fixtures',
   ).toEqual(ok());
 
   // Host can see the adjudication results: ballot data shows all contests resolved
-  const hostBallotData = await apiClient.getBallotAdjudicationData({
-    cvrId: cvrId1,
-  });
+  const hostBallotData = assertDefined(
+    (await apiClient.claimAndLoadBallot({ cvrId: cvrId1 })).unsafeUnwrap()
+  ).data;
   const adjudicatedContestIds = new Set(
     hostBallotData.adjudicatedContests.map((c) => c.contestId)
   );
@@ -1707,7 +1713,9 @@ test('qualified write-in mode: full flow with adjudication, tally reports, and c
   const cvrIds = await apiClient.getBallotAdjudicationQueue();
   let maybeCvrId: string | undefined;
   for (const id of cvrIds) {
-    const data = await apiClient.getBallotAdjudicationData({ cvrId: id });
+    const { data } = assertDefined(
+      (await apiClient.claimAndLoadBallot({ cvrId: id })).unsafeUnwrap()
+    );
     const contest = data.contests.find((c) => c.contestId === contestId);
     const option = contest?.options.find(
       (o) => o.definition.id === 'write-in-0'
@@ -1893,7 +1901,9 @@ test('deleting a qualified write-in candidate preserves adjudicated votes on unr
   const cvrIds = await apiClient.getBallotAdjudicationQueue();
   let maybeCvrId: string | undefined;
   for (const id of cvrIds) {
-    const data = await apiClient.getBallotAdjudicationData({ cvrId: id });
+    const { data } = assertDefined(
+      (await apiClient.claimAndLoadBallot({ cvrId: id })).unsafeUnwrap()
+    );
     if (
       data.contests
         .find((c) => c.contestId === governorContestId)
@@ -1913,7 +1923,9 @@ test('deleting a qualified write-in candidate preserves adjudicated votes on unr
   // Also adjudicate a different contest on the same CVR, flipping an option
   // so the change is observable. This puts a second entry into the CVR's
   // adjudicated_votes JSON alongside the Governor entry.
-  const adjData = await apiClient.getBallotAdjudicationData({ cvrId });
+  const adjData = assertDefined(
+    (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap()
+  ).data;
   const otherContest = assertDefined(
     adjData.contests.find((c) => c.contestId !== governorContestId)
   );
@@ -1962,7 +1974,9 @@ test('deleting a qualified write-in candidate preserves adjudicated votes on unr
   ).toEqual(1);
 
   // The unrelated contest's flipped vote should still be adjudicated.
-  const dataAfterDelete = await apiClient.getBallotAdjudicationData({ cvrId });
+  const dataAfterDelete = assertDefined(
+    (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap()
+  ).data;
   const adjudicatedOtherContest = assertDefined(
     dataAfterDelete.adjudicatedContests.find(
       (c) => c.contestId === otherContest.contestId
@@ -1996,19 +2010,21 @@ test('open primary crossover votes', async () => {
   expect(queue).toContain(resolvedCrossoverCvrId);
   expect(queue).toContain(unresolvedCrossoverCvrId);
   expect(
-    (
-      await apiClient.getBallotAdjudicationData({
-        cvrId: unresolvedCrossoverCvrId,
-      })
-    ).tag
+    assertDefined(
+      (
+        await apiClient.claimAndLoadBallot({
+          cvrId: unresolvedCrossoverCvrId,
+        })
+      ).unsafeUnwrap()
+    ).data.tag
   ).toEqual({ isBlankBallot: false, hasCrossoverVote: true });
   // Even after resolution, original adjudication flag is still preserved
   expect(
-    (
-      await apiClient.getBallotAdjudicationData({
-        cvrId: resolvedCrossoverCvrId,
-      })
-    ).tag
+    assertDefined(
+      (
+        await apiClient.claimAndLoadBallot({ cvrId: resolvedCrossoverCvrId })
+      ).unsafeUnwrap()
+    ).data.tag
   ).toEqual({ isBlankBallot: false, hasCrossoverVote: true });
 
   const images = await apiClient.getBallotImages({

--- a/apps/admin/backend/src/app.caching.test.ts
+++ b/apps/admin/backend/src/app.caching.test.ts
@@ -2,7 +2,7 @@ import { expect, MockInstance, test, vi } from 'vitest';
 import { electionGridLayoutNewHampshireTestBallotFixtures } from '@votingworks/fixtures';
 import { Client } from '@votingworks/grout';
 import { readFileSync } from 'node:fs';
-import { assert, ok } from '@votingworks/basics';
+import { assert, assertDefined, ok } from '@votingworks/basics';
 import { modifyCastVoteRecordExport } from '@votingworks/backend';
 import {
   BooleanEnvironmentVariableName,
@@ -132,7 +132,9 @@ test('uses and clears CVR tabulation cache appropriately', async () => {
   let cvrId: string | undefined;
   let writeIn: { optionId: string } | undefined;
   for (const id of queue) {
-    const adjData = await apiClient.getBallotAdjudicationData({ cvrId: id });
+    const adjData = assertDefined(
+      (await apiClient.claimAndLoadBallot({ cvrId: id })).unsafeUnwrap()
+    ).data;
     const contestData = adjData.contests.find((c) => c.contestId === contestId);
     const option = contestData?.options.find(
       (o) => o.writeInRecord !== undefined

--- a/apps/admin/backend/src/app.err_cdf_export.test.ts
+++ b/apps/admin/backend/src/app.err_cdf_export.test.ts
@@ -168,7 +168,9 @@ test('exports results and metadata accurately', async () => {
   const queue = await apiClient.getBallotAdjudicationQueue();
   for (const cvrId of queue) {
     if (writeInRecords.length >= 2) break;
-    const adjData = await apiClient.getBallotAdjudicationData({ cvrId });
+    const adjData = assertDefined(
+      (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap()
+    ).data;
     const contest = adjData.contests.find(
       (c) => c.contestId === candidateContestId
     );

--- a/apps/admin/backend/src/app.tally_report_csv.test.ts
+++ b/apps/admin/backend/src/app.tally_report_csv.test.ts
@@ -474,7 +474,9 @@ test('incorporates wia and manual data (grouping by voting method)', async () =>
   });
   const queue = await apiClient.getBallotAdjudicationQueue();
   for (const cvrId of queue) {
-    const adjData = await apiClient.getBallotAdjudicationData({ cvrId });
+    const adjData = assertDefined(
+      (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap()
+    ).data;
     const contest = adjData.contests.find(
       (c) => c.contestId === candidateContestId
     );

--- a/apps/admin/backend/src/app.tally_report_data.test.ts
+++ b/apps/admin/backend/src/app.tally_report_data.test.ts
@@ -10,7 +10,7 @@ import {
   buildManualResultsFixture,
   getFeatureFlagMock,
 } from '@votingworks/utils';
-import { assert, find, ok } from '@votingworks/basics';
+import { assert, assertDefined, find, ok } from '@votingworks/basics';
 import {
   BallotStyleGroupId,
   DEV_MACHINE_ID,
@@ -125,7 +125,9 @@ test('general, full election, write in adjudication', async () => {
   }> = [];
   const queue = await apiClient.getBallotAdjudicationQueue();
   for (const cvrId of queue) {
-    const adjData = await apiClient.getBallotAdjudicationData({ cvrId });
+    const adjData = assertDefined(
+      (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap()
+    ).data;
     const contest = adjData.contests.find(
       (c) => c.contestId === writeInContestId
     );
@@ -948,7 +950,9 @@ test('primary, partial write-in adjudication uses correct unadjudicated label', 
   const queue = await apiClient.getBallotAdjudicationQueue();
   const writeIns: Array<{ cvrId: string; optionId: string }> = [];
   for (const cvrId of queue) {
-    const adjData = await apiClient.getBallotAdjudicationData({ cvrId });
+    const adjData = assertDefined(
+      (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap()
+    ).data;
     const contest = adjData.contests.find(
       (c) => c.contestId === writeInContestId
     );

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -901,13 +901,6 @@ function buildApi({
       );
     },
 
-    getBallotAdjudicationData(input: { cvrId: Id }): BallotAdjudicationData {
-      return store.getBallotAdjudicationData({
-        electionId: loadCurrentElectionIdOrThrow(workspace),
-        cvrId: input.cvrId,
-      });
-    },
-
     getBallotImages(input: { cvrId: Id }): Promise<BallotImages> {
       return getBallotImages({
         store: workspace.store,

--- a/apps/admin/backend/src/app.write_in_adjudication_report_pdf.test.ts
+++ b/apps/admin/backend/src/app.write_in_adjudication_report_pdf.test.ts
@@ -10,7 +10,7 @@ import {
   getFeatureFlagMock,
 } from '@votingworks/utils';
 import { HP_LASER_PRINTER_CONFIG, renderToPdf } from '@votingworks/printing';
-import { assert, err, ok } from '@votingworks/basics';
+import { assert, assertDefined, err, ok } from '@votingworks/basics';
 import { LogEventId } from '@votingworks/logging';
 import {
   buildTestEnvironment,
@@ -132,7 +132,9 @@ test('write-in adjudication report', async () => {
   }> = [];
   const queue = await apiClient.getBallotAdjudicationQueue();
   for (const cvrId of queue) {
-    const adjData = await apiClient.getBallotAdjudicationData({ cvrId });
+    const adjData = assertDefined(
+      (await apiClient.claimAndLoadBallot({ cvrId })).unsafeUnwrap()
+    ).data;
     const contest = adjData.contests.find(
       (c) => c.contestId === writeInContestId
     );

--- a/apps/admin/backend/src/client_app.test.ts
+++ b/apps/admin/backend/src/client_app.test.ts
@@ -286,7 +286,6 @@ test('getBatteryInfo returns battery info', async () => {
 interface MockPeerApi {
   claimAndLoadBallot: ReturnType<typeof vi.fn>;
   releaseBallot: ReturnType<typeof vi.fn>;
-  getBallotAdjudicationData: ReturnType<typeof vi.fn>;
   getBallotImageMetadata: ReturnType<typeof vi.fn>;
   getWriteInCandidates: ReturnType<typeof vi.fn>;
   adjudicateCvr: ReturnType<typeof vi.fn>;
@@ -296,7 +295,6 @@ function connectToMockHost(): { mockPeerApi: MockPeerApi } {
   const mockPeerApi: MockPeerApi = {
     claimAndLoadBallot: vi.fn(),
     releaseBallot: vi.fn(),
-    getBallotAdjudicationData: vi.fn(),
     getBallotImageMetadata: vi.fn(),
     getWriteInCandidates: vi.fn(),
     adjudicateCvr: vi.fn(),
@@ -348,9 +346,6 @@ test('proxy endpoints return host-disconnect error when not connected', async ()
   expect(await env.apiClient.releaseBallot({ cvrId: 'cvr-1' })).toEqual(
     err({ type: 'host-disconnect' })
   );
-  expect(
-    await env.apiClient.getBallotAdjudicationData({ cvrId: 'cvr-1' })
-  ).toEqual(err({ type: 'host-disconnect' }));
   expect(await env.apiClient.getBallotImages({ cvrId: 'cvr-1' })).toEqual(
     err({ type: 'host-disconnect' })
   );
@@ -408,17 +403,6 @@ test('releaseBallot proxies to host peer API', async () => {
   expect(mockPeerApi.releaseBallot).toHaveBeenCalledWith(
     expect.objectContaining({ cvrId: 'cvr-1' })
   );
-});
-
-test('getBallotAdjudicationData proxies to host peer API', async () => {
-  const { mockPeerApi } = connectToMockHost();
-  const mockData = { cvrId: 'cvr-1', contests: [] } as const;
-  mockPeerApi.getBallotAdjudicationData.mockResolvedValue(mockData);
-
-  const result = await env.apiClient.getBallotAdjudicationData({
-    cvrId: 'cvr-1',
-  });
-  expect(result).toEqual(ok(mockData));
 });
 
 test('getBallotImages fetches metadata via grout and binary images via fetch', async () => {

--- a/apps/admin/backend/src/client_app.ts
+++ b/apps/admin/backend/src/client_app.ts
@@ -246,14 +246,6 @@ function buildClientApi({
       });
     },
 
-    async getBallotAdjudicationData(input: {
-      cvrId: Id;
-    }): Promise<Result<BallotAdjudicationData, AdjudicationError>> {
-      return proxy('fetch ballot data', async ({ apiClient: peerApi }) =>
-        peerApi.getBallotAdjudicationData({ cvrId: input.cvrId })
-      );
-    },
-
     async claimAndLoadBallot(input: {
       afterCvrId?: Id;
     }): Promise<

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -173,14 +173,6 @@ function buildPeerApi({ workspace, logger }: PeerAppContext) {
       });
     },
 
-    getBallotAdjudicationData(input: { cvrId: Id }): BallotAdjudicationData {
-      const electionId = assertDefined(store.getCurrentElectionId());
-      return store.getBallotAdjudicationData({
-        electionId,
-        cvrId: input.cvrId,
-      });
-    },
-
     getBallotImageMetadata(input: { cvrId: Id }): Promise<BallotImages> {
       return getBallotImageMetadata({
         store,

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -337,34 +337,6 @@ export const getNextCvrIdForBallotAdjudication = {
   },
 } as const;
 
-type GetBallotAdjudicationDataInput = QueryInput<'getBallotAdjudicationData'>;
-export const getBallotAdjudicationData = {
-  queryKey(input?: GetBallotAdjudicationDataInput): QueryKey {
-    return input
-      ? ['getBallotAdjudicationData', input.cvrId]
-      : ['getBallotAdjudicationData'];
-  },
-  useQuery(input?: GetBallotAdjudicationDataInput) {
-    const apiClient = useApiClient();
-    return useQuery(
-      this.queryKey(input),
-      input
-        ? () =>
-            apiClient.getBallotAdjudicationData({
-              cvrId: input.cvrId,
-            })
-        : /* istanbul ignore next */
-          () => fail('input is required'),
-      {
-        enabled: !!input,
-        keepPreviousData: true,
-        staleTime: 0,
-        refetchOnMount: 'always',
-      }
-    );
-  },
-} as const;
-
 type GetBallotImages = QueryInput<'getBallotImages'>;
 export const getBallotImages = {
   queryKey(input?: GetBallotImages): QueryKey {
@@ -442,7 +414,6 @@ export const updateQualifiedWriteInCandidates = {
         await queryClient.invalidateQueries(
           getBallotAdjudicationQueue.queryKey()
         );
-        queryClient.removeQueries(getBallotAdjudicationData.queryKey());
         await queryClient.invalidateQueries(
           getNextCvrIdForBallotAdjudication.queryKey()
         );
@@ -884,11 +855,8 @@ export const adjudicateCvr = {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
     return useMutation(apiClient.adjudicateCvr, {
-      async onSuccess(_data, variables) {
+      async onSuccess() {
         await Promise.all([
-          queryClient.invalidateQueries(
-            getBallotAdjudicationData.queryKey({ cvrId: variables.cvrId })
-          ),
           invalidateWriteInQueries(queryClient),
           queryClient.invalidateQueries(getBallotAdjudicationQueue.queryKey()),
           queryClient.invalidateQueries(

--- a/apps/admin/frontend/src/client/api.ts
+++ b/apps/admin/frontend/src/client/api.ts
@@ -244,20 +244,6 @@ export const releaseBallot = {
   },
 } as const;
 
-export const getBallotAdjudicationData = {
-  queryKey(cvrId: string): QueryKey {
-    return ['getBallotAdjudicationData', cvrId];
-  },
-  useQuery(cvrId: string) {
-    const apiClient = useApiClient();
-    return useQuery(
-      this.queryKey(cvrId),
-      () => apiClient.getBallotAdjudicationData({ cvrId }),
-      { staleTime: 0, refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL }
-    );
-  },
-} as const;
-
 export const getBallotImages = {
   queryKey(cvrId: string): QueryKey {
     return ['getBallotImages', cvrId];
@@ -294,11 +280,8 @@ export const adjudicateCvr = {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
     return useMutation(apiClient.adjudicateCvr, {
-      async onSuccess(_data, variables) {
+      async onSuccess() {
         await Promise.all([
-          queryClient.invalidateQueries(
-            getBallotAdjudicationData.queryKey(variables.cvrId)
-          ),
           queryClient.invalidateQueries(['getWriteInCandidates']),
         ]);
       },


### PR DESCRIPTION
## Overview
After refactoring to use claimAndLoadBallot this endpoint is now dead code. This PR migrates the remaining tests to use claimAndLoadBallot and removes the dead code. 
<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot
n/a

## Testing Plan
ran tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
