### PR TITLE
[VxAdmin] Update networking UIs for consistency w/ and inclusion of VxCentralScan

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -159,6 +159,7 @@ create table cvrs (
 
 create index idx_cvrs_election_id on cvrs(election_id);
 create index idx_cvrs_ballot_id on cvrs(ballot_id);
+create index idx_cvrs_batch_id on cvrs(election_id, batch_id);
 
 create table scanner_batches (
   id text not null,
@@ -264,6 +265,8 @@ create table machines (
   status text not null
     check (status in ('offline', 'online_locked', 'active', 'adjudicating')),
   auth_type text,
+  polling_place_id text,
+  registration_error text,
   last_seen_at integer not null
 ) strict;
 

--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -126,11 +126,21 @@ test('setMachineMode throws when election is configured', async () => {
   );
 });
 
+test('getScannerImportCounts returns empty until CVRs are imported', async () => {
+  const { apiClient, auth } = buildTestEnvironment();
+  // Unconfigured: no election to count against
+  expect(await apiClient.getScannerImportCounts()).toEqual({});
+
+  await configureMachine(apiClient, auth, readElectionGeneralDefinition());
+  expect(await apiClient.getScannerImportCounts()).toEqual({});
+});
+
 test('getNetworkStatus returns offline with no connected clients by default', async () => {
   const { apiClient } = buildTestEnvironment();
   expect(await apiClient.getNetworkStatus()).toEqual({
     isOnline: false,
     connectedClients: [],
+    connectedScanners: [],
     multipleHostsDetected: false,
   });
 });

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -302,6 +302,7 @@ function buildApi({
     getNetworkStatus(): {
       isOnline: boolean;
       connectedClients: MachineRecord[];
+      connectedScanners: MachineRecord[];
       multipleHostsDetected: boolean;
     } {
       const { machineId } = getMachineConfig();
@@ -316,8 +317,23 @@ function buildApi({
         connectedClients: machines.filter(
           (m) => m.machineRole === 'admin-client'
         ),
+        connectedScanners: machines.filter((m) => m.machineRole === 'scanner'),
         multipleHostsDetected: store.getMultipleHostsDetected(machineId),
       };
+    },
+
+    /**
+     * Counts of CVRs and batches imported from each scanner for the current
+     * election. Counting scans every CVR row, so this is too expensive for
+     * the frequently-polled getNetworkStatus — it's a separate method for
+     * the screens that need it, polled at a slower interval.
+     */
+    getScannerImportCounts(): Record<
+      string,
+      { cvrCount: number; batchCount: number }
+    > {
+      const electionId = store.getCurrentElectionId();
+      return electionId ? store.getScannerImportCounts(electionId) : {};
     },
 
     getIsClientAdjudicationEnabled(): boolean {

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -324,9 +324,7 @@ function buildApi({
 
     /**
      * Counts of CVRs and batches imported from each scanner for the current
-     * election. Counting scans every CVR row, so this is too expensive for
-     * the frequently-polled getNetworkStatus — it's a separate method for
-     * the screens that need it, polled at a slower interval.
+     * election.
      */
     getScannerImportCounts(): Record<
       string,

--- a/apps/admin/backend/src/peer_app.test.ts
+++ b/apps/admin/backend/src/peer_app.test.ts
@@ -81,8 +81,15 @@ test('registerAdjudicationStation rejects a client running an incompatible code 
 
   expect(result).toEqual(err({ type: 'code-version-mismatch' }));
 
-  // The incompatible client must not be registered as a connected machine.
-  expect(workspace.store.getMachines()).toHaveLength(0);
+  // The incompatible station is still recorded, with the error, so it can be
+  // shown in the host's UI.
+  expect(workspace.store.getMachines()).toEqual([
+    expect.objectContaining({
+      machineId: 'client-001',
+      machineRole: 'admin-client',
+      registrationError: 'code-version-mismatch',
+    }),
+  ]);
 });
 
 test('registerAdjudicationStation persists status and authType and returns adjudication enabled', async () => {
@@ -255,7 +262,7 @@ test('registerScanner records the scanner and returns the host machine config', 
   ]);
 });
 
-test('registerScanner does not record a scanner configured for a different election', async () => {
+test('registerScanner records a scanner configured for a different election with an error', async () => {
   const { peerApiClient, apiClient, auth, peerLogger, workspace } =
     buildTestEnvironment();
   await configureMachine(apiClient, auth, readElectionGeneralDefinition());
@@ -266,7 +273,12 @@ test('registerScanner does not record a scanner configured for a different elect
       ballotHash: 'some-other-ballot-hash',
     })
   ).toEqual(err({ type: 'ballot-hash-mismatch' }));
-  expect(workspace.store.getMachines()).toEqual([]);
+  expect(workspace.store.getMachines()).toEqual([
+    expect.objectContaining({
+      machineId: 'SCANNER-01',
+      registrationError: 'ballot-hash-mismatch',
+    }),
+  ]);
   expect(peerLogger.log).toHaveBeenCalledWith(
     LogEventId.AdminNetworkStatus,
     'system',
@@ -278,7 +290,7 @@ test('registerScanner does not record a scanner configured for a different elect
   );
 });
 
-test('registerScanner does not record an unconfigured scanner', async () => {
+test('registerScanner records an unconfigured scanner with an error', async () => {
   const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
   await configureMachine(apiClient, auth, readElectionGeneralDefinition());
   expect(
@@ -287,10 +299,15 @@ test('registerScanner does not record an unconfigured scanner', async () => {
       codeVersion: 'dev',
     })
   ).toEqual(err({ type: 'scanner-unconfigured' }));
-  expect(workspace.store.getMachines()).toEqual([]);
+  expect(workspace.store.getMachines()).toEqual([
+    expect.objectContaining({
+      machineId: 'SCANNER-01',
+      registrationError: 'scanner-unconfigured',
+    }),
+  ]);
 });
 
-test('registerScanner does not record a scanner when the host is unconfigured', async () => {
+test('registerScanner records a scanner with an error when the host is unconfigured', async () => {
   const { peerApiClient, workspace } = buildTestEnvironment();
   expect(
     await peerApiClient.registerScanner({
@@ -299,10 +316,15 @@ test('registerScanner does not record a scanner when the host is unconfigured', 
       ballotHash: readElectionGeneralDefinition().ballotHash,
     })
   ).toEqual(err({ type: 'host-unconfigured' }));
-  expect(workspace.store.getMachines()).toEqual([]);
+  expect(workspace.store.getMachines()).toEqual([
+    expect.objectContaining({
+      machineId: 'SCANNER-01',
+      registrationError: 'host-unconfigured',
+    }),
+  ]);
 });
 
-test('registerScanner does not record a scanner running an incompatible code version', async () => {
+test('registerScanner records a scanner running an incompatible code version with an error', async () => {
   const { peerApiClient, peerLogger, workspace } = buildTestEnvironment();
   expect(
     await peerApiClient.registerScanner({
@@ -310,7 +332,13 @@ test('registerScanner does not record a scanner running an incompatible code ver
       codeVersion: 'some-other-version',
     })
   ).toEqual(err({ type: 'code-version-mismatch' }));
-  expect(workspace.store.getMachines()).toEqual([]);
+  expect(workspace.store.getMachines()).toEqual([
+    expect.objectContaining({
+      machineId: 'SCANNER-01',
+      machineRole: 'scanner',
+      registrationError: 'code-version-mismatch',
+    }),
+  ]);
   expect(peerLogger.log).toHaveBeenCalledWith(
     LogEventId.AdminNetworkStatus,
     'system',

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -70,8 +70,22 @@ function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
       machineId: string;
       codeVersion: string;
       ballotHash?: string;
+      pollingPlaceId?: string;
     }): Result<MachineConfig, RegisterScannerError> {
       const machineConfig = getMachineConfig();
+
+      function recordScanner(
+        registrationError: RegisterScannerError['type'] | null
+      ): void {
+        store.setNetworkedMachineStatus(
+          input.machineId,
+          'scanner',
+          Admin.ClientMachineStatus.Active,
+          null,
+          input.pollingPlaceId ?? null,
+          registrationError
+        );
+      }
 
       function reject(
         error: RegisterScannerError,
@@ -85,6 +99,9 @@ function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
           error: error.type,
           ...extra,
         });
+        // Still record the scanner so it can be shown, along with the
+        // problem, in the host's UI.
+        recordScanner(error.type);
         return err(error);
       }
 
@@ -129,11 +146,7 @@ function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
         );
       }
       debug('Scanner %s registered with host', input.machineId);
-      store.setNetworkedMachineStatus(
-        input.machineId,
-        'scanner',
-        Admin.ClientMachineStatus.Active
-      );
+      recordScanner(null);
       return ok(machineConfig);
     },
 
@@ -157,6 +170,16 @@ function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
           clientCodeVersion: input.codeVersion,
           hostCodeVersion: machineConfig.codeVersion,
         });
+        // Still record the station so it can be shown, along with the
+        // problem, in the host's UI.
+        store.setNetworkedMachineStatus(
+          input.machineId,
+          'admin-client',
+          input.status,
+          input.authType,
+          null,
+          'code-version-mismatch'
+        );
         return err({ type: 'code-version-mismatch' });
       }
       debug(

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -400,6 +400,60 @@ test('delete empty scanner batches', async () => {
   expect(store.getScannerBatches(electionId)).toEqual([batchWithCvrs]);
 });
 
+test('getScannerImportCounts groups cvr and batch counts by scanner', async () => {
+  const fixtures = electionTwoPartyPrimaryFixtures;
+  const election = fixtures.readElection();
+  const ballotStyleGroups = getGroupedBallotStyles(election.ballotStyles);
+  const ballotStyleGroup = assertDefined(ballotStyleGroups[0]);
+
+  const store = Store.memoryStore(makeTemporaryDirectory());
+  const electionId = await store.addElection({
+    electionData: fixtures.electionJson.asText(),
+    systemSettingsData,
+    electionPackageSourceFilePath: makeTemporaryFile(),
+    electionPackageHash: 'test-election-package-hash',
+  });
+
+  expect(store.getScannerImportCounts(electionId)).toEqual({});
+
+  const contest = find(
+    election.contests,
+    (c): c is CandidateContest => c.type === 'candidate'
+  );
+  function mockCvr(
+    batchId: string,
+    scannerId: string
+  ): Parameters<
+    typeof addMockCvrFileToStore
+  >[0]['mockCastVoteRecordFile'][number] {
+    return {
+      ballotStyleGroupId: ballotStyleGroup.id,
+      batchId,
+      scannerId,
+      precinctId: 'precinct-1',
+      votingMethod: 'precinct',
+      votes: { [contest.id]: [contest.candidates[0]!.id] },
+      card: { type: 'bmd' },
+    };
+  }
+  addMockCvrFileToStore({
+    electionId,
+    store,
+    mockCastVoteRecordFile: [
+      mockCvr('1', 'scanner-1'),
+      mockCvr('1', 'scanner-1'),
+      mockCvr('2', 'scanner-1'),
+      mockCvr('3', 'scanner-2'),
+    ],
+    pollingPlaceId: 'polling-place-1',
+  });
+
+  expect(store.getScannerImportCounts(electionId)).toEqual({
+    'scanner-1': { cvrCount: 3, batchCount: 2 },
+    'scanner-2': { cvrCount: 1, batchCount: 1 },
+  });
+});
+
 test('getWriteInCandidates returns no candidates for an empty contestIds filter', async () => {
   const store = Store.memoryStore(makeTemporaryDirectory());
   const electionId = await store.addElection({

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -103,6 +103,7 @@ import {
   BaseStore,
   MachineRecord,
   NetworkedMachineRole,
+  RegistrationErrorType,
   BallotAdjudicationQueueMetadata,
   BallotAdjudicationData,
   ContestAdjudicationData,
@@ -3414,20 +3415,26 @@ export class Store implements BaseStore {
     machineId: string,
     machineRole: NetworkedMachineRole,
     status: Admin.ClientMachineStatus,
-    authType: UserRole | null = null
+    authType: UserRole | null = null,
+    pollingPlaceId: string | null = null,
+    registrationError: RegistrationErrorType | null = null
   ): void {
     this.client.run(
-      `insert into machines (machine_id, machine_role, status, auth_type, last_seen_at)
-       values (?, ?, ?, ?, ?)
+      `insert into machines (machine_id, machine_role, status, auth_type, polling_place_id, registration_error, last_seen_at)
+       values (?, ?, ?, ?, ?, ?, ?)
        on conflict (machine_id) do update set
          machine_role = excluded.machine_role,
          status = excluded.status,
          auth_type = excluded.auth_type,
+         polling_place_id = excluded.polling_place_id,
+         registration_error = excluded.registration_error,
          last_seen_at = excluded.last_seen_at`,
       machineId,
       machineRole,
       status,
       authType,
+      pollingPlaceId,
+      registrationError,
       getCurrentTime()
     );
   }
@@ -3439,6 +3446,8 @@ export class Store implements BaseStore {
          machine_role as machineRole,
          status,
          auth_type as authType,
+         polling_place_id as pollingPlaceId,
+         registration_error as registrationError,
          last_seen_at as lastSeenAt
        from machines
        where machine_id = ?`,
@@ -3459,6 +3468,8 @@ export class Store implements BaseStore {
            else machines.status
          end as status,
          auth_type as authType,
+         polling_place_id as pollingPlaceId,
+         registration_error as registrationError,
          last_seen_at as lastSeenAt
        from machines`,
       Admin.ClientMachineStatus.Active,
@@ -3518,6 +3529,32 @@ export class Store implements BaseStore {
     if (currentElectionId) {
       this.releaseAllActiveClaims({ electionId: currentElectionId });
     }
+  }
+
+  getScannerImportCounts(
+    electionId: Id
+  ): Record<string, { cvrCount: number; batchCount: number }> {
+    const rows = this.client.all(
+      `
+        select
+          scanner_batches.scanner_id as scannerId,
+          count(distinct scanner_batches.id) as batchCount,
+          count(cvrs.id) as cvrCount
+        from scanner_batches
+        left join cvrs
+          on cvrs.batch_id = scanner_batches.id
+          and cvrs.election_id = scanner_batches.election_id
+        where scanner_batches.election_id = ?
+        group by scanner_batches.scanner_id
+      `,
+      electionId
+    ) as Array<{ scannerId: string; batchCount: number; cvrCount: number }>;
+    return Object.fromEntries(
+      rows.map((row) => [
+        row.scannerId,
+        { cvrCount: row.cvrCount, batchCount: row.batchCount },
+      ])
+    );
   }
 
   getMultipleHostsDetected(selfMachineId: string): boolean {

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -22,6 +22,7 @@ import {
   ScannerMachineType,
   UserRole,
 } from '@votingworks/types';
+import type { RegisterScannerError } from '@votingworks/networking';
 import { z } from 'zod/v4';
 
 export type { ExportDataResult, ExportDataError } from '@votingworks/backend';
@@ -50,6 +51,11 @@ export interface RegisterAdjudicationStationError {
   type: 'code-version-mismatch';
 }
 
+/** Error type for host to machine connection */
+export type RegistrationErrorType =
+  | RegisterScannerError['type']
+  | RegisterAdjudicationStationError['type'];
+
 /** Connection status for a client machine in a multi-station setup. */
 export enum ClientConnectionStatus {
   Offline = 'offline',
@@ -65,6 +71,8 @@ export interface MachineRecord {
   machineRole: NetworkedMachineRole;
   status: Admin.ClientMachineStatus;
   authType: UserRole | null;
+  pollingPlaceId: string | null;
+  registrationError: RegistrationErrorType | null;
   lastSeenAt: number;
 }
 

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -74,6 +74,18 @@ export const setMachineMode = {
   },
 } as const;
 
+export const getScannerImportCounts = {
+  queryKey(): QueryKey {
+    return ['getScannerImportCounts'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () => apiClient.getScannerImportCounts(), {
+      refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL,
+    });
+  },
+} as const;
+
 export const getNetworkStatus = {
   queryKey(): QueryKey {
     return ['getNetworkStatus'];

--- a/apps/admin/frontend/src/app.test.tsx
+++ b/apps/admin/frontend/src/app.test.tsx
@@ -627,5 +627,8 @@ test('network status in toolbar', async () => {
   await screen.findByText('Network Online');
 
   apiMock.expectGetNetworkStatus({ isOnline: false });
-  await screen.findByText('Network Offline');
+  await screen.findByText('No Network');
+
+  apiMock.expectGetNetworkStatus({ multipleHostsDetected: true });
+  await screen.findByText('Network Error');
 });

--- a/apps/admin/frontend/src/client/client_app_root.test.tsx
+++ b/apps/admin/frontend/src/client/client_app_root.test.tsx
@@ -250,7 +250,6 @@ test('election manager sees adjudication, settings, and diagnostics tabs', async
 
 test('shows settings screen when logged in as system administrator', async () => {
   setSystemAdminAuth();
-  apiMock.expectGetNetworkConnectionStatus('online-connected-to-host');
   apiMock.expectGetUsbPortStatus();
   renderClientApp();
   await screen.findByRole('heading', { name: 'Settings' });
@@ -258,7 +257,6 @@ test('shows settings screen when logged in as system administrator', async () =>
 
 test('sysadmin sees settings and diagnostics tabs but not adjudication', async () => {
   setSystemAdminAuth();
-  apiMock.expectGetNetworkConnectionStatus('online-connected-to-host');
   apiMock.expectGetUsbPortStatus();
   renderClientApp();
   await screen.findByRole('heading', { name: 'Settings' });
@@ -270,7 +268,6 @@ test('sysadmin sees settings and diagnostics tabs but not adjudication', async (
 
 test('shows low battery alert when battery is low and discharging', async () => {
   setSystemAdminAuth();
-  apiMock.expectGetNetworkConnectionStatus('online-connected-to-host');
   apiMock.expectGetUsbPortStatus();
   apiMock.setBatteryInfo({ level: 0.1, discharging: true });
   renderClientApp();
@@ -281,7 +278,6 @@ test('shows low battery alert when battery is low and discharging', async () => 
 
 test('shows low disk space warning when disk space is low', async () => {
   setSystemAdminAuth();
-  apiMock.expectGetNetworkConnectionStatus('online-connected-to-host');
   apiMock.expectGetUsbPortStatus();
   apiMock.setDiskSpaceSummary({
     total: 100_000_000,

--- a/apps/admin/frontend/src/client/components/network_status_indicator.tsx
+++ b/apps/admin/frontend/src/client/components/network_status_indicator.tsx
@@ -1,0 +1,42 @@
+import { throwIllegalValue } from '@votingworks/basics';
+import type { NetworkConnectionStatus } from '@votingworks/admin-backend';
+import {
+  NetworkIndicatorStatus,
+  NetworkStatusIndicator as NetworkStatusIndicatorView,
+} from '@votingworks/ui';
+import { getNetworkConnectionStatus } from '../api.js';
+
+function indicatorStatus(
+  connection: NetworkConnectionStatus
+): NetworkIndicatorStatus {
+  const { status } = connection;
+  switch (status) {
+    case 'online-connected-to-host':
+      return 'connected';
+    case 'offline':
+      return 'no-network';
+    case 'online-waiting-for-host':
+      return 'no-host-connected';
+    case 'online-multiple-hosts-detected':
+    case 'online-incompatible-host-version':
+      return 'error';
+    // istanbul ignore next -- compile-time check
+    default:
+      return throwIllegalValue(status);
+  }
+}
+
+/**
+ * Toolbar network status indicator for adjudication stations, using the same
+ * status buckets as VxCentralScan's indicator.
+ */
+export function ClientNetworkStatusIndicator(): JSX.Element | null {
+  const networkStatusQuery = getNetworkConnectionStatus.useQuery();
+  if (!networkStatusQuery.isSuccess) return null;
+
+  return (
+    <NetworkStatusIndicatorView
+      status={indicatorStatus(networkStatusQuery.data)}
+    />
+  );
+}

--- a/apps/admin/frontend/src/client/screens/client_diagnostics_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_diagnostics_screen.test.tsx
@@ -34,6 +34,7 @@ test('shows diagnostics sections and battery info', async () => {
     level: 0.75,
     discharging: true,
   });
+  apiMock.expectGetNetworkConnectionStatus('online-connected-to-host', '0001');
   renderInClientContext(<ClientDiagnosticsScreen />, {
     auth: sysAdminAuth,
     apiMock,
@@ -42,4 +43,42 @@ test('shows diagnostics sections and battery info', async () => {
   screen.getByRole('heading', { name: 'Storage' });
   screen.getByRole('heading', { name: 'Battery' });
   screen.getByText(/Battery Level: 75%/);
+  screen.getByRole('heading', { name: 'Network' });
+  await screen.findByText(/Online — VxAdmin \(0001\) connected on the network/);
+});
+
+test('shows offline status', async () => {
+  apiMock.expectGetNetworkConnectionStatus('offline');
+  renderInClientContext(<ClientDiagnosticsScreen />, {
+    auth: sysAdminAuth,
+    apiMock,
+  });
+  await screen.findByText(/Offline/);
+});
+
+test('shows waiting for host status', async () => {
+  apiMock.expectGetNetworkConnectionStatus('online-waiting-for-host');
+  renderInClientContext(<ClientDiagnosticsScreen />, {
+    auth: sysAdminAuth,
+    apiMock,
+  });
+  await screen.findByText(/Online — no VxAdmin detected on the network/);
+});
+
+test('shows multiple hosts detected warning', async () => {
+  apiMock.expectGetNetworkConnectionStatus('online-multiple-hosts-detected');
+  renderInClientContext(<ClientDiagnosticsScreen />, {
+    auth: sysAdminAuth,
+    apiMock,
+  });
+  await screen.findByText(/Multiple VxAdmins detected/);
+});
+
+test('shows incompatible host version warning', async () => {
+  apiMock.expectGetNetworkConnectionStatus('online-incompatible-host-version');
+  renderInClientContext(<ClientDiagnosticsScreen />, {
+    auth: sysAdminAuth,
+    apiMock,
+  });
+  await screen.findByText(/running a different software version/);
 });

--- a/apps/admin/frontend/src/client/screens/client_diagnostics_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_diagnostics_screen.tsx
@@ -1,8 +1,63 @@
-import { AdminClientReadinessReportContents, Loading } from '@votingworks/ui';
 import { useContext } from 'react';
+import {
+  AdminClientReadinessReportContents,
+  H2,
+  Icons,
+  Loading,
+  P,
+} from '@votingworks/ui';
 import { NavigationScreen } from '../../components/navigation_screen.js';
 import { systemCallApi } from '../../shared_api.js';
 import { AppContext } from '../../contexts/app_context.js';
+import { getNetworkConnectionStatus } from '../api.js';
+
+function NetworkSection(): JSX.Element {
+  const networkStatusQuery = getNetworkConnectionStatus.useQuery();
+
+  return (
+    <section>
+      <H2>Network</H2>
+      <P>
+        {networkStatusQuery.isSuccess &&
+          networkStatusQuery.data.status === 'online-connected-to-host' && (
+            <span>
+              <Icons.Checkbox color="success" /> Online &mdash; VxAdmin (
+              {networkStatusQuery.data.hostMachineId}) connected on the network
+            </span>
+          )}
+        {networkStatusQuery.isSuccess &&
+          networkStatusQuery.data.status === 'online-waiting-for-host' && (
+            <span>
+              <Icons.Info /> Online &mdash; no VxAdmin detected on the network
+            </span>
+          )}
+        {networkStatusQuery.isSuccess &&
+          networkStatusQuery.data.status ===
+            'online-multiple-hosts-detected' && (
+            <span>
+              <Icons.Danger color="danger" /> Multiple VxAdmins detected on the
+              network. Ensure only one VxAdmin is connected.
+            </span>
+          )}
+        {networkStatusQuery.isSuccess &&
+          networkStatusQuery.data.status ===
+            'online-incompatible-host-version' && (
+            <span>
+              <Icons.Danger color="danger" /> A VxAdmin on the network is
+              running a different software version
+            </span>
+          )}
+        {networkStatusQuery.isSuccess &&
+          networkStatusQuery.data.status === 'offline' && (
+            <span>
+              <Icons.Info /> Offline
+            </span>
+          )}
+        {!networkStatusQuery.isSuccess && <span>Checking network status…</span>}
+      </P>
+    </section>
+  );
+}
 
 export function ClientDiagnosticsScreen(): JSX.Element {
   const { electionDefinition, electionPackageHash } = useContext(AppContext);
@@ -27,6 +82,7 @@ export function ClientDiagnosticsScreen(): JSX.Element {
         diskSpaceSummary={diskSpaceSummary}
         electionDefinition={electionDefinition}
         electionPackageHash={electionPackageHash}
+        networkSectionUi={<NetworkSection />}
       />
     </NavigationScreen>
   );

--- a/apps/admin/frontend/src/client/screens/client_settings_screen.test.tsx
+++ b/apps/admin/frontend/src/client/screens/client_settings_screen.test.tsx
@@ -34,14 +34,11 @@ const sysAdminAuth: DippedSmartCardAuth.SystemAdministratorLoggedIn = {
 
 test('renders settings screen for system administrator', async () => {
   apiMock.expectGetUsbPortStatus();
-  apiMock.expectGetNetworkConnectionStatus('online-connected-to-host', '0001');
   renderInClientContext(<ClientSettingsScreen />, {
     auth: sysAdminAuth,
     apiMock,
   });
   await screen.findByRole('heading', { name: 'Settings' });
-  screen.getByRole('heading', { name: 'Network' });
-  await screen.findByText(/Connected to host 0001/);
   screen.getByRole('heading', { name: 'Logs' });
   screen.getByRole('heading', { name: 'Date and Time' });
   screen.getByRole('heading', { name: 'USB Formatting' });
@@ -65,10 +62,7 @@ test('renders settings screen for election manager (fewer sections)', async () =
   });
   await screen.findByRole('heading', { name: 'Settings' });
   screen.getByRole('heading', { name: 'Logs' });
-  // EM does not see Network, USB Formatting, or Machine Mode sections
-  expect(
-    screen.queryByRole('heading', { name: 'Network' })
-  ).not.toBeInTheDocument();
+  // EM does not see USB Formatting or Machine Mode sections
   expect(
     screen.queryByRole('heading', { name: 'USB Formatting' })
   ).not.toBeInTheDocument();
@@ -77,29 +71,8 @@ test('renders settings screen for election manager (fewer sections)', async () =
   ).not.toBeInTheDocument();
 });
 
-test('shows offline status', async () => {
-  apiMock.expectGetUsbPortStatus();
-  apiMock.expectGetNetworkConnectionStatus('offline');
-  renderInClientContext(<ClientSettingsScreen />, {
-    auth: sysAdminAuth,
-    apiMock,
-  });
-  await screen.findByText(/Offline/);
-});
-
-test('shows searching for host status', async () => {
-  apiMock.expectGetUsbPortStatus();
-  apiMock.expectGetNetworkConnectionStatus('online-waiting-for-host');
-  renderInClientContext(<ClientSettingsScreen />, {
-    auth: sysAdminAuth,
-    apiMock,
-  });
-  await screen.findByText(/Searching for host…/);
-});
-
 test('does not show Switch to Host Mode when election is configured', async () => {
   apiMock.expectGetUsbPortStatus();
-  apiMock.expectGetNetworkConnectionStatus('online-connected-to-host');
   const electionDefinition = readElectionGeneralDefinition();
   renderInClientContext(<ClientSettingsScreen />, {
     auth: sysAdminAuth,
@@ -112,29 +85,8 @@ test('does not show Switch to Host Mode when election is configured', async () =
   ).not.toBeInTheDocument();
 });
 
-test('shows multiple hosts detected warning', async () => {
-  apiMock.expectGetUsbPortStatus();
-  apiMock.expectGetNetworkConnectionStatus('online-multiple-hosts-detected');
-  renderInClientContext(<ClientSettingsScreen />, {
-    auth: sysAdminAuth,
-    apiMock,
-  });
-  await screen.findByText(/Multiple hosts detected/);
-});
-
-test('shows incompatible host version warning', async () => {
-  apiMock.expectGetUsbPortStatus();
-  apiMock.expectGetNetworkConnectionStatus('online-incompatible-host-version');
-  renderInClientContext(<ClientSettingsScreen />, {
-    auth: sysAdminAuth,
-    apiMock,
-  });
-  await screen.findByText(/incompatible software version/);
-});
-
 test('shows restart screen after switching to host mode', async () => {
   apiMock.expectGetUsbPortStatus();
-  apiMock.expectGetNetworkConnectionStatus('online-connected-to-host');
   renderInClientContext(<ClientSettingsScreen />, {
     auth: sysAdminAuth,
     apiMock,

--- a/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_settings_screen.tsx
@@ -22,61 +22,10 @@ import { AppContext } from '../../contexts/app_context.js';
 import { NavigationScreen } from '../../components/navigation_screen.js';
 import {
   formatUsbDrive,
-  getNetworkConnectionStatus,
   logOut,
   setMachineMode,
   useApiClient,
 } from '../api.js';
-
-function NetworkStatusSection(): JSX.Element {
-  const networkStatusQuery = getNetworkConnectionStatus.useQuery();
-
-  return (
-    <React.Fragment>
-      <H2>Network</H2>
-      <P>
-        {networkStatusQuery.isSuccess &&
-          networkStatusQuery.data.status === 'online-connected-to-host' && (
-            <span>
-              <Icons.Done color="success" /> Connected to host{' '}
-              {networkStatusQuery.data.hostMachineId}
-            </span>
-          )}
-        {networkStatusQuery.isSuccess &&
-          networkStatusQuery.data.status === 'online-waiting-for-host' && (
-            <span>
-              <Icons.Warning color="warning" /> Searching for host…
-            </span>
-          )}
-        {networkStatusQuery.isSuccess &&
-          networkStatusQuery.data.status ===
-            'online-multiple-hosts-detected' && (
-            <span>
-              <Icons.Danger color="danger" /> Multiple hosts detected on the
-              network. Only one host should be active at a time. This
-              adjudication station will not connect until the conflict is
-              resolved.
-            </span>
-          )}
-        {networkStatusQuery.isSuccess &&
-          networkStatusQuery.data.status ===
-            'online-incompatible-host-version' && (
-            <span>
-              <Icons.Danger color="danger" /> VxAdmin with incompatible software
-              version detected on the network.
-            </span>
-          )}
-        {networkStatusQuery.isSuccess &&
-          networkStatusQuery.data.status === 'offline' && (
-            <span>
-              <Icons.Danger color="danger" /> Offline — no network connection
-            </span>
-          )}
-        {!networkStatusQuery.isSuccess && <span>Checking network status…</span>}
-      </P>
-    </React.Fragment>
-  );
-}
 
 export function ClientSettingsScreen(): JSX.Element | null {
   const { auth, electionDefinition, usbDriveStatus } = useContext(AppContext);
@@ -123,7 +72,6 @@ export function ClientSettingsScreen(): JSX.Element | null {
 
   return (
     <NavigationScreen title="Settings">
-      {isSystemAdministratorAuth(auth) && <NetworkStatusSection />}
       <H2>Logs</H2>
       <ExportLogsButton usbDriveStatus={usbDriveStatus} />
       <H2>Date and Time</H2>

--- a/apps/admin/frontend/src/components/navigation_screen.tsx
+++ b/apps/admin/frontend/src/components/navigation_screen.tsx
@@ -3,7 +3,8 @@ import React, { useContext } from 'react';
 import {
   BatteryStatus,
   DateTimeDisplay,
-  Icons,
+  HostNetworkIndicatorStatus,
+  NetworkStatusIndicator as NetworkStatusIndicatorView,
   Toolbar,
   LockMachineButton,
   UsbEjectButton,
@@ -37,33 +38,20 @@ import {
   systemCallApi,
 } from '../shared_api.js';
 import { getNetworkStatus } from '../api.js';
+import { ClientNetworkStatusIndicator } from '../client/components/network_status_indicator.js';
 import { NavItem, Sidebar } from './sidebar.js';
-
-const Row = styled.div`
-  display: flex;
-  flex-direction: row;
-  gap: 0.25rem;
-  align-items: center;
-`;
 
 function NetworkStatusIndicator(): JSX.Element | null {
   const networkStatusQuery = getNetworkStatus.useQuery();
   if (!networkStatusQuery.isSuccess) return null;
 
-  const { isOnline } = networkStatusQuery.data;
-
-  return (
-    <Row>
-      <Icons.Network color="inverse" />
-      {isOnline ? (
-        'Network Online'
-      ) : (
-        <React.Fragment>
-          <Icons.Warning color="inverseWarning" /> Network Offline
-        </React.Fragment>
-      )}
-    </Row>
-  );
+  const { isOnline, multipleHostsDetected } = networkStatusQuery.data;
+  const status: HostNetworkIndicatorStatus = !isOnline
+    ? 'no-network'
+    : multipleHostsDetected
+    ? 'error'
+    : 'connected';
+  return <NetworkStatusIndicatorView isHost status={status} />;
 }
 
 // Wrapper kept inside the host-mode branch so its query (which uses the host
@@ -188,6 +176,7 @@ export function NavScreenLite({ children }: NavScreenLiteProps): JSX.Element {
         {shouldShowToolbar(machineMode, auth) && (
           <Toolbar>
             {machineMode === 'host' && <HostNetworkStatusIndicator />}
+            {machineMode === 'client' && <ClientNetworkStatusIndicator />}
             {batteryInfoQuery.isSuccess && batteryInfoQuery.data && (
               <BatteryStatus batteryInfo={batteryInfoQuery.data} />
             )}

--- a/apps/admin/frontend/src/components/network_section.tsx
+++ b/apps/admin/frontend/src/components/network_section.tsx
@@ -1,0 +1,38 @@
+import { H2, Icons, P } from '@votingworks/ui';
+import { getNetworkStatus } from '../api.js';
+import { isMultiStationAdjudicationEnabled } from '../shared_api.js';
+
+export function NetworkSection(): JSX.Element | null {
+  const isMultiStationEnabled =
+    isMultiStationAdjudicationEnabled.useQuery().data ?? false;
+  const networkStatusQuery = getNetworkStatus.useQuery({
+    enabled: isMultiStationEnabled,
+  });
+
+  if (!isMultiStationEnabled || !networkStatusQuery.isSuccess) {
+    return null;
+  }
+
+  const { isOnline, multipleHostsDetected } = networkStatusQuery.data;
+
+  return (
+    <section>
+      <H2>Network</H2>
+      {isOnline ? (
+        <P>
+          <Icons.Checkbox color="success" /> Online
+        </P>
+      ) : (
+        <P>
+          <Icons.Info /> Offline
+        </P>
+      )}
+      {multipleHostsDetected && (
+        <P>
+          <Icons.Danger color="danger" /> Multiple VxAdmins detected on the
+          network. Ensure only one VxAdmin is connected.
+        </P>
+      )}
+    </section>
+  );
+}

--- a/apps/admin/frontend/src/router_paths.ts
+++ b/apps/admin/frontend/src/router_paths.ts
@@ -10,6 +10,7 @@ export const routerPaths = {
   smartcards: '/smartcards',
   tally: '/tally',
   tallyCvrs: '/tally/cvrs',
+  tallyScanners: '/tally/scanners',
   tallyManual: '/tally/manual',
   tallyManualForm: ({
     precinctId,

--- a/apps/admin/frontend/src/screens/adjudication_start_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/adjudication_start_screen.test.tsx
@@ -207,6 +207,8 @@ describe('multi-station adjudication', () => {
         machineRole: 'admin-client',
         status: Admin.ClientMachineStatus.Active,
         authType: 'election_manager',
+        pollingPlaceId: null,
+        registrationError: null,
         lastSeenAt: Date.now(),
       }),
       typedAs<MachineRecord>({
@@ -214,6 +216,8 @@ describe('multi-station adjudication', () => {
         machineRole: 'admin-client',
         status: Admin.ClientMachineStatus.OnlineLocked,
         authType: null,
+        pollingPlaceId: null,
+        registrationError: null,
         lastSeenAt: Date.now(),
       }),
       typedAs<MachineRecord>({
@@ -221,6 +225,8 @@ describe('multi-station adjudication', () => {
         machineRole: 'admin-client',
         status: Admin.ClientMachineStatus.Offline,
         authType: null,
+        pollingPlaceId: null,
+        registrationError: null,
         lastSeenAt: Date.now() - 60000,
       }),
       typedAs<MachineRecord>({
@@ -228,6 +234,17 @@ describe('multi-station adjudication', () => {
         machineRole: 'admin-client',
         status: Admin.ClientMachineStatus.Adjudicating,
         authType: 'election_manager',
+        pollingPlaceId: null,
+        registrationError: null,
+        lastSeenAt: Date.now(),
+      }),
+      typedAs<MachineRecord>({
+        machineId: 'CLIENT-005',
+        machineRole: 'admin-client',
+        status: Admin.ClientMachineStatus.Active,
+        authType: null,
+        pollingPlaceId: null,
+        registrationError: 'code-version-mismatch',
         lastSeenAt: Date.now(),
       }),
     ];
@@ -245,8 +262,8 @@ describe('multi-station adjudication', () => {
 
     await screen.findByText('CLIENT-001');
     const rows = screen.getAllByRole('row');
-    // header + 4 clients = 5 rows
-    expect(rows).toHaveLength(5);
+    // header + 5 clients = 6 rows
+    expect(rows).toHaveLength(6);
 
     const row1 = rows[1];
     within(row1).getByText('CLIENT-001');
@@ -264,6 +281,10 @@ describe('multi-station adjudication', () => {
     const row4 = rows[4];
     within(row4).getByText('CLIENT-004');
     within(row4).getByText('Adjudicating');
+
+    const row5 = rows[5];
+    within(row5).getByText('CLIENT-005');
+    within(row5).getByText('Incompatible Software');
   });
 
   test('shows network section on callout screens', async () => {

--- a/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
+++ b/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
@@ -370,7 +370,16 @@ function MultiStationClientsTable({
               return (
                 <tr key={machine.machineId}>
                   <TD>{machine.machineId}</TD>
-                  <TD>{renderClientStatus(machine.status)}</TD>
+                  <TD>
+                    {!isOffline &&
+                    machine.registrationError === 'code-version-mismatch' ? (
+                      <React.Fragment>
+                        <Icons.Danger color="danger" /> Incompatible Software
+                      </React.Fragment>
+                    ) : (
+                      renderClientStatus(machine.status)
+                    )}
+                  </TD>
                   <TD>{isOffline ? '—' : formatAuthType(machine.authType)}</TD>
                   <TD>{format.relativeTime(machine.lastSeenAt)}</TD>
                 </tr>

--- a/apps/admin/frontend/src/screens/diagnostics_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/diagnostics_screen.test.tsx
@@ -223,6 +223,48 @@ test('configuration info', async () => {
   await screen.findByText(/Example Primary Election/);
 });
 
+describe('network section', () => {
+  beforeEach(() => {
+    apiMock.setPrinterStatus({ connected: false });
+    apiMock.expectGetMostRecentPrinterDiagnostic();
+    apiMock.setMultiStationAdjudicationEnabled(true);
+  });
+
+  test('shows online status', async () => {
+    apiMock.expectGetNetworkStatus();
+    renderInAppContext(<DiagnosticsScreen />, { apiMock });
+
+    await screen.findByRole('heading', { name: 'Network' });
+    await expectTextWithIcon('Online', 'square-check');
+  });
+
+  test('shows offline status', async () => {
+    apiMock.expectGetNetworkStatus({ isOnline: false });
+    renderInAppContext(<DiagnosticsScreen />, { apiMock });
+
+    await screen.findByRole('heading', { name: 'Network' });
+    await expectTextWithIcon('Offline', 'circle-info');
+  });
+
+  test('shows multiple hosts detected warning', async () => {
+    apiMock.expectGetNetworkStatus({ multipleHostsDetected: true });
+    renderInAppContext(<DiagnosticsScreen />, { apiMock });
+
+    await screen.findByText(/Multiple VxAdmins detected/);
+  });
+
+  test('hidden when multi-station adjudication is disabled', async () => {
+    apiMock.setMultiStationAdjudicationEnabled(false);
+    renderInAppContext(<DiagnosticsScreen />, { apiMock });
+
+    await screen.findByRole('heading', { name: 'Diagnostics' });
+    await screen.findByText(/Battery Level/);
+    expect(
+      screen.queryByRole('heading', { name: 'Network' })
+    ).not.toBeInTheDocument();
+  });
+});
+
 test('saving the readiness report', async () => {
   apiMock.setPrinterStatus({ connected: true });
   apiMock.expectGetMostRecentPrinterDiagnostic();

--- a/apps/admin/frontend/src/screens/diagnostics_screen.tsx
+++ b/apps/admin/frontend/src/screens/diagnostics_screen.tsx
@@ -16,6 +16,7 @@ import {
 } from '../api.js';
 import { systemCallApi } from '../shared_api.js';
 import { PrintTestPageButton } from '../components/print_test_page_button.js';
+import { NetworkSection } from '../components/network_section.js';
 import { AppContext } from '../contexts/app_context.js';
 
 const PageLayout = styled.div`
@@ -65,6 +66,7 @@ export function DiagnosticsScreen(): JSX.Element {
             electionDefinition={electionDefinition}
             electionPackageHash={electionPackageHash}
             printerDiagnosticUi={<PrintTestPageButton />}
+            networkSectionUi={<NetworkSection />}
           />
         </div>
         <SaveReadinessReportButton

--- a/apps/admin/frontend/src/screens/settings_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.test.tsx
@@ -111,17 +111,10 @@ describe('multi-station mode', () => {
     apiMock.setMultiStationAdjudicationEnabled(true);
   });
 
-  function mockNetworkStatusQuery({
-    multipleHostsDetected = false,
-  }: {
-    multipleHostsDetected?: boolean;
-  } = {}) {
-    apiMock.expectGetNetworkStatus({ multipleHostsDetected });
-  }
-
   test('shows switch to client mode button when unconfigured', async () => {
     apiMock.expectGetUsbPortStatus();
-    mockNetworkStatusQuery();
+    // The toolbar network status indicator polls network status
+    apiMock.expectGetNetworkStatus();
     renderInAppContext(<SettingsScreen />, {
       apiMock,
       auth,
@@ -154,20 +147,9 @@ describe('multi-station mode', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('shows multiple hosts detected error', async () => {
-    apiMock.expectGetUsbPortStatus();
-    mockNetworkStatusQuery({ multipleHostsDetected: true });
-    renderInAppContext(<SettingsScreen />, {
-      apiMock,
-      auth,
-      electionDefinition: null,
-    });
-    await screen.findByText(/Multiple hosts detected/);
-  });
-
   test('shows restart screen after switching mode', async () => {
     apiMock.expectGetUsbPortStatus();
-    mockNetworkStatusQuery();
+    apiMock.expectGetNetworkStatus();
     renderInAppContext(<SettingsScreen />, {
       apiMock,
       auth,

--- a/apps/admin/frontend/src/screens/settings_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.test.tsx
@@ -138,6 +138,7 @@ describe('multi-station mode', () => {
       .resolves({
         isOnline: true,
         connectedClients: [],
+        connectedScanners: [],
         multipleHostsDetected: false,
       });
     renderInAppContext(<SettingsScreen />, { apiMock, auth });

--- a/apps/admin/frontend/src/screens/settings_screen.tsx
+++ b/apps/admin/frontend/src/screens/settings_screen.tsx
@@ -22,7 +22,6 @@ import { AppContext } from '../contexts/app_context.js';
 import { NavigationScreen } from '../components/navigation_screen.js';
 import {
   formatUsbDrive,
-  getNetworkStatus,
   logOut,
   setMachineMode,
   useApiClient,
@@ -38,9 +37,6 @@ export function SettingsScreen(): JSX.Element | null {
   const isMultiStationEnabled =
     isMultiStationAdjudicationEnabled.useQuery().data ?? false;
   const rebootMutation = useSystemCallApi().reboot.useMutation();
-  const networkStatusQuery = getNetworkStatus.useQuery({
-    enabled: isMultiStationEnabled,
-  });
 
   if (setMachineModeMutation.isSuccess) {
     return (
@@ -84,15 +80,6 @@ export function SettingsScreen(): JSX.Element | null {
         !electionDefinition && (
           <React.Fragment>
             <H2>Machine Mode</H2>
-            {networkStatusQuery.isSuccess &&
-              networkStatusQuery.data.multipleHostsDetected && (
-                <P>
-                  <Icons.Danger color="danger" /> Multiple hosts detected on the
-                  network. Only one host machine should be active at a time.
-                  Adjudication stations will not connect until the conflict is
-                  resolved.
-                </P>
-              )}
             <P>
               <Button
                 onPress={() =>

--- a/apps/admin/frontend/src/screens/tally/scanners_tab.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/scanners_tab.test.tsx
@@ -65,6 +65,11 @@ test('renders a row per scanner with polling place and status', async () => {
     'CS-02— Offline00Now',
     'CS-03not-a-real-place Connected00Now',
   ]);
+  // Distinct glyphs, not just color, differentiate connected/offline
+  expect(rows[0].querySelector("[data-icon='circle-check']")).toBeTruthy();
+  expect(
+    rows[1].querySelector("[data-icon='circle-exclamation']")
+  ).toBeTruthy();
 });
 
 test('renders scanners in error states with the rejection reason', async () => {

--- a/apps/admin/frontend/src/screens/tally/scanners_tab.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/scanners_tab.test.tsx
@@ -1,0 +1,112 @@
+import { expect, test } from 'vitest';
+import { readElectionGeneralDefinition } from '@votingworks/fixtures';
+import { Admin } from '@votingworks/types';
+import type { MachineRecord } from '@votingworks/admin-backend';
+
+import { renderInAppContext } from '../../../test/render_in_app_context.js';
+import { ScannersTab } from './scanners_tab.js';
+import { createApiMock } from '../../../test/helpers/mock_api_client.js';
+import { screen, waitFor } from '../../../test/react_testing_library.js';
+
+const electionDefinition = readElectionGeneralDefinition();
+const { election } = electionDefinition;
+const [place1] = election.pollingPlaces;
+
+function mockScanner(
+  partial: Pick<MachineRecord, 'machineId'> & Partial<MachineRecord>
+): MachineRecord {
+  return {
+    machineRole: 'scanner',
+    status: Admin.ClientMachineStatus.Active,
+    authType: null,
+    pollingPlaceId: null,
+    registrationError: null,
+    lastSeenAt: Date.now(),
+    ...partial,
+  };
+}
+
+test('renders empty state while no scanners have connected', async () => {
+  const api = createApiMock();
+  api.expectGetNetworkStatus({ connectedScanners: [] });
+  api.expectGetScannerImportCounts();
+
+  renderInAppContext(<ScannersTab />, { apiMock: api, electionDefinition });
+
+  await screen.findByText(/Waiting for central scanners to connect/);
+});
+
+test('renders a row per scanner with polling place and status', async () => {
+  const api = createApiMock();
+  api.expectGetNetworkStatus({
+    connectedScanners: [
+      mockScanner({
+        machineId: 'CS-01',
+        pollingPlaceId: place1.id,
+      }),
+      mockScanner({
+        machineId: 'CS-02',
+        status: Admin.ClientMachineStatus.Offline,
+      }),
+      mockScanner({ machineId: 'CS-03', pollingPlaceId: 'not-a-real-place' }),
+    ],
+  });
+  api.expectGetScannerImportCounts({
+    'CS-01': { cvrCount: 1412, batchCount: 3 },
+  });
+
+  renderInAppContext(<ScannersTab />, { apiMock: api, electionDefinition });
+
+  await waitFor(() => api.assertComplete());
+
+  const rows = screen.getAllByRole('row').slice(1); // skip header
+  expect(rows.map((row) => row.textContent)).toEqual([
+    `CS-01${place1.name} Connected1,4123Now`,
+    'CS-02— Offline00Now',
+    'CS-03not-a-real-place Connected00Now',
+  ]);
+});
+
+test('renders scanners in error states with the rejection reason', async () => {
+  const api = createApiMock();
+  api.expectGetNetworkStatus({
+    connectedScanners: [
+      mockScanner({
+        machineId: 'CS-01',
+        registrationError: 'code-version-mismatch',
+      }),
+      mockScanner({
+        machineId: 'CS-02',
+        registrationError: 'ballot-hash-mismatch',
+      }),
+      mockScanner({
+        machineId: 'CS-03',
+        registrationError: 'scanner-unconfigured',
+      }),
+      mockScanner({
+        machineId: 'CS-04',
+        registrationError: 'host-unconfigured',
+      }),
+      // Offline wins over a stale registration error
+      mockScanner({
+        machineId: 'CS-05',
+        registrationError: 'code-version-mismatch',
+        status: Admin.ClientMachineStatus.Offline,
+      }),
+    ],
+  });
+  api.expectGetScannerImportCounts();
+
+  renderInAppContext(<ScannersTab />, { apiMock: api, electionDefinition });
+
+  await waitFor(() => api.assertComplete());
+
+  const rows = screen.getAllByRole('row').slice(1); // skip header
+  expect(rows.map((row) => row.textContent)).toEqual([
+    'CS-01— Incompatible Software00Now',
+    'CS-02— Different Election00Now',
+    'CS-03— Scanner Not Configured00Now',
+    'CS-04— VxAdmin Not Configured00Now',
+    'CS-05— Offline00Now',
+  ]);
+});

--- a/apps/admin/frontend/src/screens/tally/scanners_tab.tsx
+++ b/apps/admin/frontend/src/screens/tally/scanners_tab.tsx
@@ -1,0 +1,168 @@
+import { useContext } from 'react';
+import styled from 'styled-components';
+
+import { Icons, Loading, Table, TD, TH } from '@votingworks/ui';
+import { format } from '@votingworks/utils';
+import { Admin } from '@votingworks/types';
+import { assertDefined, throwIllegalValue } from '@votingworks/basics';
+import type { MachineRecord } from '@votingworks/admin-backend';
+import { getNetworkStatus, getScannerImportCounts } from '../../api.js';
+import { AppContext } from '../../contexts/app_context.js';
+import { GAP } from './styles.js';
+
+const Container = styled.div`
+  height: 100%;
+  overflow-y: auto;
+  padding: 0 ${GAP};
+`;
+
+const EmptyTableMessage = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  color: ${(p) => p.theme.colors.onBackgroundMuted};
+`;
+
+const InlineStatus = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  white-space: nowrap;
+`;
+
+const StatusDot = styled(Icons.CircleSolid)`
+  font-size: 0.625em;
+`;
+
+const TableWrapper = styled.div`
+  & th,
+  & td {
+    padding: 0.625rem 1rem;
+  }
+
+  & tbody tr:last-child td {
+    border-bottom: none;
+  }
+`;
+
+function ScannerStatus({ scanner }: { scanner: MachineRecord }): JSX.Element {
+  if (scanner.status === Admin.ClientMachineStatus.Offline) {
+    return (
+      <InlineStatus>
+        <StatusDot /> Offline
+      </InlineStatus>
+    );
+  }
+  const { registrationError } = scanner;
+  if (registrationError) {
+    switch (registrationError) {
+      case 'code-version-mismatch':
+        return (
+          <InlineStatus>
+            <Icons.Danger color="danger" /> Incompatible Software
+          </InlineStatus>
+        );
+      case 'ballot-hash-mismatch':
+        return (
+          <InlineStatus>
+            <Icons.Warning color="warning" /> Different Election
+          </InlineStatus>
+        );
+      case 'scanner-unconfigured':
+        return (
+          <InlineStatus>
+            <Icons.Warning color="warning" /> Scanner Not Configured
+          </InlineStatus>
+        );
+      case 'host-unconfigured':
+        return (
+          <InlineStatus>
+            <Icons.Warning color="warning" /> VxAdmin Not Configured
+          </InlineStatus>
+        );
+      // istanbul ignore next -- compile-time check
+      default:
+        throwIllegalValue(registrationError);
+    }
+  }
+  return (
+    <InlineStatus>
+      <StatusDot color="success" /> Connected
+    </InlineStatus>
+  );
+}
+
+export function ScannersTab(): JSX.Element {
+  const { electionDefinition } = useContext(AppContext);
+  const { election } = assertDefined(electionDefinition);
+  const networkStatusQuery = getNetworkStatus.useQuery();
+  const importCountsQuery = getScannerImportCounts.useQuery();
+
+  if (!networkStatusQuery.isSuccess || !importCountsQuery.isSuccess) {
+    return <Loading isFullscreen />;
+  }
+
+  const { connectedScanners } = networkStatusQuery.data;
+  const importCounts = importCountsQuery.data;
+
+  function pollingPlaceName(pollingPlaceId: string | null): string {
+    if (!pollingPlaceId) return '—';
+    const pollingPlace = election.pollingPlaces.find(
+      (p) => p.id === pollingPlaceId
+    );
+    return pollingPlace?.name ?? pollingPlaceId;
+  }
+
+  return (
+    <Container>
+      <TableWrapper>
+        <Table>
+          <thead>
+            <tr>
+              <TH>Scanner</TH>
+              <TH>Polling Place</TH>
+              <TH>Status</TH>
+              <TH>CVRs</TH>
+              <TH>Batches</TH>
+              <TH>Last Seen</TH>
+            </tr>
+          </thead>
+          <tbody>
+            {connectedScanners.length === 0 ? (
+              <tr>
+                <TD colSpan={6}>
+                  <EmptyTableMessage>
+                    <Icons.Loading /> Waiting for central scanners to connect…
+                  </EmptyTableMessage>
+                </TD>
+              </tr>
+            ) : (
+              connectedScanners.map((scanner) => (
+                <tr key={scanner.machineId}>
+                  <TD>{scanner.machineId}</TD>
+                  <TD>{pollingPlaceName(scanner.pollingPlaceId)}</TD>
+                  <TD>
+                    <ScannerStatus scanner={scanner} />
+                  </TD>
+                  <TD>
+                    {format.count(
+                      importCounts[scanner.machineId]?.cvrCount ?? 0
+                    )}
+                  </TD>
+                  <TD>
+                    {format.count(
+                      importCounts[scanner.machineId]?.batchCount ?? 0
+                    )}
+                  </TD>
+                  <TD>{format.relativeTime(scanner.lastSeenAt)}</TD>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </Table>
+      </TableWrapper>
+    </Container>
+  );
+}

--- a/apps/admin/frontend/src/screens/tally/scanners_tab.tsx
+++ b/apps/admin/frontend/src/screens/tally/scanners_tab.tsx
@@ -32,10 +32,6 @@ const InlineStatus = styled.div`
   white-space: nowrap;
 `;
 
-const StatusDot = styled(Icons.CircleSolid)`
-  font-size: 0.625em;
-`;
-
 const TableWrapper = styled.div`
   & th,
   & td {
@@ -51,7 +47,7 @@ function ScannerStatus({ scanner }: { scanner: MachineRecord }): JSX.Element {
   if (scanner.status === Admin.ClientMachineStatus.Offline) {
     return (
       <InlineStatus>
-        <StatusDot /> Offline
+        <Icons.Danger color="danger" /> Offline
       </InlineStatus>
     );
   }
@@ -89,7 +85,7 @@ function ScannerStatus({ scanner }: { scanner: MachineRecord }): JSX.Element {
   }
   return (
     <InlineStatus>
-      <StatusDot color="success" /> Connected
+      <Icons.Done color="success" /> Connected
     </InlineStatus>
   );
 }

--- a/apps/admin/frontend/src/screens/tally/tally_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/tally_screen.tsx
@@ -20,6 +20,7 @@ import { routerPaths } from '../../router_paths.js';
 import { ConfirmRemoveAllResultsModal } from './confirm_remove_all_results_modal.js';
 import { BORDER_LIGHT, GAP } from './styles.js';
 import { CvrsScreen } from './cvrs_screen.js';
+import { ScannersTab } from './scanners_tab.js';
 
 const Container = styled.div`
   display: grid;
@@ -77,6 +78,7 @@ export function TallyScreen(): JSX.Element | null {
 
   const tabs: Array<{ title: string; path: string }> = [
     { title: 'Cast Vote Records', path: routerPaths.tallyCvrs },
+    { title: 'Networked Scanners', path: routerPaths.tallyScanners },
   ];
 
   const manualTalliesEnabled = !isCombinedBallotPrimary(election);
@@ -112,6 +114,12 @@ export function TallyScreen(): JSX.Element | null {
                 exact
                 path={routerPaths.tallyCvrs}
                 component={CvrsScreen}
+              />
+
+              <Route
+                exact
+                path={routerPaths.tallyScanners}
+                component={ScannersTab}
               />
 
               {manualTalliesEnabled && (

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -836,14 +836,24 @@ export function createApiMock(
       overrides: {
         isOnline?: boolean;
         connectedClients?: MachineRecord[];
+        connectedScanners?: MachineRecord[];
         multipleHostsDetected?: boolean;
       } = {}
     ): void {
       apiClient.getNetworkStatus.expectRepeatedCallsWith().resolves({
         isOnline: overrides.isOnline ?? true,
         connectedClients: overrides.connectedClients ?? [],
+        connectedScanners: overrides.connectedScanners ?? [],
         multipleHostsDetected: overrides.multipleHostsDetected ?? false,
       });
+    },
+
+    expectGetScannerImportCounts(
+      counts: Record<string, { cvrCount: number; batchCount: number }> = {}
+    ): void {
+      apiClient.getScannerImportCounts
+        .expectRepeatedCallsWith()
+        .resolves(counts);
     },
 
     expectGetIsClientAdjudicationEnabled(enabled = false): void {

--- a/apps/admin/frontend/test/helpers/mock_client_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_client_api_client.ts
@@ -1,5 +1,9 @@
 import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
-import type { ClientApi, MachineConfig } from '@votingworks/admin-backend';
+import type {
+  ClientApi,
+  MachineConfig,
+  NetworkConnectionStatus,
+} from '@votingworks/admin-backend';
 import {
   DEFAULT_SYSTEM_SETTINGS,
   DippedSmartCardAuth,
@@ -16,11 +20,15 @@ import { Mock, vi } from 'vitest';
 
 type MockClientApiClient = Omit<
   MockClient<ClientApi>,
-  'getBatteryInfo' | 'getDiskSpaceSummary' | 'isMultiStationAdjudicationEnabled'
+  | 'getBatteryInfo'
+  | 'getDiskSpaceSummary'
+  | 'isMultiStationAdjudicationEnabled'
+  | 'getNetworkConnectionStatus'
 > & {
   getBatteryInfo: Mock;
   getDiskSpaceSummary: Mock;
   isMultiStationAdjudicationEnabled: Mock;
+  getNetworkConnectionStatus: Mock;
 };
 
 function createMockClientApiClient(): MockClientApiClient {
@@ -33,6 +41,12 @@ function createMockClientApiClient(): MockClientApiClient {
   );
   (mockApiClient.isMultiStationAdjudicationEnabled as unknown as Mock) = vi.fn(
     () => Promise.resolve(false)
+  );
+  (mockApiClient.getNetworkConnectionStatus as unknown as Mock) = vi.fn(() =>
+    Promise.resolve<NetworkConnectionStatus>({
+      status: 'online-connected-to-host',
+      hostMachineId: '0001',
+    })
   );
   return mockApiClient as unknown as MockClientApiClient;
 }
@@ -104,9 +118,7 @@ export function createClientApiMock(
         status === 'online-connected-to-host'
           ? { status, hostMachineId: hostMachineId ?? '0001' }
           : { status };
-      apiClient.getNetworkConnectionStatus
-        .expectRepeatedCallsWith()
-        .resolves(value);
+      apiClient.getNetworkConnectionStatus.mockResolvedValue(value);
     },
 
     expectGetAdjudicationSessionStatus(

--- a/apps/central-scan/backend/src/networking.ts
+++ b/apps/central-scan/backend/src/networking.ts
@@ -143,6 +143,7 @@ export function startScannerNetworking({
             codeVersion,
             ballotHash:
               store.getElectionRecord()?.electionDefinition.ballotHash,
+            pollingPlaceId: store.getPollingPlaceId(),
           });
         } catch (error) {
           debug('Host at %s unreachable: %s', hostMachine.address, error);

--- a/apps/central-scan/frontend/src/components/network_section.test.tsx
+++ b/apps/central-scan/frontend/src/components/network_section.test.tsx
@@ -57,7 +57,7 @@ const testCases: Array<{
   },
   {
     connection: { status: 'online-host-detected', hostMachineId: '0002' },
-    expectedText: 'Online — VxAdmin (0002) detected on the network',
+    expectedText: 'Online — VxAdmin (0002) connected on the network',
     expectedIcon: 'square-check',
   },
 ];

--- a/apps/central-scan/frontend/src/components/network_section.tsx
+++ b/apps/central-scan/frontend/src/components/network_section.tsx
@@ -66,7 +66,7 @@ function ConnectionStatusMessage({
       return (
         <P>
           <Icons.Checkbox color="success" /> Online &mdash; VxAdmin (
-          {connection.hostMachineId}) detected on the network
+          {connection.hostMachineId}) connected on the network
         </P>
       );
     // istanbul ignore next -- compile-time check

--- a/apps/central-scan/frontend/src/screens/diagnostics_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/diagnostics_screen.test.tsx
@@ -81,7 +81,7 @@ test('shows the network status when networking is enabled', async () => {
     connection: { status: 'online-host-detected', hostMachineId: '0002' },
   });
   await screen.findByText(
-    'Online — VxAdmin (0002) detected on the network',
+    'Online — VxAdmin (0002) connected on the network',
     {},
     { timeout: 3000 }
   );

--- a/libs/networking/src/vx_admin_host_api.ts
+++ b/libs/networking/src/vx_admin_host_api.ts
@@ -26,6 +26,8 @@ export type VxAdminHostApi = Api<{
     codeVersion: string;
     /** The scanner's configured election, if any. */
     ballotHash?: string;
+    /** The polling place the scanner is configured for, if any. */
+    pollingPlaceId?: string;
   }) => Result<VxAdminHostMachineConfig, RegisterScannerError>;
   /**
    * Read-only, side-effect-free method also used by scanners as a

--- a/libs/ui/src/diagnostics/admin_readiness_report.tsx
+++ b/libs/ui/src/diagnostics/admin_readiness_report.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { ThemeProvider } from 'styled-components';
 import { PrinterSection, PrinterSectionProps } from './printer_section';
 import { PrintedReport } from '../reports/layout';
@@ -15,12 +16,15 @@ import { BallotStyleReadinessReport } from './ballot_style_readiness_report';
 type ReportContentsProps = ConfigurationSectionProps &
   BatterySectionProps &
   StorageSectionProps &
-  PrinterSectionProps;
+  PrinterSectionProps & {
+    /** On-screen-only network status section, not part of the printed report. */
+    networkSectionUi?: React.ReactNode;
+  };
 
 export function AdminReadinessReportContents(
   props: ReportContentsProps
 ): JSX.Element {
-  const { electionDefinition } = props;
+  const { electionDefinition, networkSectionUi } = props;
 
   return (
     <ReportContents>
@@ -28,6 +32,7 @@ export function AdminReadinessReportContents(
       <BatterySection {...props} />
       <StorageSection {...props} />
       <PrinterSection {...props} />
+      {networkSectionUi}
       {electionDefinition && (
         <BallotStyleReadinessReport electionDefinition={electionDefinition} />
       )}
@@ -37,18 +42,22 @@ export function AdminReadinessReportContents(
 
 type ClientReportContentsProps = ConfigurationSectionProps &
   BatterySectionProps &
-  StorageSectionProps;
+  StorageSectionProps & {
+    /** On-screen-only network status section, not part of the printed report. */
+    networkSectionUi?: React.ReactNode;
+  };
 
 export function AdminClientReadinessReportContents(
   props: ClientReportContentsProps
 ): JSX.Element {
-  const { electionDefinition } = props;
+  const { electionDefinition, networkSectionUi } = props;
 
   return (
     <ReportContents>
       <ConfigurationSection {...props} />
       <BatterySection {...props} />
       <StorageSection {...props} />
+      {networkSectionUi}
       {electionDefinition && (
         <BallotStyleReadinessReport electionDefinition={electionDefinition} />
       )}


### PR DESCRIPTION
## Overview
Makes the following changes to VxAdmin's networking UIs

- Updates network status indicator in icon to be consistent with VxCentralScan and new states defined in discussion: https://votingworks.slack.com/archives/CEL6D3GAD/p1787170629952689
- Adds network status indicator to adjudication stations
- Adds basic network status information to diagnostics page on both hosts and adjudication stations
- Adds a "networked scanners" tab to the tally screen for tracking connected networked scanners 

## Demo Video or Screenshot
### Host

<img width="1185" height="744" alt="Screenshot 2026-08-25 at 9 16 55 AM" src="https://github.com/user-attachments/assets/4e6c8f68-54ff-440a-aed9-87ff195dc876" />
<img width="1181" height="753" alt="Screenshot 2026-08-25 at 9 16 03 AM" src="https://github.com/user-attachments/assets/4f2f4384-b195-4f33-80d4-d26e5dd3e54d" />
<img width="1189" height="756" alt="Screenshot 2026-08-25 at 8 44 56 AM" src="https://github.com/user-attachments/assets/f1fafd5f-b37b-402f-9b8b-dc84043f96bd" />
<img width="1184" height="740" alt="Screenshot 2026-08-25 at 8 43 50 AM" src="https://github.com/user-attachments/assets/48d8276f-4831-4c48-beda-d83b7f03253d" />
<img width="1183" height="749" alt="Screenshot 2026-08-25 at 8 43 31 AM" src="https://github.com/user-attachments/assets/c2ad80f4-0940-413b-9990-cce15c3ab76f" />
<img width="1187" height="744" alt="Screenshot 2026-08-25 at 8 43 11 AM" src="https://github.com/user-attachments/assets/55b3c34d-7c51-4328-b262-d74f91ea2de0" />
<img width="1183" height="745" alt="Screenshot 2026-08-25 at 8 40 40 AM" src="https://github.com/user-attachments/assets/e4c1bcee-cd4a-4d60-8f4c-83d6d658ba5d" />


### Adjudication Stations
<img width="1178" height="750" alt="Screenshot 2026-08-25 at 9 17 08 AM" src="https://github.com/user-attachments/assets/3ba50184-5fd9-4efc-9fc0-1e2046311e16" />
<img width="1178" height="744" alt="Screenshot 2026-08-25 at 9 16 18 AM" src="https://github.com/user-attachments/assets/7982205b-1e18-4276-bbe6-4fc741c2a2dc" />
<img width="1176" height="745" alt="Screenshot 2026-08-25 at 9 14 45 AM" src="https://github.com/user-attachments/assets/50cd7a10-e89d-4346-b7ef-cc00462a94bc" />
<img width="1189" height="750" alt="Screenshot 2026-08-25 at 9 14 16 AM" src="https://github.com/user-attachments/assets/e729aa5c-789d-470f-b32a-2076f6f86a06" />
<img width="1180" height="747" alt="Screenshot 2026-08-25 at 9 13 56 AM" src="https://github.com/user-attachments/assets/1180c77c-7e21-467e-ae4a-c22fdb052653" />


## Testing Plan
Manually tested various networking states on VxAdmin Hosts and Clients - see screenshots

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
