### PR TITLE
VxDesign: Slightly reduce padding on grid cell

### DIFF
--- a/libs/hmpb/src/ballot_templates/ca_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/ca_ballot_template.tsx
@@ -620,7 +620,7 @@ function CandidateContest({
             <li
               key={candidate.id}
               className={CANDIDATE_OPTION_CLASS}
-              style={{ padding: '0.125rem 0.375rem 0.1875rem' }}
+              style={{ padding: '0.5px 0.375rem 1.5px' }}
             >
               <OptionRow>
                 <AlignedBubble compact optionInfo={optionInfo} />
@@ -668,7 +668,7 @@ function CandidateContest({
               key={`write-in-${writeInIndex}`}
               className={WRITE_IN_OPTION_CLASS}
               style={{
-                padding: '0.125rem 0.5rem 0.1875rem',
+                padding: '0.5px 0.5rem 1.5px',
                 display: 'flex',
               }}
             >


### PR DESCRIPTION
## Overview

Initially designed it so 61 candidates, 3 cols, Khmer would fit on back page. Added some text padding along the way that made the contest too long, so this removes padding from the grid cell to balance that out.

## Demo Video or Screenshot

## Testing Plan

Manually verified ballot

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
