### PR TITLE
CA demos: Small VxDesign edits

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -160,10 +160,6 @@ import {
   GenerateElectionPackageAndBallotsPayload,
   GenerateElectionPackageAndBallotsPayloadSchema,
 } from './worker/generate_election_package_and_ballots';
-import {
-  GenerateTestDecksPayload,
-  GenerateTestDecksPayloadSchema,
-} from './worker/generate_test_decks';
 
 vi.setConfig({
   testTimeout: 120_000,
@@ -2743,19 +2739,10 @@ test('Finalize ballots - DEMO state', async () => {
     electionSerializationFormat: 'vxf',
     shouldExportAudio: true,
     shouldExportSampleBallots: false,
-    shouldExportTestBallots: true,
+    shouldExportTestBallots: false,
   });
 
-  const testDecks = await apiClient.getTestDecks({ electionId });
-  const testDecksTask = assertDefined(testDecks.task);
-  const testDecksParams = safeParseJson(
-    testDecksTask.payload,
-    GenerateTestDecksPayloadSchema
-  ).unsafeUnwrap();
-  expect(testDecksParams).toEqual<GenerateTestDecksPayload>({
-    electionId,
-    electionSerializationFormat: 'vxf',
-  });
+  expect(await apiClient.getTestDecks({ electionId })).toEqual({});
 
   await apiClient.unfinalizeBallots({ electionId, reason: '' });
 

--- a/apps/design/backend/src/features.ts
+++ b/apps/design/backend/src/features.ts
@@ -235,7 +235,7 @@ export const stateFeatureConfigs: Record<StateCode, StateFeaturesConfig> = {
     BALLOT_LANGUAGE_CONFIG: true,
     DELETE_LIVE_REPORTS: true,
     EDIT_POLLING_PLACES: true,
-    EXPORT_TEST_BALLOTS: true,
+    EXPORT_TEST_BALLOTS: false, // true,
   },
 
   MI: {

--- a/apps/design/frontend/src/ballots_screen.test.tsx
+++ b/apps/design/frontend/src/ballots_screen.test.tsx
@@ -5,7 +5,10 @@ import {
   ElectionId,
   DEFAULT_SYSTEM_SETTINGS,
 } from '@votingworks/types';
-import type { ElectionRecord } from '@votingworks/design-backend';
+import type {
+  BallotTemplateId,
+  ElectionRecord,
+} from '@votingworks/design-backend';
 import {
   provideApi,
   createMockApiClient,
@@ -59,7 +62,10 @@ function renderScreen(electionId: ElectionId) {
   );
 }
 
-function expectElectionApiCalls(electionRecord: ElectionRecord) {
+function expectElectionApiCalls(
+  electionRecord: ElectionRecord,
+  ballotTemplateId: BallotTemplateId = 'VxDefaultBallot'
+) {
   const { id: electionId } = electionRecord.election;
   mockStateFeatures(apiMock, electionId);
   apiMock.listBallotStyles
@@ -77,6 +83,9 @@ function expectElectionApiCalls(electionRecord: ElectionRecord) {
   apiMock.listParties
     .expectCallWith({ electionId })
     .resolves(electionRecord.election.parties);
+  apiMock.getBallotTemplate
+    .expectCallWith({ electionId })
+    .resolves(ballotTemplateId);
 }
 
 describe('Ballot styles tab', () => {
@@ -244,12 +253,13 @@ describe('Ballot layout tab', () => {
   const { election } = electionRecord;
   const electionId = election.id;
 
-  beforeEach(() => {
-    expectElectionApiCalls(electionRecord);
+  function setup(ballotTemplateId: BallotTemplateId = 'VxDefaultBallot') {
+    expectElectionApiCalls(electionRecord, ballotTemplateId);
     apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
-  });
+  }
 
   test('has form to update paper size and density', async () => {
+    setup();
     mockStateFeatures(apiMock, electionId, {
       ONLY_LETTER_AND_LEGAL_PAPER_SIZES: false,
     });
@@ -257,9 +267,6 @@ describe('Ballot layout tab', () => {
       paperSize: election.ballotLayout.paperSize,
       compact: false,
     });
-    apiMock.getBallotTemplate
-      .expectCallWith({ electionId })
-      .resolves('VxDefaultBallot');
     renderScreen(electionId);
     await screen.findByRole('heading', { name: 'Proof Ballots' });
 
@@ -331,6 +338,7 @@ describe('Ballot layout tab', () => {
   });
 
   test('with ONLY_LETTER_AND_LEGAL_PAPER_SIZES feature flag enabled', async () => {
+    setup();
     mockStateFeatures(apiMock, electionId, {
       ONLY_LETTER_AND_LEGAL_PAPER_SIZES: true,
     });
@@ -338,9 +346,6 @@ describe('Ballot layout tab', () => {
       paperSize: election.ballotLayout.paperSize,
       compact: false,
     });
-    apiMock.getBallotTemplate
-      .expectCallWith({ electionId })
-      .resolves('VxDefaultBallot');
     renderScreen(electionId);
     await screen.findByRole('heading', { name: 'Proof Ballots' });
 
@@ -367,14 +372,12 @@ describe('Ballot layout tab', () => {
   });
 
   test('hides density for MI ballot template', async () => {
+    setup('MiBallot');
     mockStateFeatures(apiMock, electionId, {});
     apiMock.getBallotLayoutSettings.expectCallWith({ electionId }).resolves({
       paperSize: election.ballotLayout.paperSize,
       compact: false,
     });
-    apiMock.getBallotTemplate
-      .expectCallWith({ electionId })
-      .resolves('MiBallot');
     renderScreen(electionId);
     await screen.findByRole('heading', { name: 'Proof Ballots' });
 
@@ -387,14 +390,12 @@ describe('Ballot layout tab', () => {
   });
 
   test('hides density for NH state ballot template', async () => {
+    setup('NhStateBallot');
     mockStateFeatures(apiMock, electionId, {});
     apiMock.getBallotLayoutSettings.expectCallWith({ electionId }).resolves({
       paperSize: election.ballotLayout.paperSize,
       compact: false,
     });
-    apiMock.getBallotTemplate
-      .expectCallWith({ electionId })
-      .resolves('NhStateBallot');
     renderScreen(electionId);
     await screen.findByRole('heading', { name: 'Proof Ballots' });
 
@@ -407,15 +408,13 @@ describe('Ballot layout tab', () => {
   });
 
   test('cancelling', async () => {
+    setup();
     mockStateFeatures(apiMock, electionId, {});
     mockUserFeatures(apiMock, {});
     apiMock.getBallotLayoutSettings.expectCallWith({ electionId }).resolves({
       paperSize: election.ballotLayout.paperSize,
       compact: false,
     });
-    apiMock.getBallotTemplate
-      .expectCallWith({ electionId })
-      .resolves('VxDefaultBallot');
     renderScreen(electionId);
     await screen.findByRole('heading', { name: 'Proof Ballots' });
 

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -14,7 +14,12 @@ import {
 } from '@votingworks/ui';
 import { Redirect, Route, Switch, useParams } from 'react-router-dom';
 import { find } from '@votingworks/basics';
-import { HmpbBallotPaperSize, ElectionId, hasSplits } from '@votingworks/types';
+import {
+  HmpbBallotPaperSize,
+  ElectionId,
+  hasSplits,
+  LanguageCode,
+} from '@votingworks/types';
 import { useState } from 'react';
 import styled from 'styled-components';
 import { ballotStyleHasPrecinctOrSplit } from '@votingworks/utils';
@@ -185,6 +190,7 @@ function BallotStylesTab(): JSX.Element | null {
   const listBallotStylesQuery = listBallotStyles.useQuery(electionId);
   const listPartiesQuery = listParties.useQuery(electionId);
   const getBallotsFinalizedAtQuery = getBallotsFinalizedAt.useQuery(electionId);
+  const getBallotTemplateQuery = getBallotTemplate.useQuery(electionId);
 
   if (
     !(
@@ -192,7 +198,8 @@ function BallotStylesTab(): JSX.Element | null {
       listPrecinctsQuery.isSuccess &&
       listBallotStylesQuery.isSuccess &&
       listPartiesQuery.isSuccess &&
-      getBallotsFinalizedAtQuery.isSuccess
+      getBallotsFinalizedAtQuery.isSuccess &&
+      getBallotTemplateQuery.isSuccess
     )
   ) {
     return null;
@@ -200,8 +207,20 @@ function BallotStylesTab(): JSX.Element | null {
 
   const electionInfo = getElectionInfoQuery.data;
   const precincts = listPrecinctsQuery.data;
-  const ballotStyles = listBallotStylesQuery.data;
   const parties = listPartiesQuery.data;
+
+  const hideEnglishOnlyBallotStyle =
+    getBallotTemplateQuery.data === 'CaBallot' &&
+    electionInfo.languageCodes.length > 1;
+  const ballotStyles = hideEnglishOnlyBallotStyle
+    ? listBallotStylesQuery.data.filter(
+        (ballotStyle) =>
+          !(
+            ballotStyle.languages.length === 1 &&
+            ballotStyle.languages[0] === LanguageCode.ENGLISH
+          )
+      )
+    : listBallotStylesQuery.data;
   const ballotRoutes = routes.election(electionId).ballots;
   const showPartyColumn =
     electionInfo.type === 'primary' && !electionInfo.isMiCombinedBallotPrimary;

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -111,7 +111,8 @@ function BallotDesignForm({
         />
       </div>
       {ballotTemplateId !== 'MiBallot' &&
-        ballotTemplateId !== 'NhStateBallot' && (
+        ballotTemplateId !== 'NhStateBallot' &&
+        ballotTemplateId !== 'CaBallot' && (
           <div style={{ maxWidth: '16.5rem' }}>
             <RadioGroup
               label="Density"


### PR DESCRIPTION
Small VxDesign edits for CA demos:
* Skip test ballot and test deck generation to avoid an overly slow export and an overly large ballots.jsonl in the election package
* Hide the density toggle when using the CA ballot template since it's a no-op
* Hide the English-only ballot style from the proofing screen when using the CA ballot template