### PR TITLE
docs: record how to read CircleCI status and logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,6 +373,56 @@ export const saveSetting = {
 - Each app provides its API client via React context (`ApiClientContext` /
   `ApiProvider`)
 
+## CI (CircleCI)
+
+CI runs on CircleCI (`.circleci/config.yml`), not GitHub Actions — the two
+`.github/workflows/` files are unrelated. Every branch push builds; a PR is not
+required. One push creates two pipelines: a setup pipeline that path-filters,
+then a continuation pipeline whose workflows hold the ~60 real jobs.
+
+### Status
+
+With a PR: `gh pr checks <pr>` (add `--watch` to follow it).
+
+Without a PR, always pass `per_page=100`:
+
+```sh
+gh api "repos/votingworks/vxsuite/commits/<sha>/status?per_page=100" \
+  --jq '.state, (.statuses[] | select(.state != "success") | .context)'
+```
+
+The default page size is 30 and this repo posts ~62 statuses, so omitting
+`per_page` silently truncates — a truncated page can read green while a failure
+sits on page 2. CircleCI reports _statuses_, not check runs; `.../check-runs`
+returns nothing here.
+
+### Logs
+
+The project is public, so the CircleCI API needs no token:
+
+```sh
+curl -s "https://circleci.com/api/v2/project/gh/votingworks/vxsuite/pipeline?branch=<urlencoded>" \
+  | jq -r '.items[] | "\(.number) \(.id) \(.vcs.revision[0:10])"'
+curl -s "https://circleci.com/api/v2/pipeline/<pipeline-id>/workflow" \
+  | jq -r '.items[] | "\(.name) \(.id) \(.status)"'
+curl -s "https://circleci.com/api/v2/workflow/<workflow-id>/job" \
+  | jq -r '.items[] | select(.status != "success") | "\(.name) job=\(.job_number)"'
+curl -s "https://circleci.com/api/v1.1/project/github/votingworks/vxsuite/<job-number>" > /tmp/job.json
+jq -r '.steps[].actions[] | select(.status != "success") | .output_url' /tmp/job.json
+curl -s "<output-url>" | jq -r '.[].message' | sed 's/\x1b\[[0-9;]*m//g'
+```
+
+Three things that yield empty or misleading output:
+
+- A pipeline can hold more than one workflow (e.g. `test` plus a separately
+  sharded job), so iterate all workflows rather than taking `.items[0]`.
+- Select failing steps with `.status != "success"`, not `.failed == true` or a
+  non-zero `.exit_code`. A step killed by the 10-minute no-output timeout has
+  `status: "timedout"` with both of those null, so an exit-code filter finds
+  nothing and the job looks like it has no failing step.
+- `output_url` is a short-lived presigned S3 URL — fetch it immediately after
+  reading the job JSON, never from a saved earlier response.
+
 ## Pull Requests
 
 When creating PRs, use the repo template at `.github/pull_request_template.md`.


### PR DESCRIPTION
## Overview

Adds a CI section to `CLAUDE.md` covering how to check CircleCI status and read job logs from the command line.

Two traps make a failing build look green or empty, and both bit me this week: `repos/.../commits/<sha>/status` pages at 30 while this repo posts ~62 statuses, so a truncated first page can hide a failure; and a step killed by the no-output timeout reports `status: "timedout"` with `failed` and `exit_code` both null, so filtering on those finds no failing step at all. Also notes that the CircleCI API serves job details and step logs without a token, since the project is public.

## Demo Video or Screenshot

n/a — documentation only.

## Testing Plan

Every command in the section was run against this repo, including the log-fetch chain on a real failed job (`test-libs-message-coder`, job 1329135 on `main`), which the documented filter correctly surfaced as an infrastructure timeout.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
