### PR TITLE
Fix integration tests under Node 24

### DIFF
--- a/apps/admin/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/admin/integration-testing/e2e/screenshots.spec.ts
@@ -302,9 +302,13 @@ test('system administrator', async ({ page }, testInfo) => {
   await screenshot('usb-drive-formatted');
   await page.getByText('Close').click();
 
-  // formatting ejects the USB drive, so we need to re-insert
+  // Formatting ejects the USB drive, so we need to re-insert. The app only
+  // clears its no-auto-remount flag once it observes the drive gone, so wait
+  // for the removal to register before inserting again.
   usbHandler.remove();
+  await page.getByText('No USB').waitFor();
   usbHandler.insert();
+  await page.getByText('Eject USB').waitFor();
 
   await page.getByRole('button', { name: 'Signed Hash Validation' }).click();
   await page.getByText(/Scan this QR code/).waitFor();

--- a/apps/admin/integration-testing/package.json
+++ b/apps/admin/integration-testing/package.json
@@ -15,7 +15,7 @@
     "test:watch": "pnpm -w vx-task it-prebuild $npm_package_name && playwright test --ui"
   },
   "dependencies": {
-    "@playwright/test": "^1.48.1",
+    "@playwright/test": "1.55.1",
     "@votingworks/auth": "workspace:*",
     "@votingworks/backend": "workspace:*",
     "@votingworks/basics": "workspace:*",

--- a/apps/central-scan/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/central-scan/integration-testing/e2e/screenshots.spec.ts
@@ -134,13 +134,15 @@ test('screenshots', async ({ page }, testInfo) => {
 
   // Configuring progress screen. The configuration request completes too
   // quickly to screenshot reliably, so delay the response just long enough to
-  // capture the screen, then let it proceed.
+  // capture the screen, then let it proceed. `times: 1` retires the handler
+  // when it fires, so nothing unroutes it while it is still sleeping.
   await page.route(
     '**/api/configureFromElectionPackageOnUsbDrive',
     async (route) => {
       await sleep(4000);
       await route.continue();
-    }
+    },
+    { times: 1 }
   );
   usbHandler.insert(
     await mockElectionPackageFileTree(
@@ -149,7 +151,6 @@ test('screenshots', async ({ page }, testInfo) => {
   );
   await page.getByText(/Configuring VxCentralScan/).waitFor();
   await screenshot('configuring');
-  await page.unroute('**/api/configureFromElectionPackageOnUsbDrive');
   await page.getByText('No ballots have been scanned').waitFor();
 
   // Scan Ballots screen immediately after configuring, while still in test

--- a/apps/central-scan/integration-testing/package.json
+++ b/apps/central-scan/integration-testing/package.json
@@ -15,7 +15,7 @@
     "test:watch": "pnpm -w vx-task it-prebuild $npm_package_name && playwright test --ui"
   },
   "dependencies": {
-    "@playwright/test": "^1.48.1",
+    "@playwright/test": "1.55.1",
     "@votingworks/auth": "workspace:*",
     "@votingworks/backend": "workspace:*",
     "@votingworks/basics": "workspace:*",

--- a/apps/mark-scan/integration-testing/package.json
+++ b/apps/mark-scan/integration-testing/package.json
@@ -15,7 +15,7 @@
     "test:watch": "pnpm -w vx-task it-prebuild $npm_package_name && playwright test --ui"
   },
   "dependencies": {
-    "@playwright/test": "^1.48.1",
+    "@playwright/test": "1.55.1",
     "@votingworks/auth": "workspace:*",
     "@votingworks/backend": "workspace:*",
     "@votingworks/basics": "workspace:*",

--- a/apps/mark/integration-testing/package.json
+++ b/apps/mark/integration-testing/package.json
@@ -15,7 +15,7 @@
     "test:watch": "pnpm -w vx-task it-prebuild $npm_package_name && playwright test --ui"
   },
   "dependencies": {
-    "@playwright/test": "^1.48.1",
+    "@playwright/test": "1.55.1",
     "@votingworks/auth": "workspace:*",
     "@votingworks/backend": "workspace:*",
     "@votingworks/basics": "workspace:*",

--- a/apps/print/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/print/integration-testing/e2e/screenshots.spec.ts
@@ -123,14 +123,19 @@ test('election manager: configuration and settings', async ({
 
   // Configuring progress screen. Configuration completes too quickly to
   // screenshot reliably, so delay the response just long enough to capture it.
-  await page.route('**/api/configureElectionPackageFromUsb', async (route) => {
-    await sleep(4000);
-    await route.continue();
-  });
+  // `times: 1` retires the handler when it fires, so nothing unroutes it while
+  // it is still sleeping.
+  await page.route(
+    '**/api/configureElectionPackageFromUsb',
+    async (route) => {
+      await sleep(4000);
+      await route.continue();
+    },
+    { times: 1 }
+  );
   usbHandler.insert(electionPackage);
   await page.getByText(/Configuring VxPrint/).waitFor();
   await screenshot('em-configuring');
-  await page.unroute('**/api/configureElectionPackageFromUsb');
 
   // After configuration the app stays on the last-active route (the reset
   // helper leaves it on /settings), so navigate to the Election screen.

--- a/apps/print/integration-testing/package.json
+++ b/apps/print/integration-testing/package.json
@@ -15,7 +15,7 @@
     "test:watch": "pnpm -w vx-task it-prebuild $npm_package_name && playwright test --ui"
   },
   "dependencies": {
-    "@playwright/test": "^1.48.1",
+    "@playwright/test": "1.55.1",
     "@votingworks/auth": "workspace:*",
     "@votingworks/backend": "workspace:*",
     "@votingworks/basics": "workspace:*",

--- a/apps/scan/integration-testing/package.json
+++ b/apps/scan/integration-testing/package.json
@@ -15,7 +15,7 @@
     "test:watch": "pnpm -w vx-task it-prebuild $npm_package_name && playwright test --ui"
   },
   "dependencies": {
-    "@playwright/test": "^1.48.1",
+    "@playwright/test": "1.55.1",
     "@votingworks/auth": "workspace:*",
     "@votingworks/backend": "workspace:*",
     "@votingworks/fixtures": "workspace:*",

--- a/libs/integration-test-utils/package.json
+++ b/libs/integration-test-utils/package.json
@@ -29,7 +29,7 @@
     "type-check": "tsc --build"
   },
   "dependencies": {
-    "@playwright/test": "^1.48.1",
+    "@playwright/test": "1.55.1",
     "@votingworks/auth": "workspace:*",
     "@votingworks/backend": "workspace:*",
     "@votingworks/ballot-interpreter": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,8 +528,8 @@ importers:
   apps/admin/integration-testing:
     dependencies:
       '@playwright/test':
-        specifier: ^1.48.1
-        version: 1.48.1
+        specifier: 1.55.1
+        version: 1.55.1
       '@votingworks/auth':
         specifier: workspace:*
         version: link:../../../libs/auth
@@ -882,8 +882,8 @@ importers:
   apps/central-scan/integration-testing:
     dependencies:
       '@playwright/test':
-        specifier: ^1.48.1
-        version: 1.48.1
+        specifier: 1.55.1
+        version: 1.55.1
       '@votingworks/auth':
         specifier: workspace:*
         version: link:../../../libs/auth
@@ -1613,8 +1613,8 @@ importers:
   apps/mark-scan/integration-testing:
     dependencies:
       '@playwright/test':
-        specifier: ^1.48.1
-        version: 1.48.1
+        specifier: 1.55.1
+        version: 1.55.1
       '@votingworks/auth':
         specifier: workspace:*
         version: link:../../../libs/auth
@@ -1970,8 +1970,8 @@ importers:
   apps/mark/integration-testing:
     dependencies:
       '@playwright/test':
-        specifier: ^1.48.1
-        version: 1.48.1
+        specifier: 1.55.1
+        version: 1.55.1
       '@votingworks/auth':
         specifier: workspace:*
         version: link:../../../libs/auth
@@ -2650,8 +2650,8 @@ importers:
   apps/print/integration-testing:
     dependencies:
       '@playwright/test':
-        specifier: ^1.48.1
-        version: 1.48.1
+        specifier: 1.55.1
+        version: 1.55.1
       '@votingworks/auth':
         specifier: workspace:*
         version: link:../../../libs/auth
@@ -3016,8 +3016,8 @@ importers:
   apps/scan/integration-testing:
     dependencies:
       '@playwright/test':
-        specifier: ^1.48.1
-        version: 1.48.1
+        specifier: 1.55.1
+        version: 1.55.1
       '@votingworks/auth':
         specifier: workspace:*
         version: link:../../../libs/auth
@@ -4436,8 +4436,8 @@ importers:
   libs/integration-test-utils:
     dependencies:
       '@playwright/test':
-        specifier: ^1.48.1
-        version: 1.48.1
+        specifier: 1.55.1
+        version: 1.55.1
       '@votingworks/auth':
         specifier: workspace:*
         version: link:../auth
@@ -8187,8 +8187,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.48.1':
-    resolution: {integrity: sha512-s9RtWoxkOLmRJdw3oFvhFbs9OJS0BzrLUc8Hf6l2UdCNd1rqeEyD4BhCJkvzeEoD1FsK4mirsWwGerhVmYKtZg==}
+  '@playwright/test@1.55.1':
+    resolution: {integrity: sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -14011,18 +14011,8 @@ packages:
     resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
     engines: {node: '>=10'}
 
-  playwright-core@1.48.1:
-    resolution: {integrity: sha512-Yw/t4VAFX/bBr1OzwCuOMZkY1Cnb4z/doAFSwf4huqAGWmf9eMNjmK7NiOljCdLmxeRYcGPPmcDgU0zOlzP0YA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   playwright-core@1.55.1:
     resolution: {integrity: sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.48.1:
-    resolution: {integrity: sha512-j8CiHW/V6HxmbntOfyB4+T/uk08tBy6ph0MpBXwuoofkSnLmlfdYNNkFTYD6ofzzlSqLA1fwH4vwvVFvJgLN0w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -19093,9 +19083,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.48.1':
+  '@playwright/test@1.55.1':
     dependencies:
-      playwright: 1.48.1
+      playwright: 1.55.1
 
   '@prisma/instrumentation@5.22.0':
     dependencies:
@@ -26294,15 +26284,7 @@ snapshots:
     dependencies:
       find-up: 5.0.0
 
-  playwright-core@1.48.1: {}
-
   playwright-core@1.55.1: {}
-
-  playwright@1.48.1:
-    dependencies:
-      playwright-core: 1.48.1
-    optionalDependencies:
-      fsevents: 2.3.2
 
   playwright@1.55.1:
     dependencies:


### PR DESCRIPTION
## Overview

Every `test-apps-*-integration-testing` job has been red on `main` since the Node 24 upgrade (#9112). `@playwright/test` 1.48.1 deadlocks on Node 24 — `playwright test` prints nothing and never exits, so CI killed each job with "Too long with no output (exceeded 10m0s)". Node 24 runs `module.register()` hooks on a dedicated thread and 1.48's ESM loader never signals initialization, so the main thread blocks in `Atomics.wait` before the config is even loaded.

Bumps `@playwright/test` to 1.55.1 across the six `apps/*/integration-testing` packages and `libs/integration-test-utils`, pinned exactly to match the `playwright` 1.55.1 already used by `libs/hmpb` and `libs/printing`. Also fixes two test bugs the bump surfaced (a same-tick USB remove/insert that the app never observes, and `page.unroute` firing while a delayed route handler is still sleeping) — see the commit message for details.

## Testing Plan

- All six integration-testing suites pass locally and in CI on this branch.
- Verified 1.48.1 still hangs with a clean install and 1.55.1 does not, so the bump is the cause of the fix rather than an environment change.
- The one committed snapshot in these suites is a CSV, so there is no browser-version image churn.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)