### PR TITLE
VxMark: UI for voting straight party contests

### DIFF
--- a/apps/mark-scan/frontend/src/app_contest_straight_party.test.tsx
+++ b/apps/mark-scan/frontend/src/app_contest_straight_party.test.tsx
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, test, vi } from 'vitest';
+
+import { anyPollingPlace } from '@votingworks/types';
+import {
+  asElectionDefinition,
+  readElectionStraightParty,
+} from '@votingworks/fixtures';
+import userEvent from '@testing-library/user-event';
+import { render, screen, within } from '../test/react_testing_library';
+import { App } from './app';
+
+import { advanceTimersAndPromises } from '../test/helpers/timers';
+
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
+
+let apiMock: ApiMock;
+
+const election = readElectionStraightParty();
+const electionDefinition = asElectionDefinition(election);
+const pollingPlace = anyPollingPlace(election);
+const [precinctId] = Object.keys(pollingPlace.precincts);
+
+beforeEach(() => {
+  vi.useFakeTimers({
+    shouldAdvanceTime: true,
+  });
+  window.location.href = '/';
+  apiMock = createApiMock();
+  apiMock.expectGetSystemSettings();
+  apiMock.expectGetElectionRecord(electionDefinition);
+  apiMock.setPaperHandlerState('waiting_for_ballot_data');
+});
+
+afterEach(() => {
+  apiMock.mockApiClient.assertComplete();
+});
+
+test('voting and changing a straight party contest', async () => {
+  apiMock.expectGetMachineConfig();
+  apiMock.expectGetElectionState({
+    pollingPlaceId: pollingPlace.id,
+    pollsState: 'polls_open',
+  });
+
+  render(<App apiClient={apiMock.mockApiClient} />);
+  await advanceTimersAndPromises();
+
+  apiMock.setAuthStatusCardlessVoterLoggedIn({
+    ballotStyleId: '12',
+    precinctId,
+  });
+  userEvent.click(await screen.findByText('Start Voting'));
+  await advanceTimersAndPromises();
+  screen.getByRole('heading', { name: 'Straight Party' });
+
+  // Select a party
+  userEvent.click(screen.getByText('Federalist Party'));
+  await advanceTimersAndPromises();
+  screen.getByRole('option', { name: /Federalist Party/, selected: true });
+
+  // Selecting a different party is blocked until the first is deselected
+  userEvent.click(screen.getByText('Liberty Party'));
+  await advanceTimersAndPromises();
+  within(screen.getByRole('alertdialog')).getByText(/first deselect/i);
+  userEvent.click(screen.getByText('Continue'));
+  await advanceTimersAndPromises();
+  screen.getByRole('option', { name: /Liberty Party/, selected: false });
+
+  // Deselecting the party clears the selection
+  userEvent.click(
+    screen.getByRole('option', { name: /Federalist Party/, selected: true })
+  );
+  await advanceTimersAndPromises();
+  screen.getByRole('option', { name: /Federalist Party/, selected: false });
+});

--- a/apps/mark/frontend/src/app_contest_straight_party.test.tsx
+++ b/apps/mark/frontend/src/app_contest_straight_party.test.tsx
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, test, vi } from 'vitest';
+
+import { anyPollingPlace } from '@votingworks/types';
+import {
+  asElectionDefinition,
+  readElectionStraightParty,
+} from '@votingworks/fixtures';
+import userEvent from '@testing-library/user-event';
+import { render, screen, within } from '../test/react_testing_library';
+import { App } from './app';
+
+import { advanceTimersAndPromises } from '../test/helpers/timers';
+
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
+
+let apiMock: ApiMock;
+
+const election = readElectionStraightParty();
+const electionDefinition = asElectionDefinition(election);
+const pollingPlace = anyPollingPlace(election);
+const [precinctId] = Object.keys(pollingPlace.precincts);
+
+beforeEach(() => {
+  vi.useFakeTimers({
+    shouldAdvanceTime: true,
+  });
+  apiMock = createApiMock();
+  apiMock.expectGetSystemSettings();
+  apiMock.expectGetElectionRecord(electionDefinition);
+});
+
+afterEach(async () => {
+  await vi.waitFor(() => {
+    apiMock.mockApiClient.assertComplete();
+  });
+});
+
+test('voting and changing a straight party contest', async () => {
+  apiMock.expectGetMachineConfig();
+  apiMock.expectGetElectionState({
+    pollingPlaceId: pollingPlace.id,
+    pollsState: 'polls_open',
+  });
+
+  render(<App apiClient={apiMock.mockApiClient} />);
+  await advanceTimersAndPromises();
+
+  // Start voter session
+  apiMock.setAuthStatusCardlessVoterLoggedIn({
+    ballotStyleId: '12',
+    precinctId,
+  });
+
+  userEvent.click(await screen.findByText('Start Voting'));
+  await advanceTimersAndPromises();
+  screen.getByRole('heading', { name: 'Straight Party' });
+
+  // Select a party
+  userEvent.click(screen.getByText('Federalist Party'));
+  await advanceTimersAndPromises();
+  screen.getByRole('option', { name: /Federalist Party/, selected: true });
+
+  // Selecting a different party is blocked until the first is deselected
+  userEvent.click(screen.getByText('Liberty Party'));
+  await advanceTimersAndPromises();
+  within(screen.getByRole('alertdialog')).getByText(/first deselect/i);
+  userEvent.click(screen.getByText('Continue'));
+  await advanceTimersAndPromises();
+  screen.getByRole('option', { name: /Liberty Party/, selected: false });
+
+  // Deselecting the party clears the selection
+  userEvent.click(
+    screen.getByRole('option', { name: /Federalist Party/, selected: true })
+  );
+  await advanceTimersAndPromises();
+  screen.getByRole('option', { name: /Federalist Party/, selected: false });
+});

--- a/libs/mark-flow-ui/src/components/contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/contest.test.tsx
@@ -1,11 +1,17 @@
 import { expect, test, vi } from 'vitest';
 import {
   readElectionGeneral,
+  readElectionStraightParty,
   readElectionWithMsEitherNeither,
 } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
 import { assert, find } from '@votingworks/basics';
-import { CandidateContest, VotesDict, YesNoContest } from '@votingworks/types';
+import {
+  CandidateContest,
+  StraightPartyContest,
+  VotesDict,
+  YesNoContest,
+} from '@votingworks/types';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { render, screen, within } from '../../test/react_testing_library';
 
@@ -31,6 +37,12 @@ const msEitherNeitherContest = find(
   (c): c is MsEitherNeitherContest => c.type === 'ms-either-neither'
 );
 
+const electionStraightParty = readElectionStraightParty();
+const straightPartyContest = find(
+  electionStraightParty.contests,
+  (c): c is StraightPartyContest => c.type === 'straight-party'
+);
+
 test.each([
   ['with votes', candidateContest.candidates.slice(0, 1)],
   ['without votes', undefined],
@@ -48,6 +60,22 @@ test.each([
   );
   screen.getByText(candidateContest.title);
   // Tested further in candidate_contest.test.tsx
+});
+
+test('straight party contest', () => {
+  render(
+    <Contest
+      ballotStyleId={electionStraightParty.ballotStyles[0].id}
+      election={electionStraightParty}
+      contest={straightPartyContest}
+      votes={{
+        [straightPartyContest.id]: straightPartyContest.optionIds.slice(0, 1),
+      }}
+      updateVote={vi.fn()}
+    />
+  );
+  screen.getByText(straightPartyContest.title);
+  // Tested further in straight_party_contest.test.tsx
 });
 
 test('write-in character limit across contests', () => {

--- a/libs/mark-flow-ui/src/components/contest.tsx
+++ b/libs/mark-flow-ui/src/components/contest.tsx
@@ -3,6 +3,7 @@ import {
   CandidateVote,
   Election,
   OptionalYesNoVote,
+  StraightPartyVote,
   VotesDict,
 } from '@votingworks/types';
 import { AccessibilityMode } from '@votingworks/ui';
@@ -11,6 +12,7 @@ import { MsEitherNeitherContest } from './ms_either_neither_contest';
 import { YesNoContest } from './yes_no_contest';
 import { ContestsWithMsEitherNeither } from '../utils/ms_either_neither_contests';
 import { UpdateVoteFunction } from '../config/types';
+import { StraightPartyContest } from './straight_party_contest';
 
 export interface ContestProps {
   /**
@@ -106,6 +108,15 @@ export function Contest({
           election={election}
           contest={contest}
           vote={vote as OptionalYesNoVote}
+          updateVote={updateVote}
+          isReviewMode={isReviewMode}
+        />
+      )}
+      {contest.type === 'straight-party' && (
+        <StraightPartyContest
+          election={election}
+          contest={contest}
+          vote={vote as StraightPartyVote | undefined}
           updateVote={updateVote}
           isReviewMode={isReviewMode}
         />

--- a/libs/mark-flow-ui/src/components/review.test.tsx
+++ b/libs/mark-flow-ui/src/components/review.test.tsx
@@ -1,9 +1,15 @@
 import { describe, expect, test, vi } from 'vitest';
 import {
   readElectionGeneral,
+  readElectionStraightParty,
   readElectionWithMsEitherNeither,
 } from '@votingworks/fixtures';
-import { CandidateContest, Election, YesNoContest } from '@votingworks/types';
+import {
+  CandidateContest,
+  Election,
+  StraightPartyContest,
+  YesNoContest,
+} from '@votingworks/types';
 import { assert, find } from '@votingworks/basics';
 import userEvent from '@testing-library/user-event';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
@@ -689,5 +695,56 @@ describe('cross-endorsed candidates', () => {
     // Should show both party affiliations
     screen.getByText('Federalist');
     screen.getByText(/People/);
+  });
+});
+
+describe('straight party contest', () => {
+  const electionStraightParty = readElectionStraightParty();
+  const straightPartyContest = find(
+    electionStraightParty.contests,
+    (c): c is StraightPartyContest => c.type === 'straight-party'
+  );
+
+  test('with a vote shows the selected party', () => {
+    const returnToContest = vi.fn();
+    render(
+      <Review
+        election={electionStraightParty}
+        contests={[straightPartyContest]}
+        precinctId={electionStraightParty.precincts[0].id}
+        votes={{
+          [straightPartyContest.id]: [straightPartyContest.optionIds[0]],
+        }}
+        returnToContest={returnToContest}
+        ballotStyle={electionStraightParty.ballotStyles[0]}
+      />
+    );
+    const contestCard = screen
+      .getByText('Straight Party')
+      .closest('div[role="button"]') as HTMLElement;
+    screen.getByText('Federalist Party');
+    expect(
+      within(contestCard).queryByText('You may still vote in this contest.')
+    ).toEqual(null);
+
+    userEvent.click(within(contestCard).getButton(/Change/));
+    expect(returnToContest).toHaveBeenCalledWith(straightPartyContest.id);
+  });
+
+  test('with no vote shows the undervote warning', () => {
+    render(
+      <Review
+        election={electionStraightParty}
+        contests={[straightPartyContest]}
+        precinctId={electionStraightParty.precincts[0].id}
+        votes={{}}
+        returnToContest={vi.fn()}
+        ballotStyle={electionStraightParty.ballotStyles[0]}
+      />
+    );
+    const contestCard = screen
+      .getByText('Straight Party')
+      .closest('div[role="button"]') as HTMLElement;
+    within(contestCard).getByText('You may still vote in this contest.');
   });
 });

--- a/libs/mark-flow-ui/src/components/review.tsx
+++ b/libs/mark-flow-ui/src/components/review.tsx
@@ -11,6 +11,7 @@ import {
   ContestId,
   BallotStyle,
   getCandidateVoteSortedForBallotStyleRotation,
+  StraightPartyVote,
 } from '@votingworks/types';
 import {
   Caption,
@@ -33,6 +34,7 @@ import { getSingleYesNoVote } from '@votingworks/utils';
 import {
   CandidateContestResultInterface,
   MsEitherNeitherContestResultInterface,
+  StraightPartyContestResultInterface,
   YesNoContestResultInterface,
 } from '../config/types';
 
@@ -157,6 +159,39 @@ function YesNoContestResult({
       title={electionStrings.contestTitle(contest)}
       titleType="h2"
       undervoteWarning={!yesNo ? noVotesString : undefined}
+      votes={votes}
+    />
+  );
+}
+
+function StraightPartyContestResult({
+  vote = [],
+  contest,
+  election,
+  selectionsAreEditable,
+}: StraightPartyContestResultInterface): JSX.Element {
+  const district = getContestDistrict(election, contest);
+  const selectedParty = election.parties.find((party) => party.id === vote[0]);
+
+  const votes: ContestVote[] = selectedParty
+    ? [
+        {
+          id: selectedParty.id,
+          label: electionStrings.partyFullName(selectedParty),
+        },
+      ]
+    : [];
+
+  const noVotesString = selectionsAreEditable
+    ? appStrings.warningNoVotesForContest()
+    : appStrings.noteBallotContestNoSelection();
+
+  return (
+    <VoterContestSummary
+      districtName={electionStrings.districtName(district)}
+      title={electionStrings.contestTitle(contest)}
+      titleType="h2"
+      undervoteWarning={!selectedParty ? noVotesString : undefined}
       votes={votes}
     />
   );
@@ -298,6 +333,14 @@ export function Review({
             {contest.type === 'yesno' && (
               <YesNoContestResult
                 vote={votes[contest.id] as YesNoVote}
+                contest={contest}
+                election={election}
+                selectionsAreEditable={selectionsAreEditable}
+              />
+            )}
+            {contest.type === 'straight-party' && (
+              <StraightPartyContestResult
+                vote={votes[contest.id] as StraightPartyVote}
                 contest={contest}
                 election={election}
                 selectionsAreEditable={selectionsAreEditable}

--- a/libs/mark-flow-ui/src/components/straight_party_contest.test.tsx
+++ b/libs/mark-flow-ui/src/components/straight_party_contest.test.tsx
@@ -1,0 +1,137 @@
+import { expect, test, vi } from 'vitest';
+import { readElectionStraightParty } from '@votingworks/fixtures';
+import { StraightPartyContest as StraightPartyContestInterface } from '@votingworks/types';
+import { find } from '@votingworks/basics';
+import userEvent from '@testing-library/user-event';
+import { act } from '@testing-library/react';
+import { screen, within, render } from '../../test/react_testing_library';
+import { StraightPartyContest } from './straight_party_contest';
+
+const election = readElectionStraightParty();
+const contest = find(
+  election.contests,
+  (c): c is StraightPartyContestInterface => c.type === 'straight-party'
+);
+
+const FEDERALIST_PARTY_ID = '0';
+
+function getOption(accessibleName: string | RegExp) {
+  return screen.getByRole('option', { name: accessibleName });
+}
+
+test('selecting a party', () => {
+  const updateVote = vi.fn();
+  render(
+    <StraightPartyContest
+      election={election}
+      contest={contest}
+      updateVote={updateVote}
+    />
+  );
+
+  screen.getByRole('heading', { name: contest.title });
+
+  userEvent.click(getOption(/Federalist Party/i));
+  expect(updateVote).toHaveBeenCalledTimes(1);
+  expect(updateVote).toHaveBeenCalledWith(contest.id, [FEDERALIST_PARTY_ID]);
+});
+
+test('deselecting the selected party', () => {
+  const updateVote = vi.fn();
+  render(
+    <StraightPartyContest
+      election={election}
+      contest={contest}
+      vote={[FEDERALIST_PARTY_ID]}
+      updateVote={updateVote}
+    />
+  );
+
+  userEvent.click(getOption(/Selected option.+Federalist Party/i));
+  expect(updateVote).toHaveBeenCalledTimes(1);
+  expect(updateVote).toHaveBeenCalledWith(contest.id, []);
+});
+
+test('attempting to overvote shows a warning and does not change the vote', () => {
+  const updateVote = vi.fn();
+  render(
+    <StraightPartyContest
+      election={election}
+      contest={contest}
+      vote={[FEDERALIST_PARTY_ID]}
+      updateVote={updateVote}
+    />
+  );
+
+  userEvent.click(getOption(/^Liberty Party/i));
+  expect(updateVote).not.toHaveBeenCalled();
+  within(screen.getByRole('alertdialog')).getByText(/first deselect/i);
+
+  userEvent.click(screen.getByText('Continue'));
+  expect(screen.queryByRole('alertdialog')).toEqual(null);
+});
+
+test('audio cues for selected and deselected options', () => {
+  vi.useFakeTimers();
+  const updateVote = vi.fn();
+  const { rerender } = render(
+    <StraightPartyContest
+      election={election}
+      contest={contest}
+      vote={[]}
+      updateVote={updateVote}
+    />
+  );
+
+  // Initially the option announces just the party name
+  getOption(/^Federalist Party/i);
+
+  // Select the party
+  userEvent.click(getOption(/^Federalist Party/i));
+  rerender(
+    <StraightPartyContest
+      election={election}
+      contest={contest}
+      vote={[FEDERALIST_PARTY_ID]}
+      updateVote={updateVote}
+    />
+  );
+  getOption(
+    /Selected option.+Federalist Party.+completed your selections on this contest/i
+  );
+
+  // Deselect the party
+  userEvent.click(getOption(/Selected option.+Federalist Party/i));
+  rerender(
+    <StraightPartyContest
+      election={election}
+      contest={contest}
+      vote={[]}
+      updateVote={updateVote}
+    />
+  );
+  getOption(/Deselected option.+Federalist Party/i);
+
+  // After a moment, the deselected cue clears
+  act(() => {
+    vi.advanceTimersByTime(1000);
+  });
+  getOption(/^Federalist Party/i);
+  expect(
+    screen.queryByRole('option', { name: /Deselected option.+Federalist/i })
+  ).toEqual(null);
+});
+
+test('shows review mode navigation instructions when isReviewMode is true', () => {
+  render(
+    <StraightPartyContest
+      election={election}
+      contest={contest}
+      vote={[]}
+      updateVote={vi.fn()}
+      isReviewMode
+    />
+  );
+
+  screen.getByText(/return to the review screen, use the right button/i);
+});

--- a/libs/mark-flow-ui/src/components/straight_party_contest.tsx
+++ b/libs/mark-flow-ui/src/components/straight_party_contest.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import {
   Election,
   getContestDistrict,
@@ -44,10 +44,23 @@ export function StraightPartyContest({
   const district = getContestDistrict(election, contest);
   const votesRemaining = 1 - vote.length;
   const [showOvervoteWarning, setShowOvervoteWarning] = useState(false);
+  const [recentlyDeselectedOption, setRecentlyDeselectedOption] =
+    useState<PartyId>();
+
+  useEffect(() => {
+    if (recentlyDeselectedOption) {
+      const timer = setTimeout(
+        () => setRecentlyDeselectedOption(undefined),
+        100
+      );
+      return () => clearTimeout(timer);
+    }
+  }, [recentlyDeselectedOption]);
 
   function handleOptionPress(optionId: PartyId) {
     if (vote.includes(optionId)) {
       updateVote(contest.id, []);
+      setRecentlyDeselectedOption(optionId);
     } else if (vote.length > 0) {
       setShowOvervoteWarning(true);
     } else {
@@ -79,17 +92,34 @@ export function StraightPartyContest({
       </ContestHeader>
       <WithScrollButtons>
         <ChoicesGrid>
-          {contest.optionIds.map((partyId) => (
-            <ContestChoiceButton
-              key={partyId}
-              isSelected={vote.includes(partyId)}
-              label={electionStrings.partyFullName(
-                find(election.parties, (party) => party.id === partyId)
-              )}
-              choice={partyId}
-              onPress={handleOptionPress}
-            />
-          ))}
+          {contest.optionIds.map((partyId) => {
+            const isSelected = vote.includes(partyId);
+            let prefixAudioText: ReactNode = null;
+            let suffixAudioText: ReactNode = null;
+            if (isSelected) {
+              prefixAudioText = appStrings.labelSelectedOption();
+              suffixAudioText = appStrings.noteBmdContestCompleted();
+            } else if (recentlyDeselectedOption === partyId) {
+              prefixAudioText = appStrings.labelDeselectedOption();
+            }
+            return (
+              <ContestChoiceButton
+                key={partyId}
+                isSelected={isSelected}
+                label={
+                  <React.Fragment>
+                    <AudioOnly>{prefixAudioText}</AudioOnly>
+                    {electionStrings.partyFullName(
+                      find(election.parties, (party) => party.id === partyId)
+                    )}
+                    <AudioOnly>{suffixAudioText}</AudioOnly>
+                  </React.Fragment>
+                }
+                choice={partyId}
+                onPress={handleOptionPress}
+              />
+            );
+          })}
         </ChoicesGrid>
       </WithScrollButtons>
       {showOvervoteWarning && (

--- a/libs/mark-flow-ui/src/components/straight_party_contest.tsx
+++ b/libs/mark-flow-ui/src/components/straight_party_contest.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react';
+import {
+  Election,
+  getContestDistrict,
+  PartyId,
+  StraightPartyContest as StraightPartyContestInterface,
+  StraightPartyVote,
+} from '@votingworks/types';
+import {
+  Main,
+  WithScrollButtons,
+  Caption,
+  appStrings,
+  NumberString,
+  AudioOnly,
+  AssistiveTechInstructions,
+  ContestChoiceButton,
+  electionStrings,
+  Modal,
+  P,
+  Button,
+  PageNavigationButtonId,
+} from '@votingworks/ui';
+import { find } from '@votingworks/basics';
+import { UpdateVoteFunction } from '../config/types';
+import { ContestHeader } from './contest_header';
+import { ChoicesGrid } from './contest_screen_layout';
+
+interface Props {
+  election: Election;
+  contest: StraightPartyContestInterface;
+  vote?: StraightPartyVote;
+  updateVote: UpdateVoteFunction;
+  isReviewMode?: boolean;
+}
+
+export function StraightPartyContest({
+  election,
+  contest,
+  vote = [],
+  updateVote,
+  isReviewMode,
+}: Props): JSX.Element {
+  const district = getContestDistrict(election, contest);
+  const votesRemaining = 1 - vote.length;
+  const [showOvervoteWarning, setShowOvervoteWarning] = useState(false);
+
+  function handleOptionPress(optionId: PartyId) {
+    if (vote.includes(optionId)) {
+      updateVote(contest.id, []);
+    } else if (vote.length > 0) {
+      setShowOvervoteWarning(true);
+    } else {
+      updateVote(contest.id, [optionId]);
+    }
+  }
+
+  return (
+    <Main flexColumn>
+      <ContestHeader contest={contest} district={district}>
+        <Caption>
+          {appStrings.labelNumVotesRemaining()}{' '}
+          <NumberString value={votesRemaining} weight="bold" />
+          <AudioOnly>
+            <AssistiveTechInstructions
+              controllerString={
+                isReviewMode
+                  ? appStrings.instructionsBmdContestNavigationReviewMode()
+                  : appStrings.instructionsBmdContestNavigation()
+              }
+              patDeviceString={
+                isReviewMode
+                  ? appStrings.instructionsBmdContestNavigationReviewModePatDevice()
+                  : appStrings.instructionsBmdContestNavigationPatDevice()
+              }
+            />
+          </AudioOnly>
+        </Caption>
+      </ContestHeader>
+      <WithScrollButtons>
+        <ChoicesGrid>
+          {contest.optionIds.map((partyId) => (
+            <ContestChoiceButton
+              key={partyId}
+              isSelected={vote.includes(partyId)}
+              label={electionStrings.partyFullName(
+                find(election.parties, (party) => party.id === partyId)
+              )}
+              choice={partyId}
+              onPress={handleOptionPress}
+            />
+          ))}
+        </ChoicesGrid>
+      </WithScrollButtons>
+      {showOvervoteWarning && (
+        <Modal
+          centerContent
+          content={
+            <P>
+              {appStrings.warningOvervoteYesNoContest()}
+              <AudioOnly>
+                <AssistiveTechInstructions
+                  controllerString={appStrings.instructionsBmdNextToContinue()}
+                  patDeviceString={appStrings.instructionsBmdMoveToSelectToContinuePatDevice()}
+                />
+              </AudioOnly>
+            </P>
+          }
+          actions={
+            <Button
+              variant="primary"
+              autoFocus
+              onPress={() => setShowOvervoteWarning(false)}
+              id={PageNavigationButtonId.NEXT}
+            >
+              {appStrings.buttonContinue()}
+              <AudioOnly>
+                <AssistiveTechInstructions
+                  controllerString={appStrings.instructionsBmdSelectToContinue()}
+                  patDeviceString={appStrings.instructionsBmdSelectToContinuePatDevice()}
+                />
+              </AudioOnly>
+            </Button>
+          }
+        />
+      )}
+    </Main>
+  );
+}

--- a/libs/mark-flow-ui/src/config/types.ts
+++ b/libs/mark-flow-ui/src/config/types.ts
@@ -9,6 +9,8 @@ import {
   OptionalVote,
   OptionalYesNoVote,
   PrecinctId,
+  StraightPartyContest,
+  StraightPartyVote,
   VotesDict,
   YesNoContest,
 } from '@votingworks/types';
@@ -46,12 +48,18 @@ export interface CandidateContestResultInterface {
   ballotStyle: BallotStyle;
   precinctId: PrecinctId;
   selectionsAreEditable?: boolean;
-  vote: CandidateVote;
+  vote?: CandidateVote;
 }
 export interface YesNoContestResultInterface {
   contest: YesNoContest;
   election: Election;
   vote: OptionalYesNoVote;
+  selectionsAreEditable?: boolean;
+}
+export interface StraightPartyContestResultInterface {
+  contest: StraightPartyContest;
+  election: Election;
+  vote?: StraightPartyVote;
   selectionsAreEditable?: boolean;
 }
 export interface MsEitherNeitherContestResultInterface {

--- a/libs/mark-flow-ui/src/pages/contest_page.tsx
+++ b/libs/mark-flow-ui/src/pages/contest_page.tsx
@@ -9,7 +9,6 @@ import {
   OptionalVote,
   PrecinctId,
   VotesDict,
-  straightPartyNotYetImplemented,
 } from '@votingworks/types';
 import {
   LinkButton,
@@ -105,17 +104,14 @@ export function ContestPage(props: ContestPageProps): JSX.Element {
         ballotContestCount: contests.length,
       };
 
-  /* istanbul ignore next */
-  if (contest.type === 'straight-party') {
-    straightPartyNotYetImplemented();
-  }
-
   const isVoteComplete = (() => {
     switch (contest.type) {
       case 'yesno':
         return !!vote;
       case 'candidate':
         return vote && numVotesRemaining(contest, vote as CandidateVote) === 0;
+      case 'straight-party':
+        return vote?.length === 1;
       case 'ms-either-neither':
         return (
           votes[contest.pickOneContestId]?.length === 1 ||


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->
Task: https://github.com/votingworks/vxsuite/issues/8733

Adds the UI components to mark-flow-ui to support voting in straight party contests. The UI is modeled after the candidate contest UI. Also adds review screen support for straight party contests.

Derived votes based on the straight party selection will be added in a separate PR.

## Demo Video or Screenshot


https://github.com/user-attachments/assets/8a26fee3-fcdd-4fa7-8e4e-d7d34ee6a176

https://github.com/user-attachments/assets/0d1523fa-0c78-426d-8b36-a2c5ac379252






## Testing Plan
- Manual test
- Added automated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
