### PR TITLE
feat(usb-drive): add `SimulatedUsbPlatform` for test/dev

### DIFF
--- a/libs/usb-drive/src/index.ts
+++ b/libs/usb-drive/src/index.ts
@@ -3,6 +3,7 @@ export * from './media_mount_dir';
 export * from './mocks/memory_usb_drive';
 export * from './mocks/mock_multi_usb_drive';
 export * from './mocks/file_usb_drive';
+export * from './mocks/simulated_usb_platform';
 export * from './multi_usb_drive';
 export * from './types';
 export * from './usb_drive';

--- a/libs/usb-drive/src/mocks/simulated_usb_platform.test.ts
+++ b/libs/usb-drive/src/mocks/simulated_usb_platform.test.ts
@@ -1,0 +1,438 @@
+import { assertDefined } from '@votingworks/basics';
+import { makeTemporaryDirectory } from '@votingworks/fixtures';
+import { backendWaitFor } from '@votingworks/test-utils';
+import { Buffer } from 'node:buffer';
+import { existsSync } from 'node:fs';
+import { readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { expect, test, vi } from 'vitest';
+import {
+  UsbDiskDevPathSchema,
+  UsbPartitionDevPathSchema,
+  UsbPartitionMountpoint,
+  UsbPartitionMountpointSchema,
+} from '../types';
+import { UsbPlatformDrive, UsbPlatformPartition } from '../usb_platform';
+import { SimulatedUsbPlatform } from './simulated_usb_platform';
+
+function getSimulatedMountpoint(
+  platform: SimulatedUsbPlatform
+): UsbPartitionMountpoint {
+  return assertDefined(platform.getSimulatedDrives()[0]?.partition?.mountpoint);
+}
+
+async function readTestFile(platform: SimulatedUsbPlatform): Promise<string> {
+  return await readFile(
+    join(getSimulatedMountpoint(platform), 'README'),
+    'utf-8'
+  );
+}
+
+async function writeTestFile(
+  platform: SimulatedUsbPlatform,
+  data: string
+): Promise<void> {
+  await writeFile(join(getSimulatedMountpoint(platform), 'README'), data);
+}
+
+const devsdb = UsbDiskDevPathSchema.decode('/dev/sdb');
+const devsdb1 = UsbPartitionDevPathSchema.decode('/dev/sdb1');
+const devsdc = UsbDiskDevPathSchema.decode('/dev/sdc');
+const devsdc1 = UsbPartitionDevPathSchema.decode('/dev/sdc1');
+
+test('starts empty', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  await expect(platform.getDrives()).resolves.toEqual([]);
+  expect(platform.getSimulatedDrives()).toEqual([]);
+});
+
+test('tolerates a deleted devices.json', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  await rm(platform['stateFilePath']);
+  await expect(platform.getDrives()).resolves.toEqual([]);
+});
+
+test('crashes on a corrupted devices.json', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  await writeFile(platform['stateFilePath'], 'not json');
+  await expect(platform.getDrives()).rejects.toThrow();
+});
+
+test('bad diskPath crashes', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+
+  expect(() => platform.removeDrive(devsdb)).toThrow();
+  expect(() => platform.deleteDrive(devsdb)).toThrow();
+  expect(() => platform.clearDriveStorage(devsdb)).toThrow();
+  expect(() => platform.insertDrive(devsdb)).toThrow();
+  await expect(
+    platform.formatDrive(devsdb, 'fat32', 'LABEL')
+  ).rejects.toThrow();
+  await expect(platform.mountPartition(devsdb1)).rejects.toThrow();
+  await expect(
+    platform.unmountPartition(platform.storagePath(devsdb))
+  ).rejects.toThrow();
+
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  platform.insertDrive(devsdb);
+  await expect(platform.mountPartition(devsdc1)).rejects.toThrow();
+  await platform.mountPartition(devsdb1);
+  await expect(
+    platform.unmountPartition(platform.storagePath(devsdc))
+  ).rejects.toThrow();
+});
+
+test('cannot create a drive that already exists', () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  expect(() =>
+    platform.createDrive({ diskPath: devsdb, fstype: 'fat32' })
+  ).toThrow();
+});
+
+test('created drives are not present until inserted', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+
+  platform.createDrive({
+    diskPath: devsdb,
+    fstype: 'fat32',
+  });
+  // Created but not attached: invisible to the platform, but tracked.
+  await expect(platform.getDrives()).resolves.toEqual([]);
+  expect(platform.getSimulatedDrives()).toEqual([
+    expect.objectContaining({
+      diskPath: devsdb,
+      present: false,
+    }),
+  ]);
+
+  platform.insertDrive(devsdb);
+  await expect(platform.getDrives()).resolves.toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: devsdb,
+    }),
+  ]);
+  expect(platform.getSimulatedDrives()).toEqual([
+    expect.objectContaining({
+      diskPath: devsdb,
+      present: true,
+    }),
+  ]);
+  // The platform's view of attached hardware doesn't leak the presence flag.
+  const [drive] = await platform.getDrives();
+  expect(drive).not.toHaveProperty('present');
+});
+
+test('failed create cleans up storage path', () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  vi.spyOn(
+    platform as unknown as { writeStateFile: () => void },
+    'writeStateFile'
+  ).mockThrow('FAIL');
+  expect(() =>
+    platform.createDrive({ diskPath: devsdb, fstype: 'fat32' })
+  ).toThrow();
+  expect(existsSync(platform.storagePath(devsdb))).toEqual(false);
+});
+
+test('watch changes', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  const onDeviceChange1 = vi.fn();
+  const onDeviceChange2 = vi.fn();
+  const watcher1 = platform.watchChanges(onDeviceChange1);
+  const watcher2 = platform.watchChanges(onDeviceChange2);
+
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  platform.insertDrive(devsdb);
+  await backendWaitFor(() => {
+    expect(onDeviceChange1.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(onDeviceChange2.mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  watcher2.stop();
+  const callsBeforeStop = onDeviceChange2.mock.calls.length;
+  platform.createDrive({ diskPath: devsdc, fstype: 'fat32' });
+  platform.insertDrive(devsdc);
+  await backendWaitFor(() => {
+    expect(onDeviceChange1.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+  expect(onDeviceChange2.mock.calls.length).toEqual(callsBeforeStop);
+
+  platform.deleteAllDrives();
+  await backendWaitFor(() => {
+    expect(onDeviceChange1.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  watcher1.stop();
+});
+
+test('full lifecycle', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  const onDeviceChange = vi.fn();
+  const watcher = platform.watchChanges(onDeviceChange);
+  expect(onDeviceChange).toHaveBeenCalledTimes(0);
+
+  platform.createDrive({
+    diskPath: devsdb,
+    fstype: 'fat32',
+  });
+  platform.insertDrive(devsdb);
+  await backendWaitFor(() => {
+    expect(onDeviceChange.mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
+  await expect(platform.getDrives()).resolves.toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: devsdb,
+      partition: expect.objectContaining<Partial<UsbPlatformPartition>>({
+        fstype: 'fat32',
+      }),
+    }),
+  ]);
+
+  await platform.mountPartition(devsdb1);
+  const drives = await platform.getDrives();
+  expect(drives).toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: devsdb,
+      partition: expect.objectContaining<Partial<UsbPlatformPartition>>({
+        fstype: 'fat32',
+        mountpoint: expect.any(String),
+      }),
+    }),
+  ]);
+
+  await writeTestFile(platform, 'hello world');
+
+  await platform.unmountPartition(platform.storagePath(devsdb));
+  await expect(platform.getDrives()).resolves.toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: devsdb,
+      partition: expect.objectContaining<Partial<UsbPlatformPartition>>({
+        fstype: 'fat32',
+        mountpoint: undefined,
+      }),
+    }),
+  ]);
+
+  await platform.mountPartition(devsdb1);
+  const afterRemountDrives = await platform.getDrives();
+  expect(afterRemountDrives).toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
+      partition: expect.objectContaining<Partial<UsbPlatformPartition>>({
+        fstype: 'fat32',
+        mountpoint: expect.any(String),
+      }),
+    }),
+  ]);
+  await expect(readTestFile(platform)).resolves.toEqual('hello world');
+
+  // Removing a drive detaches it but preserves its storage.
+  platform.removeDrive(devsdb);
+  await expect(platform.getDrives()).resolves.toEqual([]);
+  expect(platform.getSimulatedDrives()).toEqual([
+    expect.objectContaining({
+      diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
+      present: false,
+    }),
+  ]);
+
+  // Reattaching and remounting preserves the previously written contents.
+  platform.insertDrive(devsdb);
+  await platform.mountPartition(devsdb1);
+  await expect(readTestFile(platform)).resolves.toEqual('hello world');
+
+  // Clearing wipes contents but keeps the drive present.
+  platform.clearDriveStorage(devsdb);
+  expect(platform.getSimulatedDrives()).toEqual([
+    expect.objectContaining({
+      diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
+      present: true,
+    }),
+  ]);
+  await expect(readTestFile(platform)).rejects.toThrow();
+
+  // Formatting re-partitions the drive and clears contents.
+  await writeTestFile(platform, 'should be cleared by formatDrive');
+  await platform.formatDrive(devsdb, 'ext4', 'GOODIES');
+  await platform.mountPartition(devsdb1);
+  const afterFormatDrives = await platform.getDrives();
+  expect(afterFormatDrives).toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
+      partition: expect.objectContaining<Partial<UsbPlatformPartition>>({
+        fstype: 'ext4',
+        label: 'GOODIES',
+        mountpoint: expect.any(String),
+      }),
+    }),
+  ]);
+  await expect(readTestFile(platform)).rejects.toThrow();
+
+  // Deleting a drive removes it and its storage entirely.
+  platform.deleteDrive(devsdb);
+  await expect(platform.getDrives()).resolves.toEqual([]);
+  expect(platform.getSimulatedDrives()).toEqual([]);
+
+  watcher.stop();
+  onDeviceChange.mockClear();
+
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  platform.insertDrive(devsdb);
+  await platform.mountPartition(devsdb1);
+
+  // Simulated platform `sync` doesn't really do anything.
+  await platform.sync(platform.storagePath(devsdb));
+  await expect(
+    platform.sync(UsbPartitionMountpointSchema.decode('/mnt/nonexistent'))
+  ).rejects.toThrow();
+
+  await platform.unmountPartition(platform.storagePath(devsdb));
+  platform.deleteAllDrives();
+
+  // No more calls after `watcher.stop()`.
+  expect(onDeviceChange).toHaveBeenCalledTimes(0);
+});
+
+test('createDrive can seed initial contents', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({
+    diskPath: devsdb,
+    fstype: 'fat32',
+    contents: { README: Buffer.from('seeded') },
+  });
+  platform.insertDrive(devsdb);
+  await platform.mountPartition(devsdb1);
+  await expect(readTestFile(platform)).resolves.toEqual('seeded');
+});
+
+test('deleteAllDrives is a no-op when there are no drives', () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  expect(() => platform.deleteAllDrives()).not.toThrow();
+  expect(platform.getSimulatedDrives()).toEqual([]);
+});
+
+test('can delete a created drive that was never inserted', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  platform.deleteDrive(devsdb);
+  expect(platform.getSimulatedDrives()).toEqual([]);
+  await expect(platform.getDrives()).resolves.toEqual([]);
+});
+
+test('created-but-not-attached drives cannot be operated on as hardware', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+
+  // The drive exists but is not plugged in, so hardware operations fail.
+  expect(() => platform.removeDrive(devsdb)).toThrow('Drive not attached');
+  await expect(platform.mountPartition(devsdb1)).rejects.toThrow();
+  await expect(
+    platform.unmountPartition(platform.storagePath(devsdb))
+  ).rejects.toThrow();
+
+  // Once attached, the same operations succeed.
+  platform.insertDrive(devsdb);
+  await expect(platform.mountPartition(devsdb1)).resolves.toBeUndefined();
+});
+
+test('tracks multiple drives independently', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({
+    diskPath: devsdb,
+    fstype: 'fat32',
+    label: 'FIRST',
+    contents: { README: Buffer.from('sdb-data') },
+  });
+  platform.createDrive({
+    diskPath: devsdc,
+    fstype: 'ext4',
+    label: 'SECOND',
+    contents: { README: Buffer.from('sdc-data') },
+  });
+
+  // With only sdb attached, the platform's view shows just sdb.
+  platform.insertDrive(devsdb);
+  await expect(platform.getDrives()).resolves.toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({ diskPath: devsdb }),
+  ]);
+
+  platform.insertDrive(devsdc);
+  await platform.mountPartition(devsdb1);
+  await platform.mountPartition(devsdc1);
+
+  // Each drive keeps its own partition path, fstype, and label.
+  const drives = await platform.getDrives();
+  expect(drives).toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: devsdb,
+      partition: expect.objectContaining<Partial<UsbPlatformPartition>>({
+        partPath: devsdb1,
+        fstype: 'fat32',
+        label: 'FIRST',
+      }),
+    }),
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: devsdc,
+      partition: expect.objectContaining<Partial<UsbPlatformPartition>>({
+        partPath: devsdc1,
+        fstype: 'ext4',
+        label: 'SECOND',
+      }),
+    }),
+  ]);
+
+  // Each drive has its own isolated storage at a distinct mountpoint.
+  const [sdb, sdc] = drives;
+  const sdbMountpoint = assertDefined(sdb?.partition?.mountpoint);
+  const sdcMountpoint = assertDefined(sdc?.partition?.mountpoint);
+  expect(sdbMountpoint).not.toEqual(sdcMountpoint);
+  await expect(
+    readFile(join(sdbMountpoint, 'README'), 'utf-8')
+  ).resolves.toEqual('sdb-data');
+  await expect(
+    readFile(join(sdcMountpoint, 'README'), 'utf-8')
+  ).resolves.toEqual('sdc-data');
+});
+
+test('deleteDrive removes only the target drive, leaving others intact', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  platform.createDrive({ diskPath: devsdc, fstype: 'ext4' });
+  platform.insertDrive(devsdb);
+  platform.insertDrive(devsdc);
+  await platform.mountPartition(devsdc1);
+
+  platform.deleteDrive(devsdb);
+
+  // sdc survives with its state (present, mounted, ext4) fully intact.
+  expect(platform.getSimulatedDrives()).toEqual([
+    expect.objectContaining({ diskPath: devsdc, present: true }),
+  ]);
+  await expect(platform.getDrives()).resolves.toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: devsdc,
+      partition: expect.objectContaining<Partial<UsbPlatformPartition>>({
+        fstype: 'ext4',
+        mountpoint: expect.any(String),
+      }),
+    }),
+  ]);
+});
+
+test('shares on-disk state across instances on the same root', async () => {
+  const root = makeTemporaryDirectory();
+  const platformA = new SimulatedUsbPlatform(root);
+  platformA.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  platformA.insertDrive(devsdb);
+
+  // A second instance on the same root sees state created by the first.
+  const platformB = new SimulatedUsbPlatform(root);
+  await expect(platformB.getDrives()).resolves.toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({ diskPath: devsdb }),
+  ]);
+
+  // And mutations made through B are visible to A.
+  platformB.removeDrive(devsdb);
+  await expect(platformA.getDrives()).resolves.toEqual([]);
+});

--- a/libs/usb-drive/src/mocks/simulated_usb_platform.test.ts
+++ b/libs/usb-drive/src/mocks/simulated_usb_platform.test.ts
@@ -90,6 +90,59 @@ test('cannot create a drive that already exists', () => {
   ).toThrow();
 });
 
+test('cannot create an unformatted drive with contents', () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  expect(() =>
+    platform.createDrive({
+      diskPath: devsdb,
+      contents: { README: Buffer.from('orphaned') },
+    })
+  ).toThrow('Cannot create an unformatted drive with contents');
+});
+
+test('unformatted drive lifecycle: create, insert, format', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({ diskPath: devsdb });
+  platform.insertDrive(devsdb);
+
+  // Visible to the platform, but with no usable partition — mirroring how
+  // RealUsbPlatform reports unformatted drives.
+  await expect(platform.getDrives()).resolves.toEqual([{ diskPath: devsdb }]);
+
+  // Without a partition there is nothing to mount or unmount.
+  await expect(platform.mountPartition(devsdb1)).rejects.toThrow();
+  await expect(
+    platform.unmountPartition(platform.storagePath(devsdb))
+  ).rejects.toThrow();
+
+  // Unplugging and re-attaching keeps it unformatted.
+  platform.removeDrive(devsdb);
+  platform.insertDrive(devsdb);
+
+  // Formatting installs a mounted partition.
+  await platform.formatDrive(devsdb, 'fat32', 'VxUSB-ABCDE');
+  await expect(platform.getDrives()).resolves.toEqual([
+    {
+      diskPath: devsdb,
+      partition: {
+        partPath: devsdb1,
+        fstype: 'fat32',
+        label: 'VxUSB-ABCDE',
+        mountpoint: platform.storagePath(devsdb),
+      },
+    },
+  ]);
+});
+
+test('deleting a present unformatted drive works without an unmount', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({ diskPath: devsdb });
+  platform.insertDrive(devsdb);
+  platform.deleteAllDrives();
+  expect(platform.getSimulatedDrives()).toEqual([]);
+  await expect(platform.getDrives()).resolves.toEqual([]);
+});
+
 test('created drives are not present until inserted', async () => {
   const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
 

--- a/libs/usb-drive/src/mocks/simulated_usb_platform.test.ts
+++ b/libs/usb-drive/src/mocks/simulated_usb_platform.test.ts
@@ -1,4 +1,4 @@
-import { assertDefined } from '@votingworks/basics';
+import { assertDefined, typedAs } from '@votingworks/basics';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
 import { backendWaitFor } from '@votingworks/test-utils';
 import { Buffer } from 'node:buffer';
@@ -13,7 +13,10 @@ import {
   UsbPartitionMountpointSchema,
 } from '../types';
 import { UsbPlatformDrive, UsbPlatformPartition } from '../usb_platform';
-import { SimulatedUsbPlatform } from './simulated_usb_platform';
+import {
+  SimulatedUsbDrive,
+  SimulatedUsbPlatform,
+} from './simulated_usb_platform';
 
 function getSimulatedMountpoint(
   platform: SimulatedUsbPlatform
@@ -107,7 +110,9 @@ test('unformatted drive lifecycle: create, insert, format', async () => {
 
   // Visible to the platform, but with no usable partition — mirroring how
   // RealUsbPlatform reports unformatted drives.
-  await expect(platform.getDrives()).resolves.toEqual([{ diskPath: devsdb }]);
+  await expect(platform.getDrives()).resolves.toEqual(
+    typedAs<UsbPlatformDrive[]>([{ diskPath: devsdb }])
+  );
 
   // Without a partition there is nothing to mount or unmount.
   await expect(platform.mountPartition(devsdb1)).rejects.toThrow();
@@ -121,17 +126,19 @@ test('unformatted drive lifecycle: create, insert, format', async () => {
 
   // Formatting installs a mounted partition.
   await platform.formatDrive(devsdb, 'fat32', 'VxUSB-ABCDE');
-  await expect(platform.getDrives()).resolves.toEqual([
-    {
-      diskPath: devsdb,
-      partition: {
-        partPath: devsdb1,
-        fstype: 'fat32',
-        label: 'VxUSB-ABCDE',
-        mountpoint: platform.storagePath(devsdb),
+  await expect(platform.getDrives()).resolves.toEqual(
+    typedAs<UsbPlatformDrive[]>([
+      {
+        diskPath: devsdb,
+        partition: {
+          partPath: devsdb1,
+          fstype: 'fat32',
+          label: 'VxUSB-ABCDE',
+          mountpoint: platform.storagePath(devsdb),
+        },
       },
-    },
-  ]);
+    ])
+  );
 });
 
 test('deleting a present unformatted drive works without an unmount', async () => {
@@ -460,7 +467,10 @@ test('deleteDrive removes only the target drive, leaving others intact', async (
 
   // sdc survives with its state (present, mounted, ext4) fully intact.
   expect(platform.getSimulatedDrives()).toEqual([
-    expect.objectContaining({ diskPath: devsdc, present: true }),
+    expect.objectContaining<SimulatedUsbDrive>({
+      diskPath: devsdc,
+      present: true,
+    }),
   ]);
   await expect(platform.getDrives()).resolves.toEqual([
     expect.objectContaining<Partial<UsbPlatformDrive>>({

--- a/libs/usb-drive/src/mocks/simulated_usb_platform.ts
+++ b/libs/usb-drive/src/mocks/simulated_usb_platform.ts
@@ -1,0 +1,491 @@
+/* eslint-disable no-param-reassign */
+import { isNonExistentFileOrDirectoryError, iter } from '@votingworks/basics';
+import makeDebug from 'debug';
+import assert from 'node:assert';
+import {
+  closeSync,
+  constants,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  watch,
+  writeFileSync,
+} from 'node:fs';
+import { basename, join } from 'node:path';
+import { z } from 'zod/v4';
+import {
+  UsbDiskDevPath,
+  UsbDriveFilesystemType,
+  UsbPartitionDevPath,
+  UsbPartitionDevPathSchema,
+  UsbPartitionMountpoint,
+  UsbPartitionMountpointSchema,
+} from '../types';
+import {
+  DriveWatcher,
+  UsbPlatform,
+  UsbPlatformDrive,
+  UsbPlatformDriveSchema,
+  UsbPlatformPartition,
+} from '../usb_platform';
+import { MockFileTree, writeMockFileTree } from './helpers';
+
+const debug = makeDebug('SimulatedUsbPlatform');
+
+export const SimulatedUsbDriveSchema = UsbPlatformDriveSchema.extend({
+  present: z.boolean(),
+});
+
+/**
+ * A USB drive tracked by the simulator. Its backing storage exists for as long
+ * as the drive has been created and not deleted, independent of whether it is
+ * currently attached. The `present` flag models whether the drive is "plugged
+ * in": only present drives are visible through the {@link UsbPlatform}
+ * interface (`getAllUsbDrives`), mirroring real hardware which is only visible
+ * when attached.
+ */
+export type SimulatedUsbDrive = z.output<typeof SimulatedUsbDriveSchema>;
+
+interface CreateDriveOptions {
+  diskPath: UsbDiskDevPath;
+  fstype: UsbDriveFilesystemType;
+  label?: string;
+  contents?: MockFileTree;
+}
+
+function findDrive(
+  drives: SimulatedUsbDrive[],
+  diskPath: UsbDiskDevPath
+): SimulatedUsbDrive {
+  const drive = drives.find((d) => d.diskPath === diskPath);
+  assert(drive, `Drive not found: ${diskPath}`);
+  return drive;
+}
+
+function findPresentDrive(
+  drives: SimulatedUsbDrive[],
+  diskPath: UsbDiskDevPath
+): SimulatedUsbDrive {
+  const drive = drives.find((d) => d.diskPath === diskPath);
+  assert(drive, `Drive not found: ${diskPath}`);
+  assert(drive.present, `Drive not attached: ${diskPath}`);
+  return drive;
+}
+
+/**
+ * Finds the partition with the given path on a currently-attached drive. A
+ * partition can only be mounted or unmounted while its drive is present, just
+ * as real hardware is only accessible while plugged in.
+ */
+function findPresentPartition(
+  drives: SimulatedUsbDrive[],
+  partPath: UsbPartitionDevPath
+): { drive: SimulatedUsbDrive; partition: UsbPlatformPartition } {
+  const drive = drives.find(
+    (d) => d.present && d.partition?.partPath === partPath
+  );
+  assert(drive, `Partition not found on an attached drive: ${partPath}`);
+  assert(drive.partition);
+  return { drive, partition: drive.partition };
+}
+
+/**
+ * Finds the partition with the given mountpoint on a currently-attached drive.
+ * A partition can only be mounted or unmounted while its drive is present, just
+ * as real hardware is only accessible while plugged in.
+ */
+function findPresentPartitionByMountpoint(
+  drives: SimulatedUsbDrive[],
+  mountpoint: UsbPartitionMountpoint
+): { drive: SimulatedUsbDrive; partition: UsbPlatformPartition } {
+  const drive = drives.find(
+    (d) => d.present && d.partition?.mountpoint === mountpoint
+  );
+  assert(drive, `Partition not found on an attached drive: ${mountpoint}`);
+  assert(drive.partition);
+  return { drive, partition: drive.partition };
+}
+
+export class SimulatedUsbPlatform implements UsbPlatform {
+  private watchController?: AbortController;
+
+  /**
+   * The working set of drives during an in-progress {@link mutateState}
+   * transaction. When set, it is the single source of truth that all reads and
+   * mutations operate on and that gets persisted; when unset, state is read
+   * fresh from {@link stateFilePath} each time.
+   */
+  private cachedDrives?: SimulatedUsbDrive[];
+  private readonly listeners = new Set<() => void>();
+
+  constructor(private readonly root: string) {
+    mkdirSync(this.root, { recursive: true });
+    try {
+      const fd = openSync(
+        this.stateFilePath,
+        // eslint-disable-next-line no-bitwise
+        constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY
+      );
+      writeFileSync(fd, JSON.stringify([]));
+      closeSync(fd);
+      debug('Created new devices file');
+    } catch (e) {
+      /* istanbul ignore next: unexpected errors should propagate */
+      if ((e as { code?: string }).code !== 'EEXIST') {
+        throw e;
+      }
+      debug('Using existing devices file');
+    }
+  }
+
+  async getDrives(): Promise<UsbPlatformDrive[]> {
+    await Promise.resolve();
+    return this.getSimulatedDrives()
+      .filter((drive) => drive.present)
+      .map(({ partition, diskPath }): UsbPlatformDrive => {
+        assert(partition);
+        return {
+          diskPath,
+          partition: {
+            partPath: partition.partPath,
+            fstype: partition.fstype,
+            label: partition.label,
+            mountpoint: partition.mountpoint,
+          },
+        };
+      });
+  }
+
+  /**
+   * Returns every drive the simulator is tracking, including ones that have
+   * been created but are not currently attached (`present: false`). Use this
+   * to inspect or toggle a drive's presence; use {@link getDrives} for
+   * the platform's view of attached hardware.
+   */
+  getSimulatedDrives(): SimulatedUsbDrive[] {
+    try {
+      if (this.cachedDrives) return this.cachedDrives;
+      return z
+        .array(SimulatedUsbDriveSchema)
+        .parse(JSON.parse(readFileSync(this.stateFilePath, 'utf-8')));
+    } catch (e) {
+      if (isNonExistentFileOrDirectoryError(e)) return [];
+      throw e;
+    }
+  }
+
+  /**
+   * Registers a listener to call when the platform's USB device state changes.
+   * @param onChange The listener function to call when the state changes.
+   * @returns A watcher object that can be used to stop listening.
+   */
+  watchChanges(onChange: () => void): DriveWatcher {
+    this.listeners.add(onChange);
+
+    if (!this.watchController) {
+      this.watchController = new AbortController();
+      watch(
+        this.stateFilePath,
+        { signal: this.watchController.signal },
+        (event, file) => {
+          debug('Watch event: %s %s', event, file);
+          for (const fn of this.listeners) {
+            fn();
+          }
+        }
+      );
+    }
+
+    return {
+      stop: () => {
+        this.listeners.delete(onChange);
+        if (this.listeners.size === 0) {
+          this.watchController?.abort();
+          this.watchController = undefined;
+        }
+      },
+    };
+  }
+
+  /**
+   * Creates a drive's backing storage (partition, filesystem, and contents)
+   * without attaching it. The drive starts out not present; call
+   * {@link insertDrive} to make it visible to the platform.
+   */
+  createDrive(options: CreateDriveOptions): void {
+    debug('Create drive: %s', options.diskPath);
+    assert(
+      !this.getSimulatedDrives().some((d) => d.diskPath === options.diskPath),
+      `USB drive already exists: ${options.diskPath}`
+    );
+
+    const newDrive: SimulatedUsbDrive = {
+      diskPath: options.diskPath,
+      present: false,
+      partition: {
+        partPath: this.partPathFromDiskPath(options.diskPath),
+        fstype: options.fstype,
+        label: options.label,
+      },
+    };
+
+    try {
+      this.mutateState((drives) => {
+        drives.push(newDrive);
+        const storagePath = this.reinitStorage(newDrive.diskPath);
+        if (options.contents) {
+          writeMockFileTree(storagePath, options.contents);
+        }
+      });
+    } catch (e) {
+      rmSync(this.storagePath(newDrive.diskPath), {
+        recursive: true,
+        force: true,
+      });
+      throw e;
+    }
+  }
+
+  /**
+   * Attaches a previously {@link createDrive}d drive, making it present.
+   */
+  insertDrive(diskPath: UsbDiskDevPath): void {
+    debug('Insert drive: %s', diskPath);
+    this.mutateState((drives) => {
+      findDrive(drives, diskPath).present = true;
+    });
+  }
+
+  /**
+   * Detaches a drive and marks it not present. The drive's storage is preserved
+   * and can be reattached with {@link insertDrive}. Use {@link deleteDrive} to
+   * destroy its storage.
+   */
+  removeDrive(diskPath: UsbDiskDevPath): void {
+    debug('Remove drive: %s', diskPath);
+    this.mutateState((drives) => {
+      const drive = findPresentDrive(drives, diskPath);
+      assert(drive.partition);
+      this.unmountPartitionInternal(drive.partition);
+      drive.present = false;
+    });
+  }
+
+  /**
+   * Clears a drive's data without changing its presence or format.
+   */
+  clearDriveStorage(diskPath: UsbDiskDevPath): void {
+    this.replaceDriveData(diskPath, {});
+  }
+
+  /**
+   * Replaces the data in a drive with the given contents. Does not change the
+   * state of the drive (presence or format).
+   */
+  replaceDriveData(diskPath: UsbDiskDevPath, contents: MockFileTree): void {
+    debug('Replace drive data: %s', diskPath);
+    assert(
+      this.getSimulatedDrives().some((d) => d.diskPath === diskPath),
+      `Drive not found: ${diskPath}`
+    );
+    const storagePath = this.reinitStorage(diskPath);
+    writeMockFileTree(storagePath, contents);
+  }
+
+  /**
+   * Detaches a drive and destroys its backing storage entirely.
+   */
+  deleteDrive(diskPath: UsbDiskDevPath): void {
+    debug('Delete drive: %s', diskPath);
+    this.mutateState((drives) => {
+      const [toDelete, toKeep] = iter(drives).partition(
+        (d) => d.diskPath === diskPath
+      );
+      assert(toDelete.length === 1, `USB drive not found: ${diskPath}`);
+      this.destroyDrives(toDelete);
+      return toKeep;
+    });
+  }
+
+  /** Deletes every tracked drive and destroys all backing storage. */
+  deleteAllDrives(): void {
+    debug('Delete all drives');
+    if (this.getSimulatedDrives().length === 0) return;
+    this.mutateState((drives) => {
+      this.destroyDrives(drives);
+      return [];
+    });
+  }
+
+  /**
+   * Unmounts (if present) and destroys the backing storage of each given drive.
+   * Caller is responsible for removing them from the persisted working set.
+   */
+  private destroyDrives(drives: SimulatedUsbDrive[]): void {
+    for (const drive of drives) {
+      if (drive.present) {
+        assert(drive.partition);
+        this.unmountPartitionInternal(drive.partition);
+      }
+      debug('Deleting drive storage: %s', drive.diskPath);
+      this.reinitStorage(drive.diskPath);
+    }
+  }
+
+  /**
+   * Mounts a partition by device path.
+   * @throws {Error} If the partition is not present.
+   */
+  async mountPartition(partPath: UsbPartitionDevPath): Promise<void> {
+    await Promise.resolve();
+    this.mutateState((drives) => {
+      const { drive, partition } = findPresentPartition(drives, partPath);
+      partition.mountpoint = this.storagePath(drive.diskPath);
+      mkdirSync(partition.mountpoint, { recursive: true });
+    });
+  }
+
+  /**
+   * Unmounts a drive by its mountpoint.
+   * @throws {Error} If the drive is not present.
+   */
+  async unmountPartition(mountpoint: UsbPartitionMountpoint): Promise<void> {
+    await Promise.resolve();
+    this.mutateState((drives) => {
+      const { partition } = findPresentPartitionByMountpoint(
+        drives,
+        mountpoint
+      );
+      this.unmountPartitionInternal(partition);
+    });
+  }
+
+  /**
+   * Clears a partition's mountpoint. Mutates the given partition in place, so
+   * it must be called within a {@link mutateState} transaction on a partition
+   * belonging to the working set.
+   */
+  private unmountPartitionInternal(partition: UsbPlatformPartition): void {
+    assert(this.cachedDrives, 'must be called within mutateState');
+    if (!partition.mountpoint) {
+      debug('Partition already unmounted: %s', partition.partPath);
+      return;
+    }
+    debug('Unmounting partition: %s', partition.partPath);
+    partition.mountpoint = undefined;
+  }
+
+  /**
+   * Formats a drive with the given options. This will delete any existing
+   * partitions and create a new one.
+   * @throws {Error} If the drive is not present.
+   */
+  async formatDrive(
+    diskPath: UsbDiskDevPath,
+    fstype: UsbDriveFilesystemType,
+    label: string
+  ): Promise<void> {
+    await Promise.resolve();
+    debug('Format drive: %s', diskPath);
+    this.mutateState((drives) => {
+      const drive = findPresentDrive(drives, diskPath);
+      assert(drive.partition);
+      this.unmountPartitionInternal(drive.partition);
+
+      drive.partition = {
+        partPath: this.partPathFromDiskPath(drive.diskPath),
+        fstype,
+        label,
+        mountpoint: this.storagePath(drive.diskPath),
+      };
+
+      this.replaceDriveData(drive.diskPath, {});
+    });
+  }
+
+  /**
+   * Synchronizes the contents of a drive with its storage. This operation is a
+   * no-op for a simulated drive.
+   * @throws {Error} If the drive is not present or not mounted.
+   */
+  async sync(mountpoint: UsbPartitionMountpoint): Promise<void> {
+    await Promise.resolve();
+    debug('Sync: %s', mountpoint);
+
+    const drive = this.getSimulatedDrives().find(
+      (d) => d.present && d.partition?.mountpoint === mountpoint
+    );
+    assert(!!drive, `Drive not mounted: ${mountpoint}`);
+  }
+
+  /**
+   * The path to the file used to store drive state.
+   */
+  private get stateFilePath(): string {
+    return join(this.root, 'drives.json');
+  }
+
+  /**
+   * The root directory for partition storage. Partitions each have their own
+   * subdirectory named after their devPath.
+   */
+  private get storageRoot(): string {
+    return join(this.root, 'storage');
+  }
+
+  private reinitStorage(diskPath: UsbDiskDevPath): string {
+    const storagePath = this.storagePath(diskPath);
+    rmSync(storagePath, { recursive: true, force: true });
+    mkdirSync(storagePath, { recursive: true });
+    return storagePath;
+  }
+
+  /**
+   * Returns the path to the storage directory for the given drive, which
+   * will be in a directory named after the drive's devPath. It is not
+   * guaranteed to exist on disk since it does not check that the drive
+   * actually exists.
+   */
+  storagePath(diskPath: UsbDiskDevPath): UsbPartitionMountpoint {
+    return UsbPartitionMountpointSchema.decode(
+      join(this.storageRoot, basename(diskPath))
+    );
+  }
+
+  private partPathFromDiskPath(diskPath: UsbDiskDevPath): UsbPartitionDevPath {
+    return UsbPartitionDevPathSchema.decode(`${diskPath}1`);
+  }
+
+  /**
+   * Runs a state mutation as a read-modify-write transaction. `mutate` receives
+   * the working set of drives — the only thing it may mutate — and may either
+   * mutate it in place or return a replacement array. Whatever the working set
+   * is at the end is persisted. Not re-entrant.
+   */
+  private mutateState(
+    mutate: (drives: SimulatedUsbDrive[]) => SimulatedUsbDrive[] | void
+  ): void {
+    assert(!this.cachedDrives, 'mutateState is not re-entrant');
+    this.cachedDrives = this.getSimulatedDrives();
+    try {
+      this.cachedDrives = mutate(this.cachedDrives) ?? this.cachedDrives;
+      this.writeStateFile(this.cachedDrives);
+    } finally {
+      this.cachedDrives = undefined;
+    }
+  }
+
+  private writeStateFile(devices: readonly SimulatedUsbDrive[]): void {
+    debug('Write state file: %d device(s)', devices.length);
+    for (const device of devices) {
+      debug(
+        'Write state file:   %s (%s, %s)',
+        device.diskPath,
+        device.present ? 'present' : 'absent',
+        device.partition?.mountpoint ?? 'unmounted'
+      );
+    }
+    writeFileSync(this.stateFilePath, JSON.stringify(devices, null, 2));
+  }
+}

--- a/libs/usb-drive/src/mocks/simulated_usb_platform.ts
+++ b/libs/usb-drive/src/mocks/simulated_usb_platform.ts
@@ -49,7 +49,12 @@ export type SimulatedUsbDrive = z.output<typeof SimulatedUsbDriveSchema>;
 
 interface CreateDriveOptions {
   diskPath: UsbDiskDevPath;
-  fstype: UsbDriveFilesystemType;
+  /**
+   * Filesystem type for the drive's single partition. Omit to create an
+   * unformatted drive with no usable partition, mirroring how
+   * {@link RealUsbPlatform} reports unformatted or unsupported drives.
+   */
+  fstype?: UsbDriveFilesystemType;
   label?: string;
   contents?: MockFileTree;
 }
@@ -143,18 +148,17 @@ export class SimulatedUsbPlatform implements UsbPlatform {
     await Promise.resolve();
     return this.getSimulatedDrives()
       .filter((drive) => drive.present)
-      .map(({ partition, diskPath }): UsbPlatformDrive => {
-        assert(partition);
-        return {
+      .map(
+        ({ partition, diskPath }): UsbPlatformDrive => ({
           diskPath,
-          partition: {
+          partition: partition && {
             partPath: partition.partPath,
             fstype: partition.fstype,
             label: partition.label,
             mountpoint: partition.mountpoint,
           },
-        };
-      });
+        })
+      );
   }
 
   /**
@@ -219,15 +223,21 @@ export class SimulatedUsbPlatform implements UsbPlatform {
       !this.getSimulatedDrives().some((d) => d.diskPath === options.diskPath),
       `USB drive already exists: ${options.diskPath}`
     );
+    assert(
+      !options.contents || options.fstype !== undefined,
+      'Cannot create an unformatted drive with contents'
+    );
 
     const newDrive: SimulatedUsbDrive = {
       diskPath: options.diskPath,
       present: false,
-      partition: {
-        partPath: this.partPathFromDiskPath(options.diskPath),
-        fstype: options.fstype,
-        label: options.label,
-      },
+      partition: options.fstype
+        ? {
+            partPath: this.partPathFromDiskPath(options.diskPath),
+            fstype: options.fstype,
+            label: options.label,
+          }
+        : undefined,
     };
 
     try {
@@ -266,8 +276,9 @@ export class SimulatedUsbPlatform implements UsbPlatform {
     debug('Remove drive: %s', diskPath);
     this.mutateState((drives) => {
       const drive = findPresentDrive(drives, diskPath);
-      assert(drive.partition);
-      this.unmountPartitionInternal(drive.partition);
+      if (drive.partition) {
+        this.unmountPartitionInternal(drive.partition);
+      }
       drive.present = false;
     });
   }
@@ -324,8 +335,7 @@ export class SimulatedUsbPlatform implements UsbPlatform {
    */
   private destroyDrives(drives: SimulatedUsbDrive[]): void {
     for (const drive of drives) {
-      if (drive.present) {
-        assert(drive.partition);
+      if (drive.present && drive.partition) {
         this.unmountPartitionInternal(drive.partition);
       }
       debug('Deleting drive storage: %s', drive.diskPath);
@@ -390,8 +400,9 @@ export class SimulatedUsbPlatform implements UsbPlatform {
     debug('Format drive: %s', diskPath);
     this.mutateState((drives) => {
       const drive = findPresentDrive(drives, diskPath);
-      assert(drive.partition);
-      this.unmountPartitionInternal(drive.partition);
+      if (drive.partition) {
+        this.unmountPartitionInternal(drive.partition);
+      }
 
       drive.partition = {
         partPath: this.partPathFromDiskPath(drive.diskPath),

--- a/libs/usb-drive/src/multi_usb_drive_integration.test.ts
+++ b/libs/usb-drive/src/multi_usb_drive_integration.test.ts
@@ -1,0 +1,144 @@
+// Integration tests running the production `detectMultiUsbDrive` state
+// machine against a real `SimulatedUsbPlatform` (no module mocks). These
+// guard the `UsbPlatform` contract between the state machine and platform
+// implementations — e.g. that unmount/sync are addressed by mountpoint —
+// which unit tests with mocked platforms cannot catch.
+import { sleep } from '@votingworks/basics';
+import { makeTemporaryDirectory } from '@votingworks/fixtures';
+import { LogEventId, mockLogger } from '@votingworks/logging';
+import { existsSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { expect, test, vi } from 'vitest';
+import { detectMultiUsbDrive } from './multi_usb_drive';
+import { SimulatedUsbPlatform } from './mocks/simulated_usb_platform';
+import {
+  UsbDiskDevPathSchema,
+  UsbPartitionDevPathSchema,
+  UsbPartitionMount,
+} from './types';
+
+const devsdb = UsbDiskDevPathSchema.decode('/dev/sdb');
+const devsdb1 = UsbPartitionDevPathSchema.decode('/dev/sdb1');
+
+test('detects and auto-mounts a drive attached before detection starts', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  platform.insertDrive(devsdb);
+
+  const multiUsbDrive = detectMultiUsbDrive(mockLogger({ fn: vi.fn }), {
+    platform,
+  });
+
+  try {
+    await vi.waitFor(
+      () => {
+        expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+          UsbPartitionMount.mounted(platform.storagePath(devsdb))
+        );
+      },
+      { timeout: 2000 }
+    );
+  } finally {
+    multiUsbDrive.stop();
+  }
+});
+
+test('full lifecycle: insert → auto-mount → write → sync → eject → format → remove → re-insert', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  const logger = mockLogger({ fn: vi.fn });
+  const multiUsbDrive = detectMultiUsbDrive(logger, { platform });
+
+  try {
+    await multiUsbDrive.refresh();
+    expect(multiUsbDrive.getDrives()).toEqual([]);
+
+    platform.createDrive({
+      diskPath: devsdb,
+      fstype: 'fat32',
+      label: 'VxUSB-ABCDE',
+    });
+    platform.insertDrive(devsdb);
+    await multiUsbDrive.refresh();
+
+    const mountpoint = platform.storagePath(devsdb);
+    await vi.waitFor(
+      () => {
+        expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+          UsbPartitionMount.mounted(mountpoint)
+        );
+      },
+      { timeout: 2000 }
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.UsbDriveMounted,
+      expect.any(String),
+      expect.objectContaining({ disposition: 'success' })
+    );
+
+    // Write data through the mounted filesystem and flush it
+    await writeFile(join(mountpoint, 'README'), 'hello');
+    await multiUsbDrive.sync(devsdb1);
+
+    // Eject unmounts via the platform and reports the partition as ejected
+    await multiUsbDrive.ejectDrive(devsdb);
+    expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+      UsbPartitionMount.ejected()
+    );
+    expect(
+      platform.getSimulatedDrives()[0]?.partition?.mountpoint
+    ).toBeUndefined();
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.UsbDriveEjected,
+      expect.any(String),
+      expect.objectContaining({ disposition: 'success' })
+    );
+
+    // Ejecting preserves the drive's data and prevents auto-remount
+    expect(existsSync(join(mountpoint, 'README'))).toEqual(true);
+    await multiUsbDrive.refresh();
+    await sleep(50);
+    expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+      UsbPartitionMount.ejected()
+    );
+
+    // Format preserves the VxUSB label and wipes the drive's data
+    await multiUsbDrive.formatDrive(devsdb, 'fat32');
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.UsbDriveFormatted,
+      expect.any(String),
+      expect.objectContaining({
+        disposition: 'success',
+        message: expect.stringContaining('VxUSB-ABCDE'),
+      })
+    );
+    expect(platform.getSimulatedDrives()[0]?.partition?.label).toEqual(
+      'VxUSB-ABCDE'
+    );
+    expect(existsSync(join(mountpoint, 'README'))).toEqual(false);
+
+    // Unplugging the drive is detected via the platform watcher (no explicit
+    // refresh) and the drive disappears
+    platform.removeDrive(devsdb);
+    await vi.waitFor(
+      () => {
+        expect(multiUsbDrive.getDrives()).toEqual([]);
+      },
+      { timeout: 2000 }
+    );
+
+    // Re-inserting clears the eject state and auto-mounts again
+    platform.insertDrive(devsdb);
+    await multiUsbDrive.refresh();
+    await vi.waitFor(
+      () => {
+        expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+          UsbPartitionMount.mounted(mountpoint)
+        );
+      },
+      { timeout: 2000 }
+    );
+  } finally {
+    multiUsbDrive.stop();
+  }
+});

--- a/libs/usb-drive/src/multi_usb_drive_integration.test.ts
+++ b/libs/usb-drive/src/multi_usb_drive_integration.test.ts
@@ -44,6 +44,38 @@ test('detects and auto-mounts a drive attached before detection starts', async (
   }
 });
 
+test('detects an unformatted drive and formats it', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  const logger = mockLogger({ fn: vi.fn });
+  const multiUsbDrive = detectMultiUsbDrive(logger, { platform });
+
+  try {
+    platform.createDrive({ diskPath: devsdb });
+    platform.insertDrive(devsdb);
+    await multiUsbDrive.refresh();
+
+    // Reported with no usable partition; nothing to auto-mount.
+    expect(multiUsbDrive.getDrives()).toEqual([{ diskPath: devsdb }]);
+
+    await multiUsbDrive.formatDrive(devsdb, 'fat32');
+
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.UsbDriveFormatted,
+      expect.any(String),
+      expect.objectContaining({ disposition: 'success' })
+    );
+    const partition = platform.getSimulatedDrives()[0]?.partition;
+    expect(partition?.fstype).toEqual('fat32');
+    expect(partition?.label).toMatch(/^VxUSB-[A-Z0-9]{5}$/);
+    // Formatted drives are held ejected until physically re-inserted.
+    expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+      UsbPartitionMount.ejected()
+    );
+  } finally {
+    multiUsbDrive.stop();
+  }
+});
+
 test('full lifecycle: insert → auto-mount → write → sync → eject → format → remove → re-insert', async () => {
   const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
   const logger = mockLogger({ fn: vi.fn });


### PR DESCRIPTION
## Overview
_(Part 11 of a series of PRs: [previous](https://github.com/votingworks/vxsuite/pull/8729) / [next](https://github.com/votingworks/vxsuite/pull/8743))_

This isn't another mock in the way we usually use mocks in vxsuite. This is a simulated USB drive API that has behavior not specified in each of the tests that will eventually use it. We've historically stayed away from simulations and preferred `vi.fn`-style mocking, but we _already_ have a need for a simulated USB drive platform with the dev dock. This one will replace the existing mocks that operate a bit higher up the stack in both the dev dock and in tests.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated tests for the simulator itself, plus some manual validation with the dev dock that I'm not quite ready to make a PR for.