### PR TITLE
[VxAdmin] include pw user in adjudication station machine lock copy

### DIFF
--- a/apps/admin/frontend/src/client/client_app_root.test.tsx
+++ b/apps/admin/frontend/src/client/client_app_root.test.tsx
@@ -125,9 +125,7 @@ test('shows election info when connected to a configured host', async () => {
   apiMock.expectGetNetworkConnectionStatus('online-connected-to-host');
   renderClientApp({ withElection: true });
   await screen.findByText('Adjudication Station Locked');
-  await screen.findByText(
-    'Insert system administrator, election manager, or poll worker card to unlock.'
-  );
+  await screen.findByText('Insert card to unlock.');
   const electionInfo = await screen.findByTestId('electionInfoBar');
   within(electionInfo).getByText(electionDefinition.election.title);
   within(electionInfo).getByText(DEV_MACHINE_ID);

--- a/apps/admin/frontend/src/client/client_app_root.test.tsx
+++ b/apps/admin/frontend/src/client/client_app_root.test.tsx
@@ -125,6 +125,9 @@ test('shows election info when connected to a configured host', async () => {
   apiMock.expectGetNetworkConnectionStatus('online-connected-to-host');
   renderClientApp({ withElection: true });
   await screen.findByText('Adjudication Station Locked');
+  await screen.findByText(
+    'Insert system administrator, election manager, or poll worker card to unlock.'
+  );
   const electionInfo = await screen.findByTestId('electionInfoBar');
   within(electionInfo).getByText(electionDefinition.election.title);
   within(electionInfo).getByText(DEV_MACHINE_ID);

--- a/apps/admin/frontend/src/client/screens/client_machine_locked_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_machine_locked_screen.tsx
@@ -63,7 +63,7 @@ export function ClientMachineLockedScreen(): JSX.Element {
           <H1 align="center">Adjudication Station Locked</H1>
           <H3 style={{ fontWeight: 'normal' }}>
             {electionDefinition
-              ? 'Insert system administrator, election manager, or poll worker card to unlock.'
+              ? 'Insert card to unlock.'
               : 'Insert system administrator card to unlock.'}
           </H3>
         </div>

--- a/apps/admin/frontend/src/client/screens/client_machine_locked_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_machine_locked_screen.tsx
@@ -63,7 +63,7 @@ export function ClientMachineLockedScreen(): JSX.Element {
           <H1 align="center">Adjudication Station Locked</H1>
           <H3 style={{ fontWeight: 'normal' }}>
             {electionDefinition
-              ? 'Insert system administrator or election manager card to unlock.'
+              ? 'Insert system administrator, election manager, or poll worker card to unlock.'
               : 'Insert system administrator card to unlock.'}
           </H3>
         </div>


### PR DESCRIPTION
## Overview
Adds "pollworker" to the list of options on the adjudication station machine lock copy screen since pollworkers can unlock that screen. Fixed for ca-demo already this bring onto main as well. (https://github.com/votingworks/vxsuite/pull/8982) 

## Demo Video or Screenshot
N/A

## Testing Plan
Ran Tests 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
