### PR TITLE
[ca-demo] VxHub: Omit phonetic editor option for unsupported languages

### DIFF
--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -377,6 +377,9 @@ export const translationGet = {
       key.subKey,
     ];
   },
+  queryKeyAll(electionId: string): QueryKey {
+    return ['translation', electionId];
+  },
 
   useQuery(key: TranslationKey) {
     const apiClient = useApiClient();
@@ -512,6 +515,7 @@ async function invalidateElectionQueries(
     queryClient.invalidateQueries(listParties.queryKey(electionId)),
     queryClient.invalidateQueries(listContests.queryKey(electionId)),
     queryClient.invalidateQueries(ttsStringDefaults.queryKey(electionId)),
+    queryClient.invalidateQueries(translationGet.queryKeyAll(electionId)),
   ]);
 }
 

--- a/apps/design/frontend/src/ballot_audio/audio_editor.tsx
+++ b/apps/design/frontend/src/ballot_audio/audio_editor.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { throwIllegalValue } from '@votingworks/basics';
 import { TtsStringDefault } from '@votingworks/design-backend';
-import { LanguageCode, TtsExportSource } from '@votingworks/types';
+import { LanguageCode, phonemes, TtsExportSource } from '@votingworks/types';
 import { H3, RadioGroup, RadioGroupOption } from '@votingworks/ui';
 
 import * as api from '../api';
@@ -23,15 +23,6 @@ const ModeTitle = styled(H3)`
   margin: 0;
 `;
 
-const RECORD_ONLY_LANGUAGES: LanguageCode[] = [LanguageCode.KHMER];
-
-const RECORD_ONLY_OPTION: Array<RadioGroupOption<TtsExportSource>> = [
-  {
-    value: 'recorded',
-    label: <ModeTitle>Recorded</ModeTitle>,
-  },
-];
-
 const MODE_OPTIONS: Array<RadioGroupOption<TtsExportSource>> = [
   {
     value: 'text',
@@ -41,7 +32,10 @@ const MODE_OPTIONS: Array<RadioGroupOption<TtsExportSource>> = [
     value: 'phonetic',
     label: <ModeTitle>Phonetic</ModeTitle>,
   },
-  ...RECORD_ONLY_OPTION,
+  {
+    value: 'recorded',
+    label: <ModeTitle>Recorded</ModeTitle>,
+  },
 ];
 
 export interface AudioEditorProps {
@@ -71,10 +65,18 @@ export function AudioEditor(props: AudioEditorProps): React.ReactNode {
 
   if (!savedEdit.isSuccess || !ballotsFinalizedAt.isSuccess) return null;
 
-  const recordOnly = RECORD_ONLY_LANGUAGES.includes(languageCode);
-  const defaultMode: TtsExportSource = recordOnly
-    ? 'recorded'
-    : savedEdit.data?.exportSource || 'text';
+  const config = phonemes[languageCode];
+  const availableModes = MODE_OPTIONS.filter((m) => {
+    if (m.value === 'text' && !config.supportsTextEdits) return false;
+    if (m.value === 'phonetic' && !config.supportsPhoneticEdits) return false;
+    return true;
+  });
+
+  let defaultMode: TtsExportSource = savedEdit.data?.exportSource || 'text';
+  if (!availableModes.find((m) => m.value === defaultMode)) {
+    defaultMode = availableModes[0].value;
+  }
+
   const currentMode = mode || defaultMode;
   const editable = !ballotsFinalizedAt.data;
 
@@ -85,9 +87,9 @@ export function AudioEditor(props: AudioEditorProps): React.ReactNode {
           disabled={!editable}
           label="Audio Source"
           hideLabel
-          numColumns={recordOnly ? 1 : 3}
+          numColumns={availableModes.length}
           onChange={setMode}
-          options={recordOnly ? RECORD_ONLY_OPTION : MODE_OPTIONS}
+          options={availableModes}
           value={currentMode}
         />
       </ModeContainer>

--- a/apps/design/frontend/src/ballot_audio/proofing_screen.tsx
+++ b/apps/design/frontend/src/ballot_audio/proofing_screen.tsx
@@ -285,7 +285,6 @@ const Editor = styled.div`
 
 export function LanguageProofingScreen(): React.ReactNode {
   const [searchString, setSearchString] = React.useState<string>('');
-  const searchDebounceTimer = React.useRef<number>();
 
   const {
     electionId,
@@ -304,38 +303,23 @@ export function LanguageProofingScreen(): React.ReactNode {
     }
   }, [stringDefaults, stringKey, subkey]);
 
-  const onSearch = React.useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      if (!stringDefaults) return;
-
-      if (searchDebounceTimer.current) {
-        window.clearTimeout(searchDebounceTimer.current);
-        searchDebounceTimer.current = undefined;
-      }
-
-      const newSearchString = (event.target.value || '').trim();
-      if (!newSearchString) return setSearchString('');
-
-      searchDebounceTimer.current = window.setTimeout(() => {
-        setSearchString(newSearchString);
-      }, 50);
-    },
-    [stringDefaults]
-  );
-
   const searchResults: TtsStringDefault[] = React.useMemo(() => {
     if (!stringDefaults) return [];
-    if (!searchString) return stringDefaults;
+
+    // [TODO] We don't yet have a concrete plan for repeated strings - de-duping
+    // them in the UI for now.
+    const seenStrings = new Set<string>();
 
     const results: TtsStringDefault[] = [];
-    let resultCount = 0;
     for (let i = 0; i < stringDefaults.length; i += 1) {
-      results[resultCount] = stringDefaults[i];
-      resultCount += isMatchFuzzy(
-        stringDefaults[i].text,
-        searchString
-      ) as unknown as number;
-      delete results[resultCount];
+      const seen = seenStrings.has(stringDefaults[i].text);
+      seenStrings.add(stringDefaults[i].text);
+
+      if (seen || !isMatchFuzzy(stringDefaults[i].text, searchString)) {
+        continue;
+      }
+
+      results.push(stringDefaults[i]);
     }
 
     return results;
@@ -354,10 +338,13 @@ export function LanguageProofingScreen(): React.ReactNode {
             <input
               // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus
-              onChange={onSearch}
+              onChange={(e) => setSearchString(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') setSearchString('');
+              }}
               placeholder="Search ballot contents"
               type="text"
-              defaultValue={searchString}
+              value={searchString}
             />
           </SearchBox>
           <StringSnippets>

--- a/libs/types/src/tts_phonemes.ts
+++ b/libs/types/src/tts_phonemes.ts
@@ -90,7 +90,7 @@ const SPANISH_BY_IPA = {
   'p':  { ipa: 'p',  vx: 'p',   sampleWord: 'pelo',        sampleIpa: 'ˈpelo',        sampleVx: 'ˈpelo' },
   'ɹ':  { ipa: 'ɹ',  vx: 'R',   sampleWord: 'car',         sampleIpa: 'ˈkaɹ',         sampleVx: 'ˈkaR' },
   'ɾ':  { ipa: 'ɾ',  vx: 'r',   sampleWord: 'pero',        sampleIpa: 'ˈpeɾo',        sampleVx: 'ˈperro' },
-  'r':  { ipa: 'r',  vx: 'rr',  sampleWord: 'perro',       sampleIpa: 'ˈpero',        sampleVx: 'ˈperro' },
+  'r':  { ipa: 'r',  vx: 'r',   sampleWord: 'perro',       sampleIpa: 'ˈpero',        sampleVx: 'ˈpero' },
   's':  { ipa: 's',  vx: 's',   sampleWord: 'cielo',       sampleIpa: 'ˈsjelo',       sampleVx: 'ˈsyelo' },
   'ʃ':  { ipa: 'ʃ',  vx: 'sh',  sampleWord: 'shopping',    sampleIpa: 'ˈʃopiŋ',       sampleVx: 'ˈshopiN' },
   't':  { ipa: 't',  vx: 't',   sampleWord: 'tela',        sampleIpa: 'ˈtela',        sampleVx: 'ˈtela' },
@@ -347,6 +347,10 @@ export interface TtsPhonemes {
     }
   >;
 
+  supportsPhoneticEdits: boolean;
+
+  supportsTextEdits: boolean;
+
   /**
    * All available vowel phonemes for this language. Broken out to support
    * split consonant/vowel layouts for the on-screen phonetic keyboard.
@@ -393,6 +397,8 @@ export const phonemes: Record<LanguageCode, TtsPhonemes> = {
     consonants: ALL_ENGLISH.filter((p) => !ALL_VOWELS.has(p.ipa)),
     consonantModifier: DEFAULT_CONSONANT_MODIFIER,
     stresses: STANDARD_STRESSES,
+    supportsPhoneticEdits: true,
+    supportsTextEdits: true,
     vowels: ALL_ENGLISH.filter((p) => ALL_VOWELS.has(p.ipa)),
   },
   [LanguageCode.ARABIC]: {
@@ -400,6 +406,8 @@ export const phonemes: Record<LanguageCode, TtsPhonemes> = {
     consonants: ALL_ENGLISH.filter((p) => !ALL_VOWELS.has(p.ipa)),
     consonantModifier: DEFAULT_CONSONANT_MODIFIER,
     stresses: STANDARD_STRESSES,
+    supportsPhoneticEdits: false,
+    supportsTextEdits: true,
     vowels: ALL_ENGLISH.filter((p) => ALL_VOWELS.has(p.ipa)),
   },
   [LanguageCode.BENGALI]: {
@@ -407,6 +415,8 @@ export const phonemes: Record<LanguageCode, TtsPhonemes> = {
     consonants: ALL_ENGLISH.filter((p) => !ALL_VOWELS.has(p.ipa)),
     consonantModifier: DEFAULT_CONSONANT_MODIFIER,
     stresses: STANDARD_STRESSES,
+    supportsPhoneticEdits: false,
+    supportsTextEdits: true,
     vowels: ALL_ENGLISH.filter((p) => ALL_VOWELS.has(p.ipa)),
   },
   [LanguageCode.CHINESE_SIMPLIFIED]: {
@@ -414,6 +424,8 @@ export const phonemes: Record<LanguageCode, TtsPhonemes> = {
     consonants: ALL_ENGLISH.filter((p) => !ALL_VOWELS.has(p.ipa)),
     consonantModifier: DEFAULT_CONSONANT_MODIFIER,
     stresses: STANDARD_STRESSES,
+    supportsPhoneticEdits: false,
+    supportsTextEdits: true,
     vowels: ALL_ENGLISH.filter((p) => ALL_VOWELS.has(p.ipa)),
   },
   [LanguageCode.CHINESE_TRADITIONAL]: {
@@ -421,6 +433,8 @@ export const phonemes: Record<LanguageCode, TtsPhonemes> = {
     consonants: ALL_ENGLISH.filter((p) => !ALL_VOWELS.has(p.ipa)),
     consonantModifier: DEFAULT_CONSONANT_MODIFIER,
     stresses: STANDARD_STRESSES,
+    supportsPhoneticEdits: false,
+    supportsTextEdits: true,
     vowels: ALL_ENGLISH.filter((p) => ALL_VOWELS.has(p.ipa)),
   },
   [LanguageCode.HINDI]: {
@@ -428,6 +442,8 @@ export const phonemes: Record<LanguageCode, TtsPhonemes> = {
     consonants: ALL_HINDI.filter((p) => !ALL_VOWELS.has(p.ipa)),
     consonantModifier: DEFAULT_CONSONANT_MODIFIER,
     stresses: STANDARD_STRESSES,
+    supportsPhoneticEdits: true,
+    supportsTextEdits: true,
     vowels: ALL_HINDI.filter((p) => ALL_VOWELS.has(p.ipa)),
   },
   [LanguageCode.JAPANESE]: {
@@ -435,6 +451,8 @@ export const phonemes: Record<LanguageCode, TtsPhonemes> = {
     consonants: ALL_ENGLISH.filter((p) => !ALL_VOWELS.has(p.ipa)),
     consonantModifier: DEFAULT_CONSONANT_MODIFIER,
     stresses: STANDARD_STRESSES,
+    supportsPhoneticEdits: false,
+    supportsTextEdits: true,
     vowels: ALL_ENGLISH.filter((p) => ALL_VOWELS.has(p.ipa)),
   },
   [LanguageCode.KHMER]: {
@@ -442,6 +460,8 @@ export const phonemes: Record<LanguageCode, TtsPhonemes> = {
     consonants: ALL_ENGLISH.filter((p) => !ALL_VOWELS.has(p.ipa)),
     consonantModifier: DEFAULT_CONSONANT_MODIFIER,
     stresses: STANDARD_STRESSES,
+    supportsPhoneticEdits: false,
+    supportsTextEdits: false,
     vowels: ALL_ENGLISH.filter((p) => ALL_VOWELS.has(p.ipa)),
   },
   [LanguageCode.KOREAN]: {
@@ -453,6 +473,8 @@ export const phonemes: Record<LanguageCode, TtsPhonemes> = {
       primary: { ipa: '.', vx: '.' },
       secondary: { ipa: '.', vx: '.' },
     },
+    supportsPhoneticEdits: true,
+    supportsTextEdits: true,
     vowels: ALL_KOREAN.filter((p) => ALL_VOWELS.has(p.ipa)),
   },
   [LanguageCode.SPANISH]: {
@@ -460,6 +482,8 @@ export const phonemes: Record<LanguageCode, TtsPhonemes> = {
     consonants: ALL_SPANISH.filter((p) => !ALL_VOWELS.has(p.ipa)),
     consonantModifier: 'e',
     stresses: STANDARD_STRESSES,
+    supportsPhoneticEdits: true,
+    supportsTextEdits: true,
     vowels: ALL_SPANISH.filter((p) => ALL_VOWELS.has(p.ipa)),
   },
   [LanguageCode.TAGALOG]: {
@@ -467,6 +491,8 @@ export const phonemes: Record<LanguageCode, TtsPhonemes> = {
     consonants: ALL_TAGALOG.filter((p) => !ALL_VOWELS.has(p.ipa)),
     consonantModifier: 'a',
     stresses: STANDARD_STRESSES,
+    supportsPhoneticEdits: true,
+    supportsTextEdits: true,
     vowels: ALL_TAGALOG.filter((p) => ALL_VOWELS.has(p.ipa)),
     vowelModifier: 'ʔ',
   },
@@ -475,6 +501,8 @@ export const phonemes: Record<LanguageCode, TtsPhonemes> = {
     consonants: ALL_ENGLISH.filter((p) => !ALL_VOWELS.has(p.ipa)),
     consonantModifier: DEFAULT_CONSONANT_MODIFIER,
     stresses: STANDARD_STRESSES,
+    supportsPhoneticEdits: false,
+    supportsTextEdits: true,
     vowels: ALL_ENGLISH.filter((p) => ALL_VOWELS.has(p.ipa)),
   },
 };


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/8919

Google TTS supports phoneme-based synthesis for Chinese and Japanese, but not with the IPA (each havea separate phonetic alphabet). We're leaving phonetic editing out for these, since the writing systems should theoretically allow for enough phonetic expressiveness for text editing to suffice.

Phoneme-based synthesis is not supported at all for Vietnamese, but the full range of phonetics should also be possible in this case using the language-native alphabet.

### Misc
Also making a tweak to de-dupe identical strings in the sidebar for now. In theory, you could have two identical strings that should be pronounced differently, but we don't have a clear plan for handling that yet.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/193f313d-981b-41d2-b0f4-2e2fc93e9d6d
