### PR TITLE
Dev dock: quick configure backend

### DIFF
--- a/apps/design/backend/src/globals.ts
+++ b/apps/design/backend/src/globals.ts
@@ -1,5 +1,6 @@
 import { assert } from '@votingworks/basics';
 import { unsafeParse } from '@votingworks/types';
+import { getDesignDevWorkspaceDir } from '@votingworks/utils';
 import { join } from 'node:path';
 import { z } from 'zod/v4';
 
@@ -193,7 +194,8 @@ export function circleCiBaseUrl(): string {
 export const WORKSPACE =
   process.env.WORKSPACE ??
   (NODE_ENV === 'development'
-    ? join(import.meta.dirname, '../dev-workspace')
+    ? // Shared with dev tooling that reads VxDesign's exports.
+      getDesignDevWorkspaceDir(join(import.meta.dirname, '../../../..'))
     : undefined);
 
 /**

--- a/libs/dev-dock/backend/src/dev_dock_api.test.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.test.ts
@@ -10,9 +10,14 @@ import {
 import { AddressInfo } from 'node:net';
 import {
   BooleanEnvironmentVariableName,
+  ELECTION_PACKAGE_FOLDER,
   getFeatureFlagMock,
 } from '@votingworks/utils';
-import { mockElectionPackageFileTree } from '@votingworks/backend';
+import {
+  createElectionPackageZipArchive,
+  getMostRecentElectionPackageFilepath,
+  mockElectionPackageFileTree,
+} from '@votingworks/backend';
 import {
   backendWaitFor,
   mockElectionManagerUser,
@@ -20,7 +25,11 @@ import {
   mockSystemAdministratorUser,
   zipFile,
 } from '@votingworks/test-utils';
-import { DEV_JURISDICTION } from '@votingworks/auth';
+import {
+  CardStatus,
+  DEV_JURISDICTION,
+  readFromMockFile,
+} from '@votingworks/auth';
 import {
   electionFamousNames2021Fixtures,
   makeTemporaryDirectory,
@@ -28,7 +37,7 @@ import {
   readElectionGeneral,
 } from '@votingworks/fixtures';
 import { Server } from 'node:http';
-import { assert, typedAs } from '@votingworks/basics';
+import { Optional, assert, typedAs } from '@votingworks/basics';
 import {
   constructElectionKey,
   DEFAULT_SYSTEM_SETTINGS,
@@ -45,7 +54,9 @@ import {
 } from '@votingworks/fujitsu-thermal-printer';
 import { createMockPdiScanner } from '@votingworks/pdi-scanner';
 import {
+  getMockUsbDirPath,
   getMockUsbDriveHandler,
+  SimulatedUsbPlatform,
   UsbDiskDevPathSchema,
 } from '@votingworks/usb-drive';
 import {
@@ -56,6 +67,10 @@ import {
   DEV_DOCK_ELECTION_FILE_NAME,
   PdiScannerStatus,
 } from './dev_dock_api.js';
+import {
+  QUICK_CONFIGURE_ELECTION_DIR,
+  STAGED_ELECTION_PACKAGE_FILE_NAME,
+} from './quick_configure.js';
 
 const electionGeneral = readElectionGeneral();
 
@@ -90,15 +105,18 @@ let server: Server;
 
 function setup(
   mockSpec: MockSpec = {},
-  devDockDir: string = makeTemporaryDirectory({ prefix: 'dev-dock-test-' })
+  devDockDir: string = makeTemporaryDirectory({ prefix: 'dev-dock-test-' }),
+  designExportDir: string = makeTemporaryDirectory({
+    prefix: 'design-export-test-',
+  })
 ) {
   const app = express();
-  useDevDockRouter(app, express, mockSpec, devDockDir);
+  useDevDockRouter(app, express, mockSpec, devDockDir, designExportDir);
   server = app.listen();
   const { port } = server.address() as AddressInfo;
   const baseUrl = `http://localhost:${port}/dock`;
   const apiClient = grout.createClient<Api>({ baseUrl });
-  return { apiClient, devDockDir };
+  return { apiClient, devDockDir, designExportDir };
 }
 
 beforeEach(() => {
@@ -432,6 +450,284 @@ test('usb drive mock endpoints', async () => {
   });
 });
 
+test("mounts with a default VxDesign export directory, since apps don't provide one", async () => {
+  const app = express();
+  useDevDockRouter(
+    app,
+    express,
+    {},
+    makeTemporaryDirectory({ prefix: 'dev-dock-test-' })
+  );
+  server = app.listen();
+  const { port } = server.address() as AddressInfo;
+  const apiClient = grout.createClient<Api>({
+    baseUrl: `http://localhost:${port}/dock`,
+  });
+
+  await expect(apiClient.getUsbDriveStatus()).resolves.toMatchObject({
+    status: 'removed',
+  });
+});
+
+async function writeVxDesignElectionPackage(
+  designExportDir: string,
+  fileName = 'election-package-aaa-111.zip'
+): Promise<string> {
+  const jurisdictionDir = join(designExportDir, 'dev-jurisdiction-DEMO');
+  fs.mkdirSync(jurisdictionDir, { recursive: true });
+  const packagePath = join(jurisdictionDir, fileName);
+  fs.writeFileSync(
+    packagePath,
+    await createElectionPackageZipArchive(
+      electionFamousNames2021Fixtures.toElectionPackage()
+    )
+  );
+  return packagePath;
+}
+
+test('lists the latest VxDesign election package', async () => {
+  const designExportDir = makeTemporaryDirectory({
+    prefix: 'design-export-test-',
+  });
+  await writeVxDesignElectionPackage(
+    designExportDir,
+    'election-package-old.zip'
+  );
+  const latestPath = await writeVxDesignElectionPackage(
+    designExportDir,
+    'election-package-new.zip'
+  );
+  fs.utimesSync(latestPath, new Date('2030-01-01'), new Date('2030-01-01'));
+
+  const { apiClient } = setup(
+    {},
+    makeTemporaryDirectory({ prefix: 'dev-dock-test-' }),
+    designExportDir
+  );
+
+  const elections = await apiClient.getAvailableElections();
+  expect(elections[0]).toEqual({
+    title: 'VxDesign: election-package-new.zip',
+    inputPath: latestPath,
+  });
+});
+
+test('quickConfigure requires an election package to be selected', async () => {
+  const { apiClient } = setup();
+  await apiClient.setElection({
+    inputPath: './libs/fixtures/data/electionGeneral/election.json',
+  });
+
+  await expect(apiClient.quickConfigure()).rejects.toThrow();
+  await expect(apiClient.getUsbDriveStatus()).resolves.toMatchObject({
+    status: 'removed',
+  });
+});
+
+// Note: This test overwrites the global mock card state.
+test('quickConfigure clears the card and unconfigures after staging, before programming the new card', async () => {
+  const designExportDir = makeTemporaryDirectory({
+    prefix: 'design-export-test-',
+  });
+  const packagePath = await writeVxDesignElectionPackage(designExportDir);
+  const stagedElectionPackagePath = join(
+    getMockUsbDriveHandler().getDataPath(),
+    QUICK_CONFIGURE_ELECTION_DIR,
+    ELECTION_PACKAGE_FOLDER,
+    STAGED_ELECTION_PACKAGE_FILE_NAME
+  );
+
+  let isPackageStagedAtUnconfigure = false;
+  let cardStatusAtUnconfigure: Optional<string>;
+  const unconfigure = vi.fn(() => {
+    isPackageStagedAtUnconfigure = fs.existsSync(stagedElectionPackagePath);
+    cardStatusAtUnconfigure = readFromMockFile().cardStatus.status;
+    return Promise.resolve();
+  });
+
+  const { apiClient } = setup(
+    { quickConfigure: { unconfigure, configure: () => Promise.resolve() } },
+    makeTemporaryDirectory({ prefix: 'dev-dock-test-' }),
+    designExportDir
+  );
+  await apiClient.setElection({ inputPath: packagePath });
+  await apiClient.insertCard({ role: 'election_manager' });
+
+  // Stand in for the machine mounting the drive, which configuring waits for.
+  const platform = new SimulatedUsbPlatform(getMockUsbDirPath());
+  const mounter = setInterval(() => {
+    const partition = platform
+      .getSimulatedDrives()
+      .find((drive) => drive.present)?.partition;
+    if (partition && !partition.mountpoint) {
+      void platform.mountPartition(partition.partPath);
+    }
+  }, 10);
+
+  await apiClient.quickConfigure();
+  clearInterval(mounter);
+
+  expect(unconfigure).toHaveBeenCalledTimes(1);
+  expect(isPackageStagedAtUnconfigure).toEqual(true);
+  // The stale card is removed first, so the newly unconfigured machine can't
+  // try to configure itself before the dock has programmed a matching card.
+  expect(cardStatusAtUnconfigure).toEqual('no_card');
+});
+
+// Note: This test overwrites the global mock card state.
+test('quickConfigure configures the machine once its drive is mounted, then removes the card', async () => {
+  const designExportDir = makeTemporaryDirectory({
+    prefix: 'design-export-test-',
+  });
+  const packagePath = await writeVxDesignElectionPackage(designExportDir);
+
+  const usbDriveHandler = getMockUsbDriveHandler();
+  const platform = new SimulatedUsbPlatform(getMockUsbDirPath());
+
+  let cardRoleAtConfigure: Optional<string>;
+  const configure = vi.fn(() => {
+    // Configuring reads the package off the drive, so it has to be mounted by
+    // now, with an election manager card inserted to authorize it.
+    expect(usbDriveHandler.status().status).toEqual('mounted');
+    const { cardStatus } = readFromMockFile();
+    cardRoleAtConfigure =
+      cardStatus.status === 'ready'
+        ? cardStatus.cardDetails.user?.role
+        : undefined;
+    return Promise.resolve();
+  });
+
+  const { apiClient } = setup(
+    { quickConfigure: { unconfigure: () => Promise.resolve(), configure } },
+    makeTemporaryDirectory({ prefix: 'dev-dock-test-' }),
+    designExportDir
+  );
+  await apiClient.setElection({ inputPath: packagePath });
+
+  // Stand in for the machine, which mounts an attached drive asynchronously.
+  // The delay outlasts the rest of the sequence, so quick configure has to wait
+  // for the mount rather than configuring as soon as it attaches the drive.
+  const mountDelay = setTimeout(() => {
+    const partition = platform
+      .getSimulatedDrives()
+      .find((drive) => drive.present)?.partition;
+    assert(partition);
+    void platform.mountPartition(partition.partPath);
+  }, 1_500);
+
+  await apiClient.quickConfigure();
+  clearTimeout(mountDelay);
+
+  expect(configure).toHaveBeenCalledTimes(1);
+  expect(cardRoleAtConfigure).toEqual('election_manager');
+  await expect(apiClient.getCardStatus()).resolves.toEqual({
+    status: 'no_card',
+  });
+});
+
+test('quickConfigure rejects apps that do not support it', async () => {
+  const designExportDir = makeTemporaryDirectory({
+    prefix: 'design-export-test-',
+  });
+  const packagePath = await writeVxDesignElectionPackage(designExportDir);
+
+  const { apiClient } = setup(
+    {},
+    makeTemporaryDirectory({ prefix: 'dev-dock-test-' }),
+    designExportDir
+  );
+  await apiClient.setElection({ inputPath: packagePath });
+
+  // Configuring is the point, so an app that can't be configured shouldn't be
+  // left with a staged package and a card it never used.
+  await expect(apiClient.quickConfigure()).rejects.toThrow();
+  await expect(apiClient.getUsbDriveStatus()).resolves.toMatchObject({
+    status: 'removed',
+  });
+});
+
+// Note: This test overwrites the global mock card state.
+test('quickConfigure stages the selected election package and keeps it selected', async () => {
+  const designExportDir = makeTemporaryDirectory({
+    prefix: 'design-export-test-',
+  });
+  const packagePath = await writeVxDesignElectionPackage(designExportDir);
+  const electionPackage = electionFamousNames2021Fixtures.toElectionPackage();
+
+  let cardDetailsAtConfigure: Optional<CardStatus>;
+  const { apiClient, devDockDir } = setup(
+    {
+      quickConfigure: {
+        unconfigure: () => Promise.resolve(),
+        configure: () => {
+          cardDetailsAtConfigure = readFromMockFile().cardStatus;
+          return Promise.resolve();
+        },
+      },
+    },
+    makeTemporaryDirectory({ prefix: 'dev-dock-test-' }),
+    designExportDir
+  );
+  await apiClient.setElection({ inputPath: packagePath });
+
+  // Stand in for the machine mounting the drive, which configuring waits for.
+  const platform = new SimulatedUsbPlatform(getMockUsbDirPath());
+  const mounter = setInterval(() => {
+    const partition = platform
+      .getSimulatedDrives()
+      .find((drive) => drive.present)?.partition;
+    if (partition && !partition.mountpoint) {
+      void platform.mountPartition(partition.partPath);
+    }
+  }, 10);
+
+  await apiClient.quickConfigure();
+  clearInterval(mounter);
+
+  await expect(apiClient.getUsbDriveStatus()).resolves.toMatchObject({
+    status: 'inserted',
+  });
+
+  // The machine finds the staged copy on the drive using its own reader.
+  const usbDriveDataPath = getMockUsbDriveHandler().getDataPath();
+  const foundPath =
+    await getMostRecentElectionPackageFilepath(usbDriveDataPath);
+  expect(foundPath.unsafeUnwrap()).toEqual(
+    join(
+      usbDriveDataPath,
+      QUICK_CONFIGURE_ELECTION_DIR,
+      ELECTION_PACKAGE_FOLDER,
+      STAGED_ELECTION_PACKAGE_FILE_NAME
+    )
+  );
+
+  // The selection still points at what the developer picked, not the staged
+  // copy, so the dev dock keeps showing their choice.
+  await expect(apiClient.getElection()).resolves.toEqual({
+    title: electionPackage.electionDefinition.election.title,
+    inputPath: packagePath,
+    resolvedPath: join(devDockDir, DEV_DOCK_ELECTION_FILE_NAME),
+    arePollWorkerCardPinsEnabled: false,
+    isElectionPackage: true,
+  });
+
+  // The card used to configure matches the package that was staged.
+  expect(cardDetailsAtConfigure).toEqual({
+    status: 'ready',
+    cardDetails: {
+      user: mockElectionManagerUser({
+        electionKey: constructElectionKey(
+          electionPackage.electionDefinition.election
+        ),
+        jurisdiction: DEV_JURISDICTION,
+      }),
+    },
+  });
+  await expect(apiClient.getCardStatus()).resolves.toEqual({
+    status: 'no_card',
+  });
+});
+
 test('mock spec', async () => {
   const { apiClient: apiClient1 } = setup({ printerConfig: 'fujitsu' });
   expect(await apiClient1.getMockSpec()).toEqual({
@@ -441,6 +737,7 @@ test('mock spec', async () => {
     hasAccessibleControllerMock: false,
     hasBarcodeMock: false,
     hasPatInputMock: false,
+    hasQuickConfigure: false,
   });
 
   const { apiClient: apiClient2 } = setup({
@@ -451,6 +748,10 @@ test('mock spec', async () => {
     setBarcodeConnected: vi.fn(),
     getPatInputConnected: vi.fn(),
     setPatInputConnected: vi.fn(),
+    quickConfigure: {
+      unconfigure: () => Promise.resolve(),
+      configure: () => Promise.resolve(),
+    },
   });
   expect(await apiClient2.getMockSpec()).toEqual({
     mockPdiScanner: false,
@@ -459,6 +760,7 @@ test('mock spec', async () => {
     hasAccessibleControllerMock: true,
     hasBarcodeMock: true,
     hasPatInputMock: true,
+    hasQuickConfigure: true,
   });
 });
 

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -242,6 +242,30 @@ function getElection(devDockDir: string): Optional<DevDockElectionInfo> {
     .electionInfo;
 }
 
+async function insertCard(
+  role: DevDockUserRole,
+  devDockDir: string
+): Promise<void> {
+  const electionInfo = getElection(devDockDir);
+  assert(electionInfo !== undefined);
+
+  const cardType =
+    role === 'poll_worker' && electionInfo.arePollWorkerCardPinsEnabled
+      ? 'poll-worker-with-pin'
+      : role.replace('_', '-');
+
+  await execFile(MOCK_CARD_SCRIPT_PATH, [
+    '--card-type',
+    cardType,
+    '--electionDefinition',
+    electionInfo.resolvedPath,
+  ]);
+}
+
+async function removeCard(): Promise<void> {
+  await execFile(MOCK_CARD_SCRIPT_PATH, ['--card-type', 'no-card']);
+}
+
 interface PdiScannerSheetQueueStatus {
   total: number;
   inserted: number;
@@ -345,26 +369,11 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
     },
 
     async insertCard(input: { role: DevDockUserRole }): Promise<void> {
-      const devDockFilePath = join(devDockDir, DEV_DOCK_FILE_NAME);
-      const { electionInfo } = readDevDockFileContents(devDockFilePath);
-      assert(electionInfo !== undefined);
-
-      const cardType =
-        input.role === 'poll_worker' &&
-        electionInfo.arePollWorkerCardPinsEnabled
-          ? 'poll-worker-with-pin'
-          : input.role.replace('_', '-');
-
-      await execFile(MOCK_CARD_SCRIPT_PATH, [
-        '--card-type',
-        cardType,
-        '--electionDefinition',
-        electionInfo.resolvedPath,
-      ]);
+      await insertCard(input.role, devDockDir);
     },
 
     async removeCard(): Promise<void> {
-      await execFile(MOCK_CARD_SCRIPT_PATH, ['--card-type', 'no-card']);
+      await removeCard();
     },
 
     getUsbDriveStatus(): DevDockUsbDriveInfo {

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -10,7 +10,13 @@ import {
   basename,
   dirname,
 } from 'node:path';
-import { Optional, assert, assertDefined, iter } from '@votingworks/basics';
+import {
+  Optional,
+  assert,
+  assertDefined,
+  iter,
+  sleep,
+} from '@votingworks/basics';
 import {
   asSheet,
   DEFAULT_SYSTEM_SETTINGS,
@@ -27,6 +33,7 @@ import {
   readFromMockFile as readFromCardMockFile,
 } from '@votingworks/auth';
 import {
+  getDesignDevWorkspaceDir,
   getMockStateRootDir,
   isFeatureFlagEnabled,
   BooleanEnvironmentVariableName,
@@ -40,6 +47,7 @@ import { getMostRecentElectionPackageFilepath } from '@votingworks/backend';
 import {
   getMockUsbDirPath,
   getMockUsbDriveHandler,
+  MockUsbDriveHandler,
   SimulatedUsbPlatform,
   UsbDiskDevPath,
   UsbDiskDevPathSchema,
@@ -60,6 +68,10 @@ import {
   writeImageData,
 } from '@votingworks/image-utils';
 import { execFile } from './utils.js';
+import {
+  findLatestVxDesignElectionPackage,
+  stageElectionPackageOnMockUsbDrive,
+} from './quick_configure.js';
 
 export interface MockBatchScannerApi {
   addSheets(sheets: Array<{ frontPath: string; backPath: string }>): void;
@@ -119,6 +131,12 @@ const REPO_ROOT = join(import.meta.dirname, '../../../..');
 // Directory for dev-dock mock state, namespaced by NODE_ENV for worktree isolation
 export const DEFAULT_DEV_DOCK_DIR = getMockStateRootDir(REPO_ROOT);
 
+/**
+ * Where VxDesign writes its exports in development, one subdirectory per
+ * jurisdiction.
+ */
+export const DESIGN_EXPORT_DIR = getDesignDevWorkspaceDir(REPO_ROOT);
+
 // Convert paths relative to the VxSuite root to absolute paths
 export function electionPathToAbsolute(path: string): string {
   return isAbsolute(path)
@@ -150,6 +168,21 @@ function readDevDockFileContents(devDockFilePath: string): DevDockFileContents {
   ) as DevDockFileContents;
 }
 
+/**
+ * How the dev dock replaces the host app's election. Both are needed together:
+ * some apps refuse to configure while already configured, so configuring
+ * without unconfiguring first would fail.
+ */
+export interface QuickConfigureApi {
+  /** Removes the app's current election configuration. */
+  unconfigure: () => Promise<void>;
+  /**
+   * Configures the app from the election package on the USB drive, throwing if
+   * it can't.
+   */
+  configure: () => Promise<void>;
+}
+
 export interface MockSpec {
   printerConfig?: PrinterConfig | 'fujitsu';
   mockPdiScanner?: MockScanner;
@@ -161,6 +194,8 @@ export interface MockSpec {
   setPatInputConnected?: (connected: boolean) => void;
   getAccessibleControllerConnected?: () => boolean;
   setAccessibleControllerConnected?: (connected: boolean) => void;
+  /** Lets the dev dock replace the host app's election. See {@link QuickConfigureApi}. */
+  quickConfigure?: QuickConfigureApi;
 }
 
 interface SerializableMockSpec
@@ -174,12 +209,14 @@ interface SerializableMockSpec
     | 'getBarcodeConnected'
     | 'getAccessibleControllerConnected'
     | 'getPatInputConnected'
+    | 'quickConfigure'
   > {
   mockPdiScanner?: boolean;
   mockBatchScanner?: boolean;
   hasBarcodeMock?: boolean;
   hasPatInputMock?: boolean;
   hasAccessibleControllerMock?: boolean;
+  hasQuickConfigure?: boolean;
 }
 
 async function setElection(
@@ -272,6 +309,27 @@ async function removeCard(): Promise<void> {
   await execFile(MOCK_CARD_SCRIPT_PATH, ['--card-type', 'no-card']);
 }
 
+const USB_DRIVE_MOUNT_TIMEOUT_MS = 5_000;
+const USB_DRIVE_MOUNT_POLL_INTERVAL_MS = 50;
+
+/**
+ * Waits for the host app to mount the mock USB drive, which it does
+ * asynchronously after noticing the drive was attached. Configuring reads the
+ * election package from the mounted drive, so it can't start any earlier.
+ */
+async function waitForUsbDriveToMount(
+  usbDriveHandler: MockUsbDriveHandler
+): Promise<void> {
+  const timeoutTime = Date.now() + USB_DRIVE_MOUNT_TIMEOUT_MS;
+  while (usbDriveHandler.status().status !== 'mounted') {
+    assert(
+      Date.now() < timeoutTime,
+      'Timed out waiting for the machine to mount the mock USB drive'
+    );
+    await sleep(USB_DRIVE_MOUNT_POLL_INTERVAL_MS);
+  }
+}
+
 interface PdiScannerSheetQueueStatus {
   total: number;
   inserted: number;
@@ -289,7 +347,11 @@ interface PdiScannerSheetQueueState {
   timeoutId: ReturnType<typeof setTimeout>;
 }
 
-function buildApi(devDockDir: string, mockSpec: MockSpec) {
+function buildApi(
+  devDockDir: string,
+  mockSpec: MockSpec,
+  designExportDir: string
+) {
   const printerHandler = getMockFilePrinterHandler();
   const usbDriveHandler = getMockUsbDriveHandler(MOCK_USB_DRIVE_DISK_NAME);
   const fujitsuPrinterHandler = getMockFileFujitsuPrinterHandler();
@@ -310,6 +372,7 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
         hasPatInputMock:
           Boolean(mockSpec.getPatInputConnected) &&
           Boolean(mockSpec.setPatInputConnected),
+        hasQuickConfigure: Boolean(mockSpec.quickConfigure),
       };
     },
 
@@ -322,7 +385,10 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
     },
 
     async getAvailableElections(): Promise<DevDockElectionOption[]> {
-      const baseFixturePath = join(import.meta.dirname, '../../../../libs/fixtures/data');
+      const baseFixturePath = join(
+        import.meta.dirname,
+        '../../../../libs/fixtures/data'
+      );
       const fixtureElections: DevDockElectionOption[] = fs
         .readdirSync(baseFixturePath, {
           withFileTypes: true,
@@ -367,7 +433,21 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
         })
         .toArray();
 
-      return [...usbElections, ...fixtureElections];
+      const latestVxDesignElectionPackagePath =
+        await findLatestVxDesignElectionPackage(designExportDir);
+      const vxDesignElections: DevDockElectionOption[] =
+        latestVxDesignElectionPackagePath
+          ? [
+              {
+                title: `VxDesign: ${basename(
+                  latestVxDesignElectionPackagePath
+                )}`,
+                inputPath: latestVxDesignElectionPackagePath,
+              },
+            ]
+          : [];
+
+      return [...vxDesignElections, ...usbElections, ...fixtureElections];
     },
 
     getCardStatus(): CardStatus {
@@ -398,6 +478,42 @@ function buildApi(devDockDir: string, mockSpec: MockSpec) {
 
     clearUsbDrive(): void {
       usbDriveHandler.clearData();
+    },
+
+    async quickConfigure(): Promise<void> {
+      // Frontend should prevent the following assert() cases
+      assert(
+        mockSpec.quickConfigure,
+        'Quick configure is not supported by host app'
+      );
+      const electionInfo = getElection(devDockDir);
+      assert(
+        electionInfo?.isElectionPackage,
+        'Quick configure requires an election package to be selected'
+      );
+
+      // Inserting the drive ensures it exists before staging.
+      usbDriveHandler.insert();
+      // Staging while the drive is detached keeps
+      // the machine from reading the package mid-copy.
+      usbDriveHandler.remove();
+
+      stageElectionPackageOnMockUsbDrive(
+        electionPathToAbsolute(electionInfo.inputPath),
+        usbDriveHandler.getDataPath()
+      );
+      usbDriveHandler.insert();
+
+      // Unconfigure the machine. Remove card to avoid possible election key mismatch.
+      await removeCard();
+      await mockSpec.quickConfigure.unconfigure();
+
+      // Re-configure with the selected election.
+      await insertCard('election_manager', devDockDir);
+      await waitForUsbDriveToMount(usbDriveHandler);
+      await mockSpec.quickConfigure.configure();
+
+      await removeCard();
     },
 
     async saveScreenshotForApp({
@@ -638,7 +754,9 @@ export function useDevDockRouter(
   express: typeof Express,
   mockSpec: MockSpec,
   /* istanbul ignore next */
-  devDockDir: string = DEFAULT_DEV_DOCK_DIR
+  devDockDir: string = DEFAULT_DEV_DOCK_DIR,
+  /* istanbul ignore next */
+  designExportDir: string = DESIGN_EXPORT_DIR
 ): void {
   if (!isFeatureFlagEnabled(BooleanEnvironmentVariableName.ENABLE_DEV_DOCK)) {
     return;
@@ -654,7 +772,7 @@ export function useDevDockRouter(
     writeDevDockFileContents(devDockFilePath, {});
   }
 
-  const api = buildApi(devDockDir, mockSpec);
+  const api = buildApi(devDockDir, mockSpec, designExportDir);
 
   // Set a default election if one is not already set
   if (!getElection(devDockDir)) {

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -510,10 +510,12 @@ function buildApi(
 
       // Re-configure with the selected election.
       await insertCard('election_manager', devDockDir);
-      await waitForUsbDriveToMount(usbDriveHandler);
-      await mockSpec.quickConfigure.configure();
-
-      await removeCard();
+      try {
+        await waitForUsbDriveToMount(usbDriveHandler);
+        await mockSpec.quickConfigure.configure();
+      } finally {
+        await removeCard();
+      }
     },
 
     async saveScreenshotForApp({

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -92,6 +92,11 @@ export interface DevDockElectionInfo extends DevDockElectionOption {
    * settings).
    */
   arePollWorkerCardPinsEnabled: boolean;
+  /**
+   * Whether the input is an election package rather than a bare election
+   * definition. Only election packages can be used to configure a machine.
+   */
+  isElectionPackage: boolean;
 }
 
 export const MOCK_USB_DRIVE_DISK_NAME = 'sdb';
@@ -186,8 +191,8 @@ async function setElection(
   let resolvedPath: string | undefined;
   let systemSettings = DEFAULT_SYSTEM_SETTINGS;
 
-  // Check if the file is a zip file
-  if (extname(inputAbsolutePath).toLowerCase() === '.zip') {
+  const isElectionPackage = extname(inputAbsolutePath).toLowerCase() === '.zip';
+  if (isElectionPackage) {
     // Read the zip file
     const zipContents = fs.readFileSync(inputAbsolutePath);
     const zipFile = await openZip(zipContents);
@@ -229,6 +234,7 @@ async function setElection(
     resolvedPath,
     arePollWorkerCardPinsEnabled:
       systemSettings.auth.arePollWorkerCardPinsEnabled,
+    isElectionPackage,
   };
 
   const devDockFilePath = join(devDockDir, DEV_DOCK_FILE_NAME);

--- a/libs/dev-dock/backend/src/index.ts
+++ b/libs/dev-dock/backend/src/index.ts
@@ -1,2 +1,3 @@
 /* istanbul ignore file */
 export * from './dev_dock_api.js';
+export * from './quick_configure.js';

--- a/libs/dev-dock/backend/src/quick_configure.test.ts
+++ b/libs/dev-dock/backend/src/quick_configure.test.ts
@@ -1,0 +1,149 @@
+import { expect, test } from 'vitest';
+import * as fs from 'node:fs';
+import { join } from 'node:path';
+import { makeTemporaryDirectory } from '@votingworks/fixtures';
+import { ELECTION_PACKAGE_FOLDER } from '@votingworks/utils';
+import {
+  QUICK_CONFIGURE_ELECTION_DIR,
+  STAGED_ELECTION_PACKAGE_FILE_NAME,
+  findLatestVxDesignElectionPackage,
+  stageElectionPackageOnMockUsbDrive,
+} from './quick_configure';
+
+function writeFileWithModifiedTime(path: string, mtime: Date): void {
+  fs.mkdirSync(join(path, '..'), { recursive: true });
+  fs.writeFileSync(path, path);
+  fs.utimesSync(path, mtime, mtime);
+}
+
+test('findLatestVxDesignElectionPackage returns undefined when VxDesign has not exported anything', async () => {
+  const searchDir = join(makeTemporaryDirectory(), 'dev-workspace');
+  expect(await findLatestVxDesignElectionPackage(searchDir)).toBeUndefined();
+
+  fs.mkdirSync(searchDir);
+  expect(await findLatestVxDesignElectionPackage(searchDir)).toBeUndefined();
+});
+
+test('findLatestVxDesignElectionPackage picks the newest package across jurisdictions', async () => {
+  const searchDir = makeTemporaryDirectory();
+  writeFileWithModifiedTime(
+    join(searchDir, 'jurisdiction-a/election-package-aaa-111.zip'),
+    new Date('2026-01-01')
+  );
+  const newestPath = join(
+    searchDir,
+    'jurisdiction-b/election-package-bbb-222.zip'
+  );
+  writeFileWithModifiedTime(newestPath, new Date('2026-03-01'));
+  writeFileWithModifiedTime(
+    join(searchDir, 'jurisdiction-b/election-package-ccc-333.zip'),
+    new Date('2026-02-01')
+  );
+
+  expect(await findLatestVxDesignElectionPackage(searchDir)).toEqual(
+    newestPath
+  );
+});
+
+test('findLatestVxDesignElectionPackage ignores ballot zips and loose files', async () => {
+  const searchDir = makeTemporaryDirectory();
+  const packagePath = join(
+    searchDir,
+    'jurisdiction-a/election-package-aaa-111.zip'
+  );
+  writeFileWithModifiedTime(packagePath, new Date('2026-01-01'));
+  // Ballot zips are written alongside election packages, and are newer here.
+  writeFileWithModifiedTime(
+    join(searchDir, 'jurisdiction-a/official-ballots-aaa.zip'),
+    new Date('2026-04-01')
+  );
+  writeFileWithModifiedTime(
+    join(searchDir, 'jurisdiction-a/test-ballots-aaa.zip'),
+    new Date('2026-04-01')
+  );
+  writeFileWithModifiedTime(
+    join(searchDir, 'jurisdiction-a/election-package-notes.txt'),
+    new Date('2026-04-01')
+  );
+  // Files at the top level aren't in a jurisdiction directory.
+  writeFileWithModifiedTime(
+    join(searchDir, 'election-package-ddd-444.zip'),
+    new Date('2026-04-01')
+  );
+  fs.mkdirSync(join(searchDir, 'jurisdiction-a/election-package-eee-555.zip'));
+
+  expect(await findLatestVxDesignElectionPackage(searchDir)).toEqual(
+    packagePath
+  );
+});
+
+test('stageElectionPackageOnMockUsbDrive writes the layout machines look for', () => {
+  const searchDir = makeTemporaryDirectory();
+  const packagePath = join(searchDir, 'election-package-aaa-111.zip');
+  fs.writeFileSync(packagePath, 'election package contents');
+
+  const usbDriveDataPath = makeTemporaryDirectory();
+  const stagedPath = stageElectionPackageOnMockUsbDrive(
+    packagePath,
+    usbDriveDataPath
+  );
+
+  expect(stagedPath).toEqual(
+    join(
+      usbDriveDataPath,
+      QUICK_CONFIGURE_ELECTION_DIR,
+      ELECTION_PACKAGE_FOLDER,
+      STAGED_ELECTION_PACKAGE_FILE_NAME
+    )
+  );
+  expect(fs.readFileSync(stagedPath, 'utf-8')).toEqual(
+    'election package contents'
+  );
+});
+
+test('stageElectionPackageOnMockUsbDrive replaces the staged package and nothing else', () => {
+  const searchDir = makeTemporaryDirectory();
+  const firstPackagePath = join(searchDir, 'election-package-aaa-111.zip');
+  fs.writeFileSync(firstPackagePath, 'first');
+  const secondPackagePath = join(searchDir, 'election-package-bbb-222.zip');
+  fs.writeFileSync(secondPackagePath, 'second');
+
+  const usbDriveDataPath = makeTemporaryDirectory();
+  const unrelatedPath = join(usbDriveDataPath, 'cast-vote-records/cvrs.jsonl');
+  fs.mkdirSync(join(usbDriveDataPath, 'cast-vote-records'));
+  fs.writeFileSync(unrelatedPath, 'cvrs');
+
+  const firstStagedPath = stageElectionPackageOnMockUsbDrive(
+    firstPackagePath,
+    usbDriveDataPath
+  );
+  const secondStagedPath = stageElectionPackageOnMockUsbDrive(
+    secondPackagePath,
+    usbDriveDataPath
+  );
+
+  expect(secondStagedPath).toEqual(firstStagedPath);
+  expect(fs.readFileSync(secondStagedPath, 'utf-8')).toEqual('second');
+  expect(fs.readFileSync(unrelatedPath, 'utf-8')).toEqual('cvrs');
+});
+
+test('stageElectionPackageOnMockUsbDrive skips a package that is already staged', () => {
+  const searchDir = makeTemporaryDirectory();
+  const packagePath = join(searchDir, 'election-package-aaa-111.zip');
+  fs.writeFileSync(packagePath, 'election package contents');
+
+  const usbDriveDataPath = makeTemporaryDirectory();
+  const stagedPath = stageElectionPackageOnMockUsbDrive(
+    packagePath,
+    usbDriveDataPath
+  );
+
+  // The staged package can be selected from the dev dock and staged again,
+  // which would otherwise copy the file onto itself.
+  expect(
+    stageElectionPackageOnMockUsbDrive(stagedPath, usbDriveDataPath)
+  ).toEqual(stagedPath);
+  expect(fs.readFileSync(stagedPath, 'utf-8')).toEqual(
+    'election package contents'
+  );
+});

--- a/libs/dev-dock/backend/src/quick_configure.test.ts
+++ b/libs/dev-dock/backend/src/quick_configure.test.ts
@@ -8,7 +8,7 @@ import {
   STAGED_ELECTION_PACKAGE_FILE_NAME,
   findLatestVxDesignElectionPackage,
   stageElectionPackageOnMockUsbDrive,
-} from './quick_configure';
+} from './quick_configure.js';
 
 function writeFileWithModifiedTime(path: string, mtime: Date): void {
   fs.mkdirSync(join(path, '..'), { recursive: true });

--- a/libs/dev-dock/backend/src/quick_configure.ts
+++ b/libs/dev-dock/backend/src/quick_configure.ts
@@ -1,0 +1,84 @@
+import { dirname, join, resolve } from 'node:path';
+import { Optional, iter } from '@votingworks/basics';
+import {
+  FileSystemEntry,
+  FileSystemEntryType,
+  listDirectory,
+} from '@votingworks/fs';
+import { writeMockFileTree } from '@votingworks/usb-drive';
+import { ELECTION_PACKAGE_FOLDER } from '@votingworks/utils';
+
+/**
+ * The election directory that the `QuickConfigure` feature owns on the
+ * mock USB drive.
+ */
+export const QUICK_CONFIGURE_ELECTION_DIR = 'dev-election';
+
+/**
+ * The name quick configure stages packages under. A fixed name means each
+ * staging replaces the last, so the directory never accumulates old packages.
+ */
+export const STAGED_ELECTION_PACKAGE_FILE_NAME = 'election-package.zip';
+
+const ELECTION_PACKAGE_FILE_PREFIX = 'election-package-';
+
+/**
+ * Finds the most recently exported VxDesign election package across all
+ * jurisdictions. Ballot zips are written to the same directories, so only files
+ * named like election packages are considered.
+ */
+export async function findLatestVxDesignElectionPackage(
+  searchDir: string
+): Promise<Optional<string>> {
+  const electionPackages: FileSystemEntry[] = [];
+
+  // Depth 2 covers `<search dir>/<jurisdiction>/<package>.zip`. Errors mean
+  // VxDesign hasn't written anything here yet, which is not a failure.
+  for await (const result of listDirectory(searchDir, { depth: 2 })) {
+    if (result.isErr()) continue;
+
+    const entry = result.ok();
+    if (
+      entry.type === FileSystemEntryType.File &&
+      // Only packages inside a jurisdiction directory, not loose at the top.
+      dirname(entry.path) !== searchDir &&
+      entry.name.startsWith(ELECTION_PACKAGE_FILE_PREFIX) &&
+      entry.name.endsWith('.zip')
+    ) {
+      electionPackages.push(entry);
+    }
+  }
+
+  return iter(electionPackages).maxBy((entry) => entry.mtime.getTime())?.path;
+}
+
+/**
+ * Copies an election package onto the mock USB drive in the layout machines
+ * look for: `<drive>/<election dir>/election-packages/<package>.zip`. Only the
+ * directory quick configure owns is written, leaving the rest of the drive's
+ * contents alone. Returns the path the package was copied to.
+ */
+export function stageElectionPackageOnMockUsbDrive(
+  electionPackagePath: string,
+  usbDriveDataPath: string
+): string {
+  const electionDirPath = join(usbDriveDataPath, QUICK_CONFIGURE_ELECTION_DIR);
+  const stagedElectionPackagePath = join(
+    electionDirPath,
+    ELECTION_PACKAGE_FOLDER,
+    STAGED_ELECTION_PACKAGE_FILE_NAME
+  );
+
+  // A previously staged package can be selected again from the dev dock, in
+  // which case it's already where machines look for it and copying it would
+  // just copy the file onto itself.
+  if (resolve(electionPackagePath) !== resolve(stagedElectionPackagePath)) {
+    writeMockFileTree(electionDirPath, {
+      [ELECTION_PACKAGE_FOLDER]: {
+        [STAGED_ELECTION_PACKAGE_FILE_NAME]: electionPackagePath,
+      },
+    });
+  }
+
+  return stagedElectionPackagePath;
+}

--- a/libs/dev-dock/frontend/src/dev_dock.test.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.test.tsx
@@ -107,6 +107,7 @@ beforeEach(() => {
     inputPath: './libs/fixtures/data/electionGeneral/election.json',
     resolvedPath: '/full-path',
     arePollWorkerCardPinsEnabled: false,
+    isElectionPackage: false,
   });
   featureFlagMock.enableFeatureFlag(
     BooleanEnvironmentVariableName.ENABLE_DEV_DOCK
@@ -263,6 +264,7 @@ test('election selector', async () => {
     inputPath: './libs/fixtures/data/electionFamousNames2021/election.json',
     resolvedPath: '/full-path',
     arePollWorkerCardPinsEnabled: false,
+    isElectionPackage: false,
   });
   userEvent.selectOptions(
     electionSelector,

--- a/libs/utils/src/mocking.ts
+++ b/libs/utils/src/mocking.ts
@@ -17,3 +17,16 @@ export function getMockStateRootDir(repoRoot: string): string {
   const nodeEnv = rawNodeEnv?.replace(/[^a-zA-Z0-9_-]/g, '_') || 'development';
   return join(repoRoot, '.mock-state', nodeEnv);
 }
+
+/**
+ * Returns VxDesign's development workspace, where it writes exported election
+ * packages and ballots.
+ *
+ * Shared so that dev tooling reading those exports (the dev dock) and VxDesign
+ * itself agree on one location. Note that VxDesign also honors a `WORKSPACE`
+ * environment variable, which other processes can't discover — so a custom
+ * workspace won't be visible to dev tooling.
+ */
+export function getDesignDevWorkspaceDir(repoRoot: string): string {
+  return join(repoRoot, 'apps/design/backend/dev-workspace');
+}


### PR DESCRIPTION
## Overview

Adds a `quickConfigure()` function to `libs/dev-dock/backend`. At a high level the function automates the manual steps of copying an election package to the mock USB drive and performing the unconfigure/reconfigure card dance.

## Demo Video or Screenshot

See https://votingworks.slack.com/archives/CEL6D3GAD/p1786135466821039?thread_ts=1785888421.983059&cid=CEL6D3GAD, but will post app-specific videos in subsequent PRs.

## Testing Plan

Added tests

