### PR TITLE
[VxAdmin] Add 'test mode' banner to new CVR managment screen

### DIFF
--- a/apps/admin/frontend/src/screens/tally/cvrs_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvrs_screen.test.tsx
@@ -1,6 +1,9 @@
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
-import type { CastVoteRecordFileRecord } from '@votingworks/admin-backend';
+import type {
+  CastVoteRecordFileRecord,
+  CvrFileMode,
+} from '@votingworks/admin-backend';
 
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import userEvent from '@testing-library/user-event';
@@ -203,6 +206,37 @@ test('delete button opens confirmation modal', async () => {
 
   userEvent.click(screen.getButton('Cancel'));
   expect(screen.queryButton(/Remove All CVRs/)).not.toBeInTheDocument();
+});
+
+describe('cvr modes', () => {
+  async function renderWithMode(mode: CvrFileMode) {
+    const api = createApiMock();
+    api.expectGetCastVoteRecordFileMode(mode);
+    api.expectGetCastVoteRecordFiles([]);
+
+    renderInAppContext(<CvrsScreen />, {
+      apiMock: api,
+      electionDefinition,
+    });
+
+    await waitFor(() => api.assertComplete());
+  }
+
+  test('unlocked', async () => {
+    await renderWithMode('unlocked');
+    expect(screen.queryByText(/test ballot mode/i)).not.toBeInTheDocument();
+  });
+
+  test('official', async () => {
+    await renderWithMode('official');
+    expect(screen.queryByText(/test ballot mode/i)).not.toBeInTheDocument();
+  });
+
+  // eslint-disable-next-line vitest/valid-title
+  test('test', async () => {
+    await renderWithMode('test');
+    screen.getByText(/test ballot mode/i);
+  });
 });
 
 function mockCvrFile(

--- a/apps/admin/frontend/src/screens/tally/cvrs_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvrs_screen.tsx
@@ -1,9 +1,16 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-import { Button, DesktopPalette } from '@votingworks/ui';
-
+import {
+  Button,
+  Caption,
+  Card,
+  DesktopPalette,
+  Font,
+  Icons,
+} from '@votingworks/ui';
 import { assertDefined } from '@votingworks/basics';
+
 import { CvrSummaries } from './cvr_summaries';
 import { GAP, INSET_FOCUS_OUTLINE } from './styles';
 import { LocationFilter, LocationFilterBar } from './location_filter_bar';
@@ -12,7 +19,11 @@ import { ImportCvrFilesModal } from './import_cvrfiles_modal';
 import { CvrsState, useCvrsState } from './cvrs_state';
 import { LocationList } from './location_list';
 
-const Container = styled.div`
+const TEST_MODE_CONTAINER_CSS = css`
+  grid-template-rows: min-content min-content 1fr;
+`;
+
+const Container = styled.div<{ testMode: boolean }>`
   display: grid;
   gap: ${GAP};
   grid-template-rows: min-content 1fr;
@@ -23,6 +34,8 @@ const Container = styled.div`
   > * {
     margin: 0 ${GAP};
   }
+
+  ${(p) => p.testMode && TEST_MODE_CONTAINER_CSS}
 `;
 
 export function CvrsScreen(): React.ReactNode {
@@ -32,8 +45,8 @@ export function CvrsScreen(): React.ReactNode {
   if (!state) return null;
 
   return (
-    <Container>
-      {/* [TODO] Render test mode card. */}
+    <Container testMode={state.testMode}>
+      {state.testMode && <TestModeCard />}
 
       <CvrSummaries
         cvrs={state.totalCvrs}
@@ -53,6 +66,36 @@ export function CvrsScreen(): React.ReactNode {
         <ImportCvrFilesModal onClose={() => setUiMode('view')} />
       )}
     </Container>
+  );
+}
+
+const TestModeCardContainer = styled(Card)`
+  > * {
+    gap: ${GAP};
+    padding: ${GAP} calc(1.5 * ${GAP});
+  }
+`;
+
+const TestModeCardContent = styled.div`
+  display: grid;
+  grid-template-rows: min-content 1fr;
+  gap: 0.25rem;
+`;
+
+function TestModeCard() {
+  return (
+    <TestModeCardContainer color="warning">
+      <TestModeCardContent>
+        <Font weight="bold">
+          <Icons.Warning color="warning" /> Test Ballot Mode
+        </Font>
+
+        <Caption>
+          Remove all test CVRs once you have completed testing and are ready to
+          tally official ballots.
+        </Caption>
+      </TestModeCardContent>
+    </TestModeCardContainer>
   );
 }
 


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7958

On the new CVR management screen: adding a test mode notice when test CVRs have been imported.

## Demo Video or Screenshot

<img width="1109" height="810" alt="Screenshot 2026-06-26 at 13 55 49" src="https://github.com/user-attachments/assets/39c32549-310d-4a7e-9954-1884f8dd8fd9" />

## Testing Plan
- New test cases to assert banner presence/absence in the various CVR modes

## Checklist
N/A