### PR TITLE
[ca-demo] VxCentralScan: DeskPro unexpected stream close is an error, not feeder-empty

### DIFF
--- a/apps/central-scan/backend/src/deskpro_scanner.ts
+++ b/apps/central-scan/backend/src/deskpro_scanner.ts
@@ -201,6 +201,7 @@ export class DeskProScanner implements BatchScanner {
       let pendingMeta: { side?: string } | undefined;
       let pageCount = 0;
       let ended = false;
+      let doneSeen = false;
 
       function endCapture() {
         if (ended) return;
@@ -222,6 +223,7 @@ export class DeskProScanner implements BatchScanner {
           const text = data.toString();
           if (text.includes('"done"')) {
             debug('deskpro capture done: %s', text);
+            doneSeen = true;
             endCapture();
           } else if (text.includes('"error"')) {
             rejectAll(new Error(`deskpro scanserver error: ${text}`));
@@ -250,7 +252,25 @@ export class DeskProScanner implements BatchScanner {
       });
 
       sock.on('error', (error) => rejectAll(error));
-      sock.on('close', () => endCapture());
+      sock.on('close', () => {
+        // A close is only a natural end-of-batch if the server said "done" (or
+        // we asked it to stop). Anything else -- a watchdog restart, a crashed
+        // scanserver, a dropped connection -- means sheets may remain in the
+        // feeder, so surface an ERROR rather than letting the batch pause as
+        // "tray empty" with paper still in the tray.
+        if (!ended && !stopRequested && !doneSeen) {
+          ended = true;
+          rejectAll(
+            new Error(
+              'capture stream closed unexpectedly mid-batch (scanserver ' +
+                'restarted or connection lost); unscanned sheets may remain ' +
+                'in the feeder'
+            )
+          );
+          return;
+        }
+        endCapture();
+      });
     };
 
     // Send the current capture a `stop` and wait for it to close, so the feed


### PR DESCRIPTION
## Problem

When the DeskPro capture WebSocket closes without a `done` frame (scanserver killed/restarted mid-batch, connection lost), `DeskProScanner` treated it as natural completion. The batch paused as **"tray empty" while sheets remained in the feeder**, and the operator's Continue then failed against the wedged scanner (`source open failed`) — the confusing failure mode we chased on the demo rig (batch wedges at 40–50 of ~50 sheets, whole rig needs a power cycle).

Root cause of the closes themselves was the VM-side scanserver watchdog force-killing a busy-but-healthy server mid-capture (fixed separately in the integration repo), but any unexpected disconnect produced the same misleading UX.

## Fix

Track whether the server's `done` frame was seen. A close without it (and without a requested stop) now rejects the batch with an explicit error — "capture stream closed unexpectedly mid-batch … unscanned sheets may remain in the feeder" — instead of reporting feeder-empty.

## Testing

- Verified on the demo rig: with the fix deployed, a 60-sheet 17" batch completes cleanly (natural `done` → normal tray-empty pause), including a mid-batch mechanical stop + Continue resume.
- The error path was exercised implicitly by reproducing the watchdog kill before the watchdog fix; post-fix, kills no longer occur so the path is defensive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)