### PR TITLE
Fix ballot-interpreter Rust benchmarks by using hmpb fixtures

### DIFF
--- a/libs/ballot-interpreter/benches/main.rs
+++ b/libs/ballot-interpreter/benches/main.rs
@@ -1,64 +1,82 @@
 #![allow(clippy::similar_names, clippy::unwrap_used)]
 
-use std::{fmt::Display, fs::File, io::BufReader, path::PathBuf};
+use std::{fmt::Display, path::PathBuf};
 
-use ballot_interpreter::{
-    debug::ImageDebugWriter,
-    interpret::{
-        ScanInterpreter, VerticalStreakDetection, WriteInScoring,
-        DEFAULT_MAX_CUMULATIVE_STREAK_WIDTH, DEFAULT_RETRY_STREAK_WIDTH_THRESHOLD,
-    },
-    qr_code,
+use ballot_interpreter::interpret::{
+    ScanInterpreter, VerticalStreakDetection, WriteInScoring, DEFAULT_MAX_CUMULATIVE_STREAK_WIDTH,
+    DEFAULT_RETRY_STREAK_WIDTH_THRESHOLD,
 };
 use divan::{black_box, Bencher};
 use image::GrayImage;
-use types_rs::{
-    bubble_ballot::{PartialBallotHash, PARTIAL_BALLOT_HASH_BYTE_LENGTH, PRELUDE},
-    election::Election,
-};
+use sha2::{Digest, Sha256};
+use types_rs::{bubble_ballot::PartialBallotHash, election::Election};
 
 fn main() {
     // Run registered benchmarks.
     divan::main();
 }
 
+/// A ballot card from `libs/hmpb/fixtures`. These fixtures are regenerated
+/// alongside the current metadata encoding, so their QR codes can be decoded
+/// end-to-end (unlike the field-captured fixtures in `test/fixtures`, whose
+/// QR codes predate the current encoding).
 #[derive(Debug, Clone, Copy)]
 struct InterpretFixture {
-    election: &'static str,
-    name: &'static str,
-    extension: &'static str,
+    /// Directory under `libs/hmpb/fixtures` containing rendered
+    /// `<ballot>-p<N>.jpg` page images.
+    dir: &'static str,
+
+    /// Path to the election definition the ballots were generated from,
+    /// relative to this crate's root.
+    election_json: &'static str,
+
+    /// Ballot file prefix, e.g. `blank-ballot` or `marked-ballot`.
+    ballot: &'static str,
+
+    /// Page number of the card's front page; the back page is the next page.
+    starting_page_number: usize,
 }
 
 impl InterpretFixture {
-    const fn new(election: &'static str, name: &'static str, extension: &'static str) -> Self {
+    const fn new(
+        dir: &'static str,
+        election_json: &'static str,
+        ballot: &'static str,
+        starting_page_number: usize,
+    ) -> Self {
         Self {
-            election,
-            name,
-            extension,
+            dir,
+            election_json,
+            ballot,
+            starting_page_number,
         }
     }
 
     fn load(&self) -> color_eyre::Result<(GrayImage, GrayImage, ScanInterpreter)> {
-        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test/fixtures");
-        let election_path = fixture_path.join(self.election).join("election.json");
-        let election: Election =
-            serde_json::from_reader(BufReader::new(File::open(election_path)?))?;
-        let side_a_path = fixture_path
-            .join(self.election)
-            .join(format!("{}-front{}", self.name, self.extension));
-        let side_b_path = fixture_path
-            .join(self.election)
-            .join(format!("{}-back{}", self.name, self.extension));
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let fixture_path = manifest_dir.join("../hmpb/fixtures").join(self.dir);
+        let election_bytes = std::fs::read(manifest_dir.join(self.election_json))?;
+        let election: Election = serde_json::from_slice(&election_bytes)?;
+
+        // The ballot hash is the SHA-256 of the election.json bytes, matching
+        // the TS `sha256(electionData)` convention used when generating the
+        // fixtures' QR codes.
+        let digest = Sha256::digest(&election_bytes);
+        let mut expected_ballot_hash = PartialBallotHash::default();
+        let len = expected_ballot_hash.len();
+        expected_ballot_hash.copy_from_slice(&digest[..len]);
+
+        let side_a_path = fixture_path.join(format!(
+            "{}-p{}.jpg",
+            self.ballot, self.starting_page_number
+        ));
+        let side_b_path = fixture_path.join(format!(
+            "{}-p{}.jpg",
+            self.ballot,
+            self.starting_page_number + 1
+        ));
         let side_a_image = image::open(&side_a_path)?.to_luma8();
         let side_b_image = image::open(&side_b_path)?.to_luma8();
-
-        // Pull the expected ballot hash out of side A's QR code rather than
-        // hashing election.json bytes. Some bench fixtures (e.g.
-        // `vxqa-2024-10`) ship an election.json whose SHA-256 doesn't match
-        // the hash baked into the ballot QR codes, and we don't want benchmark
-        // setup to fail on those. The hash check itself is exercised by unit
-        // tests; here we just want to time interpretation.
-        let expected_ballot_hash = decode_ballot_hash_from_image(&side_a_image);
 
         let interpreter = ScanInterpreter::new(
             election,
@@ -73,32 +91,35 @@ impl InterpretFixture {
     }
 }
 
-/// Pulls the partial ballot hash out of a ballot image's QR code. See the
-/// equivalent helper in `interpret::test` for context.
-fn decode_ballot_hash_from_image(image: &GrayImage) -> PartialBallotHash {
-    let qr = qr_code::detect_with_strategy(
-        image,
-        qr_code::SearchStrategy::BubbleCorners,
-        &ImageDebugWriter::disabled(),
-    )
-    .unwrap();
-    let (prelude, payload) = qr.bytes().split_at(PRELUDE.len());
-    assert_eq!(prelude, PRELUDE);
-    let (ballot_hash, _) = payload.split_at(PARTIAL_BALLOT_HASH_BYTE_LENGTH);
-    ballot_hash.try_into().unwrap()
-}
-
 impl Display for InterpretFixture {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/{}", self.election, self.name)
+        write!(
+            f,
+            "{}/{}-p{}",
+            self.dir, self.ballot, self.starting_page_number
+        )
     }
 }
 
 #[divan::bench(args = [
-    InterpretFixture::new("all-bubble-ballot", "blank", ".jpg"),
-    InterpretFixture::new("vxqa-2024-10", "skew", ".png"),
-    InterpretFixture::new("22in-ballot-2in-margin", "centered", ".jpeg"),
-    InterpretFixture::new("letter-ballot-2in-margin-centered", "centered", ".jpeg"),
+    InterpretFixture::new(
+        "vx-general-election/letter-en",
+        "../hmpb/fixtures/vx-general-election/letter-en/election.json",
+        "blank-ballot",
+        1,
+    ),
+    InterpretFixture::new(
+        "vx-general-election/letter-en",
+        "../hmpb/fixtures/vx-general-election/letter-en/election.json",
+        "blank-ballot",
+        3,
+    ),
+    InterpretFixture::new(
+        "vx-famous-names",
+        "../fixtures/data/electionFamousNames2021/electionGeneratedWithGridLayoutsEnglishOnly.json",
+        "marked-ballot",
+        1,
+    ),
 ])]
 fn interpret(bencher: Bencher, fixture: InterpretFixture) {
     let (side_a_image, side_b_image, interpreter) = fixture.load().unwrap();
@@ -112,11 +133,52 @@ fn interpret(bencher: Bencher, fixture: InterpretFixture) {
     });
 }
 
+/// Benchmark for ballot page preparation (border cropping) and timing mark
+/// finding only, the most pixel-intensive part of interpretation.
+#[divan::bench(args = [
+    InterpretFixture::new(
+        "vx-general-election/letter-en",
+        "../hmpb/fixtures/vx-general-election/letter-en/election.json",
+        "blank-ballot",
+        1,
+    ),
+    InterpretFixture::new(
+        "vx-famous-names",
+        "../fixtures/data/electionFamousNames2021/electionGeneratedWithGridLayoutsEnglishOnly.json",
+        "marked-ballot",
+        1,
+    ),
+])]
+fn find_timing_marks(bencher: Bencher, fixture: InterpretFixture) {
+    use ballot_interpreter::ballot_card::{BallotPage, PaperInfo};
+    use ballot_interpreter::timing_marks::{self, DefaultForGeometry};
+
+    let (side_a_image, _, _) = fixture.load().unwrap();
+
+    bencher.bench_local(move || {
+        let page =
+            BallotPage::from_image("side A", side_a_image.clone(), &PaperInfo::scanned(), None)
+                .unwrap();
+        let options = timing_marks::Options::default_for_geometry(page.geometry());
+        black_box(page.find_timing_marks(&options).unwrap());
+    });
+}
+
 /// Benchmark that includes writing normalized images to disk, which is the
 /// real-world path when scanning ballots.
 #[divan::bench(args = [
-    InterpretFixture::new("all-bubble-ballot", "blank", ".jpg"),
-    InterpretFixture::new("vxqa-2024-10", "skew", ".png"),
+    InterpretFixture::new(
+        "vx-general-election/letter-en",
+        "../hmpb/fixtures/vx-general-election/letter-en/election.json",
+        "blank-ballot",
+        1,
+    ),
+    InterpretFixture::new(
+        "vx-famous-names",
+        "../fixtures/data/electionFamousNames2021/electionGeneratedWithGridLayoutsEnglishOnly.json",
+        "marked-ballot",
+        1,
+    ),
 ])]
 fn interpret_and_save(bencher: Bencher, fixture: InterpretFixture) {
     let (side_a_image, side_b_image, interpreter) = fixture.load().unwrap();
@@ -146,8 +208,18 @@ fn interpret_and_save(bencher: Bencher, fixture: InterpretFixture) {
 
 /// For comparison: the old sequential approach of saving by re-encoding.
 #[divan::bench(args = [
-    InterpretFixture::new("all-bubble-ballot", "blank", ".jpg"),
-    InterpretFixture::new("vxqa-2024-10", "skew", ".png"),
+    InterpretFixture::new(
+        "vx-general-election/letter-en",
+        "../hmpb/fixtures/vx-general-election/letter-en/election.json",
+        "blank-ballot",
+        1,
+    ),
+    InterpretFixture::new(
+        "vx-famous-names",
+        "../fixtures/data/electionFamousNames2021/electionGeneratedWithGridLayoutsEnglishOnly.json",
+        "marked-ballot",
+        1,
+    ),
 ])]
 fn interpret_and_save_sequential(bencher: Bencher, fixture: InterpretFixture) {
     let (side_a_image, side_b_image, interpreter) = fixture.load().unwrap();


### PR DESCRIPTION
## Overview

_(Extracted from #8908)_

Every interpret benchmark panicked on setup: the ballot images in `test/fixtures` have QR codes that predate the current metadata encoding (prelude `VP\x02` vs the current `VB\x01`), so they can no longer be decoded end-to-end. This points the benchmarks at the rendered hmpb fixtures instead, which are regenerated alongside the current encoding, and derives the expected ballot hash from the `election.json` bytes the same way the tests do.

Also adds a `find_timing_marks` benchmark covering page preparation and timing mark finding only — the most pixel-intensive part of interpretation — so that hot path can be tracked in isolation. Landing this makes `cargo bench` reproducible for anyone reviewing the perf claims in the rest of this series (#9092, #9093, #9094).

## Demo Video or Screenshot

N/A — benchmark-only change; verified with `cargo bench -- --test`, which now runs all benchmarks without panicking.

## Testing Plan

`cargo bench -- --test` runs every benchmark group (`find_timing_marks`, `interpret`, `interpret_and_save`, `interpret_and_save_sequential`) to completion. No library code is touched.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoLZVgnMKXfZ1FM52PH8ii