### PR TITLE
VxPollBook: Fix statistics screen crash when a party has no check-ins

### DIFF
--- a/apps/pollbook/backend/src/local_store.test.ts
+++ b/apps/pollbook/backend/src/local_store.test.ts
@@ -1442,6 +1442,70 @@ test('getThroughputStatistics returns empty array when no check-ins exist', () =
   expect(throughputStats).toEqual([]);
 });
 
+test('getThroughputStatistics returns empty array when no check-ins match the party filter', () => {
+  const localStore = LocalStore.memoryStore(mockBaseLogger({ fn: vi.fn }));
+  const testElectionDefinition = getTestElectionDefinition();
+
+  const voters = [
+    createVoter('10', 'Dylan', `O'Brien`, {
+      middleName: 'MiD',
+      suffix: 'I',
+      precinct: 'precinct-1',
+      party: 'DEM',
+    }),
+  ];
+  const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];
+  localStore.setElectionAndVoters(
+    testElectionDefinition,
+    'mock-package-hash',
+    streets,
+    voters
+  );
+  localStore.setConfiguredPrecinct('precinct-1');
+
+  localStore.recordVoterCheckIn({
+    voterId: voters[0].voterId,
+    identificationMethod: { type: 'default' },
+    ballotParty: 'DEM',
+  });
+
+  expect(localStore.getThroughputStatistics(60, 'REP')).toEqual([]);
+});
+
+test('getThroughputStatistics returns empty array when the only check-ins are absentee', () => {
+  const localStore = LocalStore.memoryStore(mockBaseLogger({ fn: vi.fn }));
+  const testElectionDefinition = getTestElectionDefinition();
+
+  const voters = [
+    createVoter('10', 'Dylan', `O'Brien`, {
+      middleName: 'MiD',
+      suffix: 'I',
+      precinct: 'precinct-1',
+      party: 'DEM',
+    }),
+  ];
+  const streets = [createValidStreetInfo('PEGASUS', 'odd', 5, 15)];
+  localStore.setElectionAndVoters(
+    testElectionDefinition,
+    'mock-package-hash',
+    streets,
+    voters
+  );
+  localStore.setConfiguredPrecinct('precinct-1');
+
+  localStore.setIsAbsenteeMode(true);
+  localStore.recordVoterCheckIn({
+    voterId: voters[0].voterId,
+    identificationMethod: { type: 'default' },
+    ballotParty: 'DEM',
+  });
+  localStore.setIsAbsenteeMode(false);
+
+  // Absentee check-ins are excluded from throughput stats, so even the 'ALL'
+  // filter has no events left to report on.
+  expect(localStore.getThroughputStatistics(60, 'ALL')).toEqual([]);
+});
+
 test('getThroughputStatistics returns correct throughput data for single interval', () => {
   // Use fake timers to control check-in times
   vi.useFakeTimers();

--- a/apps/pollbook/backend/src/local_store.ts
+++ b/apps/pollbook/backend/src/local_store.ts
@@ -790,9 +790,6 @@ export class LocalStore extends Store {
     const checkInEventRows = this.client.all(
       `SELECT * FROM event_log WHERE event_type = '${EventType.VoterCheckIn}' ORDER BY physical_time, logical_counter, machine_id`
     ) as EventDbRow[];
-    if (checkInEventRows.length === 0) {
-      return [];
-    }
     const events = convertDbRowsToPollbookEvents(checkInEventRows);
     const checkInEvents = events.filter(
       (event): event is VoterCheckInEvent =>
@@ -809,6 +806,9 @@ export class LocalStore extends Store {
           partyFilter === 'ALL' ||
           e.checkInData.ballotParty === partyFilter)
     );
+    if (filteredCheckInEvents.length === 0) {
+      return [];
+    }
 
     const orderedByEventMachineTime = [...filteredCheckInEvents].sort((a, b) =>
       a.checkInData.timestamp.localeCompare(b.checkInData.timestamp)


### PR DESCRIPTION
## Overview

Fixes a VxPollBook crash on the statistics screen, reported in
[#vxpollbook-prodeng](https://votingworks.slack.com/archives/C07CR6T1TLK/p1786566668618689).

In a primary, checking in a single Democratic voter and then opening the
Republican tab of the statistics screen crashed the app with:

```
Cannot read properties of undefined (reading 'checkInData')
```

`getThroughputStatistics` returned early only when the event log held no
check-in events at all, and then unconditionally read
`orderedByEventMachineTime[0]` — the first event *after* absentee and party
filtering:

```ts
const checkInEventRows = this.client.all(/* ... VoterCheckIn events ... */);
if (checkInEventRows.length === 0) {
  return [];                                   // guards the UNFILTERED list
}
// ...
const filteredCheckInEvents = checkInEvents.filter(
  (e) =>
    !e.checkInData.isAbsentee &&
    (!partyFilter || partyFilter === 'ALL' || e.checkInData.ballotParty === partyFilter)
);
// ...
new Date(orderedByEventMachineTime[0].checkInData.timestamp);  // undefined[0]
```

Whenever check-ins existed but none matched the filter, that index was
`undefined` and the query threw. Grout surfaced the server-side error to the
frontend, which is why the reported stack pointed at `Proxy.<anonymous>` in the
frontend bundle rather than at backend code.

This explains why the crash needed a lopsided check-in count: with zero
check-ins the original guard caught it, and once a Republican voter checked in
the filtered list was no longer empty.

Both clauses of the filter can trigger it, so there are two reachable cases:

1. **Party filter excludes every check-in** — the reported case. Crashes the tab
   for the party with no check-ins.
2. **Every check-in is absentee** — absentee check-ins are excluded from
   throughput stats too, so this crashes *every* tab, including `All`.

The fix moves the empty check to after filtering, so an unmatched filter returns
no throughput data instead of throwing.

## Demo Video or Screenshot

No visual change beyond the screen no longer crashing — the affected party's tab
now renders with an empty throughput chart, identical to how it already rendered
before any voter had checked in. Happy to attach a screenshot from the QA town
primary package if that's useful for review.

## Testing Plan

Two regression tests in `local_store.test.ts`, one per triggering case above.
Both reproduce the exact reported error message against the unfixed code and
pass with the fix.

They aren't redundant — each catches a partial fix the other lets through, which
I verified by mutation:

| Mutation of the new guard                    | party-filter test | absentee test |
| -------------------------------------------- | ----------------- | ------------- |
| `partyFilter !== 'ALL' && length === 0`      | passes            | **fails**     |
| `partyFilter === 'ALL' && length === 0`      | **fails**         | passes        |

Note that the party-filter test intentionally has no Republican voter in the
roll, whereas the QA election does have Republican voters who simply hadn't
checked in. That difference is immaterial: `getThroughputStatistics` reads only
`event_log` filtered to `VoterCheckIn` events and never touches the voter roll,
so "zero Republican check-ins" is the same input either way.

Manual verification of the original repro against a real pollbook package hasn't
been done — the reported flow is covered by the automated tests, but a QA pass
with `pollbook-package-v1.1.0-qa-town-primary.zip` would be worth doing.

Also run locally, all green:

- `apps/pollbook/backend`: 220 tests passing, `pnpm lint` clean
- `apps/pollbook/frontend`: 185 tests passing, `pnpm lint` clean

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

No new user actions, so no new logging. Left the "user-facing-change" label off
since this restores intended behavior rather than changing it — happy to add it
if a crash fix warrants an announcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
