### PR TITLE
VxDesign: MI ballot template: Don't crash on candidate contests with no candidates

### DIFF
--- a/libs/hmpb/src/ballot_templates/mi_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/mi_ballot_template.tsx
@@ -629,7 +629,7 @@ function buildContestSections(
       case 'closed-primary':
         return contest.partyId;
       case 'general':
-        return (contest.candidates[0].partyIds ?? []).length > 0;
+        return (contest.candidates[0]?.partyIds ?? []).length > 0;
       default:
         /* istanbul ignore next */
         throwIllegalValue(election.type);


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->
Resolves Sentry error. Handles the case where a candidate contest has an empty candidate list when trying to infer whether a contest is a partisan or nonpartisan contest.

Note that this does mean that a contest with no candidates will automatically be categorized in the nonpartisan section, which is not necessarily correct, so we may need to have a different way to create the contest sections, but I don't think it's worth figuring out until we know how we're importing MI elections.

## Demo Video or Screenshot
N/A
## Testing Plan
Manual test

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
