### PR TITLE
Avoid focus outline getting cut off for first contest on BMD review screen

### DIFF
--- a/libs/mark-flow-ui/src/components/review.tsx
+++ b/libs/mark-flow-ui/src/components/review.tsx
@@ -50,7 +50,7 @@ import {
 
 const Contest = styled.div`
   display: block;
-  margin: 0 0 0.75rem;
+  margin: 0.25rem 0 0.5rem;
   border: none;
   background: none;
   width: 100%;


### PR DESCRIPTION
## Overview

| Before | After |
| - | - |
| <img width="400" alt="before" src="https://github.com/user-attachments/assets/608fde82-d177-4762-8a13-d9046832c767" /> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/af810572-2a94-4f81-9de7-aaac5d77d1dc" /> |

Too late in the day to crop images lol, but you get the idea

## Testing Plan

Manual

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [ ] ~I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~