### PR TITLE
VxDesign: Load v4.0 elections

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -62,6 +62,7 @@ import {
   ElectionPackageFileName,
   safeParseElectionDefinitionV4p0,
   LATEST_SOFTWARE_VERSION,
+  convertLatestElectionToV4p0,
 } from '@votingworks/types';
 import {
   ballotStyleHasPrecinctOrSplit,
@@ -4659,7 +4660,7 @@ test('CDF exports', async () => {
   );
 });
 
-test('v4.0 exports', async () => {
+test('v4.0 elections', async () => {
   const v4p0Jurisdiction: Jurisdiction = {
     ...nonVxJurisdiction,
     softwareVersion: 'v4.0',
@@ -4677,6 +4678,7 @@ test('v4.0 exports', async () => {
     users: [v4p0User],
   });
 
+  // Load election can import a v4.0 election
   auth0.setLoggedInUser(nonVxUser);
   const electionId = (
     await apiClient.loadElection({
@@ -4684,7 +4686,9 @@ test('v4.0 exports', async () => {
       jurisdictionId: v4p0Jurisdiction.id,
       upload: {
         format: 'vxf',
-        electionFileContents: baseElectionDefinition.electionData,
+        electionFileContents: JSON.stringify(
+          convertLatestElectionToV4p0(baseElectionDefinition.election)
+        ),
       },
     })
   ).unsafeUnwrap();

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -33,7 +33,6 @@ import {
   safeParseJson,
   CastVoteRecordReportWithoutMetadataSchema,
   PrecinctSelection,
-  safeParseElection,
   BallotStyle,
   formatBallotHash,
   PollingPlaceSchema,
@@ -42,6 +41,7 @@ import {
   hasPartialRegisteredVoterCounts,
   getPrecinctsWithoutAbsenteePollingPlace,
   ElectionTypeSchema,
+  safeParseElectionDefinitionForAnySoftwareVersion,
 } from '@votingworks/types';
 import express, { Application } from 'express';
 import {
@@ -359,9 +359,10 @@ export function buildApi(ctx: AppContext) {
         const election = ((): Election => {
           switch (input.upload.format) {
             case 'vxf': {
-              const sourceElection = safeParseElection(
-                input.upload.electionFileContents
-              ).unsafeUnwrap();
+              const { election: sourceElection } =
+                safeParseElectionDefinitionForAnySoftwareVersion(
+                  input.upload.electionFileContents
+                ).unsafeUnwrap();
 
               const { districts, precincts, parties, contests, pollingPlaces } =
                 regenerateElectionIds(sourceElection, stateFeatures);


### PR DESCRIPTION


## Overview

<!-- Add a link to a GitHub issue here -->
Allow loading elections from past software versions (currently just v4.0). Loading an election is mostly used as a convenience for internal usage, so I thought this would be a nice quality-of-life improvement since we already have the functionality to parse previous election versions.

## Demo Video or Screenshot
N/A

## Testing Plan
Updated automated test
## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
