### PR TITLE
Multistation - Frontend testing improvements

### DIFF
--- a/apps/admin/frontend/src/client/screens/client_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_adjudication_screen.test.tsx
@@ -5,6 +5,7 @@ import {
 } from '@votingworks/test-utils';
 import { DippedSmartCardAuth, constructElectionKey } from '@votingworks/types';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
+import { createMemoryHistory } from 'history';
 import { screen } from '../../../test/react_testing_library';
 import {
   ClientApiMock,
@@ -38,11 +39,14 @@ function renderAdjudicationScreen(
   auth: DippedSmartCardAuth.AuthStatus,
   { withElection = false }: { withElection?: boolean } = {}
 ) {
-  return renderInClientContext(<ClientAdjudicationScreen />, {
+  const history = createMemoryHistory();
+  renderInClientContext(<ClientAdjudicationScreen />, {
+    history,
     auth,
     apiMock,
     ...(withElection ? { electionDefinition } : {}),
   });
+  return { history };
 }
 
 test('shows enabled start button when adjudication is enabled', async () => {
@@ -68,11 +72,13 @@ test('shows waiting message and disabled button when adjudication not enabled', 
 test('start adjudication navigates to the ballot screen', async () => {
   apiMock.expectGetAdjudicationSessionStatus(true);
 
-  renderAdjudicationScreen(pollWorkerAuth, { withElection: true });
+  const { history } = renderAdjudicationScreen(pollWorkerAuth, {
+    withElection: true,
+  });
   const startButton = await screen.findByRole('button', {
     name: 'Start Adjudication',
   });
   startButton.click();
 
-  expect(window.location.pathname).toEqual(routerPaths.ballotAdjudication);
+  expect(history.location.pathname).toEqual(routerPaths.ballotAdjudication);
 });

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
@@ -10,26 +10,15 @@ import {
 } from '@votingworks/types';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import { err, ok } from '@votingworks/basics';
-import { MemoryRouter, Route } from 'react-router-dom';
-import { QueryClientProvider } from '@tanstack/react-query';
-import {
-  mockUsbDriveStatus,
-  SystemCallContextProvider,
-  TestErrorBoundary,
-} from '@votingworks/ui';
-import { render, screen, waitFor } from '../../../test/react_testing_library';
+import { Route } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import { screen, waitFor } from '../../../test/react_testing_library';
 import {
   ClientApiMock,
   createClientApiMock,
 } from '../../../test/helpers/mock_client_api_client';
+import { renderInClientContext } from '../../../test/render_in_client_context';
 import { ClientBallotAdjudicationScreen } from './client_ballot_adjudication_screen';
-import {
-  ApiClient as ClientApiClient,
-  ApiClientContext as ClientApiClientContext,
-  createQueryClient,
-} from '../api';
-import { SharedApiClientContext, systemCallApi } from '../../shared_api';
-import { AppContext } from '../../contexts/app_context';
 import { routerPaths } from '../../router_paths';
 
 // Mock BallotAdjudicationScreen to capture and expose all callbacks.
@@ -81,44 +70,30 @@ const pollWorkerAuth: DippedSmartCardAuth.PollWorkerLoggedIn = {
   sessionExpiresAt: mockSessionExpiresAt(),
 };
 
-function renderScreen() {
-  expectAdjudicationEnabled();
-  const clientApiClient = apiMock.apiClient as unknown as ClientApiClient;
-  return render(
-    <TestErrorBoundary>
-      <SharedApiClientContext.Provider value={clientApiClient}>
-        <SystemCallContextProvider api={systemCallApi}>
-          <ClientApiClientContext.Provider value={clientApiClient}>
-            <QueryClientProvider client={createQueryClient()}>
-              <AppContext.Provider
-                value={{
-                  auth: pollWorkerAuth,
-                  machineConfig: { machineId: '0000', codeVersion: 'dev' },
-                  isOfficialResults: false,
-                  usbDriveStatus: mockUsbDriveStatus('no_drive'),
-                  machineMode: 'client',
-                  electionDefinition,
-                  electionPackageHash: 'test-hash',
-                }}
-              >
-                <MemoryRouter initialEntries={[routerPaths.ballotAdjudication]}>
-                  <Route exact path={routerPaths.ballotAdjudication}>
-                    <ClientBallotAdjudicationScreen />
-                  </Route>
-                </MemoryRouter>
-              </AppContext.Provider>
-            </QueryClientProvider>
-          </ClientApiClientContext.Provider>
-        </SystemCallContextProvider>
-      </SharedApiClientContext.Provider>
-    </TestErrorBoundary>
-  );
-}
-
-function expectAdjudicationEnabled(): void {
+// Renders the screen at the ballot adjudication route and returns the memory
+// history so tests can assert on navigation (e.g. the redirect to the
+// adjudication start screen when the host disables adjudication).
+function renderScreen({
+  adjudicationEnabled = true,
+}: { adjudicationEnabled?: boolean } = {}) {
   apiMock.apiClient.getAdjudicationSessionStatus
     .expectRepeatedCallsWith()
-    .resolves({ isClientAdjudicationEnabled: true });
+    .resolves({ isClientAdjudicationEnabled: adjudicationEnabled });
+  const history = createMemoryHistory({
+    initialEntries: [routerPaths.ballotAdjudication],
+  });
+  renderInClientContext(
+    <Route exact path={routerPaths.ballotAdjudication}>
+      <ClientBallotAdjudicationScreen />
+    </Route>,
+    {
+      history,
+      auth: pollWorkerAuth,
+      electionDefinition,
+      apiMock,
+    }
+  );
+  return { history };
 }
 
 function makeBallotData(cvrId: string) {
@@ -305,47 +280,11 @@ test('redirects when host disables adjudication', async () => {
   expectGlobalDataLoaderQueries();
   expectInitialClaimAndLoad('cvr-1');
 
-  // Override adjudication status to disabled
-  apiMock.apiClient.getAdjudicationSessionStatus.reset();
-  apiMock.apiClient.getAdjudicationSessionStatus
-    .expectRepeatedCallsWith()
-    .resolves({ isClientAdjudicationEnabled: false });
+  const { history } = renderScreen({ adjudicationEnabled: false });
 
-  const clientApiClient = apiMock.apiClient as unknown as ClientApiClient;
-  render(
-    <TestErrorBoundary>
-      <SharedApiClientContext.Provider value={clientApiClient}>
-        <SystemCallContextProvider api={systemCallApi}>
-          <ClientApiClientContext.Provider value={clientApiClient}>
-            <QueryClientProvider client={createQueryClient()}>
-              <AppContext.Provider
-                value={{
-                  auth: pollWorkerAuth,
-                  machineConfig: { machineId: '0000', codeVersion: 'dev' },
-                  isOfficialResults: false,
-                  usbDriveStatus: mockUsbDriveStatus('no_drive'),
-                  machineMode: 'client',
-                  electionDefinition,
-                  electionPackageHash: 'test-hash',
-                }}
-              >
-                <MemoryRouter initialEntries={[routerPaths.ballotAdjudication]}>
-                  <Route exact path={routerPaths.ballotAdjudication}>
-                    <ClientBallotAdjudicationScreen />
-                  </Route>
-                  <Route exact path={routerPaths.adjudication}>
-                    <div>adjudication start</div>
-                  </Route>
-                </MemoryRouter>
-              </AppContext.Provider>
-            </QueryClientProvider>
-          </ClientApiClientContext.Provider>
-        </SystemCallContextProvider>
-      </SharedApiClientContext.Provider>
-    </TestErrorBoundary>
+  await waitFor(() =>
+    expect(history.location.pathname).toEqual(routerPaths.adjudication)
   );
-
-  await screen.findByText('adjudication start');
 });
 
 test('onAccept calls API and accept advances', async () => {

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
@@ -287,6 +287,29 @@ test('redirects when host disables adjudication', async () => {
   );
 });
 
+test('redirects when the host disables adjudication mid-session', async () => {
+  expectDataLoaderQueries('cvr-1');
+  expectGlobalDataLoaderQueries();
+  expectInitialClaimAndLoad('cvr-1');
+  const { history } = renderScreen();
+
+  // The session is active and a ballot is loaded
+  await screen.findByText('Adjudicating cvr-1');
+
+  // The host disables client adjudication — the polled session status query
+  // picks up the change and the screen redirects within a refetch interval
+  apiMock.apiClient.getAdjudicationSessionStatus.reset();
+  apiMock.apiClient.getAdjudicationSessionStatus
+    .expectRepeatedCallsWith()
+    .resolves({ isClientAdjudicationEnabled: false });
+
+  await waitFor(
+    () => expect(history.location.pathname).toEqual(routerPaths.adjudication),
+    { timeout: 3000 }
+  );
+  expect(screen.queryByText('Adjudicating cvr-1')).toBeNull();
+});
+
 test('onAccept calls API and accept advances', async () => {
   expectDataLoaderQueries('cvr-1');
   expectGlobalDataLoaderQueries();

--- a/apps/admin/frontend/src/screens/adjudication_start_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/adjudication_start_screen.test.tsx
@@ -124,6 +124,32 @@ test('When ballots need adjudication, shows start button with counts', async () 
   screen.getByText('2 of 5 adjudicated · 40%');
 });
 
+test('queue progress updates as other stations adjudicate ballots', async () => {
+  apiMock.expectGetBallotAdjudicationQueueMetadata({
+    pendingTally: 3,
+    totalTally: 5,
+  });
+  apiMock.expectGetCastVoteRecordFiles([mockCastVoteRecordFileRecord]);
+  renderInAppContext(<AdjudicationStartScreen />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('3 ballots remaining');
+  screen.getByText('2 of 5 adjudicated · 40%');
+
+  // Other stations adjudicate two more ballots — the queue metadata query
+  // polls on an interval, so the progress updates with no local action
+  apiMock.apiClient.getBallotAdjudicationQueueMetadata.reset();
+  apiMock.expectGetBallotAdjudicationQueueMetadata({
+    pendingTally: 1,
+    totalTally: 5,
+  });
+
+  await screen.findByText('1 ballot remaining', undefined, { timeout: 3000 });
+  screen.getByText('4 of 5 adjudicated · 80%');
+});
+
 describe('multi-station adjudication', () => {
   beforeEach(() => {
     apiMock.setMultiStationAdjudicationEnabled(true);

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -1720,6 +1720,163 @@ test('Skip onto a ballot claimed by another machine shows read-only overlay and 
     .resolves();
 });
 
+test('write-in candidates added by another station appear while adjudicating', async () => {
+  const contestId = 'zoo-council-mammal';
+  const contest = makeContestAdjudicationData(
+    contestId,
+    makeContestTag({ hasWriteIn: true })
+  );
+  addPendingWriteIns(contest, 1, [0]);
+  const adjData = makeBallotAdjudicationData(CVR_ID_1, [contest]);
+
+  apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
+  apiMock.expectGetWriteInCandidates([], [contestId]);
+  apiMock.expectGetSystemSettings();
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('Zoo Council');
+  userEvent.click(screen.getByText('Zoo Council'));
+  await screen.findByText(/Votes cast:/);
+
+  // Open the write-in combobox — no write-in candidates exist yet
+  const combobox = screen.getByRole('combobox');
+  fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+  expect(screen.queryByText('Mickey Mouse')).toBeNull();
+
+  // Another station adds a write-in candidate — the polled candidates query
+  // picks it up and the option appears with no local action
+  apiMock.apiClient.getWriteInCandidates.reset();
+  apiMock.expectGetWriteInCandidates(
+    [{ id: 'wic-1', name: 'Mickey Mouse', electionId: 'e', contestId }],
+    [contestId]
+  );
+
+  await screen.findByText('Mickey Mouse', undefined, { timeout: 3000 });
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves();
+});
+
+test('navigating to the next ballot never shows the previous ballot data', async () => {
+  // Distinct 4-char id prefixes so the "Ballot ID:" header is
+  // distinguishable, and disjoint contests so any leakage is visible.
+  const FIRST_CVR_ID = 'aaaa-first';
+  const SECOND_CVR_ID = 'bbbb-second';
+  const adjData1 = makeBallotAdjudicationData(FIRST_CVR_ID, [
+    makeContestAdjudicationData(
+      'zoo-council-mammal',
+      makeContestTag({ hasWriteIn: true })
+    ),
+  ]);
+  const adjData2 = makeBallotAdjudicationData(SECOND_CVR_ID, [
+    makeContestAdjudicationData(
+      'best-animal-mammal',
+      makeContestTag({ hasWriteIn: true })
+    ),
+  ]);
+
+  apiMock.expectGetBallotAdjudicationQueue([FIRST_CVR_ID, SECOND_CVR_ID]);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(FIRST_CVR_ID);
+  apiMock.expectClaimAndLoadBallot({ cvrId: FIRST_CVR_ID }, adjData1);
+  apiMock.expectGetBallotImages({ cvrId: FIRST_CVR_ID }, true);
+  apiMock.expectGetWriteInCandidates([], ['zoo-council-mammal']);
+  apiMock.expectGetSystemSettings();
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('Ballot 1 of 2');
+  await screen.findByText('Ballot ID: aaaa');
+  screen.getByText('Zoo Council');
+
+  // Navigate to the second ballot — every piece of the first ballot's data
+  // must be replaced, not served from a stale cache
+  apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: FIRST_CVR_ID });
+  apiMock.expectClaimAndLoadBallot({ cvrId: SECOND_CVR_ID }, adjData2);
+  apiMock.expectGetBallotImages({ cvrId: SECOND_CVR_ID }, true);
+  apiMock.expectGetWriteInCandidates([], ['best-animal-mammal']);
+
+  userEvent.click(screen.getByRole('button', { name: /Skip/ }));
+  await screen.findByText('Ballot 2 of 2');
+  await screen.findByText('Ballot ID: bbbb');
+  await screen.findByText('Best Animal');
+  expect(screen.queryByText('Zoo Council')).toBeNull();
+  expect(screen.queryByText('Ballot ID: aaaa')).toBeNull();
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: SECOND_CVR_ID })
+    .resolves();
+});
+
+test('accept advances past a ballot claimed by another station', async () => {
+  const CVR_ID_3 = 'cvr-id-3';
+  // Ballots 1 and 3 are already resolved; ballot 2 exists in the queue but
+  // is claimed by another station, so accept must land on ballot 3.
+  const votedOptionId = assertDefined(
+    makeContestAdjudicationData('zoo-council-mammal').options[0]
+  ).definition.id;
+  function makeResolvedData(cvrId: string) {
+    const contest = makeContestAdjudicationData('zoo-council-mammal');
+    return makeBallotAdjudicationData(cvrId, [contest], {
+      isResolved: true,
+      adjudicatedContests: [
+        makeAdjudicatedCvrContest('zoo-council-mammal', {
+          [votedOptionId]: true,
+        }),
+      ],
+    });
+  }
+  const adjData1 = makeResolvedData(CVR_ID_1);
+  const adjData3 = makeResolvedData(CVR_ID_3);
+
+  apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2, CVR_ID_3]);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData1);
+  apiMock.expectGetBallotImages({ cvrId: CVR_ID_1 }, true);
+  apiMock.expectGetWriteInCandidates([], ['zoo-council-mammal']);
+  apiMock.expectGetSystemSettings();
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('Ballot 1 of 3');
+
+  // Accept ballot 1. The backend reports the next unclaimed ballot after
+  // ballot 1 is ballot 3 (another station claimed ballot 2 in the meantime),
+  // so the screen must land there rather than assuming the queue order.
+  apiMock.expectReleaseBallotAdjudicationClaim({ cvrId: CVR_ID_1 });
+  apiMock.expectAdjudicateCvr({
+    cvrId: CVR_ID_1,
+    contests: [
+      makeAdjudicatedCvrContest('zoo-council-mammal', {
+        [votedOptionId]: true,
+      }),
+    ],
+  });
+  apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1, CVR_ID_2, CVR_ID_3]);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_3, CVR_ID_1);
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_3 }, adjData3);
+  apiMock.expectGetBallotImages({ cvrId: CVR_ID_3 }, true);
+
+  userEvent.click(screen.getByRole('button', { name: /Accept/ }));
+  await screen.findByText('Ballot 3 of 3');
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_3 })
+    .resolves();
+});
+
 test('shows an error with exit when the claim+load fails', async () => {
   apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
   apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);

--- a/apps/admin/frontend/test/render_in_client_context.tsx
+++ b/apps/admin/frontend/test/render_in_client_context.tsx
@@ -1,5 +1,6 @@
+import { createMemoryHistory, MemoryHistory } from 'history';
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
+import { Router } from 'react-router-dom';
 
 import { DippedSmartCardAuth, DEV_MACHINE_ID } from '@votingworks/types';
 
@@ -22,6 +23,8 @@ import { SharedApiClientContext, systemCallApi } from '../src/shared_api';
 import { ClientApiMock } from './helpers/mock_client_api_client';
 
 export interface RenderInClientContextParams {
+  route?: string;
+  history?: MemoryHistory;
   auth: DippedSmartCardAuth.AuthStatus;
   electionDefinition?: AppContextInterface['electionDefinition'];
   electionPackageHash?: string;
@@ -35,6 +38,8 @@ export interface RenderInClientContextParams {
 export function renderInClientContext(
   component: React.ReactNode,
   {
+    route = '/',
+    history = createMemoryHistory({ initialEntries: [route] }),
     auth,
     electionDefinition,
     electionPackageHash = electionDefinition
@@ -68,7 +73,7 @@ export function renderInClientContext(
                   electionPackageHash,
                 }}
               >
-                <BrowserRouter>{component}</BrowserRouter>
+                <Router history={history}>{component}</Router>
               </AppContext.Provider>
             </QueryClientProvider>
           </ClientApiClientContext.Provider>


### PR DESCRIPTION
## Overview
Refactors a badly clauded test setup in the multistation frontend tests and adds a few additional tests testing edge cases in the logic when background information is changing on the network layer while the frontend is rendered. 

## Demo Video or Screenshot
N/A

## Testing Plan
Ran Tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
