### PR TITLE
refactor(usb-drive): back dev/test USB mocks with `SimulatedUsbPlatform`

### DIFF
--- a/libs/dev-dock/backend/src/dev_dock_api.test.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.test.ts
@@ -46,8 +46,7 @@ import {
 import { createMockPdiScanner } from '@votingworks/pdi-scanner';
 import {
   getMockFileUsbDriveHandler,
-  listMockDrives,
-  removeMockDriveDir,
+  getMockUsbPlatform,
   UsbDiskDevPathSchema,
 } from '@votingworks/usb-drive';
 import {
@@ -108,9 +107,7 @@ beforeEach(() => {
     BooleanEnvironmentVariableName.ENABLE_DEV_DOCK
   );
 
-  for (const diskName of listMockDrives()) {
-    removeMockDriveDir(diskName);
-  }
+  getMockUsbPlatform().deleteAllDrives();
   getMockFilePrinterHandler().cleanup();
 });
 
@@ -252,7 +249,7 @@ test('detects election packages on mock USB drive', async () => {
 test('skips unmounted USB drives and drives without election packages', async () => {
   const { apiClient } = setup();
 
-  // Insert and then remove a drive — should be skipped (not mounted)
+  // Insert and then remove a drive — should be skipped (not attached)
   const usbDrive = getMockFileUsbDriveHandler();
   usbDrive.insert();
   usbDrive.remove();
@@ -434,6 +431,22 @@ test('usb drive mock endpoints', async () => {
   await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
     diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
     status: 'removed',
+  });
+
+  // Removing an already-removed drive is a no-op
+  await apiClient.removeUsbDrive();
+  await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
+    diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
+    status: 'removed',
+  });
+
+  // A new dev dock instance reuses the existing simulated drive
+  await apiClient.insertUsbDrive();
+  server.close();
+  const { apiClient: secondApiClient } = setup();
+  await expect(secondApiClient.getUsbDriveStatus()).resolves.toEqual({
+    diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
+    status: 'inserted',
   });
 });
 

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -38,9 +38,7 @@ import {
 } from '@votingworks/utils';
 import { getMostRecentElectionPackageFilepath } from '@votingworks/backend';
 import {
-  addMockDrive,
-  getMockFileUsbDriveHandler,
-  listMockDrives,
+  getMockUsbPlatform,
   UsbDiskDevPath,
   UsbDiskDevPathSchema,
 } from '@votingworks/usb-drive';
@@ -258,8 +256,17 @@ interface PdiScannerSheetQueueState {
 }
 
 function buildApi(devDockDir: string, mockSpec: MockSpec) {
-  if (!listMockDrives().includes(MOCK_USB_DRIVE_DISK_NAME)) {
-    addMockDrive(MOCK_USB_DRIVE_DISK_NAME);
+  const usbPlatform = getMockUsbPlatform();
+  function findMockUsbDrive() {
+    return usbPlatform
+      .getSimulatedDrives()
+      .find((drive) => drive.diskPath === MOCK_USB_DRIVE_DEV_PATH);
+  }
+  if (!findMockUsbDrive()) {
+    usbPlatform.createDrive({
+      diskPath: MOCK_USB_DRIVE_DEV_PATH,
+      fstype: 'fat32',
+    });
   }
   const printerHandler = getMockFilePrinterHandler();
   const fujitsuPrinterHandler = getMockFileFujitsuPrinterHandler();
@@ -316,20 +323,20 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
         })
         .filter((item) => item !== undefined);
 
-      // Also scan mock USB drives for election packages
-      const usbElections = await iter(listMockDrives())
+      // Also scan attached simulated USB drives for election packages
+      const usbElections = await iter(usbPlatform.getSimulatedDrives())
         .async()
-        .filterMap(async (diskName) => {
-          const handler = getMockFileUsbDriveHandler(diskName);
-          const usbDriveStatus = handler.status();
-          if (usbDriveStatus.status !== 'mounted') return undefined;
+        .filterMap(async (drive) => {
+          if (!drive.present) return undefined;
           const result = await getMostRecentElectionPackageFilepath(
-            usbDriveStatus.mountpoint
+            usbPlatform.storagePath(drive.diskPath)
           );
           if (result.isErr()) return undefined;
           const zipPath = result.ok();
           return {
-            title: `USB ${diskName}: ${basename(dirname(dirname(zipPath)))}`,
+            title: `USB ${basename(drive.diskPath)}: ${basename(
+              dirname(dirname(zipPath))
+            )}`,
             inputPath: zipPath,
           };
         })
@@ -366,22 +373,22 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
     },
 
     getUsbDriveStatus(): DevDockUsbDriveInfo {
-      const handler = getMockFileUsbDriveHandler(MOCK_USB_DRIVE_DISK_NAME);
-      const status =
-        handler.status().status === 'mounted' ? 'inserted' : 'removed';
+      const status = findMockUsbDrive()?.present ? 'inserted' : 'removed';
       return { diskPath: MOCK_USB_DRIVE_DEV_PATH, status };
     },
 
     insertUsbDrive(): void {
-      getMockFileUsbDriveHandler(MOCK_USB_DRIVE_DISK_NAME).insert();
+      usbPlatform.insertDrive(MOCK_USB_DRIVE_DEV_PATH);
     },
 
     removeUsbDrive(): void {
-      getMockFileUsbDriveHandler(MOCK_USB_DRIVE_DISK_NAME).remove();
+      if (findMockUsbDrive()?.present) {
+        usbPlatform.removeDrive(MOCK_USB_DRIVE_DEV_PATH);
+      }
     },
 
     clearUsbDrive(): void {
-      getMockFileUsbDriveHandler(MOCK_USB_DRIVE_DISK_NAME).clearData();
+      usbPlatform.clearDriveStorage(MOCK_USB_DRIVE_DEV_PATH);
     },
 
     async saveScreenshotForApp({

--- a/libs/usb-drive/src/mocks/file_usb_drive.test.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.test.ts
@@ -1,151 +1,119 @@
-import { expect, test } from 'vitest';
+import { assertDefined } from '@votingworks/basics';
+import {
+  BooleanEnvironmentVariableName,
+  getFeatureFlagMock,
+} from '@votingworks/utils';
 import { Buffer } from 'node:buffer';
 import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { beforeEach, expect, test, vi } from 'vitest';
 import {
-  addMockDrive,
-  createMockFileMultiUsbDrive,
-  createMockFileUsbDrive,
   getMockFileUsbDriveHandler,
-  listMockDrives,
-  removeMockDriveDir,
+  getMockUsbDirPath,
+  getMockUsbPlatform,
+  getSimulatedUsbPlatform,
 } from './file_usb_drive';
-import {
-  UsbDiskDevPathSchema,
-  UsbDriveInfo,
-  UsbPartitionDevPathSchema,
-  UsbPartitionMount,
-  UsbPartitionMountpointSchema,
-} from '../types';
+import { UsbDiskDevPathSchema, UsbPartitionDevPathSchema } from '../types';
+
+const featureFlagMock = getFeatureFlagMock();
+
+vi.mock(import('@votingworks/utils'), async (importActual) => ({
+  ...(await importActual()),
+  isFeatureFlagEnabled: (flag) => featureFlagMock.isEnabled(flag),
+}));
+
+beforeEach(() => {
+  featureFlagMock.resetFeatureFlags();
+});
 
 const devsdb = UsbDiskDevPathSchema.decode('/dev/sdb');
 const devsdb1 = UsbPartitionDevPathSchema.decode('/dev/sdb1');
 
-test('createMockFileMultiUsbDrive mock flow', async () => {
-  const handler = getMockFileUsbDriveHandler('sdb');
-  const multiUsbDrive = createMockFileMultiUsbDrive();
+test('getSimulatedUsbPlatform returns undefined unless the flag is enabled', () => {
+  expect(getSimulatedUsbPlatform()).toBeUndefined();
 
-  expect(multiUsbDrive.getDrives()).toEqual([]);
-
-  await expect(multiUsbDrive.refresh()).resolves.toBeUndefined();
-  await expect(multiUsbDrive.sync(devsdb1)).resolves.toBeUndefined();
-  multiUsbDrive.stop();
-
-  handler.insert();
-  const mountpoint = handler.getDataPath();
-  expect(multiUsbDrive.getDrives()).toEqual<UsbDriveInfo[]>([
-    {
-      diskPath: devsdb,
-      partition: {
-        diskPath: devsdb,
-        partPath: devsdb1,
-        fstype: 'fat32',
-        mount: UsbPartitionMount.mounted(
-          UsbPartitionMountpointSchema.decode(mountpoint!)
-        ),
-      },
-    },
-  ]);
-
-  await multiUsbDrive.ejectDrive(devsdb);
-  expect(multiUsbDrive.getDrives()).toEqual<UsbDriveInfo[]>([
-    {
-      diskPath: devsdb,
-      partition: {
-        diskPath: devsdb,
-        partPath: devsdb1,
-        fstype: 'fat32',
-        mount: UsbPartitionMount.ejected(),
-      },
-    },
-  ]);
-
-  await multiUsbDrive.ejectDrive(devsdb);
-  expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
-    UsbPartitionMount.ejected()
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE
   );
+  const platform = assertDefined(getSimulatedUsbPlatform());
 
-  handler.insert();
-  await multiUsbDrive.formatDrive(devsdb, 'fat32');
-  expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
-    UsbPartitionMount.ejected()
-  );
-
-  handler.remove();
-  expect(multiUsbDrive.getDrives()).toEqual([]);
-
-  handler.cleanup();
+  // Backed by the same state as the mock platform used by dev tooling
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  expect(
+    getMockUsbPlatform()
+      .getSimulatedDrives()
+      .map((drive) => drive.diskPath)
+  ).toEqual([devsdb]);
 });
 
-test('createMockFileMultiUsbDrive multi-drive flow', async () => {
-  const multiUsbDrive = createMockFileMultiUsbDrive();
-
-  const diskA = addMockDrive();
-  const diskB = addMockDrive();
-  const devdiskA = UsbDiskDevPathSchema.decode(`/dev/${diskA}`);
-  const devdiskB = UsbDiskDevPathSchema.decode(`/dev/${diskB}`);
-  const handlerA = getMockFileUsbDriveHandler(diskA);
-  const handlerB = getMockFileUsbDriveHandler(diskB);
-
-  expect(multiUsbDrive.getDrives()).toEqual([]);
-
-  handlerA.insert();
-  expect(multiUsbDrive.getDrives()).toHaveLength(1);
-  expect(multiUsbDrive.getDrives()[0]?.diskPath).toEqual(devdiskA);
-
-  handlerB.insert();
-  expect(multiUsbDrive.getDrives()).toHaveLength(2);
-
-  await multiUsbDrive.ejectDrive(devdiskA);
-  const drives = multiUsbDrive.getDrives();
-  expect(drives).toHaveLength(2);
-  expect(drives.find((d) => d.diskPath === devdiskA)?.partition?.mount).toEqual(
-    UsbPartitionMount.ejected()
-  );
-  expect(drives.find((d) => d.diskPath === devdiskB)?.partition?.mount).toEqual(
-    UsbPartitionMount.mounted(expect.any(String))
-  );
-
-  handlerB.remove();
-  removeMockDriveDir(diskB);
-  expect(multiUsbDrive.getDrives()).toHaveLength(1);
-
-  handlerA.cleanup();
-
-  expect(listMockDrives()).not.toContain(diskB);
-});
-
-test('mock flow', async () => {
-  const usbDrive = createMockFileUsbDrive();
-  expect(await usbDrive.status()).toEqual({ status: 'no_drive' });
-  await expect(usbDrive.eject()).resolves.toBeUndefined();
-  await expect(usbDrive.format('fat32')).resolves.toBeUndefined();
-  expect(await usbDrive.status()).toEqual({ status: 'no_drive' });
-
+test('handler lifecycle: insert, status, remove, clearData, cleanup', async () => {
   const handler = getMockFileUsbDriveHandler();
 
-  const testFilename = 'test-file.txt';
-  handler.insert({
-    [testFilename]: Buffer.from('test file contents'),
-  });
-  const expectedMountPoint = handler.getDataPath();
-  expect(await usbDrive.status()).toMatchObject({
-    mountpoint: expectedMountPoint,
+  expect(handler.status()).toEqual({ status: 'no_drive' });
+  expect(handler.getDataPath()).toEqual(
+    join(getMockUsbDirPath(), 'storage', 'sdb')
+  );
+
+  // Insert creates the drive on first use and seeds contents
+  handler.insert({ README: Buffer.from('hello') });
+  expect(handler.status()).toEqual({ status: 'ejected' });
+  await expect(
+    readFile(join(assertDefined(handler.getDataPath()), 'README'), 'utf-8')
+  ).resolves.toEqual('hello');
+
+  // Once a consuming app mounts the partition, status reports mounted
+  const platform = getMockUsbPlatform();
+  await platform.mountPartition(devsdb1);
+  expect(handler.status()).toEqual({
     status: 'mounted',
+    mountpoint: handler.getDataPath(),
   });
 
-  expect(handler.getDataPath()).toEqual(expectedMountPoint);
-  const expectedTestFilePath = join(expectedMountPoint!, testFilename);
-  expect(existsSync(expectedTestFilePath)).toEqual(true);
-
-  await usbDrive.eject();
-  expect(await usbDrive.status()).toEqual({ status: 'ejected' });
+  // Inserting again merges contents without detaching
+  handler.insert({ OTHER: Buffer.from('world') });
+  expect(handler.status()).toMatchObject({ status: 'mounted' });
+  await expect(
+    readFile(join(assertDefined(handler.getDataPath()), 'OTHER'), 'utf-8')
+  ).resolves.toEqual('world');
 
   handler.remove();
-  expect(await usbDrive.status()).toEqual({ status: 'no_drive' });
+  expect(handler.status()).toEqual({ status: 'no_drive' });
+  // Removal preserves data, like unplugging real hardware
+  expect(
+    existsSync(join(assertDefined(handler.getDataPath()), 'README'))
+  ).toEqual(true);
 
-  expect(existsSync(expectedTestFilePath)).toEqual(true);
+  // Removing again is a no-op
+  handler.remove();
+  expect(handler.status()).toEqual({ status: 'no_drive' });
+
+  handler.clearData();
+  expect(
+    existsSync(join(assertDefined(handler.getDataPath()), 'README'))
+  ).toEqual(false);
 
   handler.cleanup();
-  expect(existsSync(expectedTestFilePath)).toEqual(false);
+  expect(getMockUsbPlatform().getSimulatedDrives()).toEqual([]);
+});
+
+test('handler clearData and cleanup are no-ops before the drive exists', () => {
+  const handler = getMockFileUsbDriveHandler();
+  handler.clearData();
+  handler.cleanup();
+  expect(handler.status()).toEqual({ status: 'no_drive' });
+});
+
+test('handlers for different disk names track separate drives', () => {
+  const sdb = getMockFileUsbDriveHandler('sdb');
+  const sdc = getMockFileUsbDriveHandler('sdc');
+
+  sdb.insert();
+  expect(sdb.status()).toEqual({ status: 'ejected' });
+  expect(sdc.status()).toEqual({ status: 'no_drive' });
+
+  sdc.insert();
+  sdb.remove();
+  expect(sdb.status()).toEqual({ status: 'no_drive' });
+  expect(sdc.status()).toEqual({ status: 'ejected' });
 });

--- a/libs/usb-drive/src/mocks/file_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.ts
@@ -1,192 +1,52 @@
-import {
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
 import { Optional } from '@votingworks/basics';
-import { getMockStateRootDir } from '@votingworks/utils';
-import { basename, join } from 'node:path';
-import type { MultiUsbDrive } from '../multi_usb_drive';
-import { MockFileTree, writeMockFileTree } from './helpers';
 import {
-  UsbDiskDevPath,
-  UsbDiskDevPathSchema,
-  UsbDrive,
-  UsbDriveFilesystemType,
-  UsbDriveInfo,
-  UsbDriveStatus,
-  UsbPartitionDevPath,
-  UsbPartitionDevPathSchema,
-  UsbPartitionMount,
-  UsbPartitionMountpoint,
-  UsbPartitionMountpointSchema,
-} from '../types';
+  BooleanEnvironmentVariableName,
+  isFeatureFlagEnabled,
+} from '@votingworks/utils';
+import { MockFileTree, writeMockFileTree } from './helpers';
+import { getMockUsbDirPath } from './mock_usb_dir';
+import {
+  SimulatedUsbDrive,
+  SimulatedUsbPlatform,
+} from './simulated_usb_platform';
+import { UsbDiskDevPath, UsbDiskDevPathSchema, UsbDriveStatus } from '../types';
 
-export const MOCK_USB_DRIVE_STATE_FILENAME = 'mock-usb-state.json';
-export const MOCK_USB_DRIVE_DATA_DIRNAME = 'mock-usb-data';
-// libs/usb-drive/src/mocks/ is 4 levels below the repo root
-const REPO_ROOT = join(__dirname, '../../../..');
-const MOCK_USB_DRIVE_DIR = join(getMockStateRootDir(REPO_ROOT), 'usb-drive');
-export const DEV_MOCK_USB_DRIVE_GLOB_PATTERN = join(MOCK_USB_DRIVE_DIR, '**/*');
-
-let mockUsbDriveDirOverride: string | undefined;
+export {
+  DEV_MOCK_USB_DRIVE_GLOB_PATTERN,
+  getMockUsbDirPath,
+  resetMockUsbDriveDir,
+  setMockUsbDriveDir,
+} from './mock_usb_dir';
 
 /**
- * Overrides the mock USB drive directory. Use in test setup to isolate
- * tests from each other when they run in parallel.
+ * Returns the {@link SimulatedUsbPlatform} backing mock USB drives in dev and
+ * test, over the shared on-disk state directory. Use this to manipulate
+ * simulated drives (e.g. from the dev dock or test helpers); use
+ * {@link getSimulatedUsbPlatform} to decide whether an app should run against
+ * simulated or real hardware.
  */
-export function setMockUsbDriveDir(dir: string): void {
-  mockUsbDriveDirOverride = dir;
+export function getMockUsbPlatform(): SimulatedUsbPlatform {
+  return new SimulatedUsbPlatform(getMockUsbDirPath());
 }
 
 /**
- * Clears the mock USB drive directory override, reverting to the default.
+ * Returns the simulated USB platform when the `USE_MOCK_USB_DRIVE` feature
+ * flag is enabled, or `undefined` to use real hardware. Pass the result to
+ * `detectUsbDrive`/`detectMultiUsbDrive`:
+ *
+ * ```ts
+ * const usbDrive = detectUsbDrive(logger, {
+ *   platform: getSimulatedUsbPlatform(),
+ * });
+ * ```
  */
-export function resetMockUsbDriveDir(): void {
-  mockUsbDriveDirOverride = undefined;
-}
-
-export function getMockUsbDirPath(): string {
-  return mockUsbDriveDirOverride ?? MOCK_USB_DRIVE_DIR;
-}
-
-function getMockDriveDirPath(diskName: string): string {
-  return join(getMockUsbDirPath(), diskName);
-}
-
-function getMockDriveDataDirPath(diskName: string): UsbPartitionMountpoint {
-  return UsbPartitionMountpointSchema.decode(
-    join(getMockDriveDirPath(diskName), MOCK_USB_DRIVE_DATA_DIRNAME)
-  );
-}
-
-type MockDriveState =
-  | { state: 'removed' }
-  | { state: 'inserted'; fstype: UsbDriveFilesystemType }
-  | { state: 'ejected'; fstype: UsbDriveFilesystemType };
-
-function readMockDriveState(diskName: string): MockDriveState {
-  const stateFilePath = join(
-    getMockDriveDirPath(diskName),
-    MOCK_USB_DRIVE_STATE_FILENAME
-  );
-  if (!existsSync(stateFilePath)) {
-    return { state: 'removed' };
+export function getSimulatedUsbPlatform(): Optional<SimulatedUsbPlatform> {
+  if (
+    !isFeatureFlagEnabled(BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE)
+  ) {
+    return undefined;
   }
-  try {
-    const raw = JSON.parse(readFileSync(stateFilePath, 'utf-8')) as {
-      state: string;
-      fstype?: UsbDriveFilesystemType;
-    };
-    if (raw.state === 'inserted' || raw.state === 'ejected') {
-      return { state: raw.state, fstype: raw.fstype ?? 'fat32' };
-    }
-    return { state: 'removed' };
-  } catch {
-    return { state: 'removed' };
-  }
-}
-
-function writeMockDriveState(diskName: string, state: MockDriveState): void {
-  const driveDir = getMockDriveDirPath(diskName);
-  mkdirSync(driveDir, { recursive: true });
-  mkdirSync(getMockDriveDataDirPath(diskName), { recursive: true });
-  writeFileSync(
-    join(driveDir, MOCK_USB_DRIVE_STATE_FILENAME),
-    JSON.stringify(state)
-  );
-}
-
-function ensureMockDriveState(diskName: string): void {
-  const stateFilePath = join(
-    getMockDriveDirPath(diskName),
-    MOCK_USB_DRIVE_STATE_FILENAME
-  );
-  if (!existsSync(stateFilePath)) {
-    writeMockDriveState(diskName, { state: 'removed' });
-  }
-}
-
-export function listMockDrives(): string[] {
-  const usbRoot = getMockUsbDirPath();
-  if (!existsSync(usbRoot)) {
-    return [];
-  }
-  return readdirSync(usbRoot)
-    .filter((name) =>
-      existsSync(join(usbRoot, name, MOCK_USB_DRIVE_STATE_FILENAME))
-    )
-    .sort();
-}
-
-function chooseFreeDiskName(): string {
-  const existing = new Set(listMockDrives());
-  for (let i = 1; i <= 25; i += 1) {
-    const name = `sd${String.fromCharCode('a'.charCodeAt(0) + i)}`;
-    if (!existing.has(name)) {
-      return name;
-    }
-  }
-  throw new Error('No available mock drive slot');
-}
-
-export function addMockDrive(name = chooseFreeDiskName()): string {
-  writeMockDriveState(name, { state: 'removed' });
-  return name;
-}
-
-export function removeMockDriveDir(diskName: string): void {
-  rmSync(getMockDriveDirPath(diskName), { recursive: true, force: true });
-}
-
-export function createMockFileUsbDrive(diskName = 'sdb'): UsbDrive {
-  return {
-    status(): Promise<UsbDriveStatus> {
-      ensureMockDriveState(diskName);
-      const { state } = readMockDriveState(diskName);
-      if (state === 'removed') {
-        return Promise.resolve({ status: 'no_drive' });
-      }
-      if (state === 'ejected') {
-        return Promise.resolve({ status: 'ejected' });
-      }
-      return Promise.resolve({
-        status: 'mounted',
-        mountpoint: getMockDriveDataDirPath(diskName),
-      });
-    },
-
-    eject(): Promise<void> {
-      ensureMockDriveState(diskName);
-      const driveState = readMockDriveState(diskName);
-      if (driveState.state === 'inserted') {
-        writeMockDriveState(diskName, {
-          state: 'ejected',
-          fstype: driveState.fstype,
-        });
-      }
-      return Promise.resolve();
-    },
-
-    format(fstype): Promise<void> {
-      ensureMockDriveState(diskName);
-      const driveState = readMockDriveState(diskName);
-      if (driveState.state === 'inserted') {
-        writeMockDriveState(diskName, {
-          state: 'ejected',
-          fstype,
-        });
-      }
-      return Promise.resolve();
-    },
-
-    sync(): Promise<void> {
-      return Promise.resolve();
-    },
-  };
+  return getMockUsbPlatform();
 }
 
 export interface MockFileUsbDriveHandler {
@@ -198,101 +58,71 @@ export interface MockFileUsbDriveHandler {
   cleanup: () => void;
 }
 
-export function createMockFileMultiUsbDrive(): MultiUsbDrive {
-  return {
-    getDrives() {
-      return listMockDrives().flatMap((diskName): UsbDriveInfo[] => {
-        const driveState = readMockDriveState(diskName);
-        if (driveState.state === 'removed') return [];
-        const mount =
-          driveState.state === 'inserted'
-            ? UsbPartitionMount.mounted(getMockDriveDataDirPath(diskName))
-            : UsbPartitionMount.ejected();
-        const diskPath = UsbDiskDevPathSchema.decode(`/dev/${diskName}`);
-        return [
-          {
-            diskPath,
-            partition: {
-              diskPath,
-              partPath: UsbPartitionDevPathSchema.decode(`/dev/${diskName}1`),
-              fstype: driveState.fstype,
-              mount,
-            },
-          },
-        ];
-      });
-    },
-
-    refresh: () => Promise.resolve(),
-
-    ejectDrive(diskPath: UsbDiskDevPath): Promise<void> {
-      const diskName = basename(diskPath);
-      const driveState = readMockDriveState(diskName);
-      if (driveState.state === 'inserted') {
-        writeMockDriveState(diskName, {
-          state: 'ejected',
-          fstype: driveState.fstype,
-        });
-      }
-      return Promise.resolve();
-    },
-
-    formatDrive(
-      diskPath: UsbDiskDevPath,
-      fstype: UsbDriveFilesystemType
-    ): Promise<void> {
-      const diskName = basename(diskPath);
-      const driveState = readMockDriveState(diskName);
-      if (driveState.state !== 'removed') {
-        writeMockDriveState(diskName, { state: 'ejected', fstype });
-      }
-      return Promise.resolve();
-    },
-
-    sync: (partPath: UsbPartitionDevPath) => {
-      void partPath;
-      return Promise.resolve();
-    },
-    stop: () => {},
-    addListener: () => {},
-    removeListener: () => {},
-  };
-}
-
+/**
+ * A convenience handler for manipulating a single simulated USB drive from
+ * dev tooling and integration tests. Backed by {@link SimulatedUsbPlatform},
+ * so apps running with `USE_MOCK_USB_DRIVE` observe the same drives.
+ *
+ * Note that, unlike the historical file-based mock, an inserted drive is
+ * mounted by the consuming app's drive detection (as with real hardware), not
+ * by insertion itself.
+ */
 export function getMockFileUsbDriveHandler(
   diskName = 'sdb'
 ): MockFileUsbDriveHandler {
-  function getDataPath(): UsbPartitionMountpoint {
-    return getMockDriveDataDirPath(diskName);
+  const platform = getMockUsbPlatform();
+  const diskPath: UsbDiskDevPath = UsbDiskDevPathSchema.decode(
+    `/dev/${diskName}`
+  );
+
+  function findDrive(): Optional<SimulatedUsbDrive> {
+    return platform
+      .getSimulatedDrives()
+      .find((drive) => drive.diskPath === diskPath);
   }
 
   return {
     status: (): UsbDriveStatus => {
-      const { state } = readMockDriveState(diskName);
-      if (state === 'removed') return { status: 'no_drive' };
-      if (state === 'ejected') return { status: 'ejected' };
-      return { status: 'mounted', mountpoint: getDataPath() };
-    },
-    insert: (contents?: MockFileTree) => {
-      if (contents) {
-        writeMockFileTree(getDataPath(), contents);
+      const drive = findDrive();
+      if (!drive?.present) {
+        return { status: 'no_drive' };
       }
-      const currentState = readMockDriveState(diskName);
-      writeMockDriveState(diskName, {
-        state: 'inserted',
-        fstype:
-          currentState.state !== 'removed' ? currentState.fstype : 'fat32',
-      });
+      const mountpoint = drive.partition?.mountpoint;
+      return mountpoint
+        ? { status: 'mounted', mountpoint }
+        : { status: 'ejected' };
     },
+
+    insert: (contents?: MockFileTree) => {
+      if (!findDrive()) {
+        platform.createDrive({ diskPath, fstype: 'fat32' });
+      }
+      if (contents) {
+        writeMockFileTree(platform.storagePath(diskPath), contents);
+      }
+      if (!findDrive()?.present) {
+        platform.insertDrive(diskPath);
+      }
+    },
+
     remove: () => {
-      writeMockDriveState(diskName, { state: 'removed' });
+      if (findDrive()?.present) {
+        platform.removeDrive(diskPath);
+      }
     },
+
     clearData: () => {
-      rmSync(getDataPath(), { recursive: true, force: true });
+      if (findDrive()) {
+        platform.clearDriveStorage(diskPath);
+      }
     },
-    getDataPath: () => getDataPath(),
+
+    getDataPath: () => platform.storagePath(diskPath),
+
     cleanup: () => {
-      rmSync(getMockDriveDirPath(diskName), { recursive: true, force: true });
+      if (findDrive()) {
+        platform.deleteDrive(diskPath);
+      }
     },
   };
 }

--- a/libs/usb-drive/src/mocks/mock_usb_dir.ts
+++ b/libs/usb-drive/src/mocks/mock_usb_dir.ts
@@ -1,0 +1,28 @@
+import { getMockStateRootDir } from '@votingworks/utils';
+import { join } from 'node:path';
+
+// libs/usb-drive/src/mocks/ is 4 levels below the repo root
+const REPO_ROOT = join(__dirname, '../../../..');
+const MOCK_USB_DRIVE_DIR = join(getMockStateRootDir(REPO_ROOT), 'usb-drive');
+export const DEV_MOCK_USB_DRIVE_GLOB_PATTERN = join(MOCK_USB_DRIVE_DIR, '**/*');
+
+let mockUsbDriveDirOverride: string | undefined;
+
+/**
+ * Overrides the mock USB drive directory. Use in test setup to isolate
+ * tests from each other when they run in parallel.
+ */
+export function setMockUsbDriveDir(dir: string): void {
+  mockUsbDriveDirOverride = dir;
+}
+
+/**
+ * Clears the mock USB drive directory override, reverting to the default.
+ */
+export function resetMockUsbDriveDir(): void {
+  mockUsbDriveDirOverride = undefined;
+}
+
+export function getMockUsbDirPath(): string {
+  return mockUsbDriveDirOverride ?? MOCK_USB_DRIVE_DIR;
+}

--- a/libs/usb-drive/src/multi_usb_drive.test.ts
+++ b/libs/usb-drive/src/multi_usb_drive.test.ts
@@ -6,7 +6,8 @@ import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
 } from '@votingworks/utils';
-import { deferred, sleep } from '@votingworks/basics';
+import { assertDefined, deferred, sleep } from '@votingworks/basics';
+import { getMockFileUsbDriveHandler } from './mocks/file_usb_drive';
 import { detectMultiUsbDrive } from './multi_usb_drive';
 import { UsbPlatform } from './usb_platform';
 import { exec } from './exec';
@@ -23,16 +24,16 @@ const MOUNT_SCRIPT_PATH = join(__dirname, '../scripts');
 
 const featureFlagMock = getFeatureFlagMock();
 
+vi.mock(import('@votingworks/utils'), async (importActual) => ({
+  ...(await importActual()),
+  isFeatureFlagEnabled: (flag) => featureFlagMock.isEnabled(flag),
+}));
+
 const devsdb = UsbDiskDevPathSchema.decode('/dev/sdb');
 const devsdb1 = UsbPartitionDevPathSchema.decode('/dev/sdb1');
 const devsdc = UsbDiskDevPathSchema.decode('/dev/sdc');
 
 type ExecResult = Awaited<ReturnType<typeof exec>>;
-
-vi.mock(import('@votingworks/utils'), async (importActual) => ({
-  ...(await importActual()),
-  isFeatureFlagEnabled: (flag) => featureFlagMock.isEnabled(flag),
-}));
 
 const execMock = vi.mocked(exec);
 const getAllUsbDrivesMock = vi.mocked(getAllDiskDevices);
@@ -91,10 +92,34 @@ function makeDisk(
   };
 }
 
-test('an explicitly injected platform takes precedence over USE_MOCK_USB_DRIVE', async () => {
+test('runs against the simulated platform when USE_MOCK_USB_DRIVE is enabled', async () => {
   featureFlagMock.enableFeatureFlag(
     BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE
   );
+  const handler = getMockFileUsbDriveHandler();
+  handler.insert();
+
+  const multiUsbDrive = detectMultiUsbDrive(mockLogger({ fn: vi.fn }));
+  try {
+    // The production state machine auto-mounts the simulated drive.
+    await vi.waitFor(
+      () => {
+        expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+          UsbPartitionMount.mounted(
+            UsbPartitionMountpointSchema.decode(
+              assertDefined(handler.getDataPath())
+            )
+          )
+        );
+      },
+      { timeout: 2000 }
+    );
+  } finally {
+    multiUsbDrive.stop();
+  }
+});
+
+test('uses an injected platform', async () => {
   const platform: UsbPlatform = {
     getDrives: () => Promise.resolve([{ diskPath: devsdb }]),
     watchChanges: () => ({ stop: () => {} }),
@@ -110,15 +135,6 @@ test('an explicitly injected platform takes precedence over USE_MOCK_USB_DRIVE',
   await multiUsbDrive.refresh();
 
   expect(multiUsbDrive.getDrives()).toEqual([{ diskPath: devsdb }]);
-  multiUsbDrive.stop();
-});
-
-test('works even when USE_MOCK_USB_DRIVE feature flag is enabled', () => {
-  featureFlagMock.enableFeatureFlag(
-    BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE
-  );
-  const multiUsbDrive = detectMultiUsbDrive(mockLogger({ fn: vi.fn }));
-  expect(multiUsbDrive.getDrives()).toEqual([]);
   multiUsbDrive.stop();
 });
 

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -15,7 +15,7 @@ import {
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
 import makeDebug from 'debug';
-import { createMockFileMultiUsbDrive } from './mocks/file_usb_drive';
+import { getMockUsbPlatform } from './mocks/file_usb_drive';
 import {
   UsbDiskDevPath,
   UsbDriveFilesystemType,
@@ -140,14 +140,11 @@ export function detectMultiUsbDrive(
 ): MultiUsbDrive {
   // An explicitly injected platform takes precedence over the ambient
   // USE_MOCK_USB_DRIVE flag.
-  if (
-    !options?.platform &&
-    isFeatureFlagEnabled(BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE)
-  ) {
-    return createMockFileMultiUsbDrive();
-  }
-
-  const platform = options?.platform ?? new RealUsbPlatform();
+  const platform =
+    options?.platform ??
+    (isFeatureFlagEnabled(BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE)
+      ? getMockUsbPlatform()
+      : new RealUsbPlatform());
   const listeners = new Set<() => void>();
 
   let stopped = false;

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -1,32 +1,13 @@
 import { mockLogger } from '@votingworks/logging';
-import {
-  BooleanEnvironmentVariableName,
-  getFeatureFlagMock,
-} from '@votingworks/utils';
-import { existsSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
 import { beforeEach, expect, test, vi } from 'vitest';
 import { UsbDiskDeviceInfo } from './block_devices';
-import {
-  getMockUsbDirPath,
-  MOCK_USB_DRIVE_STATE_FILENAME,
-} from './mocks/file_usb_drive';
 import {
   UsbDiskDevPathSchema,
   UsbPartitionDevPathSchema,
   UsbPartitionMountpointSchema,
 } from './types';
 import { detectUsbDrive } from './usb_drive';
-
-const featureFlagMock = getFeatureFlagMock();
-
-vi.mock(
-  import('@votingworks/utils'),
-  async (importActual): Promise<typeof import('@votingworks/utils')> => ({
-    ...(await importActual()),
-    isFeatureFlagEnabled: (flag) => featureFlagMock.isEnabled(flag),
-  })
-);
+import { UsbPlatform } from './usb_platform';
 
 let mockDevices: UsbDiskDeviceInfo[] = [];
 
@@ -40,27 +21,6 @@ beforeEach(() => {
   mockDevices = [];
   vi.clearAllMocks();
   vi.unstubAllEnvs();
-  featureFlagMock.resetFeatureFlags();
-});
-
-test('uses a mock file USB drive when feature flag is set', async () => {
-  featureFlagMock.enableFeatureFlag(
-    BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE
-  );
-  const stateFilePath = join(
-    getMockUsbDirPath(),
-    'sdb',
-    MOCK_USB_DRIVE_STATE_FILENAME
-  );
-
-  if (existsSync(stateFilePath)) {
-    rmSync(stateFilePath);
-  }
-  expect(existsSync(stateFilePath)).toEqual(false);
-
-  const usbDrive = detectUsbDrive(mockLogger({ fn: vi.fn }));
-  expect(await usbDrive.status()).toEqual({ status: 'no_drive' });
-  expect(existsSync(stateFilePath)).toEqual(true);
 });
 
 test('returns no_drive when no drives are connected', async () => {
@@ -95,6 +55,36 @@ test('exposes the first connected drive via the UsbDrive interface', async () =>
     expect(await usbDrive.status()).toEqual({
       status: 'mounted',
       mountpoint: '/media/vx/usb-drive-sdb1',
+    });
+  });
+});
+
+test('uses an injected platform', async () => {
+  const platform: UsbPlatform = {
+    getDrives: () =>
+      Promise.resolve([
+        {
+          diskPath: UsbDiskDevPathSchema.decode('/dev/sdz'),
+          partition: {
+            partPath: UsbPartitionDevPathSchema.decode('/dev/sdz1'),
+            fstype: 'fat32',
+            mountpoint: UsbPartitionMountpointSchema.decode('/mnt/sdz1'),
+          },
+        },
+      ]),
+    watchChanges: () => ({ stop: () => {} }),
+    mountPartition: () => Promise.resolve(),
+    unmountPartition: () => Promise.resolve(),
+    formatDrive: () => Promise.resolve(),
+    sync: () => Promise.resolve(),
+  };
+
+  const usbDrive = detectUsbDrive(mockLogger({ fn: vi.fn }), { platform });
+
+  await vi.waitFor(async () => {
+    expect(await usbDrive.status()).toEqual({
+      status: 'mounted',
+      mountpoint: '/mnt/sdz1',
     });
   });
 });

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -1,18 +1,14 @@
 import { Logger } from '@votingworks/logging';
-import {
-  BooleanEnvironmentVariableName,
-  isFeatureFlagEnabled,
-} from '@votingworks/utils';
-import { createMockFileUsbDrive } from './mocks/file_usb_drive';
 import { detectMultiUsbDrive } from './multi_usb_drive';
 import { UsbDrive } from './types';
 import { createUsbDriveAdapter } from './usb_drive_adapter';
+import { UsbPlatform } from './usb_platform';
 
-export function detectUsbDrive(logger: Logger): UsbDrive {
-  if (isFeatureFlagEnabled(BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE)) {
-    return createMockFileUsbDrive();
-  }
-  const multiUsbDrive = detectMultiUsbDrive(logger);
+export function detectUsbDrive(
+  logger: Logger,
+  options?: { platform?: UsbPlatform }
+): UsbDrive {
+  const multiUsbDrive = detectMultiUsbDrive(logger, options);
   return createUsbDriveAdapter(
     multiUsbDrive,
     (drives) => drives.find((d) => d.partition?.fstype === 'fat32')?.diskPath

--- a/libs/usb-drive/test/setup.ts
+++ b/libs/usb-drive/test/setup.ts
@@ -8,7 +8,7 @@ import { join } from 'node:path';
 import {
   resetMockUsbDriveDir,
   setMockUsbDriveDir,
-} from '../src/mocks/file_usb_drive';
+} from '../src/mocks/mock_usb_dir';
 
 beforeAll(setupTemporaryRootDir);
 afterAll(clearTemporaryRootDir);


### PR DESCRIPTION
`<🤖>`

When USE_MOCK_USB_DRIVE is enabled, `detectUsbDrive`/`detectMultiUsbDrive` now run the production drive-detection state machine over the `SimulatedUsbPlatform` instead of returning a separate hand-rolled mock implementation — so dev and integration tests exercise auto-mount, eject, and format logic for real. The dev dock and `getMockFileUsbDriveHandler` manipulate the same simulated platform state, replacing the parallel mock-usb-state.json format.

Notable semantic change: inserting a mock drive no longer implies mounted — the consuming app mounts it, as with real hardware. The handler/dev dock APIs are otherwise unchanged, so integration tests and the dev dock frontend need no updates.

`</🤖>`

## Overview

_(Part 12 of a series of PRs: [previous](https://github.com/votingworks/vxsuite/pull/8730) / [next](about:blank))_

TODO

## Demo Video or Screenshot

TODO

## Testing Plan

TODO