### PR TITLE
[mark-flow-ui] Remove unused precinct selection code paths

### DIFF
--- a/libs/mark-flow-ui/src/components/insert_card_screen.test.tsx
+++ b/libs/mark-flow-ui/src/components/insert_card_screen.test.tsx
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { ALL_PRECINCTS_SELECTION } from '@votingworks/utils';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 
 import { PollsState } from '@votingworks/types';
@@ -41,7 +40,6 @@ describe('polls states', () => {
     test(`with pollsState = ${spec.pollsState}`, () => {
       render(
         <InsertCardScreen
-          appPrecinct={ALL_PRECINCTS_SELECTION}
           pollingPlaceId="a-polling-place"
           electionDefinition={electionDefinition}
           electionPackageHash="package-hash"
@@ -59,7 +57,6 @@ describe('polls states', () => {
 test('renders election info bar', () => {
   render(
     <InsertCardScreen
-      appPrecinct={ALL_PRECINCTS_SELECTION}
       pollingPlaceId="a-polling-place"
       electionDefinition={electionDefinition}
       electionPackageHash="package-hash"
@@ -74,14 +71,12 @@ test('renders election info bar', () => {
     electionDefinition,
     electionPackageHash: 'package-hash',
     pollingPlaceId: 'a-polling-place',
-    precinctSelection: ALL_PRECINCTS_SELECTION,
   });
 });
 
 test('renders test mode banner in test mode', () => {
   render(
     <InsertCardScreen
-      appPrecinct={ALL_PRECINCTS_SELECTION}
       pollingPlaceId="a-polling-place"
       electionDefinition={electionDefinition}
       electionPackageHash="package-hash"

--- a/libs/mark-flow-ui/src/components/insert_card_screen.tsx
+++ b/libs/mark-flow-ui/src/components/insert_card_screen.tsx
@@ -1,9 +1,5 @@
 import React from 'react';
-import {
-  ElectionDefinition,
-  PollsState,
-  PrecinctSelection,
-} from '@votingworks/types';
+import { ElectionDefinition, PollsState } from '@votingworks/types';
 import {
   Main,
   Screen,
@@ -18,7 +14,6 @@ import {
 import { throwIllegalValue } from '@votingworks/basics';
 
 interface Props {
-  appPrecinct?: PrecinctSelection;
   cardInsertionDirection?: CardInsertionDirection;
   electionDefinition: ElectionDefinition;
   electionPackageHash: string;
@@ -28,7 +23,6 @@ interface Props {
 }
 
 export function InsertCardScreen({
-  appPrecinct,
   cardInsertionDirection,
   electionDefinition,
   electionPackageHash,
@@ -81,7 +75,6 @@ export function InsertCardScreen({
         electionDefinition={electionDefinition}
         electionPackageHash={electionPackageHash}
         pollingPlaceId={pollingPlaceId}
-        precinctSelection={appPrecinct}
       />
     </Screen>
   );

--- a/libs/mark-flow-ui/src/components/unconfigured_polling_place_screen.tsx
+++ b/libs/mark-flow-ui/src/components/unconfigured_polling_place_screen.tsx
@@ -1,8 +1,4 @@
 import { ElectionDefinition } from '@votingworks/types';
-import {
-  BooleanEnvironmentVariableName as Feature,
-  isFeatureFlagEnabled,
-} from '@votingworks/utils';
 import { Main, Screen, ElectionInfoBar, H1, P } from '@votingworks/ui';
 
 interface Props {
@@ -14,21 +10,6 @@ export function UnconfiguredPollingPlaceScreen({
   electionDefinition,
   electionPackageHash,
 }: Props): JSX.Element {
-  if (!isFeatureFlagEnabled(Feature.ENABLE_POLLING_PLACES)) {
-    return (
-      <Screen>
-        <Main centerChild>
-          <H1>No Precinct Selected</H1>
-          <P>Insert an election manager card to select a precinct.</P>
-        </Main>
-        <ElectionInfoBar
-          electionDefinition={electionDefinition}
-          electionPackageHash={electionPackageHash}
-        />
-      </Screen>
-    );
-  }
-
   return (
     <Screen>
       <Main centerChild>

--- a/libs/mark-flow-ui/src/components/unconfigured_precinct_screen.test.tsx
+++ b/libs/mark-flow-ui/src/components/unconfigured_precinct_screen.test.tsx
@@ -1,19 +1,9 @@
 import { beforeEach, expect, test, vi } from 'vitest';
-import {
-  BooleanEnvironmentVariableName as Feature,
-  getFeatureFlagMock,
-} from '@votingworks/utils';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import { assertDefined } from '@votingworks/basics';
 import { ElectionInfoBar, ElectionInfoBarProps } from '@votingworks/ui';
 import { UnconfiguredPollingPlaceScreen } from './unconfigured_polling_place_screen';
 import { render, screen } from '../../test/react_testing_library';
-
-const featureFlagMock = getFeatureFlagMock();
-vi.mock('@votingworks/utils', async (importActual) => ({
-  ...(await importActual()),
-  isFeatureFlagEnabled: (f: Feature) => featureFlagMock.isEnabled(f),
-}));
 
 vi.mock(import('@votingworks/ui'), async (importActual) => ({
   ...(await importActual()),
@@ -25,35 +15,12 @@ const MockElectionInfoBar = vi.mocked(ElectionInfoBar);
 const electionDefinition = readElectionGeneralDefinition();
 
 beforeEach(() => {
-  featureFlagMock.resetFeatureFlags();
   MockElectionInfoBar.mockReturnValue(
     <div data-testid={MOCK_ELECTION_INFO_BAR_ID} />
   );
 });
 
-test('renders note + election info (with precinct selection)', () => {
-  featureFlagMock.disableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-
-  render(
-    <UnconfiguredPollingPlaceScreen
-      electionDefinition={electionDefinition}
-      electionPackageHash="test-hash"
-    />
-  );
-
-  screen.getByRole('heading', { name: 'No Precinct Selected' });
-
-  screen.getByTestId(MOCK_ELECTION_INFO_BAR_ID);
-  const props = assertDefined(MockElectionInfoBar.mock.lastCall)[0];
-  expect(props).toEqual<ElectionInfoBarProps>({
-    electionDefinition,
-    electionPackageHash: 'test-hash',
-  });
-});
-
 test('renders note + election info', () => {
-  featureFlagMock.enableFeatureFlag(Feature.ENABLE_POLLING_PLACES);
-
   render(
     <UnconfiguredPollingPlaceScreen
       electionDefinition={electionDefinition}


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/8381

Mark and MarkScan frontends have both been fully migrated from precinct selection to polling place selection. Cleaning up now-unused paths from shared `mark-flow-ui` components.

## Demo Video or Screenshot
N/A

## Testing Plan
- Existing tests

## Checklist
N/A