### PR TITLE
[ca-demo] VxCentralScan: Polish scan ballots screen

### DIFF
--- a/apps/central-scan/frontend/src/app.test.tsx
+++ b/apps/central-scan/frontend/src/app.test.tsx
@@ -166,7 +166,8 @@ test('configuring election from usb election package works end to end', async ()
   expectConfigureFromElectionPackageOnUsbDrive();
   apiMock.setUsbDriveStatus(mockUsbDriveStatus('mounted'));
 
-  await screen.findByText(hasTextAcrossElements('Total Batches: 0'));
+  await screen.findByText('Total Batches');
+  expect(screen.getByTestId('total-batches')).toHaveTextContent('0');
 
   screen.getByText('General Election');
   screen.getByText(/Franklin County/);

--- a/apps/central-scan/frontend/src/app_poll_worker.test.tsx
+++ b/apps/central-scan/frontend/src/app_poll_worker.test.tsx
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, expect, test } from 'vitest';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import { constructElectionKey, ElectionDefinition } from '@votingworks/types';
 import {
-  hasTextAcrossElements,
   mockPollWorkerUser,
   mockSessionExpiresAt,
 } from '@votingworks/test-utils';
@@ -95,15 +94,16 @@ test('poll worker can open batch history, which has no delete buttons', async ()
 
   // Summary stats are always visible; the line-by-line history lives on its
   // own page
-  await screen.findByText(hasTextAcrossElements('Total Batches: 2'));
-  screen.getByText(hasTextAcrossElements('Total Sheets: 57'));
+  await screen.findByText('Total Batches');
+  expect(screen.getByTestId('total-batches')).toHaveTextContent('2');
+  expect(screen.getByTestId('total-sheets')).toHaveTextContent('57');
 
   userEvent.click(screen.getByText('Batch History'));
   await screen.findByRole('heading', { name: 'Batch History' });
   screen.getByText('Batch 1');
   screen.getByText('Batch 2');
   // totals are shown on the history page too
-  screen.getByText(hasTextAcrossElements('Total Batches: 2'));
+  expect(screen.getByTestId('total-batches')).toHaveTextContent('2');
   expect(screen.queryByText('Delete')).not.toBeInTheDocument();
   expect(screen.queryByText('Delete All Batches')).not.toBeInTheDocument();
   expect(screen.queryByText('Save CVRs')).not.toBeInTheDocument();

--- a/apps/central-scan/frontend/src/components/batch_control_card.tsx
+++ b/apps/central-scan/frontend/src/components/batch_control_card.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import styled, { useTheme } from 'styled-components';
-import { Button, H2, Modal, P } from '@votingworks/ui';
+import styled from 'styled-components';
+import { Button, H2, Icons, Modal, P } from '@votingworks/ui';
 import type {
   BatchPauseReason,
   ScanStatus,
@@ -17,8 +17,8 @@ const Card = styled.div`
 
 const StatusPane = styled.div`
   background: ${(p) => p.theme.colors.containerLow};
-  padding: 2rem;
-  width: 26rem;
+  padding: 1rem;
+  width: 45%;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
@@ -34,7 +34,7 @@ const StatusPane = styled.div`
 `;
 
 const ActionsPane = styled.div`
-  padding: 2rem;
+  padding: 1rem;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -42,7 +42,7 @@ const ActionsPane = styled.div`
   flex-grow: 1;
 
   button {
-    font-size: 1.4rem;
+    font-size: 1.2rem;
     padding: 0.75rem 2rem;
   }
 `;
@@ -51,10 +51,44 @@ const ActionsFooter = styled.div`
   margin-top: auto;
 `;
 
-const PageWrapper = styled.div`
+const PageWrapper = styled.div<{
+  dashed?: boolean;
+  active?: boolean;
+}>`
   position: relative;
-  width: 12rem;
-  margin: 0 auto;
+  flex: 1 1 0;
+  min-height: 0;
+
+  > svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+
+    /* The outline is stroked on the sheet's edges; let it render without being
+     * clipped at the SVG bounds. */
+    overflow: visible;
+  }
+
+  path {
+    fill: none;
+    stroke: ${(p) =>
+      p.active ? p.theme.colors.primary : p.theme.colors.outline};
+
+    /* Match the smart card's border weight exactly: use the same border sizes,
+     * and non-scaling-stroke so the weight stays constant as the sheet scales
+     * to fill its container. */
+    stroke-width: ${(p) =>
+      p.active
+        ? p.theme.sizes.bordersRem.medium
+        : p.theme.sizes.bordersRem.thin}rem;
+    vector-effect: non-scaling-stroke;
+    stroke-linejoin: round;
+    stroke-dasharray: ${(p) => (p.dashed ? '0.3rem 0.25rem' : 'none')};
+  }
+
+  .sheet {
+    fill: ${(p) => (p.dashed ? 'none' : p.theme.colors.background)};
+  }
 `;
 
 const PageCount = styled.div`
@@ -63,19 +97,26 @@ const PageCount = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 4rem;
+  font-size: 5rem;
   font-weight: 700;
 `;
 
-const PageCaption = styled.p`
-  text-align: center;
+const StatusTitle = styled(H2)`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 `;
 
 /**
- * A page with a folded top-right corner, standing in for the batch being
+ * A sheet of paper with a folded-down corner, standing in for the batch being
  * scanned — the batch-control equivalent of the smart card illustration on
- * VxAdmin's card programming screen. Dashed while there is no batch in
- * progress.
+ * VxAdmin's card programming screen, and styled to mirror it: the outline is
+ * dashed while no batch is in progress and solid once scanning, drawn in the
+ * `outline` color (or a thicker `primary` stroke while a batch is active), and
+ * the sheet fills in once it holds a batch. The folded corner is always drawn;
+ * only its line style changes between states. The SVG scales to fill its
+ * container while `non-scaling-stroke` keeps the outline the same weight as the
+ * smart card's border.
  */
 function PageIllustration({
   dashed,
@@ -86,32 +127,18 @@ function PageIllustration({
   active?: boolean;
   children?: React.ReactNode;
 }): JSX.Element {
-  const theme = useTheme();
-  let stroke = theme.colors.onBackground;
-  if (dashed) {
-    stroke = theme.colors.outline;
-  } else if (active) {
-    stroke = theme.colors.primary;
-  }
   return (
-    <PageWrapper>
-      <svg viewBox="0 0 120 156" role="img" aria-hidden="true">
-        <path
-          d="M6 6 H84 L114 36 V150 H6 Z"
-          fill={dashed ? 'none' : theme.colors.background}
-          stroke={stroke}
-          strokeWidth="3"
-          strokeLinejoin="round"
-          strokeDasharray={dashed ? '10 8' : undefined}
-        />
-        <path
-          d="M84 6 V36 H114"
-          fill="none"
-          stroke={stroke}
-          strokeWidth="3"
-          strokeLinejoin="round"
-          strokeDasharray={dashed ? '10 8' : undefined}
-        />
+    <PageWrapper dashed={dashed} active={active}>
+      <svg
+        viewBox="0 0 102 132"
+        preserveAspectRatio="none"
+        role="img"
+        aria-hidden="true"
+      >
+        {/* Sheet outline, with the top-right corner cut away for the fold. */}
+        <path className="sheet" d="M1 1 H79 L101 23 V131 H1 Z" />
+        {/* Folded-down corner: the two edges of the flap lying on the sheet. */}
+        <path d="M79 1 V23 H101" />
       </svg>
       <PageCount>{children}</PageCount>
     </PageWrapper>
@@ -172,22 +199,39 @@ export function BatchControlCard({
     cancelBatchMutation.isLoading;
 
   let statusContent: JSX.Element;
-  let actions: JSX.Element;
-  if (!currentBatch) {
+  let actions: JSX.Element | null;
+  if (!currentBatch && !status.isScannerAttached) {
+    // No scanner is connected, so scanning isn't possible: show a disconnected
+    // status and no scan button rather than a "Ready to Scan" prompt.
     statusContent = (
       <React.Fragment>
         <div>
-          <H2>Ready to Scan</H2>
-          <P>{' '}</P>
+          <StatusTitle>
+            <Icons.Disabled color="danger" />
+            Scanner Disconnected
+          </StatusTitle>
+          <P>Connect the scanner to begin scanning.</P>
         </div>
         <PageIllustration dashed />
+      </React.Fragment>
+    );
+    actions = null;
+  } else if (!currentBatch) {
+    statusContent = (
+      <React.Fragment>
+        <div>
+          <StatusTitle>Ready to Scan</StatusTitle>
+          <P>Place ballots in the input tray</P>
+        </div>
+        <PageIllustration dashed>
+          <Icons.UpCircle style={{ height: '30%' }} />
+        </PageIllustration>
       </React.Fragment>
     );
     actions = (
       <ScanButton
         /* disable scan button while status query is refetching to avoid double clicks */
         disabled={statusIsStale || isPollingPlaceUnconfigured}
-        isScannerAttached={status.isScannerAttached}
         label={`Start Batch ${format.count(status.nextBatchNumber)}`}
       />
     );
@@ -195,11 +239,13 @@ export function BatchControlCard({
     statusContent = (
       <React.Fragment>
         <div>
-          <H2>Scanning</H2>
+          <StatusTitle>
+            <Icons.Loading color="primary" />
+            Scanning
+          </StatusTitle>
           <P>{' '}</P>
         </div>
         <PageIllustration active>{format.count(sheetCount)}</PageIllustration>
-        <PageCaption>sheets scanned in this batch</PageCaption>
       </React.Fragment>
     );
     actions = (
@@ -207,15 +253,19 @@ export function BatchControlCard({
         variant="danger"
         onPress={() => setIsConfirmingStop(true)}
         disabled={cancelBatchMutation.isLoading}
+        icon="Delete"
       >
-        Stop
+        Stop Scanning
       </Button>
     );
   } else {
     statusContent = (
       <React.Fragment>
         <div>
-          <H2>Paused</H2>
+          <StatusTitle>
+            <Icons.Paused color="warning" />
+            Paused
+          </StatusTitle>
           <P>
             {currentBatch.pauseReason
               ? PAUSE_REASON_TEXT[currentBatch.pauseReason]
@@ -223,30 +273,46 @@ export function BatchControlCard({
           </P>
         </div>
         <PageIllustration>{format.count(sheetCount)}</PageIllustration>
-        <PageCaption>sheets scanned in this batch</PageCaption>
       </React.Fragment>
     );
     actions = (
-      <React.Fragment>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+        {!status.isScannerAttached && (
+          <P>
+            <Icons.Disabled color="danger" /> Connect the scanner to continue
+            scanning.
+          </P>
+        )}
         <Button
           variant="primary"
           onPress={() => continueBatchMutation.mutate()}
-          disabled={isActing || statusIsStale}
+          disabled={isActing || statusIsStale || !status.isScannerAttached}
+          rightIcon="Next"
         >
           Continue Scanning
         </Button>
-        <Button onPress={() => setIsConfirmingSave(true)} disabled={isActing}>
-          Save Batch
-        </Button>
-        <Button
-          color="danger"
-          fill="outlined"
-          onPress={() => setIsConfirmingCancel(true)}
-          disabled={isActing}
-        >
-          Discard Batch
-        </Button>
-      </React.Fragment>
+        <div style={{ display: 'flex', gap: '0.75rem' }}>
+          <Button
+            color="danger"
+            fill="tinted"
+            onPress={() => setIsConfirmingCancel(true)}
+            disabled={isActing}
+            icon="Trash"
+            style={{ flex: 1, minWidth: 0 }}
+          >
+            Discard Batch
+          </Button>
+          <Button
+            icon="Done"
+            variant="secondary"
+            onPress={() => setIsConfirmingSave(true)}
+            disabled={isActing}
+            style={{ flex: 1, minWidth: 0 }}
+          >
+            Save Batch
+          </Button>
+        </div>
+      </div>
     );
   }
 
@@ -255,7 +321,7 @@ export function BatchControlCard({
       <Card>
         <StatusPane>{statusContent}</StatusPane>
         <ActionsPane>
-          {batch && <H2>{batch.label}</H2>}
+          {batch && <H2 style={{ margin: 0 }}>{batch.label}</H2>}
           {notice}
           {actions}
           {actionsFooter && <ActionsFooter>{actionsFooter}</ActionsFooter>}

--- a/apps/central-scan/frontend/src/components/batch_summary_stats.tsx
+++ b/apps/central-scan/frontend/src/components/batch_summary_stats.tsx
@@ -1,36 +1,57 @@
-import React from 'react';
-import { Callout, Font, Icons, P } from '@votingworks/ui';
+import { Card, Icons, P } from '@votingworks/ui';
 import styled from 'styled-components';
 import { iter } from '@votingworks/basics';
 import type { ScanStatus } from '@votingworks/central-scan-backend';
 import { format } from '@votingworks/utils';
 
-const StatLines = styled.div`
-  p {
-    margin-bottom: 0.25rem;
-    font-size: 1.4rem;
-  }
+const Stats = styled.div`
+  display: flex;
+  gap: 1rem;
 `;
 
-const StatCallout = styled(Callout)`
-  div {
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
-    gap: 2rem;
-  }
-
-  p {
-    margin-bottom: 0;
-  }
+const StatCard = styled(Card)`
+  flex: 1;
+  border-width: ${(p) => p.theme.sizes.bordersRem.hairline}rem;
 `;
+
+const StatLabel = styled.div`
+  color: ${(p) => p.theme.colors.onBackgroundMuted};
+`;
+
+const StatValue = styled.div`
+  font-size: 1.8rem;
+  font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
+  line-height: 1;
+`;
+
+function Stat({
+  label,
+  value,
+  testId,
+}: {
+  label: string;
+  value: number;
+  testId: string;
+}): JSX.Element {
+  return (
+    <div>
+      <StatLabel>{label}</StatLabel>
+      <StatValue data-testid={testId}>{format.count(value)}</StatValue>
+    </div>
+  );
+}
 
 export function BatchSummaryStats({
   status,
-  callout,
+  showEmptyState,
 }: {
   status: ScanStatus;
-  /** Renders as a compact callout row instead of large stacked lines. */
-  callout?: boolean;
+  /**
+   * When there are no saved batches, show a "no batches" message instead of
+   * stat cards reading zero (used where the stats stand alone, e.g. the batch
+   * history page).
+   */
+  showEmptyState?: boolean;
 }): JSX.Element {
   // the open batch isn't included in the saved counts
   const batches = status.batches.filter(
@@ -41,7 +62,7 @@ export function BatchSummaryStats({
     .map((b) => b.count)
     .sum();
 
-  if (batchCount === 0 && callout) {
+  if (batchCount === 0 && showEmptyState) {
     return (
       <P>
         <Icons.Info /> No batches have been saved
@@ -49,23 +70,14 @@ export function BatchSummaryStats({
     );
   }
 
-  const stats = (
-    <React.Fragment>
-      <P>
-        <Font weight="bold">Total Batches:</Font> {format.count(batchCount)}
-      </P>
-      <P>
-        <Font weight="bold">Total Sheets:</Font> {format.count(ballotCount)}
-      </P>
-    </React.Fragment>
+  return (
+    <Stats data-testid="batch-summary-stats">
+      <StatCard>
+        <Stat label="Total Batches" value={batchCount} testId="total-batches" />
+      </StatCard>
+      <StatCard>
+        <Stat label="Total Sheets" value={ballotCount} testId="total-sheets" />
+      </StatCard>
+    </Stats>
   );
-
-  if (callout) {
-    return (
-      <StatCallout color="neutral" style={{ gap: '3rem' }}>
-        {stats}
-      </StatCallout>
-    );
-  }
-  return <StatLines>{stats}</StatLines>;
 }

--- a/apps/central-scan/frontend/src/components/scan_button.test.tsx
+++ b/apps/central-scan/frontend/src/components/scan_button.test.tsx
@@ -16,26 +16,20 @@ afterEach(() => {
   apiMock.assertComplete();
 });
 
-test('is enabled by default when scanner attached', async () => {
-  renderInAppContext(<ScanButton isScannerAttached />, { apiMock });
+test('is enabled by default', async () => {
+  renderInAppContext(<ScanButton />, { apiMock });
   const button = await screen.findButton('Scan New Batch');
   expect(button).toBeEnabled();
 });
 
-test('is disabled when scanner not attached', async () => {
-  renderInAppContext(<ScanButton isScannerAttached={false} />, { apiMock });
-  const button = await screen.findButton('No Scanner');
-  expect(button).toBeDisabled();
-});
-
 test('is disabled when disabled set to true', async () => {
-  renderInAppContext(<ScanButton disabled isScannerAttached />, { apiMock });
+  renderInAppContext(<ScanButton disabled />, { apiMock });
   const button = await screen.findButton('Scan New Batch');
   expect(button).toBeDisabled();
 });
 
 test('calls scanBatch', async () => {
-  renderInAppContext(<ScanButton isScannerAttached />, { apiMock });
+  renderInAppContext(<ScanButton />, { apiMock });
   apiMock.expectScanBatch();
   userEvent.click(await screen.findButton('Scan New Batch'));
 });

--- a/apps/central-scan/frontend/src/components/scan_button.tsx
+++ b/apps/central-scan/frontend/src/components/scan_button.tsx
@@ -3,25 +3,23 @@ import { scanBatch } from '../api';
 
 export interface Props {
   disabled?: boolean;
-  isScannerAttached: boolean;
   label?: string;
 }
 
 export function ScanButton({
   disabled,
-  isScannerAttached,
   label = 'Scan New Batch',
 }: Props): JSX.Element {
   const scanBatchMutation = scanBatch.useMutation();
 
   return (
     <Button
-      icon={isScannerAttached ? 'Add' : 'Closed'}
-      disabled={disabled || !isScannerAttached || scanBatchMutation.isLoading}
+      icon="Add"
+      disabled={disabled || scanBatchMutation.isLoading}
       variant="primary"
       onPress={() => scanBatchMutation.mutate()}
     >
-      {isScannerAttached ? label : 'No Scanner'}
+      {label}
     </Button>
   );
 }

--- a/apps/central-scan/frontend/src/screens/batch_history_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/batch_history_screen.test.tsx
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { mockUsbDriveStatus } from '@votingworks/ui';
 import userEvent from '@testing-library/user-event';
 import type { ScanStatus } from '@votingworks/central-scan-backend';
@@ -67,8 +66,9 @@ test('shows summary totals and each batch with its send status', async () => {
   });
   renderScreen({ status });
 
-  await screen.findByText(hasTextAcrossElements('Total Batches: 3'));
-  screen.getByText(hasTextAcrossElements('Total Sheets: 5'));
+  await screen.findByText('Total Batches');
+  expect(screen.getByTestId('total-batches')).toHaveTextContent('3');
+  expect(screen.getByTestId('total-sheets')).toHaveTextContent('5');
 
   await screen.findByText('Sending…');
   const rows = screen.getAllByRole('row');

--- a/apps/central-scan/frontend/src/screens/batch_history_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/batch_history_screen.tsx
@@ -60,7 +60,7 @@ export function BatchHistoryScreen({
   return (
     <NavigationScreen title="Batch History">
       <Content>
-        <BatchSummaryStats status={status} callout />
+        <BatchSummaryStats status={status} showEmptyState />
         {batches.length > 0 && (
           <React.Fragment>
             <div>

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
@@ -42,8 +42,10 @@ test('warns and disables scanning when a polling place needs to be selected', ()
 test('null state', () => {
   renderScreen();
   screen.getByText('Ready to Scan');
-  screen.getByText(hasTextAcrossElements('Total Batches: 0'));
-  screen.getByText(hasTextAcrossElements('Total Sheets: 0'));
+  screen.getByText('Total Batches');
+  expect(screen.getByTestId('total-batches')).toHaveTextContent('0');
+  screen.getByText('Total Sheets');
+  expect(screen.getByTestId('total-sheets')).toHaveTextContent('0');
 });
 
 test('shows saved batch count', () => {
@@ -60,8 +62,8 @@ test('shows saved batch count', () => {
     ],
   });
   renderScreen({ status });
-  screen.getByText(hasTextAcrossElements('Total Sheets: 4'));
-  screen.getByText(hasTextAcrossElements('Total Batches: 2'));
+  expect(screen.getByTestId('total-sheets')).toHaveTextContent('4');
+  expect(screen.getByTestId('total-batches')).toHaveTextContent('2');
 });
 
 test('shows the scanning batch in the control card, not the saved list', () => {
@@ -84,11 +86,10 @@ test('shows the scanning batch in the control card, not the saved list', () => {
   screen.getByText('Scanning');
   screen.getByText('Batch 1');
   screen.getByText('5');
-  screen.getByText('sheets scanned in this batch');
-  expect(screen.getButton('Stop')).toBeEnabled();
+  expect(screen.getButton('Stop Scanning')).toBeEnabled();
 
   // only the saved batch is counted in the summary
-  screen.getByText(hasTextAcrossElements('Total Batches: 1'));
+  expect(screen.getByTestId('total-batches')).toHaveTextContent('1');
 });
 
 test('stop button confirms, cancels the batch, and shows an info modal', async () => {
@@ -97,7 +98,7 @@ test('stop button confirms, cancels the batch, and shows an info modal', async (
     batches: [mockBatch({ id: 'a', count: 5, endedAt: undefined })],
   });
   renderScreen({ status });
-  userEvent.click(screen.getButton('Stop'));
+  userEvent.click(screen.getButton('Stop Scanning'));
 
   const confirmModal = await screen.findByRole('alertdialog');
   within(confirmModal).getByRole('heading', { name: 'Stop Scanning' });
@@ -133,7 +134,6 @@ describe('paused batch', () => {
     screen.getByText('Batch 1');
     screen.getByText('Input tray empty');
     screen.getByText('7');
-    screen.getByText('sheets scanned in this batch');
   });
 
   test('shows other pause reasons', () => {
@@ -159,6 +159,17 @@ describe('paused batch', () => {
     renderScreen({ status: pausedStatus });
     apiMock.expectContinueBatch();
     userEvent.click(screen.getButton('Continue Scanning'));
+  });
+
+  test('continue scanning is disabled when the scanner is disconnected', () => {
+    renderScreen({
+      status: { ...pausedStatus, isScannerAttached: false },
+    });
+    screen.getByText('Paused');
+    screen.getByText(/Connect the scanner to continue scanning/);
+    expect(screen.getButton('Continue Scanning')).toBeDisabled();
+    expect(screen.getButton('Save Batch')).toBeEnabled();
+    expect(screen.getButton('Discard Batch')).toBeEnabled();
   });
 
   test('save batch requires confirmation', async () => {
@@ -229,9 +240,16 @@ test('there is no manual Send CVRs button; batches are sent automatically', () =
 });
 
 describe('Scan Ballots Button', () => {
-  test('disabled when no scanner is attached', () => {
+  test('hidden and shows a disconnected status when no scanner is attached', () => {
     renderScreen({ status: mockStatus({ isScannerAttached: false }) });
-    expect(screen.getButton('No Scanner')).toBeDisabled();
+    screen.getByText('Scanner Disconnected');
+    expect(screen.queryByText('Ready to Scan')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Start Batch/ })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'No Scanner' })
+    ).not.toBeInTheDocument();
   });
 
   test('replaced by batch controls when there is an ongoing batch', () => {
@@ -244,7 +262,7 @@ describe('Scan Ballots Button', () => {
     expect(
       screen.queryByRole('button', { name: /Start Batch/ })
     ).not.toBeInTheDocument();
-    screen.getButton('Stop');
+    screen.getButton('Stop Scanning');
   });
 
   test('disabled when scan status is stale', () => {

--- a/apps/central-scan/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/central-scan/integration-testing/e2e/screenshots.spec.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import test from '@playwright/test';
+import test, { expect } from '@playwright/test';
 import { sleep } from '@votingworks/basics';
 import { mockElectionPackageFileTree } from '@votingworks/backend';
 import { getMockUsbDriveHandler } from '@votingworks/usb-drive';
@@ -130,9 +130,10 @@ test('screenshots', async ({ page }, testInfo) => {
       .getByRole('alertdialog')
       .getByRole('button', { name: 'Save Batch' })
       .click();
-    await page
-      .getByText(`Total Sheets: ${expectedSheets}`)
-      .waitFor({ timeout: 60000 });
+    await expect(page.getByTestId('total-sheets')).toHaveText(
+      String(expectedSheets),
+      { timeout: 60000 }
+    );
   }
 
   // Unconfigured: insert election manager card.
@@ -162,7 +163,7 @@ test('screenshots', async ({ page }, testInfo) => {
   await page.getByText(/Configuring VxCentralScan/).waitFor();
   await screenshot('configuring');
   await page.unroute('**/api/configureFromElectionPackageOnUsbDrive');
-  await page.getByText('Total Batches: 0').waitFor();
+  await expect(page.getByTestId('total-batches')).toHaveText('0');
 
   // Scan Ballots screen immediately after configuring, while still in test
   // mode (the switch to official mode happens below). Capture it plain, then
@@ -212,10 +213,10 @@ test('screenshots', async ({ page }, testInfo) => {
 
   // Empty Scan Ballots screen and its call-to-action highlights.
   await page.getByRole('button', { name: 'Scan Ballots' }).click();
-  await page.getByText('Total Batches: 0').waitFor();
+  await expect(page.getByTestId('total-batches')).toHaveText('0');
   await screenshot('scan-ballots-empty');
   await screenshotWithLocatorHighlight(
-    page.getByText('Total Batches: 0'),
+    page.getByTestId('batch-summary-stats'),
     'scan-ballots-empty-no-ballots-highlight'
   );
   await screenshotWithButtonHighlight(
@@ -277,7 +278,7 @@ test('screenshots', async ({ page }, testInfo) => {
     /* istanbul ignore next */
     if (!shownHeading) throw new Error('Unrecognized adjudication state');
 
-    await screenshot(remainingEjectStates.get(shownHeading) as string);
+    await screenshot(remainingEjectStates.get(shownHeading));
     remainingEjectStates.delete(shownHeading);
 
     await page.getByRole('button', { name: 'Confirm Ballot Removed' }).click();
@@ -299,9 +300,10 @@ test('screenshots', async ({ page }, testInfo) => {
     .getByRole('button', { name: 'Save Batch' })
     .click();
   expectedSheets += 1; // the good ballot that led the problem batch
-  await page
-    .getByText(`Total Sheets: ${expectedSheets}`)
-    .waitFor({ timeout: 60000 });
+  await expect(page.getByTestId('total-sheets')).toHaveText(
+    String(expectedSheets),
+    { timeout: 60000 }
+  );
 
   // Batch History page with batches present: highlight Save CVRs.
   await page.getByRole('button', { name: 'Batch History' }).click();


### PR DESCRIPTION
Co-authored with Claude Code

## Overview

Polishes the scan ballots status card in VxCentralScan

## Demo Video or Screenshot

## Testing Plan

Updated automated tests.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
