### PR TITLE
test(dev-dock): use `toEqual<T>` where possible

### DIFF
--- a/libs/dev-dock/backend/src/dev_dock_api.test.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.test.ts
@@ -601,12 +601,10 @@ test('mock PDI scanner - single sheet', async () => {
     })
   ).unsafeUnwrap();
 
-  expect(await apiClient.pdiScannerGetStatus()).toEqual(
-    typedAs<PdiScannerStatus>({
-      sheetStatus: 'noSheetEnabled',
-      queue: undefined,
-    })
-  );
+  expect(await apiClient.pdiScannerGetStatus()).toEqual<PdiScannerStatus>({
+    sheetStatus: 'noSheetEnabled',
+    queue: undefined,
+  });
 
   const scanCompletePromise = new Promise<void>((resolve) => {
     const listener = mockPdiScanner.client.addListener((event) => {


### PR DESCRIPTION
## Overview
Vitest's matchers don't always allow collapsing `toEqual(typedAs(...))` like this, but when they do it's a bit nicer.

## Demo Video or Screenshot
n/a

## Testing Plan
Automated