### PR TITLE
[VxAdmin] Update live reports export to only include central-scan ballots and use the cvr defined polling place

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -165,6 +165,7 @@ create table scanner_batches (
   label text not null,
   scanner_id text not null,
   election_id varchar(36) not null,
+  polling_place_id text,
   ballot_casting_mode text check (ballot_casting_mode is null or ballot_casting_mode = 'early_voting' or ballot_casting_mode = 'election_day'),
   started_at datetime not null,
   primary key (election_id, id),

--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -165,6 +165,7 @@ create table scanner_batches (
   label text not null,
   scanner_id text not null,
   election_id varchar(36) not null,
+  scanner_machine_type text check (scanner_machine_type is null or scanner_machine_type = 'central' or scanner_machine_type = 'precinct'),
   polling_place_id text,
   ballot_casting_mode text check (ballot_casting_mode is null or ballot_casting_mode = 'early_voting' or ballot_casting_mode = 'election_day'),
   started_at datetime not null,

--- a/apps/admin/backend/src/app.live_results_reporting.test.ts
+++ b/apps/admin/backend/src/app.live_results_reporting.test.ts
@@ -56,7 +56,7 @@ function makeDefinition(pollingPlaces: PollingPlace[]) {
   return safeParseElectionDefinition(JSON.stringify(election)).unsafeUnwrap();
 }
 
-test('getMatchingAbsenteePollingPlaces and getLiveResultsReportingUrl', async () => {
+test('getLiveReportsPollingPlaces and getLiveResultsReportingUrl', async () => {
   const electionDefinition = makeDefinition([COUNTY_ABSENTEE]);
   const { apiClient, auth, workspace } = buildTestEnvironment();
   const electionId = await configureMachine(
@@ -72,11 +72,12 @@ test('getMatchingAbsenteePollingPlaces and getLiveResultsReportingUrl', async ()
   mockElectionManagerAuth(auth, electionDefinition.election);
 
   // No CVRs loaded yet.
-  expect((await apiClient.getMatchingAbsenteePollingPlaces()).err()).toEqual(
+  expect((await apiClient.getLiveReportsPollingPlaces()).err()).toEqual(
     'no-cvrs-loaded'
   );
 
-  // Load some mock CVRs covering the absentee polling place's precincts.
+  // Load some mock CVRs from central scanner batches associated with the
+  // absentee polling place.
   addMockCvrFileToStore({
     electionId,
     store: workspace.store,
@@ -90,13 +91,14 @@ test('getMatchingAbsenteePollingPlaces and getLiveResultsReportingUrl', async ()
         votes: { fishing: ['ban-fishing'] },
         card: { type: 'bmd' },
         multiplier: 2,
+        pollingPlaceId: COUNTY_ABSENTEE.id,
       },
     ],
-    pollingPlaceId: 'polling-place-1',
+    pollingPlaceId: COUNTY_ABSENTEE.id,
   });
 
   const matching = (
-    await apiClient.getMatchingAbsenteePollingPlaces()
+    await apiClient.getLiveReportsPollingPlaces()
   ).unsafeUnwrap();
   expect(matching.map((p) => p.id)).toEqual([COUNTY_ABSENTEE.id]);
 

--- a/apps/admin/backend/src/app.live_results_reporting.test.ts
+++ b/apps/admin/backend/src/app.live_results_reporting.test.ts
@@ -86,6 +86,7 @@ test('getLiveReportsPollingPlaces and getLiveResultsReportingUrl', async () => {
         ballotStyleGroupId: '1M',
         batchId: 'batch-1',
         scannerId: 'scanner-1',
+        scannerMachineType: 'central',
         precinctId: 'precinct-1',
         votingMethod: 'absentee',
         votes: { fishing: ['ban-fishing'] },

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -126,7 +126,7 @@ import { buildElectionResultsReport } from './util/cdf_results';
 import { tabulateElectionResults } from './tabulation/full_results';
 import {
   generateAdminLiveResultsReportingUrls,
-  getMatchingAbsenteePollingPlaces,
+  getLiveReportsPollingPlaces,
 } from './live_results_reporting';
 import { NODE_ENV, USB_DRIVE_CHANGE_LONG_POLL_TIMEOUT_MS } from './globals';
 import {
@@ -1513,12 +1513,9 @@ function buildApi({
       });
     },
 
-    getMatchingAbsenteePollingPlaces(): Result<
-      PollingPlace[],
-      'no-cvrs-loaded'
-    > {
+    getLiveReportsPollingPlaces(): Result<PollingPlace[], 'no-cvrs-loaded'> {
       const electionId = loadCurrentElectionIdOrThrow(workspace);
-      return getMatchingAbsenteePollingPlaces({ electionId, store });
+      return getLiveReportsPollingPlaces({ electionId, store });
     },
 
     async getLiveResultsReportingUrl(input: {

--- a/apps/admin/backend/src/cast_vote_records.ts
+++ b/apps/admin/backend/src/cast_vote_records.ts
@@ -268,6 +268,7 @@ export async function importCastVoteRecords(
         electionId,
         label: batch.label,
         scannerId: batch.scannerId,
+        scannerMachineType: batch.scannerMachineType,
         ballotCastingMode: batch.ballotCastingMode,
         pollingPlaceId: batch.pollingPlaceId,
         startedAt: batch.startTime,

--- a/apps/admin/backend/src/cast_vote_records.ts
+++ b/apps/admin/backend/src/cast_vote_records.ts
@@ -269,6 +269,7 @@ export async function importCastVoteRecords(
         label: batch.label,
         scannerId: batch.scannerId,
         ballotCastingMode: batch.ballotCastingMode,
+        pollingPlaceId: batch.pollingPlaceId,
         startedAt: batch.startTime,
       });
 

--- a/apps/admin/backend/src/live_results_reporting.test.ts
+++ b/apps/admin/backend/src/live_results_reporting.test.ts
@@ -115,6 +115,7 @@ test('returns signed QR URLs for the polling place associated with the CVRs', as
       ballotStyleGroupId: '1M',
       batchId: 'batch-1',
       scannerId: 'scanner-1',
+      scannerMachineType: 'central',
       pollingPlaceId: ABSENTEE_PLACE_ALL.id,
       precinctId: 'precinct-1',
       votingMethod: 'absentee',
@@ -126,6 +127,7 @@ test('returns signed QR URLs for the polling place associated with the CVRs', as
       ballotStyleGroupId: '2F',
       batchId: 'batch-2',
       scannerId: 'scanner-1',
+      scannerMachineType: 'central',
       pollingPlaceId: ABSENTEE_PLACE_ALL.id,
       precinctId: 'precinct-2',
       votingMethod: 'absentee',
@@ -171,12 +173,39 @@ test('getLiveReportsPollingPlaces returns no-cvrs-loaded when no ballots', async
   );
 });
 
-test('getLiveReportsPollingPlaces returns the polling places, of any type, associated with the CVRs', async () => {
+test('getLiveReportsPollingPlaces returns no-cvrs-loaded when only precinct scanner CVRs are loaded', async () => {
   const cvrs: MockCastVoteRecordFile = [
     {
       ballotStyleGroupId: '1M',
       batchId: 'batch-1',
       scannerId: 'scanner-1',
+      scannerMachineType: 'precinct',
+      pollingPlaceId: ELECTION_DAY_PLACE.id,
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
+      votes: { fishing: ['ban-fishing'] },
+      card: { type: 'bmd' },
+      multiplier: 2,
+    },
+  ];
+  const { store, electionId } = await setupStore(
+    [ABSENTEE_PLACE_ALL, ABSENTEE_PLACE_PRECINCT_1, ELECTION_DAY_PLACE],
+    DEFAULT_SYSTEM_SETTINGS,
+    cvrs
+  );
+
+  expect(getLiveReportsPollingPlaces({ electionId, store }).err()).toEqual(
+    'no-cvrs-loaded'
+  );
+});
+
+test('getLiveReportsPollingPlaces returns the polling places, of any type, associated with central scanner CVRs', async () => {
+  const cvrs: MockCastVoteRecordFile = [
+    {
+      ballotStyleGroupId: '1M',
+      batchId: 'batch-1',
+      scannerId: 'central-scanner-1',
+      scannerMachineType: 'central',
       pollingPlaceId: ABSENTEE_PLACE_PRECINCT_1.id,
       precinctId: 'precinct-1',
       votingMethod: 'absentee',
@@ -184,17 +213,31 @@ test('getLiveReportsPollingPlaces returns the polling places, of any type, assoc
       card: { type: 'bmd' },
       multiplier: 2,
     },
-    // A batch associated with a non-absentee polling place
+    // A central scanner batch associated with a non-absentee polling place
     {
       ballotStyleGroupId: '1M',
       batchId: 'batch-2',
-      scannerId: 'scanner-2',
+      scannerId: 'central-scanner-2',
+      scannerMachineType: 'central',
       pollingPlaceId: ELECTION_DAY_PLACE.id,
       precinctId: 'precinct-1',
       votingMethod: 'precinct',
       votes: { fishing: ['ban-fishing'] },
       card: { type: 'bmd' },
       multiplier: 3,
+    },
+    // Precinct scanner batches never contribute polling places
+    {
+      ballotStyleGroupId: '2F',
+      batchId: 'batch-3',
+      scannerId: 'precinct-scanner-1',
+      scannerMachineType: 'precinct',
+      pollingPlaceId: ABSENTEE_PLACE_ALL.id,
+      precinctId: 'precinct-2',
+      votingMethod: 'precinct',
+      votes: { fishing: ['ban-fishing'] },
+      card: { type: 'bmd' },
+      multiplier: 4,
     },
   ];
   const { store, electionId } = await setupStore(
@@ -214,12 +257,13 @@ test('getLiveReportsPollingPlaces returns the polling places, of any type, assoc
   ]);
 });
 
-test('getLiveReportsPollingPlaces ignores batches with no CVRs', async () => {
+test('getLiveReportsPollingPlaces ignores central scanner batches with no CVRs', async () => {
   const cvrs: MockCastVoteRecordFile = [
     {
       ballotStyleGroupId: '1M',
       batchId: 'batch-1',
-      scannerId: 'scanner-1',
+      scannerId: 'central-scanner-1',
+      scannerMachineType: 'central',
       pollingPlaceId: ABSENTEE_PLACE_PRECINCT_1.id,
       precinctId: 'precinct-1',
       votingMethod: 'absentee',
@@ -231,7 +275,8 @@ test('getLiveReportsPollingPlaces ignores batches with no CVRs', async () => {
     {
       ballotStyleGroupId: '1M',
       batchId: 'batch-2',
-      scannerId: 'scanner-2',
+      scannerId: 'central-scanner-2',
+      scannerMachineType: 'central',
       pollingPlaceId: ELECTION_DAY_PLACE.id,
       precinctId: 'precinct-1',
       votingMethod: 'precinct',
@@ -253,12 +298,13 @@ test('getLiveReportsPollingPlaces ignores batches with no CVRs', async () => {
   expect(places.map((p) => p.id)).toEqual([ABSENTEE_PLACE_PRECINCT_1.id]);
 });
 
-test('generateAdminLiveResultsReportingUrls throws for a polling place with no batches', async () => {
+test('generateAdminLiveResultsReportingUrls throws for a polling place with no central scanner batches', async () => {
   const cvrs: MockCastVoteRecordFile = [
     {
       ballotStyleGroupId: '1M',
       batchId: 'batch-1',
-      scannerId: 'scanner-1',
+      scannerId: 'central-scanner-1',
+      scannerMachineType: 'central',
       pollingPlaceId: ABSENTEE_PLACE_PRECINCT_1.id,
       precinctId: 'precinct-1',
       votingMethod: 'absentee',
@@ -285,16 +331,17 @@ test('generateAdminLiveResultsReportingUrls throws for a polling place with no b
       pollsTransitionTimestamp: new Date('2024-11-05T20:00:00Z').getTime(),
     })
   ).rejects.toThrow(
-    `No scanner batches found for polling place ${ABSENTEE_PLACE_ALL.id}`
+    `No central scanner batches found for polling place ${ABSENTEE_PLACE_ALL.id}`
   );
 });
 
-test('reported tally includes only the results of batches associated with the polling place', async () => {
+test('reported tally includes only the results of central scanner batches associated with the polling place', async () => {
   const cvrs: MockCastVoteRecordFile = [
     {
       ballotStyleGroupId: '1M',
       batchId: 'batch-1',
-      scannerId: 'scanner-1',
+      scannerId: 'central-scanner-1',
+      scannerMachineType: 'central',
       pollingPlaceId: ABSENTEE_PLACE_PRECINCT_1.id,
       precinctId: 'precinct-1',
       votingMethod: 'absentee',
@@ -302,12 +349,27 @@ test('reported tally includes only the results of batches associated with the po
       card: { type: 'bmd' },
       multiplier: 3,
     },
-    // Ballots for a different polling place in the same precinct. These must
-    // not leak into the reported tally.
+    // Precinct scanner ballots in the same precinct. These must not leak into
+    // the reported tally.
     {
       ballotStyleGroupId: '1M',
       batchId: 'batch-2',
-      scannerId: 'scanner-2',
+      scannerId: 'precinct-scanner-1',
+      scannerMachineType: 'precinct',
+      pollingPlaceId: ELECTION_DAY_PLACE.id,
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
+      votes: { fishing: ['allow-fishing'] },
+      card: { type: 'bmd' },
+      multiplier: 4,
+    },
+    // Central scanner ballots for a different polling place, also in the same
+    // precinct. These must not leak into the reported tally either.
+    {
+      ballotStyleGroupId: '1M',
+      batchId: 'batch-3',
+      scannerId: 'central-scanner-2',
+      scannerMachineType: 'central',
       pollingPlaceId: ABSENTEE_PLACE_ALL.id,
       precinctId: 'precinct-1',
       votingMethod: 'absentee',
@@ -354,5 +416,6 @@ test('reported tally includes only the results of batches associated with the po
   );
   expect(fishingResults.ballots).toEqual(3);
   expect(fishingResults.tallies['ban-fishing']).toEqual(3);
+  expect(fishingResults.tallies['allow-fishing']).toEqual(0);
   expect(fishingResults.tallies['regulate-fishing']).toEqual(0);
 });

--- a/apps/admin/backend/src/live_results_reporting.test.ts
+++ b/apps/admin/backend/src/live_results_reporting.test.ts
@@ -3,6 +3,8 @@ import {
   electionTwoPartyPrimaryFixtures,
   makeTemporaryDirectory,
 } from '@votingworks/fixtures';
+import { assert, assertDefined } from '@votingworks/basics';
+import { decodeQuickResultsMessage } from '@votingworks/auth';
 import {
   DEFAULT_SYSTEM_SETTINGS,
   Election,
@@ -12,13 +14,14 @@ import {
 } from '@votingworks/types';
 import {
   BooleanEnvironmentVariableName,
+  decodeAndReadPerPrecinctCompressedTally,
   getFeatureFlagMock,
 } from '@votingworks/utils';
 import { Buffer } from 'node:buffer';
 import { Store } from './store';
 import {
   generateAdminLiveResultsReportingUrls,
-  getMatchingAbsenteePollingPlaces,
+  getLiveReportsPollingPlaces,
 } from './live_results_reporting';
 import {
   addMockCvrFileToStore,
@@ -100,18 +103,19 @@ async function setupStore(
       electionId,
       mockCastVoteRecordFile: cvrs,
       store,
-      pollingPlaceId: 'polling-place-1',
+      pollingPlaceId: ABSENTEE_PLACE_ALL.id,
     });
   }
   return { store, electionId, electionDefinition };
 }
 
-test('returns signed QR URLs when results match polling place', async () => {
+test('returns signed QR URLs for the polling place associated with the CVRs', async () => {
   const cvrs: MockCastVoteRecordFile = [
     {
       ballotStyleGroupId: '1M',
       batchId: 'batch-1',
       scannerId: 'scanner-1',
+      pollingPlaceId: ABSENTEE_PLACE_ALL.id,
       precinctId: 'precinct-1',
       votingMethod: 'absentee',
       votes: { fishing: ['ban-fishing'] },
@@ -122,6 +126,7 @@ test('returns signed QR URLs when results match polling place', async () => {
       ballotStyleGroupId: '2F',
       batchId: 'batch-2',
       scannerId: 'scanner-1',
+      pollingPlaceId: ABSENTEE_PLACE_ALL.id,
       precinctId: 'precinct-2',
       votingMethod: 'absentee',
       votes: { fishing: ['ban-fishing'] },
@@ -154,105 +159,200 @@ test('returns signed QR URLs when results match polling place', async () => {
   }
 });
 
-test('getMatchingAbsenteePollingPlaces returns no-cvrs-loaded when no ballots', async () => {
+test('getLiveReportsPollingPlaces returns no-cvrs-loaded when no ballots', async () => {
   const { store, electionId } = await setupStore([
     ABSENTEE_PLACE_ALL,
     ABSENTEE_PLACE_PRECINCT_1,
     ELECTION_DAY_PLACE,
   ]);
 
-  expect(getMatchingAbsenteePollingPlaces({ electionId, store }).err()).toEqual(
+  expect(getLiveReportsPollingPlaces({ electionId, store }).err()).toEqual(
     'no-cvrs-loaded'
   );
 });
 
-test('getMatchingAbsenteePollingPlaces returns absentee places that cover all CVR precincts', async () => {
+test('getLiveReportsPollingPlaces returns the polling places, of any type, associated with the CVRs', async () => {
   const cvrs: MockCastVoteRecordFile = [
     {
       ballotStyleGroupId: '1M',
       batchId: 'batch-1',
       scannerId: 'scanner-1',
+      pollingPlaceId: ABSENTEE_PLACE_PRECINCT_1.id,
       precinctId: 'precinct-1',
       votingMethod: 'absentee',
       votes: { fishing: ['ban-fishing'] },
       card: { type: 'bmd' },
       multiplier: 2,
     },
-  ];
-  const { store, electionId } = await setupStore(
-    [ABSENTEE_PLACE_ALL, ABSENTEE_PLACE_PRECINCT_1, ELECTION_DAY_PLACE],
-    DEFAULT_SYSTEM_SETTINGS,
-    cvrs
-  );
-
-  const matches = getMatchingAbsenteePollingPlaces({
-    electionId,
-    store,
-  }).unsafeUnwrap();
-  expect(matches.map((p) => p.id).sort()).toEqual([
-    ABSENTEE_PLACE_ALL.id,
-    ABSENTEE_PLACE_PRECINCT_1.id,
-  ]);
-});
-
-test('getMatchingAbsenteePollingPlaces returns an empty list when no absentee place covers the CVR precincts', async () => {
-  const cvrs: MockCastVoteRecordFile = [
-    {
-      ballotStyleGroupId: '2F',
-      batchId: 'batch-1',
-      scannerId: 'scanner-1',
-      precinctId: 'precinct-2',
-      votingMethod: 'absentee',
-      votes: { fishing: ['ban-fishing'] },
-      card: { type: 'bmd' },
-      multiplier: 2,
-    },
-  ];
-  const { store, electionId } = await setupStore(
-    [ABSENTEE_PLACE_PRECINCT_1, ELECTION_DAY_PLACE],
-    DEFAULT_SYSTEM_SETTINGS,
-    cvrs
-  );
-
-  const matches = getMatchingAbsenteePollingPlaces({
-    electionId,
-    store,
-  }).unsafeUnwrap();
-  expect(matches).toEqual([]);
-});
-
-test('getMatchingAbsenteePollingPlaces excludes absentee places missing CVR precincts', async () => {
-  const cvrs: MockCastVoteRecordFile = [
+    // A batch associated with a non-absentee polling place
     {
       ballotStyleGroupId: '1M',
-      batchId: 'batch-1',
-      scannerId: 'scanner-1',
-      precinctId: 'precinct-1',
-      votingMethod: 'absentee',
-      votes: { fishing: ['ban-fishing'] },
-      card: { type: 'bmd' },
-      multiplier: 2,
-    },
-    {
-      ballotStyleGroupId: '2F',
       batchId: 'batch-2',
-      scannerId: 'scanner-1',
-      precinctId: 'precinct-2',
-      votingMethod: 'absentee',
+      scannerId: 'scanner-2',
+      pollingPlaceId: ELECTION_DAY_PLACE.id,
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
       votes: { fishing: ['ban-fishing'] },
       card: { type: 'bmd' },
       multiplier: 3,
     },
   ];
   const { store, electionId } = await setupStore(
+    [ELECTION_DAY_PLACE, ABSENTEE_PLACE_ALL, ABSENTEE_PLACE_PRECINCT_1],
+    DEFAULT_SYSTEM_SETTINGS,
+    cvrs
+  );
+
+  const places = getLiveReportsPollingPlaces({
+    electionId,
+    store,
+  }).unsafeUnwrap();
+  // In election definition order
+  expect(places.map((p) => p.id)).toEqual([
+    ELECTION_DAY_PLACE.id,
+    ABSENTEE_PLACE_PRECINCT_1.id,
+  ]);
+});
+
+test('getLiveReportsPollingPlaces ignores batches with no CVRs', async () => {
+  const cvrs: MockCastVoteRecordFile = [
+    {
+      ballotStyleGroupId: '1M',
+      batchId: 'batch-1',
+      scannerId: 'scanner-1',
+      pollingPlaceId: ABSENTEE_PLACE_PRECINCT_1.id,
+      precinctId: 'precinct-1',
+      votingMethod: 'absentee',
+      votes: { fishing: ['ban-fishing'] },
+      card: { type: 'bmd' },
+      multiplier: 2,
+    },
+    // A batch record with no CVRs
+    {
+      ballotStyleGroupId: '1M',
+      batchId: 'batch-2',
+      scannerId: 'scanner-2',
+      pollingPlaceId: ELECTION_DAY_PLACE.id,
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
+      votes: { fishing: ['ban-fishing'] },
+      card: { type: 'bmd' },
+      multiplier: 0,
+    },
+  ];
+  const { store, electionId } = await setupStore(
     [ABSENTEE_PLACE_ALL, ABSENTEE_PLACE_PRECINCT_1, ELECTION_DAY_PLACE],
     DEFAULT_SYSTEM_SETTINGS,
     cvrs
   );
 
-  const matches = getMatchingAbsenteePollingPlaces({
+  const places = getLiveReportsPollingPlaces({
     electionId,
     store,
   }).unsafeUnwrap();
-  expect(matches.map((p) => p.id)).toEqual([ABSENTEE_PLACE_ALL.id]);
+  expect(places.map((p) => p.id)).toEqual([ABSENTEE_PLACE_PRECINCT_1.id]);
+});
+
+test('generateAdminLiveResultsReportingUrls throws for a polling place with no batches', async () => {
+  const cvrs: MockCastVoteRecordFile = [
+    {
+      ballotStyleGroupId: '1M',
+      batchId: 'batch-1',
+      scannerId: 'scanner-1',
+      pollingPlaceId: ABSENTEE_PLACE_PRECINCT_1.id,
+      precinctId: 'precinct-1',
+      votingMethod: 'absentee',
+      votes: { fishing: ['ban-fishing'] },
+      card: { type: 'bmd' },
+      multiplier: 2,
+    },
+  ];
+  const { store, electionId } = await setupStore(
+    [ABSENTEE_PLACE_ALL, ABSENTEE_PLACE_PRECINCT_1],
+    {
+      ...DEFAULT_SYSTEM_SETTINGS,
+      quickResultsReportingUrl: 'https://results.example.com/submit',
+    },
+    cvrs
+  );
+
+  await expect(
+    generateAdminLiveResultsReportingUrls({
+      electionId,
+      store,
+      pollingPlaceId: ABSENTEE_PLACE_ALL.id,
+      signingMachineId: 'admin-machine-1',
+      pollsTransitionTimestamp: new Date('2024-11-05T20:00:00Z').getTime(),
+    })
+  ).rejects.toThrow(
+    `No scanner batches found for polling place ${ABSENTEE_PLACE_ALL.id}`
+  );
+});
+
+test('reported tally includes only the results of batches associated with the polling place', async () => {
+  const cvrs: MockCastVoteRecordFile = [
+    {
+      ballotStyleGroupId: '1M',
+      batchId: 'batch-1',
+      scannerId: 'scanner-1',
+      pollingPlaceId: ABSENTEE_PLACE_PRECINCT_1.id,
+      precinctId: 'precinct-1',
+      votingMethod: 'absentee',
+      votes: { fishing: ['ban-fishing'] },
+      card: { type: 'bmd' },
+      multiplier: 3,
+    },
+    // Ballots for a different polling place in the same precinct. These must
+    // not leak into the reported tally.
+    {
+      ballotStyleGroupId: '1M',
+      batchId: 'batch-2',
+      scannerId: 'scanner-2',
+      pollingPlaceId: ABSENTEE_PLACE_ALL.id,
+      precinctId: 'precinct-1',
+      votingMethod: 'absentee',
+      votes: { fishing: ['regulate-fishing'] },
+      card: { type: 'bmd' },
+      multiplier: 5,
+    },
+  ];
+  const { store, electionId, electionDefinition } = await setupStore(
+    [ABSENTEE_PLACE_ALL, ABSENTEE_PLACE_PRECINCT_1, ELECTION_DAY_PLACE],
+    {
+      ...DEFAULT_SYSTEM_SETTINGS,
+      quickResultsReportingUrl: 'https://results.example.com/submit',
+    },
+    cvrs
+  );
+
+  const urls = await generateAdminLiveResultsReportingUrls({
+    electionId,
+    store,
+    pollingPlaceId: ABSENTEE_PLACE_PRECINCT_1.id,
+    signingMachineId: 'admin-machine-1',
+    pollsTransitionTimestamp: new Date('2024-11-05T20:00:00Z').getTime(),
+  });
+  expect(urls).toHaveLength(1);
+
+  // Decode the URL payload the same way the live reports receiver does
+  const payload = assertDefined(
+    new URL(assertDefined(urls[0])).searchParams.get('p')
+  );
+  const decoded = decodeQuickResultsMessage(payload);
+  expect(decoded.numPages).toEqual(1);
+  expect(decoded.ballotCount).toEqual(3);
+
+  const contestResultsByPrecinct = decodeAndReadPerPrecinctCompressedTally({
+    election: electionDefinition.election,
+    encodedTally: decoded.encodedCompressedTally,
+  });
+  const fishingResults = assertDefined(contestResultsByPrecinct['precinct-1'])[
+    'fishing'
+  ];
+  assert(
+    fishingResults !== undefined && fishingResults.contestType === 'yesno'
+  );
+  expect(fishingResults.ballots).toEqual(3);
+  expect(fishingResults.tallies['ban-fishing']).toEqual(3);
+  expect(fishingResults.tallies['regulate-fishing']).toEqual(0);
 });

--- a/apps/admin/backend/src/live_results_reporting.ts
+++ b/apps/admin/backend/src/live_results_reporting.ts
@@ -15,14 +15,13 @@ import {
 } from '@votingworks/utils';
 import { Store } from './store';
 import { tabulateElectionResults } from './tabulation/full_results';
-import { tabulateFullCardCounts } from './tabulation/card_counts';
 
 /**
- * Returns the absentee polling places whose precinct coverage is a superset
- * of the precincts that have at least one loaded CVR (or manual tally).
- * Returns `err('no-cvrs-loaded')` if no precinct has any ballots.
+ * Returns the polling places that the loaded CVRs are associated with via
+ * their batches, in election definition order. Returns
+ * `err('no-cvrs-loaded')` if there are no CVRs.
  */
-export function getMatchingAbsenteePollingPlaces({
+export function getLiveReportsPollingPlaces({
   electionId,
   store,
 }: {
@@ -32,49 +31,29 @@ export function getMatchingAbsenteePollingPlaces({
   const { electionDefinition } = assertDefined(store.getElection(electionId));
   const { election } = electionDefinition;
 
-  const cardCountsByPrecinct = groupMapToGroupList(
-    tabulateFullCardCounts({
-      electionId,
-      election,
-      store,
-      groupBy: { groupByPrecinct: true },
-    })
-  );
-
-  const precinctsWithBallots = new Set<PrecinctId>();
-  for (const group of cardCountsByPrecinct) {
-    assert(group.precinctId !== undefined);
-    if (getBallotCount(group) > 0) {
-      precinctsWithBallots.add(group.precinctId);
-    }
-  }
-
-  if (precinctsWithBallots.size === 0) {
+  const pollingPlaceIds = new Set(store.getCvrPollingPlaceIds(electionId));
+  if (pollingPlaceIds.size === 0) {
     return err('no-cvrs-loaded');
   }
 
-  const absenteePollingPlaces = (
+  const pollingPlaces = (
     election.pollingPlaces ?? /* istanbul ignore next */ []
-  ).filter((place) => place.type === 'absentee');
-  const matches = absenteePollingPlaces.filter((place) => {
-    const placePrecinctIds = pollingPlacePrecinctIds(place);
-    for (const precinctId of precinctsWithBallots) {
-      if (!placePrecinctIds.has(precinctId)) {
-        return false;
-      }
-    }
-    return true;
-  });
-
-  return ok(matches);
+  ).filter((place) => pollingPlaceIds.has(place.id));
+  assert(
+    pollingPlaces.length === pollingPlaceIds.size,
+    'CVR batches reference polling places not in the election definition'
+  );
+  return ok(pollingPlaces);
 }
 
 /**
- * Tabulates per-precinct results for the given absentee polling place and
- * returns signed live results reporting URLs for QR code display. Callers
- * are expected to pass a polling place returned from
- * {@link getMatchingAbsenteePollingPlaces}; the screen that triggers this
- * function is gated on `systemSettings.quickResultsReportingUrl` being set.
+ * Tabulates per-precinct results from the scanner batches associated with the
+ * given polling place and returns signed live results reporting URLs for QR
+ * code display. Results from batches for other polling places and manual
+ * tallies are excluded since they cannot be attributed to this polling place.
+ * Callers are expected to pass a polling place returned from
+ * {@link getLiveReportsPollingPlaces}; the screen that triggers this function
+ * is gated on `systemSettings.quickResultsReportingUrl` being set.
  */
 export async function generateAdminLiveResultsReportingUrls({
   electionId,
@@ -98,15 +77,24 @@ export async function generateAdminLiveResultsReportingUrls({
   );
 
   const pollingPlace = pollingPlaceFromElection(election, pollingPlaceId);
-  assert(pollingPlace.type === 'absentee');
+
+  const batchIds = store
+    .getScannerBatches(electionId)
+    .filter((batch) => batch.pollingPlaceId === pollingPlaceId)
+    .map((batch) => batch.batchId);
+  assert(
+    batchIds.length > 0,
+    `No scanner batches found for polling place ${pollingPlaceId}`
+  );
 
   const groupedResults = groupMapToGroupList(
     await tabulateElectionResults({
       electionId,
       store,
+      filter: { batchIds },
       groupBy: { groupByPrecinct: true },
       includeWriteInAdjudicationResults: true,
-      includeManualResults: true,
+      includeManualResults: false,
     })
   );
 

--- a/apps/admin/backend/src/live_results_reporting.ts
+++ b/apps/admin/backend/src/live_results_reporting.ts
@@ -17,9 +17,9 @@ import { Store } from './store';
 import { tabulateElectionResults } from './tabulation/full_results';
 
 /**
- * Returns the polling places that the loaded CVRs are associated with via
- * their batches, in election definition order. Returns
- * `err('no-cvrs-loaded')` if there are no CVRs.
+ * Returns the polling places that the loaded central scanner CVRs are
+ * associated with via their batches, in election definition order. Returns
+ * `err('no-cvrs-loaded')` if there are no central scanner CVRs.
  */
 export function getLiveReportsPollingPlaces({
   electionId,
@@ -31,7 +31,9 @@ export function getLiveReportsPollingPlaces({
   const { electionDefinition } = assertDefined(store.getElection(electionId));
   const { election } = electionDefinition;
 
-  const pollingPlaceIds = new Set(store.getCvrPollingPlaceIds(electionId));
+  const pollingPlaceIds = new Set(
+    store.getCentralScanPollingPlaceIds(electionId)
+  );
   if (pollingPlaceIds.size === 0) {
     return err('no-cvrs-loaded');
   }
@@ -47,13 +49,14 @@ export function getLiveReportsPollingPlaces({
 }
 
 /**
- * Tabulates per-precinct results from the scanner batches associated with the
- * given polling place and returns signed live results reporting URLs for QR
- * code display. Results from batches for other polling places and manual
- * tallies are excluded since they cannot be attributed to this polling place.
- * Callers are expected to pass a polling place returned from
- * {@link getLiveReportsPollingPlaces}; the screen that triggers this function
- * is gated on `systemSettings.quickResultsReportingUrl` being set.
+ * Tabulates per-precinct results from the central scanner batches associated
+ * with the given polling place and returns signed live results reporting URLs
+ * for QR code display. Results from precinct scanners, central scanner
+ * batches for other polling places, and manual tallies are excluded since
+ * they cannot be attributed to this polling place. Callers are expected to
+ * pass a polling place returned from {@link getLiveReportsPollingPlaces}; the
+ * screen that triggers this function is gated on
+ * `systemSettings.quickResultsReportingUrl` being set.
  */
 export async function generateAdminLiveResultsReportingUrls({
   electionId,
@@ -80,11 +83,15 @@ export async function generateAdminLiveResultsReportingUrls({
 
   const batchIds = store
     .getScannerBatches(electionId)
-    .filter((batch) => batch.pollingPlaceId === pollingPlaceId)
+    .filter(
+      (batch) =>
+        batch.scannerMachineType === 'central' &&
+        batch.pollingPlaceId === pollingPlaceId
+    )
     .map((batch) => batch.batchId);
   assert(
     batchIds.length > 0,
-    `No scanner batches found for polling place ${pollingPlaceId}`
+    `No central scanner batches found for polling place ${pollingPlaceId}`
   );
 
   const groupedResults = groupMapToGroupList(

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -247,6 +247,7 @@ test('scanner batches', async () => {
     batchId: 'batch-1',
     label: 'Batch 1',
     scannerId: 'VX-00-001',
+    pollingPlaceId: 'polling-place-1',
     startedAt: '2024-11-05T08:00:00.000Z',
   };
   store.addScannerBatch(scannerBatch);
@@ -275,6 +276,7 @@ test('delete empty scanner batches', async () => {
     batchId: '1',
     label: 'Batch 1',
     scannerId: 'scanner-1',
+    pollingPlaceId: 'polling-place-1',
     startedAt: expect.any(String),
   };
 

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -247,6 +247,7 @@ test('scanner batches', async () => {
     batchId: 'batch-1',
     label: 'Batch 1',
     scannerId: 'VX-00-001',
+    scannerMachineType: 'precinct',
     pollingPlaceId: 'polling-place-1',
     startedAt: '2024-11-05T08:00:00.000Z',
   };

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -1297,17 +1297,19 @@ export class Store implements BaseStore {
         label,
         scanner_id,
         election_id,
+        scanner_machine_type,
         ballot_casting_mode,
         polling_place_id,
         started_at
       ) values (
-        ?, ?, ?, ?, ?, ?, ?
+        ?, ?, ?, ?, ?, ?, ?, ?
       )
     `,
       scannerBatch.batchId,
       scannerBatch.label,
       scannerBatch.scannerId,
       scannerBatch.electionId,
+      scannerBatch.scannerMachineType ?? null,
       scannerBatch.ballotCastingMode ?? null,
       scannerBatch.pollingPlaceId ?? null,
       scannerBatch.startedAt
@@ -1348,6 +1350,7 @@ export class Store implements BaseStore {
           label as label,
           scanner_id as scannerId,
           election_id as electionId,
+          scanner_machine_type as scannerMachineType,
           ballot_casting_mode as ballotCastingMode,
           polling_place_id as pollingPlaceId,
           started_at as startedAt
@@ -1359,6 +1362,7 @@ export class Store implements BaseStore {
       ) as ScannerBatch[]
     ).map((row) => ({
       ...row,
+      scannerMachineType: row.scannerMachineType ?? undefined,
       ballotCastingMode: row.ballotCastingMode ?? undefined,
       pollingPlaceId: row.pollingPlaceId ?? undefined,
     }));

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -1317,10 +1317,10 @@ export class Store implements BaseStore {
   }
 
   /**
-   * Gets the distinct polling place IDs associated with scanner batches that
-   * contain at least one cast vote record. Used for live reports.
+   * Gets the distinct polling place IDs associated with central scanner
+   * batches that contain at least one cast vote record. Used for live reports.
    */
-  getCvrPollingPlaceIds(electionId: string): string[] {
+  getCentralScanPollingPlaceIds(electionId: string): string[] {
     return (
       this.client.all(
         `
@@ -1328,6 +1328,7 @@ export class Store implements BaseStore {
         from scanner_batches
         where
           election_id = ? and
+          scanner_machine_type = 'central' and
           polling_place_id is not null and
           exists (
             select 1 from cvrs

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -1298,9 +1298,10 @@ export class Store implements BaseStore {
         scanner_id,
         election_id,
         ballot_casting_mode,
+        polling_place_id,
         started_at
       ) values (
-        ?, ?, ?, ?, ?, ?
+        ?, ?, ?, ?, ?, ?, ?
       )
     `,
       scannerBatch.batchId,
@@ -1308,8 +1309,34 @@ export class Store implements BaseStore {
       scannerBatch.scannerId,
       scannerBatch.electionId,
       scannerBatch.ballotCastingMode ?? null,
+      scannerBatch.pollingPlaceId ?? null,
       scannerBatch.startedAt
     );
+  }
+
+  /**
+   * Gets the distinct polling place IDs associated with scanner batches that
+   * contain at least one cast vote record. Used for live reports.
+   */
+  getCvrPollingPlaceIds(electionId: string): string[] {
+    return (
+      this.client.all(
+        `
+        select distinct polling_place_id as pollingPlaceId
+        from scanner_batches
+        where
+          election_id = ? and
+          polling_place_id is not null and
+          exists (
+            select 1 from cvrs
+            where cvrs.election_id = scanner_batches.election_id
+              and cvrs.batch_id = scanner_batches.id
+          )
+        order by polling_place_id
+      `,
+        electionId
+      ) as Array<{ pollingPlaceId: string }>
+    ).map((row) => row.pollingPlaceId);
   }
 
   getScannerBatches(electionId: string): ScannerBatch[] {
@@ -1322,6 +1349,7 @@ export class Store implements BaseStore {
           scanner_id as scannerId,
           election_id as electionId,
           ballot_casting_mode as ballotCastingMode,
+          polling_place_id as pollingPlaceId,
           started_at as startedAt
         from scanner_batches
         where
@@ -1332,6 +1360,7 @@ export class Store implements BaseStore {
     ).map((row) => ({
       ...row,
       ballotCastingMode: row.ballotCastingMode ?? undefined,
+      pollingPlaceId: row.pollingPlaceId ?? undefined,
     }));
   }
 

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -21,6 +21,7 @@ import {
   BallotStyleGroupId,
   BallotCastingMode,
   ContestOption,
+  ScannerMachineType,
   UserRole,
 } from '@votingworks/types';
 import { z } from 'zod/v4';
@@ -86,6 +87,7 @@ export interface CastVoteRecordFileMetadata {
 export interface ScannerBatch extends Tabulation.ScannerBatch {
   label: string;
   electionId: string;
+  scannerMachineType?: ScannerMachineType;
   ballotCastingMode?: BallotCastingMode;
   pollingPlaceId?: string;
   startedAt: string;

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -87,6 +87,7 @@ export interface ScannerBatch extends Tabulation.ScannerBatch {
   label: string;
   electionId: string;
   ballotCastingMode?: BallotCastingMode;
+  pollingPlaceId?: string;
   startedAt: string;
 }
 

--- a/apps/admin/backend/test/mock_cvr_file.ts
+++ b/apps/admin/backend/test/mock_cvr_file.ts
@@ -18,6 +18,7 @@ import {
 export type MockCastVoteRecordFile = Array<
   Tabulation.CastVoteRecord & {
     multiplier?: number;
+    pollingPlaceId?: string;
   }
 >;
 
@@ -62,6 +63,7 @@ export function addMockCvrFileToStore({
       scannerId: mockCastVoteRecord.scannerId,
       label: `Batch ${mockCastVoteRecord.batchId}`,
       ballotCastingMode: mockCastVoteRecord.ballotCastingMode,
+      pollingPlaceId: mockCastVoteRecord.pollingPlaceId ?? pollingPlaceId,
       startedAt: new Date().toISOString(),
     });
 

--- a/apps/admin/backend/test/mock_cvr_file.ts
+++ b/apps/admin/backend/test/mock_cvr_file.ts
@@ -4,6 +4,7 @@ import {
   ContestId,
   ContestOptionId,
   Id,
+  ScannerMachineType,
   Tabulation,
 } from '@votingworks/types';
 import { randomUUID as uuid } from 'node:crypto';
@@ -18,6 +19,7 @@ import {
 export type MockCastVoteRecordFile = Array<
   Tabulation.CastVoteRecord & {
     multiplier?: number;
+    scannerMachineType?: ScannerMachineType;
     pollingPlaceId?: string;
   }
 >;
@@ -62,6 +64,7 @@ export function addMockCvrFileToStore({
       batchId: mockCastVoteRecord.batchId,
       scannerId: mockCastVoteRecord.scannerId,
       label: `Batch ${mockCastVoteRecord.batchId}`,
+      scannerMachineType: mockCastVoteRecord.scannerMachineType,
       ballotCastingMode: mockCastVoteRecord.ballotCastingMode,
       pollingPlaceId: mockCastVoteRecord.pollingPlaceId ?? pollingPlaceId,
       startedAt: new Date().toISOString(),

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -483,14 +483,14 @@ export const getLiveResultsReportingUrl = {
   },
 } as const;
 
-export const getMatchingAbsenteePollingPlaces = {
+export const getLiveReportsPollingPlaces = {
   queryKey(): QueryKey {
-    return ['getMatchingAbsenteePollingPlaces'];
+    return ['getLiveReportsPollingPlaces'];
   },
   useQuery() {
     const apiClient = useApiClient();
     return useQuery(this.queryKey(), () =>
-      apiClient.getMatchingAbsenteePollingPlaces()
+      apiClient.getLiveReportsPollingPlaces()
     );
   },
 } as const;
@@ -673,9 +673,9 @@ function invalidateCastVoteRecordQueries(queryClient: QueryClient) {
     // total ballot count may be affected
     queryClient.invalidateQueries(getTotalBallotCount.queryKey()),
 
-    // matching absentee polling places and any signed live-results URLs
-    // depend on which precincts have CVRs
-    queryClient.resetQueries(getMatchingAbsenteePollingPlaces.queryKey()),
+    // live reports polling places and any signed live-results URLs depend
+    // on the loaded CVR batches
+    queryClient.resetQueries(getLiveReportsPollingPlaces.queryKey()),
     queryClient.resetQueries(getLiveResultsReportingUrl.queryKey()),
 
     // ballot adjudication queues
@@ -705,9 +705,9 @@ function invalidateManualResultsQueries(queryClient: QueryClient) {
     // total ballot count may be affected
     queryClient.invalidateQueries(getTotalBallotCount.queryKey()),
 
-    // matching absentee polling places and any signed live-results URLs
-    // depend on which precincts have ballots
-    queryClient.resetQueries(getMatchingAbsenteePollingPlaces.queryKey()),
+    // live reports polling places and any signed live-results URLs depend
+    // on the loaded CVR batches
+    queryClient.resetQueries(getLiveReportsPollingPlaces.queryKey()),
     queryClient.resetQueries(getLiveResultsReportingUrl.queryKey()),
   ]);
 }

--- a/apps/admin/frontend/src/screens/reporting/send_tally_reports_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/reporting/send_tally_reports_screen.test.tsx
@@ -5,7 +5,7 @@ import { err, ok } from '@votingworks/basics';
 import { PollingPlace } from '@votingworks/types';
 import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client';
 import { renderInAppContext } from '../../../test/render_in_app_context';
-import { screen, within } from '../../../test/react_testing_library';
+import { screen, waitFor, within } from '../../../test/react_testing_library';
 import { SendTallyReportsScreen, TITLE } from './send_tally_reports_screen';
 
 let apiMock: ApiMock;
@@ -30,10 +30,11 @@ const COUNTY_ABSENTEE: PollingPlace = {
   },
 };
 
-const REGIONAL_ABSENTEE: PollingPlace = {
-  id: 'absentee-regional',
-  name: 'Regional Absentee',
-  type: 'absentee',
+// Live reports polling places can be of any type, not just absentee
+const DOWNTOWN_ELECTION_DAY: PollingPlace = {
+  id: 'election-day-downtown',
+  name: 'Downtown Election Day',
+  type: 'election_day',
   precincts: {
     'precinct-1': { type: 'whole' },
     'precinct-2': { type: 'whole' },
@@ -41,7 +42,7 @@ const REGIONAL_ABSENTEE: PollingPlace = {
 };
 
 test('renders title and parent route link', async () => {
-  apiMock.expectGetMatchingAbsenteePollingPlaces(err('no-cvrs-loaded'));
+  apiMock.expectGetLiveReportsPollingPlaces(err('no-cvrs-loaded'));
 
   renderInAppContext(<SendTallyReportsScreen />, {
     electionDefinition,
@@ -57,7 +58,7 @@ test('renders title and parent route link', async () => {
 });
 
 test('shows info callout when no CVRs are loaded', async () => {
-  apiMock.expectGetMatchingAbsenteePollingPlaces(err('no-cvrs-loaded'));
+  apiMock.expectGetLiveReportsPollingPlaces(err('no-cvrs-loaded'));
 
   renderInAppContext(<SendTallyReportsScreen />, {
     electionDefinition,
@@ -67,21 +68,8 @@ test('shows info callout when no CVRs are loaded', async () => {
   await screen.findByText('Load CVRs to send results.');
 });
 
-test('shows warning when no absentee polling place matches the loaded CVRs', async () => {
-  apiMock.expectGetMatchingAbsenteePollingPlaces(ok([]));
-
-  renderInAppContext(<SendTallyReportsScreen />, {
-    electionDefinition,
-    apiMock,
-  });
-
-  await screen.findByText(
-    'No absentee polling place covers the precincts in the loaded CVRs.'
-  );
-});
-
 test('auto-generates QR code when exactly one polling place matches', async () => {
-  apiMock.expectGetMatchingAbsenteePollingPlaces(ok([COUNTY_ABSENTEE]));
+  apiMock.expectGetLiveReportsPollingPlaces(ok([COUNTY_ABSENTEE]));
   apiMock.expectGetLiveResultsReportingUrls(COUNTY_ABSENTEE.id, [
     'https://example.com/results?p=AAA',
   ]);
@@ -97,12 +85,12 @@ test('auto-generates QR code when exactly one polling place matches', async () =
     'https://example.com/results?p=AAA'
   );
   expect(
-    screen.queryByLabelText('Select absentee polling place')
+    screen.queryByLabelText('Select polling place')
   ).not.toBeInTheDocument();
 });
 
 test('shows danger callout when the QR code cannot be generated', async () => {
-  apiMock.expectGetMatchingAbsenteePollingPlaces(ok([COUNTY_ABSENTEE]));
+  apiMock.expectGetLiveReportsPollingPlaces(ok([COUNTY_ABSENTEE]));
   apiMock.expectGetLiveResultsReportingUrlsError(
     COUNTY_ABSENTEE.id,
     new Error('Unable to fit signed URL within QR size limits')
@@ -117,9 +105,9 @@ test('shows danger callout when the QR code cannot be generated', async () => {
   expect(screen.queryByTestId('live-results-code')).not.toBeInTheDocument();
 });
 
-test('shows dropdown when multiple polling places match and locks after selection', async () => {
-  apiMock.expectGetMatchingAbsenteePollingPlaces(
-    ok([COUNTY_ABSENTEE, REGIONAL_ABSENTEE])
+test('shows dropdown when multiple polling places match and allows changing the selection', async () => {
+  apiMock.expectGetLiveReportsPollingPlaces(
+    ok([COUNTY_ABSENTEE, DOWNTOWN_ELECTION_DAY])
   );
   apiMock.expectGetLiveResultsReportingUrls(COUNTY_ABSENTEE.id, [
     'https://example.com/results?p=AAA',
@@ -131,15 +119,12 @@ test('shows dropdown when multiple polling places match and locks after selectio
     apiMock,
   });
 
-  const select = await screen.findByLabelText('Select absentee polling place');
+  const select = await screen.findByLabelText('Select polling place');
   userEvent.click(select);
   userEvent.click(await screen.findByText('County Absentee'));
 
   const qrContainer = await screen.findByTestId('live-results-code');
   expect(within(qrContainer).getByText('1 / 2')).toBeInTheDocument();
-
-  // The dropdown is now locked.
-  expect(screen.getByLabelText('Select absentee polling place')).toBeDisabled();
 
   userEvent.click(screen.getButton('Next'));
   await within(qrContainer).findByText('2 / 2');
@@ -153,5 +138,20 @@ test('shows dropdown when multiple polling places match and locks after selectio
   expect(qrContainer.querySelector('[data-value]')).toHaveAttribute(
     'data-value',
     'https://example.com/results?p=AAA'
+  );
+
+  // The polling place can be changed after the initial selection
+  apiMock.expectGetLiveResultsReportingUrls(DOWNTOWN_ELECTION_DAY.id, [
+    'https://example.com/results?p=CCC',
+  ]);
+  userEvent.click(screen.getByLabelText('Select polling place'));
+  userEvent.click(await screen.findByText('Downtown Election Day'));
+
+  const newQrContainer = await screen.findByTestId('live-results-code');
+  await waitFor(() =>
+    expect(newQrContainer.querySelector('[data-value]')).toHaveAttribute(
+      'data-value',
+      'https://example.com/results?p=CCC'
+    )
   );
 });

--- a/apps/admin/frontend/src/screens/reporting/send_tally_reports_screen.tsx
+++ b/apps/admin/frontend/src/screens/reporting/send_tally_reports_screen.tsx
@@ -17,7 +17,7 @@ import {
   ReportScreenContainer,
 } from '../../components/reporting/shared';
 import {
-  getMatchingAbsenteePollingPlaces,
+  getLiveReportsPollingPlaces,
   getLiveResultsReportingUrl,
 } from '../../api';
 
@@ -147,16 +147,15 @@ function PollingPlaceSelector({
           <SearchSelect
             isMulti={false}
             isSearchable
-            disabled={!!pollingPlaceId}
             value={pollingPlaceId}
             options={pollingPlaces.map((p) => ({
               value: p.id,
               label: p.name,
             }))}
             onChange={(value) => setPollingPlaceId(value)}
-            aria-label="Select absentee polling place"
+            aria-label="Select polling place"
             style={{ width: '30rem' }}
-            placeholder="Select an absentee polling place."
+            placeholder="Select a polling place..."
           />
         </SelectPollingPlaceContainer>
       )}
@@ -173,7 +172,7 @@ function PollingPlaceSelector({
 }
 
 export function SendTallyReportsScreen(): JSX.Element {
-  const matchesQuery = getMatchingAbsenteePollingPlaces.useQuery();
+  const matchesQuery = getLiveReportsPollingPlaces.useQuery();
 
   if (!matchesQuery.isSuccess) {
     return (
@@ -199,18 +198,6 @@ export function SendTallyReportsScreen(): JSX.Element {
   }
 
   const pollingPlaces = matchesQuery.data.ok();
-
-  if (pollingPlaces.length === 0) {
-    return (
-      <ScreenWrapper>
-        <FullPageMessage>
-          <Callout icon="Warning" color="warning">
-            No absentee polling place covers the precincts in the loaded CVRs.
-          </Callout>
-        </FullPageMessage>
-      </ScreenWrapper>
-    );
-  }
 
   return (
     <ScreenWrapper>

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -374,12 +374,10 @@ export function createApiMock(
         .throws(error);
     },
 
-    expectGetMatchingAbsenteePollingPlaces(
+    expectGetLiveReportsPollingPlaces(
       result: Result<PollingPlace[], 'no-cvrs-loaded'>
     ) {
-      apiClient.getMatchingAbsenteePollingPlaces
-        .expectCallWith()
-        .resolves(result);
+      apiClient.getLiveReportsPollingPlaces.expectCallWith().resolves(result);
     },
 
     expectGetCastVoteRecordFileMode(fileMode: CvrFileMode) {

--- a/libs/types/src/cast_vote_records.ts
+++ b/libs/types/src/cast_vote_records.ts
@@ -13,6 +13,8 @@ import {
   ElectionDefinition,
   HmpbBallotPageMetadata,
   Precinct,
+  ScannerMachineType,
+  ScannerMachineTypeSchema,
 } from './election';
 import { ExportDataError } from './errors';
 import { Iso8601Timestamp, Iso8601TimestampSchema } from './generic';
@@ -32,9 +34,6 @@ export enum CastVoteRecordExportFileName {
   METADATA = 'metadata.json',
   REJECTED_SHEET_SUB_DIRECTORY_NAME_PREFIX = 'rejected-',
 }
-
-export const ScannerMachineTypeSchema = z.enum(['central', 'precinct']);
-export type ScannerMachineType = z.infer<typeof ScannerMachineTypeSchema>;
 
 export interface CastVoteRecordBatchMetadata {
   readonly id: string;

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -1425,6 +1425,9 @@ export interface BatchInfo {
 export const BallotCastingModeSchema = z.enum(['early_voting', 'election_day']);
 export type BallotCastingMode = z.infer<typeof BallotCastingModeSchema>;
 
+export const ScannerMachineTypeSchema = z.enum(['central', 'precinct']);
+export type ScannerMachineType = z.infer<typeof ScannerMachineTypeSchema>;
+
 export const BatchInfoSchema: z.ZodSchema<BatchInfo> = z.object({
   id: IdSchema,
   batchNumber: z.number().int().positive(),


### PR DESCRIPTION
## Overview
We implemented live reports in VxAdmin prior to having pollingPlaceId information in the imported cvrs and had a convoluted   way to determine the polling place to associate the results with. The live reports dashboard in VxAdmin is organized by polling place. See: https://votingworks.slack.com/archives/CEL6D3GAD/p1785266687944039 for more discussion but TLDR is that we decided to now determine pollingPlaceId on the live results payload from the CVRs information. If there are multiple polling places Ids we will show a dropdown and filter the results to that polling place. Additionally we are now filtering the live results data by both the polling place id we want and whether the cvr batch came from VxCentralScan (excluding VxScan). Manual tallies are now excluded from this data. 

## Demo Video or Screenshot
Multi-Polling Place flow

https://github.com/user-attachments/assets/5c109705-cef4-409e-adc2-be974d933664

Single polling place case not changed. 

See tests for logic

## Testing Plan
Ran Tests
Manual Run Through: 
 - Loaded VxAdmin with results for 
   - Polling Place A from both VxScan (voting all Democrat) 
   - Polling Place B from just VxCentralScan (voting all Republican)
 - Loaded send reports screen saw it auto-populate to send for Polling Place B, sent results, verified tally was the expected results
 - Loaded VxAdmin with results for Polling Place A from VxCentralScan (voting all Rep) 
 - Loaded send reports screen saw dropdown, sent results for both polling places saw that tallies were as expected in both cases (voting R, proper number of ballots cast) 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
