### PR TITLE
VxDesign: pass target VxSuite version to QA pipeline

### DIFF
--- a/apps/design/backend/scripts/mock_circleci_server.ts
+++ b/apps/design/backend/scripts/mock_circleci_server.ts
@@ -160,6 +160,7 @@ const server = http.createServer((req, res) => {
             webhook_url?: string;
             qa_run_id?: string;
             election_id?: string;
+            vxsuite_version?: string;
           };
         };
         const params = data.parameters ?? {};
@@ -169,6 +170,7 @@ const server = http.createServer((req, res) => {
         console.log(`  webhook_url: ${params.webhook_url}`);
         console.log(`  qa_run_id: ${params.qa_run_id}`);
         console.log(`  election_id: ${params.election_id}`);
+        console.log(`  vxsuite_version: ${params.vxsuite_version}`);
 
         pipelineCounter += 1;
         const pipelineId = `mock-pipeline-${Date.now()}-${pipelineCounter}`;

--- a/apps/design/backend/src/circleci_client.test.ts
+++ b/apps/design/backend/src/circleci_client.test.ts
@@ -37,6 +37,7 @@ describe('CircleCiClient', () => {
         webhookUrl: 'https://example.com/webhook',
         qaRunId: 'qa-run-123',
         electionId: 'election-123',
+        vxsuiteVersion: 'v4.1',
       })
     ).rejects.toThrow('CircleCI client is not configured');
   });
@@ -61,6 +62,7 @@ describe('CircleCiClient', () => {
       webhookUrl: 'https://example.com/webhook',
       qaRunId: 'qa-run-123',
       electionId: 'election-123',
+      vxsuiteVersion: 'v4.1',
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
@@ -78,6 +80,7 @@ describe('CircleCiClient', () => {
             webhook_url: 'https://example.com/webhook',
             qa_run_id: 'qa-run-123',
             election_id: 'election-123',
+            vxsuite_version: 'v4.1',
           },
         }),
       }
@@ -107,6 +110,7 @@ describe('CircleCiClient', () => {
         webhookUrl: 'https://example.com/webhook',
         qaRunId: 'qa-run-123',
         electionId: 'election-123',
+        vxsuiteVersion: 'v4.1',
       })
     ).rejects.toThrow('CircleCI API request failed: 401 Unauthorized');
   });
@@ -121,6 +125,7 @@ describe('CircleCiClient', () => {
         webhookUrl: 'https://example.com/webhook',
         qaRunId: 'qa-run-123',
         electionId: 'election-123',
+        vxsuiteVersion: 'v4.1',
       })
     ).rejects.toThrow('Network error');
   });

--- a/apps/design/backend/src/circleci_client.ts
+++ b/apps/design/backend/src/circleci_client.ts
@@ -1,3 +1,4 @@
+import { SoftwareVersion } from '@votingworks/types';
 import {
   circleCiApiToken,
   circleCiBaseUrl,
@@ -29,6 +30,12 @@ export interface TriggerPipelineParams {
    * The election ID being QA'd.
    */
   electionId: string;
+
+  /**
+   * The VxSuite version the election targets, so the QA run builds and tests
+   * against the matching VxSuite release (e.g. 'v4.0', 'v4.1').
+   */
+  vxsuiteVersion: SoftwareVersion;
 }
 
 export interface TriggerPipelineResponse {
@@ -94,7 +101,13 @@ export class CircleCiClient {
       );
     }
 
-    const { exportPackageUrl, webhookUrl, qaRunId, electionId } = params;
+    const {
+      exportPackageUrl,
+      webhookUrl,
+      qaRunId,
+      electionId,
+      vxsuiteVersion,
+    } = params;
 
     const url = `${circleCiBaseUrl()}/api/v2/project/${
       this.projectSlug
@@ -116,6 +129,7 @@ export class CircleCiClient {
           webhook_url: webhookUrl,
           qa_run_id: qaRunId,
           election_id: electionId,
+          vxsuite_version: vxsuiteVersion,
         },
       });
       const response = await fetch(url, {

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -14,6 +14,7 @@ import {
   ElectionSerializationFormatSchema,
   EncodedBallotEntry,
   BaseBallotProps,
+  SoftwareVersion,
 } from '@votingworks/types';
 import {
   hmpbStringsCatalog,
@@ -110,8 +111,15 @@ async function triggerCircleCiQaBuild(params: {
   electionId: ElectionId;
   electionPackageUrl: string;
   fileStorageClient: FileStorageClient;
+  vxsuiteVersion: SoftwareVersion;
 }): Promise<void> {
-  const { store, electionId, electionPackageUrl, fileStorageClient } = params;
+  const {
+    store,
+    electionId,
+    electionPackageUrl,
+    fileStorageClient,
+    vxsuiteVersion,
+  } = params;
 
   // Check if CircleCI integration is enabled
   if (!shouldTriggerCircleCi()) {
@@ -167,6 +175,7 @@ async function triggerCircleCiQaBuild(params: {
       webhookUrl,
       qaRunId,
       electionId,
+      vxsuiteVersion,
     });
 
     // Construct a link to the pipeline page
@@ -508,6 +517,7 @@ export async function generateElectionPackageAndBallots(
     electionId,
     electionPackageUrl,
     fileStorageClient: ctx.fileStorageClient,
+    vxsuiteVersion: jurisdiction.softwareVersion,
   });
 }
 


### PR DESCRIPTION
_Co-authored by Claude Code :robot:_

## Overview
Refs https://github.com/votingworks/vxsuite/issues/8625.
Pairs with https://github.com/votingworks/vx-qa/pull/17.

The vx-qa pipeline selects which VxSuite version to build and test against via a `vxsuite_version` parameter (aligned to VxSuite's SoftwareVersion, e.g. v4.0/v4.1), but VxDesign wasn't sending it, so QA runs fell back to a default instead of matching the election. Pass the election jurisdiction's softwareVersion through the CircleCI trigger.

## Demo Video or Screenshot
n/a

## Testing Plan
- [x] Test with mock CircleCI server locally.