### PR TITLE
libs/fs: reduce random max filesize in test

### DIFF
--- a/libs/fs/src/read_file.test.ts
+++ b/libs/fs/src/read_file.test.ts
@@ -19,7 +19,7 @@ test('file open error', async () => {
 
 test('file exceeds max size', async () => {
   await fc.assert(
-    fc.asyncProperty(fc.nat(1024 * 1024 * 10), async (maxSize) => {
+    fc.asyncProperty(fc.nat(1024 * 1024), async (maxSize) => {
       const path = makeTemporaryFile({ content: 'a'.repeat(maxSize + 1) });
       expect(await readFile(path, { maxSize })).toEqual(
         err(


### PR DESCRIPTION


## Overview

Possibly fixes test timeouts in https://app.circleci.com/pipelines/github/votingworks/vxsuite/27572/workflows/63d9ddfd-f77a-470f-8276-055e5a56bead/jobs/1286846

This test does not exercise a codepath that depends on absolute filesize, nor does it make assertions about max filesize. The [0, 10mb] filesize spread for 100 runs of temp file writing/reading was possibly causing timeouts when disk in CI was under contention.

I'm not sure if I'm missing something re: 10mb limit for random test filesize (cc @eventualbuddha in case there was some additional reasoning). If we're confident the limit can be arbitrary, we could reduce the limit in this PR to something even lower eg. 4kb.


## Demo Video or Screenshot
N/A

## Testing Plan

Existing tests
