### PR TITLE
VxPollBook: hoist fixture parsing and clean up `setInterval`

### DIFF
--- a/apps/pollbook/backend/src/app.ts
+++ b/apps/pollbook/backend/src/app.ts
@@ -74,6 +74,7 @@ import { InvalidateRegistrationReceipt } from './receipts/invalidate_registratio
 import { BarcodeScannerClient } from './barcode_scanner/client';
 import { securityHeadersMiddleware } from './security_middleware';
 import { constructAuthMachineState } from './auth';
+import { RestartablePoller, setStopBackgroundTasks } from './background_tasks';
 
 const debug = rootDebug.extend('local_app');
 
@@ -83,7 +84,16 @@ interface BuildAppParams {
   logger: Logger;
 }
 
-function buildApi({ context, logger, barcodeScannerClient }: BuildAppParams) {
+interface BuildApiParams extends BuildAppParams {
+  usbDrivePoller: RestartablePoller;
+}
+
+function buildApi({
+  context,
+  logger,
+  barcodeScannerClient,
+  usbDrivePoller,
+}: BuildApiParams) {
   const { workspace, auth, usbDrive, printer, machineId, codeVersion } =
     context;
   const { store } = workspace;
@@ -255,7 +265,7 @@ function buildApi({ context, logger, barcodeScannerClient }: BuildAppParams) {
         workspace.store.setConfigurationStatus(undefined);
       }
       await workspace.peerApiClient.unconfigure();
-      pollUsbDriveForPollbookPackage(context);
+      usbDrivePoller.restart();
     },
 
     getIsAbsenteeMode(): boolean {
@@ -790,10 +800,18 @@ export function buildLocalApp({
   // Apply security headers middleware first
   app.use(securityHeadersMiddleware);
 
-  const api = buildApi({ context, logger, barcodeScannerClient });
+  const usbDrivePoller = new RestartablePoller(() =>
+    pollUsbDriveForPollbookPackage(context)
+  );
+  const api = buildApi({
+    context,
+    logger,
+    barcodeScannerClient,
+    usbDrivePoller,
+  });
   app.use('/api', grout.buildRouter(api, express));
 
-  pollUsbDriveForPollbookPackage(context);
+  setStopBackgroundTasks(app, () => usbDrivePoller.stop());
 
   return app;
 }

--- a/apps/pollbook/backend/src/app_config.test.ts
+++ b/apps/pollbook/backend/src/app_config.test.ts
@@ -24,6 +24,20 @@ const singlePrecinctElectionTownVoters =
 const singlePrecinctElectionTownStreetNames =
   electionSimpleSinglePrecinctFixtures.pollbookTownStreetNames.asText();
 
+const multiPrecinctElectionDefinition =
+  electionMultiPartyPrimaryFixtures.readElectionDefinition();
+// Parse the street lists once at module load rather than inside each test body:
+// parsing is CPU-intensive and would otherwise count against the per-test
+// timeout (which flakes under CI load).
+const multiPrecinctCityStreets = parseValidStreetsFromCsvString(
+  electionMultiPartyPrimaryFixtures.pollbookCityStreetNames.asText(),
+  multiPrecinctElectionDefinition.election
+);
+const singlePrecinctTownStreets = parseValidStreetsFromCsvString(
+  electionSimpleSinglePrecinctFixtures.pollbookTownStreetNames.asText(),
+  singlePrecinctElectionDefinition.election
+);
+
 let mockNodeEnv: 'production' | 'test' = 'test';
 
 vi.mock(
@@ -197,16 +211,10 @@ test('app config - polling usb from backend does trigger with system admin auth'
 test('setConfiguredPrecinct sets and getPollbookConfigurationInformation returns the configured precinct', async () => {
   await withApp(async ({ localApiClient, workspace }) => {
     // Initially, no configured precinct on a multi precinct election
-    const multiPrecinctElection =
-      electionMultiPartyPrimaryFixtures.readElectionDefinition();
-    const testStreets = parseValidStreetsFromCsvString(
-      electionMultiPartyPrimaryFixtures.pollbookCityStreetNames.asText(),
-      multiPrecinctElection.election
-    );
     workspace.store.setElectionAndVoters(
-      multiPrecinctElection,
+      multiPrecinctElectionDefinition,
       'mock-package-hash',
-      testStreets,
+      multiPrecinctCityStreets,
       []
     );
     let config = await localApiClient.getPollbookConfigurationInformation();
@@ -220,14 +228,14 @@ test('setConfiguredPrecinct sets and getPollbookConfigurationInformation returns
     );
 
     const ok = await localApiClient.setConfiguredPrecinct({
-      precinctId: multiPrecinctElection.election.precincts[0].id,
+      precinctId: multiPrecinctElectionDefinition.election.precincts[0].id,
     });
     expect(ok.ok()).toEqual(undefined);
 
     // Now it should be returned
     config = await localApiClient.getPollbookConfigurationInformation();
     expect(config.configuredPrecinctId).toEqual(
-      multiPrecinctElection.election.precincts[0].id
+      multiPrecinctElectionDefinition.election.precincts[0].id
     );
   });
 });
@@ -235,14 +243,10 @@ test('setConfiguredPrecinct sets and getPollbookConfigurationInformation returns
 test('setting a single precinct election automatically sets the configured precinct', async () => {
   await withApp(async ({ localApiClient, workspace }) => {
     // Initially, no configured precinct on a multi precinct election
-    const testStreets = parseValidStreetsFromCsvString(
-      electionSimpleSinglePrecinctFixtures.pollbookTownStreetNames.asText(),
-      singlePrecinctElectionDefinition.election
-    );
     workspace.store.setElectionAndVoters(
       singlePrecinctElectionDefinition,
       'mock-package-hash',
-      testStreets,
+      singlePrecinctTownStreets,
       []
     );
     const config = await localApiClient.getPollbookConfigurationInformation();

--- a/apps/pollbook/backend/src/app_multi_node.test.ts
+++ b/apps/pollbook/backend/src/app_multi_node.test.ts
@@ -38,6 +38,14 @@ const testStreets = parseValidStreetsFromCsvString(
   electionSimpleSinglePrecinctFixtures.pollbookTownStreetNames.asText(),
   singlePrecinctElectionDefinition.election
 );
+const multiPrecinctCityVoters = parseVotersFromCsvString(
+  electionMultiPartyPrimaryFixtures.pollbookCityVoters.asText(),
+  multiPrecinctElectionDefinition.election
+);
+const multiPrecinctCityStreets = parseValidStreetsFromCsvString(
+  electionMultiPartyPrimaryFixtures.pollbookCityStreetNames.asText(),
+  multiPrecinctElectionDefinition.election
+);
 
 vi.mock(
   './globals.js',
@@ -1260,14 +1268,8 @@ test('pollbooks with different configured precinct values cannot connect', async
     pollbookContext1.workspace.store.setElectionAndVoters(
       multiPrecinctElectionDefinition,
       'mock-package-hash',
-      parseValidStreetsFromCsvString(
-        electionMultiPartyPrimaryFixtures.pollbookCityStreetNames.asText(),
-        multiPrecinctElectionDefinition.election
-      ),
-      parseVotersFromCsvString(
-        electionMultiPartyPrimaryFixtures.pollbookCityVoters.asText(),
-        multiPrecinctElectionDefinition.election
-      )
+      multiPrecinctCityStreets,
+      multiPrecinctCityVoters
     );
     pollbookContext2.workspace.store.setElectionAndVoters(
       multiPrecinctElectionDefinition,

--- a/apps/pollbook/backend/src/background_tasks.ts
+++ b/apps/pollbook/backend/src/background_tasks.ts
@@ -1,0 +1,53 @@
+import { Application } from 'express';
+
+/**
+ * A handle to a running background loop (typically backed by `setInterval`). The
+ * loop must be stopped when the app shuts down so its timer does not leak. This
+ * matters especially in tests, where a leaked interval keeps the event loop busy
+ * across subsequent test cases and can cause unrelated tests to time out.
+ */
+export interface Poller {
+  /** Stops the background loop and releases its timer. Safe to call twice. */
+  stop: () => void;
+}
+
+/**
+ * Manages a background {@link Poller} that can be restarted over the app's
+ * lifetime (e.g. polling is restarted after the machine is unconfigured). Always
+ * stops the previous loop before starting a new one so timers do not accumulate.
+ */
+export class RestartablePoller {
+  private poller: Poller;
+
+  constructor(private readonly startPoller: () => Poller) {
+    this.poller = startPoller();
+  }
+
+  restart(): void {
+    this.poller.stop();
+    this.poller = this.startPoller();
+  }
+
+  stop(): void {
+    this.poller.stop();
+  }
+}
+
+const stopFnByApp = new WeakMap<Application, () => void>();
+
+/**
+ * Records how to stop all of an app's background loops. Keyed off the app so the
+ * app builders can keep returning a plain express `Application` while still
+ * exposing cleanup to callers (notably the test harness).
+ */
+export function setStopBackgroundTasks(
+  app: Application,
+  stop: () => void
+): void {
+  stopFnByApp.set(app, stop);
+}
+
+/** Stops all background loops previously registered for `app`. */
+export function stopBackgroundTasks(app: Application): void {
+  stopFnByApp.get(app)?.();
+}

--- a/apps/pollbook/backend/src/networking.ts
+++ b/apps/pollbook/backend/src/networking.ts
@@ -22,6 +22,7 @@ import {
 } from './globals';
 import type { PeerApi } from './peer_app';
 import { intermediateScript } from './intermediate_scripts';
+import { Poller } from './background_tasks';
 
 const debug = rootDebug.extend('networking');
 
@@ -85,12 +86,17 @@ export function getNodeServiceName(machineId: string): string {
 
 export function fetchEventsFromConnectedPollbooks({
   workspace,
-}: PeerAppContext): void {
+}: PeerAppContext): Poller {
+  let intervalId: ReturnType<typeof setInterval> | undefined;
+  let stopped = false;
   // Poll to fetch events from connected pollbooks using a gossip protocol
   process.nextTick(() => {
+    if (stopped) {
+      return;
+    }
     let isPolling = false;
     let pollbookQueue: string[] = [];
-    setInterval(async () => {
+    intervalId = setInterval(async () => {
       if (isPolling) {
         return;
       }
@@ -217,6 +223,15 @@ export function fetchEventsFromConnectedPollbooks({
       }
     }, EVENT_POLLING_INTERVAL);
   });
+
+  return {
+    stop: () => {
+      stopped = true;
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+    },
+  };
 }
 
 export function isValidIpv4Address(address: string): boolean {
@@ -228,7 +243,7 @@ export function isValidIpv4Address(address: string): boolean {
 export function setupMachineNetworking({
   machineId,
   workspace,
-}: PeerAppContext): void {
+}: PeerAppContext): Poller {
   const selfMachineServiceName = getNodeServiceName(machineId);
   // Advertise a service for this machine
   debug(
@@ -242,10 +257,15 @@ export function setupMachineNetworking({
   });
 
   // Poll for new machines on the network
+  let intervalId: ReturnType<typeof setInterval> | undefined;
+  let stopped = false;
   process.nextTick(() => {
+    if (stopped) {
+      return;
+    }
     let isPolling = false;
 
-    setInterval(async () => {
+    intervalId = setInterval(async () => {
       if (isPolling) {
         return;
       }
@@ -442,4 +462,13 @@ export function setupMachineNetworking({
       }
     }, NETWORK_POLLING_INTERVAL);
   });
+
+  return {
+    stop: () => {
+      stopped = true;
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+    },
+  };
 }

--- a/apps/pollbook/backend/src/peer_app.test.ts
+++ b/apps/pollbook/backend/src/peer_app.test.ts
@@ -15,6 +15,18 @@ let mockNodeEnv: 'production' | 'test' = 'test';
 const electionDefinition =
   electionMultiPartyPrimaryFixtures.readElectionDefinition();
 
+// Parsing the full pollbook city voter/street lists is CPU-intensive (several
+// seconds). Do it once at module load rather than inside each test body, so it
+// doesn't count against the per-test timeout (which flakes under CI load).
+const testVoters = parseVotersFromCsvString(
+  electionMultiPartyPrimaryFixtures.pollbookCityVoters.asText(),
+  electionDefinition.election
+);
+const testStreets = parseValidStreetsFromCsvString(
+  electionMultiPartyPrimaryFixtures.pollbookCityStreetNames.asText(),
+  electionDefinition.election
+);
+
 vi.mock(
   './globals.js',
   async (importActual): Promise<typeof import('./globals')> => ({
@@ -38,14 +50,6 @@ test('getPollbookConfigurationInformation', async () => {
       machineId: '0102',
     });
 
-    const testVoters = parseVotersFromCsvString(
-      electionMultiPartyPrimaryFixtures.pollbookCityVoters.asText(),
-      electionDefinition.election
-    );
-    const testStreets = parseValidStreetsFromCsvString(
-      electionMultiPartyPrimaryFixtures.pollbookCityStreetNames.asText(),
-      electionDefinition.election
-    );
     workspace.store.setElectionAndVoters(
       electionDefinition,
       'mock-package-hash',
@@ -67,14 +71,6 @@ test('getPollbookConfigurationInformation', async () => {
 
 test('GET /file/pollbook-package returns 404 if file does not exist, 200 if it does', async () => {
   await withApp(async ({ peerServer, workspace }) => {
-    const testVoters = parseVotersFromCsvString(
-      electionMultiPartyPrimaryFixtures.pollbookCityVoters.asText(),
-      electionDefinition.election
-    );
-    const testStreets = parseValidStreetsFromCsvString(
-      electionMultiPartyPrimaryFixtures.pollbookCityStreetNames.asText(),
-      electionDefinition.election
-    );
     // Ensure no file exists
     const zipPath = join(workspace.assetDirectoryPath, 'pollbook-package.zip');
     if (existsSync(zipPath)) {

--- a/apps/pollbook/backend/src/peer_app.ts
+++ b/apps/pollbook/backend/src/peer_app.ts
@@ -17,8 +17,9 @@ import {
 import { pollNetworkForPollbookPackage } from './pollbook_package';
 import { POLLBOOK_PACKAGE_ASSET_FILE_NAME } from './globals';
 import { securityHeadersMiddleware } from './security_middleware';
+import { RestartablePoller, setStopBackgroundTasks } from './background_tasks';
 
-function buildApi(context: PeerAppContext) {
+function buildApi(context: PeerAppContext, networkPoller: RestartablePoller) {
   const { workspace } = context;
   const { store } = workspace;
 
@@ -39,7 +40,7 @@ function buildApi(context: PeerAppContext) {
     },
 
     unconfigure() {
-      pollNetworkForPollbookPackage(context);
+      networkPoller.restart();
     },
 
     async resetNetwork() {
@@ -66,7 +67,10 @@ export function buildPeerApp(context: PeerAppContext): Application {
   // Apply security headers middleware first
   app.use(securityHeadersMiddleware);
 
-  const api = buildApi(context);
+  const networkPoller = new RestartablePoller(() =>
+    pollNetworkForPollbookPackage(context)
+  );
+  const api = buildApi(context, networkPoller);
   app.use('/api', grout.buildRouter(api, express));
 
   // Streaming endpoint for sending the pollbook package zip file to a peer
@@ -97,9 +101,14 @@ export function buildPeerApp(context: PeerAppContext): Application {
     });
   });
 
-  setupMachineNetworking(context);
-  fetchEventsFromConnectedPollbooks(context);
-  pollNetworkForPollbookPackage(context);
+  const machineNetworkingPoller = setupMachineNetworking(context);
+  const fetchEventsPoller = fetchEventsFromConnectedPollbooks(context);
+
+  setStopBackgroundTasks(app, () => {
+    networkPoller.stop();
+    machineNetworkingPoller.stop();
+    fetchEventsPoller.stop();
+  });
 
   return app;
 }

--- a/apps/pollbook/backend/src/pollbook_package.ts
+++ b/apps/pollbook/backend/src/pollbook_package.ts
@@ -36,6 +36,7 @@ import {
   POLLBOOK_PACKAGE_FILENAME_PREFIX,
 } from './globals';
 import { constructAuthMachineState } from './auth';
+import { Poller } from './background_tasks';
 
 const usbDebug = rootDebug.extend('usb');
 const debug = rootDebug.extend('pollbook-package');
@@ -291,16 +292,21 @@ export function pollUsbDriveForPollbookPackage({
   auth,
   workspace,
   usbDrive,
-}: LocalAppContext): void {
+}: LocalAppContext): Poller {
   usbDebug('Polling USB drive for pollbook package');
   if (workspace.store.getElection()) {
-    return;
+    return { stop: () => {} };
   }
   let pollingIntervalLock = false; // Flag to prevent overlapping executions
   let hadConfigurationError = false;
+  let intervalId: ReturnType<typeof setInterval> | undefined;
+  let stopped = false;
 
   process.nextTick(() => {
-    const intervalId = setInterval(async () => {
+    if (stopped) {
+      return;
+    }
+    intervalId = setInterval(async () => {
       if (pollingIntervalLock) {
         return; // Skip if a polling iteration is already in progress
       }
@@ -406,21 +412,35 @@ export function pollUsbDriveForPollbookPackage({
       }
     }, CONFIGURATION_POLLING_INTERVAL);
   });
+
+  return {
+    stop: () => {
+      stopped = true;
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+    },
+  };
 }
 
 export function pollNetworkForPollbookPackage({
   auth,
   workspace,
-}: PeerAppContext): void {
+}: PeerAppContext): Poller {
   usbDebug('Polling network for pollbook package');
   if (workspace.store.getElection()) {
-    return;
+    return { stop: () => {} };
   }
   let pollingIntervalLock = false; // Flag to prevent overlapping executions
   let hadConfigurationError = false;
+  let intervalId: ReturnType<typeof setInterval> | undefined;
+  let stopped = false;
 
   process.nextTick(() => {
-    const intervalId = setInterval(async () => {
+    if (stopped) {
+      return;
+    }
+    intervalId = setInterval(async () => {
       if (pollingIntervalLock) {
         return; // Skip if a polling iteration is already in progress
       }
@@ -508,4 +528,13 @@ export function pollNetworkForPollbookPackage({
       }
     }, CONFIGURATION_POLLING_INTERVAL);
   });
+
+  return {
+    stop: () => {
+      stopped = true;
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+    },
+  };
 }

--- a/apps/pollbook/backend/test/app.ts
+++ b/apps/pollbook/backend/test/app.ts
@@ -39,6 +39,7 @@ import {
 } from '../src';
 import { getUserRole } from '../src/auth';
 import { buildPeerApp, PeerApi } from '../src/peer_app';
+import { stopBackgroundTasks } from '../src/background_tasks';
 import { BarcodeScannerClient } from '../src/barcode_scanner/client';
 import {
   EVENT_POLLING_INTERVAL,
@@ -195,6 +196,8 @@ export async function withApp(
     });
     mockUsbDrive.assertComplete();
   } finally {
+    stopBackgroundTasks(app);
+    stopBackgroundTasks(peerApp);
     // wait for paper backup export to finish?
     await new Promise<void>((resolve, reject) => {
       AvahiService.stopAdvertisedService();
@@ -303,6 +306,8 @@ export async function withManyApps(
   } finally {
     for (const context of contexts) {
       const serviceName = `Pollbook-test-${contexts.indexOf(context)}`;
+      stopBackgroundTasks(context.app);
+      stopBackgroundTasks(context.peerApp);
       await new Promise<void>((resolve, reject) => {
         AvahiService.stopAdvertisedService(serviceName);
         context.localServer.close((error) =>


### PR DESCRIPTION
## Overview

Mitigates flaky tests in https://app.circleci.com/pipelines/github/votingworks/vxsuite/27559/workflows/80e0990c-92aa-4ba9-a112-f376c9c8a042/jobs/1286112

This appears to be more of a true timeout than other timed out tests in the past week. We repeat CPU-heavy voter file parsing inside each test, which for large fixtures uses a few seconds of the default 10s timeout. By hoisting the parsing to the module level, we do this parsing once per file and outside the timeouts.

Also cleans up hanging `setInterval`s that were identified and ruled as a possible cause by Claude.

## Demo Video or Screenshot

N/A

## Testing Plan

Existing tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
