### PR TITLE
disable test deck print buttons when no printer is connected

### DIFF
--- a/apps/mark/frontend/src/pages/test_deck_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/test_deck_screen.test.tsx
@@ -198,7 +198,7 @@ test('disables printing and explains why when the printer is not connected', asy
   renderScreen();
 
   await screen.findByText(
-    'No printer detected. Connect the printer to print test decks.'
+    'No printer detected. Connect it to print test decks.'
   );
   expect(
     screen.getByRole('button', { name: 'Print All Test Decks' })

--- a/apps/mark/frontend/src/pages/test_deck_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/test_deck_screen.test.tsx
@@ -192,6 +192,38 @@ test('shows "Printing..." only on the precinct button and reverts after settling
   ).not.toBeInTheDocument();
 });
 
+test('disables printing and explains why when the printer is not connected', async () => {
+  apiMock.expectGetElectionRecord(electionDefinition);
+  apiMock.setPrinterStatus({ connected: false });
+  renderScreen();
+
+  await screen.findByText(
+    'No printer detected. Connect the printer to print test decks.'
+  );
+  expect(
+    screen.getByRole('button', { name: 'Print All Test Decks' })
+  ).toBeDisabled();
+  expect(
+    screen.getByRole('button', { name: 'Print Precinct Test Deck' })
+  ).toBeDisabled();
+});
+
+test('enables printing again once the printer reconnects', async () => {
+  apiMock.expectGetElectionRecord(electionDefinition);
+  apiMock.setPrinterStatus({ connected: false });
+  renderScreen();
+
+  const printAllButton = await screen.findByRole('button', {
+    name: 'Print All Test Decks',
+  });
+  expect(printAllButton).toBeDisabled();
+
+  apiMock.setPrinterStatus({ connected: true });
+
+  await vi.waitFor(() => expect(printAllButton).toBeEnabled());
+  expect(screen.queryByText(/No printer detected/)).not.toBeInTheDocument();
+});
+
 test('renders without precincts when no election is configured', async () => {
   apiMock.expectGetElectionRecord(null);
   renderScreen();

--- a/apps/mark/frontend/src/pages/test_deck_screen.tsx
+++ b/apps/mark/frontend/src/pages/test_deck_screen.tsx
@@ -45,7 +45,7 @@ export function TestDeckScreen({
 
   const isPrinterConnected = printerStatusQuery.data.connected;
   const printingInProgress = printTestDeckMutation.isLoading;
-  const printingDisabled = printingInProgress || !isPrinterConnected;
+  const isPrintingDisabled = printingInProgress || !isPrinterConnected;
 
   const printingProgressIndicator = (
     <span>
@@ -71,7 +71,7 @@ export function TestDeckScreen({
         )}
         <P>
           <Button
-            disabled={printingDisabled}
+            disabled={isPrintingDisabled}
             onPress={() => {
               setPrintingTestDeckType('all');
               printTestDeckMutation.mutate(
@@ -98,12 +98,12 @@ export function TestDeckScreen({
             value={selectedPrecinctId}
             onChange={setSelectedPrecinctId}
             style={{ width: '100%' }}
-            disabled={printingInProgress || !isPrinterConnected}
+            disabled={isPrintingDisabled}
           />
         </P>
         <P>
           <Button
-            disabled={!selectedPrecinctId || printingDisabled}
+            disabled={!selectedPrecinctId || isPrintingDisabled}
             onPress={() => {
               setPrintingTestDeckType('precinct');
               printTestDeckMutation.mutate(

--- a/apps/mark/frontend/src/pages/test_deck_screen.tsx
+++ b/apps/mark/frontend/src/pages/test_deck_screen.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import {
   Button,
+  Callout,
   H1,
   Icons,
   Loading,
@@ -10,7 +11,7 @@ import {
   SearchSelect,
 } from '@votingworks/ui';
 import { PrecinctId } from '@votingworks/types';
-import { getElectionRecord, printTestDeck } from '../api';
+import { getElectionRecord, getPrinterStatus, printTestDeck } from '../api';
 
 export interface TestDeckScreenProps {
   onBackButtonPress: () => void;
@@ -25,9 +26,10 @@ export function TestDeckScreen({
   >();
 
   const electionRecordQuery = getElectionRecord.useQuery();
+  const printerStatusQuery = getPrinterStatus.useQuery();
   const printTestDeckMutation = printTestDeck.useMutation();
 
-  if (!electionRecordQuery.isSuccess) {
+  if (!electionRecordQuery.isSuccess || !printerStatusQuery.isSuccess) {
     return (
       <Screen>
         <Main padded>
@@ -41,7 +43,9 @@ export function TestDeckScreen({
   const { electionDefinition } = electionRecordQuery.data ?? {};
   const precincts = electionDefinition?.election.precincts ?? [];
 
+  const isPrinterConnected = printerStatusQuery.data.connected;
   const printingInProgress = printTestDeckMutation.isLoading;
+  const printingDisabled = printingInProgress || !isPrinterConnected;
 
   const printingProgressIndicator = (
     <span>
@@ -58,9 +62,16 @@ export function TestDeckScreen({
             Back
           </Button>
         </P>
+        {!isPrinterConnected && (
+          <P>
+            <Callout icon="Warning" color="warning">
+              No printer detected. Connect it to print test decks.
+            </Callout>
+          </P>
+        )}
         <P>
           <Button
-            disabled={printingInProgress}
+            disabled={printingDisabled}
             onPress={() => {
               setPrintingTestDeckType('all');
               printTestDeckMutation.mutate(
@@ -87,12 +98,12 @@ export function TestDeckScreen({
             value={selectedPrecinctId}
             onChange={setSelectedPrecinctId}
             style={{ width: '100%' }}
-            disabled={printingInProgress}
+            disabled={printingInProgress || !isPrinterConnected}
           />
         </P>
         <P>
           <Button
-            disabled={!selectedPrecinctId || printingInProgress}
+            disabled={!selectedPrecinctId || printingDisabled}
             onPress={() => {
               setPrintingTestDeckType('precinct');
               printTestDeckMutation.mutate(


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/8993

When no printer is connected, disables the print buttons on test deck printing to avoid "Something went wrong" screen.

## Demo Video or Screenshot

<img width="461" height="793" alt="Screenshot 2026-07-30 at 9 27 12 PM" src="https://github.com/user-attachments/assets/f5d0f41d-be3c-4042-9db9-971ea8901764" />


## Testing Plan

- added tests
- manually tested

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
