### PR TITLE
libs/ui: Fix SearchSelect dropdown arrow on touchscreens

### DIFF
--- a/libs/ui/src/search_select.test.tsx
+++ b/libs/ui/src/search_select.test.tsx
@@ -1,7 +1,12 @@
 import { expect, test } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { render, screen, within } from '../test/react_testing_library';
+import {
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '../test/react_testing_library';
 import {
   SearchSelect,
   SearchSelectProps,
@@ -313,6 +318,38 @@ test('complex value type uses deep equality', () => {
   userEvent.click(screen.getByText('Green Apple'));
   screen.getByText('Green Apple');
   expect(screen.queryByText('Red Apple')).not.toBeInTheDocument();
+});
+
+test('dropdown arrow opens and closes the menu on touchscreens', () => {
+  render(
+    <ControlledSingleSelect options={options} aria-label="Choose Fruit" />,
+    {
+      vxTheme: makeTheme({
+        sizeMode: 'touchSmall',
+        colorMode: 'contrastMedium',
+      }),
+    }
+  );
+
+  const arrow = screen.getByRole('button', { hidden: true });
+
+  function tap(element: HTMLElement) {
+    fireEvent.touchEnd(element, {
+      changedTouches: [{ clientX: 0, clientY: 0 }],
+    });
+  }
+
+  // open dropdown
+  tap(arrow);
+  for (const option of options) {
+    screen.getByRole('option', { name: option.label });
+  }
+
+  // close dropdown
+  tap(arrow);
+  for (const option of options) {
+    expect(screen.queryByText(option.label)).not.toBeInTheDocument();
+  }
 });
 
 test('a11y', () => {

--- a/libs/ui/src/search_select.tsx
+++ b/libs/ui/src/search_select.tsx
@@ -7,29 +7,37 @@ import Select, {
   OptionProps,
   StylesConfig,
 } from 'react-select';
-import { useTheme } from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import React from 'react';
-import { Button } from './button';
+import { Button, buttonStyles, StyledButtonProps } from './button';
+import { Icons } from './icons';
+
+// The react-select DropdownIndicator component toggles the menu from its own
+// mousedown/touchend handlers, so this has to be a plain button rather than our
+// Button component, which stops touch events from propagating (and so would
+// swallow taps on touchscreens).
+const DropdownIndicatorButton = styled.button.attrs({
+  type: 'button',
+  tabIndex: -1,
+})<StyledButtonProps>`
+  ${buttonStyles}
+
+  padding: 0.25rem;
+
+  /* Turn off inset shadow on press (:active) for touchscreen themes */
+  &:active:enabled {
+    box-shadow: none;
+  }
+`;
 
 function DropdownIndicator(
   props: DropdownIndicatorProps<unknown, true>
 ): JSX.Element {
   return (
     <components.DropdownIndicator {...props}>
-      <Button
-        fill="transparent"
-        icon="CaretDown"
-        // The react-select DropdownIndicator component has its own click
-        // handler. It seems to work fine with the button inside it, so we just
-        // put a dummy handler on the button itself.
-        onPress={() => {}}
-        style={{
-          padding: '0.25rem',
-          // Turn off inset shadow on press (:active) for touchscreen themes
-          boxShadow: 'none',
-        }}
-        tabIndex={-1}
-      />
+      <DropdownIndicatorButton fill="transparent">
+        <Icons.CaretDown />
+      </DropdownIndicatorButton>
     </components.DropdownIndicator>
   );
 }
@@ -44,9 +52,10 @@ function MultiValueRemove(
         fill={selectProps.isDisabled ? 'transparent' : 'tinted'}
         color={selectProps.isDisabled ? 'neutral' : 'primary'}
         icon="X"
-        // The react-select MultiValueRemove component has its own click
-        // handler. It seems to work fine with the button inside it, so we just
-        // put a dummy handler on the button itself.
+        // Unlike the DropdownIndicator above, the react-select
+        // MultiValueRemove component removes the value from its own click
+        // handler, which Button triggers for both mouse and touch input, so we
+        // just put a dummy handler on the button itself.
         onPress={() => {}}
         style={{
           padding: '0 0.5rem',


### PR DESCRIPTION
## Overview

Fixes #6324. The `SearchSelect` dropdown arrow didn't open or close the menu —
but only on touch input, which is why it looked inconsistent. react-select's
`DropdownIndicator` toggles the menu from `onMouseDown`/`onTouchEnd` on its
container. The caret rendered our `Button` component inside that container, and
`Button.onTouchEnd` calls `stopPropagation()` (so react-select never sees the
touchend) and `preventDefault()` (so the browser never fires the compatibility
mousedown/click), then synthesizes its own click, which nothing there listens
for. With a mouse the arrow worked, since `Button` only intercepts touch. Despite
the issue title this affects every app using `SearchSelect` — admin, design,
pollbook, mark, and `PollingPlacePicker` in libs/ui.

The caret is now a plain styled `<button>` reusing the exported `buttonStyles`,
so react-select's own handlers receive the event. `Button` was arguably always
the wrong tool here: the element sits inside `aria-hidden="true"` with
`tabIndex={-1}` and a dummy `onPress`, so it's decorative chrome rather than a
control. The alternative — a prop on `Button` to opt out of its touch handling —
would add API surface to our most-used component that is only ever correct when
there is no real `onPress`, since skipping the touch handling means `onPress`
silently never fires on touchscreens.

`MultiValueRemove` (the "X" on a chip) keeps using `Button`, because react-select
gives it an `onClick` alongside the mousedown/touchend pair. `Button` normalizes
every input modality into a click, so the swallowed touchend is redundant there
— and unlike the caret, the X is a real control (`role="button"`,
`aria-label="Remove …"`, tab-reachable), so routing keyboard and touch
activation through click is exactly what we want.

## Demo Video or Screenshot

### Before

https://github.com/user-attachments/assets/80b6a8b6-2015-4f09-8700-c2bf67871c24

### After

https://github.com/user-attachments/assets/80712dac-b22a-40de-a0d8-b3d0c986bb85

## Testing Plan

- Added a regression test that fires a real `touchend` on the arrow and asserts
  the menu opens and closes. Confirmed it fails against the unfixed component —
  the existing tests only exercised `userEvent.click`, which is why this went
  unnoticed.
- Verified in Chromium (driven by Playwright) that the arrow opens and closes on
  both tap and click, in desktop and touch themes. Tapping the control itself
  and the chip-remove X worked before and after; only the arrow was broken.
- Full `libs/ui` suite passes (168 files / 940 tests), plus type-check, eslint,
  stylelint, and prettier.

## Checklist

- [ ] ~~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~~
- [ ] ~~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~~
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
