### PR TITLE
VxMark: backend to print blank ballot

### DIFF
--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -37,6 +37,7 @@ import {
 } from '@votingworks/utils';
 
 import { Buffer } from 'node:buffer';
+import { readFileSync } from 'node:fs';
 import { mockElectionPackageFileTree } from '@votingworks/backend';
 import { Server } from 'node:http';
 import * as grout from '@votingworks/grout';
@@ -566,6 +567,72 @@ test('printing ballots', async () => {
   await expect(mockPrinterHandler.getLastPrintPath()).toMatchPdfSnapshot({
     customSnapshotIdentifier: 'chinese-ballot',
     failureThreshold: 0.001,
+  });
+});
+
+test('printing a blank ballot prints the pre-rendered base ballot PDF', async () => {
+  const electionDefinition =
+    electionFamousNames2021Fixtures.readElectionDefinition();
+
+  const mockBallotPdfData = 'mock-blank-ballot-pdf-data';
+  const mockBallotPdfBase64 = Buffer.from(mockBallotPdfData).toString('base64');
+
+  const ballots: EncodedBallotEntry[] = [
+    {
+      ballotStyleId: '1',
+      precinctId: '23',
+      ballotType: BallotType.Precinct,
+      ballotMode: 'test', // Machine defaults to test mode
+      encodedBallot: mockBallotPdfBase64,
+    },
+  ];
+
+  mockElectionManagerAuth(electionDefinition);
+  mockUsbDrive.insertUsbDrive(
+    await mockElectionPackageFileTree({
+      electionDefinition,
+      systemSettings: safeParseJson(
+        systemSettings.asText(),
+        SystemSettingsSchema
+      ).unsafeUnwrap(),
+      ballots,
+    })
+  );
+  (await apiClient.configureElectionPackageFromUsb()).unsafeUnwrap();
+  mockUsbDrive.removeUsbDrive();
+  mockNoCard();
+
+  mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
+  await expectElectionState({ ballotsPrintedCount: 0 });
+
+  await apiClient.printBlankBallot({
+    ballotStyleId: '1',
+    precinctId: '23',
+  });
+
+  await expectElectionState({ ballotsPrintedCount: 1 });
+
+  // The printed data should be the decoded base ballot PDF, unmodified (no
+  // mark overlay applied).
+  const printedData = readFileSync(
+    assertDefined(mockPrinterHandler.getLastPrintPath())
+  );
+  expect(printedData.toString('utf-8')).toEqual(mockBallotPdfData);
+});
+
+test('printing a blank ballot throws when no ballot PDF is available', async () => {
+  const electionDefinition =
+    electionFamousNames2021Fixtures.readElectionDefinition();
+  await configureMachine(mockUsbDrive, electionDefinition);
+  mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
+
+  await suppressingConsoleOutput(async () => {
+    await expect(
+      apiClient.printBlankBallot({
+        ballotStyleId: '1',
+        precinctId: '23',
+      })
+    ).rejects.toThrow('No ballot PDF found');
   });
 });
 

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -608,6 +608,7 @@ test('printing a blank ballot prints the pre-rendered base ballot PDF', async ()
   await apiClient.printBlankBallot({
     ballotStyleId: '1',
     precinctId: '23',
+    languageCode: 'en',
   });
 
   await expectElectionState({ ballotsPrintedCount: 1 });
@@ -631,6 +632,7 @@ test('printing a blank ballot throws when no ballot PDF is available', async () 
       apiClient.printBlankBallot({
         ballotStyleId: '1',
         precinctId: '23',
+        languageCode: 'en',
       })
     ).rejects.toThrow('No ballot PDF found');
   });

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -51,7 +51,7 @@ import { AdminTallyReportByParty } from '@votingworks/ui';
 import { getMachineConfig } from './machine_config';
 import { Workspace } from './util/workspace';
 import { ElectionState, PrintBallotProps } from './types';
-import { printBallot } from './util/print_ballot';
+import { printBallot, printBlankBallot } from './util/print_ballot';
 import {
   isAccessibleControllerAttached,
   isPatInputAttached,
@@ -325,6 +325,18 @@ export function buildApi(ctx: Context) {
     async printBallot(input: PrintBallotProps) {
       store.setBallotsPrintedCount(store.getBallotsPrintedCount() + 1);
       await printBallot({
+        store,
+        printer,
+        ...input,
+      });
+    },
+
+    async printBlankBallot(input: {
+      ballotStyleId: BallotStyleId;
+      precinctId: string;
+    }) {
+      store.setBallotsPrintedCount(store.getBallotsPrintedCount() + 1);
+      await printBlankBallot({
         store,
         printer,
         ...input,

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -50,7 +50,11 @@ import {
 import { AdminTallyReportByParty } from '@votingworks/ui';
 import { getMachineConfig } from './machine_config';
 import { Workspace } from './util/workspace';
-import { ElectionState, PrintBallotProps } from './types';
+import {
+  ElectionState,
+  PrintBallotProps,
+  PrintBlankBallotProps,
+} from './types';
 import { printBallot, printBlankBallot } from './util/print_ballot';
 import {
   isAccessibleControllerAttached,
@@ -331,10 +335,7 @@ export function buildApi(ctx: Context) {
       });
     },
 
-    async printBlankBallot(input: {
-      ballotStyleId: BallotStyleId;
-      precinctId: string;
-    }) {
+    async printBlankBallot(input: PrintBlankBallotProps) {
       store.setBallotsPrintedCount(store.getBallotsPrintedCount() + 1);
       await printBlankBallot({
         store,

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -327,21 +327,21 @@ export function buildApi(ctx: Context) {
     }),
 
     async printBallot(input: PrintBallotProps) {
-      store.setBallotsPrintedCount(store.getBallotsPrintedCount() + 1);
       await printBallot({
         store,
         printer,
         ...input,
       });
+      store.setBallotsPrintedCount(store.getBallotsPrintedCount() + 1);
     },
 
     async printBlankBallot(input: PrintBlankBallotProps) {
-      store.setBallotsPrintedCount(store.getBallotsPrintedCount() + 1);
       await printBlankBallot({
         store,
         printer,
         ...input,
       });
+      store.setBallotsPrintedCount(store.getBallotsPrintedCount() + 1);
     },
 
     async printTestDeck({

--- a/apps/mark/backend/src/types.ts
+++ b/apps/mark/backend/src/types.ts
@@ -21,3 +21,5 @@ export interface PrintBallotProps {
   precinctId: string;
   votes: VotesDict;
 }
+
+export type PrintBlankBallotProps = Omit<PrintBallotProps, 'votes'>;

--- a/apps/mark/backend/src/util/print_ballot.tsx
+++ b/apps/mark/backend/src/util/print_ballot.tsx
@@ -10,7 +10,12 @@ import {
 } from '@votingworks/printing';
 import { assert, assertDefined, throwIllegalValue } from '@votingworks/basics';
 import { generateMarkOverlay } from '@votingworks/hmpb';
-import { getBallotStyle, getContests } from '@votingworks/types';
+import {
+  BallotStyleId,
+  Election,
+  getBallotStyle,
+  getContests,
+} from '@votingworks/types';
 import {
   BmdPaperBallot,
   BackendLanguageContextProvider,
@@ -173,30 +178,41 @@ export async function printBallot(p: PrintBallotProps): Promise<void> {
   });
 }
 
-async function printBubbleBallot(p: PrintBallotProps): Promise<void> {
-  const { electionDefinition } = assertDefined(p.store.getElectionRecord());
+function getBaseBallotPdf(
+  store: Store,
+  ballotStyleId: BallotStyleId,
+  precinctId: string
+): { election: Election; baseBallotPdf: Uint8Array } {
+  const { electionDefinition } = assertDefined(store.getElectionRecord());
   const { election } = electionDefinition;
 
-  const isLiveMode = !p.store.getTestMode();
+  const isLiveMode = !store.getTestMode();
 
-  // Get the base ballot PDF from the election package
-  const ballotEntry = p.store.getBallot({
-    ballotStyleId: p.ballotStyleId,
-    precinctId: p.precinctId,
+  const ballotEntry = store.getBallot({
+    ballotStyleId,
+    precinctId,
     isLiveMode,
   });
 
   assert(
     ballotEntry,
-    `No ballot PDF found for precinct ID: ${p.precinctId} and ballot style ID: ${p.ballotStyleId}`
+    `No ballot PDF found for precinct ID: ${precinctId} and ballot style ID: ${ballotStyleId}`
   );
 
-  // Decode the base64 ballot PDF
   const baseBallotPdf = Uint8Array.from(
     Buffer.from(ballotEntry.encodedBallot, 'base64')
   );
 
-  // Generate the mark overlay composited with the base ballot PDF
+  return { election, baseBallotPdf };
+}
+
+async function printBubbleBallot(p: PrintBallotProps): Promise<void> {
+  const { election, baseBallotPdf } = getBaseBallotPdf(
+    p.store,
+    p.ballotStyleId,
+    p.precinctId
+  );
+
   const markedBallotPdf = await generateMarkOverlay(
     election,
     p.ballotStyleId,
@@ -207,6 +223,29 @@ async function printBubbleBallot(p: PrintBallotProps): Promise<void> {
 
   return p.printer.print({
     data: markedBallotPdf,
+    sides: PrintSides.TwoSidedLongEdge,
+    size: election.ballotLayout.paperSize,
+  });
+}
+
+export interface PrintBlankBallotProps {
+  ballotStyleId: BallotStyleId;
+  precinctId: string;
+  printer: Printer;
+  store: Store;
+}
+
+export async function printBlankBallot(
+  p: PrintBlankBallotProps
+): Promise<void> {
+  const { election, baseBallotPdf } = getBaseBallotPdf(
+    p.store,
+    p.ballotStyleId,
+    p.precinctId
+  );
+
+  return p.printer.print({
+    data: baseBallotPdf,
     sides: PrintSides.TwoSidedLongEdge,
     size: election.ballotLayout.paperSize,
   });

--- a/apps/mark/backend/src/util/print_ballot.tsx
+++ b/apps/mark/backend/src/util/print_ballot.tsx
@@ -46,6 +46,8 @@ export interface PrintBallotProps extends ClientParams {
   store: Store;
 }
 
+type PrintBlankBallotProps = Omit<PrintBallotProps, 'votes'>;
+
 export async function printBallot(p: PrintBallotProps): Promise<void> {
   const { printer, store, precinctId, ballotStyleId, votes, languageCode } = p;
 
@@ -226,13 +228,6 @@ async function printBubbleBallot(p: PrintBallotProps): Promise<void> {
     sides: PrintSides.TwoSidedLongEdge,
     size: election.ballotLayout.paperSize,
   });
-}
-
-export interface PrintBlankBallotProps {
-  ballotStyleId: BallotStyleId;
-  precinctId: string;
-  printer: Printer;
-  store: Store;
 }
 
 export async function printBlankBallot(

--- a/apps/mark/frontend/src/api.ts
+++ b/apps/mark/frontend/src/api.ts
@@ -387,6 +387,7 @@ export const printBallot = {
   },
 } as const;
 
+/* istanbul ignore next */
 export const printBlankBallot = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/mark/frontend/src/api.ts
+++ b/apps/mark/frontend/src/api.ts
@@ -387,6 +387,18 @@ export const printBallot = {
   },
 } as const;
 
+export const printBlankBallot = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.printBlankBallot, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getElectionState.queryKey());
+      },
+    });
+  },
+} as const;
+
 export const setTestMode = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/mark/frontend/src/api_machine_configuration.test.tsx
+++ b/apps/mark/frontend/src/api_machine_configuration.test.tsx
@@ -7,6 +7,7 @@ import {
   ApiClient,
   configureElectionPackageFromUsb,
   createApiClient,
+  printBlankBallot,
   uiStringsApi,
   unconfigureMachine,
 } from './api';
@@ -17,6 +18,7 @@ const mockBackendApi: ApiClient = {
   ...createApiClient(),
   configureElectionPackageFromUsb: vi.fn(),
   unconfigureMachine: vi.fn(),
+  printBlankBallot: vi.fn(),
 };
 
 function QueryWrapper(props: { children: React.ReactNode }) {
@@ -71,4 +73,20 @@ test('unconfigureMachine', async () => {
   await vi.waitFor(() => expect(result.current.isSuccess).toEqual(true));
 
   expect(mockOnConfigurationChange).toHaveBeenCalled();
+});
+
+test('printBlankBallot', async () => {
+  vi.mocked(mockBackendApi).printBlankBallot.mockResolvedValueOnce();
+
+  const { result } = renderHook(() => printBlankBallot.useMutation(), {
+    wrapper: QueryWrapper,
+  });
+
+  result.current.mutate({ ballotStyleId: '1', precinctId: '23' });
+  await vi.waitFor(() => expect(result.current.isSuccess).toEqual(true));
+
+  expect(mockBackendApi.printBlankBallot).toHaveBeenCalledWith({
+    ballotStyleId: '1',
+    precinctId: '23',
+  });
 });

--- a/apps/mark/frontend/src/api_machine_configuration.test.tsx
+++ b/apps/mark/frontend/src/api_machine_configuration.test.tsx
@@ -7,7 +7,6 @@ import {
   ApiClient,
   configureElectionPackageFromUsb,
   createApiClient,
-  printBlankBallot,
   uiStringsApi,
   unconfigureMachine,
 } from './api';
@@ -73,25 +72,4 @@ test('unconfigureMachine', async () => {
   await vi.waitFor(() => expect(result.current.isSuccess).toEqual(true));
 
   expect(mockOnConfigurationChange).toHaveBeenCalled();
-});
-
-test('printBlankBallot', async () => {
-  vi.mocked(mockBackendApi).printBlankBallot.mockResolvedValueOnce();
-
-  const { result } = renderHook(() => printBlankBallot.useMutation(), {
-    wrapper: QueryWrapper,
-  });
-
-  result.current.mutate({
-    ballotStyleId: '1',
-    precinctId: '23',
-    languageCode: 'en',
-  });
-  await vi.waitFor(() => expect(result.current.isSuccess).toEqual(true));
-
-  expect(mockBackendApi.printBlankBallot).toHaveBeenCalledWith({
-    ballotStyleId: '1',
-    precinctId: '23',
-    languageCode: 'en',
-  });
 });

--- a/apps/mark/frontend/src/api_machine_configuration.test.tsx
+++ b/apps/mark/frontend/src/api_machine_configuration.test.tsx
@@ -82,11 +82,16 @@ test('printBlankBallot', async () => {
     wrapper: QueryWrapper,
   });
 
-  result.current.mutate({ ballotStyleId: '1', precinctId: '23' });
+  result.current.mutate({
+    ballotStyleId: '1',
+    precinctId: '23',
+    languageCode: 'en',
+  });
   await vi.waitFor(() => expect(result.current.isSuccess).toEqual(true));
 
   expect(mockBackendApi.printBlankBallot).toHaveBeenCalledWith({
     ballotStyleId: '1',
     precinctId: '23',
+    languageCode: 'en',
   });
 });


### PR DESCRIPTION
## Overview

Relates to https://github.com/votingworks/vxsuite/issues/8361.

Adds backend support to VxMark for printing blank ballots

* Factors out `getBaseBallotPdf` from the existing `printBubbleBallot`
* Uses `getBaseBallotPdf` in `printBlankBallot`

## Demo Video or Screenshot

N/A backend only

## Testing Plan
- added tests


