### PR TITLE
VxDesign: Convert back to yesOption noOption on v4.0 export

### DIFF
--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -165,13 +165,13 @@ export const OptionalCandidateSchema: z.ZodSchema<OptionalCandidate> =
 export type ContestId = Id;
 export const ContestIdSchema: z.ZodSchema<ContestId> = IdSchema;
 
-interface ContestBase {
+export interface ContestBase {
   readonly id: ContestId;
   readonly districtId: DistrictId;
   readonly title: string;
 }
 
-const ContestBaseSchema = z.object({
+export const ContestBaseSchema = z.object({
   id: ContestIdSchema,
   districtId: DistrictIdSchema,
   title: z.string().nonempty(),

--- a/libs/types/src/software_versions.test.ts
+++ b/libs/types/src/software_versions.test.ts
@@ -16,11 +16,22 @@ const v4p0PrimaryElectionData = JSON.stringify(
   convertLatestElectionToV4p0(primaryElection)
 );
 
+// Mirrors the yesno -> yesOption/noOption conversion in
+// convertLatestElectionToV4p0 for the 2-option ballot measures in the fixtures.
+function toV4p0Contests(contests: Election['contests']) {
+  return contests.map((contest) => {
+    if (contest.type !== 'yesno') return contest;
+    const { options, ...rest } = contest;
+    return { ...rest, yesOption: options[0], noOption: options[1] };
+  });
+}
+
 test('convertLatestElectionToV4p0', () => {
   // v4.0 uses `county`/`countyName` where v4.1 uses
   // `jurisdiction`/`jurisdictionName`; everything else is unchanged.
   expect(convertLatestElectionToV4p0(election)).toEqual({
     ...election,
+    contests: toV4p0Contests(election.contests),
     jurisdiction: undefined,
     county: election.jurisdiction,
     ballotStrings: {
@@ -36,6 +47,7 @@ test('convertLatestElectionToV4p0', () => {
   // closed-primary -> primary, same county/countyName conversion
   expect(convertLatestElectionToV4p0(primaryElection)).toEqual({
     ...primaryElection,
+    contests: toV4p0Contests(primaryElection.contests),
     type: 'primary',
     jurisdiction: undefined,
     county: primaryElection.jurisdiction,
@@ -109,8 +121,17 @@ test('convertLatestElectionToV4p0 converts yesno contests with more than two opt
     allowWriteIns: false,
     seats: 1,
   });
-  // The standard 2-option measure is left as a yesno contest.
-  expect(v4p0.contests).toContainEqual(twoOptionMeasure);
+  // The standard 2-option measure stays a yesno contest but uses the v4.0
+  // yesOption/noOption shape.
+  expect(v4p0.contests).toContainEqual({
+    id: 'measure-2',
+    type: 'yesno',
+    districtId,
+    title: 'Measure 2',
+    description: 'A standard yes/no ballot measure',
+    yesOption: { id: 'measure-2-yes', label: 'Yes' },
+    noOption: { id: 'measure-2-no', label: 'No' },
+  });
 
   // The dropped description of the 3-option measure is preserved in
   // additionalHashInput so it still affects the ballot hash. The 2-option
@@ -137,7 +158,7 @@ test('safeParseElectionDefinitionV4p0', () => {
   );
   expect(electionDefinition.electionData).toEqual(v4p0PrimaryElectionData);
   expect(electionDefinition.ballotHash).toMatchInlineSnapshot(
-    `"26dbb17e3f300fe117589b510c2eb770e1cd75182c261a555328e71ef10e9339"`
+    `"2eed58532057418228ff007d96c26a6d43529a5cf7d4e04ec925c3ae27861f30"`
   );
 
   expect(

--- a/libs/types/src/software_versions.ts
+++ b/libs/types/src/software_versions.ts
@@ -7,7 +7,10 @@ import {
   BallotStyleIdSchema,
   BallotStyleSchema,
   CandidateContest,
+  CandidateContestSchema,
   Contest,
+  ContestBase,
+  ContestBaseSchema,
   ContestId,
   ContestIdSchema,
   Election,
@@ -19,7 +22,11 @@ import {
   PollingPlace,
   PollingPlacesSchema,
   SheetPositions,
+  StraightPartyContest,
+  StraightPartyContestSchema,
   YesNoContest,
+  YesNoOption,
+  YesNoOptionSchema,
 } from './election';
 import {
   ballotPositionsFromGridPositions,
@@ -127,21 +134,49 @@ const BallotStyleV4p0Schema = BallotStyleSchema.omit({
   languages: z.array(z.string()).optional(),
 });
 
+// v4.0 represented yesno contests with `yesOption`/`noOption` (plus optional
+// `additionalOptions`) rather than the v4.1+ ordered `options` array. Deployed
+// v4.0 software still expects this shape, so we convert to/from it on export and
+// import.
+interface YesNoContestV4p0 extends ContestBase {
+  readonly type: 'yesno';
+  readonly description: string;
+  readonly yesOption: YesNoOption;
+  readonly noOption: YesNoOption;
+  readonly additionalOptions?: readonly YesNoOption[];
+}
+const YesNoContestV4p0Schema: z.ZodSchema<YesNoContestV4p0> =
+  ContestBaseSchema.extend({
+    type: z.literal('yesno'),
+    description: z.string().nonempty(),
+    yesOption: YesNoOptionSchema,
+    noOption: YesNoOptionSchema,
+    additionalOptions: z.array(YesNoOptionSchema).optional(),
+  });
+type ContestV4p0 = CandidateContest | YesNoContestV4p0 | StraightPartyContest;
+const ContestV4p0Schema: z.ZodSchema<ContestV4p0> = z.union([
+  CandidateContestSchema,
+  YesNoContestV4p0Schema,
+  StraightPartyContestSchema,
+]);
+
 type ElectionV4p0 = Omit<
   Election,
-  'type' | 'jurisdiction' | 'ballotStyles' | 'pollingPlaces'
+  'type' | 'jurisdiction' | 'ballotStyles' | 'pollingPlaces' | 'contests'
 > & {
   type: ElectionTypeV4p0;
   county: Election['jurisdiction'];
   ballotStyles: readonly BallotStyleV4p0[];
   pollingPlaces?: readonly PollingPlace[];
   gridLayouts?: readonly GridLayoutV4p0[];
+  contests: readonly ContestV4p0[];
 };
 export const ElectionV4p0Schema: z.ZodSchema<ElectionV4p0> = z.object({
   ...electionShapeForV4p0,
   ballotStyles: z.array(BallotStyleV4p0Schema),
   pollingPlaces: PollingPlacesSchema.optional(),
   gridLayouts: z.array(GridLayoutV4p0Schema).optional(),
+  contests: z.array(ContestV4p0Schema),
   county: JurisdictionSchema,
   type: ElectionTypeSchemaV4p0,
 });
@@ -274,18 +309,27 @@ export function convertLatestElectionToV4p0(election: Election): ElectionV4p0 {
     'v4.0 does not support open primaries'
   );
   const { jurisdiction, ballotStrings, ballotStyles, ...rest } = election;
-  // v4.0 doesn't support yesno contests with more than two options, so convert
-  // them to candidate contests. v4.1+ exports them natively with all options.
+  // v4.0 represents yesno contests with `yesOption`/`noOption` and doesn't
+  // support more than two options, so 2-option measures map to that shape and
+  // measures with additional options convert to candidate contests. v4.1+
+  // exports them natively as an `options` array.
   const contestsWithAdditionalOptions = election.contests.filter(
     (contest): contest is YesNoContest =>
       contest.type === 'yesno' && contest.options.length > 2
   );
-  const contestsForV4p0 = election.contests.map(
-    (contest): Contest =>
-      contest.type === 'yesno' && contest.options.length > 2
-        ? convertBallotMeasureWithAdditionalOptionsToCandidateContest(contest)
-        : contest
-  );
+  const contestsForV4p0 = election.contests.map((contest): ContestV4p0 => {
+    if (contest.type !== 'yesno') {
+      return contest;
+    }
+    if (contest.options.length > 2) {
+      return convertBallotMeasureWithAdditionalOptionsToCandidateContest(
+        contest
+      );
+    }
+    const [yesOption, noOption] = contest.options;
+    const { options: _options, ...contestRest } = contest;
+    return { ...contestRest, yesOption, noOption };
+  });
   // Converting to a candidate contest drops the yesno description, so preserve
   // it in additionalHashInput. Otherwise two elections differing only in a
   // ballot-measure description would produce identical v4.0 JSON and collide.
@@ -348,8 +392,21 @@ function convertV4p0ElectionToLatest(election: ElectionV4p0): Election {
       gridLayoutV4p0ToBallotPositions(gridLayout),
     ])
   );
+  // v4.0 represents yesno contests with `yesOption`/`noOption` (plus optional
+  // `additionalOptions`); v4.1+ uses a single ordered `options` array.
+  const contests = rest.contests.map((contest): Contest => {
+    if (contest.type !== 'yesno') {
+      return contest;
+    }
+    const { yesOption, noOption, additionalOptions, ...contestRest } = contest;
+    return {
+      ...contestRest,
+      options: [yesOption, noOption, ...(additionalOptions ?? [])],
+    };
+  });
   return {
     ...rest,
+    contests,
     // v4.0 may omit ballot-style languages; v4.1+ requires them. Default to
     // English when absent.
     ballotStyles: ballotStyles.map((ballotStyle) => ({


### PR DESCRIPTION
## Overview
Not sure how I missed this two weeks ago but I guess I forgot to implement the v4.0 conversion back to yesOption & noOption rathern then "options" when exporting a v4.0 election

## Demo Video or Screenshot
N/A

## Testing Plan
Exported an election with 2-option and 3-option ballot measures in a v4.0 jurisdiction saw them export as yesOption and noOption in the 2-option version and convert to a candidate contest for the 3 option version 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
