### PR TITLE
VxDesign: add candidate designation input

### DIFF
--- a/apps/design/backend/migrations/1787007046000_add-candidate-designation.js
+++ b/apps/design/backend/migrations/1787007046000_add-candidate-designation.js
@@ -1,0 +1,10 @@
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  pgm.addColumns('candidates', {
+    designation: { type: 'text' },
+  });
+};

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -2182,13 +2182,21 @@ test('CRUD contests', async () => {
         middleName: 'M',
         lastName: 'Three',
         name: 'Candidate M Three',
+        designation: 'Member of City Council',
       },
     ],
   };
   (
     await apiClient.updateContest({
       electionId,
-      updatedContest: updatedContest1,
+      updatedContest: {
+        ...updatedContest1,
+        candidates: updatedContest1.candidates.map((candidate) =>
+          candidate.designation
+            ? { ...candidate, designation: `${candidate.designation}` }
+            : candidate
+        ),
+      },
     })
   ).unsafeUnwrap();
   // Expect contests to have their ballot order preserved

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -31,6 +31,7 @@ import {
   AdjudicationReason,
   HmpbBallotPaperSize,
   BallotType,
+  Candidate,
   CandidateContest,
   DEFAULT_SYSTEM_SETTINGS,
   Election,
@@ -2189,14 +2190,7 @@ test('CRUD contests', async () => {
   (
     await apiClient.updateContest({
       electionId,
-      updatedContest: {
-        ...updatedContest1,
-        candidates: updatedContest1.candidates.map((candidate) =>
-          candidate.designation
-            ? { ...candidate, designation: `${candidate.designation}` }
-            : candidate
-        ),
-      },
+      updatedContest: updatedContest1,
     })
   ).unsafeUnwrap();
   // Expect contests to have their ballot order preserved
@@ -2564,6 +2558,53 @@ test('CRUD contests', async () => {
       })
     ).rejects.toThrow('auth:forbidden');
   });
+});
+
+test('candidate designation whitespace is trimmed', async () => {
+  const { apiClient, auth0 } = await setupApp({
+    organizations,
+    jurisdictions,
+    users,
+  });
+  auth0.setLoggedInUser(nonVxUser);
+  const electionId = (
+    await apiClient.createElection({
+      jurisdictionId: nonVxJurisdiction.id,
+      id: unsafeParse(ElectionIdSchema, 'election-1'),
+    })
+  ).unsafeUnwrap();
+
+  const district: District = {
+    id: unsafeParse(DistrictIdSchema, 'district-1'),
+    name: 'District 1',
+  };
+  (
+    await apiClient.updateDistricts({ electionId, newDistricts: [district] })
+  ).unsafeUnwrap();
+
+  const candidate: Candidate = {
+    id: 'candidate-1',
+    firstName: 'Candidate',
+    lastName: 'One',
+    name: 'Candidate One',
+    designation: 'Member of City Council',
+  };
+  const contest: CandidateContest = {
+    id: 'contest-1',
+    title: 'Contest 1',
+    type: 'candidate',
+    seats: 1,
+    allowWriteIns: true,
+    districtId: district.id,
+    candidates: [{ ...candidate, designation: '  Member of City Council  ' }],
+  };
+
+  (
+    await apiClient.createContest({ electionId, newContest: contest })
+  ).unsafeUnwrap();
+  expect(await apiClient.listContests({ electionId })).toEqual([
+    { ...contest, candidates: [candidate] },
+  ]);
 });
 
 test('reordering contests', async () => {

--- a/apps/design/backend/src/features.ts
+++ b/apps/design/backend/src/features.ts
@@ -196,6 +196,11 @@ export interface StateFeaturesConfig {
    * explicitly selecting them.
    */
   STRAIGHT_PARTY_VOTING?: boolean;
+  /**
+   * Enable candidate designations eg. official titles or offices that a candidate
+   * holds.
+   */
+  CANDIDATE_DESIGNATIONS?: boolean;
 }
 
 export type UserFeature = keyof UserFeaturesConfig;
@@ -236,6 +241,7 @@ export const stateFeatureConfigs: Record<StateCode, StateFeaturesConfig> = {
     DELETE_LIVE_REPORTS: true,
     EDIT_POLLING_PLACES: true,
     EXPORT_TEST_BALLOTS: true,
+    CANDIDATE_DESIGNATIONS: true,
   },
 
   MI: {

--- a/apps/design/backend/src/store.ts
+++ b/apps/design/backend/src/store.ts
@@ -445,15 +445,17 @@ async function insertContest(
               contest_id,
               first_name,
               middle_name,
-              last_name
+              last_name,
+              designation
             )
-            values ($1, $2, $3, $4, $5)
+            values ($1, $2, $3, $4, $5, $6)
           `,
           candidate.id,
           contest.id,
           candidate.firstName,
           candidate.middleName,
-          candidate.lastName
+          candidate.lastName,
+          candidate.designation
         );
         for (const partyId of candidate.partyIds ?? []) {
           await client.query(
@@ -1095,6 +1097,7 @@ export class Store {
               first_name as "firstName",
               middle_name as "middleName",
               last_name as "lastName",
+              designation,
               -- Order by name for a deterministic order (party ids are
               -- randomly generated, so ordering by them varies per import)
               array_remove(array_agg(candidates_parties.party_id ORDER BY parties.name), NULL) as "partyIds"
@@ -1114,6 +1117,7 @@ export class Store {
         firstName: string | null;
         middleName: string | null;
         lastName: string | null;
+        designation: string | null;
         partyIds: PartyId[];
       }>;
       const contests: Contest[] = contestRows.map((row) => {
@@ -1130,6 +1134,7 @@ export class Store {
                 firstName: candidate.firstName || undefined,
                 middleName: candidate.middleName || undefined,
                 lastName: candidate.lastName || undefined,
+                designation: candidate.designation || undefined,
                 name: [
                   candidate.firstName,
                   candidate.middleName,

--- a/apps/design/frontend/src/contest_form.tsx
+++ b/apps/design/frontend/src/contest_form.tsx
@@ -492,6 +492,7 @@ export function ContestForm(props: ContestFormProps): React.ReactNode {
                       <TH>Middle Name</TH>
                       <TH>Last Name</TH>
                       <TH>Party</TH>
+                      <TH>Designation</TH>
                       <TH />
                     </tr>
                   </thead>
@@ -601,6 +602,43 @@ export function ContestForm(props: ContestFormProps): React.ReactNode {
                                 ),
                               })
                             }
+                          />
+                        </TD>
+                        <TD>
+                          <input
+                            aria-label={`Candidate ${index + 1} Designation`}
+                            disabled={disabled || hasExternalSource}
+                            type="text"
+                            value={candidate.designation || ''}
+                            onChange={(e) => {
+                              const { value } = e.target;
+                              setContest({
+                                ...contest,
+                                candidates: replaceAtIndex(
+                                  contest.candidates,
+                                  index,
+                                  {
+                                    ...candidate,
+                                    designation: value || undefined,
+                                  }
+                                ),
+                              });
+                            }}
+                            onBlur={(e) => {
+                              const { value } = e.target;
+                              setContest({
+                                ...contest,
+                                candidates: replaceAtIndex(
+                                  contest.candidates,
+                                  index,
+                                  {
+                                    ...candidate,
+                                    designation: value || undefined,
+                                  }
+                                ),
+                              });
+                            }}
+                            autoComplete="off"
                           />
                         </TD>
                         <TD>
@@ -926,6 +964,7 @@ interface DraftCandidate {
   middleName: string;
   lastName: string;
   partyIds?: PartyId[];
+  designation?: string;
 }
 
 interface DraftCandidateContest {
@@ -983,6 +1022,8 @@ function draftCandidateFromCandidate(candidate: Candidate): DraftCandidate {
     firstName,
     middleName,
     lastName,
+    designation:
+      candidate.designation !== undefined ? candidate.designation : undefined,
     partyIds: candidate.partyIds?.slice(),
   };
 }

--- a/apps/design/frontend/src/contest_form.tsx
+++ b/apps/design/frontend/src/contest_form.tsx
@@ -492,7 +492,7 @@ export function ContestForm(props: ContestFormProps): React.ReactNode {
                       <TH>Middle Name</TH>
                       <TH>Last Name</TH>
                       <TH>Party</TH>
-                      <TH>Designation</TH>
+                      {features.CANDIDATE_DESIGNATIONS && <TH>Designation</TH>}
                       <TH />
                     </tr>
                   </thead>
@@ -604,43 +604,45 @@ export function ContestForm(props: ContestFormProps): React.ReactNode {
                             }
                           />
                         </TD>
-                        <TD>
-                          <input
-                            aria-label={`Candidate ${index + 1} Designation`}
-                            disabled={disabled || hasExternalSource}
-                            type="text"
-                            value={candidate.designation || ''}
-                            onChange={(e) => {
-                              const { value } = e.target;
-                              setContest({
-                                ...contest,
-                                candidates: replaceAtIndex(
-                                  contest.candidates,
-                                  index,
-                                  {
-                                    ...candidate,
-                                    designation: value || undefined,
-                                  }
-                                ),
-                              });
-                            }}
-                            onBlur={(e) => {
-                              const { value } = e.target;
-                              setContest({
-                                ...contest,
-                                candidates: replaceAtIndex(
-                                  contest.candidates,
-                                  index,
-                                  {
-                                    ...candidate,
-                                    designation: value || undefined,
-                                  }
-                                ),
-                              });
-                            }}
-                            autoComplete="off"
-                          />
-                        </TD>
+                        {features.CANDIDATE_DESIGNATIONS && (
+                          <TD>
+                            <input
+                              aria-label={`Candidate ${index + 1} Designation`}
+                              disabled={disabled || hasExternalSource}
+                              type="text"
+                              value={candidate.designation || ''}
+                              onChange={(e) => {
+                                const { value } = e.target;
+                                setContest({
+                                  ...contest,
+                                  candidates: replaceAtIndex(
+                                    contest.candidates,
+                                    index,
+                                    {
+                                      ...candidate,
+                                      designation: value || undefined,
+                                    }
+                                  ),
+                                });
+                              }}
+                              onBlur={(e) => {
+                                const { value } = e.target;
+                                setContest({
+                                  ...contest,
+                                  candidates: replaceAtIndex(
+                                    contest.candidates,
+                                    index,
+                                    {
+                                      ...candidate,
+                                      designation: value || undefined,
+                                    }
+                                  ),
+                                });
+                              }}
+                              autoComplete="off"
+                            />
+                          </TD>
+                        )}
                         <TD>
                           {editing && !hasExternalSource ? (
                             <TooltipContainer style={{ width: 'min-content' }}>

--- a/apps/design/frontend/src/contest_form.tsx
+++ b/apps/design/frontend/src/contest_form.tsx
@@ -1022,8 +1022,7 @@ function draftCandidateFromCandidate(candidate: Candidate): DraftCandidate {
     firstName,
     middleName,
     lastName,
-    designation:
-      candidate.designation !== undefined ? candidate.designation : undefined,
+    designation: candidate.designation,
     partyIds: candidate.partyIds?.slice(),
   };
 }

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -870,6 +870,31 @@ test.each(nameTestSpecs)(
   }
 );
 
+test('editing a candidate designation is not shown when flag is off', async () => {
+  const electionRecord = generalElectionRecord(jurisdiction.id);
+  const { election } = electionRecord;
+  const electionId = election.id;
+
+  apiMock.listContests
+    .expectCallWith({ electionId })
+    .resolves(election.contests);
+  expectOtherElectionApiCalls(election);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+
+  // Flag is off by default but this is more readable
+  const history = renderScreen(electionId, { CANDIDATE_DESIGNATIONS: false });
+  await navigateToContestEdit(history, electionId, election.contests[0].id);
+
+  // The rest of the candidate table still renders
+  screen.getByRole('columnheader', { name: 'First Name' });
+  screen.getByLabelText('Candidate 1 First Name');
+
+  expect(
+    screen.queryByRole('columnheader', { name: 'Designation' })
+  ).toBeNull();
+  expect(screen.queryByLabelText('Candidate 1 Designation')).toBeNull();
+});
+
 test('editing a candidate designation', async () => {
   const electionRecord = generalElectionRecord(jurisdiction.id);
   const { election } = electionRecord;
@@ -907,7 +932,7 @@ test('editing a candidate designation', async () => {
   expectOtherElectionApiCalls(election);
   apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
 
-  const history = renderScreen(electionId);
+  const history = renderScreen(electionId, { CANDIDATE_DESIGNATIONS: true });
   await navigateToContestEdit(history, electionId, savedContest.id);
 
   // The saved designation is loaded into the form

--- a/apps/design/frontend/src/contests_screen.test.tsx
+++ b/apps/design/frontend/src/contests_screen.test.tsx
@@ -5,6 +5,7 @@ import {
   Contest,
   BallotStyleGroupIdSchema,
   BallotStyleIdSchema,
+  Candidate,
   CandidateContest,
   DEFAULT_SYSTEM_SETTINGS,
   DistrictIdSchema,
@@ -53,7 +54,11 @@ import { withRoute } from '../test/routing_helpers.js';
 import { ContestsScreen } from './contests_screen.js';
 import { routes } from './routes.js';
 import { makeIdFactory } from '../test/id_helpers.js';
-import { ContestList, ContestListProps, ReorderParams } from './contest_list.js';
+import {
+  ContestList,
+  ContestListProps,
+  ReorderParams,
+} from './contest_list.js';
 import { ContestAudioPanel } from './contest_audio_panel.js';
 
 vi.mock('./contest_list.js');
@@ -217,6 +222,15 @@ const electionWithStraightPartyContestRecord: typeof electionWithNoContestsRecor
       contests: [straightPartyContest, mayorContest],
     },
   };
+
+function withUndefinedDesignations(
+  candidates: readonly Candidate[]
+): readonly Candidate[] {
+  return candidates.map((candidate) => ({
+    designation: undefined,
+    ...candidate,
+  }));
+}
 
 // Since we coarsely invalidate all election data on contest changes, there
 // are a number of other API calls that refetch when we mutate contests
@@ -588,7 +602,7 @@ test('editing a candidate contest (primary election)', async () => {
     seats: savedContest.seats + 1,
     allowWriteIns: !savedContest.allowWriteIns,
     termDescription: 'Updated Term Description',
-    candidates: [
+    candidates: withUndefinedDesignations([
       {
         ...savedContest.candidates[1],
         name: 'Updated Candidate Name',
@@ -598,7 +612,7 @@ test('editing a candidate contest (primary election)', async () => {
         partyIds: undefined,
       },
       ...savedContest.candidates.slice(2),
-    ],
+    ]),
   };
 
   apiMock.listContests
@@ -855,6 +869,72 @@ test.each(nameTestSpecs)(
     expectContestListItems([newContest]);
   }
 );
+
+test('editing a candidate designation', async () => {
+  const electionRecord = generalElectionRecord(jurisdiction.id);
+  const { election } = electionRecord;
+  const electionId = election.id;
+  const savedContest: CandidateContest = {
+    ...find(
+      election.contests,
+      (contest): contest is CandidateContest => contest.type === 'candidate'
+    ),
+    allowWriteIns: true,
+    candidates: [
+      {
+        id: 'candidate-1',
+        name: 'Candidate One',
+        firstName: 'Candidate',
+        middleName: '',
+        lastName: 'One',
+        designation: 'Mayor of Springfield',
+      },
+    ],
+  };
+  const updatedContest: CandidateContest = {
+    ...savedContest,
+    candidates: [
+      {
+        ...savedContest.candidates[0],
+        designation: 'Member of City Council',
+        middleName: undefined,
+        partyIds: undefined,
+      },
+    ],
+  };
+
+  apiMock.listContests.expectCallWith({ electionId }).resolves([savedContest]);
+  expectOtherElectionApiCalls(election);
+  apiMock.getBallotsFinalizedAt.expectCallWith({ electionId }).resolves(null);
+
+  const history = renderScreen(electionId);
+  await navigateToContestEdit(history, electionId, savedContest.id);
+
+  // The saved designation is loaded into the form
+  const designationInput = screen.getByLabelText('Candidate 1 Designation');
+  expect(designationInput).toHaveValue('Mayor of Springfield');
+
+  // Clearing it unsets the designation
+  userEvent.clear(designationInput);
+  userEvent.tab();
+  expect(designationInput).toHaveValue('');
+
+  // Designations may contain spaces
+  userEvent.type(designationInput, updatedContest.candidates[0].designation!);
+  userEvent.tab();
+  expect(designationInput).toHaveValue('Member of City Council');
+
+  apiMock.updateContest
+    .expectCallWith({ electionId, updatedContest })
+    .resolves(ok());
+  apiMock.listContests
+    .expectRepeatedCallsWith({ electionId })
+    .resolves([updatedContest]);
+  expectOtherElectionApiCalls(election);
+  userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+  await expectViewModeContest(history, electionId, updatedContest);
+});
 
 test('adding a ballot measure', async () => {
   const electionRecord = generalElectionRecord(jurisdiction.id);
@@ -1482,11 +1562,18 @@ test('error messages for duplicate candidate contest/candidates', async () => {
   await expectViewModeContest(history, electionId, election.contests[0]);
   await navigateToContestEdit(history, electionId, election.contests[1].id);
 
+  const savedContest = election.contests[1];
+  assert(savedContest.type === 'candidate');
+  const expectedContest: CandidateContest = {
+    ...savedContest,
+    candidates: withUndefinedDesignations(savedContest.candidates),
+  };
+
   // Mock the duplicate contest error, even though we didn't actually change anything
   apiMock.updateContest
     .expectCallWith({
       electionId,
-      updatedContest: election.contests[1],
+      updatedContest: expectedContest,
     })
     .resolves(err('duplicate-contest'));
   userEvent.click(screen.getByRole('button', { name: 'Save' }));
@@ -1499,7 +1586,7 @@ test('error messages for duplicate candidate contest/candidates', async () => {
   apiMock.updateContest
     .expectCallWith({
       electionId,
-      updatedContest: election.contests[1],
+      updatedContest: expectedContest,
     })
     .resolves(err('duplicate-candidate'));
   userEvent.click(screen.getByRole('button', { name: 'Save' }));

--- a/libs/types/src/cdf/ballot-definition/convert.test.ts
+++ b/libs/types/src/cdf/ballot-definition/convert.test.ts
@@ -45,6 +45,9 @@ test('convertVxfElectionToCdfBallotDefinition', () => {
 test('convertVxfElectionToCdfBallotDefinition with translated election strings', () => {
   const translatedElectionStrings: UiStringsPackage = {
     'es-US': {
+      [ElectionStringKey.CANDIDATE_DESIGNATION]: {
+        'candidate-1': 'Miembro del Concejo Municipal',
+      },
       [ElectionStringKey.CANDIDATE_NAME]: {
         'candidate-1': 'Sherlock Holmes',
         'candidate-2': 'Thomas Edison',
@@ -93,6 +96,9 @@ test('convertVxfElectionToCdfBallotDefinition with translated election strings',
       [ElectionStringKey.STATE_NAME]: 'Estado de Hamilton',
     },
     'zh-Hans': {
+      [ElectionStringKey.CANDIDATE_DESIGNATION]: {
+        'candidate-1': '市议会议员',
+      },
       [ElectionStringKey.CANDIDATE_NAME]: {
         'candidate-1': 'Sherlock Holmes',
         'candidate-2': 'Thomas Edison',
@@ -129,6 +135,17 @@ test('convertVxfElectionToCdfBallotDefinition with translated election strings',
       languageString('Winston Churchill', 'en'),
       languageString('Winston Churchill', 'es-US'),
       languageString('Winston Churchill', 'zh-Hans'),
+    ]
+  );
+
+  // Candidate designations
+  set(
+    expectedCdfBallotDefinition,
+    ['Election', 0, 'Candidate', 0, 'CampaignSlogan', 'Text'],
+    [
+      languageString('Member of City Council', 'en'),
+      languageString('Miembro del Concejo Municipal', 'es-US'),
+      languageString('市议会议员', 'zh-Hans'),
     ]
   );
 
@@ -373,58 +390,58 @@ test('ballot styles with same districts but different rotations in different pre
     optionBoundsFromTargetMark: Outset;
     gridPositions: FlatGridPosition[];
   }> = [
-      {
-        ballotStyleId: 'ballot-style-1',
-        optionBoundsFromTargetMark: { top: 1, left: 1, right: 9, bottom: 1 },
-        gridPositions: [
-          {
-            type: 'option',
-            sheetNumber: 1,
-            side: 'front',
-            contestId: 'contest-1',
-            column: 2,
-            row: 12,
-            optionId: 'candidate-1',
-            partyIds: ['party-1'],
-          },
-          {
-            type: 'option',
-            sheetNumber: 1,
-            side: 'front',
-            contestId: 'contest-1',
-            column: 2,
-            row: 14,
-            optionId: 'candidate-2',
-            partyIds: ['party-2'],
-          },
-        ],
-      },
-      {
-        ballotStyleId: 'ballot-style-2',
-        optionBoundsFromTargetMark: { top: 1, left: 1, right: 9, bottom: 1 },
-        gridPositions: [
-          {
-            type: 'option',
-            sheetNumber: 1,
-            side: 'front',
-            contestId: 'contest-1',
-            column: 2,
-            row: 12,
-            optionId: 'candidate-2',
-            partyIds: ['party-2'],
-          },
-          {
-            type: 'option',
-            sheetNumber: 1,
-            side: 'front',
-            contestId: 'contest-1',
-            column: 2,
-            row: 14,
-            optionId: 'candidate-1',
-            partyIds: ['party-1'],
-          },
-        ],
-      },
+    {
+      ballotStyleId: 'ballot-style-1',
+      optionBoundsFromTargetMark: { top: 1, left: 1, right: 9, bottom: 1 },
+      gridPositions: [
+        {
+          type: 'option',
+          sheetNumber: 1,
+          side: 'front',
+          contestId: 'contest-1',
+          column: 2,
+          row: 12,
+          optionId: 'candidate-1',
+          partyIds: ['party-1'],
+        },
+        {
+          type: 'option',
+          sheetNumber: 1,
+          side: 'front',
+          contestId: 'contest-1',
+          column: 2,
+          row: 14,
+          optionId: 'candidate-2',
+          partyIds: ['party-2'],
+        },
+      ],
+    },
+    {
+      ballotStyleId: 'ballot-style-2',
+      optionBoundsFromTargetMark: { top: 1, left: 1, right: 9, bottom: 1 },
+      gridPositions: [
+        {
+          type: 'option',
+          sheetNumber: 1,
+          side: 'front',
+          contestId: 'contest-1',
+          column: 2,
+          row: 12,
+          optionId: 'candidate-2',
+          partyIds: ['party-2'],
+        },
+        {
+          type: 'option',
+          sheetNumber: 1,
+          side: 'front',
+          contestId: 'contest-1',
+          column: 2,
+          row: 14,
+          optionId: 'candidate-1',
+          partyIds: ['party-1'],
+        },
+      ],
+    },
   ];
   const ballotPositionsByStyleId: Record<string, Vxf.SheetPositions[]> =
     Object.fromEntries(

--- a/libs/types/src/cdf/ballot-definition/convert.ts
+++ b/libs/types/src/cdf/ballot-definition/convert.ts
@@ -132,6 +132,15 @@ function electionLanguageCodes(cdfElection: Cdf.BallotDefinition): string[] {
   return electionTitleStrings.map((string) => string.Language);
 }
 
+function electionCandidates(
+  cdfElection: Cdf.BallotDefinition
+): readonly Cdf.Candidate[] {
+  return (
+    assertDefined(cdfElection.Election[0]).Candidate ||
+    /* istanbul ignore next */ []
+  );
+}
+
 const extractorFns: Record<
   ElectionStringKey,
   (cdfElection: Cdf.BallotDefinition, uiStrings: UiStringsPackage) => void
@@ -178,14 +187,20 @@ const extractorFns: Record<
     }
   },
 
-  // TODO(kevin): Extract candidate designations once they're represented in CDF.
-  [ElectionStringKey.CANDIDATE_DESIGNATION]() {},
+  [ElectionStringKey.CANDIDATE_DESIGNATION](cdfElection, uiStrings) {
+    for (const candidate of electionCandidates(cdfElection)) {
+      if (!candidate.CampaignSlogan) continue;
+
+      setInternationalizedUiStrings({
+        stringKey: [ElectionStringKey.CANDIDATE_DESIGNATION, candidate['@id']],
+        uiStrings,
+        values: candidate.CampaignSlogan.Text,
+      });
+    }
+  },
 
   [ElectionStringKey.CANDIDATE_NAME](cdfElection, uiStrings) {
-    const candidates =
-      assertDefined(cdfElection.Election[0]).Candidate ||
-      /* istanbul ignore next */ [];
-    for (const candidate of candidates) {
+    for (const candidate of electionCandidates(cdfElection)) {
       setInternationalizedUiStrings({
         stringKey: [ElectionStringKey.CANDIDATE_NAME, candidate['@id']],
         uiStrings,
@@ -798,7 +813,6 @@ export function convertVxfElectionToCdfBallotDefinition(
           )
           .flatMap((contest) => contest.candidates)
           .map(
-            // TODO(kevin): support `candidate.designation`
             (candidate): Cdf.Candidate => ({
               '@type': 'BallotDefinition.Candidate',
               '@id': candidate.id,
@@ -806,6 +820,14 @@ export function convertVxfElectionToCdfBallotDefinition(
                 ElectionStringKey.CANDIDATE_NAME,
                 candidate.id,
               ]),
+              // CDF has no dedicated field for a candidate designation, so we
+              // use the closest available: the candidate's campaign slogan.
+              CampaignSlogan: candidate.designation
+                ? text(candidate.designation, [
+                    ElectionStringKey.CANDIDATE_DESIGNATION,
+                    candidate.id,
+                  ])
+                : undefined,
             })
           ),
 
@@ -1278,7 +1300,9 @@ export function convertCdfBallotDefinitionToVxfElection(
                 // candidate is endorsed by multiple parties, and we don't
                 // care about the candidate's "home" party.
                 partyIds: option.EndorsementPartyIds,
-                // TODO(kevin): support `candidate.designation`
+                designation:
+                  candidate.CampaignSlogan &&
+                  englishText(candidate.CampaignSlogan),
               };
             }),
             partyId: contest.PrimaryPartyIds

--- a/libs/types/src/cdf/ballot-definition/extract_cdf_ui_strings.test.ts
+++ b/libs/types/src/cdf/ballot-definition/extract_cdf_ui_strings.test.ts
@@ -79,12 +79,45 @@ const tests: Record<ElectionStringKey, () => void> = {
   },
 
   [ElectionStringKey.CANDIDATE_DESIGNATION]() {
-    // CDF has no field for candidate designations yet, so none are extracted.
-    const uiStrings = extractCdfUiStrings(testCdfBallotDefinition);
+    const originalCandidates = assertDefined(ORIGINAL_ELECTION.Candidate);
 
-    expect(
-      uiStrings['en']?.[ElectionStringKey.CANDIDATE_DESIGNATION]
-    ).toBeUndefined();
+    const uiStrings = extractCdfUiStrings({
+      ...testCdfBallotDefinition,
+      Election: [
+        {
+          ...ORIGINAL_ELECTION,
+          Candidate: [
+            {
+              ...assertDefined(originalCandidates[0]),
+              '@id': 'candidate1',
+              CampaignSlogan: buildInternationalizedText({
+                en: 'Member of City Council',
+                'es-US': 'Miembro del Concejo Municipal',
+              }),
+            },
+            // Candidates without a designation are skipped.
+            {
+              ...assertDefined(originalCandidates[1]),
+              '@id': 'candidate2',
+              CampaignSlogan: undefined,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(uiStrings).toEqual({
+      en: expect.objectContaining({
+        [ElectionStringKey.CANDIDATE_DESIGNATION]: {
+          candidate1: 'Member of City Council',
+        },
+      }),
+      'es-US': expect.objectContaining({
+        [ElectionStringKey.CANDIDATE_DESIGNATION]: {
+          candidate1: 'Miembro del Concejo Municipal',
+        },
+      }),
+    });
   },
 
   [ElectionStringKey.CANDIDATE_NAME]() {

--- a/libs/types/src/cdf/ballot-definition/fixtures.ts
+++ b/libs/types/src/cdf/ballot-definition/fixtures.ts
@@ -302,6 +302,7 @@ export const testVxfElection: Election = {
         {
           id: 'candidate-1',
           name: 'Sherlock Holmes',
+          designation: 'Member of City Council',
           partyIds: ['party-1'],
         },
         {
@@ -475,6 +476,9 @@ export const testVxfElection: Election = {
         '3_en': '3_en',
         '3_es-US': '3_es-US',
       },
+      candidateDesignation: {
+        'candidate-1': 'Member of City Council',
+      },
       candidateName: {
         'candidate-1': 'Sherlock Holmes',
         'candidate-2': 'Thomas Edison',
@@ -588,6 +592,16 @@ export const testCdfBallotDefinition: BallotDefinition = {
                 '@type': 'BallotDefinition.LanguageString',
                 Language: 'en',
                 Content: 'Sherlock Holmes',
+              },
+            ],
+          },
+          CampaignSlogan: {
+            '@type': 'BallotDefinition.InternationalizedText',
+            Text: [
+              {
+                '@type': 'BallotDefinition.LanguageString',
+                Language: 'en',
+                Content: 'Member of City Council',
               },
             ],
           },

--- a/libs/types/src/cdf/ballot-definition/index.ts
+++ b/libs/types/src/cdf/ballot-definition/index.ts
@@ -680,6 +680,11 @@ export interface Candidate {
    * For the candidate’s name as listed on the ballot.
    */
   readonly BallotName: InternationalizedText;
+
+  /**
+   * The slogan or motto used by the candidate in their campaign.
+   */
+  readonly CampaignSlogan?: InternationalizedText;
 }
 
 /**
@@ -689,6 +694,7 @@ export const CandidateSchema: z.ZodSchema<Candidate> = z.object({
   '@id': z.string(),
   '@type': z.literal('BallotDefinition.Candidate'),
   BallotName: z.lazy(/* istanbul ignore next */ () => InternationalizedTextSchema),
+  CampaignSlogan: z.optional(z.lazy(/* istanbul ignore next */ () => InternationalizedTextSchema)),
 });
 
 /**

--- a/libs/types/src/cdf/ballot-definition/vx-schema.json
+++ b/libs/types/src/cdf/ballot-definition/vx-schema.json
@@ -326,6 +326,9 @@
         },
         "BallotName": {
           "$ref": "#/definitions/BallotDefinition.InternationalizedText"
+        },
+        "CampaignSlogan": {
+          "$ref": "#/definitions/BallotDefinition.InternationalizedText"
         }
       },
       "type": "object"

--- a/libs/types/src/election.test.ts
+++ b/libs/types/src/election.test.ts
@@ -476,6 +476,34 @@ test('candidate schema', () => {
       name: 'Bob Loblaw',
     })
   );
+
+  // Designations are trimmed, preserving internal whitespace
+  expect(
+    safeParse(CandidateSchema, {
+      id: 'bob-loblaw',
+      name: 'Bob Loblaw',
+      designation: '  Member of City Council  ',
+    })
+  ).toEqual(
+    ok({
+      id: 'bob-loblaw',
+      name: 'Bob Loblaw',
+      designation: 'Member of City Council',
+    })
+  );
+
+  expect(
+    safeParse(CandidateSchema, {
+      id: 'bob-loblaw',
+      name: 'Bob Loblaw',
+      designation: '   ',
+    })
+  ).toEqual(
+    ok({
+      id: 'bob-loblaw',
+      name: 'Bob Loblaw',
+    })
+  );
 });
 
 test('write-in ID schema', () => {

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -122,7 +122,10 @@ export const CandidateSchema: z.ZodSchema<Candidate> = z
   .object({
     id: CandidateIdSchema,
     name: z.string().min(1),
-    designation: z.string().nonempty().optional(),
+    designation: z
+      .string()
+      .transform((s) => s.trim() || undefined)
+      .optional(),
     partyIds: z.array(PartyIdSchema).optional(),
     isWriteIn: z.boolean().optional(),
     writeInIndex: z.number().int().nonnegative().optional(),


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/7816

* Adds an input on the Contest screen for candidate designation.
* While I was in here, added CDF support for candidate designation in the `Candidate.CampaignSlogan` field.
  * CDF has no "title" or "office" field for candidates, and `CampaignSlogan` is the only free-text `InternationalizedText` field left on `Candidate`.

## Demo Video or Screenshot

https://github.com/user-attachments/assets/3f4c4708-9bc0-4789-a850-6328a4d6c270



## Testing Plan

* Added frontend test
* Manual e2e QA

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
