### PR TITLE
feat(auth): add a `vxadmin_backup` artifact type

### DIFF
--- a/libs/auth/src/artifact_authentication.test.ts
+++ b/libs/auth/src/artifact_authentication.test.ts
@@ -18,6 +18,7 @@ import {
   authenticateArtifactUsingSignatureFile,
   prepareSignatureFile,
   SIGNATURE_FILE_EXTENSION,
+  VXADMIN_BACKUP_MANIFEST_FILE_NAME,
 } from './artifact_authentication';
 import { ArtifactAuthenticationConfig } from './config';
 
@@ -46,6 +47,10 @@ let castVoteRecords: {
   artifactToImport: ArtifactToImport;
 };
 let electionPackage: {
+  artifactToExport: ArtifactToExport;
+  artifactToImport: ArtifactToImport;
+};
+let vxAdminBackup: {
   artifactToExport: ArtifactToExport;
   artifactToImport: ArtifactToImport;
 };
@@ -119,6 +124,34 @@ beforeEach(() => {
       filePath: electionPackagePath,
     },
   };
+
+  // Prepare a mock VxAdmin backup
+  const vxAdminBackupDirectoryPath = path.join(
+    tempDirectoryPath,
+    '2026-general-election-6f28c0'
+  );
+  fs.mkdirSync(vxAdminBackupDirectoryPath);
+  const manifestFileContents = JSON.stringify({
+    version: 1,
+    files: [{ path: 'data.db', sha256: 'abcd', size: 4 }],
+  });
+  fs.writeFileSync(
+    path.join(vxAdminBackupDirectoryPath, VXADMIN_BACKUP_MANIFEST_FILE_NAME),
+    manifestFileContents
+  );
+  fs.writeFileSync(path.join(vxAdminBackupDirectoryPath, 'data.db'), 'abcd');
+  vxAdminBackup = {
+    artifactToExport: {
+      type: 'vxadmin_backup',
+      context: 'export',
+      manifestFileContents,
+    },
+    artifactToImport: {
+      type: 'vxadmin_backup',
+      context: 'import',
+      directoryPath: vxAdminBackupDirectoryPath,
+    },
+  };
 });
 
 afterEach(() => {
@@ -161,6 +194,22 @@ type ArtifactGenerator = () => {
   artifactToImport: ArtifactToImport;
 };
 
+function backupDirectoryPath(): string {
+  assert(vxAdminBackup.artifactToImport.type === 'vxadmin_backup');
+  return vxAdminBackup.artifactToImport.directoryPath;
+}
+
+/**
+ * Where the consumer of {@link prepareSignatureFile} is expected to write the signature file. A
+ * backup's signature file lives inside the backup directory, next to the manifest it signs; other
+ * artifacts' signature files sit beside them.
+ */
+function signatureFileDirectory(artifact: ArtifactToImport): string {
+  return artifact.type === 'vxadmin_backup'
+    ? artifact.directoryPath
+    : tempDirectoryPath;
+}
+
 test.each<{
   description: string;
   artifactGenerator: ArtifactGenerator;
@@ -179,6 +228,12 @@ test.each<{
     exportingMachineConfig: vxAdminTestConfig,
     importingMachineConfig: vxScanTestConfig,
   },
+  {
+    description: 'VxAdmin backup',
+    artifactGenerator: () => vxAdminBackup,
+    exportingMachineConfig: vxAdminTestConfig,
+    importingMachineConfig: vxAdminTestConfig,
+  },
 ])(
   'Preparing signature file and authenticating artifact using signature file - $description',
   async ({
@@ -192,7 +247,10 @@ test.each<{
       exportingMachineConfig
     );
     fs.writeFileSync(
-      path.join(tempDirectoryPath, signatureFile.fileName),
+      path.join(
+        signatureFileDirectory(artifactToImport),
+        signatureFile.fileName
+      ),
       signatureFile.fileContents
     );
     expect(
@@ -446,6 +504,40 @@ test.each<{
     },
     expectedErrorMessage: 'Verification failure',
   },
+  {
+    description: 'VxAdmin backup, altered manifest',
+    artifactGenerator: () => vxAdminBackup,
+    exportingMachineConfig: vxAdminTestConfig,
+    importingMachineConfig: vxAdminTestConfig,
+    editsAfterWritingSignatureFile: () => {
+      fs.appendFileSync(
+        path.join(backupDirectoryPath(), VXADMIN_BACKUP_MANIFEST_FILE_NAME),
+        '!'
+      );
+    },
+    expectedErrorMessage: 'Verification failure',
+  },
+  {
+    description: 'VxAdmin backup, removed manifest',
+    artifactGenerator: () => vxAdminBackup,
+    exportingMachineConfig: vxAdminTestConfig,
+    importingMachineConfig: vxAdminTestConfig,
+    editsAfterWritingSignatureFile: () => {
+      fs.rmSync(
+        path.join(backupDirectoryPath(), VXADMIN_BACKUP_MANIFEST_FILE_NAME)
+      );
+    },
+    expectedErrorMessage: 'ENOENT: no such file or directory',
+  },
+  {
+    description: 'VxAdmin backup, signed by a machine that is not a VxAdmin',
+    artifactGenerator: () => vxAdminBackup,
+    exportingMachineConfig: vxScanTestConfig,
+    importingMachineConfig: vxAdminTestConfig,
+    editsAfterWritingSignatureFile: () => {},
+    expectedErrorMessage:
+      'Signing machine for a VxAdmin backup should be a VxAdmin',
+  },
 ])(
   'Detecting that an artifact has been tampered with - $description',
   async ({
@@ -461,7 +553,10 @@ test.each<{
       exportingMachineConfig
     );
     fs.writeFileSync(
-      path.join(tempDirectoryPath, signatureFile.fileName),
+      path.join(
+        signatureFileDirectory(artifactToImport),
+        signatureFile.fileName
+      ),
       signatureFile.fileContents
     );
     editsAfterWritingSignatureFile();

--- a/libs/auth/src/artifact_authentication.ts
+++ b/libs/auth/src/artifact_authentication.ts
@@ -38,6 +38,12 @@ import { constructPrefixedMessage } from './signatures';
  */
 export const SIGNATURE_FILE_EXTENSION = '.vxsig';
 
+/**
+ * The name of the manifest file at the root of a VxAdmin backup directory. The manifest is the
+ * signed artifact; every other file in the backup is covered by a hash within it.
+ */
+export const VXADMIN_BACKUP_MANIFEST_FILE_NAME = 'manifest.json';
+
 interface CastVoteRecordsToExport {
   type: 'cast_vote_records';
   context: 'export';
@@ -66,24 +72,40 @@ interface ElectionPackageToImport {
 
 type ElectionPackage = ElectionPackageToExport | ElectionPackageToImport;
 
+interface VxAdminBackupToExport {
+  type: 'vxadmin_backup';
+  context: 'export';
+  manifestFileContents: string;
+}
+
+interface VxAdminBackupToImport {
+  type: 'vxadmin_backup';
+  context: 'import';
+  directoryPath: string;
+}
+
+type VxAdminBackup = VxAdminBackupToExport | VxAdminBackupToImport;
+
 /**
  * An export-time representation of an {@link Artifact}
  */
 export type ArtifactToExport =
   | CastVoteRecordsToExport
-  | ElectionPackageToExport;
+  | ElectionPackageToExport
+  | VxAdminBackupToExport;
 
 /**
  * An import-time representation of an {@link Artifact}
  */
 export type ArtifactToImport =
   | CastVoteRecordsToImport
-  | ElectionPackageToImport;
+  | ElectionPackageToImport
+  | VxAdminBackupToImport;
 
 /**
  * A machine-exported artifact whose authenticity we want to be able to verify
  */
-export type Artifact = CastVoteRecords | ElectionPackage;
+export type Artifact = CastVoteRecords | ElectionPackage | VxAdminBackup;
 
 interface ArtifactSignatureBundle {
   signature: Buffer;
@@ -130,6 +152,29 @@ function constructMessage(artifact: Artifact): {
       return {
         artifactStream: fileContents,
         message: constructPrefixedMessage(artifact.type, fileContents),
+      };
+    }
+    case 'vxadmin_backup': {
+      let manifestFileContents: Readable;
+      switch (artifact.context) {
+        case 'export': {
+          manifestFileContents = Readable.from(artifact.manifestFileContents);
+          break;
+        }
+        case 'import': {
+          manifestFileContents = createReadStream(
+            path.join(artifact.directoryPath, VXADMIN_BACKUP_MANIFEST_FILE_NAME)
+          );
+          break;
+        }
+        /* istanbul ignore next: Compile-time check for completeness */
+        default: {
+          throwIllegalValue(artifact, 'context');
+        }
+      }
+      return {
+        artifactStream: manifestFileContents,
+        message: constructPrefixedMessage(artifact.type, manifestFileContents),
       };
     }
     default: {
@@ -238,6 +283,10 @@ function constructSignatureFileName(artifact: ArtifactToExport): string {
     case 'election_package': {
       return `${artifact.exportFileName}${SIGNATURE_FILE_EXTENSION}`;
     }
+    case 'vxadmin_backup': {
+      // Written inside the backup directory, adjacent to the manifest it signs
+      return `${VXADMIN_BACKUP_MANIFEST_FILE_NAME}${SIGNATURE_FILE_EXTENSION}`;
+    }
     default: {
       /* istanbul ignore next: Compile-time check for completeness */
       throwIllegalValue(artifact, 'type');
@@ -252,6 +301,12 @@ function constructSignatureFilePath(artifact: ArtifactToImport): string {
     }
     case 'election_package': {
       return `${artifact.filePath}${SIGNATURE_FILE_EXTENSION}`;
+    }
+    case 'vxadmin_backup': {
+      return path.join(
+        artifact.directoryPath,
+        `${VXADMIN_BACKUP_MANIFEST_FILE_NAME}${SIGNATURE_FILE_EXTENSION}`
+      );
     }
     default: {
       /* istanbul ignore next: Compile-time check for completeness */
@@ -327,6 +382,14 @@ async function performArtifactSpecificAuthenticationChecks(
       assert(
         signingMachineCertDetails.component === 'admin',
         'Signing machine for election package should be a VxAdmin'
+      );
+      break;
+    }
+
+    case 'vxadmin_backup': {
+      assert(
+        signingMachineCertDetails.component === 'admin',
+        'Signing machine for a VxAdmin backup should be a VxAdmin'
       );
       break;
     }


### PR DESCRIPTION
Co-authored with Claude Code 🤖 

## Overview

Refs #7897 

Adds a `vxadmin_backup` artifact type to `libs/auth`, so that a VxAdmin backup's manifest can be signed on export and verified on import.

This is groundwork for VxAdmin election backup & archiving. A backup is a directory containing a `manifest.json` that lists every backed-up file with its size and SHA-256, plus the files themselves. The manifest is the signed artifact; every other file in the backup is covered by a hash within it. Nothing constructs this artifact type yet, so this PR is a pure addition with no behavior change.

One thing differs from the existing artifact types: **the signature file lives inside the backup directory**, next to the `manifest.json` it signs (`manifest.json.vxsig`), rather than beside the directory as it is for cast vote record exports. The artifact is the manifest, so this still follows the "signature is a sibling of the artifact" convention.

Signing and verification work in dev without a TPM or any cert setup: `getMachineCertPathAndPrivateKey` falls back to the checked-in dev certs whenever prod-cert mode is off, and every dev machine shares them, so backups round-trip (and move between dev machines) verifiably. No `SKIP_…_AUTHENTICATION`-style escape hatch is needed.

## Demo Video or Screenshot

N/A — no user-facing surface.

## Testing Plan

Covered by unit tests in `libs/auth/src/artifact_authentication.test.ts`, added to the existing round-trip and tamper-detection tables (466 tests pass; the package's coverage budget is unchanged):

- A backup signed by a VxAdmin round-trips through `prepareSignatureFile` → `authenticateArtifactUsingSignatureFile`.
- An edited manifest fails verification.
- A removed manifest fails verification.
- A backup signed by a machine that is not a VxAdmin is rejected by the artifact-specific check.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

