### PR TITLE
[ca-demo] VxAdmin: Have clients "escalate" rather then "skip" ballots 

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -151,6 +151,7 @@ create table cvrs (
   has_marginal_mark boolean not null default false,
   has_crossover_vote boolean not null,
   is_adjudicated boolean not null default false,
+  is_escalated boolean not null default false,
   created_at timestamp not null default current_timestamp,
   foreign key (election_id) references elections(id)
     on delete cascade,

--- a/apps/admin/backend/src/adjudication.test.ts
+++ b/apps/admin/backend/src/adjudication.test.ts
@@ -1008,7 +1008,12 @@ test('combined ballot primary crossover vote', async () => {
   expect(queue).toContain(crossoverCvrId);
   expect(queue).not.toContain(singlePartyCvrId);
   const metadata = store.getBallotAdjudicationQueueMetadata({ electionId });
-  expect(metadata).toEqual({ totalTally: 1, pendingTally: 1 });
+  expect(metadata).toEqual({
+    totalTally: 1,
+    pendingTally: 1,
+    escalatedTotalTally: 0,
+    escalatedPendingTally: 0,
+  });
   expect(
     store.getBallotAdjudicationData({ electionId, cvrId: crossoverCvrId }).tag
   ).toEqual({ isBlankBallot: false, hasCrossoverVote: true });

--- a/apps/admin/backend/src/app.adjudication.test.ts
+++ b/apps/admin/backend/src/app.adjudication.test.ts
@@ -1209,6 +1209,8 @@ test('adjudicating write-ins changes their status and is reflected in tallies', 
   expect(await apiClient.getBallotAdjudicationQueueMetadata()).toEqual({
     pendingTally: 62,
     totalTally: 62,
+    escalatedTotalTally: 0,
+    escalatedPendingTally: 0,
   });
   await expectContestResults({
     type: 'candidate',

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -891,9 +891,10 @@ function buildApi({
       return result;
     },
 
-    getBallotAdjudicationQueue(): Id[] {
+    getBallotAdjudicationQueue(input: { escalatedOnly?: boolean } = {}): Id[] {
       return store.getBallotAdjudicationQueue({
         electionId: loadCurrentElectionIdOrThrow(workspace),
+        escalatedOnly: input.escalatedOnly,
       });
     },
 
@@ -940,13 +941,14 @@ function buildApi({
     },
 
     getNextCvrIdForBallotAdjudication(
-      input: { afterCvrId?: Id } = {}
+      input: { afterCvrId?: Id; escalatedOnly?: boolean } = {}
     ): Id | null {
       return (
         store.getNextCvrIdForBallotAdjudication({
           electionId: loadCurrentElectionIdOrThrow(workspace),
           machineId: getMachineConfig().machineId,
           afterCvrId: input.afterCvrId,
+          escalatedFilter: input.escalatedOnly ? 'only' : undefined,
         }) ?? null
       );
     },

--- a/apps/admin/backend/src/client_app.test.ts
+++ b/apps/admin/backend/src/client_app.test.ts
@@ -308,6 +308,7 @@ test('getBatteryInfo returns battery info', async () => {
 interface MockPeerApi {
   claimAndLoadBallot: ReturnType<typeof vi.fn>;
   releaseBallot: ReturnType<typeof vi.fn>;
+  escalateBallot: ReturnType<typeof vi.fn>;
   getBallotImageMetadata: ReturnType<typeof vi.fn>;
   getWriteInCandidates: ReturnType<typeof vi.fn>;
   adjudicateCvr: ReturnType<typeof vi.fn>;
@@ -317,6 +318,7 @@ function connectToMockHost(): { mockPeerApi: MockPeerApi } {
   const mockPeerApi: MockPeerApi = {
     claimAndLoadBallot: vi.fn(),
     releaseBallot: vi.fn(),
+    escalateBallot: vi.fn(),
     getBallotImageMetadata: vi.fn(),
     getWriteInCandidates: vi.fn(),
     adjudicateCvr: vi.fn(),
@@ -368,6 +370,9 @@ test('proxy endpoints return host-disconnect error when not connected', async ()
   expect(await env.apiClient.releaseBallot({ cvrId: 'cvr-1' })).toEqual(
     err({ type: 'host-disconnect' })
   );
+  expect(await env.apiClient.escalateBallot({ cvrId: 'cvr-1' })).toEqual(
+    err({ type: 'host-disconnect' })
+  );
   expect(await env.apiClient.getBallotImages({ cvrId: 'cvr-1' })).toEqual(
     err({ type: 'host-disconnect' })
   );
@@ -385,6 +390,26 @@ test('proxy endpoints return host-disconnect error when not connected', async ()
       ],
     })
   ).toEqual(err({ type: 'host-disconnect' }));
+});
+
+test('escalateBallot proxies to host peer API', async () => {
+  const { mockPeerApi } = connectToMockHost();
+  mockPeerApi.escalateBallot.mockResolvedValue(ok());
+
+  const result = await env.apiClient.escalateBallot({ cvrId: 'cvr-1' });
+  expect(result).toEqual(ok());
+  expect(mockPeerApi.escalateBallot).toHaveBeenCalledWith({
+    machineId: DEV_MACHINE_ID,
+    cvrId: 'cvr-1',
+  });
+});
+
+test('escalateBallot passes through a claim-failed error from the host', async () => {
+  const { mockPeerApi } = connectToMockHost();
+  mockPeerApi.escalateBallot.mockResolvedValue(err({ type: 'claim-failed' }));
+
+  const result = await env.apiClient.escalateBallot({ cvrId: 'cvr-1' });
+  expect(result).toEqual(err({ type: 'claim-failed' }));
 });
 
 test('proxy returns host-disconnect when peer API throws network error', async () => {

--- a/apps/admin/backend/src/client_app.ts
+++ b/apps/admin/backend/src/client_app.ts
@@ -245,6 +245,26 @@ function buildClientApi({
       });
     },
 
+    async escalateBallot(input: {
+      cvrId: Id;
+    }): Promise<Result<void, AdjudicationError>> {
+      const proxied = await proxy(
+        'escalate ballot',
+        async ({ apiClient: peerApi }) =>
+          peerApi.escalateBallot({
+            machineId: getMachineConfig().machineId,
+            cvrId: input.cvrId,
+          })
+      );
+      if (proxied.isErr()) return proxied;
+      const result = proxied.ok();
+      if (result.isErr()) return result;
+      await logger.logAsCurrentRole(LogEventId.AdminBallotReleased, {
+        message: `Skipped ballot ${input.cvrId} and escalated it for election manager review.`,
+      });
+      return ok();
+    },
+
     async claimAndLoadBallot(input: {
       afterCvrId?: Id;
     }): Promise<

--- a/apps/admin/backend/src/peer_app.test.ts
+++ b/apps/admin/backend/src/peer_app.test.ts
@@ -354,6 +354,92 @@ test('releaseBallot frees a claimed CVR', async () => {
   expect(result).toEqual(cvrId);
 });
 
+test('escalateBallot flags the ballot and stops serving it to clients', async () => {
+  const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
+  const electionDefinition =
+    electionTwoPartyPrimaryFixtures.readElectionDefinition();
+  const electionId = await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition
+  );
+  const cvrIds = addTestCvrs(workspace.store, electionId, 2);
+
+  // Escalation requires an active claim on the ballot
+  const noClaimResult = await peerApiClient.escalateBallot({
+    machineId: 'client-001',
+    cvrId: assertDefined(cvrIds[0]),
+  });
+  expect(noClaimResult.err()).toEqual({ type: 'claim-failed' });
+
+  const escalatedCvrId = assertDefined(
+    await claimBallot(peerApiClient, { machineId: 'client-001' })
+  );
+  (
+    await peerApiClient.escalateBallot({
+      machineId: 'client-001',
+      cvrId: escalatedCvrId,
+    })
+  ).unsafeUnwrap();
+
+  // The claim is released and the escalated ballot is no longer served to
+  // clients — the same client gets the other ballot, and a second client
+  // gets nothing
+  const otherCvrId = cvrIds.find((id) => id !== escalatedCvrId);
+  expect(await claimBallot(peerApiClient, { machineId: 'client-001' })).toEqual(
+    otherCvrId
+  );
+  expect(
+    await claimBallot(peerApiClient, { machineId: 'client-002' })
+  ).toBeUndefined();
+
+  // The host keeps the escalated ballot in its main queue, sees it in the
+  // escalated-only queue, and the queue metadata counts it
+  expect(await apiClient.getBallotAdjudicationQueue()).toHaveLength(2);
+  expect(
+    await apiClient.getBallotAdjudicationQueue({ escalatedOnly: true })
+  ).toEqual([escalatedCvrId]);
+  expect(
+    await apiClient.getNextCvrIdForBallotAdjudication({ escalatedOnly: true })
+  ).toEqual(escalatedCvrId);
+  expect(await apiClient.getBallotAdjudicationQueueMetadata()).toEqual({
+    totalTally: 2,
+    pendingTally: 2,
+    escalatedTotalTally: 1,
+    escalatedPendingTally: 1,
+  });
+
+  // Ballot data carries the flag so the host UI can show the review banner
+  expect(
+    workspace.store.getBallotAdjudicationData({
+      electionId,
+      cvrId: escalatedCvrId,
+    }).isEscalated
+  ).toEqual(true);
+
+  // Once the host adjudicates the escalated ballot it leaves the escalated
+  // review queue (but stays flagged and stays in the main queue)
+  (
+    await apiClient.adjudicateCvr({ cvrId: escalatedCvrId, contests: [] })
+  ).unsafeUnwrap();
+  expect(
+    await apiClient.getBallotAdjudicationQueue({ escalatedOnly: true })
+  ).toEqual([]);
+  expect(await apiClient.getBallotAdjudicationQueue()).toHaveLength(2);
+  expect(await apiClient.getBallotAdjudicationQueueMetadata()).toEqual({
+    totalTally: 2,
+    pendingTally: 1,
+    escalatedTotalTally: 1,
+    escalatedPendingTally: 0,
+  });
+  expect(
+    workspace.store.getBallotAdjudicationData({
+      electionId,
+      cvrId: escalatedCvrId,
+    }).isEscalated
+  ).toEqual(true);
+});
+
 test("releaseBallot does not release another machine's claim", async () => {
   const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
   const electionDefinition =

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -333,6 +333,9 @@ function buildPeerApi(
         electionId,
         machineId: input.machineId,
         afterCvrId: input.afterCvrId,
+        // Escalated ballots are reserved for election manager review on the
+        // host and are never served to client stations.
+        excludeEscalated: true,
       });
       const value = result.unsafeUnwrap(); // error case is unreachable here.
       logger.log(LogEventId.AdminBallotClaimed, 'system', {
@@ -343,6 +346,39 @@ function buildPeerApi(
         clientMachineId: input.machineId,
       });
       return value;
+    },
+
+    /**
+     * Escalates a ballot for election manager review on the host: flags the
+     * ballot and releases the client's claim so the client can move on. The
+     * ballot stays in the host's queue but is no longer served to clients.
+     */
+    escalateBallot(input: {
+      machineId: string;
+      cvrId: Id;
+    }): Result<void, AdjudicationError> {
+      const electionId = assertDefined(store.getCurrentElectionId());
+      if (
+        !store.hasBallotClaim({
+          electionId,
+          cvrId: input.cvrId,
+          machineId: input.machineId,
+        })
+      ) {
+        return err({ type: 'claim-failed' });
+      }
+      store.escalateCvrBallot({ electionId, cvrId: input.cvrId });
+      store.releaseBallotClaim({
+        electionId,
+        cvrId: input.cvrId,
+        machineId: input.machineId,
+      });
+      logger.log(LogEventId.AdminBallotReleased, 'system', {
+        message: `Client ${input.machineId} skipped ballot ${input.cvrId} and escalated it for election manager review.`,
+        cvrId: input.cvrId,
+        clientMachineId: input.machineId,
+      });
+      return ok();
     },
 
     releaseBallot(input: { machineId: string; cvrId: Id }): void {

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -2418,7 +2418,13 @@ export class Store implements BaseStore {
     return conditions.join(' or ');
   }
 
-  getBallotAdjudicationQueue({ electionId }: { electionId: Id }): Id[] {
+  getBallotAdjudicationQueue({
+    electionId,
+    escalatedOnly,
+  }: {
+    electionId: Id;
+    escalatedOnly?: boolean;
+  }): Id[] {
     this.assertElectionExists(electionId);
     debug('querying database for ballot adjudication cvr queue');
     const filter = this.getAdjudicationQueueFilter(electionId);
@@ -2427,11 +2433,35 @@ export class Store implements BaseStore {
         select c.id as cvr_id
         from cvrs c
         where (${filter})
+        ${
+          /* The escalated queue is a review worklist: only ballots still
+           * awaiting adjudication. The main queue keeps adjudicated ballots
+           * so the host can page back through them. */
+          escalatedOnly ? 'and c.is_escalated = 1 and c.is_adjudicated = 0' : ''
+        }
         order by ${adjudicationSortKeyExprs('c').join(', ')}
       `
     ) as Array<{ cvr_id: Id }>;
     debug('queried ballot adjudication queue');
     return rows.map((r) => r.cvr_id);
+  }
+
+  /**
+   * Flags a ballot as escalated for election manager review on the host,
+   * e.g. when a client adjudication station skips it.
+   */
+  escalateCvrBallot({
+    electionId,
+    cvrId,
+  }: {
+    electionId: Id;
+    cvrId: Id;
+  }): void {
+    this.client.run(
+      'update cvrs set is_escalated = 1 where id = ? and election_id = ?',
+      cvrId,
+      electionId
+    );
   }
 
   getBallotAdjudicationQueueMetadata({
@@ -2447,13 +2477,19 @@ export class Store implements BaseStore {
       `
         select
           count(*) as totalTally,
-          count(case when c.is_adjudicated = 0 then 1 end) as pendingTally
+          count(case when c.is_adjudicated = 0 then 1 end) as pendingTally,
+          count(case when c.is_escalated = 1 then 1 end) as escalatedTotalTally,
+          count(
+            case when c.is_escalated = 1 and c.is_adjudicated = 0 then 1 end
+          ) as escalatedPendingTally
         from cvrs c
         where (${filter})
       `
     ) as {
       totalTally: number;
       pendingTally: number;
+      escalatedTotalTally: number;
+      escalatedPendingTally: number;
     };
 
     debug('queried ballot adjudication queue metadata');
@@ -2482,7 +2518,8 @@ export class Store implements BaseStore {
       select
         is_blank as isBlank,
         has_crossover_vote as hasCrossoverVote,
-        is_adjudicated as isResolved
+        is_adjudicated as isResolved,
+        is_escalated as isEscalated
       from cvrs
       where id = ?
       `,
@@ -2491,8 +2528,10 @@ export class Store implements BaseStore {
       isBlank: SqliteBool;
       hasCrossoverVote: SqliteBool;
       isResolved: SqliteBool;
+      isEscalated: SqliteBool;
     };
     const isResolved = fromSqliteBool(cvrRow.isResolved);
+    const isEscalated = fromSqliteBool(cvrRow.isEscalated);
     const cvrTag: CvrTag = {
       isBlankBallot: fromSqliteBool(cvrRow.isBlank),
       hasCrossoverVote: fromSqliteBool(cvrRow.hasCrossoverVote),
@@ -2586,6 +2625,7 @@ export class Store implements BaseStore {
     return {
       cvrId,
       isResolved,
+      isEscalated,
       tag: cvrTag,
       contests,
       adjudicatedContests,
@@ -2596,13 +2636,21 @@ export class Store implements BaseStore {
     electionId,
     machineId,
     afterCvrId,
+    escalatedFilter,
   }: {
     electionId: Id;
     machineId: string;
     afterCvrId?: Id;
+    escalatedFilter?: 'only' | 'exclude';
   }): Optional<Id> {
     this.assertElectionExists(electionId);
     const filter = this.getAdjudicationQueueFilter(electionId);
+    const escalatedCondition =
+      escalatedFilter === 'only'
+        ? 'and c.is_escalated = 1'
+        : escalatedFilter === 'exclude'
+        ? 'and c.is_escalated = 0'
+        : '';
     const sortKeys = adjudicationSortKeyExprs('c');
     const sortKeyList = sortKeys.join(', ');
 
@@ -2631,6 +2679,7 @@ export class Store implements BaseStore {
         where (${filter})
           and c.is_adjudicated = 0
           and mba.cvr_id is null
+          ${escalatedCondition}
         order by ${wrapOrder} ${sortKeyList}
         limit 1
       `,
@@ -3615,11 +3664,13 @@ export class Store implements BaseStore {
     machineId,
     cvrId,
     afterCvrId,
+    excludeEscalated,
   }: {
     electionId: Id;
     machineId: string;
     cvrId?: Id;
     afterCvrId?: Id;
+    excludeEscalated?: boolean;
   }): Result<
     { cvrId: Id; data: BallotAdjudicationData } | undefined,
     AdjudicationError
@@ -3636,6 +3687,7 @@ export class Store implements BaseStore {
           electionId,
           machineId,
           afterCvrId,
+          escalatedFilter: excludeEscalated ? 'exclude' : undefined,
         });
 
       if (!cvrIdToClaim) {

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -379,6 +379,8 @@ export type WriteInTally = WriteInPendingTally | WriteInAdjudicatedTally;
 export interface BallotAdjudicationQueueMetadata {
   pendingTally: number;
   totalTally: number;
+  escalatedPendingTally: number;
+  escalatedTotalTally: number;
 }
 
 /**
@@ -406,6 +408,7 @@ export interface ContestAdjudicationData {
 export interface BallotAdjudicationData {
   cvrId: Id;
   isResolved: boolean;
+  isEscalated: boolean;
   tag: CvrTag;
   contests: ContestAdjudicationData[];
   adjudicatedContests: AdjudicatedCvrContest[];

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -303,13 +303,19 @@ export const getCastVoteRecordFileMode = {
 } as const;
 
 export const getBallotAdjudicationQueue = {
-  queryKey(): QueryKey {
-    return ['getBallotAdjudicationQueue'];
+  queryKey(input?: { escalatedOnly?: boolean }): QueryKey {
+    return input
+      ? ['getBallotAdjudicationQueue', input]
+      : ['getBallotAdjudicationQueue'];
   },
-  useQuery() {
+  useQuery(input: { escalatedOnly?: boolean } = {}) {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () =>
-      apiClient.getBallotAdjudicationQueue()
+    return useQuery(
+      this.queryKey(input.escalatedOnly ? input : undefined),
+      () =>
+        input.escalatedOnly
+          ? apiClient.getBallotAdjudicationQueue(input)
+          : apiClient.getBallotAdjudicationQueue()
     );
   },
 } as const;
@@ -332,14 +338,19 @@ export const getBallotAdjudicationQueueMetadata = {
 } as const;
 
 export const getNextCvrIdForBallotAdjudication = {
-  queryKey(): QueryKey {
-    return ['getNextCvrIdForBallotAdjudication'];
+  queryKey(input?: { escalatedOnly?: boolean }): QueryKey {
+    return input
+      ? ['getNextCvrIdForBallotAdjudication', input]
+      : ['getNextCvrIdForBallotAdjudication'];
   },
-  useQuery() {
+  useQuery(input: { escalatedOnly?: boolean } = {}) {
     const apiClient = useApiClient();
     return useQuery(
-      this.queryKey(),
-      () => apiClient.getNextCvrIdForBallotAdjudication(),
+      this.queryKey(input.escalatedOnly ? input : undefined),
+      () =>
+        input.escalatedOnly
+          ? apiClient.getNextCvrIdForBallotAdjudication(input)
+          : apiClient.getNextCvrIdForBallotAdjudication(),
       {
         cacheTime: 0,
         staleTime: 0,

--- a/apps/admin/frontend/src/client/api.ts
+++ b/apps/admin/frontend/src/client/api.ts
@@ -244,6 +244,13 @@ export const releaseBallot = {
   },
 } as const;
 
+export const escalateBallot = {
+  useMutation() {
+    const apiClient = useApiClient();
+    return useMutation(apiClient.escalateBallot);
+  },
+} as const;
+
 export const getBallotImages = {
   queryKey(cvrId: string): QueryKey {
     return ['getBallotImages', cvrId];

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.test.tsx
@@ -12,7 +12,7 @@ import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import { err, ok } from '@votingworks/basics';
 import { Route } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
-import { screen, waitFor } from '../../../test/react_testing_library';
+import { screen, waitFor, within } from '../../../test/react_testing_library';
 import {
   ClientApiMock,
   createClientApiMock,
@@ -39,7 +39,7 @@ vi.mock('../../screens/ballot_adjudication_screen', () => ({
           Accept
         </button>
         <button type="button" onClick={onSkip as () => void}>
-          Skip
+          Escalate
         </button>
         <button type="button" onClick={onExit as () => void}>
           Exit
@@ -101,6 +101,7 @@ function makeBallotData(cvrId: string) {
     cvrId,
     tag: { isBlankBallot: false, hasCrossoverVote: false } as const,
     isResolved: false,
+    isEscalated: false,
     contests: [],
     adjudicatedContests: [],
   };
@@ -191,7 +192,7 @@ test('shows error screen when claim fails during accept', async () => {
   screen.getByText('Exit');
 });
 
-test('skip releases ballot and claims next after it', async () => {
+test('skip confirms, escalates the ballot, and claims next after it', async () => {
   expectDataLoaderQueries('cvr-1');
   expectDataLoaderQueries('cvr-2');
   expectGlobalDataLoaderQueries();
@@ -199,35 +200,76 @@ test('skip releases ballot and claims next after it', async () => {
   renderScreen();
   await screen.findByText('Adjudicating cvr-1');
 
-  apiMock.apiClient.releaseBallot
+  screen.getByText('Escalate').click();
+  await screen.findByText(
+    'Are you sure you want to escalate this ballot for election manager review and adjudication?'
+  );
+
+  apiMock.apiClient.escalateBallot
     .expectCallWith({ cvrId: 'cvr-1' })
     .resolves(ok());
   apiMock.apiClient.claimAndLoadBallot
     .expectCallWith({ afterCvrId: 'cvr-1' })
     .resolves(ok({ cvrId: 'cvr-2', data: makeBallotData('cvr-2') }));
 
-  screen.getByText('Skip').click();
+  within(screen.getByRole('alertdialog')).getByText('Escalate').click();
   await screen.findByText('Adjudicating cvr-2');
 });
 
-test('skip wraps to first eligible when nothing is available after current', async () => {
+test('canceling the skip modal keeps adjudicating the same ballot', async () => {
   expectDataLoaderQueries('cvr-1');
   expectGlobalDataLoaderQueries();
   expectInitialClaimAndLoad('cvr-1');
   renderScreen();
   await screen.findByText('Adjudicating cvr-1');
 
-  // Skip releases cvr-1, then asks for the next ballot after it. Nothing comes
-  // after, so the backend wraps around and hands cvr-1 back in one call.
-  apiMock.apiClient.releaseBallot
+  screen.getByText('Escalate').click();
+  await screen.findByText('Escalate Ballot');
+
+  screen.getByText('Cancel').click();
+  await waitFor(() =>
+    expect(screen.queryByText('Escalate Ballot')).not.toBeInTheDocument()
+  );
+  screen.getByText('Adjudicating cvr-1');
+});
+
+test('skipping the last eligible ballot finishes the session', async () => {
+  expectDataLoaderQueries('cvr-1');
+  expectGlobalDataLoaderQueries();
+  expectInitialClaimAndLoad('cvr-1');
+  renderScreen();
+  await screen.findByText('Adjudicating cvr-1');
+
+  // The escalated ballot is no longer served to clients, so with nothing else
+  // eligible the claim comes back empty.
+  apiMock.apiClient.escalateBallot
     .expectCallWith({ cvrId: 'cvr-1' })
     .resolves(ok());
   apiMock.apiClient.claimAndLoadBallot
     .expectCallWith({ afterCvrId: 'cvr-1' })
-    .resolves(ok({ cvrId: 'cvr-1', data: makeBallotData('cvr-1') }));
+    .resolves(ok(undefined));
 
-  screen.getByText('Skip').click();
+  screen.getByText('Escalate').click();
+  await screen.findByText('Escalate Ballot');
+  within(screen.getByRole('alertdialog')).getByText('Escalate').click();
+  await screen.findByText('No more ballots available for adjudication.');
+});
+
+test('skip shows an error when escalation fails', async () => {
+  expectDataLoaderQueries('cvr-1');
+  expectGlobalDataLoaderQueries();
+  expectInitialClaimAndLoad('cvr-1');
+  renderScreen();
   await screen.findByText('Adjudicating cvr-1');
+
+  apiMock.apiClient.escalateBallot
+    .expectCallWith({ cvrId: 'cvr-1' })
+    .resolves(err({ type: 'host-disconnect' }));
+
+  screen.getByText('Escalate').click();
+  await screen.findByText('Escalate Ballot');
+  within(screen.getByRole('alertdialog')).getByText('Escalate').click();
+  await screen.findByText('Disconnected from host.');
 });
 
 test('exit releases ballot', async () => {

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
-import { Button, Loading, Main, P, Screen } from '@votingworks/ui';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Button, Loading, Main, Modal, P, Screen } from '@votingworks/ui';
 import { useHistory } from 'react-router-dom';
 import { throwIllegalValue } from '@votingworks/basics';
 import { Id } from '@votingworks/types';
@@ -13,6 +13,7 @@ import { routerPaths } from '../../router_paths';
 import {
   adjudicateCvr,
   claimAndLoadBallot,
+  escalateBallot,
   getAdjudicationSessionStatus,
   getBallotImages,
   getSystemSettings,
@@ -47,10 +48,12 @@ export function ClientBallotAdjudicationScreen(): JSX.Element {
   const adjudicationStatusQuery = getAdjudicationSessionStatus.useQuery();
   const { mutateAsync: claimAndLoadAsync } = claimAndLoadBallot.useMutation();
   const { mutateAsync: releaseBallotAsync } = releaseBallot.useMutation();
+  const { mutateAsync: escalateBallotAsync } = escalateBallot.useMutation();
 
   const [flowState, setFlowState] = useState<FlowState>({
     type: 'initial-load',
   });
+  const [cvrIdToSkip, setCvrIdToSkip] = useState<Id>();
 
   // Navigate back if the host disables adjudication mid-session
   const isAdjudicationEnabled =
@@ -99,12 +102,20 @@ export function ClientBallotAdjudicationScreen(): JSX.Element {
     void claimNextBallot();
   }, [claimNextBallot]);
 
-  const skipBallot = useCallback(
+  // Skipping a ballot on a client escalates it for election manager review
+  // on the host: the host flags the ballot and releases our claim, then we
+  // advance past it. Escalated ballots are no longer served to clients.
+  const skipAndEscalateBallot = useCallback(
     async (cvrId: Id): Promise<void> => {
-      await releaseClaim(cvrId);
+      setCvrIdToSkip(undefined);
+      const result = await escalateBallotAsync({ cvrId });
+      if (result.isErr()) {
+        setFlowState({ type: 'error', error: result.err() });
+        return;
+      }
       await claimNextBallot(cvrId);
     },
-    [releaseClaim, claimNextBallot]
+    [escalateBallotAsync, claimNextBallot]
   );
 
   const exitBallot = useCallback(
@@ -149,13 +160,41 @@ export function ClientBallotAdjudicationScreen(): JSX.Element {
 
     case 'adjudicating':
       return (
-        <ClientBallotAdjudicationDataLoader
-          cvrId={flowState.cvrId}
-          ballotData={flowState.data}
-          onAcceptDone={() => void claimNextBallot(flowState.cvrId)}
-          onSkip={() => void skipBallot(flowState.cvrId)}
-          onExit={() => void exitBallot(flowState.cvrId)}
-        />
+        <React.Fragment>
+          <ClientBallotAdjudicationDataLoader
+            cvrId={flowState.cvrId}
+            ballotData={flowState.data}
+            onAcceptDone={() => void claimNextBallot(flowState.cvrId)}
+            onSkip={() => setCvrIdToSkip(flowState.cvrId)}
+            onExit={() => void exitBallot(flowState.cvrId)}
+          />
+          {cvrIdToSkip && (
+            <Modal
+              title="Escalate Ballot"
+              content={
+                <P>
+                  Are you sure you want to escalate this ballot for election
+                  manager review and adjudication?
+                </P>
+              }
+              actions={
+                <React.Fragment>
+                  <Button
+                    variant="primary"
+                    icon="Flag"
+                    onPress={() => void skipAndEscalateBallot(cvrIdToSkip)}
+                  >
+                    Escalate
+                  </Button>
+                  <Button onPress={() => setCvrIdToSkip(undefined)}>
+                    Cancel
+                  </Button>
+                </React.Fragment>
+              }
+              onOverlayClick={() => setCvrIdToSkip(undefined)}
+            />
+          )}
+        </React.Fragment>
       );
 
     default:
@@ -239,6 +278,7 @@ function ClientBallotAdjudicationDataLoader({
       }}
       onAcceptDone={onAcceptDone}
       onSkip={onSkip}
+      skipAction="escalate"
       onExit={onExit}
     />
   );

--- a/apps/admin/frontend/src/components/app_routes.tsx
+++ b/apps/admin/frontend/src/components/app_routes.tsx
@@ -143,6 +143,9 @@ export function AppRoutes(): JSX.Element | null {
       <Route exact path={routerPaths.ballotAdjudication}>
         <BallotAdjudicationScreen />
       </Route>
+      <Route exact path={routerPaths.ballotAdjudicationEscalated}>
+        <BallotAdjudicationScreen escalatedOnly />
+      </Route>
       <Route exact path={routerPaths.adjudicationCandidates}>
         <WriteInCandidatesScreen />
       </Route>

--- a/apps/admin/frontend/src/router_paths.ts
+++ b/apps/admin/frontend/src/router_paths.ts
@@ -40,6 +40,7 @@ export const routerPaths = {
   adjudication: '/adjudication',
   adjudicationCandidates: '/adjudication/candidates',
   ballotAdjudication: '/adjudication/ballots',
+  ballotAdjudicationEscalated: '/adjudication/ballots/escalated',
   settings: '/settings',
   hardwareDiagnostics: '/hardware-diagnostics',
   backups: '/backups',

--- a/apps/admin/frontend/src/screens/adjudication_start_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/adjudication_start_screen.test.tsx
@@ -124,6 +124,42 @@ test('When ballots need adjudication, shows start button with counts', async () 
   screen.getByText('2 of 5 adjudicated · 40%');
 });
 
+test('shows escalated ballots button when there are escalated ballots', async () => {
+  apiMock.expectGetBallotAdjudicationQueueMetadata({
+    pendingTally: 3,
+    totalTally: 5,
+    escalatedPendingTally: 2,
+    escalatedTotalTally: 2,
+  });
+  apiMock.expectGetCastVoteRecordFiles([mockCastVoteRecordFileRecord]);
+  renderInAppContext(<AdjudicationStartScreen />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByRole('button', { name: 'Adjudicate' });
+  screen.getByText('2 of 5 adjudicated · 40%');
+  screen.getByText('2 ballots escalated');
+  screen.getByRole('button', { name: 'Adjudicate Escalated Ballots' });
+});
+
+test('hides escalated ballots button when none are escalated', async () => {
+  apiMock.expectGetBallotAdjudicationQueueMetadata({
+    pendingTally: 3,
+    totalTally: 5,
+  });
+  apiMock.expectGetCastVoteRecordFiles([mockCastVoteRecordFileRecord]);
+  renderInAppContext(<AdjudicationStartScreen />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByRole('button', { name: 'Adjudicate' });
+  expect(
+    screen.queryByRole('button', { name: 'Adjudicate Escalated Ballots' })
+  ).not.toBeInTheDocument();
+});
+
 test('queue progress updates as other stations adjudicate ballots', async () => {
   apiMock.expectGetBallotAdjudicationQueueMetadata({
     pendingTally: 3,

--- a/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
+++ b/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
@@ -72,6 +72,32 @@ const LargeText = styled.div`
   line-height: 1;
 `;
 
+// Mirrors the reports-screen "Election Results are Official" card: the icon
+// is inline within the heading, and the card's content row centers the
+// heading against the button.
+const EscalatedCallout = styled(UiCard).attrs({ color: 'warning' })`
+  h3 {
+    margin: 0;
+
+    svg {
+      margin-right: 0.5rem;
+    }
+  }
+
+  > div {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+`;
+
+// A solid warning-colored variant of the filled button (the button system
+// has no built-in warning color). Filled buttons hover via a brightness
+// filter, so overriding only the background keeps hover behavior intact.
+const EscalatedLinkButton = styled(LinkButton)`
+  background-color: ${(p) => p.theme.colors.warningAccent};
+`;
+
 const EmptyTableMessage = styled.div`
   display: flex;
   justify-content: center;
@@ -455,6 +481,35 @@ function MultiStationCard(): JSX.Element {
   );
 }
 
+// Ballots skipped by client adjudication stations are escalated for election
+// manager review on the host, in their own queue.
+function EscalatedBallotsCallout(): JSX.Element | null {
+  const { isOfficialResults } = useContext(AppContext);
+  const queueMetadataQuery = getBallotAdjudicationQueueMetadata.useQuery();
+
+  if (!queueMetadataQuery.isSuccess) return null;
+  const { escalatedPendingTally } = queueMetadataQuery.data;
+  if (escalatedPendingTally === 0) return null;
+
+  return (
+    <EscalatedCallout>
+      <H3>
+        <Icons.Flag color="warning" />
+        {escalatedPendingTally} {pluralize('ballot', escalatedPendingTally)}{' '}
+        escalated
+      </H3>
+      <EscalatedLinkButton
+        variant="primary"
+        icon="PenToSquare"
+        to={routerPaths.ballotAdjudicationEscalated}
+        disabled={isOfficialResults}
+      >
+        Adjudicate Escalated Ballots
+      </EscalatedLinkButton>
+    </EscalatedCallout>
+  );
+}
+
 export function AdjudicationStartScreen(): JSX.Element {
   const { isOfficialResults } = useContext(AppContext);
   const systemSettingsQuery = getSystemSettings.useQuery();
@@ -476,6 +531,7 @@ export function AdjudicationStartScreen(): JSX.Element {
   return (
     <NavigationScreen title="Adjudication">
       <CardStack>
+        <EscalatedBallotsCallout />
         {areWriteInCandidatesQualified && <WriteInCandidatesCard />}
         <BallotAdjudicationCard showHeader={hasOtherCards} />
         {showMultiStationCard && <MultiStationCard />}

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, test } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import {
   electionCombinedBallotPrimaryFixtures,
   electionStraightPartyFixtures,
@@ -37,7 +37,10 @@ import {
 } from '../../test/react_testing_library';
 import { renderInAppContext } from '../../test/render_in_app_context';
 import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client';
-import { BallotAdjudicationScreenWrapper } from './ballot_adjudication_screen';
+import {
+  BallotAdjudicationScreen,
+  BallotAdjudicationScreenWrapper,
+} from './ballot_adjudication_screen';
 import { AdjudicationStartScreen } from './adjudication_start_screen';
 import { routerPaths } from '../router_paths';
 
@@ -136,14 +139,16 @@ function makeBallotAdjudicationData(
   {
     tag = { isBlankBallot: false, hasCrossoverVote: false },
     isResolved = false,
+    isEscalated = false,
     adjudicatedContests = [],
   }: {
     tag?: CvrTag;
     isResolved?: boolean;
+    isEscalated?: boolean;
     adjudicatedContests?: AdjudicatedCvrContest[];
   } = {}
 ): BallotAdjudicationData {
-  return { cvrId, contests, tag, isResolved, adjudicatedContests };
+  return { cvrId, contests, tag, isResolved, isEscalated, adjudicatedContests };
 }
 
 function makeAdjudicatedCvrContest(
@@ -398,6 +403,66 @@ test('ballot navigation supports back, skip, exit, and side switching', async ()
   await waitFor(() =>
     expect(history.location.pathname).toEqual('/adjudication')
   );
+});
+
+test('escalated queue shows only escalated ballots with a review banner', async () => {
+  const contestData = [
+    makeContestAdjudicationData(
+      'zoo-council-mammal',
+      makeContestTag({ hasWriteIn: true })
+    ),
+  ];
+  const adjData = makeBallotAdjudicationData(CVR_ID_1, contestData, {
+    isEscalated: true,
+  });
+
+  apiMock.apiClient.getBallotAdjudicationQueue
+    .expectCallWith({ escalatedOnly: true })
+    .resolves([CVR_ID_1]);
+  apiMock.apiClient.getNextCvrIdForBallotAdjudication
+    .expectRepeatedCallsWith({ escalatedOnly: true })
+    .resolves(CVR_ID_1);
+  apiMock.expectGetWriteInCandidates(
+    [],
+    contestData.map((c) => c.contestId)
+  );
+  apiMock.expectGetSystemSettings();
+  apiMock.expectClaimAndLoadBallot({ cvrId: CVR_ID_1 }, adjData);
+  apiMock.apiClient.getBallotImages
+    .expectRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves(makeHmpbBallotImages(CVR_ID_1));
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper escalatedOnly />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('Escalated for election manager review');
+  screen.getByText('Ballot 1 of 1');
+});
+
+test('escalate skip action renders an Escalate button with a flag instead of Skip', async () => {
+  const contestData = [makeContestAdjudicationData('best-animal-mammal')];
+  renderInAppContext(
+    <BallotAdjudicationScreen
+      cvrId={CVR_ID_1}
+      ballotAdjudicationData={makeBallotAdjudicationData(CVR_ID_1, contestData)}
+      ballotImages={makeHmpbBallotImages(CVR_ID_1)}
+      writeInCandidates={[]}
+      systemSettings={DEFAULT_SYSTEM_SETTINGS}
+      onAccept={vi.fn()}
+      onAcceptDone={vi.fn()}
+      onSkip={vi.fn()}
+      skipAction="escalate"
+      onExit={vi.fn()}
+    />,
+    { electionDefinition, apiMock }
+  );
+
+  await screen.findByRole('button', { name: 'Escalate' });
+  expect(
+    screen.queryByRole('button', { name: 'Skip' })
+  ).not.toBeInTheDocument();
 });
 
 test('opens to the back side when the only pending contest is on the back', async () => {

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -1,6 +1,14 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
-import { Button, Loading, Main, Modal, P, Screen } from '@votingworks/ui';
+import {
+  Button,
+  Icons,
+  Loading,
+  Main,
+  Modal,
+  P,
+  Screen,
+} from '@votingworks/ui';
 import {
   AdjudicationReason,
   ContestId,
@@ -73,6 +81,17 @@ const AdjudicationPanel = styled.div`
   border-left: 4px solid black;
 `;
 
+const EscalatedBanner = styled.div`
+  align-items: center;
+  background-color: ${(p) => p.theme.colors.warningContainer};
+  color: ${(p) => p.theme.colors.onBackground};
+  display: flex;
+  font-size: 0.85rem;
+  font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+`;
+
 const PanelHeader = styled.div`
   display: flex;
   justify-content: space-between;
@@ -118,6 +137,11 @@ const PrimaryNavButton = styled(Button)`
 
 const SecondaryNavButton = styled(Button)`
   width: 5.5rem;
+`;
+
+// Wider than SecondaryNavButton so the icon + "Escalate" label fits.
+const EscalateNavButton = styled(Button)`
+  min-width: 5.5rem;
 `;
 
 const ModalActions = styled.div`
@@ -166,9 +190,17 @@ function contestListItems(
   }));
 }
 
-export function BallotAdjudicationScreenWrapper(): JSX.Element {
-  const ballotQueueQuery = getBallotAdjudicationQueue.useQuery();
-  const nextCvrIdQuery = getNextCvrIdForBallotAdjudication.useQuery();
+export function BallotAdjudicationScreenWrapper({
+  escalatedOnly,
+}: {
+  escalatedOnly?: boolean;
+} = {}): JSX.Element {
+  const ballotQueueQuery = getBallotAdjudicationQueue.useQuery(
+    escalatedOnly ? { escalatedOnly } : {}
+  );
+  const nextCvrIdQuery = getNextCvrIdForBallotAdjudication.useQuery(
+    escalatedOnly ? { escalatedOnly } : {}
+  );
 
   if (!ballotQueueQuery.isSuccess || !nextCvrIdQuery.isSuccess) {
     return (
@@ -190,6 +222,7 @@ export function BallotAdjudicationScreenWrapper(): JSX.Element {
     <HostBallotAdjudicationScreen
       queue={queue}
       initialQueueIndex={initialQueueIndex}
+      escalatedOnly={escalatedOnly}
     />
   );
 }
@@ -197,9 +230,11 @@ export function BallotAdjudicationScreenWrapper(): JSX.Element {
 function HostBallotAdjudicationScreen({
   queue,
   initialQueueIndex,
+  escalatedOnly,
 }: {
   queue: Id[];
   initialQueueIndex: number;
+  escalatedOnly?: boolean;
 }): JSX.Element {
   const history = useHistory();
   const [queueIndex, setQueueIndex] = useState(initialQueueIndex);
@@ -247,6 +282,7 @@ function HostBallotAdjudicationScreen({
             contests: [],
             tag: { isBlankBallot: false, hasCrossoverVote: false },
             isResolved: false,
+            isEscalated: false,
             adjudicatedContests: [],
           });
         } else {
@@ -331,9 +367,11 @@ function HostBallotAdjudicationScreen({
   async function navigateAcceptNext(): Promise<void> {
     setIsClaimInFlight(true);
     try {
-      const nextCvrId = await apiClient.getNextCvrIdForBallotAdjudication({
-        afterCvrId: currentCvrId,
-      });
+      const nextCvrId = await apiClient.getNextCvrIdForBallotAdjudication(
+        escalatedOnly
+          ? { afterCvrId: currentCvrId, escalatedOnly: true }
+          : { afterCvrId: currentCvrId }
+      );
       const nextIndex = nextCvrId ? queue.indexOf(nextCvrId) : -1;
       if (nextIndex < 0) {
         // No ballot left, or the next one isn't in our cached queue drop back to the landing screen
@@ -499,6 +537,9 @@ export interface BallotAdjudicationScreenProps {
   }) => Promise<void>;
   onAcceptDone: () => void;
   onSkip?: () => void;
+  // Label the skip action as an escalation (used on client stations, where
+  // skipping escalates the ballot for election manager review on the host).
+  skipAction?: 'skip' | 'escalate';
   onBack?: () => void;
   onExit: () => void;
 }
@@ -601,6 +642,7 @@ function BallotView({
   onAccept,
   onAcceptDone,
   onSkip,
+  skipAction = 'skip',
   onBack,
   onExit,
 }: {
@@ -746,6 +788,12 @@ function BallotView({
               Exit
             </Button>
           </PanelHeader>
+          {ballotAdjudicationData.isEscalated && (
+            <EscalatedBanner>
+              <Icons.Flag color="warning" /> Escalated for election manager
+              review
+            </EscalatedBanner>
+          )}
           {isClaimed ? (
             <ClaimedBallotOverlay>
               <P>
@@ -806,15 +854,24 @@ function BallotView({
                   >
                     Accept
                   </PrimaryNavButton>
-                  {onSkipGuarded && (
-                    <SecondaryNavButton
-                      onPress={onSkipGuarded}
-                      rightIcon="Next"
-                      disabled={isClaimInFlight}
-                    >
-                      Skip
-                    </SecondaryNavButton>
-                  )}
+                  {onSkipGuarded &&
+                    (skipAction === 'escalate' ? (
+                      <EscalateNavButton
+                        onPress={onSkipGuarded}
+                        icon="Flag"
+                        disabled={isClaimInFlight}
+                      >
+                        Escalate
+                      </EscalateNavButton>
+                    ) : (
+                      <SecondaryNavButton
+                        onPress={onSkipGuarded}
+                        rightIcon="Next"
+                        disabled={isClaimInFlight}
+                      >
+                        Skip
+                      </SecondaryNavButton>
+                    ))}
                   {onBackGuarded && (
                     <SecondaryNavButton
                       icon="Previous"

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -388,11 +388,19 @@ export function createApiMock(
     },
 
     expectGetBallotAdjudicationQueueMetadata(
-      metadata: BallotAdjudicationQueueMetadata
+      metadata: Pick<
+        BallotAdjudicationQueueMetadata,
+        'pendingTally' | 'totalTally'
+      > &
+        Partial<BallotAdjudicationQueueMetadata>
     ) {
       return apiClient.getBallotAdjudicationQueueMetadata
         .expectRepeatedCallsWith()
-        .resolves(metadata);
+        .resolves({
+          escalatedPendingTally: 0,
+          escalatedTotalTally: 0,
+          ...metadata,
+        });
     },
 
     expectGetBallotAdjudicationQueue(cvrIds: Id[]) {


### PR DESCRIPTION
Changes the VxAdmin adjudication flow paradigm from clients "skipping" ballots to instead "escalating for review" with an escalation queue accessible from VxAdmin. 
<img width="985" height="612" alt="Screenshot 2026-07-22 at 3 07 35 PM" src="https://github.com/user-attachments/assets/ed9f1ce5-28e3-4011-a08d-5da2444f76cf" />
<img width="1171" height="652" alt="Screenshot 2026-07-22 at 2 40 52 PM" src="https://github.com/user-attachments/assets/bb8ea1d2-a7d3-4edc-826c-44238ebc1044" />
<img width="1172" height="670" alt="Screenshot 2026-07-22 at 2 40 57 PM" src="https://github.com/user-attachments/assets/aa7b5c80-9e1f-4585-9369-d93f6ba16a7c" />
