### PR TITLE
Verify bubble ballot metadata encoding across languages

### DIFF
--- a/libs/ballot-interpreter/dts-header.d.ts
+++ b/libs/ballot-interpreter/dts-header.d.ts
@@ -2,6 +2,7 @@
 /* eslint-disable */
 import type {
   BridgeDecodeBmdResult,
+  BridgeDecodeBubbleBallotMetadataResult,
   BridgeInterpretResult,
   TimingMarks,
 } from './src/bubble-ballot-ts/types';

--- a/libs/ballot-interpreter/index.d.ts
+++ b/libs/ballot-interpreter/index.d.ts
@@ -2,6 +2,7 @@
 /* eslint-disable */
 import type {
   BridgeDecodeBmdResult,
+  BridgeDecodeBubbleBallotMetadataResult,
   BridgeInterpretResult,
   TimingMarks,
 } from './src/bubble-ballot-ts/types';
@@ -24,11 +25,18 @@ export interface BridgeInterpretOptions {
   retryStreakWidthThreshold: number;
 }
 /**
- * Decodes raw QR code bytes as a `CastVoteRecord` (VB\x01). Used for
+ * Decodes raw QR code bytes as a `CastVoteRecord` (VS\x01). Used for
  * cross-language testing to verify the Rust decoder matches the TypeScript
  * encoder.
  */
 export declare function decodeBmdBallotData(election: Election, data: Buffer): Promise<BridgeDecodeBmdResult>
+
+/**
+ * Decodes raw QR code bytes as bubble ballot page metadata (VB\x01). Used for
+ * cross-language testing to verify the Rust decoder matches the TypeScript
+ * encoder.
+ */
+export declare function decodeBubbleBallotMetadata(election: Election, data: Buffer, expectedBallotHash: string): Promise<BridgeDecodeBubbleBallotMetadataResult>
 
 /**
  * Encodes a `CastVoteRecord` to raw bytes using the Rust bitstream
@@ -36,6 +44,13 @@ export declare function decodeBmdBallotData(election: Election, data: Buffer): P
  * matches the TypeScript decoder.
  */
 export declare function encodeBmdBallotData(election: Election, record: BridgeDecodeBmdResult): Promise<Buffer>
+
+/**
+ * Encodes bubble ballot page metadata to raw bytes using the Rust bitstream
+ * encoder. Used for cross-language testing to verify the Rust encoder matches
+ * the TypeScript encoder byte for byte.
+ */
+export declare function encodeBubbleBallotMetadata(election: Election, metadata: BridgeDecodeBubbleBallotMetadataResult, version: 'v4.0' | 'v4.1'): Promise<Buffer>
 
 export declare function findTimingMarkGridFromImage(imageWidth: number, imageHeight: number, imageData: Buffer | Uint8ClampedArray, debugPath?: string): Promise<TimingMarks>
 

--- a/libs/ballot-interpreter/index.js
+++ b/libs/ballot-interpreter/index.js
@@ -577,7 +577,9 @@ if (!nativeBinding) {
 
 module.exports = nativeBinding
 module.exports.decodeBmdBallotData = nativeBinding.decodeBmdBallotData
+module.exports.decodeBubbleBallotMetadata = nativeBinding.decodeBubbleBallotMetadata
 module.exports.encodeBmdBallotData = nativeBinding.encodeBmdBallotData
+module.exports.encodeBubbleBallotMetadata = nativeBinding.encodeBubbleBallotMetadata
 module.exports.findTimingMarkGridFromImage = nativeBinding.findTimingMarkGridFromImage
 module.exports.findTimingMarkGridFromPath = nativeBinding.findTimingMarkGridFromPath
 module.exports.interpretImages = nativeBinding.interpretImages

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/js/mod.rs
@@ -11,7 +11,9 @@ use napi_derive::napi;
 use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 use types_rs::bmd::cvr::CastVoteRecord;
-use types_rs::bubble_ballot::{PARTIAL_BALLOT_HASH_BYTE_LENGTH, PartialBallotHash};
+use types_rs::bubble_ballot::{
+    Metadata, PARTIAL_BALLOT_HASH_BYTE_LENGTH, PartialBallotHash, SoftwareVersion,
+};
 use types_rs::coding;
 use types_rs::election::Election;
 
@@ -414,7 +416,7 @@ pub async fn run_blank_paper_diagnostic_from_image(
     ))
 }
 
-/// Decodes raw QR code bytes as a `CastVoteRecord` (VB\x01). Used for
+/// Decodes raw QR code bytes as a `CastVoteRecord` (VS\x01). Used for
 /// cross-language testing to verify the Rust decoder matches the TypeScript
 /// encoder.
 // unused_async: napi-rs requires `async fn` to return a Promise in JS.
@@ -452,6 +454,53 @@ pub async fn encode_bmd_ballot_data(
     let record: CastVoteRecord = from_json(record)?;
 
     let bytes = coding::encode_with(&record, &election)
+        .map_err(|e| napi::Error::from_reason(format!("encoding failed: {e}")))?;
+
+    Ok(Buffer::from(bytes))
+}
+
+/// Decodes raw QR code bytes as bubble ballot page metadata (VB\x01). Used for
+/// cross-language testing to verify the Rust decoder matches the TypeScript
+/// encoder.
+// unused_async: napi-rs requires `async fn` to return a Promise in JS.
+#[allow(clippy::unused_async)]
+#[napi(
+    ts_args_type = "election: Election, data: Buffer, expectedBallotHash: string",
+    ts_return_type = "Promise<BridgeDecodeBubbleBallotMetadataResult>"
+)]
+pub async fn decode_bubble_ballot_metadata(
+    election: serde_json::Value,
+    data: Buffer,
+    expected_ballot_hash: String,
+) -> napi::Result<serde_json::Value> {
+    let election: types_rs::election::Election = from_json(election)?;
+    let expected_ballot_hash = decode_partial_ballot_hash(&expected_ballot_hash)?;
+    let bytes = data.to_vec();
+
+    let metadata = coding::decode_with::<Metadata>(&bytes, &(&election, expected_ballot_hash))
+        .map_err(|e| napi::Error::from_reason(format!("decoding failed: {e}")))?;
+    to_json(&metadata)
+}
+
+/// Encodes bubble ballot page metadata to raw bytes using the Rust bitstream
+/// encoder. Used for cross-language testing to verify the Rust encoder matches
+/// the TypeScript encoder byte for byte.
+// unused_async: napi-rs requires `async fn` to return a Promise in JS.
+#[allow(clippy::unused_async)]
+#[napi(
+    ts_args_type = "election: Election, metadata: BridgeDecodeBubbleBallotMetadataResult, version: 'v4.0' | 'v4.1'",
+    ts_return_type = "Promise<Buffer>"
+)]
+pub async fn encode_bubble_ballot_metadata(
+    election: serde_json::Value,
+    metadata: serde_json::Value,
+    version: String,
+) -> napi::Result<Buffer> {
+    let election: types_rs::election::Election = from_json(election)?;
+    let metadata: Metadata = from_json(metadata)?;
+    let version: SoftwareVersion = from_json(serde_json::Value::String(version))?;
+
+    let bytes = coding::encode_with(&metadata, &(&election, version))
         .map_err(|e| napi::Error::from_reason(format!("encoding failed: {e}")))?;
 
     Ok(Buffer::from(bytes))

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/types.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/types.ts
@@ -421,7 +421,7 @@ export type RustContestVote =
   | { type: 'straightParty'; value: string[] };
 
 /**
- * Rust-decoded CastVoteRecord (VB\x01 prelude).
+ * Rust-decoded CastVoteRecord (VS\x01 prelude).
  */
 export interface RustCastVoteRecord {
   ballotHash: number[];
@@ -440,3 +440,22 @@ export interface RustCastVoteRecord {
  * Result of decoding raw BMD ballot bytes via the Rust decoder.
  */
 export type BridgeDecodeBmdResult = RustCastVoteRecord;
+
+/**
+ * Rust-decoded bubble ballot page metadata (VB\x01 prelude). The ballot hash
+ * is the partial hash as a hex string, not the full election ballot hash.
+ */
+export interface RustBubbleBallotMetadata {
+  ballotHash: string;
+  precinctId: string;
+  ballotStyleId: string;
+  pageNumber: number;
+  isTestMode: boolean;
+  ballotType: string;
+  ballotAuditId?: string;
+}
+
+/**
+ * Result of decoding raw bubble ballot metadata bytes via the Rust decoder.
+ */
+export type BridgeDecodeBubbleBallotMetadataResult = RustBubbleBallotMetadata;

--- a/libs/ballot-interpreter/src/cross_language_bubble.test.ts
+++ b/libs/ballot-interpreter/src/cross_language_bubble.test.ts
@@ -1,0 +1,147 @@
+import { expect, test } from 'vitest';
+import fc from 'fast-check';
+import { Buffer } from 'node:buffer';
+import { BallotType, Election } from '@votingworks/types';
+import {
+  encodeHmpbBallotPageMetadata,
+  sliceBallotHashForEncoding,
+} from '@votingworks/ballot-encoder';
+import {
+  arbitraryBallotId,
+  arbitraryElectionDefinition,
+} from '@votingworks/test-utils';
+import { napi } from './bubble-ballot-ts/napi';
+
+const FC_PARAMS: fc.Parameters<unknown> = { numRuns: 100 };
+
+const BALLOT_TYPES = [
+  BallotType.Precinct,
+  BallotType.Absentee,
+  BallotType.Provisional,
+] as const;
+
+/**
+ * Picks a ballot style and a precinct it applies to, or `undefined` if the
+ * generated election has neither.
+ */
+function pickConfig(election: Election) {
+  const ballotStyle = election.ballotStyles[0];
+  if (!ballotStyle) return undefined;
+  const precinct = election.precincts.find((p) =>
+    ballotStyle.precincts.includes(p.id)
+  );
+  if (!precinct) return undefined;
+  return { ballotStyle, precinct };
+}
+
+test('bubble ballot metadata: TS encode matches Rust decode', async () => {
+  await fc.assert(
+    fc.asyncProperty(
+      arbitraryElectionDefinition(),
+      fc.boolean(),
+      fc.constantFrom(...BALLOT_TYPES),
+      fc.integer({ min: 1, max: 30 }),
+      fc.option(arbitraryBallotId(), { nil: undefined }),
+      async (
+        { election, ballotHash },
+        isTestMode,
+        ballotType,
+        pageNumber,
+        ballotAuditId
+      ) => {
+        const config = pickConfig(election);
+        if (!config) return;
+        const { ballotStyle, precinct } = config;
+
+        const encoded = encodeHmpbBallotPageMetadata(
+          election,
+          {
+            ballotHash,
+            ballotStyleId: ballotStyle.id,
+            precinctId: precinct.id,
+            isTestMode,
+            ballotType,
+            pageNumber,
+            ballotAuditId,
+          },
+          'v4.1'
+        );
+
+        const decoded = await napi.decodeBubbleBallotMetadata(
+          election,
+          Buffer.from(encoded),
+          ballotHash
+        );
+
+        expect(decoded.ballotHash).toEqual(
+          sliceBallotHashForEncoding(ballotHash)
+        );
+        expect(decoded.ballotStyleId).toEqual(ballotStyle.id);
+        expect(decoded.precinctId).toEqual(precinct.id);
+        expect(decoded.isTestMode).toEqual(isTestMode);
+        expect(decoded.pageNumber).toEqual(pageNumber);
+        expect(decoded.ballotType).toEqual(ballotType);
+        expect(decoded.ballotAuditId).toEqual(ballotAuditId);
+      }
+    ),
+    FC_PARAMS
+  );
+});
+
+test('bubble ballot metadata: Rust encode is byte-identical to TS encode', async () => {
+  await fc.assert(
+    fc.asyncProperty(
+      arbitraryElectionDefinition(),
+      fc.boolean(),
+      fc.constantFrom(...BALLOT_TYPES),
+      fc.integer({ min: 1, max: 30 }),
+      fc.option(arbitraryBallotId(), { nil: undefined }),
+      fc.constantFrom('v4.0' as const, 'v4.1' as const),
+      async (
+        { election, ballotHash },
+        isTestMode,
+        ballotType,
+        pageNumber,
+        ballotAuditId,
+        version
+      ) => {
+        const config = pickConfig(election);
+        if (!config) return;
+        const { ballotStyle, precinct } = config;
+
+        const fromTypeScript = encodeHmpbBallotPageMetadata(
+          election,
+          {
+            ballotHash,
+            ballotStyleId: ballotStyle.id,
+            precinctId: precinct.id,
+            isTestMode,
+            ballotType,
+            pageNumber,
+            ballotAuditId,
+          },
+          version
+        );
+
+        const fromRust = await napi.encodeBubbleBallotMetadata(
+          election,
+          {
+            ballotHash: sliceBallotHashForEncoding(ballotHash),
+            ballotStyleId: ballotStyle.id,
+            precinctId: precinct.id,
+            isTestMode,
+            ballotType,
+            pageNumber,
+            ballotAuditId,
+          },
+          version
+        );
+
+        expect(Buffer.from(fromRust).toString('hex')).toEqual(
+          Buffer.from(fromTypeScript).toString('hex')
+        );
+      }
+    ),
+    FC_PARAMS
+  );
+});


### PR DESCRIPTION
## Overview

`<🤖>`
Summary ballots have had a TypeScript/Rust equivalence test since #7259 landed the Rust encoder. Bubble ballot metadata, which is on every scanned ballot rather than the few summary ballots we scan, has had none — so the two implementations of that format have been free to drift.

Adds `decodeBubbleBallotMetadata` and `encodeBubbleBallotMetadata` to the napi bridge, mirroring the BMD pair already there, and a fast-check property test in both directions: Rust decodes what TypeScript writes, and Rust writes byte-identical output for both v4.0 and v4.1.

Verified the properties aren't vacuous — all 100 runs of each execute the body, none skipped — and that widening the v4.0 ballot style index back to 16 bits makes the byte-identity test fail.

Also corrects two doc comments that described the summary ballot `CastVoteRecord` as having the `VB\x01` prelude; it's `VS\x01`.
`</🤖>`

## Demo Video or Screenshot
n/a

## Testing Plan
New cross-language tests.
