### PR TITLE
[ca-demo] Fix stale translation editor contents navigating btn strings

### DIFF
--- a/apps/design/frontend/src/ballot_audio/proofing_screen.tsx
+++ b/apps/design/frontend/src/ballot_audio/proofing_screen.tsx
@@ -381,6 +381,7 @@ export function LanguageProofingScreen(): React.ReactNode {
               stringKey !== ElectionStringKey.CANDIDATE_NAME && (
                 <Translation
                   electionId={electionId}
+                  key={`${stringKey}-${subkey}-${language}`}
                   language={language}
                   stringKey={currentString.key}
                   subKey={currentString.subkey}


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/8363

Missed a commit in https://github.com/votingworks/vxsuite/pull/8907 - this prevents translation input's contents from sticking around from previous edits when navigating back and forth.
