### PR TITLE
VxDesign: order candidate party ids deterministically

### DIFF
--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -3198,7 +3198,15 @@ test('cloneElection', async () => {
               expect.objectContaining({
                 ...candidate,
                 id: expectNotEqualTo(candidate.id),
-                partyIds: candidate.partyIds?.map(updatedPartyId).sort(),
+                partyIds: candidate.partyIds
+                  ?.map(updatedPartyId)
+                  .sort((a, b) => {
+                    const aName = destParties.find((p) => p.id === a)?.name;
+                    const bName = destParties.find((p) => p.id === b)?.name;
+                    assert(typeof aName === 'string', `no party with id: ${a}`);
+                    assert(typeof bName === 'string', `no party with id: ${b}`);
+                    return aName.localeCompare(bName);
+                  }),
               })
             ),
           };

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -1095,10 +1095,13 @@ export class Store {
               first_name as "firstName",
               middle_name as "middleName",
               last_name as "lastName",
-              array_remove(array_agg(candidates_parties.party_id ORDER BY candidates_parties.party_id), NULL) as "partyIds"
+              -- Order by name for a deterministic order (party ids are
+              -- randomly generated, so ordering by them varies per import)
+              array_remove(array_agg(candidates_parties.party_id ORDER BY parties.name), NULL) as "partyIds"
             from candidates
             join contests on candidates.contest_id = contests.id
             left join candidates_parties on candidates_parties.candidate_id = candidates.id
+            left join parties on parties.id = candidates_parties.party_id
             where contests.election_id = $1
             group by candidates.id
             order by candidates.ballot_order


### PR DESCRIPTION
## Overview

Multi-party candidates' party order (e.g. "Democratic, Republican" on NH ballot previews) is nondeterministic: party ids are randomly generated per import, and the candidate read query aggregates them `ORDER BY candidates_parties.party_id`. This makes ballot preview/export content — and the image snapshots in `app.state_nh.test.ts` — a per-run coin flip (reproduced locally; surfaced by snapshot regeneration in #9078).

Fix: order the aggregation by `parties.name`, matching how the parties list itself is already ordered in the store. If NH source data implies a legally significant endorsement order, preserving it would instead need an ordinal column on `candidates_parties` — flagging for reviewer judgment; alphabetical seemed like the right-sized fix versus a schema migration.

Note: the same commit is currently also on #9078 to keep its CI green; it will merge cleanly whichever lands first.

## Demo Video or Screenshot

n/a — no visual change other than making the party order stable (alphabetical by name).

## Testing Plan

- `app.state_nh.test.ts` previously flipped between passing and failing across runs; with this change it passes consistently (verified across repeated runs).
- Full design backend suite passes (192 tests).

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
