### PR TITLE
VxDesign: add system setting to enable/disable printing of blank ballots from VxMark

### DIFF
--- a/apps/design/backend/src/features.ts
+++ b/apps/design/backend/src/features.ts
@@ -87,6 +87,11 @@ export interface UserFeaturesConfig {
    * Requires the system settings screen to be enabled.
    */
   TEST_DECK_PRINTING_SYSTEM_SETTING?: boolean;
+  /**
+   * Allow the user to toggle printing blank ballots from VxMark.
+   * Requires the system settings screen to be enabled.
+   */
+  VXMARK_PRINT_BLANK_BALLOTS_SYSTEM_SETTING?: boolean;
 }
 
 /**
@@ -212,6 +217,7 @@ const vxUserFeaturesConfig: UserFeaturesConfig = {
   VXSCAN_NUMBER_OF_REPORT_COPIES_SYSTEM_SETTING: true,
   VXSCAN_SCREEN_READER_AUDIO_SYSTEM_SETTING: true,
   VXSCAN_WRITE_IN_IMAGE_REPORT_SYSTEM_SETTING: true,
+  VXMARK_PRINT_BLANK_BALLOTS_SYSTEM_SETTING: true,
 };
 
 export const userFeatureConfigs = {

--- a/apps/design/frontend/src/system_settings_screen.test.tsx
+++ b/apps/design/frontend/src/system_settings_screen.test.tsx
@@ -846,14 +846,14 @@ test.each<{
     userFeatures: {
       VXMARK_PRINT_BLANK_BALLOTS_SYSTEM_SETTING: false,
     },
-    checkboxLabel: 'Allow Printing Blank Ballots from VxMark',
+    checkboxLabel: 'Enable Printing Blank Ballots from VxMark',
     isCheckboxExpected: false,
   },
   {
     userFeatures: {
       VXMARK_PRINT_BLANK_BALLOTS_SYSTEM_SETTING: true,
     },
-    checkboxLabel: 'Allow Printing Blank Ballots from VxMark',
+    checkboxLabel: 'Enable Printing Blank Ballots from VxMark',
     isCheckboxExpected: true,
     expectedSavedSystemSettings: { allowPrintingBlankBallotsFromVxMark: true },
   },

--- a/apps/design/frontend/src/system_settings_screen.test.tsx
+++ b/apps/design/frontend/src/system_settings_screen.test.tsx
@@ -626,7 +626,7 @@ test('all controls are disabled until clicking "Edit"', async () => {
   const allCheckboxes = document.body.querySelectorAll('[role=checkbox]');
   const allControls = [...allTextBoxes, ...allCheckboxes];
 
-  expect(allControls).toHaveLength(41);
+  expect(allControls).toHaveLength(42);
 
   for (const control of allControls) {
     expect(control).toBeDisabled();
@@ -841,6 +841,21 @@ test.each<{
     checkboxLabel: 'Enable Test Deck Printing',
     isCheckboxExpected: true,
     expectedSavedSystemSettings: { enableTestDeckPrinting: true },
+  },
+  {
+    userFeatures: {
+      VXMARK_PRINT_BLANK_BALLOTS_SYSTEM_SETTING: false,
+    },
+    checkboxLabel: 'Allow Printing Blank Ballots from VxMark',
+    isCheckboxExpected: false,
+  },
+  {
+    userFeatures: {
+      VXMARK_PRINT_BLANK_BALLOTS_SYSTEM_SETTING: true,
+    },
+    checkboxLabel: 'Allow Printing Blank Ballots from VxMark',
+    isCheckboxExpected: true,
+    expectedSavedSystemSettings: { allowPrintingBlankBallotsFromVxMark: true },
   },
 ])(
   'feature-flagged system settings toggles - $checkboxLabel',

--- a/apps/design/frontend/src/system_settings_screen.tsx
+++ b/apps/design/frontend/src/system_settings_screen.tsx
@@ -778,6 +778,23 @@ export function SystemSettingsForm({
                 />
               </InputGroup>
             )}
+            {features.VXMARK_PRINT_BLANK_BALLOTS_SYSTEM_SETTING && (
+              <CheckboxButton
+                label="Enable Printing Blank Ballots from VxMark"
+                isChecked={Boolean(
+                  systemSettings.allowPrintingBlankBallotsFromVxMark
+                )}
+                onChange={(isChecked) =>
+                  setSystemSettings({
+                    ...systemSettings,
+                    allowPrintingBlankBallotsFromVxMark: isChecked
+                      ? true
+                      : undefined,
+                  })
+                }
+                disabled={!isEditing}
+              />
+            )}
             <CheckboxButton
               label="Include Redundant Metadata in CVRs"
               isChecked={Boolean(

--- a/apps/design/frontend/test/api_helpers.tsx
+++ b/apps/design/frontend/test/api_helpers.tsx
@@ -38,6 +38,7 @@ const allUserFeaturesOnConfig: Record<UserFeature, boolean> = {
   SYSTEM_LIMIT_CHECKS_SYSTEM_SETTING: true,
   TEST_DECK_PRINTING_SYSTEM_SETTING: true,
   VOTER_HELP_BUTTONS_SYSTEM_SETTING: true,
+  VXMARK_PRINT_BLANK_BALLOTS_SYSTEM_SETTING: true,
 };
 
 export function mockUserFeatures(

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -17,6 +17,7 @@ import {
   safeParseSystemSettings,
   DEFAULT_SYSTEM_SETTINGS,
   safeParseJson,
+  SystemSettings,
   SystemSettingsSchema,
   ElectionDefinition,
   PrinterStatus,
@@ -388,17 +389,21 @@ async function expectElectionState(expected: Partial<ElectionState>) {
 async function configureMachine(
   usbDrive: MockUsbDrive,
   electionDefinition: ElectionDefinition,
-  uiStrings?: UiStringsPackage
+  uiStrings?: UiStringsPackage,
+  systemSettingsOverrides: Partial<SystemSettings> = {}
 ) {
   mockElectionManagerAuth(electionDefinition);
 
   usbDrive.insertUsbDrive(
     await mockElectionPackageFileTree({
       electionDefinition,
-      systemSettings: safeParseJson(
-        systemSettings.asText(),
-        SystemSettingsSchema
-      ).unsafeUnwrap(),
+      systemSettings: {
+        ...safeParseJson(
+          systemSettings.asText(),
+          SystemSettingsSchema
+        ).unsafeUnwrap(),
+        ...systemSettingsOverrides,
+      },
       uiStrings,
     })
   );
@@ -591,10 +596,13 @@ test('printing a blank ballot prints the pre-rendered base ballot PDF', async ()
   mockUsbDrive.insertUsbDrive(
     await mockElectionPackageFileTree({
       electionDefinition,
-      systemSettings: safeParseJson(
-        systemSettings.asText(),
-        SystemSettingsSchema
-      ).unsafeUnwrap(),
+      systemSettings: {
+        ...safeParseJson(
+          systemSettings.asText(),
+          SystemSettingsSchema
+        ).unsafeUnwrap(),
+        allowPrintingBlankBallotsFromVxMark: true,
+      },
       ballots,
     })
   );
@@ -624,7 +632,9 @@ test('printing a blank ballot prints the pre-rendered base ballot PDF', async ()
 test('printing a blank ballot throws when no ballot PDF is available', async () => {
   const electionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();
-  await configureMachine(mockUsbDrive, electionDefinition);
+  await configureMachine(mockUsbDrive, electionDefinition, undefined, {
+    allowPrintingBlankBallotsFromVxMark: true,
+  });
   mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
 
   await suppressingConsoleOutput(async () => {
@@ -635,6 +645,23 @@ test('printing a blank ballot throws when no ballot PDF is available', async () 
         languageCode: 'en',
       })
     ).rejects.toThrow('No ballot PDF found');
+  });
+});
+
+test('printing a blank ballot throws when the setting is not enabled', async () => {
+  const electionDefinition =
+    electionFamousNames2021Fixtures.readElectionDefinition();
+  await configureMachine(mockUsbDrive, electionDefinition);
+  mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
+
+  await suppressingConsoleOutput(async () => {
+    await expect(
+      apiClient.printBlankBallot({
+        ballotStyleId: '1',
+        precinctId: '23',
+        languageCode: 'en',
+      })
+    ).rejects.toThrow('Printing blank ballots from VxMark is not enabled');
   });
 });
 

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -336,6 +336,12 @@ export function buildApi(ctx: Context) {
     },
 
     async printBlankBallot(input: PrintBlankBallotProps) {
+      const systemSettings =
+        store.getSystemSettings() ?? DEFAULT_SYSTEM_SETTINGS;
+      assert(
+        systemSettings.allowPrintingBlankBallotsFromVxMark,
+        'Printing blank ballots from VxMark is not enabled'
+      );
       await printBlankBallot({
         store,
         printer,

--- a/libs/types/src/system_settings.ts
+++ b/libs/types/src/system_settings.ts
@@ -251,6 +251,11 @@ export const SystemSettingsSchema = z
      * Enables test deck printing functionality on VxPrint and VxMark.
      */
     enableTestDeckPrinting: z.boolean().optional(),
+
+    /**
+     * Allows printing blank (unmarked) ballots from VxMark.
+     */
+    allowPrintingBlankBallotsFromVxMark: z.boolean().optional(),
   })
   .refine(
     (settings) =>


### PR DESCRIPTION
## Overview

Adds a system setting for https://github.com/votingworks/vxsuite/issues/8361, but does not wire it up.

Also adds a flag to prevent showing that system setting for non-VX users until everything is landed in `main`. The flag is enabled for Vx users only.

## Demo Video or Screenshot

<img width="1672" height="1391" alt="Screenshot 2026-07-08 at 11 22 37 PM" src="https://github.com/user-attachments/assets/e9de04e9-6a24-48c1-bd5c-a4ffa40314e7" />


## Testing Plan

- added tests
- manually tested

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
