### PR TITLE
VxMark: prevent blank ballot printing when polls are closed

### DIFF
--- a/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.test.tsx
@@ -280,6 +280,14 @@ test('hides the Print Blank Ballot button when the setting is disabled', () => {
   expect(screen.queryByText('Print Blank Ballot')).toBeNull();
 });
 
+test('hides the Print Blank Ballot button when polls are not open', () => {
+  expectSystemSettings(true);
+  renderScreen({ pollsState: 'polls_closed_initial' });
+
+  screen.getByText('Poll Worker Menu');
+  expect(screen.queryByText('Print Blank Ballot')).toBeNull();
+});
+
 const multiLanguageDefinition = getMockMultiLanguageElectionDefinition(
   electionGeneralDefinition,
   ['en', 'es-US']

--- a/apps/mark/frontend/src/pages/poll_worker_screen.tsx
+++ b/apps/mark/frontend/src/pages/poll_worker_screen.tsx
@@ -148,7 +148,7 @@ export function PollWorkerScreen({
               pollingPlaceId={pollingPlaceId}
             />
           )}
-          {allowPrintingBlankBallots && (
+          {allowPrintingBlankBallots && pollsState === 'polls_open' && (
             <Button onPress={onPressPrintBlankBallot}>
               Print Blank Ballot
             </Button>


### PR DESCRIPTION
## Overview

In the latest demo branch we support blank ballot printing in 2 ways

1. Button on the pollworker screen
2. Scanning a QR code

https://github.com/votingworks/vxsuite/pull/8988 issued a fix to prevent blank ballot printing when polls are closed, similar to how starting a voting session isn't allowed when polls are closed.

In `main` we only support method blank ballot printing via method 1. This PR prevents blank ballot printing for method 1 only, and will be merged into `main` instead of the demo branch.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/5ab94635-d9d3-408f-a945-ad1281896d5d




## Testing Plan

Added tests, tested manually

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
