### PR TITLE
Scan for QR codes at half density

### DIFF
--- a/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/zedbar.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/zedbar.rs
@@ -41,7 +41,13 @@ pub fn detect_in_areas(detection_areas: &[DetectionArea]) -> Result {
 fn scan_image_for_qr_codes(
     image: &GrayImage,
 ) -> std::result::Result<Vec<(Vec<u8>, Rect)>, zedbar::Error> {
-    let config = DecoderConfig::new().enable(config::QrCode);
+    // Scan every other row and column rather than every one. The ballot QR
+    // codes are ~118px with ~25px finder patterns at scan resolution, so a
+    // density of 2 still crosses each finder pattern many times; it measured
+    // 41% faster with identical detections across a corpus of real scans.
+    let config = DecoderConfig::new()
+        .enable(config::QrCode)
+        .scan_density(2, 2);
     let mut scanner = Scanner::with_config(config);
     let mut img = Image::from_gray(image.as_bytes(), image.width(), image.height())?;
     let symbols = scanner.scan(&mut img);


### PR DESCRIPTION
## Overview

_(Extracted from #8908)_

zedbar scanned every row and column of each QR detection area. The ballot QR codes are ~118 px with ~25 px finder patterns at scan resolution, so scanning every other row and column still crosses each finder pattern many times while doing half the work: the zedbar scan measured 41% faster (1.45 ms → 0.85 ms per detection area). The whole diff is one config call — `.scan_density(2, 2)` — and the rqrr fallback is untouched.

Unlike the arithmetic reorderings earlier in this series, this isn't provably output-identical, so the verification is exhaustive instead: across 2,550 images (2,472 real scans plus the hmpb and test fixtures, 2,465 QR detections), detection successes and failures, decoded payloads, and orientations are all identical. Reported QR bounds, which feed only debug images, shift by at most 2 px due to the changed sampling grid.

**Interactive explainer:** https://votingworks.github.io/explainers/qr-half-density.html — how QR codes are found with 1-D scan lines and the finder patterns' 1:1:3:1:1 signature, with a density stepper showing why 2 keeps a comfortable margin and 8 doesn't.

## Demo Video or Screenshot

From the explainer — scan lines at density 2 over a code at real ballot scale; teal lines hit finder signatures (~10 crossings per finder), amber lines show chance matches in the data that clustering discards:

![scan lines at density 2 with finder-signature crossings highlighted](https://raw.githubusercontent.com/votingworks/explainers/main/assets/qr-half-density-lines.png)

## Testing Plan

Existing QR detection and end-to-end interpret tests pass unchanged. Corpus verification (2,550 images, identical detections/payloads/orientations in both directions) as described in the commit message.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoLZVgnMKXfZ1FM52PH8ii