### PR TITLE
VxMark: shorten barcode QR payload keys to `bsId` and `pId`

### DIFF
--- a/apps/mark/backend/src/barcodes/activation.test.ts
+++ b/apps/mark/backend/src/barcodes/activation.test.ts
@@ -56,7 +56,7 @@ function createMockBarcodeClient(): MockBarcodeClient {
 // Builds the bytes a scanner emits for a ballot style QR code.
 function qrPayload(ballotStyleId: string, precinctId?: string): Uint8Array {
   return new TextEncoder().encode(
-    JSON.stringify({ ballotStyleId, precinctId })
+    JSON.stringify({ bsId: ballotStyleId, pId: precinctId })
   );
 }
 

--- a/apps/mark/backend/src/barcodes/activation.ts
+++ b/apps/mark/backend/src/barcodes/activation.ts
@@ -123,10 +123,8 @@ export function setUpBarcodeActivation(ctx: Context): void {
         }`,
       });
     }
-    const {
-      ballotStyleId: scannedBallotStyleId,
-      precinctId: scannedPrecinctId,
-    } = parseResult.ok();
+    const { bsId: scannedBallotStyleId, pId: scannedPrecinctId } =
+      parseResult.ok();
 
     const resolved = resolveBallotStyleForPollingPlace(
       election,
@@ -211,7 +209,7 @@ export function setUpBarcodeActivation(ctx: Context): void {
 /**
  * Parses a scanned barcode string into a {@link BallotStyleQrCode}. The scanner
  * emits the QR code's textual contents, which we expect to be JSON of the form
- * `{"ballotStyleId":"<id>"}`.
+ * `{"bsId":"<id>","pId":"<id>"}`.
  */
 function parseBallotStyleQrCode(
   barcode: string

--- a/apps/mark/backend/src/barcodes/hid_pos.test.ts
+++ b/apps/mark/backend/src/barcodes/hid_pos.test.ts
@@ -11,7 +11,7 @@ function decodeToString(report: Uint8Array): string | undefined {
 }
 
 test('extracts the payload from a framed HID POS report, dropping AIM id and padding', () => {
-  const json = '{"ballotStyleId":"1_en","precinctId":"xkd0mbksmae2"}';
+  const json = '{"bsId":"1_en","pId":"xkd0mbksmae2"}';
   const jsonBytes = new TextEncoder().encode(json);
   const report = Uint8Array.from([
     REPORT_ID,

--- a/apps/mark/backend/src/barcodes/types.ts
+++ b/apps/mark/backend/src/barcodes/types.ts
@@ -8,21 +8,24 @@ import {
 
 /**
  * The payload encoded in a QR code (e.g. a VxPollbook check-in receipt) that
- * identifies which ballot style to activate. Carries the ballot style ID, which
- * is resolved against the loaded election definition. An optional precinct ID
- * disambiguates when the ballot style maps to more than one precinct in the
- * machine's configured polling place; when omitted, the precinct is derived
- * (used directly when there is only one).
+ * identifies which ballot style to activate, e.g.
+ * `{"bsId":"<ballotStyleId>","pId":"<precinctId>"}`. Keys are abbreviated to
+ * keep the encoded payload small enough to fit in a single scanner report.
+ *
+ * `bsId` (ballot style ID) is resolved against the loaded election definition.
+ * `pId` (precinct ID) is optional and disambiguates when the ballot style maps
+ * to more than one precinct in the machine's configured polling place; when
+ * omitted, the precinct is derived (used directly when there is only one).
  */
 export interface BallotStyleQrCode {
-  ballotStyleId: BallotStyleId;
-  precinctId?: PrecinctId;
+  bsId: BallotStyleId;
+  pId?: PrecinctId;
 }
 
 export const BallotStyleQrCodeSchema: z.ZodSchema<BallotStyleQrCode> = z.object(
   {
-    ballotStyleId: BallotStyleIdSchema,
-    precinctId: PrecinctIdSchema.optional(),
+    bsId: BallotStyleIdSchema,
+    pId: PrecinctIdSchema.optional(),
   }
 );
 

--- a/apps/mark/frontend/src/pages/barcode_ballot_printing_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/barcode_ballot_printing_screen.test.tsx
@@ -70,7 +70,7 @@ test('waits when there is no scan', async () => {
 
 test('ignores a stale scan from before the screen opened', async () => {
   apiMock.expectGetMostRecentBarcodeScan({
-    data: JSON.stringify({ ballotStyleId: spanishBallotStyle.id }),
+    data: JSON.stringify({ bsId: spanishBallotStyle.id }),
     timestamp: new Date(Date.now() - 10_000),
   });
   renderScreen();
@@ -88,7 +88,7 @@ test('ignores a scan that is not a valid ballot style QR code', async () => {
 
 test('waits when the scanned ballot style does not resolve to one precinct', async () => {
   apiMock.expectGetMostRecentBarcodeScan({
-    data: JSON.stringify({ ballotStyleId: spanishBallotStyle.id }),
+    data: JSON.stringify({ bsId: spanishBallotStyle.id }),
     timestamp: new Date(Date.now() + 10_000),
   });
   apiMock.mockApiClient.getPrecinctsForBallotStyle
@@ -101,8 +101,8 @@ test('waits when the scanned ballot style does not resolve to one precinct', asy
 test('uses the scanned precinct to disambiguate a multi-precinct ballot style', async () => {
   apiMock.expectGetMostRecentBarcodeScan({
     data: JSON.stringify({
-      ballotStyleId: spanishBallotStyle.id,
-      precinctId: otherPrecinctId,
+      bsId: spanishBallotStyle.id,
+      pId: otherPrecinctId,
     }),
     timestamp: new Date(Date.now() + 10_000),
   });
@@ -117,8 +117,8 @@ test('uses the scanned precinct to disambiguate a multi-precinct ballot style', 
 test('waits when the scanned precinct is not valid for the polling place', async () => {
   apiMock.expectGetMostRecentBarcodeScan({
     data: JSON.stringify({
-      ballotStyleId: spanishBallotStyle.id,
-      precinctId: 'not-a-real-precinct',
+      bsId: spanishBallotStyle.id,
+      pId: 'not-a-real-precinct',
     }),
     timestamp: new Date(Date.now() + 10_000),
   });
@@ -131,7 +131,7 @@ test('waits when the scanned precinct is not valid for the polling place', async
 
 test('opens the locked print screen for a fresh single-precinct scan', async () => {
   apiMock.expectGetMostRecentBarcodeScan({
-    data: JSON.stringify({ ballotStyleId: spanishBallotStyle.id }),
+    data: JSON.stringify({ bsId: spanishBallotStyle.id }),
     timestamp: new Date(Date.now() + 10_000),
   });
   apiMock.mockApiClient.getPrecinctsForBallotStyle

--- a/apps/mark/frontend/src/pages/barcode_ballot_printing_screen.tsx
+++ b/apps/mark/frontend/src/pages/barcode_ballot_printing_screen.tsx
@@ -16,12 +16,14 @@ import { PrintBlankBallotScreen } from './print_blank_ballot_screen';
 function parseScannedQrCode(
   data: string
 ): { ballotStyleId: string; precinctId?: string } | undefined {
+  // Wire keys are abbreviated (`bsId`/`pId`) to keep the payload small; map them
+  // to descriptive names here so the rest of the screen stays readable.
   const parsed = safeParseJson(data).ok() as
-    | { ballotStyleId?: unknown; precinctId?: unknown }
+    | { bsId?: unknown; pId?: unknown }
     | undefined;
-  const ballotStyleId = parsed?.ballotStyleId;
+  const ballotStyleId = parsed?.bsId;
   if (typeof ballotStyleId !== 'string') return undefined;
-  const precinctId = parsed?.precinctId;
+  const precinctId = parsed?.pId;
   return {
     ballotStyleId,
     precinctId: typeof precinctId === 'string' ? precinctId : undefined,

--- a/libs/dev-dock/backend/src/dev_dock_api.test.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.test.ts
@@ -469,8 +469,8 @@ test('emitBarcodeScan forwards the payload to the host app', async () => {
   const emitBarcodeScan = vi.fn();
   const { apiClient } = setup({ printerConfig: 'fujitsu', emitBarcodeScan });
 
-  await apiClient.emitBarcodeScan({ payload: '{"ballotStyleId":"1_en"}' });
-  expect(emitBarcodeScan).toHaveBeenCalledWith('{"ballotStyleId":"1_en"}');
+  await apiClient.emitBarcodeScan({ payload: '{"bsId":"1_en"}' });
+  expect(emitBarcodeScan).toHaveBeenCalledWith('{"bsId":"1_en"}');
 });
 
 test('hardware mock status endpoints for barcode, accessible controller, and pat', async () => {

--- a/libs/dev-dock/frontend/src/dev_dock.test.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.test.tsx
@@ -570,10 +570,10 @@ test('barcode scan mock control emits a scan payload', async () => {
     name: 'Barcode Payload',
   });
   userEvent.clear(payloadInput);
-  userEvent.type(payloadInput, '{{"ballotStyleId":"1_en"}');
+  userEvent.type(payloadInput, '{{"bsId":"1_en"}');
 
   mockApiClient.emitBarcodeScan
-    .expectCallWith({ payload: '{"ballotStyleId":"1_en"}' })
+    .expectCallWith({ payload: '{"bsId":"1_en"}' })
     .resolves();
   userEvent.click(screen.getByRole('button', { name: 'Emit' }));
   await waitFor(() => mockApiClient.assertComplete());

--- a/libs/dev-dock/frontend/src/dev_dock.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.tsx
@@ -755,7 +755,7 @@ function BarcodeScanMockControl() {
   const apiClient = useApiClient();
   const emitBarcodeScanMutation = useMutation(apiClient.emitBarcodeScan);
   const [isOpen, setIsOpen] = useState(false);
-  const [payload, setPayload] = useState('{"ballotStyleId":""}');
+  const [payload, setPayload] = useState('{"bsId":""}');
   const isBarcodeMockEnabled = isFeatureFlagEnabled(
     BooleanEnvironmentVariableName.USE_MOCK_BARCODE_READER
   );


### PR DESCRIPTION
## Overview

Shortens the QR payload keys to allow more headroom for payload values. HID reports are limited to 64 bytes; with the old keys, we were dangerously close to splitting payloads across 2 reports.

See context in https://votingworks.slack.com/archives/C020T5L9MUG/p1785168067004459?thread_ts=1784317496.252299&cid=C020T5L9MUG

## Demo Video or Screenshot

N/A

## Testing Plan

Existing tests + manual verification with hardware

