### PR TITLE
[Admin] Add polling place filter to report builders

### DIFF
--- a/apps/admin/backend/src/app.tally_report_data.test.ts
+++ b/apps/admin/backend/src/app.tally_report_data.test.ts
@@ -1311,3 +1311,73 @@ test('combined ballot primary, crossover ballots write-ins excluded from partisa
   expect(repContest.ballots).toEqual(0);
   expect(repContest.tallies[repCandidate.id]).toBeUndefined();
 });
+
+test('primary, filtered by polling place', async () => {
+  const electionDefinition =
+    electionPrimaryPrecinctSplitsFixtures.readElectionDefinition();
+  const { election } = electionDefinition;
+
+  const { apiClient, auth, workspace } = buildTestEnvironment();
+  const electionId = await configureMachine(
+    apiClient,
+    auth,
+    electionDefinition
+  );
+  mockElectionManagerAuth(auth, election);
+
+  // Precinct 1 and Precinct 4 are covered by different polling places and have
+  // different ballot styles, so they see different congressional contests.
+  const mockCastVoteRecordFile: MockCastVoteRecordFile = [
+    {
+      ballotStyleGroupId: '1-Ma',
+      batchId: 'precinct-1-batch',
+      scannerId: 'scanner-1',
+      precinctId: 'precinct-c1-w1-1',
+      pollingPlaceId: 'precinct-c1-w1-1-polling-place',
+      votingMethod: 'precinct',
+      votes: {},
+      card: { type: 'bmd' },
+      multiplier: 9,
+    },
+    {
+      ballotStyleGroupId: '3-Ma',
+      batchId: 'precinct-4-batch',
+      scannerId: 'scanner-2',
+      precinctId: 'precinct-c2',
+      pollingPlaceId: 'precinct-c2-polling-place',
+      votingMethod: 'precinct',
+      votes: {},
+      card: { type: 'bmd' },
+      multiplier: 4,
+    },
+  ];
+  addMockCvrFileToStore({
+    electionId,
+    mockCastVoteRecordFile,
+    store: workspace.store,
+    pollingPlaceId: 'precinct-c1-w1-1-polling-place',
+  });
+
+  const [report] = await apiClient.getResultsForTallyReports({
+    filter: { pollingPlaceIds: ['precinct-c1-w1-1-polling-place'] },
+    groupBy: {},
+  });
+  assert(report);
+  assert(report.hasPartySplits);
+
+  // only ballots scanned at that polling place are counted
+  expect(report.cardCountsByParty).toEqual({
+    '0': { bmd: [9], hmpb: [] },
+    '1': { bmd: [], hmpb: [] },
+  });
+
+  // contests are scoped to those that could appear at that polling place, so
+  // the congressional-2 and water-2 contests are excluded
+  expect([...report.contestIds].sort()).toEqual([
+    'congressional-1-fish',
+    'congressional-1-mammal',
+    'county-leader-fish',
+    'county-leader-mammal',
+    'water-1-fishing',
+  ]);
+});

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -230,7 +230,11 @@ function buildApi({
     const {
       electionDefinition: { election },
     } = assertDefined(store.getElection(electionId));
-    return convertFrontendFilterUtil(filter, election);
+    return convertFrontendFilterUtil(
+      filter,
+      election,
+      store.getScannerBatches(electionId)
+    );
   }
 
   async function getTallyReportResults(

--- a/apps/admin/backend/src/reports/titles.test.ts
+++ b/apps/admin/backend/src/reports/titles.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest';
 import { err, ok } from '@votingworks/basics';
 import {
   electionCombinedBallotPrimaryFixtures,
+  readElectionGeneralDefinition,
   readElectionTwoPartyPrimaryDefinition,
 } from '@votingworks/fixtures';
 import { Admin, BallotStyleGroupId, Tabulation } from '@votingworks/types';
@@ -79,6 +80,13 @@ test('generateTitleForReport', () => {
     },
     {
       ballotStyleGroupIds: ['1M'] as BallotStyleGroupId[],
+    },
+    {
+      pollingPlaceIds: ['precinct-1-polling-place', 'precinct-2-polling-place'],
+    },
+    {
+      pollingPlaceIds: ['precinct-1-polling-place'],
+      votingMethods: ['absentee'],
     },
   ];
 
@@ -163,6 +171,17 @@ test('generateTitleForReport', () => {
       })
     ).toEqual(ok(title));
   }
+
+  // uses an election whose polling place names differ from its precinct names,
+  // so the title is unambiguously derived from the polling place
+  expect(
+    generateTitleForReport({
+      filter: { pollingPlaceIds: ['23-polling-place'] },
+      electionDefinition: readElectionGeneralDefinition(),
+      scannerBatches: MOCK_SCANNER_BATCHES,
+      reportType: 'Tally',
+    })
+  ).toEqual(ok('Tally Report • Center Springfield'));
 
   const ballotCountFilters: Array<
     [filter: Admin.FrontendReportingFilter, title: string]

--- a/apps/admin/backend/src/reports/titles.ts
+++ b/apps/admin/backend/src/reports/titles.ts
@@ -24,7 +24,8 @@ function isCompoundFilter(filter: Admin.FrontendReportingFilter): boolean {
       (filter.scannerIds && filter.scannerIds.length > 1) ||
       (filter.votingMethods && filter.votingMethods.length > 1) ||
       (filter.adjudicationFlags && filter.adjudicationFlags.length > 1) ||
-      (filter.districtIds && filter.districtIds.length > 1)
+      (filter.districtIds && filter.districtIds.length > 1) ||
+      (filter.pollingPlaceIds && filter.pollingPlaceIds.length > 1)
   );
 }
 
@@ -40,7 +41,8 @@ function getFilterRank(filter: Admin.FrontendReportingFilter): number {
     (filter.votingMethods?.[0] ? 1 : 0) +
     (filter.partyIds?.[0] ? 1 : 0) +
     (filter.adjudicationFlags?.[0] ? 1 : 0) +
-    (filter.districtIds?.[0] ? 1 : 0)
+    (filter.districtIds?.[0] ? 1 : 0) +
+    (filter.pollingPlaceIds?.[0] ? 1 : 0)
   );
 }
 
@@ -81,6 +83,7 @@ export function generateTitleForReport({
   const partyId = filter.partyIds?.[0];
   const adjudicationFlag = filter.adjudicationFlags?.[0];
   const districtId = filter.districtIds?.[0];
+  const pollingPlaceId = filter.pollingPlaceIds?.[0];
 
   const reportSuffix = (() => {
     if (precinctId) {
@@ -149,6 +152,13 @@ export function generateTitleForReport({
       return CachedElectionLookups.getDistrictById(
         electionDefinition,
         districtId
+      ).name;
+    }
+
+    if (pollingPlaceId) {
+      return CachedElectionLookups.getPollingPlaceById(
+        electionDefinition,
+        pollingPlaceId
       ).name;
     }
   })();

--- a/apps/admin/backend/src/util/filters.test.ts
+++ b/apps/admin/backend/src/util/filters.test.ts
@@ -2,8 +2,29 @@ import { expect, test } from 'vitest';
 import { readElectionGeneral } from '@votingworks/fixtures';
 import { Admin, BallotStyleGroupId } from '@votingworks/types';
 import { assertIsBackendFilter, convertFrontendFilter } from './filters.js';
+import { ScannerBatch } from '../types.js';
 
 const electionGeneral = readElectionGeneral();
+
+function mockBatch(batchId: string, pollingPlaceId?: string): ScannerBatch {
+  return {
+    batchId,
+    label: `Batch ${batchId}`,
+    scannerId: 'scanner-1',
+    electionId: 'election-1',
+    pollingPlaceId,
+    startedAt: '2024-01-01T00:00:00.000Z',
+  };
+}
+
+// Center Springfield covers precinct 23, North Springfield covers precinct 21.
+const scannerBatches: ScannerBatch[] = [
+  mockBatch('batch-center-1', '23-polling-place'),
+  mockBatch('batch-center-2', '23-polling-place'),
+  mockBatch('batch-north-1', '21-polling-place'),
+  mockBatch('batch-south-1', '20-polling-place'),
+  mockBatch('batch-unattributed'),
+];
 
 test('convertFrontendFilter', () => {
   expect(
@@ -11,7 +32,8 @@ test('convertFrontendFilter', () => {
       {
         districtIds: ['district-1'],
       },
-      electionGeneral
+      electionGeneral,
+      scannerBatches
     )
   ).toEqual({
     ballotStyleGroupIds: ['12', '5'] as BallotStyleGroupId[],
@@ -22,7 +44,8 @@ test('convertFrontendFilter', () => {
       {
         districtIds: ['district-2'],
       },
-      electionGeneral
+      electionGeneral,
+      scannerBatches
     )
   ).toEqual({
     ballotStyleGroupIds: ['12'],
@@ -33,7 +56,8 @@ test('convertFrontendFilter', () => {
       {
         districtIds: ['district-1', 'district-2'],
       },
-      electionGeneral
+      electionGeneral,
+      scannerBatches
     )
   ).toEqual({
     ballotStyleGroupIds: ['12', '5'] as BallotStyleGroupId[],
@@ -45,7 +69,8 @@ test('convertFrontendFilter', () => {
         votingMethods: ['absentee'],
         ballotStyleGroupIds: ['12'] as BallotStyleGroupId[],
       },
-      electionGeneral
+      electionGeneral,
+      scannerBatches
     )
   ).toEqual({
     votingMethods: ['absentee'],
@@ -58,7 +83,8 @@ test('convertFrontendFilter', () => {
         districtIds: ['district-2'],
         ballotStyleGroupIds: ['12'] as BallotStyleGroupId[],
       },
-      electionGeneral
+      electionGeneral,
+      scannerBatches
     )
   ).toEqual({
     ballotStyleGroupIds: ['12'],
@@ -71,10 +97,112 @@ test('convertFrontendFilter', () => {
         districtIds: ['district-2'],
         ballotStyleGroupIds: ['5'] as BallotStyleGroupId[],
       },
-      electionGeneral
+      electionGeneral,
+      scannerBatches
     )
   ).toEqual({
     ballotStyleGroupIds: [],
+  });
+});
+
+test('convertFrontendFilter - polling place reduces to batches and precincts', () => {
+  expect(
+    convertFrontendFilter(
+      { pollingPlaceIds: ['23-polling-place'] },
+      electionGeneral,
+      scannerBatches
+    )
+  ).toEqual({
+    batchIds: ['batch-center-1', 'batch-center-2'],
+    precinctIds: ['23'],
+  });
+
+  // multiple polling places union their batches and precincts
+  expect(
+    convertFrontendFilter(
+      { pollingPlaceIds: ['23-polling-place', '21-polling-place'] },
+      electionGeneral,
+      scannerBatches
+    )
+  ).toEqual({
+    batchIds: ['batch-center-1', 'batch-center-2', 'batch-north-1'],
+    precinctIds: ['23', '21'],
+  });
+
+  // a polling place with no imported batches yet excludes all ballots
+  expect(
+    convertFrontendFilter(
+      { pollingPlaceIds: ['23-polling-place'] },
+      electionGeneral,
+      [mockBatch('batch-north-1', '21-polling-place')]
+    )
+  ).toEqual({
+    batchIds: [],
+    precinctIds: ['23'],
+  });
+});
+
+test('convertFrontendFilter - polling place intersects existing dimensions', () => {
+  expect(
+    convertFrontendFilter(
+      {
+        pollingPlaceIds: ['23-polling-place'],
+        batchIds: ['batch-center-2', 'batch-north-1'],
+      },
+      electionGeneral,
+      scannerBatches
+    )
+  ).toEqual({
+    batchIds: ['batch-center-2'],
+    precinctIds: ['23'],
+  });
+
+  expect(
+    convertFrontendFilter(
+      {
+        pollingPlaceIds: ['23-polling-place'],
+        precinctIds: ['23', '21'],
+      },
+      electionGeneral,
+      scannerBatches
+    )
+  ).toEqual({
+    batchIds: ['batch-center-1', 'batch-center-2'],
+    precinctIds: ['23'],
+  });
+
+  // no intersection between the polling place and the selected precinct
+  expect(
+    convertFrontendFilter(
+      {
+        pollingPlaceIds: ['23-polling-place'],
+        precinctIds: ['21'],
+      },
+      electionGeneral,
+      scannerBatches
+    )
+  ).toEqual({
+    batchIds: ['batch-center-1', 'batch-center-2'],
+    precinctIds: [],
+  });
+});
+
+test('convertFrontendFilter - polling place combines with other filters', () => {
+  expect(
+    convertFrontendFilter(
+      {
+        pollingPlaceIds: ['21-polling-place'],
+        districtIds: ['district-2'],
+        votingMethods: ['absentee'],
+      },
+      electionGeneral,
+      scannerBatches
+    )
+  ).toEqual({
+    ballotStyleGroupIds: ['12'],
+    batchIds: ['batch-north-1'],
+    precinctIds: ['21'],
+    votingMethods: ['absentee'],
   });
 });
 
@@ -84,6 +212,13 @@ test('assertIsBackendFilter', () => {
   };
   expect(() => {
     assertIsBackendFilter(filter);
+  }).toThrowError();
+
+  const pollingPlaceFilter: Admin.FrontendReportingFilter = {
+    pollingPlaceIds: ['23-polling-place'],
+  };
+  expect(() => {
+    assertIsBackendFilter(pollingPlaceFilter);
   }).toThrowError();
 
   expect(() => {

--- a/apps/admin/backend/src/util/filters.ts
+++ b/apps/admin/backend/src/util/filters.ts
@@ -1,38 +1,88 @@
-import { Admin, Election } from '@votingworks/types';
+import {
+  Admin,
+  Election,
+  pollingPlaceFromElection,
+  pollingPlacePrecinctIds,
+} from '@votingworks/types';
 import { getGroupedBallotStyles } from '@votingworks/utils';
+import { ScannerBatch } from '../types.js';
+
+/**
+ * Narrows an existing filter dimension to the values implied by a
+ * higher-level frontend filter. If the dimension wasn't already filtered on,
+ * the implied values become the filter.
+ */
+function intersect<T>(existing: T[] | undefined, implied: T[]): T[] {
+  return existing
+    ? existing.filter((value) => implied.includes(value))
+    : implied;
+}
 
 /**
  * The frontend filter interface allows filtering on geographical district,
  * which has a many-to-many relationship with ballot styles. In this helper,
  * we reduce the district filters into ballot style filters.
+ *
+ * It also allows filtering on polling place, which is not an attribute of a
+ * cast vote record but of the batch it was scanned in. We reduce it to the
+ * batches attributed to those polling places, plus the precincts those polling
+ * places cover. The precinct component is redundant for selecting cast vote
+ * records - every ballot in those batches is necessarily from one of those
+ * precincts - but it scopes the contests and expected groups of the report,
+ * which are derived from the election definition rather than from the cast
+ * vote records.
  */
 export function convertFrontendFilter(
   frontendFilter: Admin.FrontendReportingFilter,
-  election: Election
+  election: Election,
+  scannerBatches: ScannerBatch[]
 ): Admin.ReportingFilter {
-  const { districtIds, ...rest } = frontendFilter;
-  if (!districtIds) return rest;
+  const { districtIds, pollingPlaceIds, ...rest } = frontendFilter;
+  let filter: Admin.ReportingFilter = rest;
 
-  const districtBallotStyleGroupIds = getGroupedBallotStyles(
-    election.ballotStyles
-  )
-    .filter((bs) =>
-      bs.districts.some((districtId) => districtIds.includes(districtId))
+  if (districtIds) {
+    const districtBallotStyleGroupIds = getGroupedBallotStyles(
+      election.ballotStyles
     )
-    .map((bs) => bs.id);
-
-  // the new filter should be the intersection of the district-based ballot styles
-  // and the pre-existing list of ballot styles, if one exists
-  const ballotStyleGroupIds = rest.ballotStyleGroupIds
-    ? rest.ballotStyleGroupIds.filter((id) =>
-        districtBallotStyleGroupIds.includes(id)
+      .filter((bs) =>
+        bs.districts.some((districtId) => districtIds.includes(districtId))
       )
-    : districtBallotStyleGroupIds;
+      .map((bs) => bs.id);
 
-  return {
-    ...rest,
-    ballotStyleGroupIds,
-  };
+    filter = {
+      ...filter,
+      ballotStyleGroupIds: intersect(
+        filter.ballotStyleGroupIds,
+        districtBallotStyleGroupIds
+      ),
+    };
+  }
+
+  if (pollingPlaceIds) {
+    const pollingPlaceBatchIds = scannerBatches
+      .filter(
+        (batch) =>
+          batch.pollingPlaceId !== undefined &&
+          pollingPlaceIds.includes(batch.pollingPlaceId)
+      )
+      .map((batch) => batch.batchId);
+
+    const pollingPlacePrecinctIdList = pollingPlaceIds.flatMap(
+      (pollingPlaceId) => [
+        ...pollingPlacePrecinctIds(
+          pollingPlaceFromElection(election, pollingPlaceId)
+        ),
+      ]
+    );
+
+    filter = {
+      ...filter,
+      batchIds: intersect(filter.batchIds, pollingPlaceBatchIds),
+      precinctIds: intersect(filter.precinctIds, pollingPlacePrecinctIdList),
+    };
+  }
+
+  return filter;
 }
 
 /**
@@ -42,6 +92,12 @@ export function assertIsBackendFilter(filter?: Admin.ReportingFilter): void {
   if (filter && 'districtIds' in filter) {
     throw new Error(
       'filter contains unused dimension "districtIds" - does that need to be converted to ballotStyleIds?'
+    );
+  }
+
+  if (filter && 'pollingPlaceIds' in filter) {
+    throw new Error(
+      'filter contains unused dimension "pollingPlaceIds" - does that need to be converted to batchIds?'
     );
   }
 }

--- a/apps/admin/backend/src/util/filters.ts
+++ b/apps/admin/backend/src/util/filters.ts
@@ -8,29 +8,31 @@ import { getGroupedBallotStyles } from '@votingworks/utils';
 import { ScannerBatch } from '../types.js';
 
 /**
- * Narrows an existing filter dimension to the values implied by a
- * higher-level frontend filter. If the dimension wasn't already filtered on,
- * the implied values become the filter.
+ * Intersects two lists of values. The second list is optional; when it is
+ * omitted, the first list is returned unchanged.
  */
-function intersect<T>(existing: T[] | undefined, implied: T[]): T[] {
-  return existing
-    ? existing.filter((value) => implied.includes(value))
-    : implied;
+function intersect<T>(values: T[], otherValues?: T[]): T[] {
+  return otherValues
+    ? values.filter((value) => otherValues.includes(value))
+    : values;
 }
 
 /**
- * The frontend filter interface allows filtering on geographical district,
- * which has a many-to-many relationship with ballot styles. In this helper,
- * we reduce the district filters into ballot style filters.
+ * Reduces the higher-level dimensions the frontend filter interface offers
+ * into the lower-level cast vote record dimensions that tabulation can query
+ * on, intersecting with any filter the user already placed on those lower-level
+ * dimensions.
  *
- * It also allows filtering on polling place, which is not an attribute of a
- * cast vote record but of the batch it was scanned in. We reduce it to the
- * batches attributed to those polling places, plus the precincts those polling
- * places cover. The precinct component is redundant for selecting cast vote
- * records - every ballot in those batches is necessarily from one of those
- * precincts - but it scopes the contests and expected groups of the report,
- * which are derived from the election definition rather than from the cast
- * vote records.
+ * District has a many-to-many relationship with ballot styles, so district
+ * filters reduce to ballot style filters.
+ *
+ * Polling place is not an attribute of a cast vote record at all, but of the
+ * batch it was scanned in, so polling place filters reduce to the batches
+ * attributed to those polling places, plus the precincts those polling places
+ * cover. The precinct component is redundant for selecting cast vote records -
+ * every ballot in those batches is necessarily from one of those precincts -
+ * but it will be used later on in the reporting pipeline to filter the list of
+ * contests that appear in the report.
  */
 export function convertFrontendFilter(
   frontendFilter: Admin.FrontendReportingFilter,
@@ -52,8 +54,8 @@ export function convertFrontendFilter(
     filter = {
       ...filter,
       ballotStyleGroupIds: intersect(
-        filter.ballotStyleGroupIds,
-        districtBallotStyleGroupIds
+        districtBallotStyleGroupIds,
+        filter.ballotStyleGroupIds
       ),
     };
   }
@@ -67,6 +69,10 @@ export function convertFrontendFilter(
       )
       .map((batch) => batch.batchId);
 
+    // A polling place that covers only some splits of a precinct still
+    // contributes the whole precinct here, so its report may list contests
+    // that only the precinct's other splits vote on. We accept that
+    // imprecision rather than reducing to ballot styles.
     const pollingPlacePrecinctIdList = pollingPlaceIds.flatMap(
       (pollingPlaceId) => [
         ...pollingPlacePrecinctIds(
@@ -77,8 +83,8 @@ export function convertFrontendFilter(
 
     filter = {
       ...filter,
-      batchIds: intersect(filter.batchIds, pollingPlaceBatchIds),
-      precinctIds: intersect(filter.precinctIds, pollingPlacePrecinctIdList),
+      batchIds: intersect(pollingPlaceBatchIds, filter.batchIds),
+      precinctIds: intersect(pollingPlacePrecinctIdList, filter.precinctIds),
     };
   }
 

--- a/apps/admin/frontend/src/components/reporting/filter_editor.test.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.test.tsx
@@ -8,7 +8,10 @@ import userEvent from '@testing-library/user-event';
 import { renderInAppContext } from '../../../test/render_in_app_context.js';
 import { FilterEditor } from './filter_editor.js';
 import { screen, within } from '../../../test/react_testing_library.js';
-import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client.js';
+import {
+  ApiMock,
+  createApiMock,
+} from '../../../test/helpers/mock_api_client.js';
 
 const electionTwoPartyPrimaryDefinition =
   readElectionTwoPartyPrimaryDefinition();
@@ -324,6 +327,36 @@ test('district filter', () => {
   userEvent.click(screen.getByText('District 1'));
   expect(onChange).toHaveBeenNthCalledWith(2, {
     districtIds: ['district-1'],
+  });
+});
+
+test('polling place filter', () => {
+  const { election } = electionTwoPartyPrimaryDefinition;
+  const onChange = vi.fn();
+
+  apiMock.expectGetScannerBatches([]);
+  apiMock.expectGetSystemSettings();
+  renderInAppContext(
+    <FilterEditor
+      election={election}
+      onChange={onChange}
+      allowedFilters={['polling-place']}
+    />,
+    {
+      apiMock,
+    }
+  );
+
+  userEvent.click(screen.getButton('Add Filter'));
+  userEvent.click(screen.getByLabelText('Select New Filter Type'));
+  userEvent.click(screen.getByText('Polling Place'));
+  expect(onChange).toHaveBeenNthCalledWith(1, { pollingPlaceIds: [] });
+  userEvent.click(screen.getByLabelText('Select Filter Values'));
+  // labeled with the polling place type to disambiguate places that share a
+  // name with their precinct
+  userEvent.click(screen.getByText('Precinct 1 (Election Day)'));
+  expect(onChange).toHaveBeenNthCalledWith(2, {
+    pollingPlaceIds: ['precinct-1-polling-place'],
   });
 });
 

--- a/apps/admin/frontend/src/components/reporting/filter_editor.tsx
+++ b/apps/admin/frontend/src/components/reporting/filter_editor.tsx
@@ -8,6 +8,7 @@ import {
   Admin,
   Election,
   isCombinedBallotPrimary,
+  pollingPlaceTypeName,
   Tabulation,
 } from '@votingworks/types';
 import { useState } from 'react';
@@ -66,7 +67,8 @@ export type FilterType =
   | 'batch'
   | 'party'
   | 'adjudication-status'
-  | 'district';
+  | 'district'
+  | 'polling-place';
 
 interface FilterRow {
   rowId: number;
@@ -84,6 +86,7 @@ const FILTER_TYPE_LABELS: Record<FilterType, string> = {
   party: 'Party',
   'adjudication-status': 'Adjudication Status',
   district: 'District',
+  'polling-place': 'Polling Place',
 };
 
 const NO_PARTY_FILTER_VALUE = '__NO_PARTY_FILTER__';
@@ -181,6 +184,13 @@ function generateOptionsForFilter({
         value: district.id,
         label: district.name,
       }));
+    case 'polling-place':
+      return election.pollingPlaces.map((pollingPlace) => ({
+        value: pollingPlace.id,
+        label: `${pollingPlace.name} (${pollingPlaceTypeName(
+          pollingPlace.type
+        )})`,
+      }));
     default: {
       /* istanbul ignore next - compile-time check for completeness */
       throwIllegalValue(filterType);
@@ -224,6 +234,9 @@ function convertFilterRowsToTabulationFilter(
         break;
       case 'district':
         filter.districtIds = filterValues;
+        break;
+      case 'polling-place':
+        filter.pollingPlaceIds = filterValues;
         break;
       default: {
         /* istanbul ignore next - compile-time check for completeness */

--- a/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
@@ -54,6 +54,7 @@ export function BallotCountReportBuilder(): JSX.Element {
     'ballot-style',
     'batch',
     'precinct',
+    'polling-place',
     'scanner',
     'voting-method',
     'adjudication-status',
@@ -67,9 +68,6 @@ export function BallotCountReportBuilder(): JSX.Element {
     'groupByScanner',
     'groupByVotingMethod',
   ];
-  if (election.pollingPlaces.length > 0) {
-    allowedFilters.push('polling-place');
-  }
   if (electionDefinition.election.type === 'primary') {
     allowedFilters.push('party');
     allowedGroupBys.push('groupByParty');

--- a/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
@@ -67,6 +67,9 @@ export function BallotCountReportBuilder(): JSX.Element {
     'groupByScanner',
     'groupByVotingMethod',
   ];
+  if (election.pollingPlaces.length > 0) {
+    allowedFilters.push('polling-place');
+  }
   if (electionDefinition.election.type === 'primary') {
     allowedFilters.push('party');
     allowedGroupBys.push('groupByParty');

--- a/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/reporting/ballot_count_report_builder.tsx
@@ -51,14 +51,14 @@ export function BallotCountReportBuilder(): JSX.Element {
   }
 
   const allowedFilters: FilterType[] = [
+    'adjudication-status',
     'ballot-style',
     'batch',
-    'precinct',
+    'district',
     'polling-place',
+    'precinct',
     'scanner',
     'voting-method',
-    'adjudication-status',
-    'district',
   ];
   const allowedGroupBys: GroupByEditorOption[] = [
     'groupByBallotStyle',

--- a/apps/admin/frontend/src/screens/reporting/tally_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/reporting/tally_report_builder.tsx
@@ -48,11 +48,11 @@ export function TallyReportBuilder(): JSX.Element {
   const allowedFilters: FilterType[] = [
     'ballot-style',
     'batch',
-    'precinct',
+    'district',
     'polling-place',
+    'precinct',
     'scanner',
     'voting-method',
-    'district',
   ]; // omits party
 
   const hasMadeSelections = !isFilterEmpty(filter) || !isGroupByEmpty(groupBy);

--- a/apps/admin/frontend/src/screens/reporting/tally_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/reporting/tally_report_builder.tsx
@@ -49,13 +49,11 @@ export function TallyReportBuilder(): JSX.Element {
     'ballot-style',
     'batch',
     'precinct',
+    'polling-place',
     'scanner',
     'voting-method',
     'district',
   ]; // omits party
-  if (election.pollingPlaces.length > 0) {
-    allowedFilters.push('polling-place');
-  }
 
   const hasMadeSelections = !isFilterEmpty(filter) || !isGroupByEmpty(groupBy);
   return (

--- a/apps/admin/frontend/src/screens/reporting/tally_report_builder.tsx
+++ b/apps/admin/frontend/src/screens/reporting/tally_report_builder.tsx
@@ -9,10 +9,16 @@ import {
 import { Admin, Tabulation } from '@votingworks/types';
 import { AppContext } from '../../contexts/app_context.js';
 import { NavigationScreen } from '../../components/navigation_screen.js';
-import { FilterEditor } from '../../components/reporting/filter_editor.js';
+import {
+  FilterEditor,
+  FilterType,
+} from '../../components/reporting/filter_editor.js';
 import { GroupByEditor } from '../../components/reporting/group_by_editor.js';
 import { TallyReportViewer } from '../../components/reporting/tally_report_viewer.js';
-import { canonicalizeFilter, canonicalizeGroupBy } from '../../utils/reporting.js';
+import {
+  canonicalizeFilter,
+  canonicalizeGroupBy,
+} from '../../utils/reporting.js';
 import {
   ReportBuilderControls,
   ControlLabel,
@@ -39,6 +45,18 @@ export function TallyReportBuilder(): JSX.Element {
     setGroupBy(canonicalizeGroupBy(newGroupBy));
   }
 
+  const allowedFilters: FilterType[] = [
+    'ballot-style',
+    'batch',
+    'precinct',
+    'scanner',
+    'voting-method',
+    'district',
+  ]; // omits party
+  if (election.pollingPlaces.length > 0) {
+    allowedFilters.push('polling-place');
+  }
+
   const hasMadeSelections = !isFilterEmpty(filter) || !isGroupByEmpty(groupBy);
   return (
     <NavigationScreen title={TITLE} parentRoutes={reportParentRoutes} noPadding>
@@ -50,14 +68,7 @@ export function TallyReportBuilder(): JSX.Element {
             <FilterEditor
               election={election}
               onChange={updateFilter}
-              allowedFilters={[
-                'ballot-style',
-                'batch',
-                'precinct',
-                'scanner',
-                'voting-method',
-                'district',
-              ]} // omits party
+              allowedFilters={allowedFilters}
             />
           </div>
           <div>

--- a/apps/admin/frontend/src/utils/reporting.test.ts
+++ b/apps/admin/frontend/src/utils/reporting.test.ts
@@ -29,6 +29,7 @@ test('canonicalizeFilter', () => {
       partyIds: [],
       adjudicationFlags: [],
       districtIds: [],
+      pollingPlaceIds: [],
     })
   ).toEqual({});
   expect(
@@ -41,6 +42,7 @@ test('canonicalizeFilter', () => {
       partyIds: ['b', 'a'],
       adjudicationFlags: ['isBlank', 'hasOvervote'],
       districtIds: ['district-2', 'district-1'],
+      pollingPlaceIds: ['precinct-2-polling-place', 'precinct-1-polling-place'],
     })
   ).toEqual({
     precinctIds: ['a', 'b'],
@@ -51,6 +53,7 @@ test('canonicalizeFilter', () => {
     partyIds: ['a', 'b'],
     adjudicationFlags: ['hasOvervote', 'isBlank'],
     districtIds: ['district-1', 'district-2'],
+    pollingPlaceIds: ['precinct-1-polling-place', 'precinct-2-polling-place'],
   });
 });
 
@@ -292,6 +295,23 @@ test('generateTallyReportPdfFilename', () => {
       expectedFilename:
         'TEST-unofficial-district-1-absentee-ballots-tally-report__2023-12-09_15-59-32.pdf',
     },
+    {
+      filter: {
+        pollingPlaceIds: ['precinct-1-polling-place'],
+      },
+      expectedFilename:
+        'unofficial-precinct-1-tally-report__2023-12-09_15-59-32.pdf',
+    },
+    {
+      filter: {
+        pollingPlaceIds: [
+          'precinct-1-polling-place',
+          'precinct-2-polling-place',
+        ],
+      },
+      expectedFilename:
+        'unofficial-custom-tally-report__2023-12-09_15-59-32.pdf',
+    },
   ];
 
   for (const testCase of testCases) {
@@ -342,4 +362,5 @@ test('isFilterEmpty', () => {
   expect(isFilterEmpty({ batchIds: [] })).toEqual(false);
   expect(isFilterEmpty({ adjudicationFlags: [] })).toEqual(false);
   expect(isFilterEmpty({ districtIds: [] })).toEqual(false);
+  expect(isFilterEmpty({ pollingPlaceIds: [] })).toEqual(false);
 });

--- a/apps/admin/frontend/src/utils/reporting.ts
+++ b/apps/admin/frontend/src/utils/reporting.ts
@@ -13,7 +13,8 @@ export function isFilterEmpty(filter: Admin.FrontendReportingFilter): boolean {
   return (
     isTabulationFilterEmpty(filter) &&
     !filter.adjudicationFlags &&
-    !filter.districtIds
+    !filter.districtIds &&
+    !filter.pollingPlaceIds
   );
 }
 
@@ -29,7 +30,8 @@ function isCompoundFilter(filter: Admin.FrontendReportingFilter): boolean {
       (filter.scannerIds && filter.scannerIds.length > 1) ||
       (filter.votingMethods && filter.votingMethods.length > 1) ||
       (filter.adjudicationFlags && filter.adjudicationFlags.length > 1) ||
-      (filter.districtIds && filter.districtIds.length > 1)
+      (filter.districtIds && filter.districtIds.length > 1) ||
+      (filter.pollingPlaceIds && filter.pollingPlaceIds.length > 1)
   );
 }
 
@@ -45,7 +47,8 @@ function getFilterRank(filter: Admin.FrontendReportingFilter): number {
     (filter.votingMethods?.[0] ? 1 : 0) +
     (filter.partyIds?.[0] ? 1 : 0) +
     (filter.adjudicationFlags?.[0] ? 1 : 0) +
-    (filter.districtIds?.[0] ? 1 : 0)
+    (filter.districtIds?.[0] ? 1 : 0) +
+    (filter.pollingPlaceIds?.[0] ? 1 : 0)
   );
 }
 
@@ -90,6 +93,10 @@ export function canonicalizeFilter(
     districtIds:
       filter.districtIds && filter.districtIds.length > 0
         ? [...filter.districtIds].sort()
+        : undefined,
+    pollingPlaceIds:
+      filter.pollingPlaceIds && filter.pollingPlaceIds.length > 0
+        ? [...filter.pollingPlaceIds].sort()
         : undefined,
   };
 }
@@ -141,6 +148,7 @@ function generateReportFilenameFilterPrefix({
   const batchId = filter.batchIds?.[0];
   const adjudicationFlag = filter.adjudicationFlags?.[0];
   const districtId = filter.districtIds?.[0];
+  const pollingPlaceId = filter.pollingPlaceIds?.[0];
 
   if (precinctId) {
     const precinctName = find(
@@ -161,6 +169,18 @@ function generateReportFilenameFilterPrefix({
     ).name;
     filterPrefixes.push(
       sanitizeStringForFilename(districtName, {
+        replaceInvalidCharsWith: WORD_SEPARATOR,
+      })
+    );
+  }
+
+  if (pollingPlaceId) {
+    const pollingPlaceName = find(
+      election.pollingPlaces,
+      (p) => p.id === pollingPlaceId
+    ).name;
+    filterPrefixes.push(
+      sanitizeStringForFilename(pollingPlaceName, {
         replaceInvalidCharsWith: WORD_SEPARATOR,
       })
     );

--- a/libs/types/src/admin/reporting.ts
+++ b/libs/types/src/admin/reporting.ts
@@ -40,6 +40,7 @@ export type ReportingFilter = Tabulation.Filter & {
  */
 export type FrontendReportingFilter = ReportingFilter & {
   districtIds?: string[];
+  pollingPlaceIds?: string[];
 };
 
 /**

--- a/libs/ui/src/reports/custom_filter_summary.test.tsx
+++ b/libs/ui/src/reports/custom_filter_summary.test.tsx
@@ -115,6 +115,32 @@ test('district filter', () => {
   );
 });
 
+test('polling place filter', () => {
+  render(
+    <CustomFilterSummary
+      electionDefinition={electionDefinition}
+      scannerBatches={mockScannerBatches}
+      filter={{ pollingPlaceIds: ['23-polling-place'] }}
+    />
+  );
+  expect(screen.getByTestId('custom-filter-summary').textContent).toEqual(
+    'Polling Place: North Lincoln'
+  );
+});
+
+test('multiple polling place filter', () => {
+  render(
+    <CustomFilterSummary
+      electionDefinition={electionDefinition}
+      scannerBatches={mockScannerBatches}
+      filter={{ pollingPlaceIds: ['23-polling-place', 'central-scanning'] }}
+    />
+  );
+  expect(screen.getByTestId('custom-filter-summary').textContent).toEqual(
+    'Polling Places: North Lincoln, Central Scanning'
+  );
+});
+
 test('party filter', () => {
   const electionTwoPartyPrimaryDefinition =
     electionTwoPartyPrimaryFixtures.readElectionDefinition();

--- a/libs/ui/src/reports/custom_filter_summary.tsx
+++ b/libs/ui/src/reports/custom_filter_summary.tsx
@@ -125,6 +125,22 @@ export function CustomFilterSummary({
             .join(', ')}
         </FilterDisplayRow>
       )}
+      {filter.pollingPlaceIds && (
+        <FilterDisplayRow>
+          <Font weight="semiBold">
+            {pluralize('Polling Place', filter.pollingPlaceIds.length)}:
+          </Font>{' '}
+          {filter.pollingPlaceIds
+            .map(
+              (pollingPlaceId) =>
+                CachedElectionLookups.getPollingPlaceById(
+                  electionDefinition,
+                  pollingPlaceId
+                ).name
+            )
+            .join(', ')}
+        </FilterDisplayRow>
+      )}
       {filter.partyIds && (
         <FilterDisplayRow>
           <Font weight="semiBold">

--- a/libs/utils/src/tabulation/lookups.test.ts
+++ b/libs/utils/src/tabulation/lookups.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   getContestById,
   getPartyById,
+  getPollingPlaceById,
   getBallotStyleById,
   getParentBallotStyleById,
   getPrecinctById,
@@ -53,6 +54,19 @@ test('getPrecinctById', () => {
   expect(getPrecinctById(electionDefinition, 'precinct-1').name).toEqual(
     'Precinct 1'
   );
+});
+
+test('getPollingPlaceById', () => {
+  const electionDefinition = electionTwoPartyPrimaryDefinition;
+  expect(
+    getPollingPlaceById(electionDefinition, 'precinct-1-polling-place').name
+  ).toEqual('Precinct 1');
+  expect(
+    getPollingPlaceById(electionDefinition, 'precinct-2-polling-place').name
+  ).toEqual('Precinct 2');
+  expect(() =>
+    getPollingPlaceById(electionDefinition, 'nonexistent-polling-place')
+  ).toThrowError();
 });
 
 test('getPartyById', () => {

--- a/libs/utils/src/tabulation/lookups.ts
+++ b/libs/utils/src/tabulation/lookups.ts
@@ -9,6 +9,7 @@ import {
   ElectionDefinition,
   BallotStyleGroup,
   Party,
+  PollingPlace,
   Precinct,
   PrecinctId,
   getBallotStyle,
@@ -58,6 +59,17 @@ export const getDistrictById = createElectionMetadataLookupFunction(
       districtLookup[district.id] = district;
     }
     return districtLookup;
+  }
+);
+
+export const getPollingPlaceById = createElectionMetadataLookupFunction(
+  (election) => {
+    const { pollingPlaces } = election;
+    const pollingPlaceLookup: Record<string, PollingPlace> = {};
+    for (const pollingPlace of pollingPlaces) {
+      pollingPlaceLookup[pollingPlace.id] = pollingPlace;
+    }
+    return pollingPlaceLookup;
   }
 );
 


### PR DESCRIPTION
## Overview

Closes #9018.

Adds **Polling Place** as a filter option in the Tally Report Builder and the
Ballot Count Report Builder.

Polling place is not a cast vote record attribute. It is a property of the batch
a ballot was scanned in (`scanner_batches.polling_place_id`), so it cannot be
reduced to precincts alone — an election day polling place, the early voting
place, and the central scanning absentee place may all cover the same precincts,
and a precinct-based filter would mix all three together. This follows the
pattern already established by the district filter: `FrontendReportingFilter`
gains a `pollingPlaceIds` dimension, and the backend reduces it to lower-level
cast vote record dimensions in `convertFrontendFilter` before tabulation.

The reduction produces two things:

- **`batchIds`** — the batches attributed to the selected polling places. This is
  what actually selects the ballots, and matches the approach already used by
  live results reporting (`live_results_reporting.ts`).
- **`precinctIds`** — the precincts those polling places cover. This is redundant
  for selecting cast vote records, since every ballot in those batches is
  necessarily from one of those precincts, but the contest list and the expected
  groups of a report are derived from the election definition rather than from
  the cast vote records. Without it, a report filtered to a single polling place
  would list every contest in the election, most of them with zero votes.

Both components intersect with anything the user already selected on those
dimensions, so Polling Place composes with the existing Batch and Precinct
filters.

No schema migration, no new SQL, and no change to `Tabulation.Filter` — the new
dimension exists only on the frontend filter type and is gone by the time
tabulation runs (enforced by `assertIsBackendFilter`).

### Behavior worth knowing about

- **Manual tallies are excluded** from polling-place-filtered reports. Once the
  filter carries `batchIds` it is incompatible with manual results
  (`isFilterCompatibleWithManualResults`), and the result is dropped silently.
  This is consistent with the existing Batch and Scanner filters, and with live
  results reporting. Manual tallies are entered against precincts and ballot
  styles, which cannot be attributed to a polling place. Deliberately not
  warning the user about this here.
- **Split precincts are scoped imprecisely.** A polling place covering only some
  splits of a precinct contributes the whole precinct, so its report may list
  contests only the precinct's other splits vote on. Called out in a comment at
  the reduction site.
- **`groupByPollingPlace` is not included and is not planned.** Polling places
  can intersect, unlike every other grouping dimension, which makes them
  incompatible with the tabulation logic's grouping model.

### Pre-existing issue this does not fix

When a filter intersection comes out empty, the reduced filter carries `[]`.
`determineCsvMetadataStructure` treats an empty array as truthy, classifies the
dimension as `single`, and `assertOnlyElement([])` then throws during CSV export
(`csv_shared.ts:189`). This is reachable on `main` today via District + a
non-intersecting Ballot Style; this PR adds a second route via Polling Place + a
non-covered Precinct. Left alone here pending a decision on where to fix it.

## Demo Video or Screenshot

<img width="1063" height="661" alt="Screenshot 2026-08-09 at 5 36 27 PM" src="https://github.com/user-attachments/assets/481c1104-cd8f-477b-9e61-461733e3b3b4" />
<img width="1063" height="660" alt="Screenshot 2026-08-09 at 5 36 34 PM" src="https://github.com/user-attachments/assets/5e391450-97b6-4e4b-89e3-c611be3c55cd" />

## Testing Plan

Automated, all added in this PR:

- `apps/admin/backend/src/util/filters.test.ts` — the reduction itself: single
  and multiple polling places, union of batches and precincts, a polling place
  with no imported batches, batches with no polling place attribution,
  intersection with pre-existing `batchIds` and `precinctIds` including the
  empty-intersection case, and composition with the district and voting method
  filters.
- `apps/admin/backend/src/app.tally_report_data.test.ts` — end to end through the
  API on `electionPrimaryPrecinctSplits`, asserting both that only ballots from
  the polling place's batches are counted and that the contest list excludes the
  congressional-2 and water-2 contests that polling place cannot vote on.
- `apps/admin/backend/src/reports/titles.test.ts` — `Tally Report • Center
  Springfield` for a single polling place, and `title-not-supported` for multiple
  polling places or a polling place combined with another dimension.
- `apps/admin/frontend/src/components/reporting/filter_editor.test.tsx` — adding
  the filter row and selecting a value.
- `apps/admin/frontend/src/utils/reporting.test.ts` — canonicalization,
  `isFilterEmpty`, and report filename generation.
- `libs/ui/src/reports/custom_filter_summary.test.tsx` — the Polling Place row on
  reports whose filter is too complex for a generated title, singular and plural.
- `libs/utils/src/tabulation/lookups.test.ts` — the new cached
  `getPollingPlaceById` lookup.

Manual verification:

- Mutation tested the contest scoping claim: with the `precinctIds` intersection
  removed, the end-to-end test fails with `congressional-2-fish` and
  `congressional-2-mammal` leaking into the report, confirming the assertion is
  real rather than incidentally passing.
- Traced the grouping code path by hand and confirmed empirically that filtering
  to one polling place and grouping by precinct yields exactly that polling
  place's precinct rather than all four with three empty, and that grouping by a
  dimension the filter does not touch still produces its full set of groups.
  Details in the review thread on `filters.ts`.

Full test suites, lint, type-check, and coverage thresholds pass for all five
affected packages: `admin-backend`, `admin-frontend`, `libs/types`, `libs/ui`,
`libs/utils`.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
