### PR TITLE
[VxHub] Make language naming/ordering consistent + misc tweaks

### DIFF
--- a/apps/design/frontend/src/ballot_audio/keyboard.tsx
+++ b/apps/design/frontend/src/ballot_audio/keyboard.tsx
@@ -99,9 +99,8 @@ export interface Phoneme {
 type Alphabet = 'ipa' | 'vx';
 
 const consonantModifier = {
-  regular: 'ə',
   ipa: 'ə',
-  'x-sampa': '@',
+  vx: 'ə',
 } as const;
 
 export function Keyboard(props: {

--- a/apps/design/frontend/src/ballot_audio/language_select.tsx
+++ b/apps/design/frontend/src/ballot_audio/language_select.tsx
@@ -2,16 +2,17 @@
 
 import styled from 'styled-components';
 
-import { LanguageCode, ORDERED_LANGUAGE_CODES } from '@votingworks/types';
+import { LanguageCode } from '@votingworks/types';
+import { ORDERED_LANGUAGES, format } from '@votingworks/utils';
 import {
   DesktopPalette,
   Icons,
   SearchSelect,
   useCurrentTheme,
 } from '@votingworks/ui';
-import { format } from '@votingworks/utils';
 import { useHistory, useParams } from 'react-router-dom';
 import { BallotAudioPathParams } from './routes';
+import * as api from '../api';
 
 const Container = styled.div`
   align-items: center;
@@ -34,34 +35,41 @@ const Container = styled.div`
 
 const { ENGLISH } = LanguageCode;
 
-export function LanguageSelect(): JSX.Element {
+export function LanguageSelect(): React.ReactNode {
   const theme = useCurrentTheme();
 
   const params = useParams<BallotAudioPathParams>();
-  const { language = ENGLISH } = params;
+  const { electionId, language = ENGLISH } = params;
   const history = useHistory();
+
+  const election = api.getElectionInfo.useQuery(electionId).data;
 
   function setLanguage(newLang: LanguageCode) {
     const newPath = history.location.pathname.replace(
-      /language\/[a-zA-Z-_]+/,
+      /language(\/[a-zA-Z-_]+|$)/,
       `language/${newLang}`
     );
 
     history.replace(newPath);
   }
 
+  if (!election) return null;
+
+  const { languageCodes } = election;
+  const ordered = ORDERED_LANGUAGES.filter((l) => languageCodes.includes(l));
+  if (!ordered.includes(language)) setLanguage(LanguageCode.ENGLISH);
+
   return (
     <Container>
       <Icons.Language
         color="neutral"
-        // style={{ fontSize: '1.5rem', padding: '0 0.7rem' }}
         style={{ fontSize: '1.25rem', padding: '0 0.75rem' }}
       />
       <SearchSelect
         // @ts-expect-error - shhh
         onChange={setLanguage}
-        options={ORDERED_LANGUAGE_CODES.map((l) => ({
-          label: format.languageDisplayName({
+        options={ordered.map((l) => ({
+          label: format.languageDisplayName2({
             languageCode: l,
             displayLanguageCode: LanguageCode.ENGLISH,
           }),

--- a/apps/design/frontend/src/ballot_audio/phoneditor.tsx
+++ b/apps/design/frontend/src/ballot_audio/phoneditor.tsx
@@ -407,6 +407,11 @@ const alphabets = ['ipa', 'vx'] as const;
 
 const SHOW_DEV_MENU = process.env.NODE_ENV === 'development';
 
+const IDEOGRAPHIC_LANGS: LanguageCode[] = [
+  LanguageCode.CHINESE_SIMPLIFIED,
+  LanguageCode.CHINESE_TRADITIONAL,
+];
+
 export interface PhoneditorProps {
   editable?: boolean;
   jurisdictionId: string;
@@ -434,13 +439,15 @@ export function Phoneditor(props: PhoneditorProps): JSX.Element {
       const ssmlChunks = [...savedSsml];
       ssmlChunks[syllableIndex].syllables = undefined;
 
+      const hasAnyPhonetics = ssmlChunks.some((c) => !!c.syllables);
+
       await save({
         jurisdictionId,
         original,
         languageCode,
         data: {
-          exportSource: 'phonetic',
-          phonetic: ssmlChunks,
+          exportSource: hasAnyPhonetics ? 'phonetic' : 'text',
+          phonetic: hasAnyPhonetics ? ssmlChunks : [],
           text: savedEdit.text,
         },
       });
@@ -539,7 +546,9 @@ export function Phoneditor(props: PhoneditorProps): JSX.Element {
         );
       }
     } else {
-      const fragments = original.split(' ');
+      const fragments = IDEOGRAPHIC_LANGS.includes(languageCode)
+        ? splitIdeographic(original)
+        : original.split(' ');
 
       for (let i = 0; i < fragments.length; i += 1) {
         resolvedChunks.push({ text: fragments[i] });
@@ -558,7 +567,7 @@ export function Phoneditor(props: PhoneditorProps): JSX.Element {
     }
 
     return [resolvedChunks, elems];
-  }, [clearEdits, editable, original, savedSsml, saving]);
+  }, [clearEdits, editable, languageCode, original, savedSsml, saving]);
 
   const onInput = React.useCallback(
     (phoneme: Phoneme) => {
@@ -624,31 +633,11 @@ export function Phoneditor(props: PhoneditorProps): JSX.Element {
 
   const onPlayPreview = React.useCallback(() => {
     if (lastAudio.current) {
-      // lastAudio.current.pause();
       lastAudio.current.src = '';
       lastAudio.current = undefined;
     }
 
-    let combinedPhonemes = '';
-    for (let i = 0; i < syllables.length; i += 1) {
-      const syllable = syllables[i];
-      if (syllable.ipaPhonemes.length === 0) continue;
-
-      if (syllable.stress === 'primary') {
-        combinedPhonemes += phonemes.en.stresses.primary.ipa;
-      } else if (syllable.stress === 'secondary') {
-        combinedPhonemes += phonemes.en.stresses.secondary.ipa;
-      } else if (i > 0) {
-        combinedPhonemes += '.';
-      }
-
-      for (const phoneme of syllable.ipaPhonemes) combinedPhonemes += phoneme;
-    }
-    setSsmlToPreview(
-      `<speak>` +
-        `<phoneme alphabet="ipa" ph="${combinedPhonemes}" />.` +
-        `</speak>`
-    );
+    setSsmlToPreview(`<speak>${ssmlWord(syllables)}</speak>`);
     setPlayingPreview(true);
   }, [syllables]);
 
@@ -949,6 +938,45 @@ export function Phoneditor(props: PhoneditorProps): JSX.Element {
   );
 }
 
+// [TODO] Very rough sketch. Clean up, extend to non-ideographic text, and
+// handle splitting at punctuation/symbol boundaries too.
+function splitIdeographic(text: string) {
+  const chunks: string[] = [];
+
+  let nextChunk: string[] = [];
+  for (const codepointStr of text) {
+    const codepoint = codepointStr.codePointAt(0);
+    if (!codepoint) continue;
+
+    if (codepoint > 0xff) {
+      if (nextChunk.length) {
+        chunks.push(nextChunk.join(''));
+        nextChunk = [];
+      }
+
+      chunks.push(codepointStr);
+      continue;
+    }
+
+    if (/\s/.test(codepointStr)) {
+      if (nextChunk.length) {
+        chunks.push(nextChunk.join(''));
+        nextChunk = [];
+      }
+      continue;
+    }
+
+    nextChunk.push(codepointStr);
+  }
+
+  if (nextChunk.length) {
+    chunks.push(nextChunk.join(''));
+    nextChunk = [];
+  }
+
+  return chunks;
+}
+
 export interface PhoneticAudioControlsProps {
   disabled?: boolean;
   languageCode: string;
@@ -1011,10 +1039,12 @@ function ssmlWord(syllables: PhoneticSyllable[]) {
     const syllable = syllables[i];
     if (syllable.ipaPhonemes.length === 0) continue;
 
-    if (i > 0) combinedPhonemes += '.';
-
     if (syllable.stress === 'primary') {
       combinedPhonemes += phonemes.en.stresses.primary.ipa;
+    } else if (syllable.stress === 'secondary') {
+      combinedPhonemes += phonemes.en.stresses.secondary.ipa;
+    } else if (i > 0) {
+      combinedPhonemes += '.';
     }
 
     for (const phoneme of syllable.ipaPhonemes) combinedPhonemes += phoneme;

--- a/apps/design/frontend/src/ballot_audio/proofing_screen.tsx
+++ b/apps/design/frontend/src/ballot_audio/proofing_screen.tsx
@@ -594,6 +594,8 @@ const DescriptionEditor = styled(RichTextEditor)`
   background: ${(p) => p.theme.colors.background};
 `;
 
+// [TODO] Trim down to just the `DescriptionEditor`, now that this is mostly
+// aligned with the plain `Translation` component.
 function RichTextTranslation(props: {
   electionId: string;
   language: LanguageCode;
@@ -614,6 +616,11 @@ function RichTextTranslation(props: {
 
   return (
     <TranslationContainer header={<H3>Translation</H3>}>
+      <div>
+        <Icons.ChevronRight style={{ marginRight: '0.5rem' }} />
+        Edit the following text to change the translation shown on voter
+        ballots:
+      </div>
       <DescriptionEditor
         dir={IS_RTL[language] ? 'rtl' : undefined}
         initialHtmlContent={edit || translation.forDisplay}

--- a/apps/design/frontend/src/election_info_screen.tsx
+++ b/apps/design/frontend/src/election_info_screen.tsx
@@ -19,6 +19,7 @@ import type { ElectionInfo } from '@votingworks/design-backend';
 import { Route, Switch, useHistory, useParams } from 'react-router-dom';
 import { z } from 'zod/v4';
 import { DateWithoutTime, throwIllegalValue } from '@votingworks/basics';
+import { format, ORDERED_LANGUAGES } from '@votingworks/utils';
 import styled from 'styled-components';
 import {
   deleteElection,
@@ -325,20 +326,13 @@ function ElectionInfoForm({
               onChange={(languageCodes) => {
                 setElectionInfo({ ...electionInfo, languageCodes });
               }}
-              options={[
-                { label: 'English', value: LanguageCode.ENGLISH },
-                { label: 'Arabic', value: LanguageCode.ARABIC },
-                { label: 'Bengali', value: LanguageCode.BENGALI },
-                {
-                  label: 'Chinese (Simplified)',
-                  value: LanguageCode.CHINESE_SIMPLIFIED,
-                },
-                {
-                  label: 'Chinese (Traditional)',
-                  value: LanguageCode.CHINESE_TRADITIONAL,
-                },
-                { label: 'Spanish', value: LanguageCode.SPANISH },
-              ]}
+              options={ORDERED_LANGUAGES.map((l) => ({
+                label: format.languageDisplayName2({
+                  displayLanguageCode: LanguageCode.ENGLISH,
+                  languageCode: l,
+                }),
+                value: l,
+              }))}
             />
           </div>
         )}

--- a/libs/types/src/language_code.ts
+++ b/libs/types/src/language_code.ts
@@ -11,16 +11,6 @@ export enum LanguageCode {
 }
 
 export const LanguageCodeSchema: z.ZodType<LanguageCode> = z.enum(LanguageCode);
-
-export const ORDERED_LANGUAGE_CODES = Object.values(LanguageCode).sort(
-  /* istanbul ignore next */
-  (a, b) => {
-    if (a === LanguageCode.ENGLISH) return -1;
-    if (b === LanguageCode.ENGLISH) return 1;
-    return a.localeCompare(b);
-  }
-);
-
 export type NonEnglishLanguageCode = Exclude<
   LanguageCode,
   LanguageCode.ENGLISH

--- a/libs/utils/src/format.ts
+++ b/libs/utils/src/format.ts
@@ -1,4 +1,5 @@
 import { assertDefined } from '@votingworks/basics';
+import { LanguageCode } from '@votingworks/types';
 import { DateTime } from 'luxon';
 
 export const DEFAULT_LOCALE: string = 'en';
@@ -125,6 +126,51 @@ export function languageDisplayName(params: {
     displayLanguageCode = languageCode,
     style = 'narrow',
   } = params;
+
+  return assertDefined(
+    // TODO(kofi): This util doesn't currently have a comprehensive list of
+    // native language names for all languages, so probably better to find a
+    // reliably sourced list and hardcode the mappings instead.
+    // This at least works for the top 10 spoken in the US and is sufficient for
+    // cert.
+    new Intl.DisplayNames([displayLanguageCode], {
+      style,
+      type: 'language',
+      fallback: 'none',
+    }).of(languageCode),
+    `unexpected missing language display name for ${languageCode} in ${displayLanguageCode}`
+  );
+}
+
+export function languageDisplayName2(params: {
+  languageCode: string;
+
+  /** @default {@link params.languageCode} */
+  displayLanguageCode?: string;
+
+  /** @default 'narrow' */
+  style?: Intl.RelativeTimeFormatStyle;
+}): string {
+  const {
+    languageCode,
+    displayLanguageCode = languageCode,
+    style = 'narrow',
+  } = params;
+
+  if (displayLanguageCode === LanguageCode.ENGLISH) {
+    // Override Chinese language English labels so they sort together:
+    if (languageCode === LanguageCode.CHINESE_SIMPLIFIED) {
+      return 'Chinese (Simplified)';
+    }
+    if (languageCode === LanguageCode.CHINESE_TRADITIONAL) {
+      return 'Chinese (Traditional)';
+    }
+
+    // Omit the "(US)" qualifier for Spanish since it's the national default:
+    if (languageCode === LanguageCode.SPANISH) {
+      return 'Spanish';
+    }
+  }
 
   return assertDefined(
     // TODO(kofi): This util doesn't currently have a comprehensive list of

--- a/libs/utils/src/languages.ts
+++ b/libs/utils/src/languages.ts
@@ -1,28 +1,45 @@
 import { LanguageCode, Election } from '@votingworks/types';
+import { languageDisplayName2 } from './format';
+
+const { ENGLISH } = LanguageCode;
+
+/**
+ * All language codes, ordered in order of precedence for user selection when
+ * displayed in English.
+ */
+export const ORDERED_LANGUAGES = Object.values(LanguageCode).sort(
+  /* istanbul ignore next */
+  (a, b) => {
+    if (a === LanguageCode.ENGLISH) return -1;
+    if (b === LanguageCode.ENGLISH) return 1;
+
+    const labelA = languageDisplayName2({
+      displayLanguageCode: ENGLISH,
+      languageCode: a,
+    });
+
+    const labelB = languageDisplayName2({
+      displayLanguageCode: ENGLISH,
+      languageCode: b,
+    });
+
+    return labelA.localeCompare(labelB);
+  }
+);
 
 export function languageSort(
   languageA: LanguageCode,
   languageB: LanguageCode
 ): number {
-  const languageOrder: LanguageCode[] = [
-    LanguageCode.ENGLISH,
-    LanguageCode.ARABIC,
-    LanguageCode.BENGALI,
-    LanguageCode.CHINESE_SIMPLIFIED,
-    LanguageCode.CHINESE_TRADITIONAL,
-    LanguageCode.SPANISH,
-  ];
-  const indexA = languageOrder.indexOf(languageA);
-  const indexB = languageOrder.indexOf(languageB);
+  const indexA = ORDERED_LANGUAGES.indexOf(languageA);
+  const indexB = ORDERED_LANGUAGES.indexOf(languageB);
   return indexA - indexB;
 }
 
 export function getLanguageOptions(election: Election): LanguageCode[] {
-  return [
-    ...new Set(
-      election.ballotStyles.flatMap((bs) => bs.languages as LanguageCode[])
-    ),
-  ]
-    .filter((lang) => lang !== undefined)
-    .sort(languageSort);
+  const ballotLanguages = new Set(
+    election.ballotStyles.flatMap((bs) => bs.languages as LanguageCode[])
+  );
+
+  return ORDERED_LANGUAGES.filter((l) => ballotLanguages.has(l));
 }


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/8363
https://github.com/votingworks/vxsuite/issues/8364

- For the phonetic editor, now using a less naive word split for ideographic text to avoid bundling everything together into one "word" when splitting on whitespace:
<img width="698" height="352" alt="Screenshot 2026-07-16 at 16 58 22" src="https://github.com/user-attachments/assets/68cbd874-76bf-48f1-949f-c2b3d944bde3" />

- Consolidate logic for ordering and labelling languages in VxHub. Keeps the language picker in sync with the language options in the election info screen:
<img width="375" height="367" alt="Screenshot 2026-07-16 at 16 58 04" src="https://github.com/user-attachments/assets/a6255331-8b9d-47e6-a68d-e8fc909dccbc" />
