### PR TITLE
types: Add StraightPartyContest

### DIFF
--- a/apps/admin/backend/src/util/cast_vote_records.ts
+++ b/apps/admin/backend/src/util/cast_vote_records.ts
@@ -4,6 +4,7 @@ import {
   ContestOptionId,
   ElectionDefinition,
   MarkThresholds,
+  straightPartyNotYetImplemented,
   Tabulation,
 } from '@votingworks/types';
 import { CachedElectionLookups, hasCrossoverVote } from '@votingworks/utils';
@@ -19,6 +20,11 @@ import {
 export function getNumberVotesAllowed(contest: Contest): number {
   if (contest.type === 'yesno') {
     return 1;
+  }
+
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
   }
 
   return contest.seats;

--- a/apps/admin/backend/src/util/cdf_results.ts
+++ b/apps/admin/backend/src/util/cdf_results.ts
@@ -3,6 +3,7 @@ import {
   Election,
   NcName,
   ResultsReporting,
+  straightPartyNotYetImplemented,
   Tabulation,
   YesNoContest,
 } from '@votingworks/types';
@@ -191,6 +192,10 @@ function buildContests(
   for (const contest of election.contests) {
     const contestResults = electionResults.contestResults[contest.id];
     assert(contestResults);
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      straightPartyNotYetImplemented();
+    }
     if (contest.type === 'yesno') {
       assert(contestResults.contestType === 'yesno');
       reportContests.push(buildBallotMeasureContest(contest, contestResults));

--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -7,6 +7,7 @@ import {
   Election,
   getContestDistrictName,
   Side,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import type {
   AdjudicatedContestOption,
@@ -123,6 +124,10 @@ const StatusLineAdjudicated = styled(StatusLine).attrs({
 `;
 
 function getVotesAllowed(contest: Contest): number {
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
+  }
   return contest.type === 'yesno' ? 1 : contest.seats;
 }
 

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -8,6 +8,7 @@ import {
   BallotType,
   DEFAULT_SYSTEM_SETTINGS,
   Election,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import type { BallotPageLayout, Rect } from '@votingworks/types';
 import type {
@@ -94,6 +95,10 @@ function makeContestAdjudicationData(
       })),
       tag,
     };
+  }
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    straightPartyNotYetImplemented();
   }
   return {
     contestId,

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.test.tsx
@@ -6,6 +6,7 @@ import {
   BallotStyleGroupId,
   Election,
   getContests,
+  straightPartyNotYetImplemented,
   Tabulation,
 } from '@votingworks/types';
 import userEvent from '@testing-library/user-event';
@@ -201,6 +202,10 @@ test('entering initial ballot count and contest tallies', async () => {
     expect(undervotesInput).toHaveValue('');
     userEvent.type(undervotesInput, contestResults.undervotes.toString());
 
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      straightPartyNotYetImplemented();
+    }
     if (contest.type === 'candidate') {
       assert(contestResults.contestType === 'candidate');
       for (const candidate of contest.candidates) {

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -20,6 +20,7 @@ import {
   BallotStyleGroupId,
   Precinct,
   Election,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import {
   Button,
@@ -302,6 +303,10 @@ function emptyFormContestResults(
   contest: Contest,
   ballotCount?: number
 ): FormContestResults {
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
+  }
   switch (contest.type) {
     case 'yesno':
       return {

--- a/apps/admin/frontend/src/utils/adjudication.ts
+++ b/apps/admin/frontend/src/utils/adjudication.ts
@@ -14,6 +14,7 @@ import {
   Election,
   Rect,
   Side,
+  straightPartyNotYetImplemented,
   Vote,
   VotesDict,
 } from '@votingworks/types';
@@ -91,6 +92,10 @@ export function adjudicatedVotes(
   return Object.fromEntries(
     contests.map(({ contest, adjudicationData }): [string, Vote] => {
       const adjudicatedContest = adjudicatedContests.get(contest.id);
+      /* istanbul ignore next */
+      if (contest.type === 'straight-party') {
+        return straightPartyNotYetImplemented();
+      }
       switch (contest.type) {
         case 'candidate':
           return [

--- a/apps/design/backend/migrations/1742941957696_regenerate-duplicate-ids.js
+++ b/apps/design/backend/migrations/1742941957696_regenerate-duplicate-ids.js
@@ -1,5 +1,8 @@
 /* eslint-disable vx/gts-object-literal-types */
-const { hasSplits } = require('@votingworks/types');
+const {
+  hasSplits,
+  straightPartyNotYetImplemented,
+} = require('@votingworks/types');
 const { generateId } = require('../build/utils.js');
 
 /**
@@ -117,13 +120,22 @@ exports.up = async (pgm) => {
           : p.districtIds),
       ]),
       ...election.parties.map((p) => p.id),
-      ...election.contests.flatMap((c) => [
-        c.id,
-        ...(c.type === 'candidate' && c.partyId ? [c.partyId] : []),
-        ...(c.type === 'candidate'
-          ? c.candidates.flatMap((cand) => [cand.id, ...(cand.partyIds ?? [])])
-          : [c.yesOption.id, c.noOption.id]),
-      ]),
+      ...election.contests.flatMap((c) => {
+        /* istanbul ignore next */
+        if (c.type === 'straight-party') {
+          return straightPartyNotYetImplemented();
+        }
+        return [
+          c.id,
+          ...(c.type === 'candidate' && c.partyId ? [c.partyId] : []),
+          ...(c.type === 'candidate'
+            ? c.candidates.flatMap((cand) => [
+                cand.id,
+                ...(cand.partyIds ?? []),
+              ])
+            : [c.yesOption.id, c.noOption.id]),
+        ];
+      }),
     ];
   }
 

--- a/apps/design/backend/migrations/1742944839600_election-content-tables.js
+++ b/apps/design/backend/migrations/1742944839600_election-content-tables.js
@@ -1,5 +1,8 @@
 const { throwIllegalValue } = require('@votingworks/basics');
-const { hasSplits } = require('@votingworks/types');
+const {
+  hasSplits,
+  straightPartyNotYetImplemented,
+} = require('@votingworks/types');
 const { PgLiteral } = require('node-pg-migrate');
 
 /**
@@ -319,6 +322,10 @@ exports.up = async (pgm) => {
     }
 
     for (const contest of election.contests) {
+      /* istanbul ignore next */
+      if (contest.type === 'straight-party') {
+        straightPartyNotYetImplemented();
+      }
       switch (contest.type) {
         case 'candidate': {
           pgm.sql(`

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -63,6 +63,7 @@ import {
   safeParseElectionDefinitionV4p0,
   LATEST_SOFTWARE_VERSION,
   convertLatestElectionToV4p0,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import {
   ballotStyleHasPrecinctOrSplit,
@@ -534,35 +535,41 @@ test('create/list/delete elections', async () => {
       .id;
   }
   expect(election2Contests).toEqual(
-    sliElection.contests.map((contest) => ({
-      ...contest,
-      id: expectNotEqualTo(contest.id),
-      districtId: election2Districts[0].id,
-      ...(contest.type === 'candidate'
-        ? {
-            candidates: contest.candidates.map((candidate) =>
-              expect.objectContaining({
-                ...candidate,
-                id: expectNotEqualTo(candidate.id),
-                partyIds: candidate.partyIds?.map(updatedPartyId).sort(),
-                firstName: expect.any(String),
-                // TODO upgrade vitest to use expect.toBeOneOf
-                // middleName: expect.toBeOneOf([expect.any(String), undefined]),
-                lastName: expect.any(String),
-              })
-            ),
-          }
-        : {
-            yesOption: {
-              ...contest.yesOption,
-              id: expectNotEqualTo(contest.yesOption.id),
-            },
-            noOption: {
-              ...contest.noOption,
-              id: expectNotEqualTo(contest.noOption.id),
-            },
-          }),
-    }))
+    sliElection.contests.map((contest) => {
+      /* istanbul ignore next */
+      if (contest.type === 'straight-party') {
+        return straightPartyNotYetImplemented();
+      }
+      return {
+        ...contest,
+        id: expectNotEqualTo(contest.id),
+        districtId: election2Districts[0].id,
+        ...(contest.type === 'candidate'
+          ? {
+              candidates: contest.candidates.map((candidate) =>
+                expect.objectContaining({
+                  ...candidate,
+                  id: expectNotEqualTo(candidate.id),
+                  partyIds: candidate.partyIds?.map(updatedPartyId).sort(),
+                  firstName: expect.any(String),
+                  // TODO upgrade vitest to use expect.toBeOneOf
+                  // middleName: expect.toBeOneOf([expect.any(String), undefined]),
+                  lastName: expect.any(String),
+                })
+              ),
+            }
+          : {
+              yesOption: {
+                ...contest.yesOption,
+                id: expectNotEqualTo(contest.yesOption.id),
+              },
+              noOption: {
+                ...contest.noOption,
+                id: expectNotEqualTo(contest.noOption.id),
+              },
+            }),
+      };
+    })
   );
   expect(
     await apiClient.listBallotStyles({ electionId: sliElectionId })
@@ -3114,6 +3121,10 @@ test('cloneElection', async () => {
   }
   expect(destContests).toEqual(
     srcContests.map((contest) => {
+      /* istanbul ignore next */
+      if (contest.type === 'straight-party') {
+        return straightPartyNotYetImplemented();
+      }
       switch (contest.type) {
         case 'candidate':
           return {

--- a/apps/design/backend/src/convert_ms_results.ts
+++ b/apps/design/backend/src/convert_ms_results.ts
@@ -3,6 +3,7 @@ import {
   formatBallotHash,
   safeParseInt,
   Tabulation,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import { parse } from 'csv-parse/sync';
 import { stringify } from 'csv-stringify/sync';
@@ -226,6 +227,10 @@ export function convertMsResults(
             candidatePartyId: NONPARTISAN_PARTY_ID,
             candidatePartyLabel: NONPARTISAN_PARTY_LABEL,
           };
+        }
+        /* istanbul ignore next */
+        if (contest.type === 'straight-party') {
+          return straightPartyNotYetImplemented();
         }
         switch (contest.type) {
           case 'candidate': {

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -60,6 +60,7 @@ import {
   safeParseElectionDefinitionForAnySoftwareVersion,
   SoftwareVersion,
   ElectionType,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import {
   singlePrecinctSelectionFor,
@@ -383,6 +384,10 @@ async function insertContest(
   ballotOrder?: number
 ) {
   await assertWithinTransaction(client);
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
+  }
   switch (contest.type) {
     case 'candidate': {
       await client.query(
@@ -1088,6 +1093,10 @@ export class Store {
         partyIds: PartyId[];
       }>;
       const contests: Contest[] = contestRows.map((row) => {
+        /* istanbul ignore next */
+        if (row.type === 'straight-party') {
+          return straightPartyNotYetImplemented();
+        }
         switch (row.type) {
           case 'candidate': {
             const candidates: Candidate[] = candidateRows

--- a/apps/design/backend/src/tts_strings.ts
+++ b/apps/design/backend/src/tts_strings.ts
@@ -5,6 +5,7 @@ import {
   LanguageCode,
   TtsEdit,
   TtsEditKey,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import {
   SpeechSynthesizer,
@@ -122,6 +123,10 @@ export function apiMethods(ctx: TtsApiContext) {
           text: contest.title,
         });
 
+        /* istanbul ignore next */
+        if (contest.type === 'straight-party') {
+          straightPartyNotYetImplemented();
+        }
         switch (contest.type) {
           case 'candidate':
             if (contest.termDescription) {

--- a/apps/design/backend/src/utils.ts
+++ b/apps/design/backend/src/utils.ts
@@ -12,6 +12,7 @@ import {
   pollingPlacesGenerateFromPrecincts,
   Precinct,
   PrecinctId,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import { customAlphabet } from 'nanoid';
 import { Buffer } from 'node:buffer';
@@ -102,6 +103,10 @@ export function regenerateElectionIds(
     id: replaceId(contest.id),
     districtId: replaceId(contest.districtId),
     ...(() => {
+      /* istanbul ignore next */
+      if (contest.type === 'straight-party') {
+        return straightPartyNotYetImplemented();
+      }
       switch (contest.type) {
         case 'candidate':
           return {

--- a/apps/design/backend/test/helpers.ts
+++ b/apps/design/backend/test/helpers.ts
@@ -24,6 +24,7 @@ import {
   formatBallotHash,
   LanguageCode,
   safeParseInt,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import { Server } from 'node:http';
 import { AddressInfo } from 'node:net';
@@ -394,6 +395,10 @@ export function generateAllPrecinctsTallyReportRows(
 ): AllPrecinctsTallyReportRow[] {
   return election.precincts.flatMap((precinct) =>
     election.contests.flatMap((contest, contestIndex) => {
+      /* istanbul ignore next */
+      if (contest.type === 'straight-party') {
+        return straightPartyNotYetImplemented();
+      }
       const rowBase = {
         precinct: precinct.name,
         precinctId: precinct.id,

--- a/apps/design/frontend/src/contest_form.tsx
+++ b/apps/design/frontend/src/contest_form.tsx
@@ -17,6 +17,7 @@ import {
   safeParse,
   YesNoContestSchema,
   ElectionStringKey,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import {
   Callout,
@@ -951,6 +952,10 @@ function draftCandidateFromCandidate(candidate: Candidate): DraftCandidate {
 }
 
 function draftContestFromContest(contest: Contest): DraftContest {
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
+  }
   switch (contest.type) {
     case 'candidate':
       return {

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -7,6 +7,7 @@ import {
   Contest,
   YesNoContest,
   isPrimary,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import styled from 'styled-components';
 import { FixedViewport, ListActionsRow, Row } from './layout';
@@ -127,6 +128,10 @@ function Content(): JSX.Element | null {
   const contestParamRoutes = electionParamRoutes.contests;
 
   const filteredContests = contests.filter((contest) => {
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      return straightPartyNotYetImplemented();
+    }
     const matchesDistrict =
       filterDistrictId === FILTER_ALL ||
       contest.districtId === filterDistrictId;
@@ -151,6 +156,10 @@ function Content(): JSX.Element | null {
   const yesNoContests: YesNoContest[] = [];
 
   for (const c of contestsToShow) {
+    /* istanbul ignore next */
+    if (c.type === 'straight-party') {
+      straightPartyNotYetImplemented();
+    }
     if (c.type === 'candidate') candidateContests.push(c);
     else yesNoContests.push(c);
   }

--- a/libs/backend/src/cast_vote_records/build_cast_vote_record.ts
+++ b/libs/backend/src/cast_vote_records/build_cast_vote_record.ts
@@ -22,6 +22,7 @@ import {
   MarkStatus,
   MarkThresholds,
   SheetOf,
+  straightPartyNotYetImplemented,
   VotesDict,
   YesNoContest,
   YesNoVote,
@@ -363,6 +364,10 @@ export function buildCVRContestsFromVotes({
     const contestUnmarkedWriteIns = unmarkedWriteIns?.filter(
       ({ contestId }) => contestId === contest.id
     );
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      return straightPartyNotYetImplemented();
+    }
     switch (contest.type) {
       case 'yesno':
         cvrContests.push(

--- a/libs/backend/src/cast_vote_records/build_report_metadata.ts
+++ b/libs/backend/src/cast_vote_records/build_report_metadata.ts
@@ -6,6 +6,7 @@ import {
   CastVoteRecordBatchMetadata,
   CVR,
   Election,
+  straightPartyNotYetImplemented,
   YesNoContest,
 } from '@votingworks/types';
 
@@ -86,6 +87,10 @@ function buildBallotMeasureContest(
 function buildContest(
   contest: Contest
 ): CVR.CandidateContest | CVR.BallotMeasureContest {
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
+  }
   return contest.type === 'candidate'
     ? buildCandidateContest(contest)
     : buildBallotMeasureContest(contest);

--- a/libs/backend/src/election_package/system_limits.ts
+++ b/libs/backend/src/election_package/system_limits.ts
@@ -2,6 +2,7 @@ import { err, ok, Result, throwIllegalValue } from '@votingworks/basics';
 import {
   ElectionDefinition,
   ElectionStringKey,
+  straightPartyNotYetImplemented,
   SYSTEM_LIMITS,
   SystemLimits,
   SystemLimitViolation,
@@ -58,6 +59,10 @@ export function validateElectionDefinitionAgainstSystemLimits(
 
   let totalCandidates = 0;
   for (const contest of election.contests) {
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      return straightPartyNotYetImplemented();
+    }
     switch (contest.type) {
       case 'candidate': {
         if (contest.candidates.length > systemLimits.contest.candidates) {
@@ -166,6 +171,10 @@ export function validateElectionDefinitionAgainstSystemLimits(
       let seatsSummedAcrossContests = 0;
       let candidatesSummedAcrossContests = 0;
       for (const contest of ballotStyleContests) {
+        /* istanbul ignore next */
+        if (contest.type === 'straight-party') {
+          return straightPartyNotYetImplemented();
+        }
         switch (contest.type) {
           case 'candidate': {
             seatsSummedAcrossContests += contest.seats;

--- a/libs/ballot-encoder/src/index.ts
+++ b/libs/ballot-encoder/src/index.ts
@@ -17,6 +17,7 @@ import {
   HmpbBallotPageMetadata,
   isVotePresent,
   PrecinctId,
+  straightPartyNotYetImplemented,
   unsafeParse,
   validateVotes,
   VotesDict,
@@ -271,6 +272,10 @@ function encodeBallotVotesInto(
     const contestVote = votes[contest.id];
 
     if (isVotePresent(contestVote)) {
+      /* istanbul ignore next */
+      if (contest.type === 'straight-party') {
+        return straightPartyNotYetImplemented();
+      }
       if (contest.type === 'yesno') {
         const ynVote = contestVote as YesNoVote;
 
@@ -413,6 +418,10 @@ function decodeBallotVotes(
 
   // read vote data
   for (const contest of contestsWithAnswers) {
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      return straightPartyNotYetImplemented();
+    }
     if (contest.type === 'yesno') {
       // yesno votes get a single bit
       votes[contest.id] = bits.readBoolean()

--- a/libs/ballot-interpreter/bin/interpret.rs
+++ b/libs/ballot-interpreter/bin/interpret.rs
@@ -387,6 +387,9 @@ fn pretty_print_contest_vote(contest: &Contest, vote: &ContestVote) {
                 )
             );
         }
+        Contest::StraightParty(_) => {
+            unimplemented!("STRAIGHT_PARTY_TODO: straight-party contests are not yet implemented")
+        }
     }
 }
 

--- a/libs/ballot-interpreter/src/adjudication_reasons.ts
+++ b/libs/ballot-interpreter/src/adjudication_reasons.ts
@@ -6,6 +6,7 @@ import {
   CandidateVote,
   ContestOption,
   MarkStatus,
+  straightPartyNotYetImplemented,
   VotesDict,
   WriteInAreaStatus,
 } from '@votingworks/types';
@@ -34,6 +35,10 @@ function compareMarkStatusDescending(
 }
 
 function getExpectedVoteCount(contest: Contest): number {
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
+  }
   switch (contest.type) {
     case 'candidate':
       return contest.seats;
@@ -69,6 +74,10 @@ export function getAllPossibleAdjudicationReasonsForBmdVotes(
     // Check for undervotes
     if (actualVoteCount < expectedSelectionCount) {
       const optionIds: string[] = [];
+      /* istanbul ignore next */
+      if (contest.type === 'straight-party') {
+        return straightPartyNotYetImplemented();
+      }
       const contestType = contest.type;
       switch (contestType) {
         case 'candidate':

--- a/libs/ballot-interpreter/src/cross_language_bmd.test.ts
+++ b/libs/ballot-interpreter/src/cross_language_bmd.test.ts
@@ -9,6 +9,7 @@ import {
   getContests,
   getBallotStyle,
   Candidate,
+  straightPartyNotYetImplemented,
   YesNoVote,
 } from '@votingworks/types';
 import {
@@ -43,6 +44,10 @@ function generateVotesForContests(
 ): VotesDict {
   const votes: VotesDict = {};
   for (const contest of contests) {
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      return straightPartyNotYetImplemented();
+    }
     if (contest.type === 'candidate') {
       const namedCandidates = contest.candidates.filter((c) => !c.isWriteIn);
       const selected = namedCandidates.slice(0, contest.seats);

--- a/libs/fixture-generators/src/generate-cvrs/generate_cvrs.ts
+++ b/libs/fixture-generators/src/generate-cvrs/generate_cvrs.ts
@@ -29,6 +29,7 @@ import {
   getContests,
   mapSheet,
   Size,
+  straightPartyNotYetImplemented,
   Vote,
   VotesDict,
   YesNoVote,
@@ -250,6 +251,10 @@ export function* generateCvrs({
 
           const optionsForEachContest = new Map<string, readonly Vote[]>();
           for (const contest of contests) {
+            /* istanbul ignore next */
+            if (contest.type === 'straight-party') {
+              return straightPartyNotYetImplemented();
+            }
             switch (contest.type) {
               case 'candidate':
                 optionsForEachContest.set(
@@ -446,6 +451,10 @@ export function* generateCvrs({
                             election.contests,
                             (c) => c.id === contestId
                           );
+                          /* istanbul ignore next */
+                          if (contest.type === 'straight-party') {
+                            return straightPartyNotYetImplemented();
+                          }
                           const contestVotes = votes[contest.id] || [];
                           return {
                             '@type': 'CVR.CVRContest',

--- a/libs/hmpb/src/ballot_rotation.ts
+++ b/libs/hmpb/src/ballot_rotation.ts
@@ -5,7 +5,11 @@ import {
   groupBy,
   uniqueDeep,
 } from '@votingworks/basics';
-import { ContestId, OrderedCandidateOption } from '@votingworks/types';
+import {
+  ContestId,
+  OrderedCandidateOption,
+  straightPartyNotYetImplemented,
+} from '@votingworks/types';
 import { CandidateOrdering, RotationParams } from './types';
 import { getCandidateOrderingSetsForNhBallot } from './ballot_templates/nh_ballot_template';
 import { BallotTemplateId } from './ballot_templates';
@@ -38,6 +42,10 @@ export function getCandidateOrderingByPrecinctAlphabetical({
     > = {};
 
     for (const contest of contests) {
+      /* istanbul ignore next */
+      if (contest.type === 'straight-party') {
+        return straightPartyNotYetImplemented();
+      }
       switch (contest.type) {
         case 'yesno':
           // do nothing
@@ -98,6 +106,10 @@ function getDefaultCandidateOrdering({
   > = {};
 
   for (const contest of contests) {
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      return straightPartyNotYetImplemented();
+    }
     switch (contest.type) {
       case 'candidate':
         orderedCandidatesByContest[contest.id] = contest.candidates.map(

--- a/libs/hmpb/src/ballot_templates/mi_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/mi_ballot_template.tsx
@@ -26,6 +26,7 @@ import {
   getContests,
   getOrderedCandidatesForContestInBallotStyle,
   isPrimary,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import {
   BackendLanguageContextProvider,
@@ -466,6 +467,10 @@ function Contest({
   ballotStyle: BallotStyle;
   numContestColumns: number;
 }) {
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
+  }
   switch (contest.type) {
     case 'candidate':
       return (

--- a/libs/hmpb/src/ballot_templates/ms_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/ms_ballot_template.tsx
@@ -25,6 +25,7 @@ import {
   getContests,
   getOrderedCandidatesForContestInBallotStyle,
   getPartyForBallotStyle,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import {
   BackendLanguageContextProvider,
@@ -487,6 +488,10 @@ function Contest({
   election: Election;
   ballotStyle: BallotStyle;
 }) {
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
+  }
   switch (contest.type) {
     case 'candidate':
       return (

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -34,6 +34,7 @@ import {
   hasSplits,
   getContests,
   getOrderedCandidatesForContestInBallotStyle,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import {
   BackendLanguageContextProvider,
@@ -216,6 +217,10 @@ export function getCandidateOrderingSetsForNhBallot({
         OrderedCandidateOption[]
       > = {};
       for (const contest of contests) {
+        /* istanbul ignore next */
+        if (contest.type === 'straight-party') {
+          straightPartyNotYetImplemented();
+        }
         switch (contest.type) {
           case 'candidate':
             orderedCandidatesByContest[contest.id] = rotateCandidates(
@@ -775,6 +780,10 @@ function Contest({
   ballotStyle: BallotStyle;
   precinctId: PrecinctId;
 }) {
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
+  }
   switch (contest.type) {
     case 'candidate':
       return (

--- a/libs/hmpb/src/ballot_templates/nh_state_general_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_state_general_ballot_template.tsx
@@ -22,6 +22,7 @@ import {
   getBallotStyle,
   getContests,
   Party,
+  straightPartyNotYetImplemented,
   YesNoContest,
 } from '@votingworks/types';
 import {
@@ -691,8 +692,12 @@ export async function BallotPageContent(
 
   while (contestSections.length > 0 && heightUsed < dimensions.height) {
     const section = assertDefined(contestSections.shift());
-    const contestElements = section.map((contest, index) =>
-      contest.type === 'candidate' ? (
+    const contestElements = section.map((contest, index) => {
+      /* istanbul ignore next */
+      if (contest.type === 'straight-party') {
+        return straightPartyNotYetImplemented();
+      }
+      return contest.type === 'candidate' ? (
         <CandidateContest
           key={contest.id}
           contest={contest}
@@ -704,8 +709,8 @@ export async function BallotPageContent(
           contest={contest}
           contestNumber={index + 1}
         />
-      )
-    );
+      );
+    });
     const sectionHeader =
       section[0].type === 'candidate' ? (
         <CandidateContestSectionHeader />

--- a/libs/hmpb/src/ballot_templates/nh_state_primary_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_state_primary_ballot_template.tsx
@@ -20,6 +20,7 @@ import {
   getBallotStyle,
   getContests,
   getPartyForBallotStyle,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import {
   BackendLanguageContextProvider,
@@ -578,6 +579,10 @@ function Contest({
   election: Election;
   colorTint: ColorTint;
 }) {
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
+  }
   switch (contest.type) {
     case 'candidate':
       return <CandidateContest contest={contest} colorTint={colorTint} />;

--- a/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
@@ -24,6 +24,7 @@ import {
   getContests,
   getOrderedCandidatesForContestInBallotStyle,
   getPartyForBallotStyle,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import {
   BackendLanguageContextProvider,
@@ -439,6 +440,10 @@ function Contest({
   election: Election;
   ballotStyle: BallotStyle;
 }) {
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
+  }
   switch (contest.type) {
     case 'candidate':
       return (

--- a/libs/hmpb/src/mark_ballot.tsx
+++ b/libs/hmpb/src/mark_ballot.tsx
@@ -6,6 +6,7 @@ import {
   Vote,
   VotesDict,
   WriteInCandidate,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import { assertDefined, iter, throwIllegalValue } from '@votingworks/basics';
 import React from 'react';
@@ -160,6 +161,10 @@ export function createTestVotes(contests: readonly Contest[]): {
 } {
   const votes: VotesDict = Object.fromEntries(
     contests.map((contest, i) => {
+      /* istanbul ignore next */
+      if (contest.type === 'straight-party') {
+        return straightPartyNotYetImplemented();
+      }
       if (contest.type === 'candidate') {
         const candidates = iter(contest.candidates)
           .cycle()

--- a/libs/hmpb/src/marking.ts
+++ b/libs/hmpb/src/marking.ts
@@ -18,6 +18,7 @@ import {
   Election,
   GridPosition,
   Rect,
+  straightPartyNotYetImplemented,
   Vote,
   VotesDict,
 } from '@votingworks/types';
@@ -141,6 +142,10 @@ export async function generateMarkOverlay(
 
     const contest = election.contests.find((c) => c.id === pos.contestId);
     assert(contest, `contest ${pos.contestId} not found`);
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      straightPartyNotYetImplemented();
+    }
 
     const mark = markInfo(contestVotes, pos, contest, layout);
     if (!mark) continue;

--- a/libs/hmpb/src/render_ballot.test.tsx
+++ b/libs/hmpb/src/render_ballot.test.tsx
@@ -11,6 +11,7 @@ import {
   LanguageCode,
   YesNoContest,
   LATEST_SOFTWARE_VERSION,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import {
   assert,
@@ -344,6 +345,10 @@ test.each(templateSpecificTestCases)(
     ).toEqual(new Set(contests.map((c) => c.id)));
 
     for (const contest of contests) {
+      /* istanbul ignore next */
+      if (contest.type === 'straight-party') {
+        straightPartyNotYetImplemented();
+      }
       switch (contest.type) {
         case 'candidate': {
           const renderedOptions =

--- a/libs/integration-test-utils/src/ballots.ts
+++ b/libs/integration-test-utils/src/ballots.ts
@@ -15,6 +15,7 @@ import {
   getBallotStyle,
   getContests,
   LATEST_SOFTWARE_VERSION,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import {
   ImageData,
@@ -54,6 +55,10 @@ export function createFullyVotedBallot(
 
   return Object.fromEntries(
     contests.map((contest) => {
+      /* istanbul ignore next */
+      if (contest.type === 'straight-party') {
+        straightPartyNotYetImplemented();
+      }
       if (contest.type === 'candidate') {
         return [contest.id, contest.candidates.slice(0, contest.seats)];
       }

--- a/libs/mark-flow-ui/src/pages/contest_page.tsx
+++ b/libs/mark-flow-ui/src/pages/contest_page.tsx
@@ -9,6 +9,7 @@ import {
   OptionalVote,
   PrecinctId,
   VotesDict,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import {
   LinkButton,
@@ -103,6 +104,11 @@ export function ContestPage(props: ContestPageProps): JSX.Element {
         contestNumber: currentContestIndex + 1,
         ballotContestCount: contests.length,
       };
+
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    straightPartyNotYetImplemented();
+  }
 
   const isVoteComplete = (() => {
     switch (contest.type) {

--- a/libs/test-utils/src/election_helpers.ts
+++ b/libs/test-utils/src/election_helpers.ts
@@ -10,6 +10,7 @@ import {
   Party,
   Precinct,
   safeParseElectionDefinition,
+  straightPartyNotYetImplemented,
   VotesDict,
   YesNoContest,
 } from '@votingworks/types';
@@ -179,6 +180,10 @@ export function createMockVotes(
 
   const votes: VotesDict = {};
   for (const contest of filteredContests) {
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      straightPartyNotYetImplemented();
+    }
     if (contest.type === 'candidate') {
       votes[contest.id] = contest.candidates.slice(0, contest.seats);
     } else {

--- a/libs/types-rs/src/bmd/votes.rs
+++ b/libs/types-rs/src/bmd/votes.rs
@@ -167,6 +167,11 @@ impl FromBitStreamWith<'_> for ContestVote {
                     yesno_contest.no_option.id.clone()
                 }))
             }
+            Contest::StraightParty(_) => {
+                unimplemented!(
+                    "STRAIGHT_PARTY_TODO: straight-party contests are not yet implemented"
+                )
+            }
         }
     }
 }

--- a/libs/types-rs/src/election.rs
+++ b/libs/types-rs/src/election.rs
@@ -264,6 +264,9 @@ impl Contest {
                 Contest::Candidate(CandidateContest { party_id, .. }) => {
                     party_id == &ballot_style.party_id
                 }
+                Contest::StraightParty(_) => unimplemented!(
+                    "STRAIGHT_PARTY_TODO: straight-party contests are not yet implemented"
+                ),
             }
     }
 }

--- a/libs/types-rs/src/election.rs
+++ b/libs/types-rs/src/election.rs
@@ -229,21 +229,24 @@ pub enum Contest {
     Candidate(CandidateContest),
     #[serde(rename = "yesno")]
     YesNo(YesNoContest),
+    #[serde(rename = "straight-party")]
+    StraightParty(StraightPartyContest),
 }
 
 impl Contest {
     pub fn id(&self) -> &ContestId {
         match self {
-            Self::Candidate(CandidateContest { id, .. }) | Self::YesNo(YesNoContest { id, .. }) => {
-                id
-            }
+            Self::Candidate(CandidateContest { id, .. })
+            | Self::YesNo(YesNoContest { id, .. })
+            | Self::StraightParty(StraightPartyContest { id, .. }) => id,
         }
     }
 
     pub fn district_id(&self) -> &DistrictId {
         match self {
             Self::Candidate(CandidateContest { district_id, .. })
-            | Self::YesNo(YesNoContest { district_id, .. }) => district_id,
+            | Self::YesNo(YesNoContest { district_id, .. })
+            | Self::StraightParty(StraightPartyContest { district_id, .. }) => district_id,
         }
     }
 
@@ -437,6 +440,16 @@ pub struct YesNoContest {
 pub struct YesNoOption {
     pub id: OptionId,
     pub label: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+#[must_use]
+pub struct StraightPartyContest {
+    pub id: ContestId,
+    pub district_id: DistrictId,
+    pub title: String,
+    pub option_ids: Vec<PartyId>,
 }
 
 #[cfg(test)]

--- a/libs/types-rs/tests/bmd_multi_page_test.rs
+++ b/libs/types-rs/tests/bmd_multi_page_test.rs
@@ -70,7 +70,7 @@ fn test_multi_page_round_trip_with_votes() {
         .iter()
         .find_map(|contest| match contest {
             Contest::Candidate(cc) => Some(cc),
-            Contest::YesNo(_) => None,
+            Contest::YesNo(_) | Contest::StraightParty(_) => None,
         })
         .unwrap();
 
@@ -105,7 +105,7 @@ fn test_multi_page_round_trip_with_write_in() {
         .iter()
         .find_map(|contest| match contest {
             Contest::Candidate(cc) => Some(cc),
-            Contest::YesNo(_) => None,
+            Contest::YesNo(_) | Contest::StraightParty(_) => None,
         })
         .unwrap();
 
@@ -141,7 +141,7 @@ fn test_multi_page_round_trip_yesno_contest() {
         .iter()
         .find_map(|contest| match contest {
             Contest::YesNo(yn) => Some(yn),
-            Contest::Candidate(_) => None,
+            Contest::Candidate(_) | Contest::StraightParty(_) => None,
         })
         .unwrap();
 
@@ -174,7 +174,7 @@ fn test_multi_page_partial_contests_on_page() {
         .iter()
         .find_map(|contest| match contest {
             Contest::Candidate(cc) => Some(cc.id.clone()),
-            Contest::YesNo(_) => None,
+            Contest::YesNo(_) | Contest::StraightParty(_) => None,
         })
         .unwrap();
 
@@ -239,6 +239,9 @@ fn max_votes_for(contest: &Contest) -> (ContestId, ContestVote) {
             ),
         ),
         Contest::YesNo(yn) => (yn.id.clone(), ContestVote::YesNo(yn.yes_option.id.clone())),
+        Contest::StraightParty(_) => {
+            unimplemented!("STRAIGHT_PARTY_TODO: straight-party contests are not yet implemented")
+        }
     }
 }
 

--- a/libs/types-rs/tests/bmd_test.rs
+++ b/libs/types-rs/tests/bmd_test.rs
@@ -41,7 +41,7 @@ fn test_cast_vote_record_round_trip_write_in_vote() {
         .iter()
         .find_map(|contest| match contest {
             Contest::Candidate(candidate_contest) => Some(candidate_contest),
-            Contest::YesNo(_) => None,
+            Contest::YesNo(_) | Contest::StraightParty(_) => None,
         })
         .unwrap();
     let ballot = CastVoteRecord {
@@ -96,7 +96,10 @@ proptest! {
                 )),
                 Contest::YesNo(yesno_contest) => (yesno_contest.id.clone(), ContestVote::YesNo(
                     yesno_contest.yes_option.id.clone()
-                ))
+                )),
+                Contest::StraightParty(_) => unimplemented!(
+                    "STRAIGHT_PARTY_TODO: straight-party contests are not yet implemented"
+                ),
             }).collect(),
             is_test_mode,
             ballot_type,
@@ -116,7 +119,7 @@ fn test_yesno_contest_vote_round_trip() {
         .contests
         .iter()
         .find_map(|contest| match contest {
-            Contest::Candidate(_) => None,
+            Contest::Candidate(_) | Contest::StraightParty(_) => None,
             Contest::YesNo(yesno_contest) => Some((contest, yesno_contest)),
         })
         .unwrap();
@@ -135,7 +138,7 @@ fn test_candidate_contest_vote_round_trip() {
         .iter()
         .find_map(|contest| match contest {
             Contest::Candidate(candidate_contest) => Some((contest, candidate_contest)),
-            Contest::YesNo(_) => None,
+            Contest::YesNo(_) | Contest::StraightParty(_) => None,
         })
         .unwrap();
     let contest_vote = ContestVote::Candidate(vec![CandidateVote::NamedCandidate {

--- a/libs/types/src/__snapshots__/schema.test.ts.snap
+++ b/libs/types/src/__snapshots__/schema.test.ts.snap
@@ -99,6 +99,34 @@ exports[`parsing gives specific errors for nested objects 1`] = `
           ],
           "message": "Invalid input: expected object, received undefined"
         }
+      ],
+      [
+        {
+          "expected": "string",
+          "code": "invalid_type",
+          "path": [
+            "title"
+          ],
+          "message": "Invalid input: expected string, received number"
+        },
+        {
+          "code": "invalid_value",
+          "values": [
+            "straight-party"
+          ],
+          "path": [
+            "type"
+          ],
+          "message": "Invalid input: expected \\"straight-party\\""
+        },
+        {
+          "expected": "array",
+          "code": "invalid_type",
+          "path": [
+            "optionIds"
+          ],
+          "message": "Invalid input: expected array, received undefined"
+        }
       ]
     ],
     "path": [

--- a/libs/types/src/cdf/ballot-definition/convert.ts
+++ b/libs/types/src/cdf/ballot-definition/convert.ts
@@ -520,6 +520,10 @@ export function convertVxfElectionToCdfBallotDefinition(
       contest: Vxf.Contest,
       gridPosition: Vxf.GridPosition
     ): string {
+      /* istanbul ignore next */
+      if (contest.type === 'straight-party') {
+        return Vxf.straightPartyNotYetImplemented();
+      }
       switch (gridPosition.type) {
         case 'option': {
           switch (contest.type) {
@@ -546,6 +550,10 @@ export function convertVxfElectionToCdfBallotDefinition(
     function getOrderedPhysicalContestOptions(
       contest: Vxf.Contest
     ): Cdf.PhysicalContestOption[] {
+      /* istanbul ignore next */
+      if (contest.type === 'straight-party') {
+        return Vxf.straightPartyNotYetImplemented();
+      }
       // For candidate contests, use the ordered candidates from the ballot style
       if (contest.type === 'candidate') {
         const orderedCandidates = getOrderedCandidatesForContestInBallotStyle({
@@ -764,6 +772,10 @@ export function convertVxfElectionToCdfBallotDefinition(
 
         // eslint-disable-next-line array-callback-return
         Contest: vxfElection.contests.map((contest) => {
+          /* istanbul ignore next */
+          if (contest.type === 'straight-party') {
+            return Vxf.straightPartyNotYetImplemented();
+          }
           switch (contest.type) {
             case 'candidate':
               return {

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -275,6 +275,14 @@ export const StraightPartyContestSchema: z.ZodSchema<StraightPartyContest> =
     optionIds: z.array(PartyIdSchema).nonempty(),
   });
 
+/**
+ * This can be placed wherever type narrowing is required, and also marks all
+ * outstanding straight-party contest cases.
+ */
+export function straightPartyNotYetImplemented(): never {
+  throw new Error('Straight party contests are not yet implemented');
+}
+
 export type Contest = CandidateContest | YesNoContest | StraightPartyContest;
 export const ContestSchema: z.ZodSchema<Contest> = z.union([
   CandidateContestSchema,

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -265,10 +265,21 @@ export const YesNoContestSchema: z.ZodSchema<YesNoContest> =
     additionalOptions: z.array(YesNoOptionSchema).optional(),
   });
 
-export type Contest = CandidateContest | YesNoContest;
+export interface StraightPartyContest extends ContestBase {
+  readonly type: 'straight-party';
+  readonly optionIds: readonly PartyId[];
+}
+export const StraightPartyContestSchema: z.ZodSchema<StraightPartyContest> =
+  ContestBaseSchema.extend({
+    type: z.literal('straight-party'),
+    optionIds: z.array(PartyIdSchema).nonempty(),
+  });
+
+export type Contest = CandidateContest | YesNoContest | StraightPartyContest;
 export const ContestSchema: z.ZodSchema<Contest> = z.union([
   CandidateContestSchema,
   YesNoContestSchema,
+  StraightPartyContestSchema,
 ]);
 
 export const ContestsSchema = z.array(ContestSchema).check((ctx) => {

--- a/libs/types/src/election_utils.ts
+++ b/libs/types/src/election_utils.ts
@@ -32,6 +32,7 @@ import {
   hasSplits,
   PrecinctOrSplit,
   CandidateVote,
+  straightPartyNotYetImplemented,
 } from './election';
 
 /**
@@ -456,6 +457,10 @@ export function vote(
 ): VotesDict {
   const votes: VotesDict = {};
   for (const contest of contests) {
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      straightPartyNotYetImplemented();
+    }
     const choice = shorthand[contest.id];
     if (!choice) {
       votes[contest.id] = [];

--- a/libs/types/src/schema.test.ts
+++ b/libs/types/src/schema.test.ts
@@ -361,3 +361,24 @@ test('a contest must have at least one candidate option if write-ins are not all
       .issues[0].message
   ).toEqual('Contest must have at least one candidate or allow write-ins.');
 });
+
+test('a straight-party contest parses', () => {
+  const straightPartyContest: t.StraightPartyContest = {
+    id: 'SP',
+    type: 'straight-party',
+    title: 'SP',
+    districtId: unsafeParse(t.DistrictIdSchema, 'D'),
+    optionIds: ['party-1', 'party-2'],
+  };
+
+  expect(
+    unsafeParse(t.StraightPartyContestSchema, straightPartyContest)
+  ).toEqual(straightPartyContest);
+  expect(unsafeParse(t.ContestSchema, straightPartyContest)).toEqual(
+    straightPartyContest
+  );
+  safeParse(t.StraightPartyContestSchema, {
+    ...straightPartyContest,
+    optionIds: [],
+  }).unsafeUnwrapErr();
+});

--- a/libs/ui/src/bmd_paper_ballot.dual_language.test.tsx
+++ b/libs/ui/src/bmd_paper_ballot.dual_language.test.tsx
@@ -7,6 +7,7 @@ import {
   VotesDict,
   YesNoContest,
   getContests,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 
@@ -304,10 +305,16 @@ describe('English ballot style', () => {
 
   test('all votes filled in', async () => {
     const votes: VotesDict = Object.fromEntries(
-      contests.map((c) => [
-        c.id,
-        c.type === 'yesno' ? generateYesNoVote(c) : generateCandidateVotes(c),
-      ])
+      contests.map((c) => {
+        /* istanbul ignore next */
+        if (c.type === 'straight-party') {
+          straightPartyNotYetImplemented();
+        }
+        return [
+          c.id,
+          c.type === 'yesno' ? generateYesNoVote(c) : generateCandidateVotes(c),
+        ];
+      })
     );
 
     const { container } = render(

--- a/libs/ui/src/bmd_paper_ballot.stories.tsx
+++ b/libs/ui/src/bmd_paper_ballot.stories.tsx
@@ -8,6 +8,7 @@ import {
   getContests,
   safeParseElection,
   safeParseElectionDefinition,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import { generateBallotStyleId } from '@votingworks/utils';
 import styled from 'styled-components';
@@ -39,6 +40,11 @@ function getDuplicatedContests(idSuffix: string) {
     if (c.type === 'candidate') {
       const contest: CandidateContest = { ...c, id: `${c.id}${idSuffix}` };
       return contest;
+    }
+
+    /* istanbul ignore next */
+    if (c.type === 'straight-party') {
+      straightPartyNotYetImplemented();
     }
 
     assert(c.type === 'yesno');
@@ -164,10 +170,16 @@ const initialArgs: BmdPaperBallotProps = {
   onRendered: () => undefined,
   precinctId: election.precincts[0].id,
   votes: Object.fromEntries(
-    election.contests.map((c) => [
-      c.id,
-      c.type === 'yesno' ? generateYesNoVote(c) : generateCandidateVotes(c),
-    ])
+    election.contests.map((c) => {
+      /* istanbul ignore next */
+      if (c.type === 'straight-party') {
+        straightPartyNotYetImplemented();
+      }
+      return [
+        c.id,
+        c.type === 'yesno' ? generateYesNoVote(c) : generateCandidateVotes(c),
+      ];
+    })
   ),
   sheetSize: 'letter',
 };

--- a/libs/ui/src/reports/admin_tally_report_by_party.test.tsx
+++ b/libs/ui/src/reports/admin_tally_report_by_party.test.tsx
@@ -5,7 +5,10 @@ import {
 } from '@votingworks/fixtures';
 import { buildSimpleMockTallyReportResults } from '@votingworks/utils';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
-import { formatBallotHash } from '@votingworks/types';
+import {
+  formatBallotHash,
+  straightPartyNotYetImplemented,
+} from '@votingworks/types';
 import { render, screen, within } from '../../test/react_testing_library';
 import { AdminTallyReportByParty } from './admin_tally_report_by_party';
 import { mockScannerBatches } from '../../test/fixtures';
@@ -187,7 +190,13 @@ test('primary election, party report, test deck', () => {
           '0': 10,
         },
         contestIds: election.contests
-          .filter((c) => c.type === 'yesno' || c.partyId === '0')
+          .filter((c) => {
+            /* istanbul ignore next */
+            if (c.type === 'straight-party') {
+              straightPartyNotYetImplemented();
+            }
+            return c.type === 'yesno' || c.partyId === '0';
+          })
           .map((c) => c.id),
       })}
       scannerBatches={mockScannerBatches}

--- a/libs/ui/src/reports/admin_tally_report_by_party.tsx
+++ b/libs/ui/src/reports/admin_tally_report_by_party.tsx
@@ -1,4 +1,8 @@
-import { Admin, ElectionDefinition } from '@votingworks/types';
+import {
+  Admin,
+  ElectionDefinition,
+  straightPartyNotYetImplemented,
+} from '@votingworks/types';
 import React from 'react';
 
 import { unique } from '@votingworks/basics';
@@ -131,7 +135,13 @@ export function AdminTallyReportByParty({
         electionDefinition={electionDefinition}
         electionPackageHash={electionPackageHash}
         partyLabel="Nonpartisan Contests"
-        contests={contests.filter((c) => c.type === 'yesno' || !c.partyId)}
+        contests={contests.filter((c) => {
+          /* istanbul ignore next */
+          if (c.type === 'straight-party') {
+            straightPartyNotYetImplemented();
+          }
+          return c.type === 'yesno' || !c.partyId;
+        })}
         scannedElectionResults={tallyReportResults.scannedResults}
         manualElectionResults={tallyReportResults.manualResults}
         title={title ?? 'Tally Report'}

--- a/libs/ui/src/reports/contest_results_table.tsx
+++ b/libs/ui/src/reports/contest_results_table.tsx
@@ -6,6 +6,7 @@ import {
   getContestDistrictName,
   Tabulation,
   Contest,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import { format, getTallyReportCandidateRows } from '@votingworks/utils';
 import { throwIllegalValue, assert, Optional } from '@votingworks/basics';
@@ -218,6 +219,11 @@ export function ContestResultsTable({
     : [];
 
   const hasManualResults = Boolean(manualContestResults);
+
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
+  }
 
   switch (contest.type) {
     case 'candidate': {

--- a/libs/ui/src/reports/precinct_scanner_tally_report.test.tsx
+++ b/libs/ui/src/reports/precinct_scanner_tally_report.test.tsx
@@ -4,6 +4,7 @@ import {
   readElectionTwoPartyPrimaryDefinition,
 } from '@votingworks/fixtures';
 import {
+  straightPartyNotYetImplemented,
   anyPollingPlace,
   BatchInfo,
   formatElectionHashes,
@@ -138,9 +139,13 @@ test('renders as expected for all precincts in a primary election', () => {
       pollsTransition="open_polls"
       isLiveMode
       scannedElectionResults={primaryElectionResults}
-      contests={electionTwoPartyPrimary.contests.filter(
-        (c) => c.type === 'yesno' || c.partyId === '0'
-      )}
+      contests={electionTwoPartyPrimary.contests.filter((c) => {
+        /* istanbul ignore next */
+        if (c.type === 'straight-party') {
+          straightPartyNotYetImplemented();
+        }
+        return c.type === 'yesno' || c.partyId === '0';
+      })}
       partyId="0"
       batches={[]}
     />

--- a/libs/utils/src/bmd_votes_mock.ts
+++ b/libs/utils/src/bmd_votes_mock.ts
@@ -2,6 +2,7 @@ import { iter } from '@votingworks/basics';
 import {
   CandidateContest,
   Election,
+  straightPartyNotYetImplemented,
   Vote,
   VotesDict,
   YesNoContest,
@@ -25,11 +26,17 @@ function generateMockYesNoVote(c: YesNoContest, seed = 0): Vote {
 
 export function generateMockVotes(election: Election): VotesDict {
   return Object.fromEntries(
-    election.contests.map((c, index) => [
-      c.id,
-      c.type === 'yesno'
-        ? generateMockYesNoVote(c, index)
-        : generateMockCandidateVote(c, index),
-    ])
+    election.contests.map((c, index) => {
+      /* istanbul ignore next */
+      if (c.type === 'straight-party') {
+        straightPartyNotYetImplemented();
+      }
+      return [
+        c.id,
+        c.type === 'yesno'
+          ? generateMockYesNoVote(c, index)
+          : generateMockCandidateVote(c, index),
+      ];
+    })
   );
 }

--- a/libs/utils/src/cast_vote_records.ts
+++ b/libs/utils/src/cast_vote_records.ts
@@ -22,6 +22,7 @@ import {
   safeParseJson,
   safeParseNumber,
   Side,
+  straightPartyNotYetImplemented,
   Tabulation,
 } from '@votingworks/types';
 
@@ -252,6 +253,10 @@ export function isCastVoteRecordWriteInValid(
 }
 
 function getValidContestOptions(contest: Contest): ContestOptionId[] {
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
+  }
   switch (contest.type) {
     case 'candidate':
       return [

--- a/libs/utils/src/hmpb/all_contest_options.ts
+++ b/libs/utils/src/hmpb/all_contest_options.ts
@@ -13,6 +13,7 @@ import {
   CandidateContestOption,
   ContestOption,
   getOrderedCandidatesForContestInBallotStyle,
+  straightPartyNotYetImplemented,
   YesNoContest,
   YesNoContestOption,
 } from '@votingworks/types';
@@ -51,6 +52,10 @@ export function* allContestOptionsWithMultiEndorsements(
   contest: Contest,
   ballotStyle?: BallotStyle | BallotStyleGroup
 ): Generator<ContestOption> {
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
+  }
   switch (contest.type) {
     case 'candidate': {
       // ballotStyle is guaranteed to be defined for CandidateContest by the function overload

--- a/libs/utils/src/tabulation/compressed_tallies.ts
+++ b/libs/utils/src/tabulation/compressed_tallies.ts
@@ -8,6 +8,7 @@ import {
   Election,
   PrecinctId,
   PrecinctSelection,
+  straightPartyNotYetImplemented,
   Tabulation,
   unsafeParse,
   YesNoContestCompressedTally,
@@ -83,6 +84,10 @@ export function compressTally(
   );
   // eslint-disable-next-line array-callback-return
   return contests.map((contest) => {
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      return straightPartyNotYetImplemented();
+    }
     switch (contest.type) {
       case 'yesno': {
         const contestResults = results.contestResults[contest.id];
@@ -229,6 +234,10 @@ function getContestTalliesForCompressedContest(
   contest: Contest,
   compressedContest: CompressedTallyEntry
 ): Tabulation.ContestResults {
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
+  }
   switch (contest.type) {
     case 'yesno': {
       const [undervotes, overvotes, ballots, yesTally, noTally] = unsafeParse(
@@ -299,6 +308,10 @@ function getContestTalliesForCompressedContest(
 const yesNoContestCompressedTallyLength: YesNoContestCompressedTally['length'] = 5;
 
 function getNumberOfEntriesInContest(contest: Contest): number {
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
+  }
   switch (contest.type) {
     case 'yesno':
       return yesNoContestCompressedTallyLength;
@@ -351,6 +364,10 @@ export function decodeV0CompressedTally(
   );
   for (const contest of contests) {
     const tallyLength = getNumberOfEntriesInContest(contest);
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      straightPartyNotYetImplemented();
+    }
     if (contest.type === 'yesno') {
       compressedTally.push(
         Array.from(
@@ -390,6 +407,10 @@ function decodeContestEntriesFromUint16Array(
       uint16Array.slice(currentOffset, currentOffset + tallyLength)
     );
     let compressedEntry: CompressedTallyEntry;
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      straightPartyNotYetImplemented();
+    }
     if (contest.type === 'yesno') {
       compressedEntry = entryArray as YesNoContestCompressedTally;
     } else {

--- a/libs/utils/src/tabulation/contest_filtering.test.ts
+++ b/libs/utils/src/tabulation/contest_filtering.test.ts
@@ -6,6 +6,7 @@ import {
   readElectionTwoPartyPrimary,
 } from '@votingworks/fixtures';
 import { assert, find } from '@votingworks/basics';
+import { straightPartyNotYetImplemented } from '@votingworks/types';
 import {
   getContestIdsForBallotStyle,
   getContestIdsForPrecinct,
@@ -157,7 +158,13 @@ describe('groupContestsByParty', () => {
       'fishing',
     ]);
     expect(
-      nonPartisanGroup.contests.every((c) => c.type === 'yesno' || !c.partyId)
+      nonPartisanGroup.contests.every((c) => {
+        /* istanbul ignore next */
+        if (c.type === 'straight-party') {
+          straightPartyNotYetImplemented();
+        }
+        return c.type === 'yesno' || !c.partyId;
+      })
     ).toEqual(true);
   });
 
@@ -173,7 +180,13 @@ describe('groupContestsByParty', () => {
     expect(nonPartisanGroup!.partyId).toBeUndefined();
     expect(nonPartisanGroup!.contests).toEqual(election.contests);
     expect(
-      nonPartisanGroup!.contests.every((c) => c.type === 'yesno' || !c.partyId)
+      nonPartisanGroup!.contests.every((c) => {
+        /* istanbul ignore next */
+        if (c.type === 'straight-party') {
+          straightPartyNotYetImplemented();
+        }
+        return c.type === 'yesno' || !c.partyId;
+      })
     ).toEqual(true);
   });
 

--- a/libs/utils/src/tabulation/contest_filtering.ts
+++ b/libs/utils/src/tabulation/contest_filtering.ts
@@ -9,6 +9,7 @@ import {
   PartyId,
   getPartyIdsWithContests,
   getContests,
+  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import { assert, assertDefined, throwIllegalValue } from '@votingworks/basics';
 import { createElectionMetadataLookupFunction } from './lookups';
@@ -115,6 +116,10 @@ export function groupContestsByParty(
     partyId,
     // eslint-disable-next-line array-callback-return
     contests: contests.filter((c) => {
+      /* istanbul ignore next */
+      if (c.type === 'straight-party') {
+        return straightPartyNotYetImplemented();
+      }
       switch (c.type) {
         case 'candidate':
           return c.partyId === partyId;

--- a/libs/utils/src/tabulation/mock_tally_report_results.ts
+++ b/libs/utils/src/tabulation/mock_tally_report_results.ts
@@ -1,4 +1,10 @@
-import { Admin, Election, isPrimary, Tabulation } from '@votingworks/types';
+import {
+  Admin,
+  Election,
+  isPrimary,
+  straightPartyNotYetImplemented,
+  Tabulation,
+} from '@votingworks/types';
 import { mapObject } from '@votingworks/basics';
 import {
   ContestResultsSummaries,
@@ -11,6 +17,10 @@ function buildSimpleMockElectionResults(
 ): Tabulation.ElectionResults {
   const contestResultsSummaries: ContestResultsSummaries = {};
   for (const contest of election.contests) {
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      straightPartyNotYetImplemented();
+    }
     contestResultsSummaries[contest.id] = {
       type: contest.type === 'candidate' ? 'candidate' : 'yesno',
       ballots: ballotCount,

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -10,6 +10,7 @@ import {
   Id,
   PartyId,
   PrecinctSelection,
+  straightPartyNotYetImplemented,
   Tabulation,
   YesNoContest,
 } from '@votingworks/types';
@@ -88,6 +89,10 @@ export function getEmptyElectionResults(
 ): Tabulation.ElectionResults {
   const contestResults: Tabulation.ElectionResults['contestResults'] = {};
   for (const contest of election.contests) {
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      straightPartyNotYetImplemented();
+    }
     contestResults[contest.id] =
       contest.type === 'yesno'
         ? getEmptyYesNoContestResults(contest)
@@ -114,6 +119,10 @@ export function getEmptyManualElectionResults(
 ): Tabulation.ManualElectionResults {
   const contestResults: Tabulation.ElectionResults['contestResults'] = {};
   for (const contest of election.contests) {
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      straightPartyNotYetImplemented();
+    }
     contestResults[contest.id] =
       contest.type === 'yesno'
         ? getEmptyYesNoContestResults(contest)
@@ -540,6 +549,10 @@ export function combineContestResults({
   contest: Contest;
   allContestResults: Tabulation.ContestResults[];
 }): Tabulation.ContestResults {
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    straightPartyNotYetImplemented();
+  }
   if (contest.type === 'yesno') {
     return combineYesNoContestResults({
       contest,
@@ -751,6 +764,10 @@ export function buildContestResultsFixture({
   contestResultsSummary: ContestResultsSummary;
   includeGenericWriteIn?: boolean;
 }): Tabulation.ContestResults {
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    straightPartyNotYetImplemented();
+  }
   const contestResults =
     contest.type === 'yesno'
       ? getEmptyYesNoContestResults(contest)
@@ -807,6 +824,10 @@ function buildElectionContestResultsFixture({
   const electionContestResults: Tabulation.ElectionResults['contestResults'] =
     {};
   for (const contest of election.contests) {
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      straightPartyNotYetImplemented();
+    }
     const contestResultsSummary = contestResultsSummaries[contest.id];
     electionContestResults[contest.id] = contestResultsSummary
       ? buildContestResultsFixture({

--- a/libs/utils/src/test_decks.ts
+++ b/libs/utils/src/test_decks.ts
@@ -19,6 +19,7 @@ import {
   GridLayout,
   Tabulation,
   getGroupIdFromBallotStyleId,
+  straightPartyNotYetImplemented,
   Admin,
 } from '@votingworks/types';
 import {
@@ -47,6 +48,10 @@ export interface TestDeckBallot {
 }
 
 export function numBallotPositions(contest: Contest): number {
+  /* istanbul ignore next */
+  if (contest.type === 'straight-party') {
+    return straightPartyNotYetImplemented();
+  }
   if (contest.type === 'candidate') {
     return (
       contest.candidates.length + (contest.allowWriteIns ? contest.seats : 0)
@@ -145,12 +150,21 @@ export function generateTestDeckBallots({
           // first contest where an overvote is possible. Does not overvote
           // candidate contests where you must select a write-in to overvote. See
           // discussion: https://github.com/votingworks/vxsuite/issues/1711.
-          const overvoteContest = contests.find(
-            (contest) =>
+          const overvoteContest = contests.find((contest) => {
+            /* istanbul ignore next */
+            if (contest.type === 'straight-party') {
+              straightPartyNotYetImplemented();
+            }
+            return (
               contest.type === 'yesno' ||
               contest.candidates.length > contest.seats
-          );
+            );
+          });
           if (overvoteContest) {
+            /* istanbul ignore next */
+            if (overvoteContest.type === 'straight-party') {
+              straightPartyNotYetImplemented();
+            }
             ballots.push({
               ballotStyleId: ballotStyle.id,
               precinctId: currentPrecinctId,

--- a/libs/utils/src/votes.ts
+++ b/libs/utils/src/votes.ts
@@ -10,6 +10,7 @@ import {
   MarkThresholds,
   safeParse,
   safeParseInt,
+  straightPartyNotYetImplemented,
   Tabulation,
   Vote,
   VotesDict,
@@ -165,6 +166,10 @@ export function convertMarksToVotesDict(
   for (const mark of marks) {
     const contest = contests.find((c) => c.id === mark.contestId);
     assert(contest, `Contest not found: ${mark.contestId}`);
+    /* istanbul ignore next */
+    if (contest.type === 'straight-party') {
+      straightPartyNotYetImplemented();
+    }
     const existingVotes = votesDict[mark.contestId] ?? [];
     const newVotes =
       contest.type === 'candidate'


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->
Task: #7886 

Adds a new `StraightPartyContest` type to the election data model. Since there are many cases where we narrow contests by type, this PR just throws a not-yet-implemented error for the straight party contest case. I'll be chipping away at the various cases in upcoming feature-based PRs. 

A few notes on the design decisions for this data type:

`districtId`: Straight party contests are not really part of a district in the way that normal contests are, since they are more of a toggle for the ballot. But the CDF ballot definition does have a district ID associated with straight party contests, and we expect to import MI elections from their EMS using CDF, so it seems reasonable to expect that there will be a district to associate it with. Worst case we need to make a synthetic district. The upside of keeping `districtId` is a lot less special casing throughout VxSuite (I explored the alternative approach of dropping `districtId` in my POC and it impacted a lot of places).

`optionIds`: In my POC, I explored having no contest options listed on the contest itself and instead just building the list dynamically when needed from `Election.parties`. One advantage of this is that we can reuse the audio/translations for party names. It also has a couple of downsides: (1) we need `parties` in scope whenever we want to work with straight party contest options, and (2) the order of `Election.parties` determined the order for the contest options, which was a little confusing/inexplicit. I settled on including the party IDs in the contest as a happy medium - decoupling the order and colocating at least the IDs of the options for that contest.

## Demo Video or Screenshot
N/A

## Testing Plan
- Existing tests
- New test for the schema
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
