### PR TITLE
VxMark: Don't block on missing/unreachable barcode reader

### DIFF
--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -62,7 +62,6 @@ import {
   getPrinterStatus,
   getAccessibleControllerConnected,
   useApiClient,
-  getBarcodeConnected,
   getPatInputConnected,
 } from './api';
 
@@ -207,8 +206,6 @@ export function AppRoot(): JSX.Element | null {
   const accessibleControllerConnected = Boolean(
     accessibleControllerConnectedQuery.data
   );
-  const barcodeConnectedQuery = getBarcodeConnected.useQuery();
-  const barcodeConnected = Boolean(barcodeConnectedQuery.data ?? true);
   const patInputConnectedQuery = getPatInputConnected.useQuery();
   const patInputConnected = Boolean(patInputConnectedQuery.data);
 
@@ -537,14 +534,11 @@ export function AppRoot(): JSX.Element | null {
     );
   }
 
-  if (
-    !barcodeConnected ||
-    !patInputConnected ||
-    !accessibleControllerConnected
-  ) {
+  if (!patInputConnected || !accessibleControllerConnected) {
     return (
       <InternalConnectionProblemScreen
-        missingBarcode={!barcodeConnected}
+        // Not blocking on a missing barcode reader for now since that component is non-essential
+        // and we wouldn't want a failure of it to prevent voting
         missingPatInput={!patInputConnected}
         missingAccessibleController={!accessibleControllerConnected}
         isPollWorkerAuth={isPollWorkerAuth(authStatus)}

--- a/apps/mark/frontend/src/app_setup_errors.test.tsx
+++ b/apps/mark/frontend/src/app_setup_errors.test.tsx
@@ -184,43 +184,6 @@ describe('Displays setup warning messages and errors screens', () => {
     ).toBeNull();
   });
 
-  test('Displays internal connection problem when Barcode Reader connection is lost', async () => {
-    apiMock.expectGetMachineConfig();
-    apiMock.expectGetElectionRecord(electionGeneralDefinition);
-    apiMock.expectGetElectionState({
-      pollingPlaceId: pollingPlace.id,
-      pollsState: 'polls_open',
-    });
-
-    render(<App apiClient={apiMock.mockApiClient} />);
-
-    // Start on Insert Card screen
-    await screen.findByText(insertCardScreenText);
-
-    // Disconnect Barcode Reader
-    act(() => {
-      apiMock.setBarcodeConnected(false);
-    });
-    await advanceTimersAndPromises(
-      INTERNAL_HARDWARE_POLLING_INTERVAL_MS / 1000
-    );
-
-    // Should see Internal Connection Problem screen with barcode message
-    await vi.waitFor(() => {
-      screen.getByRole('heading', { name: /Internal Connection Problem/i });
-      screen.getByText(/Barcode reader is disconnected\./i);
-    });
-
-    // Reconnect Barcode Reader
-    act(() => {
-      apiMock.setBarcodeConnected(true);
-    });
-    await advanceTimersAndPromises(
-      INTERNAL_HARDWARE_POLLING_INTERVAL_MS / 1000
-    );
-    await screen.findByText(insertCardScreenText);
-  });
-
   test('Displays internal connection problem when Accessible Controller connection is lost', async () => {
     apiMock.expectGetMachineConfig();
     apiMock.expectGetElectionRecord(electionGeneralDefinition);


### PR DESCRIPTION
## Overview

https://votingworks.slack.com/archives/CJU9MSC6S/p1783604371309979

Tabitha's VxMark recently started booting to an internal connection error screen because the barcode reader could not be reached. It's a non essential component that we don't currently use for anything, so let's not block on it being missing/unreadable, at least for now. Just one more thing that could go wrong as customers start receiving their VxMarks (and clearly already once has for reasons we don't fully understand).

## Testing Plan

- [x] Tested a version of this patch on Tabitha's device and confirmed that it unblocked her

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [ ] ~I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~
