### PR TITLE
screenshot(fix): gallery filename collisions on CI retries

### DIFF
--- a/apps/admin/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/admin/integration-testing/e2e/screenshots.spec.ts
@@ -22,7 +22,7 @@ import { assertDefined, find, iter } from '@votingworks/basics';
 import { zipFile } from '@votingworks/test-utils';
 import {
   buildIntegrationTestHelper,
-  createScreenshotCounter,
+  createScreenshotNamer,
 } from '@votingworks/integration-test-utils';
 import {
   AdjudicationReason,
@@ -58,8 +58,6 @@ import {
   selectOpenDropdownOption,
   waitForReportToLoad,
 } from './support/navigation';
-
-const screenshotCounter = createScreenshotCounter();
 
 async function saveLastExportedReport({
   usbHandler,
@@ -112,7 +110,8 @@ test.beforeEach(async ({ page }) => {
   await page.clock.install();
 });
 
-test('system administrator', async ({ page }) => {
+test('system administrator', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   const usbHandler = getMockFileUsbDriveHandler();
   const printerHandler = getMockFilePrinterHandler();
   const electionDefinition =
@@ -124,7 +123,7 @@ test('system administrator', async ({ page }) => {
   const electionPackageFileName = 'election-package.zip';
 
   const { screenshot, screenshotWithButtonHighlight } =
-    buildIntegrationTestHelper(page, screenshotCounter);
+    buildIntegrationTestHelper(page, namer);
 
   /**
    * configuration
@@ -426,7 +425,8 @@ async function insertUsbDriveWithCvrs({
   });
 }
 
-test('results', async ({ page }) => {
+test('results', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   test.setTimeout(120_000);
   const usbHandler = getMockFileUsbDriveHandler();
   const printerHandler = getMockFilePrinterHandler();
@@ -437,7 +437,7 @@ test('results', async ({ page }) => {
     electionGridLayoutNewHampshireTestBallotFixtures;
   const { election } = electionDefinition;
 
-  const { screenshot } = buildIntegrationTestHelper(page, screenshotCounter);
+  const { screenshot } = buildIntegrationTestHelper(page, namer);
 
   await page.goto('/');
   await configureMachine({
@@ -565,7 +565,8 @@ test('results', async ({ page }) => {
   await screenshot('tally-screen-official');
 });
 
-test('adjudication', async ({ page }) => {
+test('adjudication', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   const usbHandler = getMockFileUsbDriveHandler();
   const printerHandler = getMockFilePrinterHandler();
   printerHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
@@ -606,7 +607,7 @@ test('adjudication', async ({ page }) => {
     }
   );
 
-  const { screenshot } = buildIntegrationTestHelper(page, screenshotCounter);
+  const { screenshot } = buildIntegrationTestHelper(page, namer);
 
   await page.goto('/');
   await configureMachine({
@@ -662,7 +663,8 @@ test('adjudication', async ({ page }) => {
   await page.getByRole('button', { name: 'Adjudicate' }).waitFor();
 });
 
-test('manual results', async ({ page }) => {
+test('manual results', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   const usbHandler = getMockFileUsbDriveHandler();
   const printerHandler = getMockFilePrinterHandler();
   printerHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
@@ -672,7 +674,7 @@ test('manual results', async ({ page }) => {
     electionGridLayoutNewHampshireTestBallotFixtures;
   const { election } = electionDefinition;
 
-  const { screenshot } = buildIntegrationTestHelper(page, screenshotCounter);
+  const { screenshot } = buildIntegrationTestHelper(page, namer);
 
   await page.goto('/');
   await configureMachine({

--- a/apps/central-scan/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/central-scan/integration-testing/e2e/screenshots.spec.ts
@@ -14,7 +14,7 @@ import {
   buildIntegrationTestHelper,
   captureReadinessReport,
   createFullyVotedBallot,
-  createScreenshotCounter,
+  createScreenshotNamer,
   renderFoldedCornerSheet,
   renderMarkedBallots,
   withOvervote,
@@ -30,8 +30,6 @@ import {
   forceLogOutAndResetElectionDefinition,
   logInAsElectionManager,
 } from './support/auth';
-
-const screenshotCounter = createScreenshotCounter();
 
 const BALLOT_STYLE_ID = '1-1';
 const PRECINCT_ID = '20';
@@ -64,7 +62,8 @@ test.beforeEach(async ({ page }) => {
   getMockFileUsbDriveHandler().cleanup();
 });
 
-test('screenshots', async ({ page }) => {
+test('screenshots', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   const fixtureSet = electionFamousNames2021Fixtures;
   const electionDefinition = fixtureSet.readElectionDefinition();
   const { election } = electionDefinition;
@@ -74,7 +73,7 @@ test('screenshots', async ({ page }) => {
     screenshotWithButtonHighlight,
     screenshotWithLocatorHighlight,
     withContainerVerticallyExpanded,
-  } = buildIntegrationTestHelper(page, screenshotCounter);
+  } = buildIntegrationTestHelper(page, namer);
 
   // Enable adjudication so scanned ballots with these conditions pause on the
   // "Ballot Not Counted" eject screen instead of being silently counted.
@@ -310,7 +309,7 @@ test('screenshots', async ({ page }) => {
   await page
     .getByRole('heading', { name: 'Readiness Report Saved' })
     .waitFor({ timeout: 60000 });
-  await captureReadinessReport('readiness-report', screenshotCounter);
+  await captureReadinessReport('readiness-report', namer);
 
   usbHandler.cleanup();
 });

--- a/apps/mark-scan/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/mark-scan/integration-testing/e2e/screenshots.spec.ts
@@ -8,7 +8,7 @@ import {
 import {
   MULTI_LANGUAGE_UI_STRINGS,
   buildIntegrationTestHelper,
-  createScreenshotCounter,
+  createScreenshotNamer,
 } from '@votingworks/integration-test-utils';
 import {
   DEFAULT_SYSTEM_SETTINGS,
@@ -32,8 +32,6 @@ import {
 import { captureReadinessReport } from './support/reports';
 
 const POLLING_PLACE_NAME = 'North Lincoln';
-
-const screenshotCounter = createScreenshotCounter();
 
 test.beforeAll(setupTemporaryRootDir);
 test.afterAll(clearTemporaryRootDir);
@@ -139,11 +137,12 @@ async function voteAndCaptureContests(
   }
 }
 
-test('basic election flow', async ({ page }) => {
+test('basic election flow', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   const electionDefinition = getFamousNamesElectionDefinition();
   const { election } = electionDefinition;
   const usbHandler = getMockFileUsbDriveHandler();
-  const helper = buildIntegrationTestHelper(page, screenshotCounter);
+  const helper = buildIntegrationTestHelper(page, namer);
   const {
     screenshot,
     screenshotWithButtonHighlight,
@@ -307,10 +306,11 @@ test('basic election flow', async ({ page }) => {
     .waitFor();
 });
 
-test('additional options', async ({ page }) => {
+test('additional options', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   const electionDefinition = getFamousNamesElectionDefinition();
   const { election } = electionDefinition;
-  const helper = buildIntegrationTestHelper(page, screenshotCounter);
+  const helper = buildIntegrationTestHelper(page, namer);
   const {
     screenshot,
     screenshotWithButtonHighlight,
@@ -360,7 +360,7 @@ test('additional options', async ({ page }) => {
     .getByRole('button', { name: 'Save' })
     .click();
   await page.getByText('Readiness Report Saved').waitFor();
-  await captureReadinessReport('readiness-report', screenshotCounter);
+  await captureReadinessReport('readiness-report', namer);
   await page
     .getByRole('alertdialog')
     .getByRole('button', { name: 'Close' })
@@ -435,14 +435,15 @@ test('additional options', async ({ page }) => {
   );
 });
 
-test('voter settings', async ({ page }) => {
+test('voter settings', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   // Use the same single-precinct famous-names election as the basic flow (the
   // registered uiStrings drive the language selector). We don't capture a
   // printed multi-language ballot here, so the heavier electionGeneral isn't
   // needed.
   const electionDefinition = getFamousNamesElectionDefinition();
   const { election } = electionDefinition;
-  const helper = buildIntegrationTestHelper(page, screenshotCounter);
+  const helper = buildIntegrationTestHelper(page, namer);
   const { screenshot, screenshotWithLocatorHighlight } = helper;
   const electionPackage = await buildElectionPackage(electionDefinition);
 

--- a/apps/mark-scan/integration-testing/e2e/support/reports.ts
+++ b/apps/mark-scan/integration-testing/e2e/support/reports.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { assertDefined } from '@votingworks/basics';
 import {
   capturePdfScreenshots,
-  type ScreenshotCounter,
+  type ScreenshotNamer,
 } from '@votingworks/integration-test-utils';
 import { getMockFileUsbDriveHandler } from '@votingworks/usb-drive';
 
@@ -12,7 +12,7 @@ import { getMockFileUsbDriveHandler } from '@votingworks/usb-drive';
  */
 export async function captureReadinessReport(
   name: string,
-  counter: ScreenshotCounter
+  namer: ScreenshotNamer
 ): Promise<void> {
   const dataPath = assertDefined(getMockFileUsbDriveHandler().getDataPath());
   const reportFilename = assertDefined(
@@ -23,5 +23,5 @@ export async function captureReadinessReport(
     'expected a readiness report PDF on the mock USB drive'
   );
   const pdfBytes = new Uint8Array(readFileSync(join(dataPath, reportFilename)));
-  await capturePdfScreenshots(pdfBytes, name, counter);
+  await capturePdfScreenshots(pdfBytes, name, namer);
 }

--- a/apps/mark/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/mark/integration-testing/e2e/screenshots.spec.ts
@@ -10,7 +10,7 @@ import {
   MULTI_LANGUAGE_UI_STRINGS,
   buildIntegrationTestHelper,
   captureReadinessReport,
-  createScreenshotCounter,
+  createScreenshotNamer,
 } from '@votingworks/integration-test-utils';
 import {
   DEFAULT_SYSTEM_SETTINGS,
@@ -36,8 +36,6 @@ import { configureMachine, openPolls, voteFullBallot } from './support/flows';
 import { capturePrintedBallot } from './support/reports';
 
 const POLLING_PLACE_NAME = 'North Lincoln';
-
-const screenshotCounter = createScreenshotCounter();
 
 test.beforeAll(setupTemporaryRootDir);
 test.afterAll(clearTemporaryRootDir);
@@ -144,11 +142,12 @@ async function voteAndCaptureContests(
   }
 }
 
-test('basic election flow', async ({ page }) => {
+test('basic election flow', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   const electionDefinition = getFamousNamesElectionDefinition();
   const { election } = electionDefinition;
   const usbHandler = getMockFileUsbDriveHandler();
-  const helper = buildIntegrationTestHelper(page, screenshotCounter);
+  const helper = buildIntegrationTestHelper(page, namer);
   const {
     screenshot,
     screenshotWithButtonHighlight,
@@ -263,7 +262,7 @@ test('basic election flow', async ({ page }) => {
   await screenshot('voting-almost-done');
 
   // Capture the ballot that was printed to the mock printer.
-  await capturePrintedBallot('printed-ballot', screenshotCounter);
+  await capturePrintedBallot('printed-ballot', namer);
 
   await page.getByRole('button', { name: 'Done' }).click();
 
@@ -312,10 +311,11 @@ test('basic election flow', async ({ page }) => {
     .waitFor();
 });
 
-test('additional options', async ({ page }) => {
+test('additional options', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   const electionDefinition = getFamousNamesElectionDefinition();
   const { election } = electionDefinition;
-  const helper = buildIntegrationTestHelper(page, screenshotCounter);
+  const helper = buildIntegrationTestHelper(page, namer);
   const {
     screenshot,
     screenshotWithButtonHighlight,
@@ -364,7 +364,7 @@ test('additional options', async ({ page }) => {
     .getByRole('button', { name: 'Save' })
     .click();
   await page.getByText('Readiness Report Saved').waitFor();
-  await captureReadinessReport('readiness-report', screenshotCounter);
+  await captureReadinessReport('readiness-report', namer);
   await page
     .getByRole('alertdialog')
     .getByRole('button', { name: 'Close' })
@@ -445,14 +445,15 @@ test('additional options', async ({ page }) => {
   );
 });
 
-test('voter settings', async ({ page }) => {
+test('voter settings', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   // electionGeneral ships full translations (Chinese, etc.); the helper also
   // tags its ballot styles with a Chinese ballot language so the printed ballot
   // is dual-language (Chinese + English).
   const electionDefinition = getMultiLanguageGeneralElectionDefinition();
   const { election } = electionDefinition;
   const pollingPlaceName = 'Center Springfield';
-  const helper = buildIntegrationTestHelper(page, screenshotCounter);
+  const helper = buildIntegrationTestHelper(page, namer);
   const { screenshot, screenshotWithLocatorHighlight } = helper;
   const electionPackage = await mockElectionPackageFileTree({
     electionDefinition,
@@ -606,5 +607,5 @@ test('voter settings', async ({ page }) => {
       timeout: 15000,
     })
     .not.toBe(previousPrintPath);
-  await capturePrintedBallot('printed-ballot-multilingual', screenshotCounter);
+  await capturePrintedBallot('printed-ballot-multilingual', namer);
 });

--- a/apps/mark/integration-testing/e2e/support/reports.ts
+++ b/apps/mark/integration-testing/e2e/support/reports.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { assertDefined } from '@votingworks/basics';
 import {
   capturePdfScreenshots,
-  type ScreenshotCounter,
+  type ScreenshotNamer,
 } from '@votingworks/integration-test-utils';
 import { getMockFilePrinterHandler } from '@votingworks/printing';
 
@@ -12,14 +12,14 @@ import { getMockFilePrinterHandler } from '@votingworks/printing';
  */
 export async function capturePrintedBallot(
   name: string,
-  counter: ScreenshotCounter
+  namer: ScreenshotNamer
 ): Promise<void> {
   const printPath = assertDefined(
     getMockFilePrinterHandler().getLastPrintPath(),
     'expected a printed ballot PDF from the mock printer'
   );
   const pdfBytes = new Uint8Array(readFileSync(printPath));
-  await capturePdfScreenshots(pdfBytes, name, counter, {
+  await capturePdfScreenshots(pdfBytes, name, namer, {
     skipBlankPages: true,
   });
 }

--- a/apps/print/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/print/integration-testing/e2e/screenshots.spec.ts
@@ -10,7 +10,7 @@ import {
 } from '@votingworks/fixtures';
 import {
   buildIntegrationTestHelper,
-  createScreenshotCounter,
+  createScreenshotNamer,
 } from '@votingworks/integration-test-utils';
 import {
   DEFAULT_SYSTEM_SETTINGS,
@@ -37,8 +37,6 @@ import {
 } from './support/election';
 import { buildBallotsForElection, configureMachine } from './support/flows';
 import { capturePrintedBallotsReport } from './support/reports';
-
-const screenshotCounter = createScreenshotCounter();
 
 test.beforeAll(setupTemporaryRootDir);
 test.afterAll(clearTemporaryRootDir);
@@ -89,12 +87,15 @@ function pseudoRandomBase64(seed: string, byteLength: number): string {
   return Buffer.concat(chunks).subarray(0, byteLength).toString('base64');
 }
 
-test('election manager: configuration and settings', async ({ page }) => {
+test('election manager: configuration and settings', async ({
+  page,
+}, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   const electionDefinition = getElectionDefinition();
   const { election } = electionDefinition;
   const usbHandler = getMockFileUsbDriveHandler();
   const { screenshot, screenshotWithButtonHighlight } =
-    buildIntegrationTestHelper(page, screenshotCounter);
+    buildIntegrationTestHelper(page, namer);
   const electionPackage = await buildElectionPackage(electionDefinition);
 
   // Locked, unconfigured: prompt to insert an election manager card.
@@ -258,14 +259,15 @@ test('election manager: configuration and settings', async ({ page }) => {
     .click();
 });
 
-test('election manager: print screen options', async ({ page }) => {
+test('election manager: print screen options', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   const electionDefinition = getElectionDefinition();
   const { election } = electionDefinition;
   const {
     screenshot,
     screenshotWithButtonHighlight,
     screenshotWithLocatorHighlight,
-  } = buildIntegrationTestHelper(page, screenshotCounter);
+  } = buildIntegrationTestHelper(page, namer);
   const electionPackage = await buildElectionPackage(electionDefinition);
   const partyName = election.parties[0].name;
 
@@ -314,10 +316,11 @@ test('election manager: print screen options', async ({ page }) => {
     .click();
 });
 
-test('poll worker: split precinct and reports', async ({ page }) => {
+test('poll worker: split precinct and reports', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   const electionDefinition = getElectionDefinition();
   const { election } = electionDefinition;
-  const { screenshot } = buildIntegrationTestHelper(page, screenshotCounter);
+  const { screenshot } = buildIntegrationTestHelper(page, namer);
   const electionPackage = await buildElectionPackage(electionDefinition);
   const partyName = election.parties[0].name;
 
@@ -365,20 +368,18 @@ test('poll worker: split precinct and reports', async ({ page }) => {
     .getByRole('button', { name: 'Export' })
     .click();
   await page.getByText('Ballots Printed Report Exported').waitFor();
-  await capturePrintedBallotsReport(
-    'pw-ballots-printed-report',
-    screenshotCounter
-  );
+  await capturePrintedBallotsReport('pw-ballots-printed-report', namer);
   await page
     .getByRole('alertdialog')
     .getByRole('button', { name: 'Close' })
     .click();
 });
 
-test('poll worker: precinct without splits', async ({ page }) => {
+test('poll worker: precinct without splits', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   const electionDefinition = getElectionDefinition();
   const { election } = electionDefinition;
-  const { screenshot } = buildIntegrationTestHelper(page, screenshotCounter);
+  const { screenshot } = buildIntegrationTestHelper(page, namer);
   const electionPackage = await buildElectionPackage(electionDefinition);
   const partyName = election.parties[0].name;
 
@@ -397,8 +398,9 @@ test('poll worker: precinct without splits', async ({ page }) => {
   await screenshot('pw-print-no-split-with-selections');
 });
 
-test('system administrator: settings', async ({ page }) => {
-  const { screenshot } = buildIntegrationTestHelper(page, screenshotCounter);
+test('system administrator: settings', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
+  const { screenshot } = buildIntegrationTestHelper(page, namer);
 
   await logInAsSystemAdministrator(page);
   await page.getByRole('button', { name: 'Unconfigure Machine' }).waitFor();

--- a/apps/print/integration-testing/e2e/support/reports.ts
+++ b/apps/print/integration-testing/e2e/support/reports.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { assertDefined } from '@votingworks/basics';
 import {
   capturePdfScreenshots,
-  type ScreenshotCounter,
+  type ScreenshotNamer,
 } from '@votingworks/integration-test-utils';
 import { getMockFileUsbDriveHandler } from '@votingworks/usb-drive';
 
@@ -13,7 +13,7 @@ import { getMockFileUsbDriveHandler } from '@votingworks/usb-drive';
  */
 export async function capturePrintedBallotsReport(
   name: string,
-  counter: ScreenshotCounter
+  namer: ScreenshotNamer
 ): Promise<void> {
   const dataPath = assertDefined(getMockFileUsbDriveHandler().getDataPath());
   // The report is exported into an election-specific reports subdirectory, so
@@ -29,5 +29,5 @@ export async function capturePrintedBallotsReport(
     'expected a ballots-printed report PDF on the mock USB drive'
   );
   const pdfBytes = new Uint8Array(readFileSync(join(dataPath, reportFilename)));
-  await capturePdfScreenshots(pdfBytes, name, counter);
+  await capturePdfScreenshots(pdfBytes, name, namer);
 }

--- a/apps/scan/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/scan/integration-testing/e2e/screenshots.spec.ts
@@ -11,7 +11,7 @@ import {
   MULTI_LANGUAGE_UI_STRINGS,
   buildIntegrationTestHelper,
   createFullyVotedBallot,
-  createScreenshotCounter,
+  createScreenshotNamer,
   renderMarkedBallots,
   withOvervote,
   withUndervote,
@@ -33,8 +33,6 @@ import {
 import { capturePrintedReport } from './support/print_to_png';
 import { mockPdiScannerHandler } from './support/scanner';
 
-const screenshotCounter = createScreenshotCounter();
-
 test.beforeAll(setupTemporaryRootDir);
 test.afterAll(clearTemporaryRootDir);
 
@@ -43,14 +41,15 @@ test.beforeEach(async ({ page }) => {
   getMockFileUsbDriveHandler().cleanup();
 });
 
-test('configuration', async ({ page }) => {
+test('configuration', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   const fixtureSet = electionFamousNames2021Fixtures;
   const usbHandler = getMockFileUsbDriveHandler();
   const {
     screenshot,
     screenshotWithButtonHighlight,
     withContainerVerticallyExpanded,
-  } = buildIntegrationTestHelper(page, screenshotCounter);
+  } = buildIntegrationTestHelper(page, namer);
 
   await page
     .getByText('Insert an election manager card to configure VxScan')
@@ -119,7 +118,7 @@ test('configuration', async ({ page }) => {
   await page.getByRole('button', { name: 'Print Test Page' }).click();
   await page.getByText('Test Page Printed').waitFor();
   await screenshot('em-printer-test-page-printed');
-  await capturePrintedReport('em-printer-test-page', screenshotCounter);
+  await capturePrintedReport('em-printer-test-page', namer);
   await page.getByRole('button', { name: 'Pass' }).click();
 
   await page.getByRole('tab', { name: 'Scanner' }).click();
@@ -192,7 +191,8 @@ test('configuration', async ({ page }) => {
   );
 });
 
-test('voting', async ({ page }) => {
+test('voting', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   const fixtureSet = electionFamousNames2021Fixtures;
   const electionDefinition = fixtureSet.readElectionDefinition();
   const { election } = electionDefinition;
@@ -201,7 +201,7 @@ test('voting', async ({ page }) => {
     screenshot,
     screenshotWithButtonHighlight,
     screenshotWithLocatorHighlight,
-  } = buildIntegrationTestHelper(page, screenshotCounter);
+  } = buildIntegrationTestHelper(page, namer);
 
   const systemSettings: SystemSettings = {
     ...DEFAULT_SYSTEM_SETTINGS,
@@ -300,7 +300,7 @@ test('voting', async ({ page }) => {
     .getByRole('heading', { name: 'Polls Opened' })
     .waitFor({ timeout: 60000 });
   await screenshot('polls-opened');
-  await capturePrintedReport('polls-opened-report', screenshotCounter);
+  await capturePrintedReport('polls-opened-report', namer);
   await screenshotWithButtonHighlight(
     'Reprint Polls Opened Report',
     'reprint-polls-opened-report-button'
@@ -401,7 +401,7 @@ test('voting', async ({ page }) => {
     timeout: 60000,
   });
   await screenshot('polls-closed-report');
-  await capturePrintedReport('polls-closed-report', screenshotCounter);
+  await capturePrintedReport('polls-closed-report', namer);
   await screenshotWithButtonHighlight(
     'Reprint Polls Closed Report',
     'reprint-polls-closed-report-button'
@@ -456,7 +456,7 @@ test('voting', async ({ page }) => {
     timeout: 60000,
   });
   await screenshot('pw-voting-resumed');
-  await capturePrintedReport('voting-resumed-report', screenshotCounter);
+  await capturePrintedReport('voting-resumed-report', namer);
   mockCardRemoval();
   await page.getByText('Insert Your Ballot').waitFor();
 
@@ -476,7 +476,7 @@ test('voting', async ({ page }) => {
     timeout: 60000,
   });
   await screenshot('pw-voting-paused');
-  await capturePrintedReport('voting-paused-report', screenshotCounter);
+  await capturePrintedReport('voting-paused-report', namer);
   mockCardRemoval();
   await page.getByText('Insert a poll worker card to resume voting.').waitFor();
 
@@ -501,19 +501,17 @@ test('voting', async ({ page }) => {
   await page.getByRole('heading', { name: 'Polls Closed' }).waitFor({
     timeout: 60000,
   });
-  await capturePrintedReport(
-    'polls-closed-report-multi-batch',
-    screenshotCounter
-  );
+  await capturePrintedReport('polls-closed-report-multi-batch', namer);
 
   mockCardRemoval();
   await page.getByText('Voting is complete.').waitFor();
 });
 
-test('accessibility', async ({ page }) => {
+test('accessibility', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
   const fixtureSet = electionFamousNames2021Fixtures;
   const usbHandler = getMockFileUsbDriveHandler();
-  const { screenshot } = buildIntegrationTestHelper(page, screenshotCounter);
+  const { screenshot } = buildIntegrationTestHelper(page, namer);
 
   const systemSettings: SystemSettings = {
     ...DEFAULT_SYSTEM_SETTINGS,

--- a/apps/scan/integration-testing/e2e/support/print_to_png.ts
+++ b/apps/scan/integration-testing/e2e/support/print_to_png.ts
@@ -2,16 +2,16 @@ import { readFileSync } from 'node:fs';
 import { getMockFileFujitsuPrinterHandler } from '@votingworks/fujitsu-thermal-printer';
 import {
   capturePdfScreenshots,
-  type ScreenshotCounter,
+  type ScreenshotNamer,
 } from '@votingworks/integration-test-utils';
 
 /** Reads the most recently printed PDF and saves each page as a PNG in test-results/screenshots. */
 export async function capturePrintedReport(
   name: string,
-  counter: ScreenshotCounter
+  namer: ScreenshotNamer
 ): Promise<void> {
   const printPath = getMockFileFujitsuPrinterHandler().getLastPrintPath();
   if (!printPath) return;
   const pdfBytes = new Uint8Array(readFileSync(printPath));
-  await capturePdfScreenshots(pdfBytes, name, counter);
+  await capturePdfScreenshots(pdfBytes, name, namer);
 }

--- a/libs/integration-test-utils/src/pdf.ts
+++ b/libs/integration-test-utils/src/pdf.ts
@@ -1,6 +1,6 @@
 import { pdfToImages, writeImageData } from '@votingworks/image-utils';
 import { SCREENSHOTS_DIR } from './constants';
-import type { ScreenshotCounter } from './screenshots';
+import type { ScreenshotNamer } from './screenshots';
 
 export interface CapturePdfScreenshotsOptions {
   /**
@@ -35,17 +35,14 @@ function isBlankImage(image: { data: Uint8ClampedArray }): boolean {
 export async function capturePdfScreenshots(
   pdfBytes: Uint8Array,
   name: string,
-  counter: ScreenshotCounter,
+  namer: ScreenshotNamer,
   options: CapturePdfScreenshotsOptions = {}
 ): Promise<void> {
   let captured = 0;
   for await (const { page } of pdfToImages(pdfBytes, { scale: 2 })) {
     if (options.skipBlankPages && isBlankImage(page)) continue;
     const suffix = captured === 0 ? name : `${name}-page${captured + 1}`;
-    await writeImageData(
-      `${SCREENSHOTS_DIR}/${counter.next()}-${suffix}.png`,
-      page
-    );
+    await writeImageData(`${SCREENSHOTS_DIR}/${namer.next(suffix)}.png`, page);
     captured += 1;
   }
 }

--- a/libs/integration-test-utils/src/reports.ts
+++ b/libs/integration-test-utils/src/reports.ts
@@ -2,7 +2,7 @@ import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { getMockFileUsbDriveHandler } from '@votingworks/usb-drive';
 import { capturePdfScreenshots } from './pdf';
-import type { ScreenshotCounter } from './screenshots';
+import type { ScreenshotNamer } from './screenshots';
 
 /** Recursively collects all file paths under `dir`. */
 function listFilesRecursive(dir: string): string[] {
@@ -18,7 +18,7 @@ function listFilesRecursive(dir: string): string[] {
  */
 export async function captureReadinessReport(
   name: string,
-  counter: ScreenshotCounter
+  namer: ScreenshotNamer
 ): Promise<void> {
   const usbPath = getMockFileUsbDriveHandler().getDataPath();
   if (!usbPath) throw new Error('Mock USB drive is not mounted');
@@ -32,5 +32,5 @@ export async function captureReadinessReport(
   if (!reportPath) throw new Error('No readiness report found on USB drive');
 
   const pdfBytes = new Uint8Array(readFileSync(reportPath));
-  await capturePdfScreenshots(pdfBytes, name, counter);
+  await capturePdfScreenshots(pdfBytes, name, namer);
 }

--- a/libs/integration-test-utils/src/screenshots.ts
+++ b/libs/integration-test-utils/src/screenshots.ts
@@ -1,35 +1,50 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import type { Locator, Page, PageScreenshotOptions } from '@playwright/test';
+import type {
+  Locator,
+  Page,
+  PageScreenshotOptions,
+  TestInfo,
+} from '@playwright/test';
 import { SCREENSHOTS_DIR } from './constants';
 
-export interface ScreenshotCounter {
-  next: () => string;
+/**
+ * Builds ordered, collision-free filename stems for the screenshots captured
+ * within a single test. Filenames are namespaced by test identity, so they are
+ * deterministic and independent of Playwright's worker lifecycle: a CI retry
+ * regenerates identical filenames and cleanly overwrites the previous attempt,
+ * rather than colliding with another test's screenshots (a module-global
+ * counter would reset to zero whenever a failed test spawns a fresh worker).
+ */
+export interface ScreenshotNamer {
+  /** Returns the next filename stem (no extension) for the given screenshot. */
+  next: (name: string) => string;
 }
 
-export function createScreenshotCounter(): ScreenshotCounter {
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function createScreenshotNamer(testInfo: TestInfo): ScreenshotNamer {
+  const slug = slugify(testInfo.title);
   let index = 0;
   return {
-    next(): string {
+    next(name: string): string {
       const prefix = String(index).padStart(3, '0');
       index += 1;
-      return prefix;
+      return `${slug}-${prefix}-${name}`;
     },
   };
 }
 
-export function buildIntegrationTestHelper(
-  page: Page,
-  counter: ScreenshotCounter = createScreenshotCounter()
-) {
-  function numberedName(name: string): string {
-    return `${counter.next()}-${name}`;
-  }
-
+export function buildIntegrationTestHelper(page: Page, namer: ScreenshotNamer) {
   async function screenshot(name: string, args: PageScreenshotOptions = {}) {
     await page.screenshot({
       animations: 'disabled',
       ...args,
-      path: `${SCREENSHOTS_DIR}/${numberedName(name)}.png`,
+      path: `${SCREENSHOTS_DIR}/${namer.next(name)}.png`,
     });
   }
 


### PR DESCRIPTION
## Overview

Fixes #8641.

The integration-test screenshot gallery prefixed filenames from a **module-global counter** (`000`, `001`, …). On CI (`workers: 1, retries: 2`), when a test fails Playwright tears down the worker and the retry spawns a fresh one, re-importing the spec module and resetting the counter to `000`. The retried test then re-wrote low-numbered prefixes into the shared `SCREENSHOTS_DIR`, colliding with screenshots from tests that had already passed (e.g. test A's `000–032`). The gallery (`--sort-media-by filename`) then interleaved/overwrote unrelated images.

A secondary footgun: `buildIntegrationTestHelper(page, counter = createScreenshotCounter())` defaulted to a *fresh* counter, so any test that forgot to pass the shared one silently got its own colliding `000`-based sequence.

## Fix (Option A from the issue)

Replace the worker-lifecycle-dependent counter with a per-test `ScreenshotNamer` derived from Playwright's `testInfo`. Filenames are now namespaced by test identity — `<test-slug>-<NNN>-<name>.png` — so they are **deterministic and worker-independent**: a retry regenerates identical filenames and cleanly overwrites the previous attempt. The namer is now a **required** argument, eliminating the default-parameter footgun.

The counter lived in the shared `@votingworks/integration-test-utils` lib, so this updates **all six** integration suites (admin, central-scan, scan, print, mark, mark-scan), which all had the same structural bug.

### Gallery-ordering note

Because the gallery sorts by filename, top-level grouping is now **alphabetical by test title** rather than test-execution order (e.g. for VxMark, `additional options` sorts before `basic election flow`). Each test's internal screenshot narrative is preserved.

## Testing Plan

- ✅ `@votingworks/integration-test-utils` builds
- ✅ All six integration-testing packages typecheck clean (`tsgo --noEmit`)
- ✅ ESLint clean across the lib and all six suites
- ⚠️ The Playwright suites themselves were **not** run locally — `make build`'s `libs/printing` postinstall shells out to `sudo playwright install --with-deps chromium`, which isn't available in my environment. CI will exercise them.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions. _(N/A — test-only change.)_
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates. _(N/A — test infrastructure only.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)