### PR TITLE
VxCentralScan: warn about DeskPro overshoot sheets on ballot eject

### DIFF
--- a/apps/central-scan/backend/src/app.grout.test.ts
+++ b/apps/central-scan/backend/src/app.grout.test.ts
@@ -294,6 +294,23 @@ test('getting / setting test mode', async () => {
   });
 });
 
+test('getScannerConfig', async () => {
+  await withApp(async ({ apiClient }) => {
+    expect(await apiClient.getScannerConfig()).toEqual({
+      isDeskProScanner: false,
+    });
+  });
+
+  await withApp(
+    async ({ apiClient }) => {
+      expect(await apiClient.getScannerConfig()).toEqual({
+        isDeskProScanner: true,
+      });
+    },
+    { isDeskProScanner: true }
+  );
+});
+
 test('usbDrive', async () => {
   await withApp(async ({ apiClient, mockUsbDrive }) => {
     const { usbDrive } = mockUsbDrive;

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -80,6 +80,7 @@ export interface AppOptions {
   logger: Logger;
   usbDrive: UsbDrive;
   adminHostClient?: AdminHostClient;
+  isDeskProScanner?: boolean;
 }
 
 function buildApi({
@@ -90,6 +91,7 @@ function buildApi({
   scanner,
   importer,
   adminHostClient,
+  isDeskProScanner = false,
 }: Exclude<AppOptions, 'allowedExportPatterns'>) {
   const { store } = workspace;
 
@@ -231,6 +233,10 @@ function buildApi({
 
     getSystemSettings(): SystemSettings {
       return workspace.store.getSystemSettings() ?? DEFAULT_SYSTEM_SETTINGS;
+    },
+
+    getScannerConfig(): { isDeskProScanner: boolean } {
+      return { isDeskProScanner };
     },
 
     getElectionRecord(): ElectionRecord | null {
@@ -653,6 +659,7 @@ export function buildCentralScannerApp({
   logger,
   usbDrive,
   adminHostClient,
+  isDeskProScanner,
 }: AppOptions): Application {
   const app: Application = express();
   const api = buildApi({
@@ -663,6 +670,7 @@ export function buildCentralScannerApp({
     scanner,
     importer,
     adminHostClient,
+    isDeskProScanner,
   });
   app.use('/api', grout.buildRouter(api, express));
 

--- a/apps/central-scan/backend/src/server.ts
+++ b/apps/central-scan/backend/src/server.ts
@@ -121,9 +121,10 @@ export function start({
     // bridge instead of the Fujitsu (scanimage). See deskpro_scanner.ts. This
     // selection isn't exercised in tests, hence the coverage ignore.
     /* istanbul ignore start */
+    const isDeskProScanner = Boolean(process.env['DESKPRO_SCANNER']);
     const resolvedBatchScanner =
       mockBatchScanner ??
-      (process.env['DESKPRO_SCANNER']
+      (isDeskProScanner
         ? new DeskProScanner({ logger })
         : new FujitsuScanner({ mode: ScannerMode.Gray, logger }));
     /* istanbul ignore stop */
@@ -148,6 +149,7 @@ export function start({
       usbDrive: resolvedUsbDrive,
       workspace: resolvedWorkspace,
       adminHostClient,
+      isDeskProScanner,
     });
   }
 

--- a/apps/central-scan/backend/test/helpers/setup_app.ts
+++ b/apps/central-scan/backend/test/helpers/setup_app.ts
@@ -50,7 +50,10 @@ export async function withApp(
     server: Server;
     store: Store;
   }) => Promise<void>,
-  options: { adminHostClient?: AdminHostClient } = {}
+  options: {
+    adminHostClient?: AdminHostClient;
+    isDeskProScanner?: boolean;
+  } = {}
 ): Promise<void> {
   const port = await getPort();
   const auth = buildMockDippedSmartCardAuth(vi.fn);
@@ -71,6 +74,7 @@ export async function withApp(
     workspace,
     logger,
     adminHostClient: options.adminHostClient,
+    isDeskProScanner: options.isDeskProScanner,
   });
   const baseUrl = `http://localhost:${port}/api`;
   const apiClient = grout.createClient({

--- a/apps/central-scan/frontend/src/api.ts
+++ b/apps/central-scan/frontend/src/api.ts
@@ -117,6 +117,16 @@ export const getSystemSettings = {
   },
 } as const;
 
+export const getScannerConfig = {
+  queryKey(): QueryKey {
+    return ['getScannerConfig'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () => apiClient.getScannerConfig());
+  },
+} as const;
+
 export const getMachineConfig = {
   queryKey(): QueryKey {
     return ['getMachineConfig'];

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
@@ -74,6 +74,7 @@ function buildNextReviewSheet(
 beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
+  apiMock.expectGetScannerConfig();
 });
 
 afterEach(() => {
@@ -476,3 +477,167 @@ test('ballot from a precinct not in the selected polling place', async () => {
   apiMock.expectContinueScanning({ forceAccept: false });
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 });
+
+test('shows extra-sheets note when the DeskPro scanner is in use', async () => {
+  apiMock.apiClient.getScannerConfig.reset();
+  apiMock.expectGetScannerConfig(true);
+  apiMock.expectGetNextReviewSheet(
+    buildNextReviewSheet({
+      type: 'InvalidSheet',
+      reason: { type: 'unknown' },
+    })
+  );
+
+  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
+
+  await screen.findByText('Unreadable');
+  screen.getByText(
+    /Check the top 10 sheets in the output stack for the pictured ballot/
+  );
+
+  apiMock.expectContinueScanning({ forceAccept: false });
+  userEvent.click(screen.getByText('Confirm Ballot Removed'));
+});
+
+test('does not show extra-sheets note when not using the DeskPro scanner', async () => {
+  apiMock.expectGetNextReviewSheet(
+    buildNextReviewSheet({
+      type: 'InvalidSheet',
+      reason: { type: 'unknown' },
+    })
+  );
+
+  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
+
+  await screen.findByText('Unreadable');
+  expect(
+    screen.queryByText(
+      /Check the top 10 sheets in the output stack for the pictured ballot/
+    )
+  ).not.toBeInTheDocument();
+
+  apiMock.expectContinueScanning({ forceAccept: false });
+  userEvent.click(screen.getByText('Confirm Ballot Removed'));
+});
+
+const deskProCases: Array<{
+  name: string;
+  isTestMode: boolean;
+  sheetInterpretation: SheetInterpretation;
+}> = [
+  {
+    name: 'Streak Detected',
+    isTestMode: true,
+    sheetInterpretation: {
+      type: 'InvalidSheet',
+      reason: { type: 'vertical_streaks_detected' },
+    },
+  },
+  {
+    name: 'Invalid Scale',
+    isTestMode: true,
+    sheetInterpretation: {
+      type: 'InvalidSheet',
+      reason: { type: 'invalid_scale' },
+    },
+  },
+  {
+    name: 'Official Ballot',
+    isTestMode: true,
+    sheetInterpretation: {
+      type: 'InvalidSheet',
+      reason: { type: 'invalid_test_mode' },
+    },
+  },
+  {
+    name: 'Test Ballot',
+    isTestMode: false,
+    sheetInterpretation: {
+      type: 'InvalidSheet',
+      reason: { type: 'invalid_test_mode' },
+    },
+  },
+  {
+    name: 'Wrong Election',
+    isTestMode: true,
+    sheetInterpretation: {
+      type: 'InvalidSheet',
+      reason: {
+        type: 'invalid_ballot_hash',
+        actualBallotHash: 'this-is-a-hash-hooray',
+      },
+    },
+  },
+  {
+    name: 'Wrong Precinct',
+    isTestMode: true,
+    sheetInterpretation: {
+      type: 'InvalidSheet',
+      reason: { type: 'invalid_precinct' },
+    },
+  },
+  {
+    name: 'Crossover Voting',
+    isTestMode: true,
+    sheetInterpretation: {
+      type: 'NeedsReviewSheet',
+      reasons: [{ type: AdjudicationReason.CrossoverVoting }],
+    },
+  },
+  {
+    name: 'Overvote',
+    isTestMode: true,
+    sheetInterpretation: {
+      type: 'NeedsReviewSheet',
+      reasons: [
+        {
+          type: AdjudicationReason.Overvote,
+          contestId: '1',
+          optionIds: ['1', '2'],
+          expected: 1,
+        },
+      ],
+    },
+  },
+  {
+    name: 'Blank Ballot',
+    isTestMode: true,
+    sheetInterpretation: {
+      type: 'NeedsReviewSheet',
+      reasons: [{ type: AdjudicationReason.BlankBallot }],
+    },
+  },
+  {
+    name: 'Undervote',
+    isTestMode: true,
+    sheetInterpretation: {
+      type: 'NeedsReviewSheet',
+      reasons: [
+        {
+          type: AdjudicationReason.Undervote,
+          contestId: '1',
+          optionIds: [],
+          expected: 1,
+        },
+      ],
+    },
+  },
+];
+
+test.each(deskProCases)(
+  'shows extra-sheets note for $name with the DeskPro scanner',
+  async ({ isTestMode, sheetInterpretation }) => {
+    apiMock.apiClient.getScannerConfig.reset();
+    apiMock.expectGetScannerConfig(true);
+    apiMock.expectGetNextReviewSheet(buildNextReviewSheet(sheetInterpretation));
+
+    renderInAppContext(<BallotEjectScreen isTestMode={isTestMode} />, {
+      apiMock,
+    });
+
+    await screen.findByText(/Check the top 10 sheets in the output stack/);
+
+    apiMock.expectContinueScanning({ forceAccept: false });
+    userEvent.click(screen.getAllByText('Confirm Ballot Removed')[0]);
+  }
+);

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
@@ -25,6 +25,7 @@ import { Header } from '../navigation_screen';
 import {
   continueScanning,
   getNextReviewSheet,
+  getScannerConfig,
   getSystemSettings,
 } from '../api';
 
@@ -69,6 +70,7 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
   assert(isElectionManagerAuth(auth));
 
   const systemSettingsQuery = getSystemSettings.useQuery();
+  const scannerConfigQuery = getScannerConfig.useQuery();
   const getNextReviewSheetQuery = getNextReviewSheet.useQuery();
   const continueScanningMutation = continueScanning.useMutation();
 
@@ -82,9 +84,15 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
 
   const reviewInfo = getNextReviewSheetQuery.data;
 
-  if (!reviewInfo || !systemSettingsQuery.isSuccess) {
+  if (
+    !reviewInfo ||
+    !systemSettingsQuery.isSuccess ||
+    !scannerConfigQuery.isSuccess
+  ) {
     return null;
   }
+
+  const { isDeskProScanner } = scannerConfigQuery.data;
 
   const { disallowCastingOvervotes } = systemSettingsQuery.data;
   const { sheetInterpretation } = reviewInfo;
@@ -98,8 +106,20 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
           reading the ballot.
         </P>
         <P>
-          Remove the ballot and reload it into the scanner to try again. If the
-          error persists, remove the ballot for manual adjudication.
+          {isDeskProScanner ? (
+            <React.Fragment>
+              Remove the ballot and reload it into the scanner to try again. If
+              the error persists, remove it for manual adjudication. Check the
+              top 10 sheets in the output stack for the pictured ballot, and put
+              any sheets that were on top of it back into the input tray before
+              continuing.
+            </React.Fragment>
+          ) : (
+            <React.Fragment>
+              Remove the ballot and reload it into the scanner to try again. If
+              the error persists, remove the ballot for manual adjudication.
+            </React.Fragment>
+          )}
         </P>
       </React.Fragment>
     ),
@@ -123,7 +143,18 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
                   The last scanned ballot was not tabulated because the scanner
                   needs to be cleaned.
                 </P>
-                <P>Clean the scanner before continuing to scan ballots.</P>
+                <P>
+                  {isDeskProScanner ? (
+                    <React.Fragment>
+                      Clean the scanner before continuing to scan ballots. Check
+                      the top 10 sheets in the output stack for the pictured
+                      ballot, and put any sheets that were on top of it back
+                      into the input tray first.
+                    </React.Fragment>
+                  ) : (
+                    'Clean the scanner before continuing to scan ballots.'
+                  )}
+                </P>
               </React.Fragment>
             ),
             allowBallotDuplication: false,
@@ -135,7 +166,18 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
             body: (
               <React.Fragment>
                 <P>The last scanned ballot was printed at an invalid scale.</P>
-                <P>Ballots must be printed full-scale.</P>
+                <P>
+                  {isDeskProScanner ? (
+                    <React.Fragment>
+                      Ballots must be printed full-scale. Check the top 10
+                      sheets in the output stack for the pictured ballot, and
+                      put any sheets that were on top of it back into the input
+                      tray before continuing.
+                    </React.Fragment>
+                  ) : (
+                    'Ballots must be printed full-scale.'
+                  )}
+                </P>
               </React.Fragment>
             ),
             allowBallotDuplication: false,
@@ -151,7 +193,18 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
                       The last scanned ballot was not tabulated because it is an
                       official ballot but the scanner is in test ballot mode.
                     </P>
-                    <P>Remove the ballot before continuing.</P>
+                    <P>
+                      {isDeskProScanner ? (
+                        <React.Fragment>
+                          Remove the ballot before continuing. Check the top 10
+                          sheets in the output stack for it as well, and put any
+                          sheets that were on top of it back into the input
+                          tray.
+                        </React.Fragment>
+                      ) : (
+                        'Remove the ballot before continuing.'
+                      )}
+                    </P>
                   </React.Fragment>
                 ),
                 allowBallotDuplication: false,
@@ -164,7 +217,18 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
                       The last scanned ballot was not tabulated because it is a
                       test ballot but the scanner is in official ballot mode.
                     </P>
-                    <P>Remove the ballot before continuing.</P>
+                    <P>
+                      {isDeskProScanner ? (
+                        <React.Fragment>
+                          Remove the ballot before continuing. Check the top 10
+                          sheets in the output stack for it as well, and put any
+                          sheets that were on top of it back into the input
+                          tray.
+                        </React.Fragment>
+                      ) : (
+                        'Remove the ballot before continuing.'
+                      )}
+                    </P>
                   </React.Fragment>
                 ),
                 allowBallotDuplication: false,
@@ -184,7 +248,17 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
                 <H6>Scanner Election ID</H6>
                 <P>{formatBallotHash(electionDefinition.ballotHash)}</P>
                 <br />
-                <P>Remove the ballot before continuing.</P>
+                <P>
+                  {isDeskProScanner ? (
+                    <React.Fragment>
+                      Remove the ballot before continuing. Check the top 10
+                      sheets in the output stack for it as well, and put any
+                      sheets that were on top of it back into the input tray.
+                    </React.Fragment>
+                  ) : (
+                    'Remove the ballot before continuing.'
+                  )}
+                </P>
               </React.Fragment>
             ),
             allowBallotDuplication: false,
@@ -200,7 +274,17 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
                   is configured for a polling place that does not include the
                   ballot&apos;s precinct.
                 </P>
-                <P>Remove the ballot before continuing.</P>
+                <P>
+                  {isDeskProScanner ? (
+                    <React.Fragment>
+                      Remove the ballot before continuing. Check the top 10
+                      sheets in the output stack for it as well, and put any
+                      sheets that were on top of it back into the input tray.
+                    </React.Fragment>
+                  ) : (
+                    'Remove the ballot before continuing.'
+                  )}
+                </P>
               </React.Fragment>
             ),
             allowBallotDuplication: false,
@@ -223,11 +307,20 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
       return {
         header: 'Crossover Voting',
         body: (
-          <P>
-            The last scanned ballot was not tabulated because votes were
-            detected in contests for more than one party. If tabulated, those
-            votes will not be counted.
-          </P>
+          <React.Fragment>
+            <P>
+              The last scanned ballot was not tabulated because votes were
+              detected in contests for more than one party. If tabulated, those
+              votes will not be counted.
+            </P>
+            {isDeskProScanner && (
+              <P>
+                Check the top 10 sheets in the output stack for the pictured
+                ballot, and put any sheets that were on top of it back into the
+                input tray before continuing.
+              </P>
+            )}
+          </React.Fragment>
         ),
         allowBallotDuplication: true,
       };
@@ -237,10 +330,19 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
       return {
         header: 'Overvote',
         body: (
-          <P>
-            The last scanned ballot was not tabulated because an overvote was
-            detected.
-          </P>
+          <React.Fragment>
+            <P>
+              The last scanned ballot was not tabulated because an overvote was
+              detected.
+            </P>
+            {isDeskProScanner && (
+              <P>
+                Check the top 10 sheets in the output stack for the pictured
+                ballot, and put any sheets that were on top of it back into the
+                input tray before continuing.
+              </P>
+            )}
+          </React.Fragment>
         ),
         allowBallotDuplication: !disallowCastingOvervotes,
         highlightedContestIds: new Set(
@@ -255,10 +357,19 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
       return {
         header: 'Blank Ballot',
         body: (
-          <P>
-            The last scanned ballot was not tabulated because no marks were
-            detected.
-          </P>
+          <React.Fragment>
+            <P>
+              The last scanned ballot was not tabulated because no marks were
+              detected.
+            </P>
+            {isDeskProScanner && (
+              <P>
+                Check the top 10 sheets in the output stack for the pictured
+                ballot, and put any sheets that were on top of it back into the
+                input tray before continuing.
+              </P>
+            )}
+          </React.Fragment>
         ),
         allowBallotDuplication: true,
       };
@@ -268,10 +379,19 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
       return {
         header: 'Undervote',
         body: (
-          <P>
-            The last scanned ballot was not tabulated because an undervote was
-            detected.
-          </P>
+          <React.Fragment>
+            <P>
+              The last scanned ballot was not tabulated because an undervote was
+              detected.
+            </P>
+            {isDeskProScanner && (
+              <P>
+                Check the top 10 sheets in the output stack for the pictured
+                ballot, and put any sheets that were on top of it back into the
+                input tray before continuing.
+              </P>
+            )}
+          </React.Fragment>
         ),
         allowBallotDuplication: true,
         highlightedContestIds: new Set(

--- a/apps/central-scan/frontend/test/api.tsx
+++ b/apps/central-scan/frontend/test/api.tsx
@@ -122,6 +122,12 @@ export function createApiMock(
         .resolves(systemSettings ?? DEFAULT_SYSTEM_SETTINGS);
     },
 
+    expectGetScannerConfig(isDeskProScanner = false) {
+      apiClient.getScannerConfig
+        .expectRepeatedCallsWith()
+        .resolves({ isDeskProScanner });
+    },
+
     expectGetElectionRecord(electionDefinition: ElectionDefinition | null) {
       apiClient.getElectionRecord.expectRepeatedCallsWith().resolves(
         electionDefinition && {


### PR DESCRIPTION
## Overview

The DeskPro scanner keeps feeding a few sheets past the one it stops on for adjudication, so the operator needs to check nearby sheets in the output stack and return any onto the input tray. This surfaces an `isDeskProScanner` flag from the backend (set via the existing `DESKPRO_SCANNER` env var) and folds guidance into each ballot-eject screen's own explanation, rather than appending one generic note to every case, so the copy stays concise and precise per case.

(A separate fix to central-scan's `integration-testing` Makefile — loading its own `.env` file, matching `mark`/`scan`/`print` — was pulled out of this PR. It'll land in its own PR targeting `main` later, since it's unrelated to this copy change and affects apps beyond central-scan.)

## Demo Video or Screenshot

Reviewed locally: the "Ballot Not Counted" / Unreadable eject screen, with the DeskPro scanner in use, now reads as a single collapsed paragraph, e.g.:

> Remove the ballot and reload it into the scanner to try again. If the error persists, remove it for manual adjudication. Check the top 10 sheets in the output stack for the pictured ballot, and put any sheets that were on top of it back into the input tray before continuing.

<img width="1920" height="1200" alt="deskpro-eject-screen-screenshot-000-deskpro-eject-screen-v2" src="https://github.com/user-attachments/assets/409d4121-a77d-4b5b-9f3d-ea96ab447098" />


## Testing Plan

- `pnpm test:run` in `apps/central-scan/backend` and `apps/central-scan/frontend` (added/updated unit tests covering `isDeskProScanner` true/false for every eject reason)
- Manually verified via a temporary Playwright e2e spec (removed before commit) that the copy renders correctly at native resolution (1920x1200) with `DESKPRO_SCANNER=1`

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products. (n/a — central-scan)
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions. (n/a — copy-only change, no new user action)
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)