### PR TITLE
[Mark, MarkScan] Remove repetitive prefix on single-ballot-style select button

### DIFF
--- a/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark-scan/frontend/src/app_cardless_voting.test.tsx
@@ -65,11 +65,7 @@ test('Cardless Voting Flow', async () => {
     .expectCallWith({ ballotStyleId: '12', precinctId: '23' })
     .resolves();
   apiMock.expectSetAcceptingPaperState();
-  userEvent.click(
-    screen.getByText(
-      hasTextAcrossElements('Start Voting Session: Center Springfield')
-    )
-  );
+  userEvent.click(screen.getButton('Center Springfield'));
 
   apiMock.setPaperHandlerState('accepting_paper');
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
@@ -94,11 +90,7 @@ test('Cardless Voting Flow', async () => {
     .expectCallWith({ ballotStyleId: '12', precinctId: '23' })
     .resolves();
   apiMock.expectSetAcceptingPaperState();
-  userEvent.click(
-    screen.getByText(
-      hasTextAcrossElements('Start Voting Session: Center Springfield')
-    )
-  );
+  userEvent.click(screen.getButton('Center Springfield'));
 
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
     cardlessVoterUserParams: {
@@ -145,11 +137,7 @@ test('Cardless Voting Flow', async () => {
     .expectCallWith({ ballotStyleId: '12', precinctId: '23' })
     .resolves();
   apiMock.expectSetAcceptingPaperState();
-  userEvent.click(
-    screen.getByText(
-      hasTextAcrossElements('Start Voting Session: Center Springfield')
-    )
-  );
+  userEvent.click(screen.getButton('Center Springfield'));
 
   mockLoadPaper();
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {

--- a/apps/mark-scan/frontend/src/app_open_primary.test.tsx
+++ b/apps/mark-scan/frontend/src/app_open_primary.test.tsx
@@ -49,11 +49,7 @@ async function activateCardlessVoterSession() {
     })
     .resolves();
   apiMock.expectSetAcceptingPaperState();
-  userEvent.click(
-    screen.getByText(
-      hasTextAcrossElements(`Start Voting Session: ${PRECINCT_NAME}`)
-    )
-  );
+  userEvent.click(screen.getButton(PRECINCT_NAME));
 
   apiMock.setPaperHandlerState('accepting_paper');
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {

--- a/apps/mark-scan/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/mark-scan/integration-testing/e2e/screenshots.spec.ts
@@ -32,6 +32,7 @@ import {
 } from './support/flows';
 
 const POLLING_PLACE_NAME = 'North Lincoln';
+const PRECINCT_NAME = 'North Lincoln';
 
 test.beforeAll(setupTemporaryRootDir);
 test.afterAll(clearTemporaryRootDir);
@@ -225,10 +226,10 @@ test('basic election flow', async ({ page }, testInfo) => {
   await page.getByText('Poll Worker Menu').waitFor();
   await screenshot('pw-menu-polls-open');
   await screenshotWithButtonHighlight(
-    /Start Voting Session/,
+    PRECINCT_NAME,
     'pw-start-voting-session-button'
   );
-  await page.getByText(/Start Voting Session/).click();
+  await page.getByRole('button', { name: PRECINCT_NAME }).click();
   await insertBlankBallotSheet(page);
   await page.getByText(/Remove Card/).waitFor();
   await screenshot('pw-remove-card-to-vote');
@@ -460,7 +461,7 @@ test('voter settings', async ({ page }, testInfo) => {
   mockCardRemoval();
   await page.getByText('Insert a poll worker card to open.').waitFor();
   await openPolls(page, election);
-  await startVotingSession(page);
+  await startVotingSession(page, { precinctName: PRECINCT_NAME });
   await page.getByRole('button', { name: 'Start Voting' }).click();
 
   // Voter is on the first contest; the language and settings menu buttons are

--- a/apps/mark-scan/integration-testing/e2e/support/flows.ts
+++ b/apps/mark-scan/integration-testing/e2e/support/flows.ts
@@ -91,9 +91,14 @@ export async function openPolls(page: Page, election: Election): Promise<void> {
  * mechanical states automatically, so no paper status needs to be set. Removes
  * the poll worker card and leaves the voter on the "Start Voting" screen.
  */
-export async function startVotingSession(page: Page): Promise<void> {
+export async function startVotingSession(
+  page: Page,
+  params: {
+    precinctName: string;
+  }
+): Promise<void> {
   const startButton = page.getByRole('button', {
-    name: /Start Voting Session/,
+    name: params.precinctName,
   });
   await startButton.waitFor();
   await startButton.click();

--- a/apps/mark/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark/frontend/src/app_cardless_voting.test.tsx
@@ -3,6 +3,7 @@ import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { PollingPlace } from '@votingworks/types';
+import { find } from '@votingworks/basics';
 import { render, screen } from '../test/react_testing_library';
 import * as GLOBALS from './config/globals';
 
@@ -33,6 +34,8 @@ vi.setConfig({
 const precinctId = '23';
 const pollingPlaceId = `${precinctId}-polling-place`;
 const electionDefinition = readElectionGeneralDefinition();
+const { election } = electionDefinition;
+const precinct = find(election.precincts, (p) => p.id === precinctId);
 
 test('poll worker selects ballot style, voter votes', async () => {
   apiMock.expectGetMachineConfig();
@@ -60,13 +63,13 @@ test('poll worker selects ballot style, voter votes', async () => {
   apiMock.mockApiClient.endCardlessVoterSession.expectCallWith().resolves();
   userEvent.click(await screen.findByText('Deactivate Voting Session'));
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
-  await screen.findByText('Start Voting Session:');
+  await screen.findByText('Start a New Voting Session');
 
   // Poll worker reactivates ballot style
   apiMock.mockApiClient.startCardlessVoterSession
     .expectCallWith({ ballotStyleId: '12', precinctId: '23' })
     .resolves();
-  userEvent.click(screen.getByText('Start Voting Session:'));
+  userEvent.click(await screen.findButton(precinct.name));
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
     cardlessVoterUserParams: {
       ballotStyleId: '12',
@@ -104,13 +107,13 @@ test('poll worker selects ballot style, voter votes', async () => {
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
 
   // Back on poll worker screen
-  await screen.findByText('Start Voting Session:');
+  await screen.findByText('Start a New Voting Session');
 
   // Activates Ballot Style again
   apiMock.mockApiClient.startCardlessVoterSession
     .expectCallWith({ ballotStyleId: '12', precinctId: '23' })
     .resolves();
-  userEvent.click(screen.getByText('Start Voting Session:'));
+  userEvent.click(screen.getButton(precinct.name));
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
     cardlessVoterUserParams: {
       ballotStyleId: '12',
@@ -247,8 +250,6 @@ test('poll worker card insertion during printing does not cause duplicate print'
 });
 
 test('in multi-precinct location, poll worker must select a precinct first', async () => {
-  const { election } = electionDefinition;
-
   const multiPrecinctLocation: PollingPlace = {
     id: 'multi-precinct-polling-place',
     name: 'Springfield Community Center',

--- a/apps/mark/frontend/src/app_end_to_end.test.tsx
+++ b/apps/mark/frontend/src/app_end_to_end.test.tsx
@@ -211,9 +211,7 @@ test('MarkAndPrint end-to-end flow', async () => {
     .expectCallWith({ ballotStyleId, precinctId })
     .resolves();
 
-  userEvent.click(
-    await screen.findButton(`Start Voting Session: ${pollingPlace.name}`)
-  );
+  userEvent.click(await screen.findButton(precinct.name));
   await waitFor(apiMock.mockApiClient.assertComplete);
 
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {

--- a/apps/mark/frontend/src/app_open_primary.test.tsx
+++ b/apps/mark/frontend/src/app_open_primary.test.tsx
@@ -49,7 +49,7 @@ test('poll worker activates session, voter picks party and walks through ballot'
 
   // Poll worker logs in to activate a cardless voter session.
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition);
-  await screen.findByText('Start Voting Session:');
+  await screen.findByText('Start a New Voting Session');
 
   apiMock.mockApiClient.startCardlessVoterSession
     .expectCallWith({
@@ -57,7 +57,7 @@ test('poll worker activates session, voter picks party and walks through ballot'
       precinctId: PRECINCT_ID,
     })
     .resolves();
-  userEvent.click(screen.getButton(`Start Voting Session: ${PRECINCT_NAME}`));
+  userEvent.click(screen.getButton(PRECINCT_NAME));
   apiMock.setAuthStatusPollWorkerLoggedIn(electionDefinition, {
     cardlessVoterUserParams: {
       ballotStyleId: BALLOT_STYLE_ID,

--- a/apps/mark/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/mark/integration-testing/e2e/screenshots.spec.ts
@@ -36,6 +36,7 @@ import { configureMachine, openPolls, voteFullBallot } from './support/flows';
 import { capturePrintedBallot } from './support/reports';
 
 const POLLING_PLACE_NAME = 'North Lincoln';
+const PRECINCT_NAME = 'North Lincoln';
 
 test.beforeAll(setupTemporaryRootDir);
 test.afterAll(clearTemporaryRootDir);
@@ -231,10 +232,10 @@ test('basic election flow', async ({ page }, testInfo) => {
   await page.getByText('Poll Worker Menu').waitFor();
   await screenshot('pw-menu-polls-open');
   await screenshotWithButtonHighlight(
-    /Start Voting Session/,
+    PRECINCT_NAME,
     'pw-start-voting-session-button'
   );
-  await page.getByRole('button', { name: /Start Voting Session/ }).click();
+  await page.getByRole('button', { name: PRECINCT_NAME }).click();
 
   // Poll worker prompted to remove card so the voter can begin.
   await page.getByText('Remove Card to Begin Voting Session').waitFor();
@@ -453,6 +454,7 @@ test('voter settings', async ({ page }, testInfo) => {
   const electionDefinition = getMultiLanguageGeneralElectionDefinition();
   const { election } = electionDefinition;
   const pollingPlaceName = 'Center Springfield';
+  const precinctName = 'Center Springfield';
   const helper = buildIntegrationTestHelper(page, namer);
   const { screenshot, screenshotWithLocatorHighlight } = helper;
   const electionPackage = await mockElectionPackageFileTree({
@@ -477,7 +479,7 @@ test('voter settings', async ({ page }, testInfo) => {
   mockCardRemoval();
   await page.getByText(/poll worker card/).waitFor();
   await openPolls(page, election);
-  await page.getByRole('button', { name: /Start Voting Session/ }).click();
+  await page.getByRole('button', { name: precinctName }).click();
   await page.getByText('Remove Card to Begin Voting Session').waitFor();
   mockCardRemoval();
   await page.getByRole('button', { name: 'Start Voting' }).click();

--- a/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
+++ b/apps/mark/integration-testing/e2e/scroll_buttons.spec.ts
@@ -88,7 +88,7 @@ test('configure, open polls, and test contest scroll buttons', async ({
   await openPolls(page, election);
 
   // Poll Worker: initiate voting session
-  await page.getByText('Start Voting Session: Center Springfield').click();
+  await page.getByRole('button', { name: 'Center Springfield' }).click();
   await page.getByText('Remove Card to Begin Voting Session').waitFor();
   mockCardRemoval();
 

--- a/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.test.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.test.tsx
@@ -30,7 +30,7 @@ describe('general election', () => {
       configuredPrecinctsAndSplits: toPrecinctsOrSplitList([precinct]),
     });
 
-    userEvent.click(screen.getButton(`Start Voting Session: ${precinct.name}`));
+    userEvent.click(screen.getButton(precinct.name));
     expect(onSelect).toHaveBeenCalledOnce();
     expect(onSelect).toHaveBeenCalledWith(precinct.id, ballotStyle.id);
   });
@@ -197,7 +197,7 @@ describe('open primary election', () => {
 
     // No party picker — pressing the precinct button immediately selects the
     // precinct's single (partyless) ballot style.
-    userEvent.click(screen.getButton(`Start Voting Session: ${precinct.name}`));
+    userEvent.click(screen.getButton(precinct.name));
     expect(onSelect).toHaveBeenCalledOnce();
     expect(onSelect).toHaveBeenCalledWith(precinct.id, 'ballot-style-1');
   });

--- a/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.tsx
@@ -12,14 +12,7 @@ import {
   type PrecinctOrSplit,
   type PrecinctSplitId,
 } from '@votingworks/types';
-import {
-  Button,
-  electionStrings,
-  Font,
-  P,
-  SearchSelect,
-  TextOnly,
-} from '@votingworks/ui';
+import { Button, Font, P, SearchSelect } from '@votingworks/ui';
 import { getBallotStyleGroupsForPrecinctOrSplit } from '@votingworks/utils';
 import { useState } from 'react';
 import { ButtonGrid } from './elements';
@@ -73,8 +66,7 @@ export function BallotStyleSelect(props: BallotStyleSelectProps): JSX.Element {
             rightIcon="Next"
             disabled={disabled}
           >
-            Start Voting Session:{' '}
-            <TextOnly>{electionStrings.precinctName(precinct)}</TextOnly>
+            {precinct.name}
           </Button>
         );
       }


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/8611

It's come up a couple times [[1](https://votingworks.slack.com/archives/CJU9MSC6S/p1771968004794149), [2](https://votingworks.slack.com/archives/CJU9MSC6S/p1780877078038649)] and I just noticed it again while working on another task. Needs to go.

## Demo Video or Screenshot

| Before | After |
| - | - |
| <img width="539" height="961" alt="Screenshot 2026-06-11 at 12 28 49" src="https://github.com/user-attachments/assets/327d01db-2f12-4dca-bbc8-e72b1eeb7be8" /> | <img width="539" height="961" alt="Screenshot 2026-06-11 at 12 29 03" src="https://github.com/user-attachments/assets/f2e973f1-c0dd-4fa6-9c33-1fb80bb094c1" /> |

## Testing Plan
- Updated test assertions

## Checklist

- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
