### PR TITLE
[ca-demo] VxDesign: bulk translation import/export

### DIFF
--- a/apps/design/backend/migrations/1784573693207_add-bulk-translation-uploads.js
+++ b/apps/design/backend/migrations/1784573693207_add-bulk-translation-uploads.js
@@ -1,0 +1,37 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  pgm.createTable(
+    'bulk_translation_uploads',
+    {
+      election_id: {
+        type: 'text',
+        notNull: true,
+        onDelete: 'CASCADE',
+        references: 'elections',
+      },
+      language_code: {
+        type: 'text',
+        notNull: true,
+      },
+      uploaded_at: {
+        type: 'timestamptz',
+        notNull: true,
+        default: pgm.func('now()'),
+      },
+    },
+    {
+      constraints: {
+        primaryKey: ['election_id', 'language_code'],
+      },
+    }
+  );
+};

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -132,6 +132,7 @@ import {
 } from './features';
 import { rootDebug } from './debug';
 import * as ttsStrings from './tts_strings';
+import * as bulkTranslations from './bulk_translations';
 import { convertMsElection } from './convert_ms_election';
 import { convertMsResults, ConvertMsResultsError } from './convert_ms_results';
 import { defaultSystemSettings } from './system_settings';
@@ -1215,6 +1216,8 @@ export function buildApi(ctx: AppContext) {
     },
 
     ...ttsStrings.apiMethods(ctx),
+
+    ...bulkTranslations.apiMethods(ctx),
   } as const;
 
   return grout.createApi(methods, middlewares);

--- a/apps/design/backend/src/bulk_translations.ts
+++ b/apps/design/backend/src/bulk_translations.ts
@@ -1,11 +1,7 @@
 /* istanbul ignore file - DEMO */
 
 import { Result, assert, err, ok, unique } from '@votingworks/basics';
-import {
-  ElectionStringKey,
-  LanguageCode,
-  TranslationEditKey,
-} from '@votingworks/types';
+import { ElectionStringKey, LanguageCode } from '@votingworks/types';
 import {
   Translator,
   extractElectionStrings,
@@ -100,6 +96,9 @@ export function apiMethods(ctx: BulkTranslationsApiContext) {
       language: LanguageCode;
       csvContents: string;
     }): Promise<BulkTranslationImportResult> {
+      const { election } = await ctx.workspace.store.getElection(
+        input.electionId
+      );
       const jurisdiction = await ctx.workspace.store.getElectionJurisdiction(
         input.electionId
       );
@@ -137,24 +136,50 @@ export function apiMethods(ctx: BulkTranslationsApiContext) {
         );
       }
 
+      // The exported string set for this election, keyed by the CSV ID column.
+      // Uploaded rows are validated against this so a wrong or stale file
+      // (unknown ID, or English source text that no longer matches) is
+      // rejected rather than silently creating edits for arbitrary strings.
+      const expectedEnglishById = new Map(
+        extractElectionStrings(election, {
+          include: TRANSLATABLE_STRING_KEYS,
+        }).map((s) => [stringId(s.stringKey), s.stringInEnglish])
+      );
+
       // Translations are keyed by English source text, so two rows with the
       // same English text must resolve to the same translation. An empty New
       // Translation resets that string to its auto-generated translation.
       const translationsByEnglish = new Map<string, string>();
       const conflicts: string[] = [];
+      const unexpectedRows: string[] = [];
       for (const record of records) {
-        const englishText = stripImagesFromRichText(
-          record[COLUMN_ENGLISH] ?? ''
-        );
+        const id = record[COLUMN_ID] ?? '';
+        const english = record[COLUMN_ENGLISH] ?? '';
+        if (expectedEnglishById.get(id) !== english) {
+          unexpectedRows.push(id || '(missing ID)');
+          continue;
+        }
+
+        const englishText = stripImagesFromRichText(english);
         if (!englishText) continue;
 
         const newTranslation = (record[COLUMN_NEW] ?? '').trim();
         const existing = translationsByEnglish.get(englishText);
         if (existing !== undefined && existing !== newTranslation) {
-          conflicts.push(record[COLUMN_ENGLISH] ?? '');
+          conflicts.push(english);
           continue;
         }
         translationsByEnglish.set(englishText, newTranslation);
+      }
+
+      if (unexpectedRows.length > 0) {
+        const rowList = unique(unexpectedRows)
+          .slice(0, 10)
+          .map((id) => `- ${id}`)
+          .join('\n');
+        return err(
+          `This file does not match the current election. The following rows have an unrecognized ID or an English source that no longer matches the election. Re-download the CSV and try again.\n${rowList}`
+        );
       }
 
       if (conflicts.length > 0) {
@@ -166,25 +191,15 @@ export function apiMethods(ctx: BulkTranslationsApiContext) {
         );
       }
 
-      for (const [englishText, text] of translationsByEnglish) {
-        const editKey: TranslationEditKey = {
-          jurisdictionId: jurisdiction.id,
-          languageCode: input.language,
+      await ctx.workspace.store.bulkTranslationApply({
+        electionId: input.electionId,
+        jurisdictionId: jurisdiction.id,
+        languageCode: input.language,
+        edits: [...translationsByEnglish].map(([englishText, text]) => ({
           englishText,
-        };
-        if (text) {
-          await ctx.workspace.store.translationEditsSet(editKey, text);
-        } else {
-          // Empty translation: reset to the auto-generated translation by
-          // removing any existing manual edit.
-          await ctx.workspace.store.translationEditsDelete(editKey);
-        }
-      }
-
-      await ctx.workspace.store.bulkTranslationUploadRecord(
-        input.electionId,
-        input.language
-      );
+          text: text || null,
+        })),
+      });
 
       return ok();
     },

--- a/apps/design/backend/src/bulk_translations.ts
+++ b/apps/design/backend/src/bulk_translations.ts
@@ -1,0 +1,230 @@
+/* istanbul ignore file - DEMO */
+
+import { Result, assert, err, ok, unique } from '@votingworks/basics';
+import {
+  ElectionStringKey,
+  LanguageCode,
+  TranslationEditKey,
+} from '@votingworks/types';
+import {
+  Translator,
+  extractElectionStrings,
+  stripImagesFromRichText,
+} from '@votingworks/backend';
+import { parse } from 'csv-parse/sync';
+import { stringify } from 'csv-stringify/sync';
+import { Workspace } from './workspace';
+
+export interface BulkTranslationsApiContext {
+  translator: Translator;
+  workspace: Workspace;
+}
+
+// The election string categories a translation contractor can meaningfully
+// edit. Excludes non-translatable keys (ballot style IDs, candidate names) and
+// auto-computed keys (ballot language names, election date).
+const TRANSLATABLE_STRING_KEYS: ElectionStringKey[] = [
+  ElectionStringKey.CONTEST_DESCRIPTION,
+  ElectionStringKey.CONTEST_OPTION_LABEL,
+  ElectionStringKey.CONTEST_TERM,
+  ElectionStringKey.CONTEST_TITLE,
+  ElectionStringKey.DISTRICT_NAME,
+  ElectionStringKey.ELECTION_TITLE,
+  ElectionStringKey.JURISDICTION_NAME,
+  ElectionStringKey.PARTY_FULL_NAME,
+  ElectionStringKey.PARTY_NAME,
+  ElectionStringKey.POLLING_PLACE_NAME,
+  ElectionStringKey.PRECINCT_NAME,
+  ElectionStringKey.PRECINCT_SPLIT_NAME,
+  ElectionStringKey.STATE_NAME,
+];
+
+const COLUMN_ID = 'ID';
+const COLUMN_ENGLISH = 'English';
+const COLUMN_CURRENT = 'Current Translation';
+const COLUMN_NEW = 'New Translation';
+const CSV_COLUMNS = [
+  COLUMN_ID,
+  COLUMN_ENGLISH,
+  COLUMN_CURRENT,
+  COLUMN_NEW,
+] as const;
+
+function stringId(
+  stringKey: ElectionStringKey | [ElectionStringKey, string]
+): string {
+  return typeof stringKey === 'string'
+    ? stringKey
+    : `${stringKey[0]}:${stringKey[1]}`;
+}
+
+export type BulkTranslationImportResult = Result<void, string>;
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function apiMethods(ctx: BulkTranslationsApiContext) {
+  return {
+    async bulkTranslationExport(input: {
+      electionId: string;
+      language: LanguageCode;
+    }): Promise<string> {
+      assert(input.language !== LanguageCode.ENGLISH);
+      const { election } = await ctx.workspace.store.getElection(
+        input.electionId
+      );
+      const jurisdiction = await ctx.workspace.store.getElectionJurisdiction(
+        input.electionId
+      );
+
+      const strings = extractElectionStrings(election, {
+        include: TRANSLATABLE_STRING_KEYS,
+      });
+
+      const currentTranslations = await ctx.translator.translateText(
+        strings.map((s) => s.stringInEnglish),
+        input.language,
+        jurisdiction.id
+      );
+
+      const rows = strings.map((s, i) => ({
+        [COLUMN_ID]: stringId(s.stringKey),
+        [COLUMN_ENGLISH]: s.stringInEnglish,
+        [COLUMN_CURRENT]: currentTranslations[i] ?? '',
+        [COLUMN_NEW]: '',
+      }));
+
+      return stringify(rows, { header: true, columns: [...CSV_COLUMNS] });
+    },
+
+    async bulkTranslationImport(input: {
+      electionId: string;
+      language: LanguageCode;
+      csvContents: string;
+    }): Promise<BulkTranslationImportResult> {
+      const jurisdiction = await ctx.workspace.store.getElectionJurisdiction(
+        input.electionId
+      );
+
+      let records: Array<Record<string, string>>;
+      try {
+        // Note: do NOT enable `trim` here. Edits are keyed by the English
+        // source text, and the runtime translation lookup keys on the
+        // untrimmed string, so the English column must stay byte-identical to
+        // what was exported. The New Translation cell is trimmed explicitly
+        // below.
+        records = parse(input.csvContents, {
+          columns: true,
+          skip_empty_lines: true,
+        });
+      } catch (error) {
+        return err(
+          `Could not parse CSV file: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+
+      if (records.length === 0) {
+        return ok();
+      }
+
+      const header = Object.keys(records[0]);
+      const missingColumns = CSV_COLUMNS.filter((c) => !header.includes(c));
+      if (missingColumns.length > 0) {
+        return err(
+          `Missing expected columns: ${missingColumns.join(
+            ', '
+          )}. Make sure you are uploading a file downloaded from this page.`
+        );
+      }
+
+      // Translations are keyed by English source text, so two rows with the
+      // same English text must resolve to the same translation. An empty New
+      // Translation resets that string to its auto-generated translation.
+      const translationsByEnglish = new Map<string, string>();
+      const conflicts: string[] = [];
+      for (const record of records) {
+        const englishText = stripImagesFromRichText(
+          record[COLUMN_ENGLISH] ?? ''
+        );
+        if (!englishText) continue;
+
+        const newTranslation = (record[COLUMN_NEW] ?? '').trim();
+        const existing = translationsByEnglish.get(englishText);
+        if (existing !== undefined && existing !== newTranslation) {
+          conflicts.push(record[COLUMN_ENGLISH] ?? '');
+          continue;
+        }
+        translationsByEnglish.set(englishText, newTranslation);
+      }
+
+      if (conflicts.length > 0) {
+        const conflictList = unique(conflicts)
+          .map((english) => `- "${english}"`)
+          .join('\n');
+        return err(
+          `Conflicting translations found. The same English source text was given different translations. Each occurrence of an identical English string must have the same translation.\n${conflictList}`
+        );
+      }
+
+      for (const [englishText, text] of translationsByEnglish) {
+        const editKey: TranslationEditKey = {
+          jurisdictionId: jurisdiction.id,
+          languageCode: input.language,
+          englishText,
+        };
+        if (text) {
+          await ctx.workspace.store.translationEditsSet(editKey, text);
+        } else {
+          // Empty translation: reset to the auto-generated translation by
+          // removing any existing manual edit.
+          await ctx.workspace.store.translationEditsDelete(editKey);
+        }
+      }
+
+      await ctx.workspace.store.bulkTranslationUploadRecord(
+        input.electionId,
+        input.language
+      );
+
+      return ok();
+    },
+
+    async bulkTranslationClear(input: {
+      electionId: string;
+      language: LanguageCode;
+    }): Promise<void> {
+      const { election } = await ctx.workspace.store.getElection(
+        input.electionId
+      );
+      const jurisdiction = await ctx.workspace.store.getElectionJurisdiction(
+        input.electionId
+      );
+
+      const strings = extractElectionStrings(election, {
+        include: TRANSLATABLE_STRING_KEYS,
+      });
+
+      const englishTexts = new Set(
+        strings.map((s) => stripImagesFromRichText(s.stringInEnglish))
+      );
+      for (const englishText of englishTexts) {
+        await ctx.workspace.store.translationEditsDelete({
+          jurisdictionId: jurisdiction.id,
+          languageCode: input.language,
+          englishText,
+        });
+      }
+
+      await ctx.workspace.store.bulkTranslationUploadClear(
+        input.electionId,
+        input.language
+      );
+    },
+
+    bulkTranslationUploadsGet(input: {
+      electionId: string;
+    }): Promise<Array<{ languageCode: string; uploadedAt: string }>> {
+      return ctx.workspace.store.bulkTranslationUploadsGet(input.electionId);
+    },
+  };
+}

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -3175,6 +3175,78 @@ export class Store {
     });
   }
 
+  /* istanbul ignore next - DEMO */
+  async bulkTranslationApply(input: {
+    electionId: string;
+    jurisdictionId: string;
+    languageCode: string;
+    // A `null` text resets the string to its auto-generated translation by
+    // removing any existing manual edit.
+    edits: Array<{ englishText: string; text: string | null }>;
+  }): Promise<void> {
+    const { electionId, jurisdictionId, languageCode } = input;
+    const sets = input.edits.filter((e) => e.text !== null);
+    const resetEnglishTexts = input.edits
+      .filter((e) => e.text === null)
+      .map((e) => e.englishText);
+
+    await this.db.withClient((client) =>
+      client.withTransaction(async () => {
+        for (const { englishText, text } of sets) {
+          await client.query(
+            `
+              insert into translation_edits (
+                jurisdiction_id,
+                language_code,
+                english_text,
+                text
+              )
+              values ($1, $2, $3, $4)
+              on conflict (jurisdiction_id, language_code, english_text) do update set
+                text = EXCLUDED.text
+            `,
+            jurisdictionId,
+            languageCode,
+            englishText,
+            text
+          );
+        }
+
+        if (resetEnglishTexts.length > 0) {
+          await client.query(
+            `
+              delete from translation_edits
+              where
+                jurisdiction_id = $1 and
+                language_code = $2 and
+                english_text = ANY($3)
+            `,
+            jurisdictionId,
+            languageCode,
+            resetEnglishTexts
+          );
+        }
+
+        await client.query(
+          `
+            insert into bulk_translation_uploads (
+              election_id,
+              language_code,
+              uploaded_at
+            )
+            values ($1, $2, now())
+            on conflict (election_id, language_code) do update set
+              uploaded_at = EXCLUDED.uploaded_at
+          `,
+          electionId,
+          languageCode
+        );
+
+        return true;
+      })
+    );
+  }
+
   async electionHasLiveReportData(
     electionId: string,
     ballotHash: string

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -3092,6 +3092,89 @@ export class Store {
     });
   }
 
+  /* istanbul ignore next - DEMO */
+  async translationEditsDelete(key: TranslationEditKey): Promise<void> {
+    return this.db.withClient(async (client) => {
+      await client.query(
+        `
+          delete from translation_edits
+          where
+            jurisdiction_id = $1 and
+            language_code = $2 and
+            english_text = $3
+        `,
+        key.jurisdictionId,
+        key.languageCode,
+        key.englishText
+      );
+    });
+  }
+
+  /* istanbul ignore next - DEMO */
+  async bulkTranslationUploadRecord(
+    electionId: string,
+    languageCode: string
+  ): Promise<void> {
+    return this.db.withClient(async (client) => {
+      await client.query(
+        `
+          insert into bulk_translation_uploads (
+            election_id,
+            language_code,
+            uploaded_at
+          )
+          values ($1, $2, now())
+          on conflict (election_id, language_code) do update set
+            uploaded_at = EXCLUDED.uploaded_at
+        `,
+        electionId,
+        languageCode
+      );
+    });
+  }
+
+  /* istanbul ignore next - DEMO */
+  async bulkTranslationUploadClear(
+    electionId: string,
+    languageCode: string
+  ): Promise<void> {
+    return this.db.withClient(async (client) => {
+      await client.query(
+        `
+          delete from bulk_translation_uploads
+          where
+            election_id = $1 and
+            language_code = $2
+        `,
+        electionId,
+        languageCode
+      );
+    });
+  }
+
+  /* istanbul ignore next - DEMO */
+  async bulkTranslationUploadsGet(
+    electionId: string
+  ): Promise<Array<{ languageCode: string; uploadedAt: string }>> {
+    return this.db.withClient(async (client) => {
+      const res = await client.query(
+        `
+          select
+            language_code,
+            uploaded_at
+          from bulk_translation_uploads
+          where election_id = $1
+        `,
+        electionId
+      );
+
+      return res.rows.map((row) => ({
+        languageCode: row.language_code as string,
+        uploadedAt: (row.uploaded_at as Date).toISOString(),
+      }));
+    });
+  }
+
   async electionHasLiveReportData(
     electionId: string,
     ballotHash: string

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -411,6 +411,59 @@ export const ttsStringDefaults = {
   },
 } as const;
 
+/* istanbul ignore next - DEMO */
+export const bulkTranslationExport = {
+  useMutation() {
+    const apiClient = useApiClient();
+    return useMutation(apiClient.bulkTranslationExport);
+  },
+} as const;
+
+/* istanbul ignore next - DEMO */
+export const bulkTranslationUploadsGet = {
+  queryKey(electionId: string): QueryKey {
+    return ['bulkTranslationUploads', electionId];
+  },
+  useQuery(electionId: string) {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(electionId), () =>
+      apiClient.bulkTranslationUploadsGet({ electionId })
+    );
+  },
+} as const;
+
+/* istanbul ignore next - DEMO */
+export const bulkTranslationClear = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.bulkTranslationClear, {
+      async onSuccess(_data, { electionId }) {
+        await queryClient.invalidateQueries(['translation']);
+        await queryClient.invalidateQueries(
+          bulkTranslationUploadsGet.queryKey(electionId)
+        );
+      },
+    });
+  },
+} as const;
+
+/* istanbul ignore next - DEMO */
+export const bulkTranslationImport = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.bulkTranslationImport, {
+      async onSuccess(_data, { electionId }) {
+        await queryClient.invalidateQueries(['translation']);
+        await queryClient.invalidateQueries(
+          bulkTranslationUploadsGet.queryKey(electionId)
+        );
+      },
+    });
+  },
+} as const;
+
 export const ttsSynthesizeFromSsml = {
   queryKey(input: { languageCode: string; ssml: string }): QueryKey {
     return ['synthesizedSsml', input.languageCode, input.ssml];

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -37,6 +37,7 @@ import { BallotScreen, paperSizeLabels } from './ballot_screen';
 import { useTitle } from './hooks/use_title';
 import { BallotsStatus } from './ballots_status';
 import { LanguageProofingScreen } from './ballot_audio/proofing_screen';
+import { BulkTranslationsTab } from './bulk_translations_tab';
 import { LanguageSelect } from './ballot_audio/language_select';
 
 function BallotDesignForm({
@@ -404,6 +405,7 @@ export function BallotsScreen(): JSX.Element | null {
         ballotsRoutes.ballotStyles,
         ballotsRoutes.ballotLayout,
         ballotsRoutes.language(),
+        ballotsRoutes.bulkTranslations,
       ]}
     />
   );
@@ -450,6 +452,9 @@ export function BallotsScreen(): JSX.Element | null {
             </Route>
             <Route path={ballotsParamRoutes.ballotLayout.path}>
               {withScrollContent(<BallotLayoutTab />)}
+            </Route>
+            <Route path={ballotsParamRoutes.bulkTranslations.path}>
+              {withScrollContent(<BulkTranslationsTab />)}
             </Route>
             <Route
               path={

--- a/apps/design/frontend/src/bulk_translations_tab.tsx
+++ b/apps/design/frontend/src/bulk_translations_tab.tsx
@@ -1,0 +1,199 @@
+/* istanbul ignore file - DEMO */
+
+import { useParams } from 'react-router-dom';
+import styled from 'styled-components';
+import {
+  Button,
+  Callout,
+  Caption,
+  FileInputButton,
+  Font,
+  Icons,
+  LoadingButton,
+} from '@votingworks/ui';
+import fileDownload from 'js-file-download';
+import { LanguageCode } from '@votingworks/types';
+import { ORDERED_LANGUAGES, format } from '@votingworks/utils';
+import { ElectionIdParams } from './routes';
+import {
+  bulkTranslationClear,
+  bulkTranslationExport,
+  bulkTranslationImport,
+  bulkTranslationUploadsGet,
+  getElectionInfo,
+} from './api';
+import { Column, Row } from './layout';
+
+const List = styled.div`
+  border: ${(p) => p.theme.sizes.bordersRem.thin}rem solid
+    ${(p) => p.theme.colors.outline};
+  border-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
+  width: fit-content;
+
+  > *:not(:last-child) {
+    border-bottom: ${(p) => p.theme.sizes.bordersRem.thin}rem solid
+      ${(p) => p.theme.colors.outline};
+  }
+`;
+
+const ListItem = styled.div`
+  padding: 0.75rem 1rem;
+  max-width: 40rem;
+`;
+
+const ListItemHeader = styled(Row)`
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+`;
+
+function formatUploadedAt(uploadedAt: string): string {
+  return new Date(uploadedAt).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+function LanguageRow({
+  electionId,
+  language,
+  lastUploadedAt,
+}: {
+  electionId: string;
+  language: LanguageCode;
+  lastUploadedAt?: string;
+}): JSX.Element {
+  const exportMutation = bulkTranslationExport.useMutation();
+  const importMutation = bulkTranslationImport.useMutation();
+  const clearMutation = bulkTranslationClear.useMutation();
+
+  const displayName = format.languageDisplayName2({
+    languageCode: language,
+    displayLanguageCode: LanguageCode.ENGLISH,
+  });
+
+  const importResult = importMutation.isSuccess
+    ? importMutation.data
+    : undefined;
+
+  return (
+    <ListItem>
+      <ListItemHeader>
+        <div>
+          <Font weight="bold">{displayName}</Font>
+          <div>
+            <Caption>
+              {lastUploadedAt ? (
+                <span>
+                  <Icons.Done color="primary" /> Uploaded{' '}
+                  {formatUploadedAt(lastUploadedAt)}
+                </span>
+              ) : (
+                <span>
+                  <Icons.Circle color="warning" /> No translations uploaded
+                </span>
+              )}
+            </Caption>
+          </div>
+        </div>
+        <Row style={{ gap: '0.5rem' }}>
+          {exportMutation.isLoading ? (
+            <LoadingButton>Download</LoadingButton>
+          ) : (
+            <Button
+              icon="Export"
+              onPress={() =>
+                exportMutation.mutate(
+                  { electionId, language },
+                  {
+                    onSuccess: (csv) =>
+                      fileDownload(csv, `translations-${language}.csv`),
+                  }
+                )
+              }
+            >
+              Download
+            </Button>
+          )}
+          {importMutation.isLoading ? (
+            <LoadingButton>Upload</LoadingButton>
+          ) : (
+            <FileInputButton
+              accept=".csv"
+              buttonProps={{ variant: 'neutral' }}
+              onChange={async (event) => {
+                const file = event.currentTarget.files?.[0];
+                if (!file) return;
+                const csvContents = await file.text();
+                importMutation.mutate({ electionId, language, csvContents });
+              }}
+            >
+              <Icons.Import />
+              Upload
+            </FileInputButton>
+          )}
+          <Button
+            icon="Trash"
+            variant="danger"
+            fill="transparent"
+            onPress={() => clearMutation.mutate({ electionId, language })}
+            disabled={lastUploadedAt === undefined || clearMutation.isLoading}
+            style={{ padding: '0.6rem 0.75rem' }}
+          />
+        </Row>
+      </ListItemHeader>
+      {importResult && importResult.isErr() && (
+        <Callout color="danger" icon="Danger" style={{ marginTop: '0.75rem' }}>
+          <Column style={{ gap: '0.25rem' }}>
+            {importResult
+              .err()
+              .split('\n')
+              .map((line, index) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <Caption key={index}>{line}</Caption>
+              ))}
+          </Column>
+        </Callout>
+      )}
+    </ListItem>
+  );
+}
+
+export function BulkTranslationsTab(): JSX.Element | null {
+  const { electionId } = useParams<ElectionIdParams>();
+  const electionInfo = getElectionInfo.useQuery(electionId).data;
+  const uploads = bulkTranslationUploadsGet.useQuery(electionId).data;
+  if (!electionInfo || !uploads) return null;
+
+  const languages = ORDERED_LANGUAGES.filter(
+    (language) =>
+      language !== LanguageCode.ENGLISH &&
+      electionInfo.languageCodes.includes(language)
+  );
+
+  const uploadedAtByLanguage = new Map(
+    uploads.map((upload) => [upload.languageCode, upload.uploadedAt])
+  );
+
+  return (
+    <div style={{ paddingTop: '1rem' }}>
+      {languages.length === 0 ? (
+        <Callout icon="Info" style={{ maxWidth: '45rem' }}>
+          Select languages on the Election Info screen to enable bulk
+          translation.
+        </Callout>
+      ) : (
+        <List>
+          {languages.map((language) => (
+            <LanguageRow
+              key={language}
+              electionId={electionId}
+              language={language}
+              lastUploadedAt={uploadedAtByLanguage.get(language)}
+            />
+          ))}
+        </List>
+      )}
+    </div>
+  );
+}

--- a/apps/design/frontend/src/routes.ts
+++ b/apps/design/frontend/src/routes.ts
@@ -148,6 +148,10 @@ export const routes = {
           title: 'Ballot Layout',
           path: `${root}/ballots/layout`,
         },
+        bulkTranslations: {
+          title: 'Bulk Translations',
+          path: `${root}/ballots/bulk-translations`,
+        },
         language: (lang?: ':language' | LanguageCode) => {
           const langComponent = lang ? `/${lang}` : '';
           return {


### PR DESCRIPTION

## Overview

Closes https://github.com/votingworks/vxsuite/issues/8917

Add a Bulk Translations tab to the Proof Ballots screen for importing translations in bulk from an external contractor.

- Download a per-language CSV of all translatable election strings (ID, English, current translation, blank new-translation column)
- Upload a filled-in CSV to apply translations: non-empty cells set a manual translation edit, empty cells reset the string to its auto-generated translation. Conflicting translations for the same English source text are rejected.
- Track and display when translations were last uploaded per language (new bulk_translation_uploads table)
- Clear a language's uploaded translations, reverting all strings to their auto-generated translations


<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot

<img width="2624" height="1696" alt="image" src="https://github.com/user-attachments/assets/4b2165e1-a5f8-40af-a114-dc1ad5b37291" />




## Testing Plan
Manual test
## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
