### PR TITLE
[VxAdmin] Start using new CVR management screen

### DIFF
--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -14,7 +14,11 @@ import {
   mockSessionExpiresAt,
 } from '@votingworks/test-utils';
 import { BooleanEnvironmentVariableName } from '@votingworks/utils';
-import { constructElectionKey, formatElectionHashes } from '@votingworks/types';
+import {
+  anyPollingPlace,
+  constructElectionKey,
+  formatElectionHashes,
+} from '@votingworks/types';
 import {
   fireEvent,
   screen,
@@ -381,7 +385,11 @@ test('clearing results', async () => {
     isOfficialResults: true,
   });
   apiMock.expectGetCastVoteRecordFiles([
-    { ...mockCastVoteRecordFileRecord, numCvrsImported: 3000 },
+    {
+      ...mockCastVoteRecordFileRecord,
+      numCvrsImported: 3000,
+      pollingPlaceIds: [anyPollingPlace(electionDefinition.election).id],
+    },
   ]);
   apiMock.expectGetCastVoteRecordFileMode('test');
 
@@ -390,8 +398,8 @@ test('clearing results', async () => {
 
   userEvent.click(screen.getByText('Tally'));
   await screen.findByText('Election Results are Official');
-  expect(await screen.findButton('Load CVRs')).toBeDisabled();
-  expect(await screen.findButton('Remove All CVRs')).toBeDisabled();
+  expect(screen.queryButton('Load')).not.toBeInTheDocument();
+  expect(screen.queryButton('Remove All CVRs')).not.toBeInTheDocument();
 
   apiMock.expectDeleteAllManualResults();
   apiMock.expectClearCastVoteRecordFiles();
@@ -407,9 +415,9 @@ test('clearing results', async () => {
     expect(
       screen.queryByText('Election Results Marked as Official')
     ).not.toBeInTheDocument();
-    expect(screen.getButton('Load CVRs')).toBeEnabled();
+    expect(screen.getButton('Load')).toBeEnabled();
   });
-  screen.getByText('No CVRs loaded.');
+  screen.getByText(hasTextAcrossElements(['CVRs', '0'].join('')));
 });
 
 test('can not view or print ballots', async () => {
@@ -447,7 +455,7 @@ test('election manager UI has expected nav', async () => {
   await screen.findByRole('heading', { name: 'Election' });
 
   userEvent.click(screen.getButton('Tally'));
-  await screen.findByRole('heading', { name: 'Tally' });
+  await screen.findByRole('tab', { name: 'Cast Vote Records' });
 
   apiMock.expectGetRegisteredVoterCounts(null);
   userEvent.click(screen.getByText('Reports'));

--- a/apps/admin/frontend/src/components/navigation_screen.tsx
+++ b/apps/admin/frontend/src/components/navigation_screen.tsx
@@ -214,13 +214,11 @@ export const Header = styled(MainHeader)`
   padding-left: 0.75rem;
 `;
 
-export function NavigationScreen({
-  children,
-  title,
-  parentRoutes,
-  noPadding,
-  style,
-}: Props): JSX.Element {
+export interface NavScreenLiteProps {
+  children: React.ReactNode;
+}
+
+export function NavScreenLite({ children }: NavScreenLiteProps): JSX.Element {
   const { usbDriveStatus, auth, machineMode } = useContext(AppContext);
   const logOutMutation = sharedLogOut.useMutation();
   const ejectUsbDriveMutation = sharedEjectUsbDrive.useMutation();
@@ -246,30 +244,41 @@ export function NavigationScreen({
           </Toolbar>
         )}
         <SessionTimeLimitTimer authStatus={auth} />
-        <Header>
-          <div>
-            {title && (
-              <React.Fragment>
-                {parentRoutes && (
-                  <Breadcrumbs
-                    currentTitle={title}
-                    parentRoutes={parentRoutes}
-                  />
-                )}
-                <H1>{title}</H1>
-              </React.Fragment>
-            )}
-          </div>
-        </Header>
-        <MainContent
-          style={{
-            ...(style ?? {}),
-            padding: noPadding ? 0 : undefined,
-          }}
-        >
-          {children}
-        </MainContent>
+        {children}
       </Main>
     </Screen>
+  );
+}
+
+export function NavigationScreen({
+  children,
+  title,
+  parentRoutes,
+  noPadding,
+  style,
+}: Props): JSX.Element {
+  return (
+    <NavScreenLite>
+      <Header>
+        <div>
+          {title && (
+            <React.Fragment>
+              {parentRoutes && (
+                <Breadcrumbs currentTitle={title} parentRoutes={parentRoutes} />
+              )}
+              <H1>{title}</H1>
+            </React.Fragment>
+          )}
+        </div>
+      </Header>
+      <MainContent
+        style={{
+          ...(style ?? {}),
+          padding: noPadding ? 0 : undefined,
+        }}
+      >
+        {children}
+      </MainContent>
+    </NavScreenLite>
   );
 }

--- a/apps/admin/frontend/src/components/sidebar.tsx
+++ b/apps/admin/frontend/src/components/sidebar.tsx
@@ -64,7 +64,7 @@ export function Sidebar(props: SidebarProps): JSX.Element {
     );
 
   return (
-    <LeftNav>
+    <LeftNav style={{ width: '11rem' }}>
       <Link to="/">
         <AppLogo appName={appName} />
       </Link>

--- a/apps/admin/frontend/src/screens/tally/cvrs_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvrs_screen.tsx
@@ -110,6 +110,12 @@ const ActionBar = styled.div<{ layered?: boolean }>`
   position: sticky;
   top: 0;
 
+  /*
+   * Maintain roughly the same height when buttons are omitted after results
+   * are official:
+   */
+  min-height: 2.4rem;
+
   > button:focus:focus-visible {
     ${INSET_FOCUS_OUTLINE}
   }

--- a/apps/admin/frontend/src/screens/tally/tally_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/tally_screen.test.tsx
@@ -5,7 +5,8 @@ import {
 } from '@votingworks/fixtures';
 
 import userEvent from '@testing-library/user-event';
-import { screen } from '../../../test/react_testing_library';
+import { hasTextAcrossElements } from '@votingworks/test-utils';
+import { screen, waitFor } from '../../../test/react_testing_library';
 import { TallyScreen } from './tally_screen';
 import { renderInAppContext } from '../../../test/render_in_app_context';
 import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client';
@@ -28,25 +29,34 @@ afterEach(() => {
 });
 
 const electionDefinition = electionTwoPartyPrimaryDefinition;
+const nLocations = electionDefinition.election.pollingPlaces.length;
 
 test('has tabs for CVRs and Manual Tallies', async () => {
   apiMock.expectGetCastVoteRecordFileMode('unlocked');
   apiMock.expectGetCastVoteRecordFiles([]);
-  apiMock.expectGetManualResultsMetadata([]);
-  apiMock.expectGetSystemSettings();
   renderInAppContext(<TallyScreen />, {
     electionDefinition,
     apiMock,
     route: '/tally',
   });
-  await screen.findByRole('heading', { name: 'Tally' });
 
-  screen.getByRole('tab', { name: 'Cast Vote Records (CVRs)' });
-  await screen.findByText('No CVRs loaded.');
-  expect(screen.getButton('Load CVRs')).toBeEnabled();
+  await waitFor(() => apiMock.assertComplete());
+  screen.getByRole('tab', { name: 'Cast Vote Records', selected: true });
+
+  const locationsCardText = ['Locations', `0 / ${nLocations}`].join('');
+  screen.getByText(hasTextAcrossElements(locationsCardText));
+
+  expect(screen.getButton('Load')).toBeEnabled();
   expect(
-    screen.queryByRole('button', { name: 'Remove CVRs' })
+    screen.queryByRole('button', { name: /remove/i })
   ).not.toBeInTheDocument();
+
+  for (const location of electionDefinition.election.pollingPlaces) {
+    screen.getButton(new RegExp(location.name));
+  }
+
+  apiMock.expectGetSystemSettings();
+  apiMock.expectGetManualResultsMetadata([]);
 
   userEvent.click(screen.getByRole('tab', { name: 'Manual Tallies' }));
   await screen.findByText('No manual tallies entered.');
@@ -60,9 +70,8 @@ test('hides Manual Tallies tab for open primary elections', async () => {
     apiMock,
     route: '/tally',
   });
-  await screen.findByRole('heading', { name: 'Tally' });
 
-  screen.getByRole('tab', { name: 'Cast Vote Records (CVRs)' });
+  await screen.findByRole('tab', { name: 'Cast Vote Records' });
   expect(
     screen.queryByRole('tab', { name: 'Manual Tallies' })
   ).not.toBeInTheDocument();
@@ -76,6 +85,8 @@ test('redirects /tally/manual to CVRs tab for open primary elections', async () 
     apiMock,
     route: '/tally/manual',
   });
-  await screen.findByRole('heading', { name: 'Tally' });
-  await screen.findByText('No CVRs loaded.');
+  await screen.findByRole('tab', { name: 'Cast Vote Records', selected: true });
+
+  const locationsCardText = ['Locations', `0 / ${nLocations}`].join('');
+  screen.getByText(hasTextAcrossElements(locationsCardText));
 });

--- a/apps/admin/frontend/src/screens/tally/tally_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/tally_screen.tsx
@@ -1,88 +1,137 @@
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import { isElectionManagerAuth } from '@votingworks/utils';
-import { assert } from '@votingworks/basics';
-import { Button, Icons, H3, RouterTabBar } from '@votingworks/ui';
+import { assert, assertDefined } from '@votingworks/basics';
+import {
+  Button,
+  Icons,
+  RouterTabBar,
+  MainContent,
+  DesktopPalette,
+  Font,
+  Card,
+} from '@votingworks/ui';
 import { Redirect, Route, Switch } from 'react-router-dom';
+import styled, { css } from 'styled-components';
 import { AppContext } from '../../contexts/app_context';
-import { NavigationScreen } from '../../components/navigation_screen';
-import { OfficialResultsCard } from '../../components/official_results_card';
-import { CastVoteRecordsTab } from './cast_vote_records_tab';
+import { NavScreenLite } from '../../components/navigation_screen';
 import { ManualTalliesTab } from './manual_tallies_tab';
 import { routerPaths } from '../../router_paths';
 import { ConfirmRemoveAllResultsModal } from './confirm_remove_all_results_modal';
+import { BORDER_LIGHT, GAP } from './styles';
+import { CvrsScreen } from './cvrs_screen';
+
+const Container = styled.div`
+  display: grid;
+  grid-template-rows: min-content 1fr;
+  overflow-y: hidden;
+  height: 100%;
+`;
+
+const BODY_WITH_BANNER_CSS = css`
+  grid-template-rows: min-content 1fr;
+`;
+
+const Body = styled.div<{ withBanner: boolean }>`
+  display: grid;
+  grid-template-rows: 1fr;
+  overflow-y: hidden;
+  position: relative;
+  height: 100%;
+
+  ${(p) => p.withBanner && BODY_WITH_BANNER_CSS}
+`;
+
+const Content = styled.div`
+  height: 100%;
+  overflow-y: hidden;
+  position: relative;
+`;
+
+const OfficialCard = styled(Card)`
+  ${BORDER_LIGHT}
+  margin: ${GAP} ${GAP} 0;
+
+  > * {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    padding: ${GAP};
+    padding-left: calc(1.5 * ${GAP}); /* Balance out with icon/text gap. */
+  }
+`;
+
+const TabBar = styled(RouterTabBar)`
+  border-color: ${DesktopPalette.Gray30};
+  gap: ${GAP};
+  padding: ${GAP} ${GAP} 0;
+`;
 
 export function TallyScreen(): JSX.Element | null {
-  const { electionDefinition, isOfficialResults, auth } =
-    useContext(AppContext);
-  assert(electionDefinition);
+  const ctx = useContext(AppContext);
+  const { electionDefinition, isOfficialResults, auth } = ctx;
+  const { election } = assertDefined(electionDefinition);
   assert(isElectionManagerAuth(auth));
 
-  const [
-    isConfirmRemoveAllResultsModalOpen,
-    setIsConfirmRemoveAllResultsModalOpen,
-  ] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
 
-  const manualTalliesEnabled =
-    electionDefinition.election.type !== 'open-primary';
+  const tabs: Array<{ title: string; path: string }> = [
+    { title: 'Cast Vote Records', path: routerPaths.tallyCvrs },
+  ];
+
+  const manualTalliesEnabled = election.type !== 'open-primary';
+  if (manualTalliesEnabled) {
+    tabs.push({ title: 'Manual Tallies', path: routerPaths.tallyManual });
+  }
 
   return (
-    <React.Fragment>
-      <NavigationScreen title="Tally">
-        {isOfficialResults && (
-          <OfficialResultsCard>
-            <H3>
-              <Icons.Done color="success" />
-              Election Results are Official
-            </H3>
-            <Button
-              onPress={() => setIsConfirmRemoveAllResultsModalOpen(true)}
-              icon="Delete"
-              color="danger"
-            >
-              Remove All Tallies
-            </Button>
-          </OfficialResultsCard>
-        )}
+    <NavScreenLite>
+      <Container>
+        <TabBar tabs={tabs} />
 
-        <RouterTabBar
-          tabs={[
-            {
-              title: 'Cast Vote Records (CVRs)',
-              path: routerPaths.tallyCvrs,
-            },
-            ...(manualTalliesEnabled
-              ? [
-                  {
-                    title: 'Manual Tallies',
-                    path: routerPaths.tallyManual,
-                  },
-                ]
-              : []),
-          ]}
-        />
-
-        <Switch>
-          <Route
-            exact
-            path={routerPaths.tallyCvrs}
-            component={CastVoteRecordsTab}
-          />
-          {manualTalliesEnabled && (
-            <Route
-              exact
-              path={routerPaths.tallyManual}
-              component={ManualTalliesTab}
-            />
+        <Body withBanner={isOfficialResults}>
+          {isOfficialResults && (
+            <OfficialCard>
+              <Font style={{ fontSize: '1.125rem' }} weight="bold">
+                <Icons.Done color="success" style={{ marginRight: GAP }} />
+                Election Results are Official
+              </Font>
+              <Button
+                onPress={() => setConfirmingDelete(true)}
+                icon="Trash"
+                color="danger"
+              >
+                Remove All Tallies
+              </Button>
+            </OfficialCard>
           )}
-          <Redirect from={routerPaths.tally} to={routerPaths.tallyCvrs} />
-        </Switch>
-      </NavigationScreen>
 
-      {isConfirmRemoveAllResultsModalOpen && (
+          <Content>
+            <Switch>
+              <Route
+                exact
+                path={routerPaths.tallyCvrs}
+                component={CvrsScreen}
+              />
+
+              {manualTalliesEnabled && (
+                <Route exact path={routerPaths.tallyManual}>
+                  <MainContent style={{ height: '100%', padding: `0 ${GAP}` }}>
+                    <ManualTalliesTab />
+                  </MainContent>
+                </Route>
+              )}
+
+              <Redirect from={routerPaths.tally} to={routerPaths.tallyCvrs} />
+            </Switch>
+          </Content>
+        </Body>
+      </Container>
+
+      {confirmingDelete && (
         <ConfirmRemoveAllResultsModal
-          onClose={() => setIsConfirmRemoveAllResultsModalOpen(false)}
+          onClose={() => setConfirmingDelete(false)}
         />
       )}
-    </React.Fragment>
+    </NavScreenLite>
   );
 }

--- a/apps/admin/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/admin/integration-testing/e2e/screenshots.spec.ts
@@ -570,7 +570,7 @@ test('results', async ({ page }, testInfo) => {
   await page.getByRole('heading', { name: 'Election', exact: true }).waitFor();
 
   await page.getByText('Tally').click();
-  await page.getByText('Cast Vote Records (CVRs)').waitFor();
+  await page.getByText('Cast Vote Records').waitFor();
   await screenshot('tally-screen-empty');
 
   await insertUsbDriveWithCvrs({
@@ -579,7 +579,7 @@ test('results', async ({ page }, testInfo) => {
     usbHandler,
     electionDefinition,
   });
-  await page.getByText('Load CVRs').click();
+  await page.getByRole('button', { name: 'Load', exact: true }).click();
   await page.getByText('17').first().waitFor();
   await screenshot('load-cvrs');
 
@@ -588,7 +588,7 @@ test('results', async ({ page }, testInfo) => {
   await screenshot('cvrs-loaded');
 
   await page.getByRole('button', { name: 'Close' }).click();
-  await page.getByText('Total CVR Count: 17').waitFor();
+  await page.getByText('Cvrs17').waitFor();
   await screenshot('tally-screen-with-cvrs');
 
   // Full election tally report
@@ -807,7 +807,7 @@ test('results', async ({ page }, testInfo) => {
 
   // Tally screen now reflects official results.
   await page.getByRole('button', { name: 'Tally', exact: true }).click();
-  await page.getByText('Cast Vote Records (CVRs)').waitFor();
+  await page.getByText('Cast Vote Records').waitFor();
   await screenshot('tally-screen-official');
 
   // A system administrator can revert results to unofficial.
@@ -881,7 +881,7 @@ test('adjudication', async ({ page }, testInfo) => {
   await logInAsElectionManager(page, election);
   await page.getByRole('heading', { name: 'Election', exact: true }).waitFor();
   await page.getByText('Tally').click();
-  await page.getByText('Cast Vote Records (CVRs)').waitFor();
+  await page.getByText('Cast Vote Records').waitFor();
 
   await insertUsbDriveWithCvrs({
     cvrPath: cvrExportPath,
@@ -889,11 +889,11 @@ test('adjudication', async ({ page }, testInfo) => {
     usbHandler,
     electionDefinition,
   });
-  await page.getByText('Load CVRs').click();
+  await page.getByRole('button', { name: 'Load', exact: true }).click();
   await page.getByRole('button', { name: 'Load' }).click();
   await page.getByText('3 New CVRs Loaded').waitFor();
   await page.getByRole('button', { name: 'Close' }).click();
-  await page.getByText('Total CVR Count: 3').waitFor();
+  await page.getByText('Cvrs3').waitFor();
 
   // Adjudication start screen
   await page.getByText('Adjudication').click();
@@ -1051,14 +1051,14 @@ test('qualified write-in candidates', async ({ page }, testInfo) => {
 
   // Load the CVR with the mayor write-in.
   await page.getByText('Tally').click();
-  await page.getByText('Cast Vote Records (CVRs)').waitFor();
+  await page.getByText('Cast Vote Records').waitFor();
   await insertUsbDriveWithCvrs({
     cvrPath: cvrExportPath,
     convertToOfficial: false,
     usbHandler,
     electionDefinition,
   });
-  await page.getByText('Load CVRs').click();
+  await page.getByRole('button', { name: 'Load', exact: true }).click();
   await page.getByRole('button', { name: 'Load' }).click();
   await page.getByText('1 New CVR Loaded').waitFor();
   await page.getByRole('button', { name: 'Close' }).click();
@@ -1098,7 +1098,7 @@ test('manual results', async ({ page }, testInfo) => {
   await logInAsElectionManager(page, election);
   await page.getByRole('heading', { name: 'Election', exact: true }).waitFor();
   await page.getByText('Tally').click();
-  await page.getByText('Cast Vote Records (CVRs)').waitFor();
+  await page.getByText('Cast Vote Records').waitFor();
 
   await insertUsbDriveWithCvrs({
     cvrPath: castVoteRecordExport.asDirectoryPath(),
@@ -1106,11 +1106,11 @@ test('manual results', async ({ page }, testInfo) => {
     usbHandler,
     electionDefinition,
   });
-  await page.getByText('Load CVRs').click();
+  await page.getByRole('button', { name: 'Load', exact: true }).click();
   await page.getByRole('button', { name: 'Load' }).click();
   await page.getByText('184 New CVRs Loaded').waitFor();
   await page.getByRole('button', { name: 'Close' }).click();
-  await page.getByText('Total CVR Count: 184').waitFor();
+  await page.getByText('Cvrs184').waitFor();
 
   await page.getByText('Manual Tallies').click();
   await screenshot('manual-tallies-tab-empty');

--- a/libs/ui/src/tabs.tsx
+++ b/libs/ui/src/tabs.tsx
@@ -31,6 +31,7 @@ const TabBar = styled.div.attrs({ role: 'tablist' })`
 `;
 
 export interface RouterTabBarProps {
+  className?: string;
   tabs: Array<{ title: string; path: string }>;
 }
 
@@ -41,11 +42,12 @@ export interface RouterTabBarProps {
  *
  * To render the tab content, use the {@link TabPanel} component inside a `Switch`.
  */
-export function RouterTabBar({ tabs }: RouterTabBarProps): JSX.Element {
+export function RouterTabBar(props: RouterTabBarProps): JSX.Element {
+  const { className, tabs } = props;
   const location = useLocation();
   const history = useHistory();
   return (
-    <TabBar>
+    <TabBar className={className}>
       {tabs.map((tab) => {
         const isActive = location.pathname === tab.path;
         return (


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7958

Replacing the older CVR management screen with the new, location-centric screen, with high-level summary cards, search/filter and per-location CVR import detail views.

TODO:
- The import modal has not yet been updated. That will happen in upcoming PRs, but this should be a good, working snapshot point, in case we need to cut an image before that's done.

## Demo Video or Screenshot

### Before:

<img width="1346" height="842" alt="vxadmin-cvrs-screen-before" src="https://github.com/user-attachments/assets/03813650-0772-4639-bcdd-7dfd8e241eb5" />

### After:

https://github.com/user-attachments/assets/abe0a552-66a4-4748-b85a-e2e5085ad6b1

### Test Mode:

<img  alt="vxadmin-cvrs-screen-test-mode" src="https://github.com/user-attachments/assets/843fcee1-e2f7-4ede-ac61-d075f3f0dfa5" />

### Results Official:

<img alt="vxadmin-cvrs-screen-results-official" src="https://github.com/user-attachments/assets/820a2587-528a-4b88-a193-6527364c7267" />

<img width="1346" height="842" alt="vxadmin-manual-tallies-results-official" src="https://github.com/user-attachments/assets/c6cead68-2d2b-4ac4-80f4-8084c079f498" />

## Testing Plan
- Updated tests that expect the old view + manual spot checks for import/search/filter/delete flows.

## Checklist

- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
