### PR TITLE
VxMark: UI for printing blank ballots

### DIFF
--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -642,7 +642,6 @@ test('printing a blank ballot throws when no ballot PDF is available', async () 
       apiClient.printBlankBallot({
         ballotStyleId: '1',
         precinctId: '23',
-        languageCode: 'en',
       })
     ).rejects.toThrow('No ballot PDF found');
   });

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -616,7 +616,6 @@ test('printing a blank ballot prints the pre-rendered base ballot PDF', async ()
   await apiClient.printBlankBallot({
     ballotStyleId: '1',
     precinctId: '23',
-    languageCode: 'en',
   });
 
   await expectElectionState({ ballotsPrintedCount: 1 });
@@ -658,7 +657,6 @@ test('printing a blank ballot throws when the setting is not enabled', async () 
       apiClient.printBlankBallot({
         ballotStyleId: '1',
         precinctId: '23',
-        languageCode: 'en',
       })
     ).rejects.toThrow('Printing blank ballots from VxMark is not enabled');
   });

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -626,6 +626,24 @@ test('printing a blank ballot prints the pre-rendered base ballot PDF', async ()
     assertDefined(mockPrinterHandler.getLastPrintPath())
   );
   expect(printedData.toString('utf-8')).toEqual(mockBallotPdfData);
+
+  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+    LogEventId.PrinterPrintRequest,
+    expect.objectContaining({
+      message: 'Printing a blank ballot',
+      ballotStyleId: '1',
+      precinctId: '23',
+    })
+  );
+  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+    LogEventId.PrinterPrintComplete,
+    expect.objectContaining({
+      message: 'Blank ballot printed',
+      disposition: 'success',
+      ballotStyleId: '1',
+      precinctId: '23',
+    })
+  );
 });
 
 test('printing a blank ballot throws when no ballot PDF is available', async () => {
@@ -644,6 +662,16 @@ test('printing a blank ballot throws when no ballot PDF is available', async () 
       })
     ).rejects.toThrow('No ballot PDF found');
   });
+
+  // The request is logged, but the completion is not, since printing failed.
+  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+    LogEventId.PrinterPrintRequest,
+    expect.objectContaining({ message: 'Printing a blank ballot' })
+  );
+  expect(logger.logAsCurrentRole).not.toHaveBeenCalledWith(
+    LogEventId.PrinterPrintComplete,
+    expect.anything()
+  );
 });
 
 test('printing a blank ballot throws when the setting is not enabled', async () => {

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -342,12 +342,23 @@ export function buildApi(ctx: Context) {
         systemSettings.allowPrintingBlankBallotsFromVxMark,
         'Printing blank ballots from VxMark is not enabled'
       );
+      await logger.logAsCurrentRole(LogEventId.PrinterPrintRequest, {
+        message: 'Printing a blank ballot',
+        ballotStyleId: input.ballotStyleId,
+        precinctId: input.precinctId,
+      });
       await printBlankBallot({
         store,
         printer,
         ...input,
       });
       store.setBallotsPrintedCount(store.getBallotsPrintedCount() + 1);
+      await logger.logAsCurrentRole(LogEventId.PrinterPrintComplete, {
+        message: 'Blank ballot printed',
+        disposition: 'success',
+        ballotStyleId: input.ballotStyleId,
+        precinctId: input.precinctId,
+      });
     },
 
     async printTestDeck({

--- a/apps/mark/backend/src/types.ts
+++ b/apps/mark/backend/src/types.ts
@@ -22,4 +22,7 @@ export interface PrintBallotProps {
   votes: VotesDict;
 }
 
-export type PrintBlankBallotProps = Omit<PrintBallotProps, 'votes'>;
+export type PrintBlankBallotProps = Omit<
+  PrintBallotProps,
+  'votes' | 'languageCode'
+>;

--- a/apps/mark/backend/src/util/print_ballot.tsx
+++ b/apps/mark/backend/src/util/print_ballot.tsx
@@ -46,7 +46,7 @@ export interface PrintBallotProps extends ClientParams {
   store: Store;
 }
 
-type PrintBlankBallotProps = Omit<PrintBallotProps, 'votes'>;
+type PrintBlankBallotProps = Omit<PrintBallotProps, 'votes' | 'languageCode'>;
 
 export async function printBallot(p: PrintBallotProps): Promise<void> {
   const { printer, store, precinctId, ballotStyleId, votes, languageCode } = p;

--- a/apps/mark/frontend/src/api.ts
+++ b/apps/mark/frontend/src/api.ts
@@ -387,7 +387,6 @@ export const printBallot = {
   },
 } as const;
 
-/* istanbul ignore next */
 export const printBlankBallot = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
@@ -7,6 +7,7 @@ import {
   anyPollingPlace,
   BallotStyleId,
   constructElectionKey,
+  DEFAULT_SYSTEM_SETTINGS,
   ElectionDefinition,
   formatElectionHashes,
   InsertedSmartCardAuth,
@@ -124,7 +125,15 @@ function renderScreen(
   );
 }
 
+function expectSystemSettings(allowPrintingBlankBallotsFromVxMark = false) {
+  apiMock.expectGetSystemSettings({
+    ...DEFAULT_SYSTEM_SETTINGS,
+    allowPrintingBlankBallotsFromVxMark,
+  });
+}
+
 test('renders PollWorkerScreen', () => {
+  expectSystemSettings();
   renderScreen(undefined, undefined, undefined);
   screen.getByText('Poll Worker Menu');
   expect(
@@ -138,6 +147,7 @@ test('switching out of test mode on election day', () => {
     ...election,
     date: DateWithoutTime.today(),
   });
+  expectSystemSettings();
   apiMock.expectSetTestMode(false);
   renderScreen({
     pollWorkerAuth: mockPollWorkerAuth(electionDefinition),
@@ -155,6 +165,7 @@ test('keeping test mode on election day', () => {
     ...election,
     date: DateWithoutTime.today(),
   });
+  expectSystemSettings();
   renderScreen({ electionDefinition });
 
   screen.getByText(
@@ -164,6 +175,7 @@ test('keeping test mode on election day', () => {
 });
 
 test('live mode on election day', () => {
+  expectSystemSettings();
   renderScreen({ isLiveMode: true });
   expect(
     screen.queryByText(
@@ -173,6 +185,7 @@ test('live mode on election day', () => {
 });
 
 test('Shows election info', () => {
+  expectSystemSettings();
   renderScreen();
   screen.getByText(election.title);
   screen.getByText(
@@ -189,6 +202,7 @@ test('renders session start section', () => {
   const activateCardlessVoterSession = vi.fn();
   const pollingPlaceId = pollingPlace.id;
 
+  expectSystemSettings();
   renderScreen({
     activateCardlessVoterSession,
     pollingPlaceId,
@@ -212,6 +226,7 @@ test('renders session start section', () => {
 });
 
 test('prints a blank ballot for the selected ballot style', async () => {
+  expectSystemSettings(true);
   apiMock.mockApiClient.printBlankBallot
     .expectCallWith({
       precinctId: MOCK_BALLOT_STYLE_PRECINCT_ID,
@@ -221,7 +236,7 @@ test('prints a blank ballot for the selected ballot style', async () => {
 
   renderScreen();
 
-  fireEvent.click(screen.getByText('Print Blank Ballot'));
+  fireEvent.click(await screen.findByText('Print Blank Ballot'));
   screen.getByText('Select a Ballot Style to Print');
 
   fireEvent.click(screen.getByText('Mock Select Ballot Style'));
@@ -244,16 +259,25 @@ test('prints a blank ballot for the selected ballot style', async () => {
   });
 });
 
-test('returns to the poll worker menu from the print blank ballot screen', () => {
+test('returns to the poll worker menu from the print blank ballot screen', async () => {
+  expectSystemSettings(true);
   renderScreen();
 
-  fireEvent.click(screen.getByText('Print Blank Ballot'));
+  fireEvent.click(await screen.findByText('Print Blank Ballot'));
   screen.getByText('Select a Ballot Style to Print');
 
   fireEvent.click(screen.getByRole('button', { name: 'Back' }));
 
   expect(screen.queryByText('Select a Ballot Style to Print')).toBeNull();
   screen.getByText('Print Blank Ballot');
+});
+
+test('hides the Print Blank Ballot button when the setting is disabled', () => {
+  expectSystemSettings(false);
+  renderScreen();
+
+  screen.getByText('Poll Worker Menu');
+  expect(screen.queryByText('Print Blank Ballot')).toBeNull();
 });
 
 const multiLanguageDefinition = getMockMultiLanguageElectionDefinition(
@@ -286,6 +310,7 @@ test('prints a blank ballot in the language chosen from the dropdown', async () 
   }).unsafeUnwrap();
   mockBallotStyleSelectReturning(englishBallotStyle.id);
 
+  expectSystemSettings(true);
   apiMock.mockApiClient.printBlankBallot
     .expectCallWith({
       precinctId: MOCK_BALLOT_STYLE_PRECINCT_ID,
@@ -299,7 +324,7 @@ test('prints a blank ballot in the language chosen from the dropdown', async () 
     multiLanguageDefinition
   );
 
-  fireEvent.click(screen.getByText('Print Blank Ballot'));
+  fireEvent.click(await screen.findByText('Print Blank Ballot'));
 
   // Selecting a ballot style reveals a language dropdown scoped to that style.
   fireEvent.click(screen.getByText('Mock Select Ballot Style'));
@@ -325,6 +350,7 @@ test('prints a blank ballot in the language chosen from the dropdown', async () 
 test('prints in the default language when the dropdown is left unchanged', async () => {
   mockBallotStyleSelectReturning(englishBallotStyle.id);
 
+  expectSystemSettings(true);
   apiMock.mockApiClient.printBlankBallot
     .expectCallWith({
       precinctId: MOCK_BALLOT_STYLE_PRECINCT_ID,
@@ -338,7 +364,7 @@ test('prints in the default language when the dropdown is left unchanged', async
     multiLanguageDefinition
   );
 
-  fireEvent.click(screen.getByText('Print Blank Ballot'));
+  fireEvent.click(await screen.findByText('Print Blank Ballot'));
   fireEvent.click(screen.getByText('Mock Select Ballot Style'));
   screen.getByText('Language');
   fireEvent.click(screen.getByText('Print Ballot'));

--- a/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
@@ -5,10 +5,12 @@ import {
 } from '@votingworks/fixtures';
 import {
   anyPollingPlace,
+  BallotStyleId,
   constructElectionKey,
   ElectionDefinition,
   formatElectionHashes,
   InsertedSmartCardAuth,
+  PrecinctId,
 } from '@votingworks/types';
 
 import {
@@ -18,12 +20,23 @@ import {
 import userEvent from '@testing-library/user-event';
 
 import { assertDefined, DateWithoutTime } from '@votingworks/basics';
+import {
+  format,
+  getMockMultiLanguageElectionDefinition,
+  getRelatedBallotStyle,
+} from '@votingworks/utils';
 import { pollWorkerComponents } from '@votingworks/mark-flow-ui';
-import { act, fireEvent, screen } from '../../test/react_testing_library';
+import {
+  act,
+  fireEvent,
+  screen,
+  waitFor,
+} from '../../test/react_testing_library';
 
 import { render } from '../../test/test_utils';
 
 import { PollWorkerScreen, PollworkerScreenProps } from './poll_worker_screen';
+import { BALLOT_PRINTING_TIMEOUT_SECONDS } from '../config/globals';
 import { mockMachineConfig } from '../../test/helpers/mock_machine_config';
 import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
 import { ApiProvider } from '../api_provider';
@@ -32,6 +45,13 @@ const MOCK_SECTION_SESSION_START_ID = 'MockSectionSessionStart';
 const MockSectionSessionStart = vi.spyOn(
   pollWorkerComponents,
   'SectionSessionStart'
+);
+
+const MOCK_BALLOT_STYLE_PRECINCT_ID = 'precinct-1' as PrecinctId;
+const MOCK_BALLOT_STYLE_ID = 'ballot-style-1' as BallotStyleId;
+const MockBallotStyleSelect = vi.spyOn(
+  pollWorkerComponents,
+  'BallotStyleSelect'
 );
 
 const electionGeneralDefinition = readElectionGeneralDefinition();
@@ -47,6 +67,17 @@ beforeEach(() => {
 
   MockSectionSessionStart.mockImplementation(() => (
     <div data-testid={MOCK_SECTION_SESSION_START_ID} />
+  ));
+
+  MockBallotStyleSelect.mockImplementation(({ onSelect }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onSelect(MOCK_BALLOT_STYLE_PRECINCT_ID, MOCK_BALLOT_STYLE_ID)
+      }
+    >
+      Mock Select Ballot Style
+    </button>
   ));
 });
 
@@ -178,4 +209,143 @@ test('renders session start section', () => {
     'some-precinct',
     'some-ballot-style'
   );
+});
+
+test('prints a blank ballot for the selected ballot style', async () => {
+  apiMock.mockApiClient.printBlankBallot
+    .expectCallWith({
+      precinctId: MOCK_BALLOT_STYLE_PRECINCT_ID,
+      ballotStyleId: MOCK_BALLOT_STYLE_ID,
+    })
+    .resolves();
+
+  renderScreen();
+
+  fireEvent.click(screen.getByText('Print Blank Ballot'));
+  screen.getByText('Select a Ballot Style to Print');
+
+  fireEvent.click(screen.getByText('Mock Select Ballot Style'));
+  fireEvent.click(screen.getByText('Print Ballot'));
+
+  // The progress modal is shown for a fixed duration, not gated on the print
+  // job (which completes near-instantly).
+  await screen.findByText('Printing Ballot');
+  expect(screen.queryByText('Ballot Printed')).toBeNull();
+
+  act(() => {
+    vi.advanceTimersByTime(BALLOT_PRINTING_TIMEOUT_SECONDS * 1000);
+  });
+
+  await screen.findByText('Ballot Printed');
+  fireEvent.click(screen.getByText('Done'));
+
+  await waitFor(() => {
+    expect(screen.queryByText('Ballot Printed')).toBeNull();
+  });
+});
+
+test('returns to the poll worker menu from the print blank ballot screen', () => {
+  renderScreen();
+
+  fireEvent.click(screen.getByText('Print Blank Ballot'));
+  screen.getByText('Select a Ballot Style to Print');
+
+  fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+
+  expect(screen.queryByText('Select a Ballot Style to Print')).toBeNull();
+  screen.getByText('Print Blank Ballot');
+});
+
+const multiLanguageDefinition = getMockMultiLanguageElectionDefinition(
+  electionGeneralDefinition,
+  ['en', 'es-US']
+);
+const multiLanguageElection = multiLanguageDefinition.election;
+const englishBallotStyle = assertDefined(
+  multiLanguageElection.ballotStyles.find(
+    (bs) => bs.languages.length === 1 && bs.languages[0] === 'en'
+  )
+);
+
+function mockBallotStyleSelectReturning(ballotStyleId: BallotStyleId) {
+  MockBallotStyleSelect.mockImplementation(({ onSelect }) => (
+    <button
+      type="button"
+      onClick={() => onSelect(MOCK_BALLOT_STYLE_PRECINCT_ID, ballotStyleId)}
+    >
+      Mock Select Ballot Style
+    </button>
+  ));
+}
+
+test('prints a blank ballot in the language chosen from the dropdown', async () => {
+  const spanishBallotStyle = getRelatedBallotStyle({
+    ballotStyles: multiLanguageElection.ballotStyles,
+    sourceBallotStyleId: englishBallotStyle.id,
+    targetBallotStyleLanguage: 'es-US',
+  }).unsafeUnwrap();
+  mockBallotStyleSelectReturning(englishBallotStyle.id);
+
+  apiMock.mockApiClient.printBlankBallot
+    .expectCallWith({
+      precinctId: MOCK_BALLOT_STYLE_PRECINCT_ID,
+      ballotStyleId: spanishBallotStyle.id,
+    })
+    .resolves();
+
+  renderScreen(
+    {},
+    mockPollWorkerAuth(multiLanguageDefinition),
+    multiLanguageDefinition
+  );
+
+  fireEvent.click(screen.getByText('Print Blank Ballot'));
+
+  // Selecting a ballot style reveals a language dropdown scoped to that style.
+  fireEvent.click(screen.getByText('Mock Select Ballot Style'));
+  screen.getByText('Language');
+
+  // Choose Spanish from the language dropdown (defaults to English).
+  userEvent.click(
+    screen.getByText(format.languageDisplayName({ languageCode: 'en' }))
+  );
+  userEvent.click(
+    screen.getByText(format.languageDisplayName({ languageCode: 'es-US' }))
+  );
+
+  fireEvent.click(screen.getByText('Print Ballot'));
+
+  await screen.findByText('Printing Ballot');
+  act(() => {
+    vi.advanceTimersByTime(BALLOT_PRINTING_TIMEOUT_SECONDS * 1000);
+  });
+  await screen.findByText('Ballot Printed');
+});
+
+test('prints in the default language when the dropdown is left unchanged', async () => {
+  mockBallotStyleSelectReturning(englishBallotStyle.id);
+
+  apiMock.mockApiClient.printBlankBallot
+    .expectCallWith({
+      precinctId: MOCK_BALLOT_STYLE_PRECINCT_ID,
+      ballotStyleId: englishBallotStyle.id,
+    })
+    .resolves();
+
+  renderScreen(
+    {},
+    mockPollWorkerAuth(multiLanguageDefinition),
+    multiLanguageDefinition
+  );
+
+  fireEvent.click(screen.getByText('Print Blank Ballot'));
+  fireEvent.click(screen.getByText('Mock Select Ballot Style'));
+  screen.getByText('Language');
+  fireEvent.click(screen.getByText('Print Ballot'));
+
+  await screen.findByText('Printing Ballot');
+  act(() => {
+    vi.advanceTimersByTime(BALLOT_PRINTING_TIMEOUT_SECONDS * 1000);
+  });
+  await screen.findByText('Ballot Printed');
 });

--- a/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
@@ -237,7 +237,7 @@ test('prints a blank ballot for the selected ballot style', async () => {
   renderScreen();
 
   fireEvent.click(await screen.findByText('Print Blank Ballot'));
-  screen.getByText('Select a Ballot Style to Print');
+  screen.getByText('Ballot Style');
 
   fireEvent.click(screen.getByText('Mock Select Ballot Style'));
   fireEvent.click(screen.getByText('Print Ballot'));
@@ -264,11 +264,11 @@ test('returns to the poll worker menu from the print blank ballot screen', async
   renderScreen();
 
   fireEvent.click(await screen.findByText('Print Blank Ballot'));
-  screen.getByText('Select a Ballot Style to Print');
+  screen.getByText('Ballot Style');
 
   fireEvent.click(screen.getByRole('button', { name: 'Back' }));
 
-  expect(screen.queryByText('Select a Ballot Style to Print')).toBeNull();
+  expect(screen.queryByText('Ballot Style')).toBeNull();
   screen.getByText('Print Blank Ballot');
 });
 

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -61,7 +61,6 @@ export function PollWorkerScreen({
     ScreenVotingInProgress,
     SectionHeader,
     SectionPollsState,
-    SectionPrintBlankBallot,
     SectionSessionStart,
     SectionSystem,
   } = pollWorkerComponents;
@@ -151,7 +150,9 @@ export function PollWorkerScreen({
             />
           )}
           {allowPrintingBlankBallots && (
-            <SectionPrintBlankBallot onPress={onPressPrintBlankBallot} />
+            <Button onPress={onPressPrintBlankBallot}>
+              Print Blank Ballot
+            </Button>
           )}
           <SectionPollsState
             pollsState={pollsState}

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -17,7 +17,12 @@ import type { MachineConfig } from '@votingworks/mark-backend';
 
 import { pollWorkerComponents } from '@votingworks/mark-flow-ui';
 import React from 'react';
-import { setPollsState, setTestMode, useApiClient } from '../api';
+import {
+  getSystemSettings,
+  setPollsState,
+  setTestMode,
+  useApiClient,
+} from '../api';
 import { PrintBlankBallotScreen } from './print_blank_ballot_screen';
 
 export interface PollworkerScreenProps {
@@ -66,8 +71,13 @@ export function PollWorkerScreen({
     React.useState(false);
 
   const apiClient = useApiClient();
+  const systemSettingsQuery = getSystemSettings.useQuery();
   const setPollsStateMutation = setPollsState.useMutation();
   const setTestModeMutation = setTestMode.useMutation();
+
+  const allowPrintingBlankBallots = Boolean(
+    systemSettingsQuery.data?.allowPrintingBlankBallotsFromVxMark
+  );
 
   const onChooseBallotStyle = React.useCallback(
     (precinctId: PrecinctId, ballotStyleId: BallotStyleId) => {
@@ -140,7 +150,9 @@ export function PollWorkerScreen({
               pollingPlaceId={pollingPlaceId}
             />
           )}
-          <SectionPrintBlankBallot onPress={onPressPrintBlankBallot} />
+          {allowPrintingBlankBallots && (
+            <SectionPrintBlankBallot onPress={onPressPrintBlankBallot} />
+          )}
           <SectionPollsState
             pollsState={pollsState}
             updatePollsState={(newPollsState) =>

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -125,7 +125,6 @@ export function PollWorkerScreen({
     return (
       <PrintBlankBallotScreen
         isLiveMode={isLiveMode}
-        ballotsPrintedCount={ballotsPrintedCount}
         election={election}
         electionPackageHash={electionPackageHash}
         electionDefinition={electionDefinition}

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -18,6 +18,7 @@ import type { MachineConfig } from '@votingworks/mark-backend';
 import { pollWorkerComponents } from '@votingworks/mark-flow-ui';
 import React from 'react';
 import { setPollsState, setTestMode, useApiClient } from '../api';
+import { PrintBlankBallotScreen } from './print_blank_ballot_screen';
 
 export interface PollworkerScreenProps {
   pollWorkerAuth: InsertedSmartCardAuth.PollWorkerLoggedIn;
@@ -55,11 +56,14 @@ export function PollWorkerScreen({
     ScreenVotingInProgress,
     SectionHeader,
     SectionPollsState,
+    SectionPrintBlankBallot,
     SectionSessionStart,
     SectionSystem,
   } = pollWorkerComponents;
-
   const { election } = electionDefinition;
+
+  const [showPrintBlankBallotScreen, setShowPrintBlankBallotScreen] =
+    React.useState(false);
 
   const apiClient = useApiClient();
   const setPollsStateMutation = setPollsState.useMutation();
@@ -71,6 +75,10 @@ export function PollWorkerScreen({
     },
     [activateCardlessVoterSession]
   );
+
+  const onPressPrintBlankBallot = React.useCallback(() => {
+    setShowPrintBlankBallotScreen(true);
+  }, []);
 
   if (hasVotes && pollWorkerAuth.cardlessVoterUser) {
     return (
@@ -104,6 +112,21 @@ export function PollWorkerScreen({
     );
   }
 
+  if (showPrintBlankBallotScreen) {
+    return (
+      <PrintBlankBallotScreen
+        isLiveMode={isLiveMode}
+        ballotsPrintedCount={ballotsPrintedCount}
+        election={election}
+        electionPackageHash={electionPackageHash}
+        electionDefinition={electionDefinition}
+        machineConfig={machineConfig}
+        pollingPlaceId={pollingPlaceId}
+        onBackButtonPress={() => setShowPrintBlankBallotScreen(false)}
+      />
+    );
+  }
+
   return (
     <Screen>
       {!isLiveMode && <TestModeBanner />}
@@ -117,6 +140,7 @@ export function PollWorkerScreen({
               pollingPlaceId={pollingPlaceId}
             />
           )}
+          <SectionPrintBlankBallot onPress={onPressPrintBlankBallot} />
           <SectionPollsState
             pollsState={pollsState}
             updatePollsState={(newPollsState) =>

--- a/apps/mark/frontend/src/pages/print_blank_ballot_screen.tsx
+++ b/apps/mark/frontend/src/pages/print_blank_ballot_screen.tsx
@@ -27,14 +27,23 @@ import {
   Modal,
   Loading,
   SearchSelect,
+  H2,
 } from '@votingworks/ui';
+
+import styled from 'styled-components';
 
 import { BALLOT_PRINTING_TIMEOUT_SECONDS } from '../config/globals';
 import { printBlankBallot } from '../api';
 
+const Contents = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+`;
+
 export interface PrintBlankBallotScreenProps {
   isLiveMode: boolean;
-  ballotsPrintedCount: number;
   electionPackageHash: string;
   electionDefinition: ElectionDefinition;
   election: Election;
@@ -45,7 +54,6 @@ export interface PrintBlankBallotScreenProps {
 
 export function PrintBlankBallotScreen({
   isLiveMode,
-  ballotsPrintedCount,
   electionPackageHash,
   electionDefinition,
   election,
@@ -53,7 +61,7 @@ export function PrintBlankBallotScreen({
   pollingPlaceId,
   onBackButtonPress,
 }: PrintBlankBallotScreenProps): JSX.Element {
-  const { BallotStyleSelect, SectionHeader } = pollWorkerComponents;
+  const { BallotStyleSelect } = pollWorkerComponents;
   const printBlankBallotMutation = printBlankBallot.useMutation();
 
   const [printStatus, setPrintStatus] = React.useState<
@@ -124,62 +132,50 @@ export function PrintBlankBallotScreen({
     <Screen>
       {!isLiveMode && <TestModeBanner />}
       <Main padded>
-        <div>
-          <SectionHeader
-            ballotsPrintedCount={ballotsPrintedCount}
-            hideRemoveCardMessage
-          />
-          <P>
-            <Button icon="Previous" onPress={onBackButtonPress}>
-              Back
-            </Button>
-          </P>
-          <H4 as="h2">Select a Ballot Style to Print</H4>
+        <Contents>
+          <H2 as="h1">Blank Ballot Printing</H2>
+          <Button icon="Previous" onPress={onBackButtonPress}>
+            Back
+          </Button>
+          <H4 as="h2">Ballot Style</H4>
           <BallotStyleSelect
             election={election}
             onSelect={onChooseBallotStyle}
             disabled={printStatus !== 'idle'}
+            selectedBallotStyleId={selection?.ballotStyleId}
             configuredPrecinctsAndSplits={getConfiguredPrecinctsAndSplits({
               election,
               pollingPlaceId,
             })}
           />
-          {selection && (
+          {selection && showLanguagePicker && (
             <React.Fragment>
-              {showLanguagePicker && (
-                <React.Fragment>
-                  <H4 as="h2">Language</H4>
-                  <P>
-                    <SearchSelect
-                      aria-label="Ballot language"
-                      options={languageOptions.map((languageCode) => ({
-                        value: languageCode,
-                        label: format.languageDisplayName({ languageCode }),
-                      }))}
-                      value={selectedLanguage}
-                      onChange={(value) => {
-                        if (value) {
-                          setSelectedLanguage(value);
-                        }
-                      }}
-                      style={{ width: '100%' }}
-                      disabled={printStatus !== 'idle'}
-                    />
-                  </P>
-                </React.Fragment>
-              )}
-              <P>
-                <Button
-                  variant="primary"
-                  onPress={onPrint}
-                  disabled={printStatus !== 'idle'}
-                >
-                  Print Ballot
-                </Button>
-              </P>
+              <H4 as="h2">Language</H4>
+              <SearchSelect
+                aria-label="Ballot language"
+                options={languageOptions.map((languageCode) => ({
+                  value: languageCode,
+                  label: format.languageDisplayName({ languageCode }),
+                }))}
+                value={selectedLanguage}
+                onChange={(value) => {
+                  if (value) {
+                    setSelectedLanguage(value);
+                  }
+                }}
+                style={{ width: '100%' }}
+                disabled={printStatus !== 'idle'}
+              />
             </React.Fragment>
           )}
-        </div>
+          <Button
+            variant="primary"
+            onPress={onPrint}
+            disabled={printStatus !== 'idle'}
+          >
+            Print Ballot
+          </Button>
+        </Contents>
       </Main>
       {printStatus === 'printing' && (
         <Modal centerContent content={<Loading>Printing Ballot</Loading>} />

--- a/apps/mark/frontend/src/pages/print_blank_ballot_screen.tsx
+++ b/apps/mark/frontend/src/pages/print_blank_ballot_screen.tsx
@@ -1,0 +1,204 @@
+import React from 'react';
+
+import {
+  BallotStyleId,
+  Election,
+  ElectionDefinition,
+  getConfiguredPrecinctsAndSplits,
+  LanguageCode,
+  PrecinctId,
+} from '@votingworks/types';
+import { assertDefined } from '@votingworks/basics';
+import {
+  format,
+  getLanguageOptions,
+  getRelatedBallotStyle,
+} from '@votingworks/utils';
+import { MachineConfig } from '@votingworks/mark-backend';
+import { pollWorkerComponents } from '@votingworks/mark-flow-ui';
+import {
+  Button,
+  Main,
+  Screen,
+  ElectionInfoBar,
+  TestModeBanner,
+  P,
+  H4,
+  Modal,
+  Loading,
+  SearchSelect,
+} from '@votingworks/ui';
+
+import { BALLOT_PRINTING_TIMEOUT_SECONDS } from '../config/globals';
+import { printBlankBallot } from '../api';
+
+export interface PrintBlankBallotScreenProps {
+  isLiveMode: boolean;
+  ballotsPrintedCount: number;
+  electionPackageHash: string;
+  electionDefinition: ElectionDefinition;
+  election: Election;
+  machineConfig: MachineConfig;
+  pollingPlaceId: string;
+  onBackButtonPress: () => void;
+}
+
+export function PrintBlankBallotScreen({
+  isLiveMode,
+  ballotsPrintedCount,
+  electionPackageHash,
+  electionDefinition,
+  election,
+  machineConfig,
+  pollingPlaceId,
+  onBackButtonPress,
+}: PrintBlankBallotScreenProps): JSX.Element {
+  const { BallotStyleSelect, SectionHeader } = pollWorkerComponents;
+  const printBlankBallotMutation = printBlankBallot.useMutation();
+
+  const [printStatus, setPrintStatus] = React.useState<
+    'idle' | 'printing' | 'printed'
+  >('idle');
+  const [selection, setSelection] = React.useState<{
+    precinctId: PrecinctId;
+    ballotStyleId: BallotStyleId;
+  }>();
+  const [selectedLanguage, setSelectedLanguage] =
+    React.useState<LanguageCode>();
+  const printTimer = React.useRef(0);
+
+  React.useEffect(() => () => clearTimeout(printTimer.current), []);
+
+  // Language is encoded in the ballot style ID, so the languages a ballot style
+  // is available in are the ones whose language-specific variant exists in its
+  // group.
+  const availableLanguagesFor = React.useCallback(
+    (ballotStyleId: BallotStyleId): LanguageCode[] =>
+      getLanguageOptions(election).filter((languageCode) =>
+        getRelatedBallotStyle({
+          ballotStyles: election.ballotStyles,
+          sourceBallotStyleId: ballotStyleId,
+          targetBallotStyleLanguage: languageCode,
+        }).isOk()
+      ),
+    [election]
+  );
+
+  const startPrint = React.useCallback(
+    (precinctId: PrecinctId, ballotStyleId: BallotStyleId) => {
+      printBlankBallotMutation.mutate({ precinctId, ballotStyleId });
+      setPrintStatus('printing');
+      printTimer.current = window.setTimeout(() => {
+        setPrintStatus('printed');
+      }, BALLOT_PRINTING_TIMEOUT_SECONDS * 1000);
+    },
+    [printBlankBallotMutation]
+  );
+
+  const onChooseBallotStyle = React.useCallback(
+    (precinctId: PrecinctId, ballotStyleId: BallotStyleId) => {
+      setSelection({ precinctId, ballotStyleId });
+      setSelectedLanguage(availableLanguagesFor(ballotStyleId)[0]);
+    },
+    [availableLanguagesFor]
+  );
+
+  const languageOptions = selection
+    ? availableLanguagesFor(selection.ballotStyleId)
+    : [];
+  const showLanguagePicker = languageOptions.length > 1;
+
+  const onPrint = React.useCallback(() => {
+    const { precinctId, ballotStyleId } = assertDefined(selection);
+    const resolvedBallotStyleId = showLanguagePicker
+      ? getRelatedBallotStyle({
+          ballotStyles: election.ballotStyles,
+          sourceBallotStyleId: ballotStyleId,
+          targetBallotStyleLanguage: assertDefined(selectedLanguage),
+        }).unsafeUnwrap().id
+      : ballotStyleId;
+    startPrint(precinctId, resolvedBallotStyleId);
+  }, [election, selectedLanguage, selection, showLanguagePicker, startPrint]);
+
+  return (
+    <Screen>
+      {!isLiveMode && <TestModeBanner />}
+      <Main padded>
+        <div>
+          <SectionHeader
+            ballotsPrintedCount={ballotsPrintedCount}
+            hideRemoveCardMessage
+          />
+          <P>
+            <Button icon="Previous" onPress={onBackButtonPress}>
+              Back
+            </Button>
+          </P>
+          <H4 as="h2">Select a Ballot Style to Print</H4>
+          <BallotStyleSelect
+            election={election}
+            onSelect={onChooseBallotStyle}
+            disabled={printStatus !== 'idle'}
+            configuredPrecinctsAndSplits={getConfiguredPrecinctsAndSplits({
+              election,
+              pollingPlaceId,
+            })}
+          />
+          {selection && (
+            <React.Fragment>
+              {showLanguagePicker && (
+                <React.Fragment>
+                  <H4 as="h2">Language</H4>
+                  <P>
+                    <SearchSelect
+                      aria-label="Ballot language"
+                      options={languageOptions.map((languageCode) => ({
+                        value: languageCode,
+                        label: format.languageDisplayName({ languageCode }),
+                      }))}
+                      value={selectedLanguage}
+                      onChange={(value) => {
+                        if (value) {
+                          setSelectedLanguage(value);
+                        }
+                      }}
+                      style={{ width: '100%' }}
+                      disabled={printStatus !== 'idle'}
+                    />
+                  </P>
+                </React.Fragment>
+              )}
+              <P>
+                <Button
+                  variant="primary"
+                  onPress={onPrint}
+                  disabled={printStatus !== 'idle'}
+                >
+                  Print Ballot
+                </Button>
+              </P>
+            </React.Fragment>
+          )}
+        </div>
+      </Main>
+      {printStatus === 'printing' && (
+        <Modal centerContent content={<Loading>Printing Ballot</Loading>} />
+      )}
+      {printStatus === 'printed' && (
+        <Modal
+          title="Ballot Printed"
+          content={<P>Remove the printed ballot from the printer.</P>}
+          actions={<Button onPress={() => setPrintStatus('idle')}>Done</Button>}
+        />
+      )}
+      <ElectionInfoBar
+        mode="pollworker"
+        electionDefinition={electionDefinition}
+        electionPackageHash={electionPackageHash}
+        codeVersion={machineConfig.codeVersion}
+        machineId={machineConfig.machineId}
+        pollingPlaceId={pollingPlaceId}
+      />
+    </Screen>
+  );
+}

--- a/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.test.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.test.tsx
@@ -35,6 +35,23 @@ describe('general election', () => {
     expect(onSelect).toHaveBeenCalledWith(precinct.id, ballotStyle.id);
   });
 
+  test('highlights the selected precinct button', () => {
+    const precinct = election.precincts[0];
+    const ballotStyle = election.ballotStyles[0];
+
+    renderSelect({
+      election,
+      onSelect: vi.fn(),
+      configuredPrecinctsAndSplits: toPrecinctsOrSplitList([precinct]),
+      selectedBallotStyleId: ballotStyle.id,
+    });
+
+    expect(screen.getButton(precinct.name)).toHaveAttribute(
+      'data-variant',
+      'primary'
+    );
+  });
+
   test('single precinct configuration with splits', () => {
     const precinct = election.precincts[1];
     assert(hasSplits(precinct));
@@ -114,6 +131,23 @@ describe('primary election', () => {
     userEvent.click(screen.getButton('Mammal'));
     expect(onSelect).toHaveBeenCalledOnce();
     expect(onSelect).toHaveBeenCalledWith(precinct.id, '1-Ma_en');
+  });
+
+  test('highlights the selected party button', () => {
+    const precinct = election.precincts[0];
+
+    renderSelect({
+      election,
+      onSelect: vi.fn(),
+      configuredPrecinctsAndSplits: toPrecinctsOrSplitList([precinct]),
+      selectedBallotStyleId: '1-Ma_en',
+    });
+
+    expect(screen.getButton('Mammal')).toHaveAttribute(
+      'data-variant',
+      'primary'
+    );
+    expect(screen.getButton('Fish')).toHaveAttribute('data-variant', 'neutral');
   });
 
   test('single precinct configuration with splits', () => {

--- a/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.tsx
@@ -23,10 +23,18 @@ export interface BallotStyleSelectProps {
   configuredPrecinctsAndSplits: PrecinctOrSplit[];
   onSelect: OnBallotStyleSelect;
   disabled?: boolean;
+  /** Highlights the button for this ballot style, if any, as selected. */
+  selectedBallotStyleId?: BallotStyleId;
 }
 
 export function BallotStyleSelect(props: BallotStyleSelectProps): JSX.Element {
-  const { election, configuredPrecinctsAndSplits, onSelect, disabled } = props;
+  const {
+    election,
+    configuredPrecinctsAndSplits,
+    onSelect,
+    disabled,
+    selectedBallotStyleId,
+  } = props;
 
   // Only used for primary elections
   const [selectedPrecinctOrSplitId, setSelectedPrecinctOrSplitId] = useState<
@@ -49,16 +57,16 @@ export function BallotStyleSelect(props: BallotStyleSelectProps): JSX.Element {
     if (configuredPrecinctsAndSplits.length === 1) {
       const [precinctOrSplit] = configuredPrecinctsAndSplits;
       const { precinct } = precinctOrSplit;
+      const ballotStyleId =
+        getBallotStyleForPrecinctOrSplit(precinctOrSplit).id;
       return (
         <Button
-          onPress={() =>
-            onSelect(
-              precinct.id,
-              getBallotStyleForPrecinctOrSplit(precinctOrSplit).id
-            )
-          }
+          onPress={() => onSelect(precinct.id, ballotStyleId)}
           rightIcon="Next"
           disabled={disabled}
+          variant={
+            ballotStyleId === selectedBallotStyleId ? 'primary' : 'neutral'
+          }
         >
           {precinct.name}
         </Button>
@@ -150,6 +158,11 @@ export function BallotStyleSelect(props: BallotStyleSelectProps): JSX.Element {
                     onSelect(selectedPrecinctOrSplit.precinct.id, ballotStyleId)
                   }
                   disabled={disabled}
+                  variant={
+                    ballotStyleId === selectedBallotStyleId
+                      ? 'primary'
+                      : 'neutral'
+                  }
                 >
                   {
                     assertDefined(

--- a/libs/mark-flow-ui/src/components/poll_worker/sections.test.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/sections.test.tsx
@@ -7,8 +7,9 @@ import {
   pollingPlaceMembers,
 } from '@votingworks/types';
 import { assertDefined } from '@votingworks/basics';
+import userEvent from '@testing-library/user-event';
 import { render, screen } from '../../../test/react_testing_library';
-import { SectionSessionStart } from './sections';
+import { SectionPrintBlankBallot, SectionSessionStart } from './sections';
 import {
   BallotStyleSelect,
   BallotStyleSelectProps,
@@ -86,5 +87,15 @@ describe('SectionSessionStart', () => {
       election: electionMod,
       onSelect,
     });
+  });
+});
+
+describe('SectionPrintBlankBallot', () => {
+  test('calls onPress when pressed', () => {
+    const onPress = vi.fn();
+    render(<SectionPrintBlankBallot onPress={onPress} />);
+
+    userEvent.click(screen.getButton('Print Blank Ballot'));
+    expect(onPress).toHaveBeenCalledOnce();
   });
 });

--- a/libs/mark-flow-ui/src/components/poll_worker/sections.test.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/sections.test.tsx
@@ -7,9 +7,8 @@ import {
   pollingPlaceMembers,
 } from '@votingworks/types';
 import { assertDefined } from '@votingworks/basics';
-import userEvent from '@testing-library/user-event';
 import { render, screen } from '../../../test/react_testing_library';
-import { SectionPrintBlankBallot, SectionSessionStart } from './sections';
+import { SectionSessionStart } from './sections';
 import {
   BallotStyleSelect,
   BallotStyleSelectProps,
@@ -87,15 +86,5 @@ describe('SectionSessionStart', () => {
       election: electionMod,
       onSelect,
     });
-  });
-});
-
-describe('SectionPrintBlankBallot', () => {
-  test('calls onPress when pressed', () => {
-    const onPress = vi.fn();
-    render(<SectionPrintBlankBallot onPress={onPress} />);
-
-    userEvent.click(screen.getButton('Print Blank Ballot'));
-    expect(onPress).toHaveBeenCalledOnce();
   });
 });

--- a/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
@@ -17,8 +17,7 @@ import {
 } from '@votingworks/utils';
 import {
   Election,
-  pollingPlaceFromElection,
-  pollingPlaceMembers,
+  getConfiguredPrecinctsAndSplits,
   PollsState,
 } from '@votingworks/types';
 import { BallotStyleSelect, OnBallotStyleSelect } from './ballot_style_select';
@@ -80,14 +79,6 @@ export interface SectionSessionStartProps {
   onChooseBallotStyle: OnBallotStyleSelect;
   pollingPlaceId: string;
   disabled?: boolean;
-}
-
-function getConfiguredPrecinctsAndSplits(p: {
-  election: Election;
-  pollingPlaceId: string;
-}) {
-  const pollingPlace = pollingPlaceFromElection(p.election, p.pollingPlaceId);
-  return pollingPlaceMembers(p.election, pollingPlace);
 }
 
 export function SectionSessionStart(

--- a/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
@@ -26,19 +26,16 @@ import { UpdatePollsButton } from './update_polls_button';
 
 export interface HeaderProps {
   ballotsPrintedCount: number;
-  hideRemoveCardMessage?: boolean;
 }
 
 /* istanbul ignore next - currently tested via apps. */
 export function SectionHeader(props: HeaderProps): JSX.Element {
-  const { ballotsPrintedCount, hideRemoveCardMessage } = props;
+  const { ballotsPrintedCount } = props;
 
   return (
     <React.Fragment>
       <H2 as="h1">Poll Worker Menu</H2>
-      {!hideRemoveCardMessage && (
-        <P>Remove the poll worker card to leave this screen.</P>
-      )}
+      <P>Remove the poll worker card to leave this screen.</P>
       <P style={{ fontSize: '1.2em' }}>
         <Font weight="bold">Ballots Printed:</Font>{' '}
         {format.count(ballotsPrintedCount)}

--- a/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   Font,
   H2,
   H3,
@@ -103,6 +104,16 @@ export function SectionSessionStart(
       />
     </VotingSession>
   );
+}
+
+export interface SectionPrintBlankBallotProps {
+  onPress: () => void;
+}
+
+export function SectionPrintBlankBallot({
+  onPress,
+}: SectionPrintBlankBallotProps): JSX.Element {
+  return <Button onPress={onPress}>Print Blank Ballot</Button>;
 }
 
 interface SystemButtonsProps {

--- a/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
@@ -26,16 +26,19 @@ import { UpdatePollsButton } from './update_polls_button';
 
 export interface HeaderProps {
   ballotsPrintedCount: number;
+  hideRemoveCardMessage?: boolean;
 }
 
 /* istanbul ignore next - currently tested via apps. */
 export function SectionHeader(props: HeaderProps): JSX.Element {
-  const { ballotsPrintedCount } = props;
+  const { ballotsPrintedCount, hideRemoveCardMessage } = props;
 
   return (
     <React.Fragment>
       <H2 as="h1">Poll Worker Menu</H2>
-      <P>Remove the poll worker card to leave this screen.</P>
+      {!hideRemoveCardMessage && (
+        <P>Remove the poll worker card to leave this screen.</P>
+      )}
       <P style={{ fontSize: '1.2em' }}>
         <Font weight="bold">Ballots Printed:</Font>{' '}
         {format.count(ballotsPrintedCount)}

--- a/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/sections.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   Font,
   H2,
   H3,
@@ -104,16 +103,6 @@ export function SectionSessionStart(
       />
     </VotingSession>
   );
-}
-
-export interface SectionPrintBlankBallotProps {
-  onPress: () => void;
-}
-
-export function SectionPrintBlankBallot({
-  onPress,
-}: SectionPrintBlankBallotProps): JSX.Element {
-  return <Button onPress={onPress}>Print Blank Ballot</Button>;
 }
 
 interface SystemButtonsProps {

--- a/libs/types/src/polling_places.ts
+++ b/libs/types/src/polling_places.ts
@@ -117,6 +117,14 @@ export function pollingPlaceGroups(
   return groups;
 }
 
+export function getConfiguredPrecinctsAndSplits(p: {
+  election: Election;
+  pollingPlaceId: string;
+}): PrecinctOrSplit[] {
+  const pollingPlace = pollingPlaceFromElection(p.election, p.pollingPlaceId);
+  return pollingPlaceMembers(p.election, pollingPlace);
+}
+
 /**
  * All precincts and/or splits in the given election covered by the given
  * polling place.


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/8361

Adds UI gated behind a system setting to allow printing of blank ballots from VxMark.

## Demo Video or Screenshot

When multiple languages are available:

https://github.com/user-attachments/assets/7085e881-b71d-493a-bec8-42304bc96867

When only 1 language is available:

https://github.com/user-attachments/assets/46f5aa5b-49c7-4489-b40b-13e9ddd7d868


## Testing Plan
- added tests

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
