### PR TITLE
[Admin] Fix CSV export crash when a filter selects no values

### DIFF
--- a/apps/admin/backend/src/exports/csv_shared.test.ts
+++ b/apps/admin/backend/src/exports/csv_shared.test.ts
@@ -14,44 +14,6 @@ const ALL: CsvMetadataStructure = {
   batch: 'all',
 };
 
-test('determineCsvMetadataStructure - no filter or group by', () => {
-  expect(determineCsvMetadataStructure({ filter: {}, groupBy: {} })).toEqual(
-    ALL
-  );
-});
-
-test('determineCsvMetadataStructure - single and multiple filter values', () => {
-  expect(
-    determineCsvMetadataStructure({
-      filter: {
-        precinctIds: ['precinct-1'],
-        ballotStyleGroupIds: ['1M', '2F'],
-        partyIds: ['0'],
-        votingMethods: ['absentee', 'precinct'],
-        scannerIds: ['scanner-1'],
-        batchIds: ['batch-1', 'batch-2'],
-      },
-      groupBy: {},
-    })
-  ).toEqual({
-    precinct: 'single',
-    ballotStyle: 'multi',
-    party: 'single',
-    votingMethod: 'multi',
-    scanner: 'single',
-    batch: 'multi',
-  });
-});
-
-test('determineCsvMetadataStructure - grouping forces single', () => {
-  expect(
-    determineCsvMetadataStructure({
-      filter: { precinctIds: ['precinct-1', 'precinct-2'] },
-      groupBy: { groupByPrecinct: true },
-    })
-  ).toMatchObject({ precinct: 'single' });
-});
-
 // A filter dimension reduced to no values selects no ballots. It must not be
 // treated as "single", since there is no lone value to report, and must not be
 // treated as "all", which would mean the dimension is unfiltered.

--- a/apps/admin/backend/src/exports/csv_shared.test.ts
+++ b/apps/admin/backend/src/exports/csv_shared.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from 'vitest';
+import { Tabulation } from '@votingworks/types';
+import {
+  CsvMetadataStructure,
+  determineCsvMetadataStructure,
+} from './csv_shared.js';
+
+const ALL: CsvMetadataStructure = {
+  precinct: 'all',
+  ballotStyle: 'all',
+  party: 'all',
+  votingMethod: 'all',
+  scanner: 'all',
+  batch: 'all',
+};
+
+test('determineCsvMetadataStructure - no filter or group by', () => {
+  expect(determineCsvMetadataStructure({ filter: {}, groupBy: {} })).toEqual(
+    ALL
+  );
+});
+
+test('determineCsvMetadataStructure - single and multiple filter values', () => {
+  expect(
+    determineCsvMetadataStructure({
+      filter: {
+        precinctIds: ['precinct-1'],
+        ballotStyleGroupIds: ['1M', '2F'],
+        partyIds: ['0'],
+        votingMethods: ['absentee', 'precinct'],
+        scannerIds: ['scanner-1'],
+        batchIds: ['batch-1', 'batch-2'],
+      },
+      groupBy: {},
+    })
+  ).toEqual({
+    precinct: 'single',
+    ballotStyle: 'multi',
+    party: 'single',
+    votingMethod: 'multi',
+    scanner: 'single',
+    batch: 'multi',
+  });
+});
+
+test('determineCsvMetadataStructure - grouping forces single', () => {
+  expect(
+    determineCsvMetadataStructure({
+      filter: { precinctIds: ['precinct-1', 'precinct-2'] },
+      groupBy: { groupByPrecinct: true },
+    })
+  ).toMatchObject({ precinct: 'single' });
+});
+
+// A filter dimension reduced to no values selects no ballots. It must not be
+// treated as "single", since there is no lone value to report, and must not be
+// treated as "all", which would mean the dimension is unfiltered.
+test('determineCsvMetadataStructure - empty filter values are not single', () => {
+  const dimensions: Array<
+    [keyof Tabulation.Filter, keyof CsvMetadataStructure]
+  > = [
+    ['precinctIds', 'precinct'],
+    ['ballotStyleGroupIds', 'ballotStyle'],
+    ['partyIds', 'party'],
+    ['votingMethods', 'votingMethod'],
+    ['scannerIds', 'scanner'],
+    ['batchIds', 'batch'],
+  ];
+
+  for (const [filterKey, structureKey] of dimensions) {
+    const structure = determineCsvMetadataStructure({
+      filter: { [filterKey]: [] },
+      groupBy: {},
+    });
+    expect(structure).toEqual({ ...ALL, [structureKey]: 'multi' });
+  }
+});

--- a/apps/admin/backend/src/exports/csv_shared.ts
+++ b/apps/admin/backend/src/exports/csv_shared.ts
@@ -57,6 +57,13 @@ type Multiplicity = 'single' | 'multi' | 'all';
  * alongside which we want to add additional related metadata. The "multi"
  * attributes are only to ensure the CSV is self-documenting when there are
  * filters selecting for multiple values.
+ *
+ * An attribute filtered on *no* values is also treated as "multi". Filters that
+ * select nothing arise when the frontend filter is reduced to cast vote record
+ * dimensions and the reduction has no overlap with what the user already
+ * selected - e.g. a district combined with a ballot style outside it. Such a
+ * report matches no ballots and so has no rows, but the attribute is still not
+ * "single": there is no lone value to report alongside.
  */
 export type CsvMetadataStructure = {
   [K in CsvMetadataAttribute]: Multiplicity;
@@ -74,32 +81,32 @@ export function determineCsvMetadataStructure({
 }): CsvMetadataStructure {
   const filterStructure: CsvMetadataStructure = {
     precinct: filter.precinctIds
-      ? filter.precinctIds.length > 1
+      ? filter.precinctIds.length !== 1
         ? 'multi'
         : 'single'
       : 'all',
     ballotStyle: filter.ballotStyleGroupIds
-      ? filter.ballotStyleGroupIds.length > 1
+      ? filter.ballotStyleGroupIds.length !== 1
         ? 'multi'
         : 'single'
       : 'all',
     party: filter.partyIds
-      ? filter.partyIds.length > 1
+      ? filter.partyIds.length !== 1
         ? 'multi'
         : 'single'
       : 'all',
     votingMethod: filter.votingMethods
-      ? filter.votingMethods.length > 1
+      ? filter.votingMethods.length !== 1
         ? 'multi'
         : 'single'
       : 'all',
     scanner: filter.scannerIds
-      ? filter.scannerIds.length > 1
+      ? filter.scannerIds.length !== 1
         ? 'multi'
         : 'single'
       : 'all',
     batch: filter.batchIds
-      ? filter.batchIds.length > 1
+      ? filter.batchIds.length !== 1
         ? 'multi'
         : 'single'
       : 'all',

--- a/apps/admin/backend/src/exports/csv_tally_report.test.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.test.ts
@@ -3,6 +3,7 @@ import {
   electionTwoPartyPrimaryFixtures,
   makeTemporaryDirectory,
   makeTemporaryFile,
+  readElectionGeneralDefinition,
 } from '@votingworks/fixtures';
 import {
   BallotStyleGroupId,
@@ -22,6 +23,7 @@ import {
 } from './csv_tally_report.js';
 import { iterableToString, mockFileName, parseCsv } from '../../test/csv.js';
 import { Store } from '../store.js';
+import { convertFrontendFilter } from '../util/filters.js';
 
 test('uses appropriate headers', async () => {
   const store = Store.memoryStore(makeTemporaryDirectory());
@@ -840,4 +842,62 @@ test('ballots cast rows reflect per-contest ballot counts across ballot styles',
   expect(getBallotsCast('best-animal-fish')).toEqual('1');
   // non-partisan contest on both styles: 4 ballots
   expect(getBallotsCast('fishing')).toEqual('4');
+});
+
+test('filter reduced to no values exports a CSV with no rows', async () => {
+  const store = Store.memoryStore(makeTemporaryDirectory());
+  const electionDefinition = readElectionGeneralDefinition();
+  const { electionData, election } = electionDefinition;
+  const electionId = await store.addElection({
+    electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageSourceFilePath: makeTemporaryFile(),
+    electionPackageHash: 'test-election-package-hash',
+  });
+  store.setCurrentElectionId(electionId);
+
+  addMockCvrFileToStore({
+    electionId,
+    mockCastVoteRecordFile: [
+      {
+        ballotStyleGroupId: '12',
+        batchId: 'batch-1',
+        scannerId: 'scanner-1',
+        precinctId: '23',
+        votingMethod: 'precinct',
+        votes: {},
+        card: { type: 'bmd' },
+        multiplier: 3,
+      },
+    ],
+    store,
+    pollingPlaceId: '23-polling-place',
+  });
+
+  // District 2 is served only by ballot style 12, so combining it with ballot
+  // style 5 leaves no ballot styles at all. The report matches nothing, which
+  // must export cleanly rather than being mistaken for a single-value filter.
+  const filter = convertFrontendFilter(
+    {
+      districtIds: ['district-2'],
+      ballotStyleGroupIds: ['5'] as BallotStyleGroupId[],
+    },
+    election
+  );
+  expect(filter).toEqual({ ballotStyleGroupIds: [] });
+
+  const fileContents = await iterableToString(
+    generateTallyReportCsv({ store, filter, filename: mockFileName() })
+  );
+  const { headers, rows } = parseCsv(fileContents);
+
+  expect(rows).toEqual([]);
+  expect(headers).toEqual([
+    'Included Ballot Styles',
+    'Contest',
+    'Contest ID',
+    'Selection',
+    'Selection ID',
+    'Total Votes',
+  ]);
 });


### PR DESCRIPTION
## Overview

Found while reviewing #9103, but **pre-existing on `main` and independent of it** —
this branches off `main` and can merge in either order.

A report filter that selects no values crashes CSV export.
`determineCsvMetadataStructure` tests each filter dimension for truthiness, and
an empty array is truthy, so a dimension filtered on *zero* values was
classified `single`. `getCsvMetadataRowValues` then called `assertOnlyElement`
on it and threw (`csv_shared.ts:196`). This affects both the tally report and
ballot count CSV exports, which share the helper.

Empty filter dimensions are produced by `convertFrontendFilter`, which reduces
the higher-level dimensions the frontend offers into cast vote record
dimensions. When the reduction has no overlap with what the user already
selected, the result is empty. The frontend is never the source — its
`canonicalizeFilter` maps empty arrays to `undefined`.

Reachable today by selecting a **District** together with a **Ballot Style**
outside it, then exporting CSV. Once #9103 lands there is a second route, a
**Polling Place** together with a **Precinct** it does not cover; the fix here
is dimension-agnostic and covers that automatically.

### The fix

Such an attribute is now classified `multi` rather than `single`.

It is deliberately **not** classified `all`. `all` means "unfiltered", so
treating an empty selection that way would export every ballot in the election
rather than none — turning a loud crash into a silently wrong tally report. The
emptiness has to survive into the metadata classification.

The resulting CSV has the metadata header row but no data rows, since a filter
selecting nothing also yields no contests:

```
test-file-name,Election ID: bc93a55
Included Ballot Styles,Contest,Contest ID,Selection,Selection ID,Total Votes
```

## Demo Video or Screenshot

Not applicable — the user-visible change is that CSV export completes instead of
throwing.

## Testing Plan

- `apps/admin/backend/src/exports/csv_shared.test.ts` (new) — asserts an empty
  selection is not classified `single`, for each of the six dimensions. Three of
  them are reachable in production across this PR and #9103, so a partial fix
  would be caught here and not by the end-to-end test below.
- `apps/admin/backend/src/exports/csv_tally_report.test.ts` — end-to-end
  regression test driving the real `convertFrontendFilter` district route
  (District 2 + Ballot Style 5 on `electionGeneral`), asserting both that the
  reduction genuinely produces `{ ballotStyleGroupIds: [] }` and that the export
  yields headers with zero rows rather than throwing.

Both tests were confirmed to **fail without the fix** — reverting the change
produces 2 failures at `assertOnlyElement` — so they are genuine regression
tests rather than incidentally passing.

Full `admin-backend` suite passes (466 tests), along with lint, type-check, and
coverage thresholds.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
