### PR TITLE
update esbuild to 0.28.1

### DIFF
--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -80,7 +80,7 @@
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "csv-parse": "^5.5.0",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "fast-check": "2.23.2",

--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -68,7 +68,7 @@
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/bmd-ballot-fixtures": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "fast-check": "2.23.2",

--- a/apps/central-scan/frontend/package.json
+++ b/apps/central-scan/frontend/package.json
@@ -96,7 +96,7 @@
     "@votingworks/monorepo-utils": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "@votingworks/usb-drive": "workspace:*",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "history": "4.10.1",

--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -98,7 +98,7 @@
     "@votingworks/fs": "workspace:*",
     "@votingworks/image-utils": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",

--- a/apps/design/frontend/package.json
+++ b/apps/design/frontend/package.json
@@ -69,7 +69,7 @@
     "debug": "4.3.4",
     "dotenv": "16.3.1",
     "dotenv-expand": "9.0.0",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "js-file-download": "0.4.12",
     "luxon": "^3.0.0",

--- a/apps/mark-scan/backend/package.json
+++ b/apps/mark-scan/backend/package.json
@@ -71,7 +71,7 @@
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "copyfiles": "^2.4.1",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",

--- a/apps/mark/backend/package.json
+++ b/apps/mark/backend/package.json
@@ -65,7 +65,7 @@
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "copyfiles": "^2.4.1",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",

--- a/apps/pollbook/backend/package.json
+++ b/apps/pollbook/backend/package.json
@@ -80,7 +80,7 @@
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/image-utils": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",

--- a/apps/pollbook/frontend/package.json
+++ b/apps/pollbook/frontend/package.json
@@ -57,7 +57,7 @@
     "debug": "4.3.4",
     "dotenv": "16.3.1",
     "dotenv-expand": "9.0.0",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "history": "4.10.1",
     "http-proxy-middleware": "3.0.3",

--- a/apps/print/backend/package.json
+++ b/apps/print/backend/package.json
@@ -68,7 +68,7 @@
     "@votingworks/image-utils": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "copyfiles": "^2.4.1",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",

--- a/apps/print/frontend/package.json
+++ b/apps/print/frontend/package.json
@@ -55,7 +55,7 @@
     "debug": "4.3.4",
     "dotenv": "16.3.1",
     "dotenv-expand": "9.0.0",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "history": "4.10.1",
     "http-proxy-middleware": "3.0.3",

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -74,7 +74,7 @@
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/hmpb": "workspace:*",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "fast-check": "2.23.2",

--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -64,7 +64,7 @@
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/fs": "workspace:*",
     "@votingworks/hmpb": "workspace:*",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "fast-check": "2.23.2",

--- a/libs/custom-paper-handler/package.json
+++ b/libs/custom-paper-handler/package.json
@@ -38,7 +38,7 @@
     "@types/w3c-web-usb": "1.0.8",
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/test-utils": "workspace:*",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",

--- a/libs/fixture-generators/package.json
+++ b/libs/fixture-generators/package.json
@@ -37,7 +37,7 @@
     "@votingworks/utils": "workspace:*",
     "csv-stringify": "^6.4.0",
     "debug": "4.3.4",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "js-sha256": "^0.9.0",
     "jszip": "^3.9.1",

--- a/libs/fujitsu-thermal-printer/package.json
+++ b/libs/fujitsu-thermal-printer/package.json
@@ -38,7 +38,7 @@
     "@types/node": "20.17.31",
     "@types/w3c-web-usb": "1.0.8",
     "@vitest/coverage-istanbul": "^4.1.6",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",

--- a/libs/hmpb/package.json
+++ b/libs/hmpb/package.json
@@ -66,7 +66,7 @@
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/monorepo-utils": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "fast-check": "2.23.2",

--- a/libs/image-utils/package.json
+++ b/libs/image-utils/package.json
@@ -40,7 +40,7 @@
     "@types/tmp": "0.2.4",
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/fixtures": "workspace:*",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "fast-check": "2.23.2",

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -48,7 +48,7 @@
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "fast-check": "2.23.2",

--- a/libs/networking/package.json
+++ b/libs/networking/package.json
@@ -36,7 +36,7 @@
     "@types/node": "20.17.31",
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/test-utils": "workspace:*",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",

--- a/libs/printing/package.json
+++ b/libs/printing/package.json
@@ -53,7 +53,7 @@
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/image-utils": "workspace:*",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -103,7 +103,7 @@
     "assert": "^2.0.0",
     "browserify-zlib": "^0.2.0",
     "buffer": "^6.0.3",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-storybook": "^0.6.10",
     "eslint-plugin-vx": "workspace:*",

--- a/libs/usb-drive/package.json
+++ b/libs/usb-drive/package.json
@@ -38,7 +38,7 @@
     "@types/node": "20.17.31",
     "@types/tmp": "0.2.4",
     "@vitest/coverage-istanbul": "^4.1.6",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "eslint-plugin-vx": "workspace:*",
     "is-ci-cli": "2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,11 +290,11 @@ importers:
         specifier: ^5.5.0
         version: 5.5.0
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../../../libs/eslint-plugin-vx
@@ -321,7 +321,7 @@ importers:
         version: 6.1.1
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   apps/admin/frontend:
     dependencies:
@@ -562,10 +562,10 @@ importers:
         version: 1.53.1
       vite:
         specifier: 8.0.5
-        version: 8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2)
+        version: 8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   apps/admin/frontend/prodserver:
     dependencies:
@@ -755,11 +755,11 @@ importers:
         specifier: workspace:*
         version: link:../../../libs/fixtures
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../../../libs/eslint-plugin-vx
@@ -786,7 +786,7 @@ importers:
         version: 6.1.1
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   apps/central-scan/frontend:
     dependencies:
@@ -948,11 +948,11 @@ importers:
         specifier: workspace:*
         version: link:../../../libs/usb-drive
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../../../libs/eslint-plugin-vx
@@ -979,10 +979,10 @@ importers:
         version: 0.18.1
       vite:
         specifier: 8.0.5
-        version: 8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2)
+        version: 8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   apps/central-scan/frontend/prodserver:
     dependencies:
@@ -1181,11 +1181,11 @@ importers:
         specifier: workspace:*
         version: link:../../../libs/test-utils
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../../../libs/eslint-plugin-vx
@@ -1206,7 +1206,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   apps/design/frontend:
     dependencies:
@@ -1289,11 +1289,11 @@ importers:
         specifier: 9.0.0
         version: 9.0.0
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       js-file-download:
         specifier: 0.4.12
         version: 0.4.12
@@ -1423,10 +1423,10 @@ importers:
         version: 0.2.7
       vite:
         specifier: 8.0.5
-        version: 8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2)
+        version: 8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   apps/mark-scan/backend:
     dependencies:
@@ -1558,11 +1558,11 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../../../libs/eslint-plugin-vx
@@ -1580,7 +1580,7 @@ importers:
         version: 1.50.0
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   apps/mark-scan/frontend:
     dependencies:
@@ -1770,10 +1770,10 @@ importers:
         version: 1.50.0
       vite:
         specifier: 8.0.5
-        version: 8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2)
+        version: 8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   apps/mark-scan/frontend/prodserver:
     dependencies:
@@ -1942,11 +1942,11 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../../../libs/eslint-plugin-vx
@@ -1964,7 +1964,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   apps/mark/frontend:
     dependencies:
@@ -2157,10 +2157,10 @@ importers:
         version: 1.53.1
       vite:
         specifier: 8.0.5
-        version: 8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2)
+        version: 8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   apps/mark/frontend/prodserver:
     dependencies:
@@ -2323,7 +2323,7 @@ importers:
         version: 5.3.11(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -2374,11 +2374,11 @@ importers:
         specifier: workspace:*
         version: link:../../../libs/test-utils
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../../../libs/eslint-plugin-vx
@@ -2455,11 +2455,11 @@ importers:
         specifier: 9.0.0
         version: 9.0.0
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       history:
         specifier: 4.10.1
         version: 4.10.1
@@ -2589,13 +2589,13 @@ importers:
         version: 0.2.7
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.29.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.21.2)(jest@29.6.2(@types/node@20.17.31)(babel-plugin-macros@3.1.0))(typescript@5.8.3)
+        version: 29.1.1(@babel/core@7.29.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.28.1)(jest@29.6.2(@types/node@20.17.31)(babel-plugin-macros@3.1.0))(typescript@5.8.3)
       vite:
         specifier: 8.0.5
-        version: 8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2)
+        version: 8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   apps/pollbook/frontend/prodserver:
     dependencies:
@@ -2679,7 +2679,7 @@ importers:
         version: 5.3.11(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -2727,11 +2727,11 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../../../libs/eslint-plugin-vx
@@ -2793,11 +2793,11 @@ importers:
         specifier: 9.0.0
         version: 9.0.0
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       history:
         specifier: 4.10.1
         version: 4.10.1
@@ -2894,13 +2894,13 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.29.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.21.2)(jest@29.6.2(@types/node@20.17.31)(babel-plugin-macros@3.1.0))(typescript@5.8.3)
+        version: 29.1.1(@babel/core@7.29.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.28.1)(jest@29.6.2(@types/node@20.17.31)(babel-plugin-macros@3.1.0))(typescript@5.8.3)
       vite:
         specifier: 8.0.5
-        version: 8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2)
+        version: 8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   apps/print/frontend/prodserver:
     dependencies:
@@ -3096,11 +3096,11 @@ importers:
         specifier: workspace:*
         version: link:../../../libs/hmpb
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../../../libs/eslint-plugin-vx
@@ -3127,7 +3127,7 @@ importers:
         version: 6.1.1
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3317,10 +3317,10 @@ importers:
         version: 1.53.1
       vite:
         specifier: 8.0.5
-        version: 8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2)
+        version: 8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   apps/scan/frontend/prodserver:
     dependencies:
@@ -3405,7 +3405,7 @@ importers:
         version: 1.50.0
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/@types/compress-commons:
     dependencies:
@@ -3513,7 +3513,7 @@ importers:
         version: link:../test-utils
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -3528,7 +3528,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -3682,7 +3682,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/ballot-encoder:
     dependencies:
@@ -3722,7 +3722,7 @@ importers:
         version: 1.50.0
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/ballot-interpreter:
     dependencies:
@@ -3803,11 +3803,11 @@ importers:
         specifier: workspace:*
         version: link:../hmpb
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -3828,7 +3828,7 @@ importers:
         version: 1.50.0
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/basics:
     dependencies:
@@ -3862,7 +3862,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/bmd-ballot-fixtures:
     dependencies:
@@ -3929,7 +3929,7 @@ importers:
         version: 0.12.4
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/cdf-schema-builder:
     dependencies:
@@ -3969,7 +3969,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/custom-paper-handler:
     dependencies:
@@ -4017,11 +4017,11 @@ importers:
         specifier: workspace:*
         version: link:../test-utils
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -4030,7 +4030,7 @@ importers:
         version: 2.2.0
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/db:
     dependencies:
@@ -4076,7 +4076,7 @@ importers:
         version: 0.2.7
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/dev-dock/backend:
     dependencies:
@@ -4152,7 +4152,7 @@ importers:
         version: 1.50.0
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/dev-dock/frontend:
     dependencies:
@@ -4252,7 +4252,7 @@ importers:
         version: 5.3.11(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/eslint-plugin-vx:
     dependencies:
@@ -4319,7 +4319,7 @@ importers:
         version: 18.3.1
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/fixture-generators:
     dependencies:
@@ -4354,11 +4354,11 @@ importers:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       js-sha256:
         specifier: ^0.9.0
         version: 0.9.0
@@ -4407,7 +4407,7 @@ importers:
         version: 0.2.7
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/fixtures:
     dependencies:
@@ -4444,7 +4444,7 @@ importers:
         version: 1.50.0
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/fs:
     dependencies:
@@ -4511,7 +4511,7 @@ importers:
         version: 0.2.7
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/fujitsu-thermal-printer:
     dependencies:
@@ -4559,11 +4559,11 @@ importers:
         specifier: ^4.1.6
         version: 4.1.6(vitest@4.1.6)
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -4572,7 +4572,7 @@ importers:
         version: 2.2.0
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/grout:
     dependencies:
@@ -4621,7 +4621,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
       wait-for-expect:
         specifier: ^3.0.2
         version: 3.0.2
@@ -4652,7 +4652,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/hmpb:
     dependencies:
@@ -4754,11 +4754,11 @@ importers:
         specifier: workspace:*
         version: link:../test-utils
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -4779,10 +4779,10 @@ importers:
         version: 0.12.4
       vite:
         specifier: 8.0.5
-        version: 8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2)
+        version: 8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/image-utils:
     dependencies:
@@ -4836,11 +4836,11 @@ importers:
         specifier: workspace:*
         version: link:../fixtures
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -4852,7 +4852,7 @@ importers:
         version: 2.2.0
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/integration-test-utils:
     dependencies:
@@ -4904,7 +4904,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/logging:
     dependencies:
@@ -4955,11 +4955,11 @@ importers:
         specifier: workspace:*
         version: link:../test-utils
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -4974,7 +4974,7 @@ importers:
         version: 1.50.0
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/logging-utils:
     devDependencies:
@@ -5013,7 +5013,7 @@ importers:
         version: 0.2.7
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/mark-flow-ui:
     dependencies:
@@ -5237,7 +5237,7 @@ importers:
         version: 2.2.0
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/monorepo-utils:
     dependencies:
@@ -5259,7 +5259,7 @@ importers:
         version: 4.1.6(vitest@4.1.6)
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -5295,7 +5295,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/networking:
     dependencies:
@@ -5319,11 +5319,11 @@ importers:
         specifier: workspace:*
         version: link:../test-utils
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -5338,7 +5338,7 @@ importers:
         version: 1.53.1
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/pdi-scanner:
     dependencies:
@@ -5375,7 +5375,7 @@ importers:
         version: link:../test-utils
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -5384,7 +5384,7 @@ importers:
         version: 2.2.0
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/printing:
     dependencies:
@@ -5471,11 +5471,11 @@ importers:
         specifier: workspace:*
         version: link:../image-utils
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -5490,7 +5490,7 @@ importers:
         version: 1.50.0
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/test-utils:
     dependencies:
@@ -5554,7 +5554,7 @@ importers:
         version: 1.50.0
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/types:
     dependencies:
@@ -5609,7 +5609,7 @@ importers:
         version: 1.0.0(ajv@8.12.0)
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -5633,7 +5633,7 @@ importers:
         version: 1.50.0
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/ui:
     dependencies:
@@ -5843,11 +5843,11 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-storybook:
         specifier: ^0.6.10
         version: 0.6.10(eslint@8.57.0)(typescript@5.8.3)
@@ -5907,10 +5907,10 @@ importers:
         version: 0.12.4
       vite:
         specifier: 8.0.5
-        version: 8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2)
+        version: 8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
       vitest-styled-components:
         specifier: ^1.0.0
         version: 1.0.0(styled-components@5.3.11(react-dom@18.3.1(react@18.3.1))(react-is@18.2.0)(react@18.3.1))
@@ -5958,11 +5958,11 @@ importers:
         specifier: ^4.1.6
         version: 4.1.6(vitest@4.1.6)
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -5974,7 +5974,7 @@ importers:
         version: 1.50.0
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   libs/utils:
     dependencies:
@@ -6068,7 +6068,7 @@ importers:
         version: 1.50.0
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
 
   script:
     dependencies:
@@ -6095,11 +6095,11 @@ importers:
         specifier: 20.17.31
         version: 20.17.31
       esbuild:
-        specifier: 0.21.2
-        version: 0.21.2
+        specifier: 0.28.1
+        version: 0.28.1
       esbuild-runner:
         specifier: 2.2.2
-        version: 2.2.2(esbuild@0.21.2)
+        version: 2.2.2(esbuild@0.28.1)
       prettier:
         specifier: 3.0.3
         version: 3.0.3
@@ -7147,9 +7147,9 @@ packages:
   '@emotion/weak-memoize@0.3.1':
     resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
 
-  '@esbuild/aix-ppc64@0.21.2':
-    resolution: {integrity: sha512-/c7hocx0pm14bHQlqUVKmxwdT/e5/KkyoY1W8F9lk/8CkE037STDDz8PXUP/LE6faj2HqchvDs9GcShxFhI78Q==}
-    engines: {node: '>=12'}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
@@ -7165,9 +7165,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.21.2':
-    resolution: {integrity: sha512-SGZKngoTWVUriO5bDjI4WDGsNx2VKZoXcds+ita/kVYB+8IkSCKDRDaK+5yu0b5S0eq6B3S7fpiEvpsa2ammlQ==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -7183,9 +7183,9 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.21.2':
-    resolution: {integrity: sha512-G1ve3b4FeyJeyCjB4MX1CiWyTaIJwT9wAYE+8+IRA53YoN/reC/Bf2GDRXAzDTnh69Fpl+1uIKg76DiB3U6vwQ==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
@@ -7201,9 +7201,9 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.21.2':
-    resolution: {integrity: sha512-1wzzNoj2QtNkAYwIcWJ66UTRA80+RTQ/kuPMtEuP0X6dp5Ar23Dn566q3aV61h4EYrrgGlOgl/HdcqN/2S/2vg==}
-    engines: {node: '>=12'}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -7219,9 +7219,9 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.21.2':
-    resolution: {integrity: sha512-ZyMkPWc5eTROcLOA10lEqdDSTc6ds6nuh3DeHgKip/XJrYjZDfnkCVSty8svWdy+SC1f77ULtVeIqymTzaB6/Q==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
@@ -7237,9 +7237,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.21.2':
-    resolution: {integrity: sha512-K4ZdVq1zP9v51h/cKVna7im7G0zGTKKB6bP2yJiSmHjjOykbd8DdhrSi8V978sF69rkwrn8zCyL2t6I3ei6j9A==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -7255,9 +7255,9 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.21.2':
-    resolution: {integrity: sha512-4kbOGdpA61CXqadD+Gb/Pw3YXamQGiz9mal/h93rFVSjr5cgMnmJd/gbfPRm+3BMifvnaOfS1gNWaIDxkE2A3A==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
@@ -7273,9 +7273,9 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.21.2':
-    resolution: {integrity: sha512-ShS+R09nuHzDBfPeMUliKZX27Wrmr8UFp93aFf/S8p+++x5BZ+D344CLKXxmY6qzgTL3mILSImPCNJOzD6+RRg==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -7291,9 +7291,9 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.21.2':
-    resolution: {integrity: sha512-Hdu8BL+AmO+eCDvvT6kz/fPQhvuHL8YK4ExKZfANWsNe1kFGOHw7VJvS/FKSLFqheXmB3rTF3xFQIgUWPYsGnA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
@@ -7309,9 +7309,9 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.21.2':
-    resolution: {integrity: sha512-nnGXjOAv+7cM3LYRx4tJsYdgy8dGDGkAzF06oIDGppWbUkUKN9SmgQA8H0KukpU0Pjrj9XmgbWqMVSX/U7eeTA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -7327,9 +7327,9 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.21.2':
-    resolution: {integrity: sha512-m73BOCW2V9lcj7RtEMi+gBfHC6n3+VHpwQXP5offtQMPLDkpVolYn1YGXxOZ9hp4h3UPRKuezL7WkBsw+3EB3Q==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
@@ -7345,9 +7345,9 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.21.2':
-    resolution: {integrity: sha512-84eYHwwWHq3myIY/6ikALMcnwkf6Qo7NIq++xH0x+cJuUNpdwh8mlpUtRY+JiGUc60yu7ElWBbVHGWTABTclGw==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -7363,9 +7363,9 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.21.2':
-    resolution: {integrity: sha512-9siSZngT0/ZKG+AH+/agwKF29LdCxw4ODi/PiE0F52B2rtLozlDP92umf8G2GPoVV611LN4pZ+nSTckebOscUA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
@@ -7381,9 +7381,9 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.21.2':
-    resolution: {integrity: sha512-y0T4aV2CA+ic04ULya1A/8M2RDpDSK2ckgTj6jzHKFJvCq0jQg8afQQIn4EM0G8u2neyOiNHgSF9YKPfuqKOVw==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -7399,9 +7399,9 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.21.2':
-    resolution: {integrity: sha512-x5ssCdXmZC86L2Li1qQPF/VaC4VP20u/Zm8jlAu9IiVOVi79YsSz6cpPDYZl1rfKSHYCJW9XBfFCo66S5gVPSA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
@@ -7417,9 +7417,9 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.21.2':
-    resolution: {integrity: sha512-NP7fTpGSFWdXyvp8iAFU04uFh9ARoplFVM/m+8lTRpaYG+2ytHPZWyscSsMM6cvObSIK2KoPHXiZD4l99WaxbQ==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -7435,11 +7435,17 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.21.2':
-    resolution: {integrity: sha512-giZ/uOxWDKda44ZuyfKbykeXznfuVNkTgXOUOPJIjbayJV6FRpQ4zxUy9JMBPLaK9IJcdWtaoeQrYBMh3Rr4vQ==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
 
   '@esbuild/netbsd-x64@0.17.11':
     resolution: {integrity: sha512-4WaAhuz5f91h3/g43VBGdto1Q+X7VEZfpcWGtOFXnggEuLvjV+cP6DyLRU15IjiU9fKLLk41OoJfBFN5DhPvag==}
@@ -7453,11 +7459,17 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.21.2':
-    resolution: {integrity: sha512-IeFMfGFSQfIj1d4XU+6lkbFzMR+mFELUUVYrZ+jvWzG4NGvs6o53ReEHLHpYkjRbdEjJy2W3lTekTxrFHW7YJg==}
-    engines: {node: '>=12'}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.17.11':
     resolution: {integrity: sha512-UBj135Nx4FpnvtE+C8TWGp98oUgBcmNmdYgl5ToKc0mBHxVVqVE7FUS5/ELMImOp205qDAittL6Ezhasc2Ev/w==}
@@ -7471,11 +7483,17 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.21.2':
-    resolution: {integrity: sha512-48QhWD6WxcebNNaE4FCwgvQVUnAycuTd+BdvA/oZu+/MmbpU8pY2dMEYlYzj5uNHWIG5jvdDmFXu0naQeOWUoA==}
-    engines: {node: '>=12'}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
 
   '@esbuild/sunos-x64@0.17.11':
     resolution: {integrity: sha512-1/gxTifDC9aXbV2xOfCbOceh5AlIidUrPsMpivgzo8P8zUtczlq1ncFpeN1ZyQJ9lVs2hILy1PG5KPp+w8QPPg==}
@@ -7489,9 +7507,9 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.21.2':
-    resolution: {integrity: sha512-90r3nTBLgdIgD4FCVV9+cR6Hq2Dzs319icVsln+NTmTVwffWcCqXGml8rAoocHuJ85kZK36DCteii96ba/PX8g==}
-    engines: {node: '>=12'}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -7507,9 +7525,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.21.2':
-    resolution: {integrity: sha512-sNndlsBT8OeE/MZDSGpRDJlWuhjuUz/dn80nH0EP4ZzDUYvMDVa7G87DVpweBrn4xdJYyXS/y4CQNrf7R2ODXg==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -7525,9 +7543,9 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.21.2':
-    resolution: {integrity: sha512-Ti2QChGNFzWhUNNVuU4w21YkYTErsNh3h+CzvlEhzgRbwsJ7TrWQqRzW3bllLKKvTppuF3DJ3XP1GEg11AfrEQ==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
@@ -7543,9 +7561,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.21.2':
-    resolution: {integrity: sha512-VEfTCZicoZnZ6sGkjFPGRFFJuL2fZn2bLhsekZl1CJslflp2cJS/VoKs1jMk+3pDfsGW6CfQVUckP707HwbXeQ==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -11716,9 +11734,9 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
-  esbuild@0.21.2:
-    resolution: {integrity: sha512-LmHPAa5h4tSxz+g/D8IHY6wCjtIiFx8I7/Q0Aq+NmvtoYvyMnJU0KQJcqB6QH30X9x/W4CemgUtPgQDZFca5SA==}
-    engines: {node: '>=12'}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.2.0:
@@ -18573,7 +18591,7 @@ snapshots:
 
   '@emotion/weak-memoize@0.3.1': {}
 
-  '@esbuild/aix-ppc64@0.21.2':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
   '@esbuild/android-arm64@0.17.11':
@@ -18582,7 +18600,7 @@ snapshots:
   '@esbuild/android-arm64@0.18.17':
     optional: true
 
-  '@esbuild/android-arm64@0.21.2':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.17.11':
@@ -18591,7 +18609,7 @@ snapshots:
   '@esbuild/android-arm@0.18.17':
     optional: true
 
-  '@esbuild/android-arm@0.21.2':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
   '@esbuild/android-x64@0.17.11':
@@ -18600,7 +18618,7 @@ snapshots:
   '@esbuild/android-x64@0.18.17':
     optional: true
 
-  '@esbuild/android-x64@0.21.2':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.17.11':
@@ -18609,7 +18627,7 @@ snapshots:
   '@esbuild/darwin-arm64@0.18.17':
     optional: true
 
-  '@esbuild/darwin-arm64@0.21.2':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
   '@esbuild/darwin-x64@0.17.11':
@@ -18618,7 +18636,7 @@ snapshots:
   '@esbuild/darwin-x64@0.18.17':
     optional: true
 
-  '@esbuild/darwin-x64@0.21.2':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.17.11':
@@ -18627,7 +18645,7 @@ snapshots:
   '@esbuild/freebsd-arm64@0.18.17':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.21.2':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-x64@0.17.11':
@@ -18636,7 +18654,7 @@ snapshots:
   '@esbuild/freebsd-x64@0.18.17':
     optional: true
 
-  '@esbuild/freebsd-x64@0.21.2':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.17.11':
@@ -18645,7 +18663,7 @@ snapshots:
   '@esbuild/linux-arm64@0.18.17':
     optional: true
 
-  '@esbuild/linux-arm64@0.21.2':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm@0.17.11':
@@ -18654,7 +18672,7 @@ snapshots:
   '@esbuild/linux-arm@0.18.17':
     optional: true
 
-  '@esbuild/linux-arm@0.21.2':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.17.11':
@@ -18663,7 +18681,7 @@ snapshots:
   '@esbuild/linux-ia32@0.18.17':
     optional: true
 
-  '@esbuild/linux-ia32@0.21.2':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
   '@esbuild/linux-loong64@0.17.11':
@@ -18672,7 +18690,7 @@ snapshots:
   '@esbuild/linux-loong64@0.18.17':
     optional: true
 
-  '@esbuild/linux-loong64@0.21.2':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.17.11':
@@ -18681,7 +18699,7 @@ snapshots:
   '@esbuild/linux-mips64el@0.18.17':
     optional: true
 
-  '@esbuild/linux-mips64el@0.21.2':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
   '@esbuild/linux-ppc64@0.17.11':
@@ -18690,7 +18708,7 @@ snapshots:
   '@esbuild/linux-ppc64@0.18.17':
     optional: true
 
-  '@esbuild/linux-ppc64@0.21.2':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.17.11':
@@ -18699,7 +18717,7 @@ snapshots:
   '@esbuild/linux-riscv64@0.18.17':
     optional: true
 
-  '@esbuild/linux-riscv64@0.21.2':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
   '@esbuild/linux-s390x@0.17.11':
@@ -18708,7 +18726,7 @@ snapshots:
   '@esbuild/linux-s390x@0.18.17':
     optional: true
 
-  '@esbuild/linux-s390x@0.21.2':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.17.11':
@@ -18717,7 +18735,10 @@ snapshots:
   '@esbuild/linux-x64@0.18.17':
     optional: true
 
-  '@esbuild/linux-x64@0.21.2':
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-x64@0.17.11':
@@ -18726,7 +18747,10 @@ snapshots:
   '@esbuild/netbsd-x64@0.18.17':
     optional: true
 
-  '@esbuild/netbsd-x64@0.21.2':
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.17.11':
@@ -18735,7 +18759,10 @@ snapshots:
   '@esbuild/openbsd-x64@0.18.17':
     optional: true
 
-  '@esbuild/openbsd-x64@0.21.2':
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
   '@esbuild/sunos-x64@0.17.11':
@@ -18744,7 +18771,7 @@ snapshots:
   '@esbuild/sunos-x64@0.18.17':
     optional: true
 
-  '@esbuild/sunos-x64@0.21.2':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
   '@esbuild/win32-arm64@0.17.11':
@@ -18753,7 +18780,7 @@ snapshots:
   '@esbuild/win32-arm64@0.18.17':
     optional: true
 
-  '@esbuild/win32-arm64@0.21.2':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
   '@esbuild/win32-ia32@0.17.11':
@@ -18762,7 +18789,7 @@ snapshots:
   '@esbuild/win32-ia32@0.18.17':
     optional: true
 
-  '@esbuild/win32-ia32@0.21.2':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
   '@esbuild/win32-x64@0.17.11':
@@ -18771,7 +18798,7 @@ snapshots:
   '@esbuild/win32-x64@0.18.17':
     optional: true
 
-  '@esbuild/win32-x64@0.21.2':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.57.0)':
@@ -22515,7 +22542,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+      vitest: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -22536,13 +22563,13 @@ snapshots:
     optionalDependencies:
       vite: 8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2)
 
-  '@vitest/mocker@4.1.6(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.6(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2)
+      vite: 8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.1.6':
     dependencies:
@@ -23929,9 +23956,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  esbuild-runner@2.2.2(esbuild@0.21.2):
+  esbuild-runner@2.2.2(esbuild@0.28.1):
     dependencies:
-      esbuild: 0.21.2
+      esbuild: 0.28.1
       source-map-support: 0.5.21
       tslib: 2.4.0
 
@@ -23985,31 +24012,34 @@ snapshots:
       '@esbuild/win32-ia32': 0.18.17
       '@esbuild/win32-x64': 0.18.17
 
-  esbuild@0.21.2:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.2
-      '@esbuild/android-arm': 0.21.2
-      '@esbuild/android-arm64': 0.21.2
-      '@esbuild/android-x64': 0.21.2
-      '@esbuild/darwin-arm64': 0.21.2
-      '@esbuild/darwin-x64': 0.21.2
-      '@esbuild/freebsd-arm64': 0.21.2
-      '@esbuild/freebsd-x64': 0.21.2
-      '@esbuild/linux-arm': 0.21.2
-      '@esbuild/linux-arm64': 0.21.2
-      '@esbuild/linux-ia32': 0.21.2
-      '@esbuild/linux-loong64': 0.21.2
-      '@esbuild/linux-mips64el': 0.21.2
-      '@esbuild/linux-ppc64': 0.21.2
-      '@esbuild/linux-riscv64': 0.21.2
-      '@esbuild/linux-s390x': 0.21.2
-      '@esbuild/linux-x64': 0.21.2
-      '@esbuild/netbsd-x64': 0.21.2
-      '@esbuild/openbsd-x64': 0.21.2
-      '@esbuild/sunos-x64': 0.21.2
-      '@esbuild/win32-arm64': 0.21.2
-      '@esbuild/win32-ia32': 0.21.2
-      '@esbuild/win32-x64': 0.21.2
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -24251,7 +24281,7 @@ snapshots:
       eslint: 8.57.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3)
-      vitest: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.18.17)(yaml@2.8.2))
+      vitest: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -28782,7 +28812,7 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-jest@29.1.1(@babel/core@7.29.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.21.2)(jest@29.6.2(@types/node@20.17.31)(babel-plugin-macros@3.1.0))(typescript@5.8.3):
+  ts-jest@29.1.1(@babel/core@7.29.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.28.1)(jest@29.6.2(@types/node@20.17.31)(babel-plugin-macros@3.1.0))(typescript@5.8.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -28798,7 +28828,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.29.0)
-      esbuild: 0.21.2
+      esbuild: 0.28.1
 
   tsconfig-paths@3.14.1:
     dependencies:
@@ -29119,7 +29149,7 @@ snapshots:
       fsevents: 2.3.3
       yaml: 2.8.2
 
-  vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2):
+  vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -29128,7 +29158,7 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 20.17.31
-      esbuild: 0.21.2
+      esbuild: 0.28.1
       fsevents: 2.3.3
       yaml: 2.8.2
 
@@ -29168,10 +29198,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2)):
+  vitest@4.1.6(@opentelemetry/api@1.9.0)(@types/node@20.17.31)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@2.11.2))(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.6(vite@8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -29188,7 +29218,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.5(@types/node@20.17.31)(esbuild@0.21.2)(yaml@2.8.2)
+      vite: 8.0.5(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0

--- a/script/package.json
+++ b/script/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/node": "20.17.31",
-    "esbuild": "0.21.2",
+    "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "prettier": "3.0.3",
     "typescript": "5.8.3"


### PR DESCRIPTION
## Overview
Updates esbuild dependency to 0.28.1.

Dependabot failed to do this as it didn't update all packages at once see: 
https://github.com/votingworks/vxsuite/pull/8740
https://github.com/votingworks/vxsuite/pull/8739
<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot
N/A

## Testing Plan
See CI passing, sanity tested running VxAdmin locally successfully. 

## Checklist
- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
