### PR TITLE
Rename registeredVotersCounts registeredVoterCounts (removing s from voters)

### DIFF
--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -13,7 +13,7 @@ import {
   DEV_MACHINE_ID,
   ElectionPackageFileName,
   LATEST_METADATA,
-  ElectionRegisteredVotersCounts,
+  ElectionRegisteredVoterCounts,
   PrinterStatus,
   safeParseElectionDefinition,
   testElectionReport,
@@ -459,7 +459,7 @@ test('getSystemSettings happy path', async () => {
 test('getRegisteredVoterCounts', async () => {
   const electionDefinition =
     electionTwoPartyPrimaryFixtures.readElectionDefinition();
-  const registeredVoterCounts: ElectionRegisteredVotersCounts = {
+  const registeredVoterCounts: ElectionRegisteredVoterCounts = {
     'precinct-1': 500,
     'precinct-2': 400,
   };

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -5,7 +5,7 @@ import {
   Admin,
   ElectionPackageFileName,
   LATEST_METADATA,
-  ElectionRegisteredVotersCounts,
+  ElectionRegisteredVoterCounts,
   CastVoteRecordExportFileName,
   ContestId,
   DEFAULT_SYSTEM_SETTINGS,
@@ -620,7 +620,7 @@ function buildApi({
       return null;
     },
 
-    getRegisteredVoterCounts(): ElectionRegisteredVotersCounts | null {
+    getRegisteredVoterCounts(): ElectionRegisteredVoterCounts | null {
       const currentElectionId = store.getCurrentElectionId();
       if (!currentElectionId) {
         return null;

--- a/apps/admin/backend/src/app.voter_turnout_report.test.ts
+++ b/apps/admin/backend/src/app.voter_turnout_report.test.ts
@@ -14,7 +14,7 @@ import {
   DEFAULT_SYSTEM_SETTINGS,
   ElectionPackageFileName,
   LATEST_METADATA,
-  ElectionRegisteredVotersCounts,
+  ElectionRegisteredVoterCounts,
 } from '@votingworks/types';
 import { zipFile } from '@votingworks/test-utils';
 import {
@@ -76,7 +76,7 @@ test('configure persists registered voter counts from election package', async (
   const { apiClient, auth, workspace } = buildTestEnvironment();
   mockSystemAdministratorAuth(auth);
 
-  const registeredVoterCounts: ElectionRegisteredVotersCounts = {
+  const registeredVoterCounts: ElectionRegisteredVoterCounts = {
     'precinct-1': 500,
     'precinct-2': 400,
   };
@@ -87,7 +87,7 @@ test('configure persists registered voter counts from election package', async (
       DEFAULT_SYSTEM_SETTINGS
     ),
     [ElectionPackageFileName.APP_STRINGS]: JSON.stringify({}),
-    [ElectionPackageFileName.REGISTERED_VOTERS_COUNTS]: JSON.stringify(
+    [ElectionPackageFileName.REGISTERED_VOTER_COUNTS]: JSON.stringify(
       registeredVoterCounts
     ),
   });
@@ -263,7 +263,7 @@ test('voter turnout report with split precinct registered voter counts', async (
   const { apiClient, auth, workspace } = buildTestEnvironment();
   mockSystemAdministratorAuth(auth);
 
-  const registeredVoterCounts: ElectionRegisteredVotersCounts = {
+  const registeredVoterCounts: ElectionRegisteredVoterCounts = {
     'precinct-c2': {
       splits: {
         'precinct-c2-split-1': 200,
@@ -278,7 +278,7 @@ test('voter turnout report with split precinct registered voter counts', async (
       DEFAULT_SYSTEM_SETTINGS
     ),
     [ElectionPackageFileName.APP_STRINGS]: JSON.stringify({}),
-    [ElectionPackageFileName.REGISTERED_VOTERS_COUNTS]: JSON.stringify(
+    [ElectionPackageFileName.REGISTERED_VOTER_COUNTS]: JSON.stringify(
       registeredVoterCounts
     ),
   });

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -15,7 +15,7 @@ import {
   BallotStyleGroupId,
   Id,
   Election,
-  ElectionRegisteredVotersCounts,
+  ElectionRegisteredVoterCounts,
   SystemSettings,
 } from '@votingworks/types';
 import { assertDefined, find, typedAs } from '@votingworks/basics';
@@ -124,7 +124,7 @@ test('setRegisteredVoterCounts and getRegisteredVoterCounts with precinct-only c
 
   expect(store.getRegisteredVoterCounts(electionId)).toBeUndefined();
 
-  const counts: ElectionRegisteredVotersCounts = {
+  const counts: ElectionRegisteredVoterCounts = {
     'precinct-1': 500,
     'precinct-2': 300,
   };
@@ -143,7 +143,7 @@ test('setRegisteredVoterCounts and getRegisteredVoterCounts with split precinct 
   });
 
   // precinct-c2 has splits; precinct-c1-w1-1 does not
-  const counts: ElectionRegisteredVotersCounts = {
+  const counts: ElectionRegisteredVoterCounts = {
     'precinct-c1-w1-1': 400,
     'precinct-c2': {
       splits: {

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -47,8 +47,8 @@ import {
   BallotStyleGroup,
   getContests,
   SheetOf,
-  ElectionRegisteredVotersCounts,
-  ElectionRegisteredVotersCountsSchema,
+  ElectionRegisteredVoterCounts,
+  ElectionRegisteredVoterCountsSchema,
   UserRole,
   PartyId,
 } from '@votingworks/types';
@@ -400,7 +400,7 @@ export class Store implements BaseStore {
 
   setRegisteredVoterCounts(
     electionId: Id,
-    counts: ElectionRegisteredVotersCounts
+    counts: ElectionRegisteredVoterCounts
   ): void {
     this.withTransaction(() => {
       for (const [precinctId, entry] of Object.entries(counts)) {
@@ -434,7 +434,7 @@ export class Store implements BaseStore {
 
   getRegisteredVoterCounts(
     electionId: Id
-  ): ElectionRegisteredVotersCounts | undefined {
+  ): ElectionRegisteredVoterCounts | undefined {
     const precinctRows = this.client.all(
       `
       select precinct_id as precinctId, count
@@ -457,7 +457,7 @@ export class Store implements BaseStore {
       return undefined;
     }
 
-    const counts: ElectionRegisteredVotersCounts = {};
+    const counts: ElectionRegisteredVoterCounts = {};
     for (const { precinctId, count } of precinctRows) {
       counts[precinctId] = count;
     }
@@ -473,7 +473,7 @@ export class Store implements BaseStore {
         existing.splits[splitId] = count;
       }
     }
-    return ElectionRegisteredVotersCountsSchema.parse(counts);
+    return ElectionRegisteredVoterCountsSchema.parse(counts);
   }
 
   /**

--- a/apps/admin/backend/test/app.ts
+++ b/apps/admin/backend/test/app.ts
@@ -17,7 +17,7 @@ import {
   constructElectionKey,
   ElectionDefinition,
   ElectionPackageFileName,
-  ElectionRegisteredVotersCounts,
+  ElectionRegisteredVoterCounts,
   LATEST_METADATA,
   SystemSettings,
 } from '@votingworks/types';
@@ -123,7 +123,7 @@ export async function configureMachine(
   apiClient: grout.Client<Api>,
   auth: DippedSmartCardAuthApi,
   electionDefinition: ElectionDefinition,
-  registeredVoterCounts?: ElectionRegisteredVotersCounts,
+  registeredVoterCounts?: ElectionRegisteredVoterCounts,
   systemSettings: SystemSettings = DEFAULT_SYSTEM_SETTINGS
 ): Promise<string> {
   mockSystemAdministratorAuth(auth);
@@ -134,7 +134,7 @@ export async function configureMachine(
     [ElectionPackageFileName.APP_STRINGS]: JSON.stringify({}),
     ...(registeredVoterCounts
       ? {
-          [ElectionPackageFileName.REGISTERED_VOTERS_COUNTS]: JSON.stringify(
+          [ElectionPackageFileName.REGISTERED_VOTER_COUNTS]: JSON.stringify(
             registeredVoterCounts
           ),
         }

--- a/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/reports_screen.tsx
@@ -8,7 +8,7 @@ import { assert } from '@votingworks/basics';
 import styled from 'styled-components';
 import {
   Election,
-  ElectionRegisteredVotersCounts,
+  ElectionRegisteredVoterCounts,
   hasPartialRegisteredVoterCounts,
 } from '@votingworks/types';
 import { AppContext } from '../../contexts/app_context';
@@ -35,7 +35,7 @@ const CalloutIconWrapper = styled.span`
 
 export function isVoterTurnoutReportEnabled(
   election: Election,
-  registeredVoterCounts?: ElectionRegisteredVotersCounts | null
+  registeredVoterCounts?: ElectionRegisteredVoterCounts | null
 ): boolean {
   if (
     registeredVoterCounts === null ||

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -779,7 +779,7 @@ export function createApiMock(
     ),
 
     expectGetRegisteredVoterCounts(
-      counts: import('@votingworks/types').ElectionRegisteredVotersCounts | null
+      counts: import('@votingworks/types').ElectionRegisteredVoterCounts | null
     ) {
       apiClient.getRegisteredVoterCounts.expectCallWith().resolves(counts);
     },

--- a/apps/admin/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/admin/integration-testing/e2e/screenshots.spec.ts
@@ -38,7 +38,7 @@ import {
   DEFAULT_SYSTEM_SETTINGS,
   ElectionDefinition,
   ElectionPackageFileName,
-  ElectionRegisteredVotersCounts,
+  ElectionRegisteredVoterCounts,
   LATEST_METADATA,
   SystemSettings,
   VotesDict,
@@ -358,7 +358,7 @@ async function configureMachine({
   usbHandler: MockFileUsbDriveHandler;
   electionDefinition: ElectionDefinition;
   systemSettings?: SystemSettings;
-  registeredVoterCounts?: ElectionRegisteredVotersCounts;
+  registeredVoterCounts?: ElectionRegisteredVoterCounts;
 }): Promise<void> {
   const { election, electionData } = electionDefinition;
   const electionPackage = await zipFile({
@@ -368,7 +368,7 @@ async function configureMachine({
     [ElectionPackageFileName.APP_STRINGS]: JSON.stringify({}),
     ...(registeredVoterCounts
       ? {
-          [ElectionPackageFileName.REGISTERED_VOTERS_COUNTS]: JSON.stringify(
+          [ElectionPackageFileName.REGISTERED_VOTER_COUNTS]: JSON.stringify(
             registeredVoterCounts
           ),
         }
@@ -545,7 +545,7 @@ test('results', async ({ page }, testInfo) => {
   ]);
 
   // Registered-voter counts for every precinct so the turnout report is enabled.
-  const registeredVoterCounts: ElectionRegisteredVotersCounts = {
+  const registeredVoterCounts: ElectionRegisteredVoterCounts = {
     '20': 15,
     '21': 8,
     '22': 5,

--- a/apps/design/backend/migrations/1782000000000_rename-registered-voter-counts-tables.js
+++ b/apps/design/backend/migrations/1782000000000_rename-registered-voter-counts-tables.js
@@ -1,0 +1,22 @@
+exports.shorthands =
+  /** @type {import('node-pg-migrate').ColumnDefinitions | undefined} */ (
+    undefined
+  );
+
+/**
+ * Renames the registered voter count tables to the singular "voter" form, to
+ * match VxAdmin and the rest of the codebase.
+ *
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  pgm.renameTable(
+    'precinct_registered_voters_counts',
+    'precinct_registered_voter_counts'
+  );
+  pgm.renameTable(
+    'precinct_split_registered_voters_counts',
+    'precinct_split_registered_voter_counts'
+  );
+};

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -58,7 +58,7 @@ import {
   pollingPlacesGenerateFromPrecincts,
   PrecinctWithoutSplits,
   PrecinctWithSplits,
-  ElectionRegisteredVotersCounts,
+  ElectionRegisteredVoterCounts,
   ElectionPackageFileName,
   safeParseElectionDefinitionV4p0,
   LATEST_SOFTWARE_VERSION,
@@ -1523,11 +1523,11 @@ test('registered voter counts are stored and retrieved for precincts and splits'
     await apiClient.createPrecinct({
       electionId,
       newPrecinct: precinct1,
-      registeredVotersCounts: 500,
+      registeredVoterCounts: 500,
     })
   ).unsafeUnwrap();
   // Verify the initial count is written
-  expect(await apiClient.getRegisteredVotersCounts({ electionId })).toEqual({
+  expect(await apiClient.getRegisteredVoterCounts({ electionId })).toEqual({
     'precinct-1': 500,
   });
 
@@ -1536,11 +1536,11 @@ test('registered voter counts are stored and retrieved for precincts and splits'
     await apiClient.updatePrecinct({
       electionId,
       updatedPrecinct: precinct1,
-      registeredVotersCounts: 750,
+      registeredVoterCounts: 750,
     })
   ).unsafeUnwrap();
-  // Verify getRegisteredVotersCounts reflects the count
-  expect(await apiClient.getRegisteredVotersCounts({ electionId })).toEqual({
+  // Verify getRegisteredVoterCounts reflects the count
+  expect(await apiClient.getRegisteredVoterCounts({ electionId })).toEqual({
     'precinct-1': 750,
   });
 
@@ -1565,12 +1565,12 @@ test('registered voter counts are stored and retrieved for precincts and splits'
     await apiClient.createPrecinct({
       electionId,
       newPrecinct: precinct2,
-      registeredVotersCounts: { splits: { 'split-1': 200, 'split-2': 300 } },
+      registeredVoterCounts: { splits: { 'split-1': 200, 'split-2': 300 } },
     })
   ).unsafeUnwrap();
 
-  // Verify getRegisteredVotersCounts for split precincts
-  expect(await workspace.store.getRegisteredVotersCounts(electionId)).toEqual({
+  // Verify getRegisteredVoterCounts for split precincts
+  expect(await workspace.store.getRegisteredVoterCounts(electionId)).toEqual({
     'precinct-1': 750,
     'precinct-2': {
       splits: {
@@ -1580,11 +1580,11 @@ test('registered voter counts are stored and retrieved for precincts and splits'
     },
   });
 
-  // Update registered voters counts and assert update was written
+  // Update registered voter counts and assert update was written
   await workspace.store.setPrecinctRegisteredVoterCounts(precinct2, {
     splits: { 'split-1': 250, 'split-2': 350 },
   });
-  expect(await workspace.store.getRegisteredVotersCounts(electionId)).toEqual({
+  expect(await workspace.store.getRegisteredVoterCounts(electionId)).toEqual({
     'precinct-1': 750,
     'precinct-2': {
       splits: {
@@ -1616,10 +1616,10 @@ test('registered voter counts are stored and retrieved for precincts and splits'
     await apiClient.createPrecinct({
       electionId,
       newPrecinct: precinct3,
-      registeredVotersCounts: { splits: { 'split-3a': 400 } },
+      registeredVoterCounts: { splits: { 'split-3a': 400 } },
     })
   ).unsafeUnwrap();
-  expect(await workspace.store.getRegisteredVotersCounts(electionId)).toEqual({
+  expect(await workspace.store.getRegisteredVoterCounts(electionId)).toEqual({
     'precinct-1': 750,
     'precinct-2': {
       splits: {
@@ -1657,8 +1657,8 @@ test('registered voter counts are stored and retrieved for precincts and splits'
     await apiClient.createPrecinct({ electionId, newPrecinct: precinct5 })
   ).unsafeUnwrap();
 
-  // Precincts with no counts should not appear in getRegisteredVotersCounts
-  expect(await workspace.store.getRegisteredVotersCounts(electionId)).toEqual({
+  // Precincts with no counts should not appear in getRegisteredVoterCounts
+  expect(await workspace.store.getRegisteredVoterCounts(electionId)).toEqual({
     'precinct-1': 750,
     'precinct-2': {
       splits: {
@@ -2900,7 +2900,7 @@ test('Finalize ballots - rejects partial registered voter counts', async () => {
     await apiClient.updatePrecinct({
       electionId,
       updatedPrecinct: firstPrecinct,
-      registeredVotersCounts: 500,
+      registeredVoterCounts: 500,
     })
   ).unsafeUnwrap();
 
@@ -2917,7 +2917,7 @@ test('Finalize ballots - rejects partial registered voter counts', async () => {
         await apiClient.updatePrecinct({
           electionId,
           updatedPrecinct: precinct,
-          registeredVotersCounts: 500,
+          registeredVoterCounts: 500,
         })
       ).unsafeUnwrap();
     }
@@ -3622,7 +3622,7 @@ test('Election package and ballots export', async () => {
         await apiClient.updatePrecinct({
           electionId,
           updatedPrecinct: precinct,
-          registeredVotersCounts: 1000,
+          registeredVoterCounts: 1000,
         })
       ).unsafeUnwrap();
     }
@@ -3631,13 +3631,13 @@ test('Election package and ballots export', async () => {
     await apiClient.updatePrecinct({
       electionId,
       updatedPrecinct: splitPrecinct,
-      registeredVotersCounts: {
+      registeredVoterCounts: {
         splits: { [splitFirstId]: 500, [splitSecondId]: 300 },
       },
     })
   ).unsafeUnwrap();
 
-  const expectedRegisteredVoterCounts: ElectionRegisteredVotersCounts = {
+  const expectedRegisteredVoterCounts: ElectionRegisteredVoterCounts = {
     ...Object.fromEntries(
       precincts.filter((p) => !hasSplits(p)).map((p) => [p.id, 1000])
     ),

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -15,9 +15,9 @@ import {
   unsafeParse,
   getAllBallotLanguages,
   Precinct,
-  PrecinctRegisteredVotersCountEntry,
-  PrecinctRegisteredVotersCountEntrySchema,
-  ElectionRegisteredVotersCounts,
+  PrecinctRegisteredVoterCountEntry,
+  PrecinctRegisteredVoterCountEntrySchema,
+  ElectionRegisteredVoterCounts,
   District,
   PrecinctId,
   Party,
@@ -535,14 +535,14 @@ export function buildApi(ctx: AppContext) {
     async createPrecinct(input: {
       electionId: ElectionId;
       newPrecinct: Precinct;
-      registeredVotersCounts?: PrecinctRegisteredVotersCountEntry;
+      registeredVoterCounts?: PrecinctRegisteredVoterCountEntry;
     }): Promise<Result<void, DuplicatePrecinctError>> {
       const precinct = unsafeParse(PrecinctSchema, input.newPrecinct);
-      const registeredVotersCounts =
-        input.registeredVotersCounts !== undefined
+      const registeredVoterCounts =
+        input.registeredVoterCounts !== undefined
           ? unsafeParse(
-              PrecinctRegisteredVotersCountEntrySchema,
-              input.registeredVotersCounts
+              PrecinctRegisteredVoterCountEntrySchema,
+              input.registeredVoterCounts
             )
           : undefined;
       const result = await store.createPrecinct(input.electionId, precinct);
@@ -551,7 +551,7 @@ export function buildApi(ctx: AppContext) {
       }
       await store.setPrecinctRegisteredVoterCounts(
         precinct,
-        registeredVotersCounts
+        registeredVoterCounts
       );
       return ok();
     },
@@ -559,14 +559,14 @@ export function buildApi(ctx: AppContext) {
     async updatePrecinct(input: {
       electionId: ElectionId;
       updatedPrecinct: Precinct;
-      registeredVotersCounts?: PrecinctRegisteredVotersCountEntry;
+      registeredVoterCounts?: PrecinctRegisteredVoterCountEntry;
     }): Promise<Result<void, DuplicatePrecinctError>> {
       const precinct = unsafeParse(PrecinctSchema, input.updatedPrecinct);
-      const registeredVotersCounts =
-        input.registeredVotersCounts !== undefined
+      const registeredVoterCounts =
+        input.registeredVoterCounts !== undefined
           ? unsafeParse(
-              PrecinctRegisteredVotersCountEntrySchema,
-              input.registeredVotersCounts
+              PrecinctRegisteredVoterCountEntrySchema,
+              input.registeredVoterCounts
             )
           : undefined;
       const result = await store.updatePrecinct(input.electionId, precinct);
@@ -575,15 +575,15 @@ export function buildApi(ctx: AppContext) {
       }
       await store.setPrecinctRegisteredVoterCounts(
         precinct,
-        registeredVotersCounts
+        registeredVoterCounts
       );
       return ok();
     },
 
-    async getRegisteredVotersCounts(input: {
+    async getRegisteredVoterCounts(input: {
       electionId: ElectionId;
-    }): Promise<ElectionRegisteredVotersCounts> {
-      return store.getRegisteredVotersCounts(input.electionId);
+    }): Promise<ElectionRegisteredVoterCounts> {
+      return store.getRegisteredVoterCounts(input.electionId);
     },
 
     async deletePrecinct(input: {
@@ -708,8 +708,8 @@ export function buildApi(ctx: AppContext) {
       const stateFeatures = getStateFeaturesConfig(jurisdiction);
       const { election } = await store.getElection(input.electionId);
 
-      if (!stateFeatures.DISABLE_REGISTERED_VOTERS_COUNTS) {
-        const registeredVoterCounts = await store.getRegisteredVotersCounts(
+      if (!stateFeatures.DISABLE_REGISTERED_VOTER_COUNTS) {
+        const registeredVoterCounts = await store.getRegisteredVoterCounts(
           input.electionId
         );
         assert(

--- a/apps/design/backend/src/features.ts
+++ b/apps/design/backend/src/features.ts
@@ -161,7 +161,7 @@ export interface StateFeaturesConfig {
   /**
    * Hides the registered voter count fields in the precinct form.
    */
-  DISABLE_REGISTERED_VOTERS_COUNTS?: boolean;
+  DISABLE_REGISTERED_VOTER_COUNTS?: boolean;
   /**
    * Allows an election to have no absentee polling places. Enabled for states
    * where central scanning is only ever an emergency fallback (NH).

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -53,10 +53,10 @@ import {
   PollingPlace,
   PollingPlaceType,
   pollingPlaceGenerateFromPrecinct,
-  ElectionRegisteredVotersCounts,
+  ElectionRegisteredVoterCounts,
   isPrecinctCount,
   isSplitCounts,
-  PrecinctRegisteredVotersCountEntry,
+  PrecinctRegisteredVoterCountEntry,
   safeParseElectionDefinitionForAnySoftwareVersion,
   SoftwareVersion,
   ElectionType,
@@ -1787,35 +1787,35 @@ export class Store {
   /**
    * Sets the registered voter counts for a precinct or splits in a precinct.
    * @param precinct The precinct to update.
-   * @param registeredVotersCounts Will unset the registered voter count if undefined.
+   * @param registeredVoterCounts Will unset the registered voter count if undefined.
    */
   async setPrecinctRegisteredVoterCounts(
     precinct: Precinct,
-    registeredVotersCounts?: PrecinctRegisteredVotersCountEntry
+    registeredVoterCounts?: PrecinctRegisteredVoterCountEntry
   ): Promise<void> {
     await this.db.withClient((client) =>
       client.withTransaction(async () => {
         await client.query(
-          `delete from precinct_registered_voters_counts where precinct_id = $1`,
+          `delete from precinct_registered_voter_counts where precinct_id = $1`,
           precinct.id
         );
         if (
           !hasSplits(precinct) &&
-          registeredVotersCounts !== undefined &&
-          isPrecinctCount(registeredVotersCounts)
+          registeredVoterCounts !== undefined &&
+          isPrecinctCount(registeredVoterCounts)
         ) {
           await client.query(
             `
-              insert into precinct_registered_voters_counts (precinct_id, count)
+              insert into precinct_registered_voter_counts (precinct_id, count)
               values ($1, $2)
             `,
             precinct.id,
-            registeredVotersCounts
+            registeredVoterCounts
           );
         }
         await client.query(
           `
-            delete from precinct_split_registered_voters_counts
+            delete from precinct_split_registered_voter_counts
             where split_id in (
               select id from precinct_splits where precinct_id = $1
             )
@@ -1824,15 +1824,15 @@ export class Store {
         );
         if (
           hasSplits(precinct) &&
-          registeredVotersCounts !== undefined &&
-          isSplitCounts(registeredVotersCounts)
+          registeredVoterCounts !== undefined &&
+          isSplitCounts(registeredVoterCounts)
         ) {
           for (const split of precinct.splits) {
-            const splitCount = registeredVotersCounts.splits[split.id];
+            const splitCount = registeredVoterCounts.splits[split.id];
             if (splitCount !== undefined) {
               await client.query(
                 `
-                  insert into precinct_split_registered_voters_counts (split_id, count)
+                  insert into precinct_split_registered_voter_counts (split_id, count)
                   values ($1, $2)
                 `,
                 split.id,
@@ -1863,16 +1863,16 @@ export class Store {
     assert(rowCount === 1, 'Precinct not found');
   }
 
-  async getRegisteredVotersCounts(
+  async getRegisteredVoterCounts(
     electionId: ElectionId
-  ): Promise<ElectionRegisteredVotersCounts> {
+  ): Promise<ElectionRegisteredVoterCounts> {
     return this.db.withClient(async (client) => {
       const precinctRows = (
         await client.query(
           `
             select p.id, prc.count
             from precincts p
-            left join precinct_registered_voters_counts prc on prc.precinct_id = p.id
+            left join precinct_registered_voter_counts prc on prc.precinct_id = p.id
             where p.election_id = $1
           `,
           electionId
@@ -1888,7 +1888,7 @@ export class Store {
               psrc.count
             from precinct_splits ps
             join precincts p on ps.precinct_id = p.id
-            left join precinct_split_registered_voters_counts psrc on psrc.split_id = ps.id
+            left join precinct_split_registered_voter_counts psrc on psrc.split_id = ps.id
             where p.election_id = $1
           `,
           electionId
@@ -1912,7 +1912,7 @@ export class Store {
         }
       }
 
-      const counts: ElectionRegisteredVotersCounts = {};
+      const counts: ElectionRegisteredVoterCounts = {};
       for (const row of precinctRows) {
         const splits = splitsByPrecinctId.get(row.id) ?? [];
         if (splits.length > 0) {

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -357,11 +357,11 @@ export async function generateElectionPackageAndBallots(
     JSON.stringify(systemSettings, null, 2)
   );
 
-  const registeredVotersCounts =
-    await store.getRegisteredVotersCounts(electionId);
+  const registeredVoterCounts =
+    await store.getRegisteredVoterCounts(electionId);
   electionPackageZip.file(
-    ElectionPackageFileName.REGISTERED_VOTERS_COUNTS,
-    JSON.stringify(registeredVotersCounts, null, 2)
+    ElectionPackageFileName.REGISTERED_VOTER_COUNTS,
+    JSON.stringify(registeredVoterCounts, null, 2)
   );
 
   if (shouldExportAudio) {

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -248,14 +248,14 @@ export const listPollingPlaces = {
   },
 } as const;
 
-export const getRegisteredVotersCounts = {
+export const getRegisteredVoterCounts = {
   queryKey(id: ElectionId): QueryKey {
-    return ['getRegisteredVotersCounts', id];
+    return ['getRegisteredVoterCounts', id];
   },
   useQuery(id: ElectionId) {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(id), () =>
-      apiClient.getRegisteredVotersCounts({ electionId: id })
+      apiClient.getRegisteredVoterCounts({ electionId: id })
     );
   },
 } as const;
@@ -403,7 +403,7 @@ async function invalidateElectionQueries(
     queryClient.invalidateQueries(listPrecincts.queryKey(electionId)),
     queryClient.invalidateQueries(listPollingPlaces.queryKey(electionId)),
     queryClient.invalidateQueries(
-      getRegisteredVotersCounts.queryKey(electionId)
+      getRegisteredVoterCounts.queryKey(electionId)
     ),
     queryClient.invalidateQueries(listBallotStyles.queryKey(electionId)),
     queryClient.invalidateQueries(listParties.queryKey(electionId)),

--- a/apps/design/frontend/src/ballots_status.test.tsx
+++ b/apps/design/frontend/src/ballots_status.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import {
   BallotStyle,
-  ElectionRegisteredVotersCounts,
+  ElectionRegisteredVoterCounts,
   PollingPlace,
   Precinct,
 } from '@votingworks/types';
@@ -351,9 +351,9 @@ function mockPrecincts(api: MockApiClient, precincts: Precinct[]) {
 
 function mockRegisteredVoterCounts(
   api: MockApiClient,
-  counts: ElectionRegisteredVotersCounts
+  counts: ElectionRegisteredVoterCounts
 ) {
-  api.getRegisteredVotersCounts.expectCallWith({ electionId }).resolves(counts);
+  api.getRegisteredVoterCounts.expectCallWith({ electionId }).resolves(counts);
 }
 
 function mockPollingPlaces(api: MockApiClient, pollingPlaces: PollingPlace[]) {

--- a/apps/design/frontend/src/ballots_status.tsx
+++ b/apps/design/frontend/src/ballots_status.tsx
@@ -32,7 +32,7 @@ export function BallotsStatus(): React.ReactNode {
   const getStateFeaturesQuery = api.getStateFeatures.useQuery(electionId);
   const listPrecinctsQuery = api.listPrecincts.useQuery(electionId);
   const getRegisteredVoterCountsQuery =
-    api.getRegisteredVotersCounts.useQuery(electionId);
+    api.getRegisteredVoterCounts.useQuery(electionId);
   const listPollingPlacesQuery = api.listPollingPlaces.useQuery(electionId);
 
   const finalizeBallotsMutation = api.finalizeBallots.useMutation();

--- a/apps/design/frontend/src/precincts_form.tsx
+++ b/apps/design/frontend/src/precincts_form.tsx
@@ -21,7 +21,7 @@ import {
 import type {
   Precinct,
   PrecinctSplit,
-  PrecinctRegisteredVotersCountEntry,
+  PrecinctRegisteredVoterCountEntry,
 } from '@votingworks/types';
 
 import { assert, assertDefined, throwIllegalValue } from '@votingworks/basics';
@@ -31,7 +31,7 @@ import { Row, Column, InputGroup, FieldName } from './layout';
 import {
   listDistricts,
   getStateFeatures,
-  getRegisteredVotersCounts,
+  getRegisteredVoterCounts,
   updatePrecinct,
   createPrecinct,
   deletePrecinct,
@@ -73,9 +73,9 @@ export function PrecinctForm(props: PrecinctFormProps): React.ReactNode {
   const getBallotsFinalizedAtQuery = getBallotsFinalizedAt.useQuery(electionId);
   const getElectionInfoQuery = getElectionInfo.useQuery(electionId);
   const getRegisteredVoterCountsQuery =
-    getRegisteredVotersCounts.useQuery(electionId);
+    getRegisteredVoterCounts.useQuery(electionId);
 
-  const savedRegisteredVotersCounts = savedPrecinct
+  const savedRegisteredVoterCounts = savedPrecinct
     ? getRegisteredVoterCountsQuery.data?.[savedPrecinct.id]
     : undefined;
 
@@ -85,9 +85,9 @@ export function PrecinctForm(props: PrecinctFormProps): React.ReactNode {
       // so it will only be called on initial render.
       createBlankPrecinct
   );
-  const [registeredVotersCounts, setRegisteredVotersCounts] = useState<
-    PrecinctRegisteredVotersCountEntry | undefined
-  >(savedRegisteredVotersCounts);
+  const [registeredVoterCounts, setRegisteredVoterCounts] = useState<
+    PrecinctRegisteredVoterCountEntry | undefined
+  >(savedRegisteredVoterCounts);
 
   const createPrecinctMutation = createPrecinct.useMutation();
   const updatePrecinctMutation = updatePrecinct.useMutation();
@@ -128,11 +128,11 @@ export function PrecinctForm(props: PrecinctFormProps): React.ReactNode {
   }
 
   function onSubmit() {
-    const registeredVotersCountsArg =
-      registeredVotersCounts === undefined ? {} : { registeredVotersCounts };
+    const registeredVoterCountsArg =
+      registeredVoterCounts === undefined ? {} : { registeredVoterCounts };
     if (savedPrecinct) {
       updatePrecinctMutation.mutate(
-        { electionId, updatedPrecinct: precinct, ...registeredVotersCountsArg },
+        { electionId, updatedPrecinct: precinct, ...registeredVoterCountsArg },
         {
           onSuccess: (result) => {
             if (result.isErr()) return;
@@ -142,7 +142,7 @@ export function PrecinctForm(props: PrecinctFormProps): React.ReactNode {
       );
     } else {
       createPrecinctMutation.mutate(
-        { electionId, newPrecinct: precinct, ...registeredVotersCountsArg },
+        { electionId, newPrecinct: precinct, ...registeredVoterCountsArg },
         {
           onSuccess: (result) => {
             if (result.isErr()) return;
@@ -191,7 +191,7 @@ export function PrecinctForm(props: PrecinctFormProps): React.ReactNode {
           districtIds: [],
         },
       ]);
-      setRegisteredVotersCounts(undefined);
+      setRegisteredVoterCounts(undefined);
     }
 
     // If adding to an existing precinct in view mode, switch to edit mode:
@@ -209,25 +209,25 @@ export function PrecinctForm(props: PrecinctFormProps): React.ReactNode {
         splits: newSplits,
       });
       if (
-        registeredVotersCounts !== undefined &&
-        isSplitCounts(registeredVotersCounts)
+        registeredVoterCounts !== undefined &&
+        isSplitCounts(registeredVoterCounts)
       ) {
         const remainingSplits = Object.fromEntries(
-          Object.entries(registeredVotersCounts.splits).filter(
+          Object.entries(registeredVoterCounts.splits).filter(
             ([id]) => id !== removedSplitId
           )
         );
-        setRegisteredVotersCounts({ splits: remainingSplits });
+        setRegisteredVoterCounts({ splits: remainingSplits });
       }
     } else {
       setPrecinct({
         ...rest,
         districtIds: newSplits[0].districtIds,
       });
-      setRegisteredVotersCounts(
-        registeredVotersCounts !== undefined &&
-          isSplitCounts(registeredVotersCounts)
-          ? registeredVotersCounts.splits[newSplits[0].id]
+      setRegisteredVoterCounts(
+        registeredVoterCounts !== undefined &&
+          isSplitCounts(registeredVoterCounts)
+          ? registeredVoterCounts.splits[newSplits[0].id]
           : undefined
       );
     }
@@ -298,7 +298,7 @@ export function PrecinctForm(props: PrecinctFormProps): React.ReactNode {
       onReset={(e) => {
         e.preventDefault();
         setPrecinct(savedPrecinct || createBlankPrecinct);
-        setRegisteredVotersCounts(savedRegisteredVotersCounts);
+        setRegisteredVoterCounts(savedRegisteredVoterCounts);
         setIsEditing(!editing);
       }}
     >
@@ -357,7 +357,7 @@ export function PrecinctForm(props: PrecinctFormProps): React.ReactNode {
                         />
                       </InputGroup>
 
-                      {!features.DISABLE_REGISTERED_VOTERS_COUNTS && (
+                      {!features.DISABLE_REGISTERED_VOTER_COUNTS && (
                         <InputGroup label="Registered Voters">
                           <input
                             disabled={disabled}
@@ -365,16 +365,16 @@ export function PrecinctForm(props: PrecinctFormProps): React.ReactNode {
                             step={1}
                             min={0}
                             value={
-                              registeredVotersCounts !== undefined &&
-                              isSplitCounts(registeredVotersCounts)
-                                ? registeredVotersCounts.splits[split.id] ?? ''
+                              registeredVoterCounts !== undefined &&
+                              isSplitCounts(registeredVoterCounts)
+                                ? registeredVoterCounts.splits[split.id] ?? ''
                                 : ''
                             }
                             onChange={(e) => {
                               const currentSplits =
-                                registeredVotersCounts !== undefined &&
-                                isSplitCounts(registeredVotersCounts)
-                                  ? registeredVotersCounts.splits
+                                registeredVoterCounts !== undefined &&
+                                isSplitCounts(registeredVoterCounts)
+                                  ? registeredVoterCounts.splits
                                   : {};
                               const newSplits: Record<string, number> = {
                                 ...currentSplits,
@@ -390,7 +390,7 @@ export function PrecinctForm(props: PrecinctFormProps): React.ReactNode {
                               } else {
                                 delete newSplits[split.id];
                               }
-                              setRegisteredVotersCounts({ splits: newSplits });
+                              setRegisteredVoterCounts({ splits: newSplits });
                             }}
                             style={{ width: '8rem' }}
                           />
@@ -496,7 +496,7 @@ export function PrecinctForm(props: PrecinctFormProps): React.ReactNode {
               </React.Fragment>
             ) : (
               <Column style={{ gap: '1rem' }}>
-                {!features.DISABLE_REGISTERED_VOTERS_COUNTS && (
+                {!features.DISABLE_REGISTERED_VOTER_COUNTS && (
                   <InputGroup label="Registered Voters">
                     <input
                       disabled={disabled}
@@ -504,22 +504,22 @@ export function PrecinctForm(props: PrecinctFormProps): React.ReactNode {
                       min={0}
                       step={1}
                       value={
-                        registeredVotersCounts !== undefined &&
-                        isPrecinctCount(registeredVotersCounts)
-                          ? registeredVotersCounts
+                        registeredVoterCounts !== undefined &&
+                        isPrecinctCount(registeredVoterCounts)
+                          ? registeredVoterCounts
                           : ''
                       }
                       onChange={(e) => {
                         const { value } = e.target;
                         if (value === '') {
-                          setRegisteredVotersCounts(undefined);
+                          setRegisteredVoterCounts(undefined);
                           return;
                         }
                         const parseResult = safeParseInt(value);
                         if (parseResult.isErr()) {
                           return;
                         }
-                        setRegisteredVotersCounts(parseResult.ok());
+                        setRegisteredVoterCounts(parseResult.ok());
                       }}
                       style={{ width: '8rem' }}
                     />

--- a/apps/design/frontend/src/precincts_screen.test.tsx
+++ b/apps/design/frontend/src/precincts_screen.test.tsx
@@ -87,7 +87,7 @@ beforeEach(() => {
   apiMock.getSystemSettings
     .expectCallWith({ electionId })
     .resolves(DEFAULT_SYSTEM_SETTINGS);
-  apiMock.getRegisteredVotersCounts
+  apiMock.getRegisteredVoterCounts
     .expectRepeatedCallsWith({ electionId })
     .resolves({});
 
@@ -465,7 +465,7 @@ test('editing a precinct - removing splits preserves last split voter count', as
     .expectCallWith({
       electionId,
       updatedPrecinct: precinctWithoutSplits,
-      registeredVotersCounts: 400,
+      registeredVoterCounts: 400,
     })
     .resolves(ok());
   apiMock.listPrecincts
@@ -985,12 +985,12 @@ test('shows voter count field by default', async () => {
   screen.getByLabelText('Registered Voters');
 });
 
-test('DISABLE_REGISTERED_VOTERS_COUNTS hides voter count field', async () => {
+test('DISABLE_REGISTERED_VOTER_COUNTS hides voter count field', async () => {
   const savedPrecinct = election.precincts[0];
   assert(!hasSplits(savedPrecinct));
 
   mockStateFeatures(apiMock, electionId, {
-    DISABLE_REGISTERED_VOTERS_COUNTS: true,
+    DISABLE_REGISTERED_VOTER_COUNTS: true,
   });
   apiMock.listPrecincts
     .expectCallWith({ electionId })
@@ -1034,7 +1034,7 @@ test('saves registered voter counts for a precinct with splits', async () => {
     .expectCallWith({
       electionId,
       updatedPrecinct: savedPrecinct,
-      registeredVotersCounts: { splits: { [split2.id]: 300 } },
+      registeredVoterCounts: { splits: { [split2.id]: 300 } },
     })
     .resolves(ok());
   apiMock.listPrecincts

--- a/libs/backend/src/election_package/election_package_io.ts
+++ b/libs/backend/src/election_package/election_package_io.ts
@@ -46,8 +46,8 @@ import {
   EncodedBallotEntrySchema,
   SystemLimitViolation,
   SystemLimits,
-  ElectionRegisteredVotersCounts,
-  ElectionRegisteredVotersCountsSchema,
+  ElectionRegisteredVoterCounts,
+  ElectionRegisteredVoterCountsSchema,
 } from '@votingworks/types';
 import { authenticateArtifactUsingSignatureFile } from '@votingworks/auth';
 import { sha256 } from 'js-sha256';
@@ -196,15 +196,15 @@ export async function readElectionPackageFromBuffer(
     }
 
     // Registered Voter Counts:
-    let registeredVoterCounts: ElectionRegisteredVotersCounts | undefined;
+    let registeredVoterCounts: ElectionRegisteredVoterCounts | undefined;
     const registeredVoterCountsEntry = maybeGetFileByName(
       entries,
-      ElectionPackageFileName.REGISTERED_VOTERS_COUNTS
+      ElectionPackageFileName.REGISTERED_VOTER_COUNTS
     );
     if (registeredVoterCountsEntry) {
       registeredVoterCounts = safeParseJson(
         await readTextEntry(registeredVoterCountsEntry),
-        ElectionRegisteredVotersCountsSchema
+        ElectionRegisteredVoterCountsSchema
       ).unsafeUnwrap();
     }
 

--- a/libs/types/src/election_package.ts
+++ b/libs/types/src/election_package.ts
@@ -10,7 +10,7 @@ import {
 } from './election';
 import { SystemSettings } from './system_settings';
 import { ElectionPackageMetadata } from './election_package_metadata';
-import { ElectionRegisteredVotersCounts } from './registered_voter_counts';
+import { ElectionRegisteredVoterCounts } from './registered_voter_counts';
 import { UiStringAudioClips } from './ui_string_audio_clips';
 import { UiStringAudioIdsPackage } from './ui_string_audio_ids';
 import { UiStringsPackage } from './ui_string_translations';
@@ -23,7 +23,7 @@ export enum ElectionPackageFileName {
   BALLOTS = 'ballots.jsonl',
   ELECTION = 'election.json',
   METADATA = 'metadata.json',
-  REGISTERED_VOTERS_COUNTS = 'registeredVotersCounts.json',
+  REGISTERED_VOTER_COUNTS = 'registeredVoterCounts.json',
   SYSTEM_SETTINGS = 'systemSettings.json',
 }
 
@@ -31,7 +31,7 @@ export interface ElectionPackage {
   ballots?: EncodedBallotEntry[];
   electionDefinition: ElectionDefinition;
   metadata: ElectionPackageMetadata;
-  registeredVoterCounts?: ElectionRegisteredVotersCounts;
+  registeredVoterCounts?: ElectionRegisteredVoterCounts;
   systemSettings: SystemSettings;
   uiStringAudioClips: UiStringAudioClips;
   uiStringAudioIds: UiStringAudioIdsPackage;

--- a/libs/types/src/registered_voter_counts.test.ts
+++ b/libs/types/src/registered_voter_counts.test.ts
@@ -5,8 +5,8 @@ import {
   isSplitCounts,
 } from './registered_voter_counts';
 import type {
-  ElectionRegisteredVotersCounts,
-  PrecinctRegisteredVotersCountEntry,
+  ElectionRegisteredVoterCounts,
+  PrecinctRegisteredVoterCountEntry,
 } from './registered_voter_counts';
 import type { Precinct } from './election';
 
@@ -22,15 +22,15 @@ const pSplit: Precinct = {
 };
 
 test('isPrecinctCount', () => {
-  const number: PrecinctRegisteredVotersCountEntry = 500;
-  const splits: PrecinctRegisteredVotersCountEntry = { splits: { s1: 100 } };
+  const number: PrecinctRegisteredVoterCountEntry = 500;
+  const splits: PrecinctRegisteredVoterCountEntry = { splits: { s1: 100 } };
   expect(isPrecinctCount(number)).toEqual(true);
   expect(isPrecinctCount(splits)).toEqual(false);
 });
 
 test('isSplitCounts', () => {
-  const number: PrecinctRegisteredVotersCountEntry = 500;
-  const splits: PrecinctRegisteredVotersCountEntry = { splits: { s1: 100 } };
+  const number: PrecinctRegisteredVoterCountEntry = 500;
+  const splits: PrecinctRegisteredVoterCountEntry = { splits: { s1: 100 } };
   expect(isSplitCounts(splits)).toEqual(true);
   expect(isSplitCounts(number)).toEqual(false);
 });
@@ -40,7 +40,7 @@ test('hasPartialRegisteredVoterCounts - no precincts', () => {
 });
 
 test('hasPartialRegisteredVoterCounts - all non-split precincts have counts', () => {
-  const counts: ElectionRegisteredVotersCounts = { p1: 100, p2: 200 };
+  const counts: ElectionRegisteredVoterCounts = { p1: 100, p2: 200 };
   expect(hasPartialRegisteredVoterCounts([p1, p2], counts)).toEqual(false);
 });
 
@@ -49,12 +49,12 @@ test('hasPartialRegisteredVoterCounts - no non-split precincts have counts', () 
 });
 
 test('hasPartialRegisteredVoterCounts - some non-split precincts have counts', () => {
-  const counts: ElectionRegisteredVotersCounts = { p1: 100 };
+  const counts: ElectionRegisteredVoterCounts = { p1: 100 };
   expect(hasPartialRegisteredVoterCounts([p1, p2], counts)).toEqual(true);
 });
 
 test('hasPartialRegisteredVoterCounts - all splits have counts', () => {
-  const counts: ElectionRegisteredVotersCounts = {
+  const counts: ElectionRegisteredVoterCounts = {
     ps: { splits: { s1: 100, s2: 200 } },
   };
   expect(hasPartialRegisteredVoterCounts([pSplit], counts)).toEqual(false);
@@ -65,7 +65,7 @@ test('hasPartialRegisteredVoterCounts - no splits have counts', () => {
 });
 
 test('hasPartialRegisteredVoterCounts - some splits have counts', () => {
-  const counts: ElectionRegisteredVotersCounts = {
+  const counts: ElectionRegisteredVoterCounts = {
     ps: { splits: { s1: 100 } },
   };
   expect(hasPartialRegisteredVoterCounts([pSplit], counts)).toEqual(true);
@@ -73,14 +73,14 @@ test('hasPartialRegisteredVoterCounts - some splits have counts', () => {
 
 test('hasPartialRegisteredVoterCounts - split precinct entry present but no split counts', () => {
   // precinctEntry is defined but isSplitCounts branch has no matching splits
-  const counts: ElectionRegisteredVotersCounts = {
+  const counts: ElectionRegisteredVoterCounts = {
     ps: 500,
   };
   expect(hasPartialRegisteredVoterCounts([pSplit], counts)).toEqual(false);
 });
 
 test('hasPartialRegisteredVoterCounts - mixed non-split and split precincts, all have counts', () => {
-  const counts: ElectionRegisteredVotersCounts = {
+  const counts: ElectionRegisteredVoterCounts = {
     p1: 100,
     ps: { splits: { s1: 100, s2: 200 } },
   };
@@ -89,6 +89,6 @@ test('hasPartialRegisteredVoterCounts - mixed non-split and split precincts, all
 
 test('hasPartialRegisteredVoterCounts - mixed non-split and split precincts, partial counts', () => {
   // p1 has a count but pSplit splits do not
-  const counts: ElectionRegisteredVotersCounts = { p1: 100 };
+  const counts: ElectionRegisteredVoterCounts = { p1: 100 };
   expect(hasPartialRegisteredVoterCounts([p1, pSplit], counts)).toEqual(true);
 });

--- a/libs/types/src/registered_voter_counts.ts
+++ b/libs/types/src/registered_voter_counts.ts
@@ -5,44 +5,44 @@ import { hasSplits, Precinct, PrecinctId, PrecinctSplitId } from './election';
  * Registered voter counts for a precinct with splits, keyed by split ID.
  * Only splits with a count set are included.
  */
-export interface PrecinctWithSplitsRegisteredVotersCounts {
+export interface PrecinctWithSplitsRegisteredVoterCounts {
   splits: Record<PrecinctSplitId, number>;
 }
 
 /**
- * Registered voters counts for a single precinct
+ * Registered voter counts for a single precinct
  *
  * For precincts without splits, the value is the total count as a number.
  * For precincts with splits, the value is a record mapping split IDs to counts.
  */
-export type PrecinctRegisteredVotersCountEntry =
+export type PrecinctRegisteredVoterCountEntry =
   | number
-  | PrecinctWithSplitsRegisteredVotersCounts;
+  | PrecinctWithSplitsRegisteredVoterCounts;
 
 /**
- * Registered voters counts for all precincts in an election, keyed by
+ * Registered voter counts for all precincts in an election, keyed by
  * PrecinctId. Only precincts or splits with a count set are included.
  */
-export type ElectionRegisteredVotersCounts = Record<
+export type ElectionRegisteredVoterCounts = Record<
   PrecinctId,
-  PrecinctRegisteredVotersCountEntry
+  PrecinctRegisteredVoterCountEntry
 >;
 
 export function isPrecinctCount(
-  entry: PrecinctRegisteredVotersCountEntry
+  entry: PrecinctRegisteredVoterCountEntry
 ): entry is number {
   return typeof entry === 'number';
 }
 
 export function isSplitCounts(
-  entry: PrecinctRegisteredVotersCountEntry
-): entry is PrecinctWithSplitsRegisteredVotersCounts {
+  entry: PrecinctRegisteredVoterCountEntry
+): entry is PrecinctWithSplitsRegisteredVoterCounts {
   return typeof entry === 'object';
 }
 
 export function hasPartialRegisteredVoterCounts(
   precincts: readonly Precinct[],
-  counts: ElectionRegisteredVotersCounts
+  counts: ElectionRegisteredVoterCounts
 ): boolean {
   let someHaveCount = false;
   let someMissingCount = false;
@@ -74,16 +74,16 @@ export function hasPartialRegisteredVoterCounts(
   return someHaveCount && someMissingCount;
 }
 
-export const PrecinctWithSplitsRegisteredVotersCountsSchema: z.ZodType<PrecinctWithSplitsRegisteredVotersCounts> =
+export const PrecinctWithSplitsRegisteredVoterCountsSchema: z.ZodType<PrecinctWithSplitsRegisteredVoterCounts> =
   z.object({
     splits: z.record(z.string(), z.number().int().nonnegative()),
   });
 
-export const PrecinctRegisteredVotersCountEntrySchema: z.ZodType<PrecinctRegisteredVotersCountEntry> =
+export const PrecinctRegisteredVoterCountEntrySchema: z.ZodType<PrecinctRegisteredVoterCountEntry> =
   z.union([
     z.number().int().nonnegative(),
-    PrecinctWithSplitsRegisteredVotersCountsSchema,
+    PrecinctWithSplitsRegisteredVoterCountsSchema,
   ]);
 
-export const ElectionRegisteredVotersCountsSchema: z.ZodType<ElectionRegisteredVotersCounts> =
-  z.record(z.string(), PrecinctRegisteredVotersCountEntrySchema);
+export const ElectionRegisteredVoterCountsSchema: z.ZodType<ElectionRegisteredVoterCounts> =
+  z.record(z.string(), PrecinctRegisteredVoterCountEntrySchema);

--- a/libs/ui/src/reports/voter_turnout_report.tsx
+++ b/libs/ui/src/reports/voter_turnout_report.tsx
@@ -1,7 +1,7 @@
 import {
   ElectionDefinition,
-  ElectionRegisteredVotersCounts,
-  PrecinctRegisteredVotersCountEntry,
+  ElectionRegisteredVoterCounts,
+  PrecinctRegisteredVoterCountEntry,
   Tabulation,
 } from '@votingworks/types';
 import { getBallotCount } from '@votingworks/utils';
@@ -72,9 +72,7 @@ const TurnoutGrid = styled.div`
   }
 `;
 
-function sumRegisteredVoters(
-  entry: PrecinctRegisteredVotersCountEntry
-): number {
+function sumRegisteredVoters(entry: PrecinctRegisteredVoterCountEntry): number {
   if (typeof entry === 'number') return entry;
   return Object.values(entry.splits).reduce((acc, n) => acc + n, 0);
 }
@@ -93,7 +91,7 @@ export interface VoterTurnoutReportProps {
   isOfficial: boolean;
   isTest: boolean;
   cardCountsList: Tabulation.GroupList<Tabulation.CardCounts>;
-  registeredVoterCounts: ElectionRegisteredVotersCounts;
+  registeredVoterCounts: ElectionRegisteredVoterCounts;
   generatedAtTime: Date;
 }
 


### PR DESCRIPTION
## Overview

Just a small nit as I've been gearing up for v4.1 submission. We sometimes use "registered voters counts" (with an s at the end of voters) and other times "registered voter counts" in variables. I find the latter to read better, so I'm (with Claude's help) renaming. Most important thing to rename now is the name of the file in the election package since changing that later would be a breaking change.

## Testing Plan

Relying on CI but will also cover during v4.1 QA

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [ ] ~I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~