### PR TITLE
[VxAdmin] Add inital scaffolding for new CVR management screen

### DIFF
--- a/apps/admin/frontend/src/screens/tally/cvrs_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvrs_screen.test.tsx
@@ -1,0 +1,162 @@
+import { expect, test } from 'vitest';
+import { readElectionGeneralDefinition } from '@votingworks/fixtures';
+import type { CastVoteRecordFileRecord } from '@votingworks/admin-backend';
+
+import { hasTextAcrossElements } from '@votingworks/test-utils';
+import userEvent from '@testing-library/user-event';
+import { mockUsbDriveStatus } from '@votingworks/ui';
+import { renderInAppContext } from '../../../test/render_in_app_context';
+import { CvrsScreen } from './cvrs_screen';
+import { createApiMock } from '../../../test/helpers/mock_api_client';
+import { screen, waitFor } from '../../../test/react_testing_library';
+
+const electionDefinition = readElectionGeneralDefinition();
+const { election } = electionDefinition;
+
+const nLocations = election.pollingPlaces.length;
+const [place1, place2] = election.pollingPlaces;
+
+test('renders summary cards', async () => {
+  const api = createApiMock();
+
+  api.expectGetCastVoteRecordFileMode('unlocked');
+  api.expectGetCastVoteRecordFiles([
+    mockCvrFile({
+      numCvrsImported: 15,
+      pollingPlaceIds: [place1.id],
+      scannerIds: ['001'],
+    }),
+    mockCvrFile({
+      numCvrsImported: 25,
+      pollingPlaceIds: [place2.id],
+      scannerIds: ['002'],
+    }),
+  ]);
+
+  renderInAppContext(<CvrsScreen />, {
+    apiMock: api,
+    electionDefinition,
+  });
+
+  await waitFor(() => api.assertComplete());
+
+  const n = nLocations;
+  screen.getByText(hasTextAcrossElements(['Locations', `2 / ${n}`].join('')));
+  screen.getByText(hasTextAcrossElements(['Scanners', '2'].join('')));
+  screen.getByText(hasTextAcrossElements(['CVRs', '40'].join('')));
+});
+
+test('renders location name search box', async () => {
+  const api = createApiMock();
+
+  api.expectGetCastVoteRecordFileMode('unlocked');
+  api.expectGetCastVoteRecordFiles([]);
+
+  renderInAppContext(<CvrsScreen />, {
+    apiMock: api,
+    electionDefinition,
+  });
+
+  await waitFor(() => api.assertComplete());
+
+  const emptyInput = screen.getByPlaceholderText('Search Locations');
+  userEvent.type(emptyInput, place2.name);
+
+  screen.getByDisplayValue(place2.name);
+  // [TODO] Assert that displayed locations are filtered.
+});
+
+test('renders location filter buttons', async () => {
+  const api = createApiMock();
+
+  api.expectGetCastVoteRecordFileMode('unlocked');
+  api.expectGetCastVoteRecordFiles([
+    mockCvrFile({
+      numCvrsImported: 15,
+      pollingPlaceIds: [place1.id],
+      scannerIds: ['001'],
+    }),
+  ]);
+
+  renderInAppContext(<CvrsScreen />, {
+    apiMock: api,
+    electionDefinition,
+  });
+
+  await waitFor(() => api.assertComplete());
+
+  const nPending = nLocations - 1;
+  screen.getByRole('option', { name: `All ${nLocations}`, selected: true });
+  screen.getByRole('option', { name: `Pending ${nPending}`, selected: false });
+
+  userEvent.click(
+    screen.getByRole('option', { name: 'Loaded 1', selected: false })
+  );
+  screen.getByRole('option', { name: 'Loaded 1', selected: true });
+  screen.getByRole('option', { name: /All/, selected: false });
+  screen.getByRole('option', { name: /Pending/, selected: false });
+
+  // [TODO] Assert that displayed locations are filtered.
+});
+
+test('load button opens import panel', async () => {
+  const api = createApiMock();
+
+  api.expectGetCastVoteRecordFileMode('unlocked');
+  api.expectGetCastVoteRecordFiles([]);
+
+  renderInAppContext(<CvrsScreen />, {
+    apiMock: api,
+    electionDefinition,
+    usbDriveStatus: mockUsbDriveStatus('mounted'),
+  });
+
+  await waitFor(() => api.assertComplete());
+  expect(screen.queryByText(/Load CVRs/)).not.toBeInTheDocument();
+
+  api.expectListCastVoteRecordFilesOnUsb([]);
+  userEvent.click(screen.getButton('Load'));
+
+  await waitFor(() => api.assertComplete());
+  screen.getByText(/Load CVRs/);
+
+  userEvent.click(screen.getButton('Cancel'));
+  expect(screen.queryByText(/Load CVRs/)).not.toBeInTheDocument();
+});
+
+test('delete button opens confirmation modal', async () => {
+  const api = createApiMock();
+
+  api.expectGetCastVoteRecordFileMode('unlocked');
+  api.expectGetCastVoteRecordFiles([
+    mockCvrFile({
+      numCvrsImported: 15,
+      pollingPlaceIds: [place1.id],
+      scannerIds: ['001'],
+    }),
+  ]);
+
+  renderInAppContext(<CvrsScreen />, {
+    apiMock: api,
+    electionDefinition,
+    usbDriveStatus: mockUsbDriveStatus('mounted'),
+  });
+
+  await waitFor(() => api.assertComplete());
+  expect(screen.queryButton(/Remove All CVRs/)).not.toBeInTheDocument();
+
+  api.expectGetManualResultsMetadata([]);
+  userEvent.click(screen.getButton('Remove All'));
+
+  await waitFor(() => api.assertComplete());
+  screen.getButton(/Remove All CVRs/);
+
+  userEvent.click(screen.getButton('Cancel'));
+  expect(screen.queryButton(/Remove All CVRs/)).not.toBeInTheDocument();
+});
+
+function mockCvrFile(
+  file: Partial<CastVoteRecordFileRecord>
+): CastVoteRecordFileRecord {
+  return file as CastVoteRecordFileRecord;
+}

--- a/apps/admin/frontend/src/screens/tally/cvrs_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvrs_screen.tsx
@@ -1,0 +1,152 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+import { Button, DesktopPalette } from '@votingworks/ui';
+
+import { CvrSummaries } from './cvr_summaries';
+import { GAP, INSET_FOCUS_OUTLINE } from './styles';
+import { LocationFilter, LocationFilterBar } from './location_filter_bar';
+import { RemoveAllCvrsModal } from './remove_all_cvrs_modal';
+import { ImportCvrFilesModal } from './import_cvrfiles_modal';
+import { CvrsState, useCvrsState } from './cvrs_state';
+
+const Container = styled.div`
+  display: grid;
+  gap: ${GAP};
+  grid-template-rows: min-content 1fr;
+  height: 100%;
+  overflow-y: hidden;
+  padding: ${GAP} 0;
+
+  > * {
+    margin: 0 ${GAP};
+  }
+`;
+
+export function CvrsScreen(): React.ReactNode {
+  const [uiMode, setUiMode] = useState<'import' | 'view'>('view');
+
+  const state = useCvrsState();
+  if (!state) return null;
+
+  return (
+    <Container>
+      {/* [TODO] Render test mode card. */}
+
+      <CvrSummaries
+        cvrs={state.totalCvrs}
+        locations={{
+          loaded: state.locationsLoaded,
+          total: state.locations.length,
+        }}
+        scanners={state.scannersLoaded}
+      />
+
+      {uiMode === 'view' && (
+        <ViewPanel openImportPanel={() => setUiMode('import')} state={state} />
+      )}
+
+      {/* [TODO] Render inline import panel instead of modal. */}
+      {uiMode === 'import' && (
+        <ImportCvrFilesModal onClose={() => setUiMode('view')} />
+      )}
+    </Container>
+  );
+}
+
+const LOAD_BUTTON_CLASS = 'LoadButton';
+
+const ActionBar = styled.div<{ layered?: boolean }>`
+  display: grid;
+  gap: ${GAP};
+  grid-auto-columns: min-content;
+  grid-auto-flow: column;
+  grid-template-columns: 1fr;
+  position: sticky;
+  top: 0;
+
+  > button:focus:focus-visible {
+    ${INSET_FOCUS_OUTLINE}
+  }
+
+  > .${LOAD_BUTTON_CLASS} {
+    box-shadow: 0.125rem 0.125rem 0.25rem rgba(0, 0, 0, 25%);
+
+    :focus:focus-visible {
+      /*
+       * Create some contrast with the primary button color, since we're
+       * insetting the outline.
+       */
+      outline-color: ${DesktopPalette.Purple40};
+    }
+  }
+`;
+
+const ViewPanelContainer = styled.div`
+  display: grid;
+  grid-template-rows: min-content 1fr;
+  gap: ${GAP};
+  position: relative;
+  height: 100%;
+  margin: 0;
+  overflow-y: hidden;
+
+  > * {
+    margin: 0 ${GAP};
+  }
+`;
+
+export function ViewPanel(props: {
+  openImportPanel: VoidFunction;
+  state: CvrsState;
+}): React.ReactNode {
+  const { openImportPanel, state } = props;
+
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [filter, setFilter] = React.useState<LocationFilter>('all');
+  const [query, setQuery] = React.useState('');
+
+  const showLoad = !state.isOfficialResults;
+  const showDelete = state.files.length > 0 && !state.isOfficialResults;
+
+  return (
+    <ViewPanelContainer>
+      <ActionBar>
+        <LocationFilterBar
+          filter={filter}
+          nLoaded={state.locationsLoaded}
+          nLocations={state.locations.length}
+          query={query}
+          setFilter={setFilter}
+          setQuery={setQuery}
+        />
+        {showLoad && (
+          <Button
+            className={LOAD_BUTTON_CLASS}
+            icon="Import"
+            variant="primary"
+            onPress={openImportPanel}
+          >
+            Load
+          </Button>
+        )}
+        {showDelete && (
+          <Button
+            icon="Trash"
+            color="danger"
+            disabled={confirmingDelete}
+            onPress={setConfirmingDelete}
+            value
+          >
+            Remove All
+          </Button>
+        )}
+        {confirmingDelete && (
+          <RemoveAllCvrsModal onClose={() => setConfirmingDelete(false)} />
+        )}
+      </ActionBar>
+
+      {/* [TODO] Render location list. */}
+    </ViewPanelContainer>
+  );
+}

--- a/apps/admin/frontend/src/screens/tally/cvrs_state.ts
+++ b/apps/admin/frontend/src/screens/tally/cvrs_state.ts
@@ -1,0 +1,98 @@
+import React from 'react';
+
+import type { CastVoteRecordFileRecord } from '@votingworks/admin-backend';
+import { Id, PollingPlace } from '@votingworks/types/src';
+import { assertDefined } from '@votingworks/basics';
+
+import * as api from '../../api';
+import { AppContext } from '../../contexts/app_context';
+
+export interface CvrsState {
+  files: CastVoteRecordFileRecord[];
+  isOfficialResults: boolean;
+  locationCvrs: Map<Id, LocationCvrs>;
+  locations: readonly PollingPlace[];
+  locationsLoaded: number;
+  scannersLoaded: number;
+  testMode: boolean;
+  totalCvrs: number;
+}
+
+export interface LocationCvrs {
+  cvrCount: number;
+  files: CastVoteRecordFileRecord[];
+  scannerIds: Set<string>;
+}
+
+export function useCvrsState(): CvrsState | null {
+  const ctx = React.useContext(AppContext);
+  const { electionDefinition, isOfficialResults } = ctx;
+  const { election } = assertDefined(electionDefinition);
+  const locations = election.pollingPlaces;
+
+  const files = api.getCastVoteRecordFiles.useQuery().data;
+  const mode = api.getCastVoteRecordFileMode.useQuery().data;
+
+  return React.useMemo((): CvrsState | null => {
+    if (!files || !mode) return null;
+
+    const testMode = mode === 'test';
+    const locationCvrs = buildLocationCvrMap(locations, files);
+
+    let totalCvrs = 0;
+    let locationsLoaded = 0;
+    let scannersLoaded = 0;
+    for (const meta of locationCvrs.values()) {
+      totalCvrs += meta.cvrCount;
+      if (meta.files.length > 0) locationsLoaded += 1;
+      if (meta.scannerIds.size > 0) scannersLoaded += 1;
+    }
+
+    return {
+      files,
+      isOfficialResults,
+      locationCvrs,
+      locations,
+      locationsLoaded,
+      scannersLoaded,
+      testMode,
+      totalCvrs,
+    };
+  }, [files, isOfficialResults, locations, mode]);
+}
+
+function buildLocationCvrMap(
+  places: readonly PollingPlace[],
+  files: CastVoteRecordFileRecord[]
+): Map<Id, LocationCvrs> {
+  const map = new Map(
+    places.map<[Id, LocationCvrs]>((p) => [
+      p.id,
+      {
+        absenteeCount: 0,
+        earlyVotingCount: 0,
+        cvrCount: 0,
+        files: [],
+        scannerIds: new Set(),
+      },
+    ])
+  );
+
+  for (const file of files) {
+    const placeId = assertDefined(
+      file.pollingPlaceIds[0],
+      'missing polling place ID in CVR export'
+    );
+
+    const meta = assertDefined(
+      map.get(placeId),
+      'invalid polling place ID in CVR export'
+    );
+
+    meta.cvrCount += file.numCvrsImported;
+    meta.files.push(file);
+    for (const id of file.scannerIds) meta.scannerIds.add(id);
+  }
+
+  return map;
+}

--- a/apps/admin/frontend/src/screens/tally/remove_all_cvrs_modal.tsx
+++ b/apps/admin/frontend/src/screens/tally/remove_all_cvrs_modal.tsx
@@ -61,7 +61,7 @@ export function RemoveAllCvrsModal({
         actions={
           <React.Fragment>
             <Button
-              icon="Delete"
+              icon="Trash"
               variant="danger"
               onPress={() => removeCvrs()}
               disabled={clearCastVoteRecordFilesMutation.isLoading}
@@ -93,7 +93,7 @@ export function RemoveAllCvrsModal({
       actions={
         <React.Fragment>
           <Button
-            icon="Delete"
+            icon="Trash"
             variant="danger"
             onPress={removeManualResults}
             disabled={deleteAllManualResultsMutation.isLoading}

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -84,7 +84,7 @@ import {
   faStrikethrough,
   faTable,
   faTextHeight,
-  faTrash,
+  faTrashCan,
   faUnderline,
   faVolumeHigh,
   faVolumeMute,
@@ -668,7 +668,7 @@ export const Icons = {
   },
 
   Trash(props) {
-    return <FaIcon {...props} flipInRtlMode={false} type={faTrash} />;
+    return <FaIcon {...props} flipInRtlMode={false} type={faTrashCan} />;
   },
 
   Underline(props) {


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7958

Adding a new `CvrsScreen`, to eventually replace the existing `CastVoteRecordsTab`. Handles the necessary data fetching and glue code for the summary cards, filter bar, load/delete buttons and their associated modals.

TODO (later PRs):
- Add the conditional test mode banner.
- Render the location list/detail panel.
- Inline the CVR import modal, once the updated version is ready.

## Demo Video or Screenshot

_In-context mocks are available in [Figma](https://www.figma.com/design/0Mari2J3cgG8dSYx9pnF1P/VxAdmin-CVR-Management?node-id=1-5&t=QJg1Q388OLjE6w7n-1)_

https://github.com/user-attachments/assets/53b94f09-6d41-4f84-a727-f19d01f7e058

## Testing Plan
- State/event unit tests

## Checklist
N/A