### PR TITLE
[ALL] Make optional election package files required

### DIFF
--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_SYSTEM_SETTINGS,
   DEV_MACHINE_ID,
   ElectionPackageFileName,
+  LATEST_METADATA,
   ElectionRegisteredVotersCounts,
   PrinterStatus,
   safeParseElectionDefinition,
@@ -218,6 +219,10 @@ test('managing the current election', async () => {
   // try configuring with malformed election data
   const badElectionPackage = await zipFile({
     [ElectionPackageFileName.ELECTION]: '{}',
+    [ElectionPackageFileName.METADATA]: JSON.stringify(LATEST_METADATA),
+    [ElectionPackageFileName.SYSTEM_SETTINGS]: JSON.stringify(
+      DEFAULT_SYSTEM_SETTINGS
+    ),
   });
   const badElectionConfigureResult = await apiClient.configure({
     electionFilePath: saveTmpFile(badElectionPackage),
@@ -241,6 +246,7 @@ test('managing the current election', async () => {
 
   const badSystemSettingsPackage = await zipFile({
     [ElectionPackageFileName.ELECTION]: electionDefinition.electionData,
+    [ElectionPackageFileName.METADATA]: JSON.stringify(LATEST_METADATA),
     [ElectionPackageFileName.SYSTEM_SETTINGS]: '{}',
   });
   // try configuring with malformed system settings data
@@ -262,9 +268,11 @@ test('managing the current election', async () => {
   // configure with well-formed data
   const goodPackage = await zipFile({
     [ElectionPackageFileName.ELECTION]: electionDefinition.electionData,
+    [ElectionPackageFileName.METADATA]: JSON.stringify(LATEST_METADATA),
     [ElectionPackageFileName.SYSTEM_SETTINGS]: JSON.stringify(
       DEFAULT_SYSTEM_SETTINGS
     ),
+    [ElectionPackageFileName.APP_STRINGS]: JSON.stringify({}),
   });
   const { electionId } = (
     await apiClient.configure({
@@ -371,6 +379,11 @@ test('configuring with a CDF election', async () => {
   ).unsafeUnwrap();
   const electionPackage = await zipFile({
     [ElectionPackageFileName.ELECTION]: electionData,
+    [ElectionPackageFileName.METADATA]: JSON.stringify(LATEST_METADATA),
+    [ElectionPackageFileName.SYSTEM_SETTINGS]: JSON.stringify(
+      DEFAULT_SYSTEM_SETTINGS
+    ),
+    [ElectionPackageFileName.APP_STRINGS]: JSON.stringify({}),
   });
 
   // configure with well-formed election data

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -4,6 +4,7 @@ import { LogEventId, Logger } from '@votingworks/logging';
 import {
   Admin,
   ElectionPackageFileName,
+  LATEST_METADATA,
   ElectionRegisteredVotersCounts,
   CastVoteRecordExportFileName,
   ContestId,
@@ -555,8 +556,19 @@ function buildApi({
             contents: electionDefinition.electionData,
           });
           await addFileToZipStream(zipStream, {
+            path: ElectionPackageFileName.METADATA,
+            contents: JSON.stringify(LATEST_METADATA, null, 2),
+          });
+          await addFileToZipStream(zipStream, {
             path: ElectionPackageFileName.SYSTEM_SETTINGS,
             contents: JSON.stringify(systemSettings, null, 2),
+          });
+          // appStrings.json is required in every package; a bare election.json
+          // has no app strings, so write an empty one (UI strings still come
+          // from the election's ballotStrings).
+          await addFileToZipStream(zipStream, {
+            path: ElectionPackageFileName.APP_STRINGS,
+            contents: JSON.stringify({}, null, 2),
           });
           zipStream.finish();
           await zipPromise.promise;

--- a/apps/admin/backend/src/app.voter_turnout_report.test.ts
+++ b/apps/admin/backend/src/app.voter_turnout_report.test.ts
@@ -13,6 +13,7 @@ import { LogEventId } from '@votingworks/logging';
 import {
   DEFAULT_SYSTEM_SETTINGS,
   ElectionPackageFileName,
+  LATEST_METADATA,
   ElectionRegisteredVotersCounts,
 } from '@votingworks/types';
 import { zipFile } from '@votingworks/test-utils';
@@ -81,9 +82,11 @@ test('configure persists registered voter counts from election package', async (
   };
   const electionPackageBuffer = await zipFile({
     [ElectionPackageFileName.ELECTION]: electionDefinition.electionData,
+    [ElectionPackageFileName.METADATA]: JSON.stringify(LATEST_METADATA),
     [ElectionPackageFileName.SYSTEM_SETTINGS]: JSON.stringify(
       DEFAULT_SYSTEM_SETTINGS
     ),
+    [ElectionPackageFileName.APP_STRINGS]: JSON.stringify({}),
     [ElectionPackageFileName.REGISTERED_VOTERS_COUNTS]: JSON.stringify(
       registeredVoterCounts
     ),
@@ -270,9 +273,11 @@ test('voter turnout report with split precinct registered voter counts', async (
   };
   const electionPackageBuffer = await zipFile({
     [ElectionPackageFileName.ELECTION]: electionDefinition.electionData,
+    [ElectionPackageFileName.METADATA]: JSON.stringify(LATEST_METADATA),
     [ElectionPackageFileName.SYSTEM_SETTINGS]: JSON.stringify(
       DEFAULT_SYSTEM_SETTINGS
     ),
+    [ElectionPackageFileName.APP_STRINGS]: JSON.stringify({}),
     [ElectionPackageFileName.REGISTERED_VOTERS_COUNTS]: JSON.stringify(
       registeredVoterCounts
     ),

--- a/apps/admin/backend/test/app.ts
+++ b/apps/admin/backend/test/app.ts
@@ -18,6 +18,7 @@ import {
   ElectionDefinition,
   ElectionPackageFileName,
   ElectionRegisteredVotersCounts,
+  LATEST_METADATA,
   SystemSettings,
 } from '@votingworks/types';
 import * as grout from '@votingworks/grout';
@@ -128,7 +129,9 @@ export async function configureMachine(
   mockSystemAdministratorAuth(auth);
   const electionPackage = await zipFile({
     [ElectionPackageFileName.ELECTION]: electionDefinition.electionData,
+    [ElectionPackageFileName.METADATA]: JSON.stringify(LATEST_METADATA),
     [ElectionPackageFileName.SYSTEM_SETTINGS]: JSON.stringify(systemSettings),
+    [ElectionPackageFileName.APP_STRINGS]: JSON.stringify({}),
     ...(registeredVoterCounts
       ? {
           [ElectionPackageFileName.REGISTERED_VOTERS_COUNTS]: JSON.stringify(

--- a/apps/admin/integration-testing/e2e/reports.spec.ts
+++ b/apps/admin/integration-testing/e2e/reports.spec.ts
@@ -18,7 +18,11 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { assert, assertDefined } from '@votingworks/basics';
 import { zipFile } from '@votingworks/test-utils';
-import { ElectionPackageFileName } from '@votingworks/types';
+import {
+  DEFAULT_SYSTEM_SETTINGS,
+  ElectionPackageFileName,
+  LATEST_METADATA,
+} from '@votingworks/types';
 import {
   forceLogOutAndResetElectionDefinition,
   logInAsElectionManager,
@@ -48,6 +52,11 @@ test('viewing and exporting reports', async ({ page }) => {
   const { election, ballotHash, electionData } = electionDefinition;
   const electionPackage = await zipFile({
     [ElectionPackageFileName.ELECTION]: electionData,
+    [ElectionPackageFileName.METADATA]: JSON.stringify(LATEST_METADATA),
+    [ElectionPackageFileName.SYSTEM_SETTINGS]: JSON.stringify(
+      DEFAULT_SYSTEM_SETTINGS
+    ),
+    [ElectionPackageFileName.APP_STRINGS]: JSON.stringify({}),
   });
   const electionPackageFileName = 'election-package.zip';
 

--- a/apps/admin/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/admin/integration-testing/e2e/screenshots.spec.ts
@@ -33,6 +33,7 @@ import {
   DEFAULT_SYSTEM_SETTINGS,
   ElectionDefinition,
   ElectionPackageFileName,
+  LATEST_METADATA,
   SystemSettings,
 } from '@votingworks/types';
 import {
@@ -99,6 +100,11 @@ test('system administrator', async ({ page }, testInfo) => {
   const { election, electionData } = electionDefinition;
   const electionPackage = await zipFile({
     [ElectionPackageFileName.ELECTION]: electionData,
+    [ElectionPackageFileName.METADATA]: JSON.stringify(LATEST_METADATA),
+    [ElectionPackageFileName.SYSTEM_SETTINGS]: JSON.stringify(
+      DEFAULT_SYSTEM_SETTINGS
+    ),
+    [ElectionPackageFileName.APP_STRINGS]: JSON.stringify({}),
   });
   const electionPackageFileName = 'election-package.zip';
 
@@ -351,7 +357,9 @@ async function configureMachine({
   const { election, electionData } = electionDefinition;
   const electionPackage = await zipFile({
     [ElectionPackageFileName.ELECTION]: electionData,
+    [ElectionPackageFileName.METADATA]: JSON.stringify(LATEST_METADATA),
     [ElectionPackageFileName.SYSTEM_SETTINGS]: JSON.stringify(systemSettings),
+    [ElectionPackageFileName.APP_STRINGS]: JSON.stringify({}),
   });
   const electionPackageFileName = 'election-package.zip';
 

--- a/apps/mark/backend/src/app.diagnostics.test.ts
+++ b/apps/mark/backend/src/app.diagnostics.test.ts
@@ -8,7 +8,6 @@ import {
   constructElectionKey,
   DEFAULT_SYSTEM_SETTINGS,
   DiagnosticRecord,
-  ElectionPackage,
 } from '@votingworks/types';
 import { Server } from 'node:http';
 import * as grout from '@votingworks/grout';
@@ -16,6 +15,7 @@ import { MockUsbDrive } from '@votingworks/usb-drive';
 import {
   getDiskSpaceSummary,
   mockElectionPackageFileTree,
+  PartialElectionPackage,
 } from '@votingworks/backend';
 import type { DiskSpaceSummary } from '@votingworks/utils';
 import {
@@ -278,7 +278,10 @@ test('saveReadinessReport - machine configured', async () => {
   });
 
   const systemSettings = DEFAULT_SYSTEM_SETTINGS;
-  const electionPkg: ElectionPackage = { electionDefinition, systemSettings };
+  const electionPkg: PartialElectionPackage = {
+    electionDefinition,
+    systemSettings,
+  };
   mockUsbDrive.insertUsbDrive(await mockElectionPackageFileTree(electionPkg));
   mockUsbDrive.usbDrive.sync.expectCallWith().resolves();
 

--- a/apps/scan/backend/src/scanner_scan_shoeshine_mode.test.ts
+++ b/apps/scan/backend/src/scanner_scan_shoeshine_mode.test.ts
@@ -1,9 +1,9 @@
 import { vxFamousNamesFixtures } from '@votingworks/hmpb';
 import {
   DEFAULT_SYSTEM_SETTINGS,
-  ElectionPackage,
   SheetInterpretation,
 } from '@votingworks/types';
+import { PartialElectionPackage } from '@votingworks/backend';
 import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
@@ -33,7 +33,7 @@ beforeEach(() => {
   );
 });
 
-const electionPackage: ElectionPackage = {
+const electionPackage: PartialElectionPackage = {
   electionDefinition: vxFamousNamesFixtures.electionDefinition,
   systemSettings: {
     ...DEFAULT_SYSTEM_SETTINGS,

--- a/apps/scan/backend/test/helpers/shared_helpers.ts
+++ b/apps/scan/backend/test/helpers/shared_helpers.ts
@@ -1,7 +1,10 @@
 import { Mocked, expect, vi } from 'vitest';
 import { InsertedSmartCardAuthApi } from '@votingworks/auth';
 import { iter, ok } from '@votingworks/basics';
-import { mockElectionPackageFileTree } from '@votingworks/backend';
+import {
+  mockElectionPackageFileTree,
+  PartialElectionPackage,
+} from '@votingworks/backend';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import * as grout from '@votingworks/grout';
 import {
@@ -11,7 +14,6 @@ import {
 import { randomUUID as uuid } from 'node:crypto';
 import {
   BallotMetadata,
-  ElectionPackage,
   PageInterpretationWithFiles,
   anyPollingPlace,
   PrecinctScannerState,
@@ -78,7 +80,7 @@ export async function configureApp(
     testMode = false,
     openPolls = true,
   }: {
-    electionPackage?: ElectionPackage;
+    electionPackage?: PartialElectionPackage;
     pollingPlaceId?: string;
     testMode?: boolean;
     openPolls?: boolean;

--- a/libs/backend/src/election_package/election_package_io.test.ts
+++ b/libs/backend/src/election_package/election_package_io.test.ts
@@ -99,10 +99,28 @@ function assertFilesCreatedInOrder(
   }
 }
 
+// Election packages require metadata.json, systemSettings.json, and
+// appStrings.json; inject empty/default versions so tests that build raw zips
+// stay valid. Audio files are optional and omitted by default. Override or add
+// via `contents` (or use zipFile directly to omit a required file and exercise
+// a missing-file error).
+function electionPackageZip(
+  contents: Record<string, Buffer | string>
+): Promise<Buffer> {
+  return zipFile({
+    [ElectionPackageFileName.METADATA]: JSON.stringify(LATEST_METADATA),
+    [ElectionPackageFileName.SYSTEM_SETTINGS]: JSON.stringify(
+      DEFAULT_SYSTEM_SETTINGS
+    ),
+    [ElectionPackageFileName.APP_STRINGS]: JSON.stringify({}),
+    ...contents,
+  });
+}
+
 test('readElectionPackageFromFile reads an election package without system settings from a file', async () => {
   const electionDefinition =
     electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
-  const pkg = await zipFile({
+  const pkg = await electionPackageZip({
     [ElectionPackageFileName.ELECTION]: electionDefinition.electionData,
   });
   const file = makeTemporaryFile({ content: pkg });
@@ -112,6 +130,8 @@ test('readElectionPackageFromFile reads an election package without system setti
   ).toEqual<ElectionPackageWithFileContents>({
     electionPackage: {
       electionDefinition,
+      metadata: LATEST_METADATA,
+      uiStringAudioIds: {},
       systemSettings: DEFAULT_SYSTEM_SETTINGS,
       uiStrings: electionDefinition.election.ballotStrings,
       uiStringAudioClips: [],
@@ -125,7 +145,7 @@ test('readElectionPackageFromFile reads an election package without system setti
 test('readElectionPackageFromFile reads an election package with system settings from a file', async () => {
   const electionDefinition =
     electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
-  const pkg = await zipFile({
+  const pkg = await electionPackageZip({
     [ElectionPackageFileName.ELECTION]: electionDefinition.electionData,
     [ElectionPackageFileName.SYSTEM_SETTINGS]: JSON.stringify(
       typedAs<SystemSettings>(DEFAULT_SYSTEM_SETTINGS)
@@ -138,6 +158,8 @@ test('readElectionPackageFromFile reads an election package with system settings
   ).toEqual<ElectionPackageWithFileContents>({
     electionPackage: {
       electionDefinition,
+      metadata: LATEST_METADATA,
+      uiStringAudioIds: {},
       systemSettings: DEFAULT_SYSTEM_SETTINGS,
       uiStrings: electionDefinition.election.ballotStrings,
       uiStringAudioClips: [],
@@ -161,7 +183,7 @@ test('readElectionPackageFromFile loads available ui strings', async () => {
     },
   };
 
-  const pkg = await zipFile({
+  const pkg = await electionPackageZip({
     [ElectionPackageFileName.ELECTION]: electionDefinition.electionData,
     [ElectionPackageFileName.APP_STRINGS]: JSON.stringify(appStrings),
   });
@@ -190,6 +212,8 @@ test('readElectionPackageFromFile loads available ui strings', async () => {
   ).toEqual<ElectionPackageWithFileContents>({
     electionPackage: {
       electionDefinition,
+      metadata: LATEST_METADATA,
+      uiStringAudioIds: {},
       systemSettings: DEFAULT_SYSTEM_SETTINGS,
       uiStrings: expectedUiStrings,
       uiStringAudioClips: [],
@@ -202,7 +226,7 @@ test('readElectionPackageFromFile loads available ui strings', async () => {
 
 test('readElectionPackageFromFile loads election strings from CDF', async () => {
   const testCdfElectionData = JSON.stringify(testCdfBallotDefinition);
-  const pkg = await zipFile({
+  const pkg = await electionPackageZip({
     [ElectionPackageFileName.ELECTION]: testCdfElectionData,
   });
   const file = makeTemporaryFile({ content: pkg });
@@ -216,6 +240,8 @@ test('readElectionPackageFromFile loads election strings from CDF', async () => 
     electionPackage: {
       electionDefinition:
         safeParseElectionDefinition(testCdfElectionData).unsafeUnwrap(),
+      metadata: LATEST_METADATA,
+      uiStringAudioIds: {},
       systemSettings: DEFAULT_SYSTEM_SETTINGS,
       uiStrings: expectedCdfStrings,
       uiStringAudioClips: [],
@@ -242,7 +268,7 @@ test('readElectionPackageFromFile loads UI string audio IDs', async () => {
     },
   };
 
-  const pkg = await zipFile({
+  const pkg = await electionPackageZip({
     [ElectionPackageFileName.ELECTION]: electionData,
     [ElectionPackageFileName.AUDIO_IDS]: JSON.stringify(audioIds),
   });
@@ -262,6 +288,7 @@ test('readElectionPackageFromFile loads UI string audio IDs', async () => {
   ).toEqual<ElectionPackageWithFileContents>({
     electionPackage: {
       electionDefinition,
+      metadata: LATEST_METADATA,
       systemSettings: DEFAULT_SYSTEM_SETTINGS,
       uiStrings: electionDefinition.election.ballotStrings,
       uiStringAudioIds: expectedAudioIds,
@@ -283,7 +310,7 @@ test('readElectionPackageFromFile loads UI string audio clips', async () => {
     { dataBase64: 'DDEF==', id: 'd1e2f3', languageCode: 'es-US' },
   ];
 
-  const pkg = await zipFile({
+  const pkg = await electionPackageZip({
     [ElectionPackageFileName.ELECTION]: electionData,
     [ElectionPackageFileName.AUDIO_CLIPS]: audioClips
       .map((clip) => JSON.stringify(clip))
@@ -296,6 +323,8 @@ test('readElectionPackageFromFile loads UI string audio clips', async () => {
   ).toEqual<ElectionPackageWithFileContents>({
     electionPackage: {
       electionDefinition,
+      metadata: LATEST_METADATA,
+      uiStringAudioIds: {},
       systemSettings: DEFAULT_SYSTEM_SETTINGS,
       uiStrings: electionDefinition.election.ballotStrings,
       uiStringAudioClips: audioClips,
@@ -328,7 +357,7 @@ test('readElectionPackageFromFile loads base64-encoded ballots', async () => {
     },
   ];
 
-  const pkg = await zipFile({
+  const pkg = await electionPackageZip({
     [ElectionPackageFileName.ELECTION]: electionData,
     [ElectionPackageFileName.BALLOTS]: ballots
       .map((ballot) => JSON.stringify(ballot))
@@ -341,6 +370,8 @@ test('readElectionPackageFromFile loads base64-encoded ballots', async () => {
   ).toEqual<ElectionPackageWithFileContents>({
     electionPackage: {
       electionDefinition,
+      metadata: LATEST_METADATA,
+      uiStringAudioIds: {},
       systemSettings: DEFAULT_SYSTEM_SETTINGS,
       uiStrings: electionDefinition.election.ballotStrings,
       uiStringAudioClips: [],
@@ -357,7 +388,7 @@ test('readElectionPackageFromFile reads metadata', async () => {
   const { electionData } = electionDefinition;
   const metadata: ElectionPackageMetadata = LATEST_METADATA;
 
-  const pkg = await zipFile({
+  const pkg = await electionPackageZip({
     [ElectionPackageFileName.ELECTION]: electionData,
     [ElectionPackageFileName.METADATA]: JSON.stringify(metadata),
   });
@@ -370,6 +401,7 @@ test('readElectionPackageFromFile reads metadata', async () => {
       electionDefinition,
       metadata,
       systemSettings: DEFAULT_SYSTEM_SETTINGS,
+      uiStringAudioIds: {},
       uiStringAudioClips: [],
       uiStrings: electionDefinition.election.ballotStrings,
       ballots: [],
@@ -380,7 +412,7 @@ test('readElectionPackageFromFile reads metadata', async () => {
 });
 
 test('readElectionPackageFromFile errors when an election.json is not present', async () => {
-  const pkg = await zipFile({});
+  const pkg = await electionPackageZip({});
   const file = makeTemporaryFile({ content: pkg });
   expect(await readElectionPackageFromFile(file)).toEqual(
     err({
@@ -403,7 +435,7 @@ test('readElectionPackageFromFile errors throws when given an invalid zip file',
 });
 
 test('readElectionPackageFromFile errors when given an invalid election', async () => {
-  const pkg = await zipFile({
+  const pkg = await electionPackageZip({
     [ElectionPackageFileName.ELECTION]: 'not a valid election',
   });
   const file = makeTemporaryFile({ content: pkg });
@@ -417,7 +449,7 @@ test('readElectionPackageFromFile errors when given an invalid election', async 
 });
 
 test('readElectionPackageFromFile errors when given invalid system settings', async () => {
-  const pkg = await zipFile({
+  const pkg = await electionPackageZip({
     [ElectionPackageFileName.ELECTION]:
       electionGridLayoutNewHampshireTestBallotFixtures.electionJson.asText(),
     [ElectionPackageFileName.SYSTEM_SETTINGS]: 'not a valid system settings',
@@ -433,7 +465,7 @@ test('readElectionPackageFromFile errors when given invalid system settings', as
 });
 
 test('readElectionPackageFromFile errors when given invalid metadata', async () => {
-  const pkg = await zipFile({
+  const pkg = await electionPackageZip({
     [ElectionPackageFileName.ELECTION]:
       electionGridLayoutNewHampshireTestBallotFixtures.electionJson.asText(),
     [ElectionPackageFileName.METADATA]: 'asdf',
@@ -447,6 +479,35 @@ test('readElectionPackageFromFile errors when given invalid metadata', async () 
     })
   );
 });
+
+test.each([
+  ElectionPackageFileName.METADATA,
+  ElectionPackageFileName.SYSTEM_SETTINGS,
+  ElectionPackageFileName.APP_STRINGS,
+])(
+  'readElectionPackageFromFile errors when %s is missing',
+  async (missingFile) => {
+    const electionDefinition =
+      electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
+    const allFiles: Record<string, string> = {
+      [ElectionPackageFileName.ELECTION]: electionDefinition.electionData,
+      [ElectionPackageFileName.METADATA]: JSON.stringify(LATEST_METADATA),
+      [ElectionPackageFileName.SYSTEM_SETTINGS]: JSON.stringify(
+        DEFAULT_SYSTEM_SETTINGS
+      ),
+      [ElectionPackageFileName.APP_STRINGS]: JSON.stringify({}),
+    };
+    delete allFiles[missingFile];
+    const file = makeTemporaryFile({ content: await zipFile(allFiles) });
+
+    expect(await readElectionPackageFromFile(file)).toEqual(
+      err({
+        type: 'invalid-zip',
+        message: expect.stringContaining(missingFile),
+      })
+    );
+  }
+);
 
 test('readSignedElectionPackageFromDirectory can read an election package from a directory', async () => {
   const electionDefinition =
@@ -888,7 +949,7 @@ test.each<{
   async (testConfig) => {
     const electionDefinition =
       electionTwoPartyPrimaryFixtures.readElectionDefinition();
-    const electionPackageContents = await zipFile({
+    const electionPackageContents = await electionPackageZip({
       [ElectionPackageFileName.ELECTION]: electionDefinition.electionData,
       [ElectionPackageFileName.SYSTEM_SETTINGS]: JSON.stringify(
         typedAs<SystemSettings>(testConfig.systemSettings)

--- a/libs/backend/src/election_package/election_package_io.ts
+++ b/libs/backend/src/election_package/election_package_io.ts
@@ -29,7 +29,6 @@ import {
   ElectionPackageConfigurationError,
   DippedSmartCardAuth,
   InsertedSmartCardAuth,
-  DEFAULT_SYSTEM_SETTINGS,
   ElectionPackageFileName,
   UiStringAudioClip,
   UiStringAudioClipSchema,
@@ -37,7 +36,6 @@ import {
   UiStringsPackageSchema,
   safeParseJson,
   safeParseSystemSettings,
-  ElectionPackageMetadata,
   ElectionPackageMetadataSchema,
   mergeUiStrings,
   UiStringAudioIdsPackage,
@@ -96,37 +94,31 @@ export async function readElectionPackageFromBuffer(
 
     // Metadata:
 
-    let metadata: ElectionPackageMetadata | undefined;
-    const metadataEntry = maybeGetFileByName(
+    const metadataEntry = getFileByName(
       entries,
-      ElectionPackageFileName.METADATA
+      ElectionPackageFileName.METADATA,
+      zipName
     );
-    if (metadataEntry) {
-      const metadataText = await readTextEntry(metadataEntry);
-      const metadataResult = safeParseJson(
-        metadataText,
-        ElectionPackageMetadataSchema
-      );
-      if (metadataResult.isErr()) {
-        return err({
-          type: 'invalid-metadata',
-          message: metadataResult.err().message,
-        });
-      }
-      metadata = metadataResult.ok();
+    const metadataResult = safeParseJson(
+      await readTextEntry(metadataEntry),
+      ElectionPackageMetadataSchema
+    );
+    if (metadataResult.isErr()) {
+      return err({
+        type: 'invalid-metadata',
+        message: metadataResult.err().message,
+      });
     }
+    const metadata = metadataResult.ok();
 
     // System Settings:
 
-    let systemSettingsData = JSON.stringify(DEFAULT_SYSTEM_SETTINGS);
-
-    const systemSettingsEntry = maybeGetFileByName(
+    const systemSettingsEntry = getFileByName(
       entries,
-      ElectionPackageFileName.SYSTEM_SETTINGS
+      ElectionPackageFileName.SYSTEM_SETTINGS,
+      zipName
     );
-    if (systemSettingsEntry) {
-      systemSettingsData = await readTextEntry(systemSettingsEntry);
-    }
+    const systemSettingsData = await readTextEntry(systemSettingsEntry);
     const systemSettingsResult = safeParseSystemSettings(systemSettingsData);
     if (systemSettingsResult.isErr()) {
       return err({
@@ -150,25 +142,28 @@ export async function readElectionPackageFromBuffer(
 
     // UI Strings:
 
-    const appStringsEntry = maybeGetFileByName(
+    const appStringsEntry = getFileByName(
       entries,
-      ElectionPackageFileName.APP_STRINGS
+      ElectionPackageFileName.APP_STRINGS,
+      zipName
     );
-    const appStrings =
-      appStringsEntry &&
-      safeParseJson(
-        await readTextEntry(appStringsEntry),
-        UiStringsPackageSchema
-      ).unsafeUnwrap();
+    const appStrings = safeParseJson(
+      await readTextEntry(appStringsEntry),
+      UiStringsPackageSchema
+    ).unsafeUnwrap();
 
     const uiStrings = mergeUiStrings(
-      appStrings ?? {},
+      appStrings,
       electionDefinition.election.ballotStrings
     );
 
     // UI String Audio IDs:
+    //
+    // Audio files are optional: VxDesign omits audioIds.json and
+    // audioClips.jsonl when audio isn't included in an export, so packages in
+    // the field may not have them. Default to empty when absent.
 
-    let uiStringAudioIds: UiStringAudioIdsPackage | undefined;
+    let uiStringAudioIds: UiStringAudioIdsPackage = {};
     const audioIdsEntry = maybeGetFileByName(
       entries,
       ElectionPackageFileName.AUDIO_IDS
@@ -191,8 +186,9 @@ export async function readElectionPackageFromBuffer(
       const audioClipsFileLines = readline.createInterface(
         getEntryStream(audioClipsEntry)
       );
-
       for await (const line of audioClipsFileLines) {
+        // Skip blank lines (an empty audioClips.jsonl has no clips).
+        if (line.trim().length === 0) continue;
         uiStringAudioClips.push(
           safeParseJson(line, UiStringAudioClipSchema).unsafeUnwrap()
         );

--- a/libs/backend/src/election_package/test_utils.ts
+++ b/libs/backend/src/election_package/test_utils.ts
@@ -1,5 +1,10 @@
 // istanbul ignore file - test helpers
-import { ElectionPackage, ElectionPackageFileName } from '@votingworks/types';
+import {
+  DEFAULT_SYSTEM_SETTINGS,
+  ElectionPackage,
+  ElectionPackageFileName,
+  LATEST_METADATA,
+} from '@votingworks/types';
 import { Buffer } from 'node:buffer';
 import {
   ELECTION_PACKAGE_FOLDER,
@@ -9,32 +14,45 @@ import { MockFileTree } from '@votingworks/usb-drive';
 import { zipFile } from '@votingworks/test-utils';
 
 /**
+ * An election package for building test fixtures, where only the election
+ * definition is required and any subset of the other files may be provided.
+ * Used to build packages with arbitrary file combinations, including ones
+ * intentionally missing files to exercise reader error paths.
+ */
+export type PartialElectionPackage = Partial<ElectionPackage> &
+  Pick<ElectionPackage, 'electionDefinition'>;
+
+/**
  * Builds an election package zip archive from a ElectionPackage object.
  */
 export function createElectionPackageZipArchive(
-  electionPackage: ElectionPackage
+  electionPackage: PartialElectionPackage
 ): Promise<Buffer> {
+  // metadata.json, systemSettings.json, and appStrings.json are required in a
+  // real package, so default any that aren't provided to produce a valid
+  // package. Audio files are optional and handled below.
   const zipContents: Record<string, Buffer | string> = {
     [ElectionPackageFileName.ELECTION]:
       electionPackage.electionDefinition.electionData,
+    [ElectionPackageFileName.METADATA]: JSON.stringify(
+      electionPackage.metadata ?? LATEST_METADATA,
+      null,
+      2
+    ),
+    [ElectionPackageFileName.SYSTEM_SETTINGS]: JSON.stringify(
+      electionPackage.systemSettings ?? DEFAULT_SYSTEM_SETTINGS,
+      null,
+      2
+    ),
+    [ElectionPackageFileName.APP_STRINGS]: JSON.stringify(
+      electionPackage.uiStrings ?? {},
+      null,
+      2
+    ),
   };
 
-  if (electionPackage.systemSettings) {
-    zipContents[ElectionPackageFileName.SYSTEM_SETTINGS] = JSON.stringify(
-      electionPackage.systemSettings,
-      null,
-      2
-    );
-  }
-
-  if (electionPackage.uiStrings) {
-    zipContents[ElectionPackageFileName.APP_STRINGS] = JSON.stringify(
-      electionPackage.uiStrings,
-      null,
-      2
-    );
-  }
-
+  // Audio files are optional in an election package, so only include them when
+  // provided.
   if (electionPackage.uiStringAudioIds) {
     zipContents[ElectionPackageFileName.AUDIO_IDS] = JSON.stringify(
       electionPackage.uiStringAudioIds,
@@ -42,7 +60,6 @@ export function createElectionPackageZipArchive(
       2
     );
   }
-
   if (electionPackage.uiStringAudioClips) {
     zipContents[ElectionPackageFileName.AUDIO_CLIPS] =
       electionPackage.uiStringAudioClips
@@ -64,7 +81,7 @@ export function createElectionPackageZipArchive(
  * saved to it.
  */
 export async function mockElectionPackageFileTree(
-  electionPackage: ElectionPackage
+  electionPackage: PartialElectionPackage
 ): Promise<MockFileTree> {
   const { election, ballotHash } = electionPackage.electionDefinition;
   return {

--- a/libs/backend/src/ui_strings/ui_strings_machine_configuration_test_runner.ts
+++ b/libs/backend/src/ui_strings/ui_strings_machine_configuration_test_runner.ts
@@ -42,7 +42,10 @@ export function runUiStringMachineConfigurationTests(
   } = context;
   const expectedElectionStrings = electionDefinition.election.ballotStrings;
 
-  async function doTestConfigure(usbElectionPackage: ElectionPackage) {
+  async function doTestConfigure(
+    usbElectionPackage: Partial<ElectionPackage> &
+      Pick<ElectionPackage, 'electionDefinition'>
+  ) {
     getMockUsbDrive().insertUsbDrive(
       await mockElectionPackageFileTree(usbElectionPackage)
     );

--- a/libs/backend/src/ui_strings/ui_strings_machine_configuration_test_runner.ts
+++ b/libs/backend/src/ui_strings/ui_strings_machine_configuration_test_runner.ts
@@ -3,7 +3,6 @@
 import type * as vitest from 'vitest';
 import {
   ElectionDefinition,
-  ElectionPackage,
   UiStringAudioClips,
   UiStringAudioIdsPackage,
   UiStringsPackage,
@@ -11,7 +10,10 @@ import {
 import { MockUsbDrive } from '@votingworks/usb-drive';
 import { Result, assertDefined } from '@votingworks/basics';
 import { UiStringsStore } from './ui_strings_store';
-import { mockElectionPackageFileTree } from '../election_package/test_utils';
+import {
+  mockElectionPackageFileTree,
+  PartialElectionPackage,
+} from '../election_package/test_utils';
 
 type MockUsbDriveLike = Pick<MockUsbDrive, 'insertUsbDrive'>;
 
@@ -42,10 +44,7 @@ export function runUiStringMachineConfigurationTests(
   } = context;
   const expectedElectionStrings = electionDefinition.election.ballotStrings;
 
-  async function doTestConfigure(
-    usbElectionPackage: Partial<ElectionPackage> &
-      Pick<ElectionPackage, 'electionDefinition'>
-  ) {
+  async function doTestConfigure(usbElectionPackage: PartialElectionPackage) {
     getMockUsbDrive().insertUsbDrive(
       await mockElectionPackageFileTree(usbElectionPackage)
     );

--- a/libs/fixtures/src/builders.ts
+++ b/libs/fixtures/src/builders.ts
@@ -4,6 +4,7 @@ import {
   ElectionDefinition,
   ElectionPackage,
   ImageData,
+  LATEST_METADATA,
   safeParseElection,
   safeParseElectionDefinition,
   SystemSettings,
@@ -160,12 +161,19 @@ export function election(path: string): ElectionFixture {
     readElection: () => safeParseElection(inner.asText()).unsafeUnwrap(),
     readElectionDefinition: () =>
       safeParseElectionDefinition(inner.asText()).unsafeUnwrap(),
-    toElectionPackage: (systemSettings = DEFAULT_SYSTEM_SETTINGS) => ({
-      electionDefinition: safeParseElectionDefinition(
+    toElectionPackage: (systemSettings = DEFAULT_SYSTEM_SETTINGS) => {
+      const electionDefinition = safeParseElectionDefinition(
         inner.asText()
-      ).unsafeUnwrap(),
-      systemSettings,
-    }),
+      ).unsafeUnwrap();
+      return {
+        electionDefinition,
+        metadata: LATEST_METADATA,
+        systemSettings,
+        uiStrings: electionDefinition.election.ballotStrings,
+        uiStringAudioClips: [],
+        uiStringAudioIds: {},
+      };
+    },
   };
 }
 

--- a/libs/types/src/election_package.ts
+++ b/libs/types/src/election_package.ts
@@ -30,12 +30,12 @@ export enum ElectionPackageFileName {
 export interface ElectionPackage {
   ballots?: EncodedBallotEntry[];
   electionDefinition: ElectionDefinition;
-  metadata?: ElectionPackageMetadata; // TODO(kofi): Make required
+  metadata: ElectionPackageMetadata;
   registeredVoterCounts?: ElectionRegisteredVotersCounts;
-  systemSettings?: SystemSettings; // TODO(kevin): Make required
-  uiStringAudioClips?: UiStringAudioClips; // TODO(kofi): Make required
-  uiStringAudioIds?: UiStringAudioIdsPackage; // TODO(kofi): Make required
-  uiStrings?: UiStringsPackage; // TODO(kofi): Make required
+  systemSettings: SystemSettings;
+  uiStringAudioClips: UiStringAudioClips;
+  uiStringAudioIds: UiStringAudioIdsPackage;
+  uiStrings: UiStringsPackage;
 }
 
 export interface ElectionPackageWithHash {


### PR DESCRIPTION
## Overview
Updates the ElectionPackage type so that the previously optional fields are now required and enforces that the files when reading the zip package corresponding to those types are required. The audio files are currently NOT written in the election package from VxDesign if the include audio box is not checked so I did NOT make those files required in the zip package reading. However it was simple enough to set defaults and make the type still required. 

## Demo Video or Screenshot
N/A

## Testing Plan
CI

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
