### PR TITLE
Gate integration tests on backend readiness

### DIFF
--- a/libs/integration-test-utils/src/global_setup.ts
+++ b/libs/integration-test-utils/src/global_setup.ts
@@ -1,0 +1,61 @@
+import { sleep } from '@votingworks/basics';
+import { methodUrl } from '@votingworks/grout';
+import { BASE_URL } from './constants';
+
+/**
+ * Side-effect-free grout method posted to probe backend readiness. Present in
+ * every app's API, so the gate works for all integration suites.
+ */
+const READINESS_METHOD = 'getAuthStatus';
+
+/** How long to wait for the backend to respond before giving up. */
+const READINESS_TIMEOUT_MS = 60_000;
+
+/** Delay between readiness probes. */
+const POLL_INTERVAL_MS = 250;
+
+/**
+ * Playwright `globalSetup` that blocks until the app backend answers an API
+ * call through the dev-server proxy.
+ *
+ * Playwright's `webServer.url` only confirms the Vite dev server (port 3000) is
+ * serving; it does not confirm the backend (port 3001) that Vite proxies
+ * `/api/*` to has finished starting. A test that posts to the API in
+ * `beforeEach` therefore races backend startup and gets a 504 from the proxy.
+ * The `retries` setting then masks it as a passing-on-retry flake — most
+ * reliably on VxMarkScan, whose backend is the slowest to boot. Polling a real
+ * round-trip here closes that window before any test runs.
+ *
+ * `webServer` is started before `globalSetup`, so the proxy is already up and
+ * each probe reaches the backend (returning 5xx until it is ready, then 200).
+ */
+export async function waitForBackendReady(): Promise<void> {
+  const url = methodUrl(READINESS_METHOD, `${BASE_URL}/api`);
+  const deadline = Date.now() + READINESS_TIMEOUT_MS;
+  let lastResult = 'no response';
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      if (response.ok) {
+        return;
+      }
+      lastResult = `HTTP ${response.status}`;
+    } catch (error) {
+      lastResult = error instanceof Error ? error.message : String(error);
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  throw new Error(
+    `Backend at ${url} not ready after ${READINESS_TIMEOUT_MS}ms (last: ${lastResult})`
+  );
+}
+
+// Playwright invokes a global-setup module's default export.
+// eslint-disable-next-line vx/gts-no-default-exports -- required by Playwright's globalSetup contract
+export default waitForBackendReady;

--- a/libs/integration-test-utils/src/index.ts
+++ b/libs/integration-test-utils/src/index.ts
@@ -4,6 +4,7 @@ export * from './ballots';
 export * from './cast_vote_records';
 export * from './constants';
 export * from './fonts';
+export * from './global_setup';
 export * from './screenshots';
 export * from './pdf';
 export * from './playwright_config';

--- a/libs/integration-test-utils/src/playwright_config.ts
+++ b/libs/integration-test-utils/src/playwright_config.ts
@@ -6,6 +6,10 @@ import {
 import { join } from 'node:path';
 import { BASE_URL, OUTPUT_DIR } from './constants';
 
+// Resolves to the built `global_setup.js` alongside this compiled module, so
+// the path is correct regardless of which app loads the shared config.
+const GLOBAL_SETUP_PATH = join(__dirname, 'global_setup.js');
+
 /** Options for {@link defineIntegrationTestPlaywrightConfig}. */
 export interface IntegrationTestPlaywrightConfigOptions {
   /** Browser viewport size — the setting that varies between apps. */
@@ -26,6 +30,9 @@ export function defineIntegrationTestPlaywrightConfig(
   return defineConfig({
     testDir: './e2e',
     outputDir: OUTPUT_DIR,
+    // Wait for the backend (not just the Vite dev server) to be reachable
+    // before any test runs, so API calls in `beforeEach` don't race startup.
+    globalSetup: GLOBAL_SETUP_PATH,
     ...(options.timeout !== undefined ? { timeout: options.timeout } : {}),
     // All test suites share one server, so they cannot run in parallel; global
     // state like Java card mocking also precludes parallelism.


### PR DESCRIPTION
## Overview

Fixes VxMarkScan integration-test flakiness that was being masked by Playwright's `retries: 2`. The suites' `webServer.url` only waits for the Vite dev server (:3000), not the backend (:3001) that Vite proxies `/api/*` to. The first test's `beforeEach` posts to the API before the backend has finished starting and gets a `504` from the proxy (`POST endCardlessVoterSession failed: 504`, dying in ~70ms), which the retry then silently absorbs. Since #8634 reorganized those tests, this hit VxMarkScan on **100% of CI runs** on its first test (`screenshots.spec.ts` › `basic election flow`). VxMarkScan is affected because its backend is the slowest to boot; other suites run identical code but their lighter backends win the race.

Fix: a shared Playwright `globalSetup` that polls a side-effect-free API method (`getAuthStatus`, present in every app) through the proxy until the backend answers, before any test runs. `webServer` is started before `globalSetup` (verified in Playwright 1.48's task ordering), so the proxy is already up and each probe reaches the backend — returning 5xx until ready, then 200. The gate lives in the shared config, but it's a no-op for suites whose backend is already up (the probe returns 200 immediately); in practice only VxMarkScan's behavior changes.

## Demo Video or Screenshot

N/A — CI infrastructure change. Validated in an earlier run on this branch with `retries` temporarily forced to 0: VxMarkScan integration went **green** (https://circleci.com/gh/votingworks/vxsuite/1244106), where pre-fix it failed ~100% on the first test. That temporary `retries: 0` commit has been dropped; this PR is the gate alone.

## Testing Plan

- VxMarkScan integration job passes (with the temporary `retries: 0` validation above proving the gate closes the startup race, not the retry).

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions. _(N/A — test-only infrastructure.)_
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)