### PR TITLE
hmpb: Refactor template pagination to pass contests explicitly

### DIFF
--- a/libs/hmpb/src/all_bubble_ballot/template.tsx
+++ b/libs/hmpb/src/all_bubble_ballot/template.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import {
   ballotPaperDimensions,
   BaseBallotProps,
+  Contest,
   HmpbBallotPaperSize,
 } from '@votingworks/types';
-import { assertDefined, ok, range, Result } from '@votingworks/basics';
+import { assert, ok, range, Result } from '@votingworks/basics';
 import {
   BallotPageTemplate,
   ContentComponentResult,
@@ -75,11 +76,12 @@ export function allBubbleBallotTemplate(
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async function BallotPageContent(
-    props: (BaseBallotProps & { dimensions: PixelDimensions }) | undefined,
+    _props: BaseBallotProps & { dimensions: PixelDimensions },
+    contests: readonly Contest[],
     _scratchpad: RenderScratchpad
-  ): Promise<ContentComponentResult<BaseBallotProps>> {
-    const { election, ...restProps } = assertDefined(props);
-    const pageNumber = numPages - election.contests.length + 1;
+  ): Promise<ContentComponentResult> {
+    assert(contests.length > 0);
+    const pageNumber = numPages - contests.length + 1;
     const bubbles = (
       <div
         style={{
@@ -110,25 +112,16 @@ export function allBubbleBallotTemplate(
         ))}
       </div>
     );
-    const contestsLeft = election.contests.slice(1);
     return ok({
       currentPageElement: bubbles,
-      nextPageProps:
-        contestsLeft.length === 0
-          ? undefined
-          : {
-              ...restProps,
-              election: {
-                ...election,
-                contests: contestsLeft,
-              },
-            },
+      leftoverContests: contests.slice(1),
     });
   }
 
   return {
     stylesComponent: BaseStyles,
     frameComponent: BallotPageFrame,
+    contestsForBallot: (props) => props.election.contests,
     contentComponent: BallotPageContent,
     isAllBubbleBallot: true,
   };

--- a/libs/hmpb/src/ballot_templates/mi_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/mi_ballot_template.tsx
@@ -995,25 +995,30 @@ async function CombinedBallotPrimaryContestColumns({
   };
 }
 
-async function BallotPageContent(
-  props: (BaseBallotProps & { dimensions: PixelDimensions }) | undefined,
-  scratchpad: RenderScratchpad
-): Promise<ContentComponentResult<BaseBallotProps>> {
-  if (!props) {
-    return ok({
-      currentPageElement: <BlankPageMessage />,
-      nextPageProps: undefined,
-    });
-  }
-
-  const { election, ballotStyleId, dimensions, ...restProps } = props;
+function contestsForBallot(props: BaseBallotProps): readonly ContestStruct[] {
+  const { election, ballotStyleId } = props;
   const ballotStyle = assertDefined(
     getBallotStyle({ election, ballotStyleId })
   );
-  const contests = getContests({ election, ballotStyle });
+  return getContests({ election, ballotStyle });
+}
+
+async function BallotPageContent(
+  props: BaseBallotProps & { dimensions: PixelDimensions },
+  contests: readonly ContestStruct[],
+  scratchpad: RenderScratchpad
+): Promise<ContentComponentResult> {
   if (contests.length === 0) {
-    throw new Error('No contests assigned to this precinct.');
+    return ok({
+      currentPageElement: <BlankPageMessage />,
+      leftoverContests: [],
+    });
   }
+
+  const { election, ballotStyleId, dimensions } = props;
+  const ballotStyle = assertDefined(
+    getBallotStyle({ election, ballotStyleId })
+  );
 
   const { leftoverContests, sectionsElement } = isCombinedBallotPrimary(
     election
@@ -1040,26 +1045,15 @@ async function BallotPageContent(
     });
   }
 
-  const nextPageProps =
-    leftoverContests.length > 0
-      ? {
-          ...restProps,
-          ballotStyleId,
-          election: {
-            ...election,
-            contests: leftoverContests,
-          },
-        }
-      : undefined;
-
   return ok({
     currentPageElement: sectionsElement,
-    nextPageProps,
+    leftoverContests,
   });
 }
 
 export const miBallotTemplate: BallotPageTemplate<BaseBallotProps> = {
   stylesComponent: BaseStyles,
   frameComponent: BallotPageFrame,
+  contestsForBallot,
   contentComponent: BallotPageContent,
 };

--- a/libs/hmpb/src/ballot_templates/ms_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/ms_ballot_template.tsx
@@ -508,27 +508,32 @@ function Contest({
   }
 }
 
+function contestsForBallot(props: BaseBallotProps): readonly ContestStruct[] {
+  const { election, ballotStyleId } = props;
+  const ballotStyle = assertDefined(
+    getBallotStyle({ election, ballotStyleId })
+  );
+  return getContests({ election, ballotStyle });
+}
+
 async function BallotPageContent(
-  props: (BaseBallotProps & { dimensions: PixelDimensions }) | undefined,
+  props: BaseBallotProps & { dimensions: PixelDimensions },
+  contests: readonly ContestStruct[],
   scratchpad: RenderScratchpad
-): Promise<ContentComponentResult<BaseBallotProps>> {
-  if (!props) {
+): Promise<ContentComponentResult> {
+  if (contests.length === 0) {
     return ok({
       currentPageElement: <BlankPageMessage />,
-      nextPageProps: undefined,
+      leftoverContests: [],
     });
   }
 
-  const { election, ballotStyleId, dimensions, ...restProps } = props;
+  const { election, ballotStyleId, dimensions } = props;
   const ballotStyle = assertDefined(
     getBallotStyle({ election, ballotStyleId })
   );
   // For now, just one section for candidate contests, one for ballot measures.
   // TODO support arbitrarily defined sections
-  const contests = getContests({ election, ballotStyle });
-  if (contests.length === 0) {
-    throw new Error('No contests assigned to this precinct.');
-  }
   const contestSections = iter(contests)
     .partition((contest) => contest.type === 'candidate')
     .filter((section) => section.length > 0);
@@ -617,11 +622,11 @@ async function BallotPageContent(
     );
   }
 
-  const contestsLeftToLayout = contestSections.flat();
+  const leftoverContests = contestSections.flat();
   if (heightUsed === 0) {
     return err({
       error: 'contestTooLong',
-      contest: contestsLeftToLayout[0],
+      contest: leftoverContests[0],
     });
   }
 
@@ -639,26 +644,15 @@ async function BallotPageContent(
     ) : (
       <BlankPageMessage />
     );
-  const nextPageProps =
-    contestsLeftToLayout.length > 0
-      ? {
-          ...restProps,
-          ballotStyleId,
-          election: {
-            ...election,
-            contests: contestsLeftToLayout,
-          },
-        }
-      : undefined;
-
   return ok({
     currentPageElement,
-    nextPageProps,
+    leftoverContests,
   });
 }
 
 export const msBallotTemplate: BallotPageTemplate<BaseBallotProps> = {
   stylesComponent: BaseStyles,
   frameComponent: BallotPageFrame,
+  contestsForBallot,
   contentComponent: BallotPageContent,
 };

--- a/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_ballot_template.tsx
@@ -891,27 +891,32 @@ async function splitLongBallotMeasureAcrossPages(
   });
 }
 
+function contestsForBallot(props: NhBallotProps): readonly ContestStruct[] {
+  const { election, ballotStyleId } = props;
+  const ballotStyle = assertDefined(
+    getBallotStyle({ election, ballotStyleId })
+  );
+  return getContests({ election, ballotStyle });
+}
+
 async function BallotPageContent(
-  props: (NhBallotProps & { dimensions: PixelDimensions }) | undefined,
+  props: NhBallotProps & { dimensions: PixelDimensions },
+  contests: readonly ContestStruct[],
   scratchpad: RenderScratchpad
-): Promise<ContentComponentResult<NhBallotProps>> {
-  if (!props) {
+): Promise<ContentComponentResult> {
+  if (contests.length === 0) {
     return ok({
       currentPageElement: <BlankPageMessage />,
-      nextPageProps: undefined,
+      leftoverContests: [],
     });
   }
 
-  const { compact, election, ballotStyleId, dimensions, ...restProps } = props;
+  const { compact, election, ballotStyleId, dimensions } = props;
   const ballotStyle = assertDefined(
     getBallotStyle({ election, ballotStyleId })
   );
   // For now, just one section for candidate contests, one for ballot measures.
   // TODO support arbitrarily defined sections
-  const contests = getContests({ election, ballotStyle });
-  if (contests.length === 0) {
-    throw new Error('No contests assigned to this precinct.');
-  }
   const contestSections = iter(contests)
     .partition((contest) => contest.type === 'candidate')
     .filter((section) => section.length > 0);
@@ -1067,22 +1072,9 @@ async function BallotPageContent(
     ) : (
       <BlankPageMessage />
     );
-  const nextPageProps =
-    contestsLeftToLayout.length > 0
-      ? {
-          ...restProps,
-          compact,
-          ballotStyleId,
-          election: {
-            ...election,
-            contests: contestsLeftToLayout,
-          },
-        }
-      : undefined;
-
   return ok({
     currentPageElement,
-    nextPageProps,
+    leftoverContests: contestsLeftToLayout,
   });
 }
 
@@ -1091,5 +1083,6 @@ export type NhBallotProps = BaseBallotProps & NhPrecinctSplitOptions;
 export const nhBallotTemplate: BallotPageTemplate<NhBallotProps> = {
   stylesComponent: BaseStyles,
   frameComponent: BallotPageFrame,
+  contestsForBallot,
   contentComponent: BallotPageContent,
 };

--- a/libs/hmpb/src/ballot_templates/nh_state_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_state_ballot_template.tsx
@@ -1,5 +1,5 @@
-import { ok, throwIllegalValue } from '@votingworks/basics';
-import React from 'react';
+import { assertDefined, throwIllegalValue } from '@votingworks/basics';
+import { Contest, getBallotStyle, getContests } from '@votingworks/types';
 import {
   BallotPageTemplate,
   ContentComponent,
@@ -7,7 +7,11 @@ import {
 } from '../render_ballot';
 import * as General from './nh_state_general_ballot_template';
 import * as Primary from './nh_state_primary_ballot_template';
-import { BaseStyles, NhStateBallotProps } from './nh_state_ballot_components';
+import {
+  BaseStyles,
+  isFederalOfficeContest,
+  NhStateBallotProps,
+} from './nh_state_ballot_components';
 
 const BallotPageFrame: FrameComponent<NhStateBallotProps> = (props) => {
   switch (props.election.type) {
@@ -21,21 +25,26 @@ const BallotPageFrame: FrameComponent<NhStateBallotProps> = (props) => {
   }
 };
 
-const BallotPageContent: ContentComponent<NhStateBallotProps> = async (
+function contestsForBallot(props: NhStateBallotProps): readonly Contest[] {
+  const { election, ballotStyleId } = props;
+  const ballotStyle = assertDefined(
+    getBallotStyle({ election, ballotStyleId })
+  );
+  return getContests({ election, ballotStyle }).filter((contest) =>
+    props.isFederalOfficeOnly ? isFederalOfficeContest(contest) : true
+  );
+}
+
+const BallotPageContent: ContentComponent<NhStateBallotProps> = (
   props,
+  contests,
   scratchpad
 ) => {
-  if (!props) {
-    return ok({
-      currentPageElement: <React.Fragment />,
-      nextPageProps: undefined,
-    });
-  }
   switch (props.election.type) {
     case 'general':
-      return General.BallotPageContent(props, scratchpad);
+      return General.BallotPageContent(props, contests, scratchpad);
     case 'primary':
-      return Primary.BallotPageContent(props, scratchpad);
+      return Primary.BallotPageContent(props, contests, scratchpad);
     default:
       /* istanbul ignore next */
       throwIllegalValue(props.election.type);
@@ -46,6 +55,7 @@ export type { NhStateBallotProps };
 
 export const nhStateBallotTemplate: BallotPageTemplate<NhStateBallotProps> = {
   frameComponent: BallotPageFrame,
+  contestsForBallot,
   contentComponent: BallotPageContent,
   stylesComponent: BaseStyles,
 };

--- a/libs/hmpb/src/ballot_templates/nh_state_general_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_state_general_ballot_template.tsx
@@ -14,13 +14,12 @@ import {
   BallotMode,
   ballotPaperDimensions,
   BallotType,
-  BaseBallotProps,
   Candidate,
   CandidateContest as CandidateContestStruct,
+  Contest as ContestStruct,
   ContestId,
   Election,
   getBallotStyle,
-  getContests,
   Party,
   straightPartyNotYetImplemented,
   YesNoContest,
@@ -52,7 +51,6 @@ import {
   allCaps,
   HandCountInsignia,
   Instructions,
-  isFederalOfficeContest,
   Footer,
   NhStateBallotProps,
   isDemocraticParty,
@@ -667,21 +665,22 @@ function BallotMeasureContest({
 
 export async function BallotPageContent(
   props: NhStateBallotProps & { dimensions: PixelDimensions },
+  contests: readonly ContestStruct[],
   scratchpad: RenderScratchpad
-): Promise<ContentComponentResult<BaseBallotProps>> {
-  const { election, ballotStyleId, dimensions, ...restProps } = props;
+): Promise<ContentComponentResult> {
+  if (contests.length === 0) {
+    return ok({
+      currentPageElement: <React.Fragment />,
+      leftoverContests: [],
+    });
+  }
+
+  const { election, ballotStyleId, dimensions } = props;
   const ballotStyle = assertDefined(
     getBallotStyle({ election, ballotStyleId })
   );
-  const contests = getContests({ election, ballotStyle });
-  if (contests.length === 0) {
-    throw new Error('No contests assigned to this precinct.');
-  }
   // One section for candidate contests, one for ballot measures.
   const contestSections = iter(contests)
-    .filter((contest) =>
-      restProps.isFederalOfficeOnly ? isFederalOfficeContest(contest) : true
-    )
     .partition((contest) => contest.type === 'candidate')
     .filter((section) => section.length > 0);
 
@@ -776,11 +775,11 @@ export async function BallotPageContent(
     );
   }
 
-  const contestsLeftToLayout = contestSections.flat();
+  const leftoverContests = contestSections.flat();
   if (heightUsed === 0) {
     return err({
       error: 'contestTooLong',
-      contest: contestsLeftToLayout[0],
+      contest: leftoverContests[0],
     });
   }
 
@@ -798,20 +797,9 @@ export async function BallotPageContent(
     ) : (
       <React.Fragment />
     );
-  const nextPageProps =
-    contestsLeftToLayout.length > 0
-      ? {
-          ...restProps,
-          ballotStyleId,
-          election: {
-            ...election,
-            contests: contestsLeftToLayout,
-          },
-        }
-      : undefined;
 
   return ok({
     currentPageElement,
-    nextPageProps,
+    leftoverContests,
   });
 }

--- a/libs/hmpb/src/ballot_templates/nh_state_primary_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/nh_state_primary_ballot_template.tsx
@@ -18,7 +18,6 @@ import {
   YesNoContest,
   ballotPaperDimensions,
   getBallotStyle,
-  getContests,
   getPartyForBallotStyle,
   straightPartyNotYetImplemented,
 } from '@votingworks/types';
@@ -53,7 +52,6 @@ import {
   allCaps,
   HandCountInsignia,
   Instructions,
-  isFederalOfficeContest,
   Footer,
   NhStateBallotProps,
   isDemocraticParty,
@@ -615,9 +613,17 @@ function Contest({
 
 export async function BallotPageContent(
   props: NhStateBallotProps & { dimensions: PixelDimensions },
+  contests: readonly ContestStruct[],
   scratchpad: RenderScratchpad
-): Promise<ContentComponentResult<NhStateBallotProps>> {
-  const { election, ballotStyleId, dimensions, ...restProps } = props;
+): Promise<ContentComponentResult> {
+  if (contests.length === 0) {
+    return ok({
+      currentPageElement: <React.Fragment />,
+      leftoverContests: [],
+    });
+  }
+
+  const { election, ballotStyleId, dimensions } = props;
   const ballotStyle = assertDefined(
     getBallotStyle({ election, ballotStyleId })
   );
@@ -625,15 +631,8 @@ export async function BallotPageContent(
     getPartyForBallotStyle({ election, ballotStyleId })
   );
   const colorTint = colorTintForParty(party);
-  const contests = getContests({ election, ballotStyle });
-  if (contests.length === 0) {
-    throw new Error('No contests assigned to this precinct.');
-  }
   // One section for candidate contests, one for ballot measures
   const contestSections = iter(contests)
-    .filter((contest) =>
-      restProps.isFederalOfficeOnly ? isFederalOfficeContest(contest) : true
-    )
     .partition((contest) => contest.type === 'candidate')
     .filter((section) => section.length > 0);
 
@@ -723,11 +722,11 @@ export async function BallotPageContent(
     );
   }
 
-  const contestsLeftToLayout = contestSections.flat();
+  const leftoverContests = contestSections.flat();
   if (heightUsed === 0) {
     return err({
       error: 'contestTooLong',
-      contest: contestsLeftToLayout[0],
+      contest: leftoverContests[0],
     });
   }
 
@@ -745,20 +744,8 @@ export async function BallotPageContent(
     ) : (
       <React.Fragment />
     );
-  const nextPageProps =
-    contestSections.length > 0
-      ? {
-          ...restProps,
-          ballotStyleId,
-          election: {
-            ...election,
-            contests: contestSections.flat(),
-          },
-        }
-      : undefined;
-
   return ok({
     currentPageElement,
-    nextPageProps,
+    leftoverContests,
   });
 }

--- a/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
+++ b/libs/hmpb/src/ballot_templates/vx_default_ballot_template.tsx
@@ -460,27 +460,32 @@ function Contest({
   }
 }
 
+function contestsForBallot(props: BaseBallotProps): readonly ContestStruct[] {
+  const { election, ballotStyleId } = props;
+  const ballotStyle = assertDefined(
+    getBallotStyle({ election, ballotStyleId })
+  );
+  return getContests({ election, ballotStyle });
+}
+
 async function BallotPageContent(
-  props: (BaseBallotProps & { dimensions: PixelDimensions }) | undefined,
+  props: BaseBallotProps & { dimensions: PixelDimensions },
+  contests: readonly ContestStruct[],
   scratchpad: RenderScratchpad
-): Promise<ContentComponentResult<BaseBallotProps>> {
-  if (!props) {
+): Promise<ContentComponentResult> {
+  if (contests.length === 0) {
     return ok({
       currentPageElement: <BlankPageMessage />,
-      nextPageProps: undefined,
+      leftoverContests: [],
     });
   }
 
-  const { election, ballotStyleId, dimensions, ...restProps } = props;
+  const { election, ballotStyleId, dimensions } = props;
   const ballotStyle = assertDefined(
     getBallotStyle({ election, ballotStyleId })
   );
   // For now, just one section for candidate contests, one for ballot measures.
   // TODO support arbitrarily defined sections
-  const contests = getContests({ election, ballotStyle });
-  if (contests.length === 0) {
-    throw new Error('No contests assigned to this precinct.');
-  }
   const contestSections = iter(contests)
     .partition((contest) => contest.type === 'candidate')
     .filter((section) => section.length > 0);
@@ -569,11 +574,11 @@ async function BallotPageContent(
     );
   }
 
-  const contestsLeftToLayout = contestSections.flat();
+  const leftoverContests = contestSections.flat();
   if (heightUsed === 0) {
     return err({
       error: 'contestTooLong',
-      contest: contestsLeftToLayout[0],
+      contest: leftoverContests[0],
     });
   }
 
@@ -591,26 +596,15 @@ async function BallotPageContent(
     ) : (
       <BlankPageMessage />
     );
-  const nextPageProps =
-    contestsLeftToLayout.length > 0
-      ? {
-          ...restProps,
-          ballotStyleId,
-          election: {
-            ...election,
-            contests: contestsLeftToLayout,
-          },
-        }
-      : undefined;
-
   return ok({
     currentPageElement,
-    nextPageProps,
+    leftoverContests,
   });
 }
 
 export const vxDefaultBallotTemplate: BallotPageTemplate<BaseBallotProps> = {
   stylesComponent: BaseStyles,
   frameComponent: BallotPageFrame,
+  contestsForBallot,
   contentComponent: BallotPageContent,
 };

--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -67,9 +67,9 @@ export type FrameComponent<P> = (
   props: P & { children: JSX.Element; pageNumber: number; totalPages?: number }
 ) => Result<JSX.Element, BallotLayoutError>;
 
-export interface PaginatedContent<P> {
+export interface PaginatedContent {
   currentPageElement: JSX.Element;
-  nextPageProps?: P;
+  leftoverContests: readonly Contest[];
 }
 
 interface ContestTooLongError {
@@ -83,30 +83,34 @@ interface MissingSignatureError {
 
 export type BallotLayoutError = ContestTooLongError | MissingSignatureError;
 
-export type ContentComponentResult<P> = Result<
-  PaginatedContent<P>,
+export type ContentComponentResult = Result<
+  PaginatedContent,
   BallotLayoutError
 >;
 
 export type ContentComponent<P> = (
-  props: (P & { dimensions: PixelDimensions }) | undefined,
+  props: P & { dimensions: PixelDimensions },
+  contests: readonly Contest[],
   // The content component is passed the scratchpad so that it can measure
   // elements in order to determine how much content fits on each page.
   scratchpad: RenderScratchpad
-) => Promise<ContentComponentResult<P>>;
+) => Promise<ContentComponentResult>;
 
 /**
- * A page template consists of two interlocking pieces:
+ * A page template consists of interlocking pieces:
  * - A styles component that defines the root styles to add to the page's head (e.g. fonts, sizes)
  * - A frame component (imagine it like a picture frame) that is rendered on each page
- * - A content component that knows how to render a page at a time of content
- * within the frame. Given a set of props (e.g. list of contests) the content component returns two items:
+ * - A function that determines which contests should be laid out for a given
+ * ballot (e.g. filtering by ballot style)
+ * - A content component that knows how to render a page of contests within the frame.
+ * Given the ballot props and the contests left to lay out, it returns two items:
  *     - The content element for the current page (e.g. the contest boxes for this page)
- *     - The props for the next page (e.g. the contests that didn't fit on this page)
+ *     - The contests that didn't fit on this page
  */
 export interface BallotPageTemplate<P extends object> {
   stylesComponent: StylesComponent<P>;
   frameComponent: FrameComponent<P>;
+  contestsForBallot: (props: P) => readonly Contest[];
   contentComponent: ContentComponent<P>;
   isAllBubbleBallot?: boolean;
 }
@@ -128,15 +132,13 @@ async function paginateBallotContent<P extends object>(
   props: P,
   scratchpad: RenderScratchpad
 ): Promise<Result<JSX.Element[], BallotLayoutError>> {
-  const pages: Array<PaginatedContent<P>> = [];
-
   const { frameComponent, contentComponent } = pageTemplate;
-  do {
+  async function layOutPage(
+    pageProps: P & { pageNumber: number; totalPages?: number },
+    contests: readonly Contest[]
+  ) {
     const pageFrameResult = frameComponent({
-      // eslint-disable-next-line vx/gts-spread-like-types
-      ...props,
-      pageNumber: pages.length + 1,
-      totalPages: 0,
+      ...pageProps,
       children: <ContentSlot />,
     });
     if (pageFrameResult.isErr()) {
@@ -148,34 +150,44 @@ async function paginateBallotContent<P extends object>(
       pageFrame,
       `.${CONTENT_SLOT_CLASS}`
     );
-    const currentPageProps: P = pages.at(-1)?.nextPageProps ?? props;
+    const dimensions: PixelDimensions = {
+      width: contentSlotMeasurements.width,
+      height: contentSlotMeasurements.height,
+    };
 
-    // If the props are the same as the last page, we're in an infinite loop.
-    // This can happen if the content is too tall to fit on a page. We expect
-    // the contentComponent to handle this case and throw a meaningful error
-    // that points out which contest is too tall, so this is just a backup
-    // safeguard.
-    assert(
-      !deepEqual(currentPageProps, pages[pages.length - 2]?.nextPageProps),
-      'Contest is too tall to fit on page'
-    );
+    return contentComponent({ ...pageProps, dimensions }, contests, scratchpad);
+  }
 
-    const pageResult = await contentComponent(
+  const pages: PaginatedContent[] = [];
+  let contestsToPaginate = pageTemplate.contestsForBallot(props);
+  assert(contestsToPaginate.length > 0, 'No contests assigned to this ballot');
+
+  do {
+    const pageResult = await layOutPage(
       {
         // eslint-disable-next-line vx/gts-spread-like-types
-        ...currentPageProps,
-        dimensions: {
-          width: contentSlotMeasurements.width,
-          height: contentSlotMeasurements.height,
-        },
+        ...props,
+        pageNumber: pages.length + 1,
+        totalPages: 0,
       },
-      scratchpad
+      contestsToPaginate
     );
     if (pageResult.isErr()) {
       return pageResult;
     }
-    pages.push(pageResult.ok());
-  } while (pages.at(-1)?.nextPageProps);
+    const page = pageResult.ok();
+    // If the leftover contests are the same as the given contests, we're in an
+    // infinite loop.  This can happen if the content is too tall to fit on a
+    // page. We expect the contentComponent to handle this case and throw a
+    // meaningful error that points out which contest is too tall, so this is
+    // just a backup safeguard.
+    assert(
+      !deepEqual(page.leftoverContests, contestsToPaginate),
+      'Contest is too tall to fit on page'
+    );
+    pages.push(page);
+    contestsToPaginate = page.leftoverContests;
+  } while (contestsToPaginate.length > 0);
 
   // Frame pages first so the page numbering and footer voting progress
   // instructions reflect only pages with content.
@@ -194,17 +206,22 @@ async function paginateBallotContent<P extends object>(
     framedPages.push(frameResult.ok());
   }
 
+  // Then add a blank page if the number of pages is odd.
   if (pages.length % 2 === 1) {
-    const lastPageResult = await contentComponent(undefined, scratchpad);
-    if (lastPageResult.isErr()) {
-      return lastPageResult;
+    const blankPageResult = await layOutPage(
+      // eslint-disable-next-line vx/gts-spread-like-types
+      { ...props, pageNumber: pages.length + 1 },
+      []
+    );
+    if (blankPageResult.isErr()) {
+      return blankPageResult;
     }
-    const page = lastPageResult.ok();
+    const blankPage = blankPageResult.ok();
     const lastFrameResult = frameComponent({
       // eslint-disable-next-line vx/gts-spread-like-types
       ...props,
       pageNumber: pages.length + 1,
-      children: page.currentPageElement,
+      children: blankPage.currentPageElement,
     });
     if (lastFrameResult.isErr()) {
       return lastFrameResult;


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Refactors ballot template pagination so contests flow explicitly through the renderer instead of being passed through `nextPageProps` via a cloned election object. Templates declare `contestsForBallot(props)` (ballot-style filtering plus template-specific filtering, e.g. NH state's federal-office-only), and the renderer passes each page's remaining contests to the content component, which returns the leftovers.

This will open the door for single-sided ballot documents (e.g. NH's federal-office-only and UOCAVA variants) in an upcoming PR.

## Demo Video or Screenshot

N/A

## Testing Plan

Existing automated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
