### PR TITLE
libs/test-decks: add includeBubbleBallots param to generated CVRs

### DIFF
--- a/apps/design/backend/src/test_decks.ts
+++ b/apps/design/backend/src/test_decks.ts
@@ -86,6 +86,7 @@ export async function createTestDeckTallyReports({
   const reports = new Map<string, Uint8Array>();
 
   const cvrs = generateTestDeckCastVoteRecords(election, {
+    includeBubbleBallots: true,
     includeSummaryBallots,
   });
 

--- a/apps/print/backend/src/app.ts
+++ b/apps/print/backend/src/app.ts
@@ -580,6 +580,7 @@ export function buildApi(ctx: AppContext) {
 
       const allCvrs = generateTestDeckCastVoteRecords(election, {
         includeSummaryBallots: false,
+        includeBubbleBallots: true,
       });
       const cvrs = precinctId
         ? allCvrs.filter((cvr) => cvr.precinctId === precinctId)

--- a/libs/test-decks/src/test_decks.test.ts
+++ b/libs/test-decks/src/test_decks.test.ts
@@ -240,6 +240,7 @@ describe('getTallyReportResults', () => {
 
     const cvrs = generateTestDeckCastVoteRecords(election, {
       includeSummaryBallots: false,
+      includeBubbleBallots: true,
     });
     const tallyReportResults = await getTallyReportResults(election, cvrs);
 
@@ -282,6 +283,7 @@ describe('getTallyReportResults', () => {
 
     const cvrs = generateTestDeckCastVoteRecords(election, {
       includeSummaryBallots: true,
+      includeBubbleBallots: true,
     });
     const tallyReportResults = await getTallyReportResults(election, cvrs);
 
@@ -320,6 +322,7 @@ describe('getTallyReportResults', () => {
 
     const cvrs = generateTestDeckCastVoteRecords(election, {
       includeSummaryBallots: false,
+      includeBubbleBallots: true,
     });
     const tallyReportResults = await getTallyReportResults(election, cvrs);
 
@@ -374,6 +377,7 @@ describe('getTallyReportResults', () => {
 
     const cvrs = generateTestDeckCastVoteRecords(election, {
       includeSummaryBallots: true,
+      includeBubbleBallots: true,
     });
     const tallyReportResults = await getTallyReportResults(election, cvrs);
 
@@ -426,6 +430,7 @@ describe('getTallyReportResults', () => {
 
     const cvrs = generateTestDeckCastVoteRecords(election, {
       includeSummaryBallots: false,
+      includeBubbleBallots: true,
     });
     const precinctCvrs = cvrs.filter((cvr) => cvr.precinctId === precinct.id);
     const tallyReportResults = await getTallyReportResults(
@@ -472,6 +477,7 @@ describe('getTallyReportResults', () => {
 
     const cvrs = generateTestDeckCastVoteRecords(election, {
       includeSummaryBallots: false,
+      includeBubbleBallots: true,
     });
     const precinctCvrs = cvrs.filter((cvr) => cvr.precinctId === precinct.id);
     const tallyReportResults = await getTallyReportResults(
@@ -520,5 +526,32 @@ describe('getTallyReportResults', () => {
         includeGenericWriteIn: false,
       })
     );
+  });
+});
+
+describe('generateTestDeckCastVoteRecords', () => {
+  test('excludes bubble ballots when includeBubbleBallots is false', () => {
+    const election = electionFamousNames2021Fixtures.readElection();
+
+    const cvrs = generateTestDeckCastVoteRecords(election, {
+      includeSummaryBallots: true,
+      includeBubbleBallots: false,
+    });
+
+    expect(cvrs.length).toBeGreaterThan(0);
+    // Bubble ballots produce 'hmpb' CVRs; summary ballots produce 'bmd' CVRs
+    expect(cvrs.some((cvr) => cvr.card.type === 'hmpb')).toEqual(false);
+    expect(cvrs.every((cvr) => cvr.card.type === 'bmd')).toEqual(true);
+  });
+
+  test('returns an empty array when both ballot types are excluded', () => {
+    const election = electionFamousNames2021Fixtures.readElection();
+
+    const cvrs = generateTestDeckCastVoteRecords(election, {
+      includeSummaryBallots: false,
+      includeBubbleBallots: false,
+    });
+
+    expect(cvrs).toEqual([]);
   });
 });

--- a/libs/test-decks/src/test_decks.ts
+++ b/libs/test-decks/src/test_decks.ts
@@ -239,17 +239,23 @@ function getBallotContestLayouts(
 
 export function generateTestDeckCastVoteRecords(
   election: Election,
-  options: { includeSummaryBallots: boolean }
+  options: { includeSummaryBallots: boolean; includeBubbleBallots: boolean }
 ): Tabulation.CastVoteRecord[] {
-  const { includeSummaryBallots = false } = options;
+  const { includeSummaryBallots, includeBubbleBallots } = options;
 
-  // Generate HMPB ballot specs
-  const hmpbBallotSpecs: TestDeckBallot[] = generateTestDeckBallots({
-    election,
-    ballotFormat: 'bubble',
-    includeBlankBallots: false,
-    includeOvervotedBallots: false,
-  });
+  if (!includeSummaryBallots && !includeBubbleBallots) {
+    return [];
+  }
+
+  // Generate HMPB ballot specs if configured
+  const hmpbBallotSpecs: TestDeckBallot[] = includeBubbleBallots
+    ? generateTestDeckBallots({
+        election,
+        ballotFormat: 'bubble',
+        includeBlankBallots: false,
+        includeOvervotedBallots: false,
+      })
+    : [];
 
   // Generate summary ballot specs if configured
   const summaryBallotSpecs: TestDeckBallot[] = includeSummaryBallots


### PR DESCRIPTION
Changes `generateTestDeckCastVoteRecords` to include only bubble ballots, only summary ballots, or both

* Add `includeBubbleBallots` option to `generateTestDeckCastVoteRecords`. Bubble ballots were previously assumed but aren't desired for VxMark test deck printing
* Remove unnecessary default assignment for `includeSummaryBallots`

## Overview

Supports https://github.com/votingworks/vxsuite/issues/8252

## Demo Video or Screenshot

N/A no behavior change

## Testing Plan

Added tests


