### PR TITLE
[libs/integration-test-utils] Fix broken CVR batch type

### DIFF
--- a/libs/integration-test-utils/src/cast_vote_records.ts
+++ b/libs/integration-test-utils/src/cast_vote_records.ts
@@ -13,6 +13,7 @@ import { type MarginalMark } from '@votingworks/hmpb';
 import { pdfToImages, type ImageData } from '@votingworks/image-utils';
 import {
   AdjudicationReason,
+  anyPollingPlace,
   BallotId,
   BallotIdSchema,
   BallotStyleId,
@@ -234,6 +235,9 @@ export async function generateCastVoteRecordExport(
       label: batchId,
       startedAt: new Date().toISOString(),
       count: ballots.length,
+      // [TODO] This will need to be varied based on caller input to get
+      // screenshot coverage on multiple polling places in VxAdmin.
+      pollingPlaceId: anyPollingPlace(electionDefinition.election).id,
     },
   ];
   const reportMetadata = buildCastVoteRecordReportMetadata({


### PR DESCRIPTION
## Overview

Fixing a merge conflict between https://github.com/votingworks/vxsuite/pull/8768 and https://github.com/votingworks/vxsuite/pull/8775 - the latter made the `pollingPlaceId` field required in CVR batches, but was branched off a version of main before the former.

## Demo Video or Screenshot
N/A

## Testing Plan
- Existing tests

## Checklist
N/A