### PR TITLE
DevDock: Add multiplier to central scanner queuing & add ability to queue error

### DIFF
--- a/apps/central-scan/backend/src/mock_batch_scanner.test.ts
+++ b/apps/central-scan/backend/src/mock_batch_scanner.test.ts
@@ -19,16 +19,16 @@ test('initial status checks pass as expected', async () => {
   const scanner = createScanner();
   expect(scanner.isAttached()).toEqual(true);
   expect(await scanner.isImprinterAttached()).toEqual(false);
-  expect(scanner.getStatus()).toEqual({ sheetCount: 0 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 0, errorQueued: false });
 });
 
 test('addSheets and getStatus', () => {
   const scanner = createScanner();
   scanner.addSheets([sheet(1), sheet(2)]);
-  expect(scanner.getStatus()).toEqual({ sheetCount: 2 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 2, errorQueued: false });
 
   scanner.addSheets([sheet(3)]);
-  expect(scanner.getStatus()).toEqual({ sheetCount: 3 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 3, errorQueued: false });
 });
 
 test('imageDir is a writable directory', () => {
@@ -54,7 +54,7 @@ test('scanSheets returns sheets and preserves the queue', async () => {
   scanner.addSheets([sheet(1), sheet(2)]);
 
   const batch = scanner.scanSheets();
-  expect(scanner.getStatus()).toEqual({ sheetCount: 2 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 2, errorQueued: false });
 
   expect(await batch.scanSheet()).toEqual(sheet(1));
   expect(await batch.scanSheet()).toEqual(sheet(2));
@@ -99,7 +99,7 @@ test('addSheets appends to existing queue for next scan', async () => {
   expect(await batch1.scanSheet()).toBeUndefined();
 
   scanner.addSheets([sheet(2)]);
-  expect(scanner.getStatus()).toEqual({ sheetCount: 2 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 2, errorQueued: false });
 
   const batch2 = scanner.scanSheets();
   expect(await batch2.scanSheet()).toEqual(sheet(1));
@@ -110,10 +110,10 @@ test('addSheets appends to existing queue for next scan', async () => {
 test('setCopies scales the queued sheets', async () => {
   const scanner = createScanner();
   scanner.addSheets([sheet(1), sheet(2)]);
-  expect(scanner.getStatus()).toEqual({ sheetCount: 2 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 2, errorQueued: false });
 
   scanner.setCopies(3);
-  expect(scanner.getStatus()).toEqual({ sheetCount: 6 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 6, errorQueued: false });
 
   const batch = scanner.scanSheets();
   expect(await batch.scanSheet()).toEqual(sheet(1));
@@ -125,7 +125,52 @@ test('setCopies scales the queued sheets', async () => {
   expect(await batch.scanSheet()).toBeUndefined();
 
   scanner.setCopies(1);
-  expect(scanner.getStatus()).toEqual({ sheetCount: 2 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 2, errorQueued: false });
+});
+
+test('a queued error makes the next scan attempt fail once', async () => {
+  const scanner = createScanner();
+  scanner.addSheets([sheet(1), sheet(2)]);
+
+  const batch = scanner.scanSheets();
+  expect(await batch.scanSheet()).toEqual(sheet(1));
+
+  scanner.setErrorQueued(true);
+  expect(scanner.getStatus()).toEqual({ sheetCount: 2, errorQueued: true });
+  await expect(batch.scanSheet()).rejects.toThrowError(
+    'simulated scanner error'
+  );
+
+  // the error is consumed; scanning resumes, whether on the same session or a
+  // fresh one
+  expect(scanner.getStatus()).toEqual({ sheetCount: 2, errorQueued: false });
+  expect(await batch.scanSheet()).toEqual(sheet(2));
+  expect(await batch.scanSheet()).toBeUndefined();
+
+  const batch2 = scanner.scanSheets();
+  expect(await batch2.scanSheet()).toEqual(sheet(1));
+});
+
+test('setErrorQueued(false) cancels a queued error', async () => {
+  const scanner = createScanner();
+  scanner.addSheets([sheet(1)]);
+  scanner.setErrorQueued(true);
+  expect(scanner.getStatus()).toEqual({ sheetCount: 1, errorQueued: true });
+
+  scanner.setErrorQueued(false);
+  expect(scanner.getStatus()).toEqual({ sheetCount: 1, errorQueued: false });
+
+  const batch = scanner.scanSheets();
+  expect(await batch.scanSheet()).toEqual(sheet(1));
+});
+
+test('clearSheets clears a queued error', () => {
+  const scanner = createScanner();
+  scanner.setErrorQueued(true);
+  expect(scanner.getStatus()).toEqual({ sheetCount: 0, errorQueued: true });
+
+  scanner.clearSheets();
+  expect(scanner.getStatus()).toEqual({ sheetCount: 0, errorQueued: false });
 });
 
 test('clearSheets resets so next scan returns nothing', async () => {
@@ -138,7 +183,7 @@ test('clearSheets resets so next scan returns nothing', async () => {
   expect(await batch1.scanSheet()).toEqual(sheet(1));
 
   scanner.clearSheets();
-  expect(scanner.getStatus()).toEqual({ sheetCount: 0 });
+  expect(scanner.getStatus()).toEqual({ sheetCount: 0, errorQueued: false });
 
   const batch2 = scanner.scanSheets();
   expect(await batch2.scanSheet()).toBeUndefined();

--- a/apps/central-scan/backend/src/mock_batch_scanner.test.ts
+++ b/apps/central-scan/backend/src/mock_batch_scanner.test.ts
@@ -107,6 +107,27 @@ test('addSheets appends to existing queue for next scan', async () => {
   expect(await batch2.scanSheet()).toBeUndefined();
 });
 
+test('setCopies scales the queued sheets', async () => {
+  const scanner = createScanner();
+  scanner.addSheets([sheet(1), sheet(2)]);
+  expect(scanner.getStatus()).toEqual({ sheetCount: 2 });
+
+  scanner.setCopies(3);
+  expect(scanner.getStatus()).toEqual({ sheetCount: 6 });
+
+  const batch = scanner.scanSheets();
+  expect(await batch.scanSheet()).toEqual(sheet(1));
+  expect(await batch.scanSheet()).toEqual(sheet(1));
+  expect(await batch.scanSheet()).toEqual(sheet(1));
+  expect(await batch.scanSheet()).toEqual(sheet(2));
+  expect(await batch.scanSheet()).toEqual(sheet(2));
+  expect(await batch.scanSheet()).toEqual(sheet(2));
+  expect(await batch.scanSheet()).toBeUndefined();
+
+  scanner.setCopies(1);
+  expect(scanner.getStatus()).toEqual({ sheetCount: 2 });
+});
+
 test('clearSheets resets so next scan returns nothing', async () => {
   const scanner = createScanner();
   const testFile = join(scanner.imageDir, 'test.jpg');

--- a/apps/central-scan/backend/src/mock_batch_scanner.ts
+++ b/apps/central-scan/backend/src/mock_batch_scanner.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import { range } from '@votingworks/basics';
 import {
   BatchControl,
   BatchScanner,
@@ -9,6 +10,7 @@ export interface MockBatchScannerApi {
   addSheets(sheets: readonly ScannedSheetInfo[]): void;
   getStatus(): { sheetCount: number };
   clearSheets(): void;
+  setCopies(copies: number): void;
   /** Directory for writing temporary ballot images. */
   imageDir: string;
 }
@@ -21,11 +23,18 @@ export interface MockBatchScannerApi {
  * the same ballots can be scanned repeatedly. Use `clearSheets()` to reset
  * and clean up temporary files.
  *
+ * `setCopies(n)` scales the stack: each queued sheet is scanned `n` times,
+ * simulating a larger stack (and therefore a longer scanning window, e.g. to
+ * try the Stop button). It applies to sheets already in the queue and takes
+ * effect when the next scan session starts; `getStatus()` reports the scaled
+ * sheet count.
+ *
  * Images are stored in the provided directory rather than a random temp
  * directory, so previous runs' files are cleaned up on startup.
  */
 export class MockBatchScanner implements BatchScanner, MockBatchScannerApi {
   private queue: ScannedSheetInfo[] = [];
+  private copies = 1;
 
   constructor(private readonly imageDirPath: string) {
     // Wipe any leftover images from a previous run
@@ -45,12 +54,16 @@ export class MockBatchScanner implements BatchScanner, MockBatchScannerApi {
     return Promise.resolve(false);
   }
 
-  addSheets(sheets: ScannedSheetInfo[]): void {
+  addSheets(sheets: readonly ScannedSheetInfo[]): void {
     this.queue.push(...sheets);
   }
 
   getStatus(): { sheetCount: number } {
-    return { sheetCount: this.queue.length };
+    return { sheetCount: this.queue.length * this.copies };
+  }
+
+  setCopies(copies: number): void {
+    this.copies = copies;
   }
 
   clearSheets(): void {
@@ -61,7 +74,9 @@ export class MockBatchScanner implements BatchScanner, MockBatchScannerApi {
 
   /* eslint-disable @typescript-eslint/require-await */
   scanSheets(): BatchControl {
-    const snapshot = [...this.queue];
+    const snapshot = this.queue.flatMap((sheet) =>
+      range(0, this.copies).map(() => sheet)
+    );
     let index = 0;
 
     return {

--- a/apps/central-scan/backend/src/mock_batch_scanner.ts
+++ b/apps/central-scan/backend/src/mock_batch_scanner.ts
@@ -8,9 +8,10 @@ import {
 
 export interface MockBatchScannerApi {
   addSheets(sheets: readonly ScannedSheetInfo[]): void;
-  getStatus(): { sheetCount: number };
+  getStatus(): { sheetCount: number; errorQueued: boolean };
   clearSheets(): void;
   setCopies(copies: number): void;
+  setErrorQueued(errorQueued: boolean): void;
   /** Directory for writing temporary ballot images. */
   imageDir: string;
 }
@@ -29,12 +30,18 @@ export interface MockBatchScannerApi {
  * effect when the next scan session starts; `getStatus()` reports the scaled
  * sheet count.
  *
+ * `setErrorQueued(true)` queues a one-shot scanner error: the next attempt to
+ * scan a sheet fails, whether mid-batch or when opening the next scan session.
+ * This exercises the batch error flow; retrying succeeds since the error is
+ * consumed. `setErrorQueued(false)` cancels a queued error.
+ *
  * Images are stored in the provided directory rather than a random temp
  * directory, so previous runs' files are cleaned up on startup.
  */
 export class MockBatchScanner implements BatchScanner, MockBatchScannerApi {
   private queue: ScannedSheetInfo[] = [];
   private copies = 1;
+  private pendingError?: Error;
 
   constructor(private readonly imageDirPath: string) {
     // Wipe any leftover images from a previous run
@@ -58,8 +65,11 @@ export class MockBatchScanner implements BatchScanner, MockBatchScannerApi {
     this.queue.push(...sheets);
   }
 
-  getStatus(): { sheetCount: number } {
-    return { sheetCount: this.queue.length * this.copies };
+  getStatus(): { sheetCount: number; errorQueued: boolean } {
+    return {
+      sheetCount: this.queue.length * this.copies,
+      errorQueued: this.pendingError !== undefined,
+    };
   }
 
   setCopies(copies: number): void {
@@ -68,8 +78,15 @@ export class MockBatchScanner implements BatchScanner, MockBatchScannerApi {
 
   clearSheets(): void {
     this.queue = [];
+    this.pendingError = undefined;
     fs.rmSync(this.imageDirPath, { recursive: true, force: true });
     fs.mkdirSync(this.imageDirPath, { recursive: true });
+  }
+
+  setErrorQueued(errorQueued: boolean): void {
+    this.pendingError = errorQueued
+      ? new Error('simulated scanner error')
+      : undefined;
   }
 
   /* eslint-disable @typescript-eslint/require-await */
@@ -80,7 +97,12 @@ export class MockBatchScanner implements BatchScanner, MockBatchScannerApi {
     let index = 0;
 
     return {
-      async scanSheet(): Promise<ScannedSheetInfo | undefined> {
+      scanSheet: async (): Promise<ScannedSheetInfo | undefined> => {
+        if (this.pendingError) {
+          const error = this.pendingError;
+          this.pendingError = undefined;
+          throw error;
+        }
         if (index >= snapshot.length) {
           return undefined;
         }

--- a/libs/dev-dock/backend/src/dev_dock_api.test.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.test.ts
@@ -834,19 +834,24 @@ test('mock PDI scanner - odd-page PDF gets blank back', async () => {
 function createMockBatchScanner(imageDir: string): MockBatchScannerApi {
   let sheets: Array<{ frontPath: string; backPath: string }> = [];
   let copies = 1;
+  let errorQueued = false;
   return {
     imageDir,
     addSheets(newSheets) {
       sheets.push(...newSheets);
     },
     getStatus() {
-      return { sheetCount: sheets.length * copies };
+      return { sheetCount: sheets.length * copies, errorQueued };
     },
     clearSheets() {
       sheets = [];
+      errorQueued = false;
     },
     setCopies(newCopies) {
       copies = newCopies;
+    },
+    setErrorQueued(newErrorQueued) {
+      errorQueued = newErrorQueued;
     },
   };
 }
@@ -855,7 +860,28 @@ test('mock batch scanner - get status', async () => {
   const devDockDir = makeTemporaryDirectory({ prefix: 'dev-dock-test-' });
   const mockBatchScanner = createMockBatchScanner(devDockDir);
   const { apiClient } = setup({ mockBatchScanner }, devDockDir);
-  expect(await apiClient.batchScannerGetStatus()).toEqual({ sheetCount: 0 });
+  expect(await apiClient.batchScannerGetStatus()).toEqual({
+    sheetCount: 0,
+    errorQueued: false,
+  });
+});
+
+test('mock batch scanner - queue and cancel an error', async () => {
+  const devDockDir = makeTemporaryDirectory({ prefix: 'dev-dock-test-' });
+  const mockBatchScanner = createMockBatchScanner(devDockDir);
+  const { apiClient } = setup({ mockBatchScanner }, devDockDir);
+
+  await apiClient.batchScannerSetErrorQueued({ errorQueued: true });
+  expect(await apiClient.batchScannerGetStatus()).toEqual({
+    sheetCount: 0,
+    errorQueued: true,
+  });
+
+  await apiClient.batchScannerSetErrorQueued({ errorQueued: false });
+  expect(await apiClient.batchScannerGetStatus()).toEqual({
+    sheetCount: 0,
+    errorQueued: false,
+  });
 });
 
 test('mock batch scanner - set copies scales the queued sheets', async () => {
@@ -873,11 +899,13 @@ test('mock batch scanner - set copies scales the queued sheets', async () => {
   await apiClient.batchScannerSetCopies({ copies: 3 });
   expect(await apiClient.batchScannerGetStatus()).toEqual({
     sheetCount: singleCopySheetCount * 3,
+    errorQueued: false,
   });
 
   await apiClient.batchScannerSetCopies({ copies: 1 });
   expect(await apiClient.batchScannerGetStatus()).toEqual({
     sheetCount: singleCopySheetCount,
+    errorQueued: false,
   });
 });
 
@@ -907,7 +935,10 @@ test('mock batch scanner - clear ballots', async () => {
   );
 
   await apiClient.batchScannerClearBallots();
-  expect(await apiClient.batchScannerGetStatus()).toEqual({ sheetCount: 0 });
+  expect(await apiClient.batchScannerGetStatus()).toEqual({
+    sheetCount: 0,
+    errorQueued: false,
+  });
 });
 
 test('mock batch scanner - load image files as front/back pairs', async () => {
@@ -925,7 +956,10 @@ test('mock batch scanner - load image files as front/back pairs', async () => {
   await writeImageData(img2, createImageData(10, 10));
 
   await apiClient.batchScannerLoadBallots({ paths: [img1, img2] });
-  expect(await apiClient.batchScannerGetStatus()).toEqual({ sheetCount: 1 });
+  expect(await apiClient.batchScannerGetStatus()).toEqual({
+    sheetCount: 1,
+    errorQueued: false,
+  });
 });
 
 test('mock batch scanner - odd image gets a blank back', async () => {
@@ -940,7 +974,10 @@ test('mock batch scanner - odd image gets a blank back', async () => {
   await writeImageData(img, createImageData(10, 10));
 
   await apiClient.batchScannerLoadBallots({ paths: [img] });
-  expect(await apiClient.batchScannerGetStatus()).toEqual({ sheetCount: 1 });
+  expect(await apiClient.batchScannerGetStatus()).toEqual({
+    sheetCount: 1,
+    errorQueued: false,
+  });
 });
 
 test('mock batch scanner - single page PDF gets blank back', async () => {
@@ -952,7 +989,10 @@ test('mock batch scanner - single page PDF gets blank back', async () => {
   fs.writeFileSync(pdfPath, SINGLE_PAGE_PDF);
 
   await apiClient.batchScannerLoadBallots({ paths: [pdfPath] });
-  expect(await apiClient.batchScannerGetStatus()).toEqual({ sheetCount: 1 });
+  expect(await apiClient.batchScannerGetStatus()).toEqual({
+    sheetCount: 1,
+    errorQueued: false,
+  });
 });
 
 test('mock batch scanner - mock spec reports mockBatchScanner', async () => {

--- a/libs/dev-dock/backend/src/dev_dock_api.test.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.test.ts
@@ -833,16 +833,20 @@ test('mock PDI scanner - odd-page PDF gets blank back', async () => {
 
 function createMockBatchScanner(imageDir: string): MockBatchScannerApi {
   let sheets: Array<{ frontPath: string; backPath: string }> = [];
+  let copies = 1;
   return {
     imageDir,
     addSheets(newSheets) {
       sheets.push(...newSheets);
     },
     getStatus() {
-      return { sheetCount: sheets.length };
+      return { sheetCount: sheets.length * copies };
     },
     clearSheets() {
       sheets = [];
+    },
+    setCopies(newCopies) {
+      copies = newCopies;
     },
   };
 }
@@ -852,6 +856,29 @@ test('mock batch scanner - get status', async () => {
   const mockBatchScanner = createMockBatchScanner(devDockDir);
   const { apiClient } = setup({ mockBatchScanner }, devDockDir);
   expect(await apiClient.batchScannerGetStatus()).toEqual({ sheetCount: 0 });
+});
+
+test('mock batch scanner - set copies scales the queued sheets', async () => {
+  const devDockDir = makeTemporaryDirectory({ prefix: 'dev-dock-test-' });
+  const mockBatchScanner = createMockBatchScanner(devDockDir);
+  const { apiClient } = setup({ mockBatchScanner }, devDockDir);
+
+  await apiClient.batchScannerLoadBallots({
+    paths: [vxFamousNamesFixtures.markedBallotPath],
+  });
+  const { sheetCount: singleCopySheetCount } =
+    await apiClient.batchScannerGetStatus();
+  expect(singleCopySheetCount).toBeGreaterThan(0);
+
+  await apiClient.batchScannerSetCopies({ copies: 3 });
+  expect(await apiClient.batchScannerGetStatus()).toEqual({
+    sheetCount: singleCopySheetCount * 3,
+  });
+
+  await apiClient.batchScannerSetCopies({ copies: 1 });
+  expect(await apiClient.batchScannerGetStatus()).toEqual({
+    sheetCount: singleCopySheetCount,
+  });
 });
 
 test('mock batch scanner - load ballots from PDF', async () => {

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -65,6 +65,7 @@ export interface MockBatchScannerApi {
   addSheets(sheets: Array<{ frontPath: string; backPath: string }>): void;
   getStatus(): { sheetCount: number };
   clearSheets(): void;
+  setCopies(copies: number): void;
   readonly imageDir: string;
 }
 
@@ -525,6 +526,11 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
 
     batchScannerGetStatus(): { sheetCount: number } {
       return assertDefined(mockSpec.mockBatchScanner).getStatus();
+    },
+
+    batchScannerSetCopies(input: { copies: number }): void {
+      assert(Number.isInteger(input.copies) && input.copies >= 1);
+      assertDefined(mockSpec.mockBatchScanner).setCopies(input.copies);
     },
 
     async batchScannerLoadBallots(input: { paths: string[] }): Promise<void> {

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -63,9 +63,10 @@ import { execFile } from './utils';
 
 export interface MockBatchScannerApi {
   addSheets(sheets: Array<{ frontPath: string; backPath: string }>): void;
-  getStatus(): { sheetCount: number };
+  getStatus(): { sheetCount: number; errorQueued: boolean };
   clearSheets(): void;
   setCopies(copies: number): void;
+  setErrorQueued(errorQueued: boolean): void;
   readonly imageDir: string;
 }
 
@@ -524,13 +525,19 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
       }
     },
 
-    batchScannerGetStatus(): { sheetCount: number } {
+    batchScannerGetStatus(): { sheetCount: number; errorQueued: boolean } {
       return assertDefined(mockSpec.mockBatchScanner).getStatus();
     },
 
     batchScannerSetCopies(input: { copies: number }): void {
       assert(Number.isInteger(input.copies) && input.copies >= 1);
       assertDefined(mockSpec.mockBatchScanner).setCopies(input.copies);
+    },
+
+    batchScannerSetErrorQueued(input: { errorQueued: boolean }): void {
+      assertDefined(mockSpec.mockBatchScanner).setErrorQueued(
+        input.errorQueued
+      );
     },
 
     async batchScannerLoadBallots(input: { paths: string[] }): Promise<void> {

--- a/libs/dev-dock/frontend/src/dev_dock.test.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.test.tsx
@@ -10,6 +10,7 @@ import {
 } from 'vitest';
 import {
   cleanup,
+  fireEvent,
   render as renderWithoutTheme,
   screen,
   waitFor,
@@ -853,6 +854,7 @@ describe('batch scanner mock', () => {
     await waitFor(() => {
       expect(screen.queryByText(/sheet\(s\) queued/)).not.toBeInTheDocument();
     });
+    expect(clearButton).toBeDisabled();
   });
 
   test('ignores canceled open file dialog', async () => {
@@ -878,6 +880,41 @@ describe('batch scanner mock', () => {
       expect(kiosk.showOpenDialog).toHaveBeenCalled();
       mockApiClient.assertComplete();
     });
+  });
+
+  test('changing copies updates the queued sheet count', async () => {
+    mockApiClient.getMockSpec.reset();
+    mockApiClient.getMockSpec
+      .expectCallWith()
+      .resolves({ mockBatchScanner: true });
+    mockApiClient.batchScannerGetStatus
+      .expectRepeatedCallsWith()
+      .resolves({ sheetCount: 2 });
+
+    renderDock(mockApiClient);
+    await screen.findByText(/2 sheet\(s\) queued/);
+    const copiesInput = screen.getByRole('spinbutton', { name: 'Copies' });
+
+    mockApiClient.batchScannerSetCopies
+      .expectCallWith({ copies: 3 })
+      .resolves();
+    mockApiClient.batchScannerGetStatus
+      .expectRepeatedCallsWith()
+      .resolves({ sheetCount: 6 });
+    fireEvent.change(copiesInput, { target: { value: '3' } });
+
+    await screen.findByText(/6 sheet\(s\) queued/);
+
+    // Blanking the input falls back to a single copy
+    mockApiClient.batchScannerSetCopies
+      .expectCallWith({ copies: 1 })
+      .resolves();
+    mockApiClient.batchScannerGetStatus
+      .expectRepeatedCallsWith()
+      .resolves({ sheetCount: 2 });
+    fireEvent.change(copiesInput, { target: { value: '' } });
+
+    await screen.findByText(/2 sheet\(s\) queued/);
   });
 });
 

--- a/libs/dev-dock/frontend/src/dev_dock.test.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.test.tsx
@@ -818,7 +818,7 @@ describe('batch scanner mock', () => {
       .resolves({ mockBatchScanner: true });
     mockApiClient.batchScannerGetStatus
       .expectRepeatedCallsWith()
-      .resolves({ sheetCount: 0 });
+      .resolves({ sheetCount: 0, errorQueued: false });
 
     renderDock(mockApiClient);
     const loadButton = await screen.findByRole('button', {
@@ -836,7 +836,7 @@ describe('batch scanner mock', () => {
       .resolves();
     mockApiClient.batchScannerGetStatus
       .expectRepeatedCallsWith()
-      .resolves({ sheetCount: 2 });
+      .resolves({ sheetCount: 2, errorQueued: false });
     userEvent.click(loadButton);
 
     const queuedText = await screen.findByText(/2 sheet\(s\) queued/);
@@ -849,7 +849,7 @@ describe('batch scanner mock', () => {
     mockApiClient.batchScannerClearBallots.expectCallWith().resolves();
     mockApiClient.batchScannerGetStatus
       .expectRepeatedCallsWith()
-      .resolves({ sheetCount: 0 });
+      .resolves({ sheetCount: 0, errorQueued: false });
     userEvent.click(clearButton);
     await waitFor(() => {
       expect(screen.queryByText(/sheet\(s\) queued/)).not.toBeInTheDocument();
@@ -864,7 +864,7 @@ describe('batch scanner mock', () => {
       .resolves({ mockBatchScanner: true });
     mockApiClient.batchScannerGetStatus
       .expectRepeatedCallsWith()
-      .resolves({ sheetCount: 0 });
+      .resolves({ sheetCount: 0, errorQueued: false });
 
     renderDock(mockApiClient);
     const loadButton = await screen.findByRole('button', {
@@ -889,7 +889,7 @@ describe('batch scanner mock', () => {
       .resolves({ mockBatchScanner: true });
     mockApiClient.batchScannerGetStatus
       .expectRepeatedCallsWith()
-      .resolves({ sheetCount: 2 });
+      .resolves({ sheetCount: 2, errorQueued: false });
 
     renderDock(mockApiClient);
     await screen.findByText(/2 sheet\(s\) queued/);
@@ -900,7 +900,7 @@ describe('batch scanner mock', () => {
       .resolves();
     mockApiClient.batchScannerGetStatus
       .expectRepeatedCallsWith()
-      .resolves({ sheetCount: 6 });
+      .resolves({ sheetCount: 6, errorQueued: false });
     fireEvent.change(copiesInput, { target: { value: '3' } });
 
     await screen.findByText(/6 sheet\(s\) queued/);
@@ -911,10 +911,49 @@ describe('batch scanner mock', () => {
       .resolves();
     mockApiClient.batchScannerGetStatus
       .expectRepeatedCallsWith()
-      .resolves({ sheetCount: 2 });
+      .resolves({ sheetCount: 2, errorQueued: false });
     fireEvent.change(copiesInput, { target: { value: '' } });
 
     await screen.findByText(/2 sheet\(s\) queued/);
+  });
+
+  test('queue and cancel a simulated scanner error', async () => {
+    mockApiClient.getMockSpec.reset();
+    mockApiClient.getMockSpec
+      .expectCallWith()
+      .resolves({ mockBatchScanner: true });
+    mockApiClient.batchScannerGetStatus
+      .expectRepeatedCallsWith()
+      .resolves({ sheetCount: 0, errorQueued: false });
+
+    renderDock(mockApiClient);
+    const errorButton = await screen.findByRole('button', {
+      name: 'Queue Error',
+    });
+    expect(errorButton).toBeEnabled();
+
+    mockApiClient.batchScannerSetErrorQueued
+      .expectCallWith({ errorQueued: true })
+      .resolves();
+    mockApiClient.batchScannerGetStatus
+      .expectRepeatedCallsWith()
+      .resolves({ sheetCount: 0, errorQueued: true });
+    userEvent.click(errorButton);
+
+    const cancelButton = await screen.findByRole('button', {
+      name: 'Cancel Error',
+    });
+    expect(cancelButton).toBeEnabled();
+
+    mockApiClient.batchScannerSetErrorQueued
+      .expectCallWith({ errorQueued: false })
+      .resolves();
+    mockApiClient.batchScannerGetStatus
+      .expectRepeatedCallsWith()
+      .resolves({ sheetCount: 0, errorQueued: false });
+    userEvent.click(cancelButton);
+
+    await screen.findByRole('button', { name: 'Queue Error' });
   });
 });
 

--- a/libs/dev-dock/frontend/src/dev_dock.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.tsx
@@ -804,6 +804,13 @@ function BatchScannerMockControl() {
     onSuccess: async () =>
       await queryClient.invalidateQueries(['batchScannerGetStatus']),
   });
+  const setErrorQueuedMutation = useMutation(
+    apiClient.batchScannerSetErrorQueued,
+    {
+      onSuccess: async () =>
+        await queryClient.invalidateQueries(['batchScannerGetStatus']),
+    }
+  );
   const setCopiesMutation = useMutation(apiClient.batchScannerSetCopies, {
     onSuccess: async () =>
       await queryClient.invalidateQueries(['batchScannerGetStatus']),
@@ -812,6 +819,7 @@ function BatchScannerMockControl() {
 
   const status = getStatusQuery.data;
   const sheetCount = status?.sheetCount ?? 0;
+  const errorQueued = status?.errorQueued ?? false;
 
   return (
     <BatchScannerControls>
@@ -859,6 +867,14 @@ function BatchScannerMockControl() {
           disabled={sheetCount === 0}
         >
           Clear
+        </ScannerButton>
+        <ScannerButton
+          onClick={() =>
+            setErrorQueuedMutation.mutate({ errorQueued: !errorQueued })
+          }
+          disabled={setErrorQueuedMutation.isLoading}
+        >
+          {errorQueued ? 'Cancel Error' : 'Queue Error'}
         </ScannerButton>
       </ScannerControls>
     </BatchScannerControls>

--- a/libs/dev-dock/frontend/src/dev_dock.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.tsx
@@ -774,6 +774,20 @@ const ScannerControls = styled.div`
   gap: 8px;
 `;
 
+const CopiesInput = styled.input`
+  width: 70px;
+  padding: 8px;
+  border-radius: 8px;
+  border: 1px solid ${Colors.BORDER};
+  color: ${Colors.TEXT};
+`;
+
+const BatchScannerControls = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
 function BatchScannerMockControl() {
   const queryClient = useQueryClient();
   const apiClient = useApiClient();
@@ -790,42 +804,64 @@ function BatchScannerMockControl() {
     onSuccess: async () =>
       await queryClient.invalidateQueries(['batchScannerGetStatus']),
   });
+  const setCopiesMutation = useMutation(apiClient.batchScannerSetCopies, {
+    onSuccess: async () =>
+      await queryClient.invalidateQueries(['batchScannerGetStatus']),
+  });
+  const [copies, setCopies] = useState(1);
 
   const status = getStatusQuery.data;
   const sheetCount = status?.sheetCount ?? 0;
 
   return (
-    <div>
-      <strong>Batch Scanner:</strong>{' '}
-      <ScannerButton
-        onClick={async () => {
-          const dialogResult = await assertDefined(window.kiosk).showOpenDialog(
-            {
+    <BatchScannerControls>
+      <ScannerControls>
+        <strong>Batch Scanner:</strong>
+        <ScannerButton
+          onClick={async () => {
+            const dialogResult = await assertDefined(
+              window.kiosk
+            ).showOpenDialog({
               properties: ['openFile', 'multiSelections'],
               filters: [
                 { name: 'Ballots', extensions: ['pdf', 'jpg', 'jpeg', 'png'] },
               ],
+            });
+            if (dialogResult.canceled) return;
+            if (dialogResult.filePaths.length > 0) {
+              loadBallotsMutation.mutate({ paths: dialogResult.filePaths });
             }
-          );
-          if (dialogResult.canceled) return;
-          if (dialogResult.filePaths.length > 0) {
-            loadBallotsMutation.mutate({ paths: dialogResult.filePaths });
-          }
-        }}
-        disabled={loadBallotsMutation.isLoading}
-      >
-        {loadBallotsMutation.isLoading ? 'Loading...' : 'Load Ballots'}
-      </ScannerButton>
-      {sheetCount > 0 && (
-        <>
-          {' '}
-          {sheetCount} sheet(s) queued{' '}
-          <ScannerButton onClick={() => clearBallotsMutation.mutate()}>
-            Clear
-          </ScannerButton>
-        </>
-      )}
-    </div>
+          }}
+          disabled={loadBallotsMutation.isLoading}
+        >
+          {loadBallotsMutation.isLoading ? 'Loading...' : 'Load Ballots'}
+        </ScannerButton>
+        ×
+        <CopiesInput
+          aria-label="Copies"
+          type="number"
+          min={1}
+          value={copies}
+          onChange={(event) => {
+            const value = event.target.valueAsNumber;
+            const newCopies = Number.isNaN(value)
+              ? 1
+              : Math.max(1, Math.floor(value));
+            setCopies(newCopies);
+            setCopiesMutation.mutate({ copies: newCopies });
+          }}
+        />
+      </ScannerControls>
+      <ScannerControls>
+        {sheetCount > 0 && <span>{sheetCount} sheet(s) queued</span>}
+        <ScannerButton
+          onClick={() => clearBallotsMutation.mutate()}
+          disabled={sheetCount === 0}
+        >
+          Clear
+        </ScannerButton>
+      </ScannerControls>
+    </BatchScannerControls>
   );
 }
 


### PR DESCRIPTION
## Overview
Ports over two dev dock mock batch scanner features from `ca-demo`

- Sheets Multiplier - On `ca-demo` I had this as an environment variable which was sort of annoying to use in practice and a bit heavy handed in the implementation. Here I instead add a number input to the devdock so you can now more easily control how many sheets you scan at once. This is helpful because in the batch scanner we often want to test how the UI will work when scanning a large number of sheets not just 1 and manually queuing a large number is obviously hard. 
- Queue Error - I had a bug in `ca-demo` where when the scanner implementation threw an error on scanSheet the app would explode, this adds the ability to simulate scanSheet throwing an error. On main the app just stops scanning and otherwise does nothing which is a little uneventful but I still think its good to keep this edge case in mind and be able to test it. 

## Demo Video or Screenshot

https://github.com/user-attachments/assets/f124f883-834d-49d7-b30b-35db4adcb223


## Testing Plan
See video 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
