### PR TITLE
[ca-demo] VxDesign: finalize status for translations & audio

### DIFF
--- a/apps/design/backend/migrations/1784671743476_add-finalized-strings.js
+++ b/apps/design/backend/migrations/1784671743476_add-finalized-strings.js
@@ -1,0 +1,46 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  pgm.createTable(
+    'finalized_strings',
+    {
+      election_id: {
+        type: 'text',
+        notNull: true,
+        onDelete: 'CASCADE',
+        references: 'elections',
+      },
+      language_code: {
+        type: 'text',
+        notNull: true,
+      },
+      string_key: {
+        type: 'text',
+        notNull: true,
+      },
+      subkey: {
+        type: 'text',
+        notNull: true,
+        default: '',
+      },
+      finalized_at: {
+        type: 'timestamptz',
+        notNull: true,
+        default: pgm.func('now()'),
+      },
+    },
+    {
+      constraints: {
+        primaryKey: ['election_id', 'language_code', 'string_key', 'subkey'],
+      },
+    }
+  );
+};

--- a/apps/design/backend/src/bulk_translations.ts
+++ b/apps/design/backend/src/bulk_translations.ts
@@ -201,6 +201,13 @@ export function apiMethods(ctx: BulkTranslationsApiContext) {
         })),
       });
 
+      // A bulk upload rewrites this language's translations, so any prior
+      // per-string finalizations for the language no longer apply.
+      await ctx.workspace.store.finalizedStringsClearForLanguage({
+        electionId: input.electionId,
+        languageCode: input.language,
+      });
+
       return ok();
     },
 
@@ -234,6 +241,11 @@ export function apiMethods(ctx: BulkTranslationsApiContext) {
         input.electionId,
         input.language
       );
+
+      await ctx.workspace.store.finalizedStringsClearForLanguage({
+        electionId: input.electionId,
+        languageCode: input.language,
+      });
     },
 
     bulkTranslationUploadsGet(input: {

--- a/apps/design/backend/src/index.ts
+++ b/apps/design/backend/src/index.ts
@@ -52,7 +52,11 @@ export type {
 } from './features';
 export type { Api, AuthErrorCode, UnauthenticatedApi } from './app';
 export type { ConvertMsResultsError } from './convert_ms_results';
-export type { Translation, TranslationKey } from './tts_strings';
+export type {
+  FinalizedStringKey,
+  Translation,
+  TranslationKey,
+} from './tts_strings';
 
 export type { BallotTemplateId } from '@votingworks/hmpb';
 

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -3247,6 +3247,101 @@ export class Store {
     );
   }
 
+  /* istanbul ignore next - DEMO */
+  async finalizedStringsGet(input: {
+    electionId: string;
+    languageCode: string;
+  }): Promise<Array<{ stringKey: string; subkey: string }>> {
+    return this.db.withClient(async (client) => {
+      const res = await client.query(
+        `
+          select
+            string_key as "stringKey",
+            subkey
+          from finalized_strings
+          where election_id = $1 and language_code = $2
+        `,
+        input.electionId,
+        input.languageCode
+      );
+
+      return res.rows.map((row) => ({
+        stringKey: row.stringKey as string,
+        subkey: row.subkey as string,
+      }));
+    });
+  }
+
+  /* istanbul ignore next - DEMO */
+  async stringFinalizedSet(input: {
+    electionId: string;
+    languageCode: string;
+    stringKey: string;
+    subkey?: string;
+  }): Promise<void> {
+    return this.db.withClient(async (client) => {
+      await client.query(
+        `
+          insert into finalized_strings (
+            election_id,
+            language_code,
+            string_key,
+            subkey
+          )
+          values ($1, $2, $3, $4)
+          on conflict (election_id, language_code, string_key, subkey)
+            do nothing
+        `,
+        input.electionId,
+        input.languageCode,
+        input.stringKey,
+        input.subkey ?? ''
+      );
+    });
+  }
+
+  /* istanbul ignore next - DEMO */
+  async stringFinalizedDelete(input: {
+    electionId: string;
+    languageCode: string;
+    stringKey: string;
+    subkey?: string;
+  }): Promise<void> {
+    return this.db.withClient(async (client) => {
+      await client.query(
+        `
+          delete from finalized_strings
+          where
+            election_id = $1 and
+            language_code = $2 and
+            string_key = $3 and
+            subkey = $4
+        `,
+        input.electionId,
+        input.languageCode,
+        input.stringKey,
+        input.subkey ?? ''
+      );
+    });
+  }
+
+  /* istanbul ignore next - DEMO */
+  async finalizedStringsClearForLanguage(input: {
+    electionId: string;
+    languageCode: string;
+  }): Promise<void> {
+    return this.db.withClient(async (client) => {
+      await client.query(
+        `
+          delete from finalized_strings
+          where election_id = $1 and language_code = $2
+        `,
+        input.electionId,
+        input.languageCode
+      );
+    });
+  }
+
   async electionHasLiveReportData(
     electionId: string,
     ballotHash: string

--- a/apps/design/backend/src/tts_strings.ts
+++ b/apps/design/backend/src/tts_strings.ts
@@ -42,6 +42,17 @@ export interface Translation {
   forAudio: string;
 }
 
+// Identifies a single finalized string, keyed to match the sidebar/panel
+// identity in the proofing screen. `languageCode` is the selected language,
+// which may differ from a string's audio synthesis language (e.g. candidate
+// names are voiced in English).
+export interface FinalizedStringKey {
+  electionId: string;
+  languageCode: LanguageCode;
+  stringKey: string;
+  subkey?: string;
+}
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function apiMethods(ctx: TtsApiContext) {
   return {
@@ -114,6 +125,27 @@ export function apiMethods(ctx: TtsApiContext) {
 
     ttsEditsSet(input: TtsEditKey & { data: TtsEdit }): Promise<void> {
       return ctx.workspace.store.ttsEditsSet(input, input.data);
+    },
+
+    /* istanbul ignore next - DEMO */
+    async getFinalizedStrings(input: {
+      electionId: string;
+      language: LanguageCode;
+    }): Promise<Array<{ stringKey: string; subkey: string }>> {
+      return ctx.workspace.store.finalizedStringsGet({
+        electionId: input.electionId,
+        languageCode: input.language,
+      });
+    },
+
+    /* istanbul ignore next - DEMO */
+    async setStringFinalized(
+      input: FinalizedStringKey & { finalized: boolean }
+    ): Promise<void> {
+      const { finalized, ...key } = input;
+      return finalized
+        ? ctx.workspace.store.stringFinalizedSet(key)
+        : ctx.workspace.store.stringFinalizedDelete(key);
     },
 
     async ttsStringDefaults(input: {

--- a/apps/design/frontend/src/api.ts
+++ b/apps/design/frontend/src/api.ts
@@ -19,6 +19,7 @@ import {
   BallotType,
   ElectionId,
   ElectionSerializationFormat,
+  LanguageCode,
   PollingPlaceType,
   PrecinctSelection,
   TtsEditKey,
@@ -353,6 +354,33 @@ export const ttsEditsGet = {
   },
 } as const;
 
+/* istanbul ignore next - DEMO */
+export const getFinalizedStrings = {
+  queryKey(electionId: string, language: LanguageCode): QueryKey {
+    return ['finalizedStrings', electionId, language];
+  },
+  useQuery(electionId: string, language: LanguageCode) {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(electionId, language), () =>
+      apiClient.getFinalizedStrings({ electionId, language })
+    );
+  },
+} as const;
+
+/* istanbul ignore next - DEMO */
+export const setStringFinalized = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.setStringFinalized, {
+      onSuccess: (_, params) =>
+        queryClient.invalidateQueries(
+          getFinalizedStrings.queryKey(params.electionId, params.languageCode)
+        ),
+    });
+  },
+} as const;
+
 /* istanbul ignore next - WIP */
 export const ttsEditsSet = {
   useMutation() {
@@ -441,10 +469,13 @@ export const bulkTranslationClear = {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
     return useMutation(apiClient.bulkTranslationClear, {
-      async onSuccess(_data, { electionId }) {
+      async onSuccess(_data, { electionId, language }) {
         await queryClient.invalidateQueries(['translation']);
         await queryClient.invalidateQueries(
           bulkTranslationUploadsGet.queryKey(electionId)
+        );
+        await queryClient.invalidateQueries(
+          getFinalizedStrings.queryKey(electionId, language)
         );
       },
     });
@@ -457,10 +488,13 @@ export const bulkTranslationImport = {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
     return useMutation(apiClient.bulkTranslationImport, {
-      async onSuccess(_data, { electionId }) {
+      async onSuccess(_data, { electionId, language }) {
         await queryClient.invalidateQueries(['translation']);
         await queryClient.invalidateQueries(
           bulkTranslationUploadsGet.queryKey(electionId)
+        );
+        await queryClient.invalidateQueries(
+          getFinalizedStrings.queryKey(electionId, language)
         );
       },
     });

--- a/apps/design/frontend/src/ballot_audio/audio_editor.test.tsx
+++ b/apps/design/frontend/src/ballot_audio/audio_editor.test.tsx
@@ -47,6 +47,7 @@ test('defaults to plain text editor if no saved edits exist', async () => {
     languageCode,
     jurisdictionId,
     ttsDefault,
+    finalized: false,
   });
 
   await screen.findByTestId(TEXT_EDITOR_TEST_ID);
@@ -83,6 +84,7 @@ test.skip('picks initial editor based on saved edits', async () => {
     languageCode,
     jurisdictionId,
     ttsDefault,
+    finalized: false,
   });
 
   await screen.findByText(PHONETIC_EDITOR_CONTENT);
@@ -120,6 +122,7 @@ test.skip('supports switching between text and phonetic editing', async () => {
     languageCode,
     jurisdictionId,
     ttsDefault,
+    finalized: false,
   });
 
   // Start with phonetic:
@@ -163,6 +166,7 @@ test('text mode - not editable after ballots are finalized', async () => {
     languageCode,
     jurisdictionId,
     ttsDefault,
+    finalized: false,
   });
 
   await screen.findByTestId(TEXT_EDITOR_TEST_ID);
@@ -196,6 +200,7 @@ test.skip('phonetic mode - not editable after ballots are finalized', async () =
     languageCode,
     jurisdictionId,
     ttsDefault,
+    finalized: false,
   });
 
   await screen.findByText(PHONETIC_EDITOR_CONTENT);

--- a/apps/design/frontend/src/ballot_audio/audio_editor.tsx
+++ b/apps/design/frontend/src/ballot_audio/audio_editor.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import React from 'react';
 
 import { throwIllegalValue } from '@votingworks/basics';
-import { TtsStringDefault } from '@votingworks/design-backend';
+import type { TtsStringDefault } from '@votingworks/design-backend';
 import { LanguageCode, phonemes, TtsExportSource } from '@votingworks/types';
 import { H3, RadioGroup, RadioGroupOption } from '@votingworks/ui';
 
@@ -44,11 +44,18 @@ export interface AudioEditorProps {
   languageCode: LanguageCode;
   jurisdictionId: string;
   ttsDefault: TtsStringDefault;
+  finalized: boolean;
 }
 
 export function AudioEditor(props: AudioEditorProps): React.ReactNode {
-  const { electionId, hackyKey, languageCode, jurisdictionId, ttsDefault } =
-    props;
+  const {
+    electionId,
+    hackyKey,
+    languageCode,
+    jurisdictionId,
+    ttsDefault,
+    finalized,
+  } = props;
   const [mode, setMode] = React.useState<TtsExportSource | null>(null);
 
   const ballotsFinalizedAt = api.getBallotsFinalizedAt.useQuery(electionId);
@@ -78,7 +85,7 @@ export function AudioEditor(props: AudioEditorProps): React.ReactNode {
   }
 
   const currentMode = mode || defaultMode;
-  const editable = !ballotsFinalizedAt.data;
+  const editable = !ballotsFinalizedAt.data && !finalized;
 
   return (
     <React.Fragment>

--- a/apps/design/frontend/src/ballot_audio/audio_editor_panel.test.tsx
+++ b/apps/design/frontend/src/ballot_audio/audio_editor_panel.test.tsx
@@ -32,7 +32,16 @@ test('renders editor, along with a preview of the original text', () => {
   };
 
   const mockApi = createMockApiClient();
-  setUpEditorMock({ electionId, languageCode, jurisdictionId, ttsDefault });
+  mockApi.getFinalizedStrings
+    .expectCallWith({ electionId, language: languageCode })
+    .resolves([]);
+  setUpEditorMock({
+    electionId,
+    languageCode,
+    jurisdictionId,
+    ttsDefault,
+    finalized: false,
+  });
 
   const header = <h1>Election Audio: State</h1>;
 
@@ -67,7 +76,16 @@ test('renders contest descriptions using original, unstripped HTML', async () =>
     subkey: mockContest.id,
     text: 'Do you agree?',
   };
-  setUpEditorMock({ electionId, languageCode, jurisdictionId, ttsDefault });
+  mockApi.getFinalizedStrings
+    .expectCallWith({ electionId, language: languageCode })
+    .resolves([]);
+  setUpEditorMock({
+    electionId,
+    languageCode,
+    jurisdictionId,
+    ttsDefault,
+    finalized: false,
+  });
 
   renderPanel(mockApi, {
     electionId,

--- a/apps/design/frontend/src/ballot_audio/audio_editor_panel.tsx
+++ b/apps/design/frontend/src/ballot_audio/audio_editor_panel.tsx
@@ -39,6 +39,17 @@ export function AudioEditorPanel(
   const { electionId, header, languageCode, jurisdictionId, ttsDefault } =
     props;
 
+  // Strings finalized on the proofing screen must be locked here too, since
+  // TTS edits are shared across all audio editing surfaces.
+  const finalizedStrings = api.getFinalizedStrings.useQuery(
+    electionId,
+    languageCode
+  ).data;
+  const finalized = !!finalizedStrings?.some(
+    (s) =>
+      s.stringKey === ttsDefault.key && s.subkey === (ttsDefault.subkey ?? '')
+  );
+
   return (
     <Container>
       <div>{header}</div>
@@ -60,6 +71,7 @@ export function AudioEditorPanel(
         languageCode={languageCode}
         jurisdictionId={jurisdictionId}
         ttsDefault={ttsDefault}
+        finalized={finalized}
       />
     </Container>
   );

--- a/apps/design/frontend/src/ballot_audio/proofing_screen.tsx
+++ b/apps/design/frontend/src/ballot_audio/proofing_screen.tsx
@@ -295,6 +295,12 @@ export function LanguageProofingScreen(): React.ReactNode {
   const getElectionInfoQuery = api.getElectionInfo.useQuery(electionId);
 
   const stringDefaults = api.ttsStringDefaults.useQuery(electionId).data;
+  const finalizedStrings = api.getFinalizedStrings.useQuery(
+    electionId,
+    language
+  ).data;
+  const ballotsFinalized =
+    !!api.getBallotsFinalizedAt.useQuery(electionId).data;
   const currentString = React.useMemo(() => {
     for (const appString of stringDefaults || []) {
       if (appString.key !== stringKey || appString.subkey !== subkey) continue;
@@ -329,6 +335,25 @@ export function LanguageProofingScreen(): React.ReactNode {
 
   const election = getElectionInfoQuery.data;
 
+  const finalizedSet = new Set(
+    (finalizedStrings ?? []).map((f) =>
+      finalizedLookupKey(f.stringKey, f.subkey)
+    )
+  );
+  const currentFinalized =
+    !!currentString &&
+    finalizedSet.has(
+      finalizedLookupKey(currentString.key, currentString.subkey)
+    );
+  // A string is locked from editing when finalized individually or when the
+  // whole election's ballots have been finalized.
+  let lockReason: TranslationLockReason | undefined;
+  if (ballotsFinalized) {
+    lockReason = 'ballotsFinalized';
+  } else if (currentFinalized) {
+    lockReason = 'stringFinalized';
+  }
+
   return (
     <Container>
       <SideBarContainer>
@@ -349,7 +374,13 @@ export function LanguageProofingScreen(): React.ReactNode {
           </SearchBox>
           <StringSnippets>
             {searchResults.map((string) => (
-              <StringSnippet key={joinStringKey(string)} string={string} />
+              <StringSnippet
+                key={joinStringKey(string)}
+                string={string}
+                finalized={finalizedSet.has(
+                  finalizedLookupKey(string.key, string.subkey)
+                )}
+              />
             ))}
           </StringSnippets>
         </SideBar>
@@ -357,6 +388,15 @@ export function LanguageProofingScreen(): React.ReactNode {
       <Body>
         {currentString && (
           <StringPanel>
+            <FinalizeToggle
+              electionId={electionId}
+              language={language}
+              stringKey={currentString.key}
+              subkey={currentString.subkey}
+              finalized={currentFinalized}
+              disabled={ballotsFinalized}
+            />
+
             <StringInfo
               stringKey={currentString.key}
               subkey={currentString.subkey}
@@ -375,6 +415,7 @@ export function LanguageProofingScreen(): React.ReactNode {
                 }
                 stringKey={currentString.key}
                 subKey={currentString.subkey}
+                lockReason={lockReason}
               />
             )}
 
@@ -386,6 +427,7 @@ export function LanguageProofingScreen(): React.ReactNode {
                   ? ENGLISH
                   : language
               }
+              finalized={currentFinalized}
             />
           </StringPanel>
         )}
@@ -398,8 +440,9 @@ function LanguageAudioEditor(props: {
   election: ElectionInfo;
   language: LanguageCode;
   englishDefault: TtsStringDefault;
+  finalized: boolean;
 }) {
-  const { election, englishDefault, language } = props;
+  const { election, englishDefault, language, finalized } = props;
 
   const translation = api.translationGet.useQuery({
     electionId: election.electionId,
@@ -427,6 +470,7 @@ function LanguageAudioEditor(props: {
         }
         jurisdictionId={election.jurisdictionId}
         ttsDefault={ttsDefault}
+        finalized={finalized}
       />
     </Card>
   );
@@ -435,6 +479,80 @@ function LanguageAudioEditor(props: {
 // [TODO] Actual fuzzy match?
 function isMatchFuzzy(haystack: string, needle: string) {
   return haystack.toLowerCase().includes(needle.trim().toLowerCase());
+}
+
+// Stable lookup key for a finalized string, matching the backend's
+// (stringKey, subkey) identity. A space separator is safe because string keys
+// (ElectionStringKey values) never contain spaces.
+function finalizedLookupKey(stringKey: string, subkey?: string): string {
+  return `${stringKey} ${subkey ?? ''}`;
+}
+
+const FinalizeBar = styled.div<{ finalized: boolean }>`
+  align-items: center;
+  background: ${(p) =>
+    p.finalized ? DesktopPalette.Purple10 : DesktopPalette.Gray5};
+  border: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid
+    ${DesktopPalette.Gray30};
+  border-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  max-width: 75ch;
+  padding: 0.5rem 0.5rem 0.5rem 1rem;
+`;
+
+const FinalizeStatus = styled.div`
+  align-items: center;
+  display: flex;
+  font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
+  gap: 0.5rem;
+`;
+
+function FinalizeToggle(props: {
+  electionId: string;
+  language: LanguageCode;
+  stringKey: ElectionStringKey;
+  subkey?: string;
+  finalized: boolean;
+  disabled: boolean;
+}) {
+  const { electionId, language, stringKey, subkey, finalized, disabled } =
+    props;
+  const mutation = api.setStringFinalized.useMutation();
+
+  return (
+    <FinalizeBar finalized={finalized}>
+      <FinalizeStatus>
+        {finalized ? (
+          <React.Fragment>
+            <Icons.Done color="primary" /> Finalized
+          </React.Fragment>
+        ) : (
+          <React.Fragment>
+            <Icons.Circle color="warning" /> Not Finalized
+          </React.Fragment>
+        )}
+      </FinalizeStatus>
+      <Button
+        disabled={disabled || mutation.isLoading}
+        icon={finalized ? 'RotateLeft' : 'Done'}
+        color={finalized ? 'neutral' : 'primary'}
+        fill="outlined"
+        onPress={() =>
+          mutation.mutate({
+            electionId,
+            languageCode: language,
+            stringKey,
+            subkey,
+            finalized: !finalized,
+          })
+        }
+      >
+        {finalized ? 'Unfinalize' : 'Finalize'}
+      </Button>
+    </FinalizeBar>
+  );
 }
 
 const TranslationContainer = styled(Card)`
@@ -472,13 +590,30 @@ const StringKey = styled(Caption)`
   white-space: nowrap;
 `;
 
+type TranslationLockReason = 'stringFinalized' | 'ballotsFinalized';
+
+function TranslationLockMessage(props: {
+  lockReason: TranslationLockReason;
+}): JSX.Element {
+  const { lockReason } = props;
+  return (
+    <React.Fragment>
+      <Icons.Lock style={{ marginRight: '0.5rem' }} />
+      {lockReason === 'stringFinalized'
+        ? 'This string is finalized. Unfinalize it to edit the translation.'
+        : 'Ballots are finalized, so the translation may not be edited.'}
+    </React.Fragment>
+  );
+}
+
 function Translation(props: {
   electionId: string;
   stringKey: ElectionStringKey;
   subKey?: string;
   language: LanguageCode;
+  lockReason?: TranslationLockReason;
 }) {
-  const { electionId, language, stringKey, subKey } = props;
+  const { electionId, language, stringKey, subKey, lockReason } = props;
   const [edit, setEdit] = React.useState<string>();
 
   const englishOnly = stringKey === ElectionStringKey.CANDIDATE_NAME;
@@ -511,9 +646,11 @@ function Translation(props: {
     );
   }
 
+  const editable = !englishOnly && !lockReason;
+
   return (
     <TranslationContainer header={<H3>Translation</H3>}>
-      {!englishOnly && (
+      {editable && (
         <div>
           <Icons.ChevronRight style={{ marginRight: '0.5rem' }} />
           Edit the following text to change the translation shown on voter
@@ -525,6 +662,12 @@ function Translation(props: {
         <div>
           <Icons.Info style={{ marginRight: '0.5rem' }} />
           Candidate names are displayed in English for ballots in this language.
+        </div>
+      )}
+
+      {lockReason && !englishOnly && (
+        <div>
+          <TranslationLockMessage lockReason={lockReason} />
         </div>
       )}
 
@@ -543,8 +686,8 @@ function Translation(props: {
 
         <TextArea
           dir={IS_RTL[language] ? 'rtl' : undefined}
-          editable={!englishOnly}
-          disabled={saving || englishOnly}
+          editable={editable}
+          disabled={saving || !editable}
           id="ttsTextEditor"
           name="ttsText"
           onChange={(event) => setEdit(event.target.value)}
@@ -556,7 +699,7 @@ function Translation(props: {
           value={edit || translation.forDisplay}
         />
       </Editor>
-      {!englishOnly && (
+      {editable && (
         <FormButtons>
           {changed && (
             <Button
@@ -606,8 +749,11 @@ function RichTextTranslation(props: {
   stringKey: ElectionStringKey;
   subKey?: string;
   translation: Translation;
+  lockReason?: TranslationLockReason;
 }) {
-  const { electionId, language, stringKey, subKey, translation } = props;
+  const { electionId, language, stringKey, subKey, translation, lockReason } =
+    props;
+  const readOnly = !!lockReason;
   const [edit, setEdit] = React.useState<string>();
   const [resets, setResets] = React.useState<number>(0);
 
@@ -621,46 +767,55 @@ function RichTextTranslation(props: {
   return (
     <TranslationContainer header={<H3>Translation</H3>}>
       <div>
-        <Icons.ChevronRight style={{ marginRight: '0.5rem' }} />
-        Edit the following text to change the translation shown on voter
-        ballots:
+        {lockReason ? (
+          <TranslationLockMessage lockReason={lockReason} />
+        ) : (
+          <React.Fragment>
+            <Icons.ChevronRight style={{ marginRight: '0.5rem' }} />
+            Edit the following text to change the translation shown on voter
+            ballots:
+          </React.Fragment>
+        )}
       </div>
       <DescriptionEditor
         dir={IS_RTL[language] ? 'rtl' : undefined}
+        disabled={readOnly}
         initialHtmlContent={edit || translation.forDisplay}
         key={`${stringKey}-${subKey}-${language}-${resets}`}
         onChange={setEdit}
       />
-      <FormButtons>
-        {changed && (
+      {!readOnly && (
+        <FormButtons>
+          {changed && (
+            <Button
+              disabled={saving}
+              onPress={() => {
+                setEdit(undefined);
+                setResets(resets + 1);
+              }}
+              type="reset"
+            >
+              Cancel
+            </Button>
+          )}
           <Button
-            disabled={saving}
-            onPress={() => {
-              setEdit(undefined);
-              setResets(resets + 1);
+            disabled={saveDisabled}
+            icon={saving ? 'Loading' : 'Save'}
+            onPress={translationSet}
+            value={{
+              electionId,
+              language,
+              stringKey,
+              subKey,
+              text: edit || '',
             }}
-            type="reset"
+            type="submit"
+            variant={saveDisabled ? 'neutral' : 'primary'}
           >
-            Cancel
+            {saving ? 'Saving...' : 'Save'}
           </Button>
-        )}
-        <Button
-          disabled={saveDisabled}
-          icon={saving ? 'Loading' : 'Save'}
-          onPress={translationSet}
-          value={{
-            electionId,
-            language,
-            stringKey,
-            subKey,
-            text: edit || '',
-          }}
-          type="submit"
-          variant={saveDisabled ? 'neutral' : 'primary'}
-        >
-          {saving ? 'Saving...' : 'Save'}
-        </Button>
-      </FormButtons>
+        </FormButtons>
+      )}
     </TranslationContainer>
   );
 }
@@ -1178,11 +1333,13 @@ const StringSnippetContainer = styled(Link)`
   border-bottom: 1px solid #eee;
   box-shadow: inset 0 0 0 ${DesktopPalette.Purple40};
   box-sizing: border-box;
+  align-items: center;
   color: ${(p) => p.theme.colors.onBackground} !important;
   cursor: pointer;
-  display: block;
+  display: flex;
   font-size: 1rem;
   font-weight: ${(p) => p.theme.sizes.fontWeight.regular} !important;
+  gap: 0.5rem;
   margin: 0;
   min-height: max-content;
   overflow-x: hidden;
@@ -1190,11 +1347,9 @@ const StringSnippetContainer = styled(Link)`
   padding: 0.75rem;
   text-align: left;
   text-decoration: none;
-  text-overflow: ellipsis;
   transition-duration: 120ms;
   transition-property: background-color, border, color;
   transition-timing-function: ease-out;
-  white-space: nowrap;
 
   :focus,
   :hover {
@@ -1214,8 +1369,19 @@ const StringSnippetContainer = styled(Link)`
   }
 `;
 
-function StringSnippet(props: { string: TtsStringDefault }) {
-  const { string } = props;
+const SnippetText = styled.span`
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+function StringSnippet(props: {
+  string: TtsStringDefault;
+  finalized: boolean;
+}) {
+  const { string, finalized } = props;
   const {
     electionId,
     stringKey,
@@ -1235,7 +1401,12 @@ function StringSnippet(props: { string: TtsStringDefault }) {
       }
       role="option"
     >
-      {string.text}
+      <SnippetText>{string.text}</SnippetText>
+      {finalized ? (
+        <Icons.Done color="primary" style={{ flexShrink: 0 }} />
+      ) : (
+        <Icons.Circle color="warning" style={{ flexShrink: 0 }} />
+      )}
     </StringSnippetContainer>
   );
 }

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -80,6 +80,7 @@ import {
   faSortDown,
   faTowerBroadcast,
   faRotate,
+  faRotateLeft,
   faEnvelope,
   faFlag,
   faSortUp,
@@ -617,6 +618,10 @@ export const Icons = {
 
   Rotate(props) {
     return <FaIcon {...props} flipInRtlMode={false} type={faRotate} />;
+  },
+
+  RotateLeft(props) {
+    return <FaIcon {...props} flipInRtlMode={false} type={faRotateLeft} />;
   },
 
   RotateRight(props) {


### PR DESCRIPTION
🤖 Generated with Claude Code

## Overview

Task: #8921

With a large translation and audio team, there's no way to track which election strings are complete and reviewed. This adds a per-string, per-language Finalize toggle to the Language and Audio proofing screen: finalizing a string locks its translation and audio from editing (same lock model as ballot finalize, including the standalone audio editor panels), and the sidebar shows per-string status icons. Bulk translation import/clear resets finalizations for that language, since imported translations haven't been re-reviewed.

## Demo Video or Screenshot

## Testing Plan

No new automated tests (demo branch). Migration validation, coverage suites, lint, and type-check pass locally for design backend/frontend and libs/ui.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
