### PR TITLE
[ca-demo] VxDesign: transliterate candidate names for non-Latin-script languages

### DIFF
--- a/apps/design/backend/src/tts_strings.ts
+++ b/apps/design/backend/src/tts_strings.ts
@@ -45,7 +45,7 @@ export interface Translation {
 // Identifies a single finalized string, keyed to match the sidebar/panel
 // identity in the proofing screen. `languageCode` is the selected language,
 // which may differ from a string's audio synthesis language (e.g. candidate
-// names are voiced in English).
+// names are voiced in English for languages that don't transliterate names).
 export interface FinalizedStringKey {
   electionId: string;
   languageCode: LanguageCode;

--- a/apps/design/frontend/src/ballot_audio/proofing_screen.tsx
+++ b/apps/design/frontend/src/ballot_audio/proofing_screen.tsx
@@ -24,6 +24,7 @@ import {
   ElectionStringKey,
   LanguageCode,
   IS_RTL,
+  NEEDS_TRANSLITERATED_NAMES,
   StraightPartyContest,
   YesNoContest,
   hasSplits,
@@ -42,6 +43,20 @@ import { RichTextEditor } from '../rich_text_editor';
 import { cssThemedScrollbars } from '../scrollbars';
 
 const { ENGLISH } = LanguageCode;
+
+// Candidate names aren't translated like other election strings: for
+// languages written in a non-Latin script they're phonetically transliterated
+// via the translation API, and for all other languages they're kept in
+// English.
+function stringLanguage(
+  stringKey: ElectionStringKey,
+  language: LanguageCode
+): LanguageCode {
+  return stringKey === ElectionStringKey.CANDIDATE_NAME &&
+    !NEEDS_TRANSLITERATED_NAMES[language]
+    ? ENGLISH
+    : language;
+}
 
 const Container = styled.div`
   box-sizing: border-box;
@@ -407,12 +422,7 @@ export function LanguageProofingScreen(): React.ReactNode {
               <Translation
                 electionId={electionId}
                 key={`${stringKey}-${subkey}-${language}`}
-                language={
-                  // [TODO] Allow languages that support transliterated names.
-                  stringKey === ElectionStringKey.CANDIDATE_NAME
-                    ? ENGLISH
-                    : language
-                }
+                language={stringLanguage(currentString.key, language)}
                 stringKey={currentString.key}
                 subKey={currentString.subkey}
                 lockReason={lockReason}
@@ -422,11 +432,7 @@ export function LanguageProofingScreen(): React.ReactNode {
             <LanguageAudioEditor
               election={election}
               englishDefault={currentString}
-              language={
-                stringKey === ElectionStringKey.CANDIDATE_NAME
-                  ? ENGLISH
-                  : language
-              }
+              language={stringLanguage(currentString.key, language)}
               finalized={currentFinalized}
             />
           </StringPanel>
@@ -463,11 +469,7 @@ function LanguageAudioEditor(props: {
       <AudioEditor
         electionId={election.electionId}
         hackyKey={`${englishDefault.key}-${englishDefault.subkey}`}
-        languageCode={
-          englishDefault.key === ElectionStringKey.CANDIDATE_NAME
-            ? ENGLISH
-            : language
-        }
+        languageCode={language}
         jurisdictionId={election.jurisdictionId}
         ttsDefault={ttsDefault}
         finalized={finalized}
@@ -616,7 +618,10 @@ function Translation(props: {
   const { electionId, language, stringKey, subKey, lockReason } = props;
   const [edit, setEdit] = React.useState<string>();
 
-  const englishOnly = stringKey === ElectionStringKey.CANDIDATE_NAME;
+  // Candidate names are passed through `stringLanguage`, so `language` is
+  // English when the name isn't transliterated for the selected language.
+  const englishOnly =
+    stringKey === ElectionStringKey.CANDIDATE_NAME && language === ENGLISH;
 
   const translation = api.translationGet.useQuery({
     electionId,

--- a/libs/backend/src/language_and_audio/ballot_strings.test.ts
+++ b/libs/backend/src/language_and_audio/ballot_strings.test.ts
@@ -71,13 +71,19 @@ describe('translateBallotStrings', () => {
       LanguageCode.CHINESE_TRADITIONAL,
       LanguageCode.SPANISH,
     ]);
-    for (const languageCode of Object.keys(result)) {
-      if (languageCode === LanguageCode.ENGLISH) {
-        continue; // tested above
-      }
+    // Chinese uses a non-Latin script, so it additionally includes
+    // transliterated candidate names; Spanish keeps them in English only.
+    const expectedKeyCounts: Record<string, number> = {
+      [LanguageCode.CHINESE_SIMPLIFIED]: 17,
+      [LanguageCode.CHINESE_TRADITIONAL]: 17,
+      [LanguageCode.SPANISH]: 16,
+    };
+    for (const [languageCode, expectedKeyCount] of Object.entries(
+      expectedKeyCounts
+    )) {
       const subResults = result[languageCode];
       assert(subResults);
-      expect(Object.keys(subResults)).toHaveLength(16);
+      expect(Object.keys(subResults)).toHaveLength(expectedKeyCount);
     }
   });
 });

--- a/libs/backend/src/language_and_audio/election_strings.test.ts
+++ b/libs/backend/src/language_and_audio/election_strings.test.ts
@@ -3,7 +3,11 @@ import {
   electionPrimaryPrecinctSplitsFixtures,
   electionTwoPartyPrimaryFixtures,
 } from '@votingworks/fixtures';
-import { LanguageCode, BallotLanguageConfigs } from '@votingworks/types';
+import {
+  LanguageCode,
+  BallotLanguageConfigs,
+  ElectionStringKey,
+} from '@votingworks/types';
 import { assert } from '@votingworks/basics';
 import { extractAndTranslateElectionStrings } from './election_strings';
 import { GoogleCloudTranslator } from './translator';
@@ -14,6 +18,9 @@ const englishOnlyConfig: BallotLanguageConfigs = [
 ];
 const englishSpanishLanguageConfig: BallotLanguageConfigs = [
   { languages: [LanguageCode.ENGLISH, LanguageCode.SPANISH] },
+];
+const englishChineseLanguageConfig: BallotLanguageConfigs = [
+  { languages: [LanguageCode.ENGLISH, LanguageCode.CHINESE_SIMPLIFIED] },
 ];
 
 describe('extractAndTranslateElectionStrings', () => {
@@ -75,5 +82,33 @@ describe('extractAndTranslateElectionStrings', () => {
     assert(spanishResults);
     // Should translate all the same fields
     expect(spanishResults).toMatchSnapshot();
+    // Spanish uses a Latin script, so candidate names stay English-only
+    expect(spanishResults[ElectionStringKey.CANDIDATE_NAME]).toBeUndefined();
+  });
+
+  test('should transliterate candidate names for languages with non-Latin scripts', async () => {
+    const translationClient = makeMockGoogleCloudTranslationClient({
+      fn: vi.fn,
+    });
+    const mockTranslator = new GoogleCloudTranslator({ translationClient });
+    const result = await extractAndTranslateElectionStrings(
+      mockTranslator,
+      electionPrimaryPrecinctSplitsFixtures.readElection(),
+      englishChineseLanguageConfig
+    );
+
+    const englishResults = result[LanguageCode.ENGLISH];
+    const chineseResults = result[LanguageCode.CHINESE_SIMPLIFIED];
+    assert(englishResults);
+    assert(chineseResults);
+
+    const englishNames = englishResults[ElectionStringKey.CANDIDATE_NAME];
+    const chineseNames = chineseResults[ElectionStringKey.CANDIDATE_NAME];
+    assert(typeof englishNames === 'object');
+    assert(typeof chineseNames === 'object');
+
+    expect(englishNames['horse']).toEqual('Horse');
+    expect(chineseNames['horse']).toEqual('Horse (in zh-Hans)');
+    expect(Object.keys(chineseNames)).toEqual(Object.keys(englishNames));
   });
 });

--- a/libs/backend/src/language_and_audio/election_strings.ts
+++ b/libs/backend/src/language_and_audio/election_strings.ts
@@ -8,6 +8,8 @@ import {
   BallotLanguageConfigs,
   getAllBallotLanguages,
   LanguageCode,
+  NEEDS_TRANSLITERATED_NAMES,
+  NonEnglishLanguageCode,
   hasSplits,
   DEFAULT_LANGUAGE_CODE,
 } from '@votingworks/types';
@@ -27,6 +29,12 @@ interface ElectionStringConfigNotTranslatable {
 
 interface ElectionStringConfigTranslatable {
   translatable: true;
+  /**
+   * When provided, the string is only translated into languages for which
+   * this returns true. The English original is always included, so untranslated
+   * languages fall back to English at display time.
+   */
+  shouldTranslate?: (languageCode: NonEnglishLanguageCode) => boolean;
   customTranslationMethod?: (input: {
     stringKey: ElectionStringKey | [ElectionStringKey, string];
     stringInEnglish: string;
@@ -55,7 +63,12 @@ const electionStringConfigs: Record<ElectionStringKey, ElectionStringConfig> = {
     translatable: true,
   },
   [ElectionStringKey.CANDIDATE_NAME]: {
-    translatable: false,
+    translatable: true,
+    // Candidate names aren't translated, but for languages written in a
+    // non-Latin script they're phonetically transliterated (which is how the
+    // translation API handles proper names). For all other languages they're
+    // kept in English.
+    shouldTranslate: (languageCode) => NEEDS_TRANSLITERATED_NAMES[languageCode],
   },
   [ElectionStringKey.CONTEST_DESCRIPTION]: {
     translatable: true,
@@ -322,10 +335,13 @@ export async function extractAndTranslateElectionStrings(
 ): Promise<UiStringsPackage> {
   const languages = getAllBallotLanguages(ballotLanguageConfigs);
   const untranslatedElectionStrings = extractElectionStrings(election);
-  const electionStringsNotToTranslate = untranslatedElectionStrings.filter(
+  // Strings that are only translated into some languages (shouldTranslate)
+  // always include their English original, since the other languages fall
+  // back to English at display time.
+  const electionStringsToIncludeInEnglish = untranslatedElectionStrings.filter(
     (electionString) => {
       const config = getElectionStringConfig(electionString);
-      return !config.translatable;
+      return !config.translatable || config.shouldTranslate !== undefined;
     }
   );
   const electionStringsToCloudTranslate = untranslatedElectionStrings.filter(
@@ -343,8 +359,8 @@ export async function extractAndTranslateElectionStrings(
 
   const electionStrings: UiStringsPackage = {};
 
-  // Election strings not to translate
-  for (const electionString of electionStringsNotToTranslate) {
+  // Election strings to include in English
+  for (const electionString of electionStringsToIncludeInEnglish) {
     setUiString(
       electionStrings,
       LanguageCode.ENGLISH,
@@ -354,10 +370,18 @@ export async function extractAndTranslateElectionStrings(
   }
 
   // Election strings to cloud translate
-  const stringsInEnglish = electionStringsToCloudTranslate.map(
-    ({ stringInEnglish }) => stringInEnglish
-  );
   for (const languageCode of languages) {
+    const stringsToInclude =
+      languageCode === LanguageCode.ENGLISH
+        ? electionStringsToCloudTranslate
+        : electionStringsToCloudTranslate.filter((electionString) => {
+            const config = getElectionStringConfig(electionString);
+            assert(config.translatable);
+            return config.shouldTranslate?.(languageCode) ?? true;
+          });
+    const stringsInEnglish = stringsToInclude.map(
+      ({ stringInEnglish }) => stringInEnglish
+    );
     const stringsInLanguage =
       languageCode === LanguageCode.ENGLISH
         ? stringsInEnglish
@@ -366,14 +390,9 @@ export async function extractAndTranslateElectionStrings(
             languageCode,
             jurisdictionId
           );
-    for (const [
-      i,
-      electionString,
-    ] of electionStringsToCloudTranslate.entries()) {
+    for (const [i, electionString] of stringsToInclude.entries()) {
       const { stringKey } = electionString;
       const stringInLanguage = stringsInLanguage[i];
-      const config = getElectionStringConfig(electionString);
-      assert(config.translatable);
       setUiString(
         electionStrings,
         languageCode,

--- a/libs/types/src/language_code.ts
+++ b/libs/types/src/language_code.ts
@@ -31,6 +31,26 @@ export function isLanguageCode(value: string): value is LanguageCode {
   return Object.values(LanguageCode).includes(value as LanguageCode);
 }
 
+/**
+ * Languages for which proper names (e.g. candidate names) should be
+ * phonetically transliterated into the language's script rather than kept in
+ * English.
+ */
+export const NEEDS_TRANSLITERATED_NAMES: Record<LanguageCode, boolean> = {
+  [LanguageCode.ARABIC]: false,
+  [LanguageCode.BENGALI]: false,
+  [LanguageCode.CHINESE_SIMPLIFIED]: true,
+  [LanguageCode.CHINESE_TRADITIONAL]: true,
+  [LanguageCode.ENGLISH]: false,
+  [LanguageCode.HINDI]: true,
+  [LanguageCode.JAPANESE]: true,
+  [LanguageCode.KHMER]: true,
+  [LanguageCode.KOREAN]: true,
+  [LanguageCode.SPANISH]: false,
+  [LanguageCode.TAGALOG]: false,
+  [LanguageCode.VIETNAMESE]: false,
+};
+
 export const IS_RTL: Record<LanguageCode, boolean> = {
   [LanguageCode.ARABIC]: true,
   [LanguageCode.BENGALI]: false,


### PR DESCRIPTION
🤖 Generated with Claude Code

## Overview

For ballot languages written in a non-Latin script (Chinese, Japanese, Khmer, Hindi, Korean), candidate names were previously kept in English everywhere — the audio proofing screen showed "Candidate names are displayed in English for ballots in this language" and synthesized name audio with the English voice. This PR adds a per-language `NEEDS_TRANSLITERATED_NAMES` flag and, for flagged languages, runs candidate names through the existing cloud translation pipeline, which phonetically transliterates proper names (e.g. "Joseph Barchi and Joseph Hallaren" → 约瑟夫·巴尔奇和约瑟夫·哈拉伦 / ジョセフ・バルチとジョセフ・ハラレン / 조셉 바르치와 조셉 할라렌). Transliterated names show up in the proofing screen (editable and finalizable like any other translation, voiced by the target-language TTS voice) and in the exported election package. Latin-script languages (Spanish, Tagalog, Vietnamese) keep English names as before, since translating names in those languages mangles them ("John Smith" → "Juan Smith"). The English original is always included in the package so non-flagged languages fall back to English.

Note for reviewers: election package strings drive ballot display as well as audio, so BMD screens and printed ballots in flagged languages will show the transliterated names.

## Demo Video or Screenshot



## Testing Plan

Updated automated tests. Manually verified in the running app against the live translation API: proofing screen shows editable transliterations with target-language audio for zh-Hans/zh-Hant/ja-JP/hi/ko and unchanged English-only behavior for es-US; election package string generation produces transliterated names for all flagged languages and English fallback for the rest.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
