### PR TITLE
[VxAdmin] Fix slow CVR files query

### DIFF
--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -1526,22 +1526,14 @@ export class Store implements BaseStore {
         cvr_files.id as id,
         filename,
         export_timestamp as exportTimestamp,
-        count(cvr_id) as numCvrsImported,
+        count(cvr_file_entries.cvr_id) as numCvrsImported,
         polling_place_ids as pollingPlaceIds,
         precinct_ids as precinctIds,
         scanner_ids as scannerIds,
         sha256_hash as sha256Hash,
         datetime(cvr_files.created_at, 'localtime') as createdAt
       from cvr_files
-      left join (
-        select
-          cvr_file_entries.cvr_id,
-          min(cvr_files.created_at) as min_import_date,
-          cvr_file_entries.cvr_file_id
-        from cvr_file_entries, cvr_files
-        group by cvr_file_entries.cvr_id
-      ) cvrs_by_min_import_date on
-        cvrs_by_min_import_date.cvr_file_id = cvr_files.id
+      left join cvr_file_entries on cvr_file_entries.cvr_file_id = cvr_files.id
       where cvr_files.election_id = ?
       group by cvr_files.id
       order by export_timestamp desc


### PR DESCRIPTION
## Overview

Related to https://github.com/votingworks/vxsuite/issues/8370

Scale testing with 1M+ CVRs uncovered this wayward full scan on the `cvr_file_entries` table when computing CVR counts for each `cvr_files` record. Was starting to take upwards of a minute as the number of imported CVRs increased (drops to ~150ms on my machine after the change).

I think the removed subquery ended up with unused remnants of previous iterations in the original PR, from what I can tell - can be replaced altogether with a plain join without changing the result.

## Demo Video or Screenshot

Before:
```
QUERY PLAN
|--MATERIALIZE cvrs_by_min_import_date
|  |--SCAN cvr_file_entries
|  |--SCAN cvr_files
|  `--USE TEMP B-TREE FOR GROUP BY
|--SCAN cvr_files USING INDEX sqlite_autoindex_cvr_files_1
|--SEARCH cvrs_by_min_import_date
|  USING AUTOMATIC COVERING INDEX (cvr_file_id=?) LEFT-JOIN
`--USE TEMP B-TREE FOR ORDER BY
```

After:
```
QUERY PLAN
|--SCAN cvr_files USING INDEX sqlite_autoindex_cvr_files_1
|--SEARCH cvr_file_entries
|  USING COVERING INDEX sqlite_autoindex_cvr_file_entries_1 (cvr_file_id=?) LEFT-JOIN
`--USE TEMP B-TREE FOR ORDER BY
```

## Testing Plan
- Existing tests as regression guard, manual scale test

## Checklist
N/A