### PR TITLE
ci: move screenshot gallery build from CircleCI to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1582,52 +1582,19 @@ jobs:
           command: |
             ./script/validate-monorepo
 
-  publish-screenshot-gallery:
+  notify-gallery:
     executor: nodejs
     resource_class: small
     steps:
-      - aws-cli/setup
       - run:
-          name: Install thumbsup native dependencies
+          name: Trigger screenshot gallery build on GitHub Actions
           command: |
-            apt-get update -qq
-            apt-get install -y --no-install-recommends graphicsmagick exiftool
-      - run:
-          name: Download screenshots from S3
-          command: |
-            mkdir -p screenshots
-            aws s3 sync "s3://$SCREENSHOT_BUCKET/screenshots/" screenshots/
-      - run:
-          name: Write gallery theme CSS
-          command: |
-            printf '%s\n' \
-              'body { border-top-color: #6638b6; }' \
-              'h1, h3, footer { color: #6638b6; }' \
-              'nav.breadcrumbs a { background-color: #6638b6; }' \
-              'nav.breadcrumbs li.active { background-color: #a580d8; }' \
-              > ./gallery-theme.css
-      - run:
-          name: Build gallery with thumbsup
-          command: |
-            npx --yes thumbsup@2.18.0 \
-              --input ./screenshots \
-              --output ./gallery \
-              --title "VxSuite Automated Screenshots" \
-              --albums-from "%path" \
-              --sort-albums-by title \
-              --sort-media-by filename \
-              --theme classic \
-              --theme-style ./gallery-theme.css \
-              --thumb-size 200 \
-              --photo-preview copy \
-              --photo-download copy \
-              --include-videos false \
-              --home-album-name "VxSuite Screenshots"
-      - run:
-          name: Upload gallery to S3
-          command: |
-            aws s3 sync ./gallery/ "s3://$SCREENSHOT_BUCKET/" \
-              --delete --exclude "screenshots/*"
+            curl --fail --silent --show-error -X POST \
+              -H "Authorization: Bearer $GALLERY_DISPATCH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/votingworks/vxsuite/dispatches" \
+              -d '{"event_type":"build-screenshot-gallery","client_payload":{"ref":"<< pipeline.git.branch >>","tag":"<< pipeline.git.tag >>","sha":"<< pipeline.git.revision >>"}}'
 
 workflows:
   test:
@@ -1816,7 +1783,7 @@ workflows:
       - test-rust-crates:
           context:
             - screenshots-publishing
-      - publish-screenshot-gallery:
+      - notify-gallery:
           context:
             - screenshots-publishing
           requires:

--- a/.github/workflows/screenshot-gallery.yml
+++ b/.github/workflows/screenshot-gallery.yml
@@ -1,0 +1,80 @@
+name: Build screenshot gallery
+
+# Assembles the static gallery of automated screenshots. The screenshots
+# themselves are produced and uploaded to S3 by each app's integration-testing
+# job in CircleCI; CircleCI fires a `build-screenshot-gallery` repository
+# dispatch once all of those uploads have completed (see the `notify-gallery`
+# job in .circleci/config.yml). Keeping the image processing here, rather than
+# in CircleCI, takes it off the test pipeline's critical path.
+#
+# Required configuration (set up in repo/org settings — see PR description):
+#   - vars.AWS_GALLERY_ROLE_ARN: IAM role assumed via GitHub OIDC, scoped to
+#     read/write the screenshot bucket only.
+#   - vars.AWS_REGION:           region of the screenshot bucket.
+#   - vars.SCREENSHOT_BUCKET:    bucket name (no s3:// prefix).
+
+on:
+  repository_dispatch:
+    types: [build-screenshot-gallery]
+  workflow_dispatch: {}
+
+# Collapse overlapping rebuilds (repository_dispatch can fire more than once
+# per run). The build is idempotent, so cancelling an in-flight run is safe.
+concurrency:
+  group: screenshot-gallery
+  cancel-in-progress: true
+
+permissions:
+  id-token: write # required for AWS OIDC role assumption
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.AWS_GALLERY_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Install thumbsup native dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends graphicsmagick exiftool
+
+      - name: Download screenshots from S3
+        run: |
+          mkdir -p screenshots
+          aws s3 sync "s3://${{ vars.SCREENSHOT_BUCKET }}/screenshots/" screenshots/
+
+      - name: Write gallery theme CSS
+        run: |
+          printf '%s\n' \
+            'body { border-top-color: #6638b6; }' \
+            'h1, h3, footer { color: #6638b6; }' \
+            'nav.breadcrumbs a { background-color: #6638b6; }' \
+            'nav.breadcrumbs li.active { background-color: #a580d8; }' \
+            > ./gallery-theme.css
+
+      - name: Build gallery with thumbsup
+        run: |
+          npx --yes thumbsup@2.18.0 \
+            --input ./screenshots \
+            --output ./gallery \
+            --title "VxSuite Automated Screenshots" \
+            --albums-from "%path" \
+            --sort-albums-by title \
+            --sort-media-by filename \
+            --theme classic \
+            --theme-style ./gallery-theme.css \
+            --thumb-size 200 \
+            --photo-preview copy \
+            --photo-download copy \
+            --include-videos false \
+            --home-album-name "VxSuite Screenshots"
+
+      - name: Upload gallery to S3
+        run: |
+          aws s3 sync ./gallery/ "s3://${{ vars.SCREENSHOT_BUCKET }}/" \
+            --delete --exclude "screenshots/*"

--- a/libs/monorepo-utils/src/circleci.test.ts
+++ b/libs/monorepo-utils/src/circleci.test.ts
@@ -23,10 +23,12 @@ test('generateConfig', () => {
   expect(pbConfig).toContain('test-apps-pollbook-backend');
 
   // Screenshot publishing: per-app upload step is emitted for each
-  // integration-testing job, and the singleton publish-screenshot-gallery
-  // job is wired into the workflow on `main` only.
+  // integration-testing job, and the notify-gallery job (which triggers the
+  // GitHub Actions gallery build) is wired into the workflow on `main` only.
   expect(mainConfig).toContain('aws-cli: circleci/aws-cli@5');
-  expect(mainConfig).toContain('publish-screenshot-gallery');
+  expect(mainConfig).toContain('notify-gallery');
+  expect(mainConfig).toContain('build-screenshot-gallery');
+  expect(mainConfig).not.toContain('thumbsup');
   expect(mainConfig).toContain('"s3://$SCREENSHOT_BUCKET/screenshots/admin/"');
   expect(mainConfig).toContain(
     '"s3://$SCREENSHOT_BUCKET/screenshots/mark-scan/"'

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -102,10 +102,10 @@ function generateTestJobForNodeJsPackage(
     if (hasPlaywrightTests) {
       lines.push(`${indent}- store_artifacts:`);
       lines.push(`${indent}    path: ${pkg.relativePath}/test-results/`);
-      // On `main` only, upload screenshots to S3 so the singleton
-      // publish-screenshot-gallery job can build a browseable gallery.
-      // AWS credentials and bucket name come from the
-      // `screenshots-publishing` CircleCI context.
+      // On `main` only, upload screenshots to S3 so the GitHub Actions
+      // screenshot-gallery workflow can build a browseable gallery. AWS
+      // credentials and bucket name come from the `screenshots-publishing`
+      // CircleCI context.
       const appName = pkg.relativePath
         .replace(/^apps\//, '')
         .replace(/\/integration-testing$/, '');
@@ -136,57 +136,30 @@ function generateTestJobForNodeJsPackage(
   return lines;
 }
 
-const PUBLISH_SCREENSHOT_GALLERY_JOB_ID = 'publish-screenshot-gallery';
-const THUMBSUP_VERSION = '2.18.0';
+const NOTIFY_GALLERY_JOB_ID = 'notify-gallery';
 
-function generatePublishScreenshotGalleryJob(): string[] {
+// Screenshots are uploaded to S3 by each app's integration-testing job (see
+// the upload step in `generateTestJobForNodeJsPackage`). The gallery itself
+// is assembled by a GitHub Actions workflow
+// (.github/workflows/screenshot-gallery.yml) so that the image-processing work
+// stays off the CircleCI critical path. This job does nothing but signal
+// GitHub, via a repository dispatch, once all screenshots have been uploaded.
+// The GitHub token comes from the `screenshots-publishing` CircleCI context.
+function generateNotifyGalleryJob(): string[] {
   return [
-    `${PUBLISH_SCREENSHOT_GALLERY_JOB_ID}:`,
+    `${NOTIFY_GALLERY_JOB_ID}:`,
     `  executor: nodejs`,
     `  resource_class: small`,
     `  steps:`,
-    `    - aws-cli/setup`,
     `    - run:`,
-    `        name: Install thumbsup native dependencies`,
+    `        name: Trigger screenshot gallery build on GitHub Actions`,
     `        command: |`,
-    `          apt-get update -qq`,
-    `          apt-get install -y --no-install-recommends graphicsmagick exiftool`,
-    `    - run:`,
-    `        name: Download screenshots from S3`,
-    `        command: |`,
-    `          mkdir -p screenshots`,
-    `          aws s3 sync "s3://$SCREENSHOT_BUCKET/screenshots/" screenshots/`,
-    `    - run:`,
-    `        name: Write gallery theme CSS`,
-    `        command: |`,
-    `          printf '%s\\n' \\`,
-    `            'body { border-top-color: #6638b6; }' \\`,
-    `            'h1, h3, footer { color: #6638b6; }' \\`,
-    `            'nav.breadcrumbs a { background-color: #6638b6; }' \\`,
-    `            'nav.breadcrumbs li.active { background-color: #a580d8; }' \\`,
-    `            > ./gallery-theme.css`,
-    `    - run:`,
-    `        name: Build gallery with thumbsup`,
-    `        command: |`,
-    `          npx --yes thumbsup@${THUMBSUP_VERSION} \\`,
-    `            --input ./screenshots \\`,
-    `            --output ./gallery \\`,
-    `            --title "VxSuite Automated Screenshots" \\`,
-    `            --albums-from "%path" \\`,
-    `            --sort-albums-by title \\`,
-    `            --sort-media-by filename \\`,
-    `            --theme classic \\`,
-    `            --theme-style ./gallery-theme.css \\`,
-    `            --thumb-size 200 \\`,
-    `            --photo-preview copy \\`,
-    `            --photo-download copy \\`,
-    `            --include-videos false \\`,
-    `            --home-album-name "VxSuite Screenshots"`,
-    `    - run:`,
-    `        name: Upload gallery to S3`,
-    `        command: |`,
-    `          aws s3 sync ./gallery/ "s3://$SCREENSHOT_BUCKET/" \\`,
-    `            --delete --exclude "screenshots/*"`,
+    `          curl --fail --silent --show-error -X POST \\`,
+    `            -H "Authorization: Bearer $GALLERY_DISPATCH_TOKEN" \\`,
+    `            -H "Accept: application/vnd.github+json" \\`,
+    `            -H "X-GitHub-Api-Version: 2022-11-28" \\`,
+    `            "https://api.github.com/repos/votingworks/vxsuite/dispatches" \\`,
+    `            -d '{"event_type":"build-screenshot-gallery","client_payload":{"ref":"<< pipeline.git.branch >>","tag":"<< pipeline.git.tag >>","sha":"<< pipeline.git.revision >>"}}'`,
   ];
 }
 
@@ -410,8 +383,8 @@ export function generateAllConfigs(
     RUST_CRATES_JOB_ID,
   ];
 
-  const publishGalleryWorkflowEntry = [
-    `      - ${PUBLISH_SCREENSHOT_GALLERY_JOB_ID}:`,
+  const notifyGalleryWorkflowEntry = [
+    `      - ${NOTIFY_GALLERY_JOB_ID}:`,
     `          context:`,
     `            - screenshots-publishing`,
     `          requires:`,
@@ -488,7 +461,7 @@ ${rustJobLines.map((line) => `  ${line}\n`).join('')}
           command: |
             ./script/validate-monorepo
 
-${generatePublishScreenshotGalleryJob()
+${generateNotifyGalleryJob()
   .map((line) => `  ${line}`)
   .join('\n')}
 
@@ -505,7 +478,7 @@ ${allJobIds
       `      - ${jobId}:\n          context:\n            - screenshots-publishing`
   )
   .join('\n')}
-${publishGalleryWorkflowEntry}
+${notifyGalleryWorkflowEntry}
 
 commands:
   checkout-and-install:


### PR DESCRIPTION
## Overview

The `publish-screenshot-gallery` CircleCI job did pure S3→transform→S3 work
(`thumbsup` image processing) that has nothing to do with the repo's code or
build artifacts, yet it sat on the `test` workflow's critical path — the
CircleCI pipeline on `main` wasn't "done" until this unrelated job finished
(apt install + `npx thumbsup` cold start + two full S3 syncs).

This moves the gallery **assembly** out to GitHub Actions, where it belongs as
a downstream artifact-publishing concern, and leaves CircleCI with only a tiny
trigger. Screenshot *production* (the integration tests) and the per-app S3
uploads are unchanged — only the gallery build relocates.

### How it works now

- Each app's `integration-testing` job still uploads its PNGs to
  `s3://$SCREENSHOT_BUCKET/screenshots/<app>/` on `main` (unchanged).
- A new lightweight `notify-gallery` CircleCI job `requires` all 6 integration
  jobs, then fires a `build-screenshot-gallery` `repository_dispatch` to GitHub
  (passing `ref`/`tag`/`sha` in the payload).
- A new GitHub Actions workflow (`.github/workflows/screenshot-gallery.yml`)
  builds the gallery with `thumbsup` (ported verbatim) and syncs it to S3,
  authenticating via **OIDC** (no long-lived AWS secrets). It also exposes a
  `workflow_dispatch` button for manual rebuilds.

Source is edited in `libs/monorepo-utils/src/circleci.ts`; `config.yml` is
regenerated.

### Why dispatch (not check_suite / on:push:tags)

The dispatch payload carries the ref/tag explicitly, so extending this beyond
`main` to tagged builds later is a small change with no trigger rework. The
gallery workflow always runs from the default branch, which keeps the OIDC
trust policy pinned to `main` even for future tag-driven builds.

## Demo Video or Screenshot

N/A — CI/infrastructure change. Gallery output is identical
(`thumbsup@2.18.0`, same flags + theme).

## Testing Plan

Requires one-time infra (tracked separately): OIDC IAM role, the
`AWS_GALLERY_ROLE_ARN`/`AWS_REGION`/`SCREENSHOT_BUCKET` GitHub variables, and a
`GALLERY_DISPATCH_TOKEN` in the `screenshots-publishing` CircleCI context.

- [ ] Pre-merge: temporary `push:` trigger on this branch + branch ref added to
      the role trust policy → confirm the Actions run assumes the role via OIDC,
      runs `thumbsup`, and round-trips to S3. (Temp trigger removed and trust
      re-pinned to `main` before merge.)
- [ ] Post-merge: confirm CircleCI `notify-gallery` succeeds on the next `main`
      run and the dispatched Actions run publishes the gallery.
- [x] `libs/monorepo-utils` unit test updated; `pnpm lint` passes; generated
      `config.yml` verified in sync with the generator.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
