### PR TITLE
VxAdmin: Basic straight party contest adjudication

### DIFF
--- a/apps/admin/backend/src/tabulation/full_results.test.ts
+++ b/apps/admin/backend/src/tabulation/full_results.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { Buffer } from 'node:buffer';
+import { sha256 } from 'js-sha256';
 import {
   electionGridLayoutNewHampshireTestBallotFixtures,
   electionStraightPartyFixtures,
@@ -15,11 +16,11 @@ import {
 } from '@votingworks/utils';
 import { assert, assertDefined } from '@votingworks/basics';
 import {
+  AdjudicationReason,
   anyPollingPlace,
   BallotIdSchema,
   BallotStyleGroupId,
   BallotType,
-  CVR,
   DEFAULT_SYSTEM_SETTINGS,
   getContests,
   InterpretedBmdPage,
@@ -994,7 +995,9 @@ test('tabulateElectionResults - imports and derives straight-party votes', async
     );
   }
 
-  function buildStraightPartyCvr(id: string, votes: VotesDict): CVR.CVR {
+  function buildStraightPartyCvr(id: string, votes: VotesDict) {
+    const dummyImageContents = Buffer.from('dummy-ballot-image');
+    const dummyImageHash = sha256(dummyImageContents);
     const ballotId = unsafeParse(BallotIdSchema, id);
     const interpretation: InterpretedBmdPage = {
       type: 'InterpretedBmdPage',
@@ -1017,15 +1020,25 @@ test('tabulateElectionResults - imports and derives straight-party votes', async
         ignoredReasonInfos: [],
       },
     };
-    return buildCastVoteRecord({
-      electionDefinition,
-      electionId: ballotHash,
-      scannerId: 'VX-00-000',
-      castVoteRecordId: ballotId,
-      batchId: 'batch-1',
-      ballotMarkingMode: 'machine',
-      interpretation,
-    });
+    return {
+      castVoteRecord: buildCastVoteRecord({
+        electionDefinition,
+        electionId: ballotHash,
+        scannerId: 'VX-00-000',
+        castVoteRecordId: ballotId,
+        batchId: 'batch-1',
+        ballotMarkingMode: 'machine',
+        interpretation,
+        images: [
+          { imageHash: dummyImageHash, imageRelativePath: 'front.jpg' },
+          { imageHash: dummyImageHash, imageRelativePath: 'back.jpg' },
+        ],
+      }),
+      referencedFiles: [
+        { fileName: 'front.jpg', contents: dummyImageContents },
+        { fileName: 'back.jpg', contents: dummyImageContents },
+      ],
+    };
   }
 
   // Only vote the straight-party contest, letting the other partisan contest
@@ -1044,14 +1057,17 @@ test('tabulateElectionResults - imports and derives straight-party votes', async
       ...blankVotes(),
       'straight-party-ticket': ['1'],
     }),
+    buildStraightPartyCvr('cvr-4', {
+      ...blankVotes(),
+      // Overvote, which will require adjudication
+      'straight-party-ticket': ['0', '1'],
+    }),
   ];
 
   await writeCastVoteRecordExport({
     exportDirectoryPath,
     electionDefinition,
-    castVoteRecords: castVoteRecords.map((castVoteRecord) => ({
-      castVoteRecord,
-    })),
+    castVoteRecords,
     pollingPlaceId: anyPollingPlace(election).id,
     isTestMode: true,
   });
@@ -1060,7 +1076,10 @@ test('tabulateElectionResults - imports and derives straight-party votes', async
   const logger = mockBaseLogger({ fn: vi.fn });
   const electionId = store.addElection({
     electionData: electionDefinition.electionData,
-    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    systemSettingsData: JSON.stringify({
+      ...DEFAULT_SYSTEM_SETTINGS,
+      adminAdjudicationReasons: [AdjudicationReason.Overvote],
+    }),
     electionPackageFileContents: Buffer.of(),
     electionPackageHash: 'test-election-package-hash',
   });
@@ -1072,35 +1091,88 @@ test('tabulateElectionResults - imports and derives straight-party votes', async
     logger
   );
   const { id: fileId } = importResult.unsafeUnwrap();
-  expect(store.getCastVoteRecordCountByFileId(fileId)).toEqual(3);
+  expect(store.getCastVoteRecordCountByFileId(fileId)).toEqual(4);
 
-  const results = (await tabulateElectionResults({ electionId, store }))[
-    GROUP_KEY
-  ];
-  assert(results);
-
-  const expectedResults = buildElectionResultsFixture({
+  const resultsBeforeAdjudication = (
+    await tabulateElectionResults({ electionId, store })
+  )[GROUP_KEY];
+  assert(resultsBeforeAdjudication);
+  const expectedResultsBeforeAdjudication = buildElectionResultsFixture({
     election,
-    cardCounts: { bmd: [3], hmpb: [] },
+    cardCounts: { bmd: [4], hmpb: [] },
     contestResultsSummaries: {
       'straight-party-ticket': {
         type: 'straight-party',
-        ballots: 3,
+        ballots: 4,
+        overvotes: 1,
         optionTallies: { '0': 2, '1': 1 },
       },
       president: {
         type: 'candidate',
-        ballots: 3,
+        ballots: 4,
+        undervotes: 1,
         officialOptionTallies: { 'barchi-hallaren': 2, 'cramer-vuocolo': 1 },
       },
     },
     includeGenericWriteIn: true,
   });
-
-  expect(results.contestResults['straight-party-ticket']).toEqual(
-    expectedResults.contestResults['straight-party-ticket']
+  expect(
+    resultsBeforeAdjudication.contestResults['straight-party-ticket']
+  ).toEqual(
+    expectedResultsBeforeAdjudication.contestResults['straight-party-ticket']
   );
-  expect(results.contestResults['president']).toEqual(
-    expectedResults.contestResults['president']
+  expect(resultsBeforeAdjudication.contestResults['president']).toEqual(
+    expectedResultsBeforeAdjudication.contestResults['president']
+  );
+
+  const queue = store.getBallotAdjudicationQueue({ electionId });
+  expect(queue).toHaveLength(1);
+  const [cvrId] = queue;
+  assert(cvrId !== undefined);
+  adjudicateCvr(
+    {
+      cvrId,
+      contests: [
+        {
+          contestId: 'straight-party-ticket',
+          adjudicatedContestOptionById: {
+            '1': { type: 'official-option', hasVote: false },
+          },
+        },
+      ],
+    },
+    'test-machine',
+    store,
+    logger
+  );
+
+  const resultsAfterAdjudication = (
+    await tabulateElectionResults({ electionId, store })
+  )[GROUP_KEY];
+  assert(resultsAfterAdjudication);
+  const expectedResultsAfterAdjudication = buildElectionResultsFixture({
+    election,
+    cardCounts: { bmd: [4], hmpb: [] },
+    contestResultsSummaries: {
+      'straight-party-ticket': {
+        type: 'straight-party',
+        ballots: 4,
+        optionTallies: { '0': 3, '1': 1 },
+      },
+      president: {
+        type: 'candidate',
+        ballots: 4,
+        officialOptionTallies: { 'barchi-hallaren': 3, 'cramer-vuocolo': 1 },
+      },
+    },
+    includeGenericWriteIn: true,
+  });
+  expect(
+    resultsAfterAdjudication.contestResults['straight-party-ticket']
+  ).toEqual(
+    expectedResultsAfterAdjudication.contestResults['straight-party-ticket']
+  );
+  expect(resultsAfterAdjudication.contestResults['president']).toEqual(
+    expectedResultsAfterAdjudication.contestResults['president']
   );
 });

--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -191,6 +191,7 @@ function getAdjudicatedContestStatusLine(
 }
 
 function getAdjudicatedOptionStatusLine(
+  election: Election,
   option: ContestOptionAdjudicationData,
   contest: Contest,
   adjudicatedOption?: AdjudicatedContestOption
@@ -240,8 +241,8 @@ function getAdjudicatedOptionStatusLine(
     const newValue = currentVote ? 'valid' : 'invalid';
     return (
       <StatusLineAdjudicated>
-        Marginal mark for {contestOptionName(contest, definition)} adjudicated
-        as {newValue}
+        Marginal mark for {contestOptionName(election, contest, definition)}{' '}
+        adjudicated as {newValue}
       </StatusLineAdjudicated>
     );
   }
@@ -251,8 +252,8 @@ function getAdjudicatedOptionStatusLine(
     const newValue = currentVote ? 'valid' : 'invalid';
     return (
       <StatusLineAdjudicated>
-        {preface} for {contestOptionName(contest, definition)} adjudicated as{' '}
-        {newValue}
+        {preface} for {contestOptionName(election, contest, definition)}{' '}
+        adjudicated as {newValue}
       </StatusLineAdjudicated>
     );
   }
@@ -262,10 +263,12 @@ function ContestAdjudicationSummary({
   item,
   showUndervoteStatus,
   adjudicatedContest,
+  election,
 }: {
   item: ContestListItem;
   showUndervoteStatus: boolean;
   adjudicatedContest?: AdjudicatedCvrContest;
+  election: Election;
 }): JSX.Element | null {
   if (!adjudicatedContest) {
     const { tag } = item.adjudicationData;
@@ -310,6 +313,7 @@ function ContestAdjudicationSummary({
   const optionLines = item.adjudicationData.options.map((option) => (
     <React.Fragment key={option.definition.id}>
       {getAdjudicatedOptionStatusLine(
+        election,
         option,
         item.contest,
         adjudicatedContest.adjudicatedContestOptionById[option.definition.id]
@@ -460,6 +464,7 @@ function BallotSideContestList({
                     item={item}
                     showUndervoteStatus={showUndervoteStatus}
                     adjudicatedContest={adjudicatedContest}
+                    election={election}
                   />
                 )}
               </Column>

--- a/apps/admin/frontend/src/components/adjudication_contest_list.tsx
+++ b/apps/admin/frontend/src/components/adjudication_contest_list.tsx
@@ -7,7 +7,6 @@ import {
   Election,
   getContestDistrictName,
   Side,
-  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import type {
   AdjudicatedContestOption,
@@ -124,11 +123,7 @@ const StatusLineAdjudicated = styled(StatusLine).attrs({
 `;
 
 function getVotesAllowed(contest: Contest): number {
-  /* istanbul ignore next */
-  if (contest.type === 'straight-party') {
-    return straightPartyNotYetImplemented();
-  }
-  return contest.type === 'yesno' ? 1 : contest.seats;
+  return contest.type === 'candidate' ? contest.seats : 1;
 }
 
 type VoteStatus = 'overvote' | 'undervote' | 'normal';

--- a/apps/admin/frontend/src/components/contest_option_button.tsx
+++ b/apps/admin/frontend/src/components/contest_option_button.tsx
@@ -21,7 +21,7 @@ const StyledCheckboxButton = styled(CheckboxButton)<{
 `;
 
 interface Props {
-  option: { id: Id; label: string };
+  option: { id: Id; label: React.ReactNode };
   isSelected: boolean;
   marginalMarkStatus?: MarginalMarkStatus;
   onSelect: () => void;

--- a/apps/admin/frontend/src/components/contest_option_button.tsx
+++ b/apps/admin/frontend/src/components/contest_option_button.tsx
@@ -10,9 +10,14 @@ import {
 
 const StyledCheckboxButton = styled(CheckboxButton)<{
   onlyRoundBottom?: boolean;
+  primaryOutline?: boolean;
 }>`
   border-radius: ${({ onlyRoundBottom }) =>
     onlyRoundBottom ? '0 0 0.5rem 0.5rem' : '0.5rem'};
+  border-color: ${(p) =>
+    p.primaryOutline ? p.theme.colors.primary : undefined};
+  background-color: ${(p) =>
+    p.primaryOutline ? p.theme.colors.containerLow : undefined};
 `;
 
 interface Props {
@@ -24,6 +29,7 @@ interface Props {
   onDismissFlag?: () => void;
   caption?: React.ReactNode;
   disabled?: boolean;
+  isDerivedVote?: boolean;
 }
 
 export const ContestOptionButton = forwardRef<HTMLDivElement, Props>(
@@ -37,6 +43,7 @@ export const ContestOptionButton = forwardRef<HTMLDivElement, Props>(
       onDismissFlag,
       caption,
       disabled,
+      isDerivedVote,
     },
     ref
   ) => {
@@ -51,9 +58,10 @@ export const ContestOptionButton = forwardRef<HTMLDivElement, Props>(
         <StyledCheckboxButton
           key={option.id}
           label={option.label}
-          isChecked={isSelected}
+          isChecked={isSelected || Boolean(isDerivedVote)}
           disabled={disabled}
           onlyRoundBottom={showMarginalMarkFlag}
+          primaryOutline={isDerivedVote}
           onChange={() => {
             if (!isSelected) {
               onSelect();

--- a/apps/admin/frontend/src/hooks/use_contest_adjudication_state.test.ts
+++ b/apps/admin/frontend/src/hooks/use_contest_adjudication_state.test.ts
@@ -9,6 +9,7 @@ import {
   CandidateContest,
   Contest,
   ContestOption,
+  Election,
   YesNoContest,
 } from '@votingworks/types';
 import { act, renderHook } from '@testing-library/react';
@@ -40,6 +41,17 @@ const yesNoContest: YesNoContest = {
   noOption: { id: 'no', label: 'No' },
 };
 
+const election: Pick<Election, 'parties'> = {
+  parties: [
+    {
+      id: 'party',
+      name: 'Party',
+      fullName: 'Party Full Name',
+      abbrev: 'P',
+    },
+  ],
+};
+
 function makeOption(
   definition: ContestOption,
   overrides: Partial<Omit<ContestOptionAdjudicationData, 'definition'>> = {}
@@ -61,6 +73,7 @@ function renderAdjudicationState(
 ) {
   return renderHook(() =>
     useContestAdjudicationState({
+      election,
       contestAdjudicationData,
       writeInCandidates,
       contest,

--- a/apps/admin/frontend/src/hooks/use_contest_adjudication_state.ts
+++ b/apps/admin/frontend/src/hooks/use_contest_adjudication_state.ts
@@ -8,7 +8,10 @@ import type {
 import type { ContestOptionId, Contest } from '@votingworks/types';
 import { assert, assertDefined, deepEqual, find } from '@votingworks/basics';
 
-import { contestOptionName } from '@votingworks/utils';
+import {
+  contestOptionName,
+  deriveStraightPartyVotesForContest,
+} from '@votingworks/utils';
 import type { DoubleVoteAlert } from '../components/adjudication_double_vote_alert_modal';
 import { normalizeWriteInName } from '../utils/adjudication';
 
@@ -89,6 +92,7 @@ export function useContestAdjudicationState(initialValues: {
   writeInCandidates: WriteInCandidateRecord[];
   contest: Contest;
   adjudicatedOptions?: AdjudicatedContestOptions;
+  selectedStraightPartyId?: string;
 }): {
   setOptionHasVote: (optionId: ContestOptionId, hasVote: boolean) => void;
   getOptionHasVote: (optionId: ContestOptionId) => boolean;
@@ -116,12 +120,14 @@ export function useContestAdjudicationState(initialValues: {
   firstOptionIdPendingAdjudication?: ContestOptionId;
   selectedCandidateNames: string[];
   voteCount: number;
+  derivedStraightPartyVotes: ContestOptionId[];
 } {
   const {
     contestAdjudicationData,
     contest,
     adjudicatedOptions = {},
     writeInCandidates,
+    selectedStraightPartyId,
   } = initialValues;
   const [optionState, setState] =
     useState<AdjudicatedContestOptions>(adjudicatedOptions);
@@ -370,7 +376,16 @@ export function useContestAdjudicationState(initialValues: {
     return result;
   }
 
-  const voteCount = optionsList.filter((o) => getOptionHasVote(o.id)).length;
+  const votedOptionIds = optionsList
+    .filter((o) => getOptionHasVote(o.id))
+    .map((o) => o.id);
+  const derivedStraightPartyVotes = deriveStraightPartyVotesForContest(
+    contest,
+    votedOptionIds,
+    selectedStraightPartyId
+  );
+
+  const voteCount = votedOptionIds.length + derivedStraightPartyVotes.length;
 
   const isModified = !deepEqual(optionState, adjudicatedOptions);
 
@@ -388,5 +403,6 @@ export function useContestAdjudicationState(initialValues: {
     firstOptionIdPendingAdjudication,
     selectedCandidateNames,
     voteCount,
+    derivedStraightPartyVotes,
   };
 }

--- a/apps/admin/frontend/src/hooks/use_contest_adjudication_state.ts
+++ b/apps/admin/frontend/src/hooks/use_contest_adjudication_state.ts
@@ -5,7 +5,7 @@ import type {
   ContestAdjudicationData,
   WriteInCandidateRecord,
 } from '@votingworks/admin-backend';
-import type { ContestOptionId, Contest } from '@votingworks/types';
+import type { ContestOptionId, Contest, Election } from '@votingworks/types';
 import { assert, assertDefined, deepEqual, find } from '@votingworks/basics';
 
 import {
@@ -88,6 +88,7 @@ export function isMarginalMarkPending(
 }
 
 export function useContestAdjudicationState(initialValues: {
+  election: Pick<Election, 'parties'>;
   contestAdjudicationData: ContestAdjudicationData;
   writeInCandidates: WriteInCandidateRecord[];
   contest: Contest;
@@ -123,6 +124,7 @@ export function useContestAdjudicationState(initialValues: {
   derivedStraightPartyVotes: ContestOptionId[];
 } {
   const {
+    election,
     contestAdjudicationData,
     contest,
     adjudicatedOptions = {},
@@ -136,7 +138,7 @@ export function useContestAdjudicationState(initialValues: {
     .filter((o) => o.definition.type !== 'candidate' || !o.definition.isWriteIn)
     .map((o) => ({
       ...o.definition,
-      name: contestOptionName(contest, o.definition),
+      name: contestOptionName(election, contest, o.definition),
     }));
 
   function getOptionState(

--- a/apps/admin/frontend/src/hooks/use_contest_adjudication_state.ts
+++ b/apps/admin/frontend/src/hooks/use_contest_adjudication_state.ts
@@ -5,7 +5,12 @@ import type {
   ContestAdjudicationData,
   WriteInCandidateRecord,
 } from '@votingworks/admin-backend';
-import type { ContestOptionId, Contest, Election } from '@votingworks/types';
+import type {
+  ContestOptionId,
+  Contest,
+  Election,
+  PartyId,
+} from '@votingworks/types';
 import { assert, assertDefined, deepEqual, find } from '@votingworks/basics';
 
 import {
@@ -93,7 +98,7 @@ export function useContestAdjudicationState(initialValues: {
   writeInCandidates: WriteInCandidateRecord[];
   contest: Contest;
   adjudicatedOptions?: AdjudicatedContestOptions;
-  selectedStraightPartyId?: string;
+  selectedStraightPartyId?: PartyId;
 }): {
   setOptionHasVote: (optionId: ContestOptionId, hasVote: boolean) => void;
   getOptionHasVote: (optionId: ContestOptionId) => boolean;

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, expect, test } from 'vitest';
 import {
   electionOpenPrimaryFixtures,
+  electionStraightPartyFixtures,
   readElectionTwoPartyPrimaryDefinition,
 } from '@votingworks/fixtures';
 import {
@@ -8,7 +9,6 @@ import {
   BallotType,
   DEFAULT_SYSTEM_SETTINGS,
   Election,
-  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import type { BallotPageLayout, Rect } from '@votingworks/types';
 import type {
@@ -46,6 +46,9 @@ const { election: primaryElection } = electionDefinition;
 const openPrimaryDefinition =
   electionOpenPrimaryFixtures.readElectionDefinition();
 const openPrimaryElection = openPrimaryDefinition.election;
+const straightPartyElectionDefinition =
+  electionStraightPartyFixtures.readElectionDefinition();
+const straightPartyElection = straightPartyElectionDefinition.election;
 
 let apiMock: ApiMock;
 
@@ -97,9 +100,20 @@ function makeContestAdjudicationData(
       tag,
     };
   }
-  /* istanbul ignore next */
   if (contest.type === 'straight-party') {
-    straightPartyNotYetImplemented();
+    return {
+      contestId,
+      options: contest.optionIds.map((partyId) => ({
+        definition: {
+          id: partyId,
+          contestId,
+          type: 'straight-party' as const,
+        },
+        scannedVote: false,
+        hasMarginalMark: false,
+      })),
+      tag,
+    };
   }
   return {
     contestId,
@@ -2165,6 +2179,96 @@ test('crossover voting created indicator persists when the ballot is resolved', 
   getContestListItem(/Democratic Party/).getByText('Crossover vote created');
   getContestListItem(/Republican Party/).getByText('Crossover vote created');
   expect(screen.queryByText(/Crossover Voting/)).toBeNull();
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves();
+});
+
+test('straight party derived votes update when the straight party contest is adjudicated', async () => {
+  const straightPartyContest = makeContestAdjudicationData(
+    'straight-party-ticket',
+    makeContestTag({ hasWriteIn: false }),
+    straightPartyElection
+  );
+  // Set up a scanned straight party vote for the Federalist Party
+  assertDefined(
+    straightPartyContest.options.find((o) => o.definition.id === '0')
+  ).scannedVote = true;
+  const presidentContest = makeContestAdjudicationData(
+    'president',
+    makeContestTag({ hasWriteIn: false }),
+    straightPartyElection
+  );
+  const adjData = makeBallotAdjudicationData(CVR_ID_1, [
+    straightPartyContest,
+    presidentContest,
+  ]);
+
+  const ballotCoordinates = { x: 0, y: 0, width: 1000, height: 1000 } as const;
+  const ballotImages: BallotImages = {
+    cvrId: CVR_ID_1,
+    front: {
+      type: 'hmpb',
+      imageUrl: `mock-front-image-${CVR_ID_1}`,
+      ballotCoordinates,
+      layout: makeHmpbPageLayout(['straight-party-ticket', 'president']),
+    },
+    back: {
+      type: 'hmpb',
+      imageUrl: `mock-back-image-${CVR_ID_1}`,
+      ballotCoordinates,
+      layout: makeHmpbPageLayout([]),
+    },
+  };
+
+  apiMock.expectGetBallotAdjudicationQueue([CVR_ID_1]);
+  apiMock.expectGetNextCvrIdForBallotAdjudication(CVR_ID_1);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    adjData.contests.map((c) => c.contestId)
+  );
+  apiMock.expectGetSystemSettings();
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.apiClient.getBallotImages
+    .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves(ballotImages);
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition: straightPartyElectionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText(/Ballot ID:/);
+
+  // Federalist candidate in President should show as a derived vote
+  userEvent.click(screen.getByText('President and Vice-President'));
+  expect(
+    await screen.findByRole('checkbox', { name: /Barchi/i })
+  ).toHaveTextContent('Federalist Party - Straight party vote');
+  expect(screen.getByRole('checkbox', { name: /Barchi/i })).toBeChecked();
+  expect(
+    screen.getByRole('checkbox', { name: /Cramer/i })
+  ).not.toHaveTextContent('Straight party vote');
+  expect(screen.getByRole('checkbox', { name: /Cramer/i })).not.toBeChecked();
+  userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+  // Adjudicate the straight party contest from Federalist to People's Party
+  userEvent.click(await screen.findByText('Straight Party'));
+  userEvent.click(await screen.findByRole('checkbox', { name: /Federalist/i }));
+  userEvent.click(screen.getByRole('checkbox', { name: /People/i }));
+  userEvent.click(screen.getByRole('button', { name: /Confirm/ }));
+
+  // The derived vote has updated to the People's Party candidate
+  userEvent.click(await screen.findByText('President and Vice-President'));
+  expect(
+    await screen.findByRole('checkbox', { name: /Cramer/i })
+  ).toHaveTextContent('Straight party vote');
+  expect(screen.getByRole('checkbox', { name: /Cramer/i })).toBeChecked();
+  expect(
+    screen.getByRole('checkbox', { name: /Barchi/i })
+  ).not.toHaveTextContent('Straight party vote');
+  expect(screen.getByRole('checkbox', { name: /Barchi/i })).not.toBeChecked();
 
   apiMock.apiClient.releaseBallotAdjudicationClaim
     .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -534,6 +534,7 @@ export function BallotAdjudicationScreen(
     election
   );
   const votesAfterAdjudication = adjudicatedVotes(
+    election,
     contestItems,
     adjudicatedContests
   );

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -41,9 +41,11 @@ import { AppContext } from '../contexts/app_context';
 import { ContestAdjudicationScreen } from './contest_adjudication_screen';
 import {
   AdjudicatedContests,
+  adjudicatedVotes,
   ContestListItem,
   deriveCrossoverVoteStatus,
   isContestTagOnlyUndervote,
+  selectedStraightPartyIdAfterAdjudication,
 } from '../utils/adjudication';
 import { DiscardChangesModal } from '../components/discard_changes_modal';
 
@@ -505,6 +507,8 @@ export interface BallotAdjudicationScreenProps {
 export function BallotAdjudicationScreen(
   props: BallotAdjudicationScreenProps
 ): JSX.Element {
+  const { electionDefinition } = useContext(AppContext);
+  const { election } = assertDefined(electionDefinition);
   const {
     cvrId,
     ballotAdjudicationData,
@@ -522,6 +526,21 @@ export function BallotAdjudicationScreen(
   );
   const [adjudicatedContests, setAdjudicatedContests] =
     useState<AdjudicatedContests>(adjudicatedContestsBaseline);
+
+  const contestItems = contestListItems(
+    ballotImages,
+    ballotAdjudicationData.contests,
+    adjudicatedContests,
+    election
+  );
+  const votesAfterAdjudication = adjudicatedVotes(
+    contestItems,
+    adjudicatedContests
+  );
+  const selectedStraightPartyId = selectedStraightPartyIdAfterAdjudication(
+    election,
+    votesAfterAdjudication
+  );
 
   if (selectedContestId && !isClaimed) {
     return (
@@ -548,6 +567,7 @@ export function BallotAdjudicationScreen(
             new Map(prev).set(input.contestId, input)
           );
         }}
+        selectedStraightPartyId={selectedStraightPartyId}
       />
     );
   }
@@ -559,6 +579,7 @@ export function BallotAdjudicationScreen(
         !deepEqual(adjudicatedContests, adjudicatedContestsBaseline)
       }
       setSelectedContestId={setSelectedContestId}
+      contestItems={contestItems}
       {...props}
     />
   );
@@ -568,6 +589,7 @@ function BallotView({
   adjudicatedContests,
   haveEditsBeenMade,
   setSelectedContestId,
+  contestItems,
   cvrId,
   ballotAdjudicationData,
   ballotImages,
@@ -585,17 +607,11 @@ function BallotView({
   adjudicatedContests: AdjudicatedContests;
   haveEditsBeenMade: boolean;
   setSelectedContestId: (contestId: ContestId | null) => void;
+  contestItems: ContestListItem[];
 } & Omit<BallotAdjudicationScreenProps, 'writeInCandidates'>): React.ReactNode {
   const { electionDefinition } = useContext(AppContext);
   const { election } = assertDefined(electionDefinition);
-  const { tag: cvrTag, contests: contestAdjudicationData } =
-    ballotAdjudicationData;
-  const contestItems = contestListItems(
-    ballotImages,
-    contestAdjudicationData,
-    adjudicatedContests,
-    election
-  );
+  const { tag: cvrTag } = ballotAdjudicationData;
   const firstUnresolvedContest =
     cvrTag.isBlankBallot || cvrTag.hasCrossoverVote
       ? undefined

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import {
   readElectionTwoPartyPrimaryDefinition,
   electionFamousNames2021Fixtures,
+  electionStraightPartyFixtures,
 } from '@votingworks/fixtures';
 import {
   BallotStyleGroupId,
@@ -252,6 +253,7 @@ function renderScreen(
     writeInCandidates = [] as WriteInCandidateRecord[],
     onConfirmContest = vi.fn(),
     adjudicatedOptions,
+    selectedStraightPartyId,
   }: {
     areWriteInCandidatesQualified?: boolean;
     ballotImages?: BallotImages;
@@ -261,6 +263,7 @@ function renderScreen(
     writeInCandidates?: WriteInCandidateRecord[];
     onConfirmContest?: (input: AdjudicatedCvrContest) => void;
     adjudicatedOptions?: AdjudicatedContestOptions;
+    selectedStraightPartyId?: string;
   } = {}
 ) {
   const images =
@@ -279,6 +282,7 @@ function renderScreen(
         writeInCandidates={writeInCandidates}
         onConfirmContest={onConfirmContest}
         adjudicatedOptions={adjudicatedOptions}
+        selectedStraightPartyId={selectedStraightPartyId}
       />,
       { electionDefinition: electionDef, apiMock }
     ),
@@ -1817,5 +1821,84 @@ describe('candidate ordering', () => {
       name: /Thomas Edison/i,
     });
     expect(edisonCheckboxes).toHaveLength(1);
+  });
+});
+
+describe('straight party voting', () => {
+  const straightPartyElectionDefinition =
+    electionStraightPartyFixtures.readElectionDefinition();
+  const cvrId = 'sp-cvr';
+
+  test('renders derived straight-party votes as checked', async () => {
+    const data = buildContestAdjudicationData({
+      electionDef: straightPartyElectionDefinition,
+      contestId: 'president',
+    });
+    renderScreen(data, cvrId, {
+      electionDef: straightPartyElectionDefinition,
+      ballotImages: buildBmdBallotImages(cvrId),
+      selectedStraightPartyId: '0',
+    });
+
+    await waitForBallotById(cvrId);
+
+    expect(getCheckboxByName('Barchi')).toBeChecked();
+    expect(getCheckboxByName('Cramer')).not.toBeChecked();
+  });
+
+  test('captions candidates with their party name and "Straight party vote"', async () => {
+    const data = buildContestAdjudicationData({
+      electionDef: straightPartyElectionDefinition,
+      contestId: 'president',
+      votes: ['barchi-hallaren'],
+    });
+    renderScreen(data, cvrId, {
+      electionDef: straightPartyElectionDefinition,
+      ballotImages: buildBmdBallotImages(cvrId),
+      selectedStraightPartyId: '0',
+    });
+
+    await waitForBallotById(cvrId);
+
+    const partyCheckbox = getCheckboxByName('Barchi');
+    expect(partyCheckbox).toHaveTextContent(
+      'Federalist Party - Straight party vote'
+    );
+    const otherPartyCheckbox = getCheckboxByName('Cramer');
+    expect(otherPartyCheckbox).toHaveTextContent('People');
+    expect(otherPartyCheckbox).not.toHaveTextContent('Straight party vote');
+  });
+
+  test('omits candidate party caption for candidates without a party', async () => {
+    const data = buildContestAdjudicationData({
+      electionDef: straightPartyElectionDefinition,
+      contestId: 'county-registrar-of-wills',
+    });
+    renderScreen(data, cvrId, {
+      electionDef: straightPartyElectionDefinition,
+      ballotImages: buildBmdBallotImages(cvrId),
+      selectedStraightPartyId: '0',
+    });
+
+    await waitForBallotById(cvrId);
+
+    expect(getCheckboxByName('Ramachandrani')).toBeInTheDocument();
+    expect(screen.queryByText(/Straight party vote/)).not.toBeInTheDocument();
+  });
+
+  test('omits option party caption for non-candidate contests', async () => {
+    const data = buildContestAdjudicationData({
+      electionDef: straightPartyElectionDefinition,
+      contestId: 'question-a',
+    });
+    renderScreen(data, cvrId, {
+      electionDef: straightPartyElectionDefinition,
+      ballotImages: buildBmdBallotImages(cvrId),
+      selectedStraightPartyId: '0',
+    });
+
+    await waitForBallotById(cvrId);
+
+    expect(screen.queryByText(/Straight party vote/)).not.toBeInTheDocument();
   });
 });

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
@@ -7,7 +7,14 @@ import {
   useState,
 } from 'react';
 import styled from 'styled-components';
-import { getContestDistrictName, Id } from '@votingworks/types';
+import {
+  CandidateContest,
+  CandidateId,
+  Election,
+  getContestDistrictName,
+  Id,
+  PartyId,
+} from '@votingworks/types';
 import { Button, Main, Screen, Icons, H2, H1, P } from '@votingworks/ui';
 import { assert, assertDefined, find } from '@votingworks/basics';
 import type {
@@ -121,6 +128,10 @@ const ContestOptionButtonCaption = styled.span`
   margin: 0.25rem 0 0.25rem 0.125rem;
 `;
 
+const ContestOptionPartyCaption = styled.div`
+  font-size: 0.75rem;
+`;
+
 const CompactH1 = styled(H1)`
   font-size: 1.125rem;
   margin: 0;
@@ -192,6 +203,32 @@ function renderContestOptionButtonCaption({
   );
 }
 
+function CandidateOptionPartyCaption({
+  contest,
+  candidateId,
+  election,
+  selectedStraightPartyId,
+}: {
+  contest: CandidateContest;
+  candidateId: CandidateId;
+  election: Election;
+  selectedStraightPartyId?: PartyId;
+}) {
+  const candidate = find(contest.candidates, (c) => c.id === candidateId);
+  const parties = (candidate.partyIds ?? []).map((partyId) =>
+    find(election.parties, (party) => party.id === partyId)
+  );
+  if (parties.length === 0) return null;
+  const partyNames = parties.map((p) => p.fullName).join(', ');
+  return (
+    <ContestOptionPartyCaption>
+      {partyNames}
+      {parties.some((party) => party.id === selectedStraightPartyId) &&
+        ' - Straight party vote'}
+    </ContestOptionPartyCaption>
+  );
+}
+
 interface ContestAdjudicationScreenProps {
   areWriteInCandidatesQualified: boolean;
   ballotImages: BallotImages;
@@ -201,7 +238,7 @@ interface ContestAdjudicationScreenProps {
   onConfirmContest: (input: AdjudicatedCvrContest) => void;
   adjudicatedOptions?: AdjudicatedContestOptions;
   writeInCandidates: WriteInCandidateRecord[];
-  selectedStraightPartyId?: string;
+  selectedStraightPartyId?: PartyId;
 }
 
 export function ContestAdjudicationScreen({
@@ -223,6 +260,9 @@ export function ContestAdjudicationScreen({
   const contest = find(election.contests, (c) => c.id === contestId);
   const isCandidateContest = contest.type === 'candidate';
   const partyLabel = contestPartyLabel(election, contest);
+  const electionHasStraightPartyContest = election.contests.some(
+    (c) => c.type === 'straight-party'
+  );
 
   const officialOptions = useMemo(
     () =>
@@ -403,11 +443,25 @@ export function ContestAdjudicationScreen({
           </BallotVoteCount>
           <ContestOptionButtonList role="listbox">
             {officialOptions.map((officialOption) => {
-              const { id: optionId, name: optionLabel } = officialOption;
+              const { id: optionId, name: optionName } = officialOption;
+
               const { scannedVote } = assertDefined(
                 contestOptions.find((o) => o.definition.id === optionId)
               );
               const currentVote = getOptionHasVote(optionId);
+              const optionLabel = (
+                <div>
+                  <div>{optionName}</div>
+                  {electionHasStraightPartyContest && isCandidateContest && (
+                    <CandidateOptionPartyCaption
+                      contest={contest}
+                      candidateId={optionId}
+                      election={election}
+                      selectedStraightPartyId={selectedStraightPartyId}
+                    />
+                  )}
+                </div>
+              );
               const isDerivedVote =
                 derivedStraightPartyVotes.includes(optionId);
               const marginalMarkStatus = getOptionMarginalMarkStatus(optionId);
@@ -435,7 +489,7 @@ export function ContestAdjudicationScreen({
                     isBmd ||
                     // Disabled when there is a write-in selection for the candidate
                     (!currentVote &&
-                      selectedCandidateNames.includes(optionLabel))
+                      selectedCandidateNames.includes(optionName))
                   }
                   caption={renderContestOptionButtonCaption({
                     scannedVote,

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
@@ -201,6 +201,7 @@ interface ContestAdjudicationScreenProps {
   onConfirmContest: (input: AdjudicatedCvrContest) => void;
   adjudicatedOptions?: AdjudicatedContestOptions;
   writeInCandidates: WriteInCandidateRecord[];
+  selectedStraightPartyId?: string;
 }
 
 export function ContestAdjudicationScreen({
@@ -212,6 +213,7 @@ export function ContestAdjudicationScreen({
   onConfirmContest,
   adjudicatedOptions,
   writeInCandidates,
+  selectedStraightPartyId,
 }: ContestAdjudicationScreenProps): JSX.Element {
   const { electionDefinition } = useContext(AppContext);
   assert(electionDefinition);
@@ -257,11 +259,13 @@ export function ContestAdjudicationScreen({
     firstOptionIdPendingAdjudication,
     selectedCandidateNames,
     voteCount,
+    derivedStraightPartyVotes,
   } = useContestAdjudicationState({
     contestAdjudicationData,
     writeInCandidates,
     contest,
     adjudicatedOptions,
+    selectedStraightPartyId,
   });
 
   // Vote and write-in state for adjudication management
@@ -403,11 +407,14 @@ export function ContestAdjudicationScreen({
                 contestOptions.find((o) => o.definition.id === optionId)
               );
               const currentVote = getOptionHasVote(optionId);
+              const isDerivedVote =
+                derivedStraightPartyVotes.includes(optionId);
               const marginalMarkStatus = getOptionMarginalMarkStatus(optionId);
               return (
                 <ContestOptionButton
                   key={optionId + cvrId}
                   isSelected={currentVote}
+                  isDerivedVote={isDerivedVote}
                   marginalMarkStatus={marginalMarkStatus}
                   ref={
                     optionId === firstOptionIdPendingAdjudication

--- a/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/contest_adjudication_screen.tsx
@@ -231,9 +231,9 @@ export function ContestAdjudicationScreen({
         .filter((option) => option.type !== 'candidate' || !option.isWriteIn)
         .map((option) => ({
           ...option,
-          name: contestOptionName(contest, option),
+          name: contestOptionName(election, contest, option),
         })),
-    [contestOptions, contest]
+    [election, contestOptions, contest]
   );
 
   const writeInOptionIds = useMemo(
@@ -261,6 +261,7 @@ export function ContestAdjudicationScreen({
     voteCount,
     derivedStraightPartyVotes,
   } = useContestAdjudicationState({
+    election,
     contestAdjudicationData,
     writeInCandidates,
     contest,

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -842,7 +842,7 @@ function ContestForm({
                         }
                       />
                       <label htmlFor={`${candidate.id}`}>
-                        {contestOptionName(contest, candidate)}
+                        {contestOptionName(election, contest, candidate)}
                       </label>
                     </ContestDataRow>
                   ))}

--- a/apps/admin/frontend/src/utils/adjudication.ts
+++ b/apps/admin/frontend/src/utils/adjudication.ts
@@ -90,6 +90,7 @@ export function isContestCrossoverVoted(
 }
 
 export function adjudicatedVotes(
+  election: Election,
   contests: ContestListItem[],
   adjudicatedContests: AdjudicatedContests
 ): VotesDict {
@@ -110,7 +111,11 @@ export function adjudicatedVotes(
                 ? [
                     {
                       ...option.definition,
-                      name: contestOptionName(contest, option.definition),
+                      name: contestOptionName(
+                        election,
+                        contest,
+                        option.definition
+                      ),
                     },
                   ]
                 : []
@@ -164,7 +169,7 @@ export function deriveCrossoverVoteStatus(
 ): BallotCrossoverVoteStatus {
   const ballotHasCrossoverVoteAfterAdjudication = hasCrossoverVote(
     election,
-    adjudicatedVotes(contestItems, adjudicatedContests)
+    adjudicatedVotes(election, contestItems, adjudicatedContests)
   );
   return {
     ballotHasScannedCrossoverVote,

--- a/apps/admin/frontend/src/utils/adjudication.ts
+++ b/apps/admin/frontend/src/utils/adjudication.ts
@@ -5,7 +5,7 @@ import type {
   ContestOptionAdjudicationData,
   CvrContestTag,
 } from '@votingworks/admin-backend';
-import { find, throwIllegalValue } from '@votingworks/basics';
+import { assertDefined, find, throwIllegalValue } from '@votingworks/basics';
 import {
   Contest,
   BallotPageContestOptionLayout,
@@ -14,11 +14,15 @@ import {
   Election,
   Rect,
   Side,
-  straightPartyNotYetImplemented,
   Vote,
   VotesDict,
+  StraightPartyVote,
 } from '@votingworks/types';
-import { contestOptionName, hasCrossoverVote } from '@votingworks/utils';
+import {
+  contestOptionName,
+  hasCrossoverVote,
+  selectedStraightPartyId,
+} from '@votingworks/utils';
 
 export type AdjudicatedContests = Map<ContestId, AdjudicatedCvrContest>;
 
@@ -92,10 +96,6 @@ export function adjudicatedVotes(
   return Object.fromEntries(
     contests.map(({ contest, adjudicationData }): [string, Vote] => {
       const adjudicatedContest = adjudicatedContests.get(contest.id);
-      /* istanbul ignore next */
-      if (contest.type === 'straight-party') {
-        return straightPartyNotYetImplemented();
-      }
       switch (contest.type) {
         case 'candidate':
           return [
@@ -117,6 +117,7 @@ export function adjudicatedVotes(
             ),
           ];
         case 'yesno':
+        case 'straight-party':
           return [
             contest.id,
             adjudicationData.options.flatMap((option) =>
@@ -205,4 +206,18 @@ export function contestPartyLabel(
     contest.partyId
     ? find(election.parties, (p) => p.id === contest.partyId).fullName
     : undefined;
+}
+
+export function selectedStraightPartyIdAfterAdjudication(
+  election: Election,
+  votesAfterAdjudication: VotesDict
+): string | undefined {
+  const straightPartyContest = election.contests.find(
+    (contest) => contest.type === 'straight-party'
+  );
+  if (!straightPartyContest) return undefined;
+  const straightPartyContestVotes = assertDefined(
+    votesAfterAdjudication[straightPartyContest.id]
+  ) as StraightPartyVote;
+  return selectedStraightPartyId(straightPartyContestVotes);
 }

--- a/apps/admin/frontend/src/utils/adjudication.ts
+++ b/apps/admin/frontend/src/utils/adjudication.ts
@@ -12,6 +12,7 @@ import {
   ContestId,
   ContestOptionId,
   Election,
+  PartyId,
   Rect,
   Side,
   Vote,
@@ -216,7 +217,7 @@ export function contestPartyLabel(
 export function selectedStraightPartyIdAfterAdjudication(
   election: Election,
   votesAfterAdjudication: VotesDict
-): string | undefined {
+): PartyId | undefined {
   const straightPartyContest = election.contests.find(
     (contest) => contest.type === 'straight-party'
   );

--- a/libs/ui/src/checkbox_button.tsx
+++ b/libs/ui/src/checkbox_button.tsx
@@ -1,8 +1,9 @@
+import React from 'react';
 import styled from 'styled-components';
 import { Button } from './button';
 
 export interface CheckboxButtonProps {
-  label: string;
+  label: React.ReactNode;
   isChecked: boolean;
   onChange: (isChecked: boolean) => void;
   disabled?: boolean;

--- a/libs/utils/src/hmpb/all_contest_options.test.ts
+++ b/libs/utils/src/hmpb/all_contest_options.test.ts
@@ -9,12 +9,18 @@ import {
   CandidateContest,
   CandidateContestOption,
   ContestOption,
+  Party,
   StraightPartyContest,
   YesNoContestOption,
 } from '@votingworks/types';
 import fc from 'fast-check';
 import { expect, expectTypeOf, test } from 'vitest';
 import { allContestOptions, contestOptionName } from './all_contest_options';
+
+const parties: Party[] = [
+  { id: 'party-1', name: 'Party 1', fullName: 'Party One', abbrev: 'P1' },
+  { id: 'party-2', name: 'Party 2', fullName: 'Party Two', abbrev: 'P2' },
+];
 
 test('candidate contest with no write-ins', () => {
   fc.assert(
@@ -29,7 +35,7 @@ test('candidate contest with no write-ins', () => {
           assert(option.type === 'candidate');
           expect(option.id).toEqual(contest.candidates[i]?.id);
           expect(option.contestId).toEqual(contest.id);
-          expect(contestOptionName(contest, option)).toEqual(
+          expect(contestOptionName({ parties }, contest, option)).toEqual(
             contest.candidates[i]?.name
           );
           expect(option.isWriteIn).toEqual(false);
@@ -55,7 +61,7 @@ test('candidate contest with write-ins', () => {
               `write-in-${i - contest.candidates.length}`
           );
           expect(option.contestId).toEqual(contest.id);
-          expect(contestOptionName(contest, option)).toEqual(
+          expect(contestOptionName({ parties }, contest, option)).toEqual(
             contest.candidates[i]?.name ?? 'Write-In'
           );
           expect(option.isWriteIn).toEqual(i >= contest.candidates.length);
@@ -87,10 +93,10 @@ test('yesno contest', () => {
           contestId: contest.id,
         },
       ]);
-      expect(contestOptionName(contest, options[0]!)).toEqual(
+      expect(contestOptionName({ parties }, contest, options[0]!)).toEqual(
         contest.yesOption.label
       );
-      expect(contestOptionName(contest, options[1]!)).toEqual(
+      expect(contestOptionName({ parties }, contest, options[1]!)).toEqual(
         contest.noOption.label
       );
     })
@@ -155,11 +161,13 @@ test('candidate contest with ballot style ordering', () => {
   // Verify the order matches the ballot style ordering
   expect(options).toHaveLength(3);
   expect(options[0]?.id).toEqual('candidate-c');
-  expect(contestOptionName(contest, options[0]!)).toEqual('Charlie');
+  expect(contestOptionName({ parties }, contest, options[0]!)).toEqual(
+    'Charlie'
+  );
   expect(options[1]?.id).toEqual('candidate-a');
-  expect(contestOptionName(contest, options[1]!)).toEqual('Alice');
+  expect(contestOptionName({ parties }, contest, options[1]!)).toEqual('Alice');
   expect(options[2]?.id).toEqual('candidate-b');
-  expect(contestOptionName(contest, options[2]!)).toEqual('Bob');
+  expect(contestOptionName({ parties }, contest, options[2]!)).toEqual('Bob');
 });
 
 test('candidate contest with multi-endorsed candidates are deduplicated', () => {
@@ -199,9 +207,9 @@ test('candidate contest with multi-endorsed candidates are deduplicated', () => 
   // Verify multi-endorsed candidate appears only once (deduplicated by id)
   expect(options).toHaveLength(2);
   expect(options[0]?.id).toEqual('candidate-a');
-  expect(contestOptionName(contest, options[0]!)).toEqual('Alice');
+  expect(contestOptionName({ parties }, contest, options[0]!)).toEqual('Alice');
   expect(options[1]?.id).toEqual('candidate-b');
-  expect(contestOptionName(contest, options[1]!)).toEqual('Bob');
+  expect(contestOptionName({ parties }, contest, options[1]!)).toEqual('Bob');
 });
 
 test('straight party contest', () => {
@@ -227,4 +235,10 @@ test('straight party contest', () => {
       contestId: 'contest-1',
     },
   ]);
+  expect(contestOptionName({ parties }, contest, options[0]!)).toEqual(
+    'Party One'
+  );
+  expect(contestOptionName({ parties }, contest, options[1]!)).toEqual(
+    'Party Two'
+  );
 });

--- a/libs/utils/src/hmpb/all_contest_options.ts
+++ b/libs/utils/src/hmpb/all_contest_options.ts
@@ -13,11 +13,11 @@ import {
   CandidateContestOption,
   ContestOption,
   getOrderedCandidatesForContestInBallotStyle,
-  straightPartyNotYetImplemented,
   YesNoContest,
   YesNoContestOption,
   StraightPartyContest,
   StraightPartyContestOption,
+  Election,
 } from '@votingworks/types';
 
 /**
@@ -180,13 +180,10 @@ export function* allContestOptions(
  * Given a {@link ContestOption}, returns the display name for that option based on the contest definition.
  */
 export function contestOptionName(
+  election: Pick<Election, 'parties'>,
   contest: Contest,
   option: ContestOption
 ): string {
-  /* istanbul ignore next */
-  if (option.type === 'straight-party') {
-    return straightPartyNotYetImplemented();
-  }
   switch (option.type) {
     case 'candidate': {
       assert(contest.type === 'candidate');
@@ -200,6 +197,10 @@ export function contestOptionName(
         [contest.yesOption, contest.noOption],
         (o) => o.id === option.id
       ).label;
+    }
+    case 'straight-party': {
+      assert(contest.type === 'straight-party');
+      return find(election.parties, (p) => p.id === option.id).fullName;
     }
     default:
       /* istanbul ignore next */

--- a/libs/utils/src/tabulation/straight_party.ts
+++ b/libs/utils/src/tabulation/straight_party.ts
@@ -1,4 +1,10 @@
-import { Election, Tabulation } from '@votingworks/types';
+import {
+  Contest,
+  ContestOptionId,
+  Election,
+  PartyId,
+  Tabulation,
+} from '@votingworks/types';
 import { assert, assertDefined, mapObject } from '@votingworks/basics';
 
 export function deriveStraightPartyVotes(
@@ -13,11 +19,10 @@ export function deriveStraightPartyVotes(
   }
   assert(election.type === 'general');
 
-  const straightPartyVotes = assertDefined(votes[straightPartyContest.id]);
-  if (straightPartyVotes.length !== 1) {
-    return votes;
-  }
-  const selectedStraightPartyId = assertDefined(straightPartyVotes[0]);
+  const straightPartyId = selectedStraightPartyId(
+    assertDefined(votes[straightPartyContest.id])
+  );
+  if (!straightPartyId) return votes;
 
   const contestsById = Object.fromEntries(
     election.contests.map((contest) => [contest.id, contest])
@@ -25,18 +30,41 @@ export function deriveStraightPartyVotes(
 
   return mapObject(votes, (optionIds, contestId) => {
     const contest = assertDefined(contestsById[contestId]);
-    if (contest.type !== 'candidate') return optionIds;
-    const remainingSeats = contest.seats - optionIds.length;
-    const unselectedStraightPartyCandidateIds = contest.candidates
-      .filter(
-        (candidate) =>
-          candidate.partyIds?.includes(selectedStraightPartyId) &&
-          !optionIds.includes(candidate.id)
-      )
-      .map((candidate) => candidate.id);
-    if (remainingSeats >= unselectedStraightPartyCandidateIds.length) {
-      return [...optionIds, ...unselectedStraightPartyCandidateIds];
-    }
-    return optionIds;
+    const derivedVotes = deriveStraightPartyVotesForContest(
+      contest,
+      optionIds,
+      straightPartyId
+    );
+    return [...optionIds, ...derivedVotes];
   });
+}
+
+export function selectedStraightPartyId(
+  straightPartyContestVotes: readonly ContestOptionId[]
+): PartyId | undefined {
+  if (straightPartyContestVotes.length !== 1) {
+    return undefined;
+  }
+  return assertDefined(straightPartyContestVotes[0]);
+}
+
+export function deriveStraightPartyVotesForContest(
+  contest: Contest,
+  votedOptionIds: readonly ContestOptionId[],
+  straightPartyId?: PartyId
+): ContestOptionId[] {
+  if (!(contest.type === 'candidate' && straightPartyId)) {
+    return [];
+  }
+  const remainingSeats = contest.seats - votedOptionIds.length;
+  const unselectedStraightPartyCandidateIds = contest.candidates
+    .filter(
+      (candidate) =>
+        candidate.partyIds?.includes(straightPartyId) &&
+        !votedOptionIds.includes(candidate.id)
+    )
+    .map((candidate) => candidate.id);
+  return remainingSeats >= unselectedStraightPartyCandidateIds.length
+    ? unselectedStraightPartyCandidateIds
+    : [];
 }


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->
Closes https://github.com/votingworks/vxsuite/issues/7888

Adds support for adjudicating straight party contests. Like any contest, the adjudicated votes are saved in the database and included in tabulation. Previous PRs already set up the tabulation logic such that changing the straight party selection via adjudication will change the tabulated derived votes when reporting results. A test is added to verify this behavior.

If there is a straight party selection (either from the scanned ballot or after adjudication), the contest adjudication will indicate the derived votes. The derived votes update as the user adjudicates the contest. This is just a visual aid to help the adjudicator see the impact of the adjudication on the derived votes - they aren't saved to the backend, since they will be derived there already.

The POC for this included some additional captions/labels on the contest list, which I'm omitting for now to cut initial scope. Follow up task: https://github.com/votingworks/vxsuite/issues/8735.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/1bd39268-3e35-46b7-a3ec-3d728877060c



## Testing Plan
- Manual test
- Added new automated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
