### PR TITLE
Dev dock: wire apps to quick configure feature

### DIFF
--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -519,17 +519,11 @@ export function buildApp(
   workspace: Workspace,
   usbDrive: UsbDrive,
   stateMachine?: PaperHandlerStateMachine,
-  paperHandler?: PaperHandlerDriverInterface
+  paperHandler?: PaperHandlerDriverInterface,
+  /* istanbul ignore next */
+  api = buildApi(auth, usbDrive, logger, workspace, stateMachine, paperHandler)
 ): Application {
   const app: Application = express();
-  const api = buildApi(
-    auth,
-    usbDrive,
-    logger,
-    workspace,
-    stateMachine,
-    paperHandler
-  );
   app.use('/api', grout.buildRouter(api, express));
   return app;
 }

--- a/apps/mark-scan/backend/src/app.ts
+++ b/apps/mark-scan/backend/src/app.ts
@@ -520,7 +520,6 @@ export function buildApp(
   usbDrive: UsbDrive,
   stateMachine?: PaperHandlerStateMachine,
   paperHandler?: PaperHandlerDriverInterface,
-  /* istanbul ignore next */
   api = buildApi(auth, usbDrive, logger, workspace, stateMachine, paperHandler)
 ): Application {
   const app: Application = express();

--- a/apps/mark-scan/backend/src/server.ts
+++ b/apps/mark-scan/backend/src/server.ts
@@ -19,7 +19,7 @@ import {
   startCpuMetricsLogging,
 } from '@votingworks/backend';
 import { useDevDockRouter } from '@votingworks/dev-dock-backend';
-import { buildApp } from './app.js';
+import { buildApi, buildApp } from './app.js';
 import { Workspace } from './util/workspace.js';
 import { getPaperHandlerStateMachine } from './custom-paper-handler/state_machine.js';
 import { getDefaultAuth, getUserRole } from './util/auth.js';
@@ -114,16 +114,32 @@ export async function start({
 
   await initializeSystemAudio();
 
+  const api = buildApi(
+    resolvedAuth,
+    usbDrive,
+    logger,
+    workspace,
+    stateMachine,
+    driver
+  );
   const app = buildApp(
     resolvedAuth,
     logger,
     workspace,
     usbDrive,
     stateMachine,
-    driver
+    driver,
+    api
   );
 
-  useDevDockRouter(app, express, {});
+  useDevDockRouter(app, express, {
+    quickConfigure: {
+      unconfigure: () => api.methods().unconfigureMachine(),
+      configure: async () => {
+        (await api.methods().configureElectionPackageFromUsb()).unsafeUnwrap();
+      },
+    },
+  });
 
   // Start periodic CPU metrics logging
   startCpuMetricsLogging(logger);

--- a/apps/mark-scan/backend/src/server.ts
+++ b/apps/mark-scan/backend/src/server.ts
@@ -132,6 +132,7 @@ export async function start({
     api
   );
 
+  /* istanbul ignore next - internal dev use only */
   useDevDockRouter(app, express, {
     quickConfigure: {
       unconfigure: () => api.methods().unconfigureMachine(),

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -76,7 +76,7 @@ const TEST_UPS_USER_PASS_REASON = 'UPS connected and fully charged per user.';
 const TEST_UPS_USER_FAIL_REASON =
   'UPS not connected or not fully charged per user.';
 
-interface Context {
+export interface Context {
   audioPlayer?: AudioPlayer;
   auth: InsertedSmartCardAuthApi;
   barcodeClient: barcodes.BarcodeReader;
@@ -663,9 +663,12 @@ export function buildApi(ctx: Context) {
 
 export type Api = ReturnType<typeof buildApi>;
 
-export function buildApp(ctx: Context): Application {
+export function buildApp(
+  ctx: Context,
+  /* istanbul ignore next */
+  api = buildApi(ctx)
+): Application {
   const app: Application = express();
-  const api = buildApi(ctx);
   app.use('/api', grout.buildRouter(api, express));
 
   setUpBarcodeActivation(ctx);

--- a/apps/mark/backend/src/app.ts
+++ b/apps/mark/backend/src/app.ts
@@ -663,11 +663,7 @@ export function buildApi(ctx: Context) {
 
 export type Api = ReturnType<typeof buildApi>;
 
-export function buildApp(
-  ctx: Context,
-  /* istanbul ignore next */
-  api = buildApi(ctx)
-): Application {
+export function buildApp(ctx: Context, api = buildApi(ctx)): Application {
   const app: Application = express();
   app.use('/api', grout.buildRouter(api, express));
 

--- a/apps/mark/backend/src/server.test.ts
+++ b/apps/mark/backend/src/server.test.ts
@@ -98,7 +98,7 @@ test('start passes context to `buildApp`', async () => {
     workspace,
   });
 
-  expect(buildAppMock).toHaveBeenCalledWith({
+  expect(buildAppMock.mock.lastCall?.[0]).toEqual({
     audioPlayer: mockAudioPlayer,
     auth: expect.anything(),
     barcodeClient: expect.anything(),

--- a/apps/mark/backend/src/server.ts
+++ b/apps/mark/backend/src/server.ts
@@ -10,7 +10,7 @@ import {
   BooleanEnvironmentVariableName,
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
-import { buildApp } from './app.js';
+import { buildApp, buildApi, Context } from './app.js';
 import { Workspace } from './util/workspace.js';
 import { getDefaultAuth, getUserRole } from './util/auth.js';
 import { BarcodeClient } from './barcodes/index.js';
@@ -65,7 +65,7 @@ export async function start({
   const audioInfo = await initializeAudio(logger);
   const audioPlayer = new AudioPlayer(NODE_ENV, logger, audioInfo.builtin.name);
 
-  const app = buildApp({
+  const context: Context = {
     audioPlayer,
     auth: resolvedAuth,
     barcodeClient,
@@ -73,7 +73,9 @@ export async function start({
     workspace,
     usbDrive,
     printer,
-  });
+  };
+  const api = buildApi(context);
+  const app = buildApp(context, api);
 
   /* istanbul ignore next - internal dev use only */
   useDevDockRouter(app, express, {
@@ -91,6 +93,12 @@ export async function start({
     getPatInputConnected: () => getMockPatInputConnected(),
     setPatInputConnected: (connected: boolean) =>
       setMockPatInputConnected(connected),
+    quickConfigure: {
+      unconfigure: () => api.methods().unconfigureMachine(),
+      configure: async () => {
+        (await api.methods().configureElectionPackageFromUsb()).unsafeUnwrap();
+      },
+    },
   });
 
   // Start periodic CPU metrics logging

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -711,7 +711,6 @@ export function buildApp(
     usbDrive: UsbDrive;
     logger: Logger;
   },
-  /* istanbul ignore next */
   api = buildApi({
     audioPlayer,
     auth,

--- a/apps/scan/backend/src/app.ts
+++ b/apps/scan/backend/src/app.ts
@@ -693,25 +693,8 @@ export function buildApi({
 
 export type Api = ReturnType<typeof buildApi>;
 
-export function buildApp({
-  audioPlayer,
-  auth,
-  machine,
-  workspace,
-  usbDrive,
-  printer,
-  logger,
-}: {
-  audioPlayer: AudioPlayerInterface;
-  auth: InsertedSmartCardAuthApi;
-  machine: PrecinctScannerStateMachine;
-  workspace: Workspace;
-  printer: FujitsuThermalPrinterInterface;
-  usbDrive: UsbDrive;
-  logger: Logger;
-}): Application {
-  const app: Application = express();
-  const api = buildApi({
+export function buildApp(
+  {
     audioPlayer,
     auth,
     machine,
@@ -719,7 +702,27 @@ export function buildApp({
     usbDrive,
     printer,
     logger,
-  });
+  }: {
+    audioPlayer: AudioPlayerInterface;
+    auth: InsertedSmartCardAuthApi;
+    machine: PrecinctScannerStateMachine;
+    workspace: Workspace;
+    printer: FujitsuThermalPrinterInterface;
+    usbDrive: UsbDrive;
+    logger: Logger;
+  },
+  /* istanbul ignore next */
+  api = buildApi({
+    audioPlayer,
+    auth,
+    machine,
+    workspace,
+    usbDrive,
+    printer,
+    logger,
+  })
+): Application {
+  const app: Application = express();
   app.use('/api', grout.buildRouter(api, express));
   return app;
 }

--- a/apps/scan/backend/src/server.test.ts
+++ b/apps/scan/backend/src/server.test.ts
@@ -75,7 +75,7 @@ test('start passes context to `buildApp`', async () => {
     logger,
   });
 
-  expect(buildAppMock).toHaveBeenCalledWith({
+  expect(buildAppMock.mock.lastCall?.[0]).toEqual({
     audioPlayer: mockAudioPlayer,
     auth: expect.anything(),
     machine: expect.anything(),

--- a/apps/scan/backend/src/server.ts
+++ b/apps/scan/backend/src/server.ts
@@ -106,6 +106,7 @@ export async function start({
   const api = buildApi(context);
   const app = buildApp(context, api);
 
+  /* istanbul ignore next - internal dev use only */
   useDevDockRouter(app, express, {
     quickConfigure: {
       unconfigure: () => api.methods().unconfigureElection(),

--- a/apps/scan/backend/src/server.ts
+++ b/apps/scan/backend/src/server.ts
@@ -18,7 +18,7 @@ import {
   FujitsuThermalPrinterInterface,
   getFujitsuThermalPrinter,
 } from '@votingworks/fujitsu-thermal-printer';
-import { buildApp } from './app.js';
+import { buildApi, buildApp } from './app.js';
 import { NODE_ENV, PORT } from './globals.js';
 import { Workspace } from './util/workspace.js';
 import * as scanner from './scanner.js';
@@ -94,7 +94,7 @@ export async function start({
   );
   await resolvedAudioPlayer.setIsScreenReaderEnabled(isScreenReaderEnabled);
 
-  const app = buildApp({
+  const context: Parameters<typeof buildApi>[0] = {
     audioPlayer: resolvedAudioPlayer,
     auth,
     machine: precinctScannerStateMachine,
@@ -102,9 +102,19 @@ export async function start({
     usbDrive: resolvedUsbDrive,
     printer: resolvedPrinter,
     logger,
-  });
+  };
+  const api = buildApi(context);
+  const app = buildApp(context, api);
 
   useDevDockRouter(app, express, {
+    quickConfigure: {
+      unconfigure: () => api.methods().unconfigureElection(),
+      configure: async () => {
+        (
+          await api.methods().configureFromElectionPackageOnUsbDrive()
+        ).unsafeUnwrap();
+      },
+    },
     printerConfig: 'fujitsu',
     mockPdiScanner,
   });

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -502,7 +502,6 @@ function buildApi(
         electionPathToAbsolute(electionInfo.inputPath),
         usbDriveHandler.getDataPath()
       );
-      usbDriveHandler.insert();
 
       // Unconfigure the machine. Remove card to avoid possible election key mismatch.
       await removeCard();
@@ -510,6 +509,7 @@ function buildApi(
 
       // Re-configure with the selected election.
       await insertCard('election_manager', devDockDir);
+      usbDriveHandler.insert();
       try {
         await waitForUsbDriveToMount(usbDriveHandler);
         await mockSpec.quickConfigure.configure();

--- a/libs/dev-dock/frontend/src/dev_dock.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.tsx
@@ -667,9 +667,7 @@ function QuickConfigureButton(): JSX.Element {
   return (
     <IconButton
       isActive={quickConfigureMutation.isLoading}
-      disabled={
-        !isElectionPackageSelected || quickConfigureMutation.isLoading
-      }
+      disabled={!isElectionPackageSelected || quickConfigureMutation.isLoading}
       onClick={() => {
         setError(undefined);
         quickConfigureMutation.mutate();

--- a/libs/grout/src/grout.test.ts
+++ b/libs/grout/src/grout.test.ts
@@ -612,6 +612,17 @@ test('can access methods directly for testing', async () => {
   } as const;
   const api = createApi(methods);
   expect(api.methods()).toEqual(methods);
+
+  // Also allowed in development, where dev-only tooling drives an app's own API
+  // rather than duplicating its logic.
+  vi.stubEnv('NODE_ENV', 'development');
+  expect(api.methods()).toEqual(methods);
+
+  // But not in production, where it would bypass middleware.
+  vi.stubEnv('NODE_ENV', 'production');
+  expect(() => api.methods()).toThrow();
+
+  vi.unstubAllEnvs();
 });
 
 test('client can handle various JS language property gets without triggering RPC', async () => {

--- a/libs/grout/src/server.ts
+++ b/libs/grout/src/server.ts
@@ -69,9 +69,12 @@ export interface Api<
   /** @private Grout internal use only */
   _middlewares?: Middlewares<Context>;
   /**
-   * Expose `methods()` for testing the API methods directly without having to
+   * Expose `methods()` for calling the API methods directly without having to
    * run a server. Note that using this approach will bypass any middleware, so
    * it's not recommended for most testing.
+   *
+   * Allowed in development as well as tests, so that dev-only tooling (e.g. the
+   * dev dock) can drive an app's own API instead of duplicating its logic.
    */
   methods(): Readonly<Methods>;
 }
@@ -172,7 +175,10 @@ export function createApi<
     _methods: methods,
     _middlewares: middlewares,
     methods(): Readonly<Methods> {
-      assert(process.env.NODE_ENV === 'test');
+      assert(
+        process.env.NODE_ENV === 'test' ||
+          process.env.NODE_ENV === 'development'
+      );
       return methods;
     },
   };


### PR DESCRIPTION
## Overview

Reopening this PR because https://github.com/votingworks/vxsuite/pull/9126 was unable to retarget base branch after the upstack branches were merged.

Wires up apps with inserted smart card auth to dev dock's quick configure. Dipped smart card auth is a separate case that we'll need to handle later.

## Demo Video or Screenshot



https://github.com/user-attachments/assets/cade1d95-4016-4b6e-80aa-1c34cd65aeee


https://github.com/user-attachments/assets/7656d368-59e4-4888-aec4-be86bf634a90

https://github.com/user-attachments/assets/e066056a-1647-421f-9e5c-f36019a3214a



## Testing Plan

Manually tested apps; isolated dev dock behavior has automated tests added in previous PRs.
