### PR TITLE
VxMark/VxMarkScan: Fix contest count on start screen for open primaries

### DIFF
--- a/apps/mark-scan/frontend/src/app_open_primary.test.tsx
+++ b/apps/mark-scan/frontend/src/app_open_primary.test.tsx
@@ -81,6 +81,9 @@ test('poll worker activates session, voter picks party and walks through ballot'
   await activateCardlessVoterSession();
 
   // Start screen -> party selection
+  screen.getByText(
+    hasTextAcrossElements('Number of contests on your ballot: 13')
+  );
   userEvent.click(screen.getByText('Start Voting'));
   await screen.findByRole('heading', { name: 'Choose Your Party' });
 

--- a/apps/mark-scan/frontend/src/app_root.tsx
+++ b/apps/mark-scan/frontend/src/app_root.tsx
@@ -252,9 +252,14 @@ export function AppRoot(): JSX.Element | null {
           // For open primaries, show only partisan contests for the party
           // selected by the user + nonpartisan contests.
           .filter((contest) => {
-            if (isOpenPrimary(electionDefinition.election) && selectedPartyId) {
+            if (isOpenPrimary(electionDefinition.election)) {
+              // If the voter hasn't selected a party yet (e.g. on the start
+              // screen), default to a random party so the contest count
+              // matches.
+              const partyId =
+                selectedPartyId ?? electionDefinition.election.parties[0].id;
               return contest.type === 'candidate'
-                ? !contest.partyId || contest.partyId === selectedPartyId
+                ? !contest.partyId || contest.partyId === partyId
                 : true;
             }
             return true;

--- a/apps/mark/frontend/src/app_open_primary.test.tsx
+++ b/apps/mark/frontend/src/app_open_primary.test.tsx
@@ -82,6 +82,9 @@ test('poll worker activates session, voter picks party and walks through ballot'
   await screen.findByText('Start Voting');
 
   // Start screen -> party selection
+  screen.getByText(
+    hasTextAcrossElements('Number of contests on your ballot: 13')
+  );
   userEvent.click(screen.getByText('Start Voting'));
   await screen.findByRole('heading', { name: 'Choose Your Party' });
 

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -260,9 +260,14 @@ export function AppRoot(): JSX.Element | null {
           // For open primaries, show only partisan contests for the party
           // selected by the user + nonpartisan contests.
           .filter((contest) => {
-            if (isOpenPrimary(electionDefinition.election) && selectedPartyId) {
+            if (isOpenPrimary(electionDefinition.election)) {
+              // If the voter hasn't selected a party yet (e.g. on the start
+              // screen), default to a random party so the contest count
+              // matches.
+              const partyId =
+                selectedPartyId ?? electionDefinition.election.parties[0].id;
               return contest.type === 'candidate'
-                ? !contest.partyId || contest.partyId === selectedPartyId
+                ? !contest.partyId || contest.partyId === partyId
                 : true;
             }
             return true;


### PR DESCRIPTION


## Overview
Fixes https://github.com/votingworks/vxsuite/issues/8622
<!-- Add a link to a GitHub issue here -->
Previously, on the start screen, since the user hadn't yet selected a party, we were passing in all contests for the ballot style to the ballot context. This meant the start screen showed a count of all the contests for all parties, which is misleading. Now, if the user hasn't yet selected a party, we select one for them arbitrarily so the count reflects what would happen once they do select a party.

Alternative fix to https://github.com/votingworks/vxsuite/pull/8640

## Demo Video or Screenshot

## Testing Plan
- Manual test
- Added regression test

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
