### PR TITLE
VxDesign: Skip generating straight party contest for blank elections

### DIFF
--- a/apps/design/backend/src/app.state_mi.test.ts
+++ b/apps/design/backend/src/app.state_mi.test.ts
@@ -2,7 +2,7 @@ import { afterAll, expect, test, vi } from 'vitest';
 import { find } from '@votingworks/basics';
 import { electionGeneralFixtures } from '@votingworks/fixtures';
 import { readElectionPackageFromBuffer } from '@votingworks/backend';
-import { BallotType } from '@votingworks/types';
+import { BallotType, ElectionIdSchema, unsafeParse } from '@votingworks/types';
 import {
   exportElectionPackage,
   getExportedFile,
@@ -29,6 +29,25 @@ const miUser: JurisdictionUser = {
   organization: miJurisdiction.organization,
   jurisdictions: [miJurisdiction],
 };
+
+test('blank general election omits straight party contest', async () => {
+  const { apiClient, auth0 } = await setupApp({
+    organizations,
+    jurisdictions,
+    users: [...users, miUser],
+  });
+  auth0.setLoggedInUser(miUser);
+
+  const electionId = (
+    await apiClient.createElection({
+      id: unsafeParse(ElectionIdSchema, 'mi-blank-election-id'),
+      jurisdictionId: miJurisdiction.id,
+    })
+  ).unsafeUnwrap();
+
+  const contests = await apiClient.listContests({ electionId });
+  expect(contests).toEqual([]);
+});
 
 test('general elections include generated straight party contest', async () => {
   const election = electionGeneralFixtures.readElection();

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -1193,22 +1193,21 @@ export class Store {
       ) {
         // The straight party contest's district must be on every ballot style
         // so the contest appears on every ballot.
-        const district = assertDefined(
-          districts.find((d) =>
-            ballotStyles.every((ballotStyle) =>
-              ballotStyle.districts.includes(d.id)
-            )
-          ),
-          'Straight party contest requires a district shared by all ballot styles'
+        const district = districts.find((d) =>
+          ballotStyles.every((ballotStyle) =>
+            ballotStyle.districts.includes(d.id)
+          )
         );
-        const straightPartyContest: StraightPartyContest = {
-          id: straightPartyContestId(electionId),
-          type: 'straight-party',
-          title: 'Straight Party Ticket',
-          districtId: district.id,
-          optionIds: parties.map((party) => party.id),
-        };
-        contests.unshift(straightPartyContest);
+        if (district) {
+          const straightPartyContest: StraightPartyContest = {
+            id: straightPartyContestId(electionId),
+            type: 'straight-party',
+            title: 'Straight Party Ticket',
+            districtId: district.id,
+            optionIds: parties.map((party) => party.id),
+          };
+          contests.unshift(straightPartyContest);
+        }
       }
 
       const election: Election = {

--- a/apps/design/frontend/src/ballots_status.test.tsx
+++ b/apps/design/frontend/src/ballots_status.test.tsx
@@ -1,12 +1,16 @@
 import { describe, expect, test } from 'vitest';
 import {
   BallotStyle,
+  Contest,
   ElectionRegisteredVoterCounts,
+  ElectionType,
+  LanguageCode,
   PollingPlace,
   Precinct,
 } from '@votingworks/types';
+import type { ElectionInfo } from '@votingworks/design-backend';
 import userEvent from '@testing-library/user-event';
-import { sleep } from '@votingworks/basics';
+import { DateWithoutTime, sleep } from '@votingworks/basics';
 import { createMemoryHistory } from 'history';
 import { routes } from './routes';
 import { withRoute } from '../test/routing_helpers';
@@ -26,6 +30,8 @@ test('ballots incomplete', async () => {
   mockFinalizedAt(api, null);
   mockApprovedAt(api, null);
   mockStateFeatures(api, {});
+  mockElectionInfo(api, 'general');
+  mockContests(api, []);
   mockPrecincts(api, []);
   mockRegisteredVoterCounts(api, {});
   mockPollingPlaces(api, []);
@@ -39,12 +45,81 @@ test('ballots incomplete', async () => {
   expect(screen.queryByRole('button')).not.toBeInTheDocument();
 });
 
+describe('straight party contest is missing', () => {
+  const ballotStyles = [{} as unknown as BallotStyle]; // Content irrelevant.
+  const straightPartyContest = {
+    type: 'straight-party',
+  } as unknown as Contest;
+  const otherContest = { type: 'candidate' } as unknown as Contest;
+
+  test('blocks a general election missing its straight party contest', async () => {
+    const api = createMockApiClient();
+    mockBallotStyles(api, ballotStyles);
+    mockFinalizedAt(api, null);
+    mockApprovedAt(api, null);
+    mockStateFeatures(api, { STRAIGHT_PARTY_VOTING: true });
+    mockElectionInfo(api, 'general');
+    mockContests(api, [otherContest]);
+    mockPrecincts(api, []);
+    mockRegisteredVoterCounts(api, {});
+    mockPollingPlaces(api, []);
+
+    renderUi(api);
+
+    const soleHeading = await screen.findByRole('heading');
+    api.assertComplete();
+
+    expect(soleHeading).toHaveTextContent(
+      'Cannot generate straight party contest'
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  test('does not block when the straight party contest is present', async () => {
+    const api = createMockApiClient();
+    mockBallotStyles(api, ballotStyles);
+    mockFinalizedAt(api, null);
+    mockApprovedAt(api, null);
+    mockStateFeatures(api, { STRAIGHT_PARTY_VOTING: true });
+    mockElectionInfo(api, 'general');
+    mockContests(api, [straightPartyContest, otherContest]);
+    mockPrecincts(api, []);
+    mockRegisteredVoterCounts(api, {});
+    mockPollingPlaces(api, []);
+
+    renderUi(api);
+
+    await screen.findByRole('heading', { name: 'Ballots Not Finalized' });
+    api.assertComplete();
+  });
+
+  test('does not block a non-general election', async () => {
+    const api = createMockApiClient();
+    mockBallotStyles(api, ballotStyles);
+    mockFinalizedAt(api, null);
+    mockApprovedAt(api, null);
+    mockStateFeatures(api, { STRAIGHT_PARTY_VOTING: true });
+    mockElectionInfo(api, 'closed-primary');
+    mockContests(api, [otherContest]);
+    mockPrecincts(api, []);
+    mockRegisteredVoterCounts(api, {});
+    mockPollingPlaces(api, []);
+
+    renderUi(api);
+
+    await screen.findByRole('heading', { name: 'Ballots Not Finalized' });
+    api.assertComplete();
+  });
+});
+
 test('ballots ready to finalize', async () => {
   const api = createMockApiClient();
   mockBallotStyles(api, [{} as unknown as BallotStyle]); // Content irrelevant.
   mockFinalizedAt(api, null);
   mockApprovedAt(api, null);
   mockStateFeatures(api, {});
+  mockElectionInfo(api, 'general');
+  mockContests(api, []);
   mockPrecincts(api, []);
   mockRegisteredVoterCounts(api, {});
   mockPollingPlaces(api, []);
@@ -74,6 +149,8 @@ test('start finalize and cancel', async () => {
   mockFinalizedAt(api, null);
   mockApprovedAt(api, null);
   mockStateFeatures(api, {});
+  mockElectionInfo(api, 'general');
+  mockContests(api, []);
   mockPrecincts(api, []);
   mockRegisteredVoterCounts(api, {});
   mockPollingPlaces(api, []);
@@ -98,6 +175,8 @@ test('start finalize and confirm', async () => {
   mockFinalizedAt(api, null);
   mockApprovedAt(api, null);
   mockStateFeatures(api, {});
+  mockElectionInfo(api, 'general');
+  mockContests(api, []);
   mockPrecincts(api, []);
   mockRegisteredVoterCounts(api, {});
   mockPollingPlaces(api, []);
@@ -130,6 +209,8 @@ test.each([false, true])(
     mockStateFeatures(api, {
       POST_FINALIZE_CHANGE_FEE_WARNING: isPostFinalizeChangeFeeWarningEnabled,
     });
+    mockElectionInfo(api, 'general');
+    mockContests(api, []);
     mockPrecincts(api, []);
     mockRegisteredVoterCounts(api, {});
     mockPollingPlaces(api, []);
@@ -158,6 +239,8 @@ test('ballots finalized', async () => {
   mockFinalizedAt(api, new Date());
   mockApprovedAt(api, null);
   mockStateFeatures(api, {});
+  mockElectionInfo(api, 'general');
+  mockContests(api, []);
   mockPrecincts(api, []);
   mockRegisteredVoterCounts(api, {});
   mockPollingPlaces(api, []);
@@ -177,6 +260,8 @@ test('ballots approved', async () => {
   mockFinalizedAt(api, new Date());
   mockApprovedAt(api, new Date());
   mockStateFeatures(api, {});
+  mockElectionInfo(api, 'general');
+  mockContests(api, []);
   mockPrecincts(api, []);
   mockRegisteredVoterCounts(api, {});
   mockPollingPlaces(api, []);
@@ -202,6 +287,8 @@ describe('registered voter counts', () => {
     mockFinalizedAt(api, null);
     mockApprovedAt(api, null);
     mockStateFeatures(api, {});
+    mockElectionInfo(api, 'general');
+    mockContests(api, []);
     mockPrecincts(api, [
       { id: 'p1', name: 'Precinct 1', districtIds: [] },
       { id: 'p2', name: 'Precinct 2', districtIds: [] },
@@ -227,6 +314,8 @@ describe('registered voter counts', () => {
     mockFinalizedAt(api, null);
     mockApprovedAt(api, null);
     mockStateFeatures(api, {});
+    mockElectionInfo(api, 'general');
+    mockContests(api, []);
     mockPrecincts(api, [
       {
         id: 'p1',
@@ -264,6 +353,8 @@ describe('absentee polling place coverage', () => {
     mockFinalizedAt(api, null);
     mockApprovedAt(api, null);
     mockStateFeatures(api, features);
+    mockElectionInfo(api, 'general');
+    mockContests(api, []);
     mockPrecincts(api, precincts);
     mockRegisteredVoterCounts(api, {});
   }
@@ -343,6 +434,25 @@ function mockStateFeatures(
   features: Record<string, boolean>
 ) {
   api.getStateFeatures.expectCallWith({ electionId }).resolves(features);
+}
+
+function mockElectionInfo(api: MockApiClient, type: ElectionType) {
+  const electionInfo: ElectionInfo = {
+    electionId,
+    jurisdictionId: 'jurisdiction-1',
+    type,
+    date: new DateWithoutTime('2024-11-05'),
+    title: 'Test Election',
+    state: 'MI',
+    jurisdictionName: 'Test County',
+    seal: '',
+    languageCodes: [LanguageCode.ENGLISH],
+  };
+  api.getElectionInfo.expectCallWith({ electionId }).resolves(electionInfo);
+}
+
+function mockContests(api: MockApiClient, contests: Contest[]) {
+  api.listContests.expectCallWith({ electionId }).resolves(contests);
 }
 
 function mockPrecincts(api: MockApiClient, precincts: Precinct[]) {

--- a/apps/design/frontend/src/ballots_status.tsx
+++ b/apps/design/frontend/src/ballots_status.tsx
@@ -30,6 +30,8 @@ export function BallotsStatus(): React.ReactNode {
   const approvedAtQuery = api.getBallotsApprovedAt.useQuery(electionId);
   const finalizedAtQuery = api.getBallotsFinalizedAt.useQuery(electionId);
   const getStateFeaturesQuery = api.getStateFeatures.useQuery(electionId);
+  const getElectionInfoQuery = api.getElectionInfo.useQuery(electionId);
+  const listContestsQuery = api.listContests.useQuery(electionId);
   const listPrecinctsQuery = api.listPrecincts.useQuery(electionId);
   const getRegisteredVoterCountsQuery =
     api.getRegisteredVoterCounts.useQuery(electionId);
@@ -42,6 +44,8 @@ export function BallotsStatus(): React.ReactNode {
     !finalizedAtQuery.isSuccess ||
     !approvedAtQuery.isSuccess ||
     !getStateFeaturesQuery.isSuccess ||
+    !getElectionInfoQuery.isSuccess ||
+    !listContestsQuery.isSuccess ||
     !listPrecinctsQuery.isSuccess ||
     !getRegisteredVoterCountsQuery.isSuccess ||
     !listPollingPlacesQuery.isSuccess
@@ -59,6 +63,23 @@ export function BallotsStatus(): React.ReactNode {
       <Callout color="neutral" icon={<Icons.Info />} title="Ballots Incomplete">
         VxDesign will create ballot styles for your election once you have
         created districts, precincts, and contests.
+      </Callout>
+    );
+  }
+
+  if (
+    features.STRAIGHT_PARTY_VOTING &&
+    getElectionInfoQuery.data.type === 'general' &&
+    !listContestsQuery.data.some((contest) => contest.type === 'straight-party')
+  ) {
+    return (
+      <Callout
+        color="neutral"
+        icon={<Icons.Info />}
+        title="Cannot generate straight party contest"
+      >
+        To generate the straight party contest, the election must include a
+        district that covers every precinct.
       </Callout>
     );
   }


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->
When creating a new blank general election for MI, VxDesign previously crashed because it was looking for a district to use for the generated straight party contest. To fix this, we only add the straight party contest when there is an appropriate district (that spans all precincts). We also add a guard to prevent finalizing ballots without the straight party contest.

## Demo Video or Screenshot
<img width="1424" height="930" alt="Screenshot 2026-07-06 at 1 06 35 PM" src="https://github.com/user-attachments/assets/feab7727-98c3-4578-aa82-a154bac7c6f0" />


## Testing Plan
Added automated test cases

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
