### PR TITLE
backend: Add straight party contest to CVRs

### DIFF
--- a/apps/scan/backend/src/app_polls_reports.test.ts
+++ b/apps/scan/backend/src/app_polls_reports.test.ts
@@ -681,9 +681,6 @@ test('can tabulate results and print polls closed report for straight party', as
         electionPackage: { electionDefinition },
       });
 
-      // TODO: remove this line when straight-party CVR export is implemented.
-      workspace.store.setIsContinuousExportEnabled(false);
-
       const { election } = electionDefinition;
       const ballotStyle = assertDefined(
         getBallotStyle({ election, ballotStyleId: '12' })

--- a/libs/backend/src/cast_vote_records/build_cast_vote_record.test.ts
+++ b/libs/backend/src/cast_vote_records/build_cast_vote_record.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 import { assert, find } from '@votingworks/basics';
 import {
   electionFamousNames2021Fixtures,
+  readElectionStraightPartyDefinition,
   readElectionTwoPartyPrimaryDefinition,
 } from '@votingworks/fixtures';
 import {
@@ -1005,6 +1006,116 @@ describe('buildCVRContestsFromVotes with candidate rotation', () => {
           ContestSelectionId: 'vincent-van-gogh',
           OptionPosition: 0,
         }),
+      ],
+    });
+  });
+});
+
+describe('buildCVRContestsFromVotes with straight party contest', () => {
+  const straightPartyElectionDefinition = readElectionStraightPartyDefinition();
+  const straightPartyContestId = 'straight-party-ticket';
+  const ballotStyleId = '12';
+
+  test('single party selection', () => {
+    const result = buildCVRContestsFromVotes({
+      electionDefinition: straightPartyElectionDefinition,
+      ballotStyleId,
+      votes: { [straightPartyContestId]: ['3'] },
+      options: { ballotMarkingMode: 'machine' },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual<CVR.CVRContest>({
+      '@type': 'CVR.CVRContest',
+      ContestId: straightPartyContestId,
+      Overvotes: 0,
+      Undervotes: 0,
+      Status: undefined,
+      CVRContestSelection: [
+        {
+          '@type': 'CVR.CVRContestSelection',
+          ContestSelectionId: '3',
+          OptionPosition: 3,
+          Status: undefined,
+          SelectionPosition: [
+            {
+              '@type': 'CVR.SelectionPosition',
+              HasIndication: CVR.IndicationStatus.Yes,
+              NumberVotes: 1,
+              IsAllocable: CVR.AllocationStatus.Yes,
+              Status: undefined,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  test('undervote', () => {
+    const result = buildCVRContestsFromVotes({
+      electionDefinition: straightPartyElectionDefinition,
+      ballotStyleId,
+      votes: { [straightPartyContestId]: [] },
+      options: { ballotMarkingMode: 'machine' },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual<CVR.CVRContest>({
+      '@type': 'CVR.CVRContest',
+      ContestId: straightPartyContestId,
+      Overvotes: 0,
+      Undervotes: 1,
+      Status: [CVR.ContestStatus.Undervoted, CVR.ContestStatus.NotIndicated],
+      CVRContestSelection: [],
+    });
+  });
+
+  test('overvote', () => {
+    const result = buildCVRContestsFromVotes({
+      electionDefinition: straightPartyElectionDefinition,
+      ballotStyleId,
+      votes: { [straightPartyContestId]: ['3', '7'] },
+      options: { ballotMarkingMode: 'machine' },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual<CVR.CVRContest>({
+      '@type': 'CVR.CVRContest',
+      ContestId: straightPartyContestId,
+      Overvotes: 1,
+      Undervotes: 0,
+      Status: [CVR.ContestStatus.Overvoted, CVR.ContestStatus.InvalidatedRules],
+      CVRContestSelection: [
+        {
+          '@type': 'CVR.CVRContestSelection',
+          ContestSelectionId: '3',
+          OptionPosition: 3,
+          Status: [CVR.ContestSelectionStatus.InvalidatedRules],
+          SelectionPosition: [
+            {
+              '@type': 'CVR.SelectionPosition',
+              HasIndication: CVR.IndicationStatus.Yes,
+              NumberVotes: 1,
+              IsAllocable: CVR.AllocationStatus.No,
+              Status: [CVR.PositionStatus.InvalidatedRules],
+            },
+          ],
+        },
+        {
+          '@type': 'CVR.CVRContestSelection',
+          ContestSelectionId: '7',
+          OptionPosition: 7,
+          Status: [CVR.ContestSelectionStatus.InvalidatedRules],
+          SelectionPosition: [
+            {
+              '@type': 'CVR.SelectionPosition',
+              HasIndication: CVR.IndicationStatus.Yes,
+              NumberVotes: 1,
+              IsAllocable: CVR.AllocationStatus.No,
+              Status: [CVR.PositionStatus.InvalidatedRules],
+            },
+          ],
+        },
       ],
     });
   });

--- a/libs/backend/src/cast_vote_records/build_cast_vote_record.ts
+++ b/libs/backend/src/cast_vote_records/build_cast_vote_record.ts
@@ -21,7 +21,9 @@ import {
   MarkStatus,
   MarkThresholds,
   SheetOf,
-  straightPartyNotYetImplemented,
+  StraightPartyContest,
+  StraightPartyVote,
+  Vote,
   VotesDict,
   YesNoContest,
   YesNoVote,
@@ -99,6 +101,16 @@ export function buildCvrImageData({
   };
 }
 
+// VVSG 2.0 1.1.5-E.2
+function countOvervotes(votes: Vote, votesAllowed: number): number {
+  return votes.length > votesAllowed ? votesAllowed : 0;
+}
+
+// VVSG 2.0 1.1.5-E.2
+function countUndervotes(votes: Vote, votesAllowed: number): number {
+  return votes.length < votesAllowed ? votesAllowed - votes.length : 0;
+}
+
 function buildCVRBallotMeasureContest({
   contest,
   vote,
@@ -110,14 +122,17 @@ function buildCVRBallotMeasureContest({
   electionDefinition: ElectionDefinition;
   ballotStyleId: BallotStyleId;
 }): CVR.CVRContest {
-  const overvoted = vote.length > 1;
-  const undervoted = vote.length < 1;
+  const votesAllowed = 1;
+  const overvotes = countOvervotes(vote, votesAllowed);
+  const undervotes = countUndervotes(vote, votesAllowed);
+  const overvoted = overvotes > 0;
+  const undervoted = undervotes > 0;
 
   return {
     '@type': 'CVR.CVRContest',
     ContestId: contest.id,
-    Overvotes: vote.length > 1 ? 1 : 0,
-    Undervotes: Math.max(1 - vote.length, 0),
+    Overvotes: overvotes,
+    Undervotes: undervotes,
     Status: overvoted
       ? [CVR.ContestStatus.Overvoted, CVR.ContestStatus.InvalidatedRules]
       : undervoted
@@ -181,8 +196,10 @@ function buildCVRCandidateContest({
   unmarkedWriteIns?: InterpretedHmpbPage['unmarkedWriteIns'];
   options: CVRContestRequiredBallotPageOptions;
 }): CVR.CVRContest {
-  const overvoted = vote.length > contest.seats;
-  const undervoted = vote.length < contest.seats;
+  const overvotes = countOvervotes(vote, contest.seats);
+  const undervotes = countUndervotes(vote, contest.seats);
+  const overvoted = overvotes > 0;
+  const undervoted = undervotes > 0;
 
   const statuses: CVR.ContestStatus[] = [];
   if (vote.length === 0) {
@@ -232,8 +249,12 @@ function buildCVRCandidateContest({
       const { isWriteIn } = candidate;
 
       const selectionStatuses: CVR.ContestSelectionStatus[] = [];
-      if (overvoted) selectionStatuses.push(CVR.ContestSelectionStatus.InvalidatedRules);
-      if (isWriteIn) selectionStatuses.push(CVR.ContestSelectionStatus.NeedsAdjudication);
+      if (overvoted) {
+        selectionStatuses.push(CVR.ContestSelectionStatus.InvalidatedRules);
+      }
+      if (isWriteIn) {
+        selectionStatuses.push(CVR.ContestSelectionStatus.NeedsAdjudication);
+      }
 
       return {
         '@type': 'CVR.CVRContestSelection',
@@ -318,14 +339,69 @@ function buildCVRCandidateContest({
   return {
     '@type': 'CVR.CVRContest',
     ContestId: contest.id,
-    Overvotes: vote.length > contest.seats ? contest.seats : 0, // VVSG 2.0 1.1.5-E.2
-    Undervotes: Math.max(contest.seats - vote.length, 0), // VVSG 2.0 1.1.5-E.2
+    Overvotes: overvotes,
+    Undervotes: undervotes,
     WriteIns: numWriteIns, // VVSG 2.0 1.1.5-E.3
     Status: statuses.length > 0 ? statuses : undefined,
     CVRContestSelection: [
       ...markedVoteSelections,
       ...unmarkedWriteInSelections,
     ],
+  };
+}
+
+function buildCVRStraightPartyContest({
+  contest,
+  electionDefinition,
+  ballotStyleId,
+  vote,
+}: {
+  contest: StraightPartyContest;
+  electionDefinition: ElectionDefinition;
+  ballotStyleId: BallotStyleId;
+  vote: StraightPartyVote;
+}): CVR.CVRContest {
+  const votesAllowed = 1;
+  const overvotes = countOvervotes(vote, votesAllowed);
+  const undervotes = countUndervotes(vote, votesAllowed);
+  const overvoted = overvotes > 0;
+  const undervoted = undervotes > 0;
+
+  return {
+    '@type': 'CVR.CVRContest',
+    ContestId: contest.id,
+    Overvotes: overvotes,
+    Undervotes: undervotes,
+    Status: overvoted
+      ? [CVR.ContestStatus.Overvoted, CVR.ContestStatus.InvalidatedRules]
+      : undervoted
+      ? [CVR.ContestStatus.Undervoted, CVR.ContestStatus.NotIndicated]
+      : undefined,
+    CVRContestSelection: vote.map((partyId) => ({
+      '@type': 'CVR.CVRContestSelection',
+      ContestSelectionId: partyId,
+      // include position on the ballot per VVSG 2.0 1.1.5-C.2
+      OptionPosition: CachedElectionLookups.getOptionPosition(
+        electionDefinition,
+        ballotStyleId,
+        contest.id,
+        partyId
+      ),
+      Status: overvoted
+        ? [CVR.ContestSelectionStatus.InvalidatedRules]
+        : undefined,
+      SelectionPosition: [
+        {
+          '@type': 'CVR.SelectionPosition',
+          HasIndication: CVR.IndicationStatus.Yes,
+          NumberVotes: 1,
+          IsAllocable: overvoted
+            ? CVR.AllocationStatus.No
+            : CVR.AllocationStatus.Yes,
+          Status: overvoted ? [CVR.PositionStatus.InvalidatedRules] : undefined,
+        },
+      ],
+    })),
   };
 }
 
@@ -363,10 +439,6 @@ export function buildCVRContestsFromVotes({
     const contestUnmarkedWriteIns = unmarkedWriteIns?.filter(
       ({ contestId }) => contestId === contest.id
     );
-    /* istanbul ignore next */
-    if (contest.type === 'straight-party') {
-      return straightPartyNotYetImplemented();
-    }
     switch (contest.type) {
       case 'yesno':
         cvrContests.push(
@@ -387,6 +459,16 @@ export function buildCVRContestsFromVotes({
             vote: contestVote as CandidateVote,
             unmarkedWriteIns: contestUnmarkedWriteIns,
             options,
+          })
+        );
+        break;
+      case 'straight-party':
+        cvrContests.push(
+          buildCVRStraightPartyContest({
+            contest,
+            electionDefinition,
+            ballotStyleId,
+            vote: contestVote as StraightPartyVote,
           })
         );
         break;

--- a/libs/backend/src/cast_vote_records/build_report_metadata.test.ts
+++ b/libs/backend/src/cast_vote_records/build_report_metadata.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, expect, test, vi } from 'vitest';
 import { assert, find, iter } from '@votingworks/basics';
-import { readElectionTwoPartyPrimaryDefinition } from '@votingworks/fixtures';
+import {
+  readElectionStraightPartyDefinition,
+  readElectionTwoPartyPrimaryDefinition,
+} from '@votingworks/fixtures';
 import {
   CandidateContest,
   CastVoteRecordBatchMetadata,
@@ -208,6 +211,42 @@ test('builds well-formed cast vote record report', () => {
       ])
     );
   }
+});
+
+test('builds straight party contests as CVR.PartyContest', () => {
+  const { election: straightPartyElection } =
+    readElectionStraightPartyDefinition();
+  const report = buildCastVoteRecordReportMetadata({
+    election: straightPartyElection,
+    electionId,
+    generatingDeviceId: scannerId,
+    scannerIds: [scannerId],
+    reportTypes: [CVR.ReportType.OriginatingDeviceExport],
+    isTestMode: false,
+    batchInfo: [],
+  });
+
+  const contests = report.Election[0]!.Contest;
+  const partyContest = find(
+    contests,
+    (contest) => contest['@id'] === 'straight-party-ticket'
+  );
+  expect(partyContest).toEqual({
+    '@type': 'CVR.PartyContest',
+    '@id': 'straight-party-ticket',
+    Name: 'Straight Party',
+    ContestSelection: [
+      { '@type': 'CVR.PartySelection', '@id': '0', PartyIds: ['0'] },
+      { '@type': 'CVR.PartySelection', '@id': '1', PartyIds: ['1'] },
+      { '@type': 'CVR.PartySelection', '@id': '2', PartyIds: ['2'] },
+      { '@type': 'CVR.PartySelection', '@id': '3', PartyIds: ['3'] },
+      { '@type': 'CVR.PartySelection', '@id': '4', PartyIds: ['4'] },
+      { '@type': 'CVR.PartySelection', '@id': '5', PartyIds: ['5'] },
+      { '@type': 'CVR.PartySelection', '@id': '6', PartyIds: ['6'] },
+      { '@type': 'CVR.PartySelection', '@id': '7', PartyIds: ['7'] },
+      { '@type': 'CVR.PartySelection', '@id': '8', PartyIds: ['8'] },
+    ],
+  });
 });
 
 test('represents test mode as an "OtherReportType"', () => {

--- a/libs/backend/src/cast_vote_records/build_report_metadata.ts
+++ b/libs/backend/src/cast_vote_records/build_report_metadata.ts
@@ -1,4 +1,4 @@
-import { integers } from '@votingworks/basics';
+import { integers, throwIllegalValue } from '@votingworks/basics';
 import {
   Contest,
   BatchInfo,
@@ -6,8 +6,8 @@ import {
   CastVoteRecordBatchMetadata,
   CVR,
   Election,
-  straightPartyNotYetImplemented,
   YesNoContest,
+  StraightPartyContest,
 } from '@votingworks/types';
 
 /**
@@ -84,16 +84,37 @@ function buildBallotMeasureContest(
   };
 }
 
+function buildStraightPartyContest(
+  contest: StraightPartyContest
+): CVR.PartyContest {
+  return {
+    '@id': contest.id,
+    '@type': 'CVR.PartyContest',
+    Name: contest.title,
+    ContestSelection: contest.optionIds.map(
+      (partyId): CVR.PartySelection => ({
+        '@id': partyId,
+        '@type': 'CVR.PartySelection',
+        PartyIds: [partyId],
+      })
+    ),
+  };
+}
+
 function buildContest(
   contest: Contest
-): CVR.CandidateContest | CVR.BallotMeasureContest {
-  /* istanbul ignore next */
-  if (contest.type === 'straight-party') {
-    return straightPartyNotYetImplemented();
+): CVR.CandidateContest | CVR.BallotMeasureContest | CVR.PartyContest {
+  switch (contest.type) {
+    case 'candidate':
+      return buildCandidateContest(contest);
+    case 'yesno':
+      return buildBallotMeasureContest(contest);
+    case 'straight-party':
+      return buildStraightPartyContest(contest);
+    default:
+      /* istanbul ignore next */
+      throwIllegalValue(contest);
   }
-  return contest.type === 'candidate'
-    ? buildCandidateContest(contest)
-    : buildBallotMeasureContest(contest);
 }
 
 function buildElection({

--- a/libs/backend/vitest.config.ts
+++ b/libs/backend/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
       exclude: ['src/ui_strings/**'],
       thresholds: {
         lines: -15,
-        branches: -30,
+        branches: -31,
       },
     },
   },

--- a/libs/types/src/cdf/cast-vote-records/index.ts
+++ b/libs/types/src/cdf/cast-vote-records/index.ts
@@ -950,7 +950,7 @@ export interface CandidateContest {
   /**
    * Identifies the contest selections in the contest.
    */
-  readonly ContestSelection: ReadonlyArray<ContestSelection | BallotMeasureSelection | CandidateSelection>;
+  readonly ContestSelection: ReadonlyArray<ContestSelection | PartySelection | BallotMeasureSelection | CandidateSelection>;
 
   /**
    * Title or name of the contest, e.g., "Governor" or "Question on Legalization of Gambling".
@@ -991,7 +991,7 @@ export const CandidateContestSchema: z.ZodSchema<CandidateContest> = z.object({
   '@type': z.literal('CVR.CandidateContest'),
   Abbreviation: z.optional(z.string()),
   Code: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CodeSchema))),
-  ContestSelection: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSelectionSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureSelectionSchema), z.lazy(/* istanbul ignore next */ () => CandidateSelectionSchema)])).min(1),
+  ContestSelection: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSelectionSchema), z.lazy(/* istanbul ignore next */ () => PartySelectionSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureSelectionSchema), z.lazy(/* istanbul ignore next */ () => CandidateSelectionSchema)])).min(1),
   Name: z.optional(z.string()),
   NumberElected: z.optional(integerSchema),
   OtherVoteVariation: z.optional(z.string()),
@@ -1270,7 +1270,7 @@ export interface Election {
   /**
    * Used for establishing a collection of contest definitions that will be referenced by the CVRs.
    */
-  readonly Contest: ReadonlyArray<Contest | BallotMeasureContest | CandidateContest>;
+  readonly Contest: ReadonlyArray<Contest | PartyContest | BallotMeasureContest | CandidateContest>;
 
   /**
    * Used to identify the election scope, i.e., the political geography corresponding to the election.
@@ -1291,7 +1291,7 @@ export const ElectionSchema: z.ZodSchema<Election> = z.object({
   '@type': z.literal('CVR.Election'),
   Candidate: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CandidateSchema))),
   Code: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CodeSchema))),
-  Contest: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureContestSchema), z.lazy(/* istanbul ignore next */ () => CandidateContestSchema)])).min(1),
+  Contest: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSchema), z.lazy(/* istanbul ignore next */ () => PartyContestSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureContestSchema), z.lazy(/* istanbul ignore next */ () => CandidateContestSchema)])).min(1),
   ElectionScopeId: z.string(),
   Name: z.optional(z.string()),
 });
@@ -1479,6 +1479,88 @@ export const PartySchema: z.ZodSchema<Party> = z.object({
   Abbreviation: z.optional(z.string()),
   Code: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CodeSchema))),
   Name: z.optional(z.string()),
+});
+
+/**
+ * PartyContest is a subclass of Contest and is used to identify the type of contest as involving a straight party selection.  It inherits attributes from Contest.
+ */
+export interface PartyContest {
+  readonly '@id': string;
+
+  readonly '@type': 'CVR.PartyContest';
+
+  /**
+   * An abbreviation associated with the contest.
+   */
+  readonly Abbreviation?: string;
+
+  /**
+   * A code or identifier used for this contest.
+   */
+  readonly Code?: readonly Code[];
+
+  /**
+   * Identifies the contest selections in the contest.
+   */
+  readonly ContestSelection: ReadonlyArray<ContestSelection | PartySelection | BallotMeasureSelection | CandidateSelection>;
+
+  /**
+   * Title or name of the contest, e.g., "Governor" or "Question on Legalization of Gambling".
+   */
+  readonly Name?: string;
+
+  /**
+   * If VoteVariation is 'other', the vote variation for this contest.
+   */
+  readonly OtherVoteVariation?: string;
+
+  /**
+   * The vote variation for this contest, from the VoteVariation enumeration.
+   */
+  readonly VoteVariation?: VoteVariation;
+}
+
+/**
+ * Schema for {@link PartyContest}.
+ */
+export const PartyContestSchema: z.ZodSchema<PartyContest> = z.object({
+  '@id': z.string(),
+  '@type': z.literal('CVR.PartyContest'),
+  Abbreviation: z.optional(z.string()),
+  Code: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CodeSchema))),
+  ContestSelection: z.array(z.union([z.lazy(/* istanbul ignore next */ () => ContestSelectionSchema), z.lazy(/* istanbul ignore next */ () => PartySelectionSchema), z.lazy(/* istanbul ignore next */ () => BallotMeasureSelectionSchema), z.lazy(/* istanbul ignore next */ () => CandidateSelectionSchema)])).min(1),
+  Name: z.optional(z.string()),
+  OtherVoteVariation: z.optional(z.string()),
+  VoteVariation: z.optional(z.lazy(/* istanbul ignore next */ () => VoteVariationSchema)),
+});
+
+/**
+ * PartySelection is a subclass of ContestSelection and is used typically for a contest selection in a straight-party contest.
+ */
+export interface PartySelection {
+  readonly '@id': string;
+
+  readonly '@type': 'CVR.PartySelection';
+
+  /**
+   * Code used to identify the contest selection.
+   */
+  readonly Code?: readonly Code[];
+
+  /**
+   * The party associated with the contest selection.
+   */
+  readonly PartyIds: readonly string[];
+}
+
+/**
+ * Schema for {@link PartySelection}.
+ */
+export const PartySelectionSchema: z.ZodSchema<PartySelection> = z.object({
+  '@id': z.string(),
+  '@type': z.literal('CVR.PartySelection'),
+  Code: z.optional(z.array(z.lazy(/* istanbul ignore next */ () => CodeSchema))),
+  PartyIds: z.array(z.string()).min(1),
 });
 
 /**

--- a/libs/types/src/cdf/cast-vote-records/vx-schema.json
+++ b/libs/types/src/cdf/cast-vote-records/vx-schema.json
@@ -208,6 +208,7 @@
           "type": "string",
           "refTypes": [
             "CVR.Contest",
+            "CVR.PartyContest",
             "CVR.BallotMeasureContest",
             "CVR.CandidateContest"
           ]
@@ -249,6 +250,7 @@
           "type": "string",
           "refTypes": [
             "CVR.ContestSelection",
+            "CVR.PartySelection",
             "CVR.BallotMeasureSelection",
             "CVR.CandidateSelection"
           ]
@@ -406,6 +408,9 @@
             "oneOf": [
               {
                 "$ref": "#/definitions/CVR.ContestSelection"
+              },
+              {
+                "$ref": "#/definitions/CVR.PartySelection"
               },
               {
                 "$ref": "#/definitions/CVR.BallotMeasureSelection"
@@ -703,6 +708,9 @@
                 "$ref": "#/definitions/CVR.Contest"
               },
               {
+                "$ref": "#/definitions/CVR.PartyContest"
+              },
+              {
                 "$ref": "#/definitions/CVR.BallotMeasureContest"
               },
               {
@@ -869,6 +877,88 @@
         },
         "Name": {
           "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "CVR.PartyContest": {
+      "required": ["@id", "@type", "ContestSelection"],
+      "additionalProperties": false,
+      "properties": {
+        "@id": {
+          "type": "string"
+        },
+        "@type": {
+          "enum": ["CVR.PartyContest"],
+          "type": "string"
+        },
+        "Abbreviation": {
+          "type": "string"
+        },
+        "Code": {
+          "items": {
+            "$ref": "#/definitions/CVR.Code"
+          },
+          "minItems": 0,
+          "type": "array"
+        },
+        "ContestSelection": {
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/CVR.ContestSelection"
+              },
+              {
+                "$ref": "#/definitions/CVR.PartySelection"
+              },
+              {
+                "$ref": "#/definitions/CVR.BallotMeasureSelection"
+              },
+              {
+                "$ref": "#/definitions/CVR.CandidateSelection"
+              }
+            ]
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "OtherVoteVariation": {
+          "type": "string"
+        },
+        "VoteVariation": {
+          "$ref": "#/definitions/CVR.VoteVariation"
+        }
+      },
+      "type": "object"
+    },
+    "CVR.PartySelection": {
+      "required": ["@id", "@type", "PartyIds"],
+      "additionalProperties": false,
+      "properties": {
+        "@id": {
+          "type": "string"
+        },
+        "@type": {
+          "enum": ["CVR.PartySelection"],
+          "type": "string"
+        },
+        "Code": {
+          "items": {
+            "$ref": "#/definitions/CVR.Code"
+          },
+          "minItems": 0,
+          "type": "array"
+        },
+        "PartyIds": {
+          "items": {
+            "type": "string",
+            "refTypes": ["CVR.Party"]
+          },
+          "minItems": 1,
+          "type": "array"
         }
       },
       "type": "object"


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/7889
<!-- Add a link to a GitHub issue here -->
Adds support for straight party contest when building CVR reports. Updates our CDF CVR types using the PartyContest and PartySelection types from the NIST schema.

## Demo Video or Screenshot
N/A

## Testing Plan
Updated automated tests
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
