### PR TITLE
Decide QR payload unwrapping by prelude, not base64 decode success

### DIFF
--- a/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
@@ -180,6 +180,24 @@ pub fn classify_qr_payload(bytes: &[u8]) -> QrCodeKind {
     }
 }
 
+/// Whether `bytes` starts with any prelude we have ever printed.
+///
+/// This is deliberately broader than [`classify_qr_payload`]: classification
+/// names the payloads we can parse, while this answers whether a payload is
+/// ours at all, which is what deciding between raw and base64-wrapped bytes
+/// needs. The two differ for v4.0 bubble ballots, which we print but no longer
+/// decode.
+#[must_use]
+fn is_vx_payload(bytes: &[u8]) -> bool {
+    let Some(prelude) = bytes.get(0..3) else {
+        return false;
+    };
+    matches!(
+        prelude.try_into(),
+        Ok(bubble_ballot::PRELUDE | bubble_ballot::PRELUDE_V4P0 | bmd::BMD_PRELUDE)
+    )
+}
+
 #[derive(Debug, Clone, Copy)]
 #[must_use]
 pub enum Detector {
@@ -281,10 +299,25 @@ impl Error {
 
 pub type Result = std::result::Result<Detected, Error>;
 
-fn base64_decode_if_possible(detected: &Detected) -> Detected {
-    let bytes = STANDARD
-        .decode(detected.bytes())
-        .unwrap_or_else(|_| detected.bytes().to_vec());
+/// Unwraps a detected QR code payload to raw ballot bytes.
+///
+/// Payloads may be either raw bytes or base64-wrapped. Which one it is has to
+/// be decided by the ballot prelude rather than by whether base64 decoding
+/// succeeds: the base64 alphabet is a superset of the alphabets a payload can
+/// be drawn from, so a payload that was never base64 can still decode
+/// "successfully" into garbage. Unrecognized payloads are passed through
+/// unchanged so that the prelude check downstream reports the error.
+fn unwrap_qr_payload(detected: &Detected) -> Detected {
+    let raw = detected.bytes();
+    let bytes = if is_vx_payload(raw) {
+        raw.to_vec()
+    } else {
+        match STANDARD.decode(raw) {
+            Ok(decoded) if is_vx_payload(&decoded) => decoded,
+            _ => raw.to_vec(),
+        }
+    };
+
     Detected::new(
         detected.detector(),
         detected.detection_areas().to_vec(),
@@ -323,7 +356,7 @@ pub fn detect_with_strategy(
         debug::draw_qr_code_debug_image_mut(canvas, detect_result.as_ref().ok(), &detection_areas);
     });
 
-    detect_result.map(|detected| base64_decode_if_possible(&detected))
+    detect_result.map(|detected| unwrap_qr_payload(&detected))
 }
 
 #[cfg(test)]
@@ -376,6 +409,85 @@ mod test {
         #[test]
         fn test_classify_never_panics(bytes: Vec<u8>) {
             let _ = classify_qr_payload(&bytes);
+        }
+    }
+
+    fn detected(bytes: &[u8]) -> Detected {
+        Detected::new(
+            Detector::Zedbar,
+            vec![],
+            bytes.to_vec(),
+            Rect::new(0, 0, 1, 1),
+            Orientation::Portrait,
+        )
+    }
+
+    #[test]
+    fn test_unwrap_base64_wrapped_payload() {
+        let raw = [0x56, 0x53, 0x01, 0xab, 0xcd];
+        let wrapped = STANDARD.encode(raw);
+        assert_eq!(
+            unwrap_qr_payload(&detected(wrapped.as_bytes())).bytes(),
+            raw
+        );
+    }
+
+    #[test]
+    fn test_unwrap_raw_payload() {
+        let raw = [0x56, 0x42, 0x01, 0xab, 0xcd];
+        assert_eq!(unwrap_qr_payload(&detected(&raw)).bytes(), raw);
+    }
+
+    #[test]
+    fn test_unwrap_recognizes_deprecated_v4p0_payload() {
+        let raw = [0x56, 0x50, 0x02, 0xab, 0xcd];
+        let wrapped = STANDARD.encode(raw);
+        assert_eq!(
+            unwrap_qr_payload(&detected(wrapped.as_bytes())).bytes(),
+            raw
+        );
+    }
+
+    /// A payload drawn from the base64 alphabet decodes without error even
+    /// though it was never base64. Decoding it anyway would silently replace it
+    /// with garbage, and only for lengths that happen to be a multiple of 4.
+    #[test]
+    fn test_unwrap_leaves_incidentally_decodable_payload_alone() {
+        for payload in [
+            "VXBABCDEFGH01234567",
+            "VXBABCDEFGH012345678",
+            "VXBABCDEFGH0123456789",
+            "1234567890123456",
+        ] {
+            assert_eq!(
+                unwrap_qr_payload(&detected(payload.as_bytes())).bytes(),
+                payload.as_bytes(),
+                "payload of length {} was modified",
+                payload.len()
+            );
+        }
+    }
+
+    proptest! {
+        /// Whatever a QR code turns out to contain, unwrapping must either
+        /// produce a payload we recognize or leave the bytes untouched.
+        #[test]
+        fn test_unwrap_never_produces_unrecognized_bytes(bytes: Vec<u8>) {
+            let unwrapped = unwrap_qr_payload(&detected(&bytes));
+            assert!(is_vx_payload(unwrapped.bytes()) || unwrapped.bytes() == bytes);
+        }
+
+        /// Same property, but over payloads drawn from the base64 alphabet,
+        /// where an unconditional decode succeeds and quietly returns garbage.
+        /// Lengths that are a multiple of 4 are the dangerous ones.
+        #[test]
+        fn test_unwrap_never_mangles_base64_alphabet_payload(
+            payload in "[A-Za-z0-9+/]{0,64}"
+        ) {
+            let unwrapped = unwrap_qr_payload(&detected(payload.as_bytes()));
+            assert!(
+                is_vx_payload(unwrapped.bytes()) || unwrapped.bytes() == payload.as_bytes()
+            );
         }
     }
 

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
@@ -183,10 +183,9 @@ pub fn classify_qr_payload(bytes: &[u8]) -> QrCodeKind {
 /// Whether `bytes` starts with any prelude we have ever printed.
 ///
 /// This is deliberately broader than [`classify_qr_payload`]: classification
-/// names the payloads we can parse, while this answers whether a payload is
-/// ours at all, which is what deciding between raw and base64-wrapped bytes
-/// needs. The two differ for v4.0 bubble ballots, which we print but no longer
-/// decode.
+/// names the payloads we can parse, while this answers whether a base64 decode
+/// produced ballot data at all. The two differ for v4.0 bubble ballots, which
+/// we print but no longer decode.
 #[must_use]
 fn is_vx_payload(bytes: &[u8]) -> bool {
     let Some(prelude) = bytes.get(0..3) else {
@@ -299,23 +298,18 @@ impl Error {
 
 pub type Result = std::result::Result<Detected, Error>;
 
-/// Unwraps a detected QR code payload to raw ballot bytes.
+/// Unwraps a base64-wrapped QR code payload to raw ballot bytes.
 ///
-/// Payloads may be either raw bytes or base64-wrapped. Which one it is has to
-/// be decided by the ballot prelude rather than by whether base64 decoding
-/// succeeds: the base64 alphabet is a superset of the alphabets a payload can
-/// be drawn from, so a payload that was never base64 can still decode
-/// "successfully" into garbage. Unrecognized payloads are passed through
-/// unchanged so that the prelude check downstream reports the error.
+/// The decode is kept only if it produced something with a ballot prelude. A
+/// successful decode on its own proves nothing: the base64 alphabet is a
+/// superset of the alphabets a QR payload can be drawn from, so a payload that
+/// was never base64 can decode without error into garbage. Anything we don't
+/// recognize is passed through unchanged so that the prelude check downstream
+/// reports the error.
 fn unwrap_qr_payload(detected: &Detected) -> Detected {
-    let raw = detected.bytes();
-    let bytes = if is_vx_payload(raw) {
-        raw.to_vec()
-    } else {
-        match STANDARD.decode(raw) {
-            Ok(decoded) if is_vx_payload(&decoded) => decoded,
-            _ => raw.to_vec(),
-        }
+    let bytes = match STANDARD.decode(detected.bytes()) {
+        Ok(decoded) if is_vx_payload(&decoded) => decoded,
+        _ => detected.bytes().to_vec(),
     };
 
     Detected::new(
@@ -432,8 +426,11 @@ mod test {
         );
     }
 
+    /// Nothing we print is unwrapped bytes, but a payload that isn't base64 at
+    /// all must still reach the prelude check downstream intact rather than
+    /// being replaced by whatever a decode attempt produced.
     #[test]
-    fn test_unwrap_raw_payload() {
+    fn test_unwrap_leaves_undecodable_payload_alone() {
         let raw = [0x56, 0x42, 0x01, 0xab, 0xcd];
         assert_eq!(unwrap_qr_payload(&detected(&raw)).bytes(), raw);
     }

--- a/libs/ballot-interpreter/src/summary-ballot/utils/qrcode.test.ts
+++ b/libs/ballot-interpreter/src/summary-ballot/utils/qrcode.test.ts
@@ -42,14 +42,9 @@ test('unwrapVxPayload unwraps base64-wrapped ballot data', () => {
   expect(unwrapVxPayload(Buffer.from(raw.toString('base64')))).toEqual(raw);
 });
 
-test('unwrapVxPayload passes through unwrapped ballot data', () => {
-  const raw = Buffer.from([0x56, 0x53, 0x01, 0xab, 0xcd]);
-  expect(unwrapVxPayload(raw)).toEqual(raw);
-});
-
 test('unwrapVxPayload rejects payloads that are not ballot data', () => {
   // `Buffer.from(s, 'base64')` drops unrecognized characters rather than
-  // failing, so all of these "decode" successfully into garbage. Deciding by
+  // failing, so all of these "decode" successfully into garbage. Checking the
   // prelude is what keeps that garbage from being treated as ballot data.
   for (const payload of [
     'VXBABCDEFGH01234567',
@@ -60,6 +55,14 @@ test('unwrapVxPayload rejects payloads that are not ballot data', () => {
   ]) {
     expect(unwrapVxPayload(Buffer.from(payload))).toBeUndefined();
   }
+});
+
+test('unwrapVxPayload rejects unwrapped ballot data', () => {
+  // Nothing we print is unwrapped, so this is rejected rather than passed
+  // through. Recognizing an unwrapped payload is a change for whenever we move
+  // off base64, not a compatibility path for anything in the field.
+  const raw = Buffer.from([0x56, 0x53, 0x01, 0xab, 0xcd]);
+  expect(unwrapVxPayload(raw)).toBeUndefined();
 });
 
 test('getSearchArea', () => {

--- a/libs/ballot-interpreter/src/summary-ballot/utils/qrcode.test.ts
+++ b/libs/ballot-interpreter/src/summary-ballot/utils/qrcode.test.ts
@@ -6,7 +6,12 @@ import {
   sampleBallotImages,
 } from '@votingworks/fixtures';
 import { renderBmdBallotFixture } from '@votingworks/bmd-ballot-fixtures';
-import { QrCodePageResult, detectInBallot, getSearchAreas } from './qrcode.js';
+import {
+  QrCodePageResult,
+  detectInBallot,
+  getSearchAreas,
+  unwrapVxPayload,
+} from './qrcode.js';
 import { pdfToPageImages } from '../../../test/helpers/interpretation';
 
 test('does not find QR codes when there are none to find', async () => {
@@ -30,6 +35,31 @@ test('can read metadata encoded in a QR code with base64', async () => {
       detector: 'zedbar',
     })
   );
+});
+
+test('unwrapVxPayload unwraps base64-wrapped ballot data', () => {
+  const raw = Buffer.from([0x56, 0x53, 0x01, 0xab, 0xcd]);
+  expect(unwrapVxPayload(Buffer.from(raw.toString('base64')))).toEqual(raw);
+});
+
+test('unwrapVxPayload passes through unwrapped ballot data', () => {
+  const raw = Buffer.from([0x56, 0x53, 0x01, 0xab, 0xcd]);
+  expect(unwrapVxPayload(raw)).toEqual(raw);
+});
+
+test('unwrapVxPayload rejects payloads that are not ballot data', () => {
+  // `Buffer.from(s, 'base64')` drops unrecognized characters rather than
+  // failing, so all of these "decode" successfully into garbage. Deciding by
+  // prelude is what keeps that garbage from being treated as ballot data.
+  for (const payload of [
+    'VXBABCDEFGH01234567',
+    'VXBABCDEFGH012345678',
+    '1234567890123456',
+    'VS1 4A2B1C3D4E5F6A7B8C9D 0 0',
+    '',
+  ]) {
+    expect(unwrapVxPayload(Buffer.from(payload))).toBeUndefined();
+  }
 });
 
 test('getSearchArea', () => {

--- a/libs/ballot-interpreter/src/summary-ballot/utils/qrcode.ts
+++ b/libs/ballot-interpreter/src/summary-ballot/utils/qrcode.ts
@@ -12,20 +12,15 @@ import { stats, Stats } from './luminosity';
 const debug = makeDebug('ballot-interpreter:bmd:qrcode');
 
 /**
- * Unwraps a detected QR code payload to raw ballot data, or `undefined` if it
- * isn't ballot data at all.
+ * Unwraps a base64-wrapped QR code payload to raw ballot data, or `undefined`
+ * if the payload isn't ballot data.
  *
- * Payloads may be either raw bytes or base64-wrapped. Which one it is has to be
- * decided by the ballot prelude rather than by whether base64 decoding
- * succeeds: `Buffer.from(s, 'base64')` silently drops characters it doesn't
- * recognize instead of failing, so a successful decode proves nothing about
- * whether the input was base64 in the first place.
+ * The decode is kept only if it produced something with a ballot prelude. A
+ * successful decode on its own proves nothing: `Buffer.from(s, 'base64')`
+ * silently drops characters it doesn't recognize rather than failing, so it
+ * "succeeds" on input that was never base64 and returns garbage.
  */
 export function unwrapVxPayload(data: Buffer): Optional<Buffer> {
-  if (isVxBallot(data)) {
-    return data;
-  }
-
   const decoded = Buffer.from(data.toString('utf8'), 'base64');
   return isVxBallot(decoded) ? decoded : undefined;
 }

--- a/libs/ballot-interpreter/src/summary-ballot/utils/qrcode.ts
+++ b/libs/ballot-interpreter/src/summary-ballot/utils/qrcode.ts
@@ -12,16 +12,22 @@ import { stats, Stats } from './luminosity';
 const debug = makeDebug('ballot-interpreter:bmd:qrcode');
 
 /**
- * Decodes a base64 string from bytes representing a UTF-8 string. If either the
- * UTF-8 or base64 decoding fails, the original data is returned.
+ * Unwraps a detected QR code payload to raw ballot data, or `undefined` if it
+ * isn't ballot data at all.
+ *
+ * Payloads may be either raw bytes or base64-wrapped. Which one it is has to be
+ * decided by the ballot prelude rather than by whether base64 decoding
+ * succeeds: `Buffer.from(s, 'base64')` silently drops characters it doesn't
+ * recognize instead of failing, so a successful decode proves nothing about
+ * whether the input was base64 in the first place.
  */
-function decodeBase64FromUtf8(utf8StringData: Buffer): Buffer {
-  try {
-    return Buffer.from(new TextDecoder().decode(utf8StringData), 'base64');
-  } catch {
-    /* istanbul ignore next */
-    return utf8StringData;
+export function unwrapVxPayload(data: Buffer): Optional<Buffer> {
+  if (isVxBallot(data)) {
+    return data;
   }
+
+  const decoded = Buffer.from(data.toString('utf8'), 'base64');
+  return isVxBallot(decoded) ? decoded : undefined;
 }
 
 /**
@@ -163,8 +169,8 @@ export async function detect(
       // Sometimes, our QR code detectors hallucinate and see QR codes in the noise
       // We filter the QR codes down to the ones that look like Vx ballot data.
       const recognizedResults = results
-        .map(decodeBase64FromUtf8)
-        .filter(isVxBallot);
+        .map(unwrapVxPayload)
+        .filter((result) => result !== undefined);
 
       if (recognizedResults.length === 0) {
         debug('%s no recognized QR codes in %s', detector.name, position);

--- a/libs/types-rs/src/bubble_ballot.rs
+++ b/libs/types-rs/src/bubble_ballot.rs
@@ -348,6 +348,12 @@ pub type PartialBallotHash = [u8; PARTIAL_BALLOT_HASH_BYTE_LENGTH];
 /// The first bytes of an encoded [`Metadata`].
 pub const PRELUDE: &[u8; 3] = b"VB\x01";
 
+/// The first bytes of a v4.0 encoded bubble ballot metadata. [`Metadata`] does
+/// not decode this format, but `VxDesign` still renders it, so payloads
+/// starting with it can appear on scanned ballots and must be recognized as
+/// ours.
+pub const PRELUDE_V4P0: &[u8; 3] = b"VP\x02";
+
 #[must_use]
 pub fn infer_missing_page_metadata(detected_ballot_metadata: &Metadata) -> Metadata {
     Metadata {


### PR DESCRIPTION
Co-authored with Claude Code 🤖 

## Overview

Both QR decode paths unwrapped payloads by attempting a base64 decode and treating success as proof the payload was base64. It isn't — the base64 alphabet is a superset of the alphabets a payload can be drawn from, so a payload that was never base64 can decode "successfully" into garbage.

The two failed differently. In Rust, `base64_decode_if_possible` falls back to raw bytes on a decode error, but any payload drawn from `A-Z0-9` whose length is a multiple of 4 decodes without error, so corruption was length-dependent — it would hit some ballots and not others. In TypeScript, `decodeBase64FromUtf8`'s `catch` was unreachable, because `Buffer.from(s, 'base64')` silently drops unrecognized characters instead of throwing, so every non-base64 payload was corrupted.

Both now base64-decode and keep the result only if it carries a ballot prelude, which is what actually identifies our payloads.

The second commit drops the accept-unwrapped-bytes branch. It read as backward compatibility, but isn't: we stopped writing unwrapped bytes in September 2020 (`e943bcde54`), and both unwrappers were written well after — Rust in October 2023, TypeScript in June 2024 — so neither ever read an unwrapped ballot. There are two producers today and both base64-encode. Recognizing an unwrapped payload becomes a change for whenever we move off base64, not a compatibility path for anything printed.

Latent today since we only ever feed these functions base64, but it's a prerequisite for evaluating any change to the QR payload format.

## Testing Plan

- New unit tests in both languages, each verified to fail against the previous implementation (the Rust one fails only at payload length 20, which is the point).
- Rust proptest over `[A-Za-z0-9+/]{0,64}` asserting unwrapping either produces a recognized payload or leaves the bytes untouched.
- Existing real-ballot-image detection tests still pass, including the v4.0 `VP\x02` fixture — unwrapping recognizes that prelude via the new `bubble_ballot::PRELUDE_V4P0`, while `classify_qr_payload` deliberately still doesn't, since VxDesign renders v4.0 bubble ballots that we no longer decode.
- Full `ballot-interpreter` suite green: 110 Rust, 161 TS, coverage gate passing.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.