### PR TITLE
Remove AnyContest, ContestLike, and Contests types

### DIFF
--- a/apps/admin/backend/src/exports/csv_tally_report.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.ts
@@ -4,7 +4,6 @@ import {
   Tabulation,
   ElectionDefinition,
   Id,
-  AnyContest,
   Election,
 } from '@votingworks/types';
 import { Optional, assert, assertDefined } from '@votingworks/basics';
@@ -135,7 +134,7 @@ function* generateDataRows({
         filter: groupFilter,
       })
     );
-    const includedContests: AnyContest[] = [];
+    const includedContests: Contest[] = [];
     for (const contest of election.contests) {
       if (contestIds.has(contest.id)) {
         includedContests.push(contest);

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -18,7 +18,7 @@ import {
 import { Bindable, Client as DbClient, Statement } from '@votingworks/db';
 import {
   AdjudicationReason,
-  AnyContest,
+  Contest,
   BallotId,
   BallotPageLayout,
   BallotPageLayoutSchema,
@@ -699,7 +699,7 @@ export class Store implements BaseStore {
     sortIndex,
   }: {
     electionId: Id;
-    contest: AnyContest;
+    contest: Contest;
     sortIndex: number;
   }): void {
     this.client.run(

--- a/apps/admin/backend/src/tabulation/write_ins.ts
+++ b/apps/admin/backend/src/tabulation/write_ins.ts
@@ -1,5 +1,5 @@
 import {
-  AnyContest,
+  Contest,
   ContestId,
   Election,
   ElectionDefinition,
@@ -402,7 +402,7 @@ export function modifyElectionResultsWithWriteInSummary(
 function combineContestWriteInSummaries(
   summaryA: Tabulation.ContestWriteInSummary,
   summaryB: Tabulation.ContestWriteInSummary,
-  contest: AnyContest
+  contest: Contest
 ): Tabulation.ContestWriteInSummary {
   const combinedCandidateTallies: Tabulation.ContestWriteInSummary['candidateTallies'] =
     {};

--- a/apps/admin/backend/src/util/cast_vote_records.ts
+++ b/apps/admin/backend/src/util/cast_vote_records.ts
@@ -1,6 +1,6 @@
 import {
   AdjudicationReason,
-  AnyContest,
+  Contest,
   ContestOptionId,
   ElectionDefinition,
   MarkThresholds,
@@ -16,7 +16,7 @@ import {
 /**
  * Returns the number of allowed votes for the contest
  */
-export function getNumberVotesAllowed(contest: AnyContest): number {
+export function getNumberVotesAllowed(contest: Contest): number {
   if (contest.type === 'yesno') {
     return 1;
   }
@@ -118,7 +118,7 @@ export function deriveCvrContestTag({
   markThresholds,
   adminAdjudicationReasons,
 }: {
-  contest: AnyContest;
+  contest: Contest;
   votes: ContestOptionId[];
   writeInRecords: WriteInRecord[];
   markScores?: Record<ContestOptionId, number>;

--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import {
-  AnyContest,
+  Contest,
   CandidateContest,
   ContestId,
   Election,
@@ -121,7 +121,7 @@ const StatusLineAdjudicated = styled(StatusLine).attrs({
   /* stylelint-disable-next-line no-empty-source */
 `;
 
-function getVotesAllowed(contest: AnyContest): number {
+function getVotesAllowed(contest: Contest): number {
   return contest.type === 'yesno' ? 1 : contest.seats;
 }
 
@@ -191,7 +191,7 @@ function getAdjudicatedContestStatusLine(
 
 function getAdjudicatedOptionStatusLine(
   option: ContestOptionAdjudicationData,
-  contest: AnyContest,
+  contest: Contest,
   adjudicatedOption?: AdjudicatedContestOption
 ): React.ReactNode {
   const { definition, scannedVote, hasMarginalMark, writeInRecord } = option;

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -15,7 +15,7 @@ import {
   Tabulation,
   CandidateId,
   Admin as AdminTypes,
-  AnyContest,
+  Contest,
   getPrecinctById,
   BallotStyleGroupId,
   Contests,
@@ -299,7 +299,7 @@ interface FormWriteInCandidate {
 }
 
 function emptyFormContestResults(
-  contest: AnyContest,
+  contest: Contest,
   ballotCount?: number
 ): FormContestResults {
   switch (contest.type) {

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -18,7 +18,6 @@ import {
   Contest,
   getPrecinctById,
   BallotStyleGroupId,
-  Contests,
   Precinct,
   Election,
 } from '@votingworks/types';
@@ -371,7 +370,7 @@ function validateTallies(
 }
 
 function convertTabulationResultsToFormResults(
-  contests: Contests,
+  contests: readonly Contest[],
   savedResults?: Tabulation.ManualElectionResults
 ): FormManualResults {
   const contestResults = Object.fromEntries(

--- a/apps/admin/frontend/src/utils/adjudication.ts
+++ b/apps/admin/frontend/src/utils/adjudication.ts
@@ -7,7 +7,7 @@ import type {
 } from '@votingworks/admin-backend';
 import { find, throwIllegalValue } from '@votingworks/basics';
 import {
-  AnyContest,
+  Contest,
   BallotPageContestOptionLayout,
   ContestId,
   ContestOptionId,
@@ -23,7 +23,7 @@ export type AdjudicatedContests = Map<ContestId, AdjudicatedCvrContest>;
 
 export interface ContestListItem {
   side: Side;
-  contest: AnyContest;
+  contest: Contest;
   adjudicationData: ContestAdjudicationData;
   isResolved: boolean;
 }
@@ -67,7 +67,7 @@ export function getCurrentVote(
 export function isContestCrossoverVoted(
   ballotHasCrossoverVote: boolean,
   contestItem: {
-    contest: AnyContest;
+    contest: Contest;
     adjudicationData: ContestAdjudicationData;
   },
   adjudicatedContest?: AdjudicatedCvrContest
@@ -188,7 +188,7 @@ export function deriveCrossoverVoteStatus(
 
 export function contestPartyLabel(
   election: Election,
-  contest: AnyContest
+  contest: Contest
 ): string | undefined {
   return election.type === 'open-primary' &&
     contest.type === 'candidate' &&

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -21,8 +21,8 @@ import {
   District,
   PrecinctId,
   Party,
-  AnyContest,
-  AnyContestSchema,
+  Contest,
+  ContestSchema,
   HmpbBallotPaperSizeSchema,
   SystemSettingsSchema,
   PrecinctSchema,
@@ -615,23 +615,23 @@ export function buildApi(ctx: AppContext) {
 
     async listContests(input: {
       electionId: ElectionId;
-    }): Promise<readonly AnyContest[]> {
+    }): Promise<readonly Contest[]> {
       return store.listContests(input.electionId);
     },
 
     async createContest(input: {
       electionId: ElectionId;
-      newContest: AnyContest;
+      newContest: Contest;
     }): Promise<Result<void, DuplicateContestError>> {
-      const contest = unsafeParse(AnyContestSchema, input.newContest);
+      const contest = unsafeParse(ContestSchema, input.newContest);
       return store.createContest(input.electionId, contest);
     },
 
     async updateContest(input: {
       electionId: ElectionId;
-      updatedContest: AnyContest;
+      updatedContest: Contest;
     }): Promise<Result<void, DuplicateContestError>> {
-      const contest = unsafeParse(AnyContestSchema, input.updatedContest);
+      const contest = unsafeParse(ContestSchema, input.updatedContest);
       return store.updateContest(input.electionId, contest);
     },
 

--- a/apps/design/backend/src/convert_ms_election.ts
+++ b/apps/design/backend/src/convert_ms_election.ts
@@ -7,7 +7,7 @@ import {
   uniqueDeep,
 } from '@votingworks/basics';
 import {
-  AnyContest,
+  Contest,
   Candidate,
   County,
   District,
@@ -263,7 +263,7 @@ export function convertMsElection(
     groupBy(candidateEntries, ({ contestId }) => contestId)
   );
 
-  const contests: AnyContest[] = sectionRows(7).map((row) => {
+  const contests: Contest[] = sectionRows(7).map((row) => {
     const [
       ,
       contestId,

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -27,7 +27,7 @@ import {
   District,
   PrecinctId,
   Party,
-  AnyContest,
+  Contest,
   HmpbBallotPaperSize,
   NhPrecinctSplitOptions,
   Candidate,
@@ -379,7 +379,7 @@ async function insertParty(
 async function insertContest(
   client: Client,
   electionId: ElectionId,
-  contest: AnyContest,
+  contest: Contest,
   ballotOrder?: number
 ) {
   await assertWithinTransaction(client);
@@ -1047,7 +1047,7 @@ export class Store {
       ).rows as Array<{
         id: string;
         title: string;
-        type: AnyContest['type'];
+        type: Contest['type'];
         districtId: DistrictId;
         seats: number | null;
         allowWriteIns: boolean | null;
@@ -1087,7 +1087,7 @@ export class Store {
         lastName: string | null;
         partyIds: PartyId[];
       }>;
-      const contests: AnyContest[] = contestRows.map((row) => {
+      const contests: Contest[] = contestRows.map((row) => {
         switch (row.type) {
           case 'candidate': {
             const candidates: Candidate[] = candidateRows
@@ -2022,7 +2022,7 @@ export class Store {
     return assertDefined(res);
   }
 
-  async listContests(electionId: ElectionId): Promise<readonly AnyContest[]> {
+  async listContests(electionId: ElectionId): Promise<readonly Contest[]> {
     const { election } = await this.getElection(electionId);
     return election.contests;
   }
@@ -2041,7 +2041,7 @@ export class Store {
 
   async createContest(
     electionId: ElectionId,
-    contest: AnyContest
+    contest: Contest
   ): Promise<Result<void, DuplicateContestError>> {
     if (
       contest.type === 'yesno' &&
@@ -2064,7 +2064,7 @@ export class Store {
 
   async updateContest(
     electionId: ElectionId,
-    contest: AnyContest
+    contest: Contest
   ): Promise<Result<void, DuplicateContestError>> {
     if (
       contest.type === 'yesno' &&

--- a/apps/design/backend/src/utils.ts
+++ b/apps/design/backend/src/utils.ts
@@ -1,6 +1,6 @@
 import { assertDefined, throwIllegalValue } from '@votingworks/basics';
 import {
-  AnyContest,
+  Contest,
   Candidate,
   District,
   Election,
@@ -57,7 +57,7 @@ export function regenerateElectionIds(
   districts: District[];
   precincts: Precinct[];
   parties: Party[];
-  contests: AnyContest[];
+  contests: Contest[];
   pollingPlaces?: PollingPlace[];
 } {
   const idMap = new Map<string, string>();

--- a/apps/design/frontend/src/ballot_audio/audio_editor_panel.test.tsx
+++ b/apps/design/frontend/src/ballot_audio/audio_editor_panel.test.tsx
@@ -1,11 +1,7 @@
 import { expect, test, vi } from 'vitest';
 
 import { TtsStringDefault } from '@votingworks/design-backend';
-import {
-  AnyContest,
-  ElectionStringKey,
-  YesNoContest,
-} from '@votingworks/types';
+import { Contest, ElectionStringKey, YesNoContest } from '@votingworks/types';
 
 import { AudioEditor, AudioEditorProps } from './audio_editor';
 import {
@@ -59,7 +55,7 @@ test('renders contest descriptions using original, unstripped HTML', async () =>
   const mockApi = createMockApiClient();
   mockApi.listContests
     .expectCallWith({ electionId })
-    .resolves([mockContest as AnyContest]);
+    .resolves([mockContest as Contest]);
 
   const ttsDefault: TtsStringDefault = {
     key: ElectionStringKey.CONTEST_DESCRIPTION,

--- a/apps/design/frontend/src/ballot_screen.tsx
+++ b/apps/design/frontend/src/ballot_screen.tsx
@@ -9,7 +9,7 @@ import {
   ElectionIdSchema,
   BallotStyleIdSchema,
   PrecinctIdSchema,
-  AnyContest,
+  Contest,
 } from '@votingworks/types';
 import React, { useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
@@ -224,7 +224,7 @@ export const paperSizeLabels: Record<HmpbBallotPaperSize, string> = {
 };
 
 function formContestTooLongErrorMessage(
-  contest: AnyContest,
+  contest: Contest,
   ballotTemplateId: BallotTemplateId
 ): string {
   const issue = `Contest "${contest.title}" was too long to fit on the page.`;

--- a/apps/design/frontend/src/contest_form.tsx
+++ b/apps/design/frontend/src/contest_form.tsx
@@ -7,7 +7,7 @@ import { Result, throwIllegalValue } from '@votingworks/basics';
 import {
   isPrimary,
   ElectionId,
-  AnyContest,
+  Contest,
   DistrictId,
   PartyId,
   Candidate,
@@ -117,7 +117,7 @@ const CandidateInputTable = styled(Table)`
 export interface ContestFormProps {
   editing: boolean;
   electionId: ElectionId;
-  savedContest?: AnyContest;
+  savedContest?: Contest;
   title: React.ReactNode;
 }
 
@@ -950,7 +950,7 @@ function draftCandidateFromCandidate(candidate: Candidate): DraftCandidate {
   };
 }
 
-function draftContestFromContest(contest: AnyContest): DraftContest {
+function draftContestFromContest(contest: Contest): DraftContest {
   switch (contest.type) {
     case 'candidate':
       return {
@@ -968,7 +968,7 @@ function draftContestFromContest(contest: AnyContest): DraftContest {
 
 function tryContestFromDraftContest(
   draftContest: DraftContest
-): Result<AnyContest, z.ZodError> {
+): Result<Contest, z.ZodError> {
   switch (draftContest.type) {
     case 'candidate':
       return safeParse(CandidateContestSchema, {

--- a/apps/design/frontend/src/contest_list.test.tsx
+++ b/apps/design/frontend/src/contest_list.test.tsx
@@ -30,33 +30,33 @@ const party2: Party = {
   name: 'P2',
 };
 
-const candidateContest1 = typedAs<Contest>({
+const candidateContest1 = typedAs<Partial<Contest>>({
   id: 'candidateContest1',
   title: 'Candidate Contest 1',
   districtId: district1.id,
   type: 'candidate',
-}) as AnyContest;
+}) as Contest;
 
-const candidateContest2 = typedAs<Contest>({
+const candidateContest2 = typedAs<Partial<Contest>>({
   id: 'candidateContest2',
   title: 'Candidate Contest 2',
   districtId: district2.id,
   type: 'candidate',
-}) as AnyContest;
+}) as Contest;
 
-const yesNoContest1 = typedAs<Contest>({
+const yesNoContest1 = typedAs<Partial<Contest>>({
   id: 'yesNoContest1',
   title: 'YesNo Contest 1',
   districtId: district1.id,
   type: 'yesno',
-}) as AnyContest;
+}) as Contest;
 
-const yesNoContest2 = typedAs<Contest>({
+const yesNoContest2 = typedAs<Partial<Contest>>({
   id: 'yesNoContest2',
   title: 'YesNo Contest Contest 2',
   districtId: district2.id,
   type: 'yesno',
-}) as AnyContest;
+}) as Contest;
 
 const electionId = 'election1';
 const contestRoutes = routes.election(electionId).contests;

--- a/apps/design/frontend/src/contest_list.test.tsx
+++ b/apps/design/frontend/src/contest_list.test.tsx
@@ -1,4 +1,4 @@
-import { AnyContest, Contest, District, Party } from '@votingworks/types';
+import { Contest, District, Party } from '@votingworks/types';
 import { afterEach, expect, test, vi } from 'vitest';
 import { createMemoryHistory, MemoryHistory } from 'history';
 import { Router, Route } from 'react-router-dom';
@@ -295,7 +295,7 @@ function getHeading(name: string) {
 }
 
 function getOption(
-  contest: AnyContest,
+  contest: Contest,
   district: District,
   opts: { party?: Party; selected?: boolean } = {}
 ) {
@@ -345,7 +345,7 @@ function renderList(
   );
 }
 
-function withParty(contest: AnyContest, party: Party) {
+function withParty(contest: Contest, party: Party) {
   assert(contest.type === 'candidate');
   return { ...contest, partyId: party.id };
 }

--- a/apps/design/frontend/src/contest_list.tsx
+++ b/apps/design/frontend/src/contest_list.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { Flipped, Flipper } from 'react-flip-toolkit';
 import { Button } from '@votingworks/ui';
-import { AnyContest, Party } from '@votingworks/types';
+import { Contest, Party } from '@votingworks/types';
 import { useHistory, useParams } from 'react-router-dom';
 import { Column, Row } from './layout';
 import * as api from './api';
@@ -31,8 +31,8 @@ export interface ReorderParams {
 }
 
 export interface ContestListProps {
-  candidateContests: AnyContest[];
-  yesNoContests: AnyContest[];
+  candidateContests: Contest[];
+  yesNoContests: Contest[];
   reordering: boolean;
   reorder: (params: ReorderParams) => void;
 }
@@ -97,7 +97,7 @@ export function ContestList(props: ContestListProps): React.ReactNode {
 }
 
 export function Sublist(props: {
-  contests: AnyContest[];
+  contests: Contest[];
   districtIdToName: Map<string, string>;
   onSelect: (contestId: string) => void;
   parties: readonly Party[];
@@ -180,7 +180,7 @@ export function Sublist(props: {
   );
 }
 
-function partyName(contest: AnyContest, parties: readonly Party[]) {
+function partyName(contest: Contest, parties: readonly Party[]) {
   if (contest.type !== 'candidate' || !contest.partyId) return undefined;
 
   return parties.find((p) => p.id === contest.partyId)?.fullName;

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -6,7 +6,6 @@ import {
   BallotStyleGroupIdSchema,
   BallotStyleIdSchema,
   CandidateContest,
-  Contests,
   DEFAULT_SYSTEM_SETTINGS,
   DistrictIdSchema,
   Election,
@@ -1690,7 +1689,7 @@ describe('audio editing', () => {
   });
 });
 
-function expectContestListItems(contests: Contests) {
+function expectContestListItems(contests: readonly Contest[]) {
   expectContestListProps({
     candidateContests: contests.filter((c) => c.type === 'candidate'),
     yesNoContests: contests.filter((c) => c.type === 'yesno'),

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -6,7 +6,6 @@ import {
   BallotStyleGroupIdSchema,
   BallotStyleIdSchema,
   CandidateContest,
-  Contest,
   Contests,
   DEFAULT_SYSTEM_SETTINGS,
   DistrictIdSchema,

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { createMemoryHistory, MemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';
 import {
-  AnyContest,
+  Contest,
   BallotStyleGroupIdSchema,
   BallotStyleIdSchema,
   CandidateContest,
@@ -1581,7 +1581,7 @@ describe('audio editing', () => {
   });
 
   interface AudioEnabledInputSpec {
-    contest: AnyContest;
+    contest: Contest;
     inputLabel: string;
     stringKey: ElectionStringKey;
     subkey: string;

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -4,7 +4,7 @@ import { Redirect, Route, Switch, useParams } from 'react-router-dom';
 import {
   CandidateContest,
   ContestId,
-  Contests,
+  Contest,
   YesNoContest,
   isPrimary,
 } from '@votingworks/types';
@@ -101,7 +101,8 @@ function Content(): JSX.Element | null {
 
   const [filterDistrictId, setFilterDistrictId] = useState(FILTER_ALL);
   const [filterPartyId, setFilterPartyId] = useState(FILTER_ALL);
-  const [reorderedContests, setReorderedContests] = useState<Contests>();
+  const [reorderedContests, setReorderedContests] =
+    useState<readonly Contest[]>();
 
   if (
     !(
@@ -163,7 +164,7 @@ function Content(): JSX.Element | null {
       ? contestRoutes.view(contestsToShow[0].id).path
       : null;
 
-  function onSaveReorderedContests(updatedContests: Contests) {
+  function onSaveReorderedContests(updatedContests: readonly Contest[]) {
     reorderContestsMutation.mutate(
       {
         electionId,

--- a/apps/design/frontend/src/reorder_contests_by_district_button.test.tsx
+++ b/apps/design/frontend/src/reorder_contests_by_district_button.test.tsx
@@ -5,7 +5,7 @@ import { DateWithoutTime } from '@votingworks/basics';
 import { ElectionInfo } from '@votingworks/design-backend';
 import {
   CandidateContest,
-  Contests,
+  Contest,
   District,
   DistrictIdSchema,
   HmpbBallotPaperSize,
@@ -75,7 +75,7 @@ const testDistrictC: District = {
 
 const testDistricts = [testDistrictA, testDistrictB, testDistrictC];
 
-const testContests: Contests = [
+const testContests: readonly Contest[] = [
   candidateContest(testDistrictA.id, 1),
   candidateContest(testDistrictB.id, 1),
   candidateContest(testDistrictC.id, 1),
@@ -84,7 +84,7 @@ const testContests: Contests = [
   yesNoContest(testDistrictC.id, 1),
 ];
 
-const testContestsInBcaOrder: Contests = [
+const testContestsInBcaOrder: readonly Contest[] = [
   candidateContest(testDistrictB.id, 1),
   candidateContest(testDistrictC.id, 1),
   candidateContest(testDistrictA.id, 1),
@@ -139,7 +139,7 @@ test.each<{
   description: string;
   ballotsFinalizedAt: Date | null;
   electionInfo: ElectionInfo;
-  contests: Contests;
+  contests: readonly Contest[];
   shouldButtonBeEnabled: boolean;
 }>([
   {
@@ -321,9 +321,9 @@ test('initial district order is based on the order of appearance in contests', a
 });
 
 test.each<{
-  contests: Contests;
+  contests: readonly Contest[];
   districtOrder: District[];
-  reorderedContests: Contests;
+  reorderedContests: readonly Contest[];
 }>([
   {
     contests: [

--- a/apps/design/frontend/src/reorder_contests_by_district_button.tsx
+++ b/apps/design/frontend/src/reorder_contests_by_district_button.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { assert, assertDefined } from '@votingworks/basics';
-import { Contests, District } from '@votingworks/types';
+import { Contest, District } from '@votingworks/types';
 import { Button, Modal } from '@votingworks/ui';
 
 import {
@@ -14,7 +14,7 @@ import {
 import { Column, Row } from './layout';
 import { reorderElement } from './utils';
 
-function serializeContestIds(contests: Contests): string {
+function serializeContestIds(contests: readonly Contest[]): string {
   return contests
     .map((c) => c.id)
     .sort()
@@ -22,9 +22,9 @@ function serializeContestIds(contests: Contests): string {
 }
 
 export function reorderContestsByDistrict(
-  contests: Contests,
+  contests: readonly Contest[],
   districtOrder: District[]
-): Contests {
+): readonly Contest[] {
   const candidateContests = contests.filter((c) => c.type === 'candidate');
   const yesNoContests = contests.filter((c) => c.type === 'yesno');
   assert(candidateContests.length + yesNoContests.length === contests.length);
@@ -64,11 +64,11 @@ function ReorderContestsByDistrictModal({
   onClose,
   onSave,
 }: {
-  contests: Contests;
+  contests: readonly Contest[];
   districts: readonly District[];
   isSaving: boolean;
   onClose: () => void;
-  onSave: (reordered: Contests) => void;
+  onSave: (reordered: readonly Contest[]) => void;
 }): React.ReactNode {
   const [orderedDistricts, setOrderedDistricts] = useState<District[]>(() => {
     // Initialize district order based on the order of appearance in contests

--- a/apps/mark-scan/frontend/test/test_utils.tsx
+++ b/apps/mark-scan/frontend/test/test_utils.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Router } from 'react-router-dom';
 import {
   BallotStyleId,
-  Contests,
+  Contest,
   ElectionDefinition,
   PartyId,
   PrecinctId,
@@ -43,7 +43,7 @@ export function render(
     route?: string;
     ballotStyleId?: BallotStyleId;
     electionDefinition?: ElectionDefinition;
-    contests?: Contests;
+    contests?: readonly Contest[];
     endVoterSession?: () => Promise<void>;
     history?: History;
     isCardlessVoter?: boolean;

--- a/apps/mark/frontend/test/test_utils.tsx
+++ b/apps/mark/frontend/test/test_utils.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Router } from 'react-router-dom';
 import {
   BallotStyleId,
-  Contests,
+  Contest,
   ElectionDefinition,
   PartyId,
   PrecinctId,
@@ -39,7 +39,7 @@ export function render(
     route?: string;
     ballotStyleId?: BallotStyleId;
     electionDefinition?: ElectionDefinition;
-    contests?: Contests;
+    contests?: readonly Contest[];
     endVoterSession?: () => Promise<void>;
     history?: History;
     isCardlessVoter?: boolean;

--- a/apps/scan/backend/src/util/write_in_report.ts
+++ b/apps/scan/backend/src/util/write_in_report.ts
@@ -1,12 +1,12 @@
 import { assertDefined } from '@votingworks/basics';
 import { loadImageData, crop, toDataUrl } from '@votingworks/image-utils';
-import { AnyContest, InterpretedHmpbPage, VotesDict } from '@votingworks/types';
+import { Contest, InterpretedHmpbPage, VotesDict } from '@votingworks/types';
 import { WriteInEntry } from '@votingworks/ui';
 import { rootDebug } from './debug';
 
 const debug = rootDebug.extend('write-in-report');
 
-function isContestOvervoted(contest: AnyContest, votes: VotesDict): boolean {
+function isContestOvervoted(contest: Contest, votes: VotesDict): boolean {
   if (contest.type !== 'candidate') return false;
   const vote = votes[contest.id];
   if (!vote || !Array.isArray(vote)) return false;
@@ -15,7 +15,7 @@ function isContestOvervoted(contest: AnyContest, votes: VotesDict): boolean {
 
 export function getOvervotedContestIds(
   votes: VotesDict,
-  contests: readonly AnyContest[]
+  contests: readonly Contest[]
 ): Set<string> {
   const overvoted = new Set<string>();
   for (const contest of contests) {

--- a/apps/scan/frontend/src/components/misvote_warnings/contest_list.tsx
+++ b/apps/scan/frontend/src/components/misvote_warnings/contest_list.tsx
@@ -1,6 +1,6 @@
 import styled, { DefaultTheme } from 'styled-components';
 
-import { AnyContest, SizeMode } from '@votingworks/types';
+import { Contest, SizeMode } from '@votingworks/types';
 import {
   Caption,
   Font,
@@ -12,7 +12,7 @@ import {
 import React from 'react';
 
 export interface ContestListProps {
-  contests: readonly AnyContest[];
+  contests: readonly Contest[];
   helpNote: React.ReactNode;
   maxColumns: number;
   title: React.ReactNode;

--- a/apps/scan/frontend/src/components/misvote_warnings/test_utils.test.ts
+++ b/apps/scan/frontend/src/components/misvote_warnings/test_utils.test.ts
@@ -1,11 +1,11 @@
 import { expect, test } from 'vitest';
 import { readElectionGeneral } from '@votingworks/fixtures';
-import { AnyContest } from '@votingworks/types';
+import { Contest } from '@votingworks/types';
 
-const CONTEST_TEMPLATE: AnyContest = readElectionGeneral().contests[0];
+const CONTEST_TEMPLATE: Contest = readElectionGeneral().contests[0];
 
-export function generateContests(count: number): AnyContest[] {
-  const contests: AnyContest[] = [];
+export function generateContests(count: number): Contest[] {
+  const contests: Contest[] = [];
 
   for (let i = 0; i < count; i += 1) {
     contests.push({

--- a/apps/scan/frontend/src/components/misvote_warnings/types.ts
+++ b/apps/scan/frontend/src/components/misvote_warnings/types.ts
@@ -1,9 +1,9 @@
-import { AnyContest } from '@votingworks/types';
+import { Contest } from '@votingworks/types';
 
 export interface MisvoteWarningsProps {
-  blankContests: readonly AnyContest[];
-  overvoteContests: readonly AnyContest[];
-  partiallyVotedContests: readonly AnyContest[];
+  blankContests: readonly Contest[];
+  overvoteContests: readonly Contest[];
+  partiallyVotedContests: readonly Contest[];
 }
 
 export interface MisvoteWarningsConfig {

--- a/apps/scan/frontend/src/screens/scan_warning_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.tsx
@@ -6,7 +6,7 @@ import {
   AdjudicationReasonInfo,
   OvervoteAdjudicationReasonInfo,
   UndervoteAdjudicationReasonInfo,
-  AnyContest,
+  Contest,
   SystemSettings,
   DEFAULT_SYSTEM_SETTINGS,
 } from '@votingworks/types';
@@ -73,9 +73,9 @@ function MisvoteWarningScreen({
   }
 
   // Then, map IDs to contests in the election:
-  const blankContests: AnyContest[] = [];
-  const partiallyVotedContests: AnyContest[] = [];
-  const overvoteContests: AnyContest[] = [];
+  const blankContests: Contest[] = [];
+  const partiallyVotedContests: Contest[] = [];
+  const overvoteContests: Contest[] = [];
 
   for (const contest of contests) {
     if (blankContestIds.has(contest.id)) {

--- a/libs/backend/src/cast_vote_records/build_report_metadata.ts
+++ b/libs/backend/src/cast_vote_records/build_report_metadata.ts
@@ -1,6 +1,6 @@
 import { integers } from '@votingworks/basics';
 import {
-  AnyContest,
+  Contest,
   BatchInfo,
   CandidateContest,
   CastVoteRecordBatchMetadata,
@@ -84,7 +84,7 @@ function buildBallotMeasureContest(
 }
 
 function buildContest(
-  contest: AnyContest
+  contest: Contest
 ): CVR.CandidateContest | CVR.BallotMeasureContest {
   return contest.type === 'candidate'
     ? buildCandidateContest(contest)

--- a/libs/ballot-encoder/src/index.ts
+++ b/libs/ballot-encoder/src/index.ts
@@ -9,7 +9,6 @@ import {
   CandidateVote,
   CompletedBallot,
   ContestId,
-  Contests,
   Election,
   ElectionDefinition,
   getBallotStyle,
@@ -258,7 +257,7 @@ function writeYesNoVote(
 }
 
 function encodeBallotVotesInto(
-  contests: Contests,
+  contests: readonly Contest[],
   votes: VotesDict,
   bits: BitWriter
 ): BitWriter {
@@ -393,7 +392,10 @@ function readPaddingToEnd(bits: BitReader): void {
   }
 }
 
-function decodeBallotVotes(contests: Contests, bits: BitReader): VotesDict {
+function decodeBallotVotes(
+  contests: readonly Contest[],
+  bits: BitReader
+): VotesDict {
   const votes: VotesDict = {};
 
   for (const contest of contests) {
@@ -608,7 +610,7 @@ export interface BmdMultiPageBallotPage {
   totalPages: number;
   ballotAuditId: string;
   /** The contests included on this page */
-  contests: Contests;
+  contests: readonly Contest[];
   /** Votes for the contests on this page */
   votes: VotesDict;
 }

--- a/libs/ballot-encoder/src/index.ts
+++ b/libs/ballot-encoder/src/index.ts
@@ -1,5 +1,5 @@
 import {
-  AnyContest,
+  Contest,
   BallotIdSchema,
   BallotStyleId,
   BallotType,
@@ -810,7 +810,7 @@ export function decodeBmdMultiPageBallotFromReader(
 
   // Read contest bitmap: which contests are on this page
   const contestIds: ContestId[] = [];
-  const contestsOnThisPage: AnyContest[] = [];
+  const contestsOnThisPage: Contest[] = [];
   for (const contest of allContests) {
     if (bits.readBoolean()) {
       contestIds.push(contest.id);

--- a/libs/ballot-interpreter/src/adjudication_reasons.test.ts
+++ b/libs/ballot-interpreter/src/adjudication_reasons.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import {
   AdjudicationReason,
   AdjudicationReasonInfo,
-  AnyContest,
+  Contest,
   CandidateContest,
   ContestOptionId,
   MarkStatus,
@@ -58,7 +58,7 @@ type GetAllPossibleAdjudicationReasonsOptionStatus = Parameters<
 >[1][0];
 
 function generateMockContestOptionScores(
-  contest: AnyContest,
+  contest: Contest,
   overrides: Record<
     ContestOptionId,
     { markStatus?: MarkStatus; writeInAreaStatus?: WriteInAreaStatus }

--- a/libs/ballot-interpreter/src/adjudication_reasons.ts
+++ b/libs/ballot-interpreter/src/adjudication_reasons.ts
@@ -5,7 +5,6 @@ import {
   BallotStyle,
   CandidateVote,
   ContestOption,
-  Contests,
   MarkStatus,
   VotesDict,
   WriteInAreaStatus,
@@ -51,7 +50,7 @@ function getExpectedVoteCount(contest: Contest): number {
  * the context of a BMD.
  */
 export function getAllPossibleAdjudicationReasonsForBmdVotes(
-  contests: Contests,
+  contests: readonly Contest[],
   votes: VotesDict
 ): AdjudicationReasonInfo[] {
   const reasons: AdjudicationReasonInfo[] = [];
@@ -111,7 +110,7 @@ export function getAllPossibleAdjudicationReasonsForBmdVotes(
  * the context of a HMPB.
  */
 export function getAllPossibleAdjudicationReasons(
-  contests: Contests,
+  contests: readonly Contest[],
   allScoredContestOptions: Array<{
     option: ContestOption;
     markStatus: MarkStatus;

--- a/libs/ballot-interpreter/src/adjudication_reasons.ts
+++ b/libs/ballot-interpreter/src/adjudication_reasons.ts
@@ -1,7 +1,7 @@
 import {
   AdjudicationReason,
   AdjudicationReasonInfo,
-  AnyContest,
+  Contest,
   BallotStyle,
   CandidateVote,
   ContestOption,
@@ -34,7 +34,7 @@ function compareMarkStatusDescending(
   return rankMarkStatus(markStatusB) - rankMarkStatus(markStatusA);
 }
 
-function getExpectedVoteCount(contest: AnyContest): number {
+function getExpectedVoteCount(contest: Contest): number {
   switch (contest.type) {
     case 'candidate':
       return contest.seats;

--- a/libs/ballot-interpreter/src/cross_language_bmd.test.ts
+++ b/libs/ballot-interpreter/src/cross_language_bmd.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import fc from 'fast-check';
 import {
-  AnyContest,
+  Contest,
   BallotType,
   BallotStyleId,
   Contests,
@@ -239,7 +239,7 @@ test('multi-page BMD ballot: TS encode matches Rust decode', async () => {
         if (allContests.length === 0) return;
 
         // Distribute contests across pages round-robin
-        const pages: Array<AnyContest[]> = Array.from(
+        const pages: Array<Contest[]> = Array.from(
           { length: totalPages },
           () => []
         );
@@ -435,7 +435,7 @@ test('multi-page BMD ballot: Rust encode matches TS decode', async () => {
         const allContests = getContests({ ballotStyle, election });
         if (allContests.length === 0) return;
 
-        const pages: Array<AnyContest[]> = Array.from(
+        const pages: Array<Contest[]> = Array.from(
           { length: totalPages },
           () => []
         );

--- a/libs/ballot-interpreter/src/cross_language_bmd.test.ts
+++ b/libs/ballot-interpreter/src/cross_language_bmd.test.ts
@@ -4,7 +4,6 @@ import {
   Contest,
   BallotType,
   BallotStyleId,
-  Contests,
   Election,
   VotesDict,
   getContests,
@@ -39,7 +38,7 @@ import type {
  * `includeWriteIns` is set). For yes/no contests, picks yes.
  */
 function generateVotesForContests(
-  contests: Contests,
+  contests: readonly Contest[],
   includeWriteIns: boolean
 ): VotesDict {
   const votes: VotesDict = {};
@@ -312,7 +311,7 @@ function ballotHashToBytes(ballotHash: string): number[] {
  */
 function tsVotesToRustVotes(
   votes: VotesDict,
-  contests: Contests
+  contests: readonly Contest[]
 ): Record<string, RustContestVote> {
   const rustVotes: Record<string, RustContestVote> = {};
   for (const contest of contests) {

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -21,7 +21,6 @@ import {
   BallotType,
   ContestId,
   ContestOption,
-  Contests,
   Corners,
   ElectionDefinition,
   getBallotStyle,
@@ -93,7 +92,7 @@ interface ScoredContestOption {
 }
 
 function getContestOptionForGridPosition(
-  contests: Contests,
+  contests: readonly Contest[],
   gridPosition: GridPosition,
   ballotStyle: BallotStyle
 ): ContestOption {
@@ -155,7 +154,7 @@ function aggregateContestOptionScores({
 }: {
   marks: ScoredBubbleMarks;
   writeIns: ScoredPositionArea[];
-  contests: Contests;
+  contests: readonly Contest[];
   options: InterpreterOptions;
   ballotStyle: BallotStyle;
 }): ScoredContestOption[] {
@@ -356,7 +355,7 @@ export function determineAdjudicationInfoFromScoredContestOptions(
 }
 
 function convertContestLayouts(
-  contests: Contests,
+  contests: readonly Contest[],
   contestLayouts: InterpretedContestLayout[],
   ballotStyle: BallotStyle
 ): BallotPageContestLayout[] {

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -12,7 +12,7 @@ import { fromGrayScale, isRgba } from '@votingworks/image-utils';
 import {
   AdjudicationInfo,
   AdjudicationReason,
-  AnyContest,
+  Contest,
   BallotPageContestLayout,
   BallotPageContestOptionLayout,
   BallotStyle,
@@ -383,7 +383,7 @@ function convertContestLayouts(
   }
 
   function convertContestOptionLayout(
-    contest: AnyContest,
+    contest: Contest,
     { bounds, optionId }: InterpretedContestOptionLayout
   ): BallotPageContestOptionLayout {
     const option = iter(allContestOptions(contest, ballotStyle)).find(

--- a/libs/fixture-generators/src/generate-cvrs/utils.ts
+++ b/libs/fixture-generators/src/generate-cvrs/utils.ts
@@ -2,7 +2,7 @@ import { IteratorPlus, assert, iter } from '@votingworks/basics';
 import { sha256 } from 'js-sha256';
 import {
   BallotPageLayout,
-  Contests,
+  Contest,
   CVR,
   Election,
   getBallotStyle,
@@ -69,7 +69,7 @@ export function splitContestsByPage({
   allVotes: VotesDict;
   ballotPageLayouts: readonly BallotPageLayout[];
   election: Election;
-}): Contests[] {
+}): Array<readonly Contest[]> {
   const metadata = ballotPageLayouts[0]?.metadata;
   assert(metadata);
   const ballotStyle = getBallotStyle({
@@ -82,7 +82,7 @@ export function splitContestsByPage({
     ballotStyle,
   });
 
-  const contestsByPage: Contests[] = [];
+  const contestsByPage: Array<readonly Contest[]> = [];
   let contestOffset = 0;
   for (const layout of ballotPageLayouts) {
     contestsByPage.push(
@@ -100,11 +100,11 @@ export function splitContestsByPage({
  * as from [[...A], [...B], [...C], [...D]] to [[[...A], [...B]], [[...C],[...D]]]
  */
 export function arrangeContestsBySheet(
-  contestsByPage: Iterable<Contests>
-): IteratorPlus<SheetOf<Contests>> {
+  contestsByPage: Iterable<readonly Contest[]>
+): IteratorPlus<SheetOf<readonly Contest[]>> {
   return iter(contestsByPage)
     .chunks(2)
-    .map<SheetOf<Contests>>(([front, back = []]) => [front, back]);
+    .map<SheetOf<readonly Contest[]>>(([front, back = []]) => [front, back]);
 }
 
 /**
@@ -113,7 +113,7 @@ export function arrangeContestsBySheet(
  */
 export function filterVotesByContests(
   votes: VotesDict,
-  contests: Contests
+  contests: readonly Contest[]
 ): VotesDict {
   const filteredVotes: VotesDict = {};
   for (const contest of contests) {

--- a/libs/fixture-generators/src/generate-election/generate_election.ts
+++ b/libs/fixture-generators/src/generate-election/generate_election.ts
@@ -6,7 +6,7 @@ import {
   unique,
 } from '@votingworks/basics';
 import {
-  AnyContest,
+  Contest,
   HmpbBallotPaperSize,
   BallotStyle,
   District,
@@ -114,7 +114,7 @@ export function generateElection(
   }
   const parties = range(0, config.numParties).map(generateParty);
 
-  function generateContest(index: number): AnyContest {
+  function generateContest(index: number): Contest {
     const baseContest = {
       id: `contest-${index}`,
       districtId: chooseRandom(districts).id,

--- a/libs/hmpb/src/ballot_styles.test.ts
+++ b/libs/hmpb/src/ballot_styles.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import { typedAs } from '@votingworks/basics';
 import {
-  AnyContest,
+  Contest,
   District,
   DistrictId,
   Party,
@@ -23,7 +23,7 @@ function makeContest(
   id: string,
   districtId: DistrictId,
   partyId?: PartyId
-): AnyContest {
+): Contest {
   return {
     id,
     districtId,

--- a/libs/hmpb/src/ballot_styles.ts
+++ b/libs/hmpb/src/ballot_styles.ts
@@ -2,7 +2,7 @@ import { groupBy, throwIllegalValue, unique } from '@votingworks/basics';
 import {
   BallotLanguageConfigs,
   CandidateContest,
-  Contests,
+  Contest,
   DistrictId,
   Parties,
   PrecinctOrSplitId,
@@ -40,7 +40,7 @@ import { getAllPossibleCandidateOrderings } from './ballot_rotation';
  * precinct/split and set of contests it will get its own ballot style.
  */
 export function generateBallotStyles(params: {
-  contests: Contests;
+  contests: readonly Contest[];
   ballotLanguageConfigs: BallotLanguageConfigs;
   electionType: ElectionType;
   parties: Parties;

--- a/libs/hmpb/src/ballot_templates/mi_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/mi_ballot_template.tsx
@@ -12,7 +12,7 @@ import {
   throwIllegalValue,
 } from '@votingworks/basics';
 import {
-  AnyContest,
+  Contest as ContestStruct,
   BallotMode,
   BallotStyle,
   BallotStyleId,
@@ -462,7 +462,7 @@ function Contest({
   ballotStyle,
   numContestColumns,
 }: {
-  contest: AnyContest;
+  contest: ContestStruct;
   ballotStyle: BallotStyle;
   numContestColumns: number;
 }) {
@@ -483,7 +483,7 @@ function Contest({
 }
 
 interface ContestElement {
-  contest: AnyContest;
+  contest: ContestStruct;
   element: JSX.Element;
 }
 
@@ -492,7 +492,7 @@ type ContestSection = Section<JSX.Element, ContestElement>;
 function buildSubsectionsByDistrict(
   election: Election,
   ballotStyle: BallotStyle,
-  sectionContests: AnyContest[],
+  sectionContests: ContestStruct[],
   numColumns: number
 ): ContestSection['subsections'] {
   return groupBy(sectionContests, (contest) => contest.districtId).map(
@@ -520,7 +520,7 @@ function buildSections(
   election: Election,
   ballotStyle: BallotStyle,
   numColumns: number,
-  sectionTemplates: Array<{ header: JSX.Element; contests: AnyContest[] }>
+  sectionTemplates: Array<{ header: JSX.Element; contests: ContestStruct[] }>
 ): ContestSection[] {
   return sectionTemplates
     .filter((section) => section.contests.length > 0)
@@ -536,7 +536,7 @@ function buildSections(
 }
 
 function buildClosedPrimaryContestSections(
-  contests: readonly AnyContest[],
+  contests: readonly ContestStruct[],
   election: Election,
   ballotStyle: BallotStyle,
   numColumns: number
@@ -562,7 +562,7 @@ function buildClosedPrimaryContestSections(
 }
 
 function buildOpenPrimaryContestSections(
-  contests: readonly AnyContest[],
+  contests: readonly ContestStruct[],
   election: Election,
   ballotStyle: BallotStyle,
   numColumns: number
@@ -695,7 +695,7 @@ async function measureSectionElements(
 
 interface ContestColumnsResult {
   sectionsElement: JSX.Element;
-  leftoverContests: AnyContest[];
+  leftoverContests: ContestStruct[];
 }
 
 async function ClosedPrimaryContestColumns({
@@ -705,7 +705,7 @@ async function ClosedPrimaryContestColumns({
   dimensions,
   scratchpad,
 }: {
-  contests: readonly AnyContest[];
+  contests: readonly ContestStruct[];
   election: Election;
   ballotStyle: BallotStyle;
   dimensions: PixelDimensions;
@@ -759,7 +759,7 @@ async function OpenPrimaryContestColumns({
   dimensions,
   scratchpad,
 }: {
-  contests: readonly AnyContest[];
+  contests: readonly ContestStruct[];
   election: Election;
   ballotStyle: BallotStyle;
   dimensions: PixelDimensions;

--- a/libs/hmpb/src/ballot_templates/ms_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/ms_ballot_template.tsx
@@ -10,7 +10,7 @@ import {
 } from '@votingworks/basics';
 import { Buffer } from 'node:buffer';
 import {
-  AnyContest,
+  Contest as ContestStruct,
   BallotMode,
   BallotStyle,
   BallotStyleId,
@@ -483,7 +483,7 @@ function Contest({
   election,
   ballotStyle,
 }: {
-  contest: AnyContest;
+  contest: ContestStruct;
   election: Election;
   ballotStyle: BallotStyle;
 }) {

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -11,7 +11,7 @@ import {
 } from '@votingworks/basics';
 import { Buffer } from 'node:buffer';
 import {
-  AnyContest,
+  Contest as ContestStruct,
   BallotMode,
   BallotStyle,
   BallotStyleId,
@@ -770,7 +770,7 @@ function Contest({
   ballotStyle,
 }: {
   compact?: boolean;
-  contest: AnyContest;
+  contest: ContestStruct;
   election: Election;
   ballotStyle: BallotStyle;
   precinctId: PrecinctId;

--- a/libs/hmpb/src/ballot_templates/nh_state_ballot_components.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_state_ballot_components.tsx
@@ -6,7 +6,7 @@ import {
   Election,
   BallotMode,
   BallotType,
-  AnyContest,
+  Contest,
   BaseBallotProps,
   Party,
 } from '@votingworks/types';
@@ -380,7 +380,7 @@ export function Footer({
   );
 }
 
-export function isFederalOfficeContest(contest: AnyContest): boolean {
+export function isFederalOfficeContest(contest: Contest): boolean {
   return [
     'President and Vice-President of the United States',
     'United States Senator',

--- a/libs/hmpb/src/ballot_templates/nh_state_primary_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_state_primary_ballot_template.tsx
@@ -9,7 +9,7 @@ import {
 } from '@votingworks/basics';
 import { Buffer } from 'node:buffer';
 import {
-  AnyContest,
+  Contest as ContestStruct,
   BallotMode,
   BallotType,
   CandidateContest as CandidateContestStruct,
@@ -574,7 +574,7 @@ function Contest({
   contest,
   colorTint,
 }: {
-  contest: AnyContest;
+  contest: ContestStruct;
   election: Election;
   colorTint: ColorTint;
 }) {

--- a/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
@@ -10,7 +10,7 @@ import {
 } from '@votingworks/basics';
 import { Buffer } from 'node:buffer';
 import {
-  AnyContest,
+  Contest as ContestStruct,
   BallotMode,
   BallotStyle,
   BallotStyleId,
@@ -435,7 +435,7 @@ function Contest({
   election,
   ballotStyle,
 }: {
-  contest: AnyContest;
+  contest: ContestStruct;
   election: Election;
   ballotStyle: BallotStyle;
 }) {

--- a/libs/hmpb/src/mark_ballot.tsx
+++ b/libs/hmpb/src/mark_ballot.tsx
@@ -1,7 +1,7 @@
 import {
   Candidate,
   ContestId,
-  Contests,
+  Contest,
   Id,
   Vote,
   VotesDict,
@@ -154,7 +154,7 @@ export async function markBallotDocument(
   return ballotDocument;
 }
 
-export function createTestVotes(contests: Contests): {
+export function createTestVotes(contests: readonly Contest[]): {
   votes: VotesDict;
   unmarkedWriteIns: UnmarkedWriteInVote[];
 } {

--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -12,7 +12,7 @@ import {
   throwIllegalValue,
 } from '@votingworks/basics';
 import {
-  AnyContest,
+  Contest,
   BALLOT_MODES,
   BallotStyleId,
   BallotType,
@@ -75,7 +75,7 @@ export interface PaginatedContent<P> {
 
 interface ContestTooLongError {
   error: 'contestTooLong';
-  contest: AnyContest;
+  contest: Contest;
 }
 
 interface MissingSignatureError {
@@ -704,7 +704,7 @@ export async function layOutBallotsAndCreateElectionDefinition<
     // Temporary workaround to transform ballot measures with additional options
     // into candidate contests, since VxSuite doesn't support the
     // contest.additionalOptions field.
-    .map((contest): AnyContest => {
+    .map((contest): Contest => {
       if (
         contest.type !== 'yesno' ||
         !contest.additionalOptions ||

--- a/libs/hmpb/src/types.ts
+++ b/libs/hmpb/src/types.ts
@@ -1,5 +1,5 @@
 import {
-  AnyContest,
+  Contest,
   ContestId,
   OrderedCandidateOption,
   Precinct,
@@ -39,7 +39,7 @@ export interface PrintCalibration {
 }
 
 export interface RotationParams {
-  contests: readonly AnyContest[];
+  contests: readonly Contest[];
   precincts: readonly Precinct[];
   districtIds: readonly string[];
   precinctsOrSplitIds: readonly PrecinctOrSplitId[];

--- a/libs/mark-flow-ui/src/utils/ms_either_neither_contests.ts
+++ b/libs/mark-flow-ui/src/utils/ms_either_neither_contests.ts
@@ -1,6 +1,5 @@
 import { assert, assertDefined, find } from '@votingworks/basics';
 import {
-  AnyContest,
   Contest,
   ContestId,
   Contests,
@@ -33,7 +32,7 @@ export interface MsEitherNeitherContest extends Omit<Contest, 'type'> {
  * A list of contests including merged MS either-neither contests.
  */
 export type ContestsWithMsEitherNeither = ReadonlyArray<
-  AnyContest | MsEitherNeitherContest
+  Contest | MsEitherNeitherContest
 >;
 
 function insertAtIndex<T>(array: T[], index: number, item: T): T[] {
@@ -108,7 +107,7 @@ export function mergeMsEitherNeitherContests(
  */
 export function getContestDistrictName(
   election: Election,
-  contest: AnyContest | MsEitherNeitherContest
+  contest: Contest | MsEitherNeitherContest
 ): string {
   if (contest.type === 'ms-either-neither') {
     const district = find(

--- a/libs/mark-flow-ui/src/utils/ms_either_neither_contests.ts
+++ b/libs/mark-flow-ui/src/utils/ms_either_neither_contests.ts
@@ -2,7 +2,6 @@ import { assert, assertDefined, find } from '@votingworks/basics';
 import {
   Contest,
   ContestId,
-  Contests,
   YesNoOption,
   getContestDistrictName as getContestDistrictNameBase,
   Election,
@@ -45,7 +44,7 @@ function insertAtIndex<T>(array: T[], index: number, item: T): T[] {
  * structure.
  */
 export function mergeMsEitherNeitherContests(
-  contests: Contests | ContestsWithMsEitherNeither
+  contests: readonly Contest[] | ContestsWithMsEitherNeither
 ): ContestsWithMsEitherNeither {
   const eitherNeitherContest = contests.find(
     (contest) =>

--- a/libs/printing/src/summary_ballot_layout.tsx
+++ b/libs/printing/src/summary_ballot_layout.tsx
@@ -5,7 +5,7 @@ import { assert } from '@votingworks/basics';
 import {
   BallotStyleId,
   ContestId,
-  Contests,
+  Contest,
   ElectionDefinition,
   getBallotStyle,
   getContests,
@@ -102,7 +102,7 @@ async function measureBallotHeight(
   electionDefinition: ElectionDefinition,
   ballotStyleId: BallotStyleId,
   precinctId: string,
-  contests: Contests,
+  contests: readonly Contest[],
   votes: VotesDict,
   machineType: MachineType,
   isMultiPage: boolean,
@@ -215,7 +215,7 @@ async function findMaxContestsThatFit(
   electionDefinition: ElectionDefinition,
   ballotStyleId: BallotStyleId,
   precinctId: string,
-  contests: Contests,
+  contests: readonly Contest[],
   votes: VotesDict,
   machineType: MachineType,
   isMultiPage: boolean,
@@ -251,7 +251,7 @@ async function findMaxContestsThatFit(
 
   while (low <= high) {
     const mid = Math.floor((low + high) / 2);
-    const testContests = contests.slice(0, mid) as Contests;
+    const testContests = contests.slice(0, mid);
 
     const height = await measureBallotHeight(
       page,
@@ -366,7 +366,7 @@ export class SummaryBallotLayoutRenderer {
 
     // Multi-page layout needed
     const pages: SummaryBallotPageLayout[] = [];
-    let remainingContests = [...contests] as Contests;
+    let remainingContests = [...contests];
     let pageNumber = 1;
     // Use total contest count for consistent layout across all pages
     const layout = selectLayout(totalContestCount, machineType);
@@ -385,7 +385,7 @@ export class SummaryBallotLayoutRenderer {
         languageContext
       );
 
-      const pageContests = remainingContests.slice(0, maxFit) as Contests;
+      const pageContests = remainingContests.slice(0, maxFit);
 
       pages.push({
         pageNumber,

--- a/libs/test-utils/src/arbitraries.ts
+++ b/libs/test-utils/src/arbitraries.ts
@@ -14,7 +14,6 @@ import {
   CandidateContest,
   CandidateId,
   ContestId,
-  Contests,
   County,
   CountyId,
   District,
@@ -33,6 +32,7 @@ import {
   ElectionId,
   BallotStyleGroupId,
   PrecinctSplit,
+  Contest,
 } from '@votingworks/types';
 import { sha256 } from 'js-sha256';
 import { DateWithoutTime, assertDefined } from '@votingworks/basics';
@@ -318,7 +318,7 @@ export function arbitraryContests({
   partyIds,
 }: {
   partyIds?: fc.Arbitrary<Array<Party['id']>>;
-} = {}): fc.Arbitrary<Contests> {
+} = {}): fc.Arbitrary<readonly Contest[]> {
   return fc
     .tuple(
       fc.array(

--- a/libs/test-utils/src/election_helpers.ts
+++ b/libs/test-utils/src/election_helpers.ts
@@ -1,6 +1,6 @@
 import { DateWithoutTime } from '@votingworks/basics';
 import {
-  AnyContest,
+  Contest,
   BallotStyle,
   CandidateContest,
   District,
@@ -61,7 +61,7 @@ export function createTestElection(
     abbrev: 'TP',
   };
 
-  const contests: AnyContest[] = [];
+  const contests: Contest[] = [];
 
   // Generate candidate contests
   for (let i = 0; i < numCandidateContests; i += 1) {
@@ -170,7 +170,7 @@ export function createElectionDefinition(
  * @param contestIds - Optional filter to only create votes for specific contest IDs
  */
 export function createMockVotes(
-  contests: AnyContest[],
+  contests: Contest[],
   contestIds?: string[]
 ): VotesDict {
   const filteredContests = contestIds

--- a/libs/types/src/cdf/ballot-definition/convert.ts
+++ b/libs/types/src/cdf/ballot-definition/convert.ts
@@ -517,7 +517,7 @@ export function convertVxfElectionToCdfBallotDefinition(
     );
 
     function optionIdForPosition(
-      contest: Vxf.AnyContest,
+      contest: Vxf.Contest,
       gridPosition: Vxf.GridPosition
     ): string {
       switch (gridPosition.type) {
@@ -544,7 +544,7 @@ export function convertVxfElectionToCdfBallotDefinition(
     }
 
     function getOrderedPhysicalContestOptions(
-      contest: Vxf.AnyContest
+      contest: Vxf.Contest
     ): Cdf.PhysicalContestOption[] {
       // For candidate contests, use the ordered candidates from the ballot style
       if (contest.type === 'candidate') {
@@ -1120,7 +1120,7 @@ export function convertCdfBallotDefinitionToVxfElection(
       abbrev: englishText(party.Abbreviation),
     })),
 
-    contests: election.Contest.map((contest): Vxf.AnyContest => {
+    contests: election.Contest.map((contest): Vxf.Contest => {
       const contestBase = {
         id: contest['@id'],
         title: englishText(contest.BallotTitle),

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -271,7 +271,6 @@ export const ContestSchema: z.ZodSchema<Contest> = z.union([
   YesNoContestSchema,
 ]);
 
-export type Contests = readonly Contest[];
 export const ContestsSchema = z.array(ContestSchema).check((ctx) => {
   const contests = ctx.value;
   for (const [index, id] of findDuplicateIds(contests)) {
@@ -697,7 +696,7 @@ export interface Election {
   readonly ballotLayout: BallotLayout;
   readonly ballotStrings: UiStringsPackage;
   readonly ballotStyles: readonly BallotStyle[];
-  readonly contests: Contests;
+  readonly contests: readonly Contest[];
   readonly county: County;
   readonly date: DateWithoutTime;
   readonly districts: readonly District[];

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -164,34 +164,21 @@ export const OptionalCandidateSchema: z.ZodSchema<OptionalCandidate> =
   CandidateSchema.optional();
 
 // Contests
-export type ContestTypes = 'candidate' | 'yesno';
-export const ContestTypesSchema: z.ZodSchema<ContestTypes> = z.union([
-  z.literal('candidate'),
-  z.literal('yesno'),
-]);
 export type ContestId = Id;
 export const ContestIdSchema: z.ZodSchema<ContestId> = IdSchema;
-export interface Contest {
+
+interface ContestBase {
   readonly id: ContestId;
   readonly districtId: DistrictId;
   readonly title: string;
-  readonly type: ContestTypes;
 }
 
-/**
- * Generic type-agnostic contest type, enabling common operations on canonical
- * {@link Contest}s and BMD-specific ms-either-neither contests.
- */
-export type ContestLike = Pick<Contest, 'id' | 'districtId' | 'title'>;
-
-const ContestInternalSchema = z.object({
+const ContestBaseSchema = z.object({
   id: ContestIdSchema,
   districtId: DistrictIdSchema,
   title: z.string().nonempty(),
-  type: ContestTypesSchema,
 });
-export const ContestSchema: z.ZodSchema<Contest> = ContestInternalSchema;
-export interface CandidateContest extends Contest {
+export interface CandidateContest extends ContestBase {
   readonly type: 'candidate';
   readonly seats: number;
   readonly candidates: readonly Candidate[];
@@ -200,16 +187,14 @@ export interface CandidateContest extends Contest {
   readonly termDescription?: string;
 }
 export const CandidateContestSchema: z.ZodSchema<CandidateContest> =
-  ContestInternalSchema.merge(
-    z.object({
-      type: z.literal('candidate'),
-      seats: z.number().int().positive(),
-      candidates: z.array(CandidateSchema),
-      allowWriteIns: z.boolean(),
-      partyId: PartyIdSchema.optional(),
-      termDescription: z.string().nonempty().optional(),
-    })
-  ).check((ctx) => {
+  ContestBaseSchema.extend({
+    type: z.literal('candidate'),
+    seats: z.number().int().positive(),
+    candidates: z.array(CandidateSchema),
+    allowWriteIns: z.boolean(),
+    partyId: PartyIdSchema.optional(),
+    termDescription: z.string().nonempty().optional(),
+  }).check((ctx) => {
     const contest = ctx.value;
     for (const [index, id] of findDuplicateIds(contest.candidates)) {
       ctx.issues.push({
@@ -264,7 +249,7 @@ export const YesNoOptionSchema: z.ZodSchema<YesNoOption> = z.object({
   label: z.string().nonempty(),
 });
 
-export interface YesNoContest extends Contest {
+export interface YesNoContest extends ContestBase {
   readonly type: 'yesno';
   readonly description: string;
   readonly yesOption: YesNoOption;
@@ -272,24 +257,22 @@ export interface YesNoContest extends Contest {
   readonly additionalOptions?: readonly YesNoOption[];
 }
 export const YesNoContestSchema: z.ZodSchema<YesNoContest> =
-  ContestInternalSchema.merge(
-    z.object({
-      type: z.literal('yesno'),
-      description: z.string().nonempty(),
-      yesOption: YesNoOptionSchema,
-      noOption: YesNoOptionSchema,
-      additionalOptions: z.array(YesNoOptionSchema).optional(),
-    })
-  );
+  ContestBaseSchema.extend({
+    type: z.literal('yesno'),
+    description: z.string().nonempty(),
+    yesOption: YesNoOptionSchema,
+    noOption: YesNoOptionSchema,
+    additionalOptions: z.array(YesNoOptionSchema).optional(),
+  });
 
-export type AnyContest = CandidateContest | YesNoContest;
-export const AnyContestSchema: z.ZodSchema<AnyContest> = z.union([
+export type Contest = CandidateContest | YesNoContest;
+export const ContestSchema: z.ZodSchema<Contest> = z.union([
   CandidateContestSchema,
   YesNoContestSchema,
 ]);
 
-export type Contests = readonly AnyContest[];
-export const ContestsSchema = z.array(AnyContestSchema).check((ctx) => {
+export type Contests = readonly Contest[];
+export const ContestsSchema = z.array(ContestSchema).check((ctx) => {
   const contests = ctx.value;
   for (const [index, id] of findDuplicateIds(contests)) {
     ctx.issues.push({

--- a/libs/types/src/election_utils.ts
+++ b/libs/types/src/election_utils.ts
@@ -6,15 +6,13 @@ import {
   throwIllegalValue,
 } from '@votingworks/basics';
 import {
-  AnyContest,
+  Contest,
   HmpbBallotPaperSize,
   BallotStyle,
   BallotStyleId,
   Candidate,
   CandidateContest,
-  Contest,
   ContestId,
-  ContestLike,
   Contests,
   District,
   DistrictId,
@@ -216,7 +214,7 @@ export function findContest({
 }: {
   contests: Contests;
   contestId: ContestId;
-}): AnyContest | undefined {
+}): Contest | undefined {
   return contests.find((c) => c.id === contestId);
 }
 

--- a/libs/types/src/election_utils.ts
+++ b/libs/types/src/election_utils.ts
@@ -402,7 +402,7 @@ export function getPartyIdsInBallotStyles(
 
 export function getContestDistrict(
   election: Election,
-  contest: ContestLike
+  contest: Pick<Contest, 'districtId'>
 ): District {
   const district = election.districts.find((d) => d.id === contest.districtId);
   /* istanbul ignore next */

--- a/libs/types/src/election_utils.ts
+++ b/libs/types/src/election_utils.ts
@@ -13,7 +13,6 @@ import {
   Candidate,
   CandidateContest,
   ContestId,
-  Contests,
   District,
   DistrictId,
   Election,
@@ -44,7 +43,7 @@ export function getContests({
 }: {
   ballotStyle: BallotStyle | BallotStyleGroup;
   election: Election;
-}): Contests {
+}): readonly Contest[] {
   return election.contests.filter(
     (contest) =>
       ballotStyle.districts.includes(contest.districtId) &&
@@ -212,7 +211,7 @@ export function findContest({
   contests,
   contestId,
 }: {
-  contests: Contests;
+  contests: readonly Contest[];
   contestId: ContestId;
 }): Contest | undefined {
   return contests.find((c) => c.id === contestId);
@@ -224,7 +223,7 @@ export function findContest({
 export function getContestsFromIds(
   election: Election,
   contestIds: readonly ContestId[]
-): Contests {
+): readonly Contest[] {
   return Array.from(new Set(contestIds)).map((id) => {
     const contest = election.contests.find((c) => c.id === id);
     if (!contest) {
@@ -450,7 +449,7 @@ export function getContestDistrictName(
  * })
  */
 export function vote(
-  contests: Contests,
+  contests: readonly Contest[],
   shorthand: {
     [key: string]: Vote | string | readonly string[] | Candidate;
   }

--- a/libs/types/src/polling_places.test.ts
+++ b/libs/types/src/polling_places.test.ts
@@ -1,8 +1,7 @@
 import { expect, test, vi } from 'vitest';
 import {
-  AnyContest,
-  BallotStyle,
   Contest,
+  BallotStyle,
   Election,
   PollingPlace,
   Precinct,
@@ -95,10 +94,7 @@ test('pollingPlaceContests', () => {
     precincts: [precinct1, precinct2],
   });
 
-  function expectContests(
-    place: Partial<PollingPlace>,
-    expected: AnyContest[]
-  ) {
+  function expectContests(place: Partial<PollingPlace>, expected: Contest[]) {
     expect(pollingPlaceContests(election, mockPollingPlace(place))).toEqual(
       expected
     );
@@ -360,8 +356,8 @@ function mockBallotStyle(partial: Partial<BallotStyle>): BallotStyle {
   return partial as BallotStyle;
 }
 
-function mockContest(partial: Partial<Contest>): AnyContest {
-  return partial as AnyContest;
+function mockContest(partial: Partial<Contest>): Contest {
+  return partial as Contest;
 }
 
 function mockElection(partial: Partial<Election>): Election {

--- a/libs/types/src/polling_places.ts
+++ b/libs/types/src/polling_places.ts
@@ -1,7 +1,7 @@
 import { assertDefined, throwIllegalValue } from '@votingworks/basics';
 import {
   BallotStyle,
-  Contests,
+  Contest,
   Election,
   hasSplits,
   PollingPlace,
@@ -31,7 +31,7 @@ export function pollingPlaceBallotStyles(
 export function pollingPlaceContests(
   election: Election,
   place: PollingPlace
-): Contests {
+): readonly Contest[] {
   const districts = pollingPlaceDistrictIds(election, place);
   return election.contests.filter((c) => districts.has(c.districtId));
 }

--- a/libs/types/src/tabulation.ts
+++ b/libs/types/src/tabulation.ts
@@ -1,5 +1,5 @@
 import {
-  AnyContest,
+  Contest,
   BallotCastingMode,
   BallotStyleGroupId,
   BallotType,
@@ -20,7 +20,7 @@ export interface ContestResultsMetadata {
 
 type ContestResultsBase = ContestResultsMetadata & {
   readonly contestId: ContestId;
-  readonly contestType: AnyContest['type'];
+  readonly contestType: Contest['type'];
 };
 
 export type YesNoContestResults = ContestResultsBase & {

--- a/libs/ui/src/bmd_paper_ballot.tsx
+++ b/libs/ui/src/bmd_paper_ballot.tsx
@@ -12,7 +12,7 @@ import {
   BallotType,
   CandidateContest,
   CandidateVote,
-  Contests,
+  Contest,
   Election,
   ElectionDefinition,
   formatBallotHash,
@@ -235,14 +235,14 @@ export const MAX_CONTESTS_PER_MULTI_PAGE_BALLOT_PAGE = 25;
  * Returns an array where each element is the contests for one page.
  */
 export function splitContestsForPages(
-  contests: Contests,
+  contests: readonly Contest[],
   maxContestsPerPage: number = MAX_CONTESTS_PER_MULTI_PAGE_BALLOT_PAGE
-): Contests[] {
+): Array<readonly Contest[]> {
   if (contests.length === 0) {
     return [contests];
   }
 
-  const pages: Contests[] = [];
+  const pages: Array<readonly Contest[]> = [];
   for (let i = 0; i < contests.length; i += maxContestsPerPage) {
     pages.push(contests.slice(i, i + maxContestsPerPage));
   }
@@ -254,7 +254,7 @@ export function splitContestsForPages(
  * Determines if a ballot with the given contests needs multiple pages.
  */
 export function needsMultiplePages(
-  contests: Contests,
+  contests: readonly Contest[],
   maxContestsPerPage: number = MAX_CONTESTS_PER_MULTI_PAGE_BALLOT_PAGE
 ): boolean {
   return contests.length > maxContestsPerPage;
@@ -265,7 +265,7 @@ export function needsMultiplePages(
  */
 export function filterVotesForContests(
   votes: VotesDict,
-  contests: Contests
+  contests: readonly Contest[]
 ): VotesDict {
   const contestIds = new Set(contests.map((c) => c.id));
   const filtered: VotesDict = {};
@@ -408,7 +408,7 @@ const BallotSelections = styled.div<{ numColumns: number }>`
   columns: ${(p) => p.numColumns};
   column-gap: 1em;
 `;
-const Contest = styled.div`
+const ContestContainer = styled.div`
   border-bottom: 0.01em solid #000;
   padding: 0.25em 0;
   break-inside: avoid;
@@ -645,7 +645,7 @@ export interface BmdPaperBallotProps {
    * For multi-page BMD ballots: the subset of contests to render on this page.
    * When provided, only these contests are rendered and encoded.
    */
-  contestsForPage?: Contests;
+  contestsForPage?: readonly Contest[];
 }
 
 /**
@@ -661,7 +661,7 @@ function withPrintTheme(ballot: JSX.Element): JSX.Element {
 }
 
 function qrCodeLevelOverride(
-  contests: Contests,
+  contests: readonly Contest[],
   votes: VotesDict
 ): QrCodeLevel | undefined {
   let writeInCharCount = 0;
@@ -873,7 +873,7 @@ export function BmdPaperBallot({
                   ? find(election.parties, (p) => p.id === contest.partyId)
                   : undefined;
               return (
-                <Contest key={contest.id}>
+                <ContestContainer key={contest.id}>
                   {contestParty && (
                     <ContestParty>
                       <DualLanguageText
@@ -918,7 +918,7 @@ export function BmdPaperBallot({
                       vote={votes[contest.id] as YesNoVote}
                     />
                   )}
-                </Contest>
+                </ContestContainer>
               );
             })}
           </BallotSelections>

--- a/libs/ui/src/diagnostics/ballot_style_readiness_report.tsx
+++ b/libs/ui/src/diagnostics/ballot_style_readiness_report.tsx
@@ -1,9 +1,5 @@
 import styled from 'styled-components';
-import {
-  AnyContest,
-  ElectionDefinition,
-  getContests,
-} from '@votingworks/types';
+import { Contest, ElectionDefinition, getContests } from '@votingworks/types';
 import { format } from '@votingworks/utils';
 import React from 'react';
 import { Font, H2, H3 } from '../typography';
@@ -74,7 +70,7 @@ function BallotStyleDetail(props: BallotStyleDetailProps) {
   );
 }
 
-function getContestLabel(contest: AnyContest) {
+function getContestLabel(contest: Contest) {
   const prefix =
     contest.type === 'candidate' ? `[Vote for ${contest.seats}] ` : '';
   return `${prefix}${contest.title}`;

--- a/libs/ui/src/reports/admin_tally_report.tsx
+++ b/libs/ui/src/reports/admin_tally_report.tsx
@@ -1,6 +1,6 @@
 import {
   Admin,
-  Contests,
+  Contest,
   ElectionDefinition,
   Tabulation,
 } from '@votingworks/types';
@@ -35,7 +35,7 @@ export interface AdminTallyReportProps {
   electionDefinition: ElectionDefinition;
   electionPackageHash?: string;
   partyLabel?: string;
-  contests: Contests;
+  contests: readonly Contest[];
   scannedElectionResults: Tabulation.ElectionResults;
   manualElectionResults?: Tabulation.ManualElectionResults;
   cardCountsOverride?: Tabulation.CardCounts;

--- a/libs/ui/src/reports/contest_results_table.tsx
+++ b/libs/ui/src/reports/contest_results_table.tsx
@@ -36,7 +36,7 @@ const MetadataLabel = styled.p`
   font-size: 0.8em;
 `;
 
-const Contest = styled.div`
+const ContestContainer = styled.div`
   margin: 2.5em 0;
   page-break-inside: avoid;
 `;
@@ -280,7 +280,7 @@ export function ContestResultsTable({
   }
 
   return (
-    <Contest data-testid={`results-table-${contest.id}`}>
+    <ContestContainer data-testid={`results-table-${contest.id}`}>
       <DistrictName>{getContestDistrictName(election, contest)}</DistrictName>
       <ContestTitle>{contest.title}</ContestTitle>
       {contest.type === 'candidate' && (
@@ -320,6 +320,6 @@ export function ContestResultsTable({
       <ContestTable>
         <tbody>{contestTableRows}</tbody>
       </ContestTable>
-    </Contest>
+    </ContestContainer>
   );
 }

--- a/libs/ui/src/reports/contest_results_table.tsx
+++ b/libs/ui/src/reports/contest_results_table.tsx
@@ -5,7 +5,7 @@ import {
   Election,
   getContestDistrictName,
   Tabulation,
-  AnyContest,
+  Contest,
 } from '@votingworks/types';
 import { format, getTallyReportCandidateRows } from '@votingworks/utils';
 import { throwIllegalValue, assert, Optional } from '@votingworks/basics';
@@ -165,7 +165,7 @@ function ContestMetadataRow({
 
 interface Props {
   election: Election;
-  contest: AnyContest;
+  contest: Contest;
   scannedContestResults: Tabulation.ContestResults;
   manualContestResults?: Tabulation.ContestResults;
   aggregateInsignificantWriteIns?: boolean;

--- a/libs/ui/src/reports/precinct_scanner_tally_report.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_report.tsx
@@ -1,6 +1,6 @@
 import {
   BatchInfo,
-  Contests,
+  Contest,
   ElectionDefinition,
   PartyId,
   PrecinctSelection,
@@ -25,7 +25,7 @@ interface Props {
   partyId?: PartyId;
   pollingPlaceId?: string;
   precinctSelection?: PrecinctSelection;
-  contests: Contests;
+  contests: readonly Contest[];
   scannedElectionResults: Tabulation.ElectionResults;
   pollsTransition: StandardPollsTransitionType;
   isLiveMode: boolean;

--- a/libs/ui/src/reports/write_in_adjudication_report.tsx
+++ b/libs/ui/src/reports/write_in_adjudication_report.tsx
@@ -1,5 +1,5 @@
 import {
-  AnyContest,
+  Contest,
   CandidateContest,
   ElectionDefinition,
   isPrimary,
@@ -26,7 +26,7 @@ import {
 import { ReportGeneratedMetadata } from './report_generated_metadata';
 
 function getEmptyContestWriteInSummary(
-  contest: AnyContest
+  contest: Contest
 ): Tabulation.ContestWriteInSummary {
   return {
     contestId: contest.id,

--- a/libs/ui/src/ui_strings/election_strings.tsx
+++ b/libs/ui/src/ui_strings/election_strings.tsx
@@ -4,7 +4,7 @@ import {
   BallotStyle,
   Candidate,
   CandidateContest,
-  ContestLike,
+  Contest,
   County,
   DEFAULT_LANGUAGE_CODE,
   District,
@@ -22,7 +22,7 @@ import { UiRichTextString, UiString } from './ui_string';
 import { DateString } from './date_string';
 import { InEnglish } from './language_override';
 
-type ContestWithDescription = ContestLike & {
+type ContestWithDescription = Contest & {
   description: string;
 };
 
@@ -80,7 +80,7 @@ export const electionStrings = {
     </UiString>
   ),
 
-  [Key.CONTEST_TITLE]: (contest: ContestLike) => (
+  [Key.CONTEST_TITLE]: (contest: Pick<Contest, 'id' | 'title'>) => (
     <UiString uiStringKey={Key.CONTEST_TITLE} uiStringSubKey={contest.id}>
       {contest.title}
     </UiString>

--- a/libs/utils/src/cast_vote_records.ts
+++ b/libs/utils/src/cast_vote_records.ts
@@ -15,7 +15,6 @@ import {
   CastVoteRecordExportFileName,
   ContestId,
   ContestOptionId,
-  Contests,
   CVR,
   CVRSnapshotOtherStatus,
   CVRSnapshotOtherStatusSchema,
@@ -279,7 +278,7 @@ export type ContestReferenceError =
  */
 export function castVoteRecordHasValidContestReferences(
   cvr: CVR.CVR,
-  electionContests: Contests
+  electionContests: readonly Contest[]
 ): Result<void, ContestReferenceError> {
   for (const cvrSnapshot of cvr.CVRSnapshot) {
     for (const cvrContest of cvrSnapshot.CVRContest) {

--- a/libs/utils/src/cast_vote_records.ts
+++ b/libs/utils/src/cast_vote_records.ts
@@ -10,7 +10,7 @@ import {
   typedAs,
 } from '@votingworks/basics';
 import {
-  AnyContest,
+  Contest,
   BallotType,
   CastVoteRecordExportFileName,
   ContestId,
@@ -252,7 +252,7 @@ export function isCastVoteRecordWriteInValid(
   return Boolean(cvrWriteIn.side || cvrWriteIn.text);
 }
 
-function getValidContestOptions(contest: AnyContest): ContestOptionId[] {
+function getValidContestOptions(contest: Contest): ContestOptionId[] {
   switch (contest.type) {
     case 'candidate':
       return [

--- a/libs/utils/src/hmpb/all_contest_options.ts
+++ b/libs/utils/src/hmpb/all_contest_options.ts
@@ -4,7 +4,7 @@ import {
   uniqueBy,
 } from '@votingworks/basics';
 import {
-  AnyContest,
+  Contest,
   BallotStyle,
   BallotStyleGroup,
   CandidateContest,
@@ -37,7 +37,7 @@ export function allContestOptionsWithMultiEndorsements(
  * For candidate contests, respects ballot style-specific candidate rotation.
  */
 export function allContestOptionsWithMultiEndorsements(
-  contest: AnyContest,
+  contest: Contest,
   ballotStyle: BallotStyle | BallotStyleGroup
 ): Generator<ContestOption>;
 /**
@@ -46,7 +46,7 @@ export function allContestOptionsWithMultiEndorsements(
  * For candidate contests, respects ballot style-specific candidate rotation.
  */
 export function* allContestOptionsWithMultiEndorsements(
-  contest: AnyContest,
+  contest: Contest,
   ballotStyle?: BallotStyle | BallotStyleGroup
 ): Generator<ContestOption> {
   switch (contest.type) {
@@ -125,7 +125,7 @@ export function allContestOptions(
  * For candidate contests, respects ballot style-specific candidate rotation.
  */
 export function allContestOptions(
-  contest: AnyContest,
+  contest: Contest,
   ballotStyle: BallotStyle | BallotStyleGroup
 ): Generator<ContestOption>;
 /**
@@ -134,7 +134,7 @@ export function allContestOptions(
  * candidates to the first appearance.
  */
 export function* allContestOptions(
-  contest: AnyContest,
+  contest: Contest,
   ballotStyle?: BallotStyle | BallotStyleGroup
 ): Generator<ContestOption> {
   // Get all options including multi-endorsed duplicates, then de-duplicate by id

--- a/libs/utils/src/tabulation/compressed_tallies.ts
+++ b/libs/utils/src/tabulation/compressed_tallies.ts
@@ -1,5 +1,5 @@
 import {
-  AnyContest,
+  Contest,
   CandidateContestCompressedTally,
   CandidateContestCompressedTallySchema,
   CompressedTally,
@@ -226,7 +226,7 @@ export function compressAndEncodePerPrecinctTally({
 }
 
 function getContestTalliesForCompressedContest(
-  contest: AnyContest,
+  contest: Contest,
   compressedContest: CompressedTallyEntry
 ): Tabulation.ContestResults {
   switch (contest.type) {
@@ -298,7 +298,7 @@ function getContestTalliesForCompressedContest(
 // The length of a yes/no contest compressed tally is always 5: undervotes, overvotes, ballots, yes, no
 const yesNoContestCompressedTallyLength: YesNoContestCompressedTally['length'] = 5;
 
-function getNumberOfEntriesInContest(contest: AnyContest): number {
+function getNumberOfEntriesInContest(contest: Contest): number {
   switch (contest.type) {
     case 'yesno':
       return yesNoContestCompressedTallyLength;
@@ -379,7 +379,7 @@ export function decodeV0CompressedTally(
  */
 function decodeContestEntriesFromUint16Array(
   uint16Array: Uint16Array,
-  contests: readonly AnyContest[],
+  contests: readonly Contest[],
   offset: number
 ): { contestResults: Record<ContestId, ContestResults>; nextOffset: number } {
   const contestResults: Record<ContestId, ContestResults> = {};

--- a/libs/utils/src/tabulation/contest_filtering.ts
+++ b/libs/utils/src/tabulation/contest_filtering.ts
@@ -4,7 +4,7 @@ import {
   Election,
   ElectionDefinition,
   PrecinctId,
-  AnyContest,
+  Contest,
   Contests,
   PrecinctSelection,
   PartyId,
@@ -62,7 +62,7 @@ export const getContestIdsForPrecinct = createElectionMetadataLookupFunction(
 export function mapContestIdsToContests(
   electionDefinition: ElectionDefinition,
   contestIds: Set<ContestId>
-): AnyContest[] {
+): Contest[] {
   return electionDefinition.election.contests.filter((c) =>
     contestIds.has(c.id)
   );

--- a/libs/utils/src/tabulation/contest_filtering.ts
+++ b/libs/utils/src/tabulation/contest_filtering.ts
@@ -5,7 +5,6 @@ import {
   ElectionDefinition,
   PrecinctId,
   Contest,
-  Contests,
   PrecinctSelection,
   PartyId,
   getPartyIdsWithContests,
@@ -71,7 +70,7 @@ export function mapContestIdsToContests(
 export function getContestsForPrecinct(
   electionDefinition: ElectionDefinition,
   precinctSelection: PrecinctSelection
-): Contests {
+): readonly Contest[] {
   const { election } = electionDefinition;
   if (precinctSelection.kind === 'AllPrecincts') {
     return election.contests;
@@ -91,7 +90,7 @@ export function getContestsForPrecinct(
 export function getContestsForPrecinctAndElection(
   election: Election,
   precinctSelection: PrecinctSelection
-): Contests {
+): readonly Contest[] {
   if (precinctSelection.kind === 'AllPrecincts') {
     return election.contests;
   }
@@ -105,12 +104,12 @@ export function getContestsForPrecinctAndElection(
 export interface PartyWithContests {
   partyId?: PartyId; // undefined for non-partisan contests
   partyName?: string;
-  contests: Contests;
+  contests: readonly Contest[];
 }
 
 export function groupContestsByParty(
   election: Election,
-  contests: Contests
+  contests: readonly Contest[]
 ): PartyWithContests[] {
   return getPartyIdsWithContests(election).map((partyId) => ({
     partyId,

--- a/libs/utils/src/tabulation/lookups.ts
+++ b/libs/utils/src/tabulation/lookups.ts
@@ -1,6 +1,6 @@
 import { assert, assertDefined } from '@votingworks/basics';
 import {
-  AnyContest,
+  Contest,
   BallotStyle,
   BallotStyleGroupId,
   BallotStyleId,
@@ -73,7 +73,7 @@ export const getPartyById = createElectionMetadataLookupFunction((election) => {
 export const getContestById = createElectionMetadataLookupFunction(
   (election) => {
     const { contests } = election;
-    const lookup: Record<string, AnyContest> = {};
+    const lookup: Record<string, Contest> = {};
     for (const contest of contests) {
       lookup[contest.id] = contest;
     }

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -1,6 +1,6 @@
 import { assert, assertDefined, iter } from '@votingworks/basics';
 import {
-  AnyContest,
+  Contest,
   BallotStyleGroupId,
   CandidateContest,
   CandidateId,
@@ -523,7 +523,7 @@ export function combineContestResults({
   contest,
   allContestResults,
 }: {
-  contest: AnyContest;
+  contest: Contest;
   allContestResults: Tabulation.ContestResults[];
 }): Tabulation.ContestResults {
   if (contest.type === 'yesno') {
@@ -733,7 +733,7 @@ export function buildContestResultsFixture({
   contestResultsSummary,
   includeGenericWriteIn,
 }: {
-  contest: AnyContest;
+  contest: Contest;
   contestResultsSummary: ContestResultsSummary;
   includeGenericWriteIn?: boolean;
 }): Tabulation.ContestResults {

--- a/libs/utils/src/test_decks.ts
+++ b/libs/utils/src/test_decks.ts
@@ -6,7 +6,7 @@ import {
   uniqueBy,
 } from '@votingworks/basics';
 import {
-  AnyContest,
+  Contest,
   WriteInCandidate,
   CandidateContest,
   Candidate,
@@ -46,7 +46,7 @@ export interface TestDeckBallot {
   votes: VotesDict;
 }
 
-export function numBallotPositions(contest: AnyContest): number {
+export function numBallotPositions(contest: Contest): number {
   if (contest.type === 'candidate') {
     return (
       contest.candidates.length + (contest.allowWriteIns ? contest.seats : 0)

--- a/libs/utils/src/votes.ts
+++ b/libs/utils/src/votes.ts
@@ -5,7 +5,7 @@ import {
   CandidateContest,
   CandidateId,
   CandidateVote,
-  Contests,
+  Contest,
   MarkStatus,
   MarkThresholds,
   safeParse,
@@ -157,7 +157,7 @@ function deduplicateVotes(vote: Vote): Vote {
  * Convert {@link BallotTargetMark}s to {@link VotesDict}.
  */
 export function convertMarksToVotesDict(
-  contests: Contests,
+  contests: readonly Contest[],
   markThresholds: MarkThresholdsOptionalMarginal,
   marks: Iterable<BallotTargetMark>
 ): VotesDict {


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->
Just a little cleanup before adding a new straight party contest type. Removes the various confusing types associated with contests and reduces down to a single union type: `Contest`.

## Demo Video or Screenshot
N/A

## Testing Plan
Existing tests
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
