### PR TITLE
feat(usb-drive): allow listeners to register later

### DIFF
--- a/libs/usb-drive/src/cli.ts
+++ b/libs/usb-drive/src/cli.ts
@@ -32,9 +32,8 @@ export async function main(args: string[]): Promise<number> {
   const logger = new Logger(LogSource.System, () => Promise.resolve('unknown'));
 
   if (command === 'watch') {
-    const multiUsbDrive = detectMultiUsbDrive(logger, {
-      onChange: () => printDrives(multiUsbDrive, stdout),
-    });
+    const multiUsbDrive = detectMultiUsbDrive(logger);
+    multiUsbDrive.addListener(() => printDrives(multiUsbDrive, stdout));
     // Wait until process is terminated (e.g. Ctrl+C)
     await new Promise<never>(() => {});
   }

--- a/libs/usb-drive/src/mocks/file_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.ts
@@ -261,6 +261,8 @@ export function createMockFileMultiUsbDrive(): MultiUsbDrive {
       return Promise.resolve();
     },
     stop: () => {},
+    addListener: () => {},
+    removeListener: () => {},
   };
 }
 

--- a/libs/usb-drive/src/mocks/mock_multi_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/mock_multi_usb_drive.ts
@@ -57,6 +57,8 @@ export function createMockMultiUsbDrive(): MockMultiUsbDrive {
     formatDrive: mockFunction('formatDrive'),
     sync: mockFunction('sync'),
     stop: mockFunction('stop'),
+    addListener: mockFunction('addListener'),
+    removeListener: mockFunction('removeListener'),
   };
 
   // Initialize with no drive connected

--- a/libs/usb-drive/src/multi_usb_drive.test.ts
+++ b/libs/usb-drive/src/multi_usb_drive.test.ts
@@ -186,10 +186,11 @@ describe('refresh', () => {
     multiUsbDrive.stop();
   });
 
-  test('calls onChange on first refresh and when state changes, but not on no-op refreshes', async () => {
+  test('calls change listeners on first refresh and when state changes, but not on no-op refreshes', async () => {
     const logger = mockLogger({ fn: vi.fn });
     const onChange = vi.fn();
-    const multiUsbDrive = detectMultiUsbDrive(logger, { onChange });
+    const multiUsbDrive = detectMultiUsbDrive(logger);
+    multiUsbDrive.addListener(onChange);
 
     // Initial refresh fires onChange (first refresh always fires)
     await multiUsbDrive.refresh();
@@ -201,6 +202,12 @@ describe('refresh', () => {
 
     // Refresh with new state — should fire onChange
     mockDrives = [makeDisk()];
+    await multiUsbDrive.refresh();
+    expect(onChange).toHaveBeenCalledTimes(2);
+
+    // Removed listeners no longer fire
+    multiUsbDrive.removeListener(onChange);
+    mockDrives = [];
     await multiUsbDrive.refresh();
     expect(onChange).toHaveBeenCalledTimes(2);
 
@@ -352,9 +359,8 @@ describe('stop', () => {
 
     const onChangeCalls: number[] = [];
     const logger = mockLogger({ fn: vi.fn });
-    const multiUsbDrive = detectMultiUsbDrive(logger, {
-      onChange: () => onChangeCalls.push(Date.now()),
-    });
+    const multiUsbDrive = detectMultiUsbDrive(logger);
+    multiUsbDrive.addListener(() => onChangeCalls.push(Date.now()));
 
     // Trigger auto-mount by refreshing.
     await multiUsbDrive.refresh();
@@ -1148,11 +1154,10 @@ describe('autoMount', () => {
     const mountStatesOnChange: string[] = [];
     const logger = mockLogger({ fn: vi.fn });
     mockDrives = [unmountedPartitionDisk];
-    const multiUsbDrive = detectMultiUsbDrive(logger, {
-      onChange: () => {
-        const mount = multiUsbDrive.getDrives()[0]?.partitions[0]?.mount;
-        if (mount) mountStatesOnChange.push(mount.type);
-      },
+    const multiUsbDrive = detectMultiUsbDrive(logger);
+    multiUsbDrive.addListener(() => {
+      const mount = multiUsbDrive.getDrives()[0]?.partitions[0]?.mount;
+      if (mount) mountStatesOnChange.push(mount.type);
     });
 
     // Wait until onChange is called with the drive in mounted state.

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -118,10 +118,6 @@ export interface UsbDriveInfo {
   partitions: UsbPartitionInfo[];
 }
 
-export interface MultiUsbDriveOptions {
-  onChange?: () => void;
-}
-
 export interface MultiUsbDrive {
   getDrives(): UsbDriveInfo[];
   refresh(): Promise<void>;
@@ -132,6 +128,8 @@ export interface MultiUsbDrive {
   ): Promise<void>;
   sync(partitionDevPath: string): Promise<void>;
   stop(): void;
+  addListener(listener: () => void): void;
+  removeListener(listener: () => void): void;
 }
 
 /**
@@ -204,15 +202,12 @@ class KeyedTaskRunner<Key, Task> {
   }
 }
 
-export function detectMultiUsbDrive(
-  logger: Logger,
-  options?: MultiUsbDriveOptions
-): MultiUsbDrive {
+export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
   if (isFeatureFlagEnabled(BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE)) {
     return createMockFileMultiUsbDrive();
   }
 
-  const { onChange } = options ?? {};
+  const listeners = new Set<() => void>();
 
   let stopped = false;
   let isFirstRefresh = true;
@@ -226,6 +221,12 @@ export function detectMultiUsbDrive(
 
   // Per-partition action lock: 'mounting'.
   const partitionAction = new KeyedTaskRunner<string, 'mounting'>();
+
+  function onChange() {
+    for (const listener of listeners) {
+      listener();
+    }
+  }
 
   function computeMount(
     diskDevPath: string,
@@ -288,7 +289,7 @@ export function detectMultiUsbDrive(
         doMountPartitionWithRetry(diskDevPath, partitionDevPath)
       )
       ?.then(() => {
-        if (!stopped) onChange?.();
+        if (!stopped) onChange();
       });
   }
 
@@ -379,7 +380,7 @@ export function detectMultiUsbDrive(
     }
 
     if (stateChanged) {
-      onChange?.();
+      onChange();
     }
   }
 
@@ -548,6 +549,15 @@ export function detectMultiUsbDrive(
     stop(): void {
       stopped = true;
       watcher.stop();
+      listeners.clear();
+    },
+
+    addListener(listener: () => void): void {
+      listeners.add(listener);
+    },
+
+    removeListener(listener: () => void): void {
+      listeners.delete(listener);
     },
   };
 }

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -8,14 +8,11 @@ import { MockFileUsbDrive } from './mocks/file_usb_drive';
 import { detectMultiUsbDrive, isFat32Partition } from './multi_usb_drive';
 import { createUsbDriveAdapter } from './usb_drive_adapter';
 
-export function detectUsbDrive(
-  logger: Logger,
-  onRefresh?: () => void
-): UsbDrive {
+export function detectUsbDrive(logger: Logger): UsbDrive {
   if (isFeatureFlagEnabled(BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE)) {
     return new MockFileUsbDrive();
   }
-  const multiUsbDrive = detectMultiUsbDrive(logger, { onChange: onRefresh });
+  const multiUsbDrive = detectMultiUsbDrive(logger);
   return createUsbDriveAdapter(
     multiUsbDrive,
     (drives) => drives.find((d) => isFat32Partition(d.partitions[0]))?.devPath


### PR DESCRIPTION
## Overview
I plan to add a listener in `apps/admin/src/app.ts` to provide client notification of USB changes without the use of polling. Since `detectMultiUsbDrive` is not called there, this API will make it simpler to add the listener where it's needed.

## Demo Video or Screenshot
n/a

## Testing Plan
Ran `./bin/usb-drive watch` and plugged/unplugged drives, verifying that the changes were reflected in the state.