### PR TITLE
[VxAdmin] Add CVR import button card component

### DIFF
--- a/apps/admin/frontend/src/screens/tally/location_cvr_card.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_cvr_card.tsx
@@ -25,6 +25,7 @@ const ContentSection = styled.div`
   align-items: center;
   display: grid;
   grid-template-columns: 1fr;
+  gap: 0.125rem;
   min-width: 0;
   padding: ${GAP};
 `;
@@ -44,11 +45,6 @@ export const IconSection = styled.div`
   height: 100%;
   justify-items: center;
   padding: 1rem;
-
-  /* Expand padding when icon label is present, for more square appearance. */
-  :has(${IconLabel}) {
-    padding: 1rem 1.5rem;
-  }
 `;
 
 const Meta = styled(Caption)`

--- a/apps/admin/frontend/src/screens/tally/location_import_card.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_import_card.test.tsx
@@ -1,0 +1,141 @@
+/* eslint-disable prefer-regex-literals */
+import { expect, test, vi } from 'vitest';
+
+import { pollingPlaceTypeName } from '@votingworks/types/src';
+import userEvent from '@testing-library/user-event';
+
+import { render, screen } from '../../../test/react_testing_library';
+import { LocationImportCard } from './location_import_card';
+
+test('official import with single-scanner batches', () => {
+  render(
+    <LocationImportCard
+      disabled={false}
+      exportTimestamp={new Date('2020-11-07T18:00:00Z')}
+      name="Vx West"
+      nCvrs={432}
+      onPress={vi.fn()}
+      path="/dev/sdb/west/metadata.json"
+      scannerIds={['SCN-001']}
+      status="ready"
+      testExport={false}
+      type="absentee"
+    />
+  );
+
+  screen.getByText('Load');
+  screen.getByText(/OFFICIAL/);
+  screen.getByText(new RegExp('11/07/2020'));
+  screen.getByText('Vx West');
+  screen.getByText(new RegExp(pollingPlaceTypeName('absentee')));
+  screen.getByText(/Scanner SCN-001/);
+  screen.getByText('432');
+});
+
+test('test-mode import with multi-scanner batches', () => {
+  render(
+    <LocationImportCard
+      disabled={false}
+      exportTimestamp={new Date('2021-11-08T18:00:00Z')}
+      name="Vx North"
+      nCvrs={2048}
+      onPress={vi.fn()}
+      path="/dev/sdb/west/metadata.json"
+      scannerIds={['SCN-001', 'SCN-002']}
+      status="ready"
+      testExport
+      type="early_voting"
+    />
+  );
+
+  screen.getByText('Load');
+  screen.getByText(/TEST/);
+  screen.getByText(new RegExp('11/08/2021'));
+  screen.getByText('Vx North');
+  screen.getByText(new RegExp(pollingPlaceTypeName('early_voting')));
+  screen.getByText(/Scanners: SCN-001, SCN-002/);
+  screen.getByText('2,048');
+});
+
+test('emits onPress event on click', () => {
+  const onPress = vi.fn();
+  const path = '/dev/sdb/south/metadata.json';
+
+  render(
+    <LocationImportCard
+      disabled={false}
+      exportTimestamp={new Date('2020-11-07T18:00:00Z')}
+      name="Vx South"
+      nCvrs={432}
+      onPress={onPress}
+      path={path}
+      scannerIds={['SCN-001']}
+      status="ready"
+      testExport={false}
+      type="election_day"
+    />
+  );
+
+  expect(onPress).not.toHaveBeenCalled();
+  userEvent.click(screen.getButton(/Vx South/));
+  expect(onPress).toHaveBeenCalledExactlyOnceWith(path);
+});
+
+test('status = "importing"', () => {
+  render(
+    <LocationImportCard
+      disabled={false}
+      exportTimestamp={new Date('2021-11-08T18:00:00Z')}
+      name="Vx North"
+      nCvrs={2048}
+      onPress={vi.fn()}
+      path="/dev/sdb/west/metadata.json"
+      scannerIds={['SCN-001', 'SCN-002']}
+      status="importing"
+      testExport
+      type="early_voting"
+    />
+  );
+
+  screen.getByText('Loading');
+  expect(screen.getButton(/Vx North/)).toBeDisabled();
+});
+
+test('status = "imported"', () => {
+  render(
+    <LocationImportCard
+      disabled={false}
+      exportTimestamp={new Date('2021-11-08T18:00:00Z')}
+      name="Vx North"
+      nCvrs={2048}
+      onPress={vi.fn()}
+      path="/dev/sdb/west/metadata.json"
+      scannerIds={['SCN-001', 'SCN-002']}
+      status="imported"
+      testExport
+      type="early_voting"
+    />
+  );
+
+  screen.getByText('Loaded');
+  expect(screen.getButton(/Vx North/)).toBeDisabled();
+});
+
+test('disabled by `disabled` prop', () => {
+  render(
+    <LocationImportCard
+      disabled
+      exportTimestamp={new Date()}
+      name="Vx Central"
+      nCvrs={0}
+      onPress={vi.fn()}
+      path="/dev/sdb/foo"
+      scannerIds={['SCN-001']}
+      status="ready"
+      testExport={false}
+      type="election_day"
+    />
+  );
+
+  expect(screen.getButton(/Vx Central/)).toBeDisabled();
+});

--- a/apps/admin/frontend/src/screens/tally/location_import_card.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_import_card.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { DateTime } from 'luxon';
+
+import { Font, Icons } from '@votingworks/ui';
+import { PollingPlaceType, pollingPlaceTypeName } from '@votingworks/types';
+
+import { TIME_FORMAT } from '../../config/globals';
+import { LocationCvrCard } from './location_cvr_card';
+
+export type LocationImportCardProps = Props;
+interface Props {
+  disabled: boolean;
+  exportTimestamp: Date;
+  name: string;
+  path: string;
+  nCvrs: number;
+  onPress: (path: string) => void;
+  scannerIds: string[];
+  status: Status;
+  testExport: boolean;
+  type: PollingPlaceType;
+}
+
+export type Status = 'imported' | 'importing' | 'ready';
+
+const ColorText = styled.span<{ color: 'primary' | 'warningAccent' }>`
+  color: ${(p) => p.theme.colors[p.color]};
+  font-weight: ${(p) => p.theme.sizes.fontWeight.bold};
+`;
+
+const HEADER_MUTED_CSS = css`
+  color: ${(p) => p.theme.colors.onBackgroundMuted};
+
+  ${ColorText} {
+    color: ${(p) => p.theme.colors.onBackgroundMuted};
+  }
+`;
+
+const Header = styled(Font)<{ muted: boolean }>`
+  color: ${(p) => p.theme.colors.onBackground};
+  ${(p) => p.muted && HEADER_MUTED_CSS}
+`;
+
+const Label = styled.div`
+  text-align: center;
+
+  /* Keep width consistent across states, to avoid container width changes. */
+  width: 7ch;
+`;
+
+const ICONS: Record<Status, JSX.Element> = {
+  importing: <Icons.Loading />,
+  imported: <Icons.Done />,
+  ready: <Icons.Import color="primary" />,
+};
+
+const ICON_LABELS: Record<Status, string> = {
+  imported: 'Loaded',
+  importing: 'Loading',
+  ready: 'Load',
+};
+
+export function LocationImportCard(props: Props): React.ReactNode {
+  const {
+    disabled,
+    exportTimestamp,
+    name,
+    nCvrs,
+    onPress,
+    path,
+    scannerIds,
+    status,
+    testExport,
+    type,
+  } = props;
+
+  const muted = disabled || status !== 'ready';
+  const separator = <span> &bull; </span>;
+
+  return (
+    <LocationCvrCard
+      disabled={muted}
+      id={path}
+      onClick={onPress}
+      icon={ICONS[status]}
+      iconLabel={<Label>{ICON_LABELS[status]}</Label>}
+      header={
+        <Header muted={muted}>
+          <ColorText color={testExport ? 'warningAccent' : 'primary'}>
+            {testExport ? 'TEST' : 'OFFICIAL'}
+          </ColorText>
+          {separator}
+          {DateTime.fromJSDate(exportTimestamp).toFormat(TIME_FORMAT)}
+        </Header>
+      }
+      name={name}
+      caption={
+        <React.Fragment>
+          {pollingPlaceTypeName(type)}
+          {separator}
+          {scannerIds.length === 1
+            ? `Scanner ${scannerIds[0]}`
+            : `Scanners: ${scannerIds.join(', ')}`}
+        </React.Fragment>
+      }
+      count={nCvrs}
+    />
+  );
+}


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7958

Adding the import card for use in the upcoming import panel on the CVR management screen ([in-context mock](https://www.figma.com/design/0Mari2J3cgG8dSYx9pnF1P/VxAdmin-CVR-Management?node-id=1-10&t=Dlbsl3l3C57MHxWg-0)). Supports multi-scanner exports, but we only have single-scanner CVR exports in practice, at the moment.

Also making some tweaks to the base location card component:
- Remove the padding special case for when the icon container includes a label - moving that responsibility to the import card implementation.
- Adding a tiny bit of spacing between lines - import card starts to look crowded with 3 lines.

## Demo Video or Screenshot

**Samples of various states:**

https://github.com/user-attachments/assets/6c59a7af-fcff-4d08-be77-2a953d6ee2ec

## Testing Plan
- Presentational unit tests

## Checklist
N/A