### PR TITLE
[VxAdmin] Add scaffolding for updated CVR import panel

### DIFF
--- a/apps/admin/frontend/src/screens/tally/cvr_import_panel.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvr_import_panel.test.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import type { CastVoteRecordFileRecord as CvrImport } from '@votingworks/admin-backend';
+import { readElectionGeneralDefinition } from '@votingworks/fixtures';
+import { UsbDriveStatus } from '@votingworks/usb-drive';
+import { mockUsbDriveStatus } from '@votingworks/ui';
+import userEvent from '@testing-library/user-event';
+
+import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client';
+import { screen, waitFor } from '../../../test/react_testing_library';
+import { CvrImportPanel } from './cvr_import_panel';
+import { renderInAppContext } from '../../../test/render_in_app_context';
+
+const electionDefinition = readElectionGeneralDefinition();
+
+describe('title reflects CVR mode', () => {
+  async function expectTitle(api: ApiMock, title: string) {
+    render(<CvrImportPanel onClose={vi.fn()} />, {
+      api,
+      usbStatus: mockUsbDriveStatus('no_drive'),
+    });
+
+    await waitFor(() => api.assertComplete());
+    screen.getByRole('heading', { name: title });
+  }
+
+  test('mode = unlocked', async () => {
+    const api = createApiMock();
+    mockModeUnlocked(api);
+    await expectTitle(api, 'Load CVRs');
+  });
+
+  test('mode = test', async () => {
+    const api = createApiMock();
+    mockModeTest(api, []);
+    await expectTitle(api, 'Load Test Ballot CVRs');
+  });
+
+  test('mode = official', async () => {
+    const api = createApiMock();
+    mockModeOfficial(api, []);
+    await expectTitle(api, 'Load Official Ballot CVRs');
+  });
+});
+
+test('shows "no USB" callout', async () => {
+  const api = createApiMock();
+  mockModeUnlocked(api);
+
+  const onClose = vi.fn();
+  render(<CvrImportPanel onClose={onClose} />, {
+    api,
+    usbStatus: mockUsbDriveStatus('no_drive'),
+  });
+
+  await waitFor(() => api.assertComplete());
+  screen.getByText('No USB Drive Detected');
+
+  expect(onClose).not.toHaveBeenCalled();
+  userEvent.click(screen.getButton('Done'));
+  expect(onClose).toHaveBeenCalledOnce();
+});
+
+function mockModeOfficial(api: ApiMock, imports: CvrImport[]) {
+  api.expectGetCastVoteRecordFileMode('official');
+  api.expectGetCastVoteRecordFiles(imports);
+}
+
+function mockModeTest(api: ApiMock, imports: CvrImport[]) {
+  api.expectGetCastVoteRecordFileMode('test');
+  api.expectGetCastVoteRecordFiles(imports);
+}
+
+function mockModeUnlocked(api: ApiMock) {
+  api.expectGetCastVoteRecordFileMode('unlocked');
+  api.expectGetCastVoteRecordFiles([]);
+}
+
+function render(
+  ui: React.ReactNode,
+  p: { api: ApiMock; usbStatus: UsbDriveStatus }
+) {
+  renderInAppContext(ui, {
+    electionDefinition,
+    apiMock: p.api,
+    usbDriveStatus: p.usbStatus,
+  });
+}

--- a/apps/admin/frontend/src/screens/tally/cvr_import_panel.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvr_import_panel.tsx
@@ -77,7 +77,7 @@ export function CvrImportPanel(props: Props): React.ReactNode {
 
   return (
     <Panel {...props} importer={importer} mode={mode}>
-      <CvrUsbExports key="exports" importer={importer} />
+      <CvrUsbExports importer={importer} />
       {alert}
     </Panel>
   );
@@ -211,14 +211,19 @@ function PartialImportAlert(props: {
 
   if (total === 1) {
     return (
-      <Alert close={close} title="1 New CVR Loaded">
+      <Alert close={close} title="No New CVRs Loaded">
         The 1 CVR in the selected export was previously loaded.
       </Alert>
     );
   }
 
+  const title =
+    newlyAdded === 1
+      ? '1 New CVR Loaded'
+      : `${format.count(newlyAdded)} New CVRs Loaded`;
+
   return (
-    <Alert close={close} title={`${format.count(newlyAdded)} New CVRs Loaded`}>
+    <Alert close={close} title={title}>
       {format.count(alreadyPresent)} of the {format.count(total)} total CVRs in
       the selected export {alreadyPresent === 1 ? 'was' : 'were'} previously
       loaded.

--- a/apps/admin/frontend/src/screens/tally/cvr_import_panel.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvr_import_panel.tsx
@@ -1,0 +1,227 @@
+/* istanbul ignore file - TODO: remove when CvrUsbExports is implemented. */
+import React from 'react';
+import styled from 'styled-components';
+
+import { Button, Card, Font, H3, H4, Icons, Modal, P } from '@votingworks/ui';
+
+import { format } from '@votingworks/utils';
+import type {
+  CvrFileImportInfo,
+  CvrFileMode,
+} from '@votingworks/admin-backend';
+import { throwIllegalValue } from '@votingworks/basics';
+import { CvrImporter, useCvrImporter } from './cvr_importer';
+import { CvrUsbExports } from './cvr_usb_exports';
+import { BORDER_LIGHT, GAP } from './styles';
+
+export interface Props {
+  className?: string;
+  onClose: () => void;
+}
+
+export function CvrImportPanel(props: Props): React.ReactNode {
+  const importer = useCvrImporter();
+
+  if (importer.state === 'loading') {
+    return (
+      <Panel {...props} importer={importer} mode={null}>
+        <Loading />
+      </Panel>
+    );
+  }
+
+  const { mode } = importer.existingImports;
+
+  if (importer.state === 'noUsb') {
+    return (
+      <Panel {...props} importer={importer} mode={mode}>
+        <NoUsb />
+      </Panel>
+    );
+  }
+
+  const alert: React.ReactNode = (() => {
+    switch (importer.state) {
+      case 'error':
+        return (
+          <Alert close={importer.reset} title="Error">
+            There was an error reading the contents of{' '}
+            <Font weight="bold">{importer.filename}</Font>:{' '}
+            {importer.errorMessage}
+          </Alert>
+        );
+
+      case 'duplicate':
+        return (
+          <Alert close={importer.reset} title="Duplicate Export">
+            The selected export was ignored as a duplicate of a previously
+            loaded export.
+          </Alert>
+        );
+
+      case 'success':
+        if (importer.result.alreadyPresent === 0) return null;
+        return (
+          <PartialImportAlert close={importer.reset} result={importer.result} />
+        );
+
+      case 'importing':
+      case 'init':
+        return null;
+
+      /* istanbul ignore next */
+      default:
+        throwIllegalValue(importer, 'state');
+    }
+  })();
+
+  return (
+    <Panel {...props} importer={importer} mode={mode}>
+      <CvrUsbExports key="exports" importer={importer} />
+      {alert}
+    </Panel>
+  );
+}
+
+const Body = styled.div`
+  display: grid;
+  gap: ${GAP};
+  grid-template-rows: min-content 1fr;
+  overflow-y: hidden;
+`;
+
+const Container = styled.div`
+  display: grid;
+  grid-template-rows: 1fr min-content;
+  gap: ${GAP};
+  height: 100%;
+  overflow-y: hidden;
+`;
+
+const TITLES: Record<CvrFileMode, string> = {
+  official: 'Load Official Ballot CVRs',
+  test: 'Load Test Ballot CVRs',
+  unlocked: 'Load CVRs',
+};
+
+function Panel(props: {
+  children?: React.ReactNode;
+  className?: string;
+  importer: CvrImporter;
+  mode: CvrFileMode | null;
+  onClose: () => void;
+}) {
+  const { children, className, importer, mode, onClose } = props;
+  const disableClose = importer.state === 'importing';
+
+  return (
+    <Container className={className}>
+      <Body>
+        {mode && <H3 style={{ fontWeight: 700, margin: 0 }}>{TITLES[mode]}</H3>}
+        {children}
+      </Body>
+
+      <div style={{ display: 'flex', justifyContent: 'end' }}>
+        <Button
+          disabled={disableClose}
+          fill="outlined"
+          icon="Done"
+          onPress={onClose}
+          variant={disableClose ? 'neutral' : 'primary'}
+        >
+          Done
+        </Button>
+      </div>
+    </Container>
+  );
+}
+
+function Alert(props: {
+  children: React.ReactNode;
+  close: () => void;
+  title: React.ReactNode;
+}) {
+  const { children, close, title } = props;
+
+  return (
+    <Modal
+      title={title}
+      content={<P>{children}</P>}
+      onOverlayClick={close}
+      actions={
+        <Button icon="Done" onPress={close}>
+          Close
+        </Button>
+      }
+    />
+  );
+}
+
+const LoadingContainer = styled(Card)`
+  ${BORDER_LIGHT}
+  padding: 5rem;
+
+  > * {
+    align-items: center;
+    color: ${(p) => p.theme.colors.neutral};
+    display: grid;
+    justify-content: center;
+
+    > h3 {
+      align-items: center;
+      display: flex;
+      gap: ${GAP};
+      font-size: 1.5rem;
+    }
+  }
+`;
+
+function Loading() {
+  return (
+    <LoadingContainer>
+      <H3>
+        <Icons.Loading />
+        <Font weight="semiBold">Loading</Font>
+      </H3>
+    </LoadingContainer>
+  );
+}
+
+function NoUsb(): React.ReactNode {
+  return (
+    <div>
+      <Card color="warning" style={{ maxWidth: 'max-content' }}>
+        <H4>
+          <Icons.Warning color="warning" style={{ marginRight: GAP }} />
+          No USB Drive Detected
+        </H4>
+        <Font>Insert a USB drive in order to load CVRs from a scanner.</Font>
+      </Card>
+    </div>
+  );
+}
+
+function PartialImportAlert(props: {
+  close: () => void;
+  result: CvrFileImportInfo;
+}) {
+  const { close, result } = props;
+  const { alreadyPresent, newlyAdded } = result;
+  const total = alreadyPresent + newlyAdded;
+
+  if (total === 1) {
+    return (
+      <Alert close={close} title="1 New CVR Loaded">
+        The 1 CVR in the selected export was previously loaded.
+      </Alert>
+    );
+  }
+
+  return (
+    <Alert close={close} title={`${format.count(newlyAdded)} New CVRs Loaded`}>
+      {format.count(alreadyPresent)} of the {format.count(total)} total CVRs in
+      the selected export {alreadyPresent === 1 ? 'was' : 'were'} previously
+      loaded.
+    </Alert>
+  );
+}

--- a/apps/admin/frontend/src/screens/tally/cvr_importer.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvr_importer.tsx
@@ -24,18 +24,21 @@ export type CvrImporter =
       state: 'duplicate';
       existingImports: ExistingImports;
       result: CvrFileImportInfo;
+      reset: () => void;
       usbExports: CvrExport[];
     }
   | {
       state: 'error';
-      errorMessage?: string;
+      errorMessage: string;
       existingImports: ExistingImports;
       filename: string;
+      reset: () => void;
       usbExports: CvrExport[];
     }
   | {
       state: 'importing';
       existingImports: ExistingImports;
+      path: string;
       usbExports: CvrExport[];
     }
   | {
@@ -50,6 +53,7 @@ export type CvrImporter =
     }
   | {
       state: 'noUsb';
+      existingImports: ExistingImports;
       manualImportButton: React.ReactNode;
     }
   | {
@@ -57,6 +61,7 @@ export type CvrImporter =
       existingImports: ExistingImports;
       import: ImportFn;
       manualImportButton: React.ReactNode;
+      reset: () => void;
       result: CvrFileImportInfo;
       usbExports: CvrExport[];
     };
@@ -81,18 +86,7 @@ export function useCvrImporter(): CvrImporter {
     <ManualImportButton importFn={importMutation.mutate} />
   );
 
-  if (
-    usbDriveStatus.status === 'no_drive' ||
-    usbDriveStatus.status === 'ejected' ||
-    usbDriveStatus.status === 'error'
-  ) {
-    return {
-      state: 'noUsb',
-      manualImportButton,
-    };
-  }
-
-  if (!imports.isSuccess || !cvrMode.isSuccess || !usbExports.isSuccess) {
+  if (!imports.isSuccess || !cvrMode.isSuccess) {
     return { state: 'loading' };
   }
 
@@ -101,10 +95,27 @@ export function useCvrImporter(): CvrImporter {
     mode: cvrMode.data,
   };
 
+  if (
+    usbDriveStatus.status === 'no_drive' ||
+    usbDriveStatus.status === 'ejected' ||
+    usbDriveStatus.status === 'error'
+  ) {
+    return {
+      state: 'noUsb',
+      existingImports,
+      manualImportButton,
+    };
+  }
+
+  if (!usbExports.isSuccess) {
+    return { state: 'loading' };
+  }
+
   if (importMutation.status === 'loading') {
     return {
       state: 'importing',
       existingImports,
+      path: assertDefined(importMutation.variables).path,
       usbExports: usbExports.data,
     };
   }
@@ -116,6 +127,7 @@ export function useCvrImporter(): CvrImporter {
         errorMessage: errorMessage(importMutation.data.err()),
         existingImports,
         filename: assertDefined(importMutation.variables).path,
+        reset: importMutation.reset,
         usbExports: usbExports.data,
       };
     }
@@ -126,6 +138,7 @@ export function useCvrImporter(): CvrImporter {
       return {
         state: 'duplicate',
         existingImports,
+        reset: importMutation.reset,
         result,
         usbExports: usbExports.data,
       };
@@ -136,6 +149,7 @@ export function useCvrImporter(): CvrImporter {
       existingImports,
       import: importMutation.mutate,
       manualImportButton,
+      reset: importMutation.reset,
       result,
       usbExports: usbExports.data,
     };

--- a/apps/admin/frontend/src/screens/tally/cvr_usb_exports.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvr_usb_exports.tsx
@@ -1,0 +1,13 @@
+/* istanbul ignore file - TODO: remove when implemented. */
+import React from 'react';
+
+import { CvrImporter } from './cvr_importer';
+
+type Importer = Exclude<CvrImporter, { state: 'loading' | 'noUsb' }>;
+
+export function CvrUsbExports(props: { importer: Importer }): React.ReactNode {
+  const { importer } = props;
+
+  // [TODO]
+  return <div>Importer state: {importer.state}</div>;
+}


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7958

This will be replacing the older `ImportCvrFilesModal` as an inline panel component on the CVR management screen. This first piece sets up the structure and state-specific content/alerts, but doesn't yet include the clickable list of exports. Working on tests for those and will follow up with a PR to build on this one later.

## Demo Video or Screenshot (eventual state with import buttons hooked up)

### Happy Path

https://github.com/user-attachments/assets/cd195e71-efc5-4e92-b199-8a3f83794456

### Partially Duplicated Import

https://github.com/user-attachments/assets/9b321fae-a353-4fe8-9c9f-9b2bcb9ae806

### Fully Duplicated Import (Mocked)

https://github.com/user-attachments/assets/ac04ceda-899c-4a40-866b-ad34ae437e2c

### Empty State/No New CVRs Found

https://github.com/user-attachments/assets/e56d7d80-427e-436b-80a9-df831c3118e9

## Testing Plan
- Fairly minimal unit tests to verify rendering. Following up with more coverage in next PR
- Some manual testing with local prototype.

## Checklist
N/A