### PR TITLE
VxPrint: prevent testmode and test deck printing when no test ballots

### DIFF
--- a/apps/mark/backend/src/store.ts
+++ b/apps/mark/backend/src/store.ts
@@ -448,13 +448,14 @@ export class Store {
   }
 
   /**
-   * Whether any test-mode ballot PDFs were included in the election package.
+   * Whether any test ballot PDFs are present in the election package.
    */
   hasTestBallots(): boolean {
-    const row = this.client.one(
-      `select 1 as present from ballots where ballot_mode = 'test' limit 1`
-    ) as { present: number } | undefined;
-    return row !== undefined;
+    return (
+      this.client.one(
+        `select 1 from ballots where ballot_mode = 'test' limit 1`
+      ) !== undefined
+    );
   }
 
   /**

--- a/apps/print/backend/src/app.ballots_printed_report.test.ts
+++ b/apps/print/backend/src/app.ballots_printed_report.test.ts
@@ -77,7 +77,7 @@ vi.mock(import('@votingworks/types'), async (importActual) => {
 beforeAll(async () => {
   ballots = await buildBallotsForElection({
     electionDefinition,
-    ballotModes: ['official'],
+    ballotModes: ['official', 'test'],
   });
 });
 

--- a/apps/print/backend/src/app.test.ts
+++ b/apps/print/backend/src/app.test.ts
@@ -392,7 +392,7 @@ test('mode toggling', async () => {
     electionFamousNames2021Fixtures.readElectionDefinition();
   const ballots = await buildBallotsForElection({
     electionDefinition,
-    ballotModes: ['official'],
+    ballotModes: ['official', 'test'],
   });
   await configureMachine({
     electionDefinition,
@@ -403,11 +403,12 @@ test('mode toggling', async () => {
   });
 
   expect(await apiClient.getTestMode()).toEqual(false);
+  expect(await apiClient.hasTestBallots()).toEqual(true);
 
   await apiClient.setTestMode({ testMode: true });
   expect(await apiClient.getTestMode()).toEqual(true);
-  expect(await apiClient.getBallots({})).toHaveLength(0);
-  expect(await apiClient.getBallotPrintCounts()).toHaveLength(0);
+  expect(await apiClient.getBallots({})).not.toHaveLength(0);
+  expect(await apiClient.getBallotPrintCounts()).not.toHaveLength(0);
   expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
     LogEventId.ToggledTestMode,
     expect.objectContaining({ disposition: 'success' })
@@ -421,6 +422,46 @@ test('mode toggling', async () => {
   );
 });
 
+test('cannot switch to test mode when the election package has no test ballots', async () => {
+  const electionDefinition =
+    electionFamousNames2021Fixtures.readElectionDefinition();
+  const ballots = await buildBallotsForElection({
+    electionDefinition,
+    ballotModes: ['official'],
+  });
+  await configureMachine({
+    electionDefinition,
+    ballots,
+    apiClient,
+    auth,
+    mockUsbDrive,
+  });
+
+  expect(await apiClient.hasTestBallots()).toEqual(false);
+  expect(await apiClient.getTestMode()).toEqual(false);
+
+  mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
+  await apiClient.printBallot({
+    precinctId: electionDefinition.election.ballotStyles[0].precincts[0],
+    languageCode: LanguageCode.ENGLISH,
+    ballotType: BallotType.Precinct,
+    copies: 1,
+  });
+  const printCounts = await apiClient.getBallotPrintCounts();
+  expect(printCounts.some((count) => count.totalCount > 0)).toEqual(true);
+
+  await expect(apiClient.setTestMode({ testMode: true })).rejects.toThrow(
+    'Cannot switch to test ballot mode: the election package does not contain test ballots.'
+  );
+  expect(await apiClient.getTestMode()).toEqual(false);
+  // The rejected switch must not have reset the print counts.
+  expect(await apiClient.getBallotPrintCounts()).toEqual(printCounts);
+
+  // Switching to official mode is always allowed.
+  await apiClient.setTestMode({ testMode: false });
+  expect(await apiClient.getTestMode()).toEqual(false);
+});
+
 test('unconfigureMachine clears election configuration', async () => {
   // Test with a cdf election for coverage
   const electionDefinition = safeParseElectionDefinition(
@@ -428,7 +469,7 @@ test('unconfigureMachine clears election configuration', async () => {
   ).unsafeUnwrap();
   const ballots = await buildBallotsForElection({
     electionDefinition,
-    ballotModes: ['official'],
+    ballotModes: ['official', 'test'],
   });
   await configureMachine({
     electionDefinition,
@@ -457,45 +498,6 @@ test('unconfigureMachine clears election configuration', async () => {
     LogEventId.ElectionUnconfigured,
     expect.anything(),
     expect.objectContaining({ disposition: 'success' })
-  );
-});
-
-test('printBallot logs when ballot is not found', async () => {
-  const {
-    famousNamesMultiLangElectionDefinition: electionDefinition,
-    famousNamesMultiLangOfficialBallots,
-  } = sharedFixtures;
-
-  // Only configure official ballots so that printing in test mode will result in ballot not found
-  await configureMachine({
-    electionDefinition,
-    ballots: famousNamesMultiLangOfficialBallots,
-    apiClient,
-    auth,
-    mockUsbDrive,
-    pollingPlaceId: anyPollingPlace(electionDefinition.election).id,
-  });
-
-  mockPrinterHandler.connectPrinter(HP_LASER_PRINTER_CONFIG);
-
-  await apiClient.setTestMode({ testMode: true });
-
-  const precinctId = electionDefinition.election.precincts[0].id;
-
-  // Try to print a ballot - the precinct exists but no test mode ballot is stored
-  await apiClient.printBallot({
-    precinctId,
-    languageCode: LanguageCode.ENGLISH,
-    ballotType: BallotType.Precinct,
-    copies: 1,
-  });
-
-  expect(logger.logAsCurrentRole).toHaveBeenLastCalledWith(
-    LogEventId.PrinterPrintRequest,
-    expect.objectContaining({
-      disposition: 'failure',
-      message: 'No ballot found',
-    })
   );
 });
 

--- a/apps/print/backend/src/app.ts
+++ b/apps/print/backend/src/app.ts
@@ -261,8 +261,23 @@ export function buildApi(ctx: AppContext) {
       return store.getTestMode();
     },
 
+    /**
+     * Whether the election package contains test mode ballot PDFs. Every ballot
+     * VxPrint prints (including test decks, which are always test mode) comes
+     * from a pre-rendered PDF in the election package, so without test ballots
+     * neither test ballot mode nor test deck printing are possible.
+     */
+    hasTestBallots(): boolean {
+      return store.hasTestBallots();
+    },
+
     async setTestMode(input: { testMode: boolean }): Promise<void> {
       const { testMode } = input;
+      // Frontend should prevent this but we assert as a failsafe
+      assert(
+        !testMode || store.hasTestBallots(),
+        'Cannot switch to test ballot mode: the election package does not contain test ballots.'
+      );
       await logger.logAsCurrentRole(LogEventId.TogglingTestMode, {
         message: `Toggling to ${testMode ? 'Test' : 'Official'} Ballot Mode...`,
       });
@@ -372,27 +387,14 @@ export function buildApi(ctx: AppContext) {
       const isTestMode = store.getTestMode();
       const ballotMode = isTestMode ? 'test' : 'official';
 
-      const ballot = store.getBallot({
-        ballotStyleId,
-        precinctId: input.precinctId,
-        ballotType: input.ballotType,
-        ballotMode,
-      });
-      if (!ballot) {
-        await logger.logAsCurrentRole(LogEventId.PrinterPrintRequest, {
-          message: 'No ballot found',
-          ballotProps: JSON.stringify({
-            precinctId: input.precinctId,
-            splitId: input.splitId,
-            partyId: input.partyId,
-            languageCode: input.languageCode,
-            ballotType: input.ballotType,
-            ballotMode,
-          }),
-          disposition: 'failure',
-        });
-        return;
-      }
+      const ballot = assertDefined(
+        store.getBallot({
+          ballotStyleId,
+          precinctId: input.precinctId,
+          ballotType: input.ballotType,
+          ballotMode,
+        })
+      );
 
       await printBallots(electionDefinition, {
         data: Buffer.from(ballot.encodedBallot, 'base64'),

--- a/apps/print/backend/src/store.test.ts
+++ b/apps/print/backend/src/store.test.ts
@@ -1,4 +1,5 @@
 import { test, expect } from 'vitest';
+import { Buffer } from 'node:buffer';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import { BallotType, LanguageCode } from '@votingworks/types';
 import { Store } from './store';
@@ -56,4 +57,34 @@ test('unconfigured machine early returns or errors for relevant API calls', () =
       precinctId: 'precinct-1',
     })
   ).toBeNull();
+
+  expect(store.hasTestBallots()).toEqual(false);
+});
+
+test('hasTestBallots', () => {
+  const store = Store.memoryStore();
+
+  expect(store.hasTestBallots()).toEqual(false);
+
+  store.setBallots([
+    {
+      ballotStyleId: '1M',
+      precinctId: 'precinct-1',
+      ballotType: BallotType.Precinct,
+      ballotMode: 'official',
+      encodedBallot: Buffer.from('official-pdf').toString('base64'),
+    },
+  ]);
+  expect(store.hasTestBallots()).toEqual(false);
+
+  store.setBallots([
+    {
+      ballotStyleId: '1M',
+      precinctId: 'precinct-1',
+      ballotType: BallotType.Precinct,
+      ballotMode: 'test',
+      encodedBallot: Buffer.from('test-pdf').toString('base64'),
+    },
+  ]);
+  expect(store.hasTestBallots()).toEqual(true);
 });

--- a/apps/print/backend/src/store.ts
+++ b/apps/print/backend/src/store.ts
@@ -392,6 +392,17 @@ export class Store {
     ) || null) as BallotPrintEntry | null;
   }
 
+  /**
+   * Whether any test ballot PDFs are present in the election package.
+   */
+  hasTestBallots(): boolean {
+    return (
+      this.client.one(
+        `select 1 from ballots where ballot_mode = 'test' limit 1`
+      ) !== undefined
+    );
+  }
+
   getDistinctBallotStylesCount({
     ballotMode,
     ballotType,

--- a/apps/print/frontend/src/api.ts
+++ b/apps/print/frontend/src/api.ts
@@ -98,6 +98,16 @@ export const getSystemSettings = {
   },
 } as const;
 
+export const hasTestBallots = {
+  queryKey(): QueryKey {
+    return ['hasTestBallots'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () => apiClient.hasTestBallots());
+  },
+} as const;
+
 export const configureElectionPackageFromUsb = {
   useMutation() {
     const apiClient = useApiClient();
@@ -106,6 +116,7 @@ export const configureElectionPackageFromUsb = {
       async onSuccess() {
         await queryClient.invalidateQueries(getElectionRecord.queryKey());
         await queryClient.invalidateQueries(getSystemSettings.queryKey());
+        await queryClient.invalidateQueries(hasTestBallots.queryKey());
       },
     });
   },

--- a/apps/print/frontend/src/components/toggle_test_mode_button.test.tsx
+++ b/apps/print/frontend/src/components/toggle_test_mode_button.test.tsx
@@ -29,7 +29,6 @@ function mockQueries({
   testBallotsPresent = true,
   totalPrintCount = 0,
 } = {}) {
-  // The setTestMode mutation invalidates these queries, so they may refetch.
   apiMock.getTestMode.expectRepeatedCallsWith().resolves(isTestMode);
   apiMock.hasTestBallots.expectRepeatedCallsWith().resolves(testBallotsPresent);
   apiMock.getBallotPrintCounts.expectRepeatedCallsWith().resolves(
@@ -105,7 +104,6 @@ test('Cancel closes the confirmation without toggling', async () => {
   userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
   expect(screen.queryByText(confirmPrompt)).not.toBeInTheDocument();
-  // The absence of a setTestMode call is verified by assertComplete().
 });
 
 test('disables the toggle and explains why when the election package has no test ballots', async () => {

--- a/apps/print/frontend/src/components/toggle_test_mode_button.test.tsx
+++ b/apps/print/frontend/src/components/toggle_test_mode_button.test.tsx
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { LanguageCode } from '@votingworks/types';
+import { render, screen } from '../../test/react_testing_library';
+import {
+  ApiMock,
+  ApiMockProvider,
+  createApiMock,
+} from '../../test/mock_api_client';
+import { ToggleTestModeButton } from './toggle_test_mode_button';
+
+const NO_TEST_BALLOTS_MESSAGE =
+  'Election package does not contain test ballots required for test mode.';
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  apiMock = createApiMock();
+});
+
+afterEach(() => {
+  apiMock.assertComplete();
+  vi.useRealTimers();
+});
+
+function mockQueries({
+  isTestMode = false,
+  testBallotsPresent = true,
+  totalPrintCount = 0,
+} = {}) {
+  // The setTestMode mutation invalidates these queries, so they may refetch.
+  apiMock.getTestMode.expectRepeatedCallsWith().resolves(isTestMode);
+  apiMock.hasTestBallots.expectRepeatedCallsWith().resolves(testBallotsPresent);
+  apiMock.getBallotPrintCounts.expectRepeatedCallsWith().resolves(
+    totalPrintCount > 0
+      ? [
+          {
+            ballotStyleId: '1-1',
+            precinctId: '20',
+            precinctOrSplitName: 'Precinct 20',
+            languageCode: LanguageCode.ENGLISH,
+            absenteeCount: 0,
+            precinctCount: totalPrintCount,
+            totalCount: totalPrintCount,
+          },
+        ]
+      : []
+  );
+}
+
+function renderButton() {
+  return render(
+    <ApiMockProvider apiMock={apiMock}>
+      <ToggleTestModeButton />
+    </ApiMockProvider>
+  );
+}
+
+function getOption(name: string) {
+  return screen.getByRole('option', { name });
+}
+
+test('toggles to test mode without confirmation when nothing has been printed', async () => {
+  mockQueries();
+  renderButton();
+
+  await vi.waitFor(() => expect(getOption('Test Ballot Mode')).toBeEnabled());
+
+  apiMock.setTestMode.expectCallWith({ testMode: true }).resolves();
+  userEvent.click(getOption('Test Ballot Mode'));
+
+  await vi.waitFor(() => apiMock.setTestMode.assertComplete());
+});
+
+test('confirms before toggling when ballots have been printed', async () => {
+  mockQueries({ totalPrintCount: 3 });
+  renderButton();
+
+  await vi.waitFor(() => expect(getOption('Test Ballot Mode')).toBeEnabled());
+  userEvent.click(getOption('Test Ballot Mode'));
+
+  await screen.findByText(
+    'Switching to test ballot mode will reset all official ballot print counts to zero.'
+  );
+
+  apiMock.setTestMode.expectCallWith({ testMode: true }).resolves();
+  userEvent.click(
+    screen.getByRole('button', { name: 'Switch to Test Ballot Mode' })
+  );
+
+  await vi.waitFor(() => apiMock.setTestMode.assertComplete());
+});
+
+test('Cancel closes the confirmation without toggling', async () => {
+  mockQueries({ totalPrintCount: 3 });
+  renderButton();
+
+  await vi.waitFor(() => expect(getOption('Test Ballot Mode')).toBeEnabled());
+  userEvent.click(getOption('Test Ballot Mode'));
+
+  const confirmPrompt =
+    'Switching to test ballot mode will reset all official ballot print counts to zero.';
+  await screen.findByText(confirmPrompt);
+  userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+  expect(screen.queryByText(confirmPrompt)).not.toBeInTheDocument();
+  // The absence of a setTestMode call is verified by assertComplete().
+});
+
+test('disables the toggle and explains why when the election package has no test ballots', async () => {
+  mockQueries({ testBallotsPresent: false });
+  renderButton();
+
+  await screen.findByText(NO_TEST_BALLOTS_MESSAGE);
+  const testOption = getOption('Test Ballot Mode');
+  expect(testOption).toBeDisabled();
+  expect(getOption('Official Ballot Mode')).toBeDisabled();
+
+  // Clicking the disabled option must not switch modes. The absence of an
+  // expected setTestMode mutation is verified by assertComplete().
+  userEvent.click(testOption);
+});

--- a/apps/print/frontend/src/components/toggle_test_mode_button.tsx
+++ b/apps/print/frontend/src/components/toggle_test_mode_button.tsx
@@ -1,6 +1,11 @@
-import { Button, Modal, P, SegmentedButton } from '@votingworks/ui';
+import { Button, Icons, Modal, P, SegmentedButton } from '@votingworks/ui';
 import React, { useState } from 'react';
-import { getTestMode, setTestMode, getBallotPrintCounts } from '../api';
+import {
+  getTestMode,
+  setTestMode,
+  getBallotPrintCounts,
+  hasTestBallots,
+} from '../api';
 
 /**
  * Presents a button to toggle between test & official modes with a confirmation.
@@ -8,6 +13,7 @@ import { getTestMode, setTestMode, getBallotPrintCounts } from '../api';
 export function ToggleTestModeButton(): JSX.Element | null {
   const testModeQuery = getTestMode.useQuery();
   const ballotPrintCountsQuery = getBallotPrintCounts.useQuery();
+  const hasTestBallotsQuery = hasTestBallots.useQuery();
   const setTestModeMutation = setTestMode.useMutation();
 
   const [flowState, setFlowState] = useState<'none' | 'confirmation'>('none');
@@ -15,8 +21,10 @@ export function ToggleTestModeButton(): JSX.Element | null {
   const disabled =
     testModeQuery.isLoading ||
     ballotPrintCountsQuery.isLoading ||
+    hasTestBallotsQuery.isLoading ||
     setTestModeMutation.isLoading;
   const isTestMode = testModeQuery.data ?? false;
+  const isTestModeAvailable = hasTestBallotsQuery.data ?? false;
 
   function toggleTestMode() {
     setTestModeMutation.mutate(
@@ -37,23 +45,31 @@ export function ToggleTestModeButton(): JSX.Element | null {
 
   return (
     <React.Fragment>
-      <SegmentedButton
-        disabled={setTestModeMutation.isLoading}
-        label="Ballot Mode"
-        hideLabel
-        onChange={() => {
-          if (totalPrintCount > 0) {
-            setFlowState('confirmation');
-          } else {
-            toggleTestMode();
-          }
-        }}
-        options={[
-          { id: 'test', label: 'Test Ballot Mode' },
-          { id: 'official', label: 'Official Ballot Mode' },
-        ]}
-        selectedOptionId={isTestMode ? 'test' : 'official'}
-      />
+      <P>
+        <SegmentedButton
+          disabled={disabled || !isTestModeAvailable}
+          label="Ballot Mode"
+          hideLabel
+          onChange={() => {
+            if (totalPrintCount > 0) {
+              setFlowState('confirmation');
+            } else {
+              toggleTestMode();
+            }
+          }}
+          options={[
+            { id: 'test', label: 'Test Ballot Mode' },
+            { id: 'official', label: 'Official Ballot Mode' },
+          ]}
+          selectedOptionId={isTestMode ? 'test' : 'official'}
+        />
+      </P>
+      {hasTestBallotsQuery.isSuccess && !isTestModeAvailable && (
+        <P>
+          <Icons.Info /> Election package does not contain test ballots required
+          for test mode.
+        </P>
+      )}
       {flowState === 'confirmation' && (
         <Modal
           title={

--- a/apps/print/frontend/src/screens/settings_screen.tsx
+++ b/apps/print/frontend/src/screens/settings_screen.tsx
@@ -80,9 +80,7 @@ export function SettingsScreen({
         ) : (
           <React.Fragment>
             <H2>Ballot Mode</H2>
-            <P>
-              <ToggleTestModeButton />
-            </P>
+            <ToggleTestModeButton />
           </React.Fragment>
         )}
 

--- a/apps/print/frontend/src/screens/test_deck_screen.test.tsx
+++ b/apps/print/frontend/src/screens/test_deck_screen.test.tsx
@@ -28,7 +28,13 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-function mockBaseQueries({ printerConnected = true } = {}) {
+const NO_TEST_BALLOTS_MESSAGE =
+  'Election package does not contain test ballots required to print test decks.';
+
+function mockBaseQueries({
+  printerConnected = true,
+  testBallotsPresent = true,
+} = {}) {
   apiMock.getDeviceStatuses.expectRepeatedCallsWith().resolves({
     usbDrive: { status: 'no_drive' },
     printer: printerConnected
@@ -49,6 +55,7 @@ function mockBaseQueries({ printerConnected = true } = {}) {
     enableTestDeckPrinting: true,
   });
   apiMock.getTestMode.expectCallWith().resolves(true);
+  apiMock.hasTestBallots.expectCallWith().resolves(testBallotsPresent);
 }
 
 function renderScreen() {
@@ -217,4 +224,37 @@ test('disables all print buttons when the printer is not connected', async () =>
   expect(getButton('Print Overall Tally Report')).toBeDisabled();
   expect(getButton('Print All Test Decks')).toBeDisabled();
   expect(getButton('Print Precinct Test Deck')).toBeDisabled();
+  expect(screen.queryByText(NO_TEST_BALLOTS_MESSAGE)).not.toBeInTheDocument();
+});
+
+test('disables test deck ballot printing and explains why when the election package has no test ballots', async () => {
+  mockBaseQueries({ testBallotsPresent: false });
+  renderScreen();
+
+  await screen.findByRole('heading', { name: 'Test Decks' });
+  await screen.findByText(NO_TEST_BALLOTS_MESSAGE);
+  expect(getButton('Print All Test Decks')).toBeDisabled();
+  expect(getButton('Print Precinct Test Deck')).toBeDisabled();
+});
+
+test('prints the overall tally report when there are no test deck ballots', async () => {
+  // The overall tally report does not rely on prerendered test ballots
+  mockBaseQueries({ testBallotsPresent: false });
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Test Decks' });
+
+  apiMock.getTestDeckBallotCount
+    .expectRepeatedCallsWith({ precinctId: undefined })
+    .resolves(0);
+  userEvent.click(getButton('Print Overall Tally Report'));
+
+  await screen.findByText('Print the overall tally report?');
+  expect(getButton('Print')).toBeEnabled();
+
+  apiMock.printTestDeck
+    .expectCallWith({ overallTallyReportOnly: true })
+    .resolves();
+  userEvent.click(getButton('Print'));
+
+  await screen.findByText('Printing');
 });

--- a/apps/print/frontend/src/screens/test_deck_screen.tsx
+++ b/apps/print/frontend/src/screens/test_deck_screen.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { Election, Id } from '@votingworks/types';
-import { Button, Modal, Loading, P } from '@votingworks/ui';
+import { Button, Callout, Modal, Loading, P } from '@votingworks/ui';
 import { assertDefined } from '@votingworks/basics';
 import {
   Column,
@@ -18,6 +18,7 @@ import {
   getDeviceStatuses,
   getElectionRecord,
   getTestDeckBallotCount,
+  hasTestBallots,
   printTestDeck,
 } from '../api';
 
@@ -33,6 +34,10 @@ const FormSection = styled.div`
   > strong {
     padding-left: 0.25rem;
   }
+`;
+
+const CalloutRow = styled.div`
+  padding: 1rem 1rem 0;
 `;
 
 function PrintTestDeckModal({
@@ -117,7 +122,9 @@ function PrintTestDeckModal({
             icon="Print"
             variant="primary"
             onPress={handlePrint}
-            disabled={ballotCount === 0}
+            // The overall tally report is rendered on the fly and needs no
+            // ballots; the ballot decks do.
+            disabled={!overallTallyReportOnly && ballotCount === 0}
           >
             {buttonText}
           </Button>
@@ -138,8 +145,13 @@ export function TestDeckScreen(): JSX.Element | null {
 
   const getElectionRecordQuery = getElectionRecord.useQuery();
   const getDeviceStatusesQuery = getDeviceStatuses.useQuery();
+  const hasTestBallotsQuery = hasTestBallots.useQuery();
 
-  if (!getElectionRecordQuery.isSuccess || !getDeviceStatusesQuery.isSuccess) {
+  if (
+    !getElectionRecordQuery.isSuccess ||
+    !getDeviceStatusesQuery.isSuccess ||
+    !hasTestBallotsQuery.isSuccess
+  ) {
     return null;
   }
 
@@ -147,6 +159,9 @@ export function TestDeckScreen(): JSX.Element | null {
     electionDefinition: { election },
   } = assertDefined(getElectionRecordQuery.data);
   const { printer } = getDeviceStatusesQuery.data;
+  // Test decks are always printed from the election package's test ballots,
+  // regardless of the machine's current ballot mode.
+  const canPrintTestDecks = hasTestBallotsQuery.data;
 
   return (
     <ScreenWrapper authType="election_manager">
@@ -166,7 +181,7 @@ export function TestDeckScreen(): JSX.Element | null {
                 Print Overall Tally Report
               </Button>
               <Button
-                disabled={!printer.connected}
+                disabled={!printer.connected || !canPrintTestDecks}
                 color="neutral"
                 fill="outlined"
                 onPress={() => {
@@ -178,6 +193,14 @@ export function TestDeckScreen(): JSX.Element | null {
             </React.Fragment>
           }
         />
+        {!canPrintTestDecks && (
+          <CalloutRow>
+            <Callout icon="Warning" color="warning">
+              Election package does not contain test ballots required to print
+              test decks.
+            </Callout>
+          </CalloutRow>
+        )}
         <Form>
           <Column>
             <FormSection>
@@ -199,7 +222,9 @@ export function TestDeckScreen(): JSX.Element | null {
             onPress={() =>
               setPrintTestDeckTarget({ precinctId: selectedPrecinctId })
             }
-            disabled={!selectedPrecinctId || !printer.connected}
+            disabled={
+              !selectedPrecinctId || !printer.connected || !canPrintTestDecks
+            }
           >
             Print Precinct Test Deck
           </PrintButton>


### PR DESCRIPTION
## Overview

Disables test mode and test deck printing in VxPrint when no pre-rendered test ballots exist in the election package.

## Demo Video or Screenshot

<img width="1465" height="833" alt="vxprint-disabled-test-mode" src="https://github.com/user-attachments/assets/f1201e76-b1d8-45a3-8b6e-b6887112c7ab" />

<img width="1471" height="838" alt="vxprint-disabled-test-deck" src="https://github.com/user-attachments/assets/8da7012b-95d1-4f08-9fc6-f8c4a61da319" />


## Testing Plan
- added tests
- manually verified

## Checklist

- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
