### PR TITLE
[VxMark] [Backend] Remove old precint-selection code paths

### DIFF
--- a/apps/mark/backend/schema.sql
+++ b/apps/mark/backend/schema.sql
@@ -4,7 +4,6 @@ create table election (
   election_data text not null,
   election_package_hash text not null,
   jurisdiction text not null,
-  precinct_selection text, -- [TODO] Remove after migration to polling places
   polling_place_id text,
   is_test_mode boolean not null default true,
   polls_state text not null default "polls_closed_initial",

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -29,11 +29,9 @@ import {
   BallotType,
 } from '@votingworks/types';
 import {
-  ALL_PRECINCTS_SELECTION,
   ELECTION_PACKAGE_FOLDER,
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
-  singlePrecinctSelectionFor,
   getMockMultiLanguageElectionDefinition,
   generateMockVotes,
 } from '@votingworks/utils';
@@ -397,11 +395,7 @@ async function configureMachine(
   mockNoCard();
 }
 
-// [TODO] Update test name after migration to Polling Places.
-test('single precinct election automatically has precinct set on configure', async () => {
-  const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
-  mockFeatureFlagger.enableFeatureFlag(ENABLE_POLLING_PLACES);
-
+test('configureMachine auto-selects polling place for single-location election', async () => {
   const fixtures = electionTwoPartyPrimaryFixtures;
   const def = fixtures.makeSinglePrecinctElectionDefinition();
   const defaultPollingPlace = assertDefined(def.election.pollingPlaces?.[0]);
@@ -409,7 +403,6 @@ test('single precinct election automatically has precinct set on configure', asy
   await configureMachine(mockUsbDrive, def);
 
   await expectElectionState({
-    precinctSelection: singlePrecinctSelectionFor('precinct-1'),
     pollingPlaceId: defaultPollingPlace.id,
   });
 });
@@ -474,42 +467,6 @@ test('"test" mode', async () => {
 
   await apiClient.setTestMode({ isTestMode: true });
   await expectElectionState({ isTestMode: true });
-});
-
-test('setting precinct', async () => {
-  expect(
-    (await apiClient.getElectionState()).precinctSelection
-  ).toBeUndefined();
-
-  await configureMachine(
-    mockUsbDrive,
-    electionFamousNames2021Fixtures.readElectionDefinition()
-  );
-  expect(
-    (await apiClient.getElectionState()).precinctSelection
-  ).toBeUndefined();
-
-  await apiClient.setPrecinctSelection({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
-  });
-  await expectElectionState({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
-  });
-
-  const singlePrecinctSelection = singlePrecinctSelectionFor('23');
-  await apiClient.setPrecinctSelection({
-    precinctSelection: singlePrecinctSelection,
-  });
-  await expectElectionState({
-    precinctSelection: singlePrecinctSelection,
-  });
-  expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
-    LogEventId.PollingPlaceChanged,
-    {
-      disposition: 'success',
-      message: 'User set the precinct for the machine to North Lincoln',
-    }
-  );
 });
 
 test('set polling place', async () => {

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -20,20 +20,13 @@ import {
   SystemSettings,
   DEFAULT_SYSTEM_SETTINGS,
   PollsState,
-  PrecinctSelection,
   PrinterStatus,
   DiagnosticRecord,
   DiagnosticType,
   DiagnosticOutcome,
   pollingPlaceFromElection,
 } from '@votingworks/types';
-import {
-  BooleanEnvironmentVariableName,
-  getPrecinctSelectionName,
-  isElectionManagerAuth,
-  isFeatureFlagEnabled,
-  singlePrecinctSelectionFor,
-} from '@votingworks/utils';
+import { isElectionManagerAuth } from '@votingworks/utils';
 
 import {
   createUiStringsApi,
@@ -239,22 +232,10 @@ export function buildApi(ctx: Context) {
           workspace.store.setBallots(ballots);
         }
 
-        // automatically set precinct for single precinct elections
-        if (electionDefinition.election.precincts.length === 1) {
-          workspace.store.setPrecinctSelection(
-            singlePrecinctSelectionFor(
-              electionDefinition.election.precincts[0].id
-            )
+        if (electionDefinition.election.pollingPlaces?.length === 1) {
+          workspace.store.setPollingPlaceId(
+            electionDefinition.election.pollingPlaces[0].id
           );
-        }
-
-        const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
-        if (isFeatureFlagEnabled(ENABLE_POLLING_PLACES)) {
-          if (electionDefinition.election.pollingPlaces?.length === 1) {
-            workspace.store.setPollingPlaceId(
-              electionDefinition.election.pollingPlaces[0].id
-            );
-          }
         }
 
         configureUiStrings({
@@ -334,21 +315,6 @@ export function buildApi(ctx: Context) {
       store.setBallotsPrintedCount(0);
     },
 
-    async setPrecinctSelection(input: {
-      precinctSelection: PrecinctSelection;
-    }): Promise<void> {
-      const { electionDefinition } = assertDefined(store.getElectionRecord());
-      store.setPrecinctSelection(input.precinctSelection);
-      store.setBallotsPrintedCount(0);
-      await logger.logAsCurrentRole(LogEventId.PollingPlaceChanged, {
-        disposition: 'success',
-        message: `User set the precinct for the machine to ${getPrecinctSelectionName(
-          electionDefinition.election.precincts,
-          input.precinctSelection
-        )}`,
-      });
-    },
-
     setPollingPlaceId(input: { id: string }): void {
       const { electionDefinition } = assertDefined(
         store.getElectionRecord(),
@@ -369,7 +335,6 @@ export function buildApi(ctx: Context) {
 
     getElectionState(): ElectionState {
       return {
-        precinctSelection: store.getPrecinctSelection(),
         pollingPlaceId: store.getPollingPlaceId(),
         ballotsPrintedCount: store.getBallotsPrintedCount(),
         isTestMode: store.getTestMode(),

--- a/apps/mark/backend/src/barcodes/activation.test.ts
+++ b/apps/mark/backend/src/barcodes/activation.test.ts
@@ -20,10 +20,8 @@ import {
   TEST_JURISDICTION,
 } from '@votingworks/types';
 import {
-  ALL_PRECINCTS_SELECTION,
   BooleanEnvironmentVariableName as Feature,
   getFeatureFlagMock,
-  singlePrecinctSelectionFor,
 } from '@votingworks/utils';
 import {
   mockCardlessVoterUser,
@@ -172,7 +170,6 @@ describe('setUpBarcodeActivation', () => {
       electionPackageHash: 'test-hash',
     });
     workspace.store.setPollingPlaceId(pollingPlace.id);
-    workspace.store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
     workspace.store.setPollsState('polls_open');
     // System settings default has bmdEnableQrBallotActivation as undefined/false
 
@@ -221,7 +218,6 @@ describe('setUpBarcodeActivation', () => {
     });
     workspace.store.setSystemSettings(systemSettings);
     workspace.store.setPollingPlaceId(pollingPlace.id);
-    workspace.store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
     workspace.store.setPollsState('polls_closed_initial');
 
     const ctx: Context = {
@@ -261,7 +257,6 @@ describe('setUpBarcodeActivation', () => {
     });
     workspace.store.setSystemSettings(systemSettings);
     workspace.store.setPollingPlaceId(pollingPlace.id);
-    workspace.store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
     workspace.store.setPollsState('polls_open');
 
     // Mock that there's already a cardless voter session active
@@ -294,82 +289,7 @@ describe('setUpBarcodeActivation', () => {
     expect(mockAuth.startCardlessVoterSession).not.toHaveBeenCalled();
   });
 
-  test('starts voter session on valid barcode scan when barcode feature is enabled (polling places disabled)', async () => {
-    setPollingPlacesEnabled(false);
-
-    // Configure election with feature enabled and polls open
-    const systemSettings: SystemSettings = {
-      ...DEFAULT_SYSTEM_SETTINGS,
-      bmdEnableQrBallotActivation: true,
-    };
-
-    workspace.store.setElectionAndJurisdiction({
-      electionData: electionDefinition.electionData,
-      jurisdiction: TEST_JURISDICTION,
-      electionPackageHash: 'test-hash',
-    });
-    workspace.store.setSystemSettings(systemSettings);
-    workspace.store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
-    workspace.store.setPollsState('polls_open');
-
-    // Mock no current auth session initially, then voter session after start
-    let sessionStarted = false;
-    vi.mocked(mockAuth.getAuthStatus).mockImplementation(() => {
-      if (sessionStarted) {
-        return Promise.resolve({
-          status: 'logged_in' as const,
-          user: mockCardlessVoterUser({
-            ballotStyleId: election.ballotStyles[0].id,
-            precinctId: election.ballotStyles[0].precincts[0],
-          }),
-          sessionExpiresAt: mockSessionExpiresAt(),
-        });
-      }
-      return Promise.resolve({
-        status: 'logged_out' as const,
-        reason: 'no_card' as const,
-      });
-    });
-
-    vi.mocked(mockAuth.startCardlessVoterSession).mockImplementation(() => {
-      sessionStarted = true;
-      return Promise.resolve();
-    });
-
-    const ctx: Context = {
-      auth: mockAuth,
-      barcodeClient: mockBarcodeClient as unknown as BarcodeReader,
-      logger,
-      workspace,
-    };
-
-    setUpBarcodeActivation(ctx);
-
-    mockBarcodeClient.emit('scan', new TextEncoder().encode('test-barcode'));
-
-    await vi.waitFor(() => {
-      expect(mockAuth.startCardlessVoterSession).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          ballotStyleId: election.ballotStyles[0].id,
-          precinctId: election.ballotStyles[0].precincts[0],
-          skipPollWorkerCheck: true,
-        })
-      );
-    });
-
-    expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        message: 'voter session started successfully',
-        disposition: 'success',
-      })
-    );
-  });
-
   test('starts voter session on valid barcode scan when feature is enabled', async () => {
-    setPollingPlacesEnabled(true);
-
     // Configure election with feature enabled and polls open
     const systemSettings: SystemSettings = {
       ...DEFAULT_SYSTEM_SETTINGS,
@@ -456,7 +376,6 @@ describe('setUpBarcodeActivation', () => {
     });
     workspace.store.setSystemSettings(systemSettings);
     workspace.store.setPollingPlaceId(pollingPlace.id);
-    workspace.store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
     workspace.store.setPollsState('polls_open');
 
     vi.mocked(mockAuth.getAuthStatus).mockResolvedValue({
@@ -490,68 +409,4 @@ describe('setUpBarcodeActivation', () => {
       );
     });
   });
-
-  test('starts voter session with single precinct selection', async () => {
-    // Configure election with feature enabled and polls open
-    const systemSettings: SystemSettings = {
-      ...DEFAULT_SYSTEM_SETTINGS,
-      bmdEnableQrBallotActivation: true,
-    };
-
-    const precinctId = election.precincts[0].id;
-    // Find the first ballot style that includes this precinct
-    const matchingBallotStyle = election.ballotStyles.find((b) =>
-      b.precincts.includes(precinctId)
-    )!;
-
-    workspace.store.setElectionAndJurisdiction({
-      electionData: electionDefinition.electionData,
-      jurisdiction: TEST_JURISDICTION,
-      electionPackageHash: 'test-hash',
-    });
-    workspace.store.setSystemSettings(systemSettings);
-    // Use single precinct selection to cover the else branch (lines 93-97)
-    workspace.store.setPrecinctSelection(
-      singlePrecinctSelectionFor(precinctId)
-    );
-    workspace.store.setPollsState('polls_open');
-
-    vi.mocked(mockAuth.getAuthStatus).mockResolvedValue({
-      status: 'logged_out',
-      reason: 'no_card',
-    });
-
-    vi.mocked(mockAuth.startCardlessVoterSession).mockResolvedValue();
-
-    const ctx: Context = {
-      auth: mockAuth,
-      barcodeClient: mockBarcodeClient as unknown as BarcodeReader,
-      logger,
-      workspace,
-    };
-
-    setUpBarcodeActivation(ctx);
-
-    mockBarcodeClient.emit('scan', new TextEncoder().encode('test-barcode'));
-
-    await vi.waitFor(() => {
-      expect(mockAuth.startCardlessVoterSession).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          ballotStyleId: matchingBallotStyle.id,
-          // Should use the precinctId from single precinct selection, not from ballot style
-          precinctId,
-          skipPollWorkerCheck: true,
-        })
-      );
-    });
-  });
 });
-
-function setPollingPlacesEnabled(enabled: boolean) {
-  if (enabled) {
-    featureFlagMock.enableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  } else {
-    featureFlagMock.disableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  }
-}

--- a/apps/mark/backend/src/barcodes/activation.ts
+++ b/apps/mark/backend/src/barcodes/activation.ts
@@ -2,17 +2,12 @@ import util from 'node:util';
 
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import { LogEventId, Logger } from '@votingworks/logging';
-import {
-  BooleanEnvironmentVariableName as Feature,
-  isCardlessVoterAuth,
-  isFeatureFlagEnabled,
-} from '@votingworks/utils';
+import { isCardlessVoterAuth } from '@votingworks/utils';
 import { assert, find } from '@votingworks/basics';
 import {
   SystemSettings,
   DEFAULT_SYSTEM_SETTINGS,
   Election,
-  PrecinctSelection,
   pollingPlaceBallotStyles,
   pollingPlaceFromElection,
 } from '@votingworks/types';
@@ -76,15 +71,9 @@ export function setUpBarcodeActivation(ctx: Context): void {
 
     const electionRecord = ctx.workspace.store.getElectionRecord();
     const pollsState = ctx.workspace.store.getPollsState();
-    const precinctSelection = ctx.workspace.store.getPrecinctSelection();
     const pollingPlaceId = ctx.workspace.store.getPollingPlaceId();
 
-    const { ENABLE_POLLING_PLACES } = Feature;
-    const pollingPlacesEnabled = isFeatureFlagEnabled(ENABLE_POLLING_PLACES);
-
-    const locationConfigured = pollingPlacesEnabled
-      ? !!pollingPlaceId
-      : !!precinctSelection;
+    const locationConfigured = !!pollingPlaceId;
 
     if (!electionRecord || pollsState !== 'polls_open' || !locationConfigured) {
       return ctx.logger.logAsCurrentRole(LogEventId.Info, {
@@ -108,9 +97,10 @@ export function setUpBarcodeActivation(ctx: Context): void {
     }
 
     const { election } = electionRecord.electionDefinition;
-    const { ballotStyle, precinctId } = pollingPlacesEnabled
-      ? ballotStyleForPollingPlace(election, pollingPlaceId)
-      : ballotStyleForPrecinctSelection(election, precinctSelection);
+    const { ballotStyle, precinctId } = ballotStyleForPollingPlace(
+      election,
+      pollingPlaceId
+    );
 
     void ctx.logger.logAsCurrentRole(LogEventId.Info, {
       ballotStyleId: ballotStyle.id,
@@ -159,26 +149,6 @@ export function setUpBarcodeActivation(ctx: Context): void {
   ctx.logger.log(LogEventId.Info, 'system', {
     message: 'listening for barcode scans...',
   });
-}
-
-function ballotStyleForPrecinctSelection(
-  election: Election,
-  selection?: PrecinctSelection
-) {
-  assert(!!selection);
-  const ballotStyle = find(
-    election.ballotStyles,
-    (b) =>
-      selection.kind === 'AllPrecincts' ||
-      b.precincts.includes(selection.precinctId)
-  );
-
-  const precinctId =
-    selection.kind === 'AllPrecincts'
-      ? ballotStyle.precincts[0]
-      : selection.precinctId;
-
-  return { ballotStyle, precinctId };
 }
 
 function ballotStyleForPollingPlace(election: Election, placeId?: string) {

--- a/apps/mark/backend/src/store.ts
+++ b/apps/mark/backend/src/store.ts
@@ -22,9 +22,6 @@ import {
   safeParseElectionDefinition,
   SystemSettings,
   safeParseSystemSettings,
-  PrecinctSelection,
-  PrecinctSelectionSchema,
-  safeParseJson,
   PollsState,
   safeParse,
   PollsStateSchema,
@@ -234,52 +231,6 @@ export class Store {
 
   getUiStringsStore(): UiStringsStore {
     return this.uiStringsStore;
-  }
-
-  /**
-   * Gets the current precinct for which voters can cast ballots. If set to
-   * `undefined`, ballots from all precincts will be accepted (this is the
-   * default).
-   */
-  getPrecinctSelection(): Optional<PrecinctSelection> {
-    const electionRow = this.client.one(
-      'select precinct_selection as rawPrecinctSelection from election'
-    ) as { rawPrecinctSelection: string } | undefined;
-
-    const rawPrecinctSelection = electionRow?.rawPrecinctSelection;
-
-    if (!rawPrecinctSelection) {
-      // precinct selection is undefined when there is no election
-      return undefined;
-    }
-
-    const precinctSelectionParseResult = safeParseJson(
-      rawPrecinctSelection,
-      PrecinctSelectionSchema
-    );
-
-    /* istanbul ignore next */
-    if (precinctSelectionParseResult.isErr()) {
-      throw new Error('Unable to parse stored precinct selection.');
-    }
-
-    return precinctSelectionParseResult.ok();
-  }
-
-  /**
-   * Sets the current precinct for which voters can cast ballots. Set to
-   * `undefined` to accept from all precincts (this is the default).
-   */
-  setPrecinctSelection(precinctSelection: PrecinctSelection): void {
-    /* istanbul ignore next */
-    if (!this.hasElection()) {
-      throw new Error('Cannot set precinct selection without an election.');
-    }
-
-    this.client.run(
-      'update election set precinct_selection = ?',
-      JSON.stringify(precinctSelection)
-    );
   }
 
   /**

--- a/apps/mark/backend/src/types.ts
+++ b/apps/mark/backend/src/types.ts
@@ -1,9 +1,4 @@
-import {
-  BallotStyleId,
-  PollsState,
-  PrecinctSelection,
-  VotesDict,
-} from '@votingworks/types';
+import { BallotStyleId, PollsState, VotesDict } from '@votingworks/types';
 
 export interface MachineConfig {
   machineId: string;
@@ -12,7 +7,6 @@ export interface MachineConfig {
 }
 
 export interface ElectionState {
-  precinctSelection?: PrecinctSelection;
   pollingPlaceId?: string;
   ballotsPrintedCount: number;
   isTestMode: boolean;


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/8381

Cleaning up the `ENABLE_POLLING_PLACES` dev flag and removing the deprecated branches related to precinct selection. VxMark will now require polling places in imported election definitions, regardless of the state of the flag.

## Demo Video or Screenshot
N/A

## Testing Plan
- Existing tests cover the Polling Places paths

## Checklist
N/A
