### PR TITLE
VxPrint: Let EMs print for all precincts regardless of polling place selection

### DIFF
--- a/apps/print/frontend/src/screens/print_screen.test.tsx
+++ b/apps/print/frontend/src/screens/print_screen.test.tsx
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { HP_LASER_PRINTER_CONFIG } from '@votingworks/printing';
+import { render, screen } from '../../test/react_testing_library';
+import {
+  ApiMock,
+  ApiMockProvider,
+  createApiMock,
+} from '../../test/mock_api_client';
+import { PrintScreen } from './print_screen';
+
+const electionDefinition =
+  electionFamousNames2021Fixtures.readElectionDefinition();
+
+// This polling place covers only the North Lincoln precinct (id '23').
+const SINGLE_PRECINCT_POLLING_PLACE_ID = '23-polling-place';
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  apiMock = createApiMock();
+});
+
+afterEach(() => {
+  apiMock.assertComplete();
+  vi.useRealTimers();
+});
+
+function mockBaseQueries({
+  pollingPlaceId = null,
+}: { pollingPlaceId?: string | null } = {}) {
+  apiMock.getElectionRecord.expectOptionalRepeatedCallsWith().resolves({
+    electionDefinition,
+    electionPackageHash: 'test-hash',
+  });
+  apiMock.getMachineConfig.expectOptionalRepeatedCallsWith().resolves({
+    machineId: 'test-machine',
+    codeVersion: 'test-version',
+  });
+  apiMock.getPollingPlaceId
+    .expectOptionalRepeatedCallsWith()
+    .resolves(pollingPlaceId);
+  apiMock.getDeviceStatuses.expectOptionalRepeatedCallsWith().resolves({
+    usbDrive: { status: 'no_drive' },
+    printer: { connected: true, config: HP_LASER_PRINTER_CONFIG },
+  });
+  apiMock.getTestMode.expectOptionalRepeatedCallsWith().resolves(true);
+}
+
+function renderScreen({
+  isElectionManagerAuth,
+}: {
+  isElectionManagerAuth: boolean;
+}) {
+  return render(
+    <ApiMockProvider apiMock={apiMock}>
+      <MemoryRouter initialEntries={['/print']}>
+        <PrintScreen isElectionManagerAuth={isElectionManagerAuth} />
+      </MemoryRouter>
+    </ApiMockProvider>
+  );
+}
+
+test('poll workers only see precincts for the configured polling place', async () => {
+  mockBaseQueries({ pollingPlaceId: SINGLE_PRECINCT_POLLING_PLACE_ID });
+  renderScreen({ isElectionManagerAuth: false });
+
+  await screen.findByRole('option', { name: 'North Lincoln' });
+  expect(
+    screen.queryByRole('option', { name: 'South Lincoln' })
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole('option', { name: 'East Lincoln' })
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole('option', { name: 'West Lincoln' })
+  ).not.toBeInTheDocument();
+});
+
+test('election managers see all precincts regardless of the configured polling place', async () => {
+  mockBaseQueries({ pollingPlaceId: SINGLE_PRECINCT_POLLING_PLACE_ID });
+  renderScreen({ isElectionManagerAuth: true });
+
+  await screen.findByRole('option', { name: 'North Lincoln' });
+  screen.getByRole('option', { name: 'South Lincoln' });
+  screen.getByRole('option', { name: 'East Lincoln' });
+  screen.getByRole('option', { name: 'West Lincoln' });
+});

--- a/apps/print/frontend/src/screens/print_screen.tsx
+++ b/apps/print/frontend/src/screens/print_screen.tsx
@@ -98,13 +98,15 @@ export function PrintScreen({
 
     const { election } = getElectionRecordQuery.data.electionDefinition;
 
-    if (!pollingPlaceId) return election.precincts;
+    // Election managers can print ballots for any precinct, so don't filter
+    // down to the configured polling place's precincts.
+    if (isElectionManagerAuth || !pollingPlaceId) return election.precincts;
 
     const place = pollingPlaceFromElection(election, pollingPlaceId);
     const precinctIds = pollingPlacePrecinctIds(place);
 
     return election.precincts.filter((p) => precinctIds.has(p.id));
-  }, [getElectionRecordQuery.data, pollingPlaceId]);
+  }, [getElectionRecordQuery.data, pollingPlaceId, isElectionManagerAuth]);
 
   if (!selectedPrecinctId && precincts.length > 0) {
     const defaultSelection = precincts[0].id;

--- a/apps/print/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/print/integration-testing/e2e/screenshots.spec.ts
@@ -308,8 +308,11 @@ test('election manager: print screen options', async ({ page }, testInfo) => {
   await page.getByRole('button', { name: 'Print Ballot' }).waitFor();
   await screenshot('em-print-no-selections');
 
-  // Make selections: split, then party (language defaults to English).
-  await page.getByText('Precinct 4 - Split 1', { exact: true }).click();
+  // Make selections: precinct, split, then party (language defaults to English).
+  await page.getByRole('option', { name: 'Precinct 4', exact: true }).click();
+  await page
+    .getByRole('option', { name: 'Precinct 4 - Split 1', exact: true })
+    .click();
   await page.getByRole('radio', { name: partyName }).click();
   await screenshot('em-print-with-selections');
 


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/8771

Precinct scoping given polling place selection should only be applied to poll workers. Election managers should always be able to print for all precincts.

## Demo Video or Screenshot

### Before

https://github.com/user-attachments/assets/6f1d53b7-e23f-40f4-a630-4c67089699fb

### After

https://github.com/user-attachments/assets/c47b0cea-2003-433d-8cb8-9c399f2efa15

## Testing Plan

- [x] Added automated tests
- [x] Tested manually

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.