### PR TITLE
Avoid most obvious straight party voting crashes

### DIFF
--- a/apps/admin/backend/src/util/cdf_results.ts
+++ b/apps/admin/backend/src/util/cdf_results.ts
@@ -3,7 +3,6 @@ import {
   Election,
   NcName,
   ResultsReporting,
-  straightPartyNotYetImplemented,
   Tabulation,
   YesNoContest,
 } from '@votingworks/types';
@@ -173,12 +172,19 @@ function buildContests(
   const reportContests: ReportContest[] = [];
 
   for (const contest of election.contests) {
-    const contestResults = electionResults.contestResults[contest.id];
-    assert(contestResults);
     /* istanbul ignore next */
     if (contest.type === 'straight-party') {
-      straightPartyNotYetImplemented();
+      /**
+       * Simply skip the straight party contest for now so that the export
+       * doesn't crash.
+       *
+       * Including this reference for easy cataloging of straight party gaps:
+       * straightPartyNotYetImplemented()
+       */
+      continue;
     }
+    const contestResults = electionResults.contestResults[contest.id];
+    assert(contestResults);
     if (contest.type === 'yesno') {
       assert(contestResults.contestType === 'yesno');
       reportContests.push(buildBallotMeasureContest(contest, contestResults));

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -437,7 +437,10 @@ function BallotCountForm({
   const ballotStyleGroup = assertDefined(
     getBallotStyleGroup({ election, ballotStyleGroupId })
   );
-  const contests = getContests({ election, ballotStyle: ballotStyleGroup });
+  const contests = getContests({
+    election,
+    ballotStyle: ballotStyleGroup,
+  }).filter((c) => c.type !== 'straight-party'); // Simply skip the straight party contest for now
 
   const initialManualResults = convertTabulationResultsToFormResults(
     contests,
@@ -552,7 +555,10 @@ function ContestForm({
     getBallotStyleGroup({ election, ballotStyleGroupId })
   );
 
-  const contests = getContests({ election, ballotStyle: ballotStyleGroup });
+  const contests = getContests({
+    election,
+    ballotStyle: ballotStyleGroup,
+  }).filter((c) => c.type !== 'straight-party'); // Simply skip the straight party contest for now
   const contest = find(contests, (c) => c.id === contestId);
   const contestIndex = contests.indexOf(contest);
   const nextContest = contests[contestIndex + 1];


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/8822

We know that there are gaps to fill and refine in our straight party voting implementation per https://github.com/votingworks/vxsuite/issues/8734.

And we've taken the simple approach of crashing in places where haven't yet accounted for straight party voting. Many of these points are easily avoidable or can't even be reached at all, but at least two were in core-ish flows in the offline voting system: manual tally entry and CDF results exports. These would almost certainly get reported back to us as cert discrepancies. To preempt that, I've landed minimal solutions. For manual tally entry, this means not including the straight party contest in that flow. And for CDF results exports, this means not including the straight party contest in the export. Note that the effects of the straight party votes are of course still accounted for in the CDF results export.

I'll leave some notes in https://github.com/votingworks/vxsuite/issues/8734 to help us out whenever we come back to straight party voting.

## Testing

Tested manually by generating a straight party election, surfacing the two crashes before edits, and verifying that the crashes were no more after edits.

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [ ] ~I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~
