### PR TITLE
[VxPrint] [Frontend] Remove old precinct-selection code paths

### DIFF
--- a/apps/print/backend/src/reports/readiness.ts
+++ b/apps/print/backend/src/reports/readiness.ts
@@ -27,11 +27,9 @@ async function getReadinessReport({
   const { store } = workspace;
   const electionRecord = store.getElectionRecord();
   const { electionDefinition, electionPackageHash } = electionRecord ?? {};
-  const precinctSelection = store.getPrecinctSelection();
   const pollingPlaceId = store.getPollingPlaceId();
 
   return PrintReadinessReport({
-    precinctSelection,
     pollingPlaceId,
     batteryInfo:
       (await getBatteryInfo({ logger })) ??

--- a/apps/print/frontend/src/api.ts
+++ b/apps/print/frontend/src/api.ts
@@ -110,31 +110,6 @@ export const configureElectionPackageFromUsb = {
   },
 } as const;
 
-// [TODO] Remove after migration to polling places.
-export const getPrecinctSelection = {
-  queryKey(): QueryKey {
-    return ['getPrecinctSelection'];
-  },
-  useQuery() {
-    const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getPrecinctSelection());
-  },
-} as const;
-
-// [TODO] Remove after migration to polling places.
-export const setPrecinctSelection = {
-  useMutation() {
-    const apiClient = useApiClient();
-    const queryClient = useQueryClient();
-    return useMutation(apiClient.setPrecinctSelection, {
-      async onSuccess() {
-        await queryClient.invalidateQueries(getPrecinctSelection.queryKey());
-      },
-    });
-  },
-} as const;
-
-/* istanbul ignore next - WIP */
 export const getPollingPlaceId = {
   queryKey(): QueryKey {
     return ['getPollingPlaceId'];
@@ -145,7 +120,6 @@ export const getPollingPlaceId = {
   },
 } as const;
 
-/* istanbul ignore next - WIP */
 export const setPollingPlaceId = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/print/frontend/src/app.tsx
+++ b/apps/print/frontend/src/app.tsx
@@ -19,9 +19,7 @@ import { BaseLogger, LogSource } from '@votingworks/logging';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import {
-  BooleanEnvironmentVariableName as Feature,
   isElectionManagerAuth,
-  isFeatureFlagEnabled,
   isPollWorkerAuth,
   isSystemAdministratorAuth,
   isVendorAuth,
@@ -104,16 +102,12 @@ function AppRoot({
       return <MachineLockedScreen />;
     }
 
-    const locationType = isFeatureFlagEnabled(Feature.ENABLE_POLLING_PLACES)
-      ? 'polling place'
-      : 'precinct';
-
     return (
       <InvalidCardScreen
         reasonAndContext={authStatus}
         recommendedAction={
           authStatus.reason === 'machine_not_configured'
-            ? `Use an election manager card and select a ${locationType} to finish configuration.`
+            ? `Use an election manager card and select a polling place to finish configuration.`
             : 'Use a valid card.'
         }
         cardInsertionDirection="right"

--- a/apps/print/frontend/src/components/screen_wrapper.tsx
+++ b/apps/print/frontend/src/components/screen_wrapper.tsx
@@ -14,12 +14,7 @@ import {
 
 import { Toolbar } from './toolbar';
 import { routeMap } from '../routes';
-import {
-  getElectionRecord,
-  getMachineConfig,
-  getPollingPlaceId,
-  getPrecinctSelection,
-} from '../api';
+import { getElectionRecord, getMachineConfig, getPollingPlaceId } from '../api';
 
 export function ScreenWrapper({
   children,
@@ -33,13 +28,11 @@ export function ScreenWrapper({
   const currentRoute = useRouteMatch();
   const getElectionRecordQuery = getElectionRecord.useQuery();
   const getMachineConfigQuery = getMachineConfig.useQuery();
-  const getPrecinctSelectionQuery = getPrecinctSelection.useQuery();
   const getPollingPlaceIdQuery = getPollingPlaceId.useQuery();
 
   if (
     !getElectionRecordQuery.isSuccess ||
     !getMachineConfigQuery.isSuccess ||
-    !getPrecinctSelectionQuery.isSuccess ||
     !getPollingPlaceIdQuery.isSuccess
   ) {
     return null;
@@ -47,7 +40,6 @@ export function ScreenWrapper({
 
   const electionRecord = getElectionRecordQuery.data;
   const machineConfig = getMachineConfigQuery.data;
-  const precinctSelection = getPrecinctSelectionQuery.data;
   const pollingPlaceId = getPollingPlaceIdQuery.data;
 
   const showNavItems = electionRecord !== null || authType === 'system_admin';
@@ -79,7 +71,6 @@ export function ScreenWrapper({
             codeVersion={machineConfig.codeVersion}
             machineId={machineConfig.machineId}
             inverse
-            precinctSelection={precinctSelection || undefined}
             pollingPlaceId={pollingPlaceId || undefined}
           />
         </div>

--- a/apps/print/frontend/src/election_manager_app.tsx
+++ b/apps/print/frontend/src/election_manager_app.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
-import {
-  BooleanEnvironmentVariableName as Feature,
-  isFeatureFlagEnabled,
-} from '@votingworks/utils';
 import { PrintScreen } from './screens/print_screen';
 import { SettingsScreen } from './screens/settings_screen';
 import { ReportScreen } from './screens/report_screen';
@@ -12,29 +8,17 @@ import { ElectionScreen } from './screens/election_screen';
 import { DiagnosticsScreen } from './screens/diagnostics_screen';
 import { electionManagerRoutes } from './routes';
 import { PrinterAlertWrapper } from './components/printer_alert_wrapper';
-import {
-  getElectionRecord,
-  getPollingPlaceId,
-  getPrecinctSelection,
-} from './api';
+import { getElectionRecord, getPollingPlaceId } from './api';
 
 export function ElectionManagerApp(): JSX.Element | null {
   const electionRecordQuery = getElectionRecord.useQuery();
-  const precinctSelectionQuery = getPrecinctSelection.useQuery();
   const pollingPlaceIdQuery = getPollingPlaceId.useQuery();
 
-  if (
-    !electionRecordQuery.isSuccess ||
-    !precinctSelectionQuery.isSuccess ||
-    !pollingPlaceIdQuery.isSuccess
-  ) {
+  if (!electionRecordQuery.isSuccess || !pollingPlaceIdQuery.isSuccess) {
     return null;
   }
 
-  const locationConfigured = isFeatureFlagEnabled(Feature.ENABLE_POLLING_PLACES)
-    ? pollingPlaceIdQuery.data !== null
-    : precinctSelectionQuery.data !== null;
-
+  const locationConfigured = pollingPlaceIdQuery.data !== null;
   const isMachineConfigured =
     electionRecordQuery.data !== null && locationConfigured;
 

--- a/apps/print/frontend/src/screens/election_screen.tsx
+++ b/apps/print/frontend/src/screens/election_screen.tsx
@@ -56,16 +56,6 @@ export function ElectionScreen(): JSX.Element | null {
   }
 
   const pollingPlaces = election.pollingPlaces || [];
-  const locationPicker = pollingPlaces.length > 1 && (
-    <PollingPlacePicker
-      mode="default"
-      places={pollingPlaces}
-      searchable
-      selectedId={pollingPlaceIdQuery.data || undefined}
-      selectPlace={(id) => selectPollingPlace({ id })}
-      style={{ width: '16rem' }}
-    />
-  );
 
   return (
     <ScreenWrapper authType="election_manager">
@@ -87,7 +77,16 @@ export function ElectionScreen(): JSX.Element | null {
           </Row>
         </Card>
         <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
-          {locationPicker}
+          {pollingPlaces.length > 1 && (
+            <PollingPlacePicker
+              mode="default"
+              places={pollingPlaces}
+              searchable
+              selectedId={pollingPlaceIdQuery.data || undefined}
+              selectPlace={(id) => selectPollingPlace({ id })}
+              style={{ width: '16rem' }}
+            />
+          )}
           <UnconfigureMachineButton
             unconfigureMachine={unconfigure}
             isMachineConfigured

--- a/apps/print/frontend/src/screens/election_screen.tsx
+++ b/apps/print/frontend/src/screens/election_screen.tsx
@@ -5,22 +5,15 @@ import {
   P,
   Seal,
   UnconfigureMachineButton,
-  ChangePrecinctButton,
   PollingPlacePicker,
 } from '@votingworks/ui';
-import {
-  BooleanEnvironmentVariableName,
-  format,
-  isFeatureFlagEnabled,
-} from '@votingworks/utils';
+import { format } from '@votingworks/utils';
 import { assertDefined } from '@votingworks/basics';
 import styled from 'styled-components';
 import {
   getElectionRecord,
   getPollingPlaceId,
   setPollingPlaceId,
-  setPrecinctSelection,
-  getPrecinctSelection,
   unconfigureMachine,
   ejectUsbDrive,
 } from '../api';
@@ -39,22 +32,13 @@ const Content = styled(MainContent)`
 `;
 
 export function ElectionScreen(): JSX.Element | null {
-  const usePollingPlaces = isFeatureFlagEnabled(
-    BooleanEnvironmentVariableName.ENABLE_POLLING_PLACES
-  );
   const getElectionRecordQuery = getElectionRecord.useQuery();
   const pollingPlaceIdQuery = getPollingPlaceId.useQuery();
-  const selectedPrecinctQuery = getPrecinctSelection.useQuery();
-  const selectPrecinct = setPrecinctSelection.useMutation().mutateAsync;
   const selectPollingPlace = setPollingPlaceId.useMutation().mutateAsync;
   const unconfigureMutation = unconfigureMachine.useMutation();
   const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
 
-  if (
-    !getElectionRecordQuery.isSuccess ||
-    !selectedPrecinctQuery.isSuccess ||
-    !pollingPlaceIdQuery.isSuccess
-  ) {
+  if (!getElectionRecordQuery.isSuccess || !pollingPlaceIdQuery.isSuccess) {
     return null;
   }
 
@@ -72,30 +56,16 @@ export function ElectionScreen(): JSX.Element | null {
   }
 
   const pollingPlaces = election.pollingPlaces || [];
-  const locationPicker = usePollingPlaces
-    ? pollingPlaces.length > 1 && (
-        <PollingPlacePicker
-          mode="default"
-          places={pollingPlaces}
-          searchable
-          selectedId={pollingPlaceIdQuery.data || undefined}
-          selectPlace={(id) => selectPollingPlace({ id })}
-          style={{ width: '16rem' }}
-        />
-      )
-    : election.precincts.length > 1 && (
-        <ChangePrecinctButton
-          appPrecinctSelection={selectedPrecinctQuery.data || undefined}
-          election={election}
-          mode="default"
-          style={{ width: '16rem' }}
-          searchable
-          updatePrecinctSelection={(precinctSelection) =>
-            selectPrecinct({ precinctSelection })
-          }
-          useMenuPortal
-        />
-      );
+  const locationPicker = pollingPlaces.length > 1 && (
+    <PollingPlacePicker
+      mode="default"
+      places={pollingPlaces}
+      searchable
+      selectedId={pollingPlaceIdQuery.data || undefined}
+      selectPlace={(id) => selectPollingPlace({ id })}
+      style={{ width: '16rem' }}
+    />
+  );
 
   return (
     <ScreenWrapper authType="election_manager">

--- a/apps/print/frontend/src/screens/machine_locked_screen.tsx
+++ b/apps/print/frontend/src/screens/machine_locked_screen.tsx
@@ -8,16 +8,7 @@ import {
   Main,
   Screen,
 } from '@votingworks/ui';
-import {
-  BooleanEnvironmentVariableName as Feature,
-  isFeatureFlagEnabled,
-} from '@votingworks/utils';
-import {
-  getElectionRecord,
-  getMachineConfig,
-  getPollingPlaceId,
-  getPrecinctSelection,
-} from '../api';
+import { getElectionRecord, getMachineConfig, getPollingPlaceId } from '../api';
 
 const LockedImage = styled.img`
   margin-right: auto;
@@ -27,16 +18,13 @@ const LockedImage = styled.img`
 `;
 
 export function MachineLockedScreen(): JSX.Element | null {
-  const usePollingPlaces = isFeatureFlagEnabled(Feature.ENABLE_POLLING_PLACES);
   const getElectionRecordQuery = getElectionRecord.useQuery();
   const getMachineConfigQuery = getMachineConfig.useQuery();
-  const getPrecinctSelectionQuery = getPrecinctSelection.useQuery();
   const getPollingPlaceIdQuery = getPollingPlaceId.useQuery();
 
   if (
     !getElectionRecordQuery.isSuccess ||
     !getMachineConfigQuery.isSuccess ||
-    !getPrecinctSelectionQuery.isSuccess ||
     !getPollingPlaceIdQuery.isSuccess
   ) {
     return null;
@@ -47,13 +35,9 @@ export function MachineLockedScreen(): JSX.Element | null {
   const machineConfig = getMachineConfigQuery.data;
   const pollingPlaceId = getPollingPlaceIdQuery.data;
   const requiresElectionConfiguration = !electionDefinition;
-  const requiresLocationSelection = usePollingPlaces
-    ? !pollingPlaceId
-    : !getPrecinctSelectionQuery.data;
+  const requiresLocationSelection = !pollingPlaceId;
   const isConfigured =
     !requiresElectionConfiguration && !requiresLocationSelection;
-
-  const locationType = usePollingPlaces ? 'polling place' : 'precinct';
 
   return (
     <Screen>
@@ -70,7 +54,7 @@ export function MachineLockedScreen(): JSX.Element | null {
             <H1 style={{ maxWidth: '27rem', marginTop: '0' }}>
               {requiresElectionConfiguration
                 ? 'Insert an election manager card to configure VxPrint.'
-                : `Insert an election manager card to select a ${locationType}.`}
+                : `Insert an election manager card to select a polling place.`}
             </H1>
           </Font>
         )}

--- a/apps/print/frontend/src/screens/print_screen.tsx
+++ b/apps/print/frontend/src/screens/print_screen.tsx
@@ -1,12 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 
-import {
-  BooleanEnvironmentVariableName as Feature,
-  format,
-  getLanguageOptions,
-  isFeatureFlagEnabled,
-} from '@votingworks/utils';
+import { format, getLanguageOptions } from '@votingworks/utils';
 import {
   BallotType,
   hasSplits,
@@ -24,7 +19,7 @@ import {
   Modal,
   Loading,
 } from '@votingworks/ui';
-import { assertDefined, find } from '@votingworks/basics';
+import { assertDefined } from '@votingworks/basics';
 import { ExpandedSelect } from '../components/expanded_select';
 import { TitleBar } from '../components/title_bar';
 import { PrintAllButton } from '../components/print_all_button';
@@ -32,7 +27,6 @@ import {
   getDeviceStatuses,
   getElectionRecord,
   getPollingPlaceId,
-  getPrecinctSelection,
   printBallot,
 } from '../api';
 import { getPartyOptions } from '../utils';
@@ -136,10 +130,9 @@ export function PrintScreen({
   const printBallotMutation = printBallot.useMutation();
 
   const getElectionRecordQuery = getElectionRecord.useQuery();
-  const getConfiguredPrecinctQuery = getPrecinctSelection.useQuery();
   const getDeviceStatusesQuery = getDeviceStatuses.useQuery();
-  const configuredPrecinct = getConfiguredPrecinctQuery.data;
-  const pollingPlaceId = getPollingPlaceId.useQuery().data;
+  const pollingPlaceIdQuery = getPollingPlaceId.useQuery();
+  const pollingPlaceId = pollingPlaceIdQuery.data;
 
   const [isShowingPrintingModal, setIsShowingPrintingModal] = useState(false);
 
@@ -148,22 +141,13 @@ export function PrintScreen({
 
     const { election } = getElectionRecordQuery.data.electionDefinition;
 
-    if (!isFeatureFlagEnabled(Feature.ENABLE_POLLING_PLACES)) {
-      if (configuredPrecinct?.kind === 'SinglePrecinct') {
-        const { precinctId } = configuredPrecinct;
-        return [find(election.precincts, (p) => p.id === precinctId)];
-      }
-
-      return election.precincts;
-    }
-
     if (!pollingPlaceId) return election.precincts;
 
     const place = pollingPlaceFromElection(election, pollingPlaceId);
     const precinctIds = pollingPlacePrecinctIds(place);
 
     return election.precincts.filter((p) => precinctIds.has(p.id));
-  }, [configuredPrecinct, getElectionRecordQuery.data, pollingPlaceId]);
+  }, [getElectionRecordQuery.data, pollingPlaceId]);
 
   if (!selectedPrecinctId && precincts.length > 0) {
     const defaultSelection = precincts[0].id;
@@ -172,7 +156,7 @@ export function PrintScreen({
 
   if (
     !getElectionRecordQuery.isSuccess ||
-    !getConfiguredPrecinctQuery.isSuccess ||
+    !pollingPlaceIdQuery.isSuccess ||
     !getDeviceStatusesQuery.isSuccess
   ) {
     return null;
@@ -192,7 +176,7 @@ export function PrintScreen({
   // If VxPrint is configured for a single precinct, hide the precinct
   // selection for Poll Workers and default to the configured precinct
   const hidePrecinctSelection =
-    configuredPrecinct?.kind === 'SinglePrecinct' && !isElectionManagerAuth;
+    precincts.length === 1 && !isElectionManagerAuth;
   const selectedPrecinct = selectedPrecinctId
     ? precincts.find((p) => p.id === selectedPrecinctId)
     : undefined;

--- a/libs/ui/src/diagnostics/print_readiness_report.test.tsx
+++ b/libs/ui/src/diagnostics/print_readiness_report.test.tsx
@@ -1,12 +1,7 @@
-import { test, vi } from 'vitest';
+import { test } from 'vitest';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { readElectionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
 import { assertDefined } from '@votingworks/basics';
-import {
-  getFeatureFlagMock,
-  BooleanEnvironmentVariableName,
-  ALL_PRECINCTS_SELECTION,
-} from '@votingworks/utils';
 import { PrintReadinessReport } from './print_readiness_report';
 import { render, screen } from '../../test/react_testing_library';
 import {
@@ -14,32 +9,11 @@ import {
   MOCK_PRINTER_CONFIG,
 } from './admin_readiness_report.test';
 
-const mockFeatureFlagger = getFeatureFlagMock();
-vi.mock(import('@votingworks/utils'), async (importActual) => ({
-  ...(await importActual()),
-  isFeatureFlagEnabled: (flag) => mockFeatureFlagger.isEnabled(flag),
-}));
-
-const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
-mockFeatureFlagger.enableFeatureFlag(ENABLE_POLLING_PLACES);
-
 const electionDef = readElectionTwoPartyPrimaryDefinition();
 const { election } = electionDef;
-const precinctSelection = ALL_PRECINCTS_SELECTION;
 const selectedPollingPlace = assertDefined(election.pollingPlaces)[0];
 
 test('PrintReadinessReport', () => {
-  mockFeatureFlagger.disableFeatureFlag(ENABLE_POLLING_PLACES);
-  testReport('Precinct: All Precincts');
-});
-
-test('PrintReadinessReport - polling places enabled', () => {
-  mockFeatureFlagger.enableFeatureFlag(ENABLE_POLLING_PLACES);
-  testReport(`Polling Place: ${selectedPollingPlace.name}`);
-});
-
-// [TODO] Merge into test after migration to polling places.
-function testReport(expectedPrecinctOrPollingPlaceString: string) {
   const generatedAtTime = new Date('2022-01-01T00:00:00');
   const machineId = 'MOCK';
   render(
@@ -54,7 +28,6 @@ function testReport(expectedPrecinctOrPollingPlaceString: string) {
         used: 500000000,
       }}
       pollingPlaceId={selectedPollingPlace.id}
-      precinctSelection={precinctSelection}
       printerStatus={{
         connected: true,
         config: MOCK_PRINTER_CONFIG,
@@ -79,10 +52,10 @@ function testReport(expectedPrecinctOrPollingPlaceString: string) {
   screen.getByText(hasTextAcrossElements('Machine ID: MOCK'));
   screen.getByText(hasTextAcrossElements('Date: Jan 1, 2022, 12:00:00 AM'));
   screen.getByText(/Example Primary Election/);
-  screen.getByText(expectedPrecinctOrPollingPlaceString);
+  screen.getByText(`Polling Place: ${selectedPollingPlace.name}`);
   screen.getByText('Battery Level: 50%');
   screen.getByText('Power Source: Battery');
   screen.getByText('Ready to print');
   screen.getByText('Toner Level: 100%');
   screen.getByText('Test print successful, 1/1/2022, 12:00:00 AM');
-}
+});

--- a/libs/ui/src/diagnostics/print_readiness_report.tsx
+++ b/libs/ui/src/diagnostics/print_readiness_report.tsx
@@ -1,8 +1,4 @@
 import { ThemeProvider } from 'styled-components';
-import {
-  BooleanEnvironmentVariableName,
-  isFeatureFlagEnabled,
-} from '@votingworks/utils';
 import { PrinterSection, PrinterSectionProps } from './printer_section';
 import { PrintedReport } from '../reports/layout';
 import { makeTheme } from '../themes/make_theme';
@@ -10,8 +6,6 @@ import { ReadinessReportHeader } from './report_header';
 import {
   ConfigurationSectionProps,
   ConfigurationSection,
-  PrecinctSelectionSection,
-  PrecinctSelectionSectionProps,
   PollingPlaceSectionProps,
   PollingPlaceSection,
 } from './configuration_section';
@@ -20,7 +14,6 @@ import { BatterySection, BatterySectionProps } from './battery_section';
 import { StorageSection, StorageSectionProps } from './storage_section';
 
 type ReportContentsProps = ConfigurationSectionProps &
-  PrecinctSelectionSectionProps &
   PollingPlaceSectionProps &
   BatterySectionProps &
   StorageSectionProps &
@@ -29,24 +22,16 @@ type ReportContentsProps = ConfigurationSectionProps &
 export function PrintReadinessReportContents(
   props: ReportContentsProps
 ): JSX.Element {
-  const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
-  const { electionDefinition, pollingPlaceId, precinctSelection } = props;
+  const { electionDefinition, pollingPlaceId } = props;
   const election = electionDefinition?.election;
 
   return (
     <ReportContents>
       <ConfigurationSection {...props}>
-        {isFeatureFlagEnabled(ENABLE_POLLING_PLACES) ? (
-          <PollingPlaceSection
-            election={election}
-            pollingPlaceId={pollingPlaceId}
-          />
-        ) : (
-          <PrecinctSelectionSection
-            election={election}
-            precinctSelection={precinctSelection}
-          />
-        )}
+        <PollingPlaceSection
+          election={election}
+          pollingPlaceId={pollingPlaceId}
+        />
       </ConfigurationSection>
       <BatterySection {...props} />
       <StorageSection {...props} />


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/8381

Cleaning up the `ENABLE_POLLING_PLACES` flag, which is now on by default. Removing the older code paths related precinct selection, which will now solely be based on polling place configuration.

## Demo Video or Screenshot
N/A

## Testing Plan
- Existing backend test cover the Polling Places code path affected by this change
- Removed the precinct selection path from affected tests in libs/ui
- No test setup yet for VxPrint frontend, so no updates there

## Checklist
N/A
