### PR TITLE
[Admin] Fix `convertFrontendFilter` call in `csv_tally_report.test.ts`

### DIFF
--- a/apps/admin/backend/src/exports/csv_tally_report.test.ts
+++ b/apps/admin/backend/src/exports/csv_tally_report.test.ts
@@ -882,7 +882,8 @@ test('filter reduced to no values exports a CSV with no rows', async () => {
       districtIds: ['district-2'],
       ballotStyleGroupIds: ['5'] as BallotStyleGroupId[],
     },
-    election
+    election,
+    store.getScannerBatches(electionId)
   );
   expect(filter).toEqual({ ballotStyleGroupIds: [] });
 


### PR DESCRIPTION
## Overview

#9103 added a required `scannerBatches` parameter to `convertFrontendFilter` while #9104 added a call site using the old two-argument signature, so each PR type-checked in isolation but `main` broke once both landed; this passes the election's scanner batches at that call site, mirroring the wiring in `app.ts`.

## Demo Video or Screenshot

N/A

## Testing Plan

`pnpm --filter @votingworks/admin-backend lint` passes, and `csv_tally_report.test.ts` and `filters.test.ts` pass (16 tests). The filter under test has no polling place dimension, so the scanner batches don't change its result.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)