### PR TITLE
test(e2e): load `.env` in `Makefile` consistently across apps

### DIFF
--- a/apps/admin/integration-testing/Makefile
+++ b/apps/admin/integration-testing/Makefile
@@ -1,6 +1,12 @@
 APP := ..
 export ADMIN_WORKSPACE=/tmp/admin-integration-testing
 
+# Load and export environment variables from this package's .env file so they
+# take precedence over any .env.local overrides in the frontend/backend
+# packages when running locally.
+include .env
+export
+
 build:
 	# building the frontend builds the backend too
 	make -C $(APP)/frontend install; \

--- a/apps/central-scan/integration-testing/Makefile
+++ b/apps/central-scan/integration-testing/Makefile
@@ -4,6 +4,12 @@ export SCAN_WORKSPACE=/tmp/central-scan-integration-testing
 export REACT_APP_VX_ENABLE_DEV_DOCK=TRUE
 export REACT_APP_VX_USE_MOCK_CENTRAL_SCANNER=TRUE
 
+# Load and export environment variables from this package's .env file so they
+# take precedence over any .env.local overrides in the frontend/backend
+# packages when running locally.
+include .env
+export
+
 build-frontend:
 	make -C $(APP)/frontend install; \
 	make -C $(APP)/frontend build; \

--- a/apps/mark-scan/integration-testing/Makefile
+++ b/apps/mark-scan/integration-testing/Makefile
@@ -2,7 +2,9 @@ APP := ..
 export PIPENV_VENV_IN_PROJECT=1
 export MARK_SCAN_WORKSPACE=/tmp/mark-scan-integration-testing
 
-# Load environment variables from .env file
+# Load and export environment variables from this package's .env file so they
+# take precedence over any .env.local overrides in the frontend/backend
+# packages when running locally.
 include .env
 export
 


### PR DESCRIPTION
## Overview

central-scan's `Makefile` never loaded its `.env` file itself, so `REACT_APP_VX_USE_MOCK_USB_DRIVE` et al only reached the backend by accident, via Playwright's own `dotenv.config()` call reaching the `webServer` child process it spawns. Running `make run` by hand (e.g. to debug or grab a screenshot) silently produced a backend with no mock USB drive and no obvious error.

Adds the same `include .env` / `export` block that mark, scan, and print already have, so `make run` behaves correctly regardless of who invokes it. mark-scan already had the mechanism, so this just updates the comment to match.

## Demo Video or Screenshot
n/a

## Testing Plan
Ran `make run` locally and ensured that `.env` took precedence over `.env.local` for the server spawned for integration testing.