### PR TITLE
VxScan: Keep the primary action consistent through ballot review

### DIFF
--- a/apps/scan/frontend/src/screens/ballot_review_screen.tsx
+++ b/apps/scan/frontend/src/screens/ballot_review_screen.tsx
@@ -184,6 +184,12 @@ export interface BallotReviewScreenProps {
   hasCastBallot: boolean;
   onCastBallot: () => void;
   overvoteContestIds?: ReadonlySet<ContestId>;
+  /**
+   * Whether returning the ballot, rather than casting it, is the primary
+   * action. Should match the primary action on the screen the voter came from,
+   * so that the emphasized action doesn't change as they review their votes.
+   */
+  returnBallotIsPrimary?: boolean;
 }
 
 /**
@@ -199,6 +205,7 @@ export function BallotReviewScreen({
   hasCastBallot,
   onCastBallot,
   overvoteContestIds = new Set(),
+  returnBallotIsPrimary = false,
 }: BallotReviewScreenProps): JSX.Element {
   const returnBallotMutation = returnBallot.useMutation();
 
@@ -214,6 +221,7 @@ export function BallotReviewScreen({
         <React.Fragment>
           <Button
             id={PageNavigationButtonId.PREVIOUS_AFTER_CONFIRM}
+            variant={returnBallotIsPrimary ? 'primary' : undefined}
             onPress={() => returnBallotMutation.mutate()}
             disabled={hasCastBallot}
           >
@@ -221,7 +229,7 @@ export function BallotReviewScreen({
           </Button>
           <Button
             id={PageNavigationButtonId.NEXT_AFTER_CONFIRM}
-            variant="primary"
+            variant={returnBallotIsPrimary ? undefined : 'primary'}
             onPress={onCastBallot}
             disabled={hasCastBallot}
           >

--- a/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.test.tsx
@@ -108,8 +108,13 @@ test('overvote', async () => {
   expect(isButtonVariantPrimary(reviewButton)).toEqual(false);
   userEvent.click(reviewButton);
 
-  // On the ballot review screen, cast the ballot.
+  // Returning the ballot stays the primary action on the ballot review screen.
   const castBallotButton = await screen.findButton('Cast Ballot');
+  expect(isButtonVariantPrimary(screen.getButton('Return Ballot'))).toEqual(
+    true
+  );
+  expect(isButtonVariantPrimary(castBallotButton)).toEqual(false);
+
   userEvent.click(castBallotButton);
   expect(castBallotButton).toBeDisabled();
 });
@@ -171,8 +176,13 @@ test('crossover voting (cast ballot)', async () => {
   expect(isButtonVariantPrimary(reviewButton)).toEqual(false);
   userEvent.click(reviewButton);
 
-  // On the ballot review screen, cast the ballot.
+  // Returning the ballot stays the primary action on the ballot review screen.
   const castBallotButton = await screen.findButton('Cast Ballot');
+  expect(isButtonVariantPrimary(screen.getButton('Return Ballot'))).toEqual(
+    true
+  );
+  expect(isButtonVariantPrimary(castBallotButton)).toEqual(false);
+
   userEvent.click(castBallotButton);
   expect(castBallotButton).toBeDisabled();
 });
@@ -203,8 +213,13 @@ test('blank ballot', async () => {
   expect(isButtonVariantPrimary(reviewButton)).toEqual(false);
   userEvent.click(reviewButton);
 
-  // On the ballot review screen, cast the ballot.
+  // Returning the ballot stays the primary action on the ballot review screen.
   const castBallotButton = await screen.findButton('Cast Ballot');
+  expect(isButtonVariantPrimary(screen.getButton('Return Ballot'))).toEqual(
+    true
+  );
+  expect(isButtonVariantPrimary(castBallotButton)).toEqual(false);
+
   userEvent.click(castBallotButton);
   expect(castBallotButton).toBeDisabled();
 });
@@ -243,8 +258,13 @@ test('undervote no votes', async () => {
   expect(isButtonVariantPrimary(returnBallotButton)).toEqual(false);
   userEvent.click(reviewButton);
 
-  // On the ballot review screen, cast the ballot.
+  // Casting the ballot stays the primary action on the ballot review screen.
   const castBallotButton = await screen.findButton('Cast Ballot');
+  expect(isButtonVariantPrimary(castBallotButton)).toEqual(true);
+  expect(isButtonVariantPrimary(screen.getButton('Return Ballot'))).toEqual(
+    false
+  );
+
   userEvent.click(castBallotButton);
   expect(castBallotButton).toBeDisabled();
 });
@@ -285,8 +305,13 @@ test('undervote by 1', async () => {
   expect(isButtonVariantPrimary(returnBallotButton)).toEqual(false);
   userEvent.click(reviewButton);
 
-  // On the ballot review screen, cast the ballot.
+  // Casting the ballot stays the primary action on the ballot review screen.
   const castBallotButton = await screen.findButton('Cast Ballot');
+  expect(isButtonVariantPrimary(castBallotButton)).toEqual(true);
+  expect(isButtonVariantPrimary(screen.getButton('Return Ballot'))).toEqual(
+    false
+  );
+
   userEvent.click(castBallotButton);
   expect(castBallotButton).toBeDisabled();
 });
@@ -323,8 +348,13 @@ test('multiple undervotes', async () => {
   expect(isButtonVariantPrimary(returnBallotButton)).toEqual(false);
   userEvent.click(reviewButton);
 
-  // On the ballot review screen, cast the ballot.
+  // Casting the ballot stays the primary action on the ballot review screen.
   const castBallotButton = await screen.findButton('Cast Ballot');
+  expect(isButtonVariantPrimary(castBallotButton)).toEqual(true);
+  expect(isButtonVariantPrimary(screen.getButton('Return Ballot'))).toEqual(
+    false
+  );
+
   userEvent.click(castBallotButton);
   expect(castBallotButton).toBeDisabled();
 });

--- a/apps/scan/frontend/src/screens/scan_warning_screen.tsx
+++ b/apps/scan/frontend/src/screens/scan_warning_screen.tsx
@@ -37,6 +37,7 @@ interface MisvoteWarningScreenProps {
   overvotes: readonly OvervoteAdjudicationReasonInfo[];
   undervotes: readonly UndervoteAdjudicationReasonInfo[];
   isTestMode: boolean;
+  returnBallotIsPrimary: boolean;
   onReview: () => void;
 }
 
@@ -46,6 +47,7 @@ function MisvoteWarningScreen({
   overvotes,
   undervotes,
   isTestMode,
+  returnBallotIsPrimary,
   onReview,
 }: MisvoteWarningScreenProps): JSX.Element {
   const returnBallotMutation = returnBallot.useMutation();
@@ -99,19 +101,13 @@ function MisvoteWarningScreen({
     }
   }
 
-  // If there are overvotes, we nudge the voter toward returning the ballot.
-  // Given that undervotes are often intentional, we don't discourage casting
-  // the ballot in that case. Note that completely blank ballots are handled
-  // by another component.
-  const returnBallotButtonIsPrimary = overvoteContests.length > 0;
-
   return (
     <Screen
       actionButtons={
         <React.Fragment>
           <Button
             id={PageNavigationButtonId.PREVIOUS_AFTER_CONFIRM}
-            variant={returnBallotButtonIsPrimary ? 'primary' : undefined}
+            variant={returnBallotIsPrimary ? 'primary' : undefined}
             onPress={onReturnBallot}
             disabled={hasReturnedBallot}
           >
@@ -121,7 +117,7 @@ function MisvoteWarningScreen({
           {(allowCastingOvervotes || overvoteContests.length === 0) && (
             <Button
               id={PageNavigationButtonId.NEXT_AFTER_CONFIRM}
-              variant={returnBallotButtonIsPrimary ? undefined : 'primary'}
+              variant={returnBallotIsPrimary ? undefined : 'primary'}
               onPress={onReview}
               disabled={hasReturnedBallot}
             >
@@ -371,6 +367,16 @@ export function ScanWarningScreen({
     }
   }
 
+  // We nudge the voter toward returning the ballot for every warning except
+  // undervotes alone, since undervotes are often intentional. Whichever action
+  // is primary here stays primary on the ballot review screen.
+  const isUndervoteOnlyWarning =
+    !isBlank &&
+    !isCrossover &&
+    overvoteReasons.length === 0 &&
+    undervoteReasons.length > 0;
+  const returnBallotIsPrimary = !isUndervoteOnlyWarning;
+
   // Once the voter chooses to review, show the detailed ballot review screen
   // (with over/undervote and blank-contest warnings) where they cast or return.
   if (showBallotReviewScreen) {
@@ -386,6 +392,7 @@ export function ScanWarningScreen({
         hasCastBallot={hasCastBallot}
         onCastBallot={onCastBallot}
         overvoteContestIds={overvoteContestIds}
+        returnBallotIsPrimary={returnBallotIsPrimary}
       />
     );
   }
@@ -413,6 +420,7 @@ export function ScanWarningScreen({
         undervotes={undervoteReasons}
         overvotes={overvoteReasons}
         isTestMode={isTestMode}
+        returnBallotIsPrimary={returnBallotIsPrimary}
         onReview={onReview}
       />
     );


### PR DESCRIPTION
The ballot review screen always makes Cast Ballot the primary action, even when the preceding warning screen nudges the voter toward returning the ballot (e.g. in the case of an overvote). Pass the primary action down from the warning screen so that it doesn't change as the voter reviews their votes.