### PR TITLE
feat(printing): support HP Color LaserJet Pro 4201dn

### DIFF
--- a/libs/printing/supported_printers/configs.json
+++ b/libs/printing/supported_printers/configs.json
@@ -24,6 +24,14 @@
     "supportsIpp": true
   },
   {
+    "label": "HP Color LaserJet Pro 4201dn",
+    "vendorId": 1008,
+    "productId": 3698,
+    "baseDeviceUri": "usb://HP/Color%20LaserJet%20Pro%204201",
+    "ppd": "generic-postscript-driver.ppd",
+    "supportsIpp": true
+  },
+  {
     "label": "Citizen CT-E351",
     "vendorId": 7568,
     "productId": 8432,


### PR DESCRIPTION
## Overview

Closes part of #9060.

Adds the HP Color LaserJet Pro 4201dn to the supported printer configs. It needs no new PPD and no code changes — the existing generic PostScript PPD drives it.

Note: duplex on this printer is broken at every paper size except letter. The underlying defect is in Ghostscript's PDF-to-PostScript output and applies to all our laser printers, but only the 4201 exhibits it — the others tolerate it. It is fixed in the stacked PR on top of this one. **This printer should not be used for two-sided ballots until that lands.**

## Demo Video or Screenshot

n/a — config only.

## Testing Plan

Verified on hardware (4201dw, 8.5x17 and 8.5x22 stock):

- Detected and auto-configured from the USB URI
- Full-page 17" and 22" output, correct page size
- No tray confirmation prompt (unlike the M404n)
- No clipping — ballot margins (12pt) match the printer's reported `HWMargins` (11.99pt)

`libs/printing` unit tests pass.

**Known gap:** the recorded product ID (3698) was read from a 4201**dw**, which shares it. Detection matches on the URI prefix, so discovery works either way — but the USB attachment check in `printer.ts` compares product IDs, and the **dn**'s value still needs confirming against field hardware.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
