### PR TITLE
[ca-demo] VxCentralScan: dont enforce codeversion matches for central scan networking

### DIFF
--- a/apps/admin/backend/src/peer_app.scanner.test.ts
+++ b/apps/admin/backend/src/peer_app.scanner.test.ts
@@ -100,7 +100,7 @@ async function readExportMetadata(
   ).unsafeUnwrap();
 }
 
-test('registerScanner records a compatible scanner in the machines table', async () => {
+test('registerScanner records the scanner in the machines table', async () => {
   const { peerApiClient, workspace } = buildTestEnvironment();
   const machineConfig = getMachineConfig();
 
@@ -108,7 +108,7 @@ test('registerScanner records a compatible scanner in the machines table', async
     machineId: 'SCANNER-01',
     codeVersion: machineConfig.codeVersion,
   });
-  expect(result).toEqual({ ...machineConfig, isCompatible: true });
+  expect(result).toEqual(machineConfig);
   expect(workspace.store.getMachine('SCANNER-01')).toMatchObject({
     machineId: 'SCANNER-01',
     machineMode: 'scanner',
@@ -116,7 +116,7 @@ test('registerScanner records a compatible scanner in the machines table', async
   });
 });
 
-test('registerScanner rejects a scanner running a different code version', async () => {
+test('registerScanner accepts a scanner running a different code version', async () => {
   const { peerApiClient, workspace } = buildTestEnvironment();
   const machineConfig = getMachineConfig();
 
@@ -124,8 +124,12 @@ test('registerScanner rejects a scanner running a different code version', async
     machineId: 'SCANNER-02',
     codeVersion: 'some-other-version',
   });
-  expect(result).toEqual({ ...machineConfig, isCompatible: false });
-  expect(workspace.store.getMachine('SCANNER-02')).toBeUndefined();
+  expect(result).toEqual(machineConfig);
+  expect(workspace.store.getMachine('SCANNER-02')).toMatchObject({
+    machineId: 'SCANNER-02',
+    machineMode: 'scanner',
+    status: Admin.ClientMachineStatus.Active,
+  });
 });
 
 test('cvr transfer session imports cast vote records one at a time', async () => {

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -165,19 +165,8 @@ function buildPeerApi(
     registerScanner(input: {
       machineId: string;
       codeVersion: string;
-    }): MachineConfig & { isCompatible: boolean } {
+    }): MachineConfig {
       const machineConfig = getMachineConfig();
-      // Refuse to register a scanner running a different code version.
-      if (input.codeVersion !== machineConfig.codeVersion) {
-        logger.log(LogEventId.AdminNetworkStatus, 'system', {
-          message: `Rejected connection from central scanner ${input.machineId}: incompatible software version (scanner ${input.codeVersion}, host ${machineConfig.codeVersion}).`,
-          disposition: 'failure',
-          scannerMachineId: input.machineId,
-          scannerCodeVersion: input.codeVersion,
-          hostCodeVersion: machineConfig.codeVersion,
-        });
-        return { ...machineConfig, isCompatible: false };
-      }
       const previous = store.getMachine(input.machineId);
       if (
         !previous ||
@@ -194,7 +183,7 @@ function buildPeerApi(
         'scanner',
         Admin.ClientMachineStatus.Active
       );
-      return { ...machineConfig, isCompatible: true };
+      return machineConfig;
     },
 
     /**

--- a/apps/central-scan/backend/src/app.scanning.test.ts
+++ b/apps/central-scan/backend/src/app.scanning.test.ts
@@ -135,10 +135,15 @@ test('cancelBatch while scanning halts the feed and discards the batch', async (
       .end();
 
     await apiClient.scanBatch();
-    await vi.waitFor(async () => {
-      const status = await apiClient.getStatus();
-      expect(status.batches[0]?.count).toEqual(1);
-    });
+    // Interpreting the first sheet can take a while under load; the default
+    // 1s timeout flakes.
+    await vi.waitFor(
+      async () => {
+        const status = await apiClient.getStatus();
+        expect(status.batches[0]?.count).toEqual(1);
+      },
+      { timeout: 10_000 }
+    );
 
     // stopping discards the whole batch, including the in-flight sheet
     const cancelPromise = apiClient.cancelBatch();

--- a/apps/central-scan/backend/src/networking.ts
+++ b/apps/central-scan/backend/src/networking.ts
@@ -146,19 +146,6 @@ export function startScannerNetworking({
             machineId,
             codeVersion,
           });
-          if (!hostConfig.isCompatible) {
-            debug(
-              'Host at %s runs incompatible code version %s (scanner is %s), refusing to connect',
-              address,
-              hostConfig.codeVersion,
-              codeVersion
-            );
-            setConnectionState({
-              status: 'incompatible-host-version',
-              hostMachineId: hostConfig.machineId,
-            });
-            return;
-          }
           setConnectionState(
             {
               status: 'connected-to-host',

--- a/apps/central-scan/backend/src/types.ts
+++ b/apps/central-scan/backend/src/types.ts
@@ -15,8 +15,7 @@ export type HostConnectionStatus =
   | 'offline'
   | 'waiting-for-host'
   | 'connected-to-host'
-  | 'multiple-hosts-detected'
-  | 'incompatible-host-version';
+  | 'multiple-hosts-detected';
 
 /** Summary of the scanner's connection to a VxAdmin host. */
 export interface HostConnectionInfo {


### PR DESCRIPTION
## Overview
Since we're matching a dev VxCentralScan with a qa image VxAdmin keeping the code versions in line is mildly annoying, in dev we always just default to "dev" as the code version. This removes this check and enforcement for the purposes of the central-scan  and admin communication (admins still check code version with one another and should all match) which will make it a bit more seamless to set up the machines. 
