### PR TITLE
test(scan): add write-in image report screenshot + speed up scan screenshot suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
           path: apps/admin/integration-testing/test-results/
       - when:
           condition:
-            equal: [ main, << pipeline.git.branch >> ]
+            equal: [ drew/scan-write-in-report-screenshot, << pipeline.git.branch >> ]
           steps:
             - aws-cli/setup
             - run:
@@ -205,7 +205,7 @@ jobs:
           path: apps/central-scan/integration-testing/test-results/
       - when:
           condition:
-            equal: [ main, << pipeline.git.branch >> ]
+            equal: [ drew/scan-write-in-report-screenshot, << pipeline.git.branch >> ]
           steps:
             - aws-cli/setup
             - run:
@@ -349,7 +349,7 @@ jobs:
           path: apps/mark-scan/integration-testing/test-results/
       - when:
           condition:
-            equal: [ main, << pipeline.git.branch >> ]
+            equal: [ drew/scan-write-in-report-screenshot, << pipeline.git.branch >> ]
           steps:
             - aws-cli/setup
             - run:
@@ -443,7 +443,7 @@ jobs:
           path: apps/mark/integration-testing/test-results/
       - when:
           condition:
-            equal: [ main, << pipeline.git.branch >> ]
+            equal: [ drew/scan-write-in-report-screenshot, << pipeline.git.branch >> ]
           steps:
             - aws-cli/setup
             - run:
@@ -561,7 +561,7 @@ jobs:
           path: apps/print/integration-testing/test-results/
       - when:
           condition:
-            equal: [ main, << pipeline.git.branch >> ]
+            equal: [ drew/scan-write-in-report-screenshot, << pipeline.git.branch >> ]
           steps:
             - aws-cli/setup
             - run:
@@ -655,7 +655,7 @@ jobs:
           path: apps/scan/integration-testing/test-results/
       - when:
           condition:
-            equal: [ main, << pipeline.git.branch >> ]
+            equal: [ drew/scan-write-in-report-screenshot, << pipeline.git.branch >> ]
           steps:
             - aws-cli/setup
             - run:
@@ -1795,7 +1795,7 @@ workflows:
             - test-apps-scan-integration-testing
           filters:
             branches:
-              only: main
+              only: drew/scan-write-in-report-screenshot
 
 commands:
   checkout-and-install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
           path: apps/admin/integration-testing/test-results/
       - when:
           condition:
-            equal: [ drew/scan-write-in-report-screenshot, << pipeline.git.branch >> ]
+            equal: [ main, << pipeline.git.branch >> ]
           steps:
             - aws-cli/setup
             - run:
@@ -205,7 +205,7 @@ jobs:
           path: apps/central-scan/integration-testing/test-results/
       - when:
           condition:
-            equal: [ drew/scan-write-in-report-screenshot, << pipeline.git.branch >> ]
+            equal: [ main, << pipeline.git.branch >> ]
           steps:
             - aws-cli/setup
             - run:
@@ -349,7 +349,7 @@ jobs:
           path: apps/mark-scan/integration-testing/test-results/
       - when:
           condition:
-            equal: [ drew/scan-write-in-report-screenshot, << pipeline.git.branch >> ]
+            equal: [ main, << pipeline.git.branch >> ]
           steps:
             - aws-cli/setup
             - run:
@@ -443,7 +443,7 @@ jobs:
           path: apps/mark/integration-testing/test-results/
       - when:
           condition:
-            equal: [ drew/scan-write-in-report-screenshot, << pipeline.git.branch >> ]
+            equal: [ main, << pipeline.git.branch >> ]
           steps:
             - aws-cli/setup
             - run:
@@ -561,7 +561,7 @@ jobs:
           path: apps/print/integration-testing/test-results/
       - when:
           condition:
-            equal: [ drew/scan-write-in-report-screenshot, << pipeline.git.branch >> ]
+            equal: [ main, << pipeline.git.branch >> ]
           steps:
             - aws-cli/setup
             - run:
@@ -655,7 +655,7 @@ jobs:
           path: apps/scan/integration-testing/test-results/
       - when:
           condition:
-            equal: [ drew/scan-write-in-report-screenshot, << pipeline.git.branch >> ]
+            equal: [ main, << pipeline.git.branch >> ]
           steps:
             - aws-cli/setup
             - run:
@@ -1795,7 +1795,7 @@ workflows:
             - test-apps-scan-integration-testing
           filters:
             branches:
-              only: drew/scan-write-in-report-screenshot
+              only: main
 
 commands:
   checkout-and-install:

--- a/apps/scan/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/scan/integration-testing/e2e/screenshots.spec.ts
@@ -1,4 +1,4 @@
-import test from '@playwright/test';
+import test, { expect } from '@playwright/test';
 import { mockCardRemoval } from '@votingworks/auth';
 import { mockElectionPackageFileTree } from '@votingworks/backend';
 import {
@@ -338,12 +338,15 @@ test('voting', async ({ page }, testInfo) => {
   await page.getByText('Insert Your Ballot').waitFor();
 
   // Successful scan: full votes, capture scanning screen then counted screen.
+  // Throughout this test, after a ballot is scanned we move straight to the
+  // next action without waiting for the "Insert Your Ballot" screen to return —
+  // the backend re-enables scanning as soon as a ballot is accepted, so we don't
+  // need to wait out the (3s) accepted-screen display hold.
   mockPdiScannerHandler.insertSheet(fullPdf);
   await page.getByText('Please wait').waitFor({ timeout: 15000 });
   await screenshot('scanning');
   await page.getByText('Your ballot was counted!').waitFor({ timeout: 15000 });
   await screenshot('ballot-counted');
-  await page.getByText('Insert Your Ballot').waitFor({ timeout: 15000 });
 
   // Blank ballot warning.
   mockPdiScannerHandler.insertSheet(blankPdf);
@@ -352,16 +355,18 @@ test('voting', async ({ page }, testInfo) => {
     .waitFor({ timeout: 15000 });
   await screenshot('blank-ballot-warning');
   await page.getByRole('button', { name: 'Cast Ballot' }).click();
-  await page.getByText('Insert Your Ballot').waitFor({ timeout: 15000 });
 
-  // Undervote warning.
+  // Undervote warning. Each subsequent warning scan is inserted right after the
+  // previous "Cast Ballot" click, without waiting for "Insert Your Ballot" in
+  // between — the backend re-enables scanning as soon as a ballot is accepted.
+  // The review screen ("Review Your Ballot") is distinct from the prior
+  // accepted screen, so waiting for it is unambiguous.
   mockPdiScannerHandler.insertSheet(undervotePdf);
   await page
     .getByRole('heading', { name: 'Review Your Ballot' })
     .waitFor({ timeout: 15000 });
   await screenshot('undervote-warning');
   await page.getByRole('button', { name: 'Cast Ballot' }).click();
-  await page.getByText('Insert Your Ballot').waitFor({ timeout: 15000 });
 
   // Overvote warning.
   mockPdiScannerHandler.insertSheet(overvotePdf);
@@ -370,7 +375,6 @@ test('voting', async ({ page }, testInfo) => {
     .waitFor({ timeout: 15000 });
   await screenshot('overvote-warning');
   await page.getByRole('button', { name: 'Cast Ballot' }).click();
-  await page.getByText('Insert Your Ballot').waitFor({ timeout: 15000 });
 
   // Mixed overvote + undervote warning.
   mockPdiScannerHandler.insertSheet(mixedPdf);
@@ -463,7 +467,6 @@ test('voting', async ({ page }, testInfo) => {
 
   mockPdiScannerHandler.insertSheet(fullPdf);
   await page.getByText('Your ballot was counted!').waitFor({ timeout: 15000 });
-  await page.getByText('Insert Your Ballot').waitFor({ timeout: 15000 });
 
   // Pause voting.
   logInAsPollWorker(election);
@@ -493,7 +496,6 @@ test('voting', async ({ page }, testInfo) => {
 
   mockPdiScannerHandler.insertSheet(fullPdf);
   await page.getByText('Your ballot was counted!').waitFor({ timeout: 15000 });
-  await page.getByText('Insert Your Ballot').waitFor({ timeout: 15000 });
 
   // Closing polls flow (multi-batch).
   logInAsPollWorker(election);
@@ -667,13 +669,21 @@ test('write-in-report', async ({ page }, testInfo) => {
   mockCardRemoval();
   await page.getByText('Insert Your Ballot').waitFor();
 
-  for (const writeInPdf of [writeInPdfA, writeInPdfB]) {
+  // Scan each ballot. Between scans we wait only for the scanned-ballot count to
+  // advance, not for the "Insert Your Ballot" screen to return — the backend
+  // re-enables scanning as soon as a ballot is accepted, so we can insert the
+  // next sheet without waiting out the (3s) accepted-screen display hold. We
+  // assert on the count (rather than the "counted" text, which is identical
+  // between consecutive successful scans) so each scan is confirmed distinctly.
+  const writeInPdfs = [writeInPdfA, writeInPdfB];
+  for (const [index, writeInPdf] of writeInPdfs.entries()) {
     mockPdiScannerHandler.insertSheet(writeInPdf);
-    await page
-      .getByText('Your ballot was counted!')
-      .waitFor({ timeout: 15000 });
-    await page.getByText('Insert Your Ballot').waitFor({ timeout: 15000 });
+    await expect(page.getByTestId('ballot-count')).toHaveText(
+      String(index + 1),
+      { timeout: 15000 }
+    );
   }
+  await page.getByText('Insert Your Ballot').waitFor({ timeout: 15000 });
 
   // Close polls.
   logInAsPollWorker(election);

--- a/apps/scan/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/scan/integration-testing/e2e/screenshots.spec.ts
@@ -356,11 +356,7 @@ test('voting', async ({ page }, testInfo) => {
   await screenshot('blank-ballot-warning');
   await page.getByRole('button', { name: 'Cast Ballot' }).click();
 
-  // Undervote warning. Each subsequent warning scan is inserted right after the
-  // previous "Cast Ballot" click, without waiting for "Insert Your Ballot" in
-  // between — the backend re-enables scanning as soon as a ballot is accepted.
-  // The review screen ("Review Your Ballot") is distinct from the prior
-  // accepted screen, so waiting for it is unambiguous.
+  // Undervote warning.
   mockPdiScannerHandler.insertSheet(undervotePdf);
   await page
     .getByRole('heading', { name: 'Review Your Ballot' })
@@ -669,12 +665,10 @@ test('write-in-report', async ({ page }, testInfo) => {
   mockCardRemoval();
   await page.getByText('Insert Your Ballot').waitFor();
 
-  // Scan each ballot. Between scans we wait only for the scanned-ballot count to
-  // advance, not for the "Insert Your Ballot" screen to return — the backend
-  // re-enables scanning as soon as a ballot is accepted, so we can insert the
-  // next sheet without waiting out the (3s) accepted-screen display hold. We
-  // assert on the count (rather than the "counted" text, which is identical
-  // between consecutive successful scans) so each scan is confirmed distinctly.
+  // Scan each ballot, inserting the next as soon as the count advances rather
+  // than waiting for the "Insert Your Ballot" screen (see the voting test). We
+  // assert on the count rather than the "counted" text, which is identical
+  // between consecutive successful scans.
   const writeInPdfs = [writeInPdfA, writeInPdfB];
   for (const [index, writeInPdf] of writeInPdfs.entries()) {
     mockPdiScannerHandler.insertSheet(writeInPdf);

--- a/apps/scan/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/scan/integration-testing/e2e/screenshots.spec.ts
@@ -15,6 +15,7 @@ import {
   renderMarkedBallots,
   withOvervote,
   withUndervote,
+  withWriteIns,
 } from '@votingworks/integration-test-utils';
 import {
   AdjudicationReason,
@@ -594,4 +595,110 @@ test('accessibility', async ({ page }, testInfo) => {
   await screenshot('a11y-settings-audio');
   await page.getByRole('button', { name: 'Done' }).click();
   await page.getByText('Insert Your Ballot').waitFor();
+});
+
+test('write-in-report', async ({ page }, testInfo) => {
+  const namer = createScreenshotNamer(testInfo);
+  const fixtureSet = electionFamousNames2021Fixtures;
+  const electionDefinition = fixtureSet.readElectionDefinition();
+  const { election } = electionDefinition;
+  const usbHandler = getMockFileUsbDriveHandler();
+  const { screenshot, screenshotWithButtonHighlight } =
+    buildIntegrationTestHelper(page, namer);
+
+  // Enables the "Print Write-In Image Report" button on the poll worker screen
+  // after polls close.
+  const systemSettings: SystemSettings = {
+    ...DEFAULT_SYSTEM_SETTINGS,
+    precinctScanEnableWriteInImageReport: true,
+  };
+
+  const candidateContests = election.contests.filter(
+    (c): c is CandidateContest => c.type === 'candidate' && !!c.allowWriteIns
+  );
+  const singleSeatContest = candidateContests.find((c) => c.seats === 1);
+  const multiSeatContest = candidateContests.find((c) => c.seats > 1);
+  /* istanbul ignore next */
+  if (!singleSeatContest || !multiSeatContest) {
+    throw new Error('Expected single- and multi-seat write-in contests');
+  }
+
+  // Two ballots producing a non-uniform write-in report: one single-seat
+  // contest with a single write-in, and one multi-seat contest with two
+  // distinct write-ins.
+  const fullVotes = createFullyVotedBallot(electionDefinition, '1-1');
+  const ballotSpec = {
+    electionDefinition,
+    ballotStyleId: '1-1',
+    precinctId: '20',
+  } as const;
+  const [writeInPdfA, writeInPdfB] = await renderMarkedBallots([
+    {
+      ...ballotSpec,
+      votes: withWriteIns(fullVotes, singleSeatContest, ['BOB']),
+    },
+    {
+      ...ballotSpec,
+      votes: withWriteIns(fullVotes, multiSeatContest, ['ALICE', 'CARLOS']),
+    },
+  ]);
+
+  await page.goto('/');
+  await logInAsElectionManager(page, election);
+  usbHandler.insert(
+    await mockElectionPackageFileTree({ electionDefinition, systemSettings })
+  );
+  await page.getByText('Election Manager Menu').waitFor();
+  await page.getByLabel(/select a polling place/i).click({ force: true });
+  await page.getByText('West Lincoln', { exact: true }).click();
+  await page.locator('.search-select').getByText('West Lincoln').waitFor();
+  await page.getByText('Official Ballot Mode').click();
+  await page.getByText('Test Ballot Mode').waitFor();
+
+  mockCardRemoval();
+  await page.getByText('Insert a poll worker card to open polls.').waitFor();
+
+  logInAsPollWorker(election);
+  await page.getByRole('button', { name: 'Open Polls' }).click();
+  await page
+    .getByRole('heading', { name: 'Polls Opened' })
+    .waitFor({ timeout: 60000 });
+
+  mockCardRemoval();
+  await page.getByText('Insert Your Ballot').waitFor();
+
+  for (const writeInPdf of [writeInPdfA, writeInPdfB]) {
+    mockPdiScannerHandler.insertSheet(writeInPdf);
+    await page
+      .getByText('Your ballot was counted!')
+      .waitFor({ timeout: 15000 });
+    await page.getByText('Insert Your Ballot').waitFor({ timeout: 15000 });
+  }
+
+  // Close polls.
+  logInAsPollWorker(election);
+  await page.getByText('Do you want to close the polls?').waitFor();
+  await page.getByRole('button', { name: 'Close Polls' }).click();
+  await page.getByRole('heading', { name: 'Polls Closed' }).waitFor({
+    timeout: 60000,
+  });
+
+  mockCardRemoval();
+  await page.getByText('Voting is complete.').waitFor();
+
+  // Poll worker menu after polls are closed — print the write-in image report.
+  logInAsPollWorker(election);
+  await page
+    .getByText('Voting is complete and the polls cannot be reopened.')
+    .waitFor();
+  await screenshotWithButtonHighlight(
+    'Print Write-In Image Report',
+    'pw-print-write-in-image-report-button'
+  );
+  await page
+    .getByRole('button', { name: 'Print Write-In Image Report' })
+    .click();
+  await page.getByText('Write-In Image Report Printed').waitFor();
+  await screenshot('pw-write-in-image-report-printed');
+  await capturePrintedReport('write-in-image-report', namer);
 });

--- a/libs/integration-test-utils/src/ballots.ts
+++ b/libs/integration-test-utils/src/ballots.ts
@@ -98,6 +98,34 @@ export function withOvervote(
 }
 
 /**
+ * Returns a copy of `votes` with the given candidate contest's trailing pick(s)
+ * replaced by write-in candidate(s) — one per name, at successive
+ * `writeInIndex`es starting from 0. The contest must `allowWriteIns` and have at
+ * least `names.length` seats.
+ */
+export function withWriteIns(
+  votes: VotesDict,
+  contest: CandidateContest,
+  names: string[]
+): VotesDict {
+  const current = (votes[contest.id] ?? []) as CandidateContest['candidates'];
+  // Keep enough existing picks that the total stays within `seats`.
+  const kept = current.slice(0, contest.seats - names.length);
+  return {
+    ...votes,
+    [contest.id]: [
+      ...kept,
+      ...names.map((name, writeInIndex) => ({
+        id: `write-in-${writeInIndex}`,
+        name,
+        isWriteIn: true,
+        writeInIndex,
+      })),
+    ],
+  };
+}
+
+/**
  * Renders one or more marked HMPB ballot PDFs to temp files and returns their
  * paths. Reuses a single Chromium instance across all renders so the startup
  * cost is paid once regardless of how many ballots are requested.


### PR DESCRIPTION
## Overview

Adds a **Write-In Image Report** screenshot to the VxScan integration screenshot
suite, and speeds up the suite along the way.

- New `write-in-report` test: enables `precinctScanEnableWriteInImageReport`,
  scans ballots with non-uniform write-ins (one single-seat contest with one
  write-in, one multi-seat contest with two distinct write-ins), reaches the
  poll-worker `polls_closed_final` screen, prints the report, and captures it.
- New reusable `withWriteIns` helper in `@votingworks/integration-test-utils`
  for constructing write-in votes.
- **Suite speedup (no production change):** the precinct scanner re-enables
  scanning as soon as a ballot is accepted; the ~3s "Your ballot was counted!"
  screen is only a display hold and does not block scanning. The suite was
  waiting for "Insert Your Ballot" to reappear between scans, paying that hold
  on every scan. Now we insert the next sheet as soon as the current one is
  confirmed (asserting on the scanned-ballot count for consecutive successful
  scans, or the distinct review screen for warning scans). This cut the
  `voting` test from ~50s to ~30s and the whole `scan` screenshot suite from
  ~84s to ~57s.

### ⚠️ Contains a temporary commit to revert before merge

`TEMP: run screenshot gallery on this branch` points the CircleCI screenshot
S3-upload steps and the `notify-gallery` job at this branch instead of `main`,
so the gallery can be previewed before merge. **This commit must be reverted
before merging.**

## Demo Video or Screenshot

Write-In Image Report (captured by the new test): BOB under Mayor, ALICE +
CARLOS under Board of Alderman, other contests at 0.

## Testing Plan

- `pnpm --filter @votingworks/integration-test-utils... build`
- From `apps/scan/integration-testing`: run the Playwright screenshot suite;
  all four tests pass and the `write-in-image-report` PNG renders the expected
  non-uniform write-ins.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
