### PR TITLE
VxMark/VxMarkScan: end cardless voter sessions when the configuration changes

### DIFF
--- a/apps/mark-scan/backend/src/app.auth.test.ts
+++ b/apps/mark-scan/backend/src/app.auth.test.ts
@@ -9,7 +9,11 @@ import {
 } from '@votingworks/types';
 import * as grout from '@votingworks/grout';
 
-import { InsertedSmartCardAuthApi } from '@votingworks/auth';
+import { assertDefined } from '@votingworks/basics';
+import {
+  InsertedSmartCardAuthApi,
+  InsertedSmartCardAuthMachineState,
+} from '@votingworks/auth';
 import { Server } from 'node:http';
 import {
   BooleanEnvironmentVariableName,
@@ -153,6 +157,45 @@ test('endCardlessVoterSession', async () => {
     machineType,
   });
   expect(stateMachine.reset).toHaveBeenCalled();
+});
+
+test('changing a relevant setting force ends any cardless voter session', async () => {
+  vi.spyOn(stateMachine, 'reset');
+
+  await configureApp(apiClient, mockAuth, mockUsbDrive, systemSettings);
+  const authMachineState: InsertedSmartCardAuthMachineState = {
+    ...systemSettings.auth,
+    electionKey,
+    jurisdiction,
+    machineType,
+  };
+
+  await apiClient.setTestMode({ isTestMode: false });
+  expect(mockAuth.endCardlessVoterSession).toHaveBeenNthCalledWith(
+    1,
+    authMachineState
+  );
+
+  const pollingPlace = assertDefined(election.pollingPlaces?.[0]);
+  await apiClient.setPollingPlaceId({ id: pollingPlace.id });
+  expect(mockAuth.endCardlessVoterSession).toHaveBeenNthCalledWith(
+    2,
+    authMachineState
+  );
+
+  // Ended before the store is reset, so the machine state still describes the
+  // election the session was started for.
+  await apiClient.unconfigureMachine();
+  expect(mockAuth.endCardlessVoterSession).toHaveBeenNthCalledWith(
+    3,
+    authMachineState
+  );
+
+  expect(mockAuth.endCardlessVoterSession).toHaveBeenCalledTimes(3);
+
+  // Ending a session this way is about the configuration, not about a voter
+  // being finished with the machine, so the paper handler is left as it is.
+  expect(stateMachine.reset).not.toHaveBeenCalled();
 });
 
 test('getAuthStatus before election definition has been configured', async () => {

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -83,6 +83,10 @@ export function buildApi(
 ) {
   const { store } = workspace;
 
+  function endCardlessVoterSessionIfAny() {
+    auth.endCardlessVoterSession(constructAuthMachineState(workspace));
+  }
+
   return grout.createApi({
     getMachineConfig,
 
@@ -135,7 +139,7 @@ export function buildApi(
 
     endCardlessVoterSession() {
       stateMachine?.reset();
-      return auth.endCardlessVoterSession(constructAuthMachineState(workspace));
+      endCardlessVoterSessionIfAny();
     },
 
     getElectionRecord(): ElectionRecord | null {
@@ -147,6 +151,7 @@ export function buildApi(
     },
 
     async unconfigureMachine() {
+      endCardlessVoterSessionIfAny();
       workspace.store.reset();
       await logger.logAsCurrentRole(LogEventId.ElectionUnconfigured, {
         disposition: 'success',
@@ -387,6 +392,7 @@ export function buildApi(
         message: `Toggling from ${logMessage} mode`,
         isTestMode: input.isTestMode,
       });
+      endCardlessVoterSessionIfAny();
       store.setTestMode(input.isTestMode);
       store.setPollsState('polls_closed_initial');
       store.setBallotsPrintedCount(0);
@@ -406,6 +412,7 @@ export function buildApi(
       const { election } = electionDefinition;
       const { name } = pollingPlaceFromElection(election, input.id);
 
+      endCardlessVoterSessionIfAny();
       store.setPollingPlaceId(input.id);
       store.setBallotsPrintedCount(0);
 

--- a/apps/mark-scan/integration-testing/e2e/support/auth.ts
+++ b/apps/mark-scan/integration-testing/e2e/support/auth.ts
@@ -13,5 +13,4 @@ export const {
 } = buildInsertedSmartCardAuthHelpers({
   appName: 'VxMarkScan',
   pinDigitSelector: 'text',
-  endsCardlessVoterSession: true,
 });

--- a/apps/mark-scan/integration-testing/e2e/support/auth.ts
+++ b/apps/mark-scan/integration-testing/e2e/support/auth.ts
@@ -13,4 +13,5 @@ export const {
 } = buildInsertedSmartCardAuthHelpers({
   appName: 'VxMarkScan',
   pinDigitSelector: 'text',
+  allowsCardlessVoterSessions: true,
 });

--- a/apps/mark/backend/src/app.auth.test.ts
+++ b/apps/mark/backend/src/app.auth.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { DateTime } from 'luxon';
+import { assertDefined } from '@votingworks/basics';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import {
   DEFAULT_SYSTEM_SETTINGS,
@@ -12,7 +13,10 @@ import {
   BooleanEnvironmentVariableName,
   getFeatureFlagMock,
 } from '@votingworks/utils';
-import { generateSignedHashValidationQrCodeValue } from '@votingworks/auth';
+import {
+  generateSignedHashValidationQrCodeValue,
+  InsertedSmartCardAuthMachineState,
+} from '@votingworks/auth';
 import { LogEventId } from '@votingworks/logging';
 import { configureApp, createApp } from '../test/app_helpers.js';
 
@@ -138,6 +142,40 @@ test('endCardlessVoterSession', async () => {
     jurisdiction,
     machineType,
   });
+});
+
+test('changing a relevant setting force ends any cardless voter session', async () => {
+  const { apiClient, mockAuth, mockUsbDrive } = createApp();
+  await configureApp(apiClient, mockAuth, mockUsbDrive, systemSettings);
+  const authMachineState: InsertedSmartCardAuthMachineState = {
+    ...systemSettings.auth,
+    electionKey,
+    jurisdiction,
+    machineType,
+  };
+
+  await apiClient.setTestMode({ isTestMode: false });
+  expect(mockAuth.endCardlessVoterSession).toHaveBeenNthCalledWith(
+    1,
+    authMachineState
+  );
+
+  const pollingPlace = assertDefined(election.pollingPlaces?.[0]);
+  await apiClient.setPollingPlaceId({ id: pollingPlace.id });
+  expect(mockAuth.endCardlessVoterSession).toHaveBeenNthCalledWith(
+    2,
+    authMachineState
+  );
+
+  // Ended before the store is reset, so the machine state still describes the
+  // election the session was started for.
+  await apiClient.unconfigureMachine();
+  expect(mockAuth.endCardlessVoterSession).toHaveBeenNthCalledWith(
+    3,
+    authMachineState
+  );
+
+  expect(mockAuth.endCardlessVoterSession).toHaveBeenCalledTimes(3);
 });
 
 test('getAuthStatus before election definition has been configured', async () => {

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -171,6 +171,10 @@ export function buildApi(ctx: Context) {
       auth.getAuthStatus(constructAuthMachineState(workspace)),
   });
 
+  function endCardlessVoterSessionIfAny() {
+    auth.endCardlessVoterSession(constructAuthMachineState(workspace));
+  }
+
   return grout.createApi({
     getMachineConfig,
 
@@ -256,7 +260,7 @@ export function buildApi(ctx: Context) {
     },
 
     endCardlessVoterSession() {
-      return auth.endCardlessVoterSession(constructAuthMachineState(workspace));
+      endCardlessVoterSessionIfAny();
     },
 
     getElectionRecord(): ElectionRecord | null {
@@ -268,6 +272,7 @@ export function buildApi(ctx: Context) {
     },
 
     async unconfigureMachine() {
+      endCardlessVoterSessionIfAny();
       workspace.store.reset();
       // Re-enable USB ports in case they were auto-disabled while an alarm was
       // active (see setup_printer_page). Otherwise they remain silently
@@ -531,6 +536,7 @@ export function buildApi(ctx: Context) {
     },
 
     setTestMode(input: { isTestMode: boolean }) {
+      endCardlessVoterSessionIfAny();
       store.setTestMode(input.isTestMode);
       store.setPollsState('polls_closed_initial');
       store.setBallotsPrintedCount(0);
@@ -545,6 +551,7 @@ export function buildApi(ctx: Context) {
       const { election } = electionDefinition;
       const { name } = pollingPlaceFromElection(election, input.id);
 
+      endCardlessVoterSessionIfAny();
       store.setPollingPlaceId(input.id);
       store.setBallotsPrintedCount(0);
 

--- a/apps/mark/integration-testing/e2e/support/auth.ts
+++ b/apps/mark/integration-testing/e2e/support/auth.ts
@@ -9,5 +9,4 @@ export const {
   forceLogOutAndResetElectionDefinition,
 } = buildInsertedSmartCardAuthHelpers({
   appName: 'VxMark',
-  endsCardlessVoterSession: true,
 });

--- a/apps/mark/integration-testing/e2e/support/auth.ts
+++ b/apps/mark/integration-testing/e2e/support/auth.ts
@@ -9,4 +9,5 @@ export const {
   forceLogOutAndResetElectionDefinition,
 } = buildInsertedSmartCardAuthHelpers({
   appName: 'VxMark',
+  allowsCardlessVoterSessions: true,
 });

--- a/libs/auth/src/inserted_smart_card_auth.test.ts
+++ b/libs/auth/src/inserted_smart_card_auth.test.ts
@@ -1448,6 +1448,26 @@ test('skipPollWorkerCheck does not work when logged in as non-poll-worker', asyn
   });
 });
 
+test('Ending a cardless voter session when there is no session is a no-op', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: { ...defaultConfig, allowCardlessVoterSessions: true },
+    logger: mockLogger,
+  });
+
+  await logInAsElectionManager(auth);
+  vi.mocked(mockLogger.log).mockClear();
+
+  auth.endCardlessVoterSession();
+
+  expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
+    status: 'logged_in',
+    user: electionManagerUser,
+    sessionExpiresAt: expect.any(Date),
+  });
+  expect(mockLogger.log).not.toHaveBeenCalled();
+});
+
 test('Attempting to start a cardless voter session when not allowed by config', async () => {
   const auth = new InsertedSmartCardAuth({
     card: mockCard,

--- a/libs/auth/src/inserted_smart_card_auth.ts
+++ b/libs/auth/src/inserted_smart_card_auth.ts
@@ -319,6 +319,13 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
   endCardlessVoterSession(): void {
     assert(this.config.allowCardlessVoterSessions);
 
+    // Callers that end a session defensively - e.g. on unconfigure, where a
+    // dangling session is invisible to them because an election manager is
+    // logged in - shouldn't produce a logout event when there was no session.
+    if (!this.cardlessVoterUser) {
+      return;
+    }
+
     this.cardlessVoterUser = undefined;
 
     this.logger.log(LogEventId.AuthLogout, 'cardless_voter', {

--- a/libs/integration-test-utils/src/auth.ts
+++ b/libs/integration-test-utils/src/auth.ts
@@ -47,12 +47,6 @@ export interface InsertedSmartCardAuthConfig {
    * the others render them as buttons.
    */
   pinDigitSelector?: 'button' | 'text';
-  /**
-   * Whether `forceLogOutAndResetElectionDefinition` should first end a lingering
-   * cardless voter session. VxMark and VxMarkScan need this; see the workaround
-   * note on the internal `endCardlessVoterSession`.
-   */
-  endsCardlessVoterSession?: boolean;
 }
 
 export interface InsertedSmartCardAuthHelpers {
@@ -70,11 +64,7 @@ export interface InsertedSmartCardAuthHelpers {
 export function buildInsertedSmartCardAuthHelpers(
   config: InsertedSmartCardAuthConfig
 ): InsertedSmartCardAuthHelpers {
-  const {
-    appName,
-    pinDigitSelector = 'button',
-    endsCardlessVoterSession: endsSession = false,
-  } = config;
+  const { appName, pinDigitSelector = 'button' } = config;
 
   async function enterPin(page: Page): Promise<void> {
     await page.getByText('Enter Card PIN').waitFor();
@@ -109,23 +99,9 @@ export function buildInsertedSmartCardAuthHelpers(
     await postToApiOrThrow(page, 'logOut');
   }
 
-  /**
-   * Ends any active cardless voter session, bypassing the UI. Needed before
-   * unconfiguring: a session left active when the machine is unconfigured (and
-   * later reconfigured with a different election) references a now-missing
-   * ballot style and crashes the app on boot. Workaround for
-   * https://github.com/votingworks/vxsuite/issues/8553 — remove once fixed.
-   */
-  async function endCardlessVoterSession(page: Page): Promise<void> {
-    await postToApiOrThrow(page, 'endCardlessVoterSession');
-  }
-
   async function forceLogOutAndResetElectionDefinition(
     page: Page
   ): Promise<void> {
-    if (endsSession) {
-      await endCardlessVoterSession(page);
-    }
     await forceLogOut(page);
     await page.goto('/');
     mockCardRemoval();

--- a/libs/integration-test-utils/src/auth.ts
+++ b/libs/integration-test-utils/src/auth.ts
@@ -47,6 +47,15 @@ export interface InsertedSmartCardAuthConfig {
    * the others render them as buttons.
    */
   pinDigitSelector?: 'button' | 'text';
+  /**
+   * Whether the app's auth allows cardless voter sessions (VxMark and
+   * VxMarkScan). Resetting those apps has to end any active voter session
+   * explicitly: `logOut` only ends the session belonging to a card, so a
+   * cardless voter session leaves the machine reporting a logged-in voter with
+   * no card inserted. Apps that don't allow such sessions can't make the call
+   * at all - their auth asserts on it.
+   */
+  allowsCardlessVoterSessions?: boolean;
 }
 
 export interface InsertedSmartCardAuthHelpers {
@@ -64,7 +73,11 @@ export interface InsertedSmartCardAuthHelpers {
 export function buildInsertedSmartCardAuthHelpers(
   config: InsertedSmartCardAuthConfig
 ): InsertedSmartCardAuthHelpers {
-  const { appName, pinDigitSelector = 'button' } = config;
+  const {
+    appName,
+    pinDigitSelector = 'button',
+    allowsCardlessVoterSessions = false,
+  } = config;
 
   async function enterPin(page: Page): Promise<void> {
     await page.getByText('Enter Card PIN').waitFor();
@@ -102,6 +115,11 @@ export function buildInsertedSmartCardAuthHelpers(
   async function forceLogOutAndResetElectionDefinition(
     page: Page
   ): Promise<void> {
+    // Has to happen before waitForLoggedOut below: a cardless voter session
+    // outlives logOut, leaving the machine logged in as a voter with no card.
+    if (allowsCardlessVoterSessions) {
+      await postToApiOrThrow(page, 'endCardlessVoterSession');
+    }
     await forceLogOut(page);
     await page.goto('/');
     mockCardRemoval();


### PR DESCRIPTION
## Overview

Fixes #8553.

A cardless voter session lives in the auth state machine rather than the store, and `getAuthStatus` hides it while an election manager is logged in. Unconfiguring the machine mid-session therefore left the session alive: reconfiguring with an election that lacked that ballot style crashed the app on boot with `ballot style not found` and rendered the error boundary. Switching test mode or polling place had the same problem — the session resumed against a configuration it wasn't started for.

VxMark and VxMarkScan are affected identically and get the same treatment: both backends now end any active cardless voter session wherever the machine's configuration changes — `unconfigureMachine`, `setTestMode`, and `setPollingPlaceId`.

One small tweak in `libs/auth`: `endCardlessVoterSession` is now a no-op when no session is active. The callers above can't tell whether a session exists — that's the nature of the bug — so without this they'd emit `AuthLogout` events for voters who never had a session.

On the integration-testing side, the shared reset helper keeps ending voter sessions explicitly, but no longer as a workaround for this issue. It's needed permanently: the helper waits for the machine to report `logged_out` before inserting the next card, and `logOut` only ends the session belonging to a card — a cardless voter session keeps the machine reporting a logged-in voter with no card inserted. The flag that gates the call is renamed to reflect that it tracks the app's auth config (only VxMark and VxMarkScan allow such sessions; other apps' auth asserts on the call).

## Demo Video or Screenshot

N/A

## Testing Plan

Unit tests cover the new behavior in both backends (the session is ended on each configuration change) and in `libs/auth` (ending a session when none is active changes no state and logs nothing). The VxMark and VxMarkScan integration suites exercise the reset path.

To verify by hand on VxMark: configure with election A, open polls, start a voter session, then unconfigure with an election manager card and reconfigure with an election B that doesn't share election A's ballot styles. Before this change the app boots into "Something went wrong"; now it boots normally.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
