### PR TITLE
VxAdmin: raise timeout on file-store tests prone to CI disk contention

### DIFF
--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -54,7 +54,7 @@ test('create a file store', () => {
 
   expect(store).toBeInstanceOf(Store);
   expect(store.getDbPath()).toEqual(tmpDbPath);
-});
+}, 30_000);
 
 test('create a memory store', () => {
   const store = Store.memoryStore(makeTemporaryDirectory());

--- a/apps/admin/backend/src/util/workspace.test.ts
+++ b/apps/admin/backend/src/util/workspace.test.ts
@@ -21,7 +21,7 @@ test('createWorkspace', () => {
   const workspace = createWorkspace(dir, mockBaseLogger({ fn: vi.fn }));
   expect(workspace.path).toEqual(dir);
   expect(workspace.store).toBeInstanceOf(Store);
-});
+}, 30_000);
 
 test('createClientWorkspace', async () => {
   const dir = makeTemporaryDirectory();


### PR DESCRIPTION

## Overview

Bumps timeout for 2 admin/backend tests that open an on-disk SQLite db. Possibly addresses flaky tests in https://app.circleci.com/pipelines/github/votingworks/vxsuite/27577/workflows/48adb34d-3142-44f8-9a0d-623feae61da4/jobs/1287160. When disk on CI machines is under contention this operation can time out.

These tests run in ~40ms locally so I expect the tests are failing because of contention and are not actually slow.

## Demo Video or Screenshot

N/A

## Testing Plan

Existing tests

