### PR TITLE
refactor(usb-drive): move mock-platform selection to app composition roots

### DIFF
--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -17,7 +17,11 @@ import {
   isFeatureFlagEnabled,
   isIntegrationTest,
 } from '@votingworks/utils';
-import { detectMultiUsbDrive, MultiUsbDrive } from '@votingworks/usb-drive';
+import {
+  getSimulatedUsbPlatform,
+  detectMultiUsbDrive,
+  MultiUsbDrive,
+} from '@votingworks/usb-drive';
 import {
   HP_LASER_PRINTER_CONFIG,
   Printer,
@@ -127,7 +131,8 @@ export async function start(options: StartOptions = {}): Promise<Server> {
         () => getUserRole(auth, workspace.store)
       );
       const multiUsbDrive =
-        options.multiUsbDrive ?? detectMultiUsbDrive(logger);
+        options.multiUsbDrive ??
+        detectMultiUsbDrive(logger, { platform: getSimulatedUsbPlatform() });
       const printer = options.printer ?? detectPrinter(logger);
 
       // Release any stale ballot claims from this host machine left over
@@ -211,7 +216,8 @@ export async function start(options: StartOptions = {}): Promise<Server> {
       );
 
       const multiUsbDrive =
-        options.multiUsbDrive ?? detectMultiUsbDrive(logger);
+        options.multiUsbDrive ??
+        detectMultiUsbDrive(logger, { platform: getSimulatedUsbPlatform() });
 
       startClientNetworking({
         machineId: getMachineConfig().machineId,

--- a/apps/central-scan/backend/src/server.ts
+++ b/apps/central-scan/backend/src/server.ts
@@ -13,7 +13,11 @@ import {
   isFeatureFlagEnabled,
   isIntegrationTest,
 } from '@votingworks/utils';
-import { UsbDrive, detectUsbDrive } from '@votingworks/usb-drive';
+import {
+  getSimulatedUsbPlatform,
+  UsbDrive,
+  detectUsbDrive,
+} from '@votingworks/usb-drive';
 import { detectDevices, startCpuMetricsLogging } from '@votingworks/backend';
 import {
   DEFAULT_DEV_DOCK_DIR,
@@ -127,7 +131,9 @@ export function start({
         logger,
       });
 
-    const resolvedUsbDrive = usbDrive ?? detectUsbDrive(logger);
+    const resolvedUsbDrive =
+      usbDrive ??
+      detectUsbDrive(logger, { platform: getSimulatedUsbPlatform() });
 
     resolvedApp = buildCentralScannerApp({
       auth,

--- a/apps/mark-scan/backend/src/index.ts
+++ b/apps/mark-scan/backend/src/index.ts
@@ -10,7 +10,10 @@ import {
   Logger,
   LogSource,
 } from '@votingworks/logging';
-import { detectUsbDrive } from '@votingworks/usb-drive';
+import {
+  getSimulatedUsbPlatform,
+  detectUsbDrive,
+} from '@votingworks/usb-drive';
 import {
   BooleanEnvironmentVariableName,
   isFeatureFlagEnabled,
@@ -57,7 +60,9 @@ async function main(): Promise<number> {
   ) {
     const { auth, card } = getDefaultAuth(baseLogger);
     const logger = Logger.from(baseLogger, () => getUserRole(auth, workspace));
-    const usbDrive = detectUsbDrive(logger);
+    const usbDrive = detectUsbDrive(logger, {
+      platform: getSimulatedUsbPlatform(),
+    });
     startElectricalTestingServer({
       card,
       cardReaderErrorTracker: new CardReaderErrorTracker(),

--- a/apps/mark-scan/backend/src/server.ts
+++ b/apps/mark-scan/backend/src/server.ts
@@ -12,7 +12,10 @@ import {
   BooleanEnvironmentVariableName,
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
-import { detectUsbDrive } from '@votingworks/usb-drive';
+import {
+  getSimulatedUsbPlatform,
+  detectUsbDrive,
+} from '@votingworks/usb-drive';
 import {
   detectDevices,
   initializeSystemAudio,
@@ -110,7 +113,9 @@ export async function start({
     });
   }
 
-  const usbDrive = detectUsbDrive(logger);
+  const usbDrive = detectUsbDrive(logger, {
+    platform: getSimulatedUsbPlatform(),
+  });
 
   await initializeSystemAudio();
 

--- a/apps/mark/backend/src/index.ts
+++ b/apps/mark/backend/src/index.ts
@@ -11,7 +11,10 @@ import {
   loadEnvVarsFromDotenvFiles,
   TaskController,
 } from '@votingworks/backend';
-import { detectUsbDrive } from '@votingworks/usb-drive';
+import {
+  getSimulatedUsbPlatform,
+  detectUsbDrive,
+} from '@votingworks/usb-drive';
 import { detectPrinter } from '@votingworks/printing';
 import {
   BooleanEnvironmentVariableName,
@@ -65,7 +68,9 @@ async function main(): Promise<number> {
   ) {
     const { auth, card } = getDefaultAuth(baseLogger);
     const logger = Logger.from(baseLogger, () => getUserRole(auth, workspace));
-    const usbDrive = detectUsbDrive(logger);
+    const usbDrive = detectUsbDrive(logger, {
+      platform: getSimulatedUsbPlatform(),
+    });
     const printer = detectPrinter(logger);
     const useMockBarcode = isFeatureFlagEnabled(
       BooleanEnvironmentVariableName.USE_MOCK_BARCODE_READER

--- a/apps/mark/backend/src/server.ts
+++ b/apps/mark/backend/src/server.ts
@@ -2,7 +2,10 @@ import express from 'express';
 import { Server } from 'node:http';
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import { LogEventId, BaseLogger, Logger } from '@votingworks/logging';
-import { detectUsbDrive } from '@votingworks/usb-drive';
+import {
+  getSimulatedUsbPlatform,
+  detectUsbDrive,
+} from '@votingworks/usb-drive';
 import { startCpuMetricsLogging } from '@votingworks/backend';
 import { detectPrinter, HP_LASER_PRINTER_CONFIG } from '@votingworks/printing';
 import { useDevDockRouter } from '@votingworks/dev-dock-backend';
@@ -50,7 +53,9 @@ export async function start({
     baseLogger,
     /* istanbul ignore next */ () => getUserRole(resolvedAuth, workspace)
   );
-  const usbDrive = detectUsbDrive(logger);
+  const usbDrive = detectUsbDrive(logger, {
+    platform: getSimulatedUsbPlatform(),
+  });
   const printer = detectPrinter(logger);
 
   // Skip creating real barcode client when mock barcode is enabled

--- a/apps/pollbook/backend/src/index.ts
+++ b/apps/pollbook/backend/src/index.ts
@@ -3,7 +3,10 @@
 import { resolve } from 'node:path';
 import { loadEnvVarsFromDotenvFiles } from '@votingworks/backend';
 import { BaseLogger, Logger, LogSource } from '@votingworks/logging';
-import { detectUsbDrive } from '@votingworks/usb-drive';
+import {
+  getSimulatedUsbPlatform,
+  detectUsbDrive,
+} from '@votingworks/usb-drive';
 import {
   isFeatureFlagEnabled,
   BooleanEnvironmentVariableName,
@@ -54,7 +57,9 @@ function main(): Promise<number> {
   const codeVersion = process.env.VX_CODE_VERSION || 'dev';
 
   const logger = Logger.from(baseLogger, () => Promise.resolve('system'));
-  const usbDrive = detectUsbDrive(logger);
+  const usbDrive = detectUsbDrive(logger, {
+    platform: getSimulatedUsbPlatform(),
+  });
   const printer = detectPrinter(logger);
   const peerWorkspace = createPeerWorkspace(
     workspacePath,

--- a/apps/print/backend/src/server.ts
+++ b/apps/print/backend/src/server.ts
@@ -1,7 +1,10 @@
 import express from 'express';
 import { BaseLogger, Logger, LogEventId } from '@votingworks/logging';
 import { DippedSmartCardAuthApi } from '@votingworks/auth';
-import { detectUsbDrive } from '@votingworks/usb-drive';
+import {
+  getSimulatedUsbPlatform,
+  detectUsbDrive,
+} from '@votingworks/usb-drive';
 import { useDevDockRouter } from '@votingworks/dev-dock-backend';
 import { detectPrinter, HP_LASER_PRINTER_CONFIG } from '@votingworks/printing';
 import { startCpuMetricsLogging } from '@votingworks/backend';
@@ -25,10 +28,11 @@ export function start({ auth, baseLogger, workspace }: StartOptions): void {
   const resolvedAuth = auth ?? getDefaultAuth(baseLogger);
   const logger = Logger.from(
     baseLogger,
-    /* istanbul ignore next */ () =>
-      getUserRole(resolvedAuth, workspace)
+    /* istanbul ignore next */ () => getUserRole(resolvedAuth, workspace)
   );
-  const usbDrive = detectUsbDrive(logger);
+  const usbDrive = detectUsbDrive(logger, {
+    platform: getSimulatedUsbPlatform(),
+  });
   const printer = detectPrinter(logger);
 
   const context: AppContext = {

--- a/apps/scan/backend/src/index.ts
+++ b/apps/scan/backend/src/index.ts
@@ -5,7 +5,10 @@ import {
   Logger,
   LogSource,
 } from '@votingworks/logging';
-import { detectUsbDrive } from '@votingworks/usb-drive';
+import {
+  getSimulatedUsbPlatform,
+  detectUsbDrive,
+} from '@votingworks/usb-drive';
 import {
   InsertedSmartCardAuth,
   JavaCard,
@@ -72,7 +75,9 @@ async function main(): Promise<number> {
   });
   const workspace = resolveWorkspace();
   const logger = Logger.from(baseLogger, () => getUserRole(auth, workspace));
-  const usbDrive = detectUsbDrive(logger);
+  const usbDrive = detectUsbDrive(logger, {
+    platform: getSimulatedUsbPlatform(),
+  });
   const printer = getFujitsuThermalPrinter(logger);
 
   if (

--- a/apps/scan/backend/src/server.ts
+++ b/apps/scan/backend/src/server.ts
@@ -1,7 +1,11 @@
 import express from 'express';
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import { LogEventId, Logger } from '@votingworks/logging';
-import { UsbDrive, detectUsbDrive } from '@votingworks/usb-drive';
+import {
+  getSimulatedUsbPlatform,
+  UsbDrive,
+  detectUsbDrive,
+} from '@votingworks/usb-drive';
 import { detectDevices, startCpuMetricsLogging } from '@votingworks/backend';
 import { useDevDockRouter } from '@votingworks/dev-dock-backend';
 import {
@@ -50,7 +54,8 @@ export async function start({
   audioPlayer,
 }: StartOptions): Promise<void> {
   detectDevices({ logger });
-  const resolvedUsbDrive = usbDrive ?? detectUsbDrive(logger);
+  const resolvedUsbDrive =
+    usbDrive ?? detectUsbDrive(logger, { platform: getSimulatedUsbPlatform() });
   const resolvedPrinter = printer ?? getFujitsuThermalPrinter(logger);
 
   // TODO: We can likely consolidate on the file-based mock scanner in all

--- a/libs/dev-dock/backend/src/dev_dock_api.test.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.test.ts
@@ -46,8 +46,7 @@ import {
 import { createMockPdiScanner } from '@votingworks/pdi-scanner';
 import {
   getMockFileUsbDriveHandler,
-  listMockDrives,
-  removeMockDriveDir,
+  getMockUsbPlatform,
   UsbDiskDevPathSchema,
 } from '@votingworks/usb-drive';
 import {
@@ -108,9 +107,7 @@ beforeEach(() => {
     BooleanEnvironmentVariableName.ENABLE_DEV_DOCK
   );
 
-  for (const diskName of listMockDrives()) {
-    removeMockDriveDir(diskName);
-  }
+  getMockUsbPlatform().deleteAllDrives();
   getMockFilePrinterHandler().cleanup();
 });
 
@@ -248,7 +245,7 @@ test('detects election packages on mock USB drive', async () => {
 test('skips unmounted USB drives and drives without election packages', async () => {
   const { apiClient } = setup();
 
-  // Insert and then remove a drive — should be skipped (not mounted)
+  // Insert and then remove a drive — should be skipped (not attached)
   const usbDrive = getMockFileUsbDriveHandler();
   usbDrive.insert();
   usbDrive.remove();
@@ -430,6 +427,22 @@ test('usb drive mock endpoints', async () => {
   await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
     diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
     status: 'removed',
+  });
+
+  // Removing an already-removed drive is a no-op
+  await apiClient.removeUsbDrive();
+  await expect(apiClient.getUsbDriveStatus()).resolves.toEqual({
+    diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
+    status: 'removed',
+  });
+
+  // A new dev dock instance reuses the existing simulated drive
+  await apiClient.insertUsbDrive();
+  server.close();
+  const { apiClient: secondApiClient } = setup();
+  await expect(secondApiClient.getUsbDriveStatus()).resolves.toEqual({
+    diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
+    status: 'inserted',
   });
 });
 

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -38,9 +38,7 @@ import {
 } from '@votingworks/utils';
 import { getMostRecentElectionPackageFilepath } from '@votingworks/backend';
 import {
-  addMockDrive,
-  getMockFileUsbDriveHandler,
-  listMockDrives,
+  getMockUsbPlatform,
   UsbDiskDevPath,
   UsbDiskDevPathSchema,
 } from '@votingworks/usb-drive';
@@ -258,8 +256,17 @@ interface PdiScannerSheetQueueState {
 }
 
 function buildApi(devDockDir: string, mockSpec: MockSpec) {
-  if (!listMockDrives().includes(MOCK_USB_DRIVE_DISK_NAME)) {
-    addMockDrive(MOCK_USB_DRIVE_DISK_NAME);
+  const usbPlatform = getMockUsbPlatform();
+  function findMockUsbDrive() {
+    return usbPlatform
+      .getSimulatedDrives()
+      .find((drive) => drive.diskPath === MOCK_USB_DRIVE_DEV_PATH);
+  }
+  if (!findMockUsbDrive()) {
+    usbPlatform.createDrive({
+      diskPath: MOCK_USB_DRIVE_DEV_PATH,
+      fstype: 'fat32',
+    });
   }
   const printerHandler = getMockFilePrinterHandler();
   const fujitsuPrinterHandler = getMockFileFujitsuPrinterHandler();
@@ -316,20 +323,20 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
         })
         .filter((item) => item !== undefined);
 
-      // Also scan mock USB drives for election packages
-      const usbElections = await iter(listMockDrives())
+      // Also scan attached simulated USB drives for election packages
+      const usbElections = await iter(usbPlatform.getSimulatedDrives())
         .async()
-        .filterMap(async (diskName) => {
-          const handler = getMockFileUsbDriveHandler(diskName);
-          const usbDriveStatus = handler.status();
-          if (usbDriveStatus.status !== 'mounted') return undefined;
+        .filterMap(async (drive) => {
+          if (!drive.present) return undefined;
           const result = await getMostRecentElectionPackageFilepath(
-            usbDriveStatus.mountpoint
+            usbPlatform.storagePath(drive.diskPath)
           );
           if (result.isErr()) return undefined;
           const zipPath = result.ok();
           return {
-            title: `USB ${diskName}: ${basename(dirname(dirname(zipPath)))}`,
+            title: `USB ${basename(drive.diskPath)}: ${basename(
+              dirname(dirname(zipPath))
+            )}`,
             inputPath: zipPath,
           };
         })
@@ -366,22 +373,22 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
     },
 
     getUsbDriveStatus(): DevDockUsbDriveInfo {
-      const handler = getMockFileUsbDriveHandler(MOCK_USB_DRIVE_DISK_NAME);
-      const status =
-        handler.status().status === 'mounted' ? 'inserted' : 'removed';
+      const status = findMockUsbDrive()?.present ? 'inserted' : 'removed';
       return { diskPath: MOCK_USB_DRIVE_DEV_PATH, status };
     },
 
     insertUsbDrive(): void {
-      getMockFileUsbDriveHandler(MOCK_USB_DRIVE_DISK_NAME).insert();
+      usbPlatform.insertDrive(MOCK_USB_DRIVE_DEV_PATH);
     },
 
     removeUsbDrive(): void {
-      getMockFileUsbDriveHandler(MOCK_USB_DRIVE_DISK_NAME).remove();
+      if (findMockUsbDrive()?.present) {
+        usbPlatform.removeDrive(MOCK_USB_DRIVE_DEV_PATH);
+      }
     },
 
     clearUsbDrive(): void {
-      getMockFileUsbDriveHandler(MOCK_USB_DRIVE_DISK_NAME).clearData();
+      usbPlatform.clearDriveStorage(MOCK_USB_DRIVE_DEV_PATH);
     },
 
     async saveScreenshotForApp({

--- a/libs/usb-drive/src/index.ts
+++ b/libs/usb-drive/src/index.ts
@@ -3,6 +3,7 @@ export * from './media_mount_dir';
 export * from './mocks/memory_usb_drive';
 export * from './mocks/mock_multi_usb_drive';
 export * from './mocks/file_usb_drive';
+export * from './mocks/simulated_usb_platform';
 export * from './multi_usb_drive';
 export * from './types';
 export * from './usb_drive';

--- a/libs/usb-drive/src/mocks/file_usb_drive.test.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.test.ts
@@ -1,151 +1,119 @@
-import { expect, test } from 'vitest';
+import { assertDefined } from '@votingworks/basics';
+import {
+  BooleanEnvironmentVariableName,
+  getFeatureFlagMock,
+} from '@votingworks/utils';
 import { Buffer } from 'node:buffer';
 import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { beforeEach, expect, test, vi } from 'vitest';
 import {
-  addMockDrive,
-  createMockFileMultiUsbDrive,
-  createMockFileUsbDrive,
   getMockFileUsbDriveHandler,
-  listMockDrives,
-  removeMockDriveDir,
+  getMockUsbDirPath,
+  getMockUsbPlatform,
+  getSimulatedUsbPlatform,
 } from './file_usb_drive';
-import {
-  UsbDiskDevPathSchema,
-  UsbDriveInfo,
-  UsbPartitionDevPathSchema,
-  UsbPartitionMount,
-  UsbPartitionMountpointSchema,
-} from '../types';
+import { UsbDiskDevPathSchema, UsbPartitionDevPathSchema } from '../types';
+
+const featureFlagMock = getFeatureFlagMock();
+
+vi.mock(import('@votingworks/utils'), async (importActual) => ({
+  ...(await importActual()),
+  isFeatureFlagEnabled: (flag) => featureFlagMock.isEnabled(flag),
+}));
+
+beforeEach(() => {
+  featureFlagMock.resetFeatureFlags();
+});
 
 const devsdb = UsbDiskDevPathSchema.decode('/dev/sdb');
 const devsdb1 = UsbPartitionDevPathSchema.decode('/dev/sdb1');
 
-test('createMockFileMultiUsbDrive mock flow', async () => {
-  const handler = getMockFileUsbDriveHandler('sdb');
-  const multiUsbDrive = createMockFileMultiUsbDrive();
+test('getSimulatedUsbPlatform returns undefined unless the flag is enabled', () => {
+  expect(getSimulatedUsbPlatform()).toBeUndefined();
 
-  expect(multiUsbDrive.getDrives()).toEqual([]);
-
-  await expect(multiUsbDrive.refresh()).resolves.toBeUndefined();
-  await expect(multiUsbDrive.sync(devsdb1)).resolves.toBeUndefined();
-  multiUsbDrive.stop();
-
-  handler.insert();
-  const mountpoint = handler.getDataPath();
-  expect(multiUsbDrive.getDrives()).toEqual<UsbDriveInfo[]>([
-    {
-      diskPath: devsdb,
-      partition: {
-        diskPath: devsdb,
-        partPath: devsdb1,
-        fstype: 'fat32',
-        mount: UsbPartitionMount.mounted(
-          UsbPartitionMountpointSchema.decode(mountpoint!)
-        ),
-      },
-    },
-  ]);
-
-  await multiUsbDrive.ejectDrive(devsdb);
-  expect(multiUsbDrive.getDrives()).toEqual<UsbDriveInfo[]>([
-    {
-      diskPath: devsdb,
-      partition: {
-        diskPath: devsdb,
-        partPath: devsdb1,
-        fstype: 'fat32',
-        mount: UsbPartitionMount.ejected(),
-      },
-    },
-  ]);
-
-  await multiUsbDrive.ejectDrive(devsdb);
-  expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
-    UsbPartitionMount.ejected()
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE
   );
+  const platform = assertDefined(getSimulatedUsbPlatform());
 
-  handler.insert();
-  await multiUsbDrive.formatDrive(devsdb, 'fat32');
-  expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
-    UsbPartitionMount.ejected()
-  );
-
-  handler.remove();
-  expect(multiUsbDrive.getDrives()).toEqual([]);
-
-  handler.cleanup();
+  // Backed by the same state as the mock platform used by dev tooling
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  expect(
+    getMockUsbPlatform()
+      .getSimulatedDrives()
+      .map((drive) => drive.diskPath)
+  ).toEqual([devsdb]);
 });
 
-test('createMockFileMultiUsbDrive multi-drive flow', async () => {
-  const multiUsbDrive = createMockFileMultiUsbDrive();
-
-  const diskA = addMockDrive();
-  const diskB = addMockDrive();
-  const devdiskA = UsbDiskDevPathSchema.decode(`/dev/${diskA}`);
-  const devdiskB = UsbDiskDevPathSchema.decode(`/dev/${diskB}`);
-  const handlerA = getMockFileUsbDriveHandler(diskA);
-  const handlerB = getMockFileUsbDriveHandler(diskB);
-
-  expect(multiUsbDrive.getDrives()).toEqual([]);
-
-  handlerA.insert();
-  expect(multiUsbDrive.getDrives()).toHaveLength(1);
-  expect(multiUsbDrive.getDrives()[0]?.diskPath).toEqual(devdiskA);
-
-  handlerB.insert();
-  expect(multiUsbDrive.getDrives()).toHaveLength(2);
-
-  await multiUsbDrive.ejectDrive(devdiskA);
-  const drives = multiUsbDrive.getDrives();
-  expect(drives).toHaveLength(2);
-  expect(drives.find((d) => d.diskPath === devdiskA)?.partition?.mount).toEqual(
-    UsbPartitionMount.ejected()
-  );
-  expect(drives.find((d) => d.diskPath === devdiskB)?.partition?.mount).toEqual(
-    UsbPartitionMount.mounted(expect.any(String))
-  );
-
-  handlerB.remove();
-  removeMockDriveDir(diskB);
-  expect(multiUsbDrive.getDrives()).toHaveLength(1);
-
-  handlerA.cleanup();
-
-  expect(listMockDrives()).not.toContain(diskB);
-});
-
-test('mock flow', async () => {
-  const usbDrive = createMockFileUsbDrive();
-  expect(await usbDrive.status()).toEqual({ status: 'no_drive' });
-  await expect(usbDrive.eject()).resolves.toBeUndefined();
-  await expect(usbDrive.format('fat32')).resolves.toBeUndefined();
-  expect(await usbDrive.status()).toEqual({ status: 'no_drive' });
-
+test('handler lifecycle: insert, status, remove, clearData, cleanup', async () => {
   const handler = getMockFileUsbDriveHandler();
 
-  const testFilename = 'test-file.txt';
-  handler.insert({
-    [testFilename]: Buffer.from('test file contents'),
-  });
-  const expectedMountPoint = handler.getDataPath();
-  expect(await usbDrive.status()).toMatchObject({
-    mountpoint: expectedMountPoint,
+  expect(handler.status()).toEqual({ status: 'no_drive' });
+  expect(handler.getDataPath()).toEqual(
+    join(getMockUsbDirPath(), 'storage', 'sdb')
+  );
+
+  // Insert creates the drive on first use and seeds contents
+  handler.insert({ README: Buffer.from('hello') });
+  expect(handler.status()).toEqual({ status: 'ejected' });
+  await expect(
+    readFile(join(assertDefined(handler.getDataPath()), 'README'), 'utf-8')
+  ).resolves.toEqual('hello');
+
+  // Once a consuming app mounts the partition, status reports mounted
+  const platform = getMockUsbPlatform();
+  await platform.mountPartition(devsdb1);
+  expect(handler.status()).toEqual({
     status: 'mounted',
+    mountpoint: handler.getDataPath(),
   });
 
-  expect(handler.getDataPath()).toEqual(expectedMountPoint);
-  const expectedTestFilePath = join(expectedMountPoint!, testFilename);
-  expect(existsSync(expectedTestFilePath)).toEqual(true);
-
-  await usbDrive.eject();
-  expect(await usbDrive.status()).toEqual({ status: 'ejected' });
+  // Inserting again merges contents without detaching
+  handler.insert({ OTHER: Buffer.from('world') });
+  expect(handler.status()).toMatchObject({ status: 'mounted' });
+  await expect(
+    readFile(join(assertDefined(handler.getDataPath()), 'OTHER'), 'utf-8')
+  ).resolves.toEqual('world');
 
   handler.remove();
-  expect(await usbDrive.status()).toEqual({ status: 'no_drive' });
+  expect(handler.status()).toEqual({ status: 'no_drive' });
+  // Removal preserves data, like unplugging real hardware
+  expect(
+    existsSync(join(assertDefined(handler.getDataPath()), 'README'))
+  ).toEqual(true);
 
-  expect(existsSync(expectedTestFilePath)).toEqual(true);
+  // Removing again is a no-op
+  handler.remove();
+  expect(handler.status()).toEqual({ status: 'no_drive' });
+
+  handler.clearData();
+  expect(
+    existsSync(join(assertDefined(handler.getDataPath()), 'README'))
+  ).toEqual(false);
 
   handler.cleanup();
-  expect(existsSync(expectedTestFilePath)).toEqual(false);
+  expect(getMockUsbPlatform().getSimulatedDrives()).toEqual([]);
+});
+
+test('handler clearData and cleanup are no-ops before the drive exists', () => {
+  const handler = getMockFileUsbDriveHandler();
+  handler.clearData();
+  handler.cleanup();
+  expect(handler.status()).toEqual({ status: 'no_drive' });
+});
+
+test('handlers for different disk names track separate drives', () => {
+  const sdb = getMockFileUsbDriveHandler('sdb');
+  const sdc = getMockFileUsbDriveHandler('sdc');
+
+  sdb.insert();
+  expect(sdb.status()).toEqual({ status: 'ejected' });
+  expect(sdc.status()).toEqual({ status: 'no_drive' });
+
+  sdc.insert();
+  sdb.remove();
+  expect(sdb.status()).toEqual({ status: 'no_drive' });
+  expect(sdc.status()).toEqual({ status: 'ejected' });
 });

--- a/libs/usb-drive/src/mocks/file_usb_drive.ts
+++ b/libs/usb-drive/src/mocks/file_usb_drive.ts
@@ -1,192 +1,52 @@
-import {
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
 import { Optional } from '@votingworks/basics';
-import { getMockStateRootDir } from '@votingworks/utils';
-import { basename, join } from 'node:path';
-import type { MultiUsbDrive } from '../multi_usb_drive';
-import { MockFileTree, writeMockFileTree } from './helpers';
 import {
-  UsbDiskDevPath,
-  UsbDiskDevPathSchema,
-  UsbDrive,
-  UsbDriveFilesystemType,
-  UsbDriveInfo,
-  UsbDriveStatus,
-  UsbPartitionDevPath,
-  UsbPartitionDevPathSchema,
-  UsbPartitionMount,
-  UsbPartitionMountpoint,
-  UsbPartitionMountpointSchema,
-} from '../types';
+  BooleanEnvironmentVariableName,
+  isFeatureFlagEnabled,
+} from '@votingworks/utils';
+import { MockFileTree, writeMockFileTree } from './helpers';
+import { getMockUsbDirPath } from './mock_usb_dir';
+import {
+  SimulatedUsbDrive,
+  SimulatedUsbPlatform,
+} from './simulated_usb_platform';
+import { UsbDiskDevPath, UsbDiskDevPathSchema, UsbDriveStatus } from '../types';
 
-export const MOCK_USB_DRIVE_STATE_FILENAME = 'mock-usb-state.json';
-export const MOCK_USB_DRIVE_DATA_DIRNAME = 'mock-usb-data';
-// libs/usb-drive/src/mocks/ is 4 levels below the repo root
-const REPO_ROOT = join(__dirname, '../../../..');
-const MOCK_USB_DRIVE_DIR = join(getMockStateRootDir(REPO_ROOT), 'usb-drive');
-export const DEV_MOCK_USB_DRIVE_GLOB_PATTERN = join(MOCK_USB_DRIVE_DIR, '**/*');
-
-let mockUsbDriveDirOverride: string | undefined;
+export {
+  DEV_MOCK_USB_DRIVE_GLOB_PATTERN,
+  getMockUsbDirPath,
+  resetMockUsbDriveDir,
+  setMockUsbDriveDir,
+} from './mock_usb_dir';
 
 /**
- * Overrides the mock USB drive directory. Use in test setup to isolate
- * tests from each other when they run in parallel.
+ * Returns the {@link SimulatedUsbPlatform} backing mock USB drives in dev and
+ * test, over the shared on-disk state directory. Use this to manipulate
+ * simulated drives (e.g. from the dev dock or test helpers); use
+ * {@link getSimulatedUsbPlatform} to decide whether an app should run against
+ * simulated or real hardware.
  */
-export function setMockUsbDriveDir(dir: string): void {
-  mockUsbDriveDirOverride = dir;
+export function getMockUsbPlatform(): SimulatedUsbPlatform {
+  return new SimulatedUsbPlatform(getMockUsbDirPath());
 }
 
 /**
- * Clears the mock USB drive directory override, reverting to the default.
+ * Returns the simulated USB platform when the `USE_MOCK_USB_DRIVE` feature
+ * flag is enabled, or `undefined` to use real hardware. Pass the result to
+ * `detectUsbDrive`/`detectMultiUsbDrive`:
+ *
+ * ```ts
+ * const usbDrive = detectUsbDrive(logger, {
+ *   platform: getSimulatedUsbPlatform(),
+ * });
+ * ```
  */
-export function resetMockUsbDriveDir(): void {
-  mockUsbDriveDirOverride = undefined;
-}
-
-export function getMockUsbDirPath(): string {
-  return mockUsbDriveDirOverride ?? MOCK_USB_DRIVE_DIR;
-}
-
-function getMockDriveDirPath(diskName: string): string {
-  return join(getMockUsbDirPath(), diskName);
-}
-
-function getMockDriveDataDirPath(diskName: string): UsbPartitionMountpoint {
-  return UsbPartitionMountpointSchema.decode(
-    join(getMockDriveDirPath(diskName), MOCK_USB_DRIVE_DATA_DIRNAME)
-  );
-}
-
-type MockDriveState =
-  | { state: 'removed' }
-  | { state: 'inserted'; fstype: UsbDriveFilesystemType }
-  | { state: 'ejected'; fstype: UsbDriveFilesystemType };
-
-function readMockDriveState(diskName: string): MockDriveState {
-  const stateFilePath = join(
-    getMockDriveDirPath(diskName),
-    MOCK_USB_DRIVE_STATE_FILENAME
-  );
-  if (!existsSync(stateFilePath)) {
-    return { state: 'removed' };
+export function getSimulatedUsbPlatform(): Optional<SimulatedUsbPlatform> {
+  if (
+    !isFeatureFlagEnabled(BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE)
+  ) {
+    return undefined;
   }
-  try {
-    const raw = JSON.parse(readFileSync(stateFilePath, 'utf-8')) as {
-      state: string;
-      fstype?: UsbDriveFilesystemType;
-    };
-    if (raw.state === 'inserted' || raw.state === 'ejected') {
-      return { state: raw.state, fstype: raw.fstype ?? 'fat32' };
-    }
-    return { state: 'removed' };
-  } catch {
-    return { state: 'removed' };
-  }
-}
-
-function writeMockDriveState(diskName: string, state: MockDriveState): void {
-  const driveDir = getMockDriveDirPath(diskName);
-  mkdirSync(driveDir, { recursive: true });
-  mkdirSync(getMockDriveDataDirPath(diskName), { recursive: true });
-  writeFileSync(
-    join(driveDir, MOCK_USB_DRIVE_STATE_FILENAME),
-    JSON.stringify(state)
-  );
-}
-
-function ensureMockDriveState(diskName: string): void {
-  const stateFilePath = join(
-    getMockDriveDirPath(diskName),
-    MOCK_USB_DRIVE_STATE_FILENAME
-  );
-  if (!existsSync(stateFilePath)) {
-    writeMockDriveState(diskName, { state: 'removed' });
-  }
-}
-
-export function listMockDrives(): string[] {
-  const usbRoot = getMockUsbDirPath();
-  if (!existsSync(usbRoot)) {
-    return [];
-  }
-  return readdirSync(usbRoot)
-    .filter((name) =>
-      existsSync(join(usbRoot, name, MOCK_USB_DRIVE_STATE_FILENAME))
-    )
-    .sort();
-}
-
-function chooseFreeDiskName(): string {
-  const existing = new Set(listMockDrives());
-  for (let i = 1; i <= 25; i += 1) {
-    const name = `sd${String.fromCharCode('a'.charCodeAt(0) + i)}`;
-    if (!existing.has(name)) {
-      return name;
-    }
-  }
-  throw new Error('No available mock drive slot');
-}
-
-export function addMockDrive(name = chooseFreeDiskName()): string {
-  writeMockDriveState(name, { state: 'removed' });
-  return name;
-}
-
-export function removeMockDriveDir(diskName: string): void {
-  rmSync(getMockDriveDirPath(diskName), { recursive: true, force: true });
-}
-
-export function createMockFileUsbDrive(diskName = 'sdb'): UsbDrive {
-  return {
-    status(): Promise<UsbDriveStatus> {
-      ensureMockDriveState(diskName);
-      const { state } = readMockDriveState(diskName);
-      if (state === 'removed') {
-        return Promise.resolve({ status: 'no_drive' });
-      }
-      if (state === 'ejected') {
-        return Promise.resolve({ status: 'ejected' });
-      }
-      return Promise.resolve({
-        status: 'mounted',
-        mountpoint: getMockDriveDataDirPath(diskName),
-      });
-    },
-
-    eject(): Promise<void> {
-      ensureMockDriveState(diskName);
-      const driveState = readMockDriveState(diskName);
-      if (driveState.state === 'inserted') {
-        writeMockDriveState(diskName, {
-          state: 'ejected',
-          fstype: driveState.fstype,
-        });
-      }
-      return Promise.resolve();
-    },
-
-    format(fstype): Promise<void> {
-      ensureMockDriveState(diskName);
-      const driveState = readMockDriveState(diskName);
-      if (driveState.state === 'inserted') {
-        writeMockDriveState(diskName, {
-          state: 'ejected',
-          fstype,
-        });
-      }
-      return Promise.resolve();
-    },
-
-    sync(): Promise<void> {
-      return Promise.resolve();
-    },
-  };
+  return getMockUsbPlatform();
 }
 
 export interface MockFileUsbDriveHandler {
@@ -198,101 +58,71 @@ export interface MockFileUsbDriveHandler {
   cleanup: () => void;
 }
 
-export function createMockFileMultiUsbDrive(): MultiUsbDrive {
-  return {
-    getDrives() {
-      return listMockDrives().flatMap((diskName): UsbDriveInfo[] => {
-        const driveState = readMockDriveState(diskName);
-        if (driveState.state === 'removed') return [];
-        const mount =
-          driveState.state === 'inserted'
-            ? UsbPartitionMount.mounted(getMockDriveDataDirPath(diskName))
-            : UsbPartitionMount.ejected();
-        const diskPath = UsbDiskDevPathSchema.decode(`/dev/${diskName}`);
-        return [
-          {
-            diskPath,
-            partition: {
-              diskPath,
-              partPath: UsbPartitionDevPathSchema.decode(`/dev/${diskName}1`),
-              fstype: driveState.fstype,
-              mount,
-            },
-          },
-        ];
-      });
-    },
-
-    refresh: () => Promise.resolve(),
-
-    ejectDrive(diskPath: UsbDiskDevPath): Promise<void> {
-      const diskName = basename(diskPath);
-      const driveState = readMockDriveState(diskName);
-      if (driveState.state === 'inserted') {
-        writeMockDriveState(diskName, {
-          state: 'ejected',
-          fstype: driveState.fstype,
-        });
-      }
-      return Promise.resolve();
-    },
-
-    formatDrive(
-      diskPath: UsbDiskDevPath,
-      fstype: UsbDriveFilesystemType
-    ): Promise<void> {
-      const diskName = basename(diskPath);
-      const driveState = readMockDriveState(diskName);
-      if (driveState.state !== 'removed') {
-        writeMockDriveState(diskName, { state: 'ejected', fstype });
-      }
-      return Promise.resolve();
-    },
-
-    sync: (partPath: UsbPartitionDevPath) => {
-      void partPath;
-      return Promise.resolve();
-    },
-    stop: () => {},
-    addListener: () => {},
-    removeListener: () => {},
-  };
-}
-
+/**
+ * A convenience handler for manipulating a single simulated USB drive from
+ * dev tooling and integration tests. Backed by {@link SimulatedUsbPlatform},
+ * so apps running with `USE_MOCK_USB_DRIVE` observe the same drives.
+ *
+ * Note that, unlike the historical file-based mock, an inserted drive is
+ * mounted by the consuming app's drive detection (as with real hardware), not
+ * by insertion itself.
+ */
 export function getMockFileUsbDriveHandler(
   diskName = 'sdb'
 ): MockFileUsbDriveHandler {
-  function getDataPath(): UsbPartitionMountpoint {
-    return getMockDriveDataDirPath(diskName);
+  const platform = getMockUsbPlatform();
+  const diskPath: UsbDiskDevPath = UsbDiskDevPathSchema.decode(
+    `/dev/${diskName}`
+  );
+
+  function findDrive(): Optional<SimulatedUsbDrive> {
+    return platform
+      .getSimulatedDrives()
+      .find((drive) => drive.diskPath === diskPath);
   }
 
   return {
     status: (): UsbDriveStatus => {
-      const { state } = readMockDriveState(diskName);
-      if (state === 'removed') return { status: 'no_drive' };
-      if (state === 'ejected') return { status: 'ejected' };
-      return { status: 'mounted', mountpoint: getDataPath() };
-    },
-    insert: (contents?: MockFileTree) => {
-      if (contents) {
-        writeMockFileTree(getDataPath(), contents);
+      const drive = findDrive();
+      if (!drive?.present) {
+        return { status: 'no_drive' };
       }
-      const currentState = readMockDriveState(diskName);
-      writeMockDriveState(diskName, {
-        state: 'inserted',
-        fstype:
-          currentState.state !== 'removed' ? currentState.fstype : 'fat32',
-      });
+      const mountpoint = drive.partition?.mountpoint;
+      return mountpoint
+        ? { status: 'mounted', mountpoint }
+        : { status: 'ejected' };
     },
+
+    insert: (contents?: MockFileTree) => {
+      if (!findDrive()) {
+        platform.createDrive({ diskPath, fstype: 'fat32' });
+      }
+      if (contents) {
+        writeMockFileTree(platform.storagePath(diskPath), contents);
+      }
+      if (!findDrive()?.present) {
+        platform.insertDrive(diskPath);
+      }
+    },
+
     remove: () => {
-      writeMockDriveState(diskName, { state: 'removed' });
+      if (findDrive()?.present) {
+        platform.removeDrive(diskPath);
+      }
     },
+
     clearData: () => {
-      rmSync(getDataPath(), { recursive: true, force: true });
+      if (findDrive()) {
+        platform.clearDriveStorage(diskPath);
+      }
     },
-    getDataPath: () => getDataPath(),
+
+    getDataPath: () => platform.storagePath(diskPath),
+
     cleanup: () => {
-      rmSync(getMockDriveDirPath(diskName), { recursive: true, force: true });
+      if (findDrive()) {
+        platform.deleteDrive(diskPath);
+      }
     },
   };
 }

--- a/libs/usb-drive/src/mocks/mock_usb_dir.ts
+++ b/libs/usb-drive/src/mocks/mock_usb_dir.ts
@@ -1,0 +1,28 @@
+import { getMockStateRootDir } from '@votingworks/utils';
+import { join } from 'node:path';
+
+// libs/usb-drive/src/mocks/ is 4 levels below the repo root
+const REPO_ROOT = join(__dirname, '../../../..');
+const MOCK_USB_DRIVE_DIR = join(getMockStateRootDir(REPO_ROOT), 'usb-drive');
+export const DEV_MOCK_USB_DRIVE_GLOB_PATTERN = join(MOCK_USB_DRIVE_DIR, '**/*');
+
+let mockUsbDriveDirOverride: string | undefined;
+
+/**
+ * Overrides the mock USB drive directory. Use in test setup to isolate
+ * tests from each other when they run in parallel.
+ */
+export function setMockUsbDriveDir(dir: string): void {
+  mockUsbDriveDirOverride = dir;
+}
+
+/**
+ * Clears the mock USB drive directory override, reverting to the default.
+ */
+export function resetMockUsbDriveDir(): void {
+  mockUsbDriveDirOverride = undefined;
+}
+
+export function getMockUsbDirPath(): string {
+  return mockUsbDriveDirOverride ?? MOCK_USB_DRIVE_DIR;
+}

--- a/libs/usb-drive/src/mocks/simulated_usb_platform.test.ts
+++ b/libs/usb-drive/src/mocks/simulated_usb_platform.test.ts
@@ -1,0 +1,438 @@
+import { assertDefined } from '@votingworks/basics';
+import { makeTemporaryDirectory } from '@votingworks/fixtures';
+import { backendWaitFor } from '@votingworks/test-utils';
+import { Buffer } from 'node:buffer';
+import { existsSync } from 'node:fs';
+import { readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { expect, test, vi } from 'vitest';
+import {
+  UsbDiskDevPathSchema,
+  UsbPartitionDevPathSchema,
+  UsbPartitionMountpoint,
+  UsbPartitionMountpointSchema,
+} from '../types';
+import { UsbPlatformDrive, UsbPlatformPartition } from '../usb_platform';
+import { SimulatedUsbPlatform } from './simulated_usb_platform';
+
+function getSimulatedMountpoint(
+  platform: SimulatedUsbPlatform
+): UsbPartitionMountpoint {
+  return assertDefined(platform.getSimulatedDrives()[0]?.partition?.mountpoint);
+}
+
+async function readTestFile(platform: SimulatedUsbPlatform): Promise<string> {
+  return await readFile(
+    join(getSimulatedMountpoint(platform), 'README'),
+    'utf-8'
+  );
+}
+
+async function writeTestFile(
+  platform: SimulatedUsbPlatform,
+  data: string
+): Promise<void> {
+  await writeFile(join(getSimulatedMountpoint(platform), 'README'), data);
+}
+
+const devsdb = UsbDiskDevPathSchema.decode('/dev/sdb');
+const devsdb1 = UsbPartitionDevPathSchema.decode('/dev/sdb1');
+const devsdc = UsbDiskDevPathSchema.decode('/dev/sdc');
+const devsdc1 = UsbPartitionDevPathSchema.decode('/dev/sdc1');
+
+test('starts empty', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  await expect(platform.getDrives()).resolves.toEqual([]);
+  expect(platform.getSimulatedDrives()).toEqual([]);
+});
+
+test('tolerates a deleted devices.json', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  await rm(platform['stateFilePath']);
+  await expect(platform.getDrives()).resolves.toEqual([]);
+});
+
+test('crashes on a corrupted devices.json', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  await writeFile(platform['stateFilePath'], 'not json');
+  await expect(platform.getDrives()).rejects.toThrow();
+});
+
+test('bad diskPath crashes', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+
+  expect(() => platform.removeDrive(devsdb)).toThrow();
+  expect(() => platform.deleteDrive(devsdb)).toThrow();
+  expect(() => platform.clearDriveStorage(devsdb)).toThrow();
+  expect(() => platform.insertDrive(devsdb)).toThrow();
+  await expect(
+    platform.formatDrive(devsdb, 'fat32', 'LABEL')
+  ).rejects.toThrow();
+  await expect(platform.mountPartition(devsdb1)).rejects.toThrow();
+  await expect(
+    platform.unmountPartition(platform.storagePath(devsdb))
+  ).rejects.toThrow();
+
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  platform.insertDrive(devsdb);
+  await expect(platform.mountPartition(devsdc1)).rejects.toThrow();
+  await platform.mountPartition(devsdb1);
+  await expect(
+    platform.unmountPartition(platform.storagePath(devsdc))
+  ).rejects.toThrow();
+});
+
+test('cannot create a drive that already exists', () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  expect(() =>
+    platform.createDrive({ diskPath: devsdb, fstype: 'fat32' })
+  ).toThrow();
+});
+
+test('created drives are not present until inserted', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+
+  platform.createDrive({
+    diskPath: devsdb,
+    fstype: 'fat32',
+  });
+  // Created but not attached: invisible to the platform, but tracked.
+  await expect(platform.getDrives()).resolves.toEqual([]);
+  expect(platform.getSimulatedDrives()).toEqual([
+    expect.objectContaining({
+      diskPath: devsdb,
+      present: false,
+    }),
+  ]);
+
+  platform.insertDrive(devsdb);
+  await expect(platform.getDrives()).resolves.toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: devsdb,
+    }),
+  ]);
+  expect(platform.getSimulatedDrives()).toEqual([
+    expect.objectContaining({
+      diskPath: devsdb,
+      present: true,
+    }),
+  ]);
+  // The platform's view of attached hardware doesn't leak the presence flag.
+  const [drive] = await platform.getDrives();
+  expect(drive).not.toHaveProperty('present');
+});
+
+test('failed create cleans up storage path', () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  vi.spyOn(
+    platform as unknown as { writeStateFile: () => void },
+    'writeStateFile'
+  ).mockThrow('FAIL');
+  expect(() =>
+    platform.createDrive({ diskPath: devsdb, fstype: 'fat32' })
+  ).toThrow();
+  expect(existsSync(platform.storagePath(devsdb))).toEqual(false);
+});
+
+test('watch changes', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  const onDeviceChange1 = vi.fn();
+  const onDeviceChange2 = vi.fn();
+  const watcher1 = platform.watchChanges(onDeviceChange1);
+  const watcher2 = platform.watchChanges(onDeviceChange2);
+
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  platform.insertDrive(devsdb);
+  await backendWaitFor(() => {
+    expect(onDeviceChange1.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(onDeviceChange2.mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  watcher2.stop();
+  const callsBeforeStop = onDeviceChange2.mock.calls.length;
+  platform.createDrive({ diskPath: devsdc, fstype: 'fat32' });
+  platform.insertDrive(devsdc);
+  await backendWaitFor(() => {
+    expect(onDeviceChange1.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+  expect(onDeviceChange2.mock.calls.length).toEqual(callsBeforeStop);
+
+  platform.deleteAllDrives();
+  await backendWaitFor(() => {
+    expect(onDeviceChange1.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  watcher1.stop();
+});
+
+test('full lifecycle', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  const onDeviceChange = vi.fn();
+  const watcher = platform.watchChanges(onDeviceChange);
+  expect(onDeviceChange).toHaveBeenCalledTimes(0);
+
+  platform.createDrive({
+    diskPath: devsdb,
+    fstype: 'fat32',
+  });
+  platform.insertDrive(devsdb);
+  await backendWaitFor(() => {
+    expect(onDeviceChange.mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
+  await expect(platform.getDrives()).resolves.toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: devsdb,
+      partition: expect.objectContaining<Partial<UsbPlatformPartition>>({
+        fstype: 'fat32',
+      }),
+    }),
+  ]);
+
+  await platform.mountPartition(devsdb1);
+  const drives = await platform.getDrives();
+  expect(drives).toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: devsdb,
+      partition: expect.objectContaining<Partial<UsbPlatformPartition>>({
+        fstype: 'fat32',
+        mountpoint: expect.any(String),
+      }),
+    }),
+  ]);
+
+  await writeTestFile(platform, 'hello world');
+
+  await platform.unmountPartition(platform.storagePath(devsdb));
+  await expect(platform.getDrives()).resolves.toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: devsdb,
+      partition: expect.objectContaining<Partial<UsbPlatformPartition>>({
+        fstype: 'fat32',
+        mountpoint: undefined,
+      }),
+    }),
+  ]);
+
+  await platform.mountPartition(devsdb1);
+  const afterRemountDrives = await platform.getDrives();
+  expect(afterRemountDrives).toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
+      partition: expect.objectContaining<Partial<UsbPlatformPartition>>({
+        fstype: 'fat32',
+        mountpoint: expect.any(String),
+      }),
+    }),
+  ]);
+  await expect(readTestFile(platform)).resolves.toEqual('hello world');
+
+  // Removing a drive detaches it but preserves its storage.
+  platform.removeDrive(devsdb);
+  await expect(platform.getDrives()).resolves.toEqual([]);
+  expect(platform.getSimulatedDrives()).toEqual([
+    expect.objectContaining({
+      diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
+      present: false,
+    }),
+  ]);
+
+  // Reattaching and remounting preserves the previously written contents.
+  platform.insertDrive(devsdb);
+  await platform.mountPartition(devsdb1);
+  await expect(readTestFile(platform)).resolves.toEqual('hello world');
+
+  // Clearing wipes contents but keeps the drive present.
+  platform.clearDriveStorage(devsdb);
+  expect(platform.getSimulatedDrives()).toEqual([
+    expect.objectContaining({
+      diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
+      present: true,
+    }),
+  ]);
+  await expect(readTestFile(platform)).rejects.toThrow();
+
+  // Formatting re-partitions the drive and clears contents.
+  await writeTestFile(platform, 'should be cleared by formatDrive');
+  await platform.formatDrive(devsdb, 'ext4', 'GOODIES');
+  await platform.mountPartition(devsdb1);
+  const afterFormatDrives = await platform.getDrives();
+  expect(afterFormatDrives).toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: UsbDiskDevPathSchema.decode('/dev/sdb'),
+      partition: expect.objectContaining<Partial<UsbPlatformPartition>>({
+        fstype: 'ext4',
+        label: 'GOODIES',
+        mountpoint: expect.any(String),
+      }),
+    }),
+  ]);
+  await expect(readTestFile(platform)).rejects.toThrow();
+
+  // Deleting a drive removes it and its storage entirely.
+  platform.deleteDrive(devsdb);
+  await expect(platform.getDrives()).resolves.toEqual([]);
+  expect(platform.getSimulatedDrives()).toEqual([]);
+
+  watcher.stop();
+  onDeviceChange.mockClear();
+
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  platform.insertDrive(devsdb);
+  await platform.mountPartition(devsdb1);
+
+  // Simulated platform `sync` doesn't really do anything.
+  await platform.sync(platform.storagePath(devsdb));
+  await expect(
+    platform.sync(UsbPartitionMountpointSchema.decode('/mnt/nonexistent'))
+  ).rejects.toThrow();
+
+  await platform.unmountPartition(platform.storagePath(devsdb));
+  platform.deleteAllDrives();
+
+  // No more calls after `watcher.stop()`.
+  expect(onDeviceChange).toHaveBeenCalledTimes(0);
+});
+
+test('createDrive can seed initial contents', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({
+    diskPath: devsdb,
+    fstype: 'fat32',
+    contents: { README: Buffer.from('seeded') },
+  });
+  platform.insertDrive(devsdb);
+  await platform.mountPartition(devsdb1);
+  await expect(readTestFile(platform)).resolves.toEqual('seeded');
+});
+
+test('deleteAllDrives is a no-op when there are no drives', () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  expect(() => platform.deleteAllDrives()).not.toThrow();
+  expect(platform.getSimulatedDrives()).toEqual([]);
+});
+
+test('can delete a created drive that was never inserted', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  platform.deleteDrive(devsdb);
+  expect(platform.getSimulatedDrives()).toEqual([]);
+  await expect(platform.getDrives()).resolves.toEqual([]);
+});
+
+test('created-but-not-attached drives cannot be operated on as hardware', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+
+  // The drive exists but is not plugged in, so hardware operations fail.
+  expect(() => platform.removeDrive(devsdb)).toThrow('Drive not attached');
+  await expect(platform.mountPartition(devsdb1)).rejects.toThrow();
+  await expect(
+    platform.unmountPartition(platform.storagePath(devsdb))
+  ).rejects.toThrow();
+
+  // Once attached, the same operations succeed.
+  platform.insertDrive(devsdb);
+  await expect(platform.mountPartition(devsdb1)).resolves.toBeUndefined();
+});
+
+test('tracks multiple drives independently', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({
+    diskPath: devsdb,
+    fstype: 'fat32',
+    label: 'FIRST',
+    contents: { README: Buffer.from('sdb-data') },
+  });
+  platform.createDrive({
+    diskPath: devsdc,
+    fstype: 'ext4',
+    label: 'SECOND',
+    contents: { README: Buffer.from('sdc-data') },
+  });
+
+  // With only sdb attached, the platform's view shows just sdb.
+  platform.insertDrive(devsdb);
+  await expect(platform.getDrives()).resolves.toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({ diskPath: devsdb }),
+  ]);
+
+  platform.insertDrive(devsdc);
+  await platform.mountPartition(devsdb1);
+  await platform.mountPartition(devsdc1);
+
+  // Each drive keeps its own partition path, fstype, and label.
+  const drives = await platform.getDrives();
+  expect(drives).toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: devsdb,
+      partition: expect.objectContaining<Partial<UsbPlatformPartition>>({
+        partPath: devsdb1,
+        fstype: 'fat32',
+        label: 'FIRST',
+      }),
+    }),
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: devsdc,
+      partition: expect.objectContaining<Partial<UsbPlatformPartition>>({
+        partPath: devsdc1,
+        fstype: 'ext4',
+        label: 'SECOND',
+      }),
+    }),
+  ]);
+
+  // Each drive has its own isolated storage at a distinct mountpoint.
+  const [sdb, sdc] = drives;
+  const sdbMountpoint = assertDefined(sdb?.partition?.mountpoint);
+  const sdcMountpoint = assertDefined(sdc?.partition?.mountpoint);
+  expect(sdbMountpoint).not.toEqual(sdcMountpoint);
+  await expect(
+    readFile(join(sdbMountpoint, 'README'), 'utf-8')
+  ).resolves.toEqual('sdb-data');
+  await expect(
+    readFile(join(sdcMountpoint, 'README'), 'utf-8')
+  ).resolves.toEqual('sdc-data');
+});
+
+test('deleteDrive removes only the target drive, leaving others intact', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  platform.createDrive({ diskPath: devsdc, fstype: 'ext4' });
+  platform.insertDrive(devsdb);
+  platform.insertDrive(devsdc);
+  await platform.mountPartition(devsdc1);
+
+  platform.deleteDrive(devsdb);
+
+  // sdc survives with its state (present, mounted, ext4) fully intact.
+  expect(platform.getSimulatedDrives()).toEqual([
+    expect.objectContaining({ diskPath: devsdc, present: true }),
+  ]);
+  await expect(platform.getDrives()).resolves.toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({
+      diskPath: devsdc,
+      partition: expect.objectContaining<Partial<UsbPlatformPartition>>({
+        fstype: 'ext4',
+        mountpoint: expect.any(String),
+      }),
+    }),
+  ]);
+});
+
+test('shares on-disk state across instances on the same root', async () => {
+  const root = makeTemporaryDirectory();
+  const platformA = new SimulatedUsbPlatform(root);
+  platformA.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  platformA.insertDrive(devsdb);
+
+  // A second instance on the same root sees state created by the first.
+  const platformB = new SimulatedUsbPlatform(root);
+  await expect(platformB.getDrives()).resolves.toEqual([
+    expect.objectContaining<Partial<UsbPlatformDrive>>({ diskPath: devsdb }),
+  ]);
+
+  // And mutations made through B are visible to A.
+  platformB.removeDrive(devsdb);
+  await expect(platformA.getDrives()).resolves.toEqual([]);
+});

--- a/libs/usb-drive/src/mocks/simulated_usb_platform.test.ts
+++ b/libs/usb-drive/src/mocks/simulated_usb_platform.test.ts
@@ -90,6 +90,59 @@ test('cannot create a drive that already exists', () => {
   ).toThrow();
 });
 
+test('cannot create an unformatted drive with contents', () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  expect(() =>
+    platform.createDrive({
+      diskPath: devsdb,
+      contents: { README: Buffer.from('orphaned') },
+    })
+  ).toThrow('Cannot create an unformatted drive with contents');
+});
+
+test('unformatted drive lifecycle: create, insert, format', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({ diskPath: devsdb });
+  platform.insertDrive(devsdb);
+
+  // Visible to the platform, but with no usable partition — mirroring how
+  // RealUsbPlatform reports unformatted drives.
+  await expect(platform.getDrives()).resolves.toEqual([{ diskPath: devsdb }]);
+
+  // Without a partition there is nothing to mount or unmount.
+  await expect(platform.mountPartition(devsdb1)).rejects.toThrow();
+  await expect(
+    platform.unmountPartition(platform.storagePath(devsdb))
+  ).rejects.toThrow();
+
+  // Unplugging and re-attaching keeps it unformatted.
+  platform.removeDrive(devsdb);
+  platform.insertDrive(devsdb);
+
+  // Formatting installs a mounted partition.
+  await platform.formatDrive(devsdb, 'fat32', 'VxUSB-ABCDE');
+  await expect(platform.getDrives()).resolves.toEqual([
+    {
+      diskPath: devsdb,
+      partition: {
+        partPath: devsdb1,
+        fstype: 'fat32',
+        label: 'VxUSB-ABCDE',
+        mountpoint: platform.storagePath(devsdb),
+      },
+    },
+  ]);
+});
+
+test('deleting a present unformatted drive works without an unmount', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({ diskPath: devsdb });
+  platform.insertDrive(devsdb);
+  platform.deleteAllDrives();
+  expect(platform.getSimulatedDrives()).toEqual([]);
+  await expect(platform.getDrives()).resolves.toEqual([]);
+});
+
 test('created drives are not present until inserted', async () => {
   const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
 

--- a/libs/usb-drive/src/mocks/simulated_usb_platform.test.ts
+++ b/libs/usb-drive/src/mocks/simulated_usb_platform.test.ts
@@ -1,4 +1,4 @@
-import { assertDefined } from '@votingworks/basics';
+import { assertDefined, typedAs } from '@votingworks/basics';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
 import { backendWaitFor } from '@votingworks/test-utils';
 import { Buffer } from 'node:buffer';
@@ -13,7 +13,10 @@ import {
   UsbPartitionMountpointSchema,
 } from '../types';
 import { UsbPlatformDrive, UsbPlatformPartition } from '../usb_platform';
-import { SimulatedUsbPlatform } from './simulated_usb_platform';
+import {
+  SimulatedUsbDrive,
+  SimulatedUsbPlatform,
+} from './simulated_usb_platform';
 
 function getSimulatedMountpoint(
   platform: SimulatedUsbPlatform
@@ -107,7 +110,9 @@ test('unformatted drive lifecycle: create, insert, format', async () => {
 
   // Visible to the platform, but with no usable partition — mirroring how
   // RealUsbPlatform reports unformatted drives.
-  await expect(platform.getDrives()).resolves.toEqual([{ diskPath: devsdb }]);
+  await expect(platform.getDrives()).resolves.toEqual(
+    typedAs<UsbPlatformDrive[]>([{ diskPath: devsdb }])
+  );
 
   // Without a partition there is nothing to mount or unmount.
   await expect(platform.mountPartition(devsdb1)).rejects.toThrow();
@@ -121,17 +126,19 @@ test('unformatted drive lifecycle: create, insert, format', async () => {
 
   // Formatting installs a mounted partition.
   await platform.formatDrive(devsdb, 'fat32', 'VxUSB-ABCDE');
-  await expect(platform.getDrives()).resolves.toEqual([
-    {
-      diskPath: devsdb,
-      partition: {
-        partPath: devsdb1,
-        fstype: 'fat32',
-        label: 'VxUSB-ABCDE',
-        mountpoint: platform.storagePath(devsdb),
+  await expect(platform.getDrives()).resolves.toEqual(
+    typedAs<UsbPlatformDrive[]>([
+      {
+        diskPath: devsdb,
+        partition: {
+          partPath: devsdb1,
+          fstype: 'fat32',
+          label: 'VxUSB-ABCDE',
+          mountpoint: platform.storagePath(devsdb),
+        },
       },
-    },
-  ]);
+    ])
+  );
 });
 
 test('deleting a present unformatted drive works without an unmount', async () => {
@@ -460,7 +467,10 @@ test('deleteDrive removes only the target drive, leaving others intact', async (
 
   // sdc survives with its state (present, mounted, ext4) fully intact.
   expect(platform.getSimulatedDrives()).toEqual([
-    expect.objectContaining({ diskPath: devsdc, present: true }),
+    expect.objectContaining<SimulatedUsbDrive>({
+      diskPath: devsdc,
+      present: true,
+    }),
   ]);
   await expect(platform.getDrives()).resolves.toEqual([
     expect.objectContaining<Partial<UsbPlatformDrive>>({

--- a/libs/usb-drive/src/mocks/simulated_usb_platform.ts
+++ b/libs/usb-drive/src/mocks/simulated_usb_platform.ts
@@ -1,0 +1,491 @@
+/* eslint-disable no-param-reassign */
+import { isNonExistentFileOrDirectoryError, iter } from '@votingworks/basics';
+import makeDebug from 'debug';
+import assert from 'node:assert';
+import {
+  closeSync,
+  constants,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  watch,
+  writeFileSync,
+} from 'node:fs';
+import { basename, join } from 'node:path';
+import { z } from 'zod/v4';
+import {
+  UsbDiskDevPath,
+  UsbDriveFilesystemType,
+  UsbPartitionDevPath,
+  UsbPartitionDevPathSchema,
+  UsbPartitionMountpoint,
+  UsbPartitionMountpointSchema,
+} from '../types';
+import {
+  DriveWatcher,
+  UsbPlatform,
+  UsbPlatformDrive,
+  UsbPlatformDriveSchema,
+  UsbPlatformPartition,
+} from '../usb_platform';
+import { MockFileTree, writeMockFileTree } from './helpers';
+
+const debug = makeDebug('SimulatedUsbPlatform');
+
+export const SimulatedUsbDriveSchema = UsbPlatformDriveSchema.extend({
+  present: z.boolean(),
+});
+
+/**
+ * A USB drive tracked by the simulator. Its backing storage exists for as long
+ * as the drive has been created and not deleted, independent of whether it is
+ * currently attached. The `present` flag models whether the drive is "plugged
+ * in": only present drives are visible through the {@link UsbPlatform}
+ * interface (`getAllUsbDrives`), mirroring real hardware which is only visible
+ * when attached.
+ */
+export type SimulatedUsbDrive = z.output<typeof SimulatedUsbDriveSchema>;
+
+interface CreateDriveOptions {
+  diskPath: UsbDiskDevPath;
+  fstype: UsbDriveFilesystemType;
+  label?: string;
+  contents?: MockFileTree;
+}
+
+function findDrive(
+  drives: SimulatedUsbDrive[],
+  diskPath: UsbDiskDevPath
+): SimulatedUsbDrive {
+  const drive = drives.find((d) => d.diskPath === diskPath);
+  assert(drive, `Drive not found: ${diskPath}`);
+  return drive;
+}
+
+function findPresentDrive(
+  drives: SimulatedUsbDrive[],
+  diskPath: UsbDiskDevPath
+): SimulatedUsbDrive {
+  const drive = drives.find((d) => d.diskPath === diskPath);
+  assert(drive, `Drive not found: ${diskPath}`);
+  assert(drive.present, `Drive not attached: ${diskPath}`);
+  return drive;
+}
+
+/**
+ * Finds the partition with the given path on a currently-attached drive. A
+ * partition can only be mounted or unmounted while its drive is present, just
+ * as real hardware is only accessible while plugged in.
+ */
+function findPresentPartition(
+  drives: SimulatedUsbDrive[],
+  partPath: UsbPartitionDevPath
+): { drive: SimulatedUsbDrive; partition: UsbPlatformPartition } {
+  const drive = drives.find(
+    (d) => d.present && d.partition?.partPath === partPath
+  );
+  assert(drive, `Partition not found on an attached drive: ${partPath}`);
+  assert(drive.partition);
+  return { drive, partition: drive.partition };
+}
+
+/**
+ * Finds the partition with the given mountpoint on a currently-attached drive.
+ * A partition can only be mounted or unmounted while its drive is present, just
+ * as real hardware is only accessible while plugged in.
+ */
+function findPresentPartitionByMountpoint(
+  drives: SimulatedUsbDrive[],
+  mountpoint: UsbPartitionMountpoint
+): { drive: SimulatedUsbDrive; partition: UsbPlatformPartition } {
+  const drive = drives.find(
+    (d) => d.present && d.partition?.mountpoint === mountpoint
+  );
+  assert(drive, `Partition not found on an attached drive: ${mountpoint}`);
+  assert(drive.partition);
+  return { drive, partition: drive.partition };
+}
+
+export class SimulatedUsbPlatform implements UsbPlatform {
+  private watchController?: AbortController;
+
+  /**
+   * The working set of drives during an in-progress {@link mutateState}
+   * transaction. When set, it is the single source of truth that all reads and
+   * mutations operate on and that gets persisted; when unset, state is read
+   * fresh from {@link stateFilePath} each time.
+   */
+  private cachedDrives?: SimulatedUsbDrive[];
+  private readonly listeners = new Set<() => void>();
+
+  constructor(private readonly root: string) {
+    mkdirSync(this.root, { recursive: true });
+    try {
+      const fd = openSync(
+        this.stateFilePath,
+        // eslint-disable-next-line no-bitwise
+        constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY
+      );
+      writeFileSync(fd, JSON.stringify([]));
+      closeSync(fd);
+      debug('Created new devices file');
+    } catch (e) {
+      /* istanbul ignore next: unexpected errors should propagate */
+      if ((e as { code?: string }).code !== 'EEXIST') {
+        throw e;
+      }
+      debug('Using existing devices file');
+    }
+  }
+
+  async getDrives(): Promise<UsbPlatformDrive[]> {
+    await Promise.resolve();
+    return this.getSimulatedDrives()
+      .filter((drive) => drive.present)
+      .map(({ partition, diskPath }): UsbPlatformDrive => {
+        assert(partition);
+        return {
+          diskPath,
+          partition: {
+            partPath: partition.partPath,
+            fstype: partition.fstype,
+            label: partition.label,
+            mountpoint: partition.mountpoint,
+          },
+        };
+      });
+  }
+
+  /**
+   * Returns every drive the simulator is tracking, including ones that have
+   * been created but are not currently attached (`present: false`). Use this
+   * to inspect or toggle a drive's presence; use {@link getDrives} for
+   * the platform's view of attached hardware.
+   */
+  getSimulatedDrives(): SimulatedUsbDrive[] {
+    try {
+      if (this.cachedDrives) return this.cachedDrives;
+      return z
+        .array(SimulatedUsbDriveSchema)
+        .parse(JSON.parse(readFileSync(this.stateFilePath, 'utf-8')));
+    } catch (e) {
+      if (isNonExistentFileOrDirectoryError(e)) return [];
+      throw e;
+    }
+  }
+
+  /**
+   * Registers a listener to call when the platform's USB device state changes.
+   * @param onChange The listener function to call when the state changes.
+   * @returns A watcher object that can be used to stop listening.
+   */
+  watchChanges(onChange: () => void): DriveWatcher {
+    this.listeners.add(onChange);
+
+    if (!this.watchController) {
+      this.watchController = new AbortController();
+      watch(
+        this.stateFilePath,
+        { signal: this.watchController.signal },
+        (event, file) => {
+          debug('Watch event: %s %s', event, file);
+          for (const fn of this.listeners) {
+            fn();
+          }
+        }
+      );
+    }
+
+    return {
+      stop: () => {
+        this.listeners.delete(onChange);
+        if (this.listeners.size === 0) {
+          this.watchController?.abort();
+          this.watchController = undefined;
+        }
+      },
+    };
+  }
+
+  /**
+   * Creates a drive's backing storage (partition, filesystem, and contents)
+   * without attaching it. The drive starts out not present; call
+   * {@link insertDrive} to make it visible to the platform.
+   */
+  createDrive(options: CreateDriveOptions): void {
+    debug('Create drive: %s', options.diskPath);
+    assert(
+      !this.getSimulatedDrives().some((d) => d.diskPath === options.diskPath),
+      `USB drive already exists: ${options.diskPath}`
+    );
+
+    const newDrive: SimulatedUsbDrive = {
+      diskPath: options.diskPath,
+      present: false,
+      partition: {
+        partPath: this.partPathFromDiskPath(options.diskPath),
+        fstype: options.fstype,
+        label: options.label,
+      },
+    };
+
+    try {
+      this.mutateState((drives) => {
+        drives.push(newDrive);
+        const storagePath = this.reinitStorage(newDrive.diskPath);
+        if (options.contents) {
+          writeMockFileTree(storagePath, options.contents);
+        }
+      });
+    } catch (e) {
+      rmSync(this.storagePath(newDrive.diskPath), {
+        recursive: true,
+        force: true,
+      });
+      throw e;
+    }
+  }
+
+  /**
+   * Attaches a previously {@link createDrive}d drive, making it present.
+   */
+  insertDrive(diskPath: UsbDiskDevPath): void {
+    debug('Insert drive: %s', diskPath);
+    this.mutateState((drives) => {
+      findDrive(drives, diskPath).present = true;
+    });
+  }
+
+  /**
+   * Detaches a drive and marks it not present. The drive's storage is preserved
+   * and can be reattached with {@link insertDrive}. Use {@link deleteDrive} to
+   * destroy its storage.
+   */
+  removeDrive(diskPath: UsbDiskDevPath): void {
+    debug('Remove drive: %s', diskPath);
+    this.mutateState((drives) => {
+      const drive = findPresentDrive(drives, diskPath);
+      assert(drive.partition);
+      this.unmountPartitionInternal(drive.partition);
+      drive.present = false;
+    });
+  }
+
+  /**
+   * Clears a drive's data without changing its presence or format.
+   */
+  clearDriveStorage(diskPath: UsbDiskDevPath): void {
+    this.replaceDriveData(diskPath, {});
+  }
+
+  /**
+   * Replaces the data in a drive with the given contents. Does not change the
+   * state of the drive (presence or format).
+   */
+  replaceDriveData(diskPath: UsbDiskDevPath, contents: MockFileTree): void {
+    debug('Replace drive data: %s', diskPath);
+    assert(
+      this.getSimulatedDrives().some((d) => d.diskPath === diskPath),
+      `Drive not found: ${diskPath}`
+    );
+    const storagePath = this.reinitStorage(diskPath);
+    writeMockFileTree(storagePath, contents);
+  }
+
+  /**
+   * Detaches a drive and destroys its backing storage entirely.
+   */
+  deleteDrive(diskPath: UsbDiskDevPath): void {
+    debug('Delete drive: %s', diskPath);
+    this.mutateState((drives) => {
+      const [toDelete, toKeep] = iter(drives).partition(
+        (d) => d.diskPath === diskPath
+      );
+      assert(toDelete.length === 1, `USB drive not found: ${diskPath}`);
+      this.destroyDrives(toDelete);
+      return toKeep;
+    });
+  }
+
+  /** Deletes every tracked drive and destroys all backing storage. */
+  deleteAllDrives(): void {
+    debug('Delete all drives');
+    if (this.getSimulatedDrives().length === 0) return;
+    this.mutateState((drives) => {
+      this.destroyDrives(drives);
+      return [];
+    });
+  }
+
+  /**
+   * Unmounts (if present) and destroys the backing storage of each given drive.
+   * Caller is responsible for removing them from the persisted working set.
+   */
+  private destroyDrives(drives: SimulatedUsbDrive[]): void {
+    for (const drive of drives) {
+      if (drive.present) {
+        assert(drive.partition);
+        this.unmountPartitionInternal(drive.partition);
+      }
+      debug('Deleting drive storage: %s', drive.diskPath);
+      this.reinitStorage(drive.diskPath);
+    }
+  }
+
+  /**
+   * Mounts a partition by device path.
+   * @throws {Error} If the partition is not present.
+   */
+  async mountPartition(partPath: UsbPartitionDevPath): Promise<void> {
+    await Promise.resolve();
+    this.mutateState((drives) => {
+      const { drive, partition } = findPresentPartition(drives, partPath);
+      partition.mountpoint = this.storagePath(drive.diskPath);
+      mkdirSync(partition.mountpoint, { recursive: true });
+    });
+  }
+
+  /**
+   * Unmounts a drive by its mountpoint.
+   * @throws {Error} If the drive is not present.
+   */
+  async unmountPartition(mountpoint: UsbPartitionMountpoint): Promise<void> {
+    await Promise.resolve();
+    this.mutateState((drives) => {
+      const { partition } = findPresentPartitionByMountpoint(
+        drives,
+        mountpoint
+      );
+      this.unmountPartitionInternal(partition);
+    });
+  }
+
+  /**
+   * Clears a partition's mountpoint. Mutates the given partition in place, so
+   * it must be called within a {@link mutateState} transaction on a partition
+   * belonging to the working set.
+   */
+  private unmountPartitionInternal(partition: UsbPlatformPartition): void {
+    assert(this.cachedDrives, 'must be called within mutateState');
+    if (!partition.mountpoint) {
+      debug('Partition already unmounted: %s', partition.partPath);
+      return;
+    }
+    debug('Unmounting partition: %s', partition.partPath);
+    partition.mountpoint = undefined;
+  }
+
+  /**
+   * Formats a drive with the given options. This will delete any existing
+   * partitions and create a new one.
+   * @throws {Error} If the drive is not present.
+   */
+  async formatDrive(
+    diskPath: UsbDiskDevPath,
+    fstype: UsbDriveFilesystemType,
+    label: string
+  ): Promise<void> {
+    await Promise.resolve();
+    debug('Format drive: %s', diskPath);
+    this.mutateState((drives) => {
+      const drive = findPresentDrive(drives, diskPath);
+      assert(drive.partition);
+      this.unmountPartitionInternal(drive.partition);
+
+      drive.partition = {
+        partPath: this.partPathFromDiskPath(drive.diskPath),
+        fstype,
+        label,
+        mountpoint: this.storagePath(drive.diskPath),
+      };
+
+      this.replaceDriveData(drive.diskPath, {});
+    });
+  }
+
+  /**
+   * Synchronizes the contents of a drive with its storage. This operation is a
+   * no-op for a simulated drive.
+   * @throws {Error} If the drive is not present or not mounted.
+   */
+  async sync(mountpoint: UsbPartitionMountpoint): Promise<void> {
+    await Promise.resolve();
+    debug('Sync: %s', mountpoint);
+
+    const drive = this.getSimulatedDrives().find(
+      (d) => d.present && d.partition?.mountpoint === mountpoint
+    );
+    assert(!!drive, `Drive not mounted: ${mountpoint}`);
+  }
+
+  /**
+   * The path to the file used to store drive state.
+   */
+  private get stateFilePath(): string {
+    return join(this.root, 'drives.json');
+  }
+
+  /**
+   * The root directory for partition storage. Partitions each have their own
+   * subdirectory named after their devPath.
+   */
+  private get storageRoot(): string {
+    return join(this.root, 'storage');
+  }
+
+  private reinitStorage(diskPath: UsbDiskDevPath): string {
+    const storagePath = this.storagePath(diskPath);
+    rmSync(storagePath, { recursive: true, force: true });
+    mkdirSync(storagePath, { recursive: true });
+    return storagePath;
+  }
+
+  /**
+   * Returns the path to the storage directory for the given drive, which
+   * will be in a directory named after the drive's devPath. It is not
+   * guaranteed to exist on disk since it does not check that the drive
+   * actually exists.
+   */
+  storagePath(diskPath: UsbDiskDevPath): UsbPartitionMountpoint {
+    return UsbPartitionMountpointSchema.decode(
+      join(this.storageRoot, basename(diskPath))
+    );
+  }
+
+  private partPathFromDiskPath(diskPath: UsbDiskDevPath): UsbPartitionDevPath {
+    return UsbPartitionDevPathSchema.decode(`${diskPath}1`);
+  }
+
+  /**
+   * Runs a state mutation as a read-modify-write transaction. `mutate` receives
+   * the working set of drives — the only thing it may mutate — and may either
+   * mutate it in place or return a replacement array. Whatever the working set
+   * is at the end is persisted. Not re-entrant.
+   */
+  private mutateState(
+    mutate: (drives: SimulatedUsbDrive[]) => SimulatedUsbDrive[] | void
+  ): void {
+    assert(!this.cachedDrives, 'mutateState is not re-entrant');
+    this.cachedDrives = this.getSimulatedDrives();
+    try {
+      this.cachedDrives = mutate(this.cachedDrives) ?? this.cachedDrives;
+      this.writeStateFile(this.cachedDrives);
+    } finally {
+      this.cachedDrives = undefined;
+    }
+  }
+
+  private writeStateFile(devices: readonly SimulatedUsbDrive[]): void {
+    debug('Write state file: %d device(s)', devices.length);
+    for (const device of devices) {
+      debug(
+        'Write state file:   %s (%s, %s)',
+        device.diskPath,
+        device.present ? 'present' : 'absent',
+        device.partition?.mountpoint ?? 'unmounted'
+      );
+    }
+    writeFileSync(this.stateFilePath, JSON.stringify(devices, null, 2));
+  }
+}

--- a/libs/usb-drive/src/mocks/simulated_usb_platform.ts
+++ b/libs/usb-drive/src/mocks/simulated_usb_platform.ts
@@ -49,7 +49,12 @@ export type SimulatedUsbDrive = z.output<typeof SimulatedUsbDriveSchema>;
 
 interface CreateDriveOptions {
   diskPath: UsbDiskDevPath;
-  fstype: UsbDriveFilesystemType;
+  /**
+   * Filesystem type for the drive's single partition. Omit to create an
+   * unformatted drive with no usable partition, mirroring how
+   * {@link RealUsbPlatform} reports unformatted or unsupported drives.
+   */
+  fstype?: UsbDriveFilesystemType;
   label?: string;
   contents?: MockFileTree;
 }
@@ -143,18 +148,17 @@ export class SimulatedUsbPlatform implements UsbPlatform {
     await Promise.resolve();
     return this.getSimulatedDrives()
       .filter((drive) => drive.present)
-      .map(({ partition, diskPath }): UsbPlatformDrive => {
-        assert(partition);
-        return {
+      .map(
+        ({ partition, diskPath }): UsbPlatformDrive => ({
           diskPath,
-          partition: {
+          partition: partition && {
             partPath: partition.partPath,
             fstype: partition.fstype,
             label: partition.label,
             mountpoint: partition.mountpoint,
           },
-        };
-      });
+        })
+      );
   }
 
   /**
@@ -219,15 +223,21 @@ export class SimulatedUsbPlatform implements UsbPlatform {
       !this.getSimulatedDrives().some((d) => d.diskPath === options.diskPath),
       `USB drive already exists: ${options.diskPath}`
     );
+    assert(
+      !options.contents || options.fstype !== undefined,
+      'Cannot create an unformatted drive with contents'
+    );
 
     const newDrive: SimulatedUsbDrive = {
       diskPath: options.diskPath,
       present: false,
-      partition: {
-        partPath: this.partPathFromDiskPath(options.diskPath),
-        fstype: options.fstype,
-        label: options.label,
-      },
+      partition: options.fstype
+        ? {
+            partPath: this.partPathFromDiskPath(options.diskPath),
+            fstype: options.fstype,
+            label: options.label,
+          }
+        : undefined,
     };
 
     try {
@@ -266,8 +276,9 @@ export class SimulatedUsbPlatform implements UsbPlatform {
     debug('Remove drive: %s', diskPath);
     this.mutateState((drives) => {
       const drive = findPresentDrive(drives, diskPath);
-      assert(drive.partition);
-      this.unmountPartitionInternal(drive.partition);
+      if (drive.partition) {
+        this.unmountPartitionInternal(drive.partition);
+      }
       drive.present = false;
     });
   }
@@ -324,8 +335,7 @@ export class SimulatedUsbPlatform implements UsbPlatform {
    */
   private destroyDrives(drives: SimulatedUsbDrive[]): void {
     for (const drive of drives) {
-      if (drive.present) {
-        assert(drive.partition);
+      if (drive.present && drive.partition) {
         this.unmountPartitionInternal(drive.partition);
       }
       debug('Deleting drive storage: %s', drive.diskPath);
@@ -390,8 +400,9 @@ export class SimulatedUsbPlatform implements UsbPlatform {
     debug('Format drive: %s', diskPath);
     this.mutateState((drives) => {
       const drive = findPresentDrive(drives, diskPath);
-      assert(drive.partition);
-      this.unmountPartitionInternal(drive.partition);
+      if (drive.partition) {
+        this.unmountPartitionInternal(drive.partition);
+      }
 
       drive.partition = {
         partPath: this.partPathFromDiskPath(drive.diskPath),

--- a/libs/usb-drive/src/multi_usb_drive.test.ts
+++ b/libs/usb-drive/src/multi_usb_drive.test.ts
@@ -6,7 +6,8 @@ import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
 } from '@votingworks/utils';
-import { deferred, sleep } from '@votingworks/basics';
+import { assertDefined, deferred, sleep } from '@votingworks/basics';
+import { getMockFileUsbDriveHandler } from './mocks/file_usb_drive';
 import { detectMultiUsbDrive } from './multi_usb_drive';
 import { UsbPlatform } from './usb_platform';
 import { exec } from './exec';
@@ -23,16 +24,16 @@ const MOUNT_SCRIPT_PATH = join(__dirname, '../scripts');
 
 const featureFlagMock = getFeatureFlagMock();
 
+vi.mock(import('@votingworks/utils'), async (importActual) => ({
+  ...(await importActual()),
+  isFeatureFlagEnabled: (flag) => featureFlagMock.isEnabled(flag),
+}));
+
 const devsdb = UsbDiskDevPathSchema.decode('/dev/sdb');
 const devsdb1 = UsbPartitionDevPathSchema.decode('/dev/sdb1');
 const devsdc = UsbDiskDevPathSchema.decode('/dev/sdc');
 
 type ExecResult = Awaited<ReturnType<typeof exec>>;
-
-vi.mock(import('@votingworks/utils'), async (importActual) => ({
-  ...(await importActual()),
-  isFeatureFlagEnabled: (flag) => featureFlagMock.isEnabled(flag),
-}));
 
 const execMock = vi.mocked(exec);
 const getAllUsbDrivesMock = vi.mocked(getAllDiskDevices);
@@ -91,10 +92,34 @@ function makeDisk(
   };
 }
 
-test('an explicitly injected platform takes precedence over USE_MOCK_USB_DRIVE', async () => {
+test('runs against the simulated platform when USE_MOCK_USB_DRIVE is enabled', async () => {
   featureFlagMock.enableFeatureFlag(
     BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE
   );
+  const handler = getMockFileUsbDriveHandler();
+  handler.insert();
+
+  const multiUsbDrive = detectMultiUsbDrive(mockLogger({ fn: vi.fn }));
+  try {
+    // The production state machine auto-mounts the simulated drive.
+    await vi.waitFor(
+      () => {
+        expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+          UsbPartitionMount.mounted(
+            UsbPartitionMountpointSchema.decode(
+              assertDefined(handler.getDataPath())
+            )
+          )
+        );
+      },
+      { timeout: 2000 }
+    );
+  } finally {
+    multiUsbDrive.stop();
+  }
+});
+
+test('uses an injected platform', async () => {
   const platform: UsbPlatform = {
     getDrives: () => Promise.resolve([{ diskPath: devsdb }]),
     watchChanges: () => ({ stop: () => {} }),
@@ -110,15 +135,6 @@ test('an explicitly injected platform takes precedence over USE_MOCK_USB_DRIVE',
   await multiUsbDrive.refresh();
 
   expect(multiUsbDrive.getDrives()).toEqual([{ diskPath: devsdb }]);
-  multiUsbDrive.stop();
-});
-
-test('works even when USE_MOCK_USB_DRIVE feature flag is enabled', () => {
-  featureFlagMock.enableFeatureFlag(
-    BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE
-  );
-  const multiUsbDrive = detectMultiUsbDrive(mockLogger({ fn: vi.fn }));
-  expect(multiUsbDrive.getDrives()).toEqual([]);
   multiUsbDrive.stop();
 });
 

--- a/libs/usb-drive/src/multi_usb_drive.test.ts
+++ b/libs/usb-drive/src/multi_usb_drive.test.ts
@@ -7,7 +7,10 @@ import {
   getFeatureFlagMock,
 } from '@votingworks/utils';
 import { assertDefined, deferred, sleep } from '@votingworks/basics';
-import { getMockFileUsbDriveHandler } from './mocks/file_usb_drive';
+import {
+  getMockFileUsbDriveHandler,
+  getSimulatedUsbPlatform,
+} from './mocks/file_usb_drive';
 import { detectMultiUsbDrive } from './multi_usb_drive';
 import { UsbPlatform } from './usb_platform';
 import { exec } from './exec';
@@ -99,7 +102,10 @@ test('runs against the simulated platform when USE_MOCK_USB_DRIVE is enabled', a
   const handler = getMockFileUsbDriveHandler();
   handler.insert();
 
-  const multiUsbDrive = detectMultiUsbDrive(mockLogger({ fn: vi.fn }));
+  // Mirrors how app backends wire up drive detection
+  const multiUsbDrive = detectMultiUsbDrive(mockLogger({ fn: vi.fn }), {
+    platform: getSimulatedUsbPlatform(),
+  });
   try {
     // The production state machine auto-mounts the simulated drive.
     await vi.waitFor(

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -15,7 +15,7 @@ import {
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
 import makeDebug from 'debug';
-import { createMockFileMultiUsbDrive } from './mocks/file_usb_drive';
+import { getMockUsbPlatform } from './mocks/file_usb_drive';
 import {
   UsbDiskDevPath,
   UsbDriveFilesystemType,
@@ -140,14 +140,11 @@ export function detectMultiUsbDrive(
 ): MultiUsbDrive {
   // An explicitly injected platform takes precedence over the ambient
   // USE_MOCK_USB_DRIVE flag.
-  if (
-    !options?.platform &&
-    isFeatureFlagEnabled(BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE)
-  ) {
-    return createMockFileMultiUsbDrive();
-  }
-
-  const platform = options?.platform ?? new RealUsbPlatform();
+  const platform =
+    options?.platform ??
+    (isFeatureFlagEnabled(BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE)
+      ? getMockUsbPlatform()
+      : new RealUsbPlatform());
   const listeners = new Set<() => void>();
 
   let stopped = false;

--- a/libs/usb-drive/src/multi_usb_drive.ts
+++ b/libs/usb-drive/src/multi_usb_drive.ts
@@ -10,12 +10,7 @@ import {
   sleep,
 } from '@votingworks/basics';
 import { LogEventId, Logger } from '@votingworks/logging';
-import {
-  BooleanEnvironmentVariableName,
-  isFeatureFlagEnabled,
-} from '@votingworks/utils';
 import makeDebug from 'debug';
-import { getMockUsbPlatform } from './mocks/file_usb_drive';
 import {
   UsbDiskDevPath,
   UsbDriveFilesystemType,
@@ -138,13 +133,7 @@ export function detectMultiUsbDrive(
   logger: Logger,
   options?: { platform?: UsbPlatform }
 ): MultiUsbDrive {
-  // An explicitly injected platform takes precedence over the ambient
-  // USE_MOCK_USB_DRIVE flag.
-  const platform =
-    options?.platform ??
-    (isFeatureFlagEnabled(BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE)
-      ? getMockUsbPlatform()
-      : new RealUsbPlatform());
+  const platform = options?.platform ?? new RealUsbPlatform();
   const listeners = new Set<() => void>();
 
   let stopped = false;

--- a/libs/usb-drive/src/multi_usb_drive_integration.test.ts
+++ b/libs/usb-drive/src/multi_usb_drive_integration.test.ts
@@ -1,0 +1,144 @@
+// Integration tests running the production `detectMultiUsbDrive` state
+// machine against a real `SimulatedUsbPlatform` (no module mocks). These
+// guard the `UsbPlatform` contract between the state machine and platform
+// implementations — e.g. that unmount/sync are addressed by mountpoint —
+// which unit tests with mocked platforms cannot catch.
+import { sleep } from '@votingworks/basics';
+import { makeTemporaryDirectory } from '@votingworks/fixtures';
+import { LogEventId, mockLogger } from '@votingworks/logging';
+import { existsSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { expect, test, vi } from 'vitest';
+import { detectMultiUsbDrive } from './multi_usb_drive';
+import { SimulatedUsbPlatform } from './mocks/simulated_usb_platform';
+import {
+  UsbDiskDevPathSchema,
+  UsbPartitionDevPathSchema,
+  UsbPartitionMount,
+} from './types';
+
+const devsdb = UsbDiskDevPathSchema.decode('/dev/sdb');
+const devsdb1 = UsbPartitionDevPathSchema.decode('/dev/sdb1');
+
+test('detects and auto-mounts a drive attached before detection starts', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  platform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  platform.insertDrive(devsdb);
+
+  const multiUsbDrive = detectMultiUsbDrive(mockLogger({ fn: vi.fn }), {
+    platform,
+  });
+
+  try {
+    await vi.waitFor(
+      () => {
+        expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+          UsbPartitionMount.mounted(platform.storagePath(devsdb))
+        );
+      },
+      { timeout: 2000 }
+    );
+  } finally {
+    multiUsbDrive.stop();
+  }
+});
+
+test('full lifecycle: insert → auto-mount → write → sync → eject → format → remove → re-insert', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  const logger = mockLogger({ fn: vi.fn });
+  const multiUsbDrive = detectMultiUsbDrive(logger, { platform });
+
+  try {
+    await multiUsbDrive.refresh();
+    expect(multiUsbDrive.getDrives()).toEqual([]);
+
+    platform.createDrive({
+      diskPath: devsdb,
+      fstype: 'fat32',
+      label: 'VxUSB-ABCDE',
+    });
+    platform.insertDrive(devsdb);
+    await multiUsbDrive.refresh();
+
+    const mountpoint = platform.storagePath(devsdb);
+    await vi.waitFor(
+      () => {
+        expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+          UsbPartitionMount.mounted(mountpoint)
+        );
+      },
+      { timeout: 2000 }
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.UsbDriveMounted,
+      expect.any(String),
+      expect.objectContaining({ disposition: 'success' })
+    );
+
+    // Write data through the mounted filesystem and flush it
+    await writeFile(join(mountpoint, 'README'), 'hello');
+    await multiUsbDrive.sync(devsdb1);
+
+    // Eject unmounts via the platform and reports the partition as ejected
+    await multiUsbDrive.ejectDrive(devsdb);
+    expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+      UsbPartitionMount.ejected()
+    );
+    expect(
+      platform.getSimulatedDrives()[0]?.partition?.mountpoint
+    ).toBeUndefined();
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.UsbDriveEjected,
+      expect.any(String),
+      expect.objectContaining({ disposition: 'success' })
+    );
+
+    // Ejecting preserves the drive's data and prevents auto-remount
+    expect(existsSync(join(mountpoint, 'README'))).toEqual(true);
+    await multiUsbDrive.refresh();
+    await sleep(50);
+    expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+      UsbPartitionMount.ejected()
+    );
+
+    // Format preserves the VxUSB label and wipes the drive's data
+    await multiUsbDrive.formatDrive(devsdb, 'fat32');
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.UsbDriveFormatted,
+      expect.any(String),
+      expect.objectContaining({
+        disposition: 'success',
+        message: expect.stringContaining('VxUSB-ABCDE'),
+      })
+    );
+    expect(platform.getSimulatedDrives()[0]?.partition?.label).toEqual(
+      'VxUSB-ABCDE'
+    );
+    expect(existsSync(join(mountpoint, 'README'))).toEqual(false);
+
+    // Unplugging the drive is detected via the platform watcher (no explicit
+    // refresh) and the drive disappears
+    platform.removeDrive(devsdb);
+    await vi.waitFor(
+      () => {
+        expect(multiUsbDrive.getDrives()).toEqual([]);
+      },
+      { timeout: 2000 }
+    );
+
+    // Re-inserting clears the eject state and auto-mounts again
+    platform.insertDrive(devsdb);
+    await multiUsbDrive.refresh();
+    await vi.waitFor(
+      () => {
+        expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+          UsbPartitionMount.mounted(mountpoint)
+        );
+      },
+      { timeout: 2000 }
+    );
+  } finally {
+    multiUsbDrive.stop();
+  }
+});

--- a/libs/usb-drive/src/multi_usb_drive_integration.test.ts
+++ b/libs/usb-drive/src/multi_usb_drive_integration.test.ts
@@ -44,6 +44,38 @@ test('detects and auto-mounts a drive attached before detection starts', async (
   }
 });
 
+test('detects an unformatted drive and formats it', async () => {
+  const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  const logger = mockLogger({ fn: vi.fn });
+  const multiUsbDrive = detectMultiUsbDrive(logger, { platform });
+
+  try {
+    platform.createDrive({ diskPath: devsdb });
+    platform.insertDrive(devsdb);
+    await multiUsbDrive.refresh();
+
+    // Reported with no usable partition; nothing to auto-mount.
+    expect(multiUsbDrive.getDrives()).toEqual([{ diskPath: devsdb }]);
+
+    await multiUsbDrive.formatDrive(devsdb, 'fat32');
+
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.UsbDriveFormatted,
+      expect.any(String),
+      expect.objectContaining({ disposition: 'success' })
+    );
+    const partition = platform.getSimulatedDrives()[0]?.partition;
+    expect(partition?.fstype).toEqual('fat32');
+    expect(partition?.label).toMatch(/^VxUSB-[A-Z0-9]{5}$/);
+    // Formatted drives are held ejected until physically re-inserted.
+    expect(multiUsbDrive.getDrives()[0]?.partition?.mount).toEqual(
+      UsbPartitionMount.ejected()
+    );
+  } finally {
+    multiUsbDrive.stop();
+  }
+});
+
 test('full lifecycle: insert → auto-mount → write → sync → eject → format → remove → re-insert', async () => {
   const platform = new SimulatedUsbPlatform(makeTemporaryDirectory());
   const logger = mockLogger({ fn: vi.fn });

--- a/libs/usb-drive/src/usb_drive.test.ts
+++ b/libs/usb-drive/src/usb_drive.test.ts
@@ -1,32 +1,13 @@
 import { mockLogger } from '@votingworks/logging';
-import {
-  BooleanEnvironmentVariableName,
-  getFeatureFlagMock,
-} from '@votingworks/utils';
-import { existsSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
 import { beforeEach, expect, test, vi } from 'vitest';
 import { UsbDiskDeviceInfo } from './block_devices';
-import {
-  getMockUsbDirPath,
-  MOCK_USB_DRIVE_STATE_FILENAME,
-} from './mocks/file_usb_drive';
 import {
   UsbDiskDevPathSchema,
   UsbPartitionDevPathSchema,
   UsbPartitionMountpointSchema,
 } from './types';
 import { detectUsbDrive } from './usb_drive';
-
-const featureFlagMock = getFeatureFlagMock();
-
-vi.mock(
-  import('@votingworks/utils'),
-  async (importActual): Promise<typeof import('@votingworks/utils')> => ({
-    ...(await importActual()),
-    isFeatureFlagEnabled: (flag) => featureFlagMock.isEnabled(flag),
-  })
-);
+import { UsbPlatform } from './usb_platform';
 
 let mockDevices: UsbDiskDeviceInfo[] = [];
 
@@ -40,27 +21,6 @@ beforeEach(() => {
   mockDevices = [];
   vi.clearAllMocks();
   vi.unstubAllEnvs();
-  featureFlagMock.resetFeatureFlags();
-});
-
-test('uses a mock file USB drive when feature flag is set', async () => {
-  featureFlagMock.enableFeatureFlag(
-    BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE
-  );
-  const stateFilePath = join(
-    getMockUsbDirPath(),
-    'sdb',
-    MOCK_USB_DRIVE_STATE_FILENAME
-  );
-
-  if (existsSync(stateFilePath)) {
-    rmSync(stateFilePath);
-  }
-  expect(existsSync(stateFilePath)).toEqual(false);
-
-  const usbDrive = detectUsbDrive(mockLogger({ fn: vi.fn }));
-  expect(await usbDrive.status()).toEqual({ status: 'no_drive' });
-  expect(existsSync(stateFilePath)).toEqual(true);
 });
 
 test('returns no_drive when no drives are connected', async () => {
@@ -95,6 +55,36 @@ test('exposes the first connected drive via the UsbDrive interface', async () =>
     expect(await usbDrive.status()).toEqual({
       status: 'mounted',
       mountpoint: '/media/vx/usb-drive-sdb1',
+    });
+  });
+});
+
+test('uses an injected platform', async () => {
+  const platform: UsbPlatform = {
+    getDrives: () =>
+      Promise.resolve([
+        {
+          diskPath: UsbDiskDevPathSchema.decode('/dev/sdz'),
+          partition: {
+            partPath: UsbPartitionDevPathSchema.decode('/dev/sdz1'),
+            fstype: 'fat32',
+            mountpoint: UsbPartitionMountpointSchema.decode('/mnt/sdz1'),
+          },
+        },
+      ]),
+    watchChanges: () => ({ stop: () => {} }),
+    mountPartition: () => Promise.resolve(),
+    unmountPartition: () => Promise.resolve(),
+    formatDrive: () => Promise.resolve(),
+    sync: () => Promise.resolve(),
+  };
+
+  const usbDrive = detectUsbDrive(mockLogger({ fn: vi.fn }), { platform });
+
+  await vi.waitFor(async () => {
+    expect(await usbDrive.status()).toEqual({
+      status: 'mounted',
+      mountpoint: '/mnt/sdz1',
     });
   });
 });

--- a/libs/usb-drive/src/usb_drive.ts
+++ b/libs/usb-drive/src/usb_drive.ts
@@ -1,18 +1,14 @@
 import { Logger } from '@votingworks/logging';
-import {
-  BooleanEnvironmentVariableName,
-  isFeatureFlagEnabled,
-} from '@votingworks/utils';
-import { createMockFileUsbDrive } from './mocks/file_usb_drive';
 import { detectMultiUsbDrive } from './multi_usb_drive';
 import { UsbDrive } from './types';
 import { createUsbDriveAdapter } from './usb_drive_adapter';
+import { UsbPlatform } from './usb_platform';
 
-export function detectUsbDrive(logger: Logger): UsbDrive {
-  if (isFeatureFlagEnabled(BooleanEnvironmentVariableName.USE_MOCK_USB_DRIVE)) {
-    return createMockFileUsbDrive();
-  }
-  const multiUsbDrive = detectMultiUsbDrive(logger);
+export function detectUsbDrive(
+  logger: Logger,
+  options?: { platform?: UsbPlatform }
+): UsbDrive {
+  const multiUsbDrive = detectMultiUsbDrive(logger, options);
   return createUsbDriveAdapter(
     multiUsbDrive,
     (drives) => drives.find((d) => d.partition?.fstype === 'fat32')?.diskPath

--- a/libs/usb-drive/test/setup.ts
+++ b/libs/usb-drive/test/setup.ts
@@ -8,7 +8,7 @@ import { join } from 'node:path';
 import {
   resetMockUsbDriveDir,
   setMockUsbDriveDir,
-} from '../src/mocks/file_usb_drive';
+} from '../src/mocks/mock_usb_dir';
 
 beforeAll(setupTemporaryRootDir);
 afterAll(clearTemporaryRootDir);


### PR DESCRIPTION
`<🤖>`

`detectUsbDrive`/`detectMultiUsbDrive` no longer consult the USE_MOCK_USB_DRIVE flag — they are deterministic over the platform they are given. App backends decide explicitly via
`getSimulatedUsbPlatform()`, which returns the simulated platform when the flag is set and undefined (real hardware) otherwise.

`</🤖>`

## Overview

_(Part 13 of a series of PRs: [previous](https://github.com/votingworks/vxsuite/pull/8743) / [next](about:blank))_

TODO

## Demo Video or Screenshot

TODO

## Testing Plan

TODO