### PR TITLE
VxPollbook: Fix re-throwing caught error after logging

### DIFF
--- a/apps/pollbook/backend/src/app.auth.test.ts
+++ b/apps/pollbook/backend/src/app.auth.test.ts
@@ -3,6 +3,7 @@ import { SignedHashValidationQrCodeValue } from '@votingworks/types';
 import { generateSignedHashValidationQrCodeValue } from '@votingworks/auth';
 import { electionSimpleSinglePrecinctFixtures } from '@votingworks/fixtures';
 import { CITIZEN_THERMAL_PRINTER_CONFIG } from '@votingworks/printing';
+import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import { withApp } from '../test/app';
 import {
   parseValidStreetsFromCsvString,
@@ -62,9 +63,11 @@ describe('generateSignedHashValidationQrCodeValue', () => {
         new Error('oops')
       );
 
-      await expect(
-        localApiClient.generateSignedHashValidationQrCodeValue
-      ).rejects.toThrow();
+      await suppressingConsoleOutput(() =>
+        expect(
+          localApiClient.generateSignedHashValidationQrCodeValue
+        ).rejects.toThrow()
+      );
     });
   });
 });

--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -760,7 +760,7 @@ function buildApi({ context, logger, barcodeScannerClient }: BuildAppParams) {
           message: (error as Error).message,
         });
 
-        throw err;
+        throw error;
       }
     },
 


### PR DESCRIPTION
## Overview
Fixes an issue where we intended to re-throw a caught error but throw the `err` function.

## Demo Video or Screenshot
n/a

## Testing Plan
Verified that the "oops" message from the tests showed in the output before intentionally suppressing it.