### PR TITLE
[VxCentralScan] Handle all possible connection errors

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -255,11 +255,11 @@ create table diagnostics (
 
 create table machines (
   machine_id text primary key,
-  machine_mode text not null
+  machine_role text not null
     check (
-      machine_mode = 'host' or
-      machine_mode = 'client' or
-      machine_mode = 'scanner'
+      machine_role = 'admin-host' or
+      machine_role = 'admin-client' or
+      machine_role = 'scanner'
     ),
   status text not null
     check (status in ('offline', 'online_locked', 'active', 'adjudicating')),

--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -256,7 +256,11 @@ create table diagnostics (
 create table machines (
   machine_id text primary key,
   machine_mode text not null
-    check (machine_mode = 'host' or machine_mode = 'client'),
+    check (
+      machine_mode = 'host' or
+      machine_mode = 'client' or
+      machine_mode = 'scanner'
+    ),
   status text not null
     check (status in ('offline', 'online_locked', 'active', 'adjudicating')),
   auth_type text,

--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -139,7 +139,7 @@ test('getNetworkStatus returns online when host is connected', async () => {
   const { apiClient, workspace } = buildTestEnvironment();
   workspace.store.setNetworkedMachineStatus(
     DEV_MACHINE_ID,
-    'host',
+    'admin-host',
     Admin.ClientMachineStatus.Active
   );
   expect(await apiClient.getNetworkStatus()).toMatchObject({
@@ -152,17 +152,17 @@ test('getNetworkStatus returns all clients including disconnected', async () => 
   const { apiClient, workspace } = buildTestEnvironment();
   workspace.store.setNetworkedMachineStatus(
     DEV_MACHINE_ID,
-    'host',
+    'admin-host',
     Admin.ClientMachineStatus.Active
   );
   workspace.store.setNetworkedMachineStatus(
     'CLIENT-001',
-    'client',
+    'admin-client',
     Admin.ClientMachineStatus.Active
   );
   workspace.store.setNetworkedMachineStatus(
     'CLIENT-002',
-    'client',
+    'admin-client',
     Admin.ClientMachineStatus.Offline
   );
   const status = await apiClient.getNetworkStatus();

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -307,13 +307,15 @@ function buildApi({
       const { machineId } = getMachineConfig();
       const machines = store.getMachines();
       const hostRecord = machines.find(
-        (m) => m.machineMode === 'host' && m.machineId === machineId
+        (m) => m.machineRole === 'admin-host' && m.machineId === machineId
       );
       return {
         isOnline:
           hostRecord !== undefined &&
           hostRecord.status !== Admin.ClientMachineStatus.Offline,
-        connectedClients: machines.filter((m) => m.machineMode === 'client'),
+        connectedClients: machines.filter(
+          (m) => m.machineRole === 'admin-client'
+        ),
         multipleHostsDetected: store.getMultipleHostsDetected(machineId),
       };
     },

--- a/apps/admin/backend/src/app_networking.test.ts
+++ b/apps/admin/backend/src/app_networking.test.ts
@@ -188,7 +188,7 @@ test('client discovers host and connects - host stores client info in database',
       status: Admin.ClientMachineStatus.Active,
     });
 
-    // Host should record the client via the connectToHost peer API call
+    // Host should record the client via the registerAdjudicationStation peer API call
     expect(machines.find((m) => m.machineId === clientMachineId)).toMatchObject(
       {
         machineId: clientMachineId,
@@ -271,7 +271,7 @@ test('host calls cleanupStaleMachines on each polling cycle and cleans stale con
   mockFindAllVxAdminHostMachines.mockResolvedValue([]);
 
   // Wait for the client to fully disconnect before checking stale cleanup,
-  // to avoid a race with in-flight connectToHost calls
+  // to avoid a race with in-flight registerAdjudicationStation calls
   await waitFor(() => {
     vi.advanceTimersByTime(NETWORK_POLLING_INTERVAL_MS);
     expect(clientStore.getConnectionStatus()).toEqual(

--- a/apps/admin/backend/src/app_networking.test.ts
+++ b/apps/admin/backend/src/app_networking.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, expect, test, vi, vitest } from 'vitest';
 import {
   findAllVxAdminHostMachines,
   hasOnlineInterface,
+  NETWORK_POLLING_INTERVAL_MS,
 } from '@votingworks/networking';
 import { AddressInfo } from 'node:net';
 import { Server } from 'node:http';
@@ -42,10 +43,7 @@ import {
 
 import { ClientStore } from './client_store.js';
 import { createClientWorkspace, createWorkspace } from './util/workspace.js';
-import {
-  NETWORK_POLLING_INTERVAL_MS,
-  STALE_MACHINE_THRESHOLD_MS,
-} from './globals.js';
+import { STALE_MACHINE_THRESHOLD_MS } from './globals.js';
 import { getCurrentTime } from './get_current_time.js';
 
 vi.mock('./get_current_time');

--- a/apps/admin/backend/src/app_networking.test.ts
+++ b/apps/admin/backend/src/app_networking.test.ts
@@ -184,7 +184,7 @@ test('client discovers host and connects - host stores client info in database',
     // Host should record itself as connected
     expect(machines.find((m) => m.machineId === hostMachineId)).toMatchObject({
       machineId: hostMachineId,
-      machineMode: 'host',
+      machineRole: 'admin-host',
       status: Admin.ClientMachineStatus.Active,
     });
 
@@ -192,7 +192,7 @@ test('client discovers host and connects - host stores client info in database',
     expect(machines.find((m) => m.machineId === clientMachineId)).toMatchObject(
       {
         machineId: clientMachineId,
-        machineMode: 'client',
+        machineRole: 'admin-client',
         status: Admin.ClientMachineStatus.OnlineLocked,
       }
     );

--- a/apps/admin/backend/src/globals.ts
+++ b/apps/admin/backend/src/globals.ts
@@ -42,12 +42,6 @@ export const PORT = Number(process.env.FRONTEND_PORT || 3000) + 1;
 // eslint-disable-next-line vx/gts-safe-number-parse
 export const PEER_PORT = Number(process.env['PEER_PORT'] || PORT + 1);
 
-/**  How often to poll the network for changes (in milliseconds) */
-export const NETWORK_POLLING_INTERVAL_MS = 2 * 1000;
-
-/**  Network request timeout (in milliseconds) */
-export const NETWORK_REQUEST_TIMEOUT_MS = 1 * 1000;
-
 /** How long to wait before considering a machine stale (in milliseconds) */
 export const STALE_MACHINE_THRESHOLD_MS = 10 * 1000;
 

--- a/apps/admin/backend/src/networking.test.ts
+++ b/apps/admin/backend/src/networking.test.ts
@@ -3,6 +3,7 @@ import {
   AvahiService,
   findAllVxAdminHostMachines,
   hasOnlineInterface,
+  NETWORK_POLLING_INTERVAL_MS,
 } from '@votingworks/networking';
 import * as grout from '@votingworks/grout';
 import { buildMockDippedSmartCardAuth } from '@votingworks/auth';
@@ -26,10 +27,7 @@ import { Store } from './store.js';
 import { ClientConnectionStatus } from './types.js';
 import { ClientStore } from './client_store.js';
 import { getCurrentTime } from './get_current_time.js';
-import {
-  NETWORK_POLLING_INTERVAL_MS,
-  STALE_MACHINE_THRESHOLD_MS,
-} from './globals.js';
+import { STALE_MACHINE_THRESHOLD_MS } from './globals.js';
 
 vi.mock('./get_current_time');
 // Partial mock: keep the pure service-name helpers real so the

--- a/apps/admin/backend/src/networking.test.ts
+++ b/apps/admin/backend/src/networking.test.ts
@@ -155,7 +155,7 @@ describe('startHostNetworking', () => {
     expect(machines).toHaveLength(1);
     expect(machines[0]).toMatchObject({
       machineId: '0001',
-      machineMode: 'host',
+      machineRole: 'admin-host',
       status: Admin.ClientMachineStatus.Active,
     });
   });
@@ -182,7 +182,7 @@ describe('startHostNetworking', () => {
     expect(store.getMultipleHostsDetected('0001')).toEqual(true);
     const otherHost = store.getMachines().find((m) => m.machineId === 'OTHER');
     expect(otherHost).toMatchObject({
-      machineMode: 'host',
+      machineRole: 'admin-host',
       status: Admin.ClientMachineStatus.Active,
     });
   });

--- a/apps/admin/backend/src/networking.test.ts
+++ b/apps/admin/backend/src/networking.test.ts
@@ -5,6 +5,7 @@ import {
   hasOnlineInterface,
   NETWORK_POLLING_INTERVAL_MS,
 } from '@votingworks/networking';
+import { err, ok } from '@votingworks/basics';
 import * as grout from '@votingworks/grout';
 import { buildMockDippedSmartCardAuth } from '@votingworks/auth';
 import {
@@ -362,7 +363,7 @@ describe('startClientNetworking', () => {
   }
 
   interface MockPeerClientOverrides {
-    connectToHost?: ReturnType<typeof vi.fn>;
+    registerAdjudicationStation?: ReturnType<typeof vi.fn>;
     getElectionPackageHash?: ReturnType<typeof vi.fn>;
     getCurrentElectionMetadata?: ReturnType<typeof vi.fn>;
     getSystemSettings?: ReturnType<typeof vi.fn>;
@@ -372,11 +373,13 @@ describe('startClientNetworking', () => {
     overrides: MockPeerClientOverrides = {}
   ): grout.Client<PeerApi> {
     const defaults: MockPeerClientOverrides = {
-      connectToHost: vi.fn().mockResolvedValue({
-        machineId: 'HOST1',
-        codeVersion: 'dev',
-        isClientAdjudicationEnabled: false,
-      }),
+      registerAdjudicationStation: vi.fn().mockResolvedValue(
+        ok({
+          machineId: 'HOST1',
+          codeVersion: 'dev',
+          isClientAdjudicationEnabled: false,
+        })
+      ),
       getElectionPackageHash: vi.fn().mockResolvedValue(undefined),
       getCurrentElectionMetadata: vi.fn().mockResolvedValue(undefined),
       getSystemSettings: vi.fn().mockResolvedValue(undefined),
@@ -738,7 +741,7 @@ describe('startClientNetworking', () => {
     });
     await advancePollingInterval();
 
-    expect(mockClient.connectToHost).toHaveBeenCalledWith({
+    expect(mockClient.registerAdjudicationStation).toHaveBeenCalledWith({
       machineId: '0002',
       codeVersion: 'dev',
       status: Admin.ClientMachineStatus.OnlineLocked,
@@ -752,11 +755,9 @@ describe('startClientNetworking', () => {
       { machineId: 'HOST1', address: 'http://192.168.1.10:3002' },
     ]);
     const mockClient = createMockPeerClient({
-      connectToHost: vi.fn().mockResolvedValue({
-        machineId: 'HOST1',
-        codeVersion: 'a-different-version',
-        isClientAdjudicationEnabled: true,
-      }),
+      registerAdjudicationStation: vi
+        .fn()
+        .mockResolvedValue(err({ type: 'code-version-mismatch' })),
     });
     vi.mocked(grout.createClient).mockReturnValue(mockClient);
 
@@ -781,7 +782,6 @@ describe('startClientNetworking', () => {
       'system',
       expect.objectContaining({
         newStatus: ClientConnectionStatus.OnlineIncompatibleHostVersion,
-        hostCodeVersion: 'a-different-version',
         clientCodeVersion: 'dev',
       })
     );
@@ -811,7 +811,7 @@ describe('startClientNetworking', () => {
     });
     await advancePollingInterval();
 
-    expect(mockClient.connectToHost).toHaveBeenCalledWith({
+    expect(mockClient.registerAdjudicationStation).toHaveBeenCalledWith({
       machineId: '0002b',
       codeVersion: 'dev',
       status: Admin.ClientMachineStatus.Active,
@@ -870,11 +870,11 @@ describe('startClientNetworking', () => {
 
     // First poll: connect
     await advancePollingInterval();
-    expect(mockClient.connectToHost).toHaveBeenCalledTimes(1);
+    expect(mockClient.registerAdjudicationStation).toHaveBeenCalledTimes(1);
 
-    // Second poll: heartbeat via connectToHost
+    // Second poll: heartbeat via registerAdjudicationStation
     await vi.advanceTimersByTimeAsync(2000);
-    expect(mockClient.connectToHost).toHaveBeenCalledTimes(2);
+    expect(mockClient.registerAdjudicationStation).toHaveBeenCalledTimes(2);
   });
 
   test('disconnects when heartbeat fails', async () => {
@@ -883,9 +883,9 @@ describe('startClientNetworking', () => {
       { machineId: 'HOST1', address: 'http://192.168.1.10:3002' },
     ]);
     const mockClient = createMockPeerClient({
-      connectToHost: vi
+      registerAdjudicationStation: vi
         .fn()
-        .mockResolvedValueOnce({ machineId: 'HOST1', codeVersion: 'dev' })
+        .mockResolvedValueOnce(ok({ machineId: 'HOST1', codeVersion: 'dev' }))
         .mockRejectedValue(new Error('connection lost')),
     });
     vi.mocked(grout.createClient).mockReturnValue(mockClient);
@@ -908,7 +908,7 @@ describe('startClientNetworking', () => {
     const newMockClient = createMockPeerClient();
     vi.mocked(grout.createClient).mockReturnValue(newMockClient);
     await vi.advanceTimersByTimeAsync(2000);
-    expect(newMockClient.connectToHost).toHaveBeenCalled();
+    expect(newMockClient.registerAdjudicationStation).toHaveBeenCalled();
   });
 
   test('handles connection failure to new host', async () => {
@@ -917,7 +917,9 @@ describe('startClientNetworking', () => {
       { machineId: 'HOST1', address: 'http://192.168.1.10:3002' },
     ]);
     const mockClient = createMockPeerClient({
-      connectToHost: vi.fn().mockRejectedValue(new Error('connection refused')),
+      registerAdjudicationStation: vi
+        .fn()
+        .mockRejectedValue(new Error('connection refused')),
     });
     vi.mocked(grout.createClient).mockReturnValue(mockClient);
 
@@ -930,7 +932,7 @@ describe('startClientNetworking', () => {
     });
     await advancePollingInterval();
 
-    expect(mockClient.connectToHost).toHaveBeenCalled();
+    expect(mockClient.registerAdjudicationStation).toHaveBeenCalled();
   });
 
   test('clears connected host when host disappears', async () => {
@@ -951,7 +953,7 @@ describe('startClientNetworking', () => {
       logger,
     });
     await advancePollingInterval();
-    expect(mockClient.connectToHost).toHaveBeenCalledTimes(1);
+    expect(mockClient.registerAdjudicationStation).toHaveBeenCalledTimes(1);
 
     // Second poll: host gone
     vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([]);
@@ -962,7 +964,7 @@ describe('startClientNetworking', () => {
       { machineId: 'HOST1', address: 'http://192.168.1.10:3002' },
     ]);
     await vi.advanceTimersByTimeAsync(2000);
-    expect(mockClient.connectToHost).toHaveBeenCalledTimes(2);
+    expect(mockClient.registerAdjudicationStation).toHaveBeenCalledTimes(2);
   });
 
   test('logs when client adjudication is enabled by host', async () => {
@@ -970,13 +972,15 @@ describe('startClientNetworking', () => {
     vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([
       { machineId: 'HOST1', address: 'http://192.168.1.10:3002' },
     ]);
-    const mockConnectToHost = vi.fn().mockResolvedValue({
-      machineId: 'HOST1',
-      codeVersion: 'dev',
-      isClientAdjudicationEnabled: false,
-    });
+    const mockRegisterAdjudicationStation = vi.fn().mockResolvedValue(
+      ok({
+        machineId: 'HOST1',
+        codeVersion: 'dev',
+        isClientAdjudicationEnabled: false,
+      })
+    );
     const mockClient = createMockPeerClient({
-      connectToHost: mockConnectToHost,
+      registerAdjudicationStation: mockRegisterAdjudicationStation,
     });
     vi.mocked(grout.createClient).mockReturnValue(mockClient);
 
@@ -994,11 +998,13 @@ describe('startClientNetworking', () => {
     expect(clientStore.getIsClientAdjudicationEnabled()).toEqual(false);
 
     // Host enables adjudication
-    mockConnectToHost.mockResolvedValue({
-      machineId: 'HOST1',
-      codeVersion: 'dev',
-      isClientAdjudicationEnabled: true,
-    });
+    mockRegisterAdjudicationStation.mockResolvedValue(
+      ok({
+        machineId: 'HOST1',
+        codeVersion: 'dev',
+        isClientAdjudicationEnabled: true,
+      })
+    );
     await vi.advanceTimersByTimeAsync(2000);
     expect(clientStore.getIsClientAdjudicationEnabled()).toEqual(true);
 
@@ -1011,11 +1017,13 @@ describe('startClientNetworking', () => {
     );
 
     // Host disables adjudication
-    mockConnectToHost.mockResolvedValue({
-      machineId: 'HOST1',
-      codeVersion: 'dev',
-      isClientAdjudicationEnabled: false,
-    });
+    mockRegisterAdjudicationStation.mockResolvedValue(
+      ok({
+        machineId: 'HOST1',
+        codeVersion: 'dev',
+        isClientAdjudicationEnabled: false,
+      })
+    );
     await vi.advanceTimersByTimeAsync(2000);
     expect(clientStore.getIsClientAdjudicationEnabled()).toEqual(false);
 

--- a/apps/admin/backend/src/networking.ts
+++ b/apps/admin/backend/src/networking.ts
@@ -338,17 +338,18 @@ export function startClientNetworking({
             constructAuthMachineState(clientStore)
           );
           const { status, authType } = getClientMachineStatus(authStatus);
-          const hostConfig = await apiClient.connectToHost({
+          const registerResult = await apiClient.registerAdjudicationStation({
             machineId,
             codeVersion,
             status,
             authType,
           });
-          if (codeVersion !== hostConfig.codeVersion) {
+          if (registerResult.isErr()) {
+            const errorType = registerResult.err().type;
+            assert(errorType === 'code-version-mismatch');
             debug(
-              'Host at %s runs incompatible code version %s (client is %s), refusing to connect',
+              'Host at %s refused registration: incompatible code version (client is %s)',
               hostAddress,
-              hostConfig.codeVersion,
               codeVersion
             );
             logStatusTransition(
@@ -356,17 +357,14 @@ export function startClientNetworking({
                 connectionStatus:
                   ClientConnectionStatus.OnlineIncompatibleHostVersion,
               },
-              {
-                hostMachineId: hostConfig.machineId,
-                hostCodeVersion: hostConfig.codeVersion,
-                clientCodeVersion: codeVersion,
-              }
+              { clientCodeVersion: codeVersion }
             );
             clientStore.setConnection(
               ClientConnectionStatus.OnlineIncompatibleHostVersion
             );
             return;
           }
+          const hostConfig = registerResult.ok();
           logStatusTransition(
             {
               connectionStatus: ClientConnectionStatus.OnlineConnectedToHost,

--- a/apps/admin/backend/src/networking.ts
+++ b/apps/admin/backend/src/networking.ts
@@ -117,7 +117,7 @@ export function startHostNetworking({
         const isOnline = await hasOnlineInterface();
         store.setNetworkedMachineStatus(
           machineId,
-          'host',
+          'admin-host',
           isOnline
             ? Admin.ClientMachineStatus.Active
             : Admin.ClientMachineStatus.Offline
@@ -138,7 +138,7 @@ export function startHostNetworking({
             await peerClient.getCurrentElectionMetadata();
             store.setNetworkedMachineStatus(
               otherHost.machineId,
-              'host',
+              'admin-host',
               Admin.ClientMachineStatus.Active
             );
           } catch {

--- a/apps/admin/backend/src/networking.ts
+++ b/apps/admin/backend/src/networking.ts
@@ -4,6 +4,8 @@ import {
   findAllVxAdminHostMachines,
   getVxAdminServiceName,
   hasOnlineInterface,
+  NETWORK_POLLING_INTERVAL_MS,
+  NETWORK_REQUEST_TIMEOUT_MS,
 } from '@votingworks/networking';
 import { assert, deepEqual } from '@votingworks/basics';
 import { DippedSmartCardAuthApi } from '@votingworks/auth';
@@ -21,10 +23,6 @@ import { ClientConnectionStatus } from './types.js';
 import { getMachineConfig } from './machine_config.js';
 import { constructAuthMachineState } from './util/auth.js';
 import { rootDebug } from './util/debug.js';
-import {
-  NETWORK_POLLING_INTERVAL_MS,
-  NETWORK_REQUEST_TIMEOUT_MS,
-} from './globals.js';
 
 const debug = rootDebug.extend('networking');
 

--- a/apps/admin/backend/src/peer_app.test.ts
+++ b/apps/admin/backend/src/peer_app.test.ts
@@ -10,7 +10,7 @@ import {
   electionTwoPartyPrimaryFixtures,
   readElectionGeneralDefinition,
 } from '@votingworks/fixtures';
-import { assertDefined, err, range } from '@votingworks/basics';
+import { assertDefined, err, ok, range } from '@votingworks/basics';
 import { LogEventId } from '@votingworks/logging';
 import type { Result } from '@votingworks/basics';
 import { buildTestEnvironment, configureMachine } from '../test/app.js';
@@ -218,6 +218,99 @@ test('connectToHost updates store when client status changes', async () => {
     status: Admin.ClientMachineStatus.Active,
     authType: 'election_manager',
   });
+});
+
+test('registerScanner records the scanner and returns the host machine config', async () => {
+  const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
+  const electionDefinition = readElectionGeneralDefinition();
+  await configureMachine(apiClient, auth, electionDefinition);
+  expect(
+    await peerApiClient.registerScanner({
+      machineId: 'SCANNER-01',
+      codeVersion: 'dev',
+      ballotHash: electionDefinition.ballotHash,
+    })
+  ).toEqual(
+    ok({
+      machineId: DEV_MACHINE_ID,
+      codeVersion: 'dev',
+    })
+  );
+  expect(workspace.store.getMachines()).toEqual([
+    expect.objectContaining({
+      machineId: 'SCANNER-01',
+      machineMode: 'scanner',
+      status: Admin.ClientMachineStatus.Active,
+    }),
+  ]);
+});
+
+test('registerScanner does not record a scanner configured for a different election', async () => {
+  const { peerApiClient, apiClient, auth, peerLogger, workspace } =
+    buildTestEnvironment();
+  await configureMachine(apiClient, auth, readElectionGeneralDefinition());
+  expect(
+    await peerApiClient.registerScanner({
+      machineId: 'SCANNER-01',
+      codeVersion: 'dev',
+      ballotHash: 'some-other-ballot-hash',
+    })
+  ).toEqual(err({ type: 'ballot-hash-mismatch' }));
+  expect(workspace.store.getMachines()).toEqual([]);
+  expect(peerLogger.log).toHaveBeenCalledWith(
+    LogEventId.AdminNetworkStatus,
+    'system',
+    expect.objectContaining({
+      disposition: 'failure',
+      scannerMachineId: 'SCANNER-01',
+      scannerBallotHash: 'some-other-ballot-hash',
+    })
+  );
+});
+
+test('registerScanner does not record an unconfigured scanner', async () => {
+  const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
+  await configureMachine(apiClient, auth, readElectionGeneralDefinition());
+  expect(
+    await peerApiClient.registerScanner({
+      machineId: 'SCANNER-01',
+      codeVersion: 'dev',
+    })
+  ).toEqual(err({ type: 'scanner-unconfigured' }));
+  expect(workspace.store.getMachines()).toEqual([]);
+});
+
+test('registerScanner does not record a scanner when the host is unconfigured', async () => {
+  const { peerApiClient, workspace } = buildTestEnvironment();
+  expect(
+    await peerApiClient.registerScanner({
+      machineId: 'SCANNER-01',
+      codeVersion: 'dev',
+      ballotHash: readElectionGeneralDefinition().ballotHash,
+    })
+  ).toEqual(err({ type: 'host-unconfigured' }));
+  expect(workspace.store.getMachines()).toEqual([]);
+});
+
+test('registerScanner does not record a scanner running an incompatible code version', async () => {
+  const { peerApiClient, peerLogger, workspace } = buildTestEnvironment();
+  expect(
+    await peerApiClient.registerScanner({
+      machineId: 'SCANNER-01',
+      codeVersion: 'some-other-version',
+    })
+  ).toEqual(err({ type: 'code-version-mismatch' }));
+  expect(workspace.store.getMachines()).toEqual([]);
+  expect(peerLogger.log).toHaveBeenCalledWith(
+    LogEventId.AdminNetworkStatus,
+    'system',
+    expect.objectContaining({
+      disposition: 'failure',
+      scannerMachineId: 'SCANNER-01',
+      scannerCodeVersion: 'some-other-version',
+      hostCodeVersion: 'dev',
+    })
+  );
 });
 
 test('getCurrentElectionMetadata returns null when no election configured', async () => {

--- a/apps/admin/backend/src/peer_app.test.ts
+++ b/apps/admin/backend/src/peer_app.test.ts
@@ -62,7 +62,7 @@ test('registerAdjudicationStation registers client and returns host machine conf
   expect(machines).toHaveLength(1);
   expect(machines[0]).toMatchObject({
     machineId: 'client-001',
-    machineMode: 'client',
+    machineRole: 'admin-client',
     status: Admin.ClientMachineStatus.OnlineLocked,
     authType: null,
   });
@@ -249,7 +249,7 @@ test('registerScanner records the scanner and returns the host machine config', 
   expect(workspace.store.getMachines()).toEqual([
     expect.objectContaining({
       machineId: 'SCANNER-01',
-      machineMode: 'scanner',
+      machineRole: 'scanner',
       status: Admin.ClientMachineStatus.Active,
     }),
   ]);
@@ -804,7 +804,7 @@ test('adjudication endpoints reject requests when multiple hosts are detected', 
   // A second host appears on the network
   workspace.store.setNetworkedMachineStatus(
     'other-host',
-    'host',
+    'admin-host',
     Admin.ClientMachineStatus.Active
   );
 
@@ -833,7 +833,7 @@ test('adjudication endpoints reject requests when multiple hosts are detected', 
   // Once the other host goes offline, adjudication operations resume
   workspace.store.setNetworkedMachineStatus(
     'other-host',
-    'host',
+    'admin-host',
     Admin.ClientMachineStatus.Offline
   );
   await peerApiClient.releaseBallot({ machineId: 'client-001', cvrId });

--- a/apps/admin/backend/src/peer_app.test.ts
+++ b/apps/admin/backend/src/peer_app.test.ts
@@ -42,19 +42,21 @@ beforeEach(() => {
   vi.mocked(getCurrentTime).mockImplementation(() => Date.now());
 });
 
-test('connectToHost registers client and returns host machine config with adjudication status', async () => {
+test('registerAdjudicationStation registers client and returns host machine config with adjudication status', async () => {
   const { peerApiClient, workspace } = buildTestEnvironment();
-  const result = await peerApiClient.connectToHost({
+  const result = await peerApiClient.registerAdjudicationStation({
     machineId: 'client-001',
     codeVersion: 'dev',
     status: Admin.ClientMachineStatus.OnlineLocked,
     authType: null,
   });
-  expect(result).toEqual({
-    machineId: DEV_MACHINE_ID,
-    codeVersion: 'dev',
-    isClientAdjudicationEnabled: false,
-  });
+  expect(result).toEqual(
+    ok({
+      machineId: DEV_MACHINE_ID,
+      codeVersion: 'dev',
+      isClientAdjudicationEnabled: false,
+    })
+  );
 
   const machines = workspace.store.getMachines();
   expect(machines).toHaveLength(1);
@@ -66,40 +68,34 @@ test('connectToHost registers client and returns host machine config with adjudi
   });
 });
 
-test('connectToHost rejects a client running an incompatible code version', async () => {
+test('registerAdjudicationStation rejects a client running an incompatible code version', async () => {
   const { peerApiClient, workspace } = buildTestEnvironment();
   workspace.store.setIsClientAdjudicationEnabled(true);
 
-  const result = await peerApiClient.connectToHost({
+  const result = await peerApiClient.registerAdjudicationStation({
     machineId: 'client-001',
     codeVersion: 'an-incompatible-version',
     status: Admin.ClientMachineStatus.Active,
     authType: 'election_manager',
   });
 
-  // Host reports its own version and never enables adjudication for an
-  // incompatible client.
-  expect(result).toEqual({
-    machineId: DEV_MACHINE_ID,
-    codeVersion: 'dev',
-    isClientAdjudicationEnabled: false,
-  });
+  expect(result).toEqual(err({ type: 'code-version-mismatch' }));
 
   // The incompatible client must not be registered as a connected machine.
   expect(workspace.store.getMachines()).toHaveLength(0);
 });
 
-test('connectToHost persists status and authType and returns adjudication enabled', async () => {
+test('registerAdjudicationStation persists status and authType and returns adjudication enabled', async () => {
   const { peerApiClient, workspace } = buildTestEnvironment();
 
   workspace.store.setIsClientAdjudicationEnabled(true);
-  const result = await peerApiClient.connectToHost({
+  const result = await peerApiClient.registerAdjudicationStation({
     machineId: 'client-001',
     codeVersion: 'dev',
     status: Admin.ClientMachineStatus.Active,
     authType: 'election_manager',
   });
-  expect(result.isClientAdjudicationEnabled).toEqual(true);
+  expect(result.unsafeUnwrap().isClientAdjudicationEnabled).toEqual(true);
 
   const machines = workspace.store.getMachines();
   expect(machines[0]).toMatchObject({
@@ -109,7 +105,7 @@ test('connectToHost persists status and authType and returns adjudication enable
   });
 });
 
-test("connectToHost releases the client's claims when it transitions to OnlineLocked", async () => {
+test("registerAdjudicationStation releases the client's claims when it transitions to OnlineLocked", async () => {
   const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
   const electionDefinition =
     electionTwoPartyPrimaryFixtures.readElectionDefinition();
@@ -122,30 +118,34 @@ test("connectToHost releases the client's claims when it transitions to OnlineLo
   workspace.store.setIsClientAdjudicationEnabled(true);
 
   // Client logs in (Active) and claims a ballot.
-  await peerApiClient.connectToHost({
-    machineId: 'client-001',
-    codeVersion: 'dev',
-    status: Admin.ClientMachineStatus.Active,
-    authType: 'election_manager',
-  });
+  (
+    await peerApiClient.registerAdjudicationStation({
+      machineId: 'client-001',
+      codeVersion: 'dev',
+      status: Admin.ClientMachineStatus.Active,
+      authType: 'election_manager',
+    })
+  ).unsafeUnwrap();
   const cvrId = assertDefined(
     await claimBallot(peerApiClient, { machineId: 'client-001' })
   );
 
   // Client transitions to OnlineLocked (logout / session expiry).
-  await peerApiClient.connectToHost({
-    machineId: 'client-001',
-    codeVersion: 'dev',
-    status: Admin.ClientMachineStatus.OnlineLocked,
-    authType: null,
-  });
+  (
+    await peerApiClient.registerAdjudicationStation({
+      machineId: 'client-001',
+      codeVersion: 'dev',
+      status: Admin.ClientMachineStatus.OnlineLocked,
+      authType: null,
+    })
+  ).unsafeUnwrap();
 
   // The claim should be released — another machine can now pick it up.
   const result = await claimBallot(peerApiClient, { machineId: 'client-002' });
   expect(result).toEqual(cvrId);
 });
 
-test('connectToHost does not release claims when status stays Active or transitions Active→Adjudicating', async () => {
+test('registerAdjudicationStation does not release claims when status stays Active or transitions Active→Adjudicating', async () => {
   const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
   const electionDefinition =
     electionTwoPartyPrimaryFixtures.readElectionDefinition();
@@ -157,63 +157,73 @@ test('connectToHost does not release claims when status stays Active or transiti
   addTestCvrs(workspace.store, electionId, 1);
   workspace.store.setIsClientAdjudicationEnabled(true);
 
-  await peerApiClient.connectToHost({
-    machineId: 'client-001',
-    codeVersion: 'dev',
-    status: Admin.ClientMachineStatus.Active,
-    authType: 'election_manager',
-  });
+  (
+    await peerApiClient.registerAdjudicationStation({
+      machineId: 'client-001',
+      codeVersion: 'dev',
+      status: Admin.ClientMachineStatus.Active,
+      authType: 'election_manager',
+    })
+  ).unsafeUnwrap();
   const cvrId = assertDefined(
     await claimBallot(peerApiClient, { machineId: 'client-001' })
   );
 
   // Repeated heartbeats with the same Active status should not release.
-  await peerApiClient.connectToHost({
-    machineId: 'client-001',
-    codeVersion: 'dev',
-    status: Admin.ClientMachineStatus.Active,
-    authType: 'election_manager',
-  });
+  (
+    await peerApiClient.registerAdjudicationStation({
+      machineId: 'client-001',
+      codeVersion: 'dev',
+      status: Admin.ClientMachineStatus.Active,
+      authType: 'election_manager',
+    })
+  ).unsafeUnwrap();
   // Another machine still cannot claim it.
   expect(
     await claimBallot(peerApiClient, { machineId: 'client-002' })
   ).toBeUndefined();
 
   // Active → Adjudicating must not release either.
-  await peerApiClient.connectToHost({
-    machineId: 'client-001',
-    codeVersion: 'dev',
-    status: Admin.ClientMachineStatus.Adjudicating,
-    authType: 'election_manager',
-  });
+  (
+    await peerApiClient.registerAdjudicationStation({
+      machineId: 'client-001',
+      codeVersion: 'dev',
+      status: Admin.ClientMachineStatus.Adjudicating,
+      authType: 'election_manager',
+    })
+  ).unsafeUnwrap();
   expect(
     await claimBallot(peerApiClient, { machineId: 'client-002' })
   ).toBeUndefined();
   expect(cvrId).toBeDefined();
 });
 
-test('connectToHost updates store when client status changes', async () => {
+test('registerAdjudicationStation updates store when client status changes', async () => {
   const { peerApiClient, workspace } = buildTestEnvironment();
 
   // First call: new client
-  await peerApiClient.connectToHost({
-    machineId: 'client-002',
-    codeVersion: 'dev',
-    status: Admin.ClientMachineStatus.OnlineLocked,
-    authType: null,
-  });
+  (
+    await peerApiClient.registerAdjudicationStation({
+      machineId: 'client-002',
+      codeVersion: 'dev',
+      status: Admin.ClientMachineStatus.OnlineLocked,
+      authType: null,
+    })
+  ).unsafeUnwrap();
   expect(workspace.store.getMachine('client-002')).toMatchObject({
     status: Admin.ClientMachineStatus.OnlineLocked,
     authType: null,
   });
 
   // Second call: status changes
-  await peerApiClient.connectToHost({
-    machineId: 'client-002',
-    codeVersion: 'dev',
-    status: Admin.ClientMachineStatus.Active,
-    authType: 'election_manager',
-  });
+  (
+    await peerApiClient.registerAdjudicationStation({
+      machineId: 'client-002',
+      codeVersion: 'dev',
+      status: Admin.ClientMachineStatus.Active,
+      authType: 'election_manager',
+    })
+  ).unsafeUnwrap();
   expect(workspace.store.getMachine('client-002')).toMatchObject({
     status: Admin.ClientMachineStatus.Active,
     authType: 'election_manager',

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -27,6 +27,7 @@ import {
   AdjudicationError,
   ElectionRecord,
   MachineConfig,
+  RegisterAdjudicationStationError,
   AdjudicatedCvr,
   BallotAdjudicationData,
   BallotImages,
@@ -136,23 +137,27 @@ function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
       return ok(machineConfig);
     },
 
-    connectToHost(input: {
+    registerAdjudicationStation(input: {
       machineId: string;
       codeVersion: string;
       status: Admin.ClientMachineStatus;
       authType: UserRole | null;
-    }): MachineConfig & { isClientAdjudicationEnabled: boolean } {
+    }): Result<
+      MachineConfig & { isClientAdjudicationEnabled: boolean },
+      RegisterAdjudicationStationError
+    > {
       const machineConfig = getMachineConfig();
-      // Refuse to register a client running a different code version.
+      // Refuse to register an adjudication station running a different code
+      // version.
       if (input.codeVersion !== machineConfig.codeVersion) {
         logger.log(LogEventId.AdminNetworkStatus, 'system', {
-          message: `Rejected connection from client ${input.machineId}: incompatible software version (client ${input.codeVersion}, host ${machineConfig.codeVersion}).`,
+          message: `Rejected registration from adjudication station ${input.machineId}: incompatible software version (station ${input.codeVersion}, host ${machineConfig.codeVersion}).`,
           disposition: 'failure',
           clientMachineId: input.machineId,
           clientCodeVersion: input.codeVersion,
           hostCodeVersion: machineConfig.codeVersion,
         });
-        return { ...machineConfig, isClientAdjudicationEnabled: false };
+        return err({ type: 'code-version-mismatch' });
       }
       debug(
         'Client %s connected to host (election: %s, status: %s)',
@@ -197,10 +202,10 @@ function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
         input.status,
         input.authType
       );
-      return {
+      return ok({
         ...machineConfig,
         isClientAdjudicationEnabled: store.getIsClientAdjudicationEnabled(),
-      };
+      });
     },
 
     getElectionPackageHash(): Optional<string> {

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -17,6 +17,10 @@ import {
   type UserRole,
 } from '@votingworks/types';
 import { BaseLogger, LogEventId } from '@votingworks/logging';
+import type {
+  RegisterScannerError,
+  VxAdminHostApi,
+} from '@votingworks/networking';
 import { getMachineConfig } from './machine_config.js';
 import { Workspace } from './util/workspace.js';
 import {
@@ -60,7 +64,78 @@ function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
     );
   }
 
-  return grout.createApi({
+  const api = grout.createApi({
+    registerScanner(input: {
+      machineId: string;
+      codeVersion: string;
+      ballotHash?: string;
+    }): Result<MachineConfig, RegisterScannerError> {
+      const machineConfig = getMachineConfig();
+
+      function reject(
+        error: RegisterScannerError,
+        details: string,
+        extra: Record<string, string> = {}
+      ): Result<MachineConfig, RegisterScannerError> {
+        logger.log(LogEventId.AdminNetworkStatus, 'system', {
+          message: `Rejected registration from scanner ${input.machineId}: ${details}`,
+          disposition: 'failure',
+          scannerMachineId: input.machineId,
+          error: error.type,
+          ...extra,
+        });
+        return err(error);
+      }
+
+      // Refuse to register a scanner running a different code version.
+      if (input.codeVersion !== machineConfig.codeVersion) {
+        return reject(
+          { type: 'code-version-mismatch' },
+          `incompatible software version (scanner ${input.codeVersion}, host ${machineConfig.codeVersion}).`,
+          {
+            scannerCodeVersion: input.codeVersion,
+            hostCodeVersion: machineConfig.codeVersion,
+          }
+        );
+      }
+      // Refuse to register a scanner that isn't configured for the same
+      // election as this host.
+      if (input.ballotHash === undefined) {
+        return reject(
+          { type: 'scanner-unconfigured' },
+          'the scanner is not configured with an election.'
+        );
+      }
+      const currentElectionId = store.getCurrentElectionId();
+      const hostBallotHash = currentElectionId
+        ? assertDefined(store.getElection(currentElectionId)).electionDefinition
+            .ballotHash
+        : undefined;
+      if (hostBallotHash === undefined) {
+        return reject(
+          { type: 'host-unconfigured' },
+          'this host is not configured with an election.'
+        );
+      }
+      if (input.ballotHash !== hostBallotHash) {
+        return reject(
+          { type: 'ballot-hash-mismatch' },
+          `configured for a different election (scanner ${input.ballotHash}, host ${hostBallotHash}).`,
+          {
+            scannerBallotHash: input.ballotHash,
+            hostBallotHash,
+          }
+        );
+      }
+      debug('Scanner %s registered with host', input.machineId);
+      store.setNetworkedMachineStatus(
+        input.machineId,
+        'scanner',
+        Admin.ClientMachineStatus.Active
+      );
+      return ok(machineConfig);
+    },
+
     connectToHost(input: {
       machineId: string;
       codeVersion: string;
@@ -253,6 +328,11 @@ function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
       return ok();
     },
   });
+
+  // The peer API implements the scanner-facing contract shared in
+  // libs/networking; this fails to compile if the two drift apart. Methods
+  // may return richer types than the contract requires.
+  return api satisfies VxAdminHostApi;
 }
 
 /**

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -198,7 +198,7 @@ function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
       }
       store.setNetworkedMachineStatus(
         input.machineId,
-        'client',
+        'admin-client',
         input.status,
         input.authType
       );

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -1084,7 +1084,7 @@ describe('machine ballot adjudication assignments', () => {
 
     store.setNetworkedMachineStatus(
       'client-001',
-      'client',
+      'admin-client',
       Admin.ClientMachineStatus.Active
     );
     const claimed = claimNextForClient('client-001');
@@ -1104,12 +1104,12 @@ describe('machine ballot adjudication assignments', () => {
 
     store.setNetworkedMachineStatus(
       'client-001',
-      'client',
+      'admin-client',
       Admin.ClientMachineStatus.Active
     );
     store.setNetworkedMachineStatus(
       'client-002',
-      'client',
+      'admin-client',
       Admin.ClientMachineStatus.Active
     );
     const staleClaim = claimNextForClient('client-001');
@@ -1121,7 +1121,7 @@ describe('machine ballot adjudication assignments', () => {
     // client-002 heartbeats again, so only client-001 is stale
     store.setNetworkedMachineStatus(
       'client-002',
-      'client',
+      'admin-client',
       Admin.ClientMachineStatus.Active
     );
     store.cleanupStaleMachines();
@@ -1205,12 +1205,12 @@ describe('machine ballot adjudication assignments', () => {
 
     store.setNetworkedMachineStatus(
       'client-001',
-      'client',
+      'admin-client',
       Admin.ClientMachineStatus.Active
     );
     store.setNetworkedMachineStatus(
       'client-002',
-      'client',
+      'admin-client',
       Admin.ClientMachineStatus.Active
     );
 

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -102,7 +102,7 @@ import {
   WriteInForTally,
   BaseStore,
   MachineRecord,
-  MachineMode,
+  NetworkedMachineRole,
   BallotAdjudicationQueueMetadata,
   BallotAdjudicationData,
   ContestAdjudicationData,
@@ -3377,7 +3377,7 @@ export class Store implements BaseStore {
 
   setNetworkedMachineStatus(
     machineId: string,
-    machineMode: MachineMode,
+    machineMode: NetworkedMachineRole,
     status: Admin.ClientMachineStatus,
     authType: UserRole | null = null
   ): void {

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -3377,20 +3377,20 @@ export class Store implements BaseStore {
 
   setNetworkedMachineStatus(
     machineId: string,
-    machineMode: NetworkedMachineRole,
+    machineRole: NetworkedMachineRole,
     status: Admin.ClientMachineStatus,
     authType: UserRole | null = null
   ): void {
     this.client.run(
-      `insert into machines (machine_id, machine_mode, status, auth_type, last_seen_at)
+      `insert into machines (machine_id, machine_role, status, auth_type, last_seen_at)
        values (?, ?, ?, ?, ?)
        on conflict (machine_id) do update set
-         machine_mode = excluded.machine_mode,
+         machine_role = excluded.machine_role,
          status = excluded.status,
          auth_type = excluded.auth_type,
          last_seen_at = excluded.last_seen_at`,
       machineId,
-      machineMode,
+      machineRole,
       status,
       authType,
       getCurrentTime()
@@ -3401,7 +3401,7 @@ export class Store implements BaseStore {
     return this.client.one(
       `select
          machine_id as machineId,
-         machine_mode as machineMode,
+         machine_role as machineRole,
          status,
          auth_type as authType,
          last_seen_at as lastSeenAt
@@ -3415,7 +3415,7 @@ export class Store implements BaseStore {
     return this.client.all(
       `select
          machine_id as machineId,
-         machine_mode as machineMode,
+         machine_role as machineRole,
          case
            when status = ? and exists (
              select 1 from machine_ballot_adjudication_assignments
@@ -3488,7 +3488,7 @@ export class Store implements BaseStore {
   getMultipleHostsDetected(selfMachineId: string): boolean {
     const count = this.client.one(
       `select count(*) as cnt from machines
-       where machine_mode = 'host' and status != ? and machine_id != ?`,
+       where machine_role = 'admin-host' and status != ? and machine_id != ?`,
       Admin.ClientMachineStatus.Offline,
       selfMachineId
     ) as { cnt: number };

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -45,6 +45,11 @@ export interface BaseStore {
   getSystemSettings(electionId: Id): SystemSettings | undefined;
 }
 
+/** Why a VxAdmin host refused to register an adjudication station. */
+export interface RegisterAdjudicationStationError {
+  type: 'code-version-mismatch';
+}
+
 /** Connection status for a client machine in a multi-station setup. */
 export enum ClientConnectionStatus {
   Offline = 'offline',

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -32,6 +32,12 @@ export type { ExportDataResult, ExportDataError } from '@votingworks/backend';
  */
 export type MachineMode = 'host' | 'client';
 
+/**
+ * The role a machine plays on the network: a VxAdmin host or client, or a
+ * networked central scanner.
+ */
+export type NetworkedMachineRole = MachineMode | 'scanner';
+
 /** Shared interface for stores that support auth state construction. */
 export interface BaseStore {
   getCurrentElectionId(): Id | undefined;
@@ -51,7 +57,7 @@ export enum ClientConnectionStatus {
 /** A record of a machine in the multi-station machines table. */
 export interface MachineRecord {
   machineId: string;
-  machineMode: MachineMode;
+  machineMode: NetworkedMachineRole;
   status: Admin.ClientMachineStatus;
   authType: UserRole | null;
   lastSeenAt: number;

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -36,7 +36,7 @@ export type MachineMode = 'host' | 'client';
  * The role a machine plays on the network: a VxAdmin host or client, or a
  * networked central scanner.
  */
-export type NetworkedMachineRole = MachineMode | 'scanner';
+export type NetworkedMachineRole = 'admin-host' | 'admin-client' | 'scanner';
 
 /** Shared interface for stores that support auth state construction. */
 export interface BaseStore {
@@ -62,7 +62,7 @@ export enum ClientConnectionStatus {
 /** A record of a machine in the multi-station machines table. */
 export interface MachineRecord {
   machineId: string;
-  machineMode: NetworkedMachineRole;
+  machineRole: NetworkedMachineRole;
   status: Admin.ClientMachineStatus;
   authType: UserRole | null;
   lastSeenAt: number;

--- a/apps/admin/frontend/src/screens/adjudication_start_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/adjudication_start_screen.test.tsx
@@ -204,28 +204,28 @@ describe('multi-station adjudication', () => {
     const connectedClients: MachineRecord[] = [
       typedAs<MachineRecord>({
         machineId: 'CLIENT-001',
-        machineMode: 'client',
+        machineRole: 'admin-client',
         status: Admin.ClientMachineStatus.Active,
         authType: 'election_manager',
         lastSeenAt: Date.now(),
       }),
       typedAs<MachineRecord>({
         machineId: 'CLIENT-002',
-        machineMode: 'client',
+        machineRole: 'admin-client',
         status: Admin.ClientMachineStatus.OnlineLocked,
         authType: null,
         lastSeenAt: Date.now(),
       }),
       typedAs<MachineRecord>({
         machineId: 'CLIENT-003',
-        machineMode: 'client',
+        machineRole: 'admin-client',
         status: Admin.ClientMachineStatus.Offline,
         authType: null,
         lastSeenAt: Date.now() - 60000,
       }),
       typedAs<MachineRecord>({
         machineId: 'CLIENT-004',
-        machineMode: 'client',
+        machineRole: 'admin-client',
         status: Admin.ClientMachineStatus.Adjudicating,
         authType: 'election_manager',
         lastSeenAt: Date.now(),

--- a/apps/central-scan/backend/src/globals.ts
+++ b/apps/central-scan/backend/src/globals.ts
@@ -30,8 +30,3 @@ export const SCAN_WORKSPACE =
   (NODE_ENV === 'development'
     ? join(import.meta.dirname, '../dev-workspace')
     : undefined);
-
-/**
- * How often to poll the network for a VxAdmin host.
- */
-export const NETWORK_POLLING_INTERVAL_MS = 2000;

--- a/apps/central-scan/backend/src/networking.test.ts
+++ b/apps/central-scan/backend/src/networking.test.ts
@@ -247,7 +247,7 @@ test('reports ballot-hash-mismatch when the host is configured for a different e
   });
 });
 
-test('reports host-detected and reuses the API client when everything matches', async () => {
+test('reports host-detected when everything matches', async () => {
   vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([HOST_MACHINE]);
   const mockClient = createMockHostApiClient();
   const store = Store.memoryStore();
@@ -263,10 +263,6 @@ test('reports host-detected and reuses the API client when everything matches', 
     codeVersion: 'dev',
     ballotHash: readElectionGeneralDefinition().ballotHash,
   });
-
-  // A second poll of the same host reuses the same API client
-  await advancePollingInterval();
-  expect(grout.createClient).toHaveBeenCalledTimes(1);
 });
 
 test('logs status transitions and returns to offline when the interface goes down', async () => {

--- a/apps/central-scan/backend/src/networking.test.ts
+++ b/apps/central-scan/backend/src/networking.test.ts
@@ -1,10 +1,19 @@
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, Mock, test, vi } from 'vitest';
+import { err, ok } from '@votingworks/basics';
+import * as grout from '@votingworks/grout';
 import {
   findAllVxAdminHostMachines,
   hasOnlineInterface,
   NETWORK_POLLING_INTERVAL_MS,
+  VxAdminHostMachine,
 } from '@votingworks/networking';
 import { mockBaseLogger } from '@votingworks/logging';
+import { readElectionGeneralDefinition } from '@votingworks/fixtures';
+import {
+  DEV_MACHINE_ID,
+  ElectionDefinition,
+  TEST_JURISDICTION,
+} from '@votingworks/types';
 import { startScannerNetworking } from './networking.js';
 import { Store } from './store.js';
 
@@ -13,9 +22,53 @@ vi.mock(import('@votingworks/networking'), async (importActual) => ({
   hasOnlineInterface: vi.fn(),
   findAllVxAdminHostMachines: vi.fn(),
 }));
+vi.mock('@votingworks/grout');
+
+const HOST_MACHINE: VxAdminHostMachine = {
+  machineId: '0002',
+  address: 'http://192.168.1.10:3002',
+};
+
+// A type literal (not an interface) so it's assignable to grout's
+// index-signature-based Client type.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type MockHostApiClient = {
+  registerScanner: Mock;
+  getCurrentElectionMetadata: Mock;
+};
+
+function buildMockHostApiClient(): MockHostApiClient {
+  return {
+    registerScanner: vi.fn().mockResolvedValue(
+      ok({
+        machineId: HOST_MACHINE.machineId,
+        codeVersion: 'dev',
+      })
+    ),
+    getCurrentElectionMetadata: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockHostApiClient(): MockHostApiClient {
+  const mockClient = buildMockHostApiClient();
+  vi.mocked(grout.createClient).mockReturnValue(mockClient);
+  return mockClient;
+}
+
+function configureStore(
+  store: Store,
+  electionDefinition: ElectionDefinition
+): void {
+  store.setElectionAndJurisdiction({
+    electionData: electionDefinition.electionData,
+    jurisdiction: TEST_JURISDICTION,
+    electionPackageHash: 'test-election-package-hash',
+  });
+}
 
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: false });
+  vi.mocked(hasOnlineInterface).mockResolvedValue(true);
   vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([]);
 });
 
@@ -50,8 +103,6 @@ test('reports offline when no network interface is online', async () => {
 });
 
 test('reports waiting-for-host when online but no VxAdmin is advertised', async () => {
-  vi.mocked(hasOnlineInterface).mockResolvedValue(true);
-  vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([]);
   const store = Store.memoryStore();
   startScannerNetworking({ logger: mockBaseLogger({ fn: vi.fn }), store });
   await advancePollingInterval();
@@ -60,27 +111,170 @@ test('reports waiting-for-host when online but no VxAdmin is advertised', async 
   });
 });
 
-test('reports host-detected with the host machine ID', async () => {
-  vi.mocked(hasOnlineInterface).mockResolvedValue(true);
+test('reports multiple-hosts-detected when more than one advertised VxAdmin is reachable', async () => {
   vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([
-    { machineId: '0002', address: 'http://192.168.1.10:3002' },
+    HOST_MACHINE,
+    { machineId: '0003', address: 'http://192.168.1.11:3002' },
   ]);
+  createMockHostApiClient();
   const store = Store.memoryStore();
+  startScannerNetworking({ logger: mockBaseLogger({ fn: vi.fn }), store });
+  await advancePollingInterval();
+  expect(store.getNetworkConnectionInfo()).toEqual({
+    status: 'online-multiple-hosts-detected',
+  });
+});
+
+test('ignores a stale advertisement and connects to the single reachable host', async () => {
+  vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([
+    // Stale advertisement from a host that is no longer reachable
+    { machineId: '0003', address: 'http://192.168.1.11:3002' },
+    HOST_MACHINE,
+  ]);
+  const staleClient = buildMockHostApiClient();
+  staleClient.getCurrentElectionMetadata.mockRejectedValue(
+    new Error('ECONNREFUSED')
+  );
+  const reachableClient = buildMockHostApiClient();
+  vi.mocked(grout.createClient).mockImplementation(({ baseUrl }) =>
+    baseUrl.startsWith(HOST_MACHINE.address) ? reachableClient : staleClient
+  );
+  const store = Store.memoryStore();
+  configureStore(store, readElectionGeneralDefinition());
   startScannerNetworking({ logger: mockBaseLogger({ fn: vi.fn }), store });
   await advancePollingInterval();
   expect(store.getNetworkConnectionInfo()).toEqual({
     status: 'online-host-detected',
     hostMachineId: '0002',
   });
+  expect(staleClient.registerScanner).not.toHaveBeenCalled();
+});
+
+test('reports waiting-for-host when no advertised VxAdmin is reachable', async () => {
+  vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([
+    HOST_MACHINE,
+    { machineId: '0003', address: 'http://192.168.1.11:3002' },
+  ]);
+  const mockClient = createMockHostApiClient();
+  mockClient.getCurrentElectionMetadata.mockRejectedValue(
+    new Error('ECONNREFUSED')
+  );
+  const store = Store.memoryStore();
+  startScannerNetworking({ logger: mockBaseLogger({ fn: vi.fn }), store });
+  await advancePollingInterval();
+  expect(store.getNetworkConnectionInfo()).toEqual({
+    status: 'online-waiting-for-host',
+  });
+});
+
+test('reports waiting-for-host when the advertised host is unreachable', async () => {
+  vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([HOST_MACHINE]);
+  const mockClient = createMockHostApiClient();
+  mockClient.registerScanner.mockRejectedValue(new Error('ECONNREFUSED'));
+  const store = Store.memoryStore();
+  startScannerNetworking({ logger: mockBaseLogger({ fn: vi.fn }), store });
+  await advancePollingInterval();
+  expect(store.getNetworkConnectionInfo()).toEqual({
+    status: 'online-waiting-for-host',
+  });
+});
+
+test('reports code-version-mismatch when the host runs a different software version', async () => {
+  vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([HOST_MACHINE]);
+  const mockClient = createMockHostApiClient();
+  mockClient.registerScanner.mockResolvedValue(
+    err({ type: 'code-version-mismatch' })
+  );
+  const store = Store.memoryStore();
+  configureStore(store, readElectionGeneralDefinition());
+  startScannerNetworking({ logger: mockBaseLogger({ fn: vi.fn }), store });
+  await advancePollingInterval();
+  expect(store.getNetworkConnectionInfo()).toEqual({
+    status: 'online-code-version-mismatch',
+    hostMachineId: '0002',
+  });
+});
+
+test('reports machine-unconfigured when this scanner has no election', async () => {
+  vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([HOST_MACHINE]);
+  const mockClient = createMockHostApiClient();
+  mockClient.registerScanner.mockResolvedValue(
+    err({ type: 'scanner-unconfigured' })
+  );
+  const store = Store.memoryStore();
+  startScannerNetworking({ logger: mockBaseLogger({ fn: vi.fn }), store });
+  await advancePollingInterval();
+  expect(store.getNetworkConnectionInfo()).toEqual({
+    status: 'online-machine-unconfigured',
+    hostMachineId: '0002',
+  });
+  expect(mockClient.registerScanner).toHaveBeenCalledWith({
+    machineId: DEV_MACHINE_ID,
+    codeVersion: 'dev',
+    ballotHash: undefined,
+  });
+});
+
+test('reports host-unconfigured when the host has no election', async () => {
+  vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([HOST_MACHINE]);
+  const mockClient = createMockHostApiClient();
+  mockClient.registerScanner.mockResolvedValue(
+    err({ type: 'host-unconfigured' })
+  );
+  const store = Store.memoryStore();
+  configureStore(store, readElectionGeneralDefinition());
+  startScannerNetworking({ logger: mockBaseLogger({ fn: vi.fn }), store });
+  await advancePollingInterval();
+  expect(store.getNetworkConnectionInfo()).toEqual({
+    status: 'online-host-unconfigured',
+    hostMachineId: '0002',
+  });
+});
+
+test('reports ballot-hash-mismatch when the host is configured for a different election', async () => {
+  vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([HOST_MACHINE]);
+  const mockClient = createMockHostApiClient();
+  mockClient.registerScanner.mockResolvedValue(
+    err({ type: 'ballot-hash-mismatch' })
+  );
+  const store = Store.memoryStore();
+  configureStore(store, readElectionGeneralDefinition());
+  startScannerNetworking({ logger: mockBaseLogger({ fn: vi.fn }), store });
+  await advancePollingInterval();
+  expect(store.getNetworkConnectionInfo()).toEqual({
+    status: 'online-ballot-hash-mismatch',
+    hostMachineId: '0002',
+  });
+});
+
+test('reports host-detected and reuses the API client when everything matches', async () => {
+  vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([HOST_MACHINE]);
+  const mockClient = createMockHostApiClient();
+  const store = Store.memoryStore();
+  configureStore(store, readElectionGeneralDefinition());
+  startScannerNetworking({ logger: mockBaseLogger({ fn: vi.fn }), store });
+  await advancePollingInterval();
+  expect(store.getNetworkConnectionInfo()).toEqual({
+    status: 'online-host-detected',
+    hostMachineId: '0002',
+  });
+  expect(mockClient.registerScanner).toHaveBeenCalledWith({
+    machineId: DEV_MACHINE_ID,
+    codeVersion: 'dev',
+    ballotHash: readElectionGeneralDefinition().ballotHash,
+  });
+
+  // A second poll of the same host reuses the same API client
+  await advancePollingInterval();
+  expect(grout.createClient).toHaveBeenCalledTimes(1);
 });
 
 test('logs status transitions and returns to offline when the interface goes down', async () => {
   const logger = mockBaseLogger({ fn: vi.fn });
-  vi.mocked(hasOnlineInterface).mockResolvedValue(true);
-  vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([
-    { machineId: '0002', address: 'http://192.168.1.10:3002' },
-  ]);
+  vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([HOST_MACHINE]);
+  createMockHostApiClient();
   const store = Store.memoryStore();
+  configureStore(store, readElectionGeneralDefinition());
   startScannerNetworking({ logger, store });
   await advancePollingInterval();
   expect(store.getNetworkConnectionInfo()).toEqual({

--- a/apps/central-scan/backend/src/networking.test.ts
+++ b/apps/central-scan/backend/src/networking.test.ts
@@ -2,10 +2,10 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import {
   findAllVxAdminHostMachines,
   hasOnlineInterface,
+  NETWORK_POLLING_INTERVAL_MS,
 } from '@votingworks/networking';
 import { mockBaseLogger } from '@votingworks/logging';
 import { startScannerNetworking } from './networking.js';
-import { NETWORK_POLLING_INTERVAL_MS } from './globals.js';
 import { Store } from './store.js';
 
 vi.mock(import('@votingworks/networking'), async (importActual) => ({

--- a/apps/central-scan/backend/src/networking.ts
+++ b/apps/central-scan/backend/src/networking.ts
@@ -67,19 +67,11 @@ export function startScannerNetworking({
     store.setNetworkConnectionInfo(newInfo);
   }
 
-  const apiClients = new Map<string, grout.Client<VxAdminHostApi>>();
-
-  function getApiClient(address: string): grout.Client<VxAdminHostApi> {
-    let apiClient = apiClients.get(address);
-    if (!apiClient) {
-      debug('Creating peer API client for %s', address);
-      apiClient = grout.createClient<VxAdminHostApi>({
-        baseUrl: `${address}/api`,
-        timeout: NETWORK_REQUEST_TIMEOUT_MS,
-      });
-      apiClients.set(address, apiClient);
-    }
-    return apiClient;
+  function createApiClient(address: string): grout.Client<VxAdminHostApi> {
+    return grout.createClient<VxAdminHostApi>({
+      baseUrl: `${address}/api`,
+      timeout: NETWORK_REQUEST_TIMEOUT_MS,
+    });
   }
 
   let isPolling = false;
@@ -114,7 +106,7 @@ export function startScannerNetworking({
           const reachableHosts: VxAdminHostMachine[] = [];
           for (const candidate of hostMachines) {
             try {
-              await getApiClient(
+              await createApiClient(
                 candidate.address
               ).getCurrentElectionMetadata();
               reachableHosts.push(candidate);
@@ -141,7 +133,7 @@ export function startScannerNetworking({
           [hostMachine] = reachableHosts;
         }
         const { machineId: hostMachineId } = hostMachine;
-        const apiClient = getApiClient(hostMachine.address);
+        const apiClient = createApiClient(hostMachine.address);
 
         const { machineId, codeVersion } = getMachineConfig();
         let registerResult;

--- a/apps/central-scan/backend/src/networking.ts
+++ b/apps/central-scan/backend/src/networking.ts
@@ -3,9 +3,9 @@ import { BaseLogger, LogEventId } from '@votingworks/logging';
 import {
   findAllVxAdminHostMachines,
   hasOnlineInterface,
+  NETWORK_POLLING_INTERVAL_MS,
 } from '@votingworks/networking';
 import makeDebug from 'debug';
-import { NETWORK_POLLING_INTERVAL_MS } from './globals.js';
 import { Store } from './store.js';
 import { NetworkConnectionInfo } from './types.js';
 

--- a/apps/central-scan/backend/src/networking.ts
+++ b/apps/central-scan/backend/src/networking.ts
@@ -1,19 +1,46 @@
-import { deepEqual } from '@votingworks/basics';
+import { deepEqual, throwIllegalValue } from '@votingworks/basics';
+import * as grout from '@votingworks/grout';
 import { BaseLogger, LogEventId } from '@votingworks/logging';
 import {
   findAllVxAdminHostMachines,
   hasOnlineInterface,
   NETWORK_POLLING_INTERVAL_MS,
+  NETWORK_REQUEST_TIMEOUT_MS,
+  RegisterScannerError,
+  VxAdminHostApi,
+  VxAdminHostMachine,
 } from '@votingworks/networking';
 import makeDebug from 'debug';
+import { getMachineConfig } from './machine_config.js';
 import { Store } from './store.js';
-import { NetworkConnectionInfo } from './types.js';
+import { NetworkConnectionInfo, NetworkConnectionStatus } from './types.js';
 
 const debug = makeDebug('scan:networking');
 
+function statusForRegistrationError(
+  error: RegisterScannerError
+): NetworkConnectionStatus {
+  const errorType = error.type;
+  switch (errorType) {
+    case 'code-version-mismatch':
+      return 'online-code-version-mismatch';
+    case 'scanner-unconfigured':
+      return 'online-machine-unconfigured';
+    case 'host-unconfigured':
+      return 'online-host-unconfigured';
+    case 'ballot-hash-mismatch':
+      return 'online-ballot-hash-mismatch';
+    // istanbul ignore next -- compile-time check
+    default:
+      return throwIllegalValue(errorType);
+  }
+}
+
 /**
  * Starts scanner networking: watches the network for an advertised VxAdmin
- * host via avahi and tracks the scanner's connection status in the store.
+ * host via avahi, registers with it (the host refuses registration when the
+ * scanner is incompatible — different software version or election), and
+ * tracks the resulting connection status in the store.
  */
 export function startScannerNetworking({
   logger,
@@ -40,6 +67,21 @@ export function startScannerNetworking({
     store.setNetworkConnectionInfo(newInfo);
   }
 
+  const apiClients = new Map<string, grout.Client<VxAdminHostApi>>();
+
+  function getApiClient(address: string): grout.Client<VxAdminHostApi> {
+    let apiClient = apiClients.get(address);
+    if (!apiClient) {
+      debug('Creating peer API client for %s', address);
+      apiClient = grout.createClient<VxAdminHostApi>({
+        baseUrl: `${address}/api`,
+        timeout: NETWORK_REQUEST_TIMEOUT_MS,
+      });
+      apiClients.set(address, apiClient);
+    }
+    return apiClient;
+  }
+
   let isPolling = false;
 
   process.nextTick(() => {
@@ -62,11 +104,73 @@ export function startScannerNetworking({
           return;
         }
 
-        // TODO(@caro) - Handle error conditions when there are multiple hosts, mismatched code versions, mismatched ballot hashes, etc.
-        const [hostMachine] = hostMachines;
+        let hostMachine: VxAdminHostMachine;
+        if (hostMachines.length === 1) {
+          [hostMachine] = hostMachines;
+        } else {
+          // Avahi advertisements alone can be stale (e.g. an orphaned
+          // advertisement from a rebooted VxAdmin), so verify each advertised
+          // host by communicating with it before declaring a conflict.
+          const reachableHosts: VxAdminHostMachine[] = [];
+          for (const candidate of hostMachines) {
+            try {
+              await getApiClient(
+                candidate.address
+              ).getCurrentElectionMetadata();
+              reachableHosts.push(candidate);
+            } catch {
+              debug(
+                'Advertised host %s at %s unreachable, ignoring',
+                candidate.machineId,
+                candidate.address
+              );
+            }
+          }
+          if (reachableHosts.length === 0) {
+            setConnectionInfo({ status: 'online-waiting-for-host' });
+            return;
+          }
+          if (reachableHosts.length > 1) {
+            debug(
+              'Multiple reachable VxAdmin hosts found on network (%d)',
+              reachableHosts.length
+            );
+            setConnectionInfo({ status: 'online-multiple-hosts-detected' });
+            return;
+          }
+          [hostMachine] = reachableHosts;
+        }
+        const { machineId: hostMachineId } = hostMachine;
+        const apiClient = getApiClient(hostMachine.address);
+
+        const { machineId, codeVersion } = getMachineConfig();
+        let registerResult;
+        try {
+          registerResult = await apiClient.registerScanner({
+            machineId,
+            codeVersion,
+            ballotHash:
+              store.getElectionRecord()?.electionDefinition.ballotHash,
+          });
+        } catch (error) {
+          debug('Host at %s unreachable: %s', hostMachine.address, error);
+          setConnectionInfo({ status: 'online-waiting-for-host' });
+          return;
+        }
+
+        if (registerResult.isErr()) {
+          const error = registerResult.err();
+          debug('Host %s refused registration: %s', hostMachineId, error.type);
+          setConnectionInfo({
+            status: statusForRegistrationError(error),
+            hostMachineId,
+          });
+          return;
+        }
+
         setConnectionInfo({
           status: 'online-host-detected',
-          hostMachineId: hostMachine.machineId,
+          hostMachineId,
         });
       } catch (error) {
         /* istanbul ignore next - defensive */

--- a/apps/central-scan/backend/src/types.ts
+++ b/apps/central-scan/backend/src/types.ts
@@ -29,12 +29,20 @@ export interface BallotImage {
 export type NetworkConnectionStatus =
   | 'offline'
   | 'online-waiting-for-host'
+  | 'online-multiple-hosts-detected'
+  | 'online-code-version-mismatch'
+  | 'online-machine-unconfigured'
+  | 'online-host-unconfigured'
+  | 'online-ballot-hash-mismatch'
   | 'online-host-detected';
 
 /** The scanner's current connection state and the detected host, if any. */
 export interface NetworkConnectionInfo {
   status: NetworkConnectionStatus;
-  /** Machine ID of the detected host, parsed from its avahi service name. */
+  /**
+   * Machine ID of the detected host, parsed from its avahi service name.
+   * Present whenever exactly one host was found on the network.
+   */
   hostMachineId?: string;
 }
 

--- a/apps/central-scan/frontend/src/components/network_section.test.tsx
+++ b/apps/central-scan/frontend/src/components/network_section.test.tsx
@@ -1,0 +1,68 @@
+import { expect, test } from 'vitest';
+import type { NetworkConnectionInfo } from '@votingworks/central-scan-backend';
+import { render, screen } from '../../test/react_testing_library.js';
+import { NetworkSection } from './network_section.js';
+
+const testCases: Array<{
+  connection: NetworkConnectionInfo;
+  expectedText: string;
+}> = [
+  {
+    connection: { status: 'offline' },
+    expectedText: 'Offline',
+  },
+  {
+    connection: { status: 'online-waiting-for-host' },
+    expectedText: 'Online — no VxAdmin detected on the network',
+  },
+  {
+    connection: { status: 'online-multiple-hosts-detected' },
+    expectedText:
+      'Multiple VxAdmins detected on the network. Ensure only one VxAdmin is connected.',
+  },
+  {
+    connection: {
+      status: 'online-code-version-mismatch',
+      hostMachineId: '0002',
+    },
+    expectedText: 'VxAdmin (0002) is running a different software version',
+  },
+  {
+    connection: {
+      status: 'online-machine-unconfigured',
+      hostMachineId: '0002',
+    },
+    expectedText:
+      'VxAdmin (0002) detected on the network. Configure this machine with an election to connect.',
+  },
+  {
+    connection: { status: 'online-host-unconfigured', hostMachineId: '0002' },
+    expectedText:
+      'VxAdmin (0002) detected on the network, but it is not configured with an election.',
+  },
+  {
+    connection: {
+      status: 'online-ballot-hash-mismatch',
+      hostMachineId: '0002',
+    },
+    expectedText: 'VxAdmin (0002) is configured for a different election',
+  },
+  {
+    connection: { status: 'online-host-detected', hostMachineId: '0002' },
+    expectedText: 'Online — VxAdmin (0002) detected on the network',
+  },
+];
+
+test.each(testCases)(
+  'renders $connection.status',
+  ({ connection, expectedText }) => {
+    const { unmount } = render(<NetworkSection connection={connection} />);
+    screen.getByText('Network');
+    expect(
+      screen.getByText(
+        (_, element) => element?.textContent?.trim() === expectedText
+      )
+    ).toBeInTheDocument();
+    unmount();
+  }
+);

--- a/apps/central-scan/frontend/src/components/network_section.tsx
+++ b/apps/central-scan/frontend/src/components/network_section.tsx
@@ -27,6 +27,41 @@ function ConnectionStatusMessage({
           <Icons.Info /> Online &mdash; no VxAdmin detected on the network
         </P>
       );
+    case 'online-multiple-hosts-detected':
+      return (
+        <P>
+          <Icons.Warning color="warning" /> Multiple VxAdmins detected on the
+          network. Ensure only one VxAdmin is connected.
+        </P>
+      );
+    case 'online-code-version-mismatch':
+      return (
+        <P>
+          <Icons.Warning color="warning" /> VxAdmin ({connection.hostMachineId})
+          is running a different software version
+        </P>
+      );
+    case 'online-machine-unconfigured':
+      return (
+        <P>
+          <Icons.Info /> VxAdmin ({connection.hostMachineId}) detected on the
+          network. Configure this machine with an election to connect.
+        </P>
+      );
+    case 'online-host-unconfigured':
+      return (
+        <P>
+          <Icons.Info /> VxAdmin ({connection.hostMachineId}) detected on the
+          network, but it is not configured with an election.
+        </P>
+      );
+    case 'online-ballot-hash-mismatch':
+      return (
+        <P>
+          <Icons.Warning color="warning" /> VxAdmin ({connection.hostMachineId})
+          is configured for a different election
+        </P>
+      );
     case 'online-host-detected':
       return (
         <P>

--- a/libs/networking/package.json
+++ b/libs/networking/package.json
@@ -32,6 +32,9 @@
   },
   "dependencies": {
     "@votingworks/backend": "workspace:*",
+    "@votingworks/basics": "workspace:*",
+    "@votingworks/grout": "workspace:*",
+    "@votingworks/types": "workspace:*",
     "@votingworks/utils": "workspace:*",
     "debug": "4.3.4"
   },

--- a/libs/networking/src/globals.test.ts
+++ b/libs/networking/src/globals.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'vitest';
+import {
+  NETWORK_POLLING_INTERVAL_MS,
+  NETWORK_REQUEST_TIMEOUT_MS,
+} from './globals.js';
+
+test('network timing constants', () => {
+  expect(NETWORK_POLLING_INTERVAL_MS).toBeGreaterThan(0);
+  expect(NETWORK_REQUEST_TIMEOUT_MS).toBeGreaterThan(0);
+});

--- a/libs/networking/src/globals.ts
+++ b/libs/networking/src/globals.ts
@@ -1,0 +1,9 @@
+/**
+ * How often networked machines poll the network for changes.
+ */
+export const NETWORK_POLLING_INTERVAL_MS = 2000;
+
+/**
+ * Timeout for requests to a peer machine's API.
+ */
+export const NETWORK_REQUEST_TIMEOUT_MS = 1000;

--- a/libs/networking/src/index.ts
+++ b/libs/networking/src/index.ts
@@ -2,6 +2,10 @@
 export { AvahiService, hasOnlineInterface } from './avahi.js';
 export type { AvahiDiscoveredService } from './avahi.js';
 export { isNetworkingEnabled } from './config.js';
+export {
+  NETWORK_POLLING_INTERVAL_MS,
+  NETWORK_REQUEST_TIMEOUT_MS,
+} from './globals.js';
 export { intermediateScript } from './intermediate_scripts.js';
 export { isValidIpv4Address } from './utils.js';
 export {

--- a/libs/networking/src/index.ts
+++ b/libs/networking/src/index.ts
@@ -10,3 +10,8 @@ export {
   machineIdFromVxAdminServiceName,
 } from './vx_admin_service.js';
 export type { VxAdminHostMachine } from './vx_admin_service.js';
+export type {
+  RegisterScannerError,
+  VxAdminHostApi,
+  VxAdminHostMachineConfig,
+} from './vx_admin_host_api.js';

--- a/libs/networking/src/vx_admin_host_api.ts
+++ b/libs/networking/src/vx_admin_host_api.ts
@@ -1,0 +1,37 @@
+import type { Result } from '@votingworks/basics';
+import type { Api } from '@votingworks/grout';
+import type { ElectionDefinition } from '@votingworks/types';
+
+/** Machine config reported by a VxAdmin host. */
+export interface VxAdminHostMachineConfig {
+  machineId: string;
+  codeVersion: string;
+}
+
+/** Why a VxAdmin host refused to register a scanner. */
+export type RegisterScannerError =
+  | { type: 'code-version-mismatch' }
+  | { type: 'scanner-unconfigured' }
+  | { type: 'host-unconfigured' }
+  | { type: 'ballot-hash-mismatch' };
+
+/**
+ * The subset of VxAdmin's peer API used by networked central scanners.
+ * VxAdmin's peer API statically implements this contract (via `satisfies` in
+ * `apps/admin/backend/src/peer_app.ts`), so the two cannot drift apart.
+ */
+export type VxAdminHostApi = Api<{
+  registerScanner: (input: {
+    machineId: string;
+    codeVersion: string;
+    /** The scanner's configured election, if any. */
+    ballotHash?: string;
+  }) => Result<VxAdminHostMachineConfig, RegisterScannerError>;
+  /**
+   * Read-only, side-effect-free method also used by scanners as a
+   * reachability probe when verifying advertised hosts.
+   */
+  getCurrentElectionMetadata: () =>
+    | { electionDefinition: ElectionDefinition }
+    | undefined;
+}>;

--- a/libs/networking/tsconfig.build.json
+++ b/libs/networking/tsconfig.build.json
@@ -14,6 +14,8 @@
     { "path": "../../libs/backend/tsconfig.build.json" },
     { "path": "../../libs/basics/tsconfig.build.json" },
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../../libs/grout/tsconfig.build.json" },
+    { "path": "../../libs/types/tsconfig.build.json" },
     { "path": "../../libs/utils/tsconfig.build.json" },
     { "path": "../test-utils/tsconfig.build.json" }
   ]

--- a/libs/networking/tsconfig.json
+++ b/libs/networking/tsconfig.json
@@ -15,6 +15,8 @@
     { "path": "../../libs/backend/tsconfig.build.json" },
     { "path": "../../libs/basics/tsconfig.build.json" },
     { "path": "../../libs/eslint-plugin-vx/tsconfig.build.json" },
+    { "path": "../../libs/grout/tsconfig.build.json" },
+    { "path": "../../libs/types/tsconfig.build.json" },
     { "path": "../../libs/utils/tsconfig.build.json" },
     { "path": "../test-utils/tsconfig.build.json" }
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4770,6 +4770,15 @@ importers:
       '@votingworks/backend':
         specifier: workspace:*
         version: link:../backend
+      '@votingworks/basics':
+        specifier: workspace:*
+        version: link:../basics
+      '@votingworks/grout':
+        specifier: workspace:*
+        version: link:../grout
+      '@votingworks/types':
+        specifier: workspace:*
+        version: link:../types
       '@votingworks/utils':
         specifier: workspace:*
         version: link:../utils


### PR DESCRIPTION
## Overview
Adds handling for the various types of connection errors that can be surfaced when networking a VxCentralScan to a VxAdmin. For now these errors are explained in the Network section of the diagnostics tab, I imagine we will want to iterate on the UI treatment and a possible network status indicator in future prs, this PR is more intended to get the backend scaffolding in place. 

I also refactor parts of the adjudication station connection setup to better match how the scanner is set up. 

Note: Any UI or indication of connected scanners on the VxAdmin side is also left for future PR(s) 

## Demo Video or Screenshot
<img width="1168" height="739" alt="Screenshot 2026-08-19 at 12 52 55 PM" src="https://github.com/user-attachments/assets/ef18d230-98fc-4d2d-bf25-008e835c6819" />
<img width="1176" height="746" alt="Screenshot 2026-08-19 at 12 52 03 PM" src="https://github.com/user-attachments/assets/409588a4-9fdf-46b7-8f8e-b8eaca121639" />
<img width="1180" height="754" alt="Screenshot 2026-08-19 at 12 51 16 PM" src="https://github.com/user-attachments/assets/18bb6a11-ba7e-4223-bcb8-17cfc8365d2e" />
<img width="1191" height="751" alt="Screenshot 2026-08-19 at 12 51 01 PM" src="https://github.com/user-attachments/assets/ef5b6f98-8690-4dad-80b9-677179d5d241" />
<img width="1166" height="740" alt="Screenshot 2026-08-19 at 12 50 14 PM" src="https://github.com/user-attachments/assets/6e3ed435-89f5-496f-9450-63159f14980b" />
<img width="1169" height="731" alt="Screenshot 2026-08-19 at 12 49 54 PM" src="https://github.com/user-attachments/assets/87caaa97-09ae-487f-a1b8-df28c6046737" />

## Testing Plan
See Above

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
