### PR TITLE
[VxScan] [Backend] Remove old precinct selection code paths

### DIFF
--- a/apps/scan/backend/schema.sql
+++ b/apps/scan/backend/schema.sql
@@ -4,7 +4,6 @@ create table election (
   election_data text not null,
   election_package_hash text not null,
   jurisdiction text not null,
-  precinct_selection text, -- [TODO] Remove after migration to polling places
   polling_place_id text,
   is_test_mode boolean not null default true,
   ballot_casting_mode text not null default 'election_day',

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -3,21 +3,13 @@ import { LogEventId, Logger } from '@votingworks/logging';
 import {
   ElectionPackageConfigurationError,
   DEFAULT_SYSTEM_SETTINGS,
-  PrecinctSelection,
-  SinglePrecinctSelection,
   DiagnosticRecord,
   DiagnosticOutcome,
   doesPollsStateSupportLiveReporting,
   BallotCastingMode,
   pollingPlaceFromElection,
 } from '@votingworks/types';
-import {
-  BooleanEnvironmentVariableName,
-  getPrecinctSelectionName,
-  isElectionManagerAuth,
-  isFeatureFlagEnabled,
-  singlePrecinctSelectionFor,
-} from '@votingworks/utils';
+import { isElectionManagerAuth } from '@votingworks/utils';
 import express, { Application } from 'express';
 import {
   createUiStringsApi,
@@ -190,12 +182,6 @@ export function buildApi({
         electionPackageResult.ok();
       const { electionDefinition, systemSettings } = electionPackage;
       assert(systemSettings);
-      let precinctSelection: SinglePrecinctSelection | undefined;
-      if (electionDefinition.election.precincts.length === 1) {
-        precinctSelection = singlePrecinctSelectionFor(
-          electionDefinition.election.precincts[0].id
-        );
-      }
 
       await store.withTransaction(async () => {
         store.setElectionAndJurisdiction({
@@ -203,17 +189,11 @@ export function buildApi({
           jurisdiction: authStatus.user.jurisdiction,
           electionPackageHash,
         });
-        if (precinctSelection) {
-          store.setPrecinctSelection(precinctSelection);
-        }
 
-        const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
-        if (isFeatureFlagEnabled(ENABLE_POLLING_PLACES)) {
-          if (electionDefinition.election.pollingPlaces?.length === 1) {
-            workspace.store.setPollingPlaceId(
-              electionDefinition.election.pollingPlaces[0].id
-            );
-          }
+        if (electionDefinition.election.pollingPlaces?.length === 1) {
+          workspace.store.setPollingPlaceId(
+            electionDefinition.election.pollingPlaces[0].id
+          );
         }
 
         store.setSystemSettings(systemSettings);
@@ -247,7 +227,6 @@ export function buildApi({
         electionDefinition: electionRecord?.electionDefinition,
         electionPackageHash: electionRecord?.electionPackageHash,
         systemSettings: store.getSystemSettings() ?? DEFAULT_SYSTEM_SETTINGS,
-        precinctSelection: store.getPrecinctSelection(),
         pollingPlaceId: store.getPollingPlaceId(),
         isSoundMuted: store.getIsSoundMuted(),
         isTestMode: store.getTestMode(),
@@ -278,29 +257,6 @@ export function buildApi({
         disposition: 'success',
         message:
           'User successfully unconfigured the machine to remove the current election and all current ballot data.',
-      });
-    },
-
-    async setPrecinctSelection(input: {
-      precinctSelection: PrecinctSelection;
-    }): Promise<void> {
-      const { electionDefinition } = assertDefined(store.getElectionRecord());
-      assert(
-        store.getPollsState() !== 'polls_closed_final',
-        'Attempt to change precinct selection after polls closed'
-      );
-      assert(
-        store.getBallotsCounted() === 0,
-        'Attempt to change precinct selection after ballots have been cast'
-      );
-      store.setPrecinctSelection(input.precinctSelection);
-      workspace.resetElectionSession();
-      await logger.logAsCurrentRole(LogEventId.PollingPlaceChanged, {
-        disposition: 'success',
-        message: `User set the precinct for the machine to ${getPrecinctSelectionName(
-          electionDefinition.election.precincts,
-          input.precinctSelection
-        )}`,
       });
     },
 
@@ -404,11 +360,8 @@ export function buildApi({
 
       // Any previous polling place selection will no longer be valid after
       // switching casting modes.
-      const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
-      if (isFeatureFlagEnabled(ENABLE_POLLING_PLACES)) {
-        store.setPollingPlaceId(null);
-        workspace.resetElectionSession();
-      }
+      store.setPollingPlaceId(null);
+      workspace.resetElectionSession();
 
       await logger.logAsCurrentRole(LogEventId.SetBallotCastingMode, {
         message: `Successfully set ballot casting mode to ${input.ballotCastingMode}.`,

--- a/apps/scan/backend/src/app_config.test.ts
+++ b/apps/scan/backend/src/app_config.test.ts
@@ -8,7 +8,6 @@ import { LogEventId } from '@votingworks/logging';
 import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
-  singlePrecinctSelectionFor,
 } from '@votingworks/utils';
 import { assertDefined, err, ok } from '@votingworks/basics';
 import {
@@ -145,8 +144,7 @@ test('fails to configure election package if election definition on card does no
   });
 });
 
-// [TODO] Update test name after migration to Polling Places.
-test("if there's only one precinct in the election, it's selected automatically on configure", async () => {
+test('in single-location election, auto-select polling place on configure', async () => {
   const fixtures = electionTwoPartyPrimaryFixtures;
   const electionDefinition = fixtures.makeSinglePrecinctElectionDefinition();
 
@@ -154,9 +152,6 @@ test("if there's only one precinct in the election, it's selected automatically 
   const defaultPollingPlace = assertDefined(election.pollingPlaces?.[0]);
 
   await withApp(async ({ apiClient, mockUsbDrive, mockAuth, logger }) => {
-    const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
-    mockFeatureFlagger.enableFeatureFlag(ENABLE_POLLING_PLACES);
-
     mockElectionManager(mockAuth, electionDefinition);
     mockUsbDrive.insertUsbDrive(
       await mockElectionPackageFileTree({
@@ -173,42 +168,9 @@ test("if there's only one precinct in the election, it's selected automatically 
       })
     );
     const config = await apiClient.getConfig();
-    expect(config.precinctSelection).toMatchObject({
-      kind: 'SinglePrecinct',
-      precinctId: 'precinct-1',
-    });
     expect(config.pollingPlaceId).toEqual(defaultPollingPlace.id);
     expect(config.electionDefinition).toEqual(electionDefinition);
     expect(config.electionPackageHash).toEqual(expect.any(String));
-  });
-});
-
-test('setPrecinctSelection will reset polls to closed', async () => {
-  await withApp(async ({ apiClient, mockUsbDrive, mockAuth, logger }) => {
-    await configureApp(apiClient, mockAuth, mockUsbDrive);
-
-    expect(await apiClient.getPollsInfo()).toEqual<PrecinctScannerPollsInfo>({
-      pollsState: 'polls_open',
-      lastPollsTransition: {
-        type: 'open_polls',
-        time: expect.anything(),
-        ballotCount: 0,
-      },
-    });
-
-    await apiClient.setPrecinctSelection({
-      precinctSelection: singlePrecinctSelectionFor('21'),
-    });
-    expect(await apiClient.getPollsInfo()).toEqual<PrecinctScannerPollsInfo>({
-      pollsState: 'polls_closed_initial',
-    });
-    expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
-      LogEventId.PollingPlaceChanged,
-      {
-        disposition: 'success',
-        message: 'User set the precinct for the machine to East Lincoln',
-      }
-    );
   });
 });
 
@@ -263,9 +225,6 @@ test('cannot set polling place in polls_closed_final state', async () => {
 });
 
 test('switching ballot casting modes clears polling place selection', async () => {
-  const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
-  mockFeatureFlagger.enableFeatureFlag(ENABLE_POLLING_PLACES);
-
   await withApp(async (ctx) => {
     const { apiClient, mockUsbDrive, mockAuth, logger, workspace } = ctx;
     await configureApp(apiClient, mockAuth, mockUsbDrive);

--- a/apps/scan/backend/src/app_diagnostics.test.ts
+++ b/apps/scan/backend/src/app_diagnostics.test.ts
@@ -186,8 +186,6 @@ test('user logged "fail" after a test print completes', async () => {
 });
 
 test('printing a readiness report', async () => {
-  setPollingPlacesEnabled(true);
-
   await withApp(
     async ({ apiClient, mockUsbDrive, mockAuth, logger, workspace }) => {
       await configureApp(apiClient, mockAuth, mockUsbDrive, {
@@ -272,12 +270,3 @@ test('user logged "fail" for UPS diagnostic', async () => {
     );
   });
 });
-
-function setPollingPlacesEnabled(enabled: boolean) {
-  const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
-  if (enabled) {
-    mockFeatureFlagger.enableFeatureFlag(ENABLE_POLLING_PLACES);
-  } else {
-    mockFeatureFlagger.disableFeatureFlag(ENABLE_POLLING_PLACES);
-  }
-}

--- a/apps/scan/backend/src/app_export.test.ts
+++ b/apps/scan/backend/src/app_export.test.ts
@@ -432,6 +432,7 @@ test('audit ballot IDs', async () => {
             precinctScanEnableBallotAuditIds: true,
           },
         },
+        pollingPlaceId: `${ballotPropsWithAuditId.precinctId}-polling-place`,
       });
 
       await scanBallot(mockScanner, clock, apiClient, workspace.store, 0, {

--- a/apps/scan/backend/src/app_flow.test.ts
+++ b/apps/scan/backend/src/app_flow.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { buildMockInsertedSmartCardAuth } from '@votingworks/auth';
 import { createMockUsbDrive } from '@votingworks/usb-drive';
 import {
@@ -7,11 +7,6 @@ import {
   mockSessionExpiresAt,
   mockSystemAdministratorUser,
 } from '@votingworks/test-utils';
-import {
-  BooleanEnvironmentVariableName as Feature,
-  getFeatureFlagMock,
-  ALL_PRECINCTS_SELECTION,
-} from '@votingworks/utils';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import { constructElectionKey, TEST_JURISDICTION } from '@votingworks/types';
 import { doesUsbDriveRequireCastVoteRecordSync } from '@votingworks/backend';
@@ -31,19 +26,9 @@ vi.mock(import('@votingworks/backend'), async (importActual) => ({
   doesUsbDriveRequireCastVoteRecordSync: vi.fn(),
 }));
 
-const mockFeatureFlagger = getFeatureFlagMock();
-vi.mock(import('@votingworks/utils'), async (importActual) => ({
-  ...(await importActual()),
-  isFeatureFlagEnabled: (f: Feature) => mockFeatureFlagger.isEnabled(f),
-}));
-
 const doesUsbDriveRequireCastVoteRecordSyncMock = vi.mocked(
   doesUsbDriveRequireCastVoteRecordSync
 );
-
-beforeEach(() => {
-  mockFeatureFlagger.resetFeatureFlags();
-});
 
 test('setup_card_reader', async () => {
   const auth = buildMockInsertedSmartCardAuth(vi.fn);
@@ -261,38 +246,7 @@ test('logged_in:election_manager', async () => {
   ).toEqual(false);
 });
 
-test('unconfigured:precinct', async () => {
-  setPollingPlacesEnabled(false);
-
-  const auth = buildMockInsertedSmartCardAuth(vi.fn);
-  const store = Store.memoryStore();
-  const mockUsbDrive = createMockUsbDrive();
-  const pollWorkerUser = mockPollWorkerUser({ electionKey });
-
-  store.setElectionAndJurisdiction({
-    electionData: electionDefinition.electionData,
-    jurisdiction: TEST_JURISDICTION,
-    electionPackageHash,
-  });
-
-  auth.getAuthStatus.mockResolvedValue({
-    status: 'logged_in',
-    user: pollWorkerUser,
-    sessionExpiresAt: mockSessionExpiresAt(),
-  });
-
-  expect(
-    await isReadyToScan({
-      auth,
-      store,
-      usbDrive: mockUsbDrive.usbDrive,
-    })
-  ).toEqual(false);
-});
-
 test('unconfigured:polling_place', async () => {
-  setPollingPlacesEnabled(true);
-
   const auth = buildMockInsertedSmartCardAuth(vi.fn);
   const store = Store.memoryStore();
   const mockUsbDrive = createMockUsbDrive();
@@ -330,7 +284,7 @@ test('USB drive removed', async () => {
     jurisdiction: TEST_JURISDICTION,
     electionPackageHash,
   });
-  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
+  store.setPollingPlaceId(pollingPlace1.id);
   store.transitionPolls({ type: 'open_polls', time: Date.now() });
 
   expect(
@@ -380,7 +334,7 @@ test('logged_in:poll_worker', async () => {
     sessionExpiresAt: mockSessionExpiresAt(),
   });
 
-  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
+  store.setPollingPlaceId(pollingPlace1.id);
   mockUsbDrive.insertUsbDrive({});
 
   expect(
@@ -403,7 +357,7 @@ test('polls_not_open', async () => {
     electionPackageHash,
   });
 
-  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
+  store.setPollingPlaceId(pollingPlace1.id);
   mockUsbDrive.insertUsbDrive({});
 
   expect(
@@ -426,7 +380,7 @@ test('cast_vote_record_sync_required', async () => {
     electionPackageHash,
   });
 
-  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
+  store.setPollingPlaceId(pollingPlace1.id);
   mockUsbDrive.insertUsbDrive({});
   store.transitionPolls({ type: 'open_polls', time: Date.now() });
 
@@ -441,37 +395,7 @@ test('cast_vote_record_sync_required', async () => {
   ).toEqual(false);
 });
 
-test('ballot:waiting_to_scan (polling places disabled)', async () => {
-  setPollingPlacesEnabled(false);
-
-  const auth = buildMockInsertedSmartCardAuth(vi.fn);
-  const store = Store.memoryStore();
-  const mockUsbDrive = createMockUsbDrive();
-
-  store.setElectionAndJurisdiction({
-    electionData: electionDefinition.electionData,
-    jurisdiction: TEST_JURISDICTION,
-    electionPackageHash,
-  });
-
-  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
-  mockUsbDrive.insertUsbDrive({});
-  store.transitionPolls({ type: 'open_polls', time: Date.now() });
-
-  doesUsbDriveRequireCastVoteRecordSyncMock.mockResolvedValue(false);
-
-  expect(
-    await isReadyToScan({
-      auth,
-      store,
-      usbDrive: mockUsbDrive.usbDrive,
-    })
-  ).toEqual(true);
-});
-
 test('ballot:waiting_to_scan', async () => {
-  setPollingPlacesEnabled(true);
-
   const auth = buildMockInsertedSmartCardAuth(vi.fn);
   const store = Store.memoryStore();
   const mockUsbDrive = createMockUsbDrive();
@@ -492,11 +416,3 @@ test('ballot:waiting_to_scan', async () => {
     await isReadyToScan({ auth, store, usbDrive: mockUsbDrive.usbDrive })
   ).toEqual(true);
 });
-
-function setPollingPlacesEnabled(enabled: boolean) {
-  if (enabled) {
-    mockFeatureFlagger.enableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  } else {
-    mockFeatureFlagger.disableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  }
-}

--- a/apps/scan/backend/src/app_flow.ts
+++ b/apps/scan/backend/src/app_flow.ts
@@ -1,10 +1,6 @@
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import { doesUsbDriveRequireCastVoteRecordSync } from '@votingworks/backend';
 import { UsbDrive } from '@votingworks/usb-drive';
-import {
-  BooleanEnvironmentVariableName,
-  isFeatureFlagEnabled,
-} from '@votingworks/utils';
 import { Store } from './store';
 import { constructAuthMachineState } from './util/auth';
 
@@ -36,12 +32,7 @@ export async function isReadyToScan({
     return false;
   }
 
-  const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
-  const locationConfigured = isFeatureFlagEnabled(ENABLE_POLLING_PLACES)
-    ? store.getPollingPlaceId()
-    : store.getPrecinctSelection();
-
-  if (!locationConfigured) {
+  if (!store.getPollingPlaceId()) {
     return false;
   }
 

--- a/apps/scan/backend/src/app_polls_reports.test.ts
+++ b/apps/scan/backend/src/app_polls_reports.test.ts
@@ -29,7 +29,11 @@ import {
   pdfToImageSheet,
 } from '../test/helpers/shared_helpers';
 import type { Store } from './store';
-import { scanBallot, withApp } from '../test/helpers/scanner_helpers';
+import {
+  POLLING_PLACE_ID_COMPETE_BMD,
+  scanBallot,
+  withApp,
+} from '../test/helpers/scanner_helpers';
 import { getScannerResults } from './util/results';
 
 // UUIDs and timestamps are displayed on the polls reports.
@@ -84,8 +88,6 @@ beforeEach(() => {
 });
 
 test('printReportSection can print each part of a primary report separately', async () => {
-  setPollingPlacesEnabled(true);
-
   await withApp(
     async ({
       apiClient,
@@ -170,8 +172,6 @@ test('printReportSection can print each part of a primary report separately', as
 });
 
 test('printing report before polls opened should fail', async () => {
-  setPollingPlacesEnabled(true);
-
   await withApp(async ({ apiClient, mockUsbDrive, mockAuth }) => {
     await configureApp(apiClient, mockAuth, mockUsbDrive, {
       testMode: true,
@@ -188,8 +188,6 @@ test('printing report before polls opened should fail', async () => {
 });
 
 test('re-printing report after scanning a ballot should fail', async () => {
-  setPollingPlacesEnabled(true);
-
   await withApp(
     async ({
       apiClient,
@@ -215,36 +213,7 @@ test('re-printing report after scanning a ballot should fail', async () => {
   );
 });
 
-test('can print report with precinct selection', async () => {
-  setPollingPlacesEnabled(false);
-
-  await withApp(
-    async ({
-      apiClient,
-      mockUsbDrive,
-      mockAuth,
-      mockFujitsuPrinterHandler,
-    }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
-
-      expect(await apiClient.printReportSection({ index: 0 })).toEqual({
-        printResult: ok(),
-
-        numberOfSections: 1,
-      });
-
-      const printPath = mockFujitsuPrinterHandler.getLastPrintPath();
-      await expect(printPath).toMatchPdfSnapshot({
-        customSnapshotIdentifier: 'voting-opened-report-precinct-selection',
-        failureThreshold: 0.0001,
-      });
-    }
-  );
-});
-
 test('can print voting paused and voting resumed reports', async () => {
-  setPollingPlacesEnabled(true);
-
   await withApp(
     async ({
       apiClient,
@@ -291,8 +260,6 @@ test('can print voting paused and voting resumed reports', async () => {
 });
 
 test('can tabulate results and print polls closed report', async () => {
-  setPollingPlacesEnabled(true);
-
   await withApp(
     async ({
       apiClient,
@@ -304,6 +271,8 @@ test('can tabulate results and print polls closed report', async () => {
       clock,
     }) => {
       await configureApp(apiClient, mockAuth, mockUsbDrive, {
+        // `scanBallot` defaults to the precinct for this location.
+        pollingPlaceId: POLLING_PLACE_ID_COMPETE_BMD,
         testMode: true,
       });
 
@@ -328,8 +297,6 @@ test('can tabulate results and print polls closed report', async () => {
 });
 
 test('polls closed report shows correct sheet counts for multi-page BMD ballots', async () => {
-  setPollingPlacesEnabled(true);
-
   await withApp(
     async ({
       apiClient,
@@ -428,8 +395,6 @@ test('polls closed report shows correct sheet counts for multi-page BMD ballots'
 });
 
 test('can print write-in image report after polls closed', async () => {
-  setPollingPlacesEnabled(true);
-
   await withApp(
     async ({
       apiClient,
@@ -453,35 +418,6 @@ test('can print write-in image report after polls closed', async () => {
         mockFujitsuPrinterHandler.getLastPrintPath()
       ).toMatchPdfSnapshot({
         customSnapshotIdentifier: 'write-in-image-report-integration',
-      });
-
-      mockFujitsuPrinterHandler.cleanup();
-    }
-  );
-});
-
-test('can print write-in image report with precinct selection', async () => {
-  setPollingPlacesEnabled(false);
-
-  await withApp(
-    async ({
-      apiClient,
-      mockScanner,
-      mockUsbDrive,
-      mockFujitsuPrinterHandler,
-      mockAuth,
-      workspace,
-      clock,
-    }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
-      await scanBallot(mockScanner, clock, apiClient, workspace.store, 0);
-      await apiClient.closePolls();
-
-      (await apiClient.printWriteInImageReport()).unsafeUnwrap();
-
-      const printPath = mockFujitsuPrinterHandler.getLastPrintPath();
-      await expect(printPath).toMatchPdfSnapshot({
-        customSnapshotIdentifier: 'write-in-image-report-precinct-selection',
       });
 
       mockFujitsuPrinterHandler.cleanup();
@@ -520,8 +456,6 @@ function recordHmpbBallotInStore({
 }
 
 test('can tabulate results and print polls closed report for closed primary', async () => {
-  setPollingPlacesEnabled(true);
-
   await withApp(
     async ({
       apiClient,
@@ -613,10 +547,6 @@ test('can tabulate results and print polls closed report for closed primary', as
 });
 
 test('can tabulate results and print polls closed report for open primary', async () => {
-  // The open primary fixture doesn't define pollingPlaces, so use precinct
-  // selection instead.
-  setPollingPlacesEnabled(false);
-
   const electionOpenPrimaryDefinition = readElectionOpenPrimaryDefinition();
   await withApp(
     async ({
@@ -631,7 +561,6 @@ test('can tabulate results and print polls closed report for open primary', asyn
         electionPackage: {
           electionDefinition: electionOpenPrimaryDefinition,
         },
-        precinctId: 'precinct-1',
       });
 
       function record(votes: VotesDict): void {
@@ -731,12 +660,3 @@ test('can tabulate results and print polls closed report for open primary', asyn
     }
   );
 });
-
-function setPollingPlacesEnabled(enabled: boolean) {
-  const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
-  if (enabled) {
-    mockFeatureFlagger.enableFeatureFlag(ENABLE_POLLING_PLACES);
-  } else {
-    mockFeatureFlagger.disableFeatureFlag(ENABLE_POLLING_PLACES);
-  }
-}

--- a/apps/scan/backend/src/app_scanning.test.ts
+++ b/apps/scan/backend/src/app_scanning.test.ts
@@ -8,7 +8,11 @@ import {
 } from '@votingworks/utils';
 import { readFile } from 'node:fs/promises';
 import { beforeEach, expect, test, vi } from 'vitest';
-import { simulateScan, withApp } from '../test/helpers/scanner_helpers';
+import {
+  POLLING_PLACE_ID_COMPLETE_HMPB,
+  simulateScan,
+  withApp,
+} from '../test/helpers/scanner_helpers';
 import { configureApp, waitForStatus } from '../test/helpers/shared_helpers';
 import { delays } from './scanner';
 
@@ -68,6 +72,7 @@ test('scanBatch with streaked page', async () => {
         electionPackage: {
           electionDefinition: vxFamousNamesFixtures.electionDefinition,
         },
+        pollingPlaceId: POLLING_PLACE_ID_COMPLETE_HMPB,
         testMode: true,
       });
 
@@ -113,6 +118,7 @@ test('scanBatch with streaked page', async () => {
         electionPackage: {
           electionDefinition: vxFamousNamesFixtures.electionDefinition,
         },
+        pollingPlaceId: POLLING_PLACE_ID_COMPLETE_HMPB,
         testMode: true,
       });
 

--- a/apps/scan/backend/src/printing/print_report_section.ts
+++ b/apps/scan/backend/src/printing/print_report_section.ts
@@ -1,11 +1,8 @@
 import { assert, assertDefined } from '@votingworks/basics';
 import {
-  BooleanEnvironmentVariableName as Feature,
   combineElectionResults,
-  getContestsForPrecinct,
   getEmptyElectionResults,
   groupContestsByParty,
-  isFeatureFlagEnabled,
   isPollsSuspensionTransition,
   PartyWithContests,
 } from '@votingworks/utils';
@@ -61,12 +58,10 @@ function getReportSections(store: Store): ReportSection[] {
     return [{ type: 'ballotCount', pollsTransitionType }];
   }
 
-  const fullReportContests = isFeatureFlagEnabled(Feature.ENABLE_POLLING_PLACES)
-    ? contestsForPollingPlace(election, store.getPollingPlaceId())
-    : getContestsForPrecinct(
-        electionDefinition,
-        assertDefined(store.getPrecinctSelection())
-      );
+  const fullReportContests = contestsForPollingPlace(
+    election,
+    store.getPollingPlaceId()
+  );
   return groupContestsByParty(election, fullReportContests).map(
     (partyWithContests) => ({
       type: 'tally',
@@ -83,7 +78,6 @@ async function getReportSection(
   const { electionDefinition, electionPackageHash } = assertDefined(
     store.getElectionRecord()
   );
-  const precinctSelection = store.getPrecinctSelection();
   const pollingPlaceId = store.getPollingPlaceId();
   const isLiveMode = !store.getTestMode();
   const { machineId } = getMachineConfig();
@@ -114,7 +108,6 @@ async function getReportSection(
       electionDefinition,
       electionPackageHash,
       pollingPlaceId,
-      precinctSelection,
       totalBallotsScanned: pollsTransition.ballotCount,
       mostRecentBatchCount,
       batches: allBatches,
@@ -147,7 +140,6 @@ async function getReportSection(
     electionDefinition,
     electionPackageHash,
     pollingPlaceId,
-    precinctSelection,
     partyId,
     pollsTransition: reportSection.pollsTransitionType,
     pollsTransitionedTime: pollsTransition.time,

--- a/apps/scan/backend/src/printing/print_write_in_image_report.ts
+++ b/apps/scan/backend/src/printing/print_write_in_image_report.ts
@@ -20,7 +20,6 @@ export async function printWriteInImageReport({
   const { electionDefinition, electionPackageHash } = assertDefined(
     store.getElectionRecord()
   );
-  const precinctSelection = store.getPrecinctSelection();
   const pollingPlaceId = store.getPollingPlaceId();
   const isLiveMode = !store.getTestMode();
   const { machineId } = getMachineConfig();
@@ -31,7 +30,6 @@ export async function printWriteInImageReport({
     electionDefinition,
     electionPackageHash,
     pollingPlaceId,
-    precinctSelection,
     isLiveMode,
     reportPrintedTime: getCurrentTime(),
     precinctScannerMachineId: machineId,

--- a/apps/scan/backend/src/scanner.ts
+++ b/apps/scan/backend/src/scanner.ts
@@ -29,13 +29,7 @@ import {
   Election,
 } from '@votingworks/types';
 import { UsbDrive } from '@votingworks/usb-drive';
-import {
-  getPrecinctSelectionIds,
-  BooleanEnvironmentVariableName,
-  isFeatureFlagEnabled,
-  time,
-  Timer,
-} from '@votingworks/utils';
+import { time, Timer } from '@votingworks/utils';
 import { exportCastVoteRecordsToUsbDrive } from '@votingworks/backend';
 import { ImageData } from 'canvas';
 import { randomUUID as uuid } from 'node:crypto';
@@ -255,13 +249,6 @@ async function interpretSheet(
 }
 
 function validPrecinctIds(store: Store, election: Election) {
-  const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
-
-  if (!isFeatureFlagEnabled(ENABLE_POLLING_PLACES)) {
-    const precinctSelection = assertDefined(store.getPrecinctSelection());
-    return getPrecinctSelectionIds(election.precincts, precinctSelection);
-  }
-
   const pollingPlaceId = assertDefined(store.getPollingPlaceId());
   const pollingPlace = pollingPlaceFromElection(election, pollingPlaceId);
 

--- a/apps/scan/backend/src/scanner_scan.test.ts
+++ b/apps/scan/backend/src/scanner_scan.test.ts
@@ -1,5 +1,4 @@
 import { err, ok, typedAs } from '@votingworks/basics';
-import { DEFAULT_FAMOUS_NAMES_PRECINCT_ID } from '@votingworks/bmd-ballot-fixtures';
 import { electionGridLayoutNewHampshireTestBallotFixtures } from '@votingworks/fixtures';
 import { vxFamousNamesFixtures } from '@votingworks/hmpb';
 import { mockScannerStatus } from '@votingworks/pdi-scanner';
@@ -16,6 +15,9 @@ import {
 import { beforeEach, expect, test, vi } from 'vitest';
 import {
   ballotImages,
+  POLLING_PLACE_ID_COMPETE_BMD,
+  POLLING_PLACE_ID_COMPLETE_HMPB,
+  POLLING_PLACE_ID_OVERVOTE_HMPB,
   simulateScan,
   withApp,
 } from '../test/helpers/scanner_helpers';
@@ -57,6 +59,7 @@ test('configure and scan hmpb', async () => {
         electionPackage: {
           electionDefinition: vxFamousNamesFixtures.electionDefinition,
         },
+        pollingPlaceId: POLLING_PLACE_ID_COMPLETE_HMPB,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
@@ -135,7 +138,7 @@ test('configure and scan bmd ballot', async () => {
     async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
       await configureApp(apiClient, mockAuth, mockUsbDrive, {
         testMode: true,
-        precinctId: DEFAULT_FAMOUS_NAMES_PRECINCT_ID,
+        pollingPlaceId: POLLING_PLACE_ID_COMPETE_BMD,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
@@ -188,6 +191,7 @@ test('ballot needs review - return', async () => {
             precinctScanAdjudicationReasons: [AdjudicationReason.Overvote],
           },
         },
+        pollingPlaceId: POLLING_PLACE_ID_OVERVOTE_HMPB,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
@@ -244,6 +248,7 @@ test('ballot needs review - accept', async () => {
             precinctScanAdjudicationReasons: [AdjudicationReason.Overvote],
           },
         },
+        pollingPlaceId: POLLING_PLACE_ID_OVERVOTE_HMPB,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
@@ -333,44 +338,7 @@ test('ballot with wrong election rejected', async () => {
   );
 });
 
-test('ballot with wrong precinct rejected (polling places disabled)', async () => {
-  setPollingPlacesEnabled(false);
-
-  await withApp(
-    async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
-      await configureApp(apiClient, mockAuth, mockUsbDrive, {
-        precinctId: '22',
-        testMode: true,
-      });
-
-      clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
-      await waitForStatus(apiClient, { state: 'waiting_for_ballot' });
-
-      await simulateScan(
-        apiClient,
-        mockScanner,
-        await ballotImages.completeBmd()
-      );
-
-      const interpretation: SheetInterpretation = {
-        type: 'InvalidSheet',
-        reason: { type: 'invalid_precinct' },
-      };
-      await waitForStatus(apiClient, { state: 'rejecting', interpretation });
-      expect(mockScanner.client.ejectDocument).toHaveBeenCalledWith(
-        'toFrontAndHold'
-      );
-      mockScanner.setScannerStatus(mockScannerStatus.documentInFront);
-      clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
-
-      await waitForStatus(apiClient, { state: 'rejected', interpretation });
-    }
-  );
-});
-
 test('ballot with wrong precinct rejected', async () => {
-  setPollingPlacesEnabled(true);
-
   await withApp(
     async ({ apiClient, mockScanner, mockUsbDrive, mockAuth, clock }) => {
       await configureApp(apiClient, mockAuth, mockUsbDrive, {
@@ -761,12 +729,3 @@ test('disconnect scanner errors absorbed in unrecoverable_error state', async ()
     }
   );
 });
-
-function setPollingPlacesEnabled(enabled: boolean) {
-  const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
-  if (enabled) {
-    mockFeatureFlagger.enableFeatureFlag(ENABLE_POLLING_PLACES);
-  } else {
-    mockFeatureFlagger.disableFeatureFlag(ENABLE_POLLING_PLACES);
-  }
-}

--- a/apps/scan/backend/src/scanner_scan_disconnect.test.ts
+++ b/apps/scan/backend/src/scanner_scan_disconnect.test.ts
@@ -20,6 +20,8 @@ import waitForExpect from 'wait-for-expect';
 import { SimulatedClock } from 'xstate/lib/SimulatedClock';
 import {
   MockPdiScannerClient,
+  POLLING_PLACE_ID_COMPLETE_HMPB,
+  POLLING_PLACE_ID_OVERVOTE_HMPB,
   ballotImages,
   createMockPdiScannerClient,
   simulateScan,
@@ -159,6 +161,7 @@ test('scanner disconnected while accepting', async () => {
         electionPackage: {
           electionDefinition: vxFamousNamesFixtures.electionDefinition,
         },
+        pollingPlaceId: POLLING_PLACE_ID_COMPLETE_HMPB,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
@@ -199,6 +202,7 @@ test('scanner disconnected while accepting - ejectDocument fails', async () => {
         electionPackage: {
           electionDefinition: vxFamousNamesFixtures.electionDefinition,
         },
+        pollingPlaceId: POLLING_PLACE_ID_COMPLETE_HMPB,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
@@ -234,6 +238,7 @@ test('scanner disconnected after accepting', async () => {
         electionPackage: {
           electionDefinition: vxFamousNamesFixtures.electionDefinition,
         },
+        pollingPlaceId: POLLING_PLACE_ID_COMPLETE_HMPB,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
@@ -353,6 +358,7 @@ test('scanner disconnected while returning', async () => {
             precinctScanAdjudicationReasons: [AdjudicationReason.Overvote],
           },
         },
+        pollingPlaceId: POLLING_PLACE_ID_OVERVOTE_HMPB,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);

--- a/apps/scan/backend/src/scanner_scan_double_sheet.test.ts
+++ b/apps/scan/backend/src/scanner_scan_double_sheet.test.ts
@@ -19,6 +19,8 @@ import {
 import { beforeEach, expect, test, vi } from 'vitest';
 import {
   ballotImages,
+  POLLING_PLACE_ID_COMPLETE_HMPB,
+  POLLING_PLACE_ID_OVERVOTE_HMPB,
   simulateScan,
   withApp,
 } from '../test/helpers/scanner_helpers';
@@ -52,6 +54,7 @@ test('insert second ballot after scan', async () => {
         electionPackage: {
           electionDefinition: vxFamousNamesFixtures.electionDefinition,
         },
+        pollingPlaceId: POLLING_PLACE_ID_COMPLETE_HMPB,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
@@ -104,6 +107,7 @@ test('insert second ballot before accept', async () => {
         electionPackage: {
           electionDefinition: vxFamousNamesFixtures.electionDefinition,
         },
+        pollingPlaceId: POLLING_PLACE_ID_COMPLETE_HMPB,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
@@ -146,6 +150,7 @@ test('insert second ballot during accept', async () => {
         electionPackage: {
           electionDefinition: vxFamousNamesFixtures.electionDefinition,
         },
+        pollingPlaceId: POLLING_PLACE_ID_COMPLETE_HMPB,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
@@ -195,6 +200,7 @@ test('insert second ballot before accept after review', async () => {
             precinctScanAdjudicationReasons: [AdjudicationReason.Overvote],
           },
         },
+        pollingPlaceId: POLLING_PLACE_ID_OVERVOTE_HMPB,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
@@ -245,6 +251,7 @@ test('insert second ballot after accept, should be scanned', async () => {
         electionPackage: {
           electionDefinition: vxFamousNamesFixtures.electionDefinition,
         },
+        pollingPlaceId: POLLING_PLACE_ID_COMPLETE_HMPB,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);

--- a/apps/scan/backend/src/scanner_scan_jam.test.ts
+++ b/apps/scan/backend/src/scanner_scan_jam.test.ts
@@ -14,6 +14,7 @@ import {
 import { beforeEach, expect, test, vi } from 'vitest';
 import {
   ballotImages,
+  POLLING_PLACE_ID_COMPLETE_HMPB,
   simulateScan,
   withApp,
 } from '../test/helpers/scanner_helpers';
@@ -85,6 +86,7 @@ test('jam while accepting', async () => {
             precinctScanAdjudicationReasons: [AdjudicationReason.Overvote],
           },
         },
+        pollingPlaceId: POLLING_PLACE_ID_COMPLETE_HMPB,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
@@ -145,6 +147,7 @@ test('timeout while accepting', async () => {
             precinctScanAdjudicationReasons: [AdjudicationReason.Overvote],
           },
         },
+        pollingPlaceId: POLLING_PLACE_ID_COMPLETE_HMPB,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
@@ -239,6 +242,7 @@ test('jam while returning', async () => {
             precinctScanAdjudicationReasons: [AdjudicationReason.Overvote],
           },
         },
+        pollingPlaceId: POLLING_PLACE_ID_COMPLETE_HMPB,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);

--- a/apps/scan/backend/src/scanner_scan_shoeshine_mode.test.ts
+++ b/apps/scan/backend/src/scanner_scan_shoeshine_mode.test.ts
@@ -11,6 +11,7 @@ import {
 import { beforeEach, expect, test, vi } from 'vitest';
 import {
   ballotImages,
+  POLLING_PLACE_ID_COMPLETE_HMPB,
   simulateScan,
   withApp,
 } from '../test/helpers/scanner_helpers';
@@ -46,6 +47,7 @@ test('shoeshine mode scans the same ballot repeatedly', async () => {
       await configureApp(apiClient, mockAuth, mockUsbDrive, {
         testMode: true,
         electionPackage,
+        pollingPlaceId: POLLING_PLACE_ID_COMPLETE_HMPB,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);
@@ -98,6 +100,7 @@ test('handles error on eject for rescan', async () => {
       await configureApp(apiClient, mockAuth, mockUsbDrive, {
         testMode: true,
         electionPackage,
+        pollingPlaceId: POLLING_PLACE_ID_COMPLETE_HMPB,
       });
 
       clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);

--- a/apps/scan/backend/src/store.test.ts
+++ b/apps/scan/backend/src/store.test.ts
@@ -23,11 +23,7 @@ import {
   TEST_JURISDICTION,
 } from '@votingworks/types';
 import { createMockUsbDrive } from '@votingworks/usb-drive';
-import {
-  ALL_PRECINCTS_SELECTION,
-  getFeatureFlagMock,
-  singlePrecinctSelectionFor,
-} from '@votingworks/utils';
+import { getFeatureFlagMock } from '@votingworks/utils';
 import { sha256 } from 'js-sha256';
 import { DateTime } from 'luxon';
 import { randomUUID as uuid } from 'node:crypto';
@@ -252,34 +248,6 @@ test('get/set isContinuousExportEnabled', () => {
   // Make sure that resetting election session resumes continuous export if paused
   store.resetElectionSession();
   expect(store.getIsContinuousExportEnabled()).toEqual(true);
-});
-
-test('get/set precinct selection', () => {
-  const store = Store.memoryStore(mockBaseLogger({ fn: vi.fn }));
-
-  // Before setting an election
-  expect(store.getPrecinctSelection()).toEqual(undefined);
-  expect(() =>
-    store.setPrecinctSelection(ALL_PRECINCTS_SELECTION)
-  ).toThrowError();
-
-  store.setElectionAndJurisdiction({
-    electionData:
-      electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition()
-        .electionData,
-    jurisdiction,
-    electionPackageHash,
-  });
-
-  // After setting an election
-  expect(store.getPrecinctSelection()).toEqual(undefined);
-
-  store.setPrecinctSelection(ALL_PRECINCTS_SELECTION);
-  expect(store.getPrecinctSelection()).toEqual(ALL_PRECINCTS_SELECTION);
-
-  const precinctSelection = singlePrecinctSelectionFor('precinct-1');
-  store.setPrecinctSelection(precinctSelection);
-  expect(store.getPrecinctSelection()).toMatchObject(precinctSelection);
 });
 
 test('get/set polling place', () => {

--- a/apps/scan/backend/src/store.ts
+++ b/apps/scan/backend/src/store.ts
@@ -12,8 +12,6 @@ import {
   PageInterpretationWithFiles,
   PollsState as PollsStateType,
   PollsStateSchema,
-  PrecinctSelection as PrecinctSelectionType,
-  PrecinctSelectionSchema,
   safeParse,
   safeParseElectionDefinition,
   safeParseJson,
@@ -447,50 +445,6 @@ export class Store {
   getAdjudicationReasons(): readonly AdjudicationReason[] {
     return assertDefined(this.getSystemSettings())
       .precinctScanAdjudicationReasons;
-  }
-
-  /**
-   * Gets the current precinct `scan` is accepting ballots for. If set to
-   * `undefined`, ballots from all precincts will be accepted (this is the
-   * default).
-   */
-  getPrecinctSelection(): Optional<PrecinctSelectionType> {
-    const electionRow = this.client.one(
-      'select precinct_selection as rawPrecinctSelection from election'
-    ) as { rawPrecinctSelection: string } | undefined;
-
-    const rawPrecinctSelection = electionRow?.rawPrecinctSelection;
-
-    if (!rawPrecinctSelection) {
-      // precinct selection is undefined when there is no election
-      return undefined;
-    }
-
-    const precinctSelectionParseResult = safeParseJson(
-      rawPrecinctSelection,
-      PrecinctSelectionSchema
-    );
-
-    if (precinctSelectionParseResult.isErr()) {
-      throw new Error('Unable to parse stored precinct selection.');
-    }
-
-    return precinctSelectionParseResult.ok();
-  }
-
-  /**
-   * Sets the current precinct `scan` is accepting ballots for. Set to
-   * `undefined` to accept from all precincts (this is the default).
-   */
-  setPrecinctSelection(precinctSelection?: PrecinctSelectionType): void {
-    if (!this.hasElection()) {
-      throw new Error('Cannot set precinct selection without an election.');
-    }
-
-    this.client.run(
-      'update election set precinct_selection = ?',
-      precinctSelection ? JSON.stringify(precinctSelection) : null
-    );
   }
 
   /**

--- a/apps/scan/backend/src/types.ts
+++ b/apps/scan/backend/src/types.ts
@@ -4,7 +4,6 @@ import {
   PageInterpretation,
   PollsState,
   PollsTransitionType,
-  PrecinctSelection,
   SheetInterpretationWithPages,
   SystemSettings,
   PrecinctScannerMachineStatus,
@@ -36,7 +35,6 @@ export interface PrecinctScannerConfig {
   electionDefinition?: ElectionDefinition;
   electionPackageHash?: string;
   systemSettings: SystemSettings;
-  precinctSelection?: PrecinctSelection;
   pollingPlaceId?: string;
   isSoundMuted: boolean;
   isDoubleFeedDetectionDisabled: boolean;

--- a/apps/scan/backend/test/helpers/scanner_helpers.ts
+++ b/apps/scan/backend/test/helpers/scanner_helpers.ts
@@ -5,6 +5,7 @@ import {
 import { Result, deferred, ok } from '@votingworks/basics';
 import {
   DEFAULT_FAMOUS_NAMES_BALLOT_STYLE_ID,
+  DEFAULT_FAMOUS_NAMES_POLLING_PLACE_ID,
   DEFAULT_FAMOUS_NAMES_PRECINCT_ID,
   DEFAULT_FAMOUS_NAMES_VOTES,
   renderBmdBallotFixture,
@@ -214,6 +215,11 @@ export async function withApp(
   }
 }
 
+export const POLLING_PLACE_ID_COMPLETE_HMPB = '20-polling-place';
+export const POLLING_PLACE_ID_OVERVOTE_HMPB = POLLING_PLACE_ID_COMPLETE_HMPB;
+export const POLLING_PLACE_ID_COMPETE_BMD =
+  DEFAULT_FAMOUS_NAMES_POLLING_PLACE_ID;
+
 export const ballotImages = {
   completeHmpb: async () =>
     pdfToImageSheet(
@@ -285,18 +291,22 @@ export async function scanBallot(
     state: 'waiting_for_ballot',
     ballotsCounted: initialBallotsCounted,
   });
+
   await simulateScan(
     apiClient,
     mockScanner,
     options.ballotImages ?? (await ballotImages.completeBmd()),
     initialBallotsCounted
   );
+
   await waitForStatus(apiClient, {
     state: 'accepting',
     ballotsCounted: initialBallotsCounted,
     interpretation: { type: 'ValidSheet' },
   });
+
   expect(mockScanner.client.ejectDocument).toHaveBeenCalledWith('toRear');
+
   mockScanner.setScannerStatus(mockScannerStatus.idleScanningDisabled);
   clock.increment(delays.DELAY_SCANNER_STATUS_POLLING_INTERVAL);
   await waitForStatus(apiClient, {
@@ -304,7 +314,9 @@ export async function scanBallot(
     interpretation: { type: 'ValidSheet' },
     ballotsCounted: initialBallotsCounted + 1,
   });
+
   await apiClient.readyForNextBallot();
+
   await waitForStatus(apiClient, {
     state: 'waiting_for_ballot',
     ballotsCounted: initialBallotsCounted + 1,

--- a/apps/scan/backend/test/helpers/shared_helpers.ts
+++ b/apps/scan/backend/test/helpers/shared_helpers.ts
@@ -1,6 +1,6 @@
 import { Mocked, expect, vi } from 'vitest';
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
-import { assertDefined, iter, ok } from '@votingworks/basics';
+import { iter, ok } from '@votingworks/basics';
 import { mockElectionPackageFileTree } from '@votingworks/backend';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import * as grout from '@votingworks/grout';
@@ -13,7 +13,7 @@ import {
   BallotMetadata,
   ElectionPackage,
   PageInterpretationWithFiles,
-  PrecinctId,
+  anyPollingPlace,
   PrecinctScannerState,
   SheetOf,
   VotesDict,
@@ -21,12 +21,6 @@ import {
   constructElectionKey,
   pollingPlaceFromElection,
 } from '@votingworks/types';
-import {
-  ALL_PRECINCTS_SELECTION,
-  BooleanEnvironmentVariableName,
-  isFeatureFlagEnabled,
-  singlePrecinctSelectionFor,
-} from '@votingworks/utils';
 import waitForExpect from 'wait-for-expect';
 import { MockUsbDrive } from '@votingworks/usb-drive';
 import { mockLogger, LogSource, MockLogger } from '@votingworks/logging';
@@ -81,13 +75,11 @@ export async function configureApp(
   {
     electionPackage = electionFamousNames2021Fixtures.electionJson.toElectionPackage(),
     pollingPlaceId,
-    precinctId,
     testMode = false,
     openPolls = true,
   }: {
     electionPackage?: ElectionPackage;
     pollingPlaceId?: string;
-    precinctId?: PrecinctId;
     testMode?: boolean;
     openPolls?: boolean;
   } = {}
@@ -113,19 +105,10 @@ export async function configureApp(
   );
 
   const { election } = electionPackage.electionDefinition;
-  const { ENABLE_POLLING_PLACES } = BooleanEnvironmentVariableName;
-  if (isFeatureFlagEnabled(ENABLE_POLLING_PLACES)) {
-    const pollingPlace = pollingPlaceId
-      ? pollingPlaceFromElection(election, pollingPlaceId)
-      : assertDefined(election.pollingPlaces)[0];
-    await apiClient.setPollingPlaceId({ id: pollingPlace.id });
-  } else {
-    await apiClient.setPrecinctSelection({
-      precinctSelection: precinctId
-        ? singlePrecinctSelectionFor(precinctId)
-        : ALL_PRECINCTS_SELECTION,
-    });
-  }
+  const pollingPlace = pollingPlaceId
+    ? pollingPlaceFromElection(election, pollingPlaceId)
+    : anyPollingPlace(election);
+  await apiClient.setPollingPlaceId({ id: pollingPlace.id });
 
   await apiClient.setTestMode({ isTestMode: testMode });
   if (openPolls) {

--- a/libs/printing/src/render.precinct_scanner_write_in_image_report.test.tsx
+++ b/libs/printing/src/render.precinct_scanner_write_in_image_report.test.tsx
@@ -1,9 +1,5 @@
 import { expect, test, vi } from 'vitest';
 import {
-  ALL_PRECINCTS_SELECTION,
-  singlePrecinctSelectionFor,
-} from '@votingworks/utils';
-import {
   electionFamousNames2021Fixtures,
   electionTwoPartyPrimaryFixtures,
 } from '@votingworks/fixtures';
@@ -11,6 +7,7 @@ import {
   ContestWriteIns,
   PrecinctScannerWriteInImageReport,
 } from '@votingworks/ui';
+import { anyPollingPlace } from '@votingworks/types';
 import { PAPER_DIMENSIONS, renderToPdf } from './render';
 
 vi.mock(import('@votingworks/types'), async (importActual) => {
@@ -33,7 +30,7 @@ const DEFAULT_PROPS: Omit<
 > = {
   electionDefinition,
   electionPackageHash: 'test-package-hash',
-  precinctSelection: ALL_PRECINCTS_SELECTION,
+  pollingPlaceId: anyPollingPlace(electionDefinition.election).id,
   isLiveMode: true,
   reportPrintedTime: REPORT_PRINTED_TIME,
   precinctScannerMachineId: 'SC-00-000',
@@ -177,9 +174,7 @@ test('primary election with party headers', async () => {
   const report = PrecinctScannerWriteInImageReport({
     electionDefinition: primaryElectionDefinition,
     electionPackageHash: 'test-package-hash',
-    precinctSelection: singlePrecinctSelectionFor(
-      primaryElectionDefinition.election.precincts[0].id
-    ),
+    pollingPlaceId: anyPollingPlace(primaryElectionDefinition.election).id,
     isLiveMode: true,
     reportPrintedTime: REPORT_PRINTED_TIME,
     precinctScannerMachineId: 'SC-00-000',

--- a/libs/ui/src/reports/precinct_scanner_ballot_count_report.test.tsx
+++ b/libs/ui/src/reports/precinct_scanner_ballot_count_report.test.tsx
@@ -1,13 +1,15 @@
 import { expect, test, vi } from 'vitest';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import {
-  ALL_PRECINCTS_SELECTION,
   BooleanEnvironmentVariableName as Feature,
   getFeatureFlagMock,
 } from '@votingworks/utils';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
-import { BatchInfo, formatElectionHashes } from '@votingworks/types';
-import { assertDefined } from '@votingworks/basics';
+import {
+  anyPollingPlace,
+  BatchInfo,
+  formatElectionHashes,
+} from '@votingworks/types';
 import { render, screen } from '../../test/react_testing_library';
 import { PrecinctScannerBallotCountReport } from './precinct_scanner_ballot_count_report';
 
@@ -21,6 +23,9 @@ const electionGeneralDefinition = readElectionGeneralDefinition();
 const pollsTransitionedTime = new Date(2021, 8, 19, 11, 5).getTime();
 const reportPrintedTime = new Date(2021, 8, 19, 11, 6).getTime();
 
+const { election } = electionGeneralDefinition;
+const pollingPlace = anyPollingPlace(election);
+
 const testBatches: BatchInfo[] = [
   {
     id: 'a3c38c4b-0012-4ab1-b4ef-0d95671595ca',
@@ -33,11 +38,6 @@ const testBatches: BatchInfo[] = [
 ];
 
 test('renders info properly', () => {
-  setPollingPlacesEnabled(true);
-
-  const { election } = electionGeneralDefinition;
-  const [pollingPlace] = assertDefined(election.pollingPlaces);
-
   render(
     <PrecinctScannerBallotCountReport
       electionDefinition={electionGeneralDefinition}
@@ -89,36 +89,12 @@ test('renders info properly', () => {
   expect(screen.queryByText('Time Voting Paused')).toBeNull();
 });
 
-test('renders precinct selection', () => {
-  setPollingPlacesEnabled(false);
-
-  render(
-    <PrecinctScannerBallotCountReport
-      electionDefinition={electionGeneralDefinition}
-      electionPackageHash="test-election-package-hash"
-      precinctSelection={ALL_PRECINCTS_SELECTION}
-      totalBallotsScanned={23}
-      mostRecentBatchCount={23}
-      batches={testBatches}
-      pollsTransition="pause_voting"
-      pollsTransitionedTime={pollsTransitionedTime}
-      reportPrintedTime={reportPrintedTime}
-      isLiveMode={false}
-      precinctScannerMachineId="SC-01-000"
-    />
-  );
-
-  screen.getByText('Voting Paused Report • All Precincts');
-});
-
 test('omits most recent batch count on resume_voting', () => {
-  setPollingPlacesEnabled(false);
-
   render(
     <PrecinctScannerBallotCountReport
       electionDefinition={electionGeneralDefinition}
       electionPackageHash="test-election-package-hash"
-      precinctSelection={ALL_PRECINCTS_SELECTION}
+      pollingPlaceId={pollingPlace.id}
       totalBallotsScanned={23}
       batches={testBatches}
       pollsTransition="resume_voting"
@@ -133,13 +109,11 @@ test('omits most recent batch count on resume_voting', () => {
 });
 
 test('renders batch summary table', () => {
-  setPollingPlacesEnabled(false);
-
   render(
     <PrecinctScannerBallotCountReport
       electionDefinition={electionGeneralDefinition}
       electionPackageHash="test-election-package-hash"
-      precinctSelection={ALL_PRECINCTS_SELECTION}
+      pollingPlaceId={pollingPlace.id}
       totalBallotsScanned={23}
       mostRecentBatchCount={23}
       batches={testBatches}
@@ -156,11 +130,3 @@ test('renders batch summary table', () => {
   screen.getByText('Polls Opened / Resumed');
   screen.getByText('a3c38c4b-0d95671595ca');
 });
-
-function setPollingPlacesEnabled(enabled: boolean) {
-  if (enabled) {
-    mockFeatureFlagger.enableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  } else {
-    mockFeatureFlagger.disableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  }
-}

--- a/libs/ui/src/reports/precinct_scanner_ballot_count_report.tsx
+++ b/libs/ui/src/reports/precinct_scanner_ballot_count_report.tsx
@@ -2,7 +2,6 @@ import {
   BatchInfo,
   ElectionDefinition,
   PollsSuspensionTransitionType,
-  PrecinctSelection,
 } from '@votingworks/types';
 import styled, { ThemeProvider } from 'styled-components';
 import { BatchSummaryTable } from './batch_summary_table';
@@ -37,7 +36,6 @@ interface Props {
   electionDefinition: ElectionDefinition;
   electionPackageHash: string;
   pollingPlaceId?: string;
-  precinctSelection?: PrecinctSelection;
   totalBallotsScanned: number;
   mostRecentBatchCount?: number;
   batches: BatchInfo[];
@@ -52,7 +50,6 @@ export function PrecinctScannerBallotCountReport({
   electionDefinition,
   electionPackageHash,
   pollingPlaceId,
-  precinctSelection,
   totalBallotsScanned,
   mostRecentBatchCount,
   batches,
@@ -69,7 +66,6 @@ export function PrecinctScannerBallotCountReport({
           electionDefinition={electionDefinition}
           electionPackageHash={electionPackageHash}
           pollingPlaceId={pollingPlaceId}
-          precinctSelection={precinctSelection}
           pollsTransition={pollsTransition}
           isLiveMode={isLiveMode}
           pollsTransitionedTime={pollsTransitionedTime}

--- a/libs/ui/src/reports/precinct_scanner_report_header.test.tsx
+++ b/libs/ui/src/reports/precinct_scanner_report_header.test.tsx
@@ -1,24 +1,13 @@
-import { expect, test, vi } from 'vitest';
-import {
-  ALL_PRECINCTS_SELECTION,
-  BooleanEnvironmentVariableName as Feature,
-  getFeatureFlagMock,
-} from '@votingworks/utils';
+import { expect, test } from 'vitest';
 import {
   electionFamousNames2021Fixtures,
   readElectionTwoPartyPrimaryDefinition,
 } from '@votingworks/fixtures';
-import { formatElectionHashes } from '@votingworks/types';
+import { anyPollingPlace, formatElectionHashes } from '@votingworks/types';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { assertDefined } from '@votingworks/basics';
 import { render, screen } from '../../test/react_testing_library';
 import { PrecinctScannerReportHeader } from './precinct_scanner_report_header';
-
-const mockFeatureFlagger = getFeatureFlagMock();
-vi.mock(import('@votingworks/utils'), async (importActual) => ({
-  ...(await importActual()),
-  isFeatureFlagEnabled: (f: Feature) => mockFeatureFlagger.isEnabled(f),
-}));
 
 const pollsTransitionedTime = new Date('2022-10-31T16:23:00.000').getTime();
 const reportPrintedTime = new Date('2022-10-31T16:24:00.000').getTime();
@@ -28,9 +17,7 @@ const electionTwoPartyPrimaryDefinition =
 const generalElectionDefinition =
   electionFamousNames2021Fixtures.readElectionDefinition();
 
-test('general election, all precincts, polls open, test mode', () => {
-  setPollingPlacesEnabled(true);
-
+test('general election, polls open, test mode', () => {
   const { election } = generalElectionDefinition;
   const [pollingPlace] = assertDefined(election.pollingPlaces);
 
@@ -73,8 +60,6 @@ test('general election, all precincts, polls open, test mode', () => {
 });
 
 test('primary election, single precinct, polls closed, live mode', () => {
-  setPollingPlacesEnabled(true);
-
   const { election } = electionTwoPartyPrimaryDefinition;
   const [pollingPlace] = assertDefined(election.pollingPlaces);
 
@@ -119,8 +104,6 @@ test('primary election, single precinct, polls closed, live mode', () => {
 });
 
 test('primary election nonpartisan contests', () => {
-  setPollingPlacesEnabled(true);
-
   const { election } = electionTwoPartyPrimaryDefinition;
   const [pollingPlace] = assertDefined(election.pollingPlaces);
 
@@ -143,8 +126,6 @@ test('primary election nonpartisan contests', () => {
 });
 
 test('primary election, polls paused', () => {
-  setPollingPlacesEnabled(true);
-
   const { election } = electionTwoPartyPrimaryDefinition;
   const [pollingPlace] = assertDefined(election.pollingPlaces);
 
@@ -168,33 +149,15 @@ test('primary election, polls paused', () => {
   );
 });
 
-test('renders precinct selection name', () => {
-  setPollingPlacesEnabled(false);
-
-  render(
-    <PrecinctScannerReportHeader
-      electionDefinition={electionTwoPartyPrimaryDefinition}
-      electionPackageHash="test-election-package-hash"
-      partyId="0"
-      precinctSelection={ALL_PRECINCTS_SELECTION}
-      pollsTransition="pause_voting"
-      pollsTransitionedTime={pollsTransitionedTime}
-      isLiveMode={false}
-      reportPrintedTime={reportPrintedTime}
-      precinctScannerMachineId="SC-01-000"
-    />
-  );
-  screen.getByText('Voting Paused Report • All Precincts');
-});
-
 test('renders batch ID in metadata when provided', () => {
-  setPollingPlacesEnabled(false);
+  const { election } = electionTwoPartyPrimaryDefinition;
+  const pollingPlace = anyPollingPlace(election);
 
   render(
     <PrecinctScannerReportHeader
       electionDefinition={electionTwoPartyPrimaryDefinition}
       electionPackageHash="test-election-package-hash"
-      precinctSelection={ALL_PRECINCTS_SELECTION}
+      pollingPlaceId={pollingPlace.id}
       pollsTransition="close_polls"
       isLiveMode
       pollsTransitionedTime={pollsTransitionedTime}
@@ -211,13 +174,14 @@ test('renders batch ID in metadata when provided', () => {
 });
 
 test('does not render batch ID when not provided', () => {
-  setPollingPlacesEnabled(false);
+  const { election } = electionTwoPartyPrimaryDefinition;
+  const pollingPlace = anyPollingPlace(election);
 
   render(
     <PrecinctScannerReportHeader
       electionDefinition={electionTwoPartyPrimaryDefinition}
       electionPackageHash="test-election-package-hash"
-      precinctSelection={ALL_PRECINCTS_SELECTION}
+      pollingPlaceId={pollingPlace.id}
       pollsTransition="close_polls"
       isLiveMode
       pollsTransitionedTime={pollsTransitionedTime}
@@ -228,11 +192,3 @@ test('does not render batch ID when not provided', () => {
 
   expect(screen.queryByText('Batch ID:')).toBeNull();
 });
-
-function setPollingPlacesEnabled(enabled: boolean) {
-  if (enabled) {
-    mockFeatureFlagger.enableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  } else {
-    mockFeatureFlagger.disableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  }
-}

--- a/libs/ui/src/reports/precinct_scanner_report_header.tsx
+++ b/libs/ui/src/reports/precinct_scanner_report_header.tsx
@@ -6,7 +6,6 @@ import {
   PartyId,
   pollingPlaceFromElection,
   PollsTransitionType,
-  PrecinctSelection,
   Tabulation,
 } from '@votingworks/types';
 import {
@@ -14,9 +13,6 @@ import {
   CachedElectionLookups,
   getPollsReportTitle,
   getPollsTransitionActionPastTense,
-  getPrecinctSelectionName,
-  isFeatureFlagEnabled,
-  BooleanEnvironmentVariableName as Feature,
 } from '@votingworks/utils';
 import { DateTime } from 'luxon';
 import React from 'react';
@@ -38,7 +34,6 @@ interface Props {
   electionPackageHash: string;
   partyId?: PartyId;
   pollingPlaceId?: string;
-  precinctSelection?: PrecinctSelection;
   pollsTransition: PollsTransitionType;
   isLiveMode: boolean;
   pollsTransitionedTime: number;
@@ -52,7 +47,6 @@ export function PrecinctScannerReportHeader({
   electionPackageHash,
   partyId,
   pollingPlaceId,
-  precinctSelection,
   pollsTransition,
   isLiveMode,
   pollsTransitionedTime,
@@ -66,7 +60,6 @@ export function PrecinctScannerReportHeader({
   const locationName = precinctScannerLocationName({
     election,
     pollingPlaceId,
-    precinctSelection,
   });
   const reportTitle = `${getPollsReportTitle(
     pollsTransition
@@ -126,13 +119,7 @@ export function PrecinctScannerReportHeader({
 export function precinctScannerLocationName(p: {
   election: Election;
   pollingPlaceId?: string;
-  precinctSelection?: PrecinctSelection;
 }): string {
-  if (!isFeatureFlagEnabled(Feature.ENABLE_POLLING_PLACES)) {
-    const selection = assertDefined(p.precinctSelection);
-    return getPrecinctSelectionName(p.election.precincts, selection);
-  }
-
   const pollingPlaceId = assertDefined(p.pollingPlaceId);
   const pollingPlace = pollingPlaceFromElection(p.election, pollingPlaceId);
 

--- a/libs/ui/src/reports/precinct_scanner_tally_report.test.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_report.test.tsx
@@ -1,26 +1,19 @@
-import { expect, test, vi } from 'vitest';
+import { expect, test } from 'vitest';
 import {
   electionFamousNames2021Fixtures,
   readElectionTwoPartyPrimaryDefinition,
 } from '@votingworks/fixtures';
-import { BatchInfo, formatElectionHashes } from '@votingworks/types';
 import {
-  ALL_PRECINCTS_SELECTION,
-  BooleanEnvironmentVariableName as Feature,
-  buildElectionResultsFixture,
-  getFeatureFlagMock,
-} from '@votingworks/utils';
+  anyPollingPlace,
+  BatchInfo,
+  formatElectionHashes,
+} from '@votingworks/types';
+import { buildElectionResultsFixture } from '@votingworks/utils';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { assertDefined } from '@votingworks/basics';
 import { render, screen, within } from '../../test/react_testing_library';
 
 import { PrecinctScannerTallyReport } from './precinct_scanner_tally_report';
-
-const mockFeatureFlagger = getFeatureFlagMock();
-vi.mock(import('@votingworks/utils'), async (importActual) => ({
-  ...(await importActual()),
-  isFeatureFlagEnabled: (f: Feature) => mockFeatureFlagger.isEnabled(f),
-}));
 
 const electionTwoPartyPrimaryDefinition =
   readElectionTwoPartyPrimaryDefinition();
@@ -54,8 +47,6 @@ const generalElectionResults = buildElectionResultsFixture({
 });
 
 test('renders as expected for a single precinct in a general election', () => {
-  setPollingPlacesEnabled(true);
-
   const [pollingPlace] = assertDefined(generalElection.pollingPlaces);
 
   render(
@@ -134,8 +125,6 @@ const primaryElectionResults = buildElectionResultsFixture({
 });
 
 test('renders as expected for all precincts in a primary election', () => {
-  setPollingPlacesEnabled(true);
-
   const [pollingPlace] = assertDefined(electionTwoPartyPrimary.pollingPlaces);
 
   render(
@@ -194,8 +183,6 @@ test('renders as expected for all precincts in a primary election', () => {
 });
 
 test('displays only passed contests', () => {
-  setPollingPlacesEnabled(true);
-
   const [pollingPlace] = assertDefined(electionTwoPartyPrimary.pollingPlaces);
 
   render(
@@ -221,28 +208,6 @@ test('displays only passed contests', () => {
   expect(screen.getAllByTestId(/results-table-/)).toHaveLength(1);
 });
 
-test('renders precinct selection name', () => {
-  setPollingPlacesEnabled(false);
-
-  render(
-    <PrecinctScannerTallyReport
-      pollsTransitionedTime={pollsTransitionedTime}
-      reportPrintedTime={reportPrintedTime}
-      precinctScannerMachineId="SC-01-000"
-      electionDefinition={generalElectionDefinition}
-      electionPackageHash="test-election-package-hash"
-      precinctSelection={ALL_PRECINCTS_SELECTION}
-      pollsTransition="open_polls"
-      isLiveMode={false}
-      scannedElectionResults={generalElectionResults}
-      contests={generalElection.contests}
-      batches={[]}
-    />
-  );
-
-  screen.getByText('Polls Opened Report • All Precincts');
-});
-
 const singleBatch: BatchInfo = {
   id: 'c1d2e3f4-a5b6-4789-abcd-ef1234567890',
   batchNumber: 1,
@@ -265,8 +230,6 @@ const multiBatch: BatchInfo[] = [
 ];
 
 test('shows batch ID in header metadata for single batch (close_polls)', () => {
-  setPollingPlacesEnabled(false);
-
   render(
     <PrecinctScannerTallyReport
       pollsTransitionedTime={pollsTransitionedTime}
@@ -274,7 +237,7 @@ test('shows batch ID in header metadata for single batch (close_polls)', () => {
       precinctScannerMachineId="SC-01-000"
       electionDefinition={generalElectionDefinition}
       electionPackageHash="test-election-package-hash"
-      precinctSelection={ALL_PRECINCTS_SELECTION}
+      pollingPlaceId={anyPollingPlace(generalElectionDefinition.election).id}
       pollsTransition="close_polls"
       isLiveMode={false}
       scannedElectionResults={generalElectionResults}
@@ -291,8 +254,6 @@ test('shows batch ID in header metadata for single batch (close_polls)', () => {
 });
 
 test('shows batch table (not header batch ID) for multiple batches (close_polls)', () => {
-  setPollingPlacesEnabled(false);
-
   render(
     <PrecinctScannerTallyReport
       pollsTransitionedTime={pollsTransitionedTime}
@@ -300,7 +261,7 @@ test('shows batch table (not header batch ID) for multiple batches (close_polls)
       precinctScannerMachineId="SC-01-000"
       electionDefinition={generalElectionDefinition}
       electionPackageHash="test-election-package-hash"
-      precinctSelection={ALL_PRECINCTS_SELECTION}
+      pollingPlaceId={anyPollingPlace(generalElectionDefinition.election).id}
       pollsTransition="close_polls"
       isLiveMode={false}
       scannedElectionResults={generalElectionResults}
@@ -316,8 +277,6 @@ test('shows batch table (not header batch ID) for multiple batches (close_polls)
 });
 
 test('shows no batch info when batches is empty (open_polls)', () => {
-  setPollingPlacesEnabled(false);
-
   render(
     <PrecinctScannerTallyReport
       pollsTransitionedTime={pollsTransitionedTime}
@@ -325,7 +284,7 @@ test('shows no batch info when batches is empty (open_polls)', () => {
       precinctScannerMachineId="SC-01-000"
       electionDefinition={generalElectionDefinition}
       electionPackageHash="test-election-package-hash"
-      precinctSelection={ALL_PRECINCTS_SELECTION}
+      pollingPlaceId={anyPollingPlace(generalElectionDefinition.election).id}
       pollsTransition="open_polls"
       isLiveMode={false}
       scannedElectionResults={generalElectionResults}
@@ -337,11 +296,3 @@ test('shows no batch info when batches is empty (open_polls)', () => {
   expect(screen.queryByText('Batch ID:')).toBeNull();
   expect(screen.queryByText('Batch ID')).toBeNull();
 });
-
-function setPollingPlacesEnabled(enabled: boolean) {
-  if (enabled) {
-    mockFeatureFlagger.enableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  } else {
-    mockFeatureFlagger.disableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  }
-}

--- a/libs/ui/src/reports/precinct_scanner_tally_report.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_report.tsx
@@ -3,7 +3,6 @@ import {
   Contest,
   ElectionDefinition,
   PartyId,
-  PrecinctSelection,
   StandardPollsTransitionType,
   Tabulation,
 } from '@votingworks/types';
@@ -24,7 +23,6 @@ interface Props {
   electionPackageHash: string;
   partyId?: PartyId;
   pollingPlaceId?: string;
-  precinctSelection?: PrecinctSelection;
   contests: readonly Contest[];
   scannedElectionResults: Tabulation.ElectionResults;
   pollsTransition: StandardPollsTransitionType;
@@ -44,7 +42,6 @@ export function PrecinctScannerTallyReport({
   electionPackageHash,
   partyId,
   pollingPlaceId,
-  precinctSelection,
   contests,
   scannedElectionResults,
   pollsTransition,
@@ -66,7 +63,6 @@ export function PrecinctScannerTallyReport({
           electionPackageHash={electionPackageHash}
           partyId={partyId}
           pollingPlaceId={pollingPlaceId}
-          precinctSelection={precinctSelection}
           pollsTransition={pollsTransition}
           isLiveMode={isLiveMode}
           pollsTransitionedTime={pollsTransitionedTime}

--- a/libs/ui/src/reports/precinct_scanner_write_in_image_report.test.tsx
+++ b/libs/ui/src/reports/precinct_scanner_write_in_image_report.test.tsx
@@ -4,7 +4,6 @@ import {
   electionTwoPartyPrimaryFixtures,
 } from '@votingworks/fixtures';
 import {
-  ALL_PRECINCTS_SELECTION,
   BooleanEnvironmentVariableName as Feature,
   getFeatureFlagMock,
 } from '@votingworks/utils';
@@ -43,7 +42,6 @@ const DEFAULT_PROPS: Omit<
 > = {
   electionDefinition,
   electionPackageHash: 'test-package-hash',
-  precinctSelection: ALL_PRECINCTS_SELECTION,
   pollingPlaceId: pollingPlace.id,
   isLiveMode: true,
   reportPrintedTime: REPORT_PRINTED_TIME,
@@ -51,8 +49,6 @@ const DEFAULT_PROPS: Omit<
 };
 
 test('renders contest heading with inline write-in count', () => {
-  setPollingPlacesEnabled(true);
-
   const contestWriteIns: ContestWriteIns[] = [
     {
       contestId: 'mayor',
@@ -77,8 +73,6 @@ test('renders contest heading with inline write-in count', () => {
 });
 
 test('renders image write-ins as img elements', () => {
-  setPollingPlacesEnabled(true);
-
   const contestWriteIns: ContestWriteIns[] = [
     {
       contestId: 'mayor',
@@ -100,8 +94,6 @@ test('renders image write-ins as img elements', () => {
 });
 
 test('renders text write-ins with "Summary Ballot Write-In" label', () => {
-  setPollingPlacesEnabled(true);
-
   const contestWriteIns: ContestWriteIns[] = [
     {
       contestId: 'mayor',
@@ -119,8 +111,6 @@ test('renders text write-ins with "Summary Ballot Write-In" label', () => {
 });
 
 test('renders contests with 0 write-ins without a grid', () => {
-  setPollingPlacesEnabled(true);
-
   const contestWriteIns: ContestWriteIns[] = [
     {
       contestId: 'mayor',
@@ -148,8 +138,6 @@ test('renders contests with 0 write-ins without a grid', () => {
 });
 
 test('intermixes image and text entries in a single grid', () => {
-  setPollingPlacesEnabled(true);
-
   const contestWriteIns: ContestWriteIns[] = [
     {
       contestId: 'mayor',
@@ -172,8 +160,6 @@ test('intermixes image and text entries in a single grid', () => {
 });
 
 test('shows test mode banner when not in live mode', () => {
-  setPollingPlacesEnabled(true);
-
   const contestWriteIns: ContestWriteIns[] = [];
 
   render(
@@ -188,8 +174,6 @@ test('shows test mode banner when not in live mode', () => {
 });
 
 test('does not show test mode banner in live mode', () => {
-  setPollingPlacesEnabled(true);
-
   const contestWriteIns: ContestWriteIns[] = [];
 
   render(
@@ -204,8 +188,6 @@ test('does not show test mode banner in live mode', () => {
 });
 
 test('renders multiple contests in order', () => {
-  setPollingPlacesEnabled(true);
-
   const contestWriteIns: ContestWriteIns[] = [
     {
       contestId: 'mayor',
@@ -238,8 +220,6 @@ test('renders multiple contests in order', () => {
 });
 
 test('renders party headers for primary elections', () => {
-  setPollingPlacesEnabled(true);
-
   const primaryElectionDefinition =
     electionTwoPartyPrimaryFixtures.readElectionDefinition();
   const [primaryPollingPlace] = assertDefined(
@@ -280,8 +260,6 @@ test('renders party headers for primary elections', () => {
 });
 
 test('does not render party headers for general elections', () => {
-  setPollingPlacesEnabled(true);
-
   const contestWriteIns: ContestWriteIns[] = [
     {
       contestId: 'mayor',
@@ -299,26 +277,3 @@ test('does not render party headers for general elections', () => {
   expect(screen.queryByText('Mammal Party')).toBeNull();
   expect(screen.queryByText('Fish Party')).toBeNull();
 });
-
-test('renders precinct selection name', () => {
-  setPollingPlacesEnabled(false);
-
-  render(
-    PrecinctScannerWriteInImageReport({
-      ...DEFAULT_PROPS,
-      pollingPlaceId: undefined,
-      precinctSelection: ALL_PRECINCTS_SELECTION,
-      contestWriteIns: [],
-    })
-  );
-
-  screen.getByText('Write-In Image Report • All Precincts');
-});
-
-function setPollingPlacesEnabled(enabled: boolean) {
-  if (enabled) {
-    mockFeatureFlagger.enableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  } else {
-    mockFeatureFlagger.disableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-  }
-}

--- a/libs/ui/src/reports/precinct_scanner_write_in_image_report.tsx
+++ b/libs/ui/src/reports/precinct_scanner_write_in_image_report.tsx
@@ -1,8 +1,4 @@
-import {
-  ElectionDefinition,
-  PrecinctSelection,
-  formatElectionHashes,
-} from '@votingworks/types';
+import { ElectionDefinition, formatElectionHashes } from '@votingworks/types';
 import { unique } from '@votingworks/basics';
 import {
   CachedElectionLookups,
@@ -48,7 +44,6 @@ interface PrecinctScannerWriteInImageReportProps {
   electionDefinition: ElectionDefinition;
   electionPackageHash: string;
   pollingPlaceId?: string;
-  precinctSelection?: PrecinctSelection;
   isLiveMode: boolean;
   reportPrintedTime: number;
   precinctScannerMachineId: string;
@@ -63,7 +58,6 @@ export function PrecinctScannerWriteInImageReport({
   electionDefinition,
   electionPackageHash,
   pollingPlaceId,
-  precinctSelection,
   isLiveMode,
   reportPrintedTime,
   precinctScannerMachineId,
@@ -73,7 +67,6 @@ export function PrecinctScannerWriteInImageReport({
   const locationName = precinctScannerLocationName({
     election,
     pollingPlaceId,
-    precinctSelection,
   });
 
   const relevantPartyIds = unique(contestWriteIns.map((c) => c.partyId));


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/8381

Cleaning up the `ENABLE_POLLING_PLACES` feature flag, now that it's on by default. Removing unused code paths related to precinct selection from the VxScan backend.

## Demo Video or Screenshot
N/A

## Testing Plan
- Existing tests that cover Polling Place code paths are left as is
- Tests specific to precinct selection are deleted
- All other tests migrated over to using polling-place-based configuration

## Checklist
N/A