### PR TITLE
VxDesign: stop leaking an advancing fake clock past test teardown

### DIFF
--- a/apps/design/frontend/test/setupTests.ts
+++ b/apps/design/frontend/test/setupTests.ts
@@ -79,3 +79,7 @@ window.matchMedia = vi.fn().mockImplementation(() => ({ matches: false }));
 
 beforeAll(setupTemporaryRootDir);
 afterAll(clearTemporaryRootDir);
+
+afterAll(() => {
+  vi.useRealTimers();
+});


### PR DESCRIPTION
## Overview

`test-apps-design-frontend` fails intermittently with `ReferenceError: document is not defined` thrown from `resetToBaseTitle` in `src/hooks/use_title.ts` — while all 46 files and 434 tests pass. The job goes red on an unhandled error, not a failed assertion.

`export_screen.test.tsx` installs `vi.useFakeTimers({ shouldAdvanceTime: true })` at module scope and never restores real timers, so a real interval keeps advancing fake time after that file's tests finish. `useTitle` schedules a title reset on unmount that nothing clears, so timers are still queued when the file ends. Whether that interval gets one more tick before jsdom is torn down is a race — hence roughly one failure in ten runs.

Uninstalling the clock in a global `afterAll` runs after each file's own hooks and before teardown, so no file can leak an advancing clock regardless of its own timer discipline. `live_reports_screen.test.tsx` already restores correctly; this makes that the floor rather than something each file has to remember.

## Testing Plan

- Instrumented the end of `export_screen.test.tsx`: fake timers still installed with **235 pending timers** when the file finishes.
- With this change, the same probe reads `installed=false` after the hook — the advancing clock and its queued callbacks are gone before teardown.
- Full suite green: 46 files / 434 tests, coverage unchanged at 97.2% lines / 90.98% branches.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEwdwX2jTiDjWkA3NQMgeK