### PR TITLE
Enable React act(...) checks in all test suites

### DIFF
--- a/libs/ui/src/session_time_limit_tracker.tsx
+++ b/libs/ui/src/session_time_limit_tracker.tsx
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon';
 import pluralize from 'pluralize';
 import React, { useState } from 'react';
 import { useIdleTimer } from 'react-idle-timer';
+import useInterval from 'use-interval';
 import {
   DippedSmartCardAuth,
   InsertedSmartCardAuth,
@@ -197,6 +198,26 @@ const TimerCallout = styled(Card).attrs({ color: 'warning' })`
   }
 `;
 
+// Polls every second, but stores whether the prompt should be shown rather than
+// the current time, so that the ticks that don't change the answer — i.e. all
+// of them, until the session is nearly expired — are dropped by React's state
+// bailout instead of re-rendering.
+function useShouldDisplayTimeLimitPrompt(
+  authStatus: SessionTimeLimitTimerProps['authStatus']
+): boolean {
+  function compute() {
+    return (
+      authStatus?.status === 'logged_in' &&
+      shouldDisplayTimeLimitPrompt(authStatus, new Date())
+    );
+  }
+
+  const [shouldDisplay, setShouldDisplay] = useState(compute);
+  useInterval(() => setShouldDisplay(compute()), 1000);
+
+  return shouldDisplay;
+}
+
 /**
  * Displays a count down timer to session expiry. Appears at the same time as the prompts surfaced
  * by SessionTimeLimitTracker.
@@ -204,12 +225,12 @@ const TimerCallout = styled(Card).attrs({ color: 'warning' })`
 export function SessionTimeLimitTimer({
   authStatus,
 }: SessionTimeLimitTimerProps): JSX.Element | null {
-  const now = useNow().toJSDate();
+  const shouldDisplay = useShouldDisplayTimeLimitPrompt(authStatus);
 
   if (authStatus?.status !== 'logged_in') {
     return null;
   }
-  if (shouldDisplayTimeLimitPrompt(authStatus, now)) {
+  if (shouldDisplay) {
     return (
       <TimerCallout>
         Machine will automatically lock in{' '}

--- a/libs/ui/src/toolbar.test.tsx
+++ b/libs/ui/src/toolbar.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '../test/react_testing_library';
+import { act, render, screen } from '../test/react_testing_library';
 
 import {
   BatteryStatus,
@@ -54,6 +54,25 @@ test('DateTimeDisplay renders current date and time', () => {
   vi.setSystemTime(new Date('2026-01-15T14:30:00'));
   render(<DateTimeDisplay />);
   screen.getByText(/Jan 15/);
+});
+
+test('DateTimeDisplay updates when the displayed minute changes', () => {
+  vi.setSystemTime(new Date('2026-01-15T14:30:00'));
+  render(<DateTimeDisplay />);
+  screen.getByText(/2:30 PM/);
+
+  // Ticks within the same minute don't change what's displayed.
+  vi.setSystemTime(new Date('2026-01-15T14:30:30'));
+  act(() => {
+    vi.advanceTimersByTime(1000);
+  });
+  screen.getByText(/2:30 PM/);
+
+  vi.setSystemTime(new Date('2026-01-15T14:31:00'));
+  act(() => {
+    vi.advanceTimersByTime(1000);
+  });
+  screen.getByText(/2:31 PM/);
 });
 
 test('LockMachineButton calls onLock when pressed', () => {

--- a/libs/ui/src/toolbar.test.tsx
+++ b/libs/ui/src/toolbar.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '../test/react_testing_library';
+import { act, render, screen } from '../test/react_testing_library';
 
 import { mockUsbDriveStatus } from './test-utils/mock_usb_drive';
 import {
@@ -56,6 +56,25 @@ test('DateTimeDisplay renders current date and time', () => {
   vi.setSystemTime(new Date('2026-01-15T14:30:00'));
   render(<DateTimeDisplay />);
   screen.getByText(/Jan 15/);
+});
+
+test('DateTimeDisplay updates when the displayed minute changes', () => {
+  vi.setSystemTime(new Date('2026-01-15T14:30:00'));
+  render(<DateTimeDisplay />);
+  screen.getByText(/2:30 PM/);
+
+  // Ticks within the same minute don't change what's displayed.
+  vi.setSystemTime(new Date('2026-01-15T14:30:30'));
+  act(() => {
+    vi.advanceTimersByTime(1000);
+  });
+  screen.getByText(/2:30 PM/);
+
+  vi.setSystemTime(new Date('2026-01-15T14:31:00'));
+  act(() => {
+    vi.advanceTimersByTime(1000);
+  });
+  screen.getByText(/2:31 PM/);
 });
 
 test('LockMachineButton calls onLock when pressed', () => {

--- a/libs/ui/src/toolbar.tsx
+++ b/libs/ui/src/toolbar.tsx
@@ -59,22 +59,26 @@ export function BatteryStatus({
   );
 }
 
-function useCurrentDate(): Date {
-  const [currentDate, setCurrentDate] = useState(new Date());
+// Polls every second, but stores the formatted text rather than the Date, so
+// that the ~59 out of 60 ticks that don't change the displayed minute are
+// dropped by React's state bailout instead of re-rendering the toolbar.
+function useCurrentDateTimeText(): string {
+  const [currentDateTimeText, setCurrentDateTimeText] = useState(() =>
+    format.clockDateAndTime(new Date())
+  );
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setCurrentDate(new Date());
+      setCurrentDateTimeText(format.clockDateAndTime(new Date()));
     }, 1000);
     return () => clearInterval(interval);
   }, []);
 
-  return currentDate;
+  return currentDateTimeText;
 }
 
 export function DateTimeDisplay(): JSX.Element {
-  const currentDate = useCurrentDate();
-  return <span>{format.clockDateAndTime(currentDate)}</span>;
+  return <span>{useCurrentDateTimeText()}</span>;
 }
 
 type ExtendedUsbDriveStatus = UsbDriveStatus['status'] | 'ejecting';

--- a/libs/ui/src/toolbar.tsx
+++ b/libs/ui/src/toolbar.tsx
@@ -52,22 +52,26 @@ export function BatteryStatus({
   );
 }
 
-function useCurrentDate(): Date {
-  const [currentDate, setCurrentDate] = useState(new Date());
+// Polls every second, but stores the formatted text rather than the Date, so
+// that the ~59 out of 60 ticks that don't change the displayed minute are
+// dropped by React's state bailout instead of re-rendering the toolbar.
+function useCurrentDateTimeText(): string {
+  const [currentDateTimeText, setCurrentDateTimeText] = useState(() =>
+    format.clockDateAndTime(new Date())
+  );
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setCurrentDate(new Date());
+      setCurrentDateTimeText(format.clockDateAndTime(new Date()));
     }, 1000);
     return () => clearInterval(interval);
   }, []);
 
-  return currentDate;
+  return currentDateTimeText;
 }
 
 export function DateTimeDisplay(): JSX.Element {
-  const currentDate = useCurrentDate();
-  return <span>{format.clockDateAndTime(currentDate)}</span>;
+  return <span>{useCurrentDateTimeText()}</span>;
 }
 
 export function LockMachineButton({

--- a/vitest.config.shared.mts
+++ b/vitest.config.shared.mts
@@ -1,9 +1,17 @@
+import { fileURLToPath } from 'node:url';
 import * as vitest from 'vitest/config';
 
 const isCI = process.env['CI'] === 'true';
 
+// Resolved from this file rather than the consuming package, since setup file
+// paths are otherwise interpreted relative to each package's root.
+const sharedSetupFile = fileURLToPath(
+  new URL('./vitest.setup.shared.mts', import.meta.url)
+);
+
 export const base: vitest.ViteUserConfig = {
   test: {
+    setupFiles: [sharedSetupFile],
     include: ['src/**/*.test.{ts,tsx}', 'test/**/*.test.{ts,tsx}'],
     coverage: {
       thresholds: {

--- a/vitest.config.shared.mts
+++ b/vitest.config.shared.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import * as vitest from 'vitest/config';
 
 const isCI = process.env['CI'] === 'true';
@@ -25,8 +26,15 @@ function parseTestWorkers(value: string | undefined): number | undefined {
 
 const localMaxWorkers = parseTestWorkers(process.env['VX_TEST_WORKERS']);
 
+// Resolved from this file rather than the consuming package, since setup file
+// paths are otherwise interpreted relative to each package's root.
+const sharedSetupFile = fileURLToPath(
+  new URL('./vitest.setup.shared.mts', import.meta.url)
+);
+
 export const base: vitest.ViteUserConfig = {
   test: {
+    setupFiles: [sharedSetupFile],
     include: ['src/**/*.test.{ts,tsx}', 'test/**/*.test.{ts,tsx}'],
     coverage: {
       // Collect coverage (and enforce thresholds) in CI only; locally, tests

--- a/vitest.setup.shared.mts
+++ b/vitest.setup.shared.mts
@@ -1,0 +1,13 @@
+declare global {
+  // eslint-disable-next-line no-var, vars-on-top
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+// React only performs its act(...) checks when this flag is set, and only warns
+// that an update wasn't wrapped in act(...) while it's true. React Testing
+// Library sets it in a `beforeAll`, but only when the test runner injects
+// globals — which vitest doesn't do here (`globals` is left at its default), so
+// without this the checks are silently disabled everywhere.
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+export {};


### PR DESCRIPTION
## Overview

React's `act(...)` checks have been silently disabled across the whole repo: RTL only sets `IS_REACT_ACT_ENVIRONMENT` when the test runner injects globals, and vitest doesn't. This turns them on from a shared setup file, so un-awaited async updates in tests become visible instead of being swallowed.

Two `libs/ui` components re-rendered every second while producing unchanged output; fixing them is a real (if small) win on always-mounted chrome, and it takes the newly-visible warning count from 4261 to ~721 so this doesn't land a wall of noise. Each is its own commit — see the commit messages for details.

Working the remaining ~721 down is follow-up work.

## Demo Video or Screenshot

No user-visible change. The two component fixes drop redundant re-renders only; the clock and session-timer behavior is unchanged and now has test coverage.

## Testing Plan

- All 11 jsdom packages pass with unchanged test counts (2922 passed, 2 skipped), and the 80 pre-existing "not configured to support act(...)" warnings (`libs/ui` 61, pollbook 19) are gone.
- Sampled 6 node-environment packages, which now also load the shared setup — all green.
- Verified `mergeConfig` concatenates `setupFiles`, so each package's own setup still runs.
- `libs/ui` lint and coverage (`test:ci`) pass; the toolbar interval callback went from uncovered to covered.
- The new toolbar test was mutation-checked: making the interval never fire fails it.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
