### PR TITLE
fix(printing): render PDFs with poppler on the 4201 so duplex works

### DIFF
--- a/libs/printing/src/printer/printer.test.ts
+++ b/libs/printing/src/printer/printer.test.ts
@@ -9,7 +9,11 @@ import {
 import { PrinterRichStatus } from '@votingworks/types';
 import { isDeviceAttached } from '@votingworks/backend';
 import { detectPrinter } from './printer';
-import { CITIZEN_THERMAL_PRINTER_CONFIG, HP_LASER_PRINTER_CONFIG } from '.';
+import {
+  CITIZEN_THERMAL_PRINTER_CONFIG,
+  HP_4201_PRINTER_CONFIG,
+  HP_LASER_PRINTER_CONFIG,
+} from '.';
 import { MockFilePrinter } from './mocks/file_printer';
 
 const featureFlagMock = getFeatureFlagMock();
@@ -58,7 +62,7 @@ vi.mock(
   import('./print.js'),
   async (importActual): Promise<typeof import('./print')> => ({
     ...(await importActual()),
-    print: () => mockPrintData(),
+    print: (props) => mockPrintData(props),
   })
 );
 
@@ -118,7 +122,9 @@ test('status and configuration', async () => {
     }
   );
 
-  mockPrintData.expectCallWith().returns(undefined);
+  mockPrintData
+    .expectCallWith({ data: Buffer.of(), raw: {} })
+    .returns(undefined);
   await printer.print({ data: Buffer.of() });
 
   // supported printer does not configure again
@@ -213,6 +219,74 @@ describe('rich status', () => {
       connected: true,
       config,
       richStatus,
+    });
+  });
+});
+
+describe('pdftops renderer', () => {
+  test('passes the renderer option for printers that need it', async () => {
+    const printer = detectPrinter(mockBaseLogger({ fn: vi.fn }));
+
+    const uri = `${HP_4201_PRINTER_CONFIG.baseDeviceUri}?serial=1234`;
+    const config = HP_4201_PRINTER_CONFIG;
+    mockGetConnectedDeviceUris.expectCallWith().returns([uri]);
+    mockConfigurePrinter.expectCallWith({ uri, config }).returns(undefined);
+    mockGetPrinterRichStatus.expectCallWith().returns(undefined);
+    await printer.status();
+
+    mockPrintData
+      .expectCallWith({
+        data: Buffer.of(),
+        raw: { 'pdftops-renderer': 'pdftops' },
+      })
+      .returns(undefined);
+    await printer.print({ data: Buffer.of() });
+  });
+
+  test('does not pass the renderer option for other printers', async () => {
+    const printer = detectPrinter(mockBaseLogger({ fn: vi.fn }));
+
+    const uri = `${HP_LASER_PRINTER_CONFIG.baseDeviceUri}?serial=1234`;
+    const config = HP_LASER_PRINTER_CONFIG;
+    mockGetConnectedDeviceUris.expectCallWith().returns([uri]);
+    mockConfigurePrinter.expectCallWith({ uri, config }).returns(undefined);
+    mockGetPrinterRichStatus.expectCallWith().returns(undefined);
+    await printer.status();
+
+    mockPrintData
+      .expectCallWith({ data: Buffer.of(), raw: {} })
+      .returns(undefined);
+    await printer.print({ data: Buffer.of() });
+  });
+
+  test('passes no renderer options when no printer is configured', async () => {
+    const printer = detectPrinter(mockBaseLogger({ fn: vi.fn }));
+
+    mockPrintData
+      .expectCallWith({ data: Buffer.of(), raw: {} })
+      .returns(undefined);
+    await printer.print({ data: Buffer.of() });
+  });
+
+  test('caller-supplied raw options take precedence', async () => {
+    const printer = detectPrinter(mockBaseLogger({ fn: vi.fn }));
+
+    const uri = `${HP_4201_PRINTER_CONFIG.baseDeviceUri}?serial=1234`;
+    const config = HP_4201_PRINTER_CONFIG;
+    mockGetConnectedDeviceUris.expectCallWith().returns([uri]);
+    mockConfigurePrinter.expectCallWith({ uri, config }).returns(undefined);
+    mockGetPrinterRichStatus.expectCallWith().returns(undefined);
+    await printer.status();
+
+    mockPrintData
+      .expectCallWith({
+        data: Buffer.of(),
+        raw: { 'pdftops-renderer': 'gs' },
+      })
+      .returns(undefined);
+    await printer.print({
+      data: Buffer.of(),
+      raw: { 'pdftops-renderer': 'gs' },
     });
   });
 });

--- a/libs/printing/src/printer/printer.ts
+++ b/libs/printing/src/printer/printer.ts
@@ -10,7 +10,7 @@ import { getConnectedDeviceUris } from './device_uri';
 import { configurePrinter } from './configure';
 import { Printer } from './types';
 import { print as printData } from './print';
-import { getPrinterConfig } from './supported';
+import { getPdfRendererOptions, getPrinterConfig } from './supported';
 import { MockFilePrinter } from './mocks/file_printer';
 import { CUPS_DEFAULT_IPP_URI, getPrinterRichStatus } from './status';
 
@@ -101,9 +101,14 @@ export function detectPrinter(logger: BaseLogger): Printer {
       };
     },
 
-    print: async (props) => {
+    print: async ({ raw = {}, ...props }) => {
       printerDevice.lastPrint = Date.now();
-      return printData(props);
+      const rendererOptions = printerDevice.uri
+        ? getPdfRendererOptions(
+            assertDefined(getPrinterConfig(printerDevice.uri))
+          )
+        : {};
+      return printData({ ...props, raw: { ...rendererOptions, ...raw } });
     },
   };
 }

--- a/libs/printing/src/printer/supported.ts
+++ b/libs/printing/src/printer/supported.ts
@@ -11,6 +11,7 @@ export const PrinterConfigSchema: z.ZodSchema<PrinterConfig> = z.object({
   baseDeviceUri: z.string(),
   ppd: z.string(),
   supportsIpp: z.boolean(),
+  pdfRenderer: z.optional(z.enum(['gs', 'pdftops'])),
 });
 
 const RELATIVE_PATH_TO_SUPPORTED_PRINTERS = '../../supported_printers';
@@ -52,6 +53,22 @@ export const M404N_PRINTER_CONFIG = find(
   SUPPORTED_PRINTER_CONFIGS,
   (config) => config.label === 'HP LaserJet Pro M404n'
 );
+
+export const HP_4201_PRINTER_CONFIG = find(
+  SUPPORTED_PRINTER_CONFIGS,
+  (config) => config.label === 'HP Color LaserJet Pro 4201dn'
+);
+
+/**
+ * Builds the `lpr` options that select a printer's PDF-to-PostScript renderer.
+ * Empty when the config does not pin one, leaving the CUPS default in place.
+ * See {@link PrinterConfig.pdfRenderer} for why a printer might pin it.
+ */
+export function getPdfRendererOptions(config: PrinterConfig): {
+  [key: string]: string;
+} {
+  return config.pdfRenderer ? { 'pdftops-renderer': config.pdfRenderer } : {};
+}
 
 /**
  * See {@link deriveM404nPpd} for more details.

--- a/libs/printing/supported_printers/configs.json
+++ b/libs/printing/supported_printers/configs.json
@@ -29,7 +29,8 @@
     "productId": 3698,
     "baseDeviceUri": "usb://HP/Color%20LaserJet%20Pro%204201",
     "ppd": "generic-postscript-driver.ppd",
-    "supportsIpp": true
+    "supportsIpp": true,
+    "pdfRenderer": "pdftops"
   },
   {
     "label": "Citizen CT-E351",

--- a/libs/types/src/ipp_printing.ts
+++ b/libs/types/src/ipp_printing.ts
@@ -1,3 +1,9 @@
+/**
+ * A PDF-to-PostScript renderer supported by the CUPS `pdftops` filter, selected
+ * via its `pdftops-renderer` option. See {@link PrinterConfig.pdfRenderer}.
+ */
+export type PdfRenderer = 'gs' | 'pdftops';
+
 export interface PrinterConfig {
   label: string;
   vendorId: number;
@@ -10,6 +16,29 @@ export interface PrinterConfig {
    * its status beyond just whether it's connected or not.
    */
   supportsIpp: boolean;
+  /**
+   * Which renderer CUPS should use to convert PDFs to PostScript for this
+   * printer. Omit to use the CUPS default, Ghostscript.
+   *
+   * Ghostscript's `ps2write` re-asserts the page device on every page for any
+   * paper size other than its built-in default of letter. A mid-job
+   * `setpagedevice` ends the current sheet, which breaks duplex sheet pairing:
+   * the duplexer engages and the sheet takes the duplex path, but each page
+   * lands on a fresh sheet front and the backs come out blank. The job silently
+   * comes out single-sided, with no error from CUPS. Poppler's `pdftops` only
+   * calls `setpagedevice` when the page size actually changes, so the pairing
+   * holds.
+   *
+   * Every paper size is affected except letter, which is Ghostscript's own
+   * built-in default. This is independent of the PPD: pinning a different
+   * `*DefaultPageSize` does not change which size is exempt.
+   *
+   * Ending the sheet on a redundant `setpagedevice` is permitted by the
+   * PostScript spec, so printers that need `pdftops` are stricter rather than
+   * broken; the others ignore the redundant assertion and duplex correctly on
+   * the default renderer.
+   */
+  pdfRenderer?: PdfRenderer;
 }
 
 export type PrinterStatus =


### PR DESCRIPTION
## Overview

Closes #9060. **Stacked on #9174 — review/merge that first.**

Duplex jobs on the 4201 silently print single-sided on any paper size other than letter. The duplexer engages and the sheet takes the duplex path, but every page lands on a fresh sheet front and the backs come out blank. Nothing surfaces an error: CUPS reports success, and VxPrint increments its ballot count for ballots that printed wrong.

### Cause

CUPS converts our PDFs to PostScript with Ghostscript's `ps2write`, which re-asserts the page device on **every page** for any size other than its built-in default of letter. A mid-job `setpagedevice` ends the current sheet, which breaks duplex sheet pairing. Traced by shadowing the operator:

| stream (4-page ballot) | `setpagedevice` calls |
| --- | --- |
| Ghostscript, letter | 1 (duplex only) |
| Ghostscript, legal / 17" / 22" | 1 + **one per page** |
| poppler, any size | 1 + **one total** |

Poppler's `pdftops` guards against this explicitly — its prologue comments that it changes paper size only when it differs, "otherwise duplex fails."

The trigger is the page size, not the paper length: **legal reproduces it**. Passing real dimensions to Ghostscript (`-dDEVICEWIDTHPOINTS`/`-dFIXEDMEDIA`) does not suppress it, cups-filters offers no way to pass Ghostscript arguments, and there is no PPD keyword for renderer selection — so this option is the only available lever. cups-filters ships an analogous built-in workaround forcing poppler for Brother and Minolta printers.

### Scoped to the 4201, via config

The renderer is an optional `pdfRenderer` field on `PrinterConfig`, set to `pdftops` for the 4201 in `configs.json`. It sits alongside `ppd` as part of how a printer is driven; printers that omit it keep the CUPS default.


Ending the sheet on a redundant `setpagedevice` is permitted by the PostScript spec, so the 4201 is stricter rather than broken; the M404n, M454 and 4001n ignore the assertion and duplex correctly today. Applying the renderer change to every printer would alter output for models already in the field whose firmware variations we can't all test, so it is scoped to the model known to need it.

## Demo Video or Screenshot

Not attached — the observable result is sheet count.

## Testing Plan

On an HP Color LaserJet Pro 4201, at legal, 8.5x17 and 8.5x22, each against a control on the same paper and one job at a time:

| size | Ghostscript (control) | poppler (fix) |
| --- | --- | --- |
| legal, 4pp | 4 sheets, backs blank | **2 sheets, duplexed** |
| 8.5x17, 4pp | 4 sheets, backs blank | **2 sheets, duplexed** |
| 8.5x22, 2pp | 2 sheets, backs blank | **1 sheet, duplexed** |

### Renderer output comparison

Compared across all ballot sizes (blank and marked, every page), in case the scoping is ever widened:

- **Timing-mark geometry identical** — every mark's start position and length, on both mark rows and both mark columns. This is what `ballot-interpreter` keys on.
- Page count and page size identical.
- Ink coverage differs by **0.5% at 600dpi** (15% at 100dpi — the apparent difference is a low-resolution artefact). Prints are visually indistinguishable.
- Poppler is arguably more faithful: it preserves the source Roboto TrueType outlines as Type42, where Ghostscript re-authors several faces as Type3 glyph procedures.

Drew - because Poppler is "arguably more faithful" we considered switching everything to Poppler. But that seemed like some risk on other models without any gain. We don't have any problem with the PDF-to-Postscript part of the pipeline. I compared prints via Poppler and Ghostscript, and had Nikhil look at them too - we can genuinely not tell any difference at all. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
