### PR TITLE
chore(ballot-interpreter): update zedbar to 0.5.1

### DIFF
--- a/libs/ballot-interpreter/Cargo.lock
+++ b/libs/ballot-interpreter/Cargo.lock
@@ -2724,9 +2724,9 @@ checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "zedbar"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14bfeae54f360a7279c9e95827c8c893939fa2c6462798eaed7687545c969a3c"
+checksum = "fc62824a05454c6c7c52c522a2b3d0f69a7899e5b67cd81aa03695de73731972"
 dependencies = [
  "encoding_rs",
  "rand 0.10.1",

--- a/libs/ballot-interpreter/Cargo.lock
+++ b/libs/ballot-interpreter/Cargo.lock
@@ -2724,9 +2724,9 @@ checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "zedbar"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc62824a05454c6c7c52c522a2b3d0f69a7899e5b67cd81aa03695de73731972"
+checksum = "bf6766cca4c0ca75ba3785c24f2688113030a48d5240f9deb3bbe6fc40228167"
 dependencies = [
  "encoding_rs",
  "rand 0.10.1",

--- a/libs/ballot-interpreter/Cargo.toml
+++ b/libs/ballot-interpreter/Cargo.toml
@@ -62,7 +62,7 @@ sha2 = "0.10"
 hex = "0.4.3"
 itertools = "0.12.1"
 rqrr = "0.7.1"
-zedbar = { version = "0.4.1", default-features = false, features = ["qrcode"] }
+zedbar = { version = "0.4.2", default-features = false, features = ["qrcode"] }
 base64 = "0.22.0"
 thiserror = "1.0.50"
 tokio = { version = "1.44.2", features = ["fs", "macros"] }

--- a/libs/ballot-interpreter/Cargo.toml
+++ b/libs/ballot-interpreter/Cargo.toml
@@ -62,7 +62,7 @@ sha2 = "0.10"
 hex = "0.4.3"
 itertools = "0.12.1"
 rqrr = "0.7.1"
-zedbar = { version = "0.4.2", default-features = false, features = ["qrcode"] }
+zedbar = { version = "0.5.1", default-features = false, features = ["qrcode"] }
 base64 = "0.22.0"
 thiserror = "1.0.50"
 tokio = { version = "1.44.2", features = ["fs", "macros"] }

--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -48,7 +48,7 @@
     "debug": "4.3.4",
     "node-quirc": "^2.2.1",
     "tmp": "^0.2.6",
-    "zedbar": "^0.4.1"
+    "zedbar": "^0.4.2"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.5.1",

--- a/libs/ballot-interpreter/package.json
+++ b/libs/ballot-interpreter/package.json
@@ -48,7 +48,7 @@
     "debug": "4.3.4",
     "node-quirc": "^2.2.1",
     "tmp": "^0.2.6",
-    "zedbar": "^0.4.2"
+    "zedbar": "^0.5.1"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.5.1",

--- a/libs/ballot-interpreter/src/summary-ballot/utils/qrcode.ts
+++ b/libs/ballot-interpreter/src/summary-ballot/utils/qrcode.ts
@@ -125,9 +125,14 @@ export async function detect(
         const grayscale = rgbaToGrayscale(data, width, height);
         const options = new ScanOptions();
         options.symbologies = ['QR-Code'];
-        return scanGrayscale(grayscale, width, height, options).map((symbol) =>
-          Buffer.from(symbol.data)
-        );
+        // Restricting the symbologies does not guarantee that every result is
+        // a whole QR code: zedbar also reports "Partial", a structured-append
+        // group with some of its codes missing from the image, whose data is
+        // the parts that were found joined by NUL bytes. Ballot QR codes are
+        // never structured append, so a partial result is never ballot data.
+        return scanGrayscale(grayscale, width, height, options)
+          .filter((symbol) => symbol.symbolType === 'QR-Code')
+          .map((symbol) => Buffer.from(symbol.data));
       },
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3468,8 +3468,8 @@ importers:
         specifier: ^0.2.6
         version: 0.2.7
       zedbar:
-        specifier: ^0.4.1
-        version: 0.4.1
+        specifier: ^0.4.2
+        version: 0.4.2
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.5.1
@@ -15842,8 +15842,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zedbar@0.4.1:
-    resolution: {integrity: sha512-FfmsXIHizX7l4eRW6I/GGyIdHErGJgsdMW5TiQuLUwPi1wNdUipPhm15hRqVRyQek2pgaBVg5g+gT5HcYEvEmA==}
+  zedbar@0.4.2:
+    resolution: {integrity: sha512-nRewVhLwQyykoQ7cySbdT+Y59B1FLe6k40Db5ycFqdWYbYZl67rcBxWImvu2jfb3TRI6tbGHOicE9xHEG5iLmQ==}
     engines: {node: '>=16.0.0'}
     hasBin: true
 
@@ -27992,7 +27992,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zedbar@0.4.1: {}
+  zedbar@0.4.2: {}
 
   zip-stream@4.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3468,8 +3468,8 @@ importers:
         specifier: ^0.2.6
         version: 0.2.7
       zedbar:
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: ^0.5.1
+        version: 0.5.1
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.5.1
@@ -15842,8 +15842,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zedbar@0.4.2:
-    resolution: {integrity: sha512-nRewVhLwQyykoQ7cySbdT+Y59B1FLe6k40Db5ycFqdWYbYZl67rcBxWImvu2jfb3TRI6tbGHOicE9xHEG5iLmQ==}
+  zedbar@0.5.1:
+    resolution: {integrity: sha512-zdKVpWbsvvPFpJmGvqO4XXSdU1KPWhW3eTCZfSRlUcZ0ybmiifV7CJYiy7PmOoAtXjI96oauA1gcP5cYgkxqBg==}
     engines: {node: '>=16.0.0'}
     hasBin: true
 
@@ -27992,7 +27992,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zedbar@0.4.2: {}
+  zedbar@0.5.1: {}
 
   zip-stream@4.1.0:
     dependencies:


### PR DESCRIPTION
Updates zedbar from 0.4.1 to 0.5.1 and stops treating a partial read as a whole QR code.

**0.5.1** carries the fixes from an audit of the Rust port against the zbar C source: GS1 `%` escapes, symbols dropped when a byte segment was followed by another segment, a doubled UTF-8 BOM, ECI charsets 4–18 and multi-byte ECI designators, incomplete structured-append groups reported as `Partial` rather than as whole codes, and seven inputs that panicked a debug build on integer overflow. It also narrowed the automatic retry of undecoded QR finder regions to 2D symbologies, which is what that retry exists for.

**The `symbolType` filter** in `src/summary-ballot/utils/qrcode.ts` is the one behavior change here. Restricting the scan to `QR-Code` does not mean every result is a whole QR code: as of 0.5.1 a structured-append group missing some of its codes comes back as `Partial`, with the found parts joined by NUL bytes. Ballot QR codes are never structured append, so nothing changes today — the Rust detector already filtered on `SymbolType::QrCode`, and this brings the JS detector in line.

**Nothing vxsuite decodes changes.** Scanning 3,048 ballot images from `libs/` and `vx-qa` with 0.4.1 and 0.5.1 side by side, through this package's own `DecoderConfig::new().enable(QrCode).scan_density(2, 2)`, gives identical payloads and identical bounds across all 727 symbols found.

Verified in a worktree on this branch: `cargo test` (103), `pnpm build:rust-addon`, `pnpm type-check`, and `pnpm test:ts:run` (21 files, 158 tests) all pass.
