### PR TITLE
[VxAdmin] Split out CVR import modal state logic for reuse

### DIFF
--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -14,7 +14,10 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 import * as grout from '@votingworks/grout';
-import type { UsbDriveStatus } from '@votingworks/usb-drive';
+import type {
+  UsbDriveStatus,
+  UsbPartitionMountpoint,
+} from '@votingworks/usb-drive';
 import { DEFAULT_QUERY_REFETCH_INTERVAL } from './utils/globals';
 
 const PRINTER_STATUS_POLLING_INTERVAL_MS = 100;
@@ -257,13 +260,17 @@ export const getCurrentElectionMetadata = {
 } as const;
 
 export const listCastVoteRecordFilesOnUsb = {
-  queryKey(): QueryKey {
-    return ['listCastVoteRecordFilesOnUsb'];
+  queryKey(usbPath?: UsbPartitionMountpoint): QueryKey {
+    return ['listCastVoteRecordFilesOnUsb', usbPath];
   },
-  useQuery() {
+  useQuery(usb: UsbDriveStatus) {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () =>
-      apiClient.listCastVoteRecordFilesOnUsb()
+    const path = usb.status === 'mounted' ? usb.mountpoint : undefined;
+
+    return useQuery(
+      this.queryKey(path),
+      () => apiClient.listCastVoteRecordFilesOnUsb(),
+      { enabled: usb.status === 'mounted' }
     );
   },
 } as const;

--- a/apps/admin/frontend/src/screens/tally/cast_vote_records_tab.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/cast_vote_records_tab.test.tsx
@@ -68,7 +68,6 @@ test('loading CVRs', async () => {
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });
 
-  apiMock.expectListCastVoteRecordFilesOnUsb(mockCastVoteRecordFileMetadata);
   userEvent.click(screen.getButton('Load CVRs'));
   importModal = await screen.findByRole('alertdialog');
 

--- a/apps/admin/frontend/src/screens/tally/cvr_importer.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvr_importer.tsx
@@ -77,6 +77,9 @@ export function useCvrImporter(): CvrImporter {
   const usbExports = api.listCastVoteRecordFilesOnUsb.useQuery(usbDriveStatus);
 
   const importMutation = api.addCastVoteRecordFile.useMutation();
+  const manualImportButton = (
+    <ManualImportButton importFn={importMutation.mutate} />
+  );
 
   if (
     usbDriveStatus.status === 'no_drive' ||
@@ -85,7 +88,7 @@ export function useCvrImporter(): CvrImporter {
   ) {
     return {
       state: 'noUsb',
-      manualImportButton: manualImportButton(importMutation.mutate),
+      manualImportButton,
     };
   }
 
@@ -132,7 +135,7 @@ export function useCvrImporter(): CvrImporter {
       state: 'success',
       existingImports,
       import: importMutation.mutate,
-      manualImportButton: manualImportButton(importMutation.mutate),
+      manualImportButton,
       result,
       usbExports: usbExports.data,
     };
@@ -142,12 +145,14 @@ export function useCvrImporter(): CvrImporter {
     state: 'init',
     existingImports,
     import: importMutation.mutate,
-    manualImportButton: manualImportButton(importMutation.mutate),
+    manualImportButton,
     usbExports: usbExports.data,
   };
 }
 
-function manualImportButton(importFn: ImportFn) {
+function ManualImportButton(props: { importFn: ImportFn }) {
+  const { importFn } = props;
+
   return (
     window.kiosk && (
       <Button

--- a/apps/admin/frontend/src/screens/tally/cvr_importer.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvr_importer.tsx
@@ -1,0 +1,289 @@
+import { useContext } from 'react';
+
+import {
+  isElectionManagerAuth,
+  isSystemAdministratorAuth,
+} from '@votingworks/utils';
+import { assert, assertDefined, throwIllegalValue } from '@votingworks/basics';
+import type {
+  CastVoteRecordFileRecord as CvrImport,
+  CastVoteRecordFileMetadata as CvrExport,
+  CvrFileImportInfo,
+  ImportCastVoteRecordsError,
+  CvrFileMode,
+} from '@votingworks/admin-backend';
+import { Button } from '@votingworks/ui';
+
+import { AppContext } from '../../contexts/app_context';
+import * as api from '../../api';
+
+export type ImportFn = (p: { path: string }) => void;
+
+export type CvrImporter =
+  | {
+      state: 'duplicate';
+      existingImports: ExistingImports;
+      result: CvrFileImportInfo;
+      usbExports: CvrExport[];
+    }
+  | {
+      state: 'error';
+      errorMessage?: string;
+      existingImports: ExistingImports;
+      filename: string;
+      usbExports: CvrExport[];
+    }
+  | {
+      state: 'importing';
+      existingImports: ExistingImports;
+      usbExports: CvrExport[];
+    }
+  | {
+      state: 'init';
+      existingImports: ExistingImports;
+      import: ImportFn;
+      manualImportButton: React.ReactNode;
+      usbExports: CvrExport[];
+    }
+  | {
+      state: 'loading';
+    }
+  | {
+      state: 'noUsb';
+      manualImportButton: React.ReactNode;
+    }
+  | {
+      state: 'success';
+      existingImports: ExistingImports;
+      import: ImportFn;
+      manualImportButton: React.ReactNode;
+      result: CvrFileImportInfo;
+      usbExports: CvrExport[];
+    };
+
+export interface ExistingImports {
+  imports: CvrImport[];
+  mode: CvrFileMode;
+}
+
+export function useCvrImporter(): CvrImporter {
+  const { usbDriveStatus, electionDefinition, auth } = useContext(AppContext);
+
+  assert(electionDefinition);
+  assert(isElectionManagerAuth(auth) || isSystemAdministratorAuth(auth));
+
+  const imports = api.getCastVoteRecordFiles.useQuery();
+  const cvrMode = api.getCastVoteRecordFileMode.useQuery();
+  const usbExports = api.listCastVoteRecordFilesOnUsb.useQuery(usbDriveStatus);
+
+  const importMutation = api.addCastVoteRecordFile.useMutation();
+
+  if (
+    usbDriveStatus.status === 'no_drive' ||
+    usbDriveStatus.status === 'ejected' ||
+    usbDriveStatus.status === 'error'
+  ) {
+    return {
+      state: 'noUsb',
+      manualImportButton: manualImportButton(importMutation.mutate),
+    };
+  }
+
+  if (!imports.isSuccess || !cvrMode.isSuccess || !usbExports.isSuccess) {
+    return { state: 'loading' };
+  }
+
+  const existingImports: ExistingImports = {
+    imports: imports.data,
+    mode: cvrMode.data,
+  };
+
+  if (importMutation.status === 'loading') {
+    return {
+      state: 'importing',
+      existingImports,
+      usbExports: usbExports.data,
+    };
+  }
+
+  if (importMutation.status === 'success') {
+    if (importMutation.data.isErr()) {
+      return {
+        state: 'error',
+        errorMessage: errorMessage(importMutation.data.err()),
+        existingImports,
+        filename: assertDefined(importMutation.variables).path,
+        usbExports: usbExports.data,
+      };
+    }
+
+    const result = importMutation.data.ok();
+
+    if (result.wasExistingFile) {
+      return {
+        state: 'duplicate',
+        existingImports,
+        result,
+        usbExports: usbExports.data,
+      };
+    }
+
+    return {
+      state: 'success',
+      existingImports,
+      import: importMutation.mutate,
+      manualImportButton: manualImportButton(importMutation.mutate),
+      result,
+      usbExports: usbExports.data,
+    };
+  }
+
+  return {
+    state: 'init',
+    existingImports,
+    import: importMutation.mutate,
+    manualImportButton: manualImportButton(importMutation.mutate),
+    usbExports: usbExports.data,
+  };
+}
+
+function manualImportButton(importFn: ImportFn) {
+  return (
+    window.kiosk && (
+      <Button
+        onPress={async () => {
+          const kiosk = assertDefined(window.kiosk);
+          const dialogResult = await kiosk.showOpenDialog({
+            properties: ['openFile'],
+            filters: [{ name: '', extensions: ['json'] }],
+          });
+
+          if (dialogResult.canceled) return;
+
+          const path = dialogResult.filePaths[0];
+          if (path) importFn({ path });
+        }}
+      >
+        Select CVR Export Manually…
+      </Button>
+    )
+  );
+}
+
+function errorMessage(err: ImportCastVoteRecordsError): string {
+  switch (err.type) {
+    case 'authentication-error': {
+      return (
+        'Unable to authenticate cast vote records. Try exporting them' +
+        'from the scanner again.'
+      );
+    }
+
+    case 'ballot-id-already-exists-with-different-data': {
+      return (
+        `Found a cast vote record at index ${err.index} that has the` +
+        'same ballot ID as a previously imported cast vote record, but with ' +
+        'different data.'
+      );
+    }
+
+    case 'invalid-mode': {
+      return {
+        official:
+          'You are currently tabulating official results but the selected ' +
+          'cast vote record export contains test results.',
+
+        test:
+          'You are currently tabulating test results but the selected ' +
+          'cast vote record export contains official results.',
+      }[err.currentMode];
+    }
+
+    case 'invalid-cast-vote-record': {
+      const msgBase = `Found an invalid cast vote record at index ${err.index}.`;
+      const msgDetail = (() => {
+        switch (err.subType) {
+          case 'ballot-style-not-found': {
+            return 'The record references a ballot style that does not exist.';
+          }
+          case 'batch-id-not-found': {
+            return 'The record references a batch ID that does not exist.';
+          }
+          case 'contest-not-found': {
+            return 'The record references a contest that does not exist.';
+          }
+          case 'contest-option-not-found': {
+            return 'The record references a contest option that does not exist.';
+          }
+          case 'election-mismatch': {
+            return 'The record references the wrong election.';
+          }
+          case 'image-not-found': {
+            return 'The record references an image that does not exist.';
+          }
+          case 'image-read-error': {
+            return 'The record references an image that could not be read.';
+          }
+          case 'incorrect-image-hash': {
+            return 'The record references an image with an incorrect hash.';
+          }
+          case 'incorrect-layout-file-hash': {
+            return 'The record references a layout file with an incorrect hash.';
+          }
+          case 'invalid-ballot-image-field': {
+            return 'The record contains an incorrectly formatted ballot image field.';
+          }
+          case 'invalid-ballot-sheet-id': {
+            return 'The record contains an incorrectly formatted ballot sheet ID.';
+          }
+          case 'invalid-write-in-field': {
+            return 'The record contains an incorrectly formatted write-in field.';
+          }
+          case 'layout-file-not-found': {
+            return 'The record references a layout file that does not exist.';
+          }
+          case 'layout-file-parse-error': {
+            return 'The record references a layout file that could not be parsed.';
+          }
+          case 'layout-file-read-error': {
+            return 'The record references a layout file that could not be read.';
+          }
+          case 'no-current-snapshot': {
+            return (
+              'The record does not contain a current snapshot of the ' +
+              'interpreted results.'
+            );
+          }
+          case 'no-original-snapshot': {
+            return 'The record does not contain the original snapshot of the results.';
+          }
+          case 'parse-error': {
+            return 'The record could not be parsed.';
+          }
+          case 'precinct-not-found': {
+            return 'The record references a precinct that does not exist.';
+          }
+
+          /* istanbul ignore next */
+          default: {
+            throwIllegalValue(err, 'subType');
+          }
+        }
+      })();
+      return [msgBase, msgDetail].join(' ');
+    }
+
+    case 'metadata-file-not-found': {
+      return 'Unable to find metadata file.';
+    }
+
+    case 'metadata-file-parse-error': {
+      return 'Unable to parse metadata file.';
+    }
+
+    /* istanbul ignore next */
+    default: {
+      throwIllegalValue(err, 'type');
+    }
+  }
+}

--- a/apps/admin/frontend/src/screens/tally/import_cvrfiles_modal.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/import_cvrfiles_modal.test.tsx
@@ -40,7 +40,7 @@ test('when USB is not present or valid', async () => {
     const closeFn = vi.fn();
     apiMock.expectGetCastVoteRecordFileMode('unlocked');
     apiMock.expectGetCastVoteRecordFiles([]);
-    apiMock.expectListCastVoteRecordFilesOnUsb([]);
+
     const { unmount } = renderInAppContext(
       <ImportCvrFilesModal onClose={closeFn} />,
       {
@@ -143,7 +143,6 @@ describe('when USB is properly mounted', () => {
     apiMock.expectGetCastVoteRecordFiles([]);
 
     userEvent.click(domGetByText(tableRows[0], 'Load'));
-    await screen.findByText('Loading CVRs');
     await screen.findByText('1,000 New CVRs Loaded');
   });
 

--- a/apps/admin/frontend/src/screens/tally/import_cvrfiles_modal.tsx
+++ b/apps/admin/frontend/src/screens/tally/import_cvrfiles_modal.tsx
@@ -1,6 +1,5 @@
-import React, { useContext, useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
-import { basename } from 'node:path';
 import { DateTime } from 'luxon';
 
 import {
@@ -9,32 +8,16 @@ import {
   Table,
   TD,
   Button,
-  useExternalStateChangeListener,
   P,
   Font,
   Icons,
+  H3,
 } from '@votingworks/ui';
-import {
-  format,
-  isElectionManagerAuth,
-  isSystemAdministratorAuth,
-} from '@votingworks/utils';
-import { assert, assertDefined, throwIllegalValue } from '@votingworks/basics';
+import { format } from '@votingworks/utils';
 
-import type {
-  CvrFileImportInfo,
-  ImportCastVoteRecordsError,
-} from '@votingworks/admin-backend';
-import { AppContext } from '../../contexts/app_context';
 import { Loading } from '../../components/loading';
-import { CastVoteRecordFilePreprocessedData } from '../../config/types';
 import { NODE_ENV, TIME_FORMAT } from '../../config/globals';
-import {
-  addCastVoteRecordFile,
-  getCastVoteRecordFileMode,
-  getCastVoteRecordFiles,
-  listCastVoteRecordFilesOnUsb,
-} from '../../api';
+import { useCvrImporter } from './cvr_importer';
 
 const CvrFileTableWrapper = styled.div`
   background: ${(p) => p.theme.colors.containerLow};
@@ -66,203 +49,37 @@ const Content = styled.div`
   overflow: hidden;
 `;
 
-function userReadableMessageFromImportError(
-  error: ImportCastVoteRecordsError
-): string {
-  switch (error.type) {
-    case 'authentication-error': {
-      return 'Unable to authenticate cast vote records. Try exporting them from the scanner again.';
-    }
-    case 'ballot-id-already-exists-with-different-data': {
-      return `Found a cast vote record at index ${error.index} that has the same ballot ID as a previously imported cast vote record, but with different data.`;
-    }
-    case 'invalid-mode': {
-      return {
-        official:
-          'You are currently tabulating official results but the selected cast vote record export contains test results.',
-        test: 'You are currently tabulating test results but the selected cast vote record export contains official results.',
-      }[error.currentMode];
-    }
-    case 'invalid-cast-vote-record': {
-      const messageBase = `Found an invalid cast vote record at index ${error.index}. `;
-      const messageDetail = (() => {
-        switch (error.subType) {
-          case 'ballot-style-not-found': {
-            return 'The record references a ballot style that does not exist.';
-          }
-          case 'batch-id-not-found': {
-            return 'The record references a batch ID that does not exist.';
-          }
-          case 'contest-not-found': {
-            return 'The record references a contest that does not exist.';
-          }
-          case 'contest-option-not-found': {
-            return 'The record references a contest option that does not exist.';
-          }
-          case 'election-mismatch': {
-            return 'The record references the wrong election.';
-          }
-          case 'image-not-found': {
-            return 'The record references an image that does not exist.';
-          }
-          case 'image-read-error': {
-            return 'The record references an image that could not be read.';
-          }
-          case 'incorrect-image-hash': {
-            return 'The record references an image with an incorrect hash.';
-          }
-          case 'incorrect-layout-file-hash': {
-            return 'The record references a layout file with an incorrect hash.';
-          }
-          case 'invalid-ballot-image-field': {
-            return 'The record contains an incorrectly formatted ballot image field.';
-          }
-          case 'invalid-ballot-sheet-id': {
-            return 'The record contains an incorrectly formatted ballot sheet ID.';
-          }
-          case 'invalid-write-in-field': {
-            return 'The record contains an incorrectly formatted write-in field.';
-          }
-          case 'layout-file-not-found': {
-            return 'The record references a layout file that does not exist.';
-          }
-          case 'layout-file-parse-error': {
-            return 'The record references a layout file that could not be parsed.';
-          }
-          case 'layout-file-read-error': {
-            return 'The record references a layout file that could not be read.';
-          }
-          case 'no-current-snapshot': {
-            return 'The record does not contain a current snapshot of the interpreted results.';
-          }
-          case 'no-original-snapshot': {
-            return 'The record does not contain the original snapshot of the results.';
-          }
-          case 'parse-error': {
-            return 'The record could not be parsed.';
-          }
-          case 'precinct-not-found': {
-            return 'The record references a precinct that does not exist.';
-          }
-          default: {
-            /* istanbul ignore next: Compile-time check for completeness */
-            throwIllegalValue(error, 'subType');
-          }
-        }
-      })();
-      return [messageBase, messageDetail].join(' ');
-    }
-    case 'metadata-file-not-found': {
-      return 'Unable to find metadata file.';
-    }
-    case 'metadata-file-parse-error': {
-      return 'Unable to parse metadata file.';
-    }
-    default: {
-      /* istanbul ignore next: Compile-time check for completeness */
-      throwIllegalValue(error, 'type');
-    }
-  }
-}
-
-type ModalState =
-  | { state: 'error'; errorMessage?: string; filename: string }
-  | { state: 'loading' }
-  | { state: 'duplicate'; result: CvrFileImportInfo }
-  | { state: 'init' }
-  | { state: 'success'; result: CvrFileImportInfo };
-
 export interface Props {
   onClose: () => void;
 }
 
 export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
-  const { usbDriveStatus, electionDefinition, auth } = useContext(AppContext);
-  const castVoteRecordFilesQuery = getCastVoteRecordFiles.useQuery();
-  const castVoteRecordFileModeQuery = getCastVoteRecordFileMode.useQuery();
-  const cvrFilesOnUsbQuery = listCastVoteRecordFilesOnUsb.useQuery();
-  const addCastVoteRecordFileMutation = addCastVoteRecordFile.useMutation();
+  const importer = useCvrImporter();
 
-  assert(electionDefinition);
-  assert(isElectionManagerAuth(auth) || isSystemAdministratorAuth(auth)); // TODO(auth) check permissions for loaded cvr
-  const [currentState, setCurrentState] = useState<ModalState>({
-    state: 'init',
-  });
-
-  function importCastVoteRecordFile(path: string) {
-    const filename = basename(path);
-    setCurrentState({ state: 'loading' });
-
-    addCastVoteRecordFileMutation.mutate(
-      { path },
-      {
-        onSuccess: (addCastVoteRecordFileResult) => {
-          if (addCastVoteRecordFileResult.isErr()) {
-            const error = addCastVoteRecordFileResult.err();
-            setCurrentState({
-              state: 'error',
-              errorMessage: userReadableMessageFromImportError(error),
-              filename,
-            });
-          } else if (addCastVoteRecordFileResult.ok().wasExistingFile) {
-            setCurrentState({
-              state: 'duplicate',
-              result: addCastVoteRecordFileResult.ok(),
-            });
-          } else {
-            setCurrentState({
-              state: 'success',
-              result: addCastVoteRecordFileResult.ok(),
-            });
-          }
-        },
-      }
+  if (importer.state === 'loading') {
+    return (
+      <Modal
+        centerContent={false}
+        content={
+          <H3 align="center">
+            <Icons.Loading /> Loading
+          </H3>
+        }
+        onOverlayClick={onClose}
+        actions={<Button onPress={onClose}>Cancel</Button>}
+      />
     );
   }
 
-  function importSelectedFile(fileData: CastVoteRecordFilePreprocessedData) {
-    importCastVoteRecordFile(fileData.path);
-  }
-
-  async function onSelectFileManually(): Promise<void> {
-    const dialogResult = await assertDefined(window.kiosk).showOpenDialog({
-      properties: ['openFile'],
-      filters: [
-        {
-          name: '',
-          extensions: ['json'],
-        },
-      ],
-    });
-    if (dialogResult.canceled) {
-      onClose();
-      return;
-    }
-    const selectedPath = dialogResult.filePaths[0];
-    if (selectedPath) {
-      importCastVoteRecordFile(selectedPath);
-    }
-  }
-
-  // TODO: Rather than explicitly refetching, which is outside of the standard
-  // React Query pattern, we should invalidate the query on USB drive status
-  // change. Currently React Query is not managing USB drive status and polling
-  // is being performed elsewhere.
-  useExternalStateChangeListener(usbDriveStatus.status, () => {
-    if (usbDriveStatus.status === 'mounted') {
-      void cvrFilesOnUsbQuery.refetch();
-    }
-  });
-
-  if (currentState.state === 'error') {
+  if (importer.state === 'error') {
     return (
       <Modal
         title="Error"
         content={
           <P>
             There was an error reading the contents of{' '}
-            <Font weight="bold">{currentState.filename}</Font>:{' '}
-            {currentState.errorMessage}
+            <Font weight="bold">{importer.filename}</Font>:{' '}
+            {importer.errorMessage}
           </P>
         }
         onOverlayClick={onClose}
@@ -271,7 +88,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
     );
   }
 
-  if (currentState.state === 'duplicate') {
+  if (importer.state === 'duplicate') {
     return (
       <Modal
         title="Duplicate Export"
@@ -287,8 +104,8 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
     );
   }
 
-  if (currentState.state === 'success') {
-    const { alreadyPresent, newlyAdded } = currentState.result;
+  if (importer.state === 'success') {
+    const { alreadyPresent, newlyAdded } = importer.result;
     const total = alreadyPresent + newlyAdded;
     const content = (() => {
       if (alreadyPresent > 0) {
@@ -319,33 +136,11 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
     );
   }
 
-  if (
-    !castVoteRecordFilesQuery.isSuccess ||
-    !castVoteRecordFileModeQuery.isSuccess ||
-    !cvrFilesOnUsbQuery.isSuccess
-  ) {
-    return (
-      <Modal
-        content={<Loading />}
-        onOverlayClick={onClose}
-        actions={
-          <Button disabled onPress={onClose}>
-            Cancel
-          </Button>
-        }
-      />
-    );
-  }
-
-  if (currentState.state === 'loading') {
+  if (importer.state === 'importing') {
     return <Modal content={<Loading>Loading CVRs</Loading>} />;
   }
 
-  if (
-    usbDriveStatus.status === 'no_drive' ||
-    usbDriveStatus.status === 'ejected' ||
-    usbDriveStatus.status === 'error'
-  ) {
+  if (importer.state === 'noUsb') {
     return (
       <Modal
         title="No USB Drive Detected"
@@ -355,11 +150,7 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
         onOverlayClick={onClose}
         actions={
           <React.Fragment>
-            {window.kiosk && NODE_ENV === 'development' && (
-              <Button onPress={onSelectFileManually}>
-                Select CVR Export Manually…
-              </Button>
-            )}
+            {NODE_ENV === 'development' && importer.manualImportButton}
             <Button onPress={onClose}>Cancel</Button>
           </React.Fragment>
         }
@@ -367,141 +158,135 @@ export function ImportCvrFilesModal({ onClose }: Props): JSX.Element | null {
     );
   }
 
-  const fileMode = castVoteRecordFileModeQuery.data;
+  const fileMode = importer.existingImports.mode;
 
-  if (usbDriveStatus.status === 'mounted') {
-    // Determine if we are already locked to a filemode based on previously loaded CVRs
-    const fileModeLocked = fileMode !== 'unlocked';
+  // Determine if we are already locked to a filemode based on previously loaded CVRs
+  const fileModeLocked = fileMode !== 'unlocked';
 
-    // Parse the file options on the USB drive and build table rows for each valid file.
-    const fileTableRows: JSX.Element[] = [];
-    let numberOfNewFiles = 0;
-    const importedCvrFiles = castVoteRecordFilesQuery.data;
-    for (const file of cvrFilesOnUsbQuery.data) {
-      const { isTestModeResults, scannerIds, exportTimestamp, cvrCount, name } =
-        file;
-      // To tell if a CVR export was already imported, we need to check its name
-      // and export timestamp, since a VxScan continuous CVR export will reuse
-      // the same export directory as CVRs are added, updating the export
-      // timestamp each time. So if you want to re-import a continuous export
-      // later after more CVRs have been added, you should be able to.
-      const isFileAlreadyImported = importedCvrFiles.some(
-        (importedCvrFile) =>
-          importedCvrFile.filename === name &&
-          importedCvrFile.exportTimestamp === exportTimestamp.toISOString()
-      );
-      const inProperFileMode =
-        !fileModeLocked ||
-        (isTestModeResults && fileMode === 'test') ||
-        (!isTestModeResults && fileMode === 'official');
-      const canImport = !isFileAlreadyImported && inProperFileMode;
-      const row = (
-        <tr key={name} data-testid="table-row">
-          <td>{DateTime.fromJSDate(exportTimestamp).toFormat(TIME_FORMAT)}</td>
-          <td>{scannerIds.join(', ')}</td>
-          <td data-testid="cvr-count">{format.count(cvrCount)}</td>
-          {!fileModeLocked && (
-            <td>
-              {isTestModeResults ? (
-                <LabelText>
-                  <Icons.Warning color="warning" /> Test
-                </LabelText>
-              ) : (
-                <LabelText>Official</LabelText>
-              )}
-            </td>
-          )}
-          <TD textAlign="right">
-            <Button
-              onPress={importSelectedFile}
-              value={file}
-              disabled={!canImport}
-              variant="primary"
-            >
-              {canImport ? 'Load' : 'Loaded'}
-            </Button>
-          </TD>
-        </tr>
-      );
-      if (inProperFileMode) {
-        fileTableRows.push(row);
-        if (canImport) {
-          numberOfNewFiles += 1;
-        }
+  // Parse the file options on the USB drive and build table rows for each valid file.
+  const fileTableRows: JSX.Element[] = [];
+  let numberOfNewFiles = 0;
+  const importedCvrFiles = importer.existingImports.imports;
+  for (const file of importer.usbExports) {
+    const { isTestModeResults, scannerIds, exportTimestamp, cvrCount, name } =
+      file;
+    // To tell if a CVR export was already imported, we need to check its name
+    // and export timestamp, since a VxScan continuous CVR export will reuse
+    // the same export directory as CVRs are added, updating the export
+    // timestamp each time. So if you want to re-import a continuous export
+    // later after more CVRs have been added, you should be able to.
+    const isFileAlreadyImported = importedCvrFiles.some(
+      (importedCvrFile) =>
+        importedCvrFile.filename === name &&
+        importedCvrFile.exportTimestamp === exportTimestamp.toISOString()
+    );
+    const inProperFileMode =
+      !fileModeLocked ||
+      (isTestModeResults && fileMode === 'test') ||
+      (!isTestModeResults && fileMode === 'official');
+    const canImport = !isFileAlreadyImported && inProperFileMode;
+    const row = (
+      <tr key={name} data-testid="table-row">
+        <td>{DateTime.fromJSDate(exportTimestamp).toFormat(TIME_FORMAT)}</td>
+        <td>{scannerIds.join(', ')}</td>
+        <td data-testid="cvr-count">{format.count(cvrCount)}</td>
+        {!fileModeLocked && (
+          <td>
+            {isTestModeResults ? (
+              <LabelText>
+                <Icons.Warning color="warning" /> Test
+              </LabelText>
+            ) : (
+              <LabelText>Official</LabelText>
+            )}
+          </td>
+        )}
+        <TD textAlign="right">
+          <Button
+            onPress={importer.import}
+            value={{ path: file.path }}
+            disabled={!canImport}
+            variant="primary"
+          >
+            {canImport ? 'Load' : 'Loaded'}
+          </Button>
+        </TD>
+      </tr>
+    );
+    if (inProperFileMode) {
+      fileTableRows.push(row);
+      if (canImport) {
+        numberOfNewFiles += 1;
       }
     }
-    // Set the header and instructional text for the modal
-    const headerModeText =
-      fileMode === 'test'
-        ? 'Test Ballot'
-        : fileMode === 'official'
-        ? 'Official Ballot'
-        : '';
+  }
+  // Set the header and instructional text for the modal
+  const headerModeText =
+    fileMode === 'test'
+      ? 'Test Ballot'
+      : fileMode === 'official'
+      ? 'Official Ballot'
+      : '';
 
-    let instructionalText: JSX.Element | string;
-    if (numberOfNewFiles === 0) {
-      instructionalText = fileModeLocked ? (
-        <React.Fragment>
-          No new {headerModeText.toLowerCase()} CVR exports were automatically
-          found on the USB drive.
-        </React.Fragment>
-      ) : (
-        <React.Fragment>
-          No new CVR exports were automatically found on the USB drive.
-        </React.Fragment>
-      );
-    } else if (fileModeLocked) {
-      instructionalText = (
-        <React.Fragment>
-          The following {headerModeText.toLowerCase()} CVR exports were
-          automatically found on the USB drive:
-        </React.Fragment>
-      );
-    } else {
-      instructionalText = (
-        <React.Fragment>
-          The following CVR exports were automatically found on the USB drive:
-        </React.Fragment>
-      );
-    }
-
-    return (
-      <Modal
-        modalWidth={ModalWidth.Wide}
-        title={`Load ${headerModeText} CVRs`}
-        content={
-          <Content>
-            <P>{instructionalText}</P>
-            {fileTableRows.length > 0 && (
-              <CvrFileTableWrapper>
-                <Table>
-                  <thead>
-                    <tr>
-                      <th>Saved At</th>
-                      <th>Scanner ID</th>
-                      <th>CVR Count</th>
-                      {!fileModeLocked && <th>Ballot Type</th>}
-                      <th />
-                    </tr>
-                  </thead>
-                  <tbody>{fileTableRows}</tbody>
-                </Table>
-              </CvrFileTableWrapper>
-            )}
-          </Content>
-        }
-        onOverlayClick={onClose}
-        actions={
-          <React.Fragment>
-            <Button onPress={onSelectFileManually}>
-              Select CVR Export Manually…
-            </Button>
-            <Button onPress={onClose}>Cancel</Button>
-          </React.Fragment>
-        }
-      />
+  let instructionalText: JSX.Element | string;
+  if (numberOfNewFiles === 0) {
+    instructionalText = fileModeLocked ? (
+      <React.Fragment>
+        No new {headerModeText.toLowerCase()} CVR exports were automatically
+        found on the USB drive.
+      </React.Fragment>
+    ) : (
+      <React.Fragment>
+        No new CVR exports were automatically found on the USB drive.
+      </React.Fragment>
+    );
+  } else if (fileModeLocked) {
+    instructionalText = (
+      <React.Fragment>
+        The following {headerModeText.toLowerCase()} CVR exports were
+        automatically found on the USB drive:
+      </React.Fragment>
+    );
+  } else {
+    instructionalText = (
+      <React.Fragment>
+        The following CVR exports were automatically found on the USB drive:
+      </React.Fragment>
     );
   }
-  // istanbul ignore next
-  throwIllegalValue(usbDriveStatus, 'status');
+
+  return (
+    <Modal
+      modalWidth={ModalWidth.Wide}
+      title={`Load ${headerModeText} CVRs`}
+      content={
+        <Content>
+          <P>{instructionalText}</P>
+          {fileTableRows.length > 0 && (
+            <CvrFileTableWrapper>
+              <Table>
+                <thead>
+                  <tr>
+                    <th>Saved At</th>
+                    <th>Scanner ID</th>
+                    <th>CVR Count</th>
+                    {!fileModeLocked && <th>Ballot Type</th>}
+                    <th />
+                  </tr>
+                </thead>
+                <tbody>{fileTableRows}</tbody>
+              </Table>
+            </CvrFileTableWrapper>
+          )}
+        </Content>
+      }
+      onOverlayClick={onClose}
+      actions={
+        <React.Fragment>
+          {importer.manualImportButton}
+          <Button onPress={onClose}>Cancel</Button>
+        </React.Fragment>
+      }
+    />
+  );
 }


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7958

_Easier to review with the "hide whitespace" option._

Extracting state management logic from the existing CVR import modal for later reuse in the upcoming inline import panel as part of the CVR management flow updates. Should make it a little easier to stage the changes for the new panel and swap it in place of the modal later.

## Demo Video or Screenshot
### Using existing modal with the newly extracted state logic

https://github.com/user-attachments/assets/4196b2b5-41e2-4628-b1f9-18cf19ee09e9

## Testing Plan
- Existing tests as regression check.
- Noticed a few spots with pre-existing missing coverage - will backfill after migrating to the new import panel.

## Checklist
N/A