### PR TITLE
VxMark: Prevent blank ballot printing when polls are closed

### DIFF
--- a/apps/mark/frontend/src/app_barcode_ballot_printing.test.tsx
+++ b/apps/mark/frontend/src/app_barcode_ballot_printing.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { anyPollingPlace, DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
@@ -50,4 +50,28 @@ test('poll worker still sees the poll worker screen until a ballot style is scan
   buildApp(apiMock).renderApp();
 
   await screen.findByText(hasTextAcrossElements('Polls: Open'));
+});
+
+test('ignores scans while polls are closed', async () => {
+  // Same setup as ballot-printing mode, but polls are not open. The frontend
+  // never even polls for the most recent scan (no expectGetMostRecentBarcodeScan
+  // below), so a scanned ballot style cannot open the printing screen.
+  apiMock.expectGetMachineConfig();
+  apiMock.expectGetSystemSettings({
+    ...DEFAULT_SYSTEM_SETTINGS,
+    bmdEnableQrBallotActivation: true,
+  });
+  apiMock.expectGetElectionRecord(electionGeneralDefinition);
+  apiMock.expectGetElectionState({
+    pollingPlaceId: pollingPlace.id,
+    pollsState: 'polls_closed_initial',
+  });
+  apiMock.mockApiClient.getBarcodeActivationMode
+    .expectRepeatedCallsWith()
+    .resolves('ballot_printing');
+  apiMock.setAuthStatusPollWorkerLoggedIn(electionGeneralDefinition);
+  buildApp(apiMock).renderApp();
+
+  await screen.findByText(hasTextAcrossElements('Polls: Closed'));
+  expect(screen.queryByText('Blank Ballot Printing')).toBeNull();
 });

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -238,7 +238,8 @@ export function AppRoot(): JSX.Element | null {
 
   // When QR ballot activation is set to "ballot_printing" mode, a scanned ballot
   // style QR code opens the blank ballot printing screen instead of starting a
-  // voter session.
+  // voter session. Like starting a voter session, this is only available while
+  // polls are open; scans are ignored when polls are closed.
   const systemSettingsQuery = getSystemSettings.useQuery();
   const isQrBallotActivationEnabled = Boolean(
     systemSettingsQuery.data?.bmdEnableQrBallotActivation
@@ -247,7 +248,8 @@ export function AppRoot(): JSX.Element | null {
     enabled: isQrBallotActivationEnabled,
   });
   const isBallotPrintingScanMode =
-    barcodeActivationModeQuery.data === 'ballot_printing';
+    barcodeActivationModeQuery.data === 'ballot_printing' &&
+    pollsState === 'polls_open';
 
   const precinctId = isCardlessVoterAuth(authStatus)
     ? authStatus.user.precinctId

--- a/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
@@ -280,6 +280,14 @@ test('hides the Print Blank Ballot button when the setting is disabled', () => {
   expect(screen.queryByText('Print Blank Ballot')).toBeNull();
 });
 
+test('hides the Print Blank Ballot button when polls are not open', () => {
+  expectSystemSettings(true);
+  renderScreen({ pollsState: 'polls_closed_initial' });
+
+  screen.getByText('Poll Worker Menu');
+  expect(screen.queryByText('Print Blank Ballot')).toBeNull();
+});
+
 const multiLanguageDefinition = getMockMultiLanguageElectionDefinition(
   electionGeneralDefinition,
   ['en', 'es-US']

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -148,7 +148,7 @@ export function PollWorkerScreen({
               pollingPlaceId={pollingPlaceId}
             />
           )}
-          {allowPrintingBlankBallots && (
+          {allowPrintingBlankBallots && pollsState === 'polls_open' && (
             <Button onPress={onPressPrintBlankBallot}>
               Print Blank Ballot
             </Button>


### PR DESCRIPTION
Gates blank ballot printing behind the same condition as voter session initiation - polls have to be opened. This applies to both blank ballot printing via the poll worker menu and via QR code scan.