### PR TITLE
VxDesign: Update polling-place auto-generation logic to include an early voting polling place for MS

### DIFF
--- a/apps/design/backend/src/app.state_ms.test.ts
+++ b/apps/design/backend/src/app.state_ms.test.ts
@@ -2,6 +2,8 @@ import { vi, afterAll, expect, test } from 'vitest';
 import {
   centralScanningPollingPlaceId,
   CENTRAL_SCANNING_POLLING_PLACE_NAME,
+  earlyVotingPollingPlaceId,
+  EARLY_VOTING_POLLING_PLACE_NAME,
   ElectionIdSchema,
   formatBallotHash,
   HmpbBallotPaperSize,
@@ -227,7 +229,7 @@ test('finalizing a Mississippi election does not require absentee polling places
   );
 });
 
-test('a Central Scanning absentee polling place is added to the export for Mississippi', async () => {
+test('a central scanning absentee polling place and an early voting polling place are added to the export for Mississippi', async () => {
   const { apiClient, auth0, workspace, fileStorageClient } = await setupApp({
     organizations,
     jurisdictions,
@@ -273,10 +275,8 @@ test('a Central Scanning absentee polling place is added to the export for Missi
     await readElectionPackageFromBuffer(electionPackageContents)
   ).unsafeUnwrap();
 
-  // A single Central Scanning absentee place covering every precinct is added
-  // on export, since Mississippi has no user-defined absentee polling places.
   const exportedElection = electionPackage.electionDefinition.election;
-  const absenteePlaces = (exportedElection.pollingPlaces ?? []).filter(
+  const absenteePlaces = exportedElection.pollingPlaces.filter(
     (place) => place.type === 'absentee'
   );
   expect(absenteePlaces).toEqual([
@@ -284,6 +284,22 @@ test('a Central Scanning absentee polling place is added to the export for Missi
       id: centralScanningPollingPlaceId(exportedElection.id),
       name: CENTRAL_SCANNING_POLLING_PLACE_NAME,
       type: 'absentee',
+      precincts: Object.fromEntries(
+        exportedElection.precincts.map((precinct) => [
+          precinct.id,
+          { type: 'whole' },
+        ])
+      ),
+    },
+  ]);
+  const earlyVotingPlaces = exportedElection.pollingPlaces.filter(
+    (place) => place.type === 'early_voting'
+  );
+  expect(earlyVotingPlaces).toEqual([
+    {
+      id: earlyVotingPollingPlaceId(exportedElection.id),
+      name: EARLY_VOTING_POLLING_PLACE_NAME,
+      type: 'early_voting',
       precincts: Object.fromEntries(
         exportedElection.precincts.map((precinct) => [
           precinct.id,

--- a/apps/design/backend/src/ballots.test.ts
+++ b/apps/design/backend/src/ballots.test.ts
@@ -4,6 +4,9 @@ import {
   BaseBallotProps,
   centralScanningPollingPlaceId,
   CENTRAL_SCANNING_POLLING_PLACE_NAME,
+  DEFAULT_SYSTEM_SETTINGS,
+  earlyVotingPollingPlaceId,
+  EARLY_VOTING_POLLING_PLACE_NAME,
   Election,
   ElectionStringKey,
   hasSplits,
@@ -124,14 +127,18 @@ test('formatElectionForExport', () => {
   });
 });
 
-test('addPollingPlacesForExport - non-editing state generates election_day places plus a Central Scanning absentee place', () => {
+test('addPollingPlacesForExport - non-editing state generates election_day places plus a central scanning absentee place', () => {
   const electionInput: Election = {
     ...election,
     pollingPlaces: [],
   };
 
-  const result = addPollingPlacesForExport(electionInput, msJurisdiction);
-  const pollingPlaces = result.pollingPlaces ?? [];
+  const result = addPollingPlacesForExport(
+    electionInput,
+    msJurisdiction,
+    DEFAULT_SYSTEM_SETTINGS
+  );
+  const { pollingPlaces } = result;
 
   // One election_day place per precinct (existing behavior).
   expect(
@@ -155,6 +162,41 @@ test('addPollingPlacesForExport - non-editing state generates election_day place
       ),
     },
   ]);
+
+  // Early voting is not enabled, so no early voting place is generated.
+  expect(pollingPlaces.some((place) => place.type === 'early_voting')).toEqual(
+    false
+  );
+});
+
+test('addPollingPlacesForExport - generates an early voting polling place when early voting is enabled', () => {
+  const electionInput: Election = {
+    ...election,
+    pollingPlaces: [],
+  };
+
+  const result = addPollingPlacesForExport(electionInput, msJurisdiction, {
+    ...DEFAULT_SYSTEM_SETTINGS,
+    enableEarlyVoting: true,
+  });
+  const { pollingPlaces } = result;
+
+  const earlyVotingPlaces = pollingPlaces.filter(
+    (place) => place.type === 'early_voting'
+  );
+  expect(earlyVotingPlaces).toEqual([
+    {
+      id: earlyVotingPollingPlaceId(electionInput.id),
+      name: EARLY_VOTING_POLLING_PLACE_NAME,
+      type: 'early_voting',
+      precincts: Object.fromEntries(
+        electionInput.precincts.map((precinct) => [
+          precinct.id,
+          { type: 'whole' },
+        ])
+      ),
+    },
+  ]);
 });
 
 test('addPollingPlacesForExport - state that allows empty absentee polling places gets no Central Scanning place', () => {
@@ -163,7 +205,11 @@ test('addPollingPlacesForExport - state that allows empty absentee polling place
     pollingPlaces: [],
   };
 
-  const result = addPollingPlacesForExport(electionInput, nhJurisdiction);
+  const result = addPollingPlacesForExport(
+    electionInput,
+    nhJurisdiction,
+    DEFAULT_SYSTEM_SETTINGS
+  );
   const pollingPlaces = result.pollingPlaces ?? [];
 
   expect(pollingPlaces).toHaveLength(electionInput.precincts.length);
@@ -183,7 +229,11 @@ test('addPollingPlacesForExport - editing state keeps user-created absentee plac
   ];
   const electionInput: Election = { ...election, pollingPlaces };
 
-  const result = addPollingPlacesForExport(electionInput, miJurisdiction);
+  const result = addPollingPlacesForExport(
+    electionInput,
+    miJurisdiction,
+    DEFAULT_SYSTEM_SETTINGS
+  );
 
   // Nothing added; the election is returned unchanged.
   expect(result).toEqual(electionInput);
@@ -201,7 +251,11 @@ test('addPollingPlacesForExport - editing state does not generate a Central Scan
   ];
   const electionInput: Election = { ...election, pollingPlaces };
 
-  const result = addPollingPlacesForExport(electionInput, miJurisdiction);
+  const result = addPollingPlacesForExport(
+    electionInput,
+    miJurisdiction,
+    DEFAULT_SYSTEM_SETTINGS
+  );
 
   // Editing states are validated at finalization instead of having a Central
   // Scanning place auto-generated, so nothing is added here.

--- a/apps/design/backend/src/ballots.ts
+++ b/apps/design/backend/src/ballots.ts
@@ -3,10 +3,13 @@ import {
   BaseBallotProps,
   centralScanningPollingPlaceId,
   CENTRAL_SCANNING_POLLING_PLACE_NAME,
+  earlyVotingPollingPlaceId,
+  EARLY_VOTING_POLLING_PLACE_NAME,
   Election,
   hasSplits,
   PollingPlace,
   pollingPlacesGenerateFromPrecincts,
+  SystemSettings,
   UiStringsPackage,
 } from '@votingworks/types';
 import {
@@ -41,20 +44,20 @@ export function defaultBallotTemplate(
   }
 }
 
-function centralScanningPollingPlace(election: Election): PollingPlace {
-  return {
-    id: centralScanningPollingPlaceId(election.id),
-    name: CENTRAL_SCANNING_POLLING_PLACE_NAME,
-    type: 'absentee',
-    precincts: Object.fromEntries(
-      election.precincts.map((precinct) => [precinct.id, { type: 'whole' }])
-    ),
-  };
+function allPrecinctsWhole(election: Election): PollingPlace['precincts'] {
+  return Object.fromEntries(
+    election.precincts.map((precinct) => [precinct.id, { type: 'whole' }])
+  );
 }
 
+/**
+ * Auto-generates polling places for states that don't require the ability to custom define them
+ * and for whom we accordingly hide the polling place editor.
+ */
 export function addPollingPlacesForExport(
   election: Election,
-  jurisdiction: Jurisdiction
+  jurisdiction: Jurisdiction,
+  systemSettings: SystemSettings
 ): Election {
   const stateFeatures = getStateFeaturesConfig(jurisdiction);
 
@@ -62,20 +65,34 @@ export function addPollingPlacesForExport(
     return election;
   }
 
-  // Generate election day polling places from precincts and unless
-  // this state allows elections with no absentee polling places, add a single
-  // Central Scanning absentee place covering all precincts.
+  // Generate an election day polling place for each precinct
   const pollingPlaces = pollingPlacesGenerateFromPrecincts(
     election.precincts,
     'election_day',
     (p) => `${p.id}-polling-place`
   );
-  return {
-    ...election,
-    pollingPlaces: stateFeatures.OMIT_ABSENTEE_POLLING_PLACES
-      ? pollingPlaces
-      : [...pollingPlaces, centralScanningPollingPlace(election)],
-  };
+
+  // Generate a single central scanning polling place covering all precincts if necessary
+  if (!stateFeatures.OMIT_ABSENTEE_POLLING_PLACES) {
+    pollingPlaces.push({
+      id: centralScanningPollingPlaceId(election.id),
+      name: CENTRAL_SCANNING_POLLING_PLACE_NAME,
+      type: 'absentee',
+      precincts: allPrecinctsWhole(election),
+    });
+  }
+
+  // Generate a single early voting polling place covering all precincts if necessary
+  if (systemSettings.enableEarlyVoting) {
+    pollingPlaces.push({
+      id: earlyVotingPollingPlaceId(election.id),
+      name: EARLY_VOTING_POLLING_PLACE_NAME,
+      type: 'early_voting',
+      precincts: allPrecinctsWhole(election),
+    });
+  }
+
+  return { ...election, pollingPlaces };
 }
 
 export function formatElectionForExport(

--- a/apps/design/backend/src/convert_ms_election.test.ts
+++ b/apps/design/backend/src/convert_ms_election.test.ts
@@ -46,7 +46,13 @@ async function expectValidElection(election: Election) {
   // polling places; they are generated at export. Validate the export form.
   const stored = (await store.getElection(election.id)).election;
   expect(
-    safeParseElection(addPollingPlacesForExport(stored, jurisdiction)).err()
+    safeParseElection(
+      addPollingPlacesForExport(
+        stored,
+        jurisdiction,
+        defaultSystemSettings(jurisdiction)
+      )
+    ).err()
   ).toBeUndefined();
 }
 

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -267,7 +267,8 @@ export async function generateElectionPackageAndBallots(
   const jurisdiction = await store.getJurisdiction(jurisdictionId);
   const election = addPollingPlacesForExport(
     electionRecord.election,
-    jurisdiction
+    jurisdiction,
+    systemSettings
   );
 
   const [appStrings, hmpbStrings, electionStrings] =

--- a/apps/design/backend/src/worker/generate_test_decks.ts
+++ b/apps/design/backend/src/worker/generate_test_decks.ts
@@ -62,7 +62,8 @@ export async function generateTestDecks(
   const jurisdiction = await store.getJurisdiction(jurisdictionId);
   const election = addPollingPlacesForExport(
     electionRecord.election,
-    jurisdiction
+    jurisdiction,
+    systemSettings
   );
   const { compact } = await store.getBallotLayoutSettings(electionId);
 

--- a/libs/types/src/polling_places.test.ts
+++ b/libs/types/src/polling_places.test.ts
@@ -23,7 +23,18 @@ import {
   pollingPlacesGenerateFromPrecincts,
   pollingPlaceTypeName,
   getPrecinctsWithoutAbsenteePollingPlace,
+  centralScanningPollingPlaceId,
+  earlyVotingPollingPlaceId,
 } from './polling_places';
+
+test('deterministic default polling place ids', () => {
+  expect(centralScanningPollingPlaceId('election-1')).toEqual(
+    'election-1-central-scanning'
+  );
+  expect(earlyVotingPollingPlaceId('election-1')).toEqual(
+    'election-1-early-voting'
+  );
+});
 
 test('anyPollingPlace', () => {
   expect(() => anyPollingPlace(mockElection({}))).toThrow(/no polling places/i);

--- a/libs/types/src/polling_places.ts
+++ b/libs/types/src/polling_places.ts
@@ -183,6 +183,16 @@ export function centralScanningPollingPlaceId(electionId: string): string {
 export const CENTRAL_SCANNING_POLLING_PLACE_NAME = 'Central Scanning';
 
 /**
+ * The id and name of the default "Early Voting" polling place, derived
+ * deterministically from the election id following the same convention as
+ * {@link centralScanningPollingPlaceId}.
+ */
+export function earlyVotingPollingPlaceId(electionId: string): string {
+  return `${electionId}-early-voting`;
+}
+export const EARLY_VOTING_POLLING_PLACE_NAME = 'Early Voting';
+
+/**
  * Returns the precincts not covered by any absentee polling place, i.e.
  * precincts whose centrally-scanned ballots would have no location to be
  * tabulated under.


### PR DESCRIPTION
## Overview

This PR updates our polling-place auto-generation logic to include an early voting polling place for MS. Recently learned that MS passed a minimal form of early voting and discovered this gap while conducting corresponding QA.

## Testing Plan

- [x] Updated automated tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [ ] ~I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~
