### PR TITLE
Multi-Station: Handle disabling adjudication edge cases better

### DIFF
--- a/apps/admin/backend/src/app.adjudication.test.ts
+++ b/apps/admin/backend/src/app.adjudication.test.ts
@@ -5,6 +5,7 @@ import {
   electionTwoPartyPrimaryFixtures,
 } from '@votingworks/fixtures';
 import { assert, assertDefined, err, find, ok } from '@votingworks/basics';
+import type { Result } from '@votingworks/basics';
 import { loadImageMetadata } from '@votingworks/image-utils';
 import { join } from 'node:path';
 import { readFile, writeFile } from 'node:fs/promises';
@@ -57,12 +58,12 @@ async function claimBallot(
     claimAndLoadBallot: (input: {
       machineId: string;
       afterCvrId?: string;
-    }) => Promise<{ cvrId: string } | undefined>;
+    }) => Promise<Result<{ cvrId: string } | undefined, unknown>>;
   },
   input: { machineId: string; afterCvrId?: string }
 ): Promise<string | undefined> {
   const result = await peerApiClient.claimAndLoadBallot(input);
-  return result?.cvrId;
+  return result.unsafeUnwrap()?.cvrId;
 }
 
 // mock SKIP_CVR_BALLOT_HASH_CHECK to allow us to use old cvr fixtures
@@ -1547,7 +1548,9 @@ test('peer API: claim, adjudicate, and resolve a ballot with real CVR fixtures',
   // Two clients claim different ballots. Claiming returns the claimed ballot's
   // adjudication data, mirroring the real client flow.
   const client1Claim = assertDefined(
-    await peerApiClient.claimAndLoadBallot({ machineId: 'client-001' })
+    (
+      await peerApiClient.claimAndLoadBallot({ machineId: 'client-001' })
+    ).unsafeUnwrap()
   );
   const cvrId1 = client1Claim.cvrId;
   const ballotData = client1Claim.data;

--- a/apps/admin/backend/src/app_networking.test.ts
+++ b/apps/admin/backend/src/app_networking.test.ts
@@ -121,7 +121,7 @@ async function setupHostAndClient(
   const logger = mockBaseLogger({ fn: vi.fn });
   const workspace = createWorkspace(tmpDir, logger);
   const { store } = workspace;
-  const peerApp = buildPeerApp({ workspace, logger });
+  const peerApp = buildPeerApp({ workspace, logger, machineId: hostMachineId });
   peerServer = peerApp.listen();
   const { port: peerPort } = peerServer.address() as AddressInfo;
 
@@ -388,6 +388,7 @@ async function addElectionWithAdjudicableCvrs(
     electionPackageHash: 'test-hash',
   });
   store.setCurrentElectionId(electionId);
+  store.setIsClientAdjudicationEnabled(true);
   const cvrIds = addMockCvrFileToStore({
     electionId,
     mockCastVoteRecordFile: Array.from({ length: count }, () => ({
@@ -437,9 +438,11 @@ test('a ballot claimed via the peer API is released when the client goes stale',
   const peerApiClient = grout.createClient<PeerApi>({
     baseUrl: `http://127.0.0.1:${peerPort}/api`,
   });
-  const claimed = await peerApiClient.claimAndLoadBallot({
-    machineId: clientMachineId,
-  });
+  const claimed = (
+    await peerApiClient.claimAndLoadBallot({
+      machineId: clientMachineId,
+    })
+  ).unsafeUnwrap();
   expect(claimed?.cvrId).toEqual(cvrId);
   expect(claimNextOnHost(store, electionId, 'OTHER-MACHINE')).toBeUndefined();
 
@@ -490,9 +493,11 @@ test('a client logging out releases its ballot claim on the next heartbeat', asy
   const peerApiClient = grout.createClient<PeerApi>({
     baseUrl: `http://127.0.0.1:${peerPort}/api`,
   });
-  const claimed = await peerApiClient.claimAndLoadBallot({
-    machineId: clientMachineId,
-  });
+  const claimed = (
+    await peerApiClient.claimAndLoadBallot({
+      machineId: clientMachineId,
+    })
+  ).unsafeUnwrap();
   expect(claimed?.cvrId).toEqual(cvrId);
   expect(claimNextOnHost(store, electionId, 'OTHER-MACHINE')).toBeUndefined();
 

--- a/apps/admin/backend/src/client_app.test.ts
+++ b/apps/admin/backend/src/client_app.test.ts
@@ -341,10 +341,12 @@ test('claimAndLoadBallot proxies to host peer API', async () => {
     contests: [],
     adjudicatedContests: [],
   } as const;
-  mockPeerApi.claimAndLoadBallot.mockResolvedValue({
-    cvrId: 'cvr-1',
-    data: ballotData,
-  });
+  mockPeerApi.claimAndLoadBallot.mockResolvedValue(
+    ok({
+      cvrId: 'cvr-1',
+      data: ballotData,
+    })
+  );
 
   const result = await env.apiClient.claimAndLoadBallot({});
   expect(result).toEqual(ok({ cvrId: 'cvr-1', data: ballotData }));
@@ -355,10 +357,20 @@ test('claimAndLoadBallot proxies to host peer API', async () => {
 
 test('claimAndLoadBallot returns undefined when no ballots available', async () => {
   const { mockPeerApi } = connectToMockHost();
-  mockPeerApi.claimAndLoadBallot.mockResolvedValue(undefined);
+  mockPeerApi.claimAndLoadBallot.mockResolvedValue(ok(undefined));
 
   const result = await env.apiClient.claimAndLoadBallot({});
   expect(result).toEqual(ok(undefined));
+});
+
+test('claimAndLoadBallot passes through typed errors from the host', async () => {
+  const { mockPeerApi } = connectToMockHost();
+  mockPeerApi.claimAndLoadBallot.mockResolvedValue(
+    err({ type: 'adjudication-disabled' })
+  );
+
+  const result = await env.apiClient.claimAndLoadBallot({});
+  expect(result).toEqual(err({ type: 'adjudication-disabled' }));
 });
 
 test('proxy endpoints return host-disconnect error when not connected', async () => {

--- a/apps/admin/backend/src/client_app.ts
+++ b/apps/admin/backend/src/client_app.ts
@@ -253,7 +253,7 @@ function buildClientApi({
         AdjudicationError
       >
     > {
-      const result = await proxy(
+      const proxied = await proxy(
         'claim and load ballot',
         async ({ apiClient: peerApi }) =>
           peerApi.claimAndLoadBallot({
@@ -261,16 +261,17 @@ function buildClientApi({
             afterCvrId: input.afterCvrId,
           })
       );
-      if (result.isOk()) {
-        const value = result.ok();
-        if (value) {
-          await logger.logAsCurrentRole(LogEventId.AdminBallotClaimed, {
-            message: `Claimed ballot ${value.cvrId}.`,
-            disposition: 'success',
-          });
-        }
+      if (proxied.isErr()) return proxied;
+      const result = proxied.ok();
+      if (result.isErr()) return result;
+      const value = result.ok();
+      if (value) {
+        await logger.logAsCurrentRole(LogEventId.AdminBallotClaimed, {
+          message: `Claimed ballot ${value.cvrId}.`,
+          disposition: 'success',
+        });
       }
-      return result;
+      return ok(value);
     },
 
     async getBallotImages(input: {

--- a/apps/admin/backend/src/networking.test.ts
+++ b/apps/admin/backend/src/networking.test.ts
@@ -15,7 +15,7 @@ import {
   mockSessionExpiresAt,
 } from '@votingworks/test-utils';
 import { Admin, DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
-import { mockBaseLogger } from '@votingworks/logging';
+import { LogEventId, mockBaseLogger } from '@votingworks/logging';
 import {
   getHostServiceName,
   startHostNetworking,
@@ -183,6 +183,71 @@ describe('startHostNetworking', () => {
       machineMode: 'host',
       status: Admin.ClientMachineStatus.Active,
     });
+  });
+
+  test('disables client adjudication when another host is detected', async () => {
+    const store = Store.memoryStore(makeTemporaryDirectory());
+    store.setIsClientAdjudicationEnabled(true);
+    vi.mocked(hasOnlineInterface).mockResolvedValue(true);
+    vi.mocked(AvahiService.discoverHttpServices).mockResolvedValue([
+      {
+        name: 'VxAdmin-0001',
+        host: 'self.local',
+        resolvedIp: '192.168.1.1',
+        port: '3002',
+      },
+    ]);
+    const mockClient = {
+      getCurrentElectionMetadata: vi.fn().mockResolvedValue(undefined),
+    } as unknown as grout.Client<PeerApi>;
+    vi.mocked(grout.createClient).mockReturnValue(mockClient);
+    const logger = mockBaseLogger({ fn: vi.fn });
+    startHostNetworking({
+      machineId: '0001',
+      peerPort: 3002,
+      store,
+      logger,
+    });
+
+    // Alone on the network — adjudication stays enabled
+    await advancePollingInterval();
+    expect(store.getIsClientAdjudicationEnabled()).toEqual(true);
+
+    // A second host appears — adjudication is disabled
+    vi.mocked(AvahiService.discoverHttpServices).mockResolvedValue([
+      {
+        name: 'VxAdmin-0001',
+        host: 'self.local',
+        resolvedIp: '192.168.1.1',
+        port: '3002',
+      },
+      {
+        name: 'VxAdmin-OTHER',
+        host: 'other.local',
+        resolvedIp: '192.168.1.2',
+        port: '3002',
+      },
+    ]);
+    await advancePollingInterval();
+    expect(store.getIsClientAdjudicationEnabled()).toEqual(false);
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.AdminClientAdjudicationToggled,
+      'system',
+      expect.objectContaining({ disposition: 'failure', enabled: false })
+    );
+
+    // It stays disabled even after the other host disappears — an election
+    // manager must explicitly re-enable it
+    vi.mocked(AvahiService.discoverHttpServices).mockResolvedValue([
+      {
+        name: 'VxAdmin-0001',
+        host: 'self.local',
+        resolvedIp: '192.168.1.1',
+        port: '3002',
+      },
+    ]);
+    await advancePollingInterval();
+    expect(store.getIsClientAdjudicationEnabled()).toEqual(false);
   });
 
   test('does not record other host when communication fails', async () => {

--- a/apps/admin/backend/src/networking.ts
+++ b/apps/admin/backend/src/networking.ts
@@ -161,7 +161,7 @@ export function startHostNetworking({
           }
         }
 
-        if (otherHosts.length > 1) {
+        if (otherHosts.length >= 1) {
           logStatusTransition('multipleHosts', {
             hostCount: String(otherHosts.length),
           });

--- a/apps/admin/backend/src/networking.ts
+++ b/apps/admin/backend/src/networking.ts
@@ -170,6 +170,22 @@ export function startHostNetworking({
         }
 
         store.cleanupStaleMachines();
+
+        // Client adjudication cannot run safely with multiple hosts on the
+        // network — disable it (which also releases all active ballot
+        // claims). It stays off until an election manager re-enables it.
+        if (
+          store.getIsClientAdjudicationEnabled() &&
+          store.getMultipleHostsDetected(machineId)
+        ) {
+          store.setIsClientAdjudicationEnabled(false);
+          logger.log(LogEventId.AdminClientAdjudicationToggled, 'system', {
+            message:
+              'Client adjudication disabled because multiple VxAdmin hosts were detected on the network.',
+            disposition: 'failure',
+            enabled: false,
+          });
+        }
       } finally {
         isPolling = false;
       }

--- a/apps/admin/backend/src/peer_app.test.ts
+++ b/apps/admin/backend/src/peer_app.test.ts
@@ -311,6 +311,7 @@ test('parallel claims from more machines than ballots assign each ballot exactly
     electionDefinition
   );
   const cvrIds = addTestCvrs(workspace.store, electionId, 3);
+  workspace.store.setIsClientAdjudicationEnabled(true);
 
   const results = await Promise.all(
     range(1, 6).map((i) =>
@@ -334,6 +335,7 @@ test('releaseBallot frees a claimed CVR', async () => {
     electionDefinition
   );
   addTestCvrs(workspace.store, electionId, 1);
+  workspace.store.setIsClientAdjudicationEnabled(true);
 
   const cvrId = assertDefined(
     await claimBallot(peerApiClient, { machineId: 'client-001' })
@@ -398,6 +400,7 @@ test('claimAndLoadBallot advances past a just-completed ballot', async () => {
     electionDefinition
   );
   addTestCvrs(workspace.store, electionId, 3);
+  workspace.store.setIsClientAdjudicationEnabled(true);
 
   // Arrange for client-001 to hold the SECOND ballot in queue order, with
   // the first ballot released back to the pool. The accept-and-next cursor

--- a/apps/admin/backend/src/peer_app.test.ts
+++ b/apps/admin/backend/src/peer_app.test.ts
@@ -12,6 +12,7 @@ import {
 } from '@votingworks/fixtures';
 import { assertDefined, err, range } from '@votingworks/basics';
 import { LogEventId } from '@votingworks/logging';
+import type { Result } from '@votingworks/basics';
 import { buildTestEnvironment, configureMachine } from '../test/app';
 import { getCurrentTime } from './get_current_time';
 import {
@@ -29,12 +30,12 @@ async function claimBallot(
     claimAndLoadBallot: (input: {
       machineId: string;
       afterCvrId?: string;
-    }) => Promise<{ cvrId: string } | undefined>;
+    }) => Promise<Result<{ cvrId: string } | undefined, unknown>>;
   },
   input: { machineId: string; afterCvrId?: string }
 ): Promise<string | undefined> {
   const result = await peerApiClient.claimAndLoadBallot(input);
-  return result?.cvrId;
+  return result.unsafeUnwrap()?.cvrId;
 }
 
 beforeEach(() => {
@@ -118,6 +119,7 @@ test("connectToHost releases the client's claims when it transitions to OnlineLo
     electionDefinition
   );
   addTestCvrs(workspace.store, electionId, 2);
+  workspace.store.setIsClientAdjudicationEnabled(true);
 
   // Client logs in (Active) and claims a ballot.
   await peerApiClient.connectToHost({
@@ -153,6 +155,7 @@ test('connectToHost does not release claims when status stays Active or transiti
     electionDefinition
   );
   addTestCvrs(workspace.store, electionId, 1);
+  workspace.store.setIsClientAdjudicationEnabled(true);
 
   await peerApiClient.connectToHost({
     machineId: 'client-001',
@@ -285,6 +288,7 @@ test('claimBallot claims an unresolved CVR', async () => {
     electionDefinition
   );
   const cvrIds = addTestCvrs(workspace.store, electionId, 2);
+  workspace.store.setIsClientAdjudicationEnabled(true);
 
   const result1 = await claimBallot(peerApiClient, { machineId: 'client-001' });
   expect(cvrIds).toContain(result1);
@@ -364,6 +368,7 @@ test("releaseBallot does not release another machine's claim", async () => {
     electionDefinition
   );
   addTestCvrs(workspace.store, electionId, 1);
+  workspace.store.setIsClientAdjudicationEnabled(true);
 
   const cvrId = assertDefined(
     await claimBallot(peerApiClient, { machineId: 'client-001' })
@@ -437,6 +442,7 @@ test('adjudicateCvr completes the ballot claim', async () => {
     electionDefinition
   );
   const cvrIds = addTestCvrs(workspace.store, electionId, 2);
+  workspace.store.setIsClientAdjudicationEnabled(true);
 
   const claimedCvrId = assertDefined(
     await claimBallot(peerApiClient, { machineId: 'client-001' })
@@ -637,6 +643,7 @@ test('adjudicateCvr returns claim-failed when machine has no claim', async () =>
     electionDefinition
   );
   const cvrIds = addTestCvrs(workspace.store, electionId, 1);
+  workspace.store.setIsClientAdjudicationEnabled(true);
 
   const result = await peerApiClient.adjudicateCvr({
     machineId: 'unknown-machine',
@@ -644,4 +651,87 @@ test('adjudicateCvr returns claim-failed when machine has no claim', async () =>
     contests: [],
   });
   expect(result).toEqual(err({ type: 'claim-failed' }));
+});
+
+test('adjudication endpoints reject requests when client adjudication is disabled', async () => {
+  const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
+  const electionDefinition =
+    electionTwoPartyPrimaryFixtures.readElectionDefinition();
+  const electionId = await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition
+  );
+  const cvrIds = addTestCvrs(workspace.store, electionId, 1);
+  const cvrId = assertDefined(cvrIds[0]);
+
+  // Client adjudication was never enabled — claims and adjudications are
+  // rejected at the peer API even if a client tries anyway
+  expect(
+    await peerApiClient.claimAndLoadBallot({ machineId: 'client-001' })
+  ).toEqual(err({ type: 'adjudication-disabled' }));
+  expect(
+    await peerApiClient.adjudicateCvr({
+      machineId: 'client-001',
+      cvrId,
+      contests: [],
+    })
+  ).toEqual(err({ type: 'adjudication-disabled' }));
+});
+
+test('adjudication endpoints reject requests when multiple hosts are detected', async () => {
+  const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
+  const electionDefinition =
+    electionTwoPartyPrimaryFixtures.readElectionDefinition();
+  const electionId = await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition
+  );
+  addTestCvrs(workspace.store, electionId, 1);
+  workspace.store.setIsClientAdjudicationEnabled(true);
+
+  const cvrId = assertDefined(
+    await claimBallot(peerApiClient, { machineId: 'client-001' })
+  );
+
+  // A second host appears on the network
+  workspace.store.setNetworkedMachineStatus(
+    'other-host',
+    'host',
+    Admin.ClientMachineStatus.Active
+  );
+
+  expect(
+    await peerApiClient.claimAndLoadBallot({ machineId: 'client-002' })
+  ).toEqual(err({ type: 'adjudication-disabled' }));
+  expect(
+    await peerApiClient.adjudicateCvr({
+      machineId: 'client-001',
+      cvrId,
+      contests: [],
+    })
+  ).toEqual(err({ type: 'adjudication-disabled' }));
+
+  // Release requests are ignored while adjudication is not allowed — claim
+  // cleanup is the host's responsibility in this state
+  await peerApiClient.releaseBallot({ machineId: 'client-001', cvrId });
+  expect(
+    workspace.store.hasBallotClaim({
+      electionId,
+      cvrId,
+      machineId: 'client-001',
+    })
+  ).toEqual(true);
+
+  // Once the other host goes offline, adjudication operations resume
+  workspace.store.setNetworkedMachineStatus(
+    'other-host',
+    'host',
+    Admin.ClientMachineStatus.Offline
+  );
+  await peerApiClient.releaseBallot({ machineId: 'client-001', cvrId });
+  expect(await claimBallot(peerApiClient, { machineId: 'client-002' })).toEqual(
+    cvrId
+  );
 });

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -43,9 +43,10 @@ const debug = rootDebug.extend('peer-app');
 export interface PeerAppContext {
   workspace: Workspace;
   logger: BaseLogger;
+  machineId: string;
 }
 
-function buildPeerApi({ workspace, logger }: PeerAppContext) {
+function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
   const { store } = workspace;
 
   // Client adjudication operations are only served while the host has client
@@ -55,7 +56,7 @@ function buildPeerApi({ workspace, logger }: PeerAppContext) {
   function isClientAdjudicationAllowed(): boolean {
     return (
       store.getIsClientAdjudicationEnabled() &&
-      !store.getMultipleHostsDetected(getMachineConfig().machineId)
+      !store.getMultipleHostsDetected(machineId)
     );
   }
 

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -48,6 +48,17 @@ export interface PeerAppContext {
 function buildPeerApi({ workspace, logger }: PeerAppContext) {
   const { store } = workspace;
 
+  // Client adjudication operations are only served while the host has client
+  // adjudication enabled and is the sole host on the network. Enforced
+  // server-side so a client whose UI hasn't yet observed a state change (or
+  // any stale request) cannot claim or adjudicate ballots.
+  function isClientAdjudicationAllowed(): boolean {
+    return (
+      store.getIsClientAdjudicationEnabled() &&
+      !store.getMultipleHostsDetected(getMachineConfig().machineId)
+    );
+  }
+
   return grout.createApi({
     connectToHost(input: {
       machineId: string;
@@ -141,7 +152,18 @@ function buildPeerApi({ workspace, logger }: PeerAppContext) {
     claimAndLoadBallot(input: {
       machineId: string;
       afterCvrId?: Id;
-    }): { cvrId: Id; data: BallotAdjudicationData } | undefined {
+    }): Result<
+      { cvrId: Id; data: BallotAdjudicationData } | undefined,
+      AdjudicationError
+    > {
+      if (!isClientAdjudicationAllowed()) {
+        logger.log(LogEventId.AdminBallotClaimed, 'system', {
+          message: `Rejected ballot claim from client ${input.machineId}: client adjudication is not allowed.`,
+          disposition: 'failure',
+          clientMachineId: input.machineId,
+        });
+        return err({ type: 'adjudication-disabled' });
+      }
       const electionId = assertDefined(store.getCurrentElectionId());
       const result = store.claimAndLoadBallotData({
         electionId,
@@ -156,10 +178,21 @@ function buildPeerApi({ workspace, logger }: PeerAppContext) {
         disposition: value ? 'success' : 'failure',
         clientMachineId: input.machineId,
       });
-      return value;
+      return ok(value);
     },
 
     releaseBallot(input: { machineId: string; cvrId: Id }): void {
+      // When client adjudication is not allowed, claims are managed by the
+      // host (released on toggle / multi-host detection), so a stale release
+      // request is a no-op rather than an error.
+      if (!isClientAdjudicationAllowed()) {
+        debug(
+          'Ignoring release of ballot %s from client %s: client adjudication is not allowed',
+          input.cvrId,
+          input.machineId
+        );
+        return;
+      }
       const electionId = assertDefined(store.getCurrentElectionId());
       store.releaseBallotClaim({
         electionId,
@@ -191,6 +224,15 @@ function buildPeerApi({ workspace, logger }: PeerAppContext) {
     adjudicateCvr(
       input: AdjudicatedCvr & { machineId: string }
     ): Result<void, AdjudicationError> {
+      if (!isClientAdjudicationAllowed()) {
+        logger.log(LogEventId.AdminBallotAdjudicationComplete, 'system', {
+          message: `Rejected adjudication of ballot ${input.cvrId} from client ${input.machineId}: client adjudication is not allowed.`,
+          disposition: 'failure',
+          cvrId: input.cvrId,
+          clientMachineId: input.machineId,
+        });
+        return err({ type: 'adjudication-disabled' });
+      }
       const electionId = assertDefined(store.getCurrentElectionId());
       if (
         !store.hasBallotClaim({

--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -146,7 +146,11 @@ export async function start(options: StartOptions = {}): Promise<Server> {
       const isMultiStationEnabled = isMultiStationAdjudicationEnabled();
 
       if (isMultiStationEnabled) {
-        const peerApp = buildPeerApp({ workspace, logger: baseLogger });
+        const peerApp = buildPeerApp({
+          workspace,
+          logger: baseLogger,
+          machineId: getMachineConfig().machineId,
+        });
         peerApp.listen(peerPort, () => {
           debug('Peer API server running at http://localhost:%d/', peerPort);
           baseLogger.log(LogEventId.ApplicationStartup, 'system', {

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -694,4 +694,5 @@ export type ImportElectionResultsReportingError =
  */
 export type AdjudicationError =
   | { type: 'host-disconnect' }
-  | { type: 'claim-failed' };
+  | { type: 'claim-failed' }
+  | { type: 'adjudication-disabled' };

--- a/apps/admin/backend/test/app.ts
+++ b/apps/admin/backend/test/app.ts
@@ -48,6 +48,7 @@ import { BaseStore } from '../src/types';
 import { createWorkspace } from '../src/util/workspace';
 import { buildApp } from '../src/app';
 import { buildPeerApp } from '../src/peer_app';
+import { getMachineConfig } from '../src/machine_config';
 import { deleteTmpFileAfterTestSuiteCompletes } from './cleanup';
 import { getUserRole } from '../src/util/auth';
 
@@ -219,6 +220,7 @@ export function buildTestEnvironment(workspaceRoot?: string) {
   const peerApp = buildPeerApp({
     workspace,
     logger: peerLogger,
+    machineId: getMachineConfig().machineId,
   });
   const peerServer = peerApp.listen();
   const { port: peerPort } = peerServer.address() as AddressInfo;

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
@@ -274,6 +274,19 @@ test('shows host-disconnect error with exit button', async () => {
   screen.getByText('Exit');
 });
 
+test('shows adjudication-disabled error with exit button', async () => {
+  apiMock.apiClient.claimAndLoadBallot
+    .expectRepeatedCallsWith({})
+    .resolves(err({ type: 'adjudication-disabled' }));
+
+  renderScreen();
+
+  await screen.findByText(
+    'Adjudication is not currently enabled on the host machine.'
+  );
+  screen.getByText('Exit');
+});
+
 test('redirects when host disables adjudication', async () => {
   // Data loader queries fire before the redirect.
   expectDataLoaderQueries('cvr-1');

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.tsx
@@ -26,6 +26,8 @@ function proxyErrorMessage(error: AdjudicationError): string {
       return 'This machine no longer has an active claim on this ballot. Please try again.';
     case 'host-disconnect':
       return 'Disconnected from host.';
+    case 'adjudication-disabled':
+      return 'Adjudication is not currently enabled on the host machine.';
     default:
       /* istanbul ignore next */
       throwIllegalValue(error, 'type');


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/8568 
I noticed when adding more extensive testing to multi-station that we are not blocking adjudication-related queries when adjudication in disabled, either from the toggle, or from multiple-hosts being detected. The latter of which I noticed in QA (see ticket). This updates the code so that adjudication is disabled when multiple hosts are detected and that all adjudication-related endpoints are rejected on the hosts if called when adjudication is disabled. 

## Demo Video or Screenshot
N/A 

## Testing Plan
Ran Tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
