### PR TITLE
Disallow closing polls before 7PM by default in MS (and block polls close button in menu during early voting)

### DIFF
--- a/apps/design/backend/src/__snapshots__/system_settings.test.ts.snap
+++ b/apps/design/backend/src/__snapshots__/system_settings.test.ts.snap
@@ -98,6 +98,8 @@ exports[`Default system settings for 'MS' - If a change is intentional, update s
   "disableSystemLimitChecks": true,
   "disableVoterHelpButtons": true,
   "disallowCastingOvervotes": false,
+  "disallowClosingPollsBeforeElectionDayPollsCloseTime": true,
+  "electionDayPollsCloseTime": "19:00:00",
   "enableEarlyVoting": true,
   "enableTestDeckPrinting": true,
   "markThresholds": {

--- a/apps/design/backend/src/system_settings.ts
+++ b/apps/design/backend/src/system_settings.ts
@@ -100,6 +100,8 @@ export const stateDefaultSystemSettings: Record<StateCode, SystemSettings> = {
     adminAdjudicationReasons: [],
 
     bmdPrintMode: 'summary',
+    disallowClosingPollsBeforeElectionDayPollsCloseTime: true,
+    electionDayPollsCloseTime: '19:00:00',
     enableEarlyVoting: true,
     enableTestDeckPrinting: true,
     precinctScanNumberOfReportCopies: 2,

--- a/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.test.tsx
@@ -1454,6 +1454,54 @@ describe('election day polls close time enforcement', () => {
       expect(screen.queryByText('Close Polls')).not.toBeInTheDocument();
     });
 
+    test('before close time, disallow flag set, polls open - Close Polls in menu is disabled with explanation', async () => {
+      vi.setSystemTime(BEFORE_CLOSE_TIME);
+      apiMock.mockApiClient.getConfig.reset();
+      apiMock.expectGetConfig({
+        isTestMode: false,
+        ballotCastingMode: 'early_voting',
+        systemSettings: {
+          ...DEFAULT_SYSTEM_SETTINGS,
+          electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+          disallowClosingPollsBeforeElectionDayPollsCloseTime: true,
+        },
+      });
+      apiMock.expectGetPollsInfo('polls_open');
+      renderScreen({});
+
+      const pauseVotingButton = await screen.findButton('Pause Voting');
+      expect(pauseVotingButton).toHaveAttribute('data-variant', 'primary');
+
+      userEvent.click(await screen.findByText('Menu'));
+      await screen.findByText(/Polls cannot be closed until/);
+      await screen.findByText(/8:00 PM/);
+      expect(screen.getButton('Close Polls')).toBeDisabled();
+    });
+
+    test('before close time, disallow flag set, polls paused - Close Polls in menu is disabled with explanation', async () => {
+      vi.setSystemTime(BEFORE_CLOSE_TIME);
+      apiMock.mockApiClient.getConfig.reset();
+      apiMock.expectGetConfig({
+        isTestMode: false,
+        ballotCastingMode: 'early_voting',
+        systemSettings: {
+          ...DEFAULT_SYSTEM_SETTINGS,
+          electionDayPollsCloseTime: POLLS_CLOSE_TIME,
+          disallowClosingPollsBeforeElectionDayPollsCloseTime: true,
+        },
+      });
+      apiMock.expectGetPollsInfo('polls_paused');
+      renderScreen({});
+
+      const resumeVotingButton = await screen.findButton('Resume Voting');
+      expect(resumeVotingButton).toHaveAttribute('data-variant', 'primary');
+
+      userEvent.click(await screen.findByText('Menu'));
+      await screen.findByText(/Polls cannot be closed until/);
+      await screen.findByText(/8:00 PM/);
+      expect(screen.getButton('Close Polls')).toBeDisabled();
+    });
+
     test('past close time - Close Polls is primary action in menu', async () => {
       vi.setSystemTime(AFTER_CLOSE_TIME);
       apiMock.mockApiClient.getConfig.reset();

--- a/apps/scan/frontend/src/screens/poll_worker_screen.tsx
+++ b/apps/scan/frontend/src/screens/poll_worker_screen.tsx
@@ -405,7 +405,6 @@ function PollWorkerScreenContents({
 
   const isClosingPollsBlocked =
     !isTestMode &&
-    ballotCastingMode === 'election_day' &&
     systemSettings.disallowClosingPollsBeforeElectionDayPollsCloseTime &&
     pollsCloseTime !== undefined &&
     now < pollsCloseTime;
@@ -417,6 +416,14 @@ function PollWorkerScreenContents({
     isTestMode &&
     pollsCloseTime !== undefined &&
     systemSettings.disallowClosingPollsBeforeElectionDayPollsCloseTime;
+
+  const closePollsBlockedMessage = isClosingPollsBlocked ? (
+    <React.Fragment>
+      {' '}
+      Polls cannot be closed until{' '}
+      {pollsCloseTime.toLocaleString(DateTime.TIME_SIMPLE)}.
+    </React.Fragment>
+  ) : null;
 
   function showAllPollWorkerActions() {
     return setPollWorkerFlowState(undefined);
@@ -590,7 +597,9 @@ function PollWorkerScreenContents({
 
   if (
     isClosingPollsBlocked &&
-    pollWorkerFlowState?.type === 'close-polls-prompt'
+    pollWorkerFlowState?.type === 'close-polls-prompt' &&
+    // Default action when in early voting mode is pausing polls, which is fine to display
+    ballotCastingMode !== 'early_voting'
   ) {
     // Skip the close-polls prompt and fall through to render the pollworker menu below
   } else if (pollWorkerFlowState) {
@@ -835,18 +844,10 @@ function PollWorkerScreenContents({
             <Container>
               {closePollsWarningModal}
               <P>
-                {isClosingPollsBlocked ? (
-                  <React.Fragment>
-                    The polls are <Font weight="bold">open</Font>. Polls cannot
-                    be closed until{' '}
-                    {pollsCloseTime.toLocaleString(DateTime.TIME_SIMPLE)}.
-                  </React.Fragment>
-                ) : (
-                  <React.Fragment>
-                    The polls are <Font weight="bold">open</Font>. Close the
-                    polls to end voting.
-                  </React.Fragment>
-                )}
+                The polls are <Font weight="bold">open</Font>.
+                {isClosingPollsBlocked
+                  ? closePollsBlockedMessage
+                  : ' Close the polls to end voting.'}
               </P>
               <ButtonGrid>
                 <Button
@@ -877,6 +878,7 @@ function PollWorkerScreenContents({
             {closePollsWarningModal}
             <P>
               The polls are <Font weight="bold">open</Font>.
+              {closePollsBlockedMessage}
             </P>
             <ButtonGrid>
               <Button variant="primary" onPress={pauseVoting}>
@@ -888,6 +890,7 @@ function PollWorkerScreenContents({
               <Button
                 onPress={handleClosePollsPress}
                 disabled={
+                  isClosingPollsBlocked ||
                   !shouldAllowTogglingPolls(
                     printerSummary,
                     mustInsertUsbDriveToContinue
@@ -907,6 +910,7 @@ function PollWorkerScreenContents({
           <Container>
             <P>
               Voting is <Font weight="bold">paused</Font>.
+              {closePollsBlockedMessage}
             </P>
             <ButtonGrid>
               <Button
@@ -927,6 +931,7 @@ function PollWorkerScreenContents({
               <Button
                 onPress={handleClosePollsPress}
                 disabled={
+                  isClosingPollsBlocked ||
                   !shouldAllowTogglingPolls(
                     printerSummary,
                     mustInsertUsbDriveToContinue


### PR DESCRIPTION
## Overview

https://votingworks.slack.com/archives/CJU9MSC6S/p1783546365052959

Two pieces to this one. First, we have confirmation that we want to disallow closing polls before 7PM by default in MS for upcoming fall elections. Second, we identified a gap in that logic where, in early voting mode, the close polls button could still be reached through the sub-menu. Extending the blocking to that button too. Confirmed not intentional.

## Demo Video or Screenshot

### Early voting mode, polls open

Base screen unchanged

<table>
<img width="400" alt="Screenshot 2026-07-09 at 5 06 53 PM" src="https://github.com/user-attachments/assets/03fabbcb-a6ac-4c30-abc3-aee158448096" />
</table>

Sub-menu changed

| Before | After |
| - | - |
| <img width="400" alt="Screenshot 2026-07-09 at 5 06 45 PM" src="https://github.com/user-attachments/assets/e5fc910d-1a0d-4ade-adfb-7c1c31b507e4" /> | <img width="400" alt="Screenshot 2026-07-09 at 5 06 19 PM" src="https://github.com/user-attachments/assets/06c17c45-83e5-43e4-8a83-fbe525542cc5" /> |


### Early voting mode, polls paused

Base screen unchanged

<table>
<img width="400" alt="Screenshot 2026-07-09 at 5 07 08 PM" src="https://github.com/user-attachments/assets/c3732404-f91d-4672-86db-658ff3314596" />
</table>

Sub-menu changed

| Before | After |
| - | - |
| <img width="400" alt="Screenshot 2026-07-09 at 5 07 11 PM" src="https://github.com/user-attachments/assets/f6f4231f-73f4-4d23-855d-41c23ca4d2dd" /> | <img width="400" alt="Screenshot 2026-07-09 at 5 07 20 PM" src="https://github.com/user-attachments/assets/62ed540e-0526-434d-b079-9cd17f0591ef" /> |

## Testing Plan

- [x] Added automated tests
- [x] Tested manually

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.