### PR TITLE
VxScan: Show early voting status consistently in footer

### DIFF
--- a/apps/scan/frontend/src/app_root.tsx
+++ b/apps/scan/frontend/src/app_root.tsx
@@ -181,7 +181,6 @@ export function AppRoot(): JSX.Element | null {
     pollingPlaceId,
     isSoundMuted,
     isContinuousExportEnabled,
-    ballotCastingMode,
   } = configQuery.data;
   const scannerStatus = scannerStatusQuery.data;
   const usbDrive = usbDriveStatusQuery.data;
@@ -375,7 +374,6 @@ export function AppRoot(): JSX.Element | null {
     return (
       <PollsNotOpenScreen
         isTestMode={isTestMode}
-        isEarlyVotingMode={ballotCastingMode === 'early_voting'}
         pollsState={pollsState}
         scannedBallotCount={scannerStatus.ballotsCounted}
       />
@@ -421,7 +419,6 @@ export function AppRoot(): JSX.Element | null {
         electionDefinition={electionDefinition}
         systemSettings={systemSettings}
         isTestMode={isTestMode}
-        isEarlyVotingMode={ballotCastingMode === 'early_voting'}
         isSoundMuted={isSoundMuted}
       />
     </PatDeviceContextProvider>

--- a/apps/scan/frontend/src/components/layout.tsx
+++ b/apps/scan/frontend/src/components/layout.tsx
@@ -45,7 +45,6 @@ export interface ScreenProps {
   padded?: boolean;
   title?: React.ReactNode;
   showTestModeBanner: boolean;
-  showEarlyVotingBanner: boolean;
   voterFacing: boolean;
   disableSettingsButtons?: boolean;
   disableReadOnLoad?: boolean;
@@ -153,7 +152,6 @@ export function Screen(props: ScreenProps): JSX.Element | null {
     infoBarMode,
     hideInfoBar: hideInfoBarFromProps,
     showTestModeBanner,
-    showEarlyVotingBanner,
     padded,
     title,
     voterFacing,
@@ -185,7 +183,9 @@ export function Screen(props: ScreenProps): JSX.Element | null {
     precinctSelection,
     pollingPlaceId,
     systemSettings,
+    ballotCastingMode,
   } = configQuery.data;
+  const showEarlyVotingBanner = ballotCastingMode === 'early_voting';
 
   if (shouldShowLanguageSettings) {
     return (

--- a/apps/scan/frontend/src/screens/accessibility_input_disconnected_screen.tsx
+++ b/apps/scan/frontend/src/screens/accessibility_input_disconnected_screen.tsx
@@ -16,7 +16,6 @@ export function AccessibilityInputDisconnectedScreen({
     <ScreenMainCenterChild
       disableSettingsButtons={enableAlarm}
       showTestModeBanner={false}
-      showEarlyVotingBanner={false}
       voterFacing
     >
       <CenteredText>

--- a/apps/scan/frontend/src/screens/card_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/card_error_screen.tsx
@@ -3,11 +3,7 @@ import { CenteredText, ScreenMainCenterChild } from '../components/layout';
 
 export function CardErrorScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild
-      voterFacing={false}
-      showTestModeBanner={false}
-      showEarlyVotingBanner={false}
-    >
+    <ScreenMainCenterChild voterFacing={false} showTestModeBanner={false}>
       <RotateCardImage />
       <CenteredText>
         <H1>Card Backward</H1>

--- a/apps/scan/frontend/src/screens/cast_vote_record_sync_required_screen.tsx
+++ b/apps/scan/frontend/src/screens/cast_vote_record_sync_required_screen.tsx
@@ -29,11 +29,7 @@ interface Props {
 
 export function CastVoteRecordSyncRequiredVoterScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild
-      voterFacing={false}
-      showTestModeBanner={false}
-      showEarlyVotingBanner={false}
-    >
+    <ScreenMainCenterChild voterFacing={false} showTestModeBanner={false}>
       <FullScreenPromptLayout
         title={appStrings.titleScannerCvrSyncRequired()}
         image={
@@ -121,11 +117,7 @@ export function CastVoteRecordSyncRequiredScreen({
   }
 
   return (
-    <ScreenMainCenterChild
-      voterFacing={false}
-      showTestModeBanner={false}
-      showEarlyVotingBanner={false}
-    >
+    <ScreenMainCenterChild voterFacing={false} showTestModeBanner={false}>
       <FullScreenPromptLayout
         title="CVR Sync Required"
         image={

--- a/apps/scan/frontend/src/screens/diagnostics_screen.tsx
+++ b/apps/scan/frontend/src/screens/diagnostics_screen.tsx
@@ -69,7 +69,6 @@ export function DiagnosticsScreen({
         title="Diagnostics"
         voterFacing={false}
         showTestModeBanner={false}
-        showEarlyVotingBanner={false}
         padded
       >
         <Loading />
@@ -105,7 +104,6 @@ export function DiagnosticsScreen({
       title="Diagnostics"
       voterFacing={false}
       showTestModeBanner={false}
-      showEarlyVotingBanner={false}
       hideBallotCount
       hideInfoBar
       padded

--- a/apps/scan/frontend/src/screens/election_manager_screen.tsx
+++ b/apps/scan/frontend/src/screens/election_manager_screen.tsx
@@ -365,7 +365,6 @@ export function ElectionManagerScreen({
       title="Election Manager Menu"
       voterFacing={false}
       showTestModeBanner={false}
-      showEarlyVotingBanner={false}
     >
       <TabbedSection aria-label="Election Manager Menu" tabs={tabs} />
 

--- a/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
+++ b/apps/scan/frontend/src/screens/insert_ballot_screen.tsx
@@ -5,13 +5,11 @@ import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout'
 interface Props {
   scannedBallotCount: number;
   isTestMode: boolean;
-  isEarlyVotingMode: boolean;
 }
 
 export function InsertBallotScreen({
   scannedBallotCount,
   isTestMode,
-  isEarlyVotingMode,
 }: Props): JSX.Element {
   return (
     <Screen
@@ -19,7 +17,6 @@ export function InsertBallotScreen({
       ballotCountOverride={scannedBallotCount}
       voterFacing
       showTestModeBanner={isTestMode}
-      showEarlyVotingBanner={isEarlyVotingMode}
       // Don't read aloud "Insert your ballot" to ensure that prior "Your ballot was counted" audio
       // is not interrupted
       disableReadOnLoad
@@ -36,22 +33,10 @@ export function InsertBallotScreen({
 
 /* istanbul ignore next */
 export function ZeroBallotsScannedPreview(): JSX.Element {
-  return (
-    <InsertBallotScreen
-      scannedBallotCount={0}
-      isTestMode={false}
-      isEarlyVotingMode={false}
-    />
-  );
+  return <InsertBallotScreen scannedBallotCount={0} isTestMode={false} />;
 }
 
 /* istanbul ignore next */
 export function ManyBallotsScannedPreview(): JSX.Element {
-  return (
-    <InsertBallotScreen
-      scannedBallotCount={1234}
-      isTestMode={false}
-      isEarlyVotingMode={false}
-    />
-  );
+  return <InsertBallotScreen scannedBallotCount={1234} isTestMode={false} />;
 }

--- a/apps/scan/frontend/src/screens/insert_usb_screen.tsx
+++ b/apps/scan/frontend/src/screens/insert_usb_screen.tsx
@@ -22,7 +22,6 @@ export function InsertUsbScreen({
     <ScreenMainCenterChild
       disableSettingsButtons={enableAlarm}
       showTestModeBanner={false}
-      showEarlyVotingBanner={false}
       voterFacing={pollsState === 'polls_open'}
     >
       <CenteredText>

--- a/apps/scan/frontend/src/screens/internal_connection_problem_screen.tsx
+++ b/apps/scan/frontend/src/screens/internal_connection_problem_screen.tsx
@@ -34,7 +34,6 @@ export function InternalConnectionProblemScreen({
       ballotCountOverride={scannedBallotCount}
       voterFacing
       showTestModeBanner={false}
-      showEarlyVotingBanner={false}
     >
       <CenteredText>
         <H1>{appStrings.titleInternalConnectionProblem()}</H1>

--- a/apps/scan/frontend/src/screens/invalid_card_screen.tsx
+++ b/apps/scan/frontend/src/screens/invalid_card_screen.tsx
@@ -13,7 +13,6 @@ export function InvalidCardScreen({
       infoBarMode="pollworker"
       voterFacing={false}
       showTestModeBanner={false}
-      showEarlyVotingBanner={false}
     >
       <SharedInvalidCardScreen
         reasonAndContext={authStatus}

--- a/apps/scan/frontend/src/screens/loading_configuration_screen.tsx
+++ b/apps/scan/frontend/src/screens/loading_configuration_screen.tsx
@@ -3,11 +3,7 @@ import { CenteredText, ScreenMainCenterChild } from '../components/layout';
 
 export function LoadingConfigurationScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild
-      voterFacing={false}
-      showTestModeBanner={false}
-      showEarlyVotingBanner={false}
-    >
+    <ScreenMainCenterChild voterFacing={false} showTestModeBanner={false}>
       <LoadingAnimation />
       <CenteredText>
         <H1>Loading Configuration…</H1>

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -970,7 +970,6 @@ function PollWorkerScreenContents({
       infoBarMode="admin"
       voterFacing={false}
       showTestModeBanner={false}
-      showEarlyVotingBanner={false}
     >
       {content}
     </PlainScreen>

--- a/apps/scan/frontend/src/screens/poll_worker_shared.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_shared.tsx
@@ -8,10 +8,7 @@ import {
 export function Screen(
   props: Omit<
     CenteredScreenProps,
-    | 'infoBarMode'
-    | 'voterFacing'
-    | 'showTestModeBanner'
-    | 'showEarlyVotingBanner'
+    'infoBarMode' | 'voterFacing' | 'showTestModeBanner'
   >
 ): JSX.Element {
   const { children } = props;
@@ -21,7 +18,6 @@ export function Screen(
       infoBarMode="pollworker"
       voterFacing={false}
       showTestModeBanner={false}
-      showEarlyVotingBanner={false}
     >
       {children}
     </ScreenMainCenterChild>

--- a/apps/scan/frontend/src/screens/polls_not_open_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/polls_not_open_screen.test.tsx
@@ -36,7 +36,6 @@ function renderScreen(props: Partial<PollsNotOpenScreenProps> = {}) {
       apiMock,
       <PollsNotOpenScreen
         isTestMode={false}
-        isEarlyVotingMode={false}
         pollsState="polls_closed_initial"
         scannedBallotCount={TEST_BALLOT_COUNT}
         {...props}

--- a/apps/scan/frontend/src/screens/polls_not_open_screen.tsx
+++ b/apps/scan/frontend/src/screens/polls_not_open_screen.tsx
@@ -5,14 +5,12 @@ import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout'
 
 export interface PollsNotOpenScreenProps {
   isTestMode: boolean;
-  isEarlyVotingMode: boolean;
   pollsState: Omit<PollsState, 'polls_open'>;
   scannedBallotCount: number;
 }
 
 export function PollsNotOpenScreen({
   isTestMode,
-  isEarlyVotingMode,
   pollsState,
   scannedBallotCount,
 }: PollsNotOpenScreenProps): JSX.Element {
@@ -20,7 +18,6 @@ export function PollsNotOpenScreen({
     <Screen
       centerContent
       showTestModeBanner={isTestMode}
-      showEarlyVotingBanner={isEarlyVotingMode}
       infoBarMode="pollworker"
       ballotCountOverride={scannedBallotCount}
       voterFacing={false}
@@ -54,7 +51,6 @@ export function DefaultPreview(): JSX.Element {
   return (
     <PollsNotOpenScreen
       isTestMode={false}
-      isEarlyVotingMode={false}
       pollsState="polls_closed_initial"
       scannedBallotCount={42}
     />
@@ -66,7 +62,6 @@ export function DefaultTestModePreview(): JSX.Element {
   return (
     <PollsNotOpenScreen
       isTestMode
-      isEarlyVotingMode
       pollsState="polls_closed_initial"
       scannedBallotCount={42}
     />
@@ -78,7 +73,6 @@ export function NoPowerConnectedPreview(): JSX.Element {
   return (
     <PollsNotOpenScreen
       isTestMode={false}
-      isEarlyVotingMode={false}
       pollsState="polls_closed_initial"
       scannedBallotCount={42}
     />
@@ -90,7 +84,6 @@ export function PollsPausedPreview(): JSX.Element {
   return (
     <PollsNotOpenScreen
       isTestMode={false}
-      isEarlyVotingMode={false}
       pollsState="polls_paused"
       scannedBallotCount={42}
     />
@@ -102,7 +95,6 @@ export function PollsClosedFinalPreview(): JSX.Element {
   return (
     <PollsNotOpenScreen
       isTestMode={false}
-      isEarlyVotingMode={false}
       pollsState="polls_closed_final"
       scannedBallotCount={42}
     />

--- a/apps/scan/frontend/src/screens/printer_cover_open_screen.tsx
+++ b/apps/scan/frontend/src/screens/printer_cover_open_screen.tsx
@@ -3,11 +3,7 @@ import { CenteredText, ScreenMainCenterChild } from '../components/layout';
 
 export function PrinterCoverOpenScreen(): JSX.Element {
   return (
-    <ScreenMainCenterChild
-      voterFacing
-      showTestModeBanner={false}
-      showEarlyVotingBanner={false}
-    >
+    <ScreenMainCenterChild voterFacing showTestModeBanner={false}>
       <CenteredText>
         <H1>{appStrings.titlePrinterCoverIsOpen()}</H1>
         <P>{appStrings.instructionsAskForHelp()}</P>

--- a/apps/scan/frontend/src/screens/scan_busy_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_busy_screen.tsx
@@ -10,20 +10,13 @@ import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout'
 
 export interface ScanBusyScreenProps {
   isTestMode: boolean;
-  isEarlyVotingMode: boolean;
 }
 
 export function ScanBusyScreen({
   isTestMode,
-  isEarlyVotingMode,
 }: ScanBusyScreenProps): JSX.Element {
   return (
-    <Screen
-      centerContent
-      voterFacing
-      showTestModeBanner={isTestMode}
-      showEarlyVotingBanner={isEarlyVotingMode}
-    >
+    <Screen centerContent voterFacing showTestModeBanner={isTestMode}>
       <FullScreenPromptLayout
         title={appStrings.titleRemoveYourBallot()}
         image={
@@ -41,5 +34,5 @@ export function ScanBusyScreen({
 
 /* istanbul ignore next */
 export function DefaultPreview(): JSX.Element {
-  return <ScanBusyScreen isTestMode={false} isEarlyVotingMode={false} />;
+  return <ScanBusyScreen isTestMode={false} />;
 }

--- a/apps/scan/frontend/src/screens/scan_double_sheet_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_double_sheet_screen.test.tsx
@@ -25,11 +25,7 @@ test('renders double sheet screen as expected', async () => {
   render(
     provideApi(
       apiMock,
-      <ScanDoubleSheetScreen
-        scannedBallotCount={42}
-        isTestMode={false}
-        isEarlyVotingMode={false}
-      />
+      <ScanDoubleSheetScreen scannedBallotCount={42} isTestMode={false} />
     )
   );
   await screen.findByText('Multiple Sheets Detected');

--- a/apps/scan/frontend/src/screens/scan_double_sheet_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_double_sheet_screen.tsx
@@ -11,13 +11,11 @@ import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout'
 interface Props {
   scannedBallotCount: number;
   isTestMode: boolean;
-  isEarlyVotingMode: boolean;
 }
 
 export function ScanDoubleSheetScreen({
   scannedBallotCount,
   isTestMode,
-  isEarlyVotingMode,
 }: Props): JSX.Element {
   return (
     <Screen
@@ -25,7 +23,6 @@ export function ScanDoubleSheetScreen({
       ballotCountOverride={scannedBallotCount}
       voterFacing
       showTestModeBanner={isTestMode}
-      showEarlyVotingBanner={isEarlyVotingMode}
     >
       <FullScreenPromptLayout
         title={appStrings.titleScannerMultipleSheetsDetected()}
@@ -44,11 +41,5 @@ export function ScanDoubleSheetScreen({
 
 /* istanbul ignore next */
 export function DefaultPreview(): JSX.Element {
-  return (
-    <ScanDoubleSheetScreen
-      scannedBallotCount={42}
-      isTestMode={false}
-      isEarlyVotingMode={false}
-    />
-  );
+  return <ScanDoubleSheetScreen scannedBallotCount={42} isTestMode={false} />;
 }

--- a/apps/scan/frontend/src/screens/scan_error_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.test.tsx
@@ -25,12 +25,7 @@ test('render correct unreadable ballot screen', async () => {
   render(
     provideApi(
       apiMock,
-      <ScanErrorScreen
-        error="unreadable"
-        isTestMode
-        isEarlyVotingMode
-        scannedBallotCount={42}
-      />
+      <ScanErrorScreen error="unreadable" isTestMode scannedBallotCount={42} />
     )
   );
   await screen.findByText('Ballot Scan Failed');
@@ -47,7 +42,6 @@ test('render correct test ballot error screen when we are in test mode', async (
       <ScanErrorScreen
         error="invalid_test_mode"
         isTestMode
-        isEarlyVotingMode
         scannedBallotCount={42}
       />
     )
@@ -66,7 +60,6 @@ test('render correct test ballot error screen when we are in live mode', async (
       <ScanErrorScreen
         error="invalid_test_mode"
         isTestMode={false}
-        isEarlyVotingMode={false}
         scannedBallotCount={42}
       />
     )
@@ -85,7 +78,6 @@ test('render correct invalid precinct screen', async () => {
       <ScanErrorScreen
         error="invalid_precinct"
         isTestMode
-        isEarlyVotingMode
         scannedBallotCount={42}
       />
     )
@@ -104,7 +96,6 @@ test('render correct invalid ballot hash screen', async () => {
       <ScanErrorScreen
         error="invalid_ballot_hash"
         isTestMode={false}
-        isEarlyVotingMode={false}
         scannedBallotCount={42}
       />
     )
@@ -123,7 +114,6 @@ test('render correct BMD ballot scanning disabled screen', async () => {
       <ScanErrorScreen
         error="bmd_ballot_scanning_disabled"
         isTestMode={false}
-        isEarlyVotingMode={false}
         scannedBallotCount={42}
       />
     )
@@ -142,7 +132,6 @@ test('warning when scanner needs cleaning', async () => {
       <ScanErrorScreen
         error="vertical_streaks_detected"
         isTestMode
-        isEarlyVotingMode
         scannedBallotCount={42}
       />
     )
@@ -161,7 +150,6 @@ test('warning when ballot was printed with the wrong scale', async () => {
       <ScanErrorScreen
         error="invalid_scale"
         isTestMode
-        isEarlyVotingMode
         scannedBallotCount={42}
       />
     )
@@ -179,7 +167,6 @@ test('double feed error screen', async () => {
       <ScanErrorScreen
         error="double_feed_detected"
         isTestMode
-        isEarlyVotingMode
         scannedBallotCount={42}
       />
     )
@@ -196,7 +183,6 @@ test('recoverable error screen', async () => {
       <ScanErrorScreen
         error="paper_in_back_after_reconnect"
         isTestMode
-        isEarlyVotingMode
         scannedBallotCount={42}
       />
     )
@@ -216,7 +202,6 @@ test('restart required', async () => {
         restartRequired
         error="client_error"
         isTestMode
-        isEarlyVotingMode
         scannedBallotCount={42}
       />
     )

--- a/apps/scan/frontend/src/screens/scan_error_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_error_screen.tsx
@@ -17,7 +17,6 @@ import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout'
 export interface Props {
   error?: InvalidInterpretationReason | PrecinctScannerErrorType;
   isTestMode: boolean;
-  isEarlyVotingMode: boolean;
   scannedBallotCount: number;
   restartRequired?: boolean;
 }
@@ -25,7 +24,6 @@ export interface Props {
 export function ScanErrorScreen({
   error,
   isTestMode,
-  isEarlyVotingMode,
   scannedBallotCount,
   restartRequired = false,
 }: Props): JSX.Element {
@@ -137,7 +135,6 @@ export function ScanErrorScreen({
     <Screen
       centerContent
       showTestModeBanner={isTestMode}
-      showEarlyVotingBanner={isEarlyVotingMode}
       ballotCountOverride={scannedBallotCount}
       voterFacing
     >
@@ -161,7 +158,6 @@ export function UnreadablePreview(): JSX.Element {
   return (
     <ScanErrorScreen
       isTestMode={false}
-      isEarlyVotingMode={false}
       error="unreadable"
       scannedBallotCount={42}
     />
@@ -173,7 +169,6 @@ export function InvalidBallotHashPreview(): JSX.Element {
   return (
     <ScanErrorScreen
       isTestMode={false}
-      isEarlyVotingMode={false}
       error="invalid_ballot_hash"
       scannedBallotCount={42}
     />
@@ -185,7 +180,6 @@ export function InvalidBallotTestModePreview(): JSX.Element {
   return (
     <ScanErrorScreen
       isTestMode
-      isEarlyVotingMode
       error="invalid_test_mode"
       scannedBallotCount={42}
     />
@@ -197,7 +191,6 @@ export function InvalidBallotPreview(): JSX.Element {
   return (
     <ScanErrorScreen
       isTestMode={false}
-      isEarlyVotingMode={false}
       error="invalid_test_mode"
       scannedBallotCount={42}
     />
@@ -209,7 +202,6 @@ export function InvalidPrecinctPreview(): JSX.Element {
   return (
     <ScanErrorScreen
       isTestMode={false}
-      isEarlyVotingMode={false}
       error="invalid_precinct"
       scannedBallotCount={42}
     />
@@ -221,7 +213,6 @@ export function UnknownInterpretationErrorPreview(): JSX.Element {
   return (
     <ScanErrorScreen
       isTestMode={false}
-      isEarlyVotingMode={false}
       error="unknown"
       scannedBallotCount={42}
     />
@@ -233,7 +224,6 @@ export function AfterReconnectBallotInFrontPreview(): JSX.Element {
   return (
     <ScanErrorScreen
       isTestMode={false}
-      isEarlyVotingMode={false}
       error="paper_in_front_after_reconnect"
       scannedBallotCount={42}
     />
@@ -245,7 +235,6 @@ export function AfterReconnectBallotInBackPreview(): JSX.Element {
   return (
     <ScanErrorScreen
       isTestMode={false}
-      isEarlyVotingMode={false}
       error="paper_in_back_after_reconnect"
       scannedBallotCount={42}
     />
@@ -257,7 +246,6 @@ export function UnexpectedScannerErrorPreview(): JSX.Element {
   return (
     <ScanErrorScreen
       isTestMode={false}
-      isEarlyVotingMode={false}
       error="client_error"
       scannedBallotCount={42}
       restartRequired
@@ -270,7 +258,6 @@ export function VerticalStreaksDetectedErrorPreview(): JSX.Element {
   return (
     <ScanErrorScreen
       isTestMode={false}
-      isEarlyVotingMode={false}
       error="vertical_streaks_detected"
       scannedBallotCount={42}
     />
@@ -282,7 +269,6 @@ export function DoubleSheetErrorPreview(): JSX.Element {
   return (
     <ScanErrorScreen
       isTestMode={false}
-      isEarlyVotingMode={false}
       error="double_feed_detected"
       scannedBallotCount={42}
     />

--- a/apps/scan/frontend/src/screens/scan_jam_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_jam_screen.tsx
@@ -13,14 +13,12 @@ interface Props {
   error?: PrecinctScannerErrorType;
   scannedBallotCount: number;
   isTestMode: boolean;
-  isEarlyVotingMode: boolean;
 }
 
 export function ScanJamScreen({
   error,
   scannedBallotCount,
   isTestMode,
-  isEarlyVotingMode,
 }: Props): JSX.Element {
   const isOutfeedBlocked = error === 'outfeed_blocked';
   return (
@@ -29,7 +27,6 @@ export function ScanJamScreen({
       ballotCountOverride={scannedBallotCount}
       voterFacing
       showTestModeBanner={isTestMode}
-      showEarlyVotingBanner={isEarlyVotingMode}
     >
       <FullScreenPromptLayout
         title={
@@ -54,13 +51,7 @@ export function ScanJamScreen({
 
 /* istanbul ignore next */
 export function InternalJamPreview(): JSX.Element {
-  return (
-    <ScanJamScreen
-      scannedBallotCount={42}
-      isTestMode={false}
-      isEarlyVotingMode={false}
-    />
-  );
+  return <ScanJamScreen scannedBallotCount={42} isTestMode={false} />;
 }
 
 /* istanbul ignore next */
@@ -70,7 +61,6 @@ export function OutfeedJamPreview(): JSX.Element {
       scannedBallotCount={42}
       error="outfeed_blocked"
       isTestMode={false}
-      isEarlyVotingMode={false}
     />
   );
 }

--- a/apps/scan/frontend/src/screens/scan_processing_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_processing_screen.tsx
@@ -3,19 +3,13 @@ import { CenteredText, ScreenMainCenterChild } from '../components/layout';
 
 export interface ScanProcessingScreenProps {
   isTestMode: boolean;
-  isEarlyVotingMode: boolean;
 }
 
 export function ScanProcessingScreen({
   isTestMode,
-  isEarlyVotingMode,
 }: ScanProcessingScreenProps): JSX.Element {
   return (
-    <ScreenMainCenterChild
-      voterFacing
-      showTestModeBanner={isTestMode}
-      showEarlyVotingBanner={isEarlyVotingMode}
-    >
+    <ScreenMainCenterChild voterFacing showTestModeBanner={isTestMode}>
       <LoadingAnimation />
       <CenteredText>
         <H1>{appStrings.titleScannerProcessingScreen()}</H1>
@@ -27,5 +21,5 @@ export function ScanProcessingScreen({
 
 /* istanbul ignore next */
 export function DefaultPreview(): JSX.Element {
-  return <ScanProcessingScreen isTestMode={false} isEarlyVotingMode={false} />;
+  return <ScanProcessingScreen isTestMode={false} />;
 }

--- a/apps/scan/frontend/src/screens/scan_returned_ballot_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_returned_ballot_screen.tsx
@@ -3,19 +3,13 @@ import { CenteredText, ScreenMainCenterChild } from '../components/layout';
 
 export interface ScanReturnedBallotScreenProps {
   isTestMode: boolean;
-  isEarlyVotingMode: boolean;
 }
 
 export function ScanReturnedBallotScreen({
   isTestMode,
-  isEarlyVotingMode,
 }: ScanReturnedBallotScreenProps): JSX.Element {
   return (
-    <ScreenMainCenterChild
-      voterFacing
-      showTestModeBanner={isTestMode}
-      showEarlyVotingBanner={isEarlyVotingMode}
-    >
+    <ScreenMainCenterChild voterFacing showTestModeBanner={isTestMode}>
       {/* TODO: make a graphic for this screen */}
       <CenteredText>
         <H1>{appStrings.titleRemoveYourBallot()}</H1>
@@ -27,7 +21,5 @@ export function ScanReturnedBallotScreen({
 
 /* istanbul ignore next */
 export function DefaultPreview(): JSX.Element {
-  return (
-    <ScanReturnedBallotScreen isTestMode={false} isEarlyVotingMode={false} />
-  );
+  return <ScanReturnedBallotScreen isTestMode={false} />;
 }

--- a/apps/scan/frontend/src/screens/scan_success_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_success_screen.tsx
@@ -6,13 +6,11 @@ import { FullScreenPromptLayout } from '../components/full_screen_prompt_layout'
 interface Props {
   scannedBallotCount: number;
   isTestMode: boolean;
-  isEarlyVotingMode: boolean;
 }
 
 export function ScanSuccessScreen({
   scannedBallotCount,
   isTestMode,
-  isEarlyVotingMode,
 }: Props): JSX.Element {
   return (
     <Screen
@@ -20,7 +18,6 @@ export function ScanSuccessScreen({
       ballotCountOverride={scannedBallotCount}
       voterFacing
       showTestModeBanner={isTestMode}
-      showEarlyVotingBanner={isEarlyVotingMode}
     >
       <FullScreenPromptLayout
         title={appStrings.titleScannerSuccessScreen()}
@@ -38,11 +35,5 @@ export function ScanSuccessScreen({
 
 /* istanbul ignore next */
 export function DefaultPreview(): JSX.Element {
-  return (
-    <ScanSuccessScreen
-      scannedBallotCount={42}
-      isTestMode={false}
-      isEarlyVotingMode={false}
-    />
-  );
+  return <ScanSuccessScreen scannedBallotCount={42} isTestMode={false} />;
 }

--- a/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
@@ -66,7 +66,6 @@ function renderScreen(props: Partial<Props> = {}) {
         systemSettings={DEFAULT_SYSTEM_SETTINGS}
         adjudicationReasonInfo={[]}
         isTestMode={false}
-        isEarlyVotingMode={false}
         {...props}
       />
     )

--- a/apps/scan/frontend/src/screens/scan_warning_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.tsx
@@ -33,7 +33,6 @@ interface MisvoteWarningScreenProps {
   overvotes: readonly OvervoteAdjudicationReasonInfo[];
   undervotes: readonly UndervoteAdjudicationReasonInfo[];
   isTestMode: boolean;
-  isEarlyVotingMode: boolean;
 }
 
 function MisvoteWarningScreen({
@@ -42,7 +41,6 @@ function MisvoteWarningScreen({
   overvotes,
   undervotes,
   isTestMode,
-  isEarlyVotingMode,
 }: MisvoteWarningScreenProps): JSX.Element {
   const returnBallotMutation = returnBallot.useMutation();
   const acceptBallotMutation = acceptBallot.useMutation();
@@ -136,7 +134,6 @@ function MisvoteWarningScreen({
       }
       voterFacing
       showTestModeBanner={isTestMode}
-      showEarlyVotingBanner={isEarlyVotingMode}
     >
       <MisvoteWarnings
         blankContests={blankContests}
@@ -149,12 +146,10 @@ function MisvoteWarningScreen({
 
 interface BlankBallotWarningScreenProps {
   isTestMode: boolean;
-  isEarlyVotingMode: boolean;
 }
 
 function BlankBallotWarningScreen({
   isTestMode,
-  isEarlyVotingMode,
 }: BlankBallotWarningScreenProps): JSX.Element {
   const returnBallotMutation = returnBallot.useMutation();
   const acceptBallotMutation = acceptBallot.useMutation();
@@ -190,7 +185,6 @@ function BlankBallotWarningScreen({
       padded
       voterFacing
       showTestModeBanner={isTestMode}
-      showEarlyVotingBanner={isEarlyVotingMode}
     >
       <FullScreenPromptLayout
         title={appStrings.titleScannerBallotWarningsScreen()}
@@ -209,12 +203,10 @@ function BlankBallotWarningScreen({
 
 interface CrossoverVotingWarningScreenProps {
   isTestMode: boolean;
-  isEarlyVotingMode: boolean;
 }
 
 function CrossoverVotingWarningScreen({
   isTestMode,
-  isEarlyVotingMode,
 }: CrossoverVotingWarningScreenProps): JSX.Element {
   const returnBallotMutation = returnBallot.useMutation();
   const acceptBallotMutation = acceptBallot.useMutation();
@@ -250,7 +242,6 @@ function CrossoverVotingWarningScreen({
       padded
       voterFacing
       showTestModeBanner={isTestMode}
-      showEarlyVotingBanner={isEarlyVotingMode}
     >
       <FullScreenPromptLayout
         title={appStrings.titleScannerBallotWarningsScreen()}
@@ -269,12 +260,10 @@ function CrossoverVotingWarningScreen({
 
 interface OtherReasonWarningScreenProps {
   isTestMode: boolean;
-  isEarlyVotingMode: boolean;
 }
 
 function OtherReasonWarningScreen({
   isTestMode,
-  isEarlyVotingMode,
 }: OtherReasonWarningScreenProps): JSX.Element {
   const returnBallotMutation = returnBallot.useMutation();
   const acceptBallotMutation = acceptBallot.useMutation();
@@ -310,7 +299,6 @@ function OtherReasonWarningScreen({
       padded
       voterFacing
       showTestModeBanner={isTestMode}
-      showEarlyVotingBanner={isEarlyVotingMode}
     >
       <FullScreenPromptLayout
         title={appStrings.titleScanningFailed()}
@@ -332,7 +320,6 @@ export interface Props {
   adjudicationReasonInfo: readonly AdjudicationReasonInfo[];
   systemSettings: SystemSettings;
   isTestMode: boolean;
-  isEarlyVotingMode: boolean;
 }
 
 export function ScanWarningScreen({
@@ -340,7 +327,6 @@ export function ScanWarningScreen({
   adjudicationReasonInfo,
   systemSettings,
   isTestMode,
-  isEarlyVotingMode,
 }: Props): JSX.Element {
   let isBlank = false;
   let isCrossover = false;
@@ -360,21 +346,11 @@ export function ScanWarningScreen({
   }
 
   if (isCrossover) {
-    return (
-      <CrossoverVotingWarningScreen
-        isTestMode={isTestMode}
-        isEarlyVotingMode={isEarlyVotingMode}
-      />
-    );
+    return <CrossoverVotingWarningScreen isTestMode={isTestMode} />;
   }
 
   if (isBlank) {
-    return (
-      <BlankBallotWarningScreen
-        isTestMode={isTestMode}
-        isEarlyVotingMode={isEarlyVotingMode}
-      />
-    );
+    return <BlankBallotWarningScreen isTestMode={isTestMode} />;
   }
 
   if (undervoteReasons.length > 0 || overvoteReasons.length > 0) {
@@ -385,17 +361,11 @@ export function ScanWarningScreen({
         undervotes={undervoteReasons}
         overvotes={overvoteReasons}
         isTestMode={isTestMode}
-        isEarlyVotingMode={isEarlyVotingMode}
       />
     );
   }
 
-  return (
-    <OtherReasonWarningScreen
-      isTestMode={isTestMode}
-      isEarlyVotingMode={isEarlyVotingMode}
-    />
-  );
+  return <OtherReasonWarningScreen isTestMode={isTestMode} />;
 }
 
 /* istanbul ignore next */
@@ -432,7 +402,6 @@ export function OvervotePreview(): JSX.Element {
       ]}
       systemSettings={DEFAULT_SYSTEM_SETTINGS}
       isTestMode={false}
-      isEarlyVotingMode={false}
     />
   );
 }
@@ -464,7 +433,6 @@ export function UndervoteNoVotes1ContestPreview(): JSX.Element {
         },
       ]}
       isTestMode={false}
-      isEarlyVotingMode={false}
     />
   );
 }
@@ -494,7 +462,6 @@ export function UndervoteNoVotesManyContestsPreview(): JSX.Element {
         expected: contest.seats,
       }))}
       isTestMode={false}
-      isEarlyVotingMode={false}
     />
   );
 }
@@ -528,7 +495,6 @@ export function Undervote1ContestPreview(): JSX.Element {
         },
       ]}
       isTestMode={false}
-      isEarlyVotingMode={false}
     />
   );
 }
@@ -574,7 +540,6 @@ export function MixedOvervotesAndUndervotesPreview(): JSX.Element {
         })),
       ]}
       isTestMode={false}
-      isEarlyVotingMode={false}
     />
   );
 }
@@ -594,7 +559,6 @@ export function CrossoverVotingPreview(): JSX.Element {
       systemSettings={DEFAULT_SYSTEM_SETTINGS}
       adjudicationReasonInfo={[{ type: AdjudicationReason.CrossoverVoting }]}
       isTestMode={false}
-      isEarlyVotingMode={false}
     />
   );
 }
@@ -614,7 +578,6 @@ export function BlankBallotPreview(): JSX.Element {
       systemSettings={DEFAULT_SYSTEM_SETTINGS}
       adjudicationReasonInfo={[{ type: AdjudicationReason.BlankBallot }]}
       isTestMode={false}
-      isEarlyVotingMode={false}
     />
   );
 }

--- a/apps/scan/frontend/src/screens/scanner_cover_open_screen.tsx
+++ b/apps/scan/frontend/src/screens/scanner_cover_open_screen.tsx
@@ -14,7 +14,6 @@ export function ScannerCoverOpenScreen({ disableAlarm }: Props): JSX.Element {
     <ScreenMainCenterChild
       disableSettingsButtons={enableAlarm}
       showTestModeBanner={false}
-      showEarlyVotingBanner={false}
       voterFacing
     >
       <CenteredText>

--- a/apps/scan/frontend/src/screens/system_administrator_screen.tsx
+++ b/apps/scan/frontend/src/screens/system_administrator_screen.tsx
@@ -55,7 +55,6 @@ export function SystemAdministratorScreen({
       title="System Administrator Menu"
       voterFacing={false}
       showTestModeBanner={false}
-      showEarlyVotingBanner={false}
       infoBarMode="admin"
       padded
       hideBallotCount

--- a/apps/scan/frontend/src/screens/unconfigured_polling_place_screen.tsx
+++ b/apps/scan/frontend/src/screens/unconfigured_polling_place_screen.tsx
@@ -8,11 +8,7 @@ import { CenteredText, ScreenMainCenterChild } from '../components/layout';
 export function UnconfiguredPollingPlaceScreen(): JSX.Element {
   if (!isFeatureFlagEnabled(Feature.ENABLE_POLLING_PLACES)) {
     return (
-      <ScreenMainCenterChild
-        voterFacing={false}
-        showTestModeBanner={false}
-        showEarlyVotingBanner={false}
-      >
+      <ScreenMainCenterChild voterFacing={false} showTestModeBanner={false}>
         <CenteredText>
           <H1>No Precinct Selected</H1>
           <P>Insert an election manager card to select a precinct.</P>
@@ -22,11 +18,7 @@ export function UnconfiguredPollingPlaceScreen(): JSX.Element {
   }
 
   return (
-    <ScreenMainCenterChild
-      voterFacing={false}
-      showTestModeBanner={false}
-      showEarlyVotingBanner={false}
-    >
+    <ScreenMainCenterChild voterFacing={false} showTestModeBanner={false}>
       <CenteredText>
         <H1>No Polling Place Selected</H1>
         <P>Insert an election manager card to select a polling place.</P>

--- a/apps/scan/frontend/src/screens/voter_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.test.tsx
@@ -40,7 +40,6 @@ function renderScreen(
         electionDefinition={electionDefinition}
         isSoundMuted={false}
         isTestMode={false}
-        isEarlyVotingMode={false}
         systemSettings={DEFAULT_SYSTEM_SETTINGS}
         {...props}
       />

--- a/apps/scan/frontend/src/screens/voter_screen.tsx
+++ b/apps/scan/frontend/src/screens/voter_screen.tsx
@@ -24,7 +24,6 @@ export interface VoterScreenProps {
   electionDefinition: ElectionDefinition;
   systemSettings: SystemSettings;
   isTestMode: boolean;
-  isEarlyVotingMode: boolean;
   isSoundMuted: boolean;
 }
 
@@ -32,7 +31,6 @@ export function VoterScreen({
   electionDefinition,
   systemSettings,
   isTestMode,
-  isEarlyVotingMode,
   isSoundMuted,
 }: VoterScreenProps): JSX.Element | null {
   const scannerStatusQuery = getScannerStatus.useQuery({
@@ -130,7 +128,6 @@ export function VoterScreen({
 
   const sharedScreenProps = {
     isTestMode,
-    isEarlyVotingMode,
     scannedBallotCount: scannerStatus.ballotsCounted,
   } as const;
 


### PR DESCRIPTION
## Overview

Closes #8661.

The display pattern of the early voting mode banner was modeled after the test mode banner, but these are different use cases. The test mode banners is part-status and part-warning - it's very loud - and is only shown on the unauthenticated and voting flow screens where you'd want to make sure you're in official mode. The early voting mode icon is more of a status than a warning, and it blipping in and out of place in the footer as you authenticate (because the footer itself is already consistent across screens) seemed like unnecessary change on screen. 

This PR moves the status check down into the layout component and always renders the early voting status on all screens.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.