### PR TITLE
VxAdmin: Watch USB drive changes

### DIFF
--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -592,6 +592,33 @@ test('usbDrive', async () => {
   expect(await apiClient.formatUsbDrive()).toEqual(err(error));
 });
 
+test('waitForUsbDriveChange resolves when a USB drive change is detected', async () => {
+  const { apiClient, usbPlatform } = buildTestEnvironment();
+  usbPlatform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+
+  let changed: boolean | undefined;
+  void apiClient.waitForUsbDriveChange().then((result) => {
+    changed = result;
+  });
+
+  // Toggle the drive's presence until the long-poll observes a change. Looping
+  // makes this robust against a change firing before the request reaches the
+  // backend handler.
+  let present = false;
+  await vi.waitFor(
+    () => {
+      present = !present;
+      if (present) {
+        usbPlatform.insertDrive(devsdb);
+      } else {
+        usbPlatform.removeDrive(devsdb);
+      }
+      expect(changed).toEqual(true);
+    },
+    { timeout: 10_000, interval: 250 }
+  );
+});
+
 test('usbDrive without proper auth', async () => {
   const { apiClient, auth, usbPlatform } = buildTestEnvironment();
   const electionDefinition =

--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -592,19 +592,40 @@ test('usbDrive', async () => {
   expect(await apiClient.formatUsbDrive()).toEqual(err(error));
 });
 
-test('waitForUsbDriveChange resolves when a USB drive change is detected', async () => {
+test('waitForUsbDriveChange returns immediately when the sequence is already ahead', async () => {
   const { apiClient, usbPlatform } = buildTestEnvironment();
-  usbPlatform.createDrive({ diskPath: devsdb, fstype: 'fat32' });
+  // Attaching a drive advances the change sequence past the caller's `lastSeq`.
+  await attachUsbDrive(apiClient, usbPlatform);
 
-  let changed: boolean | undefined;
-  void apiClient.waitForUsbDriveChange().then((result) => {
-    changed = result;
+  // Because a change already happened, the poll resolves without waiting.
+  const seq = await apiClient.waitForUsbDriveChange({ lastSeq: 0 });
+  expect(seq).toBeGreaterThan(0);
+});
+
+test('waitForUsbDriveChange waits for and reports the next change', async () => {
+  const { apiClient, usbPlatform } = buildTestEnvironment();
+  await attachUsbDrive(apiClient, usbPlatform);
+
+  // Learn the current sequence (this returns immediately since attaching the
+  // drive already advanced it), giving us a quiet baseline.
+  const baselineSeq = await apiClient.waitForUsbDriveChange({ lastSeq: 0 });
+
+  // With no change since the baseline, this poll parks until the next change.
+  let observedSeq: number | undefined;
+  void apiClient.waitForUsbDriveChange({ lastSeq: baselineSeq }).then((seq) => {
+    observedSeq = seq;
   });
 
-  // Toggle the drive's presence until the long-poll observes a change. Looping
-  // makes this robust against a change firing before the request reaches the
-  // backend handler.
-  let present = false;
+  // The sequence can only advance when we drive `usbPlatform`, so it stays
+  // frozen here. A couple of round-trips give the poll time to park; it must
+  // not resolve while nothing has changed.
+  await apiClient.getUsbDriveStatus();
+  await apiClient.getUsbDriveStatus();
+  expect(observedSeq).toBeUndefined();
+
+  // Now a change wakes the parked poll. Toggle presence in case a single
+  // filesystem event is missed.
+  let present = true;
   await vi.waitFor(
     () => {
       present = !present;
@@ -613,7 +634,7 @@ test('waitForUsbDriveChange resolves when a USB drive change is detected', async
       } else {
         usbPlatform.removeDrive(devsdb);
       }
-      expect(changed).toEqual(true);
+      expect(observedSeq).toBeGreaterThan(baselineSeq);
     },
     { timeout: 10_000, interval: 250 }
   );

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -128,7 +128,7 @@ import {
   generateAdminLiveResultsReportingUrls,
   getMatchingAbsenteePollingPlaces,
 } from './live_results_reporting';
-import { NODE_ENV } from './globals';
+import { NODE_ENV, USB_DRIVE_CHANGE_LONG_POLL_TIMEOUT_MS } from './globals';
 import {
   exportWriteInAdjudicationReportPdf,
   generateWriteInAdjudicationReportPreview,
@@ -393,8 +393,9 @@ function buildApi({
     /**
      * Long-polls for a USB drive change. The caller passes the last change
      * sequence it observed; this resolves with the current sequence once it is
-     * ahead of `lastSeq` (i.e. a change has happened), or after a 30-second
-     * timeout with the sequence unchanged. Comparing sequences lets the caller
+     * ahead of `lastSeq` (i.e. a change has happened), or after
+     * {@link USB_DRIVE_CHANGE_LONG_POLL_TIMEOUT_MS} with the sequence
+     * unchanged. Comparing sequences lets the caller
      * detect a change that occurred between polls, so none are missed.
      */
     async waitForUsbDriveChange({
@@ -402,16 +403,16 @@ function buildApi({
     }: {
       lastSeq: number;
     }): Promise<number> {
-      // Capture the wake signal before reading the counter so a change firing
-      // between the two is still observed (either the counter is already ahead,
-      // or the promise we captured is the one it resolves).
-      const changed = nextUsbDriveChange.promise;
       if (usbDriveChangeSeq > lastSeq) {
         return usbDriveChangeSeq;
       }
-      // Bound the wait so Node.js doesn't kill an idle request; on timeout the
-      // sequence is unchanged and the caller simply polls again.
-      await timeout(30_000, changed);
+      // Bound the wait so the held-open connection is recycled rather than
+      // lingering indefinitely; on timeout the sequence is unchanged and the
+      // caller simply polls again.
+      await timeout(
+        USB_DRIVE_CHANGE_LONG_POLL_TIMEOUT_MS,
+        nextUsbDriveChange.promise
+      );
       return usbDriveChangeSeq;
     },
 

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -209,11 +209,16 @@ function buildApi({
     (drives) => drives.find((d) => d.partition?.fstype === 'fat32')?.diskPath
   );
 
-  // Signals `waitForUsbDriveChange` long-polls. A change that lands between one
-  // long-poll resolving and the next one starting is missed here, but the
-  // frontend's slow fallback poll of `getUsbDriveStatus` covers that gap.
+  // Backs the `waitForUsbDriveChange` long-poll. `usbDriveChangeSeq` is a
+  // monotonic counter bumped on every change; `nextUsbDriveChange` resolves to
+  // wake any parked long-polls. The counter makes the long-poll level-triggered
+  // rather than edge-triggered: a client passes the last sequence it saw, so a
+  // change that fires between two long-polls is reported on the next one
+  // instead of being lost.
+  let usbDriveChangeSeq = 0;
   let nextUsbDriveChange = deferred<void>();
   multiUsbDrive.addListener(() => {
+    usbDriveChangeSeq += 1;
     nextUsbDriveChange.resolve();
     nextUsbDriveChange = deferred<void>();
   });
@@ -386,14 +391,28 @@ function buildApi({
     },
 
     /**
-     * Waits for a USB drive change, with a 30-second timeout.
-     * @returns `true` if a change is detected, `false` if the timeout is reached.
+     * Long-polls for a USB drive change. The caller passes the last change
+     * sequence it observed; this resolves with the current sequence once it is
+     * ahead of `lastSeq` (i.e. a change has happened), or after a 30-second
+     * timeout with the sequence unchanged. Comparing sequences lets the caller
+     * detect a change that occurred between polls, so none are missed.
      */
-    async waitForUsbDriveChange(): Promise<boolean> {
-      // Use a timeout so Node.js doesn't just kill the request when no
-      // network activity is detected.
-      const result = await timeout(30_000, nextUsbDriveChange.promise);
-      return result.type === 'success';
+    async waitForUsbDriveChange({
+      lastSeq,
+    }: {
+      lastSeq: number;
+    }): Promise<number> {
+      // Capture the wake signal before reading the counter so a change firing
+      // between the two is still observed (either the counter is already ahead,
+      // or the promise we captured is the one it resolves).
+      const changed = nextUsbDriveChange.promise;
+      if (usbDriveChangeSeq > lastSeq) {
+        return usbDriveChangeSeq;
+      }
+      // Bound the wait so Node.js doesn't kill an idle request; on timeout the
+      // sequence is unchanged and the caller simply polls again.
+      await timeout(30_000, changed);
+      return usbDriveChangeSeq;
     },
 
     async ejectUsbDrive(): Promise<void> {

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -167,6 +167,7 @@ import { constructAuthMachineState } from './util/auth';
 import { parseElectionResultsReportingFile } from './tabulation/election_results_reporting';
 import { generateReportsDirectoryPath } from './util/filenames';
 import { getHostServiceName } from './networking';
+import { timeout } from './util/timeout';
 
 const debug = rootDebug.extend('app');
 
@@ -207,6 +208,15 @@ function buildApi({
     // return the first FAT32 drive
     (drives) => drives.find((d) => d.partition?.fstype === 'fat32')?.diskPath
   );
+
+  // Signals `waitForUsbDriveChange` long-polls. A change that lands between one
+  // long-poll resolving and the next one starting is missed here, but the
+  // frontend's slow fallback poll of `getUsbDriveStatus` covers that gap.
+  let nextUsbDriveChange = deferred<void>();
+  multiUsbDrive.addListener(() => {
+    nextUsbDriveChange.resolve();
+    nextUsbDriveChange = deferred<void>();
+  });
 
   function convertFrontendFilter(
     filter: Admin.FrontendReportingFilter
@@ -373,6 +383,17 @@ function buildApi({
 
     getUsbDriveStatus(): Promise<UsbDriveStatus> {
       return usbDriveAdapter.status();
+    },
+
+    /**
+     * Waits for a USB drive change, with a 30-second timeout.
+     * @returns `true` if a change is detected, `false` if the timeout is reached.
+     */
+    async waitForUsbDriveChange(): Promise<boolean> {
+      // Use a timeout so Node.js doesn't just kill the request when no
+      // network activity is detected.
+      const result = await timeout(30_000, nextUsbDriveChange.promise);
+      return result.type === 'success';
     },
 
     async ejectUsbDrive(): Promise<void> {

--- a/apps/admin/backend/src/globals.ts
+++ b/apps/admin/backend/src/globals.ts
@@ -51,6 +51,17 @@ export const NETWORK_REQUEST_TIMEOUT_MS = 1 * 1000;
 /** How long to wait before considering a machine stale (in milliseconds) */
 export const STALE_MACHINE_THRESHOLD_MS = 10 * 1000;
 
+/**
+ * How long `waitForUsbDriveChange` blocks before returning with an unchanged
+ * sequence. Nothing in the request stack imposes a timeout — the backend's
+ * Node.js idle socket timeout is explicitly disabled (see `server.ts`), the
+ * proxy layers set none, and the Grout client sends no request timeout — so
+ * this application-level bound is the sole mechanism that recycles the
+ * held-open long-poll connection and lets a vanished client be noticed on its
+ * next poll, rather than lingering indefinitely.
+ */
+export const USB_DRIVE_CHANGE_LONG_POLL_TIMEOUT_MS = 30 * 1000;
+
 const DEFAULT_ALLOWED_EXPORT_PATTERNS =
   NODE_ENV === 'production'
     ? isIntegrationTest()

--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -261,5 +261,14 @@ export async function start(options: StartOptions = {}): Promise<Server> {
       disposition: 'success',
     });
   });
+
+  // Explicitly disable Node.js's idle socket timeout (its default) so long-
+  // running requests are never reset mid-flight: the `waitForUsbDriveChange`
+  // long-poll holds a connection open, and slow operations (e.g. large report
+  // generation) leave the socket idle while computing. The long-poll bounds
+  // its own wait at the application layer
+  // (USB_DRIVE_CHANGE_LONG_POLL_TIMEOUT_MS); no socket-level timeout is needed.
+  server.timeout = 0;
+
   return server;
 }

--- a/apps/admin/backend/src/util/timeout.test.ts
+++ b/apps/admin/backend/src/util/timeout.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { deferred } from '@votingworks/basics';
+import { timeout } from './timeout';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test('resolves with the value when the promise settles before the deadline', async () => {
+  const result = await timeout(30_000, Promise.resolve('done'));
+  expect(result).toEqual({ type: 'success', value: 'done' });
+});
+
+test('resolves with a timeout when the deadline is reached first', async () => {
+  const neverResolves = new Promise<string>(() => {});
+  const resultPromise = timeout(30_000, neverResolves);
+
+  await vi.advanceTimersByTimeAsync(30_000);
+
+  expect(await resultPromise).toEqual({ type: 'timeout' });
+});
+
+test('clears the timer once the promise settles', async () => {
+  const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+  const { promise, resolve } = deferred<number>();
+
+  const resultPromise = timeout(30_000, promise);
+  resolve(42);
+
+  expect(await resultPromise).toEqual({ type: 'success', value: 42 });
+  expect(clearTimeoutSpy).toHaveBeenCalled();
+  // No pending timers remain, so advancing time changes nothing.
+  expect(vi.getTimerCount()).toEqual(0);
+});

--- a/apps/admin/backend/src/util/timeout.ts
+++ b/apps/admin/backend/src/util/timeout.ts
@@ -1,0 +1,30 @@
+import { deferred } from '@votingworks/basics';
+
+/**
+ * The result of {@link timeout}: either the awaited promise's value, or a
+ * signal that the duration was exceeded before it resolved.
+ */
+export type TimeoutResult<T> =
+  | { type: 'success'; value: T }
+  | { type: 'timeout' };
+
+/**
+ * Waits until a promise resolves or a specified duration is exceeded,
+ * whichever comes first. The timer is always cleared, so a promise that
+ * resolves before the deadline leaves no dangling timer behind.
+ */
+export async function timeout<T>(
+  duration: number,
+  thenable: Promise<T>
+): Promise<TimeoutResult<T>> {
+  const { promise, resolve } = deferred<void>();
+  const timer = setTimeout(resolve, duration);
+  try {
+    return await Promise.race([
+      thenable.then((value) => ({ type: 'success', value }) as const),
+      promise.then(() => ({ type: 'timeout' }) as const),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -4,7 +4,6 @@ import type { Api } from '@votingworks/admin-backend';
 import {
   AUTH_STATUS_POLLING_INTERVAL_MS,
   QUERY_CLIENT_DEFAULT_OPTIONS,
-  USB_DRIVE_STATUS_POLLING_INTERVAL_MS,
 } from '@votingworks/ui';
 import {
   QueryClient,
@@ -20,6 +19,7 @@ import type {
 } from '@votingworks/usb-drive';
 import { DEFAULT_QUERY_REFETCH_INTERVAL } from './utils/globals';
 
+const SLOW_USB_DRIVE_STATUS_POLLING_INTERVAL_MS = 2000;
 const PRINTER_STATUS_POLLING_INTERVAL_MS = 100;
 
 export type ApiClient = grout.Client<Api>;
@@ -203,7 +203,7 @@ export const getUsbDriveStatus = {
   useQuery() {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(), () => apiClient.getUsbDriveStatus(), {
-      refetchInterval: USB_DRIVE_STATUS_POLLING_INTERVAL_MS,
+      refetchInterval: SLOW_USB_DRIVE_STATUS_POLLING_INTERVAL_MS,
       structuralSharing(oldData, newData) {
         if (!oldData) {
           return newData;

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -19,7 +19,6 @@ import type {
 } from '@votingworks/usb-drive';
 import { DEFAULT_QUERY_REFETCH_INTERVAL } from './utils/globals';
 
-const SLOW_USB_DRIVE_STATUS_POLLING_INTERVAL_MS = 2000;
 const PRINTER_STATUS_POLLING_INTERVAL_MS = 100;
 
 export type ApiClient = grout.Client<Api>;
@@ -203,7 +202,6 @@ export const getUsbDriveStatus = {
   useQuery() {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(), () => apiClient.getUsbDriveStatus(), {
-      refetchInterval: SLOW_USB_DRIVE_STATUS_POLLING_INTERVAL_MS,
       structuralSharing(oldData, newData) {
         if (!oldData) {
           return newData;

--- a/apps/admin/frontend/src/app_root.tsx
+++ b/apps/admin/frontend/src/app_root.tsx
@@ -5,12 +5,12 @@ import {
   getAuthStatus,
   getCurrentElectionMetadata,
   getMachineConfig,
-  getUsbDriveStatus,
 } from './api';
+import { useWatchUsbDriveStatus } from './hooks/use_watch_usb_drive_status';
 
 export function AppRoot(): JSX.Element | null {
   const authStatusQuery = getAuthStatus.useQuery();
-  const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
+  const usbDriveStatusQuery = useWatchUsbDriveStatus();
   const getMachineConfigQuery = getMachineConfig.useQuery();
   const currentElectionMetadataQuery = getCurrentElectionMetadata.useQuery();
 

--- a/apps/admin/frontend/src/hooks/use_watch_usb_drive_status.test.tsx
+++ b/apps/admin/frontend/src/hooks/use_watch_usb_drive_status.test.tsx
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { deferred } from '@votingworks/basics';
+import { mockUsbDriveStatus } from '@votingworks/ui';
+import { ApiClient, ApiClientContext, createQueryClient } from '../api';
+import { useWatchUsbDriveStatus } from './use_watch_usb_drive_status';
+
+const USB_DRIVE_STATUS_QUERY_KEY = ['getUsbDriveStatus'];
+
+function buildApiClient(
+  waitForUsbDriveChange: () => Promise<boolean>
+): ApiClient {
+  return {
+    waitForUsbDriveChange: vi.fn(waitForUsbDriveChange),
+    getUsbDriveStatus: vi.fn(() =>
+      Promise.resolve(mockUsbDriveStatus('no_drive'))
+    ),
+  } as unknown as ApiClient;
+}
+
+function renderWatchHook(apiClient: ApiClient, queryClient: QueryClient) {
+  return renderHook(() => useWatchUsbDriveStatus(), {
+    wrapper: ({ children }) => (
+      <ApiClientContext.Provider value={apiClient}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </ApiClientContext.Provider>
+    ),
+  });
+}
+
+function pending(): Promise<boolean> {
+  return new Promise<boolean>(() => {});
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test('invalidates the USB drive status query when a change is signaled', async () => {
+  const change = deferred<boolean>();
+  let callCount = 0;
+  const apiClient = buildApiClient(() => {
+    callCount += 1;
+    return callCount === 1 ? change.promise : pending();
+  });
+  const queryClient = createQueryClient();
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+  renderWatchHook(apiClient, queryClient);
+  await waitFor(() =>
+    expect(apiClient.waitForUsbDriveChange).toHaveBeenCalled()
+  );
+  expect(invalidateSpy).not.toHaveBeenCalled();
+
+  change.resolve(true);
+  await waitFor(() =>
+    expect(invalidateSpy).toHaveBeenCalledWith(USB_DRIVE_STATUS_QUERY_KEY)
+  );
+});
+
+test('does not invalidate when the long-poll times out with no change', async () => {
+  const timeout = deferred<boolean>();
+  let callCount = 0;
+  const apiClient = buildApiClient(() => {
+    callCount += 1;
+    return callCount === 1 ? timeout.promise : pending();
+  });
+  const queryClient = createQueryClient();
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+  renderWatchHook(apiClient, queryClient);
+
+  timeout.resolve(false);
+  // The loop should re-issue the long-poll without invalidating anything.
+  await waitFor(() =>
+    expect(apiClient.waitForUsbDriveChange).toHaveBeenCalledTimes(2)
+  );
+  expect(invalidateSpy).not.toHaveBeenCalled();
+});
+
+test('backs off and retries when the long-poll fails', async () => {
+  let callCount = 0;
+  const apiClient = buildApiClient(() => {
+    callCount += 1;
+    return callCount === 1
+      ? Promise.reject(new Error('network error'))
+      : pending();
+  });
+  const queryClient = createQueryClient();
+
+  renderWatchHook(apiClient, queryClient);
+  await waitFor(() =>
+    expect(apiClient.waitForUsbDriveChange).toHaveBeenCalledTimes(1)
+  );
+
+  // It should not retry until the backoff has elapsed.
+  await vi.advanceTimersByTimeAsync(1000);
+  await waitFor(() =>
+    expect(apiClient.waitForUsbDriveChange).toHaveBeenCalledTimes(2)
+  );
+});
+
+test('stops polling after unmount', async () => {
+  const apiClient = buildApiClient(pending);
+  const queryClient = createQueryClient();
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+  const { unmount } = renderWatchHook(apiClient, queryClient);
+  await waitFor(() =>
+    expect(apiClient.waitForUsbDriveChange).toHaveBeenCalledTimes(1)
+  );
+
+  unmount();
+  await vi.advanceTimersByTimeAsync(1000);
+
+  expect(apiClient.waitForUsbDriveChange).toHaveBeenCalledTimes(1);
+  expect(invalidateSpy).not.toHaveBeenCalled();
+});

--- a/apps/admin/frontend/src/hooks/use_watch_usb_drive_status.test.tsx
+++ b/apps/admin/frontend/src/hooks/use_watch_usb_drive_status.test.tsx
@@ -9,7 +9,7 @@ import { useWatchUsbDriveStatus } from './use_watch_usb_drive_status';
 const USB_DRIVE_STATUS_QUERY_KEY = ['getUsbDriveStatus'];
 
 function buildApiClient(
-  waitForUsbDriveChange: () => Promise<boolean>
+  waitForUsbDriveChange: () => Promise<number>
 ): ApiClient {
   return {
     waitForUsbDriveChange: vi.fn(waitForUsbDriveChange),
@@ -31,8 +31,8 @@ function renderWatchHook(apiClient: ApiClient, queryClient: QueryClient) {
   });
 }
 
-function pending(): Promise<boolean> {
-  return new Promise<boolean>(() => {});
+function pending(): Promise<number> {
+  return new Promise<number>(() => {});
 }
 
 beforeEach(() => {
@@ -43,8 +43,8 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-test('invalidates the USB drive status query when a change is signaled', async () => {
-  const change = deferred<boolean>();
+test('invalidates the USB drive status query when the sequence advances', async () => {
+  const change = deferred<number>();
   let callCount = 0;
   const apiClient = buildApiClient(() => {
     callCount += 1;
@@ -55,18 +55,23 @@ test('invalidates the USB drive status query when a change is signaled', async (
 
   renderWatchHook(apiClient, queryClient);
   await waitFor(() =>
-    expect(apiClient.waitForUsbDriveChange).toHaveBeenCalled()
+    expect(apiClient.waitForUsbDriveChange).toHaveBeenCalledWith({ lastSeq: 0 })
   );
   expect(invalidateSpy).not.toHaveBeenCalled();
 
-  change.resolve(true);
+  // A sequence ahead of the caller's `lastSeq` means a change occurred.
+  change.resolve(1);
   await waitFor(() =>
     expect(invalidateSpy).toHaveBeenCalledWith(USB_DRIVE_STATUS_QUERY_KEY)
   );
+  // The next poll advances its cursor to the observed sequence.
+  await waitFor(() =>
+    expect(apiClient.waitForUsbDriveChange).toHaveBeenCalledWith({ lastSeq: 1 })
+  );
 });
 
-test('does not invalidate when the long-poll times out with no change', async () => {
-  const timeout = deferred<boolean>();
+test('does not invalidate when the sequence is unchanged (timeout)', async () => {
+  const timeout = deferred<number>();
   let callCount = 0;
   const apiClient = buildApiClient(() => {
     callCount += 1;
@@ -77,8 +82,9 @@ test('does not invalidate when the long-poll times out with no change', async ()
 
   renderWatchHook(apiClient, queryClient);
 
-  timeout.resolve(false);
-  // The loop should re-issue the long-poll without invalidating anything.
+  // The timeout resolves with the same sequence the caller passed in.
+  timeout.resolve(0);
+  // The loop re-issues the long-poll (still from seq 0) without invalidating.
   await waitFor(() =>
     expect(apiClient.waitForUsbDriveChange).toHaveBeenCalledTimes(2)
   );

--- a/apps/admin/frontend/src/hooks/use_watch_usb_drive_status.ts
+++ b/apps/admin/frontend/src/hooks/use_watch_usb_drive_status.ts
@@ -1,0 +1,51 @@
+import { useQueryClient, UseQueryResult } from '@tanstack/react-query';
+import type { UsbDriveStatus } from '@votingworks/usb-drive';
+import { deferred, sleep } from '@votingworks/basics';
+import { useEffect } from 'react';
+import { getUsbDriveStatus, useApiClient } from '../api';
+
+const WATCH_RETRY_BACKOFF_MS = 1000;
+
+/**
+ * Subscribes to USB drive changes via long-polling and keeps the
+ * `getUsbDriveStatus` query up to date, returning that query's result.
+ *
+ * Mount this once per app root. Other components can read the status with
+ * `getUsbDriveStatus.useQuery()`, which shares the same query and is kept
+ * fresh by the invalidation here (plus the query's own slow fallback poll,
+ * which also covers the rare change that lands between long-poll requests).
+ */
+export function useWatchUsbDriveStatus(): UseQueryResult<UsbDriveStatus> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    let isMounted = true;
+    const waitForUnmount = deferred<void>();
+
+    void (async () => {
+      while (isMounted) {
+        try {
+          const hasChanged = await Promise.race([
+            apiClient.waitForUsbDriveChange(),
+            waitForUnmount.promise.then(() => false),
+          ]);
+          if (hasChanged) {
+            await queryClient.invalidateQueries(getUsbDriveStatus.queryKey());
+          }
+        } catch {
+          // Back off before retrying so a persistent failure (e.g. the backend
+          // restarting) doesn't turn this into a busy loop.
+          await sleep(WATCH_RETRY_BACKOFF_MS);
+        }
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+      waitForUnmount.resolve();
+    };
+  }, [apiClient, queryClient]);
+
+  return getUsbDriveStatus.useQuery();
+}

--- a/apps/admin/frontend/src/hooks/use_watch_usb_drive_status.ts
+++ b/apps/admin/frontend/src/hooks/use_watch_usb_drive_status.ts
@@ -6,14 +6,19 @@ import { getUsbDriveStatus, useApiClient } from '../api';
 
 const WATCH_RETRY_BACKOFF_MS = 1000;
 
+const UNMOUNTED = Symbol('unmounted');
+
 /**
  * Subscribes to USB drive changes via long-polling and keeps the
  * `getUsbDriveStatus` query up to date, returning that query's result.
  *
+ * Each long-poll passes the last change sequence it saw; the backend replies
+ * with the current sequence once it is ahead, so a change that lands between
+ * two polls is reported on the next one rather than lost.
+ *
  * Mount this once per app root. Other components can read the status with
  * `getUsbDriveStatus.useQuery()`, which shares the same query and is kept
- * fresh by the invalidation here (plus the query's own slow fallback poll,
- * which also covers the rare change that lands between long-poll requests).
+ * fresh by the invalidation here.
  */
 export function useWatchUsbDriveStatus(): UseQueryResult<UsbDriveStatus> {
   const apiClient = useApiClient();
@@ -21,16 +26,21 @@ export function useWatchUsbDriveStatus(): UseQueryResult<UsbDriveStatus> {
 
   useEffect(() => {
     let isMounted = true;
-    const waitForUnmount = deferred<void>();
+    let lastSeq = 0;
+    const waitForUnmount = deferred<typeof UNMOUNTED>();
 
     void (async () => {
       while (isMounted) {
         try {
-          const hasChanged = await Promise.race([
-            apiClient.waitForUsbDriveChange(),
-            waitForUnmount.promise.then(() => false),
+          const seq = await Promise.race([
+            apiClient.waitForUsbDriveChange({ lastSeq }),
+            waitForUnmount.promise,
           ]);
-          if (hasChanged) {
+          if (seq === UNMOUNTED) {
+            break;
+          }
+          if (seq !== lastSeq) {
+            lastSeq = seq;
             await queryClient.invalidateQueries(getUsbDriveStatus.queryKey());
           }
         } catch {
@@ -43,7 +53,7 @@ export function useWatchUsbDriveStatus(): UseQueryResult<UsbDriveStatus> {
 
     return () => {
       isMounted = false;
-      waitForUnmount.resolve();
+      waitForUnmount.resolve(UNMOUNTED);
     };
   }, [apiClient, queryClient]);
 

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -93,6 +93,12 @@ export function createMockApiClient(): MockApiClient {
   (mockApiClient.isMultiStationAdjudicationEnabled as unknown as Mock) = vi.fn(
     () => Promise.resolve(false)
   );
+  // The USB drive watcher long-polls this continuously. Default it to a
+  // never-resolving promise; `createApiMock` replaces it with a controllable
+  // version that reports a change whenever the expected status is updated.
+  (mockApiClient.waitForUsbDriveChange as unknown as Mock) = vi.fn(
+    () => new Promise<boolean>(() => {})
+  );
   return mockApiClient as unknown as MockApiClient;
 }
 
@@ -147,6 +153,34 @@ function createDeferredMock<T, U>(
 export function createApiMock(
   apiClient: MockApiClient = createMockApiClient()
 ) {
+  // Emulates the backend's `waitForUsbDriveChange` long-poll: each expected
+  // status change reports exactly one change, so the watcher refetches
+  // `getUsbDriveStatus` once (rather than idly polling). The pending flag
+  // covers the case where a change is reported before the watcher has
+  // re-issued its long-poll.
+  let usbDriveChange = deferred<boolean>();
+  let usbDriveChangeParked = false;
+  let usbDriveChangePending = false;
+  (apiClient.waitForUsbDriveChange as unknown as Mock).mockImplementation(
+    () => {
+      if (usbDriveChangePending) {
+        usbDriveChangePending = false;
+        return Promise.resolve(true);
+      }
+      usbDriveChange = deferred<boolean>();
+      usbDriveChangeParked = true;
+      return usbDriveChange.promise;
+    }
+  );
+  function reportUsbDriveChange(): void {
+    if (usbDriveChangeParked) {
+      usbDriveChangeParked = false;
+      usbDriveChange.resolve(true);
+    } else {
+      usbDriveChangePending = true;
+    }
+  }
+
   function setPrinterStatus(printerStatus: Partial<PrinterStatus> = {}): void {
     apiClient.getPrinterStatus.expectRepeatedCallsWith().resolves({
       connected: true,
@@ -258,6 +292,7 @@ export function createApiMock(
       apiClient.getUsbDriveStatus
         .expectRepeatedCallsWith()
         .resolves(mockUsbDriveStatus(status));
+      reportUsbDriveChange();
     },
 
     expectEjectUsbDrive(): void {

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -22,7 +22,7 @@ import type {
 import type { BatteryInfo } from '@votingworks/backend';
 import type { DiskSpaceSummary } from '@votingworks/utils';
 import { FileSystemEntry, FileSystemEntryType } from '@votingworks/fs';
-import { Result, deferred, ok } from '@votingworks/basics';
+import { Deferred, Result, deferred, ok } from '@votingworks/basics';
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
 import { Buffer } from 'node:buffer';
 import {
@@ -97,7 +97,7 @@ export function createMockApiClient(): MockApiClient {
   // never-resolving promise; `createApiMock` replaces it with a controllable
   // version that reports a change whenever the expected status is updated.
   (mockApiClient.waitForUsbDriveChange as unknown as Mock) = vi.fn(
-    () => new Promise<boolean>(() => {})
+    () => new Promise<number>(() => {})
   );
   return mockApiClient as unknown as MockApiClient;
 }
@@ -153,31 +153,28 @@ function createDeferredMock<T, U>(
 export function createApiMock(
   apiClient: MockApiClient = createMockApiClient()
 ) {
-  // Emulates the backend's `waitForUsbDriveChange` long-poll: each expected
-  // status change reports exactly one change, so the watcher refetches
-  // `getUsbDriveStatus` once (rather than idly polling). The pending flag
-  // covers the case where a change is reported before the watcher has
-  // re-issued its long-poll.
-  let usbDriveChange = deferred<boolean>();
-  let usbDriveChangeParked = false;
-  let usbDriveChangePending = false;
+  // Emulates the backend's sequence-based `waitForUsbDriveChange` long-poll:
+  // each expected status change bumps the sequence, so the watcher refetches
+  // `getUsbDriveStatus` once (rather than idly polling). Comparing against
+  // `lastSeq` covers the case where a change is reported before the watcher
+  // has re-issued its long-poll — it simply returns the new sequence at once.
+  let usbDriveChangeSeq = 0;
+  let usbDriveChangeWaiter: Deferred<number> | undefined;
   (apiClient.waitForUsbDriveChange as unknown as Mock).mockImplementation(
-    () => {
-      if (usbDriveChangePending) {
-        usbDriveChangePending = false;
-        return Promise.resolve(true);
+    ({ lastSeq }: { lastSeq: number }) => {
+      if (usbDriveChangeSeq > lastSeq) {
+        return Promise.resolve(usbDriveChangeSeq);
       }
-      usbDriveChange = deferred<boolean>();
-      usbDriveChangeParked = true;
-      return usbDriveChange.promise;
+      usbDriveChangeWaiter = deferred<number>();
+      return usbDriveChangeWaiter.promise;
     }
   );
   function reportUsbDriveChange(): void {
-    if (usbDriveChangeParked) {
-      usbDriveChangeParked = false;
-      usbDriveChange.resolve(true);
-    } else {
-      usbDriveChangePending = true;
+    usbDriveChangeSeq += 1;
+    if (usbDriveChangeWaiter) {
+      const waiter = usbDriveChangeWaiter;
+      usbDriveChangeWaiter = undefined;
+      waiter.resolve(usbDriveChangeSeq);
     }
   }
 


### PR DESCRIPTION
## Overview
Uses the underlying watcher architecture to notify the VxAdmin frontend when USB drive state changes occur. The mechanism to do the notification is long polling since that's what fits best with Grout. At the moment this is a single-purpose endpoint, but longer term we'd want to consolidate all the watchable things into a single endpoint so as not to monopolize the browser's HTTP connection pool.

The long-polling endpoint does not return any data, just indicates a change has occurred which triggers the frontend to invalidate its USB drive status query. I left the auto-refresh behavior for that query even though it should be unnecessary now, but bumped it from 100ms to 2s which greatly reduces the Network Inspector spam.

Submitted as a draft. I'm curious in particular to get @jonahkagan's take as this uses Grout in a way it wasn't designed for. Also interested in @kofi-q's take since we've discussed ways to eliminate polling in the past.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/b215e399-c644-4fbf-8e0c-ea66cf52120f


## Testing Plan
Automated tests added. Tested manually with both real USB drives and the dev dock.
