### PR TITLE
Migrate all Cargo workspaces to the 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
   "apps/mark-scan/accessible-controller",
   "apps/mark-scan/daemon-utils",

--- a/apps/mark-scan/accessible-controller/Cargo.toml
+++ b/apps/mark-scan/accessible-controller/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controllerd"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "controllerd"

--- a/apps/mark-scan/accessible-controller/src/controllerd.rs
+++ b/apps/mark-scan/accessible-controller/src/controllerd.rs
@@ -13,18 +13,18 @@ use std::{
     path::PathBuf,
     process::exit,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
     thread::sleep,
     time::Duration,
 };
 use uinput::event::keyboard;
-use vx_logging::{log, set_source, Disposition, EventId, EventType, Source};
+use vx_logging::{Disposition, EventId, EventType, Source, log, set_source};
 
 use crate::{
     commands::handle_command,
-    device::{create_keyboard, VirtualKeyboard},
+    device::{VirtualKeyboard, create_keyboard},
     port::Port,
 };
 

--- a/apps/mark-scan/accessible-controller/src/device.rs
+++ b/apps/mark-scan/accessible-controller/src/device.rs
@@ -1,8 +1,8 @@
 use std::{thread, time::Duration};
 
 use uinput::{
-    event::{keyboard, Keyboard},
     Device,
+    event::{Keyboard, keyboard},
 };
 
 const UINPUT_PATH: &str = "/dev/uinput";
@@ -56,7 +56,7 @@ impl VirtualKeyboard for Device {
     }
 }
 
-pub fn create_keyboard(name: &str) -> color_eyre::Result<impl VirtualKeyboard> {
+pub fn create_keyboard(name: &str) -> color_eyre::Result<impl VirtualKeyboard + use<>> {
     let keyboard = uinput::open(UINPUT_PATH)?
         .name(name)?
         .event(Keyboard::All)?

--- a/apps/mark-scan/accessible-controller/src/port.rs
+++ b/apps/mark-scan/accessible-controller/src/port.rs
@@ -3,8 +3,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-use serialport::{available_ports, SerialPort, SerialPortType};
-use vx_logging::{log, Disposition, EventId, EventType};
+use serialport::{SerialPort, SerialPortType, available_ports};
+use vx_logging::{Disposition, EventId, EventType, log};
 
 use crate::commands::EchoCommand;
 

--- a/apps/mark-scan/daemon-utils/Cargo.toml
+++ b/apps/mark-scan/daemon-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "daemon-utils"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 path = "src/lib.rs"

--- a/apps/mark-scan/daemon-utils/src/lib.rs
+++ b/apps/mark-scan/daemon-utils/src/lib.rs
@@ -4,13 +4,13 @@ use std::{
     path::Path,
     process,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
     thread::sleep,
     time::{Duration, Instant},
 };
-use vx_logging::{log, EventId, EventType};
+use vx_logging::{EventId, EventType, log};
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 const NOOP_LOOP_INTERVAL: Duration = Duration::from_secs(1);

--- a/apps/mark-scan/fai-100-controller/Cargo.toml
+++ b/apps/mark-scan/fai-100-controller/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fai100-controllerd"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "fai100-controllerd"

--- a/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
+++ b/apps/mark-scan/fai-100-controller/src/fai_100_controllerd.rs
@@ -8,8 +8,8 @@
 
 use clap::Parser;
 use commands::{
-    ButtonSignal, CommandError, NotificationStatusResponse, SipAndPuffDeviceStatus,
-    SipAndPuffSignalStatus, VersionResponse, RESPONSE_BYTE_LENGTH,
+    ButtonSignal, CommandError, NotificationStatusResponse, RESPONSE_BYTE_LENGTH,
+    SipAndPuffDeviceStatus, SipAndPuffSignalStatus, VersionResponse,
 };
 use daemon_utils::{run_no_op_event_loop, write_pid_file};
 use std::{
@@ -18,16 +18,16 @@ use std::{
     path::{Path, PathBuf},
     process::exit,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
     thread::sleep,
     time::{Duration, Instant},
 };
 use uinput::event::keyboard;
 use usb_device::UsbDevice;
-use virtual_keyboard::{create_keyboard, VirtualKeyboard};
-use vx_logging::{log, set_source, Disposition, EventId, EventType, Source};
+use virtual_keyboard::{VirtualKeyboard, create_keyboard};
+use vx_logging::{Disposition, EventId, EventType, Source, log, set_source};
 
 mod commands;
 mod usb_device;

--- a/apps/mark-scan/fai-100-controller/src/usb_device.rs
+++ b/apps/mark-scan/fai-100-controller/src/usb_device.rs
@@ -1,6 +1,6 @@
 use std::{io, time::Duration};
 
-use color_eyre::eyre::{bail, eyre, ErrReport, Result};
+use color_eyre::eyre::{ErrReport, Result, bail, eyre};
 use rusb::{Context, DeviceHandle, UsbContext};
 
 const INTERFACE_NUMBER: u8 = 0x00;

--- a/apps/mark-scan/fai-100-controller/src/virtual_keyboard.rs
+++ b/apps/mark-scan/fai-100-controller/src/virtual_keyboard.rs
@@ -1,8 +1,8 @@
 use std::{thread, time::Duration};
 
 use uinput::{
-    event::{keyboard, Keyboard},
     Device,
+    event::{Keyboard, keyboard},
 };
 
 const UINPUT_PATH: &str = "/dev/uinput";
@@ -33,7 +33,7 @@ impl VirtualKeyboard for Device {
     }
 }
 
-pub fn create_keyboard(name: &str) -> color_eyre::Result<impl VirtualKeyboard> {
+pub fn create_keyboard(name: &str) -> color_eyre::Result<impl VirtualKeyboard + use<>> {
     let keyboard = uinput::open(UINPUT_PATH)?
         .name(name)?
         .event(Keyboard::All)?

--- a/apps/mark-scan/pat-device-input/Cargo.toml
+++ b/apps/mark-scan/pat-device-input/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "patinputd"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "patinputd"

--- a/apps/mark-scan/pat-device-input/src/pat_input_reader.rs
+++ b/apps/mark-scan/pat-device-input/src/pat_input_reader.rs
@@ -1,5 +1,5 @@
 use std::io;
-use vx_logging::{log, EventId};
+use vx_logging::{EventId, log};
 
 use crate::pin::Pin;
 

--- a/apps/mark-scan/pat-device-input/src/patinputd.rs
+++ b/apps/mark-scan/pat-device-input/src/patinputd.rs
@@ -13,18 +13,18 @@ use pat_input_reader::PatInputReader;
 use std::{
     process::exit,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
     thread,
     time::Duration,
 };
 use uinput::{
-    event::{keyboard, Keyboard},
     Device,
+    event::{Keyboard, keyboard},
 };
 
-use vx_logging::{log, set_source, Disposition, EventId, EventType, Source};
+use vx_logging::{Disposition, EventId, EventType, Source, log, set_source};
 
 use crate::pin::GpioPin;
 
@@ -106,9 +106,9 @@ fn main() {
             let mut signal_b = reader.is_signal_b_active();
 
             log!(
-        EventId::ConnectToPatInputInit,
-        "Connected to PAT with initial values [is_connected={is_connected}], [signal_a={signal_a}], [signal_b={signal_b}]"
-    );
+                EventId::ConnectToPatInputInit,
+                "Connected to PAT with initial values [is_connected={is_connected}], [signal_a={signal_a}], [signal_b={signal_b}]"
+            );
 
             loop {
                 if !running.load(Ordering::SeqCst) {
@@ -120,23 +120,25 @@ fn main() {
                 let new_signal_a = reader.is_signal_a_active();
                 let new_signal_b = reader.is_signal_b_active();
 
-                if new_signal_a && !signal_a {
-                    if let Err(err) = send_key(&mut device, keyboard::Key::_1) {
-                        log!(
-                            event_id: EventId::PatDeviceError,
-                            message:  format!("Error sending 1 keypress event: {err}"),
-                            disposition: Disposition::Failure
-                        );
-                    }
+                if new_signal_a
+                    && !signal_a
+                    && let Err(err) = send_key(&mut device, keyboard::Key::_1)
+                {
+                    log!(
+                        event_id: EventId::PatDeviceError,
+                        message: format!("Error sending 1 keypress event: {err}"),
+                        disposition: Disposition::Failure
+                    );
                 }
-                if new_signal_b && !signal_b {
-                    if let Err(err) = send_key(&mut device, keyboard::Key::_2) {
-                        log!(
-                            event_id: EventId::PatDeviceError,
-                            message: format!("Error sending 2 keypress event: {err}"),
-                            disposition: Disposition::Failure
-                        );
-                    }
+                if new_signal_b
+                    && !signal_b
+                    && let Err(err) = send_key(&mut device, keyboard::Key::_2)
+                {
+                    log!(
+                        event_id: EventId::PatDeviceError,
+                        message: format!("Error sending 2 keypress event: {err}"),
+                        disposition: Disposition::Failure
+                    );
                 }
 
                 signal_a = new_signal_a;

--- a/apps/mark-scan/pat-device-input/src/pin.rs
+++ b/apps/mark-scan/pat-device-input/src/pin.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use vx_logging::{log, Disposition, EventId};
+use vx_logging::{Disposition, EventId, log};
 
 const EXPORT_PIN_FILEPATH: &str = "/sys/class/gpio/export";
 const UNEXPORT_PIN_FILEPATH: &str = "/sys/class/gpio/unexport";

--- a/apps/pollbook/barcode-scanner-daemon/Cargo.toml
+++ b/apps/pollbook/barcode-scanner-daemon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "barcode-scanner-daemon"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license.workspace = true
 
 [[bin]]

--- a/apps/pollbook/barcode-scanner-daemon/src/cino_s680_daemon.rs
+++ b/apps/pollbook/barcode-scanner-daemon/src/cino_s680_daemon.rs
@@ -10,9 +10,9 @@ use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::Mutex;
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 use tokio_serial::{DataBits, FlowControl, Parity, SerialPortBuilderExt, SerialStream, StopBits};
-use vx_logging::{log, set_source, Disposition, EventId, EventType, Source};
+use vx_logging::{Disposition, EventId, EventType, Source, log, set_source};
 
 use crate::parse_aamva::{AamvaParseError, ELEMENT_ID_SIZE};
 

--- a/apps/pollbook/barcode-scanner-daemon/src/fsc_protocol.rs
+++ b/apps/pollbook/barcode-scanner-daemon/src/fsc_protocol.rs
@@ -1,6 +1,6 @@
 use std::io::Error;
 use tokio::io::AsyncWriteExt;
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 use tokio_serial::SerialStream;
 
 /// `FuzzyScan` Serial Command packet delimiter (prefix and suffix)

--- a/libs/ballot-interpreter/Cargo.toml
+++ b/libs/ballot-interpreter/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 license = "GPL-3.0-only"
@@ -17,7 +17,7 @@ unwrap_used = "deny"
 [package]
 name = "ballot-interpreter"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/libs/ballot-interpreter/benches/main.rs
+++ b/libs/ballot-interpreter/benches/main.rs
@@ -3,10 +3,10 @@
 use std::{fmt::Display, path::PathBuf};
 
 use ballot_interpreter::interpret::{
-    ScanInterpreter, VerticalStreakDetection, WriteInScoring, DEFAULT_MAX_CUMULATIVE_STREAK_WIDTH,
-    DEFAULT_RETRY_STREAK_WIDTH_THRESHOLD,
+    DEFAULT_MAX_CUMULATIVE_STREAK_WIDTH, DEFAULT_RETRY_STREAK_WIDTH_THRESHOLD, ScanInterpreter,
+    VerticalStreakDetection, WriteInScoring,
 };
-use divan::{black_box, Bencher};
+use divan::{Bencher, black_box};
 use image::GrayImage;
 use sha2::{Digest, Sha256};
 use types_rs::{bubble_ballot::PartialBallotHash, election::Election};

--- a/libs/ballot-interpreter/bin/debug-timing-marks.rs
+++ b/libs/ballot-interpreter/bin/debug-timing-marks.rs
@@ -115,13 +115,15 @@ fn process_path<W: Write>(
             Some(detected_scale) => {
                 if detected_scale < minimum_detected_scale {
                     bail!(
-                    "Detected scale is too low: {detected_scale} is less than {minimum_detected_scale}",
-                    detected_scale = detected_scale.0
-                );
+                        "Detected scale is too low: {detected_scale} is less than {minimum_detected_scale}",
+                        detected_scale = detected_scale.0
+                    );
                 }
             }
             None => {
-                bail!("Unable to detect scale of the printed ballot; cannot compare against minimum ({minimum_detected_scale})");
+                bail!(
+                    "Unable to detect scale of the printed ballot; cannot compare against minimum ({minimum_detected_scale})"
+                );
             }
         }
     }

--- a/libs/ballot-interpreter/bin/interpret.rs
+++ b/libs/ballot-interpreter/bin/interpret.rs
@@ -8,8 +8,8 @@ use std::{
 use ballot_interpreter::{
     debug::ImageDebugWriter,
     interpret::{
-        ScanInterpreter, VerticalStreakDetection, WriteInScoring,
-        DEFAULT_MAX_CUMULATIVE_STREAK_WIDTH, DEFAULT_RETRY_STREAK_WIDTH_THRESHOLD,
+        DEFAULT_MAX_CUMULATIVE_STREAK_WIDTH, DEFAULT_RETRY_STREAK_WIDTH_THRESHOLD, ScanInterpreter,
+        VerticalStreakDetection, WriteInScoring,
     },
     qr_code,
     scoring::UnitIntervalScore,

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/ballot_card.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/ballot_card.rs
@@ -4,21 +4,21 @@ use crate::{
     image_utils::{crop_to_image, otsu_level, threshold},
     qr_code::SearchStrategy,
 };
-use image::{imageops::rotate180_in_place, GrayImage};
+use image::{GrayImage, imageops::rotate180_in_place};
 use itertools::Itertools;
 use serde::Serialize;
 
 use crate::{
     debug::ImageDebugWriter,
     image_utils::{
-        bleed, detect_vertical_streaks, find_scanned_document_inset, Inset, VerticalStreak, BLACK,
+        BLACK, Inset, VerticalStreak, bleed, detect_vertical_streaks, find_scanned_document_inset,
     },
     interpret::{BallotPageAndGeometry, Error, Result},
-    layout::{build_interpreted_page_layout, InterpretedContestLayout},
+    layout::{InterpretedContestLayout, build_interpreted_page_layout},
     qr_code,
     scoring::{
-        score_bubble_marks_from_grid_layout, score_write_in_areas, ScoredBubbleMarks,
-        ScoredPositionAreas, UnitIntervalScore,
+        ScoredBubbleMarks, ScoredPositionAreas, UnitIntervalScore,
+        score_bubble_marks_from_grid_layout, score_write_in_areas,
     },
     timing_marks,
 };
@@ -481,13 +481,13 @@ impl BallotCard {
         self.as_pair()
             .zip(timing_marks)
             .map(|(ballot_page, timing_marks)| {
-                if let Some(scale) = timing_marks.compute_scale() {
-                    if scale < minimum_scale {
-                        return Err(Error::InvalidScale {
-                            label: ballot_page.label().to_owned(),
-                            scale,
-                        });
-                    }
+                if let Some(scale) = timing_marks.compute_scale()
+                    && scale < minimum_scale
+                {
+                    return Err(Error::InvalidScale {
+                        label: ballot_page.label().to_owned(),
+                        scale,
+                    });
                 }
 
                 Ok(())

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/debug.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/debug.rs
@@ -8,7 +8,7 @@ use crate::draw_utils::{
     draw_text_mut, text_size,
 };
 use ab_glyph::{FontRef, PxScale};
-use image::{imageops::rotate180, DynamicImage, GrayImage, Rgb, RgbImage};
+use image::{DynamicImage, GrayImage, Rgb, RgbImage, imageops::rotate180};
 use log::debug;
 use types_rs::election::GridPosition;
 use types_rs::geometry::{
@@ -17,7 +17,7 @@ use types_rs::geometry::{
 
 use crate::ballot_card::{BallotImage, Geometry};
 
-use crate::image_utils::{dark_rainbow, rainbow, VerticalStreak};
+use crate::image_utils::{VerticalStreak, dark_rainbow, rainbow};
 use crate::layout::InterpretedContestLayout;
 use crate::scoring::{BubbleRegion, UnitIntervalScore};
 use crate::timing_marks::scoring::CandidateTimingMark;
@@ -128,7 +128,8 @@ pub fn draw_vertical_streaks_debug_image_mut(
         draw_cross_mut(canvas, color, x_start, y);
         draw_text_with_background_mut(
             canvas,
-            &format!("x={x_start}..={x_end}, Black: {percent_black_pixels:?}, Gap: {longest_white_gap_length:?}",
+            &format!(
+                "x={x_start}..={x_end}, Black: {percent_black_pixels:?}, Gap: {longest_white_gap_length:?}",
                 percent_black_pixels = vertical_streak.scores,
                 longest_white_gap_length = vertical_streak.longest_white_gaps
             ),
@@ -538,7 +539,8 @@ pub fn draw_scored_bubble_marks_debug_image_mut(
         draw_cross_mut(canvas, color, x_start, y);
         draw_text_with_background_mut(
             canvas,
-            &format!("x={x_start}..={x_end}, Black: {percent_black_pixels:?}, Gap: {longest_white_gap_length:?}",
+            &format!(
+                "x={x_start}..={x_end}, Black: {percent_black_pixels:?}, Gap: {longest_white_gap_length:?}",
                 percent_black_pixels = vertical_streak.scores,
                 longest_white_gap_length = vertical_streak.longest_white_gaps
             ),

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/diagnostic.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/diagnostic.rs
@@ -5,9 +5,9 @@ use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use types_rs::geometry::Rect;
 
 use crate::{
-    ballot_card::{ballot_scan_bubble_image, BallotImage},
+    ballot_card::{BallotImage, ballot_scan_bubble_image},
     debug::draw_diagnostic_cells,
-    image_utils::{count_pixels, threshold, BLACK},
+    image_utils::{BLACK, count_pixels, threshold},
 };
 
 const FAIL_SCORE: f32 = 0.05;

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/draw_utils.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/draw_utils.rs
@@ -2,7 +2,7 @@
 //! previously used. All functions operate directly on `RgbImage` with our own
 //! `Rect` type so no external drawing crate is required.
 
-use ab_glyph::{point, Font, GlyphId, OutlinedGlyph, PxScale, Rect as GlyphRect, ScaleFont};
+use ab_glyph::{Font, GlyphId, OutlinedGlyph, PxScale, Rect as GlyphRect, ScaleFont, point};
 use image::{Rgb, RgbImage};
 use types_rs::geometry::Rect;
 

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/interpret.rs
@@ -14,15 +14,15 @@ use types_rs::geometry::PixelPosition;
 use types_rs::geometry::{PixelUnit, Size, SubGridUnit};
 use types_rs::pair::Pair;
 
-use crate::ballot_card::ballot_scan_bubble_image;
 use crate::ballot_card::BallotCard;
 use crate::ballot_card::BallotPage;
 use crate::ballot_card::Geometry;
 use crate::ballot_card::Orientation;
 use crate::ballot_card::PaperInfo;
+use crate::ballot_card::ballot_scan_bubble_image;
 use crate::debug::draw_timing_mark_debug_image_mut;
-use crate::image_utils::binarize_and_encode_png;
 use crate::image_utils::Inset;
+use crate::image_utils::binarize_and_encode_png;
 use crate::layout::InterpretedContestLayout;
 use crate::scoring::ScoredBubbleMarks;
 use crate::scoring::ScoredPositionAreas;
@@ -571,7 +571,7 @@ pub fn ballot_card(
 mod test {
     use std::path::{Path, PathBuf};
 
-    use image::{imageops::FilterType, DynamicImage, GenericImage, Luma, Rgb};
+    use image::{DynamicImage, GenericImage, Luma, Rgb, imageops::FilterType};
     use itertools::Itertools;
     use sha2::{Digest, Sha256};
     use types_rs::{
@@ -583,7 +583,7 @@ mod test {
 
     use crate::{
         ballot_card::ballot_scan_bubble_image,
-        debug::{monospace_font, ImageDebugWriter},
+        debug::{ImageDebugWriter, monospace_font},
         draw_utils::draw_text_mut,
         qr_code,
         scoring::{self, UnitIntervalScore},
@@ -1087,10 +1087,10 @@ mod test {
             .marks
             .iter()
             .filter_map(|(grid_position, scored_bubble)| {
-                if let Some(scored_bubble) = scored_bubble {
-                    if scored_bubble.fill_score > UnitIntervalScore(0.1) {
-                        return Some(grid_position);
-                    }
+                if let Some(scored_bubble) = scored_bubble
+                    && scored_bubble.fill_score > UnitIntervalScore(0.1)
+                {
+                    return Some(grid_position);
                 }
                 None
             })
@@ -1566,7 +1566,10 @@ mod test {
             panic!("Unexpected error variant: {error:?}");
         };
 
-        assert!((detected_scale.0 - artificial_scale).abs() < 0.01, "Detected scale was not close to artificial scale: detected={detected_scale}, artificial={artificial_scale}");
+        assert!(
+            (detected_scale.0 - artificial_scale).abs() < 0.01,
+            "Detected scale was not close to artificial scale: detected={detected_scale}, artificial={artificial_scale}"
+        );
     }
 
     /// Tests that when timing marks cannot be found and streaks are detected

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/js/mod.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/js/mod.rs
@@ -11,14 +11,14 @@ use napi_derive::napi;
 use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 use types_rs::bmd::cvr::CastVoteRecord;
-use types_rs::bubble_ballot::{PartialBallotHash, PARTIAL_BALLOT_HASH_BYTE_LENGTH};
+use types_rs::bubble_ballot::{PARTIAL_BALLOT_HASH_BYTE_LENGTH, PartialBallotHash};
 use types_rs::coding;
 use types_rs::election::Election;
 
-use crate::ballot_card::{ballot_scan_bubble_image, BallotPage, PaperInfo};
+use crate::ballot_card::{BallotPage, PaperInfo, ballot_scan_bubble_image};
 use crate::interpret::{
-    self, ballot_card, InterpretedBallotCard, MetadataSource, Options, VerticalStreakDetection,
-    WriteInScoring,
+    self, InterpretedBallotCard, MetadataSource, Options, VerticalStreakDetection, WriteInScoring,
+    ballot_card,
 };
 use crate::scoring::UnitIntervalScore;
 use crate::timing_marks::{self, DefaultForGeometry, TimingMarks};

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
@@ -1,6 +1,6 @@
 use std::cell::OnceCell;
 
-use base64::{engine::general_purpose::STANDARD, Engine as _};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use image::GrayImage;
 use serde::Serialize;
 use types_rs::{

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/mod.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/mod.rs
@@ -2,4 +2,4 @@ mod detect;
 mod rqrr;
 mod zedbar;
 
-pub use detect::{classify_qr_payload, detect_with_strategy, Detected, QrCodeKind, SearchStrategy};
+pub use detect::{Detected, QrCodeKind, SearchStrategy, classify_qr_payload, detect_with_strategy};

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/zedbar.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/zedbar.rs
@@ -1,6 +1,6 @@
 use image::{EncodableLayout, GrayImage};
 use types_rs::geometry::{PixelUnit, Point, Rect};
-use zedbar::{config, DecoderConfig, Image, Scanner, SymbolType};
+use zedbar::{DecoderConfig, Image, Scanner, SymbolType, config};
 
 use super::detect::{Detected, DetectionArea, Detector, Error, Result};
 
@@ -26,7 +26,7 @@ pub fn detect_in_areas(detection_areas: &[DetectionArea<'_>]) -> Result {
                 return Err(Error::DetectFailed {
                     detection_areas: detection_area_rects,
                     message: e.to_string(),
-                })
+                });
             }
         }
     }

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/scoring.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/scoring.rs
@@ -12,7 +12,7 @@ use types_rs::geometry::{PixelPosition, PixelUnit, Point, Quadrilateral, Rect, S
 
 use crate::ballot_card::BallotImage;
 use crate::debug;
-use crate::image_utils::{count_pixels_in_shape, VerticalStreak};
+use crate::image_utils::{VerticalStreak, count_pixels_in_shape};
 use crate::interpret::{Error, Result};
 use crate::timing_marks::TimingMarks;
 
@@ -190,8 +190,8 @@ pub(crate) fn score_bubble_marks_from_grid_layout(
 
     // Check for vertical streaks after collecting
     for (_, scored_bubble_mark) in &scored_bubbles {
-        if let Some(scored_bubble_mark) = scored_bubble_mark {
-            if detected_vertical_streaks.iter().any(|streak| {
+        if let Some(scored_bubble_mark) = scored_bubble_mark
+            && detected_vertical_streaks.iter().any(|streak| {
                 Rect::new(
                     *streak.x_range.start(),
                     0,
@@ -200,15 +200,15 @@ pub(crate) fn score_bubble_marks_from_grid_layout(
                 )
                 .intersect(&scored_bubble_mark.matched_bounds)
                 .is_some()
-            }) {
-                return Err(Error::VerticalStreaksDetected {
-                    label: label.to_owned(),
-                    x_coordinates: detected_vertical_streaks
-                        .iter()
-                        .flat_map(|streak| streak.x_range.clone())
-                        .collect(),
-                });
-            }
+            })
+        {
+            return Err(Error::VerticalStreaksDetected {
+                label: label.to_owned(),
+                x_coordinates: detected_vertical_streaks
+                    .iter()
+                    .flat_map(|streak| streak.x_range.clone())
+                    .collect(),
+            });
         }
     }
 

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/timing_marks/border_finding.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/timing_marks/border_finding.rs
@@ -5,8 +5,8 @@ use crate::{
     interpret::Error,
     scoring::UnitIntervalScore,
     timing_marks::{
-        corner_finding::BallotGridCorners, mark_finding::BallotGridCandidateMarks,
-        util::mark_distances_to_point, Border, CandidateTimingMark, DefaultForGeometry,
+        Border, CandidateTimingMark, DefaultForGeometry, corner_finding::BallotGridCorners,
+        mark_finding::BallotGridCandidateMarks, util::mark_distances_to_point,
     },
 };
 use image::RgbImage;
@@ -145,11 +145,11 @@ impl GridBorder {
                     .min_by(|(a, _), (b, _)| a.total_cmp(b))
             else {
                 return Err(Error::MissingTimingMarks {
-                        reason: format!(
-                            "Unable to find mark along {border:?} border at index {index}; no marks close enough?",
-                            index = marks.len()
-                        ),
-                    });
+                    reason: format!(
+                        "Unable to find mark along {border:?} border at index {index}; no marks close enough?",
+                        index = marks.len()
+                    ),
+                });
             };
 
             marks.push(*closest_mark_to_expected_center);

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/timing_marks/corner_finding.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/timing_marks/corner_finding.rs
@@ -10,9 +10,9 @@ use crate::{
     interpret::Error,
     scoring::UnitIntervalScore,
     timing_marks::{
-        mark_finding::BallotGridCandidateMarks,
-        util::{mark_distances_to_point, CornerWise, EdgeWise},
         CandidateTimingMark, Corner, DefaultForGeometry,
+        mark_finding::BallotGridCandidateMarks,
+        util::{CornerWise, EdgeWise, mark_distances_to_point},
     },
 };
 
@@ -125,7 +125,12 @@ impl BallotGridCorners {
                 Point::new(0.0, -vertical_timing_mark_center_to_center_distance),
             );
 
-        let [top_left_result, top_right_result, bottom_left_result, bottom_right_result] = [
+        let [
+            top_left_result,
+            top_right_result,
+            bottom_left_result,
+            bottom_right_result,
+        ] = [
             (top_left_corner_candidates.clone(), Corner::TopLeft),
             (top_right_corner_candidates.clone(), Corner::TopRight),
             (bottom_left_corner_candidates.clone(), Corner::BottomLeft),

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/timing_marks/mark_finding.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/timing_marks/mark_finding.rs
@@ -8,7 +8,7 @@ use crate::{
     debug::monospace_font,
     draw_utils::{draw_filled_rect_mut, draw_text_mut, text_size},
     image_utils::rainbow,
-    timing_marks::{shape_finding::BallotGridBorderShapes, CandidateTimingMark},
+    timing_marks::{CandidateTimingMark, shape_finding::BallotGridBorderShapes},
 };
 
 /// Represents the candidate timing marks found on a ballot grid.

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/timing_marks/mod.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/timing_marks/mod.rs
@@ -87,7 +87,12 @@ pub fn find_timing_mark_grid(
         borders.debug_draw(canvas);
     });
 
-    let [top_left_mark, top_right_mark, bottom_left_mark, bottom_right_mark] = [
+    let [
+        top_left_mark,
+        top_right_mark,
+        bottom_left_mark,
+        bottom_right_mark,
+    ] = [
         corners.top_left(),
         corners.top_right(),
         corners.bottom_left(),
@@ -95,7 +100,12 @@ pub fn find_timing_mark_grid(
     ]
     .map_cornerwise(|corner| corner.best_corner_grouping().corner_mark());
 
-    let [top_left_corner, top_right_corner, bottom_left_corner, bottom_right_corner] = [
+    let [
+        top_left_corner,
+        top_right_corner,
+        bottom_left_corner,
+        bottom_right_corner,
+    ] = [
         top_left_mark,
         top_right_mark,
         bottom_left_mark,

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/timing_marks/shape_finding/mod.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/timing_marks/shape_finding/mod.rs
@@ -9,10 +9,10 @@ use types_rs::{
 
 use crate::{
     ballot_card::{BallotImage, Geometry},
-    image_utils::{rainbow, Inset},
+    image_utils::{Inset, rainbow},
     timing_marks::{
-        rect_could_be_timing_mark, shape_finding::shape_list_builder::ShapeListBuilder,
-        util::median_filter, CandidateTimingMark, DefaultForGeometry,
+        CandidateTimingMark, DefaultForGeometry, rect_could_be_timing_mark,
+        shape_finding::shape_list_builder::ShapeListBuilder, util::median_filter,
     },
 };
 

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/timing_marks/shape_finding/shape_list_builder.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/timing_marks/shape_finding/shape_list_builder.rs
@@ -403,7 +403,7 @@ mod tests {
         builder.add_slice(0, 0..=10);
         builder.add_slice(7, 0..=10);
         builder.combine_adjacent_shapes(5, 2); // max_x_gap = 5
-                                               // Should not be combined because gap (6) > max_x_gap (5)
+        // Should not be combined because gap (6) > max_x_gap (5)
         assert_eq!(
             builder.into_shapes(),
             vec![
@@ -426,7 +426,7 @@ mod tests {
         builder.add_slice(0, 0..=10);
         builder.add_slice(2, 15..=25); // y offset is 5 pixels
         builder.combine_adjacent_shapes(5, 2); // max_y_offset = 2
-                                               // Should not be combined because y offset (5) > max_y_offset (2)
+        // Should not be combined because y offset (5) > max_y_offset (2)
         assert_eq!(
             builder.into_shapes(),
             vec![

--- a/libs/fs/Cargo.toml
+++ b/libs/fs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "vx-fs"
 version = "0.0.0"
 

--- a/libs/fs/src/rust/lib.rs
+++ b/libs/fs/src/rust/lib.rs
@@ -10,7 +10,7 @@
 use napi::{Error, Result};
 use napi_derive::napi;
 use nix::errno::Errno;
-use nix::fcntl::{flock, posix_fadvise, renameat2, FlockArg, PosixFadviseAdvice, RenameFlags};
+use nix::fcntl::{FlockArg, PosixFadviseAdvice, RenameFlags, flock, posix_fadvise, renameat2};
 use nix::unistd::syncfs as nix_syncfs;
 
 fn errno_error(errno: Errno) -> Error {

--- a/libs/logging-utils/Cargo.toml
+++ b/libs/logging-utils/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "logging-utils"
 version = "0.0.0"
 

--- a/libs/logging-utils/src/lib.rs
+++ b/libs/logging-utils/src/lib.rs
@@ -3,9 +3,9 @@
 use std::path::{Path, PathBuf};
 
 use napi::{
+    Task,
     bindgen_prelude::*,
     threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode},
-    Task,
 };
 use napi_derive::napi;
 use vx_logging::{Disposition, EventId, Source};

--- a/libs/logging-utils/src/ser.rs
+++ b/libs/logging-utils/src/ser.rs
@@ -1,8 +1,8 @@
 use std::cell::Cell;
 
 use serde::{
-    ser::{SerializeSeq, Serializer},
     Serialize,
+    ser::{SerializeSeq, Serializer},
 };
 
 /// Makes a `Serializable` out of an iterable of `Serializable` values.

--- a/libs/logging-utils/src/stream.rs
+++ b/libs/logging-utils/src/stream.rs
@@ -2,7 +2,7 @@
 
 use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
 
-use flate2::{read::GzDecoder, write::GzEncoder, Compression};
+use flate2::{Compression, read::GzDecoder, write::GzEncoder};
 
 /// Reads data as either an uncompressed or gzip-compressed stream.
 pub enum Reader<R: Read> {

--- a/libs/logging/Cargo.toml
+++ b/libs/logging/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vx-logging"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/libs/logging/types-rust/src/types.rs
+++ b/libs/logging/types-rust/src/types.rs
@@ -4,9 +4,8 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    derive_display,
+    SOURCE, derive_display,
     log_event_enums::{EventId, EventType, Source},
-    SOURCE,
 };
 
 #[derive(Serialize, Deserialize)]

--- a/libs/pdi-scanner/Cargo.toml
+++ b/libs/pdi-scanner/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 license = "GPL-3.0-only"
@@ -20,7 +20,7 @@ debug = "line-tables-only" # Enable stack traces
 [package]
 name = "pdi-scanner"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 name = "pdi_scanner"

--- a/libs/pdi-scanner/examples/eject_at_boot.rs
+++ b/libs/pdi-scanner/examples/eject_at_boot.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
 use std::{str::FromStr, time::Duration};
-use tokio::time::{sleep, timeout, Instant};
+use tokio::time::{Instant, sleep, timeout};
 use tracing_subscriber::prelude::*;
 
 use pdi_scanner::{

--- a/libs/pdi-scanner/examples/scan_forever.rs
+++ b/libs/pdi-scanner/examples/scan_forever.rs
@@ -9,7 +9,7 @@ use tracing_subscriber::prelude::*;
 use pdi_scanner::{
     client::Client,
     protocol::{
-        image::{RawImageData, Sheet, DEFAULT_IMAGE_WIDTH},
+        image::{DEFAULT_IMAGE_WIDTH, RawImageData, Sheet},
         packets::{ImageData, Incoming},
         types::{
             ClampedPercentage, DoubleFeedDetectionMode, EjectMotion, FeederMode, ScanSideMode,
@@ -121,11 +121,9 @@ async fn main() -> color_eyre::Result<()> {
 
                                 if let Ok(status) =
                                     timeout(Duration::from_secs(1), client.get_scanner_status()).await?
-                                {
-                                    if status.rear_sensors_covered() {
+                                    && status.rear_sensors_covered() {
                                         client.eject_document(EjectMotion::ToFront).await?;
                                     }
-                                }
                             }
                             Ok(_) => unreachable!(
                                 "try_decode_scan called with {:?} returned non-duplex sheet",

--- a/libs/pdi-scanner/src/rust/client.rs
+++ b/libs/pdi-scanner/src/rust/client.rs
@@ -6,12 +6,12 @@ use tokio::{
 };
 
 use crate::{
+    Error, Result,
     protocol::types::{
         AutoRunOutAtEndOfScanBehavior, BootEjectMotion, Direction, DoubleFeedDetectionMode,
         EjectPauseMode, FeederMode, PickOnCommandMode, RegisterIndex, Side,
     },
     scanner::Scanner,
-    Error, Result,
 };
 
 use super::protocol::{

--- a/libs/pdi-scanner/src/rust/main.rs
+++ b/libs/pdi-scanner/src/rust/main.rs
@@ -14,16 +14,16 @@ use tokio::{
 use tracing_subscriber::prelude::*;
 
 use pdi_scanner::{
+    Error, UsbError,
     client::{Client, DoubleFeedDetectionCalibrationConfig, ImageCalibrationTables},
     protocol::{
-        image::{RawImageData, Sheet, DEFAULT_IMAGE_WIDTH},
+        image::{DEFAULT_IMAGE_WIDTH, RawImageData, Sheet},
         packets::{Incoming, IncomingType},
         types::{
             BootEjectMotion, ClampedPercentage, DoubleFeedDetectionCalibrationType,
             DoubleFeedDetectionMode, EjectMotion, FeederMode, ScanSideMode, Status,
         },
     },
-    Error, UsbError,
 };
 
 #[cfg(feature = "recording")]
@@ -361,10 +361,10 @@ impl Drop for Output {
         // Close the queue so the writer thread drains what remains and exits,
         // then wait for it: nothing already queued is lost on shutdown.
         drop(self.frames_tx.take());
-        if let Some(writer_thread) = self.writer_thread.take() {
-            if writer_thread.join().is_err() {
-                tracing::error!("stdout writer thread panicked");
-            }
+        if let Some(writer_thread) = self.writer_thread.take()
+            && writer_thread.join().is_err()
+        {
+            tracing::error!("stdout writer thread panicked");
         }
     }
 }
@@ -609,11 +609,10 @@ async fn handle_commands_and_events<
                         // PickOnCommandMode::FeederMustBeReenabledBetweenScans
                         // is supposed to do this, but it only works when the
                         // paper reaches the rear sensors.
-                        if let Some(c) = client.as_mut() {
-                            if let Err(e) = c.set_feeder_mode(FeederMode::Disabled).await {
+                        if let Some(c) = client.as_mut()
+                            && let Err(e) = c.set_feeder_mode(FeederMode::Disabled).await {
                                 tracing::warn!("failed to disable feeder after scan: {e:?}");
                             }
-                        }
 
                         match raw_image_data.try_decode_scan(
                             DEFAULT_IMAGE_WIDTH,
@@ -707,14 +706,14 @@ mod tests {
         recording::{self, Endpoint, Entry, FramePayload, Record},
         scanner::Scanner,
     };
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
     use tokio::{
         io::{AsyncWriteExt, BufReader},
         sync::mpsc,
         time::timeout,
     };
 
-    use super::{handle_commands_and_events, FRAME_HEADER_LENGTH, FRAME_TYPE_LENGTH};
+    use super::{FRAME_HEADER_LENGTH, FRAME_TYPE_LENGTH, handle_commands_and_events};
 
     const TEST_TIMEOUT: Duration = Duration::from_secs(3);
 
@@ -1664,13 +1663,12 @@ mod tests {
             );
             if let (Ok(Value::Object(mut expected_json)), Ok(Value::Object(mut actual_json))) =
                 parsed
+                && expected_json.contains_key("code")
             {
-                if expected_json.contains_key("code") {
-                    expected_json.remove("message");
-                    actual_json.remove("message");
-                    if expected_json == actual_json {
-                        return;
-                    }
+                expected_json.remove("message");
+                actual_json.remove("message");
+                if expected_json == actual_json {
+                    return;
                 }
             }
             panic!(

--- a/libs/pdi-scanner/src/rust/parse_traffic.rs
+++ b/libs/pdi-scanner/src/rust/parse_traffic.rs
@@ -6,7 +6,7 @@ use pdi_scanner::{
     client::ImageCalibrationTables,
     protocol::{
         self,
-        image::{RawImageData, Sheet, DEFAULT_IMAGE_WIDTH},
+        image::{DEFAULT_IMAGE_WIDTH, RawImageData, Sheet},
         packets::{Incoming, Packet},
         types::{ScanSideMode, Side},
     },

--- a/libs/pdi-scanner/src/rust/protocol/packets.rs
+++ b/libs/pdi-scanner/src/rust/protocol/packets.rs
@@ -855,10 +855,11 @@ impl Outgoing {
                 Command::new(b">")
                     .with_data(format!("{:03x}{:08x}", register_index.get(), value).as_bytes()),
                 |input| -> nom::IResult<&[u8], Register> {
-                    if let Ok((&[], register)) = parsers::write_data_to_register_request(input) {
-                        if register.index() == *register_index && register.value() == *value {
-                            return Ok((&[], register));
-                        }
+                    if let Ok((&[], register)) = parsers::write_data_to_register_request(input)
+                        && register.index() == *register_index
+                        && register.value() == *value
+                    {
+                        return Ok((&[], register));
                     }
 
                     Err(nom::Err::Failure(nom::error::Error::new(

--- a/libs/pdi-scanner/src/rust/protocol/parsers.rs
+++ b/libs/pdi-scanner/src/rust/protocol/parsers.rs
@@ -1,22 +1,22 @@
 use std::{str::from_utf8, time::Duration};
 
 use super::{
-    packets::{crc, Incoming, Packet, PACKET_DATA_END, PACKET_DATA_START},
+    Outgoing, Settings, Status, Version,
+    packets::{Incoming, PACKET_DATA_END, PACKET_DATA_START, Packet, crc},
     types::{
         BitonalAdjustment, ClampedPercentage, Direction, DoubleFeedDetectionCalibrationType,
         Register, RegisterIndex, Resolution, Side,
     },
-    Outgoing, Settings, Status, Version,
 };
 use nom::{
+    IResult,
     branch::alt,
     bytes::complete::{tag, take, take_until, take_while_m_n},
     character::is_digit,
     combinator::{map, map_res, value},
     multi::many1,
-    number::complete::{le_u16, le_u8},
-    sequence::{delimited, tuple, Tuple},
-    IResult,
+    number::complete::{le_u8, le_u16},
+    sequence::{Tuple, delimited, tuple},
 };
 
 /// Creates a simple request parser with no payload.
@@ -645,10 +645,10 @@ fn packet_with_crc<'a, O, List: Tuple<&'a [u8], O, nom::error::Error<&'a [u8]>>>
 /// Returns an error if the input does not start with a decimal digit.
 pub fn decimal_digit(input: &[u8]) -> IResult<&[u8], u8> {
     map_res(take(1usize), |bytes: &[u8]| {
-        if let [byte, ..] = bytes {
-            if is_digit(*byte) {
-                return Ok(*byte - b'0');
-            }
+        if let [byte, ..] = bytes
+            && is_digit(*byte)
+        {
+            return Ok(*byte - b'0');
         }
 
         Err(nom::Err::Failure(nom::error::Error::new(
@@ -706,10 +706,10 @@ pub fn decimal_number(input: &[u8]) -> IResult<&[u8], u16> {
 /// number is an invalid percentage.
 pub fn decimal_percentage(input: &[u8]) -> IResult<&[u8], ClampedPercentage> {
     map_res(decimal_number, |number| {
-        if let Ok(number) = u8::try_from(number) {
-            if let Some(percentage) = ClampedPercentage::new(number) {
-                return Ok(percentage);
-            }
+        if let Ok(number) = u8::try_from(number)
+            && let Some(percentage) = ClampedPercentage::new(number)
+        {
+            return Ok(percentage);
         }
 
         Err(nom::Err::Failure(nom::error::Error::new(
@@ -874,14 +874,13 @@ pub fn get_current_firmware_build_version_string_response(input: &[u8]) -> IResu
         tag(b":"),
         take(2usize),
     ))(input)
+        && let Some(body) = extract_packet_body(input)
     {
-        if let Some(body) = extract_packet_body(input) {
-            return from_utf8(&input[b"X".len()..])
-                .map(|string| (&[] as &[u8], string))
-                .map_err(|_| {
-                    nom::Err::Failure(nom::error::Error::new(body, nom::error::ErrorKind::Verify))
-                });
-        }
+        return from_utf8(&input[b"X".len()..])
+            .map(|string| (&[] as &[u8], string))
+            .map_err(|_| {
+                nom::Err::Failure(nom::error::Error::new(body, nom::error::ErrorKind::Verify))
+            });
     }
 
     Err(nom::Err::Error(nom::error::Error::new(

--- a/libs/pdi-scanner/src/rust/recording.rs
+++ b/libs/pdi-scanner/src/rust/recording.rs
@@ -23,8 +23,8 @@ use std::{
     time::Instant,
 };
 
-use base64::{engine::general_purpose::STANDARD, Engine as _};
-use flate2::{bufread::GzDecoder, write::GzEncoder, Compression};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use flate2::{Compression, bufread::GzDecoder, write::GzEncoder};
 use nusb::transfer::TransferError;
 
 use crate::{Error, UsbError};

--- a/libs/pdi-scanner/src/rust/scanner.rs
+++ b/libs/pdi-scanner/src/rust/scanner.rs
@@ -10,7 +10,7 @@ use nusb::transfer::{Completion, RequestBuffer, TransferError};
 
 #[cfg(feature = "recording")]
 use crate::recording;
-use crate::{protocol::parsers, Error, Result, UsbError};
+use crate::{Error, Result, UsbError, protocol::parsers};
 
 use super::protocol::packets::{self, Incoming, IncomingType};
 
@@ -136,10 +136,10 @@ impl Scanner {
         if let Some(stop_tx) = self.stop_tx.take() {
             let _ = stop_tx.send(());
         }
-        if let Some(handle) = self.task_handle.take() {
-            if let Err(err) = handle.await {
-                tracing::error!("Scanner background task failed: {err:?}");
-            }
+        if let Some(handle) = self.task_handle.take()
+            && let Err(err) = handle.await
+        {
+            tracing::error!("Scanner background task failed: {err:?}");
         }
         tracing::debug!("Scanner disconnected");
     }
@@ -453,8 +453,8 @@ mod tests {
     };
 
     use super::{
-        acquire_scanner_lock, claim_error, poll_scanner, BulkInQueue, Scanner, UsbInterface,
-        ENDPOINT_IN_IMAGE_DATA, ENDPOINT_IN_PRIMARY, ENDPOINT_OUT,
+        BulkInQueue, ENDPOINT_IN_IMAGE_DATA, ENDPOINT_IN_PRIMARY, ENDPOINT_OUT, Scanner,
+        UsbInterface, acquire_scanner_lock, claim_error, poll_scanner,
     };
 
     const TEST_TIMEOUT: Duration = Duration::from_millis(100);

--- a/libs/types-rs/Cargo.toml
+++ b/libs/types-rs/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 license = "GPL-3.0-only"
@@ -17,7 +17,7 @@ unwrap_used = "deny"
 [package]
 name = "types-rs"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 bitstream-io = "4.0.0"

--- a/libs/types-rs/src/bmd/cvr.rs
+++ b/libs/types-rs/src/bmd/cvr.rs
@@ -5,10 +5,10 @@ use bitstream_io::{FromBitStreamWith, ToBitStreamWith};
 use crate::{
     ballot_card::BallotType,
     bmd::{
+        BMD_PRELUDE, PartialBallotHash,
         encoding::{self, BallotAuditId, BallotHeader},
         error::Error,
         votes::ContestVote,
-        PartialBallotHash, BMD_PRELUDE,
     },
     codable,
     election::{BallotStyleId, ContestId, Election, PrecinctId},

--- a/libs/types-rs/src/bmd/encoding.rs
+++ b/libs/types-rs/src/bmd/encoding.rs
@@ -8,7 +8,7 @@ use crate::{
     election::{BallotStyle, BallotStyleId, Contest, ContestId, Election, PrecinctId},
 };
 
-use super::{error::Error, votes::ContestVote, PartialBallotHash};
+use super::{PartialBallotHash, error::Error, votes::ContestVote};
 
 /// Fields decoded from the common header portion of a BMD ballot's bitstream
 /// (ballot hash, precinct index, ballot style index).
@@ -93,10 +93,10 @@ pub fn write_roll_call_and_votes<W: bitstream_io::BitWrite + ?Sized>(
     }
 
     for contest in contests {
-        if let Some(contest_vote) = votes.get(contest.id()) {
-            if contest_vote.has_votes() {
-                w.build_with(contest_vote, contest)?;
-            }
+        if let Some(contest_vote) = votes.get(contest.id())
+            && contest_vote.has_votes()
+        {
+            w.build_with(contest_vote, contest)?;
         }
     }
 

--- a/libs/types-rs/src/bmd/votes.rs
+++ b/libs/types-rs/src/bmd/votes.rs
@@ -103,7 +103,7 @@ impl ToBitStreamWith<'_> for ContestVote {
                         "Contest '{}' and its associated votes are not the same contest type",
                         contest.id()
                     ),
-                })
+                });
             }
         }
 

--- a/libs/types-rs/src/bubble_ballot.rs
+++ b/libs/types-rs/src/bubble_ballot.rs
@@ -153,7 +153,7 @@ pub enum MetadataMismatch {
 pub mod ballot_hash_serde {
     use serde::{Deserialize, Deserializer, Serializer};
 
-    use super::{PartialBallotHash, PARTIAL_BALLOT_HASH_BYTE_LENGTH};
+    use super::{PARTIAL_BALLOT_HASH_BYTE_LENGTH, PartialBallotHash};
 
     /// Serialize a `PartialBallotHash` as a hexadecimal string.
     ///

--- a/libs/types-rs/src/geometry.rs
+++ b/libs/types-rs/src/geometry.rs
@@ -549,74 +549,62 @@ impl Segment {
 
         if let (Some(left_intersection), Some(right_intersection)) =
             (left_intersection, right_intersection)
+            && left_intersection.y >= rect.top() as f32
+            && left_intersection.y <= rect.bottom() as f32
+            && right_intersection.y >= rect.top() as f32
+            && right_intersection.y <= rect.bottom() as f32
         {
-            if left_intersection.y >= rect.top() as f32
-                && left_intersection.y <= rect.bottom() as f32
-                && right_intersection.y >= rect.top() as f32
-                && right_intersection.y <= rect.bottom() as f32
-            {
-                return Some(Self::new(left_intersection, right_intersection));
-            }
+            return Some(Self::new(left_intersection, right_intersection));
         }
 
         if let (Some(top_intersection), Some(bottom_intersection)) =
             (top_intersection, bottom_intersection)
+            && top_intersection.x >= rect.left() as f32
+            && top_intersection.x <= rect.right() as f32
+            && bottom_intersection.x >= rect.left() as f32
+            && bottom_intersection.x <= rect.right() as f32
         {
-            if top_intersection.x >= rect.left() as f32
-                && top_intersection.x <= rect.right() as f32
-                && bottom_intersection.x >= rect.left() as f32
-                && bottom_intersection.x <= rect.right() as f32
-            {
-                return Some(Self::new(top_intersection, bottom_intersection));
-            }
+            return Some(Self::new(top_intersection, bottom_intersection));
         }
 
         if let (Some(left_intersection), Some(top_intersection)) =
             (left_intersection, top_intersection)
+            && left_intersection.y >= rect.top() as f32
+            && left_intersection.y <= rect.bottom() as f32
+            && top_intersection.x >= rect.left() as f32
+            && top_intersection.x <= rect.right() as f32
         {
-            if left_intersection.y >= rect.top() as f32
-                && left_intersection.y <= rect.bottom() as f32
-                && top_intersection.x >= rect.left() as f32
-                && top_intersection.x <= rect.right() as f32
-            {
-                return Some(Self::new(left_intersection, top_intersection));
-            }
+            return Some(Self::new(left_intersection, top_intersection));
         }
 
         if let (Some(left_intersection), Some(bottom_intersection)) =
             (left_intersection, bottom_intersection)
+            && left_intersection.y >= rect.top() as f32
+            && left_intersection.y <= rect.bottom() as f32
+            && bottom_intersection.x >= rect.left() as f32
+            && bottom_intersection.x <= rect.right() as f32
         {
-            if left_intersection.y >= rect.top() as f32
-                && left_intersection.y <= rect.bottom() as f32
-                && bottom_intersection.x >= rect.left() as f32
-                && bottom_intersection.x <= rect.right() as f32
-            {
-                return Some(Self::new(left_intersection, bottom_intersection));
-            }
+            return Some(Self::new(left_intersection, bottom_intersection));
         }
 
         if let (Some(right_intersection), Some(top_intersection)) =
             (right_intersection, top_intersection)
+            && right_intersection.y >= rect.top() as f32
+            && right_intersection.y <= rect.bottom() as f32
+            && top_intersection.x >= rect.left() as f32
+            && top_intersection.x <= rect.right() as f32
         {
-            if right_intersection.y >= rect.top() as f32
-                && right_intersection.y <= rect.bottom() as f32
-                && top_intersection.x >= rect.left() as f32
-                && top_intersection.x <= rect.right() as f32
-            {
-                return Some(Self::new(right_intersection, top_intersection));
-            }
+            return Some(Self::new(right_intersection, top_intersection));
         }
 
         if let (Some(right_intersection), Some(bottom_intersection)) =
             (right_intersection, bottom_intersection)
+            && right_intersection.y >= rect.top() as f32
+            && right_intersection.y <= rect.bottom() as f32
+            && bottom_intersection.x >= rect.left() as f32
+            && bottom_intersection.x <= rect.right() as f32
         {
-            if right_intersection.y >= rect.top() as f32
-                && right_intersection.y <= rect.bottom() as f32
-                && bottom_intersection.x >= rect.left() as f32
-                && bottom_intersection.x <= rect.right() as f32
-            {
-                return Some(Self::new(right_intersection, bottom_intersection));
-            }
+            return Some(Self::new(right_intersection, bottom_intersection));
         }
 
         None

--- a/libs/types-rs/tests/bmd_test.rs
+++ b/libs/types-rs/tests/bmd_test.rs
@@ -5,11 +5,11 @@ use std::collections::HashMap;
 use proptest::prelude::Strategy;
 use proptest::proptest;
 use types_rs::ballot_card::BallotType;
+use types_rs::bmd::PartialBallotHash;
 use types_rs::bmd::cvr::{CastVoteRecord, PageNumber};
 use types_rs::bmd::encoding::BallotAuditId;
 use types_rs::bmd::votes::{CandidateVote, ContestVote};
 use types_rs::bmd::write_in_name::WriteInName;
-use types_rs::bmd::PartialBallotHash;
 use types_rs::coding;
 use types_rs::election::{Candidate, Contest, ContestId, DistrictId, Election, OptionId};
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,6 @@
-# Only sets the parser edition, needed when rustfmt is invoked directly on a
-# file (as the lint-staged pre-commit hook does) rather than via `cargo fmt`,
-# which reads the edition from Cargo.toml. Without it, rustfmt parses as
-# edition 2015 and errors on `async fn`. Formatting style is rustfmt defaults.
-edition = "2021"
+# Needed when rustfmt is invoked directly on a file (as the lint-staged
+# pre-commit hook does) rather than via `cargo fmt`, which reads the edition
+# from Cargo.toml. Without it, rustfmt parses as edition 2015 and errors on
+# `async fn`. Keep in sync with the `edition` in every Cargo.toml: it selects
+# both the parser edition and, by default, the matching style edition.
+edition = "2024"


### PR DESCRIPTION
## Overview

Bumps `edition` to 2024 in all four Cargo workspaces (root, `libs/ballot-interpreter`, `libs/pdi-scanner`, `libs/types-rs`) and `resolver` to `3`. `Cargo.lock` is unchanged, so the resolver picked the same graph.

Code changes are mechanical: two `impl Trait + use<>` bounds, let-chain collapses now that `clippy::collapsible_if` can suggest them, and import reordering from rustfmt's 2024 style edition. The commit message explains the two `cargo fix --edition` suggestions I deliberately didn't take.

## Testing Plan

- `cargo fmt --check`, `cargo build`, and `cargo clippy --all-targets` are clean in all four workspaces
- `cargo test` passes: 383 tests, 0 failures
- `napi build --release` plus JS tests pass for `libs/logging-utils`, confirming the native-addon path still builds

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.