### PR TITLE
VxCentralScan: NetworkOff icon cleanup

### DIFF
--- a/apps/admin/frontend/src/components/navigation_screen.tsx
+++ b/apps/admin/frontend/src/components/navigation_screen.tsx
@@ -53,7 +53,7 @@ function NetworkStatusIndicator(): JSX.Element | null {
 
   return (
     <Row>
-      <Icons.Sitemap color="inverse" />
+      <Icons.Network color="inverse" />
       {isOnline ? (
         'Network Online'
       ) : (

--- a/apps/admin/frontend/src/components/navigation_screen.tsx
+++ b/apps/admin/frontend/src/components/navigation_screen.tsx
@@ -15,6 +15,7 @@ import {
   H1,
   Route,
   Breadcrumbs,
+  ToolbarButtons,
 } from '@votingworks/ui';
 import {
   BooleanEnvironmentVariableName,
@@ -191,12 +192,14 @@ export function NavScreenLite({ children }: NavScreenLiteProps): JSX.Element {
               <BatteryStatus batteryInfo={batteryInfoQuery.data} />
             )}
             <DateTimeDisplay />
-            <UsbEjectButton
-              usbDriveStatus={usbDriveStatus}
-              onEject={() => ejectUsbDriveMutation.mutate()}
-              isEjecting={ejectUsbDriveMutation.isLoading}
-            />
-            <LockMachineButton onLock={() => logOutMutation.mutate()} />
+            <ToolbarButtons>
+              <UsbEjectButton
+                usbDriveStatus={usbDriveStatus}
+                onEject={() => ejectUsbDriveMutation.mutate()}
+                isEjecting={ejectUsbDriveMutation.isLoading}
+              />
+              <LockMachineButton onLock={() => logOutMutation.mutate()} />
+            </ToolbarButtons>
           </Toolbar>
         )}
         <SessionTimeLimitTimer authStatus={auth} />

--- a/apps/central-scan/frontend/src/components/network_status_indicator.test.tsx
+++ b/apps/central-scan/frontend/src/components/network_status_indicator.test.tsx
@@ -1,9 +1,13 @@
 import { expect, test } from 'vitest';
 import type { NetworkConnectionInfo } from '@votingworks/central-scan-backend';
+import { makeTheme } from '@votingworks/ui';
 import { renderInAppContext } from '../../test/render_in_app_context.js';
 import { createApiMock } from '../../test/api.js';
 import { screen, waitFor } from '../../test/react_testing_library.js';
 import { NetworkStatusIndicator } from './network_status_indicator.js';
+
+const DANGER_COLOR = makeTheme({ colorMode: 'desktop', sizeMode: 'desktop' })
+  .colors.inverseDangerAccent;
 
 test('renders nothing when networking is disabled', async () => {
   const apiMock = createApiMock();
@@ -90,26 +94,24 @@ test.each(testCases)(
         ).toBeInTheDocument();
         expect(indicator.querySelectorAll('[data-icon]')).toHaveLength(1);
         expect(
-          indicator.querySelector(`[data-testid='network-off-icon']`)
+          indicator.querySelector(`[data-icon='network-off']`)
         ).not.toBeInTheDocument();
         break;
       // Warning states show the slashed network icon
       case 'warning':
         expect(
-          indicator.querySelector(`[data-testid='network-off-icon']`)
+          indicator.querySelector(`[data-icon='network-off']`)
         ).toBeInTheDocument();
-        expect(indicator.querySelectorAll('[data-icon]')).toHaveLength(0);
+        expect(indicator.querySelectorAll('[data-icon]')).toHaveLength(1);
         break;
-      // Error states show the slashed network icon with a danger icon next
-      // to it
-      case 'error':
-        expect(
-          indicator.querySelector(`[data-testid='network-off-icon']`)
-        ).toBeInTheDocument();
-        expect(
-          indicator.querySelector(`[data-icon='circle-exclamation']`)
-        ).toBeInTheDocument();
+      // Error states show the slashed network icon in the danger color
+      case 'error': {
+        const icon = indicator.querySelector(`[data-icon='network-off']`);
+        expect(icon).toBeInTheDocument();
+        expect(indicator.querySelectorAll('[data-icon]')).toHaveLength(1);
+        expect(icon).toHaveStyle(`color: ${DANGER_COLOR}`);
         break;
+      }
       default:
         throw new Error('unreachable');
     }

--- a/apps/central-scan/frontend/src/navigation_screen.tsx
+++ b/apps/central-scan/frontend/src/navigation_screen.tsx
@@ -15,6 +15,7 @@ import {
   SessionTimeLimitTimer,
   TestModeBanner,
   Toolbar,
+  ToolbarButtons,
   UsbEjectButton,
   VerticalElectionInfoBar,
 } from '@votingworks/ui';
@@ -96,12 +97,14 @@ function NavigationToolbar(): JSX.Element {
         <BatteryStatus batteryInfo={batteryInfoQuery.data} />
       )}
       <DateTimeDisplay />
-      <UsbEjectButton
-        usbDriveStatus={usbDriveStatus}
-        onEject={() => ejectUsbDriveMutation.mutate()}
-        isEjecting={ejectUsbDriveMutation.isLoading}
-      />
-      <LockMachineButton onLock={() => logOutMutation.mutate()} />
+      <ToolbarButtons>
+        <UsbEjectButton
+          usbDriveStatus={usbDriveStatus}
+          onEject={() => ejectUsbDriveMutation.mutate()}
+          isEjecting={ejectUsbDriveMutation.isLoading}
+        />
+        <LockMachineButton onLock={() => logOutMutation.mutate()} />
+      </ToolbarButtons>
     </Toolbar>
   );
 }

--- a/apps/print/frontend/src/components/toolbar.tsx
+++ b/apps/print/frontend/src/components/toolbar.tsx
@@ -9,6 +9,7 @@ import {
   IconName,
   Icons,
   LockMachineButton,
+  ToolbarButtons,
   Toolbar as ToolbarContainer,
 } from '@votingworks/ui';
 import { UsbDriveStatus } from '@votingworks/usb-drive';
@@ -211,8 +212,10 @@ export function Toolbar(): JSX.Element {
       <PrinterStatus status={printer} />
       {battery && <BatteryStatus batteryInfo={battery} />}
       <DateTimeDisplay />
-      <UsbControllerButton status={usbDrive} />
-      <LockMachineButton onLock={handleLock} />
+      <ToolbarButtons>
+        <UsbControllerButton status={usbDrive} />
+        <LockMachineButton onLock={handleLock} />
+      </ToolbarButtons>
     </ToolbarContainer>
   );
 }

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -630,7 +630,7 @@ export const Icons = {
     return <FaIcon {...props} flipInRtlMode={false} type={faSimCard} />;
   },
 
-  Sitemap(props) {
+  Network(props) {
     return <FaIcon {...props} flipInRtlMode={false} type={faSitemap} />;
   },
 

--- a/libs/ui/src/icons.tsx
+++ b/libs/ui/src/icons.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import {
   faCircle,
@@ -632,6 +633,55 @@ export const Icons = {
 
   Network(props) {
     return <FaIcon {...props} flipInRtlMode={false} type={faSitemap} />;
+  },
+
+  NetworkOff(props: Pick<IconProps, 'className' | 'color' | 'style'>) {
+    const { className, color, style = {} } = props;
+    const theme = useTheme();
+    const maskId = useId();
+    return (
+      <StyledSvgIcon
+        aria-hidden="true"
+        className={[FONT_AWESOME_INLINE_SVG_CLASS_NAME, className]
+          .filter(Boolean)
+          .join(' ')}
+        data-icon="network-off"
+        role="img"
+        viewBox="0 0 576 512"
+        style={{
+          width: '1.125em',
+          color: iconColor(theme, color),
+          ...style,
+        }}
+      >
+        <mask
+          id={maskId}
+          maskUnits="userSpaceOnUse"
+          x="0"
+          y="-64"
+          width="576"
+          height="640"
+        >
+          <rect y="-64" width="576" height="640" fill="white" />
+          <path
+            d="M53 4L523 508"
+            stroke="black"
+            strokeWidth="110"
+            strokeLinecap="round"
+          />
+        </mask>
+        <path
+          mask={`url(#${maskId})`}
+          d="M208 80c0-26.5 21.5-48 48-48l64 0c26.5 0 48 21.5 48 48l0 64c0 26.5-21.5 48-48 48l-8 0 0 40 152 0c30.9 0 56 25.1 56 56l0 32 8 0c26.5 0 48 21.5 48 48l0 64c0 26.5-21.5 48-48 48l-64 0c-26.5 0-48-21.5-48-48l0-64c0-26.5 21.5-48 48-48l8 0 0-32c0-4.4-3.6-8-8-8l-152 0 0 40 8 0c26.5 0 48 21.5 48 48l0 64c0 26.5-21.5 48-48 48l-64 0c-26.5 0-48-21.5-48-48l0-64c0-26.5 21.5-48 48-48l8 0 0-40-152 0c-4.4 0-8 3.6-8 8l0 32 8 0c26.5 0 48 21.5 48 48l0 64c0 26.5-21.5 48-48 48l-64 0c-26.5 0-48-21.5-48-48l0-64c0-26.5 21.5-48 48-48l8 0 0-32c0-30.9 25.1-56 56-56l152 0 0-40-8 0c-26.5 0-48-21.5-48-48l0-64z"
+        />
+        <path
+          d="M94 48L482 464"
+          stroke="currentColor"
+          strokeWidth="54"
+          strokeLinecap="round"
+        />
+      </StyledSvgIcon>
+    );
   },
 
   Sort(props) {

--- a/libs/ui/src/network_status_indicator.test.tsx
+++ b/libs/ui/src/network_status_indicator.test.tsx
@@ -5,6 +5,10 @@ import {
   NetworkIndicatorStatus,
   NetworkStatusIndicator,
 } from './network_status_indicator';
+import { makeTheme } from './themes/make_theme';
+
+const THEME = makeTheme({ colorMode: 'desktop', sizeMode: 'desktop' });
+const DANGER_COLOR = THEME.colors.inverseDangerAccent;
 
 const testCases: Array<{
   status: NetworkIndicatorStatus;
@@ -36,7 +40,9 @@ const testCases: Array<{
 test.each(testCases)(
   'renders $status',
   ({ status, expectedLabel, expectedTreatment }) => {
-    const { unmount } = render(<NetworkStatusIndicator status={status} />);
+    const { unmount } = render(<NetworkStatusIndicator status={status} />, {
+      vxTheme: { colorMode: 'desktop', sizeMode: 'desktop' },
+    });
     const indicator = screen.getByTestId('network-status');
     expect(indicator).toHaveTextContent(expectedLabel);
     switch (expectedTreatment) {
@@ -47,26 +53,24 @@ test.each(testCases)(
         ).toBeInTheDocument();
         expect(indicator.querySelectorAll('[data-icon]')).toHaveLength(1);
         expect(
-          indicator.querySelector(`[data-testid='network-off-icon']`)
+          indicator.querySelector(`[data-icon='network-off']`)
         ).not.toBeInTheDocument();
         break;
       // Warning states show the slashed network icon
       case 'warning':
         expect(
-          indicator.querySelector(`[data-testid='network-off-icon']`)
+          indicator.querySelector(`[data-icon='network-off']`)
         ).toBeInTheDocument();
-        expect(indicator.querySelectorAll('[data-icon]')).toHaveLength(0);
+        expect(indicator.querySelectorAll('[data-icon]')).toHaveLength(1);
         break;
-      // Error states show the slashed network icon with a danger icon next
-      // to it
-      case 'error':
-        expect(
-          indicator.querySelector(`[data-testid='network-off-icon']`)
-        ).toBeInTheDocument();
-        expect(
-          indicator.querySelector(`[data-icon='circle-exclamation']`)
-        ).toBeInTheDocument();
+      // Error states show the slashed network icon in the danger color
+      case 'error': {
+        const icon = indicator.querySelector(`[data-icon='network-off']`);
+        expect(icon).toBeInTheDocument();
+        expect(indicator.querySelectorAll('[data-icon]')).toHaveLength(1);
+        expect(icon).toHaveStyle(`color: ${DANGER_COLOR}`);
         break;
+      }
       /* istanbul ignore next - compile-time check */
       default:
         throw new Error('unreachable');

--- a/libs/ui/src/network_status_indicator.tsx
+++ b/libs/ui/src/network_status_indicator.tsx
@@ -1,6 +1,6 @@
-import React, { useId } from 'react';
-import styled from 'styled-components';
-import { Icons } from './icons';
+import { useId } from 'react';
+import styled, { useTheme } from 'styled-components';
+import { iconColor, IconProps, Icons } from './icons';
 
 /**
  * The network statuses a machine's toolbar indicator can display, grouped by
@@ -32,7 +32,7 @@ export type HostNetworkIndicatorStatus = Exclude<
 const IndicatorRow = styled.div`
   display: flex;
   flex-direction: row;
-  gap: 0.4rem;
+  gap: 0.5rem;
   align-items: center;
   white-space: nowrap;
 `;
@@ -44,49 +44,45 @@ const IndicatorRow = styled.div`
  */
 const NetworkOffSvg = styled.svg`
   height: 1em;
-  width: 1em;
+  width: 1.125em;
   vertical-align: -0.125em;
-  color: ${(p) => p.theme.colors.onInverse};
 `;
 
-function NetworkOffIcon(): JSX.Element {
+function NetworkOffIcon({ color }: Pick<IconProps, 'color'>): JSX.Element {
   const maskId = useId();
+  const theme = useTheme();
   return (
     <NetworkOffSvg
       data-testid="network-off-icon"
       xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 640 640"
-      fill="currentColor"
+      viewBox="0 0 576 512"
+      fill="none"
       aria-hidden="true"
+      style={{ color: iconColor(theme, color) }}
     >
       <mask
         id={maskId}
         maskUnits="userSpaceOnUse"
         x="0"
-        y="0"
-        width="640"
+        y="-64"
+        width="576"
         height="640"
       >
-        <rect width="640" height="640" fill="#fff" />
-        <line
-          x1="60"
-          y1="85.2"
-          x2="568"
-          y2="629.9"
-          stroke="#000"
-          strokeWidth="150"
+        <rect y="-64" width="576" height="640" fill="white" />
+        <path
+          d="M53 4L523 508"
+          stroke="black"
+          strokeWidth="110"
           strokeLinecap="round"
         />
       </mask>
       <path
         mask={`url(#${maskId})`}
-        d="M256 128C256 110.3 270.3 96 288 96L352 96C369.7 96 384 110.3 384 128L384 192C384 209.7 369.7 224 352 224L344 224L344 288L464 288C503.8 288 536 320.2 536 360L536 416L544 416C561.7 416 576 430.3 576 448L576 512C576 529.7 561.7 544 544 544L480 544C462.3 544 448 529.7 448 512L448 448C448 430.3 462.3 416 480 416L488 416L488 360C488 346.7 477.3 336 464 336L344 336L344 416L352 416C369.7 416 384 430.3 384 448L384 512C384 529.7 369.7 544 352 544L288 544C270.3 544 256 529.7 256 512L256 448C256 430.3 270.3 416 288 416L296 416L296 336L176 336C162.7 336 152 346.7 152 360L152 416L160 416C177.7 416 192 430.3 192 448L192 512C192 529.7 177.7 544 160 544L96 544C78.3 544 64 529.7 64 512L64 448C64 430.3 78.3 416 96 416L104 416L104 360C104 320.2 136.2 288 176 288L296 288L296 224L288 224C270.3 224 256 209.7 256 192L256 128z"
+        fill="currentColor"
+        d="M208 80c0-26.5 21.5-48 48-48l64 0c26.5 0 48 21.5 48 48l0 64c0 26.5-21.5 48-48 48l-8 0 0 40 152 0c30.9 0 56 25.1 56 56l0 32 8 0c26.5 0 48 21.5 48 48l0 64c0 26.5-21.5 48-48 48l-64 0c-26.5 0-48-21.5-48-48l0-64c0-26.5 21.5-48 48-48l8 0 0-32c0-4.4-3.6-8-8-8l-152 0 0 40 8 0c26.5 0 48 21.5 48 48l0 64c0 26.5-21.5 48-48 48l-64 0c-26.5 0-48-21.5-48-48l0-64c0-26.5 21.5-48 48-48l8 0 0-40-152 0c-4.4 0-8 3.6-8 8l0 32 8 0c26.5 0 48 21.5 48 48l0 64c0 26.5-21.5 48-48 48l-64 0c-26.5 0-48-21.5-48-48l0-64c0-26.5 21.5-48 48-48l8 0 0-32c0-30.9 25.1-56 56-56l152 0 0-40-8 0c-26.5 0-48-21.5-48-48l0-64z"
       />
-      <line
-        x1="120"
-        y1="149.5"
-        x2="508"
-        y2="565.6"
+      <path
+        d="M94 48L482 464"
         stroke="currentColor"
         strokeWidth="54"
         strokeLinecap="round"
@@ -117,20 +113,16 @@ export function NetworkStatusIndicator(
       label: isHost ? 'Network Online' : 'Connected',
     },
     'no-host-connected': {
-      icon: <NetworkOffIcon />,
+      icon: <NetworkOffIcon color="inverse" />,
+
       label: 'No VxAdmin Connected',
     },
     'no-network': {
-      icon: <NetworkOffIcon />,
+      icon: <NetworkOffIcon color="inverse" />,
       label: 'No Network',
     },
     error: {
-      icon: (
-        <React.Fragment>
-          <NetworkOffIcon />
-          <Icons.Danger color="inverseDanger" />
-        </React.Fragment>
-      ),
+      icon: <NetworkOffIcon color="inverseDanger" />,
       label: 'Network Error',
     },
   };

--- a/libs/ui/src/network_status_indicator.tsx
+++ b/libs/ui/src/network_status_indicator.tsx
@@ -1,6 +1,5 @@
-import { useId } from 'react';
-import styled, { useTheme } from 'styled-components';
-import { iconColor, IconProps, Icons } from './icons';
+import styled from 'styled-components';
+import { Icons } from './icons';
 
 /**
  * The network statuses a machine's toolbar indicator can display, grouped by
@@ -37,60 +36,6 @@ const IndicatorRow = styled.div`
   white-space: nowrap;
 `;
 
-/**
- * A slashed variant of the network (sitemap) icon, used for warning and error
- * states. Not part of FontAwesome, so it's inlined here. Sized and aligned to
- * match the FontAwesome icons rendered by `Icons`.
- */
-const NetworkOffSvg = styled.svg`
-  height: 1em;
-  width: 1.125em;
-  vertical-align: -0.125em;
-`;
-
-function NetworkOffIcon({ color }: Pick<IconProps, 'color'>): JSX.Element {
-  const maskId = useId();
-  const theme = useTheme();
-  return (
-    <NetworkOffSvg
-      data-testid="network-off-icon"
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 576 512"
-      fill="none"
-      aria-hidden="true"
-      style={{ color: iconColor(theme, color) }}
-    >
-      <mask
-        id={maskId}
-        maskUnits="userSpaceOnUse"
-        x="0"
-        y="-64"
-        width="576"
-        height="640"
-      >
-        <rect y="-64" width="576" height="640" fill="white" />
-        <path
-          d="M53 4L523 508"
-          stroke="black"
-          strokeWidth="110"
-          strokeLinecap="round"
-        />
-      </mask>
-      <path
-        mask={`url(#${maskId})`}
-        fill="currentColor"
-        d="M208 80c0-26.5 21.5-48 48-48l64 0c26.5 0 48 21.5 48 48l0 64c0 26.5-21.5 48-48 48l-8 0 0 40 152 0c30.9 0 56 25.1 56 56l0 32 8 0c26.5 0 48 21.5 48 48l0 64c0 26.5-21.5 48-48 48l-64 0c-26.5 0-48-21.5-48-48l0-64c0-26.5 21.5-48 48-48l8 0 0-32c0-4.4-3.6-8-8-8l-152 0 0 40 8 0c26.5 0 48 21.5 48 48l0 64c0 26.5-21.5 48-48 48l-64 0c-26.5 0-48-21.5-48-48l0-64c0-26.5 21.5-48 48-48l8 0 0-40-152 0c-4.4 0-8 3.6-8 8l0 32 8 0c26.5 0 48 21.5 48 48l0 64c0 26.5-21.5 48-48 48l-64 0c-26.5 0-48-21.5-48-48l0-64c0-26.5 21.5-48 48-48l8 0 0-32c0-30.9 25.1-56 56-56l152 0 0-40-8 0c-26.5 0-48-21.5-48-48l0-64z"
-      />
-      <path
-        d="M94 48L482 464"
-        stroke="currentColor"
-        strokeWidth="54"
-        strokeLinecap="round"
-      />
-    </NetworkOffSvg>
-  );
-}
-
 export type NetworkStatusIndicatorProps =
   | { isHost: true; status: HostNetworkIndicatorStatus }
   | { isHost?: false; status: NetworkIndicatorStatus };
@@ -113,16 +58,15 @@ export function NetworkStatusIndicator(
       label: isHost ? 'Network Online' : 'Connected',
     },
     'no-host-connected': {
-      icon: <NetworkOffIcon color="inverse" />,
-
+      icon: <Icons.NetworkOff color="inverse" />,
       label: 'No VxAdmin Connected',
     },
     'no-network': {
-      icon: <NetworkOffIcon color="inverse" />,
+      icon: <Icons.NetworkOff color="inverse" />,
       label: 'No Network',
     },
     error: {
-      icon: <NetworkOffIcon color="inverseDanger" />,
+      icon: <Icons.NetworkOff color="inverseDanger" />,
       label: 'Network Error',
     },
   };

--- a/libs/ui/src/network_status_indicator.tsx
+++ b/libs/ui/src/network_status_indicator.tsx
@@ -109,7 +109,7 @@ export function NetworkStatusIndicator(
     { icon: JSX.Element; label: string }
   > = {
     connected: {
-      icon: <Icons.Sitemap color="inverse" />,
+      icon: <Icons.Network color="inverse" />,
       label: isHost ? 'Network Online' : 'Connected',
     },
     'no-host-connected': {

--- a/libs/ui/src/toolbar.tsx
+++ b/libs/ui/src/toolbar.tsx
@@ -14,12 +14,18 @@ export const Toolbar = styled.div`
   top: 0;
   width: 100%;
   height: 2.2rem;
-  gap: 1.25rem;
+  gap: 1.5rem;
   justify-content: flex-end;
   align-items: center;
   background: ${(p) => p.theme.colors.inverseContainer};
   color: ${(p) => p.theme.colors.onInverse};
   padding: 0.25rem 1rem;
+`;
+
+export const ToolbarButtons = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
 `;
 
 const Row = styled.div`


### PR DESCRIPTION
## Overview

<!-- Add a link to a GitHub issue here -->
This PR is a bit of a grab bag of various polish items for the VxCentralScan network off icon. The main one is to rebuild the icon using the appropriate base FontAwesome icon (I accidentally used the wrong version initially, so it didn't match our existing icon). Commits detail the rest of the changes.

## Demo Video or Screenshot

<img width="960" height="600" alt="Screenshot-VxCentralScan-2026-08-24T22:32:32 415Z" src="https://github.com/user-attachments/assets/310a0df4-663a-4713-8066-64734dabcb76" />
<img width="960" height="600" alt="Screenshot-VxCentralScan-2026-08-24T22:32:53 239Z" src="https://github.com/user-attachments/assets/35b8a46c-3cae-400a-8907-ac09826f9af5" />
<img width="960" height="600" alt="Screenshot-VxCentralScan-2026-08-24T22:33:10 844Z" src="https://github.com/user-attachments/assets/08f3f0ad-eb6a-4914-a38b-ab32b5bace22" />


## Testing Plan
Visual inspection, updated some automated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
