### PR TITLE
Fix validate-monorepo gate and add missing tsconfig references

### DIFF
--- a/apps/admin/backend/tsconfig.build.json
+++ b/apps/admin/backend/tsconfig.build.json
@@ -26,6 +26,7 @@
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
     { "path": "../../../libs/usb-drive/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/fs/tsconfig.build.json" }
   ]
 }

--- a/apps/admin/backend/tsconfig.json
+++ b/apps/admin/backend/tsconfig.json
@@ -32,6 +32,7 @@
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
     { "path": "../../../libs/usb-drive/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/fs/tsconfig.build.json" }
   ]
 }

--- a/apps/admin/frontend/tsconfig.json
+++ b/apps/admin/frontend/tsconfig.json
@@ -31,6 +31,8 @@
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
     { "path": "../../../libs/utils/tsconfig.build.json" },
-    { "path": "../backend/tsconfig.build.json" }
+    { "path": "../backend/tsconfig.build.json" },
+    { "path": "../../../libs/backend/tsconfig.build.json" },
+    { "path": "../../../libs/usb-drive/tsconfig.build.json" }
   ]
 }

--- a/apps/admin/integration-testing/tsconfig.json
+++ b/apps/admin/integration-testing/tsconfig.json
@@ -26,6 +26,10 @@
     { "path": "../../../libs/grout/tsconfig.build.json" },
     { "path": "../../../libs/integration-test-utils/tsconfig.build.json" },
     { "path": "../../../libs/test-utils/tsconfig.build.json" },
-    { "path": "../../../libs/types/tsconfig.build.json" }
+    { "path": "../../../libs/types/tsconfig.build.json" },
+    { "path": "../../../libs/backend/tsconfig.build.json" },
+    { "path": "../../../libs/printing/tsconfig.build.json" },
+    { "path": "../../../libs/usb-drive/tsconfig.build.json" },
+    { "path": "../../../libs/utils/tsconfig.build.json" }
   ]
 }

--- a/apps/central-scan/backend/tsconfig.build.json
+++ b/apps/central-scan/backend/tsconfig.build.json
@@ -27,6 +27,7 @@
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
     { "path": "../../../libs/usb-drive/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/bmd-ballot-fixtures/tsconfig.build.json" }
   ]
 }

--- a/apps/central-scan/frontend/tsconfig.json
+++ b/apps/central-scan/frontend/tsconfig.json
@@ -29,6 +29,8 @@
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
     { "path": "../../../libs/utils/tsconfig.build.json" },
-    { "path": "../backend/tsconfig.build.json" }
+    { "path": "../backend/tsconfig.build.json" },
+    { "path": "../../../libs/backend/tsconfig.build.json" },
+    { "path": "../../../libs/usb-drive/tsconfig.build.json" }
   ]
 }

--- a/apps/central-scan/integration-testing/tsconfig.json
+++ b/apps/central-scan/integration-testing/tsconfig.json
@@ -23,6 +23,10 @@
     { "path": "../../../libs/fixtures/tsconfig.build.json" },
     { "path": "../../../libs/grout/tsconfig.build.json" },
     { "path": "../../../libs/integration-test-utils/tsconfig.build.json" },
-    { "path": "../../../libs/types/tsconfig.build.json" }
+    { "path": "../../../libs/types/tsconfig.build.json" },
+    { "path": "../../../libs/backend/tsconfig.build.json" },
+    { "path": "../../../libs/basics/tsconfig.build.json" },
+    { "path": "../../../libs/dev-dock/backend/tsconfig.build.json" },
+    { "path": "../../../libs/usb-drive/tsconfig.build.json" }
   ]
 }

--- a/apps/design/backend/tsconfig.build.json
+++ b/apps/design/backend/tsconfig.build.json
@@ -24,6 +24,8 @@
     { "path": "../../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/logging/tsconfig.build.json" },
+    { "path": "../../../libs/fs/tsconfig.build.json" }
   ]
 }

--- a/apps/design/backend/tsconfig.json
+++ b/apps/design/backend/tsconfig.json
@@ -34,6 +34,7 @@
     { "path": "../../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/logging/tsconfig.build.json" }
   ]
 }

--- a/apps/design/frontend/tsconfig.json
+++ b/apps/design/frontend/tsconfig.json
@@ -25,6 +25,8 @@
     { "path": "../../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/monorepo-utils/tsconfig.build.json" },
+    { "path": "../../../libs/eslint-plugin-vx/tsconfig.build.json" }
   ]
 }

--- a/apps/mark-scan/backend/tsconfig.build.json
+++ b/apps/mark-scan/backend/tsconfig.build.json
@@ -28,6 +28,8 @@
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
     { "path": "../../../libs/usb-drive/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/fs/tsconfig.build.json" },
+    { "path": "../../../libs/message-coder/tsconfig.build.json" }
   ]
 }

--- a/apps/mark-scan/backend/tsconfig.json
+++ b/apps/mark-scan/backend/tsconfig.json
@@ -37,6 +37,8 @@
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
     { "path": "../../../libs/usb-drive/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/fs/tsconfig.build.json" },
+    { "path": "../../../libs/message-coder/tsconfig.build.json" }
   ]
 }

--- a/apps/mark-scan/frontend/tsconfig.json
+++ b/apps/mark-scan/frontend/tsconfig.json
@@ -30,6 +30,8 @@
     { "path": "../../../libs/grout/test-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/usb-drive/tsconfig.build.json" },
+    { "path": "../../../libs/backend/tsconfig.build.json" }
   ]
 }

--- a/apps/mark/backend/tsconfig.build.json
+++ b/apps/mark/backend/tsconfig.build.json
@@ -21,6 +21,12 @@
     { "path": "../../../libs/logging/tsconfig.build.json" },
     { "path": "../../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/hmpb/tsconfig.build.json" },
+    { "path": "../../../libs/image-utils/tsconfig.build.json" },
+    { "path": "../../../libs/printing/tsconfig.build.json" },
+    { "path": "../../../libs/test-decks/tsconfig.build.json" },
+    { "path": "../../../libs/ui/tsconfig.build.json" },
+    { "path": "../../../libs/usb-drive/tsconfig.build.json" }
   ]
 }

--- a/apps/mark/backend/tsconfig.json
+++ b/apps/mark/backend/tsconfig.json
@@ -31,6 +31,11 @@
     { "path": "../../../libs/logging/tsconfig.build.json" },
     { "path": "../../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/image-utils/tsconfig.build.json" },
+    { "path": "../../../libs/printing/tsconfig.build.json" },
+    { "path": "../../../libs/test-decks/tsconfig.build.json" },
+    { "path": "../../../libs/ui/tsconfig.build.json" },
+    { "path": "../../../libs/usb-drive/tsconfig.build.json" }
   ]
 }

--- a/apps/mark/frontend/tsconfig.json
+++ b/apps/mark/frontend/tsconfig.json
@@ -30,6 +30,8 @@
     { "path": "../../../libs/grout/test-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/usb-drive/tsconfig.build.json" },
+    { "path": "../../../libs/backend/tsconfig.build.json" }
   ]
 }

--- a/apps/mark/integration-testing/tsconfig.json
+++ b/apps/mark/integration-testing/tsconfig.json
@@ -23,6 +23,11 @@
     { "path": "../../../libs/fixtures/tsconfig.build.json" },
     { "path": "../../../libs/grout/tsconfig.build.json" },
     { "path": "../../../libs/integration-test-utils/tsconfig.build.json" },
-    { "path": "../../../libs/types/tsconfig.build.json" }
+    { "path": "../../../libs/types/tsconfig.build.json" },
+    { "path": "../../../libs/backend/tsconfig.build.json" },
+    { "path": "../../../libs/basics/tsconfig.build.json" },
+    { "path": "../../../libs/printing/tsconfig.build.json" },
+    { "path": "../../../libs/usb-drive/tsconfig.build.json" },
+    { "path": "../../../libs/utils/tsconfig.build.json" }
   ]
 }

--- a/apps/pollbook/backend/tsconfig.build.json
+++ b/apps/pollbook/backend/tsconfig.build.json
@@ -23,6 +23,10 @@
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
     { "path": "../../../libs/usb-drive/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/logging/tsconfig.build.json" },
+    { "path": "../../../libs/networking/tsconfig.build.json" },
+    { "path": "../../../libs/image-utils/tsconfig.build.json" },
+    { "path": "../../../libs/test-utils/tsconfig.build.json" }
   ]
 }

--- a/apps/pollbook/backend/tsconfig.json
+++ b/apps/pollbook/backend/tsconfig.json
@@ -32,6 +32,9 @@
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
     { "path": "../../../libs/usb-drive/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/logging/tsconfig.build.json" },
+    { "path": "../../../libs/image-utils/tsconfig.build.json" },
+    { "path": "../../../libs/test-utils/tsconfig.build.json" }
   ]
 }

--- a/apps/pollbook/frontend/tsconfig.json
+++ b/apps/pollbook/frontend/tsconfig.json
@@ -27,6 +27,10 @@
     { "path": "../../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/backend/tsconfig.build.json" },
+    { "path": "../../../libs/monorepo-utils/tsconfig.build.json" },
+    { "path": "../../../libs/usb-drive/tsconfig.build.json" },
+    { "path": "../../../libs/eslint-plugin-vx/tsconfig.build.json" }
   ]
 }

--- a/apps/print/backend/tsconfig.build.json
+++ b/apps/print/backend/tsconfig.build.json
@@ -20,9 +20,14 @@
     { "path": "../../../libs/fixtures/tsconfig.build.json" },
     { "path": "../../../libs/grout/tsconfig.build.json" },
     { "path": "../../../libs/printing/tsconfig.build.json" },
+    { "path": "../../../libs/test-decks/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
     { "path": "../../../libs/usb-drive/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/hmpb/tsconfig.build.json" },
+    { "path": "../../../libs/logging/tsconfig.build.json" },
+    { "path": "../../../libs/image-utils/tsconfig.build.json" },
+    { "path": "../../../libs/test-utils/tsconfig.build.json" }
   ]
 }

--- a/apps/print/backend/tsconfig.json
+++ b/apps/print/backend/tsconfig.json
@@ -28,9 +28,14 @@
     { "path": "../../../libs/fixtures/tsconfig.build.json" },
     { "path": "../../../libs/grout/tsconfig.build.json" },
     { "path": "../../../libs/printing/tsconfig.build.json" },
+    { "path": "../../../libs/test-decks/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
     { "path": "../../../libs/usb-drive/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/hmpb/tsconfig.build.json" },
+    { "path": "../../../libs/logging/tsconfig.build.json" },
+    { "path": "../../../libs/image-utils/tsconfig.build.json" },
+    { "path": "../../../libs/test-utils/tsconfig.build.json" }
   ]
 }

--- a/apps/print/frontend/tsconfig.json
+++ b/apps/print/frontend/tsconfig.json
@@ -27,6 +27,10 @@
     { "path": "../../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/usb-drive/tsconfig.build.json" },
+    { "path": "../../../libs/backend/tsconfig.build.json" },
+    { "path": "../../../libs/monorepo-utils/tsconfig.build.json" },
+    { "path": "../../../libs/eslint-plugin-vx/tsconfig.build.json" }
   ]
 }

--- a/apps/scan/backend/tsconfig.build.json
+++ b/apps/scan/backend/tsconfig.build.json
@@ -28,6 +28,8 @@
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
     { "path": "../../../libs/usb-drive/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/bmd-ballot-fixtures/tsconfig.build.json" },
+    { "path": "../../../libs/hmpb/tsconfig.build.json" }
   ]
 }

--- a/apps/scan/frontend/tsconfig.json
+++ b/apps/scan/frontend/tsconfig.json
@@ -31,6 +31,8 @@
     { "path": "../../../libs/types/tsconfig.build.json" },
     { "path": "../../../libs/ui/tsconfig.build.json" },
     { "path": "../../../libs/usb-drive/tsconfig.build.json" },
-    { "path": "../../../libs/utils/tsconfig.build.json" }
+    { "path": "../../../libs/utils/tsconfig.build.json" },
+    { "path": "../../../libs/backend/tsconfig.build.json" },
+    { "path": "../../../libs/printing/tsconfig.build.json" }
   ]
 }

--- a/apps/scan/integration-testing/tsconfig.json
+++ b/apps/scan/integration-testing/tsconfig.json
@@ -26,6 +26,8 @@
     { "path": "../../../libs/fujitsu-thermal-printer/tsconfig.build.json" },
     { "path": "../../../libs/integration-test-utils/tsconfig.build.json" },
     { "path": "../../../libs/types/tsconfig.build.json" },
-    { "path": "../../../libs/usb-drive/tsconfig.build.json" }
+    { "path": "../../../libs/usb-drive/tsconfig.build.json" },
+    { "path": "../../../libs/backend/tsconfig.build.json" },
+    { "path": "../../../libs/grout/tsconfig.build.json" }
   ]
 }

--- a/libs/backend/tsconfig.build.json
+++ b/libs/backend/tsconfig.build.json
@@ -19,6 +19,7 @@
     { "path": "../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../libs/types/tsconfig.build.json" },
     { "path": "../../libs/usb-drive/tsconfig.build.json" },
-    { "path": "../../libs/utils/tsconfig.build.json" }
+    { "path": "../../libs/utils/tsconfig.build.json" },
+    { "path": "../db/tsconfig.build.json" }
   ]
 }

--- a/libs/backend/tsconfig.json
+++ b/libs/backend/tsconfig.json
@@ -25,6 +25,7 @@
     { "path": "../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../libs/types/tsconfig.build.json" },
     { "path": "../../libs/usb-drive/tsconfig.build.json" },
-    { "path": "../../libs/utils/tsconfig.build.json" }
+    { "path": "../../libs/utils/tsconfig.build.json" },
+    { "path": "../db/tsconfig.build.json" }
   ]
 }

--- a/libs/ballot-interpreter/tsconfig.build.json
+++ b/libs/ballot-interpreter/tsconfig.build.json
@@ -19,6 +19,8 @@
     { "path": "../types/tsconfig.build.json" },
     { "path": "../test-utils/tsconfig.build.json" },
     { "path": "../ui/tsconfig.build.json" },
-    { "path": "../utils/tsconfig.build.json" }
+    { "path": "../utils/tsconfig.build.json" },
+    { "path": "../bmd-ballot-fixtures/tsconfig.build.json" },
+    { "path": "../fs/tsconfig.build.json" }
   ]
 }

--- a/libs/bmd-ballot-fixtures/tsconfig.build.json
+++ b/libs/bmd-ballot-fixtures/tsconfig.build.json
@@ -13,6 +13,10 @@
     { "path": "../image-utils/tsconfig.build.json" },
     { "path": "../printing/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },
-    { "path": "../ui/tsconfig.build.json" }
+    { "path": "../ui/tsconfig.build.json" },
+    { "path": "../basics/tsconfig.build.json" },
+    { "path": "../fs/tsconfig.build.json" },
+    { "path": "../test-utils/tsconfig.build.json" },
+    { "path": "../eslint-plugin-vx/tsconfig.build.json" }
   ]
 }

--- a/libs/bmd-ballot-fixtures/tsconfig.json
+++ b/libs/bmd-ballot-fixtures/tsconfig.json
@@ -17,6 +17,10 @@
     { "path": "../fixtures/tsconfig.build.json" },
     { "path": "../printing/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },
-    { "path": "../ui/tsconfig.build.json" }
+    { "path": "../ui/tsconfig.build.json" },
+    { "path": "../fs/tsconfig.build.json" },
+    { "path": "../image-utils/tsconfig.build.json" },
+    { "path": "../test-utils/tsconfig.build.json" },
+    { "path": "../eslint-plugin-vx/tsconfig.build.json" }
   ]
 }

--- a/libs/db/tsconfig.build.json
+++ b/libs/db/tsconfig.build.json
@@ -12,6 +12,7 @@
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../logging/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
-    { "path": "../utils/tsconfig.build.json" }
+    { "path": "../utils/tsconfig.build.json" },
+    { "path": "../fixtures/tsconfig.build.json" }
   ]
 }

--- a/libs/db/tsconfig.json
+++ b/libs/db/tsconfig.json
@@ -13,6 +13,8 @@
   "references": [
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
-    { "path": "../utils/tsconfig.build.json" }
+    { "path": "../utils/tsconfig.build.json" },
+    { "path": "../logging/tsconfig.build.json" },
+    { "path": "../fixtures/tsconfig.build.json" }
   ]
 }

--- a/libs/dev-dock/backend/tsconfig.build.json
+++ b/libs/dev-dock/backend/tsconfig.build.json
@@ -23,6 +23,8 @@
     { "path": "../../test-utils/tsconfig.build.json" },
     { "path": "../../types/tsconfig.build.json" },
     { "path": "../../usb-drive/tsconfig.build.json" },
-    { "path": "../../utils/tsconfig.build.json" }
+    { "path": "../../utils/tsconfig.build.json" },
+    { "path": "../../backend/tsconfig.build.json" },
+    { "path": "../../hmpb/tsconfig.build.json" }
   ]
 }

--- a/libs/dev-dock/backend/tsconfig.json
+++ b/libs/dev-dock/backend/tsconfig.json
@@ -24,6 +24,8 @@
     { "path": "../../test-utils/tsconfig.build.json" },
     { "path": "../../types/tsconfig.build.json" },
     { "path": "../../usb-drive/tsconfig.build.json" },
-    { "path": "../../utils/tsconfig.build.json" }
+    { "path": "../../utils/tsconfig.build.json" },
+    { "path": "../../backend/tsconfig.build.json" },
+    { "path": "../../hmpb/tsconfig.build.json" }
   ]
 }

--- a/libs/fixture-generators/tsconfig.build.json
+++ b/libs/fixture-generators/tsconfig.build.json
@@ -17,6 +17,8 @@
     { "path": "../image-utils/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },
     { "path": "../utils/tsconfig.build.json" },
-    { "path": "../backend/tsconfig.build.json" }
+    { "path": "../backend/tsconfig.build.json" },
+    { "path": "../hmpb/tsconfig.build.json" },
+    { "path": "../test-utils/tsconfig.build.json" }
   ]
 }

--- a/libs/fixture-generators/tsconfig.json
+++ b/libs/fixture-generators/tsconfig.json
@@ -20,6 +20,7 @@
     { "path": "../types/tsconfig.build.json" },
     { "path": "../utils/tsconfig.build.json" },
     { "path": "../hmpb/tsconfig.build.json" },
-    { "path": "../backend/tsconfig.build.json" }
+    { "path": "../backend/tsconfig.build.json" },
+    { "path": "../test-utils/tsconfig.build.json" }
   ]
 }

--- a/libs/fs/tsconfig.build.json
+++ b/libs/fs/tsconfig.build.json
@@ -15,6 +15,7 @@
     { "path": "../../libs/logging/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../libs/types/tsconfig.build.json" },
-    { "path": "../../libs/utils/tsconfig.build.json" }
+    { "path": "../../libs/utils/tsconfig.build.json" },
+    { "path": "../grout/tsconfig.build.json" }
   ]
 }

--- a/libs/fs/tsconfig.json
+++ b/libs/fs/tsconfig.json
@@ -21,6 +21,7 @@
     { "path": "../../libs/logging/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../libs/types/tsconfig.build.json" },
-    { "path": "../../libs/utils/tsconfig.build.json" }
+    { "path": "../../libs/utils/tsconfig.build.json" },
+    { "path": "../grout/tsconfig.build.json" }
   ]
 }

--- a/libs/fujitsu-thermal-printer/tsconfig.json
+++ b/libs/fujitsu-thermal-printer/tsconfig.json
@@ -21,6 +21,7 @@
     { "path": "../../libs/image-utils/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },
     { "path": "../../libs/types/tsconfig.build.json" },
-    { "path": "../../libs/utils/tsconfig.build.json" }
+    { "path": "../../libs/utils/tsconfig.build.json" },
+    { "path": "../logging/tsconfig.build.json" }
   ]
 }

--- a/libs/hmpb/tsconfig.build.json
+++ b/libs/hmpb/tsconfig.build.json
@@ -17,6 +17,9 @@
     { "path": "../image-utils/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },
     { "path": "../ui/tsconfig.build.json" },
-    { "path": "../utils/tsconfig.build.json" }
+    { "path": "../utils/tsconfig.build.json" },
+    { "path": "../fs/tsconfig.build.json" },
+    { "path": "../monorepo-utils/tsconfig.build.json" },
+    { "path": "../test-utils/tsconfig.build.json" }
   ]
 }

--- a/libs/hmpb/tsconfig.json
+++ b/libs/hmpb/tsconfig.json
@@ -26,6 +26,8 @@
     { "path": "../image-utils/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },
     { "path": "../ui/tsconfig.build.json" },
-    { "path": "../utils/tsconfig.build.json" }
+    { "path": "../utils/tsconfig.build.json" },
+    { "path": "../monorepo-utils/tsconfig.build.json" },
+    { "path": "../test-utils/tsconfig.build.json" }
   ]
 }

--- a/libs/integration-test-utils/tsconfig.build.json
+++ b/libs/integration-test-utils/tsconfig.build.json
@@ -17,6 +17,9 @@
     { "path": "../hmpb/tsconfig.build.json" },
     { "path": "../image-utils/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },
-    { "path": "../usb-drive/tsconfig.build.json" }
+    { "path": "../usb-drive/tsconfig.build.json" },
+    { "path": "../backend/tsconfig.build.json" },
+    { "path": "../ballot-interpreter/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" }
   ]
 }

--- a/libs/integration-test-utils/tsconfig.json
+++ b/libs/integration-test-utils/tsconfig.json
@@ -20,6 +20,9 @@
     { "path": "../hmpb/tsconfig.build.json" },
     { "path": "../image-utils/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },
-    { "path": "../usb-drive/tsconfig.build.json" }
+    { "path": "../usb-drive/tsconfig.build.json" },
+    { "path": "../backend/tsconfig.build.json" },
+    { "path": "../ballot-interpreter/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" }
   ]
 }

--- a/libs/logging-utils/tsconfig.json
+++ b/libs/logging-utils/tsconfig.json
@@ -19,6 +19,7 @@
     { "path": "../../libs/fixtures/tsconfig.build.json" },
     { "path": "../../libs/logging/tsconfig.build.json" },
     { "path": "../../libs/test-utils/tsconfig.build.json" },
-    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" }
+    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" }
   ]
 }

--- a/libs/networking/tsconfig.build.json
+++ b/libs/networking/tsconfig.build.json
@@ -12,7 +12,7 @@
   "references": [
     { "path": "../../libs/backend/tsconfig.build.json" },
     { "path": "../../libs/basics/tsconfig.build.json" },
-    { "path": "../../libs/types/tsconfig.build.json" },
-    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" }
+    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../test-utils/tsconfig.build.json" }
   ]
 }

--- a/libs/networking/tsconfig.json
+++ b/libs/networking/tsconfig.json
@@ -14,6 +14,7 @@
   "references": [
     { "path": "../../libs/backend/tsconfig.build.json" },
     { "path": "../../libs/basics/tsconfig.build.json" },
-    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" }
+    { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../test-utils/tsconfig.build.json" }
   ]
 }

--- a/libs/pdi-scanner/tsconfig.build.json
+++ b/libs/pdi-scanner/tsconfig.build.json
@@ -12,6 +12,7 @@
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../image-utils/tsconfig.build.json" },
-    { "path": "../types/tsconfig.build.json" }
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../test-utils/tsconfig.build.json" }
   ]
 }

--- a/libs/test-decks/tsconfig.build.json
+++ b/libs/test-decks/tsconfig.build.json
@@ -18,6 +18,7 @@
     { "path": "../printing/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },
     { "path": "../ui/tsconfig.build.json" },
-    { "path": "../utils/tsconfig.build.json" }
+    { "path": "../utils/tsconfig.build.json" },
+    { "path": "../test-utils/tsconfig.build.json" }
   ]
 }

--- a/libs/ui/tsconfig.build.json
+++ b/libs/ui/tsconfig.build.json
@@ -27,6 +27,7 @@
     { "path": "../test-utils/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },
     { "path": "../utils/tsconfig.build.json" },
-    { "path": "../usb-drive/tsconfig.build.json" }
+    { "path": "../usb-drive/tsconfig.build.json" },
+    { "path": "../image-utils/tsconfig.build.json" }
   ]
 }

--- a/libs/ui/tsconfig.json
+++ b/libs/ui/tsconfig.json
@@ -27,6 +27,7 @@
     { "path": "../test-utils/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },
     { "path": "../utils/tsconfig.build.json" },
-    { "path": "../usb-drive/tsconfig.build.json" }
+    { "path": "../usb-drive/tsconfig.build.json" },
+    { "path": "../image-utils/tsconfig.build.json" }
   ]
 }

--- a/libs/usb-drive/tsconfig.build.json
+++ b/libs/usb-drive/tsconfig.build.json
@@ -14,6 +14,8 @@
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fs/tsconfig.build.json" },
     { "path": "../logging/tsconfig.build.json" },
-    { "path": "../test-utils/tsconfig.build.json" }
+    { "path": "../test-utils/tsconfig.build.json" },
+    { "path": "../fixtures/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" }
   ]
 }

--- a/libs/usb-drive/tsconfig.json
+++ b/libs/usb-drive/tsconfig.json
@@ -15,6 +15,8 @@
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fs/tsconfig.build.json" },
     { "path": "../logging/tsconfig.build.json" },
-    { "path": "../test-utils/tsconfig.build.json" }
+    { "path": "../test-utils/tsconfig.build.json" },
+    { "path": "../fixtures/tsconfig.build.json" },
+    { "path": "../utils/tsconfig.build.json" }
   ]
 }

--- a/script/src/validate-monorepo/validation/tsconfig.ts
+++ b/script/src/validate-monorepo/validation/tsconfig.ts
@@ -244,7 +244,11 @@ export async function* checkConfig(
       continue;
     }
 
-    if (!packageJson.devDependencies?.['typescript']) {
+    // The monorepo migrated to a root-level `@typescript/native` compiler, so
+    // individual packages no longer declare a `typescript` devDependency. Gate on
+    // the presence of a tsconfig.json instead — a robust signal that a package
+    // uses TypeScript, independent of how the compiler is provided.
+    if (!ts.sys.fileExists(join(pkg.path, 'tsconfig.json'))) {
       continue;
     }
 


### PR DESCRIPTION
## Overview

validate-monorepo was silently skipping ~71/73 packages: its gate required a literal `typescript` devDependency, which the TypeScript 7 migration removed (the compiler is now a root-level `@typescript/native`). This gates on `tsconfig.json` presence instead, then adds the missing project references that the now-working check surfaces (workspace deps present in `package.json` but absent from tsconfig `references`).

## Testing Plan

`./script/validate-monorepo` passes (0 issues).

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)