### PR TITLE
VxDesign: Ensure that polling place precinct order is stable across saves/exports

### DIFF
--- a/apps/design/backend/src/app.polling_places.test.ts
+++ b/apps/design/backend/src/app.polling_places.test.ts
@@ -121,8 +121,8 @@ test('polling places CRUD', async () => {
   ).toEqual(ok());
 
   expect(await apiClient.listPollingPlaces({ electionId })).toEqual([
-    updatedPlace1,
     place1EarlyVoting,
+    updatedPlace1,
   ]);
 
   // Add new place, get updated list:
@@ -148,10 +148,10 @@ test('polling places CRUD', async () => {
   ).toEqual(ok());
 
   expect(await apiClient.listPollingPlaces({ electionId })).toEqual([
-    updatedPlace1,
-    place1EarlyVoting,
     place2,
+    place1EarlyVoting,
     place3,
+    updatedPlace1,
   ]);
 
   // Delete existing place, get updated list:
@@ -160,11 +160,86 @@ test('polling places CRUD', async () => {
   await apiClient.deletePollingPlace({ electionId, id: place2.id }); // no-op
 
   expect(await apiClient.listPollingPlaces({ electionId })).toEqual([
-    updatedPlace1,
     place1EarlyVoting,
     place3,
+    updatedPlace1,
   ]);
 }, 20_000);
+
+test('polling place precinct order is stable regardless of save order - necessary for guaranteeing a consistent ballot hash', async () => {
+  const user = nonVxUser;
+  const jurisdiction = user.jurisdictions[0];
+
+  const { apiClient, auth0 } = await setupApp({
+    organizations,
+    jurisdictions,
+    users: [user],
+  });
+  auth0.setLoggedInUser(user);
+
+  const electionId = (
+    await apiClient.createElection({
+      jurisdictionId: jurisdiction.id,
+      id: 'election1',
+    })
+  ).unsafeUnwrap();
+
+  const precincts: Precinct[] = [
+    { id: 'precinct1', name: 'Precinct 1', districtIds: [] },
+    { id: 'precinct2', name: 'Precinct 2', districtIds: [] },
+    { id: 'precinct3', name: 'Precinct 3', districtIds: [] },
+  ];
+  for (const newPrecinct of precincts) {
+    (
+      await apiClient.createPrecinct({ electionId, newPrecinct })
+    ).unsafeUnwrap();
+  }
+
+  const place: PollingPlace = {
+    id: 'place1',
+    name: 'Place 1',
+    precincts: {
+      precinct1: { type: 'whole' },
+      precinct2: { type: 'whole' },
+      precinct3: { type: 'whole' },
+    },
+    type: 'election_day',
+  };
+  (await apiClient.setPollingPlace({ electionId, place })).unsafeUnwrap();
+
+  async function savedPrecinctIds() {
+    const [savedPlace] = await apiClient.listPollingPlaces({ electionId });
+    return Object.keys(savedPlace.precincts);
+  }
+
+  expect(await savedPrecinctIds()).toEqual([
+    'precinct1',
+    'precinct2',
+    'precinct3',
+  ]);
+
+  // Unchecking and re-checking a precinct in the UI might move it to the end
+  // of the list, so the same set of precincts gets saved in a different order.
+  (
+    await apiClient.setPollingPlace({
+      electionId,
+      place: {
+        ...place,
+        precincts: {
+          precinct2: { type: 'whole' },
+          precinct3: { type: 'whole' },
+          precinct1: { type: 'whole' },
+        },
+      },
+    })
+  ).unsafeUnwrap();
+
+  expect(await savedPrecinctIds()).toEqual([
+    'precinct1',
+    'precinct2',
+    'precinct3',
+  ]);
+});
 
 test('polling place updates on precinct creation/update/deletion', async () => {
   const user = nonVxUser;
@@ -370,17 +445,17 @@ describe('loadElection', () => {
       });
       expect(await api.listPollingPlaces({ electionId })).toEqual([
         {
-          ...place1,
-          id: expect.not.stringMatching(place1.id),
-          precincts: { [precinctCopy1.id]: { type: 'whole' } },
-        },
-        {
           ...place2,
           id: expect.not.stringMatching(place2.id),
           precincts: {
             [precinctCopy1.id]: { type: 'whole' },
             [precinctCopy2.id]: { type: 'whole' },
           },
+        },
+        {
+          ...place1,
+          id: expect.not.stringMatching(place1.id),
+          precincts: { [precinctCopy1.id]: { type: 'whole' } },
         },
       ]);
     });
@@ -509,17 +584,17 @@ describe('cloneElection', () => {
         await api.listPollingPlaces({ electionId: clonedElectionId })
       ).toEqual([
         {
-          ...place1,
-          id: expect.not.stringMatching(place1.id),
-          precincts: { [precinctCopy1.id]: { type: 'whole' } },
-        },
-        {
           ...place2,
           id: expect.not.stringMatching(place2.id),
           precincts: {
             [precinctCopy1.id]: { type: 'whole' },
             [precinctCopy2.id]: { type: 'whole' },
           },
+        },
+        {
+          ...place1,
+          id: expect.not.stringMatching(place1.id),
+          precincts: { [precinctCopy1.id]: { type: 'whole' } },
         },
       ]);
     });

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -3526,7 +3526,7 @@ export class Store {
           select
             id,
             name,
-            array_remove(array_agg(precinct_id), NULL) as "precinct_ids",
+            array_remove(array_agg(precinct_id order by precinct_id), NULL) as "precinct_ids",
             type
           from polling_places
           left join polling_places_precincts as precincts on
@@ -3534,7 +3534,7 @@ export class Store {
           where
             election_id = $1
           group by id
-          order by name collate natural_sort
+          order by type, name collate natural_sort
       `,
         electionId
       )) as {


### PR DESCRIPTION
## Overview

Part of https://github.com/votingworks/vxsuite/issues/8986

I recently encountered a situation where I exported an election package, unfinalized to adjust system settings without changing the actual election definition, and re-exported, but the ballot hash changed. The order of precincts within polling places varied across the two exports.

This PR ensures that polling place precinct order is stable across saves/exports. It also ensures that polling place order is stable when polling places have the same name but different types. Together, these updates ensure a consistent ballot hash across saves/exports that don't actually change the fundamental contents of the election.

## Testing Plan

- [x] Added automated tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [ ] ~I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~
