### PR TITLE
Give mark-scan integration tests a 90s timeout

### DIFF
--- a/apps/mark-scan/integration-testing/playwright.config.ts
+++ b/apps/mark-scan/integration-testing/playwright.config.ts
@@ -10,4 +10,10 @@ process.env['NODE_ENV'] = 'production';
 /** See https://playwright.dev/docs/test-configuration. */
 export default defineIntegrationTestPlaywrightConfig({
   viewport: { width: 1080, height: 1920 },
+  // The basic-election-flow test does real work (auth, cardless session, scan +
+  // interpret, rendering) and runs ~21-22s; Playwright's default 30s timeout is
+  // too tight under CI load, where it tips over and times out waiting for the
+  // transient "Loading Sheet" screen. Match the 90s headroom the scan and
+  // central-scan integration suites already use.
+  timeout: 90_000,
 });


### PR DESCRIPTION
Came out of investigating Turborepo build caching; good regardless: matches the 90s Playwright timeout the other integration suites use, so mark-scan doesn't flake under CI load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xsE94bqP8cXQwHfSQK7xu