### PR TITLE
VxDesign: Support encoding hmpb metadata using v4.0 format

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -4785,23 +4785,30 @@ test('v4.0 elections', async () => {
     ElectionPackageFileName.ELECTION
   );
   const electionData = await readTextEntry(electionEntry);
-  const exportedElectionDefinition =
-    safeParseElectionDefinitionV4p0(electionData).unsafeUnwrap();
+  safeParseElectionDefinitionV4p0(electionData).unsafeUnwrap();
 
-  const testDecksFilePath = await exportTestDecks({
-    fileStorageClient,
-    apiClient,
+  // The official ballots in the election package must be rendered with v4.0 QR
+  // metadata so deployed v4.0 scanners can read them.
+  const officialBallotRenderCalls = vi.mocked(
+    renderAllBallotPdfsAndCreateElectionDefinition
+  ).mock.calls;
+  expect(officialBallotRenderCalls.length).toBeGreaterThan(0);
+  for (const call of officialBallotRenderCalls) {
+    expect(call[3].version).toEqual('v4.0');
+  }
+
+  // Test decks aren't supported for v4.0 jurisdictions
+  await apiClient.exportTestDecks({
     electionId,
-    workspace,
     electionSerializationFormat: 'vxf',
   });
-
-  const testDecksBallotHash = testDecksFilePath.match(
-    'test-decks-(.*).zip'
-  )![1];
-  expect(formatBallotHash(exportedElectionDefinition.ballotHash)).toEqual(
-    testDecksBallotHash
+  await processNextBackgroundTaskIfAny({ fileStorageClient, workspace });
+  const testDecks = await apiClient.getTestDecks({ electionId });
+  expect(testDecks.url).toBeUndefined();
+  expect(testDecks.task?.error).toContain(
+    'Test deck generation is not supported for software version v4.0'
   );
+  expect(vi.mocked(createPrecinctTestDeck)).not.toHaveBeenCalled();
 
   // Live reports should be able to parse the saved exported election
   // definition, even though it's a previous version

--- a/apps/design/backend/src/test_decks.ts
+++ b/apps/design/backend/src/test_decks.ts
@@ -1,5 +1,9 @@
 import { find } from '@votingworks/basics';
-import { BaseBallotProps, ElectionDefinition } from '@votingworks/types';
+import {
+  BaseBallotProps,
+  ElectionDefinition,
+  LATEST_SOFTWARE_VERSION,
+} from '@votingworks/types';
 import {
   generateTestDeckCastVoteRecords,
   getTallyReportResults,
@@ -52,7 +56,8 @@ export async function createPrecinctTestDeck({
       const ballotPdf = await renderBallotPdfWithMetadataQrCode(
         props,
         markedBallot,
-        electionDefinition
+        electionDefinition,
+        LATEST_SOFTWARE_VERSION
       );
       return ballotPdf;
     }),

--- a/apps/design/backend/src/worker/generate_test_decks.ts
+++ b/apps/design/backend/src/worker/generate_test_decks.ts
@@ -60,6 +60,14 @@ export async function generateTestDecks(
     systemSettings,
   } = electionRecord;
   const jurisdiction = await store.getJurisdiction(jurisdictionId);
+  // Currently, we don't support generating BMD ballots with v4.0 QR code
+  // encoding, so we can't generate test decks targeting v4.0. If we end up
+  // needing to support this, we can add that support back in.
+  if (jurisdiction.softwareVersion === 'v4.0') {
+    throw new Error(
+      'Test deck generation is not supported for software version v4.0'
+    );
+  }
   const election = addPollingPlacesForExport(
     electionRecord.election,
     jurisdiction,

--- a/libs/ballot-encoder/src/index.test.ts
+++ b/libs/ballot-encoder/src/index.test.ts
@@ -6,10 +6,12 @@ import {
 } from '@votingworks/fixtures';
 import {
   BallotType,
+  BallotTypeMaximumValue,
   Candidate,
   CandidateContest,
   getContests,
   HmpbBallotPageMetadata,
+  LATEST_SOFTWARE_VERSION,
   vote,
   VotesDict,
 } from '@votingworks/types';
@@ -17,6 +19,8 @@ import {
   decodeBallotHash,
   isVxBallot,
   BALLOT_HASH_ENCODING_LENGTH,
+  BubbleBallotPreludeV4p0,
+  HexEncoding,
   SummaryBallotPrelude,
   sliceBallotHashForEncoding,
   encodeHmpbBallotPageMetadata,
@@ -25,7 +29,7 @@ import {
   decodeSummaryBallotPage,
   SummaryBallotPage,
 } from '.';
-import { BitWriter } from './bits';
+import { BitReader, BitWriter } from './bits';
 
 test('sliceBallotHashForEncoding', () => {
   expect(sliceBallotHashForEncoding('0000000000000000000000000')).toEqual(
@@ -59,7 +63,11 @@ test('encode HMPB ballot page metadata', () => {
     ballotAuditId: 'test-ballot-audit-id',
   };
 
-  const encoded = encodeHmpbBallotPageMetadata(election, ballotMetadata);
+  const encoded = encodeHmpbBallotPageMetadata(
+    election,
+    ballotMetadata,
+    LATEST_SOFTWARE_VERSION
+  );
 
   // We can at least verify that the ballot hash decodes from the encoded
   // metadata. There is no public HMPB metadata decoder in ballot-encoder.
@@ -80,7 +88,11 @@ test('encode HMPB ballot page metadata without a ballot audit id', () => {
     ballotType: BallotType.Precinct,
   };
 
-  const encoded = encodeHmpbBallotPageMetadata(election, ballotMetadata);
+  const encoded = encodeHmpbBallotPageMetadata(
+    election,
+    ballotMetadata,
+    LATEST_SOFTWARE_VERSION
+  );
 
   expect(decodeBallotHash(encoded)).toEqual(
     sliceBallotHashForEncoding(ballotMetadata.ballotHash)
@@ -100,7 +112,11 @@ test('encode HMPB ballot page metadata with bad precinct fails', () => {
   };
 
   expect(() =>
-    encodeHmpbBallotPageMetadata(election, ballotMetadata)
+    encodeHmpbBallotPageMetadata(
+      election,
+      ballotMetadata,
+      LATEST_SOFTWARE_VERSION
+    )
   ).toThrowError('precinct ID not found: SanDimas');
 });
 
@@ -117,8 +133,68 @@ test('encode HMPB ballot page metadata with bad ballot style fails', () => {
   };
 
   expect(() =>
-    encodeHmpbBallotPageMetadata(election, ballotMetadata)
+    encodeHmpbBallotPageMetadata(
+      election,
+      ballotMetadata,
+      LATEST_SOFTWARE_VERSION
+    )
   ).toThrowError('ballot style ID not found: 42');
+});
+
+test('encode HMPB ballot page metadata - v4.0', () => {
+  const electionDefinition = readElectionDefinition();
+  const { election } = electionDefinition;
+  const ballotMetadata: HmpbBallotPageMetadata = {
+    ballotHash: electionDefinition.ballotHash,
+    precinctId: election.ballotStyles[0]!.precincts[0]!,
+    ballotStyleId: election.ballotStyles[0]!.id,
+    pageNumber: 3,
+    isTestMode: true,
+    ballotType: BallotType.Precinct,
+    ballotAuditId: 'test-ballot-audit-id',
+  };
+
+  const encodedV40 = encodeHmpbBallotPageMetadata(
+    election,
+    ballotMetadata,
+    'v4.0'
+  );
+  const encodedLatest = encodeHmpbBallotPageMetadata(
+    election,
+    ballotMetadata,
+    LATEST_SOFTWARE_VERSION
+  );
+
+  // v4.0 uses the `V P 2` prelude; the latest format uses `V B 1`.
+  expect(Array.from(encodedV40.slice(0, 3))).toEqual([86, 80, 2]);
+  expect([...BubbleBallotPreludeV4p0]).toEqual([86, 80, 2]);
+  expect(Array.from(encodedV40)).not.toEqual(Array.from(encodedLatest));
+
+  // Independently decode the v4.0 encoded data with literal field widths and
+  // confirm every field round-trips.
+  const bits = new BitReader(encodedV40);
+  expect(bits.skipUint8(86, 80, 2)).toEqual(true);
+  expect(
+    bits.readString({
+      encoding: HexEncoding,
+      length: BALLOT_HASH_ENCODING_LENGTH,
+    })
+  ).toEqual(sliceBallotHashForEncoding(ballotMetadata.ballotHash));
+  const precinctIndex = election.precincts.findIndex(
+    (p) => p.id === ballotMetadata.precinctId
+  );
+  const ballotStyleIndex = election.ballotStyles.findIndex(
+    (bs) => bs.id === ballotMetadata.ballotStyleId
+  );
+  expect(bits.readUint({ max: 8191 })).toEqual(precinctIndex);
+  expect(bits.readUint({ max: 8191 })).toEqual(ballotStyleIndex);
+  expect(bits.readUint({ max: 30 })).toEqual(3);
+  expect(bits.readBoolean()).toEqual(true); // isTestMode
+  expect(bits.readUint({ max: BallotTypeMaximumValue })).toEqual(
+    Object.values(BallotType).indexOf(BallotType.Precinct)
+  );
+  expect(bits.readBoolean()).toEqual(true); // ballotAuditId present
+  expect(bits.readString()).toEqual('test-ballot-audit-id');
 });
 
 // Multi-page summary ballot tests

--- a/libs/ballot-encoder/src/index.ts
+++ b/libs/ballot-encoder/src/index.ts
@@ -15,6 +15,7 @@ import {
   HmpbBallotPageMetadata,
   isVotePresent,
   PrecinctId,
+  SoftwareVersion,
   unsafeParse,
   VotesDict,
   YesNoContest,
@@ -62,8 +63,6 @@ export function sliceBallotHashForEncoding(ballotHash: string): string {
   return ballotHash.slice(0, BALLOT_HASH_ENCODING_LENGTH);
 }
 
-// TODO: include "magic number" and encoding version
-
 /**
  * Encoding for write-ins, defines the characters allowed in a write-in. Should
  * match the values present on BMD's `{@link VirtualKeyboard}`.
@@ -90,6 +89,22 @@ export const BubbleBallotPrelude: readonly Uint8[] = [
 export const SummaryBallotPrelude: readonly Uint8[] = [
   /* V = VotingWorks */ 86, /* S = summary ballot */ 83, /* version = */ 1,
 ];
+
+/**
+ * @deprecated
+ * The bytes a v4.0 bubble ballot starts with. Retained so VxDesign can render
+ * v4.0 bubble ballots.
+ */
+export const BubbleBallotPreludeV4p0: readonly Uint8[] = [
+  /* V = VotingWorks */ 86, /* P = Paper */ 80, /* version = */ 2,
+];
+
+/**
+ * @deprecated
+ * Maximum ballot style index that we can encode. Retained so VxDesign can
+ * render v4.0 bubble ballots.
+ */
+export const MAXIMUM_BALLOT_STYLE_INDEX_V4_0 = 4096;
 
 /**
  * Detect whether `data` is a VotingWorks encoded ballot / metadata.
@@ -131,7 +146,8 @@ export function encodeBallotConfigInto(
     pageNumber,
     ballotAuditId,
   }: BallotConfig,
-  bits: BitWriter
+  bits: BitWriter,
+  version: SoftwareVersion
 ): BitWriter {
   const { precincts, ballotStyles } = election;
   const precinctIndex = precincts.findIndex((p) => p.id === precinctId);
@@ -149,7 +165,12 @@ export function encodeBallotConfigInto(
 
   bits
     .writeUint(precinctIndex, { max: MAXIMUM_PRECINCT_INDEX })
-    .writeUint(ballotStyleIndex, { max: MAXIMUM_BALLOT_STYLE_INDEX })
+    .writeUint(ballotStyleIndex, {
+      max:
+        version === 'v4.0'
+          ? MAXIMUM_BALLOT_STYLE_INDEX_V4_0
+          : MAXIMUM_BALLOT_STYLE_INDEX,
+    })
     .writeUint(pageNumber, { max: MAXIMUM_PAGE_NUMBERS });
 
   bits.writeBoolean(isTestMode);
@@ -404,10 +425,13 @@ export function encodeHmpbBallotPageMetadataInto(
     precinctId,
     ballotAuditId,
   }: HmpbBallotPageMetadata,
-  bits: BitWriter
+  bits: BitWriter,
+  version: SoftwareVersion
 ): BitWriter {
   return bits
-    .writeUint8(...BubbleBallotPrelude)
+    .writeUint8(
+      ...(version === 'v4.0' ? BubbleBallotPreludeV4p0 : BubbleBallotPrelude)
+    )
     .writeString(sliceBallotHashForEncoding(ballotHash), {
       encoding: HexEncoding,
       includeLength: false,
@@ -424,7 +448,8 @@ export function encodeHmpbBallotPageMetadataInto(
           precinctId,
           ballotAuditId,
         },
-        bits
+        bits,
+        version
       )
     );
 }
@@ -434,12 +459,14 @@ export function encodeHmpbBallotPageMetadataInto(
  */
 export function encodeHmpbBallotPageMetadata(
   election: Election,
-  metadata: HmpbBallotPageMetadata
+  metadata: HmpbBallotPageMetadata,
+  version: SoftwareVersion
 ): Uint8Array {
   return encodeHmpbBallotPageMetadataInto(
     election,
     metadata,
-    new BitWriter()
+    new BitWriter(),
+    version
   ).toUint8Array();
 }
 

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
@@ -145,9 +145,9 @@ pub fn get_detection_areas_for_strategy(
 /// The kind of ballot as determined by the 3-byte QR code prelude.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum QrCodeKind {
-    /// `VP\x02` — Hand-marked paper ballot (bubble ballot) metadata.
+    /// `VB\x01` — bubble ballot (hand-marked paper ballot) metadata.
     BubbleBallot,
-    /// `VB\x01` — BMD summary ballot page.
+    /// `VS\x01` — summary (BMD) ballot page.
     SummaryBallot,
     /// Unrecognized prelude.
     Unknown,

--- a/libs/ballot-interpreter/src/interpret_vx_bubble_ballot.test.ts
+++ b/libs/ballot-interpreter/src/interpret_vx_bubble_ballot.test.ts
@@ -914,7 +914,8 @@ describe('Contest option bounds', () => {
       await renderBallotPdfWithMetadataQrCode(
         ballotProps[0]!,
         ballotDocument,
-        electionDefinition
+        electionDefinition,
+        LATEST_SOFTWARE_VERSION
       );
 
       await markBallotDocument(ballotDocument, votes);
@@ -975,7 +976,8 @@ describe('Contest option bounds', () => {
       await renderBallotPdfWithMetadataQrCode(
         ballotProps[0]!,
         ballotDocument,
-        electionDefinition
+        electionDefinition,
+        LATEST_SOFTWARE_VERSION
       );
 
       await markBallotDocument(ballotDocument, votes);

--- a/libs/hmpb/src/all_bubble_ballot_fixtures.ts
+++ b/libs/hmpb/src/all_bubble_ballot_fixtures.ts
@@ -93,7 +93,8 @@ export function allBubbleBallotFixtures(
         const blankBallotPdf = await renderBallotPdfWithMetadataQrCode(
           ballotProps,
           ballotDocument,
-          electionDefinition
+          electionDefinition,
+          LATEST_SOFTWARE_VERSION
         );
 
         debug(`Generating: ${filledBallotPath}`);
@@ -108,7 +109,8 @@ export function allBubbleBallotFixtures(
         const filledBallotPdf = await renderBallotPdfWithMetadataQrCode(
           ballotProps,
           ballotDocument,
-          electionDefinition
+          electionDefinition,
+          LATEST_SOFTWARE_VERSION
         );
 
         debug(`Generating: ${cyclingTestDeckPath}`);
@@ -157,7 +159,8 @@ export function allBubbleBallotFixtures(
             const pdf = await renderBallotPdfWithMetadataQrCode(
               ballotProps,
               sheetDocument,
-              electionDefinition
+              electionDefinition,
+              LATEST_SOFTWARE_VERSION
             );
             return pdf;
           })

--- a/libs/hmpb/src/ballot_fixtures.ts
+++ b/libs/hmpb/src/ballot_fixtures.ts
@@ -190,7 +190,8 @@ export const vxFamousNamesFixtures = lazyFixtures(() => {
         const blankBallotPdf = await renderBallotPdfWithMetadataQrCode(
           allBallotPropsTest[0],
           ballotDocument,
-          electionDefinition
+          electionDefinition,
+          LATEST_SOFTWARE_VERSION
         );
 
         debug(`Generating: ${markedBallotPath}`);
@@ -206,7 +207,8 @@ export const vxFamousNamesFixtures = lazyFixtures(() => {
         const blankOfficialBallotPdf = await renderBallotPdfWithMetadataQrCode(
           allBallotPropsOfficial[0],
           officialBallotDocument,
-          electionDefinition
+          electionDefinition,
+          LATEST_SOFTWARE_VERSION
         );
 
         debug(`Generating: ${markedOfficialBallotPath}`);
@@ -223,7 +225,8 @@ export const vxFamousNamesFixtures = lazyFixtures(() => {
         const sampleBallotPdf = await renderBallotPdfWithMetadataQrCode(
           allBallotPropsSample[0],
           sampleBallotDocument,
-          electionDefinition
+          electionDefinition,
+          LATEST_SOFTWARE_VERSION
         );
 
         return {
@@ -397,7 +400,8 @@ export const vxGeneralElectionFixtures = lazyFixtures(() => {
             const blankBallotPdf = await renderBallotPdfWithMetadataQrCode(
               ballotProps,
               ballotDocument,
-              electionDefinition
+              electionDefinition,
+              LATEST_SOFTWARE_VERSION
             );
 
             debug(`Generating: ${spec.markedBallotPath}`);
@@ -533,7 +537,8 @@ export const vxPrimaryElectionFixtures = lazyFixtures(() => {
               : await renderBallotPdfWithMetadataQrCode(
                   ballotProps,
                   ballotDocument,
-                  layouts.electionDefinition
+                  layouts.electionDefinition,
+                  LATEST_SOFTWARE_VERSION
                 );
 
             debug(`Generating: ${spec.markedBallotPath}`);
@@ -542,7 +547,8 @@ export const vxPrimaryElectionFixtures = lazyFixtures(() => {
             const markedBallotPdf = await renderBallotPdfWithMetadataQrCode(
               ballotProps,
               ballotDocument,
-              electionDefinition
+              electionDefinition,
+              LATEST_SOFTWARE_VERSION
             );
 
             return { blankBallotPdf, markedBallotPdf };
@@ -570,7 +576,8 @@ export const vxPrimaryElectionFixtures = lazyFixtures(() => {
               return await renderBallotPdfWithMetadataQrCode(
                 otherPrecinctBallotProps,
                 otherPrecinctBallotDocument,
-                electionDefinition
+                electionDefinition,
+                LATEST_SOFTWARE_VERSION
               );
             });
 
@@ -751,7 +758,8 @@ export const nhGeneralElectionFixtures = lazyFixtures(() => {
             const blankBallotPdf = await renderBallotPdfWithMetadataQrCode(
               ballotProps,
               ballotDocument,
-              electionDefinition
+              electionDefinition,
+              LATEST_SOFTWARE_VERSION
             );
 
             debug(`Generating: ${spec.markedBallotPath}`);
@@ -934,7 +942,8 @@ export const nhStateGeneralElectionFixtures = lazyFixtures(() => {
           const blankPdf = await renderBallotPdfWithMetadataQrCode(
             chosenProps,
             doc,
-            layout.electionDefinition
+            layout.electionDefinition,
+            LATEST_SOFTWARE_VERSION
           );
           if (!paths.markedPath) {
             return { blankPdf };
@@ -1146,7 +1155,8 @@ export const nhStatePrimaryElectionFixtures = lazyFixtures(() => {
           const blankPdf = await renderBallotPdfWithMetadataQrCode(
             chosenProps,
             doc,
-            layout.electionDefinition
+            layout.electionDefinition,
+            LATEST_SOFTWARE_VERSION
           );
           if (!spec.markedPath) {
             return { blankPdf };
@@ -1271,7 +1281,8 @@ export const msGeneralElectionFixtures = lazyFixtures(() => {
           const blankBallotPdf = await renderBallotPdfWithMetadataQrCode(
             allBallotProps[0],
             ballotDocument,
-            electionDefinition
+            electionDefinition,
+            LATEST_SOFTWARE_VERSION
           );
 
           debug(`Generating: ${markedBallotPath}`);
@@ -1389,7 +1400,8 @@ export const miClosedPrimaryElectionFixtures = lazyFixtures(() => {
           const blankBallotPdf = await renderBallotPdfWithMetadataQrCode(
             ballotProps,
             ballotDocument,
-            electionDefinition
+            electionDefinition,
+            LATEST_SOFTWARE_VERSION
           );
 
           debug(`Generating: ${spec.markedBallotPath}`);
@@ -1485,7 +1497,8 @@ export const miCombinedBallotPrimaryElectionFixtures = lazyFixtures(() => {
         const blankBallotPdf = await renderBallotPdfWithMetadataQrCode(
           ballotProps,
           ballotDocument,
-          electionDefinition
+          electionDefinition,
+          LATEST_SOFTWARE_VERSION
         );
 
         debug(`Generating: ${markedBallotPath}`);
@@ -1599,7 +1612,8 @@ export const miGeneralElectionFixtures = lazyFixtures(() => {
         const blankBallotPdf = await renderBallotPdfWithMetadataQrCode(
           ballotProps,
           ballotDocument,
-          electionDefinition
+          electionDefinition,
+          LATEST_SOFTWARE_VERSION
         );
 
         debug(`Generating: ${markedBallotPath}`);

--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -449,15 +449,20 @@ async function extractBallotPositions(
 async function addQrCodesAndBallotHashes(
   document: RenderDocument,
   election: Election,
-  metadata: Omit<HmpbBallotPageMetadata, 'pageNumber'>
+  metadata: Omit<HmpbBallotPageMetadata, 'pageNumber'>,
+  version: SoftwareVersion
 ) {
   const pages = await document.inspectElements(`.${PAGE_CLASS}`);
   for (const i of pages.keys()) {
     const pageNumber = i + 1;
-    const encodedMetadata = encodeHmpbBallotPageMetadata(election, {
-      ...metadata,
-      pageNumber,
-    });
+    const encodedMetadata = encodeHmpbBallotPageMetadata(
+      election,
+      {
+        ...metadata,
+        pageNumber,
+      },
+      version
+    );
     const qrCode = (
       <div
         style={{
@@ -489,17 +494,23 @@ async function addQrCodesAndBallotHashes(
 export async function renderBallotPdfWithMetadataQrCode(
   props: BaseBallotProps,
   document: RenderDocument,
-  electionDefinition: ElectionDefinition
+  electionDefinition: ElectionDefinition,
+  version: SoftwareVersion
 ): Promise<Uint8Array> {
   if (props.ballotMode !== 'sample') {
-    await addQrCodesAndBallotHashes(document, electionDefinition.election, {
-      ballotHash: electionDefinition.ballotHash,
-      ballotStyleId: props.ballotStyleId,
-      precinctId: props.precinctId,
-      ballotType: props.ballotType,
-      isTestMode: props.ballotMode !== 'official',
-      ballotAuditId: props.ballotAuditId,
-    });
+    await addQrCodesAndBallotHashes(
+      document,
+      electionDefinition.election,
+      {
+        ballotHash: electionDefinition.ballotHash,
+        ballotStyleId: props.ballotStyleId,
+        precinctId: props.precinctId,
+        ballotType: props.ballotType,
+        isTestMode: props.ballotMode !== 'official',
+        ballotAuditId: props.ballotAuditId,
+      },
+      version
+    );
   }
 
   return await document.renderToPdf();
@@ -767,7 +778,8 @@ export async function renderAllBallotPdfsAndCreateElectionDefinition<
         const ballotPdf = await renderBallotPdfWithMetadataQrCode(
           props,
           document,
-          electionDefinition
+          electionDefinition,
+          electionSerializationOptions.version
         );
         return ballotPdf;
       })

--- a/libs/integration-test-utils/src/ballots.ts
+++ b/libs/integration-test-utils/src/ballots.ts
@@ -183,7 +183,8 @@ export async function renderMarkedBallots(
         return renderBallotPdfWithMetadataQrCode(
           sharedBallotProps,
           doc,
-          spec.electionDefinition
+          spec.electionDefinition,
+          LATEST_SOFTWARE_VERSION
         );
       })
     );


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

<!-- Add a link to a GitHub issue here -->
When exporting ballots for jurisdictions on v4.0, we need to encode the ballot metadata using the v4.0 format, otherwise v4.0 software can't tabulate those ballots. There were some [small breaking changes](https://github.com/votingworks/vxsuite/pull/8800/changes/0f797d83967a9574ee9bbc98dcfa0c196c3ded0c) to the format in v4.1.

I opted to not add support for BMD ballots, since the only use case would be for generating test decks, which I'm pretty sure we don't need for NH. Instead, I added an error message if you try to export test decks targeting v4.0.

## Demo Video or Screenshot
N/A

## Testing Plan
- Added automated test
- Manual test of tabulating ballot on v4.0 software

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
