### PR TITLE
Parse DateWithoutTime in schema

### DIFF
--- a/libs/types/src/__snapshots__/election.test.ts.snap
+++ b/libs/types/src/__snapshots__/election.test.ts.snap
@@ -21,7 +21,7 @@ exports[`safeParseElection shows VXF parsing errors by default 1`] = `
 - ballotStyles: Invalid input: expected array, received undefined
 - contests: Invalid input: expected array, received undefined
 - county: Invalid input: expected object, received undefined
-- date: Invalid input: expected DateWithoutTime, received undefined
+- date: Invalid input
 - districts: Invalid input: expected array, received undefined
 - id: Invalid input: expected string, received undefined
 - parties: Invalid input: expected array, received undefined

--- a/libs/types/src/__snapshots__/schema.test.ts.snap
+++ b/libs/types/src/__snapshots__/schema.test.ts.snap
@@ -13,19 +13,32 @@ exports[`contest IDs cannot start with an underscore 1`] = `
 `;
 
 exports[`ensures election date is YYYY-MM-DD 1`] = `
-ZodError {
-  "message": "[
+[ZodError: [
   {
-    "code": "custom",
-    "message": "Date must be in the format YYYY-MM-DD",
+    "code": "invalid_union",
+    "errors": [
+      [
+        {
+          "code": "invalid_type",
+          "expected": "DateWithoutTime",
+          "path": [],
+          "message": "Invalid input: expected DateWithoutTime, received string"
+        }
+      ],
+      [
+        {
+          "code": "custom",
+          "message": "Date must be in the format YYYY-MM-DD",
+          "path": []
+        }
+      ]
+    ],
     "path": [
       "date"
     ],
-    "input": "not ISO"
+    "message": "Invalid input"
   }
-]",
-  "name": "ZodError",
-}
+]]
 `;
 
 exports[`parsing gives specific errors for nested objects 1`] = `

--- a/libs/types/src/election_parsing.ts
+++ b/libs/types/src/election_parsing.ts
@@ -1,10 +1,4 @@
-import {
-  Result,
-  err,
-  ok,
-  DateWithoutTime,
-  extractErrorMessage,
-} from '@votingworks/basics';
+import { Result, err, ok } from '@votingworks/basics';
 import { sha256 } from 'js-sha256';
 import { z } from 'zod/v4';
 import { safeParseCdfBallotDefinition } from './cdf/ballot-definition/convert';
@@ -13,49 +7,12 @@ import { Election, ElectionDefinition, ElectionSchema } from './election';
 import { safeParse, safeParseJson } from './generic';
 
 /**
- * Parse the date field of an Election object from a string to a
- * DateWithoutTime.
- */
-export function parseElectionDate(value: unknown): Result<unknown, z.ZodError> {
-  if (!value || typeof value !== 'object') {
-    return ok(value);
-  }
-
-  // We're casting it here to make it easier to use, but in this function you
-  // must assume the type is unknown.
-  let election = value as Election;
-
-  if (election.date && typeof election.date === 'string') {
-    try {
-      election = { ...election, date: new DateWithoutTime(election.date) };
-    } catch (error) {
-      return err(
-        new z.ZodError([
-          {
-            code: 'custom',
-            message: extractErrorMessage(error),
-            path: ['date'],
-            input: election.date,
-          },
-        ])
-      );
-    }
-  }
-
-  return ok(election);
-}
-
-/**
  * Parses `value` as a VXF `Election` object.
  */
 export function safeParseVxfElection(
   value: unknown
 ): Result<Election, z.ZodError> {
-  const valueWithParsedDate = parseElectionDate(value);
-  if (valueWithParsedDate.isErr()) {
-    return valueWithParsedDate;
-  }
-  return safeParse(ElectionSchema, valueWithParsedDate.ok());
+  return safeParse(ElectionSchema, value);
 }
 
 function prettyZodError(error: z.ZodError): string {

--- a/libs/types/src/generic.test.ts
+++ b/libs/types/src/generic.test.ts
@@ -40,11 +40,22 @@ test('safeParseJson', () => {
 });
 
 test('DateWithoutTime schema', () => {
+  // Accepts an existing DateWithoutTime instance unchanged.
   expect(
     safeParse(
       DateWithoutTimeSchema,
       new DateWithoutTime('2024-02-22')
     ).unsafeUnwrap()
   ).toEqual(new DateWithoutTime('2024-02-22'));
-  safeParse(DateWithoutTimeSchema, '2024-02-22').unsafeUnwrapErr();
+
+  // Accepts and parses a YYYY-MM-DD string into a DateWithoutTime.
+  expect(safeParse(DateWithoutTimeSchema, '2024-02-22').unsafeUnwrap()).toEqual(
+    new DateWithoutTime('2024-02-22')
+  );
+
+  // Rejects a malformed date string.
+  safeParse(DateWithoutTimeSchema, 'not a date').unsafeUnwrapErr();
+
+  // Rejects values that are neither a string nor a DateWithoutTime.
+  safeParse(DateWithoutTimeSchema, 12345).unsafeUnwrapErr();
 });

--- a/libs/types/src/generic.ts
+++ b/libs/types/src/generic.ts
@@ -7,6 +7,7 @@ import {
   Result,
   wrapException,
   DateWithoutTime,
+  extractErrorMessage,
 } from '@votingworks/basics';
 
 export interface Dictionary<T> {
@@ -117,4 +118,18 @@ export const Iso8601DateTimeSchema = z
 export type Iso8601Timestamp = string;
 export const Iso8601TimestampSchema = Iso8601DateTimeSchema;
 
-export const DateWithoutTimeSchema = z.instanceof(DateWithoutTime);
+/**
+ * Accepts either a {@link DateWithoutTime} instance or a serialized `YYYY-MM-DD` string,
+ * normalizing to a {@link DateWithoutTime} instance.
+ */
+export const DateWithoutTimeSchema = z.union([
+  z.instanceof(DateWithoutTime),
+  z.string().transform((value, ctx) => {
+    try {
+      return new DateWithoutTime(value);
+    } catch (error) {
+      ctx.addIssue({ code: 'custom', message: extractErrorMessage(error) });
+      return z.NEVER;
+    }
+  }),
+]);

--- a/libs/types/src/software_versions.ts
+++ b/libs/types/src/software_versions.ts
@@ -2,10 +2,7 @@ import { z } from 'zod/v4';
 import { assert, ok, Result } from '@votingworks/basics';
 import { sha256 } from 'js-sha256';
 import { Election, ElectionDefinition, ElectionSchema } from './election';
-import {
-  parseElectionDate,
-  safeParseElectionDefinition,
-} from './election_parsing';
+import { safeParseElectionDefinition } from './election_parsing';
 import { safeParse, safeParseJson } from './generic';
 
 export const SoftwareVersions = ['v4.0', 'v4.1'] as const;
@@ -55,9 +52,7 @@ export function safeParseElectionDefinitionV4p0(
 ): Result<ElectionDefinitionV4p0, z.ZodError | SyntaxError> {
   const valueJson = safeParseJson(value);
   if (valueJson.isErr()) return valueJson;
-  const valueWithParsedDate = parseElectionDate(valueJson.ok());
-  if (valueWithParsedDate.isErr()) return valueWithParsedDate;
-  const election = safeParse(ElectionV4p0Schema, valueWithParsedDate.ok());
+  const election = safeParse(ElectionV4p0Schema, valueJson.ok());
   if (election.isErr()) return election;
   return ok({
     election: election.ok(),


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

<!-- Add a link to a GitHub issue here -->
Updates DateWithoutTimeSchema to be able to parse strings and convert them to DateWithoutTime, allowing us to remove the custom parsing function we had in place previously. Using a custom function was fine before, but now that there are multiple election parsing paths (for multiple versions), it seemed simpler to consolidate the parsing in the schema.

## Demo Video or Screenshot
N/A

## Testing Plan
Existing tests, with some additions

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
