### PR TITLE
[ca-demo] Fix exports for recorded audio overrides

### DIFF
--- a/apps/design/backend/src/store.test.ts
+++ b/apps/design/backend/src/store.test.ts
@@ -519,6 +519,7 @@ describe('tts_strings', () => {
         languageCode: 'en',
         original: 'one two',
         phonetic: [],
+        recordingDataUrl: '',
         text: 'wun too',
       },
       {
@@ -526,6 +527,7 @@ describe('tts_strings', () => {
         languageCode: 'es',
         original: 'three four',
         phonetic: [],
+        recordingDataUrl: '',
         text: 'three foar',
       },
     ]);

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -2964,7 +2964,7 @@ export class Store {
         original: row.original,
         languageCode: row.languageCode,
         phonetic: safeParse(PhoneticWordsSchema, row.phonetic).unsafeUnwrap(),
-        recordingDataUrl: row.recording_data_url,
+        recordingDataUrl: row.recordingDataUrl,
         text: row.text as string,
       }));
     });


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/8916

Fix missing field in exported clips for recorded audio overrides, missed in https://github.com/votingworks/vxsuite/pull/8926.