### PR TITLE
VxDesign: compare branch migrations against the merge-base, not main's tip

### DIFF
--- a/apps/design/backend/scripts/ci-validate-migrations.sh
+++ b/apps/design/backend/scripts/ci-validate-migrations.sh
@@ -14,19 +14,35 @@ cd "$REPO_ROOT" >/dev/null 2>&1
 MODE="${1:-auto}"
 
 validate_commits_vs_origin_main() {
-  # Fetch origin/main if needed
+  # Fetch origin/main if needed. Dev and CI clones both carry full history, so
+  # the merge-base is reachable. The checks below read only commits and trees,
+  # so under CI's blobless clone this stays blobless.
   git rev-parse --verify --quiet origin/main >/dev/null \
-    || git fetch --no-tags --depth=1 origin main:refs/remotes/origin/main
+    || git fetch --no-tags origin main:refs/remotes/origin/main
 
+  merge_base="$(git merge-base origin/main HEAD)" || {
+    echo "No common ancestor between origin/main and HEAD." >&2
+    echo "This check requires a clone with full history." >&2
+    exit 1
+  }
+
+  merge_base_tempfile="$(mktemp)"
   origin_main_tempfile="$(mktemp)"
   head_tempfile="$(mktemp)"
-  trap 'rm -f "$origin_main_tempfile" "$head_tempfile"' EXIT # Clean tempfiles on exit
+  # Clean tempfiles on exit
+  trap 'rm -f "$merge_base_tempfile" "$origin_main_tempfile" "$head_tempfile"' EXIT
 
-  # Compare migrations on origin/main vs HEAD
-  git ls-tree -r --name-only origin/main -- "$MIGRATION_DIR" | grep -E '\.js$' | sort -u >"$origin_main_tempfile" || true
-  git ls-tree -r --name-only HEAD        -- "$MIGRATION_DIR" | grep -E '\.js$' | sort -u >"$head_tempfile" || true
-  missing_migrations="$(comm -23 "$origin_main_tempfile" "$head_tempfile" || true)"
-  added_migrations="$(comm -13 "$origin_main_tempfile" "$head_tempfile" || true)"
+  list_migrations() { # <commit> <outfile>
+    git ls-tree -r --name-only "$1" -- "$MIGRATION_DIR" | grep -E '\.js$' | sort -u >"$2" || true
+  }
+  list_migrations "$merge_base" "$merge_base_tempfile"
+  list_migrations origin/main "$origin_main_tempfile"
+  list_migrations HEAD "$head_tempfile"
+
+  # What this branch itself added or deleted, measured from where it forked off
+  # main: migrations that landed on main after the fork point are not its doing.
+  missing_migrations="$(comm -23 "$merge_base_tempfile" "$head_tempfile" || true)"
+  added_migrations="$(comm -13 "$merge_base_tempfile" "$head_tempfile" || true)"
 
   # Check: migrations from main must not be deleted
   if [[ -n "$missing_migrations" ]]; then

--- a/apps/design/backend/scripts/ci-validate-migrations.sh
+++ b/apps/design/backend/scripts/ci-validate-migrations.sh
@@ -14,11 +14,9 @@ cd "$REPO_ROOT" >/dev/null 2>&1
 MODE="${1:-auto}"
 
 validate_commits_vs_origin_main() {
-  # Fetch origin/main if needed. Dev and CI clones both carry full history, so
-  # the merge-base is reachable. The checks below read only commits and trees,
-  # so under CI's blobless clone this stays blobless.
-  git rev-parse --verify --quiet origin/main >/dev/null \
-    || git fetch --no-tags origin main:refs/remotes/origin/main
+  # Fetch origin/main if needed
+  git rev-parse --verify --quiet origin/main >/dev/null ||
+    git fetch --no-tags origin main:refs/remotes/origin/main
 
   merge_base="$(git merge-base origin/main HEAD)" || {
     echo "No common ancestor between origin/main and HEAD." >&2
@@ -39,8 +37,8 @@ validate_commits_vs_origin_main() {
   list_migrations origin/main "$origin_main_tempfile"
   list_migrations HEAD "$head_tempfile"
 
-  # What this branch itself added or deleted, measured from where it forked off
-  # main: migrations that landed on main after the fork point are not its doing.
+  # Diff against the rev where this branch split from main (the merge base).
+  # Migrations on main from after that split must not count as deletions.
   missing_migrations="$(comm -23 "$merge_base_tempfile" "$head_tempfile" || true)"
   added_migrations="$(comm -13 "$merge_base_tempfile" "$head_tempfile" || true)"
 
@@ -69,8 +67,8 @@ validate_commits_vs_origin_main() {
 
 validate_head_vs_prev_commit() {
   # Ensure we have the previous commit
-  git rev-parse --verify --quiet HEAD~1 >/dev/null \
-    || git fetch --no-tags --depth=2 origin main:refs/remotes/origin/main
+  git rev-parse --verify --quiet HEAD~1 >/dev/null ||
+    git fetch --no-tags --depth=2 origin main:refs/remotes/origin/main
 
   # Check: migrations from previous commit must not be deleted or renamed
   # Use directory path (not glob) since deleted/renamed files don't exist on disk
@@ -85,8 +83,9 @@ validate_head_vs_prev_commit() {
   added_migrations="$(git diff --diff-filter=A --name-only HEAD~1..HEAD -- "$MIGRATION_DIR" | grep -E '\.js$' || true)"
   [[ -z "$added_migrations" ]] && exit 0
 
-  prev_newest_migration="$(git ls-tree -r --name-only HEAD~1 -- "$MIGRATION_DIR" \
-      | grep -E '\.js$' | sort | tail -n1 || true
+  prev_newest_migration="$(
+    git ls-tree -r --name-only HEAD~1 -- "$MIGRATION_DIR" |
+      grep -E '\.js$' | sort | tail -n1 || true
   )"
 
   # Ensure all added migrations are timestamped after previous newest migration
@@ -102,18 +101,19 @@ validate_head_vs_prev_commit() {
 }
 
 case "$MODE" in
-  vs-origin-main) validate_commits_vs_origin_main ;;
-  on-origin-main) validate_head_vs_prev_commit ;;
-  auto)
-    # Auto-detect if current branch is main and choose appropriate validation
-    current_branch="$(git rev-parse --abbrev-ref HEAD)"
-    case "$current_branch" in
-      main) validate_head_vs_prev_commit ;;
-      *)    validate_commits_vs_origin_main ;;
-    esac
-    ;;
-  *)
-    echo "Usage: $0 [vs-origin-main|on-origin-main]" >&2
-    exit 2
-    ;;
+vs-origin-main) validate_commits_vs_origin_main ;;
+on-origin-main) validate_head_vs_prev_commit ;;
+auto)
+  # Auto-detect if current branch is main and choose appropriate validation
+  current_branch="$(git rev-parse --abbrev-ref HEAD)"
+  case "$current_branch" in
+  main) validate_head_vs_prev_commit ;;
+  *) validate_commits_vs_origin_main ;;
+  esac
+  ;;
+*)
+  echo "Usage: $0 [vs-origin-main|on-origin-main]" >&2
+  exit 2
+  ;;
 esac
+


### PR DESCRIPTION
`ci-validate-migrations.sh` compared the migrations on the tip of `origin/main` against `HEAD` and called anything missing a deletion. But "on main's tip, not on my branch" also describes a branch that simply forked before that migration landed, so any branch older than the newest migration failed `test-apps-design-backend` no matter what it touched. That's what #9108 (Rust-only, in `libs/pdi-scanner`) hit.

This baselines the branch's own additions and deletions on `git merge-base origin/main HEAD`, so genuine deletions still fail and a stale fork point doesn't. The timestamp-ordering check still compares against main's tip, where that's the real invariant.

## Testing

- **Verified in CI that a real deletion still fails.** I temporarily pushed a commit deleting `1787007046000_add-candidate-designation.js` — the same migration whose arrival caused the false positive on #9108 — and `test-apps-design-backend` failed as it should: [job 1337671](https://circleci.com/gh/votingworks/vxsuite/1337671), on the since-removed commit `6bb369cbba`.

  ```
  Branch deletes migration(s) from main:
  apps/design/backend/migrations/1787007046000_add-candidate-designation.js
  Migrations must not be deleted once merged to main.
  ```

  The commit before it (`76448492b9`, the current tip) was green on all 63 checks, so the failure is attributable to the deletion alone.
- Exercised the old and new scripts against synthetic histories: stale fork point touching no migrations, deleting a fork-point migration (with and without a stale base), adding a migration older than main's newest, and adding the newest migration. New script gets all five right; the old one fails all five once main advances, and misreports cases 4 and 5 as deletions.
- Checked the removal of `--depth=1` is not a blob-fetching regression: a partial clone reuses its object filter for later fetches, and the checks read only commits and trees. Verified the script completes with `GIT_NO_LAZY_FETCH=1` and the remote unreachable.
- `shellcheck` clean.