### PR TITLE
Format staged Rust files in the pre-commit hook

### DIFF
--- a/.lintstagedrc.shared.js
+++ b/.lintstagedrc.shared.js
@@ -5,6 +5,10 @@ const base = {
     'prettier --write',
   ],
   '*.+(js|jsx|ts|tsx)': ['eslint --cache --quiet --fix'],
+  // skip_children keeps rustfmt from recursively formatting a staged file's
+  // out-of-line child modules, which may not be staged. The parser edition
+  // comes from the root rustfmt.toml.
+  '*.rs': ['rustfmt --config skip_children=true'],
   'package.json': ['sort-package-json'],
 };
 

--- a/libs/ballot-interpreter/.lintstagedrc.js
+++ b/libs/ballot-interpreter/.lintstagedrc.js
@@ -26,5 +26,6 @@ module.exports = {
       ? [`eslint --cache --quiet --fix ${filtered.join(' ')}`]
       : [];
   },
+  '*.rs': base['*.rs'],
   'package.json': ['sort-package-json'],
 };

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,5 @@
+# Only sets the parser edition, needed when rustfmt is invoked directly on a
+# file (as the lint-staged pre-commit hook does) rather than via `cargo fmt`,
+# which reads the edition from Cargo.toml. Without it, rustfmt parses as
+# edition 2015 and errors on `async fn`. Formatting style is rustfmt defaults.
+edition = "2021"


### PR DESCRIPTION
## Overview

The lint-staged configs only covered JS/TS-adjacent files, so Rust code landed unformatted and CI's `cargo fmt --check` was the first thing to notice. This adds pre-commit formatting for staged `.rs` files:

- A `*.rs` rule in the shared `base` lint-staged config, all configs inherit implicitly, except for `ballot-interpreter`'s custom config where it's inherited explicitly.
- A root `rustfmt.toml` declaring `edition = "2021"`, needed because bare rustfmt parses as edition 2015 and errors on `async fn`. `cargo fmt` and CI are unaffected (they read the edition from `Cargo.toml`), and per-file rustfmt with default style matches `cargo fmt --check` exactly since the repo has no style overrides.

`cargo clippy` deliberately stays CI-only: it needs a full dependency build per cargo root and the workspace denies `clippy::pedantic`, which might be a bit slow for a commit-blocking action. However, `eslint` is slower so there's an argument to be made that we should add `cargo clippy` too.

I chose this approach over migrating to lefthook or otherwise after evaluating the current versions of each. `lint-staged`'s partial-staging machinery is the most mature, and the change required to add Rust support were minimal.

## Demo Video or Screenshot

n/a

## Testing Plan

- All four cargo roots (`.`, `libs/ballot-interpreter`, `libs/types-rs`, `libs/pdi-scanner`) verify `cargo fmt --check` clean with the new `rustfmt.toml` present, so CI behavior is unchanged.
- Verified end to end through the real hook: a deliberately misformatted `async fn` committed in `libs/types-rs` (covered by the root config fallthrough) landed formatted; the same worked through ballot-interpreter's custom config; and a partially staged file committed its staged hunk formatted while the unstaged hunks survived untouched in the worktree.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions (_none — tooling only_).
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoLZVgnMKXfZ1FM52PH8ii
