### PR TITLE
[VxCentralScan] Add Polling Place Configuration

### DIFF
--- a/apps/central-scan/backend/schema.sql
+++ b/apps/central-scan/backend/schema.sql
@@ -7,6 +7,7 @@ create table election (
   is_test_mode boolean not null default true,
   polls_state text not null default "polls_closed_initial",
   is_sound_muted boolean not null default false,
+  polling_place_id text,
   scanner_backed_up_at datetime,
   created_at timestamp not null default current_timestamp
 );
@@ -15,6 +16,7 @@ create table batches (
   batch_number integer primary key autoincrement,
   id varchar(36) unique,
   label text,
+  polling_place_id text,
   started_at datetime default current_timestamp not null,
   ended_at datetime,
   deleted_at datetime,

--- a/apps/central-scan/backend/src/app.grout.test.ts
+++ b/apps/central-scan/backend/src/app.grout.test.ts
@@ -1,6 +1,7 @@
 import { mockElectionPackageFileTree } from '@votingworks/backend';
 import { err } from '@votingworks/basics';
 import {
+  electionFamousNames2021Fixtures,
   electionGridLayoutNewHampshireTestBallotFixtures,
   readElectionGeneralDefinition,
   readElectionTwoPartyPrimaryDefinition,
@@ -44,6 +45,11 @@ vi.mock(import('@votingworks/utils'), async (importActual) => ({
 }));
 
 const jurisdiction = TEST_JURISDICTION;
+
+// The famous names fixture defines polling places, including a single absentee
+// "Central Scanning" location (id 'central-scanning') covering all precincts.
+const famousNamesDefinition =
+  electionFamousNames2021Fixtures.readElectionDefinition();
 
 let frontImagePath: string;
 let backImagePath: string;
@@ -125,6 +131,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  featureFlagMock.resetFeatureFlags();
 });
 
 test('getElectionDefinition', async () => {
@@ -358,6 +365,48 @@ test('configure with CDF election', async () => {
     // Ensure loading auth election key from db works
     expect(await apiClient.getAuthStatus()).toMatchObject({
       status: 'logged_in',
+    });
+  });
+});
+test('get/set polling place id', async () => {
+  await withApp(async ({ apiClient, auth, importer, store, logger }) => {
+    mockElectionManagerAuth(auth, famousNamesDefinition);
+    importer.configure(
+      famousNamesDefinition,
+      jurisdiction,
+      'test-election-package-hash'
+    );
+
+    // No polling place selected initially (importer.configure does not
+    // auto-select; only the configure-from-USB API does).
+    expect(await apiClient.getPollingPlaceId()).toEqual(null);
+
+    await apiClient.setPollingPlaceId({ id: 'central-scanning' });
+    expect(await apiClient.getPollingPlaceId()).toEqual('central-scanning');
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.PollingPlaceChanged,
+      'election_manager',
+      {
+        disposition: 'success',
+        message: expect.stringContaining('Central Scanning'),
+      }
+    );
+
+    // Setting an unknown polling place id throws.
+    await suppressingConsoleOutput(async () => {
+      await expect(
+        apiClient.setPollingPlaceId({ id: 'nonexistent' })
+      ).rejects.toThrow();
+    });
+
+    // Cannot change the polling place once scanning has begun.
+    store.addBatch();
+    await suppressingConsoleOutput(async () => {
+      await expect(
+        apiClient.setPollingPlaceId({ id: 'central-scanning' })
+      ).rejects.toThrow(
+        'Attempt to change polling place after scanning has begun'
+      );
     });
   });
 });

--- a/apps/central-scan/backend/src/app.grout.test.ts
+++ b/apps/central-scan/backend/src/app.grout.test.ts
@@ -368,6 +368,7 @@ test('configure with CDF election', async () => {
     });
   });
 });
+
 test('get/set polling place id', async () => {
   await withApp(async ({ apiClient, auth, importer, store, logger }) => {
     mockElectionManagerAuth(auth, famousNamesDefinition);
@@ -411,7 +412,82 @@ test('get/set polling place id', async () => {
   });
 });
 
+test('configure auto-selects the single absentee polling place', async () => {
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_ELECTION_PACKAGE_AUTHENTICATION
+  );
+
+  await withApp(async ({ apiClient, auth, mockUsbDrive }) => {
+    mockElectionManagerAuth(auth, famousNamesDefinition);
+    mockUsbDrive.insertUsbDrive(
+      await mockElectionPackageFileTree({
+        electionDefinition: famousNamesDefinition,
+      })
+    );
+
+    (await apiClient.configureFromElectionPackageOnUsbDrive()).unsafeUnwrap();
+
+    expect(await apiClient.getPollingPlaceId()).toEqual('central-scanning');
+  });
+});
+
+test('configure does not auto-select when there are multiple absentee polling places', async () => {
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_ELECTION_PACKAGE_AUTHENTICATION
+  );
+
+  const electionDefinition = safeParseElectionDefinition(
+    JSON.stringify({
+      ...famousNamesDefinition.election,
+      pollingPlaces: [
+        ...(famousNamesDefinition.election.pollingPlaces ?? []),
+        {
+          id: 'central-scanning-2',
+          name: 'Central Scanning 2',
+          precincts: { '20': { type: 'whole' } },
+          type: 'absentee',
+        },
+      ],
+    })
+  ).unsafeUnwrap();
+
+  await withApp(async ({ apiClient, auth, mockUsbDrive }) => {
+    mockElectionManagerAuth(auth, electionDefinition);
+    mockUsbDrive.insertUsbDrive(
+      await mockElectionPackageFileTree({ electionDefinition })
+    );
+
+    (await apiClient.configureFromElectionPackageOnUsbDrive()).unsafeUnwrap();
+
+    expect(await apiClient.getPollingPlaceId()).toEqual(null);
+  });
+});
+
+test('configure does not auto-select when there are no absentee polling places', async () => {
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_ELECTION_PACKAGE_AUTHENTICATION
+  );
+
+  // The two-party primary fixture has no absentee polling places.
+  const electionDefinition = electionTwoPartyPrimaryDefinition;
+
+  await withApp(async ({ apiClient, auth, mockUsbDrive }) => {
+    mockElectionManagerAuth(auth, electionDefinition);
+    mockUsbDrive.insertUsbDrive(
+      await mockElectionPackageFileTree({ electionDefinition })
+    );
+
+    (await apiClient.configureFromElectionPackageOnUsbDrive()).unsafeUnwrap();
+
+    expect(await apiClient.getPollingPlaceId()).toEqual(null);
+  });
+});
+
 test('configure with invalid file', async () => {
+  // Skip signature authentication so the election key mismatch is reached.
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_ELECTION_PACKAGE_AUTHENTICATION
+  );
   await withApp(async ({ apiClient, auth, mockUsbDrive, logger }) => {
     mockElectionManagerAuth(auth, electionGeneralDefinition);
     mockUsbDrive.insertUsbDrive(

--- a/apps/central-scan/backend/src/app.scanning.test.ts
+++ b/apps/central-scan/backend/src/app.scanning.test.ts
@@ -12,8 +12,12 @@ import {
   PageInterpretation,
   TEST_JURISDICTION,
 } from '@votingworks/types';
+import {
+  BooleanEnvironmentVariableName,
+  getFeatureFlagMock,
+} from '@votingworks/utils';
 import { readFile } from 'node:fs/promises';
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 import { mockElectionManagerAuth } from '../test/helpers/auth';
 import { generateBmdBallotFixture } from '../test/helpers/ballots';
 import { withApp } from '../test/helpers/setup_app';
@@ -22,6 +26,17 @@ import { ScannedSheetInfo } from './fujitsu_scanner';
 const jurisdiction = TEST_JURISDICTION;
 
 vi.setConfig({ testTimeout: 20000 });
+
+const featureFlagMock = getFeatureFlagMock();
+vi.mock(import('@votingworks/utils'), async (importActual) => ({
+  ...(await importActual()),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
+
+beforeEach(() => {
+  featureFlagMock.resetFeatureFlags();
+});
 
 test('scanBatch with multiple sheets', async () => {
   const electionDefinition =
@@ -40,6 +55,9 @@ test('scanBatch with multiple sheets', async () => {
     );
     workspace.store.setSystemSettings(DEFAULT_SYSTEM_SETTINGS);
     await apiClient.setTestMode({ testMode: true });
+    // The scanned ballot is for precinct '23', which is covered by
+    // '23-polling-place', so all sheets are accepted.
+    await apiClient.setPollingPlaceId({ id: '23-polling-place' });
 
     scanner
       .withNextScannerSession()
@@ -62,6 +80,7 @@ test('scanBatch with multiple sheets', async () => {
       count: 3,
       startedAt: expect.any(String),
       endedAt: expect.any(String),
+      pollingPlaceId: '23-polling-place',
     });
   });
 });
@@ -79,6 +98,7 @@ test('continueScanning after invalid ballot', async () => {
     );
     workspace.store.setSystemSettings(DEFAULT_SYSTEM_SETTINGS);
     await apiClient.setTestMode({ testMode: true });
+    await apiClient.setPollingPlaceId({ id: 'central-scanning' });
 
     scanner
       .withNextScannerSession()
@@ -105,6 +125,7 @@ test('continueScanning after invalid ballot', async () => {
         count: 2,
         startedAt: expect.any(String),
         endedAt: undefined, // not ended
+        pollingPlaceId: 'central-scanning',
       });
     }
     await apiClient.continueScanning({ forceAccept: false });
@@ -121,6 +142,7 @@ test('continueScanning after invalid ballot', async () => {
         count: 2, // bad ballot removed
         startedAt: expect.any(String),
         endedAt: expect.any(String),
+        pollingPlaceId: 'central-scanning',
       });
     }
   });
@@ -174,6 +196,7 @@ test('scanBatch with streaked page', async () => {
       disableVerticalStreakDetection: false,
     });
     await apiClient.setTestMode({ testMode: true });
+    await apiClient.setPollingPlaceId({ id: 'central-scanning' });
 
     scanner.withNextScannerSession().sheet(scannedBallot).end();
 
@@ -205,6 +228,7 @@ test('scanBatch with streaked page', async () => {
       disableVerticalStreakDetection: true,
     });
     await apiClient.setTestMode({ testMode: true });
+    await apiClient.setPollingPlaceId({ id: 'central-scanning' });
 
     scanner.withNextScannerSession().sheet(scannedBallot).end();
 
@@ -213,5 +237,39 @@ test('scanBatch with streaked page', async () => {
 
     // no adjudication should be needed
     expect(workspace.store.getNextAdjudicationSheet()).toBeUndefined();
+  });
+});
+
+test('rejects ballots whose precinct is not in the selected polling place', async () => {
+  // The famous names fixture's ballot is for precinct '23'. Select the
+  // '20-polling-place' location (which covers only precinct '20') so the
+  // scanned ballot is rejected as being outside the selected polling place.
+  const bmdFixture = await generateBmdBallotFixture();
+  const scannedBallot: ScannedSheetInfo = {
+    frontPath: bmdFixture.sheet[0],
+    backPath: bmdFixture.sheet[1],
+  };
+
+  await withApp(async ({ auth, apiClient, scanner, importer, workspace }) => {
+    mockElectionManagerAuth(auth, bmdFixture.electionDefinition);
+    importer.configure(
+      bmdFixture.electionDefinition,
+      jurisdiction,
+      'test-election-package-hash'
+    );
+    workspace.store.setSystemSettings(DEFAULT_SYSTEM_SETTINGS);
+    await apiClient.setTestMode({ testMode: true });
+    await apiClient.setPollingPlaceId({ id: '20-polling-place' });
+
+    scanner.withNextScannerSession().sheet(scannedBallot).end();
+
+    await apiClient.scanBatch();
+    await importer.waitForEndOfBatchOrScanningPause();
+
+    const nextAdjudicationSheet = workspace.store.getNextAdjudicationSheet();
+    expect(nextAdjudicationSheet?.pages[0]).toMatchObject({
+      type: 'InvalidPrecinctPage',
+      metadata: expect.objectContaining({ precinctId: '23' }),
+    });
   });
 });

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -184,6 +184,13 @@ function buildApi({
       );
       store.setSystemSettings(systemSettings);
 
+      const absenteePollingPlaces = assertDefined(
+        electionDefinition.election.pollingPlaces
+      ).filter((pollingPlace) => pollingPlace.type === 'absentee');
+      if (absenteePollingPlaces.length === 1) {
+        store.setPollingPlaceId(absenteePollingPlaces[0].id);
+      }
+
       await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
         message: `Machine configured for election with hash: ${electionDefinition.ballotHash}`,
         disposition: 'success',

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -19,6 +19,7 @@ import {
   DiagnosticOutcome,
   Rect,
   mapSheet,
+  pollingPlaceFromElection,
   SheetInterpretation,
   SheetOf,
 } from '@votingworks/types';
@@ -198,6 +199,30 @@ function buildApi({
 
     getElectionRecord(): ElectionRecord | null {
       return store.getElectionRecord() || null;
+    },
+
+    getPollingPlaceId(): string | null {
+      return store.getPollingPlaceId() ?? null;
+    },
+
+    setPollingPlaceId(input: { id: string }): void {
+      const electionRecord = assertDefined(
+        store.getElectionRecord(),
+        'Cannot set polling place without an election.'
+      );
+      assert(
+        store.getBatches().length === 0,
+        'Attempt to change polling place after scanning has begun'
+      );
+      const { name } = pollingPlaceFromElection(
+        electionRecord.electionDefinition.election,
+        input.id
+      );
+      store.setPollingPlaceId(input.id);
+      void logger.logAsCurrentRole(LogEventId.PollingPlaceChanged, {
+        disposition: 'success',
+        message: `User set the polling place for the machine to ${name}`,
+      });
     },
 
     getStatus(): ScanStatus {

--- a/apps/central-scan/backend/src/end_to_end_bmd.test.ts
+++ b/apps/central-scan/backend/src/end_to_end_bmd.test.ts
@@ -96,9 +96,17 @@ test('going through the whole process works - BMD', async () => {
         )[0];
         expect(cvrReportDirectoryPath).toContain('TEST__machine_0000__');
 
-        const { castVoteRecordIterator } = (
+        const { castVoteRecordExportMetadata, castVoteRecordIterator } = (
           await readCastVoteRecordExport(cvrReportDirectoryPath)
         ).unsafeUnwrap();
+
+        // The configured polling place is exported with the batch metadata.
+        // Famous names has a single absentee polling place, which is
+        // auto-selected on configuration.
+        expect(
+          castVoteRecordExportMetadata.batchManifest[0].pollingPlaceId
+        ).toEqual('central-scanning');
+
         const cvrs: CVR.CVR[] = (await castVoteRecordIterator.toArray()).map(
           (castVoteRecordResult) =>
             castVoteRecordResult.unsafeUnwrap().castVoteRecord

--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -11,6 +11,8 @@ import {
   Id,
   PageInterpretation,
   PageInterpretationWithFiles,
+  pollingPlaceFromElection,
+  pollingPlacePrecinctIds,
   SheetOf,
 } from '@votingworks/types';
 import makeDebug from 'debug';
@@ -39,7 +41,6 @@ import {
 import { ScanStatus } from './types';
 
 const debug = makeDebug('scan:importer');
-
 export interface Options {
   workspace: Workspace;
   scanner: BatchScanner;
@@ -228,12 +229,14 @@ export class Importer {
       maxCumulativeStreakWidth,
       retryStreakWidthThreshold,
     } = assertDefined(store.getSystemSettings());
-    const { precincts } = electionDefinition.election;
 
+    const pollingPlaceId = assertDefined(store.getPollingPlaceId());
     return await interpretSheetAndSaveImages(
       {
         electionDefinition,
-        validPrecinctIds: new Set(precincts.map((p) => p.id)),
+        validPrecinctIds: pollingPlacePrecinctIds(
+          pollingPlaceFromElection(electionDefinition.election, pollingPlaceId)
+        ),
         testMode: store.getTestMode(),
         disableVerticalStreakDetection,
         adjudicationReasons: store.getAdjudicationReasons(),

--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -56,6 +56,50 @@ test('get/set election', () => {
   expect(store.getElectionRecord()).toBeUndefined();
 });
 
+test('get/set polling place id', () => {
+  const store = Store.memoryStore();
+
+  // Cannot set a polling place without an election
+  expect(() => store.setPollingPlaceId('pp-1')).toThrowError();
+
+  store.setElectionAndJurisdiction({
+    electionData,
+    jurisdiction,
+    electionPackageHash,
+  });
+  expect(store.getPollingPlaceId()).toBeUndefined();
+
+  store.setPollingPlaceId('pp-1');
+  expect(store.getPollingPlaceId()).toEqual('pp-1');
+
+  store.setPollingPlaceId(null);
+  expect(store.getPollingPlaceId()).toBeUndefined();
+});
+
+test('addBatch stamps the selected polling place id', () => {
+  const store = Store.memoryStore();
+  store.setElectionAndJurisdiction({
+    electionData,
+    jurisdiction,
+    electionPackageHash,
+  });
+
+  // No polling place selected: batch is untagged
+  const untaggedBatchId = store.addBatch();
+
+  // Once a polling place is selected, subsequent batches are tagged with it
+  store.setPollingPlaceId('pp-1');
+  const taggedBatchId = store.addBatch();
+
+  const batches = store.getBatches();
+  expect(
+    batches.find((batch) => batch.id === untaggedBatchId)?.pollingPlaceId
+  ).toBeUndefined();
+  expect(
+    batches.find((batch) => batch.id === taggedBatchId)?.pollingPlaceId
+  ).toEqual('pp-1');
+});
+
 test('get/set test mode', () => {
   const store = Store.memoryStore();
 

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -280,6 +280,26 @@ export class Store {
   }
 
   /**
+   * Gets the polling place where ballots are being centrally scanned, if one
+   * has been selected.
+   */
+  getPollingPlaceId(): Optional<string> {
+    const row = this.client.one('select polling_place_id from election') as
+      | { polling_place_id: string | null }
+      | undefined;
+
+    return row?.polling_place_id || undefined;
+  }
+
+  /**
+   * Sets the polling place where ballots are being centrally scanned.
+   */
+  setPollingPlaceId(id: string | null): void {
+    assert(this.hasElection(), 'Cannot set polling place without an election.');
+    this.client.run('update election set polling_place_id = ?', id);
+  }
+
+  /**
    * Deletes system settings
    */
   deleteSystemSettings(): void {
@@ -422,7 +442,12 @@ export class Store {
    */
   addBatch(): string {
     const id = uuid();
-    this.client.run('insert into batches (id) values (?)', id);
+    const pollingPlaceId = this.getPollingPlaceId() || null;
+    this.client.run(
+      'insert into batches (id, polling_place_id) values (?, ?)',
+      id,
+      pollingPlaceId
+    );
     this.client.run(
       `update batches set label = 'Batch ' || batch_number WHERE id = ?`,
       id
@@ -764,6 +789,7 @@ export class Store {
       id: string;
       batchNumber: number;
       label: string;
+      pollingPlaceId: string | null;
       startedAt: string;
       endedAt: string | null;
       error: string | null;
@@ -774,6 +800,7 @@ export class Store {
         batches.id as id,
         batches.batch_number as batchNumber,
         batches.label as label,
+        batches.polling_place_id as pollingPlaceId,
         strftime('%s', started_at) as startedAt,
         (case when ended_at is null then ended_at else strftime('%s', ended_at) end) as endedAt,
         error,
@@ -798,6 +825,7 @@ export class Store {
       id: info.id,
       batchNumber: info.batchNumber,
       label: info.label,
+      pollingPlaceId: info.pollingPlaceId || undefined,
       // eslint-disable-next-line vx/gts-safe-number-parse
       startedAt: DateTime.fromSeconds(Number(info.startedAt)).toISO(),
       endedAt:

--- a/apps/central-scan/frontend/src/api.ts
+++ b/apps/central-scan/frontend/src/api.ts
@@ -190,6 +190,16 @@ export const getNextReviewSheet = {
   },
 } as const;
 
+export const getPollingPlaceId = {
+  queryKey(): QueryKey {
+    return ['getPollingPlaceId'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () => apiClient.getPollingPlaceId());
+  },
+} as const;
+
 // Mutations
 
 export const setTestMode = {
@@ -199,6 +209,19 @@ export const setTestMode = {
     return useMutation(apiClient.setTestMode, {
       async onSuccess() {
         await queryClient.invalidateQueries(getTestMode.queryKey());
+      },
+    });
+  },
+} as const;
+
+export const setPollingPlaceId = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.setPollingPlaceId, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getPollingPlaceId.queryKey());
+        await queryClient.invalidateQueries(getStatus.queryKey());
       },
     });
   },
@@ -284,6 +307,8 @@ export const configureFromElectionPackageOnUsbDrive = {
       async onSuccess() {
         await queryClient.invalidateQueries(getSystemSettings.queryKey());
         await queryClient.invalidateQueries(getElectionRecord.queryKey());
+        // Configuring may auto-select a polling place.
+        await queryClient.invalidateQueries(getPollingPlaceId.queryKey());
       },
     });
   },

--- a/apps/central-scan/frontend/src/app.test.tsx
+++ b/apps/central-scan/frontend/src/app.test.tsx
@@ -40,6 +40,7 @@ beforeEach(() => {
   apiMock.expectGetSystemSettings();
   apiMock.expectGetMachineConfig();
   apiMock.setStatus();
+  apiMock.expectGetPollingPlaceId('23-polling-place');
 });
 
 afterEach(() => {

--- a/apps/central-scan/frontend/src/app_polling_place.test.tsx
+++ b/apps/central-scan/frontend/src/app_polling_place.test.tsx
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, expect, test } from 'vitest';
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { constructElectionKey, ElectionDefinition } from '@votingworks/types';
+import {
+  mockElectionManagerUser,
+  mockSessionExpiresAt,
+} from '@votingworks/test-utils';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '../test/react_testing_library';
+import { App } from './app';
+import { ApiMock, createApiMock } from '../test/api';
+
+// The famous names fixture defines a 'central-scanning' absentee polling place.
+const electionDefinition =
+  electionFamousNames2021Fixtures.readElectionDefinition();
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  // Reset the URL since navigation in one test persists into the next.
+  window.history.replaceState({}, '', '/');
+  apiMock = createApiMock();
+  apiMock.setAuthStatus({ status: 'logged_out', reason: 'machine_locked' });
+  apiMock.setUsbDriveStatus({ status: 'no_drive' });
+  apiMock.expectGetSystemSettings();
+  apiMock.expectGetMachineConfig();
+  apiMock.setStatus();
+  apiMock.expectGetTestMode(false);
+});
+
+afterEach(() => {
+  apiMock.assertComplete();
+});
+
+function logInAsElectionManager(electionForKey: ElectionDefinition) {
+  apiMock.setAuthStatus({
+    status: 'logged_in',
+    user: mockElectionManagerUser({
+      electionKey: constructElectionKey(electionForKey.election),
+    }),
+    sessionExpiresAt: mockSessionExpiresAt(),
+  });
+}
+
+test('warns and disables scanning when no polling place is selected', async () => {
+  apiMock.expectGetElectionRecord(electionDefinition);
+  apiMock.expectGetPollingPlaceId(null);
+  render(<App apiClient={apiMock.apiClient} />);
+
+  await screen.findByText('VxCentralScan Locked');
+  logInAsElectionManager(electionDefinition);
+
+  await screen.findByText(/No polling place selected/);
+  expect(screen.getButton('Scan New Batch')).toBeDisabled();
+
+  // The user can navigate to the settings screen to select a polling place.
+  userEvent.click(screen.getByText('Settings'));
+  await screen.findByRole('heading', { name: 'Polling Place' });
+});
+
+test('does not warn when a polling place is already selected', async () => {
+  apiMock.expectGetElectionRecord(electionDefinition);
+  apiMock.expectGetPollingPlaceId('central-scanning');
+  render(<App apiClient={apiMock.apiClient} />);
+
+  await screen.findByText('VxCentralScan Locked');
+  logInAsElectionManager(electionDefinition);
+
+  await screen.findByText('Scan New Batch');
+  expect(screen.getButton('Scan New Batch')).toBeEnabled();
+  expect(
+    screen.queryByText(/No polling place selected/)
+  ).not.toBeInTheDocument();
+});

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -29,6 +29,7 @@ import {
   getAuthStatus,
   getElectionRecord,
   getMachineConfig,
+  getPollingPlaceId,
   getStatus,
   getTestMode,
   getUsbDriveStatus,
@@ -58,6 +59,7 @@ export function AppRoot({ logger }: AppRootProps): JSX.Element | null {
   const isTestMode = getTestModeQuery.data ?? false;
 
   const electionRecordQuery = getElectionRecord.useQuery();
+  const pollingPlaceIdQuery = getPollingPlaceId.useQuery();
 
   if (
     !machineConfigQuery.isSuccess ||
@@ -65,7 +67,8 @@ export function AppRoot({ logger }: AppRootProps): JSX.Element | null {
     !usbDriveStatusQuery.isSuccess ||
     !electionRecordQuery.isSuccess ||
     !getTestModeQuery.isSuccess ||
-    !statusQuery.isSuccess
+    !statusQuery.isSuccess ||
+    !pollingPlaceIdQuery.isSuccess
   ) {
     return (
       <Screen>
@@ -186,6 +189,9 @@ export function AppRoot({ logger }: AppRootProps): JSX.Element | null {
     );
   }
 
+  // A polling place must be selected before scanning.
+  const isPollingPlaceUnconfigured = !pollingPlaceIdQuery.data;
+
   if (status.adjudicationsRemaining > 0) {
     return (
       <AppContext.Provider value={currentContext}>
@@ -202,10 +208,14 @@ export function AppRoot({ logger }: AppRootProps): JSX.Element | null {
           <ScanBallotsScreen
             status={status}
             statusIsStale={statusQuery.isStale}
+            isPollingPlaceUnconfigured={isPollingPlaceUnconfigured}
           />
         </Route>
         <Route path="/settings">
-          <SettingsScreen canUnconfigure={status.canUnconfigure} />
+          <SettingsScreen
+            canUnconfigure={status.canUnconfigure}
+            hasScannedBatches={status.batches.length > 0}
+          />
         </Route>
         <Route path="/hardware-diagnostics">
           <DiagnosticsScreen />

--- a/apps/central-scan/frontend/src/app_vendor_screen.test.tsx
+++ b/apps/central-scan/frontend/src/app_vendor_screen.test.tsx
@@ -23,6 +23,7 @@ beforeEach(() => {
   apiMock.expectGetSystemSettings();
   apiMock.expectGetMachineConfig();
   apiMock.setStatus();
+  apiMock.expectGetPollingPlaceId();
   apiMock.setDiskSpaceSummary();
 });
 

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
@@ -456,3 +456,23 @@ test('ballot with invalid scale', async () => {
   apiMock.expectContinueScanning({ forceAccept: false });
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 });
+
+test('ballot from a precinct not in the selected polling place', async () => {
+  apiMock.expectGetNextReviewSheet(
+    buildNextReviewSheet({
+      type: 'InvalidSheet',
+      reason: { type: 'invalid_precinct' },
+    })
+  );
+
+  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
+
+  await screen.findByText('Wrong Precinct');
+  screen.getByText(
+    "The last scanned ballot was not tabulated because the scanner is configured for a polling place that does not include the ballot's precinct."
+  );
+  expect(screen.queryAllByText('Tabulate Ballot').length).toEqual(0);
+
+  apiMock.expectContinueScanning({ forceAccept: false });
+  userEvent.click(screen.getByText('Confirm Ballot Removed'));
+});

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
@@ -191,6 +191,21 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
           };
 
         case 'invalid_precinct':
+          return {
+            header: 'Wrong Precinct',
+            body: (
+              <React.Fragment>
+                <P>
+                  The last scanned ballot was not tabulated because the scanner
+                  is configured for a polling place that does not include the
+                  ballot&apos;s precinct.
+                </P>
+                <P>Remove the ballot before continuing.</P>
+              </React.Fragment>
+            ),
+            allowBallotDuplication: false,
+          };
+
         case 'bmd_ballot_scanning_disabled':
         case 'unreadable':
         case 'unknown':

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
@@ -26,11 +26,18 @@ function renderScreen(props?: Partial<ScanBallotsScreenProps>) {
     <ScanBallotsScreen
       status={mockStatus()}
       statusIsStale={false}
+      isPollingPlaceUnconfigured={false}
       {...props}
     />,
     { apiMock }
   );
 }
+
+test('warns and disables scanning when a polling place needs to be selected', () => {
+  renderScreen({ isPollingPlaceUnconfigured: true });
+  screen.getByText(/No polling place selected/);
+  expect(screen.getButton('Scan New Batch')).toBeDisabled();
+});
 
 test('null state', () => {
   renderScreen();

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
@@ -74,11 +74,13 @@ const DeleteAllWrapper = styled.div`
 export interface ScanBallotsScreenProps {
   status: ScanStatus;
   statusIsStale: boolean;
+  isPollingPlaceUnconfigured: boolean;
 }
 
 export function ScanBallotsScreen({
   status,
   statusIsStale,
+  isPollingPlaceUnconfigured,
 }: ScanBallotsScreenProps): JSX.Element {
   const isScanning = !!status.ongoingBatchId;
   const { batches } = status;
@@ -117,6 +119,12 @@ export function ScanBallotsScreen({
   return (
     <NavigationScreen title="Scan Ballots">
       <Content>
+        {isPollingPlaceUnconfigured && (
+          <Callout color="warning" icon="Warning">
+            No polling place selected. Select a polling place on the Settings
+            screen before scanning ballots.
+          </Callout>
+        )}
         <TopBar>
           {batchCount ? (
             <TopBarStats color="neutral" style={{ gap: '3rem' }}>
@@ -148,7 +156,9 @@ export function ScanBallotsScreen({
             </Button>
             <ScanButton
               /* disable scan button while status query is refetching to avoid double clicks */
-              disabled={isScanning || statusIsStale}
+              disabled={
+                isScanning || statusIsStale || isPollingPlaceUnconfigured
+              }
               isScannerAttached={status.isScannerAttached}
             />
           </TopBarActions>

--- a/apps/central-scan/frontend/src/screens/settings_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/settings_screen.test.tsx
@@ -1,10 +1,15 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import { screen, within } from '../../test/react_testing_library';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { SettingsScreenProps, SettingsScreen } from './settings_screen';
 import { ApiMock, createApiMock } from '../../test/api';
+
+// The famous names fixture defines a 'central-scanning' absentee polling place.
+const electionWithPollingPlaces =
+  electionFamousNames2021Fixtures.readElectionDefinition();
 
 let apiMock: ApiMock;
 
@@ -12,6 +17,7 @@ beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetTestMode(false);
   apiMock.setStatus();
+  apiMock.expectGetPollingPlaceId();
 });
 
 afterEach(() => {
@@ -23,7 +29,11 @@ function renderScreen(
   history = createMemoryHistory()
 ) {
   return renderInAppContext(
-    <SettingsScreen canUnconfigure={false} {...props} />,
+    <SettingsScreen
+      canUnconfigure={false}
+      hasScannedBatches={false}
+      {...props}
+    />,
     { apiMock, history }
   );
 }
@@ -89,4 +99,30 @@ test('clicking "Update Date and Time" shows modal to set clock', async () => {
   });
 
   vi.useRealTimers();
+});
+
+test('shows a polling place picker when the election has polling places', async () => {
+  apiMock.expectSetPollingPlaceId({ id: 'central-scanning' });
+  renderInAppContext(
+    <SettingsScreen canUnconfigure={false} hasScannedBatches={false} />,
+    { apiMock, electionDefinition: electionWithPollingPlaces }
+  );
+
+  await screen.findByRole('heading', { name: 'Polling Place' });
+  userEvent.click(screen.getByLabelText('Select a polling place…'));
+  userEvent.click(screen.getByText('Central Scanning'));
+  await vi.waitFor(() => apiMock.assertComplete());
+});
+
+test('disables the polling place picker after scanning has begun', async () => {
+  renderInAppContext(
+    <SettingsScreen canUnconfigure={false} hasScannedBatches />,
+    { apiMock, electionDefinition: electionWithPollingPlaces }
+  );
+
+  await screen.findByRole('heading', { name: 'Polling Place' });
+  expect(screen.getByLabelText('Select a polling place…')).toBeDisabled();
+  screen.getByText(
+    'The polling place cannot be changed after scanning has begun.'
+  );
 });

--- a/apps/central-scan/frontend/src/screens/settings_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/settings_screen.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { assert } from '@votingworks/basics';
+import { assert, assertDefined } from '@votingworks/basics';
 import {
   Caption,
   CurrentDateAndTime,
@@ -7,6 +7,7 @@ import {
   H2,
   Icons,
   P,
+  PollingPlacePicker,
   SetClockButton,
   SignedHashValidationButton,
   UnconfigureMachineButton,
@@ -16,7 +17,14 @@ import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import { ToggleTestModeButton } from '../components/toggle_test_mode_button';
 import { AppContext } from '../contexts/app_context';
-import { logOut, unconfigure, ejectUsbDrive, useApiClient } from '../api';
+import {
+  ejectUsbDrive,
+  getPollingPlaceId,
+  logOut,
+  setPollingPlaceId,
+  unconfigure,
+  useApiClient,
+} from '../api';
 import { NavigationScreen } from '../navigation_screen';
 
 const ButtonRow = styled.div`
@@ -27,18 +35,25 @@ const ButtonRow = styled.div`
 
 export interface SettingsScreenProps {
   canUnconfigure: boolean;
+  hasScannedBatches: boolean;
 }
 
 export function SettingsScreen({
   canUnconfigure,
+  hasScannedBatches,
 }: SettingsScreenProps): JSX.Element {
   const history = useHistory();
-  const { auth, usbDriveStatus } = useContext(AppContext);
+  const { auth, electionDefinition, usbDriveStatus } = useContext(AppContext);
   assert(isElectionManagerAuth(auth));
   const apiClient = useApiClient();
   const logOutMutation = logOut.useMutation();
   const unconfigureMutation = unconfigure.useMutation();
   const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
+  const pollingPlaceIdQuery = getPollingPlaceId.useQuery();
+  const setPollingPlaceIdMutation = setPollingPlaceId.useMutation();
+
+  const { election } = assertDefined(electionDefinition);
+  const pollingPlaces = assertDefined(election.pollingPlaces);
 
   async function unconfigureMachine() {
     try {
@@ -66,6 +81,25 @@ export function SettingsScreen({
         <Caption>
           <Icons.Warning color="warning" /> You must save CVRs before you can
           unconfigure this machine.
+        </Caption>
+      )}
+
+      <H2>Polling Place</H2>
+      <P>
+        <PollingPlacePicker
+          mode={hasScannedBatches ? 'disabled' : 'default'}
+          includedTypes={['absentee', 'election_day', 'early_voting']}
+          places={pollingPlaces}
+          selectedId={pollingPlaceIdQuery.data ?? undefined}
+          selectPlace={(id) => setPollingPlaceIdMutation.mutateAsync({ id })}
+          searchable
+          style={{ width: '16rem' }}
+        />
+      </P>
+      {hasScannedBatches && (
+        <Caption>
+          <Icons.Warning color="warning" /> The polling place cannot be changed
+          after scanning has begun.
         </Caption>
       )}
 

--- a/apps/central-scan/frontend/test/api.tsx
+++ b/apps/central-scan/frontend/test/api.tsx
@@ -122,6 +122,16 @@ export function createApiMock(
       apiClient.getTestMode.expectRepeatedCallsWith().resolves(testMode);
     },
 
+    expectGetPollingPlaceId(pollingPlaceId: string | null = null) {
+      apiClient.getPollingPlaceId
+        .expectRepeatedCallsWith()
+        .resolves(pollingPlaceId);
+    },
+
+    expectSetPollingPlaceId(input: { id: string }) {
+      apiClient.setPollingPlaceId.expectCallWith(input).resolves();
+    },
+
     expectConfigure(electionDefinition: ElectionDefinition) {
       apiClient.configureFromElectionPackageOnUsbDrive
         .expectCallWith()

--- a/libs/ui/src/polling_place_picker.test.tsx
+++ b/libs/ui/src/polling_place_picker.test.tsx
@@ -144,6 +144,27 @@ describe('dropdown contents', () => {
   }
 });
 
+test('orders types according to the order of includedTypes', () => {
+  render(
+    <PollingPlacePicker
+      mode="default"
+      includedTypes={['absentee', 'election_day', 'early_voting']}
+      places={ALL_PLACES}
+      selectPlace={vi.fn(() => Promise.resolve())}
+    />
+  );
+
+  userEvent.click(getDropdown());
+  expect(getAllOptions().map((opt) => opt.textContent)).toEqual([
+    `Absentee Voting${absentee1.name}`,
+    `Absentee Voting${absentee2.name}`,
+    `Election Day${electionDay1.name}`,
+    `Election Day${electionDay2.name}`,
+    `Early Voting${earlyVoting1.name}`,
+    `Early Voting${earlyVoting2.name}`,
+  ]);
+});
+
 test('default mode - changing selection triggers callback', () => {
   const mockSelectPlace = vi.fn().mockResolvedValueOnce(undefined);
   render(

--- a/libs/ui/src/polling_place_picker.tsx
+++ b/libs/ui/src/polling_place_picker.tsx
@@ -36,6 +36,10 @@ export type PollingPlacePickerMode =
   | 'disabled';
 
 export interface PollingPlacePickerProps {
+  /**
+   * The polling place types to show, listed in the order given. Defaults to
+   * early voting, then election day, then absentee.
+   */
   includedTypes?: PollingPlaceType[];
   mode: PollingPlacePickerMode;
   places: readonly PollingPlace[];
@@ -46,7 +50,7 @@ export interface PollingPlacePickerProps {
 }
 
 export function PollingPlacePicker({
-  includedTypes = ['absentee', 'early_voting', 'election_day'],
+  includedTypes = ['early_voting', 'election_day', 'absentee'],
   mode,
   places,
   selectedId,
@@ -89,16 +93,8 @@ export function PollingPlacePicker({
     const allGroups = pollingPlaceGroups(places);
     const grouped: PollingPlace[] = [];
 
-    const orderedTypes: PollingPlaceType[] = [
-      'early_voting',
-      'election_day',
-      'absentee',
-    ];
-
     let nVisibleGroups = 0;
-    for (const type of orderedTypes) {
-      if (!includedTypes.includes(type)) continue;
-
+    for (const type of includedTypes) {
       const group = allGroups[type];
       grouped.push(...group);
       if (group.length > 0) nVisibleGroups += 1;


### PR DESCRIPTION
## Overview
Adds logic to VxCentralScan to:
- Expect configuration to a polling place 
- Add a UI for configuring the polling place 
- Automatically set the polling place when there is only 1 absentee polling place in the election
- Reject ballots from precincts outside of the configured polling place

Best reviewed by commit. 

## Demo Video or Screenshot
<img width="1261" height="725" alt="Screenshot 2026-06-10 at 4 52 45 PM" src="https://github.com/user-attachments/assets/9925ae44-f2f1-4af9-a96e-5c0d1ffcd6c5" />
<img width="1274" height="732" alt="Screenshot 2026-06-10 at 5 04 04 PM" src="https://github.com/user-attachments/assets/573df02f-9a1a-427b-afad-88fca7601099" />
<img width="1282" height="730" alt="Screenshot 2026-06-10 at 4 59 15 PM" src="https://github.com/user-attachments/assets/7eab51de-07c7-4448-bd03-c9c374760be2" />
<img width="1271" height="752" alt="Screenshot 2026-06-10 at 4 53 10 PM" src="https://github.com/user-attachments/assets/26ab9bc8-d33d-4b20-b782-01e42a2f5f3a" />
<img width="1271" height="721" alt="Screenshot 2026-06-10 at 4 52 54 PM" src="https://github.com/user-attachments/assets/e7334839-8bad-4edd-9c08-e9a8f5dc4217" />
<img width="1911" height="1080" alt="Screenshot 2026-06-11 at 9 47 23 AM" src="https://github.com/user-attachments/assets/39ca0e67-68a6-4a28-b4fa-dcc6cc6ef919" />


## Testing Plan
Manually tested with elections mimicking the setup of mi, ms and nh configurations and saw expected behavior. Scanned ballots in wrong precinct. 

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
