### PR TITLE
ui/hmpb: Emphasize ballot measure first token

### DIFF
--- a/libs/hmpb/src/ballot_templates/ca_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/ca_ballot_template.tsx
@@ -19,6 +19,7 @@ import {
   BaseBallotProps,
   CandidateContest as CandidateContestStruct,
   ContestNominationType,
+  DEFAULT_LANGUAGE_CODE,
   District,
   Election,
   PrecinctId,
@@ -717,6 +718,40 @@ function CandidateContest({
   );
 }
 
+// Santa Clara County measure descriptions start with the measure's
+// designation (e.g. the "B" in "B To renew local school funding..."), printed
+// in a larger bold font. We assume the first word of the description is the
+// designation, as long as it looks like one (a short all-caps/numeric token).
+const MEASURE_DESIGNATION_PATTERN = /^[0-9A-Z]{1,3}$/;
+// Any leading tags/whitespace, then the first word, then trailing whitespace
+const LEADING_WORD_PATTERN = /^((?:<[^>]*>|\s)*)([^\s<]+)\s*/;
+
+/**
+ * Emphasizes the measure designation at the start of the English description,
+ * like the official Santa Clara County ballots. In translated descriptions,
+ * drops the designation if the translation kept it (and only if it exactly
+ * matches the English designation), since the emphasized English designation
+ * shown directly above already identifies the measure.
+ */
+function transformMeasureDescription(contest: YesNoContest) {
+  return (html: string, languageCode: string): string => {
+    const designation = contest.description.match(LEADING_WORD_PATTERN)?.[2];
+    if (!designation || !MEASURE_DESIGNATION_PATTERN.test(designation)) {
+      return html;
+    }
+    const match = html.match(LEADING_WORD_PATTERN);
+    if (!match || match[2] !== designation) {
+      return html;
+    }
+    const [matched, leadingTags] = match;
+    const rest = html.slice(matched.length);
+    if (languageCode !== DEFAULT_LANGUAGE_CODE) {
+      return `${leadingTags}${rest}`;
+    }
+    return `${leadingTags}<span style="font-size: 2em; line-height: 1; font-weight: bold;">${designation}</span> ${rest}`;
+  };
+}
+
 function BallotMeasureContest({ contest }: { contest: YesNoContest }) {
   return (
     <Box>
@@ -748,7 +783,9 @@ function BallotMeasureContest({ contest }: { contest: YesNoContest }) {
               tableBorderColor={Colors.DARKER_GRAY}
               tableHeaderBackgroundColor={Colors.LIGHT_GRAY}
             >
-              {electionStrings.contestDescription(contest)}
+              {electionStrings.contestDescription(contest, {
+                transformHtml: transformMeasureDescription(contest),
+              })}
             </RichText>
           </DualLanguageText>
         </div>

--- a/libs/ui/src/ui_strings/election_strings.tsx
+++ b/libs/ui/src/ui_strings/election_strings.tsx
@@ -68,10 +68,14 @@ export const electionStrings = {
     </InEnglish>
   ),
 
-  [Key.CONTEST_DESCRIPTION]: (contest: ContestWithDescription) => (
+  [Key.CONTEST_DESCRIPTION]: (
+    contest: ContestWithDescription,
+    options?: { transformHtml?: (html: string, languageCode: string) => string }
+  ) => (
     <UiRichTextString
       uiStringKey={Key.CONTEST_DESCRIPTION}
       uiStringSubKey={contest.id}
+      transformHtml={options?.transformHtml}
     >
       {contest.description}
     </UiRichTextString>

--- a/libs/ui/src/ui_strings/ui_string.test.tsx
+++ b/libs/ui/src/ui_strings/ui_string.test.tsx
@@ -173,4 +173,41 @@ describe('UiRichTextString', () => {
     );
     await screen.findByText('fall back text');
   });
+
+  test('applies transformHtml with the current language code', async () => {
+    const { container } = render(
+      <UiRichTextString
+        uiStringKey="richText"
+        uiStringSubKey="bold"
+        transformHtml={(html, languageCode) => `[${languageCode}] ${html}`}
+      >
+        {'[Untranslated] This is <strong>bold</strong>'}
+      </UiRichTextString>
+    );
+    await screen.findByText(/This is/);
+    expect(container.firstElementChild?.innerHTML).toEqual(
+      '<div>[en] This is <strong>bold</strong></div>'
+    );
+
+    act(() => getLanguageContext()?.setLanguage('es-US'));
+    await waitFor(() => screen.findByText(/Esto es/));
+    expect(container.firstElementChild?.innerHTML).toEqual(
+      '<div>[es-US] Esto es <strong>negrita</strong></div>'
+    );
+  });
+
+  test('applies transformHtml without UiStringContext', () => {
+    const { container } = renderWithoutContext(
+      <UiRichTextString
+        uiStringKey="richText"
+        uiStringSubKey="bold"
+        transformHtml={(html, languageCode) => `[${languageCode}] ${html}`}
+      >
+        {'[Untranslated] This is <strong>bold</strong>'}
+      </UiRichTextString>
+    );
+    expect(container.firstElementChild?.innerHTML).toEqual(
+      '<div>[en] [Untranslated] This is <strong>bold</strong></div>'
+    );
+  });
 });

--- a/libs/ui/src/ui_strings/ui_string.tsx
+++ b/libs/ui/src/ui_strings/ui_string.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Trans } from 'react-i18next';
 
 import sanitizeHtml from 'sanitize-html';
+import { DEFAULT_LANGUAGE_CODE } from '@votingworks/types';
 import { ReactUiString } from './types';
 import { useLanguageContext } from './language_context';
 import { WithAudio } from './with_audio';
@@ -56,6 +57,13 @@ interface UiRichTextStringProps {
   children: string;
   uiStringKey: string;
   uiStringSubKey?: string;
+  /**
+   * Optional transform applied to the sanitized HTML before it's rendered
+   * (e.g. to add presentational markup), along with the language code of the
+   * string being rendered. The transform's output is rendered without further
+   * sanitization, so it must only add trusted markup.
+   */
+  transformHtml?: (html: string, languageCode: string) => string;
 }
 
 const sanitizeOptions: sanitizeHtml.IOptions = {
@@ -74,13 +82,20 @@ const sanitizeOptions: sanitizeHtml.IOptions = {
  * tag replacement. Sanitizes the HTML to prevent XSS attacks.
  */
 export function UiRichTextString(props: UiRichTextStringProps): JSX.Element {
-  const { children, uiStringKey, uiStringSubKey } = props;
+  const { children, uiStringKey, uiStringSubKey, transformHtml } = props;
 
   const languageContext = useLanguageContext();
 
   const i18nKey =
     uiStringKey &&
     (uiStringSubKey ? `${uiStringKey}.${uiStringSubKey}` : uiStringKey);
+
+  function toRenderedHtml(html: string, languageCode: string): string {
+    const sanitizedHtml = sanitizeHtml(html, sanitizeOptions);
+    return transformHtml
+      ? transformHtml(sanitizedHtml, languageCode)
+      : sanitizedHtml;
+  }
 
   // Enable tests to run without the need for a UiStringContext
   if (!languageContext) {
@@ -89,7 +104,7 @@ export function UiRichTextString(props: UiRichTextStringProps): JSX.Element {
         <div
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{
-            __html: sanitizeHtml(children, sanitizeOptions),
+            __html: toRenderedHtml(children, DEFAULT_LANGUAGE_CODE),
           }}
         />
       </WithAudio>
@@ -109,7 +124,10 @@ export function UiRichTextString(props: UiRichTextStringProps): JSX.Element {
       <div
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{
-          __html: sanitizeHtml(translatedString, sanitizeOptions),
+          __html: toRenderedHtml(
+            translatedString,
+            languageContext.currentLanguageCode
+          ),
         }}
       />
     </WithAudio>


### PR DESCRIPTION
## Overview

CA ballots often add the ballot measure letter/number with emphasis to the beginning of the description. We match this by taking the first token in the description and emphasizing it. We then drop it from the translated description so it isn't duplicated (following their ballot).

## Demo Video or Screenshot

CA ballot 
<img width="374" height="344" alt="Screenshot 2026-07-23 at 4 24 45 PM" src="https://github.com/user-attachments/assets/9ff36d12-1330-462d-bc68-a70585735fca" />

Our ballot
<img width="1019" height="637" alt="Screenshot 2026-07-23 at 4 26 27 PM" src="https://github.com/user-attachments/assets/1a96f1ae-093f-4d68-9783-267c0e5f5b10" />


## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

