### PR TITLE
refactor(usb-drive): remove useless `MockFileUsbDrive` class

### DIFF
--- a/libs/fujitsu-thermal-printer/src/mocks/file_printer.ts
+++ b/libs/fujitsu-thermal-printer/src/mocks/file_printer.ts
@@ -114,7 +114,7 @@ function readFromMockFileHelper(): Optional<MockStateFileContents> {
 }
 
 /**
- * Reads and parses the contents of the file underlying a MockFileUsbDrive
+ * Reads and parses the contents of the mock state file.
  */
 function readFromMockFile(): MockStateFileContents {
   let mockFileContents = readFromMockFileHelper();

--- a/libs/usb-drive/src/block_devices.ts
+++ b/libs/usb-drive/src/block_devices.ts
@@ -1,22 +1,11 @@
 import type { ChildProcess } from 'node:child_process';
 import makeDebug from 'debug';
 import { promises as fs } from 'node:fs';
-import { basename } from 'node:path';
 import { assert, Optional } from '@votingworks/basics';
 import { exec, spawn } from './exec';
 import { RESOLVED_MEDIA_MOUNT_DIR } from './media_mount_dir';
 
 const debug = makeDebug('usb-drive');
-
-export interface BlockDeviceInfo {
-  name: string;
-  path: string;
-  mountpoint?: string;
-  fstype?: string;
-  fsver?: string;
-  label?: string;
-  type: 'disk' | 'part';
-}
 
 // All block device info comes from two sources that don't require privileged
 // access:
@@ -43,6 +32,7 @@ function parseMountpoints(mountsContent: string): Map<string, string> {
 interface UsbBlockDevice {
   devname: string;
   devtype: 'disk' | 'partition';
+  mountpoint?: string;
   fstype?: string;
   fsver?: string;
   label?: string;
@@ -85,12 +75,11 @@ function parseExportDb(output: string): UsbBlockDevice[] {
   return devices;
 }
 
-function isDataUsbDrive(blockDeviceInfo: BlockDeviceInfo): boolean {
+function isDataUsbDrive(device: UsbBlockDevice): boolean {
   return (
-    (blockDeviceInfo.type === 'part' || blockDeviceInfo.type === 'disk') &&
-    !blockDeviceInfo.fstype?.includes('LVM') && // no partitions acting as LVMs
-    (!blockDeviceInfo.mountpoint ||
-      blockDeviceInfo.mountpoint.startsWith(`${RESOLVED_MEDIA_MOUNT_DIR}/`))
+    !device.fstype?.includes('LVM') && // no partitions acting as LVMs
+    (!device.mountpoint ||
+      device.mountpoint.startsWith(`${RESOLVED_MEDIA_MOUNT_DIR}/`))
   );
 }
 
@@ -145,13 +134,15 @@ export async function getAllUsbDrives(): Promise<UsbDiskDeviceInfo[]> {
     fs.readFile('/proc/mounts', 'utf-8').catch(() => ''),
   ]);
 
-  const usbBlockDevices = parseExportDb(exportDbOutput);
+  const mountpoints = parseMountpoints(mountsContent);
+  const usbBlockDevices = parseExportDb(exportDbOutput).map((d) => ({
+    ...d,
+    mountpoint: mountpoints.get(d.devname),
+  }));
   if (usbBlockDevices.length === 0) {
     debug('No USB block devices found in udev database');
     return [];
   }
-
-  const mountpoints = parseMountpoints(mountsContent);
 
   const diskDevices = usbBlockDevices.filter((d) => d.devtype === 'disk');
   const partitionDevices = usbBlockDevices.filter(
@@ -161,16 +152,6 @@ export async function getAllUsbDrives(): Promise<UsbDiskDeviceInfo[]> {
   const result: UsbDiskDeviceInfo[] = [];
 
   for (const disk of diskDevices) {
-    const diskInfo: BlockDeviceInfo = {
-      name: basename(disk.devname),
-      path: disk.devname,
-      type: 'disk',
-      mountpoint: mountpoints.get(disk.devname),
-      fstype: disk.fstype,
-      fsver: disk.fsver,
-      label: disk.label,
-    };
-
     const diskPartitions = partitionDevices.filter((p) =>
       isPartitionOfDisk(p.devname, disk.devname)
     );
@@ -178,20 +159,9 @@ export async function getAllUsbDrives(): Promise<UsbDiskDeviceInfo[]> {
     if (diskPartitions.length > 0) {
       // Drive has partitions — only include valid data partitions
       const validPartitions: UsbPartitionDeviceInfo[] = diskPartitions
-        .map(
-          (p): BlockDeviceInfo => ({
-            name: basename(p.devname),
-            path: p.devname,
-            type: 'part',
-            mountpoint: mountpoints.get(p.devname),
-            fstype: p.fstype,
-            fsver: p.fsver,
-            label: p.label,
-          })
-        )
         .filter(isDataUsbDrive)
         .map((p) => ({
-          devPath: p.path,
+          devPath: p.devname,
           mountpoint: p.mountpoint,
           fstype: p.fstype,
           fsver: p.fsver,
@@ -209,7 +179,7 @@ export async function getAllUsbDrives(): Promise<UsbDiskDeviceInfo[]> {
         serial: disk.serial,
         partitions: validPartitions,
       });
-    } else if (isDataUsbDrive(diskInfo)) {
+    } else if (isDataUsbDrive(disk)) {
       // Unformatted drive (no partitions) — include it with empty partitions
       result.push({
         devPath: disk.devname,
@@ -229,17 +199,7 @@ export async function getAllUsbDrives(): Promise<UsbDiskDeviceInfo[]> {
   for (const partition of partitionDevices) {
     const diskDevPath = partition.devname.replace(/(?<=\d)p\d+$|\d+$/, '');
     if (diskDevPaths.has(diskDevPath)) continue;
-
-    const partitionInfo: BlockDeviceInfo = {
-      name: basename(partition.devname),
-      path: partition.devname,
-      type: 'part',
-      mountpoint: mountpoints.get(partition.devname),
-      fstype: partition.fstype,
-      fsver: partition.fsver,
-      label: partition.label,
-    };
-    if (!isDataUsbDrive(partitionInfo)) continue;
+    if (!isDataUsbDrive(partition)) continue;
 
     result.push({
       devPath: diskDevPath,
@@ -249,7 +209,7 @@ export async function getAllUsbDrives(): Promise<UsbDiskDeviceInfo[]> {
       partitions: [
         {
           devPath: partition.devname,
-          mountpoint: partitionInfo.mountpoint,
+          mountpoint: partition.mountpoint,
           fstype: partition.fstype,
           fsver: partition.fsver,
           label: partition.label,

--- a/libs/usb-drive/src/mocks/file_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.ts
@@ -171,26 +171,6 @@ export function createMockFileUsbDrive(diskName = 'sdb'): UsbDrive {
   };
 }
 
-export class MockFileUsbDrive implements UsbDrive {
-  private readonly usbDrive = createMockFileUsbDrive();
-
-  status(): Promise<UsbDriveStatus> {
-    return this.usbDrive.status();
-  }
-
-  eject(): Promise<void> {
-    return this.usbDrive.eject();
-  }
-
-  format(fstype: UsbDriveFilesystemType): Promise<void> {
-    return this.usbDrive.format(fstype);
-  }
-
-  sync(): Promise<void> {
-    return this.usbDrive.sync();
-  }
-}
-
 export interface MockFileUsbDriveHandler {
   status: () => UsbDriveStatus;
   insert: (contents?: MockFileTree) => void;

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -384,6 +384,32 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
     }
   }
 
+  /**
+   * Helper for operations that need to unmount all disk partitions first.
+   * Returns the freshly-read disk.
+   */
+  async function unmountAllPartitions(
+    driveDevPath: string
+  ): Promise<UsbDiskDeviceInfo> {
+    const disk = cachedDrives.find((d) => d.devPath === driveDevPath);
+    assert(disk, `Drive not found: ${driveDevPath}`);
+
+    await Promise.all(
+      disk.partitions.map((p) => partitionAction.join(p.devPath))
+    );
+
+    const freshDisk = cachedDrives.find((d) => d.devPath === driveDevPath);
+    assert(freshDisk, `Drive not found: ${driveDevPath}`);
+
+    await Promise.all(
+      iter(freshDisk.partitions)
+        .filterMap((p) => p.mountpoint)
+        .map((mountpoint) => unmountPartition(mountpoint))
+    );
+
+    return freshDisk;
+  }
+
   const watcher = createBlockDeviceChangeWatcher(() => {
     void doRefresh().catch((e) => debug(`background refresh failed: ${e}`));
   });
@@ -402,27 +428,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
       const result = driveAction.perform(driveDevPath, 'ejecting', async () => {
         await logger.logAsCurrentRole(LogEventId.UsbDriveEjectInit);
         try {
-          const disk = cachedDrives.find((d) => d.devPath === driveDevPath);
-          assert(disk, `Drive not found: ${driveDevPath}`);
-
-          // Wait for any in-progress partition mounts to finish. Without this,
-          // a mount that completes after the unmount loop would leave the
-          // partition mounted even though the eject appeared to succeed.
-          await Promise.all(
-            disk.partitions.map((p) => partitionAction.join(p.devPath))
-          );
-
-          // Re-read cachedDrives — mounts may have completed during the wait.
-          const freshDisk = cachedDrives.find(
-            (d) => d.devPath === driveDevPath
-          );
-          assert(freshDisk, `Drive not found: ${driveDevPath}`);
-
-          await Promise.all(
-            iter(freshDisk.partitions)
-              .filterMap((p) => p.mountpoint)
-              .map((mountpoint) => unmountPartition(mountpoint))
-          );
+          await unmountAllPartitions(driveDevPath);
 
           ejectedDrives.add(driveDevPath);
           await doRefresh();
@@ -462,28 +468,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
         async () => {
           await logger.logAsCurrentRole(LogEventId.UsbDriveFormatInit);
           try {
-            const disk = cachedDrives.find((d) => d.devPath === driveDevPath);
-            assert(disk, `Drive not found: ${driveDevPath}`);
-
-            // Wait for any in-progress partition mounts to finish. Without this,
-            // a mount that completes after the unmount loop would leave the
-            // partition mounted even though the format appeared to succeed.
-            await Promise.all(
-              disk.partitions.map((p) => partitionAction.join(p.devPath))
-            );
-
-            // Re-read cachedDrives — mounts may have completed during the wait.
-            const freshDisk = cachedDrives.find(
-              (d) => d.devPath === driveDevPath
-            );
-            assert(freshDisk, `Drive not found: ${driveDevPath}`);
-
-            // Unmount all mounted partitions first
-            await Promise.all(
-              iter(freshDisk.partitions)
-                .filterMap((p) => p.mountpoint)
-                .map((mountpoint) => unmountPartition(mountpoint))
-            );
+            const freshDisk = await unmountAllPartitions(driveDevPath);
 
             // Determine label — reuse existing label if it matches VxUSB pattern
             const label = generateVxUsbLabel(freshDisk.partitions[0]?.label);

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -38,7 +38,7 @@ beforeEach(() => {
   featureFlagMock.resetFeatureFlags();
 });
 
-test('uses MockFileUsbDrive when feature flag is set', async () => {
+test('uses a mock file USB drive when feature flag is set', async () => {
   featureFlagMock.enableFeatureFlag(
     BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE
   );

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -4,13 +4,13 @@ import {
 } from '@votingworks/utils';
 import { Logger } from '@votingworks/logging';
 import { UsbDrive } from './types';
-import { MockFileUsbDrive } from './mocks/file_usb_drive';
+import { createMockFileUsbDrive } from './mocks/file_usb_drive';
 import { detectMultiUsbDrive, isFat32Partition } from './multi_usb_drive';
 import { createUsbDriveAdapter } from './usb_drive_adapter';
 
 export function detectUsbDrive(logger: Logger): UsbDrive {
   if (isFeatureFlagEnabled(BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE)) {
-    return new MockFileUsbDrive();
+    return createMockFileUsbDrive();
   }
   const multiUsbDrive = detectMultiUsbDrive(logger);
   return createUsbDriveAdapter(


### PR DESCRIPTION
## Overview
It just forwards to the object created by `createMockFileUsbDrive`. Also fixes copy-pasted comment with the wrong name.

## Demo Video or Screenshot
n/a

## Testing Plan
Existing automated tests.