### PR TITLE
[ca-demo] VxCentralScan: Pause Batches instead of Finalizing when Scan Errors are hit

### DIFF
--- a/apps/central-scan/backend/src/importer.test.ts
+++ b/apps/central-scan/backend/src/importer.test.ts
@@ -219,7 +219,7 @@ test('batch controls require the right batch state', async () => {
   expect(workspace.store.getBatches()[0].endedAt).toBeDefined();
 });
 
-test('a scanner error finishes the batch with an error', async () => {
+test('a scanner error pauses the batch so it can be retried', async () => {
   const { importer, workspace, scanner } = setupImporter();
   importer.configure(electionDefinition, 'test-jurisdiction', 'test-hash');
   workspace.store.setPollingPlaceId(anyPollingPlace(election).id);
@@ -229,10 +229,64 @@ test('a scanner error finishes the batch with an error', async () => {
   await importer.startImport();
   await importer.waitForEndOfBatchOrScanningPause();
 
+  // the batch stays open, paused with an error, instead of being finished
+  expect(importer.getStatus().currentBatch).toEqual({
+    batchId: expect.any(String),
+    state: 'paused',
+    pauseReason: 'error',
+  });
+  expect(workspace.store.getBatches()[0].endedAt).toBeUndefined();
+
+  // continuing retries with a fresh scanner session
+  scanner.withNextScannerSession().end();
+  importer.continueBatch();
+  await importer.waitForEndOfBatchOrScanningPause();
+  expect(importer.getStatus().currentBatch).toEqual({
+    batchId: expect.any(String),
+    state: 'paused',
+    pauseReason: 'tray-empty',
+  });
+
+  await importer.saveBatch();
   expect(importer.getStatus().currentBatch).toBeUndefined();
+  expect(workspace.store.getBatches()[0].endedAt).toBeDefined();
+});
+
+test('a scanner error finishes the batch if pausing also fails', async () => {
+  const { workspace } = setupImporter();
+
+  // A scanner whose sheet stream errors AND whose session refuses to end, so
+  // pausing the batch is impossible.
+  const scanner: BatchScanner = {
+    isAttached: vi.fn().mockReturnValue(true),
+    isImprinterAttached: vi.fn().mockResolvedValue(false),
+    scanSheets: () => {
+      const control: BatchControl = {
+        scanSheet: vi.fn().mockRejectedValue(new Error('scan failed')),
+        endBatch: vi.fn().mockRejectedValue(new Error('end failed')),
+      };
+      return control;
+    },
+  };
+
+  const importer = new Importer({
+    workspace,
+    scanner,
+    logger: mockLogger({ fn: vi.fn }),
+  });
+  importer.configure(electionDefinition, 'test-jurisdiction', 'test-hash');
+  workspace.store.setPollingPlaceId(anyPollingPlace(election).id);
+
+  await importer.startImport();
+  await vi.waitFor(() => {
+    expect(importer.getStatus().currentBatch).toBeUndefined();
+  });
+
+  // last resort: the batch is finished, recording the error
   const batches = workspace.store.getBatches();
   expect(batches).toHaveLength(1);
   expect(batches[0].endedAt).toBeDefined();
+  expect(batches[0].error).toContain('scan failed');
 });
 
 test('startImport cleans up batch on failure after addBatch', async () => {

--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -421,24 +421,37 @@ export class Importer {
   }
 
   /**
-   * Kick off scanning the next sheet, routing failures to `finishBatch`.
+   * Kick off scanning the next sheet, pausing the batch on failure.
    */
   private scanNextSheet(): void {
-    this.scanOneSheet().catch((error) => {
+    this.scanOneSheet().catch(async (error) => {
       const message = extractErrorMessage(error);
       debug('processing sheet failed with error: %s', message);
       void this.logger.logAsCurrentRole(LogEventId.ScanSheetComplete, {
         disposition: 'failure',
         message: `Processing sheet failed: ${message}`,
       });
-      void this.finishBatch(message).catch((finishError) => {
-        void this.logger.logAsCurrentRole(LogEventId.ScanBatchComplete, {
-          disposition: 'failure',
-          message: `Additionally, finishing batch failed: ${extractErrorMessage(
-            finishError
-          )}`,
+      try {
+        // Pause rather than finish the batch: an error (e.g. a failure to
+        // open a fresh scanner session when continuing a batch) must not take
+        // the in-progress batch away from the operator. They can retry with
+        // "Continue Scanning", or save or cancel what was scanned so far.
+        await this.pauseBatch('error');
+      } catch (pauseError) {
+        debug(
+          'pausing batch after error failed: %s',
+          extractErrorMessage(pauseError)
+        );
+        // Last resort: end the batch, recording the original error.
+        void this.finishBatch(message).catch((finishError) => {
+          void this.logger.logAsCurrentRole(LogEventId.ScanBatchComplete, {
+            disposition: 'failure',
+            message: `Additionally, finishing batch failed: ${extractErrorMessage(
+              finishError
+            )}`,
+          });
         });
-      });
+      }
     });
   }
 
@@ -597,6 +610,13 @@ export class Importer {
       currentBatch.stopRequested = true;
       await currentBatch.sheetGenerator.endBatch();
       await this.waitForEndOfBatchOrScanningPause();
+
+      // The scan loop may have ended the batch while we waited (last-resort
+      // error handling); in that case there is nothing left to cancel.
+      /* istanbul ignore next - timing-dependent race */
+      if (this.currentBatch !== currentBatch) {
+        throw new Error('batch already ended');
+      }
     }
 
     this.currentBatch = undefined;

--- a/apps/central-scan/backend/src/mock_batch_scanner.test.ts
+++ b/apps/central-scan/backend/src/mock_batch_scanner.test.ts
@@ -23,16 +23,16 @@ test('initial status checks pass as expected', async () => {
   const scanner = createScanner();
   expect(scanner.isAttached()).toEqual(true);
   expect(await scanner.isImprinterAttached()).toEqual(false);
-  expect(scanner.getStatus()).toEqual({ sheetCount: 0 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 0, errorQueued: false });
 });
 
 test('addSheets and getStatus', () => {
   const scanner = createScanner();
   scanner.addSheets([inputSheet(1), inputSheet(2)]);
-  expect(scanner.getStatus()).toEqual({ sheetCount: 2 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 2, errorQueued: false });
 
   scanner.addSheets([inputSheet(3)]);
-  expect(scanner.getStatus()).toEqual({ sheetCount: 3 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 3, errorQueued: false });
 });
 
 test('sheetCopies loads each added sheet multiple times', async () => {
@@ -40,7 +40,7 @@ test('sheetCopies loads each added sheet multiple times', async () => {
   const scanner = new MockBatchScanner(join(dir, 'images'), 3);
 
   scanner.addSheets([inputSheet(1), inputSheet(2)]);
-  expect(scanner.getStatus()).toEqual({ sheetCount: 6 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 6, errorQueued: false });
 
   const batch = scanner.scanSheets();
   expect(await batch.scanSheet()).toEqual(scannedSheet(1));
@@ -75,12 +75,12 @@ test('scanSheets consumes sheets from the tray', async () => {
   scanner.addSheets([inputSheet(1), inputSheet(2)]);
 
   const batch = scanner.scanSheets();
-  expect(scanner.getStatus()).toEqual({ sheetCount: 2 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 2, errorQueued: false });
 
   expect(await batch.scanSheet()).toEqual(scannedSheet(1));
-  expect(scanner.getStatus()).toEqual({ sheetCount: 1 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 1, errorQueued: false });
   expect(await batch.scanSheet()).toEqual(scannedSheet(2));
-  expect(scanner.getStatus()).toEqual({ sheetCount: 0 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 0, errorQueued: false });
   expect(await batch.scanSheet()).toBeUndefined();
 });
 
@@ -91,7 +91,7 @@ test('sheets left in the tray when a session ends stay for the next session', as
   const batch1 = scanner.scanSheets();
   expect(await batch1.scanSheet()).toEqual(scannedSheet(1));
   await batch1.endBatch();
-  expect(scanner.getStatus()).toEqual({ sheetCount: 1 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 1, errorQueued: false });
 
   const batch2 = scanner.scanSheets();
   expect(await batch2.scanSheet()).toEqual(scannedSheet(2));
@@ -123,11 +123,41 @@ test('addSheets reloads the tray for the next scan', async () => {
   expect(await batch1.scanSheet()).toBeUndefined();
 
   scanner.addSheets([inputSheet(2)]);
-  expect(scanner.getStatus()).toEqual({ sheetCount: 1 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 1, errorQueued: false });
 
   const batch2 = scanner.scanSheets();
   expect(await batch2.scanSheet()).toEqual(scannedSheet(2));
   expect(await batch2.scanSheet()).toBeUndefined();
+});
+
+test('simulateError makes the next scan attempt fail once', async () => {
+  const scanner = createScanner();
+  scanner.addSheets([inputSheet(1), inputSheet(2)]);
+
+  const batch = scanner.scanSheets();
+  expect(await batch.scanSheet()).toEqual(scannedSheet(1));
+
+  scanner.simulateError();
+  expect(scanner.getStatus()).toEqual({ sheetCount: 1, errorQueued: true });
+  await expect(batch.scanSheet()).rejects.toThrowError(
+    'simulated scanner error'
+  );
+
+  // the error is consumed; scanning resumes with the remaining sheets, whether
+  // on the same session or a fresh one (a continued batch)
+  expect(scanner.getStatus()).toEqual({ sheetCount: 1, errorQueued: false });
+  const batch2 = scanner.scanSheets();
+  expect(await batch2.scanSheet()).toEqual(scannedSheet(2));
+  expect(await batch2.scanSheet()).toBeUndefined();
+});
+
+test('clearSheets clears a queued error', () => {
+  const scanner = createScanner();
+  scanner.simulateError();
+  expect(scanner.getStatus()).toEqual({ sheetCount: 0, errorQueued: true });
+
+  scanner.clearSheets();
+  expect(scanner.getStatus()).toEqual({ sheetCount: 0, errorQueued: false });
 });
 
 test('clearSheets resets so next scan returns nothing', async () => {
@@ -140,7 +170,7 @@ test('clearSheets resets so next scan returns nothing', async () => {
   expect(await batch1.scanSheet()).toEqual(scannedSheet(1));
 
   scanner.clearSheets();
-  expect(scanner.getStatus()).toEqual({ sheetCount: 0 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 0, errorQueued: false });
 
   const batch2 = scanner.scanSheets();
   expect(await batch2.scanSheet()).toBeUndefined();

--- a/apps/central-scan/backend/src/mock_batch_scanner.ts
+++ b/apps/central-scan/backend/src/mock_batch_scanner.ts
@@ -10,8 +10,9 @@ export interface MockBatchScannerApi {
   addSheets(
     sheets: ReadonlyArray<{ frontPath: string; backPath: string }>
   ): void;
-  getStatus(): { sheetCount: number };
+  getStatus(): { sheetCount: number; errorQueued: boolean };
   clearSheets(): void;
+  simulateError(): void;
   /** Directory for writing temporary ballot images. */
   imageDir: string;
 }
@@ -27,11 +28,17 @@ export interface MockBatchScannerApi {
  * `sheetCopies` loads each added sheet that many times, simulating a larger
  * stack (and therefore a longer scanning window, e.g. to try the Stop button).
  *
+ * `simulateError()` queues a one-shot scanner error: the next attempt to scan
+ * a sheet fails, whether mid-batch or when opening the next scan session.
+ * This exercises the batch pause-on-error flow; retrying (Continue Scanning)
+ * succeeds since the error is consumed.
+ *
  * Images are stored in the provided directory rather than a random temp
  * directory, so previous runs' files are cleaned up on startup.
  */
 export class MockBatchScanner implements BatchScanner, MockBatchScannerApi {
   private queue: ScannedSheetInfo[] = [];
+  private pendingError?: Error;
 
   constructor(
     private readonly imageDirPath: string,
@@ -67,14 +74,22 @@ export class MockBatchScanner implements BatchScanner, MockBatchScannerApi {
     );
   }
 
-  getStatus(): { sheetCount: number } {
-    return { sheetCount: this.queue.length };
+  getStatus(): { sheetCount: number; errorQueued: boolean } {
+    return {
+      sheetCount: this.queue.length,
+      errorQueued: this.pendingError !== undefined,
+    };
   }
 
   clearSheets(): void {
     this.queue = [];
+    this.pendingError = undefined;
     fs.rmSync(this.imageDirPath, { recursive: true, force: true });
     fs.mkdirSync(this.imageDirPath, { recursive: true });
+  }
+
+  simulateError(): void {
+    this.pendingError = new Error('simulated scanner error');
   }
 
   /* eslint-disable @typescript-eslint/require-await */
@@ -83,7 +98,12 @@ export class MockBatchScanner implements BatchScanner, MockBatchScannerApi {
     let done = false;
 
     return {
-      async scanSheet(): Promise<ScannedSheetInfo | undefined> {
+      scanSheet: async (): Promise<ScannedSheetInfo | undefined> => {
+        if (this.pendingError) {
+          const error = this.pendingError;
+          this.pendingError = undefined;
+          throw error;
+        }
         if (done) {
           return undefined;
         }

--- a/apps/central-scan/backend/src/types.ts
+++ b/apps/central-scan/backend/src/types.ts
@@ -33,7 +33,11 @@ export type SendCastVoteRecordsToHostError =
 export type ScanState = 'idle' | 'scanning' | 'adjudication';
 
 /** Why an in-progress batch is paused. */
-export type BatchPauseReason = 'tray-empty' | 'stopped' | 'ballot-review';
+export type BatchPauseReason =
+  | 'tray-empty'
+  | 'stopped'
+  | 'ballot-review'
+  | 'error';
 
 /**
  * The batch currently being scanned. A batch stays open when scanning is

--- a/apps/central-scan/frontend/src/components/batch_control_card.tsx
+++ b/apps/central-scan/frontend/src/components/batch_control_card.tsx
@@ -48,6 +48,7 @@ const PAUSE_REASON_TEXT: Record<BatchPauseReason, string> = {
   'tray-empty': 'input tray is empty',
   stopped: 'scanning stopped',
   'ballot-review': 'a ballot required review',
+  error: 'a scanning error occurred',
 };
 
 export interface BatchControlCardProps {

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
@@ -131,13 +131,22 @@ describe('paused batch', () => {
   });
 
   test('shows other pause reasons', () => {
-    renderScreen({
+    const { unmount } = renderScreen({
       status: mockStatus({
         currentBatch: { batchId: 'a', state: 'paused', pauseReason: 'stopped' },
         batches: [mockBatch({ id: 'a', endedAt: undefined })],
       }),
     });
     screen.getByText('Batch paused — scanning stopped');
+    unmount();
+
+    renderScreen({
+      status: mockStatus({
+        currentBatch: { batchId: 'a', state: 'paused', pauseReason: 'error' },
+        batches: [mockBatch({ id: 'a', endedAt: undefined })],
+      }),
+    });
+    screen.getByText('Batch paused — a scanning error occurred');
   });
 
   test('continue scanning', () => {

--- a/libs/dev-dock/backend/src/dev_dock_api.test.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.test.ts
@@ -833,16 +833,21 @@ test('mock PDI scanner - odd-page PDF gets blank back', async () => {
 
 function createMockBatchScanner(imageDir: string): MockBatchScannerApi {
   let sheets: Array<{ frontPath: string; backPath: string }> = [];
+  let errorQueued = false;
   return {
     imageDir,
     addSheets(newSheets) {
       sheets.push(...newSheets);
     },
     getStatus() {
-      return { sheetCount: sheets.length };
+      return { sheetCount: sheets.length, errorQueued };
     },
     clearSheets() {
       sheets = [];
+      errorQueued = false;
+    },
+    simulateError() {
+      errorQueued = true;
     },
   };
 }
@@ -851,7 +856,22 @@ test('mock batch scanner - get status', async () => {
   const devDockDir = makeTemporaryDirectory({ prefix: 'dev-dock-test-' });
   const mockBatchScanner = createMockBatchScanner(devDockDir);
   const { apiClient } = setup({ mockBatchScanner }, devDockDir);
-  expect(await apiClient.batchScannerGetStatus()).toEqual({ sheetCount: 0 });
+  expect(await apiClient.batchScannerGetStatus()).toEqual({
+    sheetCount: 0,
+    errorQueued: false,
+  });
+});
+
+test('mock batch scanner - simulate error', async () => {
+  const devDockDir = makeTemporaryDirectory({ prefix: 'dev-dock-test-' });
+  const mockBatchScanner = createMockBatchScanner(devDockDir);
+  const { apiClient } = setup({ mockBatchScanner }, devDockDir);
+
+  await apiClient.batchScannerSimulateError();
+  expect(await apiClient.batchScannerGetStatus()).toEqual({
+    sheetCount: 0,
+    errorQueued: true,
+  });
 });
 
 test('mock batch scanner - load ballots from PDF', async () => {
@@ -880,7 +900,10 @@ test('mock batch scanner - clear ballots', async () => {
   );
 
   await apiClient.batchScannerClearBallots();
-  expect(await apiClient.batchScannerGetStatus()).toEqual({ sheetCount: 0 });
+  expect(await apiClient.batchScannerGetStatus()).toEqual({
+    sheetCount: 0,
+    errorQueued: false,
+  });
 });
 
 test('mock batch scanner - load image files as front/back pairs', async () => {
@@ -898,7 +921,10 @@ test('mock batch scanner - load image files as front/back pairs', async () => {
   await writeImageData(img2, createImageData(10, 10));
 
   await apiClient.batchScannerLoadBallots({ paths: [img1, img2] });
-  expect(await apiClient.batchScannerGetStatus()).toEqual({ sheetCount: 1 });
+  expect(await apiClient.batchScannerGetStatus()).toEqual({
+    sheetCount: 1,
+    errorQueued: false,
+  });
 });
 
 test('mock batch scanner - odd image gets a blank back', async () => {
@@ -913,7 +939,10 @@ test('mock batch scanner - odd image gets a blank back', async () => {
   await writeImageData(img, createImageData(10, 10));
 
   await apiClient.batchScannerLoadBallots({ paths: [img] });
-  expect(await apiClient.batchScannerGetStatus()).toEqual({ sheetCount: 1 });
+  expect(await apiClient.batchScannerGetStatus()).toEqual({
+    sheetCount: 1,
+    errorQueued: false,
+  });
 });
 
 test('mock batch scanner - single page PDF gets blank back', async () => {
@@ -925,7 +954,10 @@ test('mock batch scanner - single page PDF gets blank back', async () => {
   fs.writeFileSync(pdfPath, SINGLE_PAGE_PDF);
 
   await apiClient.batchScannerLoadBallots({ paths: [pdfPath] });
-  expect(await apiClient.batchScannerGetStatus()).toEqual({ sheetCount: 1 });
+  expect(await apiClient.batchScannerGetStatus()).toEqual({
+    sheetCount: 1,
+    errorQueued: false,
+  });
 });
 
 test('mock batch scanner - mock spec reports mockBatchScanner', async () => {

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -63,8 +63,9 @@ import { execFile } from './utils';
 
 export interface MockBatchScannerApi {
   addSheets(sheets: Array<{ frontPath: string; backPath: string }>): void;
-  getStatus(): { sheetCount: number };
+  getStatus(): { sheetCount: number; errorQueued: boolean };
   clearSheets(): void;
+  simulateError(): void;
   readonly imageDir: string;
 }
 
@@ -523,8 +524,12 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
       }
     },
 
-    batchScannerGetStatus(): { sheetCount: number } {
+    batchScannerGetStatus(): { sheetCount: number; errorQueued: boolean } {
       return assertDefined(mockSpec.mockBatchScanner).getStatus();
+    },
+
+    batchScannerSimulateError(): void {
+      assertDefined(mockSpec.mockBatchScanner).simulateError();
     },
 
     async batchScannerLoadBallots(input: { paths: string[] }): Promise<void> {

--- a/libs/dev-dock/frontend/src/dev_dock.test.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.test.tsx
@@ -817,7 +817,7 @@ describe('batch scanner mock', () => {
       .resolves({ mockBatchScanner: true });
     mockApiClient.batchScannerGetStatus
       .expectRepeatedCallsWith()
-      .resolves({ sheetCount: 0 });
+      .resolves({ sheetCount: 0, errorQueued: false });
 
     renderDock(mockApiClient);
     const loadButton = await screen.findByRole('button', {
@@ -835,7 +835,7 @@ describe('batch scanner mock', () => {
       .resolves();
     mockApiClient.batchScannerGetStatus
       .expectRepeatedCallsWith()
-      .resolves({ sheetCount: 2 });
+      .resolves({ sheetCount: 2, errorQueued: false });
     userEvent.click(loadButton);
 
     const queuedText = await screen.findByText(/2 sheet\(s\) queued/);
@@ -848,7 +848,7 @@ describe('batch scanner mock', () => {
     mockApiClient.batchScannerClearBallots.expectCallWith().resolves();
     mockApiClient.batchScannerGetStatus
       .expectRepeatedCallsWith()
-      .resolves({ sheetCount: 0 });
+      .resolves({ sheetCount: 0, errorQueued: false });
     userEvent.click(clearButton);
     await waitFor(() => {
       expect(screen.queryByText(/sheet\(s\) queued/)).not.toBeInTheDocument();
@@ -862,7 +862,7 @@ describe('batch scanner mock', () => {
       .resolves({ mockBatchScanner: true });
     mockApiClient.batchScannerGetStatus
       .expectRepeatedCallsWith()
-      .resolves({ sheetCount: 0 });
+      .resolves({ sheetCount: 0, errorQueued: false });
 
     renderDock(mockApiClient);
     const loadButton = await screen.findByRole('button', {
@@ -878,6 +878,33 @@ describe('batch scanner mock', () => {
       expect(kiosk.showOpenDialog).toHaveBeenCalled();
       mockApiClient.assertComplete();
     });
+  });
+
+  test('queue a simulated scanner error', async () => {
+    mockApiClient.getMockSpec.reset();
+    mockApiClient.getMockSpec
+      .expectCallWith()
+      .resolves({ mockBatchScanner: true });
+    mockApiClient.batchScannerGetStatus
+      .expectRepeatedCallsWith()
+      .resolves({ sheetCount: 0, errorQueued: false });
+
+    renderDock(mockApiClient);
+    const errorButton = await screen.findByRole('button', {
+      name: 'Queue Error',
+    });
+    expect(errorButton).toBeEnabled();
+
+    mockApiClient.batchScannerSimulateError.expectCallWith().resolves();
+    mockApiClient.batchScannerGetStatus
+      .expectRepeatedCallsWith()
+      .resolves({ sheetCount: 0, errorQueued: true });
+    userEvent.click(errorButton);
+
+    const queuedButton = await screen.findByRole('button', {
+      name: 'Error Queued',
+    });
+    expect(queuedButton).toBeDisabled();
   });
 });
 

--- a/libs/dev-dock/frontend/src/dev_dock.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.tsx
@@ -790,9 +790,17 @@ function BatchScannerMockControl() {
     onSuccess: async () =>
       await queryClient.invalidateQueries(['batchScannerGetStatus']),
   });
+  const simulateErrorMutation = useMutation(
+    apiClient.batchScannerSimulateError,
+    {
+      onSuccess: async () =>
+        await queryClient.invalidateQueries(['batchScannerGetStatus']),
+    }
+  );
 
   const status = getStatusQuery.data;
   const sheetCount = status?.sheetCount ?? 0;
+  const errorQueued = status?.errorQueued ?? false;
 
   return (
     <div>
@@ -824,7 +832,13 @@ function BatchScannerMockControl() {
             Clear
           </ScannerButton>
         </>
-      )}
+      )}{' '}
+      <ScannerButton
+        onClick={() => simulateErrorMutation.mutate()}
+        disabled={errorQueued || simulateErrorMutation.isLoading}
+      >
+        {errorQueued ? 'Error Queued' : 'Queue Error'}
+      </ScannerButton>
     </div>
   );
 }


### PR DESCRIPTION
## Overview
Previously if scanning returned an error we would auto save/finalize the last batch and end the in progress batch. Instead we now just want to stay paused in this sitution. Also adds the ability to queue an error in the mock scanner for testing. 

Flow:
Scan a 1 ballot - Have batch paused with 1 scan
Queue Error
Scan
What we saw before: The batch was auto-saved with 1 scan and there is no longer an in progress batch
What we see now: Status changes to Paused - scanner error and we're still in progress on the batch with 1 scan in place. 