### PR TITLE
pdictl: simplify the client/USB-task channel protocol, fix bugs it surfaced

### DIFF
--- a/libs/pdi-scanner/src/rust/client.rs
+++ b/libs/pdi-scanner/src/rust/client.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::{collections::VecDeque, io, time::Duration};
+use std::{io, time::Duration};
 use tokio::{
     sync::mpsc::error::TryRecvError,
     time::{sleep, timeout},
@@ -44,8 +44,6 @@ pub struct ImageCalibrationTables {
 }
 
 pub struct Client {
-    id: usize,
-    unhandled_packets: VecDeque<Incoming>,
     scanner: Scanner,
 }
 
@@ -62,36 +60,34 @@ impl Client {
 
     #[must_use]
     pub fn from_scanner(scanner: Scanner) -> Self {
-        Self {
-            id: 0,
-            unhandled_packets: VecDeque::new(),
-            scanner,
-        }
+        Self { scanner }
     }
 
     async fn send(&mut self, packet: Outgoing) -> Result<()> {
-        self.clear_unhandled_solicited_packets();
+        self.discard_stale_responses();
 
-        let id = self.id;
-        self.id = self.id.wrapping_add(1);
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
         self.scanner
             .host_to_scanner_tx
-            .send((id, packet))
+            .send((packet, ack_tx))
             .map_err(|_| {
                 Error::from(nusb::Error::new(
                     io::ErrorKind::ConnectionAborted,
                     "failed to send packet to scanner (host to scanner channel closed)",
                 ))
             })?;
-        let Some(ack_id) = self.scanner.host_to_scanner_ack_rx.recv().await else {
-            return Err(nusb::Error::new(
+        // The USB task acks each successful write on the command's one-shot
+        // channel. If the write fails, the task reports the error as an event
+        // and shuts down, dropping the ack sender — which we observe here as
+        // the channel closing. If *we* are cancelled while waiting (e.g. by a
+        // caller's timeout), the dropped receiver leaves no shared state
+        // behind to confuse a later command.
+        ack_rx.await.map_err(|_| {
+            Error::from(nusb::Error::new(
                 io::ErrorKind::ConnectionAborted,
                 "failed to receive ack from scanner (host to scanner ack channel closed)",
-            )
-            .into());
-        };
-        assert_eq!(id, ack_id);
-        Ok(())
+            ))
+        })
     }
 
     // There should only be one command/response occurring at a time, so before
@@ -103,19 +99,10 @@ impl Client {
     // delay sending a response to a command (e.g. when the "eject pause"
     // feature pauses the scanner, it will queue commands received during that
     // time).
-    fn clear_unhandled_solicited_packets(&mut self) {
-        let mut unhandled_packets = VecDeque::with_capacity(self.unhandled_packets.len());
-        std::mem::swap(&mut unhandled_packets, &mut self.unhandled_packets);
-
-        let (unsolicited_packets, solicited_packets): (Vec<_>, Vec<_>) = unhandled_packets
-            .into_iter()
-            .partition(|packet| packet.message_type().is_unsolicited());
-
-        if !solicited_packets.is_empty() {
-            tracing::debug!("clearing unhandled solicited packets: {solicited_packets:?}");
+    fn discard_stale_responses(&mut self) {
+        while let Ok(packet) = self.scanner.responses_rx.try_recv() {
+            tracing::debug!("discarding stale response: {packet:?}");
         }
-
-        self.unhandled_packets.extend(unsolicited_packets);
     }
 
     /// Enables CRC checking on the scanner.
@@ -607,70 +594,43 @@ impl Client {
             .await
     }
 
-    /// Returns the next unhandled packet from the internal queue or awaits
-    /// a packet from the scanner if the internal queue is empty.
+    /// Awaits the next unsolicited event from the scanner: scan and
+    /// calibration events, image data, unknown packets, and errors that shut
+    /// down the USB task. Solicited responses never arrive here — they are
+    /// routed to the commands awaiting them.
     ///
     /// # Errors
     ///
     /// If the channel to the scanner has closed, this function will return
     /// [`Error::TryRecvError`].
     pub async fn recv(&mut self) -> Result<Incoming> {
-        if let Some(packet) = self.unhandled_packets.pop_front() {
-            tracing::debug!("returning unhandled packet: {packet:?}");
-            return Ok(packet);
-        }
-
-        match self.scanner.scanner_to_host_rx.recv().await {
+        match self.scanner.events_rx.recv().await {
             Some(result) => result,
             None => Err(Error::TryRecvError(TryRecvError::Disconnected)),
         }
     }
 
-    /// Receives packets from the scanner until a call to the provided function
-    /// returns [`Ok`] with the data to return from this call. If the packet does
-    /// not match it should be returned from the function using [`Err`], and it
-    /// will be added to the list of unhandled packets to be tried on subsequent
-    /// calls to [`Self::recv_matching`].
+    /// Receives response packets from the scanner until a call to the provided
+    /// function returns [`Ok`] with the data to return from this call. If the
+    /// packet does not match it should be returned from the function using
+    /// [`Err`]; it is a stale response (e.g. a delayed response to a previous
+    /// command that timed out) and is discarded.
     ///
     /// # Errors
     ///
     /// This function will return an error if a communication error occurs.
-    #[allow(clippy::missing_panics_doc)]
     async fn recv_matching<P>(
         &mut self,
         filter_map: impl Fn(Incoming) -> Result<P, Incoming>,
     ) -> Result<P> {
-        let mut unhandled_packets = VecDeque::with_capacity(self.unhandled_packets.len());
-        std::mem::swap(&mut unhandled_packets, &mut self.unhandled_packets);
-
-        let mut received_value = None;
-
-        for packet in unhandled_packets {
-            if received_value.is_some() {
-                self.unhandled_packets.push_back(packet);
-            } else {
-                match filter_map(packet) {
-                    Ok(value) => {
-                        received_value = Some(value);
-                    }
-                    Err(packet) => {
-                        self.unhandled_packets.push_back(packet);
-                    }
-                }
-            }
-        }
-
-        if let Some(value) = received_value {
-            return Ok(value);
-        }
-
         loop {
-            match self.scanner.scanner_to_host_rx.recv().await {
-                Some(Ok(packet)) => match filter_map(packet) {
+            match self.scanner.responses_rx.recv().await {
+                Some(packet) => match filter_map(packet) {
                     Ok(value) => return Ok(value),
-                    Err(packet) => self.unhandled_packets.push_back(packet),
+                    Err(packet) => {
+                        tracing::debug!("discarding non-matching response: {packet:?}");
+                    }
                 },
-                Some(Err(error)) => return Err(error),
                 None => return Err(Error::TryRecvError(TryRecvError::Disconnected)),
             }
         }
@@ -1149,10 +1109,11 @@ impl Client {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use std::time::Duration;
 
-    use tokio::time::timeout;
+    use tokio::{sync::mpsc, time::timeout};
 
     use crate::{
         protocol::packets::{ImageData, Incoming, Outgoing},
@@ -1161,19 +1122,40 @@ mod tests {
 
     use super::Client;
 
+    struct MockScannerHarness {
+        /// Packets successfully "written" to the scanner, in order.
+        outgoing_rx: mpsc::UnboundedReceiver<Outgoing>,
+        responses_tx: mpsc::UnboundedSender<Incoming>,
+        events_tx: mpsc::UnboundedSender<crate::Result<Incoming>>,
+    }
+
+    /// Creates a client whose mock USB task acknowledges every write
+    /// immediately and forwards the written packets for assertions.
+    fn mock_client() -> (Client, MockScannerHarness) {
+        let (host_to_scanner_tx, mut host_to_scanner_rx) =
+            mpsc::unbounded_channel::<crate::scanner::OutgoingCommand>();
+        let (responses_tx, responses_rx) = mpsc::unbounded_channel();
+        let (events_tx, events_rx) = mpsc::unbounded_channel();
+        let (outgoing_tx, outgoing_rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            while let Some((packet, ack)) = host_to_scanner_rx.recv().await {
+                let _ = outgoing_tx.send(packet);
+                let _ = ack.send(());
+            }
+        });
+        (
+            Client::from_scanner(Scanner::mock(host_to_scanner_tx, responses_rx, events_rx)),
+            MockScannerHarness {
+                outgoing_rx,
+                responses_tx,
+                events_tx,
+            },
+        )
+    }
+
     #[tokio::test]
     async fn test_enable_crc_checking_sends_expected_packet() {
-        let (host_to_scanner_tx, mut host_to_scanner_rx) = tokio::sync::mpsc::unbounded_channel();
-        let (host_to_scanner_ack_tx, host_to_scanner_ack_rx) =
-            tokio::sync::mpsc::unbounded_channel();
-        let (_scanner_to_host_tx, scanner_to_host_rx) = tokio::sync::mpsc::unbounded_channel();
-        let mut client = Client::from_scanner(Scanner::mock(
-            host_to_scanner_tx,
-            host_to_scanner_ack_rx,
-            scanner_to_host_rx,
-        ));
-
-        host_to_scanner_ack_tx.send(0).unwrap();
+        let (mut client, mut harness) = mock_client();
 
         timeout(Duration::from_millis(10), client.enable_crc_checking())
             .await
@@ -1181,85 +1163,58 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            host_to_scanner_rx.recv().await.unwrap(),
-            (0, Outgoing::EnableCrcCheckingRequest)
+            harness.outgoing_rx.recv().await.unwrap(),
+            Outgoing::EnableCrcCheckingRequest
         );
     }
 
     #[tokio::test]
     async fn test_wait_until_ready_enables_crc_before_retrying_get_test_string() {
-        let (host_to_scanner_tx, mut host_to_scanner_rx) = tokio::sync::mpsc::unbounded_channel();
-        let (host_to_scanner_ack_tx, host_to_scanner_ack_rx) =
-            tokio::sync::mpsc::unbounded_channel();
-        let (scanner_to_host_tx, scanner_to_host_rx) = tokio::sync::mpsc::unbounded_channel();
-        let mut client = Client::from_scanner(Scanner::mock(
-            host_to_scanner_tx,
-            host_to_scanner_ack_rx,
-            scanner_to_host_rx,
-        ));
+        let (mut client, mut harness) = mock_client();
 
-        // Each loop iteration sends enable_crc_checking then get_test_string,
-        // so we need two ACKs per iteration.
-        host_to_scanner_ack_tx.send(0).unwrap();
-        host_to_scanner_ack_tx.send(1).unwrap();
-        host_to_scanner_ack_tx.send(2).unwrap();
-        host_to_scanner_ack_tx.send(3).unwrap();
+        // Only answer the second get_test_string: the first times out
+        // internally, which is what makes wait_until_ready retry. Respond
+        // reactively, since a response sent before the command would be
+        // discarded as stale.
+        let responses_tx = harness.responses_tx.clone();
+        let (seen_tx, mut seen_rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            let mut test_string_requests = 0;
+            while let Some(packet) = harness.outgoing_rx.recv().await {
+                if packet == Outgoing::GetTestStringRequest {
+                    test_string_requests += 1;
+                    if test_string_requests == 2 {
+                        let _ =
+                            responses_tx.send(Incoming::GetTestStringResponse("test".to_owned()));
+                    }
+                }
+                let _ = seen_tx.send(packet);
+            }
+        });
 
-        // First get_test_string fails, second succeeds.
-        scanner_to_host_tx
-            .send(Err(crate::Error::RecvTimeout))
-            .unwrap();
-        scanner_to_host_tx
-            .send(Ok(Incoming::GetTestStringResponse("test".to_owned())))
-            .unwrap();
-
-        timeout(Duration::from_millis(500), client.wait_until_ready())
+        timeout(Duration::from_secs(1), client.wait_until_ready())
             .await
             .unwrap();
 
-        // Iteration 1: enable_crc_checking, then get_test_string (fails)
-        assert_eq!(
-            host_to_scanner_rx.recv().await.unwrap(),
-            (0, Outgoing::EnableCrcCheckingRequest)
-        );
-        assert_eq!(
-            host_to_scanner_rx.recv().await.unwrap(),
-            (1, Outgoing::GetTestStringRequest)
-        );
-        // Iteration 2: enable_crc_checking again, then get_test_string (succeeds)
-        assert_eq!(
-            host_to_scanner_rx.recv().await.unwrap(),
-            (2, Outgoing::EnableCrcCheckingRequest)
-        );
-        assert_eq!(
-            host_to_scanner_rx.recv().await.unwrap(),
-            (3, Outgoing::GetTestStringRequest)
-        );
+        // Iteration 1: enable_crc_checking, then get_test_string (times out);
+        // iteration 2: enable_crc_checking again, then get_test_string
+        // (answered).
+        for expected in [
+            Outgoing::EnableCrcCheckingRequest,
+            Outgoing::GetTestStringRequest,
+            Outgoing::EnableCrcCheckingRequest,
+            Outgoing::GetTestStringRequest,
+        ] {
+            assert_eq!(seen_rx.recv().await.unwrap(), expected);
+        }
     }
 
     #[tokio::test]
     async fn test_wait_until_ready_retries_indefinitely_until_caller_timeout() {
-        let (host_to_scanner_tx, mut host_to_scanner_rx) = tokio::sync::mpsc::unbounded_channel();
-        let (host_to_scanner_ack_tx, host_to_scanner_ack_rx) =
-            tokio::sync::mpsc::unbounded_channel();
-        let (_scanner_to_host_tx, scanner_to_host_rx) = tokio::sync::mpsc::unbounded_channel();
-        let mut client = Client::from_scanner(Scanner::mock(
-            host_to_scanner_tx,
-            host_to_scanner_ack_rx,
-            scanner_to_host_rx,
-        ));
+        let (mut client, mut harness) = mock_client();
 
-        // Each loop iteration sends enable_crc_checking + get_test_string,
-        // so we need two ACKs per iteration. Provide enough for several
-        // iterations but never send a successful response so
-        // wait_until_ready never returns on its own.
-        let iteration_count: usize = 3;
-        for ack_id in 0..(iteration_count * 2) {
-            host_to_scanner_ack_tx.send(ack_id).unwrap();
-        }
-
-        // The caller's timeout is what stops wait_until_ready, not an
-        // internal attempt limit.
+        // Never respond, so wait_until_ready never returns on its own: the
+        // caller's timeout is what stops it, not an internal attempt limit.
         let result = timeout(Duration::from_secs(1), client.wait_until_ready()).await;
         assert!(
             result.is_err(),
@@ -1267,99 +1222,132 @@ mod tests {
         );
 
         // Verify it sent enable_crc_checking + get_test_string pairs.
-        for iteration in 0..iteration_count {
-            let base_id = iteration * 2;
+        for _ in 0..3 {
             assert_eq!(
-                host_to_scanner_rx.recv().await.unwrap(),
-                (base_id, Outgoing::EnableCrcCheckingRequest)
+                harness.outgoing_rx.recv().await.unwrap(),
+                Outgoing::EnableCrcCheckingRequest
             );
             assert_eq!(
-                host_to_scanner_rx.recv().await.unwrap(),
-                (base_id + 1, Outgoing::GetTestStringRequest)
+                harness.outgoing_rx.recv().await.unwrap(),
+                Outgoing::GetTestStringRequest
             );
         }
     }
 
-    #[tokio::test]
-    async fn test_pending_image_data_is_not_dropped_on_new_request() {
-        let (host_to_scanner_tx, mut host_to_scanner_rx) = tokio::sync::mpsc::unbounded_channel();
-        let (host_to_scanner_ack_tx, host_to_scanner_ack_rx) =
-            tokio::sync::mpsc::unbounded_channel();
-        let (scanner_to_host_tx, scanner_to_host_rx) = tokio::sync::mpsc::unbounded_channel();
-        let mut client = Client::from_scanner(Scanner::mock(
-            host_to_scanner_tx,
-            host_to_scanner_ack_rx,
-            scanner_to_host_rx,
-        ));
+    /// Runs a command on a spawned task, sending its response only once the
+    /// outgoing packet is observed (a response sent earlier would be
+    /// discarded as stale).
+    async fn get_test_string_with_response(
+        mut client: Client,
+        harness: &mut MockScannerHarness,
+        response: &str,
+    ) -> Client {
+        let command_task = tokio::spawn(async move {
+            let result = timeout(Duration::from_millis(100), client.get_test_string())
+                .await
+                .unwrap();
+            (client, result)
+        });
+        assert_eq!(
+            harness.outgoing_rx.recv().await.unwrap(),
+            Outgoing::GetTestStringRequest
+        );
+        harness
+            .responses_tx
+            .send(Incoming::GetTestStringResponse(response.to_owned()))
+            .unwrap();
+        let (client, result) = command_task.await.unwrap();
+        assert_eq!(result.unwrap(), response);
+        client
+    }
 
-        // add some image data to the incoming queue of data
-        scanner_to_host_tx
+    #[tokio::test]
+    async fn test_image_data_is_not_consumed_by_commands() {
+        let (mut client, mut harness) = mock_client();
+
+        // Image data arrives (as an unsolicited event) before any command
+        // traffic.
+        harness
+            .events_tx
             .send(Ok(Incoming::ImageData(ImageData(vec![0x00]))))
             .unwrap();
 
-        // set up response to `get_test_string`
-        scanner_to_host_tx
-            .send(Ok(Incoming::GetTestStringResponse("test".to_owned())))
-            .unwrap();
-        host_to_scanner_ack_tx.send(0).unwrap();
+        // Commands get their responses, unaffected by the image data.
+        client = get_test_string_with_response(client, &mut harness, "test").await;
+        client = get_test_string_with_response(client, &mut harness, "test2").await;
 
-        // make sure the response came through okay, and force the above
-        // `Incoming::ImageData` into the `unhandled_packets` queue
+        // The image data is still waiting on the events channel.
         assert_eq!(
-            timeout(Duration::from_millis(10), client.get_test_string())
+            timeout(Duration::from_millis(10), client.recv())
                 .await
                 .unwrap()
                 .unwrap(),
-            "test"
+            Incoming::ImageData(ImageData(vec![0x00]))
         );
+    }
 
-        // check the data sent to the scanner
-        assert_eq!(
-            host_to_scanner_rx.recv().await.unwrap(),
-            (0, Outgoing::GetTestStringRequest)
-        );
+    #[tokio::test]
+    async fn test_stale_responses_are_discarded_and_skipped() {
+        let (mut client, mut harness) = mock_client();
 
-        // make sure the image data is in the queue
-        assert_eq!(
-            client.unhandled_packets.front().cloned(),
-            Some(Incoming::ImageData(ImageData(vec![0x00])))
-        );
-
-        // set up another response to `get_test_string`
-        scanner_to_host_tx
-            .send(Ok(Incoming::GetTestStringResponse("test2".to_owned())))
+        // A stale response that arrived before the command is sent gets
+        // drained by discard_stale_responses; one that arrives while the
+        // command is awaiting its response gets skipped by recv_matching.
+        // Either way the command matches its own response.
+        harness
+            .responses_tx
+            .send(Incoming::GetTestStringResponse("stale".to_owned()))
             .unwrap();
-        host_to_scanner_ack_tx.send(1).unwrap();
 
-        // make sure the second response came through and didn't discard
-        // the image data as a side effect of this request
-        assert_eq!(
-            timeout(Duration::from_millis(10), client.get_test_string())
+        let command_task = tokio::spawn(async move {
+            let result = timeout(Duration::from_millis(100), client.get_test_string())
                 .await
-                .unwrap()
-                .unwrap(),
-            "test2"
-        );
+                .unwrap();
+            (client, result)
+        });
 
-        // make sure the image data was not discarded
+        // Once the outgoing packet is observed, the command is in flight (and
+        // the pre-existing stale response has been drained), so these arrive
+        // while it awaits its response.
         assert_eq!(
-            client.unhandled_packets.front().cloned(),
-            Some(Incoming::ImageData(ImageData(vec![0x00])))
+            harness.outgoing_rx.recv().await.unwrap(),
+            Outgoing::GetTestStringRequest
         );
+        harness
+            .responses_tx
+            .send(Incoming::GetSetRequiredInputSensorsResponse {
+                current_sensors_required: 2,
+                total_sensors_available: 5,
+            })
+            .unwrap();
+        harness
+            .responses_tx
+            .send(Incoming::GetTestStringResponse("real".to_owned()))
+            .unwrap();
 
-        // make sure we can retreive the image data
-        assert_eq!(
-            timeout(
-                Duration::from_millis(10),
-                client.recv_matching(|packet| match packet {
-                    Incoming::ImageData(image_data) => Ok(image_data),
-                    packet => Err(packet),
-                })
-            )
+        let (_client, result) = command_task.await.unwrap();
+        assert_eq!(result.unwrap(), "real");
+    }
+
+    #[tokio::test]
+    async fn test_send_fails_when_usb_task_is_gone() {
+        let (host_to_scanner_tx, host_to_scanner_rx) = mpsc::unbounded_channel();
+        let (_responses_tx, responses_rx) = mpsc::unbounded_channel();
+        let (_events_tx, events_rx) = mpsc::unbounded_channel();
+        let mut client =
+            Client::from_scanner(Scanner::mock(host_to_scanner_tx, responses_rx, events_rx));
+
+        // Simulate the USB task shutting down after a failed write: the
+        // command channel (and with it the pending ack) is dropped.
+        drop(host_to_scanner_rx);
+
+        let error = timeout(Duration::from_millis(100), client.enable_crc_checking())
             .await
             .unwrap()
-            .unwrap(),
-            ImageData(vec![0x00])
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("failed to send packet"),
+            "{error}"
         );
     }
 }

--- a/libs/pdi-scanner/src/rust/client.rs
+++ b/libs/pdi-scanner/src/rust/client.rs
@@ -76,12 +76,6 @@ impl Client {
                     "failed to send packet to scanner (host to scanner channel closed)",
                 ))
             })?;
-        // The USB task acks each successful write on the command's one-shot
-        // channel. If the write fails, the task reports the error as an event
-        // and shuts down, dropping the ack sender — which we observe here as
-        // the channel closing. If *we* are cancelled while waiting (e.g. by a
-        // caller's timeout), the dropped receiver leaves no shared state
-        // behind to confuse a later command.
         ack_rx.await.map_err(|_| {
             Error::from(nusb::Error::new(
                 io::ErrorKind::ConnectionAborted,

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -235,10 +235,13 @@ const FRAME_HEADER_LENGTH: usize = FRAME_TYPE_LENGTH + size_of::<u32>();
 struct Output<W: Write> {
     stdout: W,
     // We reject sending a command while a scan is in progress because it will
-    // interrupt the scan. To ensure this flag gets reset whenever a scan stops
-    // (whether successfully or with an error or disconnection), we manage this
-    // flag in the send_response/send_event methods, since they are called in
-    // basically every case when the scanner state changes.
+    // interrupt the scan. The flag is set by the scan start event and cleared
+    // by every other scanner event (any event during a scan — completion,
+    // scan failure, double feed, cover open — means the scan is over or
+    // aborted) and by scanner disconnection. Responses must NOT clear it:
+    // the only response possible while scanning is the ScanInProgress
+    // rejection itself, and clearing on it would disarm the guard after
+    // blocking a single command.
     scan_in_progress: bool,
 }
 
@@ -273,7 +276,6 @@ impl<W: Write> Output<W> {
 
     fn send_response(&mut self, response: Response) -> color_eyre::Result<()> {
         tracing::debug!("sending response: {response:?}");
-        self.scan_in_progress = false;
         self.send_to_stdout(&Message::Response(response))
     }
 
@@ -533,6 +535,11 @@ async fn handle_commands_and_events<R: tokio::io::AsyncBufRead + Unpin, W: Write
                     Err(Error::TryRecvError(tokio::sync::mpsc::error::TryRecvError::Disconnected)) => {
                         tracing::debug!("scanner channel disconnected");
                         client = None;
+                        // No event is emitted on this path, so clear the scan
+                        // flag directly: a disconnected scanner is not
+                        // scanning, and a stuck flag would reject every
+                        // command forever.
+                        output.scan_in_progress = false;
                         continue;
                     }
                     Err(e) => {
@@ -1112,6 +1119,19 @@ mod tests {
                         json!({"response": "error", "code": "scanInProgress", "message": null})
                     );
 
+                    // The rejection must not disarm the guard: a second
+                    // command during the same scan is also rejected.
+                    let msg = send_command(
+                        &mut stdin_write,
+                        &mut output_rx,
+                        r#"{"command":"getScannerStatus"}"#,
+                    )
+                    .await;
+                    assert_eq!(
+                        msg,
+                        json!({"response": "error", "code": "scanInProgress", "message": null})
+                    );
+
                     send_exit(&mut stdin_write).await;
                 }
             )
@@ -1227,6 +1247,54 @@ mod tests {
                         &mut stdin_write,
                         &mut output_rx,
                         r#"{"command":"disableScanning"}"#,
+                    )
+                    .await;
+                    assert_eq!(
+                        msg,
+                        json!({"response": "error", "code": "disconnected", "message": null})
+                    );
+
+                    send_exit(&mut stdin_write).await;
+                }
+            )
+        })
+        .await
+        .unwrap();
+        result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn disconnect_during_scan_clears_scan_in_progress() {
+        let (client, harness) = setup_connected_client();
+        let mut client_slot = Some(client);
+        let (stdin_read, mut stdin_write) = tokio::io::duplex(4096);
+        let (stdout_writer, mut output_rx) = ChannelWriter::new();
+
+        let (result, ()) = timeout(TEST_TIMEOUT, async {
+            tokio::join!(
+                handle_commands_and_events(BufReader::new(stdin_read), stdout_writer, || {
+                    Ok(client_slot.take().expect("connect called more than once"))
+                }),
+                async {
+                    send_command(&mut stdin_write, &mut output_rx, r#"{"command":"connect"}"#)
+                        .await;
+
+                    // Start a scan, then disconnect the scanner mid-scan (no
+                    // event is emitted on this path).
+                    harness
+                        .events_tx
+                        .send(Ok(Incoming::BeginScanEvent))
+                        .unwrap();
+                    let msg = recv_output(&mut output_rx).await;
+                    assert_eq!(msg, json!({"event": "scanStart"}));
+                    drop(harness.events_tx);
+
+                    // Commands must report the disconnection, not get stuck
+                    // behind a scan that will never finish.
+                    let msg = send_command(
+                        &mut stdin_write,
+                        &mut output_rx,
+                        r#"{"command":"getScannerStatus"}"#,
                     )
                     .await;
                     assert_eq!(

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -582,8 +582,8 @@ async fn handle_commands_and_events<R: tokio::io::AsyncBufRead + Unpin, W: Write
                         match raw_image_data.try_decode_scan(
                             DEFAULT_IMAGE_WIDTH,
                             ScanSideMode::Duplex,
-                            &image_calibration_tables
-                                .clone()
+                            image_calibration_tables
+                                .as_ref()
                                 .expect("image calibration tables not set"),
                         ) {
                             Ok(Sheet::Duplex(top, bottom)) => {

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -647,7 +647,7 @@ mod tests {
         client::Client,
         protocol::{
             image::DEFAULT_IMAGE_WIDTH,
-            packets::{ImageData, Incoming, Outgoing},
+            packets::{ImageData, Incoming, IncomingType, Outgoing},
             parsers,
             types::{Register, RegisterIndex, Resolution},
         },
@@ -780,9 +780,13 @@ mod tests {
     }
 
     struct ConnectedTestHarness {
-        host_to_scanner_rx: mpsc::UnboundedReceiver<(usize, Outgoing)>,
-        host_to_scanner_ack_tx: mpsc::UnboundedSender<usize>,
-        scanner_to_host_tx: mpsc::UnboundedSender<pdi_scanner::Result<Incoming>>,
+        /// Packets successfully "written" to the scanner, in order (writes are
+        /// acknowledged automatically).
+        outgoing_rx: mpsc::UnboundedReceiver<Outgoing>,
+        /// Kept alive so the responses channel stays open, as it would with a
+        /// live USB task.
+        _responses_tx: mpsc::UnboundedSender<Incoming>,
+        events_tx: mpsc::UnboundedSender<pdi_scanner::Result<Incoming>>,
     }
 
     fn setup_connected_client() -> (Client, ConnectedTestHarness) {
@@ -793,48 +797,59 @@ mod tests {
         white_calibration_table: &[u8],
         black_calibration_table: &[u8],
     ) -> (Client, ConnectedTestHarness) {
-        let (host_to_scanner_tx, host_to_scanner_rx) = mpsc::unbounded_channel();
-        let (host_to_scanner_ack_tx, host_to_scanner_ack_rx) = mpsc::unbounded_channel();
-        let (scanner_to_host_tx, scanner_to_host_rx) = mpsc::unbounded_channel();
+        let (host_to_scanner_tx, mut host_to_scanner_rx) =
+            mpsc::unbounded_channel::<pdi_scanner::scanner::OutgoingCommand>();
+        let (responses_tx, responses_rx) = mpsc::unbounded_channel();
+        let (events_tx, events_rx) = mpsc::unbounded_channel();
+        let (outgoing_tx, outgoing_rx) = mpsc::unbounded_channel();
 
-        // Pre-load responses for initialize_connected_scanner:
-        // wait_until_ready: EnableCrcChecking (ack 0) + GetTestString (ack 1 + response)
-        // initialize_scanning:
-        //   DisableFeeder (ack 2)
-        //   set_boot_eject_motion reads register 9 (ack 3 + response)
-        //     value 0x200 = BootEjectMotion::None already set, so no write needed
-        //   GetCalibrationInfo (ack 4 + 2 responses)
-        for i in 0..5 {
-            host_to_scanner_ack_tx.send(i).unwrap();
-        }
-        let register_9 = pdi_scanner::protocol::types::RegisterIndex::new(9).unwrap();
-        scanner_to_host_tx
-            .send(Ok(Incoming::GetTestStringResponse("test".into())))
-            .unwrap();
-        scanner_to_host_tx
-            .send(Ok(Incoming::ReadRegisterDataResponse(Register::new(
-                register_9, 0x200, // BootEjectMotion::None (2) << 8
-            ))))
-            .unwrap();
-        let cal = || Incoming::GetCalibrationInformationResponse {
-            white_calibration_table: white_calibration_table.to_vec(),
-            black_calibration_table: black_calibration_table.to_vec(),
-        };
-        scanner_to_host_tx.send(Ok(cal())).unwrap();
-        scanner_to_host_tx.send(Ok(cal())).unwrap();
+        // Mini mock scanner: acks every write, forwards the written packets
+        // for assertions, and answers the requests that expect responses —
+        // enough for initialize_connected_scanner. Register 9 reads back
+        // 0x200 = BootEjectMotion::None, so no register write follows.
+        // Responses must be sent reactively: a response sitting in the
+        // channel before its command is sent would be discarded as stale.
+        let white_calibration_table = white_calibration_table.to_vec();
+        let black_calibration_table = black_calibration_table.to_vec();
+        let mock_responses_tx = responses_tx.clone();
+        tokio::spawn(async move {
+            while let Some((packet, ack)) = host_to_scanner_rx.recv().await {
+                let _ = ack.send(());
+                let responses = match &packet {
+                    Outgoing::GetTestStringRequest => {
+                        vec![Incoming::GetTestStringResponse("test".into())]
+                    }
+                    Outgoing::ReadRegisterDataRequest(index) => {
+                        vec![Incoming::ReadRegisterDataResponse(Register::new(
+                            *index, 0x200,
+                        ))]
+                    }
+                    Outgoing::GetCalibrationInformationRequest { .. } => {
+                        let cal = || Incoming::GetCalibrationInformationResponse {
+                            white_calibration_table: white_calibration_table.clone(),
+                            black_calibration_table: black_calibration_table.clone(),
+                        };
+                        // One request, two responses (front and back sensors)
+                        vec![cal(), cal()]
+                    }
+                    _ => vec![],
+                };
+                for response in responses {
+                    let _ = mock_responses_tx.send(response);
+                }
+                let _ = outgoing_tx.send(packet);
+            }
+        });
 
-        let client = Client::from_scanner(Scanner::mock(
-            host_to_scanner_tx,
-            host_to_scanner_ack_rx,
-            scanner_to_host_rx,
-        ));
+        let client =
+            Client::from_scanner(Scanner::mock(host_to_scanner_tx, responses_rx, events_rx));
 
         (
             client,
             ConnectedTestHarness {
-                host_to_scanner_rx,
-                host_to_scanner_ack_tx,
-                scanner_to_host_tx,
+                outgoing_rx,
+                _responses_tx: responses_tx,
+                events_tx,
             },
         )
     }
@@ -1048,7 +1063,7 @@ mod tests {
                     assert_eq!(msg, json!({"response": "ok"}));
 
                     harness
-                        .scanner_to_host_tx
+                        .events_tx
                         .send(Ok(Incoming::CoverOpenEvent))
                         .unwrap();
                     let msg = recv_output(&mut output_rx).await;
@@ -1080,7 +1095,7 @@ mod tests {
                         .await;
 
                     harness
-                        .scanner_to_host_tx
+                        .events_tx
                         .send(Ok(Incoming::BeginScanEvent))
                         .unwrap();
                     let msg = recv_output(&mut output_rx).await;
@@ -1123,15 +1138,9 @@ mod tests {
                         .await;
 
                     // Drain the init commands
-                    while harness.host_to_scanner_rx.try_recv().is_ok() {}
+                    while harness.outgoing_rx.try_recv().is_ok() {}
 
-                    // EndScan needs an ack for the feeder disable command (ID 5, after
-                    // the 5 init commands used IDs 0-4)
-                    harness.host_to_scanner_ack_tx.send(5).unwrap();
-                    harness
-                        .scanner_to_host_tx
-                        .send(Ok(Incoming::EndScanEvent))
-                        .unwrap();
+                    harness.events_tx.send(Ok(Incoming::EndScanEvent)).unwrap();
                     let msg = recv_output(&mut output_rx).await;
                     assert_eq!(msg["event"], "error");
                     assert_eq!(msg["code"], "scanFailed");
@@ -1145,7 +1154,7 @@ mod tests {
         result.unwrap();
 
         // Verify the feeder disable command was sent (after draining init commands)
-        let (_, packet) = timeout(TEST_TIMEOUT, harness.host_to_scanner_rx.recv())
+        let packet = timeout(TEST_TIMEOUT, harness.outgoing_rx.recv())
             .await
             .unwrap()
             .unwrap();
@@ -1169,7 +1178,7 @@ mod tests {
                         .await;
 
                     harness
-                        .scanner_to_host_tx
+                        .events_tx
                         .send(Err(pdi_scanner::Error::RecvTimeout))
                         .unwrap();
                     let msg = recv_output(&mut output_rx).await;
@@ -1205,10 +1214,10 @@ mod tests {
                     // then drop the channel so the next recv gets Disconnected
                     // and clears the client.
                     harness
-                        .scanner_to_host_tx
+                        .events_tx
                         .send(Err(pdi_scanner::Error::RecvTimeout))
                         .unwrap();
-                    drop(harness.scanner_to_host_tx);
+                    drop(harness.events_tx);
                     // Wait for the error event — confirms the error was processed
                     let msg = recv_output(&mut output_rx).await;
                     assert_eq!(msg["event"], "error");
@@ -1236,16 +1245,14 @@ mod tests {
 
     #[tokio::test]
     async fn connect_initialization_failure() {
+        // Keep the command receiver alive but never ack any writes, so init
+        // times out.
         let (host_to_scanner_tx, _host_to_scanner_rx) = mpsc::unbounded_channel();
-        let (_host_to_scanner_ack_tx, host_to_scanner_ack_rx) = mpsc::unbounded_channel();
-        let (_scanner_to_host_tx, scanner_to_host_rx) = mpsc::unbounded_channel();
+        let (_responses_tx, responses_rx) = mpsc::unbounded_channel();
+        let (_events_tx, events_rx) = mpsc::unbounded_channel();
 
-        // Client connects but init times out (no acks pre-loaded)
-        let client = Client::from_scanner(Scanner::mock(
-            host_to_scanner_tx,
-            host_to_scanner_ack_rx,
-            scanner_to_host_rx,
-        ));
+        let client =
+            Client::from_scanner(Scanner::mock(host_to_scanner_tx, responses_rx, events_rx));
         let mut client_slot = Some(client);
 
         let (stdin_read, mut stdin_write) = tokio::io::duplex(4096);
@@ -1302,10 +1309,10 @@ mod tests {
                         .await;
 
                     // Drain init commands
-                    while harness.host_to_scanner_rx.try_recv().is_ok() {}
+                    while harness.outgoing_rx.try_recv().is_ok() {}
 
                     harness
-                        .scanner_to_host_tx
+                        .events_tx
                         .send(Ok(Incoming::BeginScanEvent))
                         .unwrap();
                     let msg = recv_output(&mut output_rx).await;
@@ -1318,16 +1325,11 @@ mod tests {
                         data.push(BOTTOM_PIXEL);
                     }
                     harness
-                        .scanner_to_host_tx
+                        .events_tx
                         .send(Ok(Incoming::ImageData(ImageData(data))))
                         .unwrap();
 
-                    // EndScan needs an ack for the feeder disable command
-                    harness.host_to_scanner_ack_tx.send(5).unwrap();
-                    harness
-                        .scanner_to_host_tx
-                        .send(Ok(Incoming::EndScanEvent))
-                        .unwrap();
+                    harness.events_tx.send(Ok(Incoming::EndScanEvent)).unwrap();
                     let msg = recv_output(&mut output_rx).await;
                     assert_eq!(
                         msg,
@@ -1366,16 +1368,17 @@ mod tests {
     /// stdout frames) are awaited and asserted to match the recording.
     #[allow(clippy::too_many_lines)]
     async fn replay_recording(entries: &[Entry]) {
-        let (host_to_scanner_tx, mut host_to_scanner_rx) = mpsc::unbounded_channel();
-        let (host_to_scanner_ack_tx, host_to_scanner_ack_rx) = mpsc::unbounded_channel();
-        let (scanner_to_host_tx, scanner_to_host_rx) = mpsc::unbounded_channel();
-        let client = Client::from_scanner(Scanner::mock(
-            host_to_scanner_tx,
-            host_to_scanner_ack_rx,
-            scanner_to_host_rx,
-        ));
+        let (host_to_scanner_tx, host_to_scanner_rx) = mpsc::unbounded_channel();
+        let (responses_tx, responses_rx) = mpsc::unbounded_channel();
+        let (events_tx, events_rx) = mpsc::unbounded_channel();
+        let client =
+            Client::from_scanner(Scanner::mock(host_to_scanner_tx, responses_rx, events_rx));
         let mut client_slot = Some(client);
-        let mut scanner_to_host_tx = Some(scanner_to_host_tx);
+        // Held as Options so a ScannerTaskEnded entry can drop them all,
+        // mimicking the real USB task shutting down.
+        let mut host_to_scanner_rx = Some(host_to_scanner_rx);
+        let mut responses_tx = Some(responses_tx);
+        let mut events_tx = Some(events_tx);
 
         let (stdin_read, mut stdin_write) = tokio::io::duplex(1 << 16);
         let (frame_writer, mut frame_rx) = RawFrameChannelWriter::new();
@@ -1420,11 +1423,21 @@ mod tests {
                                         packet
                                     }
                                 };
-                                scanner_to_host_tx
-                                    .as_ref()
-                                    .expect("scanner task already ended")
-                                    .send(Ok(packet))
-                                    .unwrap();
+                                // Route by classification, mirroring the USB
+                                // task.
+                                if matches!(packet.message_type(), IncomingType::Response) {
+                                    responses_tx
+                                        .as_ref()
+                                        .expect("scanner task already ended")
+                                        .send(packet)
+                                        .unwrap();
+                                } else {
+                                    events_tx
+                                        .as_ref()
+                                        .expect("scanner task already ended")
+                                        .send(Ok(packet))
+                                        .unwrap();
+                                }
                             }
                             Entry::ScannerToHostError { disconnected, .. } => {
                                 // The exact recorded error isn't reconstructible;
@@ -1441,32 +1454,37 @@ mod tests {
                                 } else {
                                     pdi_scanner::Error::RecvTimeout
                                 };
-                                scanner_to_host_tx
+                                events_tx
                                     .as_ref()
                                     .expect("scanner task already ended")
                                     .send(Err(error))
                                     .unwrap();
                             }
                             Entry::ScannerTaskEnded => {
-                                scanner_to_host_tx.take();
+                                events_tx.take();
+                                responses_tx.take();
+                                host_to_scanner_rx.take();
                             }
                             Entry::HostToScanner { data_base64 } => {
                                 let expected = recording::decode_base64(data_base64).unwrap();
-                                let (id, packet) =
-                                    timeout(REPLAY_STEP_TIMEOUT, host_to_scanner_rx.recv())
-                                        .await
-                                        .unwrap_or_else(|_| {
-                                            panic!(
-                                                "entry {index}: timed out waiting for outgoing packet"
-                                            )
-                                        })
-                                        .expect("outgoing packet channel closed");
+                                let (packet, ack) = timeout(
+                                    REPLAY_STEP_TIMEOUT,
+                                    host_to_scanner_rx
+                                        .as_mut()
+                                        .expect("scanner task already ended")
+                                        .recv(),
+                                )
+                                .await
+                                .unwrap_or_else(|_| {
+                                    panic!("entry {index}: timed out waiting for outgoing packet")
+                                })
+                                .expect("outgoing packet channel closed");
                                 assert_eq!(
                                     packet.to_bytes(),
                                     expected,
                                     "entry {index}: outgoing packet mismatch: {packet:?}"
                                 );
-                                host_to_scanner_ack_tx.send(id).unwrap();
+                                let _ = ack.send(());
                             }
                             Entry::StdoutFrame {
                                 frame_type,
@@ -1561,16 +1579,15 @@ mod tests {
     /// JSON outputs are asserted to be unaffected by the substitution.
     #[allow(clippy::too_many_lines)]
     async fn synthesize_recording(records: &[Record]) -> Vec<Record> {
-        let (host_to_scanner_tx, mut host_to_scanner_rx) = mpsc::unbounded_channel();
-        let (host_to_scanner_ack_tx, host_to_scanner_ack_rx) = mpsc::unbounded_channel();
-        let (scanner_to_host_tx, scanner_to_host_rx) = mpsc::unbounded_channel();
-        let client = Client::from_scanner(Scanner::mock(
-            host_to_scanner_tx,
-            host_to_scanner_ack_rx,
-            scanner_to_host_rx,
-        ));
+        let (host_to_scanner_tx, host_to_scanner_rx) = mpsc::unbounded_channel();
+        let (responses_tx, responses_rx) = mpsc::unbounded_channel();
+        let (events_tx, events_rx) = mpsc::unbounded_channel();
+        let client =
+            Client::from_scanner(Scanner::mock(host_to_scanner_tx, responses_rx, events_rx));
         let mut client_slot = Some(client);
-        let mut scanner_to_host_tx = Some(scanner_to_host_tx);
+        let mut host_to_scanner_rx = Some(host_to_scanner_rx);
+        let mut responses_tx = Some(responses_tx);
+        let mut events_tx = Some(events_tx);
 
         let (stdin_read, mut stdin_write) = tokio::io::duplex(1 << 16);
         let (frame_writer, mut frame_rx) = RawFrameChannelWriter::new();
@@ -1609,7 +1626,7 @@ mod tests {
                                     .map(|i| synthetic_image_byte(image_stream_offset + i))
                                     .collect();
                                 image_stream_offset += original.len() as u64;
-                                scanner_to_host_tx
+                                events_tx
                                     .as_ref()
                                     .expect("scanner task already ended")
                                     .send(Ok(Incoming::ImageData(ImageData(synthetic.clone()))))
@@ -1632,11 +1649,19 @@ mod tests {
                                     remaining.is_empty(),
                                     "entry {index}: trailing bytes after primary packet"
                                 );
-                                scanner_to_host_tx
-                                    .as_ref()
-                                    .expect("scanner task already ended")
-                                    .send(Ok(packet))
-                                    .unwrap();
+                                if matches!(packet.message_type(), IncomingType::Response) {
+                                    responses_tx
+                                        .as_ref()
+                                        .expect("scanner task already ended")
+                                        .send(packet)
+                                        .unwrap();
+                                } else {
+                                    events_tx
+                                        .as_ref()
+                                        .expect("scanner task already ended")
+                                        .send(Ok(packet))
+                                        .unwrap();
+                                }
                                 out.push(record.clone());
                             }
                             Entry::ScannerToHostError { disconnected, .. } => {
@@ -1650,7 +1675,7 @@ mod tests {
                                 } else {
                                     pdi_scanner::Error::RecvTimeout
                                 };
-                                scanner_to_host_tx
+                                events_tx
                                     .as_ref()
                                     .expect("scanner task already ended")
                                     .send(Err(error))
@@ -1658,14 +1683,19 @@ mod tests {
                                 out.push(record.clone());
                             }
                             Entry::ScannerTaskEnded => {
-                                scanner_to_host_tx.take();
+                                events_tx.take();
+                                responses_tx.take();
+                                host_to_scanner_rx.take();
                                 out.push(record.clone());
                             }
                             Entry::HostToScanner { data_base64 } => {
                                 let expected = recording::decode_base64(data_base64).unwrap();
-                                let (id, packet) = timeout(
+                                let (packet, ack) = timeout(
                                     REPLAY_STEP_TIMEOUT,
-                                    host_to_scanner_rx.recv(),
+                                    host_to_scanner_rx
+                                        .as_mut()
+                                        .expect("scanner task already ended")
+                                        .recv(),
                                 )
                                 .await
                                 .unwrap_or_else(|_| {
@@ -1680,7 +1710,7 @@ mod tests {
                                     expected,
                                     "entry {index}: outgoing packet mismatch: {packet:?}"
                                 );
-                                host_to_scanner_ack_tx.send(id).unwrap();
+                                let _ = ack.send(());
                                 out.push(record.clone());
                             }
                             Entry::StdoutFrame {
@@ -1933,29 +1963,24 @@ mod tests {
                         .await;
 
                     // Drain init commands
-                    while harness.host_to_scanner_rx.try_recv().is_ok() {}
+                    while harness.outgoing_rx.try_recv().is_ok() {}
 
                     // Start a scan
                     harness
-                        .scanner_to_host_tx
+                        .events_tx
                         .send(Ok(Incoming::BeginScanEvent))
                         .unwrap();
                     let msg = recv_output(&mut output_rx).await;
                     assert_eq!(msg, json!({"event": "scanStart"}));
 
-                    // End the scan (needs ack for feeder disable)
-                    harness.host_to_scanner_ack_tx.send(5).unwrap();
-                    harness
-                        .scanner_to_host_tx
-                        .send(Ok(Incoming::EndScanEvent))
-                        .unwrap();
+                    // End the scan
+                    harness.events_tx.send(Ok(Incoming::EndScanEvent)).unwrap();
                     // Wait for scanFailed event (image decode fails on empty data)
                     let msg = recv_output(&mut output_rx).await;
                     assert_eq!(msg["event"], "error");
                     assert_eq!(msg["code"], "scanFailed");
 
                     // Now a command should succeed (not get scanInProgress)
-                    harness.host_to_scanner_ack_tx.send(6).unwrap();
                     let msg = send_command(
                         &mut stdin_write,
                         &mut output_rx,

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -531,10 +531,6 @@ async fn handle_commands_and_events<R: tokio::io::AsyncBufRead + Unpin, W: Write
                         tracing::debug!("PACKET: {packet:?}");
                         packet
                     },
-                    Err(Error::TryRecvError(tokio::sync::mpsc::error::TryRecvError::Empty)) => {
-                        tracing::debug!("scanner channel received empty packet");
-                        continue;
-                    },
                     Err(Error::TryRecvError(tokio::sync::mpsc::error::TryRecvError::Disconnected)) => {
                         tracing::debug!("scanner channel disconnected");
                         client = None;
@@ -988,7 +984,7 @@ mod tests {
         assert_eq!(
             messages,
             vec![
-                json!({"response": "error", "code": "other", "message": "failed to serialize JSON: expected ident at line 1 column 2"})
+                json!({"response": "error", "code": "other", "message": "JSON error: expected ident at line 1 column 2"})
             ]
         );
     }

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -232,8 +232,15 @@ const FRAME_HEADER_LENGTH: usize = FRAME_TYPE_LENGTH + size_of::<u32>();
 /// payload length, and the payload. Sending image data as raw bytes rather
 /// than JSON avoids base64-encoding multi-megabyte scans and parsing them
 /// back out of a giant JSON document on the Node side.
-struct Output<W: Write> {
-    stdout: W,
+///
+/// Frames are written by a dedicated thread so that a slow reader (e.g. Node
+/// busy interpreting the previous sheet) never stalls the command/event loop,
+/// which must keep servicing scanner packets and commands. Frames are queued
+/// unbounded; dropping `Output` closes the queue and joins the thread, so
+/// everything queued is flushed before the process exits.
+struct Output {
+    frames_tx: Option<std::sync::mpsc::Sender<Vec<u8>>>,
+    writer_thread: Option<std::thread::JoinHandle<()>>,
     // We reject sending a command while a scan is in progress because it will
     // interrupt the scan. The flag is set by the scan start event and cleared
     // by every other scanner event (any event during a scan — completion,
@@ -245,27 +252,50 @@ struct Output<W: Write> {
     scan_in_progress: bool,
 }
 
-impl<W: Write> Output<W> {
+impl Output {
+    fn new<W: Write + Send + 'static>(mut stdout: W) -> Self {
+        let (frames_tx, frames_rx) = std::sync::mpsc::channel::<Vec<u8>>();
+        let writer_thread = std::thread::spawn(move || {
+            for frame in frames_rx {
+                // Stdout is line-buffered and frames don't end in newlines,
+                // so flush explicitly or the frame may sit in the buffer
+                // indefinitely.
+                if let Err(error) = stdout.write_all(&frame).and_then(|()| stdout.flush()) {
+                    tracing::error!("failed to write frame to stdout: {error}");
+                    // Dropping the receiver makes subsequent write_frame
+                    // calls fail, which shuts down the main loop.
+                    break;
+                }
+            }
+        });
+        Self {
+            frames_tx: Some(frames_tx),
+            writer_thread: Some(writer_thread),
+            scan_in_progress: false,
+        }
+    }
+
     fn write_frame(&mut self, frame_type: u8, payload_parts: &[&[u8]]) -> color_eyre::Result<()> {
         let payload_length: usize = payload_parts.iter().map(|part| part.len()).sum();
+        let mut frame = Vec::with_capacity(FRAME_HEADER_LENGTH + payload_length);
+        frame.push(frame_type);
+        frame.extend_from_slice(&u32::try_from(payload_length)?.to_le_bytes());
+        for part in payload_parts {
+            frame.extend_from_slice(part);
+        }
         #[cfg(feature = "recording")]
         if recording::is_enabled() {
-            let mut payload = Vec::with_capacity(payload_length);
-            for part in payload_parts {
-                payload.extend_from_slice(part);
-            }
-            recording::record(&recording::Entry::stdout_frame(frame_type, &payload));
+            recording::record(&recording::Entry::stdout_frame(
+                frame_type,
+                &frame[FRAME_HEADER_LENGTH..],
+            ));
         }
-        let mut header = [0u8; FRAME_HEADER_LENGTH];
-        header[0] = frame_type;
-        header[FRAME_TYPE_LENGTH..].copy_from_slice(&u32::try_from(payload_length)?.to_le_bytes());
-        self.stdout.write_all(&header)?;
-        for part in payload_parts {
-            self.stdout.write_all(part)?;
+        let Some(frames_tx) = self.frames_tx.as_ref() else {
+            bail!("stdout writer thread is not running");
+        };
+        if frames_tx.send(frame).is_err() {
+            bail!("stdout writer thread stopped");
         }
-        // Stdout is line-buffered and frames don't end in newlines, so flush
-        // explicitly or the frame may sit in the buffer indefinitely.
-        self.stdout.flush()?;
         Ok(())
     }
 
@@ -329,20 +359,33 @@ impl<W: Write> Output<W> {
     }
 }
 
+impl Drop for Output {
+    fn drop(&mut self) {
+        // Close the queue so the writer thread drains what remains and exits,
+        // then wait for it: nothing already queued is lost on shutdown.
+        drop(self.frames_tx.take());
+        if let Some(writer_thread) = self.writer_thread.take() {
+            if writer_thread.join().is_err() {
+                tracing::error!("stdout writer thread panicked");
+            }
+        }
+    }
+}
+
 /// Runs the main command/event loop. Reads newline-delimited JSON commands
 /// from `stdin`, writes TLV-framed responses and events to `stdout` (see
 /// [`Output`]), and uses `connect` to create new scanner connections.
 #[allow(clippy::too_many_lines)]
-async fn handle_commands_and_events<R: tokio::io::AsyncBufRead + Unpin, W: Write>(
+async fn handle_commands_and_events<
+    R: tokio::io::AsyncBufRead + Unpin,
+    W: Write + Send + 'static,
+>(
     stdin: R,
     stdout: W,
     mut connect: impl FnMut() -> pdi_scanner::Result<Client>,
 ) -> color_eyre::Result<()> {
     let mut stdin_lines = stdin.lines();
-    let mut output = Output {
-        stdout,
-        scan_in_progress: false,
-    };
+    let mut output = Output::new(stdout);
 
     let mut client: Option<Client> = None;
     let mut image_calibration_tables: Option<ImageCalibrationTables> = None;

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -235,9 +235,7 @@ const FRAME_HEADER_LENGTH: usize = FRAME_TYPE_LENGTH + size_of::<u32>();
 ///
 /// Frames are written by a dedicated thread so that a slow reader (e.g. Node
 /// busy interpreting the previous sheet) never stalls the command/event loop,
-/// which must keep servicing scanner packets and commands. Frames are queued
-/// unbounded; dropping `Output` closes the queue and joins the thread, so
-/// everything queued is flushed before the process exits.
+/// which must keep servicing scanner packets and commands.
 struct Output {
     frames_tx: Option<std::sync::mpsc::Sender<Vec<u8>>>,
     writer_thread: Option<std::thread::JoinHandle<()>>,
@@ -245,10 +243,9 @@ struct Output {
     // interrupt the scan. The flag is set by the scan start event and cleared
     // by every other scanner event (any event during a scan — completion,
     // scan failure, double feed, cover open — means the scan is over or
-    // aborted) and by scanner disconnection. Responses must NOT clear it:
-    // the only response possible while scanning is the ScanInProgress
-    // rejection itself, and clearing on it would disarm the guard after
-    // blocking a single command.
+    // aborted) and by scanner disconnection. Responses must NOT clear it: the
+    // only response possible while scanning is the ScanInProgress rejection
+    // itself.
     scan_in_progress: bool,
 }
 

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -440,6 +440,9 @@ async fn handle_commands_and_events<R: tokio::io::AsyncBufRead + Unpin, W: Write
                                     paper_length_inches,
                                 },
                             ) => {
+                                // Discard any leftover image data from an
+                                // aborted scan before a new scan session.
+                                raw_image_data.clear();
                                 let double_feed_detection_mode = if double_feed_detection_enabled {
                                     DoubleFeedDetectionMode::RejectDoubleFeeds
                                 } else {
@@ -550,8 +553,14 @@ async fn handle_commands_and_events<R: tokio::io::AsyncBufRead + Unpin, W: Write
                 };
 
                 match packet {
+                    // Note: the accumulator is deliberately NOT reset here.
+                    // The USB task polls the image data endpoint ahead of the
+                    // primary endpoint, so the first image chunks of a scan
+                    // can be forwarded before the begin event that the
+                    // scanner physically emitted first; resetting here would
+                    // drop them. The accumulator is cleared after each scan
+                    // is decoded and when scanning is enabled.
                     Incoming::BeginScanEvent => {
-                        raw_image_data = RawImageData::new();
                         output.send_event(Event::ScanStart)?;
                     }
                     Incoming::ImageData(image_data) => {
@@ -593,6 +602,7 @@ async fn handle_commands_and_events<R: tokio::io::AsyncBufRead + Unpin, W: Write
                                 })?;
                             }
                         }
+                        raw_image_data.clear();
                     }
                     Incoming::CoverOpenEvent => {
                         output.send_event(Event::CoverOpen)?;
@@ -1290,17 +1300,30 @@ mod tests {
                     drop(harness.events_tx);
 
                     // Commands must report the disconnection, not get stuck
-                    // behind a scan that will never finish.
-                    let msg = send_command(
-                        &mut stdin_write,
-                        &mut output_rx,
-                        r#"{"command":"getScannerStatus"}"#,
-                    )
-                    .await;
-                    assert_eq!(
-                        msg,
-                        json!({"response": "error", "code": "disconnected", "message": null})
-                    );
+                    // behind a scan that will never finish. The event loop
+                    // may serve a command before it observes the closed
+                    // channel, in which case the scan guard still rejects it;
+                    // it must never wedge on scanInProgress forever.
+                    let mut attempts = 0;
+                    loop {
+                        let msg = send_command(
+                            &mut stdin_write,
+                            &mut output_rx,
+                            r#"{"command":"getScannerStatus"}"#,
+                        )
+                        .await;
+                        if msg
+                            == json!({"response": "error", "code": "disconnected", "message": null})
+                        {
+                            break;
+                        }
+                        assert_eq!(
+                            msg,
+                            json!({"response": "error", "code": "scanInProgress", "message": null})
+                        );
+                        attempts += 1;
+                        assert!(attempts < 10, "never observed the disconnection");
+                    }
 
                     send_exit(&mut stdin_write).await;
                 }
@@ -2012,6 +2035,70 @@ mod tests {
         ];
 
         replay_recording(&entries).await;
+    }
+
+    /// The USB task polls the image data endpoint ahead of the primary
+    /// endpoint, so image chunks can be forwarded before the begin scan event
+    /// that physically preceded them. They must still end up in the decoded
+    /// scan.
+    #[tokio::test]
+    async fn image_data_arriving_before_begin_scan_event_is_not_dropped() {
+        use pdi_scanner::protocol::image::DEFAULT_IMAGE_WIDTH;
+
+        const WIDTH: usize = DEFAULT_IMAGE_WIDTH as usize;
+        const HEIGHT: usize = 4;
+
+        let (client, harness) =
+            setup_connected_client_with_calibration(&[u8::MAX; WIDTH], &[0; WIDTH]);
+        let mut client_slot = Some(client);
+        let (stdin_read, mut stdin_write) = tokio::io::duplex(4096);
+        let (stdout_writer, mut output_rx) = ChannelWriter::new();
+
+        let (result, ()) = timeout(TEST_TIMEOUT, async {
+            tokio::join!(
+                handle_commands_and_events(BufReader::new(stdin_read), stdout_writer, || {
+                    Ok(client_slot.take().expect("connect called more than once"))
+                }),
+                async {
+                    send_command(&mut stdin_write, &mut output_rx, r#"{"command":"connect"}"#)
+                        .await;
+
+                    let mut data = Vec::with_capacity(2 * WIDTH * HEIGHT);
+                    for _ in 0..(WIDTH * HEIGHT) {
+                        data.push(7);
+                        data.push(9);
+                    }
+                    let (first_chunk, rest) = data.split_at(2 * WIDTH);
+
+                    // The first chunk beats the begin scan event
+                    harness
+                        .events_tx
+                        .send(Ok(Incoming::ImageData(ImageData(first_chunk.to_vec()))))
+                        .unwrap();
+                    harness
+                        .events_tx
+                        .send(Ok(Incoming::BeginScanEvent))
+                        .unwrap();
+                    let msg = recv_output(&mut output_rx).await;
+                    assert_eq!(msg, json!({"event": "scanStart"}));
+
+                    harness
+                        .events_tx
+                        .send(Ok(Incoming::ImageData(ImageData(rest.to_vec()))))
+                        .unwrap();
+                    harness.events_tx.send(Ok(Incoming::EndScanEvent)).unwrap();
+                    let msg = recv_output(&mut output_rx).await;
+                    assert_eq!(msg["event"], "scanComplete");
+                    assert_eq!(msg["images"][0]["height"], HEIGHT);
+                    assert_eq!(msg["images"][1]["height"], HEIGHT);
+
+                    send_exit(&mut stdin_write).await;
+                }
+            )
+        })
+        .await
+        .unwrap();
+        result.unwrap();
     }
 
     #[tokio::test]

--- a/libs/pdi-scanner/src/rust/protocol/image.rs
+++ b/libs/pdi-scanner/src/rust/protocol/image.rs
@@ -105,11 +105,6 @@ impl RawImageData {
             "Image calibration tables must be the same length as the row"
         );
 
-        // Decode in a single parallel pass, writing each output pixel exactly
-        // once into preallocated buffers: de-interleave the duplex byte
-        // stream (even bytes are the top side, odd bytes the bottom),
-        // reverse the top side's pixel order within each row, and apply the
-        // per-column calibration.
         let mut top = vec![0u8; width * height as usize];
         let mut bottom = vec![0u8; width * height as usize];
         top.par_chunks_exact_mut(width)

--- a/libs/pdi-scanner/src/rust/protocol/image.rs
+++ b/libs/pdi-scanner/src/rust/protocol/image.rs
@@ -1,4 +1,7 @@
-use rayon::{prelude::ParallelIterator, slice::ParallelSlice};
+use rayon::{
+    iter::{IndexedParallelIterator, ParallelIterator},
+    slice::ParallelSliceMut,
+};
 
 use image::GrayImage;
 
@@ -8,34 +11,20 @@ use super::types::ScanSideMode;
 
 pub const DEFAULT_IMAGE_WIDTH: u32 = 1728;
 
-/// Applies image calibration to a single row of pixel data based on the
-/// provided white and black calibration tables (retrieved from the scanner).
-/// The formula used is based on guidance from PDI.
-fn apply_image_calibration(
-    row: &[u8],
-    white_calibration_table: &[u8],
-    black_calibration_table: &[u8],
-) -> Vec<u8> {
-    assert!(
-        row.len() == white_calibration_table.len() && row.len() == black_calibration_table.len(),
-        "Image calibration tables must be the same length as the row"
-    );
-
-    row.iter()
-        .zip(white_calibration_table.iter())
-        .zip(black_calibration_table.iter())
-        .map(|((&pixel, &white_calibration), &black_calibration)| {
-            let denominator = white_calibration.saturating_sub(black_calibration);
-            let numerator = pixel.saturating_sub(black_calibration);
-            #[allow(clippy::cast_possible_truncation)]
-            if denominator == 0 {
-                0
-            } else {
-                ((u32::from(numerator) * u32::from(u8::MAX)) / u32::from(denominator))
-                    .min(u32::from(u8::MAX)) as u8
-            }
-        })
-        .collect()
+/// Applies image calibration to a single pixel based on the white and black
+/// calibration values for its column (retrieved from the scanner). The
+/// formula used is based on guidance from PDI.
+fn apply_image_calibration(pixel: u8, white_calibration: u8, black_calibration: u8) -> u8 {
+    let denominator = white_calibration.saturating_sub(black_calibration);
+    if denominator == 0 {
+        return 0;
+    }
+    let numerator = pixel.saturating_sub(black_calibration);
+    #[allow(clippy::cast_possible_truncation)]
+    {
+        ((u32::from(numerator) * u32::from(u8::MAX)) / u32::from(denominator))
+            .min(u32::from(u8::MAX)) as u8
+    }
 }
 
 /// Container for raw image data from the scanner. Decodes the data as images
@@ -105,43 +94,45 @@ impl RawImageData {
             return Err(Error::InvalidData("empty image data".to_string()));
         }
         let height = self.compute_expected_height(width, scan_side_mode)?;
+        let width = width as usize;
 
-        let (top_raw, bottom_raw): (Vec<u8>, Vec<u8>) = self
-            .data
-            .par_chunks_exact(2)
-            .map(|pixel_pair| (pixel_pair[0], pixel_pair[1]))
-            .unzip();
-
-        let (top, bottom) = rayon::join(
-            || {
-                top_raw
-                    .par_chunks_exact(width as usize)
-                    .map(|row| row.iter().copied().rev().collect::<Vec<_>>())
-                    .map(|row| {
-                        apply_image_calibration(
-                            &row,
-                            &image_calibration_tables.front_white,
-                            &image_calibration_tables.front_black,
-                        )
-                    })
-                    .flatten()
-                    .collect()
-            },
-            || {
-                bottom_raw
-                    .par_chunks_exact(width as usize)
-                    .map(|row| {
-                        apply_image_calibration(
-                            row,
-                            &image_calibration_tables.back_white,
-                            &image_calibration_tables.back_black,
-                        )
-                    })
-                    .flatten()
-                    .collect()
-            },
+        let tables = image_calibration_tables;
+        assert!(
+            tables.front_white.len() == width
+                && tables.front_black.len() == width
+                && tables.back_white.len() == width
+                && tables.back_black.len() == width,
+            "Image calibration tables must be the same length as the row"
         );
 
+        // Decode in a single parallel pass, writing each output pixel exactly
+        // once into preallocated buffers: de-interleave the duplex byte
+        // stream (even bytes are the top side, odd bytes the bottom),
+        // reverse the top side's pixel order within each row, and apply the
+        // per-column calibration.
+        let mut top = vec![0u8; width * height as usize];
+        let mut bottom = vec![0u8; width * height as usize];
+        top.par_chunks_exact_mut(width)
+            .zip(bottom.par_chunks_exact_mut(width))
+            .enumerate()
+            .for_each(|(row_index, (top_row, bottom_row))| {
+                let input_row = &self.data[row_index * 2 * width..(row_index + 1) * 2 * width];
+                for x in 0..width {
+                    top_row[x] = apply_image_calibration(
+                        input_row[2 * (width - 1 - x)],
+                        tables.front_white[x],
+                        tables.front_black[x],
+                    );
+                    bottom_row[x] = apply_image_calibration(
+                        input_row[2 * x + 1],
+                        tables.back_white[x],
+                        tables.back_black[x],
+                    );
+                }
+            });
+
+        #[allow(clippy::cast_possible_truncation)]
+        let width = width as u32;
         let top_page = GrayImage::from_raw(width, height, top)
             .ok_or_else(|| Error::InvalidData("unexpected data length".to_string()))?;
         let bottom_page = GrayImage::from_raw(width, height, bottom)
@@ -231,6 +222,58 @@ mod tests {
                     vec![0b0101_0101, 0b0101_0101, 0b0101_0101, 0b0101_0101]
                 )
                 .unwrap(),
+            )
+        );
+    }
+
+    /// Pins the full decode semantics with asymmetric data: de-interleaving,
+    /// the top side's right-to-left pixel reversal, per-output-column
+    /// calibration (applied after the reversal), and clamping to 255.
+    #[test]
+    fn test_duplex_reversal_calibration_and_clamping() {
+        let mut data = RawImageData::new();
+        let image_calibration_tables = ImageCalibrationTables {
+            // Output column 0 of the top side is scaled by 255/51 = 5x
+            front_white: vec![51, 255, 255],
+            front_black: vec![0, 0, 0],
+            // Output column 1 of the bottom side is scaled by 5x
+            back_white: vec![255, 51, 255],
+            back_black: vec![0, 0, 0],
+        };
+        // Interleaved: top stream [10, 20, 30, 40, 50, 60],
+        // bottom stream [1, 2, 3, 4, 5, 6]; width 3, so 2 rows per side
+        data.extend_from_slice(&[10, 1, 20, 2, 30, 3, 40, 4, 50, 5, 60, 6]);
+        assert_eq!(
+            data.try_decode_scan(3, ScanSideMode::Duplex, &image_calibration_tables)
+                .unwrap(),
+            Sheet::Duplex(
+                // Top rows reverse ([10, 20, 30] -> [30, 20, 10]), then
+                // column 0 scales 5x; 60 * 5 = 300 clamps to 255
+                GrayImage::from_raw(3, 2, vec![150, 20, 10, 255, 50, 40]).unwrap(),
+                // Bottom rows keep their order; column 1 scales 5x
+                GrayImage::from_raw(3, 2, vec![1, 10, 3, 4, 25, 6]).unwrap(),
+            )
+        );
+    }
+
+    /// A white calibration value equal to the black value would divide by
+    /// zero; those pixels are forced to 0.
+    #[test]
+    fn test_zero_calibration_denominator() {
+        let mut data = RawImageData::new();
+        let image_calibration_tables = ImageCalibrationTables {
+            front_white: vec![100, 255],
+            front_black: vec![100, 0],
+            back_white: vec![255, 100],
+            back_black: vec![0, 100],
+        };
+        data.extend_from_slice(&[10, 1, 20, 2]);
+        assert_eq!(
+            data.try_decode_scan(2, ScanSideMode::Duplex, &image_calibration_tables)
+                .unwrap(),
+            Sheet::Duplex(
+                GrayImage::from_raw(2, 1, vec![0, 10]).unwrap(),
+                GrayImage::from_raw(2, 1, vec![1, 0]).unwrap(),
             )
         );
     }

--- a/libs/pdi-scanner/src/rust/scanner.rs
+++ b/libs/pdi-scanner/src/rust/scanner.rs
@@ -238,8 +238,7 @@ fn find_pdi_device() -> Result<nusb::Device> {
 /// data and errors) on the other. Outgoing commands are serialized, written
 /// to the USB OUT endpoint, and acknowledged via their one-shot channel.
 ///
-/// If the client side of the channels is dropped, the task logs and stops
-/// rather than panicking.
+/// If the client side of the channels is dropped, the task logs and stops.
 #[allow(clippy::too_many_lines)]
 fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Duration) -> Scanner {
     let (host_to_scanner_tx, mut host_to_scanner_rx) =
@@ -301,10 +300,6 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                         break;
                     }
 
-                    // Resubmit a fresh transfer buffer: the received data was
-                    // moved into the channel rather than copied, trading a
-                    // memcpy of up to 1MiB per transfer for a cheap
-                    // uninitialized allocation.
                     in_image_data_queue.submit(RequestBuffer::new(IMAGE_BUFFER_SIZE));
                 }
 

--- a/libs/pdi-scanner/src/rust/scanner.rs
+++ b/libs/pdi-scanner/src/rust/scanner.rs
@@ -238,11 +238,8 @@ fn find_pdi_device() -> Result<nusb::Device> {
 /// data and errors) on the other. Outgoing commands are serialized, written
 /// to the USB OUT endpoint, and acknowledged via their one-shot channel.
 ///
-/// # Panics
-///
-/// If the in-process channel between the scanner and the client becomes
-/// disconnected.
-#[allow(clippy::unwrap_used)]
+/// If the client side of the channels is dropped, the task logs and stops
+/// rather than panicking.
 #[allow(clippy::too_many_lines)]
 fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Duration) -> Scanner {
     let (host_to_scanner_tx, mut host_to_scanner_rx) =
@@ -284,7 +281,7 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                         if recording::is_enabled() {
                             recording::record(&recording::Entry::scanner_to_host_error(&err));
                         }
-                        events_tx.send(Err(err)).unwrap();
+                        let _ = events_tx.send(Err(err));
                         break;
                     }
                     let data = completion.data;
@@ -296,9 +293,13 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                             &data,
                         ));
                     }
-                    events_tx
+                    if events_tx
                         .send(Ok(packets::Incoming::ImageData(packets::ImageData(data))))
-                        .unwrap();
+                        .is_err()
+                    {
+                        tracing::debug!("client dropped; stopping USB task");
+                        break;
+                    }
 
                     // Resubmit a fresh transfer buffer: the received data was
                     // moved into the channel rather than copied, trading a
@@ -315,7 +316,7 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                         if recording::is_enabled() {
                             recording::record(&recording::Entry::scanner_to_host_error(&err));
                         }
-                        events_tx.send(Err(err)).unwrap();
+                        let _ = events_tx.send(Err(err));
                         break;
                     }
                     let data = completion.data;
@@ -333,10 +334,17 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                     match parsers::any_incoming(&data) {
                         Ok(([], packet)) => {
                             tracing::debug!("Received incoming packet: {packet:?}");
-                            if matches!(packet.message_type(), IncomingType::Response) {
-                                responses_tx.send(packet).unwrap();
+                            let send_result = if matches!(
+                                packet.message_type(),
+                                IncomingType::Response
+                            ) {
+                                responses_tx.send(packet).map_err(|_| ())
                             } else {
-                                events_tx.send(Ok(packet)).unwrap();
+                                events_tx.send(Ok(packet)).map_err(|_| ())
+                            };
+                            if send_result.is_err() {
+                                tracing::debug!("client dropped; stopping USB task");
+                                break;
                             }
                         }
                         Ok((remaining, packet)) => {
@@ -345,18 +353,14 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                                     len = remaining.len(),
                                     remaining = String::from_utf8_lossy(remaining)
                                 );
-                            events_tx
-                                .send(Ok(Incoming::Unknown(data.clone())))
-                                .unwrap();
+                            let _ = events_tx.send(Ok(Incoming::Unknown(data.clone())));
                         }
                         Err(err) => {
                             tracing::error!(
                                 "Error parsing packet: {data:?} (err={err})",
                                 data = String::from_utf8_lossy(&data)
                             );
-                            events_tx
-                                .send(Ok(Incoming::Unknown(data.clone())))
-                                .unwrap();
+                            let _ = events_tx.send(Ok(Incoming::Unknown(data.clone())));
                         }
                     }
 
@@ -398,7 +402,7 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                             if recording::is_enabled() {
                                 recording::record(&recording::Entry::scanner_to_host_error(&err));
                             }
-                            events_tx.send(Err(err)).unwrap();
+                            let _ = events_tx.send(Err(err));
                             break;
                         }
                         Err(_) => {
@@ -412,7 +416,7 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                             if recording::is_enabled() {
                                 recording::record(&recording::Entry::scanner_to_host_error(&err));
                             }
-                            events_tx.send(Err(err)).unwrap();
+                            let _ = events_tx.send(Err(err));
                             break;
                         }
                     }

--- a/libs/pdi-scanner/src/rust/scanner.rs
+++ b/libs/pdi-scanner/src/rust/scanner.rs
@@ -297,11 +297,14 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                         ));
                     }
                     events_tx
-                        .send(Ok(packets::Incoming::ImageData(packets::ImageData(data.clone()))))
+                        .send(Ok(packets::Incoming::ImageData(packets::ImageData(data))))
                         .unwrap();
 
-                    // resubmit the transfer to receive more data
-                    in_image_data_queue.submit(RequestBuffer::reuse(data, IMAGE_BUFFER_SIZE));
+                    // Resubmit a fresh transfer buffer: the received data was
+                    // moved into the channel rather than copied, trading a
+                    // memcpy of up to 1MiB per transfer for a cheap
+                    // uninitialized allocation.
+                    in_image_data_queue.submit(RequestBuffer::new(IMAGE_BUFFER_SIZE));
                 }
 
                 completion = in_primary_queue.next_complete() => {

--- a/libs/pdi-scanner/src/rust/scanner.rs
+++ b/libs/pdi-scanner/src/rust/scanner.rs
@@ -12,7 +12,15 @@ use nusb::transfer::{Completion, RequestBuffer, TransferError};
 use crate::recording;
 use crate::{protocol::parsers, Error, Result, UsbError};
 
-use super::protocol::packets::{self, Incoming};
+use super::protocol::packets::{self, Incoming, IncomingType};
+
+/// A command for the USB task: the packet to write and a one-shot channel
+/// acknowledging a successful write. If the write fails, the USB task reports
+/// the error on the events channel and shuts down, dropping the ack sender —
+/// so a sender awaiting the ack learns of the failure by the channel closing.
+/// If the sender is cancelled (e.g. by a timeout) before the ack arrives, the
+/// dropped receiver is harmless: no state is shared with later commands.
+pub type OutgoingCommand = (packets::Outgoing, tokio::sync::oneshot::Sender<()>);
 
 pub(crate) trait BulkInQueue: Send + 'static {
     fn submit(&mut self, buf: RequestBuffer);
@@ -70,11 +78,13 @@ const DEFAULT_BUFFER_SIZE: usize = 16_384;
 /// otherwise we get a `FifoOverflow` error from the scanner.
 const IMAGE_BUFFER_SIZE: usize = 1_048_576; // 1 MiB
 
-#[allow(clippy::struct_field_names)]
 pub struct Scanner {
-    pub(crate) host_to_scanner_tx: tokio::sync::mpsc::UnboundedSender<(usize, packets::Outgoing)>,
-    pub(crate) host_to_scanner_ack_rx: tokio::sync::mpsc::UnboundedReceiver<usize>,
-    pub(crate) scanner_to_host_rx: tokio::sync::mpsc::UnboundedReceiver<Result<packets::Incoming>>,
+    pub(crate) host_to_scanner_tx: tokio::sync::mpsc::UnboundedSender<OutgoingCommand>,
+    /// Solicited responses to commands, in command order.
+    pub(crate) responses_rx: tokio::sync::mpsc::UnboundedReceiver<packets::Incoming>,
+    /// Unsolicited traffic: scan/calibration events, image data, unknown
+    /// packets, and errors that shut down the USB task.
+    pub(crate) events_rx: tokio::sync::mpsc::UnboundedReceiver<Result<packets::Incoming>>,
     stop_tx: Option<tokio::sync::oneshot::Sender<()>>,
     task_handle: Option<tokio::task::JoinHandle<()>>,
     /// Advisory inter-process lock on the scanner, held for the lifetime of
@@ -105,14 +115,14 @@ impl Scanner {
     /// [`Client`](crate::client::Client) without real USB hardware.
     #[must_use]
     pub fn mock(
-        host_to_scanner_tx: tokio::sync::mpsc::UnboundedSender<(usize, packets::Outgoing)>,
-        host_to_scanner_ack_rx: tokio::sync::mpsc::UnboundedReceiver<usize>,
-        scanner_to_host_rx: tokio::sync::mpsc::UnboundedReceiver<Result<packets::Incoming>>,
+        host_to_scanner_tx: tokio::sync::mpsc::UnboundedSender<OutgoingCommand>,
+        responses_rx: tokio::sync::mpsc::UnboundedReceiver<packets::Incoming>,
+        events_rx: tokio::sync::mpsc::UnboundedReceiver<Result<packets::Incoming>>,
     ) -> Self {
         Self {
             host_to_scanner_tx,
-            host_to_scanner_ack_rx,
-            scanner_to_host_rx,
+            responses_rx,
+            events_rx,
             stop_tx: None,
             task_handle: None,
             lock_file: None,
@@ -223,9 +233,10 @@ fn find_pdi_device() -> Result<nusb::Device> {
 
 /// Spawns a background task that bridges USB I/O with in-process channels.
 /// The task polls the primary and image data USB endpoints for incoming
-/// packets, parses them, and forwards them to the returned scanner's
-/// channels. Outgoing packets sent on the scanner's channels are serialized
-/// and written to the USB OUT endpoint.
+/// packets, parses them, and routes them to the returned scanner's channels:
+/// solicited responses on one channel, unsolicited events (including image
+/// data and errors) on the other. Outgoing commands are serialized, written
+/// to the USB OUT endpoint, and acknowledged via their one-shot channel.
 ///
 /// # Panics
 ///
@@ -235,10 +246,9 @@ fn find_pdi_device() -> Result<nusb::Device> {
 #[allow(clippy::too_many_lines)]
 fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Duration) -> Scanner {
     let (host_to_scanner_tx, mut host_to_scanner_rx) =
-        tokio::sync::mpsc::unbounded_channel::<(usize, packets::Outgoing)>();
-    let (host_to_scanner_ack_tx, host_to_scanner_ack_rx) =
-        tokio::sync::mpsc::unbounded_channel::<usize>();
-    let (scanner_to_host_tx, scanner_to_host_rx) = tokio::sync::mpsc::unbounded_channel();
+        tokio::sync::mpsc::unbounded_channel::<OutgoingCommand>();
+    let (responses_tx, responses_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (events_tx, events_rx) = tokio::sync::mpsc::unbounded_channel();
     let (stop_tx, mut stop_rx) = tokio::sync::oneshot::channel();
 
     let mut in_primary_queue = usb_interface.bulk_in_queue(ENDPOINT_IN_PRIMARY);
@@ -274,7 +284,7 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                         if recording::is_enabled() {
                             recording::record(&recording::Entry::scanner_to_host_error(&err));
                         }
-                        scanner_to_host_tx.send(Err(err)).unwrap();
+                        events_tx.send(Err(err)).unwrap();
                         break;
                     }
                     let data = completion.data;
@@ -286,7 +296,7 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                             &data,
                         ));
                     }
-                    scanner_to_host_tx
+                    events_tx
                         .send(Ok(packets::Incoming::ImageData(packets::ImageData(data.clone()))))
                         .unwrap();
 
@@ -302,7 +312,7 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                         if recording::is_enabled() {
                             recording::record(&recording::Entry::scanner_to_host_error(&err));
                         }
-                        scanner_to_host_tx.send(Err(err)).unwrap();
+                        events_tx.send(Err(err)).unwrap();
                         break;
                     }
                     let data = completion.data;
@@ -320,7 +330,11 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                     match parsers::any_incoming(&data) {
                         Ok(([], packet)) => {
                             tracing::debug!("Received incoming packet: {packet:?}");
-                            scanner_to_host_tx.send(Ok(packet)).unwrap();
+                            if matches!(packet.message_type(), IncomingType::Response) {
+                                responses_tx.send(packet).unwrap();
+                            } else {
+                                events_tx.send(Ok(packet)).unwrap();
+                            }
                         }
                         Ok((remaining, packet)) => {
                             tracing::warn!(
@@ -328,7 +342,7 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                                     len = remaining.len(),
                                     remaining = String::from_utf8_lossy(remaining)
                                 );
-                            scanner_to_host_tx
+                            events_tx
                                 .send(Ok(Incoming::Unknown(data.clone())))
                                 .unwrap();
                         }
@@ -337,7 +351,7 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                                 "Error parsing packet: {data:?} (err={err})",
                                 data = String::from_utf8_lossy(&data)
                             );
-                            scanner_to_host_tx
+                            events_tx
                                 .send(Ok(Incoming::Unknown(data.clone())))
                                 .unwrap();
                         }
@@ -347,7 +361,7 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                     in_primary_queue.submit(RequestBuffer::reuse(data, DEFAULT_BUFFER_SIZE));
                 }
 
-                Some((id, packet)) = host_to_scanner_rx.recv() => {
+                Some((packet, ack)) = host_to_scanner_rx.recv() => {
                     let bytes = packet.to_bytes();
                     tracing::debug!(
                         "sending packet: {packet:?} (data: {data:?})",
@@ -370,7 +384,9 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                             if let Some(bytes) = bytes_for_recording {
                                 recording::record(&recording::Entry::host_to_scanner(&bytes));
                             }
-                            host_to_scanner_ack_tx.send(id).unwrap();
+                            // The sender may have been cancelled while waiting
+                            // (e.g. by a timeout); a dropped receiver is fine.
+                            let _ = ack.send(());
                         }
                         Ok(Err(err)) => {
                             tracing::error!("Error sending outgoing packet: {err:?}");
@@ -379,7 +395,7 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                             if recording::is_enabled() {
                                 recording::record(&recording::Entry::scanner_to_host_error(&err));
                             }
-                            scanner_to_host_tx.send(Err(err)).unwrap();
+                            events_tx.send(Err(err)).unwrap();
                             break;
                         }
                         Err(_) => {
@@ -393,7 +409,7 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
                             if recording::is_enabled() {
                                 recording::record(&recording::Entry::scanner_to_host_error(&err));
                             }
-                            scanner_to_host_tx.send(Err(err)).unwrap();
+                            events_tx.send(Err(err)).unwrap();
                             break;
                         }
                     }
@@ -409,8 +425,8 @@ fn poll_scanner<U: UsbInterface>(usb_interface: &Arc<U>, default_timeout: Durati
 
     Scanner {
         host_to_scanner_tx,
-        host_to_scanner_ack_rx,
-        scanner_to_host_rx,
+        responses_rx,
+        events_rx,
         stop_tx: Some(stop_tx),
         task_handle: Some(task_handle),
         lock_file: None,
@@ -582,12 +598,33 @@ mod tests {
             })
             .unwrap();
 
-        let packet = timeout(TEST_TIMEOUT, scanner.scanner_to_host_rx.recv())
+        let packet = timeout(TEST_TIMEOUT, scanner.events_rx.recv())
             .await
             .unwrap()
             .unwrap()
             .unwrap();
         assert_eq!(packet, Incoming::CoverOpenEvent);
+    }
+
+    #[tokio::test]
+    async fn incoming_primary_response_routed_to_responses_channel() {
+        let (handles, mut scanner) = start_mock_scanner();
+
+        // A test string response is a solicited response, so it must arrive
+        // on the responses channel, not the events channel.
+        handles
+            .primary_tx
+            .send(Completion {
+                data: encode_packet(b"D"),
+                status: Ok(()),
+            })
+            .unwrap();
+
+        let packet = timeout(TEST_TIMEOUT, scanner.responses_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(packet, Incoming::GetTestStringResponse(String::new()));
     }
 
     #[tokio::test]
@@ -603,7 +640,7 @@ mod tests {
             })
             .unwrap();
 
-        let packet = timeout(TEST_TIMEOUT, scanner.scanner_to_host_rx.recv())
+        let packet = timeout(TEST_TIMEOUT, scanner.events_rx.recv())
             .await
             .unwrap()
             .unwrap()
@@ -626,7 +663,7 @@ mod tests {
             })
             .unwrap();
 
-        let packet = timeout(TEST_TIMEOUT, scanner.scanner_to_host_rx.recv())
+        let packet = timeout(TEST_TIMEOUT, scanner.events_rx.recv())
             .await
             .unwrap()
             .unwrap()
@@ -649,7 +686,7 @@ mod tests {
             })
             .unwrap();
 
-        let packet = timeout(TEST_TIMEOUT, scanner.scanner_to_host_rx.recv())
+        let packet = timeout(TEST_TIMEOUT, scanner.events_rx.recv())
             .await
             .unwrap()
             .unwrap()
@@ -661,11 +698,12 @@ mod tests {
 
     #[tokio::test]
     async fn outgoing_command_forwarded_and_acked() {
-        let (mut handles, mut scanner) = start_mock_scanner();
+        let (mut handles, scanner) = start_mock_scanner();
 
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
         scanner
             .host_to_scanner_tx
-            .send((123, Outgoing::EnableCrcCheckingRequest))
+            .send((Outgoing::EnableCrcCheckingRequest, ack_tx))
             .unwrap();
 
         // Verify the serialized bytes arrive on the correct endpoint
@@ -679,11 +717,7 @@ mod tests {
         handles.bulk_out_response_tx.send(Ok(())).unwrap();
 
         // Verify the ack
-        let ack_id = timeout(TEST_TIMEOUT, scanner.host_to_scanner_ack_rx.recv())
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(ack_id, 123);
+        timeout(TEST_TIMEOUT, ack_rx).await.unwrap().unwrap();
     }
 
     // --- Errors ---
@@ -700,14 +734,14 @@ mod tests {
             })
             .unwrap();
 
-        let result = timeout(TEST_TIMEOUT, scanner.scanner_to_host_rx.recv())
+        let result = timeout(TEST_TIMEOUT, scanner.events_rx.recv())
             .await
             .unwrap()
             .unwrap();
         assert!(result.is_err());
 
         // Task should have exited — channel closes
-        assert!(scanner.scanner_to_host_rx.recv().await.is_none());
+        assert!(scanner.events_rx.recv().await.is_none());
     }
 
     #[tokio::test]
@@ -722,22 +756,23 @@ mod tests {
             })
             .unwrap();
 
-        let result = timeout(TEST_TIMEOUT, scanner.scanner_to_host_rx.recv())
+        let result = timeout(TEST_TIMEOUT, scanner.events_rx.recv())
             .await
             .unwrap()
             .unwrap();
         assert!(result.is_err());
 
-        assert!(scanner.scanner_to_host_rx.recv().await.is_none());
+        assert!(scanner.events_rx.recv().await.is_none());
     }
 
     #[tokio::test]
     async fn outgoing_transfer_error_forwarded_and_task_exits() {
         let (mut handles, mut scanner) = start_mock_scanner();
 
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
         scanner
             .host_to_scanner_tx
-            .send((1, Outgoing::EnableCrcCheckingRequest))
+            .send((Outgoing::EnableCrcCheckingRequest, ack_tx))
             .unwrap();
 
         let (endpoint, _data) = timeout(TEST_TIMEOUT, handles.bulk_out_data_rx.recv())
@@ -750,7 +785,7 @@ mod tests {
             .send(Err(TransferError::Disconnected))
             .unwrap();
 
-        let err = timeout(TEST_TIMEOUT, scanner.scanner_to_host_rx.recv())
+        let err = timeout(TEST_TIMEOUT, scanner.events_rx.recv())
             .await
             .unwrap()
             .unwrap()
@@ -763,8 +798,10 @@ mod tests {
             }
         ));
 
-        // Task should have exited — channel closes
-        assert!(scanner.scanner_to_host_rx.recv().await.is_none());
+        // Task should have exited — channel closes, and the failed write was
+        // never acked
+        assert!(scanner.events_rx.recv().await.is_none());
+        assert!(ack_rx.await.is_err());
     }
 
     #[tokio::test]
@@ -772,9 +809,10 @@ mod tests {
         // Use a short timeout so the test runs quickly
         let (mut handles, mut scanner) = start_mock_scanner_with_timeout(Duration::from_millis(10));
 
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
         scanner
             .host_to_scanner_tx
-            .send((1, Outgoing::EnableCrcCheckingRequest))
+            .send((Outgoing::EnableCrcCheckingRequest, ack_tx))
             .unwrap();
 
         // Wait for the packet to arrive at the mock (before the timeout fires)
@@ -785,7 +823,7 @@ mod tests {
         assert_eq!(endpoint, ENDPOINT_OUT);
 
         // No response sent — mock hangs on response_rx until timeout fires
-        let err = timeout(TEST_TIMEOUT, scanner.scanner_to_host_rx.recv())
+        let err = timeout(TEST_TIMEOUT, scanner.events_rx.recv())
             .await
             .unwrap()
             .unwrap()
@@ -798,8 +836,10 @@ mod tests {
             } if e.kind() == std::io::ErrorKind::TimedOut
         ));
 
-        // Task should have exited — channel closes
-        assert!(scanner.scanner_to_host_rx.recv().await.is_none());
+        // Task should have exited — channel closes, and the timed-out write
+        // was never acked
+        assert!(scanner.events_rx.recv().await.is_none());
+        assert!(ack_rx.await.is_err());
     }
 
     // --- Lifecycle ---
@@ -841,7 +881,7 @@ mod tests {
                 status: Ok(()),
             })
             .unwrap();
-        let _ = timeout(TEST_TIMEOUT, scanner.scanner_to_host_rx.recv()).await;
+        let _ = timeout(TEST_TIMEOUT, scanner.events_rx.recv()).await;
         assert_eq!(handles.primary_submissions.lock().unwrap().len(), 2);
 
         // Send an image data completion — should trigger a resubmit
@@ -852,7 +892,7 @@ mod tests {
                 status: Ok(()),
             })
             .unwrap();
-        let _ = timeout(TEST_TIMEOUT, scanner.scanner_to_host_rx.recv()).await;
+        let _ = timeout(TEST_TIMEOUT, scanner.events_rx.recv()).await;
         assert_eq!(handles.image_data_submissions.lock().unwrap().len(), 3);
     }
 

--- a/libs/pdi-scanner/src/rust/types.rs
+++ b/libs/pdi-scanner/src/rust/types.rs
@@ -29,7 +29,7 @@ pub enum Error {
     #[error("failed to validate request: {0}")]
     ValidateRequest(String),
 
-    #[error("failed to serialize JSON: {0}")]
+    #[error("JSON error: {0}")]
     Serde(#[from] serde_json::Error),
 
     #[error("timed out receiving data")]


### PR DESCRIPTION
## Overview

Simplifies pdictl's client/USB-task channel protocol and fixes bugs found along the way.

- **Protocol**: commands carry a `oneshot` ack and the task routes packets by classification (solicited responses vs. everything else). The request-ID machinery and packet stash are gone; a caller timeout can no longer leave a stale ack that panics the next command; image data can't interfere with command traffic.
- **Fixes**: the `scan_in_progress` guard disarmed itself after rejecting one command; image chunks arriving before `BeginScanEvent` were silently dropped; assorted hygiene (error text, dead code, task shutdown).
- **Perf**: single-pass scan decode with no intermediate allocations; stdout frames written from a dedicated thread so a slow reader never stalls the event loop.

## Demo Video or Screenshot

n/a

## Testing Plan

- The committed synthetic corpus from #9154 (below this PR) replays green in CI at every commit here, and the six full-fidelity source recordings replay green on this branch locally — the wire and stdout behavior is unchanged.
- Every commit passes the full Rust suite, fmt, and clippy; new regression tests pin each fix.
- Still planned: live stress (status hammer during scans) and a shoeshine soak.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions (_none_).
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoLZVgnMKXfZ1FM52PH8ii

