### PR TITLE
fix(scan): run the scanner diagnostic on grayscale images in Rust, bypassing node-canvas

### DIFF
--- a/apps/scan/backend/src/scanner.ts
+++ b/apps/scan/backend/src/scanner.ts
@@ -47,9 +47,7 @@ import {
   spawn,
 } from 'xstate';
 import type { Clock } from 'xstate/lib/interpreter.js';
-import { runBlankPaperDiagnostic } from '@votingworks/ballot-interpreter';
-import { writeImageData } from '@votingworks/image-utils';
-import { join } from 'node:path';
+import { runBlankPaperDiagnosticFromImage } from '@votingworks/ballot-interpreter';
 import { isReadyToScan } from './app_flow.js';
 import { interpret } from './interpret.js';
 import { InterpretationResult, PrecinctScannerStateMachine } from './types.js';
@@ -269,26 +267,10 @@ function anyFrontSensorCovered(status: ScannerStatus): boolean {
   );
 }
 
-async function runScannerDiagnostic(
-  workspace: Workspace,
-  scanImages: SheetOf<ImageData>
-) {
-  const sheetId = uuid();
-  const [frontPath, backPath] = await mapSheet(
-    scanImages,
-    async (image, side) => {
-      const path = join(
-        workspace.scannedImagesPath,
-        `diagnostic-${sheetId}-${side}.png`
-      );
-      await writeImageData(path, image);
-      return path;
-    }
+async function runScannerDiagnostic(scanImages: SheetOf<ImageData>) {
+  const [frontPassed, backPassed] = await mapSheet(scanImages, (image) =>
+    runBlankPaperDiagnosticFromImage(image)
   );
-  const [frontPassed, backPassed] = await Promise.all([
-    runBlankPaperDiagnostic(frontPath),
-    runBlankPaperDiagnostic(backPath),
-  ]);
   return frontPassed && backPassed;
 }
 
@@ -1372,7 +1354,7 @@ function buildMachine({
             runningDiagnostic: {
               invoke: {
                 src: ({ scanImages }) =>
-                  runScannerDiagnostic(workspace, assertDefined(scanImages)),
+                  runScannerDiagnostic(assertDefined(scanImages)),
                 onDone: {
                   actions: assign({
                     error: (_, { data }) =>

--- a/apps/scan/backend/src/scanner.ts
+++ b/apps/scan/backend/src/scanner.ts
@@ -174,6 +174,12 @@ export function cleanLogData(key: string, value: unknown): unknown {
       data: value.data.length,
     };
   }
+  // Grayscale scan images from the scanner client are plain objects, not
+  // `ImageData` instances, so catch their pixel buffers directly rather than
+  // serializing millions of bytes as JSON numbers.
+  if (value instanceof Uint8ClampedArray) {
+    return `[${value.length} bytes]`;
+  }
   if (value instanceof Error) {
     return { ...value, message: value.message, stack: value.stack };
   }

--- a/apps/scan/backend/src/scanner_diagnostic.test.ts
+++ b/apps/scan/backend/src/scanner_diagnostic.test.ts
@@ -97,35 +97,6 @@ test('scanner diagnostic, unconfigured - pass', async () => {
   });
 });
 
-test('scanner diagnostic, grayscale scan images - pass', async () => {
-  await withApp(async ({ apiClient, mockScanner, mockAuth }) => {
-    vi.mocked(mockAuth.getAuthStatus).mockResolvedValue({
-      status: 'logged_in',
-      user: mockSystemAdministratorUser(),
-      sessionExpiresAt: mockSessionExpiresAt(),
-    });
-    await expectStatus(apiClient, { state: 'paused' });
-
-    await apiClient.beginScannerDiagnostic();
-    await waitForStatus(apiClient, { state: 'scanner_diagnostic.running' });
-
-    mockScanner.emitEvent({ event: 'scanStart' });
-    mockScanner.emitEvent({
-      event: 'scanComplete',
-      images: await ballotImages.blankSheetGrayscale(),
-    });
-    await waitForStatus(apiClient, { state: 'scanner_diagnostic.done' });
-
-    await apiClient.endScannerDiagnostic();
-    await waitForStatus(apiClient, { state: 'paused' });
-    expect(await apiClient.getMostRecentScannerDiagnostic()).toEqual({
-      type: 'blank-sheet-scan',
-      outcome: 'pass',
-      timestamp: expect.any(Number),
-    });
-  });
-});
-
 test('scanner diagnostic, configured - fail', async () => {
   const electionPackage =
     electionFamousNames2021Fixtures.electionJson.toElectionPackage();

--- a/apps/scan/backend/src/scanner_diagnostic.test.ts
+++ b/apps/scan/backend/src/scanner_diagnostic.test.ts
@@ -97,6 +97,35 @@ test('scanner diagnostic, unconfigured - pass', async () => {
   });
 });
 
+test('scanner diagnostic, grayscale scan images - pass', async () => {
+  await withApp(async ({ apiClient, mockScanner, mockAuth }) => {
+    vi.mocked(mockAuth.getAuthStatus).mockResolvedValue({
+      status: 'logged_in',
+      user: mockSystemAdministratorUser(),
+      sessionExpiresAt: mockSessionExpiresAt(),
+    });
+    await expectStatus(apiClient, { state: 'paused' });
+
+    await apiClient.beginScannerDiagnostic();
+    await waitForStatus(apiClient, { state: 'scanner_diagnostic.running' });
+
+    mockScanner.emitEvent({ event: 'scanStart' });
+    mockScanner.emitEvent({
+      event: 'scanComplete',
+      images: await ballotImages.blankSheetGrayscale(),
+    });
+    await waitForStatus(apiClient, { state: 'scanner_diagnostic.done' });
+
+    await apiClient.endScannerDiagnostic();
+    await waitForStatus(apiClient, { state: 'paused' });
+    expect(await apiClient.getMostRecentScannerDiagnostic()).toEqual({
+      type: 'blank-sheet-scan',
+      outcome: 'pass',
+      timestamp: expect.any(Number),
+    });
+  });
+});
+
 test('scanner diagnostic, configured - fail', async () => {
   const electionPackage =
     electionFamousNames2021Fixtures.electionJson.toElectionPackage();

--- a/apps/scan/backend/test/helpers/scanner_helpers.ts
+++ b/apps/scan/backend/test/helpers/scanner_helpers.ts
@@ -236,10 +236,21 @@ function toGrayscaleImageData({ width, height, data }: ImageData): ImageData {
   return { width, height, data: pixels };
 }
 
+function toGrayscaleSheet(sheet: SheetOf<ImageData>): SheetOf<ImageData> {
+  return mapSheet(sheet, toGrayscaleImageData);
+}
+
+/**
+ * Scan images as the scanner client emits them: grayscale, one byte per
+ * pixel. The fixtures render as RGBA, so each sheet is reshaped to match real
+ * hardware.
+ */
 export const ballotImages = {
   completeHmpb: async () =>
-    pdfToImageSheet(
-      Uint8Array.from(await readFile(vxFamousNamesFixtures.blankBallotPath))
+    toGrayscaleSheet(
+      await pdfToImageSheet(
+        Uint8Array.from(await readFile(vxFamousNamesFixtures.blankBallotPath))
+      )
     ),
   completeHmpbInvalidScale: async () => {
     const scale = 0.95;
@@ -253,46 +264,51 @@ export const ballotImages = {
       sheet[0].width / scale,
       sheet[0].height / scale
     );
-    return mapSheet(sheet, (page) => {
-      const ctx = canvas.getContext('2d');
-      ctx.fillStyle = 'white';
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
-      ctx.putImageData(
-        page,
-        Math.round((canvas.width - page.width) / 2),
-        Math.round((canvas.height - page.height) / 2)
-      );
-      return ctx.getImageData(0, 0, canvas.width, canvas.height);
-    });
+    return toGrayscaleSheet(
+      mapSheet(sheet, (page) => {
+        const ctx = canvas.getContext('2d');
+        ctx.fillStyle = 'white';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.putImageData(
+          page,
+          Math.round((canvas.width - page.width) / 2),
+          Math.round((canvas.height - page.height) / 2)
+        );
+        return ctx.getImageData(0, 0, canvas.width, canvas.height);
+      })
+    );
   },
   completeBmd: async () =>
-    pdfToImageSheet(
-      await renderBmdBallotFixture({
-        electionDefinition:
-          electionFamousNames2021Fixtures.readElectionDefinition(),
-        ballotStyleId: DEFAULT_FAMOUS_NAMES_BALLOT_STYLE_ID,
-        precinctId: DEFAULT_FAMOUS_NAMES_PRECINCT_ID,
-        votes: DEFAULT_FAMOUS_NAMES_VOTES,
-      })
+    toGrayscaleSheet(
+      await pdfToImageSheet(
+        await renderBmdBallotFixture({
+          electionDefinition:
+            electionFamousNames2021Fixtures.readElectionDefinition(),
+          ballotStyleId: DEFAULT_FAMOUS_NAMES_BALLOT_STYLE_ID,
+          precinctId: DEFAULT_FAMOUS_NAMES_PRECINCT_ID,
+          votes: DEFAULT_FAMOUS_NAMES_VOTES,
+        })
+      )
     ),
   overvoteHmpb: async () =>
-    pdfToImageSheet(
-      Uint8Array.from(await readFile(vxFamousNamesFixtures.markedBallotPath))
+    toGrayscaleSheet(
+      await pdfToImageSheet(
+        Uint8Array.from(await readFile(vxFamousNamesFixtures.markedBallotPath))
+      )
     ),
   wrongElectionBmd: async () =>
-    pdfToImageSheet(
-      await renderBmdBallotFixture({
-        electionDefinition: readElectionGeneralDefinition(),
-      })
+    toGrayscaleSheet(
+      await pdfToImageSheet(
+        await renderBmdBallotFixture({
+          electionDefinition: readElectionGeneralDefinition(),
+        })
+      )
     ),
-  blankSheet: async () => [
-    await sampleBallotImages.blankPage.asImageData(),
-    await sampleBallotImages.blankPage.asImageData(),
-  ],
-  blankSheetGrayscale: async () => [
-    toGrayscaleImageData(await sampleBallotImages.blankPage.asImageData()),
-    toGrayscaleImageData(await sampleBallotImages.blankPage.asImageData()),
-  ],
+  blankSheet: async () =>
+    toGrayscaleSheet([
+      await sampleBallotImages.blankPage.asImageData(),
+      await sampleBallotImages.blankPage.asImageData(),
+    ]),
 } satisfies Record<string, () => Promise<SheetOf<ImageData>>>;
 
 export async function scanBallot(

--- a/apps/scan/backend/test/helpers/scanner_helpers.ts
+++ b/apps/scan/backend/test/helpers/scanner_helpers.ts
@@ -21,7 +21,7 @@ import {
 } from '@votingworks/fujitsu-thermal-printer';
 import * as grout from '@votingworks/grout';
 import { vxFamousNamesFixtures } from '@votingworks/hmpb';
-import { ImageData } from '@votingworks/image-utils';
+import { ImageData, RGBA_CHANNEL_COUNT } from '@votingworks/image-utils';
 import { Logger, mockBaseLogger } from '@votingworks/logging';
 import {
   Listener,
@@ -43,7 +43,10 @@ import { SimulatedClock } from 'xstate/lib/SimulatedClock.js';
 import { createCanvas } from 'canvas';
 import { Api, buildApp } from '../../src/app.js';
 import { Player as AudioPlayer } from '../../src/audio/player.js';
-import { createPrecinctScannerStateMachine, delays } from '../../src/scanner.js';
+import {
+  createPrecinctScannerStateMachine,
+  delays,
+} from '../../src/scanner.js';
 import { Store } from '../../src/store.js';
 import { Workspace, createWorkspace } from '../../src/util/workspace.js';
 import {
@@ -220,6 +223,19 @@ export const POLLING_PLACE_ID_OVERVOTE_HMPB = POLLING_PLACE_ID_COMPLETE_HMPB;
 export const POLLING_PLACE_ID_COMPETE_BMD =
   DEFAULT_FAMOUS_NAMES_POLLING_PLACE_ID;
 
+/**
+ * Reshapes RGBA image data into the grayscale (one byte per pixel) image data
+ * the real PDI scanner client emits. See `libs/pdi-scanner/src/ts/scanner_client.ts`.
+ * Assumes the RGBA image was actually expanded from a grayscale image originally.
+ */
+function toGrayscaleImageData({ width, height, data }: ImageData): ImageData {
+  const pixels = new Uint8ClampedArray(width * height);
+  for (let i = 0; i < pixels.length; i += 1) {
+    pixels[i] = data[i * RGBA_CHANNEL_COUNT];
+  }
+  return { width, height, data: pixels };
+}
+
 export const ballotImages = {
   completeHmpb: async () =>
     pdfToImageSheet(
@@ -272,6 +288,10 @@ export const ballotImages = {
   blankSheet: async () => [
     await sampleBallotImages.blankPage.asImageData(),
     await sampleBallotImages.blankPage.asImageData(),
+  ],
+  blankSheetGrayscale: async () => [
+    toGrayscaleImageData(await sampleBallotImages.blankPage.asImageData()),
+    toGrayscaleImageData(await sampleBallotImages.blankPage.asImageData()),
   ],
 } satisfies Record<string, () => Promise<SheetOf<ImageData>>>;
 

--- a/apps/scan/integration-testing/e2e/scanner_diagnostic.spec.ts
+++ b/apps/scan/integration-testing/e2e/scanner_diagnostic.spec.ts
@@ -1,0 +1,62 @@
+import { test } from '@playwright/test';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  forceLogOutAndResetElectionDefinition,
+  logInAsSystemAdministrator,
+} from './support/auth.js';
+import { mockPdiScannerHandler } from './support/scanner.js';
+import {
+  makeBlankSheetPdf,
+  makeStreakedSheetPdf,
+} from './support/synthesized_pdfs.js';
+
+// Regression test for the v4.1.0 diagnostics-menu scan bug: the PDI scanner
+// client emits grayscale images, and the diagnostic previously routed them
+// through node-canvas, which reads four bytes per pixel unconditionally —
+// yielding garbage pixels ("Test Scan Failed" on a blank sheet) or a backend
+// crash. The mock scanner now emits grayscale like the real client, so this
+// exercises the fixed path end to end.
+test('scanner diagnostic passes on a blank sheet and fails on a streaked sheet', async ({
+  page,
+}) => {
+  const pdfDir = mkdtempSync(join(tmpdir(), 'scan-diagnostic-'));
+  const blankSheetPdfPath = join(pdfDir, 'blank-sheet.pdf');
+  writeFileSync(blankSheetPdfPath, makeBlankSheetPdf());
+  const streakedSheetPdfPath = join(pdfDir, 'streaked-sheet.pdf');
+  writeFileSync(streakedSheetPdfPath, makeStreakedSheetPdf());
+
+  mockPdiScannerHandler.cleanup();
+  await forceLogOutAndResetElectionDefinition(page);
+  await page
+    .getByText('Insert an election manager card to configure VxScan')
+    .waitFor();
+
+  await logInAsSystemAdministrator(page);
+  await page.getByRole('button', { name: 'Diagnostics' }).click();
+
+  // A blank sheet scans as blank: the diagnostic passes.
+  await page.getByRole('button', { name: 'Perform Test Scan' }).click();
+  await page.getByText('Insert a blank sheet into the scanner.').waitFor();
+  await page.waitForTimeout(1_000); // let the instruction screen register on video
+  mockPdiScannerHandler.insertSheet(blankSheetPdfPath);
+  await page.getByText('Test Scan Successful').waitFor();
+  await page.waitForTimeout(2_000);
+  mockPdiScannerHandler.removeSheet();
+  await page.getByRole('button', { name: 'Close' }).click();
+
+  // A streaked sheet scans as not blank: the diagnostic still catches real
+  // failures rather than passing unconditionally.
+  await page.getByRole('button', { name: 'Perform Test Scan' }).click();
+  await page.getByText('Insert a blank sheet into the scanner.').waitFor();
+  await page.waitForTimeout(1_000);
+  mockPdiScannerHandler.insertSheet(streakedSheetPdfPath);
+  await page.getByText('Test Scan Failed').waitFor();
+  await page.waitForTimeout(2_000);
+  mockPdiScannerHandler.removeSheet();
+  await page.getByRole('button', { name: 'Close' }).click();
+
+  await page.getByText('Diagnostics').first().waitFor();
+  mockPdiScannerHandler.cleanup();
+});

--- a/apps/scan/integration-testing/e2e/support/synthesized_pdfs.ts
+++ b/apps/scan/integration-testing/e2e/support/synthesized_pdfs.ts
@@ -1,0 +1,70 @@
+import { Buffer } from 'node:buffer';
+
+const LETTER_WIDTH_POINTS = 612;
+const LETTER_HEIGHT_POINTS = 792;
+
+/**
+ * Builds a minimal valid PDF with one page per entry in `pageContents`, each
+ * entry being a PDF content stream (empty string for a blank page). Pages are
+ * letter-sized. This lets tests synthesize scanner input sheets without
+ * depending on ballot fixtures.
+ */
+function buildPdf(pageContents: string[]): Buffer {
+  const objects: string[] = [];
+  const pageObjectNumbers = pageContents.map(
+    (_, i) => 3 + i * 2 // catalog=1, pages=2, then alternating page/content
+  );
+
+  objects.push('<< /Type /Catalog /Pages 2 0 R >>');
+  objects.push(
+    `<< /Type /Pages /Kids [${pageObjectNumbers
+      .map((n) => `${n} 0 R`)
+      .join(' ')}] /Count ${pageContents.length} >>`
+  );
+  for (const [i, content] of pageContents.entries()) {
+    const pageObjectNumber = pageObjectNumbers[i];
+    objects.push(
+      `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${LETTER_WIDTH_POINTS} ${LETTER_HEIGHT_POINTS}] /Contents ${
+        pageObjectNumber + 1
+      } 0 R >>`
+    );
+    objects.push(
+      `<< /Length ${content.length} >>\nstream\n${content}\nendstream`
+    );
+  }
+
+  let body = '%PDF-1.4\n';
+  const offsets: number[] = [];
+  for (const [i, object] of objects.entries()) {
+    offsets.push(body.length);
+    body += `${i + 1} 0 obj\n${object}\nendobj\n`;
+  }
+
+  const xrefOffset = body.length;
+  body += `xref\n0 ${objects.length + 1}\n`;
+  body += '0000000000 65535 f \n';
+  for (const offset of offsets) {
+    body += `${offset.toString().padStart(10, '0')} 00000 n \n`;
+  }
+  body += `trailer\n<< /Size ${
+    objects.length + 1
+  } /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+
+  return Buffer.from(body, 'ascii');
+}
+
+/** A two-page PDF of entirely blank sheets. */
+export function makeBlankSheetPdf(): Buffer {
+  return buildPdf(['', '']);
+}
+
+/**
+ * A two-page PDF with dark vertical streaks on each page, simulating the
+ * output of a scanner with a dirty image sensor.
+ */
+export function makeStreakedSheetPdf(): Buffer {
+  const streaks = [120, 300, 480]
+    .map((x) => `0 0 0 rg ${x} 0 6 ${LETTER_HEIGHT_POINTS} re f`)
+    .join(' ');
+  return buildPdf([streaks, streaks]);
+}

--- a/libs/ballot-interpreter/index.d.ts
+++ b/libs/ballot-interpreter/index.d.ts
@@ -45,6 +45,8 @@ export declare function interpretImages(election: Election, sideAImageWidth: num
 
 export declare function interpretPaths(election: Election, sideAImagePath: string, sideBImagePath: string, options: BridgeInterpretOptions): Promise<BridgeInterpretResult>
 
+export declare function runBlankPaperDiagnosticFromImage(imageWidth: number, imageHeight: number, imageData: Buffer | Uint8ClampedArray, debugPath?: string): Promise<boolean>
+
 export declare function runBlankPaperDiagnosticFromPath(imagePath: string, debugPath?: string): Promise<boolean>
 
 /** Encodes image data (RGBA or grayscale) as a grayscale PNG and writes it to disk. */

--- a/libs/ballot-interpreter/index.js
+++ b/libs/ballot-interpreter/index.js
@@ -582,5 +582,6 @@ module.exports.findTimingMarkGridFromImage = nativeBinding.findTimingMarkGridFro
 module.exports.findTimingMarkGridFromPath = nativeBinding.findTimingMarkGridFromPath
 module.exports.interpretImages = nativeBinding.interpretImages
 module.exports.interpretPaths = nativeBinding.interpretPaths
+module.exports.runBlankPaperDiagnosticFromImage = nativeBinding.runBlankPaperDiagnosticFromImage
 module.exports.runBlankPaperDiagnosticFromPath = nativeBinding.runBlankPaperDiagnosticFromPath
 module.exports.writeImageToPng = nativeBinding.writeImageToPng

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/js/mod.rs
@@ -391,6 +391,29 @@ pub async fn run_blank_paper_diagnostic_from_path(
     ))
 }
 
+// unused_async: napi-rs requires `async fn` to return a Promise in JS.
+#[allow(clippy::unused_async)]
+#[napi(
+    ts_args_type = "imageWidth: number, imageHeight: number, imageData: Buffer | Uint8ClampedArray, debugPath?: string",
+    ts_return_type = "Promise<boolean>"
+)]
+pub async fn run_blank_paper_diagnostic_from_image(
+    image_width: f64,
+    image_height: f64,
+    image_data: Buffer,
+    debug_path: Option<String>,
+) -> napi::Result<bool> {
+    let image = gray_image(
+        as_u32(image_width)?,
+        as_u32(image_height)?,
+        image_data.to_vec(),
+    )?;
+    Ok(crate::diagnostic::blank_paper(
+        image,
+        debug_path.map(PathBuf::from),
+    ))
+}
+
 /// Decodes raw QR code bytes as a `CastVoteRecord` (VB\x01). Used for
 /// cross-language testing to verify the Rust decoder matches the TypeScript
 /// encoder.

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/diagnostic.test.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/diagnostic.test.ts
@@ -1,25 +1,65 @@
 import { expect, test } from 'vitest';
 import { join } from 'node:path';
-import { runBlankPaperDiagnostic } from './diagnostic';
+import { ImageData } from 'canvas';
+import { loadImageData, RGBA_CHANNEL_COUNT } from '@votingworks/image-utils';
+import {
+  runBlankPaperDiagnostic,
+  runBlankPaperDiagnosticFromImage,
+} from './diagnostic';
+
+const blankImagePath = join(
+  __dirname,
+  '../../test/fixtures/diagnostic/blank/20lb/bc0367d0-444a-4f1b-a88e-78de0bda5cb5-back.jpg'
+);
+const streakedImagePath = join(
+  __dirname,
+  '../../test/fixtures/diagnostic/streaked/0dc29646-3c6a-4abd-9d2d-ae1b03a3b4ad-front.jpg'
+);
+
+/**
+ * Reshapes RGBA image data into the grayscale (one byte per pixel) image data
+ * that scanner clients emit. Assumes the RGBA image was actually expanded from
+ * a grayscale image originally.
+ */
+function toGrayscaleImageData({ width, height, data }: ImageData): ImageData {
+  const pixels = new Uint8ClampedArray(width * height);
+  for (let i = 0; i < pixels.length; i += 1) {
+    pixels[i] = data[i * RGBA_CHANNEL_COUNT] as number;
+  }
+  return { width, height, data: pixels };
+}
 
 test('runBlankPaperDiagnostic can pass', async () => {
-  expect(
-    await runBlankPaperDiagnostic(
-      join(
-        __dirname,
-        '../../test/fixtures/diagnostic/blank/20lb/bc0367d0-444a-4f1b-a88e-78de0bda5cb5-back.jpg'
-      )
-    )
-  ).toEqual(true);
+  expect(await runBlankPaperDiagnostic(blankImagePath)).toEqual(true);
 });
 
 test('runBlankPaperDiagnostic can fail', async () => {
-  expect(
-    await runBlankPaperDiagnostic(
-      join(
-        __dirname,
-        '../../test/fixtures/diagnostic/streaked/0dc29646-3c6a-4abd-9d2d-ae1b03a3b4ad-front.jpg'
-      )
-    )
-  ).toEqual(false);
+  expect(await runBlankPaperDiagnostic(streakedImagePath)).toEqual(false);
+});
+
+test('runBlankPaperDiagnosticFromImage accepts RGBA image data', async () => {
+  const image = (await loadImageData(blankImagePath)).unsafeUnwrap();
+  expect(await runBlankPaperDiagnosticFromImage(image)).toEqual(true);
+});
+
+test('runBlankPaperDiagnosticFromImage accepts grayscale image data', async () => {
+  const blank = toGrayscaleImageData(
+    (await loadImageData(blankImagePath)).unsafeUnwrap()
+  );
+  expect(await runBlankPaperDiagnosticFromImage(blank)).toEqual(true);
+
+  const streaked = toGrayscaleImageData(
+    (await loadImageData(streakedImagePath)).unsafeUnwrap()
+  );
+  expect(await runBlankPaperDiagnosticFromImage(streaked)).toEqual(false);
+});
+
+test('runBlankPaperDiagnosticFromImage rejects malformed image data', async () => {
+  await expect(
+    runBlankPaperDiagnosticFromImage({
+      width: 2,
+      height: 2,
+      data: new Uint8ClampedArray(3),
+    })
+  ).rejects.toThrow('Unexpected buffer length');
 });

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/diagnostic.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/diagnostic.ts
@@ -1,3 +1,4 @@
+import { ImageData } from 'canvas';
 import { napi } from './napi';
 
 /**
@@ -9,4 +10,21 @@ export async function runBlankPaperDiagnostic(
   debugBasePath?: string
 ): Promise<boolean> {
   return napi.runBlankPaperDiagnosticFromPath(imagePath, debugBasePath);
+}
+
+/**
+ * Runs a diagnostic on in-memory blank paper image data to determine if it is
+ * a valid ballot. Accepts either grayscale (one byte per pixel) or RGBA image
+ * data, as scanner clients emit grayscale.
+ */
+export async function runBlankPaperDiagnosticFromImage(
+  image: ImageData,
+  debugBasePath?: string
+): Promise<boolean> {
+  return napi.runBlankPaperDiagnosticFromImage(
+    image.width,
+    image.height,
+    image.data,
+    debugBasePath
+  );
 }

--- a/libs/image-utils/src/image_data.test.ts
+++ b/libs/image-utils/src/image_data.test.ts
@@ -190,6 +190,31 @@ test('toDataUrl image/jpeg', async () => {
   );
 });
 
+test('canvas encoders reject non-RGBA image data', async () => {
+  const width = 4;
+  const height = 4;
+  const grayscaleImageData: ImageData = {
+    width,
+    height,
+    data: new Uint8ClampedArray(width * height),
+  };
+  const expectedError = 'Expected RGBA image data, got 1 channel(s)';
+
+  const filePath = makeTemporaryFile({ postfix: '.png' });
+  await expect(writeImageData(filePath, grayscaleImageData)).rejects.toThrow(
+    expectedError
+  );
+  await expect(
+    encodeImageData(grayscaleImageData, 'image/png')
+  ).rejects.toThrow(expectedError);
+  expect(() => toImageBuffer(grayscaleImageData, 'image/png')).toThrow(
+    expectedError
+  );
+  expect(() => toDataUrl(grayscaleImageData, 'image/png')).toThrow(
+    expectedError
+  );
+});
+
 test('ensureImageData', () => {
   const imageData = createImageData(1, 1);
   expect(ensureImageData(imageData) === imageData).toBeTruthy();
@@ -381,7 +406,9 @@ test('loadImageMetadata on JPEG truncated before segment length', async () => {
 test('loadImageMetadata on JPEG with invalid segment length', async () => {
   // SOI + APP0 marker (FF E0) + 2-byte length field of 1, which is less than
   // the minimum valid value of 2 (the length field includes itself)
-  const result = await loadImageMetadata(Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x01]));
+  const result = await loadImageMetadata(
+    Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x01])
+  );
   expect(result).toEqual(
     err({ type: 'invalid-image-file', message: expect.any(String) })
   );

--- a/libs/image-utils/src/image_data.ts
+++ b/libs/image-utils/src/image_data.ts
@@ -266,6 +266,12 @@ export function fromGrayScale(
 }
 
 function createCanvasWithImageData(imageData: ImageData) {
+  assert(
+    isRgba(imageData),
+    `Expected RGBA image data, got ${getImageChannelCount(
+      imageData
+    )} channel(s)`
+  );
   const canvas = createCanvas(imageData.width, imageData.height);
   const context = canvas.getContext('2d');
   context.putImageData(ensureImageData(imageData), 0, 0);
@@ -369,9 +375,7 @@ export function toImageBuffer(
   imageData: ImageData,
   mimeType: 'image/png' | 'image/jpeg' = 'image/png'
 ): Buffer {
-  const canvas = createCanvas(imageData.width, imageData.height);
-  const context = canvas.getContext('2d');
-  context.putImageData(ensureImageData(imageData), 0, 0);
+  const canvas = createCanvasWithImageData(imageData);
   // Help TS match the union type branches to overloaded function signatures
   return mimeType === 'image/png'
     ? canvas.toBuffer(mimeType)

--- a/libs/integration-test-utils/src/playwright_config.ts
+++ b/libs/integration-test-utils/src/playwright_config.ts
@@ -63,7 +63,12 @@ export function defineIntegrationTestPlaywrightConfig(
       },
     ],
     webServer: {
-      command: 'make run',
+      // The backends log every state-machine event and transition to stdout,
+      // which floods the test output with large JSON lines. Redirect stdout
+      // to a file so the logs stay available for debugging without drowning
+      // out the test results; stderr still streams through so server crashes
+      // are visible.
+      command: `mkdir -p ${OUTPUT_DIR} && make run > ${OUTPUT_DIR}/server-output.log`,
       url: BASE_URL,
       reuseExistingServer: !isCi,
       stdout: 'pipe',

--- a/libs/pdi-scanner/src/ts/mock_file_scanner.ts
+++ b/libs/pdi-scanner/src/ts/mock_file_scanner.ts
@@ -1,7 +1,7 @@
 import { iter } from '@votingworks/basics';
 import {
   ImageData,
-  createImageData,
+  RGBA_CHANNEL_COUNT,
   pdfToImages,
 } from '@votingworks/image-utils';
 import { asSheet, SheetOf } from '@votingworks/types';
@@ -29,6 +29,27 @@ const MOCK_STATE_DIR = join(
   'pdi-scanner'
 );
 const COMMAND_FILE = join(MOCK_STATE_DIR, 'command.json');
+
+/**
+ * Reshapes RGBA image data into the grayscale (one byte per pixel) image data
+ * the real scanner client emits (see `scanner_client.ts`), so that mock scans
+ * exercise the same downstream image handling as real hardware.
+ */
+function toGrayscaleImageData({ width, height, data }: ImageData): ImageData {
+  const pixels = new Uint8ClampedArray(width * height);
+  for (let i = 0; i < pixels.length; i += 1) {
+    pixels[i] = data[i * RGBA_CHANNEL_COUNT] as number;
+  }
+  return { width, height, data: pixels };
+}
+
+function blankGrayscalePage(width: number, height: number): ImageData {
+  return {
+    width,
+    height,
+    data: new Uint8ClampedArray(width * height).fill(0xff),
+  };
+}
 
 type Command =
   | { type: 'insert'; path: string }
@@ -125,11 +146,12 @@ export function createMockFilePdiScanner(): MockScanner {
         for await (const sheet of iter(
           pdfToImages(pdfData, { scale: 200 / 72 })
         )
-          .map(({ page }: { page: ImageData }) => page)
+          .map(({ page }: { page: ImageData }) => toGrayscaleImageData(page))
           .chunks(2)
           .map((pages: [ImageData] | [ImageData, ImageData]) => {
             const front = pages[0];
-            const back = pages[1] ?? createImageData(front.width, front.height);
+            const back =
+              pages[1] ?? blankGrayscalePage(front.width, front.height);
             return asSheet([front, back]);
           })) {
           inner.insertSheet(sheet);

--- a/libs/pdi-scanner/src/ts/mock_file_scanner.ts
+++ b/libs/pdi-scanner/src/ts/mock_file_scanner.ts
@@ -40,15 +40,39 @@ function toGrayscaleImageData({ width, height, data }: ImageData): ImageData {
   for (let i = 0; i < pixels.length; i += 1) {
     pixels[i] = data[i * RGBA_CHANNEL_COUNT] as number;
   }
-  return { width, height, data: pixels };
+  return grayscaleImageData(width, height, pixels);
 }
 
 function blankGrayscalePage(width: number, height: number): ImageData {
-  return {
+  return grayscaleImageData(
     width,
     height,
-    data: new Uint8ClampedArray(width * height).fill(0xff),
+    new Uint8ClampedArray(width * height).fill(0xff)
+  );
+}
+
+interface LoggableImageData extends ImageData {
+  // eslint-disable-next-line vx/gts-identifiers
+  toJSON(): string;
+}
+
+function grayscaleImageData(
+  width: number,
+  height: number,
+  data: Uint8ClampedArray
+): ImageData {
+  const image: LoggableImageData = {
+    width,
+    height,
+    data,
+
+    // Define `toJSON` such that `JSON.stringify` does not try to serialize
+    // all the bytes in `data` as an array of numbers, matching the real
+    // scanner client (see `scanner_client.ts`).
+    // eslint-disable-next-line vx/gts-identifiers
+    toJSON: () => `[ImageData ${width}x${height}]`,
   };
+  return image;
 }
 
 type Command =

--- a/libs/pdi-scanner/src/ts/mock_scanner.ts
+++ b/libs/pdi-scanner/src/ts/mock_scanner.ts
@@ -247,7 +247,11 @@ export function createMockPdiScanner(
         on: {
           EJECT_DOCUMENT: [
             {
-              cond: (_, event) => event.motion === 'toFrontAndHold',
+              // The mock doesn't model holding, so ejecting to the front with
+              // or without holding both leave the sheet in front of the
+              // scanner, where it can be removed with REMOVE_SHEET.
+              cond: (_, event) =>
+                event.motion === 'toFront' || event.motion === 'toFrontAndHold',
               target: 'ejectingToFrontAndHold',
             },
             {
@@ -266,6 +270,9 @@ export function createMockPdiScanner(
               target: 'ejectingToRear',
             },
           ],
+          // pdictl accepts disabling scanning at any time; scanning is
+          // already effectively disabled with a sheet in front
+          DISABLE_SCANNING: {},
           // pdictl disables scanning after ejecting, and we had to eject
           // previously for the paper to be in front
           REMOVE_SHEET: 'idleScanningDisabled',


### PR DESCRIPTION
## Overview

Fixes #9084 — VxScan's diagnostics-menu scan either wrongly reports a blank sheet as not blank, or crashes.

Both symptoms are one bug. #8277 changed the PDI scanner client to emit zero-copy grayscale images (one byte per pixel), but the diagnostic still wrote scan images to PNG via node-canvas, whose `putImageData` reads `width * height * 4` bytes without checking the buffer length. Grayscale input made it read 4x past the end of the allocation: usually garbage pixels ("not blank"), sometimes a segfault ("something went wrong"). Normal scanning was unaffected because it goes to the Rust interpreter, which handles grayscale natively — the diagnostic was the only scanner-image path routed through node-canvas.

This supersedes the approach in #9120 (which converted grayscale to RGBA inside `image-utils`). Instead, the fix moves the work into Rust and removes node-canvas from the path entirely:

- **`libs/ballot-interpreter`**: new `runBlankPaperDiagnosticFromImage` napi export that takes raw image data directly, mirroring `findTimingMarkGridFromImage`. It reuses the existing `gray_image()` helper, which length-checks the buffer and accepts both grayscale and RGBA.
- **`apps/scan/backend`**: `runScannerDiagnostic` passes the scan images straight to Rust. The `writeImageData` call and the intermediate `diagnostic-*.png` temp files (which nothing read) are gone.
- **`libs/image-utils`**: the canvas encoders now fail fast with a clear error on non-RGBA input instead of silently reading out of bounds, so any future grayscale producer gets an exception rather than garbage pixels or a dead worker.
- **`libs/pdi-scanner`**: mock-fidelity fixes that let tests catch this class of bug — the mock file scanner now emits grayscale like the real `scanner_client.ts` (it emitted RGBA, which is exactly why CI never saw this), supports the `toFront` eject motion the diagnostic uses, and accepts `disableScanning` with a sheet in front, as pdictl does.

## Demo Video or Screenshot

Playwright recording of the fixed diagnostic running end to end — production frontend + backend, mock scanner feeding grayscale images from synthesized PDFs. A blank sheet passes; a streaked sheet (simulating a dirty image sensor) fails, showing the diagnostic still discriminates:

**[Demo video + shot list](https://claude.ai/code/artifact/def61ac3-33bd-45c1-876e-80b8beeccd14)** (artifact page with the video embedded)

The raw recording is produced by `apps/scan/integration-testing/e2e/scanner_diagnostic.spec.ts` on every run (`test-results/**/video.webm`).

## Testing Plan

- New integration test `scanner_diagnostic.spec.ts` drives the full UI flow twice with grayscale scan images: blank sheet → "Test Scan Successful", streaked sheet → "Test Scan Failed". Passes in ~17s.
- New `libs/ballot-interpreter` tests cover `runBlankPaperDiagnosticFromImage` with RGBA input, grayscale pass/fail fixtures, and a malformed-buffer rejection.
- New VxScan backend test drives the diagnostic state machine with the grayscale image data the real scanner emits (previously every scan-backend test fed RGBA).
- New `libs/image-utils` test asserts all four canvas encoders reject grayscale input with a clear error.
- Full `apps/scan/backend` suite passes (36 files, 228 tests). `libs/image-utils` passes at 100% coverage; `libs/ballot-interpreter` and `libs/pdi-scanner` pass their coverage thresholds. `cargo fmt`/`clippy` clean.
- Note for review: the grayscale mock change means the whole scan integration suite now feeds grayscale into interpretation (matching real hardware). The new spec passes; worth a full `screenshots.spec.ts` CI run before merging.
- Not verified on hardware; worth confirming on a real VxScan before closing the issue.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
