### PR TITLE
[VxAdmin] Add LocationCvrsPanel component for CVR management screen

### DIFF
--- a/apps/admin/frontend/src/screens/tally/location_cvrs_panel.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_cvrs_panel.test.tsx
@@ -1,0 +1,100 @@
+import { expect, test, vi } from 'vitest';
+import { pollingPlaceTypeName } from '@votingworks/types/src';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '../../../test/react_testing_library';
+import { LocationCvrsPanel } from './location_cvrs_panel';
+
+test('renders nothing when not open', () => {
+  const { container } = render(
+    <LocationCvrsPanel
+      closePanel={vi.fn()}
+      imports={[]}
+      name="Vx City"
+      open={false}
+      type="absentee"
+    />
+  );
+
+  expect(container).toHaveTextContent('');
+});
+
+test('renders empty state note when open with no imports available', () => {
+  render(
+    <LocationCvrsPanel
+      closePanel={vi.fn()}
+      imports={[]}
+      name="Vx City"
+      open
+      type="absentee"
+    />
+  );
+
+  screen.getButton('Close Panel');
+  screen.getByText(pollingPlaceTypeName('absentee'));
+  screen.getByText('Vx City');
+  screen.getByText('No CVRs');
+
+  expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
+});
+
+test('renders import details when non-empty', () => {
+  render(
+    <LocationCvrsPanel
+      closePanel={vi.fn()}
+      imports={[
+        {
+          id: 'one',
+          exportTimestamp: '2020-11-07T08:00:00',
+          numCvrsImported: 412,
+          scannerIds: ['SCAN-01-0001'],
+        },
+        {
+          id: 'two',
+          exportTimestamp: '2020-11-07T09:00:00',
+          numCvrsImported: 943,
+          scannerIds: ['SCAN-01-0001', 'SCAN-01-0002'],
+        },
+      ]}
+      name="Vx City"
+      open
+      type="absentee"
+    />
+  );
+
+  screen.getButton('Close Panel');
+  screen.getByText(pollingPlaceTypeName('absentee'));
+  screen.getByText('Vx City');
+
+  screen.queryByRole('listitem', {
+    name: ['2020/11/07, 8:00AM', 'Scanner SCAN-01-0001', '412'].join(' '),
+  });
+  screen.queryByRole('listitem', {
+    name: [
+      '2020/11/07, 9:00AM',
+      'Scanners:',
+      'SCAN-01-0001',
+      'SCAN-01-0002',
+      '412',
+    ].join(' '),
+  });
+
+  expect(screen.queryByText('No CVRs')).not.toBeInTheDocument();
+});
+
+test('emits close event when on close button press', () => {
+  const close = vi.fn();
+
+  render(
+    <LocationCvrsPanel
+      closePanel={close}
+      imports={[]}
+      name="Vx City"
+      open
+      type="absentee"
+    />
+  );
+
+  expect(close).not.toHaveBeenCalled();
+  userEvent.click(screen.getButton('Close Panel'));
+  expect(close).toHaveBeenCalledOnce();
+});

--- a/apps/admin/frontend/src/screens/tally/location_cvrs_panel.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_cvrs_panel.tsx
@@ -1,0 +1,177 @@
+import styled, { css } from 'styled-components';
+
+import {
+  Button,
+  Callout,
+  Caption,
+  DesktopPalette,
+  Font,
+  Icons,
+} from '@votingworks/ui';
+import { format } from '@votingworks/utils';
+import { PollingPlaceType, pollingPlaceTypeName } from '@votingworks/types';
+import type { CastVoteRecordFileRecord } from '@votingworks/admin-backend';
+import { GAP, INSET_FOCUS_OUTLINE } from './styles';
+
+export interface LocationCvrsPanelProps {
+  closePanel: () => void;
+  open: boolean;
+  imports: LocationCvrImport[];
+  name: string;
+  type: PollingPlaceType;
+}
+
+export type LocationCvrImport = Pick<
+  CastVoteRecordFileRecord,
+  'id' | 'exportTimestamp' | 'numCvrsImported' | 'scannerIds'
+>;
+
+const CalloutContent = styled(Caption)`
+  align-items: start;
+  display: grid;
+  gap: ${GAP};
+  grid-template-rows: min-content 1fr;
+`;
+
+const Container = styled.div`
+  height: 100%;
+  min-width: 0;
+  overflow: hidden;
+`;
+
+/*
+ * istanbul ignore next - @starting-style rule is incompatible with our
+ * current jsdom version.
+ */
+const CONTENT_STARTING_STYLE =
+  process.env.NODE_ENV !== 'test' &&
+  css`
+    /* stylelint-disable-next-line at-rule-no-unknown */
+    @starting-style {
+      opacity: 0;
+    }
+  `;
+
+const Content = styled.div`
+  display: grid;
+  gap: ${GAP};
+  grid-template-rows: min-content 1fr;
+  min-width: min-content;
+  opacity: 1;
+  transition: opacity 250ms ease-in;
+
+  ${CONTENT_STARTING_STYLE}
+`;
+
+const DetailsBody = styled.ul`
+  align-items: start;
+  align-items: center;
+  display: grid;
+  gap: ${GAP};
+  margin: 0;
+  padding: 0;
+`;
+
+const BOTTOM_BORDER_SEPARATOR = css`
+  border-bottom: 1px dashed ${DesktopPalette.Gray40};
+`;
+
+const Header = styled.div`
+  ${BOTTOM_BORDER_SEPARATOR}
+
+  align-items: start;
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: ${GAP};
+`;
+
+const IconButton = styled.div`
+  border-color: transparent;
+  font-size: 0.75rem;
+  gap: 0.25rem;
+  padding: 0.35rem 0.5rem; /* Squares out the button's dimensions. */
+
+  :focus:focus-visible {
+    ${INSET_FOCUS_OUTLINE}
+  }
+`;
+
+const Import = styled.li`
+  ${BOTTOM_BORDER_SEPARATOR}
+
+  align-items: center;
+  display: grid;
+  gap: ${GAP};
+  grid-template-columns: 1fr min-content min-content;
+  padding-bottom: ${GAP};
+`;
+
+const Title = styled.div`
+  display: grid;
+`;
+
+export function LocationCvrsPanel(props: LocationCvrsPanelProps): JSX.Element {
+  const { closePanel, imports, name, open, type } = props;
+
+  if (!open) return <Container />;
+
+  function scannerDetails(i: LocationCvrImport) {
+    return i.scannerIds.length === 1
+      ? `Scanner ${i.scannerIds[0]}`
+      : `Scanners: ${i.scannerIds.join(', ')}`;
+  }
+
+  return (
+    <Container>
+      <Content>
+        <Header>
+          <Title>
+            <Caption>{pollingPlaceTypeName(type)}</Caption>
+            <Font weight="bold">{name}</Font>
+          </Title>
+          <IconButton
+            aria-label="Close Panel"
+            as={Button}
+            icon="X"
+            onPress={closePanel}
+            color="primary"
+          />
+        </Header>
+
+        <DetailsBody>
+          {imports.map((i) => (
+            <Import key={i.id}>
+              <Caption weight="semiBold">
+                {format.localeShortDateAndTime(new Date(i.exportTimestamp))}
+                <br />
+                <Caption weight="regular">{scannerDetails(i)}</Caption>
+              </Caption>
+
+              <Font weight="bold">{format.count(i.numCvrsImported)}</Font>
+
+              {/*
+               * [TODO](https://github.com/votingworks/vxsuite/issues/4048)
+               * Add single-import delete button.
+               */}
+            </Import>
+          ))}
+
+          {imports.length === 0 && (
+            <Callout>
+              <CalloutContent>
+                <Font weight="bold">
+                  <Icons.Info /> No CVRs
+                </Font>
+                <span>
+                  No files have been loaded from this location yet. When you are
+                  ready, insert the USB drive containing an export from the
+                  location and click &quot;Load&quot; to import it.
+                </span>
+              </CalloutContent>
+            </Callout>
+          )}
+        </DetailsBody>
+      </Content>
+    </Container>
+  );
+}

--- a/apps/admin/frontend/src/screens/tally/location_cvrs_panel.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_cvrs_panel.tsx
@@ -64,7 +64,6 @@ const Content = styled.div`
 `;
 
 const DetailsBody = styled.ul`
-  align-items: start;
   align-items: center;
   display: grid;
   gap: ${GAP};


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7958

Adding a CVR detail component for the upcoming CVR management screen update. This panel can be opened for a given location to show details of all previous imports for that location. The open/close functionality will be handled later in parent component containing the list of locations (see mocks below).

This will eventually also include buttons for deleting individual imports, but that feature will be added on later after the initial V4.1 release.

## Demo Video or Screenshot

_In-context mocks are available in [Figma](https://www.figma.com/design/0Mari2J3cgG8dSYx9pnF1P/VxAdmin-CVR-Management?node-id=1-5&t=QJg1Q388OLjE6w7n-1)_

### Empty State

https://github.com/user-attachments/assets/d5993c46-d391-423b-a237-a8f323a6aaec

### With Imports

https://github.com/user-attachments/assets/7e414d8e-5871-4ff4-8f0b-946cae614d85

## Testing Plan
- State/event tests

## Checklist
N/A