### PR TITLE
[ca-demo] VxDesign: Language picker on ballot preview screen

### DIFF
--- a/apps/design/frontend/src/ballot_screen.test.tsx
+++ b/apps/design/frontend/src/ballot_screen.test.tsx
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, expect, test, vi, describe } from 'vitest';
-import { BallotType, CandidateContest, YesNoContest } from '@votingworks/types';
+import {
+  BallotType,
+  CandidateContest,
+  LanguageCode,
+  YesNoContest,
+} from '@votingworks/types';
 import type { BallotTemplateId } from '@votingworks/design-backend';
 import { DocumentProps, PageProps } from 'react-pdf';
 import { useEffect } from 'react';
@@ -93,7 +98,7 @@ afterEach(() => {
   apiMock.assertComplete();
 });
 
-function renderScreen() {
+function renderScreen(ballotStyleId = ballotStyle.id) {
   render(
     provideApi(
       apiMock,
@@ -103,7 +108,7 @@ function renderScreen() {
           .ballots.viewBallot(':ballotStyleId', ':precinctId').path,
         path: routes
           .election(electionId)
-          .ballots.viewBallot(ballotStyle.id, precinct.id).path,
+          .ballots.viewBallot(ballotStyleId, precinct.id).path,
       })
     )
   );
@@ -279,6 +284,82 @@ test('changes tabulation mode', async () => {
   userEvent.click(testRadioOption);
   await screen.findByText('mock test ballot pdf');
   screen.getByRole('radio', { name: 'L&A Test Ballot', checked: true });
+});
+
+test('CaBallot template: language picker switches between language variants', async () => {
+  const ballotStylesWithVariants = electionRecord.election.ballotStyles.flatMap(
+    (style) => [
+      style,
+      {
+        ...style,
+        id: style.id.replace('_en', '_es-US'),
+        languages: [LanguageCode.SPANISH],
+      },
+      {
+        ...style,
+        id: style.id.replace('_en', '_zh-Hans'),
+        languages: [LanguageCode.CHINESE_SIMPLIFIED],
+      },
+    ]
+  );
+  const spanishBallotStyleId = ballotStyle.id.replace('_en', '_es-US');
+  const chineseBallotStyleId = ballotStyle.id.replace('_en', '_zh-Hans');
+  apiMock.getBallotTemplate.reset();
+  apiMock.getBallotTemplate.expectCallWith({ electionId }).resolves('CaBallot');
+  apiMock.listBallotStyles.reset();
+  apiMock.listBallotStyles
+    .expectCallWith({ electionId })
+    .resolves(ballotStylesWithVariants);
+  apiMock.getBallotPreviewPdf
+    .expectCallWith({
+      electionId,
+      ballotStyleId: spanishBallotStyleId,
+      precinctId: precinct.id,
+      ballotType: BallotType.Precinct,
+      ballotMode: 'official',
+      isFederalOfficeOnly: undefined,
+    })
+    .resolves(
+      ok({
+        pdfData: Buffer.from('mock spanish ballot pdf'),
+        fileName: 'mock spanish ballot.pdf',
+      })
+    );
+  renderScreen(spanishBallotStyleId);
+
+  await screen.findByRole('heading', { name: 'View Ballot' });
+  await screen.findByText('mock spanish ballot pdf');
+
+  // Shows the ballot style group ID rather than the language-specific ID
+  screen.getByText(ballotStyle.groupId);
+  expect(screen.queryByText(spanishBallotStyleId)).not.toBeInTheDocument();
+
+  const languageSelect = screen.getByLabelText('Language');
+  screen.getByText('Spanish');
+
+  // The English-only variant is not offered
+  userEvent.click(languageSelect);
+  expect(screen.queryByText('English')).not.toBeInTheDocument();
+
+  apiMock.getBallotPreviewPdf
+    .expectCallWith({
+      electionId,
+      ballotStyleId: chineseBallotStyleId,
+      precinctId: precinct.id,
+      ballotType: BallotType.Precinct,
+      ballotMode: 'official',
+      isFederalOfficeOnly: undefined,
+    })
+    .resolves(
+      ok({
+        pdfData: Buffer.from('mock chinese ballot pdf'),
+        fileName: 'mock chinese ballot.pdf',
+      })
+    );
+  userEvent.click(screen.getByText('Chinese (Simplified)'));
+  await screen.findByText('mock chinese ballot pdf');
+  screen.getByText('Chinese (Simplified)');
+  screen.getByText(ballotStyle.groupId);
 });
 
 test('NhStateBallot template: Federal Office Only option locks mode to Official', async () => {

--- a/apps/design/frontend/src/ballot_screen.tsx
+++ b/apps/design/frontend/src/ballot_screen.tsx
@@ -1,6 +1,11 @@
 import fileDownload from 'js-file-download';
-import { Link, useParams } from 'react-router-dom';
-import { find, range, throwIllegalValue } from '@votingworks/basics';
+import { Link, useHistory, useParams } from 'react-router-dom';
+import {
+  assertDefined,
+  find,
+  range,
+  throwIllegalValue,
+} from '@votingworks/basics';
 import {
   HmpbBallotPaperSize,
   BallotMode,
@@ -10,6 +15,7 @@ import {
   BallotStyleIdSchema,
   PrecinctIdSchema,
   Contest,
+  LanguageCode,
 } from '@votingworks/types';
 import React, { useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
@@ -21,13 +27,14 @@ import {
   Icons,
   LinkButton,
   RadioGroup,
+  SearchSelect,
   TaskContent,
   TaskControls,
   TaskHeader,
   TaskScreen,
 } from '@votingworks/ui';
 import { Document, Page, pdfjs } from 'react-pdf';
-import { format } from '@votingworks/utils';
+import { format, getRelatedBallotStyle } from '@votingworks/utils';
 import type { BallotTemplateId } from '@votingworks/design-backend';
 import {
   getBallotPreviewPdf,
@@ -40,6 +47,7 @@ import {
 } from './api';
 import { routes } from './routes';
 import { FieldName as BaseFieldName, Row } from './layout';
+import { caBallotStyleLanguages } from './utils';
 
 // Worker file must be copied from pdfjs-dist into public directory
 pdfjs.GlobalWorkerOptions.workerSrc = '/pdf.worker.js';
@@ -277,6 +285,7 @@ export function BallotScreen(): JSX.Element | null {
     params
   );
 
+  const history = useHistory();
   const getElectionInfoQuery = getElectionInfo.useQuery(electionId);
   const listPrecinctsQuery = listPrecincts.useQuery(electionId);
   const listBallotStylesQuery = listBallotStyles.useQuery(electionId);
@@ -344,6 +353,26 @@ export function BallotScreen(): JSX.Element | null {
 
   const ballotRoutes = routes.election(electionId).ballots;
   const { title } = ballotRoutes.viewBallot(ballotStyle.id, precinct.id);
+
+  // The CA ballot template generates a separate ballot style per language, so
+  // we show a language picker that switches between the language variants in
+  // the ballot style's group.
+  const isCaBallot = ballotTemplateId === 'CaBallot';
+  const groupLanguages = caBallotStyleLanguages(
+    ballotStyles.filter((bs) => bs.groupId === ballotStyle.groupId)
+  );
+  const showLanguagePicker = isCaBallot && groupLanguages.length > 1;
+
+  function onLanguageChange(language?: LanguageCode) {
+    const targetBallotStyle = getRelatedBallotStyle({
+      ballotStyles,
+      sourceBallotStyleId: ballotStyle.id,
+      targetBallotStyleLanguage: assertDefined(language),
+    }).unsafeUnwrap();
+    history.replace(
+      ballotRoutes.viewBallot(targetBallotStyle.id, precinct.id).path
+    );
+  }
 
   return (
     <TaskScreen>
@@ -421,7 +450,7 @@ export function BallotScreen(): JSX.Element | null {
         <Controls>
           <div>
             <FieldName>Ballot Style</FieldName>
-            {ballotStyle.id}
+            {isCaBallot ? ballotStyle.groupId : ballotStyle.id}
           </div>
 
           <div>
@@ -441,6 +470,27 @@ export function BallotScreen(): JSX.Element | null {
             <FieldName>Page Size</FieldName>
             {paperSizeLabels[paperSize]}{' '}
           </div>
+
+          {showLanguagePicker && (
+            <div>
+              <FieldName>Language</FieldName>
+              <SearchSelect
+                aria-label="Language"
+                isSearchable={false}
+                inverse
+                value={ballotStyle.languages[0] as LanguageCode}
+                options={groupLanguages.map((language) => ({
+                  value: language,
+                  label: format.languageDisplayName2({
+                    languageCode: language,
+                    displayLanguageCode: LanguageCode.ENGLISH,
+                  }),
+                }))}
+                onChange={onLanguageChange}
+                style={{ width: '100%' }}
+              />
+            </div>
+          )}
 
           {enableFederalOfficeOnly ? (
             <RadioGroup

--- a/apps/design/frontend/src/ballots_screen.test.tsx
+++ b/apps/design/frontend/src/ballots_screen.test.tsx
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
+import { createMemoryHistory } from 'history';
 import {
+  BallotType,
   HmpbBallotPaperSize,
   ElectionId,
   DEFAULT_SYSTEM_SETTINGS,
+  LanguageCode,
 } from '@votingworks/types';
 import type {
   BallotTemplateId,
@@ -50,13 +53,19 @@ afterEach(() => {
   apiMock.assertComplete();
 });
 
-function renderScreen(electionId: ElectionId) {
+function renderScreen(
+  electionId: ElectionId,
+  history = createMemoryHistory({
+    initialEntries: [routes.election(electionId).ballots.root.path],
+  })
+) {
   render(
     provideApi(
       apiMock,
       withRoute(<BallotsScreen />, {
         paramPath: routes.election(':electionId').ballots.root.path,
         path: routes.election(electionId).ballots.root.path,
+        history,
       })
     )
   );
@@ -122,6 +131,83 @@ describe('Ballot styles tab', () => {
       ['North Springfield - Split 2', '1_en', 'View Ballot'],
       ['South Springfield', 'No contests assigned', ''],
     ]);
+  });
+
+  test('CA ballot template shows one row per ballot style group', async () => {
+    const record = generalElectionRecord(jurisdiction.id);
+    const electionRecord: ElectionRecord = {
+      ...record,
+      election: {
+        ...record.election,
+        ballotStyles: record.election.ballotStyles.flatMap((ballotStyle) => [
+          ballotStyle,
+          {
+            ...ballotStyle,
+            id: ballotStyle.id.replace('_en', '_es-US'),
+            languages: [LanguageCode.SPANISH],
+          },
+          {
+            ...ballotStyle,
+            id: ballotStyle.id.replace('_en', '_zh-Hans'),
+            languages: [LanguageCode.CHINESE_SIMPLIFIED],
+          },
+        ]),
+      },
+    };
+    const electionId = electionRecord.election.id;
+    expectElectionApiCalls(electionRecord, 'CaBallot');
+    apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+    const history = createMemoryHistory({
+      initialEntries: [routes.election(electionId).ballots.root.path],
+    });
+    renderScreen(electionId, history);
+    await screen.findByRole('heading', { name: 'Proof Ballots' });
+
+    const table = screen.getByRole('table');
+    expect(
+      within(table)
+        .getAllByRole('row')
+        .slice(1)
+        .map((row) =>
+          within(row)
+            .getAllByRole('cell')
+            .map((cell) => cell.textContent)
+        )
+    ).toEqual([
+      ['Center Springfield', '1', 'View Ballot'],
+      ['North Springfield', '', ''],
+      ['North Springfield - Split 1', '2', 'View Ballot'],
+      ['North Springfield - Split 2', '1', 'View Ballot'],
+      ['South Springfield', 'No contests assigned', ''],
+    ]);
+
+    // Viewing a ballot opens the group's first translated variant (the
+    // English-only variant is not shown for the CA template)
+    const centerSpringfield = electionRecord.election.precincts[0];
+    apiMock.getBallotLayoutSettings.expectCallWith({ electionId }).resolves({
+      paperSize: electionRecord.election.ballotLayout.paperSize,
+      compact: false,
+    });
+    apiMock.getBallotPreviewPdf
+      .expectCallWith({
+        electionId,
+        ballotStyleId: '1_zh-Hans',
+        precinctId: centerSpringfield.id,
+        ballotType: BallotType.Precinct,
+        ballotMode: 'official',
+        isFederalOfficeOnly: undefined,
+      })
+      .returns(new Promise(() => {}));
+    const firstRow = within(table).getAllByRole('row')[1];
+    userEvent.click(
+      within(firstRow).getByRole('button', { name: 'View Ballot' })
+    );
+    await screen.findByRole('heading', { name: 'View Ballot' });
+    expect(history.location.pathname).toEqual(
+      routes
+        .election(electionId)
+        .ballots.viewBallot('1_zh-Hans', centerSpringfield.id).path
+    );
   });
 
   test('Primary election with splits', async () => {

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -14,15 +14,13 @@ import {
 } from '@votingworks/ui';
 import { Redirect, Route, Switch, useParams } from 'react-router-dom';
 import { find } from '@votingworks/basics';
-import {
-  HmpbBallotPaperSize,
-  ElectionId,
-  hasSplits,
-  LanguageCode,
-} from '@votingworks/types';
+import { HmpbBallotPaperSize, ElectionId, hasSplits } from '@votingworks/types';
 import { useState } from 'react';
 import styled from 'styled-components';
-import { ballotStyleHasPrecinctOrSplit } from '@votingworks/utils';
+import {
+  ballotStyleHasPrecinctOrSplit,
+  getGroupedBallotStyles,
+} from '@votingworks/utils';
 import type { BallotTemplateId } from '@votingworks/design-backend';
 import {
   getBallotsFinalizedAt,
@@ -39,6 +37,7 @@ import { Column, Form, FormActionsRow, NestedTr } from './layout';
 import { ElectionNavScreen, Header } from './nav_screen';
 import { ElectionIdParams, electionParamRoutes, routes } from './routes';
 import { BallotScreen, paperSizeLabels } from './ballot_screen';
+import { caBallotStyleLanguages } from './utils';
 import { useTitle } from './hooks/use_title';
 import { BallotsStatus } from './ballots_status';
 import { LanguageProofingScreen } from './ballot_audio/proofing_screen';
@@ -209,18 +208,25 @@ function BallotStylesTab(): JSX.Element | null {
   const precincts = listPrecinctsQuery.data;
   const parties = listPartiesQuery.data;
 
-  const hideEnglishOnlyBallotStyle =
-    getBallotTemplateQuery.data === 'CaBallot' &&
-    electionInfo.languageCodes.length > 1;
-  const ballotStyles = hideEnglishOnlyBallotStyle
-    ? listBallotStylesQuery.data.filter(
-        (ballotStyle) =>
-          !(
-            ballotStyle.languages.length === 1 &&
-            ballotStyle.languages[0] === LanguageCode.ENGLISH
-          )
-      )
-    : listBallotStylesQuery.data;
+  // The CA ballot template generates a separate ballot style per language.
+  // Rather than a row per language variant, show one row per ballot style
+  // group that links to the group's default language variant, and let users
+  // switch languages on the ballot preview screen.
+  const ballotStyles =
+    getBallotTemplateQuery.data === 'CaBallot'
+      ? getGroupedBallotStyles(listBallotStylesQuery.data).map((group) => {
+          const defaultLanguage = caBallotStyleLanguages(group.ballotStyles)[0];
+          return {
+            ...find(group.ballotStyles, (ballotStyle) =>
+              ballotStyle.languages.includes(defaultLanguage)
+            ),
+            displayId: group.id,
+          };
+        })
+      : listBallotStylesQuery.data.map((ballotStyle) => ({
+          ...ballotStyle,
+          displayId: ballotStyle.id,
+        }));
   const ballotRoutes = routes.election(electionId).ballots;
   const showPartyColumn =
     electionInfo.type === 'primary' && !electionInfo.isMiCombinedBallotPrimary;
@@ -266,7 +272,7 @@ function BallotStylesTab(): JSX.Element | null {
                   return precinctBallotStyles.map((ballotStyle) => (
                     <tr key={precinct.id + ballotStyle.id}>
                       <TD>{precinct.name}</TD>
-                      <TD>{ballotStyle.id}</TD>
+                      <TD>{ballotStyle.displayId}</TD>
                       {showPartyColumn && (
                         <TD>
                           {
@@ -327,7 +333,7 @@ function BallotStylesTab(): JSX.Element | null {
                   return splitBallotStyles.map((ballotStyle) => (
                     <NestedTr key={split.id + ballotStyle.id}>
                       <TD>{split.name}</TD>
-                      <TD>{ballotStyle.id}</TD>
+                      <TD>{ballotStyle.displayId}</TD>
                       {showPartyColumn && (
                         <TD>
                           {

--- a/apps/design/frontend/src/utils.test.ts
+++ b/apps/design/frontend/src/utils.test.ts
@@ -1,5 +1,22 @@
 import { expect, test } from 'vitest';
-import { downloadFile, reorderElement } from './utils';
+import { LanguageCode } from '@votingworks/types';
+import { caBallotStyleLanguages, downloadFile, reorderElement } from './utils';
+
+test('caBallotStyleLanguages omits English when translated variants exist', () => {
+  expect(
+    caBallotStyleLanguages([
+      { languages: [LanguageCode.SPANISH] },
+      { languages: [LanguageCode.ENGLISH] },
+      { languages: [LanguageCode.CHINESE_SIMPLIFIED] },
+    ])
+  ).toEqual([LanguageCode.CHINESE_SIMPLIFIED, LanguageCode.SPANISH]);
+});
+
+test('caBallotStyleLanguages keeps English when it is the only language', () => {
+  expect(
+    caBallotStyleLanguages([{ languages: [LanguageCode.ENGLISH] }])
+  ).toEqual([LanguageCode.ENGLISH]);
+});
 
 test('downloadFile cleans up temporary anchor tag', () => {
   downloadFile('http://localhost:1234/file.zip');

--- a/apps/design/frontend/src/utils.ts
+++ b/apps/design/frontend/src/utils.ts
@@ -1,6 +1,29 @@
 import { assert } from '@votingworks/basics';
+import { BallotStyle, LanguageCode } from '@votingworks/types';
+import { ORDERED_LANGUAGES } from '@votingworks/utils';
 import { customAlphabet } from 'nanoid';
 import useSoundLib from 'use-sound';
+
+/**
+ * The languages available for viewing the ballot styles in a CA template
+ * ballot style group. The CA template generates a separate ballot style per
+ * language, with non-English ballots rendered bilingually (English alongside
+ * the translated language), so the English-only variant is omitted whenever
+ * translated variants exist.
+ */
+export function caBallotStyleLanguages(
+  groupBallotStyles: ReadonlyArray<Pick<BallotStyle, 'languages'>>
+): LanguageCode[] {
+  const languages = ORDERED_LANGUAGES.filter((language) =>
+    groupBallotStyles.some((ballotStyle) =>
+      ballotStyle.languages.includes(language)
+    )
+  );
+  const translatedLanguages = languages.filter(
+    (language) => language !== LanguageCode.ENGLISH
+  );
+  return translatedLanguages.length > 0 ? translatedLanguages : languages;
+}
 
 const idGenerator = customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', 12);
 

--- a/libs/ui/src/search_select.test.tsx
+++ b/libs/ui/src/search_select.test.tsx
@@ -115,6 +115,22 @@ test('single and not searchable', () => {
   screen.getByText('Banana');
 });
 
+test('single with inverse styling', () => {
+  render(
+    <ControlledSingleSelect
+      options={options}
+      aria-label="Choose Fruit"
+      value="apple"
+      inverse
+    />
+  );
+
+  const select = screen.getByLabelText('Choose Fruit');
+  screen.getByText('Apple');
+  userEvent.click(select);
+  screen.getByRole('option', { name: 'Banana' });
+});
+
 test('single and searchable', async () => {
   render(
     <ControlledSingleSelect

--- a/libs/ui/src/search_select.tsx
+++ b/libs/ui/src/search_select.tsx
@@ -11,27 +11,30 @@ import { useTheme } from 'styled-components';
 import React from 'react';
 import { Button } from './button';
 
-function DropdownIndicator(
-  props: DropdownIndicatorProps<unknown, true>
-): JSX.Element {
-  return (
-    <components.DropdownIndicator {...props}>
-      <Button
-        fill="transparent"
-        icon="CaretDown"
-        // The react-select DropdownIndicator component has its own click
-        // handler. It seems to work fine with the button inside it, so we just
-        // put a dummy handler on the button itself.
-        onPress={() => {}}
-        style={{
-          padding: '0.25rem',
-          // Turn off inset shadow on press (:active) for touchscreen themes
-          boxShadow: 'none',
-        }}
-        tabIndex={-1}
-      />
-    </components.DropdownIndicator>
-  );
+function makeDropdownIndicator(inverse?: boolean) {
+  return function DropdownIndicator(
+    props: DropdownIndicatorProps<unknown, true>
+  ): JSX.Element {
+    return (
+      <components.DropdownIndicator {...props}>
+        <Button
+          fill="transparent"
+          color={inverse ? 'inverseNeutral' : 'neutral'}
+          icon="CaretDown"
+          // The react-select DropdownIndicator component has its own click
+          // handler. It seems to work fine with the button inside it, so we just
+          // put a dummy handler on the button itself.
+          onPress={() => {}}
+          style={{
+            padding: '0.25rem',
+            // Turn off inset shadow on press (:active) for touchscreen themes
+            boxShadow: 'none',
+          }}
+          tabIndex={-1}
+        />
+      </components.DropdownIndicator>
+    );
+  };
 }
 
 function MultiValueRemove(
@@ -107,6 +110,8 @@ interface SearchSelectBaseProps<T = string> {
   onInputChange?: (value?: T) => void;
   menuPortalTarget?: HTMLElement;
   menuShadow?: boolean;
+  /** Style the select for display on an inverse (dark) background. */
+  inverse?: boolean;
   minMenuHeight?: number;
   maxMenuHeight?: number;
   noOptionsMessage?: () => React.ReactNode;
@@ -153,6 +158,7 @@ export function SearchSelect<T = string>({
   required,
   menuPortalTarget,
   menuShadow,
+  inverse,
   minMenuHeight,
   noOptionsMessage,
   maxMenuHeight = 600, // in px, 1/2 admin's vh
@@ -160,6 +166,10 @@ export function SearchSelect<T = string>({
 }: SearchSelectSingleProps<T> | SearchSelectMultiProps<T>): JSX.Element {
   const theme = useTheme();
   const borderRadius = `${theme.sizes.borderRadiusRem}rem`;
+  const DropdownIndicator = React.useMemo(
+    () => makeDropdownIndicator(inverse),
+    [inverse]
+  );
 
   return (
     <Select
@@ -206,11 +216,15 @@ export function SearchSelect<T = string>({
         }),
         control: (baseStyles, state) => ({
           ...baseStyles,
+          // Match the border color RadioGroup uses in both regular and
+          // inverse modes.
           border: `${theme.colors.outline} solid ${theme.sizes.bordersRem.thin}rem`,
           borderStyle: state.isDisabled ? 'dashed' : 'solid',
           borderRadius: style?.borderRadius ?? borderRadius,
           backgroundColor: style?.backgroundColor
             ? style.backgroundColor
+            : inverse
+            ? theme.colors.inverseContainer
             : state.isDisabled
             ? theme.colors.container
             : state.isFocused
@@ -218,6 +232,10 @@ export function SearchSelect<T = string>({
             : theme.colors.containerLow,
           padding: '0.25rem',
           outline: state.isFocused ? `var(--focus-outline)` : undefined,
+        }),
+        singleValue: (baseStyles) => ({
+          ...baseStyles,
+          color: inverse ? theme.colors.onInverse : baseStyles.color,
         }),
         valueContainer: (baseStyles, state) => ({
           ...baseStyles,


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/8976
<!-- Add a link to a GitHub issue here -->
Instead of listing every language variant of a ballot style group in the ballot styles list, just list each group once. Then, add a language picker to the ballot preview screen.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated by Claude Code