### PR TITLE
Build ballot-interpreter release with thin LTO and one codegen unit

### DIFF
--- a/libs/ballot-interpreter/Cargo.toml
+++ b/libs/ballot-interpreter/Cargo.toml
@@ -77,3 +77,7 @@ tempfile = "3.3.0"
 
 [lints]
 workspace = true
+
+[profile.release]
+lto = "thin"
+codegen-units = 1


### PR DESCRIPTION
## Overview

_(Extracted from #8908)_

Enables thin LTO and a single codegen unit for the ballot-interpreter release profile: ~5% faster end-to-end interpretation measured on production-class hardware (Intel N97), at the cost of a slower release build. This is pure build configuration — no code changes, no new instruction-set requirements, so it's safe on every machine in the fleet.

Note: `libs/ballot-interpreter` is excluded from the repo's root cargo workspace and is its own workspace root, so the `[profile.release]` section here is honored (cargo ignores profile sections in workspace *member* manifests).

The companion `x86-64-v3` target commit from #8908 is intentionally **not** included: VxMarkScan (which runs the interpreter for printed-ballot verification) is believed to use an Atom x5-E8000, which has no AVX2, so that flag would crash it. It may return later as `x86-64-v2` (safe on that hardware, and it would make the bubble scorer's `count_ones()` a single `POPCNT` instruction) pending re-measurement on real hardware.

## Demo Video or Screenshot

N/A — build configuration only.

## Testing Plan

`cargo build --release` completes with the new profile (~38 s wall on a 16-core dev machine); `cargo test --lib` unaffected (dev profile). Perf measured on Intel N97 as described in the commit message.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoLZVgnMKXfZ1FM52PH8ii