### PR TITLE
VxPrint: fold diagnostics screenshots into config/settings flow

### DIFF
--- a/apps/print/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/print/integration-testing/e2e/screenshots.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@votingworks/fixtures';
 import {
   buildIntegrationTestHelper,
+  captureReadinessReport,
   createScreenshotNamer,
 } from '@votingworks/integration-test-utils';
 import {
@@ -94,8 +95,11 @@ test('election manager: configuration and settings', async ({
   const electionDefinition = getElectionDefinition();
   const { election } = electionDefinition;
   const usbHandler = getMockFileUsbDriveHandler();
-  const { screenshot, screenshotWithButtonHighlight } =
-    buildIntegrationTestHelper(page, namer);
+  const {
+    screenshot,
+    screenshotWithButtonHighlight,
+    withContainerVerticallyExpanded,
+  } = buildIntegrationTestHelper(page, namer);
   const electionPackage = await buildElectionPackage(electionDefinition);
 
   // Locked, unconfigured: prompt to insert an election manager card.
@@ -240,6 +244,28 @@ test('election manager: configuration and settings', async ({
     .click();
   await page.getByRole('alertdialog').waitFor({ state: 'hidden' });
   await page.unroute('**/api/generateSignedHashValidationQrCodeValue');
+
+  // Diagnostics screen (full height — the readiness report content can exceed
+  // the viewport, so grow the window to capture it all).
+  await navigateTo(page, 'Diagnostics');
+  await page.getByRole('heading', { name: 'Diagnostics' }).waitFor();
+  await withContainerVerticallyExpanded('main', async () => {
+    await screenshot('em-diagnostics-full');
+  });
+
+  // Save the readiness report to the USB drive (still inserted from
+  // configuration), then capture the saved PDF.
+  await page.getByRole('button', { name: 'Save Readiness Report' }).click();
+  await page
+    .getByRole('alertdialog')
+    .getByRole('button', { name: 'Save' })
+    .click();
+  await page.getByText('Readiness Report Saved').waitFor();
+  await captureReadinessReport('readiness-report', namer);
+  await page
+    .getByRole('alertdialog')
+    .getByRole('button', { name: 'Close' })
+    .click();
 
   // Election screen — unconfigure machine.
   await navigateTo(page, 'Election');

--- a/vxsuite.code-workspace
+++ b/vxsuite.code-workspace
@@ -81,6 +81,10 @@
       "path": "apps/print/frontend"
     },
     {
+      "name": "apps/print/integration-testing",
+      "path": "apps/print/integration-testing"
+    },
+    {
       "name": "apps/scan/backend",
       "path": "apps/scan/backend"
     },


### PR DESCRIPTION
## Summary

- Merge the standalone `election manager: diagnostics` screenshot test into the `election manager: configuration and settings` test. The Diagnostics screen capture (`em-diagnostics-full`) and readiness report (`readiness-report`) are now produced from within the existing configured flow — between the Signed Hash Validation step and the final Unconfigure Machine step — instead of re-running `configureMachine` in a separate test.
- Add `apps/print/integration-testing` to the VS Code workspace folders, alongside the other apps' integration-testing entries.

## Testing

- `npx playwright test -g "election manager: configuration and settings"` passes; `em-diagnostics-full` and `readiness-report` screenshots are still generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)