### PR TITLE
refactor(usb-drive): specialize dev paths into branded types

### DIFF
--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -44,8 +44,8 @@ import { ManualResultsIdentifier, ManualResultsRecord } from './types';
 const electionGeneralDefinition = readElectionGeneralDefinition();
 const electionGeneral = electionGeneralDefinition.election;
 
-const devsdb = UsbDiskDevPathSchema.parse('/dev/sdb');
-const devsdb1 = UsbPartitionDevPathSchema.parse('/dev/sdb1');
+const devsdb = UsbDiskDevPathSchema.decode('/dev/sdb');
+const devsdb1 = UsbPartitionDevPathSchema.decode('/dev/sdb1');
 
 let mockNodeEnv: 'production' | 'test' = 'test';
 
@@ -595,9 +595,7 @@ test('usbDrive', async () => {
 
   mockMultiUsbDrive.insertUsbDrive({});
 
-  mockMultiUsbDrive.multiUsbDrive.ejectDrive
-    .expectCallWith(UsbDiskDevPathSchema.parse('/dev/sdb'))
-    .resolves();
+  mockMultiUsbDrive.multiUsbDrive.ejectDrive.expectCallWith(devsdb).resolves();
   await apiClient.ejectUsbDrive();
 
   mockMultiUsbDrive.multiUsbDrive.formatDrive

--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -25,7 +25,11 @@ import {
   getMockConnectedPrinterStatus,
 } from '@votingworks/printing';
 import { CandidateContestResults } from '@votingworks/types/src/tabulation';
-import { UsbPartitionMount } from '@votingworks/usb-drive';
+import {
+  UsbDiskDevPathSchema,
+  UsbPartitionDevPathSchema,
+  UsbPartitionMount,
+} from '@votingworks/usb-drive';
 import {
   buildTestEnvironment,
   configureMachine,
@@ -39,6 +43,9 @@ import { ManualResultsIdentifier, ManualResultsRecord } from './types';
 
 const electionGeneralDefinition = readElectionGeneralDefinition();
 const electionGeneral = electionGeneralDefinition.election;
+
+const devsdb = UsbDiskDevPathSchema.parse('/dev/sdb');
+const devsdb1 = UsbPartitionDevPathSchema.parse('/dev/sdb1');
 
 let mockNodeEnv: 'production' | 'test' = 'test';
 
@@ -573,10 +580,10 @@ test('usbDrive', async () => {
   mockMultiUsbDrive.multiUsbDrive.getDrives.reset();
   mockMultiUsbDrive.multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
     {
-      diskPath: '/dev/sdb',
+      diskPath: devsdb,
       partition: {
-        diskPath: '/dev/sdb',
-        partPath: '/dev/sdb1',
+        diskPath: devsdb,
+        partPath: devsdb1,
         fstype: 'ext4',
         mount: UsbPartitionMount.unmounted(),
       },
@@ -589,18 +596,18 @@ test('usbDrive', async () => {
   mockMultiUsbDrive.insertUsbDrive({});
 
   mockMultiUsbDrive.multiUsbDrive.ejectDrive
-    .expectCallWith('/dev/sdb')
+    .expectCallWith(UsbDiskDevPathSchema.parse('/dev/sdb'))
     .resolves();
   await apiClient.ejectUsbDrive();
 
   mockMultiUsbDrive.multiUsbDrive.formatDrive
-    .expectCallWith('/dev/sdb', 'fat32')
+    .expectCallWith(devsdb, 'fat32')
     .resolves();
   (await apiClient.formatUsbDrive()).assertOk('format failed');
 
   const error = new Error('format failed');
   mockMultiUsbDrive.multiUsbDrive.formatDrive
-    .expectCallWith('/dev/sdb', 'fat32')
+    .expectCallWith(devsdb, 'fat32')
     .throws(error);
   expect(await apiClient.formatUsbDrive()).toEqual(err(error));
 });

--- a/apps/pollbook/frontend/src/election_manager_screen.test.tsx
+++ b/apps/pollbook/frontend/src/election_manager_screen.test.tsx
@@ -178,7 +178,7 @@ describe('Settings tab', () => {
   beforeEach(() => {
     apiMock.expectGetUsbDriveStatus({
       status: 'mounted',
-      mountpoint: UsbPartitionMountpointSchema.parse('/dev/null'),
+      mountpoint: UsbPartitionMountpointSchema.decode('/dev/null'),
     });
   });
 

--- a/apps/pollbook/frontend/src/election_manager_screen.test.tsx
+++ b/apps/pollbook/frontend/src/election_manager_screen.test.tsx
@@ -4,6 +4,7 @@ import {
   electionSimpleSinglePrecinctFixtures,
 } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
+import { UsbPartitionMountpointSchema } from '@votingworks/usb-drive';
 import { screen } from '../test/react_testing_library';
 import {
   ApiMock,
@@ -177,7 +178,7 @@ describe('Settings tab', () => {
   beforeEach(() => {
     apiMock.expectGetUsbDriveStatus({
       status: 'mounted',
-      mountpoint: '/dev/null',
+      mountpoint: UsbPartitionMountpointSchema.parse('/dev/null'),
     });
   });
 

--- a/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
+++ b/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
@@ -220,7 +220,7 @@ describe('Settings tab', () => {
     apiMock.expectHaveElectionEventsOccurred(false);
     apiMock.expectGetUsbDriveStatus({
       status: 'mounted',
-      mountpoint: UsbPartitionMountpointSchema.parse('/dev/null'),
+      mountpoint: UsbPartitionMountpointSchema.decode('/dev/null'),
     });
   });
 

--- a/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
+++ b/apps/pollbook/frontend/src/system_administrator_screen.test.tsx
@@ -6,6 +6,7 @@ import {
   PollbookServiceInfo,
 } from '@votingworks/pollbook-backend';
 import { within } from '@testing-library/react';
+import { UsbPartitionMountpointSchema } from '@votingworks/usb-drive';
 import { screen } from '../test/react_testing_library';
 import { ApiMock, createApiMock } from '../test/mock_api_client';
 import { SystemAdministratorScreen } from './system_administrator_screen';
@@ -219,7 +220,7 @@ describe('Settings tab', () => {
     apiMock.expectHaveElectionEventsOccurred(false);
     apiMock.expectGetUsbDriveStatus({
       status: 'mounted',
-      mountpoint: '/dev/null',
+      mountpoint: UsbPartitionMountpointSchema.parse('/dev/null'),
     });
   });
 

--- a/libs/backend/src/exporter.test.ts
+++ b/libs/backend/src/exporter.test.ts
@@ -5,7 +5,10 @@ import { readFile, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { Readable } from 'node:stream';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
-import { createMockUsbDrive } from '@votingworks/usb-drive';
+import {
+  createMockUsbDrive,
+  UsbPartitionMountpointSchema,
+} from '@votingworks/usb-drive';
 import { Exporter, ExportDataResult } from './exporter';
 import { execFile } from './exec';
 
@@ -152,9 +155,10 @@ test('exportDataToUsbDrive with no drives', async () => {
 test('exportDataToUsbDrive happy path', async () => {
   const tmpDir = makeTemporaryDirectory();
   const path = join(tmpDir, 'bucket/test.txt');
-  usbDrive.status
-    .expectCallWith()
-    .resolves({ status: 'mounted', mountpoint: tmpDir });
+  usbDrive.status.expectCallWith().resolves({
+    status: 'mounted',
+    mountpoint: UsbPartitionMountpointSchema.parse(tmpDir),
+  });
   usbDrive.sync.expectCallWith().resolves();
   const result = await exporter.exportDataToUsbDrive(
     'bucket',
@@ -168,9 +172,10 @@ test('exportDataToUsbDrive happy path', async () => {
 test('exportDataToUsbDrive with maximumFileSize', async () => {
   const tmpDir = makeTemporaryDirectory();
   const path = join(tmpDir, 'bucket/test.txt');
-  usbDrive.status
-    .expectCallWith()
-    .resolves({ status: 'mounted', mountpoint: tmpDir });
+  usbDrive.status.expectCallWith().resolves({
+    status: 'mounted',
+    mountpoint: UsbPartitionMountpointSchema.parse(tmpDir),
+  });
   usbDrive.sync.expectCallWith().resolves();
   const result = await exporter.exportDataToUsbDrive(
     'bucket',
@@ -187,9 +192,10 @@ test('exportDataToUsbDrive with maximumFileSize', async () => {
 
 test('exportDataToUsbDrive with machineDirectoryToWriteToFirst', async () => {
   const tmpDir = makeTemporaryDirectory();
-  usbDrive.status
-    .expectCallWith()
-    .resolves({ status: 'mounted', mountpoint: tmpDir });
+  usbDrive.status.expectCallWith().resolves({
+    status: 'mounted',
+    mountpoint: UsbPartitionMountpointSchema.parse(tmpDir),
+  });
   usbDrive.sync.expectCallWith().resolves();
 
   const result = await exporter.exportDataToUsbDrive(

--- a/libs/backend/src/exporter.test.ts
+++ b/libs/backend/src/exporter.test.ts
@@ -157,7 +157,7 @@ test('exportDataToUsbDrive happy path', async () => {
   const path = join(tmpDir, 'bucket/test.txt');
   usbDrive.status.expectCallWith().resolves({
     status: 'mounted',
-    mountpoint: UsbPartitionMountpointSchema.parse(tmpDir),
+    mountpoint: UsbPartitionMountpointSchema.decode(tmpDir),
   });
   usbDrive.sync.expectCallWith().resolves();
   const result = await exporter.exportDataToUsbDrive(
@@ -174,7 +174,7 @@ test('exportDataToUsbDrive with maximumFileSize', async () => {
   const path = join(tmpDir, 'bucket/test.txt');
   usbDrive.status.expectCallWith().resolves({
     status: 'mounted',
-    mountpoint: UsbPartitionMountpointSchema.parse(tmpDir),
+    mountpoint: UsbPartitionMountpointSchema.decode(tmpDir),
   });
   usbDrive.sync.expectCallWith().resolves();
   const result = await exporter.exportDataToUsbDrive(
@@ -194,7 +194,7 @@ test('exportDataToUsbDrive with machineDirectoryToWriteToFirst', async () => {
   const tmpDir = makeTemporaryDirectory();
   usbDrive.status.expectCallWith().resolves({
     status: 'mounted',
-    mountpoint: UsbPartitionMountpointSchema.parse(tmpDir),
+    mountpoint: UsbPartitionMountpointSchema.decode(tmpDir),
   });
   usbDrive.sync.expectCallWith().resolves();
 

--- a/libs/backend/src/system_call/export_logs_to_usb.test.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.test.ts
@@ -162,7 +162,7 @@ test('exportLogsToUsb works for vxf format when all conditions are met', async (
   mockUsbDrive.usbDrive.status.reset();
   mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
     status: 'mounted',
-    mountpoint: UsbPartitionMountpointSchema.parse('/media/usb-drive'),
+    mountpoint: UsbPartitionMountpointSchema.decode('/media/usb-drive'),
   });
   mockUsbDrive.usbDrive.sync.expectCallWith().resolves();
 
@@ -216,7 +216,7 @@ testPlainAndCompressed('when CDF conversion fails - [$0]', async (fmt) => {
   mockUsbDrive.usbDrive.status.reset();
   mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
     status: 'mounted',
-    mountpoint: UsbPartitionMountpointSchema.parse('/media/usb-drive'),
+    mountpoint: UsbPartitionMountpointSchema.decode('/media/usb-drive'),
   });
 
   const mockStats = new Stats();
@@ -251,7 +251,7 @@ test('exportLogsToUsb returns error when error filtering fails', async () => {
   mockUsbDrive.usbDrive.status.reset();
   mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
     status: 'mounted',
-    mountpoint: UsbPartitionMountpointSchema.parse('/media/usb-drive'),
+    mountpoint: UsbPartitionMountpointSchema.decode('/media/usb-drive'),
   });
 
   const mockStats = new Stats();
@@ -298,7 +298,7 @@ testPlainAndCompressed('works for CDF format - [$0]', async (fmt) => {
   mockUsbDrive.usbDrive.status.reset();
   mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
     status: 'mounted',
-    mountpoint: UsbPartitionMountpointSchema.parse('/media/usb-drive'),
+    mountpoint: UsbPartitionMountpointSchema.decode('/media/usb-drive'),
   });
   mockUsbDrive.usbDrive.sync.expectCallWith().resolves();
 
@@ -387,7 +387,7 @@ testPlainAndCompressed('works for error format - [$0]', async (fmt) => {
   mockUsbDrive.usbDrive.status.reset();
   mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
     status: 'mounted',
-    mountpoint: UsbPartitionMountpointSchema.parse('/media/usb-drive'),
+    mountpoint: UsbPartitionMountpointSchema.decode('/media/usb-drive'),
   });
   mockUsbDrive.usbDrive.sync.expectCallWith().resolves();
 

--- a/libs/backend/src/system_call/export_logs_to_usb.test.ts
+++ b/libs/backend/src/system_call/export_logs_to_usb.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, expect, MockInstance, test, vi } from 'vitest';
-import { createMockUsbDrive } from '@votingworks/usb-drive';
+import {
+  createMockUsbDrive,
+  UsbPartitionMountpointSchema,
+} from '@votingworks/usb-drive';
 import * as fs from 'node:fs/promises';
 import {
   Stats,
@@ -159,7 +162,7 @@ test('exportLogsToUsb works for vxf format when all conditions are met', async (
   mockUsbDrive.usbDrive.status.reset();
   mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
     status: 'mounted',
-    mountpoint: '/media/usb-drive',
+    mountpoint: UsbPartitionMountpointSchema.parse('/media/usb-drive'),
   });
   mockUsbDrive.usbDrive.sync.expectCallWith().resolves();
 
@@ -213,7 +216,7 @@ testPlainAndCompressed('when CDF conversion fails - [$0]', async (fmt) => {
   mockUsbDrive.usbDrive.status.reset();
   mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
     status: 'mounted',
-    mountpoint: '/media/usb-drive',
+    mountpoint: UsbPartitionMountpointSchema.parse('/media/usb-drive'),
   });
 
   const mockStats = new Stats();
@@ -248,7 +251,7 @@ test('exportLogsToUsb returns error when error filtering fails', async () => {
   mockUsbDrive.usbDrive.status.reset();
   mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
     status: 'mounted',
-    mountpoint: '/media/usb-drive',
+    mountpoint: UsbPartitionMountpointSchema.parse('/media/usb-drive'),
   });
 
   const mockStats = new Stats();
@@ -295,7 +298,7 @@ testPlainAndCompressed('works for CDF format - [$0]', async (fmt) => {
   mockUsbDrive.usbDrive.status.reset();
   mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
     status: 'mounted',
-    mountpoint: '/media/usb-drive',
+    mountpoint: UsbPartitionMountpointSchema.parse('/media/usb-drive'),
   });
   mockUsbDrive.usbDrive.sync.expectCallWith().resolves();
 
@@ -384,7 +387,7 @@ testPlainAndCompressed('works for error format - [$0]', async (fmt) => {
   mockUsbDrive.usbDrive.status.reset();
   mockUsbDrive.usbDrive.status.expectRepeatedCallsWith().resolves({
     status: 'mounted',
-    mountpoint: '/media/usb-drive',
+    mountpoint: UsbPartitionMountpointSchema.parse('/media/usb-drive'),
   });
   mockUsbDrive.usbDrive.sync.expectCallWith().resolves();
 

--- a/libs/dev-dock/backend/src/dev_dock_api.test.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.test.ts
@@ -48,6 +48,7 @@ import {
   getMockFileUsbDriveHandler,
   listMockDrives,
   removeMockDriveDir,
+  UsbDiskDevPathSchema,
 } from '@votingworks/usb-drive';
 import {
   Api,
@@ -403,31 +404,31 @@ test('poll worker card has a PIN when the election package enables them', async 
 test('usb drive mock endpoints', async () => {
   const { apiClient } = setup();
   await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
-    devPath: '/dev/sdb',
+    diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
     status: 'removed',
   });
 
   await apiClient.insertUsbDrive();
   await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
-    devPath: '/dev/sdb',
+    diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
     status: 'inserted',
   });
 
   await apiClient.clearUsbDrive();
   await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
-    devPath: '/dev/sdb',
+    diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
     status: 'inserted',
   });
 
   await apiClient.removeUsbDrive();
   await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
-    devPath: '/dev/sdb',
+    diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
     status: 'removed',
   });
 
   await apiClient.clearUsbDrive();
   await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
-    devPath: '/dev/sdb',
+    diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
     status: 'removed',
   });
 });

--- a/libs/dev-dock/backend/src/dev_dock_api.test.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.test.ts
@@ -404,31 +404,31 @@ test('poll worker card has a PIN when the election package enables them', async 
 test('usb drive mock endpoints', async () => {
   const { apiClient } = setup();
   await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
-    diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
+    diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
     status: 'removed',
   });
 
   await apiClient.insertUsbDrive();
   await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
-    diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
+    diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
     status: 'inserted',
   });
 
   await apiClient.clearUsbDrive();
   await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
-    diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
+    diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
     status: 'inserted',
   });
 
   await apiClient.removeUsbDrive();
   await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
-    diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
+    diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
     status: 'removed',
   });
 
   await apiClient.clearUsbDrive();
   await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
-    diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
+    diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
     status: 'removed',
   });
 });

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -41,6 +41,8 @@ import {
   addMockDrive,
   getMockFileUsbDriveHandler,
   listMockDrives,
+  UsbDiskDevPath,
+  UsbDiskDevPathSchema,
 } from '@votingworks/usb-drive';
 import {
   getMockFileFujitsuPrinterHandler,
@@ -69,7 +71,7 @@ export interface MockBatchScannerApi {
 export type DevDockUserRole = Exclude<UserRole, 'cardless_voter'>;
 export type DevDockUsbDriveStatus = 'inserted' | 'removed';
 export interface DevDockUsbDriveInfo {
-  devPath: string;
+  diskPath: UsbDiskDevPath;
   status: DevDockUsbDriveStatus;
 }
 export interface DevDockElectionOption {
@@ -91,7 +93,9 @@ export interface DevDockElectionInfo extends DevDockElectionOption {
 }
 
 export const MOCK_USB_DRIVE_DISK_NAME = 'sdb';
-export const MOCK_USB_DRIVE_DEV_PATH = `/dev/${MOCK_USB_DRIVE_DISK_NAME}`;
+export const MOCK_USB_DRIVE_DEV_PATH = UsbDiskDevPathSchema.parse(
+  `/dev/${MOCK_USB_DRIVE_DISK_NAME}`
+);
 
 export const DEFAULT_DEV_DOCK_ELECTION_INPUT_PATH =
   './libs/fixtures/data/electionGeneral/election.json';
@@ -365,7 +369,7 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
       const handler = getMockFileUsbDriveHandler(MOCK_USB_DRIVE_DISK_NAME);
       const status =
         handler.status().status === 'mounted' ? 'inserted' : 'removed';
-      return { devPath: MOCK_USB_DRIVE_DEV_PATH, status };
+      return { diskPath: MOCK_USB_DRIVE_DEV_PATH, status };
     },
 
     insertUsbDrive(): void {

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -93,7 +93,7 @@ export interface DevDockElectionInfo extends DevDockElectionOption {
 }
 
 export const MOCK_USB_DRIVE_DISK_NAME = 'sdb';
-export const MOCK_USB_DRIVE_DEV_PATH = UsbDiskDevPathSchema.parse(
+export const MOCK_USB_DRIVE_DEV_PATH = UsbDiskDevPathSchema.decode(
   `/dev/${MOCK_USB_DRIVE_DISK_NAME}`
 );
 

--- a/libs/dev-dock/frontend/src/dev_dock.test.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.test.tsx
@@ -18,7 +18,7 @@ import {
 import { assertDefined } from '@votingworks/basics';
 import userEvent from '@testing-library/user-event';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
-import type { Api } from '@votingworks/dev-dock-backend';
+import type { Api, DevDockUsbDriveInfo } from '@votingworks/dev-dock-backend';
 import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
@@ -35,6 +35,8 @@ import { makeRender } from '@votingworks/ui';
 import { DevDock } from './dev_dock';
 
 export const render = makeRender(onTestFinished);
+
+const mockDiskPath = '/dev/sdb' as DevDockUsbDriveInfo['diskPath'];
 
 const noCardStatus: CardStatus = {
   status: 'no_card',
@@ -84,7 +86,7 @@ beforeEach(() => {
   mockApiClient.getCardStatus.expectCallWith().resolves(noCardStatus);
   mockApiClient.getUsbDriveStatus
     .expectRepeatedCallsWith()
-    .resolves({ devPath: '/dev/sdb', status: 'removed' });
+    .resolves({ diskPath: mockDiskPath, status: 'removed' });
   mockApiClient.getAvailableElections.expectCallWith().resolves([
     {
       title: 'electionGeneral',
@@ -282,14 +284,14 @@ test('USB drive controls', async () => {
   mockApiClient.insertUsbDrive.expectCallWith().resolves();
   mockApiClient.getUsbDriveStatus
     .expectCallWith()
-    .resolves({ devPath: '/dev/sdb', status: 'inserted' });
+    .resolves({ diskPath: mockDiskPath, status: 'inserted' });
   userEvent.click(usbDriveControl);
   await waitFor(() => mockApiClient.assertComplete());
 
   mockApiClient.removeUsbDrive.expectCallWith().resolves();
   mockApiClient.getUsbDriveStatus
     .expectCallWith()
-    .resolves({ devPath: '/dev/sdb', status: 'removed' });
+    .resolves({ diskPath: mockDiskPath, status: 'removed' });
   userEvent.click(usbDriveControl);
   await waitFor(() => mockApiClient.assertComplete());
 
@@ -299,7 +301,7 @@ test('USB drive controls', async () => {
   mockApiClient.clearUsbDrive.expectCallWith().resolves();
   mockApiClient.getUsbDriveStatus
     .expectCallWith()
-    .resolves({ devPath: '/dev/sdb', status: 'removed' });
+    .resolves({ diskPath: mockDiskPath, status: 'removed' });
   userEvent.click(clearUsbDriveButton);
   await waitFor(() => mockApiClient.assertComplete());
 });

--- a/libs/dev-dock/frontend/src/dev_dock.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.tsx
@@ -386,7 +386,7 @@ function UsbDriveMockControls() {
           }}
           isInserted={isInserted}
           disabled={controlsDisabled}
-          aria-label={`USB Drive ${drive.devPath}`}
+          aria-label={`USB Drive ${drive.diskPath}`}
         >
           <UsbDriveIcon isInserted={isInserted} disabled={controlsDisabled} />
           {!isFeatureEnabled && (
@@ -396,7 +396,7 @@ function UsbDriveMockControls() {
           )}
         </UsbDriveControl>
       </div>
-      <UsbDriveDevLabel>{drive.devPath}</UsbDriveDevLabel>
+      <UsbDriveDevLabel>{drive.diskPath}</UsbDriveDevLabel>
       <UsbDriveClearButton
         onClick={() => handleClearClick()}
         disabled={controlsDisabled}

--- a/libs/ui/src/electrical_testing_screen.test.tsx
+++ b/libs/ui/src/electrical_testing_screen.test.tsx
@@ -142,7 +142,7 @@ test('save logs', async () => {
       powerDown={vi.fn()}
       usbDriveStatus={{
         status: 'mounted',
-        mountpoint: UsbPartitionMountpointSchema.parse('/media/vx/usb-drive'),
+        mountpoint: UsbPartitionMountpointSchema.decode('/media/vx/usb-drive'),
       }}
       apiClient={mockApiClient}
     />

--- a/libs/ui/src/electrical_testing_screen.test.tsx
+++ b/libs/ui/src/electrical_testing_screen.test.tsx
@@ -2,6 +2,7 @@ import userEvent from '@testing-library/user-event';
 import { DateTime } from 'luxon';
 import { expect, test, vi } from 'vitest';
 import { assertDefined, ok } from '@votingworks/basics';
+import { UsbPartitionMountpointSchema } from '@votingworks/usb-drive';
 import { screen } from '../test/react_testing_library';
 import { ElectricalTestingScreen } from './electrical_testing_screen';
 import { Icons } from './icons';
@@ -139,7 +140,10 @@ test('save logs', async () => {
     <ElectricalTestingScreen
       tasks={[]}
       powerDown={vi.fn()}
-      usbDriveStatus={{ status: 'mounted', mountpoint: '/media/vx/usb-drive' }}
+      usbDriveStatus={{
+        status: 'mounted',
+        mountpoint: UsbPartitionMountpointSchema.parse('/media/vx/usb-drive'),
+      }}
       apiClient={mockApiClient}
     />
   );

--- a/libs/ui/src/test-utils/mock_usb_drive.ts
+++ b/libs/ui/src/test-utils/mock_usb_drive.ts
@@ -1,9 +1,9 @@
 /* istanbul ignore file */
 import { throwIllegalValue } from '@votingworks/basics';
 
-import {
-  type UsbDriveStatus,
-  UsbPartitionMountpointSchema,
+import type {
+  UsbDriveStatus,
+  UsbPartitionMountpoint,
 } from '@votingworks/usb-drive';
 
 export function mockUsbDriveStatus(
@@ -13,7 +13,7 @@ export function mockUsbDriveStatus(
     case 'mounted':
       return {
         status,
-        mountpoint: UsbPartitionMountpointSchema.parse('/test-mount-point'),
+        mountpoint: '/test-mount-point' as UsbPartitionMountpoint,
       };
     case 'no_drive':
     case 'ejected':

--- a/libs/ui/src/test-utils/mock_usb_drive.ts
+++ b/libs/ui/src/test-utils/mock_usb_drive.ts
@@ -1,7 +1,10 @@
 /* istanbul ignore file */
 import { throwIllegalValue } from '@votingworks/basics';
 
-import type { UsbDriveStatus } from '@votingworks/usb-drive';
+import {
+  type UsbDriveStatus,
+  UsbPartitionMountpointSchema,
+} from '@votingworks/usb-drive';
 
 export function mockUsbDriveStatus(
   status: UsbDriveStatus['status']
@@ -10,7 +13,7 @@ export function mockUsbDriveStatus(
     case 'mounted':
       return {
         status,
-        mountpoint: 'test-mount-point',
+        mountpoint: UsbPartitionMountpointSchema.parse('/test-mount-point'),
       };
     case 'no_drive':
     case 'ejected':

--- a/libs/usb-drive/package.json
+++ b/libs/usb-drive/package.json
@@ -30,7 +30,8 @@
     "@votingworks/test-utils": "workspace:*",
     "@votingworks/utils": "workspace:*",
     "debug": "4.3.4",
-    "tmp": "^0.2.6"
+    "tmp": "^0.2.6",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@types/debug": "4.1.12",

--- a/libs/usb-drive/src/block_devices.test.ts
+++ b/libs/usb-drive/src/block_devices.test.ts
@@ -243,7 +243,7 @@ describe('getAllUsbDrives', () => {
 
     expect(result).toEqual<UsbDiskDeviceInfo[]>([
       {
-        diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
+        diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
         vendor: undefined,
         model: undefined,
         serial: undefined,
@@ -369,14 +369,14 @@ describe('getAllUsbDrives', () => {
 
     expect(result).toEqual<UsbDiskDeviceInfo[]>([
       {
-        diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
+        diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
         vendor: undefined,
         model: undefined,
         serial: undefined,
         partitions: [
           {
-            partPath: UsbPartitionDevPathSchema.parse('/dev/sdb1'),
-            mountpoint: UsbPartitionMountpointSchema.parse(
+            partPath: UsbPartitionDevPathSchema.decode('/dev/sdb1'),
+            mountpoint: UsbPartitionMountpointSchema.decode(
               '/media/vx/usb-drive-sdb1'
             ),
             fstype: 'vfat',
@@ -407,13 +407,13 @@ describe('getAllUsbDrives', () => {
 
     expect(result).toEqual<UsbDiskDeviceInfo[]>([
       {
-        diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
+        diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
         vendor: undefined,
         model: undefined,
         serial: undefined,
         partitions: [
           {
-            partPath: UsbPartitionDevPathSchema.parse('/dev/sdb1'),
+            partPath: UsbPartitionDevPathSchema.decode('/dev/sdb1'),
             mountpoint: undefined,
             fstype: 'vfat',
             fsver: 'FAT32',
@@ -446,14 +446,14 @@ describe('getAllUsbDrives', () => {
 
     expect(result).toEqual<UsbDiskDeviceInfo[]>([
       {
-        diskPath: UsbDiskDevPathSchema.parse('/dev/sdp'),
+        diskPath: UsbDiskDevPathSchema.decode('/dev/sdp'),
         vendor: undefined,
         model: undefined,
         serial: undefined,
         partitions: [
           {
-            partPath: UsbPartitionDevPathSchema.parse('/dev/sdp1'),
-            mountpoint: UsbPartitionMountpointSchema.parse(
+            partPath: UsbPartitionDevPathSchema.decode('/dev/sdp1'),
+            mountpoint: UsbPartitionMountpointSchema.decode(
               '/media/vx/usb-drive-sdp1'
             ),
             fstype: 'vfat',

--- a/libs/usb-drive/src/block_devices.test.ts
+++ b/libs/usb-drive/src/block_devices.test.ts
@@ -388,6 +388,42 @@ describe('getAllUsbDrives', () => {
     ]);
   });
 
+  test('includes unmounted partition with no parent disk entry in udev', async () => {
+    // An orphan partition is unmounted when first detected — before
+    // auto-mounting has run — so a missing mountpoint must not crash the scan.
+    execMock.mockResolvedValueOnce({
+      stdout: exportDbEntry({
+        devname: '/dev/sdb1',
+        devtype: 'partition',
+        fstype: 'vfat',
+        fsver: 'FAT32',
+        label: 'VxUSB-ABCDE',
+      }),
+      stderr: '',
+    });
+    readFileMock.mockResolvedValueOnce(procMountsContent([]));
+
+    const result = await getAllDiskDevices();
+
+    expect(result).toEqual<UsbDiskDeviceInfo[]>([
+      {
+        diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
+        vendor: undefined,
+        model: undefined,
+        serial: undefined,
+        partitions: [
+          {
+            partPath: UsbPartitionDevPathSchema.parse('/dev/sdb1'),
+            mountpoint: undefined,
+            fstype: 'vfat',
+            fsver: 'FAT32',
+            label: 'VxUSB-ABCDE',
+          },
+        ],
+      },
+    ]);
+  });
+
   test('derives parent disk path for orphan partition on a p-suffixed disk', async () => {
     // /dev/nvme0p1 → /dev/nvme0 is right, but /dev/sdp1 → /dev/sd is not.
     execMock.mockResolvedValueOnce({

--- a/libs/usb-drive/src/block_devices.test.ts
+++ b/libs/usb-drive/src/block_devices.test.ts
@@ -7,6 +7,11 @@ import {
   UsbDiskDeviceInfo,
 } from './block_devices';
 import { exec, spawn } from './exec';
+import {
+  UsbDiskDevPathSchema,
+  UsbPartitionDevPathSchema,
+  UsbPartitionMountpointSchema,
+} from './types';
 
 const readFileMock = vi.mocked(fs.readFile);
 const execMock = vi.mocked(exec);
@@ -153,7 +158,7 @@ describe('getAllUsbDrives', () => {
     // Disk has no real partitions (the partition with the same devname is not
     // recognized as a child), so it appears as an unformatted drive.
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({ devPath: '/dev/sdb', partitions: [] });
+    expect(result[0]).toMatchObject({ diskPath: '/dev/sdb', partitions: [] });
   });
 
   test('recognizes nvme-style p-suffix partitions', async () => {
@@ -176,8 +181,8 @@ describe('getAllUsbDrives', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
-      devPath: '/dev/nvme0n1',
-      partitions: [{ devPath: '/dev/nvme0n1p1' }],
+      diskPath: '/dev/nvme0n1',
+      partitions: [{ partPath: '/dev/nvme0n1p1' }],
     });
   });
 
@@ -211,13 +216,13 @@ describe('getAllUsbDrives', () => {
 
     expect(result).toEqual([
       {
-        devPath: '/dev/sdb',
+        diskPath: '/dev/sdb',
         vendor: 'SanDisk',
         model: 'Ultra',
         serial: 'ABC123',
         partitions: [
           {
-            devPath: '/dev/sdb1',
+            partPath: '/dev/sdb1',
             mountpoint: '/media/vx/usb-drive-sdb1',
             fstype: 'vfat',
             fsver: 'FAT32',
@@ -238,7 +243,7 @@ describe('getAllUsbDrives', () => {
 
     expect(result).toEqual<UsbDiskDeviceInfo[]>([
       {
-        devPath: '/dev/sdb',
+        diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
         vendor: undefined,
         model: undefined,
         serial: undefined,
@@ -274,8 +279,8 @@ describe('getAllUsbDrives', () => {
     const result = await getAllDiskDevices();
 
     expect(result).toHaveLength(2);
-    expect(result[0]).toMatchObject({ devPath: '/dev/sdb' });
-    expect(result[1]).toMatchObject({ devPath: '/dev/sdc' });
+    expect(result[0]).toMatchObject({ diskPath: '/dev/sdb' });
+    expect(result[1]).toMatchObject({ diskPath: '/dev/sdc' });
   });
 
   test('excludes disk whose only partition is LVM', async () => {
@@ -364,14 +369,16 @@ describe('getAllUsbDrives', () => {
 
     expect(result).toEqual<UsbDiskDeviceInfo[]>([
       {
-        devPath: '/dev/sdb',
+        diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
         vendor: undefined,
         model: undefined,
         serial: undefined,
         partitions: [
           {
-            devPath: '/dev/sdb1',
-            mountpoint: '/media/vx/usb-drive-sdb1',
+            partPath: UsbPartitionDevPathSchema.parse('/dev/sdb1'),
+            mountpoint: UsbPartitionMountpointSchema.parse(
+              '/media/vx/usb-drive-sdb1'
+            ),
             fstype: 'vfat',
             fsver: 'FAT32',
             label: 'VxUSB-ABCDE',
@@ -403,14 +410,16 @@ describe('getAllUsbDrives', () => {
 
     expect(result).toEqual<UsbDiskDeviceInfo[]>([
       {
-        devPath: '/dev/sdp',
+        diskPath: UsbDiskDevPathSchema.parse('/dev/sdp'),
         vendor: undefined,
         model: undefined,
         serial: undefined,
         partitions: [
           {
-            devPath: '/dev/sdp1',
-            mountpoint: '/media/vx/usb-drive-sdp1',
+            partPath: UsbPartitionDevPathSchema.parse('/dev/sdp1'),
+            mountpoint: UsbPartitionMountpointSchema.parse(
+              '/media/vx/usb-drive-sdp1'
+            ),
             fstype: 'vfat',
             fsver: 'FAT32',
             label: 'VxUSB-ABCDE',

--- a/libs/usb-drive/src/block_devices.ts
+++ b/libs/usb-drive/src/block_devices.ts
@@ -219,7 +219,9 @@ export async function getAllDiskDevices(): Promise<UsbDiskDeviceInfo[]> {
       partitions: [
         {
           partPath: UsbPartitionDevPathSchema.parse(partition.devname),
-          mountpoint: UsbPartitionMountpointSchema.parse(partition.mountpoint),
+          mountpoint: partition.mountpoint
+            ? UsbPartitionMountpointSchema.parse(partition.mountpoint)
+            : undefined,
           fstype: partition.fstype,
           fsver: partition.fsver,
           label: partition.label,

--- a/libs/usb-drive/src/block_devices.ts
+++ b/libs/usb-drive/src/block_devices.ts
@@ -168,10 +168,10 @@ export async function getAllDiskDevices(): Promise<UsbDiskDeviceInfo[]> {
       const validPartitions: UsbPartitionDeviceInfo[] = diskPartitions
         .filter(isDataUsbDrive)
         .map((p) => ({
-          partPath: UsbPartitionDevPathSchema.parse(p.devname),
+          partPath: UsbPartitionDevPathSchema.decode(p.devname),
           mountpoint:
             typeof p.mountpoint === 'string'
-              ? UsbPartitionMountpointSchema.parse(p.mountpoint)
+              ? UsbPartitionMountpointSchema.decode(p.mountpoint)
               : undefined,
           fstype: p.fstype,
           fsver: p.fsver,
@@ -183,7 +183,7 @@ export async function getAllDiskDevices(): Promise<UsbDiskDeviceInfo[]> {
       if (validPartitions.length === 0) continue;
 
       result.push({
-        diskPath: UsbDiskDevPathSchema.parse(disk.devname),
+        diskPath: UsbDiskDevPathSchema.decode(disk.devname),
         vendor: disk.vendor,
         model: disk.model,
         serial: disk.serial,
@@ -192,7 +192,7 @@ export async function getAllDiskDevices(): Promise<UsbDiskDeviceInfo[]> {
     } else if (isDataUsbDrive(disk)) {
       // Unformatted drive (no partitions) — include it with empty partitions
       result.push({
-        diskPath: UsbDiskDevPathSchema.parse(disk.devname),
+        diskPath: UsbDiskDevPathSchema.decode(disk.devname),
         vendor: disk.vendor,
         model: disk.model,
         serial: disk.serial,
@@ -212,15 +212,15 @@ export async function getAllDiskDevices(): Promise<UsbDiskDeviceInfo[]> {
     if (!isDataUsbDrive(partition)) continue;
 
     result.push({
-      diskPath: UsbDiskDevPathSchema.parse(diskDevPath),
+      diskPath: UsbDiskDevPathSchema.decode(diskDevPath),
       vendor: undefined,
       model: undefined,
       serial: undefined,
       partitions: [
         {
-          partPath: UsbPartitionDevPathSchema.parse(partition.devname),
+          partPath: UsbPartitionDevPathSchema.decode(partition.devname),
           mountpoint: partition.mountpoint
-            ? UsbPartitionMountpointSchema.parse(partition.mountpoint)
+            ? UsbPartitionMountpointSchema.decode(partition.mountpoint)
             : undefined,
           fstype: partition.fstype,
           fsver: partition.fsver,

--- a/libs/usb-drive/src/block_devices.ts
+++ b/libs/usb-drive/src/block_devices.ts
@@ -4,6 +4,14 @@ import { promises as fs } from 'node:fs';
 import { assert, Optional } from '@votingworks/basics';
 import { exec, spawn } from './exec';
 import { RESOLVED_MEDIA_MOUNT_DIR } from './media_mount_dir';
+import {
+  UsbDiskDevPath,
+  UsbDiskDevPathSchema,
+  UsbPartitionDevPath,
+  UsbPartitionDevPathSchema,
+  UsbPartitionMountpoint,
+  UsbPartitionMountpointSchema,
+} from './types';
 
 const debug = makeDebug('usb-drive');
 
@@ -106,15 +114,15 @@ function isPartitionOfDisk(
 }
 
 interface UsbPartitionDeviceInfo {
-  devPath: string;
-  mountpoint?: string;
+  partPath: UsbPartitionDevPath;
+  mountpoint?: UsbPartitionMountpoint;
   fstype?: string;
   fsver?: string;
   label?: string;
 }
 
 export interface UsbDiskDeviceInfo {
-  devPath: string;
+  diskPath: UsbDiskDevPath;
   vendor?: string;
   model?: string;
   serial?: string;
@@ -160,8 +168,11 @@ export async function getAllDiskDevices(): Promise<UsbDiskDeviceInfo[]> {
       const validPartitions: UsbPartitionDeviceInfo[] = diskPartitions
         .filter(isDataUsbDrive)
         .map((p) => ({
-          devPath: p.devname,
-          mountpoint: p.mountpoint,
+          partPath: UsbPartitionDevPathSchema.parse(p.devname),
+          mountpoint:
+            typeof p.mountpoint === 'string'
+              ? UsbPartitionMountpointSchema.parse(p.mountpoint)
+              : undefined,
           fstype: p.fstype,
           fsver: p.fsver,
           label: p.label,
@@ -172,7 +183,7 @@ export async function getAllDiskDevices(): Promise<UsbDiskDeviceInfo[]> {
       if (validPartitions.length === 0) continue;
 
       result.push({
-        devPath: disk.devname,
+        diskPath: UsbDiskDevPathSchema.parse(disk.devname),
         vendor: disk.vendor,
         model: disk.model,
         serial: disk.serial,
@@ -181,7 +192,7 @@ export async function getAllDiskDevices(): Promise<UsbDiskDeviceInfo[]> {
     } else if (isDataUsbDrive(disk)) {
       // Unformatted drive (no partitions) — include it with empty partitions
       result.push({
-        devPath: disk.devname,
+        diskPath: UsbDiskDevPathSchema.parse(disk.devname),
         vendor: disk.vendor,
         model: disk.model,
         serial: disk.serial,
@@ -201,14 +212,14 @@ export async function getAllDiskDevices(): Promise<UsbDiskDeviceInfo[]> {
     if (!isDataUsbDrive(partition)) continue;
 
     result.push({
-      devPath: diskDevPath,
+      diskPath: UsbDiskDevPathSchema.parse(diskDevPath),
       vendor: undefined,
       model: undefined,
       serial: undefined,
       partitions: [
         {
-          devPath: partition.devname,
-          mountpoint: partition.mountpoint,
+          partPath: UsbPartitionDevPathSchema.parse(partition.devname),
+          mountpoint: UsbPartitionMountpointSchema.parse(partition.mountpoint),
           fstype: partition.fstype,
           fsver: partition.fsver,
           label: partition.label,

--- a/libs/usb-drive/src/cli.ts
+++ b/libs/usb-drive/src/cli.ts
@@ -56,7 +56,7 @@ export async function main(args: string[]): Promise<number> {
           stderr.write('Usage: usb-drive eject <devPath>\n');
           return 1;
         }
-        await multiUsbDrive.ejectDrive(UsbDiskDevPathSchema.parse(devPath));
+        await multiUsbDrive.ejectDrive(UsbDiskDevPathSchema.decode(devPath));
         stdout.write(`Ejected ${devPath}\n`);
         await multiUsbDrive.refresh();
         printDrives(multiUsbDrive, stdout);
@@ -78,7 +78,7 @@ export async function main(args: string[]): Promise<number> {
         }
         stdout.write(`Formatting ${devPath} as ${fstypeArg}...\n`);
         await multiUsbDrive.formatDrive(
-          UsbDiskDevPathSchema.parse(devPath),
+          UsbDiskDevPathSchema.decode(devPath),
           fstypeArg
         );
         stdout.write('Formatted.\n');

--- a/libs/usb-drive/src/cli.ts
+++ b/libs/usb-drive/src/cli.ts
@@ -2,6 +2,7 @@
 import { LogSource, Logger } from '@votingworks/logging';
 import { detectMultiUsbDrive, MultiUsbDrive } from './multi_usb_drive';
 import type { UsbDriveFilesystemType } from './multi_usb_drive';
+import { UsbDiskDevPathSchema } from './types';
 
 function printDrives(multiUsbDrive: MultiUsbDrive, stdout: NodeJS.WriteStream) {
   stdout.write(`${JSON.stringify(multiUsbDrive.getDrives(), null, 2)}\n`);
@@ -55,7 +56,7 @@ export async function main(args: string[]): Promise<number> {
           stderr.write('Usage: usb-drive eject <devPath>\n');
           return 1;
         }
-        await multiUsbDrive.ejectDrive(devPath);
+        await multiUsbDrive.ejectDrive(UsbDiskDevPathSchema.parse(devPath));
         stdout.write(`Ejected ${devPath}\n`);
         await multiUsbDrive.refresh();
         printDrives(multiUsbDrive, stdout);
@@ -76,7 +77,10 @@ export async function main(args: string[]): Promise<number> {
           return 1;
         }
         stdout.write(`Formatting ${devPath} as ${fstypeArg}...\n`);
-        await multiUsbDrive.formatDrive(devPath, fstypeArg);
+        await multiUsbDrive.formatDrive(
+          UsbDiskDevPathSchema.parse(devPath),
+          fstypeArg
+        );
         stdout.write('Formatted.\n');
         await multiUsbDrive.refresh();
         printDrives(multiUsbDrive, stdout);

--- a/libs/usb-drive/src/mocks/file_usb_drive.test.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.test.ts
@@ -18,8 +18,8 @@ import {
   UsbPartitionMountpointSchema,
 } from '../types';
 
-const devsdb = UsbDiskDevPathSchema.parse('/dev/sdb');
-const devsdb1 = UsbPartitionDevPathSchema.parse('/dev/sdb1');
+const devsdb = UsbDiskDevPathSchema.decode('/dev/sdb');
+const devsdb1 = UsbPartitionDevPathSchema.decode('/dev/sdb1');
 
 test('createMockFileMultiUsbDrive mock flow', async () => {
   const handler = getMockFileUsbDriveHandler('sdb');
@@ -41,7 +41,7 @@ test('createMockFileMultiUsbDrive mock flow', async () => {
         partPath: devsdb1,
         fstype: 'fat32',
         mount: UsbPartitionMount.mounted(
-          UsbPartitionMountpointSchema.parse(mountpoint!)
+          UsbPartitionMountpointSchema.decode(mountpoint!)
         ),
       },
     },
@@ -82,8 +82,8 @@ test('createMockFileMultiUsbDrive multi-drive flow', async () => {
 
   const diskA = addMockDrive();
   const diskB = addMockDrive();
-  const devdiskA = UsbDiskDevPathSchema.parse(`/dev/${diskA}`);
-  const devdiskB = UsbDiskDevPathSchema.parse(`/dev/${diskB}`);
+  const devdiskA = UsbDiskDevPathSchema.decode(`/dev/${diskA}`);
+  const devdiskB = UsbDiskDevPathSchema.decode(`/dev/${diskB}`);
   const handlerA = getMockFileUsbDriveHandler(diskA);
   const handlerB = getMockFileUsbDriveHandler(diskB);
 

--- a/libs/usb-drive/src/mocks/file_usb_drive.test.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.test.ts
@@ -10,7 +10,16 @@ import {
   listMockDrives,
   removeMockDriveDir,
 } from './file_usb_drive';
-import { UsbDriveInfo, UsbPartitionMount } from '../types';
+import {
+  UsbDiskDevPathSchema,
+  UsbDriveInfo,
+  UsbPartitionDevPathSchema,
+  UsbPartitionMount,
+  UsbPartitionMountpointSchema,
+} from '../types';
+
+const devsdb = UsbDiskDevPathSchema.parse('/dev/sdb');
+const devsdb1 = UsbPartitionDevPathSchema.parse('/dev/sdb1');
 
 test('createMockFileMultiUsbDrive mock flow', async () => {
   const handler = getMockFileUsbDriveHandler('sdb');
@@ -19,43 +28,45 @@ test('createMockFileMultiUsbDrive mock flow', async () => {
   expect(multiUsbDrive.getDrives()).toEqual([]);
 
   await expect(multiUsbDrive.refresh()).resolves.toBeUndefined();
-  await expect(multiUsbDrive.sync('/dev/sdb1')).resolves.toBeUndefined();
+  await expect(multiUsbDrive.sync(devsdb1)).resolves.toBeUndefined();
   multiUsbDrive.stop();
 
   handler.insert();
   const mountpoint = handler.getDataPath();
   expect(multiUsbDrive.getDrives()).toEqual<UsbDriveInfo[]>([
     {
-      diskPath: '/dev/sdb',
+      diskPath: devsdb,
       partition: {
-        diskPath: '/dev/sdb',
-        partPath: '/dev/sdb1',
+        diskPath: devsdb,
+        partPath: devsdb1,
         fstype: 'fat32',
-        mount: UsbPartitionMount.mounted(mountpoint!),
+        mount: UsbPartitionMount.mounted(
+          UsbPartitionMountpointSchema.parse(mountpoint!)
+        ),
       },
     },
   ]);
 
-  await multiUsbDrive.ejectDrive('/dev/sdb');
+  await multiUsbDrive.ejectDrive(devsdb);
   expect(multiUsbDrive.getDrives()).toEqual<UsbDriveInfo[]>([
     {
-      diskPath: '/dev/sdb',
+      diskPath: devsdb,
       partition: {
-        diskPath: '/dev/sdb',
-        partPath: '/dev/sdb1',
+        diskPath: devsdb,
+        partPath: devsdb1,
         fstype: 'fat32',
         mount: UsbPartitionMount.ejected(),
       },
     },
   ]);
 
-  await multiUsbDrive.ejectDrive('/dev/sdb');
+  await multiUsbDrive.ejectDrive(devsdb);
   expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
     UsbPartitionMount.ejected()
   );
 
   handler.insert();
-  await multiUsbDrive.formatDrive('/dev/sdb', 'fat32');
+  await multiUsbDrive.formatDrive(devsdb, 'fat32');
   expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
     UsbPartitionMount.ejected()
   );
@@ -71,6 +82,8 @@ test('createMockFileMultiUsbDrive multi-drive flow', async () => {
 
   const diskA = addMockDrive();
   const diskB = addMockDrive();
+  const devdiskA = UsbDiskDevPathSchema.parse(`/dev/${diskA}`);
+  const devdiskB = UsbDiskDevPathSchema.parse(`/dev/${diskB}`);
   const handlerA = getMockFileUsbDriveHandler(diskA);
   const handlerB = getMockFileUsbDriveHandler(diskB);
 
@@ -78,20 +91,20 @@ test('createMockFileMultiUsbDrive multi-drive flow', async () => {
 
   handlerA.insert();
   expect(multiUsbDrive.getDrives()).toHaveLength(1);
-  expect(multiUsbDrive.getDrives()[0]?.diskPath).toEqual(`/dev/${diskA}`);
+  expect(multiUsbDrive.getDrives()[0]?.diskPath).toEqual(devdiskA);
 
   handlerB.insert();
   expect(multiUsbDrive.getDrives()).toHaveLength(2);
 
-  await multiUsbDrive.ejectDrive(`/dev/${diskA}`);
+  await multiUsbDrive.ejectDrive(devdiskA);
   const drives = multiUsbDrive.getDrives();
   expect(drives).toHaveLength(2);
-  expect(
-    drives.find((d) => d.diskPath === `/dev/${diskA}`)?.partition?.mount
-  ).toEqual(UsbPartitionMount.ejected());
-  expect(
-    drives.find((d) => d.diskPath === `/dev/${diskB}`)?.partition?.mount
-  ).toEqual(UsbPartitionMount.mounted(expect.any(String)));
+  expect(drives.find((d) => d.diskPath === devdiskA)?.partition?.mount).toEqual(
+    UsbPartitionMount.ejected()
+  );
+  expect(drives.find((d) => d.diskPath === devdiskB)?.partition?.mount).toEqual(
+    UsbPartitionMount.mounted(expect.any(String))
+  );
 
   handlerB.remove();
   removeMockDriveDir(diskB);

--- a/libs/usb-drive/src/mocks/file_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.ts
@@ -57,7 +57,7 @@ function getMockDriveDirPath(diskName: string): string {
 }
 
 function getMockDriveDataDirPath(diskName: string): UsbPartitionMountpoint {
-  return UsbPartitionMountpointSchema.parse(
+  return UsbPartitionMountpointSchema.decode(
     join(getMockDriveDirPath(diskName), MOCK_USB_DRIVE_DATA_DIRNAME)
   );
 }
@@ -207,13 +207,13 @@ export function createMockFileMultiUsbDrive(): MultiUsbDrive {
           driveState.state === 'inserted'
             ? UsbPartitionMount.mounted(getMockDriveDataDirPath(diskName))
             : UsbPartitionMount.ejected();
-        const diskPath = UsbDiskDevPathSchema.parse(`/dev/${diskName}`);
+        const diskPath = UsbDiskDevPathSchema.decode(`/dev/${diskName}`);
         return [
           {
             diskPath,
             partition: {
               diskPath,
-              partPath: UsbPartitionDevPathSchema.parse(`/dev/${diskName}1`),
+              partPath: UsbPartitionDevPathSchema.decode(`/dev/${diskName}1`),
               fstype: driveState.fstype,
               mount,
             },

--- a/libs/usb-drive/src/mocks/file_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.ts
@@ -12,10 +12,16 @@ import { basename, join } from 'node:path';
 import type { MultiUsbDrive, UsbDriveFilesystemType } from '../multi_usb_drive';
 import { MockFileTree, writeMockFileTree } from './helpers';
 import {
+  UsbDiskDevPath,
+  UsbDiskDevPathSchema,
   UsbDrive,
   UsbDriveInfo,
   UsbDriveStatus,
+  UsbPartitionDevPath,
+  UsbPartitionDevPathSchema,
   UsbPartitionMount,
+  UsbPartitionMountpoint,
+  UsbPartitionMountpointSchema,
 } from '../types';
 
 export const MOCK_USB_DRIVE_STATE_FILENAME = 'mock-usb-state.json';
@@ -50,8 +56,10 @@ function getMockDriveDirPath(diskName: string): string {
   return join(getMockUsbDirPath(), diskName);
 }
 
-function getMockDriveDataDirPath(diskName: string): string {
-  return join(getMockDriveDirPath(diskName), MOCK_USB_DRIVE_DATA_DIRNAME);
+function getMockDriveDataDirPath(diskName: string): UsbPartitionMountpoint {
+  return UsbPartitionMountpointSchema.parse(
+    join(getMockDriveDirPath(diskName), MOCK_USB_DRIVE_DATA_DIRNAME)
+  );
 }
 
 type MockDriveState =
@@ -199,12 +207,13 @@ export function createMockFileMultiUsbDrive(): MultiUsbDrive {
           driveState.state === 'inserted'
             ? UsbPartitionMount.mounted(getMockDriveDataDirPath(diskName))
             : UsbPartitionMount.ejected();
+        const diskPath = UsbDiskDevPathSchema.parse(`/dev/${diskName}`);
         return [
           {
-            diskPath: `/dev/${diskName}`,
+            diskPath,
             partition: {
-              diskPath: `/dev/${diskName}`,
-              partPath: `/dev/${diskName}1`,
+              diskPath,
+              partPath: UsbPartitionDevPathSchema.parse(`/dev/${diskName}1`),
               fstype: driveState.fstype,
               mount,
             },
@@ -215,7 +224,7 @@ export function createMockFileMultiUsbDrive(): MultiUsbDrive {
 
     refresh: () => Promise.resolve(),
 
-    ejectDrive(diskPath: string): Promise<void> {
+    ejectDrive(diskPath: UsbDiskDevPath): Promise<void> {
       const diskName = basename(diskPath);
       const driveState = readMockDriveState(diskName);
       if (driveState.state === 'inserted') {
@@ -228,7 +237,7 @@ export function createMockFileMultiUsbDrive(): MultiUsbDrive {
     },
 
     formatDrive(
-      diskPath: string,
+      diskPath: UsbDiskDevPath,
       fstype: UsbDriveFilesystemType
     ): Promise<void> {
       const diskName = basename(diskPath);
@@ -239,7 +248,7 @@ export function createMockFileMultiUsbDrive(): MultiUsbDrive {
       return Promise.resolve();
     },
 
-    sync: (partPath: string) => {
+    sync: (partPath: UsbPartitionDevPath) => {
       void partPath;
       return Promise.resolve();
     },
@@ -252,7 +261,7 @@ export function createMockFileMultiUsbDrive(): MultiUsbDrive {
 export function getMockFileUsbDriveHandler(
   diskName = 'sdb'
 ): MockFileUsbDriveHandler {
-  function getDataPath(): string {
+  function getDataPath(): UsbPartitionMountpoint {
     return getMockDriveDataDirPath(diskName);
   }
 

--- a/libs/usb-drive/src/mocks/memory_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/memory_usb_drive.ts
@@ -2,7 +2,7 @@ import { getTemporaryRootDir } from '@votingworks/fixtures';
 import { Mocked, mockFunction } from '@votingworks/test-utils';
 import tmp from 'tmp';
 import { MockFileTree, writeMockFileTree } from './helpers';
-import { UsbDrive } from '../types';
+import { UsbDrive, UsbPartitionMountpointSchema } from '../types';
 
 /**
  * A mock of the UsbDrive interface. See createMockUsbDrive for details.
@@ -56,7 +56,7 @@ export function createMockUsbDrive(): MockUsbDrive {
       usbDrive.status.reset();
       usbDrive.status.expectRepeatedCallsWith().resolves({
         status: 'mounted',
-        mountpoint: mockUsbTmpDir.name,
+        mountpoint: UsbPartitionMountpointSchema.parse(mockUsbTmpDir.name),
       });
     },
 

--- a/libs/usb-drive/src/mocks/memory_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/memory_usb_drive.ts
@@ -56,7 +56,7 @@ export function createMockUsbDrive(): MockUsbDrive {
       usbDrive.status.reset();
       usbDrive.status.expectRepeatedCallsWith().resolves({
         status: 'mounted',
-        mountpoint: UsbPartitionMountpointSchema.parse(mockUsbTmpDir.name),
+        mountpoint: UsbPartitionMountpointSchema.decode(mockUsbTmpDir.name),
       });
     },
 

--- a/libs/usb-drive/src/mocks/mock_multi_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/mock_multi_usb_drive.ts
@@ -12,7 +12,7 @@ import {
   UsbPartitionMountpointSchema,
 } from '../types';
 
-const MOCK_SINGLETON_DISK_DEV_PATH = UsbDiskDevPathSchema.parse('/dev/sdb');
+const MOCK_SINGLETON_DISK_DEV_PATH = UsbDiskDevPathSchema.decode('/dev/sdb');
 
 export interface MockMultiUsbDrive {
   multiUsbDrive: Mocked<MultiUsbDrive>;
@@ -77,16 +77,16 @@ export function createMockMultiUsbDrive(): MockMultiUsbDrive {
     const mountpoint = makeTemporaryDirectory();
     mockUsbTmpDirs.push(mountpoint);
     writeMockFileTree(mountpoint, contents);
-    const diskPath = UsbDiskDevPathSchema.parse(options.diskPath);
+    const diskPath = UsbDiskDevPathSchema.decode(options.diskPath);
     drives.push({
       diskPath,
       partition: {
         diskPath,
-        partPath: UsbPartitionDevPathSchema.parse(`${options.diskPath}1`),
+        partPath: UsbPartitionDevPathSchema.decode(`${options.diskPath}1`),
         label: 'VxUSB-ABCDE',
         fstype,
         mount: UsbPartitionMount.mounted(
-          UsbPartitionMountpointSchema.parse(mountpoint)
+          UsbPartitionMountpointSchema.decode(mountpoint)
         ),
       },
     });

--- a/libs/usb-drive/src/mocks/mock_multi_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/mock_multi_usb_drive.ts
@@ -3,9 +3,16 @@ import { makeTemporaryDirectory } from '@votingworks/fixtures';
 import { rmSync } from 'node:fs';
 import { MultiUsbDrive, UsbDriveFilesystemType } from '../multi_usb_drive';
 import { MockFileTree, writeMockFileTree } from './helpers';
-import { UsbDriveInfo, UsbPartitionMount } from '../types';
+import {
+  UsbDiskDevPath,
+  UsbDiskDevPathSchema,
+  UsbDriveInfo,
+  UsbPartitionDevPathSchema,
+  UsbPartitionMount,
+  UsbPartitionMountpointSchema,
+} from '../types';
 
-const MOCK_SINGLETON_DISK_DEV_PATH = '/dev/sdb';
+const MOCK_SINGLETON_DISK_DEV_PATH = UsbDiskDevPathSchema.parse('/dev/sdb');
 
 export interface MockMultiUsbDrive {
   multiUsbDrive: Mocked<MultiUsbDrive>;
@@ -18,7 +25,7 @@ export interface MockMultiUsbDrive {
    */
   addUsbDrive(
     contents: MockFileTree,
-    options?: { diskPath: string; fstype?: UsbDriveFilesystemType }
+    options?: { diskPath: UsbDiskDevPath; fstype?: UsbDriveFilesystemType }
   ): void;
 
   /**
@@ -64,20 +71,23 @@ export function createMockMultiUsbDrive(): MockMultiUsbDrive {
 
   function addUsbDrive(
     contents: MockFileTree,
-    options: { diskPath: string; fstype?: UsbDriveFilesystemType }
+    options: { diskPath: UsbDiskDevPath; fstype?: UsbDriveFilesystemType }
   ) {
     const fstype = options.fstype ?? 'fat32';
     const mountpoint = makeTemporaryDirectory();
     mockUsbTmpDirs.push(mountpoint);
     writeMockFileTree(mountpoint, contents);
+    const diskPath = UsbDiskDevPathSchema.parse(options.diskPath);
     drives.push({
-      diskPath: options.diskPath,
+      diskPath,
       partition: {
-        diskPath: options.diskPath,
-        partPath: `${options.diskPath}1`,
+        diskPath,
+        partPath: UsbPartitionDevPathSchema.parse(`${options.diskPath}1`),
         label: 'VxUSB-ABCDE',
         fstype,
-        mount: UsbPartitionMount.mounted(mountpoint),
+        mount: UsbPartitionMount.mounted(
+          UsbPartitionMountpointSchema.parse(mountpoint)
+        ),
       },
     });
     multiUsbDrive.getDrives.reset();

--- a/libs/usb-drive/src/multi_usb_drive.test.ts
+++ b/libs/usb-drive/src/multi_usb_drive.test.ts
@@ -10,11 +10,21 @@ import { deferred, sleep } from '@votingworks/basics';
 import { detectMultiUsbDrive } from './multi_usb_drive';
 import { exec } from './exec';
 import { getAllDiskDevices, UsbDiskDeviceInfo } from './block_devices';
-import { UsbPartitionInfo, UsbPartitionMount } from './types';
+import {
+  UsbDiskDevPathSchema,
+  UsbPartitionDevPathSchema,
+  UsbPartitionInfo,
+  UsbPartitionMount,
+  UsbPartitionMountpointSchema,
+} from './types';
 
 const MOUNT_SCRIPT_PATH = join(__dirname, '../scripts');
 
 const featureFlagMock = getFeatureFlagMock();
+
+const devsdb = UsbDiskDevPathSchema.parse('/dev/sdb');
+const devsdb1 = UsbPartitionDevPathSchema.parse('/dev/sdb1');
+const devsdc = UsbDiskDevPathSchema.parse('/dev/sdc');
 
 type ExecResult = Awaited<ReturnType<typeof exec>>;
 
@@ -61,14 +71,16 @@ function makeDisk(
   overrides: Partial<UsbDiskDeviceInfo> = {}
 ): UsbDiskDeviceInfo {
   return {
-    devPath: '/dev/sdb',
+    diskPath: devsdb,
     vendor: 'SanDisk',
     model: 'Ultra',
     serial: 'SN123',
     partitions: [
       {
-        devPath: '/dev/sdb1',
-        mountpoint: '/media/vx/usb-drive-sdb1',
+        partPath: devsdb1,
+        mountpoint: UsbPartitionMountpointSchema.parse(
+          '/media/vx/usb-drive-sdb1'
+        ),
         fstype: 'vfat',
         fsver: 'FAT32',
         label: 'VxUSB-ABCDE',
@@ -103,11 +115,15 @@ describe('getDrives', () => {
     await multiUsbDrive.refresh();
 
     const [drive] = multiUsbDrive.getDrives();
-    expect(drive).toMatchObject({ diskPath: '/dev/sdb' });
+    expect(drive).toMatchObject({
+      diskPath: devsdb,
+    });
     expect(drive?.partition).toMatchObject<Partial<UsbPartitionInfo>>({
-      diskPath: '/dev/sdb',
-      partPath: '/dev/sdb1',
-      mount: UsbPartitionMount.mounted('/media/vx/usb-drive-sdb1'),
+      diskPath: devsdb,
+      partPath: devsdb1,
+      mount: UsbPartitionMount.mounted(
+        UsbPartitionMountpointSchema.parse('/media/vx/usb-drive-sdb1')
+      ),
     });
 
     multiUsbDrive.stop();
@@ -118,7 +134,7 @@ describe('getDrives', () => {
       makeDisk({
         partitions: [
           {
-            devPath: '/dev/sdb1',
+            partPath: devsdb1,
             mountpoint: undefined,
             fstype: 'vfat',
             fsver: 'FAT32',
@@ -149,7 +165,7 @@ describe('getDrives', () => {
       makeDisk({
         partitions: [
           {
-            devPath: '/dev/sdb1',
+            partPath: devsdb1,
             mountpoint: undefined,
             fstype: 'exfat',
             fsver: '1.0',
@@ -184,8 +200,11 @@ describe('getDrives', () => {
 
   test('returns multiple drives', async () => {
     mockDrives = [
-      makeDisk({ devPath: '/dev/sdb' }),
-      makeDisk({ devPath: '/dev/sdc', partitions: [] }),
+      makeDisk({ diskPath: devsdb }),
+      makeDisk({
+        diskPath: devsdc,
+        partitions: [],
+      }),
     ];
     const logger = mockLogger({ fn: vi.fn });
     const multiUsbDrive = detectMultiUsbDrive(logger);
@@ -267,7 +286,7 @@ describe('refresh', () => {
     await multiUsbDrive.refresh();
 
     execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // unmount
-    await multiUsbDrive.ejectDrive('/dev/sdb');
+    await multiUsbDrive.ejectDrive(devsdb);
 
     // Drive is physically removed
     mockDrives = [];
@@ -281,7 +300,7 @@ describe('refresh', () => {
       makeDisk({
         partitions: [
           {
-            devPath: '/dev/sdb1',
+            partPath: devsdb1,
             mountpoint: undefined,
             fstype: 'vfat',
             fsver: 'FAT32',
@@ -324,7 +343,7 @@ describe('stop', () => {
     const unmountedPartitionDisk = makeDisk({
       partitions: [
         {
-          devPath: '/dev/sdb1',
+          partPath: devsdb1,
           mountpoint: undefined,
           fstype: 'vfat',
           fsver: 'FAT32',
@@ -368,7 +387,7 @@ describe('stop', () => {
     const unmountedPartitionDisk = makeDisk({
       partitions: [
         {
-          devPath: '/dev/sdb1',
+          partPath: devsdb1,
           mountpoint: undefined,
           fstype: 'vfat',
           fsver: 'FAT32',
@@ -421,7 +440,7 @@ describe('ejectDrive', () => {
 
     execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // unmount
 
-    await multiUsbDrive.ejectDrive('/dev/sdb');
+    await multiUsbDrive.ejectDrive(devsdb);
 
     expect(execMock).toHaveBeenCalledWith('sudo', [
       '-n',
@@ -454,10 +473,12 @@ describe('ejectDrive', () => {
       unmountOperation.promise as PromiseWithChild<ExecResult>
     );
 
-    const ejectPromise = multiUsbDrive.ejectDrive('/dev/sdb');
+    const ejectPromise = multiUsbDrive.ejectDrive(devsdb);
 
     expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
-      UsbPartitionMount.unmounting('/media/vx/usb-drive-sdb1')
+      UsbPartitionMount.unmounting(
+        UsbPartitionMountpointSchema.parse('/media/vx/usb-drive-sdb1')
+      )
     );
 
     unmountOperation.resolve({ stdout: '', stderr: '' });
@@ -473,7 +494,7 @@ describe('ejectDrive', () => {
       const unmountedPartitionDisk = makeDisk({
         partitions: [
           {
-            devPath: '/dev/sdb1',
+            partPath: devsdb1,
             mountpoint: undefined,
             fstype: 'vfat',
             fsver: 'FAT32',
@@ -505,7 +526,7 @@ describe('ejectDrive', () => {
       await vi.advanceTimersByTimeAsync(0);
 
       // Start eject — the while loop sleeps because partitionAction has 'mounting'
-      const ejectPromise = multiUsbDrive.ejectDrive('/dev/sdb');
+      const ejectPromise = multiUsbDrive.ejectDrive(devsdb);
 
       // Resolve mount exec so mountPartitionWithRetry completes during the sleep
       mountOperation.resolve({ stdout: '', stderr: '' });
@@ -533,7 +554,7 @@ describe('ejectDrive', () => {
       makeDisk({
         partitions: [
           {
-            devPath: '/dev/sdb1',
+            partPath: devsdb1,
             mountpoint: undefined,
             fstype: 'vfat',
             fsver: 'FAT32',
@@ -549,7 +570,7 @@ describe('ejectDrive', () => {
 
     // Start eject without awaiting — driveAction is set to 'ejecting' synchronously
     // before the first await, so getDrives() can observe the in-progress state.
-    const ejectPromise = multiUsbDrive.ejectDrive('/dev/sdb');
+    const ejectPromise = multiUsbDrive.ejectDrive(devsdb);
 
     expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
       UsbPartitionMount.ejected()
@@ -565,7 +586,7 @@ describe('ejectDrive', () => {
       makeDisk({
         partitions: [
           {
-            devPath: '/dev/sdb1',
+            partPath: devsdb1,
             mountpoint: undefined,
             fstype: 'vfat',
             fsver: 'FAT32',
@@ -579,7 +600,7 @@ describe('ejectDrive', () => {
 
     await multiUsbDrive.refresh();
 
-    await multiUsbDrive.ejectDrive('/dev/sdb');
+    await multiUsbDrive.ejectDrive(devsdb);
 
     expect(execMock).not.toHaveBeenCalledWith(
       'sudo',
@@ -598,7 +619,7 @@ describe('ejectDrive', () => {
 
     execMock.mockRejectedValueOnce(new Error('unmount failed'));
 
-    await expect(multiUsbDrive.ejectDrive('/dev/sdb')).rejects.toThrow(
+    await expect(multiUsbDrive.ejectDrive(devsdb)).rejects.toThrow(
       'unmount failed'
     );
 
@@ -623,8 +644,8 @@ describe('ejectDrive', () => {
       firstEjectOperation.promise as PromiseWithChild<ExecResult>
     );
 
-    const firstEject = multiUsbDrive.ejectDrive('/dev/sdb');
-    await multiUsbDrive.ejectDrive('/dev/sdb'); // no-op
+    const firstEject = multiUsbDrive.ejectDrive(devsdb);
+    await multiUsbDrive.ejectDrive(devsdb); // no-op
 
     firstEjectOperation.resolve({ stdout: '', stderr: '' });
     await firstEject;
@@ -644,7 +665,7 @@ describe('ejectDrive', () => {
 
     execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // unmount
 
-    await multiUsbDrive.ejectDrive('/dev/sdb');
+    await multiUsbDrive.ejectDrive(devsdb);
 
     expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
       UsbPartitionMount.ejected()
@@ -665,7 +686,7 @@ describe('formatDrive', () => {
     execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // unmount
     execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // format
 
-    await multiUsbDrive.formatDrive('/dev/sdb', 'fat32');
+    await multiUsbDrive.formatDrive(devsdb, 'fat32');
 
     expect(execMock).toHaveBeenCalledWith('sudo', [
       '-n',
@@ -702,7 +723,7 @@ describe('formatDrive', () => {
     execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // unmount
     execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // format
 
-    await multiUsbDrive.formatDrive('/dev/sdb', 'ext4');
+    await multiUsbDrive.formatDrive(devsdb, 'ext4');
 
     expect(execMock).toHaveBeenCalledWith('sudo', [
       '-n',
@@ -727,7 +748,7 @@ describe('formatDrive', () => {
       formatOperation.promise as PromiseWithChild<ExecResult>
     );
 
-    const formatPromise = multiUsbDrive.formatDrive('/dev/sdb', 'fat32');
+    const formatPromise = multiUsbDrive.formatDrive(devsdb, 'fat32');
 
     expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
       UsbPartitionMount.formatting()
@@ -746,7 +767,7 @@ describe('formatDrive', () => {
       const unmountedPartitionDisk = makeDisk({
         partitions: [
           {
-            devPath: '/dev/sdb1',
+            partPath: devsdb1,
             mountpoint: undefined,
             fstype: 'vfat',
             fsver: 'FAT32',
@@ -779,7 +800,7 @@ describe('formatDrive', () => {
       await vi.advanceTimersByTimeAsync(0);
 
       // Start format — the while loop sleeps because partitionAction has 'mounting'
-      const formatPromise = multiUsbDrive.formatDrive('/dev/sdb', 'fat32');
+      const formatPromise = multiUsbDrive.formatDrive(devsdb, 'fat32');
 
       // Resolve mount exec so mountPartitionWithRetry completes during the sleep
       mountOperation.resolve({ stdout: '', stderr: '' });
@@ -807,7 +828,7 @@ describe('formatDrive', () => {
       makeDisk({
         partitions: [
           {
-            devPath: '/dev/sdb1',
+            partPath: devsdb1,
             mountpoint: undefined,
             fstype: 'exfat',
             fsver: '1.0',
@@ -823,7 +844,7 @@ describe('formatDrive', () => {
 
     execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // format (no unmount needed)
 
-    await multiUsbDrive.formatDrive('/dev/sdb', 'fat32');
+    await multiUsbDrive.formatDrive(devsdb, 'fat32');
 
     const formatArgs = execMock.mock.calls.find((c) =>
       (c[1] as string[]).some((a) => a.includes('format_fat32.sh'))
@@ -843,7 +864,7 @@ describe('formatDrive', () => {
 
     execMock.mockResolvedValueOnce({ stdout: '', stderr: '' }); // format
 
-    await multiUsbDrive.formatDrive('/dev/sdb', 'fat32');
+    await multiUsbDrive.formatDrive(devsdb, 'fat32');
 
     const formatArgs = execMock.mock.calls.find((c) =>
       (c[1] as string[]).some((a) => a.includes('format_fat32.sh'))
@@ -863,9 +884,9 @@ describe('formatDrive', () => {
 
     execMock.mockRejectedValueOnce(new Error('format failed'));
 
-    await expect(
-      multiUsbDrive.formatDrive('/dev/sdb', 'fat32')
-    ).rejects.toThrow('format failed');
+    await expect(multiUsbDrive.formatDrive(devsdb, 'fat32')).rejects.toThrow(
+      'format failed'
+    );
 
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.UsbDriveFormatted,
@@ -888,8 +909,8 @@ describe('formatDrive', () => {
       formatOperation.promise as PromiseWithChild<ExecResult>
     );
 
-    const firstFormat = multiUsbDrive.formatDrive('/dev/sdb', 'fat32');
-    await multiUsbDrive.formatDrive('/dev/sdb', 'fat32'); // no-op
+    const firstFormat = multiUsbDrive.formatDrive(devsdb, 'fat32');
+    await multiUsbDrive.formatDrive(devsdb, 'fat32'); // no-op
 
     formatOperation.resolve({ stdout: '', stderr: '' });
     await firstFormat;
@@ -910,7 +931,7 @@ describe('sync', () => {
 
     execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
-    await multiUsbDrive.sync('/dev/sdb1');
+    await multiUsbDrive.sync(devsdb1);
 
     expect(execMock).toHaveBeenCalledWith('sync', [
       '-f',
@@ -925,7 +946,7 @@ describe('sync', () => {
       makeDisk({
         partitions: [
           {
-            devPath: '/dev/sdb1',
+            partPath: devsdb1,
             mountpoint: undefined,
             fstype: 'vfat',
             fsver: 'FAT32',
@@ -939,7 +960,7 @@ describe('sync', () => {
 
     await multiUsbDrive.refresh();
 
-    await multiUsbDrive.sync('/dev/sdb1');
+    await multiUsbDrive.sync(devsdb1);
 
     const { calls } = execMock.mock;
     for (const args of calls) {
@@ -956,7 +977,7 @@ describe('sync', () => {
 
     await multiUsbDrive.refresh();
 
-    await multiUsbDrive.sync('/dev/sdb1');
+    await multiUsbDrive.sync(devsdb1);
 
     expect(execMock).not.toHaveBeenCalled();
 
@@ -968,7 +989,7 @@ describe('sync', () => {
     const logger = mockLogger({ fn: vi.fn });
     const multiUsbDrive = detectMultiUsbDrive(logger);
 
-    await multiUsbDrive.sync('/dev/sdb1');
+    await multiUsbDrive.sync(devsdb1);
 
     expect(execMock).not.toHaveBeenCalled();
 
@@ -981,7 +1002,7 @@ describe('autoMount', () => {
     const unmountedPartitionDisk = makeDisk({
       partitions: [
         {
-          devPath: '/dev/sdb1',
+          partPath: devsdb1,
           mountpoint: undefined,
           fstype: 'vfat',
           fsver: 'FAT32',
@@ -1041,7 +1062,7 @@ describe('autoMount', () => {
     const unmountedExt4Disk = makeDisk({
       partitions: [
         {
-          devPath: '/dev/sdb1',
+          partPath: devsdb1,
           mountpoint: undefined,
           fstype: 'ext4',
           fsver: '1.0',
@@ -1052,8 +1073,10 @@ describe('autoMount', () => {
     const mountedExt4Disk = makeDisk({
       partitions: [
         {
-          devPath: '/dev/sdb1',
-          mountpoint: '/media/vx/usb-drive-sdb1',
+          partPath: devsdb1,
+          mountpoint: UsbPartitionMountpointSchema.parse(
+            '/media/vx/usb-drive-sdb1'
+          ),
           fstype: 'ext4',
           fsver: '1.0',
           label: 'VxUSB-ABCDE',
@@ -1100,7 +1123,7 @@ describe('autoMount', () => {
     const unmountedPartitionDisk = makeDisk({
       partitions: [
         {
-          devPath: '/dev/sdb1',
+          partPath: devsdb1,
           mountpoint: undefined,
           fstype: 'vfat',
           fsver: 'FAT32',
@@ -1138,7 +1161,7 @@ describe('autoMount', () => {
     const unmountedPartitionDisk = makeDisk({
       partitions: [
         {
-          devPath: '/dev/sdb1',
+          partPath: devsdb1,
           mountpoint: undefined,
           fstype: 'vfat',
           fsver: 'FAT32',
@@ -1176,7 +1199,7 @@ describe('autoMount', () => {
     const unmountedPartitionDisk = makeDisk({
       partitions: [
         {
-          devPath: '/dev/sdb1',
+          partPath: devsdb1,
           mountpoint: undefined,
           fstype: 'vfat',
           fsver: 'FAT32',
@@ -1225,7 +1248,7 @@ describe('autoMount', () => {
       const unmountedPartitionDisk = makeDisk({
         partitions: [
           {
-            devPath: '/dev/sdb1',
+            partPath: devsdb1,
             mountpoint: undefined,
             fstype: 'vfat',
             fsver: 'FAT32',
@@ -1252,7 +1275,9 @@ describe('autoMount', () => {
       await vi.advanceTimersByTimeAsync(100);
 
       expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
-        UsbPartitionMount.mounted('/media/vx/usb-drive-sdb1')
+        UsbPartitionMount.mounted(
+          UsbPartitionMountpointSchema.parse('/media/vx/usb-drive-sdb1')
+        )
       );
 
       multiUsbDrive.stop();
@@ -1268,7 +1293,7 @@ describe('autoMount', () => {
       const unmountedPartitionDisk = makeDisk({
         partitions: [
           {
-            devPath: '/dev/sdb1',
+            partPath: devsdb1,
             mountpoint: undefined,
             fstype: 'vfat',
             fsver: 'FAT32',
@@ -1317,7 +1342,7 @@ describe('autoMount', () => {
       unmountOperation.promise as PromiseWithChild<ExecResult>
     );
 
-    const ejectPromise = multiUsbDrive.ejectDrive('/dev/sdb');
+    const ejectPromise = multiUsbDrive.ejectDrive(devsdb);
 
     // Watcher fires while driveAction === 'ejecting' but ejectState is not set.
     // doAutoMount must return early at the driveAction check (line 190).
@@ -1344,14 +1369,14 @@ describe('autoMount', () => {
     await multiUsbDrive.refresh();
 
     // Eject the drive
-    await multiUsbDrive.ejectDrive('/dev/sdb');
+    await multiUsbDrive.ejectDrive(devsdb);
 
     // Now the drive reappears unmounted
     mockDrives = [
       makeDisk({
         partitions: [
           {
-            devPath: '/dev/sdb1',
+            partPath: devsdb1,
             mountpoint: undefined,
             fstype: 'vfat',
             fsver: 'FAT32',
@@ -1380,7 +1405,7 @@ describe('autoMount', () => {
       makeDisk({
         partitions: [
           {
-            devPath: '/dev/sdb1',
+            partPath: devsdb1,
             mountpoint: undefined,
             fstype: 'exfat',
             fsver: undefined,

--- a/libs/usb-drive/src/multi_usb_drive.test.ts
+++ b/libs/usb-drive/src/multi_usb_drive.test.ts
@@ -22,9 +22,9 @@ const MOUNT_SCRIPT_PATH = join(__dirname, '../scripts');
 
 const featureFlagMock = getFeatureFlagMock();
 
-const devsdb = UsbDiskDevPathSchema.parse('/dev/sdb');
-const devsdb1 = UsbPartitionDevPathSchema.parse('/dev/sdb1');
-const devsdc = UsbDiskDevPathSchema.parse('/dev/sdc');
+const devsdb = UsbDiskDevPathSchema.decode('/dev/sdb');
+const devsdb1 = UsbPartitionDevPathSchema.decode('/dev/sdb1');
+const devsdc = UsbDiskDevPathSchema.decode('/dev/sdc');
 
 type ExecResult = Awaited<ReturnType<typeof exec>>;
 
@@ -78,7 +78,7 @@ function makeDisk(
     partitions: [
       {
         partPath: devsdb1,
-        mountpoint: UsbPartitionMountpointSchema.parse(
+        mountpoint: UsbPartitionMountpointSchema.decode(
           '/media/vx/usb-drive-sdb1'
         ),
         fstype: 'vfat',
@@ -122,7 +122,7 @@ describe('getDrives', () => {
       diskPath: devsdb,
       partPath: devsdb1,
       mount: UsbPartitionMount.mounted(
-        UsbPartitionMountpointSchema.parse('/media/vx/usb-drive-sdb1')
+        UsbPartitionMountpointSchema.decode('/media/vx/usb-drive-sdb1')
       ),
     });
 
@@ -477,7 +477,7 @@ describe('ejectDrive', () => {
 
     expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
       UsbPartitionMount.unmounting(
-        UsbPartitionMountpointSchema.parse('/media/vx/usb-drive-sdb1')
+        UsbPartitionMountpointSchema.decode('/media/vx/usb-drive-sdb1')
       )
     );
 
@@ -1074,7 +1074,7 @@ describe('autoMount', () => {
       partitions: [
         {
           partPath: devsdb1,
-          mountpoint: UsbPartitionMountpointSchema.parse(
+          mountpoint: UsbPartitionMountpointSchema.decode(
             '/media/vx/usb-drive-sdb1'
           ),
           fstype: 'ext4',
@@ -1276,7 +1276,7 @@ describe('autoMount', () => {
 
       expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
         UsbPartitionMount.mounted(
-          UsbPartitionMountpointSchema.parse('/media/vx/usb-drive-sdb1')
+          UsbPartitionMountpointSchema.decode('/media/vx/usb-drive-sdb1')
         )
       );
 

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -23,6 +23,11 @@ import {
 } from './block_devices';
 import { createMockFileMultiUsbDrive } from './mocks/file_usb_drive';
 import { UsbDriveInfo, UsbPartitionMount } from './types';
+import type {
+  UsbDiskDevPath,
+  UsbPartitionDevPath,
+  UsbPartitionMountpoint,
+} from './types';
 
 const VX_USB_LABEL_REGEXP = /^VxUSB-[A-Z0-9]{5}$/i;
 
@@ -43,7 +48,7 @@ async function unmountPartition(mountpoint: string): Promise<void> {
 export type UsbDriveFilesystemType = 'fat32' | 'ext4';
 
 async function formatDriveAsFat32(
-  diskPath: string,
+  diskPath: UsbDiskDevPath,
   label: string
 ): Promise<void> {
   await exec('sudo', [
@@ -55,7 +60,7 @@ async function formatDriveAsFat32(
 }
 
 async function formatDriveAsExt4(
-  diskPath: string,
+  diskPath: UsbDiskDevPath,
   label: string
 ): Promise<void> {
   await exec('sudo', [
@@ -104,24 +109,27 @@ function isSupportedPartition(partition?: {
  * baked in at refresh time.
  */
 interface CachedPartition {
-  partPath: string;
+  partPath: UsbPartitionDevPath;
   fstype: UsbDriveFilesystemType;
   label?: string;
-  mountpoint?: string;
+  mountpoint?: UsbPartitionMountpoint;
 }
 
 /** Internal cached representation of a detected USB disk. */
 interface CachedDrive {
-  diskPath: string;
+  diskPath: UsbDiskDevPath;
   partition?: CachedPartition;
 }
 
 export interface MultiUsbDrive {
   getDrives(): UsbDriveInfo[];
   refresh(): Promise<void>;
-  ejectDrive(diskPath: string): Promise<void>;
-  formatDrive(diskPath: string, fstype: UsbDriveFilesystemType): Promise<void>;
-  sync(partPath: string): Promise<void>;
+  ejectDrive(diskPath: UsbDiskDevPath): Promise<void>;
+  formatDrive(
+    diskPath: UsbDiskDevPath,
+    fstype: UsbDriveFilesystemType
+  ): Promise<void>;
+  sync(partPath: UsbPartitionDevPath): Promise<void>;
   stop(): void;
   addListener(listener: () => void): void;
   removeListener(listener: () => void): void;
@@ -224,7 +232,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
   }
 
   function computeMount(
-    diskPath: string,
+    diskPath: UsbDiskDevPath,
     partition: CachedPartition
   ): UsbPartitionMount {
     const dAction = driveAction.getTask(diskPath);
@@ -271,7 +279,10 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
     };
   }
 
-  function mountPartitionWithRetry(diskPath: string, partPath: string): void {
+  function mountPartitionWithRetry(
+    diskPath: UsbDiskDevPath,
+    partPath: UsbPartitionDevPath
+  ): void {
     void partitionAction
       .perform(partPath, 'mounting', () =>
         doMountPartitionWithRetry(diskPath, partPath)
@@ -282,8 +293,8 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
   }
 
   async function doMountPartitionWithRetry(
-    diskPath: string,
-    partPath: string
+    diskPath: UsbDiskDevPath,
+    partPath: UsbPartitionDevPath
   ): Promise<void> {
     try {
       await logger.logAsCurrentRole(LogEventId.UsbDriveMountInit);
@@ -342,12 +353,12 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
     const newDrives: CachedDrive[] = (await getAllDiskDevices()).map((d) => {
       const partition = d.partitions.length === 1 ? d.partitions[0] : undefined;
       if (!partition || !isSupportedPartition(partition)) {
-        return { diskPath: d.devPath };
+        return { diskPath: d.diskPath };
       }
       return {
-        diskPath: d.devPath,
+        diskPath: d.diskPath,
         partition: {
-          partPath: partition.devPath,
+          partPath: partition.partPath,
           fstype: isFat32Partition(partition) ? 'fat32' : 'ext4',
           label: partition.label,
           mountpoint: partition.mountpoint,
@@ -381,7 +392,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
    * Helper for operations that need to unmount all disk partitions first.
    * Returns the freshly-read disk.
    */
-  async function unmountDrive(diskPath: string): Promise<CachedDrive> {
+  async function unmountDrive(diskPath: UsbDiskDevPath): Promise<CachedDrive> {
     const disk = cachedDrives.find((d) => d.diskPath === diskPath);
     assert(disk, `Drive not found: ${diskPath}`);
     if (!disk.partition) return disk;
@@ -412,7 +423,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
       await doRefresh();
     },
 
-    async ejectDrive(diskPath: string): Promise<void> {
+    async ejectDrive(diskPath: UsbDiskDevPath): Promise<void> {
       const result = driveAction.perform(diskPath, 'ejecting', async () => {
         await logger.logAsCurrentRole(LogEventId.UsbDriveEjectInit);
         try {
@@ -447,7 +458,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
     },
 
     async formatDrive(
-      diskPath: string,
+      diskPath: UsbDiskDevPath,
       fstype: UsbDriveFilesystemType
     ): Promise<void> {
       const result = driveAction.perform(diskPath, 'formatting', async () => {

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -514,7 +514,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
       await result;
     },
 
-    async sync(partPath: string): Promise<void> {
+    async sync(partPath: UsbPartitionDevPath): Promise<void> {
       const partition = cachedDrives
         .flatMap((d) => (d.partition ? [d.partition] : []))
         .find((p) => p.partPath === partPath);

--- a/libs/usb-drive/src/types.ts
+++ b/libs/usb-drive/src/types.ts
@@ -1,13 +1,57 @@
+import { z } from 'zod/v4';
 import { type UsbDriveFilesystemType } from './multi_usb_drive';
 
 export type UsbDriveStatus =
   | { status: 'no_drive' }
   | {
       status: 'mounted';
-      mountpoint: string;
+      mountpoint: UsbPartitionMountpoint;
     }
   | { status: 'ejected' }
   | { status: 'error'; reason: 'bad_format' };
+
+/**
+ * A branded string type for USB disk device paths, e.g. `/dev/sdb`.
+ */
+export const UsbDiskDevPathSchema = z
+  .string()
+  .regex(/^\/dev\/[a-z0-9]+$/)
+  .brand('UsbDiskDevPath');
+
+/**
+ * A branded string type for USB partition device paths, e.g. `/dev/sdb1`.
+ */
+export const UsbPartitionDevPathSchema = z
+  .string()
+  .regex(/^\/dev\/[a-z0-9]+[0-9]$/)
+  .brand('UsbPartitionDevPath');
+
+/**
+ * A branded string type for USB partition mountpoints, e.g.
+ * `/media/vx/usb-drive-sdb1`.
+ */
+export const UsbPartitionMountpointSchema = z
+  .string()
+  .regex(/^\//)
+  .brand('UsbPartitionMountpoint');
+
+/**
+ * A branded string type for USB disk device paths, e.g. `/dev/sdb`.
+ */
+export type UsbDiskDevPath = z.output<typeof UsbDiskDevPathSchema>;
+
+/**
+ * A branded string type for USB partition device paths, e.g. `/dev/sdb1`.
+ */
+export type UsbPartitionDevPath = z.output<typeof UsbPartitionDevPathSchema>;
+
+/**
+ * A branded string type for USB partition mountpoints, e.g.
+ * `/media/vx/usb-drive-sdb1`.
+ */
+export type UsbPartitionMountpoint = z.output<
+  typeof UsbPartitionMountpointSchema
+>;
 
 export interface UsbDrive {
   status(): Promise<UsbDriveStatus>;
@@ -20,7 +64,7 @@ export interface UsbDrive {
  * A USB drive with `partition` set if it has a single supported partition.
  */
 export interface UsbDriveInfo {
-  diskPath: string;
+  diskPath: UsbDiskDevPath;
   partition?: UsbPartitionInfo;
 }
 
@@ -28,8 +72,8 @@ export interface UsbDriveInfo {
  * A USB partition with one of the supported file systems.
  */
 export interface UsbPartitionInfo {
-  diskPath: string;
-  partPath: string;
+  diskPath: UsbDiskDevPath;
+  partPath: UsbPartitionDevPath;
   fstype: UsbDriveFilesystemType;
   mount: UsbPartitionMount;
   label?: string;
@@ -40,11 +84,11 @@ export const UsbPartitionMount = {
   ejected: (): UsbPartitionMount => ({ type: 'ejected' }),
   mounting: (): UsbPartitionMount => ({ type: 'mounting' }),
   formatting: (): UsbPartitionMount => ({ type: 'formatting' }),
-  mounted: (mountpoint: string): UsbPartitionMount => ({
+  mounted: (mountpoint: UsbPartitionMountpoint): UsbPartitionMount => ({
     type: 'mounted',
     mountpoint,
   }),
-  unmounting: (mountpoint: string): UsbPartitionMount => ({
+  unmounting: (mountpoint: UsbPartitionMountpoint): UsbPartitionMount => ({
     type: 'unmounting',
     mountpoint,
   }),
@@ -55,5 +99,5 @@ export type UsbPartitionMount =
   | { type: 'ejected' }
   | { type: 'mounting' }
   | { type: 'formatting' }
-  | { type: 'mounted'; mountpoint: string }
-  | { type: 'unmounting'; mountpoint: string };
+  | { type: 'mounted'; mountpoint: UsbPartitionMountpoint }
+  | { type: 'unmounting'; mountpoint: UsbPartitionMountpoint };

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -12,6 +12,11 @@ import {
   getMockUsbDirPath,
   MOCK_USB_DRIVE_STATE_FILENAME,
 } from './mocks/file_usb_drive';
+import {
+  UsbDiskDevPathSchema,
+  UsbPartitionDevPathSchema,
+  UsbPartitionMountpointSchema,
+} from './types';
 
 const featureFlagMock = getFeatureFlagMock();
 
@@ -66,17 +71,19 @@ test('returns no_drive when no drives are connected', async () => {
 test('exposes the first connected drive via the UsbDrive interface', async () => {
   mockDevices = [
     {
-      devPath: '/dev/sdb',
+      diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
       vendor: undefined,
       model: undefined,
       serial: undefined,
       partitions: [
         {
-          devPath: '/dev/sdb1',
+          partPath: UsbPartitionDevPathSchema.parse('/dev/sdb1'),
           label: 'VxUSB-00000',
           fstype: 'vfat',
           fsver: 'FAT32',
-          mountpoint: '/media/vx/usb-drive-sdb1',
+          mountpoint: UsbPartitionMountpointSchema.parse(
+            '/media/vx/usb-drive-sdb1'
+          ),
         },
       ],
     },

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -71,17 +71,17 @@ test('returns no_drive when no drives are connected', async () => {
 test('exposes the first connected drive via the UsbDrive interface', async () => {
   mockDevices = [
     {
-      diskPath: UsbDiskDevPathSchema.parse('/dev/sdb'),
+      diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
       vendor: undefined,
       model: undefined,
       serial: undefined,
       partitions: [
         {
-          partPath: UsbPartitionDevPathSchema.parse('/dev/sdb1'),
+          partPath: UsbPartitionDevPathSchema.decode('/dev/sdb1'),
           label: 'VxUSB-00000',
           fstype: 'vfat',
           fsver: 'FAT32',
-          mountpoint: UsbPartitionMountpointSchema.parse(
+          mountpoint: UsbPartitionMountpointSchema.decode(
             '/media/vx/usb-drive-sdb1'
           ),
         },

--- a/libs/usb-drive/src/usb_drive_adapter.test.ts
+++ b/libs/usb-drive/src/usb_drive_adapter.test.ts
@@ -10,9 +10,9 @@ import {
   UsbPartitionMountpointSchema,
 } from './types';
 
-const devsdb = UsbDiskDevPathSchema.parse('/dev/sdb');
-const devsdb1 = UsbPartitionDevPathSchema.parse('/dev/sdb1');
-const mountpointSdb1 = UsbPartitionMountpointSchema.parse(
+const devsdb = UsbDiskDevPathSchema.decode('/dev/sdb');
+const devsdb1 = UsbPartitionDevPathSchema.decode('/dev/sdb1');
+const mountpointSdb1 = UsbPartitionMountpointSchema.decode(
   '/media/vx/usb-drive-sdb1'
 );
 
@@ -44,7 +44,7 @@ describe('createUsbDriveAdapter', () => {
     test('returns no_drive when drive not found in getDrives()', async () => {
       const { multiUsbDrive } = createMockMultiUsbDrive();
       const adapter = createUsbDriveAdapter(multiUsbDrive, () =>
-        UsbDiskDevPathSchema.parse('/dev/sdz')
+        UsbDiskDevPathSchema.decode('/dev/sdz')
       );
       multiUsbDrive.getDrives.reset();
 
@@ -221,7 +221,7 @@ describe('createUsbDriveAdapter', () => {
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([]);
 
       multiUsbDrive.ejectDrive
-        .expectCallWith(UsbDiskDevPathSchema.parse('/dev/sdb'))
+        .expectCallWith(UsbDiskDevPathSchema.decode('/dev/sdb'))
         .resolves();
       await adapter.eject();
 

--- a/libs/usb-drive/src/usb_drive_adapter.test.ts
+++ b/libs/usb-drive/src/usb_drive_adapter.test.ts
@@ -1,17 +1,30 @@
 import { describe, expect, test, vi } from 'vitest';
 import { createUsbDriveAdapter } from './usb_drive_adapter';
 import { createMockMultiUsbDrive } from './mocks/mock_multi_usb_drive';
-import { UsbDriveInfo, UsbDriveStatus, UsbPartitionMount } from './types';
+import {
+  UsbDiskDevPathSchema,
+  UsbDriveInfo,
+  UsbDriveStatus,
+  UsbPartitionDevPathSchema,
+  UsbPartitionMount,
+  UsbPartitionMountpointSchema,
+} from './types';
+
+const devsdb = UsbDiskDevPathSchema.parse('/dev/sdb');
+const devsdb1 = UsbPartitionDevPathSchema.parse('/dev/sdb1');
+const mountpointSdb1 = UsbPartitionMountpointSchema.parse(
+  '/media/vx/usb-drive-sdb1'
+);
 
 function makeDriveInfo(overrides: Partial<UsbDriveInfo> = {}): UsbDriveInfo {
   return {
-    diskPath: '/dev/sdb',
+    diskPath: devsdb,
     partition: {
-      diskPath: '/dev/sdb',
-      partPath: '/dev/sdb1',
+      diskPath: devsdb,
+      partPath: devsdb1,
       label: 'VxUSB-ABCDE',
       fstype: 'fat32',
-      mount: UsbPartitionMount.mounted('/media/vx/usb-drive-sdb1'),
+      mount: UsbPartitionMount.mounted(mountpointSdb1),
     },
     ...overrides,
   };
@@ -30,7 +43,9 @@ describe('createUsbDriveAdapter', () => {
 
     test('returns no_drive when drive not found in getDrives()', async () => {
       const { multiUsbDrive } = createMockMultiUsbDrive();
-      const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdz');
+      const adapter = createUsbDriveAdapter(multiUsbDrive, () =>
+        UsbDiskDevPathSchema.parse('/dev/sdz')
+      );
       multiUsbDrive.getDrives.reset();
 
       multiUsbDrive.getDrives
@@ -75,29 +90,29 @@ describe('createUsbDriveAdapter', () => {
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
         makeDriveInfo({
           partition: {
-            diskPath: '/dev/sdb',
-            partPath: '/dev/sdb1',
+            diskPath: devsdb,
+            partPath: devsdb1,
             fstype: 'ext4',
-            mount: UsbPartitionMount.mounted('/media/vx/usb-drive-sdb1'),
+            mount: UsbPartitionMount.mounted(mountpointSdb1),
           },
         }),
       ]);
       expect(await adapter.status()).toEqual<UsbDriveStatus>({
         status: 'mounted',
-        mountpoint: '/media/vx/usb-drive-sdb1',
+        mountpoint: mountpointSdb1,
       });
     });
 
     test('returns no_drive when partition is mounting', async () => {
       const { multiUsbDrive } = createMockMultiUsbDrive();
-      const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdb');
+      const adapter = createUsbDriveAdapter(multiUsbDrive, () => devsdb);
       multiUsbDrive.getDrives.reset();
 
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
         makeDriveInfo({
           partition: {
-            diskPath: '/dev/sdb',
-            partPath: '/dev/sdb1',
+            diskPath: devsdb,
+            partPath: devsdb1,
             fstype: 'fat32',
             mount: UsbPartitionMount.mounting(),
           },
@@ -108,7 +123,7 @@ describe('createUsbDriveAdapter', () => {
 
     test('returns mounted when partition is mounted', async () => {
       const { multiUsbDrive } = createMockMultiUsbDrive();
-      const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdb');
+      const adapter = createUsbDriveAdapter(multiUsbDrive, () => devsdb);
       multiUsbDrive.getDrives.reset();
 
       multiUsbDrive.getDrives
@@ -116,20 +131,20 @@ describe('createUsbDriveAdapter', () => {
         .returns([makeDriveInfo()]);
       expect(await adapter.status()).toEqual({
         status: 'mounted',
-        mountpoint: '/media/vx/usb-drive-sdb1',
+        mountpoint: mountpointSdb1,
       });
     });
 
     test('returns no_drive for unmounted partition', async () => {
       const { multiUsbDrive } = createMockMultiUsbDrive();
-      const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdb');
+      const adapter = createUsbDriveAdapter(multiUsbDrive, () => devsdb);
       multiUsbDrive.getDrives.reset();
 
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
         makeDriveInfo({
           partition: {
-            diskPath: '/dev/sdb',
-            partPath: '/dev/sdb1',
+            diskPath: devsdb,
+            partPath: devsdb1,
             fstype: 'fat32',
             mount: UsbPartitionMount.unmounted(),
           },
@@ -140,14 +155,14 @@ describe('createUsbDriveAdapter', () => {
 
     test('returns ejected when partition mount type is ejected', async () => {
       const { multiUsbDrive, assertComplete } = createMockMultiUsbDrive();
-      const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdb');
+      const adapter = createUsbDriveAdapter(multiUsbDrive, () => devsdb);
       multiUsbDrive.getDrives.reset();
 
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
         makeDriveInfo({
           partition: {
-            diskPath: '/dev/sdb',
-            partPath: '/dev/sdb1',
+            diskPath: devsdb,
+            partPath: devsdb1,
             fstype: 'fat32',
             mount: UsbPartitionMount.ejected(),
           },
@@ -160,14 +175,14 @@ describe('createUsbDriveAdapter', () => {
 
     test('returns ejected when partition is formatting', async () => {
       const { multiUsbDrive } = createMockMultiUsbDrive();
-      const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdb');
+      const adapter = createUsbDriveAdapter(multiUsbDrive, () => devsdb);
       multiUsbDrive.getDrives.reset();
 
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
         makeDriveInfo({
           partition: {
-            diskPath: '/dev/sdb',
-            partPath: '/dev/sdb1',
+            diskPath: devsdb,
+            partPath: devsdb1,
             fstype: 'fat32',
             mount: UsbPartitionMount.formatting(),
           },
@@ -178,22 +193,22 @@ describe('createUsbDriveAdapter', () => {
 
     test('returns mounted when partition is unmounting', async () => {
       const { multiUsbDrive } = createMockMultiUsbDrive();
-      const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdb');
+      const adapter = createUsbDriveAdapter(multiUsbDrive, () => devsdb);
       multiUsbDrive.getDrives.reset();
 
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
         makeDriveInfo({
           partition: {
-            diskPath: '/dev/sdb',
-            partPath: '/dev/sdb1',
+            diskPath: devsdb,
+            partPath: devsdb1,
             fstype: 'fat32',
-            mount: UsbPartitionMount.unmounting('/media/vx/usb-drive-sdb1'),
+            mount: UsbPartitionMount.unmounting(mountpointSdb1),
           },
         }),
       ]);
       expect(await adapter.status()).toEqual({
         status: 'mounted',
-        mountpoint: '/media/vx/usb-drive-sdb1',
+        mountpoint: mountpointSdb1,
       });
     });
   });
@@ -201,11 +216,13 @@ describe('createUsbDriveAdapter', () => {
   describe('eject', () => {
     test('calls ejectDrive on the multiUsbDrive', async () => {
       const { multiUsbDrive, assertComplete } = createMockMultiUsbDrive();
-      const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdb');
+      const adapter = createUsbDriveAdapter(multiUsbDrive, () => devsdb);
       multiUsbDrive.getDrives.reset();
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([]);
 
-      multiUsbDrive.ejectDrive.expectCallWith('/dev/sdb').resolves();
+      multiUsbDrive.ejectDrive
+        .expectCallWith(UsbDiskDevPathSchema.parse('/dev/sdb'))
+        .resolves();
       await adapter.eject();
 
       assertComplete();
@@ -226,11 +243,11 @@ describe('createUsbDriveAdapter', () => {
   describe('format', () => {
     test('calls formatDrive on the multiUsbDrive', async () => {
       const { multiUsbDrive, assertComplete } = createMockMultiUsbDrive();
-      const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdb');
+      const adapter = createUsbDriveAdapter(multiUsbDrive, () => devsdb);
       multiUsbDrive.getDrives.reset();
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([]);
 
-      multiUsbDrive.formatDrive.expectCallWith('/dev/sdb', 'fat32').resolves();
+      multiUsbDrive.formatDrive.expectCallWith(devsdb, 'fat32').resolves();
       await adapter.format('fat32');
 
       assertComplete();
@@ -251,13 +268,13 @@ describe('createUsbDriveAdapter', () => {
   describe('sync', () => {
     test('calls sync on the mounted partition', async () => {
       const { multiUsbDrive, assertComplete } = createMockMultiUsbDrive();
-      const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdb');
+      const adapter = createUsbDriveAdapter(multiUsbDrive, () => devsdb);
       multiUsbDrive.getDrives.reset();
 
       multiUsbDrive.getDrives
         .expectRepeatedCallsWith()
         .returns([makeDriveInfo()]);
-      multiUsbDrive.sync.expectCallWith('/dev/sdb1').resolves();
+      multiUsbDrive.sync.expectCallWith(devsdb1).resolves();
       await adapter.sync();
 
       assertComplete();
@@ -265,16 +282,16 @@ describe('createUsbDriveAdapter', () => {
 
     test('does nothing while partition is unmounting', async () => {
       const { multiUsbDrive, assertComplete } = createMockMultiUsbDrive();
-      const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdb');
+      const adapter = createUsbDriveAdapter(multiUsbDrive, () => devsdb);
       multiUsbDrive.getDrives.reset();
 
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
         makeDriveInfo({
           partition: {
-            diskPath: '/dev/sdb',
-            partPath: '/dev/sdb1',
+            diskPath: devsdb,
+            partPath: devsdb1,
             fstype: 'fat32',
-            mount: UsbPartitionMount.unmounting('/media/vx/usb-drive-sdb1'),
+            mount: UsbPartitionMount.unmounting(mountpointSdb1),
           },
         }),
       ]);
@@ -285,14 +302,14 @@ describe('createUsbDriveAdapter', () => {
 
     test('does nothing when no mounted partition', async () => {
       const { multiUsbDrive, assertComplete } = createMockMultiUsbDrive();
-      const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdb');
+      const adapter = createUsbDriveAdapter(multiUsbDrive, () => devsdb);
       multiUsbDrive.getDrives.reset();
 
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([
         makeDriveInfo({
           partition: {
-            diskPath: '/dev/sdb',
-            partPath: '/dev/sdb1',
+            diskPath: devsdb,
+            partPath: devsdb1,
             fstype: 'fat32',
             mount: UsbPartitionMount.unmounted(),
           },
@@ -316,7 +333,7 @@ describe('createUsbDriveAdapter', () => {
 
     test('does nothing when drive not found', async () => {
       const { multiUsbDrive, assertComplete } = createMockMultiUsbDrive();
-      const adapter = createUsbDriveAdapter(multiUsbDrive, () => '/dev/sdb');
+      const adapter = createUsbDriveAdapter(multiUsbDrive, () => devsdb);
       multiUsbDrive.getDrives.reset();
 
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([]);

--- a/libs/usb-drive/src/usb_drive_adapter.test.ts
+++ b/libs/usb-drive/src/usb_drive_adapter.test.ts
@@ -220,9 +220,7 @@ describe('createUsbDriveAdapter', () => {
       multiUsbDrive.getDrives.reset();
       multiUsbDrive.getDrives.expectRepeatedCallsWith().returns([]);
 
-      multiUsbDrive.ejectDrive
-        .expectCallWith(UsbDiskDevPathSchema.decode('/dev/sdb'))
-        .resolves();
+      multiUsbDrive.ejectDrive.expectCallWith(devsdb).resolves();
       await adapter.eject();
 
       assertComplete();

--- a/libs/usb-drive/src/usb_drive_adapter.ts
+++ b/libs/usb-drive/src/usb_drive_adapter.ts
@@ -1,7 +1,12 @@
 import makeDebug from 'debug';
 import { assert, throwIllegalValue } from '@votingworks/basics';
 import { MultiUsbDrive, UsbDriveFilesystemType } from './multi_usb_drive';
-import { UsbDrive, UsbDriveInfo, UsbDriveStatus } from './types';
+import {
+  UsbDiskDevPath,
+  UsbDrive,
+  UsbDriveInfo,
+  UsbDriveStatus,
+} from './types';
 
 const debug = makeDebug('usb-drive:adapter');
 
@@ -15,7 +20,9 @@ const debug = makeDebug('usb-drive:adapter');
  */
 export function createUsbDriveAdapter(
   multiUsbDrive: MultiUsbDrive,
-  getDriveDevPath: (usbDrives: readonly UsbDriveInfo[]) => string | undefined
+  getDriveDevPath: (
+    usbDrives: readonly UsbDriveInfo[]
+  ) => UsbDiskDevPath | undefined
 ): UsbDrive {
   return {
     status(): Promise<UsbDriveStatus> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5941,6 +5941,9 @@ importers:
       tmp:
         specifier: ^0.2.6
         version: 0.2.7
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/debug':
         specifier: 4.1.12


### PR DESCRIPTION
## Overview
_(Part 9 of a series of PRs: [previous](https://github.com/votingworks/vxsuite/pull/8727) / [next](https://github.com/votingworks/vxsuite/pull/8729))_

Add branded `UsbDiskDevPath`, `UsbPartitionDevPath`, and `UsbPartitionMountpoint` types to prevent mixing up disk/partition paths and mountpoints. Values of these types are still `string`s at runtime.

## Demo Video or Screenshot
With this change, passing a bare `string` where a branded string is expected results in an error:

```ts
{
  partitions: [
    {
      partPath: '/dev/sdb1',
//    ^^^^^^^^
// Type 'string' is not assignable to type 'string & $brand<"UsbPartitionDevPath">'.
//  Type 'string' is not assignable to type '$brand<"UsbPartitionDevPath">'.
```

## Testing Plan
Automated tests, plus verifying that bare strings are rejected as above.