### PR TITLE
fix(admin): snapshot backups over the workspace's own SQLite connection

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -1,6 +1,7 @@
 create table elections (
   id text primary key,
   election_data text not null,
+  ballot_hash text not null,
   system_settings_data text not null,
   election_package_hash text not null,
   is_official_results integer not null default false,

--- a/apps/admin/backend/src/backup/cli/main.test.ts
+++ b/apps/admin/backend/src/backup/cli/main.test.ts
@@ -247,6 +247,21 @@ test('create fails when the workspace cannot be read', async () => {
   expect(stderr).toContain('Workspace directory could not be found');
 });
 
+test('create fails fast when the workspace cannot be opened for another reason', async () => {
+  const workspace = join(makeTemporaryDirectory(), 'a-file');
+  writeFileSync(workspace, 'not a workspace');
+
+  await expect(
+    run([
+      'create',
+      '--workspace',
+      workspace,
+      '--target',
+      makeTemporaryDirectory(),
+    ])
+  ).rejects.toThrow('ENOTDIR');
+});
+
 test('validate lists the backup files', async () => {
   const { code, stdout, stderr } = await run(['validate', makeBackup()]);
   expect(code).toEqual(0);

--- a/apps/admin/backend/src/backup/cli/main.ts
+++ b/apps/admin/backend/src/backup/cli/main.ts
@@ -2,7 +2,10 @@ import assert from 'node:assert';
 import { relative } from 'node:path';
 import { inspect } from 'node:util';
 import yargs from 'yargs';
-import { extractErrorMessage } from '@votingworks/basics';
+import {
+  extractErrorMessage,
+  isNonExistentFileOrDirectoryError,
+} from '@votingworks/basics';
 import { FileSystemEntryType, listDirectoryRecursive } from '@votingworks/fs';
 import { BaseLogger, LogSource } from '@votingworks/logging';
 import { getNodeEnv } from '@votingworks/backend';
@@ -13,6 +16,7 @@ import * as views from './views.js';
 import { Backup } from '../backup.js';
 import { ProgressEvent } from '../create/types.js';
 import { createBackup } from '../create/index.js';
+import { openWorkspace, Workspace } from '../../util/workspace.js';
 
 /**
  * IO streams given to the CLI.
@@ -163,6 +167,25 @@ function displayProgress(event: ProgressEvent): DisplayProgress {
 }
 
 /**
+ * Opens the workspace to back up, or returns `undefined` if there is no
+ * workspace at `path`. Any other failure to open it is a bug and throws.
+ */
+function openWorkspaceIfPresent(
+  path: string,
+  logger: BaseLogger
+): Workspace | undefined {
+  try {
+    return openWorkspace(path, logger);
+  } catch (error) {
+    if (isNonExistentFileOrDirectoryError(error)) {
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
+/**
  * Create a backup using the CLI-provided arguments.
  */
 async function create(
@@ -193,8 +216,17 @@ async function create(
     Boolean((stderr as NodeJS.WriteStream).isTTY)
   );
 
+  // The CLI owns the workspace it opens: `createBackup` snapshots over the
+  // connection it is given and leaves closing it to the caller.
+  using workspace = openWorkspaceIfPresent(args.workspace, logger);
+
+  if (!workspace) {
+    stderr.write('Error: Workspace directory could not be found\n');
+    return 1;
+  }
+
   const createBackupResult = await createBackup({
-    workspace: args.workspace,
+    workspace,
     target: args.target,
     logger,
     onProgressEvent: (event) => display.update(displayProgress(event)),

--- a/apps/admin/backend/src/backup/create/copy_step.test.ts
+++ b/apps/admin/backend/src/backup/create/copy_step.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import { Buffer } from 'node:buffer';
 import { readFile } from 'node:fs/promises';
+import { assertDefined } from '@votingworks/basics';
 import {
   electionFamousNames2021Fixtures,
   makeTemporaryDirectory,
@@ -139,19 +140,22 @@ test('copies staged files to the backup directory and builds a manifest', async 
   addCvrWithBallotImage(workspace);
 
   const prepareResult = await prepare({
-    workspace: workspace.path,
+    workspace,
     target: makeTemporaryDirectory(),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
-  const { source, store, electionRecord } = prepareResult.unsafeUnwrap();
+  const { electionId, source, snapshotStore } = prepareResult.unsafeUnwrap();
 
   const backupPath = join(makeTemporaryDirectory(), 'backup');
   const progressEvents: ProgressEvent[] = [];
 
+  const electionMetadata = assertDefined(
+    snapshotStore.getElectionMetadata(electionId)
+  );
   const manifest = await copy({
+    electionId,
     source,
-    store,
-    electionRecord,
+    store: snapshotStore,
     backup: backupPath,
     logger: mockBaseLogger({ fn: vi.fn }),
     onProgressEvent: (event) => progressEvents.push(event),
@@ -178,11 +182,7 @@ test('copies staged files to the backup directory and builds a manifest', async 
 
   expect(manifest.machineId).toEqual(DEV_MACHINE_ID);
   expect(manifest.softwareVersion).toEqual(LATEST_SOFTWARE_VERSION);
-  expect(manifest.election).toEqual({
-    id: electionRecord.electionDefinition.election.id,
-    title: electionRecord.electionDefinition.election.title,
-    date: electionRecord.electionDefinition.election.date,
-  });
+  expect(manifest.election).toEqual(electionMetadata);
 
   // Progress events bracket the copy with 0/total and total/total, and each
   // in-between event names the file currently being copied.
@@ -225,17 +225,21 @@ async function copyWithProgress(
   addCvrWithBallotImage(workspace);
 
   const prepareResult = await prepare({
-    workspace: workspace.path,
+    workspace,
     target: makeTemporaryDirectory(),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
-  const { source, store, electionRecord } = prepareResult.unsafeUnwrap();
+  const {
+    electionId,
+    source,
+    snapshotStore: store,
+  } = prepareResult.unsafeUnwrap();
   const events: ProgressEvent[] = [];
 
   await copy({
+    electionId,
     source,
     store,
-    electionRecord,
     backup: join(makeTemporaryDirectory(), 'backup'),
     logger: mockBaseLogger({ fn: vi.fn }),
     progressEventIntervalBytes,

--- a/apps/admin/backend/src/backup/create/copy_step.ts
+++ b/apps/admin/backend/src/backup/create/copy_step.ts
@@ -6,7 +6,7 @@ import { createHash } from 'node:crypto';
 import { pipeline } from 'node:stream/promises';
 import { Transform } from 'node:stream';
 import { DateTime } from 'luxon';
-import { assert } from '@votingworks/basics';
+import { assert, assertDefined } from '@votingworks/basics';
 import { LATEST_SOFTWARE_VERSION } from '@votingworks/types';
 import { BackupManifest, BackupManifestEntry } from '../backup_manifest.js';
 import { CopyBackupOptions } from './types.js';
@@ -26,7 +26,7 @@ const DEFAULT_PROGRESS_EVENT_INTERVAL_BYTES = 8_000_000; // 8 MB
 export async function copy(
   options: CopyBackupOptions
 ): Promise<BackupManifest> {
-  const { source, store, electionRecord } = options;
+  const { electionId, source, store } = options;
   const progressEventIntervalBytes =
     options.progressEventIntervalBytes ?? DEFAULT_PROGRESS_EVENT_INTERVAL_BYTES;
   let copiedCount = 0;
@@ -43,6 +43,10 @@ export async function copy(
   });
   const backupPath = options.backup;
   const backupWorkspacePath = join(backupPath, 'workspace');
+
+  // `prepare` resolved this election ID against the same snapshot, so its
+  // metadata is necessarily there.
+  const electionMetadata = assertDefined(store.getElectionMetadata(electionId));
 
   for (const file of source.listStagedFiles()) {
     options.onProgressEvent?.({
@@ -121,17 +125,12 @@ export async function copy(
 
   const softwareVersion = LATEST_SOFTWARE_VERSION;
   const machineConfig = getMachineConfig();
-  const electionDefinitionId = store.getElectionDefinitionId(electionRecord.id);
 
   return new BackupManifest(
     softwareVersion,
     machineConfig.machineId,
     DateTime.now().toISO(),
-    {
-      id: electionDefinitionId,
-      title: electionRecord.electionDefinition.election.title,
-      date: electionRecord.electionDefinition.election.date,
-    },
+    electionMetadata,
     backupManifestEntries
   );
 }

--- a/apps/admin/backend/src/backup/create/index.test.ts
+++ b/apps/admin/backend/src/backup/create/index.test.ts
@@ -182,7 +182,7 @@ test('a second backup atomically replaces the first, leaving no leftovers', asyn
   const fileStore = vi.spyOn(Store, 'fileStore');
 
   const firstResult = await createBackup({
-    workspace: workspace.path,
+    workspace,
     target,
     logger,
   });
@@ -241,7 +241,7 @@ test('a second backup atomically replaces the first, leaving no leftovers', asyn
   // first-ever plain rename.
   addCvrWithBallotImage(workspace, { ballotId: 'ballot-2' });
   const secondResult = await createBackup({
-    workspace: workspace.path,
+    workspace,
     target,
     logger,
   });
@@ -284,7 +284,7 @@ test('reports an error when copying the backup fails', async () => {
   vi.mocked(copy).mockRejectedValueOnce(outOfSpaceError());
 
   const result = await createBackup({
-    workspace: workspace.path,
+    workspace,
     target,
     logger: mockBaseLogger({ fn: vi.fn }),
   });
@@ -301,7 +301,7 @@ test('reports an error when writing the manifest fails, leaving no partial backu
   vi.mocked(writeManifest).mockRejectedValueOnce(outOfSpaceError());
 
   const result = await createBackup({
-    workspace: workspace.path,
+    workspace,
     target,
     logger: mockBaseLogger({ fn: vi.fn }),
   });
@@ -321,7 +321,7 @@ test('fails fast when writing the backup fails unexpectedly', async () => {
 
   await expect(
     createBackup({
-      workspace: workspace.path,
+      workspace,
       target,
       logger: mockBaseLogger({ fn: vi.fn }),
     })
@@ -349,7 +349,7 @@ test('reports an error when clearing a leftover in-progress backup fails', async
   );
 
   const result = await createBackup({
-    workspace: workspace.path,
+    workspace,
     target,
     logger: mockBaseLogger({ fn: vi.fn }),
   });
@@ -374,7 +374,7 @@ test('reports a failed swap rather than a created backup', async () => {
   );
 
   const result = await createBackup({
-    workspace: workspace.path,
+    workspace,
     target,
     logger: mockBaseLogger({ fn: vi.fn }),
   });

--- a/apps/admin/backend/src/backup/create/index.ts
+++ b/apps/admin/backend/src/backup/create/index.ts
@@ -1,7 +1,12 @@
 import { dirname } from 'node:path';
 import { mkdir, rm } from 'node:fs/promises';
-import { err, extractErrorMessage, ok, Result } from '@votingworks/basics';
-import { generateElectionBasedSubfolderName } from '@votingworks/utils';
+import {
+  assertDefined,
+  err,
+  extractErrorMessage,
+  ok,
+  Result,
+} from '@votingworks/basics';
 import { prepare, PrepareError } from './prepare_step.js';
 import { PrepareBackupOptions } from './types.js';
 import { copy } from './copy_step.js';
@@ -58,11 +63,11 @@ export async function createBackup(
     return prepareResult;
   }
 
-  const { source, store, electionRecord } = prepareResult.ok();
+  const { electionId, source, snapshotStore } = prepareResult.ok();
 
-  const electionBackupName = generateElectionBasedSubfolderName(
-    electionRecord.electionDefinition.election,
-    electionRecord.electionDefinition.ballotHash
+  const electionBackupName = assertDefined(
+    snapshotStore.getElectionBasedSubfolderName(electionId),
+    'the election `prepare` found must still be in the snapshot it took'
   );
 
   const root = new BackupRoot(options.target);
@@ -83,9 +88,9 @@ export async function createBackup(
       await rm(inProgressBackupPath, { recursive: true, force: true });
 
       manifest = await copy({
+        electionId,
         source,
-        store,
-        electionRecord,
+        store: snapshotStore,
         backup: inProgressBackupPath,
         logger: options.logger,
         onProgressEvent: options.onProgressEvent,
@@ -93,7 +98,7 @@ export async function createBackup(
     } finally {
       // Close the snapshot's connection before deleting the file it holds
       // open, or the space it occupies won't be reclaimed until we exit.
-      store.close();
+      snapshotStore.close();
       await source.cleanup();
     }
 

--- a/apps/admin/backend/src/backup/create/prepare_step.test.ts
+++ b/apps/admin/backend/src/backup/create/prepare_step.test.ts
@@ -176,11 +176,11 @@ test('reclaims a killed run’s staging area before measuring free space', async
   });
 
   const result = await prepare({
-    workspace: workspace.path,
+    workspace,
     target: makeTemporaryDirectory(),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
-  const { source, store } = result.unsafeUnwrap();
+  const { source, snapshotStore: store } = result.unsafeUnwrap();
 
   expect(staleBytesAtMeasureTime).toEqual(0);
 
@@ -194,6 +194,57 @@ test('reclaims a killed run’s staging area before measuring free space', async
   expect(existsSync(stagingAreaPath)).toEqual(false);
 });
 
+test('refuses while a write transaction is open on the workspace', async () => {
+  const workspace = await makeConfiguredWorkspace();
+
+  // What a CVR import looks like from here: it holds its transaction open
+  // across awaits for the whole import.
+  workspace.store['client'].run('begin transaction');
+
+  const result = await prepare({
+    workspace,
+    target: makeTemporaryDirectory(),
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  expect(result.err()).toEqual({
+    type: 'write-in-progress',
+    message:
+      'Cannot back up while another operation is writing to the database',
+  });
+
+  workspace.store['client'].run('rollback');
+});
+
+test('refuses when a write begins after the snapshot is cleared to start', async () => {
+  const workspace = await makeConfiguredWorkspace();
+  const dbClient = workspace.store['client'];
+
+  // Slip the write in after `prepare` checks, to stand in for the window
+  // between the check and the snapshot actually starting. It takes a real
+  // write, not just an open transaction, for SQLite to hold the write lock
+  // that makes the snapshot a no-op.
+  vi.spyOn(dbClient, 'isInTransaction').mockImplementationOnce(() => {
+    dbClient.run('begin transaction');
+    dbClient.run('update elections set election_data = election_data');
+    return false;
+  });
+
+  const result = await prepare({
+    workspace,
+    target: makeTemporaryDirectory(),
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  expect(result.err()).toEqual({
+    type: 'write-in-progress',
+    message:
+      'Cannot back up while another operation is writing to the database',
+  });
+
+  dbClient.run('rollback');
+});
+
 test('refuses when a backup of the workspace is already running', async () => {
   const workspace = await makeConfiguredWorkspace();
   const held = (
@@ -201,7 +252,7 @@ test('refuses when a backup of the workspace is already running', async () => {
   ).unsafeUnwrap();
 
   const result = await prepare({
-    workspace: workspace.path,
+    workspace,
     target: makeTemporaryDirectory(),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
@@ -214,21 +265,12 @@ test('refuses when a backup of the workspace is already running', async () => {
   await held.cleanup();
 });
 
-test('fails when the workspace directory does not exist', async () => {
-  const result = await prepare({
-    workspace: join(makeTemporaryDirectory(), 'does-not-exist'),
-    target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
-  });
-  expect(result.err()).toMatchObject({ type: 'file-not-found' });
-});
-
 test('fails when no election is configured', async () => {
   const logger = new BaseLogger(LogSource.VxAdminService);
   const workspace = createWorkspace(makeTemporaryDirectory(), logger);
 
   const result = await prepare({
-    workspace: workspace.path,
+    workspace,
     target: makeTemporaryDirectory(),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
@@ -244,7 +286,7 @@ test('fails when the backup target directory does not exist', async () => {
   const target = join(makeTemporaryDirectory(), 'not-mounted');
 
   const result = await prepare({
-    workspace: workspace.path,
+    workspace,
     target,
     logger: mockBaseLogger({ fn: vi.fn }),
   });
@@ -262,7 +304,7 @@ test('fails when the backup target is not a directory', async () => {
   writeFileSync(target, 'not a directory');
 
   const result = await prepare({
-    workspace: workspace.path,
+    workspace,
     target,
     logger: mockBaseLogger({ fn: vi.fn }),
   });
@@ -298,7 +340,7 @@ test('fails when the backup target goes away while staging', async () => {
   });
 
   const result = await prepare({
-    workspace: workspace.path,
+    workspace,
     target,
     logger: mockBaseLogger({ fn: vi.fn }),
   });
@@ -329,7 +371,7 @@ test('fails fast when the target disk space check fails for another reason', asy
 
   await expect(
     prepare({
-      workspace: workspace.path,
+      workspace,
       target,
       logger: mockBaseLogger({ fn: vi.fn }),
     })
@@ -351,7 +393,7 @@ test('fails with insufficient-workspace-storage when the workspace volume is too
   );
 
   const result = await prepare({
-    workspace: workspace.path,
+    workspace,
     target: makeTemporaryDirectory(),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
@@ -382,7 +424,7 @@ test('fails with insufficient-target-storage when the target volume is too full'
   const fileStore = vi.spyOn(Store, 'fileStore');
 
   const result = await prepare({
-    workspace: workspace.path,
+    workspace,
     target,
     logger: mockBaseLogger({ fn: vi.fn }),
   });
@@ -401,7 +443,7 @@ test('stages a database snapshot, election package, and ballot images', async ()
   const progressEvents: Array<{ type: string }> = [];
 
   const result = await prepare({
-    workspace: workspace.path,
+    workspace,
     target: makeTemporaryDirectory(),
     logger: mockBaseLogger({ fn: vi.fn }),
     onProgressEvent: (event) => progressEvents.push(event),
@@ -435,7 +477,7 @@ test('fails loudly when a referenced ballot image is missing from disk', async (
   unlinkSync(imagePath);
 
   const result = await prepare({
-    workspace: workspace.path,
+    workspace,
     target: makeTemporaryDirectory(),
     logger: mockBaseLogger({ fn: vi.fn }),
   });

--- a/apps/admin/backend/src/backup/create/prepare_step.ts
+++ b/apps/admin/backend/src/backup/create/prepare_step.ts
@@ -1,3 +1,5 @@
+import { Stats } from 'node:fs';
+import { stat } from 'node:fs/promises';
 import {
   assertDefined,
   err,
@@ -8,13 +10,10 @@ import {
   Result,
 } from '@votingworks/basics';
 import { getDiskSpaceSummaries } from '@votingworks/backend';
-import { Stats } from 'node:fs';
-import { stat } from 'node:fs/promises';
-import { openWorkspace } from '../../util/workspace.js';
+import { Id } from '@votingworks/types';
 import { Store } from '../../store.js';
 import { PrepareBackupOptions } from './types.js';
 import { BackupStagingArea } from '../staging_area.js';
-import { ElectionRecord } from '../../types.js';
 
 const DEFAULT_MIN_AVAILABLE_STORAGE_BYTES = 50_000_000; // 50 MB
 
@@ -49,6 +48,10 @@ export type PrepareError =
       message: string;
     }
   | {
+      type: 'write-in-progress';
+      message: string;
+    }
+  | {
       type: 'insufficient-workspace-storage';
       available: number;
       required: number;
@@ -62,6 +65,36 @@ export type PrepareError =
     };
 
 /**
+ * Reported when the database cannot be snapshotted because something else is
+ * partway through writing to it.
+ */
+const WRITE_IN_PROGRESS_ERROR: PrepareError = {
+  type: 'write-in-progress',
+  message: 'Cannot back up while another operation is writing to the database',
+};
+
+/**
+ * A backup staged on the local disk and ready to be copied, minus the manifest.
+ */
+export interface PreparedBackup {
+  /**
+   * The database ID of the election to be backed up.
+   */
+  electionId: Id;
+
+  /**
+   * Manages the location on disk where the database snapshot and other files to
+   * be copied were staged.
+   */
+  source: BackupStagingArea;
+
+  /**
+   * A store for the staged database snapshot, not the original workspace store.
+   */
+  snapshotStore: Store;
+}
+
+/**
  * Prepares the backup creation to take place by ensuring the source workspace
  * and target locations are known and able to fit the data to be copied. Stages
  * the data to be copied, including a database snapshot, returning a reference
@@ -69,33 +102,21 @@ export type PrepareError =
  */
 export async function prepare(
   options: PrepareBackupOptions
-): Promise<
-  Result<
-    { source: BackupStagingArea; store: Store; electionRecord: ElectionRecord },
-    PrepareError
-  >
-> {
+): Promise<Result<PreparedBackup, PrepareError>> {
+  const { logger, onProgressEvent, target, workspace } = options;
   const minAvailableStorageBytes =
     options.minAvailableStorageBytes ?? DEFAULT_MIN_AVAILABLE_STORAGE_BYTES;
-  options.onProgressEvent?.({ type: 'preparing' });
-
-  if (!(await statOrUndefined(options.workspace))) {
-    return err({
-      type: 'file-not-found',
-      path: options.workspace,
-      message: 'Workspace directory could not be found',
-    });
-  }
+  onProgressEvent?.({ type: 'preparing' });
 
   // Check the target up front: an unmounted backup drive is the likeliest
   // reason for a backup to fail, and snapshotting the database before noticing
   // would waste a full copy of it.
-  const targetStat = await statOrUndefined(options.target);
+  const targetStat = await statOrUndefined(target);
 
   if (!targetStat) {
     return err({
       type: 'file-not-found',
-      path: options.target,
+      path: target,
       message: 'Backup target directory could not be found',
     });
   }
@@ -103,17 +124,15 @@ export async function prepare(
   if (!targetStat.isDirectory()) {
     return err({
       type: 'not-directory',
-      path: options.target,
-      message: `${options.target} is not a directory`,
+      path: target,
+      message: `${target} is not a directory`,
     });
   }
 
   // Claim the staging area first. It reclaims what a killed run left behind,
   // so the free space measured below doesn't count a dead run's snapshot
   // against this one, and it holds the lock that makes reclaiming safe.
-  const stagingAreaResult = await BackupStagingArea.inWorkspace(
-    options.workspace
-  );
+  const stagingAreaResult = await BackupStagingArea.inWorkspace(workspace.path);
   if (stagingAreaResult.isErr()) {
     return err({
       type: 'backup-in-progress',
@@ -121,13 +140,14 @@ export async function prepare(
     });
   }
   const stagingArea = stagingAreaResult.ok();
+  // The workspace's own connection, so that writes made through it update the
+  // snapshot in place instead of restarting it.
+  const dbClient = workspace.store['client'];
   let snapshotStore: Store | undefined;
   let shouldPurgeStagingArea = true;
 
   try {
-    const [workspaceDiskSpace] = await getDiskSpaceSummaries([
-      options.workspace,
-    ]);
+    const [workspaceDiskSpace] = await getDiskSpaceSummaries([workspace.path]);
     const workspaceDiskAvailableBytes = workspaceDiskSpace.available * 1024;
 
     //
@@ -136,12 +156,8 @@ export async function prepare(
     // basis of the backup.
     //
 
-    using workspace = openWorkspace(options.workspace, options.logger);
     const currentElectionId = workspace.store.getCurrentElectionId();
-    const currentElectionRecord =
-      currentElectionId && workspace.store.getElection(currentElectionId);
-
-    if (!currentElectionRecord) {
+    if (!currentElectionId) {
       return err({
         type: 'unconfigured',
         message: 'An unconfigured VxAdmin cannot be backed up',
@@ -166,9 +182,20 @@ export async function prepare(
     const dbSnapshotPath = await stagingArea.prepareStagingPath(
       workspace.store.getDbPath()
     );
-    await workspace.store['client'].backup(dbSnapshotPath, {
+
+    // SQLite refuses to copy a page while a write transaction is open on the
+    // connection running the backup, and `better-sqlite3` reports that refusal
+    // as a backup that finished with nothing left to do, deleting the
+    // destination on its way out. Catch the case we can see coming — a CVR
+    // import holds its transaction open across awaits for the whole import —
+    // rather than letting it look like a successful snapshot.
+    if (dbClient.isInTransaction()) {
+      return err(WRITE_IN_PROGRESS_ERROR);
+    }
+
+    await dbClient.backup(dbSnapshotPath, {
       progress(info) {
-        options.onProgressEvent?.({
+        onProgressEvent?.({
           type: 'db_snapshot',
           progress: (info.totalPages - info.remainingPages) / info.totalPages,
         });
@@ -178,7 +205,13 @@ export async function prepare(
         return undefined as unknown as number;
       },
     });
-    options.onProgressEvent?.({ type: 'db_snapshot', progress: 1 });
+    if (!(await statOrUndefined(dbSnapshotPath))) {
+      // A write that began after the check above lands here: the backup
+      // resolved without copying anything and unlinked the snapshot.
+      return err(WRITE_IN_PROGRESS_ERROR);
+    }
+
+    onProgressEvent?.({ type: 'db_snapshot', progress: 1 });
     await stagingArea.markStagingPathReady(dbSnapshotPath);
 
     // Enumerate ballot images from the snapshot we just took, not the live
@@ -191,7 +224,7 @@ export async function prepare(
       dbSnapshotPath,
       workspace.store.getBallotImagesPath(),
       workspace.store.getElectionPackagesPath(),
-      options.logger
+      logger
     );
 
     const electionPackageSourcePath = assertDefined(
@@ -206,7 +239,7 @@ export async function prepare(
       snapshotBallotImagePaths.map(async (ballotImagePath) => {
         await stagingArea.linkWorkspaceFile(ballotImagePath);
         linkedCount += 1;
-        options.onProgressEvent?.({
+        onProgressEvent?.({
           type: 'staging_files',
           progress: linkedCount / snapshotBallotImagePaths.length,
         });
@@ -219,19 +252,19 @@ export async function prepare(
       .sum();
     let targetDiskAvailableBytes: number;
     try {
-      const [targetDiskSpace] = await getDiskSpaceSummaries([options.target]);
+      const [targetDiskSpace] = await getDiskSpaceSummaries([target]);
       targetDiskAvailableBytes = targetDiskSpace.available * 1024;
     } catch (error) {
       // `df` exits non-zero when its path is gone and rejects with that exit
       // code rather than an ENOENT, so ask the filesystem directly to tell a
       // drive removed mid-backup from a genuine failure.
-      if (await statOrUndefined(options.target)) {
+      if (await statOrUndefined(target)) {
         throw error;
       }
 
       return err({
         type: 'file-not-found',
-        path: options.target,
+        path: target,
         message: 'Backup target directory could not be found',
       });
     }
@@ -247,9 +280,9 @@ export async function prepare(
 
     shouldPurgeStagingArea = false;
     return ok({
+      electionId: currentElectionId,
       source: stagingArea,
-      store: snapshotStore,
-      electionRecord: currentElectionRecord,
+      snapshotStore,
     });
   } catch (error) {
     if (isNonExistentFileOrDirectoryError(error)) {

--- a/apps/admin/backend/src/backup/create/types.ts
+++ b/apps/admin/backend/src/backup/create/types.ts
@@ -1,8 +1,9 @@
 import { BaseLogger } from '@votingworks/logging';
+import { Id } from '@votingworks/types';
 import { BackupStagingArea } from '../staging_area.js';
 import { Store } from '../../store.js';
-import { ElectionRecord } from '../../types.js';
 import { BackupManifest } from '../backup_manifest.js';
+import { Workspace } from '../../util/workspace.js';
 
 /**
  * Basic options for all steps.
@@ -44,9 +45,12 @@ export type ProgressEvent =
  */
 export interface PrepareBackupOptions extends ProgressTracking {
   /**
-   * Directory path of the workspace to back up.
+   * The workspace to back up with an already-open client for the database.
+   * Using the same database as the running app means backups do not get
+   * restarted out from under us whenever a write occurs. If writes come in from
+   * other connections then the backup will be restarted.
    */
-  workspace: string;
+  workspace: Workspace;
 
   /**
    * Directory path of the root location containing all election backups.
@@ -69,6 +73,11 @@ export interface PrepareBackupOptions extends ProgressTracking {
  */
 export interface CopyBackupOptions extends ProgressTracking {
   /**
+   * The database ID of the election to be backed up.
+   */
+  electionId: Id;
+
+  /**
    * The already-prepared backup staging area to copy.
    */
   source: BackupStagingArea;
@@ -78,8 +87,6 @@ export interface CopyBackupOptions extends ProgressTracking {
    * database in a way that would produce an invalid backup.
    */
   store: Store;
-
-  electionRecord: ElectionRecord;
 
   /**
    * Directory path to place the backup. This may not be the final location.

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -18,6 +18,8 @@ import {
   Election,
   ElectionRegisteredVoterCounts,
   SystemSettings,
+  convertVxfElectionToCdfBallotDefinition,
+  safeParseElectionDefinition,
 } from '@votingworks/types';
 import { assert, assertDefined, find, typedAs } from '@votingworks/basics';
 import { join } from 'node:path';
@@ -187,6 +189,36 @@ test('reads election metadata without parsing the election definition', async ()
   expect(store.getElectionMetadata('nonexistent-id')).toEqual(undefined);
   expect(store.getElectionBasedSubfolderName('nonexistent-id')).toEqual(
     undefined
+  );
+});
+
+test('reads election metadata from a CDF election definition', async () => {
+  const { election: vxfElection } =
+    electionTwoPartyPrimaryFixtures.readElectionDefinition();
+  const cdfElectionDefinition = safeParseElectionDefinition(
+    JSON.stringify(convertVxfElectionToCdfBallotDefinition(vxfElection))
+  ).unsafeUnwrap();
+  const store = Store.memoryStore(makeTemporaryDirectory());
+  const electionId = await store.addElection({
+    electionData: cdfElectionDefinition.electionData,
+    systemSettingsData,
+    electionPackageSourceFilePath: makeTemporaryFile(),
+    electionPackageHash: 'test-election-package-hash',
+  });
+
+  // CDF has none of these fields where the fast path looks for them, so both
+  // methods have to fall back to parsing the election definition.
+  const { election } = cdfElectionDefinition;
+  expect(store.getElectionMetadata(electionId)).toEqual({
+    id: election.id,
+    title: election.title,
+    date: election.date,
+  });
+  expect(store.getElectionBasedSubfolderName(electionId)).toEqual(
+    generateElectionBasedSubfolderName(
+      election,
+      cdfElectionDefinition.ballotHash
+    )
   );
 });
 

--- a/apps/admin/backend/src/store.test.ts
+++ b/apps/admin/backend/src/store.test.ts
@@ -24,7 +24,10 @@ import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import { zipFile } from '@votingworks/test-utils';
 import { mockBaseLogger } from '@votingworks/logging';
-import { getGroupedBallotStyles } from '@votingworks/utils';
+import {
+  generateElectionBasedSubfolderName,
+  getGroupedBallotStyles,
+} from '@votingworks/utils';
 import {
   addMockCvrFileToStore,
   MockCastVoteRecordFile,
@@ -158,6 +161,33 @@ test('add an election', async () => {
 
   expect(store.getElection('nonexistent-id')).toEqual(undefined);
   expect(store.getElectionPackageFilePath('nonexistent-id')).toEqual(undefined);
+});
+
+test('reads election metadata without parsing the election definition', async () => {
+  const electionDefinition =
+    electionTwoPartyPrimaryFixtures.readElectionDefinition();
+  const store = Store.memoryStore(makeTemporaryDirectory());
+  const electionId = await store.addElection({
+    electionData: electionDefinition.electionData,
+    systemSettingsData,
+    electionPackageSourceFilePath: makeTemporaryFile(),
+    electionPackageHash: 'test-election-package-hash',
+  });
+
+  const { election } = electionDefinition;
+  expect(store.getElectionMetadata(electionId)).toEqual({
+    id: election.id,
+    title: election.title,
+    date: election.date,
+  });
+  expect(store.getElectionBasedSubfolderName(electionId)).toEqual(
+    generateElectionBasedSubfolderName(election, electionDefinition.ballotHash)
+  );
+
+  expect(store.getElectionMetadata('nonexistent-id')).toEqual(undefined);
+  expect(store.getElectionBasedSubfolderName('nonexistent-id')).toEqual(
+    undefined
+  );
 });
 
 test('addElection surfaces the copy error when the package source is missing', async () => {

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -47,6 +47,7 @@ import {
   BallotStyleGroup,
   getContests,
   SheetOf,
+  ElectionId,
   ElectionRegisteredVoterCounts,
   ElectionRegisteredVoterCountsSchema,
   UserRole,
@@ -57,11 +58,12 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { copyFile, mkdir, rm } from 'node:fs/promises';
 import { dirname, join, sep } from 'node:path';
 import { Buffer } from 'node:buffer';
-import { randomUUID as uuid } from 'node:crypto';
+import { createHash, randomUUID as uuid } from 'node:crypto';
 import {
   allContestOptions,
   asSqliteBool,
   fromSqliteBool,
+  generateElectionBasedSubfolderName,
   getBallotStyleGroup,
   getGroupedBallotStyles,
   getOfficialCandidateNameLookup,
@@ -116,6 +118,7 @@ import { deriveCvrContestTag } from './util/cast_vote_records.js';
 import { rootDebug } from './util/debug.js';
 import { getCurrentTime } from './get_current_time.js';
 import { STALE_MACHINE_THRESHOLD_MS } from './globals.js';
+import { type ElectionMetadata } from './backup/backup_manifest.js';
 
 const debug = rootDebug.extend('store');
 
@@ -308,6 +311,7 @@ export class Store implements BaseStore {
     electionPackageHash: string;
   }): Promise<Id> {
     const id = uuid();
+    const ballotHash = createHash('sha256').update(electionData).digest('hex');
 
     const electionPackageFilePath = constructElectionPackageFilePath(
       this.electionPackagesPath,
@@ -323,12 +327,14 @@ export class Store implements BaseStore {
           insert into elections (
             id,
             election_data,
+            ballot_hash,
             system_settings_data,
             election_package_hash
-          ) values (?, ?, ?, ?)
+          ) values (?, ?, ?, ?, ?)
           `,
           id,
           electionData,
+          ballotHash,
           systemSettingsData,
           electionPackageHash
         );
@@ -414,6 +420,63 @@ export class Store implements BaseStore {
       isOfficialResults: result.isOfficialResults === 1,
       electionPackageHash: result.electionPackageHash,
     };
+  }
+
+  /**
+   * Fetches the identifying election data a backup's manifest records.
+   */
+  getElectionMetadata(electionId: Id): ElectionMetadata | undefined {
+    const row = this.client.one(
+      `
+      select
+        election_data ->> '$.id' as id,
+        election_data ->> '$.title' as title,
+        election_data ->> '$.date' as date
+      from elections
+      where id = ?
+      `,
+      electionId
+    ) as { id: ElectionId; title: string; date: string } | undefined;
+
+    if (!row) {
+      return undefined;
+    }
+
+    return {
+      id: row.id,
+      title: row.title,
+      date: new DateWithoutTime(row.date),
+    };
+  }
+
+  /**
+   * Builds the name of the directory that holds this election's exports, e.g.
+   * backups. As with {@link getElectionMetadata}, this reads only the fields it
+   * needs rather than the whole election definition.
+   */
+  getElectionBasedSubfolderName(electionId: Id): string | undefined {
+    const row = this.client.one(
+      `
+      select
+        election_data ->> '$.title' as title,
+        election_data ->> '$.jurisdiction.name' as jurisdictionName,
+        ballot_hash as ballotHash
+      from elections
+      where id = ?
+      `,
+      electionId
+    ) as
+      | { title: string; jurisdictionName: string; ballotHash: string }
+      | undefined;
+
+    if (!row) {
+      return undefined;
+    }
+
+    return generateElectionBasedSubfolderName(
+      { title: row.title, jurisdiction: { name: row.jurisdictionName } },
+      row.ballotHash
+    );
   }
 
   getElectionPackageFilePath(electionId: string): string | undefined {

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -436,10 +436,26 @@ export class Store implements BaseStore {
       where id = ?
       `,
       electionId
-    ) as { id: ElectionId; title: string; date: string } | undefined;
+    ) as
+      | { id: ElectionId | null; title: string | null; date: string | null }
+      | undefined;
 
     if (!row) {
       return undefined;
+    }
+
+    // As in {@link getElectionKey}, a CDF election has none of these fields at
+    // the top level, so fall back to parsing it. CDF need not be fast.
+    if (!(row.id && row.title && row.date)) {
+      const { election } = assertDefined(
+        this.getElection(electionId)
+      ).electionDefinition;
+
+      return {
+        id: election.id,
+        title: election.title,
+        date: election.date,
+      };
     }
 
     return {
@@ -466,11 +482,23 @@ export class Store implements BaseStore {
       `,
       electionId
     ) as
-      | { title: string; jurisdictionName: string; ballotHash: string }
+      | {
+          title: string | null;
+          jurisdictionName: string | null;
+          ballotHash: string;
+        }
       | undefined;
 
     if (!row) {
       return undefined;
+    }
+
+    if (!(row.title && row.jurisdictionName)) {
+      const { election, ballotHash } = assertDefined(
+        this.getElection(electionId)
+      ).electionDefinition;
+
+      return generateElectionBasedSubfolderName(election, ballotHash);
     }
 
     return generateElectionBasedSubfolderName(

--- a/libs/db/src/client.test.ts
+++ b/libs/db/src/client.test.ts
@@ -324,6 +324,25 @@ test('read/write', () => {
   );
 });
 
+test('isInTransaction', () => {
+  const client = Client.memoryClient();
+  client.exec('create table muppets (name varchar(255) unique not null)');
+
+  expect(client.isInTransaction()).toEqual(false);
+
+  client.transaction(() => {
+    expect(client.isInTransaction()).toEqual(true);
+  });
+
+  expect(client.isInTransaction()).toEqual(false);
+
+  // Also true for a transaction begun by running `begin` directly.
+  client.run('begin transaction');
+  expect(client.isInTransaction()).toEqual(true);
+  client.run('rollback');
+  expect(client.isInTransaction()).toEqual(false);
+});
+
 test('transactions', async () => {
   const client = Client.memoryClient();
 

--- a/libs/db/src/client.ts
+++ b/libs/db/src/client.ts
@@ -289,6 +289,15 @@ export class Client {
   }
 
   /**
+   * Whether a transaction is currently open on this connection. True for a
+   * transaction started by {@link transaction} as well as one begun by running
+   * `begin` directly.
+   */
+  isInTransaction(): boolean {
+    return this.getDatabase().inTransaction;
+  }
+
+  /**
    * Run {@link fn} within a transaction and roll back the transaction if an
    * exception occurs.
    *

--- a/libs/utils/src/filenames.ts
+++ b/libs/utils/src/filenames.ts
@@ -43,7 +43,9 @@ export function sanitizeStringForFilename(
 }
 
 export function generateElectionBasedSubfolderName(
-  election: Election,
+  election: Pick<Election, 'title'> & {
+    jurisdiction: Pick<Election['jurisdiction'], 'name'>;
+  },
   ballotHash: string
 ): string {
   const jurisdictionCountyName = sanitizeStringForFilename(


### PR DESCRIPTION
## Overview

Refs #7897 

`prepare` opened a second connection to the workspace database to take the backup snapshot, so any write through the app's connection restarted the copy. The every-2s client heartbeat writes could cause a large enough database backup to restart indefinitely. We now pass the workspace and the database connection it references, causing SQLite to update in place instead of restarting.

Sharing the connection introduces one issue: SQLite won't copy pages while a write transaction is open on that same connection, and `better-sqlite3` reports the refusal as a finished backup, unlinking the destination. `prepare` now checks for an open transaction before starting and for a missing snapshot after, reporting `write-in-progress` either way rather than producing an empty backup.

I also stopped reading the entire election record/definition out of the database since it can be quite large. Uses SQLite's built-in support for reading fields out of the JSON values. In service of this I added an `elections.ballot_hash` column so `Store` can stop pulling the entire election data to compute it.

## Testing Plan

New automated tests. Verified some of the SQLite behavior manually.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.