### PR TITLE
Upgrade pnpm to v10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1837,11 +1837,9 @@ commands:
           name: Ensure Rust tooling is in PATH
           command: |
             echo 'export PATH="/root/.cargo/bin:$PATH"' >> $BASH_ENV
-      # TODO: Remove once the CI base images ship pnpm 10 (VX_DOCKER images).
       - run:
-          name: Install pnpm 10
+          name: Fix node-gyp gyp entrypoint permissions
           command: |
-            npm install --global pnpm@10.34.5
             # TODO: Remove once we upgrade past pnpm 11.10, which ships
             # node-gyp with the gyp entrypoints executable.
             # See https://github.com/pnpm/pnpm/issues/12455

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,14 +12,14 @@ orbs:
 executors:
   nodejs:
     docker:
-      - image: votingworks/cimg-debian12:4.5.0
+      - image: votingworks/cimg-debian12:4.6.0
         auth:
           username: $VX_DOCKER_USERNAME
           password: $VX_DOCKER_PASSWORD
 
   nodejs_postgres:
     docker:
-      - image: votingworks/cimg-debian12:4.5.0
+      - image: votingworks/cimg-debian12:4.6.0
         auth:
           username: $VX_DOCKER_USERNAME
           password: $VX_DOCKER_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1837,6 +1837,10 @@ commands:
           name: Ensure Rust tooling is in PATH
           command: |
             echo 'export PATH="/root/.cargo/bin:$PATH"' >> $BASH_ENV
+      # TODO: Remove once the CI base images ship pnpm 10 (VX_DOCKER images).
+      - run:
+          name: Install pnpm 10
+          command: npm install --global pnpm@10.34.5
       - checkout
       # Edit this comment somehow in order to invalidate the CircleCI cache.
       # Since the contents of this file affect the cache key, editing only a
@@ -1857,7 +1861,7 @@ commands:
                 key:
                   pnpm-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum "pnpm-lock.yaml" }}
                 paths:
-                  - /root/.local/share/pnpm/store/v3
+                  - /root/.local/share/pnpm/store/v10
                   - /root/.cache/ms-playwright
       - restore_cache:
           name: Restore Cargo Cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1840,7 +1840,12 @@ commands:
       # TODO: Remove once the CI base images ship pnpm 10 (VX_DOCKER images).
       - run:
           name: Install pnpm 10
-          command: npm install --global pnpm@10.34.5
+          command: |
+            npm install --global pnpm@10.34.5
+            # TODO: Remove once we upgrade past pnpm 11.10, which ships
+            # node-gyp with the gyp entrypoints executable.
+            # See https://github.com/pnpm/pnpm/issues/12455
+            chmod +x "$(npm root -g)/pnpm/dist/node_modules/node-gyp/gyp/gyp" "$(npm root -g)/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py"
       - checkout
       # Edit this comment somehow in order to invalidate the CircleCI cache.
       # Since the contents of this file affect the cache key, editing only a

--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -92,5 +92,5 @@
     "supertest": "^6.0.1",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -126,7 +126,7 @@
     "vite": "8.0.16",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.34.5",
   "vx": {
     "env": {
       "VX_MACHINE_TYPE": "admin"

--- a/apps/admin/frontend/prodserver/package.json
+++ b/apps/admin/frontend/prodserver/package.json
@@ -8,5 +8,5 @@
     "http-proxy-middleware": "3.0.7",
     "resolve": "1.18.1"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/admin/integration-testing/package.json
+++ b/apps/admin/integration-testing/package.json
@@ -36,5 +36,5 @@
     "eslint-plugin-vx": "workspace:*",
     "sort-package-json": "^1.50.0"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -80,5 +80,5 @@
     "supertest": "^6.0.1",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/central-scan/frontend/package.json
+++ b/apps/central-scan/frontend/package.json
@@ -109,7 +109,7 @@
     "vite": "8.0.16",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.34.5",
   "vx": {
     "env": {
       "VX_MACHINE_TYPE": "central-scan"

--- a/apps/central-scan/frontend/prodserver/package.json
+++ b/apps/central-scan/frontend/prodserver/package.json
@@ -7,5 +7,5 @@
     "express": "4.18.2",
     "http-proxy-middleware": "3.0.7"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/central-scan/integration-testing/package.json
+++ b/apps/central-scan/integration-testing/package.json
@@ -31,5 +31,5 @@
     "eslint-plugin-vx": "workspace:*",
     "sort-package-json": "^1.50.0"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -110,5 +110,5 @@
     "sort-package-json": "^1.50.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/design/frontend/package.json
+++ b/apps/design/frontend/package.json
@@ -118,7 +118,7 @@
     "vite": "8.0.16",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.34.5",
   "vx": {
     "isBundled": true,
     "services": [

--- a/apps/mark-scan/backend/package.json
+++ b/apps/mark-scan/backend/package.json
@@ -80,5 +80,5 @@
     "sort-package-json": "^1.50.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/mark-scan/frontend/package.json
+++ b/apps/mark-scan/frontend/package.json
@@ -108,7 +108,7 @@
     "vite": "8.0.16",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.34.5",
   "vx": {
     "env": {
       "VX_MACHINE_TYPE": "mark-scan"

--- a/apps/mark-scan/frontend/prodserver/package.json
+++ b/apps/mark-scan/frontend/prodserver/package.json
@@ -7,5 +7,5 @@
     "express": "4.18.2",
     "http-proxy-middleware": "3.0.7"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/mark-scan/integration-testing/package.json
+++ b/apps/mark-scan/integration-testing/package.json
@@ -30,5 +30,5 @@
     "eslint-plugin-vx": "workspace:*",
     "sort-package-json": "^1.50.0"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/mark/backend/package.json
+++ b/apps/mark/backend/package.json
@@ -75,5 +75,5 @@
     "sort-package-json": "^1.50.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/mark/frontend/package.json
+++ b/apps/mark/frontend/package.json
@@ -109,7 +109,7 @@
     "vite": "8.0.16",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.34.5",
   "vx": {
     "env": {
       "VX_MACHINE_TYPE": "mark"

--- a/apps/mark/frontend/prodserver/package.json
+++ b/apps/mark/frontend/prodserver/package.json
@@ -7,5 +7,5 @@
     "express": "4.18.2",
     "http-proxy-middleware": "3.0.7"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/mark/integration-testing/package.json
+++ b/apps/mark/integration-testing/package.json
@@ -32,5 +32,5 @@
     "eslint-plugin-vx": "workspace:*",
     "sort-package-json": "^1.50.0"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/pollbook/backend/.circleci/config.yml
+++ b/apps/pollbook/backend/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
 executors:
   nodejs:
     docker:
-      - image: votingworks/cimg-debian12:4.5.0
+      - image: votingworks/cimg-debian12:4.6.0
         auth:
           username: $VX_DOCKER_USERNAME
           password: $VX_DOCKER_PASSWORD

--- a/apps/pollbook/backend/.circleci/config.yml
+++ b/apps/pollbook/backend/.circleci/config.yml
@@ -24,6 +24,10 @@ commands:
           name: Ensure Rust tooling is in PATH
           command: |
             echo 'export PATH="/root/.cargo/bin:$PATH"' >> $BASH_ENV
+      # TODO: Remove once the CI base images ship pnpm 10 (VX_DOCKER images).
+      - run:
+          name: Install pnpm 10
+          command: npm install --global pnpm@10.34.5
       - checkout
       # Edit this comment somehow in order to invalidate the CircleCI cache.
       # Since the contents of this file affect the cache key, editing only a
@@ -46,7 +50,7 @@ commands:
                   pnpm-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum
                   "pnpm-lock.yaml" }}
                 paths:
-                  - /root/.local/share/pnpm/store/v3
+                  - /root/.local/share/pnpm/store/v10
                   - /root/.cache/ms-playwright
       - restore_cache:
           name: Restore Cargo Cache

--- a/apps/pollbook/backend/.circleci/config.yml
+++ b/apps/pollbook/backend/.circleci/config.yml
@@ -24,11 +24,9 @@ commands:
           name: Ensure Rust tooling is in PATH
           command: |
             echo 'export PATH="/root/.cargo/bin:$PATH"' >> $BASH_ENV
-      # TODO: Remove once the CI base images ship pnpm 10 (VX_DOCKER images).
       - run:
-          name: Install pnpm 10
+          name: Fix node-gyp gyp entrypoint permissions
           command: |
-            npm install --global pnpm@10.34.5
             # TODO: Remove once we upgrade past pnpm 11.10, which ships
             # node-gyp with the gyp entrypoints executable.
             # See https://github.com/pnpm/pnpm/issues/12455

--- a/apps/pollbook/backend/.circleci/config.yml
+++ b/apps/pollbook/backend/.circleci/config.yml
@@ -27,7 +27,12 @@ commands:
       # TODO: Remove once the CI base images ship pnpm 10 (VX_DOCKER images).
       - run:
           name: Install pnpm 10
-          command: npm install --global pnpm@10.34.5
+          command: |
+            npm install --global pnpm@10.34.5
+            # TODO: Remove once we upgrade past pnpm 11.10, which ships
+            # node-gyp with the gyp entrypoints executable.
+            # See https://github.com/pnpm/pnpm/issues/12455
+            chmod +x "$(npm root -g)/pnpm/dist/node_modules/node-gyp/gyp/gyp" "$(npm root -g)/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py"
       - checkout
       # Edit this comment somehow in order to invalidate the CircleCI cache.
       # Since the contents of this file affect the cache key, editing only a

--- a/apps/pollbook/backend/package.json
+++ b/apps/pollbook/backend/package.json
@@ -90,5 +90,5 @@
     "tmp": "^0.2.6",
     "yargs": "17.7.1"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/pollbook/frontend/package.json
+++ b/apps/pollbook/frontend/package.json
@@ -108,7 +108,7 @@
     "vite": "8.0.16",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.34.5",
   "vx": {
     "env": {
       "VX_MACHINE_TYPE": "poll-book"

--- a/apps/pollbook/frontend/prodserver/package.json
+++ b/apps/pollbook/frontend/prodserver/package.json
@@ -8,5 +8,5 @@
     "http-proxy-middleware": "3.0.7",
     "resolve": "1.18.1"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/print/backend/package.json
+++ b/apps/print/backend/package.json
@@ -78,5 +78,5 @@
     "nodemon": "^3.1.7",
     "sort-package-json": "^1.50.0"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/print/frontend/package.json
+++ b/apps/print/frontend/package.json
@@ -94,7 +94,7 @@
     "vite": "8.0.16",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.34.5",
   "vx": {
     "env": {
       "VX_MACHINE_TYPE": "print"

--- a/apps/print/frontend/prodserver/package.json
+++ b/apps/print/frontend/prodserver/package.json
@@ -8,5 +8,5 @@
     "http-proxy-middleware": "3.0.7",
     "resolve": "1.18.1"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/print/integration-testing/package.json
+++ b/apps/print/integration-testing/package.json
@@ -32,5 +32,5 @@
     "eslint-plugin-vx": "workspace:*",
     "sort-package-json": "^1.50.0"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -87,5 +87,5 @@
     "vitest": "^4.1.6",
     "wait-for-expect": "^3.0.2"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -108,7 +108,7 @@
     "vite": "8.0.16",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.34.5",
   "vx": {
     "env": {
       "VX_MACHINE_TYPE": "scan"

--- a/apps/scan/frontend/prodserver/package.json
+++ b/apps/scan/frontend/prodserver/package.json
@@ -7,5 +7,5 @@
     "express": "4.18.2",
     "http-proxy-middleware": "3.0.7"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/apps/scan/integration-testing/package.json
+++ b/apps/scan/integration-testing/package.json
@@ -31,5 +31,5 @@
     "eslint-plugin-vx": "workspace:*",
     "sort-package-json": "^1.50.0"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/docs/exercises/package.json
+++ b/docs/exercises/package.json
@@ -25,5 +25,5 @@
     "sort-package-json": "^1.50.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -58,5 +58,5 @@
     "vitest": "^4.1.6",
     "wait-for-expect": "^3.0.2"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -79,5 +79,5 @@
     "sort-package-json": "^1.50.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -42,5 +42,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -82,5 +82,5 @@
       "x86_64-unknown-linux-gnu"
     ]
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/basics/package.json
+++ b/libs/basics/package.json
@@ -36,5 +36,5 @@
     "sort-package-json": "^1.50.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/bmd-ballot-fixtures/package.json
+++ b/libs/bmd-ballot-fixtures/package.json
@@ -56,5 +56,5 @@
   "peerDependencies": {
     "react": "18.3.1"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/cdf-schema-builder/package.json
+++ b/libs/cdf-schema-builder/package.json
@@ -46,5 +46,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/custom-paper-handler/package.json
+++ b/libs/custom-paper-handler/package.json
@@ -44,5 +44,5 @@
     "is-ci-cli": "2.2.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -40,5 +40,5 @@
     "tmp": "^0.2.6",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/dev-dock/backend/package.json
+++ b/libs/dev-dock/backend/package.json
@@ -50,5 +50,5 @@
     "sort-package-json": "^1.50.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/dev-dock/frontend/package.json
+++ b/libs/dev-dock/frontend/package.json
@@ -63,5 +63,5 @@
     "react": "18.3.1",
     "styled-components": "^5.3.11"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/eslint-plugin-vx/package.json
+++ b/libs/eslint-plugin-vx/package.json
@@ -52,5 +52,5 @@
     "react": "18.3.1",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/fixture-generators/package.json
+++ b/libs/fixture-generators/package.json
@@ -58,5 +58,5 @@
     "tmp": "^0.2.6",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/fixtures/package.json
+++ b/libs/fixtures/package.json
@@ -42,5 +42,5 @@
     "sort-package-json": "^1.50.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/fs/package.json
+++ b/libs/fs/package.json
@@ -50,5 +50,5 @@
     "tmp": "^0.2.6",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/fujitsu-thermal-printer/package.json
+++ b/libs/fujitsu-thermal-printer/package.json
@@ -44,5 +44,5 @@
     "is-ci-cli": "2.2.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/grout/package.json
+++ b/libs/grout/package.json
@@ -42,5 +42,5 @@
     "vitest": "^4.1.6",
     "wait-for-expect": "^3.0.2"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/grout/test-utils/package.json
+++ b/libs/grout/test-utils/package.json
@@ -37,5 +37,5 @@
   "peerDependencies": {
     "@votingworks/grout": "workspace:*"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/hmpb/package.json
+++ b/libs/hmpb/package.json
@@ -77,5 +77,5 @@
     "vite": "8.0.16",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/image-utils/package.json
+++ b/libs/image-utils/package.json
@@ -47,5 +47,5 @@
     "is-ci-cli": "2.2.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/integration-test-utils/package.json
+++ b/libs/integration-test-utils/package.json
@@ -48,5 +48,5 @@
     "sort-package-json": "^1.50.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/logging-utils/package.json
+++ b/libs/logging-utils/package.json
@@ -43,5 +43,5 @@
       "x86_64-unknown-linux-gnu"
     ]
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -56,5 +56,5 @@
     "sort-package-json": "^1.50.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/mark-flow-ui/package.json
+++ b/libs/mark-flow-ui/package.json
@@ -103,5 +103,5 @@
     "react-dom": "18.3.1",
     "styled-components": "^5.3.11"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/message-coder/package.json
+++ b/libs/message-coder/package.json
@@ -32,5 +32,5 @@
     "is-ci-cli": "2.2.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/monorepo-utils/package.json
+++ b/libs/monorepo-utils/package.json
@@ -44,5 +44,5 @@
     "typescript": "npm:@typescript/typescript6@6.0.2",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -291,7 +291,12 @@ function generateCircleCiFilteredAppConfigForPackage(
     '      # TODO: Remove once the CI base images ship pnpm 10 (VX_DOCKER images).',
     '      - run:',
     '          name: Install pnpm 10',
-    '          command: npm install --global pnpm@10.34.5',
+    '          command: |',
+    '            npm install --global pnpm@10.34.5',
+    '            # TODO: Remove once we upgrade past pnpm 11.10, which ships',
+    '            # node-gyp with the gyp entrypoints executable.',
+    '            # See https://github.com/pnpm/pnpm/issues/12455',
+    '            chmod +x "$(npm root -g)/pnpm/dist/node_modules/node-gyp/gyp/gyp" "$(npm root -g)/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py"',
     '      - checkout',
     '      # Edit this comment somehow in order to invalidate the CircleCI cache.',
     '      # Since the contents of this file affect the cache key, editing only a',
@@ -498,7 +503,12 @@ commands:
       # TODO: Remove once the CI base images ship pnpm 10 (VX_DOCKER images).
       - run:
           name: Install pnpm 10
-          command: npm install --global pnpm@10.34.5
+          command: |
+            npm install --global pnpm@10.34.5
+            # TODO: Remove once we upgrade past pnpm 11.10, which ships
+            # node-gyp with the gyp entrypoints executable.
+            # See https://github.com/pnpm/pnpm/issues/12455
+            chmod +x "$(npm root -g)/pnpm/dist/node_modules/node-gyp/gyp/gyp" "$(npm root -g)/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py"
       - checkout
       # Edit this comment somehow in order to invalidate the CircleCI cache.
       # Since the contents of this file affect the cache key, editing only a

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -288,6 +288,10 @@ function generateCircleCiFilteredAppConfigForPackage(
     '          name: Ensure Rust tooling is in PATH',
     '          command: |',
     '            echo \'export PATH="/root/.cargo/bin:$PATH"\' >> $BASH_ENV',
+    '      # TODO: Remove once the CI base images ship pnpm 10 (VX_DOCKER images).',
+    '      - run:',
+    '          name: Install pnpm 10',
+    '          command: npm install --global pnpm@10.34.5',
     '      - checkout',
     '      # Edit this comment somehow in order to invalidate the CircleCI cache.',
     '      # Since the contents of this file affect the cache key, editing only a',
@@ -310,7 +314,7 @@ function generateCircleCiFilteredAppConfigForPackage(
     '                  pnpm-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum',
     '                  "pnpm-lock.yaml" }}',
     '                paths:',
-    '                  - /root/.local/share/pnpm/store/v3',
+    '                  - /root/.local/share/pnpm/store/v10',
     '                  - /root/.cache/ms-playwright',
     '      - restore_cache:',
     '          name: Restore Cargo Cache',
@@ -491,6 +495,10 @@ commands:
           name: Ensure Rust tooling is in PATH
           command: |
             echo 'export PATH="/root/.cargo/bin:$PATH"' >> $BASH_ENV
+      # TODO: Remove once the CI base images ship pnpm 10 (VX_DOCKER images).
+      - run:
+          name: Install pnpm 10
+          command: npm install --global pnpm@10.34.5
       - checkout
       # Edit this comment somehow in order to invalidate the CircleCI cache.
       # Since the contents of this file affect the cache key, editing only a
@@ -511,7 +519,7 @@ commands:
                 key:
                   pnpm-cache-{{ checksum ".circleci/config.yml" }}-{{ checksum "pnpm-lock.yaml" }}
                 paths:
-                  - /root/.local/share/pnpm/store/v3
+                  - /root/.local/share/pnpm/store/v10
                   - /root/.cache/ms-playwright
       - restore_cache:
           name: Restore Cargo Cache

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -272,7 +272,7 @@ function generateCircleCiFilteredAppConfigForPackage(
     'executors:',
     '  nodejs:',
     '    docker:',
-    '      - image: votingworks/cimg-debian12:4.5.0',
+    '      - image: votingworks/cimg-debian12:4.6.0',
     '        auth:',
     '          username: $VX_DOCKER_USERNAME',
     '          password: $VX_DOCKER_PASSWORD',
@@ -418,14 +418,14 @@ orbs:
 executors:
   nodejs:
     docker:
-      - image: votingworks/cimg-debian12:4.5.0
+      - image: votingworks/cimg-debian12:4.6.0
         auth:
           username: $VX_DOCKER_USERNAME
           password: $VX_DOCKER_PASSWORD
 
   nodejs_postgres:
     docker:
-      - image: votingworks/cimg-debian12:4.5.0
+      - image: votingworks/cimg-debian12:4.6.0
         auth:
           username: $VX_DOCKER_USERNAME
           password: $VX_DOCKER_PASSWORD

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -288,11 +288,9 @@ function generateCircleCiFilteredAppConfigForPackage(
     '          name: Ensure Rust tooling is in PATH',
     '          command: |',
     '            echo \'export PATH="/root/.cargo/bin:$PATH"\' >> $BASH_ENV',
-    '      # TODO: Remove once the CI base images ship pnpm 10 (VX_DOCKER images).',
     '      - run:',
-    '          name: Install pnpm 10',
+    '          name: Fix node-gyp gyp entrypoint permissions',
     '          command: |',
-    '            npm install --global pnpm@10.34.5',
     '            # TODO: Remove once we upgrade past pnpm 11.10, which ships',
     '            # node-gyp with the gyp entrypoints executable.',
     '            # See https://github.com/pnpm/pnpm/issues/12455',
@@ -500,11 +498,9 @@ commands:
           name: Ensure Rust tooling is in PATH
           command: |
             echo 'export PATH="/root/.cargo/bin:$PATH"' >> $BASH_ENV
-      # TODO: Remove once the CI base images ship pnpm 10 (VX_DOCKER images).
       - run:
-          name: Install pnpm 10
+          name: Fix node-gyp gyp entrypoint permissions
           command: |
-            npm install --global pnpm@10.34.5
             # TODO: Remove once we upgrade past pnpm 11.10, which ships
             # node-gyp with the gyp entrypoints executable.
             # See https://github.com/pnpm/pnpm/issues/12455

--- a/libs/networking/package.json
+++ b/libs/networking/package.json
@@ -44,5 +44,5 @@
     "sort-package-json": "^1.50.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/pdi-scanner/package.json
+++ b/libs/pdi-scanner/package.json
@@ -49,5 +49,5 @@
     "is-ci-cli": "2.2.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/printing/package.json
+++ b/libs/printing/package.json
@@ -62,5 +62,5 @@
     "sort-package-json": "^1.50.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/test-decks/package.json
+++ b/libs/test-decks/package.json
@@ -51,5 +51,5 @@
     "sort-package-json": "^1.50.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -49,5 +49,5 @@
     "sort-package-json": "^1.50.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -58,5 +58,5 @@
     "sort-package-json": "^1.50.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -134,5 +134,5 @@
     "react-dom": "18.3.1",
     "styled-components": "^5.3.11"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/usb-drive/package.json
+++ b/libs/usb-drive/package.json
@@ -45,5 +45,5 @@
     "sort-package-json": "^1.50.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -59,5 +59,5 @@
     "sort-package-json": "^1.50.0",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }

--- a/package.json
+++ b/package.json
@@ -53,8 +53,16 @@
     "typescript": "npm:@typescript/typescript6@6.0.2",
     "vitest": "^4.1.6"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.34.5",
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "canvas",
+      "esbuild",
+      "node-hid",
+      "pcsclite",
+      "usb"
+    ],
     "overrides": {
       "@babel/traverse": "7.23.2",
       "@types/eslint": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
       "canvas",
       "esbuild",
       "node-hid",
+      "node-quirc",
       "pcsclite",
       "usb"
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   nan: ^2.20.0
   typescript: npm:@typescript/typescript6@6.0.2
 
-pnpmfileChecksum: uetddhm7yuyz4oy3jwth2zsotq
+pnpmfileChecksum: sha256-eJokq7EzJEMySZukx+IFLhIhOHaScrqbyNUKycTI+/k=
 
 importers:
 
@@ -113,7 +113,7 @@ importers:
         version: 5.2.0
       postcss-styled-syntax:
         specifier: ^0.4.0
-        version: 0.4.0(@typescript/typescript6@6.0.2)(postcss@8.4.27)
+        version: 0.4.0(@typescript/typescript6@6.0.2)(postcss@8.5.16)
       prettier:
         specifier: ^3.0.3
         version: 3.0.3
@@ -2595,7 +2595,7 @@ importers:
         version: 0.2.7
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.29.0)(@jest/types@29.6.3)(@typescript/typescript6@6.0.2)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.28.1)(jest@29.6.2(@types/node@20.17.31)(babel-plugin-macros@3.1.0))
+        version: 29.1.1(@babel/core@7.29.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.28.1)(jest@29.6.2(@types/node@20.17.31)(babel-plugin-macros@3.1.0))(typescript@7.0.2)
       vite:
         specifier: 8.0.16
         version: 8.0.16(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2)
@@ -2906,7 +2906,7 @@ importers:
         version: 1.53.1
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.29.0)(@jest/types@29.6.3)(@typescript/typescript6@6.0.2)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.28.1)(jest@29.6.2(@types/node@20.17.31)(babel-plugin-macros@3.1.0))
+        version: 29.1.1(@babel/core@7.29.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.28.1)(jest@29.6.2(@types/node@20.17.31)(babel-plugin-macros@3.1.0))(typescript@7.0.2)
       vite:
         specifier: 8.0.16
         version: 8.0.16(@types/node@20.17.31)(esbuild@0.28.1)(yaml@2.8.2)
@@ -5107,7 +5107,7 @@ importers:
         version: 7.2.2
       '@storybook/react':
         specifier: ^7.2.2
-        version: 7.2.2(@typescript/typescript6@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 7.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@7.0.2)
       '@tanstack/react-query':
         specifier: 4.32.1
         version: 4.32.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5182,7 +5182,7 @@ importers:
         version: 6.0.3
       eslint-plugin-storybook:
         specifier: ^0.6.10
-        version: 0.6.10(@typescript/typescript6@6.0.2)(eslint@8.57.0)
+        version: 0.6.10(eslint@8.57.0)(typescript@7.0.2)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -5842,7 +5842,7 @@ importers:
         version: 7.2.2
       '@storybook/react':
         specifier: ^7.2.2
-        version: 7.2.2(@typescript/typescript6@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 7.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@7.0.2)
       '@tanstack/react-query':
         specifier: 4.32.1
         version: 4.32.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5950,7 +5950,7 @@ importers:
         version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-storybook:
         specifier: ^0.6.10
-        version: 0.6.10(@typescript/typescript6@6.0.2)(eslint@8.57.0)
+        version: 0.6.10(eslint@8.57.0)(typescript@7.0.2)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -8015,7 +8015,7 @@ packages:
   '@joshwooding/vite-plugin-react-docgen-typescript@0.2.1':
     resolution: {integrity: sha512-ou4ZJSXMMWHqGS4g8uNRbC5TiTWxAgQZiVucoUrOCWuPrTbkpJbmVyIi9jU72SBry7gQtuMEDp4YR8EEXAg7VQ==}
     peerDependencies:
-      typescript: npm:@typescript/typescript6@6.0.2
+      typescript: '>= 4.3.x'
       vite: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       typescript:
@@ -8141,42 +8141,49 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/lzma-linux-arm64-musl@1.4.5':
     resolution: {integrity: sha512-yWjcPDgJ2nIL3KNvi4536dlT/CcCWO0DUyEOlBs/SacG7BeD6IjGh6yYzd3/X1Y3JItCbZoDoLUH8iB1lTXo3w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/lzma-linux-ppc64-gnu@1.4.5':
     resolution: {integrity: sha512-0XRhKuIU/9ZjT4WDIG/qnX7Xz7mSQHYZo9Gb3MP2gcvBgr6BA4zywQ9k3gmQaPn9ECE+CZg2V7DV7kT+x2pUMQ==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/lzma-linux-riscv64-gnu@1.4.5':
     resolution: {integrity: sha512-QrqDIPEUUB23GCpyQj/QFyMlr8SGxxyExeZz9OWFnHfb70kXdTLWrHS/hEI1Ru+lSbQ/6xRqeoGyQ4Aqdg+/RA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/lzma-linux-s390x-gnu@1.4.5':
     resolution: {integrity: sha512-k8RVM5aMhW86E9H0QXdquwojew4H3SwPxbRVbl49/COJQWCUjGi79X6mYruMnMPEznZinUiT1jgKbFo2A00NdA==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/lzma-linux-x64-gnu@1.4.5':
     resolution: {integrity: sha512-6rMtBgnIq2Wcl1rQdZsnM+rtCcVCbws1nF8S2NzaUsVaZv8bjrPiAa0lwg4Eqnn1d9lgwqT+cZgm5m+//K08Kw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/lzma-linux-x64-musl@1.4.5':
     resolution: {integrity: sha512-eiadGBKi7Vd0bCArBUOO/qqRYPHt/VQVvGyYvDFt6C2ZSIjlD+HuOl+2oS1sjf4CFjK4eDIog6EdXnL0NE6iyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/lzma-wasm32-wasi@1.4.5':
     resolution: {integrity: sha512-+VyHHlr68dvey6fXc2hehw9gHVFIW3TtGF1XkcbAu65qVXsA9D/T+uuoRVqhE+JCyFHFrO0ixRbZDRK1XJt1sA==}
@@ -8246,36 +8253,42 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/tar-linux-arm64-musl@1.1.0':
     resolution: {integrity: sha512-L/y1/26q9L/uBqiW/JdOb/Dc94egFvNALUZV2WCGKQXc6UByPBMgdiEyW2dtoYxYYYYc+AKD+jr+wQPcvX2vrQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/tar-linux-ppc64-gnu@1.1.0':
     resolution: {integrity: sha512-EPE1K/80RQvPbLRJDJs1QmCIcH+7WRi0F73+oTe1582y9RtfGRuzAkzeBuAGRXAQEjRQw/RjtNqr6UTJ+8UuWQ==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/tar-linux-s390x-gnu@1.1.0':
     resolution: {integrity: sha512-B2jhWiB1ffw1nQBqLUP1h4+J1ovAxBOoe5N2IqDMOc63fsPZKNqF1PvO/dIem8z7LL4U4bsfmhy3gBfu547oNQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/tar-linux-x64-gnu@1.1.0':
     resolution: {integrity: sha512-tbZDHnb9617lTnsDMGo/eAMZxnsQFnaRe+MszRqHguKfMwkisc9CCJnks/r1o84u5fECI+J/HOrKXgczq/3Oww==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/tar-linux-x64-musl@1.1.0':
     resolution: {integrity: sha512-dV6cODlzbO8u6Anmv2N/ilQHq/AWz0xyltuXoLU3yUyXbZcnWYZuB2rL8OBGPmqNcD+x9NdScBNXh7vWN0naSQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/tar-wasm32-wasi@1.1.0':
     resolution: {integrity: sha512-jIa9nb2HzOrfH0F8QQ9g3WE4aMH5vSI5/1NYVNm9ysCmNjCCtMXCAhlI3WKCdm/DwHf0zLqdrrtDFXODcNaqMw==}
@@ -8348,24 +8361,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/wasm-tools-linux-arm64-musl@1.0.1':
     resolution: {integrity: sha512-jAasbIvjZXCgX0TCuEFQr+4D6Lla/3AAVx2LmDuMjgG4xoIXzjKWl7c4chuaD+TI+prWT0X6LJcdzFT+ROKGHQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/wasm-tools-linux-x64-gnu@1.0.1':
     resolution: {integrity: sha512-Plgk5rPqqK2nocBGajkMVbGm010Z7dnUgq0wtnYRZbzWWxwWcXfZMPa8EYxrK4eE8SzpI7VlZP1tdVsdjgGwMw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/wasm-tools-linux-x64-musl@1.0.1':
     resolution: {integrity: sha512-GW7AzGuWxtQkyHknHWYFdR0CHmW6is8rG2Rf4V6GNmMpmwtXt/ItWYWtBe4zqJWycMNazpfZKSw/BpT7/MVCXQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/wasm-tools-wasm32-wasi@1.0.1':
     resolution: {integrity: sha512-/nQVSTrqSsn7YdAc2R7Ips/tnw5SPUcl3D7QrXCNGPqjbatIspnaexvaOYNyKMU6xPu+pc0BTnKVmqhlJJCPLA==}
@@ -9020,36 +9037,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -9622,7 +9645,7 @@ packages:
     resolution: {integrity: sha512-3YDxZPJsHOsRQob/85X2Xf6pYfwbQilJBsEcuwmEV0JEO4p3JijOlO8xV58uCjkZSpuJ0ARl6t5oCMBo89DKCQ==}
     peerDependencies:
       '@preact/preset-vite': '*'
-      typescript: npm:@typescript/typescript6@6.0.2
+      typescript: '>= 4.3.x'
       vite: ^3.0.0 || ^4.0.0
       vite-plugin-glimmerx: '*'
     peerDependenciesMeta:
@@ -9751,7 +9774,7 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-      typescript: npm:@typescript/typescript6@6.0.2
+      typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -10334,27 +10357,27 @@ packages:
     peerDependencies:
       '@typescript-eslint/parser': ^8.59.2
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: npm:@typescript/typescript6@6.0.2
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/parser@8.59.2':
     resolution: {integrity: sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: npm:@typescript/typescript6@6.0.2
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/project-service@8.59.2':
     resolution: {integrity: sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: npm:@typescript/typescript6@6.0.2
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/rule-tester@8.59.2':
     resolution: {integrity: sha512-u6yY503P7E76xIzIQw2R6FCJwwifh0fOJsOWtkpEPeUUVmUApi1Hdnahz5mKSqRDi5wUN+iiUBedM0qZ41owYw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: npm:@typescript/typescript6@6.0.2
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/scope-manager@5.62.0':
     resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
@@ -10372,14 +10395,14 @@ packages:
     resolution: {integrity: sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: npm:@typescript/typescript6@6.0.2
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/type-utils@8.59.2':
     resolution: {integrity: sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: npm:@typescript/typescript6@6.0.2
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/types@5.62.0':
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
@@ -10415,7 +10438,7 @@ packages:
     resolution: {integrity: sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: npm:@typescript/typescript6@6.0.2
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/utils@5.62.0':
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
@@ -10434,7 +10457,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: npm:@typescript/typescript6@6.0.2
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/visitor-keys@5.62.0':
     resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
@@ -13600,24 +13623,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -14946,7 +14973,7 @@ packages:
   react-docgen-typescript@2.2.2:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
-      typescript: npm:@typescript/typescript6@6.0.2
+      typescript: '>= 4.3.x'
 
   react-docgen@6.0.0-alpha.3:
     resolution: {integrity: sha512-DDLvB5EV9As1/zoUsct6Iz2Cupw9FObEGD3DMcIs3EDFIoSKyz8FZtoWj3Wj+oodrU4/NfidN0BL5yrapIcTSA==}
@@ -15976,13 +16003,13 @@ packages:
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
     engines: {node: '>=16'}
     peerDependencies:
-      typescript: npm:@typescript/typescript6@6.0.2
+      typescript: '>=4.2.0'
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
-      typescript: npm:@typescript/typescript6@6.0.2
+      typescript: '>=4.8.4'
 
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
@@ -15998,7 +16025,7 @@ packages:
       babel-jest: ^29.0.0
       esbuild: '*'
       jest: ^29.0.0
-      typescript: npm:@typescript/typescript6@6.0.2
+      typescript: '>=4.3 <6'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -16028,7 +16055,7 @@ packages:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
-      typescript: npm:@typescript/typescript6@6.0.2
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -17274,7 +17301,7 @@ snapshots:
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-member-expression-to-functions': 7.22.5
       '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.29.0)
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
@@ -17285,12 +17312,6 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.2.2
 
-  '@babel/helper-create-regexp-features-plugin@7.20.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.22.5
-      regexpu-core: 5.2.2
-
   '@babel/helper-create-regexp-features-plugin@7.22.9(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
@@ -17298,27 +17319,9 @@ snapshots:
       regexpu-core: 5.3.2
       semver: 6.3.1
 
-  '@babel/helper-create-regexp-features-plugin@7.22.9(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.22.5
-      regexpu-core: 5.3.2
-      semver: 6.3.1
-
   '@babel/helper-define-polyfill-provider@0.4.2(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
-      debug: 4.3.4(supports-color@5.5.0)
-      lodash.debounce: 4.0.8
-      resolve: 1.18.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-define-polyfill-provider@0.4.2(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.26.5
       debug: 4.3.4(supports-color@5.5.0)
@@ -17402,23 +17405,9 @@ snapshots:
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-wrap-function': 7.22.10
 
-  '@babel/helper-remap-async-to-generator@7.22.9(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-wrap-function': 7.22.10
-
   '@babel/helper-replace-supers@7.22.9(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-member-expression-to-functions': 7.22.5
-      '@babel/helper-optimise-call-expression': 7.22.5
-
-  '@babel/helper-replace-supers@7.22.9(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-environment-visitor': 7.24.7
       '@babel/helper-member-expression-to-functions': 7.22.5
       '@babel/helper-optimise-call-expression': 7.22.5
@@ -17476,24 +17465,12 @@ snapshots:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.22.9)
-
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.29.0)
 
   '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.29.0)':
     dependencies:
@@ -17517,10 +17494,6 @@ snapshots:
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.22.9)':
     dependencies:
@@ -17562,19 +17535,9 @@ snapshots:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-
   '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-flow@7.18.6(@babel/core@7.29.0)':
@@ -17587,19 +17550,9 @@ snapshots:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-
   '@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.29.0)':
@@ -17728,20 +17681,9 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.26.5
-
   '@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-async-generator-functions@7.22.10(@babel/core@7.22.9)':
@@ -17752,14 +17694,6 @@ snapshots:
       '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.22.9)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.22.9)
 
-  '@babel/plugin-transform-async-generator-functions@7.22.10(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.29.0)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.0)
-
   '@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
@@ -17769,33 +17703,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-
   '@babel/plugin-transform-block-scoping@7.22.10(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-transform-block-scoping@7.22.10(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.22.9)':
@@ -17804,25 +17719,12 @@ snapshots:
       '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.26.5
-
   '@babel/plugin-transform-class-static-block@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.22.9)
-
-  '@babel/plugin-transform-class-static-block@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0)
 
   '@babel/plugin-transform-classes@7.22.6(@babel/core@7.22.9)':
     dependencies:
@@ -17837,28 +17739,9 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
 
-  '@babel/plugin-transform-classes@7.22.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-function-name': 7.24.7
-      '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.29.0)
-      '@babel/helper-split-export-declaration': 7.22.6
-      globals: 11.12.0
-
   '@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/template': 7.28.6
-
-  '@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/template': 7.28.6
 
@@ -17867,31 +17750,15 @@ snapshots:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-destructuring@7.22.10(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-
   '@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.26.5
-
   '@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-dynamic-import@7.22.5(@babel/core@7.22.9)':
@@ -17900,21 +17767,9 @@ snapshots:
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.9)
 
-  '@babel/plugin-transform-dynamic-import@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0)
-
   '@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.10
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.10
       '@babel/helper-plugin-utils': 7.26.5
 
@@ -17923,12 +17778,6 @@ snapshots:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.22.9)
-
-  '@babel/plugin-transform-export-namespace-from@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.29.0)
 
   '@babel/plugin-transform-flow-strip-types@7.19.0(@babel/core@7.29.0)':
     dependencies:
@@ -17941,21 +17790,9 @@ snapshots:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-for-of@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-
   '@babel/plugin-transform-function-name@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-function-name': 7.24.7
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-transform-function-name@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-plugin-utils': 7.26.5
@@ -17966,20 +17803,9 @@ snapshots:
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.22.9)
 
-  '@babel/plugin-transform-json-strings@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0)
-
   '@babel/plugin-transform-literals@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-transform-literals@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-logical-assignment-operators@7.22.5(@babel/core@7.22.9)':
@@ -17988,34 +17814,15 @@ snapshots:
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.22.9)
 
-  '@babel/plugin-transform-logical-assignment-operators@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
-
   '@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.22.9)
-      '@babel/helper-plugin-utils': 7.26.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.26.5
     transitivePeerDependencies:
       - supports-color
@@ -18032,7 +17839,7 @@ snapshots:
   '@babel/plugin-transform-modules-commonjs@7.22.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-simple-access': 7.22.5
     transitivePeerDependencies:
@@ -18048,28 +17855,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/helper-validator-identifier': 7.25.9
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.22.9)
-      '@babel/helper-plugin-utils': 7.26.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.26.5
     transitivePeerDependencies:
       - supports-color
@@ -18080,20 +17869,9 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.26.5
-
   '@babel/plugin-transform-new-target@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-transform-new-target@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.22.5(@babel/core@7.22.9)':
@@ -18102,23 +17880,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.22.9)
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
-
   '@babel/plugin-transform-numeric-separator@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.22.9)
-
-  '@babel/plugin-transform-numeric-separator@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.0)
 
   '@babel/plugin-transform-object-rest-spread@7.22.5(@babel/core@7.22.9)':
     dependencies:
@@ -18129,38 +17895,17 @@ snapshots:
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.9)
       '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.22.9)
 
-  '@babel/plugin-transform-object-rest-spread@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/compat-data': 7.26.3
-      '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.29.0)
-
   '@babel/plugin-transform-object-super@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-replace-supers': 7.22.9(@babel/core@7.22.9)
 
-  '@babel/plugin-transform-object-super@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.29.0)
-
   '@babel/plugin-transform-optional-catch-binding@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.22.9)
-
-  '@babel/plugin-transform-optional-catch-binding@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.0)
 
   '@babel/plugin-transform-optional-chaining@7.22.10(@babel/core@7.22.9)':
     dependencies:
@@ -18169,33 +17914,15 @@ snapshots:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.9)
 
-  '@babel/plugin-transform-optional-chaining@7.22.10(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
-
   '@babel/plugin-transform-parameters@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-transform-parameters@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.22.9)
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-private-property-in-object@7.22.5(@babel/core@7.22.9)':
@@ -18206,22 +17933,9 @@ snapshots:
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.22.9)
 
-  '@babel/plugin-transform-private-property-in-object@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.22.10(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
-
   '@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-react-jsx-development@7.18.6(@babel/core@7.26.0)':
@@ -18268,30 +17982,14 @@ snapshots:
       '@babel/helper-plugin-utils': 7.26.5
       regenerator-transform: 0.15.2
 
-  '@babel/plugin-transform-regenerator@7.22.10(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-      regenerator-transform: 0.15.2
-
   '@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-
   '@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-spread@7.22.5(@babel/core@7.22.9)':
@@ -18300,20 +17998,9 @@ snapshots:
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
-  '@babel/plugin-transform-spread@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-
   '@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.22.9)':
@@ -18321,19 +18008,9 @@ snapshots:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-
   '@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-typescript@7.16.8(@babel/core@7.29.0)':
@@ -18348,21 +18025,10 @@ snapshots:
       '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-unicode-escapes@7.22.10(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-
   '@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.22.9)':
@@ -18371,28 +18037,16 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.26.5
-
   '@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-unicode-sets-regex@7.22.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/preset-env@7.22.10(@babel/core@7.22.9)':
+  '@babel/preset-env@7.22.10(@babel/core@7.29.0)':
     dependencies:
       '@babel/compat-data': 7.26.3
-      '@babel/core': 7.22.9
+      '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-validator-option': 7.25.9
@@ -18475,92 +18129,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-env@7.22.10(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/compat-data': 7.26.3
-      '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.25.9
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/helper-validator-option': 7.25.9
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-generator-functions': 7.22.10(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoping': 7.22.10(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-destructuring': 7.22.10(@babel/core@7.29.0)
-      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-dynamic-import': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-export-namespace-from': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-json-strings': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-numeric-separator': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.22.10(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.29.0)
-      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.29.0)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0)
-      '@babel/types': 7.26.0
-      babel-plugin-polyfill-corejs2: 0.4.5(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs3: 0.8.3(@babel/core@7.29.0)
-      babel-plugin-polyfill-regenerator: 0.5.2(@babel/core@7.29.0)
-      core-js-compat: 3.32.0
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/preset-flow@7.18.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -18571,13 +18139,6 @@ snapshots:
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.22.9)':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/types': 7.29.0
-      esutils: 2.0.3
-
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/types': 7.29.0
       esutils: 2.0.3
@@ -21479,7 +21040,7 @@ snapshots:
   '@storybook/cli@7.2.2':
     dependencies:
       '@babel/core': 7.22.9
-      '@babel/preset-env': 7.22.10(@babel/core@7.22.9)
+      '@babel/preset-env': 7.22.10(@babel/core@7.29.0)
       '@babel/types': 7.22.5
       '@ndelangen/get-tarball': 3.0.9
       '@storybook/codemod': 7.2.2
@@ -21817,6 +21378,37 @@ snapshots:
       util-deprecate: 1.0.2
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@storybook/react@7.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@7.0.2)':
+    dependencies:
+      '@storybook/client-logger': 7.2.2
+      '@storybook/core-client': 7.2.2
+      '@storybook/docs-tools': 7.2.2
+      '@storybook/global': 5.0.0
+      '@storybook/preview-api': 7.2.2
+      '@storybook/react-dom-shim': 7.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/types': 7.2.2
+      '@types/escodegen': 0.0.6
+      '@types/estree': 0.0.51
+      '@types/node': 16.18.23
+      acorn: 7.4.1
+      acorn-jsx: 5.3.2(acorn@7.4.1)
+      acorn-walk: 7.2.0
+      escodegen: 2.0.0
+      html-tags: 3.3.1
+      lodash: 4.17.21
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-element-to-jsx-string: 15.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      ts-dedent: 2.2.0
+      type-fest: 2.19.0
+      util-deprecate: 1.0.2
+    optionalDependencies:
+      typescript: 7.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -22530,12 +22122,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.59.2(eslint@8.57.0)(typescript@7.0.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@7.0.2)
+      '@typescript-eslint/visitor-keys': 8.59.2
+      debug: 4.4.3
+      eslint: 8.57.0
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.59.2(@typescript/typescript6@6.0.2)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.59.2(@typescript/typescript6@6.0.2)
       '@typescript-eslint/types': 8.59.2
       debug: 4.4.3
       typescript: '@typescript/typescript6@6.0.2'
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.2(typescript@7.0.2)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@7.0.2)
+      '@typescript-eslint/types': 8.59.2
+      debug: 4.4.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -22572,6 +22185,10 @@ snapshots:
     dependencies:
       typescript: '@typescript/typescript6@6.0.2'
 
+  '@typescript-eslint/tsconfig-utils@8.59.2(typescript@7.0.2)':
+    dependencies:
+      typescript: 7.0.2
+
   '@typescript-eslint/type-utils@8.59.2(@typescript/typescript6@6.0.2)(eslint@8.57.0)':
     dependencies:
       '@typescript-eslint/types': 8.59.2
@@ -22601,6 +22218,20 @@ snapshots:
       tsutils: 3.21.0(@typescript/typescript6@6.0.2)
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@7.0.2)':
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/visitor-keys': 5.62.0
+      debug: 4.3.4(supports-color@5.5.0)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.7.2
+      tsutils: 3.21.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -22634,15 +22265,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.62.0(@typescript/typescript6@6.0.2)(eslint@8.57.0)':
+  '@typescript-eslint/typescript-estree@8.59.2(typescript@7.0.2)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.2(typescript@7.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@7.0.2)
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/visitor-keys': 8.59.2
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.5.0(typescript@7.0.2)
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@7.0.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.0)
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
-      '@typescript-eslint/parser': 8.59.2(@typescript/typescript6@6.0.2)(eslint@8.57.0)
+      '@typescript-eslint/parser': 8.59.2(eslint@8.57.0)(typescript@7.0.2)
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@7.0.2)
       eslint: 8.57.0
       eslint-scope: 5.1.1
       semver: 7.7.4
@@ -23158,15 +22804,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs2@0.4.5(@babel/core@7.29.0):
-    dependencies:
-      '@babel/compat-data': 7.26.3
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.29.0)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-polyfill-corejs3@0.8.3(@babel/core@7.22.9):
     dependencies:
       '@babel/core': 7.22.9
@@ -23175,25 +22812,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.8.3(@babel/core@7.29.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.29.0)
-      core-js-compat: 3.32.0
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-polyfill-regenerator@0.5.2(@babel/core@7.22.9):
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.9)
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-plugin-polyfill-regenerator@0.5.2(@babel/core@7.29.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -24508,10 +24130,10 @@ snapshots:
       semver: 6.3.0
       string.prototype.matchall: 4.0.7
 
-  eslint-plugin-storybook@0.6.10(@typescript/typescript6@6.0.2)(eslint@8.57.0):
+  eslint-plugin-storybook@0.6.10(eslint@8.57.0)(typescript@7.0.2):
     dependencies:
       '@storybook/csf': 0.0.1
-      '@typescript-eslint/utils': 5.62.0(@typescript/typescript6@6.0.2)(eslint@8.57.0)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@7.0.2)
       eslint: 8.57.0
       requireindex: 1.2.0
       ts-dedent: 2.2.0
@@ -26268,7 +25890,7 @@ snapshots:
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.0)
       '@babel/plugin-proposal-optional-chaining': 7.20.7(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.29.0)
-      '@babel/preset-env': 7.22.10(@babel/core@7.22.9)
+      '@babel/preset-env': 7.22.10(@babel/core@7.29.0)
       '@babel/preset-flow': 7.18.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.16.7(@babel/core@7.29.0)
       '@babel/register': 7.18.9(@babel/core@7.29.0)
@@ -27441,11 +27063,11 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-styled-syntax@0.4.0(@typescript/typescript6@6.0.2)(postcss@8.4.27):
+  postcss-styled-syntax@0.4.0(@typescript/typescript6@6.0.2)(postcss@8.5.16):
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(@typescript/typescript6@6.0.2)
       estree-walker: 2.0.2
-      postcss: 8.4.27
+      postcss: 8.5.16
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -29052,9 +28674,13 @@ snapshots:
     dependencies:
       typescript: '@typescript/typescript6@6.0.2'
 
+  ts-api-utils@2.5.0(typescript@7.0.2):
+    dependencies:
+      typescript: 7.0.2
+
   ts-dedent@2.2.0: {}
 
-  ts-jest@29.1.1(@babel/core@7.29.0)(@jest/types@29.6.3)(@typescript/typescript6@6.0.2)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.28.1)(jest@29.6.2(@types/node@20.17.31)(babel-plugin-macros@3.1.0)):
+  ts-jest@29.1.1(@babel/core@7.29.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.28.1)(jest@29.6.2(@types/node@20.17.31)(babel-plugin-macros@3.1.0))(typescript@7.0.2):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -29064,7 +28690,7 @@ snapshots:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.7.2
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.29.0
@@ -29091,6 +28717,11 @@ snapshots:
     dependencies:
       tslib: 1.14.1
       typescript: '@typescript/typescript6@6.0.2'
+
+  tsutils@3.21.0(typescript@7.0.2):
+    dependencies:
+      tslib: 1.14.1
+      typescript: 7.0.2
 
   tunnel-agent@0.6.0:
     dependencies:

--- a/script/package.json
+++ b/script/package.json
@@ -23,5 +23,5 @@
     "prettier": "3.0.3",
     "typescript": "npm:@typescript/typescript6@6.0.2"
   },
-  "packageManager": "pnpm@9.15.9"
+  "packageManager": "pnpm@10.34.5"
 }


### PR DESCRIPTION
## Overview

Pairs with https://github.com/votingworks/vxsuite-build-system/pull/254. Once that is merged and the CI images are built, this PR can be updated to use the new images and drop the commit to upgrade pnpm.

Updates `pnpm` to 10.34.5. The main difference in this version compared to v9 is that v10 longer runs dependency build scripts by default. Packages needing them must be listed in `pnpm.onlyBuiltDependencies` in vxsuite's `package.json`.

## Demo Video or Screenshot
n/a

## Testing Plan
`pnpm install` locally, CI build.
