### PR TITLE
refactor: stream election package entries as async generators

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -10,6 +10,7 @@ import {
   deferred,
   err,
   find,
+  iter,
   ok,
   range,
   throwIllegalValue,
@@ -86,6 +87,7 @@ import {
   readElectionPackageFromBuffer,
   streamElectionPackageAudioClips,
   streamElectionPackageBallots,
+  withElectionPackageZip,
 } from '@votingworks/backend';
 import {
   backendWaitFor,
@@ -319,30 +321,28 @@ afterEach(() => {
   vi.mocked(createTestDeckTallyReports).mockRestore();
 });
 
-async function readBallotsFromElectionPackage(
+function readBallotsFromElectionPackage(
   electionPackageContents: Buffer
 ): Promise<EncodedBallotEntry[]> {
-  const ballots: EncodedBallotEntry[] = [];
-  await streamElectionPackageBallots(
+  return withElectionPackageZip(
     makeTemporaryFile({ content: electionPackageContents }),
-    (batch) => {
-      ballots.push(...batch);
-    }
+    (electionPackageZip) =>
+      iter(streamElectionPackageBallots(electionPackageZip))
+        .flatMap((batch) => batch)
+        .toArray()
   );
-  return ballots;
 }
 
-async function readAudioClipsFromElectionPackage(
+function readAudioClipsFromElectionPackage(
   electionPackageContents: Buffer
 ): Promise<UiStringAudioClip[]> {
-  const audioClips: UiStringAudioClip[] = [];
-  await streamElectionPackageAudioClips(
+  return withElectionPackageZip(
     makeTemporaryFile({ content: electionPackageContents }),
-    (batch) => {
-      audioClips.push(...batch);
-    }
+    (electionPackageZip) =>
+      iter(streamElectionPackageAudioClips(electionPackageZip))
+        .flatMap((batch) => batch)
+        .toArray()
   );
-  return audioClips;
 }
 
 test('all methods require authentication', async () => {

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -33,6 +33,7 @@ import {
   createSystemCallApi,
   ExportDataResult,
   configureUiStringAudioClipsStreaming,
+  withElectionPackageZip,
 } from '@votingworks/backend';
 import { LogEventId, Logger } from '@votingworks/logging';
 import { UsbDrive, UsbDriveStatus } from '@votingworks/usb-drive';
@@ -206,11 +207,13 @@ export function buildApi(
       });
 
       try {
-        await configureUiStringAudioClipsStreaming({
-          electionPackageFilePath: filePath,
-          store: workspace.store.getUiStringsStore(),
-          withTransaction: (fn) => workspace.store.withTransaction(fn),
-        });
+        await withElectionPackageZip(filePath, (electionPackageZip) =>
+          configureUiStringAudioClipsStreaming({
+            electionPackageZip,
+            store: workspace.store.getUiStringsStore(),
+            withTransaction: (fn) => workspace.store.withTransaction(fn),
+          })
+        );
       } catch (error) {
         workspace.store.reset();
         throw error;

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -38,6 +38,7 @@ import {
   ExportDataResult,
   configureUiStringAudioClipsStreaming,
   streamElectionPackageBallots,
+  withElectionPackageZip,
 } from '@votingworks/backend';
 import { LogEventId, Logger } from '@votingworks/logging';
 import { UsbDrive, UsbDriveStatus } from '@votingworks/usb-drive';
@@ -313,59 +314,65 @@ export function buildApi(ctx: Context) {
       const { electionDefinition, systemSettings } = electionPackage;
       assert(systemSettings);
 
-      // Stream the serialized ballots (potentially GBs, and optional in the
-      // package) into the store in batches rather than holding them all in
-      // memory. The ballots table is independent of the election record, so
-      // a failed import is cleaned up without leaving the machine configured.
-      workspace.store.deleteBallots();
-      try {
-        await streamElectionPackageBallots(filePath, (ballots) =>
-          workspace.store.addBallots(ballots)
-        );
-      } catch (error) {
+      // Ballots and audio clips are both streamed from the package, so open it
+      // once and stream both entries over the same open file.
+      await withElectionPackageZip(filePath, async (electionPackageZip) => {
+        // Stream the serialized ballots (potentially GBs, and optional in the
+        // package) into the store in batches rather than holding them all in
+        // memory. The ballots table is independent of the election record, so
+        // a failed import is cleaned up without leaving the machine configured.
         workspace.store.deleteBallots();
-        throw error;
-      }
-
-      workspace.store.withTransaction(() => {
-        workspace.store.setElectionAndJurisdiction({
-          electionData: electionDefinition.electionData,
-          jurisdiction: authStatus.user.jurisdiction,
-          electionPackageHash,
-        });
-        workspace.store.setSystemSettings(systemSettings);
-
-        // The machine defaults to test mode, but if test mode isn't available
-        // for this election package (no test ballots for a print flow that
-        // needs them), start in official mode to avoid footgun of allowing
-        // users to try to print test mode ballots that don't exist.
-        if (!isTestModeAvailable(workspace.store)) {
-          workspace.store.setTestMode(false);
+        try {
+          for await (const ballots of streamElectionPackageBallots(
+            electionPackageZip
+          )) {
+            workspace.store.addBallots(ballots);
+          }
+        } catch (error) {
+          workspace.store.deleteBallots();
+          throw error;
         }
 
-        if (electionDefinition.election.pollingPlaces?.length === 1) {
-          workspace.store.setPollingPlaceId(
-            electionDefinition.election.pollingPlaces[0].id
-          );
-        }
+        workspace.store.withTransaction(() => {
+          workspace.store.setElectionAndJurisdiction({
+            electionData: electionDefinition.electionData,
+            jurisdiction: authStatus.user.jurisdiction,
+            electionPackageHash,
+          });
+          workspace.store.setSystemSettings(systemSettings);
 
-        configureUiStrings({
-          electionPackage,
-          logger,
-          store: workspace.store.getUiStringsStore(),
+          // The machine defaults to test mode, but if test mode isn't available
+          // for this election package (no test ballots for a print flow that
+          // needs them), start in official mode to avoid footgun of allowing
+          // users to try to print test mode ballots that don't exist.
+          if (!isTestModeAvailable(workspace.store)) {
+            workspace.store.setTestMode(false);
+          }
+
+          if (electionDefinition.election.pollingPlaces?.length === 1) {
+            workspace.store.setPollingPlaceId(
+              electionDefinition.election.pollingPlaces[0].id
+            );
+          }
+
+          configureUiStrings({
+            electionPackage,
+            logger,
+            store: workspace.store.getUiStringsStore(),
+          });
         });
+
+        try {
+          await configureUiStringAudioClipsStreaming({
+            electionPackageZip,
+            store: workspace.store.getUiStringsStore(),
+            withTransaction: (fn) => workspace.store.withTransaction(fn),
+          });
+        } catch (error) {
+          workspace.store.reset();
+          throw error;
+        }
       });
-
-      try {
-        await configureUiStringAudioClipsStreaming({
-          electionPackageFilePath: filePath,
-          store: workspace.store.getUiStringsStore(),
-          withTransaction: (fn) => workspace.store.withTransaction(fn),
-        });
-      } catch (error) {
-        workspace.store.reset();
-        throw error;
-      }
 
       await logger.logAsCurrentRole(LogEventId.ElectionConfigured, {
         message: `Machine configured for election with hash: ${electionDefinition.ballotHash}`,

--- a/apps/print/backend/src/app.ts
+++ b/apps/print/backend/src/app.ts
@@ -26,6 +26,7 @@ import {
   getBatteryInfo,
   readSignedElectionPackageFromDirectory,
   streamElectionPackageBallots,
+  withElectionPackageZip,
 } from '@votingworks/backend';
 import {
   electionHasBallotPositions,
@@ -200,9 +201,14 @@ export function buildApi(ctx: AppContext) {
       store.deleteBallots();
       let ballotCount = 0;
       try {
-        ballotCount = await streamElectionPackageBallots(filePath, (ballots) =>
-          store.addBallots(ballots)
-        );
+        await withElectionPackageZip(filePath, async (electionPackageZip) => {
+          for await (const ballots of streamElectionPackageBallots(
+            electionPackageZip
+          )) {
+            store.addBallots(ballots);
+            ballotCount += ballots.length;
+          }
+        });
       } catch (error) {
         store.deleteBallots();
         throw error;

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -21,6 +21,7 @@ import {
   Exporter,
   SCAN_ALLOWED_EXPORT_PATTERNS,
   ExportDataResult,
+  withElectionPackageZip,
 } from '@votingworks/backend';
 import { assert, assertDefined, err, ok, Result } from '@votingworks/basics';
 import {
@@ -210,11 +211,13 @@ export function buildApi({
       });
 
       try {
-        await configureUiStringAudioClipsStreaming({
-          electionPackageFilePath: filePath,
-          store: workspace.store.getUiStringsStore(),
-          withTransaction: (fn) => store.withTransaction(fn),
-        });
+        await withElectionPackageZip(filePath, (electionPackageZip) =>
+          configureUiStringAudioClipsStreaming({
+            electionPackageZip,
+            store: workspace.store.getUiStringsStore(),
+            withTransaction: (fn) => store.withTransaction(fn),
+          })
+        );
       } catch (error) {
         workspace.reset();
         throw error;

--- a/libs/backend/src/election_package/election_package_io.test.ts
+++ b/libs/backend/src/election_package/election_package_io.test.ts
@@ -13,7 +13,6 @@ import {
   SystemLimitViolation,
   SystemLimits,
   SystemSettings,
-  UiStringAudioClip,
   UiStringAudioClips,
   UiStringAudioIdsPackage,
   UiStringsPackage,
@@ -38,7 +37,16 @@ import {
   readElectionGeneralDefinition,
   makeTemporaryFile,
 } from '@votingworks/fixtures';
-import { assertDefined, err, ok, range, typedAs } from '@votingworks/basics';
+import {
+  assert,
+  assertDefined,
+  err,
+  fail,
+  iter,
+  ok,
+  range,
+  typedAs,
+} from '@votingworks/basics';
 import {
   ELECTION_PACKAGE_FOLDER,
   BooleanEnvironmentVariableName,
@@ -49,6 +57,7 @@ import { authenticateArtifactUsingSignatureFile } from '@votingworks/auth';
 import { join } from 'node:path';
 import * as fs from 'node:fs';
 import { Buffer } from 'node:buffer';
+import { Readable } from 'node:stream';
 import { writeMockFileTree } from '@votingworks/usb-drive';
 import { sha256 } from 'js-sha256';
 import {
@@ -56,6 +65,7 @@ import {
   mockElectionPackageFileTree,
 } from './test_utils';
 import {
+  ElectionPackageZip,
   ParsedElectionPackageWithHash,
   readElectionPackageFromBuffer,
   readElectionPackageFromFile,
@@ -527,125 +537,109 @@ function makeTestBallot(index: number): EncodedBallotEntry {
   };
 }
 
+/**
+ * A fake {@link ElectionPackageZip} holding a single JSONL entry, so the
+ * streaming helpers can be exercised without building a zip.
+ */
+function jsonlEntryZip(entryName: string, jsonl: string): ElectionPackageZip {
+  return {
+    hasEntry: (name) => name === entryName,
+    openEntryStream: (name) => {
+      assert(name === entryName);
+      return Promise.resolve(Readable.from([jsonl], { objectMode: false }));
+    },
+    readEntryText: () => fail('unexpected call to readEntryText'),
+  };
+}
+
+function ballotsZip(ballots: EncodedBallotEntry[]): ElectionPackageZip {
+  return jsonlEntryZip(
+    ElectionPackageFileName.BALLOTS,
+    ballots.map((ballot) => `${JSON.stringify(ballot)}\n`).join('')
+  );
+}
+
 test('streamElectionPackageBallots streams small ballots in a single batch', async () => {
-  const electionDefinition =
-    electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
   const ballots = range(0, 501).map(makeTestBallot);
-  const pkg = await electionPackageZip({
-    [ElectionPackageFileName.ELECTION]: electionDefinition.electionData,
-    [ElectionPackageFileName.BALLOTS]: ballots
-      .map((ballot) => JSON.stringify(ballot))
-      .join('\n'),
-  });
-  const file = makeTemporaryFile({ content: pkg });
 
-  const batches: Array<EncodedBallotEntry[]> = [];
-  const count = await streamElectionPackageBallots(file, (batch) => {
-    batches.push(batch);
-  });
+  const batches = await iter(
+    streamElectionPackageBallots(ballotsZip(ballots))
+  ).toArray();
 
-  expect(count).toEqual(501);
   expect(batches.map((batch) => batch.length)).toEqual([501]);
   expect(batches.flat()).toEqual(ballots);
 });
 
 test('streamElectionPackageBallots flushes a batch per ballot when each exceeds the batch size', async () => {
-  const electionDefinition =
-    electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
   // ~9MB encoded ballots: each line alone exceeds the 8MB batch cap
   const ballots = range(0, 2).map((index) => ({
     ...makeTestBallot(index),
     encodedBallot: 'x'.repeat(9 * 1024 * 1024),
   }));
-  const pkg = await electionPackageZip({
-    [ElectionPackageFileName.ELECTION]: electionDefinition.electionData,
-    [ElectionPackageFileName.BALLOTS]: ballots
-      .map((ballot) => JSON.stringify(ballot))
-      .join('\n'),
-  });
-  const file = makeTemporaryFile({ content: pkg });
 
-  const batchLengths: number[] = [];
-  const count = await streamElectionPackageBallots(file, (batch) => {
-    batchLengths.push(batch.length);
-  });
+  const batchLengths = await iter(
+    streamElectionPackageBallots(ballotsZip(ballots))
+  )
+    .map((batch) => batch.length)
+    .toArray();
 
-  expect(count).toEqual(2);
   expect(batchLengths).toEqual([1, 1]);
 });
 
 test('streamElectionPackageBallots caps batches by size for large ballots', async () => {
-  const electionDefinition =
-    electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
   // ~5MB encoded ballots: an 8MB batch cap flushes after every two
   const ballots = range(0, 3).map((index) => ({
     ...makeTestBallot(index),
     encodedBallot: 'x'.repeat(5 * 1024 * 1024),
   }));
-  const pkg = await electionPackageZip({
-    [ElectionPackageFileName.ELECTION]: electionDefinition.electionData,
-    [ElectionPackageFileName.BALLOTS]: ballots
-      .map((ballot) => JSON.stringify(ballot))
-      .join('\n'),
-  });
-  const file = makeTemporaryFile({ content: pkg });
 
-  const batchLengths: number[] = [];
-  const count = await streamElectionPackageBallots(file, (batch) => {
-    batchLengths.push(batch.length);
-  });
+  const batchLengths = await iter(
+    streamElectionPackageBallots(ballotsZip(ballots))
+  )
+    .map((batch) => batch.length)
+    .toArray();
 
-  expect(count).toEqual(3);
   expect(batchLengths).toEqual([2, 1]);
 });
 
 test('streamElectionPackageAudioClips streams clips and skips blank lines', async () => {
-  const electionDefinition =
-    electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
   const audioClips: UiStringAudioClips = [
     { dataBase64: 'AABC==', id: 'a1b2c3', languageCode: 'en' },
     { dataBase64: 'DDEF==', id: 'd1e2f3', languageCode: 'es-US' },
   ];
-  const pkg = await electionPackageZip({
-    [ElectionPackageFileName.ELECTION]: electionDefinition.electionData,
-    [ElectionPackageFileName.AUDIO_CLIPS]: `${audioClips
-      .map((clip) => JSON.stringify(clip))
-      .join('\n\n')}\n`,
-  });
-  const file = makeTemporaryFile({ content: pkg });
 
-  const clips: UiStringAudioClip[] = [];
-  const count = await streamElectionPackageAudioClips(file, (batch) => {
-    clips.push(...batch);
-  });
+  const clips = await iter(
+    streamElectionPackageAudioClips(
+      jsonlEntryZip(
+        ElectionPackageFileName.AUDIO_CLIPS,
+        `${audioClips.map((clip) => JSON.stringify(clip)).join('\n\n')}\n`
+      )
+    )
+  ).toArray();
 
-  expect(count).toEqual(2);
-  expect(clips).toEqual(audioClips);
+  expect(clips.flat()).toEqual(audioClips);
 });
 
-test('streamElectionPackageBallots returns 0 for a package without ballots', async () => {
-  const electionDefinition =
-    electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
-  const pkg = await electionPackageZip({
-    [ElectionPackageFileName.ELECTION]: electionDefinition.electionData,
-  });
-  const file = makeTemporaryFile({ content: pkg });
-
-  const onBatch = vi.fn();
-  expect(await streamElectionPackageBallots(file, onBatch)).toEqual(0);
-  expect(onBatch).not.toHaveBeenCalled();
+test('streamElectionPackageBallots yields nothing for a package without ballots', async () => {
+  expect(
+    await iter(
+      streamElectionPackageBallots({
+        hasEntry: () => false,
+        openEntryStream: () => fail('unexpected call to openEntryStream'),
+        readEntryText: () => fail('unexpected call to readEntryText'),
+      })
+    ).toArray()
+  ).toHaveLength(0);
 });
 
 test('streamElectionPackageBallots throws on an invalid ballot line', async () => {
-  const electionDefinition =
-    electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
-  const pkg = await electionPackageZip({
-    [ElectionPackageFileName.ELECTION]: electionDefinition.electionData,
-    [ElectionPackageFileName.BALLOTS]: 'not a valid ballot',
-  });
-  const file = makeTemporaryFile({ content: pkg });
-
-  await expect(streamElectionPackageBallots(file, vi.fn())).rejects.toThrow();
+  await expect(
+    iter(
+      streamElectionPackageBallots(
+        jsonlEntryZip(ElectionPackageFileName.BALLOTS, 'not a valid ballot\n')
+      )
+    ).toArray()
+  ).rejects.toThrow();
 });
 
 test('readSignedElectionPackageFromDirectory can read an election package from a directory', async () => {

--- a/libs/backend/src/election_package/election_package_io.ts
+++ b/libs/backend/src/election_package/election_package_io.ts
@@ -54,6 +54,7 @@ import {
 } from '@votingworks/types';
 import { authenticateArtifactUsingSignatureFile } from '@votingworks/auth';
 import { sha256 } from 'js-sha256';
+import { z } from 'zod/v4';
 import { validateElectionDefinitionAgainstSystemLimits } from './system_limits';
 
 /**
@@ -109,7 +110,7 @@ function missingEntryError(name: string): Error {
  * Uniform entry access over an election package zip, whether opened from an
  * in-memory buffer or streamed from a file on disk.
  */
-interface ElectionPackageZip {
+export interface ElectionPackageZip {
   hasEntry(name: string): boolean;
   /** Reads a whole entry into memory as UTF-8 text. Throws if missing. */
   readEntryText(name: string): Promise<string>;
@@ -320,6 +321,25 @@ async function parseElectionPackage(
 }
 
 /**
+ * Opens the election package zip at `path`, passes it to `fn`, and closes it
+ * once `fn` settles. Entries are streamed from disk on demand, so the zip is
+ * never read into memory as a whole. Opening once and passing the zip down
+ * lets a caller stream several entries — e.g. ballots and audio clips — over a
+ * single open file.
+ */
+export async function withElectionPackageZip<T>(
+  path: string,
+  fn: (electionPackageZip: ElectionPackageZip) => Promise<T>
+): Promise<T> {
+  const { zip, close } = await openFileBackedZip(path);
+  try {
+    return await fn(zip);
+  } finally {
+    close();
+  }
+}
+
+/**
  * Parses an package from the given buffer and hashes the raw contents.
  */
 export async function readElectionPackageFromBuffer(
@@ -355,25 +375,22 @@ export async function readElectionPackageFromFile(
   path: string,
   options?: ReadElectionPackageOptions
 ): Promise<Result<ParsedElectionPackageWithHash, ElectionPackageError>> {
-  let close: (() => void) | undefined;
   try {
-    const fileBackedZip = await openFileBackedZip(path);
-    close = fileBackedZip.close;
-    const [electionPackageHash, result] = await Promise.all([
-      sha256File(path),
-      parseElectionPackage(fileBackedZip.zip, options),
-    ]);
-    if (result.isErr()) {
-      return result;
-    }
-    return ok({ electionPackage: result.ok(), electionPackageHash });
+    return await withElectionPackageZip(path, async (zip) => {
+      const [electionPackageHash, result] = await Promise.all([
+        sha256File(path),
+        parseElectionPackage(zip, options),
+      ]);
+      if (result.isErr()) {
+        return result;
+      }
+      return ok({ electionPackage: result.ok(), electionPackageHash });
+    });
   } catch (error) {
     return err({
       type: 'invalid-zip',
       message: String(error),
     });
-  } finally {
-    close?.();
   }
 }
 
@@ -382,68 +399,54 @@ export async function readElectionPackageFromFile(
 const STREAM_BATCH_MAX_CHARS = 8 * 1024 * 1024;
 
 /**
- * Streams a JSONL entry in an election package zip from disk, delivering
- * parsed lines to `onBatch` in batches capped at roughly
- * {@link STREAM_BATCH_MAX_CHARS} of JSONL, so that the full entry contents
- * are never held in memory. Blank lines are skipped. Returns the total number
- * of items streamed (0 if the package has no such entry).
+ * Streams a JSONL entry from an election package zip, yielding parsed batches
+ * capped at roughly {@link STREAM_BATCH_MAX_CHARS} of JSONL, so that the full
+ * entry contents are never held in memory. Blank lines are skipped.
+ *
+ * Intended as a second pass after the package has been read and validated;
+ * parse errors are unexpected at that point and throw.
  */
-async function streamElectionPackageJsonlEntry<T>(
-  path: string,
+export async function* streamElectionPackageJsonlEntry<T>(
+  electionPackageZip: ElectionPackageZip,
   entryName: string,
-  parseLine: (line: string) => T,
-  onBatch: (items: T[]) => void | Promise<void>
-): Promise<number> {
-  const { zip, close } = await openFileBackedZip(path);
-  try {
-    if (!zip.hasEntry(entryName)) {
-      return 0;
-    }
+  schema: z.ZodType<T>
+): AsyncIterable<T[]> {
+  if (!electionPackageZip.hasEntry(entryName)) return;
 
-    const fileLines = readline.createInterface(
-      await zip.openEntryStream(entryName)
-    );
-    let batch: T[] = [];
-    let batchChars = 0;
-    let count = 0;
-    for await (const line of fileLines) {
-      if (line.trim().length === 0) continue;
-      batch.push(parseLine(line));
-      batchChars += line.length;
-      count += 1;
-      if (batchChars >= STREAM_BATCH_MAX_CHARS) {
-        await onBatch(batch);
-        batch = [];
-        batchChars = 0;
-      }
+  const fileLines = readline.createInterface(
+    await electionPackageZip.openEntryStream(entryName)
+  );
+  let batch: T[] = [];
+  let batchChars = 0;
+  for await (const line of fileLines) {
+    if (line.trim().length === 0) continue;
+    batch.push(safeParseJson(line, schema).unsafeUnwrap());
+    batchChars += line.length;
+    if (batchChars >= STREAM_BATCH_MAX_CHARS) {
+      yield batch;
+      batch = [];
+      batchChars = 0;
     }
-    if (batch.length > 0) {
-      await onBatch(batch);
-    }
-    return count;
-  } finally {
-    close();
+  }
+  if (batch.length > 0) {
+    yield batch;
   }
 }
 
 /**
- * Streams the serialized ballots in an election package zip from disk in
- * size-capped batches, so that the full set is never held in memory. Returns
- * the total number of ballots streamed (0 if the package has no ballots
- * file).
+ * Streams the serialized ballots in an election package zip in size-capped
+ * batches, so that the full set is never held in memory.
  *
  * Intended as a second pass after the package has been read and validated;
  * parse errors are unexpected at that point and throw.
  */
 export function streamElectionPackageBallots(
-  path: string,
-  onBatch: (ballots: EncodedBallotEntry[]) => void | Promise<void>
-): Promise<number> {
+  electionPackageZip: ElectionPackageZip
+): AsyncIterable<EncodedBallotEntry[]> {
   return streamElectionPackageJsonlEntry(
-    path,
+    electionPackageZip,
     ElectionPackageFileName.BALLOTS,
-    (line) => safeParseJson(line, EncodedBallotEntrySchema).unsafeUnwrap(),
-    onBatch
+    EncodedBallotEntrySchema
   );
 }
 
@@ -458,14 +461,12 @@ export function streamElectionPackageBallots(
  * parse errors are unexpected at that point and throw.
  */
 export function streamElectionPackageAudioClips(
-  path: string,
-  onBatch: (clips: UiStringAudioClip[]) => void | Promise<void>
-): Promise<number> {
+  electionPackageZip: ElectionPackageZip
+): AsyncIterable<UiStringAudioClip[]> {
   return streamElectionPackageJsonlEntry(
-    path,
+    electionPackageZip,
     ElectionPackageFileName.AUDIO_CLIPS,
-    (line) => safeParseJson(line, UiStringAudioClipSchema).unsafeUnwrap(),
-    onBatch
+    UiStringAudioClipSchema
   );
 }
 

--- a/libs/backend/src/ui_strings/ui_strings_machine_configuration.ts
+++ b/libs/backend/src/ui_strings/ui_strings_machine_configuration.ts
@@ -2,6 +2,7 @@
 
 import { BaseLogger } from '@votingworks/logging';
 import {
+  ElectionPackageZip,
   ParsedElectionPackage,
   streamElectionPackageAudioClips,
 } from '../election_package/election_package_io';
@@ -55,30 +56,31 @@ export function configureUiStrings(input: ElectionPackageProcessorInput): void {
 }
 
 /**
- * Streams the audio clips in the election package zip at
- * `electionPackageFilePath` into the provided store in size-capped batches,
- * so that the full set (potentially GBs) is never held in memory. Only clips
- * for languages already configured in the store (see
- * {@link configureUiStrings}) are loaded, and each batch is inserted within
- * `withTransaction`.
+ * Streams the audio clips in the given election package zip into the provided
+ * store in size-capped batches, so that the full set (potentially GBs) is
+ * never held in memory. Only clips for languages already configured in the
+ * store (see {@link configureUiStrings}) are loaded, and each batch is
+ * inserted within `withTransaction`.
  */
 export async function configureUiStringAudioClipsStreaming({
-  electionPackageFilePath,
+  electionPackageZip,
   store,
   withTransaction,
 }: {
-  electionPackageFilePath: string;
+  electionPackageZip: ElectionPackageZip;
   store: UiStringsStore;
   withTransaction: (fn: () => void) => void;
 }): Promise<void> {
   const configuredLanguages = new Set(store.getLanguages());
-  await streamElectionPackageAudioClips(electionPackageFilePath, (clips) =>
+  for await (const clips of streamElectionPackageAudioClips(
+    electionPackageZip
+  )) {
     withTransaction(() => {
       for (const clip of clips) {
         if (configuredLanguages.has(clip.languageCode)) {
           store.setAudioClip(clip);
         }
       }
-    })
-  );
+    });
+  }
 }


### PR DESCRIPTION
## Overview

Follow-up to #9020, targeting that branch.

Converts the election package JSONL streaming helpers from a callback API (`streamElectionPackageBallots(path, onBatch)`) to async generators that take an already-open zip, and adds `withElectionPackageZip(path, fn)` to scope the open file. Callers now open the package once and stream both ballots and audio clips over a single open file rather than reopening it per entry — VxMark previously opened the same zip twice during configuration.

Batches are still yielded (rather than individual items) because the batch is load-bearing in two ways: `Store.addBallots` and `configureUiStringAudioClipsStreaming` each wrap one batch in a single SQLite transaction, and the cap is measured in bytes of raw JSONL, which keeps peak memory at ~one batch even when individual ballots are multiple MB. Consumers that don't care can flatten with `iter(...).flatMap((batch) => batch)`.

## Demo Video or Screenshot

n/a — backend refactor with no user-visible change.

## Testing Plan

Existing suites cover every migrated caller; no behavior change intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)