### PR TITLE
[ca-demo] Networking resiliency improvements

### DIFF
--- a/apps/admin/backend/src/globals.ts
+++ b/apps/admin/backend/src/globals.ts
@@ -46,7 +46,7 @@ export const PEER_PORT = Number(process.env['PEER_PORT'] || PORT + 1);
 export const NETWORK_POLLING_INTERVAL_MS = 2 * 1000;
 
 /**  Network request timeout (in milliseconds) */
-export const NETWORK_REQUEST_TIMEOUT_MS = 1 * 1000;
+export const NETWORK_REQUEST_TIMEOUT_MS = 3 * 1000;
 
 /** How long to wait before considering a machine stale (in milliseconds) */
 export const STALE_MACHINE_THRESHOLD_MS = 10 * 1000;

--- a/apps/central-scan/backend/src/app.cvr_sync.test.ts
+++ b/apps/central-scan/backend/src/app.cvr_sync.test.ts
@@ -71,9 +71,11 @@ interface MockHost {
 function startMockHost({
   refuseTransfer = false,
   rejectCvrs = false,
+  hangCvrs = false,
 }: {
   refuseTransfer?: boolean;
   rejectCvrs?: boolean;
+  hangCvrs?: boolean;
 } = {}): MockHost {
   const mockHost: Omit<MockHost, 'address'> = {
     startInputs: [],
@@ -86,6 +88,10 @@ function startMockHost({
     const chunks: Buffer[] = [];
     req.on('data', (chunk) => chunks.push(chunk));
     req.on('end', () => {
+      if (hangCvrs) {
+        // Never respond, simulating a hung connection
+        return;
+      }
       if (rejectCvrs) {
         res.status(400).json({ error: 'invalid-cast-vote-record' });
         return;
@@ -318,6 +324,29 @@ test('a batch stays unsent and the error is surfaced when the host rejects a cas
       expect(mockHost.finishedSessionIds).toHaveLength(0);
     },
     { adminHostClient: mockAdminHostClient(mockHost.address) }
+  );
+});
+
+test('a batch stays unsent and a timeout error is surfaced when a cast vote record upload hangs', async () => {
+  const mockHost = startMockHost({ hangCvrs: true });
+
+  await withApp(
+    async (context) => {
+      await configureApp(context);
+      await scanAndSaveBatch(context);
+
+      await context.cvrSync?.triggerSync();
+      const syncStatus = await context.apiClient.getCvrSyncStatus();
+      expect(syncStatus.unsentBatchCount).toEqual(1);
+      expect(syncStatus.lastError).toEqual(
+        'Upload timed out after 0.1 seconds.'
+      );
+      expect(mockHost.finishedSessionIds).toHaveLength(0);
+    },
+    {
+      adminHostClient: mockAdminHostClient(mockHost.address),
+      cvrSyncUploadTimeoutMs: 100,
+    }
   );
 });
 

--- a/apps/central-scan/backend/src/cvr_sync.ts
+++ b/apps/central-scan/backend/src/cvr_sync.ts
@@ -22,7 +22,11 @@ import { AdminHostClient, HostConnection } from './networking';
 import { zipFilesToBuffer } from './util/zip';
 import { getMachineConfig } from './machine_config';
 import { CvrSyncStatus, SendCastVoteRecordsToHostError } from './types';
-import { CVR_SYNC_INTERVAL_MS, CVR_SYNC_RETRY_BACKOFF_MS } from './globals';
+import {
+  CVR_SYNC_INTERVAL_MS,
+  CVR_SYNC_RETRY_BACKOFF_MS,
+  CVR_UPLOAD_TIMEOUT_MS,
+} from './globals';
 
 const debug = makeDebug('scan:cvr-sync');
 
@@ -70,12 +74,14 @@ async function sendBatchToHost({
   logger,
   batch,
   onProgress,
+  uploadTimeoutMs,
 }: {
   workspace: Workspace;
   hostConnection: HostConnection;
   logger: Logger;
   batch: BatchInfo;
   onProgress: (sheetsSent: number, sheetsTotal: number) => void;
+  uploadTimeoutMs: number;
 }): Promise<
   Result<
     { newlyAdded: number; alreadyPresent: number },
@@ -148,6 +154,7 @@ async function sendBatchToHost({
         method: 'POST',
         headers: { 'content-type': 'application/zip' },
         body: zipBuffer,
+        signal: AbortSignal.timeout(uploadTimeoutMs),
       });
       if (!response.ok) {
         const message = `Host responded with status ${
@@ -180,7 +187,12 @@ async function sendBatchToHost({
     }
     return ok(finishResult.ok());
   } catch (error) {
-    const message = error instanceof Error ? error.message : `${error}`;
+    const message =
+      error instanceof Error && error.name === 'AbortError'
+        ? `Upload timed out after ${uploadTimeoutMs / 1000} seconds.`
+        : /* istanbul ignore next */ error instanceof Error
+        ? error.message
+        : /* istanbul ignore next */ `${error}`;
     logFailure(message);
     return err({ type: 'upload-failed', message });
   }
@@ -198,11 +210,13 @@ export function startCvrSync({
   adminHostClient,
   logger,
   pollingIntervalMs = CVR_SYNC_INTERVAL_MS,
+  uploadTimeoutMs = CVR_UPLOAD_TIMEOUT_MS,
 }: {
   workspace: Workspace;
   adminHostClient: AdminHostClient;
   logger: Logger;
   pollingIntervalMs?: number;
+  uploadTimeoutMs?: number;
 }): CvrSync {
   const { store } = workspace;
   let state: CvrSyncStatus['state'] = 'idle';
@@ -249,6 +263,7 @@ export function startCvrSync({
               sheetsSent,
               sheetsTotal,
             }),
+          uploadTimeoutMs,
         });
         if (result.isErr()) {
           lastError = describeSendError(result.err());

--- a/apps/central-scan/backend/src/globals.ts
+++ b/apps/central-scan/backend/src/globals.ts
@@ -39,7 +39,7 @@ export const NETWORK_POLLING_INTERVAL_MS = 2000;
 /**
  * Timeout for requests to a VxAdmin host's peer API.
  */
-export const NETWORK_REQUEST_TIMEOUT_MS = 1000;
+export const NETWORK_REQUEST_TIMEOUT_MS = 3000;
 
 /**
  * How often the background sync checks for saved batches that haven't been
@@ -53,6 +53,14 @@ export const CVR_SYNC_INTERVAL_MS = 2000;
  * sessions every polling tick.
  */
 export const CVR_SYNC_RETRY_BACKOFF_MS = 15_000;
+
+/**
+ * Timeout for uploading a single cast vote record to a VxAdmin host. Generous
+ * relative to {@link NETWORK_REQUEST_TIMEOUT_MS} since uploads carry ballot
+ * images. Without a timeout, a hung connection would stall the sync loop
+ * indefinitely.
+ */
+export const CVR_UPLOAD_TIMEOUT_MS = 30_000;
 
 /**
  * Dev override for the VxAdmin host peer API address, e.g.

--- a/apps/central-scan/backend/test/helpers/setup_app.ts
+++ b/apps/central-scan/backend/test/helpers/setup_app.ts
@@ -55,6 +55,7 @@ export async function withApp(
   options: {
     adminHostClient?: AdminHostClient;
     cvrSyncPollingIntervalMs?: number;
+    cvrSyncUploadTimeoutMs?: number;
     isDeskProScanner?: boolean;
   } = {}
 ): Promise<void> {
@@ -74,6 +75,7 @@ export async function withApp(
         adminHostClient: options.adminHostClient,
         logger,
         pollingIntervalMs: options.cvrSyncPollingIntervalMs,
+        uploadTimeoutMs: options.cvrSyncUploadTimeoutMs,
       })
     : undefined;
   const app = buildCentralScannerApp({


### PR DESCRIPTION
Upon further reflection the NETWORK_REQUEST_TIMEOUT_MS I had at 1s previously may be unnecessarily aggresive. I've seen imaged machines flicker when connected, bumping this could be an easy way to improve that that seems safe to try. 

Separately in discussion with claude around possible network bugs or issues it identified that we are not aborting on requests when the central-scan process is uploading a single cvr, if the connection died in that moment we could end up stuck hanging forever, so this adds a conservative 30s abort timeout to avoid a possible confusing stuck failure in that unlikely event. 