### PR TITLE
[VxScan/VxCentralScan] Set scanner reporting device in cvr batch manifest file

### DIFF
--- a/libs/backend/src/cast_vote_records/build_report_metadata.test.ts
+++ b/libs/backend/src/cast_vote_records/build_report_metadata.test.ts
@@ -341,6 +341,7 @@ test('buildBatchManifest', () => {
         },
       ],
       scannerId,
+      scannerMachineType: 'precinct',
     })
   ).toEqual<CastVoteRecordBatchMetadata[]>([
     {
@@ -351,6 +352,7 @@ test('buildBatchManifest', () => {
       endTime: new Date(1989, 11, 14).toISOString(),
       sheetCount: 2,
       scannerId,
+      scannerMachineType: 'precinct',
       ballotCastingMode: 'early_voting',
       pollingPlaceId: 'polling-place-1',
     },
@@ -371,6 +373,7 @@ test('buildBatchManifest - optional fields omitted', () => {
         },
       ],
       scannerId,
+      scannerMachineType: 'central',
     })
   ).toEqual<CastVoteRecordBatchMetadata[]>([
     {
@@ -380,6 +383,7 @@ test('buildBatchManifest - optional fields omitted', () => {
       startTime: new Date(1989, 11, 13).toISOString(),
       sheetCount: 2,
       scannerId,
+      scannerMachineType: 'central',
       pollingPlaceId,
     },
   ]);

--- a/libs/backend/src/cast_vote_records/build_report_metadata.ts
+++ b/libs/backend/src/cast_vote_records/build_report_metadata.ts
@@ -6,6 +6,7 @@ import {
   CastVoteRecordBatchMetadata,
   CVR,
   Election,
+  ScannerMachineType,
   YesNoContest,
   StraightPartyContest,
 } from '@votingworks/types';
@@ -245,6 +246,7 @@ export function buildCastVoteRecordReportMetadata({
 export function buildBatchManifest(p: {
   batches: BatchInfo[];
   scannerId: string;
+  scannerMachineType: ScannerMachineType;
 }): CastVoteRecordBatchMetadata[] {
   return p.batches.map((batch) => ({
     id: batch.id,
@@ -254,6 +256,7 @@ export function buildBatchManifest(p: {
     endTime: batch.endedAt,
     sheetCount: batch.count,
     scannerId: p.scannerId,
+    scannerMachineType: p.scannerMachineType,
     ballotCastingMode: batch.ballotCastingMode,
     pollingPlaceId: batch.pollingPlaceId,
   }));

--- a/libs/backend/src/cast_vote_records/export.test.ts
+++ b/libs/backend/src/cast_vote_records/export.test.ts
@@ -501,6 +501,7 @@ test('precinct scanner continuous export', async () => {
     id: batch1.id,
     label: batch1.label,
     startTime: batch1.startedAt,
+    scannerMachineType: 'precinct',
   });
 });
 
@@ -1375,6 +1376,10 @@ test('ballot_casting_mode is not exported for central scanners', async () => {
     assertDefined(castVoteRecordExportMetadata.batchManifest[0])
       .ballotCastingMode
   ).toBeUndefined();
+  expect(
+    assertDefined(castVoteRecordExportMetadata.batchManifest[0])
+      .scannerMachineType
+  ).toEqual('central');
 });
 
 test('ballot_casting_mode is exported per batch for precinct scanners - continuous export', async () => {

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -34,6 +34,7 @@ import {
   MarkThresholds,
   PageInterpretation,
   PollsState,
+  ScannerMachineType,
   SheetOf,
   SystemSettings,
   unsafeParse,
@@ -91,14 +92,14 @@ export interface ScannerStoreBase {
  * The subset of central scanner store methods relevant to exporting cast vote records
  */
 export interface CentralScannerStore extends ScannerStoreBase {
-  scannerType: 'central';
+  scannerType: Extract<ScannerMachineType, 'central'>;
 }
 
 /**
  * The subset of precinct scanner store methods relevant to exporting cast vote records
  */
 export interface PrecinctScannerStore extends ScannerStoreBase {
-  scannerType: 'precinct';
+  scannerType: Extract<ScannerMachineType, 'precinct'>;
 
   deleteAllPendingContinuousExportOperations(): void;
   deletePendingContinuousExportOperation(sheetId: string): void;
@@ -130,11 +131,11 @@ interface ScannerStateUnchangedByExport {
 }
 
 interface CentralScannerOptions {
-  scannerType: 'central';
+  scannerType: Extract<ScannerMachineType, 'central'>;
 }
 
 interface PrecinctScannerOptions {
-  scannerType: 'precinct';
+  scannerType: Extract<ScannerMachineType, 'precinct'>;
   arePollsClosing?: boolean;
   /**
    * Precinct scanners export continuously as ballots are cast, but also still support full exports
@@ -542,6 +543,7 @@ async function exportMetadataFileToUsbDrive(
     batchManifest: buildBatchManifest({
       batches: exportContext.scannerState.batches,
       scannerId: VX_MACHINE_ID,
+      scannerMachineType: exportOptions.scannerType,
     }),
   };
   const metadataFileContents = JSON.stringify(metadata);

--- a/libs/backend/src/cast_vote_records/test_utils.ts
+++ b/libs/backend/src/cast_vote_records/test_utils.ts
@@ -271,7 +271,7 @@ export async function writeCastVoteRecordExport({
     castVoteRecordRootHash:
       await computeCastVoteRecordRootHashFromScratch(exportDirectoryPath),
     batchManifest: batchesByScannerId.flatMap((batchScanner) =>
-      buildBatchManifest(batchScanner)
+      buildBatchManifest({ ...batchScanner, scannerMachineType: 'precinct' })
     ),
   };
   const metadataFileContents = JSON.stringify(castVoteRecordExportMetadata);

--- a/libs/integration-test-utils/src/cast_vote_records.ts
+++ b/libs/integration-test-utils/src/cast_vote_records.ts
@@ -292,7 +292,11 @@ export async function generateCastVoteRecordExport(
     castVoteRecordReportMetadata: reportMetadata,
     castVoteRecordRootHash:
       await computeCastVoteRecordRootHashFromScratch(exportDirectory),
-    batchManifest: buildBatchManifest({ scannerId, batches }),
+    batchManifest: buildBatchManifest({
+      scannerId,
+      scannerMachineType: 'precinct',
+      batches,
+    }),
   };
   const metadataFileContents = JSON.stringify(metadata);
   await fs.writeFile(

--- a/libs/types/src/cast_vote_records.ts
+++ b/libs/types/src/cast_vote_records.ts
@@ -33,6 +33,13 @@ export enum CastVoteRecordExportFileName {
   REJECTED_SHEET_SUB_DIRECTORY_NAME_PREFIX = 'rejected-',
 }
 
+/**
+ * The type of scanning machine that produced a cast vote record export, i.e. a central scanner
+ * (VxCentralScan) or a precinct scanner (VxScan)
+ */
+export const ScannerMachineTypeSchema = z.enum(['central', 'precinct']);
+export type ScannerMachineType = z.infer<typeof ScannerMachineTypeSchema>;
+
 export interface CastVoteRecordBatchMetadata {
   readonly id: string;
   readonly label: string;
@@ -53,6 +60,7 @@ export interface CastVoteRecordBatchMetadata {
 
   readonly sheetCount: number;
   readonly scannerId: string;
+  readonly scannerMachineType?: ScannerMachineType;
   readonly ballotCastingMode?: BallotCastingMode;
   readonly pollingPlaceId: string;
 }
@@ -66,6 +74,7 @@ export const CastVoteRecordBatchMetadataSchema: z.ZodSchema<CastVoteRecordBatchM
     endTime: Iso8601TimestampSchema.optional(),
     sheetCount: z.number(),
     scannerId: z.string(),
+    scannerMachineType: ScannerMachineTypeSchema.optional(),
     ballotCastingMode: z.enum(['early_voting', 'election_day']).optional(),
     pollingPlaceId: z.string(),
   });

--- a/libs/types/src/cast_vote_records.ts
+++ b/libs/types/src/cast_vote_records.ts
@@ -33,10 +33,6 @@ export enum CastVoteRecordExportFileName {
   REJECTED_SHEET_SUB_DIRECTORY_NAME_PREFIX = 'rejected-',
 }
 
-/**
- * The type of scanning machine that produced a cast vote record export, i.e. a central scanner
- * (VxCentralScan) or a precinct scanner (VxScan)
- */
 export const ScannerMachineTypeSchema = z.enum(['central', 'precinct']);
 export type ScannerMachineType = z.infer<typeof ScannerMachineTypeSchema>;
 


### PR DESCRIPTION
## Overview
First step for https://github.com/votingworks/vxsuite/issues/8338 

We want to filter the live reporting results in VxAdmin to VxCentralScan results only, while "absentee" cvrs and cvrs attached to "absentee" polling places are approximations for such results, we allow for it to be possible in the system to have "precinct" ballots/cvrs and "election day" polling places set in VxCentralScan and in those cases we still want to send that data to live reports through VxAdmin. 

I was torn between putting this information in the batch manifest vs. using the "Model" field in "ReportingDevice" on the CDF definition for an individual CVR. I wasn't sure if we had best practices for making that decision, I went with putting it on the batch manifest which just felt a tiny bit simpler, and made sense since you can not have a batch with cvrs created from different devices. This feels a little less interoperable with the CDF format then using ReportingDevice.Model however, but I don't think we've made that a priority in the past. 

Future PRs will import this information into VxAdmin and update VxAdmins live reporting filtering. 

I'm not entirely sure how this task might intersect with cumulative CVRs, @adghayes called out a risk of double submission through live reporting when we build that in the task. 

## Demo Video or Screenshot
N/A 

## Testing Plan
Ran tests
Exported CVRs manually verified CVRs

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
