### PR TITLE
Fix invalid HTML nesting flagged by validateDOMNesting

### DIFF
--- a/apps/central-scan/frontend/src/screens/settings_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/settings_screen.tsx
@@ -85,7 +85,7 @@ export function SettingsScreen({
       )}
 
       <H2>Polling Place</H2>
-      <P>
+      <P as="div">
         <PollingPlacePicker
           mode={hasScannedBatches ? 'disabled' : 'default'}
           includedTypes={['absentee', 'election_day', 'early_voting']}

--- a/apps/design/frontend/src/districts_screen.tsx
+++ b/apps/design/frontend/src/districts_screen.tsx
@@ -237,7 +237,7 @@ function Contents(props: { editing: boolean }): React.ReactNode {
                   </strong>
                 </P>
               ) : (
-                <P>
+                <P as="div">
                   Are you sure you want to delete the following districts?{' '}
                   <strong>
                     This will delete all contests associated with these

--- a/apps/design/frontend/src/proofing_status.tsx
+++ b/apps/design/frontend/src/proofing_status.tsx
@@ -230,7 +230,7 @@ export function ProofingStatus(): React.ReactNode {
                 Unfinalizing will clear exports and reenable editing. Enter a
                 reason for unfinalizing.
               </P>
-              <P>
+              <P as="div">
                 <InputGroup label="Reason">
                   <TextArea
                     id="reason-for-unfinalizing"
@@ -327,7 +327,7 @@ function QaStatus({ qaRun }: { qaRun: ExportQaRun }): React.ReactNode {
     return (
       <Callout color="danger" icon="Danger">
         <div>
-          <P style={{ lineHeight: 1 }} weight="bold">
+          <P as="div" style={{ lineHeight: 1 }} weight="bold">
             QA Check Failed
             {resultsUrl && (
               <P>

--- a/apps/mark-scan/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark-scan/frontend/src/pages/admin_screen.tsx
@@ -106,7 +106,7 @@ export function AdminScreen({
           {format.count(ballotsPrintedCount)}
         </P>
         <H3 as="h2">Configuration</H3>
-        <P>
+        <P as="div">
           <LocationPicker
             election={election}
             pollsState={pollsState}

--- a/apps/mark/frontend/src/pages/admin_screen.tsx
+++ b/apps/mark/frontend/src/pages/admin_screen.tsx
@@ -123,7 +123,7 @@ export function AdminScreen({
           {format.count(ballotsPrintedCount)}
         </P>
         <H3 as="h2">Configuration</H3>
-        <P>
+        <P as="div">
           <LocationPicker
             election={election}
             pollsState={pollsState}

--- a/apps/mark/frontend/src/pages/test_deck_screen.tsx
+++ b/apps/mark/frontend/src/pages/test_deck_screen.tsx
@@ -63,7 +63,7 @@ export function TestDeckScreen({
           </Button>
         </P>
         {!isPrinterConnected && (
-          <P>
+          <P as="div">
             <Callout icon="Warning" color="warning">
               No printer detected. Connect it to print test decks.
             </Callout>
@@ -85,7 +85,7 @@ export function TestDeckScreen({
               : 'Print All Test Decks'}
           </Button>
         </P>
-        <P>
+        <P as="div">
           <SearchSelect
             aria-label="Select a precinct"
             isMulti={false}

--- a/apps/scan/frontend/src/screens/internal_connection_problem_screen.tsx
+++ b/apps/scan/frontend/src/screens/internal_connection_problem_screen.tsx
@@ -43,7 +43,7 @@ export function InternalConnectionProblemScreen({
             <PrinterErrorMessage printerStatus={printerStatus} />
           </P>
         )}
-        <P>
+        <P as="div">
           {isPollWorkerAuth ? (
             <P>
               <PowerDownButton variant="primary" />

--- a/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.tsx
+++ b/libs/mark-flow-ui/src/components/poll_worker/ballot_style_select.tsx
@@ -142,7 +142,7 @@ export function BallotStyleSelect(props: BallotStyleSelectProps): JSX.Element {
       )}
 
       {selectedPrecinctOrSplit && (
-        <P>
+        <P as="div">
           <Font weight="semiBold">Select ballot style:</Font>
           <ButtonGrid>
             {getBallotStyleGroupsForPrecinctOrSplit({

--- a/libs/ui/src/typography.tsx
+++ b/libs/ui/src/typography.tsx
@@ -21,6 +21,16 @@ export interface FontProps {
   maxLines?: number;
 }
 
+/** Props for {@link P}. */
+export type ParagraphProps = FontProps & {
+  /**
+   * Renders a `<div>` instead of a `<p>`, keeping the paragraph styling. Use
+   * when the paragraph contains block-level content (e.g. a list, or a
+   * component that renders a `<div>`), which is invalid inside a `<p>`.
+   */
+  as?: 'div';
+};
+
 /**
  * Props for {@link H1}, {@link H2}, {@link H3}, {@link H4}, {@link H5}, and
  * {@link H6}
@@ -173,7 +183,7 @@ export function H6(props: HeadingProps): JSX.Element {
 }
 
 /** Styled block paragraph text for regular copy. */
-export function P(props: FontProps): JSX.Element {
+export function P(props: ParagraphProps): JSX.Element {
   return <StyledP {...props} />;
 }
 


### PR DESCRIPTION
## Overview

Claude's writeup below. This is a bit outside my wheelhouse. This approach feels like a hack, but there is some precedent in the codebase. Opening this mainly as a nudge to silencing some test warnings, but very much open to alternative ideas.

---

Ten product sites wrapped block-level content in a `<p>`, which React flags as `validateDOMNesting` noise on every test run. `libs/ui`'s `P` now accepts `as="div"` — mirroring the existing `<H2 as="h1">` idiom — and the offending sites use it. Because `as` reuses the same styled component, the generated class and emitted CSS are unchanged.

See the commit for the audit method, validation, and alternatives considered.

## Demo Video or Screenshot

No visual change — that's the point. Before/after DOM and Chromium rendering are identical; details in the commit message.

## Testing Plan

- All 11 jsdom suites pass with identical test counts (2922 passed, 2 skipped) and zero `validateDOMNesting` output. Note that `vitest.config.shared.mts` sets `reporters: []` outside CI, which suppresses console output — reproducing this locally needs `--reporter=default`.
- A temporary DOM audit (patching `appendChild`/`insertBefore` to record any flow-content element inserted under a `<p>`) records zero hits across all jsdom packages after the fix, and found sites React's deduped warning never reported.
- Full-document captures (including the injected styled-components stylesheet) from the affected tests, before vs after: `<head>` byte-identical across 99 captures; the only edits anywhere are `<p …>` → `<div …>` with identical attributes.
- 61 of those pages replayed in Chromium with the before-DOM rebuilt via DOM APIs: zero of 5228 elements changed geometry or any of 35 computed CSS properties, and residual pixel deltas exactly equal a provably no-op div-to-div re-creation control.
- `lint` (which type-checks) clean on all 13 packages that use `P`.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
