### PR TITLE
feat(usb-drive): add `UsbPlatform` abstraction

### DIFF
--- a/libs/usb-drive/src/cli.ts
+++ b/libs/usb-drive/src/cli.ts
@@ -1,8 +1,7 @@
 /* istanbul ignore file */
 import { LogSource, Logger } from '@votingworks/logging';
 import { detectMultiUsbDrive, MultiUsbDrive } from './multi_usb_drive';
-import type { UsbDriveFilesystemType } from './multi_usb_drive';
-import { UsbDiskDevPathSchema } from './types';
+import { UsbDiskDevPathSchema, UsbDriveFilesystemType } from './types';
 
 function printDrives(multiUsbDrive: MultiUsbDrive, stdout: NodeJS.WriteStream) {
   stdout.write(`${JSON.stringify(multiUsbDrive.getDrives(), null, 2)}\n`);

--- a/libs/usb-drive/src/index.ts
+++ b/libs/usb-drive/src/index.ts
@@ -7,4 +7,5 @@ export * from './multi_usb_drive';
 export * from './types';
 export * from './usb_drive';
 export * from './usb_drive_adapter';
+export * from './usb_platform';
 export { type MockFileTree, writeMockFileTree } from './mocks/helpers';

--- a/libs/usb-drive/src/mocks/file_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.ts
@@ -9,12 +9,13 @@ import {
 import { Optional } from '@votingworks/basics';
 import { getMockStateRootDir } from '@votingworks/utils';
 import { basename, join } from 'node:path';
-import type { MultiUsbDrive, UsbDriveFilesystemType } from '../multi_usb_drive';
+import type { MultiUsbDrive } from '../multi_usb_drive';
 import { MockFileTree, writeMockFileTree } from './helpers';
 import {
   UsbDiskDevPath,
   UsbDiskDevPathSchema,
   UsbDrive,
+  UsbDriveFilesystemType,
   UsbDriveInfo,
   UsbDriveStatus,
   UsbPartitionDevPath,

--- a/libs/usb-drive/src/mocks/mock_multi_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/mock_multi_usb_drive.ts
@@ -1,16 +1,17 @@
-import { Mocked, mockFunction } from '@votingworks/test-utils';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
+import { Mocked, mockFunction } from '@votingworks/test-utils';
 import { rmSync } from 'node:fs';
-import { MultiUsbDrive, UsbDriveFilesystemType } from '../multi_usb_drive';
-import { MockFileTree, writeMockFileTree } from './helpers';
+import { MultiUsbDrive } from '../multi_usb_drive';
 import {
   UsbDiskDevPath,
   UsbDiskDevPathSchema,
+  UsbDriveFilesystemType,
   UsbDriveInfo,
   UsbPartitionDevPathSchema,
   UsbPartitionMount,
   UsbPartitionMountpointSchema,
 } from '../types';
+import { MockFileTree, writeMockFileTree } from './helpers';
 
 const MOCK_SINGLETON_DISK_DEV_PATH = UsbDiskDevPathSchema.decode('/dev/sdb');
 

--- a/libs/usb-drive/src/multi_usb_drive.test.ts
+++ b/libs/usb-drive/src/multi_usb_drive.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@votingworks/utils';
 import { deferred, sleep } from '@votingworks/basics';
 import { detectMultiUsbDrive } from './multi_usb_drive';
+import { UsbPlatform } from './usb_platform';
 import { exec } from './exec';
 import { getAllDiskDevices, UsbDiskDeviceInfo } from './block_devices';
 import {
@@ -89,6 +90,28 @@ function makeDisk(
     ...overrides,
   };
 }
+
+test('an explicitly injected platform takes precedence over USE_MOCK_USB_DRIVE', async () => {
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE
+  );
+  const platform: UsbPlatform = {
+    getDrives: () => Promise.resolve([{ diskPath: devsdb }]),
+    watchChanges: () => ({ stop: () => {} }),
+    mountPartition: () => Promise.resolve(),
+    unmountPartition: () => Promise.resolve(),
+    formatDrive: () => Promise.resolve(),
+    sync: () => Promise.resolve(),
+  };
+  const multiUsbDrive = detectMultiUsbDrive(mockLogger({ fn: vi.fn }), {
+    platform,
+  });
+
+  await multiUsbDrive.refresh();
+
+  expect(multiUsbDrive.getDrives()).toEqual([{ diskPath: devsdb }]);
+  multiUsbDrive.stop();
+});
 
 test('works even when USE_MOCK_USB_DRIVE feature flag is enabled', () => {
   featureFlagMock.enableFeatureFlag(

--- a/libs/usb-drive/src/multi_usb_drive.test.ts
+++ b/libs/usb-drive/src/multi_usb_drive.test.ts
@@ -284,6 +284,46 @@ describe('refresh', () => {
     multiUsbDrive.stop();
   });
 
+  test('notifies listeners when ejecting an already-unmounted drive', async () => {
+    mockDrives = [
+      makeDisk({
+        partitions: [
+          {
+            partPath: devsdb1,
+            mountpoint: undefined,
+            fstype: 'vfat',
+            fsver: 'FAT32',
+            label: undefined,
+          },
+        ],
+      }),
+    ];
+    const logger = mockLogger({ fn: vi.fn });
+
+    // Fail the auto-mount so the partition settles at unmounted.
+    execMock.mockRejectedValue(new Error('mount failed'));
+
+    const multiUsbDrive = detectMultiUsbDrive(logger);
+    await vi.waitFor(() => {
+      expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+        UsbPartitionMount.unmounted()
+      );
+    });
+
+    // Ejecting changes only derived state (the platform snapshot is
+    // unchanged), but listeners must still hear about it.
+    const onChange = vi.fn();
+    multiUsbDrive.addListener(onChange);
+    await multiUsbDrive.ejectDrive(devsdb);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+      UsbPartitionMount.ejected()
+    );
+
+    multiUsbDrive.stop();
+  });
+
   test('watcher callback triggers a refresh', async () => {
     mockDrives = [];
     const logger = mockLogger({ fn: vi.fn });

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -151,7 +151,7 @@ export function detectMultiUsbDrive(
   const listeners = new Set<() => void>();
 
   let stopped = false;
-  let isFirstRefresh = true;
+  let lastReportedState: Optional<string>;
   let cachedDrives: UsbPlatformDrive[] = [];
 
   // Per-drive eject state: cleared when the drive is no longer detected.
@@ -167,6 +167,19 @@ export function detectMultiUsbDrive(
     for (const listener of listeners) {
       listener();
     }
+  }
+
+  /**
+   * Notifies listeners if the drive state visible through {@link getDrives}
+   * has changed since the last notification. Compares the built drive infos —
+   * not the raw platform snapshot — so transitions that only change derived
+   * state (e.g. ejecting an already-unmounted drive) are still reported.
+   */
+  function notifyIfChanged() {
+    const newState = JSON.stringify(cachedDrives.map(buildDriveInfo));
+    if (newState === lastReportedState) return;
+    lastReportedState = newState;
+    onChange();
   }
 
   function computeMount(
@@ -226,7 +239,7 @@ export function detectMultiUsbDrive(
         doMountPartitionWithRetry(diskPath, partPath)
       )
       ?.then(() => {
-        if (!stopped) onChange();
+        if (!stopped) notifyIfChanged();
       });
   }
 
@@ -297,19 +310,13 @@ export function detectMultiUsbDrive(
       }
     }
 
-    const stateChanged =
-      isFirstRefresh ||
-      JSON.stringify(newDrives) !== JSON.stringify(cachedDrives);
-    isFirstRefresh = false;
     cachedDrives = newDrives;
 
     for (const disk of newDrives) {
       doAutoMount(disk);
     }
 
-    if (stateChanged) {
-      onChange();
-    }
+    notifyIfChanged();
   }
 
   /**

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -1,75 +1,41 @@
-import { join } from 'node:path';
-import makeDebug from 'debug';
 import {
   assert,
   assertDefined,
   Deferred,
   deferred,
   extractErrorMessage,
+  iter,
   MaybePromise,
   Optional,
   sleep,
-  throwIllegalValue,
 } from '@votingworks/basics';
 import { LogEventId, Logger } from '@votingworks/logging';
 import {
   BooleanEnvironmentVariableName,
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
-import { exec } from './exec';
-import {
-  createBlockDeviceChangeWatcher,
-  getAllDiskDevices,
-} from './block_devices';
+import makeDebug from 'debug';
 import { createMockFileMultiUsbDrive } from './mocks/file_usb_drive';
-import { UsbDriveInfo, UsbPartitionMount } from './types';
-import type {
+import {
   UsbDiskDevPath,
+  UsbDriveFilesystemType,
+  UsbDriveInfo,
   UsbPartitionDevPath,
-  UsbPartitionMountpoint,
+  UsbPartitionMount,
 } from './types';
+import {
+  RealUsbPlatform,
+  UsbPlatform,
+  UsbPlatformDrive,
+  UsbPlatformPartition,
+} from './usb_platform';
 
 const VX_USB_LABEL_REGEXP = /^VxUSB-[A-Z0-9]{5}$/i;
 
 const debug = makeDebug('usb-drive:multi');
 
-const MOUNT_SCRIPT_PATH = join(__dirname, '../scripts');
 const MOUNT_TIMEOUT_MS = 5_000;
 const MOUNT_RETRY_INTERVAL_MS = 100;
-
-async function mountPartition(partPath: string): Promise<void> {
-  await exec('sudo', ['-n', join(MOUNT_SCRIPT_PATH, 'mount.sh'), partPath]);
-}
-
-async function unmountPartition(mountpoint: string): Promise<void> {
-  await exec('sudo', ['-n', join(MOUNT_SCRIPT_PATH, 'unmount.sh'), mountpoint]);
-}
-
-export type UsbDriveFilesystemType = 'fat32' | 'ext4';
-
-async function formatDriveAsFat32(
-  diskPath: UsbDiskDevPath,
-  label: string
-): Promise<void> {
-  await exec('sudo', [
-    '-n',
-    join(MOUNT_SCRIPT_PATH, 'format_fat32.sh'),
-    diskPath,
-    label,
-  ]);
-}
-
-async function formatDriveAsExt4(
-  diskPath: UsbDiskDevPath,
-  label: string
-): Promise<void> {
-  await exec('sudo', [
-    '-n',
-    join(MOUNT_SCRIPT_PATH, 'format_ext4.sh'),
-    diskPath,
-    label,
-  ]);
-}
 
 function generateVxUsbLabel(previousLabel?: string): string {
   if (previousLabel && VX_USB_LABEL_REGEXP.test(previousLabel)) {
@@ -82,43 +48,6 @@ function generateVxUsbLabel(previousLabel?: string): string {
     label += assertDefined(CHARS[Math.floor(Math.random() * CHARS.length)]);
   }
   return label;
-}
-
-export function isFat32Partition(partition?: {
-  fstype?: string;
-  fsver?: string;
-}): boolean {
-  return partition?.fstype === 'vfat' && partition.fsver === 'FAT32';
-}
-
-export function isExt4Partition(partition?: { fstype?: string }): boolean {
-  return partition?.fstype === 'ext4';
-}
-
-function isSupportedPartition(partition?: {
-  fstype?: string;
-  fsver?: string;
-}): boolean {
-  return isFat32Partition(partition) || isExt4Partition(partition);
-}
-
-/**
- * Internal cached representation of a detected partition. Holds the raw
- * mountpoint so the displayed {@link UsbPartitionMount} can be recomputed on
- * each read (reflecting in-progress eject/format/mount actions) rather than
- * baked in at refresh time.
- */
-interface CachedPartition {
-  partPath: UsbPartitionDevPath;
-  fstype: UsbDriveFilesystemType;
-  label?: string;
-  mountpoint?: UsbPartitionMountpoint;
-}
-
-/** Internal cached representation of a detected USB disk. */
-interface CachedDrive {
-  diskPath: UsbDiskDevPath;
-  partition?: CachedPartition;
 }
 
 export interface MultiUsbDrive {
@@ -205,16 +134,25 @@ class KeyedTaskRunner<Key, Task> {
   }
 }
 
-export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
-  if (isFeatureFlagEnabled(BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE)) {
+export function detectMultiUsbDrive(
+  logger: Logger,
+  options?: { platform?: UsbPlatform }
+): MultiUsbDrive {
+  // An explicitly injected platform takes precedence over the ambient
+  // USE_MOCK_USB_DRIVE flag.
+  if (
+    !options?.platform &&
+    isFeatureFlagEnabled(BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE)
+  ) {
     return createMockFileMultiUsbDrive();
   }
 
+  const platform = options?.platform ?? new RealUsbPlatform();
   const listeners = new Set<() => void>();
 
   let stopped = false;
   let isFirstRefresh = true;
-  let cachedDrives: CachedDrive[] = [];
+  let cachedDrives: UsbPlatformDrive[] = [];
 
   // Per-drive eject state: cleared when the drive is no longer detected.
   const ejectedDrives = new Set<string>();
@@ -233,7 +171,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
 
   function computeMount(
     diskPath: UsbDiskDevPath,
-    partition: CachedPartition
+    partition: UsbPlatformPartition
   ): UsbPartitionMount {
     const dAction = driveAction.getTask(diskPath);
 
@@ -263,7 +201,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
     return UsbPartitionMount.unmounted();
   }
 
-  function buildDriveInfo(drive: CachedDrive): UsbDriveInfo {
+  function buildDriveInfo(drive: UsbPlatformDrive): UsbDriveInfo {
     if (!drive.partition) {
       return { diskPath: drive.diskPath };
     }
@@ -298,7 +236,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
   ): Promise<void> {
     try {
       await logger.logAsCurrentRole(LogEventId.UsbDriveMountInit);
-      await mountPartition(partPath);
+      await platform.mountPartition(partPath);
 
       let mountpoint: Optional<string>;
       const deadline = Date.now() + MOUNT_TIMEOUT_MS;
@@ -334,7 +272,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
     }
   }
 
-  function doAutoMount(drive: CachedDrive): void {
+  function doAutoMount(drive: UsbPlatformDrive): void {
     if (stopped) return;
     if (ejectedDrives.has(drive.diskPath)) return;
     if (driveAction.isBusy(drive.diskPath)) return;
@@ -350,21 +288,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
     // Every detected USB disk is included. `partition` is set only when the
     // disk has exactly one supported (FAT32/ext4) partition; otherwise the disk
     // appears with no partition (e.g. unformatted or unsupported drives).
-    const newDrives: CachedDrive[] = (await getAllDiskDevices()).map((d) => {
-      const partition = d.partitions.length === 1 ? d.partitions[0] : undefined;
-      if (!partition || !isSupportedPartition(partition)) {
-        return { diskPath: d.diskPath };
-      }
-      return {
-        diskPath: d.diskPath,
-        partition: {
-          partPath: partition.partPath,
-          fstype: isFat32Partition(partition) ? 'fat32' : 'ext4',
-          label: partition.label,
-          mountpoint: partition.mountpoint,
-        },
-      };
-    });
+    const newDrives = await platform.getDrives();
 
     // Clear eject state for drives that have been physically removed
     for (const devPath of ejectedDrives) {
@@ -392,7 +316,9 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
    * Helper for operations that need to unmount all disk partitions first.
    * Returns the freshly-read disk.
    */
-  async function unmountDrive(diskPath: UsbDiskDevPath): Promise<CachedDrive> {
+  async function unmountDrive(
+    diskPath: UsbDiskDevPath
+  ): Promise<UsbPlatformDrive> {
     const disk = cachedDrives.find((d) => d.diskPath === diskPath);
     assert(disk, `Drive not found: ${diskPath}`);
     if (!disk.partition) return disk;
@@ -404,12 +330,12 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
     const freshDisk = cachedDrives.find((d) => d.diskPath === diskPath);
     assert(freshDisk, `Drive not found: ${diskPath}`);
     if (freshDisk.partition?.mountpoint) {
-      await unmountPartition(freshDisk.partition.mountpoint);
+      await platform.unmountPartition(freshDisk.partition.mountpoint);
     }
     return freshDisk;
   }
 
-  const watcher = createBlockDeviceChangeWatcher(() => {
+  const watcher = platform.watchChanges(() => {
     void doRefresh().catch((e) => debug(`background refresh failed: ${e}`));
   });
   void doRefresh().catch((e) => debug(`initial refresh failed: ${e}`));
@@ -472,18 +398,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
           debug(
             `formatting drive ${diskPath} as ${fstype} with label ${label}`
           );
-          switch (fstype) {
-            case 'fat32':
-              await formatDriveAsFat32(diskPath, label);
-              break;
-            case 'ext4':
-              await formatDriveAsExt4(diskPath, label);
-              break;
-            /* istanbul ignore start */
-            default:
-              throwIllegalValue(fstype);
-            /* istanbul ignore stop */
-          }
+          await platform.formatDrive(diskPath, fstype, label);
           ejectedDrives.add(diskPath); // prevent auto-remount
           await doRefresh();
 
@@ -515,8 +430,8 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
     },
 
     async sync(partPath: UsbPartitionDevPath): Promise<void> {
-      const partition = cachedDrives
-        .flatMap((d) => (d.partition ? [d.partition] : []))
+      const partition = iter(cachedDrives)
+        .filterMap((d) => d.partition)
         .find((p) => p.partPath === partPath);
 
       if (!partition?.mountpoint) {
@@ -524,7 +439,7 @@ export function detectMultiUsbDrive(logger: Logger): MultiUsbDrive {
         return;
       }
 
-      await exec('sync', ['-f', partition.mountpoint]);
+      await platform.sync(partition.mountpoint);
     },
 
     stop(): void {

--- a/libs/usb-drive/src/types.ts
+++ b/libs/usb-drive/src/types.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod/v4';
-import { type UsbDriveFilesystemType } from './multi_usb_drive';
 
 export type UsbDriveStatus =
   | { status: 'no_drive' }
@@ -101,3 +100,8 @@ export type UsbPartitionMount =
   | { type: 'formatting' }
   | { type: 'mounted'; mountpoint: UsbPartitionMountpoint }
   | { type: 'unmounting'; mountpoint: UsbPartitionMountpoint };
+
+export const UsbDriveFilesystemTypeSchema = z.enum(['fat32', 'ext4']);
+export type UsbDriveFilesystemType = z.output<
+  typeof UsbDriveFilesystemTypeSchema
+>;

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -1,12 +1,11 @@
-import { beforeEach, expect, test, vi } from 'vitest';
-import { existsSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
 import { mockLogger } from '@votingworks/logging';
 import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
 } from '@votingworks/utils';
-import { detectUsbDrive } from './usb_drive';
+import { existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { beforeEach, expect, test, vi } from 'vitest';
 import { UsbDiskDeviceInfo } from './block_devices';
 import {
   getMockUsbDirPath,
@@ -17,6 +16,7 @@ import {
   UsbPartitionDevPathSchema,
   UsbPartitionMountpointSchema,
 } from './types';
+import { detectUsbDrive } from './usb_drive';
 
 const featureFlagMock = getFeatureFlagMock();
 
@@ -91,12 +91,10 @@ test('exposes the first connected drive via the UsbDrive interface', async () =>
 
   const usbDrive = detectUsbDrive(mockLogger({ fn: vi.fn }));
 
-  // doRefresh() is fired asynchronously but only awaits Promise.resolve(mockDrives),
-  // so one microtask tick is enough for it to complete and populate the drive cache.
-  await Promise.resolve();
-
-  expect(await usbDrive.status()).toEqual({
-    status: 'mounted',
-    mountpoint: '/media/vx/usb-drive-sdb1',
+  await vi.waitFor(async () => {
+    expect(await usbDrive.status()).toEqual({
+      status: 'mounted',
+      mountpoint: '/media/vx/usb-drive-sdb1',
+    });
   });
 });

--- a/libs/usb-drive/src/usb_drive_adapter.ts
+++ b/libs/usb-drive/src/usb_drive_adapter.ts
@@ -1,9 +1,10 @@
-import makeDebug from 'debug';
 import { assert, throwIllegalValue } from '@votingworks/basics';
-import { MultiUsbDrive, UsbDriveFilesystemType } from './multi_usb_drive';
+import makeDebug from 'debug';
+import { MultiUsbDrive } from './multi_usb_drive';
 import {
   UsbDiskDevPath,
   UsbDrive,
+  UsbDriveFilesystemType,
   UsbDriveInfo,
   UsbDriveStatus,
 } from './types';

--- a/libs/usb-drive/src/usb_platform.ts
+++ b/libs/usb-drive/src/usb_platform.ts
@@ -1,0 +1,175 @@
+import { throwIllegalValue } from '@votingworks/basics';
+import { join } from 'node:path';
+import z from 'zod/v4';
+import {
+  createBlockDeviceChangeWatcher,
+  getAllDiskDevices,
+} from './block_devices';
+import { exec } from './exec';
+import {
+  UsbDiskDevPath,
+  UsbDiskDevPathSchema,
+  UsbDriveFilesystemType,
+  UsbPartitionDevPath,
+  UsbPartitionDevPathSchema,
+  UsbPartitionMountpoint,
+  UsbPartitionMountpointSchema,
+} from './types';
+
+const MOUNT_SCRIPT_PATH = join(__dirname, '../scripts');
+
+export function isFat32Partition(partition?: {
+  fstype?: string;
+  fsver?: string;
+}): boolean {
+  return partition?.fstype === 'vfat' && partition.fsver === 'FAT32';
+}
+
+export function isExt4Partition(partition?: { fstype?: string }): boolean {
+  return partition?.fstype === 'ext4';
+}
+
+function isSupportedPartition(partition?: {
+  fstype?: string;
+  fsver?: string;
+}): boolean {
+  return isFat32Partition(partition) || isExt4Partition(partition);
+}
+
+export interface DriveWatcher {
+  stop(): void;
+}
+
+export interface UsbPlatform {
+  /**
+   * Get all drives and their usable partitions.
+   */
+  getDrives(): Promise<UsbPlatformDrive[]>;
+
+  /**
+   * Watch for changes to the list of drives. Call {@link DriveWatcher.stop} to
+   * stop watching.
+   */
+  watchChanges(onChange: () => void): DriveWatcher;
+
+  /**
+   * Mount a partition by its path (e.g. `/dev/sda1`).
+   */
+  mountPartition(partPath: UsbPartitionDevPath): Promise<void>;
+
+  /**
+   * Unmount a partition by its mount point (e.g. `/media/vx/usb-drive-sda1`).
+   */
+  unmountPartition(mountpoint: UsbPartitionMountpoint): Promise<void>;
+
+  /**
+   * Format a drive with the specified filesystem type and label.
+   */
+  formatDrive(
+    diskPath: UsbDiskDevPath,
+    fstype: UsbDriveFilesystemType,
+    label: string
+  ): Promise<void>;
+
+  /**
+   * Sync the contents of a mounted partition to disk.
+   */
+  sync(mountpoint: UsbPartitionMountpoint): Promise<void>;
+}
+
+export const UsbPlatformPartitionSchema = z.object({
+  partPath: UsbPartitionDevPathSchema,
+  fstype: z.enum(['fat32', 'ext4']),
+  label: z.string().optional(),
+  mountpoint: UsbPartitionMountpointSchema.optional(),
+});
+
+/**
+ * Platform representation of a USB drive partition.
+ */
+export type UsbPlatformPartition = z.output<typeof UsbPlatformPartitionSchema>;
+
+export const UsbPlatformDriveSchema = z.object({
+  diskPath: UsbDiskDevPathSchema,
+  partition: UsbPlatformPartitionSchema.optional(),
+});
+
+/**
+ * Platform representation of a USB drive, including a single valid partition
+ * if any is present. A missing partition means the drive has no usable
+ * partitions, not that there are no partitions at all.
+ */
+export type UsbPlatformDrive = z.output<typeof UsbPlatformDriveSchema>;
+
+export class RealUsbPlatform implements UsbPlatform {
+  async getDrives(): Promise<UsbPlatformDrive[]> {
+    const drives = await getAllDiskDevices();
+    return drives.map((drive): UsbPlatformDrive => {
+      const partition =
+        drive.partitions.length === 1 ? drive.partitions[0] : undefined;
+
+      if (!partition || !isSupportedPartition(partition)) {
+        return { diskPath: drive.diskPath };
+      }
+
+      return {
+        diskPath: drive.diskPath,
+        partition: {
+          partPath: partition.partPath,
+          fstype: isFat32Partition(partition) ? 'fat32' : 'ext4',
+          label: partition.label,
+          mountpoint: partition.mountpoint,
+        },
+      };
+    });
+  }
+
+  watchChanges(onChange: () => void): DriveWatcher {
+    return createBlockDeviceChangeWatcher(onChange);
+  }
+
+  async mountPartition(partPath: UsbPartitionDevPath): Promise<void> {
+    await exec('sudo', ['-n', join(MOUNT_SCRIPT_PATH, 'mount.sh'), partPath]);
+  }
+
+  async unmountPartition(mountpoint: UsbPartitionMountpoint): Promise<void> {
+    await exec('sudo', [
+      '-n',
+      join(MOUNT_SCRIPT_PATH, 'unmount.sh'),
+      mountpoint,
+    ]);
+  }
+
+  async formatDrive(
+    diskPath: UsbDiskDevPath,
+    fstype: UsbDriveFilesystemType,
+    label: string
+  ): Promise<void> {
+    switch (fstype) {
+      case 'fat32':
+        await exec('sudo', [
+          '-n',
+          join(MOUNT_SCRIPT_PATH, 'format_fat32.sh'),
+          diskPath,
+          label,
+        ]);
+        break;
+      case 'ext4':
+        await exec('sudo', [
+          '-n',
+          join(MOUNT_SCRIPT_PATH, 'format_ext4.sh'),
+          diskPath,
+          label,
+        ]);
+        break;
+      /* istanbul ignore start */
+      default:
+        throwIllegalValue(fstype);
+      /* istanbul ignore stop */
+    }
+  }
+
+  async sync(mountpoint: UsbPartitionMountpoint): Promise<void> {
+    await exec('sync', ['-f', mountpoint]);
+  }
+}


### PR DESCRIPTION
## Overview
_(Part 10 of a series of PRs: [previous](https://github.com/votingworks/vxsuite/pull/8728) / [next](https://github.com/votingworks/vxsuite/pull/8730))_

Provides a seam to inject a mock/simulated platform for testing and the dev dock.

## Demo Video or Screenshot
n/a

## Testing Plan
Manually test common USB drive actions in VxAdmin.