### PR TITLE
[VxCentralScan] Use VxAdmin topbar and add network status indicator 

### DIFF
--- a/apps/admin/frontend/src/components/navigation_screen.tsx
+++ b/apps/admin/frontend/src/components/navigation_screen.tsx
@@ -2,12 +2,11 @@ import React, { useContext } from 'react';
 
 import {
   BatteryStatus,
-  Button,
   DateTimeDisplay,
-  IconName,
   Icons,
   Toolbar,
   LockMachineButton,
+  UsbEjectButton,
   MainHeader,
   MainContent,
   Screen,
@@ -17,7 +16,6 @@ import {
   Route,
   Breadcrumbs,
 } from '@votingworks/ui';
-import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import {
   BooleanEnvironmentVariableName,
   isElectionManagerAuth,
@@ -164,48 +162,6 @@ function shouldShowToolbar(
       /* istanbul ignore next */
       throwIllegalValue(machineMode);
   }
-}
-
-const ToolbarButton = styled(Button)`
-  font-size: 0.8rem;
-  padding: 0.25rem 0.75rem;
-`;
-
-type ExtendedUsbDriveStatus = UsbDriveStatus['status'] | 'ejecting';
-const USB_BUTTON_ICON_AND_TEXT: Record<
-  ExtendedUsbDriveStatus,
-  [IconName, string]
-> = {
-  no_drive: ['Disabled', 'No USB'],
-  error: ['Disabled', 'No USB'],
-  mounted: ['Eject', 'Eject USB'],
-  ejecting: ['Eject', 'Ejecting...'],
-  ejected: ['Disabled', 'USB Ejected'],
-};
-
-function UsbEjectButton({
-  usbDriveStatus,
-  onEject,
-  isEjecting,
-}: {
-  usbDriveStatus: UsbDriveStatus;
-  onEject: () => void;
-  isEjecting: boolean;
-}): JSX.Element {
-  const extendedStatus: ExtendedUsbDriveStatus = isEjecting
-    ? 'ejecting'
-    : usbDriveStatus.status;
-  const [icon, text] = USB_BUTTON_ICON_AND_TEXT[extendedStatus];
-  return (
-    <ToolbarButton
-      icon={icon}
-      onPress={onEject}
-      color="inverseNeutral"
-      disabled={extendedStatus !== 'mounted' || isEjecting}
-    >
-      {text}
-    </ToolbarButton>
-  );
 }
 
 export const Header = styled(MainHeader)`

--- a/apps/central-scan/frontend/src/components/network_section.test.tsx
+++ b/apps/central-scan/frontend/src/components/network_section.test.tsx
@@ -6,19 +6,23 @@ import { NetworkSection } from './network_section.js';
 const testCases: Array<{
   connection: NetworkConnectionInfo;
   expectedText: string;
+  expectedIcon: string;
 }> = [
   {
     connection: { status: 'offline' },
     expectedText: 'Offline',
+    expectedIcon: 'circle-info',
   },
   {
     connection: { status: 'online-waiting-for-host' },
     expectedText: 'Online — no VxAdmin detected on the network',
+    expectedIcon: 'circle-info',
   },
   {
     connection: { status: 'online-multiple-hosts-detected' },
     expectedText:
       'Multiple VxAdmins detected on the network. Ensure only one VxAdmin is connected.',
+    expectedIcon: 'circle-exclamation',
   },
   {
     connection: {
@@ -26,6 +30,7 @@ const testCases: Array<{
       hostMachineId: '0002',
     },
     expectedText: 'VxAdmin (0002) is running a different software version',
+    expectedIcon: 'circle-exclamation',
   },
   {
     connection: {
@@ -34,11 +39,13 @@ const testCases: Array<{
     },
     expectedText:
       'VxAdmin (0002) detected on the network. Configure this machine with an election to connect.',
+    expectedIcon: 'circle-info',
   },
   {
     connection: { status: 'online-host-unconfigured', hostMachineId: '0002' },
     expectedText:
       'VxAdmin (0002) detected on the network, but it is not configured with an election.',
+    expectedIcon: 'circle-info',
   },
   {
     connection: {
@@ -46,22 +53,28 @@ const testCases: Array<{
       hostMachineId: '0002',
     },
     expectedText: 'VxAdmin (0002) is configured for a different election',
+    expectedIcon: 'circle-info',
   },
   {
     connection: { status: 'online-host-detected', hostMachineId: '0002' },
     expectedText: 'Online — VxAdmin (0002) detected on the network',
+    expectedIcon: 'square-check',
   },
 ];
 
 test.each(testCases)(
   'renders $connection.status',
-  ({ connection, expectedText }) => {
+  ({ connection, expectedText, expectedIcon }) => {
     const { unmount } = render(<NetworkSection connection={connection} />);
     screen.getByText('Network');
+    const message = screen.getByText(
+      (_, element) => element?.textContent?.trim() === expectedText
+    );
+    expect(message).toBeInTheDocument();
+    // The icon severity matches the top-bar network status indicator's
+    // bucket for this status
     expect(
-      screen.getByText(
-        (_, element) => element?.textContent?.trim() === expectedText
-      )
+      message.querySelector(`[data-icon='${expectedIcon}']`)
     ).toBeInTheDocument();
     unmount();
   }

--- a/apps/central-scan/frontend/src/components/network_section.tsx
+++ b/apps/central-scan/frontend/src/components/network_section.tsx
@@ -30,14 +30,14 @@ function ConnectionStatusMessage({
     case 'online-multiple-hosts-detected':
       return (
         <P>
-          <Icons.Warning color="warning" /> Multiple VxAdmins detected on the
+          <Icons.Danger color="danger" /> Multiple VxAdmins detected on the
           network. Ensure only one VxAdmin is connected.
         </P>
       );
     case 'online-code-version-mismatch':
       return (
         <P>
-          <Icons.Warning color="warning" /> VxAdmin ({connection.hostMachineId})
+          <Icons.Danger color="danger" /> VxAdmin ({connection.hostMachineId})
           is running a different software version
         </P>
       );
@@ -58,8 +58,8 @@ function ConnectionStatusMessage({
     case 'online-ballot-hash-mismatch':
       return (
         <P>
-          <Icons.Warning color="warning" /> VxAdmin ({connection.hostMachineId})
-          is configured for a different election
+          <Icons.Info /> VxAdmin ({connection.hostMachineId}) is configured for
+          a different election
         </P>
       );
     case 'online-host-detected':

--- a/apps/central-scan/frontend/src/components/network_status_indicator.test.tsx
+++ b/apps/central-scan/frontend/src/components/network_status_indicator.test.tsx
@@ -1,0 +1,118 @@
+import { expect, test } from 'vitest';
+import type { NetworkConnectionInfo } from '@votingworks/central-scan-backend';
+import { renderInAppContext } from '../../test/render_in_app_context.js';
+import { createApiMock } from '../../test/api.js';
+import { screen, waitFor } from '../../test/react_testing_library.js';
+import { NetworkStatusIndicator } from './network_status_indicator.js';
+
+test('renders nothing when networking is disabled', async () => {
+  const apiMock = createApiMock();
+  const { container } = renderInAppContext(<NetworkStatusIndicator />, {
+    apiMock,
+  });
+  await waitFor(() =>
+    expect(apiMock.apiClient.getNetworkStatus).toHaveBeenCalled()
+  );
+  expect(container).toBeEmptyDOMElement();
+});
+
+const testCases: Array<{
+  connection: NetworkConnectionInfo;
+  expectedLabel: string;
+  expectedTreatment: 'connected' | 'warning' | 'error';
+}> = [
+  {
+    connection: { status: 'offline' },
+    expectedLabel: 'No Network',
+    expectedTreatment: 'warning',
+  },
+  {
+    connection: { status: 'online-waiting-for-host' },
+    expectedLabel: 'No VxAdmin Connected',
+    expectedTreatment: 'warning',
+  },
+  {
+    connection: {
+      status: 'online-machine-unconfigured',
+      hostMachineId: '0002',
+    },
+    expectedLabel: 'No VxAdmin Connected',
+    expectedTreatment: 'warning',
+  },
+  {
+    connection: { status: 'online-host-unconfigured', hostMachineId: '0002' },
+    expectedLabel: 'No VxAdmin Connected',
+    expectedTreatment: 'warning',
+  },
+  {
+    connection: {
+      status: 'online-ballot-hash-mismatch',
+      hostMachineId: '0002',
+    },
+    expectedLabel: 'No VxAdmin Connected',
+    expectedTreatment: 'warning',
+  },
+  {
+    connection: { status: 'online-multiple-hosts-detected' },
+    expectedLabel: 'Network Error',
+    expectedTreatment: 'error',
+  },
+  {
+    connection: {
+      status: 'online-code-version-mismatch',
+      hostMachineId: '0002',
+    },
+    expectedLabel: 'Network Error',
+    expectedTreatment: 'error',
+  },
+  {
+    connection: { status: 'online-host-detected', hostMachineId: '0002' },
+    expectedLabel: 'Connected',
+    expectedTreatment: 'connected',
+  },
+];
+
+test.each(testCases)(
+  'renders $connection.status',
+  async ({ connection, expectedLabel, expectedTreatment }) => {
+    const apiMock = createApiMock();
+    apiMock.setNetworkStatus({ isEnabled: true, connection });
+    const { unmount } = renderInAppContext(<NetworkStatusIndicator />, {
+      apiMock,
+    });
+    const indicator = await screen.findByTestId('network-status');
+    expect(indicator).toHaveTextContent(expectedLabel);
+    switch (expectedTreatment) {
+      // Connected states show the plain network icon
+      case 'connected':
+        expect(
+          indicator.querySelector(`[data-icon='sitemap']`)
+        ).toBeInTheDocument();
+        expect(indicator.querySelectorAll('[data-icon]')).toHaveLength(1);
+        expect(
+          indicator.querySelector(`[data-testid='network-off-icon']`)
+        ).not.toBeInTheDocument();
+        break;
+      // Warning states show the slashed network icon
+      case 'warning':
+        expect(
+          indicator.querySelector(`[data-testid='network-off-icon']`)
+        ).toBeInTheDocument();
+        expect(indicator.querySelectorAll('[data-icon]')).toHaveLength(0);
+        break;
+      // Error states show the slashed network icon with a danger icon next
+      // to it
+      case 'error':
+        expect(
+          indicator.querySelector(`[data-testid='network-off-icon']`)
+        ).toBeInTheDocument();
+        expect(
+          indicator.querySelector(`[data-icon='circle-exclamation']`)
+        ).toBeInTheDocument();
+        break;
+      default:
+        throw new Error('unreachable');
+    }
+    unmount();
+  }
+);

--- a/apps/central-scan/frontend/src/components/network_status_indicator.tsx
+++ b/apps/central-scan/frontend/src/components/network_status_indicator.tsx
@@ -1,0 +1,43 @@
+import { throwIllegalValue } from '@votingworks/basics';
+import type { NetworkConnectionInfo } from '@votingworks/central-scan-backend';
+import {
+  NetworkIndicatorStatus,
+  NetworkStatusIndicator as NetworkStatusIndicatorView,
+} from '@votingworks/ui';
+import { getNetworkStatus } from '../api.js';
+
+function indicatorStatus(
+  connection: NetworkConnectionInfo
+): NetworkIndicatorStatus {
+  const { status } = connection;
+  switch (status) {
+    case 'online-host-detected':
+      return 'connected';
+    case 'offline':
+      return 'no-network';
+    case 'online-waiting-for-host':
+    case 'online-machine-unconfigured':
+    case 'online-host-unconfigured':
+    case 'online-ballot-hash-mismatch':
+      return 'no-host-connected';
+    case 'online-multiple-hosts-detected':
+    case 'online-code-version-mismatch':
+      return 'error';
+    // istanbul ignore next -- compile-time check
+    default:
+      return throwIllegalValue(status);
+  }
+}
+
+export function NetworkStatusIndicator(): JSX.Element | null {
+  const networkStatusQuery = getNetworkStatus.useQuery();
+  if (!networkStatusQuery.isSuccess || !networkStatusQuery.data.isEnabled) {
+    return null;
+  }
+
+  return (
+    <NetworkStatusIndicatorView
+      status={indicatorStatus(networkStatusQuery.data.connection)}
+    />
+  );
+}

--- a/apps/central-scan/frontend/src/navigation_screen.tsx
+++ b/apps/central-scan/frontend/src/navigation_screen.tsx
@@ -28,6 +28,7 @@ import { DippedSmartCardAuth, ElectionDefinition } from '@votingworks/types';
 import { Link, useRouteMatch } from 'react-router-dom';
 import { AppContext } from './contexts/app_context.js';
 import { ejectUsbDrive, logOut, systemCallApi } from './api.js';
+import { NetworkStatusIndicator } from './components/network_status_indicator.js';
 
 interface Props {
   children: React.ReactNode;
@@ -90,6 +91,7 @@ function NavigationToolbar(): JSX.Element {
 
   return (
     <Toolbar>
+      <NetworkStatusIndicator />
       {batteryInfoQuery.isSuccess && batteryInfoQuery.data && (
         <BatteryStatus batteryInfo={batteryInfoQuery.data} />
       )}

--- a/apps/central-scan/frontend/src/navigation_screen.tsx
+++ b/apps/central-scan/frontend/src/navigation_screen.tsx
@@ -1,9 +1,10 @@
 import {
   AppLogo,
-  BatteryDisplay,
-  Button,
+  BatteryStatus,
+  DateTimeDisplay,
   H1,
   LeftNav,
+  LockMachineButton,
   Main,
   MainContent,
   MainHeader,
@@ -13,7 +14,8 @@ import {
   Screen,
   SessionTimeLimitTimer,
   TestModeBanner,
-  UsbControllerButton,
+  Toolbar,
+  UsbEjectButton,
   VerticalElectionInfoBar,
 } from '@votingworks/ui';
 import styled from 'styled-components';
@@ -25,7 +27,7 @@ import {
 import { DippedSmartCardAuth, ElectionDefinition } from '@votingworks/types';
 import { Link, useRouteMatch } from 'react-router-dom';
 import { AppContext } from './contexts/app_context.js';
-import { ejectUsbDrive, logOut } from './api.js';
+import { ejectUsbDrive, logOut, systemCallApi } from './api.js';
 
 interface Props {
   children: React.ReactNode;
@@ -37,13 +39,6 @@ export const Header = styled(MainHeader)`
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
-`;
-
-const HeaderActions = styled.div`
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-  flex-shrink: 0;
 `;
 
 // Because the VxCentralScan is such a long app name, we have to resize the app
@@ -87,19 +82,40 @@ function getNavItems(
   return [];
 }
 
+function NavigationToolbar(): JSX.Element {
+  const { usbDriveStatus } = useContext(AppContext);
+  const logOutMutation = logOut.useMutation();
+  const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
+  const batteryInfoQuery = systemCallApi.getBatteryInfo.useQuery();
+
+  return (
+    <Toolbar>
+      {batteryInfoQuery.isSuccess && batteryInfoQuery.data && (
+        <BatteryStatus batteryInfo={batteryInfoQuery.data} />
+      )}
+      <DateTimeDisplay />
+      <UsbEjectButton
+        usbDriveStatus={usbDriveStatus}
+        onEject={() => ejectUsbDriveMutation.mutate()}
+        isEjecting={ejectUsbDriveMutation.isLoading}
+      />
+      <LockMachineButton onLock={() => logOutMutation.mutate()} />
+    </Toolbar>
+  );
+}
+
 export function NavigationScreen({ children, title }: Props): JSX.Element {
   const {
     electionDefinition,
     electionPackageHash,
     isTestMode,
     machineConfig,
-    usbDriveStatus,
     auth,
   } = useContext(AppContext);
-  const logOutMutation = logOut.useMutation();
-  const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
   const currentRoute = useRouteMatch();
   const navItems = getNavItems(auth, electionDefinition);
+  const showToolbar =
+    isSystemAdministratorAuth(auth) || isElectionManagerAuth(auth);
 
   function isActivePath(path: string): boolean {
     return currentRoute.path.startsWith(path);
@@ -132,28 +148,13 @@ export function NavigationScreen({ children, title }: Props): JSX.Element {
         </div>
       </LeftNav>
       <Main flexColumn>
+        {showToolbar && <NavigationToolbar />}
         <SessionTimeLimitTimer authStatus={auth} />
         {isTestMode && isElectionManagerAuth(auth) && electionDefinition && (
           <TestModeBanner />
         )}
         <Header>
           <H1>{title}</H1>
-          <HeaderActions>
-            {(isSystemAdministratorAuth(auth) ||
-              isElectionManagerAuth(auth)) && (
-              <React.Fragment>
-                <UsbControllerButton
-                  usbDriveEject={() => ejectUsbDriveMutation.mutate()}
-                  usbDriveStatus={usbDriveStatus}
-                  usbDriveIsEjecting={ejectUsbDriveMutation.isLoading}
-                />
-                <Button onPress={() => logOutMutation.mutate()} icon="Lock">
-                  Lock Machine
-                </Button>
-                <BatteryDisplay />
-              </React.Fragment>
-            )}
-          </HeaderActions>
         </Header>
         <MainContent>{children}</MainContent>
       </Main>

--- a/apps/central-scan/frontend/test/api.tsx
+++ b/apps/central-scan/frontend/test/api.tsx
@@ -32,12 +32,13 @@ import { screen } from './react_testing_library.js';
 
 export type MockApiClient = Omit<
   MockClient<Api>,
-  'getBatteryInfo' | 'getDiskSpaceSummary'
+  'getBatteryInfo' | 'getDiskSpaceSummary' | 'getNetworkStatus'
 > & {
   // Because these are polled so frequently, we opt for a standard vitest mock instead of a
   // libs/test-utils mock since the latter requires every call to be explicitly mocked
   getBatteryInfo: Mock;
   getDiskSpaceSummary: Mock;
+  getNetworkStatus: Mock;
 };
 
 export function createMockApiClient(): MockApiClient {
@@ -46,6 +47,12 @@ export function createMockApiClient(): MockApiClient {
   // of the mockApiClient, so we override like this instead
   (mockApiClient.getBatteryInfo as unknown as Mock) = vi.fn(() =>
     Promise.resolve({ level: 1, discharging: false })
+  );
+  (mockApiClient.getNetworkStatus as unknown as Mock) = vi.fn(() =>
+    Promise.resolve<NetworkStatus>({
+      isEnabled: false,
+      connection: { status: 'offline' },
+    })
   );
   (mockApiClient.getDiskSpaceSummary as unknown as Mock) = vi.fn(() =>
     Promise.resolve({ total: 3, used: 2, available: 1 })
@@ -119,9 +126,7 @@ export function createApiMock(
         connection: { status: 'offline' },
       }
     ) {
-      apiClient.getNetworkStatus
-        .expectRepeatedCallsWith()
-        .resolves(networkStatus);
+      apiClient.getNetworkStatus.mockResolvedValue(networkStatus);
     },
 
     expectGetElectionRecord(electionDefinition: ElectionDefinition | null) {

--- a/libs/types/src/ui_theme.ts
+++ b/libs/types/src/ui_theme.ts
@@ -78,6 +78,7 @@ export interface ColorTheme {
   readonly inverseContainer: ColorString;
   readonly inversePrimary: ColorString;
   readonly inverseWarningAccent: ColorString;
+  readonly inverseDangerAccent: ColorString;
 
   readonly dangerAccent: ColorString;
   readonly warningAccent: ColorString;

--- a/libs/ui/src/icons.test.tsx
+++ b/libs/ui/src/icons.test.tsx
@@ -28,6 +28,7 @@ test(`Icon renders with color`, () => {
     inverse: theme.colors.onInverse,
     inversePrimary: theme.colors.inversePrimary,
     inverseWarning: theme.colors.inverseWarningAccent,
+    inverseDanger: theme.colors.inverseDangerAccent,
   };
 
   for (const [color, expectedColor] of Object.entries(expectedColors)) {

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -123,6 +123,7 @@ export const ICON_COLORS = [
   'inverse',
   'inversePrimary',
   'inverseWarning',
+  'inverseDanger',
 ] as const;
 
 export type IconColor = (typeof ICON_COLORS)[number];
@@ -171,6 +172,7 @@ function iconColor(theme: UiTheme, color?: IconColor) {
     inverse: colors.onInverse,
     inversePrimary: colors.inversePrimary,
     inverseWarning: colors.inverseWarningAccent,
+    inverseDanger: colors.inverseDangerAccent,
     default: undefined,
   }[color];
 }

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -128,6 +128,7 @@ export * from './fonts/roboto';
 export * from './battery_display';
 export * from './battery_low_alert';
 export * from './toolbar';
+export * from './network_status_indicator';
 export * from './fonts/font_awesome_styles';
 export * from './save_readiness_report_button';
 export * from './tabs';

--- a/libs/ui/src/network_status_indicator.test.tsx
+++ b/libs/ui/src/network_status_indicator.test.tsx
@@ -1,0 +1,89 @@
+import { expect, test } from 'vitest';
+import { render, screen } from '../test/react_testing_library';
+
+import {
+  NetworkIndicatorStatus,
+  NetworkStatusIndicator,
+} from './network_status_indicator';
+
+const testCases: Array<{
+  status: NetworkIndicatorStatus;
+  expectedLabel: string;
+  expectedTreatment: 'connected' | 'warning' | 'error';
+}> = [
+  {
+    status: 'connected',
+    expectedLabel: 'Connected',
+    expectedTreatment: 'connected',
+  },
+  {
+    status: 'no-host-connected',
+    expectedLabel: 'No VxAdmin Connected',
+    expectedTreatment: 'warning',
+  },
+  {
+    status: 'no-network',
+    expectedLabel: 'No Network',
+    expectedTreatment: 'warning',
+  },
+  {
+    status: 'error',
+    expectedLabel: 'Network Error',
+    expectedTreatment: 'error',
+  },
+];
+
+test.each(testCases)(
+  'renders $status',
+  ({ status, expectedLabel, expectedTreatment }) => {
+    const { unmount } = render(<NetworkStatusIndicator status={status} />);
+    const indicator = screen.getByTestId('network-status');
+    expect(indicator).toHaveTextContent(expectedLabel);
+    switch (expectedTreatment) {
+      // Connected states show the plain network icon
+      case 'connected':
+        expect(
+          indicator.querySelector(`[data-icon='sitemap']`)
+        ).toBeInTheDocument();
+        expect(indicator.querySelectorAll('[data-icon]')).toHaveLength(1);
+        expect(
+          indicator.querySelector(`[data-testid='network-off-icon']`)
+        ).not.toBeInTheDocument();
+        break;
+      // Warning states show the slashed network icon
+      case 'warning':
+        expect(
+          indicator.querySelector(`[data-testid='network-off-icon']`)
+        ).toBeInTheDocument();
+        expect(indicator.querySelectorAll('[data-icon]')).toHaveLength(0);
+        break;
+      // Error states show the slashed network icon with a danger icon next
+      // to it
+      case 'error':
+        expect(
+          indicator.querySelector(`[data-testid='network-off-icon']`)
+        ).toBeInTheDocument();
+        expect(
+          indicator.querySelector(`[data-icon='circle-exclamation']`)
+        ).toBeInTheDocument();
+        break;
+      /* istanbul ignore next - compile-time check */
+      default:
+        throw new Error('unreachable');
+    }
+    unmount();
+  }
+);
+
+test('host machines label the connected state as network online', () => {
+  render(<NetworkStatusIndicator isHost status="connected" />);
+  const indicator = screen.getByTestId('network-status');
+  expect(indicator).toHaveTextContent('Network Online');
+  expect(indicator.querySelector(`[data-icon='sitemap']`)).toBeInTheDocument();
+});
+
+test('is not interactive', () => {
+  render(<NetworkStatusIndicator status="connected" />);
+  expect(screen.getByTestId('network-status').tagName).not.toEqual('BUTTON');
+  expect(screen.queryByRole('button')).not.toBeInTheDocument();
+});

--- a/libs/ui/src/network_status_indicator.tsx
+++ b/libs/ui/src/network_status_indicator.tsx
@@ -1,0 +1,145 @@
+import React, { useId } from 'react';
+import styled from 'styled-components';
+import { Icons } from './icons';
+
+/**
+ * The network statuses a machine's toolbar indicator can display, grouped by
+ * severity:
+ * - `connected` — neutral; on the network and connected to a host (or, for
+ *   the host itself, online).
+ * - `no-host-connected` — warning; online but not connected to a compatible
+ *   VxAdmin host (none detected, or one detected but not connectable, e.g.
+ *   configured for a different election). Not applicable to the host itself.
+ * - `no-network` — warning; no network connection.
+ * - `error` — danger; a network conflict that blocks all connections (e.g.
+ *   multiple hosts detected or an incompatible software version).
+ */
+export type NetworkIndicatorStatus =
+  | 'connected'
+  | 'no-host-connected'
+  | 'no-network'
+  | 'error';
+
+/**
+ * Network statuses applicable to the VxAdmin host machine itself, which is
+ * never waiting on a VxAdmin connection.
+ */
+export type HostNetworkIndicatorStatus = Exclude<
+  NetworkIndicatorStatus,
+  'no-host-connected'
+>;
+
+const IndicatorRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 0.4rem;
+  align-items: center;
+  white-space: nowrap;
+`;
+
+/**
+ * A slashed variant of the network (sitemap) icon, used for warning and error
+ * states. Not part of FontAwesome, so it's inlined here. Sized and aligned to
+ * match the FontAwesome icons rendered by `Icons`.
+ */
+const NetworkOffSvg = styled.svg`
+  height: 1em;
+  width: 1em;
+  vertical-align: -0.125em;
+  color: ${(p) => p.theme.colors.onInverse};
+`;
+
+function NetworkOffIcon(): JSX.Element {
+  const maskId = useId();
+  return (
+    <NetworkOffSvg
+      data-testid="network-off-icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 640 640"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <mask
+        id={maskId}
+        maskUnits="userSpaceOnUse"
+        x="0"
+        y="0"
+        width="640"
+        height="640"
+      >
+        <rect width="640" height="640" fill="#fff" />
+        <line
+          x1="60"
+          y1="85.2"
+          x2="568"
+          y2="629.9"
+          stroke="#000"
+          strokeWidth="150"
+          strokeLinecap="round"
+        />
+      </mask>
+      <path
+        mask={`url(#${maskId})`}
+        d="M256 128C256 110.3 270.3 96 288 96L352 96C369.7 96 384 110.3 384 128L384 192C384 209.7 369.7 224 352 224L344 224L344 288L464 288C503.8 288 536 320.2 536 360L536 416L544 416C561.7 416 576 430.3 576 448L576 512C576 529.7 561.7 544 544 544L480 544C462.3 544 448 529.7 448 512L448 448C448 430.3 462.3 416 480 416L488 416L488 360C488 346.7 477.3 336 464 336L344 336L344 416L352 416C369.7 416 384 430.3 384 448L384 512C384 529.7 369.7 544 352 544L288 544C270.3 544 256 529.7 256 512L256 448C256 430.3 270.3 416 288 416L296 416L296 336L176 336C162.7 336 152 346.7 152 360L152 416L160 416C177.7 416 192 430.3 192 448L192 512C192 529.7 177.7 544 160 544L96 544C78.3 544 64 529.7 64 512L64 448C64 430.3 78.3 416 96 416L104 416L104 360C104 320.2 136.2 288 176 288L296 288L296 224L288 224C270.3 224 256 209.7 256 192L256 128z"
+      />
+      <line
+        x1="120"
+        y1="149.5"
+        x2="508"
+        y2="565.6"
+        stroke="currentColor"
+        strokeWidth="54"
+        strokeLinecap="round"
+      />
+    </NetworkOffSvg>
+  );
+}
+
+export type NetworkStatusIndicatorProps =
+  | { isHost: true; status: HostNetworkIndicatorStatus }
+  | { isHost?: false; status: NetworkIndicatorStatus };
+
+/**
+ * A toolbar indicator showing a machine's network status. Rendered on inverse
+ * (dark) toolbar backgrounds.
+ */
+export function NetworkStatusIndicator(
+  props: NetworkStatusIndicatorProps
+): JSX.Element {
+  const { isHost, status } = props;
+
+  const contents: Record<
+    NetworkIndicatorStatus,
+    { icon: JSX.Element; label: string }
+  > = {
+    connected: {
+      icon: <Icons.Sitemap color="inverse" />,
+      label: isHost ? 'Network Online' : 'Connected',
+    },
+    'no-host-connected': {
+      icon: <NetworkOffIcon />,
+      label: 'No VxAdmin Connected',
+    },
+    'no-network': {
+      icon: <NetworkOffIcon />,
+      label: 'No Network',
+    },
+    error: {
+      icon: (
+        <React.Fragment>
+          <NetworkOffIcon />
+          <Icons.Danger color="inverseDanger" />
+        </React.Fragment>
+      ),
+      label: 'Network Error',
+    },
+  };
+  const { icon, label } = contents[status];
+
+  return (
+    <IndicatorRow data-testid="network-status">
+      {icon}
+      {label}
+    </IndicatorRow>
+  );
+}

--- a/libs/ui/src/themes/color_theme.stories.tsx
+++ b/libs/ui/src/themes/color_theme.stories.tsx
@@ -487,6 +487,20 @@ export function ColorThemes(): JSX.Element {
                 <ContrastTag />
               </span>
             </Accent>
+            <Accent>
+              <span
+                style={{
+                  color: colors.inverseDangerAccent,
+                  fontSize: '1.5rem',
+                }}
+              >
+                <Icons.Danger />
+              </span>
+              Inverse Danger Accent
+              <span style={{ color: colors.inverseDangerAccent }}>
+                <ContrastTag />
+              </span>
+            </Accent>
           </div>
         </RoundedRect>
         <RoundedRect

--- a/libs/ui/src/themes/color_theme.stories.tsx
+++ b/libs/ui/src/themes/color_theme.stories.tsx
@@ -533,6 +533,20 @@ export function ColorThemes(): JSX.Element {
                 <ContrastTag />
               </span>
             </Accent>
+            <Accent>
+              <span
+                style={{
+                  color: colors.inverseDangerAccent,
+                  fontSize: '1.5rem',
+                }}
+              >
+                <Icons.Danger />
+              </span>
+              Inverse Danger Accent
+              <span style={{ color: colors.inverseDangerAccent }}>
+                <ContrastTag />
+              </span>
+            </Accent>
           </div>
         </RoundedRect>
       </Section>

--- a/libs/ui/src/themes/make_theme.ts
+++ b/libs/ui/src/themes/make_theme.ts
@@ -194,6 +194,7 @@ function expandToFullColorTheme(theme: TouchscreenColorTheme): ColorTheme {
     inversePrimary: theme.background,
     inverseContainer: theme.onBackground,
     inverseWarningAccent: theme.warningAccent,
+    inverseDangerAccent: theme.danger,
 
     successAccent: theme.successAccent,
     warningAccent: theme.warningAccent,
@@ -266,6 +267,7 @@ export const colorThemes: Record<ColorMode, ColorTheme> = {
     inversePrimary: DesktopPalette.Purple30,
     inverseContainer: DesktopPalette.Gray80,
     inverseWarningAccent: DesktopPalette.Orange30,
+    inverseDangerAccent: DesktopPalette.Red40,
 
     successAccent: DesktopPalette.Green60,
     warningAccent: DesktopPalette.Orange50,

--- a/libs/ui/src/toolbar.test.tsx
+++ b/libs/ui/src/toolbar.test.tsx
@@ -2,11 +2,13 @@ import { expect, test, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '../test/react_testing_library';
 
+import { mockUsbDriveStatus } from './test-utils/mock_usb_drive';
 import {
   BatteryStatus,
   DateTimeDisplay,
   LockMachineButton,
   Toolbar,
+  UsbEjectButton,
 } from './toolbar';
 
 vi.useFakeTimers({
@@ -70,4 +72,52 @@ test('Toolbar renders children', () => {
     </Toolbar>
   );
   screen.getByText('test content');
+});
+
+test('UsbEjectButton ejects a mounted drive', () => {
+  const onEject = vi.fn();
+  render(
+    <UsbEjectButton
+      usbDriveStatus={mockUsbDriveStatus('mounted')}
+      onEject={onEject}
+      isEjecting={false}
+    />
+  );
+  const button = screen.getByRole('button', { name: /Eject USB/ });
+  expect(button).toBeEnabled();
+  userEvent.click(button);
+  expect(onEject).toHaveBeenCalledTimes(1);
+});
+
+test('UsbEjectButton is disabled while ejecting', () => {
+  render(
+    <UsbEjectButton
+      usbDriveStatus={mockUsbDriveStatus('mounted')}
+      onEject={vi.fn()}
+      isEjecting
+    />
+  );
+  expect(screen.getByRole('button', { name: /Ejecting/ })).toBeDisabled();
+});
+
+test('UsbEjectButton is disabled without a drive', () => {
+  render(
+    <UsbEjectButton
+      usbDriveStatus={mockUsbDriveStatus('no_drive')}
+      onEject={vi.fn()}
+      isEjecting={false}
+    />
+  );
+  expect(screen.getByRole('button', { name: /No USB/ })).toBeDisabled();
+});
+
+test('UsbEjectButton shows ejected state', () => {
+  render(
+    <UsbEjectButton
+      usbDriveStatus={mockUsbDriveStatus('ejected')}
+      onEject={vi.fn()}
+      isEjecting={false}
+    />
+  );
+  expect(screen.getByRole('button', { name: /USB Ejected/ })).toBeDisabled();
 });

--- a/libs/ui/src/toolbar.tsx
+++ b/libs/ui/src/toolbar.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import type { BatteryInfo } from '@votingworks/backend';
+import type { UsbDriveStatus } from '@votingworks/usb-drive';
 import { format } from '@votingworks/utils';
 import { Button } from './button';
 import { getBatteryIcon } from './battery_display';
-import { Icons } from './icons';
+import { IconName, Icons } from './icons';
 
 export const Toolbar = styled.div`
   display: flex;
@@ -68,6 +69,43 @@ function useCurrentDate(): Date {
 export function DateTimeDisplay(): JSX.Element {
   const currentDate = useCurrentDate();
   return <span>{format.clockDateAndTime(currentDate)}</span>;
+}
+
+type ExtendedUsbDriveStatus = UsbDriveStatus['status'] | 'ejecting';
+const USB_BUTTON_ICON_AND_TEXT: Record<
+  ExtendedUsbDriveStatus,
+  [IconName, string]
+> = {
+  no_drive: ['Disabled', 'No USB'],
+  error: ['Disabled', 'No USB'],
+  mounted: ['Eject', 'Eject USB'],
+  ejecting: ['Eject', 'Ejecting...'],
+  ejected: ['Disabled', 'USB Ejected'],
+};
+
+export function UsbEjectButton({
+  usbDriveStatus,
+  onEject,
+  isEjecting,
+}: {
+  usbDriveStatus: UsbDriveStatus;
+  onEject: () => void;
+  isEjecting: boolean;
+}): JSX.Element {
+  const extendedStatus: ExtendedUsbDriveStatus = isEjecting
+    ? 'ejecting'
+    : usbDriveStatus.status;
+  const [icon, text] = USB_BUTTON_ICON_AND_TEXT[extendedStatus];
+  return (
+    <CompactButton
+      icon={icon}
+      onPress={onEject}
+      color="inverseNeutral"
+      disabled={extendedStatus !== 'mounted' || isEjecting}
+    >
+      {text}
+    </CompactButton>
+  );
 }
 
 export function LockMachineButton({


### PR DESCRIPTION
## Overview
Moves VxCentralScan to use the same compact topbar as VxAdmin and adds a network status indicator to it. 

See: https://votingworks.slack.com/archives/CEL6D3GAD/p1787170629952689 for more discussion and context. 

VxAdmin will be adapted to use the new shared version of the network status icon in a future pr. 

## Demo Video or Screenshot
<img width="1173" height="738" alt="Screenshot 2026-08-20 at 3 03 17 PM" src="https://github.com/user-attachments/assets/e621fabe-afc0-47a9-ab0e-31475e94c21a" />
<img width="1185" height="750" alt="Screenshot 2026-08-24 at 11 06 07 AM" src="https://github.com/user-attachments/assets/00ea312f-d5f2-4427-8788-4967a63bdee0" />
<img width="1191" height="753" alt="Screenshot 2026-08-24 at 11 05 08 AM" src="https://github.com/user-attachments/assets/30535788-a72b-4ea9-817a-c860d53ae457" />
<img width="1174" height="746" alt="Screenshot 2026-08-24 at 11 04 57 AM" src="https://github.com/user-attachments/assets/43c31a3b-09e8-4de9-b6a5-38e48f61c353" />


## Testing Plan
Tested all possible network states 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
