### PR TITLE
VxMark: Disable test mode where impossible

### DIFF
--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -488,9 +488,9 @@ test('"test" mode', async () => {
   await expectElectionState({ isTestMode: true });
 });
 
-test('isTestModeAvailable is true when the print flow does not need preprinted ballots', async () => {
+test('isTestModeAvailable is true when the print flow does not need pre-rendered ballots', async () => {
   // Summary mode (the default) renders ballots on the fly, so test mode is
-  // available even without preprinted test ballots.
+  // available even without pre-rendered test ballots.
   await configureMachine(
     mockUsbDrive,
     electionFamousNames2021Fixtures.readElectionDefinition()
@@ -498,7 +498,7 @@ test('isTestModeAvailable is true when the print flow does not need preprinted b
   await expectElectionState({ isTestMode: true, isTestModeAvailable: true });
 });
 
-test('forces official mode and marks test mode unavailable when a preprinted flow lacks test ballots', async () => {
+test('forces official mode and marks test mode unavailable when a pre-rendered flow lacks test ballots', async () => {
   const electionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();
   const officialOnlyBallots: EncodedBallotEntry[] = [
@@ -530,11 +530,11 @@ test('forces official mode and marks test mode unavailable when a preprinted flo
   mockNoCard();
 
   // The machine defaults to test mode, but since test ballots are missing for
-  // a preprinted flow, it's forced into official mode and the toggle disabled.
+  // a pre-rendered flow, it's forced into official mode and the toggle disabled.
   await expectElectionState({ isTestMode: false, isTestModeAvailable: false });
 });
 
-test('isTestModeAvailable is true when a preprinted flow has test ballots', async () => {
+test('isTestModeAvailable is true when a pre-rendered flow has test ballots', async () => {
   const electionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();
   const ballots: EncodedBallotEntry[] = [

--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -488,6 +488,86 @@ test('"test" mode', async () => {
   await expectElectionState({ isTestMode: true });
 });
 
+test('isTestModeAvailable is true when the print flow does not need preprinted ballots', async () => {
+  // Summary mode (the default) renders ballots on the fly, so test mode is
+  // available even without preprinted test ballots.
+  await configureMachine(
+    mockUsbDrive,
+    electionFamousNames2021Fixtures.readElectionDefinition()
+  );
+  await expectElectionState({ isTestMode: true, isTestModeAvailable: true });
+});
+
+test('forces official mode and marks test mode unavailable when a preprinted flow lacks test ballots', async () => {
+  const electionDefinition =
+    electionFamousNames2021Fixtures.readElectionDefinition();
+  const officialOnlyBallots: EncodedBallotEntry[] = [
+    {
+      ballotStyleId: '1',
+      precinctId: '23',
+      ballotType: BallotType.Precinct,
+      ballotMode: 'official',
+      encodedBallot: Buffer.from('official-pdf').toString('base64'),
+    },
+  ];
+
+  mockElectionManagerAuth(electionDefinition);
+  mockUsbDrive.insertUsbDrive(
+    await mockElectionPackageFileTree({
+      electionDefinition,
+      systemSettings: {
+        ...safeParseJson(
+          systemSettings.asText(),
+          SystemSettingsSchema
+        ).unsafeUnwrap(),
+        bmdPrintMode: 'bubble_ballot',
+      },
+      ballots: officialOnlyBallots,
+    })
+  );
+  (await apiClient.configureElectionPackageFromUsb()).unsafeUnwrap();
+  mockUsbDrive.removeUsbDrive();
+  mockNoCard();
+
+  // The machine defaults to test mode, but since test ballots are missing for
+  // a preprinted flow, it's forced into official mode and the toggle disabled.
+  await expectElectionState({ isTestMode: false, isTestModeAvailable: false });
+});
+
+test('isTestModeAvailable is true when a preprinted flow has test ballots', async () => {
+  const electionDefinition =
+    electionFamousNames2021Fixtures.readElectionDefinition();
+  const ballots: EncodedBallotEntry[] = [
+    {
+      ballotStyleId: '1',
+      precinctId: '23',
+      ballotType: BallotType.Precinct,
+      ballotMode: 'test',
+      encodedBallot: Buffer.from('test-pdf').toString('base64'),
+    },
+  ];
+
+  mockElectionManagerAuth(electionDefinition);
+  mockUsbDrive.insertUsbDrive(
+    await mockElectionPackageFileTree({
+      electionDefinition,
+      systemSettings: {
+        ...safeParseJson(
+          systemSettings.asText(),
+          SystemSettingsSchema
+        ).unsafeUnwrap(),
+        bmdPrintMode: 'bubble_ballot',
+      },
+      ballots,
+    })
+  );
+  (await apiClient.configureElectionPackageFromUsb()).unsafeUnwrap();
+  mockUsbDrive.removeUsbDrive();
+  mockNoCard();
+
+  await expectElectionState({ isTestMode: true, isTestModeAvailable: true });
+});
+
 test('set polling place', async () => {
   expect((await apiClient.getElectionState()).pollingPlaceId).toBeUndefined();
 

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -93,19 +93,19 @@ let lastBarcodeScanTimestamp: Date | undefined;
 
 /**
  * Whether the machine can be put into test mode. Test mode requires test mode
- * ballot PDFs only for flows that print from the preprinted ballots in the
+ * ballot PDFs only for flows that print from the pre-rendered ballots in the
  * election package: `bubble_ballot` printing and blank ballot printing. In
  * those flows, entering test mode without test ballots present would fail at
  * print time, so test mode is unavailable. Other print modes render ballots on
- * the fly and don't need preprinted test ballots.
+ * the fly and don't need pre-rendered test ballots.
  *
  */
 function isTestModeAvailable(store: Store): boolean {
   const systemSettings = store.getSystemSettings() ?? DEFAULT_SYSTEM_SETTINGS;
-  const requiresPreprintedTestBallots =
+  const requiresPreRenderedTestBallots =
     systemSettings.bmdPrintMode === 'bubble_ballot' ||
     systemSettings.allowPrintingBlankBallotsFromVxMark;
-  return !requiresPreprintedTestBallots || store.hasTestBallots();
+  return !requiresPreRenderedTestBallots || store.hasTestBallots();
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -61,7 +61,7 @@ import {
   isPatInputAttached,
 } from './util/accessible_controller';
 import { constructAuthMachineState } from './util/auth';
-import { ElectionRecord } from './store';
+import { ElectionRecord, Store } from './store';
 import * as barcodes from './barcodes';
 import { setUpBarcodeActivation } from './barcodes/activation';
 import { Player as AudioPlayer, SoundName } from './audio/player';
@@ -90,6 +90,23 @@ interface TestDeckError {
 // Track last barcode scan for diagnostics
 let lastBarcodeScanData: string | undefined;
 let lastBarcodeScanTimestamp: Date | undefined;
+
+/**
+ * Whether the machine can be put into test mode. Test mode requires test mode
+ * ballot PDFs only for flows that print from the preprinted ballots in the
+ * election package: `bubble_ballot` printing and blank ballot printing. In
+ * those flows, entering test mode without test ballots present would fail at
+ * print time, so test mode is unavailable. Other print modes render ballots on
+ * the fly and don't need preprinted test ballots.
+ *
+ */
+function isTestModeAvailable(store: Store): boolean {
+  const systemSettings = store.getSystemSettings() ?? DEFAULT_SYSTEM_SETTINGS;
+  const requiresPreprintedTestBallots =
+    systemSettings.bmdPrintMode === 'bubble_ballot' ||
+    systemSettings.allowPrintingBlankBallotsFromVxMark;
+  return !requiresPreprintedTestBallots || store.hasTestBallots();
+}
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function buildApi(ctx: Context) {
@@ -287,6 +304,14 @@ export function buildApi(ctx: Context) {
         // Store ballot PDFs if available in the election package
         if (ballots && ballots.length > 0) {
           workspace.store.setBallots(ballots);
+        }
+
+        // The machine defaults to test mode, but if test mode isn't available
+        // for this election package (no test ballots for a print flow that
+        // needs them), start in official mode to avoid footgun of allowing
+        // users to try to print test mode ballots that don't exist.
+        if (!isTestModeAvailable(workspace.store)) {
+          workspace.store.setTestMode(false);
         }
 
         if (electionDefinition.election.pollingPlaces?.length === 1) {
@@ -495,6 +520,7 @@ export function buildApi(ctx: Context) {
         pollingPlaceId: store.getPollingPlaceId(),
         ballotsPrintedCount: store.getBallotsPrintedCount(),
         isTestMode: store.getTestMode(),
+        isTestModeAvailable: isTestModeAvailable(store),
         pollsState: store.getPollsState(),
       };
     },

--- a/apps/mark/backend/src/store.test.ts
+++ b/apps/mark/backend/src/store.test.ts
@@ -187,6 +187,37 @@ test('get/set/delete ballots', () => {
   expect(deletedBallot).toBeUndefined();
 });
 
+test('hasTestBallots', () => {
+  const store = Store.memoryStore();
+
+  // No ballots at all.
+  expect(store.hasTestBallots()).toEqual(false);
+
+  // Only official ballots.
+  store.setBallots([
+    {
+      ballotStyleId: '1M',
+      precinctId: 'precinct-1',
+      ballotType: BallotType.Precinct,
+      ballotMode: 'official',
+      encodedBallot: Buffer.from('official-pdf').toString('base64'),
+    },
+  ]);
+  expect(store.hasTestBallots()).toEqual(false);
+
+  // Test ballots present.
+  store.setBallots([
+    {
+      ballotStyleId: '1M',
+      precinctId: 'precinct-1',
+      ballotType: BallotType.Precinct,
+      ballotMode: 'test',
+      encodedBallot: Buffer.from('test-pdf').toString('base64'),
+    },
+  ]);
+  expect(store.hasTestBallots()).toEqual(true);
+});
+
 test('getElectricalTestingStatusMessages and setElectricalTestingStatusMessage', () => {
   const store = Store.memoryStore();
 

--- a/apps/mark/backend/src/store.ts
+++ b/apps/mark/backend/src/store.ts
@@ -448,6 +448,16 @@ export class Store {
   }
 
   /**
+   * Whether any test-mode ballot PDFs were included in the election package.
+   */
+  hasTestBallots(): boolean {
+    const row = this.client.one(
+      `select 1 as present from ballots where ballot_mode = 'test' limit 1`
+    ) as { present: number } | undefined;
+    return row !== undefined;
+  }
+
+  /**
    * Adds a diagnostic record to the store.
    */
   addDiagnosticRecord(record: Omit<DiagnosticRecord, 'timestamp'>): void {

--- a/apps/mark/backend/src/types.ts
+++ b/apps/mark/backend/src/types.ts
@@ -10,6 +10,7 @@ export interface ElectionState {
   pollingPlaceId?: string;
   ballotsPrintedCount: number;
   isTestMode: boolean;
+  isTestModeAvailable: boolean;
   pollsState: PollsState;
 }
 

--- a/apps/mark/frontend/src/app_root.tsx
+++ b/apps/mark/frontend/src/app_root.tsx
@@ -92,6 +92,7 @@ export const blankBallotVotes: VotesDict = {};
 export const initialElectionState: Readonly<ElectionState> = {
   ballotsPrintedCount: 0,
   isTestMode: true,
+  isTestModeAvailable: true,
   pollsState: 'polls_closed_initial',
 };
 
@@ -228,10 +229,15 @@ export function AppRoot(): JSX.Element | null {
     getElectionRecordQuery.data ?? {};
 
   const electionStateQuery = getElectionState.useQuery();
-  const { pollingPlaceId, ballotsPrintedCount, isTestMode, pollsState } =
-    electionStateQuery.isSuccess
-      ? electionStateQuery.data
-      : initialElectionState;
+  const {
+    pollingPlaceId,
+    ballotsPrintedCount,
+    isTestMode,
+    isTestModeAvailable,
+    pollsState,
+  } = electionStateQuery.isSuccess
+    ? electionStateQuery.data
+    : initialElectionState;
 
   const precinctId = isCardlessVoterAuth(authStatus)
     ? authStatus.user.precinctId
@@ -557,6 +563,7 @@ export function AppRoot(): JSX.Element | null {
         electionDefinition={electionDefinition}
         electionPackageHash={assertDefined(electionPackageHash)}
         isTestMode={isTestMode}
+        isTestModeAvailable={isTestModeAvailable}
         unconfigure={unconfigure}
         machineConfig={machineConfig}
         pollingPlaceId={pollingPlaceId}

--- a/apps/mark/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.test.tsx
@@ -51,6 +51,7 @@ function renderScreen(props: Partial<AdminScreenProps> = {}) {
         electionDefinition={asElectionDefinition(election)}
         electionPackageHash="test-election-package-hash"
         isTestMode
+        isTestModeAvailable
         unconfigure={vi.fn()}
         machineConfig={mockMachineConfig({
           codeVersion: 'test', // Override default
@@ -268,6 +269,26 @@ test('switching to test ballot mode without ballots printed', () => {
   userEvent.click(screen.getByRole('option', { name: 'Test Ballot Mode' }));
 });
 
+test('ballot mode toggle is disabled when test mode is unavailable', () => {
+  apiMock.expectGetSystemSettings();
+  apiMock.expectGetUsbPortStatus();
+  renderScreen({
+    ballotsPrintedCount: 0,
+    isTestMode: false,
+    isTestModeAvailable: false,
+  });
+
+  const testOption = screen.getByRole('option', { name: 'Test Ballot Mode' });
+  expect(testOption).toBeDisabled();
+  expect(
+    screen.getByRole('option', { name: 'Official Ballot Mode' })
+  ).toBeDisabled();
+
+  // Clicking the disabled option must not switch modes. The absence of an
+  // expected setTestMode mutation is verified by assertComplete() in afterEach.
+  userEvent.click(testOption);
+});
+
 test('navigates to diagnostics screen and back', async () => {
   apiMock.expectGetSystemSettings();
   apiMock.expectGetUsbPortStatus();
@@ -277,6 +298,7 @@ test('navigates to diagnostics screen and back', async () => {
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
+    isTestModeAvailable: true,
   });
   apiMock.mockApiClient.getDiskSpaceSummary.mockResolvedValue({
     available: 1_000_000_000,

--- a/apps/mark/frontend/src/pages/admin_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.test.tsx
@@ -289,6 +289,25 @@ test('ballot mode toggle is disabled when test mode is unavailable', () => {
   userEvent.click(testOption);
 });
 
+test('ballot mode toggle is enabled and switches modes when test mode is available', () => {
+  apiMock.expectGetSystemSettings();
+  apiMock.expectGetUsbPortStatus();
+  renderScreen({
+    ballotsPrintedCount: 0,
+    isTestMode: false,
+    isTestModeAvailable: true,
+  });
+
+  const testOption = screen.getByRole('option', { name: 'Test Ballot Mode' });
+  expect(testOption).toBeEnabled();
+  expect(
+    screen.getByRole('option', { name: 'Official Ballot Mode' })
+  ).toBeEnabled();
+
+  apiMock.expectSetTestMode(true);
+  userEvent.click(testOption);
+});
+
 test('navigates to diagnostics screen and back', async () => {
   apiMock.expectGetSystemSettings();
   apiMock.expectGetUsbPortStatus();

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -54,6 +54,7 @@ export interface AdminScreenProps {
   electionDefinition: ElectionDefinition;
   electionPackageHash: string;
   isTestMode: boolean;
+  isTestModeAvailable: boolean;
   unconfigure: () => Promise<void>;
   machineConfig: MachineConfig;
   pollingPlaceId?: string;
@@ -66,6 +67,7 @@ export function AdminScreen({
   electionDefinition,
   electionPackageHash,
   isTestMode,
+  isTestModeAvailable,
   unconfigure,
   machineConfig,
   pollingPlaceId,
@@ -132,6 +134,7 @@ export function AdminScreen({
           <SegmentedButton
             label="Ballot Mode"
             hideLabel
+            disabled={!isTestModeAvailable}
             onChange={() => {
               if (ballotsPrintedCount > 0) {
                 setIsConfirmingModeSwitch(true);

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -17,6 +17,7 @@ import {
   PowerDownButton,
   Button,
   ToggleUsbPortsButton,
+  Icons,
 } from '@votingworks/ui';
 import { ElectionDefinition, PollsState } from '@votingworks/types';
 import type { MachineConfig } from '@votingworks/mark-backend';
@@ -149,6 +150,12 @@ export function AdminScreen({
             selectedOptionId={isTestMode ? 'test' : 'official'}
           />
         </P>
+        {!isTestModeAvailable && (
+          <P>
+            <Icons.Info /> Election package does not contain test ballots
+            required for test mode.
+          </P>
+        )}
         <P>
           <UnconfigureMachineButton
             isMachineConfigured

--- a/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/diagnostics_screen.test.tsx
@@ -66,6 +66,7 @@ test('renders diagnostics screen with all sections', async () => {
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
+    isTestModeAvailable: true,
   });
   apiMock.mockApiClient.getDiskSpaceSummary.mockResolvedValue({
     available: 1_000_000_000,
@@ -100,6 +101,7 @@ test('navigating to and from system audio diagnostic - pass', async () => {
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
+    isTestModeAvailable: true,
   });
   apiMock.mockApiClient.getDiskSpaceSummary.mockResolvedValue({
     available: 1_000_000_000,
@@ -136,6 +138,7 @@ test('navigating to and from system audio diagnostic - fail', async () => {
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
+    isTestModeAvailable: true,
   });
   apiMock.mockApiClient.getDiskSpaceSummary.mockResolvedValue({
     available: 1_000_000_000,
@@ -172,6 +175,7 @@ test('navigating to and from system audio diagnostic - cancel', async () => {
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
+    isTestModeAvailable: true,
   });
   apiMock.mockApiClient.getDiskSpaceSummary.mockResolvedValue({
     available: 1_000_000_000,
@@ -197,6 +201,7 @@ test('navigating to and from headphone input diagnostic - pass', async () => {
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
+    isTestModeAvailable: true,
   });
   apiMock.mockApiClient.getDiskSpaceSummary.mockResolvedValue({
     available: 1_000_000_000,
@@ -233,6 +238,7 @@ test('navigating to and from headphone input diagnostic - fail', async () => {
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
+    isTestModeAvailable: true,
   });
   apiMock.mockApiClient.getDiskSpaceSummary.mockResolvedValue({
     available: 1_000_000_000,
@@ -269,6 +275,7 @@ test('navigating to and from headphone input diagnostic - cancel', async () => {
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
+    isTestModeAvailable: true,
   });
   apiMock.mockApiClient.getDiskSpaceSummary.mockResolvedValue({
     available: 1_000_000_000,
@@ -294,6 +301,7 @@ test('navigating to and from PAT input diagnostic - pass', async () => {
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
+    isTestModeAvailable: true,
   });
   apiMock.mockApiClient.getDiskSpaceSummary.mockResolvedValue({
     available: 1_000_000_000,
@@ -343,6 +351,7 @@ test('navigating to and from PAT input diagnostic - cancel', async () => {
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
+    isTestModeAvailable: true,
   });
   apiMock.mockApiClient.getDiskSpaceSummary.mockResolvedValue({
     available: 1_000_000_000,
@@ -380,6 +389,7 @@ test('navigating to and from barcode reader diagnostic - fail', async () => {
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
+    isTestModeAvailable: true,
   });
   apiMock.mockApiClient.getDiskSpaceSummary.mockResolvedValue({
     available: 1_000_000_000,
@@ -422,6 +432,7 @@ test('navigating to and from barcode reader diagnostic - cancel', async () => {
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
+    isTestModeAvailable: true,
   });
   apiMock.mockApiClient.getDiskSpaceSummary.mockResolvedValue({
     available: 1_000_000_000,
@@ -450,6 +461,7 @@ test('UPS diagnostic - pass', async () => {
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
+    isTestModeAvailable: true,
   });
   apiMock.mockApiClient.getDiskSpaceSummary.mockResolvedValue({
     available: 1_000_000_000,
@@ -486,6 +498,7 @@ test('UPS diagnostic - fail', async () => {
     pollsState: 'polls_closed_initial',
     ballotsPrintedCount: 0,
     isTestMode: true,
+    isTestModeAvailable: true,
   });
   apiMock.mockApiClient.getDiskSpaceSummary.mockResolvedValue({
     available: 1_000_000_000,


### PR DESCRIPTION


## Overview

Closes https://github.com/votingworks/vxsuite/issues/8825

Disables test mode when there are no prerendered test mode bubble ballots in the election and one of the following configurations is set:

1. Ballot printing mode is bubble_ballot
2. Blank ballot printing mode is enabled (always prints bubble ballots)

## Demo Video or Screenshot
<img width="455" height="787" alt="Screenshot 2026-07-28 at 2 23 48 PM" src="https://github.com/user-attachments/assets/1e6bac4a-5e27-4a4e-8043-713e7fd6dfbb" />



## Testing Plan
Added tests

## Checklist

- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
