### PR TITLE
fix(db): require strict tables and fkey type agreement

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -1,59 +1,59 @@
 create table elections (
-  id serial primary key,
+  id text primary key,
   election_data text not null,
   system_settings_data text not null,
   election_package_hash text not null,
-  is_official_results boolean not null default false,
-  created_at timestamp not null default current_timestamp
-);
+  is_official_results integer not null default false,
+  created_at text not null default current_timestamp
+) strict;
 
 create table precincts(
-  election_id integer not null,
+  election_id text not null,
   id text not null,
   name text not null,
   primary key (election_id, id),
   foreign key (election_id) references elections(id)
     on delete cascade
-);
+) strict;
 
 create table precinct_registered_voter_counts (
-  election_id integer not null,
+  election_id text not null,
   precinct_id text not null,
   count integer not null,
   primary key (election_id, precinct_id),
   foreign key (election_id, precinct_id) references precincts(election_id, id)
     on delete cascade
-);
+) strict;
 
 create table precinct_split_registered_voter_counts (
-  election_id integer not null,
+  election_id text not null,
   precinct_id text not null,
   split_id text not null,
   count integer not null,
   primary key (election_id, precinct_id, split_id),
   foreign key (election_id, precinct_id) references precincts(election_id, id)
     on delete cascade
-);
+) strict;
 
 create table ballot_styles (
-  election_id integer not null,
+  election_id text not null,
   group_id text not null,
   party_id text,
   primary key (election_id, group_id),
   foreign key (election_id) references elections(id)
     on delete cascade
-);
+) strict;
 
 create table ballot_styles_to_precincts(
-  election_id integer not null,
+  election_id text not null,
   ballot_style_group_id text not null,
   precinct_id text not null,
   primary key (election_id, ballot_style_group_id, precinct_id),
   foreign key (election_id, ballot_style_group_id) references ballot_styles(election_id, group_id)
-    on delete cascade
+    on delete cascade,
   foreign key (election_id, precinct_id) references precincts(election_id, id)
     on delete cascade
-);
+) strict;
 
 create index idx_ballot_styles_to_precincts_precinct_id on 
   ballot_styles_to_precincts(election_id, precinct_id);
@@ -65,7 +65,7 @@ create table ballot_styles_to_districts(
   primary key (election_id, ballot_style_group_id, district_id),
   foreign key (election_id, ballot_style_group_id) references ballot_styles(election_id, group_id)
     on delete cascade
-);
+) strict;
 
 create index idx_ballot_styles_to_districts_district_id on 
   ballot_styles_to_districts(election_id, district_id);
@@ -79,41 +79,41 @@ create table contests(
   primary key (election_id, id),
   foreign key (election_id) references elections(id)
     on delete cascade
-);
+) strict;
 
 create table voting_methods(
-  election_id integer not null,
+  election_id text not null,
   voting_method text not null
     check (voting_method = 'absentee' or voting_method = 'precinct' or voting_method = 'provisional' or voting_method = 'early_voting'),
   primary key (election_id, voting_method),
   foreign key (election_id) references elections(id)
     on delete cascade
-);
+) strict;
 
 create table write_in_candidates (
-  id varchar(36) primary key,
-  election_id varchar(36) not null,
+  id text primary key,
+  election_id text not null,
   contest_id text not null,
   name text not null,
-  created_at timestamp not null default current_timestamp,
+  created_at text not null default current_timestamp,
   foreign key (election_id) references elections(id)
     on delete cascade,
   unique (election_id, contest_id, name)
-);
+) strict;
 
 create table write_ins (
   sequence_id integer primary key autoincrement,
-  id varchar(36) not null unique,
-  cvr_id varchar(36) not null,
-  election_id varchar(36) not null,
+  id text not null unique,
+  cvr_id text not null,
+  election_id text not null,
   contest_id text not null,
   option_id text not null,
-  is_unmarked boolean not null default false,
+  is_unmarked integer not null default false,
   official_candidate_id text,
-  write_in_candidate_id varchar(36),
-  is_invalid boolean not null default false,
-  is_undetected boolean not null default false,
-  created_at timestamp not null default current_timestamp,
+  write_in_candidate_id text,
+  is_invalid integer not null default false,
+  is_undetected integer not null default false,
+  created_at text not null default current_timestamp,
   machine_marked_text text,
   foreign key (election_id) references elections(id),
   foreign key (cvr_id) references cvrs(id)
@@ -128,12 +128,12 @@ create table write_ins (
       is_invalid
     ) < 2
   )
-);
+) strict;
 
 create table cvrs (
-  id varchar(36) primary key,
-  election_id varchar(36) not null,
-  ballot_id varchar(36) not null,
+  id text primary key,
+  election_id text not null,
+  ballot_id text not null,
   ballot_style_group_id text not null,
   ballot_type text not null 
     check (ballot_type = 'absentee' or ballot_type = 'precinct' or ballot_type = 'provisional'),
@@ -144,18 +144,18 @@ create table cvrs (
   votes text not null,
   adjudicated_votes text,
   mark_scores text,
-  is_blank boolean not null,
-  has_overvote boolean not null,
-  has_undervote boolean not null,
-  has_write_in boolean not null,
-  has_marginal_mark boolean not null default false,
-  has_crossover_vote boolean not null,
-  is_adjudicated boolean not null default false,
-  created_at timestamp not null default current_timestamp,
+  is_blank integer not null,
+  has_overvote integer not null,
+  has_undervote integer not null,
+  has_write_in integer not null,
+  has_marginal_mark integer not null default false,
+  has_crossover_vote integer not null,
+  is_adjudicated integer not null default false,
+  created_at text not null default current_timestamp,
   foreign key (election_id) references elections(id)
     on delete cascade,
   foreign key (election_id, batch_id) references scanner_batches(election_id, id)
-);
+) strict;
 
 create index idx_cvrs_election_id on cvrs(election_id);
 create index idx_cvrs_ballot_id on cvrs(ballot_id);
@@ -164,84 +164,84 @@ create table scanner_batches (
   id text not null,
   label text not null,
   scanner_id text not null,
-  election_id varchar(36) not null,
+  election_id text not null,
   scanner_machine_type text check (scanner_machine_type is null or scanner_machine_type = 'central' or scanner_machine_type = 'precinct'),
   polling_place_id text,
   ballot_casting_mode text check (ballot_casting_mode is null or ballot_casting_mode = 'early_voting' or ballot_casting_mode = 'election_day'),
-  started_at datetime not null,
+  started_at text not null,
   primary key (election_id, id),
   foreign key (election_id) references elections(id)
     on delete cascade
-);
+) strict;
 
 create table cvr_files (
-  id varchar(36) primary key,
-  election_id varchar(36) not null,
-  is_test_mode boolean not null,
+  id text primary key,
+  election_id text not null,
+  is_test_mode integer not null,
   filename text not null,
-  export_timestamp timestamp not null,
+  export_timestamp text not null,
   precinct_ids text not null,
   scanner_ids text not null,
   polling_place_ids text not null,
   batch_ids text not null,
   sha256_hash text not null,
-  created_at timestamp not null default current_timestamp,
+  created_at text not null default current_timestamp,
   foreign key (election_id) references elections(id)
     on delete cascade
-);
+) strict;
 
 create table cvr_file_entries (
-  cvr_file_id varchar(36) not null,
-  cvr_id varchar(36) not null,
+  cvr_file_id text not null,
+  cvr_id text not null,
   primary key (cvr_file_id, cvr_id),
   foreign key (cvr_file_id) references cvr_files(id)
     on delete cascade,
   foreign key (cvr_id) references cvrs(id)
     on delete cascade
-);
+) strict;
 
 create table ballot_images (
   -- image files stored on disk based on cvr_id
-  cvr_id varchar(36) not null,
+  cvr_id text not null,
   side text not null check (side = 'front' or side = 'back'),
   layout text, -- Machine-marked ballots do not have a layout
   primary key (cvr_id, side),
   foreign key (cvr_id) references cvrs(id)
     on delete cascade
-);
+) strict;
 
 create table manual_results (
   id integer primary key,
-  election_id integer not null,
+  election_id text not null,
   precinct_id text not null,
   ballot_style_group_id text not null,
   voting_method text not null
     check (voting_method = 'absentee' or voting_method = 'precinct' or voting_method = 'early_voting'),
   ballot_count integer not null,
   contest_results text not null,
-  created_at timestamp not null default current_timestamp,
+  created_at text not null default current_timestamp,
   unique (election_id, precinct_id, ballot_style_group_id, voting_method),
   foreign key (election_id) references elections(id)
     on delete cascade
-);
+) strict;
 
 create table manual_result_write_in_candidate_references (
   manual_result_id integer not null,
-  write_in_candidate_id varchar(36) not null,
+  write_in_candidate_id text not null,
   primary key (manual_result_id, write_in_candidate_id),
   foreign key (manual_result_id) references manual_results(id)
     on delete cascade,
   foreign key (write_in_candidate_id) references write_in_candidates(id)
     on delete cascade
-);
+) strict;
 
 create table settings (
   -- enforce singleton table
   id integer primary key check (id = 1),
-  current_election_id varchar(36),
-  is_client_adjudication_enabled boolean not null default 0,
+  current_election_id text,
+  is_client_adjudication_enabled integer not null default 0,
   foreign key (current_election_id) references elections(id)
-);
+) strict;
 
 insert into settings default values;
 
@@ -250,8 +250,8 @@ create table diagnostics (
   type text not null,
   outcome text not null check (outcome = 'pass' or outcome = 'fail'),
   message text,
-  timestamp number not null
-);  
+  timestamp integer not null
+) strict;
 
 create table machines (
   machine_id text primary key,
@@ -261,7 +261,7 @@ create table machines (
     check (status in ('offline', 'online_locked', 'active', 'adjudicating')),
   auth_type text,
   last_seen_at integer not null
-);
+) strict;
 
 create table machine_ballot_adjudication_assignments (
   cvr_id text not null references cvrs(id) on delete cascade,
@@ -272,16 +272,16 @@ create table machine_ballot_adjudication_assignments (
   status text not null default 'claimed'
     check (status in ('claimed', 'completed')),
   primary key (cvr_id, election_id)
-);
+) strict;
 
 -- to track data changes in order to invalidate cached data
 create table data_versions (
-  election_id varchar(36),
+  election_id text,
   cvrs_data_version integer,
   primary key (election_id),
   foreign key (election_id) references elections(id)
     on delete cascade
-);
+) strict;
 
 create trigger cvr_file_added after insert on cvr_files
 begin

--- a/apps/admin/backend/src/schema.test.ts
+++ b/apps/admin/backend/src/schema.test.ts
@@ -1,0 +1,9 @@
+import { test } from 'vitest';
+import { Client } from '@votingworks/db';
+import { join } from 'node:path';
+
+test('schema is valid', () => {
+  Client.memoryClient(
+    join(import.meta.dirname, '../schema.sql')
+  ).assertSchemaIsValid();
+});

--- a/apps/central-scan/backend/schema.sql
+++ b/apps/central-scan/backend/schema.sql
@@ -4,29 +4,29 @@ create table election (
   election_data text not null,
   election_package_hash text not null,
   jurisdiction text not null,
-  is_test_mode boolean not null default true,
-  polls_state text not null default "polls_closed_initial",
-  is_sound_muted boolean not null default false,
+  is_test_mode integer not null default true,
+  polls_state text not null default 'polls_closed_initial',
+  is_sound_muted integer not null default false,
   polling_place_id text,
-  scanner_backed_up_at datetime,
-  created_at timestamp not null default current_timestamp
-);
+  scanner_backed_up_at text,
+  created_at text not null default current_timestamp
+) strict;
 
 create table batches (
   batch_number integer primary key autoincrement,
-  id varchar(36) unique,
+  id text unique,
   label text,
   polling_place_id text not null,
-  started_at datetime default current_timestamp not null,
-  ended_at datetime,
-  deleted_at datetime,
-  error varchar(4000)
-);
+  started_at text default current_timestamp not null,
+  ended_at text,
+  deleted_at text,
+  error text
+) strict;
 
 create table sheets (
-  id varchar(36) primary key,
-  batch_id varchar(36),
-  ballot_audit_id varchar(41), -- <batch_id>_<4-digit-sequence>
+  id text primary key,
+  batch_id text,
+  ballot_audit_id text, -- <batch_id>_<4-digit-sequence>
 
   -- Paths for the sheet images.
   front_image_path text unique,
@@ -38,25 +38,25 @@ create table sheets (
   back_interpretation_json text not null,
 
   -- Did this sheet require adjudication? This value should never be updated.
-  requires_adjudication boolean,
+  requires_adjudication integer,
 
   -- When adjudication is finished, this value is updated to now.
-  finished_adjudication_at datetime,
+  finished_adjudication_at text,
 
-  created_at datetime default current_timestamp not null,
-  deleted_at datetime,
+  created_at text default current_timestamp not null,
+  deleted_at text,
 
   foreign key (batch_id)
   references batches (id)
     on update cascade
     on delete cascade
-);
+) strict;
 
 create table system_settings (
   -- enforce singleton table
   id integer primary key check (id = 1),
   data text not null -- JSON blob
-);
+) strict;
 
 create table cvr_hashes (
   cvr_id_level_1_prefix text not null check (
@@ -74,7 +74,7 @@ create table cvr_hashes (
   cvr_hash text not null check (
     length(cvr_hash) = 64
   )
-);
+) strict;
 
 create unique index idx_cvr_hashes on cvr_hashes (
   cvr_id_level_1_prefix,
@@ -87,5 +87,5 @@ create table diagnostics (
   type text not null,
   outcome text not null check (outcome = 'pass' or outcome = 'fail'),
   message text,
-  timestamp number not null
-);
+  timestamp integer not null
+) strict;

--- a/apps/central-scan/backend/src/schema.test.ts
+++ b/apps/central-scan/backend/src/schema.test.ts
@@ -1,0 +1,9 @@
+import { test } from 'vitest';
+import { Client } from '@votingworks/db';
+import { join } from 'node:path';
+
+test('schema is valid', () => {
+  Client.memoryClient(
+    join(import.meta.dirname, '../schema.sql')
+  ).assertSchemaIsValid();
+});

--- a/apps/mark-scan/backend/schema.sql
+++ b/apps/mark-scan/backend/schema.sql
@@ -5,28 +5,28 @@ create table election (
   election_package_hash text not null,
   jurisdiction text not null,
   polling_place_id text,
-  is_test_mode boolean not null default true,
-  polls_state text not null default "polls_closed_initial",
+  is_test_mode integer not null default true,
+  polls_state text not null default 'polls_closed_initial',
   ballots_printed_count integer not null default 0,
   ballots_cast_since_last_ballot_box_change integer not null default 0,
-  created_at timestamp not null default current_timestamp
-);
+  created_at text not null default current_timestamp
+) strict;
 
 create table system_settings (
   -- enforce singleton table
   id integer primary key check (id = 1),
   data text not null -- JSON blob
-);
+) strict;
 
 create table languages (
   code text primary key
-);
+) strict;
 
 create table ui_strings (
   language_code text primary key,
   data text not null, -- JSON blob - see libs/types/UiStringTranslationsSchema
   foreign key (language_code) references languages(code)
-);
+) strict;
 
 create table audio_clips (
   id text not null,
@@ -34,24 +34,24 @@ create table audio_clips (
   data_base64 text not null, -- Base64-encoded audio bytes
   primary key (language_code, id),
   foreign key (language_code) references languages(code)
-);
+) strict;
 
 create table ui_string_audio_ids (
   language_code text primary key,
   data text not null, -- JSON blob - see libs/types/UiStringAudioIdsSchema
   foreign key (language_code) references languages(code)
-);
+) strict;
 
 create table diagnostics (
   id integer primary key,
   type text not null,
   outcome text not null check (outcome = 'pass' or outcome = 'fail'),
   message text,
-  timestamp number not null
-);
+  timestamp integer not null
+) strict;
 
 create table electrical_testing_status_messages (
   component text primary key,
   status_message text not null,
-  updated_at datetime default current_timestamp not null
-);
+  updated_at text default current_timestamp not null
+) strict;

--- a/apps/mark-scan/backend/src/schema.test.ts
+++ b/apps/mark-scan/backend/src/schema.test.ts
@@ -1,0 +1,9 @@
+import { test } from 'vitest';
+import { Client } from '@votingworks/db';
+import { join } from 'node:path';
+
+test('schema is valid', () => {
+  Client.memoryClient(
+    join(import.meta.dirname, '../schema.sql')
+  ).assertSchemaIsValid();
+});

--- a/apps/mark/backend/schema.sql
+++ b/apps/mark/backend/schema.sql
@@ -5,11 +5,11 @@ create table election (
   election_package_hash text not null,
   jurisdiction text not null,
   polling_place_id text,
-  is_test_mode boolean not null default true,
-  polls_state text not null default "polls_closed_initial",
+  is_test_mode integer not null default true,
+  polls_state text not null default 'polls_closed_initial',
   ballots_printed_count integer not null default 0,
-  created_at timestamp not null default current_timestamp
-);
+  created_at text not null default current_timestamp
+) strict;
 
 -- Temporary dev table:
 create table print_calibration (
@@ -17,23 +17,23 @@ create table print_calibration (
   id integer primary key check (id = 1),
   offset_mm_x real not null,
   offset_mm_y real not null
-);
+) strict;
 
 create table system_settings (
   -- enforce singleton table
   id integer primary key check (id = 1),
   data text not null -- JSON blob
-);
+) strict;
 
 create table languages (
   code text primary key
-);
+) strict;
 
 create table ui_strings (
   language_code text primary key,
   data text not null, -- JSON blob - see libs/types/UiStringTranslationsSchema
   foreign key (language_code) references languages(code)
-);
+) strict;
 
 create table audio_clips (
   id text not null,
@@ -41,13 +41,13 @@ create table audio_clips (
   data_base64 text not null, -- Base64-encoded audio bytes
   primary key (language_code, id),
   foreign key (language_code) references languages(code)
-);
+) strict;
 
 create table ui_string_audio_ids (
   language_code text primary key,
   data text not null, -- JSON blob - see libs/types/UiStringAudioIdsSchema
   foreign key (language_code) references languages(code)
-);
+) strict;
 
 create table ballots (
   id integer primary key,
@@ -56,18 +56,18 @@ create table ballots (
   ballot_type text not null,
   ballot_mode text not null,
   encoded_ballot text not null -- Base64 encoded ballot
-);
+) strict;
 
 create table diagnostics (
   id integer primary key,
   type text not null,
   outcome text not null check (outcome = 'pass' or outcome = 'fail'),
   message text,
-  timestamp number not null
-);
+  timestamp integer not null
+) strict;
 
 create table electrical_testing_status_messages (
   component text primary key,
   status_message text not null,
-  updated_at datetime default current_timestamp not null
-);
+  updated_at text default current_timestamp not null
+) strict;

--- a/apps/mark/backend/src/schema.test.ts
+++ b/apps/mark/backend/src/schema.test.ts
@@ -1,0 +1,9 @@
+import { test } from 'vitest';
+import { Client } from '@votingworks/db';
+import { join } from 'node:path';
+
+test('schema is valid', () => {
+  Client.memoryClient(
+    join(import.meta.dirname, '../schema.sql')
+  ).assertSchemaIsValid();
+});

--- a/apps/pollbook/backend/schema.sql
+++ b/apps/pollbook/backend/schema.sql
@@ -9,14 +9,14 @@ CREATE TABLE voters (
     updated_last_name TEXT,
     updated_suffix TEXT,
     voter_data TEXT not null
-);
+) STRICT;
 
 CREATE TABLE machines (
     machine_id TEXT PRIMARY KEY,
     status TEXT NOT NULL, -- PollbookConnectionStatus enum
     last_seen INTEGER NOT NULL, -- last time the machine was seen
     pollbook_information TEXT NOT NULL -- JSON blob of PollbookInformation
-);
+) STRICT;
 
 CREATE TABLE elections (
     election_id TEXT PRIMARY KEY,
@@ -24,9 +24,9 @@ CREATE TABLE elections (
     ballot_hash TEXT not null,
     package_hash TEXT not null,
     valid_street_data TEXT,
-    is_absentee_mode BOOLEAN NOT NULL,
+    is_absentee_mode INTEGER NOT NULL,
     configured_precinct_id TEXT
-);
+) STRICT;
 
 CREATE TABLE event_log (
     event_id INTEGER not null, -- local event id
@@ -37,13 +37,13 @@ CREATE TABLE event_log (
     voter_id TEXT, -- voter_id of the voter involved in the event, if any
     event_data TEXT not null, -- JSON data for additional details associated with the event (id type used for check in, etc.)
     PRIMARY KEY (event_id, machine_id)
-);
+) STRICT;
 
 -- Utility table to store any simple fields that need to be shared between the local and peer servers
 CREATE TABLE config_data (
     id INTEGER PRIMARY KEY CHECK (id = 0), -- enforces there is only one row to this table
     configuration_status TEXT
-);
+) STRICT;
 INSERT INTO config_data (id, configuration_status) VALUES (0, null);
 
 -- Index for sorting events by hybrid logical clock physical time then logical counter - machine id is included in the rare event of tie
@@ -56,9 +56,9 @@ CREATE INDEX idx_updated_last_name ON voters (updated_last_name);
 CREATE TABLE check_in_status (
     voter_id TEXT NOT NULL,
     machine_id TEXT,
-    is_checked_in BOOLEAN NOT NULL,
+    is_checked_in INTEGER NOT NULL,
     PRIMARY KEY (voter_id)
-);
+) STRICT;
 
 CREATE INDEX idx_check_in_status ON check_in_status (is_checked_in);
 CREATE INDEX idx_machine_check_in_status ON check_in_status (machine_id, is_checked_in);
@@ -69,8 +69,8 @@ CREATE TABLE anomalies (
     detected_at INTEGER NOT NULL, -- timestamp when anomaly was detected
     anomaly_details TEXT NOT NULL, -- JSON blob with additional details
     dismissed_at INTEGER, -- timestamp when anomaly was dismissed, null if not dismissed
-    dismissed BOOLEAN NOT NULL DEFAULT 0 -- whether the anomaly has been dismissed
-);
+    dismissed INTEGER NOT NULL DEFAULT 0 -- whether the anomaly has been dismissed
+) STRICT;
 
 CREATE INDEX idx_anomalies_dismissed ON anomalies (dismissed);
 CREATE INDEX idx_anomalies_detected_at ON anomalies (detected_at);

--- a/apps/pollbook/backend/src/schema.test.ts
+++ b/apps/pollbook/backend/src/schema.test.ts
@@ -1,0 +1,9 @@
+import { test } from 'vitest';
+import { Client } from '@votingworks/db';
+import { join } from 'node:path';
+
+test('schema is valid', () => {
+  Client.memoryClient(
+    join(import.meta.dirname, '../schema.sql')
+  ).assertSchemaIsValid();
+});

--- a/apps/print/backend/schema.sql
+++ b/apps/print/backend/schema.sql
@@ -4,16 +4,16 @@ create table election (
   election_data text not null,
   election_package_hash text not null,
   jurisdiction text not null,
-  created_at timestamp not null default current_timestamp,
+  created_at text not null default current_timestamp,
   polling_place_id text,
-  is_test_mode boolean not null default false
-);
+  is_test_mode integer not null default false
+) strict;
 
 create table system_settings (
   -- enforce singleton table
   id integer primary key check (id = 1),
   data text not null -- JSON blob
-);
+) strict;
 
 create table ballots (
   id integer primary key,
@@ -23,12 +23,12 @@ create table ballots (
   ballot_mode text not null,
   encoded_ballot text not null, -- Base64 encoded ballot
   print_count integer not null default 0
-);
+) strict;
 
 create table diagnostics (
   id integer primary key,
   type text not null,
   outcome text not null check (outcome = 'pass' or outcome = 'fail'),
   message text,
-  timestamp number not null
-);
+  timestamp integer not null
+) strict;

--- a/apps/print/backend/src/schema.test.ts
+++ b/apps/print/backend/src/schema.test.ts
@@ -1,0 +1,9 @@
+import { test } from 'vitest';
+import { Client } from '@votingworks/db';
+import { join } from 'node:path';
+
+test('schema is valid', () => {
+  Client.memoryClient(
+    join(import.meta.dirname, '../schema.sql')
+  ).assertSchemaIsValid();
+});

--- a/apps/scan/backend/schema.sql
+++ b/apps/scan/backend/schema.sql
@@ -5,33 +5,33 @@ create table election (
   election_package_hash text not null,
   jurisdiction text not null,
   polling_place_id text,
-  is_test_mode boolean not null default true,
+  is_test_mode integer not null default true,
   ballot_casting_mode text not null default 'election_day',
-  polls_state text not null default "polls_closed_initial",
+  polls_state text not null default 'polls_closed_initial',
   last_polls_transition_type text,
   last_polls_transition_time integer,
   last_polls_transition_ballot_count integer,
-  is_sound_muted boolean not null default false,
-  is_double_feed_detection_disabled boolean not null default false,
-  is_continuous_export_enabled boolean not null default true,
-  created_at timestamp not null default current_timestamp,
+  is_sound_muted integer not null default false,
+  is_double_feed_detection_disabled integer not null default false,
+  is_continuous_export_enabled integer not null default true,
+  created_at text not null default current_timestamp,
   ballot_audit_id_secret_key text
-);
+) strict;
 
 create table batches (
   batch_number integer primary key autoincrement,
-  id varchar(36) unique,
+  id text unique,
   label text,
-  started_at datetime default current_timestamp not null,
-  ended_at datetime,
+  started_at text default current_timestamp not null,
+  ended_at text,
   ballot_casting_mode text,
   polling_place_id text not null,
-  error varchar(4000)
-);
+  error text
+) strict;
 
 create table sheets (
-  id varchar(36) primary key,
-  batch_id varchar(36),
+  id text primary key,
+  batch_id text,
 
   -- Paths for the sheet images.
   front_image_path text unique,
@@ -42,14 +42,14 @@ create table sheets (
   front_interpretation_json text not null,
   back_interpretation_json text not null,
 
-  created_at datetime default current_timestamp not null,
-  rejected_at datetime,
+  created_at text default current_timestamp not null,
+  rejected_at text,
 
   foreign key (batch_id)
   references batches (id)
     on update cascade
     on delete cascade
-);
+) strict;
 
 -- Supports counting ballots and batch sheet counts without reading full sheet
 -- rows, which would require decoding past the large interpretation JSON blobs.
@@ -60,25 +60,25 @@ create table system_settings (
   -- Enforce singleton table
   id integer primary key check (id = 1),
   data text not null -- JSON blob
-);
+) strict;
 
 create table diagnostics (
   id integer primary key,
   type text not null,
   outcome text not null check (outcome = 'pass' or outcome = 'fail'),
   message text,
-  timestamp number not null
-);
+  timestamp integer not null
+) strict;
 
 create table export_directory_name (
   -- Enforce singleton table
   id integer primary key check (id = 1),
   export_directory_name text not null
-);
+) strict;
 
 create table pending_continuous_export_operations (
   sheet_id text primary key check (length(sheet_id) = 36)
-);
+) strict;
 
 create table cvr_hashes (
   cvr_id_level_1_prefix text not null check (
@@ -96,7 +96,7 @@ create table cvr_hashes (
   cvr_hash text not null check (
     length(cvr_hash) = 64
   )
-);
+) strict;
 
 create unique index idx_cvr_hashes on cvr_hashes (
   cvr_id_level_1_prefix,
@@ -106,13 +106,13 @@ create unique index idx_cvr_hashes on cvr_hashes (
 
 create table languages (
   code text primary key
-);
+) strict;
 
 create table ui_strings (
   language_code text primary key,
   data text not null, -- JSON blob - see libs/types/UiStringTranslationsSchema
   foreign key (language_code) references languages(code)
-);
+) strict;
 
 create table audio_clips (
   id text not null,
@@ -120,16 +120,16 @@ create table audio_clips (
   data_base64 text not null, -- Base64-encoded audio bytes
   primary key (language_code, id),
   foreign key (language_code) references languages(code)
-);
+) strict;
 
 create table ui_string_audio_ids (
   language_code text primary key,
   data text not null, -- JSON blob - see libs/types/UiStringAudioIdsSchema
   foreign key (language_code) references languages(code)
-);
+) strict;
 
 create table electrical_testing_status_messages (
   component text primary key,
   status_message text not null,
-  updated_at datetime default current_timestamp not null
-);
+  updated_at text default current_timestamp not null
+) strict;

--- a/apps/scan/backend/src/schema.test.ts
+++ b/apps/scan/backend/src/schema.test.ts
@@ -1,0 +1,9 @@
+import { test } from 'vitest';
+import { Client } from '@votingworks/db';
+import { join } from 'node:path';
+
+test('schema is valid', () => {
+  Client.memoryClient(
+    join(import.meta.dirname, '../schema.sql')
+  ).assertSchemaIsValid();
+});

--- a/libs/auth/src/cast_vote_record_hashes.ts
+++ b/libs/auth/src/cast_vote_record_hashes.ts
@@ -152,7 +152,7 @@ create table cvr_hashes (
   cvr_hash text not null check (
     length(cvr_hash) = 64
   )
-);
+) strict;
 
 create unique index idx_cvr_hashes on cvr_hashes (
   cvr_id_level_1_prefix,

--- a/libs/backend/src/diagnostics.ts
+++ b/libs/backend/src/diagnostics.ts
@@ -14,8 +14,8 @@ create table diagnostics (
     type text not null,
     outcome text not null check (outcome = 'pass' or outcome = 'fail'),
     message text,
-    timestamp number not null
-  );  
+    timestamp integer not null
+  ) strict;
 `;
 
 /**

--- a/libs/db/src/client.ts
+++ b/libs/db/src/client.ts
@@ -13,6 +13,7 @@ import * as fs from 'node:fs';
 import Database from 'better-sqlite3';
 import { dirname, join } from 'node:path';
 import { SchemaDigestMismatchError } from './schema_digest_mismatch_error';
+import { findSchemaViolations } from './schema_validation';
 
 type Database = Database.Database;
 
@@ -136,7 +137,7 @@ export class Client {
    */
   private writeSchemaDigest(): void {
     this.exec(
-      `create table if not exists ${SCHEMA_DIGEST_TABLE} (digest text not null)`
+      `create table if not exists ${SCHEMA_DIGEST_TABLE} (digest text not null) strict`
     );
     this.run(`delete from ${SCHEMA_DIGEST_TABLE}`);
     this.run(
@@ -574,6 +575,22 @@ export class Client {
       debug
     );
     return db;
+  }
+
+  /**
+   * Asserts that the schema follows our conventions, listing every violation
+   * found. See {@link findSchemaViolations} for the conventions checked.
+   */
+  assertSchemaIsValid(): void {
+    const violations = findSchemaViolations(this);
+
+    if (violations.length > 0) {
+      throw new Error(
+        `invalid schema at ${
+          this.schemaPath ?? this.getDatabasePath()
+        }:\n${violations.map((violation) => `  - ${violation}`).join('\n')}`
+      );
+    }
   }
 
   private close(): void {

--- a/libs/db/src/index.ts
+++ b/libs/db/src/index.ts
@@ -1,3 +1,4 @@
 /* istanbul ignore file */
 export * from './client';
 export * from './schema_digest_mismatch_error';
+export * from './schema_validation';

--- a/libs/db/src/schema_validation.test.ts
+++ b/libs/db/src/schema_validation.test.ts
@@ -1,0 +1,157 @@
+import { expect, test } from 'vitest';
+import { makeTemporaryFile } from '@votingworks/fixtures';
+import { Client } from './client';
+import { findSchemaViolations } from './schema_validation';
+
+function clientWithSchema(schema: string): Client {
+  const client = Client.memoryClient();
+  client.exec(schema);
+  return client;
+}
+
+test('no violations in a valid schema', () => {
+  const client = clientWithSchema(`
+    create table elections (
+      id text primary key,
+      created_at text not null default current_timestamp
+    ) strict;
+
+    create table cvrs (
+      id text primary key,
+      election_id text not null,
+      foreign key (election_id) references elections(id)
+    ) strict;
+
+    create table cvr_write_ins (
+      cvr_id text primary key,
+      foreign key (cvr_id) references cvrs
+    ) strict;
+  `);
+
+  expect(findSchemaViolations(client)).toEqual([]);
+});
+
+test('flags tables that are not strict', () => {
+  const client = clientWithSchema(`
+    create table strict_table (id text primary key) strict;
+    create table lax_table (id serial primary key);
+  `);
+
+  expect(findSchemaViolations(client)).toEqual([
+    'table lax_table is not declared strict',
+  ]);
+});
+
+test('flags foreign keys whose type differs from the column they reference', () => {
+  const client = clientWithSchema(`
+    create table elections (id text primary key) strict;
+
+    create table cvrs (
+      id text primary key,
+      election_id integer not null,
+      foreign key (election_id) references elections(id)
+    ) strict;
+  `);
+
+  expect(findSchemaViolations(client)).toEqual([
+    'cvrs.election_id is declared integer but references elections.id, which is declared text',
+  ]);
+});
+
+test('flags foreign keys referencing a table outside the schema', () => {
+  const client = clientWithSchema(`
+    create table cvrs (
+      id text primary key,
+      election_id text not null references elections(id)
+    ) strict;
+  `);
+
+  expect(findSchemaViolations(client)).toEqual([
+    'cvrs.election_id references unknown table elections',
+  ]);
+});
+
+test('flags foreign keys referencing a column the table does not have', () => {
+  const client = clientWithSchema(`
+    create table elections (id text primary key) strict;
+
+    create table cvrs (
+      id text primary key,
+      election_id text not null references elections(election_id)
+    ) strict;
+  `);
+
+  expect(findSchemaViolations(client)).toEqual([
+    'cvrs.election_id references unknown column elections.election_id',
+  ]);
+});
+
+test('flags implicit references to a table with no primary key', () => {
+  const client = clientWithSchema(`
+    create table elections (id text not null) strict;
+
+    create table cvrs (
+      id text primary key,
+      election_id text not null references elections
+    ) strict;
+  `);
+
+  expect(findSchemaViolations(client)).toEqual([
+    'cvrs.election_id references unknown column elections.<primary key>',
+  ]);
+});
+
+test('reports every violation in a composite foreign key', () => {
+  const client = clientWithSchema(`
+    create table precincts (
+      election_id text not null,
+      id text not null,
+      primary key (election_id, id)
+    ) strict;
+
+    create table precinct_voter_counts (
+      election_id integer not null,
+      precinct_id integer not null,
+      foreign key (election_id, precinct_id) references precincts
+    ) strict;
+  `);
+
+  expect(findSchemaViolations(client)).toEqual([
+    'precinct_voter_counts.election_id is declared integer but references precincts.election_id, which is declared text',
+    'precinct_voter_counts.precinct_id is declared integer but references precincts.id, which is declared text',
+  ]);
+});
+
+test('assertSchemaIsValid does nothing for a valid schema', () => {
+  const client = clientWithSchema('create table muppets (name text) strict;');
+
+  expect(() => client.assertSchemaIsValid()).not.toThrow();
+});
+
+test('assertSchemaIsValid reports every violation at once', () => {
+  const client = clientWithSchema(`
+    create table elections (id text primary key);
+
+    create table cvrs (
+      id text primary key,
+      election_id integer not null,
+      foreign key (election_id) references elections(id)
+    ) strict;
+  `);
+
+  expect(() => client.assertSchemaIsValid()).toThrowError(
+    `invalid schema at :memory::
+  - table elections is not declared strict
+  - cvrs.election_id is declared integer but references elections.id, which is declared text`
+  );
+});
+
+test('assertSchemaIsValid names the schema file when there is one', () => {
+  const schemaPath = makeTemporaryFile({
+    content: 'create table muppets (name text);',
+  });
+
+  expect(() => Client.memoryClient(schemaPath).assertSchemaIsValid())
+    .toThrowError(`invalid schema at ${schemaPath}:
+  - table muppets is not declared strict`);
+});

--- a/libs/db/src/schema_validation.ts
+++ b/libs/db/src/schema_validation.ts
@@ -1,0 +1,146 @@
+import type { Client } from './client';
+
+interface TableListRow {
+  name: string;
+  strict: number;
+}
+
+interface TableInfoRow {
+  name: string;
+  type: string;
+  pk: number;
+}
+
+interface ForeignKeyListRow {
+  seq: number;
+  table: string;
+  from: string;
+  to: string | null;
+}
+
+interface TableSchema {
+  name: string;
+  isStrict: boolean;
+  columnTypes: ReadonlyMap<string, string>;
+  primaryKeyColumns: string[];
+}
+
+function readTableSchemas(client: Client): Map<string, TableSchema> {
+  const tables = client.all(
+    `
+    select name, strict
+    from pragma_table_list
+    where schema = 'main' and type = 'table' and name not like 'sqlite_%'
+    order by name
+    `
+  ) as TableListRow[];
+
+  return new Map(
+    tables.map((table) => {
+      const columns = client.all(
+        'select name, type, pk from pragma_table_info(?) order by cid',
+        table.name
+      ) as TableInfoRow[];
+
+      return [
+        table.name.toLowerCase(),
+        {
+          name: table.name,
+          isStrict: table.strict !== 0,
+          columnTypes: new Map(
+            columns.map((column) => [
+              column.name.toLowerCase(),
+              column.type.toLowerCase(),
+            ])
+          ),
+          primaryKeyColumns: columns
+            .filter((column) => column.pk > 0)
+            .sort((a, b) => a.pk - b.pk)
+            .map((column) => column.name),
+        },
+      ];
+    })
+  );
+}
+
+function findForeignKeyViolations(
+  client: Client,
+  table: TableSchema,
+  schemasByTableName: ReadonlyMap<string, TableSchema>
+): string[] {
+  const violations: string[] = [];
+
+  const foreignKeys = client.all(
+    'select seq, "table", "from", "to" from pragma_foreign_key_list(?)',
+    table.name
+  ) as ForeignKeyListRow[];
+
+  for (const foreignKey of foreignKeys) {
+    const referencedTable = schemasByTableName.get(
+      foreignKey.table.toLowerCase()
+    );
+
+    if (!referencedTable) {
+      violations.push(
+        `${table.name}.${foreignKey.from} references unknown table ${foreignKey.table}`
+      );
+      continue;
+    }
+
+    // A foreign key with no explicit column list references the primary key of
+    // the referenced table, one column per position in the key.
+    const referencedColumn =
+      foreignKey.to ?? referencedTable.primaryKeyColumns[foreignKey.seq];
+    const referencedColumnType =
+      referencedColumn &&
+      referencedTable.columnTypes.get(referencedColumn.toLowerCase());
+
+    if (!referencedColumn || !referencedColumnType) {
+      violations.push(
+        `${table.name}.${foreignKey.from} references unknown column ${
+          referencedTable.name
+        }.${referencedColumn ?? '<primary key>'}`
+      );
+      continue;
+    }
+
+    const columnType = table.columnTypes.get(foreignKey.from.toLowerCase());
+
+    if (columnType !== referencedColumnType) {
+      violations.push(
+        `${table.name}.${foreignKey.from} is declared ${columnType} but references ${referencedTable.name}.${referencedColumn}, which is declared ${referencedColumnType}`
+      );
+    }
+  }
+
+  return violations;
+}
+
+/**
+ * Finds all the ways `client`'s schema fails our conventions:
+ *
+ * - every table must be declared `strict`, so that sqlite enforces the declared
+ *   column types rather than silently applying type affinity
+ * - every foreign key column must be declared with the same type as the column
+ *   it references
+ *
+ * Returns a message per violation, or an empty array if the schema is valid.
+ */
+export function findSchemaViolations(client: Client): string[] {
+  const schemasByTableName = readTableSchemas(client);
+  const violations: string[] = [];
+
+  for (const table of schemasByTableName.values()) {
+    if (!table.isStrict) {
+      violations.push(`table ${table.name} is not declared strict`);
+    }
+  }
+
+  for (const table of schemasByTableName.values()) {
+    violations.push(
+      ...findForeignKeyViolations(client, table, schemasByTableName)
+    );
+  }
+
+  return violations;
+}

--- a/libs/db/test/fixtures/schema.sql
+++ b/libs/db/test/fixtures/schema.sql
@@ -3,6 +3,6 @@ create table users (
   name text not null,
   email text not null,
   password_hash text not null,
-  created_at timestamp not null default current_timestamp,
-  updated_at timestamp not null default current_timestamp
-);
+  created_at text not null default current_timestamp,
+  updated_at text not null default current_timestamp
+) strict;


### PR DESCRIPTION
## Overview

Column types in sqlite are, by default, a loosey-goosey affair. You can use whatever label you want and sqlite will just figure it out. This leads to situations where the declared type for a column is actively misleading, such as VxAdmin's `elections.id` pkey that was declared `serial` but was actually given UUID text values. Some places that referenced it also said `integer`, and some said `text`.

This changes two things:
1. All sqlite tables are now marked as `strict`, which forces the column types to be actual type names and not wishcasted names like `uuid` (which doesn't exist but sqlite accepted anyway).
2. All fkey columns must be declared using the same type as the column they reference.

As far as I can tell these changes have no real effect on sqlite and are both about reducing _human_ confusion when reading the schemas.

## Demo Video or Screenshot

An example from the PR of enforcement of a foreign key type mismatch:
```ts
test('reports every violation in a composite foreign key', () => {
  const client = clientWithSchema(`
    create table precincts (
      election_id text not null,
      id text not null,
      primary key (election_id, id)
    ) strict;
    create table precinct_voter_counts (
      election_id integer not null,
      precinct_id integer not null,
      foreign key (election_id, precinct_id) references precincts
    ) strict;
  `);

  expect(findSchemaViolations(client)).toEqual([
    'precinct_voter_counts.election_id is declared integer but references precincts.election_id, which is declared text',
    'precinct_voter_counts.precinct_id is declared integer but references precincts.id, which is declared text',
  ]);
});
```

## Testing Plan
New validations that check each `schema.sql` file and tests for the validators themselves.
