### PR TITLE
refactor(admin): inject machine mode controller

### DIFF
--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -99,7 +99,7 @@ import {
 import { Workspace } from './util/workspace.js';
 import { getMachineConfig } from './machine_config.js';
 import { isMultiStationAdjudicationEnabled } from './multi_station_config.js';
-import { readMachineMode, writeMachineMode } from './machine_mode.js';
+import { MachineModeController } from './machine_mode.js';
 import { getBallotImages } from './util/adjudication.js';
 import {
   transformWriteInsAndSetManualResults,
@@ -191,12 +191,14 @@ function getCurrentElectionRecord(
 function buildApi({
   auth,
   workspace,
+  machineMode,
   logger,
   multiUsbDrive,
   printer,
 }: {
   auth: DippedSmartCardAuthApi;
   workspace: Workspace;
+  machineMode: MachineModeController;
   logger: Logger;
   multiUsbDrive: MultiUsbDrive;
   printer: Printer;
@@ -279,7 +281,7 @@ function buildApi({
     getMachineConfig,
 
     getMachineMode(): MachineMode {
-      return readMachineMode(workspace.path);
+      return machineMode.get();
     },
 
     async setMachineMode(input: { mode: MachineMode }): Promise<void> {
@@ -287,15 +289,21 @@ function buildApi({
         store.getCurrentElectionId() === undefined,
         'Cannot change machine mode while an election is configured.'
       );
-      if (input.mode === 'client') {
+
+      // Set the value and re-read it so the value is normalized before we take
+      // action based on its value.
+      machineMode.set(input.mode);
+      const newMachineMode = machineMode.get();
+
+      if (newMachineMode === 'client') {
         const { machineId } = getMachineConfig();
         AvahiService.stopAdvertisedService(getHostServiceName(machineId));
       }
-      writeMachineMode(workspace.path, input.mode);
+
       await logger.logAsCurrentRole(LogEventId.AdminMachineModeChanged, {
-        message: `Machine mode changed to ${input.mode}.`,
+        message: `Machine mode changed to ${newMachineMode}.`,
         disposition: 'success',
-        newMode: input.mode,
+        newMode: newMachineMode,
       });
     },
 
@@ -1624,12 +1632,14 @@ export type Api = ReturnType<typeof buildApi>;
 export function buildApp({
   auth,
   workspace,
+  machineMode,
   logger,
   multiUsbDrive,
   printer,
 }: {
   auth: DippedSmartCardAuthApi;
   workspace: Workspace;
+  machineMode: MachineModeController;
   logger: Logger;
   multiUsbDrive: MultiUsbDrive;
   printer: Printer;
@@ -1638,6 +1648,7 @@ export function buildApp({
   const api = buildApi({
     auth,
     workspace,
+    machineMode,
     logger,
     multiUsbDrive,
     printer,

--- a/apps/admin/backend/src/app_networking.test.ts
+++ b/apps/admin/backend/src/app_networking.test.ts
@@ -33,7 +33,7 @@ import type { PeerApi } from './peer_app.js';
 import { buildClientApp } from './client_app.js';
 import type { ClientApi } from './client_app.js';
 import { Store } from './store.js';
-import { ClientConnectionStatus } from './types.js';
+import { ClientConnectionStatus, MachineMode } from './types.js';
 import { addMockCvrFileToStore } from '../test/mock_cvr_file.js';
 import {
   buildMockLogger,
@@ -130,6 +130,7 @@ async function setupHostAndClient(
   const { clientStore } = clientWorkspace;
   const auth = buildMockDippedSmartCardAuth(vi.fn);
   const mockLogger = buildMockLogger(auth, clientStore);
+  let machineMode: MachineMode = 'host';
   const clientApp = buildClientApp({
     auth,
     workspace: clientWorkspace,
@@ -138,6 +139,12 @@ async function setupHostAndClient(
       logger: mockLogger,
       platform: new SimulatedUsbPlatform(makeTemporaryDirectory()),
     }),
+    machineMode: {
+      get: () => machineMode,
+      set: (newMachineMode) => {
+        machineMode = newMachineMode;
+      },
+    },
   });
   clientServer = clientApp.listen();
   const { port: clientPort } = clientServer.address() as AddressInfo;

--- a/apps/admin/backend/src/client_app.test.ts
+++ b/apps/admin/backend/src/client_app.test.ts
@@ -24,7 +24,11 @@ import { buildClientApp, ClientApi } from './client_app.js';
 import { isMultiStationAdjudicationEnabled } from './multi_station_config.js';
 import type { PeerApi } from './peer_app.js';
 import { createClientWorkspace } from './util/workspace.js';
-import { ClientConnectionStatus, ElectionRecord } from './types.js';
+import {
+  ClientConnectionStatus,
+  ElectionRecord,
+  MachineMode,
+} from './types.js';
 
 import {
   attachUsbDrive,
@@ -48,11 +52,18 @@ function buildClientTestEnvironment() {
     logger,
     platform: usbPlatform,
   });
+  let machineMode: MachineMode = 'host';
   const app = buildClientApp({
     auth,
     workspace,
     logger,
     multiUsbDrive,
+    machineMode: {
+      get: () => machineMode,
+      set: (newMachineMode) => {
+        machineMode = newMachineMode;
+      },
+    },
   });
   const server = app.listen();
   const { port } = server.address() as AddressInfo;

--- a/apps/admin/backend/src/client_app.ts
+++ b/apps/admin/backend/src/client_app.ts
@@ -30,7 +30,7 @@ import {
 } from '@votingworks/types';
 import { getMachineConfig } from './machine_config.js';
 import { isMultiStationAdjudicationEnabled } from './multi_station_config.js';
-import { readMachineMode, writeMachineMode } from './machine_mode.js';
+import { MachineModeController } from './machine_mode.js';
 import {
   type MachineMode,
   BallotPageImage,
@@ -139,11 +139,13 @@ async function fetchBallotImagesFromHost(
 function buildClientApi({
   auth,
   workspace,
+  machineMode,
   logger,
   multiUsbDrive,
 }: {
   auth: DippedSmartCardAuthApi;
   workspace: ClientWorkspace;
+  machineMode: MachineModeController;
   logger: Logger;
   multiUsbDrive: MultiUsbDrive;
 }) {
@@ -166,7 +168,7 @@ function buildClientApi({
     getMachineConfig,
 
     getMachineMode(): MachineMode {
-      return readMachineMode(workspace.path);
+      return machineMode.get();
     },
 
     isMultiStationAdjudicationEnabled(): boolean {
@@ -178,7 +180,7 @@ function buildClientApi({
         clientStore.getCurrentElectionId() === undefined,
         'Cannot change machine mode while an election is configured.'
       );
-      writeMachineMode(workspace.path, input.mode);
+      machineMode.set(input.mode);
       await logger.logAsCurrentRole(LogEventId.AdminMachineModeChanged, {
         message: `Machine mode changed to ${input.mode}.`,
         disposition: 'success',
@@ -412,16 +414,24 @@ export type ClientApi = ReturnType<typeof buildClientApi>;
 export function buildClientApp({
   auth,
   workspace,
+  machineMode,
   logger,
   multiUsbDrive,
 }: {
   auth: DippedSmartCardAuthApi;
   workspace: ClientWorkspace;
+  machineMode: MachineModeController;
   logger: Logger;
   multiUsbDrive: MultiUsbDrive;
 }): Application {
   const app: Application = express();
-  const api = buildClientApi({ auth, workspace, logger, multiUsbDrive });
+  const api = buildClientApi({
+    auth,
+    workspace,
+    machineMode,
+    logger,
+    multiUsbDrive,
+  });
   app.use('/api', grout.buildRouter(api, express));
   return app;
 }

--- a/apps/admin/backend/src/machine_mode.test.ts
+++ b/apps/admin/backend/src/machine_mode.test.ts
@@ -1,63 +1,88 @@
-import { existsSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { describe, expect, test, beforeEach } from 'vitest';
-import tmp from 'tmp';
-import { readMachineMode, writeMachineMode } from './machine_mode.js';
+import { existsSync, readFileSync } from 'node:fs';
+import { describe, expect, test } from 'vitest';
+import {
+  makeTemporaryDirectory,
+  makeTemporaryFile,
+  makeTemporaryPath,
+} from '@votingworks/fixtures';
+import { FileBackedMachineModeController } from './machine_mode.js';
+import { MachineMode } from './types.js';
 
-let workspacePath: string;
-
-beforeEach(() => {
-  workspacePath = tmp.dirSync().name;
-});
-
-describe('readMachineMode', () => {
+describe('FileBackedMachineModeController::get', () => {
   test('returns host when no mode file exists', () => {
-    expect(readMachineMode(workspacePath)).toEqual('host');
+    const controller = new FileBackedMachineModeController(makeTemporaryPath());
+    expect(controller.get()).toEqual('host');
   });
 
   test('returns host when mode file contains host', () => {
-    writeFileSync(join(workspacePath, 'machine_mode'), 'host', 'utf-8');
-    expect(readMachineMode(workspacePath)).toEqual('host');
+    const controller = new FileBackedMachineModeController(
+      makeTemporaryFile({ content: 'host' })
+    );
+    expect(controller.get()).toEqual('host');
   });
 
   test('returns client when mode file contains client', () => {
-    writeFileSync(join(workspacePath, 'machine_mode'), 'client', 'utf-8');
-    expect(readMachineMode(workspacePath)).toEqual('client');
+    const controller = new FileBackedMachineModeController(
+      makeTemporaryFile({ content: 'client' })
+    );
+    expect(controller.get()).toEqual('client');
   });
 
   test('returns host for unrecognized mode file contents', () => {
-    writeFileSync(join(workspacePath, 'machine_mode'), 'unknown', 'utf-8');
-    expect(readMachineMode(workspacePath)).toEqual('host');
+    const controller = new FileBackedMachineModeController(
+      makeTemporaryFile({ content: 'unknown' })
+    );
+    expect(controller.get()).toEqual('host');
   });
 
   test('trims whitespace from mode file', () => {
-    writeFileSync(join(workspacePath, 'machine_mode'), '  client\n', 'utf-8');
-    expect(readMachineMode(workspacePath)).toEqual('client');
+    const controller = new FileBackedMachineModeController(
+      makeTemporaryFile({ content: '  client\n' })
+    );
+    expect(controller.get()).toEqual('client');
+  });
+
+  test('fails if an existing mode file exists but cannot be read', () => {
+    const controller = new FileBackedMachineModeController(
+      makeTemporaryDirectory()
+    );
+    expect(() => controller.get()).toThrow();
   });
 });
 
-describe('writeMachineMode', () => {
+describe('FileBackedMachineModeController::set', () => {
   test('writes host mode', () => {
-    writeMachineMode(workspacePath, 'host');
-    expect(readMachineMode(workspacePath)).toEqual('host');
+    const controller = new FileBackedMachineModeController(makeTemporaryFile());
+    controller.set('host');
+    expect(controller.get()).toEqual('host');
   });
 
   test('writes client mode', () => {
-    writeMachineMode(workspacePath, 'client');
-    expect(readMachineMode(workspacePath)).toEqual('client');
+    const controller = new FileBackedMachineModeController(makeTemporaryFile());
+    controller.set('client');
+    expect(controller.get()).toEqual('client');
   });
 
   test('creates the file if it does not exist', () => {
-    const filePath = join(workspacePath, 'machine_mode');
-    expect(existsSync(filePath)).toEqual(false);
-    writeMachineMode(workspacePath, 'client');
-    expect(existsSync(filePath)).toEqual(true);
+    const filePath = makeTemporaryPath();
+    expect(existsSync(filePath)).toBeFalsy();
+    const controller = new FileBackedMachineModeController(filePath);
+    controller.set('client');
+    expect(existsSync(filePath)).toBeTruthy();
   });
 
   test('overwrites existing mode', () => {
-    writeMachineMode(workspacePath, 'client');
-    expect(readMachineMode(workspacePath)).toEqual('client');
-    writeMachineMode(workspacePath, 'host');
-    expect(readMachineMode(workspacePath)).toEqual('host');
+    const controller = new FileBackedMachineModeController(makeTemporaryFile());
+    controller.set('client');
+    expect(controller.get()).toEqual('client');
+    controller.set('host');
+    expect(controller.get()).toEqual('host');
+  });
+
+  test('replaces junk data with the default', () => {
+    const filePath = makeTemporaryFile();
+    const controller = new FileBackedMachineModeController(filePath);
+    controller.set('#!/usr/bin/env bash\nreboot' as unknown as MachineMode);
+    expect(readFileSync(filePath, 'utf-8')).toEqual('host');
   });
 });

--- a/apps/admin/backend/src/machine_mode.ts
+++ b/apps/admin/backend/src/machine_mode.ts
@@ -1,36 +1,45 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { isNonExistentFileOrDirectoryError } from '@votingworks/basics';
 import type { MachineMode } from './types.js';
 
-const MACHINE_MODE_FILENAME = 'machine_mode';
-
-function machineModeFilePath(workspacePath: string): string {
-  return join(workspacePath, MACHINE_MODE_FILENAME);
+/**
+ * Provides machine mode switching between `host` and `client` modes.
+ */
+export interface MachineModeController {
+  get(): MachineMode;
+  set(mode: MachineMode): void;
 }
 
 /**
- * Reads the machine mode from the workspace directory. Returns 'host' if no
- * mode file exists.
+ * Builds a controller that uses `filePath` as the backing store for the current
+ * machine mode setting.
  */
-export function readMachineMode(workspacePath: string): MachineMode {
-  const filePath = machineModeFilePath(workspacePath);
-  if (!existsSync(filePath)) {
+export class FileBackedMachineModeController {
+  constructor(private readonly filePath: string) {}
+
+  get(): MachineMode {
+    try {
+      const contents = readFileSync(this.filePath, 'utf-8').trim();
+      if (contents === 'client') {
+        return 'client';
+      }
+    } catch (error) {
+      if (!isNonExistentFileOrDirectoryError(error)) {
+        throw error;
+      }
+    }
+
     return 'host';
   }
-  const contents = readFileSync(filePath, 'utf-8').trim();
-  if (contents === 'client') {
-    return 'client';
-  }
-  return 'host';
-}
 
-/**
- * Writes the machine mode to the workspace directory.
- */
-export function writeMachineMode(
-  workspacePath: string,
-  mode: MachineMode
-): void {
-  const filePath = machineModeFilePath(workspacePath);
-  writeFileSync(filePath, mode, 'utf-8');
+  set(mode: MachineMode): void {
+    writeFileSync(this.filePath, mode === 'client' ? mode : 'host', 'utf-8');
+  }
+
+  static forWorkspace(workspacePath: string): FileBackedMachineModeController {
+    return new FileBackedMachineModeController(
+      join(workspacePath, 'machine_mode')
+    );
+  }
 }

--- a/apps/admin/backend/src/server.test.ts
+++ b/apps/admin/backend/src/server.test.ts
@@ -24,7 +24,6 @@ import { createMockPrinterHandler } from '@votingworks/printing';
 import { start } from './server.js';
 import { createWorkspace } from './util/workspace.js';
 import { importCastVoteRecords } from './cast_vote_records.js';
-import { writeMachineMode } from './machine_mode.js';
 import { startHostNetworking, startClientNetworking } from './networking.js';
 
 // Mock modules that start() creates or calls internally
@@ -325,14 +324,20 @@ test('starts client networking in client mode', async () => {
   const workspacePath = makeTemporaryDirectory();
   const logger = mockLogger({ fn: vi.fn });
 
-  writeMachineMode(workspacePath, 'client');
-
   featureFlagMock.enableFeatureFlag(
     BooleanEnvironmentVariableName.ENABLE_MULTI_STATION_ADMIN
   );
 
   server = await suppressingConsoleOutput(() =>
-    start({ workspacePath, logger, port: 0 })
+    start({
+      workspacePath,
+      logger,
+      port: 0,
+      machineMode: {
+        get: () => 'client',
+        set: vi.fn().mockThrow('do not set machineMode'),
+      },
+    })
   );
 
   expect(startClientNetworking).toHaveBeenCalled();

--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -35,13 +35,16 @@ import { createWorkspace, createClientWorkspace } from './util/workspace.js';
 import { buildApp } from './app.js';
 import { buildClientApp } from './client_app.js';
 import { buildPeerApp } from './peer_app.js';
-import { readMachineMode } from './machine_mode.js';
 import { getMachineConfig } from './machine_config.js';
 import { isMultiStationAdjudicationEnabled } from './multi_station_config.js';
 import { startHostNetworking, startClientNetworking } from './networking.js';
 import { rootDebug } from './util/debug.js';
 import { getUserRole } from './util/auth.js';
 import type { MachineMode } from './types.js';
+import {
+  FileBackedMachineModeController,
+  MachineModeController,
+} from './machine_mode.js';
 
 const debug = rootDebug.extend('server');
 
@@ -98,6 +101,7 @@ export interface StartOptions {
   workspacePath?: string;
   multiUsbDrive?: MultiUsbDrive;
   printer?: Printer;
+  machineMode?: MachineModeController;
 }
 
 /**
@@ -115,11 +119,14 @@ export async function start(options: StartOptions = {}): Promise<Server> {
 
   const workspacePath =
     options.workspacePath ?? resolveWorkspacePath(baseLogger);
-  const machineMode = readMachineMode(workspacePath);
+  const machineMode =
+    options.machineMode ??
+    FileBackedMachineModeController.forWorkspace(workspacePath);
 
   let app;
 
-  switch (machineMode) {
+  const machineModeValue = machineMode.get();
+  switch (machineModeValue) {
     case 'host': {
       // TODO(CARO) add some kind of validation that the workspace is properly configured for host mode
       const workspace = createWorkspace(workspacePath, baseLogger);
@@ -173,6 +180,7 @@ export async function start(options: StartOptions = {}): Promise<Server> {
         multiUsbDrive,
         printer,
         workspace,
+        machineMode,
       });
 
       // Log election results data check at startup
@@ -232,6 +240,7 @@ export async function start(options: StartOptions = {}): Promise<Server> {
         logger,
         workspace: clientWorkspace,
         multiUsbDrive,
+        machineMode,
       });
 
       baseLogger.log(LogEventId.DataCheckOnStartup, 'system', {
@@ -245,7 +254,7 @@ export async function start(options: StartOptions = {}): Promise<Server> {
 
     default:
       /* istanbul ignore next */
-      throwIllegalValue(machineMode);
+      throwIllegalValue(machineModeValue);
   }
 
   useDevDockRouter(app, express, {

--- a/apps/admin/backend/test/app.ts
+++ b/apps/admin/backend/test/app.ts
@@ -43,7 +43,7 @@ import {
   mockLogger,
 } from '@votingworks/logging';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
-import { Api, PeerApi } from '../src/index.js';
+import { Api, MachineMode, PeerApi } from '../src/index.js';
 import { BaseStore } from '../src/types.js';
 import { createWorkspace } from '../src/util/workspace.js';
 import { buildApp } from '../src/app.js';
@@ -201,12 +201,19 @@ export function buildTestEnvironment(workspaceRoot?: string) {
   const usbPlatform = new SimulatedUsbPlatform(makeTemporaryDirectory());
   const multiUsbDrive = detectMultiUsbDrive({ logger, platform: usbPlatform });
   const mockPrinterHandler = createMockPrinterHandler();
+  let machineMode: MachineMode = 'host';
   const app = buildApp({
     auth,
     workspace,
     logger,
     multiUsbDrive,
     printer: mockPrinterHandler.printer,
+    machineMode: {
+      get: () => machineMode,
+      set: (newMachineMode) => {
+        machineMode = newMachineMode;
+      },
+    },
   });
   // port 0 will bind to a random, free port assigned by the OS
   const server = app.listen();


### PR DESCRIPTION
## Overview
Replaces the read/write free functions for managing the machine mode with an injected object that can get and set the value. This is part of consolidating knowledge of how the workspace is laid out, and `read/writeMachineMode` both knew about the location of the mode file within the workspace.

## Demo Video or Screenshot
n/a

## Testing Plan
Existing automated tests.