### PR TITLE
Tabulate straight party contests

### DIFF
--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -380,11 +380,18 @@ function convertTabulationResultsToFormResults(
   savedResults?: Tabulation.ManualElectionResults
 ): FormManualResults {
   const contestResults = Object.fromEntries(
-    contests.map((contest) => [
-      contest.id,
-      savedResults?.contestResults[contest.id] ??
-        emptyFormContestResults(contest, savedResults?.ballotCount),
-    ])
+    contests.map((contest): [ContestId, FormContestResults] => {
+      const savedContestResults = savedResults?.contestResults[contest.id];
+      assert(
+        savedContestResults?.contestType !== 'straight-party',
+        'Straight party contests are not yet supported for manual tallies'
+      );
+      return [
+        contest.id,
+        savedContestResults ??
+          emptyFormContestResults(contest, savedResults?.ballotCount),
+      ];
+    })
   );
   return { contestResults, ballotCount: savedResults?.ballotCount ?? '' };
 }

--- a/libs/types/src/tabulation.ts
+++ b/libs/types/src/tabulation.ts
@@ -41,11 +41,19 @@ export type CandidateContestResults = ContestResultsBase & {
   readonly tallies: Record<CandidateId, CandidateTally>;
 };
 
+export type StraightPartyContestResults = ContestResultsBase & {
+  readonly contestType: 'straight-party';
+  readonly tallies: Record<PartyId, number>;
+};
+
 /**
  * Represents the results of a single contest in an election, often filtered by
  * some cast vote record attributes.
  */
-export type ContestResults = YesNoContestResults | CandidateContestResults;
+export type ContestResults =
+  | YesNoContestResults
+  | CandidateContestResults
+  | StraightPartyContestResults;
 
 export type VotingMethod = `${BallotType}` | 'early_voting';
 export const SUPPORTED_VOTING_METHODS: VotingMethod[] = [

--- a/libs/utils/src/tabulation/index.ts
+++ b/libs/utils/src/tabulation/index.ts
@@ -5,6 +5,7 @@ export * from './compressed_tallies';
 export * as CachedElectionLookups from './lookups';
 export * from './mock_tally_report_results';
 export * from './open_primary';
+export * from './straight_party';
 export * from './tabulation';
 export * from './tally_reports';
 export * from './transformations';

--- a/libs/utils/src/tabulation/straight_party.test.ts
+++ b/libs/utils/src/tabulation/straight_party.test.ts
@@ -1,0 +1,450 @@
+import { describe, expect, test } from 'vitest';
+import {
+  Candidate,
+  CandidateContest,
+  Contest,
+  Election,
+  StraightPartyContest,
+  YesNoContest,
+} from '@votingworks/types';
+import { assertDefined } from '@votingworks/basics';
+import { electionStraightPartyFixtures } from '@votingworks/fixtures';
+import { deriveStraightPartyVotes } from './straight_party';
+
+// These tests encode the Michigan straight-party tabulation rules from Michigan
+// Administrative Rule R 168.773, Rule 3(6) using the examples provided in that
+// document.
+
+const baseElection = electionStraightPartyFixtures.readElection();
+const { id: districtId } = assertDefined(baseElection.districts[0]);
+
+function candidate(id: string, partyId: string): Candidate {
+  return { id, name: id, partyIds: [partyId] };
+}
+
+const straightPartyContest: StraightPartyContest = {
+  id: 'straight-party',
+  type: 'straight-party',
+  districtId,
+  title: 'Straight Party Ticket',
+  optionIds: ['party-1', 'party-2', 'party-3', 'party-4', 'party-5', 'party-6'],
+};
+
+function candidateContest(
+  id: string,
+  seats: number,
+  candidates: Candidate[]
+): CandidateContest {
+  return {
+    id,
+    type: 'candidate',
+    districtId,
+    title: id,
+    seats,
+    candidates,
+    allowWriteIns: true,
+  };
+}
+
+function buildElection(contests: Contest[]): Election {
+  return { ...baseElection, contests };
+}
+
+describe('vote-for-1 partisan offices (MI examples 3-9)', () => {
+  const election = buildElection([
+    straightPartyContest,
+    candidateContest('senator', 1, [
+      candidate('candidate-a', 'party-1'),
+      candidate('candidate-b', 'party-2'),
+      candidate('candidate-c', 'party-3'),
+      candidate('candidate-d', 'party-4'),
+      candidate('candidate-e', 'party-5'),
+    ]),
+    candidateContest('representative', 1, [
+      candidate('candidate-f', 'party-1'),
+      candidate('candidate-g', 'party-2'),
+      candidate('candidate-h', 'party-3'),
+    ]),
+  ]);
+
+  test('example 3: straight party, no individual votes', () => {
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-2'],
+        senator: [],
+        representative: [],
+      })
+    ).toEqual({
+      'straight-party': ['party-2'],
+      senator: ['candidate-b'],
+      representative: ['candidate-g'],
+    });
+  });
+
+  test('example 4: overvoted straight party, no individual votes', () => {
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-2', 'party-3'],
+        senator: [],
+        representative: [],
+      })
+    ).toEqual({
+      'straight-party': ['party-2', 'party-3'],
+      senator: [],
+      representative: [],
+    });
+  });
+
+  test('example 5: straight party plus individual votes for that party', () => {
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-2'],
+        senator: ['candidate-b'],
+        representative: ['candidate-g'],
+      })
+    ).toEqual({
+      'straight-party': ['party-2'],
+      senator: ['candidate-b'],
+      representative: ['candidate-g'],
+    });
+  });
+
+  test('example 6: crossover vote fills the office, party vote fills the rest', () => {
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-1'],
+        senator: ['candidate-b'],
+        representative: [],
+      })
+    ).toEqual({
+      'straight-party': ['party-1'],
+      senator: ['candidate-b'],
+      representative: ['candidate-f'],
+    });
+  });
+
+  test('example 7: overvoted straight party, individual votes kept', () => {
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-1', 'party-3'],
+        senator: ['candidate-a'],
+        representative: ['candidate-g'],
+      })
+    ).toEqual({
+      'straight-party': ['party-1', 'party-3'],
+      senator: ['candidate-a'],
+      representative: ['candidate-g'],
+    });
+  });
+
+  test('example 8: overvoted straight party and overvoted offices', () => {
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-1', 'party-2'],
+        senator: ['candidate-a', 'candidate-b'],
+        representative: ['candidate-f', 'candidate-g'],
+      })
+    ).toEqual({
+      'straight-party': ['party-1', 'party-2'],
+      senator: ['candidate-a', 'candidate-b'],
+      representative: ['candidate-f', 'candidate-g'],
+    });
+  });
+
+  test('example 9: overvoted straight party, one office overvoted, one explicit', () => {
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-2', 'party-3'],
+        senator: ['candidate-b', 'candidate-c'],
+        representative: ['candidate-h'],
+      })
+    ).toEqual({
+      'straight-party': ['party-2', 'party-3'],
+      senator: ['candidate-b', 'candidate-c'],
+      representative: ['candidate-h'],
+    });
+  });
+});
+
+describe('two vote-for-2 partisan offices (MI examples 10-12)', () => {
+  const election = buildElection([
+    straightPartyContest,
+    candidateContest('state-board', 2, [
+      candidate('candidate-a', 'party-1'),
+      candidate('candidate-b', 'party-1'),
+      candidate('candidate-c', 'party-2'),
+      candidate('candidate-d', 'party-2'),
+      candidate('candidate-e', 'party-3'),
+    ]),
+    candidateContest('regent', 2, [
+      candidate('candidate-f', 'party-1'),
+      candidate('candidate-g', 'party-1'),
+      candidate('candidate-h', 'party-2'),
+      candidate('candidate-i', 'party-2'),
+      candidate('candidate-j', 'party-3'),
+    ]),
+  ]);
+
+  test('example 10: blank office derives both party candidates; full office unchanged', () => {
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-1'],
+        'state-board': [],
+        regent: ['candidate-h', 'candidate-i'],
+      })
+    ).toEqual({
+      'straight-party': ['party-1'],
+      'state-board': ['candidate-a', 'candidate-b'],
+      regent: ['candidate-h', 'candidate-i'],
+    });
+  });
+
+  test('example 11: both offices full with explicit votes', () => {
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-1'],
+        'state-board': ['candidate-d', 'candidate-e'],
+        regent: [],
+      })
+    ).toEqual({
+      'straight-party': ['party-1'],
+      'state-board': ['candidate-d', 'candidate-e'],
+      regent: ['candidate-f', 'candidate-g'],
+    });
+  });
+
+  test('example 12: both offices full with cross-party votes', () => {
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-1'],
+        'state-board': ['candidate-c', 'candidate-d'],
+        regent: ['candidate-i', 'candidate-j'],
+      })
+    ).toEqual({
+      'straight-party': ['party-1'],
+      'state-board': ['candidate-c', 'candidate-d'],
+      regent: ['candidate-i', 'candidate-j'],
+    });
+  });
+});
+
+describe('single vote-for-2 partisan office (MI examples 13-19)', () => {
+  const election = buildElection([
+    straightPartyContest,
+    candidateContest('state-board', 2, [
+      candidate('candidate-a', 'party-1'),
+      candidate('candidate-b', 'party-1'),
+      candidate('candidate-c', 'party-2'),
+      candidate('candidate-d', 'party-2'),
+      candidate('candidate-e', 'party-3'),
+    ]),
+  ]);
+
+  test('example 13: party has 2 candidates, 1 seat left — ambiguous', () => {
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-1'],
+        'state-board': ['candidate-c'],
+      })
+    ).toEqual({
+      'straight-party': ['party-1'],
+      'state-board': ['candidate-c'],
+    });
+  });
+
+  test('example 14: one party candidate marked, one party candidate left', () => {
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-1'],
+        'state-board': ['candidate-b'],
+      })
+    ).toEqual({
+      'straight-party': ['party-1'],
+      'state-board': ['candidate-b', 'candidate-a'],
+    });
+  });
+
+  test('example 15: office full with mixed votes', () => {
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-1'],
+        'state-board': ['candidate-b', 'candidate-c'],
+      })
+    ).toEqual({
+      'straight-party': ['party-1'],
+      'state-board': ['candidate-b', 'candidate-c'],
+    });
+  });
+
+  test('example 16: party has 2 candidates, 1 seat left after crossover', () => {
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-1'],
+        'state-board': ['candidate-e'],
+      })
+    ).toEqual({
+      'straight-party': ['party-1'],
+      'state-board': ['candidate-e'],
+    });
+  });
+
+  test('example 17: party has only 1 candidate for a vote-for-2 office', () => {
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-3'],
+        'state-board': [],
+      })
+    ).toEqual({
+      'straight-party': ['party-3'],
+      'state-board': ['candidate-e'],
+    });
+  });
+
+  test('example 18: crossover vote plus single party candidate', () => {
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-3'],
+        'state-board': ['candidate-b'],
+      })
+    ).toEqual({
+      'straight-party': ['party-3'],
+      'state-board': ['candidate-b', 'candidate-e'],
+    });
+  });
+
+  test('example 19: party vote plus one party candidate marked (not an overvote)', () => {
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-2'],
+        'state-board': ['candidate-c'],
+      })
+    ).toEqual({
+      'straight-party': ['party-2'],
+      'state-board': ['candidate-c', 'candidate-d'],
+    });
+  });
+});
+
+describe('other cases not covered by examples', () => {
+  const voteFor1Election = buildElection([
+    straightPartyContest,
+    candidateContest('senator', 1, [
+      candidate('candidate-a', 'party-1'),
+      candidate('candidate-b', 'party-2'),
+    ]),
+    candidateContest('representative', 1, [
+      candidate('candidate-f', 'party-1'),
+      candidate('candidate-g', 'party-2'),
+    ]),
+  ]);
+
+  const stateBoardElection = buildElection([
+    straightPartyContest,
+    candidateContest('state-board', 2, [
+      candidate('candidate-a', 'party-1'),
+      candidate('candidate-b', 'party-1'),
+      candidate('candidate-e', 'party-3'),
+    ]),
+  ]);
+
+  test('no straight-party contest in the election — votes returned unchanged', () => {
+    const election = buildElection([
+      candidateContest('senator', 1, [
+        candidate('candidate-a', 'party-1'),
+        candidate('candidate-b', 'party-2'),
+      ]),
+    ]);
+    expect(deriveStraightPartyVotes(election, { senator: [] })).toEqual({
+      senator: [],
+    });
+  });
+
+  test('no straight-party selection — tabulate offices as marked', () => {
+    expect(
+      deriveStraightPartyVotes(voteFor1Election, {
+        'straight-party': [],
+        senator: [],
+        representative: ['candidate-g'],
+      })
+    ).toEqual({
+      'straight-party': [],
+      senator: [],
+      representative: ['candidate-g'],
+    });
+  });
+
+  test('selected party has no candidates anywhere — nothing derived', () => {
+    expect(
+      deriveStraightPartyVotes(voteFor1Election, {
+        'straight-party': ['party-6'],
+        senator: [],
+        representative: [],
+      })
+    ).toEqual({
+      'straight-party': ['party-6'],
+      senator: [],
+      representative: [],
+    });
+  });
+
+  test('a write-in occupies a seat, leaving the party derivation ambiguous', () => {
+    expect(
+      deriveStraightPartyVotes(stateBoardElection, {
+        'straight-party': ['party-1'],
+        'state-board': ['write-in-0'],
+      })
+    ).toEqual({
+      'straight-party': ['party-1'],
+      'state-board': ['write-in-0'],
+    });
+  });
+
+  test('a write-in occupies a seat, a single fitting party candidate is still derived', () => {
+    expect(
+      deriveStraightPartyVotes(stateBoardElection, {
+        'straight-party': ['party-3'],
+        'state-board': ['write-in-0'],
+      })
+    ).toEqual({
+      'straight-party': ['party-3'],
+      'state-board': ['write-in-0', 'candidate-e'],
+    });
+  });
+
+  test('non-partisan candidate contests and ballot measures are untouched', () => {
+    const yesNoContest: YesNoContest = {
+      id: 'measure',
+      type: 'yesno',
+      districtId,
+      title: 'Measure',
+      description: 'A ballot measure',
+      yesOption: { id: 'measure-yes', label: 'Yes' },
+      noOption: { id: 'measure-no', label: 'No' },
+    };
+    const election = buildElection([
+      straightPartyContest,
+      candidateContest('senator', 1, [
+        candidate('candidate-a', 'party-1'),
+        candidate('candidate-b', 'party-2'),
+      ]),
+      candidateContest('judge', 1, [
+        { id: 'candidate-judge', name: 'A Judge' },
+      ]),
+      yesNoContest,
+    ]);
+
+    expect(
+      deriveStraightPartyVotes(election, {
+        'straight-party': ['party-1'],
+        senator: [],
+        judge: [],
+        measure: ['measure-yes'],
+      })
+    ).toEqual({
+      'straight-party': ['party-1'],
+      senator: ['candidate-a'],
+      judge: [],
+      measure: ['measure-yes'],
+    });
+  });
+});

--- a/libs/utils/src/tabulation/straight_party.ts
+++ b/libs/utils/src/tabulation/straight_party.ts
@@ -1,5 +1,5 @@
 import { Election, Tabulation } from '@votingworks/types';
-import { assertDefined, mapObject } from '@votingworks/basics';
+import { assert, assertDefined, mapObject } from '@votingworks/basics';
 
 export function deriveStraightPartyVotes(
   election: Election,
@@ -11,6 +11,7 @@ export function deriveStraightPartyVotes(
   if (!straightPartyContest) {
     return votes;
   }
+  assert(election.type === 'general');
 
   const straightPartyVotes = assertDefined(votes[straightPartyContest.id]);
   if (straightPartyVotes.length !== 1) {

--- a/libs/utils/src/tabulation/straight_party.ts
+++ b/libs/utils/src/tabulation/straight_party.ts
@@ -1,0 +1,41 @@
+import { Election, Tabulation } from '@votingworks/types';
+import { assertDefined, mapObject } from '@votingworks/basics';
+
+export function deriveStraightPartyVotes(
+  election: Election,
+  votes: Tabulation.Votes
+): Tabulation.Votes {
+  const straightPartyContest = election.contests.find(
+    (contest) => contest.type === 'straight-party'
+  );
+  if (!straightPartyContest) {
+    return votes;
+  }
+
+  const straightPartyVotes = assertDefined(votes[straightPartyContest.id]);
+  if (straightPartyVotes.length !== 1) {
+    return votes;
+  }
+  const selectedStraightPartyId = assertDefined(straightPartyVotes[0]);
+
+  const contestsById = Object.fromEntries(
+    election.contests.map((contest) => [contest.id, contest])
+  );
+
+  return mapObject(votes, (optionIds, contestId) => {
+    const contest = assertDefined(contestsById[contestId]);
+    if (contest.type !== 'candidate') return optionIds;
+    const remainingSeats = contest.seats - optionIds.length;
+    const unselectedStraightPartyCandidateIds = contest.candidates
+      .filter(
+        (candidate) =>
+          candidate.partyIds?.includes(selectedStraightPartyId) &&
+          !optionIds.includes(candidate.id)
+      )
+      .map((candidate) => candidate.id);
+    if (remainingSeats >= unselectedStraightPartyCandidateIds.length) {
+      return [...optionIds, ...unselectedStraightPartyCandidateIds];
+    }
+    return optionIds;
+  });
+}

--- a/libs/utils/src/tabulation/tabulation.test.ts
+++ b/libs/utils/src/tabulation/tabulation.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, test } from 'vitest';
 import {
   electionFamousNames2021Fixtures,
+  electionStraightPartyFixtures,
   electionTwoPartyPrimaryFixtures,
   electionWithMsEitherNeitherFixtures,
   readElectionOpenPrimary,
@@ -1319,6 +1320,63 @@ describe('tabulateCastVoteRecords', () => {
   });
 });
 
+test('tabulateCastVoteRecords with a straight-party contest', async () => {
+  const election = electionStraightPartyFixtures.readElection();
+  const metadata = {
+    ballotStyleGroupId: '12' as BallotStyleGroupId,
+    precinctId: '23',
+    votingMethod: BallotType.Precinct,
+    batchId: 'batch-1',
+    scannerId: 'scanner-1',
+  } as const;
+
+  const allVotes: Tabulation.Votes[] = [
+    { 'straight-party-ticket': ['0'], president: [] },
+    { 'straight-party-ticket': ['0'], president: [] },
+    { 'straight-party-ticket': ['1'], president: [] },
+    { 'straight-party-ticket': [] }, // undervote
+    { 'straight-party-ticket': ['0', '1'] }, // overvote
+  ];
+  const results = await tabulateCastVoteRecords({
+    election,
+    cvrs: allVotes.map((votes) => ({
+      card: { type: 'bmd' },
+      votes,
+      ...metadata,
+    })),
+  });
+  const result = assertDefined(results[GROUP_KEY]);
+
+  // The straight-party contest itself is tallied as a vote-for-1 contest.
+  expect(
+    result.contestResults['straight-party-ticket']
+  ).toEqual<Tabulation.StraightPartyContestResults>({
+    contestId: 'straight-party-ticket',
+    contestType: 'straight-party',
+    ballots: 5,
+    overvotes: 1,
+    undervotes: 1,
+    tallies: {
+      '0': 2,
+      '1': 1,
+      '2': 0,
+      '3': 0,
+      '4': 0,
+      '5': 0,
+      '6': 0,
+      '7': 0,
+      '8': 0,
+    },
+  });
+
+  // Basic test for derived votes. The derivation rules are covered in detail in
+  // straight_party.test.ts.
+  const { president } = result.contestResults;
+  assert(president?.contestType === 'candidate');
+  expect(president.tallies['barchi-hallaren']?.tally).toEqual(2);
+  expect(president.tallies['cramer-vuocolo']?.tally).toEqual(1);
+});
+
 describe('open primaries', () => {
   const openPrimaryElection = readElectionOpenPrimary();
 
@@ -1667,6 +1725,68 @@ test('combineManualElectionResults', () => {
   );
 
   // test for combineElectionResults
+  expect(
+    combineElectionResults({
+      election,
+      allElectionResults: [
+        convertManualElectionResults(manualResults1),
+        convertManualElectionResults(manualResults2),
+      ],
+    })
+  ).toEqual(convertManualElectionResults(combinedResults));
+});
+
+test('combineManualElectionResults with a straight-party contest', () => {
+  const election = electionStraightPartyFixtures.readElection();
+
+  const manualResults1 = buildManualResultsFixture({
+    election,
+    ballotCount: 10,
+    contestResultsSummaries: {
+      'straight-party-ticket': {
+        type: 'straight-party',
+        ballots: 10,
+        overvotes: 1,
+        undervotes: 2,
+        optionTallies: { '0': 4, '1': 3 },
+      },
+    },
+  });
+  const manualResults2 = buildManualResultsFixture({
+    election,
+    ballotCount: 20,
+    contestResultsSummaries: {
+      'straight-party-ticket': {
+        type: 'straight-party',
+        ballots: 20,
+        overvotes: 2,
+        undervotes: 3,
+        optionTallies: { '0': 10, '1': 5 },
+      },
+    },
+  });
+
+  const combinedResults = combineManualElectionResults({
+    election,
+    allManualResults: [manualResults1, manualResults2],
+  });
+
+  expect(combinedResults).toEqual(
+    buildManualResultsFixture({
+      election,
+      ballotCount: 30,
+      contestResultsSummaries: {
+        'straight-party-ticket': {
+          type: 'straight-party',
+          ballots: 30,
+          overvotes: 3,
+          undervotes: 5,
+          optionTallies: { '0': 14, '1': 8 },
+        },
+      },
+    })
+  );
+
   expect(
     combineElectionResults({
       election,
@@ -2207,8 +2327,25 @@ test('areContestResultsValid', () => {
     noTally: 10,
   };
 
+  const validStraightPartyContestResults: Tabulation.StraightPartyContestResults =
+    {
+      ballots: 50,
+      contestId: 'contest-1',
+      contestType: 'straight-party',
+      overvotes: 10,
+      undervotes: 5,
+      tallies: {
+        'party-1': 20,
+        'party-2': 10,
+        'party-3': 5,
+      },
+    };
+
   expect(areContestResultsValid(validCandidateContestResults)).toEqual(true);
   expect(areContestResultsValid(validYesNoContestResults)).toEqual(true);
+  expect(areContestResultsValid(validStraightPartyContestResults)).toEqual(
+    true
+  );
 
   expect(
     areContestResultsValid({
@@ -2258,6 +2395,28 @@ test('areContestResultsValid', () => {
     areContestResultsValid({
       ...validYesNoContestResults,
       noTally: validYesNoContestResults.noTally + 1,
+    })
+  ).toEqual(false);
+
+  expect(
+    areContestResultsValid({
+      ...validStraightPartyContestResults,
+      overvotes: validStraightPartyContestResults.overvotes - 1,
+    })
+  ).toEqual(false);
+  expect(
+    areContestResultsValid({
+      ...validStraightPartyContestResults,
+      undervotes: validStraightPartyContestResults.undervotes - 1,
+    })
+  ).toEqual(false);
+  expect(
+    areContestResultsValid({
+      ...validStraightPartyContestResults,
+      tallies: {
+        ...validStraightPartyContestResults.tallies,
+        'party-1': validStraightPartyContestResults.tallies['party-1']! + 1,
+      },
     })
   ).toEqual(false);
 });

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -191,39 +191,56 @@ function addCastVoteRecordToElectionResult(
 
     contestResult.ballots += 1;
 
-    if (contestResult.contestType === 'yesno') {
-      if (optionIds.length === 2) {
-        contestResult.overvotes += 1;
-      } else if (optionIds.length === 0) {
-        contestResult.undervotes += 1;
-      } else if (optionIds[0] === contestResult.yesOptionId) {
-        contestResult.yesTally += 1;
-      } else {
-        assert(
-          optionIds[0] === contestResult.noOptionId,
-          `Invalid option id: ${optionIds[0]}`
-        );
-        contestResult.noTally += 1;
-      }
-    } else if (optionIds.length > contestResult.votesAllowed) {
-      contestResult.overvotes += contestResult.votesAllowed;
-    } else {
-      if (optionIds.length < contestResult.votesAllowed) {
-        contestResult.undervotes +=
-          contestResult.votesAllowed - optionIds.length;
+    const numVotesAllowed = votesAllowed(contestResult);
+    if (optionIds.length > numVotesAllowed) {
+      contestResult.overvotes += numVotesAllowed;
+      continue;
+    }
+
+    if (optionIds.length < numVotesAllowed) {
+      contestResult.undervotes += numVotesAllowed - optionIds.length;
+    }
+
+    switch (contestResult.contestType) {
+      case 'candidate': {
+        for (const optionId of optionIds) {
+          if (optionId.startsWith('write-in-')) {
+            const genericWriteInTally = assertDefined(
+              contestResult.tallies[Tabulation.GENERIC_WRITE_IN_ID]
+            );
+            genericWriteInTally.tally += 1;
+          } else {
+            const candidateTally = assertDefined(
+              contestResult.tallies[optionId]
+            );
+            candidateTally.tally += 1;
+          }
+        }
+        break;
       }
 
-      for (const optionId of optionIds) {
-        if (optionId.startsWith('write-in-')) {
-          const genericWriteInTally = assertDefined(
-            contestResult.tallies[Tabulation.GENERIC_WRITE_IN_ID]
-          );
-          genericWriteInTally.tally += 1;
-        } else {
-          const candidateTally = assertDefined(contestResult.tallies[optionId]);
-          candidateTally.tally += 1;
+      case 'yesno': {
+        for (const optionId of optionIds) {
+          if (optionId === contestResult.yesOptionId) {
+            contestResult.yesTally += 1;
+          } else if (optionId === contestResult.noOptionId) {
+            contestResult.noTally += 1;
+          }
         }
+        break;
       }
+
+      case 'straight-party': {
+        for (const partyId of optionIds) {
+          contestResult.tallies[partyId] =
+            assertDefined(contestResult.tallies[partyId]) + 1;
+        }
+        break;
+      }
+
+      default:
+        /* istanbul ignore next */
+        throwIllegalValue(contestResult);
     }
   }
 

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -18,6 +18,7 @@ import { isGroupByEmpty } from './arguments';
 import { getGroupedBallotStyles } from '../ballot_styles';
 import { readV0CompressedTallyAsContestResults } from './compressed_tallies';
 import { inferPartyFromVotes, partisanContests } from './open_primary';
+import { deriveStraightPartyVotes } from './straight_party';
 
 export function getEmptyYesNoContestResults(
   contest: YesNoContest
@@ -177,7 +178,9 @@ function addCastVoteRecordToElectionResult(
     }
   }
 
-  for (const [contestId, optionIds] of Object.entries(cvr.votes)) {
+  const votes = deriveStraightPartyVotes(election, cvr.votes);
+
+  for (const [contestId, optionIds] of Object.entries(votes)) {
     if (voidedContestIds?.has(contestId)) {
       continue;
     }

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -829,6 +829,10 @@ export type ContestResultsSummary = {
       yesTally?: number;
       noTally?: number;
     }
+  | {
+      type: 'straight-party';
+      optionTallies?: Record<PartyId, number>;
+    }
 );
 
 export function buildContestResultsFixture({
@@ -840,47 +844,60 @@ export function buildContestResultsFixture({
   contestResultsSummary: ContestResultsSummary;
   includeGenericWriteIn?: boolean;
 }): Tabulation.ContestResults {
-  /* istanbul ignore next */
-  if (contest.type === 'straight-party') {
-    straightPartyNotYetImplemented();
-  }
-  const contestResults =
-    contest.type === 'yesno'
-      ? getEmptyYesNoContestResults(contest)
-      : getEmptyCandidateContestResults(contest, includeGenericWriteIn);
+  const contestResults = getEmptyContestResults(contest, includeGenericWriteIn);
 
   contestResults.overvotes = contestResultsSummary.overvotes ?? 0;
   contestResults.undervotes = contestResultsSummary.undervotes ?? 0;
   contestResults.ballots = contestResultsSummary.ballots;
 
-  if (contest.type === 'yesno') {
-    assert(contestResultsSummary.type === 'yesno');
-    assert(contestResults.contestType === 'yesno');
-    contestResults.yesTally = contestResultsSummary.yesTally ?? 0;
-    contestResults.noTally = contestResultsSummary.noTally ?? 0;
-  } else {
-    assert(contestResultsSummary.type === 'candidate');
-    assert(contestResults.contestType === 'candidate');
-    // add official candidate vote counts to existing option tallies
-    for (const [candidateId, candidateTally] of Object.entries(
-      contestResults.tallies
-    )) {
-      candidateTally.tally =
-        contestResultsSummary.officialOptionTallies?.[candidateId] ?? 0;
+  switch (contest.type) {
+    case 'yesno': {
+      assert(contestResultsSummary.type === 'yesno');
+      assert(contestResults.contestType === 'yesno');
+      contestResults.yesTally = contestResultsSummary.yesTally ?? 0;
+      contestResults.noTally = contestResultsSummary.noTally ?? 0;
+      break;
+    }
+    case 'candidate': {
+      assert(contestResultsSummary.type === 'candidate');
+      assert(contestResults.contestType === 'candidate');
+      // add official candidate vote counts to existing option tallies
+      for (const [candidateId, candidateTally] of Object.entries(
+        contestResults.tallies
+      )) {
+        candidateTally.tally =
+          contestResultsSummary.officialOptionTallies?.[candidateId] ?? 0;
+      }
+
+      // add write-in candidate option tallies if specified
+      if (contestResultsSummary.writeInOptionTallies) {
+        for (const [candidateId, candidateTally] of Object.entries(
+          contestResultsSummary.writeInOptionTallies
+        )) {
+          contestResults.tallies[candidateId] = {
+            id: candidateId,
+            ...candidateTally,
+            isWriteIn: true,
+          };
+        }
+      }
+      break;
     }
 
-    // add write-in candidate option tallies if specified
-    if (contestResultsSummary.writeInOptionTallies) {
-      for (const [candidateId, candidateTally] of Object.entries(
-        contestResultsSummary.writeInOptionTallies
+    case 'straight-party': {
+      assert(contestResultsSummary.type === 'straight-party');
+      assert(contestResults.contestType === 'straight-party');
+      for (const [partyId, tally] of Object.entries(
+        contestResultsSummary.optionTallies ?? {}
       )) {
-        contestResults.tallies[candidateId] = {
-          id: candidateId,
-          ...candidateTally,
-          isWriteIn: true,
-        };
+        contestResults.tallies[partyId] = tally;
       }
+      break;
     }
+
+    default:
+      /* istanbul ignore next */
+      throwIllegalValue(contest);
   }
 
   return contestResults;
@@ -900,10 +917,6 @@ function buildElectionContestResultsFixture({
   const electionContestResults: Tabulation.ElectionResults['contestResults'] =
     {};
   for (const contest of election.contests) {
-    /* istanbul ignore next */
-    if (contest.type === 'straight-party') {
-      straightPartyNotYetImplemented();
-    }
     const contestResultsSummary = contestResultsSummaries[contest.id];
     electionContestResults[contest.id] = contestResultsSummary
       ? buildContestResultsFixture({
@@ -911,9 +924,7 @@ function buildElectionContestResultsFixture({
           contestResultsSummary,
           includeGenericWriteIn,
         })
-      : contest.type === 'yesno'
-      ? getEmptyYesNoContestResults(contest)
-      : getEmptyCandidateContestResults(contest, includeGenericWriteIn);
+      : getEmptyContestResults(contest, includeGenericWriteIn);
   }
 
   return electionContestResults;

--- a/libs/utils/src/tabulation/tabulation.ts
+++ b/libs/utils/src/tabulation/tabulation.ts
@@ -1,4 +1,9 @@
-import { assert, assertDefined, iter } from '@votingworks/basics';
+import {
+  assert,
+  assertDefined,
+  iter,
+  throwIllegalValue,
+} from '@votingworks/basics';
 import {
   Contest,
   BallotStyleGroupId,
@@ -10,9 +15,9 @@ import {
   Id,
   PartyId,
   PrecinctSelection,
-  straightPartyNotYetImplemented,
   Tabulation,
   YesNoContest,
+  StraightPartyContest,
 } from '@votingworks/types';
 import { isGroupByEmpty } from './arguments';
 import { getGroupedBallotStyles } from '../ballot_styles';
@@ -73,6 +78,41 @@ export function getEmptyCandidateContestResults(
   };
 }
 
+export function getEmptyStraightPartyContestResults(
+  contest: StraightPartyContest
+): Tabulation.StraightPartyContestResults {
+  return {
+    contestId: contest.id,
+    contestType: 'straight-party',
+    overvotes: 0,
+    undervotes: 0,
+    ballots: 0,
+    tallies: Object.fromEntries(
+      contest.optionIds.map((partyId) => [partyId, 0])
+    ),
+  };
+}
+
+function getEmptyContestResults(
+  contest: Contest,
+  includeGenericWriteInIfAllowed?: boolean
+): Tabulation.ContestResults {
+  switch (contest.type) {
+    case 'candidate':
+      return getEmptyCandidateContestResults(
+        contest,
+        includeGenericWriteInIfAllowed
+      );
+    case 'yesno':
+      return getEmptyYesNoContestResults(contest);
+    case 'straight-party':
+      return getEmptyStraightPartyContestResults(contest);
+    default:
+      /* istanbul ignore next */
+      throwIllegalValue(contest);
+  }
+}
+
 export function getEmptyCardCounts(): Tabulation.CardCounts {
   return {
     bmd: [],
@@ -88,21 +128,12 @@ export function getEmptyElectionResults(
   election: Election,
   includeGenericWriteInIfAllowed = true
 ): Tabulation.ElectionResults {
-  const contestResults: Tabulation.ElectionResults['contestResults'] = {};
-  for (const contest of election.contests) {
-    /* istanbul ignore next */
-    if (contest.type === 'straight-party') {
-      straightPartyNotYetImplemented();
-    }
-    contestResults[contest.id] =
-      contest.type === 'yesno'
-        ? getEmptyYesNoContestResults(contest)
-        : getEmptyCandidateContestResults(
-            contest,
-            includeGenericWriteInIfAllowed
-          );
-  }
-
+  const contestResults = Object.fromEntries(
+    election.contests.map((contest) => [
+      contest.id,
+      getEmptyContestResults(contest, includeGenericWriteInIfAllowed),
+    ])
+  );
   return {
     contestResults,
     cardCounts: getEmptyCardCounts(),
@@ -118,18 +149,12 @@ export function getEmptyElectionResults(
 export function getEmptyManualElectionResults(
   election: Election
 ): Tabulation.ManualElectionResults {
-  const contestResults: Tabulation.ElectionResults['contestResults'] = {};
-  for (const contest of election.contests) {
-    /* istanbul ignore next */
-    if (contest.type === 'straight-party') {
-      straightPartyNotYetImplemented();
-    }
-    contestResults[contest.id] =
-      contest.type === 'yesno'
-        ? getEmptyYesNoContestResults(contest)
-        : getEmptyCandidateContestResults(contest, false);
-  }
-
+  const contestResults = Object.fromEntries(
+    election.contests.map((contest) => [
+      contest.id,
+      getEmptyContestResults(contest, false),
+    ])
+  );
   return {
     contestResults,
     ballotCount: 0,
@@ -525,6 +550,30 @@ export function combineYesNoContestResults({
 }
 
 /**
+ * Combines contest results for straight-party contests. If an empty list is passed,
+ * returns empty (all zero) contest results.
+ */
+export function combineStraightPartyContestResults({
+  contest,
+  allContestResults,
+}: {
+  contest: StraightPartyContest;
+  allContestResults: Tabulation.StraightPartyContestResults[];
+}): Tabulation.StraightPartyContestResults {
+  const combinedContestResults = getEmptyStraightPartyContestResults(contest);
+  for (const contestResults of allContestResults) {
+    combinedContestResults.overvotes += contestResults.overvotes;
+    combinedContestResults.undervotes += contestResults.undervotes;
+    combinedContestResults.ballots += contestResults.ballots;
+    for (const [partyId, tally] of Object.entries(contestResults.tallies)) {
+      combinedContestResults.tallies[partyId] =
+        assertDefined(combinedContestResults.tallies[partyId]) + tally;
+    }
+  }
+  return combinedContestResults;
+}
+
+/**
  * Combines contest results for candidate contests. If an empty list is passed,
  * returns empty (all zero) contest results that include placeholder zero
  * tallies for all official candidates but none for any write-in candidates.
@@ -569,22 +618,29 @@ export function combineContestResults({
   contest: Contest;
   allContestResults: Tabulation.ContestResults[];
 }): Tabulation.ContestResults {
-  /* istanbul ignore next */
-  if (contest.type === 'straight-party') {
-    straightPartyNotYetImplemented();
+  switch (contest.type) {
+    case 'candidate':
+      return combineCandidateContestResults({
+        contest,
+        allContestResults:
+          allContestResults as Tabulation.CandidateContestResults[],
+      });
+    case 'yesno':
+      return combineYesNoContestResults({
+        contest,
+        allContestResults:
+          allContestResults as Tabulation.YesNoContestResults[],
+      });
+    case 'straight-party':
+      return combineStraightPartyContestResults({
+        contest,
+        allContestResults:
+          allContestResults as Tabulation.StraightPartyContestResults[],
+      });
+    default:
+      /* istanbul ignore next */
+      throwIllegalValue(contest);
   }
-  if (contest.type === 'yesno') {
-    return combineYesNoContestResults({
-      contest,
-      allContestResults: allContestResults as Tabulation.YesNoContestResults[],
-    });
-  }
-
-  return combineCandidateContestResults({
-    contest,
-    allContestResults:
-      allContestResults as Tabulation.CandidateContestResults[],
-  });
 }
 
 /**
@@ -922,7 +978,7 @@ export function mergeWriteInTallies<
     {};
 
   for (const contestResults of Object.values(anyResults.contestResults)) {
-    if (contestResults.contestType === 'yesno') {
+    if (contestResults.contestType !== 'candidate') {
       newElectionContestResults[contestResults.contestId] = contestResults;
       continue;
     }
@@ -958,6 +1014,22 @@ export function mergeWriteInTallies<
   };
 }
 
+function sumTallies(contestResults: Tabulation.ContestResults): number {
+  switch (contestResults.contestType) {
+    case 'candidate':
+      return iter(Object.values(contestResults.tallies)).sum(
+        ({ tally }) => tally
+      );
+    case 'yesno':
+      return contestResults.yesTally + contestResults.noTally;
+    case 'straight-party':
+      return iter(Object.values(contestResults.tallies)).sum();
+    default:
+      /* istanbul ignore next */
+      throwIllegalValue(contestResults);
+  }
+}
+
 /**
  * Validates that the number of votes entered for the contest matches the number
  * of ballots.
@@ -965,15 +1037,16 @@ export function mergeWriteInTallies<
 export function areContestResultsValid(
   contestResults: Tabulation.ContestResults
 ): boolean {
-  const votesAllowed =
-    contestResults.contestType === 'yesno' ? 1 : contestResults.votesAllowed;
-  const expectedVotes = contestResults.ballots * votesAllowed;
+  const expectedVotes = contestResults.ballots * votesAllowed(contestResults);
   const tallyVotes =
     contestResults.overvotes +
     contestResults.undervotes +
-    (contestResults.contestType === 'yesno'
-      ? contestResults.yesTally + contestResults.noTally
-      : iter(Object.values(contestResults.tallies)).sum(({ tally }) => tally));
-
+    sumTallies(contestResults);
   return tallyVotes === expectedVotes;
+}
+
+function votesAllowed(contestResults: Tabulation.ContestResults): number {
+  return contestResults.contestType === 'candidate'
+    ? contestResults.votesAllowed
+    : 1;
 }


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/7887
<!-- Add a link to a GitHub issue here -->
Updates the core tabulation logic to support straight party contests. There are two pieces to this:
- Tabulating the straight party contest itself and including that in results
- Deriving straight party votes for other contests based on the party selected in the straight party contest (based on [MI rules](https://drive.google.com/file/d/17I7IjqCJj5pR9nOqNv5kvnLwxSfqADxA/view))

## Demo Video or Screenshot
N/A

## Testing Plan
Updated automated tests
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
