### PR TITLE
VxDesign: Disable test deck generation for open primaries

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -3289,6 +3289,21 @@ test('open primary elections', async () => {
       })
     ).rejects.toThrow('Open primary')
   );
+
+  // Finalizing an open primary generates the election package but skips test
+  // decks, which don't yet support open primaries.
+  await addAbsenteePollingPlaceCoveringAllPrecincts(apiClient, electionId);
+  const originalMiConfig = stateFeatureConfigs.MI;
+  stateFeatureConfigs.MI = { ...originalMiConfig, EXPORT_TEST_BALLOTS: true };
+  try {
+    await apiClient.finalizeBallots({ electionId });
+  } finally {
+    stateFeatureConfigs.MI = originalMiConfig;
+  }
+  expect(
+    assertDefined(await apiClient.getElectionPackage({ electionId })).task
+  ).toBeDefined();
+  expect(await apiClient.getTestDecks({ electionId })).toEqual({});
 });
 
 test('Election package management', async () => {

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -705,6 +705,7 @@ export function buildApi(ctx: AppContext) {
         input.electionId
       );
       const stateFeatures = getStateFeaturesConfig(jurisdiction);
+      const { election } = await store.getElection(input.electionId);
 
       if (!stateFeatures.DISABLE_REGISTERED_VOTERS_COUNTS) {
         const registeredVoterCounts = await store.getRegisteredVotersCounts(
@@ -723,7 +724,6 @@ export function buildApi(ctx: AppContext) {
         !stateFeatures.OMIT_ABSENTEE_POLLING_PLACES &&
         stateFeatures.EDIT_POLLING_PLACES
       ) {
-        const { election } = await store.getElection(input.electionId);
         assert(
           getPrecinctsWithoutAbsenteePollingPlace(
             election.precincts,
@@ -741,7 +741,11 @@ export function buildApi(ctx: AppContext) {
         shouldExportTestBallots: !!stateFeatures.EXPORT_TEST_BALLOTS,
       });
 
-      if (stateFeatures.EXPORT_TEST_BALLOTS) {
+      // Test decks have not yet been updated to support open primaries
+      if (
+        stateFeatures.EXPORT_TEST_BALLOTS &&
+        election.type !== 'open-primary'
+      ) {
         await store.createTestDecksBackgroundTask(input.electionId, 'vxf');
       }
 

--- a/apps/design/frontend/src/export_screen.test.tsx
+++ b/apps/design/frontend/src/export_screen.test.tsx
@@ -170,6 +170,19 @@ test('omits test deck exports for states without test ballots enabled', async ()
   expect(screen.queryByText('Export Test Decks')).not.toBeInTheDocument();
 });
 
+test('omits test deck exports for open primary elections', async () => {
+  mockStateFeatures(apiMock, electionId, { EXPORT_TEST_BALLOTS: true });
+  apiMock.getElectionInfo.reset();
+  apiMock.getElectionInfo.expectCallWith({ electionId }).resolves({
+    ...electionInfoFromRecord(electionRecord),
+    type: 'open-primary',
+  });
+
+  renderScreen();
+  await screen.findAllByRole('heading', { name: 'Export' });
+  expect(screen.queryByText('Export Test Decks')).not.toBeInTheDocument();
+});
+
 test('export election package and ballots', async () => {
   renderScreen();
   await screen.findAllByRole('heading', { name: 'Export' });

--- a/apps/design/frontend/src/export_screen.tsx
+++ b/apps/design/frontend/src/export_screen.tsx
@@ -19,6 +19,7 @@ import {
   exportElectionPackage,
   exportTestDecks,
   getBallotsFinalizedAt,
+  getElectionInfo,
   getElectionPackage,
   setBallotTemplate,
   getUserFeatures,
@@ -54,6 +55,7 @@ export function ExportScreen(): JSX.Element | null {
   useTitle(routes.election(electionId).export.title);
   const getUserFeaturesQuery = getUserFeatures.useQuery();
   const getStateFeaturesQuery = getStateFeatures.useQuery(electionId);
+  const getElectionInfoQuery = getElectionInfo.useQuery(electionId);
   const electionPackageQuery = getElectionPackage.useQuery(electionId);
   const exportElectionPackageMutation = exportElectionPackage.useMutation();
   const testDecksQuery = getTestDecks.useQuery(electionId);
@@ -110,11 +112,13 @@ export function ExportScreen(): JSX.Element | null {
       getBallotsFinalizedAtQuery.isSuccess &&
       getBallotTemplateQuery.isSuccess &&
       getStateFeaturesQuery.isSuccess &&
+      getElectionInfoQuery.isSuccess &&
       getUserFeaturesQuery.isSuccess
     )
   ) {
     return null;
   }
+  const electionInfo = getElectionInfoQuery.data;
   const electionPackage = electionPackageQuery.data;
   const testDecks = testDecksQuery.data;
 
@@ -124,7 +128,10 @@ export function ExportScreen(): JSX.Element | null {
   const stateFeatures = getStateFeaturesQuery.data;
 
   const canExportTestDecks =
-    features.EXPORT_TEST_DECKS && stateFeatures.EXPORT_TEST_BALLOTS;
+    features.EXPORT_TEST_DECKS &&
+    stateFeatures.EXPORT_TEST_BALLOTS &&
+    // Test decks have not yet been updated to support open primaries
+    electionInfo.type !== 'open-primary';
 
   async function onSelectCvrsToDecrypt(event: FormEvent<HTMLInputElement>) {
     const input = event.currentTarget;


### PR DESCRIPTION
🤖 Co-authored with Claude Code
## Overview

<!-- Add a link to a GitHub issue here -->
Closes https://github.com/votingworks/vxsuite/issues/8629
Test deck generation for open primaries doesn't work well currently - all of the ballots are crossover voted, and the tally report generation crashes. We don't need this feature yet, so just disabling it for now.

## Demo Video or Screenshot
N/A

## Testing Plan
Updated automated tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
