### PR TITLE
libs/db: insert the vacuum test's fixture rows in one transaction

### DIFF
--- a/libs/db/src/client.test.ts
+++ b/libs/db/src/client.test.ts
@@ -402,9 +402,10 @@ test('vacuuming reduces file size', () => {
 
   const preInsertSize = fs.statSync(dbFile).size;
 
-  for (let i = 0; i < 1000; i += 1) {
-    client.run(
-      `
+  client.transaction(() => {
+    for (let i = 0; i < 1000; i += 1) {
+      client.run(
+        `
       insert into users (
         id,
         name,
@@ -414,12 +415,13 @@ test('vacuuming reduces file size', () => {
         ?, ?, ?, ?
       )
     `,
-      `user-${i}`,
-      'User',
-      'user@email.org',
-      'hash'
-    );
-  }
+        `user-${i}`,
+        'User',
+        'user@email.org',
+        'hash'
+      );
+    }
+  });
 
   const postInsertSize = fs.statSync(dbFile).size;
   client.run('delete from users');


### PR DESCRIPTION
## Overview

`libs/db`'s `vacuuming reduces file size` test is the slowest test in the package and flakes on CI. It inserts 1000 rows so the database is big enough for vacuuming to be measurable, but it did that with 1000 separate `client.run()` calls — each its own implicit transaction, each fsyncing. That loop is the entire cost of the test; the vacuum itself takes milliseconds.

Wrapping the loop in the `client.transaction()` the class already provides fixes it.

| | test time |
| --- | --- |
| before | 2480 ms |
| after | **31 ms** |

**Nothing about what the test checks changes.** The file sizes are byte-identical at every step — pre-insert 12288, post-insert 102400, post-vacuum 12288 — so all four assertions hold exactly as they did.

## Why not just raise the timeout

The shared vitest config caps tests at 10s in CI (`testTimeout: isCI ? 10_000 : undefined`) and `libs/db` sets no per-test override. Locally the test takes ~2.5s, but on CI runners it has been observed at 11954 ms and 14564 ms — 4.7-5.8x slower — so it fails whenever a runner is contended, which has now flaked two separate PRs in the ESM migration stack.

A per-test timeout would have to be 30s+ to cover the worst run seen, which is only ~2x headroom over an already-slow test. At 31 ms the problem is eliminated rather than deferred.

## Alternatives considered

**Assert SQLite's own counters instead of filesystem size.** With 50 rows: `page_count` 53 → 3 and `freelist_count` 50 → 0 after vacuuming, in 12 ms. That is arguably a more precise statement of what vacuuming does, and it is page-granular rather than dependent on filesystem block allocation. Not taken here because `postVacuumSize === preInsertSize` on the real file is the user-visible property the test's name claims, and it is worth keeping. Would make a reasonable addition rather than a replacement.

**A single large blob row instead of many rows.** Equally fast, but one fat row does not represent the many-deleted-rows case this test exists for.

## Demo Video or Screenshot

N/A — test-only change.

## Testing Plan

Full `libs/db` suite passes 13/13 with coverage unchanged at 100% statements, branches and lines; `lint` and `tsc` clean.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added logging where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
