### PR TITLE
Summary ballot encoding for straight party contests

### DIFF
--- a/libs/ballot-encoder/src/index.test.ts
+++ b/libs/ballot-encoder/src/index.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from 'vitest';
-import { readElectionGeneralDefinition as readElectionDefinition } from '@votingworks/fixtures';
+import {
+  readElectionGeneralDefinition as readElectionDefinition,
+  readElectionStraightPartyDefinition,
+} from '@votingworks/fixtures';
 import {
   BallotType,
   Candidate,
@@ -325,6 +328,36 @@ test('encodes & decodes multi-page summary ballot with yes/no votes', () => {
     pageNumber: 1,
     totalPages: 1,
     ballotAuditId: 'yesno-audit-id',
+    contests: pageContests,
+    votes,
+  };
+
+  const encoded = encodeSummaryBallotPage(election, page);
+  const decoded = decodeSummaryBallotPage(electionDefinition, encoded);
+
+  expect(decoded.votes).toEqual(votes);
+});
+
+test('encodes & decodes summary ballot with a straight party contest vote', () => {
+  const electionDefinition = readElectionStraightPartyDefinition();
+  const { election, ballotHash } = electionDefinition;
+  const ballotStyle = election.ballotStyles[0]!;
+  const precinct = election.precincts[0]!;
+  const contests = getContests({ election, ballotStyle });
+  const pageContests = contests.filter((c) => c.id === 'straight-party-ticket');
+  const votes = vote(pageContests, {
+    'straight-party-ticket': ['0'],
+  });
+
+  const page: SummaryBallotPage = {
+    ballotHash,
+    ballotStyleId: ballotStyle.id,
+    precinctId: precinct.id,
+    isTestMode: false,
+    ballotType: BallotType.Precinct,
+    pageNumber: 1,
+    totalPages: 1,
+    ballotAuditId: 'straight-party-audit-id',
     contests: pageContests,
     votes,
   };

--- a/libs/ballot-encoder/src/index.ts
+++ b/libs/ballot-encoder/src/index.ts
@@ -15,13 +15,18 @@ import {
   HmpbBallotPageMetadata,
   isVotePresent,
   PrecinctId,
-  straightPartyNotYetImplemented,
   unsafeParse,
   VotesDict,
   YesNoContest,
   YesNoVote,
+  StraightPartyVote,
 } from '@votingworks/types';
-import { assert, assertDefined, iter } from '@votingworks/basics';
+import {
+  assert,
+  assertDefined,
+  iter,
+  throwIllegalValue,
+} from '@votingworks/basics';
 import { BitReader, BitWriter, CustomEncoding, Uint8, Uint8Size } from './bits';
 
 /**
@@ -196,45 +201,59 @@ function encodeBallotVotesInto(
     const contestVote = votes[contest.id];
 
     if (isVotePresent(contestVote)) {
-      /* istanbul ignore next */
-      if (contest.type === 'straight-party') {
-        return straightPartyNotYetImplemented();
-      }
-      if (contest.type === 'yesno') {
-        const ynVote = contestVote as YesNoVote;
-
-        writeYesNoVote(bits, ynVote, contest);
-      } else {
-        const choices = contestVote as CandidateVote;
-
-        // candidate choices get one bit per candidate
-        for (const candidate of contest.candidates) {
-          bits.writeBoolean(
-            choices.some((choice) => choice.id === candidate.id)
-          );
+      switch (contest.type) {
+        case 'yesno': {
+          const ynVote = contestVote as YesNoVote;
+          writeYesNoVote(bits, ynVote, contest);
+          break;
         }
+        case 'candidate': {
+          const choices = contestVote as CandidateVote;
 
-        if (contest.allowWriteIns) {
-          // write write-in data
-          const writeInCount = iter(choices)
-            .filter((choice) => choice.isWriteIn)
-            .count();
-          const nonWriteInCount = choices.length - writeInCount;
-          const maximumWriteIns = Math.max(0, contest.seats - nonWriteInCount);
+          // candidate choices get one bit per candidate
+          for (const candidate of contest.candidates) {
+            bits.writeBoolean(
+              choices.some((choice) => choice.id === candidate.id)
+            );
+          }
 
-          if (maximumWriteIns > 0) {
-            bits.writeUint(writeInCount, { max: maximumWriteIns });
+          if (contest.allowWriteIns) {
+            // write write-in data
+            const writeInCount = iter(choices)
+              .filter((choice) => choice.isWriteIn)
+              .count();
+            const nonWriteInCount = choices.length - writeInCount;
+            const maximumWriteIns = Math.max(
+              0,
+              contest.seats - nonWriteInCount
+            );
 
-            for (const choice of choices) {
-              if (choice.isWriteIn) {
-                bits.writeString(choice.name, {
-                  encoding: WriteInEncoding,
-                  maxLength: MAXIMUM_WRITE_IN_LENGTH,
-                });
+            if (maximumWriteIns > 0) {
+              bits.writeUint(writeInCount, { max: maximumWriteIns });
+
+              for (const choice of choices) {
+                if (choice.isWriteIn) {
+                  bits.writeString(choice.name, {
+                    encoding: WriteInEncoding,
+                    maxLength: MAXIMUM_WRITE_IN_LENGTH,
+                  });
+                }
               }
             }
           }
+          break;
         }
+        case 'straight-party': {
+          for (const partyId of contest.optionIds) {
+            bits.writeBoolean(
+              (contestVote as StraightPartyVote).includes(partyId)
+            );
+          }
+          break;
+        }
+        default:
+          /* istanbul ignore next */
+          throwIllegalValue(contest);
       }
     }
   }
@@ -283,48 +302,65 @@ function decodeBallotVotes(
 
   // read vote data
   for (const contest of contestsWithAnswers) {
-    /* istanbul ignore next */
-    if (contest.type === 'straight-party') {
-      return straightPartyNotYetImplemented();
-    }
-    if (contest.type === 'yesno') {
-      // yesno votes get a single bit
-      votes[contest.id] = bits.readBoolean()
-        ? [contest.yesOption.id]
-        : [contest.noOption.id];
-    } else {
-      const contestVote: Candidate[] = [];
-
-      // candidate choices get one bit per candidate
-      for (const candidate of contest.candidates) {
-        if (bits.readBoolean()) {
-          contestVote.push(candidate);
-        }
+    switch (contest.type) {
+      case 'yesno': {
+        // yesno votes get a single bit
+        votes[contest.id] = bits.readBoolean()
+          ? [contest.yesOption.id]
+          : [contest.noOption.id];
+        break;
       }
+      case 'candidate': {
+        const contestVote: Candidate[] = [];
 
-      if (contest.allowWriteIns) {
-        // read write-in data
-        const maximumWriteIns = Math.max(0, contest.seats - contestVote.length);
-
-        if (maximumWriteIns > 0) {
-          const writeInCount = bits.readUint({ max: maximumWriteIns });
-
-          for (let i = 0; i < writeInCount; i += 1) {
-            const name = bits.readString({
-              encoding: WriteInEncoding,
-              maxLength: MAXIMUM_WRITE_IN_LENGTH,
-            });
-
-            contestVote.push({
-              id: `write-in-${name}`,
-              name,
-              isWriteIn: true,
-            });
+        // candidate choices get one bit per candidate
+        for (const candidate of contest.candidates) {
+          if (bits.readBoolean()) {
+            contestVote.push(candidate);
           }
         }
-      }
 
-      votes[contest.id] = contestVote;
+        if (contest.allowWriteIns) {
+          // read write-in data
+          const maximumWriteIns = Math.max(
+            0,
+            contest.seats - contestVote.length
+          );
+
+          if (maximumWriteIns > 0) {
+            const writeInCount = bits.readUint({ max: maximumWriteIns });
+
+            for (let i = 0; i < writeInCount; i += 1) {
+              const name = bits.readString({
+                encoding: WriteInEncoding,
+                maxLength: MAXIMUM_WRITE_IN_LENGTH,
+              });
+
+              contestVote.push({
+                id: `write-in-${name}`,
+                name,
+                isWriteIn: true,
+              });
+            }
+          }
+        }
+
+        votes[contest.id] = contestVote;
+        break;
+      }
+      case 'straight-party': {
+        const contestVote = [];
+        for (const partyId of contest.optionIds) {
+          if (bits.readBoolean()) {
+            contestVote.push(partyId);
+          }
+        }
+        votes[contest.id] = contestVote;
+        break;
+      }
+      default:
+        /* istanbul ignore next */
+        throwIllegalValue(contest);
     }
   }
 

--- a/libs/ballot-encoder/vitest.config.ts
+++ b/libs/ballot-encoder/vitest.config.ts
@@ -3,5 +3,11 @@ import { defineConfig } from '../../vitest.config.shared.mjs';
 export default defineConfig({
   test: {
     setupFiles: ['test/expect.ts'],
+    coverage: {
+      thresholds: {
+        branches: -2,
+        lines: 100,
+      },
+    },
   },
 });

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/types.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/types.ts
@@ -408,7 +408,8 @@ export type RustCandidateVote =
 
 export type RustContestVote =
   | { type: 'candidate'; value: RustCandidateVote[] }
-  | { type: 'yesNo'; value: string };
+  | { type: 'yesNo'; value: string }
+  | { type: 'straightParty'; value: string[] };
 
 /**
  * Rust-decoded CastVoteRecord (VB\x01 prelude).

--- a/libs/ballot-interpreter/src/cross_language_bmd.test.ts
+++ b/libs/ballot-interpreter/src/cross_language_bmd.test.ts
@@ -9,7 +9,6 @@ import {
   getContests,
   getBallotStyle,
   Candidate,
-  straightPartyNotYetImplemented,
   YesNoVote,
 } from '@votingworks/types';
 import {
@@ -23,6 +22,7 @@ import {
   arbitraryElectionDefinition,
 } from '@votingworks/test-utils';
 import { Buffer } from 'node:buffer';
+import { throwIllegalValue } from '@votingworks/basics';
 import { napi } from './bubble-ballot-ts/napi';
 import type {
   BridgeDecodeBmdResult,
@@ -41,31 +41,38 @@ function generateVotesForContests(
 ): VotesDict {
   const votes: VotesDict = {};
   for (const contest of contests) {
-    /* istanbul ignore next */
-    if (contest.type === 'straight-party') {
-      return straightPartyNotYetImplemented();
-    }
-    if (contest.type === 'candidate') {
-      const namedCandidates = contest.candidates.filter((c) => !c.isWriteIn);
-      const selected = namedCandidates.slice(0, contest.seats);
-      if (
-        includeWriteIns &&
-        contest.allowWriteIns &&
-        selected.length < contest.seats
-      ) {
-        votes[contest.id] = [
-          ...selected,
-          {
-            id: 'write-in-TEST',
-            name: 'TEST',
-            isWriteIn: true,
-          },
-        ];
-      } else {
-        votes[contest.id] = selected;
+    switch (contest.type) {
+      case 'candidate': {
+        const namedCandidates = contest.candidates.filter((c) => !c.isWriteIn);
+        const selected = namedCandidates.slice(0, contest.seats);
+        if (
+          includeWriteIns &&
+          contest.allowWriteIns &&
+          selected.length < contest.seats
+        ) {
+          votes[contest.id] = [
+            ...selected,
+            {
+              id: 'write-in-TEST',
+              name: 'TEST',
+              isWriteIn: true,
+            },
+          ];
+        } else {
+          votes[contest.id] = selected;
+        }
+        break;
       }
-    } else {
-      votes[contest.id] = [contest.yesOption.id];
+      case 'yesno': {
+        votes[contest.id] = [contest.yesOption.id];
+        break;
+      }
+      case 'straight-party': {
+        votes[contest.id] = contest.optionIds.slice(0, 1);
+        break;
+      }
+      default:
+        throwIllegalValue(contest);
     }
   }
   return votes;
@@ -249,25 +256,37 @@ function tsVotesToRustVotes(
     const voteArr = vote as unknown[];
     if (voteArr.length === 0) continue;
 
-    if (contest.type === 'candidate') {
-      const candidates: RustCandidateVote[] = voteArr.map((c) => {
-        const candidate = c as Candidate;
-        if (candidate.isWriteIn) {
+    switch (contest.type) {
+      case 'candidate': {
+        const candidates: RustCandidateVote[] = voteArr.map((c) => {
+          const candidate = c as Candidate;
+          if (candidate.isWriteIn) {
+            return {
+              type: 'writeInCandidate',
+              candidateId: candidate.id,
+              name: candidate.name ?? '',
+            };
+          }
           return {
-            type: 'writeInCandidate',
+            type: 'namedCandidate',
             candidateId: candidate.id,
-            name: candidate.name ?? '',
           };
-        }
-        return {
-          type: 'namedCandidate',
-          candidateId: candidate.id,
-        };
-      });
-      rustVotes[contest.id] = { type: 'candidate', value: candidates };
-    } else {
-      const optionId = (voteArr as YesNoVote)[0]!;
-      rustVotes[contest.id] = { type: 'yesNo', value: optionId };
+        });
+        rustVotes[contest.id] = { type: 'candidate', value: candidates };
+        break;
+      }
+      case 'yesno': {
+        const optionId = (voteArr as YesNoVote)[0]!;
+        rustVotes[contest.id] = { type: 'yesNo', value: optionId };
+        break;
+      }
+      case 'straight-party': {
+        const partyIds = voteArr as string[];
+        rustVotes[contest.id] = { type: 'straightParty', value: partyIds };
+        break;
+      }
+      default:
+        throwIllegalValue(contest);
     }
   }
   return rustVotes;

--- a/libs/test-utils/src/arbitraries.ts
+++ b/libs/test-utils/src/arbitraries.ts
@@ -33,6 +33,7 @@ import {
   BallotStyleGroupId,
   PrecinctSplit,
   Contest,
+  ElectionType,
 } from '@votingworks/types';
 import { sha256 } from 'js-sha256';
 import { DateWithoutTime, assertDefined } from '@votingworks/basics';
@@ -314,13 +315,43 @@ export function arbitraryCandidateContest({
   });
 }
 
+function arbitraryStraightPartyContest({
+  id = arbitraryContestId(),
+  districtId = arbitraryDistrictId(),
+  partyIds = fc.array(arbitraryPartyId(), { minLength: 1 }),
+}: {
+  id?: fc.Arbitrary<Contest['id']>;
+  districtId?: fc.Arbitrary<District['id']>;
+  partyIds?: fc.Arbitrary<Array<Party['id']>>;
+} = {}): fc.Arbitrary<Contest> {
+  return fc.record({
+    type: fc.constant('straight-party' as const),
+    id,
+    title: fc.string({ minLength: 1 }),
+    districtId,
+    optionIds: partyIds,
+  });
+}
+
 export function arbitraryContests({
+  electionType,
   partyIds,
 }: {
+  electionType?: ElectionType;
   partyIds?: fc.Arbitrary<Array<Party['id']>>;
 } = {}): fc.Arbitrary<readonly Contest[]> {
+  const arbitraryStraightPartyContests: fc.Arbitrary<Contest[]> = (
+    partyIds ?? fc.constant([])
+  ).chain((ids) =>
+    electionType === 'general' && ids.length === 0
+      ? fc.constant([])
+      : fc
+          .option(arbitraryStraightPartyContest({ partyIds }))
+          .map((contest) => (contest ? [contest] : []))
+  );
   return fc
     .tuple(
+      arbitraryStraightPartyContests,
       fc.array(
         arbitraryCandidateContest({
           partyIds,
@@ -329,7 +360,8 @@ export function arbitraryContests({
       ),
       fc.array(arbitraryYesNoContest())
     )
-    .map(([candidateContests, otherContests]) => [
+    .map(([straightPartyContests, candidateContests, otherContests]) => [
+      ...straightPartyContests,
       ...candidateContests,
       ...otherContests,
     ])
@@ -486,6 +518,7 @@ export function arbitraryElection(): fc.Arbitrary<Election> {
           seal: fc.string({ minLength: 1, maxLength: 200 }),
           parties: fc.constant(parties),
           contests: arbitraryContests({
+            electionType: type,
             partyIds: fc.constant(parties.map(({ id }) => id)),
           }),
           ballotStyles: fc

--- a/libs/types-rs/src/bmd/votes.rs
+++ b/libs/types-rs/src/bmd/votes.rs
@@ -4,7 +4,7 @@ use super::error::Error;
 use super::write_in_name::WriteInName;
 use crate::{
     coding::BitSize,
-    election::{Contest, OptionId},
+    election::{Contest, OptionId, PartyId},
 };
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -35,6 +35,7 @@ pub type YesNoVote = OptionId;
 pub enum ContestVote {
     Candidate(Vec<CandidateVote>),
     YesNo(YesNoVote),
+    StraightParty(Vec<PartyId>),
 }
 
 impl ToBitStreamWith<'_> for ContestVote {
@@ -96,6 +97,12 @@ impl ToBitStreamWith<'_> for ContestVote {
                             yesno_contest.no_option.id,
                         )
                     });
+                }
+            }
+
+            (Contest::StraightParty(straight_party_contest), Self::StraightParty(votes)) => {
+                for party_id in &straight_party_contest.option_ids {
+                    w.write_bit(votes.contains(party_id))?;
                 }
             }
 
@@ -167,10 +174,15 @@ impl FromBitStreamWith<'_> for ContestVote {
                     yesno_contest.no_option.id.clone()
                 }))
             }
-            Contest::StraightParty(_) => {
-                unimplemented!(
-                    "STRAIGHT_PARTY_TODO: straight-party contests are not yet implemented"
-                )
+            Contest::StraightParty(straight_party_contest) => {
+                // straight-party votes get one bit per party
+                let mut votes = Vec::new();
+                for party_id in &straight_party_contest.option_ids {
+                    if r.read_bit()? {
+                        votes.push(party_id.clone());
+                    }
+                }
+                Ok(Self::StraightParty(votes))
             }
         }
     }
@@ -182,6 +194,7 @@ impl ContestVote {
         match self {
             Self::Candidate(votes) => !votes.is_empty(),
             Self::YesNo(_) => true,
+            Self::StraightParty(votes) => !votes.is_empty(),
         }
     }
 }

--- a/libs/types-rs/src/election.rs
+++ b/libs/types-rs/src/election.rs
@@ -260,13 +260,11 @@ impl Contest {
             // and has matching party or no party
             && match self {
                 Contest::YesNo(_)
+                | Contest::StraightParty(_)
                 | Contest::Candidate(CandidateContest { party_id: None, .. }) => true,
                 Contest::Candidate(CandidateContest { party_id, .. }) => {
                     party_id == &ballot_style.party_id
                 }
-                Contest::StraightParty(_) => unimplemented!(
-                    "STRAIGHT_PARTY_TODO: straight-party contests are not yet implemented"
-                ),
             }
     }
 }

--- a/libs/types/src/election_utils.ts
+++ b/libs/types/src/election_utils.ts
@@ -32,7 +32,6 @@ import {
   hasSplits,
   PrecinctOrSplit,
   CandidateVote,
-  straightPartyNotYetImplemented,
 } from './election';
 
 /**
@@ -457,15 +456,14 @@ export function vote(
 ): VotesDict {
   const votes: VotesDict = {};
   for (const contest of contests) {
-    /* istanbul ignore next */
-    if (contest.type === 'straight-party') {
-      straightPartyNotYetImplemented();
-    }
     const choice = shorthand[contest.id];
     if (!choice) {
       votes[contest.id] = [];
-    } else if (contest.type === 'yesno') {
-      assert(Array.isArray(choice), 'yesno shorthand must be an array');
+    } else if (contest.type === 'yesno' || contest.type === 'straight-party') {
+      assert(
+        Array.isArray(choice),
+        'yesno/straight-party shorthand must be an array'
+      );
       votes[contest.id] = choice;
     } else if (Array.isArray(choice) && typeof choice[0] === 'string') {
       votes[contest.id] = contest.candidates.filter((c) =>


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

<!-- Add a link to a GitHub issue here -->
Task: https://github.com/votingworks/vxsuite/issues/8733

Updates ballot-encoder (TS) and ballot-interpreter (RS) ballot encoding/decoding logic to support straight party contests, mirroring the approach for candidate contests (a bit for each option, encoding whether or not it was voted).

## Demo Video or Screenshot
N/A

## Testing Plan
Updated automated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
