### PR TITLE
re-enable usb ports on unconfigure

### DIFF
--- a/apps/mark/backend/src/app.test.ts
+++ b/apps/mark/backend/src/app.test.ts
@@ -290,6 +290,15 @@ test('unconfigureMachine deletes system settings and election definition', async
   expect(electionRecord).toBeNull();
 });
 
+test('unconfigureMachine re-enables USB ports', async () => {
+  await apiClient.toggleUsbPorts({ action: 'disable' });
+  expect(await apiClient.getUsbPortStatus()).toEqual({ enabled: false });
+
+  await apiClient.unconfigureMachine();
+
+  expect(await apiClient.getUsbPortStatus()).toEqual({ enabled: true });
+});
+
 test('configureElectionPackageFromUsb throws when no USB drive mounted', async () => {
   const electionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -141,6 +141,16 @@ export function buildApi(ctx: Context) {
     });
   }
 
+  const systemCallApi = createSystemCallApi({
+    usbDrive,
+    logger,
+    machineId: getMachineConfig().machineId,
+    codeVersion: getMachineConfig().codeVersion,
+    workspacePath: workspace.path,
+    getAuthStatus: /* istanbul ignore next */ () =>
+      auth.getAuthStatus(constructAuthMachineState(workspace)),
+  });
+
   return grout.createApi({
     getMachineConfig,
 
@@ -239,6 +249,14 @@ export function buildApi(ctx: Context) {
 
     async unconfigureMachine() {
       workspace.store.reset();
+      // Re-enable USB ports in case they were auto-disabled while an alarm was
+      // active (see setup_printer_page). Otherwise they remain silently
+      // disabled, preventing the machine from recognizing a new election
+      // package.
+      const { enabled } = await systemCallApi.getUsbPortStatus();
+      if (!enabled) {
+        await systemCallApi.toggleUsbPorts({ action: 'enable' });
+      }
       await logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
         disposition: 'success',
         message:
@@ -316,15 +334,7 @@ export function buildApi(ctx: Context) {
       store: workspace.store.getUiStringsStore(),
     }),
 
-    ...createSystemCallApi({
-      usbDrive,
-      logger,
-      machineId: getMachineConfig().machineId,
-      codeVersion: getMachineConfig().codeVersion,
-      workspacePath: workspace.path,
-      getAuthStatus: /* istanbul ignore next */ () =>
-        auth.getAuthStatus(constructAuthMachineState(workspace)),
-    }),
+    ...systemCallApi,
 
     async printBallot(input: PrintBallotProps) {
       await printBallot({

--- a/apps/mark/frontend/src/api.ts
+++ b/apps/mark/frontend/src/api.ts
@@ -357,6 +357,7 @@ export const unconfigureMachine = {
         await queryClient.invalidateQueries(getElectionRecord.queryKey());
         await queryClient.invalidateQueries(getSystemSettings.queryKey());
         await queryClient.invalidateQueries(getElectionState.queryKey());
+        await queryClient.invalidateQueries(['getUsbPortStatus']);
         await uiStringsApi.onMachineConfigurationChange(queryClient);
       },
     });

--- a/apps/mark/frontend/src/api_machine_configuration.test.tsx
+++ b/apps/mark/frontend/src/api_machine_configuration.test.tsx
@@ -61,6 +61,7 @@ test('configureElectionPackageFromUsb', async () => {
 
 test('unconfigureMachine', async () => {
   vi.mocked(mockBackendApi).unconfigureMachine.mockResolvedValueOnce();
+  const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
 
   const { result } = renderHook(() => unconfigureMachine.useMutation(), {
     wrapper: QueryWrapper,
@@ -72,4 +73,7 @@ test('unconfigureMachine', async () => {
   await vi.waitFor(() => expect(result.current.isSuccess).toEqual(true));
 
   expect(mockOnConfigurationChange).toHaveBeenCalled();
+  // USB ports may have been re-enabled on the backend, so the cached status
+  // must be invalidated for the UI to reflect it.
+  expect(invalidateQueries).toHaveBeenCalledWith(['getUsbPortStatus']);
 });


### PR DESCRIPTION
## Overview

Re-enables USB ports when VxMark is unconfigured.

Closes https://github.com/votingworks/vxsuite/issues/8854

## Demo Video or Screenshot



https://github.com/user-attachments/assets/7e1cddf0-9404-42d8-a6c9-ecc44ed11583


https://github.com/user-attachments/assets/cbaf1803-1750-48f1-8764-4c79f957f54f


## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] (Already exists) I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
