### PR TITLE
libs/ui: Delay full screen loading component visibility to avoid flashing

### DIFF
--- a/libs/ui/src/loading.test.tsx
+++ b/libs/ui/src/loading.test.tsx
@@ -1,7 +1,11 @@
-import { expect, test } from 'vitest';
-import { render, screen } from '../test/react_testing_library';
+import { afterEach, expect, test, vi } from 'vitest';
+import { act, render, screen } from '../test/react_testing_library';
 
-import { Loading } from './loading';
+import { FULLSCREEN_LOADING_DELAY_MS, Loading } from './loading';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 test('Renders Loading with defaults', () => {
   const { container } = render(<Loading />);
@@ -10,6 +14,7 @@ test('Renders Loading with defaults', () => {
 });
 
 test('Renders Loading with: fullscreen, tag, label, and animation duration', () => {
+  vi.useFakeTimers();
   const { container } = render(
     <Loading isFullscreen as="p" animationDurationS={1}>
       Printing
@@ -17,6 +22,13 @@ test('Renders Loading with: fullscreen, tag, label, and animation duration', () 
   );
   expect(container.firstChild).toHaveStyleRule('display', 'flex');
   expect(container.firstChild).toHaveStyleRule('flex', '1');
+
+  // The fullscreen indicator is delayed to avoid flashing on fast loads
+  expect(screen.queryByText('Printing')).not.toBeInTheDocument();
+  act(() => {
+    vi.advanceTimersByTime(FULLSCREEN_LOADING_DELAY_MS);
+  });
+
   const progressEllipsis = screen.getByText('Printing');
   expect(progressEllipsis).toHaveStyleRule(
     'animation',

--- a/libs/ui/src/loading.tsx
+++ b/libs/ui/src/loading.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { ProgressEllipsis } from './progress_ellipsis';
+
+export const FULLSCREEN_LOADING_DELAY_MS = 200;
 
 const Fullscreen = styled.div`
   display: flex;
@@ -22,6 +24,17 @@ export function Loading({
   isFullscreen = false,
   animationDurationS,
 }: LoadingProps): JSX.Element {
+  const [showIndicator, setShowIndicator] = useState(!isFullscreen);
+
+  useEffect(() => {
+    if (showIndicator) return undefined;
+    const timer = setTimeout(
+      () => setShowIndicator(true),
+      FULLSCREEN_LOADING_DELAY_MS
+    );
+    return () => clearTimeout(timer);
+  }, [showIndicator]);
+
   const content = (
     <div>
       {/* FIXME: Workaround for https://github.com/jamesmfriedman/rmwc/issues/501 */}
@@ -35,7 +48,7 @@ export function Loading({
     </div>
   );
   if (isFullscreen) {
-    return <Fullscreen>{content}</Fullscreen>;
+    return <Fullscreen>{showIndicator && content}</Fullscreen>;
   }
   return content;
 }


### PR DESCRIPTION
## Overview

https://github.com/votingworks/vxsuite/issues/7049

In the process of consolidating/improving our loading indicators. Best practice according to [Material Design](https://m3.material.io/components/loading-indicator/guidelines) (and others) is to hide loading indicators for ~200ms to avoid flashing on the screen. For now applying only to full screen loading, as it's the least controversial. 

Next step will be to replace other situations where we return null instead of the loading component for screens with this updated component. Tracked in the ticket above, to be picked up on the next design day.

## Demo Video or Screenshot

## Testing Plan

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
