### PR TITLE
fix(printing): define custom-8.5x18 and custom-8.5x20 in printer PPDs

### DIFF
--- a/libs/printing/src/printer/supported.test.ts
+++ b/libs/printing/src/printer/supported.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest';
 import { readFile } from 'node:fs/promises';
+import { HmpbBallotPaperSize } from '@votingworks/types';
 import {
   SUPPORTED_PRINTER_CONFIGS,
   getPpdPath,
@@ -23,4 +24,34 @@ test('M404n PPD stays in sync with the generic PPD (run `pnpm generate-m404n-ppd
   );
   const m404nPpd = await readFile(getPpdPath(M404N_PRINTER_CONFIG), 'utf8');
   expect(m404nPpd).toEqual(deriveM404nPpd(genericPpd));
+});
+
+// The laser printers print hand-marked paper ballots, so their PPDs must define
+// every ballot paper size. CUPS resolves the `media` option against PPD page
+// size names case-insensitively, and a name with no PPD entry silently falls
+// back to the PPD default rather than failing.
+test.each([
+  ['generic', HP_LASER_PRINTER_CONFIG],
+  ['M404n', M404N_PRINTER_CONFIG],
+])('%s PPD defines every ballot paper size', async (_label, printerConfig) => {
+  const ppdContent = await readFile(getPpdPath(printerConfig), 'utf8');
+
+  for (const keyword of [
+    'PageSize',
+    'PageRegion',
+    'ImageableArea',
+    'PaperDimension',
+  ]) {
+    const definedSizes = [
+      ...ppdContent.matchAll(
+        new RegExp(String.raw`^\*${keyword}\s+(\S+?)/`, 'gm')
+      ),
+    ].map(([, name]) => name.toLowerCase());
+
+    for (const paperSize of Object.values(HmpbBallotPaperSize)) {
+      expect(definedSizes, `${keyword} is missing ${paperSize}`).toContain(
+        paperSize.toLowerCase()
+      );
+    }
+  }
 });

--- a/libs/printing/supported_printers/generic-postscript-driver.ppd
+++ b/libs/printing/supported_printers/generic-postscript-driver.ppd
@@ -47,7 +47,9 @@
 *PageSize EnvDL/Envelope DL: "<</PageSize[312 624]/ImagingBBox null>>setpagedevice"
 *PageSize EnvMonarch/Envelope Monarch: "<</PageSize[279 540]/ImagingBBox null>>setpagedevice"
 *PageSize Custom-8.5x17/Custom 8.5x17: "<</PageSize[612 1224]/ImagingBBox null>>setpagedevice"
+*PageSize Custom-8.5x18/Custom 8.5x18: "<</PageSize[612 1296]/ImagingBBox null>>setpagedevice"
 *PageSize Custom-8.5x19/Custom 8.5x19: "<</PageSize[612 1368]/ImagingBBox null>>setpagedevice"
+*PageSize Custom-8.5x20/Custom 8.5x20: "<</PageSize[612 1440]/ImagingBBox null>>setpagedevice"
 *PageSize Custom-8.5x22/Custom 8.5x22: "<</PageSize[612 1584]/ImagingBBox null>>setpagedevice"
 *CloseUI: *PageSize
 *OpenUI *PageRegion/Media Size: PickOne
@@ -67,7 +69,9 @@
 *PageRegion EnvDL/Envelope DL: "<</PageSize[312 624]/ImagingBBox null>>setpagedevice"
 *PageRegion EnvMonarch/Envelope Monarch: "<</PageSize[279 540]/ImagingBBox null>>setpagedevice"
 *PageRegion Custom-8.5x17/Custom 8.5x17: "<</PageSize[612 1224]/ImagingBBox null>>setpagedevice"
+*PageRegion Custom-8.5x18/Custom 8.5x18: "<</PageSize[612 1296]/ImagingBBox null>>setpagedevice"
 *PageRegion Custom-8.5x19/Custom 8.5x19: "<</PageSize[612 1368]/ImagingBBox null>>setpagedevice"
+*PageRegion Custom-8.5x20/Custom 8.5x20: "<</PageSize[612 1440]/ImagingBBox null>>setpagedevice"
 *PageRegion Custom-8.5x22/Custom 8.5x22: "<</PageSize[612 1584]/ImagingBBox null>>setpagedevice"
 *CloseUI: *PageRegion
 *DefaultImageableArea: Letter
@@ -85,7 +89,9 @@
 *ImageableArea EnvDL/Envelope DL: "12 12 300 612"
 *ImageableArea EnvMonarch/Envelope Monarch: "12 12 267 528"
 *ImageableArea Custom-8.5x17/Custom 8.5x17: "12 12 600 1212"
+*ImageableArea Custom-8.5x18/Custom 8.5x18: "12 12 600 1284"
 *ImageableArea Custom-8.5x19/Custom 8.5x19: "12 12 600 1356"
+*ImageableArea Custom-8.5x20/Custom 8.5x20: "12 12 600 1428"
 *ImageableArea Custom-8.5x22/Custom 8.5x22: "12 12 600 1572"
 *DefaultPaperDimension: Letter
 *PaperDimension Letter/US Letter: "612 792"
@@ -102,7 +108,9 @@
 *PaperDimension EnvDL/Envelope DL: "312 624"
 *PaperDimension EnvMonarch/Envelope Monarch: "279 540"
 *PaperDimension Custom-8.5x17/Custom 8.5x17: "612 1224"
+*PaperDimension Custom-8.5x18/Custom 8.5x18: "612 1296"
 *PaperDimension Custom-8.5x19/Custom 8.5x19: "612 1368"
+*PaperDimension Custom-8.5x20/Custom 8.5x20: "612 1440"
 *PaperDimension Custom-8.5x22/Custom 8.5x22: "612 1584"
 *OpenUI *InputSlot/Media Source: PickOne
 *OrderDependency: 10 AnySetup *InputSlot

--- a/libs/printing/supported_printers/hp-laserjet-pro-m404n.ppd
+++ b/libs/printing/supported_printers/hp-laserjet-pro-m404n.ppd
@@ -47,7 +47,9 @@
 *PageSize EnvDL/Envelope DL: "<</PageSize[312 624]/ImagingBBox null>>setpagedevice"
 *PageSize EnvMonarch/Envelope Monarch: "<</PageSize[279 540]/ImagingBBox null>>setpagedevice"
 *PageSize Custom-8.5x17/Custom 8.5x17: "<</PageSize[612 1224]/ImagingBBox null>>setpagedevice"
+*PageSize Custom-8.5x18/Custom 8.5x18: "<</PageSize[612 1296]/ImagingBBox null>>setpagedevice"
 *PageSize Custom-8.5x19/Custom 8.5x19: "<</PageSize[612 1368]/ImagingBBox null>>setpagedevice"
+*PageSize Custom-8.5x20/Custom 8.5x20: "<</PageSize[612 1440]/ImagingBBox null>>setpagedevice"
 *PageSize Custom-8.5x22/Custom 8.5x22: "<</PageSize[612 1584]/ImagingBBox null>>setpagedevice"
 *CloseUI: *PageSize
 *OpenUI *PageRegion/Media Size: PickOne
@@ -67,7 +69,9 @@
 *PageRegion EnvDL/Envelope DL: "<</PageSize[312 624]/ImagingBBox null>>setpagedevice"
 *PageRegion EnvMonarch/Envelope Monarch: "<</PageSize[279 540]/ImagingBBox null>>setpagedevice"
 *PageRegion Custom-8.5x17/Custom 8.5x17: "<</PageSize[612 1224]/ImagingBBox null>>setpagedevice"
+*PageRegion Custom-8.5x18/Custom 8.5x18: "<</PageSize[612 1296]/ImagingBBox null>>setpagedevice"
 *PageRegion Custom-8.5x19/Custom 8.5x19: "<</PageSize[612 1368]/ImagingBBox null>>setpagedevice"
+*PageRegion Custom-8.5x20/Custom 8.5x20: "<</PageSize[612 1440]/ImagingBBox null>>setpagedevice"
 *PageRegion Custom-8.5x22/Custom 8.5x22: "<</PageSize[612 1584]/ImagingBBox null>>setpagedevice"
 *CloseUI: *PageRegion
 *DefaultImageableArea: Letter
@@ -85,7 +89,9 @@
 *ImageableArea EnvDL/Envelope DL: "12 12 300 612"
 *ImageableArea EnvMonarch/Envelope Monarch: "12 12 267 528"
 *ImageableArea Custom-8.5x17/Custom 8.5x17: "12 12 600 1212"
+*ImageableArea Custom-8.5x18/Custom 8.5x18: "12 12 600 1284"
 *ImageableArea Custom-8.5x19/Custom 8.5x19: "12 12 600 1356"
+*ImageableArea Custom-8.5x20/Custom 8.5x20: "12 12 600 1428"
 *ImageableArea Custom-8.5x22/Custom 8.5x22: "12 12 600 1572"
 *DefaultPaperDimension: Letter
 *PaperDimension Letter/US Letter: "612 792"
@@ -102,7 +108,9 @@
 *PaperDimension EnvDL/Envelope DL: "312 624"
 *PaperDimension EnvMonarch/Envelope Monarch: "279 540"
 *PaperDimension Custom-8.5x17/Custom 8.5x17: "612 1224"
+*PaperDimension Custom-8.5x18/Custom 8.5x18: "612 1296"
 *PaperDimension Custom-8.5x19/Custom 8.5x19: "612 1368"
+*PaperDimension Custom-8.5x20/Custom 8.5x20: "612 1440"
 *PaperDimension Custom-8.5x22/Custom 8.5x22: "612 1584"
 *OpenUI *InputSlot/Media Source: PickOne
 *OrderDependency: 10 AnySetup *InputSlot


### PR DESCRIPTION
## Overview

Closes #9168

`HmpbBallotPaperSize` offers five custom ballot lengths, but the laser printer PPDs in
`libs/printing/supported_printers/` only defined three. `custom-8.5x18` and
`custom-8.5x20` had no entries at all:

| `HmpbBallotPaperSize` | before | after |
| --- | --- | --- |
| `custom-8.5x17` | defined | defined |
| `custom-8.5x18` | **missing** | defined (612 x 1296 pt) |
| `custom-8.5x19` | defined | defined |
| `custom-8.5x20` | **missing** | defined (612 x 1440 pt) |
| `custom-8.5x22` | defined | defined |

This matters because there is no fallback. Neither PPD declares a generic
`*CustomPageSize` / `*ParamCustomPageSize`, so the custom lengths exist only as fixed
named page sizes that emit PostScript directly. `print.ts` passes the enum value straight
through as `lpr -o media=<size>`; CUPS accepts the keyword at submission without
validating it against the PPD, and resolution happens later in the filter chain, where an
unmatched page-size name falls back to the PPD default. So an election configured for 18"
or 20" stock could print at the wrong page size with nothing surfaced to the user.

Adds the missing `*PageSize`, `*PageRegion`, `*ImageableArea`, and `*PaperDimension`
entries to both PPDs, keeping the ascending order and the existing 12 pt margin convention
(`ImageableArea` = `12 12 600 <height - 12>`).

Also adds a test asserting that every `HmpbBallotPaperSize` value has an entry in all four
sections of both laser PPDs, so the enum and the PPDs can't drift apart again. The thermal
printer PPD is excluded since it defines receipt sizes, not ballot sizes.

## Demo Video or Screenshot

n/a — data files and a test.

## Testing Plan

- `pnpm --filter @votingworks/printing test:run src/printer/supported.test.ts` — 4 passed,
  including the pre-existing "M404n PPD stays in sync with the generic PPD" check (both
  PPDs were edited identically, so `deriveM404nPpd` still round-trips).
- Mutation-checked the new test: deleting the `*PageSize Custom-8.5x18` line makes it fail
  with `PageSize is missing custom-8.5x18`, and restoring it passes.
- `pnpm --filter @votingworks/printing lint` — clean.

Not verified: that 18" and 20" now print at the correct physical size. I did not have
paper or a firmware-updated printer to confirm, and the earlier behavior (silent fallback
to the PPD default) is inferred from how CUPS resolves page sizes rather than observed. A
test print for each of the two new sizes would close that out — see #9168 for the
suggested check.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

