### PR TITLE
VxDesign: Clean unused fields from store.getElection return value

### DIFF
--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -1171,9 +1171,6 @@ export class Store {
 
       const pollingPlaces = await this.listPollingPlaces(electionId);
 
-      // Fill in our precinct/ballot style overrides in the VXF election format.
-      // This is important for pieces of the code that rely on the VXF election
-      // (e.g. rendering ballots)
       const election: Election = {
         id: electionId,
         type: electionRow.type,
@@ -1209,9 +1206,6 @@ export class Store {
 
       return {
         election,
-        type: electionRow.type,
-        precincts,
-        ballotStyles,
         systemSettings,
         ballotTemplateId: electionRow.ballotTemplateId,
         createdAt: electionRow.createdAt.toISOString(),


### PR DESCRIPTION


## Overview

<!-- Add a link to a GitHub issue here -->
These were a remnant of a time when VxDesign had different internal data models from VxSuite for precincts/ballot styles/election types, so those pieces of data were returned separately from the election itself. When this changed, the fields were removed from the ElectionRecord type but still returned by store.getElection, but never used.

## Demo Video or Screenshot
N/A
## Testing Plan
Existing tests
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
