### PR TITLE
Shard Otsu histogram accumulation

### DIFF
--- a/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
@@ -397,12 +397,43 @@ pub fn detect_vertical_streaks(ballot_image: &BallotImage) -> Vec<VerticalStreak
     streaks
 }
 
+/// Builds a luma histogram of the given pixels.
+///
+/// Accumulates into several interleaved shard histograms and sums them at the
+/// end. Scanned ballots contain long runs of identical pixel values (blank
+/// paper, black borders), and with a single histogram every increment in such
+/// a run depends on the store of the previous one, so the CPU executes them
+/// serially. Sharding gives each of the `HISTOGRAM_SHARDS` consecutive pixels
+/// an independent histogram to increment, breaking the dependency chain. This
+/// measured about twice as fast as a single histogram on real ballot scans.
+/// The result is identical to a single histogram since the counts commute.
+pub(crate) fn histogram(pixels: &[u8]) -> [u32; 256] {
+    const HISTOGRAM_SHARDS: usize = 8;
+
+    let mut shards = [[0u32; 256]; HISTOGRAM_SHARDS];
+    let chunks = pixels.chunks_exact(HISTOGRAM_SHARDS);
+    let remainder = chunks.remainder();
+    for chunk in chunks {
+        for (shard, &p) in shards.iter_mut().zip(chunk.iter()) {
+            shard[p as usize] += 1;
+        }
+    }
+    for &p in remainder {
+        shards[0][p as usize] += 1;
+    }
+
+    let mut hist = [0u32; 256];
+    for shard in &shards {
+        for (total, &count) in hist.iter_mut().zip(shard.iter()) {
+            *total += count;
+        }
+    }
+    hist
+}
+
 /// Computes Otsu's threshold for a grayscale image.
 pub(crate) fn otsu_level(image: &GrayImage) -> u8 {
-    let mut hist = [0u32; 256];
-    for &p in image.as_raw() {
-        hist[p as usize] += 1;
-    }
+    let hist = histogram(image.as_raw());
     let total = f64::from(image.width()) * f64::from(image.height());
     let sum: f64 = hist
         .iter()
@@ -575,6 +606,20 @@ mod test {
                     assert!(gap > 1, "adjacent/overlapping streaks should coalesce");
                 }
             }
+        }
+    }
+
+    proptest::proptest! {
+        // Covers all `len % 8` remainder cases via the arbitrary length.
+        #[test]
+        fn histogram_matches_naive_single_histogram(
+            pixels in proptest::collection::vec(proptest::num::u8::ANY, 0..2048),
+        ) {
+            let mut expected = [0u32; 256];
+            for &p in &pixels {
+                expected[p as usize] += 1;
+            }
+            assert_eq!(histogram(&pixels), expected);
         }
     }
 

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
@@ -423,9 +423,9 @@ pub(crate) fn histogram(pixels: &[u8]) -> [u32; 256] {
     }
 
     let mut hist = [0u32; 256];
-    for shard in &shards {
-        for (total, &count) in hist.iter_mut().zip(shard.iter()) {
-            *total += count;
+    for i in 0..hist.len() {
+        for shard in &shards {
+            hist[i] += shard[i];
         }
     }
     hist


### PR DESCRIPTION
## Overview

_(Extracted from #8908)_

Otsu's threshold runs over the full image up to twice per ballot page, and its histogram loop was the dominant cost of page preparation: scanned pages are long runs of identical pixels (blank paper, black borders), so consecutive increments hit the same bin and serialize on the store-to-load dependency. Accumulating into eight interleaved shard histograms and summing them gives the out-of-order core eight independent chains — about 2× faster on real scans (1.97 → 1.01 ms per pass), roughly halving page preparation. Counts commute, so the merged histogram (and therefore the threshold) is exactly identical; a property test checks the sharded histogram against a naive one.

**Interactive explainer:** https://votingworks.github.io/explainers/otsu-sharding.html — including why the win is out-of-order execution rather than SIMD, and why the same trick would *lose* on random (run-free) data.

## Demo Video or Screenshot

The core mechanism, from the explainer — the same 24 increments on a modeled out-of-order core, as one dependency chain vs. eight:

![cycle timeline: one histogram serializes at 120 cycles, eight shards overlap and finish in 16](https://raw.githubusercontent.com/votingworks/explainers/main/assets/otsu-sharding-timeline.png)

## Testing Plan

The new `histogram_matches_naive_single_histogram` property test verifies the sharded histogram equals a naive single histogram on arbitrary inputs; all existing `image_utils` tests pass unchanged.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoLZVgnMKXfZ1FM52PH8ii