### PR TITLE
VxAdmin: basic placeholder CLI for backups

### DIFF
--- a/apps/admin/backend/bin/backups
+++ b/apps/admin/backend/bin/backups
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { main } from '../build/backup/cli/main.js';
+
+try {
+  process.exitCode = await main(process.argv, process);
+} catch (error) {
+  console.error(error);
+  process.exitCode = 1;
+}

--- a/apps/admin/backend/package.json
+++ b/apps/admin/backend/package.json
@@ -60,6 +60,7 @@
     "object-hash": "^3.0.0",
     "react": "18.3.1",
     "tmp": "^0.2.6",
+    "yargs": "17.7.1",
     "zip-stream": "^4.1.0",
     "zod": "4.4.3"
   },
@@ -76,6 +77,7 @@
     "@types/object-hash": "^3.0.6",
     "@types/react": "18.3.3",
     "@types/tmp": "0.2.4",
+    "@types/yargs": "17.0.22",
     "@types/zip-stream": "workspace:*",
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/fixtures": "workspace:*",

--- a/apps/admin/backend/src/backup/backup.test.ts
+++ b/apps/admin/backend/src/backup/backup.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest';
+import { Backup } from './backup.js';
+import { BackupManifestFile } from './backup_manifest_file.js';
+
+test('exposes the backup path', () => {
+  expect(new Backup('/media/vx/backup/vxadmin-backups/backup-1').path).toEqual(
+    '/media/vx/backup/vxadmin-backups/backup-1'
+  );
+});
+
+test('locates the manifest file within the backup', () => {
+  const backup = new Backup('/media/vx/backup/vxadmin-backups/backup-1');
+  expect(backup.manifestFile).toBeInstanceOf(BackupManifestFile);
+  expect(backup.manifestFile.path).toEqual(
+    '/media/vx/backup/vxadmin-backups/backup-1/manifest.json'
+  );
+});

--- a/apps/admin/backend/src/backup/backup.ts
+++ b/apps/admin/backend/src/backup/backup.ts
@@ -1,0 +1,20 @@
+import { join } from 'node:path';
+import { VXADMIN_BACKUP_MANIFEST_FILE_NAME } from '@votingworks/auth';
+import { BackupManifestFile } from './backup_manifest_file.js';
+
+/**
+ * Helper for managing a complete on-disk backup.
+ */
+export class Backup {
+  constructor(private readonly backupPath: string) {}
+
+  get path(): string {
+    return this.backupPath;
+  }
+
+  get manifestFile(): BackupManifestFile {
+    return new BackupManifestFile(
+      join(this.backupPath, VXADMIN_BACKUP_MANIFEST_FILE_NAME)
+    );
+  }
+}

--- a/apps/admin/backend/src/backup/backup_manifest.test.ts
+++ b/apps/admin/backend/src/backup/backup_manifest.test.ts
@@ -1,0 +1,138 @@
+import { expect, test } from 'vitest';
+import { DateWithoutTime, err, ok } from '@votingworks/basics';
+import { safeParse, unsafeParse } from '@votingworks/types';
+import { z } from 'zod/v4';
+import {
+  BACKUP_MANIFEST_VERSION,
+  BackupManifest,
+  BackupManifestEntrySchema,
+  BackupManifestStruct,
+  BackupManifestStructSchema,
+  ElectionMetadata,
+} from './backup_manifest.js';
+
+const election: ElectionMetadata = {
+  id: 'election-1',
+  title: 'General Election',
+  date: new DateWithoutTime('2026-11-03'),
+};
+
+const hashA = '0a'.repeat(32);
+const hashB = '1b'.repeat(32);
+
+const validStruct: BackupManifestStruct = {
+  version: BACKUP_MANIFEST_VERSION,
+  softwareVersion: '4.0.0',
+  machineId: 'VX-00-001',
+  createdAt: '2026-08-18T12:00:00.000Z',
+  election,
+  files: [
+    { path: 'data/election.db', hash: hashA, size: 1024 },
+    { path: 'logs/vx-logs.log', hash: hashB, size: 0 },
+  ],
+};
+
+test('parses a valid manifest struct', () => {
+  const parsed = unsafeParse(BackupManifestStructSchema, validStruct);
+  expect(parsed.version).toEqual(BACKUP_MANIFEST_VERSION);
+  expect(parsed.softwareVersion).toEqual('4.0.0');
+  expect(parsed.machineId).toEqual('VX-00-001');
+  expect(parsed.createdAt).toEqual('2026-08-18T12:00:00.000Z');
+  expect(parsed.election).toEqual(election);
+  expect(parsed.files).toEqual(validStruct.files);
+});
+
+test('rejects an unknown manifest version', () => {
+  expect(
+    safeParse(BackupManifestStructSchema, {
+      ...validStruct,
+      version: BACKUP_MANIFEST_VERSION + 1,
+    })
+  ).toEqual(err(expect.anything()));
+});
+
+test.each([
+  '',
+  '/absolute/path',
+  'windows\\path',
+  '..',
+  '../outside',
+  'a/../b',
+  './a',
+  'a//b',
+  'a/',
+])('rejects manifest entry path: %j', (path) => {
+  expect(
+    safeParse(BackupManifestEntrySchema, {
+      path,
+      hash: hashA,
+      size: 1,
+    })
+  ).toEqual(err(expect.anything()));
+});
+
+test.each(['a', 'a/b/c', '.hidden', 'a b/c d.txt'])(
+  'accepts manifest entry path: %j',
+  (path) => {
+    expect(
+      safeParse(BackupManifestEntrySchema, {
+        path,
+        hash: hashA,
+        size: 1,
+      })
+    ).toEqual(ok(expect.anything()));
+  }
+);
+
+test.each([
+  '',
+  'abc123',
+  `sha256:${'0a'.repeat(32)}`,
+  '0A'.repeat(32),
+  '0g'.repeat(32),
+])('rejects manifest entry hash: %j', (hash) => {
+  expect(
+    safeParse(BackupManifestEntrySchema, {
+      path: 'a',
+      hash,
+      size: 1,
+    })
+  ).toEqual(err(expect.anything()));
+});
+
+test.each([-1, 1.5])('rejects manifest entry size: %j', (size) => {
+  expect(
+    safeParse(BackupManifestEntrySchema, {
+      path: 'a',
+      hash: hashA,
+      size,
+    })
+  ).toEqual(err(expect.anything()));
+});
+
+test('BackupManifest exposes the struct fields', () => {
+  const parsed = unsafeParse(BackupManifestStructSchema, validStruct);
+  const manifest = BackupManifest.fromStruct(parsed);
+  expect(manifest.softwareVersion).toEqual('4.0.0');
+  expect(manifest.machineId).toEqual('VX-00-001');
+  expect(manifest.createdAt).toEqual('2026-08-18T12:00:00.000Z');
+  expect(manifest.election).toEqual(election);
+  expect(manifest.files).toEqual(parsed.files);
+});
+
+test('BackupManifest round-trips through toJSON', () => {
+  const parsed = unsafeParse(BackupManifestStructSchema, validStruct);
+  const manifest = BackupManifest.fromStruct(parsed);
+  expect(manifest.toJSON()).toEqual(validStruct);
+});
+
+test('toJSON fails fast on an invalid manifest', () => {
+  const manifest = new BackupManifest(
+    '4.0.0',
+    'VX-00-001',
+    '2026-08-18T12:00:00.000Z',
+    election,
+    [{ path: '../outside', hash: hashA, size: 1 }]
+  );
+  expect(() => manifest.toJSON()).toThrow(z.ZodError);
+});

--- a/apps/admin/backend/src/backup/backup_manifest.ts
+++ b/apps/admin/backend/src/backup/backup_manifest.ts
@@ -1,0 +1,134 @@
+import { z } from 'zod/v4';
+import {
+  DateWithoutTimeSchema,
+  ElectionIdSchema,
+  Iso8601DateTimeSchema,
+  Iso8601Timestamp,
+} from '@votingworks/types';
+
+/**
+ * The current backup manifest version. Change this whenever the schema changes.
+ */
+export const BACKUP_MANIFEST_VERSION = 1;
+
+/**
+ * Schema for {@link ElectionMetadata}.
+ */
+export const ElectionMetadataSchema = z.object({
+  id: ElectionIdSchema,
+  title: z.string().nonempty(),
+  date: DateWithoutTimeSchema,
+});
+
+/**
+ * Basic information about an election for identification purposes.
+ */
+export interface ElectionMetadata
+  extends z.infer<typeof ElectionMetadataSchema> {}
+
+/**
+ * Schema for {@link BackupManifestEntry}.
+ */
+export const BackupManifestEntrySchema = z.object({
+  path: z.string().refine(isContainedRelativePath, {
+    message: 'must be a relative path within the backup, using `/` separators',
+  }),
+  hash: z
+    .string()
+    .regex(/^[0-9a-f]{64}$/, 'hash must be a lowercase hex SHA-256 digest'),
+  size: z.number().int().nonnegative(),
+});
+
+function isContainedRelativePath(path: string): boolean {
+  if (path.length === 0 || path.startsWith('/') || path.includes('\\')) {
+    return false;
+  }
+
+  const segments = path.split('/');
+  return segments.every(
+    (segment) => segment !== '' && segment !== '.' && segment !== '..'
+  );
+}
+
+/**
+ * An entry in a `manifest.json` file.
+ */
+export interface BackupManifestEntry
+  extends z.infer<typeof BackupManifestEntrySchema> {}
+
+/**
+ * Schema for {@see BackupManifestStruct}.
+ */
+export const BackupManifestStructSchema = z.object({
+  version: z.literal(BACKUP_MANIFEST_VERSION),
+  softwareVersion: z.string().nonempty(),
+  machineId: z.string().nonempty(),
+  createdAt: Iso8601DateTimeSchema,
+  election: ElectionMetadataSchema,
+  files: BackupManifestEntrySchema.array(),
+});
+
+/**
+ * A plain object version of the backup manifest.
+ */
+export interface BackupManifestStruct
+  extends z.infer<typeof BackupManifestStructSchema> {}
+
+/**
+ * An in-memory representation of a backup's `manifest.json`.
+ */
+export class BackupManifest {
+  constructor(
+    private readonly manifestSoftwareVersion: string,
+    private readonly manifestMachineId: string,
+    private readonly manifestCreatedAt: Iso8601Timestamp,
+    private readonly manifestElection: ElectionMetadata,
+    private readonly manifestFiles: BackupManifestEntry[]
+  ) {}
+
+  static fromStruct(data: BackupManifestStruct): BackupManifest {
+    return new BackupManifest(
+      data.softwareVersion,
+      data.machineId,
+      data.createdAt,
+      data.election,
+      data.files
+    );
+  }
+
+  get softwareVersion(): string {
+    return this.manifestSoftwareVersion;
+  }
+
+  get machineId(): string {
+    return this.manifestMachineId;
+  }
+
+  get createdAt(): Iso8601Timestamp {
+    return this.manifestCreatedAt;
+  }
+
+  get election(): ElectionMetadata {
+    return this.manifestElection;
+  }
+
+  get files(): readonly BackupManifestEntry[] {
+    return this.manifestFiles;
+  }
+
+  toJSON(): BackupManifestStruct {
+    const manifest: BackupManifestStruct = {
+      version: BACKUP_MANIFEST_VERSION,
+      softwareVersion: this.manifestSoftwareVersion,
+      machineId: this.manifestMachineId,
+      createdAt: this.manifestCreatedAt.toString(),
+      election: this.manifestElection,
+      files: [...this.manifestFiles],
+    };
+
+    // assert validity
+    BackupManifestStructSchema.parse(manifest);
+
+    return manifest;
+  }
+}

--- a/apps/admin/backend/src/backup/backup_manifest_file.test.ts
+++ b/apps/admin/backend/src/backup/backup_manifest_file.test.ts
@@ -1,0 +1,67 @@
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect, test } from 'vitest';
+import { z } from 'zod/v4';
+import { makeTemporaryDirectory } from '@votingworks/fixtures';
+import { BackupManifestFile } from './backup_manifest_file.js';
+import { BACKUP_MANIFEST_VERSION } from './backup_manifest.js';
+
+const validManifestJson = JSON.stringify({
+  version: BACKUP_MANIFEST_VERSION,
+  softwareVersion: '4.0.0',
+  machineId: 'VX-00-001',
+  createdAt: '2026-08-18T12:00:00.000Z',
+  election: {
+    id: 'election-1',
+    title: 'General Election',
+    date: '2026-11-03',
+  },
+  files: [{ path: 'data/election.db', hash: '0a'.repeat(32), size: 1024 }],
+});
+
+test('exposes the manifest path', () => {
+  const manifestFile = new BackupManifestFile('/backup/manifest.json');
+  expect(manifestFile.path).toEqual('/backup/manifest.json');
+});
+
+test('reads a valid manifest', async () => {
+  const dir = makeTemporaryDirectory();
+  const manifestPath = join(dir, 'manifest.json');
+  writeFileSync(manifestPath, validManifestJson);
+
+  const manifest = (
+    await new BackupManifestFile(manifestPath).readManifest()
+  ).unsafeUnwrap();
+  expect(manifest.machineId).toEqual('VX-00-001');
+  expect(manifest.files).toEqual([
+    { path: 'data/election.db', hash: '0a'.repeat(32), size: 1024 },
+  ]);
+});
+
+test('returns an error when the manifest is missing', async () => {
+  const dir = makeTemporaryDirectory();
+  const manifestFile = new BackupManifestFile(join(dir, 'manifest.json'));
+
+  const result = await manifestFile.readManifest();
+  expect(result.unsafeUnwrapErr()).toEqual(
+    expect.objectContaining({ type: 'OpenFileError' })
+  );
+});
+
+test('returns an error when the manifest is not valid JSON', async () => {
+  const dir = makeTemporaryDirectory();
+  const manifestPath = join(dir, 'manifest.json');
+  writeFileSync(manifestPath, 'not json');
+
+  const result = await new BackupManifestFile(manifestPath).readManifest();
+  expect(result.unsafeUnwrapErr()).toBeInstanceOf(SyntaxError);
+});
+
+test('returns an error when the manifest does not match the schema', async () => {
+  const dir = makeTemporaryDirectory();
+  const manifestPath = join(dir, 'manifest.json');
+  writeFileSync(manifestPath, JSON.stringify({ version: 'invalid' }));
+
+  const result = await new BackupManifestFile(manifestPath).readManifest();
+  expect(result.unsafeUnwrapErr()).toBeInstanceOf(z.ZodError);
+});

--- a/apps/admin/backend/src/backup/backup_manifest_file.ts
+++ b/apps/admin/backend/src/backup/backup_manifest_file.ts
@@ -1,0 +1,37 @@
+import { readFile, ReadFileError } from '@votingworks/fs';
+import { ok, Result } from '@votingworks/basics';
+import { safeParseJson } from '@votingworks/types';
+import { z } from 'zod/v4';
+import {
+  BackupManifest,
+  BackupManifestStructSchema,
+} from './backup_manifest.js';
+
+const BACKUP_MANIFEST_MAX_SIZE = 100_000_000; // 100 MB
+
+/**
+ * Backup manifest manager for the on-disk `manifest.json` within a backup.
+ */
+export class BackupManifestFile {
+  constructor(private readonly manifestPath: string) {}
+
+  get path(): string {
+    return this.manifestPath;
+  }
+
+  async readManifest(): Promise<
+    Result<BackupManifest, ReadFileError | SyntaxError | z.ZodError<unknown>>
+  > {
+    const readFileResult = await readFile(this.manifestPath, {
+      maxSize: BACKUP_MANIFEST_MAX_SIZE,
+    });
+    if (readFileResult.isErr()) return readFileResult;
+    const parseManifestResult = safeParseJson(
+      readFileResult.ok().toString('utf-8'),
+      BackupManifestStructSchema
+    );
+    return parseManifestResult.isErr()
+      ? parseManifestResult
+      : ok(BackupManifest.fromStruct(parseManifestResult.ok()));
+  }
+}

--- a/apps/admin/backend/src/backup/backup_root.test.ts
+++ b/apps/admin/backend/src/backup/backup_root.test.ts
@@ -1,0 +1,98 @@
+import { expect, test, vi } from 'vitest';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { makeTemporaryDirectory } from '@votingworks/fixtures';
+import { BackupRoot } from './backup_root.js';
+
+vi.mock(
+  import('node:fs/promises'),
+  async (importActual): Promise<typeof import('node:fs/promises')> => {
+    const actual = await importActual();
+    return {
+      ...actual,
+      readdir: vi.fn(actual.readdir) as unknown as typeof readdir,
+    };
+  }
+);
+
+test('exposes the root path', () => {
+  expect(new BackupRoot('/media/vx/backup').path).toEqual('/media/vx/backup');
+});
+
+test('lists backup directories, ignoring stray files', async () => {
+  const rootPath = makeTemporaryDirectory();
+  const backupsPath = join(rootPath, 'vxadmin-backups');
+  mkdirSync(join(backupsPath, 'backup-1'), { recursive: true });
+  mkdirSync(join(backupsPath, 'backup-2'), { recursive: true });
+  writeFileSync(join(backupsPath, 'stray-file.txt'), 'not a backup');
+
+  const backups = (await new BackupRoot(rootPath).listBackups()).unsafeUnwrap();
+  expect(backups.map((backup) => backup.path).sort()).toEqual([
+    join(backupsPath, 'backup-1'),
+    join(backupsPath, 'backup-2'),
+  ]);
+});
+
+test('lists no backups when the backups directory is empty', async () => {
+  const rootPath = makeTemporaryDirectory();
+  mkdirSync(join(rootPath, 'vxadmin-backups'));
+
+  expect((await new BackupRoot(rootPath).listBackups()).unsafeUnwrap()).toEqual(
+    []
+  );
+});
+
+test('lists no backups when the backups directory does not exist', async () => {
+  const rootPath = makeTemporaryDirectory();
+
+  expect((await new BackupRoot(rootPath).listBackups()).unsafeUnwrap()).toEqual(
+    []
+  );
+});
+
+test('returns an error when the root does not exist', async () => {
+  const rootPath = join(makeTemporaryDirectory(), 'does-not-exist');
+
+  const result = await new BackupRoot(rootPath).listBackups();
+  expect(result.unsafeUnwrapErr()).toEqual({
+    type: 'root-not-found',
+    message: `${rootPath} does not exist`,
+  });
+});
+
+test('returns an error when the root is not a directory', async () => {
+  const rootPath = join(makeTemporaryDirectory(), 'file.txt');
+  writeFileSync(rootPath, 'not a directory');
+
+  const result = await new BackupRoot(rootPath).listBackups();
+  expect(result.unsafeUnwrapErr()).toEqual({
+    type: 'not-directory',
+    message: `${rootPath} is not a directory`,
+  });
+});
+
+test('returns an error when the backups directory is not a directory', async () => {
+  const rootPath = makeTemporaryDirectory();
+  const backupsPath = join(rootPath, 'vxadmin-backups');
+  writeFileSync(backupsPath, 'not a directory');
+
+  const result = await new BackupRoot(rootPath).listBackups();
+  expect(result.unsafeUnwrapErr()).toEqual({
+    type: 'not-directory',
+    message: `${backupsPath} is not a directory`,
+  });
+});
+
+test('fails fast on unexpected errors', async () => {
+  const rootPath = makeTemporaryDirectory();
+  mkdirSync(join(rootPath, 'vxadmin-backups'));
+
+  const error = new Error('permission denied') as NodeJS.ErrnoException;
+  error.code = 'EACCES';
+  vi.mocked(readdir).mockRejectedValueOnce(error);
+
+  await expect(new BackupRoot(rootPath).listBackups()).rejects.toThrow(
+    'permission denied'
+  );
+});

--- a/apps/admin/backend/src/backup/backup_root.ts
+++ b/apps/admin/backend/src/backup/backup_root.ts
@@ -1,0 +1,74 @@
+import { Dirent, Stats } from 'node:fs';
+import { readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { err, ok, Result } from '@votingworks/basics';
+import { Backup } from './backup.js';
+
+/**
+ * The directory containing all VxAdmin backups within a root.
+ */
+const BACKUPS_DIRECTORY_NAME = 'vxadmin-backups';
+
+/**
+ * Expected errors that can occur when listing backups.
+ */
+export type ListBackupsError =
+  | { type: 'root-not-found'; message: string }
+  | { type: 'not-directory'; message: string };
+
+/**
+ * Helper for managing backups in a given location.
+ */
+export class BackupRoot {
+  constructor(private readonly rootPath: string) {}
+
+  get path(): string {
+    return this.rootPath;
+  }
+
+  /**
+   * Lists the backups within this root. A root without a backups directory
+   * has no backups, e.g. a backup drive that has never been backed up to.
+   */
+  async listBackups(): Promise<Result<Backup[], ListBackupsError>> {
+    let rootStat: Stats;
+    try {
+      rootStat = await stat(this.rootPath);
+    } catch {
+      return err({
+        type: 'root-not-found',
+        message: `${this.rootPath} does not exist`,
+      });
+    }
+    if (!rootStat.isDirectory()) {
+      return err({
+        type: 'not-directory',
+        message: `${this.rootPath} is not a directory`,
+      });
+    }
+
+    const backupsPath = join(this.rootPath, BACKUPS_DIRECTORY_NAME);
+    let entries: Dirent[];
+    try {
+      entries = await readdir(backupsPath, { withFileTypes: true });
+    } catch (error) {
+      const { code } = error as NodeJS.ErrnoException;
+      if (code === 'ENOENT') {
+        return ok([]);
+      }
+      if (code === 'ENOTDIR') {
+        return err({
+          type: 'not-directory',
+          message: `${backupsPath} is not a directory`,
+        });
+      }
+      throw error;
+    }
+
+    return ok(
+      entries
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => new Backup(join(entry.parentPath, entry.name)))
+    );
+  }
+}

--- a/apps/admin/backend/src/backup/cli/main.test.ts
+++ b/apps/admin/backend/src/backup/cli/main.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { makeTemporaryDirectory } from '@votingworks/fixtures';
+import { format } from '@votingworks/utils';
+import {
+  MockReadable,
+  MockWritable,
+  mockReadable,
+  mockWritable,
+} from '@votingworks/test-utils';
+import { BACKUP_MANIFEST_VERSION } from '../backup_manifest.js';
+import { main } from './main.js';
+
+interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+interface MockStreams {
+  stdin: MockReadable;
+  stdout: MockWritable;
+  stderr: MockWritable;
+}
+
+async function run(args: string[]): Promise<RunResult> {
+  const streams: MockStreams = {
+    stdin: mockReadable(),
+    stdout: mockWritable(),
+    stderr: mockWritable(),
+  };
+  const code = await main(['node', 'backups', ...args], streams);
+  return {
+    code,
+    stdout: streams.stdout.toString(),
+    stderr: streams.stderr.toString(),
+  };
+}
+
+function makeWorkspace(): string {
+  const workspace = makeTemporaryDirectory();
+  mkdirSync(join(workspace, 'data'));
+  writeFileSync(join(workspace, 'data', 'election.db'), 'sqlite');
+  return workspace;
+}
+
+const MANIFEST_CREATED_AT = '2026-08-18T12:00:00.000Z';
+
+function writeManifest(backupPath: string): void {
+  writeFileSync(
+    join(backupPath, 'manifest.json'),
+    JSON.stringify({
+      version: BACKUP_MANIFEST_VERSION,
+      softwareVersion: '4.0.0',
+      machineId: 'VX-00-001',
+      createdAt: MANIFEST_CREATED_AT,
+      election: {
+        id: 'election-1',
+        title: 'General Election',
+        date: '2026-11-03',
+      },
+      files: [{ path: 'data/election.db', hash: '0a'.repeat(32), size: 1024 }],
+    })
+  );
+}
+
+function makeBackup(): string {
+  const backup = makeTemporaryDirectory();
+  writeManifest(backup);
+  return backup;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+test('requires a command', async () => {
+  const { code, stderr } = await run([]);
+  expect(code).toEqual(1);
+  expect(stderr).toContain('A command is required');
+});
+
+test('rejects unknown commands', async () => {
+  const { code, stderr } = await run(['destroy']);
+  expect(code).toEqual(1);
+  expect(stderr).toContain('Unknown argument: destroy');
+});
+
+test('prints help without error', async () => {
+  const { code, stderr } = await run(['--help']);
+  expect(code).toEqual(0);
+  expect(stderr).toContain('Usage: backups <command> [options]');
+});
+
+test('create requires a target', async () => {
+  const { code, stderr } = await run([
+    'create',
+    '--workspace',
+    makeTemporaryDirectory(),
+  ]);
+  expect(code).toEqual(1);
+  expect(stderr).toContain('target');
+});
+
+test('create lists the workspace files', async () => {
+  const { code, stdout, stderr } = await run([
+    'create',
+    '--workspace',
+    makeWorkspace(),
+    '--target',
+    makeTemporaryDirectory(),
+  ]);
+  expect(code).toEqual(0);
+  expect(stderr).toContain('NOT IMPLEMENTED YET.');
+  expect(stdout).toContain('Here are the workspace files to be backed up:');
+  expect(stdout).toContain('data/');
+  expect(stdout).toContain('data/election.db');
+});
+
+test('create uses $ADMIN_WORKSPACE as the default workspace', async () => {
+  vi.stubEnv('ADMIN_WORKSPACE', makeWorkspace());
+  const { code, stdout } = await run([
+    'create',
+    '--target',
+    makeTemporaryDirectory(),
+  ]);
+  expect(code).toEqual(0);
+  expect(stdout).toContain('data/election.db');
+});
+
+test('create fails when the workspace cannot be read', async () => {
+  const { code, stderr } = await run([
+    'create',
+    '--workspace',
+    join(makeTemporaryDirectory(), 'does-not-exist'),
+    '--target',
+    makeTemporaryDirectory(),
+  ]);
+  expect(code).toEqual(1);
+  expect(stderr).toContain('!! Failed to read source entry: [no-entity]');
+});
+
+test('validate lists the backup files', async () => {
+  const { code, stdout, stderr } = await run(['validate', makeBackup()]);
+  expect(code).toEqual(0);
+  expect(stderr).toContain('NOT IMPLEMENTED YET.');
+  expect(stdout).toContain('Here are the backup files to be validated:');
+  expect(stdout).toContain('manifest.json');
+});
+
+test('validate fails when the backup cannot be read', async () => {
+  const { code, stderr } = await run([
+    'validate',
+    join(makeTemporaryDirectory(), 'does-not-exist'),
+  ]);
+  expect(code).toEqual(1);
+  expect(stderr).toContain('!! Failed to read source entry: [no-entity]');
+});
+
+test('list prints the backups on a backup drive', async () => {
+  const target = makeTemporaryDirectory();
+  const backupsPath = join(target, 'vxadmin-backups');
+  mkdirSync(join(backupsPath, 'backup-1'), { recursive: true });
+  mkdirSync(join(backupsPath, 'backup-2'), { recursive: true });
+  writeManifest(join(backupsPath, 'backup-1'));
+  writeManifest(join(backupsPath, 'backup-2'));
+
+  const { code, stdout, stderr } = await run(['list', target]);
+  expect(code).toEqual(0);
+  expect(stderr).toEqual('');
+  expect(stdout).toContain('● backup-1');
+  expect(stdout).toContain('● backup-2');
+  expect(stdout).toContain('Election  General Election · 2026-11-03');
+  expect(stdout).toContain(
+    `Created   ${format.localeShortDateAndTime(
+      new Date(MANIFEST_CREATED_AT)
+    )} · machine VX-00-001 · 4.0.0`
+  );
+  expect(stdout).toContain(`Files     1 (${format.bytes(1024)})`);
+  // no ANSI escapes (\u001b is ESC) when the output stream is not a TTY
+  expect(stdout).not.toContain('\u001b[');
+});
+
+test('list reports backups with unreadable manifests on stderr', async () => {
+  const target = makeTemporaryDirectory();
+  const backupsPath = join(target, 'vxadmin-backups');
+  mkdirSync(join(backupsPath, 'backup-1'), { recursive: true });
+  mkdirSync(join(backupsPath, 'no-manifest'), { recursive: true });
+  writeManifest(join(backupsPath, 'backup-1'));
+
+  const { code, stdout, stderr } = await run(['list', target]);
+  expect(code).toEqual(0);
+  expect(stdout).toContain('● backup-1');
+  expect(stdout).not.toContain('no-manifest');
+  expect(stderr).toContain(
+    `[Unreadable Manifest] ${join(
+      backupsPath,
+      'no-manifest',
+      'manifest.json'
+    )} is invalid:`
+  );
+});
+
+test('list reports no backups on an unused backup drive', async () => {
+  const { code, stdout } = await run(['list', makeTemporaryDirectory()]);
+  expect(code).toEqual(0);
+  expect(stdout).toContain('No backups found.');
+});
+
+test('list fails when the target does not exist', async () => {
+  const target = join(makeTemporaryDirectory(), 'does-not-exist');
+  const { code, stderr } = await run(['list', target]);
+  expect(code).toEqual(1);
+  expect(stderr).toContain(
+    `Error: unable to list backups: [root-not-found] ${target} does not exist`
+  );
+});
+
+test('restore prints the backup manifest', async () => {
+  const { code, stdout, stderr } = await run([
+    'restore',
+    '--workspace',
+    makeTemporaryDirectory(),
+    '--backup',
+    makeBackup(),
+  ]);
+  expect(code).toEqual(0);
+  expect(stderr).toContain('NOT IMPLEMENTED YET.');
+  expect(stdout).toContain('BackupManifest');
+  expect(stdout).toContain('VX-00-001');
+});
+
+test('restore fails when the manifest cannot be read', async () => {
+  const backup = makeTemporaryDirectory();
+  const { code, stderr } = await run([
+    'restore',
+    '--workspace',
+    makeTemporaryDirectory(),
+    '--backup',
+    backup,
+  ]);
+  expect(code).toEqual(1);
+  expect(stderr).toContain(
+    `Error: unable to read manifest at ${join(backup, 'manifest.json')}`
+  );
+});

--- a/apps/admin/backend/src/backup/cli/main.ts
+++ b/apps/admin/backend/src/backup/cli/main.ts
@@ -1,0 +1,277 @@
+import assert from 'node:assert';
+import { relative } from 'node:path';
+import { inspect } from 'node:util';
+import yargs from 'yargs';
+import { extractErrorMessage } from '@votingworks/basics';
+import { FileSystemEntryType, listDirectoryRecursive } from '@votingworks/fs';
+import { BackupRoot } from '../backup_root.js';
+import { StyledPrinter } from './styled_printer.js';
+import * as views from './views.js';
+import { Backup } from '../backup.js';
+
+/**
+ * IO streams given to the CLI.
+ */
+export interface Streams {
+  stdin: NodeJS.ReadableStream;
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+}
+
+interface BackupArguments {
+  _: Array<string | number>;
+  workspace?: string;
+  target?: string;
+  backup?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Entry point for the `backups` CLI.
+ */
+export async function main(
+  argv: readonly string[],
+  { stdin, stdout, stderr }: Streams
+): Promise<number> {
+  const parser = yargs()
+    .scriptName('backups')
+    .usage('Usage: $0 <command> [options]')
+    .command('create', 'Back up a workspace', (command) =>
+      command.options({
+        workspace: {
+          type: 'string',
+          description: 'VxAdmin workspace directory',
+          default: process.env['ADMIN_WORKSPACE'],
+          defaultDescription: '$ADMIN_WORKSPACE',
+          demandOption: true,
+          requiresArg: true,
+        },
+        target: {
+          type: 'string',
+          description: 'Backup drive mount point, e.g. /media/vx/backup',
+          demandOption: true,
+          requiresArg: true,
+        },
+      })
+    )
+    .command(
+      'validate <backup>',
+      'Check a backup against its signed manifest',
+      (command) =>
+        command.positional('backup', {
+          type: 'string',
+          description: 'Backup directory to check',
+        })
+    )
+    .command('list <target>', 'List the backups on a backup drive', (command) =>
+      command.positional('target', {
+        type: 'string',
+        description: 'Backup drive mount point, e.g. /media/vx/backup',
+      })
+    )
+    .command('restore', 'Restore a backup to a workspace', (command) =>
+      command.options({
+        workspace: {
+          type: 'string',
+          description: 'VxAdmin workspace directory',
+          default: process.env['ADMIN_WORKSPACE'],
+          defaultDescription: '$ADMIN_WORKSPACE',
+          demandOption: true,
+          requiresArg: true,
+        },
+        backup: {
+          type: 'string',
+          description: 'Backup directory to restore from',
+          demandOption: true,
+          requiresArg: true,
+        },
+      })
+    )
+    .demandCommand(1, 'A command is required')
+    .epilogue(
+      'Stop VxAdmin before running these commands: they use its workspace.'
+    )
+    .strict()
+    .exitProcess(false)
+    .version(false);
+
+  let parseError: Error | undefined;
+  let parserOutput = '';
+
+  const args = (await parser.parseAsync(
+    argv.slice(2),
+    (error: Error | undefined, _parsed: unknown, output: string) => {
+      parseError = error;
+      parserOutput = output;
+    }
+  )) as BackupArguments;
+
+  if (parseError || parserOutput) {
+    stderr.write(`${parserOutput}\n`);
+    return parseError ? 1 : 0;
+  }
+
+  switch (args._[0]) {
+    case 'create':
+      return await create(args, { stdin, stdout, stderr });
+    case 'validate':
+      return await validate(args, { stdin, stdout, stderr });
+    case 'list':
+      return await list(args, { stdin, stdout, stderr });
+    case 'restore':
+      return await restore(args, { stdin, stdout, stderr });
+    /* istanbul ignore next: `strict` rejects unknown commands */
+    default:
+      throw new Error(`Unknown command: ${args._[0]}`);
+  }
+}
+
+/**
+ * Create a backup using the CLI-provided arguments.
+ */
+async function create(
+  args: BackupArguments,
+  { stdout, stderr }: Streams
+): Promise<number> {
+  const { workspace, target } = args;
+  assert(typeof workspace === 'string');
+  assert(typeof target === 'string');
+
+  stderr.write('NOT IMPLEMENTED YET.\n');
+  stdout.write('Here are the workspace files to be backed up:\n');
+
+  const { errorCount } = await enumerateSourceFiles(workspace, {
+    stdout,
+    stderr,
+  });
+  return errorCount ? 1 : 0;
+}
+
+/**
+ * Validate a backup using the CLI-provided arguments.
+ */
+async function validate(
+  args: BackupArguments,
+  { stdout, stderr }: Streams
+): Promise<number> {
+  const { backup } = args;
+  assert(typeof backup === 'string');
+
+  stderr.write('NOT IMPLEMENTED YET.\n');
+  stdout.write('Here are the backup files to be validated:\n');
+
+  const { errorCount } = await enumerateSourceFiles(backup, { stdout, stderr });
+  return errorCount ? 1 : 0;
+}
+
+/**
+ * List backups at the CLI-given location.
+ */
+async function list(
+  args: BackupArguments,
+  { stdout, stderr }: Streams
+): Promise<number> {
+  const { target } = args;
+  assert(typeof target === 'string');
+
+  const root = new BackupRoot(target);
+  const listBackupsResult = await root.listBackups();
+  if (listBackupsResult.isErr()) {
+    stderr.write(
+      `Error: unable to list backups: [${listBackupsResult.err().type}] ${
+        listBackupsResult.err().message
+      }\n`
+    );
+    return 1;
+  }
+
+  const backups = listBackupsResult.ok();
+  if (backups.length === 0) {
+    stdout.write('No backups found.\n');
+  }
+
+  const printer = new StyledPrinter(stdout);
+  const errorPrinter = new StyledPrinter(stderr);
+  let printedBackup = false;
+
+  for (const backup of backups) {
+    const readManifestResult = await backup.manifestFile.readManifest();
+    if (readManifestResult.isErr()) {
+      views.unreadableManifest(errorPrinter, {
+        manifestPath: backup.manifestFile.path,
+        error: readManifestResult.err(),
+      });
+      continue;
+    }
+
+    if (printedBackup) {
+      printer.println();
+    }
+    printedBackup = true;
+
+    views.backupInfo(printer, {
+      path: backup.path,
+      manifest: readManifestResult.ok(),
+    });
+  }
+
+  return 0;
+}
+/**
+ * Restores a backup using the CLI-given locations.
+ */
+async function restore(
+  args: BackupArguments,
+  { stdout, stderr }: Streams
+): Promise<number> {
+  assert(typeof args.workspace === 'string');
+  assert(typeof args.backup === 'string');
+
+  stderr.write('NOT IMPLEMENTED YET.\n');
+
+  const backup = new Backup(args.backup);
+  const readManifestResult = await backup.manifestFile.readManifest();
+
+  if (readManifestResult.isErr()) {
+    stderr.write(
+      `Error: unable to read manifest at ${
+        backup.manifestFile.path
+      }: ${extractErrorMessage(readManifestResult.err())}`
+    );
+    return 1;
+  }
+
+  const manifest = readManifestResult.ok();
+  stdout.write(inspect(manifest));
+  stdout.write('\n');
+
+  return await Promise.resolve(0);
+}
+
+async function enumerateSourceFiles(
+  source: string,
+  { stdout, stderr }: Pick<Streams, 'stdout' | 'stderr'>
+): Promise<{ errorCount: number }> {
+  let errorCount = 0;
+
+  for await (const result of listDirectoryRecursive(source)) {
+    if (result.isErr()) {
+      stderr.write(
+        `!! Failed to read source entry: [${result.err().type}] ${
+          result.err().message
+        }`
+      );
+      errorCount += 1;
+      continue;
+    }
+
+    const entry = result.ok();
+    stdout.write(
+      `${relative(source, entry.path)}${
+        entry.type === FileSystemEntryType.Directory ? '/' : ''
+      }\n`
+    );
+  }
+
+  return { errorCount };
+}

--- a/apps/admin/backend/src/backup/cli/styled_printer.test.ts
+++ b/apps/admin/backend/src/backup/cli/styled_printer.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { mockWritable } from '@votingworks/test-utils';
+import { StyledPrinter } from './styled_printer.js';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+test('println writes the joined parts and a newline', () => {
+  const stream = mockWritable();
+  const printer = new StyledPrinter(stream);
+  printer.println('a', 'b', 'c');
+  printer.println();
+  expect(stream.toString()).toEqual('abc\n\n');
+});
+
+test('style returns plain text when the stream is not a TTY', () => {
+  const printer = new StyledPrinter(mockWritable());
+  expect(printer.style('cyan', 'text')).toEqual('text');
+  expect(printer.style(['bold', 'cyan'], 'text')).toEqual('text');
+});
+
+test('style applies ANSI codes when FORCE_COLOR is set', () => {
+  vi.stubEnv('FORCE_COLOR', '1');
+  const printer = new StyledPrinter(mockWritable());
+  expect(printer.style('cyan', 'text')).toEqual(
+    // \u001b is ESC; [36m and [39m set and reset the cyan foreground
+    '\u001b[36mtext\u001b[39m'
+  );
+});
+
+test('style applies every format in an array', () => {
+  vi.stubEnv('FORCE_COLOR', '1');
+  const printer = new StyledPrinter(mockWritable());
+  expect(printer.style(['bold', 'cyan'], 'text')).toEqual(
+    // \u001b is ESC; [1m/[22m toggle bold, [36m/[39m toggle cyan
+    '\u001b[1m\u001b[36mtext\u001b[39m\u001b[22m'
+  );
+});

--- a/apps/admin/backend/src/backup/cli/styled_printer.ts
+++ b/apps/admin/backend/src/backup/cli/styled_printer.ts
@@ -1,0 +1,34 @@
+import { styleText } from 'node:util';
+
+/**
+ * A single text style understood by `util.styleText`, e.g. 'bold' or 'cyan'.
+ */
+export type TextStyle = Extract<Parameters<typeof styleText>[0], string>;
+
+/**
+ * Prints styled text to a stream. Styles are only applied when the stream is
+ * a color-capable TTY (or FORCE_COLOR is set), so piped output and tests see
+ * plain text.
+ */
+export class StyledPrinter {
+  constructor(private readonly stream: NodeJS.WritableStream) {}
+
+  /**
+   * Styles `text` for this printer's stream. Formats are applied one at a
+   * time because Node 20's `styleText` skips stream validation for array
+   * formats.
+   */
+  style(formatting: TextStyle | TextStyle[], text: string): string {
+    return (Array.isArray(formatting) ? formatting : [formatting]).reduceRight(
+      (styled, item) => styleText(item, styled, { stream: this.stream }),
+      text
+    );
+  }
+
+  /**
+   * Writes `parts` to the stream followed by a newline.
+   */
+  println(...parts: string[]): void {
+    this.stream.write(`${parts.join('')}\n`);
+  }
+}

--- a/apps/admin/backend/src/backup/cli/views.test.ts
+++ b/apps/admin/backend/src/backup/cli/views.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from 'vitest';
+import { mockWritable } from '@votingworks/test-utils';
+import { unsafeParse } from '@votingworks/types';
+import { format } from '@votingworks/utils';
+import {
+  BACKUP_MANIFEST_VERSION,
+  BackupManifest,
+  BackupManifestStructSchema,
+} from '../backup_manifest.js';
+import { StyledPrinter } from './styled_printer.js';
+import { backupInfo, unreadableManifest } from './views.js';
+
+const CREATED_AT = '2026-08-18T12:00:00.000Z';
+
+const manifest = BackupManifest.fromStruct(
+  unsafeParse(BackupManifestStructSchema, {
+    version: BACKUP_MANIFEST_VERSION,
+    softwareVersion: '4.0.0',
+    machineId: 'VX-00-001',
+    createdAt: CREATED_AT,
+    election: {
+      id: 'election-1',
+      title: 'General Election',
+      date: '2026-11-03',
+    },
+    files: [
+      { path: 'data/election.db', hash: '0a'.repeat(32), size: 1024 },
+      { path: 'logs/vx-logs.log', hash: '1b'.repeat(32), size: 512 },
+    ],
+  })
+);
+
+test('backupInfo renders a tree-style backup summary', () => {
+  const stream = mockWritable();
+  backupInfo(new StyledPrinter(stream), {
+    path: '/media/vx/backup/vxadmin-backups/backup-1',
+    manifest,
+  });
+
+  expect(stream.toString()).toEqual(
+    `● backup-1\n` +
+      `│  Election  General Election · 2026-11-03\n` +
+      `│  Created   ${format.localeShortDateAndTime(
+        new Date(CREATED_AT)
+      )} · machine VX-00-001 · 4.0.0\n` +
+      `╰─ Files     2 (${format.bytes(1536)})\n`
+  );
+});
+
+test('unreadableManifest renders the path and error message', () => {
+  const stream = mockWritable();
+  unreadableManifest(new StyledPrinter(stream), {
+    manifestPath: '/backup/manifest.json',
+    error: new Error('boom'),
+  });
+
+  expect(stream.toString()).toEqual(
+    '[Unreadable Manifest] /backup/manifest.json is invalid: boom\n'
+  );
+});

--- a/apps/admin/backend/src/backup/cli/views.ts
+++ b/apps/admin/backend/src/backup/cli/views.ts
@@ -1,0 +1,69 @@
+import { basename } from 'node:path';
+import { extractErrorMessage, iter } from '@votingworks/basics';
+import { format } from '@votingworks/utils';
+import { BackupManifest } from '../backup_manifest.js';
+import { StyledPrinter } from './styled_printer.js';
+
+const LABEL_WIDTH = 8;
+
+function label(printer: StyledPrinter, text: string): string {
+  return printer.style('dim', text.padEnd(LABEL_WIDTH));
+}
+
+/**
+ * Renders a tree-style summary of a backup:
+ *
+ *   ● franklin-county_general-election_e13505110f
+ *   │  Election  General Election · 2020-11-03
+ *   │  Created   10/30/2020, 6:12 AM · machine 0000 · dev
+ *   ╰─ Files     2,004 (297.3 MB)
+ */
+export function backupInfo(
+  printer: StyledPrinter,
+  { path, manifest }: { path: string; manifest: BackupManifest }
+): void {
+  printer.println(printer.style(['bold', 'cyan'], `● ${basename(path)}`));
+  printer.println(
+    printer.style('dim', '│'),
+    '  ',
+    label(printer, 'Election'),
+    '  ',
+    `${manifest.election.title} · ${manifest.election.date.toISOString()}`
+  );
+  printer.println(
+    printer.style('dim', '│'),
+    '  ',
+    label(printer, 'Created'),
+    '  ',
+    format.localeShortDateAndTime(new Date(manifest.createdAt)),
+    ' · ',
+    printer.style('dim', 'machine'),
+    ` ${manifest.machineId} · `,
+    printer.style('dim', manifest.softwareVersion)
+  );
+  printer.println(
+    printer.style('dim', '╰─'),
+    ' ',
+    label(printer, 'Files'),
+    '  ',
+    format.count(manifest.files.length),
+    ` (${format.bytes(iter(manifest.files).sum(({ size }) => size))})`
+  );
+}
+
+/**
+ * Renders a warning for a backup whose manifest could not be read.
+ */
+export function unreadableManifest(
+  printer: StyledPrinter,
+  { manifestPath, error }: { manifestPath: string; error: unknown }
+): void {
+  printer.println(
+    printer.style(
+      'red',
+      `[Unreadable Manifest] ${manifestPath} is invalid: ${extractErrorMessage(
+        error
+      )}`
+    )
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
       tmp:
         specifier: ^0.2.6
         version: 0.2.7
+      yargs:
+        specifier: 17.7.1
+        version: 17.7.1
       zip-stream:
         specifier: ^4.1.0
         version: 4.1.0
@@ -264,6 +267,9 @@ importers:
       '@types/tmp':
         specifier: 0.2.4
         version: 0.2.4
+      '@types/yargs':
+        specifier: 17.0.22
+        version: 17.0.22
       '@types/zip-stream':
         specifier: workspace:*
         version: link:../../../libs/@types/zip-stream


### PR DESCRIPTION
## Overview

Refs #7897

Adds a placeholder `backups` CLI to the VxAdmin backend with four subcommands: `create`, `validate`, `list`, and `restore`. Only `list` works as it likely will in the final version; the rest are placeholders.

This CLI may or may not ship. It may prove useful as a development tool and stick around, or it may be removed once the real backup/restore functionality lands. For now it's a way to more easily validate the core backup and restore functionality.

## Demo Video or Screenshot

```
$ ./bin/backups --help
Usage: backups <command> [options]

Commands:
  backups create             Back up a workspace
  backups validate <backup>  Check a backup against its signed manifest
  backups list <target>      List the backups on a backup drive
  backups restore            Restore a backup to a workspace

Options:
  --help  Show help                                                    [boolean]

Stop VxAdmin before running these commands: they use its workspace.
```

`list` output:

```
$ ./bin/backups list /tmp/vxadmin-demo-drive-bpzS
● franklin-county_general-election_e13505110f
│  Election  General Election · 2020-11-03
│  Created   8/13/2026, 4:28 PM · machine 0000 · dev
╰─ Files     2,004 (297.3 MB)
```

## Testing Plan

- Unit tests for the CLI, manifest schema, and backup listing
- Ran `list` manually against a demo backup drive (output above)

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions. _(none yet)_
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
