### PR TITLE
Copy only the cast vote records a fixture keeps

### DIFF
--- a/apps/admin/backend/src/app.caching.test.ts
+++ b/apps/admin/backend/src/app.caching.test.ts
@@ -81,9 +81,18 @@ test('uses and clears CVR tabulation cache appropriately', async () => {
     true
   );
 
+  // This test counts tabulations rather than inspecting them, so it only needs
+  // enough cast vote records to produce non-zero results and one write-in to
+  // adjudicate. Importing the whole export twice costs three quarters of the
+  // test's runtime.
+  const castVoteRecordExportPath = await modifyCastVoteRecordExport(
+    castVoteRecordExport.asDirectoryPath(),
+    { numCastVoteRecordsToKeep: 10 }
+  );
+
   // adding a CVR file should should clear the cache
   const loadFileResult = await apiClient.addCastVoteRecordFile({
-    path: castVoteRecordExport.asDirectoryPath(),
+    path: castVoteRecordExportPath,
   });
   expect(loadFileResult).toEqual(ok(expect.anything()));
   const resultsExport = await getParsedExport({
@@ -101,15 +110,12 @@ test('uses and clears CVR tabulation cache appropriately', async () => {
 
   // adding another CVR file should should clear the cache again
   const loadFileAgainResult = await apiClient.addCastVoteRecordFile({
-    path: await modifyCastVoteRecordExport(
-      castVoteRecordExport.asDirectoryPath(),
-      {
-        castVoteRecordModifier: (castVoteRecord) => ({
-          ...castVoteRecord,
-          UniqueId: `${castVoteRecord.UniqueId}'`,
-        }),
-      }
-    ),
+    path: await modifyCastVoteRecordExport(castVoteRecordExportPath, {
+      castVoteRecordModifier: (castVoteRecord) => ({
+        ...castVoteRecord,
+        UniqueId: `${castVoteRecord.UniqueId}'`,
+      }),
+    }),
   });
   loadFileAgainResult.assertOk('load file failed');
   const doubledResultsExport = await getParsedExport({

--- a/libs/backend/src/cast_vote_records/test_utils.ts
+++ b/libs/backend/src/cast_vote_records/test_utils.ts
@@ -82,26 +82,34 @@ export async function modifyCastVoteRecordExport(
     numCastVoteRecordsToKeep,
   } = modifications;
 
+  const castVoteRecordIds = new Set(
+    await getExportedCastVoteRecordIds(exportDirectoryPath)
+  );
+  const castVoteRecordIdsToKeep = new Set(
+    [...castVoteRecordIds].sort().slice(0, numCastVoteRecordsToKeep)
+  );
+
   const modifiedExportDirectoryPath = `${exportDirectoryPath}-modified`;
+  // Skip the cast vote records being dropped rather than copying them and
+  // deleting them afterward. An export runs to hundreds of records and tens of
+  // megabytes of ballot images, so a fixture that keeps a handful of them
+  // spends nearly all of its time on the copy.
   fs.cpSync(exportDirectoryPath, modifiedExportDirectoryPath, {
     recursive: true,
+    filter: (source) => {
+      const entryName = path.relative(exportDirectoryPath, source);
+      return (
+        !castVoteRecordIds.has(entryName) ||
+        castVoteRecordIdsToKeep.has(entryName)
+      );
+    },
   });
 
-  const castVoteRecordIds = await getExportedCastVoteRecordIds(
-    modifiedExportDirectoryPath
-  );
-  for (const [i, castVoteRecordId] of [...castVoteRecordIds].sort().entries()) {
+  for (const castVoteRecordId of castVoteRecordIdsToKeep) {
     const castVoteRecordDirectoryPath = path.join(
       modifiedExportDirectoryPath,
       castVoteRecordId
     );
-    if (
-      numCastVoteRecordsToKeep !== undefined &&
-      i >= numCastVoteRecordsToKeep
-    ) {
-      fs.rmSync(castVoteRecordDirectoryPath, { recursive: true });
-      continue;
-    }
 
     const { castVoteRecord, castVoteRecordReportContents } = readCastVoteRecord(
       castVoteRecordDirectoryPath


### PR DESCRIPTION
## Overview

`app.caching.test.ts` was intermittently timing out at vitest's 5s default during full-suite runs. In isolation its body took ~2.0s, so it only failed when the machine was oversubscribed — but three quarters of that time was avoidable.

Two changes, one behind the other:

**`modifyCastVoteRecordExport` copied everything, then deleted what it was told to drop.** It `cpSync`s an entire export and afterwards `rmSync`s each record past `numCastVoteRecordsToKeep`. The New Hampshire grid-layout export is 184 records and 15MB, mostly ballot images, so a caller keeping ten of them paid for all 184. It now works out which records to keep first and passes a `filter` to `cpSync`, which skips the rest without ever descending into them. 28 call sites across `apps/admin/backend` and `libs/backend` pass `numCastVoteRecordsToKeep`.

**`app.caching.test.ts` imported the full export twice.** The test counts `getCastVoteRecords` calls to prove the tabulation cache is invalidated at the right moments — it never inspects the tallies, so the record count is incidental. It needs enough records for non-zero results and one write-in to adjudicate in `State-Representatives-Hillsborough-District-34-b1012d38`. Checking every record in sorted order, indexes 0, 10, and 11 carry such a write-in, so trimming to 10 always retains one.

Measured on the test body, excluding vitest's per-file transform and import overhead:

| | before | after |
| --- | --- | --- |
| `addCastVoteRecordFile` #1 | 645ms | 64ms |
| trim + `addCastVoteRecordFile` #2 | 835ms | 92ms |
| whole test | ~1920ms | ~700ms |

That is ~7x headroom against the 5s timeout instead of ~2.5x.

## Testing Plan

- `apps/admin/backend`: 521 tests across 46 files pass; the caching test itself runs green five times over, at 639-740ms.
- `libs/backend`: 360 tests across 46 files pass — this is where the other trimming call sites live.
- Both packages lint and type-check clean.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXXiT4ycyDvqojRK44CKNs