### PR TITLE
CI: Version the automated screenshot gallery by branch/tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,15 +111,18 @@ jobs:
           path: apps/admin/integration-testing/test-results/
       - when:
           condition:
-            equal: [ main, << pipeline.git.branch >> ]
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+              - matches: { pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$', value: << pipeline.git.tag >> }
           steps:
             - aws-cli/setup
             - run:
                 name: Upload screenshots to S3
                 command: |
+                  VERSION="${CIRCLE_TAG:-$CIRCLE_BRANCH}"
                   if [ -d "apps/admin/integration-testing/test-results/screenshots" ]; then
                     aws s3 sync apps/admin/integration-testing/test-results/screenshots/ \
-                      "s3://$SCREENSHOT_BUCKET/screenshots/admin/" \
+                      "s3://$SCREENSHOT_BUCKET/screenshots/$VERSION/admin/" \
                       --exclude "*" --include "*.png" --delete
                   fi
 
@@ -205,15 +208,18 @@ jobs:
           path: apps/central-scan/integration-testing/test-results/
       - when:
           condition:
-            equal: [ main, << pipeline.git.branch >> ]
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+              - matches: { pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$', value: << pipeline.git.tag >> }
           steps:
             - aws-cli/setup
             - run:
                 name: Upload screenshots to S3
                 command: |
+                  VERSION="${CIRCLE_TAG:-$CIRCLE_BRANCH}"
                   if [ -d "apps/central-scan/integration-testing/test-results/screenshots" ]; then
                     aws s3 sync apps/central-scan/integration-testing/test-results/screenshots/ \
-                      "s3://$SCREENSHOT_BUCKET/screenshots/central-scan/" \
+                      "s3://$SCREENSHOT_BUCKET/screenshots/$VERSION/central-scan/" \
                       --exclude "*" --include "*.png" --delete
                   fi
 
@@ -349,15 +355,18 @@ jobs:
           path: apps/mark-scan/integration-testing/test-results/
       - when:
           condition:
-            equal: [ main, << pipeline.git.branch >> ]
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+              - matches: { pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$', value: << pipeline.git.tag >> }
           steps:
             - aws-cli/setup
             - run:
                 name: Upload screenshots to S3
                 command: |
+                  VERSION="${CIRCLE_TAG:-$CIRCLE_BRANCH}"
                   if [ -d "apps/mark-scan/integration-testing/test-results/screenshots" ]; then
                     aws s3 sync apps/mark-scan/integration-testing/test-results/screenshots/ \
-                      "s3://$SCREENSHOT_BUCKET/screenshots/mark-scan/" \
+                      "s3://$SCREENSHOT_BUCKET/screenshots/$VERSION/mark-scan/" \
                       --exclude "*" --include "*.png" --delete
                   fi
 
@@ -443,15 +452,18 @@ jobs:
           path: apps/mark/integration-testing/test-results/
       - when:
           condition:
-            equal: [ main, << pipeline.git.branch >> ]
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+              - matches: { pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$', value: << pipeline.git.tag >> }
           steps:
             - aws-cli/setup
             - run:
                 name: Upload screenshots to S3
                 command: |
+                  VERSION="${CIRCLE_TAG:-$CIRCLE_BRANCH}"
                   if [ -d "apps/mark/integration-testing/test-results/screenshots" ]; then
                     aws s3 sync apps/mark/integration-testing/test-results/screenshots/ \
-                      "s3://$SCREENSHOT_BUCKET/screenshots/mark/" \
+                      "s3://$SCREENSHOT_BUCKET/screenshots/$VERSION/mark/" \
                       --exclude "*" --include "*.png" --delete
                   fi
 
@@ -561,15 +573,18 @@ jobs:
           path: apps/print/integration-testing/test-results/
       - when:
           condition:
-            equal: [ main, << pipeline.git.branch >> ]
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+              - matches: { pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$', value: << pipeline.git.tag >> }
           steps:
             - aws-cli/setup
             - run:
                 name: Upload screenshots to S3
                 command: |
+                  VERSION="${CIRCLE_TAG:-$CIRCLE_BRANCH}"
                   if [ -d "apps/print/integration-testing/test-results/screenshots" ]; then
                     aws s3 sync apps/print/integration-testing/test-results/screenshots/ \
-                      "s3://$SCREENSHOT_BUCKET/screenshots/print/" \
+                      "s3://$SCREENSHOT_BUCKET/screenshots/$VERSION/print/" \
                       --exclude "*" --include "*.png" --delete
                   fi
 
@@ -655,15 +670,18 @@ jobs:
           path: apps/scan/integration-testing/test-results/
       - when:
           condition:
-            equal: [ main, << pipeline.git.branch >> ]
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+              - matches: { pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$', value: << pipeline.git.tag >> }
           steps:
             - aws-cli/setup
             - run:
                 name: Upload screenshots to S3
                 command: |
+                  VERSION="${CIRCLE_TAG:-$CIRCLE_BRANCH}"
                   if [ -d "apps/scan/integration-testing/test-results/screenshots" ]; then
                     aws s3 sync apps/scan/integration-testing/test-results/screenshots/ \
-                      "s3://$SCREENSHOT_BUCKET/screenshots/scan/" \
+                      "s3://$SCREENSHOT_BUCKET/screenshots/$VERSION/scan/" \
                       --exclude "*" --include "*.png" --delete
                   fi
 
@@ -1593,26 +1611,21 @@ jobs:
             apt-get update -qq
             apt-get install -y --no-install-recommends graphicsmagick exiftool
       - run:
-          name: Download screenshots from S3
+          name: Build and publish versioned gallery
           command: |
+            VERSION="${CIRCLE_TAG:-$CIRCLE_BRANCH}"
             mkdir -p screenshots
-            aws s3 sync "s3://$SCREENSHOT_BUCKET/screenshots/" screenshots/
-      - run:
-          name: Write gallery theme CSS
-          command: |
+            aws s3 sync "s3://$SCREENSHOT_BUCKET/screenshots/$VERSION/" screenshots/
             printf '%s\n' \
               'body { border-top-color: #6638b6; }' \
               'h1, h3, footer { color: #6638b6; }' \
               'nav.breadcrumbs a { background-color: #6638b6; }' \
               'nav.breadcrumbs li.active { background-color: #a580d8; }' \
               > ./gallery-theme.css
-      - run:
-          name: Build gallery with thumbsup
-          command: |
             npx --yes thumbsup@2.18.0 \
               --input ./screenshots \
               --output ./gallery \
-              --title "VxSuite Automated Screenshots" \
+              --title "VxSuite Screenshots — $VERSION" \
               --albums-from "%path" \
               --sort-albums-by title \
               --sort-media-by filename \
@@ -1622,12 +1635,23 @@ jobs:
               --photo-preview copy \
               --photo-download copy \
               --include-videos false \
-              --home-album-name "VxSuite Screenshots"
+              --home-album-name "VxSuite Screenshots ($VERSION)"
+            aws s3 sync ./gallery/ "s3://$SCREENSHOT_BUCKET/$VERSION/" --delete
       - run:
-          name: Upload gallery to S3
+          name: Regenerate landing index
           command: |
-            aws s3 sync ./gallery/ "s3://$SCREENSHOT_BUCKET/" \
-              --delete --exclude "screenshots/*"
+            versions=$(aws s3 ls "s3://$SCREENSHOT_BUCKET/screenshots/" | awk '/ PRE / {print $2}' | sed 's#/$##')
+            {
+              echo '<!DOCTYPE html><html><head><meta charset="utf-8">'
+              echo '<title>VxSuite Screenshot Galleries</title>'
+              echo '<style>body{font-family:sans-serif;max-width:40rem;margin:3rem auto;padding:0 1rem}h1,a{color:#6638b6}li{margin:.4rem 0}</style>'
+              echo '</head><body><h1>VxSuite Screenshot Galleries</h1><ul>'
+              for v in main $(echo "$versions" | grep -vx main | sort -rV); do
+                echo "$versions" | grep -qx "$v" && echo "<li><a href=\"./$v/\">$v</a></li>"
+              done
+              echo '</ul></body></html>'
+            } > index.html
+            aws s3 cp index.html "s3://$SCREENSHOT_BUCKET/index.html" --content-type text/html
 
 workflows:
   test:
@@ -1648,6 +1672,9 @@ workflows:
       - test-apps-admin-integration-testing:
           context:
             - screenshots-publishing
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - test-apps-central-scan-backend:
           context:
             - screenshots-publishing
@@ -1657,6 +1684,9 @@ workflows:
       - test-apps-central-scan-integration-testing:
           context:
             - screenshots-publishing
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - test-apps-design-backend:
           context:
             - screenshots-publishing
@@ -1672,6 +1702,9 @@ workflows:
       - test-apps-mark-scan-integration-testing:
           context:
             - screenshots-publishing
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - test-apps-mark-backend:
           context:
             - screenshots-publishing
@@ -1681,6 +1714,9 @@ workflows:
       - test-apps-mark-integration-testing:
           context:
             - screenshots-publishing
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - test-apps-pollbook-frontend:
           context:
             - screenshots-publishing
@@ -1693,6 +1729,9 @@ workflows:
       - test-apps-print-integration-testing:
           context:
             - screenshots-publishing
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - test-apps-scan-backend:
           context:
             - screenshots-publishing
@@ -1702,6 +1741,9 @@ workflows:
       - test-apps-scan-integration-testing:
           context:
             - screenshots-publishing
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - test-docs-exercises:
           context:
             - screenshots-publishing
@@ -1829,6 +1871,8 @@ workflows:
           filters:
             branches:
               only: main
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 
 commands:
   checkout-and-install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1647,7 +1647,7 @@ jobs:
               echo '<style>body{font-family:sans-serif;max-width:40rem;margin:3rem auto;padding:0 1rem}h1,a{color:#6638b6}li{margin:.4rem 0}</style>'
               echo '</head><body><h1>VxSuite Screenshot Galleries</h1><ul>'
               for v in main $(echo "$versions" | grep -vx main | sort -rV); do
-                echo "$versions" | grep -qx "$v" && echo "<li><a href=\"./$v/\">$v</a></li>"
+                echo "$versions" | grep -qx "$v" && echo "<li><a href=\"./$v/index.html\">$v</a></li>"
               done
               echo '</ul></body></html>'
             } > index.html

--- a/libs/monorepo-utils/src/circleci.test.ts
+++ b/libs/monorepo-utils/src/circleci.test.ts
@@ -23,13 +23,19 @@ test('generateConfig', () => {
   expect(pbConfig).toContain('test-apps-pollbook-backend');
 
   // Screenshot publishing: per-app upload step is emitted for each
-  // integration-testing job, and the singleton publish-screenshot-gallery
-  // job is wired into the workflow on `main` only.
+  // integration-testing job under a per-version prefix, and the
+  // publish-screenshot-gallery job is wired into the workflow on `main` and on
+  // release tags.
   expect(mainConfig).toContain('aws-cli: circleci/aws-cli@5');
   expect(mainConfig).toContain('publish-screenshot-gallery');
-  expect(mainConfig).toContain('"s3://$SCREENSHOT_BUCKET/screenshots/admin/"');
   expect(mainConfig).toContain(
-    '"s3://$SCREENSHOT_BUCKET/screenshots/mark-scan/"'
+    '"s3://$SCREENSHOT_BUCKET/screenshots/$VERSION/admin/"'
+  );
+  expect(mainConfig).toContain(
+    '"s3://$SCREENSHOT_BUCKET/screenshots/$VERSION/mark-scan/"'
   );
   expect(mainConfig).toContain('only: main');
+  // Release tags trigger the integration jobs and the gallery job (and the
+  // require-chain demands the tag filter appear on the required jobs too).
+  expect(mainConfig).toContain('only: /^v[0-9]+\\.[0-9]+\\.[0-9]+$/');
 });

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -13,6 +13,14 @@ const POSTGRES_PACKAGES: string[] = ['apps/design/backend'];
 // The following packages are only tested when there is a change to its directory.
 const PACKAGES_ONLY_TEST_ON_CHANGES = ['apps/pollbook/backend'];
 
+// Screenshots are published into a per-version S3 prefix: `main` for the main
+// branch and the tag name (e.g. `v4.1.0`) for release tags. The `$` anchor
+// matches release tags only (vA.B.C), excluding -rc/-alpha/-beta and the
+// date-*-hwta / vxpollbook-* tag families. Single backslashes are intentional:
+// the same string is used verbatim as a CircleCI filter regex (`/.../`) and as
+// a single-quoted `matches` pattern in a `when` condition.
+const RELEASE_TAG_PATTERN = '^v[0-9]+\\.[0-9]+\\.[0-9]+$';
+
 function findImageSnapshotDirsRelativeToSrc(pkgPath: string): string[] {
   const srcPath = join(pkgPath, 'src');
   if (!existsSync(srcPath)) return [];
@@ -102,21 +110,32 @@ function generateTestJobForNodeJsPackage(
     if (hasPlaywrightTests) {
       lines.push(`${indent}- store_artifacts:`);
       lines.push(`${indent}    path: ${pkg.relativePath}/test-results/`);
-      // On `main` only, upload screenshots to S3 so the singleton
-      // publish-screenshot-gallery job can build a browseable gallery.
-      // AWS credentials and bucket name come from the
-      // `screenshots-publishing` CircleCI context.
+      // On `main` and on release tags, upload screenshots to S3 under a
+      // per-version prefix (`screenshots/main/...` or `screenshots/<tag>/...`)
+      // so the publish-screenshot-gallery job can build a versioned gallery.
+      // AWS credentials and bucket name come from the `screenshots-publishing`
+      // CircleCI context. VERSION resolves to the tag on a tag build, else the
+      // branch name (`main`).
       const appName = pkg.relativePath
         .replace(/^apps\//, '')
         .replace(/\/integration-testing$/, '');
       lines.push(`${indent}- when:`);
       lines.push(`${indent}    condition:`);
-      lines.push(`${indent}      equal: [ main, << pipeline.git.branch >> ]`);
+      lines.push(`${indent}      or:`);
+      lines.push(
+        `${indent}        - equal: [ main, << pipeline.git.branch >> ]`
+      );
+      lines.push(
+        `${indent}        - matches: { pattern: '${RELEASE_TAG_PATTERN}', value: << pipeline.git.tag >> }`
+      );
       lines.push(`${indent}    steps:`);
       lines.push(`${indent}      - aws-cli/setup`);
       lines.push(`${indent}      - run:`);
       lines.push(`${indent}          name: Upload screenshots to S3`);
       lines.push(`${indent}          command: |`);
+      lines.push(
+        `${indent}            VERSION="\${CIRCLE_TAG:-$CIRCLE_BRANCH}"`
+      );
       lines.push(
         `${indent}            if [ -d "${pkg.relativePath}/test-results/screenshots" ]; then`
       );
@@ -124,7 +143,7 @@ function generateTestJobForNodeJsPackage(
         `${indent}              aws s3 sync ${pkg.relativePath}/test-results/screenshots/ \\`
       );
       lines.push(
-        `${indent}                "s3://$SCREENSHOT_BUCKET/screenshots/${appName}/" \\`
+        `${indent}                "s3://$SCREENSHOT_BUCKET/screenshots/$VERSION/${appName}/" \\`
       );
       lines.push(
         `${indent}                --exclude "*" --include "*.png" --delete`
@@ -152,26 +171,24 @@ function generatePublishScreenshotGalleryJob(): string[] {
     `          apt-get update -qq`,
     `          apt-get install -y --no-install-recommends graphicsmagick exiftool`,
     `    - run:`,
-    `        name: Download screenshots from S3`,
+    // Each run rebuilds only its own version's gallery into the `$VERSION/`
+    // prefix; the landing index (regenerated below) is what ties the versions
+    // together, so historical galleries are never re-thumbsup'd.
+    `        name: Build and publish versioned gallery`,
     `        command: |`,
+    `          VERSION="\${CIRCLE_TAG:-$CIRCLE_BRANCH}"`,
     `          mkdir -p screenshots`,
-    `          aws s3 sync "s3://$SCREENSHOT_BUCKET/screenshots/" screenshots/`,
-    `    - run:`,
-    `        name: Write gallery theme CSS`,
-    `        command: |`,
+    `          aws s3 sync "s3://$SCREENSHOT_BUCKET/screenshots/$VERSION/" screenshots/`,
     `          printf '%s\\n' \\`,
     `            'body { border-top-color: #6638b6; }' \\`,
     `            'h1, h3, footer { color: #6638b6; }' \\`,
     `            'nav.breadcrumbs a { background-color: #6638b6; }' \\`,
     `            'nav.breadcrumbs li.active { background-color: #a580d8; }' \\`,
     `            > ./gallery-theme.css`,
-    `    - run:`,
-    `        name: Build gallery with thumbsup`,
-    `        command: |`,
     `          npx --yes thumbsup@${THUMBSUP_VERSION} \\`,
     `            --input ./screenshots \\`,
     `            --output ./gallery \\`,
-    `            --title "VxSuite Automated Screenshots" \\`,
+    `            --title "VxSuite Screenshots — $VERSION" \\`,
     `            --albums-from "%path" \\`,
     `            --sort-albums-by title \\`,
     `            --sort-media-by filename \\`,
@@ -181,12 +198,25 @@ function generatePublishScreenshotGalleryJob(): string[] {
     `            --photo-preview copy \\`,
     `            --photo-download copy \\`,
     `            --include-videos false \\`,
-    `            --home-album-name "VxSuite Screenshots"`,
+    `            --home-album-name "VxSuite Screenshots ($VERSION)"`,
+    // --delete is scoped to the `$VERSION/` prefix so it never touches other
+    // versions' galleries.
+    `          aws s3 sync ./gallery/ "s3://$SCREENSHOT_BUCKET/$VERSION/" --delete`,
     `    - run:`,
-    `        name: Upload gallery to S3`,
+    `        name: Regenerate landing index`,
     `        command: |`,
-    `          aws s3 sync ./gallery/ "s3://$SCREENSHOT_BUCKET/" \\`,
-    `            --delete --exclude "screenshots/*"`,
+    `          versions=$(aws s3 ls "s3://$SCREENSHOT_BUCKET/screenshots/" | awk '/ PRE / {print $2}' | sed 's#/$##')`,
+    `          {`,
+    `            echo '<!DOCTYPE html><html><head><meta charset="utf-8">'`,
+    `            echo '<title>VxSuite Screenshot Galleries</title>'`,
+    `            echo '<style>body{font-family:sans-serif;max-width:40rem;margin:3rem auto;padding:0 1rem}h1,a{color:#6638b6}li{margin:.4rem 0}</style>'`,
+    `            echo '</head><body><h1>VxSuite Screenshot Galleries</h1><ul>'`,
+    `            for v in main $(echo "$versions" | grep -vx main | sort -rV); do`,
+    `              echo "$versions" | grep -qx "$v" && echo "<li><a href=\\"./$v/\\">$v</a></li>"`,
+    `            done`,
+    `            echo '</ul></body></html>'`,
+    `          } > index.html`,
+    `          aws s3 cp index.html "s3://$SCREENSHOT_BUCKET/index.html" --content-type text/html`,
   ];
 }
 
@@ -419,6 +449,8 @@ export function generateAllConfigs(
     `          filters:`,
     `            branches:`,
     `              only: main`,
+    `            tags:`,
+    `              only: /${RELEASE_TAG_PATTERN}/`,
   ].join('\n');
 
   const baseConfig = `
@@ -500,10 +532,18 @@ ${[...pnpmJobsToFilter.values()]
   .map((lines) => lines.map((line) => `  ${line}`).join('\n'))
   .join('\n\n')}
 ${allJobIds
-  .map(
-    (jobId) =>
-      `      - ${jobId}:\n          context:\n            - screenshots-publishing`
-  )
+  .map((jobId) => {
+    const entry = `      - ${jobId}:\n          context:\n            - screenshots-publishing`;
+    // The integration-testing jobs are required by publish-screenshot-gallery,
+    // which runs on release tags. CircleCI drops a required job on a tag build
+    // unless it also carries a matching tag filter, so the gallery would never
+    // run. A tags filter leaves branch behavior unchanged (jobs still run on
+    // all branches) while making these eligible on release tags. Other jobs
+    // intentionally stay unfiltered so a tag doesn't run the whole suite.
+    return integrationTestingJobIds.includes(jobId)
+      ? `${entry}\n          filters:\n            tags:\n              only: /${RELEASE_TAG_PATTERN}/`
+      : entry;
+  })
   .join('\n')}
 ${publishGalleryWorkflowEntry}
 

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -212,7 +212,7 @@ function generatePublishScreenshotGalleryJob(): string[] {
     `            echo '<style>body{font-family:sans-serif;max-width:40rem;margin:3rem auto;padding:0 1rem}h1,a{color:#6638b6}li{margin:.4rem 0}</style>'`,
     `            echo '</head><body><h1>VxSuite Screenshot Galleries</h1><ul>'`,
     `            for v in main $(echo "$versions" | grep -vx main | sort -rV); do`,
-    `              echo "$versions" | grep -qx "$v" && echo "<li><a href=\\"./$v/\\">$v</a></li>"`,
+    `              echo "$versions" | grep -qx "$v" && echo "<li><a href=\\"./$v/index.html\\">$v</a></li>"`,
     `            done`,
     `            echo '</ul></body></html>'`,
     `          } > index.html`,


### PR DESCRIPTION
## Overview

Today the screenshot suites publish into a single gallery that **every `main` build overwrites**. This PR namespaces published screenshots and galleries **by version** — `main` plus each release tag (`vA.B.C`) gets its own browseable gallery — tied together by an auto-generated landing index.

All changes are to the generator (`libs/monorepo-utils/src/circleci.ts`); `.circleci/config.yml` is regenerated via `pnpm -w generate-circleci-config`.

### What changed

- **Per-version upload.** Each integration-testing job uploads to `s3://$SCREENSHOT_BUCKET/screenshots/$VERSION/<app>/`, where `VERSION` is the tag on a tag build, else the branch (`main`). Gated on `main` **or** a release tag, so PRs still don't upload.
- **Per-version gallery.** `publish-screenshot-gallery` rebuilds only its own version's gallery into the `$VERSION/` prefix (scoped `--delete`) and regenerates a landing `index.html` listing every version (from `aws s3 ls`).
- **Tag triggering.** `publish-screenshot-gallery` and the integration jobs it `requires:` get a `tags: only: /^v[0-9]+\.[0-9]+\.[0-9]+$/` filter (release tags only — excludes `-rc`/`-alpha`/`-hwta`/`vxpollbook-*`). The require-chain rule means the required jobs **must** carry the filter too. **All other jobs stay unfiltered**, so a tag doesn't run the whole suite.

### Why tag-triggered (not "promote main")

Release tags in this repo are cut from long-lived release branches that diverge substantially from `main` (e.g. `v4.0.7` forked ~310 `main`-commits back), so copying `main`'s screenshots into a version folder would capture the wrong code. Generating against the tagged ref is the only version-correct option.

## Demo Video or Screenshot

N/A — CI-only change.

## Testing Plan

- `pnpm test:ci` for `@votingworks/monorepo-utils` passes (coverage gate green).
- `tsgo --noEmit` and `lint` clean.
- Both regenerated YAML files parse; generator output has no drift from the committed config.
- **Required before merge takes effect:** an admin must enable tag builds for the CircleCI project (this config change is the documented prerequisite). After enabling, push a throwaway `v9.9.9` tag to confirm only the integration jobs + gallery fire, then delete it.

### Follow-ups (intentionally not in this PR)

- One-time S3 cleanup of the old un-versioned `screenshots/<app>/` paths and old root gallery artifacts, so they don't surface as bogus "versions" in the landing index.
- Tag builds run the full integration e2e suite, not just `screenshots.spec.ts` (acceptable for now).

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products. (N/A — repo-wide CI)
- [x] I have added logging where appropriate for any new user actions. (N/A — CI config)
- [x] I have added the "user-facing-change" label to this PR, if relevant. (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)