### PR TITLE
Ignore jest-image-snapshot `__diff_output__` dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ junit.xml
 
 # Mock state files (namespaced by NODE_ENV for worktree isolation)
 /.mock-state
+
+# jest-image-snapshot failure diffs, regenerated on each failing run
+**/__diff_output__/


### PR DESCRIPTION
Came out of investigating Turborepo build caching; good regardless: ignoring `**/__diff_output__/` keeps jest-image-snapshot failure diffs out of `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xsE94bqP8cXQwHfSQK7xu