### PR TITLE
ca: remove election manager auth gate on ballot eject screens

### DIFF
--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
@@ -17,7 +17,6 @@ import {
   P,
   Screen,
 } from '@votingworks/ui';
-import { isElectionManagerAuth } from '@votingworks/utils';
 import React, { useContext } from 'react';
 import styled from 'styled-components';
 import { AppContext } from '../contexts/app_context';
@@ -65,9 +64,8 @@ interface EjectInformation {
 }
 
 export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
-  const { auth, electionDefinition } = useContext(AppContext);
+  const { electionDefinition } = useContext(AppContext);
   assert(electionDefinition);
-  assert(isElectionManagerAuth(auth));
 
   const systemSettingsQuery = getSystemSettings.useQuery();
   const scannerConfigQuery = getScannerConfig.useQuery();


### PR DESCRIPTION
## Overview

VxCentralScan crashes on the ballot eject screen when authenticated as a poll worker due to an unnecessary auth check in the React component. Fixing!