### PR TITLE
Don't rely on callers to provide contests to BmdPaperBallot in canonical order

### DIFF
--- a/libs/ballot-encoder/src/index.test.ts
+++ b/libs/ballot-encoder/src/index.test.ts
@@ -222,6 +222,52 @@ test('encodes & decodes multi-page summary ballot with votes', () => {
   expect(decoded.votes).toEqual(votes);
 });
 
+test('encodes votes in canonical order even when caller passes them out of order', () => {
+  const electionDefinition = readElectionDefinition();
+  const { election, ballotHash } = electionDefinition;
+  const ballotStyle = election.ballotStyles.find((bs) => bs.id === '12')!;
+  const precinct = election.precincts[0]!;
+  const canonicalContests = getContests({ election, ballotStyle });
+
+  // Give each contest a distinct selection so that an incorrectly ordered
+  // decode can't coincidentally round-trip to the same bits
+  const votes: VotesDict = {};
+  for (const [i, contest] of canonicalContests.entries()) {
+    if (contest.type === 'candidate') {
+      votes[contest.id] =
+        contest.allowWriteIns && i % 3 === 0
+          ? [{ id: 'write-in-WRITE IN', name: 'WRITE IN', isWriteIn: true }]
+          : [contest.candidates[i % contest.candidates.length]!];
+    }
+  }
+
+  const scrambledContests = [...canonicalContests].reverse();
+  expect(scrambledContests.map((c) => c.id)).not.toEqual(
+    canonicalContests.map((c) => c.id)
+  );
+  const page: SummaryBallotPage = {
+    ballotHash,
+    ballotStyleId: ballotStyle.id,
+    precinctId: precinct.id,
+    isTestMode: true,
+    ballotType: BallotType.Precinct,
+    pageNumber: 1,
+    totalPages: 1,
+    ballotAuditId: 'test-audit-id',
+    contests: scrambledContests,
+    votes,
+  };
+  const encoded = encodeSummaryBallotPage(election, page);
+  const decoded = decodeSummaryBallotPage(electionDefinition, encoded);
+
+  expect(decoded.metadata.contestIds).toEqual(
+    canonicalContests.map((c) => c.id)
+  );
+  for (const [contestId, expectedVote] of Object.entries(votes)) {
+    expect(decoded.votes[contestId]).toEqual(expectedVote);
+  }
+});
+
 test('encodes & decodes multi-page summary ballot with write-in votes', () => {
   const electionDefinition = readElectionDefinition();
   const { election, ballotHash } = electionDefinition;

--- a/libs/ballot-encoder/src/index.ts
+++ b/libs/ballot-encoder/src/index.ts
@@ -460,7 +460,12 @@ export interface SummaryBallotPage {
   pageNumber: number;
   totalPages: number;
   ballotAuditId: string;
-  /** The contests included on this page */
+  /**
+   * The contests included on this page
+   * TODO: Change this to a list of contest IDs rather than contest objects
+   * since that's all we need. We can and should look up the whole contest
+   * objects via the election def for the given ballot style ID.
+   */
   contests: readonly Contest[];
   /** Votes for the contests on this page */
   votes: VotesDict;

--- a/libs/ballot-encoder/src/index.ts
+++ b/libs/ballot-encoder/src/index.ts
@@ -535,7 +535,14 @@ export function encodeSummaryBallotPageInto(
 
   // Encode which contests are on this page as a bitmap
   // One bit per contest in the ballot style, true if contest is on this page
-  const contestsOnPage = new Set(contests.map((c) => c.id));
+  const contestIdsOnPage = new Set(contests.map((c) => c.id));
+
+  // Encode votes in canonical `getContests` order, which is the order the
+  // decoder expects them in. Don't rely on callers to handle this ordering
+  // themselves.
+  const contestsOnPageInCanonicalOrder = allContests.filter((c) =>
+    contestIdsOnPage.has(c.id)
+  );
 
   return bits
     .writeUint8(...SummaryBallotPrelude)
@@ -562,11 +569,13 @@ export function encodeSummaryBallotPageInto(
     .with(() => {
       // Write contest bitmap: which contests are on this page
       for (const contest of allContests) {
-        bits.writeBoolean(contestsOnPage.has(contest.id));
+        bits.writeBoolean(contestIdsOnPage.has(contest.id));
       }
       return bits;
     })
-    .with(() => encodeBallotVotesInto(contests, votes, bits));
+    .with(() =>
+      encodeBallotVotesInto(contestsOnPageInCanonicalOrder, votes, bits)
+    );
 }
 
 /**

--- a/libs/ui/src/bmd_paper_ballot.tsx
+++ b/libs/ui/src/bmd_paper_ballot.tsx
@@ -724,6 +724,12 @@ export function BmdPaperBallot({
   pageNumber,
   totalPages,
   ballotAuditId,
+  /**
+   * The contests included on this page
+   * TODO: Change this to a list of contest IDs rather than contest objects
+   * since that's all we need. We can and should look up the whole contest
+   * objects via the election def for the given ballot style ID.
+   */
   contestsForPage,
 }: BmdPaperBallotProps): JSX.Element {
   const {

--- a/libs/ui/src/bmd_paper_ballot.tsx
+++ b/libs/ui/src/bmd_paper_ballot.tsx
@@ -724,7 +724,7 @@ export function BmdPaperBallot({
   pageNumber,
   totalPages,
   ballotAuditId,
-  contestsForPage: contests,
+  contestsForPage,
 }: BmdPaperBallotProps): JSX.Element {
   const {
     election,
@@ -734,6 +734,15 @@ export function BmdPaperBallot({
   const ballotStyle = getBallotStyle({ ballotStyleId, election });
   assert(ballotStyle);
   const primaryBallotLanguage = assertDefined(ballotStyle.languages[0]);
+
+  // The ballot encoder canonicalizes order internally, but we still want to
+  // canonicalize the order here too so that the contests on the ballot are
+  // rendered in a consistent, expected order.
+  const contestIdsForPage = new Set(contestsForPage.map((c) => c.id));
+  const contestsForPageInCanonicalOrder = getContests({
+    ballotStyle,
+    election,
+  }).filter((c) => contestIdsForPage.has(c.id));
 
   const precinctOrSplit = find(
     getPrecinctsAndSplitsForBallotStyle({ election, ballotStyle }),
@@ -754,14 +763,16 @@ export function BmdPaperBallot({
     pageNumber,
     totalPages,
     ballotAuditId,
-    contests,
+    contests: contestsForPageInCanonicalOrder,
   });
 
   const ballotLayout =
     layout ??
     getLayout(machineType, ballotStyleId, electionDefinition).unsafeUnwrap();
 
-  const numColumns = Math.ceil(contests.length / ballotLayout.maxRows);
+  const numColumns = Math.ceil(
+    contestsForPageInCanonicalOrder.length / ballotLayout.maxRows
+  );
 
   const isCombinedBallotPrimaryElection = isCombinedBallotPrimary(election);
 
@@ -868,14 +879,17 @@ export function BmdPaperBallot({
               </div>
             </div>
             <QrCode
-              level={qrCodeLevelOverride(contests, votes)}
+              level={qrCodeLevelOverride(
+                contestsForPageInCanonicalOrder,
+                votes
+              )}
               value={fromByteArray(encodedBallot)}
             />
           </QrCodeContainer>
         </Header>
         <Content layout={ballotLayout}>
           <BallotSelections numColumns={numColumns}>
-            {contests.map((contest) => {
+            {contestsForPageInCanonicalOrder.map((contest) => {
               const contestParty =
                 isCombinedBallotPrimaryElection &&
                 contest.type === 'candidate' &&


### PR DESCRIPTION
## Overview

https://votingworks.slack.com/archives/CJU9MSC6S/p1783555871491809

I recently generated a summary ballot test deck on VxMark, and on scanning, two of the ballots crashed the interpreter:

```
Error: unexpected data found while reading padding, expected EOF\n    at readPaddingToEnd
```

This uncovered an assumption in the BmdPaperBallot component code. The component assumes that callers will provide contests in canonical order. While callers typically do this, summary ballot test deck generation is not. This resulted in summary ballots that could either crash interpretation or, even worse, be misinterpreted because of a mismatch in expectations between the ballot encoder and decoder. The decoder always assumes canonical order.

Rather than updating that one caller, I updated the ballot encoder to canonicalize order such that its outputs are always compatible with the ballot decoder.

## Testing Plan

- [x] Generated a summary ballot test deck on VxMark, scanned, and verified tallies
- [x] Added an automated test

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [ ] ~I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~