### PR TITLE
refactor(usb-drive): consolidate on `mountpoint` not `mountPoint`

### DIFF
--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -566,7 +566,7 @@ test('usbDrive', async () => {
   mockMultiUsbDrive.insertUsbDrive({});
   expect(await apiClient.getUsbDriveStatus()).toMatchObject({
     status: 'mounted',
-    mountPoint: expect.any(String),
+    mountpoint: expect.any(String),
   });
 
   // ext4 drives are filtered out by the adapter — they appear as no_drive

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -485,7 +485,7 @@ function buildApi({
 
       const potentialElectionPackages: FileSystemEntry[] = [];
 
-      for await (const result of listDirectory(usbDriveStatus.mountPoint, {
+      for await (const result of listDirectory(usbDriveStatus.mountpoint, {
         depth: 3,
         excludeHidden: true,
       })) {
@@ -668,7 +668,7 @@ function buildApi({
         usbDriveStatus.status === 'mounted'
           ? await listCastVoteRecordExportsInDirectory(
               join(
-                usbDriveStatus.mountPoint,
+                usbDriveStatus.mountpoint,
                 getCastVoteRecordsPath(electionDefinition)
               )
             )

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -160,7 +160,7 @@ function buildApi({
       const electionPackageResult =
         await readSignedElectionPackageFromDirectory(
           authStatus,
-          usbDriveStatus.mountPoint,
+          usbDriveStatus.mountpoint,
           logger
         );
       if (electionPackageResult.isErr()) {

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -165,7 +165,7 @@ export function buildApi(
       const electionPackageResult =
         await readSignedElectionPackageFromDirectory(
           authStatus,
-          usbDriveStatus.mountPoint,
+          usbDriveStatus.mountpoint,
           logger,
           { checkMarkScanSystemLimits: true }
         );

--- a/apps/mark-scan/backend/src/electrical_testing/background.ts
+++ b/apps/mark-scan/backend/src/electrical_testing/background.ts
@@ -86,7 +86,7 @@ export async function runCardReadAndUsbDriveWriteTask({
         const usbDriveStatus = await usbDrive.status();
         assert(usbDriveStatus.status === 'mounted', 'USB drive not mounted');
         await fs.appendFile(
-          join(usbDriveStatus.mountPoint, USB_DRIVE_FILE_NAME),
+          join(usbDriveStatus.mountpoint, USB_DRIVE_FILE_NAME),
           `${new Date().toISOString()}\n`
         );
       } catch (error) {

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -201,7 +201,7 @@ export function buildApi(ctx: Context) {
       const electionPackageResult =
         await readSignedElectionPackageFromDirectory(
           authStatus,
-          usbDriveStatus.mountPoint,
+          usbDriveStatus.mountpoint,
           logger,
           { checkMarkSystemLimits: true }
         );

--- a/apps/mark/backend/src/electrical_testing/background.ts
+++ b/apps/mark/backend/src/electrical_testing/background.ts
@@ -71,7 +71,7 @@ export async function runCardReadAndUsbDriveWriteTask({
         const usbDriveStatus = await usbDrive.status();
         assert(usbDriveStatus.status === 'mounted', 'USB drive not mounted');
         await fs.appendFile(
-          join(usbDriveStatus.mountPoint, USB_DRIVE_FILE_NAME),
+          join(usbDriveStatus.mountpoint, USB_DRIVE_FILE_NAME),
           `${new Date().toISOString()}\n`
         );
       } catch (error) {

--- a/apps/pollbook/backend/src/backup_worker.ts
+++ b/apps/pollbook/backend/src/backup_worker.ts
@@ -219,9 +219,9 @@ export async function exportBackupVoterChecklist(
     const inProgressName = `part_${
       i + 1
     }_backup_voter_checklist.in_progress.pdf`;
-    const inProgressPath = join(usbDriveStatus.mountPoint, inProgressName);
+    const inProgressPath = join(usbDriveStatus.mountpoint, inProgressName);
     const finalPath = join(
-      usbDriveStatus.mountPoint,
+      usbDriveStatus.mountpoint,
       `part_${i + 1}_backup_voter_checklist.pdf`
     );
     (

--- a/apps/pollbook/backend/src/pollbook_package.ts
+++ b/apps/pollbook/backend/src/pollbook_package.ts
@@ -331,17 +331,17 @@ export function pollUsbDriveForPollbookPackage({
         if (hadConfigurationError) {
           return;
         }
-        usbDebug('Found USB drive mounted at %s', usbDriveStatus.mountPoint);
+        usbDebug('Found USB drive mounted at %s', usbDriveStatus.mountpoint);
 
         workspace.store.setConfigurationStatus('loading');
-        const files = await readdir(usbDriveStatus.mountPoint);
+        const files = await readdir(usbDriveStatus.mountpoint);
         const pollbookFiles = files
           .filter(
             (file) =>
               file.startsWith(POLLBOOK_PACKAGE_FILENAME_PREFIX) &&
               file.endsWith('.zip')
           )
-          .map((file) => join(usbDriveStatus.mountPoint, file));
+          .map((file) => join(usbDriveStatus.mountpoint, file));
         if (pollbookFiles.length === 0) {
           workspace.store.setConfigurationStatus('not-found-usb');
           hadConfigurationError = true;

--- a/apps/pollbook/frontend/src/election_manager_screen.test.tsx
+++ b/apps/pollbook/frontend/src/election_manager_screen.test.tsx
@@ -177,7 +177,7 @@ describe('Settings tab', () => {
   beforeEach(() => {
     apiMock.expectGetUsbDriveStatus({
       status: 'mounted',
-      mountPoint: '/dev/null',
+      mountpoint: '/dev/null',
     });
   });
 

--- a/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
+++ b/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
@@ -219,7 +219,7 @@ describe('Settings tab', () => {
     apiMock.expectHaveElectionEventsOccurred(false);
     apiMock.expectGetUsbDriveStatus({
       status: 'mounted',
-      mountPoint: '/dev/null',
+      mountpoint: '/dev/null',
     });
   });
 

--- a/apps/print/backend/src/app.ballots_printed_report.test.ts
+++ b/apps/print/backend/src/app.ballots_printed_report.test.ts
@@ -128,10 +128,10 @@ test('ballots printed report (zero) can be printed and exported (pdf snapshots)'
   });
   const usbStatus = await mockUsbDrive.usbDrive.status();
   expect(usbStatus.status).toEqual('mounted');
-  const { mountPoint } = usbStatus as { status: 'mounted'; mountPoint: string };
+  const { mountpoint } = usbStatus as { status: 'mounted'; mountpoint: string };
 
   const reportsDir = join(
-    mountPoint,
+    mountpoint,
     generateReportsDirectoryPath(electionDefinition)
   );
   const exportedFilename = `ballots-printed-report__${generateFileTimeSuffix(
@@ -203,9 +203,9 @@ test('ballots printed report (non-zero) can be printed and exported (pdf snapsho
   });
   const usbStatus = await mockUsbDrive.usbDrive.status();
   expect(usbStatus.status).toEqual('mounted');
-  const { mountPoint } = usbStatus as { status: 'mounted'; mountPoint: string };
+  const { mountpoint } = usbStatus as { status: 'mounted'; mountpoint: string };
   const reportsDir = join(
-    mountPoint,
+    mountpoint,
     generateReportsDirectoryPath(electionDefinition)
   );
   const exportedFilename = `ballots-printed-report__${generateFileTimeSuffix(

--- a/apps/print/backend/src/app.ts
+++ b/apps/print/backend/src/app.ts
@@ -84,7 +84,7 @@ export function buildApi(ctx: AppContext) {
       const electionPackageResult =
         await readSignedElectionPackageFromDirectory(
           authStatus,
-          usbDriveStatus.mountPoint,
+          usbDriveStatus.mountpoint,
           logger
         );
       if (electionPackageResult.isErr()) {

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -166,7 +166,7 @@ export function buildApi({
       const electionPackageResult =
         await readSignedElectionPackageFromDirectory(
           authStatus,
-          usbDriveStatus.mountPoint,
+          usbDriveStatus.mountpoint,
           logger
         );
       if (electionPackageResult.isErr()) {

--- a/apps/scan/backend/src/app_export.test.ts
+++ b/apps/scan/backend/src/app_export.test.ts
@@ -458,7 +458,7 @@ test('audit ballot IDs', async () => {
       const usbDriveStatus = await mockUsbDrive.usbDrive.status();
       assert(usbDriveStatus.status === 'mounted', 'No USB drive mounted');
       const secretKeyPath = path.join(
-        usbDriveStatus.mountPoint,
+        usbDriveStatus.mountpoint,
         BALLOT_AUDIT_ID_FILE_NAME
       );
       const secretKey = await readFile(secretKeyPath, 'utf-8');

--- a/apps/scan/backend/src/app_usb_drive.test.ts
+++ b/apps/scan/backend/src/app_usb_drive.test.ts
@@ -30,7 +30,7 @@ test('getUsbDriveStatus', async () => {
     mockUsbDrive.insertUsbDrive({});
     await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
       status: 'mounted',
-      mountPoint: expect.any(String),
+      mountpoint: expect.any(String),
     });
   });
 });
@@ -55,7 +55,7 @@ test('doesUsbDriveRequireCastVoteRecordSync is properly populated', async () => 
       await configureApp(apiClient, mockAuth, mockUsbDrive, { testMode: true });
       const mountedUsbDriveStatus = {
         status: 'mounted',
-        mountPoint: expect.any(String),
+        mountpoint: expect.any(String),
       } as const;
 
       await expect(apiClient.getUsbDriveStatus()).resolves.toEqual(

--- a/apps/scan/backend/src/electrical_testing/tasks/card_read_and_usb_drive_write_task.test.ts
+++ b/apps/scan/backend/src/electrical_testing/tasks/card_read_and_usb_drive_write_task.test.ts
@@ -14,7 +14,7 @@ async function hasWrittenFileToUsbDrive(usbDrive: UsbDrive) {
   const status = await usbDrive.status();
   return (
     status.status === 'mounted' &&
-    exists(join(status.mountPoint, USB_DRIVE_FILE_NAME))
+    exists(join(status.mountpoint, USB_DRIVE_FILE_NAME))
   );
 }
 

--- a/apps/scan/backend/src/electrical_testing/tasks/card_read_and_usb_drive_write_task.ts
+++ b/apps/scan/backend/src/electrical_testing/tasks/card_read_and_usb_drive_write_task.ts
@@ -58,7 +58,7 @@ export async function runCardReadAndUsbDriveWriteTask({
         const usbDriveStatus = await usbDrive.status();
         assert(usbDriveStatus.status === 'mounted', 'USB drive not mounted');
         await fs.appendFile(
-          path.join(usbDriveStatus.mountPoint, USB_DRIVE_FILE_NAME),
+          path.join(usbDriveStatus.mountpoint, USB_DRIVE_FILE_NAME),
           `${new Date().toISOString()}\n`
         );
       } catch (error) {

--- a/apps/scan/backend/src/electrical_testing/tasks/print_and_scan_task.ts
+++ b/apps/scan/backend/src/electrical_testing/tasks/print_and_scan_task.ts
@@ -155,7 +155,7 @@ export async function runPrintAndScanTask({
         const usbDriveStatus = await usbDrive.status();
         if (usbDriveStatus.status === 'mounted') {
           const usbDriveExportDirectory = join(
-            usbDriveStatus.mountPoint,
+            usbDriveStatus.mountpoint,
             'ballot-images'
           );
           await mkdir(usbDriveExportDirectory, { recursive: true });

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -668,7 +668,7 @@ export async function exportCastVoteRecordsToUsbDrive(
   assert(scannerStore.scannerType === exportOptions.scannerType);
   const usbDriveStatus = await usbDrive.status();
   const usbMountPoint =
-    usbDriveStatus.status === 'mounted' ? usbDriveStatus.mountPoint : undefined;
+    usbDriveStatus.status === 'mounted' ? usbDriveStatus.mountpoint : undefined;
   if (usbMountPoint === undefined) {
     return err({ type: 'missing-usb-drive' });
   }
@@ -900,7 +900,7 @@ export async function doesUsbDriveRequireCastVoteRecordSync(
     if (usbDriveStatus.status !== 'mounted') {
       return false;
     }
-    const usbMountPoint = usbDriveStatus.mountPoint;
+    const usbMountPoint = usbDriveStatus.mountpoint;
 
     const electionRecord = scannerStore.getElectionRecord();
     if (!electionRecord) {

--- a/libs/backend/src/cast_vote_records/test_utils.ts
+++ b/libs/backend/src/cast_vote_records/test_utils.ts
@@ -142,7 +142,7 @@ export async function getCastVoteRecordExportDirectoryPaths(
 ): Promise<string[]> {
   const usbDriveStatus = await usbDrive.status();
   const usbMountPoint =
-    usbDriveStatus.status === 'mounted' ? usbDriveStatus.mountPoint : undefined;
+    usbDriveStatus.status === 'mounted' ? usbDriveStatus.mountpoint : undefined;
   assert(usbMountPoint !== undefined);
 
   const electionDirectoryNames = fs.readdirSync(usbMountPoint);

--- a/libs/backend/src/exporter.test.ts
+++ b/libs/backend/src/exporter.test.ts
@@ -154,7 +154,7 @@ test('exportDataToUsbDrive happy path', async () => {
   const path = join(tmpDir, 'bucket/test.txt');
   usbDrive.status
     .expectCallWith()
-    .resolves({ status: 'mounted', mountPoint: tmpDir });
+    .resolves({ status: 'mounted', mountpoint: tmpDir });
   usbDrive.sync.expectCallWith().resolves();
   const result = await exporter.exportDataToUsbDrive(
     'bucket',
@@ -170,7 +170,7 @@ test('exportDataToUsbDrive with maximumFileSize', async () => {
   const path = join(tmpDir, 'bucket/test.txt');
   usbDrive.status
     .expectCallWith()
-    .resolves({ status: 'mounted', mountPoint: tmpDir });
+    .resolves({ status: 'mounted', mountpoint: tmpDir });
   usbDrive.sync.expectCallWith().resolves();
   const result = await exporter.exportDataToUsbDrive(
     'bucket',
@@ -189,7 +189,7 @@ test('exportDataToUsbDrive with machineDirectoryToWriteToFirst', async () => {
   const tmpDir = makeTemporaryDirectory();
   usbDrive.status
     .expectCallWith()
-    .resolves({ status: 'mounted', mountPoint: tmpDir });
+    .resolves({ status: 'mounted', mountpoint: tmpDir });
   usbDrive.sync.expectCallWith().resolves();
 
   const result = await exporter.exportDataToUsbDrive(

--- a/libs/backend/src/exporter.ts
+++ b/libs/backend/src/exporter.ts
@@ -183,7 +183,7 @@ export class Exporter {
     }
 
     const result = await this.exportData(
-      join(usbDriveStatus.mountPoint, bucket, name),
+      join(usbDriveStatus.mountpoint, bucket, name),
       dataToWrite,
       { maximumFileSize }
     );

--- a/libs/backend/src/system_call/export_logs_to_usb.test.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.test.ts
@@ -159,7 +159,7 @@ test('exportLogsToUsb works for vxf format when all conditions are met', async (
   mockUsbDrive.usbDrive.status.reset();
   mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
     status: 'mounted',
-    mountPoint: '/media/usb-drive',
+    mountpoint: '/media/usb-drive',
   });
   mockUsbDrive.usbDrive.sync.expectCallWith().resolves();
 
@@ -213,7 +213,7 @@ testPlainAndCompressed('when CDF conversion fails - [$0]', async (fmt) => {
   mockUsbDrive.usbDrive.status.reset();
   mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
     status: 'mounted',
-    mountPoint: '/media/usb-drive',
+    mountpoint: '/media/usb-drive',
   });
 
   const mockStats = new Stats();
@@ -248,7 +248,7 @@ test('exportLogsToUsb returns error when error filtering fails', async () => {
   mockUsbDrive.usbDrive.status.reset();
   mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
     status: 'mounted',
-    mountPoint: '/media/usb-drive',
+    mountpoint: '/media/usb-drive',
   });
 
   const mockStats = new Stats();
@@ -295,7 +295,7 @@ testPlainAndCompressed('works for CDF format - [$0]', async (fmt) => {
   mockUsbDrive.usbDrive.status.reset();
   mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
     status: 'mounted',
-    mountPoint: '/media/usb-drive',
+    mountpoint: '/media/usb-drive',
   });
   mockUsbDrive.usbDrive.sync.expectCallWith().resolves();
 
@@ -384,7 +384,7 @@ testPlainAndCompressed('works for error format - [$0]', async (fmt) => {
   mockUsbDrive.usbDrive.status.reset();
   mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
     status: 'mounted',
-    mountPoint: '/media/usb-drive',
+    mountpoint: '/media/usb-drive',
   });
   mockUsbDrive.usbDrive.sync.expectCallWith().resolves();
 

--- a/libs/backend/src/system_call/export_logs_to_usb.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.ts
@@ -145,7 +145,7 @@ async function exportLogsToUsbHelper({
     return err({ code: 'no-usb-drive' });
   }
 
-  const machineNamePath = join(status.mountPoint, `/logs/machine_${machineId}`);
+  const machineNamePath = join(status.mountpoint, `/logs/machine_${machineId}`);
 
   const destinationDirectory = join(machineNamePath, generateFileTimeSuffix());
   const tempDirectory = dirSync().name;

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -320,7 +320,7 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
           const usbDriveStatus = handler.status();
           if (usbDriveStatus.status !== 'mounted') return undefined;
           const result = await getMostRecentElectionPackageFilepath(
-            usbDriveStatus.mountPoint
+            usbDriveStatus.mountpoint
           );
           if (result.isErr()) return undefined;
           const zipPath = result.ok();

--- a/libs/ui/src/electrical_testing_screen.test.tsx
+++ b/libs/ui/src/electrical_testing_screen.test.tsx
@@ -139,7 +139,7 @@ test('save logs', async () => {
     <ElectricalTestingScreen
       tasks={[]}
       powerDown={vi.fn()}
-      usbDriveStatus={{ status: 'mounted', mountPoint: '/media/vx/usb-drive' }}
+      usbDriveStatus={{ status: 'mounted', mountpoint: '/media/vx/usb-drive' }}
       apiClient={mockApiClient}
     />
   );

--- a/libs/ui/src/test-utils/mock_usb_drive.ts
+++ b/libs/ui/src/test-utils/mock_usb_drive.ts
@@ -10,7 +10,7 @@ export function mockUsbDriveStatus(
     case 'mounted':
       return {
         status,
-        mountPoint: 'test-mount-point',
+        mountpoint: 'test-mount-point',
       };
     case 'no_drive':
     case 'ejected':

--- a/libs/usb-drive/src/mocks/file_usb_drive.test.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.test.ts
@@ -23,7 +23,7 @@ test('createMockFileMultiUsbDrive mock flow', async () => {
   multiUsbDrive.stop();
 
   handler.insert();
-  const mountPoint = handler.getDataPath();
+  const mountpoint = handler.getDataPath();
   expect(multiUsbDrive.getDrives()).toEqual<UsbDriveInfo[]>([
     {
       diskPath: '/dev/sdb',
@@ -31,7 +31,7 @@ test('createMockFileMultiUsbDrive mock flow', async () => {
         diskPath: '/dev/sdb',
         partPath: '/dev/sdb1',
         fstype: 'fat32',
-        mount: UsbPartitionMount.mounted(mountPoint!),
+        mount: UsbPartitionMount.mounted(mountpoint!),
       },
     },
   ]);
@@ -117,7 +117,7 @@ test('mock flow', async () => {
   });
   const expectedMountPoint = handler.getDataPath();
   expect(await usbDrive.status()).toMatchObject({
-    mountPoint: expectedMountPoint,
+    mountpoint: expectedMountPoint,
     status: 'mounted',
   });
 

--- a/libs/usb-drive/src/mocks/file_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.ts
@@ -146,7 +146,7 @@ export function createMockFileUsbDrive(diskName = 'sdb'): UsbDrive {
       }
       return Promise.resolve({
         status: 'mounted',
-        mountPoint: getMockDriveDataDirPath(diskName),
+        mountpoint: getMockDriveDataDirPath(diskName),
       });
     },
 
@@ -261,7 +261,7 @@ export function getMockFileUsbDriveHandler(
       const { state } = readMockDriveState(diskName);
       if (state === 'removed') return { status: 'no_drive' };
       if (state === 'ejected') return { status: 'ejected' };
-      return { status: 'mounted', mountPoint: getDataPath() };
+      return { status: 'mounted', mountpoint: getDataPath() };
     },
     insert: (contents?: MockFileTree) => {
       if (contents) {

--- a/libs/usb-drive/src/mocks/memory_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/memory_usb_drive.ts
@@ -56,7 +56,7 @@ export function createMockUsbDrive(): MockUsbDrive {
       usbDrive.status.reset();
       usbDrive.status.expectRepeatedCallsWith().resolves({
         status: 'mounted',
-        mountPoint: mockUsbTmpDir.name,
+        mountpoint: mockUsbTmpDir.name,
       });
     },
 

--- a/libs/usb-drive/src/mocks/mock_multi_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/mock_multi_usb_drive.ts
@@ -67,9 +67,9 @@ export function createMockMultiUsbDrive(): MockMultiUsbDrive {
     options: { diskPath: string; fstype?: UsbDriveFilesystemType }
   ) {
     const fstype = options.fstype ?? 'fat32';
-    const mountPoint = makeTemporaryDirectory();
-    mockUsbTmpDirs.push(mountPoint);
-    writeMockFileTree(mountPoint, contents);
+    const mountpoint = makeTemporaryDirectory();
+    mockUsbTmpDirs.push(mountpoint);
+    writeMockFileTree(mountpoint, contents);
     drives.push({
       diskPath: options.diskPath,
       partition: {
@@ -77,7 +77,7 @@ export function createMockMultiUsbDrive(): MockMultiUsbDrive {
         partPath: `${options.diskPath}1`,
         label: 'VxUSB-ABCDE',
         fstype,
-        mount: UsbPartitionMount.mounted(mountPoint),
+        mount: UsbPartitionMount.mounted(mountpoint),
       },
     });
     multiUsbDrive.getDrives.reset();

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -36,8 +36,8 @@ async function mountPartition(partPath: string): Promise<void> {
   await exec('sudo', ['-n', join(MOUNT_SCRIPT_PATH, 'mount.sh'), partPath]);
 }
 
-async function unmountPartition(mountPoint: string): Promise<void> {
-  await exec('sudo', ['-n', join(MOUNT_SCRIPT_PATH, 'unmount.sh'), mountPoint]);
+async function unmountPartition(mountpoint: string): Promise<void> {
+  await exec('sudo', ['-n', join(MOUNT_SCRIPT_PATH, 'unmount.sh'), mountpoint]);
 }
 
 export type UsbDriveFilesystemType = 'fat32' | 'ext4';

--- a/libs/usb-drive/src/types.ts
+++ b/libs/usb-drive/src/types.ts
@@ -4,7 +4,7 @@ export type UsbDriveStatus =
   | { status: 'no_drive' }
   | {
       status: 'mounted';
-      mountPoint: string;
+      mountpoint: string;
     }
   | { status: 'ejected' }
   | { status: 'error'; reason: 'bad_format' };
@@ -40,13 +40,13 @@ export const UsbPartitionMount = {
   ejected: (): UsbPartitionMount => ({ type: 'ejected' }),
   mounting: (): UsbPartitionMount => ({ type: 'mounting' }),
   formatting: (): UsbPartitionMount => ({ type: 'formatting' }),
-  mounted: (mountPoint: string): UsbPartitionMount => ({
+  mounted: (mountpoint: string): UsbPartitionMount => ({
     type: 'mounted',
-    mountPoint,
+    mountpoint,
   }),
-  unmounting: (mountPoint: string): UsbPartitionMount => ({
+  unmounting: (mountpoint: string): UsbPartitionMount => ({
     type: 'unmounting',
-    mountPoint,
+    mountpoint,
   }),
 } as const;
 
@@ -55,5 +55,5 @@ export type UsbPartitionMount =
   | { type: 'ejected' }
   | { type: 'mounting' }
   | { type: 'formatting' }
-  | { type: 'mounted'; mountPoint: string }
-  | { type: 'unmounting'; mountPoint: string };
+  | { type: 'mounted'; mountpoint: string }
+  | { type: 'unmounting'; mountpoint: string };

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -90,6 +90,6 @@ test('exposes the first connected drive via the UsbDrive interface', async () =>
 
   expect(await usbDrive.status()).toEqual({
     status: 'mounted',
-    mountPoint: '/media/vx/usb-drive-sdb1',
+    mountpoint: '/media/vx/usb-drive-sdb1',
   });
 });

--- a/libs/usb-drive/src/usb_drive_adapter.test.ts
+++ b/libs/usb-drive/src/usb_drive_adapter.test.ts
@@ -84,7 +84,7 @@ describe('createUsbDriveAdapter', () => {
       ]);
       expect(await adapter.status()).toEqual<UsbDriveStatus>({
         status: 'mounted',
-        mountPoint: '/media/vx/usb-drive-sdb1',
+        mountpoint: '/media/vx/usb-drive-sdb1',
       });
     });
 
@@ -116,7 +116,7 @@ describe('createUsbDriveAdapter', () => {
         .returns([makeDriveInfo()]);
       expect(await adapter.status()).toEqual({
         status: 'mounted',
-        mountPoint: '/media/vx/usb-drive-sdb1',
+        mountpoint: '/media/vx/usb-drive-sdb1',
       });
     });
 
@@ -193,7 +193,7 @@ describe('createUsbDriveAdapter', () => {
       ]);
       expect(await adapter.status()).toEqual({
         status: 'mounted',
-        mountPoint: '/media/vx/usb-drive-sdb1',
+        mountpoint: '/media/vx/usb-drive-sdb1',
       });
     });
   });

--- a/libs/usb-drive/src/usb_drive_adapter.ts
+++ b/libs/usb-drive/src/usb_drive_adapter.ts
@@ -49,16 +49,16 @@ export function createUsbDriveAdapter(
           debug('adapter: partition is mounting, returning no_drive');
           return Promise.resolve({ status: 'no_drive' });
         case 'mounted':
-          debug(`adapter: partition is mounted at ${mount.mountPoint}`);
+          debug(`adapter: partition is mounted at ${mount.mountpoint}`);
           return Promise.resolve({
             status: 'mounted',
-            mountPoint: mount.mountPoint,
+            mountpoint: mount.mountpoint,
           });
         case 'unmounting':
           debug('adapter: partition is unmounting, returning mounted');
           return Promise.resolve({
             status: 'mounted',
-            mountPoint: mount.mountPoint,
+            mountpoint: mount.mountpoint,
           });
         case 'formatting':
           // Formatting unmounts the drive first; present it as ejected, which

--- a/specs/0004-multi-usb-drive.md
+++ b/specs/0004-multi-usb-drive.md
@@ -49,8 +49,8 @@ export type UsbPartitionMount =
   | { type: 'unmounted' }
   | { type: 'ejected' }
   | { type: 'mounting' }
-  | { type: 'mounted'; mountPoint: string }
-  | { type: 'unmounting'; mountPoint: string };
+  | { type: 'mounted'; mountpoint: string }
+  | { type: 'unmounting'; mountpoint: string };
 
 export interface UsbPartitionInfo {
   devPath: string; // e.g. '/dev/sdb1'


### PR DESCRIPTION
_(Part 8 of a series of PRs: [previous](https://github.com/votingworks/vxsuite/pull/8725) / [next](https://github.com/votingworks/vxsuite/pull/8728))_

This was inconsistent. I went with `mountpoint` because it's the name of a Linux CLI and is in an option to `findmnt`.