### PR TITLE
fix: convert grayscale images to RGBA before canvas encoding

### DIFF
--- a/apps/scan/backend/src/scanner_diagnostic.test.ts
+++ b/apps/scan/backend/src/scanner_diagnostic.test.ts
@@ -97,6 +97,41 @@ test('scanner diagnostic, unconfigured - pass', async () => {
   });
 });
 
+test('scanner diagnostic, grayscale scan images - pass', async () => {
+  // The scanner client emits grayscale image data, but every other test here
+  // feeds the RGBA image data that the fixtures produce. The diagnostic is the
+  // only path that routes scan images through node-canvas rather than the Rust
+  // interpreter, so it is the only one where that difference matters. The
+  // deterministic regression test for the grayscale encoding itself lives in
+  // libs/image-utils.
+  await withApp(async ({ apiClient, mockScanner, mockAuth }) => {
+    vi.mocked(mockAuth.getAuthStatus).mockResolvedValue({
+      status: 'logged_in',
+      user: mockSystemAdministratorUser(),
+      sessionExpiresAt: mockSessionExpiresAt(),
+    });
+    await expectStatus(apiClient, { state: 'paused' });
+
+    await apiClient.beginScannerDiagnostic();
+    await waitForStatus(apiClient, { state: 'scanner_diagnostic.running' });
+
+    mockScanner.emitEvent({ event: 'scanStart' });
+    mockScanner.emitEvent({
+      event: 'scanComplete',
+      images: await ballotImages.blankSheetGrayscale(),
+    });
+    await waitForStatus(apiClient, { state: 'scanner_diagnostic.done' });
+
+    await apiClient.endScannerDiagnostic();
+    await waitForStatus(apiClient, { state: 'paused' });
+    expect(await apiClient.getMostRecentScannerDiagnostic()).toEqual({
+      type: 'blank-sheet-scan',
+      outcome: 'pass',
+      timestamp: expect.any(Number),
+    });
+  });
+});
+
 test('scanner diagnostic, configured - fail', async () => {
   const electionPackage =
     electionFamousNames2021Fixtures.electionJson.toElectionPackage();

--- a/apps/scan/backend/test/helpers/scanner_helpers.ts
+++ b/apps/scan/backend/test/helpers/scanner_helpers.ts
@@ -21,7 +21,7 @@ import {
 } from '@votingworks/fujitsu-thermal-printer';
 import * as grout from '@votingworks/grout';
 import { vxFamousNamesFixtures } from '@votingworks/hmpb';
-import { ImageData } from '@votingworks/image-utils';
+import { ImageData, RGBA_CHANNEL_COUNT } from '@votingworks/image-utils';
 import { Logger, mockBaseLogger } from '@votingworks/logging';
 import {
   Listener,
@@ -43,7 +43,10 @@ import { SimulatedClock } from 'xstate/lib/SimulatedClock.js';
 import { createCanvas } from 'canvas';
 import { Api, buildApp } from '../../src/app.js';
 import { Player as AudioPlayer } from '../../src/audio/player.js';
-import { createPrecinctScannerStateMachine, delays } from '../../src/scanner.js';
+import {
+  createPrecinctScannerStateMachine,
+  delays,
+} from '../../src/scanner.js';
 import { Store } from '../../src/store.js';
 import { Workspace, createWorkspace } from '../../src/util/workspace.js';
 import {
@@ -220,6 +223,18 @@ export const POLLING_PLACE_ID_OVERVOTE_HMPB = POLLING_PLACE_ID_COMPLETE_HMPB;
 export const POLLING_PLACE_ID_COMPETE_BMD =
   DEFAULT_FAMOUS_NAMES_POLLING_PLACE_ID;
 
+/**
+ * Reshapes RGBA image data into the grayscale (one byte per pixel) image data
+ * the real PDI scanner client emits. See `libs/pdi-scanner/src/ts/scanner_client.ts`.
+ */
+function toGrayscaleImageData({ width, height, data }: ImageData): ImageData {
+  const pixels = new Uint8ClampedArray(width * height);
+  for (let i = 0; i < pixels.length; i += 1) {
+    pixels[i] = data[i * RGBA_CHANNEL_COUNT];
+  }
+  return { width, height, data: pixels };
+}
+
 export const ballotImages = {
   completeHmpb: async () =>
     pdfToImageSheet(
@@ -272,6 +287,10 @@ export const ballotImages = {
   blankSheet: async () => [
     await sampleBallotImages.blankPage.asImageData(),
     await sampleBallotImages.blankPage.asImageData(),
+  ],
+  blankSheetGrayscale: async () => [
+    toGrayscaleImageData(await sampleBallotImages.blankPage.asImageData()),
+    toGrayscaleImageData(await sampleBallotImages.blankPage.asImageData()),
   ],
 } satisfies Record<string, () => Promise<SheetOf<ImageData>>>;
 

--- a/libs/image-utils/src/image_data.test.ts
+++ b/libs/image-utils/src/image_data.test.ts
@@ -2,10 +2,10 @@ import { expect, test } from 'vitest';
 import { Buffer } from 'node:buffer';
 import { ImageData, createImageData } from 'canvas';
 import fc from 'fast-check';
-import { writeFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import { makeTemporaryFile } from '@votingworks/fixtures';
 import { randomFillSync } from 'node:crypto';
-import { err, ok, MaybePromise } from '@votingworks/basics';
+import { err, ok, iter, MaybePromise, range } from '@votingworks/basics';
 import { arbitraryImageData } from '../test/arbitraries';
 import {
   RGBA_CHANNEL_COUNT,
@@ -188,6 +188,63 @@ test('toDataUrl image/jpeg', async () => {
       }
     )
   );
+});
+
+test('canvas encoders accept grayscale image data', async () => {
+  // Scanner clients emit grayscale image data (one byte per pixel), but
+  // `putImageData` reads four bytes per pixel regardless of the buffer length.
+  // Encoding grayscale without converting it first reads past the end of the
+  // allocation, which yields garbage pixels or crashes the process, so assert
+  // that the pixels survive the round trip rather than expecting a throw.
+  const width = 64;
+  const height = 64;
+  const grayscaleImageData: ImageData = {
+    width,
+    height,
+    data: Uint8ClampedArray.from(range(0, width * height), (i) => i % 0x100),
+  };
+
+  const encoders: Array<[string, () => MaybePromise<Buffer>]> = [
+    [
+      'writeImageData',
+      async () => {
+        const filePath = makeTemporaryFile({ postfix: '.png' });
+        await writeImageData(filePath, grayscaleImageData);
+        return await readFile(filePath);
+      },
+    ],
+    ['encodeImageData', () => encodeImageData(grayscaleImageData, 'image/png')],
+    ['toImageBuffer', () => toImageBuffer(grayscaleImageData, 'image/png')],
+    [
+      'toDataUrl',
+      () =>
+        Buffer.from(
+          toDataUrl(grayscaleImageData, 'image/png').replace(
+            /^data:image\/png;base64,/,
+            ''
+          ),
+          'base64'
+        ),
+    ],
+  ];
+
+  for (const [name, encode] of encoders) {
+    const decoded = (await loadImageData(await encode())).unsafeUnwrap();
+    expect({ name, width: decoded.width, height: decoded.height }).toEqual({
+      name,
+      width,
+      height,
+    });
+
+    const decodedGray = iter(decoded.data)
+      .chunks(RGBA_CHANNEL_COUNT)
+      .map(([red]) => red)
+      .toArray();
+    expect({ name, pixels: decodedGray }).toEqual({
+      name,
+      pixels: [...grayscaleImageData.data],
+    });
+  }
 });
 
 test('ensureImageData', () => {
@@ -381,7 +438,9 @@ test('loadImageMetadata on JPEG truncated before segment length', async () => {
 test('loadImageMetadata on JPEG with invalid segment length', async () => {
   // SOI + APP0 marker (FF E0) + 2-byte length field of 1, which is less than
   // the minimum valid value of 2 (the length field includes itself)
-  const result = await loadImageMetadata(Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x01]));
+  const result = await loadImageMetadata(
+    Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x01])
+  );
   expect(result).toEqual(
     err({ type: 'invalid-image-file', message: expect.any(String) })
   );

--- a/libs/image-utils/src/image_data.ts
+++ b/libs/image-utils/src/image_data.ts
@@ -266,9 +266,15 @@ export function fromGrayScale(
 }
 
 function createCanvasWithImageData(imageData: ImageData) {
+  // `putImageData` reads `width * height * RGBA_CHANNEL_COUNT` bytes from the
+  // buffer without checking its length, so passing a grayscale image reads past
+  // the end of the allocation, producing garbage pixels or segfaulting.
+  const rgbaImageData = isRgba(imageData)
+    ? ensureImageData(imageData)
+    : fromGrayScale(imageData.data, imageData.width, imageData.height);
   const canvas = createCanvas(imageData.width, imageData.height);
   const context = canvas.getContext('2d');
-  context.putImageData(ensureImageData(imageData), 0, 0);
+  context.putImageData(rgbaImageData, 0, 0);
   return canvas;
 }
 
@@ -369,9 +375,7 @@ export function toImageBuffer(
   imageData: ImageData,
   mimeType: 'image/png' | 'image/jpeg' = 'image/png'
 ): Buffer {
-  const canvas = createCanvas(imageData.width, imageData.height);
-  const context = canvas.getContext('2d');
-  context.putImageData(ensureImageData(imageData), 0, 0);
+  const canvas = createCanvasWithImageData(imageData);
   // Help TS match the union type branches to overloaded function signatures
   return mimeType === 'image/png'
     ? canvas.toBuffer(mimeType)


### PR DESCRIPTION
## Overview

Fixes #9084 — VxScan's diagnostics-menu scan either wrongly reports a blank sheet as not blank, or crashes.

Both symptoms are one bug. `putImageData` reads `width * height * 4` bytes from the buffer without checking its length, so passing a grayscale image (1 byte per pixel) reads 4x past the end of the allocation. Whatever happens to sit past the buffer becomes the image: usually garbage pixels (→ "not blank"), sometimes an unmapped page (→ segfault, surfacing as "something went wrong").

#8277 changed the PDI scanner client to emit zero-copy grayscale images instead of converting to RGBA up front. That PR added `ensureRgba` to the interpreter but missed `runScannerDiagnostic`, which is the only VxScan path that routes scanner images through node-canvas (via `writeImageData`). Normal scanning goes to the Rust addon, which handles grayscale natively — so only the diagnostic broke.

**VxCentralScan is not affected.** Its Fujitsu scanner writes image files to disk directly, so `performScanDiagnostic` hands `runBlankPaperDiagnostic` a path and never touches node-canvas.

The fix converts grayscale to RGBA in `createCanvasWithImageData`, the chokepoint for the canvas encoders, so any grayscale producer is safe rather than just the one that surfaced here. `toImageBuffer` had its own copy of the unguarded `putImageData` call and now routes through the same helper. RGBA input is unchanged.

Reproduction of the underlying read, before the fix:

```
$ node -e '... createImageData(new Uint8ClampedArray(1728*2200), 1728, 2200) → putImageData ...'
Segmentation fault
```

and at smaller sizes, on an all-white grayscale source: `nonWhite pixels: 5992 of 8000`.

## Testing Plan

- New `libs/image-utils` test round-trips grayscale image data through all four canvas encoders (`writeImageData`, `encodeImageData`, `toImageBuffer`, `toDataUrl`) and asserts the pixels come back intact. Verified it fails on `main` and passes with the fix. It asserts a successful round trip rather than expecting a throw, because the unfixed code takes down the worker process rather than raising. It deliberately uses a non-uniform image: a uniform one round-trips close enough under the bug to still pass.
- New VxScan test drives the diagnostic state machine with the grayscale image data the real scanner emits — previously every scan-backend test fed RGBA, which is why CI never saw this. It's coverage for the path, not a regression test for the bug: the blank-page fixture is uniform, so it passes with and without the fix.
- `libs/image-utils` at 100% statement/branch/function/line coverage.
- `apps/scan/backend` `scanner_diagnostic` and `app_diagnostics` suites pass.
- `libs/ballot-interpreter`: one pre-existing image-snapshot failure (`crops black headers and footers`, 41 differing pixels) reproduces on unmodified `main` — unrelated to this change.

Not verified on hardware; worth confirming on a real VxScan before closing the issue.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)