### PR TITLE
ci: do not cache playwright install flag

### DIFF
--- a/libs/printing/scripts/install-playwright-deps
+++ b/libs/printing/scripts/install-playwright-deps
@@ -13,12 +13,17 @@
 # dependencies followed by existence checks for each and 2) checking for a
 # network connection before running the install commands. All felt fragile in
 # their own ways.
+#
+# The flag file deliberately lives outside the Playwright browser cache. CI
+# caches that directory but not the system packages installed alongside it, so
+# a flag file stored there would outlive the packages it vouches for and let a
+# job run against a partial install.
 
 set -euo pipefail
 
-PLAYWRIGHT_CACHE_DIRECTORY="${HOME}/.cache/ms-playwright"
+PLAYWRIGHT_DEPS_FLAG_DIRECTORY="${HOME}/.cache/vx-playwright-deps"
 PLAYWRIGHT_VERSION="$(pnpm exec playwright --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
-PLAYWRIGHT_DEPS_INSTALLED_FLAG_FILE="${PLAYWRIGHT_CACHE_DIRECTORY}/${PLAYWRIGHT_VERSION}_DEPS_INSTALLED"
+PLAYWRIGHT_DEPS_INSTALLED_FLAG_FILE="${PLAYWRIGHT_DEPS_FLAG_DIRECTORY}/${PLAYWRIGHT_VERSION}_DEPS_INSTALLED"
 
 if [[ -f "${PLAYWRIGHT_DEPS_INSTALLED_FLAG_FILE}" ]]; then
   message="Playwright dependencies already installed for version ${PLAYWRIGHT_VERSION}
@@ -29,5 +34,6 @@ To force a reinstall, delete this file.
   echo "${message}"
 else
   pnpm exec playwright install --with-deps chromium
+  mkdir -p "${PLAYWRIGHT_DEPS_FLAG_DIRECTORY}"
   touch "${PLAYWRIGHT_DEPS_INSTALLED_FLAG_FILE}"
 fi


### PR DESCRIPTION
## Overview

`playwright install` affects more than just the `~/.cache/ms-playwright` directory, so gating whether we run that command based on a file inside the cached `ms-playwright` directory means we'll skip doing those other steps on machines where that file is restored from the cache. In practice this means we skip installing the fonts we need, which shows up as mismatching HMPB fixtures and downstream election grid layouts.

We fix this by putting the install flag file outside the set of cached directories.

## Demo Video or Screenshot
n/a
## Testing Plan

CI, but I'm guessing the first run will fail because changes to the install script won't trigger a cache miss. I'll likely have to add a change to the CircleCI config to bust the cache.