### PR TITLE
Fix flaky dual-language BMD ballot test

### DIFF
--- a/libs/ui/src/bmd_paper_ballot.dual_language.test.tsx
+++ b/libs/ui/src/bmd_paper_ballot.dual_language.test.tsx
@@ -98,7 +98,8 @@ function expectSingleLanguageString(params: MockUiStringOutput) {
   ).not.toBeInTheDocument();
 }
 
-const { getLanguageContext, mockApiClient, render } = newUiStringsTestContext();
+const { getLanguageContext, mockApiClient, queryClient, render } =
+  newUiStringsTestContext();
 
 beforeEach(() => {
   mockApiClient.getAvailableLanguages.mockResolvedValueOnce(ballotLanguages);
@@ -359,17 +360,21 @@ describe('English ballot style', () => {
     // affected:
     act(() => getLanguageContext()!.setLanguage('es-US'));
 
-    // Wait for both the language context update and all cascading re-renders
-    // to settle. The language change triggers async effects in UiStringsLoader
-    // (via i18next resource updates and react-i18next re-renders), which can
-    // cause transient intermediate render states where LanguageOverride's
-    // nested context hasn't yet propagated to its children.
-    await waitFor(() => {
-      expect(getLanguageContext()?.currentLanguageCode).toEqual('es-US');
-      expect(container).not.toHaveTextContent(
-        new RegExp(getMockUiStringPrefix('es-US'))
-      );
+    // The language change kicks off async resource loads (e.g. UiStringsLoader
+    // fetching es-US strings/audio ids via react-query), which in turn drive
+    // i18next resource updates and react-i18next re-renders. Rather than
+    // racing those against a fixed-time waitFor (which previously flaked under
+    // CI load when the loads took longer than the default 1000ms timeout),
+    // wait on the actual, deterministic signal that all in-flight queries
+    // triggered by the language switch have settled.
+    await waitFor(() => expect(queryClient.isFetching()).toEqual(0), {
+      timeout: 5000,
     });
+
+    expect(getLanguageContext()?.currentLanguageCode).toEqual('es-US');
+    expect(container).not.toHaveTextContent(
+      new RegExp(getMockUiStringPrefix('es-US'))
+    );
   });
 
   test('no votes', async () => {


### PR DESCRIPTION
## Summary

See [this CircleCI run](https://app.circleci.com/pipelines/gh/votingworks/vxsuite/27511/details?useNewPipelines=true&workflowId=3591057b-28f3-4a60-af55-a0c30bdb3a29).

- The `English ballot style > all votes filled in` test in `libs/ui/src/bmd_paper_ballot.dual_language.test.tsx` raced a fixed-timeout `waitFor` (default 1000ms) against the async work triggered by switching the app-wide language: react-query fetches for `es-US` strings/audio ids, i18next resource updates, and cascading re-renders. Under CI load that work could exceed the timeout, producing an intermittent `expected 'en' to deeply equal 'es-US'` failure even though nothing was actually broken.
- Replaced the time-bound wait with a deterministic one: wait for `queryClient.isFetching()` to settle to `0` (with a longer 5000ms backstop timeout), then assert directly.
- Verified with a mutation test (temporarily broke `LanguageOverride`'s language clamp) that the real assertion still fails as expected — the fix doesn't weaken test coverage.

## Test plan
- [x] Ran `bmd_paper_ballot.dual_language.test.tsx` 25 consecutive times locally — all passed
- [x] Ran full `libs/ui` suite (`pnpm test:run`) — 168 files / 939 tests passed, no regressions
- [x] Confirmed lint/type-check pass on the changed file
- [x] Mutation test confirms the assertion still catches a real regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)