### PR TITLE
refactor(usb-drive): simplify drive representation

### DIFF
--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -25,10 +25,11 @@ import {
   getMockConnectedPrinterStatus,
 } from '@votingworks/printing';
 import { CandidateContestResults } from '@votingworks/types/src/tabulation';
+import { UsbPartitionMount } from '@votingworks/usb-drive';
 import {
   buildTestEnvironment,
   configureMachine,
-  getMountedUsbDrivePartitionDevPath,
+  getMountedUsbDrive,
   mockElectionManagerAuth,
   mockSystemAdministratorAuth,
   saveTmpFile,
@@ -528,7 +529,9 @@ test('saveElectionPackageToUsb', async () => {
 
   mockUsbDrive.insertUsbDrive({});
   mockUsbDrive.multiUsbDrive.sync
-    .expectRepeatedCallsWith(getMountedUsbDrivePartitionDevPath(mockUsbDrive))
+    .expectRepeatedCallsWith(
+      assertDefined(getMountedUsbDrive(mockUsbDrive).partition).partPath
+    )
     .resolves();
   const response = await apiClient.saveElectionPackageToUsb();
   expect(response).toEqual(ok());
@@ -570,15 +573,13 @@ test('usbDrive', async () => {
   mockMultiUsbDrive.multiUsbDrive.getDrives.reset();
   mockMultiUsbDrive.multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
     {
-      devPath: '/dev/sdb',
-      partitions: [
-        {
-          devPath: '/dev/sdb1',
-          fstype: 'ext4',
-          fsver: '1.0',
-          mount: { type: 'unmounted' },
-        },
-      ],
+      diskPath: '/dev/sdb',
+      partition: {
+        diskPath: '/dev/sdb',
+        partPath: '/dev/sdb1',
+        fstype: 'ext4',
+        mount: UsbPartitionMount.unmounted(),
+      },
     },
   ]);
   expect(await apiClient.getUsbDriveStatus()).toEqual({

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -65,7 +65,6 @@ import {
   readElection,
 } from '@votingworks/fs';
 import {
-  isFat32Partition,
   MultiUsbDrive,
   REAL_USB_DRIVE_GLOB_PATTERN,
   UsbDriveStatus,
@@ -205,7 +204,7 @@ function buildApi({
   const usbDriveAdapter = createUsbDriveAdapter(
     multiUsbDrive,
     // return the first FAT32 drive
-    (drives) => drives.find((d) => isFat32Partition(d.partitions[0]))?.devPath
+    (drives) => drives.find((d) => d.partition?.fstype === 'fat32')?.diskPath
   );
 
   function convertFrontendFilter(

--- a/apps/admin/backend/src/client_app.test.ts
+++ b/apps/admin/backend/src/client_app.test.ts
@@ -19,10 +19,10 @@ import { createClientWorkspace } from './util/workspace';
 import { ClientConnectionStatus, ElectionRecord } from './types';
 
 import {
-  getMountedUsbDriveDevPath,
   mockMachineLocked,
   mockSystemAdministratorAuth,
   buildMockLogger,
+  getMountedUsbDrive,
 } from '../test/app';
 
 vi.mock('./multi_station_config', () => ({
@@ -237,7 +237,7 @@ test('getUsbDriveStatus returns usb drive status', async () => {
 
 test('ejectUsbDrive ejects the usb drive', async () => {
   env.mockUsbDrive.insertUsbDrive({});
-  const devPath = getMountedUsbDriveDevPath(env.mockUsbDrive);
+  const devPath = getMountedUsbDrive(env.mockUsbDrive).diskPath;
   env.mockUsbDrive.multiUsbDrive.ejectDrive.expectCallWith(devPath).resolves();
   await env.apiClient.ejectUsbDrive();
 });
@@ -251,7 +251,7 @@ test('formatUsbDrive returns error when not system administrator', async () => {
 test('formatUsbDrive formats drive when system administrator', async () => {
   mockSystemAdministratorAuth(env.auth);
   env.mockUsbDrive.insertUsbDrive({});
-  const devPath = getMountedUsbDriveDevPath(env.mockUsbDrive);
+  const devPath = getMountedUsbDrive(env.mockUsbDrive).diskPath;
   env.mockUsbDrive.multiUsbDrive.formatDrive
     .expectCallWith(devPath, 'fat32')
     .resolves();
@@ -261,7 +261,7 @@ test('formatUsbDrive formats drive when system administrator', async () => {
 test('formatUsbDrive returns error when format fails', async () => {
   mockSystemAdministratorAuth(env.auth);
   env.mockUsbDrive.insertUsbDrive({});
-  const devPath = getMountedUsbDriveDevPath(env.mockUsbDrive);
+  const devPath = getMountedUsbDrive(env.mockUsbDrive).diskPath;
   env.mockUsbDrive.multiUsbDrive.formatDrive
     .expectCallWith(devPath, 'fat32')
     .throws(new Error('format failed'));

--- a/apps/admin/backend/src/client_app.ts
+++ b/apps/admin/backend/src/client_app.ts
@@ -17,7 +17,6 @@ import { createSystemCallApi } from '@votingworks/backend';
 import { Logger, LogEventId } from '@votingworks/logging';
 import { isSystemAdministratorAuth } from '@votingworks/utils';
 import {
-  isFat32Partition,
   MultiUsbDrive,
   UsbDriveStatus,
   createUsbDriveAdapter,
@@ -160,7 +159,7 @@ function buildClientApi({
   const usbDriveAdapter = createUsbDriveAdapter(
     multiUsbDrive,
     // return the first FAT32 drive
-    (drives) => drives.find((d) => isFat32Partition(d.partitions[0]))?.devPath
+    (drives) => drives.find((d) => d.partition?.fstype === 'fat32')?.diskPath
   );
 
   return grout.createApi({

--- a/apps/admin/backend/test/app.ts
+++ b/apps/admin/backend/test/app.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest';
+import { assertDefined } from '@votingworks/basics';
 import {
   buildMockDippedSmartCardAuth,
   DippedSmartCardAuthApi,
@@ -30,6 +31,7 @@ import {
 import {
   createMockMultiUsbDrive,
   MockMultiUsbDrive,
+  UsbDriveInfo,
 } from '@votingworks/usb-drive';
 import { writeFileSync } from 'node:fs';
 import { createMockPrinterHandler } from '@votingworks/printing';
@@ -153,30 +155,21 @@ export function buildMockLogger(
   });
 }
 
-export function getMountedUsbDriveDevPath(
+export function getMountedUsbDrive(
   mockMultiUsbDrive: MockMultiUsbDrive
-): string {
+): UsbDriveInfo {
   const drive = mockMultiUsbDrive.multiUsbDrive.getDrives()[0];
-  if (!drive) {
+  if (!drive?.partition?.mount.isMounted) {
     throw new Error('Expected a mounted USB drive in the test environment.');
   }
-  return drive.devPath;
-}
-
-export function getMountedUsbDrivePartitionDevPath(
-  mockMultiUsbDrive: MockMultiUsbDrive
-): string {
-  const mountedPartition =
-    mockMultiUsbDrive.multiUsbDrive.getDrives()[0]?.partitions[0];
-  if (!mountedPartition) {
-    throw new Error('Expected a mounted USB drive in the test environment.');
-  }
-  return mountedPartition.devPath;
+  return drive;
 }
 
 export function expectUsbDriveSync(mockMultiUsbDrive: MockMultiUsbDrive): void {
   mockMultiUsbDrive.multiUsbDrive.sync
-    .expectCallWith(getMountedUsbDrivePartitionDevPath(mockMultiUsbDrive))
+    .expectCallWith(
+      assertDefined(getMountedUsbDrive(mockMultiUsbDrive).partition).partPath
+    )
     .resolves();
 }
 

--- a/apps/admin/backend/test/app.ts
+++ b/apps/admin/backend/test/app.ts
@@ -159,7 +159,7 @@ export function getMountedUsbDrive(
   mockMultiUsbDrive: MockMultiUsbDrive
 ): UsbDriveInfo {
   const drive = mockMultiUsbDrive.multiUsbDrive.getDrives()[0];
-  if (!drive?.partition?.mount.isMounted) {
+  if (drive?.partition?.mount.type !== 'mounted') {
     throw new Error('Expected a mounted USB drive in the test environment.');
   }
   return drive;

--- a/libs/usb-drive/src/block_devices.test.ts
+++ b/libs/usb-drive/src/block_devices.test.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'node:fs';
 import { mockChildProcess } from '@votingworks/test-utils';
 import {
   createBlockDeviceChangeWatcher,
-  getAllUsbDrives,
+  getAllDiskDevices,
   UsbDiskDeviceInfo,
 } from './block_devices';
 import { exec, spawn } from './exec';
@@ -103,14 +103,14 @@ describe('getAllUsbDrives', () => {
     execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
     readFileMock.mockResolvedValueOnce('');
 
-    expect(await getAllUsbDrives()).toEqual([]);
+    expect(await getAllDiskDevices()).toEqual([]);
   });
 
   test('returns empty array when udevadm fails', async () => {
     execMock.mockRejectedValueOnce(new Error('udevadm failed'));
     readFileMock.mockResolvedValueOnce('');
 
-    expect(await getAllUsbDrives()).toEqual([]);
+    expect(await getAllDiskDevices()).toEqual([]);
   });
 
   test('ignores non-USB, non-block, unexpected DEVTYPE, and missing DEVNAME entries', async () => {
@@ -129,7 +129,7 @@ describe('getAllUsbDrives', () => {
     });
     readFileMock.mockResolvedValueOnce('');
 
-    expect(await getAllUsbDrives()).toEqual([]);
+    expect(await getAllDiskDevices()).toEqual([]);
   });
 
   test('does not treat a disk as its own partition when devnames match', async () => {
@@ -148,7 +148,7 @@ describe('getAllUsbDrives', () => {
     });
     readFileMock.mockResolvedValueOnce(procMountsContent());
 
-    const result = await getAllUsbDrives();
+    const result = await getAllDiskDevices();
 
     // Disk has no real partitions (the partition with the same devname is not
     // recognized as a child), so it appears as an unformatted drive.
@@ -172,7 +172,7 @@ describe('getAllUsbDrives', () => {
     });
     readFileMock.mockResolvedValueOnce(procMountsContent());
 
-    const result = await getAllUsbDrives();
+    const result = await getAllDiskDevices();
 
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
@@ -207,7 +207,7 @@ describe('getAllUsbDrives', () => {
       ])
     );
 
-    const result = await getAllUsbDrives();
+    const result = await getAllDiskDevices();
 
     expect(result).toEqual([
       {
@@ -234,7 +234,7 @@ describe('getAllUsbDrives', () => {
     );
     readFileMock.mockResolvedValueOnce(procMountsContent());
 
-    const result = await getAllUsbDrives();
+    const result = await getAllDiskDevices();
 
     expect(result).toEqual<UsbDiskDeviceInfo[]>([
       {
@@ -271,7 +271,7 @@ describe('getAllUsbDrives', () => {
     });
     readFileMock.mockResolvedValueOnce(procMountsContent());
 
-    const result = await getAllUsbDrives();
+    const result = await getAllDiskDevices();
 
     expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({ devPath: '/dev/sdb' });
@@ -292,7 +292,7 @@ describe('getAllUsbDrives', () => {
     });
     readFileMock.mockResolvedValueOnce(procMountsContent());
 
-    const result = await getAllUsbDrives();
+    const result = await getAllDiskDevices();
 
     // Disk has partitions but none are valid data partitions — skip entirely
     // rather than returning an empty-partition disk that looks unformatted.
@@ -309,7 +309,7 @@ describe('getAllUsbDrives', () => {
       ])
     );
 
-    const result = await getAllUsbDrives();
+    const result = await getAllDiskDevices();
 
     // Disk mounted outside /media is not a valid data drive
     expect(result).toEqual([]);
@@ -334,7 +334,7 @@ describe('getAllUsbDrives', () => {
       ])
     );
 
-    const result = await getAllUsbDrives();
+    const result = await getAllDiskDevices();
 
     // Partition mounted outside /media — skip the disk entirely rather than
     // returning an empty-partition disk that looks like an unformatted drive.
@@ -360,7 +360,7 @@ describe('getAllUsbDrives', () => {
       ])
     );
 
-    const result = await getAllUsbDrives();
+    const result = await getAllDiskDevices();
 
     expect(result).toEqual<UsbDiskDeviceInfo[]>([
       {
@@ -399,7 +399,7 @@ describe('getAllUsbDrives', () => {
       ])
     );
 
-    const result = await getAllUsbDrives();
+    const result = await getAllDiskDevices();
 
     expect(result).toEqual<UsbDiskDeviceInfo[]>([
       {
@@ -439,7 +439,7 @@ describe('getAllUsbDrives', () => {
       ])
     );
 
-    const result = await getAllUsbDrives();
+    const result = await getAllDiskDevices();
 
     // Partition mounted outside /media is not a valid data drive
     expect(result).toEqual([]);
@@ -461,7 +461,7 @@ describe('getAllUsbDrives', () => {
     });
     readFileMock.mockRejectedValueOnce(new Error('/proc/mounts unreadable'));
 
-    const result = await getAllUsbDrives();
+    const result = await getAllDiskDevices();
 
     expect(result).toHaveLength(1);
     expect(result[0]?.partitions[0]).toMatchObject({ mountpoint: undefined });
@@ -488,7 +488,7 @@ describe('getAllUsbDrives', () => {
       ])
     );
 
-    expect(await getAllUsbDrives()).toEqual([]);
+    expect(await getAllDiskDevices()).toEqual([]);
   });
 });
 

--- a/libs/usb-drive/src/block_devices.ts
+++ b/libs/usb-drive/src/block_devices.ts
@@ -105,7 +105,7 @@ function isPartitionOfDisk(
   return /^[0-9]+$/.test(suffix) || /^p[0-9]+$/.test(suffix);
 }
 
-export interface UsbPartitionDeviceInfo {
+interface UsbPartitionDeviceInfo {
   devPath: string;
   mountpoint?: string;
   fstype?: string;
@@ -123,10 +123,9 @@ export interface UsbDiskDeviceInfo {
 
 /**
  * Returns all USB block devices as a structured disk → partitions hierarchy.
- * Includes vendor/model/serial parsed from udev for each disk. Applies the
- * same `isDataUsbDrive` filter as `getUsbDriveDeviceInfo`.
+ * Includes vendor/model/serial parsed from udev for each disk.
  */
-export async function getAllUsbDrives(): Promise<UsbDiskDeviceInfo[]> {
+export async function getAllDiskDevices(): Promise<UsbDiskDeviceInfo[]> {
   const [exportDbOutput, mountsContent] = await Promise.all([
     exec('udevadm', ['info', '--export-db'])
       .then(({ stdout }) => stdout)

--- a/libs/usb-drive/src/mocks/file_usb_drive.test.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.test.ts
@@ -10,6 +10,7 @@ import {
   listMockDrives,
   removeMockDriveDir,
 } from './file_usb_drive';
+import { UsbDriveInfo, UsbPartitionMount } from '../types';
 
 test('createMockFileMultiUsbDrive mock flow', async () => {
   const handler = getMockFileUsbDriveHandler('sdb');
@@ -23,45 +24,41 @@ test('createMockFileMultiUsbDrive mock flow', async () => {
 
   handler.insert();
   const mountPoint = handler.getDataPath();
-  expect(multiUsbDrive.getDrives()).toEqual([
+  expect(multiUsbDrive.getDrives()).toEqual<UsbDriveInfo[]>([
     {
-      devPath: '/dev/sdb',
-      partitions: [
-        {
-          devPath: '/dev/sdb1',
-          fstype: 'vfat',
-          fsver: 'FAT32',
-          mount: { type: 'mounted', mountPoint },
-        },
-      ],
+      diskPath: '/dev/sdb',
+      partition: {
+        diskPath: '/dev/sdb',
+        partPath: '/dev/sdb1',
+        fstype: 'fat32',
+        mount: UsbPartitionMount.mounted(mountPoint!),
+      },
     },
   ]);
 
   await multiUsbDrive.ejectDrive('/dev/sdb');
-  expect(multiUsbDrive.getDrives()).toEqual([
+  expect(multiUsbDrive.getDrives()).toEqual<UsbDriveInfo[]>([
     {
-      devPath: '/dev/sdb',
-      partitions: [
-        {
-          devPath: '/dev/sdb1',
-          fstype: 'vfat',
-          fsver: 'FAT32',
-          mount: { type: 'ejected' },
-        },
-      ],
+      diskPath: '/dev/sdb',
+      partition: {
+        diskPath: '/dev/sdb',
+        partPath: '/dev/sdb1',
+        fstype: 'fat32',
+        mount: UsbPartitionMount.ejected(),
+      },
     },
   ]);
 
   await multiUsbDrive.ejectDrive('/dev/sdb');
-  expect(multiUsbDrive.getDrives()[0]?.partitions[0]?.mount).toEqual({
-    type: 'ejected',
-  });
+  expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+    UsbPartitionMount.ejected()
+  );
 
   handler.insert();
   await multiUsbDrive.formatDrive('/dev/sdb', 'fat32');
-  expect(multiUsbDrive.getDrives()[0]?.partitions[0]?.mount).toEqual({
-    type: 'ejected',
-  });
+  expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+    UsbPartitionMount.ejected()
+  );
 
   handler.remove();
   expect(multiUsbDrive.getDrives()).toEqual([]);
@@ -81,7 +78,7 @@ test('createMockFileMultiUsbDrive multi-drive flow', async () => {
 
   handlerA.insert();
   expect(multiUsbDrive.getDrives()).toHaveLength(1);
-  expect(multiUsbDrive.getDrives()[0]?.devPath).toEqual(`/dev/${diskA}`);
+  expect(multiUsbDrive.getDrives()[0]?.diskPath).toEqual(`/dev/${diskA}`);
 
   handlerB.insert();
   expect(multiUsbDrive.getDrives()).toHaveLength(2);
@@ -90,11 +87,11 @@ test('createMockFileMultiUsbDrive multi-drive flow', async () => {
   const drives = multiUsbDrive.getDrives();
   expect(drives).toHaveLength(2);
   expect(
-    drives.find((d) => d.devPath === `/dev/${diskA}`)?.partitions[0]?.mount
-  ).toEqual({ type: 'ejected' });
+    drives.find((d) => d.diskPath === `/dev/${diskA}`)?.partition?.mount
+  ).toEqual(UsbPartitionMount.ejected());
   expect(
-    drives.find((d) => d.devPath === `/dev/${diskB}`)?.partitions[0]?.mount.type
-  ).toEqual('mounted');
+    drives.find((d) => d.diskPath === `/dev/${diskB}`)?.partition?.mount
+  ).toEqual(UsbPartitionMount.mounted(expect.any(String)));
 
   handlerB.remove();
   removeMockDriveDir(diskB);

--- a/libs/usb-drive/src/mocks/file_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.ts
@@ -239,8 +239,8 @@ export function createMockFileMultiUsbDrive(): MultiUsbDrive {
       return Promise.resolve();
     },
 
-    sync: (partitionPath: string) => {
-      void partitionPath;
+    sync: (partPath: string) => {
+      void partPath;
       return Promise.resolve();
     },
     stop: () => {},

--- a/libs/usb-drive/src/mocks/file_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.ts
@@ -11,7 +11,12 @@ import { getMockStateRootDir } from '@votingworks/utils';
 import { basename, join } from 'node:path';
 import type { MultiUsbDrive, UsbDriveFilesystemType } from '../multi_usb_drive';
 import { MockFileTree, writeMockFileTree } from './helpers';
-import { UsbDrive, UsbDriveStatus } from '../types';
+import {
+  UsbDrive,
+  UsbDriveInfo,
+  UsbDriveStatus,
+  UsbPartitionMount,
+} from '../types';
 
 export const MOCK_USB_DRIVE_STATE_FILENAME = 'mock-usb-state.json';
 export const MOCK_USB_DRIVE_DATA_DIRNAME = 'mock-usb-data';
@@ -187,28 +192,22 @@ export interface MockFileUsbDriveHandler {
 export function createMockFileMultiUsbDrive(): MultiUsbDrive {
   return {
     getDrives() {
-      return listMockDrives().flatMap((diskName) => {
+      return listMockDrives().flatMap((diskName): UsbDriveInfo[] => {
         const driveState = readMockDriveState(diskName);
         if (driveState.state === 'removed') return [];
         const mount =
           driveState.state === 'inserted'
-            ? ({
-                type: 'mounted',
-                mountPoint: getMockDriveDataDirPath(diskName),
-              } as const)
-            : ({ type: 'ejected' } as const);
-        const isExt4 = driveState.fstype === 'ext4';
+            ? UsbPartitionMount.mounted(getMockDriveDataDirPath(diskName))
+            : UsbPartitionMount.ejected();
         return [
           {
-            devPath: `/dev/${diskName}`,
-            partitions: [
-              {
-                devPath: `/dev/${diskName}1`,
-                fstype: isExt4 ? 'ext4' : 'vfat',
-                fsver: isExt4 ? '1.0' : 'FAT32',
-                mount,
-              },
-            ],
+            diskPath: `/dev/${diskName}`,
+            partition: {
+              diskPath: `/dev/${diskName}`,
+              partPath: `/dev/${diskName}1`,
+              fstype: driveState.fstype,
+              mount,
+            },
           },
         ];
       });
@@ -216,8 +215,8 @@ export function createMockFileMultiUsbDrive(): MultiUsbDrive {
 
     refresh: () => Promise.resolve(),
 
-    ejectDrive(driveDevPath: string): Promise<void> {
-      const diskName = basename(driveDevPath);
+    ejectDrive(diskPath: string): Promise<void> {
+      const diskName = basename(diskPath);
       const driveState = readMockDriveState(diskName);
       if (driveState.state === 'inserted') {
         writeMockDriveState(diskName, {
@@ -229,10 +228,10 @@ export function createMockFileMultiUsbDrive(): MultiUsbDrive {
     },
 
     formatDrive(
-      driveDevPath: string,
+      diskPath: string,
       fstype: UsbDriveFilesystemType
     ): Promise<void> {
-      const diskName = basename(driveDevPath);
+      const diskName = basename(diskPath);
       const driveState = readMockDriveState(diskName);
       if (driveState.state !== 'removed') {
         writeMockDriveState(diskName, { state: 'ejected', fstype });
@@ -240,8 +239,8 @@ export function createMockFileMultiUsbDrive(): MultiUsbDrive {
       return Promise.resolve();
     },
 
-    sync: (partitionDevPath: string) => {
-      void partitionDevPath;
+    sync: (partitionPath: string) => {
+      void partitionPath;
       return Promise.resolve();
     },
     stop: () => {},

--- a/libs/usb-drive/src/mocks/mock_multi_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/mock_multi_usb_drive.ts
@@ -1,12 +1,9 @@
 import { Mocked, mockFunction } from '@votingworks/test-utils';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
 import { rmSync } from 'node:fs';
-import {
-  MultiUsbDrive,
-  UsbDriveFilesystemType,
-  UsbDriveInfo,
-} from '../multi_usb_drive';
+import { MultiUsbDrive, UsbDriveFilesystemType } from '../multi_usb_drive';
 import { MockFileTree, writeMockFileTree } from './helpers';
+import { UsbDriveInfo, UsbPartitionMount } from '../types';
 
 const MOCK_SINGLETON_DISK_DEV_PATH = '/dev/sdb';
 
@@ -21,7 +18,7 @@ export interface MockMultiUsbDrive {
    */
   addUsbDrive(
     contents: MockFileTree,
-    options?: { devPath: string; fstype?: UsbDriveFilesystemType }
+    options?: { diskPath: string; fstype?: UsbDriveFilesystemType }
   ): void;
 
   /**
@@ -67,26 +64,21 @@ export function createMockMultiUsbDrive(): MockMultiUsbDrive {
 
   function addUsbDrive(
     contents: MockFileTree,
-    options: { devPath: string; fstype?: UsbDriveFilesystemType }
+    options: { diskPath: string; fstype?: UsbDriveFilesystemType }
   ) {
     const fstype = options.fstype ?? 'fat32';
     const mountPoint = makeTemporaryDirectory();
     mockUsbTmpDirs.push(mountPoint);
     writeMockFileTree(mountPoint, contents);
     drives.push({
-      devPath: options.devPath,
-      vendor: undefined,
-      model: undefined,
-      serial: undefined,
-      partitions: [
-        {
-          devPath: `${options.devPath}1`,
-          label: 'VxUSB-ABCDE',
-          fstype: fstype === 'ext4' ? 'ext4' : 'vfat',
-          fsver: fstype === 'ext4' ? '1.0' : 'FAT32',
-          mount: { type: 'mounted', mountPoint },
-        },
-      ],
+      diskPath: options.diskPath,
+      partition: {
+        diskPath: options.diskPath,
+        partPath: `${options.diskPath}1`,
+        label: 'VxUSB-ABCDE',
+        fstype,
+        mount: UsbPartitionMount.mounted(mountPoint),
+      },
     });
     multiUsbDrive.getDrives.reset();
     multiUsbDrive.getDrives.expectRepeatedCallsWith().returns(drives);
@@ -122,7 +114,7 @@ export function createMockMultiUsbDrive(): MockMultiUsbDrive {
       removeAll();
       addUsbDrive(contents, {
         ...(options ?? {}),
-        devPath: MOCK_SINGLETON_DISK_DEV_PATH,
+        diskPath: MOCK_SINGLETON_DISK_DEV_PATH,
       });
     },
 

--- a/libs/usb-drive/src/multi_usb_drive.test.ts
+++ b/libs/usb-drive/src/multi_usb_drive.test.ts
@@ -949,6 +949,20 @@ describe('sync', () => {
     multiUsbDrive.stop();
   });
 
+  test('does nothing for a drive with no usable partition', async () => {
+    mockDrives = [makeDisk({ partitions: [] })];
+    const logger = mockLogger({ fn: vi.fn });
+    const multiUsbDrive = detectMultiUsbDrive(logger);
+
+    await multiUsbDrive.refresh();
+
+    await multiUsbDrive.sync('/dev/sdb1');
+
+    expect(execMock).not.toHaveBeenCalled();
+
+    multiUsbDrive.stop();
+  });
+
   test('does nothing if drive not found', async () => {
     mockDrives = [];
     const logger = mockLogger({ fn: vi.fn });

--- a/libs/usb-drive/src/multi_usb_drive.test.ts
+++ b/libs/usb-drive/src/multi_usb_drive.test.ts
@@ -9,7 +9,8 @@ import {
 import { deferred, sleep } from '@votingworks/basics';
 import { detectMultiUsbDrive } from './multi_usb_drive';
 import { exec } from './exec';
-import { getAllUsbDrives, UsbDiskDeviceInfo } from './block_devices';
+import { getAllDiskDevices, UsbDiskDeviceInfo } from './block_devices';
+import { UsbPartitionInfo, UsbPartitionMount } from './types';
 
 const MOUNT_SCRIPT_PATH = join(__dirname, '../scripts');
 
@@ -23,7 +24,7 @@ vi.mock(import('@votingworks/utils'), async (importActual) => ({
 }));
 
 const execMock = vi.mocked(exec);
-const getAllUsbDrivesMock = vi.mocked(getAllUsbDrives);
+const getAllUsbDrivesMock = vi.mocked(getAllDiskDevices);
 
 vi.mock(import('./exec.js'), async (importActual) => ({
   ...(await importActual()),
@@ -39,7 +40,7 @@ vi.mock(import('./block_devices.js'), async (importActual) => {
   const actual = await importActual();
   return {
     ...actual,
-    getAllUsbDrives: vi.fn(() => Promise.resolve(mockDrives)),
+    getAllDiskDevices: vi.fn(() => Promise.resolve(mockDrives)),
     createBlockDeviceChangeWatcher: vi.fn((onDeviceChange: () => void) => {
       capturedWatcherCallback = onDeviceChange;
       return { stop: mockWatcherStop };
@@ -102,21 +103,48 @@ describe('getDrives', () => {
     await multiUsbDrive.refresh();
 
     const [drive] = multiUsbDrive.getDrives();
-    expect(drive).toMatchObject({
-      devPath: '/dev/sdb',
-      vendor: 'SanDisk',
-      model: 'Ultra',
-      serial: 'SN123',
-    });
-    expect(drive?.partitions[0]).toMatchObject({
-      devPath: '/dev/sdb1',
-      mount: { type: 'mounted', mountPoint: '/media/vx/usb-drive-sdb1' },
+    expect(drive).toMatchObject({ diskPath: '/dev/sdb' });
+    expect(drive?.partition).toMatchObject<Partial<UsbPartitionInfo>>({
+      diskPath: '/dev/sdb',
+      partPath: '/dev/sdb1',
+      mount: UsbPartitionMount.mounted('/media/vx/usb-drive-sdb1'),
     });
 
     multiUsbDrive.stop();
   });
 
-  test('returns unmounted partition as unmounted', async () => {
+  test('reports a supported partition as unmounted once auto-mount fails', async () => {
+    mockDrives = [
+      makeDisk({
+        partitions: [
+          {
+            devPath: '/dev/sdb1',
+            mountpoint: undefined,
+            fstype: 'vfat',
+            fsver: 'FAT32',
+            label: undefined,
+          },
+        ],
+      }),
+    ];
+    const logger = mockLogger({ fn: vi.fn });
+
+    // Fail the auto-mount so the partition settles back to unmounted rather
+    // than transitioning to mounted.
+    execMock.mockRejectedValue(new Error('mount failed'));
+
+    const multiUsbDrive = detectMultiUsbDrive(logger);
+
+    await vi.waitFor(() => {
+      expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+        UsbPartitionMount.unmounted()
+      );
+    });
+
+    multiUsbDrive.stop();
+  });
+
+  test('omits the partition for unsupported filesystems', async () => {
     mockDrives = [
       makeDisk({
         partitions: [
@@ -135,9 +163,9 @@ describe('getDrives', () => {
 
     await multiUsbDrive.refresh();
 
-    expect(multiUsbDrive.getDrives()[0]?.partitions[0]?.mount).toEqual({
-      type: 'unmounted',
-    });
+    const [drive] = multiUsbDrive.getDrives();
+    expect(drive?.diskPath).toEqual('/dev/sdb');
+    expect(drive?.partition).toBeUndefined();
 
     multiUsbDrive.stop();
   });
@@ -149,7 +177,7 @@ describe('getDrives', () => {
 
     await multiUsbDrive.refresh();
 
-    expect(multiUsbDrive.getDrives()[0]?.partitions).toEqual([]);
+    expect(multiUsbDrive.getDrives()[0]?.partition).toBeUndefined();
 
     multiUsbDrive.stop();
   });
@@ -428,10 +456,9 @@ describe('ejectDrive', () => {
 
     const ejectPromise = multiUsbDrive.ejectDrive('/dev/sdb');
 
-    expect(multiUsbDrive.getDrives()[0]?.partitions[0]?.mount).toMatchObject({
-      type: 'unmounting',
-      mountPoint: '/media/vx/usb-drive-sdb1',
-    });
+    expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+      UsbPartitionMount.unmounting('/media/vx/usb-drive-sdb1')
+    );
 
     unmountOperation.resolve({ stdout: '', stderr: '' });
     await ejectPromise;
@@ -524,9 +551,9 @@ describe('ejectDrive', () => {
     // before the first await, so getDrives() can observe the in-progress state.
     const ejectPromise = multiUsbDrive.ejectDrive('/dev/sdb');
 
-    expect(multiUsbDrive.getDrives()[0]?.partitions[0]?.mount).toEqual({
-      type: 'ejected',
-    });
+    expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+      UsbPartitionMount.ejected()
+    );
 
     await ejectPromise;
 
@@ -619,9 +646,9 @@ describe('ejectDrive', () => {
 
     await multiUsbDrive.ejectDrive('/dev/sdb');
 
-    expect(multiUsbDrive.getDrives()[0]?.partitions[0]?.mount).toEqual({
-      type: 'ejected',
-    });
+    expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+      UsbPartitionMount.ejected()
+    );
 
     multiUsbDrive.stop();
   });
@@ -702,9 +729,9 @@ describe('formatDrive', () => {
 
     const formatPromise = multiUsbDrive.formatDrive('/dev/sdb', 'fat32');
 
-    expect(multiUsbDrive.getDrives()[0]?.partitions[0]?.mount).toEqual({
-      type: 'ejected',
-    });
+    expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+      UsbPartitionMount.ejected()
+    );
 
     formatOperation.resolve({ stdout: '', stderr: '' });
     await formatPromise;
@@ -970,7 +997,9 @@ describe('autoMount', () => {
       () => {
         const drives = multiUsbDrive.getDrives();
         expect(drives.length).toEqual(1);
-        expect(drives[0]?.partitions[0]?.mount.type).toEqual('mounted');
+        expect(drives[0]?.partition?.mount).toEqual(
+          UsbPartitionMount.mounted(expect.any(String))
+        );
       },
       { timeout: 2000 }
     );
@@ -1037,7 +1066,9 @@ describe('autoMount', () => {
       () => {
         const drives = multiUsbDrive.getDrives();
         expect(drives.length).toEqual(1);
-        expect(drives[0]?.partitions[0]?.mount.type).toEqual('mounted');
+        expect(drives[0]?.partition?.mount).toEqual(
+          UsbPartitionMount.mounted(expect.any(String))
+        );
       },
       { timeout: 2000 }
     );
@@ -1114,15 +1145,14 @@ describe('autoMount', () => {
     await multiUsbDrive.refresh();
 
     // partitionAction has 'mounting' for /dev/sdb1 while exec is pending
-    expect(multiUsbDrive.getDrives()[0]?.partitions[0]?.mount).toEqual({
-      type: 'mounting',
-    });
+    expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+      UsbPartitionMount.mounting()
+    );
 
     mountOperation.resolve({ stdout: '', stderr: '' });
     mockDrives = [makeDisk()];
     await vi.waitFor(
-      () =>
-        multiUsbDrive.getDrives()[0]?.partitions[0]?.mount.type === 'mounted'
+      () => multiUsbDrive.getDrives()[0]?.partition?.mount.type === 'mounted'
     );
 
     multiUsbDrive.stop();
@@ -1156,7 +1186,7 @@ describe('autoMount', () => {
     mockDrives = [unmountedPartitionDisk];
     const multiUsbDrive = detectMultiUsbDrive(logger);
     multiUsbDrive.addListener(() => {
-      const mount = multiUsbDrive.getDrives()[0]?.partitions[0]?.mount;
+      const mount = multiUsbDrive.getDrives()[0]?.partition?.mount;
       if (mount) mountStatesOnChange.push(mount.type);
     });
 
@@ -1207,10 +1237,9 @@ describe('autoMount', () => {
       // trigger the sleep timer, then flush the final poll microtasks.
       await vi.advanceTimersByTimeAsync(100);
 
-      expect(multiUsbDrive.getDrives()[0]?.partitions[0]?.mount).toEqual({
-        type: 'mounted',
-        mountPoint: '/media/vx/usb-drive-sdb1',
-      });
+      expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+        UsbPartitionMount.mounted('/media/vx/usb-drive-sdb1')
+      );
 
       multiUsbDrive.stop();
     } finally {

--- a/libs/usb-drive/src/multi_usb_drive.test.ts
+++ b/libs/usb-drive/src/multi_usb_drive.test.ts
@@ -714,7 +714,7 @@ describe('formatDrive', () => {
     multiUsbDrive.stop();
   });
 
-  test('shows partitions as ejected during format', async () => {
+  test('shows partitions as formatting during format', async () => {
     mockDrives = [makeDisk()];
     const logger = mockLogger({ fn: vi.fn });
     const multiUsbDrive = detectMultiUsbDrive(logger);
@@ -730,7 +730,7 @@ describe('formatDrive', () => {
     const formatPromise = multiUsbDrive.formatDrive('/dev/sdb', 'fat32');
 
     expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
-      UsbPartitionMount.ejected()
+      UsbPartitionMount.formatting()
     );
 
     formatOperation.resolve({ stdout: '', stderr: '' });

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -32,12 +32,8 @@ const MOUNT_SCRIPT_PATH = join(__dirname, '../scripts');
 const MOUNT_TIMEOUT_MS = 5_000;
 const MOUNT_RETRY_INTERVAL_MS = 100;
 
-async function mountPartition(partitionPath: string): Promise<void> {
-  await exec('sudo', [
-    '-n',
-    join(MOUNT_SCRIPT_PATH, 'mount.sh'),
-    partitionPath,
-  ]);
+async function mountPartition(partPath: string): Promise<void> {
+  await exec('sudo', ['-n', join(MOUNT_SCRIPT_PATH, 'mount.sh'), partPath]);
 }
 
 async function unmountPartition(mountPoint: string): Promise<void> {
@@ -125,7 +121,7 @@ export interface MultiUsbDrive {
   refresh(): Promise<void>;
   ejectDrive(diskPath: string): Promise<void>;
   formatDrive(diskPath: string, fstype: UsbDriveFilesystemType): Promise<void>;
-  sync(partitionPath: string): Promise<void>;
+  sync(partPath: string): Promise<void>;
   stop(): void;
   addListener(listener: () => void): void;
   removeListener(listener: () => void): void;
@@ -509,13 +505,13 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
       await result;
     },
 
-    async sync(partitionPath: string): Promise<void> {
+    async sync(partPath: string): Promise<void> {
       const partition = cachedDrives
         .flatMap((d) => (d.partition ? [d.partition] : []))
-        .find((p) => p.partPath === partitionPath);
+        .find((p) => p.partPath === partPath);
 
       if (!partition?.mountpoint) {
-        debug(`partition ${partitionPath} is not mounted, skipping sync`);
+        debug(`partition ${partPath} is not mounted, skipping sync`);
         return;
       }
 

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -237,11 +237,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
     }
 
     if (dAction === 'formatting') {
-      // Report as ejected during formatting for backward compatibility — the
-      // old single-drive UsbDrive reported 'ejected' while formatting, and
-      // the adapter maps 'unmounted' to 'no_drive' which would confuse
-      // consumers expecting 'ejected'.
-      return UsbPartitionMount.ejected();
+      return UsbPartitionMount.formatting();
     }
 
     if (partitionAction.getTask(partition.partPath) === 'mounting') {

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -394,7 +394,8 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
     // unmount it rather than racing the mount.
     await partitionAction.join(disk.partition.partPath);
 
-    const freshDisk = cachedDrives.find((d) => d.diskPath === diskPath) ?? disk;
+    const freshDisk = cachedDrives.find((d) => d.diskPath === diskPath);
+    assert(freshDisk, `Drive not found: ${diskPath}`);
     if (freshDisk.partition?.mountpoint) {
       await unmountPartition(freshDisk.partition.mountpoint);
     }

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -5,7 +5,7 @@ import {
   assertDefined,
   Deferred,
   deferred,
-  iter,
+  extractErrorMessage,
   MaybePromise,
   Optional,
   sleep,
@@ -18,12 +18,11 @@ import {
 } from '@votingworks/utils';
 import { exec } from './exec';
 import {
-  getAllUsbDrives,
-  UsbDiskDeviceInfo,
-  UsbPartitionDeviceInfo,
   createBlockDeviceChangeWatcher,
+  getAllDiskDevices,
 } from './block_devices';
 import { createMockFileMultiUsbDrive } from './mocks/file_usb_drive';
+import { UsbDriveInfo, UsbPartitionMount } from './types';
 
 const VX_USB_LABEL_REGEXP = /^VxUSB-[A-Z0-9]{5}$/i;
 
@@ -33,8 +32,12 @@ const MOUNT_SCRIPT_PATH = join(__dirname, '../scripts');
 const MOUNT_TIMEOUT_MS = 5_000;
 const MOUNT_RETRY_INTERVAL_MS = 100;
 
-async function mountPartition(devicePath: string): Promise<void> {
-  await exec('sudo', ['-n', join(MOUNT_SCRIPT_PATH, 'mount.sh'), devicePath]);
+async function mountPartition(partitionPath: string): Promise<void> {
+  await exec('sudo', [
+    '-n',
+    join(MOUNT_SCRIPT_PATH, 'mount.sh'),
+    partitionPath,
+  ]);
 }
 
 async function unmountPartition(mountPoint: string): Promise<void> {
@@ -44,25 +47,25 @@ async function unmountPartition(mountPoint: string): Promise<void> {
 export type UsbDriveFilesystemType = 'fat32' | 'ext4';
 
 async function formatDriveAsFat32(
-  devicePath: string,
+  diskPath: string,
   label: string
 ): Promise<void> {
   await exec('sudo', [
     '-n',
     join(MOUNT_SCRIPT_PATH, 'format_fat32.sh'),
-    devicePath,
+    diskPath,
     label,
   ]);
 }
 
 async function formatDriveAsExt4(
-  devicePath: string,
+  diskPath: string,
   label: string
 ): Promise<void> {
   await exec('sudo', [
     '-n',
     join(MOUNT_SCRIPT_PATH, 'format_ext4.sh'),
-    devicePath,
+    diskPath,
     label,
   ]);
 }
@@ -91,42 +94,38 @@ export function isExt4Partition(partition?: { fstype?: string }): boolean {
   return partition?.fstype === 'ext4';
 }
 
-function isSupportedPartition(partition?: UsbPartitionDeviceInfo): boolean {
+function isSupportedPartition(partition?: {
+  fstype?: string;
+  fsver?: string;
+}): boolean {
   return isFat32Partition(partition) || isExt4Partition(partition);
 }
 
-export type UsbPartitionMount =
-  | { type: 'unmounted' }
-  | { type: 'ejected' }
-  | { type: 'mounting' }
-  | { type: 'mounted'; mountPoint: string }
-  | { type: 'unmounting'; mountPoint: string };
-
-export interface UsbPartitionInfo {
-  devPath: string;
+/**
+ * Internal cached representation of a detected partition. Holds the raw
+ * mountpoint so the displayed {@link UsbPartitionMount} can be recomputed on
+ * each read (reflecting in-progress eject/format/mount actions) rather than
+ * baked in at refresh time.
+ */
+interface CachedPartition {
+  partPath: string;
+  fstype: UsbDriveFilesystemType;
   label?: string;
-  fstype?: string;
-  fsver?: string;
-  mount: UsbPartitionMount;
+  mountpoint?: string;
 }
 
-export interface UsbDriveInfo {
-  devPath: string;
-  vendor?: string;
-  model?: string;
-  serial?: string;
-  partitions: UsbPartitionInfo[];
+/** Internal cached representation of a detected USB disk. */
+interface CachedDrive {
+  diskPath: string;
+  partition?: CachedPartition;
 }
 
 export interface MultiUsbDrive {
   getDrives(): UsbDriveInfo[];
   refresh(): Promise<void>;
-  ejectDrive(driveDevPath: string): Promise<void>;
-  formatDrive(
-    driveDevPath: string,
-    fstype: UsbDriveFilesystemType
-  ): Promise<void>;
-  sync(partitionDevPath: string): Promise<void>;
+  ejectDrive(diskPath: string): Promise<void>;
+  formatDrive(diskPath: string, fstype: UsbDriveFilesystemType): Promise<void>;
+  sync(partitionPath: string): Promise<void>;
   stop(): void;
   addListener(listener: () => void): void;
   removeListener(listener: () => void): void;
@@ -211,7 +210,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
 
   let stopped = false;
   let isFirstRefresh = true;
-  let cachedDrives: UsbDiskDeviceInfo[] = [];
+  let cachedDrives: CachedDrive[] = [];
 
   // Per-drive eject state: cleared when the drive is no longer detected.
   const ejectedDrives = new Set<string>();
@@ -229,17 +228,16 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
   }
 
   function computeMount(
-    diskDevPath: string,
-    partition: UsbPartitionDeviceInfo
+    diskPath: string,
+    partition: CachedPartition
   ): UsbPartitionMount {
-    const dAction = driveAction.getTask(diskDevPath);
+    const dAction = driveAction.getTask(diskPath);
 
     if (dAction === 'ejecting') {
-      // All partitions appear as unmounting (or ejected if already unmounted)
-      if (partition.mountpoint) {
-        return { type: 'unmounting', mountPoint: partition.mountpoint };
-      }
-      return { type: 'ejected' };
+      // Appears as unmounting (or ejected if already unmounted).
+      return partition.mountpoint
+        ? UsbPartitionMount.unmounting(partition.mountpoint)
+        : UsbPartitionMount.ejected();
     }
 
     if (dAction === 'formatting') {
@@ -247,124 +245,127 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
       // old single-drive UsbDrive reported 'ejected' while formatting, and
       // the adapter maps 'unmounted' to 'no_drive' which would confuse
       // consumers expecting 'ejected'.
-      return { type: 'ejected' };
+      return UsbPartitionMount.ejected();
     }
 
-    if (partitionAction.getTask(partition.devPath) === 'mounting') {
-      return { type: 'mounting' };
+    if (partitionAction.getTask(partition.partPath) === 'mounting') {
+      return UsbPartitionMount.mounting();
     }
 
-    if (ejectedDrives.has(diskDevPath)) {
-      return { type: 'ejected' };
+    if (ejectedDrives.has(diskPath)) {
+      return UsbPartitionMount.ejected();
     }
 
     if (partition.mountpoint) {
-      return { type: 'mounted', mountPoint: partition.mountpoint };
+      return UsbPartitionMount.mounted(partition.mountpoint);
     }
-    return { type: 'unmounted' };
+
+    return UsbPartitionMount.unmounted();
   }
 
-  function buildDriveInfo(disk: UsbDiskDeviceInfo): UsbDriveInfo {
+  function buildDriveInfo(drive: CachedDrive): UsbDriveInfo {
+    if (!drive.partition) {
+      return { diskPath: drive.diskPath };
+    }
     return {
-      devPath: disk.devPath,
-      vendor: disk.vendor,
-      model: disk.model,
-      serial: disk.serial,
-      partitions: disk.partitions.map((p) => ({
-        devPath: p.devPath,
-        label: p.label,
-        fstype: p.fstype,
-        fsver: p.fsver,
-        mount: computeMount(disk.devPath, p),
-      })),
+      diskPath: drive.diskPath,
+      partition: {
+        diskPath: drive.diskPath,
+        partPath: drive.partition.partPath,
+        fstype: drive.partition.fstype,
+        label: drive.partition.label,
+        mount: computeMount(drive.diskPath, drive.partition),
+      },
     };
   }
 
-  function mountPartitionWithRetry(
-    diskDevPath: string,
-    partitionDevPath: string
-  ): void {
+  function mountPartitionWithRetry(diskPath: string, partPath: string): void {
     void partitionAction
-      .perform(partitionDevPath, 'mounting', () =>
-        doMountPartitionWithRetry(diskDevPath, partitionDevPath)
+      .perform(partPath, 'mounting', () =>
+        doMountPartitionWithRetry(diskPath, partPath)
       )
       ?.then(() => {
         if (!stopped) onChange();
       });
   }
 
-  function findPartitionMountpoint(
-    diskDevPath: string,
-    partitionDevPath: string
-  ): Optional<string> {
-    return cachedDrives
-      .find((d) => d.devPath === diskDevPath)
-      ?.partitions.find((p) => p.devPath === partitionDevPath)?.mountpoint;
-  }
-
   async function doMountPartitionWithRetry(
-    diskDevPath: string,
-    partitionDevPath: string
+    diskPath: string,
+    partPath: string
   ): Promise<void> {
     try {
       await logger.logAsCurrentRole(LogEventId.UsbDriveMountInit);
-      await mountPartition(partitionDevPath);
+      await mountPartition(partPath);
 
-      let mountPoint: Optional<string>;
+      let mountpoint: Optional<string>;
       const deadline = Date.now() + MOUNT_TIMEOUT_MS;
       while (!stopped && Date.now() < deadline) {
         await doRefresh();
-        mountPoint = findPartitionMountpoint(diskDevPath, partitionDevPath);
-        if (mountPoint) break;
+        mountpoint = cachedDrives.find((d) => d.diskPath === diskPath)
+          ?.partition?.mountpoint;
+        if (mountpoint) break;
         await sleep(MOUNT_RETRY_INTERVAL_MS);
       }
 
       await logger.logAsCurrentRole(
         LogEventId.UsbDriveMounted,
-        mountPoint
+        mountpoint
           ? {
               disposition: 'success',
-              message: `USB drive partition ${partitionDevPath} successfully auto-mounted at ${mountPoint}.`,
+              message: `USB drive partition ${partPath} successfully auto-mounted at ${mountpoint}.`,
             }
           : {
               disposition: 'failure',
-              message: `Timed out waiting for USB drive partition ${partitionDevPath} to mount.`,
+              message: `Timed out waiting for USB drive partition ${partPath} to mount.`,
               result: 'USB drive partition not mounted.',
             }
       );
     } catch (error) {
-      debug(`auto-mount failed for ${partitionDevPath}: ${error}`);
+      debug(`auto-mount failed for ${partPath}: ${error}`);
       await logger.logAsCurrentRole(LogEventId.UsbDriveMounted, {
         disposition: 'failure',
-        message: `Auto-mount failed for USB drive partition ${partitionDevPath}.`,
-        error: (error as Error).message,
+        message: `Auto-mount failed for USB drive partition ${partPath}.`,
+        error: extractErrorMessage(error),
         result: 'USB drive partition not mounted.',
       });
     }
   }
 
-  function doAutoMount(disk: UsbDiskDeviceInfo): void {
+  function doAutoMount(drive: CachedDrive): void {
     if (stopped) return;
-    if (ejectedDrives.has(disk.devPath)) return;
-    if (driveAction.isBusy(disk.devPath)) return;
+    if (ejectedDrives.has(drive.diskPath)) return;
+    if (driveAction.isBusy(drive.diskPath)) return;
+    if (!drive.partition || drive.partition.mountpoint) return;
+    if (partitionAction.isBusy(drive.partition.partPath)) return;
 
-    for (const partition of disk.partitions) {
-      if (!isSupportedPartition(partition)) continue;
-      if (partition.mountpoint) continue;
-      if (partitionAction.isBusy(partition.devPath)) continue;
-
-      debug(`auto-mounting partition ${partition.devPath}`);
-      mountPartitionWithRetry(disk.devPath, partition.devPath);
-    }
+    debug(`auto-mounting partition ${drive.partition.partPath}`);
+    mountPartitionWithRetry(drive.diskPath, drive.partition.partPath);
   }
 
   async function doRefresh(): Promise<void> {
     if (stopped) return;
-    const newDrives = await getAllUsbDrives();
+    // Every detected USB disk is included. `partition` is set only when the
+    // disk has exactly one supported (FAT32/ext4) partition; otherwise the disk
+    // appears with no partition (e.g. unformatted or unsupported drives).
+    const newDrives: CachedDrive[] = (await getAllDiskDevices()).map((d) => {
+      const partition = d.partitions.length === 1 ? d.partitions[0] : undefined;
+      if (!partition || !isSupportedPartition(partition)) {
+        return { diskPath: d.devPath };
+      }
+      return {
+        diskPath: d.devPath,
+        partition: {
+          partPath: partition.devPath,
+          fstype: isFat32Partition(partition) ? 'fat32' : 'ext4',
+          label: partition.label,
+          mountpoint: partition.mountpoint,
+        },
+      };
+    });
 
     // Clear eject state for drives that have been physically removed
     for (const devPath of ejectedDrives) {
-      if (!newDrives.some((d) => d.devPath === devPath)) {
+      if (!newDrives.some((d) => d.diskPath === devPath)) {
         ejectedDrives.delete(devPath);
       }
     }
@@ -388,25 +389,19 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
    * Helper for operations that need to unmount all disk partitions first.
    * Returns the freshly-read disk.
    */
-  async function unmountAllPartitions(
-    driveDevPath: string
-  ): Promise<UsbDiskDeviceInfo> {
-    const disk = cachedDrives.find((d) => d.devPath === driveDevPath);
-    assert(disk, `Drive not found: ${driveDevPath}`);
+  async function unmountDrive(diskPath: string): Promise<CachedDrive> {
+    const disk = cachedDrives.find((d) => d.diskPath === diskPath);
+    assert(disk, `Drive not found: ${diskPath}`);
+    if (!disk.partition) return disk;
 
-    await Promise.all(
-      disk.partitions.map((p) => partitionAction.join(p.devPath))
-    );
+    // Wait for any in-progress auto-mount of this partition to settle so we
+    // unmount it rather than racing the mount.
+    await partitionAction.join(disk.partition.partPath);
 
-    const freshDisk = cachedDrives.find((d) => d.devPath === driveDevPath);
-    assert(freshDisk, `Drive not found: ${driveDevPath}`);
-
-    await Promise.all(
-      iter(freshDisk.partitions)
-        .filterMap((p) => p.mountpoint)
-        .map((mountpoint) => unmountPartition(mountpoint))
-    );
-
+    const freshDisk = cachedDrives.find((d) => d.diskPath === diskPath) ?? disk;
+    if (freshDisk.partition?.mountpoint) {
+      await unmountPartition(freshDisk.partition.mountpoint);
+    }
     return freshDisk;
   }
 
@@ -424,20 +419,20 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
       await doRefresh();
     },
 
-    async ejectDrive(driveDevPath: string): Promise<void> {
-      const result = driveAction.perform(driveDevPath, 'ejecting', async () => {
+    async ejectDrive(diskPath: string): Promise<void> {
+      const result = driveAction.perform(diskPath, 'ejecting', async () => {
         await logger.logAsCurrentRole(LogEventId.UsbDriveEjectInit);
         try {
-          await unmountAllPartitions(driveDevPath);
+          await unmountDrive(diskPath);
 
-          ejectedDrives.add(driveDevPath);
+          ejectedDrives.add(diskPath);
           await doRefresh();
 
           await logger.logAsCurrentRole(LogEventId.UsbDriveEjected, {
             disposition: 'success',
             message: 'USB drive successfully ejected.',
           });
-          debug(`Drive ${driveDevPath} ejected successfully`);
+          debug(`Drive ${diskPath} ejected successfully`);
         } catch (error) {
           await logger.logAsCurrentRole(LogEventId.UsbDriveEjected, {
             disposition: 'failure',
@@ -445,13 +440,13 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
             error: (error as Error).message,
             result: 'USB drive not ejected.',
           });
-          debug(`Drive ${driveDevPath} ejection failed: ${error}`);
+          debug(`Drive ${diskPath} ejection failed: ${error}`);
           throw error;
         }
       });
 
       if (!result) {
-        debug(`cannot eject ${driveDevPath}: action already in progress`);
+        debug(`cannot eject ${diskPath}: action already in progress`);
         return;
       }
 
@@ -459,72 +454,68 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
     },
 
     async formatDrive(
-      driveDevPath: string,
+      diskPath: string,
       fstype: UsbDriveFilesystemType
     ): Promise<void> {
-      const result = driveAction.perform(
-        driveDevPath,
-        'formatting',
-        async () => {
-          await logger.logAsCurrentRole(LogEventId.UsbDriveFormatInit);
-          try {
-            const freshDisk = await unmountAllPartitions(driveDevPath);
+      const result = driveAction.perform(diskPath, 'formatting', async () => {
+        await logger.logAsCurrentRole(LogEventId.UsbDriveFormatInit);
+        try {
+          const freshDisk = await unmountDrive(diskPath);
 
-            // Determine label — reuse existing label if it matches VxUSB pattern
-            const label = generateVxUsbLabel(freshDisk.partitions[0]?.label);
+          // Determine label — reuse existing label if it matches VxUSB pattern
+          const label = generateVxUsbLabel(freshDisk.partition?.label);
 
-            debug(
-              `formatting drive ${driveDevPath} as ${fstype} with label ${label}`
-            );
-            switch (fstype) {
-              case 'fat32':
-                await formatDriveAsFat32(driveDevPath, label);
-                break;
-              case 'ext4':
-                await formatDriveAsExt4(driveDevPath, label);
-                break;
-              default:
-                /* istanbul ignore next */
-                throwIllegalValue(fstype);
-            }
-            ejectedDrives.add(driveDevPath); // prevent auto-remount
-            await doRefresh();
-
-            await logger.logAsCurrentRole(LogEventId.UsbDriveFormatted, {
-              disposition: 'success',
-              message: `USB drive successfully formatted with a single ${
-                fstype === 'ext4' ? 'ext4' : 'FAT32'
-              } volume named "${label}".`,
-            });
-            debug(`Drive ${driveDevPath} formatted successfully`);
-          } catch (error) {
-            await logger.logAsCurrentRole(LogEventId.UsbDriveFormatted, {
-              disposition: 'failure',
-              message: 'Failed to format USB drive.',
-              error: (error as Error).message,
-              result: 'USB drive not formatted, error shown to user.',
-            });
-            debug(`Drive ${driveDevPath} format failed: ${error}`);
-            throw error;
+          debug(
+            `formatting drive ${diskPath} as ${fstype} with label ${label}`
+          );
+          switch (fstype) {
+            case 'fat32':
+              await formatDriveAsFat32(diskPath, label);
+              break;
+            case 'ext4':
+              await formatDriveAsExt4(diskPath, label);
+              break;
+            default:
+              /* istanbul ignore next */
+              throwIllegalValue(fstype);
           }
+          ejectedDrives.add(diskPath); // prevent auto-remount
+          await doRefresh();
+
+          await logger.logAsCurrentRole(LogEventId.UsbDriveFormatted, {
+            disposition: 'success',
+            message: `USB drive successfully formatted with a single ${
+              fstype === 'ext4' ? 'ext4' : 'FAT32'
+            } volume named "${label}".`,
+          });
+          debug(`Drive ${diskPath} formatted successfully`);
+        } catch (error) {
+          await logger.logAsCurrentRole(LogEventId.UsbDriveFormatted, {
+            disposition: 'failure',
+            message: 'Failed to format USB drive.',
+            error: (error as Error).message,
+            result: 'USB drive not formatted, error shown to user.',
+          });
+          debug(`Drive ${diskPath} format failed: ${error}`);
+          throw error;
         }
-      );
+      });
 
       if (!result) {
-        debug(`cannot format ${driveDevPath}: action already in progress`);
+        debug(`cannot format ${diskPath}: action already in progress`);
         return;
       }
 
       await result;
     },
 
-    async sync(partitionDevPath: string): Promise<void> {
+    async sync(partitionPath: string): Promise<void> {
       const partition = cachedDrives
-        .flatMap((d) => d.partitions)
-        .find((p) => p.devPath === partitionDevPath);
+        .flatMap((d) => (d.partition ? [d.partition] : []))
+        .find((p) => p.partPath === partitionPath);
 
       if (!partition?.mountpoint) {
-        debug(`partition ${partitionDevPath} is not mounted, skipping sync`);
+        debug(`partition ${partitionPath} is not mounted, skipping sync`);
         return;
       }
 

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -434,7 +434,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
           await logger.logAsCurrentRole(LogEventId.UsbDriveEjected, {
             disposition: 'failure',
             message: 'USB drive failed to eject.',
-            error: (error as Error).message,
+            error: extractErrorMessage(error),
             result: 'USB drive not ejected.',
           });
           debug(`Drive ${diskPath} ejection failed: ${error}`);
@@ -490,7 +490,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
           await logger.logAsCurrentRole(LogEventId.UsbDriveFormatted, {
             disposition: 'failure',
             message: 'Failed to format USB drive.',
-            error: (error as Error).message,
+            error: extractErrorMessage(error),
             result: 'USB drive not formatted, error shown to user.',
           });
           debug(`Drive ${diskPath} format failed: ${error}`);

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -468,9 +468,10 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
             case 'ext4':
               await formatDriveAsExt4(diskPath, label);
               break;
+            /* istanbul ignore start */
             default:
-              /* istanbul ignore next */
               throwIllegalValue(fstype);
+            /* istanbul ignore stop */
           }
           ejectedDrives.add(diskPath); // prevent auto-remount
           await doRefresh();

--- a/libs/usb-drive/src/types.ts
+++ b/libs/usb-drive/src/types.ts
@@ -36,24 +36,22 @@ export interface UsbPartitionInfo {
 }
 
 export const UsbPartitionMount = {
-  unmounted: (): UsbPartitionMount => ({ type: 'unmounted', isMounted: false }),
-  ejected: (): UsbPartitionMount => ({ type: 'ejected', isMounted: false }),
-  mounting: (): UsbPartitionMount => ({ type: 'mounting', isMounted: false }),
+  unmounted: (): UsbPartitionMount => ({ type: 'unmounted' }),
+  ejected: (): UsbPartitionMount => ({ type: 'ejected' }),
+  mounting: (): UsbPartitionMount => ({ type: 'mounting' }),
   mounted: (mountPoint: string): UsbPartitionMount => ({
     type: 'mounted',
-    isMounted: true,
     mountPoint,
   }),
   unmounting: (mountPoint: string): UsbPartitionMount => ({
     type: 'unmounting',
-    isMounted: true,
     mountPoint,
   }),
 } as const;
 
 export type UsbPartitionMount =
-  | { type: 'unmounted'; isMounted: false }
-  | { type: 'ejected'; isMounted: false }
-  | { type: 'mounting'; isMounted: false }
-  | { type: 'mounted'; isMounted: true; mountPoint: string }
-  | { type: 'unmounting'; isMounted: true; mountPoint: string };
+  | { type: 'unmounted' }
+  | { type: 'ejected' }
+  | { type: 'mounting' }
+  | { type: 'mounted'; mountPoint: string }
+  | { type: 'unmounting'; mountPoint: string };

--- a/libs/usb-drive/src/types.ts
+++ b/libs/usb-drive/src/types.ts
@@ -39,6 +39,7 @@ export const UsbPartitionMount = {
   unmounted: (): UsbPartitionMount => ({ type: 'unmounted' }),
   ejected: (): UsbPartitionMount => ({ type: 'ejected' }),
   mounting: (): UsbPartitionMount => ({ type: 'mounting' }),
+  formatting: (): UsbPartitionMount => ({ type: 'formatting' }),
   mounted: (mountPoint: string): UsbPartitionMount => ({
     type: 'mounted',
     mountPoint,
@@ -53,5 +54,6 @@ export type UsbPartitionMount =
   | { type: 'unmounted' }
   | { type: 'ejected' }
   | { type: 'mounting' }
+  | { type: 'formatting' }
   | { type: 'mounted'; mountPoint: string }
   | { type: 'unmounting'; mountPoint: string };

--- a/libs/usb-drive/src/types.ts
+++ b/libs/usb-drive/src/types.ts
@@ -15,3 +15,45 @@ export interface UsbDrive {
   format(fstype: UsbDriveFilesystemType): Promise<void>;
   sync(): Promise<void>;
 }
+
+/**
+ * A USB drive with `partition` set if it has a single supported partition.
+ */
+export interface UsbDriveInfo {
+  diskPath: string;
+  partition?: UsbPartitionInfo;
+}
+
+/**
+ * A USB partition with one of the supported file systems.
+ */
+export interface UsbPartitionInfo {
+  diskPath: string;
+  partPath: string;
+  fstype: UsbDriveFilesystemType;
+  mount: UsbPartitionMount;
+  label?: string;
+}
+
+export const UsbPartitionMount = {
+  unmounted: (): UsbPartitionMount => ({ type: 'unmounted', isMounted: false }),
+  ejected: (): UsbPartitionMount => ({ type: 'ejected', isMounted: false }),
+  mounting: (): UsbPartitionMount => ({ type: 'mounting', isMounted: false }),
+  mounted: (mountPoint: string): UsbPartitionMount => ({
+    type: 'mounted',
+    isMounted: true,
+    mountPoint,
+  }),
+  unmounting: (mountPoint: string): UsbPartitionMount => ({
+    type: 'unmounting',
+    isMounted: true,
+    mountPoint,
+  }),
+} as const;
+
+export type UsbPartitionMount =
+  | { type: 'unmounted'; isMounted: false }
+  | { type: 'ejected'; isMounted: false }
+  | { type: 'mounting'; isMounted: false }
+  | { type: 'mounted'; isMounted: true; mountPoint: string }
+  | { type: 'unmounting'; isMounted: true; mountPoint: string };

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -23,16 +23,16 @@ vi.mock(
   })
 );
 
-let mockDrives: UsbDiskDeviceInfo[] = [];
+let mockDevices: UsbDiskDeviceInfo[] = [];
 
 vi.mock('./block_devices', async (importActual) => ({
   ...(await importActual()),
-  getAllUsbDrives: vi.fn(() => Promise.resolve(mockDrives)),
+  getAllDiskDevices: vi.fn(() => Promise.resolve(mockDevices)),
   createBlockDeviceChangeWatcher: vi.fn(() => ({ stop: vi.fn() })),
 }));
 
 beforeEach(() => {
-  mockDrives = [];
+  mockDevices = [];
   vi.clearAllMocks();
   vi.unstubAllEnvs();
   featureFlagMock.resetFeatureFlags();
@@ -64,7 +64,7 @@ test('returns no_drive when no drives are connected', async () => {
 });
 
 test('exposes the first connected drive via the UsbDrive interface', async () => {
-  mockDrives = [
+  mockDevices = [
     {
       devPath: '/dev/sdb',
       vendor: undefined,

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -1,11 +1,11 @@
+import { Logger } from '@votingworks/logging';
 import {
   BooleanEnvironmentVariableName,
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
-import { Logger } from '@votingworks/logging';
-import { UsbDrive } from './types';
 import { createMockFileUsbDrive } from './mocks/file_usb_drive';
-import { detectMultiUsbDrive, isFat32Partition } from './multi_usb_drive';
+import { detectMultiUsbDrive } from './multi_usb_drive';
+import { UsbDrive } from './types';
 import { createUsbDriveAdapter } from './usb_drive_adapter';
 
 export function detectUsbDrive(logger: Logger): UsbDrive {
@@ -15,6 +15,6 @@ export function detectUsbDrive(logger: Logger): UsbDrive {
   const multiUsbDrive = detectMultiUsbDrive(logger);
   return createUsbDriveAdapter(
     multiUsbDrive,
-    (drives) => drives.find((d) => isFat32Partition(d.partitions[0]))?.devPath
+    (drives) => drives.find((d) => d.partition?.fstype === 'fat32')?.diskPath
   );
 }

--- a/libs/usb-drive/src/usb_drive_adapter.test.ts
+++ b/libs/usb-drive/src/usb_drive_adapter.test.ts
@@ -158,6 +158,24 @@ describe('createUsbDriveAdapter', () => {
       assertComplete();
     });
 
+    test('returns ejected when partition is formatting', async () => {
+      const { multiUsbDrive } = createMockMultiUsbDrive();
+      const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdb');
+      multiUsbDrive.getDrives.reset();
+
+      multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
+        makeDriveInfo({
+          partition: {
+            diskPath: '/dev/sdb',
+            partPath: '/dev/sdb1',
+            fstype: 'fat32',
+            mount: UsbPartitionMount.formatting(),
+          },
+        }),
+      ]);
+      expect(await adapter.status()).toEqual({ status: 'ejected' });
+    });
+
     test('returns mounted when partition is unmounting', async () => {
       const { multiUsbDrive } = createMockMultiUsbDrive();
       const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdb');

--- a/libs/usb-drive/src/usb_drive_adapter.test.ts
+++ b/libs/usb-drive/src/usb_drive_adapter.test.ts
@@ -1,21 +1,18 @@
 import { describe, expect, test, vi } from 'vitest';
 import { createUsbDriveAdapter } from './usb_drive_adapter';
 import { createMockMultiUsbDrive } from './mocks/mock_multi_usb_drive';
-import { UsbDriveInfo } from './multi_usb_drive';
-import { UsbDriveStatus } from './types';
+import { UsbDriveInfo, UsbDriveStatus, UsbPartitionMount } from './types';
 
 function makeDriveInfo(overrides: Partial<UsbDriveInfo> = {}): UsbDriveInfo {
   return {
-    devPath: '/dev/sdb',
-    partitions: [
-      {
-        devPath: '/dev/sdb1',
-        label: 'VxUSB-ABCDE',
-        fstype: 'vfat',
-        fsver: 'FAT32',
-        mount: { type: 'mounted', mountPoint: '/media/vx/usb-drive-sdb1' },
-      },
-    ],
+    diskPath: '/dev/sdb',
+    partition: {
+      diskPath: '/dev/sdb',
+      partPath: '/dev/sdb1',
+      label: 'VxUSB-ABCDE',
+      fstype: 'fat32',
+      mount: UsbPartitionMount.mounted('/media/vx/usb-drive-sdb1'),
+    },
     ...overrides,
   };
 }
@@ -61,33 +58,9 @@ describe('createUsbDriveAdapter', () => {
       );
       multiUsbDrive.getDrives.reset();
 
-      multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
-        makeDriveInfo({ partitions: [] }),
-        makeDriveInfo({
-          partitions: [
-            {
-              devPath: '/dev/sdb1',
-              label: 'VxUSB-ABCDE',
-              fstype: 'vfat',
-              fsver: 'FAT32',
-              mount: {
-                type: 'mounted',
-                mountPoint: '/media/vx/usb-drive-sdb1',
-              },
-            },
-            {
-              devPath: '/dev/sdb2',
-              label: 'VxUSB-ABCDE',
-              fstype: 'vfat',
-              fsver: 'FAT32',
-              mount: {
-                type: 'mounted',
-                mountPoint: '/media/vx/usb-drive-sdb2',
-              },
-            },
-          ],
-        }),
-      ]);
+      multiUsbDrive.getDrives
+        .expectRepeatedCallsWith()
+        .returns([makeDriveInfo({ partition: undefined })]);
       expect(await adapter.status()).toEqual({ status: 'no_drive' });
     });
 
@@ -95,22 +68,18 @@ describe('createUsbDriveAdapter', () => {
       const { multiUsbDrive } = createMockMultiUsbDrive();
       const adapter = createUsbDriveAdapter(
         multiUsbDrive,
-        (drives) => drives[0]?.devPath
+        (drives) => drives[0]?.diskPath
       );
       multiUsbDrive.getDrives.reset();
 
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
         makeDriveInfo({
-          partitions: [
-            {
-              devPath: '/dev/sdb1',
-              fstype: 'ext4',
-              mount: {
-                type: 'mounted',
-                mountPoint: '/media/vx/usb-drive-sdb1',
-              },
-            },
-          ],
+          partition: {
+            diskPath: '/dev/sdb',
+            partPath: '/dev/sdb1',
+            fstype: 'ext4',
+            mount: UsbPartitionMount.mounted('/media/vx/usb-drive-sdb1'),
+          },
         }),
       ]);
       expect(await adapter.status()).toEqual<UsbDriveStatus>({
@@ -126,14 +95,12 @@ describe('createUsbDriveAdapter', () => {
 
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
         makeDriveInfo({
-          partitions: [
-            {
-              devPath: '/dev/sdb1',
-              fstype: 'vfat',
-              fsver: 'FAT32',
-              mount: { type: 'mounting' },
-            },
-          ],
+          partition: {
+            diskPath: '/dev/sdb',
+            partPath: '/dev/sdb1',
+            fstype: 'fat32',
+            mount: UsbPartitionMount.mounting(),
+          },
         }),
       ]);
       expect(await adapter.status()).toEqual({ status: 'no_drive' });
@@ -160,14 +127,12 @@ describe('createUsbDriveAdapter', () => {
 
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
         makeDriveInfo({
-          partitions: [
-            {
-              devPath: '/dev/sdb1',
-              fstype: 'vfat',
-              fsver: 'FAT32',
-              mount: { type: 'unmounted' },
-            },
-          ],
+          partition: {
+            diskPath: '/dev/sdb',
+            partPath: '/dev/sdb1',
+            fstype: 'fat32',
+            mount: UsbPartitionMount.unmounted(),
+          },
         }),
       ]);
       expect(await adapter.status()).toEqual({ status: 'no_drive' });
@@ -180,14 +145,12 @@ describe('createUsbDriveAdapter', () => {
 
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
         makeDriveInfo({
-          partitions: [
-            {
-              devPath: '/dev/sdb1',
-              fstype: 'vfat',
-              fsver: 'FAT32',
-              mount: { type: 'ejected' },
-            },
-          ],
+          partition: {
+            diskPath: '/dev/sdb',
+            partPath: '/dev/sdb1',
+            fstype: 'fat32',
+            mount: UsbPartitionMount.ejected(),
+          },
         }),
       ]);
       expect(await adapter.status()).toEqual({ status: 'ejected' });
@@ -202,17 +165,12 @@ describe('createUsbDriveAdapter', () => {
 
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
         makeDriveInfo({
-          partitions: [
-            {
-              devPath: '/dev/sdb1',
-              fstype: 'vfat',
-              fsver: 'FAT32',
-              mount: {
-                type: 'unmounting',
-                mountPoint: '/media/vx/usb-drive-sdb1',
-              },
-            },
-          ],
+          partition: {
+            diskPath: '/dev/sdb',
+            partPath: '/dev/sdb1',
+            fstype: 'fat32',
+            mount: UsbPartitionMount.unmounting('/media/vx/usb-drive-sdb1'),
+          },
         }),
       ]);
       expect(await adapter.status()).toEqual({
@@ -294,14 +252,12 @@ describe('createUsbDriveAdapter', () => {
 
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
         makeDriveInfo({
-          partitions: [
-            {
-              devPath: '/dev/sdb1',
-              fstype: 'vfat',
-              fsver: 'FAT32',
-              mount: { type: 'unmounted' },
-            },
-          ],
+          partition: {
+            diskPath: '/dev/sdb',
+            partPath: '/dev/sdb1',
+            fstype: 'fat32',
+            mount: UsbPartitionMount.unmounted(),
+          },
         }),
       ]);
       await adapter.sync();

--- a/libs/usb-drive/src/usb_drive_adapter.test.ts
+++ b/libs/usb-drive/src/usb_drive_adapter.test.ts
@@ -245,6 +245,26 @@ describe('createUsbDriveAdapter', () => {
       assertComplete();
     });
 
+    test('does nothing while partition is unmounting', async () => {
+      const { multiUsbDrive, assertComplete } = createMockMultiUsbDrive();
+      const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdb');
+      multiUsbDrive.getDrives.reset();
+
+      multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
+        makeDriveInfo({
+          partition: {
+            diskPath: '/dev/sdb',
+            partPath: '/dev/sdb1',
+            fstype: 'fat32',
+            mount: UsbPartitionMount.unmounting('/media/vx/usb-drive-sdb1'),
+          },
+        }),
+      ]);
+      await adapter.sync();
+
+      assertComplete();
+    });
+
     test('does nothing when no mounted partition', async () => {
       const { multiUsbDrive, assertComplete } = createMockMultiUsbDrive();
       const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdb');

--- a/libs/usb-drive/src/usb_drive_adapter.ts
+++ b/libs/usb-drive/src/usb_drive_adapter.ts
@@ -1,11 +1,7 @@
 import makeDebug from 'debug';
 import { assert } from '@votingworks/basics';
-import {
-  MultiUsbDrive,
-  UsbDriveInfo,
-  UsbDriveFilesystemType,
-} from './multi_usb_drive';
-import { UsbDrive, UsbDriveStatus } from './types';
+import { MultiUsbDrive, UsbDriveFilesystemType } from './multi_usb_drive';
+import { UsbDrive, UsbDriveInfo, UsbDriveStatus } from './types';
 
 const debug = makeDebug('usb-drive:adapter');
 
@@ -23,9 +19,7 @@ export function createUsbDriveAdapter(
 ): UsbDrive {
   return {
     status(): Promise<UsbDriveStatus> {
-      const drives = multiUsbDrive
-        .getDrives()
-        .filter((d) => d.partitions.length === 1);
+      const drives = multiUsbDrive.getDrives().filter((d) => d.partition);
 
       if (drives.length === 0) {
         debug('adapter: no drives with a single partition, returning no_drive');
@@ -38,17 +32,17 @@ export function createUsbDriveAdapter(
         return Promise.resolve({ status: 'no_drive' });
       }
 
-      const drive = drives.find((d) => d.devPath === driveDevPath);
+      const drive = drives.find((d) => d.diskPath === driveDevPath);
 
       if (!drive) {
         debug('adapter: drive not found in cache, returning no_drive');
         return Promise.resolve({ status: 'no_drive' });
       }
 
-      const [firstPartition] = drive.partitions;
-      assert(firstPartition, `No partitions found on disk '${driveDevPath}'`);
+      const { partition } = drive;
+      assert(partition, `No partitions found on disk '${driveDevPath}'`);
 
-      const { mount } = firstPartition;
+      const { mount } = partition;
 
       if (mount.type === 'mounting') {
         debug('adapter: partition is mounting, returning no_drive');
@@ -109,17 +103,17 @@ export function createUsbDriveAdapter(
         return;
       }
 
-      const drive = drives.find((d) => d.devPath === driveDevPath);
-      const mountedPartition = drive?.partitions.find(
-        (p) => p.mount.type === 'mounted'
-      );
+      const drive = drives.find((d) => d.diskPath === driveDevPath);
+      const mountedPartition = drive?.partition?.mount.isMounted
+        ? drive.partition
+        : undefined;
 
       if (!mountedPartition) {
         debug('adapter: no mounted partition to sync');
         return;
       }
 
-      await multiUsbDrive.sync(mountedPartition.devPath);
+      await multiUsbDrive.sync(mountedPartition.partPath);
     },
   };
 }

--- a/libs/usb-drive/src/usb_drive_adapter.ts
+++ b/libs/usb-drive/src/usb_drive_adapter.ts
@@ -104,9 +104,12 @@ export function createUsbDriveAdapter(
       }
 
       const drive = drives.find((d) => d.diskPath === driveDevPath);
-      const mountedPartition = drive?.partition?.mount.isMounted
-        ? drive.partition
-        : undefined;
+      // Only sync a fully-mounted partition — skip while an eject is
+      // unmounting it, since syncing would race the unmount.
+      const mountedPartition =
+        drive?.partition?.mount.type === 'mounted'
+          ? drive.partition
+          : undefined;
 
       if (!mountedPartition) {
         debug('adapter: no mounted partition to sync');

--- a/libs/usb-drive/src/usb_drive_adapter.ts
+++ b/libs/usb-drive/src/usb_drive_adapter.ts
@@ -1,5 +1,5 @@
 import makeDebug from 'debug';
-import { assert } from '@votingworks/basics';
+import { assert, throwIllegalValue } from '@votingworks/basics';
 import { MultiUsbDrive, UsbDriveFilesystemType } from './multi_usb_drive';
 import { UsbDrive, UsbDriveInfo, UsbDriveStatus } from './types';
 
@@ -44,35 +44,37 @@ export function createUsbDriveAdapter(
 
       const { mount } = partition;
 
-      if (mount.type === 'mounting') {
-        debug('adapter: partition is mounting, returning no_drive');
-        return Promise.resolve({ status: 'no_drive' });
+      switch (mount.type) {
+        case 'mounting':
+          debug('adapter: partition is mounting, returning no_drive');
+          return Promise.resolve({ status: 'no_drive' });
+        case 'mounted':
+          debug(`adapter: partition is mounted at ${mount.mountPoint}`);
+          return Promise.resolve({
+            status: 'mounted',
+            mountPoint: mount.mountPoint,
+          });
+        case 'unmounting':
+          debug('adapter: partition is unmounting, returning mounted');
+          return Promise.resolve({
+            status: 'mounted',
+            mountPoint: mount.mountPoint,
+          });
+        case 'formatting':
+          // Formatting unmounts the drive first; present it as ejected, which
+          // is what legacy single-drive consumers expect mid-format.
+          debug('adapter: partition is formatting, returning ejected');
+          return Promise.resolve({ status: 'ejected' });
+        case 'ejected':
+          debug('adapter: partition is ejected, returning ejected');
+          return Promise.resolve({ status: 'ejected' });
+        case 'unmounted':
+          debug('adapter: partition is unmounted, returning no_drive');
+          return Promise.resolve({ status: 'no_drive' });
+        default:
+          /* istanbul ignore next */
+          return throwIllegalValue(mount);
       }
-
-      if (mount.type === 'mounted') {
-        debug(`adapter: partition is mounted at ${mount.mountPoint}`);
-        return Promise.resolve({
-          status: 'mounted',
-          mountPoint: mount.mountPoint,
-        });
-      }
-
-      if (mount.type === 'unmounting') {
-        debug('adapter: partition is unmounting, returning mounted');
-        return Promise.resolve({
-          status: 'mounted',
-          mountPoint: mount.mountPoint,
-        });
-      }
-
-      // mount.type === 'ejected' or 'unmounted'
-      if (mount.type === 'ejected') {
-        debug('adapter: partition is ejected, returning ejected');
-        return Promise.resolve({ status: 'ejected' });
-      }
-
-      debug('adapter: partition is unmounted, returning no_drive');
-      return Promise.resolve({ status: 'no_drive' });
     },
 
     async eject(): Promise<void> {

--- a/libs/usb-drive/src/usb_drive_adapter.ts
+++ b/libs/usb-drive/src/usb_drive_adapter.ts
@@ -71,9 +71,10 @@ export function createUsbDriveAdapter(
         case 'unmounted':
           debug('adapter: partition is unmounted, returning no_drive');
           return Promise.resolve({ status: 'no_drive' });
+        /* istanbul ignore start */
         default:
-          /* istanbul ignore next */
           return throwIllegalValue(mount);
+        /* istanbul ignore stop */
       }
     },
 


### PR DESCRIPTION
## Overview
_(Part 7 of a series of PRs: [previous](https://github.com/votingworks/vxsuite/pull/8713) / [next](https://github.com/votingworks/vxsuite/pull/8727))_

The previous version exposed too much of the underlying reality of the connected USB drives: they listed all partitions, the raw `fstype` and `fsver`, etc. In reality we only care whether a drive has a single supported partition. If it has zero or multiple or a partition with an unsupported file system we now list the drive but just say it has no usable partitions. Listing it is important because otherwise we wouldn't be able to format it.

## Demo Video or Screenshot
n/a

## Testing Plan
- [x] `./bin/usb-drive` works (`status`, `eject`, `format`, `watch`)
- [x] Manually test USB interactions within VxAdmin
- [x] Verify dev dock still works

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
