### PR TITLE
Convert percentage coverage thresholds to absolute

### DIFF
--- a/apps/central-scan/frontend/vitest.config.ts
+++ b/apps/central-scan/frontend/vitest.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
     setupFiles: ['react-app-polyfill/jsdom', 'src/setupTests.ts'],
     coverage: {
       thresholds: {
-        lines: 95,
-        branches: 90,
+        lines: -18,
+        branches: -14,
       },
       exclude: [
         'src/config',

--- a/apps/design/frontend/vitest.config.ts
+++ b/apps/design/frontend/vitest.config.ts
@@ -9,8 +9,8 @@ export default defineConfig({
 
     coverage: {
       thresholds: {
-        lines: 97,
-        branches: 90,
+        lines: -63,
+        branches: -169,
       },
       exclude: [
         'src/**/*.d.ts',

--- a/apps/mark-scan/frontend/vitest.config.ts
+++ b/apps/mark-scan/frontend/vitest.config.ts
@@ -17,8 +17,8 @@ export default defineConfig({
         'src/electrical_testing/**', // TODO: Add tests for this directory and remove this exclude
       ],
       thresholds: {
-        lines: 97,
-        branches: 96,
+        lines: -13,
+        branches: -6,
       },
     },
     alias: [

--- a/apps/mark/backend/vitest.config.ts
+++ b/apps/mark/backend/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     ],
     coverage: {
       thresholds: {
-        lines: 98,
+        lines: -1,
         branches: -5,
       },
       exclude: [

--- a/apps/mark/frontend/vitest.config.ts
+++ b/apps/mark/frontend/vitest.config.ts
@@ -19,8 +19,8 @@ export default defineConfig({
         '**/*.test.{ts,tsx}',
       ],
       thresholds: {
-        lines: 99,
-        branches: 98,
+        lines: -5,
+        branches: -5,
       },
     },
     alias: [

--- a/apps/pollbook/backend/vitest.config.ts
+++ b/apps/pollbook/backend/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     clearMocks: true,
     coverage: {
       thresholds: {
-        lines: 92,
-        branches: 87,
+        lines: -128,
+        branches: -101,
       },
       exclude: [
         '**/node_modules/**',

--- a/apps/pollbook/frontend/vitest.config.ts
+++ b/apps/pollbook/frontend/vitest.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
 
     coverage: {
       thresholds: {
-        lines: 94,
-        branches: 89,
+        lines: -64,
+        branches: -86,
       },
       exclude: [
         'src/**/*.d.ts',

--- a/apps/print/frontend/vitest.config.ts
+++ b/apps/print/frontend/vitest.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
 
     coverage: {
       thresholds: {
-        lines: 46,
-        branches: 37,
+        lines: -318,
+        branches: -195,
       },
       exclude: [
         'src/**/*.d.ts',

--- a/apps/scan/frontend/vitest.config.ts
+++ b/apps/scan/frontend/vitest.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
 
     coverage: {
       thresholds: {
-        lines: 95,
-        branches: 91,
+        lines: -52,
+        branches: -53,
       },
       exclude: [
         'src/config/*',

--- a/libs/auth/vitest.config.ts
+++ b/libs/auth/vitest.config.ts
@@ -13,8 +13,8 @@ export default defineConfig({
         'src/test_utils.ts',
       ],
       thresholds: {
-        lines: 98,
-        branches: 94,
+        lines: -1,
+        branches: -36,
       },
     },
   },

--- a/libs/basics/vitest.config.ts
+++ b/libs/basics/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: 100,
-        branches: 99,
+        branches: -1,
       },
     },
   },

--- a/libs/dev-dock/frontend/vitest.config.ts
+++ b/libs/dev-dock/frontend/vitest.config.ts
@@ -6,8 +6,8 @@ export default defineConfig({
     setupFiles: ['src/setupTests.ts'],
     coverage: {
       thresholds: {
-        lines: 87,
-        branches: 71,
+        lines: -21,
+        branches: -30,
       },
     },
   },

--- a/libs/grout/vitest.config.ts
+++ b/libs/grout/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: 100,
-        branches: 98,
+        branches: -1,
       },
     },
   },

--- a/libs/hmpb/vitest.config.ts
+++ b/libs/hmpb/vitest.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
     setupFiles: ['test/setupTests.ts'],
     coverage: {
       thresholds: {
-        lines: 92,
-        branches: 83,
+        lines: -79,
+        branches: -128,
       },
       exclude: [
         '**/*.test.ts',

--- a/libs/mark-flow-ui/vitest.config.mts
+++ b/libs/mark-flow-ui/vitest.config.mts
@@ -6,8 +6,8 @@ export default defineConfig({
     setupFiles: ['./src/setupTests.ts'],
     coverage: {
       thresholds: {
-        lines: 99,
-        branches: 96,
+        lines: -2,
+        branches: -10,
       },
       exclude: ['**/*.stories.tsx', '**/*.test.tsx', '**/*.test.ts'],
     },

--- a/libs/monorepo-utils/vitest.config.ts
+++ b/libs/monorepo-utils/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: 100,
-        branches: 97,
+        branches: -1,
       },
     },
   },

--- a/libs/printing/vitest.config.ts
+++ b/libs/printing/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: 100,
-        branches: 99,
+        branches: -1,
       },
     },
     alias: [

--- a/libs/types/vitest.config.ts
+++ b/libs/types/vitest.config.ts
@@ -4,8 +4,8 @@ export default defineConfig({
   test: {
     coverage: {
       thresholds: {
-        lines: 99,
-        branches: -25,
+        lines: -3,
+        branches: -22,
       },
     },
   },

--- a/libs/usb-drive/vitest.config.ts
+++ b/libs/usb-drive/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
       exclude: ['src/cli.ts', 'src/**/*.test.ts'],
       thresholds: {
         lines: 100,
-        branches: 98,
+        branches: 100,
       },
     },
   },


### PR DESCRIPTION
🤖 Generated with Claude Code

## Overview

Vitest coverage thresholds across the monorepo were a mix of percentage form (e.g. `lines: 95`) and absolute negative form (e.g. `lines: -52`, meaning at most 52 uncovered lines). Percentage thresholds below 100% let the absolute amount of uncovered code grow as a package grows, silently eroding coverage. This PR converts every remaining percentage threshold (19 packages) to the absolute form, set to exactly current coverage so any new uncovered line or branch fails CI.

Values were generated with vitest's `coverage.thresholds.autoUpdate` setting. A follow-up PR will enable `autoUpdate` everywhere so thresholds ratchet automatically.

Notes:

- `100` stays `100` (`-0` doesn't work — vitest only treats negative values as absolute)
- the two intentionally-exempt packages with `0` thresholds are untouched
- `usb-drive` branches went 98 → `100` because its branch coverage is genuinely 100% now

## Demo Video or Screenshot

N/A

## Testing Plan

Ran coverage in all 19 converted packages against the new thresholds.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
