### PR TITLE
Encode normalized ballot images as 1-bit PNGs in one fused pass

### DIFF
--- a/libs/ballot-interpreter/Cargo.lock
+++ b/libs/ballot-interpreter/Cargo.lock
@@ -235,6 +235,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "png",
  "proptest",
  "rayon",
  "rqrr",

--- a/libs/ballot-interpreter/Cargo.toml
+++ b/libs/ballot-interpreter/Cargo.toml
@@ -46,6 +46,7 @@ image = { version = "0.25.0", default-features = false, features = [
   "rayon",
 ] }
 log = "0.4.17"
+png = "0.18.1"
 napi = { version = "3.8.0", default-features = false, features = [
   "napi4",
   "async",

--- a/libs/ballot-interpreter/benches/main.rs
+++ b/libs/ballot-interpreter/benches/main.rs
@@ -205,36 +205,3 @@ fn interpret_and_save(bencher: Bencher, fixture: InterpretFixture) {
         black_box(result);
     });
 }
-
-/// For comparison: the old sequential approach of saving by re-encoding.
-#[divan::bench(args = [
-    InterpretFixture::new(
-        "vx-general-election/letter-en",
-        "../hmpb/fixtures/vx-general-election/letter-en/election.json",
-        "blank-ballot",
-        1,
-    ),
-    InterpretFixture::new(
-        "vx-famous-names",
-        "../fixtures/data/electionFamousNames2021/electionGeneratedWithGridLayoutsEnglishOnly.json",
-        "marked-ballot",
-        1,
-    ),
-])]
-fn interpret_and_save_sequential(bencher: Bencher, fixture: InterpretFixture) {
-    let (side_a_image, side_b_image, interpreter) = fixture.load().unwrap();
-    let tmp_dir = tempfile::tempdir().unwrap();
-    let front_path = tmp_dir.path().join("front_seq.png");
-    let back_path = tmp_dir.path().join("back_seq.png");
-
-    bencher.bench_local(move || {
-        let result = interpreter
-            .interpret(side_a_image.clone(), side_b_image.clone(), None, None)
-            .unwrap();
-
-        // Simulate the old behavior: encode and save sequentially after interpretation
-        result.front.normalized_image.save(&front_path).unwrap();
-        result.back.normalized_image.save(&back_path).unwrap();
-        black_box(result);
-    });
-}

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/image_utils.rs
@@ -2,7 +2,7 @@ use std::io::Cursor;
 use std::mem::swap;
 use std::ops::RangeInclusive;
 
-use image::{GrayImage, ImageEncoder, Luma, Rgb};
+use image::{GrayImage, Luma, Rgb};
 use itertools::Itertools;
 use serde::Serialize;
 use types_rs::geometry::{PixelPosition, PixelUnit};
@@ -512,26 +512,55 @@ pub(crate) fn threshold(image: &GrayImage, thresh: u8) -> GrayImage {
     })
 }
 
-/// Applies a binary threshold and encodes the result as PNG bytes in one step.
-/// Returns both the thresholded image and its PNG encoding.
-pub(crate) fn threshold_and_encode_png(
+/// Binarizes a grayscale image with the given threshold and encodes it as a
+/// 1-bit grayscale PNG in memory, in a single pass over the image.
+///
+/// Pixels with luma `<= thresh` become black and others white, exactly like
+/// [`threshold`], but the bits are packed directly from the source image
+/// rather than materializing an intermediate 8-bit binarized image. The
+/// 1-bit representation gives the DEFLATE step an eighth of the data an
+/// 8-bit encoding would, making encoding faster and files smaller: the `Up`
+/// filter with fast compression measured smaller *and* faster than an 8-bit
+/// encoding with the `image` crate's defaults on a corpus of real ballot
+/// scans.
+pub(crate) fn binarize_and_encode_png(
     image: &GrayImage,
     thresh: u8,
-) -> (GrayImage, image::ImageResult<Vec<u8>>) {
-    let normalized = threshold(image, thresh);
-    let encoded = encode_png(&normalized);
-    (normalized, encoded)
-}
+) -> image::ImageResult<Vec<u8>> {
+    let (width, height) = image.dimensions();
+    let row_bytes = width.div_ceil(u8::BITS) as usize;
+    let mut packed = vec![0u8; row_bytes * height as usize];
+    for (pixel_row, packed_row) in image
+        .as_raw()
+        .chunks_exact(width as usize)
+        .zip(packed.chunks_exact_mut(row_bytes))
+    {
+        for (pixels, packed_byte) in pixel_row
+            .chunks(u8::BITS as usize)
+            .zip(packed_row.iter_mut())
+        {
+            let mut byte = 0u8;
+            for (bit, &pixel) in pixels.iter().enumerate() {
+                byte |= u8::from(pixel > thresh) << ((u8::BITS - 1) as usize - bit);
+            }
+            *packed_byte = byte;
+        }
+    }
 
-/// Encodes a grayscale image as PNG bytes in memory.
-pub(crate) fn encode_png(image: &GrayImage) -> image::ImageResult<Vec<u8>> {
-    let mut buf = Vec::new();
-    image::codecs::png::PngEncoder::new(Cursor::new(&mut buf)).write_image(
-        image.as_raw(),
-        image.width(),
-        image.height(),
-        image::ExtendedColorType::L8,
-    )?;
+    let to_image_error =
+        |e: png::EncodingError| image::ImageError::IoError(std::io::Error::other(e));
+
+    // Pre-size for the compressed output; binarized ballot images compress
+    // to well under half of the packed size.
+    let mut buf = Vec::with_capacity(packed.len() / 2);
+    let mut encoder = png::Encoder::new(Cursor::new(&mut buf), width, height);
+    encoder.set_color(png::ColorType::Grayscale);
+    encoder.set_depth(png::BitDepth::One);
+    encoder.set_compression(png::Compression::Fast);
+    encoder.set_filter(png::Filter::Up);
+    let mut writer = encoder.write_header().map_err(to_image_error)?;
+    writer.write_image_data(&packed).map_err(to_image_error)?;
+    writer.finish().map_err(to_image_error)?;
     Ok(buf)
 }
 
@@ -677,6 +706,22 @@ mod test {
             let expected = image.view(x, y, width, height).to_image();
             let actual = crop_to_image(&image, x, y, width, height);
             assert_eq!(actual.as_raw(), expected.as_raw());
+        }
+
+        // Arbitrary widths cover the row padding cases (width % 8 != 0).
+        #[test]
+        fn binarize_and_encode_png_matches_threshold_exactly(
+            width in 1u32..40,
+            height in 1u32..40,
+            thresh in proptest::num::u8::ANY,
+            seed in proptest::collection::vec(proptest::num::u8::ANY, 40 * 40),
+        ) {
+            let image = GrayImage::from_fn(width, height, |x, y| {
+                Luma([seed[(y * width + x) as usize]])
+            });
+            let encoded = binarize_and_encode_png(&image, thresh).unwrap();
+            let decoded = image::load_from_memory(&encoded).unwrap().to_luma8();
+            assert_eq!(decoded.as_raw(), threshold(&image, thresh).as_raw());
         }
     }
 

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
@@ -21,7 +21,7 @@ use crate::ballot_card::Geometry;
 use crate::ballot_card::Orientation;
 use crate::ballot_card::PaperInfo;
 use crate::debug::draw_timing_mark_debug_image_mut;
-use crate::image_utils::threshold_and_encode_png;
+use crate::image_utils::binarize_and_encode_png;
 use crate::image_utils::Inset;
 use crate::layout::InterpretedContestLayout;
 use crate::scoring::ScoredBubbleMarks;
@@ -133,10 +133,9 @@ pub struct InterpretedBallotPage {
     pub metadata: BallotPageMetadata,
     pub marks: ScoredBubbleMarks,
     pub write_ins: ScoredPositionAreas,
-    #[serde(skip_serializing)] // `normalized_image` is returned separately.
-    pub normalized_image: GrayImage,
-    /// Pre-encoded PNG bytes of the normalized image. Produced in parallel with
-    /// scoring so that callers can write to disk without re-encoding.
+    /// PNG bytes of the normalized (binarized) ballot image. Produced in
+    /// parallel with scoring so that callers can write to disk without
+    /// re-encoding.
     #[serde(skip_serializing)]
     pub encoded_normalized_image: image::ImageResult<Vec<u8>>,
     pub contest_layouts: Vec<InterpretedContestLayout>,
@@ -503,7 +502,7 @@ pub fn ballot_card(
 
     // Run scoring and image normalization+encoding in parallel. The PNG
     // encoding is CPU-heavy and overlaps well with bubble-mark scoring.
-    let (scoring_result, normalized_and_encoded) = rayon::join(
+    let (scoring_result, encoded_images) = rayon::join(
         || -> Result<ScoringPairs> {
             let scored_bubble_marks = ballot_card.score_bubble_marks(
                 &timing_marks,
@@ -527,7 +526,7 @@ pub fn ballot_card(
         },
         || {
             ballot_card.as_pair().par_map(|ballot_page| {
-                threshold_and_encode_png(
+                binarize_and_encode_png(
                     ballot_page.ballot_image().image(),
                     ballot_page.ballot_image().threshold(),
                 )
@@ -536,20 +535,12 @@ pub fn ballot_card(
     );
 
     let (scored_bubble_marks, contest_layouts, write_in_area_scores) = scoring_result?;
-    let (normalized_images, encoded_images): (Pair<_>, Pair<_>) = {
-        let ((front_norm, front_enc), (back_norm, back_enc)) = normalized_and_encoded.into();
-        (
-            Pair::new(front_norm, back_norm),
-            Pair::new(front_enc, back_enc),
-        )
-    };
 
     Pair::from((
         timing_marks,
         decoded_qr_codes,
         scored_bubble_marks,
         write_in_area_scores,
-        normalized_images,
         encoded_images,
         contest_layouts,
     ))
@@ -559,7 +550,6 @@ pub fn ballot_card(
             (metadata, _),
             marks,
             write_ins,
-            normalized_image,
             encoded_normalized_image,
             contest_layouts,
         )| {
@@ -568,7 +558,6 @@ pub fn ballot_card(
                 metadata: BallotPageMetadata::QrCode(metadata),
                 marks,
                 write_ins,
-                normalized_image,
                 encoded_normalized_image,
                 contest_layouts,
             }
@@ -747,8 +736,11 @@ mod test {
         let (side_a_image, side_b_image, options) =
             load_hmpb_fixture("vx-general-election/letter-en", 1);
         let card = ballot_card(side_a_image, side_b_image, &options).unwrap();
-        assert!(is_binary_image(&card.front.normalized_image));
-        assert!(is_binary_image(&card.back.normalized_image));
+        for page in [&card.front, &card.back] {
+            let encoded = page.encoded_normalized_image.as_ref().unwrap();
+            let decoded = image::load_from_memory(encoded).unwrap().into_luma8();
+            assert!(is_binary_image(&decoded));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Overview

_(Extracted from #8908. Part of stack #9100, on top of #9095.)_

The normalized (binarized) ballot images were encoded as 8-bit grayscale PNGs by first materializing a thresholded copy of the working image and then encoding it. Since every pixel is either 0 or 255, a 1-bit grayscale PNG represents the same image losslessly while giving DEFLATE an eighth of the data. The new `binarize_and_encode_png` applies the threshold predicate while packing bits directly from the working image — one read pass, no intermediate 8-bit image — and encodes with the `png` crate using fast compression and the Up filter: ~1.6× faster encoding with ~37% smaller files (106 → 67 KiB mean) on a corpus of real binarized scans.

This also drops the `normalized_image` field from `InterpretedBallotPage`: it was never serialized across the napi bridge and production callers only use the pre-encoded PNG bytes, so the pipeline was allocating and writing a full-page 8-bit copy per side that was then discarded. The `interpret_and_save` benchmark improved from ~11.5 ms to ~9 ms median, and the now-obsolete sequential-save comparison benchmark is removed.

**Two things reviewers should weigh, since this is the one PR in the series whose output bytes change:**

- **Decoder compatibility.** Everything downstream of the saved images — node-canvas, browsers, the Rust `image` crate, and the byte-oriented CVR export path — handles 1-bit grayscale PNGs; a property test verifies the decoded output matches `threshold()` exactly, including row-padding widths (width % 8 ≠ 0).
- **File hashes change.** Anything comparing normalized-image bytes (rather than pixels) would need regenerating. In this repo the image assertions are `jest-image-snapshot` pixel comparisons, which pass unchanged; no byte-hash assertions exist in this package.

## Demo Video or Screenshot

N/A — saved images are pixel-identical; only their encoding changes.

## Testing Plan

New `binarize_and_encode_png_matches_threshold_exactly` property test (decode-and-compare against `threshold()` over arbitrary sizes and thresholds); full `cargo test --lib` passes (101/101); `cargo bench -- --test` runs all benchmarks including the reworked `interpret_and_save`.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoLZVgnMKXfZ1FM52PH8ii
