### PR TITLE
Make candidate grid columns election wide instead of contest specific

### DIFF
--- a/apps/design/backend/migrations/1784930000000_move-candidate-columns-to-election.js
+++ b/apps/design/backend/migrations/1784930000000_move-candidate-columns-to-election.js
@@ -1,0 +1,18 @@
+exports.shorthands =
+  /** @type {import('node-pg-migrate').ColumnDefinitions | undefined} */ (
+    undefined
+  );
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  pgm.dropColumn('contests', 'candidate_columns');
+  pgm.addColumn('elections', {
+    large_contest_candidate_columns: {
+      type: 'integer',
+    },
+  });
+};

--- a/apps/design/backend/src/app.ts
+++ b/apps/design/backend/src/app.ts
@@ -671,9 +671,11 @@ export function buildApi(ctx: AppContext) {
       await store.deleteContest(input.electionId, input.contestId);
     },
 
-    async getBallotLayoutSettings(input: {
-      electionId: ElectionId;
-    }): Promise<{ paperSize: HmpbBallotPaperSize; compact: boolean }> {
+    async getBallotLayoutSettings(input: { electionId: ElectionId }): Promise<{
+      paperSize: HmpbBallotPaperSize;
+      compact: boolean;
+      largeContestCandidateColumns?: number;
+    }> {
       return store.getBallotLayoutSettings(input.electionId);
     },
 
@@ -681,12 +683,14 @@ export function buildApi(ctx: AppContext) {
       electionId: ElectionId;
       paperSize: HmpbBallotPaperSize;
       compact: boolean;
+      largeContestCandidateColumns?: number;
     }): Promise<void> {
       const paperSize = unsafeParse(HmpbBallotPaperSizeSchema, input.paperSize);
       await store.updateBallotLayoutSettings(
         input.electionId,
         paperSize,
-        input.compact
+        input.compact,
+        input.largeContestCandidateColumns
       );
     },
 

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -417,11 +417,10 @@ async function insertContest(
             party_id,
             term_description,
             nomination_type,
-            candidate_columns,
             ballot_order
           )
-          values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, ${
-            ballotOrder ? '$12' : 'DEFAULT'
+          values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, ${
+            ballotOrder ? '$11' : 'DEFAULT'
           })
         `,
         contest.id,
@@ -434,7 +433,6 @@ async function insertContest(
         contest.partyId,
         contest.termDescription,
         contest.nominationType,
-        contest.candidateColumns,
         ...(ballotOrder ? [ballotOrder] : [])
       );
       for (const candidate of contest.candidates) {
@@ -923,6 +921,7 @@ export class Store {
               signature,
               system_settings_data as "systemSettingsData",
               ballot_paper_size as "ballotPaperSize",
+              large_contest_candidate_columns as "largeContestCandidateColumns",
               ballot_template_id as "ballotTemplateId",
               ballots_finalized_at as "ballotsFinalizedAt",
               created_at as "createdAt",
@@ -949,6 +948,7 @@ export class Store {
         signature: Signature | null;
         systemSettingsData: string;
         ballotPaperSize: HmpbBallotPaperSize;
+        largeContestCandidateColumns: number | null;
         ballotTemplateId: BallotTemplateId;
         ballotsFinalizedAt: Date | null;
         createdAt: Date;
@@ -1061,7 +1061,6 @@ export class Store {
               party_id as "partyId",
               term_description as "termDescription",
               nomination_type as "nominationType",
-              candidate_columns as "candidateColumns",
               description,
               yes_option_id as "yesOptionId",
               yes_option_label as "yesOptionLabel",
@@ -1084,7 +1083,6 @@ export class Store {
         partyId: PartyId | null;
         termDescription: string | null;
         nominationType: ContestNominationType | null;
-        candidateColumns: number | null;
         description: string | null;
         yesOptionId: string | null;
         yesOptionLabel: string | null;
@@ -1158,7 +1156,6 @@ export class Store {
               partyId: row.partyId ?? undefined,
               termDescription: row.termDescription ?? undefined,
               nominationType: row.nominationType ?? undefined,
-              candidateColumns: row.candidateColumns ?? undefined,
               candidates,
             });
           }
@@ -1257,6 +1254,8 @@ export class Store {
         ballotLayout: {
           paperSize: electionRow.ballotPaperSize,
           metadataEncoding: 'qr-code',
+          largeContestCandidateColumns:
+            electionRow.largeContestCandidateColumns ?? undefined,
         },
         ballotStrings: {},
       };
@@ -2223,16 +2222,19 @@ export class Store {
     assert(rowCount === 1, 'Contest not found');
   }
 
-  async getBallotLayoutSettings(
-    electionId: ElectionId
-  ): Promise<{ paperSize: HmpbBallotPaperSize; compact: boolean }> {
+  async getBallotLayoutSettings(electionId: ElectionId): Promise<{
+    paperSize: HmpbBallotPaperSize;
+    compact: boolean;
+    largeContestCandidateColumns?: number;
+  }> {
     const row = (
       await this.db.withClient((client) =>
         client.query(
           `
             select
               ballot_paper_size as "paperSize",
-              ballot_compact as "compact"
+              ballot_compact as "compact",
+              large_contest_candidate_columns as "largeContestCandidateColumns"
             from elections
             where id = $1
           `,
@@ -2241,13 +2243,18 @@ export class Store {
       )
     ).rows[0];
     assert(row, 'Election not found');
-    return row;
+    return {
+      ...row,
+      largeContestCandidateColumns:
+        row.largeContestCandidateColumns ?? undefined,
+    };
   }
 
   async updateBallotLayoutSettings(
     electionId: ElectionId,
     paperSize: HmpbBallotPaperSize,
-    compact: boolean
+    compact: boolean,
+    largeContestCandidateColumns?: number
   ): Promise<void> {
     const { rowCount } = await this.db.withClient((client) =>
       client.query(
@@ -2255,11 +2262,13 @@ export class Store {
           update elections
           set
             ballot_paper_size = $1,
-            ballot_compact = $2
-          where id = $3
+            ballot_compact = $2,
+            large_contest_candidate_columns = $3
+          where id = $4
         `,
         paperSize,
         compact,
+        largeContestCandidateColumns ?? null,
         electionId
       )
     );

--- a/apps/design/frontend/src/ballots_screen.tsx
+++ b/apps/design/frontend/src/ballots_screen.tsx
@@ -14,7 +14,12 @@ import {
 } from '@votingworks/ui';
 import { Redirect, Route, Switch, useParams } from 'react-router-dom';
 import { find } from '@votingworks/basics';
-import { HmpbBallotPaperSize, ElectionId, hasSplits } from '@votingworks/types';
+import {
+  HmpbBallotPaperSize,
+  ElectionId,
+  hasSplits,
+  safeParseNumber,
+} from '@votingworks/types';
 import { useState } from 'react';
 import styled from 'styled-components';
 import {
@@ -54,6 +59,7 @@ function BallotDesignForm({
   savedLayoutSettings: {
     paperSize: HmpbBallotPaperSize;
     compact: boolean;
+    largeContestCandidateColumns?: number;
   };
   ballotsFinalizedAt: Date | null;
   ballotTemplateId: BallotTemplateId;
@@ -114,6 +120,26 @@ function BallotDesignForm({
           disabled={!isEditing}
         />
       </div>
+      {ballotTemplateId === 'CaBallot' && (
+        <div style={{ maxWidth: '16.5rem' }}>
+          <RadioGroup
+            label="Large Contest Candidate Columns"
+            options={[
+              { value: '3', label: '3' },
+              { value: '4', label: '4' },
+            ]}
+            value={String(layoutSettings.largeContestCandidateColumns ?? 4)}
+            onChange={(value) =>
+              setLayoutSettings({
+                ...layoutSettings,
+                largeContestCandidateColumns:
+                  safeParseNumber(value).unsafeUnwrap(),
+              })
+            }
+            disabled={!isEditing}
+          />
+        </div>
+      )}
       {ballotTemplateId !== 'MiBallot' &&
         ballotTemplateId !== 'NhStateBallot' &&
         ballotTemplateId !== 'CaBallot' && (

--- a/apps/design/frontend/src/contest_form.tsx
+++ b/apps/design/frontend/src/contest_form.tsx
@@ -16,7 +16,6 @@ import {
   ContestId,
   ContestNominationType,
   safeParse,
-  safeParseNumber,
   YesNoContestSchema,
   ElectionStringKey,
   StraightPartyContest,
@@ -500,22 +499,6 @@ export function ContestForm(props: ContestFormProps): React.ReactNode {
                   selectedOptionId={contest.nominationType ?? 'voter-nominated'}
                   onChange={(value) =>
                     setContest({ ...contest, nominationType: value })
-                  }
-                />
-                <SegmentedButton
-                  disabled={disabled}
-                  label="Candidate Columns"
-                  options={[
-                    { id: '1', label: '1' },
-                    { id: '3', label: '3' },
-                    { id: '4', label: '4' },
-                  ]}
-                  selectedOptionId={String(contest.candidateColumns ?? 1)}
-                  onChange={(value) =>
-                    setContest({
-                      ...contest,
-                      candidateColumns: safeParseNumber(value).unsafeUnwrap(),
-                    })
                   }
                 />
               </InputRow>
@@ -1032,7 +1015,6 @@ interface DraftCandidateContest {
   candidates: DraftCandidate[];
   partyId?: PartyId;
   nominationType?: ContestNominationType;
-  candidateColumns?: number;
 }
 
 interface DraftOption {

--- a/libs/hmpb/src/ballot_templates/ca_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/ca_ballot_template.tsx
@@ -271,8 +271,21 @@ function nominationTypeOf(
   return contest.nominationType ?? 'voter-nominated';
 }
 
-function contestGridColumns(contest: ContestStruct): number {
-  return contest.type === 'candidate' ? contest.candidateColumns ?? 1 : 1;
+// Contests with more candidates than this render as a full-width grid of
+// candidate options (using the election's configured column count) instead of
+// flowing in a single page column.
+const LARGE_CONTEST_CANDIDATE_THRESHOLD = 20;
+const DEFAULT_LARGE_CONTEST_CANDIDATE_COLUMNS = 4;
+
+function contestGridColumns(
+  election: Election,
+  contest: ContestStruct
+): number {
+  return contest.type === 'candidate' &&
+    contest.candidates.length > LARGE_CONTEST_CANDIDATE_THRESHOLD
+    ? election.ballotLayout.largeContestCandidateColumns ??
+        DEFAULT_LARGE_CONTEST_CANDIDATE_COLUMNS
+    : 1;
 }
 
 function Header({
@@ -519,7 +532,7 @@ function CandidateContest({
     contest,
     ballotStyle,
   });
-  const gridColumns = contestGridColumns(contest);
+  const gridColumns = contestGridColumns(election, contest);
   const primaryLanguage = primaryLanguageCode(ballotStyle);
   // Transliterated candidate names, looked up directly from the election's
   // ballot strings in the ballot's primary language. Candidate names are
@@ -1123,7 +1136,7 @@ function buildBands(
       const runs: Run[] = [];
       for (const contest of districtContests) {
         const lastRun = runs.at(-1);
-        if (contestGridColumns(contest) > 1) {
+        if (contestGridColumns(election, contest) > 1) {
           runs.push({ grid: true, contest });
         } else if (lastRun && !lastRun.grid) {
           lastRun.contests.push(contest);

--- a/libs/hmpb/src/render_ballot.test.tsx
+++ b/libs/hmpb/src/render_ballot.test.tsx
@@ -323,7 +323,9 @@ test.each(templateSpecificTestCases)(
       title: 'Oversized Contest',
       seats: 1,
       allowWriteIns: false,
-      candidates: range(0, 100).map((i) => ({
+      // Large enough that it can't fit on a page even for templates that lay
+      // out large contests as a multi-column grid (e.g. the CA template)
+      candidates: range(0, 300).map((i) => ({
         id: `candidate-${i}`,
         name: `Candidate ${i}`,
       })),

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -207,9 +207,6 @@ export interface CandidateContest extends ContestBase {
   readonly partyId?: PartyId;
   readonly termDescription?: string;
   readonly nominationType?: ContestNominationType;
-  // Number of columns to lay candidate options out in on the ballot, for
-  // templates that support grid contest layouts (e.g. the CA ballot template).
-  readonly candidateColumns?: number;
 }
 export const CandidateContestSchema: z.ZodSchema<CandidateContest> =
   ContestBaseSchema.extend({
@@ -220,7 +217,6 @@ export const CandidateContestSchema: z.ZodSchema<CandidateContest> =
     partyId: PartyIdSchema.optional(),
     termDescription: z.string().nonempty().optional(),
     nominationType: ContestNominationTypeSchema.optional(),
-    candidateColumns: z.number().int().min(1).max(4).optional(),
   }).check((ctx) => {
     const contest = ctx.value;
     for (const [index, id] of findDuplicateIds(contest.candidates)) {
@@ -722,10 +718,14 @@ export type BallotPaperSize = HmpbBallotPaperSize | BmdBallotPaperSize;
 export interface BallotLayout {
   paperSize: HmpbBallotPaperSize;
   metadataEncoding: 'qr-code';
+  // Number of columns to lay out candidate options in for large contests, for
+  // templates that support grid contest layouts (e.g. the CA ballot template).
+  largeContestCandidateColumns?: number;
 }
 export const BallotLayoutSchema: z.ZodSchema<BallotLayout> = z.object({
   paperSize: HmpbBallotPaperSizeSchema,
   metadataEncoding: z.enum(['qr-code']),
+  largeContestCandidateColumns: z.number().int().min(2).max(4).optional(),
 });
 
 // Hand-marked paper & adjudication


### PR DESCRIPTION
## Overview

Relocating since this is more a layout concern rather that contest data. 

<img width="3024" height="1652" alt="Screenshot 2026-07-27 at 5 19 47 PM" src="https://github.com/user-attachments/assets/d310bb42-a673-4557-9ef7-eecbfeead2d5" />


## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
