### PR TITLE
VxPollBook: hoist fixture parsing in some tests

### DIFF
--- a/apps/pollbook/backend/src/app_config.test.ts
+++ b/apps/pollbook/backend/src/app_config.test.ts
@@ -24,6 +24,20 @@ const singlePrecinctElectionTownVoters =
 const singlePrecinctElectionTownStreetNames =
   electionSimpleSinglePrecinctFixtures.pollbookTownStreetNames.asText();
 
+const multiPrecinctElectionDefinition =
+  electionMultiPartyPrimaryFixtures.readElectionDefinition();
+// Parse the street lists once at module load rather than inside each test body:
+// parsing is CPU-intensive and would otherwise count against the per-test
+// timeout (which flakes under CI load).
+const multiPrecinctCityStreets = parseValidStreetsFromCsvString(
+  electionMultiPartyPrimaryFixtures.pollbookCityStreetNames.asText(),
+  multiPrecinctElectionDefinition.election
+);
+const singlePrecinctTownStreets = parseValidStreetsFromCsvString(
+  electionSimpleSinglePrecinctFixtures.pollbookTownStreetNames.asText(),
+  singlePrecinctElectionDefinition.election
+);
+
 let mockNodeEnv: 'production' | 'test' = 'test';
 
 vi.mock(
@@ -197,16 +211,10 @@ test('app config - polling usb from backend does trigger with system admin auth'
 test('setConfiguredPrecinct sets and getPollbookConfigurationInformation returns the configured precinct', async () => {
   await withApp(async ({ localApiClient, workspace }) => {
     // Initially, no configured precinct on a multi precinct election
-    const multiPrecinctElection =
-      electionMultiPartyPrimaryFixtures.readElectionDefinition();
-    const testStreets = parseValidStreetsFromCsvString(
-      electionMultiPartyPrimaryFixtures.pollbookCityStreetNames.asText(),
-      multiPrecinctElection.election
-    );
     workspace.store.setElectionAndVoters(
-      multiPrecinctElection,
+      multiPrecinctElectionDefinition,
       'mock-package-hash',
-      testStreets,
+      multiPrecinctCityStreets,
       []
     );
     let config = await localApiClient.getPollbookConfigurationInformation();
@@ -220,14 +228,14 @@ test('setConfiguredPrecinct sets and getPollbookConfigurationInformation returns
     );
 
     const ok = await localApiClient.setConfiguredPrecinct({
-      precinctId: multiPrecinctElection.election.precincts[0].id,
+      precinctId: multiPrecinctElectionDefinition.election.precincts[0].id,
     });
     expect(ok.ok()).toEqual(undefined);
 
     // Now it should be returned
     config = await localApiClient.getPollbookConfigurationInformation();
     expect(config.configuredPrecinctId).toEqual(
-      multiPrecinctElection.election.precincts[0].id
+      multiPrecinctElectionDefinition.election.precincts[0].id
     );
   });
 });
@@ -235,14 +243,10 @@ test('setConfiguredPrecinct sets and getPollbookConfigurationInformation returns
 test('setting a single precinct election automatically sets the configured precinct', async () => {
   await withApp(async ({ localApiClient, workspace }) => {
     // Initially, no configured precinct on a multi precinct election
-    const testStreets = parseValidStreetsFromCsvString(
-      electionSimpleSinglePrecinctFixtures.pollbookTownStreetNames.asText(),
-      singlePrecinctElectionDefinition.election
-    );
     workspace.store.setElectionAndVoters(
       singlePrecinctElectionDefinition,
       'mock-package-hash',
-      testStreets,
+      singlePrecinctTownStreets,
       []
     );
     const config = await localApiClient.getPollbookConfigurationInformation();

--- a/apps/pollbook/backend/src/app_multi_node.test.ts
+++ b/apps/pollbook/backend/src/app_multi_node.test.ts
@@ -38,6 +38,14 @@ const testStreets = parseValidStreetsFromCsvString(
   electionSimpleSinglePrecinctFixtures.pollbookTownStreetNames.asText(),
   singlePrecinctElectionDefinition.election
 );
+const multiPrecinctCityVoters = parseVotersFromCsvString(
+  electionMultiPartyPrimaryFixtures.pollbookCityVoters.asText(),
+  multiPrecinctElectionDefinition.election
+);
+const multiPrecinctCityStreets = parseValidStreetsFromCsvString(
+  electionMultiPartyPrimaryFixtures.pollbookCityStreetNames.asText(),
+  multiPrecinctElectionDefinition.election
+);
 
 vi.mock(
   './globals.js',
@@ -1260,14 +1268,8 @@ test('pollbooks with different configured precinct values cannot connect', async
     pollbookContext1.workspace.store.setElectionAndVoters(
       multiPrecinctElectionDefinition,
       'mock-package-hash',
-      parseValidStreetsFromCsvString(
-        electionMultiPartyPrimaryFixtures.pollbookCityStreetNames.asText(),
-        multiPrecinctElectionDefinition.election
-      ),
-      parseVotersFromCsvString(
-        electionMultiPartyPrimaryFixtures.pollbookCityVoters.asText(),
-        multiPrecinctElectionDefinition.election
-      )
+      multiPrecinctCityStreets,
+      multiPrecinctCityVoters
     );
     pollbookContext2.workspace.store.setElectionAndVoters(
       multiPrecinctElectionDefinition,

--- a/apps/pollbook/backend/src/peer_app.test.ts
+++ b/apps/pollbook/backend/src/peer_app.test.ts
@@ -15,6 +15,15 @@ let mockNodeEnv: 'production' | 'test' = 'test';
 const electionDefinition =
   electionMultiPartyPrimaryFixtures.readElectionDefinition();
 
+const testVoters = parseVotersFromCsvString(
+  electionMultiPartyPrimaryFixtures.pollbookCityVoters.asText(),
+  electionDefinition.election
+);
+const testStreets = parseValidStreetsFromCsvString(
+  electionMultiPartyPrimaryFixtures.pollbookCityStreetNames.asText(),
+  electionDefinition.election
+);
+
 vi.mock(
   './globals.js',
   async (importActual): Promise<typeof import('./globals')> => ({
@@ -38,14 +47,6 @@ test('getPollbookConfigurationInformation', async () => {
       machineId: '0102',
     });
 
-    const testVoters = parseVotersFromCsvString(
-      electionMultiPartyPrimaryFixtures.pollbookCityVoters.asText(),
-      electionDefinition.election
-    );
-    const testStreets = parseValidStreetsFromCsvString(
-      electionMultiPartyPrimaryFixtures.pollbookCityStreetNames.asText(),
-      electionDefinition.election
-    );
     workspace.store.setElectionAndVoters(
       electionDefinition,
       'mock-package-hash',
@@ -67,14 +68,6 @@ test('getPollbookConfigurationInformation', async () => {
 
 test('GET /file/pollbook-package returns 404 if file does not exist, 200 if it does', async () => {
   await withApp(async ({ peerServer, workspace }) => {
-    const testVoters = parseVotersFromCsvString(
-      electionMultiPartyPrimaryFixtures.pollbookCityVoters.asText(),
-      electionDefinition.election
-    );
-    const testStreets = parseValidStreetsFromCsvString(
-      electionMultiPartyPrimaryFixtures.pollbookCityStreetNames.asText(),
-      electionDefinition.election
-    );
     // Ensure no file exists
     const zipPath = join(workspace.assetDirectoryPath, 'pollbook-package.zip');
     if (existsSync(zipPath)) {


### PR DESCRIPTION
## Overview

Mitigates flaky tests in https://app.circleci.com/pipelines/github/votingworks/vxsuite/27559/workflows/80e0990c-92aa-4ba9-a112-f376c9c8a042/jobs/1286112

This appears to be more of a true timeout than other timed out tests in the past week. We repeat CPU-heavy voter file parsing inside each test, which for large fixtures uses a few seconds of the default 10s timeout. By hoisting the parsing to the module level, we do this parsing once per file and outside the timeouts.

## Demo Video or Screenshot

N/A

## Testing Plan

Existing tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
