### PR TITLE
pdictl: frame stdout messages as TLV instead of JSON lines

### DIFF
--- a/libs/pdi-scanner/Cargo.lock
+++ b/libs/pdi-scanner/Cargo.lock
@@ -203,12 +203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,7 +911,6 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 name = "pdi-scanner"
 version = "0.1.0"
 dependencies = [
- "base64",
  "clap",
  "color-eyre",
  "csv",

--- a/libs/pdi-scanner/Cargo.toml
+++ b/libs/pdi-scanner/Cargo.toml
@@ -35,7 +35,6 @@ name = "pdi-parse-traffic"
 path = "src/rust/parse_traffic.rs"
 
 [dependencies]
-base64 = "0.22.0"
 clap = { version = "4.0.29", features = ["derive", "env"] }
 color-eyre = "0.6.2"
 csv = "1.3.0"

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use color_eyre::eyre::bail;
-use image::EncodableLayout;
+use image::{EncodableLayout, GrayImage};
 use std::{
     fmt::Debug,
     future::pending,
@@ -13,7 +13,6 @@ use tokio::{
 };
 use tracing_subscriber::prelude::*;
 
-use base64::{engine::general_purpose::STANDARD, Engine as _};
 use pdi_scanner::{
     client::{Client, DoubleFeedDetectionCalibrationConfig, ImageCalibrationTables},
     protocol::{
@@ -143,8 +142,6 @@ enum Event {
 
     ScanStart,
 
-    ScanComplete(ScanComplete),
-
     CoverOpen,
     CoverClosed,
 
@@ -158,27 +155,6 @@ enum Event {
     ImageSensorCalibrationFailed {
         error: Incoming,
     },
-}
-
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ScanComplete {
-    image_data: (String, String),
-}
-
-impl Debug for ScanComplete {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ScanComplete")
-            .field(
-                "top",
-                &format_args!("{}…", self.image_data.0.get(..20).unwrap_or("utf-8 error")),
-            )
-            .field(
-                "bottom",
-                &format_args!("{}…", self.image_data.1.get(..20).unwrap_or("utf-8 error")),
-            )
-            .finish()
-    }
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -232,6 +208,27 @@ async fn initialize_connected_scanner(
     Ok((client, calibration_tables))
 }
 
+/// TLV frame type for a JSON-encoded [`Message`] (all responses and events
+/// except scan results). Must stay in sync with `scanner_client.ts`.
+const FRAME_TYPE_JSON: u8 = 1;
+
+/// TLV frame type for a completed scan. The payload contains, for each side
+/// (top then bottom): a 4-byte little-endian width, a 4-byte little-endian
+/// height, and `width * height` grayscale pixel bytes. Must stay in sync with
+/// `scanner_client.ts`.
+const FRAME_TYPE_SCAN_COMPLETE: u8 = 2;
+
+/// Byte length of the frame type field in a TLV frame header.
+const FRAME_TYPE_LENGTH: usize = 1;
+
+/// Byte length of a TLV frame header: the frame type followed by a
+/// little-endian `u32` payload length.
+const FRAME_HEADER_LENGTH: usize = FRAME_TYPE_LENGTH + size_of::<u32>();
+
+/// Writes TLV frames to stdout: a 1-byte frame type, a 4-byte little-endian
+/// payload length, and the payload. Sending image data as raw bytes rather
+/// than JSON avoids base64-encoding multi-megabyte scans and parsing them
+/// back out of a giant JSON document on the Node side.
 struct Output<W: Write> {
     stdout: W,
     // We reject sending a command while a scan is in progress because it will
@@ -243,10 +240,24 @@ struct Output<W: Write> {
 }
 
 impl<W: Write> Output<W> {
-    fn send_to_stdout(&mut self, message: &Message) -> color_eyre::Result<()> {
-        serde_json::to_writer(&mut self.stdout, message)?;
-        self.stdout.write_all(b"\n")?;
+    fn write_frame(&mut self, frame_type: u8, payload_parts: &[&[u8]]) -> color_eyre::Result<()> {
+        let payload_length: usize = payload_parts.iter().map(|part| part.len()).sum();
+        let mut header = [0u8; FRAME_HEADER_LENGTH];
+        header[0] = frame_type;
+        header[FRAME_TYPE_LENGTH..].copy_from_slice(&u32::try_from(payload_length)?.to_le_bytes());
+        self.stdout.write_all(&header)?;
+        for part in payload_parts {
+            self.stdout.write_all(part)?;
+        }
+        // Stdout is line-buffered and frames don't end in newlines, so flush
+        // explicitly or the frame may sit in the buffer indefinitely.
+        self.stdout.flush()?;
         Ok(())
+    }
+
+    fn send_to_stdout(&mut self, message: &Message) -> color_eyre::Result<()> {
+        let payload = serde_json::to_vec(message)?;
+        self.write_frame(FRAME_TYPE_JSON, &[&payload])
     }
 
     fn send_response(&mut self, response: Response) -> color_eyre::Result<()> {
@@ -259,6 +270,37 @@ impl<W: Write> Output<W> {
         tracing::debug!("sending event: {event:?}");
         self.scan_in_progress = matches!(event, Event::ScanStart);
         self.send_to_stdout(&Message::Event(event))
+    }
+
+    fn send_scan_complete(
+        &mut self,
+        top: &GrayImage,
+        bottom: &GrayImage,
+    ) -> color_eyre::Result<()> {
+        tracing::debug!(
+            "sending scanComplete: top {}x{}, bottom {}x{}",
+            top.width(),
+            top.height(),
+            bottom.width(),
+            bottom.height()
+        );
+        // A completed scan ends the scan in progress, just like the events
+        // handled in send_event.
+        self.scan_in_progress = false;
+        let (top_width, top_height) = (top.width().to_le_bytes(), top.height().to_le_bytes());
+        let (bottom_width, bottom_height) =
+            (bottom.width().to_le_bytes(), bottom.height().to_le_bytes());
+        self.write_frame(
+            FRAME_TYPE_SCAN_COMPLETE,
+            &[
+                &top_width,
+                &top_height,
+                top.as_bytes(),
+                &bottom_width,
+                &bottom_height,
+                bottom.as_bytes(),
+            ],
+        )
     }
 
     fn send_error_response(&mut self, error: &Error) -> color_eyre::Result<()> {
@@ -274,9 +316,9 @@ impl<W: Write> Output<W> {
     }
 }
 
-/// Runs the main command/event loop. Reads JSON commands from `stdin`,
-/// writes JSON responses and events to `stdout`, and uses `connect` to
-/// create new scanner connections.
+/// Runs the main command/event loop. Reads newline-delimited JSON commands
+/// from `stdin`, writes TLV-framed responses and events to `stdout` (see
+/// [`Output`]), and uses `connect` to create new scanner connections.
 #[allow(clippy::too_many_lines)]
 async fn handle_commands_and_events<R: tokio::io::AsyncBufRead + Unpin, W: Write>(
     stdin: R,
@@ -514,12 +556,7 @@ async fn handle_commands_and_events<R: tokio::io::AsyncBufRead + Unpin, W: Write
                                 .expect("image calibration tables not set"),
                         ) {
                             Ok(Sheet::Duplex(top, bottom)) => {
-                                output.send_event(Event::ScanComplete(ScanComplete {
-                                    image_data: (
-                                        STANDARD.encode(top.as_bytes()),
-                                        STANDARD.encode(bottom.as_bytes()),
-                                    ),
-                                }))?;
+                                output.send_scan_complete(&top, &bottom)?;
                             }
                             Ok(_) => unreachable!(
                                 "try_decode_scan called with {:?} returned non-duplex sheet",
@@ -601,12 +638,14 @@ mod tests {
         time::timeout,
     };
 
-    use super::handle_commands_and_events;
+    use super::{handle_commands_and_events, FRAME_HEADER_LENGTH, FRAME_TYPE_LENGTH};
 
     const TEST_TIMEOUT: Duration = Duration::from_secs(3);
 
-    /// A Write impl that sends each newline-delimited JSON message to a
-    /// channel, allowing the test to await individual messages.
+    /// A Write impl that decodes each TLV frame and sends it to a channel as
+    /// a JSON value, allowing the test to await individual messages. Scan
+    /// complete frames are decoded into
+    /// `{"event": "scanComplete", "images": [{"width", "height", "data"}, …]}`.
     struct ChannelWriter {
         tx: mpsc::UnboundedSender<Value>,
         buf: Vec<u8>,
@@ -625,12 +664,48 @@ mod tests {
         }
     }
 
+    const U32_LENGTH: usize = size_of::<u32>();
+    const IMAGE_DIMENSIONS_LENGTH: usize = 2 * U32_LENGTH;
+
+    fn read_u32_le(bytes: &[u8], offset: usize) -> usize {
+        u32::from_le_bytes(bytes[offset..offset + U32_LENGTH].try_into().unwrap()) as usize
+    }
+
+    fn decode_scan_complete_payload(payload: &[u8]) -> Value {
+        let mut images = Vec::new();
+        let mut offset = 0;
+        while offset < payload.len() {
+            let width = read_u32_le(payload, offset);
+            let height = read_u32_le(payload, offset + U32_LENGTH);
+            let data_start = offset + IMAGE_DIMENSIONS_LENGTH;
+            let data = &payload[data_start..data_start + width * height];
+            images.push(json!({ "width": width, "height": height, "data": data }));
+            offset = data_start + width * height;
+        }
+        json!({ "event": "scanComplete", "images": images })
+    }
+
     impl io::Write for ChannelWriter {
         fn write(&mut self, data: &[u8]) -> io::Result<usize> {
             self.buf.extend_from_slice(data);
-            while let Some(pos) = self.buf.iter().position(|&b| b == b'\n') {
-                let line: Vec<u8> = self.buf.drain(..=pos).collect();
-                let value: Value = serde_json::from_slice(&line).unwrap();
+            loop {
+                if self.buf.len() < FRAME_HEADER_LENGTH {
+                    break;
+                }
+                let payload_length = read_u32_le(&self.buf, FRAME_TYPE_LENGTH);
+                if self.buf.len() < FRAME_HEADER_LENGTH + payload_length {
+                    break;
+                }
+                let frame: Vec<u8> = self
+                    .buf
+                    .drain(..FRAME_HEADER_LENGTH + payload_length)
+                    .collect();
+                let (frame_type, payload) = (frame[0], &frame[FRAME_HEADER_LENGTH..]);
+                let value: Value = match frame_type {
+                    super::FRAME_TYPE_JSON => serde_json::from_slice(payload).unwrap(),
+                    super::FRAME_TYPE_SCAN_COMPLETE => decode_scan_complete_payload(payload),
+                    _ => panic!("unknown frame type: {frame_type}"),
+                };
                 let _ = self.tx.send(value);
             }
             Ok(data.len())
@@ -648,6 +723,13 @@ mod tests {
     }
 
     fn setup_connected_client() -> (Client, ConnectedTestHarness) {
+        setup_connected_client_with_calibration(&[], &[])
+    }
+
+    fn setup_connected_client_with_calibration(
+        white_calibration_table: &[u8],
+        black_calibration_table: &[u8],
+    ) -> (Client, ConnectedTestHarness) {
         use pdi_scanner::protocol::types::Register;
 
         let (host_to_scanner_tx, host_to_scanner_rx) = mpsc::unbounded_channel();
@@ -673,12 +755,12 @@ mod tests {
                 register_9, 0x200, // BootEjectMotion::None (2) << 8
             ))))
             .unwrap();
-        let empty_cal = || Incoming::GetCalibrationInformationResponse {
-            white_calibration_table: vec![],
-            black_calibration_table: vec![],
+        let cal = || Incoming::GetCalibrationInformationResponse {
+            white_calibration_table: white_calibration_table.to_vec(),
+            black_calibration_table: black_calibration_table.to_vec(),
         };
-        scanner_to_host_tx.send(Ok(empty_cal())).unwrap();
-        scanner_to_host_tx.send(Ok(empty_cal())).unwrap();
+        scanner_to_host_tx.send(Ok(cal())).unwrap();
+        scanner_to_host_tx.send(Ok(cal())).unwrap();
 
         let client = Client::from_scanner(Scanner::mock(
             host_to_scanner_tx,
@@ -1130,6 +1212,88 @@ mod tests {
                 json!({"response": "error", "code": "other", "message": "timed out receiving data"})
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn scan_complete_sends_image_frame() {
+        use pdi_scanner::protocol::{image::DEFAULT_IMAGE_WIDTH, packets::ImageData};
+
+        const WIDTH: usize = DEFAULT_IMAGE_WIDTH as usize;
+        const HEIGHT: usize = 4;
+        const TOP_PIXEL: u8 = 7;
+        const BOTTOM_PIXEL: u8 = 9;
+
+        // White = 255 and black = 0 make image calibration the identity
+        // function, so decoded pixels equal the raw pixels.
+        let (client, mut harness) =
+            setup_connected_client_with_calibration(&[u8::MAX; WIDTH], &[0; WIDTH]);
+        let mut client_slot = Some(client);
+        let (stdin_read, mut stdin_write) = tokio::io::duplex(4096);
+        let (stdout_writer, mut output_rx) = ChannelWriter::new();
+
+        let (result, ()) = timeout(TEST_TIMEOUT, async {
+            tokio::join!(
+                handle_commands_and_events(BufReader::new(stdin_read), stdout_writer, || {
+                    Ok(client_slot.take().expect("connect called more than once"))
+                }),
+                async {
+                    send_command(&mut stdin_write, &mut output_rx, r#"{"command":"connect"}"#)
+                        .await;
+
+                    // Drain init commands
+                    while harness.host_to_scanner_rx.try_recv().is_ok() {}
+
+                    harness
+                        .scanner_to_host_tx
+                        .send(Ok(Incoming::BeginScanEvent))
+                        .unwrap();
+                    let msg = recv_output(&mut output_rx).await;
+                    assert_eq!(msg, json!({"event": "scanStart"}));
+
+                    // Duplex image data alternates top and bottom pixels
+                    let mut data = Vec::with_capacity(2 * WIDTH * HEIGHT);
+                    for _ in 0..(WIDTH * HEIGHT) {
+                        data.push(TOP_PIXEL);
+                        data.push(BOTTOM_PIXEL);
+                    }
+                    harness
+                        .scanner_to_host_tx
+                        .send(Ok(Incoming::ImageData(ImageData(data))))
+                        .unwrap();
+
+                    // EndScan needs an ack for the feeder disable command
+                    harness.host_to_scanner_ack_tx.send(5).unwrap();
+                    harness
+                        .scanner_to_host_tx
+                        .send(Ok(Incoming::EndScanEvent))
+                        .unwrap();
+                    let msg = recv_output(&mut output_rx).await;
+                    assert_eq!(
+                        msg,
+                        json!({
+                            "event": "scanComplete",
+                            "images": [
+                                {
+                                    "width": WIDTH,
+                                    "height": HEIGHT,
+                                    "data": vec![TOP_PIXEL; WIDTH * HEIGHT],
+                                },
+                                {
+                                    "width": WIDTH,
+                                    "height": HEIGHT,
+                                    "data": vec![BOTTOM_PIXEL; WIDTH * HEIGHT],
+                                },
+                            ],
+                        })
+                    );
+
+                    send_exit(&mut stdin_write).await;
+                }
+            )
+        })
+        .await
+        .unwrap();
+        result.unwrap();
     }
 
     #[tokio::test]

--- a/libs/pdi-scanner/src/ts/scanner_client.test.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.test.ts
@@ -10,7 +10,6 @@ import { Buffer } from 'node:buffer';
 import {
   createPdiScannerClient,
   DoubleFeedDetectionCalibrationConfig,
-  PdictlEvent,
   SCAN_IMAGE_WIDTH,
   ScannerEvent,
   ScannerStatus,
@@ -24,9 +23,44 @@ beforeEach(() => {
   vi.mocked(spawn).mockImplementation(() => mockChildProcess);
 });
 
+// The frame layout below intentionally re-states the protocol from main.rs
+// rather than reusing scanner_client's internals, so an encode/decode bug
+// can't cancel itself out.
+const FRAME_TYPE_JSON = 1;
+const FRAME_TYPE_SCAN_COMPLETE = 2;
+const FRAME_TYPE_LENGTH = 1;
+const UINT32_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
+const FRAME_HEADER_LENGTH = FRAME_TYPE_LENGTH + UINT32_LENGTH;
+const IMAGE_DIMENSIONS_LENGTH = 2 * UINT32_LENGTH;
+
+function frame(frameType: number, payload: Buffer): Buffer {
+  const header = Buffer.alloc(FRAME_HEADER_LENGTH);
+  header.writeUInt8(frameType, 0);
+  header.writeUInt32LE(payload.length, FRAME_TYPE_LENGTH);
+  return Buffer.concat([header, payload]);
+}
+
+function jsonFrame(message: object): Buffer {
+  return frame(FRAME_TYPE_JSON, Buffer.from(JSON.stringify(message), 'utf-8'));
+}
+
+function scanCompleteFrame(images: Array<{ width: number; data: Buffer }>) {
+  return frame(
+    FRAME_TYPE_SCAN_COMPLETE,
+    Buffer.concat(
+      images.flatMap(({ width, data }) => {
+        const dimensions = Buffer.alloc(IMAGE_DIMENSIONS_LENGTH);
+        dimensions.writeUInt32LE(width, 0);
+        dimensions.writeUInt32LE(data.length / width, UINT32_LENGTH);
+        return [dimensions, data];
+      })
+    )
+  );
+}
+
 function mockStdoutResponse(response: object): void {
   setTimeout(() => {
-    mockChildProcess.stdout.emit('data', `${JSON.stringify(response)}\n`);
+    mockChildProcess.stdout.emit('data', jsonFrame(response));
   });
 }
 
@@ -282,7 +316,7 @@ test('listeners can add new listeners that dont receive the same event', async (
   expect(listener2).not.toHaveBeenCalled();
 });
 
-test('converts image data from scanComplete event', async () => {
+test('converts image data from scanComplete frame', async () => {
   const client = createPdiScannerClient();
   const listener = vi.fn();
   client.addListener(listener);
@@ -293,14 +327,15 @@ test('converts image data from scanComplete event', async () => {
       .take(SCAN_IMAGE_WIDTH * imageHeight)
       .toArray()
   );
-  const scanCompleteEvent: PdictlEvent = {
-    event: 'scanComplete',
-    imageData: [
-      rawImageGrayscalePixels.toString('base64'),
-      rawImageGrayscalePixels.toString('base64'),
-    ],
-  };
-  mockStdoutResponse(scanCompleteEvent);
+  setTimeout(() => {
+    mockChildProcess.stdout.emit(
+      'data',
+      scanCompleteFrame([
+        { width: SCAN_IMAGE_WIDTH, data: rawImageGrayscalePixels },
+        { width: SCAN_IMAGE_WIDTH, data: rawImageGrayscalePixels },
+      ])
+    );
+  });
   await backendWaitFor(() => {
     expect(listener).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -318,6 +353,145 @@ test('converts image data from scanComplete event', async () => {
       `"[ImageData ${SCAN_IMAGE_WIDTH}x${imageHeight}]"`
     );
     expect(back.data).toEqual(front.data);
+  });
+});
+
+test('reassembles frames split across many chunks', async () => {
+  const client = createPdiScannerClient();
+  const listener = vi.fn();
+  client.addListener(listener);
+
+  const imageHeight = 2;
+  const topPixels = Buffer.alloc(SCAN_IMAGE_WIDTH * imageHeight, 7);
+  const bottomPixels = Buffer.alloc(SCAN_IMAGE_WIDTH * imageHeight, 9);
+  const stream = Buffer.concat([
+    jsonFrame({ event: 'scanStart' }),
+    scanCompleteFrame([
+      { width: SCAN_IMAGE_WIDTH, data: topPixels },
+      { width: SCAN_IMAGE_WIDTH, data: bottomPixels },
+    ]),
+    jsonFrame({ event: 'coverOpen' }),
+  ]);
+
+  // Deliver the frames in chunks that split both headers and payloads,
+  // including a chunk containing the end of one frame and the start of the
+  // next.
+  setTimeout(() => {
+    const chunkSize = 1000;
+    for (let offset = 0; offset < stream.length; offset += chunkSize) {
+      mockChildProcess.stdout.emit(
+        'data',
+        stream.subarray(offset, offset + chunkSize)
+      );
+    }
+  });
+
+  await backendWaitFor(() => {
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+  expect(listener).toHaveBeenNthCalledWith(1, { event: 'scanStart' });
+  const [scanCompleteEvent] = listener.mock.calls[1] as [
+    ScannerEvent & { event: 'scanComplete' },
+  ];
+  const [top, bottom] = scanCompleteEvent.images;
+  expect([top.width, top.height]).toEqual([SCAN_IMAGE_WIDTH, imageHeight]);
+  expect(top.data).toEqual(Uint8ClampedArray.from(topPixels));
+  expect([bottom.width, bottom.height]).toEqual([
+    SCAN_IMAGE_WIDTH,
+    imageHeight,
+  ]);
+  expect(bottom.data).toEqual(Uint8ClampedArray.from(bottomPixels));
+  expect(listener).toHaveBeenNthCalledWith(3, { event: 'coverOpen' });
+});
+
+test('emits an error and ignores further output on an unknown frame type', async () => {
+  const client = createPdiScannerClient();
+  const listener = vi.fn();
+  client.addListener(listener);
+
+  setTimeout(() => {
+    mockChildProcess.stdout.emit('data', frame(255, Buffer.from('garbage')));
+  });
+
+  await backendWaitFor(() => {
+    expect(listener).toHaveBeenCalledWith({
+      event: 'error',
+      code: 'other',
+      message: 'corrupt pdictl output stream: Error: unknown frame type: 255',
+    });
+  });
+
+  // Frames received after the corrupt frame are not processed
+  mockChildProcess.stdout.emit('data', jsonFrame({ event: 'scanStart' }));
+  await sleep(0);
+  expect(listener).toHaveBeenCalledTimes(1);
+});
+
+test('emits an error on a JSON frame that is neither a response nor an event', async () => {
+  const client = createPdiScannerClient();
+  const listener = vi.fn();
+  client.addListener(listener);
+
+  setTimeout(() => {
+    mockChildProcess.stdout.emit('data', jsonFrame({ unexpected: true }));
+  });
+
+  await backendWaitFor(() => {
+    expect(listener).toHaveBeenCalledWith({
+      event: 'error',
+      code: 'other',
+      message: expect.stringContaining('corrupt pdictl output stream'),
+    });
+  });
+});
+
+test('emits an error on an implausibly large frame length', async () => {
+  const client = createPdiScannerClient();
+  const listener = vi.fn();
+  client.addListener(listener);
+
+  setTimeout(() => {
+    const header = Buffer.alloc(FRAME_HEADER_LENGTH);
+    header.writeUInt8(FRAME_TYPE_JSON, 0);
+    header.writeUInt32LE(0xffff_ffff, FRAME_TYPE_LENGTH);
+    mockChildProcess.stdout.emit('data', header);
+  });
+
+  await backendWaitFor(() => {
+    expect(listener).toHaveBeenCalledWith({
+      event: 'error',
+      code: 'other',
+      message:
+        'corrupt pdictl output stream: Error: frame payload too large: 4294967295 bytes',
+    });
+  });
+});
+
+test('emits an error on a scanComplete payload length mismatch', async () => {
+  const client = createPdiScannerClient();
+  const listener = vi.fn();
+  client.addListener(listener);
+
+  setTimeout(() => {
+    const validPayload = Buffer.concat([
+      scanCompleteFrame([
+        { width: 2, data: Buffer.alloc(4) },
+        { width: 2, data: Buffer.alloc(4) },
+      ]).subarray(5),
+      Buffer.from([0]), // extra trailing byte
+    ]);
+    mockChildProcess.stdout.emit(
+      'data',
+      frame(FRAME_TYPE_SCAN_COMPLETE, validPayload)
+    );
+  });
+
+  await backendWaitFor(() => {
+    expect(listener).toHaveBeenCalledWith({
+      event: 'error',
+      code: 'other',
+      message: expect.stringContaining('scanComplete payload length mismatch'),
+    });
   });
 });
 

--- a/libs/pdi-scanner/src/ts/scanner_client.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.ts
@@ -1,6 +1,5 @@
 import * as path from 'node:path';
 import { spawn } from 'node:child_process';
-import { createInterface } from 'node:readline';
 import {
   Result,
   assert,
@@ -12,7 +11,7 @@ import {
 } from '@votingworks/basics';
 import { ImageData } from '@votingworks/image-utils';
 import { Buffer } from 'node:buffer';
-import { SheetOf, mapSheet } from '@votingworks/types';
+import { SheetOf } from '@votingworks/types';
 import makeDebug from 'debug';
 
 const debug = makeDebug('pdi-scanner');
@@ -26,6 +25,48 @@ const PDICTL_PATH = path.join(
  * The width of the image produced by the scanner.
  */
 export const SCAN_IMAGE_WIDTH = 1728;
+
+/**
+ * `pdictl` frames its stdout messages as TLV: a 1-byte frame type, a 4-byte
+ * little-endian payload length, and the payload. These constants must stay in
+ * sync with `main.rs`.
+ */
+const FRAME_TYPE_LENGTH = 1;
+
+/**
+ * Byte length of a little-endian `u32` in the framing layout.
+ */
+const UINT32_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
+
+const FRAME_HEADER_LENGTH = FRAME_TYPE_LENGTH + UINT32_LENGTH;
+
+/**
+ * Byte length of the per-image prefix in a scanComplete payload: a `u32`
+ * width followed by a `u32` height.
+ */
+const IMAGE_DIMENSIONS_LENGTH = 2 * UINT32_LENGTH;
+
+/**
+ * TLV frame type for a JSON-encoded response or event (everything except scan
+ * results).
+ */
+const FRAME_TYPE_JSON = 1;
+
+/**
+ * TLV frame type for a completed scan. The payload contains, for each side
+ * (top then bottom): a 4-byte little-endian width, a 4-byte little-endian
+ * height, and `width * height` grayscale pixel bytes. Sending image data as
+ * raw bytes rather than JSON avoids base64-encoding multi-megabyte scans and
+ * parsing them back out of a giant JSON document.
+ */
+const FRAME_TYPE_SCAN_COMPLETE = 2;
+
+/**
+ * A frame payload larger than this cannot be legitimate (a duplex scan of the
+ * longest supported ballot is ~8MB), so it indicates a corrupt or desynced
+ * stream. Failing fast beats buffering garbage indefinitely.
+ */
+const MAX_FRAME_PAYLOAD_LENGTH = 64 * 1024 * 1024;
 
 /**
  * The status of the PDI scanner.
@@ -180,12 +221,13 @@ type PdictlResponse =
 
 /**
  * Internal type to represent the JSON messages received from `pdictl` as
- * unsolicited events (i.e. not in response to a command).
+ * unsolicited events (i.e. not in response to a command). Completed scans are
+ * not JSON messages — they arrive in their own binary frame (see
+ * {@link FRAME_TYPE_SCAN_COMPLETE}).
  */
 export type PdictlEvent =
   | ({ event: 'error' } & ScannerError)
   | { event: 'scanStart' }
-  | { event: 'scanComplete'; imageData: [string, string] }
   | { event: 'coverOpen' }
   | { event: 'coverClosed' }
   | { event: 'ejectPaused' }
@@ -207,16 +249,40 @@ function isResponse(message: PdictlMessage): message is PdictlResponse {
   return 'response' in message;
 }
 
-function loggableMessage(message: PdictlMessage) {
-  if (isEvent(message) && message.event === 'scanComplete') {
+/**
+ * Parses the payload of a {@link FRAME_TYPE_SCAN_COMPLETE} frame into the two
+ * scanned page images. The image data is a zero-copy view over the payload's
+ * memory.
+ */
+function parseScanCompletePayload(payload: Buffer): SheetOf<ImageData> {
+  let offset = 0;
+  function readImage() {
+    const width = payload.readUInt32LE(offset);
+    const height = payload.readUInt32LE(offset + UINT32_LENGTH);
+    const byteLength = width * height;
+    const data = new Uint8ClampedArray(
+      payload.buffer,
+      payload.byteOffset + offset + IMAGE_DIMENSIONS_LENGTH,
+      byteLength
+    );
+    offset += IMAGE_DIMENSIONS_LENGTH + byteLength;
     return {
-      ...message,
-      imageData: message.imageData.map(
-        (imageData) => `${imageData.length} bytes`
-      ),
+      width,
+      height,
+      data,
+
+      // Define `toJSON` such that `JSON.stringify` does not try to
+      // serialize all the bytes in `data` as an array of numbers.
+      // eslint-disable-next-line vx/gts-identifiers
+      toJSON: () => `[ImageData ${width}x${height}]`,
     };
   }
-  return message;
+  const images: SheetOf<ImageData> = [readImage(), readImage()];
+  assert(
+    offset === payload.length,
+    `scanComplete payload length mismatch: expected ${offset}, got ${payload.length}`
+  );
+  return images;
 }
 
 /**
@@ -249,12 +315,8 @@ export function createPdiScannerClient() {
   // time, so we track the commands we sent in a queue.
   const pendingResponseQueue = deferredQueue<PdictlResponse>();
 
-  // Listen for output from pdictl. We may receive either a response to a
-  // command or an unsolicited event.
-  const rl = createInterface(pdictl.stdout);
-  rl.on('line', (line) => {
-    const message = JSON.parse(line) as PdictlMessage;
-    debug('received: %o', loggableMessage(message));
+  function handleJsonMessage(message: PdictlMessage): void {
+    debug('received: %o', message);
 
     if (isResponse(message)) {
       pendingResponseQueue.resolve(message);
@@ -263,38 +325,7 @@ export function createPdiScannerClient() {
 
     assert(isEvent(message));
     switch (message.event) {
-      case 'scanStart': {
-        emit(message);
-        break;
-      }
-      case 'scanComplete': {
-        emit({
-          event: 'scanComplete',
-          images: mapSheet(message.imageData, (imageData) => {
-            const buffer = Buffer.from(imageData, 'base64');
-            // Create a Uint8ClampedArray view over the same memory
-            // instead of copying with Uint8ClampedArray.from(buffer)
-            const data = new Uint8ClampedArray(
-              buffer.buffer,
-              buffer.byteOffset,
-              buffer.byteLength
-            );
-            const width = SCAN_IMAGE_WIDTH;
-            const height = data.length / SCAN_IMAGE_WIDTH;
-            return {
-              width,
-              height,
-              data,
-
-              // Define `toJSON` such that `JSON.stringify` does not try to
-              // serialize all the bytes in `data` as an array of numbers.
-              // eslint-disable-next-line vx/gts-identifiers
-              toJSON: () => `[ImageData ${width}x${height}]`,
-            };
-          }),
-        });
-        break;
-      }
+      case 'scanStart':
       case 'error':
       case 'coverOpen':
       case 'coverClosed':
@@ -310,6 +341,98 @@ export function createPdiScannerClient() {
       default: {
         /* istanbul ignore next */
         throwIllegalValue(message, 'event');
+      }
+    }
+  }
+
+  function handleFrame(frameType: number, payload: Buffer): void {
+    switch (frameType) {
+      case FRAME_TYPE_JSON: {
+        handleJsonMessage(JSON.parse(payload.toString('utf-8')));
+        break;
+      }
+      case FRAME_TYPE_SCAN_COMPLETE: {
+        debug('received: scanComplete (%d payload bytes)', payload.length);
+        emit({
+          event: 'scanComplete',
+          images: parseScanCompletePayload(payload),
+        });
+        break;
+      }
+      default: {
+        throw new Error(`unknown frame type: ${frameType}`);
+      }
+    }
+  }
+
+  // Listen for output from pdictl, reassembling TLV frames from the stream.
+  // We may receive either a response to a command or an unsolicited event.
+  const header = Buffer.alloc(FRAME_HEADER_LENGTH);
+  let headerFilled = 0;
+  let payload: Buffer | undefined;
+  let payloadFilled = 0;
+  let streamIsCorrupt = false;
+
+  // A malformed frame means we've lost track of where frames begin, so no
+  // further output can be trusted. Report the error and ignore the rest of
+  // the stream; the consumer is expected to treat this as unrecoverable.
+  function handleCorruptStream(error: unknown): void {
+    streamIsCorrupt = true;
+    debug('corrupt pdictl output stream: %o', error);
+    emit({
+      event: 'error',
+      code: 'other',
+      message: `corrupt pdictl output stream: ${error}`,
+    });
+  }
+
+  pdictl.stdout.on('data', (chunk: Buffer) => {
+    if (streamIsCorrupt) return;
+    let offset = 0;
+    for (;;) {
+      if (payload === undefined) {
+        const bytesCopied = chunk.copy(
+          header,
+          headerFilled,
+          offset,
+          Math.min(chunk.length, offset + (FRAME_HEADER_LENGTH - headerFilled))
+        );
+        headerFilled += bytesCopied;
+        offset += bytesCopied;
+        if (headerFilled < FRAME_HEADER_LENGTH) {
+          return;
+        }
+        const payloadLength = header.readUInt32LE(FRAME_TYPE_LENGTH);
+        if (payloadLength > MAX_FRAME_PAYLOAD_LENGTH) {
+          handleCorruptStream(
+            new Error(`frame payload too large: ${payloadLength} bytes`)
+          );
+          return;
+        }
+        // Since the payload length is known upfront, each payload byte is
+        // copied exactly once from the incoming chunks into its final buffer.
+        payload = Buffer.allocUnsafe(payloadLength);
+        payloadFilled = 0;
+      }
+      const bytesCopied = chunk.copy(
+        payload,
+        payloadFilled,
+        offset,
+        Math.min(chunk.length, offset + (payload.length - payloadFilled))
+      );
+      payloadFilled += bytesCopied;
+      offset += bytesCopied;
+      if (payloadFilled < payload.length) {
+        return;
+      }
+      const framePayload = payload;
+      headerFilled = 0;
+      payload = undefined;
+      try {
+        handleFrame(header.readUInt8(0), framePayload);
+      } catch (error) {
+        handleCorruptStream(error);
+        return;
       }
     }
   });


### PR DESCRIPTION
## Overview

Each scanned sheet was base64-encoded into a ~10MB JSON line that Node reassembled via `readline`, `JSON.parse`, and a base64 decode, blocking both processes at the `scanComplete`→`interpret` handoff. Frames are now a 1-byte type plus 4-byte length: JSON payloads for responses/events, raw grayscale pixels for `scanComplete`. The Node client preallocates each payload from the header to limit copies, and malformed frames surface as an `error` event instead of an uncaught exception.

Benchmarked per letter sheet: Node-side handling 21.3ms → 1.6ms, Rust-side encoding 4.5ms → 0.13ms, pipe bytes 10.1MB → 7.6MB, 40MB of transient allocations across the two processes → zero.

Part of a stack: the record/replay tooling PR above this validates the protocol stays stable through the client refactor PR at the top.

## Demo Video or Screenshot

n/a

## Testing Plan

- Rust: new end-to-end test decodes interleaved duplex data through the real scan path and asserts the exact frame bytes; existing suite converted to parse frames.
- TS: 100% line coverage including frames split across chunk boundaries (headers and payloads both split mid-way), unknown frame type, implausible length, and payload length mismatch — all surfacing as `error` events.
- Not yet validated against a real scanner; see the stack's top PR for the hardware validation plan.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions (_none_).
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoLZVgnMKXfZ1FM52PH8ii
