### PR TITLE
[VxAdmin] Add CVR summary card components

### DIFF
--- a/apps/admin/frontend/src/screens/tally/cvr_summaries.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvr_summaries.test.tsx
@@ -1,0 +1,25 @@
+import { expect, test, vi } from 'vitest';
+import { hasTextAcrossElements } from '@votingworks/test-utils';
+import * as ui from '@votingworks/ui';
+import { render, screen } from '../../../test/react_testing_library';
+import { CvrSummaries } from './cvr_summaries';
+
+const progressBarSpy = vi.spyOn(ui, 'ProgressBar');
+
+test('renders provided metrics', () => {
+  render(
+    <CvrSummaries
+      cvrs={2048}
+      locations={{ loaded: 12, total: 60 }}
+      scanners={128}
+    />
+  );
+
+  screen.getByText(hasTextAcrossElements(['Locations', '12 / 60'].join('')));
+  screen.getByText(hasTextAcrossElements(['Scanners', '128'].join('')));
+  screen.getByText(hasTextAcrossElements(['CVRs', '2,048'].join('')));
+
+  screen.getByRole('progressbar');
+  const progressBarProps = progressBarSpy.mock.calls[0][0];
+  expect(progressBarProps.progress).toEqual(0.2);
+});

--- a/apps/admin/frontend/src/screens/tally/cvr_summaries.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvr_summaries.tsx
@@ -1,0 +1,92 @@
+import styled from 'styled-components';
+
+import { Card, ProgressBar } from '@votingworks/ui';
+import { format } from '@votingworks/utils';
+import { BORDER_LIGHT, GAP } from './styles';
+
+const Container = styled.div`
+  display: grid;
+  gap: ${GAP};
+  grid-auto-columns: 1fr;
+  grid-auto-flow: column;
+`;
+
+export interface CvrSummariesProps {
+  cvrs: number;
+  locations: Progress;
+  scanners: number;
+}
+
+interface Progress {
+  loaded: number;
+  total: number;
+}
+
+export function CvrSummaries(props: CvrSummariesProps): JSX.Element {
+  const { cvrs, locations, scanners } = props;
+
+  return (
+    <Container>
+      <ProgressCard progress={locations} title="Locations" />
+      <SummaryCard title="Scanners">{scanners}</SummaryCard>
+      <SummaryCard title="CVRs">{cvrs}</SummaryCard>
+    </Container>
+  );
+}
+
+const SummaryCardContainer = styled(Card)`
+  ${BORDER_LIGHT}
+
+  /* [TODO] Update libs/ui/Card to support custom card body styling instead. */
+  > * {
+    display: grid;
+    gap: ${GAP};
+    padding: ${GAP};
+  }
+`;
+
+const MetricPair = styled.div`
+  align-items: center;
+  display: flex;
+  font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
+  justify-content: space-between;
+
+  > * {
+    line-height: 1;
+    margin: 0;
+  }
+`;
+
+const MetricValue = styled.span`
+  font-size: 1.5rem;
+  font-weight: ${(p) => p.theme.sizes.fontWeight.bold};
+`;
+
+function SummaryCard(props: { title: string; children: number }) {
+  const { children, title } = props;
+
+  return (
+    <SummaryCardContainer>
+      <MetricPair>
+        <span>{title}</span>
+        <MetricValue>{format.count(children)}</MetricValue>
+      </MetricPair>
+    </SummaryCardContainer>
+  );
+}
+
+function ProgressCard(props: { progress: Progress; title: string }) {
+  const { progress, title } = props;
+
+  return (
+    <SummaryCardContainer>
+      <MetricPair>
+        <span>{title}</span>
+        <MetricValue>
+          {format.count(progress.loaded)} / {format.count(progress.total)}
+        </MetricValue>
+      </MetricPair>
+      <ProgressBar progress={Math.min(1, progress.loaded / progress.total)} />
+    </SummaryCardContainer>
+  );
+}

--- a/apps/admin/frontend/src/screens/tally/styles.ts
+++ b/apps/admin/frontend/src/screens/tally/styles.ts
@@ -1,0 +1,9 @@
+import { DesktopPalette } from '@votingworks/ui';
+import { css } from 'styled-components';
+
+export const BORDER_LIGHT = css`
+  border: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid
+    ${DesktopPalette.Gray30};
+`;
+
+export const GAP = '0.5rem';


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7958

Adding leaf UI components, in preparation for the updated CVR management UX in VxAdmin. This adds the import summary cards that will live at the top of the `Cast Vote Records` screen.

## Demo Video or Screenshot

_In-context mocks are available in [FIgma](https://www.figma.com/design/0Mari2J3cgG8dSYx9pnF1P/VxAdmin-CVR-Management?node-id=1-5&t=QJg1Q388OLjE6w7n-1)_

<img width="1553" height="182" alt="admin-cvr-summaries" src="https://github.com/user-attachments/assets/40818220-5be5-4f66-ba24-2ee48f9b1eec" />

## Testing Plan
- Render-check unit test

## Checklist
N/A