### PR TITLE
fix(grout): handle `await client` better

### DIFF
--- a/libs/grout/src/client.ts
+++ b/libs/grout/src/client.ts
@@ -79,6 +79,12 @@ export function createClient<Api extends AnyApi>(
   // that's the magic of the Proxy!
   return new Proxy({} as unknown as Client<Api>, {
     get(_target, methodName: string) {
+      if (methodName === 'then') {
+        // Don't look like a "thenable", otherwise anyone who awaits the client
+        // will trigger a bogus `then` RPC call.
+        return undefined;
+      }
+
       return async (input?: unknown) => {
         const inputJson = serialize(input);
 

--- a/libs/grout/src/client.ts
+++ b/libs/grout/src/client.ts
@@ -78,11 +78,33 @@ export function createClient<Api extends AnyApi>(
   // client.doSomething(), the variable methodName will be "doSomething" -
   // that's the magic of the Proxy!
   return new Proxy({} as unknown as Client<Api>, {
-    get(_target, methodName: string) {
-      if (methodName === 'then') {
-        // Don't look like a "thenable", otherwise anyone who awaits the client
-        // will trigger a bogus `then` RPC call.
+    get(_target, methodName) {
+      // Symbol-keyed properties are never RPC methods. They're accessed by
+      // JavaScript language internals (e.g. `Symbol.toPrimitive` during string
+      // or number coercion, `Symbol.iterator` during equality checks), so we
+      // return `undefined` to let those internals fall back to their defaults
+      // rather than triggering a bogus RPC call.
+      if (typeof methodName === 'symbol') {
         return undefined;
+      }
+
+      // Various common JavaScript language features will access properties
+      // on a client, and without this will trigger bogus RPC calls:
+      switch (methodName) {
+        // await client
+        case 'then':
+          return undefined;
+        // JSON.stringify(client)
+        case 'toJSON':
+          return () => ({});
+        // `${client}`
+        case 'toString':
+          return () => '[object Client]';
+        // +client
+        case 'valueOf':
+          return () => 0;
+        default:
+          break;
       }
 
       return async (input?: unknown) => {

--- a/libs/grout/src/grout.test.ts
+++ b/libs/grout/src/grout.test.ts
@@ -614,3 +614,27 @@ test('can access methods directly for testing', async () => {
   const api = createApi(methods);
   expect(api.methods()).toEqual(methods);
 });
+
+test('client can handle various JS language property gets without triggering RPC', async () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const api = createApi({
+    async getStuff(): Promise<number> {
+      return 42;
+    },
+  });
+  const app = express();
+  app.post('/api/then', () => {
+    expect.fail('this should not be called');
+  });
+  const server = app.listen();
+  const { port } = server.address() as AddressInfo;
+  const baseUrl = `http://localhost:${port}/api`;
+  const client = createClient<typeof api>({ baseUrl });
+  // eslint-disable-next-line @typescript-eslint/await-thenable
+  expect(await client).toEqual(client);
+  expect(JSON.stringify(client)).toEqual('{}');
+  expect(`${client}`).toEqual('[object Client]');
+  // eslint-disable-next-line vx/gts-safe-number-parse
+  expect(+client).toEqual(0);
+  server.close();
+});


### PR DESCRIPTION
## Overview
Previously, awaiting the client would trigger a `get` for a property called `then` in the proxy, which would cause an RPC call with a bogus "then" method name. Short-circuiting any access to a `then` property fixes this issue.

## Demo Video or Screenshot
n/a

## Testing Plan
I discovered this when playing around with using vitest fixtures and making an API client be one of the fixtures. Since fixtures can be generated by async functions, the result of the call is `await`ed. This causes the proxy's `get` to fire as described above.