### PR TITLE
Fix `module is not defined` crash in app frontends

### DIFF
--- a/libs/monorepo-utils/src/pnpm.ts
+++ b/libs/monorepo-utils/src/pnpm.ts
@@ -61,7 +61,9 @@ export function getWorkspacePackageInfo(
       main: packageJson.main,
       module: packageJson.module,
       source:
-        (packageJson.main || packageJson.module) &&
+        // ESM packages declare their entry point via `exports` rather than
+        // `main`/`module`, so check all three.
+        (packageJson.main || packageJson.module || packageJson.exports) &&
         existsSync(join(root, path, 'src/index.ts'))
           ? 'src/index.ts'
           : undefined,

--- a/libs/monorepo-utils/src/types.ts
+++ b/libs/monorepo-utils/src/types.ts
@@ -7,6 +7,7 @@ export interface PackageJson {
   readonly license?: string;
   readonly main?: string;
   readonly module?: string;
+  readonly exports?: string | Record<string, unknown>;
   readonly scripts?: { [name: string]: string };
   readonly dependencies?: { [name: string]: string };
   readonly devDependencies?: { [name: string]: string };


### PR DESCRIPTION
## Overview

Every app frontend currently crashes on load in the browser with `ReferenceError: module is not defined`.

`getWorkspacePackageInfo()` decided a workspace package was a library — and so should be aliased to its TypeScript source in the app Vite configs — by checking `main`/`module`. ESM packages declare their entry point via `exports` instead, so the packages converted in #9054 lost their aliases and Vite resolved them to `build/` output rather than source.

For the bundled frontend libs (`dev-dock-frontend`, `mark-flow-ui`) that meant serving tsc output compiled with the *production* JSX runtime, whose `react/jsx-runtime` import the dev-time dependency scanner never sees — the app itself only uses `react/jsx-dev-runtime` in dev. Vite handed the browser React's raw CJS shim, and `module.exports = ...` threw.

The fix adds `exports` to the entry-point check, which restores aliases for all 17 converted packages.

## Testing Plan

- Reproduced the crash in headless Chromium against a dev server on `main`, at `react/jsx-runtime.js:5:2`.
- After the fix, VxAdmin loads with zero page errors and renders the lock screen with a working dev dock (below).
- VxMark (the `mark-flow-ui` consumer) also loads clean.
- `libs/monorepo-utils` tests and lint pass; `vite build` for admin frontend succeeds.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)