### PR TITLE
Write tsc build-info into `build/`

### DIFF
--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -21,7 +21,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "format": "prettier '**/*.+(js|jsx|ts|tsx|css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",

--- a/apps/admin/backend/tsconfig.build.json
+++ b/apps/admin/backend/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -23,7 +23,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "format": "prettier '**/*.+(js|jsx|ts|tsx|css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",

--- a/apps/central-scan/backend/tsconfig.build.json
+++ b/apps/central-scan/backend/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/apps/design/backend/package.json
+++ b/apps/design/backend/package.json
@@ -23,7 +23,7 @@
     "build:self": "tsc --build tsconfig.build.json",
     "cancel-background-task": "pnpm build:self && node ./build/scripts/cancel_background_task.js",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "create-jurisdiction": "pnpm build:self && node ./build/scripts/create_jurisdiction.js",
     "create-jurisdiction-user": "pnpm build:self && node ./build/scripts/create_jurisdiction_user.js",
     "create-organization": "pnpm build:self && node ./build/scripts/create_organization.js",

--- a/apps/design/backend/tsconfig.build.json
+++ b/apps/design/backend/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src", "src/**/*.json"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/apps/mark-scan/backend/package.json
+++ b/apps/mark-scan/backend/package.json
@@ -20,7 +20,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json && copyfiles -u 3 src/custom-paper-handler/diagnostic/*.json build/custom-paper-handler/diagnostic",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "format": "prettier '**/*.+(js|jsx|ts|tsx|css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",

--- a/apps/mark-scan/backend/tsconfig.build.json
+++ b/apps/mark-scan/backend/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/apps/mark/backend/package.json
+++ b/apps/mark/backend/package.json
@@ -20,7 +20,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json && ./scripts/copy_build_assets.sh",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "format": "prettier '**/*.+(js|jsx|ts|tsx|css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",

--- a/apps/mark/backend/tsconfig.build.json
+++ b/apps/mark/backend/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/apps/pollbook/backend/package.json
+++ b/apps/pollbook/backend/package.json
@@ -22,7 +22,7 @@
     "build": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "format": "prettier '**/*.+(js|jsx|ts|tsx|css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",

--- a/apps/pollbook/backend/tsconfig.build.json
+++ b/apps/pollbook/backend/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src", "src/**/*.json"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/apps/print/backend/package.json
+++ b/apps/print/backend/package.json
@@ -20,7 +20,7 @@
     "build": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json && ./scripts/copy_build_assets.sh",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "format": "prettier '**/*.+(js|jsx|ts|tsx|css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",

--- a/apps/print/backend/tsconfig.build.json
+++ b/apps/print/backend/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src", "src/**/*.json"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/apps/scan/backend/package.json
+++ b/apps/scan/backend/package.json
@@ -23,7 +23,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json && ./scripts/copy_build_assets.sh",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "format": "prettier '**/*.+(js|jsx|ts|tsx|css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",

--- a/apps/scan/backend/tsconfig.build.json
+++ b/apps/scan/backend/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/auth/package.json
+++ b/libs/auth/package.json
@@ -12,7 +12,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/auth/tsconfig.build.json
+++ b/libs/auth/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "declaration": true,
     "declarationMap": true,
     "noEmit": false,

--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -16,7 +16,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/backend/tsconfig.build.json
+++ b/libs/backend/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src", "src/**/*.json"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/ballot-encoder/package.json
+++ b/libs/ballot-encoder/package.json
@@ -13,7 +13,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/ballot-encoder/tsconfig.build.json
+++ b/libs/ballot-encoder/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -22,7 +22,7 @@
     "build:self": "pnpm build:rust-addon && pnpm build:ts",
     "build:ts": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "cargo clean --release --package ballot-interpreter && rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "cargo clean --release --package ballot-interpreter && rm -rf build",
     "install:rust-addon": "cargo fetch",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",

--- a/libs/ballot-interpreter/tsconfig.build.json
+++ b/libs/ballot-interpreter/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src", "src/data/*.json"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/basics/package.json
+++ b/libs/basics/package.json
@@ -12,7 +12,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/basics/tsconfig.build.json
+++ b/libs/basics/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/bmd-ballot-fixtures/package.json
+++ b/libs/bmd-ballot-fixtures/package.json
@@ -17,7 +17,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache . && pnpm stylelint:run",
     "lint:fix": "pnpm type-check && eslint --cache . --fix && pnpm stylelint:run:fix",
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}'",

--- a/libs/bmd-ballot-fixtures/tsconfig.build.json
+++ b/libs/bmd-ballot-fixtures/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/cdf-schema-builder/package.json
+++ b/libs/cdf-schema-builder/package.json
@@ -17,7 +17,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/cdf-schema-builder/tsconfig.build.json
+++ b/libs/cdf-schema-builder/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/custom-paper-handler/package.json
+++ b/libs/custom-paper-handler/package.json
@@ -11,7 +11,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/custom-paper-handler/tsconfig.build.json
+++ b/libs/custom-paper-handler/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/db/package.json
+++ b/libs/db/package.json
@@ -12,7 +12,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/db/tsconfig.build.json
+++ b/libs/db/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "outDir": "build",
     "rootDir": "src",

--- a/libs/dev-dock/backend/package.json
+++ b/libs/dev-dock/backend/package.json
@@ -12,7 +12,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/dev-dock/backend/tsconfig.build.json
+++ b/libs/dev-dock/backend/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/dev-dock/frontend/package.json
+++ b/libs/dev-dock/frontend/package.json
@@ -12,7 +12,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/dev-dock/frontend/tsconfig.build.json
+++ b/libs/dev-dock/frontend/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/eslint-plugin-vx/package.json
+++ b/libs/eslint-plugin-vx/package.json
@@ -16,7 +16,7 @@
     "build:self": "tsc --build tsconfig.build.json",
     "build:watch": "tsc --build --watch tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "echo eslint-plugin-vs linting temporarily disabled",
     "lint:fix": "echo eslint-plugin-vs linting temporarily disabled",
     "test": "is-ci test:ci test:watch",

--- a/libs/eslint-plugin-vx/tsconfig.build.json
+++ b/libs/eslint-plugin-vx/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/fixture-generators/package.json
+++ b/libs/fixture-generators/package.json
@@ -14,7 +14,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "generate-cvr-fixtures": "./bin/generate-cvr-fixtures",
     "generate-election-packages": "./bin/regenerate-election-packages",
     "lint": "pnpm type-check && eslint --cache .",

--- a/libs/fixture-generators/tsconfig.build.json
+++ b/libs/fixture-generators/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "outDir": "build",
     "rootDir": "src",

--- a/libs/fixtures/package.json
+++ b/libs/fixtures/package.json
@@ -17,7 +17,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/fixtures/tsconfig.build.json
+++ b/libs/fixtures/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src", "src/data/*.json", "src/data/**/*.json"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",
@@ -10,6 +11,6 @@
   },
   "references": [
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
-    { "path": "../types/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" }
   ]
 }

--- a/libs/fs/package.json
+++ b/libs/fs/package.json
@@ -15,7 +15,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/fs/tsconfig.build.json
+++ b/libs/fs/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src", "src/data/*.json"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/fujitsu-thermal-printer/package.json
+++ b/libs/fujitsu-thermal-printer/package.json
@@ -11,7 +11,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/fujitsu-thermal-printer/tsconfig.build.json
+++ b/libs/fujitsu-thermal-printer/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/grout/package.json
+++ b/libs/grout/package.json
@@ -12,7 +12,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/grout/test-utils/package.json
+++ b/libs/grout/test-utils/package.json
@@ -12,7 +12,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/grout/test-utils/tsconfig.build.json
+++ b/libs/grout/test-utils/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/grout/tsconfig.build.json
+++ b/libs/grout/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/hmpb/package.json
+++ b/libs/hmpb/package.json
@@ -17,7 +17,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json && cp -R ./src/fonts ./build",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "format": "prettier '**/*.+(js|jsx|ts|tsx|css|graphql|json|less|md|mdx|sass|scss|yaml|yml)' --write",
     "generate-fixtures": "DEBUG=hmpb:ballot_fixtures ./bin/generate-fixtures",
     "generate-vxprint-test-print": "./bin/generate-vxprint-test-print",

--- a/libs/hmpb/tsconfig.build.json
+++ b/libs/hmpb/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.bench.ts"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/image-utils/package.json
+++ b/libs/image-utils/package.json
@@ -11,7 +11,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/image-utils/tsconfig.build.json
+++ b/libs/image-utils/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "outDir": "build",
     "rootDir": "src",

--- a/libs/integration-test-utils/package.json
+++ b/libs/integration-test-utils/package.json
@@ -15,7 +15,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/integration-test-utils/tsconfig.build.json
+++ b/libs/integration-test-utils/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -19,7 +19,7 @@
     "build:generate-typescript-types": "pnpm esr --cache ./scripts/generate_types_from_toml.ts",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "install:rust-addon": "cargo fetch",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",

--- a/libs/logging/tsconfig.build.json
+++ b/libs/logging/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src", "src/data/*.json"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/mark-flow-ui/package.json
+++ b/libs/mark-flow-ui/package.json
@@ -16,7 +16,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache . && pnpm stylelint:run",
     "lint:fix": "pnpm type-check && eslint --cache . --fix && pnpm stylelint:run:fix",
     "stylelint:run": "stylelint 'src/**/*.{js,jsx,ts,tsx}'",

--- a/libs/mark-flow-ui/tsconfig.build.json
+++ b/libs/mark-flow-ui/tsconfig.build.json
@@ -8,6 +8,7 @@
     "**/*.stories.tsx"
   ],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/message-coder/package.json
+++ b/libs/message-coder/package.json
@@ -11,7 +11,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/message-coder/tsconfig.build.json
+++ b/libs/message-coder/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src", "src/data/*.json"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/monorepo-utils/package.json
+++ b/libs/monorepo-utils/package.json
@@ -12,7 +12,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/monorepo-utils/tsconfig.build.json
+++ b/libs/monorepo-utils/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/networking/package.json
+++ b/libs/networking/package.json
@@ -16,7 +16,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint .",
     "lint:fix": "pnpm type-check && eslint . --fix",
     "pre-commit": "lint-staged",

--- a/libs/networking/tsconfig.build.json
+++ b/libs/networking/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/pdi-scanner/package.json
+++ b/libs/pdi-scanner/package.json
@@ -17,7 +17,7 @@
     "build:self": "pnpm build:rust-addon && pnpm build:ts",
     "build:ts": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "cargo clean --release --package pdi-scanner && rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "cargo clean --release --package pdi-scanner && rm -rf build",
     "install:rust-addon": "cargo fetch",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",

--- a/libs/pdi-scanner/tsconfig.build.json
+++ b/libs/pdi-scanner/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src/ts"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src/ts",
     "outDir": "build",

--- a/libs/printing/package.json
+++ b/libs/printing/package.json
@@ -12,7 +12,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "generate-m404n-ppd": "./scripts/generate-m404n-ppd",
     "postinstall": "test -f /usr/bin/chromium || playwright install --with-deps chromium",
     "lint": "pnpm type-check && eslint --cache .",

--- a/libs/printing/tsconfig.build.json
+++ b/libs/printing/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/test-decks/package.json
+++ b/libs/test-decks/package.json
@@ -12,7 +12,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/test-decks/tsconfig.build.json
+++ b/libs/test-decks/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/test-utils/package.json
+++ b/libs/test-utils/package.json
@@ -15,7 +15,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/test-utils/tsconfig.build.json
+++ b/libs/test-utils/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -19,7 +19,7 @@
     "cdf:err:build-schema": "cdf-schema-builder data/cdf/election-results-reporting/nist-schema.xsd data/cdf/election-results-reporting/nist-schema.json > src/cdf/election-results-reporting/index.ts",
     "cdf:logging:build-schema": "cdf-schema-builder data/cdf/election-event-logging/nist-schema.xsd data/cdf/election-event-logging/nist-schema.json > src/cdf/election-event-logging/index.ts",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/types/tsconfig.build.json
+++ b/libs/types/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -18,7 +18,7 @@
     "build:self": "tsc --build tsconfig.build.json && pnpm build:app-strings-catalog",
     "check:app-strings-catalog": "./scripts/check-app-strings-catalog",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache . && pnpm stylelint:run && pnpm check:app-strings-catalog",
     "lint:fix": "pnpm type-check && eslint --cache . --fix && pnpm stylelint:run:fix",
     "start": "storybook dev -p 6060",

--- a/libs/ui/tsconfig.build.json
+++ b/libs/ui/tsconfig.build.json
@@ -8,6 +8,7 @@
     "**/*.stories.tsx"
   ],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/usb-drive/package.json
+++ b/libs/usb-drive/package.json
@@ -12,7 +12,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/usb-drive/tsconfig.build.json
+++ b/libs/usb-drive/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -15,7 +15,7 @@
     "build:dev": "pnpm --filter $npm_package_name... build:self",
     "build:self": "tsc --build tsconfig.build.json",
     "clean": "pnpm --filter $npm_package_name... clean:self",
-    "clean:self": "rm -rf build && tsc --build --clean tsconfig.build.json",
+    "clean:self": "rm -rf build",
     "lint": "pnpm type-check && eslint --cache .",
     "lint:fix": "pnpm type-check && eslint --cache . --fix",
     "test": "is-ci test:ci test:watch",

--- a/libs/utils/tsconfig.build.json
+++ b/libs/utils/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["src", "src/**/*.json", "src/data/*.zip"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
     "noEmit": false,
     "rootDir": "src",
     "outDir": "build",

--- a/script/src/validate-monorepo/validation/tsconfig.ts
+++ b/script/src/validate-monorepo/validation/tsconfig.ts
@@ -76,6 +76,7 @@ export function* checkTsconfig(
     outDir,
     declaration,
     declarationMap,
+    tsBuildInfoFile,
     ...otherCompilerOptions
   } = tsconfig.compilerOptions ?? {};
 
@@ -127,6 +128,20 @@ export function* checkTsconfig(
         propertyKeyPath: 'compilerOptions.declarationMap',
         actualValue: declarationMap,
         expectedValue: 'true or undefined',
+      };
+    }
+
+    // Keep the incremental build-info file inside `build/` so it's removed
+    // atomically with `rm -rf build`. If it sat beside `build/`, deleting
+    // `build/` alone would leave a stale build-info that makes `tsc` skip
+    // re-emitting, leaving an empty output.
+    if (tsBuildInfoFile !== 'build/tsconfig.build.tsbuildinfo') {
+      yield {
+        kind: ValidationIssueKind.InvalidPropertyValue,
+        tsconfigPath,
+        propertyKeyPath: 'compilerOptions.tsBuildInfoFile',
+        actualValue: tsBuildInfoFile,
+        expectedValue: 'build/tsconfig.build.tsbuildinfo',
       };
     }
 


### PR DESCRIPTION
Came out of investigating Turborepo build caching; good regardless: moving each package's `tsc` build-info inside `build/` (enforced by validate-monorepo) makes `rm -rf build` a full reset, so a stale build-info can't make `tsc` skip re-emitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xsE94bqP8cXQwHfSQK7xu