### PR TITLE
[VxPrint] [Backend] Remove old precinct selection code paths

### DIFF
--- a/apps/print/backend/schema.sql
+++ b/apps/print/backend/schema.sql
@@ -5,7 +5,6 @@ create table election (
   election_package_hash text not null,
   jurisdiction text not null,
   created_at timestamp not null default current_timestamp,
-  precinct_selection text, -- [TODO] Remove after migration to polling places
   polling_place_id text,
   is_test_mode boolean not null default false
 );

--- a/apps/print/backend/src/app.diagnostics.test.ts
+++ b/apps/print/backend/src/app.diagnostics.test.ts
@@ -210,9 +210,7 @@ test('test-page print', async () => {
   });
 });
 
-test('save readiness report (with precinct selection)', async () => {
-  setPollingPlacesEnabled(true);
-
+test('save readiness report', async () => {
   const { apiClient, mockPrinterHandler, auth, logger, mockUsbDrive, server } =
     buildTestEnvironment();
   mockSystemAdministratorAuth(auth);
@@ -295,12 +293,3 @@ test('getDiskSpaceSummary', async () => {
     MOCK_DISK_SPACE_SUMMARY
   );
 });
-
-function setPollingPlacesEnabled(enabled: boolean) {
-  // The mock feature flagger doesn't seem to work when an external package
-  // (e.g. libs/ui) is checking for the flag. Need to modify the env var
-  // directly.
-  process.env['REACT_APP_VX_ENABLE_POLLING_PLACES'] = enabled
-    ? 'TRUE'
-    : 'FALSE';
-}

--- a/apps/print/backend/src/app.test.ts
+++ b/apps/print/backend/src/app.test.ts
@@ -13,6 +13,7 @@ import {
   safeParseElectionDefinition,
   testCdfBallotDefinition,
   DEFAULT_SYSTEM_SETTINGS,
+  anyPollingPlace,
 } from '@votingworks/types';
 import {
   electionFamousNames2021Fixtures,
@@ -24,8 +25,6 @@ import { LogEventId, MockLogger } from '@votingworks/logging';
 import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
-  ALL_PRECINCTS_SELECTION,
-  singlePrecinctSelectionFor,
   getMockMultiLanguageElectionDefinition,
 } from '@votingworks/utils';
 import {
@@ -295,11 +294,7 @@ test('configureElectionPackageFromUsb returns no_ballots error when election pac
   );
 });
 
-// [TODO] Update test name after migration to Polling Places.
-test('configureElectionPackageFromUsb will automatically set precinct for single precinct election on configure', async () => {
-  const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
-  mockFeatureFlagger.enableFeatureFlag(ENABLE_POLLING_PLACES);
-
+test('configureElectionPackageFromUsb auto-selects polling place for single-location election', async () => {
   const electionDefinition =
     electionTwoPartyPrimaryFixtures.makeSinglePrecinctElectionDefinition();
   const ballotStyleId = electionDefinition.election.ballotStyles[0].id;
@@ -327,53 +322,7 @@ test('configureElectionPackageFromUsb will automatically set precinct for single
   const result = await apiClient.configureElectionPackageFromUsb();
   expect(result).toEqual(ok(expect.anything()));
 
-  expect(await apiClient.getPrecinctSelection()).toEqual(
-    singlePrecinctSelectionFor(precinctId)
-  );
   expect(await apiClient.getPollingPlaceId()).toEqual(defaultPollingPlace.id);
-});
-
-test('setting precinct', async () => {
-  const electionDefinition =
-    electionFamousNames2021Fixtures.readElectionDefinition();
-  const ballots = await buildBallotsForElection({
-    electionDefinition,
-    ballotModes: ['official'],
-  });
-  expect(await apiClient.getPrecinctSelection()).toBeNull();
-
-  await configureMachine({
-    electionDefinition,
-    ballots,
-    apiClient,
-    auth,
-    mockUsbDrive,
-  });
-
-  expect(await apiClient.getPrecinctSelection()).toBeNull();
-
-  await apiClient.setPrecinctSelection({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
-  });
-  expect(await apiClient.getPrecinctSelection()).toEqual(
-    ALL_PRECINCTS_SELECTION
-  );
-
-  const precinctId = electionDefinition.election.precincts[0].id;
-  const singlePrecinctSelection = singlePrecinctSelectionFor(precinctId);
-  await apiClient.setPrecinctSelection({
-    precinctSelection: singlePrecinctSelection,
-  });
-  expect(await apiClient.getPrecinctSelection()).toEqual(
-    singlePrecinctSelection
-  );
-  expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
-    LogEventId.PollingPlaceChanged,
-    expect.objectContaining({
-      disposition: 'success',
-      message: expect.stringContaining('User set the precinct for the machine'),
-    })
-  );
 });
 
 test('set polling place', async () => {
@@ -396,7 +345,7 @@ test('set polling place', async () => {
 
   expect(await apiClient.getPollingPlaceId()).toBeNull();
 
-  const place = assertDefined(electionDefinition.election.pollingPlaces?.[0]);
+  const place = anyPollingPlace(electionDefinition.election);
   await apiClient.setPollingPlaceId({ id: place.id });
   expect(await apiClient.getPollingPlaceId()).toEqual(place.id);
 
@@ -458,22 +407,20 @@ test('unconfigureMachine clears election configuration', async () => {
     apiClient,
     auth,
     mockUsbDrive,
+    pollingPlaceId: anyPollingPlace(electionDefinition.election).id,
   });
 
   expect(await apiClient.getElectionRecord()).not.toBeNull();
 
-  await apiClient.setPrecinctSelection({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
-  });
   await apiClient.setTestMode({ testMode: true });
 
-  expect(await apiClient.getPrecinctSelection()).not.toBeNull();
+  expect(await apiClient.getPollingPlaceId()).not.toBeNull();
   expect(await apiClient.getSystemSettings()).toEqual(DEFAULT_SYSTEM_SETTINGS);
 
   await apiClient.unconfigureMachine();
 
   expect(await apiClient.getElectionRecord()).toBeNull();
-  expect(await apiClient.getPrecinctSelection()).toBeNull();
+  expect(await apiClient.getPollingPlaceId()).toBeNull();
   expect(await apiClient.getBallots({})).toEqual([]);
   expect(await apiClient.getTestMode()).toEqual(false);
   expect(workspace.store.getSystemSettings()).toBeUndefined();
@@ -486,29 +433,25 @@ test('unconfigureMachine clears election configuration', async () => {
 
 test('printBallot logs when ballot is not found', async () => {
   const {
-    famousNamesMultiLangElectionDefinition,
+    famousNamesMultiLangElectionDefinition: electionDefinition,
     famousNamesMultiLangOfficialBallots,
   } = sharedFixtures;
 
   // Only configure official ballots so that printing in test mode will result in ballot not found
   await configureMachine({
-    electionDefinition: famousNamesMultiLangElectionDefinition,
+    electionDefinition,
     ballots: famousNamesMultiLangOfficialBallots,
     apiClient,
     auth,
     mockUsbDrive,
-  });
-
-  await apiClient.setPrecinctSelection({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: anyPollingPlace(electionDefinition.election).id,
   });
 
   mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
 
   await apiClient.setTestMode({ testMode: true });
 
-  const precinctId =
-    famousNamesMultiLangElectionDefinition.election.precincts[0].id;
+  const precinctId = electionDefinition.election.precincts[0].id;
 
   // Try to print a ballot - the precinct exists but no test mode ballot is stored
   await apiClient.printBallot({
@@ -529,23 +472,21 @@ test('printBallot logs when ballot is not found', async () => {
 
 test('end-to-end printing flow updates getBallotPrintCounts', async () => {
   const {
-    famousNamesMultiLangElectionDefinition,
+    famousNamesMultiLangElectionDefinition: electionDefinition,
     famousNamesMultiLangOfficialBallots,
   } = sharedFixtures;
 
   await configureMachine({
-    electionDefinition: famousNamesMultiLangElectionDefinition,
+    electionDefinition,
     ballots: famousNamesMultiLangOfficialBallots,
     apiClient,
     auth,
     mockUsbDrive,
-  });
-  await apiClient.setPrecinctSelection({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: anyPollingPlace(electionDefinition.election).id,
   });
   mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
 
-  const { ballotStyles } = famousNamesMultiLangElectionDefinition.election;
+  const { ballotStyles } = electionDefinition.election;
   const styleA = ballotStyles[0];
   const styleB = ballotStyles[1];
   const precinctA = styleA.precincts[0];
@@ -612,9 +553,7 @@ test('end-to-end printing flow updates getBallotPrintCounts for primary election
     apiClient,
     auth,
     mockUsbDrive,
-  });
-  await apiClient.setPrecinctSelection({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: anyPollingPlace(electionDefinition.election).id,
   });
   mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
 
@@ -692,9 +631,7 @@ test('end-to-end printing flow handles open primary (consolidated ballots)', asy
     apiClient,
     auth,
     mockUsbDrive,
-  });
-  await apiClient.setPrecinctSelection({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: anyPollingPlace(electionDefinition.election).id,
   });
   mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
 
@@ -763,23 +700,21 @@ test('printAllBallotStyles works for open primary (consolidated ballots)', async
 test('end-to-end printing flow handles precinct splits correctly', async () => {
   // Use election with precinct splits - Precinct 4 has two splits
   const {
-    primaryPrecinctSplitsMultiLangElectionDefinition,
+    primaryPrecinctSplitsMultiLangElectionDefinition: electionDefinition,
     primaryPrecinctSplitsMultiLangOfficialBallots,
   } = sharedFixtures;
 
   await configureMachine({
-    electionDefinition: primaryPrecinctSplitsMultiLangElectionDefinition,
+    electionDefinition,
     ballots: primaryPrecinctSplitsMultiLangOfficialBallots,
     apiClient,
     auth,
     mockUsbDrive,
-  });
-  await apiClient.setPrecinctSelection({
-    precinctSelection: ALL_PRECINCTS_SELECTION,
+    pollingPlaceId: anyPollingPlace(electionDefinition.election).id,
   });
   mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
 
-  const { parties } = primaryPrecinctSplitsMultiLangElectionDefinition.election;
+  const { parties } = electionDefinition.election;
   const mammalParty = parties.find((p) => p.name === 'Mammal')!;
 
   // Print a ballot for the precinct with splits (precinct-c2)

--- a/apps/print/backend/src/app.ts
+++ b/apps/print/backend/src/app.ts
@@ -7,8 +7,6 @@ import {
   DiagnosticRecord,
   ElectionDefinition,
   ElectionPackageConfigurationError,
-  PrecinctSelection,
-  SinglePrecinctSelection,
   LanguageCode,
   Id,
   BallotType,
@@ -24,13 +22,7 @@ import {
   getBatteryInfo,
   readSignedElectionPackageFromDirectory,
 } from '@votingworks/backend';
-import {
-  BooleanEnvironmentVariableName,
-  getPrecinctSelectionName,
-  isElectionManagerAuth,
-  isFeatureFlagEnabled,
-  singlePrecinctSelectionFor,
-} from '@votingworks/utils';
+import { isElectionManagerAuth } from '@votingworks/utils';
 import { generateSignedHashValidationQrCodeValue } from '@votingworks/auth';
 import { PrintProps, PrintSides } from '@votingworks/printing';
 import { AppContext } from './context';
@@ -120,13 +112,6 @@ export function buildApi(ctx: AppContext) {
       }
       assert(systemSettings);
 
-      let precinctSelection: SinglePrecinctSelection | undefined;
-      if (electionDefinition.election.precincts.length === 1) {
-        precinctSelection = singlePrecinctSelectionFor(
-          electionDefinition.election.precincts[0].id
-        );
-      }
-
       store.withTransaction(() => {
         store.setElectionAndJurisdiction({
           electionData: electionDefinition.electionData,
@@ -135,17 +120,11 @@ export function buildApi(ctx: AppContext) {
         });
         store.setSystemSettings(systemSettings);
         store.setBallots(ballots);
-        if (precinctSelection) {
-          store.setPrecinctSelection(precinctSelection);
-        }
 
-        const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
-        if (isFeatureFlagEnabled(ENABLE_POLLING_PLACES)) {
-          if (electionDefinition.election.pollingPlaces?.length === 1) {
-            workspace.store.setPollingPlaceId(
-              electionDefinition.election.pollingPlaces[0].id
-            );
-          }
+        if (electionDefinition.election.pollingPlaces?.length === 1) {
+          workspace.store.setPollingPlaceId(
+            electionDefinition.election.pollingPlaces[0].id
+          );
         }
       });
 
@@ -164,24 +143,6 @@ export function buildApi(ctx: AppContext) {
 
     getSystemSettings(): SystemSettings {
       return store.getSystemSettings() ?? DEFAULT_SYSTEM_SETTINGS;
-    },
-
-    getPrecinctSelection(): PrecinctSelection | null {
-      return store.getPrecinctSelection() || null;
-    },
-
-    async setPrecinctSelection(input: {
-      precinctSelection: PrecinctSelection;
-    }): Promise<void> {
-      const { electionDefinition } = assertDefined(store.getElectionRecord());
-      store.setPrecinctSelection(input.precinctSelection);
-      await logger.logAsCurrentRole(LogEventId.PollingPlaceChanged, {
-        disposition: 'success',
-        message: `User set the precinct for the machine to ${getPrecinctSelectionName(
-          electionDefinition.election.precincts,
-          input.precinctSelection
-        )}`,
-      });
     },
 
     getPollingPlaceId(): string | null {

--- a/apps/print/backend/src/auth.test.ts
+++ b/apps/print/backend/src/auth.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 import { Server } from 'node:http';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import {
+  anyPollingPlace,
   constructElectionKey,
   DEFAULT_SYSTEM_SETTINGS,
   EncodedBallotEntry,
@@ -10,9 +11,7 @@ import {
 import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
-  singlePrecinctSelectionFor,
 } from '@votingworks/utils';
-import { assertDefined } from '@votingworks/basics';
 import {
   buildTestEnvironment,
   configureMachine,
@@ -25,6 +24,7 @@ const electionDefinition =
   electionFamousNames2021Fixtures.readElectionDefinition();
 let ballots: EncodedBallotEntry[];
 const electionKey = constructElectionKey(electionDefinition.election);
+const pollingPlace = anyPollingPlace(electionDefinition.election);
 
 const mockFeatureFlagger = getFeatureFlagMock();
 
@@ -45,7 +45,6 @@ beforeEach(() => {
   mockFeatureFlagger.enableFeatureFlag(
     BooleanEnvironmentVariableName.SKIP_ELECTION_PACKAGE_AUTHENTICATION
   );
-  setPollingPlacesEnabled(false);
 });
 
 let server: Server | undefined;
@@ -68,9 +67,7 @@ test('getAuthStatus', async () => {
     mockUsbDrive,
   });
 
-  workspace.store.setPrecinctSelection(
-    singlePrecinctSelectionFor(electionDefinition.election.precincts[0].id)
-  );
+  workspace.store.setPollingPlaceId(pollingPlace.id);
 
   vi.mocked(auth.getAuthStatus).mockClear(); // Clear mock calls from configureMachine
 
@@ -86,8 +83,6 @@ test('getAuthStatus', async () => {
 });
 
 test('getAuthStatus - configured state is based on polling place selection', async () => {
-  setPollingPlacesEnabled(true);
-
   const env = buildTestEnvironment();
   server = env.server;
   const { apiClient, auth, mockUsbDrive } = env;
@@ -109,8 +104,6 @@ test('getAuthStatus - configured state is based on polling place selection', asy
     isConfigured: false,
   });
 
-  const { election } = electionDefinition;
-  const [pollingPlace] = assertDefined(election.pollingPlaces);
   await apiClient.setPollingPlaceId({ id: pollingPlace.id });
 
   await apiClient.getAuthStatus();
@@ -136,9 +129,7 @@ test('checkPin', async () => {
     mockUsbDrive,
   });
 
-  workspace.store.setPrecinctSelection(
-    singlePrecinctSelectionFor(electionDefinition.election.precincts[0].id)
-  );
+  workspace.store.setPollingPlaceId(pollingPlace.id);
   await apiClient.checkPin({ pin: '123456' });
   expect(auth.checkPin).toHaveBeenCalledTimes(1);
   expect(auth.checkPin).toHaveBeenNthCalledWith(
@@ -167,9 +158,7 @@ test('logOut', async () => {
     mockUsbDrive,
   });
 
-  workspace.store.setPrecinctSelection(
-    singlePrecinctSelectionFor(electionDefinition.election.precincts[0].id)
-  );
+  workspace.store.setPollingPlaceId(pollingPlace.id);
   await apiClient.logOut();
   expect(auth.logOut).toHaveBeenCalledTimes(1);
   expect(auth.logOut).toHaveBeenNthCalledWith(1, {
@@ -194,9 +183,7 @@ test('updateSessionExpiry', async () => {
     mockUsbDrive,
   });
 
-  workspace.store.setPrecinctSelection(
-    singlePrecinctSelectionFor(electionDefinition.election.precincts[0].id)
-  );
+  workspace.store.setPollingPlaceId(pollingPlace.id);
   await apiClient.updateSessionExpiry({
     sessionExpiresAt: new Date(Date.now() + 60_000),
   });
@@ -213,12 +200,3 @@ test('updateSessionExpiry', async () => {
     { sessionExpiresAt: expect.any(Date) }
   );
 });
-
-function setPollingPlacesEnabled(enabled: boolean) {
-  const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
-  if (enabled) {
-    mockFeatureFlagger.enableFeatureFlag(ENABLE_POLLING_PLACES);
-  } else {
-    mockFeatureFlagger.disableFeatureFlag(ENABLE_POLLING_PLACES);
-  }
-}

--- a/apps/print/backend/src/store.test.ts
+++ b/apps/print/backend/src/store.test.ts
@@ -1,6 +1,5 @@
 import { test, expect } from 'vitest';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
-import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import { BallotType, LanguageCode } from '@votingworks/types';
 import { Store } from './store';
 
@@ -34,8 +33,8 @@ test('reset clears the database', () => {
 test('unconfigured machine early returns or errors for relevant API calls', () => {
   const store = Store.memoryStore();
   store.setElectionAndJurisdiction();
-  expect(() => store.setPrecinctSelection(ALL_PRECINCTS_SELECTION)).toThrow(
-    'Cannot set precinct selection without an election.'
+  expect(() => store.setPollingPlaceId('foo')).toThrow(
+    'Cannot set polling place without an election.'
   );
   expect(
     store.getDistinctBallotStylesCount({

--- a/apps/print/backend/src/store.ts
+++ b/apps/print/backend/src/store.ts
@@ -19,9 +19,6 @@ import {
   ElectionKey,
   constructElectionKey,
   EncodedBallotEntry,
-  PrecinctSelection as PrecinctSelectionType,
-  safeParseJson,
-  PrecinctSelectionSchema,
   BallotType,
   BallotPrintCount,
   LanguageCode,
@@ -163,49 +160,6 @@ export class Store {
       id: result.id,
       date: new DateWithoutTime(result.date),
     };
-  }
-
-  /**
-   * Get the PrecinctSelection for VxPrint, either
-   * AllPrecincts, SinglePrecinct, or undefined. If `undefined`,
-   * configuration has not been done.
-   *
-   * Configuration is done by the Election Manager and applies to Poll Workers.
-   */
-  getPrecinctSelection(): PrecinctSelectionType | undefined {
-    const electionRow = this.client.one(
-      'select precinct_selection as rawPrecinctSelection from election'
-    ) as { rawPrecinctSelection: string } | undefined;
-
-    const rawPrecinctSelection = electionRow?.rawPrecinctSelection;
-    if (!rawPrecinctSelection) {
-      return undefined;
-    }
-
-    const precinctSelectionParseResult = safeParseJson(
-      rawPrecinctSelection,
-      PrecinctSelectionSchema
-    );
-    /* istanbul ignore next */
-    if (precinctSelectionParseResult.isErr()) {
-      throw new Error('Unable to parse stored precinct selection.');
-    }
-
-    return precinctSelectionParseResult.ok();
-  }
-
-  /**
-   * Sets the current precinct `print` is configured to print ballots for
-   */
-  setPrecinctSelection(precinctSelection?: PrecinctSelectionType): void {
-    if (!this.hasElection()) {
-      throw new Error('Cannot set precinct selection without an election.');
-    }
-
-    this.client.run(
-      'update election set precinct_selection = ?',
-      precinctSelection ? JSON.stringify(precinctSelection) : null
-    );
   }
 
   /**

--- a/apps/print/backend/src/util/auth.ts
+++ b/apps/print/backend/src/util/auth.ts
@@ -42,10 +42,7 @@ export function constructAuthMachineState(
   const machineType = 'print';
   const systemSettings = store.getSystemSettings() ?? DEFAULT_SYSTEM_SETTINGS;
   const jurisdiction = store.getJurisdiction();
-
-  const locationConfigured = isFeatureFlagEnabled(Feature.ENABLE_POLLING_PLACES)
-    ? !!store.getPollingPlaceId()
-    : !!store.getPrecinctSelection();
+  const locationConfigured = !!store.getPollingPlaceId();
 
   return {
     ...systemSettings.auth,

--- a/apps/print/backend/test/app.ts
+++ b/apps/print/backend/test/app.ts
@@ -113,12 +113,14 @@ export async function configureMachine({
   auth,
   electionDefinition,
   ballots,
+  pollingPlaceId,
 }: {
   apiClient: grout.Client<Api>;
   mockUsbDrive: MockUsbDrive;
   auth: DippedSmartCardAuthApi;
   electionDefinition: ElectionDefinition;
   ballots: EncodedBallotEntry[];
+  pollingPlaceId?: string;
 }): Promise<void> {
   mockElectionManagerAuth(auth, electionDefinition);
   mockUsbDrive.insertUsbDrive(
@@ -130,6 +132,10 @@ export async function configureMachine({
   );
   (await apiClient.configureElectionPackageFromUsb()).unsafeUnwrap();
   mockUsbDrive.removeUsbDrive();
+
+  if (pollingPlaceId) {
+    await apiClient.setPollingPlaceId({ id: pollingPlaceId });
+  }
 }
 
 export function mockAuthStatus(


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/8381

Cleaning up the `ENABLE_POLLING_PLACES` feature flag, now that it's on by default. Removing VxPrint backend code paths related to precinct selection.

## Demo Video or Screenshot
N/A

## Testing Plan
- Existing tests cover polling place paths
- Removed tests specific to precinct selection
- Updated remaining relevant tests to use polling place configuration instead of precinct selection

## Checklist
N/A