### PR TITLE
fix(db): store the schema digest inside the database, fail in production on mismatch

### DIFF
--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@votingworks/basics": "workspace:*",
     "@votingworks/logging": "workspace:*",
+    "@votingworks/utils": "workspace:*",
     "better-sqlite3": "8.2.0",
     "debug": "4.3.4"
   },

--- a/libs/db/src/client.test.ts
+++ b/libs/db/src/client.test.ts
@@ -1,10 +1,15 @@
-import { expect, test, vi } from 'vitest';
+import { afterEach, expect, test, vi } from 'vitest';
 import { SqliteError } from 'better-sqlite3';
 import * as fs from 'node:fs';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { makeTemporaryFile } from '@votingworks/fixtures';
 import { mockBaseLogger } from '@votingworks/logging';
 import { Client, DbConnectionOptions, Statement } from './client';
+import { SchemaDigestMismatchError } from './schema_digest_mismatch_error';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 test('file database client', () => {
   const dbFile = makeTemporaryFile();
@@ -165,6 +170,17 @@ test('reset file database client', () => {
     (client.one('SELECT COUNT(*) as count FROM users') as { count: number })
       .count
   ).toEqual(0);
+});
+
+test('reset file database client that has not connected yet', () => {
+  const dbFile = makeTemporaryFile();
+  const client = Client.fileClient(dbFile, mockBaseLogger({ fn: vi.fn }));
+
+  client.reset();
+
+  client.exec('create table muppets (name varchar(255) not null)');
+  client.run('insert into muppets (name) values (?)', 'Kermit');
+  expect(client.all('select * from muppets')).toEqual([{ name: 'Kermit' }]);
 });
 
 test('memory database client, reset', () => {
@@ -385,6 +401,207 @@ test('connect errors', () => {
     mockBaseLogger({ fn: vi.fn })
   );
   expect(() => client.connect()).toThrow();
+});
+
+const SCHEMA_V1 = 'create table users (id text primary key);';
+const SCHEMA_V2 = 'create table users (id text primary key, name text);';
+
+function makeSchemaFile(content: string): string {
+  return makeTemporaryFile({ content });
+}
+
+function makeDbWithSchema(schemaPath: string): string {
+  const dbFile = makeTemporaryFile();
+  const client = Client.fileClient(
+    dbFile,
+    mockBaseLogger({ fn: vi.fn }),
+    schemaPath
+  );
+  client.run(`insert into users (id) values (?)`, 'kermit');
+  return dbFile;
+}
+
+function stubProductionEnv(): void {
+  vi.stubEnv('NODE_ENV', 'production');
+  vi.stubEnv('REACT_APP_VX_DEV', '');
+  vi.stubEnv('REACT_APP_IS_INTEGRATION_TEST', '');
+  vi.stubEnv('IS_INTEGRATION_TEST', '');
+  vi.stubEnv('DEPLOY_ENV', '');
+}
+
+function backupFilesFor(dbFile: string): string[] {
+  return fs
+    .readdirSync(dirname(dbFile))
+    .filter((name) => name.startsWith(`${basename(dbFile)}.backup-`));
+}
+
+test('stores the schema digest in the database rather than a sidecar file', () => {
+  const schemaFile = makeSchemaFile(SCHEMA_V1);
+  const dbFile = makeDbWithSchema(schemaFile);
+
+  expect(fs.existsSync(`${dbFile}.digest`)).toEqual(false);
+
+  const client = Client.fileClient(
+    dbFile,
+    mockBaseLogger({ fn: vi.fn }),
+    schemaFile
+  );
+  expect(client.one('select digest from vx_schema_digest')).toEqual({
+    digest: expect.stringMatching(/^[0-9a-f]{64}$/),
+  });
+
+  // reopening with an unchanged schema preserves the data
+  expect(client.one('select count(*) as count from users')).toEqual({
+    count: 1,
+  });
+});
+
+test('reopens a database whose digest is stored inside it even with no sidecar', () => {
+  const schemaFile = makeSchemaFile(SCHEMA_V1);
+  const dbFile = makeDbWithSchema(schemaFile);
+
+  // a stale sidecar left over from older software is ignored in favor of the
+  // digest stored in the database
+  fs.writeFileSync(`${dbFile}.digest`, 'stale-digest-from-older-software');
+
+  const client = Client.fileClient(
+    dbFile,
+    mockBaseLogger({ fn: vi.fn }),
+    schemaFile
+  );
+  expect(client.one('select count(*) as count from users')).toEqual({
+    count: 1,
+  });
+  expect(backupFilesFor(dbFile)).toEqual([]);
+});
+
+test('resets the database when the schema changes outside production', () => {
+  const dbFile = makeDbWithSchema(makeSchemaFile(SCHEMA_V1));
+
+  const client = Client.fileClient(
+    dbFile,
+    mockBaseLogger({ fn: vi.fn }),
+    makeSchemaFile(SCHEMA_V2)
+  );
+
+  // reset to the new schema, losing the old data
+  expect(client.one('select count(*) as count from users')).toEqual({
+    count: 0,
+  });
+  client.run(`insert into users (id, name) values (?, ?)`, 'fozzie', 'Fozzie');
+
+  // the old database was preserved alongside it
+  expect(backupFilesFor(dbFile)).toHaveLength(1);
+});
+
+test('refuses to reset the database when the schema changes in production', () => {
+  const dbFile = makeDbWithSchema(makeSchemaFile(SCHEMA_V1));
+  const contentsBefore = fs.readFileSync(dbFile);
+
+  stubProductionEnv();
+
+  expect(() =>
+    Client.fileClient(
+      dbFile,
+      mockBaseLogger({ fn: vi.fn }),
+      makeSchemaFile(SCHEMA_V2)
+    )
+  ).toThrow(SchemaDigestMismatchError);
+
+  // the database is left exactly as it was
+  expect(fs.readFileSync(dbFile)).toEqual(contentsBefore);
+  expect(backupFilesFor(dbFile)).toEqual([]);
+});
+
+test('adopts a legacy schema digest sidecar written by older software', () => {
+  const schemaFile = makeSchemaFile(SCHEMA_V1);
+  const dbFile = makeDbWithSchema(schemaFile);
+
+  // simulate a database created by software that stored the digest alongside
+  // the database instead of inside it
+  const { digest } = Client.fileClient(
+    dbFile,
+    mockBaseLogger({ fn: vi.fn }),
+    schemaFile
+  ).one('select digest from vx_schema_digest') as { digest: string };
+  const clientToStrip = Client.fileClient(
+    dbFile,
+    mockBaseLogger({ fn: vi.fn })
+  );
+  clientToStrip.exec('drop table vx_schema_digest');
+  fs.writeFileSync(`${dbFile}.digest`, digest);
+
+  stubProductionEnv();
+
+  const client = Client.fileClient(
+    dbFile,
+    mockBaseLogger({ fn: vi.fn }),
+    schemaFile
+  );
+
+  // the data survives, the digest moves into the database, and the sidecar goes
+  expect(client.one('select count(*) as count from users')).toEqual({
+    count: 1,
+  });
+  expect(client.one('select digest from vx_schema_digest')).toEqual({ digest });
+  expect(fs.existsSync(`${dbFile}.digest`)).toEqual(false);
+});
+
+test('treats a stale legacy sidecar as a schema mismatch', () => {
+  const dbFile = makeDbWithSchema(makeSchemaFile(SCHEMA_V1));
+  const clientToStrip = Client.fileClient(
+    dbFile,
+    mockBaseLogger({ fn: vi.fn })
+  );
+  clientToStrip.exec('drop table vx_schema_digest');
+  fs.writeFileSync(`${dbFile}.digest`, 'digest-from-an-older-schema');
+
+  stubProductionEnv();
+
+  expect(() =>
+    Client.fileClient(
+      dbFile,
+      mockBaseLogger({ fn: vi.fn }),
+      makeSchemaFile(SCHEMA_V1)
+    )
+  ).toThrow(SchemaDigestMismatchError);
+});
+
+test('refuses to reset an unreadable database in production', () => {
+  const dbFile = makeTemporaryFile({
+    content: 'this is not a sqlite database',
+  });
+
+  stubProductionEnv();
+
+  expect(() =>
+    Client.fileClient(
+      dbFile,
+      mockBaseLogger({ fn: vi.fn }),
+      makeSchemaFile(SCHEMA_V1)
+    )
+  ).toThrow(SchemaDigestMismatchError);
+  expect(fs.readFileSync(dbFile, 'utf-8')).toEqual(
+    'this is not a sqlite database'
+  );
+});
+
+test('creates the schema in an empty database file', () => {
+  const dbFile = makeTemporaryFile();
+  fs.writeFileSync(`${dbFile}.digest`, 'stale-sidecar');
+
+  stubProductionEnv();
+
+  const client = Client.fileClient(
+    dbFile,
+    mockBaseLogger({ fn: vi.fn }),
+    makeSchemaFile(SCHEMA_V1)
+  );
+
+  expect(client.one('select count(*) as count from users')).toEqual({
+    count: 0,
+  });
+  expect(fs.existsSync(`${dbFile}.digest`)).toEqual(false);
 });
 
 test('vacuuming reduces file size', () => {

--- a/libs/db/src/client.ts
+++ b/libs/db/src/client.ts
@@ -1,17 +1,41 @@
 import { assert } from '@votingworks/basics';
 import { BaseLogger, LogEventId, LogSource } from '@votingworks/logging';
+import {
+  isIntegrationTest,
+  isNodeEnvProduction,
+  isStagingDeploy,
+  isVxDev,
+} from '@votingworks/utils';
 import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
 import makeDebug from 'debug';
 import * as fs from 'node:fs';
 import Database from 'better-sqlite3';
 import { dirname, join } from 'node:path';
+import { SchemaDigestMismatchError } from './schema_digest_mismatch_error';
 
 type Database = Database.Database;
 
 const debug = makeDebug('db-client');
 
 const MEMORY_DB_PATH = ':memory:';
+
+/**
+ * Table holding the digest of the schema the database was created with. It is
+ * stored inside the database rather than in a sidecar file so that it cannot
+ * become separated from the data it describes, e.g. when a database file is
+ * copied, moved, or restored from a backup.
+ */
+const SCHEMA_DIGEST_TABLE = 'vx_schema_digest';
+
+function shouldResetOnSchemaDigestMismatch(): boolean {
+  return (
+    !isNodeEnvProduction() ||
+    isVxDev() ||
+    isIntegrationTest() ||
+    isStagingDeploy()
+  );
+}
 
 /**
  * Types supported for database values, i.e. what can be passed to `one`, `all`,
@@ -54,7 +78,7 @@ export class Client {
     private readonly logger: BaseLogger,
     private readonly schemaPath?: string,
     private readonly connectionOptions?: DbConnectionOptions
-  ) { }
+  ) {}
 
   /**
    * Gets the path to the SQLite database file.
@@ -77,6 +101,48 @@ export class Client {
     assert(typeof this.schemaPath === 'string', 'schemaPath is required');
     const schemaSql = fs.readFileSync(this.schemaPath, 'utf-8');
     return createHash('sha256').update(schemaSql).digest('hex');
+  }
+
+  /**
+   * Reads the schema digest stored in the database, if any.
+   */
+  private readStoredSchemaDigest(): string | undefined {
+    try {
+      const table = this.one(
+        `select name from sqlite_master where type = 'table' and name = ?`,
+        SCHEMA_DIGEST_TABLE
+      ) as { name: string } | undefined;
+
+      if (!table) {
+        return undefined;
+      }
+
+      const row = this.one(`select digest from ${SCHEMA_DIGEST_TABLE}`) as
+        | { digest: string }
+        | undefined;
+      return row?.digest;
+    } catch (error) {
+      // An unreadable or corrupt database has no usable digest, which is
+      // treated the same as a mismatched one: reset outside production, refuse
+      // to touch it in production.
+      debug('could not read stored schema digest: %s', error);
+      return undefined;
+    }
+  }
+
+  /**
+   * Stores the digest of the current schema file in the database, replacing any
+   * previously stored digest.
+   */
+  private writeSchemaDigest(): void {
+    this.exec(
+      `create table if not exists ${SCHEMA_DIGEST_TABLE} (digest text not null)`
+    );
+    this.run(`delete from ${SCHEMA_DIGEST_TABLE}`);
+    this.run(
+      `insert into ${SCHEMA_DIGEST_TABLE} (digest) values (?)`,
+      this.getSchemaDigest()
+    );
   }
 
   /**
@@ -117,45 +183,97 @@ export class Client {
       return client;
     }
 
-    const schemaDigestPath = `${dbPath}.digest`;
-    let schemaDigest: string | undefined;
-    try {
-      schemaDigest = fs.readFileSync(schemaDigestPath, 'utf-8').trim();
-    } catch {
-      debug(
-        'could not read %s, assuming the database needs to be created',
-        schemaDigestPath
-      );
-    }
     const newSchemaDigest = client.getSchemaDigest();
-    const shouldResetDatabase = newSchemaDigest !== schemaDigest;
 
-    if (shouldResetDatabase) {
-      debug(
-        'database schema has changed (%s ≉ %s)',
-        schemaDigest,
-        newSchemaDigest
-      );
-
-      try {
-        const backupPath = `${dbPath}.backup-${new Date()
-          .toISOString()
-          .replace(/[^\d]+/g, '-')
-          .replace(/-+$/, '')}`;
-        fs.renameSync(dbPath, backupPath);
-        debug('backed up database to be reset to %s', backupPath);
-      } catch {
-        // ignore for now
-      }
-
-      debug('resetting database to updated schema');
-      client.reset();
-      fs.writeFileSync(schemaDigestPath, newSchemaDigest, 'utf-8');
-    } else {
-      debug('database schema appears to be up to date');
+    // A zero-length file is treated as no database at all: it holds no data, so
+    // creating the schema in place loses nothing. Maybe creating the database
+    // was interrupted before anything could be written.
+    if (!fs.existsSync(dbPath) || fs.statSync(dbPath).size === 0) {
+      debug('no database at %s, creating it', dbPath);
+      client.create();
+      fs.rmSync(client.legacySchemaDigestSidecarPath(), { force: true });
+      return client;
     }
+
+    const schemaDigest =
+      client.readStoredSchemaDigest() ??
+      client.adoptLegacySchemaDigestSidecar(newSchemaDigest);
+
+    if (schemaDigest === newSchemaDigest) {
+      debug('database schema appears to be up to date');
+      return client;
+    }
+
+    debug(
+      'database schema has changed (%s ≉ %s)',
+      schemaDigest,
+      newSchemaDigest
+    );
+
+    if (!shouldResetOnSchemaDigestMismatch()) {
+      client.logger.log(
+        LogEventId.DatabaseSchemaMismatch,
+        'system',
+        {
+          message:
+            `Database at ${dbPath} was created with a different schema than ` +
+            `the currently running software expects. Refusing to reset it in ` +
+            `production because that would discard its data.`,
+          expectedDigest: newSchemaDigest,
+          actualDigest: schemaDigest,
+          disposition: 'failure',
+        },
+        debug
+      );
+      throw new SchemaDigestMismatchError(
+        dbPath,
+        newSchemaDigest,
+        schemaDigest
+      );
+    }
+
+    const backupPath = `${dbPath}.backup-${new Date()
+      .toISOString()
+      .replace(/[^\d]+/g, '-')
+      .replace(/-+$/, '')}`;
+    fs.renameSync(dbPath, backupPath);
+    debug('backed up database to be reset to %s', backupPath);
+
+    debug('resetting database to updated schema');
+    client.reset();
 
     return client;
+  }
+
+  private legacySchemaDigestSidecarPath(): string {
+    return `${this.dbPath}.digest`;
+  }
+
+  /**
+   * Adopts the digest from a legacy `<dbPath>.digest` sidecar file written by
+   * older software, storing it in the database and removing the sidecar. Older
+   * software wrote the digest alongside the database rather than inside it,
+   * which meant the two could become separated. Returns the adopted digest, or
+   * `undefined` if there is no sidecar to adopt.
+   */
+  private adoptLegacySchemaDigestSidecar(
+    currentSchemaDigest: string
+  ): string | undefined {
+    const sidecarPath = this.legacySchemaDigestSidecarPath();
+    let sidecarDigest: string;
+    try {
+      sidecarDigest = fs.readFileSync(sidecarPath, 'utf-8').trim();
+    } catch {
+      debug('no legacy schema digest sidecar at %s', sidecarPath);
+      return undefined;
+    }
+
+    debug('adopting legacy schema digest sidecar at %s', sidecarPath);
+    if (sidecarDigest === currentSchemaDigest) {
+      this.writeSchemaDigest();
+    }
+    fs.rmSync(sidecarPath, { force: true });
+    return sidecarDigest;
   }
 
   /**
@@ -444,6 +562,7 @@ export class Client {
     if (this.schemaPath) {
       const schema = fs.readFileSync(this.schemaPath, 'utf-8');
       this.exec(schema);
+      this.writeSchemaDigest();
     }
     this.logger.log(
       LogEventId.DatabaseCreateComplete,

--- a/libs/db/src/index.ts
+++ b/libs/db/src/index.ts
@@ -1,2 +1,3 @@
 /* istanbul ignore file */
 export * from './client';
+export * from './schema_digest_mismatch_error';

--- a/libs/db/src/schema_digest_mismatch_error.ts
+++ b/libs/db/src/schema_digest_mismatch_error.ts
@@ -1,0 +1,16 @@
+/**
+ * Thrown when an existing database was created with a different schema than the
+ * currently running software expects. Outside of production the database is
+ * reset instead, but in production resetting would silently discard data, so a
+ * human must decide how to proceed.
+ */
+export class SchemaDigestMismatchError extends Error {
+  constructor(dbPath: string, expectedDigest: string, actualDigest?: string) {
+    super(
+      `Database at ${dbPath} was created with schema digest ${
+        actualDigest ?? '(none)'
+      }, but the currently running software expects schema digest ${expectedDigest}. ` +
+        `Refusing to reset the database because that would discard its data.`
+    );
+  }
+}

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -214,6 +214,10 @@ IDs are logged with each log to identify the log being written.
 **Type:** [system-action](#system-action)
 **Description:** Database reset. Success or failure indicated by disposition.
 **Machines:** All
+### database-schema-mismatch
+**Type:** [system-action](#system-action)
+**Description:** An existing database was created with a different schema than the currently running software expects. Outside of production the database is reset, but in production it is left untouched and the application refuses to start.
+**Machines:** All
 ### file-read-error
 **Type:** [system-action](#system-action)
 **Description:** A system action failed to read a file from disk.

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -400,6 +400,11 @@ eventId = "database-reset-complete"
 eventType = "system-action"
 documentationMessage = "Database reset. Success or failure indicated by disposition."
 
+[Events.DatabaseSchemaMismatch]
+eventId = "database-schema-mismatch"
+eventType = "system-action"
+documentationMessage = "An existing database was created with a different schema than the currently running software expects. Outside of production the database is reset, but in production it is left untouched and the application refuses to start."
+
 [Events.FileReadError]
 eventId = "file-read-error"
 eventType = "system-action"

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -116,6 +116,7 @@ export enum LogEventId {
   DatabaseCreateComplete = 'database-create-complete',
   DatabaseResetInit = 'database-reset-init',
   DatabaseResetComplete = 'database-reset-complete',
+  DatabaseSchemaMismatch = 'database-schema-mismatch',
   FileReadError = 'file-read-error',
   DmVerityBoot = 'dmverity-boot',
   MachineBootInit = 'machine-boot-init',
@@ -586,6 +587,13 @@ const DatabaseResetComplete: LogDetails = {
   eventType: LogEventType.SystemAction,
   documentationMessage:
     'Database reset. Success or failure indicated by disposition.',
+};
+
+const DatabaseSchemaMismatch: LogDetails = {
+  eventId: LogEventId.DatabaseSchemaMismatch,
+  eventType: LogEventType.SystemAction,
+  documentationMessage:
+    'An existing database was created with a different schema than the currently running software expects. Outside of production the database is reset, but in production it is left untouched and the application refuses to start.',
 };
 
 const FileReadError: LogDetails = {
@@ -1623,6 +1631,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return DatabaseResetInit;
     case LogEventId.DatabaseResetComplete:
       return DatabaseResetComplete;
+    case LogEventId.DatabaseSchemaMismatch:
+      return DatabaseSchemaMismatch;
     case LogEventId.FileReadError:
       return FileReadError;
     case LogEventId.DmVerityBoot:

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -215,6 +215,8 @@ pub enum EventId {
     DatabaseResetInit,
     #[serde(rename = "database-reset-complete")]
     DatabaseResetComplete,
+    #[serde(rename = "database-schema-mismatch")]
+    DatabaseSchemaMismatch,
     #[serde(rename = "file-read-error")]
     FileReadError,
     #[serde(rename = "dmverity-boot")]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3748,6 +3748,9 @@ importers:
       '@votingworks/logging':
         specifier: workspace:*
         version: link:../logging
+      '@votingworks/utils':
+        specifier: workspace:*
+        version: link:../utils
       better-sqlite3:
         specifier: 8.2.0
         version: 8.2.0


### PR DESCRIPTION
## Overview

Refs #7897 

`Client.fileClient` compared a `<dbPath>.digest` sidecar file against the sha256 of the running software's `schema.sql` and, on mismatch, renamed the database aside and created an empty one. This (effectively) silently discard the database on mismatch and complicated the upcoming backup & restore feature for VxAdmin.

The digest now lives in a `vx_schema_digest` table inside the database, ensuring they stay together. On mismatch, production throws `SchemaDigestMismatchError` and leaves the database untouched for possible manual recovery. Outside production (i.e. dev & tests) the previous move-aside-and-reset behavior is kept as a matter of convenience.

Databases created previously are migrated on first open: a sidecar whose digest matches is adopted into the database, and the sidecar is removed either way. In practice this can only happen in development since we don't preserve workspaces on software updates.

## Demo Video or Screenshot

n/a

## Testing Plan

Validated manually in VxAdmin as well as adding new automated tests to the underlying library.