### PR TITLE
Enable pnpm minimumReleaseAge and adopt v11 security defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,15 +55,6 @@
   },
   "packageManager": "pnpm@10.34.5",
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "canvas",
-      "esbuild",
-      "node-hid",
-      "node-quirc",
-      "pcsclite",
-      "usb"
-    ],
     "overrides": {
       "@babel/traverse": "7.23.2",
       "@types/eslint": "8.4.1",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,3 +18,48 @@ packages:
 
   # code exercises
   - 'docs/exercises'
+
+# Supply-chain and safety settings. These all match pnpm v11's defaults; we
+# adopt them early while on v10 so the v11 upgrade is a no-op here.
+
+# Don't install a newly published version until it has been on the registry for
+# at least this many minutes. Gives the community time to catch and yank
+# malicious releases (24h).
+minimumReleaseAge: 1440
+
+# Only direct dependencies may use exotic sources (git repos, tarball URLs);
+# transitive deps must resolve from the registry. We have no exotic deps, so
+# this is purely preventative.
+blockExoticSubdeps: true
+
+# Fail the install (rather than warn) if a dependency has an unreviewed build
+# script. Left off on v10: pnpm caches the ignored-builds state and re-emits the
+# error on incremental installs after any `allowBuilds` change (pnpm/pnpm#10528),
+# so every `allowBuilds` edit would force a clean reinstall across the team.
+# Unreviewed builds still warn. Enable this when we upgrade to v11 (where it is
+# the default and everyone reinstalls fresh anyway).
+strictDepBuilds: false
+
+# Fast up-to-date check before installing; speeds up repeat/no-op installs.
+optimisticRepeatInstall: true
+
+# Auto-run install before `pnpm run`/`pnpm exec` when node_modules is stale.
+verifyDepsBeforeRun: install
+
+# Which dependency build scripts may run. `true` = native/binary modules we
+# rely on and want built; `false` = packages whose postinstall we intentionally
+# skip (funding banners / unused codegen). This is pnpm v11's `allowBuilds` map,
+# which supersedes the v10 `onlyBuiltDependencies`/`ignoredBuiltDependencies`
+# fields (removed in v11). Combined with `strictDepBuilds`, any unlisted build
+# script fails the install until a human classifies it here.
+allowBuilds:
+  better-sqlite3: true
+  canvas: true
+  esbuild: true
+  node-hid: true
+  node-quirc: true
+  pcsclite: true
+  usb: true
+  core-js: false
+  core-js-pure: false
+  protobufjs: false


### PR DESCRIPTION
## Overview

Follow-up to #8898 (initial pnpm v10 upgrade). Enables pnpm's `minimumReleaseAge` supply-chain protection and adopts several other pnpm **v11** default flips early while we're still on v10, so the eventual v11 upgrade is a no-op for these settings.

`pnpm-workspace.yaml`:

- `minimumReleaseAge: 1440` — quarantine newly published versions for 24h so the community has time to catch/yank malicious releases
- `blockExoticSubdeps: true` — transitive deps must resolve from the registry (no git/tarball sources; we have none today)
- `optimisticRepeatInstall: true` — faster repeat/no-op installs `verifyDepsBeforeRun: install` — auto-install before `pnpm run`/`exec` when `node_modules` is stale
- `allowBuilds` map — migrated from the v10 `pnpm.onlyBuiltDependencies` / `pnpm.ignoredBuiltDependencies` fields in `package.json` (both **removed in v11**). Native modules we rely on are allowed (`true`); `core-js`, `core-js-pure`, and `protobufjs` postinstalls are intentionally skipped (`false`).
- `strictDepBuilds: false` — **intentionally left at the v10 default**, to enable at the v11 upgrade (see below).

Frozen-lockfile CI is unaffected by `minimumReleaseAge` — it only applies when resolving new versions (`pnpm add`/`update`, non-frozen install).

### Why `strictDepBuilds` is deferred to v11

`strictDepBuilds: true` (fail, rather than warn, on an unreviewed build script) would be nice now, but on v10 it hits pnpm/pnpm#10528: pnpm caches the ignored-builds state in `node_modules/.modules.yaml` and **re-emits `ERR_PNPM_IGNORED_BUILDS` on incremental installs after any `allowBuilds` change**, without re-evaluating the new config. Verified locally:

- Adding a classification to fix the error is **not** picked up by an incremental install — it keeps failing until `rm -rf node_modules && pnpm install`.
- Amplified by `verifyDepsBeforeRun`, this blocks `pnpm test`/`lint`/`exec`, not just explicit installs.

So every `allowBuilds` edit would force a team-wide clean reinstall. Not worth it on v10. Unreviewed build scripts still **warn** (visible in CI logs). At the v11 upgrade everyone reinstalls fresh anyway (Node 22 bump), and `strictDepBuilds` is a v11 default — flip it on then.

## Demo Video or Screenshot

N/A — dependency-management config only.

## Testing Plan

- Clean install and incremental installs pass (exit 0).
- Exercised `verifyDepsBeforeRun`: removed `libs/basics/node_modules`, ran `pnpm --filter @votingworks/basics test:run`; pnpm auto-installed then ran the suite (219 tests, 24 files, all pass).
- CI install passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
