### PR TITLE
[VxAdmin] Add manual import button to CVR import panel

### DIFF
--- a/apps/admin/frontend/src/screens/tally/cvr_import_panel.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvr_import_panel.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type {
   CastVoteRecordFileRecord as CvrImport,
@@ -9,8 +9,9 @@ import type {
 import { UsbDriveStatus } from '@votingworks/usb-drive';
 import { mockUsbDriveStatus } from '@votingworks/ui';
 import userEvent from '@testing-library/user-event';
-
+import { mockKiosk } from '@votingworks/test-utils';
 import { deferred, err, ok, Result, sleep } from '@votingworks/basics';
+
 import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client';
 import { screen, waitFor, within } from '../../../test/react_testing_library';
 import { CvrImportPanel } from './cvr_import_panel';
@@ -23,6 +24,10 @@ import {
   location2,
   location2Export,
 } from '../../../test/helpers/cvrs';
+
+beforeEach(() => {
+  window.kiosk = mockKiosk(vi.fn);
+});
 
 describe('title reflects CVR mode', () => {
   async function expectTitle(api: ApiMock, title: string) {
@@ -235,11 +240,64 @@ test('disables controls while importing', async () => {
 
   expect(screen.getButton(new RegExp(location1.name))).toBeDisabled();
   expect(screen.getButton(new RegExp(location2.name))).toBeDisabled();
+  expect(screen.getButton(/Select CVR Export Manually/)).toBeDisabled();
   expect(screen.getButton('Done')).toBeDisabled();
 
   mockModeOfficial(api, []);
   deferredRes.resolve(ok(res));
   await waitFor(() => api.assertComplete());
+});
+
+test('supports manual file selection', async () => {
+  const api = createApiMock();
+  mockModeUnlocked(api);
+  mockUsbExports(api, []);
+
+  render(<CvrImportPanel onClose={vi.fn()} />, { api, usbStatus: 'mounted' });
+  await waitFor(() => api.assertComplete());
+
+  const mockPath = '/foo/metadata.json';
+  vi.mocked(window.kiosk)?.showOpenDialog.mockResolvedValueOnce({
+    canceled: false,
+    filePaths: [mockPath],
+  });
+
+  const res = resultFromExport(location1Export, {});
+  mockImportResult(api, mockPath, ok(res));
+  mockModeOfficial(api, []);
+
+  userEvent.click(screen.getButton(/Select CVR Export Manually/));
+  await waitFor(() => api.assertComplete());
+});
+
+test('handles user cancellation in manual file selection', async () => {
+  const api = createApiMock();
+  mockModeUnlocked(api);
+  mockUsbExports(api, []);
+
+  render(<CvrImportPanel onClose={vi.fn()} />, { api, usbStatus: 'mounted' });
+  await waitFor(() => api.assertComplete());
+
+  vi.mocked(window.kiosk)?.showOpenDialog.mockResolvedValueOnce({
+    canceled: true,
+    filePaths: [],
+  });
+
+  userEvent.click(screen.getButton(/Select CVR Export Manually/));
+  await waitFor(() => api.assertComplete());
+});
+
+test('omits manual file selector when running outside kiosk-browser', async () => {
+  const api = createApiMock();
+  mockModeUnlocked(api);
+  mockUsbExports(api, []);
+
+  delete window.kiosk;
+
+  render(<CvrImportPanel onClose={vi.fn()} />, { api, usbStatus: 'mounted' });
+  await waitFor(() => api.assertComplete());
+
+  expect(screen.queryButton(/Select.+Manually/)).not.toBeInTheDocument();
 });
 
 type CvrImportResult = Result<CvrImportOk, CvrImportErr>;

--- a/apps/admin/frontend/src/screens/tally/cvr_import_panel.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvr_import_panel.tsx
@@ -120,7 +120,8 @@ function Panel(props: {
         {children}
       </Body>
 
-      <div style={{ display: 'flex', justifyContent: 'end' }}>
+      <div style={{ display: 'flex', gap: GAP, justifyContent: 'end' }}>
+        {importer.manualImportButton}
         <Button
           disabled={disableClose}
           fill="outlined"

--- a/apps/admin/frontend/src/screens/tally/cvr_importer.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvr_importer.tsx
@@ -25,6 +25,7 @@ export type CvrImporter =
       state: 'duplicate';
       electionDefinition: ElectionDefinition;
       existingImports: ExistingImports;
+      manualImportButton?: undefined;
       result: CvrFileImportInfo;
       reset: () => void;
       usbExports: CvrExport[];
@@ -34,6 +35,7 @@ export type CvrImporter =
       electionDefinition: ElectionDefinition;
       errorMessage: string;
       existingImports: ExistingImports;
+      manualImportButton?: undefined;
       filename: string;
       reset: () => void;
       usbExports: CvrExport[];
@@ -42,6 +44,7 @@ export type CvrImporter =
       state: 'importing';
       electionDefinition: ElectionDefinition;
       existingImports: ExistingImports;
+      manualImportButton: React.ReactNode;
       path: string;
       usbExports: CvrExport[];
     }
@@ -55,12 +58,13 @@ export type CvrImporter =
     }
   | {
       state: 'loading';
+      manualImportButton?: undefined;
     }
   | {
       state: 'noUsb';
       electionDefinition: ElectionDefinition;
       existingImports: ExistingImports;
-      manualImportButton: React.ReactNode;
+      manualImportButton?: undefined;
     }
   | {
       state: 'success';
@@ -89,9 +93,6 @@ export function useCvrImporter(): CvrImporter {
   const usbExports = api.listCastVoteRecordFilesOnUsb.useQuery(usbDriveStatus);
 
   const importMutation = api.addCastVoteRecordFile.useMutation();
-  const manualImportButton = (
-    <ManualImportButton importFn={importMutation.mutate} />
-  );
 
   if (!imports.isSuccess || !cvrMode.isSuccess) {
     return { state: 'loading' };
@@ -111,7 +112,6 @@ export function useCvrImporter(): CvrImporter {
       state: 'noUsb',
       electionDefinition,
       existingImports,
-      manualImportButton,
     };
   }
 
@@ -124,6 +124,9 @@ export function useCvrImporter(): CvrImporter {
       state: 'importing',
       electionDefinition,
       existingImports,
+      manualImportButton: (
+        <ManualImportButton disabled importFn={importMutation.mutate} />
+      ),
       path: assertDefined(importMutation.variables).path,
       usbExports: usbExports.data,
     };
@@ -160,7 +163,9 @@ export function useCvrImporter(): CvrImporter {
       electionDefinition,
       existingImports,
       import: importMutation.mutate,
-      manualImportButton,
+      manualImportButton: (
+        <ManualImportButton importFn={importMutation.mutate} />
+      ),
       reset: importMutation.reset,
       result,
       usbExports: usbExports.data,
@@ -172,18 +177,18 @@ export function useCvrImporter(): CvrImporter {
     electionDefinition,
     existingImports,
     import: importMutation.mutate,
-    manualImportButton,
+    manualImportButton: <ManualImportButton importFn={importMutation.mutate} />,
     usbExports: usbExports.data,
   };
 }
 
-/* istanbul ignore next - TODO: remove once this is rendered in the new UI */
-function ManualImportButton(props: { importFn: ImportFn }) {
-  const { importFn } = props;
+function ManualImportButton(props: { disabled?: boolean; importFn: ImportFn }) {
+  const { disabled, importFn } = props;
 
   return (
     window.kiosk && (
       <Button
+        disabled={disabled}
         onPress={async () => {
           const kiosk = assertDefined(window.kiosk);
           const dialogResult = await kiosk.showOpenDialog({

--- a/apps/admin/frontend/src/screens/tally/cvr_usb_exports.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvr_usb_exports.test.tsx
@@ -156,6 +156,7 @@ test('import cards disabled while importing', () => {
     state: 'importing',
     electionDefinition,
     existingImports: { imports: [], mode: 'unlocked' },
+    manualImportButton: null,
     path: location2Export.path,
     usbExports: [location1Export, location2Export],
   };

--- a/apps/admin/frontend/vitest.config.ts
+++ b/apps/admin/frontend/vitest.config.ts
@@ -8,14 +8,13 @@ export default defineConfig({
 
     coverage: {
       thresholds: {
-        lines: -115,
-        branches: -137,
+        lines: -78,
+        branches: -113,
       },
       exclude: [
         'src/config',
         'src/**/*.d.ts',
         'src/index.tsx',
-        'src/demo_app.tsx',
         'src/stubs/*',
         '**/*.test.{ts,tsx}',
       ],


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/7958

Adding the manual file selector to the new import panel, for feature parity with the old modal.

One difference in dev, though: in the old modal, we made the button available for the "development" node env even when there's no USB drive inserted, but I believe that was from a time before the dev dock mock USB existed in its current form. Simplifies the app logic to leave out that special case and doesn't have much of an impact on dev flows.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/7d74e095-1456-491b-8dd6-e6dced463baf

## Testing Plan
- New unit test coverage + manual testing in kiosk-browser

## Checklist
N/A