### PR TITLE
[ballot-encoder] Rename BMD/HMPB terms to summary/bubble ballot

### DIFF
--- a/libs/ballot-encoder/src/index.test.ts
+++ b/libs/ballot-encoder/src/index.test.ts
@@ -13,28 +13,28 @@ import {
 } from '@votingworks/types';
 import { BitReader, BitWriter } from './bits';
 import {
-  decodeBallot,
+  decodeSinglePageSummaryBallot,
   decodeBallotHash,
   isVxBallot,
   BALLOT_HASH_ENCODING_LENGTH,
-  encodeBallot,
-  encodeBallotInto,
+  encodeSinglePageSummaryBallot,
+  encodeSinglePageSummaryBallotInto,
   HexEncoding,
   MAXIMUM_WRITE_IN_LENGTH,
-  BmdPrelude,
-  BmdMultiPagePrelude,
+  SummaryBallotPrelude,
+  MultiPageSummaryBallotPrelude,
   WriteInEncoding,
   sliceBallotHashForEncoding,
   encodeBallotConfigInto,
   encodeHmpbBallotPageMetadata,
   decodeBallotHashFromReader,
-  decodeBallotConfigFromReader,
+  decodeSinglePageSummaryBallotConfigFromReader,
   MAXIMUM_PRECINCTS,
   MAXIMUM_BALLOT_STYLES,
-  isBmdMultiPageBallot,
-  encodeBmdMultiPageBallot,
-  decodeBmdMultiPageBallot,
-  BmdMultiPageBallotPage,
+  isMultiPageSummaryBallot,
+  encodeMultiPageSummaryBallotPage,
+  decodeMultiPageSummaryBallotPage,
+  MultiPageSummaryBallotPage,
 } from '.';
 
 const precinctBallotTypeIndex = Object.values(BallotType).indexOf(
@@ -52,10 +52,12 @@ test('sliceBallotHashForEncoding', () => {
 });
 
 test('can detect an encoded ballot', () => {
-  expect(isVxBallot(Uint8Array.of(...BmdPrelude))).toEqual(true);
+  expect(isVxBallot(Uint8Array.of(...SummaryBallotPrelude))).toEqual(true);
   expect(isVxBallot(Uint8Array.of())).toEqual(false);
-  expect(isVxBallot(Uint8Array.of(0, ...BmdPrelude))).toEqual(false);
-  expect(isVxBallot(Uint8Array.of(...BmdPrelude.slice(0, -2)))).toEqual(false);
+  expect(isVxBallot(Uint8Array.of(0, ...SummaryBallotPrelude))).toEqual(false);
+  expect(
+    isVxBallot(Uint8Array.of(...SummaryBallotPrelude.slice(0, -2)))
+  ).toEqual(false);
 });
 
 test('encodes & decodes with Uint8Array as the standard encoding interface', () => {
@@ -77,7 +79,10 @@ test('encodes & decodes with Uint8Array as the standard encoding interface', () 
   };
 
   expect(
-    decodeBallot(electionDefinition, encodeBallot(election, ballot))
+    decodeSinglePageSummaryBallot(
+      electionDefinition,
+      encodeSinglePageSummaryBallot(election, ballot)
+    )
   ).toEqual({
     ...ballot,
     ballotHash: ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH),
@@ -125,8 +130,12 @@ test('encodes & decodes empty votes correctly', () => {
     .writeBoolean(...contests.map(() => false))
     .toUint8Array();
 
-  expect(encodeBallot(election, ballot)).toEqualBits(encodedBallot);
-  expect(decodeBallot(electionDefinition, encodedBallot)).toEqual({
+  expect(encodeSinglePageSummaryBallot(election, ballot)).toEqualBits(
+    encodedBallot
+  );
+  expect(
+    decodeSinglePageSummaryBallot(electionDefinition, encodedBallot)
+  ).toEqual({
     ...ballot,
     ballotHash: ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH),
   });
@@ -173,8 +182,12 @@ test('encodes & decodes whether it is a test ballot', () => {
     .writeBoolean(...contests.map(() => false))
     .toUint8Array();
 
-  expect(encodeBallot(election, ballot)).toEqualBits(encodedBallot);
-  expect(decodeBallot(electionDefinition, encodedBallot)).toEqual({
+  expect(encodeSinglePageSummaryBallot(election, ballot)).toEqualBits(
+    encodedBallot
+  );
+  expect(
+    decodeSinglePageSummaryBallot(electionDefinition, encodedBallot)
+  ).toEqual({
     ...ballot,
     ballotHash: ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH),
   });
@@ -224,8 +237,12 @@ test('encodes & decodes the ballot type', () => {
     .writeBoolean(...contests.map(() => false))
     .toUint8Array();
 
-  expect(encodeBallot(election, ballot)).toEqualBits(encodedBallot);
-  expect(decodeBallot(electionDefinition, encodedBallot)).toEqual({
+  expect(encodeSinglePageSummaryBallot(election, ballot)).toEqualBits(
+    encodedBallot
+  );
+  expect(
+    decodeSinglePageSummaryBallot(electionDefinition, encodedBallot)
+  ).toEqual({
     ...ballot,
     ballotHash: ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH),
   });
@@ -291,9 +308,14 @@ test('encodes & decodes yesno votes correctly', () => {
     .writeBoolean(true)
     .toUint8Array();
 
-  expect(encodeBallot(election, ballot)).toEqualBits(encodedBallot);
+  expect(encodeSinglePageSummaryBallot(election, ballot)).toEqualBits(
+    encodedBallot
+  );
   expect(
-    encodeBallot(election, decodeBallot(electionDefinition, encodedBallot))
+    encodeSinglePageSummaryBallot(
+      election,
+      decodeSinglePageSummaryBallot(electionDefinition, encodedBallot)
+    )
   ).toEqual(encodedBallot);
 });
 
@@ -314,7 +336,7 @@ test('throws on invalid precinct', () => {
     ballotType: BallotType.Precinct,
   };
 
-  expect(() => encodeBallot(election, ballot)).toThrowError(
+  expect(() => encodeSinglePageSummaryBallot(election, ballot)).toThrowError(
     'precinct ID not found: not-a-precinct'
   );
 });
@@ -359,7 +381,7 @@ test('throws on trying to encode a bad yes/no vote', () => {
     ballotType: BallotType.Precinct,
   };
 
-  expect(() => encodeBallot(election, ballot)).toThrowError(
+  expect(() => encodeSinglePageSummaryBallot(election, ballot)).toThrowError(
     'cannot encode a non-array yes/no vote: "judicial-robert-demergue-option-yes"'
   );
 
@@ -368,7 +390,7 @@ test('throws on trying to encode a bad yes/no vote', () => {
     'judicial-robert-demergue-option-yes',
     'judicial-robert-demergue-option-no',
   ];
-  expect(() => encodeBallot(election, ballot)).toThrowError(
+  expect(() => encodeSinglePageSummaryBallot(election, ballot)).toThrowError(
     'cannot encode a yes/no overvote: ["judicial-robert-demergue-option-yes","judicial-robert-demergue-option-no"]'
   );
 });
@@ -390,7 +412,7 @@ test('throws on trying to encode a ballot style', () => {
     ballotType: BallotType.Precinct,
   };
 
-  expect(() => encodeBallot(election, ballot)).toThrowError(
+  expect(() => encodeSinglePageSummaryBallot(election, ballot)).toThrowError(
     `unknown ballot style id: ${ballotStyleId}`
   );
 });
@@ -480,8 +502,12 @@ test('encodes & decodes candidate choice votes correctly', () => {
     .writeUint(0, { max: 2 }) // 3 seats - 1 selection = 2 write-ins max
     .toUint8Array();
 
-  expect(encodeBallot(election, ballot)).toEqualBits(encodedBallot);
-  expect(decodeBallot(electionDefinition, encodedBallot)).toEqual({
+  expect(encodeSinglePageSummaryBallot(election, ballot)).toEqualBits(
+    encodedBallot
+  );
+  expect(
+    decodeSinglePageSummaryBallot(electionDefinition, encodedBallot)
+  ).toEqual({
     ...ballot,
     ballotHash: ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH),
   });
@@ -543,8 +569,12 @@ test('encodes & decodes write-in votes correctly', () => {
     })
     .toUint8Array();
 
-  expect(encodeBallot(election, ballot)).toEqualBits(encodedBallot);
-  expect(decodeBallot(electionDefinition, encodedBallot)).toEqual({
+  expect(encodeSinglePageSummaryBallot(election, ballot)).toEqualBits(
+    encodedBallot
+  );
+  expect(
+    decodeSinglePageSummaryBallot(electionDefinition, encodedBallot)
+  ).toEqual({
     ...ballot,
     ballotHash: ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH),
   });
@@ -558,7 +588,9 @@ test('cannot decode a ballot without the prelude', () => {
     .writeUint8(2)
     .toUint8Array();
 
-  expect(() => decodeBallot(electionDefinition, encodedBallot)).toThrowError(
+  expect(() =>
+    decodeSinglePageSummaryBallot(electionDefinition, encodedBallot)
+  ).toThrowError(
     "expected leading prelude 'V' 'X' 0b00000002 but it was not found"
   );
 });
@@ -583,13 +615,13 @@ test('cannot decode a ballot that includes extra data at the end', () => {
 
   const writer = new BitWriter();
 
-  encodeBallotInto(election, ballot, writer);
+  encodeSinglePageSummaryBallotInto(election, ballot, writer);
 
   const corruptedBallot = writer.writeBoolean(true).toUint8Array();
 
-  expect(() => decodeBallot(electionDefinition, corruptedBallot)).toThrowError(
-    'unexpected data found while reading padding, expected EOF'
-  );
+  expect(() =>
+    decodeSinglePageSummaryBallot(electionDefinition, corruptedBallot)
+  ).toThrowError('unexpected data found while reading padding, expected EOF');
 });
 
 test('cannot decode a ballot that includes too much padding at the end', () => {
@@ -612,13 +644,13 @@ test('cannot decode a ballot that includes too much padding at the end', () => {
 
   const writer = new BitWriter();
 
-  encodeBallotInto(election, ballot, writer);
+  encodeSinglePageSummaryBallotInto(election, ballot, writer);
 
   const corruptedBallot = writer.writeUint8(0).toUint8Array();
 
-  expect(() => decodeBallot(electionDefinition, corruptedBallot)).toThrowError(
-    'unexpected data found while reading padding, expected EOF'
-  );
+  expect(() =>
+    decodeSinglePageSummaryBallot(electionDefinition, corruptedBallot)
+  ).toThrowError('unexpected data found while reading padding, expected EOF');
 });
 
 test('decode ballot hash from BMD metadata', () => {
@@ -639,9 +671,9 @@ test('decode ballot hash from BMD metadata', () => {
     ballotType: BallotType.Precinct,
   };
 
-  expect(decodeBallotHash(encodeBallot(election, ballot))).toEqual(
-    ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH)
-  );
+  expect(
+    decodeBallotHash(encodeSinglePageSummaryBallot(election, ballot))
+  ).toEqual(ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH));
 });
 
 test('fails to find the ballot hash with garbage data', () => {
@@ -669,7 +701,9 @@ test('encode HMPB ballot page metadata', () => {
     sliceBallotHashForEncoding(ballotHash)
   );
   expect(
-    decodeBallotConfigFromReader(election, reader, { readPageNumber: true })
+    decodeSinglePageSummaryBallotConfigFromReader(election, reader, {
+      readPageNumber: true,
+    })
   ).toEqual(ballotConfig);
 });
 
@@ -710,13 +744,15 @@ test('encode HMPB ballot page metadata with bad ballot style fails', () => {
 // Multi-page BMD ballot tests
 
 test('can detect a multi-page BMD ballot', () => {
-  expect(isBmdMultiPageBallot(Uint8Array.of(...BmdMultiPagePrelude))).toEqual(
-    true
-  );
-  expect(isBmdMultiPageBallot(Uint8Array.of())).toEqual(false);
-  expect(isBmdMultiPageBallot(Uint8Array.of(...BmdPrelude))).toEqual(false);
   expect(
-    isBmdMultiPageBallot(Uint8Array.of(0, ...BmdMultiPagePrelude))
+    isMultiPageSummaryBallot(Uint8Array.of(...MultiPageSummaryBallotPrelude))
+  ).toEqual(true);
+  expect(isMultiPageSummaryBallot(Uint8Array.of())).toEqual(false);
+  expect(
+    isMultiPageSummaryBallot(Uint8Array.of(...SummaryBallotPrelude))
+  ).toEqual(false);
+  expect(
+    isMultiPageSummaryBallot(Uint8Array.of(0, ...MultiPageSummaryBallotPrelude))
   ).toEqual(false);
 });
 
@@ -727,7 +763,7 @@ test('multi-page BMD ballot is still detected as VX ballot', () => {
   const precinct = election.precincts[0]!;
   const contests = getContests({ election, ballotStyle });
 
-  const page: BmdMultiPageBallotPage = {
+  const page: MultiPageSummaryBallotPage = {
     ballotHash,
     ballotStyleId: ballotStyle.id,
     precinctId: precinct.id,
@@ -740,7 +776,7 @@ test('multi-page BMD ballot is still detected as VX ballot', () => {
     votes: vote(contests.slice(0, 5), {}),
   };
 
-  const encoded = encodeBmdMultiPageBallot(election, page);
+  const encoded = encodeMultiPageSummaryBallotPage(election, page);
   expect(isVxBallot(encoded)).toEqual(true);
 });
 
@@ -753,7 +789,7 @@ test('encodes & decodes multi-page BMD ballot with empty votes', () => {
   const pageContests = contests.slice(0, 5); // first 5 contests
   const votes = vote(pageContests, {});
 
-  const page: BmdMultiPageBallotPage = {
+  const page: MultiPageSummaryBallotPage = {
     ballotHash,
     ballotStyleId: ballotStyle.id,
     precinctId: precinct.id,
@@ -766,8 +802,8 @@ test('encodes & decodes multi-page BMD ballot with empty votes', () => {
     votes,
   };
 
-  const encoded = encodeBmdMultiPageBallot(election, page);
-  const decoded = decodeBmdMultiPageBallot(electionDefinition, encoded);
+  const encoded = encodeMultiPageSummaryBallotPage(election, page);
+  const decoded = decodeMultiPageSummaryBallotPage(electionDefinition, encoded);
 
   expect(decoded.metadata.ballotHash).toEqual(
     ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH)
@@ -795,7 +831,7 @@ test('encodes & decodes multi-page BMD ballot with votes', () => {
     senator: 'weiford',
   });
 
-  const page: BmdMultiPageBallotPage = {
+  const page: MultiPageSummaryBallotPage = {
     ballotHash,
     ballotStyleId: ballotStyle.id,
     precinctId: precinct.id,
@@ -808,8 +844,8 @@ test('encodes & decodes multi-page BMD ballot with votes', () => {
     votes,
   };
 
-  const encoded = encodeBmdMultiPageBallot(election, page);
-  const decoded = decodeBmdMultiPageBallot(electionDefinition, encoded);
+  const encoded = encodeMultiPageSummaryBallotPage(election, page);
+  const decoded = decodeMultiPageSummaryBallotPage(electionDefinition, encoded);
 
   expect(decoded.metadata.isTestMode).toEqual(true);
   expect(decoded.metadata.ballotType).toEqual(BallotType.Absentee);
@@ -835,7 +871,7 @@ test('encodes & decodes multi-page BMD ballot with write-in votes', () => {
     ],
   });
 
-  const page: BmdMultiPageBallotPage = {
+  const page: MultiPageSummaryBallotPage = {
     ballotHash,
     ballotStyleId: ballotStyle.id,
     precinctId: precinct.id,
@@ -848,8 +884,8 @@ test('encodes & decodes multi-page BMD ballot with write-in votes', () => {
     votes,
   };
 
-  const encoded = encodeBmdMultiPageBallot(election, page);
-  const decoded = decodeBmdMultiPageBallot(electionDefinition, encoded);
+  const encoded = encodeMultiPageSummaryBallotPage(election, page);
+  const decoded = decodeMultiPageSummaryBallotPage(electionDefinition, encoded);
 
   expect(decoded.metadata.pageNumber).toEqual(1);
   expect(decoded.metadata.totalPages).toEqual(1);
@@ -865,7 +901,7 @@ test('decode ballot hash from multi-page BMD metadata', () => {
   const precinct = election.precincts[0]!;
   const contests = getContests({ election, ballotStyle });
 
-  const page: BmdMultiPageBallotPage = {
+  const page: MultiPageSummaryBallotPage = {
     ballotHash,
     ballotStyleId: ballotStyle.id,
     precinctId: precinct.id,
@@ -878,7 +914,7 @@ test('decode ballot hash from multi-page BMD metadata', () => {
     votes: vote(contests.slice(0, 3), {}),
   };
 
-  const encoded = encodeBmdMultiPageBallot(election, page);
+  const encoded = encodeMultiPageSummaryBallotPage(election, page);
   expect(decodeBallotHash(encoded)).toEqual(
     ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH)
   );

--- a/libs/ballot-encoder/src/index.ts
+++ b/libs/ballot-encoder/src/index.ts
@@ -4,7 +4,7 @@ import {
   BallotStyleId,
   BallotType,
   BallotTypeMaximumValue,
-  BmdMultiPageBallotPageMetadata,
+  MultiPageSummaryBallotPageMetadata,
   Candidate,
   CandidateVote,
   CompletedBallot,
@@ -37,7 +37,7 @@ export const MAXIMUM_WRITE_IN_LENGTH = 40;
 export const BALLOT_HASH_ENCODING_LENGTH = 20;
 
 /**
- * Maximum number of pages in a hand-marked paper ballot.
+ * Maximum number of pages in a bubble ballot.
  */
 export const MAXIMUM_PAGE_NUMBERS = 30;
 
@@ -75,50 +75,51 @@ export const WriteInEncoding = new CustomEncoding(
 export const HexEncoding = new CustomEncoding('0123456789abcdef');
 
 /**
- * The bytes we expect a BMD ballot to start with.
+ * The bytes we expect a summary ballot to start with.
  */
-export const BmdPrelude: readonly Uint8[] = [
+export const SummaryBallotPrelude: readonly Uint8[] = [
   /* V */ 86, /* X */ 88, /* version = */ 2,
 ];
 
 /**
- * The bytes we expect a hand-marked paper ballot to start with.
+ * The bytes we expect a bubble ballot to start with.
  */
-export const HmpbPrelude: readonly Uint8[] = [
+export const BubbleBallotPrelude: readonly Uint8[] = [
   /* V */ 86, /* P = Paper */ 80, /* version = */ 2,
 ];
 
 /**
- * The bytes we expect a multi-page BMD ballot to start with.
+ * The bytes we expect a multi-page summary ballot to start with.
  */
-export const BmdMultiPagePrelude: readonly Uint8[] = [
+export const MultiPageSummaryBallotPrelude: readonly Uint8[] = [
   /* V */ 86, /* B = BMD multi-page */ 66, /* version = */ 1,
 ];
 
 /**
- * Detect whether `data` is a votingworks encoded ballot / metadata.
- * Recognizes both single-page BMD (VX) and multi-page BMD (VB) preludes.
+ * Detect whether `data` is a VotingWorks encoded ballot / metadata.
+ * Recognizes both single-page summary ballot (VX) and multi-page
+ * summary ballot (VB) preludes.
  */
 export function isVxBallot(data: Uint8Array): boolean {
-  const prelude = data.slice(0, BmdPrelude.length);
-  if (prelude.length !== BmdPrelude.length) {
+  const prelude = data.slice(0, SummaryBallotPrelude.length);
+  if (prelude.length !== SummaryBallotPrelude.length) {
     return false;
   }
-  // Check for VX (single-page BMD) or VB (multi-page BMD) prelude
+  // Check for VX (single-page) or VB (multi-page) summary ballot prelude
   return (
-    prelude.every((byte, i) => byte === BmdPrelude[i]) ||
-    prelude.every((byte, i) => byte === BmdMultiPagePrelude[i])
+    prelude.every((byte, i) => byte === SummaryBallotPrelude[i]) ||
+    prelude.every((byte, i) => byte === MultiPageSummaryBallotPrelude[i])
   );
 }
 
 /**
- * Detect whether `data` is a multi-page BMD ballot.
+ * Detect whether `data` is a multi-page summary ballot.
  */
-export function isBmdMultiPageBallot(data: Uint8Array): boolean {
-  const prelude = data.slice(0, BmdMultiPagePrelude.length);
+export function isMultiPageSummaryBallot(data: Uint8Array): boolean {
+  const prelude = data.slice(0, MultiPageSummaryBallotPrelude.length);
   return (
-    prelude.length === BmdMultiPagePrelude.length &&
-    prelude.every((byte, i) => byte === BmdMultiPagePrelude[i])
+    prelude.length === MultiPageSummaryBallotPrelude.length &&
+    prelude.every((byte, i) => byte === MultiPageSummaryBallotPrelude[i])
   );
 }
 
@@ -131,11 +132,12 @@ export interface BallotConfig {
   isTestMode: boolean;
   precinctId: PrecinctId;
   /**
-   * For HMPB only
+   * For bubble ballots and multi-page summary ballots only
    */
   pageNumber?: number;
   /**
-   * For HMPB only, when using the SystemSettings.precinctScanEnableBallotAuditIds feature.
+   * For bubble ballots and multi-page summary ballots only. They appear on bubble
+   * ballots only when using the SystemSettings.precinctScanEnableBallotAuditIds feature.
    */
   ballotAuditId?: string;
 }
@@ -193,7 +195,7 @@ export function encodeBallotConfigInto(
 /**
  * Decodes a {@link BallotConfig} from a bit reader.
  */
-export function decodeBallotConfigFromReader(
+export function decodeSinglePageSummaryBallotConfigFromReader(
   election: Election,
   bits: BitReader,
   { readPageNumber = false }: { readPageNumber?: boolean } = {}
@@ -314,9 +316,9 @@ function encodeBallotVotesInto(
 }
 
 /**
- * Encodes a completed ballot, including metadata and votes, into a bit writer.
+ * Encodes a completed summary ballot, including metadata and votes, into a bit writer.
  */
-export function encodeBallotInto(
+export function encodeSinglePageSummaryBallotInto(
   election: Election,
   {
     ballotHash,
@@ -339,7 +341,7 @@ export function encodeBallotInto(
   const contests = getContests({ ballotStyle, election });
 
   return bits
-    .writeUint8(...BmdPrelude)
+    .writeUint8(...SummaryBallotPrelude)
     .writeString(sliceBallotHashForEncoding(ballotHash), {
       encoding: HexEncoding,
       includeLength: false,
@@ -361,14 +363,14 @@ export function encodeBallotInto(
 }
 
 /**
- * Encodes a completed ballot, including metadata and votes, as a byte array.
+ * Encodes a completed summary ballot, including metadata and votes, as a byte array.
  */
-export function encodeBallot(
+export function encodeSinglePageSummaryBallot(
   election: Election,
   ballot: CompletedBallot
 ): Uint8Array {
   const bits = new BitWriter();
-  encodeBallotInto(election, ballot, bits);
+  encodeSinglePageSummaryBallotInto(election, ballot, bits);
   return bits.toUint8Array();
 }
 
@@ -458,13 +460,13 @@ function decodeBallotVotes(
 }
 
 /**
- * Decodes a completed ballot, including metadata and votes, from a bit reader.
+ * Decodes a completed summary ballot, including metadata and votes, from a bit reader.
  */
-export function decodeBallotFromReader(
+export function decodeSinglePageSummaryBallotFromReader(
   electionDefinition: ElectionDefinition,
   bits: BitReader
 ): CompletedBallot {
-  if (!bits.skipUint8(...BmdPrelude)) {
+  if (!bits.skipUint8(...SummaryBallotPrelude)) {
     throw new Error(
       "expected leading prelude 'V' 'X' 0b00000002 but it was not found"
     );
@@ -482,7 +484,7 @@ export function decodeBallotFromReader(
 
   const { election } = electionDefinition;
   const { ballotStyleId, ballotType, isTestMode, precinctId } =
-    decodeBallotConfigFromReader(election, bits);
+    decodeSinglePageSummaryBallotConfigFromReader(election, bits);
   const ballotStyle = getBallotStyle({ ballotStyleId, election });
   const precinct = getPrecinctById({ precinctId, election });
 
@@ -505,25 +507,28 @@ export function decodeBallotFromReader(
 }
 
 /**
- * Decodes a completed ballot, including metadata and votes, from a byte array.
+ * Decodes a completed summary ballot, including metadata and votes, from a byte array.
  */
-export function decodeBallot(
+export function decodeSinglePageSummaryBallot(
   electionDefinition: ElectionDefinition,
   data: Uint8Array
 ): CompletedBallot {
-  return decodeBallotFromReader(electionDefinition, new BitReader(data));
+  return decodeSinglePageSummaryBallotFromReader(
+    electionDefinition,
+    new BitReader(data)
+  );
 }
 
 /**
- * Reads the ballot hash from an encoded BMD ballot metadata.
+ * Reads the ballot hash from an encoded ballot metadata.
  */
 export function decodeBallotHashFromReader(
   bits: BitReader
 ): string | undefined {
   if (
-    bits.skipUint8(...BmdPrelude) ||
-    bits.skipUint8(...HmpbPrelude) ||
-    bits.skipUint8(...BmdMultiPagePrelude)
+    bits.skipUint8(...SummaryBallotPrelude) ||
+    bits.skipUint8(...BubbleBallotPrelude) ||
+    bits.skipUint8(...MultiPageSummaryBallotPrelude)
   ) {
     return bits.readString({
       encoding: HexEncoding,
@@ -540,7 +545,7 @@ export function decodeBallotHash(data: Uint8Array): string | undefined {
 }
 
 /**
- * Encodes a hand-marked paper ballot's metadata into a bit writer.
+ * Encodes a bubble ballot's metadata into a bit writer.
  */
 export function encodeHmpbBallotPageMetadataInto(
   election: Election,
@@ -556,7 +561,7 @@ export function encodeHmpbBallotPageMetadataInto(
   bits: BitWriter
 ): BitWriter {
   return bits
-    .writeUint8(...HmpbPrelude)
+    .writeUint8(...BubbleBallotPrelude)
     .writeString(sliceBallotHashForEncoding(ballotHash), {
       encoding: HexEncoding,
       includeLength: false,
@@ -579,7 +584,7 @@ export function encodeHmpbBallotPageMetadataInto(
 }
 
 /**
- * Encodes hand-marked paper ballot page metadata as a byte array.
+ * Encodes bubble ballot page metadata as a byte array.
  */
 export function encodeHmpbBallotPageMetadata(
   election: Election,
@@ -593,14 +598,14 @@ export function encodeHmpbBallotPageMetadata(
 }
 
 /**
- * Maximum number of pages in a multi-page BMD ballot (same as HMPB).
+ * Maximum number of pages in a multi-page summary ballot (same as bubble ballot).
  */
-export const MAXIMUM_BMD_MULTI_PAGE_PAGES = MAXIMUM_PAGE_NUMBERS;
+export const MAXIMUM_MULTI_PAGE_SUMMARY_BALLOT_PAGES = MAXIMUM_PAGE_NUMBERS;
 
 /**
- * Data for a single page of a multi-page BMD ballot.
+ * Data for a single page of a multi-page summary ballot.
  */
-export interface BmdMultiPageBallotPage {
+export interface MultiPageSummaryBallotPage {
   ballotHash: string;
   ballotStyleId: BallotStyleId;
   precinctId: PrecinctId;
@@ -616,9 +621,9 @@ export interface BmdMultiPageBallotPage {
 }
 
 /**
- * Encodes a multi-page BMD ballot config (with page info) into the given bit writer.
+ * Encodes a multi-page summary ballot config (with page info) into the given bit writer.
  */
-function encodeBmdMultiPageBallotConfigInto(
+function encodeMultiPageSummaryBallotConfigInto(
   election: Election,
   {
     ballotStyleId,
@@ -628,7 +633,7 @@ function encodeBmdMultiPageBallotConfigInto(
     pageNumber,
     totalPages,
     ballotAuditId,
-  }: Omit<BmdMultiPageBallotPage, 'contests' | 'votes' | 'ballotHash'>,
+  }: Omit<MultiPageSummaryBallotPage, 'contests' | 'votes' | 'ballotHash'>,
   bits: BitWriter
 ): BitWriter {
   const { precincts, ballotStyles } = election;
@@ -646,23 +651,23 @@ function encodeBmdMultiPageBallotConfigInto(
   bits
     .writeUint(precinctIndex, { max: MAXIMUM_PRECINCTS })
     .writeUint(ballotStyleIndex, { max: MAXIMUM_BALLOT_STYLES })
-    .writeUint(pageNumber, { max: MAXIMUM_BMD_MULTI_PAGE_PAGES })
-    .writeUint(totalPages, { max: MAXIMUM_BMD_MULTI_PAGE_PAGES })
+    .writeUint(pageNumber, { max: MAXIMUM_MULTI_PAGE_SUMMARY_BALLOT_PAGES })
+    .writeUint(totalPages, { max: MAXIMUM_MULTI_PAGE_SUMMARY_BALLOT_PAGES })
     .writeBoolean(isTestMode);
 
   const ballotTypeIndex = Object.values(BallotType).indexOf(ballotType);
   bits.writeUint(ballotTypeIndex, { max: BallotTypeMaximumValue });
 
-  // Ballot audit ID is required for multi-page BMD ballots
+  // Ballot audit ID is required for multi-page summary ballots
   bits.writeString(ballotAuditId);
 
   return bits;
 }
 
 /**
- * Encodes a single page of a multi-page BMD ballot into a bit writer.
+ * Encodes a single page of a multi-page summary ballot into a bit writer.
  */
-export function encodeBmdMultiPageBallotInto(
+export function encodeMultiPageSummaryBallotPageInto(
   election: Election,
   {
     ballotHash,
@@ -675,7 +680,7 @@ export function encodeBmdMultiPageBallotInto(
     ballotAuditId,
     contests,
     votes,
-  }: BmdMultiPageBallotPage,
+  }: MultiPageSummaryBallotPage,
   bits: BitWriter
 ): BitWriter {
   const ballotStyle = getBallotStyle({ ballotStyleId, election });
@@ -687,14 +692,14 @@ export function encodeBmdMultiPageBallotInto(
   const contestsOnPage = new Set(contests.map((c) => c.id));
 
   return bits
-    .writeUint8(...BmdMultiPagePrelude)
+    .writeUint8(...MultiPageSummaryBallotPrelude)
     .writeString(sliceBallotHashForEncoding(ballotHash), {
       encoding: HexEncoding,
       includeLength: false,
       length: BALLOT_HASH_ENCODING_LENGTH,
     })
     .with(() =>
-      encodeBmdMultiPageBallotConfigInto(
+      encodeMultiPageSummaryBallotConfigInto(
         election,
         {
           ballotStyleId,
@@ -719,30 +724,34 @@ export function encodeBmdMultiPageBallotInto(
 }
 
 /**
- * Encodes a single page of a multi-page BMD ballot as a byte array.
+ * Encodes a single page of a multi-page summary ballot as a byte array.
  */
-export function encodeBmdMultiPageBallot(
+export function encodeMultiPageSummaryBallotPage(
   election: Election,
-  page: BmdMultiPageBallotPage
+  page: MultiPageSummaryBallotPage
 ): Uint8Array {
   const bits = new BitWriter();
-  encodeBmdMultiPageBallotInto(election, page, bits);
+  encodeMultiPageSummaryBallotPageInto(election, page, bits);
   return bits.toUint8Array();
 }
 
 /**
- * Decodes a multi-page BMD ballot config from a bit reader.
+ * Decodes a multi-page summary ballot config from a bit reader.
  */
-function decodeBmdMultiPageBallotConfigFromReader(
+function decodeMultiPageSummaryBallotConfigFromReader(
   election: Election,
   bits: BitReader
-): Omit<BmdMultiPageBallotPageMetadata, 'ballotHash' | 'contestIds'> {
+): Omit<MultiPageSummaryBallotPageMetadata, 'ballotHash' | 'contestIds'> {
   const { precincts, ballotStyles } = election;
 
   const precinctIndex = bits.readUint({ max: MAXIMUM_PRECINCTS });
   const ballotStyleIndex = bits.readUint({ max: MAXIMUM_BALLOT_STYLES });
-  const pageNumber = bits.readUint({ max: MAXIMUM_BMD_MULTI_PAGE_PAGES });
-  const totalPages = bits.readUint({ max: MAXIMUM_BMD_MULTI_PAGE_PAGES });
+  const pageNumber = bits.readUint({
+    max: MAXIMUM_MULTI_PAGE_SUMMARY_BALLOT_PAGES,
+  });
+  const totalPages = bits.readUint({
+    max: MAXIMUM_MULTI_PAGE_SUMMARY_BALLOT_PAGES,
+  });
   const isTestMode = bits.readBoolean();
 
   const ballotTypeIndex = bits.readUint({ max: BallotTypeMaximumValue });
@@ -751,7 +760,7 @@ function decodeBmdMultiPageBallotConfigFromReader(
     `ballot type index ${ballotTypeIndex} is invalid`
   );
 
-  // Ballot audit ID is required for multi-page BMD ballots
+  // Ballot audit ID is required for multi-page summary ballots
   const ballotAuditId = unsafeParse(BallotIdSchema, bits.readString());
 
   const ballotStyle = ballotStyles[ballotStyleIndex];
@@ -772,23 +781,23 @@ function decodeBmdMultiPageBallotConfigFromReader(
 }
 
 /**
- * Result of decoding a multi-page BMD ballot page.
+ * Result of decoding a multi-page summary ballot page.
  */
-export interface DecodedBmdMultiPageBallotPage {
-  metadata: BmdMultiPageBallotPageMetadata;
+export interface DecodedMultiPageSummaryBallotPage {
+  metadata: MultiPageSummaryBallotPageMetadata;
   votes: VotesDict;
 }
 
 /**
- * Decodes a single page of a multi-page BMD ballot from a bit reader.
+ * Decodes a single page of a multi-page summary ballot from a bit reader.
  */
-export function decodeBmdMultiPageBallotFromReader(
+export function decodeMultiPageSummaryBallotPageFromReader(
   electionDefinition: ElectionDefinition,
   bits: BitReader
-): DecodedBmdMultiPageBallotPage {
+): DecodedMultiPageSummaryBallotPage {
   assert(
-    bits.skipUint8(...BmdMultiPagePrelude),
-    'invalid BMD multi-page prelude'
+    bits.skipUint8(...MultiPageSummaryBallotPrelude),
+    'invalid multi-page summary ballot prelude'
   );
 
   const ballotHash = bits.readString({
@@ -802,7 +811,7 @@ export function decodeBmdMultiPageBallotFromReader(
   );
 
   const { election } = electionDefinition;
-  const config = decodeBmdMultiPageBallotConfigFromReader(election, bits);
+  const config = decodeMultiPageSummaryBallotConfigFromReader(election, bits);
   const { ballotStyleId } = config;
 
   const ballotStyle = getBallotStyle({ ballotStyleId, election });
@@ -836,13 +845,13 @@ export function decodeBmdMultiPageBallotFromReader(
 }
 
 /**
- * Decodes a single page of a multi-page BMD ballot from a byte array.
+ * Decodes a single page of a multi-page summary ballot from a byte array.
  */
-export function decodeBmdMultiPageBallot(
+export function decodeMultiPageSummaryBallotPage(
   electionDefinition: ElectionDefinition,
   data: Uint8Array
-): DecodedBmdMultiPageBallotPage {
-  return decodeBmdMultiPageBallotFromReader(
+): DecodedMultiPageSummaryBallotPage {
+  return decodeMultiPageSummaryBallotPageFromReader(
     electionDefinition,
     new BitReader(data)
   );

--- a/libs/ballot-encoder/src/stats.test.ts
+++ b/libs/ballot-encoder/src/stats.test.ts
@@ -9,7 +9,7 @@ import {
   unsafeParse,
 } from '@votingworks/types';
 import { DateWithoutTime } from '@votingworks/basics';
-import { encodeBallot } from '.';
+import { encodeSinglePageSummaryBallot } from '.';
 
 const district1Id = unsafeParse(DistrictIdSchema, 'district1');
 const electionId = unsafeParse(ElectionIdSchema, 'election-1');
@@ -55,7 +55,7 @@ const { ballotHash } = asElectionDefinition(election);
 
 test('smallest possible encoded ballot', () => {
   expect(
-    encodeBallot(election, {
+    encodeSinglePageSummaryBallot(election, {
       ballotHash,
       ballotStyleId: election.ballotStyles[0]!.id,
       precinctId: election.precincts[0]!.id,

--- a/libs/ballot-interpreter/src/cross_language_bmd.test.ts
+++ b/libs/ballot-interpreter/src/cross_language_bmd.test.ts
@@ -12,11 +12,11 @@ import {
   YesNoVote,
 } from '@votingworks/types';
 import {
-  decodeBallot,
-  decodeBmdMultiPageBallot,
-  encodeBallot,
-  encodeBmdMultiPageBallot,
-  BmdMultiPageBallotPage,
+  decodeSinglePageSummaryBallot,
+  decodeMultiPageSummaryBallotPage,
+  encodeSinglePageSummaryBallot,
+  encodeMultiPageSummaryBallotPage,
+  MultiPageSummaryBallotPage,
   sliceBallotHashForEncoding,
 } from '@votingworks/ballot-encoder';
 import {
@@ -165,7 +165,7 @@ test('single-page BMD ballot: TS encode matches Rust decode', async () => {
 
         const votes = generateVotesForContests(contests, includeWriteIns);
 
-        const encoded = encodeBallot(election, {
+        const encoded = encodeSinglePageSummaryBallot(election, {
           ballotHash,
           ballotStyleId: ballotStyle.id,
           precinctId: precinct.id,
@@ -250,7 +250,7 @@ test('multi-page BMD ballot: TS encode matches Rust decode', async () => {
           const pageNumber = pageIdx + 1;
           const votes = generateVotesForContests(pageContests, includeWriteIns);
 
-          const page: BmdMultiPageBallotPage = {
+          const page: MultiPageSummaryBallotPage = {
             ballotHash,
             ballotStyleId: ballotStyle.id,
             precinctId: precinct.id,
@@ -263,7 +263,7 @@ test('multi-page BMD ballot: TS encode matches Rust decode', async () => {
             votes,
           };
 
-          const encoded = encodeBmdMultiPageBallot(election, page);
+          const encoded = encodeMultiPageSummaryBallotPage(election, page);
 
           const result = await napi.decodeBmdBallotData(
             election,
@@ -384,7 +384,7 @@ test('single-page BMD ballot: Rust encode matches TS decode', async () => {
 
         const encoded = await napi.encodeBmdBallotData(election, rustRecord);
 
-        const decoded = decodeBallot(
+        const decoded = decodeSinglePageSummaryBallot(
           electionDefinition,
           new Uint8Array(encoded)
         );
@@ -464,7 +464,7 @@ test('multi-page BMD ballot: Rust encode matches TS decode', async () => {
 
           const encoded = await napi.encodeBmdBallotData(election, rustRecord);
 
-          const decoded = decodeBmdMultiPageBallot(
+          const decoded = decodeMultiPageSummaryBallotPage(
             electionDefinition,
             new Uint8Array(encoded)
           );

--- a/libs/ballot-interpreter/src/summary-ballot/interpret.ts
+++ b/libs/ballot-interpreter/src/summary-ballot/interpret.ts
@@ -1,7 +1,7 @@
 import { ImageData } from 'canvas';
 import { Result, err, ok } from '@votingworks/basics';
 import {
-  BmdMultiPageBallotPageMetadata,
+  MultiPageSummaryBallotPageMetadata,
   CompletedBallot,
   ElectionDefinition,
   SheetOf,
@@ -10,10 +10,10 @@ import {
 } from '@votingworks/types';
 import {
   BALLOT_HASH_ENCODING_LENGTH,
-  decodeBallot,
+  decodeSinglePageSummaryBallot,
   decodeBallotHash,
-  decodeBmdMultiPageBallot,
-  isBmdMultiPageBallot,
+  decodeMultiPageSummaryBallotPage,
+  isMultiPageSummaryBallot,
 } from '@votingworks/ballot-encoder';
 import { crop } from '@votingworks/image-utils';
 import { DetectQrCodeError, detectInBallot } from './utils/qrcode';
@@ -37,7 +37,7 @@ export interface SinglePageInterpretation {
  */
 export interface MultiPageInterpretation {
   type: 'multi-page';
-  metadata: BmdMultiPageBallotPageMetadata;
+  metadata: MultiPageSummaryBallotPageMetadata;
   votes: VotesDict;
   summaryBallotImage: ImageData;
   blankPageImage: ImageData;
@@ -139,9 +139,9 @@ export async function interpret(
 
   const blankPageImage = frontResult.isOk() ? croppedCard[1] : croppedCard[0];
 
-  // Check if this is a multi-page BMD ballot
-  if (isBmdMultiPageBallot(foundQrCode.data)) {
-    const decoded = decodeBmdMultiPageBallot(
+  // Check if this is a multi-page summary ballot
+  if (isMultiPageSummaryBallot(foundQrCode.data)) {
+    const decoded = decodeMultiPageSummaryBallotPage(
       electionDefinition,
       foundQrCode.data
     );
@@ -157,7 +157,7 @@ export async function interpret(
   // Single-page BMD ballot
   return ok({
     type: 'single-page',
-    ballot: decodeBallot(electionDefinition, foundQrCode.data),
+    ballot: decodeSinglePageSummaryBallot(electionDefinition, foundQrCode.data),
     summaryBallotImage,
     blankPageImage,
   });

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -1171,7 +1171,7 @@ export const HmpbBallotPageMetadataSchema = BallotMetadataSchema.extend({
  * Metadata for a single page of a multi-page BMD summary ballot.
  * Used when VxMark prints ballots that span multiple pages.
  */
-export interface BmdMultiPageBallotPageMetadata extends BallotMetadata {
+export interface MultiPageSummaryBallotPageMetadata extends BallotMetadata {
   pageNumber: number;
   totalPages: number;
   /**
@@ -1183,14 +1183,13 @@ export interface BmdMultiPageBallotPageMetadata extends BallotMetadata {
    */
   contestIds: ContestId[];
 }
-export const BmdMultiPageBallotPageMetadataSchema = BallotMetadataSchema.extend(
-  {
+export const MultiPageSummaryBallotPageMetadataSchema =
+  BallotMetadataSchema.extend({
     pageNumber: z.number(),
     totalPages: z.number(),
     ballotAuditId: BallotIdSchema,
     contestIds: z.array(ContestIdSchema),
-  }
-) satisfies z.ZodType<BmdMultiPageBallotPageMetadata>;
+  }) satisfies z.ZodType<MultiPageSummaryBallotPageMetadata>;
 
 export interface TargetShape {
   bounds: Rect;

--- a/libs/types/src/interpretation.ts
+++ b/libs/types/src/interpretation.ts
@@ -5,8 +5,8 @@ import {
   AdjudicationReasonInfo,
   BallotMetadata,
   BallotMetadataSchema,
-  BmdMultiPageBallotPageMetadata,
-  BmdMultiPageBallotPageMetadataSchema,
+  MultiPageSummaryBallotPageMetadata,
+  MultiPageSummaryBallotPageMetadataSchema,
   ContestId,
   ContestIdSchema,
   HmpbBallotPageMetadata,
@@ -46,7 +46,7 @@ export const InterpretedBmdPageSchema: z.ZodSchema<InterpretedBmdPage> =
  */
 export interface InterpretedBmdMultiPagePage {
   type: 'InterpretedBmdMultiPagePage';
-  metadata: BmdMultiPageBallotPageMetadata;
+  metadata: MultiPageSummaryBallotPageMetadata;
   /** Votes for only the contests on this page */
   votes: VotesDict;
   adjudicationInfo: AdjudicationInfo;
@@ -54,7 +54,7 @@ export interface InterpretedBmdMultiPagePage {
 export const InterpretedBmdMultiPagePageSchema: z.ZodSchema<InterpretedBmdMultiPagePage> =
   z.object({
     type: z.literal('InterpretedBmdMultiPagePage'),
-    metadata: BmdMultiPageBallotPageMetadataSchema,
+    metadata: MultiPageSummaryBallotPageMetadataSchema,
     votes: VotesDictSchema,
     adjudicationInfo: AdjudicationInfoSchema,
   });

--- a/libs/ui/src/bmd_paper_ballot.test.tsx
+++ b/libs/ui/src/bmd_paper_ballot.test.tsx
@@ -19,7 +19,7 @@ import {
   electionFamousNames2021Fixtures,
 } from '@votingworks/fixtures';
 
-import { encodeBallot } from '@votingworks/ballot-encoder';
+import { encodeSinglePageSummaryBallot } from '@votingworks/ballot-encoder';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { fromByteArray } from 'base64-js';
 import { assertDefined, find } from '@votingworks/basics';
@@ -54,10 +54,10 @@ const electionFamousNamesDefinition =
 vi.mock(import('@votingworks/ballot-encoder'), async (importActual) => ({
   ...(await importActual()),
   // mock encoded ballot so BMD ballot QR code does not change with every change to election definition
-  encodeBallot: vi.fn(),
+  encodeSinglePageSummaryBallot: vi.fn(),
 }));
 
-const encodeBallotMock = vi.mocked(encodeBallot);
+const encodeBallotMock = vi.mocked(encodeSinglePageSummaryBallot);
 const mockEncodedBallotData = new Uint8Array([0, 1, 2, 3]);
 
 beforeEach(() => {
@@ -339,7 +339,7 @@ test('BmdPaperBallot renders seal', () => {
   screen.getByTestId('seal');
 });
 
-test('BmdPaperBallot passes expected data to encodeBallot for use in QR code', () => {
+test('BmdPaperBallot passes expected data to encodeSinglePageSummaryBallot for use in QR code', () => {
   const QrCodeSpy = vi.spyOn(QrCodeModule, 'QrCode');
 
   renderBmdPaperBallot({
@@ -354,7 +354,7 @@ test('BmdPaperBallot passes expected data to encodeBallot for use in QR code', (
     },
   });
 
-  expect(encodeBallot).toBeCalledWith(
+  expect(encodeSinglePageSummaryBallot).toBeCalledWith(
     electionGeneralDefinition.election,
     expect.objectContaining({
       ballotStyleId: '5' as BallotStyleId,

--- a/libs/ui/src/bmd_paper_ballot.tsx
+++ b/libs/ui/src/bmd_paper_ballot.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import styled from 'styled-components';
 
 import {
-  encodeBallot,
-  encodeBmdMultiPageBallot,
+  encodeSinglePageSummaryBallot,
+  encodeMultiPageSummaryBallotPage,
 } from '@votingworks/ballot-encoder';
 import {
   BallotStyle,
@@ -728,7 +728,7 @@ export function BmdPaperBallot({
 
   // Encode ballot using appropriate format
   const encodedBallot = isMultiPage
-    ? encodeBmdMultiPageBallot(election, {
+    ? encodeMultiPageSummaryBallotPage(election, {
         ballotHash,
         precinctId,
         ballotStyleId,
@@ -740,7 +740,7 @@ export function BmdPaperBallot({
         ballotAuditId,
         contests,
       })
-    : encodeBallot(election, {
+    : encodeSinglePageSummaryBallot(election, {
         ballotHash,
         precinctId,
         ballotStyleId,


### PR DESCRIPTION
## Overview

VxMark (a ballot-marking device) can now print bubble ballots, so the old BMD-vs-HMPB dichotomy in the ballot encoder has become misleading:

- **bubble ballots** are no longer necessarily hand-marked (the BMD can print them), and
- **ballot-marking devices** no longer necessarily produce summary ballots.

This PR renames the `ballot-encoder` symbols and comments to describe the **ballot format** itself (single-page summary / multi-page summary / bubble) rather than the **device** that produced it, and updates the `ballot-interpreter` and `ui` consumers to match.

Key renames:

| Old | New |
| --- | --- |
| `BmdPrelude` | `SummaryBallotPrelude` |
| `HmpbPrelude` | `BubbleBallotPrelude` |
| `BmdMultiPagePrelude` | `MultiPageSummaryBallotPrelude` |
| `encodeBallot` | `encodeSinglePageSummaryBallot` |
| `decodeBallot` | `decodeSinglePageSummaryBallot` |
| `encodeBmdMultiPageBallot` | `encodeMultiPageSummaryBallotPage` |
| `decodeBmdMultiPageBallot` | `decodeMultiPageSummaryBallotPage` |
| `isBmdMultiPageBallot` | `isMultiPageSummaryBallot` |
| `BmdMultiPageBallotPage(Metadata)` | `MultiPageSummaryBallotPage(Metadata)` |
| `MAXIMUM_BMD_MULTI_PAGE_PAGES` | `MAXIMUM_MULTI_PAGE_SUMMARY_BALLOT_PAGES` |

...plus the related `*Into` / `*FromReader` variants, the metadata schema, and doc comments.

The single-page decode functions (`decodeBallot`, `decodeBallotFromReader`, `decodeBallotConfigFromReader`) were also renamed to the explicit `decodeSinglePageSummaryBallot*` form so the decode side mirrors the `encodeSinglePageSummaryBallot*` naming.

The broader `HmpbBallotPageMetadata` type family (used across ~15 files) is intentionally left for a follow-up to keep this change focused.

## Demo Video or Screenshot

N/A — internal rename, no behavior change.

## Testing Plan

No behavior change; relies on existing test suites. Verified locally (rebased on latest `main`):

- `libs/types` + `libs/ballot-encoder` + `libs/usb-drive` + `libs/ui` (and deps) build clean
- `libs/ui` + `libs/ballot-interpreter` typecheck clean
- Tests pass: `ballot-encoder` (86), `ui/bmd_paper_ballot` (39), `ballot-interpreter/cross_language_bmd` (4)
- `lint:fix` clean across affected packages

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
