### PR TITLE
[VxAdmin] Add server-side support for single-import CVR deletion

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -183,6 +183,7 @@ create table cvr_files (
   precinct_ids text not null,
   scanner_ids text not null,
   polling_place_ids text not null,
+  batch_ids text not null,
   sha256_hash text not null,
   created_at timestamp not null default current_timestamp,
   foreign key (election_id) references elections(id)

--- a/apps/admin/backend/src/app.cvr_files.test.ts
+++ b/apps/admin/backend/src/app.cvr_files.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { Buffer } from 'node:buffer';
 import set from 'lodash.set';
 import { err, ok, assert } from '@votingworks/basics';
@@ -964,3 +964,69 @@ test.each<{
     ).toEqual(expectedResult);
   }
 );
+
+describe('deleteCvrFile', () => {
+  test('logs successful deletions', async () => {
+    const { apiClient, auth, logger } = buildTestEnvironment();
+    await configureMachine(apiClient, auth, electionTwoPartyPrimaryDefinition);
+    mockElectionManagerAuth(auth, electionTwoPartyPrimaryDefinition.election);
+
+    const fixtures = electionTwoPartyPrimaryFixtures;
+    const exportPath = fixtures.castVoteRecordExport.asDirectoryPath();
+
+    const res = await apiClient.addCastVoteRecordFile({ path: exportPath });
+    const cvrImport = res.unsafeUnwrap();
+
+    await apiClient.deleteCvrFile({ fileId: cvrImport.id });
+
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.DeleteCvrFileInit,
+      'election_manager',
+      { message: expect.stringContaining(cvrImport.id) }
+    );
+
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.DeleteCvrFileComplete,
+      'election_manager',
+      expect.objectContaining({
+        disposition: 'success',
+        message: expect.stringContaining(cvrImport.fileName),
+      })
+    );
+
+    expect(await apiClient.getCastVoteRecordFiles()).toEqual([]);
+  });
+
+  test('logs failed deletions', async () => {
+    const { apiClient, auth, logger } = buildTestEnvironment();
+    await configureMachine(apiClient, auth, electionTwoPartyPrimaryDefinition);
+    mockElectionManagerAuth(auth, electionTwoPartyPrimaryDefinition.election);
+
+    const fixtures = electionTwoPartyPrimaryFixtures;
+    const exportPath = fixtures.castVoteRecordExport.asDirectoryPath();
+
+    const res = await apiClient.addCastVoteRecordFile({ path: exportPath });
+    const cvrImport = res.unsafeUnwrap();
+
+    await apiClient.deleteCvrFile({ fileId: 'non-existent' });
+
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.DeleteCvrFileInit,
+      'election_manager',
+      { message: expect.stringContaining('non-existent') }
+    );
+
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.DeleteCvrFileComplete,
+      'election_manager',
+      expect.objectContaining({
+        disposition: 'failure',
+        message: expect.stringContaining('non-existent'),
+      })
+    );
+
+    expect(await apiClient.getCastVoteRecordFiles()).toEqual([
+      expect.objectContaining({ id: cvrImport.id }),
+    ]);
+  });
+});

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -806,6 +806,28 @@ function buildApi({
       return importResult;
     },
 
+    async deleteCvrFile(input: { fileId: Id }): Promise<void> {
+      const electionId = loadCurrentElectionIdOrThrow(workspace);
+
+      await logger.logAsCurrentRole(LogEventId.DeleteCvrFileInit, {
+        message: `Removing CVR file ${input.fileId}...`,
+      });
+
+      const deleted = store.deleteCvrFile({ electionId, fileId: input.fileId });
+      if (!deleted) {
+        return logger.logAsCurrentRole(LogEventId.DeleteCvrFileComplete, {
+          disposition: 'failure',
+          message: `CVR file ${input.fileId} not found.`,
+        });
+      }
+
+      const batchIds = deleted.batchIds.join(', ');
+      await logger.logAsCurrentRole(LogEventId.DeleteCvrFileComplete, {
+        disposition: 'success',
+        message: `Removed CVR file ${deleted.filename}, batches ${batchIds}.`,
+      });
+    },
+
     async clearCastVoteRecordFiles(): Promise<void> {
       await logger.logAsCurrentRole(
         LogEventId.ClearImportedCastVoteRecordsInit,

--- a/apps/admin/backend/src/cast_vote_records.ts
+++ b/apps/admin/backend/src/cast_vote_records.ts
@@ -262,6 +262,7 @@ export async function importCastVoteRecords(
   return await store.withTransaction(async () => {
     const scannerIds = new Set<string>();
     const pollingPlaceIds = new Set<string>();
+    const batchIds: string[] = [];
 
     for (const batch of batchManifest) {
       store.addScannerBatch({
@@ -277,6 +278,7 @@ export async function importCastVoteRecords(
 
       scannerIds.add(batch.scannerId);
       pollingPlaceIds.add(batch.pollingPlaceId);
+      batchIds.push(batch.id);
     }
 
     // Create a top-level record for the import
@@ -289,6 +291,7 @@ export async function importCastVoteRecords(
       isTestMode: isTestReport(castVoteRecordReportMetadata),
       pollingPlaceIds,
       scannerIds,
+      batchIds,
       sha256Hash: exportHash,
     });
 

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { readdirSync, readFileSync } from 'node:fs';
+import { Buffer } from 'node:buffer';
 import {
   electionPrimaryPrecinctSplitsFixtures,
   electionTwoPartyPrimaryFixtures,
@@ -18,13 +19,16 @@ import {
   ElectionRegisteredVoterCounts,
   SystemSettings,
 } from '@votingworks/types';
-import { assertDefined, find, typedAs } from '@votingworks/basics';
+import { assert, assertDefined, find, typedAs } from '@votingworks/basics';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import { zipFile } from '@votingworks/test-utils';
 import { mockBaseLogger } from '@votingworks/logging';
 import { getGroupedBallotStyles } from '@votingworks/utils';
-import { addMockCvrFileToStore } from '../test/mock_cvr_file.js';
+import {
+  addMockCvrFileToStore,
+  MockCastVoteRecordFile,
+} from '../test/mock_cvr_file.js';
 import { Store } from './store.js';
 import {
   ElectionRecord,
@@ -1237,4 +1241,327 @@ describe('machine ballot adjudication assignments', () => {
       Admin.ClientMachineStatus.Active
     );
   });
+});
+
+describe('deleteCvrFile', () => {
+  const fixtures = electionTwoPartyPrimaryFixtures;
+  const electionDef = fixtures.readElectionDefinition();
+  const electionDefId = electionDef.election.id;
+
+  const { election } = electionDef;
+  const ballotStyle = assertDefined(election.ballotStyles[0]);
+  const precinctId = assertDefined(ballotStyle.precincts[0]);
+  const scannerId = 'scanner-1';
+
+  test('preserves CVRs shared with other files', async () => {
+    const { store, electionId } = await newStore();
+
+    const contest = find(
+      election.contests,
+      (c): c is CandidateContest => c.type === 'candidate' && c.allowWriteIns
+    );
+
+    const batch1 = mockBatch({ electionId, batchId: '1', label: 'Batch 1' });
+    const batch2 = mockBatch({ electionId, batchId: '2', label: 'Batch 2' });
+    const batch3 = mockBatch({ electionId, batchId: '3', label: 'Batch 3' });
+
+    const writeInOptionId1 = 'write-in-from-batch-1';
+    const writeInOptionId2 = 'write-in-from-batch-3';
+    const writeInOptionId3 = 'write-in-from-batch-2';
+
+    const writeInName1 = 'WRITE-IN 1';
+
+    const [cvrId1a, cvrId1b] = addMockCvrFileToStore({
+      electionId,
+      exportedTimestamp: new Date('2021-01-01'),
+      mockCastVoteRecordFile: [
+        mockCvr({
+          batchId: batch1.batchId,
+          votes: { [contest.id]: [assertDefined(contest.candidates[0]).id] },
+        }),
+        mockCvr({
+          batchId: batch2.batchId,
+          votes: { [contest.id]: [assertDefined(contest.candidates[1]).id] },
+        }),
+      ],
+      pollingPlaceId: 'polling-place-1',
+      store,
+    });
+
+    const [cvrId2a, cvrId2b] = addMockCvrFileToStore({
+      electionId,
+      exportedTimestamp: new Date('2021-01-02'),
+      mockCastVoteRecordFile: [
+        mockCvr({
+          batchId: batch2.batchId, // Duplicates batch2 in the first import.
+          votes: { [contest.id]: [assertDefined(contest.candidates[1]).id] },
+        }),
+        mockCvr({
+          batchId: batch3.batchId,
+          votes: { [contest.id]: [assertDefined(contest.candidates[2]).id] },
+        }),
+      ],
+      pollingPlaceId: 'polling-place-1',
+      store,
+    });
+
+    assert(!!cvrId1a && !!cvrId1b && !!cvrId2a && !!cvrId2b);
+
+    addBallotImages(store, cvrId1a);
+    addBallotImages(store, cvrId1b);
+    expect(cvrId2a).toEqual(cvrId1b); // Duplicate CVR already has images.
+    addBallotImages(store, cvrId2b);
+
+    const writeInIds: Id[] = [];
+    for (const [cvrId, writeInId] of [
+      [cvrId1a, writeInOptionId1],
+      [cvrId1b, writeInOptionId2],
+      [cvrId2b, writeInOptionId3],
+    ]) {
+      const id = store.addWriteIn({
+        castVoteRecordId: assertDefined(cvrId),
+        optionId: assertDefined(writeInId),
+
+        contestId: contest.id,
+        electionId,
+        isUndetected: false,
+      });
+      writeInIds.push(id);
+    }
+
+    const { id: writeInCandidateId } = store.addWriteInCandidate({
+      contestId: contest.id,
+      electionId,
+      name: writeInName1,
+    });
+    store.setWriteInRecordUnofficialCandidate({
+      candidateId: writeInCandidateId,
+      type: 'write-in-candidate',
+      writeInId: assertDefined(writeInIds[0]),
+    });
+
+    expect(store.getScannerBatches(electionId)).toEqual([
+      batch1,
+      batch2,
+      batch3,
+    ]);
+
+    const files = store.getCvrFiles(electionId);
+    expect(files).toHaveLength(2);
+
+    const [file2, file1] = files; // Results ordered most recent first.
+    assert(!!file1 && !!file2);
+
+    expectCvr(store, { electionId, cvrId: cvrId1a });
+    expectCvr(store, { electionId, cvrId: cvrId1b });
+    expectCvr(store, { electionId, cvrId: cvrId2a });
+    expectCvr(store, { electionId, cvrId: cvrId2b });
+
+    expectBallotImages(store, { cvrId: cvrId1a });
+    expectBallotImages(store, { cvrId: cvrId1b });
+    expectBallotImages(store, { cvrId: cvrId2a });
+    expectBallotImages(store, { cvrId: cvrId2b });
+
+    expectWriteIns(store, {
+      electionId,
+      optionIds: [writeInOptionId1, writeInOptionId2, writeInOptionId3],
+    });
+
+    expectWriteInCandidates(store, { electionId, names: [writeInName1] });
+
+    const res = store.deleteCvrFile({ electionId, fileId: file1.id });
+    expect(res).toEqual({
+      filename: expect.any(String),
+      batchIds: [batch1.batchId], // `batch2` is shared with remaining CVR file.
+    });
+
+    // batch2 is preserved because it still has a CVR shared with file2.
+    expect(store.getScannerBatches(electionId)).toEqual([batch2, batch3]);
+
+    expectNoCvr(store, { electionId, cvrId: cvrId1a });
+    expectCvr(store, { electionId, cvrId: cvrId1b });
+    expectCvr(store, { electionId, cvrId: cvrId2a });
+    expectCvr(store, { electionId, cvrId: cvrId2b });
+
+    expectNoBallotImages(store, { cvrId: cvrId1a });
+    expectBallotImages(store, { cvrId: cvrId1b });
+    expectBallotImages(store, { cvrId: cvrId2a });
+
+    expectWriteIns(store, {
+      electionId,
+      optionIds: [writeInOptionId2, writeInOptionId3],
+    });
+
+    // The sole write-in candidate was linked to a write-in from the deleted CVR
+    // import (writeInOptionId1).
+    expectWriteInCandidates(store, { electionId, names: [] });
+  });
+
+  test('preserves qualified write-ins', async () => {
+    const settings: SystemSettings = {
+      ...DEFAULT_SYSTEM_SETTINGS,
+      areWriteInCandidatesQualified: true,
+    };
+
+    const { store, electionId } = await newStore(JSON.stringify(settings));
+
+    const contest = find(
+      election.contests,
+      (c): c is CandidateContest => c.type === 'candidate' && c.allowWriteIns
+    );
+
+    const batch = mockBatch({ electionId, batchId: '1', label: 'Batch 1' });
+    const writeInOptionId = 'write-in-from-batch-1';
+    const writeInName = 'WRITE-IN 1';
+
+    const [cvrId1a] = addMockCvrFileToStore({
+      electionId,
+      exportedTimestamp: new Date('2021-01-01'),
+      mockCastVoteRecordFile: [
+        mockCvr({
+          batchId: batch.batchId,
+          votes: { [contest.id]: [assertDefined(contest.candidates[0]).id] },
+        }),
+      ],
+      pollingPlaceId: 'polling-place-1',
+      store,
+    });
+
+    assert(!!cvrId1a);
+
+    const writeInId = store.addWriteIn({
+      castVoteRecordId: cvrId1a,
+      contestId: contest.id,
+      electionId,
+      isUndetected: false,
+      optionId: writeInOptionId,
+    });
+
+    const { id: writeInCandidateId } = store.addWriteInCandidate({
+      contestId: contest.id,
+      electionId,
+      name: writeInName,
+    });
+    store.setWriteInRecordUnofficialCandidate({
+      candidateId: writeInCandidateId,
+      type: 'write-in-candidate',
+      writeInId,
+    });
+
+    expectWriteIns(store, { electionId, optionIds: [writeInOptionId] });
+    expectWriteInCandidates(store, { electionId, names: [writeInName] });
+
+    const cvrFile = assertDefined(store.getCvrFiles(electionId)[0]);
+    const res = store.deleteCvrFile({ electionId, fileId: cvrFile.id });
+    expect(res).toEqual({
+      filename: expect.any(String),
+      batchIds: [batch.batchId],
+    });
+
+    expectNoCvr(store, { electionId, cvrId: cvrId1a });
+    expectNoBallotImages(store, { cvrId: cvrId1a });
+
+    expectWriteIns(store, { electionId, optionIds: [] });
+    expectWriteInCandidates(store, { electionId, names: [writeInName] });
+  });
+
+  async function newStore(
+    settingsData: string = systemSettingsData
+  ): Promise<{ store: Store; electionId: Id }> {
+    const store = Store.memoryStore(makeTemporaryDirectory());
+    const electionId = await store.addElection({
+      electionData: fixtures.electionJson.asText(),
+      systemSettingsData: settingsData,
+      electionPackageSourceFilePath: makeTemporaryFile(),
+      electionPackageHash: 'test-election-package-hash',
+    });
+    return { store, electionId };
+  }
+
+  function addBallotImages(store: Store, cvrId: string) {
+    for (const side of ['front', 'back'] as const) {
+      store.addBallotImage({
+        cvrId,
+        electionDefinitionId: electionDefId,
+        imageData: Buffer.from([]),
+        side,
+      });
+    }
+  }
+
+  function expectBallotImages(store: Store, p: { cvrId: string }) {
+    store.getBallotImagesAndLayouts(p);
+  }
+
+  function expectNoBallotImages(store: Store, p: { cvrId: string }) {
+    expect(() => store.getBallotImagesAndLayouts(p)).toThrow();
+  }
+
+  function expectCvr(store: Store, p: { cvrId: string; electionId: string }) {
+    store.getCastVoteRecordVoteInfo(p);
+  }
+
+  function expectNoCvr(store: Store, p: { cvrId: string; electionId: string }) {
+    expect(() => store.getCastVoteRecordVoteInfo(p)).toThrow();
+  }
+
+  function expectWriteIns(
+    store: Store,
+    p: { electionId: Id; optionIds: Id[] }
+  ) {
+    const expected = [...p.optionIds]
+      .sort()
+      .map((id) => expect.objectContaining({ optionId: id }));
+
+    const actual = store
+      .getWriteInRecords({ electionId: p.electionId })
+      .sort((a, b) => a.optionId.localeCompare(b.optionId));
+
+    expect(actual).toEqual(expected);
+  }
+
+  function expectWriteInCandidates(
+    store: Store,
+    p: { electionId: Id; names: Id[] }
+  ) {
+    const expected = [...p.names]
+      .sort()
+      .map((name) => expect.objectContaining({ name }));
+
+    const actual = store
+      .getWriteInCandidates({ electionId: p.electionId })
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    expect(actual).toEqual(expected);
+  }
+
+  function mockCvr(p: {
+    batchId: string;
+    votes: Tabulation.Votes;
+  }): MockCastVoteRecordFile[number] {
+    return {
+      batchId: p.batchId,
+      // Using batch ID as a proxy for ballot ID for convenience:
+      ballotId: p.batchId,
+      ballotStyleGroupId: ballotStyle.groupId,
+      scannerId,
+      precinctId,
+      votes: p.votes,
+      votingMethod: 'precinct',
+      card: { type: 'bmd' },
+    };
+  }
+
+  function mockBatch(p: {
+    batchId: string;
+    label: string;
+    electionId: string;
+  }): ScannerBatch {
+    return {
+      ...p,
+      scannerId,
+      pollingPlaceId: 'polling-place-1',
+      startedAt: expect.any(String),
+    };
+  }
 });

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -1253,6 +1253,30 @@ describe('deleteCvrFile', () => {
   const precinctId = assertDefined(ballotStyle.precincts[0]);
   const scannerId = 'scanner-1';
 
+  test('is no-op if no matching file found', async () => {
+    const { store, electionId } = await newStore();
+    const res = store.deleteCvrFile({ electionId, fileId: 'missing' });
+    expect(res).toBeUndefined();
+  });
+
+  test('is no-op for mismatched election ID', async () => {
+    const { store, electionId } = await newStore();
+
+    addMockCvrFileToStore({
+      electionId,
+      exportedTimestamp: new Date('2021-01-01'),
+      mockCastVoteRecordFile: [mockCvr({ batchId: '1', votes: {} })],
+      pollingPlaceId: 'polling-place-1',
+      store,
+    });
+
+    const [file] = store.getCvrFiles(electionId);
+    assert(file);
+
+    const res = store.deleteCvrFile({ electionId: 'invalid', fileId: file.id });
+    expect(res).toBeUndefined();
+  });
+
   test('preserves CVRs shared with other files', async () => {
     const { store, electionId } = await newStore();
 

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -125,6 +125,11 @@ type StoreCastVoteRecordAttributes = Omit<
   readonly partyId: string | null;
 };
 
+interface DeleteCvrFileResult {
+  filename: string;
+  batchIds: string[];
+}
+
 /**
  * Path to the store's schema file, i.e. the file that defines the database.
  */
@@ -1995,9 +2000,25 @@ export class Store implements BaseStore {
   deleteCvrFile(p: {
     electionId: Id;
     fileId: Id;
-  }): Optional<{ filename: string; batchIds: string[] }> {
+  }): Optional<DeleteCvrFileResult> {
     let deletedCvrs: Array<{ id: Id }> = [];
-    let deletedFile: { filename: string; batchIds: string[] } | undefined;
+    let deletedFile: Optional<DeleteCvrFileResult>;
+
+    const matchingFile = this.client.one(
+      `
+        select
+          filename,
+          batch_ids as batchIds
+        from cvr_files
+        where
+          id = ?
+          and election_id = ?
+      `,
+      p.fileId,
+      p.electionId
+    ) as { filename: string; batchIds: string } | undefined;
+
+    if (!matchingFile) return undefined;
 
     this.client.transaction(() => {
       deletedCvrs = this.client.all(
@@ -2019,38 +2040,13 @@ export class Store implements BaseStore {
         p.fileId
       ) as Array<{ id: Id }>;
 
-      const deletedFileRow = this.client.one(
-        `
-          delete from cvr_files
-          where
-            id = ?
-            and election_id = ?
-          returning
-            filename,
-            batch_ids as batchIds
-        `,
-        p.fileId,
-        p.electionId
-      ) as { filename: string; batchIds: string } | undefined;
-
-      if (!deletedFileRow) return undefined;
+      this.client.run(`delete from cvr_files where id = ?`, p.fileId);
 
       if (!this.getSystemSettings(p.electionId).areWriteInCandidatesQualified) {
-        this.client.run(
-          `
-            delete from write_in_candidates
-            where
-              election_id = ?
-              and not exists (
-                select 1 from write_ins
-                where write_ins.write_in_candidate_id = write_in_candidates.id
-              )
-          `,
-          p.electionId
-        );
+        this.deleteAllWriteInCandidatesNotReferenced();
       }
 
-      const linkedBatchIds = JSON.parse(deletedFileRow.batchIds) as string[];
+      const linkedBatchIds = JSON.parse(matchingFile.batchIds) as string[];
       const placeholders = linkedBatchIds.map(() => '?').join(', ');
       const deletedBatches = this.client.all(
         `
@@ -2071,7 +2067,7 @@ export class Store implements BaseStore {
       ) as Array<{ id: Id }>;
 
       deletedFile = {
-        filename: deletedFileRow.filename,
+        filename: matchingFile.filename,
         batchIds: deletedBatches.map((batch) => batch.id),
       };
     });

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -1031,6 +1031,7 @@ export class Store implements BaseStore {
     sha256Hash,
     scannerIds,
     pollingPlaceIds,
+    batchIds,
   }: {
     id: Id;
     electionId: Id;
@@ -1040,6 +1041,7 @@ export class Store implements BaseStore {
     sha256Hash: string;
     scannerIds: Set<string>;
     pollingPlaceIds: Set<string>;
+    batchIds: string[];
   }): void {
     this.client.run(
       `
@@ -1052,9 +1054,10 @@ export class Store implements BaseStore {
           precinct_ids,
           scanner_ids,
           polling_place_ids,
+          batch_ids,
           sha256_hash
         ) values (
-          ?, ?, ?, ?, ?, ?, ?, ?, ?
+          ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
         )
       `,
       id,
@@ -1065,6 +1068,7 @@ export class Store implements BaseStore {
       JSON.stringify([]),
       JSON.stringify([...scannerIds]),
       JSON.stringify([...pollingPlaceIds]),
+      JSON.stringify(batchIds),
       sha256Hash
     );
   }
@@ -1973,14 +1977,124 @@ export class Store implements BaseStore {
   }
 
   /**
+   * Deletes a single CVR file (import) for an election.
+   *
+   * Deletes:
+   *   - CVRs that are linked to only this file.
+   *   - Write-in records linked to the deleted CVRs.
+   *   - Write-in candidate records left without write-ins.
+   *   - Ballot image files for the deleted CVRs.
+   *   - Empty scanner batches previously attached to the deleted CVRs.
+   *
+   * Preserves:
+   *   — CVRs that have links to other files (links to this file are deleted).
+   *   - All other data associated with the preserved CVRs from this file.
+   *
+   * Returns metadata about the deleted file, or `undefined` if not found.
+   */
+  deleteCvrFile(p: {
+    electionId: Id;
+    fileId: Id;
+  }): Optional<{ filename: string; batchIds: string[] }> {
+    let deletedCvrs: Array<{ id: Id }> = [];
+    let deletedFile: { filename: string; batchIds: string[] } | undefined;
+
+    this.client.transaction(() => {
+      deletedCvrs = this.client.all(
+        `
+          delete from cvrs where id in (
+            select cvr_id from cvr_file_entries
+            where
+              cvr_file_id = ?
+              and not exists (
+                select 1 from cvr_file_entries other
+                where
+                  other.cvr_id = cvr_file_entries.cvr_id
+                  and other.cvr_file_id != ?
+              )
+          )
+          returning id
+        `,
+        p.fileId,
+        p.fileId
+      ) as Array<{ id: Id }>;
+
+      const deletedFileRow = this.client.one(
+        `
+          delete from cvr_files
+          where
+            id = ?
+            and election_id = ?
+          returning
+            filename,
+            batch_ids as batchIds
+        `,
+        p.fileId,
+        p.electionId
+      ) as { filename: string; batchIds: string } | undefined;
+
+      if (!deletedFileRow) return undefined;
+
+      if (!this.getSystemSettings(p.electionId).areWriteInCandidatesQualified) {
+        this.client.run(
+          `
+            delete from write_in_candidates
+            where
+              election_id = ?
+              and not exists (
+                select 1 from write_ins
+                where write_ins.write_in_candidate_id = write_in_candidates.id
+              )
+          `,
+          p.electionId
+        );
+      }
+
+      const linkedBatchIds = JSON.parse(deletedFileRow.batchIds) as string[];
+      const placeholders = linkedBatchIds.map(() => '?').join(', ');
+      const deletedBatches = this.client.all(
+        `
+          delete from scanner_batches
+          where
+            election_id = ?
+            and id in (${placeholders})
+            and not exists (
+              select 1 from cvrs
+              where
+                cvrs.batch_id = scanner_batches.id
+                and cvrs.election_id = scanner_batches.election_id
+            )
+          returning id
+        `,
+        p.electionId,
+        ...linkedBatchIds
+      ) as Array<{ id: Id }>;
+
+      deletedFile = {
+        filename: deletedFileRow.filename,
+        batchIds: deletedBatches.map((batch) => batch.id),
+      };
+    });
+
+    // [TODO] This is a non-trivial cost for large CVR imports and failing here
+    // leaves ballot images stranded on disk - maybe worth moving to scheduled
+    // cleanup passes instead.
+    const electionDefinitionId = this.getElectionDefinitionId(p.electionId);
+    for (const { id } of deletedCvrs) {
+      for (const side of ['front', 'back'] as const) {
+        rmSync(this.getBallotImageFilePath(electionDefinitionId, id, side), {
+          force: true,
+        });
+      }
+    }
+
+    return deletedFile;
+  }
+
+  /**
    * Deletes all CVR files for an election.
    */
   deleteCastVoteRecordFiles(electionId: Id): void {
-    const { electionDefinitionId } = this.client.one(
-      `select election_data ->> 'id' as electionDefinitionId from elections where id = ?`,
-      electionId
-    ) as { electionDefinitionId: string };
-
     this.client.transaction(() => {
       this.client.run(
         `
@@ -2018,10 +2132,20 @@ export class Store implements BaseStore {
       this.deleteEmptyScannerBatches(electionId);
     });
 
+    const electionDefinitionId = this.getElectionDefinitionId(electionId);
     rmSync(join(this.ballotImagesPath, electionDefinitionId), {
       recursive: true,
       force: true,
     });
+  }
+
+  getElectionDefinitionId(electionId: Id): Id {
+    const res = this.client.one(
+      `select election_data ->> 'id' as id from elections where id = ?`,
+      electionId
+    ) as { id: Id };
+
+    return res.id;
   }
 
   getWriteInCandidates({

--- a/apps/admin/backend/test/mock_cvr_file.ts
+++ b/apps/admin/backend/test/mock_cvr_file.ts
@@ -21,6 +21,7 @@ export type MockCastVoteRecordFile = Array<
     multiplier?: number;
     scannerMachineType?: ScannerMachineType;
     pollingPlaceId?: string;
+    ballotId?: string;
   }
 >;
 
@@ -48,11 +49,13 @@ const mockPageLayout: BallotPageLayout = {
  */
 export function addMockCvrFileToStore({
   electionId,
+  exportedTimestamp,
   pollingPlaceId,
   mockCastVoteRecordFile,
   store,
 }: {
   electionId: Id;
+  exportedTimestamp?: Date;
   pollingPlaceId: Id;
   mockCastVoteRecordFile: MockCastVoteRecordFile;
   store: Store;
@@ -78,10 +81,11 @@ export function addMockCvrFileToStore({
     electionId,
     isTestMode: true,
     filename: 'mock-cvr-file',
-    exportedTimestamp: new Date().toISOString(),
+    exportedTimestamp: (exportedTimestamp || new Date()).toISOString(),
     sha256Hash: 'mock-hash',
     scannerIds,
     pollingPlaceIds: new Set(pollingPlaceId),
+    batchIds: mockCastVoteRecordFile.map((f) => f.batchId),
   });
 
   const { electionDefinition } = assertDefined(store.getElection(electionId));
@@ -127,7 +131,7 @@ export function addMockCvrFileToStore({
       const addCastVoteRecordResult = store.addCastVoteRecordFileEntry({
         electionId,
         cvrFileId,
-        ballotId: uuid(),
+        ballotId: mockCastVoteRecord.ballotId || uuid(),
         cvr: { ...mockCastVoteRecord, votes: filteredVotes },
         adjudicationFlags,
       });

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -318,6 +318,14 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)
 **Description:** Cast vote records have been imported from a USB drive (or failed to be imported). Success or failure indicated by disposition.
 **Machines:** vx-admin
+### delete-cvr-file-init
+**Type:** [user-action](#user-action)
+**Description:** Cast vote records from a single import are being deleted.
+**Machines:** vx-admin
+### delete-cvr-file-complete
+**Type:** [user-action](#user-action)
+**Description:** Cast vote records from a single import have been deleted (or failed to be deleted). Success or failure indicated by disposition.
+**Machines:** vx-admin
 ### clear-imported-cast-vote-records-init
 **Type:** [user-action](#user-action)
 **Description:** Imported cast vote records are being cleared.

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -544,6 +544,18 @@ eventType = "user-action"
 documentationMessage = "Cast vote records have been imported from a USB drive (or failed to be imported). Success or failure indicated by disposition."
 restrictInDocumentationToApps = ["vx-admin"]
 
+[Events.DeleteCvrFileInit]
+eventId = "delete-cvr-file-init"
+eventType = "user-action"
+documentationMessage = "Cast vote records from a single import are being deleted."
+restrictInDocumentationToApps = ["vx-admin"]
+
+[Events.DeleteCvrFileComplete]
+eventId = "delete-cvr-file-complete"
+eventType = "user-action"
+documentationMessage = "Cast vote records from a single import have been deleted (or failed to be deleted). Success or failure indicated by disposition."
+restrictInDocumentationToApps = ["vx-admin"]
+
 [Events.ClearImportedCastVoteRecordsInit]
 eventId = "clear-imported-cast-vote-records-init"
 eventType = "user-action"

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -142,6 +142,8 @@ export enum LogEventId {
   ImportCastVoteRecordsInit = 'import-cast-vote-records-init',
   ImportCastVoteRecordsMarkScoreDistribution = 'import-cast-vote-records-mark-score-distribution',
   ImportCastVoteRecordsComplete = 'import-cast-vote-records-complete',
+  DeleteCvrFileInit = 'delete-cvr-file-init',
+  DeleteCvrFileComplete = 'delete-cvr-file-complete',
   ClearImportedCastVoteRecordsInit = 'clear-imported-cast-vote-records-init',
   ClearImportedCastVoteRecordsComplete = 'clear-imported-cast-vote-records-complete',
   ManualTallyDataEdited = 'manual-tally-data-edited',
@@ -769,6 +771,22 @@ const ImportCastVoteRecordsComplete: LogDetails = {
   eventType: LogEventType.UserAction,
   documentationMessage:
     'Cast vote records have been imported from a USB drive (or failed to be imported). Success or failure indicated by disposition.',
+  restrictInDocumentationToApps: [AppName.VxAdmin],
+};
+
+const DeleteCvrFileInit: LogDetails = {
+  eventId: LogEventId.DeleteCvrFileInit,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'Cast vote records from a single import are being deleted.',
+  restrictInDocumentationToApps: [AppName.VxAdmin],
+};
+
+const DeleteCvrFileComplete: LogDetails = {
+  eventId: LogEventId.DeleteCvrFileComplete,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'Cast vote records from a single import have been deleted (or failed to be deleted). Success or failure indicated by disposition.',
   restrictInDocumentationToApps: [AppName.VxAdmin],
 };
 
@@ -1675,6 +1693,10 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return ImportCastVoteRecordsMarkScoreDistribution;
     case LogEventId.ImportCastVoteRecordsComplete:
       return ImportCastVoteRecordsComplete;
+    case LogEventId.DeleteCvrFileInit:
+      return DeleteCvrFileInit;
+    case LogEventId.DeleteCvrFileComplete:
+      return DeleteCvrFileComplete;
     case LogEventId.ClearImportedCastVoteRecordsInit:
       return ClearImportedCastVoteRecordsInit;
     case LogEventId.ClearImportedCastVoteRecordsComplete:

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -267,6 +267,10 @@ pub enum EventId {
     ImportCastVoteRecordsMarkScoreDistribution,
     #[serde(rename = "import-cast-vote-records-complete")]
     ImportCastVoteRecordsComplete,
+    #[serde(rename = "delete-cvr-file-init")]
+    DeleteCvrFileInit,
+    #[serde(rename = "delete-cvr-file-complete")]
+    DeleteCvrFileComplete,
     #[serde(rename = "clear-imported-cast-vote-records-init")]
     ClearImportedCastVoteRecordsInit,
     #[serde(rename = "clear-imported-cast-vote-records-complete")]


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/4048

_Partly based on work from the CA demo: https://github.com/votingworks/vxsuite/pull/8960_

We currently have an API for deleting all imported CVRs in one go - this adds an additional API for deleting a single import (referred to as "file" in the code, since imports used to be a single file IIUC).

A single import is linked to multiple individual CVRs and some of those CVRs may also be linked to other imports (when multiple imports from the same machine contain overlapping batches), so we only delete a CVR if it's no longer linked to any imports. The logic and tests get a little convoluted as a result - couldn't figure out a way to simplify without a larger structural change to the DB schema. 

### TODO
Will follow up with the corresponding UI change soon.

## Demo Video or Screenshot
N/A

## Testing Plan
- New tests for the store and API layer

## Checklist

- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
