### PR TITLE
VxDesign: Show non-editable straight party contest form

### DIFF
--- a/apps/design/backend/src/app.state_mi.test.ts
+++ b/apps/design/backend/src/app.state_mi.test.ts
@@ -106,4 +106,22 @@ test('general elections include generated straight party contest', async () => {
     })
   ).unsafeUnwrap();
   await expect(result.pdfData).toMatchPdfSnapshot({ failureThreshold: 0.001 });
+
+  // Make sure re-ordering other contests works, even though straight party
+  // contest is not in the db
+  const realContests = contests.filter(
+    (contest) => contest.type !== 'straight-party'
+  );
+  const reorderedRealContests = realContests.toReversed();
+  await apiClient.reorderContests({
+    electionId,
+    contestIds: [
+      straightPartyContest.id,
+      ...reorderedRealContests.map((contest) => contest.id),
+    ],
+  });
+  expect(await apiClient.listContests({ electionId })).toEqual([
+    straightPartyContest,
+    ...reorderedRealContests,
+  ]);
 });

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -249,6 +249,10 @@ export type DuplicateContestError =
 
 export type SetPollingPlaceError = 'duplicate-name' | 'invalid-precinct';
 
+function straightPartyContestId(electionId: ElectionId): ContestId {
+  return `${electionId}-straight-party-contest`;
+}
+
 async function insertDistrict(
   client: Client,
   electionId: ElectionId,
@@ -1193,7 +1197,7 @@ export class Store {
           'Straight party contest requires a district shared by all ballot styles'
         );
         const straightPartyContest: StraightPartyContest = {
-          id: `${electionId}-straight-party-contest`,
+          id: straightPartyContestId(electionId),
           type: 'straight-party',
           title: 'Straight Party Ticket',
           districtId: district.id,
@@ -2139,6 +2143,10 @@ export class Store {
     electionId: ElectionId,
     contestIds: string[]
   ): Promise<void> {
+    // eslint-disable-next-line no-param-reassign
+    contestIds = contestIds.filter(
+      (id) => id !== straightPartyContestId(electionId)
+    );
     await this.db.withClient((client) =>
       client.withTransaction(async () => {
         const existingContestIds = (

--- a/apps/design/backend/src/tts_strings.test.ts
+++ b/apps/design/backend/src/tts_strings.test.ts
@@ -125,6 +125,12 @@ test('ttsStringDefaults - accounts for all relevant strings', async () => {
         noOption: { id: 'option_disagree', label: 'Agree to Disagree' },
         yesOption: { id: 'option_agree', label: 'Agree' },
       },
+      {
+        id: 'contest5',
+        title: 'Straight Party Ticket',
+        type: 'straight-party',
+        optionIds: ['party1', 'party2'],
+      },
     ],
     county: { name: 'Test County' },
     districts: [
@@ -188,6 +194,7 @@ test('ttsStringDefaults - accounts for all relevant strings', async () => {
       { subkey: 'contest2', text: 'Candidate Contest 2' },
       { subkey: 'contest3', text: 'Ballot Measure 1' },
       { subkey: 'contest4', text: 'Ballot Measure 2' },
+      { subkey: 'contest5', text: 'Straight Party Ticket' },
     ],
     countyName: [{ text: 'Test County' }],
     districtName: [

--- a/apps/design/backend/src/tts_strings.ts
+++ b/apps/design/backend/src/tts_strings.ts
@@ -5,7 +5,6 @@ import {
   LanguageCode,
   TtsEdit,
   TtsEditKey,
-  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import {
   SpeechSynthesizer,
@@ -123,10 +122,6 @@ export function apiMethods(ctx: TtsApiContext) {
           text: contest.title,
         });
 
-        /* istanbul ignore next */
-        if (contest.type === 'straight-party') {
-          straightPartyNotYetImplemented();
-        }
         switch (contest.type) {
           case 'candidate':
             if (contest.termDescription) {
@@ -166,6 +161,9 @@ export function apiMethods(ctx: TtsApiContext) {
               text: contest.noOption.label,
             });
 
+            break;
+
+          case 'straight-party':
             break;
 
           default:

--- a/apps/design/frontend/src/contest_form.tsx
+++ b/apps/design/frontend/src/contest_form.tsx
@@ -3,7 +3,7 @@ import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import { z } from 'zod/v4';
 
-import { Result, throwIllegalValue } from '@votingworks/basics';
+import { assert, find, Result, throwIllegalValue } from '@votingworks/basics';
 import {
   isPrimary,
   ElectionId,
@@ -17,7 +17,7 @@ import {
   safeParse,
   YesNoContestSchema,
   ElectionStringKey,
-  straightPartyNotYetImplemented,
+  StraightPartyContest,
 } from '@votingworks/types';
 import {
   Callout,
@@ -319,6 +319,13 @@ export function ContestForm(props: ContestFormProps): React.ReactNode {
       <FormBody>
         <FormTitle>{title}</FormTitle>
 
+        {contest.type === 'straight-party' && (
+          <Callout icon="Info" color="neutral">
+            This contest is generated based on the election parties and cannot
+            be edited directly. To edit the party options, edit the party list.
+          </Callout>
+        )}
+
         <InputGroup label="Title">
           <InputWithAudio
             audioScreenUrl={contestRoutes.audio({
@@ -356,48 +363,51 @@ export function ContestForm(props: ContestFormProps): React.ReactNode {
             required
           />
         </InputGroup>
-        <InputRow>
-          <SegmentedButton
-            disabled={disabled || hasExternalSource}
-            label="Type"
-            options={
-              hasExternalSource
-                ? [
-                    { id: 'candidate', label: 'Candidate Contest' },
-                    { id: 'yesno', label: 'Ballot Measure' },
-                  ].filter((o) => o.id === contest.type)
-                : [
-                    { id: 'candidate', label: 'Candidate Contest' },
-                    { id: 'yesno', label: 'Ballot Measure' },
-                  ]
-            }
-            selectedOptionId={contest.type}
-            onChange={(type) =>
-              setContest({
-                ...(type === 'candidate'
-                  ? createBlankCandidateContest()
-                  : createBlankYesNoContest()),
-                id: contest.id,
-                title: contest.title,
-                districtId: contest.districtId,
-              })
-            }
-          />
-          {contest.type === 'candidate' && (
+
+        {contest.type !== 'straight-party' && (
+          <InputRow>
             <SegmentedButton
-              disabled={disabled}
-              label="Write-Ins Allowed?"
-              options={[
-                { id: 'yes', label: 'Yes' },
-                { id: 'no', label: 'No' },
-              ]}
-              selectedOptionId={contest.allowWriteIns ? 'yes' : 'no'}
-              onChange={(value) =>
-                setContest({ ...contest, allowWriteIns: value === 'yes' })
+              disabled={disabled || hasExternalSource}
+              label="Type"
+              options={
+                hasExternalSource
+                  ? [
+                      { id: 'candidate', label: 'Candidate Contest' },
+                      { id: 'yesno', label: 'Ballot Measure' },
+                    ].filter((o) => o.id === contest.type)
+                  : [
+                      { id: 'candidate', label: 'Candidate Contest' },
+                      { id: 'yesno', label: 'Ballot Measure' },
+                    ]
+              }
+              selectedOptionId={contest.type}
+              onChange={(type) =>
+                setContest({
+                  ...(type === 'candidate'
+                    ? createBlankCandidateContest()
+                    : createBlankYesNoContest()),
+                  id: contest.id,
+                  title: contest.title,
+                  districtId: contest.districtId,
+                })
               }
             />
-          )}
-        </InputRow>
+            {contest.type === 'candidate' && (
+              <SegmentedButton
+                disabled={disabled}
+                label="Write-Ins Allowed?"
+                options={[
+                  { id: 'yes', label: 'Yes' },
+                  { id: 'no', label: 'No' },
+                ]}
+                selectedOptionId={contest.allowWriteIns ? 'yes' : 'no'}
+                onChange={(value) =>
+                  setContest({ ...contest, allowWriteIns: value === 'yes' })
+                }
+              />
+            )}
+          </InputRow>
+        )}
 
         {contest.type === 'candidate' && (
           <React.Fragment>
@@ -808,11 +818,30 @@ export function ContestForm(props: ContestFormProps): React.ReactNode {
             </div>
           </React.Fragment>
         )}
+
+        {contest.type === 'straight-party' && (
+          <div>
+            <FieldName>Options</FieldName>
+            <Column style={{ gap: '0.5rem' }}>
+              {contest.optionIds.map((partyId) => {
+                const party = find(parties, (p) => p.id === partyId);
+                return (
+                  <input
+                    key={partyId}
+                    type="text"
+                    value={party.fullName}
+                    disabled
+                  />
+                );
+              })}
+            </Column>
+          </div>
+        )}
       </FormBody>
 
       <FormErrorContainer>{errorMessage}</FormErrorContainer>
 
-      {!isFinalized && (
+      {!isFinalized && contest.type !== 'straight-party' && (
         <FormFooter style={{ justifyContent: 'space-between' }}>
           <PrimaryFormActions disabled={disabled} editing={editing} />
 
@@ -928,7 +957,15 @@ interface DraftYesNoContest {
   additionalOptions?: readonly DraftOption[];
 }
 
-type DraftContest = DraftCandidateContest | DraftYesNoContest;
+// Straight party contests aren't editable, but we still need them to type-check
+type DraftStraightPartyContest = Omit<StraightPartyContest, 'districtId'> & {
+  districtId?: DistrictId;
+};
+
+type DraftContest =
+  | DraftCandidateContest
+  | DraftYesNoContest
+  | DraftStraightPartyContest;
 
 function draftCandidateFromCandidate(candidate: Candidate): DraftCandidate {
   let firstName = candidate.firstName ?? '';
@@ -952,10 +989,6 @@ function draftCandidateFromCandidate(candidate: Candidate): DraftCandidate {
 }
 
 function draftContestFromContest(contest: Contest): DraftContest {
-  /* istanbul ignore next */
-  if (contest.type === 'straight-party') {
-    return straightPartyNotYetImplemented();
-  }
   switch (contest.type) {
     case 'candidate':
       return {
@@ -963,6 +996,7 @@ function draftContestFromContest(contest: Contest): DraftContest {
         candidates: contest.candidates.map(draftCandidateFromCandidate),
       };
     case 'yesno':
+    case 'straight-party':
       return { ...contest };
     default: {
       /* istanbul ignore next */
@@ -974,6 +1008,10 @@ function draftContestFromContest(contest: Contest): DraftContest {
 function tryContestFromDraftContest(
   draftContest: DraftContest
 ): Result<Contest, z.ZodError> {
+  assert(
+    draftContest.type !== 'straight-party',
+    'Straight party contests are not editable'
+  );
   switch (draftContest.type) {
     case 'candidate':
       return safeParse(CandidateContestSchema, {

--- a/apps/design/frontend/src/contest_list.test.tsx
+++ b/apps/design/frontend/src/contest_list.test.tsx
@@ -73,8 +73,7 @@ test('renders labelled candidate and ballot measure sublists', async () => {
   const yesNoContests = [yesNoContest1, yesNoContest2];
 
   renderList(mockApi, newHistory(), {
-    candidateContests,
-    yesNoContests,
+    contests: [...candidateContests, ...yesNoContests],
     reorder: vi.fn(),
     reordering: false,
   });
@@ -111,8 +110,7 @@ test('renders primary election contest parties, when available', async () => {
   const yesNoContests = [yesNoContest1, yesNoContest2];
 
   renderList(mockApi, newHistory(), {
-    candidateContests,
-    yesNoContests,
+    contests: [...candidateContests, ...yesNoContests],
     reorder: vi.fn(),
     reordering: false,
   });
@@ -143,8 +141,7 @@ test('navigates on select', async () => {
   const history = newHistory();
 
   renderList(mockApi, history, {
-    candidateContests,
-    yesNoContests,
+    contests: [...candidateContests, ...yesNoContests],
     reorder: vi.fn(),
     reordering: false,
   });
@@ -175,8 +172,7 @@ test('omits ballot measure section if empty', async () => {
   const candidateContests = [candidateContest1, candidateContest2];
 
   renderList(mockApi, newHistory(), {
-    candidateContests,
-    yesNoContests: [],
+    contests: candidateContests,
     reorder: vi.fn(),
     reordering: false,
   });
@@ -199,8 +195,7 @@ test('omits candidate section if empty', async () => {
   const yesNoContests = [yesNoContest2, yesNoContest1];
 
   renderList(mockApi, newHistory(), {
-    candidateContests: [],
-    yesNoContests,
+    contests: yesNoContests,
     reorder: vi.fn(),
     reordering: false,
   });
@@ -225,8 +220,7 @@ test('omits reordering when not enabled', async () => {
   const reorder = vi.fn();
 
   renderList(mockApi, newHistory(), {
-    candidateContests,
-    yesNoContests: [],
+    contests: candidateContests,
     reorder,
     reordering: false,
   });
@@ -245,8 +239,7 @@ test('supports reordering', async () => {
   const reorder = vi.fn();
 
   renderList(mockApi, newHistory(), {
-    candidateContests,
-    yesNoContests,
+    contests: [...candidateContests, ...yesNoContests],
     reorder,
     reordering: true,
   });

--- a/apps/design/frontend/src/contest_list.test.tsx
+++ b/apps/design/frontend/src/contest_list.test.tsx
@@ -58,6 +58,13 @@ const yesNoContest2 = typedAs<Partial<Contest>>({
   type: 'yesno',
 }) as Contest;
 
+const straightPartyContest = typedAs<Partial<Contest>>({
+  id: 'straightPartyContest',
+  title: 'Straight Party Ticket',
+  districtId: district1.id,
+  type: 'straight-party',
+}) as Contest;
+
 const electionId = 'election1';
 const contestRoutes = routes.election(electionId).contests;
 const contestParamRoutes = routes.election(':electionId').contests;
@@ -129,6 +136,45 @@ test('renders primary election contest parties, when available', async () => {
 
   expect(list.item(2)).toEqual(getHeading('Ballot Measures'));
   expect(getSublist(list.item(3))).toEqual([
+    getOption(yesNoContest1, district1),
+    getOption(yesNoContest2, district2),
+  ]);
+});
+
+test('renders straight party sublist if straight party contest is present', async () => {
+  mockApi = newMockApi({ districts: [district1, district2] });
+
+  renderList(mockApi, newHistory(), {
+    contests: [
+      straightPartyContest,
+      candidateContest1,
+      candidateContest2,
+      yesNoContest1,
+      yesNoContest2,
+    ],
+    reorder: vi.fn(),
+    reordering: false,
+  });
+
+  await screen.findAllByText(district1.name);
+  mockApi.assertComplete();
+
+  const list = screen.getByRole('listbox').children;
+  expect(list).toHaveLength(6);
+
+  expect(list.item(0)).toEqual(getHeading('Straight Party'));
+  expect(getSublist(list.item(1))).toEqual([
+    getOption(straightPartyContest, district1),
+  ]);
+
+  expect(list.item(2)).toEqual(getHeading('Candidate Contests'));
+  expect(getSublist(list.item(3))).toEqual([
+    getOption(candidateContest1, district1),
+    getOption(candidateContest2, district2),
+  ]);
+
+  expect(list.item(4)).toEqual(getHeading('Ballot Measures'));
+  expect(getSublist(list.item(5))).toEqual([
     getOption(yesNoContest1, district1),
     getOption(yesNoContest2, district2),
   ]);

--- a/apps/design/frontend/src/contest_list.tsx
+++ b/apps/design/frontend/src/contest_list.tsx
@@ -4,6 +4,7 @@ import { Flipped, Flipper } from 'react-flip-toolkit';
 import { Button } from '@votingworks/ui';
 import { Contest, Party } from '@votingworks/types';
 import { useHistory, useParams } from 'react-router-dom';
+import { groupBy } from '@votingworks/basics';
 import { Column, Row } from './layout';
 import * as api from './api';
 import { ElectionIdParams, routes } from './routes';
@@ -31,8 +32,7 @@ export interface ReorderParams {
 }
 
 export interface ContestListProps {
-  candidateContests: Contest[];
-  yesNoContests: Contest[];
+  contests: readonly Contest[];
   reordering: boolean;
   reorder: (params: ReorderParams) => void;
 }
@@ -42,7 +42,7 @@ export interface ContestListProps {
 // footer. With recent changes the "reorder" button is a bit too far off now and
 // there may be plans to add support for custom contest grouping down the line.
 export function ContestList(props: ContestListProps): React.ReactNode {
-  const { candidateContests, yesNoContests, reorder, reordering } = props;
+  const { contests, reorder, reordering } = props;
   const { contestId = null, electionId } = useParams<
     ElectionIdParams & { contestId?: string }
   >();
@@ -66,31 +66,31 @@ export function ContestList(props: ContestListProps): React.ReactNode {
     return null;
   }
 
+  const contestsByType: Partial<Record<Contest['type'], Contest[]>> =
+    Object.fromEntries(groupBy(contests, (contest) => contest.type));
+  const sections: Array<[string, Contest[] | undefined]> = [
+    ['Straight Party', contestsByType['straight-party']],
+    ['Candidate Contests', contestsByType['candidate']],
+    ['Ballot Measures', contestsByType['yesno']],
+  ];
+
   return (
     <EntityList.Box>
-      {candidateContests.length > 0 && (
-        <Sublist
-          contests={candidateContests}
-          districtIdToName={districtIdToName}
-          onSelect={onSelect}
-          parties={parties.data}
-          reordering={reordering}
-          reorder={reorder}
-          selectedId={contestId}
-          title="Candidate Contests"
-        />
-      )}
-      {yesNoContests.length > 0 && (
-        <Sublist
-          contests={yesNoContests}
-          districtIdToName={districtIdToName}
-          onSelect={onSelect}
-          parties={parties.data}
-          reordering={reordering}
-          reorder={reorder}
-          selectedId={contestId}
-          title="Ballot Measures"
-        />
+      {sections.map(
+        ([title, sectionContests]) =>
+          sectionContests && (
+            <Sublist
+              key={title}
+              contests={sectionContests}
+              districtIdToName={districtIdToName}
+              onSelect={onSelect}
+              parties={parties.data}
+              reordering={reordering}
+              reorder={reorder}
+              selectedId={contestId}
+              title={title}
+            />
+          )
       )}
     </EntityList.Box>
   );

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -1690,10 +1690,7 @@ describe('audio editing', () => {
 });
 
 function expectContestListItems(contests: readonly Contest[]) {
-  expectContestListProps({
-    candidateContests: contests.filter((c) => c.type === 'candidate'),
-    yesNoContests: contests.filter((c) => c.type === 'yesno'),
-  });
+  expectContestListProps({ contests });
 }
 
 function expectContestListProps(partialProps: Partial<ContestListProps>) {

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -14,6 +14,7 @@ import {
   HmpbBallotPaperSize,
   PartyIdSchema,
   PrecinctIdSchema,
+  StraightPartyContest,
   unsafeParse,
   YesNoContest,
 } from '@votingworks/types';
@@ -156,13 +157,13 @@ const electionWithNoContestsRecord = makeElectionRecord(
     parties: [
       {
         id: unsafeParse(PartyIdSchema, 'test-party-1'),
-        name: 'Test Party 1',
+        name: 'Party 1',
         fullName: 'Test Party 1',
         abbrev: 'TP1',
       },
       {
         id: unsafeParse(PartyIdSchema, 'test-party-2'),
-        name: 'Test Party 2',
+        name: 'Party 2',
         fullName: 'Test Party 2',
         abbrev: 'TP2',
       },
@@ -171,6 +172,35 @@ const electionWithNoContestsRecord = makeElectionRecord(
   },
   jurisdiction.id
 );
+
+const straightPartyContest: StraightPartyContest = {
+  id: 'straight-party-contest',
+  type: 'straight-party',
+  title: 'Straight Party Ticket',
+  districtId: electionWithNoContestsRecord.election.districts[0].id,
+  optionIds: electionWithNoContestsRecord.election.parties.map(
+    (party) => party.id
+  ),
+};
+
+const mayorContest: CandidateContest = {
+  id: 'candidate-contest',
+  type: 'candidate',
+  title: 'Mayor',
+  districtId: electionWithNoContestsRecord.election.districts[0].id,
+  seats: 1,
+  allowWriteIns: false,
+  candidates: [],
+};
+
+const electionWithStraightPartyContestRecord: typeof electionWithNoContestsRecord =
+  {
+    ...electionWithNoContestsRecord,
+    election: {
+      ...electionWithNoContestsRecord.election,
+      contests: [straightPartyContest, mayorContest],
+    },
+  };
 
 // Since we coarsely invalidate all election data on contest changes, there
 // are a number of other API calls that refetch when we mutate contests
@@ -223,6 +253,46 @@ test('renders contest list on all sub-views', async () => {
   expectContestListItems(contests);
 
   // [TODO] Add assertion for audio editor view.
+});
+
+test('displays read-only straight party contest', async () => {
+  const { election } = electionWithStraightPartyContestRecord;
+  const electionId = election.id;
+
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(election.contests);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+  expectOtherElectionApiCalls(election);
+
+  const history = renderScreen(electionId);
+
+  await expectViewModeContest(history, electionId, straightPartyContest);
+  expectContestListItems(election.contests);
+
+  await navigateToContestView(history, electionId, straightPartyContest.id);
+  screen.getByText(
+    /This contest is generated based on the election parties and cannot be edited directly/
+  );
+
+  const titleInput = screen.getByLabelText('Title');
+  expect(titleInput).toHaveValue(straightPartyContest.title);
+  expect(titleInput).toBeDisabled();
+
+  const optionInputs = getOptionInputs();
+  expect(
+    optionInputs.map((input) => (input as HTMLInputElement).value)
+  ).toEqual(election.parties.map((party) => party.fullName));
+  for (const input of optionInputs) {
+    expect(input).toBeDisabled();
+  }
+
+  expect(
+    screen.queryByRole('button', { name: 'Edit' })
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: 'Delete Contest' })
+  ).not.toBeInTheDocument();
 });
 
 test('adding a candidate contest (general election)', async () => {

--- a/apps/design/frontend/src/contests_screen.tsx
+++ b/apps/design/frontend/src/contests_screen.tsx
@@ -1,14 +1,7 @@
 import React, { useState } from 'react';
 import { Button, LinkButton, SearchSelect, H1, Callout } from '@votingworks/ui';
 import { Redirect, Route, Switch, useParams } from 'react-router-dom';
-import {
-  CandidateContest,
-  ContestId,
-  Contest,
-  YesNoContest,
-  isPrimary,
-  straightPartyNotYetImplemented,
-} from '@votingworks/types';
+import { ContestId, Contest, isPrimary } from '@votingworks/types';
 import styled from 'styled-components';
 import { FixedViewport, ListActionsRow, Row } from './layout';
 import { ElectionNavScreen, Header } from './nav_screen';
@@ -128,17 +121,13 @@ function Content(): JSX.Element | null {
   const contestParamRoutes = electionParamRoutes.contests;
 
   const filteredContests = contests.filter((contest) => {
-    /* istanbul ignore next */
-    if (contest.type === 'straight-party') {
-      return false;
-    }
     const matchesDistrict =
       filterDistrictId === FILTER_ALL ||
       contest.districtId === filterDistrictId;
     const matchesParty =
       filterPartyId === FILTER_ALL ||
       (filterPartyId === FILTER_NONPARTISAN
-        ? contest.type === 'yesno' || contest.partyId === undefined
+        ? contest.type !== 'candidate' || contest.partyId === undefined
         : contest.type === 'candidate' && contest.partyId === filterPartyId);
     return matchesDistrict && matchesParty;
   });
@@ -152,17 +141,6 @@ function Content(): JSX.Element | null {
   const isReordering = reorderedContests !== undefined;
 
   const contestsToShow = isReordering ? reorderedContests : filteredContests;
-  const candidateContests: CandidateContest[] = [];
-  const yesNoContests: YesNoContest[] = [];
-
-  for (const c of contestsToShow) {
-    /* istanbul ignore next */
-    if (c.type === 'straight-party') {
-      straightPartyNotYetImplemented();
-    }
-    if (c.type === 'candidate') candidateContests.push(c);
-    else yesNoContests.push(c);
-  }
 
   /**
    * Used as a route redirect, to auto-select the first available contest for
@@ -252,13 +230,7 @@ function Content(): JSX.Element | null {
             ) : (
               <Button
                 icon="Sort"
-                onPress={() =>
-                  // We require candidate contests to appear before yesno,
-                  // but elections were created prior to this restriction.
-                  // To ensure all new reorders follow this, we initiate
-                  // the reordering with the requirement enforced
-                  setReorderedContests([...candidateContests, ...yesNoContests])
-                }
+                onPress={() => setReorderedContests(contestsToShow)}
                 disabled={!canReorder}
               >
                 Reorder Contests
@@ -297,8 +269,7 @@ function Content(): JSX.Element | null {
           )
         ) : (
           <ContestList
-            candidateContests={candidateContests}
-            yesNoContests={yesNoContests}
+            contests={contestsToShow}
             reordering={isReordering}
             reorder={(params) => {
               if (!isReordering) return;


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->
When an election has a straight party contest, adds a "Straight Party" section to the contest list. The section has one entry - the straight party contest - which opens the contest form panel and shows a non-editable form for the contest. It does allow opening the audio editing panel for the contest title.

I think in the future it probably makes more sense to change the sections in the contest list to match the sections on the ballot (Partisan/Nonpartisan/Proposals), but this is a minimal change to start.

## Demo Video or Screenshot
<img width="1312" height="731" alt="Screenshot 2026-06-16 at 11 56 52 AM" src="https://github.com/user-attachments/assets/47c68140-8730-4759-b3e8-28f43f1d3c86" />


## Testing Plan
- Manual test
- Automated tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
