### PR TITLE
Remove uninterable ballot adjudication reason

### DIFF
--- a/libs/types/src/__snapshots__/system_settings.test.ts.snap
+++ b/libs/types/src/__snapshots__/system_settings.test.ts.snap
@@ -58,7 +58,6 @@ exports[`disallows invalid adjudication reasons 1`] = `
   {
     "code": "invalid_value",
     "values": [
-      "UninterpretableBallot",
       "MarginalMark",
       "Overvote",
       "Undervote",
@@ -70,12 +69,11 @@ exports[`disallows invalid adjudication reasons 1`] = `
       "adminAdjudicationReasons",
       0
     ],
-    "message": "Invalid option: expected one of \\"UninterpretableBallot\\"|\\"MarginalMark\\"|\\"Overvote\\"|\\"Undervote\\"|\\"BlankBallot\\"|\\"UnmarkedWriteIn\\"|\\"CrossoverVoting\\""
+    "message": "Invalid option: expected one of \\"MarginalMark\\"|\\"Overvote\\"|\\"Undervote\\"|\\"BlankBallot\\"|\\"UnmarkedWriteIn\\"|\\"CrossoverVoting\\""
   },
   {
     "code": "invalid_value",
     "values": [
-      "UninterpretableBallot",
       "MarginalMark",
       "Overvote",
       "Undervote",
@@ -87,12 +85,11 @@ exports[`disallows invalid adjudication reasons 1`] = `
       "centralScanAdjudicationReasons",
       0
     ],
-    "message": "Invalid option: expected one of \\"UninterpretableBallot\\"|\\"MarginalMark\\"|\\"Overvote\\"|\\"Undervote\\"|\\"BlankBallot\\"|\\"UnmarkedWriteIn\\"|\\"CrossoverVoting\\""
+    "message": "Invalid option: expected one of \\"MarginalMark\\"|\\"Overvote\\"|\\"Undervote\\"|\\"BlankBallot\\"|\\"UnmarkedWriteIn\\"|\\"CrossoverVoting\\""
   },
   {
     "code": "invalid_value",
     "values": [
-      "UninterpretableBallot",
       "MarginalMark",
       "Overvote",
       "Undervote",
@@ -104,7 +101,7 @@ exports[`disallows invalid adjudication reasons 1`] = `
       "precinctScanAdjudicationReasons",
       0
     ],
-    "message": "Invalid option: expected one of \\"UninterpretableBallot\\"|\\"MarginalMark\\"|\\"Overvote\\"|\\"Undervote\\"|\\"BlankBallot\\"|\\"UnmarkedWriteIn\\"|\\"CrossoverVoting\\""
+    "message": "Invalid option: expected one of \\"MarginalMark\\"|\\"Overvote\\"|\\"Undervote\\"|\\"BlankBallot\\"|\\"UnmarkedWriteIn\\"|\\"CrossoverVoting\\""
   }
 ]]
 `;

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -701,11 +701,6 @@ export const BallotLayoutSchema: z.ZodSchema<BallotLayout> = z.object({
 
 // Hand-marked paper & adjudication
 export enum AdjudicationReason {
-  /**
-   * @deprecated - this is no longer used, but is here to keep compatibility
-   * with existing elections
-   */
-  UninterpretableBallot = 'UninterpretableBallot',
   MarginalMark = 'MarginalMark',
   Overvote = 'Overvote',
   Undervote = 'Undervote',


### PR DESCRIPTION
## Overview
Removes the long-deprecated adjudication reason "UninterableBallot" while technically a breaking change it would only be problematic if an election had this adjudication reason which has not been the case for 3 years https://github.com/votingworks/vxsuite/pull/3353 

## Demo Video or Screenshot
N/A

## Testing Plan
CI

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
