### PR TITLE
Open primaries: Don't count ballots for other party as undervotes

### DIFF
--- a/apps/admin/backend/src/app.tally_report_csv.test.ts
+++ b/apps/admin/backend/src/app.tally_report_csv.test.ts
@@ -248,9 +248,13 @@ test('open primary: crossover, nonpartisan-only, and adjudicated ballots', async
     );
   }
 
-  // 3 happy Dem (alice-jones) + 1 resolved crossover (bob-smith)
-  // + 1 flipped Dem (now nonpartisan, gov-dem undervoted)
-  // Unresolved crossover's gov-dem vote is voided.
+  // 3 happy Dem (alice-jones) +
+  // 1 crossover converted to Dem (bob-smith) +
+  // 1 crossover converted to nonpartisan only +
+  // 1 crossover
+  //
+  // Last two shouldn't count, even as undervotes
+  //
   expect(totalVotesBySelectionId('governor-democratic')).toEqual({
     'alice-jones': '3',
     'bob-smith': '1',
@@ -258,19 +262,26 @@ test('open primary: crossover, nonpartisan-only, and adjudicated ballots', async
     'dan-rivera': '0',
     'emily-tran': '0',
     overvotes: '0',
-    undervotes: '1',
-    'ballots-cast': '5',
+    undervotes: '0',
+    'ballots-cast': '4',
   });
-  // 2 happy Rep + 1 resolved crossover (gov-rep now empty → undervote).
-  // Unresolved crossover's gov-rep vote is voided.
+
+  // 2 happy Rep (dave-wilson) +
+  // 1 crossover converted to Dem +
+  // 1 crossover converted to nonpartisan only +
+  // 1 crossover
+  //
+  // Last three shouldn't count, even as undervotes
+  //
   expect(totalVotesBySelectionId('governor-republican')).toEqual({
     'dave-wilson': '2',
     'ellen-brown': '0',
     'frank-lee': '0',
     overvotes: '0',
-    undervotes: '1',
-    'ballots-cast': '3',
+    undervotes: '0',
+    'ballots-cast': '2',
   });
+
   expect(totalVotesBySelectionId('governor-libertarian')).toEqual({
     'grace-kim': '1',
     'henry-park': '0',
@@ -278,6 +289,7 @@ test('open primary: crossover, nonpartisan-only, and adjudicated ballots', async
     undervotes: '0',
     'ballots-cast': '1',
   });
+
   // Every one of the 10 ballots — single-party, nonpartisan-only,
   // crossover (resolved + unresolved), and flipped — votes nonpartisan.
   expect(totalVotesBySelectionId('circuit-court-judge')).toEqual({

--- a/libs/utils/src/tabulation/tabulation.test.ts
+++ b/libs/utils/src/tabulation/tabulation.test.ts
@@ -1471,6 +1471,76 @@ describe('open primaries', () => {
       expect(results.contestResults[contest.id]?.ballots).toEqual(0);
     }
   });
+
+  test("open primary ballots omit other parties' contests rather than counting undervotes", async () => {
+    const results = (
+      await tabulateCastVoteRecords({
+        election: openPrimaryElection,
+        cvrs: [
+          // Dem ballot
+          {
+            ...baseCvrMetadata,
+            votes: {
+              'governor-democratic': ['alice-jones'],
+              'governor-republican': [],
+              'governor-libertarian': [],
+              'secretary-of-state-democratic': [],
+              'ballot-measure-1': ['ballot-measure-1-yes'],
+            },
+          },
+          // Rep ballot
+          {
+            ...baseCvrMetadata,
+            votes: {
+              'governor-democratic': [],
+              'governor-republican': ['dave-wilson'],
+              'governor-libertarian': [],
+              'secretary-of-state-democratic': [],
+              'ballot-measure-1': ['ballot-measure-1-yes'],
+            },
+          },
+          // Crossover ballot
+          {
+            ...baseCvrMetadata,
+            votes: {
+              'governor-democratic': ['alice-jones'],
+              'governor-republican': ['dave-wilson'],
+              'governor-libertarian': [],
+              'secretary-of-state-democratic': [],
+              'ballot-measure-1': ['ballot-measure-1-yes'],
+            },
+          },
+        ],
+      })
+    )[GROUP_KEY];
+    assert(results);
+
+    // Each single-party contest counts only the ballots for that party
+    expect(results.contestResults['governor-democratic']).toMatchObject({
+      ballots: 1,
+      undervotes: 0,
+    });
+    expect(results.contestResults['governor-republican']).toMatchObject({
+      ballots: 1,
+      undervotes: 0,
+    });
+    expect(results.contestResults['governor-libertarian']).toMatchObject({
+      ballots: 0,
+      undervotes: 0,
+    });
+    expect(
+      results.contestResults['secretary-of-state-democratic']
+    ).toMatchObject({
+      ballots: 1,
+      undervotes: 1,
+    });
+
+    // The nonpartisan contest counts all ballots
+    expect(results.contestResults['ballot-measure-1']).toMatchObject({
+      ballots: 3,
+      yesTally: 3,
+    });
+  });
 });
 
 test('getOfficialCandidateNameLookup', () => {

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -13,7 +13,6 @@ import {
   Tabulation,
   YesNoContest,
 } from '@votingworks/types';
-import { isNoPartyId } from '@votingworks/types/src/tabulation';
 import { isGroupByEmpty } from './arguments';
 import { getGroupedBallotStyles } from '../ballot_styles';
 import { readV0CompressedTallyAsContestResults } from './compressed_tallies';
@@ -151,7 +150,7 @@ function addCastVoteRecordToElectionResult(
   if (election.type === 'open-primary') {
     const inferredPartyId = inferPartyFromVotes(election, cvr.votes);
 
-    if (isNoPartyId(inferredPartyId)) {
+    if (Tabulation.isNoPartyId(inferredPartyId)) {
       // If an open primary voter has either voted in no partisan contests or
       // crossover voted, omit all partisan contests so that they don't count,
       // even as undervotes.

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -13,6 +13,7 @@ import {
   Tabulation,
   YesNoContest,
 } from '@votingworks/types';
+import { isNoPartyId } from '@votingworks/types/src/tabulation';
 import { isGroupByEmpty } from './arguments';
 import { getGroupedBallotStyles } from '../ballot_styles';
 import { readV0CompressedTallyAsContestResults } from './compressed_tallies';
@@ -150,8 +151,7 @@ function addCastVoteRecordToElectionResult(
   if (election.type === 'open-primary') {
     const inferredPartyId = inferPartyFromVotes(election, cvr.votes);
 
-    if (typeof inferredPartyId !== 'string') {
-      assert(inferredPartyId.noParty);
+    if (isNoPartyId(inferredPartyId)) {
       // If an open primary voter has either voted in no partisan contests or
       // crossover voted, omit all partisan contests so that they don't count,
       // even as undervotes.

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -1,4 +1,4 @@
-import { assert, assertDefined, deepEqual, iter } from '@votingworks/basics';
+import { assert, assertDefined, iter } from '@votingworks/basics';
 import {
   AnyContest,
   BallotStyleGroupId,
@@ -150,7 +150,8 @@ function addCastVoteRecordToElectionResult(
   if (election.type === 'open-primary') {
     const inferredPartyId = inferPartyFromVotes(election, cvr.votes);
 
-    if (deepEqual(inferredPartyId, Tabulation.NO_PARTY_ID)) {
+    if (typeof inferredPartyId !== 'string') {
+      assert(inferredPartyId.noParty);
       // If an open primary voter has either voted in no partisan contests or
       // crossover voted, omit all partisan contests so that they don't count,
       // even as undervotes.

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -1,4 +1,4 @@
-import { assert, assertDefined, iter } from '@votingworks/basics';
+import { assert, assertDefined, deepEqual, iter } from '@votingworks/basics';
 import {
   AnyContest,
   BallotStyleGroupId,
@@ -16,7 +16,7 @@ import {
 import { isGroupByEmpty } from './arguments';
 import { getGroupedBallotStyles } from '../ballot_styles';
 import { readV0CompressedTallyAsContestResults } from './compressed_tallies';
-import { hasCrossoverVote, partisanContests } from './open_primary';
+import { inferPartyFromVotes, partisanContests } from './open_primary';
 
 export function getEmptyYesNoContestResults(
   contest: YesNoContest
@@ -146,13 +146,27 @@ function addCastVoteRecordToElectionResult(
       (cardCounts.hmpb[cvr.card.sheetNumber - 1] ?? 0) + 1;
   }
 
-  // In open primary elections, crossover voting is not allowed (i.e. a voter
-  // may not vote for partisan contests from multiple parties). If that happens,
-  // all of their partisan contest votes are void. Their nonpartisan contest
-  // votes still count.
-  const voidedContestIds = hasCrossoverVote(election, cvr.votes)
-    ? new Set(partisanContests(election).map((contest) => contest.id))
-    : undefined;
+  let voidedContestIds: Set<ContestId> | undefined;
+  if (election.type === 'open-primary') {
+    const inferredPartyId = inferPartyFromVotes(election, cvr.votes);
+
+    if (deepEqual(inferredPartyId, Tabulation.NO_PARTY_ID)) {
+      // If an open primary voter has either voted in no partisan contests or
+      // crossover voted, omit all partisan contests so that they don't count,
+      // even as undervotes.
+      voidedContestIds = new Set(
+        partisanContests(election).map((contest) => contest.id)
+      );
+    } else {
+      // If an open primary voter has voted validly, omit all partisan contests
+      // for the other party so that they don't count, even as undervotes.
+      voidedContestIds = new Set(
+        partisanContests(election)
+          .filter((contest) => contest.partyId !== inferredPartyId)
+          .map((contest) => contest.id)
+      );
+    }
+  }
 
   for (const [contestId, optionIds] of Object.entries(cvr.votes)) {
     if (voidedContestIds?.has(contestId)) {


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/8642

This PR makes a correction to open primary tabulation, porting and cleaning up a fix that we applied in the MI RFP demo branch.

The gist of the issue is as follows. Open primary ballots contain all partisan contests on a single ballot. Let's assume that we have a ballot with Dem and Rep contests on it.

In current code, if someone votes for a mix of Dem and Rep contests, the ballot is considered a crossover ballot, all partisan contests are correctly voided, and only non-partisan contests count. However, if someone correctly votes for only Dem contests or only Rep contests, the other party contests still flow through tally logic, contribute to totals, and get surfaced as undervotes. This PR corrects this gap by omitting all contests for the other party during tabulation.

Note that this bug affected VxAdmin reports and live reporting, but not VxScan reports. I believe this is because VxScan groups/filters by party as a first step when tallying in a sense masking the bug. Though I'd need to look more closely at the exact code to understand the precise mechanics.

## Testing Plan

- [x] Updated automated tests
- [x] Manual testing on the MI RFP demo branch, with that version of the fix
- [ ] Manual testing on main, with this version of the fix

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [ ] ~I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~