### PR TITLE
[VxDesign] Add OMIT_ABSENTEE_POLLING_PLACES state flag and appropriate behavior

### DIFF
--- a/apps/design/backend/src/app.state_ms.test.ts
+++ b/apps/design/backend/src/app.state_ms.test.ts
@@ -1,6 +1,6 @@
 import { vi, afterAll, expect, test } from 'vitest';
 import {
-  CENTRAL_SCANNING_POLLING_PLACE_ID,
+  centralScanningPollingPlaceId,
   CENTRAL_SCANNING_POLLING_PLACE_NAME,
   ElectionIdSchema,
   formatBallotHash,
@@ -281,7 +281,7 @@ test('a Central Scanning absentee polling place is added to the export for Missi
   );
   expect(absenteePlaces).toEqual([
     {
-      id: CENTRAL_SCANNING_POLLING_PLACE_ID,
+      id: centralScanningPollingPlaceId(exportedElection.id),
       name: CENTRAL_SCANNING_POLLING_PLACE_NAME,
       type: 'absentee',
       precincts: Object.fromEntries(

--- a/apps/design/backend/src/app.state_ms.test.ts
+++ b/apps/design/backend/src/app.state_ms.test.ts
@@ -1,5 +1,7 @@
 import { vi, afterAll, expect, test } from 'vitest';
 import {
+  CENTRAL_SCANNING_POLLING_PLACE_ID,
+  CENTRAL_SCANNING_POLLING_PLACE_NAME,
   ElectionIdSchema,
   formatBallotHash,
   HmpbBallotPaperSize,
@@ -8,7 +10,10 @@ import {
 import { err, ok } from '@votingworks/basics';
 import { readElectionPackageFromBuffer } from '@votingworks/backend';
 import { suppressingConsoleOutput } from '@votingworks/test-utils';
-import { readElectionGeneralDefinition } from '@votingworks/fixtures';
+import {
+  electionGeneralFixtures,
+  readElectionGeneralDefinition,
+} from '@votingworks/fixtures';
 import {
   exportElectionPackage,
   generateAllPrecinctsTallyReport,
@@ -17,7 +22,9 @@ import {
   testSetupHelpers,
 } from '../test/helpers';
 import {
+  anotherNonVxUser,
   jurisdictions,
+  msJurisdiction,
   organizations,
   users,
   vxJurisdiction,
@@ -189,4 +196,100 @@ test('convert MS results', async () => {
       `"Invalid Record Length: columns length is 7, got 1 on line 987"`
     );
   });
+});
+
+test('finalizing a Mississippi election does not require absentee polling places', async () => {
+  const { apiClient, auth0 } = await setupApp({
+    organizations,
+    jurisdictions,
+    users,
+  });
+  // Mississippi is a non-editing state, where a Central Scanning absentee place
+  // is auto-generated on export rather than validated at finalization, so
+  // finalizing requires no user-defined absentee polling places.
+  auth0.setLoggedInUser(anotherNonVxUser);
+  const electionId = (
+    await apiClient.loadElection({
+      newId: unsafeParse(ElectionIdSchema, 'election-finalize'),
+      jurisdictionId: msJurisdiction.id,
+      upload: {
+        format: 'vxf',
+        electionFileContents: JSON.stringify(
+          electionGeneralFixtures.readElection()
+        ),
+      },
+    })
+  ).unsafeUnwrap();
+
+  await apiClient.finalizeBallots({ electionId });
+  expect(await apiClient.getBallotsFinalizedAt({ electionId })).not.toEqual(
+    null
+  );
+});
+
+test('a Central Scanning absentee polling place is added to the export for Mississippi', async () => {
+  const { apiClient, auth0, workspace, fileStorageClient } = await setupApp({
+    organizations,
+    jurisdictions,
+    users,
+  });
+  auth0.setLoggedInUser(anotherNonVxUser);
+
+  const electionId = (
+    await apiClient.loadElection({
+      newId: unsafeParse(ElectionIdSchema, 'election-export'),
+      jurisdictionId: msJurisdiction.id,
+      upload: {
+        format: 'vxf',
+        electionFileContents: JSON.stringify(
+          electionGeneralFixtures.readElection()
+        ),
+      },
+    })
+  ).unsafeUnwrap();
+  await apiClient.updateBallotLayoutSettings({
+    electionId,
+    paperSize: HmpbBallotPaperSize.Legal,
+    compact: true,
+  });
+
+  const exportMeta = await exportElectionPackage({
+    apiClient,
+    workspace,
+    fileStorageClient,
+    electionId,
+    electionSerializationFormat: 'vxf',
+    shouldExportAudio: false,
+    shouldExportSampleBallots: false,
+    shouldExportTestBallots: false,
+    numAuditIdBallots: undefined,
+  });
+  const electionPackageContents = getExportedFile({
+    storage: fileStorageClient,
+    jurisdictionId: msJurisdiction.id,
+    url: exportMeta.electionPackageUrl,
+  });
+  const { electionPackage } = (
+    await readElectionPackageFromBuffer(electionPackageContents)
+  ).unsafeUnwrap();
+
+  // A single Central Scanning absentee place covering every precinct is added
+  // on export, since Mississippi has no user-defined absentee polling places.
+  const exportedElection = electionPackage.electionDefinition.election;
+  const absenteePlaces = (exportedElection.pollingPlaces ?? []).filter(
+    (place) => place.type === 'absentee'
+  );
+  expect(absenteePlaces).toEqual([
+    {
+      id: CENTRAL_SCANNING_POLLING_PLACE_ID,
+      name: CENTRAL_SCANNING_POLLING_PLACE_NAME,
+      type: 'absentee',
+      precincts: Object.fromEntries(
+        exportedElection.precincts.map((precinct) => [
+          precinct.id,
+          { type: 'whole' },
+        ])
+      ),
+    },
+  ]);
 });

--- a/apps/design/backend/src/app.state_nh.test.ts
+++ b/apps/design/backend/src/app.state_nh.test.ts
@@ -8,6 +8,7 @@ import { nhStateGeneralElectionFixtures } from '@votingworks/hmpb';
 import {
   Election,
   hasSplits,
+  HmpbBallotPaperSize,
   PrecinctWithSplits,
   LanguageCode,
   BallotType,
@@ -15,6 +16,7 @@ import {
   PrecinctWithoutSplits,
   YesNoContest,
 } from '@votingworks/types';
+import { readElectionPackageFromBuffer } from '@votingworks/backend';
 import { ballotStyleHasPrecinctOrSplit } from '@votingworks/utils';
 import { readFileSync } from 'node:fs';
 import { vi, test, expect, afterAll } from 'vitest';
@@ -25,7 +27,11 @@ import {
   nonVxUser,
   nhJurisdiction,
 } from '../test/mocks';
-import { testSetupHelpers } from '../test/helpers';
+import {
+  exportElectionPackage,
+  getExportedFile,
+  testSetupHelpers,
+} from '../test/helpers';
 
 const nhUser = nonVxUser;
 const signatureSvg = readFileSync('./test/mockSignature.svg').toString();
@@ -378,4 +384,76 @@ test('getBallotPreviewPdf routes Federal Office Only ballots when isFederalOffic
     })
   ).unsafeUnwrap();
   expect(fooResult.fileName).toMatch(/-foo\.pdf$/);
+});
+
+test('absentee polling places imported into an NH election are not exported', async () => {
+  const { apiClient, auth0, workspace, fileStorageClient } = await setupApp({
+    organizations,
+    jurisdictions,
+    users,
+  });
+  auth0.setLoggedInUser(nhUser);
+
+  const baseElection = electionGeneralFixtures.readElection();
+  const election: Election = {
+    ...baseElection,
+    state: 'New Hampshire',
+    signature: { caption: 'Test Clerk', image: signatureSvg },
+    ballotLayout: {
+      ...baseElection.ballotLayout,
+      paperSize: HmpbBallotPaperSize.Legal,
+    },
+    // An imported absentee polling place should be dropped on import and never
+    // appear in the export, since NH omits absentee polling places.
+    pollingPlaces: [
+      {
+        id: 'imported-absentee',
+        name: 'Imported Absentee Location',
+        type: 'absentee',
+        precincts: Object.fromEntries(
+          baseElection.precincts.map((precinct) => [
+            precinct.id,
+            { type: 'whole' },
+          ])
+        ),
+      },
+    ],
+  };
+
+  const electionId = (
+    await apiClient.loadElection({
+      newId: 'new-election-id',
+      jurisdictionId: nhJurisdiction.id,
+      upload: { format: 'vxf', electionFileContents: JSON.stringify(election) },
+    })
+  ).unsafeUnwrap();
+
+  const exportMeta = await exportElectionPackage({
+    apiClient,
+    workspace,
+    fileStorageClient,
+    electionId,
+    electionSerializationFormat: 'vxf',
+    shouldExportAudio: false,
+    shouldExportSampleBallots: false,
+    shouldExportTestBallots: false,
+    numAuditIdBallots: undefined,
+  });
+  const electionPackageContents = getExportedFile({
+    storage: fileStorageClient,
+    jurisdictionId: nhJurisdiction.id,
+    url: exportMeta.electionPackageUrl,
+  });
+  const { electionPackage } = (
+    await readElectionPackageFromBuffer(electionPackageContents)
+  ).unsafeUnwrap();
+
+  const exportedPollingPlaces =
+    electionPackage.electionDefinition.election.pollingPlaces ?? [];
+  // NH generates election day places on export and omits absentee places, so
+  // the imported absentee place does not survive.
+  expect(exportedPollingPlaces.length).toBeGreaterThan(0);
+  expect(
+    exportedPollingPlaces.every((place) => place.type === 'election_day')
+  ).toEqual(true);
 });

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -16,6 +16,7 @@ import {
 } from '@votingworks/basics';
 import {
   electionFamousNames2021Fixtures,
+  electionGeneralFixtures,
   electionOpenPrimaryFixtures,
   electionPrimaryPrecinctSplitsFixtures,
   electionSimpleSinglePrecinctFixtures,
@@ -93,6 +94,7 @@ import path, { join } from 'node:path';
 import { LogEventId } from '@votingworks/logging';
 import { readdir, readFile } from 'node:fs/promises';
 import {
+  ApiClient,
   ELECTION_PACKAGE_FILE_NAME_REGEX,
   exportElectionPackage,
   exportTestDecks,
@@ -165,6 +167,28 @@ function expectNotEqualTo(str: string) {
 
 function compareName(a: { name: string }, b: { name: string }) {
   return a.name.localeCompare(b.name);
+}
+
+// Editing states require absentee polling places to cover every precinct before
+// ballots can be finalized; this adds one covering all precincts.
+async function addAbsenteePollingPlaceCoveringAllPrecincts(
+  apiClient: ApiClient,
+  electionId: ElectionId
+) {
+  const precincts = await apiClient.listPrecincts({ electionId });
+  (
+    await apiClient.setPollingPlace({
+      electionId,
+      place: {
+        id: 'absentee-all',
+        name: 'Absentee Voting',
+        type: 'absentee',
+        precincts: Object.fromEntries(
+          precincts.map((precinct) => [precinct.id, { type: 'whole' }])
+        ),
+      },
+    })
+  ).unsafeUnwrap();
 }
 
 const mockFeatureFlagger = getFeatureFlagMock();
@@ -563,6 +587,7 @@ test('create/list/delete elections', async () => {
   ).toEqual(null);
 
   // Finalize ballots and check status
+  await addAbsenteePollingPlaceCoveringAllPrecincts(apiClient, sliElectionId);
   await apiClient.finalizeBallots({ electionId: sliElectionId });
   expect((await apiClient.listElections())[0].status).toEqual<ElectionStatus>(
     'ballotsFinalized'
@@ -2648,6 +2673,8 @@ test('Finalize ballots - DEMO state', async () => {
     })
   ).unsafeUnwrap();
 
+  await addAbsenteePollingPlaceCoveringAllPrecincts(apiClient, electionId);
+
   expect(await apiClient.getBallotsFinalizedAt({ electionId })).toEqual(null);
   expect(await apiClient.getElectionPackage({ electionId })).toEqual({});
   expect(await apiClient.getTestDecks({ electionId })).toEqual({});
@@ -2748,6 +2775,90 @@ test('Finalize ballots - NH state', async () => {
   expect(await apiClient.getTestDecks({ electionId })).toEqual({});
 });
 
+test('Finalize ballots - allows absentee polling places that cover all precincts', async () => {
+  const { apiClient, auth0 } = await setupApp({
+    organizations,
+    jurisdictions,
+    users,
+  });
+  auth0.setLoggedInUser(nonVxUser);
+  const electionId = (
+    await apiClient.loadElection({
+      newId: 'new-election-id',
+      jurisdictionId: nonVxJurisdiction.id,
+      upload: {
+        format: 'vxf',
+        electionFileContents: JSON.stringify(
+          electionGeneralFixtures.readElection()
+        ),
+      },
+    })
+  ).unsafeUnwrap();
+
+  const precincts = await apiClient.listPrecincts({ electionId });
+  (
+    await apiClient.setPollingPlace({
+      electionId,
+      place: {
+        id: 'absentee-all',
+        name: 'Absentee Voting',
+        type: 'absentee',
+        precincts: Object.fromEntries(
+          precincts.map((precinct) => [precinct.id, { type: 'whole' }])
+        ),
+      },
+    })
+  ).unsafeUnwrap();
+
+  await apiClient.finalizeBallots({ electionId });
+  expect(await apiClient.getBallotsFinalizedAt({ electionId })).not.toEqual(
+    null
+  );
+});
+
+test('Finalize ballots - rejects absentee polling places that do not cover all precincts', async () => {
+  const { apiClient, auth0 } = await setupApp({
+    organizations,
+    jurisdictions,
+    users,
+  });
+  auth0.setLoggedInUser(nonVxUser);
+  const electionId = (
+    await apiClient.loadElection({
+      newId: 'new-election-id',
+      jurisdictionId: nonVxJurisdiction.id,
+      upload: {
+        format: 'vxf',
+        electionFileContents: JSON.stringify(
+          electionGeneralFixtures.readElection()
+        ),
+      },
+    })
+  ).unsafeUnwrap();
+
+  // Cover only the first precinct, leaving the others uncovered.
+  const precincts = await apiClient.listPrecincts({ electionId });
+  expect(precincts.length).toBeGreaterThan(1);
+  (
+    await apiClient.setPollingPlace({
+      electionId,
+      place: {
+        id: 'absentee-partial',
+        name: 'Absentee Voting',
+        type: 'absentee',
+        precincts: { [precincts[0].id]: { type: 'whole' } },
+      },
+    })
+  ).unsafeUnwrap();
+
+  await suppressingConsoleOutput(async () => {
+    await expect(apiClient.finalizeBallots({ electionId })).rejects.toThrow(
+      'Absentee polling places must cover every precinct for central scanning'
+    );
+  });
+  expect(await apiClient.getBallotsFinalizedAt({ electionId })).toEqual(null);
+});
+
 test('Finalize ballots - rejects partial registered voter counts', async () => {
   const { apiClient, auth0 } = await setupApp({
     organizations,
@@ -2796,6 +2907,10 @@ test('Finalize ballots - rejects partial registered voter counts', async () => {
       ).unsafeUnwrap();
     }
   }
+
+  // This editing state also requires absentee polling place coverage.
+  await addAbsenteePollingPlaceCoveringAllPrecincts(apiClient, electionId);
+
   await apiClient.finalizeBallots({ electionId });
   expect(await apiClient.getBallotsFinalizedAt({ electionId })).not.toEqual(
     null
@@ -2831,6 +2946,7 @@ test('approve ballots', async () => {
     );
   });
 
+  await addAbsenteePollingPlaceCoveringAllPrecincts(apiClient, electionId);
   await apiClient.finalizeBallots({ electionId });
 
   {
@@ -2898,6 +3014,7 @@ test('cloneElection', async () => {
     electionId: srcElectionId,
     ballotTemplateId: 'VxDefaultBallot',
   });
+  await addAbsenteePollingPlaceCoveringAllPrecincts(apiClient, srcElectionId);
   await apiClient.finalizeBallots({ electionId: srcElectionId });
 
   // Support user can clone from any jurisdiction to another:
@@ -3576,6 +3693,8 @@ test('Election package and ballots export', async () => {
 
     // Include entities with IDs generated by VxDesign
     districts: await apiClient.listDistricts({ electionId }),
+    // This is an editing state, so polling places are exported as-is with no
+    // Central Scanning place auto-generated.
     pollingPlaces: await apiClient.listPollingPlaces({ electionId }),
     precincts,
     parties: await apiClient.listParties({ electionId }),

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -40,6 +40,7 @@ import {
   PollingPlace,
   PollingPlaceType,
   hasPartialRegisteredVoterCounts,
+  getPrecinctsWithoutAbsenteePollingPlace,
   ElectionTypeSchemaV4p1,
   electionTypeV4p0ToV4p1,
   ElectionTypeV4p1,
@@ -760,6 +761,23 @@ export function buildApi(ctx: AppContext) {
         assert(
           !hasPartialRegisteredVoterCounts(precincts, registeredVoterCounts),
           'Registered voter counts must be provided for all precincts and splits or none'
+        );
+      }
+
+      // When polling places are user-defined and this state does not allow
+      // elections with no absentee polling places, the user-defined absentee
+      // polling places must cover every precinct.
+      if (
+        !stateFeatures.OMIT_ABSENTEE_POLLING_PLACES &&
+        stateFeatures.EDIT_POLLING_PLACES
+      ) {
+        const { election } = await store.getElection(input.electionId);
+        assert(
+          getPrecinctsWithoutAbsenteePollingPlace(
+            election.precincts,
+            election.pollingPlaces
+          ).length === 0,
+          'Absentee polling places must cover every precinct for central scanning'
         );
       }
 

--- a/apps/design/backend/src/ballots.test.ts
+++ b/apps/design/backend/src/ballots.test.ts
@@ -2,8 +2,12 @@ import { readElectionGeneral } from '@votingworks/fixtures';
 import {
   BallotType,
   BaseBallotProps,
+  CENTRAL_SCANNING_POLLING_PLACE_ID,
+  CENTRAL_SCANNING_POLLING_PLACE_NAME,
+  Election,
   ElectionStringKey,
   hasSplits,
+  PollingPlace,
   Precinct,
   UiStringsPackage,
 } from '@votingworks/types';
@@ -18,9 +22,11 @@ import {
 } from '@votingworks/basics';
 import { NhBallotProps, NhStateBallotProps } from '@votingworks/hmpb';
 import {
+  addPollingPlacesForExport,
   createBallotPropsForTemplate,
   formatElectionForExport,
 } from './ballots';
+import { miJurisdiction, msJurisdiction, nhJurisdiction } from '../test/mocks';
 
 const election = readElectionGeneral();
 
@@ -138,4 +144,89 @@ test('formatElectionForExport', () => {
   ).toEqual({
     [ballotMeasureContest.id]: ballotMeasureContest.description,
   });
+});
+
+test('addPollingPlacesForExport - non-editing state generates election_day places plus a Central Scanning absentee place', () => {
+  const electionInput: Election = {
+    ...election,
+    pollingPlaces: undefined,
+  };
+
+  const result = addPollingPlacesForExport(electionInput, msJurisdiction);
+  const pollingPlaces = result.pollingPlaces ?? [];
+
+  // One election_day place per precinct (existing behavior).
+  expect(
+    pollingPlaces.filter((place) => place.type === 'election_day')
+  ).toHaveLength(electionInput.precincts.length);
+
+  // Plus a single absentee place covering every precinct.
+  const absenteePlaces = pollingPlaces.filter(
+    (place) => place.type === 'absentee'
+  );
+  expect(absenteePlaces).toEqual([
+    {
+      id: CENTRAL_SCANNING_POLLING_PLACE_ID,
+      name: CENTRAL_SCANNING_POLLING_PLACE_NAME,
+      type: 'absentee',
+      precincts: Object.fromEntries(
+        electionInput.precincts.map((precinct) => [
+          precinct.id,
+          { type: 'whole' },
+        ])
+      ),
+    },
+  ]);
+});
+
+test('addPollingPlacesForExport - state that allows empty absentee polling places gets no Central Scanning place', () => {
+  const electionInput: Election = {
+    ...election,
+    pollingPlaces: undefined,
+  };
+
+  const result = addPollingPlacesForExport(electionInput, nhJurisdiction);
+  const pollingPlaces = result.pollingPlaces ?? [];
+
+  expect(pollingPlaces).toHaveLength(electionInput.precincts.length);
+  expect(pollingPlaces.every((place) => place.type === 'election_day')).toEqual(
+    true
+  );
+});
+
+test('addPollingPlacesForExport - editing state keeps user-created absentee places untouched', () => {
+  const pollingPlaces: PollingPlace[] = [
+    {
+      id: 'user-absentee',
+      name: 'User Absentee Location',
+      type: 'absentee',
+      precincts: { [election.precincts[0].id]: { type: 'whole' } },
+    },
+  ];
+  const electionInput: Election = { ...election, pollingPlaces };
+
+  const result = addPollingPlacesForExport(electionInput, miJurisdiction);
+
+  // Nothing added; the election is returned unchanged.
+  expect(result).toEqual(electionInput);
+  expect(result.pollingPlaces).toEqual(pollingPlaces);
+});
+
+test('addPollingPlacesForExport - editing state does not generate a Central Scanning place when no absentee place exists', () => {
+  const pollingPlaces: PollingPlace[] = [
+    {
+      id: 'election-day-1',
+      name: 'Election Day Location',
+      type: 'election_day',
+      precincts: { [election.precincts[0].id]: { type: 'whole' } },
+    },
+  ];
+  const electionInput: Election = { ...election, pollingPlaces };
+
+  const result = addPollingPlacesForExport(electionInput, miJurisdiction);
+
+  // Editing states are validated at finalization instead of having a Central
+  // Scanning place auto-generated, so nothing is added here.
+  expect(result).toEqual(electionInput);
+  expect(result.pollingPlaces).toEqual(pollingPlaces);
 });

--- a/apps/design/backend/src/ballots.test.ts
+++ b/apps/design/backend/src/ballots.test.ts
@@ -2,7 +2,7 @@ import { readElectionGeneral } from '@votingworks/fixtures';
 import {
   BallotType,
   BaseBallotProps,
-  CENTRAL_SCANNING_POLLING_PLACE_ID,
+  centralScanningPollingPlaceId,
   CENTRAL_SCANNING_POLLING_PLACE_NAME,
   Election,
   ElectionStringKey,
@@ -166,7 +166,7 @@ test('addPollingPlacesForExport - non-editing state generates election_day place
   );
   expect(absenteePlaces).toEqual([
     {
-      id: CENTRAL_SCANNING_POLLING_PLACE_ID,
+      id: centralScanningPollingPlaceId(electionInput.id),
       name: CENTRAL_SCANNING_POLLING_PLACE_NAME,
       type: 'absentee',
       precincts: Object.fromEntries(

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -1,7 +1,7 @@
 import {
   BallotType,
   BaseBallotProps,
-  CENTRAL_SCANNING_POLLING_PLACE_ID,
+  centralScanningPollingPlaceId,
   CENTRAL_SCANNING_POLLING_PLACE_NAME,
   Election,
   hasSplits,
@@ -44,7 +44,7 @@ export function defaultBallotTemplate(
 
 function centralScanningPollingPlace(election: Election): PollingPlace {
   return {
-    id: CENTRAL_SCANNING_POLLING_PLACE_ID,
+    id: centralScanningPollingPlaceId(election.id),
     name: CENTRAL_SCANNING_POLLING_PLACE_NAME,
     type: 'absentee',
     precincts: Object.fromEntries(

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -1,8 +1,11 @@
 import {
   BallotType,
   BaseBallotProps,
+  CENTRAL_SCANNING_POLLING_PLACE_ID,
+  CENTRAL_SCANNING_POLLING_PLACE_NAME,
   Election,
   hasSplits,
+  PollingPlace,
   pollingPlacesGenerateFromPrecincts,
   UiStringsPackage,
   YesNoContest,
@@ -39,21 +42,40 @@ export function defaultBallotTemplate(
   }
 }
 
+function centralScanningPollingPlace(election: Election): PollingPlace {
+  return {
+    id: CENTRAL_SCANNING_POLLING_PLACE_ID,
+    name: CENTRAL_SCANNING_POLLING_PLACE_NAME,
+    type: 'absentee',
+    precincts: Object.fromEntries(
+      election.precincts.map((precinct) => [precinct.id, { type: 'whole' }])
+    ),
+  };
+}
+
 export function addPollingPlacesForExport(
   election: Election,
   jurisdiction: Jurisdiction
 ): Election {
   const stateFeatures = getStateFeaturesConfig(jurisdiction);
+
   if (stateFeatures.EDIT_POLLING_PLACES) {
     return election;
   }
+
+  // Generate election day polling places from precincts and unless
+  // this state allows elections with no absentee polling places, add a single
+  // Central Scanning absentee place covering all precincts.
+  const pollingPlaces = pollingPlacesGenerateFromPrecincts(
+    election.precincts,
+    'election_day',
+    (p) => `${p.id}-polling-place`
+  );
   return {
     ...election,
-    pollingPlaces: pollingPlacesGenerateFromPrecincts(
-      election.precincts,
-      'election_day',
-      (p) => `${p.id}-polling-place`
-    ),
+    pollingPlaces: stateFeatures.OMIT_ABSENTEE_POLLING_PLACES
+      ? pollingPlaces
+      : [...pollingPlaces, centralScanningPollingPlace(election)],
   };
 }
 

--- a/apps/design/backend/src/features.ts
+++ b/apps/design/backend/src/features.ts
@@ -162,6 +162,17 @@ export interface StateFeaturesConfig {
    */
   DISABLE_REGISTERED_VOTERS_COUNTS?: boolean;
   /**
+   * Allows an election to have no absentee polling places. Enabled for states
+   * where central scanning is only ever an emergency fallback (NH).
+   *
+   * When this is unset (default), every election is expected to have absentee
+   * polling places covering all precincts: if the jurisdiction has created its
+   * own, they are validated to cover all precincts at finalization; otherwise a
+   * default "Central Scanning" place covering all precincts is created on
+   * export.
+   */
+  OMIT_ABSENTEE_POLLING_PLACES?: boolean;
+  /**
    * Allow creating open primary elections, where all parties' contests are on
    * the same ballot rather than having a separate ballot for each party.
    */
@@ -234,6 +245,7 @@ export const stateFeatureConfigs: Record<StateCode, StateFeaturesConfig> = {
     PRECINCT_SPLIT_CLERK_SIGNATURE_CAPTION_OVERRIDE: true,
     ADDITIONAL_BALLOT_MEASURE_OPTIONS: true,
     POST_FINALIZE_CHANGE_FEE_WARNING: true,
+    OMIT_ABSENTEE_POLLING_PLACES: true,
   },
 };
 

--- a/apps/design/frontend/src/ballots_status.test.tsx
+++ b/apps/design/frontend/src/ballots_status.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 import {
   BallotStyle,
   ElectionRegisteredVotersCounts,
+  PollingPlace,
   Precinct,
 } from '@votingworks/types';
 import userEvent from '@testing-library/user-event';
@@ -27,6 +28,7 @@ test('ballots incomplete', async () => {
   mockStateFeatures(api, {});
   mockPrecincts(api, []);
   mockRegisteredVoterCounts(api, {});
+  mockPollingPlaces(api, []);
 
   renderUi(api);
 
@@ -45,6 +47,7 @@ test('ballots ready to finalize', async () => {
   mockStateFeatures(api, {});
   mockPrecincts(api, []);
   mockRegisteredVoterCounts(api, {});
+  mockPollingPlaces(api, []);
 
   renderUi(api);
 
@@ -73,6 +76,7 @@ test('start finalize and cancel', async () => {
   mockStateFeatures(api, {});
   mockPrecincts(api, []);
   mockRegisteredVoterCounts(api, {});
+  mockPollingPlaces(api, []);
 
   renderUi(api);
 
@@ -96,6 +100,7 @@ test('start finalize and confirm', async () => {
   mockStateFeatures(api, {});
   mockPrecincts(api, []);
   mockRegisteredVoterCounts(api, {});
+  mockPollingPlaces(api, []);
 
   renderUi(api);
 
@@ -127,6 +132,7 @@ test.each([false, true])(
     });
     mockPrecincts(api, []);
     mockRegisteredVoterCounts(api, {});
+    mockPollingPlaces(api, []);
 
     renderUi(api);
 
@@ -154,6 +160,7 @@ test('ballots finalized', async () => {
   mockStateFeatures(api, {});
   mockPrecincts(api, []);
   mockRegisteredVoterCounts(api, {});
+  mockPollingPlaces(api, []);
 
   renderUi(api);
 
@@ -172,6 +179,7 @@ test('ballots approved', async () => {
   mockStateFeatures(api, {});
   mockPrecincts(api, []);
   mockRegisteredVoterCounts(api, {});
+  mockPollingPlaces(api, []);
 
   const { history } = renderUi(api);
 
@@ -200,6 +208,7 @@ describe('registered voter counts', () => {
     ]);
     // Only p1 has a count, p2 does not - partial RVC
     mockRegisteredVoterCounts(api, { p1: 100 });
+    mockPollingPlaces(api, []);
 
     renderUi(api);
 
@@ -230,6 +239,7 @@ describe('registered voter counts', () => {
     ]);
     // Only split s1 has a count, s2 does not - partial RVC
     mockRegisteredVoterCounts(api, { p1: { splits: { s1: 100 } } });
+    mockPollingPlaces(api, []);
 
     renderUi(api);
 
@@ -240,6 +250,79 @@ describe('registered voter counts', () => {
       'Registered voter counts must be provided for all precincts and splits, or none'
     );
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});
+
+describe('absentee polling place coverage', () => {
+  const precincts: Precinct[] = [
+    { id: 'p1', name: 'Precinct 1', districtIds: [] },
+    { id: 'p2', name: 'Precinct 2', districtIds: [] },
+  ];
+
+  function mockCommon(api: MockApiClient, features: Record<string, boolean>) {
+    mockBallotStyles(api, [{} as unknown as BallotStyle]); // Content irrelevant.
+    mockFinalizedAt(api, null);
+    mockApprovedAt(api, null);
+    mockStateFeatures(api, features);
+    mockPrecincts(api, precincts);
+    mockRegisteredVoterCounts(api, {});
+  }
+
+  test('validation failed - a precinct is not covered by an absentee place', async () => {
+    const api = createMockApiClient();
+    mockCommon(api, { EDIT_POLLING_PLACES: true });
+    // Absentee place covers only p1, leaving p2 uncovered.
+    mockPollingPlaces(api, [
+      {
+        id: 'absentee-1',
+        name: 'Absentee Voting',
+        type: 'absentee',
+        precincts: { p1: { type: 'whole' } },
+      },
+    ]);
+
+    renderUi(api);
+
+    const soleHeading = await screen.findByRole('heading');
+    api.assertComplete();
+
+    expect(soleHeading).toHaveTextContent(
+      'Absentee polling places must cover every precinct'
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  test('validation passes when absentee places cover all precincts', async () => {
+    const api = createMockApiClient();
+    mockCommon(api, { EDIT_POLLING_PLACES: true });
+    mockPollingPlaces(api, [
+      {
+        id: 'absentee-1',
+        name: 'Absentee Voting',
+        type: 'absentee',
+        precincts: { p1: { type: 'whole' }, p2: { type: 'whole' } },
+      },
+    ]);
+
+    renderUi(api);
+
+    await screen.findByRole('heading', { name: 'Ballots Not Finalized' });
+    api.assertComplete();
+  });
+
+  test('no validation when the state allows empty absentee polling places', async () => {
+    const api = createMockApiClient();
+    mockCommon(api, {
+      EDIT_POLLING_PLACES: true,
+      OMIT_ABSENTEE_POLLING_PLACES: true,
+    });
+    // No absentee places at all, but coverage is not required for this state.
+    mockPollingPlaces(api, []);
+
+    renderUi(api);
+
+    await screen.findByRole('heading', { name: 'Ballots Not Finalized' });
+    api.assertComplete();
   });
 });
 
@@ -271,6 +354,10 @@ function mockRegisteredVoterCounts(
   counts: ElectionRegisteredVotersCounts
 ) {
   api.getRegisteredVotersCounts.expectCallWith({ electionId }).resolves(counts);
+}
+
+function mockPollingPlaces(api: MockApiClient, pollingPlaces: PollingPlace[]) {
+  api.listPollingPlaces.expectCallWith({ electionId }).resolves(pollingPlaces);
 }
 
 function renderUi(api: MockApiClient) {

--- a/apps/design/frontend/src/ballots_status.tsx
+++ b/apps/design/frontend/src/ballots_status.tsx
@@ -14,7 +14,10 @@ import {
   Font,
 } from '@votingworks/ui';
 
-import { hasPartialRegisteredVoterCounts } from '@votingworks/types';
+import {
+  hasPartialRegisteredVoterCounts,
+  getPrecinctsWithoutAbsenteePollingPlace,
+} from '@votingworks/types';
 import * as api from './api';
 import { ElectionIdParams, routes } from './routes';
 import { Row } from './layout';
@@ -30,6 +33,7 @@ export function BallotsStatus(): React.ReactNode {
   const listPrecinctsQuery = api.listPrecincts.useQuery(electionId);
   const getRegisteredVoterCountsQuery =
     api.getRegisteredVotersCounts.useQuery(electionId);
+  const listPollingPlacesQuery = api.listPollingPlaces.useQuery(electionId);
 
   const finalizeBallotsMutation = api.finalizeBallots.useMutation();
 
@@ -39,7 +43,8 @@ export function BallotsStatus(): React.ReactNode {
     !approvedAtQuery.isSuccess ||
     !getStateFeaturesQuery.isSuccess ||
     !listPrecinctsQuery.isSuccess ||
-    !getRegisteredVoterCountsQuery.isSuccess
+    !getRegisteredVoterCountsQuery.isSuccess ||
+    !listPollingPlacesQuery.isSuccess
   ) {
     return null;
   }
@@ -73,6 +78,27 @@ export function BallotsStatus(): React.ReactNode {
         Registered voter counts are set for some precincts but not all. Set
         counts for all precincts or remove them from all precincts before
         finalizing.
+      </Callout>
+    );
+  }
+
+  if (
+    features.EDIT_POLLING_PLACES &&
+    !features.OMIT_ABSENTEE_POLLING_PLACES &&
+    getPrecinctsWithoutAbsenteePollingPlace(
+      listPrecinctsQuery.data,
+      listPollingPlacesQuery.data
+    ).length > 0
+  ) {
+    return (
+      <Callout
+        color="neutral"
+        icon={<Icons.Info />}
+        title="Absentee polling places must cover every precinct."
+      >
+        Every precinct must be covered by an absentee polling place, so that
+        centrally-scanned ballots have a location to be tabulated under. Add or
+        edit absentee polling places to cover all precincts before finalizing.
       </Callout>
     );
   }

--- a/libs/types/src/polling_places.test.ts
+++ b/libs/types/src/polling_places.test.ts
@@ -23,6 +23,7 @@ import {
   pollingPlacePrecinctIds,
   pollingPlacesGenerateFromPrecincts,
   pollingPlaceTypeName,
+  getPrecinctsWithoutAbsenteePollingPlace,
 } from './polling_places';
 
 test('anyPollingPlace', () => {
@@ -302,6 +303,57 @@ test('pollingPlaceTypeName', () => {
   expect(pollingPlaceTypeName('absentee')).toEqual('Absentee Voting');
   expect(pollingPlaceTypeName('early_voting')).toEqual('Early Voting');
   expect(pollingPlaceTypeName('election_day')).toEqual('Election Day');
+});
+
+test('precinctsWithoutAbsenteePollingPlace', () => {
+  const precincts = [
+    mockPrecinctNoSplits({ id: 'p1' }),
+    mockPrecinctNoSplits({ id: 'p2' }),
+    mockPrecinctNoSplits({ id: 'p3' }),
+  ];
+
+  // No polling places at all (omitted): all precincts are uncovered.
+  expect(
+    getPrecinctsWithoutAbsenteePollingPlace(precincts).map((p) => p.id)
+  ).toEqual(['p1', 'p2', 'p3']);
+
+  // No absentee places: all precincts are uncovered.
+  expect(
+    getPrecinctsWithoutAbsenteePollingPlace(precincts, [
+      mockPollingPlace({
+        type: 'election_day',
+        precincts: { p1: { type: 'whole' } },
+      }),
+    ]).map((p) => p.id)
+  ).toEqual(['p1', 'p2', 'p3']);
+
+  // Absentee places cover all precincts: none uncovered.
+  expect(
+    getPrecinctsWithoutAbsenteePollingPlace(precincts, [
+      mockPollingPlace({
+        type: 'absentee',
+        precincts: {
+          p1: { type: 'whole' },
+          p2: { type: 'whole' },
+          p3: { type: 'whole' },
+        },
+      }),
+    ])
+  ).toEqual([]);
+
+  // Absentee places cover some precincts: the rest are uncovered.
+  expect(
+    getPrecinctsWithoutAbsenteePollingPlace(precincts, [
+      mockPollingPlace({
+        type: 'absentee',
+        precincts: { p1: { type: 'whole' } },
+      }),
+      mockPollingPlace({
+        type: 'absentee',
+        precincts: { p2: { type: 'partial', splitIds: ['s2'] } },
+      }),
+    ]).map((p) => p.id)
+  ).toEqual(['p3']);
 });
 
 function mockBallotStyle(partial: Partial<BallotStyle>): BallotStyle {

--- a/libs/types/src/polling_places.ts
+++ b/libs/types/src/polling_places.ts
@@ -171,6 +171,23 @@ export function pollingPlacePrecinctIds(place: PollingPlace): Set<string> {
   return new Set(Object.keys(place.precincts));
 }
 
+/**
+ * Returns the precincts not covered by any absentee polling place, i.e.
+ * precincts whose centrally-scanned ballots would have no location to be
+ * tabulated under.
+ */
+export function getPrecinctsWithoutAbsenteePollingPlace(
+  precincts: readonly Precinct[],
+  pollingPlaces: readonly PollingPlace[] = []
+): Precinct[] {
+  const coveredPrecinctIds = new Set(
+    pollingPlaces
+      .filter((place) => place.type === 'absentee')
+      .flatMap((place) => [...pollingPlacePrecinctIds(place)])
+  );
+  return precincts.filter((precinct) => !coveredPrecinctIds.has(precinct.id));
+}
+
 export function pollingPlaceTypeName(type: PollingPlaceType): string {
   switch (type) {
     case 'absentee':

--- a/libs/types/src/polling_places.ts
+++ b/libs/types/src/polling_places.ts
@@ -172,6 +172,13 @@ export function pollingPlacePrecinctIds(place: PollingPlace): Set<string> {
 }
 
 /**
+ * The deterministic id and name of the default "Central Scanning" absentee
+ * polling place.
+ */
+export const CENTRAL_SCANNING_POLLING_PLACE_ID = 'central-scanning';
+export const CENTRAL_SCANNING_POLLING_PLACE_NAME = 'Central Scanning';
+
+/**
  * Returns the precincts not covered by any absentee polling place, i.e.
  * precincts whose centrally-scanned ballots would have no location to be
  * tabulated under.

--- a/libs/types/src/polling_places.ts
+++ b/libs/types/src/polling_places.ts
@@ -172,10 +172,14 @@ export function pollingPlacePrecinctIds(place: PollingPlace): Set<string> {
 }
 
 /**
- * The deterministic id and name of the default "Central Scanning" absentee
- * polling place.
+ * The id and name of the default "Central Scanning" absentee polling place.
+ * The id is derived deterministically from the election id (so the ballot hash
+ * stays stable across exports) while remaining globally unique across
+ * elections, matching the convention used for other election entity ids.
  */
-export const CENTRAL_SCANNING_POLLING_PLACE_ID = 'central-scanning';
+export function centralScanningPollingPlaceId(electionId: string): string {
+  return `${electionId}-central-scanning`;
+}
 export const CENTRAL_SCANNING_POLLING_PLACE_NAME = 'Central Scanning';
 
 /**


### PR DESCRIPTION
## Overview
Adds the OMIT_ABSENTEE_POLLING_PLACES flag - defaults to false with the following behavior in conjunction with EDIT_POLLING_PLACES. 

- EDIT_POLLING_PLACES=TRUE  & OMIT_ABSENTEE_POLLING_PLACES=TRUE = Not a relevant state example today but would allow editing polling places with no validation done one way or another on absentee polling places at finalization, they could be added or not. 
- EDIT_POLLING_PLACES=TRUE  & OMIT_ABSENTEE_POLLING_PLACES=FALSE = MI example today. Allows editing polling places and validates before ballots can be finalized that absentee polling places cover all precincts. Absentee polling places must be manually added, no catch-all is autogenerated (for non-MI cases in the future we may want to tweak this) 
- EDIT_POLLING_PLACES=FALSE  & OMIT_ABSENTEE_POLLING_PLACES=TRUE = NH example today. Does not allow manual polling place changes and does not generate an absentee polling place, just generated per-precinct polling places. 
- EDIT_POLLING_PLACES=FALSE  & OMIT_ABSENTEE_POLLING_PLACES=FALSE = MS example today. Does not allow manual polling place changes and autogenerates a "Central Scanning" absentee polling place that covers all precincts.  

## Demo Video or Screenshot
MI ballot finalization error: 
<img width="802" height="495" alt="Screenshot 2026-06-10 at 9 56 55 AM" src="https://github.com/user-attachments/assets/28ddb519-cd3f-4303-bd5c-f2e8165b984c" />

## Testing Plan
- See automated tests
- Tested duplicating elections with manually created absentee polling place(s) both with the duplicate button in vxdesign and via loading in the election.json and then making the duplicate election jurisdication NH or MS and saw the appropriate expected behavior. Tested MI behavior validates as expected. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
