### PR TITLE
[VxAdmin] Add LocationList to new CVR management screen

### DIFF
--- a/apps/admin/frontend/src/screens/tally/cvrs_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvrs_screen.test.tsx
@@ -46,7 +46,7 @@ test('renders summary cards', async () => {
   screen.getByText(hasTextAcrossElements(['CVRs', '40'].join('')));
 });
 
-test('renders location name search box', async () => {
+test('location name search box filters location list', async () => {
   const api = createApiMock();
 
   api.expectGetCastVoteRecordFileMode('unlocked');
@@ -58,22 +58,31 @@ test('renders location name search box', async () => {
   });
 
   await waitFor(() => api.assertComplete());
+  for (const place of election.pollingPlaces) {
+    screen.getButton(new RegExp(place.name));
+  }
 
   const emptyInput = screen.getByPlaceholderText('Search Locations');
-  userEvent.type(emptyInput, place2.name);
+  userEvent.type(emptyInput, place2.name.toLowerCase());
 
-  screen.getByDisplayValue(place2.name);
-  // [TODO] Assert that displayed locations are filtered.
+  screen.getByDisplayValue(place2.name.toLowerCase());
+  screen.getButton(new RegExp(place2.name));
+
+  for (const place of election.pollingPlaces) {
+    if (place.name === place2.name) continue;
+    expect(screen.queryButton(new RegExp(place.name))).not.toBeInTheDocument();
+  }
 });
 
-test('renders location filter buttons', async () => {
+test('location filter buttons filter location list', async () => {
   const api = createApiMock();
+  const loadedPlace = place1;
 
   api.expectGetCastVoteRecordFileMode('unlocked');
   api.expectGetCastVoteRecordFiles([
     mockCvrFile({
       numCvrsImported: 15,
-      pollingPlaceIds: [place1.id],
+      pollingPlaceIds: [loadedPlace.id],
       scannerIds: ['001'],
     }),
   ]);
@@ -84,6 +93,9 @@ test('renders location filter buttons', async () => {
   });
 
   await waitFor(() => api.assertComplete());
+  for (const place of election.pollingPlaces) {
+    screen.getButton(new RegExp(place.name));
+  }
 
   const nPending = nLocations - 1;
   screen.getByRole('option', { name: `All ${nLocations}`, selected: true });
@@ -96,7 +108,45 @@ test('renders location filter buttons', async () => {
   screen.getByRole('option', { name: /All/, selected: false });
   screen.getByRole('option', { name: /Pending/, selected: false });
 
-  // [TODO] Assert that displayed locations are filtered.
+  screen.getButton(new RegExp(loadedPlace.name));
+
+  for (const place of election.pollingPlaces) {
+    if (place.name === loadedPlace.name) continue;
+    expect(screen.queryButton(new RegExp(place.name))).not.toBeInTheDocument();
+  }
+});
+
+test('search input and filter buttons are both used for filtering', async () => {
+  const api = createApiMock();
+  const loadedPlace = place1;
+
+  api.expectGetCastVoteRecordFileMode('unlocked');
+  api.expectGetCastVoteRecordFiles([
+    mockCvrFile({
+      numCvrsImported: 15,
+      pollingPlaceIds: [loadedPlace.id],
+      scannerIds: ['001'],
+    }),
+  ]);
+
+  renderInAppContext(<CvrsScreen />, {
+    apiMock: api,
+    electionDefinition,
+  });
+
+  await waitFor(() => api.assertComplete());
+  for (const place of election.pollingPlaces) {
+    screen.getButton(new RegExp(place.name));
+  }
+
+  const emptyInput = screen.getByPlaceholderText('Search Locations');
+  userEvent.type(emptyInput, loadedPlace.name);
+  screen.getButton(new RegExp(loadedPlace.name));
+
+  userEvent.click(screen.getByRole('option', { name: /Pending/ }));
+  expect(
+    screen.queryButton(new RegExp(loadedPlace.name))
+  ).not.toBeInTheDocument();
 });
 
 test('load button opens import panel', async () => {

--- a/apps/admin/frontend/src/screens/tally/cvrs_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvrs_screen.tsx
@@ -3,12 +3,14 @@ import styled from 'styled-components';
 
 import { Button, DesktopPalette } from '@votingworks/ui';
 
+import { assertDefined } from '@votingworks/basics';
 import { CvrSummaries } from './cvr_summaries';
 import { GAP, INSET_FOCUS_OUTLINE } from './styles';
 import { LocationFilter, LocationFilterBar } from './location_filter_bar';
 import { RemoveAllCvrsModal } from './remove_all_cvrs_modal';
 import { ImportCvrFilesModal } from './import_cvrfiles_modal';
 import { CvrsState, useCvrsState } from './cvrs_state';
+import { LocationList } from './location_list';
 
 const Container = styled.div`
   display: grid;
@@ -146,7 +148,30 @@ export function ViewPanel(props: {
         )}
       </ActionBar>
 
-      {/* [TODO] Render location list. */}
+      <LocationList
+        locations={filterLocations(state, filter, query)}
+        locationCvrs={state.locationCvrs}
+      />
     </ViewPanelContainer>
   );
+}
+
+function filterLocations(
+  state: CvrsState,
+  filter: LocationFilter,
+  query: string
+) {
+  const queryNormalized = query.trim().toLowerCase();
+
+  if (filter === 'all' && !queryNormalized) return state.locations;
+
+  return state.locations.filter((l) => {
+    const cvrs = assertDefined(state.locationCvrs.get(l.id));
+    if (filter === 'loaded' && cvrs.files.length === 0) return false;
+    if (filter === 'pending' && cvrs.files.length > 0) return false;
+
+    if (!queryNormalized) return true;
+
+    return l.name.toLocaleLowerCase().includes(queryNormalized);
+  });
 }

--- a/apps/admin/frontend/src/screens/tally/location_cvrs_panel.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_cvrs_panel.test.tsx
@@ -4,27 +4,12 @@ import userEvent from '@testing-library/user-event';
 import { render, screen } from '../../../test/react_testing_library';
 import { LocationCvrsPanel } from './location_cvrs_panel';
 
-test('renders nothing when not open', () => {
-  const { container } = render(
-    <LocationCvrsPanel
-      closePanel={vi.fn()}
-      imports={[]}
-      name="Vx City"
-      open={false}
-      type="absentee"
-    />
-  );
-
-  expect(container).toHaveTextContent('');
-});
-
 test('renders empty state note when open with no imports available', () => {
   render(
     <LocationCvrsPanel
       closePanel={vi.fn()}
       imports={[]}
       name="Vx City"
-      open
       type="absentee"
     />
   );
@@ -56,7 +41,6 @@ test('renders import details when non-empty', () => {
         },
       ]}
       name="Vx City"
-      open
       type="absentee"
     />
   );
@@ -65,18 +49,12 @@ test('renders import details when non-empty', () => {
   screen.getByText(pollingPlaceTypeName('absentee'));
   screen.getByText('Vx City');
 
-  screen.queryByRole('listitem', {
-    name: ['2020/11/07, 8:00AM', 'Scanner SCAN-01-0001', '412'].join(' '),
-  });
-  screen.queryByRole('listitem', {
-    name: [
-      '2020/11/07, 9:00AM',
-      'Scanners:',
-      'SCAN-01-0001',
-      'SCAN-01-0002',
-      '412',
-    ].join(' '),
-  });
+  expect(screen.getAllByRole('listitem').map((li) => li.textContent)).toEqual([
+    ['11/7/2020, 8:00 AM', 'Scanner SCAN-01-0001', '412'].join(''),
+    ['11/7/2020, 9:00 AM', 'Scanners: SCAN-01-0001, SCAN-01-0002', '943'].join(
+      ''
+    ),
+  ]);
 
   expect(screen.queryByText('No CVRs')).not.toBeInTheDocument();
 });
@@ -89,7 +67,6 @@ test('emits close event when on close button press', () => {
       closePanel={close}
       imports={[]}
       name="Vx City"
-      open
       type="absentee"
     />
   );

--- a/apps/admin/frontend/src/screens/tally/location_cvrs_panel.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_cvrs_panel.tsx
@@ -15,7 +15,6 @@ import { GAP, INSET_FOCUS_OUTLINE } from './styles';
 
 export interface LocationCvrsPanelProps {
   closePanel: () => void;
-  open: boolean;
   imports: LocationCvrImport[];
   name: string;
   type: PollingPlaceType;
@@ -56,6 +55,7 @@ const Content = styled.div`
   display: grid;
   gap: ${GAP};
   grid-template-rows: min-content 1fr;
+  max-height: 100%;
   min-width: min-content;
   opacity: 1;
   transition: opacity 250ms ease-in;
@@ -64,10 +64,10 @@ const Content = styled.div`
 `;
 
 const DetailsBody = styled.ul`
-  align-items: center;
   display: grid;
   gap: ${GAP};
   margin: 0;
+  overflow-y: auto;
   padding: 0;
 `;
 
@@ -110,9 +110,7 @@ const Title = styled.div`
 `;
 
 export function LocationCvrsPanel(props: LocationCvrsPanelProps): JSX.Element {
-  const { closePanel, imports, name, open, type } = props;
-
-  if (!open) return <Container />;
+  const { closePanel, imports, name, type } = props;
 
   function scannerDetails(i: LocationCvrImport) {
     return i.scannerIds.length === 1

--- a/apps/admin/frontend/src/screens/tally/location_list.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_list.test.tsx
@@ -1,0 +1,89 @@
+import { expect, test } from 'vitest';
+
+import { PollingPlace } from '@votingworks/types/src';
+import { CastVoteRecordFileRecord } from '@votingworks/admin-backend';
+import userEvent from '@testing-library/user-event';
+
+import { render, screen } from '../../../test/react_testing_library';
+import { LocationList } from './location_list';
+import { LocationCvrs } from './cvrs_state';
+import { LocationCvrImport } from './location_cvrs_panel';
+
+const place1 = mockPlace({ id: 'place1', name: 'Place 1', type: 'absentee' });
+const place2 = mockPlace({ id: 'place2', name: 'Place 2', type: 'absentee' });
+
+const locationCvrs1: LocationCvrs = {
+  cvrCount: 500,
+  files: [
+    mockImport({
+      id: 'one',
+      exportTimestamp: '2020-11-07T08:00:00',
+      numCvrsImported: 100,
+      scannerIds: ['SCAN-0001'],
+    }),
+    mockImport({
+      id: 'two',
+      exportTimestamp: '2020-11-07T09:00:00',
+      numCvrsImported: 400,
+      scannerIds: ['SCAN-0001', 'SCAN-0002'],
+    }),
+  ],
+  scannerIds: new Set(['SCAN-0001', 'SCAN-0002']),
+};
+
+const locationCvrs2: LocationCvrs = {
+  cvrCount: 0,
+  files: [],
+  scannerIds: new Set(),
+};
+
+const locationCvrsMap = new Map([
+  [place1.id, locationCvrs1],
+  [place2.id, locationCvrs2],
+]);
+
+test('renders given locations', () => {
+  render(
+    <LocationList locationCvrs={locationCvrsMap} locations={[place1, place2]} />
+  );
+
+  screen.getButton(/^Place 1.*2 files from 2 scanners.*500$/i);
+  screen.getButton(/^Place 2.*no cvrs.*0$/i);
+});
+
+test('toggles location CVR details on click', () => {
+  render(
+    <LocationList locationCvrs={locationCvrsMap} locations={[place1, place2]} />
+  );
+
+  userEvent.click(screen.getButton(/place 1/i));
+  expect(screen.getAllByRole('listitem').map((li) => li.textContent)).toEqual([
+    ['11/7/2020, 8:00 AM', 'Scanner SCAN-0001', '100'].join(''),
+    ['11/7/2020, 9:00 AM', 'Scanners: SCAN-0001, SCAN-0002', '400'].join(''),
+  ]);
+
+  userEvent.click(screen.getButton(/Place 1/i));
+  expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
+});
+
+test('closes location CVR details on close button', () => {
+  render(
+    <LocationList locationCvrs={locationCvrsMap} locations={[place1, place2]} />
+  );
+
+  userEvent.click(screen.getButton(/Place 2/i));
+  screen.getByText(/No files/);
+
+  userEvent.click(screen.getButton('Close Panel'));
+  expect(screen.queryByText(/No files/)).not.toBeInTheDocument();
+});
+
+function mockPlace(partial: Partial<PollingPlace>): PollingPlace {
+  return partial as PollingPlace;
+}
+
+type Import = CastVoteRecordFileRecord;
+
+function mockImport(partial: LocationCvrImport): Import {
+  return partial as Import;
+}

--- a/apps/admin/frontend/src/screens/tally/location_list.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_list.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Id, PollingPlace } from '@votingworks/types';
+import { assertDefined } from '@votingworks/basics';
+
+import { LocationCvrs } from './cvrs_state';
+import { LocationCvrsPanel } from './location_cvrs_panel';
+import { LocationStatusCard } from './location_status_card';
+import { GAP, INSET_FOCUS_OUTLINE } from './styles';
+
+export interface LocationListProps {
+  locationCvrs: Map<Id, LocationCvrs>;
+  locations: readonly PollingPlace[];
+}
+
+const Container = styled.div<{ showingDetails: boolean }>`
+  border-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
+  display: grid;
+  grid-template-columns: 3fr ${(p) => (p.showingDetails ? 2 : 0)}fr;
+  gap: ${(p) => (p.showingDetails ? GAP : 0)};
+  height: 100%;
+  overflow-y: hidden;
+  transition: 100ms ease-out;
+  transition-property: gap, grid-template-columns;
+  scroll-padding-bottom: 1rem;
+  scroll-padding-top: 1rem;
+
+  :focus:focus-visible {
+    ${INSET_FOCUS_OUTLINE}
+  }
+`;
+
+const Details = styled.div`
+  min-width: 0;
+  height: 100%;
+  overflow: hidden;
+`;
+
+const ListScrollContainer = styled.div`
+  max-height: 100%;
+  overflow-y: auto;
+`;
+
+const ListItems = styled.div`
+  align-items: start;
+  display: grid;
+  gap: ${GAP};
+  padding-right: 0.125rem; /* Make room for scrollbar. */
+`;
+
+export function LocationList(props: LocationListProps): React.ReactNode {
+  const { locationCvrs, locations } = props;
+  const [selectedId, setSelectedId] = React.useState<string>();
+
+  function toggleSelected(id: string) {
+    setSelectedId(id === selectedId ? undefined : id);
+  }
+
+  const selected = locations.find((l) => l.id === selectedId);
+
+  return (
+    <Container showingDetails={!!selected}>
+      <ListScrollContainer>
+        <ListItems>
+          {locations.map((l) => (
+            <LocationCard
+              key={l.id}
+              location={l}
+              locationCvrs={locationCvrs}
+              onPress={toggleSelected}
+              selected={l.id === selectedId}
+            />
+          ))}
+        </ListItems>
+      </ListScrollContainer>
+
+      <Details>
+        {selected && (
+          <LocationCvrsPanel
+            closePanel={() => setSelectedId(undefined)}
+            imports={assertDefined(locationCvrs.get(selected.id)).files}
+            name={selected.name}
+            type={selected.type}
+          />
+        )}
+      </Details>
+    </Container>
+  );
+}
+
+function LocationCard(props: {
+  locationCvrs: Map<Id, LocationCvrs>;
+  location: PollingPlace;
+  onPress: (id: string) => void;
+  selected: boolean;
+}) {
+  const { location, locationCvrs, onPress, selected } = props;
+  const cvrs = assertDefined(locationCvrs.get(location.id));
+
+  return (
+    <LocationStatusCard
+      id={location.id}
+      name={location.name}
+      cvrCount={cvrs.cvrCount}
+      onPress={onPress}
+      importCount={cvrs.files.length}
+      scannerIds={[...cvrs.scannerIds]}
+      type={location.type}
+      selected={selected}
+    />
+  );
+}


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7958

Adding the `LocationList` component, which handles displaying all (potentially filtered) locations and toggling the `LocationCvrsPanel` open/close state. Adding to the WIP `CvrsScreen` which isn't rendered anywhere yet.

Also making a slight update to the `LocationCvrsPanel` to drop the `open` prop - going instead with a placeholder container in `LocationList` and just skipping the panel render when no location is selected.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/589b41fd-d043-4176-8bd6-ca13a477e9e9

## Testing Plan
- State/event unit tests for the list component, glue tests for the screen component
- Bit of manual testing with a local prototype to verify the select/scroll interactions, but might need tweaking once everything is hooked up within VxAdmin's nav screen wrapper.

## Checklist
N/A