### PR TITLE
design/backend: Add candidate designation to list of translated strin…

### DIFF
--- a/apps/design/backend/src/tts_strings.test.ts
+++ b/apps/design/backend/src/tts_strings.test.ts
@@ -98,7 +98,13 @@ test('ttsStringDefaults - accounts for all relevant strings', async () => {
   const election: PartialDeep<Election> = {
     contests: [
       {
-        candidates: [{ id: 'candidate1', name: 'Candidate 1' }],
+        candidates: [
+          {
+            id: 'candidate1',
+            name: 'Candidate 1',
+            designation: 'Barnstormer',
+          },
+        ],
         id: 'contest1',
         title: 'Candidate Contest 1',
         type: 'candidate',
@@ -179,6 +185,7 @@ test('ttsStringDefaults - accounts for all relevant strings', async () => {
     ElectionStringKey,
     Array<{ subkey?: string; text: string }>
   > = {
+    candidateDesignation: [{ subkey: 'candidate1', text: 'Barnstormer' }],
     candidateName: [
       { subkey: 'candidate1', text: 'Candidate 1' },
       { subkey: 'candidate2', text: 'Candidate 2' },
@@ -232,7 +239,6 @@ test('ttsStringDefaults - accounts for all relevant strings', async () => {
     // Currently not exposed for TTS editing:
     ballotLanguage: [],
     ballotStyleId: [],
-    candidateDesignation: [],
     electionDate: [],
   };
 

--- a/apps/design/backend/src/tts_strings.ts
+++ b/apps/design/backend/src/tts_strings.ts
@@ -250,6 +250,14 @@ export function apiMethods(ctx: TtsApiContext) {
                 subkey: candidate.id,
                 text: candidate.name,
               });
+
+              if (candidate.designation) {
+                strings.push({
+                  key: ElectionStringKey.CANDIDATE_DESIGNATION,
+                  subkey: candidate.id,
+                  text: candidate.designation,
+                });
+              }
             }
 
             break;

--- a/apps/design/frontend/src/ballot_audio/proofing_screen.tsx
+++ b/apps/design/frontend/src/ballot_audio/proofing_screen.tsx
@@ -833,6 +833,9 @@ function StringInfo(props: {
   const { stringKey, subkey, text } = props;
 
   switch (stringKey) {
+    case ElectionStringKey.CANDIDATE_DESIGNATION:
+      return <StringInfoCandidateDesignation id={assertDefined(subkey)} />;
+
     case ElectionStringKey.CANDIDATE_NAME:
       return <StringInfoCandidateName id={assertDefined(subkey)} />;
 
@@ -1272,6 +1275,51 @@ function StringInfoContestDescription(props: { id: string }) {
       </StringHeader>
       {/*  eslint-disable-next-line react/no-danger */}
       <div dangerouslySetInnerHTML={{ __html: contest.description }} />
+    </TranslationContainer>
+  );
+}
+
+function StringInfoCandidateDesignation(props: { id: string }) {
+  const { id } = props;
+  const { language = ENGLISH, electionId } = useParams<BallotAudioPathParams>();
+
+  const contests = api.listContests.useQuery(electionId).data;
+
+  const [contest, candidate] = React.useMemo(() => {
+    for (const con of contests || []) {
+      if (con.type !== 'candidate') continue;
+
+      for (const can of con.candidates) {
+        if (can.id === id) return [con, can];
+      }
+    }
+
+    return [];
+  }, [contests, id]);
+
+  if (!candidate || !contest) return null;
+
+  return (
+    <TranslationContainer>
+      <StringHeader>
+        <div>
+          <SubHeading>
+            <Link
+              to={
+                routes.election(electionId).ballots.languageManage({
+                  language,
+                  stringKey: ElectionStringKey.CANDIDATE_NAME,
+                  subkey: candidate.id,
+                }).path
+              }
+            >
+              {candidate.name}
+            </Link>
+          </SubHeading>
+          <H2>{candidate.designation}</H2>
+        </div>
+        <StringKey>Candidate Designation</StringKey>
+      </StringHeader>
     </TranslationContainer>
   );
 }


### PR DESCRIPTION
## Overview

Candidate designations are being translated for the ballot template, but they weren't included in the VxDesign Language and Audio UI.

## Demo Video or Screenshot

<img width="1286" height="790" alt="Screenshot 2026-07-23 at 4 53 04 PM" src="https://github.com/user-attachments/assets/ed98374b-9ea7-4116-9763-ef9cb3ed2c27" />

## Testing Plan

## Checklist



- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
