### PR TITLE
admin/frontend: Fix test broken by rebase conflict

### DIFF
--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -19,6 +19,7 @@ import type {
   ContestAdjudicationData,
   CvrContestTag,
   CvrTag,
+  WriteInRecord,
 } from '@votingworks/admin-backend';
 import {
   HIGHLIGHT_PRIMARY_BACKGROUND,
@@ -143,6 +144,43 @@ function makeAdjudicatedCvrContest(
     };
   }
   return { contestId, adjudicatedContestOptionById };
+}
+
+function makePendingWriteInRecord(
+  contestId: string,
+  optionId: string,
+  cvrId: string = CVR_ID_1
+): WriteInRecord {
+  return {
+    status: 'pending',
+    id: `wir-${contestId}-${optionId}`,
+    cvrId,
+    contestId,
+    electionId: 'e',
+    optionId,
+  };
+}
+
+function addPendingWriteIns(
+  contest: ContestAdjudicationData,
+  numberOfWriteIns: number,
+  recordedSlots: number[]
+): void {
+  for (let i = 0; i < numberOfWriteIns; i += 1) {
+    contest.options.push({
+      definition: {
+        id: `write-in-${i}`,
+        contestId: contest.contestId,
+        type: 'candidate' as const,
+        isWriteIn: true,
+      },
+      scannedVote: recordedSlots.includes(i),
+      hasMarginalMark: false,
+      writeInRecord: recordedSlots.includes(i)
+        ? makePendingWriteInRecord(contest.contestId, `write-in-${i}`)
+        : undefined,
+    });
+  }
 }
 
 /**


### PR DESCRIPTION

## Overview

<!-- Add a link to a GitHub issue here -->
The `addPendingWriteIns` helper function was deleted in #8717 but used in #8756


## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
