### PR TITLE
feat(dev-dock): remove multi-USB UI & API

### DIFF
--- a/libs/dev-dock/backend/src/dev_dock_api.test.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.test.ts
@@ -402,47 +402,34 @@ test('poll worker card has a PIN when the election package enables them', async 
 
 test('usb drive mock endpoints', async () => {
   const { apiClient } = setup();
-  await expect(apiClient.getUsbDriveStatus()).resolves.toEqual([
-    { devPath: '/dev/sdb', status: 'removed' },
-  ]);
+  await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
+    devPath: '/dev/sdb',
+    status: 'removed',
+  });
 
-  await apiClient.insertUsbDrive({ devPath: '/dev/sdb' });
-  await expect(apiClient.getUsbDriveStatus()).resolves.toEqual([
-    { devPath: '/dev/sdb', status: 'inserted' },
-  ]);
+  await apiClient.insertUsbDrive();
+  await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
+    devPath: '/dev/sdb',
+    status: 'inserted',
+  });
 
-  await apiClient.clearUsbDrive({ devPath: '/dev/sdb' });
-  await expect(apiClient.getUsbDriveStatus()).resolves.toEqual([
-    { devPath: '/dev/sdb', status: 'inserted' },
-  ]);
+  await apiClient.clearUsbDrive();
+  await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
+    devPath: '/dev/sdb',
+    status: 'inserted',
+  });
 
-  await apiClient.removeUsbDrive({ devPath: '/dev/sdb' });
-  await expect(apiClient.getUsbDriveStatus()).resolves.toEqual([
-    { devPath: '/dev/sdb', status: 'removed' },
-  ]);
+  await apiClient.removeUsbDrive();
+  await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
+    devPath: '/dev/sdb',
+    status: 'removed',
+  });
 
-  await apiClient.clearUsbDrive({ devPath: '/dev/sdb' });
-  await expect(apiClient.getUsbDriveStatus()).resolves.toEqual([
-    { devPath: '/dev/sdb', status: 'removed' },
-  ]);
-});
-
-test('usb drive slot endpoints', async () => {
-  const { apiClient } = setup();
-
-  await expect(apiClient.getUsbDriveStatus()).resolves.toHaveLength(1);
-
-  const { devPath: newDevPath } = await apiClient.addUsbDriveSlot();
-  expect(newDevPath).toEqual('/dev/sdc');
-  await expect(apiClient.getUsbDriveStatus()).resolves.toEqual([
-    { devPath: '/dev/sdb', status: 'removed' },
-    { devPath: '/dev/sdc', status: 'removed' },
-  ]);
-
-  await apiClient.removeUsbDriveSlot({ devPath: '/dev/sdc' });
-  await expect(apiClient.getUsbDriveStatus()).resolves.toEqual([
-    { devPath: '/dev/sdb', status: 'removed' },
-  ]);
+  await apiClient.clearUsbDrive();
+  await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
+    devPath: '/dev/sdb',
+    status: 'removed',
+  });
 });
 
 test('mock spec', async () => {

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -41,7 +41,6 @@ import {
   addMockDrive,
   getMockFileUsbDriveHandler,
   listMockDrives,
-  removeMockDriveDir,
 } from '@votingworks/usb-drive';
 import {
   getMockFileFujitsuPrinterHandler,
@@ -90,6 +89,9 @@ export interface DevDockElectionInfo extends DevDockElectionOption {
    */
   arePollWorkerCardPinsEnabled: boolean;
 }
+
+export const MOCK_USB_DRIVE_DISK_NAME = 'sdb';
+export const MOCK_USB_DRIVE_DEV_PATH = `/dev/${MOCK_USB_DRIVE_DISK_NAME}`;
 
 export const DEFAULT_DEV_DOCK_ELECTION_INPUT_PATH =
   './libs/fixtures/data/electionGeneral/election.json';
@@ -252,8 +254,8 @@ interface PdiScannerSheetQueueState {
 }
 
 function buildApi(devDockDir: string, mockSpec: MockSpec) {
-  if (listMockDrives().length === 0) {
-    addMockDrive();
+  if (!listMockDrives().includes(MOCK_USB_DRIVE_DISK_NAME)) {
+    addMockDrive(MOCK_USB_DRIVE_DISK_NAME);
   }
   const printerHandler = getMockFilePrinterHandler();
   const fujitsuPrinterHandler = getMockFileFujitsuPrinterHandler();
@@ -359,38 +361,23 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
       await execFile(MOCK_CARD_SCRIPT_PATH, ['--card-type', 'no-card']);
     },
 
-    getUsbDriveStatus(): DevDockUsbDriveInfo[] {
-      return listMockDrives().map((diskName) => {
-        const handler = getMockFileUsbDriveHandler(diskName);
-        const status =
-          handler.status().status === 'mounted' ? 'inserted' : 'removed';
-        return { devPath: `/dev/${diskName}`, status };
-      });
+    getUsbDriveStatus(): DevDockUsbDriveInfo {
+      const handler = getMockFileUsbDriveHandler(MOCK_USB_DRIVE_DISK_NAME);
+      const status =
+        handler.status().status === 'mounted' ? 'inserted' : 'removed';
+      return { devPath: MOCK_USB_DRIVE_DEV_PATH, status };
     },
 
-    insertUsbDrive(input: { devPath: string }): void {
-      const diskName = basename(input.devPath);
-      getMockFileUsbDriveHandler(diskName).insert();
+    insertUsbDrive(): void {
+      getMockFileUsbDriveHandler(MOCK_USB_DRIVE_DISK_NAME).insert();
     },
 
-    removeUsbDrive(input: { devPath: string }): void {
-      const diskName = basename(input.devPath);
-      getMockFileUsbDriveHandler(diskName).remove();
+    removeUsbDrive(): void {
+      getMockFileUsbDriveHandler(MOCK_USB_DRIVE_DISK_NAME).remove();
     },
 
-    clearUsbDrive(input: { devPath: string }): void {
-      const diskName = basename(input.devPath);
-      getMockFileUsbDriveHandler(diskName).clearData();
-    },
-
-    addUsbDriveSlot(): { devPath: string } {
-      const diskName = addMockDrive();
-      return { devPath: `/dev/${diskName}` };
-    },
-
-    removeUsbDriveSlot(input: { devPath: string }): void {
-      const diskName = basename(input.devPath);
-      removeMockDriveDir(diskName);
+    clearUsbDrive(): void {
+      getMockFileUsbDriveHandler(MOCK_USB_DRIVE_DISK_NAME).clearData();
     },
 
     async saveScreenshotForApp({

--- a/libs/dev-dock/frontend/src/dev_dock.test.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.test.tsx
@@ -84,7 +84,7 @@ beforeEach(() => {
   mockApiClient.getCardStatus.expectCallWith().resolves(noCardStatus);
   mockApiClient.getUsbDriveStatus
     .expectRepeatedCallsWith()
-    .resolves([{ devPath: '/dev/sdb', status: 'removed' }]);
+    .resolves({ devPath: '/dev/sdb', status: 'removed' });
   mockApiClient.getAvailableElections.expectCallWith().resolves([
     {
       title: 'electionGeneral',
@@ -279,59 +279,28 @@ test('USB drive controls', async () => {
   });
   await waitFor(() => expect(usbDriveControl).toBeEnabled());
 
-  mockApiClient.insertUsbDrive
-    .expectCallWith({ devPath: '/dev/sdb' })
-    .resolves();
+  mockApiClient.insertUsbDrive.expectCallWith().resolves();
   mockApiClient.getUsbDriveStatus
     .expectCallWith()
-    .resolves([{ devPath: '/dev/sdb', status: 'inserted' }]);
+    .resolves({ devPath: '/dev/sdb', status: 'inserted' });
   userEvent.click(usbDriveControl);
   await waitFor(() => mockApiClient.assertComplete());
 
-  mockApiClient.removeUsbDrive
-    .expectCallWith({ devPath: '/dev/sdb' })
-    .resolves();
+  mockApiClient.removeUsbDrive.expectCallWith().resolves();
   mockApiClient.getUsbDriveStatus
     .expectCallWith()
-    .resolves([{ devPath: '/dev/sdb', status: 'removed' }]);
+    .resolves({ devPath: '/dev/sdb', status: 'removed' });
   userEvent.click(usbDriveControl);
   await waitFor(() => mockApiClient.assertComplete());
 
   const clearUsbDriveButton = screen.getByRole('button', {
     name: 'Clear',
   });
-  mockApiClient.clearUsbDrive
-    .expectCallWith({ devPath: '/dev/sdb' })
-    .resolves();
+  mockApiClient.clearUsbDrive.expectCallWith().resolves();
   mockApiClient.getUsbDriveStatus
     .expectCallWith()
-    .resolves([{ devPath: '/dev/sdb', status: 'removed' }]);
+    .resolves({ devPath: '/dev/sdb', status: 'removed' });
   userEvent.click(clearUsbDriveButton);
-  await waitFor(() => mockApiClient.assertComplete());
-});
-
-test('add and remove USB drive slots', async () => {
-  renderDock(mockApiClient);
-  await screen.findByRole('button', { name: 'USB Drive /dev/sdb' });
-
-  mockApiClient.addUsbDriveSlot
-    .expectCallWith()
-    .resolves({ devPath: '/dev/sdc' });
-  mockApiClient.getUsbDriveStatus.expectCallWith().resolves([
-    { devPath: '/dev/sdb', status: 'removed' },
-    { devPath: '/dev/sdc', status: 'removed' },
-  ]);
-  userEvent.click(screen.getByRole('button', { name: 'Add USB Drive Slot' }));
-  await screen.findByRole('button', { name: 'USB Drive /dev/sdc' });
-  await waitFor(() => mockApiClient.assertComplete());
-
-  mockApiClient.removeUsbDriveSlot
-    .expectCallWith({ devPath: '/dev/sdc' })
-    .resolves();
-  mockApiClient.getUsbDriveStatus
-    .expectCallWith()
-    .resolves([{ devPath: '/dev/sdb', status: 'removed' }]);
-  userEvent.click(screen.getByRole('button', { name: 'Remove slot /dev/sdc' }));
   await waitFor(() => mockApiClient.assertComplete());
 });
 

--- a/libs/dev-dock/frontend/src/dev_dock.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.tsx
@@ -329,52 +329,6 @@ const UsbDriveDevLabel = styled.div`
   color: ${Colors.TEXT};
 `;
 
-const UsbDriveRemoveSlotButton = styled.button`
-  position: absolute;
-  top: -6px;
-  right: -6px;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  border: 1px solid ${Colors.BORDER};
-  background-color: white;
-  color: ${Colors.TEXT};
-  font-size: 10px;
-  line-height: 1;
-  padding: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  &:hover {
-    background-color: ${Colors.BORDER};
-  }
-  &:disabled {
-    color: ${Colors.DISABLED};
-    border-color: ${Colors.DISABLED};
-  }
-`;
-
-const AddDriveSlotButton = styled.button`
-  background-color: white;
-  width: 80px;
-  height: 120px;
-  border-radius: 8px;
-  border: 1px solid ${Colors.BORDER};
-  color: ${Colors.TEXT};
-  font-size: 1.5em;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  &:hover:not(:disabled) {
-    border-color: ${Colors.ACTIVE};
-    color: ${Colors.ACTIVE};
-  }
-  &:disabled {
-    color: ${Colors.DISABLED};
-    border-color: ${Colors.DISABLED};
-  }
-`;
-
 function UsbDriveMockControls() {
   const queryClient = useQueryClient();
   const apiClient = useApiClient();
@@ -393,37 +347,19 @@ function UsbDriveMockControls() {
     onSuccess: async () =>
       await queryClient.invalidateQueries(['getUsbDriveStatus']),
   });
-  const addUsbDriveSlotMutation = useMutation(apiClient.addUsbDriveSlot, {
-    onSuccess: async () =>
-      await queryClient.invalidateQueries(['getUsbDriveStatus']),
-  });
-  const removeUsbDriveSlotMutation = useMutation(apiClient.removeUsbDriveSlot, {
-    onSuccess: async () =>
-      await queryClient.invalidateQueries(['getUsbDriveStatus']),
-  });
 
-  const [recentlyClearedDevPaths, setRecentlyClearedDevPaths] = useState(
-    new Map<string, boolean>()
-  );
+  const [isUsbDriveRecentlyCleared, setIsUsbDriveRecentlyCleared] =
+    useState(false);
 
-  function handleClearClick(devPath: string) {
-    clearUsbDriveMutation.mutate(
-      { devPath },
-      {
-        onSuccess: () => {
-          setRecentlyClearedDevPaths((prev) =>
-            new Map(prev).set(devPath, true)
-          );
-          setTimeout(() => {
-            setRecentlyClearedDevPaths((prev) => {
-              const next = new Map(prev);
-              next.delete(devPath);
-              return next;
-            });
-          }, 1500);
-        },
-      }
-    );
+  function handleClearClick() {
+    clearUsbDriveMutation.mutate(undefined, {
+      onSuccess: () => {
+        setIsUsbDriveRecentlyCleared(true);
+        setTimeout(() => {
+          setIsUsbDriveRecentlyCleared(false);
+        }, 1500);
+      },
+    });
   }
 
   const isFeatureEnabled = isFeatureFlagEnabled(
@@ -431,72 +367,43 @@ function UsbDriveMockControls() {
   );
   const controlsDisabled =
     !isFeatureEnabled || !getUsbDriveStatusQuery.isSuccess;
-  const drives = getUsbDriveStatusQuery.data ?? [];
+  const drive = getUsbDriveStatusQuery.data;
+
+  if (!drive) return null;
+
+  const isInserted = drive.status === 'inserted';
 
   return (
-    <Row>
-      {drives.map((drive) => {
-        const isInserted = drive.status === 'inserted';
-        return (
-          <Column key={drive.devPath}>
-            <div style={{ position: 'relative' }}>
-              <UsbDriveControl
-                onClick={() => {
-                  if (isInserted) {
-                    removeUsbDriveMutation.mutate({ devPath: drive.devPath });
-                  } else {
-                    insertUsbDriveMutation.mutate({ devPath: drive.devPath });
-                  }
-                }}
-                isInserted={isInserted}
-                disabled={controlsDisabled}
-                aria-label={`USB Drive ${drive.devPath}`}
-              >
-                <UsbDriveIcon
-                  isInserted={isInserted}
-                  disabled={controlsDisabled}
-                />
-                {!isFeatureEnabled && (
-                  <UsbMocksDisabledMessage>
-                    <p>USB mock disabled</p>
-                  </UsbMocksDisabledMessage>
-                )}
-              </UsbDriveControl>
-              {drive.status === 'removed' && (
-                <UsbDriveRemoveSlotButton
-                  onClick={() =>
-                    removeUsbDriveSlotMutation.mutate({
-                      devPath: drive.devPath,
-                    })
-                  }
-                  disabled={controlsDisabled}
-                  aria-label={`Remove slot ${drive.devPath}`}
-                >
-                  <FontAwesomeIcon icon={faXmark} />
-                </UsbDriveRemoveSlotButton>
-              )}
-            </div>
-            <UsbDriveDevLabel>{drive.devPath}</UsbDriveDevLabel>
-            <UsbDriveClearButton
-              onClick={() => handleClearClick(drive.devPath)}
-              disabled={controlsDisabled}
-            >
-              {recentlyClearedDevPaths.has(drive.devPath) ? '✓' : 'Clear'}
-            </UsbDriveClearButton>
-          </Column>
-        );
-      })}
-      <Column>
-        <AddDriveSlotButton
-          onClick={() => addUsbDriveSlotMutation.mutate()}
+    <React.Fragment>
+      <div style={{ position: 'relative' }}>
+        <UsbDriveControl
+          onClick={() => {
+            if (isInserted) {
+              removeUsbDriveMutation.mutate();
+            } else {
+              insertUsbDriveMutation.mutate();
+            }
+          }}
+          isInserted={isInserted}
           disabled={controlsDisabled}
-          aria-label="Add USB Drive Slot"
+          aria-label={`USB Drive ${drive.devPath}`}
         >
-          +
-        </AddDriveSlotButton>
-        <UsbDriveDevLabel>Add USB</UsbDriveDevLabel>
-      </Column>
-    </Row>
+          <UsbDriveIcon isInserted={isInserted} disabled={controlsDisabled} />
+          {!isFeatureEnabled && (
+            <UsbMocksDisabledMessage>
+              <p>USB mock disabled</p>
+            </UsbMocksDisabledMessage>
+          )}
+        </UsbDriveControl>
+      </div>
+      <UsbDriveDevLabel>{drive.devPath}</UsbDriveDevLabel>
+      <UsbDriveClearButton
+        onClick={() => handleClearClick()}
+        disabled={controlsDisabled}
+      >
+        {isUsbDriveRecentlyCleared ? '✓' : 'Clear'}
+      </UsbDriveClearButton>
+    </React.Fragment>
   );
 }
 

--- a/libs/usb-drive/src/mocks/file_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.ts
@@ -108,16 +108,20 @@ export function listMockDrives(): string[] {
     .sort();
 }
 
-export function addMockDrive(): string {
+function chooseFreeDiskName(): string {
   const existing = new Set(listMockDrives());
   for (let i = 1; i <= 25; i += 1) {
     const name = `sd${String.fromCharCode('a'.charCodeAt(0) + i)}`;
     if (!existing.has(name)) {
-      writeMockDriveState(name, { state: 'removed' });
       return name;
     }
   }
   throw new Error('No available mock drive slot');
+}
+
+export function addMockDrive(name = chooseFreeDiskName()): string {
+  writeMockDriveState(name, { state: 'removed' });
+  return name;
 }
 
 export function removeMockDriveDir(diskName: string): void {


### PR DESCRIPTION
## Overview
This is getting in the way of refactoring the underlying USB drive simulator and is not serving a useful purpose yet in the election backup and archiving project, so it's better to just remove it.

## Demo Video or Screenshot
<img width="764" height="331" alt="image" src="https://github.com/user-attachments/assets/27133fe3-d0a1-4644-b16d-fd88168014d5" />

## Testing Plan
Updated automated tests and manually verified mock USB drives still work.