### PR TITLE
fix(backend): tear down JSONL entry stream on early exit

### DIFF
--- a/libs/backend/src/election_package/election_package_io.ts
+++ b/libs/backend/src/election_package/election_package_io.ts
@@ -3,6 +3,7 @@ import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
 import { createReadStream } from 'node:fs';
 import { pipeline } from 'node:stream/promises';
+import { Readable } from 'node:stream';
 import readline from 'node:readline';
 import yauzl from 'yauzl';
 import {
@@ -413,23 +414,38 @@ export async function* streamElectionPackageJsonlEntry<T>(
 ): AsyncIterable<T[]> {
   if (!electionPackageZip.hasEntry(entryName)) return;
 
-  const fileLines = readline.createInterface(
-    await electionPackageZip.openEntryStream(entryName)
-  );
-  let batch: T[] = [];
-  let batchChars = 0;
-  for await (const line of fileLines) {
-    if (line.trim().length === 0) continue;
-    batch.push(safeParseJson(line, schema).unsafeUnwrap());
-    batchChars += line.length;
-    if (batchChars >= STREAM_BATCH_MAX_CHARS) {
-      yield batch;
-      batch = [];
-      batchChars = 0;
+  const entryStream = await electionPackageZip.openEntryStream(entryName);
+  const fileLines = readline.createInterface(entryStream);
+  try {
+    let batch: T[] = [];
+    let batchChars = 0;
+    for await (const line of fileLines) {
+      if (line.trim().length === 0) continue;
+      batch.push(safeParseJson(line, schema).unsafeUnwrap());
+      batchChars += line.length;
+      if (batchChars >= STREAM_BATCH_MAX_CHARS) {
+        yield batch;
+        batch = [];
+        batchChars = 0;
+      }
     }
-  }
-  if (batch.length > 0) {
-    yield batch;
+    if (batch.length > 0) {
+      yield batch;
+    }
+  } finally {
+    // Tear down the underlying entry stream on ANY exit — a mid-stream parse
+    // throw (invalid line), an early caller `break`, or normal completion.
+    // Without this the readline input is left open when the generator throws;
+    // when the surrounding zip is then closed the abandoned stream can emit an
+    // 'error' with no listener — an intermittent unhandled rejection that fails
+    // the run (surfaced by scan-backend's "invalid audio clip" test). Destroying
+    // an already-ended stream is a no-op, so the happy path is unaffected.
+    fileLines.close();
+    // The interface type is NodeJS.ReadableStream (no `destroy`), but the
+    // concrete streams are always node Readables; narrow before tearing down.
+    if (entryStream instanceof Readable) {
+      entryStream.destroy();
+    }
   }
 }
 


### PR DESCRIPTION
## Overview

My review patch on #9020 (@carolinemodic), which added `streamElectionPackageJsonlEntry`, opened a `readline` interface over an election-package entry stream but never tore the underlying stream down when iteration ends early. When a line fails to parse (a malformed JSONL entry) the generator throws and abandons the stream; when the surrounding `withElectionPackageZip` then closes the zip, the still-open stream can emit an `'error'` with no listener — an intermittent unhandled rejection that fails the whole `vitest run` even though every test passes.

This wraps the loop in `try/finally` and destroys the entry stream on every exit path (a parse throw, an early `break`, or normal completion). Destroying an already-ended stream is a no-op, so the happy path is unchanged. (`NodeJS.ReadableStream` doesn't expose `destroy`, but the concrete streams are always node `Readable`s, so it's narrowed with `instanceof`.)

It surfaced as a flaky `scan-backend` failure: the "cleans up when audio clip streaming fails during configure" test feeds an invalid audio-clip line and expects `configureFromElectionPackageOnUsbDrive()` to reject. The rejection propagates as expected, but the abandoned audio-clip stream's late `'error'` intermittently crashed the run. (Found while stress-testing a moon-based CI setup, which runs each package's tests uncached and exposed the latent leak.)

## Demo Video or Screenshot

N/A — internal reliability fix.

## Testing Plan

Verified locally that `@votingworks/backend` (358 tests), `scan-backend` (227), and `admin-backend` (461) all pass with the change, and that the streaming happy path (audio clips loaded during configure) is unaffected. The fix is deterministic stream teardown; the underlying flake is intermittent, so a few green CI runs are worth watching to confirm.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCP6JwwE4jnauufFdzTWQc
