### PR TITLE
[VxAdmin] CVR Management: Add UI for single-import deletion

### DIFF
--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -766,6 +766,21 @@ export const clearCastVoteRecordFiles = {
   },
 } as const;
 
+export const deleteCvrFile = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.deleteCvrFile, {
+      async onSuccess() {
+        return Promise.all([
+          invalidateCastVoteRecordQueries(queryClient),
+          invalidateWriteInQueries(queryClient),
+        ]);
+      },
+    });
+  },
+} as const;
+
 export const addCastVoteRecordFile = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/admin/frontend/src/screens/tally/cvrs_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvrs_screen.test.tsx
@@ -11,13 +11,18 @@ import { mockUsbDriveStatus } from '@votingworks/ui';
 import { renderInAppContext } from '../../../test/render_in_app_context.js';
 import { CvrsScreen } from './cvrs_screen.js';
 import { createApiMock } from '../../../test/helpers/mock_api_client.js';
-import { screen, waitFor } from '../../../test/react_testing_library.js';
+import {
+  screen,
+  waitFor,
+  within,
+} from '../../../test/react_testing_library.js';
 
 const electionDefinition = readElectionGeneralDefinition();
 const { election } = electionDefinition;
 
 const nLocations = election.pollingPlaces.length;
 const [place1, place2] = election.pollingPlaces;
+const [precinct1] = election.precincts;
 
 test('renders summary cards', async () => {
   const api = createApiMock();
@@ -239,8 +244,129 @@ describe('cvr modes', () => {
   });
 });
 
+describe('single-import deletion', () => {
+  test('unofficial results - can delete individual imports', async () => {
+    const api = createApiMock();
+
+    const file1 = mockCvrFile({
+      id: 'file1',
+      numCvrsImported: 15,
+      pollingPlaceIds: [place1.id],
+      scannerIds: ['001'],
+    });
+    const file2 = mockCvrFile({
+      id: 'file2',
+      numCvrsImported: 30,
+      pollingPlaceIds: [place1.id],
+      scannerIds: ['002'],
+    });
+
+    api.expectGetCastVoteRecordFileMode('test');
+    api.expectGetCastVoteRecordFiles([file1, file2]);
+
+    renderInAppContext(<CvrsScreen />, {
+      apiMock: api,
+      electionDefinition,
+      isOfficialResults: false,
+    });
+
+    await waitFor(() => api.assertComplete());
+
+    userEvent.click(screen.getButton(new RegExp(place1.name)));
+    const deleteButtons = screen.getAllButtons(/Remove CVR File/);
+    expect(deleteButtons).toHaveLength(2);
+
+    userEvent.click(deleteButtons[1]);
+    const modal = within(await screen.findByRole('alertdialog'));
+    modal.getByText(
+      new RegExp(`${file2.numCvrsImported} CVRs.+will be permanently deleted`)
+    );
+
+    api.apiClient.deleteCvrFile.expectCallWith({ fileId: file2.id }).resolves();
+    api.expectGetCastVoteRecordFileMode('test');
+    api.expectGetCastVoteRecordFiles([file1]);
+
+    userEvent.click(modal.getButton('Remove'));
+    await waitFor(() => api.assertComplete());
+
+    // Expect panel still open and now reflects updated file list (single file):
+    await screen.findButton(/Remove CVR File/);
+  });
+
+  test('unofficial results - can cancel out of confirmation modal', async () => {
+    const api = createApiMock();
+
+    api.expectGetCastVoteRecordFileMode('test');
+    api.expectGetCastVoteRecordFiles([
+      mockCvrFile({
+        id: 'file1',
+        numCvrsImported: 15,
+        pollingPlaceIds: [place1.id],
+        scannerIds: ['001'],
+      }),
+    ]);
+
+    renderInAppContext(<CvrsScreen />, {
+      apiMock: api,
+      electionDefinition,
+      isOfficialResults: false,
+    });
+
+    await waitFor(() => api.assertComplete());
+
+    userEvent.click(screen.getButton(new RegExp(place1.name)));
+    userEvent.click(screen.getButton(/Remove CVR File/));
+
+    const modal = within(await screen.findByRole('alertdialog'));
+    userEvent.click(modal.getButton('Cancel'));
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+
+    api.assertComplete();
+
+    await screen.findButton(/Remove CVR File/);
+  });
+
+  test('official results - delete buttons omitted', async () => {
+    const api = createApiMock();
+
+    api.expectGetCastVoteRecordFileMode('test');
+    api.expectGetCastVoteRecordFiles([
+      mockCvrFile({
+        id: 'file1',
+        numCvrsImported: 15,
+        pollingPlaceIds: [place1.id],
+      }),
+    ]);
+
+    renderInAppContext(<CvrsScreen />, {
+      apiMock: api,
+      electionDefinition,
+      isOfficialResults: true,
+    });
+
+    await waitFor(() => api.assertComplete());
+
+    userEvent.click(screen.getButton(new RegExp(place1.name)));
+    expect(screen.queryButton(/Remove CVR File/)).not.toBeInTheDocument();
+  });
+});
+
 function mockCvrFile(
   file: Partial<CastVoteRecordFileRecord>
 ): CastVoteRecordFileRecord {
-  return file as CastVoteRecordFileRecord;
+  const exportTimestamp = new Date().toISOString();
+
+  return {
+    exportTimestamp,
+    id: exportTimestamp,
+    pollingPlaceIds: [place1.id],
+    scannerIds: ['001'],
+    createdAt: exportTimestamp,
+    electionId: election.id,
+    filename: exportTimestamp,
+    numCvrsImported: 1,
+    precinctIds: [precinct1.id],
+    sha256Hash: 'hash',
+    ...file,
+  };
 }

--- a/apps/admin/frontend/src/screens/tally/cvrs_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvrs_screen.tsx
@@ -10,6 +10,7 @@ import {
   Icons,
 } from '@votingworks/ui';
 import { assertDefined } from '@votingworks/basics';
+import type { CastVoteRecordFileRecord as CvrImport } from '@votingworks/admin-backend';
 
 import { CvrSummaries } from './cvr_summaries.js';
 import { GAP, INSET_FOCUS_OUTLINE } from './styles.js';
@@ -18,6 +19,7 @@ import { RemoveAllCvrsModal } from './remove_all_cvrs_modal.js';
 import { CvrsState, useCvrsState } from './cvrs_state.js';
 import { LocationList } from './location_list.js';
 import { CvrImportPanel } from './cvr_import_panel.js';
+import { RemoveImportModal } from './remove_import_modal.js';
 
 const TEST_MODE_CONTAINER_CSS = css`
   grid-template-rows: min-content min-content 1fr;
@@ -152,12 +154,17 @@ export function ViewPanel(props: {
 }): React.ReactNode {
   const { openImportPanel, state } = props;
 
-  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [confirmingDeleteAll, setConfirmingDeleteAll] = useState(false);
+  const [importToDelete, setImportToDelete] = React.useState<CvrImport>();
   const [filter, setFilter] = React.useState<LocationFilter>('all');
   const [query, setQuery] = React.useState('');
 
   const showLoad = !state.isOfficialResults;
   const showDelete = state.files.length > 0 && !state.isOfficialResults;
+
+  function startDeleteImport(id: string) {
+    setImportToDelete(state.files.find((f) => f.id === id));
+  }
 
   return (
     <ViewPanelContainer>
@@ -184,22 +191,29 @@ export function ViewPanel(props: {
           <Button
             icon="Trash"
             color="danger"
-            disabled={confirmingDelete}
-            onPress={setConfirmingDelete}
+            disabled={confirmingDeleteAll}
+            onPress={setConfirmingDeleteAll}
             value
           >
             Remove All
           </Button>
         )}
-        {confirmingDelete && (
-          <RemoveAllCvrsModal onClose={() => setConfirmingDelete(false)} />
+        {confirmingDeleteAll && (
+          <RemoveAllCvrsModal onClose={() => setConfirmingDeleteAll(false)} />
         )}
       </ActionBar>
 
       <LocationList
+        deleteImport={state.isOfficialResults ? undefined : startDeleteImport}
         locations={filterLocations(state, filter, query)}
         locationCvrs={state.locationCvrs}
       />
+      {importToDelete && (
+        <RemoveImportModal
+          close={() => setImportToDelete(undefined)}
+          cvrImport={importToDelete}
+        />
+      )}
     </ViewPanelContainer>
   );
 }

--- a/apps/admin/frontend/src/screens/tally/location_cvrs_panel.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_cvrs_panel.tsx
@@ -9,12 +9,13 @@ import {
   Icons,
 } from '@votingworks/ui';
 import { format } from '@votingworks/utils';
-import { PollingPlaceType, pollingPlaceTypeName } from '@votingworks/types';
+import { Id, PollingPlaceType, pollingPlaceTypeName } from '@votingworks/types';
 import type { CastVoteRecordFileRecord } from '@votingworks/admin-backend';
 import { GAP, INSET_FOCUS_OUTLINE } from './styles.js';
 
 export interface LocationCvrsPanelProps {
   closePanel: () => void;
+  deleteImport?: (id: Id) => void;
   imports: LocationCvrImport[];
   name: string;
   type: PollingPlaceType;
@@ -110,12 +111,16 @@ const Title = styled.div`
 `;
 
 export function LocationCvrsPanel(props: LocationCvrsPanelProps): JSX.Element {
-  const { closePanel, imports, name, type } = props;
+  const { closePanel, deleteImport, imports, name, type } = props;
 
   function scannerDetails(i: LocationCvrImport) {
     return i.scannerIds.length === 1
       ? `Scanner ${i.scannerIds[0]}`
       : `Scanners: ${i.scannerIds.join(', ')}`;
+  }
+
+  function exportDate(i: LocationCvrImport) {
+    return format.localeShortDateAndTime(new Date(i.exportTimestamp));
   }
 
   return (
@@ -139,17 +144,23 @@ export function LocationCvrsPanel(props: LocationCvrsPanelProps): JSX.Element {
           {imports.map((i) => (
             <Import key={i.id}>
               <Caption weight="semiBold">
-                {format.localeShortDateAndTime(new Date(i.exportTimestamp))}
+                {exportDate(i)}
                 <br />
                 <Caption weight="regular">{scannerDetails(i)}</Caption>
               </Caption>
 
               <Font weight="bold">{format.count(i.numCvrsImported)}</Font>
 
-              {/*
-               * [TODO](https://github.com/votingworks/vxsuite/issues/4048)
-               * Add single-import delete button.
-               */}
+              {deleteImport && (
+                <IconButton
+                  aria-label={`Remove CVR File From ${exportDate(i)}`}
+                  as={Button<Id>}
+                  color="danger"
+                  icon="Trash"
+                  onPress={deleteImport}
+                  value={i.id}
+                />
+              )}
             </Import>
           ))}
 

--- a/apps/admin/frontend/src/screens/tally/location_cvrs_panel.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_cvrs_panel.tsx
@@ -119,7 +119,7 @@ export function LocationCvrsPanel(props: LocationCvrsPanelProps): JSX.Element {
       : `Scanners: ${i.scannerIds.join(', ')}`;
   }
 
-  function exportDate(i: LocationCvrImport) {
+  function formatExportDate(i: LocationCvrImport) {
     return format.localeShortDateAndTime(new Date(i.exportTimestamp));
   }
 
@@ -144,7 +144,7 @@ export function LocationCvrsPanel(props: LocationCvrsPanelProps): JSX.Element {
           {imports.map((i) => (
             <Import key={i.id}>
               <Caption weight="semiBold">
-                {exportDate(i)}
+                {formatExportDate(i)}
                 <br />
                 <Caption weight="regular">{scannerDetails(i)}</Caption>
               </Caption>
@@ -153,7 +153,7 @@ export function LocationCvrsPanel(props: LocationCvrsPanelProps): JSX.Element {
 
               {deleteImport && (
                 <IconButton
-                  aria-label={`Remove CVR File From ${exportDate(i)}`}
+                  aria-label={`Remove CVR File From ${formatExportDate(i)}`}
                   as={Button<Id>}
                   color="danger"
                   icon="Trash"

--- a/apps/admin/frontend/src/screens/tally/location_list.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_list.tsx
@@ -10,6 +10,7 @@ import { LocationStatusCard } from './location_status_card.js';
 import { GAP, INSET_FOCUS_OUTLINE } from './styles.js';
 
 export interface LocationListProps {
+  deleteImport?: (id: Id) => void;
   locationCvrs: Map<Id, LocationCvrs>;
   locations: readonly PollingPlace[];
 }
@@ -50,7 +51,7 @@ const ListItems = styled.div`
 `;
 
 export function LocationList(props: LocationListProps): React.ReactNode {
-  const { locationCvrs, locations } = props;
+  const { deleteImport, locationCvrs, locations } = props;
   const [selectedId, setSelectedId] = React.useState<string>();
 
   function toggleSelected(id: string) {
@@ -79,6 +80,7 @@ export function LocationList(props: LocationListProps): React.ReactNode {
         {selected && (
           <LocationCvrsPanel
             closePanel={() => setSelectedId(undefined)}
+            deleteImport={deleteImport}
             imports={assertDefined(locationCvrs.get(selected.id)).files}
             name={selected.name}
             type={selected.type}

--- a/apps/admin/frontend/src/screens/tally/remove_import_modal.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/remove_import_modal.test.tsx
@@ -1,0 +1,87 @@
+import { expect, test, vi } from 'vitest';
+
+import type { CastVoteRecordFileRecord as CvrImport } from '@votingworks/admin-backend';
+
+import { deferred } from '@votingworks/basics';
+import userEvent from '@testing-library/user-event';
+import { screen, waitFor } from '../../../test/react_testing_library';
+import { RemoveImportModal } from './remove_import_modal';
+import { renderInAppContext } from '../../../test/render_in_app_context';
+import { createApiMock } from '../../../test/helpers/mock_api_client';
+
+const exportDate = new Date('2020-01-02T18:00:00');
+const fileId = 'import1';
+
+test('shows CVR import details', () => {
+  const api = createApiMock();
+
+  renderInAppContext(
+    <RemoveImportModal
+      close={vi.fn()}
+      cvrImport={mockCvrImport({ numCvrsImported: 4112 })}
+    />,
+    { apiMock: api }
+  );
+
+  screen.getByRole('heading', { name: 'Remove CVR File' });
+  screen.getByText(/The 4,112 CVRs.+will be permanently deleted/);
+  screen.getByText('Exported:');
+  screen.getByText(/2020.+6:00 PM/);
+  screen.getByText('Scanners:');
+  screen.getByText('SCAN-001');
+});
+
+test('handles single CVR case', () => {
+  const api = createApiMock();
+
+  renderInAppContext(
+    <RemoveImportModal
+      close={vi.fn()}
+      cvrImport={mockCvrImport({ numCvrsImported: 1 })}
+    />,
+    { apiMock: api }
+  );
+
+  screen.getByText(/The 1 CVR.+will be permanently deleted/);
+});
+
+test('loading state', async () => {
+  const api = createApiMock();
+
+  const { promise, resolve } = deferred<void>();
+  api.apiClient.deleteCvrFile.expectCallWith({ fileId }).returns(promise);
+
+  renderInAppContext(
+    <RemoveImportModal
+      close={vi.fn()}
+      cvrImport={mockCvrImport({ numCvrsImported: 1 })}
+    />,
+    { apiMock: api }
+  );
+
+  userEvent.click(screen.getButton('Remove'));
+  await waitFor(() => api.assertComplete());
+
+  expect(screen.getButton('Removing')).toBeDisabled();
+  expect(screen.getButton('Cancel')).toBeDisabled();
+
+  resolve();
+  expect(await screen.findButton('Remove')).toBeEnabled();
+  expect(screen.getButton('Cancel')).toBeEnabled();
+});
+
+function mockCvrImport(partial: Partial<CvrImport>): CvrImport {
+  return {
+    createdAt: exportDate.toISOString(),
+    electionId: 'election1',
+    exportTimestamp: exportDate.toISOString(),
+    filename: 'import1.json',
+    id: fileId,
+    numCvrsImported: 1,
+    pollingPlaceIds: ['place1'],
+    precinctIds: ['precinct1'],
+    scannerIds: ['SCAN-001'],
+    sha256Hash: 'hash',
+    ...partial,
+  };
+}

--- a/apps/admin/frontend/src/screens/tally/remove_import_modal.tsx
+++ b/apps/admin/frontend/src/screens/tally/remove_import_modal.tsx
@@ -1,0 +1,73 @@
+import { Button, Font, Modal, P } from '@votingworks/ui';
+import type { CastVoteRecordFileRecord as CvrImport } from '@votingworks/admin-backend';
+import { format } from '@votingworks/utils';
+
+import React from 'react';
+import * as api from '../../api.js';
+
+export interface RemoveImportModalProps {
+  close: VoidFunction;
+  cvrImport: CvrImport;
+}
+
+export function RemoveImportModal(props: RemoveImportModalProps): JSX.Element {
+  const { cvrImport, close } = props;
+
+  const mutation = api.deleteCvrFile.useMutation();
+  const deleting = mutation.status === 'loading';
+
+  function remove() {
+    mutation.mutate({ fileId: cvrImport.id }, { onSuccess: close });
+  }
+
+  const deleteButton = (
+    <Button
+      disabled={deleting}
+      icon={deleting ? 'Loading' : 'Trash'}
+      onPress={remove}
+      variant={deleting ? 'neutral' : 'danger'}
+    >
+      {deleting ? 'Removing' : 'Remove'}
+    </Button>
+  );
+
+  const cancelButton = (
+    <Button onPress={close} disabled={deleting}>
+      Cancel
+    </Button>
+  );
+
+  const nCvrs = cvrImport.numCvrsImported;
+  const scannerIds = cvrImport.scannerIds.join(', ');
+  const exportDate = format.localeShortDateAndTime(
+    new Date(cvrImport.exportTimestamp)
+  );
+
+  return (
+    <Modal
+      title="Remove CVR File"
+      content={
+        <React.Fragment>
+          <P>
+            The {format.count(nCvrs)} {nCvrs === 1 ? 'CVR' : 'CVRs'} loaded from
+            this file will be permanently deleted and their tallies will be
+            removed from reports.
+          </P>
+          <P>
+            <Font weight="bold">Exported:</Font> {exportDate}
+          </P>
+          <P>
+            <Font weight="bold">Scanners:</Font> {scannerIds}
+          </P>
+        </React.Fragment>
+      }
+      actions={
+        <React.Fragment>
+          {deleteButton}
+          {cancelButton}
+        </React.Fragment>
+      }
+      onOverlayClick={deleting ? undefined : close}
+    />
+  );
+}


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/4048

Followup to https://github.com/votingworks/vxsuite/pull/9133:
- Adding a single-import delete button to the location CVRs panel on the CVR management screen. 
- Each import for a given location gets a separate delete button.
- The buttons are hidden when results are marked as official (there's still the "delete all tallies" path available to the user in that case).

### TODO
- In the CA demo, we made additional changes to display batch labels in the UI - we can plumb those through later and also display them in the confirmation modal.
- Worth adding a tooltip to the icon button. Working toward a shared tooltip component in libs/ui that we can later use here - avoiding adding another tooltip component copy, since we have one in VxDesign already.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/ec1c0167-4b6f-45ca-b087-0c4363fa0af0

## Testing Plan
- Unit tests + manual run-through

## Checklist

- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
