### PR TITLE
Misc write-in image report cleanup

### DIFF
--- a/apps/admin/frontend/src/screens/reporting/write_in_image_report_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/write_in_image_report_screen.test.tsx
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import {
+  electionFamousNames2021Fixtures,
+  electionTwoPartyPrimaryFixtures,
+} from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
 import { ok } from '@votingworks/basics';
 import { mockUsbDriveStatus } from '@votingworks/ui';
@@ -29,7 +32,9 @@ const MAYOR_CONTEST_ID = 'mayor';
 function selectContest(contestTitle: string) {
   const select = screen.getByRole('combobox');
   fireEvent.keyDown(select, { key: 'ArrowDown' });
-  fireEvent.click(screen.getByText(contestTitle));
+  // Option labels are disambiguated (e.g. "Mayor · City of Lincoln"), so match
+  // the title as a substring.
+  fireEvent.click(screen.getByText(contestTitle, { exact: false }));
 }
 
 test('initial state: no contest selected, no actions shown', async () => {
@@ -123,6 +128,23 @@ test('export report PDF', async () => {
   await screen.findByText('Write-In Image Report Saved');
   userEvent.click(within(exportModal).getButton('Close'));
   expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+});
+
+test('contest options are disambiguated by district, party, and term, and sorted by label', () => {
+  renderInAppContext(<WriteInImageReportScreen />, {
+    electionDefinition:
+      electionTwoPartyPrimaryFixtures.readElectionDefinition(),
+    apiMock,
+    usbDriveStatus: mockUsbDriveStatus('mounted'),
+  });
+
+  const select = screen.getByRole('combobox');
+  fireEvent.keyDown(select, { key: 'ArrowDown' });
+
+  expect(screen.getAllByRole('option').map((o) => o.textContent)).toEqual([
+    'Zoo Council · District 1 · F · For three years',
+    'Zoo Council · District 1 · Ma · For three years',
+  ]);
 });
 
 test('shows warning and disables actions when PDF is too large', async () => {

--- a/apps/admin/frontend/src/screens/reporting/write_in_image_report_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/write_in_image_report_screen.tsx
@@ -2,7 +2,12 @@ import { useContext, useState } from 'react';
 import { SearchSelect } from '@votingworks/ui';
 import { assert } from '@votingworks/basics';
 import { isElectionManagerAuth } from '@votingworks/utils';
-import { CandidateContest } from '@votingworks/types';
+import {
+  CandidateContest,
+  Election,
+  getContestDistrictName,
+  getPartyAbbreviationByPartyId,
+} from '@votingworks/types';
 import styled from 'styled-components';
 import { AppContext } from '../../contexts/app_context';
 import { NavigationScreen } from '../../components/navigation_screen';
@@ -33,6 +38,29 @@ const SelectContestContainer = styled.div`
     white-space: nowrap;
   }
 `;
+
+/**
+ * Concatenates the relevant attributes to ensure a unique label for each
+ * contest since contests can have the same title.
+ */
+function constructContestLabel(
+  contest: CandidateContest,
+  election: Election
+): string {
+  const parts = [contest.title, getContestDistrictName(election, contest)];
+  if (contest.partyId) {
+    parts.push(
+      getPartyAbbreviationByPartyId({
+        partyId: contest.partyId,
+        election,
+      })
+    );
+  }
+  if (contest.termDescription) {
+    parts.push(contest.termDescription);
+  }
+  return parts.join(' · ');
+}
 
 export function WriteInImageReportScreen(): JSX.Element {
   const { electionDefinition, auth } = useContext(AppContext);
@@ -68,10 +96,12 @@ export function WriteInImageReportScreen(): JSX.Element {
             isMulti={false}
             isSearchable
             value={contestId}
-            options={writeInContests.map((c) => ({
-              value: c.id,
-              label: c.title,
-            }))}
+            options={writeInContests
+              .map((contest) => ({
+                value: contest.id,
+                label: constructContestLabel(contest, election),
+              }))
+              .sort((o1, o2) => o1.label.localeCompare(o2.label))}
             onChange={(value) => setContestId(value)}
             aria-label="Select Contest"
             style={{ width: '30rem' }}

--- a/apps/admin/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/admin/integration-testing/e2e/screenshots.spec.ts
@@ -764,7 +764,7 @@ test('results', async ({ page }, testInfo) => {
     .getByRole('heading', { name: 'Single Contest Write-In Image Report' })
     .waitFor();
   await openDropdown(page, 'Select Contest');
-  await selectOpenDropdownOption(page, 'Mayor');
+  await selectOpenDropdownOption(page, 'Mayor', { exact: false });
   await waitForReportToLoad(page);
   await screenshot('write-in-image-report');
   await printAndCaptureReport({

--- a/apps/admin/integration-testing/e2e/support/navigation.ts
+++ b/apps/admin/integration-testing/e2e/support/navigation.ts
@@ -16,12 +16,13 @@ export async function openDropdown(
 
 export async function selectOpenDropdownOption(
   page: Page,
-  optionLabel: string
+  optionLabel: string,
+  options: { exact?: boolean } = {}
 ): Promise<void> {
   await page
     .locator('.search-select')
     .filter({ has: page.getByRole('combobox', { expanded: true }) })
-    .getByText(optionLabel, { exact: true })
+    .getByText(optionLabel, { exact: options.exact ?? true })
     .click();
 }
 

--- a/libs/ui/src/reports/admin_write_in_image_report.tsx
+++ b/libs/ui/src/reports/admin_write_in_image_report.tsx
@@ -156,8 +156,8 @@ export function AdminWriteInImageReport({
                   </React.Fragment>
                 ) : !qualifiedWriteInsEnabled && totalWriteIns === 0 ? (
                   <P>
-                    <Icons.Info />
-                    No write-in candidates have received votes in this contest.
+                    <Icons.Info /> No write-in candidates have received votes in
+                    this contest.
                   </P>
                 ) : (
                   <React.Fragment>


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/8652

This PR ports and refines a few write-in image report fixes from the MI RFP demo branch. The two fixes include:
* Adding a missing space between an icon and text (more we could do here but this is the minimal necessary change)
* Disambiguating contests in the VxAdmin write-in image report generating UI by using more than just the contest title in the selection dropdown

## Demo Video or Screenshot

### Before

<img width="1512" height="835" alt="before" src="https://github.com/user-attachments/assets/4cfa8f49-fe2e-40c8-bc94-52300727d493" />

### After

<img width="1512" height="835" alt="after" src="https://github.com/user-attachments/assets/5b4d623d-de01-4797-acec-c0e82ea5e102" />

## Testing Plan

- [x] Updated automated tests
- [x] Tested manually

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.