### PR TITLE
VxDesign: Spot color conversion for NH state primary ballot template

### DIFF
--- a/apps/design/backend/src/worker/ballot_pdfs.test.ts
+++ b/apps/design/backend/src/worker/ballot_pdfs.test.ts
@@ -1,12 +1,17 @@
 import { expect, test, vi } from 'vitest';
 import { Buffer } from 'node:buffer';
-import { convertPdfToGrayscale } from '@votingworks/hmpb';
+import {
+  convertPdfToGrayscale,
+  convertPdfToSpotColor,
+  NhStateSpotColors,
+} from '@votingworks/hmpb';
 
 import { normalizeBallotColorModeForPrinting } from './ballot_pdfs';
 
 vi.mock(import('@votingworks/hmpb'), async (importActual) => ({
   ...(await importActual()),
   convertPdfToGrayscale: vi.fn(),
+  convertPdfToSpotColor: vi.fn(),
 }));
 
 test('normalizeBallotColorModeForPrinting - converts NH ballots to grayscale', async () => {
@@ -18,6 +23,20 @@ test('normalizeBallotColorModeForPrinting - converts NH ballots to grayscale', a
     await normalizeBallotColorModeForPrinting(mockColorPdf, 'NhBallot')
   ).toStrictEqual(mockGrayscalePdfNh);
   expect(convertPdfToGrayscale).toHaveBeenCalledWith(mockColorPdf);
+});
+
+test('normalizeBallotColorModeForPrinting - converts NH state ballots to spot color', async () => {
+  const mockColorPdf = Buffer.of(0xca, 0xfe);
+  const mockSpotColorPdf = Buffer.of(0xfa, 0xce);
+  vi.mocked(convertPdfToSpotColor).mockResolvedValueOnce(mockSpotColorPdf);
+
+  expect(
+    await normalizeBallotColorModeForPrinting(mockColorPdf, 'NhStateBallot')
+  ).toStrictEqual(mockSpotColorPdf);
+  expect(convertPdfToSpotColor).toHaveBeenCalledWith(
+    mockColorPdf,
+    Object.values(NhStateSpotColors)
+  );
 });
 
 test('normalizeBallotColorModeForPrinting - doesnt convert non-NH ballots', async () => {

--- a/apps/design/backend/src/worker/ballot_pdfs.ts
+++ b/apps/design/backend/src/worker/ballot_pdfs.ts
@@ -1,8 +1,10 @@
 import {
   convertPdfToGrayscale,
+  convertPdfToSpotColor,
   calibrationSheetTemplate,
   Renderer,
   BallotTemplateId,
+  NhStateSpotColors,
 } from '@votingworks/hmpb';
 import { HmpbBallotPaperSize } from '@votingworks/types';
 
@@ -10,8 +12,17 @@ export async function normalizeBallotColorModeForPrinting(
   ballotPdf: Uint8Array,
   ballotTemplateId: BallotTemplateId
 ): Promise<Uint8Array> {
-  if (ballotTemplateId !== 'NhBallot') return ballotPdf;
-  return await convertPdfToGrayscale(ballotPdf);
+  switch (ballotTemplateId) {
+    case 'NhBallot':
+      return await convertPdfToGrayscale(ballotPdf);
+    case 'NhStateBallot':
+      return await convertPdfToSpotColor(
+        ballotPdf,
+        Object.values(NhStateSpotColors)
+      );
+    default:
+      return ballotPdf;
+  }
 }
 
 export async function renderCalibrationSheetPdf(

--- a/libs/hmpb/src/ballot_templates/index.ts
+++ b/libs/hmpb/src/ballot_templates/index.ts
@@ -7,6 +7,7 @@ import { vxDefaultBallotTemplate } from './vx_default_ballot_template';
 
 export type { NhBallotProps } from './nh_ballot_template';
 export type { NhStateBallotProps } from './nh_state_ballot_template';
+export { NhStateSpotColors } from './nh_state_primary_ballot_template';
 
 /**
  * All ballot templates, indexed by ID.

--- a/libs/hmpb/src/ballot_templates/nh_state_primary_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_state_primary_ballot_template.tsx
@@ -31,6 +31,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { BallotLayoutError, ContentComponentResult } from '../render_ballot';
 import { RenderScratchpad } from '../renderer';
+import { SpotColor } from '../pdf_conversion';
 import {
   OptionInfo,
   Page,
@@ -60,12 +61,31 @@ import {
 } from './nh_state_ballot_components';
 
 export const ColorTints = {
-  // sRGB equivalents of NH's specified CMYK values, converted via a standard
-  // CMYK profile: Blue PMS 297U / CMYK 41-4-1-0; Red PMS 699U / CMYK 2-28-9-0.
   BLUE: '#8FD0F1',
   RED: '#F4C3CC',
   GRAY: Colors.LIGHT_GRAY,
 } as const;
+
+/**
+ * The spot (Pantone) inks the NH printer prints the party tints with. Each
+ * partisan ballot is a two-ink job: the party's spot plate plus a single black
+ * plate.
+ *
+ * The `grayscaleTint` values are verified against Ghostscript's actual
+ * conversion in pdf_conversion.test.ts.
+ */
+export const NhStateSpotColors: Record<'BLUE' | 'RED', SpotColor> = {
+  BLUE: {
+    name: 'PMS 293',
+    sourceColor: ColorTints.BLUE,
+    grayscaleTint: '0.776',
+  },
+  RED: {
+    name: 'PMS 699',
+    sourceColor: ColorTints.RED,
+    grayscaleTint: '0.812',
+  },
+};
 
 export type ColorTint = keyof typeof ColorTints;
 

--- a/libs/hmpb/src/normalize_pdf.test.ts
+++ b/libs/hmpb/src/normalize_pdf.test.ts
@@ -187,6 +187,22 @@ describe('normalizePdf', () => {
     );
   });
 
+  test('zeroes /ID arrays with whitespace between entries (pdf-lib form)', () => {
+    const pdf = makePdf({
+      objects: [
+        {
+          num: 1,
+          content:
+            '/ID [ <AE62F4165DB0622FD2E57DED09838D47> <AE62F4165DB0622FD2E57DED09838D47> ]',
+        },
+      ],
+    });
+    const result = fromBytes(normalizePdf(toBuffer(pdf)));
+    expect(result).toContain(
+      '/ID [<00000000000000000000000000000000><00000000000000000000000000000000>]'
+    );
+  });
+
   test('renumbers objects sequentially', () => {
     const pdf = makePdf({
       objects: [

--- a/libs/hmpb/src/normalize_pdf.ts
+++ b/libs/hmpb/src/normalize_pdf.ts
@@ -151,10 +151,11 @@ export function normalizePdf(pdf: Buffer): Uint8Array {
 
   // Ghostscript generates unique /ID pairs per run. These are used for PDF
   // document identification (e.g. by viewers to detect the same document) — no
-  // effect on content. Handles both hex form (/ID [<hex><hex>]) and string
-  // literal form (/ID [(...)(...)]).
+  // effect on content. Handles the hex form (/ID [<hex><hex>], with optional
+  // whitespace as emitted by pdf-lib) and the string literal form
+  // (/ID [(...)(...)]).
   str = str.replace(
-    /\/ID \[<[0-9A-Fa-f]{32}><[0-9A-Fa-f]{32}>\]/g,
+    /\/ID \[\s*<[0-9A-Fa-f]{32}>\s*<[0-9A-Fa-f]{32}>\s*\]/g,
     `/ID [<${ZERO_HEX_ID}><${ZERO_HEX_ID}>]`
   );
   str = str.replace(

--- a/libs/hmpb/src/pdf_conversion.test.ts
+++ b/libs/hmpb/src/pdf_conversion.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, test } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { promisify } from 'node:util';
+import { execFile } from 'node:child_process';
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpNameSync } from 'tmp';
+import {
+  decodePDFRawStream,
+  PDFArray,
+  PDFDocument,
+  PDFName,
+  PDFRawStream,
+  rgb,
+  StandardFonts,
+} from 'pdf-lib';
+import { assert, assertDefined } from '@votingworks/basics';
+import { convertPdfToGrayscale, convertPdfToSpotColor } from './pdf_conversion';
+import { fixturesDir } from './ballot_fixtures';
+import { Colors } from './ballot_components';
+import {
+  ColorTints,
+  NhStateSpotColors,
+} from './ballot_templates/nh_state_primary_ballot_template';
+
+const PMS_293 = NhStateSpotColors.BLUE;
+
+const BLACK = '#000000';
+const WHITE = '#FFFFFF';
+const GRAY_SHADE = Colors.DARKER_GRAY;
+
+function hexToRgb(hex: string): [number, number, number] {
+  return [
+    parseInt(hex.slice(1, 3), 16) / 255,
+    parseInt(hex.slice(3, 5), 16) / 255,
+    parseInt(hex.slice(5, 7), 16) / 255,
+  ];
+}
+
+/**
+ * Builds a PDF with one page per argument, each drawing a filled rectangle for
+ * every hex color given.
+ */
+async function buildColorPdf(...pages: Array<string[]>): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  for (const colors of pages) {
+    const page = doc.addPage([200, 200]);
+    for (const [i, color] of colors.entries()) {
+      page.drawRectangle({
+        x: 10,
+        y: 10 + i * 20,
+        width: 100,
+        height: 15,
+        color: rgb(...hexToRgb(color)),
+      });
+    }
+  }
+  return doc.save();
+}
+
+/**
+ * The concatenated, decoded content streams of every page in a PDF.
+ */
+async function decodedContents(pdf: Uint8Array): Promise<string> {
+  const doc = await PDFDocument.load(pdf, { updateMetadata: false });
+  return doc
+    .getPages()
+    .map((page) => {
+      const contents = doc.context.lookup(
+        page.node.get(PDFName.of('Contents'))
+      );
+      const streams =
+        contents instanceof PDFArray
+          ? contents.asArray().map((ref) => doc.context.lookup(ref))
+          : [contents];
+      return streams
+        .map((stream) => {
+          assert(stream instanceof PDFRawStream);
+          return Buffer.from(
+            stream.dict.has(PDFName.of('Filter'))
+              ? decodePDFRawStream(stream).decode()
+              : stream.contents
+          ).toString('latin1');
+        })
+        .join('\n');
+    })
+    .join('\n');
+}
+
+describe('convertPdfToSpotColor', () => {
+  test('replaces the party tint with a named spot separation', async () => {
+    // Page 2 has no tint, exercising the untouched-content-stream path.
+    const pdf = await buildColorPdf([ColorTints.BLUE, BLACK, WHITE], [BLACK]);
+
+    const converted = await convertPdfToSpotColor(
+      pdf,
+      Object.values(NhStateSpotColors)
+    );
+
+    const result = Buffer.from(converted).toString('latin1');
+    // The named separation's alternate colorspace previews the tint as the
+    // exact source color (#8FD0F1), so the converted PDF looks like the
+    // source on screen.
+    expect(result).toContain('/Separation /PMS#20293 /DeviceRGB');
+    expect(result).toContain('/C1 [ 0.5608 0.8157 0.9451 ]');
+    // No color operators remain in the page content: black/white/tint are all
+    // expressed as grays or the spot separation.
+    expect(await decodedContents(converted)).not.toMatch(/ (rg|RG)\b/);
+  });
+
+  test('converts a stroked tint to a spot stroke', async () => {
+    const doc = await PDFDocument.create();
+    const page = doc.addPage([200, 200]);
+    page.drawRectangle({
+      x: 10,
+      y: 10,
+      width: 100,
+      height: 100,
+      borderColor: rgb(...hexToRgb(ColorTints.BLUE)),
+      borderWidth: 3,
+    });
+    const converted = await convertPdfToSpotColor(
+      await doc.save(),
+      Object.values(NhStateSpotColors)
+    );
+    expect(await decodedContents(converted)).toContain('/Spot0 CS 1 SCN');
+  });
+
+  test('produces a single named spot plate plus black', async () => {
+    const pdf = await buildColorPdf([ColorTints.BLUE, BLACK]);
+    const converted = await convertPdfToSpotColor(
+      pdf,
+      Object.values(NhStateSpotColors)
+    );
+
+    // Render one separation plate per ink via Ghostscript's tiffsep device.
+    // -dPDFSTOPONERROR makes structural errors (bad xref/stream lengths) fail
+    // instead of being silently repaired, so this also validates the PDF's
+    // structure.
+    const inputPath = tmpNameSync();
+    const outDir = tmpNameSync();
+    try {
+      await mkdir(outDir, { recursive: true });
+      await writeFile(inputPath, converted);
+      await promisify(execFile)('gs', [
+        '-q',
+        '-dNOPAUSE',
+        '-dBATCH',
+        '-dPDFSTOPONERROR',
+        '-sDEVICE=tiffsep',
+        '-r72',
+        `-sOutputFile=${outDir}/plate_%d.tif`,
+        inputPath,
+      ]);
+      const plates = await readdir(outDir);
+      // The spot ink gets its own named plate. (tiffsep always emits the CMYK
+      // process plates too — test 1 asserts no process color is actually used.)
+      expect(plates).toContain('plate_1(PMS 293).tif');
+      expect(plates).toContain('plate_1(Black).tif');
+    } finally {
+      await rm(inputPath, { force: true });
+      await rm(outDir, { recursive: true, force: true });
+    }
+  });
+
+  test('throws when more than one party tint is present', async () => {
+    // A two-ink job has exactly one spot plate; a document with both party
+    // tints is unconditionally a bug.
+    const pdf = await buildColorPdf([ColorTints.BLUE, BLACK], [ColorTints.RED]);
+    await expect(
+      convertPdfToSpotColor(pdf, Object.values(NhStateSpotColors))
+    ).rejects.toThrow(/at most one spot color/);
+  });
+
+  test('converts only the party tint, leaving other grays on the black plate', async () => {
+    // Like a Return of Votes form: a party tint plus a gray design shade.
+    const pdf = await buildColorPdf([ColorTints.BLUE, GRAY_SHADE, BLACK]);
+    const converted = await convertPdfToSpotColor(
+      pdf,
+      Object.values(NhStateSpotColors)
+    );
+
+    const contents = await decodedContents(converted);
+    // The party tint became the spot separation...
+    expect(contents).toContain('/Spot0 cs 1 scn');
+    // ...while the gray design shade stayed an ordinary gray fill (not spot).
+    const remainingGrays = [...contents.matchAll(/([\d.]+) g\b/g)]
+      .map((m) => m[1])
+      .filter((v) => v !== '0' && v !== '1');
+    expect(remainingGrays).toHaveLength(1);
+  });
+
+  test('applies no ink when no source color is present', async () => {
+    const noTint = await buildColorPdf([BLACK, WHITE, GRAY_SHADE]);
+    const converted = await convertPdfToSpotColor(
+      noTint,
+      Object.values(NhStateSpotColors)
+    );
+    expect(Buffer.from(converted).toString('latin1')).not.toContain(
+      '/Separation'
+    );
+  });
+
+  test('ignores tint-like text inside string literals', async () => {
+    // Text that happens to spell a tint operator must stay text, not become a
+    // spot fill.
+    const doc = await PDFDocument.create();
+    const font = await doc.embedFont(StandardFonts.Helvetica);
+    const page = doc.addPage([200, 200]);
+    page.drawText(`${PMS_293.grayscaleTint} g`, { x: 20, y: 150, font });
+    page.drawRectangle({
+      x: 10,
+      y: 10,
+      width: 100,
+      height: 15,
+      color: rgb(...hexToRgb(ColorTints.BLUE)),
+    });
+    const converted = await convertPdfToSpotColor(
+      await doc.save(),
+      Object.values(NhStateSpotColors)
+    );
+    // Exactly one substitution: the rectangle fill, not the text.
+    const contents = await decodedContents(converted);
+    expect(contents.match(/\/Spot0 cs 1 scn/g)).toHaveLength(1);
+  });
+
+  // The fixture ballots are real Chromium-rendered output, so these tests
+  // guard the whole pipeline: a rendering or Ghostscript change that shifts a
+  // tint's grayscale value would otherwise silently drop the party plate
+  // (converting to plain grayscale is a legitimate outcome for nonpartisan
+  // ballots, so nothing else would catch it).
+  test('converts a real rendered partisan ballot to its party plate', async () => {
+    const ballot = await readFile(
+      join(fixturesDir, 'nh-state-primary-election/dem-blank-ballot.pdf')
+    );
+    const converted = await convertPdfToSpotColor(
+      ballot,
+      Object.values(NhStateSpotColors)
+    );
+    expect(Buffer.from(converted).toString('latin1')).toContain(
+      '/Separation /PMS#20293'
+    );
+  });
+
+  test('converts a real rendered nonpartisan ballot to plain grayscale', async () => {
+    const ballot = await readFile(
+      join(fixturesDir, 'nh-state-general-election/blank-ballot.pdf')
+    );
+    const converted = await convertPdfToSpotColor(
+      ballot,
+      Object.values(NhStateSpotColors)
+    );
+    expect(Buffer.from(converted).toString('latin1')).not.toContain(
+      '/Separation'
+    );
+  });
+});
+
+describe('NH spot color declarations', () => {
+  /**
+   * The gray that Ghostscript's grayscale conversion actually produces for a
+   * hex color, discovered by converting a single-color swatch.
+   */
+  async function actualGrayscaleValue(hex: string): Promise<string> {
+    const swatch = await buildColorPdf([hex]);
+    const grayscale = await convertPdfToGrayscale(swatch);
+    const values = [
+      ...(await decodedContents(grayscale)).matchAll(/([\d.]+) g\b/g),
+    ]
+      .map((m) => m[1])
+      .filter((v) => v !== '0' && v !== '1');
+    return assertDefined(values[0]);
+  }
+
+  test('declared grayscaleTint values match the actual conversion', async () => {
+    for (const spot of Object.values(NhStateSpotColors)) {
+      expect
+        .soft(await actualGrayscaleValue(spot.sourceColor), spot.name)
+        .toEqual(spot.grayscaleTint);
+    }
+  });
+
+  test('no other template palette color collides with a spot tint', async () => {
+    // If a palette color grayscales to the same value as a party tint, the
+    // conversion would silently print it on the party plate. The palette is
+    // the closed set of colors the templates draw with.
+    const palette: Record<string, string> = {
+      ...Colors,
+      TINT_GRAY: ColorTints.GRAY,
+    };
+    const declaredTints = new Set(
+      Object.values(NhStateSpotColors).map((spot) => spot.grayscaleTint)
+    );
+    for (const [name, hex] of Object.entries(palette)) {
+      if (hex === '#000000' || hex === '#FFFFFF') continue;
+      expect
+        .soft(declaredTints.has(await actualGrayscaleValue(hex)), name)
+        .toEqual(false);
+    }
+  });
+});

--- a/libs/hmpb/src/pdf_conversion.ts
+++ b/libs/hmpb/src/pdf_conversion.ts
@@ -2,14 +2,24 @@ import { tmpNameSync } from 'tmp';
 import { promisify } from 'node:util';
 import { execFile } from 'node:child_process';
 import { readFile, rm, writeFile } from 'node:fs/promises';
+import { Buffer } from 'node:buffer';
+import {
+  decodePDFRawStream,
+  PDFArray,
+  PDFContext,
+  PDFDict,
+  PDFDocument,
+  PDFName,
+  PDFRawStream,
+  PDFRef,
+} from 'pdf-lib';
+import { assert } from '@votingworks/basics';
 import { normalizePdf } from './normalize_pdf';
 
 /**
- * Given a PDF document, convert it to grayscale.
+ * Converts a PDF to grayscale via Ghostscript, without normalizing the output.
  */
-export async function convertPdfToGrayscale(
-  pdf: Uint8Array
-): Promise<Uint8Array> {
+async function ghostscriptGrayscale(pdf: Uint8Array): Promise<Buffer> {
   const tmpPdfFilePath = tmpNameSync();
   await writeFile(tmpPdfFilePath, pdf);
   const tmpGrayscalePdfFilePath = tmpNameSync();
@@ -23,11 +33,20 @@ export async function convertPdfToGrayscale(
     tmpPdfFilePath,
   ]);
   try {
-    return normalizePdf(await readFile(tmpGrayscalePdfFilePath));
+    return await readFile(tmpGrayscalePdfFilePath);
   } finally {
     await rm(tmpGrayscalePdfFilePath);
     await rm(tmpPdfFilePath);
   }
+}
+
+/**
+ * Given a PDF document, convert it to grayscale.
+ */
+export async function convertPdfToGrayscale(
+  pdf: Uint8Array
+): Promise<Uint8Array> {
+  return normalizePdf(await ghostscriptGrayscale(pdf));
 }
 
 /**
@@ -53,4 +72,273 @@ export async function convertPdfToCmyk(pdf: Uint8Array): Promise<Uint8Array> {
     await rm(tmpCmykPdfFilePath);
     await rm(tmpPdfFilePath);
   }
+}
+
+/**
+ * A rule mapping a color that a ballot template renders onto a named spot
+ * (separation) ink for spot-color printing.
+ */
+export interface SpotColor {
+  /**
+   * The separation/ink name as it should appear in the PDF and to the
+   * printer's RIP, e.g. `'PMS 293'`.
+   */
+  readonly name: string;
+  /**
+   * The ballot template color this ink replaces, as a hex string (e.g.
+   * `'#8FD0F1'`). Also used as the separation's alternate color, so the
+   * converted PDF previews on screen exactly like the source.
+   */
+  readonly sourceColor: string;
+  /**
+   * The DeviceGray operand that Ghostscript's grayscale conversion produces
+   * for `sourceColor`, e.g. `'0.776'`.
+   */
+  readonly grayscaleTint: string;
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  const match = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+  assert(match !== null, `invalid hex color: ${hex}`);
+  return [match[1], match[2], match[3]].map(
+    (channel) => Math.round((parseInt(channel, 16) / 255) * 10000) / 10000
+  ) as [number, number, number];
+}
+
+/**
+ * Splits a content stream into segments alternating between operator text and
+ * literal strings (`(...)`, with backslash escapes and nested parens). We only
+ * want to do string replacements on operator text, not on string literals.
+ */
+function splitContentStreamOnOperators(
+  content: string
+): Array<{ text: string; isOperator: boolean }> {
+  const segments: Array<{ text: string; isOperator: boolean }> = [];
+  let segmentStart = 0;
+  let depth = 0;
+  for (let i = 0; i < content.length; i += 1) {
+    const char = content[i];
+    if (depth > 0 && char === '\\') {
+      i += 1;
+    } else if (char === '(') {
+      if (depth === 0) {
+        segments.push({
+          text: content.slice(segmentStart, i),
+          isOperator: true,
+        });
+        segmentStart = i;
+      }
+      depth += 1;
+    } else if (char === ')' && depth > 0) {
+      depth -= 1;
+      if (depth === 0) {
+        segments.push({
+          text: content.slice(segmentStart, i + 1),
+          isOperator: false,
+        });
+        segmentStart = i + 1;
+      }
+    }
+  }
+  segments.push({ text: content.slice(segmentStart), isOperator: true });
+  return segments;
+}
+
+/**
+ * The resource name for a spot color, unique within the rule list, used to
+ * select the separation colorspace in rewritten content streams.
+ */
+function spotColorResourceName(spotIndex: number): string {
+  return `Spot${spotIndex}`;
+}
+
+// A tint operand/operator match must be delimited on both sides (so e.g.
+// `10.776 g` can't match `0.776 g`). PDF tokens are delimited by whitespace or
+// one of the delimiter characters.
+const DELIMITER = String.raw`\s()<>[\]{}/%`;
+
+/**
+ * Rewrites tint fills/strokes (`<tint> g` / `<tint> G`) in a content stream to
+ * spot colors. Returns the rewritten stream and the spot colors that matched.
+ * Assumes a Ghostscript-converted grayscale PDF as input.
+ */
+function replaceTintOperatorsWithSpotColors(
+  content: string,
+  spotColors: readonly SpotColor[]
+): { content: string; appliedSpotColors: readonly SpotColor[] } {
+  const appliedSpotColorIndexes = new Set<number>();
+  const updatedContent = splitContentStreamOnOperators(content)
+    .map(({ text, isOperator }) => {
+      if (!isOperator) return text;
+      assert(!text.includes('%'), 'unexpected comment in content stream');
+      assert(
+        !new RegExp(`(^|[${DELIMITER}])BI[${DELIMITER}]`).test(text),
+        'unexpected inline image in content stream'
+      );
+      let result = text;
+      for (const [spotIndex, spot] of spotColors.entries()) {
+        const tint = spot.grayscaleTint.replace(/\./g, '\\.');
+        assert(
+          !new RegExp(
+            `(^|[${DELIMITER}])${tint}\\s+(sc|scn|SC|SCN|k|K|rg|RG)(?=[${DELIMITER}]|$)`
+          ).test(result),
+          `color tint ${spot.grayscaleTint} set via unsupported operator`
+        );
+        const name = spotColorResourceName(spotIndex);
+        result = result.replace(
+          new RegExp(
+            `(^|[${DELIMITER}])${tint}\\s+(g|G)(?=[${DELIMITER}]|$)`,
+            'g'
+          ),
+          (_, before: string, operator: string) => {
+            appliedSpotColorIndexes.add(spotIndex);
+            return `${before}${
+              operator === 'g' ? `/${name} cs 1 scn` : `/${name} CS 1 SCN`
+            }`;
+          }
+        );
+      }
+      return result;
+    })
+    .join('');
+  return {
+    content: updatedContent,
+    appliedSpotColors: [...appliedSpotColorIndexes].map((i) => spotColors[i]),
+  };
+}
+
+function decodeStream(stream: PDFRawStream): Uint8Array {
+  return stream.dict.has(PDFName.of('Filter'))
+    ? decodePDFRawStream(stream).decode()
+    : stream.contents;
+}
+
+/**
+ * A page's full content as a string (multiple content streams are equivalent
+ * to their concatenation, which per the PDF spec may only split between
+ * tokens).
+ */
+function pageContentString(context: PDFContext, pageNode: PDFDict): string {
+  const contents = context.lookup(pageNode.get(PDFName.of('Contents')));
+  if (contents === undefined) return '';
+  const streams =
+    contents instanceof PDFArray
+      ? contents.asArray().map((ref) => context.lookup(ref))
+      : [contents];
+  return streams
+    .map((stream) => {
+      assert(stream instanceof PDFRawStream);
+      return Buffer.from(decodeStream(stream)).toString('latin1');
+    })
+    .join('\n');
+}
+
+/**
+ * Converts a color ballot PDF into a spot-color PDF for two-ink printing.
+ *
+ * First converts the PDF to grayscale, then identifies the given {@link
+ * SpotColor}s in the PDF's content streams using their resulting grayscale
+ * tints. Replaces each grayscale tint with a spot color separation, and adds
+ * the separation to the page's resources. The resulting PDF is suitable for
+ * printing with a black plate and a spot-color plate.
+ *
+ * Throws if the PDF contains more than one of the given spot colors, since in
+ * our use case we only expect one spot color per ballot template.
+ */
+export async function convertPdfToSpotColor(
+  pdf: Uint8Array,
+  spotColors: readonly SpotColor[]
+): Promise<Uint8Array> {
+  const grayscalePdf = await ghostscriptGrayscale(pdf);
+  const doc = await PDFDocument.load(grayscalePdf, { updateMetadata: false });
+  const { context } = doc;
+
+  // One separation colorspace object per ink, created on first use.
+  const separationRefs = new Map<number, PDFRef>();
+  function separationRef(spotIndex: number): PDFRef {
+    const cached = separationRefs.get(spotIndex);
+    if (cached !== undefined) return cached;
+    const spot = spotColors[spotIndex];
+    const tintTransformRef = context.register(
+      context.obj({
+        FunctionType: 2,
+        Domain: [0, 1],
+        C0: [1, 1, 1],
+        C1: hexToRgb(spot.sourceColor),
+        N: 1,
+        Range: [0, 1, 0, 1, 0, 1],
+      })
+    );
+    const ref = context.register(
+      context.obj([
+        PDFName.of('Separation'),
+        PDFName.of(spot.name),
+        PDFName.of('DeviceRGB'),
+        tintTransformRef,
+      ])
+    );
+    separationRefs.set(spotIndex, ref);
+    return ref;
+  }
+
+  const appliedSpotColorNames = new Set<string>();
+  for (const page of doc.getPages()) {
+    const original = pageContentString(context, page.node);
+    const { content, appliedSpotColors } = replaceTintOperatorsWithSpotColors(
+      original,
+      spotColors
+    );
+    if (appliedSpotColors.length === 0) continue;
+
+    // Delete the replaced content stream objects: pdf-lib serializes every
+    // registered object on save, so they would otherwise remain in the file
+    // as unreferenced bloat.
+    const oldContentsValue = page.node.get(PDFName.of('Contents'));
+    const oldContents = context.lookup(oldContentsValue);
+    if (oldContents instanceof PDFArray) {
+      for (const ref of oldContents.asArray()) {
+        if (ref instanceof PDFRef) context.delete(ref);
+      }
+    }
+    if (oldContentsValue instanceof PDFRef) context.delete(oldContentsValue);
+
+    page.node.set(
+      PDFName.of('Contents'),
+      context.register(context.flateStream(content))
+    );
+
+    let resources = page.node.Resources();
+    if (resources === undefined) {
+      resources = context.obj({});
+      page.node.set(PDFName.of('Resources'), resources);
+    }
+    let colorSpaces = resources.lookupMaybe(PDFName.of('ColorSpace'), PDFDict);
+    if (colorSpaces === undefined) {
+      colorSpaces = context.obj({});
+      resources.set(PDFName.of('ColorSpace'), colorSpaces);
+    }
+    for (const spotColor of appliedSpotColors) {
+      const spotIndex = spotColors.indexOf(spotColor);
+      const name = PDFName.of(spotColorResourceName(spotIndex));
+      const existing = colorSpaces.get(name);
+      assert(
+        existing === undefined || existing === separationRef(spotIndex),
+        `page resources already define colorspace /${name.decodeText()}`
+      );
+      colorSpaces.set(name, separationRef(spotIndex));
+      appliedSpotColorNames.add(spotColor.name);
+    }
+  }
+
+  assert(
+    appliedSpotColorNames.size <= 1,
+    `expected at most one spot color per document, applied: ${[
+      ...appliedSpotColorNames,
+    ]
+      .sort()
+      .join(', ')}`
+  );
+
+  const saved = await doc.save({ useObjectStreams: false });
+  return normalizePdf(Buffer.from(saved));
 }


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

<!-- Add a link to a GitHub issue here -->
Task: https://github.com/votingworks/vxsuite/issues/8888

Converts the red/blue tint in NH state primary ballot PDFs from RGB colors to [spot colors](https://en.wikipedia.org/wiki/Spot_color) (colors that can be printed with a single pre-mixed ink by the ballot printer). To do this, we first convert the ballot to grayscale as usual (which allows the printer to use single black ink), and then replace the specific gray value that maps to the color tint for the ballot with a spot color.

## Demo Video or Screenshot
N/A

## Testing Plan
Added automated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
