### PR TITLE
Adjudication: System setting to limit full ballot editing

### DIFF
--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -10,7 +10,11 @@ import {
   DEFAULT_SYSTEM_SETTINGS,
   Election,
 } from '@votingworks/types';
-import type { BallotPageLayout, Rect } from '@votingworks/types';
+import type {
+  BallotPageLayout,
+  Rect,
+  SystemSettings,
+} from '@votingworks/types';
 import type {
   AdjudicatedCvrContest,
   AdjudicatedContestOptions,
@@ -206,11 +210,13 @@ function setupBasicMocks({
   nextCvrId = CVR_ID_1,
   adjudicationData,
   isBmd = true,
+  systemSettings,
 }: {
   queue?: string[];
   nextCvrId?: string | null;
   adjudicationData: BallotAdjudicationData;
   isBmd?: boolean;
+  systemSettings?: SystemSettings;
 }) {
   apiMock.expectGetBallotAdjudicationQueue(queue);
   apiMock.expectGetNextCvrIdForBallotAdjudication(nextCvrId);
@@ -223,7 +229,7 @@ function setupBasicMocks({
     [],
     adjudicationData.contests.map((c) => c.contestId)
   );
-  apiMock.expectGetSystemSettings();
+  apiMock.expectGetSystemSettings(systemSettings);
 }
 
 function makeHmpbPageLayout(contestIds: string[]): BallotPageLayout {
@@ -1666,6 +1672,154 @@ test('contest list only shows overvote/undervote/marginal status lines present i
   bestAnimal.getByText('1 write-in to adjudicate');
   expect(bestAnimal.queryByText('Overvote to adjudicate')).toBeNull();
   expect(bestAnimal.queryByText(/marginal mark/)).toBeNull();
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves();
+});
+
+test('contest list only shows flagged contests when limiting adjudication to flagged contests', async () => {
+  const adjData = makeBallotAdjudicationData(CVR_ID_1, [
+    makeContestAdjudicationData(
+      'zoo-council-mammal',
+      makeContestTag({ hasWriteIn: true })
+    ),
+    makeContestAdjudicationData('best-animal-mammal'),
+  ]);
+  setupBasicMocks({
+    adjudicationData: adjData,
+    systemSettings: {
+      ...DEFAULT_SYSTEM_SETTINGS,
+      limitAdminAdjudicationToFlaggedContests: true,
+    },
+  });
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('Zoo Council');
+  expect(screen.queryByText('Best Animal')).toBeNull();
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves();
+});
+
+test('all contests on a blank ballot stay listed when limiting adjudication to flagged contests', async () => {
+  const adjData = makeBallotAdjudicationData(
+    CVR_ID_1,
+    [
+      makeContestAdjudicationData('zoo-council-mammal'),
+      makeContestAdjudicationData('best-animal-mammal'),
+    ],
+    { tag: { isBlankBallot: true, hasCrossoverVote: false } }
+  );
+  setupBasicMocks({
+    adjudicationData: adjData,
+    systemSettings: {
+      ...DEFAULT_SYSTEM_SETTINGS,
+      adminAdjudicationReasons: [AdjudicationReason.BlankBallot],
+      limitAdminAdjudicationToFlaggedContests: true,
+    },
+  });
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('Blank Ballot Detected');
+  screen.getByText('Zoo Council');
+  screen.getByText('Best Animal');
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves();
+});
+
+test('blank ballot without the blank ballot adjudication reason only lists tagged contests', async () => {
+  const adjData = makeBallotAdjudicationData(
+    CVR_ID_1,
+    [
+      makeContestAdjudicationData(
+        'zoo-council-mammal',
+        makeContestTag({ hasWriteIn: false, hasUnmarkedWriteIn: true })
+      ),
+      makeContestAdjudicationData('best-animal-mammal'),
+    ],
+    { tag: { isBlankBallot: true, hasCrossoverVote: false } }
+  );
+  setupBasicMocks({
+    adjudicationData: adjData,
+    systemSettings: {
+      ...DEFAULT_SYSTEM_SETTINGS,
+      limitAdminAdjudicationToFlaggedContests: true,
+    },
+  });
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('Zoo Council');
+  expect(screen.queryByText('Best Animal')).toBeNull();
+
+  apiMock.apiClient.releaseBallotAdjudicationClaim
+    .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })
+    .resolves();
+});
+
+test('crossover voted contests stay listed when limiting adjudication to flagged contests', async () => {
+  const demContest = makeContestAdjudicationData(
+    'governor-democratic',
+    undefined,
+    combinedBallotPrimaryElection
+  );
+  demContest.options[0].scannedVote = true;
+  const repContest = makeContestAdjudicationData(
+    'governor-republican',
+    undefined,
+    combinedBallotPrimaryElection
+  );
+  repContest.options[0].scannedVote = true;
+  // Partisan contest without a vote and nonpartisan contest with a vote are
+  // not implicated in the crossover, so neither is listed
+  const unvotedPartisanContest = makeContestAdjudicationData(
+    'secretary-of-state-democratic',
+    undefined,
+    combinedBallotPrimaryElection
+  );
+  const nonpartisanContest = makeContestAdjudicationData(
+    'circuit-court-judge',
+    undefined,
+    combinedBallotPrimaryElection
+  );
+  nonpartisanContest.options[0].scannedVote = true;
+  const adjData = makeBallotAdjudicationData(
+    CVR_ID_1,
+    [demContest, repContest, unvotedPartisanContest, nonpartisanContest],
+    { tag: { isBlankBallot: false, hasCrossoverVote: true } }
+  );
+  setupBasicMocks({
+    adjudicationData: adjData,
+    systemSettings: {
+      ...DEFAULT_SYSTEM_SETTINGS,
+      limitAdminAdjudicationToFlaggedContests: true,
+    },
+  });
+
+  renderInAppContext(<BallotAdjudicationScreenWrapper />, {
+    electionDefinition: combinedBallotPrimaryDefinition,
+    apiMock,
+  });
+
+  await screen.findByText('Crossover Voting Detected');
+  expect(screen.getAllByText('Governor')).toHaveLength(2);
+  expect(screen.queryByText('Secretary of State')).toBeNull();
+  expect(screen.queryByText('Circuit Court Judge')).toBeNull();
 
   apiMock.apiClient.releaseBallotAdjudicationClaim
     .expectOptionalRepeatedCallsWith({ cvrId: CVR_ID_1 })

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -44,6 +44,7 @@ import {
   adjudicatedVotes,
   ContestListItem,
   deriveCrossoverVoteStatus,
+  isContestFlaggedForAdjudication,
   isContestTagOnlyUndervote,
 } from '../utils/adjudication';
 import { DiscardChangesModal } from '../components/discard_changes_modal';
@@ -617,6 +618,17 @@ function BallotView({
       ? undefined
       : contestItems.find((contest) => !contest.isResolved);
 
+  const visibleContestItems =
+    systemSettings.limitAdminAdjudicationToFlaggedContests
+      ? contestItems.filter((item) =>
+          isContestFlaggedForAdjudication(
+            item,
+            cvrTag,
+            systemSettings.adminAdjudicationReasons
+          )
+        )
+      : contestItems;
+
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [pendingDiscard, setPendingDiscard] = useState<{
     action: () => void;
@@ -757,7 +769,7 @@ function BallotView({
               key={cvrId}
               adjudicatedContests={adjudicatedContests}
               firstUnresolvedContestId={firstUnresolvedContest?.contest.id}
-              contestItems={contestItems}
+              contestItems={visibleContestItems}
               cvrTag={cvrTag}
               election={election}
               isBallotResolved={ballotAdjudicationData.isResolved}

--- a/apps/admin/frontend/src/utils/adjudication.ts
+++ b/apps/admin/frontend/src/utils/adjudication.ts
@@ -4,9 +4,11 @@ import type {
   ContestAdjudicationData,
   ContestOptionAdjudicationData,
   CvrContestTag,
+  CvrTag,
 } from '@votingworks/admin-backend';
 import { find, throwIllegalValue } from '@votingworks/basics';
 import {
+  AdjudicationReason,
   Contest,
   BallotPageContestOptionLayout,
   ContestId,
@@ -83,6 +85,22 @@ export function isContestCrossoverVoted(
     )
   );
   return hasVote;
+}
+
+export function isContestFlaggedForAdjudication(
+  contestItem: {
+    contest: Contest;
+    adjudicationData: ContestAdjudicationData;
+  },
+  cvrTag: CvrTag,
+  adminAdjudicationReasons: readonly AdjudicationReason[]
+): boolean {
+  return (
+    contestItem.adjudicationData.tag !== undefined ||
+    (cvrTag.isBlankBallot &&
+      adminAdjudicationReasons.includes(AdjudicationReason.BlankBallot)) ||
+    isContestCrossoverVoted(cvrTag.hasCrossoverVote, contestItem)
+  );
 }
 
 export function adjudicatedVotes(

--- a/apps/design/frontend/src/system_settings_screen.test.tsx
+++ b/apps/design/frontend/src/system_settings_screen.test.tsx
@@ -218,12 +218,29 @@ test('adjudication reasons', async () => {
     screen.getByRole('checkbox', { name: 'Disallow Casting Overvotes' })
   ).toBeChecked();
 
+  expect(
+    screen.getByRole('checkbox', {
+      name: 'Limit Adjudication to Flagged Contests',
+    })
+  ).not.toBeChecked();
+  userEvent.click(
+    screen.getByRole('checkbox', {
+      name: 'Limit Adjudication to Flagged Contests',
+    })
+  );
+  expect(
+    screen.getByRole('checkbox', {
+      name: 'Limit Adjudication to Flagged Contests',
+    })
+  ).toBeChecked();
+
   const updatedSystemSettings: SystemSettings = {
     ...DEFAULT_SYSTEM_SETTINGS,
     precinctScanAdjudicationReasons: [AdjudicationReason.Overvote],
     centralScanAdjudicationReasons: [AdjudicationReason.Overvote],
     adminAdjudicationReasons: [AdjudicationReason.Overvote],
     disallowCastingOvervotes: true,
+    limitAdminAdjudicationToFlaggedContests: true,
   };
   apiMock.updateSystemSettings
     .expectCallWith({ electionId, systemSettings: updatedSystemSettings })
@@ -240,6 +257,7 @@ test('adjudication reasons', async () => {
     if (
       option.textContent === 'Overvote' ||
       option.textContent === 'Disallow Casting Overvotes' ||
+      option.textContent === 'Limit Adjudication to Flagged Contests' ||
       option.textContent === 'Enable Summary Ballot Scanning on VxScan'
     ) {
       expect(option).toBeChecked();
@@ -637,7 +655,7 @@ test('all controls are disabled until clicking "Edit"', async () => {
   const allCheckboxes = document.body.querySelectorAll('[role=checkbox]');
   const allControls = [...allTextBoxes, ...allCheckboxes];
 
-  expect(allControls).toHaveLength(42);
+  expect(allControls).toHaveLength(43);
 
   for (const control of allControls) {
     expect(control).toBeDisabled();

--- a/apps/design/frontend/src/system_settings_screen.tsx
+++ b/apps/design/frontend/src/system_settings_screen.tsx
@@ -297,6 +297,21 @@ export function SystemSettingsForm({
               }
               disabled={!isEditing}
             />
+            <CheckboxButton
+              label="Limit Adjudication to Flagged Contests"
+              isChecked={
+                systemSettings.limitAdminAdjudicationToFlaggedContests ?? false
+              }
+              onChange={(isChecked) =>
+                setSystemSettings({
+                  ...systemSettings,
+                  limitAdminAdjudicationToFlaggedContests: isChecked
+                    ? true
+                    : undefined, // Completely omit when unchecked
+                })
+              }
+              disabled={!isEditing}
+            />
           </Column>
         </Card>
         <Card style={{ minWidth: '16rem' }}>

--- a/libs/types/src/system_settings.ts
+++ b/libs/types/src/system_settings.ts
@@ -91,6 +91,14 @@ export const SystemSettingsSchema = z
     markThresholds: MarkThresholdsSchema,
     bitonalThreshold: z.number().min(0).max(100).optional(),
     adminAdjudicationReasons: z.array(z.lazy(() => AdjudicationReasonSchema)),
+
+    /**
+     * When enabled, ballot adjudication in VxAdmin only shows and allows
+     * editing contests that were flagged for adjudication rather than
+     * allowing edits to any contest on the ballot.
+     */
+    limitAdminAdjudicationToFlaggedContests: z.boolean().optional(),
+
     centralScanAdjudicationReasons: z.array(
       z.lazy(() => AdjudicationReasonSchema)
     ),


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/8073

Limits the visible contests on the Ballot Adjudication Screen's contest list if `limitAdminAdjudicationToFlaggedContests` is set, thus preventing adjudication for unflagged contests. 

## Demo Video or Screenshot

<img width="1075" height="678" alt="Screenshot 2026-07-28 at 4 03 08 PM" src="https://github.com/user-attachments/assets/e7c330f5-f65e-4982-87c9-f9b368a9b126" />

<img width="1082" height="691" alt="Screenshot 2026-07-28 at 4 20 27 PM" src="https://github.com/user-attachments/assets/0959c0ca-3d61-4472-a6ef-96b7259c4b19" />

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
