### PR TITLE
VxDesign: Redesign home screen election list

### DIFF
--- a/apps/design/frontend/src/card_list.test.tsx
+++ b/apps/design/frontend/src/card_list.test.tsx
@@ -1,0 +1,77 @@
+import { expect, test, vi } from 'vitest';
+import { createPortal } from 'react-dom';
+import userEvent from '@testing-library/user-event';
+import { assertDefined } from '@votingworks/basics';
+import { fireEvent, render, screen } from '../test/react_testing_library.js';
+import { CardList, CardListItem } from './card_list.js';
+
+function renderCardListItem() {
+  const onPress = vi.fn();
+  render(
+    <CardList>
+      <CardListItem
+        onPress={onPress}
+        leadingSlot={<div>leading</div>}
+        contentSlot={<div>content</div>}
+        trailingSlot={<button type="button">action</button>}
+      />
+    </CardList>
+  );
+  return onPress;
+}
+
+function getItem(): HTMLElement {
+  return assertDefined(
+    screen.getByText('content').closest<HTMLElement>('[role="button"]')
+  );
+}
+
+test('renders all three slots', () => {
+  renderCardListItem();
+  screen.getByText('leading');
+  screen.getByText('content');
+  screen.getButton('action');
+});
+
+test('pressed on click', () => {
+  const onPress = renderCardListItem();
+  userEvent.click(screen.getByText('content'));
+  expect(onPress).toHaveBeenCalledTimes(1);
+});
+
+test('not pressed on clicks in children rendered in portals', () => {
+  const onPress = vi.fn();
+  render(
+    <CardList>
+      <CardListItem
+        onPress={onPress}
+        contentSlot={createPortal(
+          <button type="button">portal action</button>,
+          document.body
+        )}
+      />
+    </CardList>
+  );
+  userEvent.click(screen.getButton('portal action'));
+  expect(onPress).not.toHaveBeenCalled();
+});
+
+test('pressed with Enter or Space, but not other keys', () => {
+  const onPress = renderCardListItem();
+  getItem().focus();
+
+  userEvent.keyboard('{Enter}');
+  expect(onPress).toHaveBeenCalledTimes(1);
+
+  userEvent.keyboard(' ');
+  expect(onPress).toHaveBeenCalledTimes(2);
+
+  userEvent.keyboard('a');
+  expect(onPress).toHaveBeenCalledTimes(2);
+});
+
+test('not pressed on key presses bubbling up from children', () => {
+  const onPress = renderCardListItem();
+  fireEvent.keyDown(screen.getButton('action'), { key: 'Enter' });
+  expect(onPress).not.toHaveBeenCalled();
+});

--- a/apps/design/frontend/src/card_list.tsx
+++ b/apps/design/frontend/src/card_list.tsx
@@ -38,6 +38,9 @@ export interface CardListItemProps {
 /**
  * A row in a CardList. Has three fillable slots: leading, content, and
  * trailing.
+ *
+ * Any clicks or keyboard activation on the row will trigger the onPress
+ * callback, so you must disable event propagation on any interactive children.
  */
 export function CardListItem({
   onPress,

--- a/apps/design/frontend/src/card_list.tsx
+++ b/apps/design/frontend/src/card_list.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import styled from 'styled-components';
+import { H3 } from '@votingworks/ui';
+
+export const CardListItemTitle = styled(H3)`
+  margin: 0;
+`;
+
+export const CardListItemSubtitle = 'div';
+
+const StyledCardListItem = styled.div`
+  display: flex;
+  gap: 2rem;
+  align-items: stretch;
+  padding: 1rem;
+  border: ${(p) => p.theme.sizes.bordersRem.thin}rem solid
+    ${(p) => p.theme.colors.outline};
+  border-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    background-color: ${(p) => p.theme.colors.containerLow};
+
+    ${CardListItemTitle} {
+      text-decoration: underline;
+    }
+  }
+`;
+
+export interface CardListItemProps {
+  onPress: () => void;
+  leadingSlot?: React.ReactNode;
+  contentSlot?: React.ReactNode;
+  trailingSlot?: React.ReactNode;
+}
+
+/**
+ * A row in a CardList. Has three fillable slots: leading, content, and
+ * trailing.
+ */
+export function CardListItem({
+  onPress,
+  leadingSlot,
+  contentSlot,
+  trailingSlot,
+}: CardListItemProps): JSX.Element {
+  function onClick(event: React.MouseEvent) {
+    // Ignore clicks bubbling up through the React tree from children rendered
+    // in portals (e.g. modals), which happen outside the item in the DOM
+    if (!event.currentTarget.contains(event.target as Node)) {
+      return;
+    }
+    onPress();
+  }
+
+  function onKeyDown(event: React.KeyboardEvent) {
+    // Ignore key presses bubbling up from children
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      // Prevent Space from scrolling the page
+      event.preventDefault();
+      onPress();
+    }
+  }
+
+  return (
+    <StyledCardListItem
+      onClick={onClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+    >
+      {leadingSlot}
+      {contentSlot}
+      {trailingSlot}
+    </StyledCardListItem>
+  );
+}
+
+/**
+ * List of CardListItems.
+ */
+export const CardList = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  > *:not(:first-child) {
+    border-top: none;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+
+  > *:not(:last-child) {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+`;

--- a/apps/design/frontend/src/clone_election_button.tsx
+++ b/apps/design/frontend/src/clone_election_button.tsx
@@ -1,12 +1,5 @@
 import { assertDefined } from '@votingworks/basics';
-import {
-  P,
-  Button,
-  Modal,
-  ButtonVariant,
-  Font,
-  SearchSelect,
-} from '@votingworks/ui';
+import { P, Button, Modal, Font, SearchSelect } from '@votingworks/ui';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import type {
@@ -91,13 +84,12 @@ function CloneElectionModal(props: {
 
 export interface CloneElectionButtonProps {
   election: ElectionListing;
-  variant?: ButtonVariant;
 }
 
 export function CloneElectionButton(
   props: CloneElectionButtonProps
 ): React.ReactNode {
-  const { election, variant } = props;
+  const { election } = props;
 
   const history = useHistory();
   const cloneMutation = api.cloneElection.useMutation();
@@ -132,7 +124,9 @@ export function CloneElectionButton(
           {buttonLabel}
         </Tooltip>
         <Button
-          variant={variant}
+          fill="tinted"
+          style={{ padding: '0.75rem 1rem' }}
+          disableEventPropagation
           onPress={
             user.type === 'jurisdiction_user' && user.jurisdictions.length === 1
               ? () => cloneElection(user.jurisdictions[0].id)
@@ -145,9 +139,7 @@ export function CloneElectionButton(
             modalActive
           }
           icon="Copy"
-        >
-          Duplicate
-        </Button>
+        />
       </TooltipContainer>
       {modalActive && (
         <CloneElectionModal

--- a/apps/design/frontend/src/elections_screen.test.tsx
+++ b/apps/design/frontend/src/elections_screen.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { useState } from 'react';
-import { ok } from '@votingworks/basics';
+import { assertDefined, ok } from '@votingworks/basics';
 import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
 import { ElectionIdSchema, unsafeParse } from '@votingworks/types';
@@ -20,7 +20,12 @@ import {
   generalElectionRecord,
   primaryElectionRecord,
 } from '../test/fixtures.js';
-import { render, screen, waitFor, within } from '../test/react_testing_library.js';
+import {
+  render,
+  screen,
+  waitFor,
+  within,
+} from '../test/react_testing_library.js';
 import { withRoute } from '../test/routing_helpers.js';
 import { ElectionsScreen } from './elections_screen.js';
 import { routes } from './routes.js';
@@ -172,6 +177,17 @@ test('clone buttons are rendered', async () => {
   ]);
 });
 
+function getElectionItem(title: string): HTMLElement {
+  const heading = screen.getByRole('heading', { name: title });
+  return assertDefined(heading.closest<HTMLElement>('[role="button"]'));
+}
+
+function getElectionItemTitles() {
+  return screen
+    .getAllByRole('heading', { level: 3 })
+    .map((heading) => heading.textContent);
+}
+
 test('single jurisdiction elections list', async () => {
   const [general, primary] = [
     generalElectionRecord(jurisdiction.id),
@@ -185,29 +201,67 @@ test('single jurisdiction elections list', async () => {
   renderScreen();
   await screen.findByRole('heading', { name: 'Elections' });
 
-  const table = screen.getByRole('table');
-
-  // Verify the single jurisdiction table headers (no Status or Jurisdiction columns)
-  const headers = within(table).getAllByRole('columnheader');
-  expect(headers.map((header) => header.textContent)).toEqual([
-    'Title',
-    'Date',
-    '', // Clone button column
+  expect(getElectionItemTitles()).toEqual([
+    general.election.title,
+    primary.election.title,
   ]);
 
-  // Verify elections are displayed correctly
-  const rows = within(table).getAllByRole('row').slice(1);
-  expect(rows).toHaveLength(2);
+  const generalRow = getElectionItem(general.election.title);
+  within(generalRow).getByText('Nov 3, 2020');
+  within(generalRow).getByText('In Progress');
+  // No jurisdiction shown for single-jurisdiction users
+  expect(generalRow).not.toHaveTextContent('jurisdiction1 Name');
 
-  // Check first election row content
-  const firstRowCells = within(rows[0]).getAllByRole('cell');
-  expect(firstRowCells[0]).toHaveTextContent(general.election.title);
-  expect(firstRowCells[1]).toHaveTextContent('Nov 3, 2020');
+  const primaryRow = getElectionItem(primary.election.title);
+  within(primaryRow).getByText('Sep 8, 2021');
+  within(primaryRow).getByText('In Progress');
+});
 
-  // Check second election row content
-  const secondRowCells = within(rows[1]).getAllByRole('cell');
-  expect(secondRowCells[0]).toHaveTextContent(primary.election.title);
-  expect(secondRowCells[1]).toHaveTextContent('Sep 8, 2021');
+test('clicking an election item navigates to the election', async () => {
+  const general = generalElectionRecord(jurisdiction.id);
+  apiMock.getUser.expectCallWith().resolves(user);
+  apiMock.listElections.expectCallWith().resolves([electionListing(general)]);
+
+  const { history } = renderScreen();
+  await screen.findByRole('heading', { name: 'Elections' });
+
+  userEvent.click(getElectionItem(general.election.title));
+  expect(history.location.pathname).toEqual(
+    `/elections/${general.election.id}`
+  );
+});
+
+test('election status indicators', async () => {
+  const general = generalElectionRecord(jurisdiction.id);
+  function listing(
+    electionId: string,
+    title: string,
+    status: ElectionListing['status']
+  ): ElectionListing {
+    return {
+      ...electionListing(general),
+      electionId: unsafeParse(ElectionIdSchema, electionId),
+      title,
+      status,
+    };
+  }
+  apiMock.getUser.expectCallWith().resolves(user);
+  apiMock.listElections
+    .expectCallWith()
+    .resolves([
+      listing('not-started', 'Not Started Election', 'notStarted'),
+      listing('in-progress', 'In Progress Election', 'inProgress'),
+      listing('finalized', 'Finalized Election', 'ballotsFinalized'),
+      listing('approved', 'Approved Election', 'ballotsApproved'),
+    ]);
+
+  renderScreen();
+  await screen.findByRole('heading', { name: 'Elections' });
+
+  within(getElectionItem('Not Started Election')).getByText('In Progress');
+  within(getElectionItem('In Progress Election')).getByText('In Progress');
+  within(getElectionItem('Finalized Election')).getByText('Finalized');
+  within(getElectionItem('Approved Election')).getByText('Finalized');
 });
 
 test('elections list for user with multiple jurisdictions', async () => {
@@ -224,36 +278,28 @@ test('elections list for user with multiple jurisdictions', async () => {
   renderScreen();
   await screen.findByRole('heading', { name: 'Elections' });
 
-  const table = screen.getByRole('table');
-
-  const headers = within(table).getAllByRole('columnheader');
-  expect(headers.map((header) => header.textContent)).toEqual([
-    'Title',
-    'Date',
-    'Jurisdiction',
-    '', // Clone button column
+  expect(getElectionItemTitles()).toEqual([
+    generalJurisdiction1.election.title,
+    'Untitled Election',
   ]);
 
-  const rows = within(table).getAllByRole('row').slice(1);
-  expect(rows).toHaveLength(2);
+  // Rows show each election's jurisdiction in the subtitle
+  const firstRow = getElectionItem(generalJurisdiction1.election.title);
+  within(firstRow).getByText(/jurisdiction1 Name/);
 
-  const firstRowCells = within(rows[0]).getAllByRole('cell');
-  expect(firstRowCells[2]).toHaveTextContent('jurisdiction1 Name');
-  const secondRowCells = within(rows[1]).getAllByRole('cell');
-  expect(secondRowCells[0]).toHaveTextContent('Untitled Election');
-  expect(secondRowCells[1]).toHaveTextContent(
-    format.localeDate(
-      generalJurisdiction2.election.date.toMidnightDatetimeWithSystemTimezone()
+  const secondRow = getElectionItem('Untitled Election');
+  within(secondRow).getByText(
+    new RegExp(
+      format.localeDate(
+        generalJurisdiction2.election.date.toMidnightDatetimeWithSystemTimezone()
+      )
     )
   );
-  expect(secondRowCells[2]).toHaveTextContent('jurisdiction2 Name');
+  within(secondRow).getByText(/jurisdiction2 Name/);
 
   // Can filter by jurisdiction name
   const filterInput = screen.getByLabelText(/filter elections/i);
   userEvent.type(filterInput, 'jurisdiction2 Name');
 
-  const filteredRows = within(table).getAllByRole('row').slice(1);
-  expect(filteredRows).toHaveLength(1);
-  const filteredRowCells = within(filteredRows[0]).getAllByRole('cell');
-  expect(filteredRowCells[2]).toHaveTextContent('jurisdiction2 Name');
+  expect(getElectionItemTitles()).toEqual(['Untitled Election']);
 });

--- a/apps/design/frontend/src/elections_screen.tsx
+++ b/apps/design/frontend/src/elections_screen.tsx
@@ -1,5 +1,5 @@
-import { unique } from '@votingworks/basics';
-import { H1, MainContent, Table } from '@votingworks/ui';
+import { throwIllegalValue, unique } from '@votingworks/basics';
+import { Caption, H1, Icons, MainContent } from '@votingworks/ui';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
@@ -19,6 +19,12 @@ import { routes } from './routes.js';
 import { CloneElectionButton } from './clone_election_button.js';
 import { LoadElectionButton } from './load_election_button.js';
 import { FilterInput } from './filter_input.js';
+import {
+  CardList,
+  CardListItem,
+  CardListItemSubtitle,
+  CardListItemTitle,
+} from './card_list.js';
 
 export const ElectionRow = styled.tr`
   & td {
@@ -53,6 +59,62 @@ export function LinkCell(
   );
 }
 
+const StatusContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  width: 4rem;
+`;
+
+const StatusIcon = styled.div`
+  font-size: 1.5rem;
+`;
+
+function Status({
+  icon,
+  label,
+}: {
+  icon: React.ReactNode;
+  label: string;
+}): JSX.Element {
+  return (
+    <StatusContainer>
+      <StatusIcon>{icon}</StatusIcon>
+      <Caption style={{ lineHeight: 1 }}>{label}</Caption>
+    </StatusContainer>
+  );
+}
+
+function ElectionStatus({
+  election,
+}: {
+  election: ElectionListing;
+}): JSX.Element {
+  switch (election.status) {
+    case 'notStarted':
+    case 'inProgress':
+      return (
+        <Status icon={<Icons.Contrast color="warning" />} label="In Progress" />
+      );
+    case 'ballotsFinalized':
+    case 'ballotsApproved':
+      return <Status icon={<Icons.Done color="primary" />} label="Finalized" />;
+    /* istanbul ignore next */
+    default: {
+      throwIllegalValue(election.status);
+    }
+  }
+}
+
+const ContentContainer = styled.div`
+  margin-top: -0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  flex: 1;
+`;
+
 function ElectionsList({
   elections,
   hasMultipleJurisdictions,
@@ -60,45 +122,37 @@ function ElectionsList({
   elections: ElectionListing[];
   hasMultipleJurisdictions: boolean;
 }): JSX.Element | null {
+  const history = useHistory();
+
   return (
-    <Table>
-      <thead>
-        <tr>
-          <th>Title</th>
-          <th>Date</th>
-          {hasMultipleJurisdictions && <th>Jurisdiction</th>}
-          <th />
-        </tr>
-      </thead>
-      <tbody>
-        {elections.map((election) => (
-          <ElectionRow key={election.electionId}>
-            <LinkCell election={election}>
-              {election.title || 'Untitled Election'}
-            </LinkCell>
-
-            <LinkCell election={election}>
-              {election.date &&
-                format.localeDate(
-                  election.date.toMidnightDatetimeWithSystemTimezone()
+    <CardList>
+      {elections.map((election) => (
+        <CardListItem
+          key={election.electionId}
+          onPress={() => history.push(`/elections/${election.electionId}`)}
+          leadingSlot={<ElectionStatus election={election} />}
+          contentSlot={
+            <ContentContainer>
+              <CardListItemTitle>
+                {election.title || 'Untitled Election'}
+              </CardListItemTitle>
+              <CardListItemSubtitle>
+                {election.date &&
+                  format.localeDate(
+                    election.date.toMidnightDatetimeWithSystemTimezone()
+                  )}
+                {hasMultipleJurisdictions && (
+                  <React.Fragment>
+                    {` • ${election.jurisdictionName}`}
+                  </React.Fragment>
                 )}
-            </LinkCell>
-
-            {hasMultipleJurisdictions && (
-              <LinkCell election={election}>
-                {election.jurisdictionName}
-              </LinkCell>
-            )}
-
-            <td>
-              <Row style={{ justifyContent: 'flex-end' }}>
-                <CloneElectionButton election={election} />
-              </Row>
-            </td>
-          </ElectionRow>
-        ))}
-      </tbody>
-    </Table>
+              </CardListItemSubtitle>
+            </ContentContainer>
+          }
+          trailingSlot={<CloneElectionButton election={election} />}
+        />
+      ))}
+    </CardList>
   );
 }
 
@@ -143,15 +197,8 @@ export function ElectionsScreen({
         <H1>Elections</H1>
       </Header>
       <MainContent>
-        <Column style={{ gap: '1rem', height: '100%', overflow: 'hidden' }}>
-          <Row
-            style={{
-              gap: '0.5rem',
-              // Leave space for focus outlines on buttons/input, which
-              // otherwise overflow and are hidden
-              margin: '0.125rem',
-            }}
-          >
+        <Column style={{ gap: '1rem' }}>
+          <Row style={{ gap: '0.5rem' }}>
             <FilterInput
               value={filterText}
               onChange={setFilterText}
@@ -171,12 +218,10 @@ export function ElectionsScreen({
             <LoadElectionButton disabled={anyMutationIsLoading} />
           </Row>
 
-          <div style={{ overflow: 'auto' }}>
-            <ElectionsList
-              elections={filteredElections}
-              hasMultipleJurisdictions={hasMultipleJurisdictions}
-            />
-          </div>
+          <ElectionsList
+            elections={filteredElections}
+            hasMultipleJurisdictions={hasMultipleJurisdictions}
+          />
         </Column>
       </MainContent>
     </NavScreen>

--- a/apps/design/frontend/src/filter_input.tsx
+++ b/apps/design/frontend/src/filter_input.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@votingworks/ui';
+import { Button, Icons } from '@votingworks/ui';
 import React from 'react';
 
 export interface FilterInputProps
@@ -13,12 +13,23 @@ export function FilterInput({
   const filterRef = React.useRef<HTMLInputElement>(null);
   return (
     <div style={{ ...(props.style ?? {}), position: 'relative' }}>
+      <span
+        style={{
+          position: 'absolute',
+          left: '0.75rem',
+          top: '50%',
+          transform: 'translateY(-50%)',
+          pointerEvents: 'none',
+        }}
+      >
+        <Icons.Search color="neutralMuted" />
+      </span>
       <input
         {...props}
         ref={filterRef}
         type="text"
         onChange={(e) => onChange(e.target.value)}
-        style={{ width: '100%' }}
+        style={{ width: '100%', paddingLeft: '2.25rem' }}
       />
       <Button
         style={{

--- a/apps/design/frontend/src/support/support_home_screen.test.tsx
+++ b/apps/design/frontend/src/support/support_home_screen.test.tsx
@@ -95,14 +95,14 @@ test('lists elections', async () => {
       'jurisdiction1 Name',
       general.election.title,
       'Nov 3, 2020',
-      `Make a copy of ${general.election.title}Duplicate`,
+      `Make a copy of ${general.election.title}`,
     ],
     [
       'In progress',
       'jurisdiction1 Name',
       primary.election.title,
       'Sep 8, 2021',
-      `Make a copy of ${primary.election.title}Duplicate`,
+      `Make a copy of ${primary.election.title}`,
     ],
   ]);
 


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

<!-- Add a link to a GitHub issue here -->
Switches the election list on the home screen from a table to a list of clickable card items.

## Demo Video or Screenshot


https://github.com/user-attachments/assets/0dfdfd06-5a5b-4279-98e4-c2591e1f8a93



## Testing Plan
Updated existing tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
