### PR TITLE
fix(logging): escape quotes/newlines/etc in event data

### DIFF
--- a/libs/logging/scripts/generate_rust_enums_from_toml.ts
+++ b/libs/logging/scripts/generate_rust_enums_from_toml.ts
@@ -1,4 +1,5 @@
 import toml from '@iarna/toml';
+import { assertDefined } from '@votingworks/basics';
 import { execFileSync } from 'node:child_process';
 import { createReadStream, createWriteStream } from 'node:fs';
 import { pipeline } from 'node:stream/promises';
@@ -15,6 +16,23 @@ import {
   diffAndCleanUp,
   parseConfig,
 } from './types';
+
+const RUST_STRING_ESCAPES: ReadonlyMap<string, string> = new Map([
+  ['\\', '\\\\'],
+  ['"', '\\"'],
+  ['\n', '\\n'],
+  ['\r', '\\r'],
+  ['\t', '\\t'],
+]);
+
+// Renders `value` as a double-quoted Rust string literal, escaping the
+// characters that would otherwise terminate or alter it.
+function rustStringLiteral(value: string): string {
+  const escaped = value.replace(/[\\"\n\r\t]/g, (char) =>
+    assertDefined(RUST_STRING_ESCAPES.get(char))
+  );
+  return `"${escaped}"`;
+}
 
 function* generateLogEventIdEnum(config: LoggingConfig): Generator<string> {
   yield `
@@ -36,7 +54,7 @@ function* generateLogEventIdEnum(config: LoggingConfig): Generator<string> {
   `;
 
   for (const [enumMember, eventType] of config.apps) {
-    yield `#[serde(rename = "${eventType.name}")]
+    yield `#[serde(rename = ${rustStringLiteral(eventType.name)})]
       ${enumMember},`;
   }
 
@@ -49,7 +67,7 @@ function* generateLogEventIdEnum(config: LoggingConfig): Generator<string> {
   `;
 
   for (const [enumMember, eventType] of config.logSources) {
-    yield `#[serde(rename = "${eventType.source}")]
+    yield `#[serde(rename = ${rustStringLiteral(eventType.source)})]
       ${enumMember},`;
   }
 
@@ -62,7 +80,7 @@ function* generateLogEventIdEnum(config: LoggingConfig): Generator<string> {
   `;
 
   for (const [enumMember, eventType] of config.eventTypes) {
-    yield `#[serde(rename = "${eventType.eventType}")]
+    yield `#[serde(rename = ${rustStringLiteral(eventType.eventType)})]
       ${enumMember},`;
   }
 
@@ -81,7 +99,7 @@ function* generateLogEventIdEnum(config: LoggingConfig): Generator<string> {
   `;
 
   for (const [enumMember, logDetails] of config.events) {
-    yield `#[serde(rename = "${logDetails.eventId}")]
+    yield `#[serde(rename = ${rustStringLiteral(logDetails.eventId)})]
       ${enumMember},`;
   }
   yield '}';

--- a/libs/logging/scripts/generate_types_from_toml.ts
+++ b/libs/logging/scripts/generate_types_from_toml.ts
@@ -32,7 +32,7 @@ function* generateEnum(
 ): Generator<string> {
   yield `export enum ${name} {\n`;
   for (const [enumMember, value] of entries) {
-    yield `${enumMember} = '${value}',\n`;
+    yield `${enumMember} = ${JSON.stringify(value)},\n`;
   }
   yield '}\n';
 }
@@ -49,10 +49,10 @@ function* generateLogDetails(config: LoggingConfig): Generator<string> {
     const ${titleCaseEventId}: LogDetails = {
       eventId: LogEventId.${titleCaseEventId},
       eventType: LogEventType.${eventTypeEnumMember},
-      documentationMessage: '${details.documentationMessage}',
+      documentationMessage: ${JSON.stringify(details.documentationMessage)},
   `;
     if (details.defaultMessage) {
-      yield `defaultMessage: '${details.defaultMessage}',`;
+      yield `defaultMessage: ${JSON.stringify(details.defaultMessage)},`;
     }
     if (details.restrictInDocumentationToApps) {
       yield `restrictInDocumentationToApps: [${details.restrictInDocumentationToApps.map(
@@ -166,7 +166,7 @@ async function main(): Promise<void> {
 
   const out = createWriteStream(filepath);
 
-  await pipeline(async function* makeRustFile() {
+  await pipeline(async function* makeTsFile() {
     yield* createReadStream(logEventIdsTemplateFilepath);
     yield* '\n';
     yield* generateEnum('AppName', appNameConfig);


### PR DESCRIPTION

## Overview

We can't just interpolate the event data directly into source files surrounded by quotes and hope for the best. Anything containing a quote, newline, backslash, etc will create invalid TS & Rust syntax. Fix the issue by escaping such characters before interpolating.

## Demo Video or Screenshot
```
$ pnpm build:generate-types && pnpm build:generate-docs

> @votingworks/logging@1.0.0 build:generate-types /home/vx/code/vxsuite-brian-admin-backup-restore/libs/logging
> pnpm build:generate-typescript-types && pnpm build:generate-rust-types


> @votingworks/logging@1.0.0 build:generate-typescript-types /home/vx/code/vxsuite-brian-admin-backup-restore/libs/logging
> pnpm esr --cache ./scripts/generate_types_from_toml.ts

Error: Command failed: prettier --write /home/vx/code/vxsuite-brian-admin-backup-restore/libs/logging/scripts/../src/log_event_enums.ts
[error] src/log_event_enums.ts: SyntaxError: ',' expected. (900:107)
[error]   898 |       eventId: LogEventId.BackupRestoreMachineMismatch,
[error]   899 |       eventType: LogEventType.UserAction,
[error] > 900 |       documentationMessage: 'User is restoring a backup whose machine ID differs from the current machine's ID.',
[error]       |                                                                                                           ^
[error]   901 |   restrictInDocumentationToApps: [AppName.VxAdmin],
[error]   902 |     };
[error]   903 |
```

## Testing Plan

Tested locally with single quotes in the documentation message. Fails before, works after.
