### PR TITLE
Bump http-proxy-middleware from 3.0.3 to 3.0.7

### DIFF
--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -63,7 +63,7 @@
     "fetch-mock": "9.11.0",
     "fs-extra": "11.1.1",
     "history": "4.10.1",
-    "http-proxy-middleware": "3.0.3",
+    "http-proxy-middleware": "3.0.7",
     "identity-obj-proxy": "3.0.0",
     "js-file-download": "0.4.12",
     "js-sha256": "^0.9.0",

--- a/apps/admin/frontend/prodserver/package.json
+++ b/apps/admin/frontend/prodserver/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "express": "4.18.2",
-    "http-proxy-middleware": "3.0.3",
+    "http-proxy-middleware": "3.0.7",
     "resolve": "1.18.1"
   },
   "packageManager": "pnpm@9.15.9"

--- a/apps/central-scan/frontend/package.json
+++ b/apps/central-scan/frontend/package.json
@@ -55,7 +55,7 @@
     "dotenv-expand": "9.0.0",
     "events": "3.3.0",
     "fast-text-encoding": "^1.0.2",
-    "http-proxy-middleware": "3.0.3",
+    "http-proxy-middleware": "3.0.7",
     "js-file-download": "0.4.12",
     "normalize.css": "^8.0.1",
     "path": "^0.12.7",

--- a/apps/central-scan/frontend/prodserver/package.json
+++ b/apps/central-scan/frontend/prodserver/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "express": "4.18.2",
-    "http-proxy-middleware": "3.0.3"
+    "http-proxy-middleware": "3.0.7"
   },
   "packageManager": "pnpm@9.15.9"
 }

--- a/apps/mark-scan/frontend/package.json
+++ b/apps/mark-scan/frontend/package.json
@@ -59,7 +59,7 @@
     "dotenv": "16.3.1",
     "dotenv-expand": "9.0.0",
     "history": "4.10.1",
-    "http-proxy-middleware": "3.0.3",
+    "http-proxy-middleware": "3.0.7",
     "luxon": "^3.0.0",
     "normalize.css": "^8.0.1",
     "path": "^0.12.7",

--- a/apps/mark-scan/frontend/prodserver/package.json
+++ b/apps/mark-scan/frontend/prodserver/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "express": "4.18.2",
-    "http-proxy-middleware": "3.0.3"
+    "http-proxy-middleware": "3.0.7"
   },
   "packageManager": "pnpm@9.15.9"
 }

--- a/apps/mark/frontend/package.json
+++ b/apps/mark/frontend/package.json
@@ -60,7 +60,7 @@
     "dotenv": "16.3.1",
     "dotenv-expand": "9.0.0",
     "history": "4.10.1",
-    "http-proxy-middleware": "3.0.3",
+    "http-proxy-middleware": "3.0.7",
     "luxon": "^3.0.0",
     "normalize.css": "^8.0.1",
     "path": "^0.12.7",

--- a/apps/mark/frontend/prodserver/package.json
+++ b/apps/mark/frontend/prodserver/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "express": "4.18.2",
-    "http-proxy-middleware": "3.0.3"
+    "http-proxy-middleware": "3.0.7"
   },
   "packageManager": "pnpm@9.15.9"
 }

--- a/apps/pollbook/frontend/package.json
+++ b/apps/pollbook/frontend/package.json
@@ -60,7 +60,7 @@
     "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "history": "4.10.1",
-    "http-proxy-middleware": "3.0.3",
+    "http-proxy-middleware": "3.0.7",
     "js-file-download": "0.4.12",
     "lodash.debounce": "^4.0.8",
     "luxon": "^3.0.0",

--- a/apps/pollbook/frontend/prodserver/package.json
+++ b/apps/pollbook/frontend/prodserver/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "express": "4.18.2",
-    "http-proxy-middleware": "3.0.3",
+    "http-proxy-middleware": "3.0.7",
     "resolve": "1.18.1"
   },
   "packageManager": "pnpm@9.15.9"

--- a/apps/print/frontend/package.json
+++ b/apps/print/frontend/package.json
@@ -57,7 +57,7 @@
     "esbuild": "0.28.1",
     "esbuild-runner": "2.2.2",
     "history": "4.10.1",
-    "http-proxy-middleware": "3.0.3",
+    "http-proxy-middleware": "3.0.7",
     "path": "^0.12.7",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/apps/print/frontend/prodserver/package.json
+++ b/apps/print/frontend/prodserver/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "express": "4.18.2",
-    "http-proxy-middleware": "3.0.3",
+    "http-proxy-middleware": "3.0.7",
     "resolve": "1.18.1"
   },
   "packageManager": "pnpm@9.15.9"

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -57,7 +57,7 @@
     "debug": "4.3.4",
     "dotenv": "16.3.1",
     "dotenv-expand": "9.0.0",
-    "http-proxy-middleware": "3.0.3",
+    "http-proxy-middleware": "3.0.7",
     "luxon": "^3.0.0",
     "normalize.css": "^8.0.1",
     "path": "^0.12.7",

--- a/apps/scan/frontend/prodserver/package.json
+++ b/apps/scan/frontend/prodserver/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "express": "4.18.2",
-    "http-proxy-middleware": "3.0.3"
+    "http-proxy-middleware": "3.0.7"
   },
   "packageManager": "pnpm@9.15.9"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,8 +386,8 @@ importers:
         specifier: 4.10.1
         version: 4.10.1
       http-proxy-middleware:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.0.7
+        version: 3.0.7
       identity-obj-proxy:
         specifier: 3.0.0
         version: 3.0.0
@@ -573,8 +573,8 @@ importers:
         specifier: 4.18.2
         version: 4.18.2
       http-proxy-middleware:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.0.7
+        version: 3.0.7
       resolve:
         specifier: 1.18.1
         version: 1.18.1
@@ -830,8 +830,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.3
       http-proxy-middleware:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.0.7
+        version: 3.0.7
       js-file-download:
         specifier: 0.4.12
         version: 0.4.12
@@ -990,8 +990,8 @@ importers:
         specifier: 4.18.2
         version: 4.18.2
       http-proxy-middleware:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.0.7
+        version: 3.0.7
 
   apps/central-scan/integration-testing:
     dependencies:
@@ -1639,8 +1639,8 @@ importers:
         specifier: 4.10.1
         version: 4.10.1
       http-proxy-middleware:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.0.7
+        version: 3.0.7
       luxon:
         specifier: ^3.0.0
         version: 3.3.0
@@ -1784,8 +1784,8 @@ importers:
         specifier: 4.18.2
         version: 4.18.2
       http-proxy-middleware:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.0.7
+        version: 3.0.7
 
   apps/mark-scan/integration-testing:
     dependencies:
@@ -2029,8 +2029,8 @@ importers:
         specifier: 4.10.1
         version: 4.10.1
       http-proxy-middleware:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.0.7
+        version: 3.0.7
       luxon:
         specifier: ^3.0.0
         version: 3.3.0
@@ -2174,8 +2174,8 @@ importers:
         specifier: 4.18.2
         version: 4.18.2
       http-proxy-middleware:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.0.7
+        version: 3.0.7
 
   apps/mark/integration-testing:
     dependencies:
@@ -2470,8 +2470,8 @@ importers:
         specifier: 4.10.1
         version: 4.10.1
       http-proxy-middleware:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.0.7
+        version: 3.0.7
       js-file-download:
         specifier: 0.4.12
         version: 0.4.12
@@ -2609,8 +2609,8 @@ importers:
         specifier: 4.18.2
         version: 4.18.2
       http-proxy-middleware:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.0.7
+        version: 3.0.7
       resolve:
         specifier: 1.18.1
         version: 1.18.1
@@ -2814,8 +2814,8 @@ importers:
         specifier: 4.10.1
         version: 4.10.1
       http-proxy-middleware:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.0.7
+        version: 3.0.7
       path:
         specifier: ^0.12.7
         version: 0.12.7
@@ -2920,8 +2920,8 @@ importers:
         specifier: 4.18.2
         version: 4.18.2
       http-proxy-middleware:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.0.7
+        version: 3.0.7
       resolve:
         specifier: 1.18.1
         version: 1.18.1
@@ -3189,8 +3189,8 @@ importers:
         specifier: 9.0.0
         version: 9.0.0
       http-proxy-middleware:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.0.7
+        version: 3.0.7
       luxon:
         specifier: ^3.0.0
         version: 3.3.0
@@ -3340,8 +3340,8 @@ importers:
         specifier: 4.18.2
         version: 4.18.2
       http-proxy-middleware:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.0.7
+        version: 3.0.7
 
   apps/scan/integration-testing:
     dependencies:
@@ -11537,15 +11537,6 @@ packages:
       supports-color:
         optional: true
 
-  debug@4.4.0:
-    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
     engines: {node: '>=6.0'}
@@ -12791,9 +12782,9 @@ packages:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
 
-  http-proxy-middleware@3.0.3:
-    resolution: {integrity: sha512-usY0HG5nyDUwtqpiZdETNbmKtw3QQ1jwYFZ9wi5iHzX2BcILwQKtYDJPo7XHTsu5Z0B2Hj3W9NNnbd+AjFWjqg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+  http-proxy-middleware@3.0.7:
+    resolution: {integrity: sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==}
+    engines: {node: ^14.18.0 || ^16.10.0 || >=18.0.0}
 
   http-proxy@1.18.1:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
@@ -23819,10 +23810,6 @@ snapshots:
     optionalDependencies:
       supports-color: 5.5.0
 
-  debug@4.4.0:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
@@ -24879,9 +24866,9 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.8
 
-  follow-redirects@1.15.9(debug@4.4.0):
+  follow-redirects@1.15.9(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.0
+      debug: 4.4.3
 
   fontkit@2.0.4:
     dependencies:
@@ -25408,21 +25395,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@3.0.3:
+  http-proxy-middleware@3.0.7:
     dependencies:
       '@types/http-proxy': 1.17.15
-      debug: 4.4.0
-      http-proxy: 1.18.1(debug@4.4.0)
+      debug: 4.4.3
+      http-proxy: 1.18.1(debug@4.4.3)
       is-glob: 4.0.3
       is-plain-object: 5.0.0
       micromatch: 4.0.8
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy@1.18.1(debug@4.4.0):
+  http-proxy@1.18.1(debug@4.4.3):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.9(debug@4.4.0)
+      follow-redirects: 1.15.9(debug@4.4.3)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
## Overview

Dependabot security update for `http-proxy-middleware` (3.0.3 → 3.0.7), applied cleanly across the monorepo.

Dependabot's own PRs for this bump (#8866, #8839, #8829, #8794, #8793) all failed CI because it regenerated the shared `pnpm-lock.yaml` in a way that broke vite hoisting (`Error: Cannot find module 'vite'` in nearly every test job). This PR instead bumps all 14 frontend/prodserver `package.json` files and regenerates the lockfile via a clean local `pnpm install`. The lockfile diff is minimal — only a transitive `debug` dedup (4.4.0 → 4.4.3).

This is the base of a 2-PR stack; the vite security bump stacks on top of it.

## Demo Video or Screenshot

N/A — dependency bump.

## Testing Plan

- `pnpm install --frozen-lockfile` passes (lockfile is CI-consistent).
- Verified `createProxyMiddleware`/`pathFilter` API used by `prodserver/setupProxy.js` is intact at 3.0.7.
- Verified vitest configs load (the exact failure mode in Dependabot's PRs is absent).
- CI.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — via Claude Code