### PR TITLE
Speed up ballot interpretation ~2.5x

### DIFF
--- a/libs/ballot-interpreter/.cargo/config.toml
+++ b/libs/ballot-interpreter/.cargo/config.toml
@@ -1,0 +1,10 @@
+# Build for x86-64-v3 (AVX2/BMI2/FMA) on x86_64 Linux, the production target:
+# the production SBC (Intel N97, Alder Lake-N) is v3-capable, as is any
+# x86_64 CPU from roughly 2015 onward. The vectorizable pixel loops (Otsu,
+# streak detection, bubble scoring, PNG bit-packing) benefit measurably.
+#
+# This section only applies when compiling for x86_64 Linux. macOS builds
+# (Apple Silicon or Intel) and other targets are unaffected, and setting the
+# RUSTFLAGS environment variable overrides it entirely.
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-cpu=x86-64-v3"]

--- a/libs/ballot-interpreter/Cargo.lock
+++ b/libs/ballot-interpreter/Cargo.lock
@@ -235,6 +235,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "png",
  "proptest",
  "rayon",
  "rqrr",

--- a/libs/ballot-interpreter/Cargo.toml
+++ b/libs/ballot-interpreter/Cargo.toml
@@ -78,3 +78,7 @@ tempfile = "3.3.0"
 
 [lints]
 workspace = true
+
+[profile.release]
+lto = "thin"
+codegen-units = 1

--- a/libs/ballot-interpreter/Cargo.toml
+++ b/libs/ballot-interpreter/Cargo.toml
@@ -46,6 +46,7 @@ image = { version = "0.25.0", default-features = false, features = [
   "rayon",
 ] }
 log = "0.4.17"
+png = "0.18.1"
 napi = { version = "3.8.0", default-features = false, features = [
   "napi4",
   "async",

--- a/libs/ballot-interpreter/benches/main.rs
+++ b/libs/ballot-interpreter/benches/main.rs
@@ -205,36 +205,3 @@ fn interpret_and_save(bencher: Bencher, fixture: InterpretFixture) {
         black_box(result);
     });
 }
-
-/// For comparison: the old sequential approach of saving by re-encoding.
-#[divan::bench(args = [
-    InterpretFixture::new(
-        "vx-general-election/letter-en",
-        "../hmpb/fixtures/vx-general-election/letter-en/election.json",
-        "blank-ballot",
-        1,
-    ),
-    InterpretFixture::new(
-        "vx-famous-names",
-        "../fixtures/data/electionFamousNames2021/electionGeneratedWithGridLayoutsEnglishOnly.json",
-        "marked-ballot",
-        1,
-    ),
-])]
-fn interpret_and_save_sequential(bencher: Bencher, fixture: InterpretFixture) {
-    let (side_a_image, side_b_image, interpreter) = fixture.load().unwrap();
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let front_path = tmp_dir.path().join("front_seq.png");
-    let back_path = tmp_dir.path().join("back_seq.png");
-
-    bencher.bench_local(move || {
-        let result = interpreter
-            .interpret(side_a_image.clone(), side_b_image.clone(), None, None)
-            .unwrap();
-
-        // Simulate the old behavior: encode and save sequentially after interpretation
-        result.front.normalized_image.save(&front_path).unwrap();
-        result.back.normalized_image.save(&back_path).unwrap();
-        black_box(result);
-    });
-}

--- a/libs/ballot-interpreter/benches/main.rs
+++ b/libs/ballot-interpreter/benches/main.rs
@@ -1,64 +1,82 @@
 #![allow(clippy::similar_names, clippy::unwrap_used)]
 
-use std::{fmt::Display, fs::File, io::BufReader, path::PathBuf};
+use std::{fmt::Display, path::PathBuf};
 
-use ballot_interpreter::{
-    debug::ImageDebugWriter,
-    interpret::{
-        ScanInterpreter, VerticalStreakDetection, WriteInScoring,
-        DEFAULT_MAX_CUMULATIVE_STREAK_WIDTH, DEFAULT_RETRY_STREAK_WIDTH_THRESHOLD,
-    },
-    qr_code,
+use ballot_interpreter::interpret::{
+    ScanInterpreter, VerticalStreakDetection, WriteInScoring, DEFAULT_MAX_CUMULATIVE_STREAK_WIDTH,
+    DEFAULT_RETRY_STREAK_WIDTH_THRESHOLD,
 };
 use divan::{black_box, Bencher};
 use image::GrayImage;
-use types_rs::{
-    bubble_ballot::{PartialBallotHash, PARTIAL_BALLOT_HASH_BYTE_LENGTH, PRELUDE},
-    election::Election,
-};
+use sha2::{Digest, Sha256};
+use types_rs::{bubble_ballot::PartialBallotHash, election::Election};
 
 fn main() {
     // Run registered benchmarks.
     divan::main();
 }
 
+/// A ballot card from `libs/hmpb/fixtures`. These fixtures are regenerated
+/// alongside the current metadata encoding, so their QR codes can be decoded
+/// end-to-end (unlike the field-captured fixtures in `test/fixtures`, whose
+/// QR codes predate the current encoding).
 #[derive(Debug, Clone, Copy)]
 struct InterpretFixture {
-    election: &'static str,
-    name: &'static str,
-    extension: &'static str,
+    /// Directory under `libs/hmpb/fixtures` containing rendered
+    /// `<ballot>-p<N>.jpg` page images.
+    dir: &'static str,
+
+    /// Path to the election definition the ballots were generated from,
+    /// relative to this crate's root.
+    election_json: &'static str,
+
+    /// Ballot file prefix, e.g. `blank-ballot` or `marked-ballot`.
+    ballot: &'static str,
+
+    /// Page number of the card's front page; the back page is the next page.
+    starting_page_number: usize,
 }
 
 impl InterpretFixture {
-    const fn new(election: &'static str, name: &'static str, extension: &'static str) -> Self {
+    const fn new(
+        dir: &'static str,
+        election_json: &'static str,
+        ballot: &'static str,
+        starting_page_number: usize,
+    ) -> Self {
         Self {
-            election,
-            name,
-            extension,
+            dir,
+            election_json,
+            ballot,
+            starting_page_number,
         }
     }
 
     fn load(&self) -> color_eyre::Result<(GrayImage, GrayImage, ScanInterpreter)> {
-        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test/fixtures");
-        let election_path = fixture_path.join(self.election).join("election.json");
-        let election: Election =
-            serde_json::from_reader(BufReader::new(File::open(election_path)?))?;
-        let side_a_path = fixture_path
-            .join(self.election)
-            .join(format!("{}-front{}", self.name, self.extension));
-        let side_b_path = fixture_path
-            .join(self.election)
-            .join(format!("{}-back{}", self.name, self.extension));
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let fixture_path = manifest_dir.join("../hmpb/fixtures").join(self.dir);
+        let election_bytes = std::fs::read(manifest_dir.join(self.election_json))?;
+        let election: Election = serde_json::from_slice(&election_bytes)?;
+
+        // The ballot hash is the SHA-256 of the election.json bytes, matching
+        // the TS `sha256(electionData)` convention used when generating the
+        // fixtures' QR codes.
+        let digest = Sha256::digest(&election_bytes);
+        let mut expected_ballot_hash = PartialBallotHash::default();
+        let len = expected_ballot_hash.len();
+        expected_ballot_hash.copy_from_slice(&digest[..len]);
+
+        let side_a_path = fixture_path.join(format!(
+            "{}-p{}.jpg",
+            self.ballot, self.starting_page_number
+        ));
+        let side_b_path = fixture_path.join(format!(
+            "{}-p{}.jpg",
+            self.ballot,
+            self.starting_page_number + 1
+        ));
         let side_a_image = image::open(&side_a_path)?.to_luma8();
         let side_b_image = image::open(&side_b_path)?.to_luma8();
-
-        // Pull the expected ballot hash out of side A's QR code rather than
-        // hashing election.json bytes. Some bench fixtures (e.g.
-        // `vxqa-2024-10`) ship an election.json whose SHA-256 doesn't match
-        // the hash baked into the ballot QR codes, and we don't want benchmark
-        // setup to fail on those. The hash check itself is exercised by unit
-        // tests; here we just want to time interpretation.
-        let expected_ballot_hash = decode_ballot_hash_from_image(&side_a_image);
 
         let interpreter = ScanInterpreter::new(
             election,
@@ -73,32 +91,35 @@ impl InterpretFixture {
     }
 }
 
-/// Pulls the partial ballot hash out of a ballot image's QR code. See the
-/// equivalent helper in `interpret::test` for context.
-fn decode_ballot_hash_from_image(image: &GrayImage) -> PartialBallotHash {
-    let qr = qr_code::detect_with_strategy(
-        image,
-        qr_code::SearchStrategy::BubbleCorners,
-        &ImageDebugWriter::disabled(),
-    )
-    .unwrap();
-    let (prelude, payload) = qr.bytes().split_at(PRELUDE.len());
-    assert_eq!(prelude, PRELUDE);
-    let (ballot_hash, _) = payload.split_at(PARTIAL_BALLOT_HASH_BYTE_LENGTH);
-    ballot_hash.try_into().unwrap()
-}
-
 impl Display for InterpretFixture {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/{}", self.election, self.name)
+        write!(
+            f,
+            "{}/{}-p{}",
+            self.dir, self.ballot, self.starting_page_number
+        )
     }
 }
 
 #[divan::bench(args = [
-    InterpretFixture::new("all-bubble-ballot", "blank", ".jpg"),
-    InterpretFixture::new("vxqa-2024-10", "skew", ".png"),
-    InterpretFixture::new("22in-ballot-2in-margin", "centered", ".jpeg"),
-    InterpretFixture::new("letter-ballot-2in-margin-centered", "centered", ".jpeg"),
+    InterpretFixture::new(
+        "vx-general-election/letter-en",
+        "../hmpb/fixtures/vx-general-election/letter-en/election.json",
+        "blank-ballot",
+        1,
+    ),
+    InterpretFixture::new(
+        "vx-general-election/letter-en",
+        "../hmpb/fixtures/vx-general-election/letter-en/election.json",
+        "blank-ballot",
+        3,
+    ),
+    InterpretFixture::new(
+        "vx-famous-names",
+        "../fixtures/data/electionFamousNames2021/electionGeneratedWithGridLayoutsEnglishOnly.json",
+        "marked-ballot",
+        1,
+    ),
 ])]
 fn interpret(bencher: Bencher, fixture: InterpretFixture) {
     let (side_a_image, side_b_image, interpreter) = fixture.load().unwrap();
@@ -112,11 +133,52 @@ fn interpret(bencher: Bencher, fixture: InterpretFixture) {
     });
 }
 
+/// Benchmark for ballot page preparation (border cropping) and timing mark
+/// finding only, the most pixel-intensive part of interpretation.
+#[divan::bench(args = [
+    InterpretFixture::new(
+        "vx-general-election/letter-en",
+        "../hmpb/fixtures/vx-general-election/letter-en/election.json",
+        "blank-ballot",
+        1,
+    ),
+    InterpretFixture::new(
+        "vx-famous-names",
+        "../fixtures/data/electionFamousNames2021/electionGeneratedWithGridLayoutsEnglishOnly.json",
+        "marked-ballot",
+        1,
+    ),
+])]
+fn find_timing_marks(bencher: Bencher, fixture: InterpretFixture) {
+    use ballot_interpreter::ballot_card::{BallotPage, PaperInfo};
+    use ballot_interpreter::timing_marks::{self, DefaultForGeometry};
+
+    let (side_a_image, _, _) = fixture.load().unwrap();
+
+    bencher.bench_local(move || {
+        let page =
+            BallotPage::from_image("side A", side_a_image.clone(), &PaperInfo::scanned(), None)
+                .unwrap();
+        let options = timing_marks::Options::default_for_geometry(page.geometry());
+        black_box(page.find_timing_marks(&options).unwrap());
+    });
+}
+
 /// Benchmark that includes writing normalized images to disk, which is the
 /// real-world path when scanning ballots.
 #[divan::bench(args = [
-    InterpretFixture::new("all-bubble-ballot", "blank", ".jpg"),
-    InterpretFixture::new("vxqa-2024-10", "skew", ".png"),
+    InterpretFixture::new(
+        "vx-general-election/letter-en",
+        "../hmpb/fixtures/vx-general-election/letter-en/election.json",
+        "blank-ballot",
+        1,
+    ),
+    InterpretFixture::new(
+        "vx-famous-names",
+        "../fixtures/data/electionFamousNames2021/electionGeneratedWithGridLayoutsEnglishOnly.json",
+        "marked-ballot",
+        1,
+    ),
 ])]
 fn interpret_and_save(bencher: Bencher, fixture: InterpretFixture) {
     let (side_a_image, side_b_image, interpreter) = fixture.load().unwrap();
@@ -146,8 +208,18 @@ fn interpret_and_save(bencher: Bencher, fixture: InterpretFixture) {
 
 /// For comparison: the old sequential approach of saving by re-encoding.
 #[divan::bench(args = [
-    InterpretFixture::new("all-bubble-ballot", "blank", ".jpg"),
-    InterpretFixture::new("vxqa-2024-10", "skew", ".png"),
+    InterpretFixture::new(
+        "vx-general-election/letter-en",
+        "../hmpb/fixtures/vx-general-election/letter-en/election.json",
+        "blank-ballot",
+        1,
+    ),
+    InterpretFixture::new(
+        "vx-famous-names",
+        "../fixtures/data/electionFamousNames2021/electionGeneratedWithGridLayoutsEnglishOnly.json",
+        "marked-ballot",
+        1,
+    ),
 ])]
 fn interpret_and_save_sequential(bencher: Bencher, fixture: InterpretFixture) {
     let (side_a_image, side_b_image, interpreter) = fixture.load().unwrap();

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/ballot_card.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/ballot_card.rs
@@ -1,10 +1,10 @@
 use std::{cmp::Ordering, io, mem::swap, ops::Range, path::PathBuf, sync::LazyLock};
 
 use crate::{
-    image_utils::{otsu_level, threshold},
+    image_utils::{crop_to_image, otsu_level, threshold},
     qr_code::SearchStrategy,
 };
-use image::{imageops::rotate180_in_place, GenericImageView, GrayImage};
+use image::{imageops::rotate180_in_place, GrayImage};
 use itertools::Itertools;
 use serde::Serialize;
 
@@ -92,14 +92,13 @@ impl BallotImage {
             });
         }
 
-        let image = image
-            .view(
-                border_inset.left,
-                border_inset.top,
-                image.width() - border_inset.left - border_inset.right,
-                image.height() - border_inset.top - border_inset.bottom,
-            )
-            .to_image();
+        let image = crop_to_image(
+            &image,
+            border_inset.left,
+            border_inset.top,
+            image.width() - border_inset.left - border_inset.right,
+            image.height() - border_inset.top - border_inset.bottom,
+        );
 
         // Re-compute the threshold after cropping to ensure future
         // re-interpretations based on the saved image are consistent with the

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
@@ -142,19 +142,18 @@ pub fn count_pixels(img: &GrayImage, luma: Luma<u8>) -> CountedPixels {
 pub fn count_pixels_in_shape(ballot_image: &BallotImage, shape: &Quadrilateral) -> CountedPixels {
     let mut counted = CountedPixels::default();
     let bounds = shape.bounds();
-    for x in bounds.left()..bounds.right() {
-        if x < 0 || x >= ballot_image.width() as i32 {
-            continue;
-        }
-
-        for y in bounds.top()..bounds.bottom() {
-            if y < 0 || y >= ballot_image.height() as i32 {
-                continue;
-            }
-
+    let width = ballot_image.width() as usize;
+    let raw = ballot_image.image().as_raw();
+    let thresh = ballot_image.threshold();
+    let x_range = bounds.left().max(0)..bounds.right().min(ballot_image.width() as i32);
+    let y_range = bounds.top().max(0)..bounds.bottom().min(ballot_image.height() as i32);
+    // Iterate rows in the outer loop since the image data is stored row-major.
+    for y in y_range {
+        let row = &raw[y as usize * width..(y as usize + 1) * width];
+        for x in x_range.clone() {
             if shape.contains_subpixel(x as f32 + 0.5, y as f32 + 0.5) {
                 counted.examined += 1;
-                if ballot_image.get_pixel(x as u32, y as u32).is_foreground() {
+                if row[x as usize] <= thresh {
                     counted.matched += 1;
                 }
             }
@@ -172,33 +171,49 @@ pub fn find_scanned_document_inset(
     threshold: u8,
     min_ratio_above_threshold: UnitIntervalValue,
 ) -> Option<Inset> {
+    // Determines whether more than `required` of the pixels yielded by the
+    // given iterator are above the threshold, stopping as soon as the answer
+    // is known rather than counting every pixel.
+    fn has_enough_above_threshold(
+        pixels: impl Iterator<Item = u8>,
+        threshold: u8,
+        required: usize,
+    ) -> bool {
+        let mut count = 0;
+        for luma in pixels {
+            if luma > threshold {
+                count += 1;
+                if count > required {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     let (width, height) = image.dimensions();
     let (max_x, max_y) = (width - 1, height - 1);
+    let raw = image.as_raw();
 
-    let min_y_above_threshold = (0..height).find(|y| {
-        (0..width)
-            .filter(|x| image.get_pixel(*x, *y)[0] > threshold)
-            .count()
-            > (width as f32 * min_ratio_above_threshold) as usize
-    });
-    let max_y_above_threshold = (0..height).rev().find(|y| {
-        (0..width)
-            .filter(|x| image.get_pixel(*x, *y)[0] > threshold)
-            .count()
-            > (width as f32 * min_ratio_above_threshold) as usize
-    });
-    let min_x_above_threshold = (0..width).find(|x| {
-        (0..height)
-            .filter(|y| image.get_pixel(*x, *y)[0] > threshold)
-            .count()
-            > (height as f32 * min_ratio_above_threshold) as usize
-    });
-    let max_x_above_threshold = (0..width).rev().find(|x| {
-        (0..height)
-            .filter(|y| image.get_pixel(*x, *y)[0] > threshold)
-            .count()
-            > (height as f32 * min_ratio_above_threshold) as usize
-    });
+    let row_pixels = |y: u32| {
+        let row_start = y as usize * width as usize;
+        raw[row_start..row_start + width as usize].iter().copied()
+    };
+    let column_pixels = |x: u32| raw[x as usize..].iter().step_by(width as usize).copied();
+
+    let required_per_row = (width as f32 * min_ratio_above_threshold) as usize;
+    let required_per_column = (height as f32 * min_ratio_above_threshold) as usize;
+
+    let min_y_above_threshold = (0..height)
+        .find(|y| has_enough_above_threshold(row_pixels(*y), threshold, required_per_row));
+    let max_y_above_threshold = (0..height)
+        .rev()
+        .find(|y| has_enough_above_threshold(row_pixels(*y), threshold, required_per_row));
+    let min_x_above_threshold = (0..width)
+        .find(|x| has_enough_above_threshold(column_pixels(*x), threshold, required_per_column));
+    let max_x_above_threshold = (0..width)
+        .rev()
+        .find(|x| has_enough_above_threshold(column_pixels(*x), threshold, required_per_column));
 
     match (
         min_x_above_threshold,

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
@@ -356,9 +356,19 @@ pub fn detect_vertical_streaks(ballot_image: &BallotImage) -> Vec<VerticalStreak
     let raw = ballot_image.image().as_raw();
     let thresh = ballot_image.threshold();
 
-    // Two reusable buffers for binarized column data, swapped each iteration
-    // to avoid per-column Vec allocations and re-computing single-column streak
-    // data for each column.
+    // Count the black pixels in every column in a single row-major pass (the
+    // image data is stored row-major, so walking columns directly would miss
+    // cache on nearly every access). Only columns whose count clears
+    // MIN_ONE_COLUMN_STREAK_SCORE — usually none — need the detailed
+    // two-column analysis below, which reads just those columns.
+    let mut column_black_counts = vec![0u32; width_usize];
+    for row in raw.chunks_exact(width_usize) {
+        for (count, &p) in column_black_counts.iter_mut().zip(row.iter()) {
+            *count += u32::from(p <= thresh);
+        }
+    }
+
+    // Two reusable buffers for binarized column data of candidate columns.
     let mut cur_col = vec![false; height_usize];
     let mut next_col = vec![false; height_usize];
 
@@ -370,17 +380,16 @@ pub fn detect_vertical_streaks(ballot_image: &BallotImage) -> Vec<VerticalStreak
         }
     };
 
-    fill_column(&mut cur_col, x_range.start as usize);
-    let mut cur_black_count: usize = cur_col.iter().filter(|&&b| b).count();
-
     let mut uncoalesced: Vec<VerticalStreak> = Vec::new();
     for x in x_range.start..=x_range.end - 2 {
         debug_assert!(x_range.contains(&(x + 1)));
-        fill_column(&mut next_col, (x + 1) as usize);
-        let next_black_count: usize = next_col.iter().filter(|&&b| b).count();
+        let cur_black_count = column_black_counts[x as usize];
 
         let column_streak_score = UnitIntervalScore(cur_black_count as f32 / height as f32);
         if column_streak_score >= MIN_ONE_COLUMN_STREAK_SCORE {
+            fill_column(&mut cur_col, x as usize);
+            fill_column(&mut next_col, (x + 1) as usize);
+
             // Compute two-column stats inline without allocating.
             let mut num_two_column_black = 0u32;
             let mut longest_white_gap: PixelUnit = 0;
@@ -403,6 +412,7 @@ pub fn detect_vertical_streaks(ballot_image: &BallotImage) -> Vec<VerticalStreak
             if two_column_streak_score >= MIN_TWO_COLUMN_STREAK_SCORE
                 && longest_white_gap <= MAX_WHITE_GAP_PIXELS
             {
+                let next_black_count = column_black_counts[(x + 1) as usize];
                 let next_column_streak_score =
                     UnitIntervalScore(next_black_count as f32 / height as f32);
                 if next_column_streak_score < MIN_ONE_COLUMN_STREAK_SCORE {
@@ -420,9 +430,6 @@ pub fn detect_vertical_streaks(ballot_image: &BallotImage) -> Vec<VerticalStreak
                 }
             }
         }
-
-        swap(&mut cur_col, &mut next_col);
-        cur_black_count = next_black_count;
     }
 
     let streaks = uncoalesced

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
@@ -2,7 +2,7 @@ use std::io::Cursor;
 use std::mem::swap;
 use std::ops::RangeInclusive;
 
-use image::{GrayImage, ImageEncoder, Luma, Rgb};
+use image::{GrayImage, Luma, Rgb};
 use itertools::Itertools;
 use serde::Serialize;
 use types_rs::geometry::{PixelPosition, PixelUnit};
@@ -490,26 +490,52 @@ pub(crate) fn threshold(image: &GrayImage, thresh: u8) -> GrayImage {
     })
 }
 
-/// Applies a binary threshold and encodes the result as PNG bytes in one step.
-/// Returns both the thresholded image and its PNG encoding.
-pub(crate) fn threshold_and_encode_png(
+/// Binarizes a grayscale image with the given threshold and encodes it as a
+/// 1-bit grayscale PNG in memory, in a single pass over the image.
+///
+/// Pixels with luma `<= thresh` become black and others white, exactly like
+/// [`threshold`], but the bits are packed directly from the source image
+/// rather than materializing an intermediate 8-bit binarized image. The
+/// 1-bit representation gives the DEFLATE step an eighth of the data an
+/// 8-bit encoding would, making encoding faster and files smaller: the `Up`
+/// filter with fast compression measured smaller *and* faster than an 8-bit
+/// encoding with the `image` crate's defaults on a corpus of real ballot
+/// scans.
+pub(crate) fn binarize_and_encode_png(
     image: &GrayImage,
     thresh: u8,
-) -> (GrayImage, image::ImageResult<Vec<u8>>) {
-    let normalized = threshold(image, thresh);
-    let encoded = encode_png(&normalized);
-    (normalized, encoded)
-}
+) -> image::ImageResult<Vec<u8>> {
+    let (width, height) = image.dimensions();
+    let row_bytes = (width as usize).div_ceil(8);
+    let mut packed = vec![0u8; row_bytes * height as usize];
+    for (pixel_row, packed_row) in image
+        .as_raw()
+        .chunks_exact(width as usize)
+        .zip(packed.chunks_exact_mut(row_bytes))
+    {
+        for (pixels, packed_byte) in pixel_row.chunks(8).zip(packed_row.iter_mut()) {
+            let mut byte = 0u8;
+            for (bit, &pixel) in pixels.iter().enumerate() {
+                byte |= u8::from(pixel > thresh) << (7 - bit);
+            }
+            *packed_byte = byte;
+        }
+    }
 
-/// Encodes a grayscale image as PNG bytes in memory.
-pub(crate) fn encode_png(image: &GrayImage) -> image::ImageResult<Vec<u8>> {
-    let mut buf = Vec::new();
-    image::codecs::png::PngEncoder::new(Cursor::new(&mut buf)).write_image(
-        image.as_raw(),
-        image.width(),
-        image.height(),
-        image::ExtendedColorType::L8,
-    )?;
+    let to_image_error =
+        |e: png::EncodingError| image::ImageError::IoError(std::io::Error::other(e));
+
+    // Pre-size for the compressed output; binarized ballot images compress
+    // to well under half of the packed size.
+    let mut buf = Vec::with_capacity(packed.len() / 2);
+    let mut encoder = png::Encoder::new(Cursor::new(&mut buf), width, height);
+    encoder.set_color(png::ColorType::Grayscale);
+    encoder.set_depth(png::BitDepth::One);
+    encoder.set_compression(png::Compression::Fast);
+    encoder.set_filter(png::Filter::Up);
+    let mut writer = encoder.write_header().map_err(to_image_error)?;
+    writer.write_image_data(&packed).map_err(to_image_error)?;
+    writer.finish().map_err(to_image_error)?;
     Ok(buf)
 }
 
@@ -635,6 +661,22 @@ mod test {
                 expected[p as usize] += 1;
             }
             assert_eq!(histogram(&pixels), expected);
+        }
+
+        // Arbitrary widths cover the row padding cases (width % 8 != 0).
+        #[test]
+        fn binarize_and_encode_png_matches_threshold_exactly(
+            width in 1u32..40,
+            height in 1u32..40,
+            thresh in proptest::num::u8::ANY,
+            seed in proptest::collection::vec(proptest::num::u8::ANY, 40 * 40),
+        ) {
+            let image = GrayImage::from_fn(width, height, |x, y| {
+                Luma([seed[(y * width + x) as usize]])
+            });
+            let encoded = binarize_and_encode_png(&image, thresh).unwrap();
+            let decoded = image::load_from_memory(&encoded).unwrap().to_luma8();
+            assert_eq!(decoded.as_raw(), threshold(&image, thresh).as_raw());
         }
     }
 

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
@@ -162,6 +162,36 @@ pub fn count_pixels_in_shape(ballot_image: &BallotImage, shape: &Quadrilateral) 
     counted
 }
 
+/// Copies a rectangular region of the given image into a new image.
+///
+/// Equivalent to `image.view(x, y, width, height).to_image()`, but copies
+/// whole rows at a time rather than pixel by pixel, which measures about an
+/// order of magnitude faster.
+///
+/// # Panics
+///
+/// Panics if the region extends beyond the image bounds.
+pub(crate) fn crop_to_image(
+    image: &GrayImage,
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+) -> GrayImage {
+    assert!(
+        x + width <= image.width() && y + height <= image.height(),
+        "crop region must be within the image bounds"
+    );
+    let src_stride = image.width() as usize;
+    let raw = image.as_raw();
+    let mut out = Vec::with_capacity(width as usize * height as usize);
+    for row in 0..height as usize {
+        let start = (y as usize + row) * src_stride + x as usize;
+        out.extend_from_slice(&raw[start..start + width as usize]);
+    }
+    GrayImage::from_vec(width, height, out).expect("buffer length matches dimensions")
+}
+
 /// Finds the inset of a scanned document in an image such that each side of the
 /// inset has more than `min_ratio_above_threshold` of its pixels above the
 /// given threshold.
@@ -651,6 +681,26 @@ mod test {
     }
 
     proptest::proptest! {
+        #[test]
+        fn crop_to_image_matches_view_to_image(
+            img_w in 1u32..50,
+            img_h in 1u32..50,
+            crop in proptest::num::u32::ANY,
+            seed in proptest::collection::vec(proptest::num::u8::ANY, 50 * 50),
+        ) {
+            use image::GenericImageView;
+            let image = GrayImage::from_fn(img_w, img_h, |x, y| {
+                Luma([seed[(y * img_w + x) as usize]])
+            });
+            let x = crop % img_w;
+            let y = (crop >> 8) % img_h;
+            let width = (crop >> 16) % (img_w - x) + 1;
+            let height = (crop >> 24) % (img_h - y) + 1;
+            let expected = image.view(x, y, width, height).to_image();
+            let actual = crop_to_image(&image, x, y, width, height);
+            assert_eq!(actual.as_raw(), expected.as_raw());
+        }
+
         // Covers all `len % 8` remainder cases via the arbitrary length.
         #[test]
         fn histogram_matches_naive_single_histogram(

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
@@ -412,12 +412,43 @@ pub fn detect_vertical_streaks(ballot_image: &BallotImage) -> Vec<VerticalStreak
     streaks
 }
 
+/// Builds a luma histogram of the given pixels.
+///
+/// Accumulates into several interleaved shard histograms and sums them at the
+/// end. Scanned ballots contain long runs of identical pixel values (blank
+/// paper, black borders), and with a single histogram every increment in such
+/// a run depends on the store of the previous one, so the CPU executes them
+/// serially. Sharding gives each of the `HISTOGRAM_SHARDS` consecutive pixels
+/// an independent histogram to increment, breaking the dependency chain. This
+/// measured about twice as fast as a single histogram on real ballot scans.
+/// The result is identical to a single histogram since the counts commute.
+pub(crate) fn histogram(pixels: &[u8]) -> [u32; 256] {
+    const HISTOGRAM_SHARDS: usize = 8;
+
+    let mut shards = [[0u32; 256]; HISTOGRAM_SHARDS];
+    let chunks = pixels.chunks_exact(HISTOGRAM_SHARDS);
+    let remainder = chunks.remainder();
+    for chunk in chunks {
+        for (shard, &p) in shards.iter_mut().zip(chunk.iter()) {
+            shard[p as usize] += 1;
+        }
+    }
+    for &p in remainder {
+        shards[0][p as usize] += 1;
+    }
+
+    let mut hist = [0u32; 256];
+    for shard in &shards {
+        for (total, &count) in hist.iter_mut().zip(shard.iter()) {
+            *total += count;
+        }
+    }
+    hist
+}
+
 /// Computes Otsu's threshold for a grayscale image.
 pub(crate) fn otsu_level(image: &GrayImage) -> u8 {
-    let mut hist = [0u32; 256];
-    for &p in image.as_raw() {
-        hist[p as usize] += 1;
-    }
+    let hist = histogram(image.as_raw());
     let total = f64::from(image.width()) * f64::from(image.height());
     let sum: f64 = hist
         .iter()
@@ -590,6 +621,20 @@ mod test {
                     assert!(gap > 1, "adjacent/overlapping streaks should coalesce");
                 }
             }
+        }
+    }
+
+    proptest::proptest! {
+        // Covers all `len % 8` remainder cases via the arbitrary length.
+        #[test]
+        fn histogram_matches_naive_single_histogram(
+            pixels in proptest::collection::vec(proptest::num::u8::ANY, 0..2048),
+        ) {
+            let mut expected = [0u32; 256];
+            for &p in &pixels {
+                expected[p as usize] += 1;
+            }
+            assert_eq!(histogram(&pixels), expected);
         }
     }
 

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
@@ -21,7 +21,7 @@ use crate::ballot_card::Geometry;
 use crate::ballot_card::Orientation;
 use crate::ballot_card::PaperInfo;
 use crate::debug::draw_timing_mark_debug_image_mut;
-use crate::image_utils::threshold_and_encode_png;
+use crate::image_utils::binarize_and_encode_png;
 use crate::image_utils::Inset;
 use crate::layout::InterpretedContestLayout;
 use crate::scoring::ScoredBubbleMarks;
@@ -133,10 +133,9 @@ pub struct InterpretedBallotPage {
     pub metadata: BallotPageMetadata,
     pub marks: ScoredBubbleMarks,
     pub write_ins: ScoredPositionAreas,
-    #[serde(skip_serializing)] // `normalized_image` is returned separately.
-    pub normalized_image: GrayImage,
-    /// Pre-encoded PNG bytes of the normalized image. Produced in parallel with
-    /// scoring so that callers can write to disk without re-encoding.
+    /// PNG bytes of the normalized (binarized) ballot image. Produced in
+    /// parallel with scoring so that callers can write to disk without
+    /// re-encoding.
     #[serde(skip_serializing)]
     pub encoded_normalized_image: image::ImageResult<Vec<u8>>,
     pub contest_layouts: Vec<InterpretedContestLayout>,
@@ -503,7 +502,7 @@ pub fn ballot_card(
 
     // Run scoring and image normalization+encoding in parallel. The PNG
     // encoding is CPU-heavy and overlaps well with bubble-mark scoring.
-    let (scoring_result, normalized_and_encoded) = rayon::join(
+    let (scoring_result, encoded_images) = rayon::join(
         || -> Result<ScoringPairs> {
             let scored_bubble_marks = ballot_card.score_bubble_marks(
                 &timing_marks,
@@ -527,7 +526,7 @@ pub fn ballot_card(
         },
         || {
             ballot_card.as_pair().par_map(|ballot_page| {
-                threshold_and_encode_png(
+                binarize_and_encode_png(
                     ballot_page.ballot_image().image(),
                     ballot_page.ballot_image().threshold(),
                 )
@@ -536,20 +535,12 @@ pub fn ballot_card(
     );
 
     let (scored_bubble_marks, contest_layouts, write_in_area_scores) = scoring_result?;
-    let (normalized_images, encoded_images): (Pair<_>, Pair<_>) = {
-        let ((front_norm, front_enc), (back_norm, back_enc)) = normalized_and_encoded.into();
-        (
-            Pair::new(front_norm, back_norm),
-            Pair::new(front_enc, back_enc),
-        )
-    };
 
     Pair::from((
         timing_marks,
         decoded_qr_codes,
         scored_bubble_marks,
         write_in_area_scores,
-        normalized_images,
         encoded_images,
         contest_layouts,
     ))
@@ -559,7 +550,6 @@ pub fn ballot_card(
             (metadata, _),
             marks,
             write_ins,
-            normalized_image,
             encoded_normalized_image,
             contest_layouts,
         )| {
@@ -568,7 +558,6 @@ pub fn ballot_card(
                 metadata: BallotPageMetadata::QrCode(metadata),
                 marks,
                 write_ins,
-                normalized_image,
                 encoded_normalized_image,
                 contest_layouts,
             }
@@ -747,8 +736,11 @@ mod test {
         let (side_a_image, side_b_image, options) =
             load_hmpb_fixture("vx-general-election/letter-en", 1);
         let card = ballot_card(side_a_image, side_b_image, &options).unwrap();
-        assert!(is_binary_image(&card.front.normalized_image));
-        assert!(is_binary_image(&card.back.normalized_image));
+        for page in [&card.front, &card.back] {
+            let encoded = page.encoded_normalized_image.as_ref().unwrap();
+            let decoded = image::load_from_memory(encoded).unwrap().into_luma8();
+            assert!(is_binary_image(&decoded));
+        }
     }
 
     #[test]

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
@@ -1,7 +1,7 @@
 use std::cell::OnceCell;
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use image::{GenericImageView, GrayImage};
+use image::GrayImage;
 use serde::Serialize;
 use types_rs::{
     bmd, bubble_ballot,
@@ -11,6 +11,7 @@ use types_rs::{
 use crate::{
     ballot_card::Orientation,
     debug::{self, ImageDebugWriter},
+    image_utils::crop_to_image,
 };
 
 use super::{rqrr, zedbar};
@@ -66,14 +67,13 @@ impl<'a> DetectionArea<'a> {
 
     pub fn image(&self) -> &GrayImage {
         self.cropped.get_or_init(|| {
-            self.source
-                .view(
-                    self.origin.x,
-                    self.origin.y,
-                    self.size.width,
-                    self.size.height,
-                )
-                .to_image()
+            crop_to_image(
+                self.source,
+                self.origin.x,
+                self.origin.y,
+                self.size.width,
+                self.size.height,
+            )
         })
     }
 }

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
@@ -1,5 +1,7 @@
+use std::cell::OnceCell;
+
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use image::{DynamicImage, GenericImageView, GrayImage};
+use image::{GenericImageView, GrayImage};
 use serde::Serialize;
 use types_rs::{
     bmd, bubble_ballot,
@@ -14,31 +16,34 @@ use crate::{
 use super::{rqrr, zedbar};
 
 /// An area in a ballot image to be searched for QR codes.
-pub struct DetectionArea {
+pub struct DetectionArea<'a> {
+    source: &'a GrayImage,
     origin: Point<PixelUnit>,
+    size: Size<PixelUnit>,
     orientation: Orientation,
-    image: GrayImage,
+    cropped: OnceCell<GrayImage>,
 }
 
-impl DetectionArea {
-    /// Crops the given image at the specified point and size. Records that this
-    /// detection area represents a particular orientation.
+impl<'a> DetectionArea<'a> {
+    /// Defines an area of the given image at the specified point and size.
+    /// Records that this detection area represents a particular orientation.
+    ///
+    /// The crop itself happens lazily on first access to
+    /// [`DetectionArea::image`], so areas that are never scanned (because a
+    /// QR code was already found in an earlier area) are never copied.
     #[must_use]
     pub fn with_crop(
-        img: &GrayImage,
+        img: &'a GrayImage,
         origin: Point<PixelUnit>,
         size: Size<PixelUnit>,
         orientation: Orientation,
     ) -> Self {
-        let cropped_img = DynamicImage::from(
-            img.view(origin.x, origin.y, size.width, size.height)
-                .to_image(),
-        )
-        .into_luma8();
         Self {
+            source: img,
             origin,
-            image: cropped_img,
+            size,
             orientation,
+            cropped: OnceCell::new(),
         }
     }
 
@@ -50,8 +55,8 @@ impl DetectionArea {
         Rect::new(
             self.origin.x as i32,
             self.origin.y as i32,
-            self.image.width(),
-            self.image.height(),
+            self.size.width,
+            self.size.height,
         )
     }
 
@@ -59,8 +64,17 @@ impl DetectionArea {
         self.orientation
     }
 
-    pub const fn image(&self) -> &GrayImage {
-        &self.image
+    pub fn image(&self) -> &GrayImage {
+        self.cropped.get_or_init(|| {
+            self.source
+                .view(
+                    self.origin.x,
+                    self.origin.y,
+                    self.size.width,
+                    self.size.height,
+                )
+                .to_image()
+        })
     }
 }
 
@@ -78,7 +92,7 @@ pub enum SearchStrategy {
 }
 
 /// Gets the HMPB-specific detection areas: bottom-left and top-right corners.
-pub fn get_hmpb_detection_areas(img: &GrayImage) -> Vec<DetectionArea> {
+pub fn get_hmpb_detection_areas(img: &GrayImage) -> Vec<DetectionArea<'_>> {
     let (width, height) = img.dimensions();
     let crop_size = Size {
         width: width / 4,
@@ -105,7 +119,7 @@ pub fn get_hmpb_detection_areas(img: &GrayImage) -> Vec<DetectionArea> {
 /// top 50% of the image at full width. Uses `Portrait` for the bottom area
 /// (QR at bottom = right-side up) and `PortraitReversed` for the top area
 /// (QR at top = upside down).
-pub fn get_broad_detection_areas(img: &GrayImage) -> Vec<DetectionArea> {
+pub fn get_broad_detection_areas(img: &GrayImage) -> Vec<DetectionArea<'_>> {
     let (width, height) = img.dimensions();
     let height_midpoint = height / 2;
 
@@ -135,7 +149,7 @@ pub fn get_broad_detection_areas(img: &GrayImage) -> Vec<DetectionArea> {
 pub fn get_detection_areas_for_strategy(
     img: &GrayImage,
     strategy: SearchStrategy,
-) -> Vec<DetectionArea> {
+) -> Vec<DetectionArea<'_>> {
     match strategy {
         SearchStrategy::BubbleCorners => get_hmpb_detection_areas(img),
         SearchStrategy::Broad => get_broad_detection_areas(img),

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/rqrr.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/rqrr.rs
@@ -5,7 +5,7 @@ use super::detect::{Detected, DetectionArea, Detector, Error, Result};
 
 /// Uses the `rqrr` QR code library to detect a QR code in the given detection
 /// areas.
-pub fn detect_in_areas(detection_areas: &[DetectionArea]) -> Result {
+pub fn detect_in_areas(detection_areas: &[DetectionArea<'_>]) -> Result {
     let detection_area_rects = detection_areas.iter().map(DetectionArea::bounds).collect();
     for area in detection_areas {
         let mut prepared_img = PreparedImage::prepare(area.image().clone());

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/zedbar.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/zedbar.rs
@@ -41,7 +41,13 @@ pub fn detect_in_areas(detection_areas: &[DetectionArea<'_>]) -> Result {
 fn scan_image_for_qr_codes(
     image: &GrayImage,
 ) -> std::result::Result<Vec<(Vec<u8>, Rect)>, zedbar::Error> {
-    let config = DecoderConfig::new().enable(config::QrCode);
+    // Scan every other row and column rather than every one. The ballot QR
+    // codes are ~118px with ~25px finder patterns at scan resolution, so a
+    // density of 2 still crosses each finder pattern many times; it measured
+    // 41% faster with identical detections across a corpus of real scans.
+    let config = DecoderConfig::new()
+        .enable(config::QrCode)
+        .scan_density(2, 2);
     let mut scanner = Scanner::with_config(config);
     let mut img = Image::from_gray(image.as_bytes(), image.width(), image.height())?;
     let symbols = scanner.scan(&mut img);

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/zedbar.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/zedbar.rs
@@ -6,7 +6,7 @@ use super::detect::{Detected, DetectionArea, Detector, Error, Result};
 
 /// Uses the `zedbar` QR code library to detect a QR code in the given
 /// detection areas.
-pub fn detect_in_areas(detection_areas: &[DetectionArea]) -> Result {
+pub fn detect_in_areas(detection_areas: &[DetectionArea<'_>]) -> Result {
     let detection_area_rects = detection_areas.iter().map(DetectionArea::bounds).collect();
     for area in detection_areas {
         match scan_image_for_qr_codes(area.image()) {

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/scoring.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/scoring.rs
@@ -328,6 +328,203 @@ impl<'a> BubbleRegion<'a> {
     }
 }
 
+/// The best template placement found by a bubble search.
+struct BestMatch {
+    bounds: Rect,
+    score: UnitIntervalScore,
+}
+
+/// Bit-packed view of the pixels a bubble search touches: one `u64` per row
+/// of the search window with bit `c` set when the pixel at window column `c`
+/// is dark, and one `u64` per template row with bit `c` set when the template
+/// pixel is white. The match count at offset `(dx, dy)` — the number of
+/// pixels where `source_is_dark || template_is_white`, exactly as
+/// [`BubbleRegion::match_score`] counts them — is then a `popcount` of
+/// `(window_row >> dx) | template_row` per overlapped row, masked to the
+/// template width.
+struct PackedBubbleWindow {
+    window_rows: Vec<u64>,
+    template_rows: Vec<u64>,
+    template_width_mask: u64,
+    /// Number of candidate offsets along each axis (`2 * search distance`).
+    offsets_per_axis: usize,
+}
+
+impl PackedBubbleWindow {
+    /// Packs the search window whose offset `(0, 0)` places the template's
+    /// top-left corner at `(left - distance, top - distance)`. Returns `None`
+    /// when any candidate placement would fall outside the image (the caller
+    /// must handle edge clipping) or when a window row does not fit in a
+    /// `u64`.
+    fn new(
+        img: &GrayImage,
+        template: &GrayImage,
+        left: PixelPosition,
+        top: PixelPosition,
+        distance: PixelUnit,
+        threshold: u8,
+    ) -> Option<Self> {
+        fn pack_row(row: &[u8], is_set: impl Fn(u8) -> bool) -> u64 {
+            row.iter()
+                .enumerate()
+                .fold(0u64, |bits, (c, &p)| bits | (u64::from(is_set(p)) << c))
+        }
+
+        let (template_width, template_height) = template.dimensions();
+        if template_width == 0 || template_height == 0 || distance == 0 {
+            return None;
+        }
+        let offsets_per_axis = distance as usize * 2;
+        // Offsets range over `-distance..distance`, so the window spans
+        // `template size + 2 * distance - 1` pixels along each axis.
+        let window_width = template_width as usize + offsets_per_axis - 1;
+        let window_height = template_height as usize + offsets_per_axis - 1;
+        if window_width > u64::BITS as usize {
+            return None;
+        }
+
+        let window_left = left.checked_sub(distance as PixelPosition)?;
+        let window_top = top.checked_sub(distance as PixelPosition)?;
+        if window_left < 0
+            || window_top < 0
+            || window_left as usize + window_width > img.width() as usize
+            || window_top as usize + window_height > img.height() as usize
+        {
+            return None;
+        }
+
+        let stride = img.width() as usize;
+        let pixels = img.as_raw();
+        let mut window_rows = Vec::with_capacity(window_height);
+        let mut row_start = window_top as usize * stride + window_left as usize;
+        for _ in 0..window_height {
+            window_rows.push(pack_row(
+                &pixels[row_start..row_start + window_width],
+                |p| p <= threshold,
+            ));
+            row_start += stride;
+        }
+
+        let template_rows = template
+            .as_raw()
+            .chunks_exact(template_width as usize)
+            .map(|row| pack_row(row, |p| p == 255))
+            .collect();
+
+        Some(Self {
+            window_rows,
+            template_rows,
+            template_width_mask: (1u64 << template_width) - 1,
+            offsets_per_axis,
+        })
+    }
+
+    /// Counts matching pixels (`source_is_dark || template_is_white`) with the
+    /// template's top-left corner at window offset `(dx, dy)`.
+    fn match_count(&self, dx: usize, dy: usize) -> u32 {
+        self.window_rows[dy..dy + self.template_rows.len()]
+            .iter()
+            .zip(&self.template_rows)
+            .map(|(&window, &template)| {
+                (((window >> dx) | template) & self.template_width_mask).count_ones()
+            })
+            .sum()
+    }
+
+    /// Finds the offset with the highest match count, scoring every offset.
+    /// Iterates x-major with a strictly-greater update, matching
+    /// [`find_best_match_bytes`]'s tie-breaking exactly.
+    fn find_best(&self) -> Option<(usize, usize, u32)> {
+        let mut best: Option<(usize, usize, u32)> = None;
+        for dx in 0..self.offsets_per_axis {
+            for dy in 0..self.offsets_per_axis {
+                let count = self.match_count(dx, dy);
+                if best.is_none_or(|(_, _, best_count)| count > best_count) {
+                    best = Some((dx, dy, count));
+                }
+            }
+        }
+        best
+    }
+}
+
+/// Finds the best template placement using bit-packed rows and `popcount`.
+/// Returns `None` when any candidate placement would fall outside the image
+/// or a window row would not fit in a `u64`; the caller must then use
+/// [`find_best_match_bytes`], which clips candidates instead. When both are
+/// applicable they produce bit-identical results (see the property test
+/// pinning one against the other).
+fn find_best_match_packed(
+    img: &GrayImage,
+    template: &GrayImage,
+    left: PixelPosition,
+    top: PixelPosition,
+    distance: PixelUnit,
+    threshold: u8,
+) -> Option<BestMatch> {
+    let (width, height) = template.dimensions();
+    let packed = PackedBubbleWindow::new(img, template, left, top, distance, threshold)?;
+    packed.find_best().map(|(dx, dy, count)| BestMatch {
+        bounds: Rect::new(
+            left - distance as PixelPosition + dx as PixelPosition,
+            top - distance as PixelPosition + dy as PixelPosition,
+            width,
+            height,
+        ),
+        score: UnitIntervalScore(count as f32 / (width * height) as f32),
+    })
+}
+
+/// Finds the best template placement by scoring each candidate with the
+/// byte-per-pixel [`BubbleRegion`] loop, skipping candidates that fall
+/// outside the image.
+fn find_best_match_bytes(
+    img: &GrayImage,
+    template: &GrayImage,
+    left: PixelPosition,
+    top: PixelPosition,
+    distance: PixelUnit,
+    threshold: u8,
+) -> Option<BestMatch> {
+    let (width, height) = template.dimensions();
+    let (img_width, img_height) = img.dimensions();
+    let mut best_match: Option<BestMatch> = None;
+
+    for offset_x in -(distance as PixelPosition)..(distance as PixelPosition) {
+        let x = left + offset_x;
+        if x < 0 || x as u32 + width > img_width {
+            continue;
+        }
+
+        for offset_y in -(distance as PixelPosition)..(distance as PixelPosition) {
+            let y = top + offset_y;
+            if y < 0 || y as u32 + height > img_height {
+                continue;
+            }
+
+            let region = BubbleRegion::new(img, template, x as u32, y as u32, threshold);
+            let match_score = region.match_score();
+
+            match best_match {
+                None => {
+                    best_match = Some(BestMatch {
+                        bounds: Rect::new(x, y, width, height),
+                        score: match_score,
+                    });
+                }
+                Some(ref mut best_match) => {
+                    if match_score > best_match.score {
+                        best_match.bounds = Rect::new(x, y, width, height);
+                        best_match.score = match_score;
+                    }
+                }
+            }
+        }
+    }
+
+    best_match
+}
+
 /// Scores a bubble mark within a scanned ballot image.
 ///
 /// Compares the source image to the bubble template image at every pixel location
@@ -347,11 +544,6 @@ pub(crate) fn score_bubble_mark(
     location: &GridLocation,
     maximum_search_distance: PixelUnit,
 ) -> Option<ScoredBubbleMark> {
-    struct Match {
-        bounds: Rect,
-        score: UnitIntervalScore,
-    }
-
     let center_x = expected_bubble_center.x.round() as PixelPosition;
     let center_y = expected_bubble_center.y.round() as PixelPosition;
     let width = bubble_template.width();
@@ -361,48 +553,30 @@ pub(crate) fn score_bubble_mark(
     let expected_bounds = Rect::new(left, top, width, height);
 
     let img = ballot_image.image();
-    let img_width = img.width();
-    let img_height = img.height();
     let threshold_val = ballot_image.threshold();
-    let mut best_match = None;
 
-    for offset_x in
-        -(maximum_search_distance as PixelPosition)..(maximum_search_distance as PixelPosition)
-    {
-        let x = left + offset_x;
-        if x < 0 || x as u32 + width > img_width {
-            continue;
-        }
-
-        for offset_y in
-            -(maximum_search_distance as PixelPosition)..(maximum_search_distance as PixelPosition)
-        {
-            let y = top + offset_y;
-            if y < 0 || y as u32 + height > img_height {
-                continue;
-            }
-
-            let region = BubbleRegion::new(img, bubble_template, x as u32, y as u32, threshold_val);
-            let match_score = region.match_score();
-
-            match best_match {
-                None => {
-                    best_match = Some(Match {
-                        bounds: Rect::new(x, y, width, height),
-                        score: match_score,
-                    });
-                }
-                Some(ref mut best_match) => {
-                    if match_score > best_match.score {
-                        best_match.bounds = Rect::new(x, y, width, height);
-                        best_match.score = match_score;
-                    }
-                }
-            }
-        }
-    }
-
-    let best_match = best_match?;
+    // The packed search requires every candidate placement to be inside the
+    // image; near the edges it returns `None` and the byte path, which clips
+    // candidates instead, takes over. Interior bubbles — all of them, in
+    // practice — take the packed path.
+    let best_match = find_best_match_packed(
+        img,
+        bubble_template,
+        left,
+        top,
+        maximum_search_distance,
+        threshold_val,
+    )
+    .or_else(|| {
+        find_best_match_bytes(
+            img,
+            bubble_template,
+            left,
+            top,
+            maximum_search_distance,
+            threshold_val,
+        )
+    })?;
     let best_region = BubbleRegion::new(
         img,
         bubble_template,
@@ -756,6 +930,40 @@ mod test {
                 (actual.0 - expected.0).abs() < f32::EPSILON,
                 "compute_fill_score={} != reference={}", actual.0, expected.0
             );
+        }
+
+        /// Whenever the packed search is applicable (the whole search window
+        /// is inside the image), it must be bit-identical to the
+        /// byte-per-pixel search: same bounds, same score, same tie-breaks.
+        /// Placements range past the image edges to also cover the packed
+        /// search declining (returning `None`) so the byte path takes over.
+        #[test]
+        fn packed_search_is_bit_identical_to_byte_search(
+            img_pixels in proptest::collection::vec(proptest::num::u8::ANY, 14_400),
+            tmpl_pixels in proptest::collection::vec(
+                proptest::strategy::Union::new([
+                    proptest::strategy::Just(0u8).boxed(),
+                    proptest::strategy::Just(255u8).boxed(),
+                ]),
+                400,
+            ),
+            threshold_val in 1u8..254,
+            left in -20i32..140,
+            top in -20i32..140,
+            search_dist in 0u32..12,
+        ) {
+            let img = GrayImage::from_raw(120, 120, img_pixels).unwrap();
+            let template = GrayImage::from_raw(20, 20, tmpl_pixels).unwrap();
+
+            if let Some(packed) = find_best_match_packed(
+                &img, &template, left, top, search_dist, threshold_val,
+            ) {
+                let bytes = find_best_match_bytes(
+                    &img, &template, left, top, search_dist, threshold_val,
+                ).unwrap();
+                prop_assert_eq!(bytes.bounds, packed.bounds);
+                prop_assert_eq!(bytes.score.0.to_bits(), packed.score.0.to_bits());
+            }
         }
     }
 }

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/timing_marks/shape_finding/mod.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/timing_marks/shape_finding/mod.rs
@@ -90,45 +90,64 @@ fn find_timing_mark_shapes(
         return vec![];
     };
 
-    let x_range = search_area.left() as u32..=search_area.right() as u32;
+    let x_start = search_area.left() as u32;
     let y_range = search_area.top() as u32..=search_area.bottom() as u32;
+    let column_count = search_area.width() as usize;
 
-    for x in x_range {
-        for range in y_range
-            .clone()
-            .group_by(|&y| ballot_image.get_pixel(x, y).is_foreground())
-            .into_iter()
-            .filter(|(is_black, _)| *is_black)
-            .map(|(_, group)| group.collect_vec())
-            // Merge black pixel groups that have only a few pixels of white
-            // between them. This allows us to detect timing marks that have a
-            // fold line through them (fold lines sometimes expose the white
-            // paper underneath the black ink).
-            .coalesce(|group1, group2| {
-                let last_of_group1 = group1.last().expect("Pixel group can't be empty");
-                let first_of_group2 = group2.first().expect("Pixel group can't be empty");
-                if first_of_group2 - last_of_group1 - 1 <= allowed_white_gap_within_timing_mark {
-                    let mut merged = group1;
-                    merged.extend(group2);
-                    Ok(merged)
-                } else {
-                    Err((group1, group2))
-                }
-            })
-            .filter_map(|group| {
-                let [first, .., last] = group.as_slice() else {
-                    return None;
-                };
+    let raw = ballot_image.image().as_raw();
+    let image_width = ballot_image.width() as usize;
+    let luma_threshold = ballot_image.threshold();
 
-                if !allowed_timing_mark_height_range.contains(&last.abs_diff(*first)) {
-                    return None;
-                }
+    // The (start, last) y coordinates of the in-progress run of black pixels
+    // in each column, relative to `x_start`.
+    let mut column_runs: Vec<Option<(u32, u32)>> = vec![None; column_count];
+    let mut slices: Vec<(u32, RangeInclusive<u32>)> = vec![];
 
-                Some((*first)..=(*last))
-            })
-        {
-            shape_list_builder.add_slice(x, range);
+    // A run of black pixels is a possible vertical slice of a timing mark if
+    // it spans more than one pixel and is approximately the height of a
+    // timing mark.
+    let mut push_slice = |x: u32, start: u32, last: u32| {
+        if last > start && allowed_timing_mark_height_range.contains(&(last - start)) {
+            slices.push((x, start..=last));
         }
+    };
+
+    // Scan the search area row by row rather than column by column since the
+    // image data is stored row-major, making this far more cache-friendly.
+    // Track the current run of black pixels in each column, merging runs that
+    // have only a few pixels of white between them. This allows us to detect
+    // timing marks that have a fold line through them (fold lines sometimes
+    // expose the white paper underneath the black ink).
+    for y in y_range {
+        let row_start = y as usize * image_width + x_start as usize;
+        let row = &raw[row_start..row_start + column_count];
+        for (i, (&luma, run)) in row.iter().zip(column_runs.iter_mut()).enumerate() {
+            if luma <= luma_threshold {
+                match run {
+                    Some((_, last)) if y - *last <= allowed_white_gap_within_timing_mark + 1 => {
+                        *last = y;
+                    }
+                    Some((start, last)) => {
+                        push_slice(x_start + i as u32, *start, *last);
+                        *run = Some((y, y));
+                    }
+                    None => *run = Some((y, y)),
+                }
+            }
+        }
+    }
+
+    for (i, run) in column_runs.into_iter().enumerate() {
+        if let Some((start, last)) = run {
+            push_slice(x_start + i as u32, start, last);
+        }
+    }
+
+    // Add the slices in column-major order (matching the order a per-column
+    // scan would produce) so the resulting shape list is identical.
+    slices.sort_unstable_by_key(|(x, range)| (*x, *range.start()));
+    for (x, range) in slices {
+        shape_list_builder.add_slice(x, range);
     }
 
     // These values were chosen based on experimentation to merge timing mark
@@ -338,6 +357,164 @@ impl DefaultForGeometry for Options {
                 top: geometry.pixels_per_inch,
                 bottom: geometry.pixels_per_inch,
             },
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::cast_possible_truncation)]
+mod tests {
+    use image::{GrayImage, Luma};
+    use itertools::Itertools;
+    use proptest::prelude::*;
+
+    use super::*;
+    use crate::ballot_card::PaperInfo;
+
+    /// The previous column-major implementation of [`find_timing_mark_shapes`],
+    /// kept as a reference to verify that the row-major scan produces exactly
+    /// the same shapes.
+    fn find_timing_mark_shapes_column_major(
+        ballot_image: &BallotImage,
+        geometry: &Geometry,
+        search_area: Rect,
+        options: &Options,
+    ) -> Vec<TimingMarkShape> {
+        let allowed_timing_mark_height_range = options.timing_mark_height_range(geometry);
+        let allowed_white_gap_within_timing_mark =
+            (geometry.timing_mark_height_pixels() / 3.0) as u32;
+
+        let mut shape_list_builder = ShapeListBuilder::new(geometry.clone());
+        let image_bounds = Rect::new(0, 0, ballot_image.width(), ballot_image.height());
+
+        let Some(search_area) = search_area.intersect(&image_bounds) else {
+            return vec![];
+        };
+
+        let x_range = search_area.left() as u32..=search_area.right() as u32;
+        let y_range = search_area.top() as u32..=search_area.bottom() as u32;
+
+        for x in x_range {
+            for range in y_range
+                .clone()
+                .group_by(|&y| ballot_image.get_pixel(x, y).is_foreground())
+                .into_iter()
+                .filter(|(is_black, _)| *is_black)
+                .map(|(_, group)| group.collect_vec())
+                .coalesce(|group1, group2| {
+                    let last_of_group1 = group1.last().expect("Pixel group can't be empty");
+                    let first_of_group2 = group2.first().expect("Pixel group can't be empty");
+                    if first_of_group2 - last_of_group1 - 1 <= allowed_white_gap_within_timing_mark
+                    {
+                        let mut merged = group1;
+                        merged.extend(group2);
+                        Ok(merged)
+                    } else {
+                        Err((group1, group2))
+                    }
+                })
+                .filter_map(|group| {
+                    let [first, .., last] = group.as_slice() else {
+                        return None;
+                    };
+
+                    if !allowed_timing_mark_height_range.contains(&last.abs_diff(*first)) {
+                        return None;
+                    }
+
+                    Some((*first)..=(*last))
+                })
+            {
+                shape_list_builder.add_slice(x, range);
+            }
+        }
+
+        shape_list_builder.combine_adjacent_shapes(4, 2);
+
+        shape_list_builder
+            .into_iter()
+            .filter_map(|shape| {
+                let shape = shape.smoothed();
+                let bounds = shape.bounds();
+
+                if !rect_could_be_timing_mark(geometry, &bounds) {
+                    return None;
+                }
+
+                if (bounds.left() == image_bounds.left() && bounds.top() == image_bounds.top())
+                    || (bounds.left() == image_bounds.left()
+                        && bounds.bottom() == image_bounds.bottom())
+                    || (bounds.right() == image_bounds.right()
+                        && bounds.top() == image_bounds.top())
+                    || (bounds.right() == image_bounds.right()
+                        && bounds.bottom() == image_bounds.bottom())
+                {
+                    return None;
+                }
+
+                Some(shape)
+            })
+            .collect()
+    }
+
+    #[derive(Debug, Clone)]
+    struct BlackRect {
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    }
+
+    fn black_rect_strategy(
+        image_width: u32,
+        image_height: u32,
+    ) -> impl Strategy<Value = BlackRect> {
+        (0..image_width, 0..image_height, 1..=40u32, 1..=30u32).prop_map(|(x, y, width, height)| {
+            BlackRect {
+                x,
+                y,
+                width,
+                height,
+            }
+        })
+    }
+
+    proptest! {
+        #[test]
+        fn row_major_scan_matches_column_major_reference(
+            rects in proptest::collection::vec(black_rect_strategy(120, 220), 0..20),
+            noise in proptest::collection::vec((0..120u32, 0..220u32), 0..200),
+        ) {
+            const WIDTH: u32 = 120;
+            const HEIGHT: u32 = 220;
+
+            let mut image = GrayImage::from_pixel(WIDTH, HEIGHT, Luma([255]));
+            for rect in rects {
+                for y in rect.y..(rect.y + rect.height).min(HEIGHT) {
+                    for x in rect.x..(rect.x + rect.width).min(WIDTH) {
+                        image.put_pixel(x, y, Luma([0]));
+                    }
+                }
+            }
+            for (x, y) in noise {
+                image.put_pixel(x, y, Luma([0]));
+            }
+
+            let ballot_image = BallotImage::for_testing(image, 128);
+            let geometry = PaperInfo::scanned_letter().compute_geometry();
+            let options = Options::default_for_geometry(&geometry);
+            let search_area = Rect::new(0, 0, WIDTH, HEIGHT);
+
+            let actual =
+                find_timing_mark_shapes(&ballot_image, &geometry, search_area, &options);
+            let expected = find_timing_mark_shapes_column_major(
+                &ballot_image,
+                &geometry,
+                search_area,
+                &options,
+            );
+
+            prop_assert_eq!(actual, expected);
         }
     }
 }

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/timing_marks/util.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/timing_marks/util.rs
@@ -161,11 +161,13 @@ impl<T> CornerWise<T> for [T; 4] {
 /// See <https://en.wikipedia.org/wiki/Median_filter>
 pub(crate) fn median_filter(values: &[u32], window_size: usize) -> Vec<u32> {
     let half = window_size / 2;
+    let mut window = Vec::with_capacity(window_size + 1);
     (0..values.len())
         .map(|i| {
             let start = i.saturating_sub(half);
             let end = (i + half + 1).min(values.len());
-            let mut window = values[start..end].to_vec();
+            window.clear();
+            window.extend_from_slice(&values[start..end]);
             // If the window extends past either the start or end of the
             // values, wrap around to the other side. This ensures that
             // values on the edges have the same window size as those in


### PR DESCRIPTION
## Overview

Reduces HMPB interpretation from ~14.8ms to ~5.7ms per sheet (median, dev machine) through a series of cache-locality, allocation, and encoding optimizations in `libs/ballot-interpreter`. Most of the ideas implemented here came from @kofi's work on his Zig interpreter.

**Approach:** every change was measured before and after (divan benches, `perf`, stage-level profiling) and validated to produce identical output — bit-identical where possible — against the TRR corpus (2,472 real scans from the field) plus property tests pinning each rewrite against its previous implementation. Note the TRR corpus ballots use an outdated QR code metadata format, so they can't be decoded end-to-end, but the images remain fully useful for validating border-inset finding, timing mark detection, streak detection, and QR *detection*.

The techniques, one commit each:

- **Fix the Rust benchmarks** — the fixtures in `test/fixtures` also predate the current QR metadata encoding, so every interpret bench panicked; repointed at the hmpb fixtures.
- **Row-major timing mark shape search** — the strip scan walked columns with a full-image stride (a cache miss per pixel) and allocated a Vec per black run; now one row-major pass with per-column run state. ~20% faster timing mark finding; identical output (property-tested against the old implementation).
- **Row-major/early-exit pixel scans** — same treatment for write-in area scoring, border-inset finding, and the median filter's per-element allocations.
- **Sharded Otsu histogram** — 8 interleaved histograms break the store-forwarding dependency chain on runs of identical pixels; ~2x faster per pass, provably identical threshold.
- **1-bit PNG encoding, fused with binarization** — normalized images are already binary, so pack bits directly from the working image at threshold time and encode a bit-depth-1 PNG; ~1.6x faster *and* ~37% smaller files (106→67 KiB mean), and the never-used 8-bit `normalized_image` copy is gone. Note: changes the stored image bytes, so any externally precomputed image hashes would need regenerating.
- **Lazy + row-wise QR detection area crops** — the second corner crop is skipped when the first contains the QR, and crops copy rows instead of pixels (`SubImage::to_image` is per-pixel; ~15x faster).
- **Row-major streak detection** — count black pixels per column in one row-major pass; only candidate columns (usually none) get the detailed two-column analysis. ~5x faster; identical streaks on the corpus, including three pages with real scanner streaks.
- **Half-density QR scanning** — ballot QRs are ~118px with ~25px finder patterns, so scanning every other row/column loses nothing (verified: identical detections/payloads/orientations across 2,550 images) and is 41% faster. Inspired by @kofi's observation that our QR search does far more work than the target requires.
- **Bit-packed bubble scoring** — pack the search window's dark-pixel bits and the template's white-pixel bits into one `u64` per row, so each candidate offset's match score is a handful of shift/or/popcount ops instead of a byte-per-pixel scan over the template area; the byte path remains as the fallback for edge-clipped windows (never taken on the corpus). Bit-identical: property-tested against the byte search and verified over every interior grid cell of the TRR corpus (3,040,128 positions, zero differences). Scoring 100 bubbles drops 4.7→0.8 ms on the production SBC; ~1 ms/sheet end-to-end.
- **Thin LTO + one codegen unit** — `[profile.release]` in the crate; ~5% end-to-end for a slower release build.
- **x86-64-v3 for x86_64 Linux builds** — the production SBC (Intel N97) is AVX2-capable, so `.cargo/config.toml` sets `target-cpu=x86-64-v3` scoped to that target triple; macOS and other-arch dev builds are unaffected. Another ~5–10% end-to-end. Caveat: setting a `RUSTFLAGS` env var overrides config rustflags entirely.

## Performance

| `interpret` median (dev machine) | before | after |
|---|---|---|
| letter blank | 14.7 ms | 5.4 ms |
| letter marked (famous names) | 14.9 ms | 6.0 ms |
| interpret + save images | 15.3–16.7 ms | 5.0–6.1 ms |

With the last three commits (bit-packed scoring, LTO, x86-64-v3), measured on the production SBC (Intel N97, the shipping build flags):

| `interpret` median (production SBC) | main | after |
|---|---|---|
| letter blank | ~32.0 ms | 11.1 ms |
| letter marked (famous names) | ~32.5 ms | 10.5 ms |
| interpret + save images | ~32.4–32.8 ms | 10.6–10.8 ms |

Compared to @kofi's Zig interpreter (same machine, same sheet, his znver5 build): his end-to-end is still faster (~3.7–5.3 ms vs our ~6.7 ms wall per sheet). After this PR we're ahead on the commodity full-image passes — Otsu (~1.6x), streak detection (~1.7x), PNG encode — while his remaining lead is architectural: a grid-first design whose timing-mark finding (~8x), grid-anchored QR search (~6x), and direct bubble sampling (~10x, mostly recovered by the bit-packed scoring commit) do fundamentally less work than our shape-harvesting search and template-match scoring. Some of that difference also buys robustness/validation on our side (e.g. his build scores ballots without checking the ballot hash against the election). Closing the rest of the gap would be an architectural change, out of scope here.

## Demo Video or Screenshot

N/A (performance change; benchmark tables above).

## Testing Plan

- `cargo test` (105 tests) and `pnpm test:ts` (155 tests) pass; clippy/rustfmt clean.
- New property tests pin each rewrite to its previous behavior: row-major shape scan vs the old column-major implementation, sharded vs naive histogram, 1-bit encode vs `threshold()`, row-wise crop vs `view().to_image()`.
- A/B validation against the TRR corpus (2,472 scans): border insets + full timing mark output byte-identical; detected streaks identical; QR detections/payloads/orientations identical.
- Fixed Rust benchmarks (`cargo bench`) and existing TS benchmarks (`pnpm benchmark`) pass.
- The packed bubble search is property-tested bit-identical to the byte search, and A/B-verified over every interior timing-mark grid cell of the TRR corpus: 3,040,128 positions, zero differences in bounds or scores, packed path taken at 100% of them.
- Shipping flags verified on the production SBC: release test suite passes under thin LTO + x86-64-v3 (AVX2 confirmed in the binary), and fixture interpretation output is byte-identical across build configs and machines.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvnvRZ138pBkvZQGnTFMTU
